### PR TITLE
fix(engine): port-spec helpers error on registry miss (closes #869)

### DIFF
--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -957,13 +957,13 @@ mod tests {
             .expect("fan-in == cap must succeed");
     }
 
-    /// Wire-time integration lock for issue #869: when a processor's
-    /// registered output port carries a `PortSchemaSpec::Specific(ident)`
-    /// whose canonical id is NOT in the runtime schema registry (the
-    /// "forgot to call `runtime.load_project(...)`" footgun), the helper
-    /// chain `port_info → data_type → max_payload_bytes_for_port_spec`
+    /// Wire-time integration lock: when a processor's registered output
+    /// port carries a `PortSchemaSpec::Specific(ident)` whose canonical
+    /// id is NOT in the runtime schema registry (the "forgot to call
+    /// `runtime.load_project(...)`" footgun), the helper chain
+    /// `port_info → data_type → max_payload_bytes_for_port_spec`
     /// surfaces a typed configuration error pointing at `load_project`
-    /// rather than silently falling back to `MAX_PAYLOAD_SIZE` and
+    /// rather than silently falling back to the iceoryx2 default and
     /// deferring the failure to first publish.
     ///
     /// Locks the registry-miss-vs-load-project boundary at the same

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -352,13 +352,14 @@ fn open_iceoryx2_pubsub(
 
     // Create iceoryx2 Service (pub/sub) and paired Notify service (event/fd-wake).
     let iceoryx2_node = runtime_ctx.iceoryx2_node();
-    let max_queued_messages = max_queued_messages_for_port_spec(&output_schema);
+    let max_queued_messages = max_queued_messages_for_port_spec(&output_schema)?;
+    let max_payload = max_payload_bytes_for_port_spec(&output_schema)?;
     let service =
         iceoryx2_node.open_or_create_service(&service_name, max_queued_messages)?;
     let notify_service = iceoryx2_node.open_or_create_notify_service(&notify_service_name)?;
 
     // Create Publisher sized for this schema's declared max payload.
-    let publisher = service.create_publisher(max_payload_bytes_for_port_spec(&output_schema))?;
+    let publisher = service.create_publisher(max_payload)?;
     let notifier = notify_service.create_notifier()?;
     tracing::debug!(
         "Created iceoryx2 Publisher+Notifier for '{}' -> service '{}'",
@@ -484,8 +485,8 @@ fn open_iceoryx2_subprocess_to_subprocess(
             })
             .unwrap_or_default()
     };
-    let max_payload = max_payload_bytes_for_port_spec(&output_schema);
-    let max_queued_messages = max_queued_messages_for_port_spec(&output_schema);
+    let max_payload = max_payload_bytes_for_port_spec(&output_schema)?;
+    let max_queued_messages = max_queued_messages_for_port_spec(&output_schema)?;
 
     // Ensure both services exist (both subprocesses will open them independently).
     let iceoryx2_node = runtime_ctx.iceoryx2_node();
@@ -618,8 +619,8 @@ fn open_iceoryx2_subprocess_to_rust(
             })
             .unwrap_or_default()
     };
-    let max_payload = max_payload_bytes_for_port_spec(&output_schema);
-    let max_queued_messages = max_queued_messages_for_port_spec(&output_schema);
+    let max_payload = max_payload_bytes_for_port_spec(&output_schema)?;
+    let max_queued_messages = max_queued_messages_for_port_spec(&output_schema)?;
 
     let iceoryx2_node = runtime_ctx.iceoryx2_node();
     let service =
@@ -759,8 +760,8 @@ fn open_iceoryx2_rust_to_subprocess(
     };
 
     let iceoryx2_node = runtime_ctx.iceoryx2_node();
-    let max_payload = max_payload_bytes_for_port_spec(&output_schema);
-    let max_queued_messages = max_queued_messages_for_port_spec(&output_schema);
+    let max_payload = max_payload_bytes_for_port_spec(&output_schema)?;
+    let max_queued_messages = max_queued_messages_for_port_spec(&output_schema)?;
     let service =
         iceoryx2_node.open_or_create_service(&service_name, max_queued_messages)?;
     let notify_service = iceoryx2_node.open_or_create_notify_service(&notify_service_name)?;
