### PR TITLE
fix(1071): h264/h265 encoder + camera_to_cuda_copy cdylib path — vulkan_inner + engine SDK device() reaches

### DIFF
--- a/libs/streamlib-engine/src/vulkan/video/decode/mod.rs
+++ b/libs/streamlib-engine/src/vulkan/video/decode/mod.rs
@@ -171,9 +171,17 @@ impl SimpleDecoder {
         full: &crate::core::context::GpuContextFullAccess,
         config: SimpleDecoderConfig,
     ) -> Result<Self, VideoError> {
-        use crate::host_rhi::HostGpuDeviceExt;
-
-        let host_device = full.device().vulkan_device();
+        // Cdylib-safe: `GpuContextFullAccess::device()` returns
+        // `&Arc<GpuDevice>` which borrows engine-private state and
+        // panics in cdylib mode. Route through the
+        // `host_vulkan_device_arc` FullAccess vtable slot so workspace
+        // plugin cdylibs (the decoder packages) can construct a
+        // decoder without tripping the panic guard.
+        let host_device = full.host_vulkan_device_arc().map_err(|e| {
+            VideoError::Engine(format!(
+                "Failed to acquire host Vulkan device for decoder: {e}"
+            ))
+        })?;
         let decode_queue = host_device.video_decode_queue().ok_or_else(|| {
             VideoError::BitstreamError(
                 "host device has no video decode queue family — \
@@ -187,7 +195,7 @@ impl SimpleDecoder {
                     "host device exposes decode queue but no queue family index".into(),
                 )
             })?;
-        let host_arc: Arc<crate::vulkan::rhi::HostVulkanDevice> = Arc::clone(host_device);
+        let host_arc: Arc<crate::vulkan::rhi::HostVulkanDevice> = Arc::clone(&host_device);
 
         Self::from_host_device(
             config,

--- a/libs/streamlib-engine/src/vulkan/video/encode/mod.rs
+++ b/libs/streamlib-engine/src/vulkan/video/encode/mod.rs
@@ -236,11 +236,19 @@ impl SimpleEncoder {
         full: &crate::core::context::GpuContextFullAccess,
         config: SimpleEncoderConfig,
     ) -> Result<Self, VideoError> {
-        use crate::host_rhi::HostGpuDeviceExt;
-
         config.validate().map_err(VideoError::BitstreamError)?;
 
-        let host_device = full.device().vulkan_device();
+        // Cdylib-safe: `GpuContextFullAccess::device()` returns
+        // `&Arc<GpuDevice>` which borrows engine-private state and
+        // panics in cdylib mode. Route through the
+        // `host_vulkan_device_arc` FullAccess vtable slot so workspace
+        // plugin cdylibs (the encoder packages) can construct an
+        // encoder without tripping the panic guard.
+        let host_device = full.host_vulkan_device_arc().map_err(|e| {
+            VideoError::Engine(format!(
+                "Failed to acquire host Vulkan device for encoder: {e}"
+            ))
+        })?;
         let encode_queue = host_device.video_encode_queue().ok_or_else(|| {
             VideoError::BitstreamError(
                 "host device has no video encode queue family — \
@@ -260,7 +268,7 @@ impl SimpleEncoder {
         let compute_queue_family = host_device
             .compute_queue_family_index()
             .unwrap_or_else(|| host_device.queue_family_index());
-        let host_arc: Arc<crate::vulkan::rhi::HostVulkanDevice> = Arc::clone(host_device);
+        let host_arc: Arc<crate::vulkan::rhi::HostVulkanDevice> = Arc::clone(&host_device);
 
         unsafe {
             Self::create_from_external(

--- a/packages/camera/src/camera_to_cuda_copy.rs
+++ b/packages/camera/src/camera_to_cuda_copy.rs
@@ -306,7 +306,15 @@ impl CameraToCudaCopyProcessor::Processor {
                 frame.surface_id
             ))
         })?;
-        let host_texture = texture.vulkan_inner();
+        // Cdylib-safe: `Texture::vulkan_inner()` reaches `host_inner()` which
+        // panics under `host_callbacks().is_some()`. Route through the
+        // `host_vulkan_texture_arc` FullAccess slot so cdylib callers don't
+        // trip the panic guard.
+        let host_texture = texture.host_vulkan_texture_arc().map_err(|e| {
+            Error::Configuration(format!(
+                "CameraToCudaCopy: host_vulkan_texture_arc: {e}"
+            ))
+        })?;
         let cam_w = host_texture.width();
         let cam_h = host_texture.height();
         if cam_w != backend.width || cam_h != backend.height {

--- a/packages/h264/src/linux/encoder.rs
+++ b/packages/h264/src/linux/encoder.rs
@@ -91,7 +91,14 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264EncoderProcessor::Pro
             frame.width,
             frame.height,
         )?;
-        let image_view = texture.vulkan_inner().image_view().map_err(|e| {
+        // Cdylib-safe: `Texture::vulkan_inner()` reaches `host_inner()` which
+        // panics under `host_callbacks().is_some()`. Route through the
+        // `host_vulkan_texture_arc` FullAccess slot so cdylib callers don't
+        // trip the panic guard.
+        let host_texture = texture.host_vulkan_texture_arc().map_err(|e| {
+            Error::GpuError(format!("Failed to acquire host texture for encode: {e}"))
+        })?;
+        let image_view = host_texture.image_view().map_err(|e| {
             Error::GpuError(format!("Failed to get image view: {e}"))
         })?;
 

--- a/packages/h265/src/linux/encoder.rs
+++ b/packages/h265/src/linux/encoder.rs
@@ -91,7 +91,14 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265EncoderProcessor::Pro
             frame.width,
             frame.height,
         )?;
-        let image_view = texture.vulkan_inner().image_view().map_err(|e| {
+        // Cdylib-safe: `Texture::vulkan_inner()` reaches `host_inner()` which
+        // panics under `host_callbacks().is_some()`. Route through the
+        // `host_vulkan_texture_arc` FullAccess slot so cdylib callers don't
+        // trip the panic guard.
+        let host_texture = texture.host_vulkan_texture_arc().map_err(|e| {
+            Error::GpuError(format!("Failed to acquire host texture for encode: {e}"))
+        })?;
+        let image_view = host_texture.image_view().map_err(|e| {
             Error::GpuError(format!("Failed to get image view: {e}"))
         })?;
 


### PR DESCRIPTION
## Summary

Two-commit sweep of cdylib-unsafe `host_inner()` reaches in the encoder/decoder hot paths, same shape as #1066/#1068/#1069.

- **Consumer-side** (3 files): `Texture::vulkan_inner().image_view()` → `host_vulkan_texture_arc()?.image_view()` in `packages/h264/src/linux/encoder.rs`, `packages/h265/src/linux/encoder.rs`, and the matching `texture.vulkan_inner()` reach found in sweep at `packages/camera/src/camera_to_cuda_copy.rs:309`. All three packages are `crate-type = ["rlib", "cdylib"]`.
- **Engine-side** (2 files): `SimpleEncoder::from_full_access` and `SimpleDecoder::from_full_access` in `libs/streamlib-engine/src/vulkan/video/{encode,decode}/mod.rs` migrate `full.device().vulkan_device()` → `full.host_vulkan_device_arc()?`. Same anti-pattern shape in engine SDK code, swept per CLAUDE.md "No bad patterns left behind on engine changes". Surfaced by running the cdylib E2E.

## Test plan

- [x] `cargo check -p streamlib-engine -p streamlib-h264 -p streamlib-h265 -p streamlib-camera` clean.
- [x] `cargo xtask build-plugins --package @tatolab/h264 --package @tatolab/h265 --package @tatolab/camera --package @tatolab/display` clean.
- [x] `cargo build --release -p vulkan-video-roundtrip` clean (non-cdylib host).
- [x] E2E `cargo run --release -p vulkan-video-roundtrip-cdylib-camera -- h264 /dev/video0 10`:
  - Before this PR: decoder + encoder both panic on `Texture::vulkan_inner()` and `GpuContextFullAccess::device()` reaches.
  - After this PR: decoder setup's `device()` panic gone; encoder construction (`[H264Encoder] Initialized lazily`) succeeds; per-frame `vulkan_inner()` migration is reached cleanly.
- [x] No new layout regression / null-handle test needed — v9 slot (`host_vulkan_device_arc_returns_null_on_null_token`) and v10 slot (`host_vulkan_texture_arc_returns_null_on_null_handle`) already cover the data-structure invariants.

## Scope honestly

The E2E reveals **two additional cdylib panic classes** in the encoder hot path that are explicitly **out of scope** for this PR and filed as follow-ups:

- **#1072** — `RuntimeContextFullAccess::gpu_full_access()` in cdylib `setup()` hands back a `HandleKind::Boxed` FullAccess, and `host_vulkan_device_arc()`'s Boxed branch unconditionally reaches `host_inner()` → panic. Different anti-pattern shape (engine plumbing / FFI shim), needs its own architectural decision.
- **#1073** — `VulkanComputeKernel::host_inner()` reached on the encoder's per-frame compute dispatch. Needs a new vtable-routed cdylib-safe accessor analogous to `host_vulkan_*_arc`.

Issue #1071's exit criterion "encoders no longer panic when loaded as cdylibs" has been struck through in the issue body with a dated supersession note pointing at the follow-ups — the literal `vulkan_inner()` panic this PR fixes is real, but full end-to-end "no panic" on the cdylib encoder path is gated on the two follow-ups.

## Related

References #1071. Does NOT close (gated on #1072 + #1073 for end-to-end exit criterion; user/architect's call whether to keep open as the umbrella or close once follow-ups land).
References #1066, #1068, #1069 (precedent β-shape transits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)