### PR TITLE
fix(1073): VulkanComputeKernel raw vk::* methods — v5 vtable slots

### DIFF
--- a/docs/architecture/cdylib-reachability.md
+++ b/docs/architecture/cdylib-reachability.md
@@ -96,12 +96,13 @@ something on the host side.
      │              │              │                     │
      ▼              ▼              ▼                     ▼
    Pattern 4     Pattern 5      Pattern 3             Pattern 2
-   escalate +    (see "engine-  per-method            β-shape Arc-
-   FullAccess    SDK reach"     vtable slot           transit slot
-   work in       below — not    (set_storage_         (host_vulkan_
-   closure       a clean        buffer_pixel etc)    X_arc — #1066/
-                 pattern; see                          68/69/70/71)
-                 #1073)
+   escalate +    per-method     per-method            β-shape Arc-
+   FullAccess    vtable slot    vtable slot           transit slot
+   work in       w/ raw         (set_storage_         (host_vulkan_
+   closure       vulkanalia     buffer_pixel etc)    X_arc — #1066/
+                 handle wire                          68/69/70/71)
+                 (set_*_image_
+                  view, record)
 ```
 
 **Critical asymmetry**: Pattern 4 (escalate) only applies to
@@ -147,15 +148,23 @@ The five patterns:
   holds the gate, and re-entry panics with an actionable message
   via `EscalateGate`'s same-thread re-entry detector. The xtask
   lint `check-no-escalate-in-lifecycle` enforces this statically.
-- **Pattern 5: engine-SDK-internal reaches** (#1073 class) — when
-  engine SDK code (`SimpleEncoder`, `SimpleDecoder`, etc.) reaches
-  a `host_inner()`-only method on `VulkanComputeKernel` etc. via
-  intermediate types (the per-method vtable slots don't cover
-  these methods because they take raw `vk::*` handles). Three real
-  shapes: (A) lift the engine SDK boundary to escalate the
-  internal call; (B) build new ABI wire types for the raw
-  vulkanalia handles; (C) move the offending engine code to
-  host-only crates. See #1073's issue body for the live decision.
+- **Pattern 5: per-method vtable slot carrying a raw vulkanalia
+  handle** — `set_sampled_image_view`, `set_combined_image_sampler_view`,
+  `set_storage_image_view`, and `record` on `VulkanComputeKernel`.
+  Engine SDK code (`RgbToNv12Converter::convert`,
+  `Nv12ToRgbConverter::convert`) compiled into workspace plugin
+  cdylibs reaches these `pub(crate)` methods on the per-frame path.
+  The vtable slot carries the raw `vk::ImageView` / `vk::CommandBuffer`
+  as a `u64` wire value (vulkanalia's handle types are
+  `#[repr(transparent)]` over `u64` / `usize`); the host wrapper
+  reconstructs the typed handle via `Handle::from_raw` before
+  forwarding. Same structural shape as Pattern 3 — the asymmetry
+  is that the binding payload here is a raw vulkanalia integer
+  rather than an engine-public β-shape. The host method stays
+  `pub(crate)` because subprocess (Python/Deno) cdylibs don't
+  link the engine SDK code that reaches it; only workspace plugin
+  cdylibs (h264/h265/camera) hit this path. This pattern landed
+  via v5 of `VulkanComputeKernelMethodsVTable`.
 
 ## Constructor bridge sub-decision (was Pattern 2's sub-tree)
 
@@ -324,15 +333,17 @@ in this codebase before being caught.
    (Pattern 2 or 3) — the parallel HashMap goes stale the moment
    the host's source-of-truth changes.
 
-5. ❌ **Calling a host-only `pub(crate)` method from cdylib code
-   via a hand-built `vk::*` argument.** The `set_sampled_image_view`
-   / `set_storage_image_view` / `record` methods on
-   `VulkanComputeKernel` are `pub(crate)` precisely because cdylib
-   code can't construct raw vulkanalia handles. Reaching them via
-   `kernel.host_inner().set_*(...)` (bypassing the panic guard)
-   re-introduces UB — those methods read host-private memory.
-   **For this class of reach, see #1073 and Pattern 5 — none of
-   the existing patterns directly cover it; new design is needed.**
+5. ❌ **Bypassing the panic guard via
+   `kernel.host_inner().set_*(...)` to reach a `pub(crate)`
+   method.** The `set_sampled_image_view` /
+   `set_combined_image_sampler_view` / `set_storage_image_view` /
+   `record` methods on `VulkanComputeKernel` are now mode-routed
+   through the v5 `VulkanComputeKernelMethodsVTable` slots
+   (Pattern 5 — see the catalog above). Reaching them via
+   `host_inner()` instead skips the routing and reads host-private
+   memory from the cdylib's address space — UB. Always call the
+   public `pub(crate)` method (it picks the right path); never
+   `host_inner()`.
 
 ## Enforcement
 

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -8458,6 +8458,11 @@ unsafe extern "C" fn host_compute_kernel_bindings(
 // FFI carries the raw integer as `u64`; the host reconstructs via
 // `Handle::from_raw` before forwarding.
 
+// The four callbacks below dispatch through `*_raw` shim methods on
+// `VulkanComputeKernelInner` so that this file stays off the
+// vulkanalia allowlist (`xtask check-boundaries`). The RHI-side shim
+// is the canonical owner of `Handle::from_raw` reconstruction.
+
 #[cfg(target_os = "linux")]
 unsafe extern "C" fn host_compute_kernel_set_sampled_image_view(
     kernel_handle: *const c_void,
@@ -8467,7 +8472,6 @@ unsafe extern "C" fn host_compute_kernel_set_sampled_image_view(
     err_buf_cap: usize,
     err_len: *mut usize,
 ) -> i32 {
-    use vulkanalia::vk::{self, Handle};
     run_host_extern_c(
         "host_compute_kernel_set_sampled_image_view",
         || -> i32 {
@@ -8481,8 +8485,7 @@ unsafe extern "C" fn host_compute_kernel_set_sampled_image_view(
                 );
                 return 1;
             };
-            let view = vk::ImageView::from_raw(image_view_handle);
-            match kernel.set_sampled_image_view(binding, view) {
+            match kernel.set_sampled_image_view_raw(binding, image_view_handle) {
                 Ok(()) => 0,
                 Err(e) => {
                     write_err(
@@ -8508,7 +8511,6 @@ unsafe extern "C" fn host_compute_kernel_set_combined_image_sampler_view(
     err_buf_cap: usize,
     err_len: *mut usize,
 ) -> i32 {
-    use vulkanalia::vk::{self, Handle};
     run_host_extern_c(
         "host_compute_kernel_set_combined_image_sampler_view",
         || -> i32 {
@@ -8522,8 +8524,9 @@ unsafe extern "C" fn host_compute_kernel_set_combined_image_sampler_view(
                 );
                 return 1;
             };
-            let view = vk::ImageView::from_raw(image_view_handle);
-            match kernel.set_combined_image_sampler_view(binding, view) {
+            match kernel
+                .set_combined_image_sampler_view_raw(binding, image_view_handle)
+            {
                 Ok(()) => 0,
                 Err(e) => {
                     write_err(
@@ -8549,7 +8552,6 @@ unsafe extern "C" fn host_compute_kernel_set_storage_image_view(
     err_buf_cap: usize,
     err_len: *mut usize,
 ) -> i32 {
-    use vulkanalia::vk::{self, Handle};
     run_host_extern_c(
         "host_compute_kernel_set_storage_image_view",
         || -> i32 {
@@ -8563,8 +8565,7 @@ unsafe extern "C" fn host_compute_kernel_set_storage_image_view(
                 );
                 return 1;
             };
-            let view = vk::ImageView::from_raw(image_view_handle);
-            match kernel.set_storage_image_view(binding, view) {
+            match kernel.set_storage_image_view_raw(binding, image_view_handle) {
                 Ok(()) => 0,
                 Err(e) => {
                     write_err(
@@ -8592,7 +8593,6 @@ unsafe extern "C" fn host_compute_kernel_record(
     err_buf_cap: usize,
     err_len: *mut usize,
 ) -> i32 {
-    use vulkanalia::vk::{self, Handle};
     run_host_extern_c(
         "host_compute_kernel_record",
         || -> i32 {
@@ -8606,10 +8606,12 @@ unsafe extern "C" fn host_compute_kernel_record(
                 );
                 return 1;
             };
-            // vulkanalia's CommandBuffer wraps a usize; on every supported
-            // target usize == u64, so the cast is lossless.
-            let cb = vk::CommandBuffer::from_raw(command_buffer_handle as usize);
-            match kernel.record(cb, group_x, group_y, group_z) {
+            match kernel.record_raw(
+                command_buffer_handle,
+                group_x,
+                group_y,
+                group_z,
+            ) {
                 Ok(()) => 0,
                 Err(e) => {
                     write_err(

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -8440,9 +8440,272 @@ unsafe extern "C" fn host_compute_kernel_bindings(
     1
 }
 
-/// Host-side `VulkanComputeKernelMethodsVTable` populated with v4
-/// method slots — v3's binding-method dispatch surface plus the v4
-/// `bindings` introspection slot.
+// ---- Raw-vulkanalia-handle slots (v5 — #1073) -----------------------------
+//
+// Engine SDK code (`RgbToNv12Converter::convert`,
+// `Nv12ToRgbConverter::convert`) reaches three `pub(crate)`
+// `VulkanComputeKernel` setter methods that take raw `vk::ImageView`
+// and one `record` method that takes raw `vk::CommandBuffer`. When
+// that engine SDK code is compiled into a cdylib (workspace plugin
+// packages with `crate-type = ["rlib", "cdylib"]` — h264, h265,
+// camera), the cdylib-compiled methods can't deref `host_inner()`
+// without tripping the panic guard. These callbacks let the cdylib
+// dispatch through the host's per-method vtable instead.
+//
+// Wire shape: `vk::ImageView` is `#[repr(transparent)] pub struct
+// ImageView(u64)` and `vk::CommandBuffer` is `#[repr(transparent)]
+// pub struct CommandBuffer(usize)` (vulkanalia-sys handles.rs). The
+// FFI carries the raw integer as `u64`; the host reconstructs via
+// `Handle::from_raw` before forwarding.
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_compute_kernel_set_sampled_image_view(
+    kernel_handle: *const c_void,
+    binding: u32,
+    image_view_handle: u64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    use vulkanalia::vk::{self, Handle};
+    run_host_extern_c(
+        "host_compute_kernel_set_sampled_image_view",
+        || -> i32 {
+            let Some(kernel) = (unsafe { handle_as_compute_kernel(kernel_handle) })
+            else {
+                write_err(
+                    "set_sampled_image_view: null kernel handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            let view = vk::ImageView::from_raw(image_view_handle);
+            match kernel.set_sampled_image_view(binding, view) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("set_sampled_image_view: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_compute_kernel_set_combined_image_sampler_view(
+    kernel_handle: *const c_void,
+    binding: u32,
+    image_view_handle: u64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    use vulkanalia::vk::{self, Handle};
+    run_host_extern_c(
+        "host_compute_kernel_set_combined_image_sampler_view",
+        || -> i32 {
+            let Some(kernel) = (unsafe { handle_as_compute_kernel(kernel_handle) })
+            else {
+                write_err(
+                    "set_combined_image_sampler_view: null kernel handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            let view = vk::ImageView::from_raw(image_view_handle);
+            match kernel.set_combined_image_sampler_view(binding, view) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("set_combined_image_sampler_view: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_compute_kernel_set_storage_image_view(
+    kernel_handle: *const c_void,
+    binding: u32,
+    image_view_handle: u64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    use vulkanalia::vk::{self, Handle};
+    run_host_extern_c(
+        "host_compute_kernel_set_storage_image_view",
+        || -> i32 {
+            let Some(kernel) = (unsafe { handle_as_compute_kernel(kernel_handle) })
+            else {
+                write_err(
+                    "set_storage_image_view: null kernel handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            let view = vk::ImageView::from_raw(image_view_handle);
+            match kernel.set_storage_image_view(binding, view) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("set_storage_image_view: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_compute_kernel_record(
+    kernel_handle: *const c_void,
+    command_buffer_handle: u64,
+    group_x: u32,
+    group_y: u32,
+    group_z: u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    use vulkanalia::vk::{self, Handle};
+    run_host_extern_c(
+        "host_compute_kernel_record",
+        || -> i32 {
+            let Some(kernel) = (unsafe { handle_as_compute_kernel(kernel_handle) })
+            else {
+                write_err(
+                    "record: null kernel handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            // vulkanalia's CommandBuffer wraps a usize; on every supported
+            // target usize == u64, so the cast is lossless.
+            let cb = vk::CommandBuffer::from_raw(command_buffer_handle as usize);
+            match kernel.record(cb, group_x, group_y, group_z) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("record: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+// ---- Non-Linux stubs for v5 raw-vulkanalia-handle slots --------------------
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_compute_kernel_set_sampled_image_view(
+    _kernel_handle: *const c_void,
+    _binding: u32,
+    _image_view_handle: u64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "set_sampled_image_view: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_compute_kernel_set_combined_image_sampler_view(
+    _kernel_handle: *const c_void,
+    _binding: u32,
+    _image_view_handle: u64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "set_combined_image_sampler_view: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_compute_kernel_set_storage_image_view(
+    _kernel_handle: *const c_void,
+    _binding: u32,
+    _image_view_handle: u64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "set_storage_image_view: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_compute_kernel_record(
+    _kernel_handle: *const c_void,
+    _command_buffer_handle: u64,
+    _group_x: u32,
+    _group_y: u32,
+    _group_z: u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "record: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+/// Host-side `VulkanComputeKernelMethodsVTable` populated with v5
+/// method slots — v4's surface plus the v5 raw-vulkanalia-handle
+/// slots needed by engine-SDK-internal converter code reaching out of
+/// cdylib-resident processors (#1073).
 pub static HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE:
     streamlib_plugin_abi::VulkanComputeKernelMethodsVTable =
     streamlib_plugin_abi::VulkanComputeKernelMethodsVTable {
@@ -8456,6 +8719,11 @@ pub static HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE:
         set_sampled_texture: host_compute_kernel_set_sampled_texture,
         set_storage_image: host_compute_kernel_set_storage_image,
         bindings: host_compute_kernel_bindings,
+        set_sampled_image_view: host_compute_kernel_set_sampled_image_view,
+        set_combined_image_sampler_view:
+            host_compute_kernel_set_combined_image_sampler_view,
+        set_storage_image_view: host_compute_kernel_set_storage_image_view,
+        record: host_compute_kernel_record,
     };
 
 /// Accessor for the host's static `VulkanComputeKernelMethodsVTable`
@@ -13789,6 +14057,104 @@ mod compute_kernel_methods_vtable_null_tests {
         assert!(
             err_buf_as_str(&buf, len)
                 .contains("set_storage_image: null kernel handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    // ---- v5 raw-vulkanalia-handle slots (#1073) -----------------------------
+    //
+    // The null-kernel-handle case is the tier-1 reach: passing a real
+    // `vk::ImageView` / `vk::CommandBuffer` raw handle with a null
+    // kernel pointer must fail cleanly before any deref. Non-null but
+    // garbage kernel handles still trip the host_inner deref's pointer
+    // alignment / segfault — the same precedent the v3/v4 tests
+    // document.
+
+    #[test]
+    fn set_sampled_image_view_rejects_null_kernel_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE.set_sampled_image_view)(
+                std::ptr::null(),
+                0,
+                0,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("set_sampled_image_view: null kernel handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    fn set_combined_image_sampler_view_rejects_null_kernel_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE
+                .set_combined_image_sampler_view)(
+                std::ptr::null(),
+                0,
+                0,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("set_combined_image_sampler_view: null kernel handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    fn set_storage_image_view_rejects_null_kernel_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE.set_storage_image_view)(
+                std::ptr::null(),
+                0,
+                0,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("set_storage_image_view: null kernel handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    fn record_rejects_null_kernel_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE.record)(
+                std::ptr::null(),
+                0,
+                1, 1, 1,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("record: null kernel handle"),
             "got: {}",
             err_buf_as_str(&buf, len)
         );

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
@@ -1032,13 +1032,15 @@ impl VulkanComputeKernel {
                  this method must dispatch through the GpuContextFullAccessVTable. \
                  \
                  Read docs/architecture/cdylib-reachability.md before workarounds. \
-                 If you reached here via SimpleEncoder / SimpleDecoder / similar \
-                 engine SDK code calling a `pub(crate)` ComputeKernel method that \
-                 takes raw vk::* args (set_sampled_image_view, set_storage_image_view, \
-                 record), this is #1073's class — none of the existing patterns \
-                 directly cover it. New design needed (escalate the SDK boundary, \
-                 OR build new ABI for raw vulkanalia handles, OR move the offending \
-                 engine code host-only)."
+                 The raw-vk::* methods (set_sampled_image_view, \
+                 set_combined_image_sampler_view, set_storage_image_view, \
+                 record) are mode-routed through the v5 \
+                 VulkanComputeKernelMethodsVTable slots; if you're reaching \
+                 host_inner() from one of those, the routing is broken — \
+                 check that host_callbacks() is installed and the methods \
+                 vtable pointer is non-null. Any other public method that \
+                 still routes through host_inner() in cdylib mode is a bug \
+                 — file a regression and route it through the methods vtable."
             );
         }
         unsafe { &*(self.handle as *const VulkanComputeKernelInner) }
@@ -1110,14 +1112,20 @@ impl VulkanComputeKernel {
     /// Bind a raw `vk::ImageView` to a [`ComputeBindingKind::SampledImage`]
     /// slot. See [`VulkanComputeKernelInner::set_sampled_image_view`].
     ///
-    /// Host-only: takes a raw `vk::ImageView` which cdylibs cannot construct
-    /// (no `vulkanalia` dep). Crate-private surface; engine-internal callers
-    /// only.
+    /// Crate-private surface; engine-internal callers only. Workspace
+    /// plugin cdylibs (h264 / h265 / camera) reach this via engine SDK
+    /// code (`RgbToNv12Converter::convert`) compiled into the cdylib;
+    /// the body is mode-routed through the v5 vtable slot so cdylib
+    /// dispatch avoids the `host_inner()` panic guard. The Python /
+    /// Deno consumer-rhi cdylibs don't link this code at all.
     pub(crate) fn set_sampled_image_view(
         &self,
         binding: u32,
         view: vk::ImageView,
     ) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_set_sampled_image_view_via_vtable(binding, view);
+        }
         self.host_inner().set_sampled_image_view(binding, view)
     }
 
@@ -1125,12 +1133,18 @@ impl VulkanComputeKernel {
     /// slot that was created with an immutable sampler. See
     /// [`VulkanComputeKernelInner::set_combined_image_sampler_view`].
     ///
-    /// Host-only; see [`Self::set_sampled_image_view`] for the rationale.
+    /// See [`Self::set_sampled_image_view`] for the cdylib-routing
+    /// rationale.
     pub(crate) fn set_combined_image_sampler_view(
         &self,
         binding: u32,
         view: vk::ImageView,
     ) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_set_combined_image_sampler_view_via_vtable(
+                binding, view,
+            );
+        }
         self.host_inner()
             .set_combined_image_sampler_view(binding, view)
     }
@@ -1138,12 +1152,16 @@ impl VulkanComputeKernel {
     /// Bind a raw `vk::ImageView` to a [`ComputeBindingKind::StorageImage`]
     /// slot. See [`VulkanComputeKernelInner::set_storage_image_view`].
     ///
-    /// Host-only; see [`Self::set_sampled_image_view`] for the rationale.
+    /// See [`Self::set_sampled_image_view`] for the cdylib-routing
+    /// rationale.
     pub(crate) fn set_storage_image_view(
         &self,
         binding: u32,
         view: vk::ImageView,
     ) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_set_storage_image_view_via_vtable(binding, view);
+        }
         self.host_inner().set_storage_image_view(binding, view)
     }
 
@@ -1417,10 +1435,163 @@ impl VulkanComputeKernel {
         }
     }
 
+    // ---- v5 raw-vulkanalia-handle dispatch helpers (#1073) ------------------
+    //
+    // Each helper takes the typed `vk::ImageView` / `vk::CommandBuffer`
+    // the cdylib-side engine SDK code is already holding, extracts the
+    // raw integer via vulkanalia's `Handle::as_raw`, and dispatches
+    // through the v5 vtable slot. The host's callback reconstructs the
+    // typed handle via `Handle::from_raw` before forwarding to
+    // `host_inner()`.
+
+    #[cfg(target_os = "linux")]
+    fn dispatch_set_sampled_image_view_via_vtable(
+        &self,
+        binding: u32,
+        view: vk::ImageView,
+    ) -> Result<()> {
+        use vulkanalia::vk::Handle;
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "set_sampled_image_view: kernel methods vtable is null".into(),
+            ));
+        }
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).set_sampled_image_view)(
+                self.handle,
+                binding,
+                view.as_raw(),
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn dispatch_set_combined_image_sampler_view_via_vtable(
+        &self,
+        binding: u32,
+        view: vk::ImageView,
+    ) -> Result<()> {
+        use vulkanalia::vk::Handle;
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "set_combined_image_sampler_view: kernel methods vtable is null"
+                    .into(),
+            ));
+        }
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).set_combined_image_sampler_view)(
+                self.handle,
+                binding,
+                view.as_raw(),
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn dispatch_set_storage_image_view_via_vtable(
+        &self,
+        binding: u32,
+        view: vk::ImageView,
+    ) -> Result<()> {
+        use vulkanalia::vk::Handle;
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "set_storage_image_view: kernel methods vtable is null".into(),
+            ));
+        }
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).set_storage_image_view)(
+                self.handle,
+                binding,
+                view.as_raw(),
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn dispatch_record_via_vtable(
+        &self,
+        command_buffer: vk::CommandBuffer,
+        group_x: u32,
+        group_y: u32,
+        group_z: u32,
+    ) -> Result<()> {
+        use vulkanalia::vk::Handle;
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "record: kernel methods vtable is null".into(),
+            ));
+        }
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        // vulkanalia's CommandBuffer is `#[repr(transparent)] pub struct
+        // CommandBuffer(usize)`; `as_raw()` returns `usize` which casts
+        // losslessly to `u64` on every supported target.
+        let cb_raw: u64 = command_buffer.as_raw() as u64;
+        let status = unsafe {
+            ((*self.methods_vtable).record)(
+                self.handle,
+                cb_raw,
+                group_x,
+                group_y,
+                group_z,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
     /// Record bind + push-constants + dispatch into a caller-owned
-    /// command buffer. Host-only: takes a raw `vk::CommandBuffer`
-    /// which cdylibs cannot construct (no `vulkanalia` dep). Crate-
-    /// private surface; engine-internal callers only.
+    /// command buffer. Crate-private surface; engine-internal callers
+    /// only. See [`Self::set_sampled_image_view`] for the cdylib-
+    /// routing rationale — engine SDK code
+    /// (`RgbToNv12Converter::convert`, `Nv12ToRgbConverter::convert`)
+    /// compiled into workspace plugin cdylibs reaches this via the v5
+    /// vtable slot.
     pub(crate) fn record(
         &self,
         command_buffer: vk::CommandBuffer,
@@ -1428,6 +1599,11 @@ impl VulkanComputeKernel {
         group_y: u32,
         group_z: u32,
     ) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_record_via_vtable(
+                command_buffer, group_x, group_y, group_z,
+            );
+        }
         self.host_inner().record(command_buffer, group_x, group_y, group_z)
     }
 

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
@@ -643,6 +643,60 @@ impl VulkanComputeKernelInner {
         )
     }
 
+    // ---- Raw-handle entry points for the v5 cdylib vtable callbacks --------
+    //
+    // The four `*_raw` methods exist so the host-services callback layer
+    // (`core/plugin/host_services.rs`) can dispatch to the kernel without
+    // importing `vulkanalia` itself — that file isn't on the RHI vulkanalia
+    // allowlist by design (per `xtask check-boundaries`). Each shim
+    // reconstructs the typed vulkanalia handle via `Handle::from_raw` and
+    // forwards to the corresponding typed method above.
+
+    pub(crate) fn set_sampled_image_view_raw(
+        &self,
+        binding: u32,
+        image_view_handle: u64,
+    ) -> Result<()> {
+        use vulkanalia::vk::Handle;
+        self.set_sampled_image_view(binding, vk::ImageView::from_raw(image_view_handle))
+    }
+
+    pub(crate) fn set_combined_image_sampler_view_raw(
+        &self,
+        binding: u32,
+        image_view_handle: u64,
+    ) -> Result<()> {
+        use vulkanalia::vk::Handle;
+        self.set_combined_image_sampler_view(
+            binding,
+            vk::ImageView::from_raw(image_view_handle),
+        )
+    }
+
+    pub(crate) fn set_storage_image_view_raw(
+        &self,
+        binding: u32,
+        image_view_handle: u64,
+    ) -> Result<()> {
+        use vulkanalia::vk::Handle;
+        self.set_storage_image_view(binding, vk::ImageView::from_raw(image_view_handle))
+    }
+
+    pub(crate) fn record_raw(
+        &self,
+        command_buffer_handle: u64,
+        group_count_x: u32,
+        group_count_y: u32,
+        group_count_z: u32,
+    ) -> Result<()> {
+        use vulkanalia::vk::Handle;
+        // vulkanalia's CommandBuffer wraps a `usize`; on every supported
+        // target `usize == u64`, so the cast is lossless. The wire form
+        // is `u64` for ABI uniformity with the image-view slots.
+        let cb = vk::CommandBuffer::from_raw(command_buffer_handle as usize);
+        self.record(cb, group_count_x, group_count_y, group_count_z)
+    }
+
     fn drain_and_validate_pending(&self) -> Result<PendingState> {
         let pending = {
             let mut guard = self.pending.lock();

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -390,7 +390,19 @@ pub const TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION: u32 = 2;
 ///   in `out_specs_len`; callers reallocate and retry. Replaces the
 ///   β-shape's bare `host_inner().bindings()` call which panicked
 ///   from cdylib code.
-pub const VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 4;
+///
+/// - v5: appended four raw-vulkanalia-handle slots —
+///   `set_sampled_image_view`, `set_combined_image_sampler_view`,
+///   `set_storage_image_view`, `record`. Each carries the raw
+///   `vk::ImageView` / `vk::CommandBuffer` handle as a `u64`
+///   (vulkanalia's handles are `#[repr(transparent)] pub struct
+///   ImageView(u64)` / `CommandBuffer(usize)`, so the wire form is the
+///   raw integer the host reconstructs via `Handle::from_raw`).
+///   Replaces the β-shape's bare `host_inner().set_*_view(...)` /
+///   `host_inner().record(...)` calls that engine SDK code
+///   (`RgbToNv12Converter::convert`, `Nv12ToRgbConverter::convert`)
+///   reaches per-frame from cdylib-resident processor bodies (#1073).
+pub const VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 5;
 
 /// Layout version of [`VulkanGraphicsKernelMethodsVTable`].
 ///
@@ -3214,17 +3226,18 @@ unsafe impl Sync for TextureRingMethodsVTable {}
 /// **RHI Buffer Model Alignment** milestone and would simplify this
 /// vtable further; until then, per-type slots are the right shape.
 ///
-/// **Coverage today** (v3): `set_push_constants`, `dispatch`,
-/// `set_storage_buffer_pixel(&PixelBuffer)`,
-/// `set_storage_buffer_storage(&StorageBuffer)`,
-/// `set_uniform_buffer(&UniformBuffer)`,
-/// `set_sampled_texture(&Texture)`,
-/// `set_storage_image(&Texture)`.
-///
-/// The engine-only methods (`record(cmd_buf)`,
-/// `set_*_image_view(vk::ImageView)`, `bindings() -> Vec<ComputeBindingSpec>`)
-/// stay `host_inner`-routed — their parameter / return types are
-/// host-internal vulkanalia or allocator-crossing.
+/// **Coverage today** (v5): all v3 binding-method slots
+/// (`set_push_constants`, `dispatch`, `set_storage_buffer_pixel`,
+/// `set_storage_buffer_storage`, `set_uniform_buffer`,
+/// `set_sampled_texture`, `set_storage_image`), v4's `bindings`
+/// introspection slot, plus v5's four raw-vulkanalia-handle slots
+/// (`set_sampled_image_view`, `set_combined_image_sampler_view`,
+/// `set_storage_image_view`, `record`). The image-view-by-handle
+/// trio carries `vk::ImageView` as `u64`; the `record` slot carries
+/// `vk::CommandBuffer` as `u64`. Vulkanalia handles are
+/// `#[repr(transparent)]` wrappers over their raw `u64`/`usize`
+/// integer, so the wire form is the raw integer and the host
+/// reconstructs via `Handle::from_raw` before forwarding.
 #[repr(C)]
 pub struct VulkanComputeKernelMethodsVTable {
     /// Vtable layout version. Must equal
@@ -3341,6 +3354,66 @@ pub struct VulkanComputeKernelMethodsVTable {
         out_specs_buf: *mut ComputeBindingSpecRepr,
         out_specs_cap: usize,
         out_specs_len: *mut usize,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Bind a raw `vk::ImageView` to a sampled-image binding.
+    /// `image_view_handle` is the raw `u64` from
+    /// `vk::ImageView::as_raw()`; the host wrapper reconstructs the
+    /// vulkanalia handle via `vk::ImageView::from_raw` before
+    /// forwarding. Returns 0 on success; non-zero with UTF-8 message
+    /// in `err_buf` on declaration mismatch / null handle / unset
+    /// binding. v5.
+    pub set_sampled_image_view: unsafe extern "C" fn(
+        kernel_handle: *const c_void,
+        binding: u32,
+        image_view_handle: u64,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Bind a raw `vk::ImageView` to a sampled-texture binding that
+    /// was declared with an immutable sampler (combined-image-sampler
+    /// shape, view-only write). v5. Same `u64`-handle wire shape as
+    /// [`Self::set_sampled_image_view`].
+    pub set_combined_image_sampler_view: unsafe extern "C" fn(
+        kernel_handle: *const c_void,
+        binding: u32,
+        image_view_handle: u64,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Bind a raw `vk::ImageView` to a storage-image binding. v5.
+    /// Same `u64`-handle wire shape as [`Self::set_sampled_image_view`].
+    pub set_storage_image_view: unsafe extern "C" fn(
+        kernel_handle: *const c_void,
+        binding: u32,
+        image_view_handle: u64,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Record bind + push-constants + dispatch into a caller-owned
+    /// command buffer. `command_buffer_handle` is the raw `u64` from
+    /// `vk::CommandBuffer::as_raw() as u64` (vulkanalia stores the
+    /// dispatchable handle as `usize`; on every supported target
+    /// `usize == u64`). The host wrapper reconstructs the vulkanalia
+    /// handle via `vk::CommandBuffer::from_raw(handle as usize)`
+    /// before forwarding. Returns 0 on success; non-zero with UTF-8
+    /// message in `err_buf` for null kernel handle / dispatch error.
+    /// v5.
+    pub record: unsafe extern "C" fn(
+        kernel_handle: *const c_void,
+        command_buffer_handle: u64,
+        group_x: u32,
+        group_y: u32,
+        group_z: u32,
         err_buf: *mut u8,
         err_buf_cap: usize,
         err_len: *mut usize,
@@ -5372,7 +5445,7 @@ mod layout_tests {
         assert_eq!(SURFACE_STORE_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 10);
         assert_eq!(TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION, 2);
-        assert_eq!(VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 4);
+        assert_eq!(VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 5);
         assert_eq!(VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 3);
         assert_eq!(VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 3);
         assert_eq!(VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION, 2);
@@ -5509,19 +5582,23 @@ mod layout_tests {
 
     #[test]
     fn vulkan_compute_kernel_methods_vtable_layout() {
-        // v4 (bindings introspection slot added):
-        //   layout_version              @ 0   (4 bytes, u32)
-        //   _reserved_padding           @ 4   (4 bytes, u32)
-        //   set_push_constants          @ 8   (8 bytes, fn pointer)
-        //   dispatch                    @ 16
-        //   set_storage_buffer_pixel    @ 24
-        //   set_storage_buffer_storage  @ 32
-        //   set_uniform_buffer          @ 40
-        //   set_sampled_texture         @ 48
-        //   set_storage_image           @ 56
-        //   bindings                    @ 64
-        // Total = 72 bytes, align = 8.
-        assert_eq!(size_of::<VulkanComputeKernelMethodsVTable>(), 72);
+        // v5 (raw-vulkanalia-handle slots appended for #1073):
+        //   layout_version                    @ 0   (4 bytes, u32)
+        //   _reserved_padding                 @ 4   (4 bytes, u32)
+        //   set_push_constants                @ 8   (8 bytes, fn pointer)
+        //   dispatch                          @ 16
+        //   set_storage_buffer_pixel          @ 24
+        //   set_storage_buffer_storage        @ 32
+        //   set_uniform_buffer                @ 40
+        //   set_sampled_texture               @ 48
+        //   set_storage_image                 @ 56
+        //   bindings                          @ 64
+        //   set_sampled_image_view            @ 72   (v5)
+        //   set_combined_image_sampler_view   @ 80   (v5)
+        //   set_storage_image_view            @ 88   (v5)
+        //   record                            @ 96   (v5)
+        // Total = 104 bytes, align = 8.
+        assert_eq!(size_of::<VulkanComputeKernelMethodsVTable>(), 104);
         assert_eq!(align_of::<VulkanComputeKernelMethodsVTable>(), 8);
         assert_eq!(
             offset_of!(VulkanComputeKernelMethodsVTable, layout_version),
@@ -5562,6 +5639,22 @@ mod layout_tests {
         assert_eq!(
             offset_of!(VulkanComputeKernelMethodsVTable, bindings),
             64
+        );
+        assert_eq!(
+            offset_of!(VulkanComputeKernelMethodsVTable, set_sampled_image_view),
+            72
+        );
+        assert_eq!(
+            offset_of!(VulkanComputeKernelMethodsVTable, set_combined_image_sampler_view),
+            80
+        );
+        assert_eq!(
+            offset_of!(VulkanComputeKernelMethodsVTable, set_storage_image_view),
+            88
+        );
+        assert_eq!(
+            offset_of!(VulkanComputeKernelMethodsVTable, record),
+            96
         );
     }
 


### PR DESCRIPTION
Closes #1073.

## Summary

- Adds 4 slots to `VulkanComputeKernelMethodsVTable` (v4 → v5): `set_sampled_image_view`, `set_combined_image_sampler_view`, `set_storage_image_view`, `record`. Each carries the raw vulkanalia handle as a `u64` wire value (`vk::ImageView` is `#[repr(transparent)] pub struct ImageView(u64)`; `vk::CommandBuffer` is `#[repr(transparent)] pub struct CommandBuffer(usize)`). The host wrapper reconstructs the typed handle via `Handle::from_raw` before forwarding to `host_inner()`.
- Mode-routes the four `pub(crate)` methods on `VulkanComputeKernel` through `host_callbacks().is_some()` so engine SDK code (`RgbToNv12Converter::convert`, `Nv12ToRgbConverter::convert`) compiled into workspace plugin cdylibs (h264 / h265 / camera) reaches them via the v5 vtable instead of tripping the `host_inner() reached from cdylib code` panic guard.
- Codifies this in `docs/architecture/cdylib-reachability.md` as the canonical **Pattern 5** (per-method vtable slot carrying a raw vulkanalia handle). Anti-pattern #5 and the runtime panic message are updated accordingly.
- `Handle::from_raw` reconstruction lives on four `*_raw` shim methods on `VulkanComputeKernelInner` (inside `vulkan/rhi/`, the allowlist) so `core/plugin/host_services.rs` doesn't import vulkanalia and doesn't need a new `xtask check-boundaries` allowlist entry.

## Why per-method vtable, not escalate-at-SDK-boundary

Per the issue body's Option A vs B vs C, escalate-at-SDK-boundary would add `vkDeviceWaitIdle` + escalate-gate mutex on every `encode_image` — exactly the per-frame cost `docs/architecture/texture-ring.md` documents as the anti-pattern the engine has been eliminating. Per-method vtable adds ~4 FFI hops per frame, zero GPU sync. Option B (the user-confirmed choice).

## E2E evidence

`cargo run --release -p vulkan-video-roundtrip-cdylib-camera -- h264 /dev/video0 10` against vivid:
- Before this PR: panic on every frame in `RgbToNv12Converter::convert`.
- After this PR: `frames_encoded=50`, **zero panics**, encoder runs end-to-end clean. Same for `h265`.

Decoder side surfaces a separate pre-existing engine-tier H.264 NAL session-config bug (decoder never sees a valid IDR-with-SPS+PPS, reports "Slice NAL received before session configured — skipping" every frame; **same symptom on the non-cdylib `vulkan-video-roundtrip` baseline**, so it's not cdylib-related). Filed as #1077 for separate triage.

## Test plan

- [x] `cargo test -p streamlib-plugin-abi --lib` — 53/53 passed including the v5 layout regression (`vulkan_compute_kernel_methods_vtable_layout` locks size = 104B with the four new offsets at 72/80/88/96; `host_services_layout_versions_pinned` bumped v4 → v5).
- [x] `cargo test -p streamlib-engine --lib` — 1395/1395 passed; 4 new tier-1 wire tests reject null kernel handles on each new slot (`set_sampled_image_view_rejects_null_kernel_handle`, `set_combined_image_sampler_view_rejects_null_kernel_handle`, `set_storage_image_view_rejects_null_kernel_handle`, `record_rejects_null_kernel_handle`).
- [x] `cargo test -p streamlib-engine --test load_project_dylib_vulkan_smoke` — 1/1 passed (dlopen smoke covers the cdylib mode-routing end-to-end, the project's canonical pattern for v3/v4 slot lock-in too).
- [x] `cargo xtask check-boundaries` — 4381 files scanned, 0 violations.
- [x] E2E: `vulkan-video-roundtrip-cdylib-camera -- h264 /dev/video0 10` — zero `host_inner()` panics, 50 frames encoded.
- [x] E2E: same for `h265` codec.
- [x] Sweep for other `crate-type = ["rlib", "cdylib"]` packages calling the four `pub(crate)` methods directly — only engine SDK code does (`rgb_to_nv12.rs`, `nv12_to_rgb.rs`, `vulkan_command_recorder.rs` — already mode-routed at a higher level). No downstream call sites to update.

## Issue-body fidelity

- [x] Exit criterion 1 — "Encoder cdylib `process()` completes `encode_image` end-to-end without panic on any frame": **met** (E2E above).
- [x] Exit criterion 3 — "No new latent `VulkanComputeKernel::host_inner()` reaches from cdylib-loadable code": **met** (sweep clean per Test plan).
- [ ] Exit criterion 2 — "Decoder cdylib `process()` completes `decode_frame` end-to-end without panic on any frame": **not exercised** because of the pre-existing #1077 session-config bug. No panic surfaces (the decoder polls and gets no data, then exits cleanly), so the panic-class criterion is vacuously satisfied; the meaningful end-to-end gate moves to #1077.

🤖 Generated with [Claude Code](https://claude.com/claude-code)