@@ -954,5 +955,102 @@ mod tests {
         let dest_uid: ProcessorUniqueId = dest_id.as_str().into();
         reject_overcap_destination_fanin(&mut graph, &dest_uid)
             .expect("fan-in == cap must succeed");
+    }
+
+    /// Wire-time integration lock for issue #869: when a processor's
+    /// registered output port carries a `PortSchemaSpec::Specific(ident)`
+    /// whose canonical id is NOT in the runtime schema registry (the
+    /// "forgot to call `runtime.load_project(...)`" footgun), the helper
+    /// chain `port_info → data_type → max_payload_bytes_for_port_spec`
+    /// surfaces a typed configuration error pointing at `load_project`
+    /// rather than silently falling back to `MAX_PAYLOAD_SIZE` and
+    /// deferring the failure to first publish.
+    ///
+    /// Locks the registry-miss-vs-load-project boundary at the same
+    /// shape `open_iceoryx2_pubsub` exercises: descriptor declares port
+    /// schema → `PROCESSOR_REGISTRY.port_info(...)` reads it → the
+    /// resolver gates allocation on registry membership. The compiler-
+    /// enforced `?` operator at every helper call site in this module
+    /// guarantees the error propagates out of `open_iceoryx2_service`,
+    /// out of `compile_phase`, out of `Runner::start()`. Reverting the
+    /// helper signature back to infallible `usize` would fail compilation
+    /// of every call site immediately.
+    #[test]
+    fn unregistered_specific_port_schema_surfaces_typed_error_at_wire_time() {
+        use crate::core::descriptors::{
+            CodeExamples, PortDescriptor, ProcessorDescriptor, ProcessorRuntime,
+            ProcessorScheduling,
+        };
+        use crate::core::embedded_schemas::max_payload_bytes_for_port_spec;
+        use streamlib_idents::{Org, Package, SemVer, TypeName};
+        use streamlib_processor_schema::PortSchemaSpec;
+
+        // Mint a processor identity (the carrying processor) that's
+        // unique to this test so the registry can hold it across runs.
+        let processor_ident = SchemaIdent::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("test-wire-time-registry-miss").unwrap(),
+            TypeName::new("CarryingProcessor").unwrap(),
+            SemVer::new(1, 0, 0),
+        );
+        // Mint a wire schema identity whose package was NEVER loaded
+        // via `runtime.load_project(...)`. The processor declares an
+        // output port carrying this schema.
+        let unloaded_schema_ident = SchemaIdent::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("test-wire-time-unloaded-schema-pkg").unwrap(),
+            TypeName::new("UnloadedWireType").unwrap(),
+            SemVer::new(1, 0, 0),
+        );
+        let unloaded_spec = PortSchemaSpec::Specific(unloaded_schema_ident.clone());
+
+        let descriptor = ProcessorDescriptor {
+            name: processor_ident.clone(),
+            description: "wire-time registry-miss regression mock".into(),
+            version: "1.0.0".into(),
+            repository: String::new(),
+            runtime: ProcessorRuntime::Rust,
+            entrypoint: None,
+            config_schema: None,
+            scheduling: ProcessorScheduling::default(),
+            inputs: Vec::new(),
+            outputs: vec![PortDescriptor::iceoryx2(
+                "out_unloaded",
+                "carries UnloadedWireType",
+                unloaded_spec,
+            )],
+            examples: CodeExamples::default(),
+        };
+        PROCESSOR_REGISTRY
+            .register_descriptor_only(descriptor)
+            .expect("register_descriptor_only must accept a fresh ident");
+
+        // Drive the exact lookup chain the open_iceoryx2_pubsub /
+        // open_iceoryx2_rust_to_subprocess / open_iceoryx2_subprocess_to_*
+        // helpers run when wiring a service.
+        let (_, outputs) = PROCESSOR_REGISTRY
+            .port_info(&processor_ident)
+            .expect("port_info must return the descriptor's ports");
+        let output_spec = outputs
+            .iter()
+            .find(|p| p.name == "out_unloaded")
+            .map(|p| p.data_type.clone())
+            .expect("descriptor advertises `out_unloaded`");
+
+        let err = max_payload_bytes_for_port_spec(&output_spec)
+            .expect_err("registry miss must surface as Err at wire time");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("@tatolab/test-wire-time-unloaded-schema-pkg/UnloadedWireType"),
+            "error must name the missing canonical id; got: {msg}"
+        );
+        assert!(
+            msg.contains("load_project"),
+            "error must point at `runtime.load_project(...)` as the fix; got: {msg}"
+        );
+        assert!(
+            matches!(err, crate::core::error::Error::Configuration(_)),
+            "registry miss at wire time must surface as Error::Configuration; got: {err:?}"
+        );
     }
 }

