### PR TITLE
chore(examples): migrate cpu-readback/cuda/dma-buf polyglot examples to monorepo-with-sub-packages shape (#804, PR 2/3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,8 +65,8 @@ members = [
     "examples/camera-python-display",     # Example: Camera → Python → Display pipeline
     "examples/camera-python-subprocess",  # Example: Camera → Python subprocess → Display pipeline
     "examples/camera-deno-subprocess",   # Example: Camera → Deno subprocess → Display pipeline
-    "examples/polyglot-dma-buf-consumer", # Example: Camera → Python DMA-BUF consumer → Display (Linux polyglot E2E)
-    "examples/polyglot-cpu-readback-blur", # Example: Polyglot cpu-readback adapter — Python cv2 / Deno hand-rolled Gaussian blur (#529)
+    "examples/polyglot-dma-buf-consumer/runner", # Example: Camera → Python DMA-BUF consumer → Display (Linux polyglot E2E)
+    "examples/polyglot-cpu-readback-blur/runner", # Example: Polyglot cpu-readback adapter — Python cv2 / Deno hand-rolled Gaussian blur (#529)
     "examples/polyglot-manual-source",       # Example: Polyglot manual source — Python/Deno worker thread paced by MonotonicTimer (#542)
     "examples/polyglot-manual-source/plugin", # Counting-sink Rust dylib plugin for polyglot-manual-source (#604)
     "examples/polyglot-continuous-processor", # Example: Polyglot continuous processor — Python/Deno process() driven by monotonic-clock timerfd (#542)
@@ -75,7 +75,7 @@ members = [
     "examples/polyglot-vulkan-graphics/runner",  # Example: Polyglot Vulkan adapter — Python/Deno triangle vertex/fragment graphics kernel rendered into a host DMA-BUF VkImage (#656)
     "examples/polyglot-vulkan-ray-tracing/runner", # Example: Polyglot Vulkan adapter — Python/Deno ray-traced cube via host VulkanRayTracingKernel + AS escalate IPC (#667)
     "examples/polyglot-skia-canvas/runner",      # Example: Polyglot Skia adapter — Python skia-python draws into a host DMA-BUF VkImage via composing on the Vulkan adapter (#513)
-    "examples/polyglot-cuda-inference",   # Example: Polyglot CUDA adapter — Python YOLO inference / Deno DLPack capsule validation against a host OPAQUE_FD VkBuffer (#591)
+    "examples/polyglot-cuda-inference/runner",   # Example: Polyglot CUDA adapter — Python YOLO inference / Deno DLPack capsule validation against a host OPAQUE_FD VkBuffer (#591)
     "examples/cuda-fisheye-detection/runner", # Example: Polyglot CUDA adapter image path — host fisheye-warps bus.jpg into an OPAQUE_FD VkImage, Python undistorts via cupy.RawKernel hardware bilinear + YOLOv8n detection
     "examples/camera-rust-plugin",       # Example: Camera → Rust dylib plugin → Display pipeline
     "examples/camera-rust-plugin/plugin", # Grayscale plugin cdylib for camera-rust-plugin example

--- a/docs/architecture/adapter-authoring.md
+++ b/docs/architecture/adapter-authoring.md
@@ -453,7 +453,7 @@ has created the live `GpuContext`, before any processor's `setup()`
 runs — the window where adapter bridges and pre-allocated host
 surfaces have to be in place.
 
-See `examples/polyglot-cpu-readback-blur/src/main.rs` for the
+See `examples/polyglot-cpu-readback-blur/runner/src/main.rs` for the
 canonical reference (it exercises the bridge path; GPU adapters
 omit the `set_*_bridge` step).
 

--- a/docs/architecture/adapter-runtime-integration.md
+++ b/docs/architecture/adapter-runtime-integration.md
@@ -50,7 +50,7 @@ Metadata travels alongside FDs: `width`, `height`, `format`,
 extensible — additional JSON fields can be added without breaking
 existing clients.
 
-Already used by `examples/polyglot-dma-buf-consumer/` from both
+Already used by `examples/polyglot-dma-buf-consumer/runner/` from both
 Python and Deno via `ctx.gpu_limited_access.resolve_surface(id)`,
 which under the hood does a `check_out` and hands back a handle
 the subprocess can `lock` / read / `unlock` / `release`.
@@ -299,7 +299,7 @@ shape (`gpu.set_compute_kernel_bridge`, `set_graphics_kernel_bridge`,
 dispatch through the host RHI.
 
 Reference implementation:
-`examples/polyglot-cpu-readback-blur/src/main.rs`. That example shows
+`examples/polyglot-cpu-readback-blur/runner/src/main.rs`. That example shows
 the cpu-readback case (which exercises the bridge path); the GPU
 adapters use the same hook but skip the `set_*_bridge` step.
 

--- a/examples/polyglot-cpu-readback-blur/runner/Cargo.toml
+++ b/examples/polyglot-cpu-readback-blur/runner/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
-streamlib-adapter-cpu-readback = { path = "../../libs/streamlib-adapter-cpu-readback" }
+streamlib = { path = "../../../libs/streamlib-sdk" }
+streamlib-adapter-abi = { path = "../../../libs/streamlib-adapter-abi" }
+streamlib-adapter-cpu-readback = { path = "../../../libs/streamlib-adapter-cpu-readback" }
 serde_json = "1.0"
 png = "0.17"
 

--- a/examples/polyglot-cpu-readback-blur/runner/src/main.rs
+++ b/examples/polyglot-cpu-readback-blur/runner/src/main.rs
@@ -32,9 +32,6 @@
 //! processor ignores `frame.surface_id` and works on the
 //! cpu-readback host surface (id `1`) the host pre-registered.
 //!
-//! Build the Python `.slpkg` first:
-//!   cargo run -p streamlib-cli -- pack examples/polyglot-cpu-readback-blur/python
-//!
 //! Run:
 //!   cargo run -p polyglot-cpu-readback-blur-scenario -- \
 //!       --runtime=python --output=/tmp/cpu-readback-blur.png
@@ -201,31 +198,14 @@ fn main() -> Result<()> {
         .load_workspace_packages(["@tatolab/debug-utilities"])
         .map_err(streamlib::sdk::error::Error::from)?;
 
-    // Load the polyglot blur processor (Python or Deno subprocess host).
+    // Load the polyglot processors declaratively. The runner's
+    // `streamlib.yaml` declares both the Python and Deno sub-packages
+    // via `patch:` `path:` overrides; `load_project` walks the manifest,
+    // resolves both, and registers each package's processors + schemas.
+    // The runner then picks which one to instantiate via
+    // `schema_ident_any_version!` based on `--runtime`.
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    match runtime_kind {
-        RuntimeKind::Python => {
-            let slpkg_path =
-                manifest_dir.join("python/polyglot-cpu-readback-blur-0.1.0.slpkg");
-            if !slpkg_path.exists() {
-                return Err(Error::Configuration(format!(
-                    "Package not found: {}\nRun: cargo run -p streamlib-cli -- pack examples/polyglot-cpu-readback-blur/python",
-                    slpkg_path.display()
-                )));
-            }
-            runtime.load_package(&slpkg_path)?;
-        }
-        RuntimeKind::Deno => {
-            let project_path = manifest_dir.join("deno");
-            if !project_path.join("streamlib.yaml").exists() {
-                return Err(Error::Configuration(format!(
-                    "Deno project not found: {}",
-                    project_path.display()
-                )));
-            }
-            runtime.load_project(&project_path)?;
-        }
-    }
+    runtime.load_project(&manifest_dir)?;
 
     // Trigger source: a tiny BGRA fixture that drives Videoframes
     // through the pipeline so the polyglot processor's `process()` is

--- a/examples/polyglot-cpu-readback-blur/runner/streamlib.yaml
+++ b/examples/polyglot-cpu-readback-blur/runner/streamlib.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=../../../schemas/streamlib.schema.json
+#
+# Rust runner sub-package. Declares deps on the sibling Python and Deno
+# sub-packages via `patch:` `path:` overrides — `Runner::load_project(".")`
+# walks this manifest, resolves the declared sub-packages against their
+# local paths, and registers every declared processor + schema. The
+# runner picks which sibling's processor to instantiate at startup based
+# on `--runtime`.
+
+package:
+  org: tatolab
+  name: polyglot-cpu-readback-blur-runner
+  version: "0.1.0"
+  description: "Rust runner sub-package — host pre-registers a cpu-readback surface and wires the polyglot pipeline that runs a Gaussian blur (Python cv2 / Deno hand-rolled) against it"
+
+dependencies:
+  "@tatolab/core": "^1.0.0"
+  "@tatolab/polyglot-cpu-readback-blur": "^0.1.0"
+  "@tatolab/polyglot-cpu-readback-blur-deno": "^0.1.0"
+
+patch:
+  "@tatolab/core":
+    path: ../../../packages/core
+  "@tatolab/polyglot-cpu-readback-blur":
+    path: ../python
+  "@tatolab/polyglot-cpu-readback-blur-deno":
+    path: ../deno
+
+schemas:
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
+  VideoFrame:
+    package: "@tatolab/core"

--- a/examples/polyglot-cuda-inference/runner/Cargo.toml
+++ b/examples/polyglot-cuda-inference/runner/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
-streamlib-adapter-cuda = { path = "../../libs/streamlib-adapter-cuda" }
+streamlib = { path = "../../../libs/streamlib-sdk" }
+streamlib-adapter-abi = { path = "../../../libs/streamlib-adapter-abi" }
+streamlib-adapter-cuda = { path = "../../../libs/streamlib-adapter-cuda" }
 serde_json = "1.0"

--- a/examples/polyglot-cuda-inference/runner/src/main.rs
+++ b/examples/polyglot-cuda-inference/runner/src/main.rs
@@ -34,9 +34,6 @@
 //! The trigger frame's contents are unused — the polyglot processor
 //! works on the pre-registered cuda OPAQUE_FD surface (id `1`).
 //!
-//! Build the Python `.slpkg` first:
-//!   cargo run -p streamlib-cli -- pack examples/polyglot-cuda-inference/python
-//!
 //! Run:
 //!   cargo run -p polyglot-cuda-inference-scenario -- \
 //!       --runtime=python --output=/tmp/cuda-inference.png
@@ -189,31 +186,14 @@ fn main() -> Result<()> {
         .load_workspace_packages(["@tatolab/debug-utilities"])
         .map_err(streamlib::sdk::error::Error::from)?;
 
-    // Load the polyglot CUDA-inference processor (Python or Deno subprocess host).
+    // Load the polyglot processors declaratively. The runner's
+    // `streamlib.yaml` declares both the Python and Deno sub-packages
+    // via `patch:` `path:` overrides; `load_project` walks the manifest,
+    // resolves both, and registers each package's processors + schemas.
+    // The runner then picks which one to instantiate via
+    // `schema_ident_any_version!` based on `--runtime`.
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    match runtime_kind {
-        RuntimeKind::Python => {
-            let slpkg_path =
-                manifest_dir.join("python/polyglot-cuda-inference-0.1.0.slpkg");
-            if !slpkg_path.exists() {
-                return Err(Error::Configuration(format!(
-                    "Package not found: {}\nRun: cargo run -p streamlib-cli -- pack examples/polyglot-cuda-inference/python",
-                    slpkg_path.display()
-                )));
-            }
-            runtime.load_package(&slpkg_path)?;
-        }
-        RuntimeKind::Deno => {
-            let project_path = manifest_dir.join("deno");
-            if !project_path.join("streamlib.yaml").exists() {
-                return Err(Error::Configuration(format!(
-                    "Deno project not found: {}",
-                    project_path.display()
-                )));
-            }
-            runtime.load_project(&project_path)?;
-        }
-    }
+    runtime.load_project(&manifest_dir)?;
 
     // Trigger source: a tiny BGRA fixture that drives Videoframes
     // through the pipeline so the polyglot processor's `process()` is

--- a/examples/polyglot-cuda-inference/runner/streamlib.yaml
+++ b/examples/polyglot-cuda-inference/runner/streamlib.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=../../../schemas/streamlib.schema.json
+#
+# Rust runner sub-package. Declares deps on the sibling Python and Deno
+# sub-packages via `patch:` `path:` overrides — `Runner::load_project(".")`
+# walks this manifest, resolves the declared sub-packages against their
+# local paths, and registers every declared processor + schema. The
+# runner picks which sibling's processor to instantiate at startup based
+# on `--runtime`.
+
+package:
+  org: tatolab
+  name: polyglot-cuda-inference-runner
+  version: "0.1.0"
+  description: "Rust runner sub-package — host pre-registers an OPAQUE_FD VkBuffer and wires the polyglot pipeline that runs YOLO inference (Python) / DLPack capsule validation (Deno) against it via the CUDA adapter"
+
+dependencies:
+  "@tatolab/core": "^1.0.0"
+  "@tatolab/polyglot-cuda-inference": "^0.1.0"
+  "@tatolab/polyglot-cuda-inference-deno": "^0.1.0"
+
+patch:
+  "@tatolab/core":
+    path: ../../../packages/core
+  "@tatolab/polyglot-cuda-inference":
+    path: ../python
+  "@tatolab/polyglot-cuda-inference-deno":
+    path: ../deno
+
+schemas:
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
+  VideoFrame:
+    package: "@tatolab/core"

--- a/examples/polyglot-dma-buf-consumer/runner/Cargo.toml
+++ b/examples/polyglot-dma-buf-consumer/runner/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../../libs/streamlib-sdk" }
 serde_json = "1.0"

--- a/examples/polyglot-dma-buf-consumer/runner/src/main.rs
+++ b/examples/polyglot-dma-buf-consumer/runner/src/main.rs
@@ -20,11 +20,8 @@
 //! `force_bad_surface_id` config so resolve_surface fails deterministically on
 //! every frame — the pipeline must still shut down cleanly.
 //!
-//! Build the Python .slpkg first when running --runtime=python (or it will
-//! not be found):
-//!   cargo run -p streamlib-cli -- pack examples/polyglot-dma-buf-consumer/python
-//!
-//! The Deno project loads its `streamlib.yaml` directly — no pack step.
+//! Both Python and Deno sub-packages are loaded declaratively via the
+//! runner's `streamlib.yaml` (no separate pack step required).
 
 use std::path::PathBuf;
 
@@ -125,30 +122,14 @@ fn main() -> Result<()> {
         .load_workspace_packages(["@tatolab/camera", "@tatolab/display"])
         .map_err(streamlib::sdk::error::Error::from)?;
 
+    // Load the polyglot processors declaratively. The runner's
+    // `streamlib.yaml` declares both the Python and Deno sub-packages
+    // via `patch:` `path:` overrides; `load_project` walks the manifest,
+    // resolves both, and registers each package's processors + schemas.
+    // The runner then picks which one to instantiate via
+    // `schema_ident_any_version!` based on `--runtime`.
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    match runtime_kind {
-        RuntimeKind::Python => {
-            let slpkg_path =
-                manifest_dir.join("python/polyglot-dma-buf-consumer-0.1.0.slpkg");
-            if !slpkg_path.exists() {
-                return Err(streamlib::sdk::error::Error::Configuration(format!(
-                    "Package not found: {}\nRun: cargo run -p streamlib-cli -- pack examples/polyglot-dma-buf-consumer/python",
-                    slpkg_path.display()
-                )));
-            }
-            runtime.load_package(&slpkg_path)?;
-        }
-        RuntimeKind::Deno => {
-            let project_path = manifest_dir.join("deno");
-            if !project_path.join("streamlib.yaml").exists() {
-                return Err(streamlib::sdk::error::Error::Configuration(format!(
-                    "Deno project not found: {}",
-                    project_path.display()
-                )));
-            }
-            runtime.load_project(&project_path)?;
-        }
-    }
+    runtime.load_project(&manifest_dir)?;
 
     let camera = runtime.add_processor(ProcessorSpec::new(
         schema_ident!("tatolab", "camera", "Camera", "1.0.0"),

--- a/examples/polyglot-dma-buf-consumer/runner/streamlib.yaml
+++ b/examples/polyglot-dma-buf-consumer/runner/streamlib.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=../../../schemas/streamlib.schema.json
+#
+# Rust runner sub-package. Declares deps on the sibling Python and Deno
+# sub-packages via `patch:` `path:` overrides — `Runner::load_project(".")`
+# walks this manifest, resolves the declared sub-packages against their
+# local paths, and registers every declared processor + schema. The
+# runner picks which sibling's processor to instantiate at startup based
+# on `--runtime`.
+
+package:
+  org: tatolab
+  name: polyglot-dma-buf-consumer-runner
+  version: "0.1.0"
+  description: "Rust runner sub-package — host pre-registers a DMA-BUF surface and wires the polyglot pipeline that consumes the surface from a Python or Deno subprocess via the surface-share daemon (Linux polyglot E2E)"
+
+dependencies:
+  "@tatolab/core": "^1.0.0"
+  "@tatolab/polyglot-dma-buf-consumer": "^0.1.0"
+  "@tatolab/polyglot-dma-buf-consumer-deno": "^0.1.0"
+
+patch:
+  "@tatolab/core":
+    path: ../../../packages/core
+  "@tatolab/polyglot-dma-buf-consumer":
+    path: ../python
+  "@tatolab/polyglot-dma-buf-consumer-deno":
+    path: ../deno
+
+schemas:
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
+  VideoFrame:
+    package: "@tatolab/core"


### PR DESCRIPTION
## Summary

PR 2/3 in the goal-14 sweep against #804 — same shape as PR #1045 applied to the **cpu-readback / cuda / dma-buf cluster**.

Covered examples (3):
- `polyglot-cpu-readback-blur`
- `polyglot-cuda-inference`
- `polyglot-dma-buf-consumer`

Each example's Rust scenario binary moves into its own `runner/` sub-package; `runner/streamlib.yaml` declares the sibling Python and Deno sub-packages via `patch: path:` overrides; `main.rs` replaces the per-runtime `load_package(slpkg)` / `load_project(deno)` branches with a single `runtime.load_project(manifest_dir)` call. The separate `cargo run -p streamlib-cli -- pack examples/.../python` step is no longer required.

Cargo.toml adapter deps (`streamlib-adapter-cpu-readback`, `streamlib-adapter-cuda`, `streamlib-adapter-abi`) kept as-is — matches the cuda-fisheye-detection reference shape. Path deps bumped (`../../libs/...` → `../../../libs/...`). Workspace `Cargo.toml` member paths updated. Three stale doc references swept in `docs/architecture/adapter-{authoring,runtime-integration}.md`.

PR 3/3 will follow with the manual-source / continuous-processor + camera-{python,deno} cluster.

## Test plan

- [x] `cargo check -p polyglot-cpu-readback-blur-scenario -p polyglot-cuda-inference-scenario -p polyglot-dma-buf-consumer-scenario` — green
- [ ] E2E run of each migrated example end-to-end (Python + Deno) — requires GPU + Python/Deno hosts, run locally before merge

## Notes for reviewer

- pr-review-gate PASS, no issues.
- Pattern is identical to PR #1045 — review focus is on the dep-name / version / `patch:` correctness for the three new examples (all match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)