### PR TITLE
chore(examples): sweep non-polyglot example callers to add_module (closes #1052)

### DIFF
--- a/examples/api-server-demo/Cargo.toml
+++ b/examples/api-server-demo/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 # `@tatolab/api-server` and `@tatolab/debug-utilities` load at runtime
-# via `Runner::load_workspace_packages` — no compile-time link.
+# via `Runner::add_module` — no compile-time link.
 streamlib = { path = "../../libs/streamlib-sdk" }
 tokio = { version = "1.48.0", features = ["full"] }
 reqwest = { version = "0.12", features = ["json"] }

--- a/examples/api-server-demo/src/main.rs
+++ b/examples/api-server-demo/src/main.rs
@@ -8,6 +8,7 @@
 
 use futures_util::StreamExt;
 use std::sync::Arc;
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::runtime::Runner;
 use streamlib::sdk::schema_ident;
@@ -31,11 +32,9 @@ async fn main() -> Result<()> {
     // `"processor_type": "SimplePassthroughProcessor"` through the API
     // server's dynamic-registry endpoint and that resolution only
     // succeeds if the processor is present in PROCESSOR_REGISTRY,
-    // which load_workspace_packages populates via the cdylib registration.
-    runtime.load_workspace_packages([
-        "@tatolab/api-server",
-        "@tatolab/debug-utilities",
-    ])?;
+    // which add_module populates via the cdylib registration.
+    runtime.add_module(module_ident_any_version!("tatolab", "api-server"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "debug-utilities"))?;
 
     // Add the API server processor
     println!("Adding API server processor...");

--- a/examples/api-server/Cargo.toml
+++ b/examples/api-server/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 # `@tatolab/api-server` loaded at runtime via
-# `Runner::load_workspace_packages` — no compile-time link.
+# `Runner::add_module` — no compile-time link.
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
 serde_json = "1"

--- a/examples/api-server/src/main.rs
+++ b/examples/api-server/src/main.rs
@@ -21,8 +21,7 @@
 //! `target/streamlib-plugins/tatolab__api-server/`.
 //!
 //! Loads `@tatolab/api-server` through the imperative
-//! [`Runner::add_module`] API — the typed counterpart to the
-//! yaml-driven `load_project`. The fully spelled out
+//! [`Runner::add_module`] API. The fully spelled out
 //! [`streamlib::sdk::module_ident!`] call is one of four
 //! ergonomic shapes; the other three (split + any-version,
 //! joined + version, joined + any-version) are equally valid and
@@ -38,11 +37,10 @@ use streamlib::sdk::schema_ident;
 async fn main() -> streamlib::sdk::error::Result<()> {
     let runtime = Runner::new()?;
 
-    // Imperative module load — REST-endpoint-friendly counterpart
-    // to `Runner::load_project` / `Runner::load_package`. The
-    // runtime resolves the ident against the workspace stage dir
-    // or installed-package cache, verifies the semver range, then
-    // drives the same internal module-loading machinery.
+    // Imperative module load — the runtime resolves the ident
+    // against the workspace stage dir or installed-package cache,
+    // verifies the semver range, then drives the internal
+    // module-loading machinery.
     runtime.add_module(module_ident!("tatolab", "api-server", "^1.0.0"))?;
 
     let config = serde_json::json!({

--- a/examples/audio-mixer-demo/Cargo.toml
+++ b/examples/audio-mixer-demo/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 # Canonical reference for the All-Dynamic Package Loading milestone:
 # the only streamlib-* Cargo dep is `streamlib` (the SDK). The
 # `@tatolab/audio` package is loaded at runtime via
-# `Runner::load_workspace_packages` against `cargo xtask build-plugins`
+# `Runner::add_module` against `cargo xtask build-plugins`
 # output — no compile-time link.
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }

--- a/examples/audio-mixer-demo/src/main.rs
+++ b/examples/audio-mixer-demo/src/main.rs
@@ -5,9 +5,9 @@
 //! Loading milestone.
 //!
 //! Demonstrates loading `@tatolab/audio` at runtime via
-//! `Runner::load_workspace_packages` (no Cargo dep on
-//! `streamlib-audio`) and wiring its processors via structured
-//! `schema_ident!` + JSON config + string-named ports.
+//! `Runner::add_module` (no Cargo dep on `streamlib-audio`) and wiring
+//! its processors via structured `schema_ident!` + JSON config +
+//! string-named ports.
 //!
 //! Run prerequisite: `cargo xtask build-plugins --package @tatolab/audio`
 //! (or `cargo xtask build-plugins` with no filter) so the runtime can
@@ -15,6 +15,7 @@
 
 use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::runtime::Runner;
 use streamlib::sdk::schema_ident;
@@ -28,7 +29,7 @@ fn main() -> Result<()> {
     // 1) Load @tatolab/audio (and any deps it walks via patch:) from
     //    the workspace-staged location. `cargo xtask build-plugins`
     //    must have run first.
-    runtime.load_workspace_packages(["@tatolab/audio"])?;
+    runtime.add_module(module_ident_any_version!("tatolab", "audio"))?;
     println!("+ @tatolab/audio loaded from target/streamlib-plugins/\n");
 
     // 2) Chord generator — addressed by structured schema_ident,

--- a/examples/camera-display/src/main.rs
+++ b/examples/camera-display/src/main.rs
@@ -13,6 +13,7 @@
 
 use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::runtime::Runner;
 use streamlib::sdk::schema_ident;
@@ -22,11 +23,9 @@ fn main() -> Result<()> {
 
     let runtime = Runner::new()?;
 
-    runtime.load_workspace_packages([
-        "@tatolab/camera",
-        "@tatolab/display",
-        "@tatolab/api-server",
-    ])?;
+    runtime.add_module(module_ident_any_version!("tatolab", "camera"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "display"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "api-server"))?;
 
     println!("📷 Adding camera processor...");
     let device_id = std::env::var("STREAMLIB_CAMERA_DEVICE").ok();

--- a/examples/camera-rust-plugin/src/main.rs
+++ b/examples/camera-rust-plugin/src/main.rs
@@ -7,14 +7,15 @@
 //! sibling `plugin/` crate that builds as a cdylib carrying the
 //! `GrayscaleRust` processor, and the host manually stages that cdylib
 //! into `plugin/lib/<host_triple>/` before calling
-//! `runtime.load_project(plugin_dir)` to register it. This is the
-//! "build from source + load from path" shape, distinct from the
-//! `cargo xtask build-plugins` + `load_workspace_packages` flow that
-//! the other examples use for canonical workspace packages.
+//! `runtime.add_module_with(..., ModuleResolverStrategy::ManifestDirectory)`
+//! to register it. This is the "build from source + load from path"
+//! shape, distinct from the `cargo xtask build-plugins` +
+//! `runtime.add_module(...)` flow that the other examples use for
+//! canonical workspace packages.
 //!
 //! `@tatolab/camera` and `@tatolab/display` themselves load via
-//! `load_workspace_packages` — only the example-local plugin subdir
-//! goes through the manual stage path.
+//! `add_module` against the workspace-staged plugin dir — only the
+//! example-local plugin subdir goes through the manual stage path.
 //!
 //! ## Prerequisites
 //!
@@ -33,8 +34,9 @@
 use std::path::PathBuf;
 use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{ModuleResolverStrategy, Runner};
 use streamlib::sdk::schema_ident;
 
 fn main() -> Result<()> {
@@ -43,14 +45,15 @@ fn main() -> Result<()> {
     // 1. Load `@tatolab/camera` and `@tatolab/display` via the canonical
     //    workspace-staged path. `cargo xtask build-plugins --package
     //    @tatolab/camera --package @tatolab/display` must have run first.
-    runtime.load_workspace_packages(["@tatolab/camera", "@tatolab/display"])?;
+    runtime.add_module(module_ident_any_version!("tatolab", "camera"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "display"))?;
 
     // 2. Stage the example-local grayscale plugin cdylib at
-    //    `plugin/lib/<triple>/` so `load_project(plugin_dir)` resolves
-    //    it via the same triple-keyed convention `streamlib pack`
-    //    produces. The plugin lives in this example's repo (sibling
-    //    crate, not a workspace package) so the canonical xtask doesn't
-    //    stage it; the example handles its own copy step.
+    //    `plugin/lib/<triple>/` so the explicit `ManifestDirectory`
+    //    resolver picks it up via the same triple-keyed convention
+    //    `streamlib pack` produces. The plugin lives in this example's
+    //    repo (sibling crate, not a workspace package) so the canonical
+    //    xtask doesn't stage it; the example handles its own copy step.
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let plugin_dir = manifest_dir.join("plugin");
     let host_triple = streamlib::sdk::runtime::host_target_triple();
@@ -107,8 +110,17 @@ fn main() -> Result<()> {
     println!("Copied plugin dylib to {}", dest_dylib.display());
 
     // 3. Load the example-local plugin project (registers the
-    //    grayscale processor from the staged cdylib).
-    runtime.load_project(&plugin_dir)?;
+    //    grayscale processor from the staged cdylib). The
+    //    `ManifestDirectory` strategy preserves the recursive
+    //    dep-walker shape — it reads `plugin/streamlib.yaml`, walks
+    //    declared deps (`@tatolab/core` patched to a workspace path),
+    //    and registers the local plugin's processors + schemas.
+    runtime.add_module_with(
+        module_ident_any_version!("tatolab", "camera-rust-plugin"),
+        ModuleResolverStrategy::ManifestDirectory {
+            path: plugin_dir.clone(),
+        },
+    )?;
 
     // 4. Add processors
     let camera = runtime.add_processor(ProcessorSpec::new(

--- a/examples/jpeg-psnr/src/main.rs
+++ b/examples/jpeg-psnr/src/main.rs
@@ -17,6 +17,7 @@
 
 use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::runtime::Runner;
 use streamlib::sdk::schema_ident;
@@ -38,11 +39,9 @@ fn main() -> Result<()> {
 
     let runtime = Runner::new()?;
 
-    runtime.load_workspace_packages([
-        "@tatolab/debug-utilities",
-        "@tatolab/jpeg",
-        "@tatolab/display",
-    ])?;
+    runtime.add_module(module_ident_any_version!("tatolab", "debug-utilities"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "jpeg"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "display"))?;
 
     let source = runtime.add_processor(ProcessorSpec::new(
         schema_ident!("tatolab", "debug-utilities", "JpegBytesSource", "1.0.0"),

--- a/examples/moq-roundtrip/src/main.rs
+++ b/examples/moq-roundtrip/src/main.rs
@@ -25,6 +25,7 @@
 
 use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::runtime::Runner;
 use streamlib::sdk::schema_ident;
@@ -40,14 +41,12 @@ fn main() -> Result<()> {
 
     let runtime = Runner::new()?;
 
-    runtime.load_workspace_packages([
-        "@tatolab/audio",
-        "@tatolab/camera",
-        "@tatolab/display",
-        "@tatolab/h264",
-        "@tatolab/moq",
-        "@tatolab/opus",
-    ])?;
+    runtime.add_module(module_ident_any_version!("tatolab", "audio"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "camera"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "display"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "h264"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "moq"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "opus"))?;
 
     // ---- PUBLISH SIDE ----
 

--- a/examples/moq-roundtrip/streamlib.yaml
+++ b/examples/moq-roundtrip/streamlib.yaml
@@ -2,12 +2,13 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 #
-# moq-roundtrip example. Declares `@tatolab/core` so
-# `Runner::load_project(.)` registers the wire-vocabulary schemas
-# (VideoFrame, EncodedVideoFrame, AudioFrame, EncodedAudioFrame) with
-# the engine's runtime schema registry. Required so iceoryx2 publishers
-# size from each schema's declared `max_payload_bytes` instead of the
-# 64 KiB default — without it the encoder's first IDR is rejected as
+# moq-roundtrip example. Declares `@tatolab/core` so the runtime
+# registers the wire-vocabulary schemas (VideoFrame, EncodedVideoFrame,
+# AudioFrame, EncodedAudioFrame) — via the recursive dep walker that
+# runs when each `runtime.add_module(...)` in `src/main.rs` follows its
+# package's transitive deps. Required so iceoryx2 publishers size from
+# each schema's declared `max_payload_bytes` instead of the 64 KiB
+# default — without it the encoder's first IDR is rejected as
 # ExceedsMaxLoanSize and the decoder never sees SPS/PPS.
 
 package:

--- a/examples/vulkan-video-psnr/src/main.rs
+++ b/examples/vulkan-video-psnr/src/main.rs
@@ -17,6 +17,7 @@
 
 use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::runtime::Runner;
 use streamlib::sdk::schema_ident;
@@ -40,12 +41,10 @@ fn main() -> Result<()> {
 
     let runtime = Runner::new()?;
 
-    runtime.load_workspace_packages([
-        "@tatolab/debug-utilities",
-        "@tatolab/display",
-        "@tatolab/h264",
-        "@tatolab/h265",
-    ])?;
+    runtime.add_module(module_ident_any_version!("tatolab", "debug-utilities"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "display"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "h264"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "h265"))?;
 
     let source = runtime.add_processor(ProcessorSpec::new(
         schema_ident!("tatolab", "debug-utilities", "BgraFileSource", "1.0.0"),

--- a/examples/vulkan-video-psnr/streamlib.yaml
+++ b/examples/vulkan-video-psnr/streamlib.yaml
@@ -2,13 +2,14 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 #
-# vulkan-video-psnr example. Declares `@tatolab/core` so
-# `Runner::load_project(.)` registers the wire-vocabulary schemas
-# (VideoFrame, EncodedVideoFrame, …) with the engine's runtime schema
-# registry. Required so iceoryx2 publishers size from each schema's
-# declared `max_payload_bytes` instead of the 64 KiB default — without
-# it the encoder's first IDR is rejected as ExceedsMaxLoanSize and the
-# decoder never sees SPS/PPS.
+# vulkan-video-psnr example. Declares `@tatolab/core` so the runtime
+# registers the wire-vocabulary schemas (VideoFrame, EncodedVideoFrame,
+# …) — via the recursive dep walker that runs when each
+# `runtime.add_module(...)` in `src/main.rs` follows its package's
+# transitive deps. Required so iceoryx2 publishers size from each
+# schema's declared `max_payload_bytes` instead of the 64 KiB default —
+# without it the encoder's first IDR is rejected as ExceedsMaxLoanSize
+# and the decoder never sees SPS/PPS.
 
 package:
   org: tatolab

--- a/examples/vulkan-video-roundtrip-cdylib-camera/Cargo.toml
+++ b/examples/vulkan-video-roundtrip-cdylib-camera/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 # Deliberately NOT taking streamlib-camera as a Rust dep. The camera
-# is loaded at runtime via `Runner::load_project(...)` against a
+# is loaded at runtime via `Runner::add_module(...)` against a
 # staged copy of `packages/camera/`. Linking streamlib-camera as a
 # Rust dep would auto-register the `Camera` processor at link time,
 # conflicting with the cdylib's registration at load time.

--- a/examples/vulkan-video-roundtrip-cdylib-camera/src/main.rs
+++ b/examples/vulkan-video-roundtrip-cdylib-camera/src/main.rs
@@ -4,7 +4,7 @@
 //! Vulkan Video Encode/Decode Roundtrip Pipeline — camera-as-cdylib variant.
 //!
 //! Sibling of `examples/vulkan-video-roundtrip` that loads every
-//! processor as a cdylib via `runtime.load_workspace_packages(...)`.
+//! processor as a cdylib via `runtime.add_module(...)`.
 //! Exists to exercise the cdylib FFI surface (Phase E
 //! `RhiColorConverterMethodsVTable` + `RhiCommandRecorderMethodsVTable`)
 //! end-to-end through the encode → decode → display pipeline.
@@ -21,6 +21,7 @@
 
 use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::runtime::Runner;
 use streamlib::sdk::schema_ident;
@@ -36,17 +37,15 @@ fn main() -> Result<()> {
         "=== Vulkan Video {} Roundtrip (all-cdylib) ===",
         codec.to_uppercase()
     );
-    println!("Camera:   {device} (loaded as cdylib via load_workspace_packages)");
+    println!("Camera:   {device} (loaded as cdylib via add_module)");
     println!("Duration: {duration_secs}s\n");
 
     let runtime = Runner::new()?;
 
-    runtime.load_workspace_packages([
-        "@tatolab/camera",
-        "@tatolab/display",
-        "@tatolab/h264",
-        "@tatolab/h265",
-    ])?;
+    runtime.add_module(module_ident_any_version!("tatolab", "camera"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "display"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "h264"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "h265"))?;
     println!("+ Camera / Display / H264 / H265 loaded from target/streamlib-plugins/");
     println!("+ Wire vocabulary registered (via @tatolab/core dep walk)\n");
 

--- a/examples/vulkan-video-roundtrip-cdylib-camera/streamlib.yaml
+++ b/examples/vulkan-video-roundtrip-cdylib-camera/streamlib.yaml
@@ -2,19 +2,21 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 #
-# vulkan-video-roundtrip example. Declares `@tatolab/core` so
-# `Runner::load_project(.)` registers the wire-vocabulary schemas
-# (VideoFrame, EncodedVideoFrame, …) with the engine's runtime schema
-# registry. Without that, iceoryx2 publishers size to the 64 KiB default
-# from `streamlib-ipc-types::MAX_PAYLOAD_SIZE` and the encoder's first
-# IDR (which carries SPS+PPS) is rejected with ExceedsMaxLoanSize, so the
-# decoder never sees the session parameters and decodes zero frames.
+# vulkan-video-roundtrip-cdylib-camera example. Declares `@tatolab/core`
+# so the runtime registers the wire-vocabulary schemas (VideoFrame,
+# EncodedVideoFrame, …) — via the recursive dep walker that runs when
+# each `runtime.add_module(...)` in `src/main.rs` follows its package's
+# transitive deps. Without that, iceoryx2 publishers size to the 64 KiB
+# default from `streamlib-ipc-types::MAX_PAYLOAD_SIZE` and the encoder's
+# first IDR (which carries SPS+PPS) is rejected with ExceedsMaxLoanSize,
+# so the decoder never sees the session parameters and decodes zero
+# frames.
 
 package:
   org: tatolab
   name: vulkan-video-roundtrip-cdylib-camera
   version: "0.1.0"
-  description: "Camera → encoder → decoder → display roundtrip with the camera processor loaded via runtime.load_project (cdylib) instead of as a Rust dep. Manual gate that exercises the full cdylib FFI surface end-to-end through encode/decode, validating that the cdylib's per-frame compute kernel + recorder dispatch + pixel-buffer flow matches the baseline non-cdylib variant."
+  description: "Camera → encoder → decoder → display roundtrip with the camera processor loaded via runtime.add_module (cdylib) instead of as a Rust dep. Manual gate that exercises the full cdylib FFI surface end-to-end through encode/decode, validating that the cdylib's per-frame compute kernel + recorder dispatch + pixel-buffer flow matches the baseline non-cdylib variant."
 
 dependencies:
   "@tatolab/core": "^1.0.0"

--- a/examples/vulkan-video-roundtrip/src/main.rs
+++ b/examples/vulkan-video-roundtrip/src/main.rs
@@ -19,6 +19,7 @@
 
 use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::runtime::Runner;
 use streamlib::sdk::schema_ident;
@@ -40,12 +41,10 @@ fn main() -> Result<()> {
     // pulled in transitively by each — its wire-vocabulary schemas
     // (`EncodedVideoFrame.max_payload_bytes` in particular) are
     // load-bearing for iceoryx2 publisher sizing.
-    runtime.load_workspace_packages([
-        "@tatolab/camera",
-        "@tatolab/display",
-        "@tatolab/h264",
-        "@tatolab/h265",
-    ])?;
+    runtime.add_module(module_ident_any_version!("tatolab", "camera"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "display"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "h264"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "h265"))?;
 
     // --- Camera ---
     // STREAMLIB_CAMERA_MAX_WIDTH / STREAMLIB_CAMERA_MAX_HEIGHT cap V4L2

--- a/examples/vulkan-video-roundtrip/streamlib.yaml
+++ b/examples/vulkan-video-roundtrip/streamlib.yaml
@@ -2,13 +2,15 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 #
-# vulkan-video-roundtrip example. Declares `@tatolab/core` so
-# `Runner::load_project(.)` registers the wire-vocabulary schemas
-# (VideoFrame, EncodedVideoFrame, …) with the engine's runtime schema
-# registry. Without that, iceoryx2 publishers size to the 64 KiB default
-# from `streamlib-ipc-types::MAX_PAYLOAD_SIZE` and the encoder's first
-# IDR (which carries SPS+PPS) is rejected with ExceedsMaxLoanSize, so the
-# decoder never sees the session parameters and decodes zero frames.
+# vulkan-video-roundtrip example. Declares `@tatolab/core` so the
+# runtime registers the wire-vocabulary schemas (VideoFrame,
+# EncodedVideoFrame, …) — via the recursive dep walker that runs when
+# each `runtime.add_module(...)` in `src/main.rs` follows its package's
+# transitive deps. Without that, iceoryx2 publishers size to the 64 KiB
+# default from `streamlib-ipc-types::MAX_PAYLOAD_SIZE` and the encoder's
+# first IDR (which carries SPS+PPS) is rejected with ExceedsMaxLoanSize,
+# so the decoder never sees the session parameters and decodes zero
+# frames.
 
 package:
   org: tatolab

--- a/examples/webrtc-cloudflare-stream/src/main.rs
+++ b/examples/webrtc-cloudflare-stream/src/main.rs
@@ -28,6 +28,8 @@ use streamlib::sdk::error::Result;
 #[cfg(target_os = "linux")]
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 #[cfg(target_os = "linux")]
+use streamlib::sdk::module_ident_any_version;
+#[cfg(target_os = "linux")]
 use streamlib::sdk::runtime::Runner;
 #[cfg(target_os = "linux")]
 use streamlib::sdk::processors::ProcessorSpec;
@@ -63,13 +65,11 @@ fn main() -> Result<()> {
 
     let runtime = Runner::new()?;
 
-    runtime.load_workspace_packages([
-        "@tatolab/audio",
-        "@tatolab/camera",
-        "@tatolab/h264",
-        "@tatolab/opus",
-        "@tatolab/webrtc",
-    ])?;
+    runtime.add_module(module_ident_any_version!("tatolab", "audio"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "camera"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "h264"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "opus"))?;
+    runtime.add_module(module_ident_any_version!("tatolab", "webrtc"))?;
 
     println!("🔒 Requesting camera permission...");
     if !request_camera_permission()? {


### PR DESCRIPTION
## Summary

Mechanical sweep of every non-polyglot example caller of the three deprecated loaders (`load_workspace_packages`, `load_project`, `load_package`) to the unified `add_module(ident)` / `add_module_with(ident, ModuleResolverStrategy)` form. Examples-tier counterpart of #1059 (in-tree non-example callers) and #1060/#1061/#1062 (polyglot example sweep).

## In scope

10 examples actively migrated:

- `examples/api-server-demo`
- `examples/audio-mixer-demo`
- `examples/camera-display`
- `examples/camera-rust-plugin` (both halves: `add_module` for `@tatolab/camera` + `@tatolab/display`, and `add_module_with(ManifestDirectory)` for the example-local grayscale plugin — same shape as #1059's reference)
- `examples/jpeg-psnr`
- `examples/moq-roundtrip`
- `examples/vulkan-video-psnr`
- `examples/vulkan-video-roundtrip`
- `examples/vulkan-video-roundtrip-cdylib-camera`
- `examples/webrtc-cloudflare-stream`

Also cleaned stale doc-comment references to the deprecated loaders in:

- `examples/api-server/{src/main.rs,Cargo.toml}` (already migrated in #1059; doc comments still referenced `load_project` / `load_workspace_packages`)
- The example-root `streamlib.yaml`s for the four examples whose package description / header comment mentioned `Runner::load_project(.)` (those manifests aren't actually loaded by the example's `main.rs`, but the comment was misleading)

## Out of scope

- `examples/camera-python-display` — sibling carve-out (goal-19) covers it.
- `examples/tokio-integration` — listed in #1052's body but verified at pickup to have no `load_*` call. Already minimal.
- Polyglot examples + `cuda-fisheye-detection` — sibling sweep #1050 already merged (PRs #1060, #1061, #1062).

## Reference shape

Per #1059's commit 912c54dd:

```rust
runtime.load_workspace_packages(["@tatolab/audio"])?;
// →
runtime.add_module(module_ident_any_version!("tatolab", "audio"))?;

runtime.load_project(&plugin_dir)?;
// →
runtime.add_module_with(
    module_ident_any_version!("tatolab", "camera-rust-plugin"),
    ModuleResolverStrategy::ManifestDirectory { path: plugin_dir.clone() },
)?;
```

## Test plan

- [x] `cargo check --workspace --all-targets` clean.
- [x] `cargo xtask check-boundaries` clean (4373 files).
- [x] `cargo xtask lint-logging` clean (462 files).
- [x] `audio-mixer-demo` smoke run: chord generator loaded, processors registered, pipeline started + clean teardown.
- [x] `tokio-integration` smoke run: Runner created in tokio context, graph state queried, clean stop.
- [x] `camera-display` smoke run: pipeline reaches Camera "first frame captured", then trips a **pre-existing main-branch** FFI panic in display's cdylib `start()` (`GpuContextFullAccess::device(): return type borrows into host-private state and cannot cross the FFI boundary`). Verified identical failure by stashing this PR's changes and reproducing on `main` — not introduced by this sweep; out of scope.
- [x] `pr-review-gate` PASS verdict (mechanical migration matches #1059 reference shape; no scope creep; no underscore reach-throughs; no RHI-boundary or polyglot-sync concerns).

## Exit criteria

Both #1052 exit criteria satisfied:

- ✅ Every non-polyglot example caller of the three deprecated loaders rewrites to explicit `add_module(ident)` calls. Final `grep` of `examples/*/src/*.rs examples/*/Cargo.toml examples/*/streamlib.yaml` (excluding `camera-python-display`) returns zero matches.
- ✅ Existing example behaviors preserved — mechanical API-surface migration only; no scenario regression from the rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)