### PR TITLE
refactor(camera): carve CameraToCudaCopy into @tatolab/camera

### DIFF
--- a/examples/camera-python-display/Cargo.toml
+++ b/examples/camera-python-display/Cargo.toml
@@ -33,12 +33,18 @@ png = "0.17"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
-streamlib-adapter-cuda = { path = "../../libs/streamlib-adapter-cuda" }
-# `CameraToCudaCopyProcessor` (#612) passes the resolved camera
-# texture through `VulkanTextureLike` and uses the `VulkanLayout`
-# newtype, so the surface-adapter side stays out of `vulkanalia`
-# per the engine boundary rule.
+# `VulkanLayout` newtype used by the in-tree BlendingCompositor /
+# CrtFilmGrain wrappers when issuing layout barriers via the
+# `RhiCommandRecorder`. The wrappers are sandboxed scenario content
+# (#487); the engine boundary rule keeps the example out of
+# `vulkanalia` so this consumer-rhi import is the typed-layout
+# interop type it goes through instead.
 streamlib-consumer-rhi = { path = "../../libs/streamlib-consumer-rhi" }
+# Package deps (`@tatolab/camera`, `@tatolab/display`) flow through
+# `streamlib.yaml` and `Runner::load_workspace_packages` — not
+# through Cargo. The example never imports a package's Rust types
+# directly; processors register via the package's `STREAMLIB_PLUGIN`
+# callback and are wired via `ProcessorSpec::new(schema_ident!(...))`.
 # Direct vulkanalia dep — TRANSITIONAL exception (#487). The
 # example owns its `BlendingCompositor` + `CrtFilmGrain` graphics-
 # kernel wrappers as sandboxed scenario content; the wrappers

--- a/examples/camera-python-display/src/linux.rs
+++ b/examples/camera-python-display/src/linux.rs
@@ -73,13 +73,18 @@ use streamlib_adapter_abi::SurfaceId;
 use streamlib_consumer_rhi::VulkanLayout;
 
 use crate::blending_compositor::BlendingCompositorProcessor;
-use crate::camera_to_cuda_copy::{CameraToCudaCopyProcessor, CUDA_CAMERA_SURFACE_ID};
 use crate::crt_film_grain::CrtFilmGrainProcessor;
 
-/// Re-exported alias so the Python avatar's JSON config and other
-/// pipeline wiring keep using the historical name; the processor's
-/// own [`CUDA_CAMERA_SURFACE_ID`] is the single source of truth.
-const AVATAR_CAMERA_CUDA_SURFACE_ID: SurfaceId = CUDA_CAMERA_SURFACE_ID;
+/// Cuda surface id the host-side `CameraToCudaCopy` processor
+/// registers under and the Python `AvatarCharacter` consumes via
+/// its config. The single source of truth is
+/// `packages/camera/src/camera_to_cuda_copy.rs::CUDA_CAMERA_SURFACE_ID`
+/// — the example doesn't Cargo-dep `@tatolab/camera`, so the value
+/// is duplicated here as a literal. If `@tatolab/camera`'s constant
+/// changes, the package's bump becomes visible to this consumer
+/// the same way any package contract bump becomes visible: through
+/// the package's published version.
+const AVATAR_CAMERA_CUDA_SURFACE_ID: SurfaceId = 484_001;
 
 /// Surface UUID for the avatar mesh-render output (tiled DMA-BUF
 /// `VkImage`). The Python processor renders into it via
@@ -233,8 +238,15 @@ pub fn main() -> Result<()> {
     // module re-exported here as `AVATAR_CAMERA_CUDA_SURFACE_ID` so
     // the Python config below pins to the same value.
     println!("🚛 Adding camera→cuda copy processor (host-pipeline producer)...");
-    let camera_to_cuda =
-        runtime.add_processor(CameraToCudaCopyProcessor::node(Default::default()))?;
+    // `CameraToCudaCopy` is registered through `@tatolab/camera`'s
+    // cdylib `STREAMLIB_PLUGIN` callback alongside `Camera`, so the
+    // example wires it via `ProcessorSpec` against the package
+    // identifier — no in-tree registration. Default config (1920x1080)
+    // matches the camera processor's output dimensions.
+    let camera_to_cuda = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "camera", "CameraToCudaCopy", "1.0.0"),
+        serde_json::json!({}),
+    ))?;
     println!("✓ Camera→CUDA copy added: {camera_to_cuda}\n");
 
     // AvatarCharacter (Python subprocess). Reads the cuda surface for

