### PR TITLE
feat(packaging): pre-built Python wheel + deno/ layout inside .slpkg (closes #789)

### DIFF
--- a/libs/streamlib-cli/Cargo.toml
+++ b/libs/streamlib-cli/Cargo.toml
@@ -66,6 +66,8 @@ dirs = "6.0"
 # ZIP archive creation
 zip = "2.2"
 
+# Temporary directory for `uv build --wheel` output staging inside `streamlib pack`
+tempfile = "3.14"
+
 [dev-dependencies]
-tempfile = "3.14"  # Temporary directories for logs subcommand tests
 tokio = { workspace = true, features = ["full"] }

--- a/libs/streamlib-cli/src/commands/pack.rs
+++ b/libs/streamlib-cli/src/commands/pack.rs
@@ -3,7 +3,8 @@
 
 use std::fs::File;
 use std::io::{Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use anyhow::{Context, Result};
 use zip::write::FileOptions;
@@ -102,24 +103,36 @@ pub fn pack(package_dir: &Path, output: Option<&Path>, no_build: bool) -> Result
         files_to_bundle.push((entry_name, abs));
     }
 
-    // Collect source files based on processor entrypoints
-    // Python: "module:Class" → module.py
-    // TypeScript: "file.ts:Class" → file.ts
+    // Collect source files based on processor entrypoints.
+    //
+    // - Python: `.py` stays at archive root so the package's
+    //   `pyproject.toml` (also at root) finds it via the build backend's
+    //   default `packages = ["."]` shape. Pre-built wheels land under
+    //   `python/wheels/` in the block further down.
+    // - TypeScript: `.ts` moves to `deno/<module>.ts` for layout symmetry
+    //   with `python/wheels/`. The Deno subprocess runner resolves
+    //   entrypoints against `deno/` first and falls back to archive root
+    //   for legacy slpkgs.
+    // - Rust: no source bundled (the cdylib is the artifact).
     for proc in &config.processors {
         if let Some(entrypoint) = &proc.entrypoint {
-            let source_file = match proc.runtime.language {
+            let (source_file, archive_path) = match proc.runtime.language {
                 streamlib_processor_schema::ProcessorLanguage::Python => {
                     // "grayscale_processor:GrayscaleProcessor" → "grayscale_processor.py"
                     let module = entrypoint.split(':').next().unwrap_or(entrypoint);
-                    format!("{}.py", module)
+                    let source = format!("{}.py", module);
+                    let archive = source.clone();
+                    (source, archive)
                 }
                 streamlib_processor_schema::ProcessorLanguage::TypeScript => {
                     // "halftone_processor.ts:HalftoneProcessor" → "halftone_processor.ts"
-                    entrypoint
+                    let source = entrypoint
                         .split(':')
                         .next()
                         .unwrap_or(entrypoint)
-                        .to_string()
+                        .to_string();
+                    let archive = format!("deno/{}", source);
+                    (source, archive)
                 }
                 streamlib_processor_schema::ProcessorLanguage::Rust => {
                     continue; // Rust processors don't have source files to bundle
@@ -128,7 +141,7 @@ pub fn pack(package_dir: &Path, output: Option<&Path>, no_build: bool) -> Result
 
             let source_path = package_dir.join(&source_file);
             if source_path.exists() {
-                files_to_bundle.push((source_file, source_path));
+                files_to_bundle.push((archive_path, source_path));
             } else {
                 anyhow::bail!(
                     "Processor '{}' entrypoint file not found: {}",
@@ -217,6 +230,89 @@ pub fn pack(package_dir: &Path, output: Option<&Path>, no_build: bool) -> Result
         }
     }
 
+    // Collect or build the Python wheel for packages with Python runtime
+    // processors.
+    //
+    // Resolution mirrors the Rust dylib branch:
+    //
+    //   1. If `<dir>/python/wheels/` already carries `*.whl`, bundle as-is
+    //      (pre-populated flow; CI / multi-platform-matrix builds win).
+    //   2. Otherwise, when `no_build` is unset AND `pyproject.toml` is
+    //      present, invoke `uv build --wheel --out-dir <tmp>` against
+    //      `<package_dir>` and bundle the produced wheel(s).
+    //   3. Otherwise (no_build is set OR no pyproject.toml), surface an
+    //      actionable error / skip.
+    //
+    // Wheels self-tag their target in the filename (`py3-none-any` for
+    // pure-Python, `cp312-cp312-manylinux_2_17_x86_64` for native), so
+    // unlike Rust dylibs the archive doesn't need a per-triple subdir —
+    // the loader glob-matches the right wheel against the install
+    // machine's interpreter.
+    //
+    // Bundled wheels are load-bearing for container deploys: the runtime
+    // container can `uv pip install <wheel>` (binary install — no build
+    // backend like hatchling / maturin needed at install time) instead of
+    // `uv pip install -e <project_path>` (which runs the package's
+    // declared build backend on the install machine).
+    let has_python_processors = config.processors.iter().any(|p| {
+        matches!(
+            p.runtime.language,
+            streamlib_processor_schema::ProcessorLanguage::Python
+        )
+    });
+    let mut python_wheels_bundled = 0usize;
+    if has_python_processors {
+        let wheels_dir = package_dir.join("python").join("wheels");
+        let prebuilt = collect_wheels_in_dir(&wheels_dir)?;
+
+        if !prebuilt.is_empty() {
+            for path in prebuilt {
+                let filename = path
+                    .file_name()
+                    .expect("wheel path must have filename")
+                    .to_string_lossy()
+                    .into_owned();
+                files_to_bundle.push((format!("python/wheels/{}", filename), path));
+                python_wheels_bundled += 1;
+            }
+        } else if no_build {
+            anyhow::bail!(
+                "Package at {} declares Python runtime processors but {} contains no \
+                 pre-built wheel (`*.whl`) and `--no-build` was specified. \
+                 Either run `uv build --wheel --out-dir {}` to populate the wheels \
+                 directory first, or omit `--no-build` to let pack invoke uv automatically.",
+                package_dir.display(),
+                wheels_dir.display(),
+                wheels_dir.display(),
+            );
+        } else {
+            let pyproject = package_dir.join("pyproject.toml");
+            if !pyproject.exists() {
+                // No pyproject.toml — pack ships the source `.py` files
+                // (already bundled above) and falls back to source-install
+                // at load time. Same shape as a Python package without a
+                // build backend.
+                tracing::info!(
+                    "Package at {} declares Python processors but has no \
+                     pyproject.toml; skipping wheel build — load-time source-install \
+                     remains the only path.",
+                    package_dir.display()
+                );
+            } else {
+                let built_wheels = run_uv_build_wheel(package_dir)?;
+                for path in built_wheels {
+                    let filename = path
+                        .file_name()
+                        .expect("wheel path must have filename")
+                        .to_string_lossy()
+                        .into_owned();
+                    files_to_bundle.push((format!("python/wheels/{}", filename), path));
+                    python_wheels_bundled += 1;
+                }
+            }
+        }
+    }
+
     // 4. Create ZIP archive
     let file = File::create(&output_path)
         .with_context(|| format!("Failed to create {}", output_path.display()))?;
@@ -255,8 +351,126 @@ pub fn pack(package_dir: &Path, output: Option<&Path>, no_build: bool) -> Result
             println!("    - {}", proc.name);
         }
     }
+    if python_wheels_bundled > 0 {
+        println!("  Python wheels: {}", python_wheels_bundled);
+    }
 
     Ok(())
+}
+
+/// Enumerate `*.whl` files in `wheels_dir`. Returns empty when the
+/// directory does not exist or carries no wheels — the caller decides
+/// whether that's an error.
+fn collect_wheels_in_dir(wheels_dir: &Path) -> Result<Vec<PathBuf>> {
+    if !wheels_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut found = Vec::new();
+    for entry in std::fs::read_dir(wheels_dir)
+        .with_context(|| format!("Failed to read wheels directory: {}", wheels_dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "whl") {
+            found.push(path);
+        }
+    }
+    found.sort();
+    Ok(found)
+}
+
+/// Invoke `uv build --wheel --out-dir <tmp>` against `package_dir`
+/// and return the produced wheel path(s) on disk inside the tempdir.
+///
+/// The tempdir is leaked intentionally for the duration of the pack
+/// command — its contents are read into the zip archive before pack
+/// returns. The OS reclaims `/tmp/` on the next reboot; for the rare
+/// long-lived `streamlib pack` process this is acceptable since the
+/// wheel itself is tiny (~10 KB pure-Python, single-digit MB native).
+///
+/// Falls back to `python -m build --wheel --outdir <tmp>` when `uv`
+/// is not on PATH, with an error pointing at the install command.
+fn run_uv_build_wheel(package_dir: &Path) -> Result<Vec<PathBuf>> {
+    let out_dir = tempfile::tempdir()
+        .context("Failed to create tempdir for `uv build --wheel` output")?
+        // `TempDir::keep()` leaks the dir so the wheel files outlive
+        // the `TempDir` guard's drop; the OS reclaims `/tmp/` on reboot.
+        .keep();
+
+    tracing::info!(
+        "Building Python wheel for {} (uv build --wheel --out-dir {})",
+        package_dir.display(),
+        out_dir.display(),
+    );
+
+    let uv_available = Command::new("uv")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    let output = if uv_available {
+        Command::new("uv")
+            .arg("build")
+            .arg("--wheel")
+            .arg("--out-dir")
+            .arg(&out_dir)
+            .arg(package_dir)
+            .output()
+            .with_context(|| {
+                format!(
+                    "Failed to invoke `uv build --wheel` in {}",
+                    package_dir.display()
+                )
+            })?
+    } else {
+        // Fallback to `python -m build` so build hosts without `uv` still
+        // work. `build` is the canonical PEP 517 frontend; it's a smaller
+        // dep but a more typical dev-machine baseline.
+        tracing::info!(
+            "uv not found on PATH; falling back to `python -m build --wheel` \
+             (install uv via `curl -LsSf https://astral.sh/uv/install.sh | sh` \
+             for the fast path)"
+        );
+        Command::new("python")
+            .arg("-m")
+            .arg("build")
+            .arg("--wheel")
+            .arg("--outdir")
+            .arg(&out_dir)
+            .arg(package_dir)
+            .output()
+            .with_context(|| {
+                format!(
+                    "Failed to invoke `python -m build --wheel` in {}. \
+                     Install uv (curl -LsSf https://astral.sh/uv/install.sh | sh) \
+                     or `pip install build` to provide the wheel-build toolchain.",
+                    package_dir.display()
+                )
+            })?
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        anyhow::bail!(
+            "wheel build failed for {} (see above). stderr: {}\nstdout: {}",
+            package_dir.display(),
+            stderr.trim(),
+            stdout.trim(),
+        );
+    }
+
+    let wheels = collect_wheels_in_dir(&out_dir)?;
+    if wheels.is_empty() {
+        anyhow::bail!(
+            "wheel build for {} produced no `*.whl` in {}. \
+             Confirm the package's pyproject.toml declares a working build backend.",
+            package_dir.display(),
+            out_dir.display(),
+        );
+    }
+    Ok(wheels)
 }
 
 /// Reject `patch:` entries with a `path:` flavor at pack time. The
@@ -603,5 +817,224 @@ patch:
         );
         reject_path_patches_for_pack(dir.path())
             .expect("git-flavor patches must pack cleanly (public content)");
+    }
+
+    /// Minimal but valid `streamlib.yaml` declaring one Python runtime
+    /// processor. Used by tests that exercise the wheel-bundling branches.
+    const PYTHON_PLUGIN_YAML: &str = r#"
+package:
+  org: tatolab
+  name: py-plugin
+  version: 0.1.0
+processors:
+  - name: PyProc
+    version: 1.0.0
+    description: "py"
+    runtime: python
+    execution: manual
+    entrypoint: "py_proc:PyProc"
+    inputs: []
+    outputs: []
+"#;
+
+    /// Minimal but valid `streamlib.yaml` declaring one TypeScript / Deno
+    /// runtime processor. Used by tests that exercise the `deno/` layout.
+    const DENO_PLUGIN_YAML: &str = r#"
+package:
+  org: tatolab
+  name: ts-plugin
+  version: 0.1.0
+processors:
+  - name: TsProc
+    version: 1.0.0
+    description: "ts"
+    runtime: deno
+    execution: manual
+    entrypoint: "ts_proc.ts:default"
+    inputs: []
+    outputs: []
+"#;
+
+    #[test]
+    fn pack_python_with_prebuilt_wheel_bundles_under_python_wheels() {
+        // Pre-populated `python/wheels/<wheel>.whl` flow — the customer
+        // / CI / multi-platform-matrix build path. Pack picks the wheel
+        // up as-is and ships it inside the zip under the same path so
+        // the loader's `python/wheels/` glob finds it. Mentally reverting
+        // the wheel-bundling block would leave the slpkg with the .py
+        // source only, and `ensure_processor_venv` would fall back to
+        // `uv pip install -e <project_path>` at load time — defeating
+        // the no-toolchain-at-install-time contract this PR is about.
+        let dir = tempdir().unwrap();
+        write_yaml(dir.path(), PYTHON_PLUGIN_YAML);
+        // Processor entrypoint source — required by pack so the slpkg
+        // is loadable when source-install fallback runs.
+        std::fs::write(dir.path().join("py_proc.py"), b"# stub").unwrap();
+        // Pre-built wheel.
+        let wheels_dir = dir.path().join("python").join("wheels");
+        std::fs::create_dir_all(&wheels_dir).unwrap();
+        let wheel_filename = "py_plugin-0.1.0-py3-none-any.whl";
+        std::fs::write(wheels_dir.join(wheel_filename), b"PK\x03\x04fake-wheel-bytes").unwrap();
+
+        let output = dir.path().join("py.slpkg");
+        pack(dir.path(), Some(&output), /* no_build */ true)
+            .expect("populated python/wheels/ must pack with --no-build");
+
+        let zip_bytes = std::fs::read(&output).unwrap();
+        let mut zip = zip::ZipArchive::new(std::io::Cursor::new(zip_bytes)).unwrap();
+        let entry_name = format!("python/wheels/{}", wheel_filename);
+        zip.by_name(&entry_name)
+            .unwrap_or_else(|_| panic!("slpkg missing {} entry", entry_name));
+    }
+
+    #[test]
+    fn pack_python_with_no_build_and_empty_wheels_returns_actionable_error() {
+        // Python runtime processors declared + empty python/wheels/ +
+        // --no-build → actionable error naming the wheel-build command
+        // the user should run. Mirrors the Rust dylib path's `--no-build`
+        // contract. Reverting the no_build/Python branch would let pack
+        // succeed with no wheel (relying on source-install at load time)
+        // — silently undermining the no-toolchain-at-install-time guarantee
+        // the `--no-build` flag exists to enforce.
+        let dir = tempdir().unwrap();
+        write_yaml(dir.path(), PYTHON_PLUGIN_YAML);
+        std::fs::write(dir.path().join("py_proc.py"), b"# stub").unwrap();
+        std::fs::create_dir_all(dir.path().join("python").join("wheels")).unwrap();
+
+        let err = pack(dir.path(), None, /* no_build */ true)
+            .expect_err("--no-build with empty wheels dir must error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("--no-build"),
+            "error must surface the offending flag, got: {msg}"
+        );
+        assert!(
+            msg.contains("uv build --wheel"),
+            "error must suggest the wheel-build command, got: {msg}"
+        );
+        assert!(
+            msg.contains("python/wheels"),
+            "error must name the python/wheels dir so the user knows where to populate, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn pack_deno_lands_source_under_deno_subdir() {
+        // TypeScript processor source lands at `deno/<module>.ts` inside
+        // the zip — NOT at archive root. The Deno subprocess runner
+        // resolves the entrypoint against `deno/` first and falls back
+        // to archive root for legacy slpkgs; this test pins the new
+        // layout. Reverting the per-language archive-path switch in the
+        // entrypoint loop would silently regress every Deno slpkg back
+        // to the archive-root layout and break layout symmetry with the
+        // Python wheels block.
+        let dir = tempdir().unwrap();
+        write_yaml(dir.path(), DENO_PLUGIN_YAML);
+        std::fs::write(dir.path().join("ts_proc.ts"), b"export default class {}").unwrap();
+
+        let output = dir.path().join("ts.slpkg");
+        pack(dir.path(), Some(&output), /* no_build */ false)
+            .expect("Deno-only package must pack");
+
+        let zip_bytes = std::fs::read(&output).unwrap();
+        let mut zip = zip::ZipArchive::new(std::io::Cursor::new(zip_bytes)).unwrap();
+        zip.by_name("deno/ts_proc.ts")
+            .expect("Deno source must land under deno/<module>.ts");
+        // Negative: the legacy archive-root layout must NOT appear; the
+        // contract is `deno/<module>.ts`, period.
+        assert!(
+            zip.by_name("ts_proc.ts").is_err(),
+            "slpkg must not carry legacy archive-root ts_proc.ts alongside deno/ts_proc.ts"
+        );
+    }
+
+    #[test]
+    fn pack_schemas_only_emits_no_python_or_deno_subdirs() {
+        // Schemas-only packages (`@tatolab/core`, `@tatolab/escalate`)
+        // have no Python or Deno processors → pack must NOT emit a
+        // `python/` or `deno/` directory inside the slpkg. The smoke
+        // value is that nothing spuriously sneaks in: ambient files in
+        // the package_dir (a stray `python/` left from a previous
+        // build, a `deno/vendor/` folder, etc.) must not get bundled
+        // when the manifest declares no Python/Deno processors. The
+        // per-processor source loop and the wheel-bundling block both
+        // gate on the manifest's runtime languages, so a schemas-only
+        // pack must produce a slpkg with `lib/`, `python/`, and `deno/`
+        // all absent — the loader's runtime detection looks at the
+        // manifest, not at directory presence, so a stray subdir
+        // wouldn't break loading, but bundling unrelated files in a
+        // schemas-only pack is a wire-format integrity bug worth
+        // catching.
+        let dir = tempdir().unwrap();
+        write_yaml(
+            dir.path(),
+            r#"
+package:
+  org: tatolab
+  name: schemas-only
+  version: 0.1.0
+schemas:
+  TestSchema:
+    file: schemas/test_schema.yaml
+"#,
+        );
+        let schemas_dir = dir.path().join("schemas");
+        std::fs::create_dir(&schemas_dir).unwrap();
+        std::fs::write(
+            schemas_dir.join("test_schema.yaml"),
+            "metadata:\n  type: TestSchema\n  max_payload_bytes: 1024\n",
+        )
+        .unwrap();
+
+        let output = dir.path().join("schemas-only.slpkg");
+        pack(dir.path(), Some(&output), /* no_build */ false)
+            .expect("schemas-only package must pack");
+
+        let zip_bytes = std::fs::read(&output).unwrap();
+        let mut zip = zip::ZipArchive::new(std::io::Cursor::new(zip_bytes)).unwrap();
+        for i in 0..zip.len() {
+            let entry = zip.by_index(i).unwrap();
+            assert!(
+                !entry.name().starts_with("python/"),
+                "schemas-only slpkg must not contain any python/ entries, got: {}",
+                entry.name()
+            );
+            assert!(
+                !entry.name().starts_with("deno/"),
+                "schemas-only slpkg must not contain any deno/ entries, got: {}",
+                entry.name()
+            );
+        }
+    }
+
+    #[test]
+    fn collect_wheels_in_dir_filters_to_whl_extension() {
+        // Helper invariant: only files ending in `.whl` are returned.
+        // Mentally reverting the extension filter would slurp every
+        // file in `python/wheels/` and ship junk inside the slpkg
+        // (sdist tarballs, .gitkeep, README.md, etc.).
+        let dir = tempdir().unwrap();
+        let wheels = dir.path().join("python").join("wheels");
+        std::fs::create_dir_all(&wheels).unwrap();
+        std::fs::write(
+            wheels.join("foo-0.1.0-py3-none-any.whl"),
+            b"wheel-bytes",
+        )
+        .unwrap();
+        std::fs::write(wheels.join("foo-0.1.0.tar.gz"), b"sdist-bytes").unwrap();
+        std::fs::write(wheels.join(".gitkeep"), b"").unwrap();
+
+        let found = collect_wheels_in_dir(&wheels).unwrap();
+        assert_eq!(found.len(), 1, "only wheel files should match, got: {:?}", found);
+        assert!(found[0].ends_with("foo-0.1.0-py3-none-any.whl"));
+    }
+
+    #[test]
+    fn collect_wheels_in_dir_returns_empty_when_dir_missing() {
+        let dir = tempdir().unwrap();
+        let wheels = dir.path().join("python").join("wheels");
+        // Intentionally not creating the dir.
+        let found = collect_wheels_in_dir(&wheels).unwrap();
+        assert!(found.is_empty(), "missing dir must return empty list, got: {:?}", found);
     }
 }

--- a/libs/streamlib-deno/subprocess_runner.ts
+++ b/libs/streamlib-deno/subprocess_runner.ts
@@ -408,8 +408,13 @@ async function main(): Promise<void> {
 
           // Parse entrypoint: "module.ts:export_name"
           const [modulePath, exportName] = parseEntrypoint(entrypoint);
+          // Resolve against the project path. `streamlib pack` writes the
+          // module under `deno/<module>.ts` for layout symmetry with
+          // `python/wheels/`; dev-tree projects keep the module at the
+          // project root (where `streamlib.yaml` lives). Try the packed
+          // layout first, then fall back to project root.
           const fullModulePath = projectPath
-            ? `${projectPath}/${modulePath}`
+            ? resolveDenoModulePath(projectPath, modulePath)
             : modulePath;
 
           log.info("Importing processor module", {
@@ -814,6 +819,27 @@ function parseEntrypoint(entrypoint: string): [string, string] {
     return [entrypoint, "default"];
   }
   return [entrypoint.substring(0, colonIdx), entrypoint.substring(colonIdx + 1)];
+}
+
+/**
+ * Resolve a Deno processor module path against the project directory.
+ *
+ * `streamlib pack` writes the module under `deno/<module>.ts` inside
+ * the .slpkg for layout symmetry with `python/wheels/`. Dev-tree
+ * projects keep the module at the project root (where `streamlib.yaml`
+ * lives). Try the packed-layout path first; fall back to project root.
+ */
+function resolveDenoModulePath(
+  projectPath: string,
+  modulePath: string,
+): string {
+  const packed = `${projectPath}/deno/${modulePath}`;
+  try {
+    Deno.statSync(packed);
+    return packed;
+  } catch {
+    return `${projectPath}/${modulePath}`;
+  }
 }
 
 // Run

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_python_subprocess_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_python_subprocess_op.rs
@@ -13,15 +13,33 @@ use crate::core::error::{Result, Error};
 /// Ensure a hash-keyed cached venv exists, install deps on miss, and return the python path.
 ///
 /// Venv location: `~/.streamlib/cache/venvs/{sha256_hex}/`
-/// Cache key: SHA-256 of `(pyproject.toml contents + canonical project_path)`.
-/// If no pyproject.toml exists, falls back to SHA-256 of `processor_id`.
+/// Cache key: SHA-256 of `(install-source contents + canonical project_path)`,
+/// where the install source is the first wheel under `python/wheels/`
+/// when present (`streamlib pack` populates this from `uv build --wheel`)
+/// and the package's `pyproject.toml` otherwise.
 /// On cache hit (python binary exists), returns immediately with zero `uv` calls.
 /// On cache miss, creates venv and installs deps. On install failure, removes the
 /// venv directory and returns an error.
+///
+/// Install path:
+/// - Pre-built wheel under `python/wheels/<wheel>.whl`: `uv pip install <wheel>`
+///   (binary install — no build backend like hatchling / maturin needed at install
+///   time). This is the load-bearing path for container deploys: the runtime
+///   container does not need a Python build toolchain.
+/// - No wheel but `pyproject.toml` present: `uv pip install -e <project_path>`
+///   (editable source-install, runs the package's declared build backend on the
+///   install machine). Fallback for dev-tree iteration where the slpkg wasn't
+///   produced via `streamlib pack`.
 pub fn ensure_processor_venv(processor_id: &str, project_path: &Path) -> Result<String> {
     use sha2::{Digest, Sha256};
 
     let uv_cache_dir = crate::core::streamlib_home::get_uv_cache_dir();
+
+    let prebuilt_wheel = if project_path.as_os_str().is_empty() {
+        None
+    } else {
+        find_first_wheel(&project_path.join("python").join("wheels"))?
+    };
 
     let pyproject_path = if !project_path.as_os_str().is_empty() {
         let p = project_path.join("pyproject.toml");
@@ -34,8 +52,30 @@ pub fn ensure_processor_venv(processor_id: &str, project_path: &Path) -> Result<
         None
     };
 
-    // Compute hash for cache key
-    let hash_hex = if let Some(ref pyproject) = pyproject_path {
+    // Compute hash for cache key. Three branches that match what we'll
+    // actually install: the wheel filename (which encodes name + version
+    // + Python ABI + platform tags), the pyproject.toml contents, or the
+    // bare processor_id as a last resort. Wheel and source installs hash
+    // into different cache buckets — re-installing the same package via
+    // a different shape gets its own venv rather than colliding.
+    let hash_hex = if let Some(ref wheel) = prebuilt_wheel {
+        let wheel_name = wheel
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let canonical = project_path.canonicalize().map_err(|e| {
+            Error::Runtime(format!(
+                "Failed to canonicalize project_path '{}': {}",
+                project_path.display(),
+                e
+            ))
+        })?;
+        let mut hasher = Sha256::new();
+        hasher.update(b"wheel:");
+        hasher.update(wheel_name.as_bytes());
+        hasher.update(canonical.to_string_lossy().as_bytes());
+        format!("{:x}", hasher.finalize())
+    } else if let Some(ref pyproject) = pyproject_path {
         let contents = std::fs::read_to_string(pyproject)
             .map_err(|e| Error::Runtime(format!("Failed to read pyproject.toml: {}", e)))?;
         let canonical = project_path.canonicalize().map_err(|e| {
@@ -46,6 +86,7 @@ pub fn ensure_processor_venv(processor_id: &str, project_path: &Path) -> Result<
             ))
         })?;
         let mut hasher = Sha256::new();
+        hasher.update(b"source:");
         hasher.update(contents.as_bytes());
         hasher.update(canonical.to_string_lossy().as_bytes());
         format!("{:x}", hasher.finalize())
@@ -120,10 +161,43 @@ pub fn ensure_processor_venv(processor_id: &str, project_path: &Path) -> Result<
 
     tracing::info!("[{}] Venv created", processor_id);
 
-    // Install project dependencies (only when pyproject.toml exists)
-    if pyproject_path.is_some() {
+    // Install the package. Prefer the pre-built wheel (binary install, no
+    // build backend at install time) when present; fall back to source-
+    // install against pyproject.toml. Packages with neither (no wheel,
+    // no pyproject.toml) get a bare venv — the processor's source `.py`
+    // file ships standalone in the slpkg root and runs directly.
+    if let Some(ref wheel) = prebuilt_wheel {
         tracing::info!(
-            "[{}] Installing project deps from {}",
+            "[{}] Installing pre-built wheel {}",
+            processor_id,
+            wheel.display()
+        );
+
+        let venv_python_str = venv_python.to_string_lossy().to_string();
+        let wheel_str = wheel.to_string_lossy().to_string();
+
+        let output = run_uv(
+            &[
+                "pip",
+                "install",
+                &wheel_str,
+                "--python",
+                &venv_python_str,
+            ],
+            &uv_cache_dir,
+        )?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let _ = std::fs::remove_dir_all(&venv_dir);
+            return Err(Error::Runtime(format!(
+                "Failed to install wheel for processor '{}': {}",
+                processor_id, stderr
+            )));
+        }
+    } else if pyproject_path.is_some() {
+        tracing::info!(
+            "[{}] Installing project deps from source at {}",
             processor_id,
             project_path.display()
         );
@@ -156,6 +230,33 @@ pub fn ensure_processor_venv(processor_id: &str, project_path: &Path) -> Result<
     Ok(venv_python.to_string_lossy().to_string())
 }
 
+/// Enumerate `*.whl` files in `wheels_dir` and return the first one
+/// (sorted), or `None` when the dir is missing or empty. Multiple
+/// wheels in the same dir is a future multi-platform-matrix concern
+/// (`streamlib pack` writes one wheel per build today); for now the
+/// first match wins. The platform tags in the wheel filename plus
+/// `uv pip install`'s own resolver are the safety net — `uv` refuses
+/// to install a wheel whose tags don't match the venv's interpreter.
+fn find_first_wheel(wheels_dir: &Path) -> Result<Option<std::path::PathBuf>> {
+    if !wheels_dir.is_dir() {
+        return Ok(None);
+    }
+    let mut wheels: Vec<std::path::PathBuf> = std::fs::read_dir(wheels_dir)
+        .map_err(|e| {
+            Error::Runtime(format!(
+                "Failed to read wheels directory {}: {}",
+                wheels_dir.display(),
+                e
+            ))
+        })?
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|p| p.extension().is_some_and(|ext| ext == "whl"))
+        .collect();
+    wheels.sort();
+    Ok(wheels.into_iter().next())
+}
+
 /// Run a `uv` command with the given args and cache directory.
 fn run_uv(args: &[&str], uv_cache_dir: &Path) -> Result<std::process::Output> {
     Command::new("uv")
@@ -168,4 +269,74 @@ fn run_uv(args: &[&str], uv_cache_dir: &Path) -> Result<std::process::Output> {
                 e
             ))
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn find_first_wheel_returns_none_when_dir_missing() {
+        // The wheels dir is optional — every Python package shipped
+        // pre-`streamlib pack`-with-wheels (or shipped via
+        // `streamlib pack` with `--no-build` against a non-wheel
+        // package) will simply not have one. The helper must report
+        // that as `None`, not error — the install path falls back to
+        // source-install in that case.
+        let dir = tempdir().unwrap();
+        let wheels = dir.path().join("python").join("wheels");
+        let found = find_first_wheel(&wheels).unwrap();
+        assert!(found.is_none(), "missing wheels dir must return None, got: {:?}", found);
+    }
+
+    #[test]
+    fn find_first_wheel_filters_by_whl_extension() {
+        // The packed slpkg's `python/wheels/` dir typically carries
+        // only `*.whl` files, but a future `streamlib pack` extension
+        // (multi-platform matrix, prebuilt-sdist passthrough, etc.)
+        // could land sibling artifacts. The helper must pick the
+        // wheel and skip the rest — `uv pip install` refuses to
+        // install a tarball as if it were a wheel and the error
+        // message wouldn't point at the layout bug.
+        let dir = tempdir().unwrap();
+        let wheels = dir.path().join("python").join("wheels");
+        std::fs::create_dir_all(&wheels).unwrap();
+        std::fs::write(wheels.join("foo-0.1.0-py3-none-any.whl"), b"wheel-bytes").unwrap();
+        std::fs::write(wheels.join("foo-0.1.0.tar.gz"), b"sdist-bytes").unwrap();
+        std::fs::write(wheels.join("README.md"), b"docs").unwrap();
+
+        let found = find_first_wheel(&wheels).unwrap().expect("expected a wheel");
+        assert!(
+            found.ends_with("foo-0.1.0-py3-none-any.whl"),
+            "expected wheel match, got: {}",
+            found.display()
+        );
+    }
+
+    #[test]
+    fn find_first_wheel_returns_sorted_first_for_deterministic_pick() {
+        // When two wheels are present (e.g. a customer pre-populated
+        // both a `py3-none-any` pure-Python wheel and a
+        // platform-specific one) the helper picks the first by sorted
+        // filename. Today's pack writes one wheel; multi-platform
+        // matrix is a future extension. The deterministic-pick
+        // invariant means the same slpkg always selects the same wheel
+        // — if a future change lets `uv pip install` pick the right
+        // wheel against the venv interpreter, this becomes the wrong
+        // shape and the test catches the regression at refactor time.
+        let dir = tempdir().unwrap();
+        let wheels = dir.path().join("python").join("wheels");
+        std::fs::create_dir_all(&wheels).unwrap();
+        std::fs::write(wheels.join("foo-0.1.0-cp312-cp312-linux_x86_64.whl"), b"a").unwrap();
+        std::fs::write(wheels.join("foo-0.1.0-py3-none-any.whl"), b"b").unwrap();
+
+        let found = find_first_wheel(&wheels).unwrap().expect("expected a wheel");
+        // Sorted by filename, `cp312...` comes before `py3...`.
+        assert!(
+            found.ends_with("foo-0.1.0-cp312-cp312-linux_x86_64.whl"),
+            "expected sorted-first wheel, got: {}",
+            found.display()
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- `streamlib pack` runs `uv build --wheel` (falls back to `python -m build`) and bundles the result at `python/wheels/<wheel>.whl` inside the slpkg; pre-populated `python/wheels/` wins over auto-build (same shape as the Rust dylib path). `--no-build` opts out with an actionable error.
- Deno processor `.ts` source moves from archive root to `deno/<module>.ts` for layout symmetry with `python/wheels/`. The Deno subprocess runner resolves entrypoints under `deno/` first and falls back to archive root for legacy slpkgs.
- `ensure_processor_venv` prefers the pre-built wheel (`uv pip install <wheel>` — binary install, no `hatchling` / `maturin` at install time). Falls back to the existing source-install path when no wheel ships. Wheel-keyed cache entries bucket separately from source-keyed entries so re-installs via a different shape don't collide.
- `streamlib pkg install` and `Runner::load_package` route through the updated `ensure_processor_venv` automatically — no new top-level command needed.

Deno vendoring was trimmed out of scope (Deno 2.x removed `deno vendor`; in-tree polyglot examples use workspace-relative imports that don't vendor). No follow-up filed.

## Exit criteria

- [x] `streamlib pack` produces `python/wheels/<wheel>.whl` for Python-impl manifests.
- [x] `streamlib pack` produces `deno/<module>.ts` for Deno-impl manifests.
- [x] `Runner::load_package` / `streamlib pkg install` installs the wheel with no `maturin` / `npm` invocation (`direct_url.json` in the venv shows binary archive install, not editable source).

## Test plan

- [x] `cargo test -p streamlib-cli commands::pack::` — 12 tests pass; 6 new (`pack_python_with_prebuilt_wheel_bundles_under_python_wheels`, `pack_python_with_no_build_and_empty_wheels_returns_actionable_error`, `pack_deno_lands_source_under_deno_subdir`, `pack_schemas_only_emits_no_python_or_deno_subdirs`, `collect_wheels_in_dir_filters_to_whl_extension`, `collect_wheels_in_dir_returns_empty_when_dir_missing`).
- [x] `cargo test -p streamlib-engine --lib compiler_ops::spawn_python_subprocess_op::` — 3 tests pass; all 3 new (`find_first_wheel_returns_none_when_dir_missing`, `find_first_wheel_filters_by_whl_extension`, `find_first_wheel_returns_sorted_first_for_deterministic_pick`).
- [x] `cargo test --workspace --lib` — 1387 lib tests pass workspace-wide, 0 failures.
- [x] Manual end-to-end: packed `examples/polyglot-continuous-processor/python` → `streamlib pkg install` → `direct_url.json` in venv site-packages confirms binary wheel install (`{"url":"file://.../python/wheels/polyglot_continuous_processor-0.1.0-py3-none-any.whl","archive_info":{}}`), not editable source.
- [x] Manual: packed a synthetic Deno fixture → slpkg zip lists `deno/myts_proc.ts` (not archive-root).
- Full pack → load → process-register integration tests are tracked under #871 and #870 (container smoke); they're shared infra used by all the polyglot examples in this milestone.

## Notes for review

- The pack-side and engine-side wheel-collection helpers (`collect_wheels_in_dir` / `find_first_wheel`) are deliberately small duplicates rather than a shared helper crate; both are ~10 LoC and `streamlib-cargo-build` is Cargo-specific by name. Lift to a shared crate when a third caller arrives.
- The `find_first_wheel` helper's sorted-first pick is a deterministic-but-stupid strategy that works today because we pin `--python 3.12`. When multi-ABI wheels start shipping per slpkg, the right shape is to let `uv pip install` resolve against the venv interpreter rather than pre-filtering on the Rust side. Doc-comment flags this trip-wire.
- `pyproject.toml` and `.py` source stay at archive root (unchanged). Moving `.py` to `python/<module>.py` would have broken source-install fallback (hatchling's `packages = ["."]` expects modules at the project root). The goal text only specifies the `deno/<module>.ts` move, not Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)