### PR TITLE
fix(1066): camera-display cdylib render path — host_video_source_timeline_arc + recorder vtable slots

### DIFF
--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -3242,9 +3242,15 @@ impl GpuContextLimitedAccess {
 
     /// See [`GpuContext::video_source_timeline_semaphore`].
     ///
-    /// **Engine-only** — return type is
-    /// `Option<Arc<HostVulkanTimelineSemaphore>>` (host-internal
-    /// type). Explicit guard below.
+    /// **Engine-only** — return type
+    /// `Option<Arc<HostVulkanTimelineSemaphore>>` borrows into
+    /// host-private state, so the borrow can't cross the FFI
+    /// boundary. Calling from a cdylib panics at the explicit guard
+    /// below. **Cdylib callers** must use
+    /// [`Self::host_video_source_timeline_arc`] instead — it returns
+    /// the same `Option<Arc<...>>` but via the v14 vtable slot that
+    /// transits the Arc as a raw pointer
+    /// (`Arc::into_raw` / `Arc::from_raw`).
     #[cfg(target_os = "linux")]
     pub fn video_source_timeline_semaphore(
         &self,
@@ -3252,13 +3258,58 @@ impl GpuContextLimitedAccess {
         if crate::core::plugin::host_services::host_callbacks().is_some() {
             panic!(
                 "GpuContextLimitedAccess::video_source_timeline_semaphore() \
-                 reached from cdylib code; return type \
-                 `Option<Arc<HostVulkanTimelineSemaphore>>` is host-internal \
-                 (crate::vulkan::rhi) and cannot cross the FFI boundary. \
-                 Engine-only — cdylib code must not call it."
+                 reached from cdylib code; use \
+                 `host_video_source_timeline_arc()` instead. The legacy method \
+                 returns `Option<Arc<HostVulkanTimelineSemaphore>>` from \
+                 `host_inner()` which borrows host-private state and cannot \
+                 cross the FFI boundary."
             );
         }
         self.host_inner().video_source_timeline_semaphore()
+    }
+
+    /// Cdylib-safe sibling of
+    /// [`Self::video_source_timeline_semaphore`]. Dispatches through
+    /// the v14
+    /// [`GpuContextLimitedAccessVTable::host_video_source_timeline_arc`](streamlib_plugin_abi::GpuContextLimitedAccessVTable::host_video_source_timeline_arc)
+    /// slot in cdylib mode; in host mode the same vtable dispatch
+    /// resolves to the local `HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE`
+    /// static. Returns `None` when no producer has published a
+    /// timeline yet (the slot is empty), when the slot was cleared
+    /// via [`Self::clear_video_source_timeline_semaphore`], or when
+    /// the handle/vtable is null.
+    ///
+    /// **Arc-raw-pointer transit** — same rustc-version coupling
+    /// caveat as
+    /// [`Self::set_video_source_timeline_semaphore`].
+    /// `HostVulkanTimelineSemaphore` is not `#[repr(C)]`; in-tree
+    /// workspace plugin cdylibs share the host's rustc + dep graph
+    /// and ride this freely.
+    #[cfg(target_os = "linux")]
+    pub fn host_video_source_timeline_arc(
+        &self,
+    ) -> Option<Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>> {
+        if self.handle.is_null() || self.vtable.is_null() {
+            return None;
+        }
+        // SAFETY: handle + vtable were paired at construction. The
+        // host's callback either returns null (slot empty / null
+        // handle) or `Arc::into_raw` on a freshly cloned
+        // `Arc<HostVulkanTimelineSemaphore>` (fresh strong count
+        // moves into the cdylib).
+        let raw = unsafe {
+            ((*self.vtable).host_video_source_timeline_arc)(self.handle)
+        };
+        if raw.is_null() {
+            return None;
+        }
+        // SAFETY: matched with the host's `Arc::into_raw` above.
+        let arc = unsafe {
+            Arc::from_raw(
+                raw as *const crate::vulkan::rhi::HostVulkanTimelineSemaphore,
+            )
+        };
+        Some(arc)
     }
 
     /// Acquire a pooled texture from a pre-reserved pool (Split: fast path).

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -8458,7 +8458,20 @@ pub static HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE:
 /// the β-shape's `methods_vtable` field.
 pub fn host_vulkan_compute_kernel_methods_vtable(
 ) -> *const streamlib_plugin_abi::VulkanComputeKernelMethodsVTable {
-    &HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE
+    // Same routing as `host_gpu_context_limited_access_vtable`:
+    // cdylib β-shape constructors must store the host's vtable
+    // pointer so dispatches actually cross to host code (whose
+    // `host_callbacks()` returns `None`). Without this routing, the
+    // β-shape stored the cdylib's local static and dispatched to the
+    // cdylib's own copy of the wrapper — where `host_callbacks()`
+    // returns `Some` and any reach through `Texture::host_inner()` or
+    // sibling β-shape `host_inner()` accessors panics.
+    match host_callbacks() {
+        Some(c) if !c.vulkan_compute_kernel_methods_vtable.is_null() => {
+            c.vulkan_compute_kernel_methods_vtable
+        }
+        _ => &HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE,
+    }
 }
 
 // ---- VulkanGraphicsKernelMethodsVTable wrappers (#951) ---------------------
@@ -9919,7 +9932,15 @@ pub static HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE:
 /// the β-shape's `methods_vtable` field.
 pub fn host_vulkan_graphics_kernel_methods_vtable(
 ) -> *const streamlib_plugin_abi::VulkanGraphicsKernelMethodsVTable {
-    &HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE
+    // See [`host_vulkan_compute_kernel_methods_vtable`] for the routing
+    // rationale — cdylib β-shape constructors must store the host's
+    // vtable pointer so dispatches actually cross DSO boundaries.
+    match host_callbacks() {
+        Some(c) if !c.vulkan_graphics_kernel_methods_vtable.is_null() => {
+            c.vulkan_graphics_kernel_methods_vtable
+        }
+        _ => &HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE,
+    }
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -12526,9 +12547,18 @@ pub static HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE:
 /// Accessor for the host's static `RhiCommandRecorderMethodsVTable`
 /// — used by `RhiCommandRecorder::from_inner` to populate the
 /// β-shape's `methods_vtable` field.
+///
+/// See [`host_vulkan_compute_kernel_methods_vtable`] for the routing
+/// rationale — cdylib β-shape constructors must store the host's
+/// vtable pointer so dispatches actually cross DSO boundaries.
 pub fn host_rhi_command_recorder_methods_vtable(
 ) -> *const streamlib_plugin_abi::RhiCommandRecorderMethodsVTable {
-    &HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE
+    match host_callbacks() {
+        Some(c) if !c.rhi_command_recorder_methods_vtable.is_null() => {
+            c.rhi_command_recorder_methods_vtable
+        }
+        _ => &HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE,
+    }
 }
 
 // =============================================================================

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -12513,6 +12513,123 @@ unsafe extern "C" fn host_command_recorder_record_draw(
     1
 }
 
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_draw_indexed(
+    recorder_handle: *const c_void,
+    kernel_handle: *const c_void,
+    frame_index: u32,
+    draw: *const streamlib_plugin_abi::DrawIndexedCallRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_command_recorder_record_draw_indexed",
+        || -> i32 {
+            let Some(recorder) =
+                (unsafe { handle_as_command_recorder_mut(recorder_handle) })
+            else {
+                write_err(
+                    "record_draw_indexed: null recorder handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if kernel_handle.is_null() {
+                write_err(
+                    "record_draw_indexed: null kernel handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            if draw.is_null() {
+                write_err(
+                    "record_draw_indexed: null draw pointer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let draw_ref = unsafe { &*draw };
+            let viewport = if draw_ref.viewport_present != 0 {
+                Some(crate::core::rhi::Viewport {
+                    x: draw_ref.viewport.x,
+                    y: draw_ref.viewport.y,
+                    width: draw_ref.viewport.width,
+                    height: draw_ref.viewport.height,
+                    min_depth: draw_ref.viewport.min_depth,
+                    max_depth: draw_ref.viewport.max_depth,
+                })
+            } else {
+                None
+            };
+            let scissor = if draw_ref.scissor_present != 0 {
+                Some(crate::core::rhi::ScissorRect {
+                    x: draw_ref.scissor.x,
+                    y: draw_ref.scissor.y,
+                    width: draw_ref.scissor.width,
+                    height: draw_ref.scissor.height,
+                })
+            } else {
+                None
+            };
+            let draw_call = crate::core::rhi::DrawIndexedCall {
+                index_count: draw_ref.index_count,
+                instance_count: draw_ref.instance_count,
+                first_index: draw_ref.first_index,
+                vertex_offset: draw_ref.vertex_offset,
+                first_instance: draw_ref.first_instance,
+                viewport,
+                scissor,
+            };
+            let kernel_borrow = make_graphics_kernel_borrow(kernel_handle);
+            match recorder.record_draw_indexed(
+                &*kernel_borrow,
+                frame_index,
+                &draw_call,
+            ) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("record_draw_indexed: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_draw_indexed(
+    _recorder_handle: *const c_void,
+    _kernel_handle: *const c_void,
+    _frame_index: u32,
+    _draw: *const streamlib_plugin_abi::DrawIndexedCallRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "record_draw_indexed: Linux-only",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
 /// Host-side `RhiCommandRecorderMethodsVTable` wired to the
 /// per-method wrappers above (Phase E sub-lift slice B — #984;
 /// v3 swapchain render-path slots — #1066).
@@ -12542,6 +12659,7 @@ pub static HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE:
             host_command_recorder_cmd_end_dynamic_rendering,
         submit_with_semaphores: host_command_recorder_submit_with_semaphores,
         record_draw: host_command_recorder_record_draw,
+        record_draw_indexed: host_command_recorder_record_draw_indexed,
     };
 
 /// Accessor for the host's static `RhiCommandRecorderMethodsVTable`

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -12024,8 +12024,477 @@ unsafe extern "C" fn host_command_recorder_submit_signaling_timeline(
     1
 }
 
+// -------------------------------------------------------------------------
+// v3 (#1066) — swapchain render-path wrappers
+// -------------------------------------------------------------------------
+
+/// Reconstruct a borrowed `VulkanGraphicsKernel` β-shape from its
+/// `Arc::into_raw`-shaped handle. Same pattern as
+/// `make_compute_kernel_borrow` — cached POD fields are populated by
+/// reading the host-side inner.
+#[cfg(target_os = "linux")]
+fn make_graphics_kernel_borrow(
+    handle: *const c_void,
+) -> std::mem::ManuallyDrop<crate::vulkan::rhi::VulkanGraphicsKernel> {
+    let k_for_inner = std::mem::ManuallyDrop::new(
+        crate::vulkan::rhi::VulkanGraphicsKernel {
+            handle,
+            vtable: host_gpu_context_full_access_vtable(),
+            methods_vtable: host_vulkan_graphics_kernel_methods_vtable(),
+            cached_push_constant_size: 0,
+            cached_descriptor_sets_in_flight: 0,
+        },
+    );
+    let inner = k_for_inner.host_inner();
+    std::mem::ManuallyDrop::new(crate::vulkan::rhi::VulkanGraphicsKernel {
+        handle,
+        vtable: host_gpu_context_full_access_vtable(),
+        methods_vtable: host_vulkan_graphics_kernel_methods_vtable(),
+        cached_push_constant_size: inner.push_constant_size(),
+        cached_descriptor_sets_in_flight: inner.descriptor_sets_in_flight(),
+    })
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_swapchain_image_barrier(
+    recorder_handle: *const c_void,
+    image_raw: u64,
+    from_layout_raw: i32,
+    to_layout_raw: i32,
+    from_stage_raw: i64,
+    to_stage_raw: i64,
+    from_access_raw: i64,
+    to_access_raw: i64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_command_recorder_record_swapchain_image_barrier",
+        || -> i32 {
+            let Some(recorder) =
+                (unsafe { handle_as_command_recorder_mut(recorder_handle) })
+            else {
+                write_err(
+                    "record_swapchain_image_barrier: null recorder handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            use vulkanalia::vk::{self, Handle};
+            // SAFETY: caller passes a raw VkImage handle minted by the
+            // host-side swapchain creation; this widens it to the
+            // `Handle` type without dereferencing anything.
+            let image = vk::Image::from_raw(image_raw);
+            let old_layout = vk::ImageLayout::from_raw(from_layout_raw);
+            let new_layout = vk::ImageLayout::from_raw(to_layout_raw);
+            let src_stage =
+                vk::PipelineStageFlags2::from_bits_truncate(from_stage_raw as u64);
+            let src_access =
+                vk::AccessFlags2::from_bits_truncate(from_access_raw as u64);
+            let dst_stage =
+                vk::PipelineStageFlags2::from_bits_truncate(to_stage_raw as u64);
+            let dst_access =
+                vk::AccessFlags2::from_bits_truncate(to_access_raw as u64);
+            match recorder.record_swapchain_image_barrier(
+                image, old_layout, new_layout, src_stage, src_access, dst_stage,
+                dst_access,
+            ) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("record_swapchain_image_barrier: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_swapchain_image_barrier(
+    _recorder_handle: *const c_void,
+    _image_raw: u64,
+    _from_layout_raw: i32,
+    _to_layout_raw: i32,
+    _from_stage_raw: i64,
+    _to_stage_raw: i64,
+    _from_access_raw: i64,
+    _to_access_raw: i64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "record_swapchain_image_barrier: Linux-only",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_cmd_begin_dynamic_rendering(
+    recorder_handle: *const c_void,
+    image_view_raw: u64,
+    extent_w: u32,
+    extent_h: u32,
+    has_clear_color: u32,
+    clear_r: f32,
+    clear_g: f32,
+    clear_b: f32,
+    clear_a: f32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_command_recorder_cmd_begin_dynamic_rendering",
+        || -> i32 {
+            let Some(recorder) =
+                (unsafe { handle_as_command_recorder_mut(recorder_handle) })
+            else {
+                write_err(
+                    "cmd_begin_dynamic_rendering: null recorder handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            use vulkanalia::vk::{self, Handle};
+            let image_view = vk::ImageView::from_raw(image_view_raw);
+            let clear = if has_clear_color != 0 {
+                Some([clear_r, clear_g, clear_b, clear_a])
+            } else {
+                None
+            };
+            match recorder.cmd_begin_dynamic_rendering(
+                image_view,
+                (extent_w, extent_h),
+                clear,
+            ) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("cmd_begin_dynamic_rendering: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_cmd_begin_dynamic_rendering(
+    _recorder_handle: *const c_void,
+    _image_view_raw: u64,
+    _extent_w: u32,
+    _extent_h: u32,
+    _has_clear_color: u32,
+    _clear_r: f32,
+    _clear_g: f32,
+    _clear_b: f32,
+    _clear_a: f32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "cmd_begin_dynamic_rendering: Linux-only",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_command_recorder_cmd_end_dynamic_rendering(
+    recorder_handle: *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_command_recorder_cmd_end_dynamic_rendering",
+        || -> i32 {
+            let Some(recorder) =
+                (unsafe { handle_as_command_recorder_mut(recorder_handle) })
+            else {
+                write_err(
+                    "cmd_end_dynamic_rendering: null recorder handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            match recorder.cmd_end_dynamic_rendering() {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("cmd_end_dynamic_rendering: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_command_recorder_cmd_end_dynamic_rendering(
+    _recorder_handle: *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "cmd_end_dynamic_rendering: Linux-only",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_submit_with_semaphores(
+    recorder_handle: *const c_void,
+    waits_ptr: *const streamlib_plugin_abi::SemaphoreSubmitInfoRepr,
+    waits_count: usize,
+    signals_ptr: *const streamlib_plugin_abi::SemaphoreSubmitInfoRepr,
+    signals_count: usize,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_command_recorder_submit_with_semaphores",
+        || -> i32 {
+            let Some(recorder) =
+                (unsafe { handle_as_command_recorder_mut(recorder_handle) })
+            else {
+                write_err(
+                    "submit_with_semaphores: null recorder handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            use vulkanalia::vk::{self, Handle, HasBuilder};
+            // SAFETY: caller-owned arrays. We only read; the buffers
+            // outlive the call by the cdylib-side `Vec` they came from.
+            let waits_repr: &[streamlib_plugin_abi::SemaphoreSubmitInfoRepr] =
+                if waits_count == 0 {
+                    &[]
+                } else {
+                    unsafe { std::slice::from_raw_parts(waits_ptr, waits_count) }
+                };
+            let signals_repr: &[streamlib_plugin_abi::SemaphoreSubmitInfoRepr] =
+                if signals_count == 0 {
+                    &[]
+                } else {
+                    unsafe { std::slice::from_raw_parts(signals_ptr, signals_count) }
+                };
+            let waits: Vec<vk::SemaphoreSubmitInfo> = waits_repr
+                .iter()
+                .map(|r| {
+                    vk::SemaphoreSubmitInfo::builder()
+                        .semaphore(vk::Semaphore::from_raw(r.semaphore))
+                        .value(r.value)
+                        .stage_mask(vk::PipelineStageFlags2::from_bits_truncate(
+                            r.stage_mask,
+                        ))
+                        .device_index(r.device_index)
+                        .build()
+                })
+                .collect();
+            let signals: Vec<vk::SemaphoreSubmitInfo> = signals_repr
+                .iter()
+                .map(|r| {
+                    vk::SemaphoreSubmitInfo::builder()
+                        .semaphore(vk::Semaphore::from_raw(r.semaphore))
+                        .value(r.value)
+                        .stage_mask(vk::PipelineStageFlags2::from_bits_truncate(
+                            r.stage_mask,
+                        ))
+                        .device_index(r.device_index)
+                        .build()
+                })
+                .collect();
+            match recorder.submit_with_semaphores(&waits, &signals) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("submit_with_semaphores: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_submit_with_semaphores(
+    _recorder_handle: *const c_void,
+    _waits_ptr: *const streamlib_plugin_abi::SemaphoreSubmitInfoRepr,
+    _waits_count: usize,
+    _signals_ptr: *const streamlib_plugin_abi::SemaphoreSubmitInfoRepr,
+    _signals_count: usize,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "submit_with_semaphores: Linux-only",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_draw(
+    recorder_handle: *const c_void,
+    kernel_handle: *const c_void,
+    frame_index: u32,
+    draw: *const streamlib_plugin_abi::DrawCallRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_command_recorder_record_draw",
+        || -> i32 {
+            let Some(recorder) =
+                (unsafe { handle_as_command_recorder_mut(recorder_handle) })
+            else {
+                write_err(
+                    "record_draw: null recorder handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if kernel_handle.is_null() {
+                write_err(
+                    "record_draw: null kernel handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            if draw.is_null() {
+                write_err(
+                    "record_draw: null draw pointer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let draw_ref = unsafe { &*draw };
+            let viewport = if draw_ref.viewport_present != 0 {
+                Some(crate::core::rhi::Viewport {
+                    x: draw_ref.viewport.x,
+                    y: draw_ref.viewport.y,
+                    width: draw_ref.viewport.width,
+                    height: draw_ref.viewport.height,
+                    min_depth: draw_ref.viewport.min_depth,
+                    max_depth: draw_ref.viewport.max_depth,
+                })
+            } else {
+                None
+            };
+            let scissor = if draw_ref.scissor_present != 0 {
+                Some(crate::core::rhi::ScissorRect {
+                    x: draw_ref.scissor.x,
+                    y: draw_ref.scissor.y,
+                    width: draw_ref.scissor.width,
+                    height: draw_ref.scissor.height,
+                })
+            } else {
+                None
+            };
+            let draw_call = crate::core::rhi::DrawCall {
+                vertex_count: draw_ref.vertex_count,
+                instance_count: draw_ref.instance_count,
+                first_vertex: draw_ref.first_vertex,
+                first_instance: draw_ref.first_instance,
+                viewport,
+                scissor,
+            };
+            let kernel_borrow = make_graphics_kernel_borrow(kernel_handle);
+            match recorder.record_draw(&*kernel_borrow, frame_index, &draw_call) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("record_draw: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_draw(
+    _recorder_handle: *const c_void,
+    _kernel_handle: *const c_void,
+    _frame_index: u32,
+    _draw: *const streamlib_plugin_abi::DrawCallRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err("record_draw: Linux-only", err_buf, err_buf_cap, err_len);
+    1
+}
+
 /// Host-side `RhiCommandRecorderMethodsVTable` wired to the
-/// per-method wrappers above (Phase E sub-lift slice B — #984).
+/// per-method wrappers above (Phase E sub-lift slice B — #984;
+/// v3 swapchain render-path slots — #1066).
 pub static HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE:
     streamlib_plugin_abi::RhiCommandRecorderMethodsVTable =
     streamlib_plugin_abi::RhiCommandRecorderMethodsVTable {
@@ -12044,6 +12513,14 @@ pub static HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE:
             host_command_recorder_record_pixel_buffer_barrier,
         record_copy_image_to_pixel_buffer:
             host_command_recorder_record_copy_image_to_pixel_buffer,
+        record_swapchain_image_barrier:
+            host_command_recorder_record_swapchain_image_barrier,
+        cmd_begin_dynamic_rendering:
+            host_command_recorder_cmd_begin_dynamic_rendering,
+        cmd_end_dynamic_rendering:
+            host_command_recorder_cmd_end_dynamic_rendering,
+        submit_with_semaphores: host_command_recorder_submit_with_semaphores,
+        record_draw: host_command_recorder_record_draw,
     };
 
 /// Accessor for the host's static `RhiCommandRecorderMethodsVTable`

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -2228,6 +2228,42 @@ unsafe extern "C" fn host_gpu_lim_wait_timeline_semaphore(
 }
 
 // -------------------------------------------------------------------------
+// host_video_source_timeline_arc — v14 (#1066)
+// -------------------------------------------------------------------------
+
+/// Clone the host's `Arc<HostVulkanTimelineSemaphore>` from the
+/// publish slot and return the raw `Arc::into_raw` pointer to the
+/// cdylib. The cdylib reconstitutes via `Arc::from_raw`; the host's
+/// slot retains its own independent strong count. Returns null when
+/// `gpu_handle` is null or when no producer has published a
+/// timeline (the slot is `None`).
+unsafe extern "C" fn host_gpu_lim_host_video_source_timeline_arc(
+    handle: *const c_void,
+) -> *const c_void {
+    run_host_extern_c(
+        "host_gpu_lim_host_video_source_timeline_arc",
+        || -> *const c_void {
+            let Some(gpu) = (unsafe { handle_as_gpu_context(handle) }) else {
+                return std::ptr::null();
+            };
+            #[cfg(target_os = "linux")]
+            {
+                match gpu.video_source_timeline_semaphore() {
+                    Some(arc) => Arc::into_raw(arc) as *const c_void,
+                    None => std::ptr::null(),
+                }
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = gpu;
+                std::ptr::null()
+            }
+        },
+        std::ptr::null(),
+    )
+}
+
+// -------------------------------------------------------------------------
 // PooledTextureHandle lifecycle — drop-only (v4)
 // -------------------------------------------------------------------------
 
@@ -6774,6 +6810,8 @@ pub static HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE: GpuContextLimitedAccessVTable
         clear_video_source_timeline_semaphore:
             host_gpu_lim_clear_video_source_timeline_semaphore,
         wait_timeline_semaphore: host_gpu_lim_wait_timeline_semaphore,
+        host_video_source_timeline_arc:
+            host_gpu_lim_host_video_source_timeline_arc,
     };
 
 /// Pointer to the [`GpuContextLimitedAccessVTable`] this DSO should
@@ -12995,6 +13033,26 @@ mod gpu_lim_video_source_timeline_semaphore_tests {
             (HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE
                 .clear_video_source_timeline_semaphore)(std::ptr::null());
         }
+    }
+
+    /// v14 slot (#1066): tier-1 wire-format guard. Null `gpu_handle`
+    /// must return null rather than dereferencing the pointer. The
+    /// non-null-handle "slot empty" → null and "slot populated" →
+    /// non-null Arc pointer paths are exercised end-to-end by the
+    /// camera-display cdylib reproducer; a tier-1 unit test for them
+    /// would need a real `GpuContext` instance, which this module
+    /// deliberately avoids constructing.
+    ///
+    /// Mental-revert: stub the wrapper to `unimplemented!()` and
+    /// this test trips the underlying panic — the null-guard
+    /// contract regresses.
+    #[test]
+    fn host_video_source_timeline_arc_returns_null_on_null_gpu_handle() {
+        let raw = unsafe {
+            (HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE
+                .host_video_source_timeline_arc)(std::ptr::null())
+        };
+        assert!(raw.is_null(), "expected null on null gpu_handle");
     }
 }
 

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -12105,24 +12105,18 @@ unsafe extern "C" fn host_command_recorder_record_swapchain_image_barrier(
                 );
                 return 1;
             };
-            use vulkanalia::vk::{self, Handle};
-            // SAFETY: caller passes a raw VkImage handle minted by the
-            // host-side swapchain creation; this widens it to the
-            // `Handle` type without dereferencing anything.
-            let image = vk::Image::from_raw(image_raw);
-            let old_layout = vk::ImageLayout::from_raw(from_layout_raw);
-            let new_layout = vk::ImageLayout::from_raw(to_layout_raw);
-            let src_stage =
-                vk::PipelineStageFlags2::from_bits_truncate(from_stage_raw as u64);
-            let src_access =
-                vk::AccessFlags2::from_bits_truncate(from_access_raw as u64);
-            let dst_stage =
-                vk::PipelineStageFlags2::from_bits_truncate(to_stage_raw as u64);
-            let dst_access =
-                vk::AccessFlags2::from_bits_truncate(to_access_raw as u64);
-            match recorder.record_swapchain_image_barrier(
-                image, old_layout, new_layout, src_stage, src_access, dst_stage,
-                dst_access,
+            // Dispatch into the RHI-side `from_wire` shim — all
+            // `vulkanalia` construction stays inside `vulkan/rhi/`
+            // (the check-boundaries rule keeps raw vulkanalia out of
+            // `core/plugin/`).
+            match recorder.record_swapchain_image_barrier_from_wire(
+                image_raw,
+                from_layout_raw,
+                to_layout_raw,
+                from_stage_raw,
+                to_stage_raw,
+                from_access_raw,
+                to_access_raw,
             ) {
                 Ok(()) => 0,
                 Err(e) => {
@@ -12194,16 +12188,18 @@ unsafe extern "C" fn host_command_recorder_cmd_begin_dynamic_rendering(
                 );
                 return 1;
             };
-            use vulkanalia::vk::{self, Handle};
-            let image_view = vk::ImageView::from_raw(image_view_raw);
             let clear = if has_clear_color != 0 {
                 Some([clear_r, clear_g, clear_b, clear_a])
             } else {
                 None
             };
-            match recorder.cmd_begin_dynamic_rendering(
-                image_view,
-                (extent_w, extent_h),
+            // Dispatch into the RHI-side `from_wire` shim — see the
+            // `record_swapchain_image_barrier` wrapper above for the
+            // check-boundaries rationale.
+            match recorder.cmd_begin_dynamic_rendering_from_wire(
+                image_view_raw,
+                extent_w,
+                extent_h,
                 clear,
             ) {
                 Ok(()) => 0,
@@ -12327,7 +12323,6 @@ unsafe extern "C" fn host_command_recorder_submit_with_semaphores(
                 );
                 return 1;
             };
-            use vulkanalia::vk::{self, Handle, HasBuilder};
             // SAFETY: caller-owned arrays. We only read; the buffers
             // outlive the call by the cdylib-side `Vec` they came from.
             let waits_repr: &[streamlib_plugin_abi::SemaphoreSubmitInfoRepr] =
@@ -12342,33 +12337,11 @@ unsafe extern "C" fn host_command_recorder_submit_with_semaphores(
                 } else {
                     unsafe { std::slice::from_raw_parts(signals_ptr, signals_count) }
                 };
-            let waits: Vec<vk::SemaphoreSubmitInfo> = waits_repr
-                .iter()
-                .map(|r| {
-                    vk::SemaphoreSubmitInfo::builder()
-                        .semaphore(vk::Semaphore::from_raw(r.semaphore))
-                        .value(r.value)
-                        .stage_mask(vk::PipelineStageFlags2::from_bits_truncate(
-                            r.stage_mask,
-                        ))
-                        .device_index(r.device_index)
-                        .build()
-                })
-                .collect();
-            let signals: Vec<vk::SemaphoreSubmitInfo> = signals_repr
-                .iter()
-                .map(|r| {
-                    vk::SemaphoreSubmitInfo::builder()
-                        .semaphore(vk::Semaphore::from_raw(r.semaphore))
-                        .value(r.value)
-                        .stage_mask(vk::PipelineStageFlags2::from_bits_truncate(
-                            r.stage_mask,
-                        ))
-                        .device_index(r.device_index)
-                        .build()
-                })
-                .collect();
-            match recorder.submit_with_semaphores(&waits, &signals) {
+            // Dispatch into the RHI-side `from_wire` shim — see the
+            // `record_swapchain_image_barrier` wrapper above for the
+            // check-boundaries rationale.
+            match recorder.submit_with_semaphores_from_wire(waits_repr, signals_repr)
+            {
                 Ok(()) => 0,
                 Err(e) => {
                     write_err(

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
@@ -11,7 +11,9 @@ use streamlib_plugin_abi::GpuContextFullAccessVTable;
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 
-use crate::core::rhi::{DrawCall, DrawIndexedCall, Texture, VulkanLayout};
+use crate::core::rhi::{
+    DrawCall, DrawIndexedCall, ScissorRect, Texture, Viewport, VulkanLayout,
+};
 use crate::core::{Error, Result};
 
 use super::{
@@ -663,6 +665,112 @@ impl RhiCommandRecorderInner {
         Ok(())
     }
 
+    /// Record a layout transition on a raw `VkImage` handle.
+    /// Distinct from [`Self::record_image_barrier`] which takes a
+    /// `Texture` β-shape; this variant is used by
+    /// [`VulkanPresentTarget`](super::vulkan_present_target::VulkanPresentTarget)
+    /// for swapchain images (which are never wrapped in a `Texture`).
+    /// COLOR aspect, single mip / single layer, QUEUE_FAMILY_IGNORED
+    /// on both sides.
+    pub(crate) fn record_swapchain_image_barrier(
+        &mut self,
+        image: vk::Image,
+        old_layout: vk::ImageLayout,
+        new_layout: vk::ImageLayout,
+        src_stage: vk::PipelineStageFlags2,
+        src_access: vk::AccessFlags2,
+        dst_stage: vk::PipelineStageFlags2,
+        dst_access: vk::AccessFlags2,
+    ) -> Result<()> {
+        self.expect_recording("record_swapchain_image_barrier")?;
+        let subresource = vk::ImageSubresourceRange::builder()
+            .aspect_mask(vk::ImageAspectFlags::COLOR)
+            .base_mip_level(0)
+            .level_count(1)
+            .base_array_layer(0)
+            .layer_count(1)
+            .build();
+        let barrier = vk::ImageMemoryBarrier2::builder()
+            .src_stage_mask(src_stage)
+            .src_access_mask(src_access)
+            .dst_stage_mask(dst_stage)
+            .dst_access_mask(dst_access)
+            .old_layout(old_layout)
+            .new_layout(new_layout)
+            .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+            .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+            .image(image)
+            .subresource_range(subresource)
+            .build();
+        let barriers = [barrier];
+        let dep = vk::DependencyInfo::builder()
+            .image_memory_barriers(&barriers)
+            .build();
+        unsafe {
+            self.device.cmd_pipeline_barrier2(self.command_buffer, &dep);
+        }
+        Ok(())
+    }
+
+    /// Begin a dynamic-rendering pass against a caller-owned
+    /// `VkImageView`. CLEAR load op when `clear_color` is `Some`,
+    /// LOAD otherwise. The image must already be in
+    /// `COLOR_ATTACHMENT_OPTIMAL` (transition via
+    /// [`Self::record_swapchain_image_barrier`] beforehand). Used
+    /// by [`PresentFrame::begin_rendering`](super::vulkan_present_target::PresentFrame::begin_rendering).
+    pub(crate) fn cmd_begin_dynamic_rendering(
+        &mut self,
+        image_view: vk::ImageView,
+        extent: (u32, u32),
+        clear_color: Option<[f32; 4]>,
+    ) -> Result<()> {
+        self.expect_recording("cmd_begin_dynamic_rendering")?;
+        let load_op = if clear_color.is_some() {
+            vk::AttachmentLoadOp::CLEAR
+        } else {
+            vk::AttachmentLoadOp::LOAD
+        };
+        let clear_value = vk::ClearValue {
+            color: vk::ClearColorValue {
+                float32: clear_color.unwrap_or([0.0, 0.0, 0.0, 1.0]),
+            },
+        };
+        let color_attachment = vk::RenderingAttachmentInfo::builder()
+            .image_view(image_view)
+            .image_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
+            .load_op(load_op)
+            .store_op(vk::AttachmentStoreOp::STORE)
+            .clear_value(clear_value)
+            .build();
+        let color_attachments = [color_attachment];
+        let rendering_info = vk::RenderingInfo::builder()
+            .render_area(vk::Rect2D {
+                offset: vk::Offset2D { x: 0, y: 0 },
+                extent: vk::Extent2D {
+                    width: extent.0,
+                    height: extent.1,
+                },
+            })
+            .layer_count(1)
+            .color_attachments(&color_attachments)
+            .build();
+        unsafe {
+            self.device
+                .cmd_begin_rendering(self.command_buffer, &rendering_info);
+        }
+        Ok(())
+    }
+
+    /// Close the dynamic-rendering pass opened by
+    /// [`Self::cmd_begin_dynamic_rendering`].
+    pub(crate) fn cmd_end_dynamic_rendering(&mut self) -> Result<()> {
+        self.expect_recording("cmd_end_dynamic_rendering")?;
+        unsafe {
+            self.device.cmd_end_rendering(self.command_buffer);
+        }
+        Ok(())
+    }
+
     fn expect_recording(&self, op: &'static str) -> Result<()> {
         let state = self.state.lock();
         if *state != RecorderState::Recording {
@@ -958,14 +1066,20 @@ impl RhiCommandRecorder {
             .record_dispatch(kernel, group_x, group_y, group_z)
     }
 
-    /// Draw call. Host-only until a cdylib consumer arrives;
-    /// cdylib callers panic at [`Self::host_inner_mut`].
+    /// Draw call.
+    ///
+    /// Mode-routed: host callers dispatch through `host_inner_mut`;
+    /// cdylib callers dispatch through the v3 `record_draw` slot on
+    /// [`RhiCommandRecorderMethodsVTable`](streamlib_plugin_abi::RhiCommandRecorderMethodsVTable).
     pub fn record_draw(
         &mut self,
         kernel: &VulkanGraphicsKernel,
         frame_index: u32,
         draw: &DrawCall,
     ) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_record_draw_via_vtable(kernel, frame_index, draw);
+        }
         self.host_inner_mut().record_draw(kernel, frame_index, draw)
     }
 
@@ -1306,13 +1420,334 @@ impl RhiCommandRecorder {
     }
 
     /// Engine-internal submit path supporting binary + timeline waits.
-    /// **Engine-only** — for `VulkanPresentTarget`'s render submit.
+    /// **Engine-internal** — for `VulkanPresentTarget`'s render submit.
+    ///
+    /// Mode-routed: host callers dispatch through `host_inner_mut`;
+    /// cdylib callers dispatch through the v3
+    /// `submit_with_semaphores` slot.
     pub(crate) fn submit_with_semaphores(
         &mut self,
         waits: &[vk::SemaphoreSubmitInfo],
         signals: &[vk::SemaphoreSubmitInfo],
     ) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_submit_with_semaphores_via_vtable(waits, signals);
+        }
         self.host_inner_mut().submit_with_semaphores(waits, signals)
+    }
+
+    /// Engine-internal swapchain-image layout transition.
+    /// **Engine-internal** — for `VulkanPresentTarget`'s pre/post-draw
+    /// barriers. Mode-routed: host callers dispatch through
+    /// `host_inner_mut`; cdylib callers dispatch through the v3
+    /// `record_swapchain_image_barrier` slot.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn record_swapchain_image_barrier(
+        &mut self,
+        image: vk::Image,
+        old_layout: vk::ImageLayout,
+        new_layout: vk::ImageLayout,
+        src_stage: vk::PipelineStageFlags2,
+        src_access: vk::AccessFlags2,
+        dst_stage: vk::PipelineStageFlags2,
+        dst_access: vk::AccessFlags2,
+    ) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_record_swapchain_image_barrier_via_vtable(
+                image,
+                old_layout,
+                new_layout,
+                src_stage,
+                src_access,
+                dst_stage,
+                dst_access,
+            );
+        }
+        self.host_inner_mut().record_swapchain_image_barrier(
+            image,
+            old_layout,
+            new_layout,
+            src_stage,
+            src_access,
+            dst_stage,
+            dst_access,
+        )
+    }
+
+    /// Engine-internal dynamic-rendering begin.
+    /// **Engine-internal** — for
+    /// [`PresentFrame::begin_rendering`](super::vulkan_present_target::PresentFrame::begin_rendering).
+    /// Mode-routed: host callers dispatch through `host_inner_mut`;
+    /// cdylib callers dispatch through the v3
+    /// `cmd_begin_dynamic_rendering` slot.
+    pub(crate) fn cmd_begin_dynamic_rendering(
+        &mut self,
+        image_view: vk::ImageView,
+        extent: (u32, u32),
+        clear_color: Option<[f32; 4]>,
+    ) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_cmd_begin_dynamic_rendering_via_vtable(
+                image_view,
+                extent,
+                clear_color,
+            );
+        }
+        self.host_inner_mut()
+            .cmd_begin_dynamic_rendering(image_view, extent, clear_color)
+    }
+
+    /// Engine-internal dynamic-rendering end.
+    /// **Engine-internal** — for
+    /// [`PresentFrame::end_rendering`](super::vulkan_present_target::PresentFrame::end_rendering).
+    /// Mode-routed: host callers dispatch through `host_inner_mut`;
+    /// cdylib callers dispatch through the v3
+    /// `cmd_end_dynamic_rendering` slot.
+    pub(crate) fn cmd_end_dynamic_rendering(&mut self) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_cmd_end_dynamic_rendering_via_vtable();
+        }
+        self.host_inner_mut().cmd_end_dynamic_rendering()
+    }
+
+    // -------------------------------------------------------------------------
+    // v3 dispatch helpers (#1066) — match the v1 / v2 helpers above.
+    // -------------------------------------------------------------------------
+
+    fn dispatch_record_draw_via_vtable(
+        &self,
+        kernel: &VulkanGraphicsKernel,
+        frame_index: u32,
+        draw: &DrawCall,
+    ) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "record_draw: command recorder methods vtable is null".into(),
+            ));
+        }
+        let (viewport_present, vp) = match draw.viewport {
+            Some(v) => (1u32, v),
+            None => (0u32, Viewport::full(0, 0)),
+        };
+        let (scissor_present, sc) = match draw.scissor {
+            Some(s) => (1u32, s),
+            None => (0u32, ScissorRect::full(0, 0)),
+        };
+        let draw_repr = streamlib_plugin_abi::DrawCallRepr {
+            vertex_count: draw.vertex_count,
+            instance_count: draw.instance_count,
+            first_vertex: draw.first_vertex,
+            first_instance: draw.first_instance,
+            viewport_present,
+            scissor_present,
+            viewport: streamlib_plugin_abi::ViewportRepr {
+                x: vp.x,
+                y: vp.y,
+                width: vp.width,
+                height: vp.height,
+                min_depth: vp.min_depth,
+                max_depth: vp.max_depth,
+            },
+            scissor: streamlib_plugin_abi::ScissorRectRepr {
+                x: sc.x,
+                y: sc.y,
+                width: sc.width,
+                height: sc.height,
+            },
+        };
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).record_draw)(
+                self.handle,
+                kernel.handle,
+                frame_index,
+                &draw_repr,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn dispatch_record_swapchain_image_barrier_via_vtable(
+        &self,
+        image: vk::Image,
+        old_layout: vk::ImageLayout,
+        new_layout: vk::ImageLayout,
+        src_stage: vk::PipelineStageFlags2,
+        src_access: vk::AccessFlags2,
+        dst_stage: vk::PipelineStageFlags2,
+        dst_access: vk::AccessFlags2,
+    ) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "record_swapchain_image_barrier: command recorder methods vtable is null"
+                    .into(),
+            ));
+        }
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).record_swapchain_image_barrier)(
+                self.handle,
+                image.as_raw(),
+                old_layout.as_raw(),
+                new_layout.as_raw(),
+                src_stage.bits() as i64,
+                src_access.bits() as i64,
+                dst_stage.bits() as i64,
+                dst_access.bits() as i64,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    fn dispatch_cmd_begin_dynamic_rendering_via_vtable(
+        &self,
+        image_view: vk::ImageView,
+        extent: (u32, u32),
+        clear_color: Option<[f32; 4]>,
+    ) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "cmd_begin_dynamic_rendering: command recorder methods vtable is null"
+                    .into(),
+            ));
+        }
+        let has_clear = if clear_color.is_some() { 1u32 } else { 0u32 };
+        let rgba = clear_color.unwrap_or([0.0; 4]);
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).cmd_begin_dynamic_rendering)(
+                self.handle,
+                image_view.as_raw(),
+                extent.0,
+                extent.1,
+                has_clear,
+                rgba[0],
+                rgba[1],
+                rgba[2],
+                rgba[3],
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    fn dispatch_cmd_end_dynamic_rendering_via_vtable(&self) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "cmd_end_dynamic_rendering: command recorder methods vtable is null"
+                    .into(),
+            ));
+        }
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).cmd_end_dynamic_rendering)(
+                self.handle,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    fn dispatch_submit_with_semaphores_via_vtable(
+        &self,
+        waits: &[vk::SemaphoreSubmitInfo],
+        signals: &[vk::SemaphoreSubmitInfo],
+    ) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "submit_with_semaphores: command recorder methods vtable is null"
+                    .into(),
+            ));
+        }
+        // Project the vk::SemaphoreSubmitInfo arrays into POD reprs.
+        let waits_repr: Vec<streamlib_plugin_abi::SemaphoreSubmitInfoRepr> = waits
+            .iter()
+            .map(|w| streamlib_plugin_abi::SemaphoreSubmitInfoRepr {
+                semaphore: w.semaphore.as_raw(),
+                value: w.value,
+                stage_mask: w.stage_mask.bits() as u64,
+                device_index: w.device_index,
+                _reserved_padding: 0,
+            })
+            .collect();
+        let signals_repr: Vec<streamlib_plugin_abi::SemaphoreSubmitInfoRepr> = signals
+            .iter()
+            .map(|s| streamlib_plugin_abi::SemaphoreSubmitInfoRepr {
+                semaphore: s.semaphore.as_raw(),
+                value: s.value,
+                stage_mask: s.stage_mask.bits() as u64,
+                device_index: s.device_index,
+                _reserved_padding: 0,
+            })
+            .collect();
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).submit_with_semaphores)(
+                self.handle,
+                if waits_repr.is_empty() {
+                    std::ptr::null()
+                } else {
+                    waits_repr.as_ptr()
+                },
+                waits_repr.len(),
+                if signals_repr.is_empty() {
+                    std::ptr::null()
+                } else {
+                    signals_repr.as_ptr()
+                },
+                signals_repr.len(),
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
     }
 }
 

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
@@ -754,6 +754,92 @@ impl RhiCommandRecorderInner {
         Ok(())
     }
 
+    // -------------------------------------------------------------------------
+    // From-wire shims used by host extern "C" callbacks in
+    // `core/plugin/host_services.rs`. The check-boundaries rule keeps
+    // raw `vulkanalia` imports inside the RHI / consumer-rhi / adapter
+    // crates; the host wrappers receive raw integer wire types and
+    // dispatch through these shims so all `vk::*` construction happens
+    // inside `vulkan/rhi/`.
+    // -------------------------------------------------------------------------
+
+    /// Wire-format companion to
+    /// [`Self::record_swapchain_image_barrier`].
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn record_swapchain_image_barrier_from_wire(
+        &mut self,
+        image_raw: u64,
+        from_layout_raw: i32,
+        to_layout_raw: i32,
+        from_stage_raw: i64,
+        to_stage_raw: i64,
+        from_access_raw: i64,
+        to_access_raw: i64,
+    ) -> Result<()> {
+        let image = vk::Image::from_raw(image_raw);
+        let old_layout = vk::ImageLayout::from_raw(from_layout_raw);
+        let new_layout = vk::ImageLayout::from_raw(to_layout_raw);
+        let src_stage =
+            vk::PipelineStageFlags2::from_bits_truncate(from_stage_raw as u64);
+        let src_access =
+            vk::AccessFlags2::from_bits_truncate(from_access_raw as u64);
+        let dst_stage =
+            vk::PipelineStageFlags2::from_bits_truncate(to_stage_raw as u64);
+        let dst_access =
+            vk::AccessFlags2::from_bits_truncate(to_access_raw as u64);
+        self.record_swapchain_image_barrier(
+            image, old_layout, new_layout, src_stage, src_access, dst_stage,
+            dst_access,
+        )
+    }
+
+    /// Wire-format companion to [`Self::cmd_begin_dynamic_rendering`].
+    pub(crate) fn cmd_begin_dynamic_rendering_from_wire(
+        &mut self,
+        image_view_raw: u64,
+        extent_w: u32,
+        extent_h: u32,
+        clear_color: Option<[f32; 4]>,
+    ) -> Result<()> {
+        let image_view = vk::ImageView::from_raw(image_view_raw);
+        self.cmd_begin_dynamic_rendering(image_view, (extent_w, extent_h), clear_color)
+    }
+
+    /// Wire-format companion to [`Self::submit_with_semaphores`].
+    pub(crate) fn submit_with_semaphores_from_wire(
+        &mut self,
+        waits_repr: &[streamlib_plugin_abi::SemaphoreSubmitInfoRepr],
+        signals_repr: &[streamlib_plugin_abi::SemaphoreSubmitInfoRepr],
+    ) -> Result<()> {
+        let waits: Vec<vk::SemaphoreSubmitInfo> = waits_repr
+            .iter()
+            .map(|r| {
+                vk::SemaphoreSubmitInfo::builder()
+                    .semaphore(vk::Semaphore::from_raw(r.semaphore))
+                    .value(r.value)
+                    .stage_mask(vk::PipelineStageFlags2::from_bits_truncate(
+                        r.stage_mask,
+                    ))
+                    .device_index(r.device_index)
+                    .build()
+            })
+            .collect();
+        let signals: Vec<vk::SemaphoreSubmitInfo> = signals_repr
+            .iter()
+            .map(|r| {
+                vk::SemaphoreSubmitInfo::builder()
+                    .semaphore(vk::Semaphore::from_raw(r.semaphore))
+                    .value(r.value)
+                    .stage_mask(vk::PipelineStageFlags2::from_bits_truncate(
+                        r.stage_mask,
+                    ))
+                    .device_index(r.device_index)
+                    .build()
+            })
+            .collect();
+        self.submit_with_semaphores(&waits, &signals)
+    }
+
     fn expect_recording(&self, op: &'static str) -> Result<()> {
         let state = self.state.lock();
         if *state != RecorderState::Recording {
@@ -1784,6 +1870,7 @@ impl RhiCommandRecorder {
             Err(Error::GpuError(msg))
         }
     }
+
 }
 
 impl Drop for RhiCommandRecorder {

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
@@ -478,23 +478,6 @@ impl RhiCommandRecorderInner {
         kernel.cmd_bind_and_draw_indexed(self.command_buffer, frame_index, draw)
     }
 
-    /// Engine-internal accessor for the underlying command buffer.
-    /// Used by [`VulkanPresentTarget`](super::vulkan_present_target::VulkanPresentTarget)
-    /// to record swapchain-image transitions + `cmd_begin/end_rendering`
-    /// alongside the user's recorded draws.
-    pub(crate) fn command_buffer_raw(&self) -> vk::CommandBuffer {
-        self.command_buffer
-    }
-
-    /// Engine-internal accessor for the underlying [`HostVulkanDevice`].
-    /// Used by [`VulkanPresentTarget`](super::vulkan_present_target::VulkanPresentTarget)'s
-    /// `PresentFrame::begin_rendering` / `end_rendering` to issue
-    /// `cmd_begin_rendering` / `cmd_end_rendering` on the same command
-    /// buffer this recorder owns.
-    pub(crate) fn vulkan_device_ref(&self) -> &Arc<HostVulkanDevice> {
-        &self.vulkan_device
-    }
-
     /// Engine-internal submit path supporting binary + timeline waits
     /// and signals, used by [`VulkanPresentTarget`](super::vulkan_present_target::VulkanPresentTarget)
     /// for the swapchain image-available wait → render-finished binary
@@ -843,17 +826,17 @@ impl std::fmt::Debug for RhiCommandRecorderInner {
 ///   (the parent vtable).
 /// - The six camera-hot-path methods (`begin`, `record_image_barrier`,
 ///   `record_buffer_barrier`, `record_dispatch`,
-///   `record_copy_image_to_buffer`, `submit_signaling_timeline`)
-///   route through the per-type
+///   `record_copy_image_to_buffer`, `submit_signaling_timeline`,
+///   `record_swapchain_image_barrier`,
+///   `cmd_begin_dynamic_rendering`, `cmd_end_dynamic_rendering`,
+///   `submit_with_semaphores`, `record_draw`) route through the
+///   per-type
 ///   [`streamlib_plugin_abi::RhiCommandRecorderMethodsVTable`] when
-///   called from cdylib code (Phase E sub-lift slice B — #984).
-/// - The remaining host-only methods (`record_draw`,
-///   `record_draw_indexed`, `record_copy_buffer_to_image`, `submit`,
-///   `submit_and_wait`, the engine-internal `submit_with_semaphores`
-///   / `command_buffer_raw` / `vulkan_device_ref` accessors) keep
-///   their cdylib-mode panic via [`Self::host_inner_mut`] /
-///   [`Self::host_inner`]; a follow-up slice lifts each as a
-///   consumer arrives.
+///   called from cdylib code.
+/// - The remaining host-only methods (`record_draw_indexed`,
+///   `record_copy_buffer_to_image`, `submit`, `submit_and_wait`)
+///   keep their cdylib-mode panic via [`Self::host_inner_mut`]; a
+///   follow-up slice lifts each as a consumer arrives.
 #[repr(C)]
 pub struct RhiCommandRecorder {
     /// Opaque handle to the host's `Box<RhiCommandRecorderInner>`.
@@ -909,19 +892,6 @@ impl RhiCommandRecorder {
         // SAFETY: `self.handle` is `Box::into_raw(Box<RhiCommandRecorderInner>)`
         // and `&mut self` guarantees no other reference exists.
         unsafe { &mut *(self.handle as *mut RhiCommandRecorderInner) }
-    }
-
-    /// Engine-internal shared borrow of the host-owned
-    /// `RhiCommandRecorderInner`. **Panics if called from cdylib code.**
-    pub(crate) fn host_inner(&self) -> &RhiCommandRecorderInner {
-        if crate::core::plugin::host_services::host_callbacks().is_some() {
-            panic!(
-                "RhiCommandRecorder::host_inner() reached from cdylib code; \
-                 this method must dispatch through the GpuContextFullAccessVTable."
-            );
-        }
-        // SAFETY: `self.handle` is `Box::into_raw(Box<RhiCommandRecorderInner>)`.
-        unsafe { &*(self.handle as *const RhiCommandRecorderInner) }
     }
 
     // -------------------------------------------------------------------------
@@ -1405,18 +1375,6 @@ impl RhiCommandRecorder {
     /// Submit and block until the GPU completes.
     pub fn submit_and_wait(&mut self) -> Result<()> {
         self.host_inner_mut().submit_and_wait()
-    }
-
-    /// Engine-internal accessor for the underlying command buffer.
-    /// **Engine-only** — for `VulkanPresentTarget`.
-    pub(crate) fn command_buffer_raw(&self) -> vk::CommandBuffer {
-        self.host_inner().command_buffer_raw()
-    }
-
-    /// Engine-internal accessor for the recorder's `HostVulkanDevice`.
-    /// **Engine-only** — for `VulkanPresentTarget::begin_rendering` etc.
-    pub(crate) fn vulkan_device_ref(&self) -> &Arc<HostVulkanDevice> {
-        self.host_inner().vulkan_device_ref()
     }
 
     /// Engine-internal submit path supporting binary + timeline waits.

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
@@ -829,14 +829,14 @@ impl std::fmt::Debug for RhiCommandRecorderInner {
 ///   `record_copy_image_to_buffer`, `submit_signaling_timeline`,
 ///   `record_swapchain_image_barrier`,
 ///   `cmd_begin_dynamic_rendering`, `cmd_end_dynamic_rendering`,
-///   `submit_with_semaphores`, `record_draw`) route through the
-///   per-type
+///   `submit_with_semaphores`, `record_draw`, `record_draw_indexed`)
+///   route through the per-type
 ///   [`streamlib_plugin_abi::RhiCommandRecorderMethodsVTable`] when
 ///   called from cdylib code.
-/// - The remaining host-only methods (`record_draw_indexed`,
-///   `record_copy_buffer_to_image`, `submit`, `submit_and_wait`)
-///   keep their cdylib-mode panic via [`Self::host_inner_mut`]; a
-///   follow-up slice lifts each as a consumer arrives.
+/// - The remaining host-only methods (`record_copy_buffer_to_image`,
+///   `submit`, `submit_and_wait`) keep their cdylib-mode panic via
+///   [`Self::host_inner_mut`]; a follow-up slice lifts each as a
+///   consumer arrives.
 #[repr(C)]
 pub struct RhiCommandRecorder {
     /// Opaque handle to the host's `Box<RhiCommandRecorderInner>`.
@@ -1053,14 +1053,25 @@ impl RhiCommandRecorder {
         self.host_inner_mut().record_draw(kernel, frame_index, draw)
     }
 
-    /// Indexed-draw variant. Host-only until a cdylib consumer
-    /// arrives; cdylib callers panic at [`Self::host_inner_mut`].
+    /// Indexed-draw variant.
+    ///
+    /// Mode-routed: host callers dispatch through `host_inner_mut`;
+    /// cdylib callers dispatch through the v4 `record_draw_indexed`
+    /// slot on
+    /// [`RhiCommandRecorderMethodsVTable`](streamlib_plugin_abi::RhiCommandRecorderMethodsVTable).
     pub fn record_draw_indexed(
         &mut self,
         kernel: &VulkanGraphicsKernel,
         frame_index: u32,
         draw: &DrawIndexedCall,
     ) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_record_draw_indexed_via_vtable(
+                kernel,
+                frame_index,
+                draw,
+            );
+        }
         self.host_inner_mut()
             .record_draw_indexed(kernel, frame_index, draw)
     }
@@ -1517,6 +1528,72 @@ impl RhiCommandRecorder {
         let mut err_len: usize = 0;
         let status = unsafe {
             ((*self.methods_vtable).record_draw)(
+                self.handle,
+                kernel.handle,
+                frame_index,
+                &draw_repr,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    fn dispatch_record_draw_indexed_via_vtable(
+        &self,
+        kernel: &VulkanGraphicsKernel,
+        frame_index: u32,
+        draw: &DrawIndexedCall,
+    ) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "record_draw_indexed: command recorder methods vtable is null"
+                    .into(),
+            ));
+        }
+        let (viewport_present, vp) = match draw.viewport {
+            Some(v) => (1u32, v),
+            None => (0u32, Viewport::full(0, 0)),
+        };
+        let (scissor_present, sc) = match draw.scissor {
+            Some(s) => (1u32, s),
+            None => (0u32, ScissorRect::full(0, 0)),
+        };
+        let draw_repr = streamlib_plugin_abi::DrawIndexedCallRepr {
+            index_count: draw.index_count,
+            instance_count: draw.instance_count,
+            first_index: draw.first_index,
+            vertex_offset: draw.vertex_offset,
+            first_instance: draw.first_instance,
+            viewport_present,
+            scissor_present,
+            _reserved_padding: 0,
+            viewport: streamlib_plugin_abi::ViewportRepr {
+                x: vp.x,
+                y: vp.y,
+                width: vp.width,
+                height: vp.height,
+                min_depth: vp.min_depth,
+                max_depth: vp.max_depth,
+            },
+            scissor: streamlib_plugin_abi::ScissorRectRepr {
+                x: sc.x,
+                y: sc.y,
+                width: sc.width,
+                height: sc.height,
+            },
+        };
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).record_draw_indexed)(
                 self.handle,
                 kernel.handle,
                 frame_index,

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_present_target.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_present_target.rs
@@ -465,9 +465,7 @@ impl VulkanPresentTarget {
         // Pre-draw barrier: swapchain image UNDEFINED → COLOR_ATTACHMENT_OPTIMAL.
         // UNDEFINED is valid on every reuse because the render pass uses
         // CLEAR load op (set by `PresentFrame::begin_rendering`).
-        record_swapchain_barrier(
-            recorder.command_buffer_raw(),
-            raw_device,
+        recorder.record_swapchain_image_barrier(
             swapchain_image,
             vk::ImageLayout::UNDEFINED,
             vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
@@ -475,7 +473,7 @@ impl VulkanPresentTarget {
             vk::AccessFlags2::NONE,
             vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
             vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
-        );
+        )?;
 
         let extra_waits: Vec<vk::SemaphoreSubmitInfo> = Vec::new();
         let mut frame = PresentFrame {
@@ -495,9 +493,7 @@ impl VulkanPresentTarget {
 
         // If the user opened a render pass and didn't close it, close it now.
         if frame.inner.in_render_pass {
-            unsafe {
-                raw_device.cmd_end_rendering(frame.recorder.command_buffer_raw());
-            }
+            frame.recorder.cmd_end_dynamic_rendering()?;
             frame.inner.in_render_pass = false;
         }
 
@@ -521,9 +517,7 @@ impl VulkanPresentTarget {
         // consistent state.
         //
         // Post-draw barrier: swapchain image COLOR_ATTACHMENT_OPTIMAL → PRESENT_SRC_KHR.
-        record_swapchain_barrier(
-            frame.recorder.command_buffer_raw(),
-            raw_device,
+        frame.recorder.record_swapchain_image_barrier(
             swapchain_image,
             vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
             vk::ImageLayout::PRESENT_SRC_KHR,
@@ -531,7 +525,7 @@ impl VulkanPresentTarget {
             vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
             vk::PipelineStageFlags2::NONE,
             vk::AccessFlags2::NONE,
-        );
+        )?;
 
         // Submit: wait on image_available (binary, COLOR_ATTACHMENT_OUTPUT)
         // + any caller-added timeline waits; signal render_finished (binary,
@@ -623,42 +617,11 @@ impl<'a> PresentFrame<'a> {
                 "PresentFrame::begin_rendering: render pass already active".into(),
             ));
         }
-        let device = self.recorder.command_buffer_raw();
-        let load_op = if clear_color.is_some() {
-            vk::AttachmentLoadOp::CLEAR
-        } else {
-            vk::AttachmentLoadOp::LOAD
-        };
-        let clear_value = vk::ClearValue {
-            color: vk::ClearColorValue {
-                float32: clear_color.unwrap_or([0.0, 0.0, 0.0, 1.0]),
-            },
-        };
-        let color_attachment = vk::RenderingAttachmentInfo::builder()
-            .image_view(self.inner.image_view)
-            .image_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-            .load_op(load_op)
-            .store_op(vk::AttachmentStoreOp::STORE)
-            .clear_value(clear_value)
-            .build();
-        let color_attachments = [color_attachment];
-        let rendering_info = vk::RenderingInfo::builder()
-            .render_area(vk::Rect2D {
-                offset: vk::Offset2D { x: 0, y: 0 },
-                extent: vk::Extent2D {
-                    width: self.extent.0,
-                    height: self.extent.1,
-                },
-            })
-            .layer_count(1)
-            .color_attachments(&color_attachments)
-            .build();
-        unsafe {
-            // Reach the device handle via the recorder's already-borrowed
-            // command buffer.
-            let raw_device = recorder_device(self.recorder);
-            raw_device.cmd_begin_rendering(device, &rendering_info);
-        }
+        self.recorder.cmd_begin_dynamic_rendering(
+            self.inner.image_view,
+            self.extent,
+            clear_color,
+        )?;
         self.inner.in_render_pass = true;
         Ok(())
     }
@@ -670,11 +633,7 @@ impl<'a> PresentFrame<'a> {
                 "PresentFrame::end_rendering: no active render pass".into(),
             ));
         }
-        let cmd = self.recorder.command_buffer_raw();
-        let raw_device = recorder_device(self.recorder);
-        unsafe {
-            raw_device.cmd_end_rendering(cmd);
-        }
+        self.recorder.cmd_end_dynamic_rendering()?;
         self.inner.in_render_pass = false;
         Ok(())
     }
@@ -887,55 +846,6 @@ fn create_swapchain(
     ))
 }
 
-#[allow(clippy::too_many_arguments)]
-fn record_swapchain_barrier(
-    command_buffer: vk::CommandBuffer,
-    device: &vulkanalia::Device,
-    image: vk::Image,
-    old_layout: vk::ImageLayout,
-    new_layout: vk::ImageLayout,
-    src_stage: vk::PipelineStageFlags2,
-    src_access: vk::AccessFlags2,
-    dst_stage: vk::PipelineStageFlags2,
-    dst_access: vk::AccessFlags2,
-) {
-    let subresource = vk::ImageSubresourceRange::builder()
-        .aspect_mask(vk::ImageAspectFlags::COLOR)
-        .base_mip_level(0)
-        .level_count(1)
-        .base_array_layer(0)
-        .layer_count(1)
-        .build();
-    let barrier = vk::ImageMemoryBarrier2::builder()
-        .src_stage_mask(src_stage)
-        .src_access_mask(src_access)
-        .dst_stage_mask(dst_stage)
-        .dst_access_mask(dst_access)
-        .old_layout(old_layout)
-        .new_layout(new_layout)
-        .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
-        .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
-        .image(image)
-        .subresource_range(subresource)
-        .build();
-    let barriers = [barrier];
-    let dep = vk::DependencyInfo::builder()
-        .image_memory_barriers(&barriers)
-        .build();
-    unsafe {
-        device.cmd_pipeline_barrier2(command_buffer, &dep);
-    }
-}
-
-/// Engine-internal helper to access the recorder's underlying `vulkanalia::Device`
-/// for `cmd_begin_rendering` / `cmd_end_rendering` from inside `PresentFrame`.
-/// The recorder owns an `Arc<HostVulkanDevice>` and exposes the raw command
-/// buffer via [`RhiCommandRecorder::command_buffer_raw`]; this helper reaches
-/// the device handle via a one-line accessor on the recorder rather than
-/// duplicating an `Arc<HostVulkanDevice>` field on `PresentFrame`.
-fn recorder_device(recorder: &RhiCommandRecorder) -> &vulkanalia::Device {
-    recorder.vulkan_device_ref().device()
-}
 
 /// Strip surface formats the engine's [`vk_format_to_texture_format`]
 /// table can't project to [`TextureFormat`]. Called by

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -3686,12 +3686,14 @@ unsafe impl Sync for RhiColorConverterMethodsVTable {}
 /// Without these the β-shape's `host_inner_mut()` / `host_inner()`
 /// panic-guards fire from cdylib code on every per-frame call.
 ///
-/// The remaining `RhiCommandRecorder` methods (`record_draw`,
-/// `record_draw_indexed`, `record_copy_buffer_to_image`, `submit`,
-/// `submit_and_wait`, `submit_with_semaphores`, `command_buffer_raw`,
-/// `vulkan_device_ref`) keep their cdylib-mode panic in place — they
-/// don't sit on the camera hot path and a follow-up slice lifts
-/// them when a consumer arrives.
+/// v3 (#1066) appends `record_swapchain_image_barrier`,
+/// `cmd_begin_dynamic_rendering`, `cmd_end_dynamic_rendering`,
+/// `submit_with_semaphores`, and `record_draw` for cdylib display
+/// processors. The remaining `RhiCommandRecorder` methods
+/// (`record_draw_indexed`, `record_copy_buffer_to_image`, `submit`,
+/// `submit_and_wait`) keep their cdylib-mode panic in place — they
+/// don't sit on any cdylib hot path today and a follow-up slice
+/// lifts them when a consumer arrives.
 ///
 /// **Buffer-flavor coverage today:** the v1 `record_buffer_barrier`
 /// and `record_copy_image_to_buffer` slots accept a

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -250,7 +250,22 @@ pub const SURFACE_STORE_VTABLE_LAYOUT_VERSION: u32 = 1;
 ///   (borrowed, same shape as `set_video_source_timeline_semaphore`).
 ///   Returns 0 on success, non-zero (`err_buf` populated) on driver
 ///   failure / timeout. Linux-only on the host side.
-pub const GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 13;
+/// - v14: #1066 — adds `host_video_source_timeline_arc` slot. The
+///   read-side counterpart of v12's `set_/clear_` pair: cdylib
+///   consumers (the in-tree consumer is `LinuxDisplayProcessor`'s
+///   render loop) clone the host's published
+///   `Arc<HostVulkanTimelineSemaphore>` across the FFI to GPU-wait
+///   on the producer's writeback timeline. Mirrors the v9
+///   `host_vulkan_device_arc` FullAccess pattern: the host callback
+///   `Arc::into_raw`s a fresh clone (or returns null when no
+///   producer has published a timeline); the cdylib reconstitutes
+///   via `Arc::from_raw`. Same rustc-version + dep-graph coupling
+///   caveat as `set_video_source_timeline_semaphore` (in-tree
+///   workspace plugins share the contract;
+///   `HostVulkanTimelineSemaphore` is not `#[repr(C)]`). Linux-only
+///   on the host side; non-Linux stub returns null. Null
+///   `gpu_handle` returns null.
+pub const GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 14;
 
 /// Layout version of [`GpuContextFullAccessVTable`].
 ///
@@ -1871,6 +1886,45 @@ pub struct GpuContextLimitedAccessVTable {
         err_buf_cap: usize,
         err_len: *mut usize,
     ) -> i32,
+
+    // -------------------------------------------------------------------------
+    // host_video_source_timeline_arc (v14 — #1066)
+    // -------------------------------------------------------------------------
+
+    /// Clone the host's `Arc<HostVulkanTimelineSemaphore>` that was
+    /// most recently published via
+    /// [`Self::set_video_source_timeline_semaphore`], so a cdylib
+    /// consumer can GPU-wait on it without reaching engine-internal
+    /// state. The in-tree consumer is `LinuxDisplayProcessor`'s
+    /// render loop (waits on the camera's published timeline before
+    /// binding the captured texture).
+    ///
+    /// Mirrors the v9 `host_vulkan_device_arc` FullAccess shape:
+    /// host callback `Arc::into_raw`s a fresh clone of the
+    /// `Arc<HostVulkanTimelineSemaphore>` from the slot; cdylib
+    /// reconstitutes via `Arc::from_raw`. The fresh strong count
+    /// moves into the cdylib's Arc; the host's slot keeps its own
+    /// independent strong count.
+    ///
+    /// Returns `*const c_void` carrying the leaked Arc pointer (a
+    /// `*const HostVulkanTimelineSemaphore` widened to the FFI
+    /// type), or null when no producer has published a timeline
+    /// yet, when the slot was cleared via
+    /// [`Self::clear_video_source_timeline_semaphore`], when
+    /// `gpu_handle` is null, or on non-Linux hosts.
+    ///
+    /// **Arc-raw-pointer transit** — same rustc-version coupling
+    /// caveat as `set_video_source_timeline_semaphore`.
+    /// `HostVulkanTimelineSemaphore` is not `#[repr(C)]`; in-tree
+    /// workspace plugin cdylibs share the host's rustc + dep graph
+    /// and ride this freely. Cross-repo plugin distribution awaits
+    /// a β-shape lift of `HostVulkanTimelineSemaphore` (the same
+    /// dormant work the v12 set/clear pair flagged).
+    ///
+    /// Linux-only on the host side; non-Linux stubs return null.
+    pub host_video_source_timeline_arc: unsafe extern "C" fn(
+        gpu_handle: *const c_void,
+    ) -> *const c_void,
 }
 
 unsafe impl Send for GpuContextLimitedAccessVTable {}
@@ -5129,7 +5183,7 @@ mod layout_tests {
         // v2: added owning-Arc handle lifetime callbacks
         // (`clone_handle` / `drop_handle`).
         assert_eq!(RUNTIME_OPS_VTABLE_LAYOUT_VERSION, 2);
-        assert_eq!(GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION, 13);
+        assert_eq!(GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION, 14);
         assert_eq!(SURFACE_STORE_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 10);
         assert_eq!(TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION, 2);
@@ -5724,9 +5778,9 @@ mod layout_tests {
 
     #[test]
     fn gpu_context_limited_access_vtable_layout() {
-        // layout_version (u32) + _reserved_padding (u32) + 56 fn
-        // pointers (8 bytes each) = 4 + 4 + 448 = 456 bytes, align = 8.
-        assert_eq!(size_of::<GpuContextLimitedAccessVTable>(), 456);
+        // layout_version (u32) + _reserved_padding (u32) + 57 fn
+        // pointers (8 bytes each) = 4 + 4 + 456 = 464 bytes, align = 8.
+        assert_eq!(size_of::<GpuContextLimitedAccessVTable>(), 464);
         assert_eq!(align_of::<GpuContextLimitedAccessVTable>(), 8);
         assert_eq!(offset_of!(GpuContextLimitedAccessVTable, layout_version), 0);
         assert_eq!(
@@ -5966,6 +6020,14 @@ mod layout_tests {
         assert_eq!(
             offset_of!(GpuContextLimitedAccessVTable, wait_timeline_semaphore),
             448
+        );
+        // v14 entry (#1066).
+        assert_eq!(
+            offset_of!(
+                GpuContextLimitedAccessVTable,
+                host_video_source_timeline_arc
+            ),
+            456
         );
     }
 

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -489,7 +489,26 @@ pub const RHI_COLOR_CONVERTER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 2;
 ///   `VulkanGraphicsKernelMethodsVTable`'s
 ///   `set_storage_buffer_pixel` / `set_storage_buffer_storage`
 ///   pair.
-pub const RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 2;
+/// - v3: #1066 — appends five slots needed for cdylib display
+///   processors to drive the swapchain render path through the
+///   recorder rather than reaching for `command_buffer_raw()` /
+///   `vulkan_device_ref()` / `host_inner_mut()` directly:
+///   `record_swapchain_image_barrier` (raw `VkImage` layout
+///   transitions on swapchain images — distinct from the v1
+///   `record_image_barrier` which takes a `Texture` β-shape),
+///   `cmd_begin_dynamic_rendering` and `cmd_end_dynamic_rendering`
+///   (dynamic-rendering pass bracketing against a caller-owned
+///   `VkImageView` — no `VkRenderPass` / `VkFramebuffer` needed),
+///   `submit_with_semaphores` (general queue submit with
+///   variable-length wait/signal semaphore lists — sibling of v1
+///   `submit_signaling_timeline` but accepts arbitrary
+///   wait/signal sets), and `record_draw` (sibling of v1
+///   `record_dispatch` but binds a `VulkanGraphicsKernel`'s
+///   graphics pipeline + records `vkCmdDraw`). These slots all
+///   take raw `VkImage` / `VkImageView` / `VkSemaphore` handles as
+///   `u64` integers; the host materializes the typed `vk::*`
+///   wrappers internally.
+pub const RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 3;
 
 /// Layout version of [`OutputWriterVTable`].
 ///
@@ -3482,6 +3501,35 @@ pub struct ImageCopyRegionRepr {
     pub _reserved_padding: u32,
 }
 
+/// `#[repr(C)]` mirror of [`vk::SemaphoreSubmitInfo`]'s
+/// engine-relevant fields, for the v3 `submit_with_semaphores`
+/// vtable slot. Layout-locked by the regression test in
+/// `layout_tests`.
+///
+/// The host re-materializes a `vk::SemaphoreSubmitInfo` from these
+/// fields on the host side at the call site; the ABI doesn't pull
+/// `vulkanalia-sys` into its dep graph.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SemaphoreSubmitInfoRepr {
+    /// Raw `VkSemaphore` handle (widened to `u64`). Binary or
+    /// timeline; the host doesn't need to know which here — the
+    /// `value` field is `0` for binary semaphores by convention.
+    pub semaphore: u64,
+    /// Wait/signal value for timeline semaphores; `0` for binary
+    /// semaphores.
+    pub value: u64,
+    /// `VkPipelineStageFlags2` bitmask (Vulkan 1.3 / synchronization2).
+    pub stage_mask: u64,
+    /// Device index for multi-device submits; `0` for single-device
+    /// (the only case streamlib supports today).
+    pub device_index: u32,
+    /// Reserved padding so the struct stays 8-byte-aligned and the
+    /// trailing bytes are deterministic; zero today, never read.
+    pub _reserved_padding: u32,
+}
+
+
 /// `#[repr(C)]` mirror of `streamlib::core::color::ResolvedColorInfo`.
 ///
 /// Each field is the matching engine-side `#[repr(u32)]` enum's
@@ -3822,6 +3870,116 @@ pub struct RhiCommandRecorderMethodsVTable {
         src_layout_raw: i32,
         dst_pixel_buffer_handle: *const c_void,
         region: *const ImageCopyRegionRepr,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    // -------------------------------------------------------------------------
+    // v3 entries (#1066) — swapchain render-path slots.
+    // -------------------------------------------------------------------------
+
+    /// Record a layout transition on a raw `VkImage` handle —
+    /// distinct from v1 [`Self::record_image_barrier`] which takes
+    /// a `Texture` β-shape. Used by `VulkanPresentTarget` to
+    /// transition swapchain images (UNDEFINED →
+    /// COLOR_ATTACHMENT_OPTIMAL and COLOR_ATTACHMENT_OPTIMAL →
+    /// PRESENT_SRC_KHR) between cdylib-driven render-frame
+    /// iterations. The image is COLOR-aspect, single mip, single
+    /// array layer, QUEUE_FAMILY_IGNORED on both sides.
+    ///
+    /// - `image_raw` is the raw `VkImage` handle (`u64`).
+    /// - Layout / stage / access enumerants follow v1
+    ///   `record_image_barrier`'s integer-typed wire format.
+    pub record_swapchain_image_barrier: unsafe extern "C" fn(
+        recorder_handle: *const c_void,
+        image_raw: u64,
+        from_layout_raw: i32,
+        to_layout_raw: i32,
+        from_stage_raw: i64,
+        to_stage_raw: i64,
+        from_access_raw: i64,
+        to_access_raw: i64,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Begin a dynamic-rendering pass against a caller-owned
+    /// `VkImageView`. Used by `VulkanPresentTarget::PresentFrame`
+    /// to open the swapchain-image render pass. CLEAR load op is
+    /// selected by `has_clear_color = 1`; LOAD by
+    /// `has_clear_color = 0`.
+    ///
+    /// - `image_view_raw` is the raw `VkImageView` handle (`u64`).
+    /// - `extent_w` / `extent_h` are the render-area extents in
+    ///   pixels.
+    /// - `clear_rgba` is the CLEAR color (ignored when
+    ///   `has_clear_color == 0`).
+    pub cmd_begin_dynamic_rendering: unsafe extern "C" fn(
+        recorder_handle: *const c_void,
+        image_view_raw: u64,
+        extent_w: u32,
+        extent_h: u32,
+        has_clear_color: u32,
+        clear_r: f32,
+        clear_g: f32,
+        clear_b: f32,
+        clear_a: f32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Close the dynamic-rendering pass opened by
+    /// [`Self::cmd_begin_dynamic_rendering`].
+    pub cmd_end_dynamic_rendering: unsafe extern "C" fn(
+        recorder_handle: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// End recording and submit with arbitrary wait + signal
+    /// semaphore lists. Sibling of v1
+    /// [`Self::submit_signaling_timeline`] — that slot only
+    /// covered the single-timeline-signal case the camera
+    /// processor needed; this one covers the general case
+    /// `VulkanPresentTarget::render_frame` uses (wait on
+    /// image-available binary + caller-added timeline waits;
+    /// signal render-finished binary + frame-timeline).
+    ///
+    /// - `waits_ptr` / `waits_count` and `signals_ptr` /
+    ///   `signals_count` describe two arrays of
+    ///   [`SemaphoreSubmitInfoRepr`]. Empty arrays are valid
+    ///   (`*_ptr` may be null when `*_count == 0`).
+    pub submit_with_semaphores: unsafe extern "C" fn(
+        recorder_handle: *const c_void,
+        waits_ptr: *const SemaphoreSubmitInfoRepr,
+        waits_count: usize,
+        signals_ptr: *const SemaphoreSubmitInfoRepr,
+        signals_count: usize,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Record a non-indexed draw via
+    /// `VulkanGraphicsKernel::cmd_bind_and_draw`. Sibling of v1
+    /// [`Self::record_dispatch`] (compute) for graphics pipelines.
+    /// Bindings + push constants for `frame_index` must have been
+    /// staged via the kernel's `set_*` methods before this call.
+    ///
+    /// - `kernel_handle` is the
+    ///   `Arc::into_raw(Arc<VulkanGraphicsKernelInner>)` pointer
+    ///   from the kernel β-shape's `handle` field (borrowed).
+    /// - `draw` points at a [`DrawCallRepr`] the host reads once
+    ///   at call time.
+    pub record_draw: unsafe extern "C" fn(
+        recorder_handle: *const c_void,
+        kernel_handle: *const c_void,
+        frame_index: u32,
+        draw: *const DrawCallRepr,
         err_buf: *mut u8,
         err_buf_cap: usize,
         err_len: *mut usize,
@@ -5196,7 +5354,7 @@ mod layout_tests {
         // (`record_pixel_buffer_barrier`,
         // `record_copy_image_to_pixel_buffer`) for cdylib camera
         // per-frame copy into pooled `PixelBuffer` destinations.
-        assert_eq!(RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION, 2);
+        assert_eq!(RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION, 3);
         // v1 (issue #894): initial shape — `write_raw`, `has_port`,
         // `clone_arc`, `drop_arc`.
         assert_eq!(OUTPUT_WRITER_VTABLE_LAYOUT_VERSION, 1);
@@ -5720,7 +5878,9 @@ mod layout_tests {
         //   record_pixel_buffer_barrier          @ 56  (8 bytes, fn pointer, v2)
         //   record_copy_image_to_pixel_buffer    @ 64  (8 bytes, fn pointer, v2)
         // Total = 72 bytes, align = 8.
-        assert_eq!(size_of::<RhiCommandRecorderMethodsVTable>(), 72);
+        // layout_version (u32) + _reserved_padding (u32) + 13 fn
+        // pointers (8 bytes each) = 4 + 4 + 104 = 112 bytes, align = 8.
+        assert_eq!(size_of::<RhiCommandRecorderMethodsVTable>(), 112);
         assert_eq!(align_of::<RhiCommandRecorderMethodsVTable>(), 8);
         assert_eq!(
             offset_of!(RhiCommandRecorderMethodsVTable, layout_version),
@@ -5773,6 +5933,52 @@ mod layout_tests {
                 record_copy_image_to_pixel_buffer
             ),
             64
+        );
+        // v3 entries (#1066).
+        assert_eq!(
+            offset_of!(
+                RhiCommandRecorderMethodsVTable,
+                record_swapchain_image_barrier
+            ),
+            72
+        );
+        assert_eq!(
+            offset_of!(
+                RhiCommandRecorderMethodsVTable,
+                cmd_begin_dynamic_rendering
+            ),
+            80
+        );
+        assert_eq!(
+            offset_of!(
+                RhiCommandRecorderMethodsVTable,
+                cmd_end_dynamic_rendering
+            ),
+            88
+        );
+        assert_eq!(
+            offset_of!(RhiCommandRecorderMethodsVTable, submit_with_semaphores),
+            96
+        );
+        assert_eq!(
+            offset_of!(RhiCommandRecorderMethodsVTable, record_draw),
+            104
+        );
+    }
+
+    #[test]
+    fn semaphore_submit_info_repr_layout() {
+        // semaphore (u64, 8) + value (u64, 8) + stage_mask (u64, 8)
+        // + device_index (u32, 4) + _reserved_padding (u32, 4) = 32
+        assert_eq!(size_of::<SemaphoreSubmitInfoRepr>(), 32);
+        assert_eq!(align_of::<SemaphoreSubmitInfoRepr>(), 8);
+        assert_eq!(offset_of!(SemaphoreSubmitInfoRepr, semaphore), 0);
+        assert_eq!(offset_of!(SemaphoreSubmitInfoRepr, value), 8);
+        assert_eq!(offset_of!(SemaphoreSubmitInfoRepr, stage_mask), 16);
+        assert_eq!(offset_of!(SemaphoreSubmitInfoRepr, device_index), 24);
+        assert_eq!(
+            offset_of!(SemaphoreSubmitInfoRepr, _reserved_padding),
+            28
         );
     }
 

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -508,7 +508,14 @@ pub const RHI_COLOR_CONVERTER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 2;
 ///   take raw `VkImage` / `VkImageView` / `VkSemaphore` handles as
 ///   `u64` integers; the host materializes the typed `vk::*`
 ///   wrappers internally.
-pub const RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 3;
+/// - v4: #1066 — appends `record_draw_indexed` (sibling of v3
+///   `record_draw` for `vkCmdDrawIndexed`). Added eagerly alongside
+///   `record_draw` rather than waiting for a consumer because the
+///   marginal cost of mirroring the non-indexed slot is trivial and
+///   the asymmetry would force the next "first indexed-draw cdylib
+///   consumer" to re-derive the same engine work mid-task. Same
+///   wire shape as `record_draw` but takes a `DrawIndexedCallRepr`.
+pub const RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 4;
 
 /// Layout version of [`OutputWriterVTable`].
 ///
@@ -3689,11 +3696,15 @@ unsafe impl Sync for RhiColorConverterMethodsVTable {}
 /// v3 (#1066) appends `record_swapchain_image_barrier`,
 /// `cmd_begin_dynamic_rendering`, `cmd_end_dynamic_rendering`,
 /// `submit_with_semaphores`, and `record_draw` for cdylib display
-/// processors. The remaining `RhiCommandRecorder` methods
-/// (`record_draw_indexed`, `record_copy_buffer_to_image`, `submit`,
-/// `submit_and_wait`) keep their cdylib-mode panic in place — they
-/// don't sit on any cdylib hot path today and a follow-up slice
-/// lifts them when a consumer arrives.
+/// processors. v4 (same milestone) appends `record_draw_indexed`
+/// eagerly alongside `record_draw` — the marginal cost of mirroring
+/// the non-indexed slot is trivial and the asymmetry would force
+/// the next indexed-draw cdylib consumer to re-derive the engine
+/// work mid-task. The remaining `RhiCommandRecorder` methods
+/// (`record_copy_buffer_to_image`, `submit`, `submit_and_wait`)
+/// keep their cdylib-mode panic in place — they don't sit on any
+/// cdylib hot path today and a follow-up slice lifts them when a
+/// consumer arrives.
 ///
 /// **Buffer-flavor coverage today:** the v1 `record_buffer_barrier`
 /// and `record_copy_image_to_buffer` slots accept a
@@ -3982,6 +3993,20 @@ pub struct RhiCommandRecorderMethodsVTable {
         kernel_handle: *const c_void,
         frame_index: u32,
         draw: *const DrawCallRepr,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Indexed-draw sibling of [`Self::record_draw`]. Caller must
+    /// have bound an index buffer for `frame_index` via the kernel's
+    /// `set_index_buffer` before this call. Same wire convention as
+    /// `record_draw`; `draw` points at a [`DrawIndexedCallRepr`].
+    pub record_draw_indexed: unsafe extern "C" fn(
+        recorder_handle: *const c_void,
+        kernel_handle: *const c_void,
+        frame_index: u32,
+        draw: *const DrawIndexedCallRepr,
         err_buf: *mut u8,
         err_buf_cap: usize,
         err_len: *mut usize,
@@ -5356,7 +5381,7 @@ mod layout_tests {
         // (`record_pixel_buffer_barrier`,
         // `record_copy_image_to_pixel_buffer`) for cdylib camera
         // per-frame copy into pooled `PixelBuffer` destinations.
-        assert_eq!(RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION, 3);
+        assert_eq!(RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION, 4);
         // v1 (issue #894): initial shape — `write_raw`, `has_port`,
         // `clone_arc`, `drop_arc`.
         assert_eq!(OUTPUT_WRITER_VTABLE_LAYOUT_VERSION, 1);
@@ -5880,9 +5905,9 @@ mod layout_tests {
         //   record_pixel_buffer_barrier          @ 56  (8 bytes, fn pointer, v2)
         //   record_copy_image_to_pixel_buffer    @ 64  (8 bytes, fn pointer, v2)
         // Total = 72 bytes, align = 8.
-        // layout_version (u32) + _reserved_padding (u32) + 13 fn
-        // pointers (8 bytes each) = 4 + 4 + 104 = 112 bytes, align = 8.
-        assert_eq!(size_of::<RhiCommandRecorderMethodsVTable>(), 112);
+        // layout_version (u32) + _reserved_padding (u32) + 14 fn
+        // pointers (8 bytes each) = 4 + 4 + 112 = 120 bytes, align = 8.
+        assert_eq!(size_of::<RhiCommandRecorderMethodsVTable>(), 120);
         assert_eq!(align_of::<RhiCommandRecorderMethodsVTable>(), 8);
         assert_eq!(
             offset_of!(RhiCommandRecorderMethodsVTable, layout_version),
@@ -5965,6 +5990,11 @@ mod layout_tests {
         assert_eq!(
             offset_of!(RhiCommandRecorderMethodsVTable, record_draw),
             104
+        );
+        // v4 entry (#1066).
+        assert_eq!(
+            offset_of!(RhiCommandRecorderMethodsVTable, record_draw_indexed),
+            112
         );
     }
 

--- a/packages/display/src/linux/display.rs
+++ b/packages/display/src/linux/display.rs
@@ -623,7 +623,7 @@ impl DisplayEventLoopHandler {
         // signals this on writeback completion; we GPU-wait it at FRAGMENT_SHADER.
         let video_source_timeline_wait_value: u64 = ipc_frame.frame_index.parse().unwrap_or(0);
         let video_source_timeline =
-            self.gpu_context.video_source_timeline_semaphore();
+            self.gpu_context.host_video_source_timeline_arc();
 
         let scaling_mode = self.scaling_mode.clone();
         let kernel_for_draw = Arc::clone(&graphics_kernel);


### PR DESCRIPTION
## Summary

Issue #1066 was filed as "add `host_video_source_timeline_arc` β-shape vtable slot — fixes display render-loop cdylib panic." During pickup the reproducer (`cargo run -p camera-display` against vivid `/dev/video0`) confirmed the panic at gpu_context.rs:3253 — and walking `VulkanPresentTarget::render_frame` forward showed the timeline-arc fix alone only moves the panic one line further. There are ~8 distinct cdylib-mode panic sites on the same render iteration.

Issue body was updated in place with a supersession note + widened exit criteria covering the full sweep, per CLAUDE.md "Issues are goals, not specs."

**E2E result on this branch**: `cargo run -p camera-display` against `/dev/video0` (vivid) with `STREAMLIB_DISPLAY_FRAME_LIMIT=300` renders 300 frames cleanly, zero panics, window stays open for the full ~60s run. Before this branch: brief black flash and immediate render-thread panic.

## Closes

Closes #1066

## What landed

Five logical commits, smallest to broadest reach:

1. **v14 LimitedAccess slot — `host_video_source_timeline_arc`** (301b266b). The original #1066 ask. Mirrors the v9 `host_vulkan_device_arc` FullAccess shape: host callback `Arc::into_raw`s a fresh clone (or returns null when no producer published a timeline); cdylib reconstitutes via `Arc::from_raw`. Migrated display.rs:626 to the new accessor; left the old `video_source_timeline_semaphore()` engine-only with a doc pointer to the new method.

2. **v3 RhiCommandRecorderMethodsVTable — 5 new slots** (c461b2f2). Lifted swapchain render-path operations from inline raw-Vulkan calls in `vulkan_present_target.rs` onto the recorder's methods vtable:
   - `record_swapchain_image_barrier` — raw `VkImage` layout transitions (distinct from v1 `record_image_barrier` which takes a `Texture` β-shape).
   - `cmd_begin_dynamic_rendering` / `cmd_end_dynamic_rendering` — dynamic-rendering pass bracketing.
   - `submit_with_semaphores` — variable-length wait/signal arrays via new `SemaphoreSubmitInfoRepr` POD.
   - `record_draw` — sibling of v1 `record_dispatch` but for graphics pipelines. Placed on the recorder methods vtable to match the existing `record_dispatch` shape, rather than on the graphics kernel methods vtable as the issue body's exit criterion #3 suggested.

   All slots ride the established `dispatch_*_via_vtable` shape: ABI field + offset_of! regression + host wrapper + dispatch helper + mode-routed public method.

3. **VulkanPresentTarget migration + `recorder_device` removal** (fed2c223). Replaced 7 raw `command_buffer_raw()` / `recorder_device` reaches with calls to the new vtable-routed recorder methods. Dropped the `recorder_device` helper and the recorder's `host_inner` / `command_buffer_raw` / `vulkan_device_ref` accessors (no surviving callers; per CLAUDE.md "delete unused code completely").

4. **Methods-vtable getter routing fix** (d146bd01) — surfaced by the new cdylib code path. `host_vulkan_compute_kernel_methods_vtable` / `host_vulkan_graphics_kernel_methods_vtable` / `host_rhi_command_recorder_methods_vtable` always returned the local DSO's static. When a cdylib constructed a β-shape directly (e.g. display's `build_display_kernel` outside an escalate scope), the β-shape stored the cdylib's local static — and dispatches called the cdylib's own copies of the wrappers, which run with `host_callbacks() = Some` and panic on `Texture::host_inner()`. Mode-routed all three getters like `host_gpu_context_limited_access_vtable` already was. This is a broader engine fix than just #1066 but it's load-bearing for any future cdylib that constructs β-shapes outside escalate (per CLAUDE.md "no bad patterns left behind on engine changes"). Camera's compute kernel already worked because it's constructed inside `escalate(|full| ...)`.

5. **v4 — `record_draw_indexed` slot** (0174c987). Mirrored alongside `record_draw` eagerly rather than deferring to "first indexed-draw consumer." The marginal cost (~50 lines using the existing `DrawIndexedCallRepr` POD) is trivial; the asymmetry would force the next consumer to re-derive the engine work mid-task. Same wire shape as `record_draw` but takes `DrawIndexedCallRepr`. No new in-tree consumer exercises this slot today; display still only uses non-indexed `record_draw`.

## Exit criteria

- [x] `host_video_source_timeline_arc` slot on `GpuContextLimitedAccessVTable` (v13 → v14)
- [x] Six new slots on `RhiCommandRecorderMethodsVTable` (v2 → v4) — see commits 2 and 5 above for the `record_draw` location nuance
- [x] `recorder_device` refactored away; `recorder.command_buffer_raw()` + `vulkan_device_ref()` deleted
- [x] `@tatolab/display`'s render loop migrated to the new accessors
- [x] Old `video_source_timeline_semaphore()` stays engine-only with doc pointer
- [x] Layout regression tests + `offset_of!` assertions for every new slot; layout version bumps locked
- [x] E2E: 300 frames clean against vivid `/dev/video0`, zero panics, window stays open

## Test plan

- [x] `cargo test -p streamlib-plugin-abi --lib` — 53 passed
- [x] `cargo test -p streamlib-engine --lib` (excluding the known-flaky `core::pubsub::integration_tests`) — 1364 passed
- [x] `cargo xtask build-plugins --package @tatolab/camera --package @tatolab/display --package @tatolab/api-server` — clean build
- [x] E2E: 60 frames clean against vivid (with and without the v4 `record_draw_indexed` slot)
- [x] E2E (extended): 300 frames clean

## Follow-ups

- #1069 — PNG-sampling cdylib panic at `pixel_buffer.rs:187` (`HostPixelBufferRefExt::vulkan_inner()` reach). Same engine-model pattern; separate single-site lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)