--- a/examples/camera-python-display/src/main.rs
+++ b/examples/camera-python-display/src/main.rs
@@ -54,8 +54,6 @@ mod blending_compositor;
 // to RDG (#631).
 #[cfg(target_os = "linux")]
 mod blending_compositor_kernel;
-#[cfg(target_os = "linux")]
-mod camera_to_cuda_copy;
 // CRT/Film-Grain post-effect: processor + sandboxed kernel wrapper.
 // Wired into the Linux pipeline as
 // `BlendingCompositor → CrtFilmGrain → Glitch → Display` (#487).

--- a/examples/camera-python-display/streamlib.yaml
+++ b/examples/camera-python-display/streamlib.yaml
@@ -41,20 +41,11 @@ processors:
         schema: VideoFrame
         description: "Processed video frames"
 
-  - name: CameraToCudaCopy
-    version: 1.0.0
-    description: "Host-pipeline producer: camera VkImage -> cuda OPAQUE_FD VkBuffer with timeline signal (#612)"
-    execution: reactive
-    scheduling:
-      priority: high
-    inputs:
-      - name: video_in
-        schema: VideoFrame
-        description: "Camera ring texture (RGBA8 DMA-BUF) frame metadata"
-    outputs:
-      - name: video_out
-        schema: VideoFrame
-        description: "Camera frame forwarded verbatim; cuda surface side-effect happens during process()"
+  # `CameraToCudaCopy` lives in `@tatolab/camera` so any consumer of
+  # the camera package picks it up without re-deriving the cuda
+  # VkBuffer / timeline / surface-share wiring. The example loads it
+  # via `load_workspace_packages(["@tatolab/camera", ...])` and wires
+  # it via `ProcessorSpec` against `@tatolab/camera/CameraToCudaCopy@1.0.0`.
 
   - name: BlendingCompositor
     version: 1.0.0

--- a/packages/camera/Cargo.toml
+++ b/packages/camera/Cargo.toml
@@ -52,6 +52,16 @@ libc.workspace = true
 # this is the typed-layout interop type shared between the host RHI's
 # `RhiCommandRecorder` and the cross-process surface-share schema.
 streamlib-consumer-rhi = { path = "../../libs/streamlib-consumer-rhi" }
+# CUDA host-side surface adapter — the `CameraToCudaCopy` processor
+# allocates a DEVICE_LOCAL OPAQUE_FD VkBuffer + exportable timeline
+# and runs the host-side `vkCmdCopyImageToBuffer` per frame for
+# cross-API CUDA interop. The adapter crate itself stays cudarc-free
+# (`cudarc` integration happens in the cdylib consumer); this dep
+# does NOT pull `libcuda.so` into the camera package's link surface.
+streamlib-adapter-cuda = { path = "../../libs/streamlib-adapter-cuda" }
+# Adapter ABI — provides `SurfaceId` and `AdapterError` types the
+# CUDA adapter surface uses in its public API.
+streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 # Objective-C interop and Apple framework bindings.

--- a/packages/camera/schemas/camera_to_cuda_copy_config.yaml
+++ b/packages/camera/schemas/camera_to_cuda_copy_config.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# JSON Type Definition (RFC 8927) schema for CameraToCudaCopy config.
+
+metadata:
+  type: CameraToCudaCopyConfig
+  description: "Configuration for CameraToCudaCopy — allocates a DEVICE_LOCAL OPAQUE_FD VkBuffer for cross-API CUDA interop and issues a per-frame vkCmdCopyImageToBuffer + timeline signal. Width and height MUST match the upstream camera processor's ring texture dimensions; mismatched sizes are rejected at the first copy."
+
+# Width and height are optional in the wire schema (JTD has no
+# `default` keyword) but treated as required at the processor layer
+# — the consumer applies the 1920×1080 defaults via `.unwrap_or(...)`
+# in `setup()` so `ProcessorSpec::new(..., json!({}))` carries empty
+# JSON and still works, while `json!({"width": 1280, "height": 720})`
+# overrides cleanly.
+optionalProperties:
+  width:
+    metadata:
+      description: "Cuda buffer width in pixels. Must match the camera ring texture width. Default: 1920."
+    type: uint32
+  height:
+    metadata:
+      description: "Cuda buffer height in pixels. Must match the camera ring texture height. Default: 1080."
+    type: uint32

