### PR TITLE
chore(sdk): sweep in-tree non-example callers to add_module (closes #1049)

### DIFF
--- a/libs/streamlib-engine/src/core/runtime/module_loader/tests.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/tests.rs
@@ -203,11 +203,11 @@ fn load_workspace_packages_returns_invalid_id_before_filesystem_probe() {
 // load_project dep walker
 // =========================================================================
 
-/// Path-style dep recursion: `runtime.load_project(A)` must walk into
-/// `B` (declared as `path: ../b`) and parse its manifest.
+/// Path-style dep recursion: `add_module_with(ManifestDirectory(A))`
+/// must walk into `B` (declared as `path: ../b`) and parse its manifest.
 #[test]
 #[serial]
-fn test_load_project_recurses_into_path_dep() {
+fn test_add_module_with_manifest_directory_recurses_into_path_dep() {
     let runtime = Runner::new().unwrap();
     let tmp = tempfile::tempdir().unwrap();
 
@@ -241,13 +241,19 @@ package:
     .unwrap();
 
     runtime
-        .load_project(&a)
-        .expect("load_project should recurse into path dep without error");
+        .add_module_with(
+            streamlib_idents::ModuleIdent::any(
+                streamlib_idents::Org::new("tatolab").unwrap(),
+                streamlib_idents::Package::new("a").unwrap(),
+            ),
+            ModuleResolverStrategy::ManifestDirectory { path: a.clone() },
+        )
+        .expect("add_module_with should recurse into path dep without error");
 }
 
 #[test]
 #[serial]
-fn test_load_project_registers_package_schemas_for_runtime_lookup() {
+fn test_add_module_with_manifest_directory_registers_package_schemas_for_runtime_lookup() {
     let runtime = Runner::new().unwrap();
     let tmp = tempfile::tempdir().unwrap();
 
@@ -279,12 +285,18 @@ schemas:
 
     assert!(
         crate::core::embedded_schemas::get_embedded_schema_definition(canonical).is_none(),
-        "fresh canonical id must not exist before load_project"
+        "fresh canonical id must not exist before add_module_with"
     );
 
     runtime
-        .load_project(&pkg)
-        .expect("load_project must succeed for schemas-only package");
+        .add_module_with(
+            streamlib_idents::ModuleIdent::any(
+                streamlib_idents::Org::new("tatolab").unwrap(),
+                streamlib_idents::Package::new("test-load-project-registers-schemas").unwrap(),
+            ),
+            ModuleResolverStrategy::ManifestDirectory { path: pkg.clone() },
+        )
+        .expect("add_module_with must succeed for schemas-only package");
 
     let body = crate::core::embedded_schemas::get_embedded_schema_definition(canonical)
         .expect("registered schema must be discoverable post-load");
@@ -309,7 +321,7 @@ schemas:
 
 #[test]
 #[serial]
-fn test_load_project_path_dep_missing_manifest_propagates_error() {
+fn test_add_module_with_manifest_directory_path_dep_missing_manifest_propagates_error() {
     let runtime = Runner::new().unwrap();
     let tmp = tempfile::tempdir().unwrap();
 
@@ -329,16 +341,22 @@ dependencies:
     )
     .unwrap();
 
-    let result = runtime.load_project(&a);
+    let result = runtime.add_module_with(
+        streamlib_idents::ModuleIdent::any(
+            streamlib_idents::Org::new("tatolab").unwrap(),
+            streamlib_idents::Package::new("a").unwrap(),
+        ),
+        ModuleResolverStrategy::ManifestDirectory { path: a.clone() },
+    );
     assert!(
         result.is_err(),
-        "load_project must error when a path dep target has no streamlib.yaml"
+        "add_module_with must error when a path dep target has no streamlib.yaml"
     );
 }
 
 #[test]
 #[serial]
-fn test_load_project_resolves_registry_dep_via_consumer_patch() {
+fn test_add_module_with_manifest_directory_resolves_registry_dep_via_consumer_patch() {
     let runtime = Runner::new().unwrap();
     let tmp = tempfile::tempdir().unwrap();
 
@@ -369,13 +387,19 @@ patch:
     .unwrap();
 
     runtime
-        .load_project(&a)
+        .add_module_with(
+            streamlib_idents::ModuleIdent::any(
+                streamlib_idents::Org::new("tatolab").unwrap(),
+                streamlib_idents::Package::new("a").unwrap(),
+            ),
+            ModuleResolverStrategy::ManifestDirectory { path: a.clone() },
+        )
         .expect("consumer-scoped patch must resolve the registry dep to ../b/");
 }
 
 #[test]
 #[serial]
-fn test_load_project_resolves_git_patch_via_shared_helper() {
+fn test_add_module_with_manifest_directory_resolves_git_patch_via_shared_helper() {
     let tmp = tempfile::tempdir().unwrap();
     let repo = tmp.path().join("b-repo");
     std::fs::create_dir(&repo).unwrap();
@@ -437,13 +461,21 @@ patch:
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_project(consumer.path())
+        .add_module_with(
+            streamlib_idents::ModuleIdent::any(
+                streamlib_idents::Org::new("tatolab").unwrap(),
+                streamlib_idents::Package::new("consumer").unwrap(),
+            ),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: consumer.path().to_path_buf(),
+            },
+        )
         .expect("git patch must clone the local repo and recurse into it");
 }
 
 #[test]
 #[serial]
-fn test_load_project_strict_errors_on_missing_patch_path() {
+fn test_add_module_with_manifest_directory_strict_errors_on_missing_patch_path() {
     let runtime = Runner::new().unwrap();
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(
@@ -463,7 +495,15 @@ patch:
     .unwrap();
 
     let err = runtime
-        .load_project(tmp.path())
+        .add_module_with(
+            streamlib_idents::ModuleIdent::any(
+                streamlib_idents::Org::new("tatolab").unwrap(),
+                streamlib_idents::Package::new("a").unwrap(),
+            ),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: tmp.path().to_path_buf(),
+            },
+        )
         .expect_err("missing patch path must error strictly");
     let msg = format!("{err}");
     assert!(
@@ -495,7 +535,7 @@ impl Drop for StreamlibHomeRestore {
 
 #[test]
 #[serial]
-fn test_load_project_resolves_registry_dep_via_installed_cache() {
+fn test_add_module_with_manifest_directory_resolves_registry_dep_via_installed_cache() {
     let sandbox = tempfile::tempdir().unwrap();
     let prev_home = std::env::var_os("STREAMLIB_HOME");
     unsafe {
@@ -543,13 +583,21 @@ dependencies:
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_project(consumer.path())
+        .add_module_with(
+            streamlib_idents::ModuleIdent::any(
+                streamlib_idents::Org::new("tatolab").unwrap(),
+                streamlib_idents::Package::new("consumer").unwrap(),
+            ),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: consumer.path().to_path_buf(),
+            },
+        )
         .expect("registry dep must resolve via installed-package cache");
 }
 
 #[test]
 #[serial]
-fn test_load_project_unresolvable_registry_dep_errors_actionably() {
+fn test_add_module_with_manifest_directory_unresolvable_registry_dep_errors_actionably() {
     let runtime = Runner::new().unwrap();
     let tmp = tempfile::tempdir().unwrap();
 
@@ -569,7 +617,13 @@ dependencies:
     .unwrap();
 
     let err = runtime
-        .load_project(&a)
+        .add_module_with(
+            streamlib_idents::ModuleIdent::any(
+                streamlib_idents::Org::new("tatolab").unwrap(),
+                streamlib_idents::Package::new("a").unwrap(),
+            ),
+            ModuleResolverStrategy::ManifestDirectory { path: a.clone() },
+        )
         .expect_err("unresolvable registry dep must error");
     let msg = format!("{}", err);
     assert!(
@@ -584,7 +638,7 @@ dependencies:
 
 #[test]
 #[serial]
-fn test_load_project_rust_dylib_missing_host_triple_surfaces_available_triples() {
+fn test_add_module_with_manifest_directory_rust_dylib_missing_host_triple_surfaces_available_triples() {
     let runtime = Runner::new().unwrap();
     let tmp = tempfile::tempdir().unwrap();
 
@@ -619,7 +673,13 @@ processors:
     std::fs::write(wrong_dir.join("libfake.so"), b"not-a-real-dylib").unwrap();
 
     let err = runtime
-        .load_project(&pkg)
+        .add_module_with(
+            streamlib_idents::ModuleIdent::any(
+                streamlib_idents::Org::new("tatolab").unwrap(),
+                streamlib_idents::Package::new("triple-mismatch-pkg").unwrap(),
+            ),
+            ModuleResolverStrategy::ManifestDirectory { path: pkg.clone() },
+        )
         .expect_err("missing host-triple subdir must error");
     let msg = format!("{}", err);
     assert!(
@@ -634,7 +694,7 @@ processors:
 
 #[test]
 #[serial]
-fn test_load_project_rust_dylib_resolves_host_triple_then_dlopens() {
+fn test_add_module_with_manifest_directory_rust_dylib_resolves_host_triple_then_dlopens() {
     let runtime = Runner::new().unwrap();
     let tmp = tempfile::tempdir().unwrap();
 
@@ -676,7 +736,13 @@ processors:
     std::fs::write(&dylib_path, b"not-a-real-dylib").unwrap();
 
     let err = runtime
-        .load_project(&pkg)
+        .add_module_with(
+            streamlib_idents::ModuleIdent::any(
+                streamlib_idents::Org::new("tatolab").unwrap(),
+                streamlib_idents::Package::new("triple-match-pkg").unwrap(),
+            ),
+            ModuleResolverStrategy::ManifestDirectory { path: pkg.clone() },
+        )
         .expect_err("junk dylib must fail at dlopen, not at path resolution");
     let msg = format!("{}", err);
     assert!(
@@ -693,7 +759,7 @@ processors:
 
 #[test]
 #[serial]
-fn test_load_project_schemas_only_skips_lib_lookup() {
+fn test_add_module_with_manifest_directory_schemas_only_skips_lib_lookup() {
     let runtime = Runner::new().unwrap();
     let tmp = tempfile::tempdir().unwrap();
 
@@ -711,7 +777,13 @@ package:
     .unwrap();
 
     runtime
-        .load_project(&pkg)
+        .add_module_with(
+            streamlib_idents::ModuleIdent::any(
+                streamlib_idents::Org::new("tatolab").unwrap(),
+                streamlib_idents::Package::new("schemas-only-pkg").unwrap(),
+            ),
+            ModuleResolverStrategy::ManifestDirectory { path: pkg.clone() },
+        )
         .expect("schemas-only package must load without touching lib/");
 }
 

--- a/libs/streamlib-engine/src/core/runtime/module_loader/tests.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/tests.rs
@@ -200,7 +200,7 @@ fn load_workspace_packages_returns_invalid_id_before_filesystem_probe() {
 }
 
 // =========================================================================
-// load_project dep walker
+// add_module_with(ManifestDirectory) dep walker
 // =========================================================================
 
 /// Path-style dep recursion: `add_module_with(ManifestDirectory(A))`

--- a/libs/streamlib-engine/tests/cdylib_owns_tokio_runtime.rs
+++ b/libs/streamlib-engine/tests/cdylib_owns_tokio_runtime.rs
@@ -24,8 +24,9 @@ use std::time::{Duration, Instant};
 
 use serde_json::json;
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -105,8 +106,13 @@ fn dlopen_processor_owns_tokio_runtime_and_binds_tcp_listener() {
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_project(&fixtures_dst)
-        .expect("load_project must succeed against a real test-fixtures cdylib");
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
+        .expect("add_module_with ManifestDirectory must succeed against a real test-fixtures cdylib");
 
     let ident = schema_ident!(
         "tatolab",

--- a/libs/streamlib-engine/tests/load_project_dylib_abi_mismatch.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_abi_mismatch.rs
@@ -27,7 +27,8 @@ use std::path::Path;
 
 use serial_test::serial;
 use streamlib::sdk::error::Error;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::module_ident_any_version;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib_engine::core::runtime::host_target_triple;
 
 fn copy_dir_contents(src: &Path, dst: &Path) {
@@ -119,9 +120,15 @@ fn stage_project(tmp: &Path, source_dylib: &Path) -> std::path::PathBuf {
 
 fn assert_abi_mismatch_rejected(project_dir: &Path) {
     let runtime = Runner::new().expect("Runner::new");
-    let err = runtime
-        .load_project(project_dir)
-        .expect_err("load_project must REJECT a tampered abi_version");
+    let err: Error = runtime
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures-abi-mismatch"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: project_dir.to_path_buf(),
+            },
+        )
+        .expect_err("add_module_with must REJECT a tampered abi_version")
+        .into();
 
     let msg = match err {
         Error::Configuration(s) => s,

--- a/libs/streamlib-engine/tests/load_project_dylib_camera_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_camera_smoke.rs
@@ -187,7 +187,7 @@ fn dlopen_camera_processor_completes_lifecycle_against_vivid() {
                 path: camera_dst.clone(),
             },
         )
-        .expect("load_project must succeed against the camera cdylib");
+        .expect("add_module_with must succeed against the camera cdylib");
 
     let ident = schema_ident!("tatolab", "camera", "Camera", "1.0.0");
 

--- a/libs/streamlib-engine/tests/load_project_dylib_camera_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_camera_smoke.rs
@@ -25,9 +25,10 @@
 //! loop.
 //!
 //! Exit-criterion-#3 of #914 ("camera processor loads as a cdylib
-//! via `runtime.load_project()` and completes `setup()` + `start()`
-//! without panicking") is what this test locks: `runtime.start()`
-//! and `runtime.stop()` both return `Ok` against vivid, proving the
+//! via `runtime.add_module_with(..., ManifestDirectory)` and completes
+//! `setup()` + `start()` without panicking") is what this test locks:
+//! `runtime.start()` and `runtime.stop()` both return `Ok` against
+//! vivid, proving the
 //! synchronous lifecycle dispatches through the cdylib FFI boundary
 //! cleanly.
 //!
@@ -94,8 +95,9 @@ use std::time::Duration;
 
 use serde_json::json;
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -179,7 +181,12 @@ fn dlopen_camera_processor_completes_lifecycle_against_vivid() {
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_project(&camera_dst)
+        .add_module_with(
+            module_ident_any_version!("tatolab", "camera"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: camera_dst.clone(),
+            },
+        )
         .expect("load_project must succeed against the camera cdylib");
 
     let ident = schema_ident!("tatolab", "camera", "Camera", "1.0.0");

--- a/libs/streamlib-engine/tests/load_project_dylib_compute_kernel_cpu_ref.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_compute_kernel_cpu_ref.rs
@@ -146,7 +146,7 @@ fn dlopen_processor_dispatches_compute_kernel_against_cpu_reference() {
                 path: fixtures_dst.clone(),
             },
         )
-        .expect("load_project must succeed against the test-fixtures cdylib");
+        .expect("add_module_with must succeed against the test-fixtures cdylib");
 
     let ident = schema_ident!(
         "tatolab",

--- a/libs/streamlib-engine/tests/load_project_dylib_compute_kernel_cpu_ref.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_compute_kernel_cpu_ref.rs
@@ -56,8 +56,9 @@ use std::time::{Duration, Instant};
 
 use serde_json::json;
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -139,7 +140,12 @@ fn dlopen_processor_dispatches_compute_kernel_against_cpu_reference() {
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_project(&fixtures_dst)
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
         .expect("load_project must succeed against the test-fixtures cdylib");
 
     let ident = schema_ident!(

--- a/libs/streamlib-engine/tests/load_project_dylib_concurrent_escalate.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_concurrent_escalate.rs
@@ -26,8 +26,9 @@ use std::time::{Duration, Instant};
 
 use serde_json::json;
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -106,7 +107,14 @@ fn dlopen_concurrent_escalate_serializes_through_vtable() {
     let output_path_str = output_path.to_string_lossy().to_string();
 
     let runtime = Runner::new().unwrap();
-    runtime.load_project(&fixtures_dst).expect("load_project");
+    runtime
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
+        .expect("add_module_with ManifestDirectory");
 
     let ident = schema_ident!(
         "tatolab",

--- a/libs/streamlib-engine/tests/load_project_dylib_cpu_readback_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_cpu_readback_smoke.rs
@@ -35,8 +35,9 @@ use std::time::{Duration, Instant};
 
 use serde_json::json;
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -116,7 +117,12 @@ fn dlopen_processor_round_trips_cpu_readback_adapter() {
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_project(&fixtures_dst)
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
         .expect("load_project must succeed against the test-fixtures cdylib");
 
     let ident = schema_ident!(

--- a/libs/streamlib-engine/tests/load_project_dylib_cpu_readback_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_cpu_readback_smoke.rs
@@ -123,7 +123,7 @@ fn dlopen_processor_round_trips_cpu_readback_adapter() {
                 path: fixtures_dst.clone(),
             },
         )
-        .expect("load_project must succeed against the test-fixtures cdylib");
+        .expect("add_module_with must succeed against the test-fixtures cdylib");
 
     let ident = schema_ident!(
         "tatolab",

--- a/libs/streamlib-engine/tests/load_project_dylib_cross_rustc.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_cross_rustc.rs
@@ -59,8 +59,9 @@ use std::time::{Duration, Instant};
 
 use serde_json::json;
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -244,7 +245,12 @@ fn dlopen_cross_rustc_fixture_round_trips_every_beta_shape() {
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_project(&fixture_dst)
+        .add_module_with(
+            module_ident_any_version!("tatolab", "cross-rustc-fixture"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixture_dst.clone(),
+            },
+        )
         .expect("load_project must succeed against the cross-rustc cdylib");
 
     let ident = schema_ident!(

--- a/libs/streamlib-engine/tests/load_project_dylib_cross_rustc.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_cross_rustc.rs
@@ -251,7 +251,7 @@ fn dlopen_cross_rustc_fixture_round_trips_every_beta_shape() {
                 path: fixture_dst.clone(),
             },
         )
-        .expect("load_project must succeed against the cross-rustc cdylib");
+        .expect("add_module_with must succeed against the cross-rustc cdylib");
 
     let ident = schema_ident!(
         "tatolab",

--- a/libs/streamlib-engine/tests/load_project_dylib_cuda_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_cuda_smoke.rs
@@ -103,7 +103,7 @@ fn dlopen_processor_round_trips_cuda_adapter() {
                 path: fixtures_dst.clone(),
             },
         )
-        .expect("load_project must succeed");
+        .expect("add_module_with must succeed");
 
     let ident = schema_ident!(
         "tatolab",

--- a/libs/streamlib-engine/tests/load_project_dylib_cuda_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_cuda_smoke.rs
@@ -18,8 +18,9 @@ use std::time::{Duration, Instant};
 
 use serde_json::json;
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -96,7 +97,12 @@ fn dlopen_processor_round_trips_cuda_adapter() {
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_project(&fixtures_dst)
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
         .expect("load_project must succeed");
 
     let ident = schema_ident!(

--- a/libs/streamlib-engine/tests/load_project_dylib_escalate_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_escalate_smoke.rs
@@ -147,7 +147,7 @@ fn dlopen_processor_round_trips_escalate_vtable_callbacks() {
                 path: fixtures_dst.clone(),
             },
         )
-        .expect("load_project must succeed against the test-fixtures cdylib");
+        .expect("add_module_with must succeed against the test-fixtures cdylib");
 
     let ident = schema_ident!(
         "tatolab",

--- a/libs/streamlib-engine/tests/load_project_dylib_escalate_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_escalate_smoke.rs
@@ -59,8 +59,9 @@ use std::time::{Duration, Instant};
 
 use serde_json::json;
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -140,7 +141,12 @@ fn dlopen_processor_round_trips_escalate_vtable_callbacks() {
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_project(&fixtures_dst)
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
         .expect("load_project must succeed against the test-fixtures cdylib");
 
     let ident = schema_ident!(

--- a/libs/streamlib-engine/tests/load_project_dylib_gpu_acquire.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_gpu_acquire.rs
@@ -45,8 +45,9 @@ use std::time::{Duration, Instant};
 
 use serde_json::json;
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -126,7 +127,12 @@ fn dlopen_processor_round_trips_gpu_vtable_callbacks() {
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_project(&fixtures_dst)
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
         .expect("load_project must succeed against a real test-fixtures cdylib");
 
     let ident = schema_ident!(

--- a/libs/streamlib-engine/tests/load_project_dylib_gpu_acquire.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_gpu_acquire.rs
@@ -133,7 +133,7 @@ fn dlopen_processor_round_trips_gpu_vtable_callbacks() {
                 path: fixtures_dst.clone(),
             },
         )
-        .expect("load_project must succeed against a real test-fixtures cdylib");
+        .expect("add_module_with must succeed against a real test-fixtures cdylib");
 
     let ident = schema_ident!(
         "tatolab",

--- a/libs/streamlib-engine/tests/load_project_dylib_graphics_kernel_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_graphics_kernel_smoke.rs
@@ -54,8 +54,9 @@ use std::time::{Duration, Instant};
 
 use serde_json::json;
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -135,7 +136,12 @@ fn dlopen_processor_runs_graphics_kernel_offscreen_render_smoke() {
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_project(&fixtures_dst)
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
         .expect("load_project must succeed against the test-fixtures cdylib");
 
     let ident = schema_ident!(

--- a/libs/streamlib-engine/tests/load_project_dylib_graphics_kernel_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_graphics_kernel_smoke.rs
@@ -142,7 +142,7 @@ fn dlopen_processor_runs_graphics_kernel_offscreen_render_smoke() {
                 path: fixtures_dst.clone(),
             },
         )
-        .expect("load_project must succeed against the test-fixtures cdylib");
+        .expect("add_module_with must succeed against the test-fixtures cdylib");
 
     let ident = schema_ident!(
         "tatolab",

--- a/libs/streamlib-engine/tests/load_project_dylib_lifecycle.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_lifecycle.rs
@@ -20,8 +20,9 @@
 use std::path::Path;
 
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::{ProcessorInstance, PROCESSOR_REGISTRY};
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib_engine::core::graph::ProcessorNode;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -100,7 +101,12 @@ fn dylib_processor_create_and_drop_round_trips_through_vtable() {
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_project(&fixtures_dst)
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
         .expect("load_project must succeed against a real test-fixtures cdylib");
 
     // Locate the registered TestConfiguredProcessor's descriptor so we

--- a/libs/streamlib-engine/tests/load_project_dylib_lifecycle.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_lifecycle.rs
@@ -107,7 +107,7 @@ fn dylib_processor_create_and_drop_round_trips_through_vtable() {
                 path: fixtures_dst.clone(),
             },
         )
-        .expect("load_project must succeed against a real test-fixtures cdylib");
+        .expect("add_module_with must succeed against a real test-fixtures cdylib");
 
     // Locate the registered TestConfiguredProcessor's descriptor so we
     // can build a ProcessorNode against the exact structured ident the

--- a/libs/streamlib-engine/tests/load_project_dylib_opengl_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_opengl_smoke.rs
@@ -23,8 +23,9 @@ use std::time::{Duration, Instant};
 
 use serde_json::json;
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -101,7 +102,12 @@ fn dlopen_processor_round_trips_opengl_adapter() {
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_project(&fixtures_dst)
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
         .expect("load_project must succeed");
 
     let ident = schema_ident!(

--- a/libs/streamlib-engine/tests/load_project_dylib_opengl_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_opengl_smoke.rs
@@ -108,7 +108,7 @@ fn dlopen_processor_round_trips_opengl_adapter() {
                 path: fixtures_dst.clone(),
             },
         )
-        .expect("load_project must succeed");
+        .expect("add_module_with must succeed");
 
     let ident = schema_ident!(
         "tatolab",

--- a/libs/streamlib-engine/tests/load_project_dylib_pause_resume.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_pause_resume.rs
@@ -22,8 +22,9 @@ use std::time::{Duration, Instant};
 
 use serde_json::json;
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -122,7 +123,14 @@ fn dlopen_processor_pause_resume_hooks_fire_through_vtable() {
     let output_path_str = output_path.to_string_lossy().to_string();
 
     let runtime = Runner::new().unwrap();
-    runtime.load_project(&fixtures_dst).expect("load_project");
+    runtime
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
+        .expect("add_module_with ManifestDirectory");
 
     let ident = schema_ident!(
         "tatolab",

--- a/libs/streamlib-engine/tests/load_project_dylib_process_lifecycle.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_process_lifecycle.rs
@@ -27,8 +27,9 @@ use std::time::{Duration, Instant};
 
 use serde_json::json;
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -107,7 +108,14 @@ fn dlopen_processor_process_hook_fires_through_vtable() {
     let output_path_str = output_path.to_string_lossy().to_string();
 
     let runtime = Runner::new().unwrap();
-    runtime.load_project(&fixtures_dst).expect("load_project");
+    runtime
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
+        .expect("add_module_with ManifestDirectory");
 
     let ident = schema_ident!(
         "tatolab",

--- a/libs/streamlib-engine/tests/load_project_dylib_processor_panic_safety.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_processor_panic_safety.rs
@@ -29,8 +29,9 @@ use std::time::{Duration, Instant};
 
 use serde_json::json;
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -124,7 +125,14 @@ fn drive_manual_variant(hook: &str) {
     let fixtures_dst = tmp.path().join("test-fixtures");
 
     let runtime = Runner::new().unwrap();
-    runtime.load_project(&fixtures_dst).expect("load_project");
+    runtime
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
+        .expect("add_module_with ManifestDirectory");
 
     let ident = schema_ident!(
         "tatolab",
@@ -159,7 +167,14 @@ fn drive_continuous_variant(hook: &str) {
     let fixtures_dst = tmp.path().join("test-fixtures");
 
     let runtime = Runner::new().unwrap();
-    runtime.load_project(&fixtures_dst).expect("load_project");
+    runtime
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
+        .expect("add_module_with ManifestDirectory");
 
     let ident = schema_ident!(
         "tatolab",

--- a/libs/streamlib-engine/tests/load_project_dylib_pubsub_bridge.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_pubsub_bridge.rs
@@ -30,7 +30,8 @@ use std::time::{Duration, Instant};
 use parking_lot::Mutex;
 use serial_test::serial;
 use streamlib::sdk::pubsub::{topics, Event, EventListener, RuntimeEvent, PUBSUB};
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::module_ident_any_version;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib_engine::core::runtime::host_target_triple;
 
 fn copy_dir_contents(src: &Path, dst: &Path) {
@@ -148,7 +149,12 @@ fn plugin_register_pubsub_event_reaches_host_subscriber() {
     std::thread::sleep(Duration::from_millis(200));
 
     runtime
-        .load_project(&fixtures_dst)
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
         .expect("load_project must succeed");
 
     let deadline = Instant::now() + Duration::from_secs(2);

--- a/libs/streamlib-engine/tests/load_project_dylib_pubsub_bridge.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_pubsub_bridge.rs
@@ -155,7 +155,7 @@ fn plugin_register_pubsub_event_reaches_host_subscriber() {
                 path: fixtures_dst.clone(),
             },
         )
-        .expect("load_project must succeed");
+        .expect("add_module_with must succeed");
 
     let deadline = Instant::now() + Duration::from_secs(2);
     while matched.load(Ordering::SeqCst) == 0 && Instant::now() < deadline {

--- a/libs/streamlib-engine/tests/load_project_dylib_ray_tracing_kernel_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_ray_tracing_kernel_smoke.rs
@@ -149,7 +149,7 @@ fn dlopen_processor_runs_ray_tracing_kernel_trace_rays_smoke() {
                 path: fixtures_dst.clone(),
             },
         )
-        .expect("load_project must succeed against the test-fixtures cdylib");
+        .expect("add_module_with must succeed against the test-fixtures cdylib");
 
     let ident = schema_ident!(
         "tatolab",

--- a/libs/streamlib-engine/tests/load_project_dylib_ray_tracing_kernel_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_ray_tracing_kernel_smoke.rs
@@ -61,8 +61,9 @@ use std::time::{Duration, Instant};
 
 use serde_json::json;
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -142,7 +143,12 @@ fn dlopen_processor_runs_ray_tracing_kernel_trace_rays_smoke() {
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_project(&fixtures_dst)
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
         .expect("load_project must succeed against the test-fixtures cdylib");
 
     let ident = schema_ident!(

--- a/libs/streamlib-engine/tests/load_project_dylib_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_smoke.rs
@@ -3,18 +3,19 @@
 
 //! Smoke test for the dynamic Rust-plugin load path: build a real
 //! `packages/test-fixtures` cdylib, stage it next to its manifest in a
-//! tempdir, call `runtime.load_project(...)`, and assert
-//! `TestConfiguredProcessor` registered via the `STREAMLIB_PLUGIN`
-//! callback. Mentally revert the `export_plugin!` invocation in
-//! `packages/test-fixtures/src/lib.rs` and this test fails — the
-//! dlopen path validates the processor was registered by the dylib
-//! and surfaces a `Configuration` error when it wasn't.
+//! tempdir, route it through `add_module_with(..., ManifestDirectory)`,
+//! and assert `TestConfiguredProcessor` registered via the
+//! `STREAMLIB_PLUGIN` callback. Mentally revert the `export_plugin!`
+//! invocation in `packages/test-fixtures/src/lib.rs` and this test
+//! fails — the dlopen path validates the processor was registered by
+//! the dylib and surfaces a `Configuration` error when it wasn't.
 
 use std::path::Path;
 
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::PROCESSOR_REGISTRY;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib_engine::core::runtime::host_target_triple;
 
 fn copy_dir_contents(src: &Path, dst: &Path) {
@@ -104,8 +105,13 @@ fn load_project_real_dylib_registers_processor_via_export_plugin() {
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_project(&fixtures_dst)
-        .expect("load_project must succeed against a real test-fixtures cdylib");
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
+        .expect("add_module_with ManifestDirectory must succeed against a real test-fixtures cdylib");
 
     let registered = PROCESSOR_REGISTRY
         .list_registered()

--- a/libs/streamlib-engine/tests/load_project_dylib_surface_share_escalate_consistency.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_surface_share_escalate_consistency.rs
@@ -111,7 +111,7 @@ fn dlopen_processor_round_trips_surface_share_and_escalate_paths() {
                 path: fixtures_dst.clone(),
             },
         )
-        .expect("load_project must succeed");
+        .expect("add_module_with must succeed");
 
     let ident = schema_ident!(
         "tatolab",

--- a/libs/streamlib-engine/tests/load_project_dylib_surface_share_escalate_consistency.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_surface_share_escalate_consistency.rs
@@ -26,8 +26,9 @@ use std::time::{Duration, Instant};
 
 use serde_json::json;
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -104,7 +105,12 @@ fn dlopen_processor_round_trips_surface_share_and_escalate_paths() {
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_project(&fixtures_dst)
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
         .expect("load_project must succeed");
 
     let ident = schema_ident!(

--- a/libs/streamlib-engine/tests/load_project_dylib_tracing_bridge.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_tracing_bridge.rs
@@ -128,7 +128,7 @@ fn plugin_register_tracing_event_reaches_host_jsonl() {
                 path: fixtures_dst.clone(),
             },
         )
-        .expect("load_project must succeed");
+        .expect("add_module_with must succeed");
 
     // Tracing→JSONL flow under the callback-table architecture:
     // cdylib's `ProcessorInstanceFactory::register::<P>()` calls

--- a/libs/streamlib-engine/tests/load_project_dylib_tracing_bridge.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_tracing_bridge.rs
@@ -26,7 +26,8 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 
 use serial_test::serial;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::module_ident_any_version;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib_engine::core::runtime::host_target_triple;
 
 fn copy_dir_contents(src: &Path, dst: &Path) {
@@ -121,7 +122,12 @@ fn plugin_register_tracing_event_reaches_host_jsonl() {
         );
 
     runtime
-        .load_project(&fixtures_dst)
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
         .expect("load_project must succeed");
 
     // Tracing→JSONL flow under the callback-table architecture:

--- a/libs/streamlib-engine/tests/load_project_dylib_vulkan_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_vulkan_smoke.rs
@@ -114,7 +114,7 @@ fn dlopen_processor_round_trips_vulkan_adapter() {
                 path: fixtures_dst.clone(),
             },
         )
-        .expect("load_project must succeed against the test-fixtures cdylib");
+        .expect("add_module_with must succeed against the test-fixtures cdylib");
 
     let ident = schema_ident!(
         "tatolab",

--- a/libs/streamlib-engine/tests/load_project_dylib_vulkan_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_vulkan_smoke.rs
@@ -26,8 +26,9 @@ use std::time::{Duration, Instant};
 
 use serde_json::json;
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -107,7 +108,12 @@ fn dlopen_processor_round_trips_vulkan_adapter() {
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_project(&fixtures_dst)
+        .add_module_with(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            ModuleResolverStrategy::ManifestDirectory {
+                path: fixtures_dst.clone(),
+            },
+        )
         .expect("load_project must succeed against the test-fixtures cdylib");
 
     let ident = schema_ident!(

--- a/libs/streamlib-engine/tests/pack_then_load_smoke.rs
+++ b/libs/streamlib-engine/tests/pack_then_load_smoke.rs
@@ -46,8 +46,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use serial_test::serial;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::PROCESSOR_REGISTRY;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib_engine::core::runtime::host_target_triple;
 use streamlib_engine::schemas::current_schema_definition;
 
@@ -196,8 +197,11 @@ fn pack_then_load_rust_package_registers_processors() {
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_package(&slpkg)
-        .expect("load_package against a freshly-packed Rust slpkg must succeed");
+        .add_module_with(
+            module_ident_any_version!("tatolab", "network"),
+            ModuleResolverStrategy::SlpkgArchive { path: slpkg.clone() },
+        )
+        .expect("add_module_with SlpkgArchive against a freshly-packed Rust slpkg must succeed");
 
     let registered: Vec<String> = PROCESSOR_REGISTRY
         .list_registered()
@@ -257,8 +261,11 @@ fn pack_then_load_schemas_only_package_registers_schemas() {
 
     let runtime = Runner::new().unwrap();
     runtime
-        .load_package(&slpkg)
-        .expect("load_package against a schemas-only slpkg must succeed");
+        .add_module_with(
+            module_ident_any_version!("tatolab", "core"),
+            ModuleResolverStrategy::SlpkgArchive { path: slpkg.clone() },
+        )
+        .expect("add_module_with SlpkgArchive against a schemas-only slpkg must succeed");
 
     assert!(
         current_schema_definition("@tatolab/core/VideoFrame").is_some(),
@@ -281,8 +288,16 @@ fn load_package_with_missing_file_errors_cleanly() {
     let runtime = Runner::new().unwrap();
     let missing = std::path::PathBuf::from("/nonexistent/path/missing.slpkg");
     let err = runtime
-        .load_package(&missing)
-        .expect_err("load_package against a missing .slpkg must error");
+        .add_module_with(
+            // Any ident — the strategy resolver errors during extraction
+            // before the ident is checked against the (non-existent)
+            // archive's manifest.
+            module_ident_any_version!("tatolab", "core"),
+            ModuleResolverStrategy::SlpkgArchive {
+                path: missing.clone(),
+            },
+        )
+        .expect_err("add_module_with SlpkgArchive against a missing .slpkg must error");
     let msg = format!("{err}");
     assert!(
         msg.contains("missing.slpkg") || msg.to_lowercase().contains("no such file"),
@@ -344,8 +359,11 @@ processors:
 
     let runtime = Runner::new().unwrap();
     let err = runtime
-        .load_package(&slpkg)
-        .expect_err("load_package against a foreign-triple-only slpkg must error");
+        .add_module_with(
+            module_ident_any_version!("tatolab", "foreign-triple-fixture"),
+            ModuleResolverStrategy::SlpkgArchive { path: slpkg.clone() },
+        )
+        .expect_err("add_module_with SlpkgArchive against a foreign-triple-only slpkg must error");
     let msg = format!("{err}");
     let host = host_target_triple();
     assert!(


### PR DESCRIPTION
## Summary

- Migrate every non-example in-tree caller of `runtime.load_project(...)` / `runtime.load_package(...)` / `runtime.load_workspace_packages(...)` to the unified `add_module_with(ident, ModuleResolverStrategy)` form landed in #1048.
- 23 `libs/streamlib-engine/tests/load_project_dylib_*.rs` + `pack_then_load_smoke.rs` + `cdylib_owns_tokio_runtime.rs` integration tests rewritten to `add_module_with(module_ident_any_version!(...), ManifestDirectory { path })` (or `SlpkgArchive` for the pack→load smoke cases).
- Dep-walker tests in `module_loader/tests.rs` renamed from `test_load_project_*` to `test_add_module_with_manifest_directory_*` so the names reflect what they actually exercise.

The 3 deprecated wrapper methods stay (they're still-public thin shims around `add_module_with`); #1053 removes them.

## Out of scope (intentional, justified inline)

- `load_workspace_packages_reports_not_staged_when_dir_missing` and `load_workspace_packages_returns_invalid_id_before_filesystem_probe` in `module_loader/tests.rs` keep calling the wrapper directly — they test the wrapper's own error-translation contract (`AddModuleError` → `LoadWorkspacePackagesError`). They retire with the wrapper in #1053.
- `libs/streamlib-runtime/src/main.rs`, `processor_instance_factory.rs`, `streamlib-macros/src/lib.rs`, `streamlib-plugin-abi/src/lib.rs` — the issue body listed these as candidates, but verification against current code showed they only carry doc-comment references, not actual call sites.

## Behavioral note

`load_project_dylib_abi_mismatch.rs::assert_abi_mismatch_rejected` now unwraps `AddModuleError::LoadProjectFailed.source` to the inner `Error::Configuration` via the `From<AddModuleError> for Error` impl, so the original "ABI version mismatch" / "Rebuild the plugin" substring assertions keep firing.

## Test plan

- [x] `cargo build --tests -p streamlib-engine` — clean compile, 0 errors.
- [x] `cargo test -p streamlib-engine --lib core::runtime::module_loader::tests` — 41 passed, 0 failed (includes all 11 renamed dep-walker tests).
- [x] Bulk grep confirms zero `\.(load_project|load_package|load_workspace_packages)\(` call sites in non-example, non-wrapper-internal-test files.
- [ ] Tier-2 integration tests (`load_project_dylib_*`) are `#[serial]` + `#[cfg_attr(not(feature = "hardware-tests"), ignore)]`; they compile cleanly but run only under the hardware-tests feature.

## PR review gate verdict: PASS

Independent code review flagged 2 DISCUSS items (cosmetic: stale `.expect()` message strings + a stale section banner). Both fixed in 55c11cf. No FIX items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)