### PR TITLE
chore(schemas): regen streamlib.schema.json from Rust source of truth

### DIFF
--- a/schemas/streamlib.schema.json
+++ b/schemas/streamlib.schema.json
@@ -533,9 +533,9 @@
       "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
     },
     "SemVerRange": {
-      "description": "SemVer range matcher: `=1.2.3` exact, `>=1.2.3` lower bound, `^1.2.3` caret (npm), `~1.2.3` tilde, or bare `1.2.3` (exact).",
+      "description": "SemVer range matcher: `*` (any), `=1.2.3` exact, `>=1.2.3` lower bound, `^1.2.3` caret (npm), `~1.2.3` tilde, or bare `1.2.3` (exact).",
       "type": "string",
-      "pattern": "^(\\^|~|>=|=)?[0-9]+\\.[0-9]+\\.[0-9]+$"
+      "pattern": "^(\\*|(\\^|~|>=|=)?[0-9]+\\.[0-9]+\\.[0-9]+)$"
     },
     "ThreadPriority": {
       "description": "Thread scheduling priority.\n\nSerializes as `\"realtime\"` / `\"high\"` / `\"normal\"` so YAML manifests can declare `scheduling: { priority: high }` without PascalCase noise.",


### PR DESCRIPTION
## Summary

Run \`cargo xtask emit-manifest-schema\` to regenerate \`schemas/streamlib.schema.json\` from the Rust \`StreamlibYaml\` source of truth — main has been failing the \`xtask check-manifest-schema\` CI gate because the JSON Schema artifact drifted behind the Rust enum's recent \`*\` (wildcard) support in \`SemVerRange\`.

Two-line diff: description + pattern. No semantic change — the Rust enum already supports the wildcard; the JSON Schema mirror just hadn't been regenerated.

## Test plan

- [x] \`cargo run --bin xtask -- check-manifest-schema\` passes locally after the regen
- [x] CI's \`Check Manifest Schema\` workflow should go green on this branch (was failing on main)

Unblocks #1042 and #1043 from inheriting the same failing check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)