--- a/packages/camera/src/camera_to_cuda_copy.rs
+++ b/packages/camera/src/camera_to_cuda_copy.rs
@@ -26,7 +26,6 @@
 //! macOS / iOS builds compile a no-op stub that returns a
 //! configuration error from `setup()`.
 
-use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
@@ -46,7 +45,15 @@ use streamlib::sdk::rhi::{PixelBuffer, PixelFormat};
 #[cfg(target_os = "linux")]
 use streamlib_adapter_abi::{AdapterError, SurfaceId};
 #[cfg(target_os = "linux")]
-use streamlib_adapter_cuda::{CudaSurfaceAdapter, HostSurfaceRegistration, VulkanLayout};
+use streamlib_adapter_cuda::{CudaSurfaceAdapter, HostSurfaceRegistration};
+// Import VulkanLayout from consumer-rhi directly for consistency with
+// the rest of the camera package (`linux/camera.rs` also imports from
+// `streamlib_consumer_rhi`). `streamlib_adapter_cuda` re-exports the
+// same type — both resolve to the identical newtype — but pinning the
+// import to the canonical home avoids future drift if the adapter
+// re-export ever diverges.
+#[cfg(target_os = "linux")]
+use streamlib_consumer_rhi::VulkanLayout;
 
 /// Surface id this processor registers the cuda OPAQUE_FD `VkBuffer`
 /// under. Downstream Python / Deno consumers read it under the same
@@ -58,8 +65,13 @@ pub const CUDA_CAMERA_SURFACE_ID: SurfaceId = 484_001;
 #[cfg(not(target_os = "linux"))]
 pub const CUDA_CAMERA_SURFACE_ID: u64 = 484_001;
 
-const SURFACE_WIDTH: u32 = 1920;
-const SURFACE_HEIGHT: u32 = 1080;
+/// Default cuda buffer dimensions applied when the consumer's
+/// `ProcessorSpec` config omits `width` / `height`. Matches the
+/// camera processor's default capture resolution; consumers that
+/// run at a non-default resolution must pass `{"width": N, "height": M}`
+/// matching their camera config.
+const DEFAULT_SURFACE_WIDTH: u32 = 1920;
+const DEFAULT_SURFACE_HEIGHT: u32 = 1080;
 
 // Per-platform backend stash. The proc-macro strips `#[cfg]` from
 // individual struct fields, so we collapse the platform-conditional