--- a/libs/streamlib-engine/src/core/embedded_schemas/integration_tests.rs
+++ b/libs/streamlib-engine/src/core/embedded_schemas/integration_tests.rs
@@ -129,41 +129,53 @@ fn test_loan_256kb_succeeds_with_512kb_publisher_limit() {
 #[test]
 fn test_schema_max_payload_bytes_audioframe() {
     test_support::register_core_wire_vocabulary();
-    let bytes = max_payload_bytes_for_port_spec(&core_spec("AudioFrame"));
+    let bytes = max_payload_bytes_for_port_spec(&core_spec("AudioFrame")).unwrap();
     assert_eq!(bytes, 65536, "audioframe should declare 64 KB");
 }
 
 #[test]
 fn test_schema_max_payload_bytes_videoframe() {
     test_support::register_core_wire_vocabulary();
-    let bytes = max_payload_bytes_for_port_spec(&core_spec("VideoFrame"));
+    let bytes = max_payload_bytes_for_port_spec(&core_spec("VideoFrame")).unwrap();
     assert_eq!(
         bytes, 65536,
         "videoframe carries surface IDs only — 64 KB default is correct"
     );
 }
 
+/// A `Specific` spec for an unregistered schema must surface as a typed
+/// configuration error naming the missing canonical id and pointing at
+/// `load_project`. This is the bug-class lock for issue #869 — silent
+/// fallback to `MAX_PAYLOAD_SIZE` on registry miss would re-create the
+/// first-frame `ExceedsMaxLoanSize` footgun.
 #[test]
-fn test_schema_max_payload_bytes_unknown_schema_returns_default() {
+fn test_schema_max_payload_bytes_unknown_schema_errors_with_load_project_hint() {
     let spec = PortSchemaSpec::Specific(SchemaIdent::new(
         Org::new("unknown").unwrap(),
-        Package::new("does-not-exist").unwrap(),
+        Package::new("does-not-exist-integration").unwrap(),
         TypeName::new("Nothing").unwrap(),
         SemVer::new(1, 0, 0),
     ));
-    let bytes = max_payload_bytes_for_port_spec(&spec);
-    assert_eq!(
-        bytes,
-        MAX_PAYLOAD_SIZE as usize,
-        "unknown schema should fall back to MAX_PAYLOAD_SIZE"
+    let err = max_payload_bytes_for_port_spec(&spec)
+        .expect_err("registry miss must surface as Err, not as a silent default fallback");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("@unknown/does-not-exist-integration/Nothing"),
+        "error must name the missing canonical id; got: {msg}"
     );
+    assert!(
+        msg.contains("load_project"),
+        "error must point at runtime.load_project(...) as the fix; got: {msg}"
+    );
+    // Silence the unused import warning that the previous test consumed.
+    let _ = MAX_PAYLOAD_SIZE;
 }
 
 #[test]
 fn test_encodedvideoframe_larger_than_audioframe() {
     test_support::register_core_wire_vocabulary();
-    let audio = max_payload_bytes_for_port_spec(&core_spec("AudioFrame"));
-    let video = max_payload_bytes_for_port_spec(&core_spec("EncodedVideoFrame"));
+    let audio = max_payload_bytes_for_port_spec(&core_spec("AudioFrame")).unwrap();
+    let video = max_payload_bytes_for_port_spec(&core_spec("EncodedVideoFrame")).unwrap();
     assert!(
         video > audio,
         "encodedvideoframe ({} bytes) should declare more capacity than audioframe ({} bytes)",
@@ -193,7 +205,7 @@ fn test_audioframe_schema_publisher_rejects_256kb() {
         )
         .unwrap();
 
-    let max_bytes = max_payload_bytes_for_port_spec(&core_spec("AudioFrame"));
+    let max_bytes = max_payload_bytes_for_port_spec(&core_spec("AudioFrame")).unwrap();
     let publisher = service.create_publisher(max_bytes).unwrap();
 
     // 256 KB exceeds the 64 KB audioframe limit.
@@ -218,7 +230,7 @@ fn test_encodedvideoframe_schema_publisher_accepts_256kb() {
         )
         .unwrap();
 
-    let max_bytes = max_payload_bytes_for_port_spec(&core_spec("EncodedVideoFrame"));
+    let max_bytes = max_payload_bytes_for_port_spec(&core_spec("EncodedVideoFrame")).unwrap();
     let publisher = service.create_publisher(max_bytes).unwrap();
 
     let result = publisher.loan_slice_uninit(256 * 1024);
@@ -249,7 +261,7 @@ fn test_frame_header_plus_256kb_roundtrip_through_slice_service() {
         .unwrap();
 
     let data_size = 256 * 1024;
-    let max_bytes = max_payload_bytes_for_port_spec(&core_spec("EncodedVideoFrame"));
+    let max_bytes = max_payload_bytes_for_port_spec(&core_spec("EncodedVideoFrame")).unwrap();
     // Publisher sized like the FFI layer: schema max + header.
     let publisher = service.create_publisher(max_bytes).unwrap();
     let subscriber = service.create_subscriber().unwrap();
@@ -321,7 +333,7 @@ fn test_encodedvideoframe_schema_publisher_subscriber_roundtrip_256kb() {
         )
         .unwrap();
 
-    let max_bytes = max_payload_bytes_for_port_spec(&core_spec("EncodedVideoFrame"));
+    let max_bytes = max_payload_bytes_for_port_spec(&core_spec("EncodedVideoFrame")).unwrap();
     let publisher = service.create_publisher(max_bytes).unwrap();
     let subscriber = service.create_subscriber().unwrap();
 

--- a/libs/streamlib-engine/src/core/embedded_schemas/integration_tests.rs
+++ b/libs/streamlib-engine/src/core/embedded_schemas/integration_tests.rs
@@ -19,9 +19,7 @@
 use std::time::{Duration, Instant};
 
 use super::{max_payload_bytes_for_port_spec, test_support};
-use crate::iceoryx2::{
-    FrameHeader, Iceoryx2Node, SchemaIdentWire, FRAME_HEADER_SIZE, MAX_PAYLOAD_SIZE,
-};
+use crate::iceoryx2::{FrameHeader, Iceoryx2Node, SchemaIdentWire, FRAME_HEADER_SIZE};
 use iceoryx2::prelude::*;
 use streamlib_idents::{Org, Package, SchemaIdent, SemVer, TypeName};
 use streamlib_processor_schema::PortSchemaSpec;
@@ -145,9 +143,10 @@ fn test_schema_max_payload_bytes_videoframe() {
 
 /// A `Specific` spec for an unregistered schema must surface as a typed
 /// configuration error naming the missing canonical id and pointing at
-/// `load_project`. This is the bug-class lock for issue #869 — silent
-/// fallback to `MAX_PAYLOAD_SIZE` on registry miss would re-create the
-/// first-frame `ExceedsMaxLoanSize` footgun.
+/// `load_project`. Silent fallback to the iceoryx2 default on registry
+/// miss would defer the failure to first-frame `ExceedsMaxLoanSize`
+/// instead of catching the "forgot `runtime.load_project(...)`" footgun
+/// at wire time.
 #[test]
 fn test_schema_max_payload_bytes_unknown_schema_errors_with_load_project_hint() {
     let spec = PortSchemaSpec::Specific(SchemaIdent::new(
@@ -167,8 +166,6 @@ fn test_schema_max_payload_bytes_unknown_schema_errors_with_load_project_hint() 
         msg.contains("load_project"),
         "error must point at runtime.load_project(...) as the fix; got: {msg}"
     );
-    // Silence the unused import warning that the previous test consumed.
-    let _ = MAX_PAYLOAD_SIZE;
 }
 
 #[test]

--- a/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
+++ b/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
@@ -115,51 +115,83 @@ pub fn get_embedded_schema_definition(name: &str) -> Option<Arc<str>> {
 }
 
 /// Resolve `max_payload_bytes` from a structured port-schema spec.
-/// Renders the spec to its canonical lookup form, reads the embedded
-/// schema YAML, and returns the declared bound. Returns the iceoryx2
-/// default for `Any` and for unknown schemas.
+///
+/// Returns the iceoryx2 default for `Any` (legitimate wildcard) and for
+/// registered schemas that don't declare `metadata.max_payload_bytes`.
+/// Returns [`Error::Configuration`] when a [`PortSchemaSpec::Specific`]
+/// (or [`PortSchemaSpec::Named`]) refers to a schema absent from the
+/// runtime registry — the actionable shape catches the "forgot
+/// `runtime.load_project(...)`" footgun at wire time rather than at
+/// first-frame `ExceedsMaxLoanSize`.
+///
+/// [`Error::Configuration`]: crate::core::error::Error::Configuration
+/// [`PortSchemaSpec::Specific`]: streamlib_processor_schema::PortSchemaSpec::Specific
+/// [`PortSchemaSpec::Named`]: streamlib_processor_schema::PortSchemaSpec::Named
 pub fn max_payload_bytes_for_port_spec(
     schema_spec: &streamlib_processor_schema::PortSchemaSpec,
-) -> usize {
+) -> crate::core::error::Result<usize> {
     use crate::iceoryx2::MAX_PAYLOAD_SIZE;
-    let canonical = schema_spec.to_string();
-    if let Some(yaml) = get_embedded_schema_definition(&canonical) {
-        if let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(&yaml) {
-            if let Some(n) = value
-                .get("metadata")
-                .and_then(|m| m.get("max_payload_bytes"))
-                .and_then(|v| v.as_u64())
-            {
-                return n as usize;
-            }
-        }
-    }
-    MAX_PAYLOAD_SIZE as usize
+    resolve_metadata_u64_for_port_spec(schema_spec, "max_payload_bytes")
+        .map(|opt| opt.unwrap_or(MAX_PAYLOAD_SIZE as usize))
 }
 
 /// Resolve the iceoryx2 ring depth (slot count) for a port's wire schema
-/// from `metadata.max_queued_messages`. Returns
-/// [`DEFAULT_MAX_QUEUED_MESSAGES`] for `Any`, for unknown schemas, and
-/// for schemas that don't declare the field.
+/// from `metadata.max_queued_messages`.
+///
+/// Returns [`DEFAULT_MAX_QUEUED_MESSAGES`] for `Any` (legitimate wildcard)
+/// and for registered schemas that don't declare the field. Returns
+/// [`Error::Configuration`] when the spec refers to a schema absent from
+/// the runtime registry — the actionable shape catches the "forgot
+/// `runtime.load_project(...)`" footgun at wire time rather than as a
+/// silently undersized ring dropping messages under burst load.
 ///
 /// [`DEFAULT_MAX_QUEUED_MESSAGES`]: crate::iceoryx2::DEFAULT_MAX_QUEUED_MESSAGES
+/// [`Error::Configuration`]: crate::core::error::Error::Configuration
 pub fn max_queued_messages_for_port_spec(
     schema_spec: &streamlib_processor_schema::PortSchemaSpec,
-) -> usize {
+) -> crate::core::error::Result<usize> {
     use crate::iceoryx2::DEFAULT_MAX_QUEUED_MESSAGES;
-    let canonical = schema_spec.to_string();
-    if let Some(yaml) = get_embedded_schema_definition(&canonical) {
-        if let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(&yaml) {
-            if let Some(n) = value
-                .get("metadata")
-                .and_then(|m| m.get("max_queued_messages"))
-                .and_then(|v| v.as_u64())
-            {
-                return n as usize;
-            }
-        }
+    resolve_metadata_u64_for_port_spec(schema_spec, "max_queued_messages")
+        .map(|opt| opt.unwrap_or(DEFAULT_MAX_QUEUED_MESSAGES))
+}
+
+/// Shared lookup helper for both port-spec metadata resolvers.
+///
+/// `Any` → `Ok(None)` (caller substitutes default).
+/// `Specific` / `Named` with registry hit → `Ok(Some(value))` if the
+/// declared `metadata.<field>` parses as a `u64`, else `Ok(None)`
+/// (caller substitutes default — registered schema chose not to
+/// constrain).
+/// `Specific` / `Named` with registry miss → `Err(Configuration(...))`
+/// naming the missing canonical id and pointing the developer at
+/// `runtime.load_project(...)`.
+fn resolve_metadata_u64_for_port_spec(
+    schema_spec: &streamlib_processor_schema::PortSchemaSpec,
+    field: &str,
+) -> crate::core::error::Result<Option<usize>> {
+    if matches!(schema_spec, streamlib_processor_schema::PortSchemaSpec::Any) {
+        return Ok(None);
     }
-    DEFAULT_MAX_QUEUED_MESSAGES
+    let canonical = schema_spec.to_string();
+    let yaml = get_embedded_schema_definition(&canonical).ok_or_else(|| {
+        crate::core::error::Error::Configuration(format!(
+            "schema '{canonical}' referenced by a port spec but not in the \
+             runtime schema registry — did you forget to call \
+             `runtime.load_project(...)` for the package providing it? \
+             (Use `list_embedded_schema_names()` to inspect what's currently \
+             registered.)"
+        ))
+    })?;
+    let value: serde_yaml::Value = match serde_yaml::from_str(&yaml) {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+    let declared = value
+        .get("metadata")
+        .and_then(|m| m.get(field))
+        .and_then(|v| v.as_u64())
+        .map(|n| n as usize);
+    Ok(declared)
 }
 
 /// List every registered schema's canonical identifier (unversioned).
@@ -337,25 +369,41 @@ mod tests {
         );
     }
 
+    /// A `Specific` spec referencing a schema absent from the registry
+    /// must return a typed configuration error naming the missing
+    /// canonical id and pointing at `runtime.load_project(...)`. Mentally
+    /// reverting the resolver to silently fall back to `MAX_PAYLOAD_SIZE`
+    /// will make this test fail.
     #[test]
-    fn max_payload_bytes_returns_default_for_unknown() {
-        use crate::iceoryx2::MAX_PAYLOAD_SIZE;
-        // A PortSchemaSpec that won't resolve in the registry — Specific
-        // form, fully structured, but the package isn't registered.
+    fn max_payload_bytes_errors_on_registry_miss_with_load_project_hint() {
         let spec = PortSchemaSpec::Specific(SchemaIdent::new(
             Org::new("tatolab").unwrap(),
-            Package::new("does-not-exist").unwrap(),
+            Package::new("does-not-exist-payload").unwrap(),
             TypeName::new("Nothing").unwrap(),
             SemVer::new(1, 0, 0),
         ));
-        assert_eq!(max_payload_bytes_for_port_spec(&spec), MAX_PAYLOAD_SIZE as usize);
+        let err = max_payload_bytes_for_port_spec(&spec)
+            .expect_err("registry miss must surface as Err");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("@tatolab/does-not-exist-payload/Nothing"),
+            "error must name the missing canonical id; got: {msg}"
+        );
+        assert!(
+            msg.contains("load_project"),
+            "error must point at `runtime.load_project(...)` as the fix; got: {msg}"
+        );
+        assert!(
+            matches!(err, crate::core::error::Error::Configuration(_)),
+            "registry miss must be Error::Configuration; got: {err:?}"
+        );
     }
 
     #[test]
     fn max_payload_bytes_resolves_video_frame() {
         test_support::register_core_wire_vocabulary();
         let spec = core_spec("VideoFrame");
-        let bytes = max_payload_bytes_for_port_spec(&spec);
+        let bytes = max_payload_bytes_for_port_spec(&spec).unwrap();
         assert!(bytes >= 65536, "VideoFrame should declare a generous payload bound");
     }
 
@@ -363,23 +411,37 @@ mod tests {
     fn max_payload_bytes_any_returns_default() {
         use crate::iceoryx2::MAX_PAYLOAD_SIZE;
         assert_eq!(
-            max_payload_bytes_for_port_spec(&PortSchemaSpec::Any),
+            max_payload_bytes_for_port_spec(&PortSchemaSpec::Any).unwrap(),
             MAX_PAYLOAD_SIZE as usize
         );
     }
 
+    /// Symmetric registry-miss test for `max_queued_messages_for_port_spec`
+    /// — the more insidious half of the helper pair (an undersized ring
+    /// silently drops messages under burst load with no error visible to
+    /// the application).
     #[test]
-    fn max_queued_messages_returns_default_for_unknown() {
-        use crate::iceoryx2::DEFAULT_MAX_QUEUED_MESSAGES;
+    fn max_queued_messages_errors_on_registry_miss_with_load_project_hint() {
         let spec = PortSchemaSpec::Specific(SchemaIdent::new(
             Org::new("tatolab").unwrap(),
-            Package::new("does-not-exist").unwrap(),
+            Package::new("does-not-exist-mqm").unwrap(),
             TypeName::new("Nothing").unwrap(),
             SemVer::new(1, 0, 0),
         ));
-        assert_eq!(
-            max_queued_messages_for_port_spec(&spec),
-            DEFAULT_MAX_QUEUED_MESSAGES
+        let err = max_queued_messages_for_port_spec(&spec)
+            .expect_err("registry miss must surface as Err");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("@tatolab/does-not-exist-mqm/Nothing"),
+            "error must name the missing canonical id; got: {msg}"
+        );
+        assert!(
+            msg.contains("load_project"),
+            "error must point at `runtime.load_project(...)` as the fix; got: {msg}"
+        );
+        assert!(
+            matches!(err, crate::core::error::Error::Configuration(_)),
+            "registry miss must be Error::Configuration; got: {err:?}"
         );
     }
 
@@ -387,7 +449,7 @@ mod tests {
     fn max_queued_messages_any_returns_default() {
         use crate::iceoryx2::DEFAULT_MAX_QUEUED_MESSAGES;
         assert_eq!(
-            max_queued_messages_for_port_spec(&PortSchemaSpec::Any),
+            max_queued_messages_for_port_spec(&PortSchemaSpec::Any).unwrap(),
             DEFAULT_MAX_QUEUED_MESSAGES
         );
     }
@@ -408,12 +470,15 @@ mod tests {
             TypeName::new("HighRateStream").unwrap(),
             SemVer::new(1, 0, 0),
         ));
-        assert_eq!(max_queued_messages_for_port_spec(&spec), 128);
+        assert_eq!(max_queued_messages_for_port_spec(&spec).unwrap(), 128);
     }
 
-    /// A schema without `metadata.max_queued_messages` falls back to the
-    /// default — proves the resolver doesn't accidentally read some
-    /// adjacent field.
+    /// A registered schema without `metadata.max_queued_messages` falls
+    /// back to the default — proves the resolver doesn't accidentally
+    /// read some adjacent field, and proves the registry-miss-vs-field-
+    /// absent split: a schema that IS registered but doesn't declare the
+    /// field is a legitimate "use default" case (no error), whereas a
+    /// registry miss is a configuration error.
     #[test]
     fn max_queued_messages_falls_back_when_field_absent() {
         use crate::iceoryx2::DEFAULT_MAX_QUEUED_MESSAGES;
@@ -429,7 +494,7 @@ mod tests {
             SemVer::new(1, 0, 0),
         ));
         assert_eq!(
-            max_queued_messages_for_port_spec(&spec),
+            max_queued_messages_for_port_spec(&spec).unwrap(),
             DEFAULT_MAX_QUEUED_MESSAGES
         );
     }
@@ -450,7 +515,7 @@ mod tests {
             TypeName::new("MavlinkMessage").unwrap(),
             SemVer::new(1, 0, 0),
         ));
-        assert_eq!(max_queued_messages_for_port_spec(&spec), 64);
+        assert_eq!(max_queued_messages_for_port_spec(&spec).unwrap(), 64);
     }
 
     #[test]
@@ -486,7 +551,7 @@ mod tests {
             TypeName::new("RuntimeOnlyType").unwrap(),
             SemVer::new(1, 0, 0),
         ));
-        assert_eq!(max_payload_bytes_for_port_spec(&spec), 4096);
+        assert_eq!(max_payload_bytes_for_port_spec(&spec).unwrap(), 4096);
 
         assert!(list_embedded_schema_names().iter().any(|n| n == canonical));
     }
@@ -504,12 +569,12 @@ mod tests {
             canonical,
             "metadata:\n  type: RewrittenType\n  max_payload_bytes: 1024\n",
         );
-        assert_eq!(max_payload_bytes_for_port_spec(&spec), 1024);
+        assert_eq!(max_payload_bytes_for_port_spec(&spec).unwrap(), 1024);
         register_schema(
             canonical,
             "metadata:\n  type: RewrittenType\n  max_payload_bytes: 2048\n",
         );
-        assert_eq!(max_payload_bytes_for_port_spec(&spec), 2048);
+        assert_eq!(max_payload_bytes_for_port_spec(&spec).unwrap(), 2048);
     }
 
     #[test]

--- a/libs/streamlib-engine/src/core/runtime/runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/runtime.rs
@@ -3109,7 +3109,7 @@ schemas:
             ),
         );
         assert_eq!(
-            crate::core::embedded_schemas::max_payload_bytes_for_port_spec(&port_spec),
+            crate::core::embedded_schemas::max_payload_bytes_for_port_spec(&port_spec).unwrap(),
             8192,
             "max_payload_bytes_for_port_spec must read metadata declared by the loaded package"
         );


### PR DESCRIPTION
## Summary

- Both `max_payload_bytes_for_port_spec` and `max_queued_messages_for_port_spec` now return `Result<usize, Error>`; registry miss on a `PortSchemaSpec::Specific(ident)` surfaces as `Error::Configuration` naming the missing canonical id and pointing at `runtime.load_project(...)` rather than silently falling back to the iceoryx2 default.
- `Any` keeps its `Ok(default)` semantics (legitimate wildcard); registered schemas without `metadata.<field>` keep `Ok(default)` (registered, but chose not to constrain). The registry-miss-vs-field-absent split is preserved.
- All six call sites in `open_iceoryx2_service_op.rs` propagate via `?`; the typed `Result` signature itself is the compiler-enforced wire-time guarantee — reverting it would fail compilation everywhere the helpers are called.

The all-dynamic load model made this footgun structural: with `EMBEDDED_SCHEMAS` retired (#793), registry starts empty at `Runner::new()`, every app discovers `load_project` on its own, and a miss surfaced as `ExceedsMaxLoanSize` at first publish (or, more insidiously for `max_queued_messages`, as silently dropped messages on an undersized ring under burst load). The typed error catches it at wire time with an actionable diagnostic.

Reuses the existing `Error::Configuration(String)` variant — no new public enum shape needed; the structured info (ident + load_project hint) goes in the message string per the AI-Agent-Notes guidance in the issue body.

## Test plan

- [x] `cargo test -p streamlib-engine --lib embedded_schemas` — 29 passed (helper-level lock: `Any` round-trips to `Ok(default)`; registered schema with declared bound round-trips to `Ok(value)`; registered schema without bound round-trips to `Ok(default)`; registry miss surfaces as `Err(Configuration)` with canonical id + `load_project` hint, for BOTH helpers)
- [x] `cargo test -p streamlib-engine --lib open_iceoryx2_service` — 3 passed (wire-time integration lock via the same `port_info → data_type → max_payload_bytes_for_port_spec` chain `open_iceoryx2_pubsub` uses)
- [x] `cargo test -p streamlib-engine --lib` — 1384 passed, 0 failed, 126 ignored
- [x] `cargo build --workspace` — clean
- [x] `cargo xtask check-boundaries` — clean
- [x] Mental-revert check: reverting the resolver's `ok_or_else` to silent default fallback would fail every new `expect_err`/`Err`-asserting test

🤖 Generated with [Claude Code](https://claude.com/claude-code)