### PR TITLE
fix(1069): PNG-sampling cdylib path — drop pixel-buffer reach-through + texture-readback arc transit

### DIFF
--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_texture_readback.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_texture_readback.rs
@@ -276,11 +276,10 @@ impl VulkanTextureReadback {
             });
         }
 
-        // Route through the v10 `host_vulkan_texture_arc` FullAccess slot
-        // so this submit path is safe to call from cdylib-loaded packages
-        // (e.g. `@tatolab/display`'s `sample_texture_to_png` fallback).
-        // `Texture::vulkan_inner()` reaches `host_inner()` which panics
-        // when `host_callbacks().is_some()`.
+        // Cdylib-safe: `Texture::vulkan_inner()` reaches `host_inner()` which
+        // panics under `host_callbacks().is_some()`. Route through the
+        // `host_vulkan_texture_arc` FullAccess slot so cdylib callers don't
+        // trip the panic guard.
         let host_texture = texture.host_vulkan_texture_arc().map_err(|e| {
             TextureReadbackError::Submit {
                 label: self.label.clone(),

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_texture_readback.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_texture_readback.rs
@@ -276,7 +276,19 @@ impl VulkanTextureReadback {
             });
         }
 
-        let image = texture.vulkan_inner().image().ok_or_else(|| {
+        // Route through the v10 `host_vulkan_texture_arc` FullAccess slot
+        // so this submit path is safe to call from cdylib-loaded packages
+        // (e.g. `@tatolab/display`'s `sample_texture_to_png` fallback).
+        // `Texture::vulkan_inner()` reaches `host_inner()` which panics
+        // when `host_callbacks().is_some()`.
+        let host_texture = texture.host_vulkan_texture_arc().map_err(|e| {
+            TextureReadbackError::Submit {
+                label: self.label.clone(),
+                what: "host_vulkan_texture_arc",
+                cause: e.to_string(),
+            }
+        })?;
+        let image = host_texture.image().ok_or_else(|| {
             TextureReadbackError::TextureMissingVulkanImage {
                 label: self.label.clone(),
             }

--- a/packages/debug-utilities/src/bgra_file_source.rs
+++ b/packages/debug-utilities/src/bgra_file_source.rs
@@ -9,7 +9,6 @@
 
 use crate::_generated_::VideoFrame;
 use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess, TextureRing};
-use streamlib::sdk::engine::HostPixelBufferRefExt;
 use streamlib::sdk::error::{Error, Result};
 use streamlib::sdk::iceoryx2::OutputWriter;
 use streamlib::sdk::processors::ManualProcessor;
@@ -167,7 +166,7 @@ fn source_thread_loop(
                 }
             };
 
-        let dst_ptr = pixel_buffer.buffer_ref().vulkan_inner().mapped_ptr();
+        let dst_ptr = pixel_buffer.plane_base_address(0);
         unsafe {
             std::ptr::copy_nonoverlapping(frame_buf.as_ptr(), dst_ptr, frame_size);
         }

--- a/packages/display/src/linux/display.rs
+++ b/packages/display/src/linux/display.rs
@@ -755,9 +755,7 @@ impl DisplayEventLoopHandler {
                     self.window_id, frame_idx, input_frame_index
                 ));
                 if let Ok(buf) = self.gpu_context.resolve_pixel_buffer_by_surface_id(&ipc_frame.surface_id) {
-                    use streamlib::sdk::engine::HostPixelBufferRefExt;
-                    let vk_buf = buf.buffer_ref().vulkan_inner();
-                    let mapped_ptr = vk_buf.mapped_ptr();
+                    let mapped_ptr = buf.plane_base_address(0);
                     if !mapped_ptr.is_null() {
                         let len = (src_width as usize) * (src_height as usize) * 4;
                         let rgba =

--- a/packages/h264/src/linux/decoder.rs
+++ b/packages/h264/src/linux/decoder.rs
@@ -12,7 +12,6 @@ use crate::linux::color_vui_translate::h273_to_color_info;
 use streamlib::sdk::context::{
     GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess, TextureRing,
 };
-use streamlib::sdk::engine::HostPixelBufferRefExt;
 use streamlib::sdk::error::{Error, Result};
 use streamlib::sdk::rhi::{PixelFormat, TextureFormat, TextureUsages};
 
@@ -147,7 +146,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264DecoderProcessor::Pro
             // pre-allocated by `create_texture_ring`, reset+reused per call).
             let (_pool_id, pixel_buffer) =
                 gpu_ctx.acquire_pixel_buffer(width, height, PixelFormat::Rgba32)?;
-            let dst_ptr = pixel_buffer.buffer_ref().vulkan_inner().mapped_ptr();
+            let dst_ptr = pixel_buffer.plane_base_address(0);
             unsafe {
                 std::ptr::copy_nonoverlapping(src.as_ptr(), dst_ptr, src.len());
             }

--- a/packages/h265/src/linux/decoder.rs
+++ b/packages/h265/src/linux/decoder.rs
@@ -12,7 +12,6 @@ use crate::linux::color_vui_translate::h273_to_color_info;
 use streamlib::sdk::context::{
     GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess, TextureRing,
 };
-use streamlib::sdk::engine::HostPixelBufferRefExt;
 use streamlib::sdk::error::{Error, Result};
 use streamlib::sdk::rhi::{PixelFormat, TextureFormat, TextureUsages};
 
@@ -147,7 +146,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265DecoderProcessor::Pro
             // pre-allocated by `create_texture_ring`, reset+reused per call).
             let (_pool_id, pixel_buffer) =
                 gpu_ctx.acquire_pixel_buffer(width, height, PixelFormat::Rgba32)?;
-            let dst_ptr = pixel_buffer.buffer_ref().vulkan_inner().mapped_ptr();
+            let dst_ptr = pixel_buffer.plane_base_address(0);
             unsafe {
                 std::ptr::copy_nonoverlapping(src.as_ptr(), dst_ptr, src.len());
             }


### PR DESCRIPTION
## Summary

Display's PNG-sampling debug branch tripped `PixelBuffer::buffer_ref()` panic at `pixel_buffer.rs:187` when `@tatolab/display` was loaded as a `.slpkg`. The reach-through `buf.buffer_ref().vulkan_inner().mapped_ptr()` was unnecessary — `PixelBuffer::plane_base_address(0)` already exposes the same bytes through the existing `plane_base_address_pixel_buffer` vtable slot.

Per CLAUDE.md "no bad patterns left behind on engine changes," **swept the same anti-pattern across all four cdylib-enabled consumers** in this PR — display + h264 decoder + h265 decoder + bgra_file_source. All four declared `crate-type = ["rlib", "cdylib"]` and would panic identically when loaded as `.slpkg`s; the sweep took 1 line per consumer.

Companion engine fix in `vulkan_texture_readback.rs:279` routes `Texture::vulkan_inner().image()` through the v10 `host_vulkan_texture_arc` FullAccess slot (from #1068), making `VulkanTextureReadback::submit` cdylib-safe for display's `sample_texture_to_png` fallback and any future cdylib caller of readback.

## Closes

Closes #1069

## What changed

- `packages/display/src/linux/display.rs` — PNG sample read (reproducer site)
- `packages/h264/src/linux/decoder.rs` — decoded RGBA write into staging pixel buffer
- `packages/h265/src/linux/decoder.rs` — same shape, H.265
- `packages/debug-utilities/src/bgra_file_source.rs` — BGRA file source write
- `libs/streamlib-engine/src/vulkan/rhi/vulkan_texture_readback.rs:279` — engine-layer cdylib-safety fix

All five files migrate from `buffer_ref().vulkan_inner().mapped_ptr()` (or `vulkan_inner().image()` for the engine site) to existing cdylib-safe accessors — no new vtable slots, no v15 bump.

## Exit criteria

- [x] Display's PNG-sampling path no longer panics in cdylib mode
- [x] No new `host_callbacks().is_some()` reach in the cdylib render path
- [x] The chosen fix shape follows established patterns (existing public API for the pixel-buffer site; reused v10 `host_vulkan_texture_arc` FullAccess slot for the texture site — no new methods-vtable slot needed)

## Test plan

E2E (the issue's reproducer):

```
cargo xtask build-plugins --package @tatolab/camera --package @tatolab/display --package @tatolab/api-server
mkdir -p /tmp/camdisp-png-1069
STREAMLIB_CAMERA_DEVICE=/dev/video0 \
  STREAMLIB_DISPLAY_FRAME_LIMIT=60 \
  STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=/tmp/camdisp-png-1069 \
  STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30 \
  timeout --kill-after=5 25 cargo run -q -p camera-display
```

- [x] Zero `panicked at`, zero `OUT_OF_DEVICE_MEMORY`, zero `DEVICE_LOST`, zero `process() failed` over a 60-frame run
- [x] 2 PNG samples written at frame 0 and frame 30 (8.3 MB each, 1920×1080)
- [x] Read one PNG with the Read tool — vivid SMPTE colorbar with timecode overlay `00:00:06:407 32`, recognizable, no black/zero output

Sample PNG (frame 30, displayed frame 30, input frame 33), uploaded lossless from the actual output of the cdylib display's PNG sampler:

![display PNG sample, vivid colorbar, frame 30](https://gh-artifact.tatolab.com/pr-1070/display-png-sample-frame30-vivid.png)
- [x] `cargo check -p streamlib-engine -p streamlib-display -p streamlib-h264 -p streamlib-h265 -p streamlib-debug-utilities` clean
- [x] `cargo xtask build-plugins` clean

No new unit test added — the engine fix reuses the v10 `host_vulkan_texture_arc_returns_null_on_null_handle` test at `host_services.rs:13195`; the consumer-side migrations are adopting an existing public API and the E2E is the lock.

## Out of scope (potential follow-up)

`pr-review-gate` flagged that `packages/h264/src/linux/encoder.rs` and `packages/h265/src/linux/encoder.rs` use `texture.vulkan_inner().image_view()` — a related but distinct reach-through (texture-side, not pixel-buffer; encode path, not PNG-sampling). Both encoder packages are cdylib-enabled, so the encoder cdylib path will trip the same `host_inner()` panic guard. Outside #1069's scope (different anti-pattern, different code path) — worth filing as its own issue when a cdylib encoder reproducer surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