@@ -84,27 +96,19 @@ struct LinuxState {
     height: u32,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct CameraToCudaCopyConfig {
-    /// Buffer width in pixels. Must match the camera ring texture
-    /// width; mismatched sizes are rejected at the first copy.
-    pub width: u32,
-    /// Buffer height in pixels. Same constraint as `width`.
-    pub height: u32,
-}
-
-impl Default for CameraToCudaCopyConfig {
-    fn default() -> Self {
-        Self {
-            width: SURFACE_WIDTH,
-            height: SURFACE_HEIGHT,
-        }
-    }
-}
-
+// `CameraToCudaCopyConfig` is codegen'd from
+// `schemas/camera_to_cuda_copy_config.yaml` into `crate::_generated_`
+// — the macro pulls it via the `config:` block declared in the
+// package's `streamlib.yaml`. The `config` struct field is bound to
+// `Self::Config` (the schema-derived type), so JSON payloads passed
+// via `ProcessorSpec::new(..., serde_json::json!({...}))` reach the
+// `setup()` body through `self.config.width` / `.height` as
+// expected. (Hand-defining the struct here as a "custom field"
+// would silently discard the JSON — the macro initializes custom
+// fields via `Default::default()`. Schemas-driven config is the
+// only path that flows external config through to the processor.)
 #[streamlib::sdk::processor("CameraToCudaCopy")]
 pub struct CameraToCudaCopyProcessor {
-    config: CameraToCudaCopyConfig,
     backend: GpuBackendStash,
     frame_count: AtomicU64,
 }
@@ -141,8 +145,8 @@ impl streamlib::sdk::processors::ReactiveProcessor for CameraToCudaCopyProcessor
 impl CameraToCudaCopyProcessor::Processor {
     #[cfg(target_os = "linux")]
     fn setup_inner(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        let width = self.config.width;
-        let height = self.config.height;
+        let width = self.config.width.unwrap_or(DEFAULT_SURFACE_WIDTH);
+        let height = self.config.height.unwrap_or(DEFAULT_SURFACE_HEIGHT);
         if width == 0 || height == 0 {
             return Err(Error::Configuration(format!(
                 "CameraToCudaCopy: width/height must be non-zero, got {width}x{height}"

--- a/packages/camera/src/camera_to_cuda_copy.rs
+++ b/packages/camera/src/camera_to_cuda_copy.rs
@@ -1,46 +1,57 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Camera → CUDA host-pipeline copy processor (Linux, #612).
+//! Camera → CUDA host-pipeline copy processor (Linux only).
 //!
-//! Drops the CPU staging hop in `AvatarCharacter`'s Linux inference
-//! path. The host allocates a DEVICE_LOCAL OPAQUE_FD `VkBuffer` for
-//! the cuda surface (instead of a HOST_VISIBLE one), and this
-//! processor sits between the camera and the avatar in the DAG,
-//! issuing a per-frame `vkCmdCopyImageToBuffer` from the camera's
-//! ring `VkImage` into the cuda `VkBuffer` and signaling the cuda
-//! adapter's timeline GPU-side. Subprocess `acquire_read` waits on
-//! the same timeline value, so AvatarCharacter Python's inference
-//! reads GPU-resident bytes with zero CPU copies in the cuda path.
+//! Drops the CPU staging hop for any consumer that wants the camera
+//! frame as a GPU-resident CUDA tensor (e.g. PyTorch / JAX inference,
+//! cuDNN, OptiX). The host allocates a DEVICE_LOCAL OPAQUE_FD
+//! `VkBuffer` for the cuda surface (instead of a HOST_VISIBLE one),
+//! and this processor sits between the camera and downstream
+//! consumers in the DAG, issuing a per-frame `vkCmdCopyImageToBuffer`
+//! from the camera's ring `VkImage` into the cuda `VkBuffer` and
+//! signaling the cuda adapter's timeline GPU-side. Subprocess
+//! `acquire_read` waits on the same timeline value, so consumer
+//! Python / Deno inference reads GPU-resident bytes with zero CPU
+//! copies on the cuda path.
 //!
-//! This processor takes over the cuda-surface lifecycle that used
-//! to live in `linux.rs::register_cuda_camera_surface`.
+//! The processor owns the cuda OPAQUE_FD VkBuffer + the exportable
+//! timeline semaphore + the surface-share registration for both, all
+//! created in `setup()` and torn down when the processor's `Drop`
+//! fires. There is no setup-hook variant — the lifecycle binding to
+//! a single processor instance is what guarantees the cuda surface
+//! never outlives its producer.
+//!
+//! Linux-only. CUDA is Linux-only on the in-tree adapter set;
+//! macOS / iOS builds compile a no-op stub that returns a
+//! configuration error from `setup()`.
 
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
-use crate::_generated_::VideoFrame;
 use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
+use streamlib::sdk::error::{Error, Result};
 #[cfg(target_os = "linux")]
 use streamlib::sdk::engine::HostSurfaceStoreExt;
 
-#[cfg(target_os = "linux")]
-use streamlib::sdk::rhi::{PixelFormat, PixelBuffer};
+use crate::_generated_::VideoFrame;
+
 #[cfg(target_os = "linux")]
 use streamlib::sdk::context::GpuContextLimitedAccess;
 #[cfg(target_os = "linux")]
 use streamlib::sdk::engine::host_rhi::{HostMarker, HostVulkanBuffer, HostVulkanTimelineSemaphore};
+#[cfg(target_os = "linux")]
+use streamlib::sdk::rhi::{PixelBuffer, PixelFormat};
 #[cfg(target_os = "linux")]
 use streamlib_adapter_abi::{AdapterError, SurfaceId};
 #[cfg(target_os = "linux")]
 use streamlib_adapter_cuda::{CudaSurfaceAdapter, HostSurfaceRegistration, VulkanLayout};
 
 /// Surface id this processor registers the cuda OPAQUE_FD `VkBuffer`
-/// under. AvatarCharacter Python's `_process_linux` reads it under
-/// the same id; the Rust example main wires the avatar's Python
-/// config to this constant.
+/// under. Downstream Python / Deno consumers read it under the same
+/// id; the consumer's config pins to this constant so the wiring is
+/// fixed across the IPC boundary.
 #[cfg(target_os = "linux")]
 pub const CUDA_CAMERA_SURFACE_ID: SurfaceId = 484_001;
 
@@ -117,10 +128,10 @@ impl streamlib::sdk::processors::ReactiveProcessor for CameraToCudaCopyProcessor
         }
         let frame: VideoFrame = self.inputs.read("video_in")?;
         self.process_frame_inner(&frame)?;
-        // Forward the frame downstream verbatim — AvatarCharacter still
-        // needs the camera surface_id for its ModernGL background
-        // texture upload (handled separately, not via this processor).
-        // The cuda surface_id is in AvatarCharacter's config.
+        // Forward the frame downstream verbatim — downstream consumers
+        // still need the camera surface_id for any side-channel work
+        // (e.g. ModernGL background texture upload); the cuda surface_id
+        // travels via consumer config, not via the VideoFrame wire.
         self.outputs.write("video_out", &frame)?;
         self.frame_count.fetch_add(1, Ordering::Relaxed);
         Ok(())
@@ -146,7 +157,7 @@ impl CameraToCudaCopyProcessor::Processor {
         //    bytes; the GPU copy in `process()` populates them, and
         //    the cdylib's `cudaImportExternalMemory` →
         //    `cudaExternalMemoryGetMappedBuffer` exposes a
-        //    `kDLCUDA`-classified device pointer to PyTorch.
+        //    `kDLCUDA`-classified device pointer to PyTorch / JAX.
         let pixel_buffer = HostVulkanBuffer::new_opaque_fd_export_device_local(
             &host_device,
             (width as u64) * (height as u64) * 4,
@@ -288,8 +299,8 @@ impl CameraToCudaCopyProcessor::Processor {
         // extent extraction internally so this crate stays out of
         // `vulkanalia` per the engine boundary rule.
         //
-        // `WriteContended` is the expected race when AvatarCharacter
-        // Python's `cuda.acquire_read` is mid-YOLO-inference (~30 ms
+        // `WriteContended` is the expected race when a consumer's
+        // subprocess `cuda.acquire_read` is mid-inference (~30 ms
         // at 640x640 on Jetson-class GPUs); the camera frame is
         // dropped on this tick and the next ring slot will succeed.
         // Tearing down the pipeline on this error would defeat the

--- a/packages/camera/src/lib.rs
+++ b/packages/camera/src/lib.rs
@@ -11,6 +11,15 @@ pub mod _generated_ {
 // Cross-platform shim that re-exports the per-platform impl under a unified name.
 pub mod camera;
 
+/// Camera → CUDA host-pipeline copy processor (Linux only — CUDA is
+/// Linux-only on the in-tree adapter set; macOS / iOS compile a
+/// no-op stub that returns a configuration error from `setup()`).
+/// Lives here rather than in a downstream example so any consumer
+/// that wants the camera frame as a GPU-resident CUDA tensor picks
+/// it up for free without re-deriving the VkBuffer / timeline /
+/// surface-share / adapter wiring.
+pub mod camera_to_cuda_copy;
+
 #[cfg(target_os = "linux")]
 pub mod linux;
 
@@ -18,6 +27,12 @@ pub mod linux;
 pub mod apple;
 
 pub use camera::{CameraDevice, CameraProcessor};
+pub use camera_to_cuda_copy::{
+    CameraToCudaCopyConfig, CameraToCudaCopyProcessor, CUDA_CAMERA_SURFACE_ID,
+};
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))]
-streamlib_plugin_abi::export_plugin!(crate::CameraProcessor::Processor);
+streamlib_plugin_abi::export_plugin!(
+    crate::CameraProcessor::Processor,
+    crate::CameraToCudaCopyProcessor::Processor,
+);

--- a/packages/camera/src/lib.rs
+++ b/packages/camera/src/lib.rs
@@ -27,9 +27,11 @@ pub mod linux;
 pub mod apple;
 
 pub use camera::{CameraDevice, CameraProcessor};
-pub use camera_to_cuda_copy::{
-    CameraToCudaCopyConfig, CameraToCudaCopyProcessor, CUDA_CAMERA_SURFACE_ID,
-};
+pub use camera_to_cuda_copy::{CameraToCudaCopyProcessor, CUDA_CAMERA_SURFACE_ID};
+// Re-exported from `_generated_` (codegen'd from
+// `schemas/camera_to_cuda_copy_config.yaml`) so callers can construct
+// the config without reaching into the `_generated_` path themselves.
+pub use _generated_::CameraToCudaCopyConfig;
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))]
 streamlib_plugin_abi::export_plugin!(

--- a/packages/camera/streamlib.yaml
+++ b/packages/camera/streamlib.yaml
@@ -37,6 +37,8 @@ schemas:
   # Local config schemas this package owns.
   CameraConfig:
     file: schemas/camera_config.yaml
+  CameraToCudaCopyConfig:
+    file: schemas/camera_to_cuda_copy_config.yaml
 
 processors:
   - name: Camera
@@ -59,6 +61,9 @@ processors:
     execution: reactive
     scheduling:
       priority: high
+    config:
+      name: config
+      schema: CameraToCudaCopyConfig
     inputs:
       - name: video_in
         schema: VideoFrame

--- a/packages/camera/streamlib.yaml
+++ b/packages/camera/streamlib.yaml
@@ -2,10 +2,14 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 
-# @tatolab/camera — camera capture processor cluster carved out of the
-# streamlib engine substrate. Owns the camera config schema and the
-# Camera processor declaration (Linux V4L2 + macOS AVFoundation behind
-# a single platform-aliased name).
+# @tatolab/camera — camera capture processor cluster carved out of
+# the streamlib engine substrate. Owns:
+#  - the Camera processor (Linux V4L2 + macOS AVFoundation behind a
+#    single platform-aliased name)
+#  - the CameraToCudaCopy host-pipeline processor (Linux-only) for
+#    consumers that want the camera frame as a GPU-resident CUDA
+#    tensor (PyTorch / JAX / cuDNN / OptiX) with zero CPU staging
+#    on the inference path
 package:
   org: tatolab
   name: camera
@@ -48,3 +52,18 @@ processors:
       - name: video
         schema: VideoFrame
         description: Live video frames from the camera
+
+  - name: CameraToCudaCopy
+    version: 1.0.0
+    description: "Host-pipeline producer: camera VkImage -> cuda OPAQUE_FD VkBuffer with timeline signal for cross-API CUDA interop. Linux-only (CUDA is Linux-only on the in-tree adapter set)."
+    execution: reactive
+    scheduling:
+      priority: high
+    inputs:
+      - name: video_in
+        schema: VideoFrame
+        description: "Camera ring texture (RGBA8 DMA-BUF) frame metadata"
+    outputs:
+      - name: video_out
+        schema: VideoFrame
+        description: "Camera frame forwarded verbatim; cuda surface side-effect happens during process()"


### PR DESCRIPTION
## Summary

- Move the `CameraToCudaCopy` host-pipeline processor (camera VkImage → cuda OPAQUE_FD VkBuffer with timeline signal) out of `examples/camera-python-display/src/` and into the `@tatolab/camera` package. Any consumer that needs the camera frame as a GPU-resident CUDA tensor (PyTorch / JAX / cuDNN / OptiX) picks it up via `Runner::load_workspace_packages([\"@tatolab/camera\"])` without re-deriving the VkBuffer / timeline / surface-share wiring.
- The example switches from in-tree `runtime.add_processor(CameraToCudaCopyProcessor::node(...))` to `ProcessorSpec::new(schema_ident!(\"tatolab\", \"camera\", \"CameraToCudaCopy\", \"1.0.0\"), ...)` against the package identifier — package deps flow through `streamlib.yaml` + `Runner::load_workspace_packages`, NOT through Cargo. The example does NOT Cargo-dep `streamlib-camera`.

## Why

`CameraToCudaCopy` is a generic primitive: any consumer that wants the camera frame as a GPU-resident CUDA tensor would have to re-derive the same `HostVulkanBuffer::new_opaque_fd_export_device_local` + `HostVulkanTimelineSemaphore::new_exportable` + surface-share registration + per-frame `vkCmdCopyImageToBuffer` shape. Trapping it in a single example was always wrong-shaped — it's camera-package surface, not example surface. The `BlendingCompositor` and `CrtFilmGrain` processors are different — those encode the cyberpunk visual identity of the example, so they stay in-tree.

## Changes

- `packages/camera/src/camera_to_cuda_copy.rs` — new file (moved from `examples/camera-python-display/src/`). Imports adjusted to use the camera package's `_generated_::VideoFrame` namespace. `VulkanLayout` imported from `streamlib_consumer_rhi` (canonical home, consistent with the rest of the camera package).
- `packages/camera/src/lib.rs` — declares the new module, extends `export_plugin!` so the camera cdylib's `STREAMLIB_PLUGIN` callback registers both `Camera` and `CameraToCudaCopy`. Re-exports `CameraToCudaCopyProcessor`, `CameraToCudaCopyConfig`, and `CUDA_CAMERA_SURFACE_ID` at package scope.
- `packages/camera/streamlib.yaml` — adds `CameraToCudaCopyConfig` schema entry + `CameraToCudaCopy` processor declaration with `config: { name: config, schema: CameraToCudaCopyConfig }` so JSON payloads passed via `ProcessorSpec` actually drive width/height.
- `packages/camera/schemas/camera_to_cuda_copy_config.yaml` — new JTD schema, `optionalProperties` for width/height (JTD has no `default:` keyword; consumer applies `.unwrap_or(1920/1080)` in `setup()`).
- `packages/camera/Cargo.toml` — adds Linux-only deps on `streamlib-adapter-cuda` (the host-side CUDA surface adapter; cudarc-free, no `libcuda.so` link surface — `cudarc` integration happens in the cdylib consumer) and `streamlib-adapter-abi` (`SurfaceId` + `AdapterError` types).
- `examples/camera-python-display/src/camera_to_cuda_copy.rs` — deleted.
- `examples/camera-python-display/src/main.rs` — drops the `mod camera_to_cuda_copy;` declaration.
- `examples/camera-python-display/src/linux.rs` — switches the `add_processor` call to `ProcessorSpec::new(schema_ident!(\"tatolab\", \"camera\", \"CameraToCudaCopy\", \"1.0.0\"), json!({}))`. Inlines the cuda surface_id literal (`484_001`) with a comment pointing at the package's source-of-truth constant.
- `examples/camera-python-display/Cargo.toml` — drops the `streamlib-adapter-cuda` direct dep (transitive through `@tatolab/camera`). Clarifies that package deps flow through `streamlib.yaml`, not Cargo.
- `examples/camera-python-display/streamlib.yaml` — drops the `CameraToCudaCopy` processor declaration (the camera package owns it now).

## Out of scope

The remaining in-tree processors in `camera-python-display` (`BlendingCompositor`, `CrtFilmGrain`) have similar registration issues after the all-dynamic migration (#793 / #1040) and remain blocked on the polyglot-examples-migration goal (#804). The example will not run end-to-end after this PR; it gets past the `CameraToCudaCopy` failure point only. That's the explicit scope cut.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo run --bin xtask -- check-boundaries` green (no `vulkanalia` / `ash` outside RHI)
- [x] `cargo run --bin xtask -- check-cdylib-reach` green
- [x] `cargo run --bin xtask -- check-no-inventory-submit` green
- [x] `cargo xtask build-plugins --package @tatolab/camera` stages a cdylib that registers BOTH processors at load time
- [x] E2E: `camera-python-display` against `/dev/video0` logs `new processor type registered '@tatolab/camera/CameraToCudaCopy@1.0.0'` and progresses through the carved-out wiring (subsequent failure on `BlendingCompositor` is the documented out-of-scope issue)

## pr-review-gate verdict

DISCUSS → all 5 items investigated. The two genuine concerns were addressed in the follow-up commit:
1. The original carve-out kept the silent-discard-JSON-config pattern (custom Rust field bypasses the macro's config-resolution path). Fixed by adding the schema YAML, declaring `config:` in `streamlib.yaml`, and dropping the hand-defined Rust struct in favor of the codegen'd one.
2. `VulkanLayout` import inconsistency — moved to import from `streamlib_consumer_rhi` (canonical) matching the rest of the package.

The remaining 3 DISCUSS items were either out of scope (transitive cuda dep growth in two unrelated examples that themselves Cargo-dep `streamlib-camera` in the pre-migration shape — goal-14 territory), accepted per the user's explicit \"no Cargo dep on packages\" mandate (the surface-id literal `484_001` is duplicated in the example with a comment instead of imported), or skipped (no GPU-requiring test added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)