### PR TITLE
fix(1065): camera-python-display effects cdylib reachability — graphics-kernel v4 + recorder v5 slots + lint sweep

### DIFF
--- a/examples/camera-python-display/effects/src/blending_compositor_kernel.rs
+++ b/examples/camera-python-display/effects/src/blending_compositor_kernel.rs
@@ -328,6 +328,18 @@ impl SandboxedBlendingCompositor {
             // output → COLOR_ATTACHMENT_OPTIMAL. The placeholder is built
             // already in SHADER_READ_ONLY_OPTIMAL and stays there
             // forever, so it never needs a barrier.
+            //
+            // Each `Texture` is dereferenced through
+            // `HostTextureExt::host_vulkan_texture_arc()` (the v10
+            // FullAccess vtable slot) rather than `vulkan_inner()`:
+            // this kernel ships as a cdylib, where `vulkan_inner()`
+            // panics under the engine's `Texture::host_inner()`
+            // panic-guard. Same shape as the
+            // `packages/camera/src/camera_to_cuda_copy.rs` /
+            // `packages/h264/src/linux/encoder.rs` /
+            // `packages/h265/src/linux/encoder.rs` reaches; the
+            // `xtask check-cdylib-reach` lint enforces the rule.
+            let output_host_tex = inputs.output.texture.host_vulkan_texture_arc()?;
             let mut barriers: Vec<vk::ImageMemoryBarrier2> = Vec::with_capacity(5);
             for (layer, layout) in [
                 (inputs.video.map(|l| l.texture), vlayout),
@@ -339,12 +351,13 @@ impl SandboxedBlendingCompositor {
                 if layout == VulkanLayout::SHADER_READ_ONLY_OPTIMAL {
                     continue;
                 }
-                let image = tex.vulkan_inner().image().ok_or_else(|| {
+                let host_tex = tex.host_vulkan_texture_arc()?;
+                let image = host_tex.image().ok_or_else(|| {
                     Error::GpuError(format!("{}: input texture has no VkImage", self.label))
                 })?;
                 barriers.push(input_barrier_to_shader_read_only(image, layout.as_vk()));
             }
-            let output_image = inputs.output.texture.vulkan_inner().image().ok_or_else(|| {
+            let output_image = output_host_tex.image().ok_or_else(|| {
                 Error::GpuError(format!("{}: output texture has no VkImage", self.label))
             })?;
             barriers.push(output_barrier_to_color_attachment(
@@ -361,10 +374,7 @@ impl SandboxedBlendingCompositor {
             // already covered by the barrier above; LOAD is fine
             // because we draw a full-screen triangle that overwrites
             // every pixel.
-            let output_view = inputs
-                .output
-                .texture
-                .vulkan_inner()
+            let output_view = output_host_tex
                 .image_view()
                 .unwrap_or(vk::ImageView::null());
             let color_attachment = vk::RenderingAttachmentInfo::builder()

--- a/examples/camera-python-display/effects/src/crt_film_grain_kernel.rs
+++ b/examples/camera-python-display/effects/src/crt_film_grain_kernel.rs
@@ -268,9 +268,19 @@ impl SandboxedCrtFilmGrain {
 
             // Pre-render barriers: input → SHADER_READ_ONLY_OPTIMAL,
             // output → COLOR_ATTACHMENT_OPTIMAL.
+            //
+            // Each `Texture` is dereferenced through
+            // `HostTextureExt::host_vulkan_texture_arc()` (the v10
+            // FullAccess vtable slot) rather than `vulkan_inner()`:
+            // this kernel ships as a cdylib, where `vulkan_inner()`
+            // panics under the engine's `Texture::host_inner()`
+            // panic-guard. The `xtask check-cdylib-reach` lint
+            // enforces the rule.
+            let output_host_tex = inputs.output.texture.host_vulkan_texture_arc()?;
             let mut barriers: Vec<vk::ImageMemoryBarrier2> = Vec::with_capacity(2);
             if inputs.input.current_layout != VulkanLayout::SHADER_READ_ONLY_OPTIMAL {
-                let input_image = inputs.input.texture.vulkan_inner().image().ok_or_else(|| {
+                let input_host_tex = inputs.input.texture.host_vulkan_texture_arc()?;
+                let input_image = input_host_tex.image().ok_or_else(|| {
                     Error::GpuError(format!("{}: input texture has no VkImage", self.label))
                 })?;
                 barriers.push(input_barrier_to_shader_read_only(
@@ -278,7 +288,7 @@ impl SandboxedCrtFilmGrain {
                     inputs.input.current_layout.as_vk(),
                 ));
             }
-            let output_image = inputs.output.texture.vulkan_inner().image().ok_or_else(|| {
+            let output_image = output_host_tex.image().ok_or_else(|| {
                 Error::GpuError(format!("{}: output texture has no VkImage", self.label))
             })?;
             barriers.push(output_barrier_to_color_attachment(
@@ -293,10 +303,7 @@ impl SandboxedCrtFilmGrain {
             // Begin dynamic rendering with the output as the sole color
             // attachment. The full-screen triangle covers every pixel,
             // so DONT_CARE on load is fine.
-            let output_view = inputs
-                .output
-                .texture
-                .vulkan_inner()
+            let output_view = output_host_tex
                 .image_view()
                 .unwrap_or(vk::ImageView::null());
             let color_attachment = vk::RenderingAttachmentInfo::builder()

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -10092,26 +10092,6 @@ unsafe extern "C" fn host_graphics_kernel_offscreen_render(
     1
 }
 
-/// Host-side `VulkanGraphicsKernelMethodsVTable` populated with the
-/// v2 method slots (typed binding-method dispatch for the plugin
-/// handle's `set_storage_buffer_pixel` / `set_storage_buffer_storage`
-/// / `set_uniform_buffer` / `set_sampled_texture` /
-/// `set_storage_image` / `set_vertex_buffer` / `set_index_buffer` /
-/// `set_push_constants` / `offscreen_render` surface).
-///
-/// Raw-vulkanalia-handle slots `cmd_bind_and_draw` /
-/// `cmd_bind_and_draw_indexed` (v4) live below alongside the
-/// `bindings` v3 slot — they unblock cdylib graphics consumers
-/// that mint and manage their own `vk::CommandBuffer` (the
-/// `camera-python-display-effects` kernel wrappers, plus future
-/// pre-RDG cdylib pass authors per #1081). The wire shape mirrors
-/// the `VulkanComputeKernelMethodsVTable` v5 `record` slot:
-/// `command_buffer_handle: u64` carries `vk::CommandBuffer`'s
-/// `repr(transparent)` `usize` payload (lossless on 64-bit Linux,
-/// the only platform that ships); the draw call travels as the
-/// existing `DrawCallRepr` / `DrawIndexedCallRepr` shapes already
-/// wired for `offscreen_render`.
-///
 /// Read the graphics kernel's declared bindings into a caller-provided
 /// `[GraphicsBindingSpecRepr]` buffer. v3 (introspection).
 #[cfg(target_os = "linux")]
@@ -13045,9 +13025,10 @@ unsafe extern "C" fn host_command_recorder_record_draw_indexed(
 
 /// v5 — bare submit. Sibling of v1 `submit_signaling_timeline`
 /// without the timeline-semaphore parameters; used by
-/// `RhiToneMapper::apply_with_layouts`'s private recorder
-/// (the first in-tree cdylib consumer of this slot via the
-/// camera-python-display-effects path, #1065).
+/// `RhiToneMapper::apply_with_layouts`'s private recorder when
+/// reached from cdylib-resident processor code (the per-input
+/// tone-mapping normalization step in graphics-kernel wrappers
+/// is the first in-tree consumer).
 #[cfg(target_os = "linux")]
 unsafe extern "C" fn host_command_recorder_submit(
     recorder_handle: *const c_void,
@@ -13149,9 +13130,10 @@ unsafe extern "C" fn host_command_recorder_submit_and_wait(
 }
 
 /// Host-side `RhiCommandRecorderMethodsVTable` wired to the
-/// per-method wrappers above (Phase E sub-lift slice B — #984;
-/// v3 swapchain render-path slots — #1066; v5 bare-submit slots
-/// for `RhiToneMapper` cdylib consumers — #1065).
+/// per-method wrappers above. Covers the v1 record-then-submit
+/// slots, the v3 swapchain render-path slots used by the cdylib
+/// display, and the v5 bare-submit slots used by `RhiToneMapper`
+/// when reached from cdylib-resident processor code.
 pub static HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE:
     streamlib_plugin_abi::RhiCommandRecorderMethodsVTable =
     streamlib_plugin_abi::RhiCommandRecorderMethodsVTable {

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -10099,11 +10099,19 @@ unsafe extern "C" fn host_graphics_kernel_offscreen_render(
 /// `set_storage_image` / `set_vertex_buffer` / `set_index_buffer` /
 /// `set_push_constants` / `offscreen_render` surface).
 ///
-/// Engine-only methods that take a raw `vk::CommandBuffer`
-/// (`cmd_bind_and_draw` / `cmd_bind_and_draw_indexed`) stay
-/// `host_inner`-routed and are NOT on this vtable — minting a
-/// `vk::CommandBuffer` from cdylib code requires an
-/// `RhiCommandRecorder` β-shape, which is a separate concern.
+/// Raw-vulkanalia-handle slots `cmd_bind_and_draw` /
+/// `cmd_bind_and_draw_indexed` (v4) live below alongside the
+/// `bindings` v3 slot — they unblock cdylib graphics consumers
+/// that mint and manage their own `vk::CommandBuffer` (the
+/// `camera-python-display-effects` kernel wrappers, plus future
+/// pre-RDG cdylib pass authors per #1081). The wire shape mirrors
+/// the `VulkanComputeKernelMethodsVTable` v5 `record` slot:
+/// `command_buffer_handle: u64` carries `vk::CommandBuffer`'s
+/// `repr(transparent)` `usize` payload (lossless on 64-bit Linux,
+/// the only platform that ships); the draw call travels as the
+/// existing `DrawCallRepr` / `DrawIndexedCallRepr` shapes already
+/// wired for `offscreen_render`.
+///
 /// Read the graphics kernel's declared bindings into a caller-provided
 /// `[GraphicsBindingSpecRepr]` buffer. v3 (introspection).
 #[cfg(target_os = "linux")]
@@ -10184,6 +10192,161 @@ unsafe extern "C" fn host_graphics_kernel_bindings(
     1
 }
 
+/// v4 — record bind + push + draw into a caller-owned
+/// `vk::CommandBuffer`. The cdylib mints + manages the command
+/// buffer; this callback reconstructs the handle and forwards to
+/// `VulkanGraphicsKernelInner::cmd_bind_and_draw_raw`, which does
+/// the `vk::CommandBuffer::from_raw` conversion under the engine's
+/// canonical vulkanalia-allowlist scope.
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_graphics_kernel_cmd_bind_and_draw(
+    kernel_handle: *const c_void,
+    command_buffer_handle: u64,
+    frame_index: u32,
+    draw: *const streamlib_plugin_abi::DrawCallRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_graphics_kernel_cmd_bind_and_draw",
+        || -> i32 {
+            let Some(kernel) = (unsafe { handle_as_graphics_kernel(kernel_handle) })
+            else {
+                write_err(
+                    "cmd_bind_and_draw: null kernel handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if draw.is_null() {
+                write_err(
+                    "cmd_bind_and_draw: null draw pointer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let draw_repr = unsafe { &*draw };
+            let inner_draw = draw_call_from_repr(draw_repr);
+            match kernel.cmd_bind_and_draw_raw(
+                command_buffer_handle,
+                frame_index,
+                &inner_draw,
+            ) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("cmd_bind_and_draw: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_graphics_kernel_cmd_bind_and_draw(
+    _kernel_handle: *const c_void,
+    _command_buffer_handle: u64,
+    _frame_index: u32,
+    _draw: *const streamlib_plugin_abi::DrawCallRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "cmd_bind_and_draw: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+/// v4 — indexed variant of [`host_graphics_kernel_cmd_bind_and_draw`].
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_graphics_kernel_cmd_bind_and_draw_indexed(
+    kernel_handle: *const c_void,
+    command_buffer_handle: u64,
+    frame_index: u32,
+    draw: *const streamlib_plugin_abi::DrawIndexedCallRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_graphics_kernel_cmd_bind_and_draw_indexed",
+        || -> i32 {
+            let Some(kernel) = (unsafe { handle_as_graphics_kernel(kernel_handle) })
+            else {
+                write_err(
+                    "cmd_bind_and_draw_indexed: null kernel handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if draw.is_null() {
+                write_err(
+                    "cmd_bind_and_draw_indexed: null draw pointer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let draw_repr = unsafe { &*draw };
+            let inner_draw = draw_indexed_call_from_repr(draw_repr);
+            match kernel.cmd_bind_and_draw_indexed_raw(
+                command_buffer_handle,
+                frame_index,
+                &inner_draw,
+            ) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("cmd_bind_and_draw_indexed: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_graphics_kernel_cmd_bind_and_draw_indexed(
+    _kernel_handle: *const c_void,
+    _command_buffer_handle: u64,
+    _frame_index: u32,
+    _draw: *const streamlib_plugin_abi::DrawIndexedCallRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "cmd_bind_and_draw_indexed: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
 pub static HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE:
     streamlib_plugin_abi::VulkanGraphicsKernelMethodsVTable =
     streamlib_plugin_abi::VulkanGraphicsKernelMethodsVTable {
@@ -10200,6 +10363,8 @@ pub static HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE:
         set_push_constants: host_graphics_kernel_set_push_constants,
         offscreen_render: host_graphics_kernel_offscreen_render,
         bindings: host_graphics_kernel_bindings,
+        cmd_bind_and_draw: host_graphics_kernel_cmd_bind_and_draw,
+        cmd_bind_and_draw_indexed: host_graphics_kernel_cmd_bind_and_draw_indexed,
     };
 
 /// Accessor for the host's static `VulkanGraphicsKernelMethodsVTable`
@@ -12878,9 +13043,115 @@ unsafe extern "C" fn host_command_recorder_record_draw_indexed(
     1
 }
 
+/// v5 — bare submit. Sibling of v1 `submit_signaling_timeline`
+/// without the timeline-semaphore parameters; used by
+/// `RhiToneMapper::apply_with_layouts`'s private recorder
+/// (the first in-tree cdylib consumer of this slot via the
+/// camera-python-display-effects path, #1065).
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_command_recorder_submit(
+    recorder_handle: *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_command_recorder_submit",
+        || -> i32 {
+            let Some(recorder) =
+                (unsafe { handle_as_command_recorder_mut(recorder_handle) })
+            else {
+                write_err(
+                    "submit: null recorder handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            match recorder.submit() {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(&format!("submit: {e}"), err_buf, err_buf_cap, err_len);
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_command_recorder_submit(
+    _recorder_handle: *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err("submit: Linux-only", err_buf, err_buf_cap, err_len);
+    1
+}
+
+/// v5 — submit and block. Sibling of [`host_command_recorder_submit`];
+/// caller-side `vkWaitForFences` after submit.
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_command_recorder_submit_and_wait(
+    recorder_handle: *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_command_recorder_submit_and_wait",
+        || -> i32 {
+            let Some(recorder) =
+                (unsafe { handle_as_command_recorder_mut(recorder_handle) })
+            else {
+                write_err(
+                    "submit_and_wait: null recorder handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            match recorder.submit_and_wait() {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("submit_and_wait: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_command_recorder_submit_and_wait(
+    _recorder_handle: *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "submit_and_wait: Linux-only",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
 /// Host-side `RhiCommandRecorderMethodsVTable` wired to the
 /// per-method wrappers above (Phase E sub-lift slice B — #984;
-/// v3 swapchain render-path slots — #1066).
+/// v3 swapchain render-path slots — #1066; v5 bare-submit slots
+/// for `RhiToneMapper` cdylib consumers — #1065).
 pub static HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE:
     streamlib_plugin_abi::RhiCommandRecorderMethodsVTable =
     streamlib_plugin_abi::RhiCommandRecorderMethodsVTable {
@@ -12908,6 +13179,8 @@ pub static HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE:
         submit_with_semaphores: host_command_recorder_submit_with_semaphores,
         record_draw: host_command_recorder_record_draw,
         record_draw_indexed: host_command_recorder_record_draw_indexed,
+        submit: host_command_recorder_submit,
+        submit_and_wait: host_command_recorder_submit_and_wait,
     };
 
 /// Accessor for the host's static `RhiCommandRecorderMethodsVTable`
@@ -14428,6 +14701,47 @@ mod gpu_rhi_command_recorder_methods_vtable_null_tests {
         );
     }
 
+    // v5 — submit / submit_and_wait wrappers.
+
+    #[test]
+    fn submit_rejects_null_recorder_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE.submit)(
+                std::ptr::null(),
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len).contains("submit: null recorder handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    fn submit_and_wait_rejects_null_recorder_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE.submit_and_wait)(
+                std::ptr::null(),
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("submit_and_wait: null recorder handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
     #[test]
     fn record_pixel_buffer_barrier_rejects_null_recorder_handle() {
         let (mut buf, mut len) = make_err_buf();
@@ -14717,6 +15031,58 @@ mod graphics_kernel_methods_vtable_null_tests {
             err_buf_as_str(&buf, len)
         );
     }
+
+    // v4 — cmd_bind_and_draw / cmd_bind_and_draw_indexed wrappers.
+
+    #[test]
+    fn cmd_bind_and_draw_rejects_null_kernel_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let draw: streamlib_plugin_abi::DrawCallRepr = unsafe { std::mem::zeroed() };
+        let rc = unsafe {
+            (HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE.cmd_bind_and_draw)(
+                std::ptr::null(),
+                0,
+                0,
+                &draw,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("cmd_bind_and_draw: null kernel handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    fn cmd_bind_and_draw_indexed_rejects_null_kernel_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let draw: streamlib_plugin_abi::DrawIndexedCallRepr =
+            unsafe { std::mem::zeroed() };
+        let rc = unsafe {
+            (HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE.cmd_bind_and_draw_indexed)(
+                std::ptr::null(),
+                0,
+                0,
+                &draw,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("cmd_bind_and_draw_indexed: null kernel handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
 }
 
 #[cfg(all(test, target_os = "linux"))]

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
@@ -1534,8 +1534,7 @@ impl RhiCommandRecorder {
     /// cdylib callers dispatch through the v5 `submit_and_wait` slot
     /// on [`RhiCommandRecorderMethodsVTable`](streamlib_plugin_abi::RhiCommandRecorderMethodsVTable).
     /// `RhiToneMapper::apply_with_layouts` is the first in-tree
-    /// cdylib consumer (reached from camera-python-display-effects'
-    /// `BlendingCompositor::normalize_layer` path, #1065).
+    /// cdylib consumer.
     pub fn submit_and_wait(&mut self) -> Result<()> {
         if crate::core::plugin::host_services::host_callbacks().is_some() {
             return self.dispatch_submit_and_wait_via_vtable();

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
@@ -1464,13 +1464,82 @@ impl RhiCommandRecorder {
         }
     }
 
+    /// Cdylib-side dispatch helper for the v5 `submit` slot.
+    fn dispatch_submit_via_vtable(&self) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "submit: command recorder methods vtable is null".into(),
+            ));
+        }
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).submit)(
+                self.handle,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    /// Cdylib-side dispatch helper for the v5 `submit_and_wait` slot.
+    fn dispatch_submit_and_wait_via_vtable(&self) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "submit_and_wait: command recorder methods vtable is null".into(),
+            ));
+        }
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).submit_and_wait)(
+                self.handle,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
     /// Submit without semaphore signaling.
+    ///
+    /// Mode-routed: host callers dispatch through `host_inner_mut`;
+    /// cdylib callers dispatch through the v5 `submit` slot on
+    /// [`RhiCommandRecorderMethodsVTable`](streamlib_plugin_abi::RhiCommandRecorderMethodsVTable).
     pub fn submit(&mut self) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_submit_via_vtable();
+        }
         self.host_inner_mut().submit()
     }
 
     /// Submit and block until the GPU completes.
+    ///
+    /// Mode-routed: host callers dispatch through `host_inner_mut`;
+    /// cdylib callers dispatch through the v5 `submit_and_wait` slot
+    /// on [`RhiCommandRecorderMethodsVTable`](streamlib_plugin_abi::RhiCommandRecorderMethodsVTable).
+    /// `RhiToneMapper::apply_with_layouts` is the first in-tree
+    /// cdylib consumer (reached from camera-python-display-effects'
+    /// `BlendingCompositor::normalize_layer` path, #1065).
     pub fn submit_and_wait(&mut self) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_submit_and_wait_via_vtable();
+        }
         self.host_inner_mut().submit_and_wait()
     }
 

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_graphics_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_graphics_kernel.rs
@@ -543,14 +543,46 @@ impl VulkanGraphicsKernelInner {
         self.cmd_bind_and_draw_inner(command_buffer, frame_index, DrawKind::Draw(*draw))
     }
 
+    /// Cdylib-side shim — reconstruct the `vk::CommandBuffer` handle
+    /// the cdylib minted (via its own vulkanalia link, gated by
+    /// `xtask check-boundaries`) from the u64 wire form and forward
+    /// to [`Self::cmd_bind_and_draw`]. Owned here so this file is
+    /// the canonical site of the `vk::CommandBuffer::from_raw`
+    /// reconstruction and the host-services file (which is off the
+    /// `vulkanalia` allowlist) doesn't have to touch the type
+    /// directly. Mirrors `VulkanComputeKernelInner::record_raw`.
+    pub(crate) fn cmd_bind_and_draw_raw(
+        &self,
+        command_buffer_handle: u64,
+        frame_index: u32,
+        draw: &DrawCall,
+    ) -> Result<()> {
+        use vulkanalia::vk::Handle;
+        // vulkanalia's CommandBuffer wraps a `usize`; on every supported
+        // target `usize == u64`, so the cast is lossless. The wire form
+        // is `u64` for ABI uniformity with the compute kernel's
+        // v5 `record` slot.
+        let cb = vk::CommandBuffer::from_raw(command_buffer_handle as usize);
+        self.cmd_bind_and_draw(cb, frame_index, draw)
+    }
+
+    /// Cdylib-side shim for [`Self::cmd_bind_and_draw_indexed`].
+    /// Same reconstruction contract as
+    /// [`Self::cmd_bind_and_draw_raw`].
+    pub(crate) fn cmd_bind_and_draw_indexed_raw(
+        &self,
+        command_buffer_handle: u64,
+        frame_index: u32,
+        draw: &DrawIndexedCall,
+    ) -> Result<()> {
+        use vulkanalia::vk::Handle;
+        let cb = vk::CommandBuffer::from_raw(command_buffer_handle as usize);
+        self.cmd_bind_and_draw_indexed(cb, frame_index, draw)
+    }
+
     /// Indexed variant of [`Self::cmd_bind_and_draw`] (same drain-on-draw
     /// contract). Caller must have set an index buffer for `frame_index`
     /// via [`Self::set_index_buffer`].
-    ///
-    /// Crate-private: takes a raw `vk::CommandBuffer` which cdylibs cannot
-    /// construct (no `vulkanalia` dep). No out-of-engine consumers today;
-    /// host examples drive indexed draws through
-    /// [`RhiCommandRecorder::record_dispatch`]-style helpers instead.
     pub(crate) fn cmd_bind_and_draw_indexed(
         &self,
         command_buffer: vk::CommandBuffer,
@@ -1561,28 +1593,46 @@ impl VulkanGraphicsKernel {
             .set_index_buffer(frame_index, buffer, offset, index_type)
     }
 
-    /// Record bind + push + draw into `command_buffer`. Engine-only
-    /// — accepts a raw `vk::CommandBuffer` from a caller-managed
-    /// render-pass scope, which cdylib code cannot mint without an
-    /// `RhiCommandRecorder` β-shape (a separate concern). The
-    /// `host_inner()` reach-through panics if called from a cdylib.
+    /// Record bind + push + draw into `command_buffer`. Mode-routed:
+    /// host callers dispatch through `host_inner`; cdylib callers
+    /// dispatch through the v4 `cmd_bind_and_draw` slot on
+    /// [`VulkanGraphicsKernelMethodsVTable`](streamlib_plugin_abi::VulkanGraphicsKernelMethodsVTable).
+    ///
+    /// `command_buffer` is a raw `vk::CommandBuffer` the caller
+    /// minted and owns (typically from a cdylib's own command pool
+    /// under a `vulkanalia` boundary-check allowlist exception). The
+    /// wire form for the cdylib path carries the handle as `u64`
+    /// (same shape as `VulkanComputeKernelInner::record_raw`); on
+    /// 64-bit Linux — the only platform that ships — vulkanalia's
+    /// `CommandBuffer(usize)` cast is lossless.
     pub fn cmd_bind_and_draw(
         &self,
         cmd: vk::CommandBuffer,
         frame_index: u32,
         draw: &DrawCall,
     ) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_cmd_bind_and_draw_via_vtable(cmd, frame_index, draw);
+        }
         self.host_inner().cmd_bind_and_draw(cmd, frame_index, draw)
     }
 
-    /// Indexed variant of [`Self::cmd_bind_and_draw`]. Engine-only;
-    /// same `host_inner`-only contract.
+    /// Indexed variant of [`Self::cmd_bind_and_draw`]. Same
+    /// mode-routing contract; dispatches through the v4
+    /// `cmd_bind_and_draw_indexed` slot in cdylib mode.
     pub(crate) fn cmd_bind_and_draw_indexed(
         &self,
         cmd: vk::CommandBuffer,
         frame_index: u32,
         draw: &DrawIndexedCall,
     ) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_cmd_bind_and_draw_indexed_via_vtable(
+                cmd,
+                frame_index,
+                draw,
+            );
+        }
         self.host_inner().cmd_bind_and_draw_indexed(cmd, frame_index, draw)
     }
 
@@ -1940,6 +1990,91 @@ impl VulkanGraphicsKernel {
                 handles.len(),
                 extent.0,
                 extent.1,
+                &draw_repr,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    /// Cdylib-side dispatch helper for the v4 `cmd_bind_and_draw`
+    /// slot. Carries `vk::CommandBuffer`'s `repr(transparent)`
+    /// `usize` payload as a `u64` (lossless on 64-bit Linux) and
+    /// marshals the `DrawCall` into the `DrawCallRepr` shape the
+    /// host wrapper expects. Mirrors the `compute_kernel`'s
+    /// `dispatch_record_via_vtable`.
+    #[cfg(target_os = "linux")]
+    fn dispatch_cmd_bind_and_draw_via_vtable(
+        &self,
+        command_buffer: vk::CommandBuffer,
+        frame_index: u32,
+        draw: &DrawCall,
+    ) -> Result<()> {
+        use vulkanalia::vk::Handle;
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "cmd_bind_and_draw: graphics kernel methods vtable is null".into(),
+            ));
+        }
+        let draw_repr = draw_call_to_repr(draw);
+        let cb_handle: u64 = command_buffer.as_raw() as u64;
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).cmd_bind_and_draw)(
+                self.handle,
+                cb_handle,
+                frame_index,
+                &draw_repr,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    /// Cdylib-side dispatch helper for the v4
+    /// `cmd_bind_and_draw_indexed` slot. Same shape as
+    /// [`Self::dispatch_cmd_bind_and_draw_via_vtable`], marshals
+    /// `DrawIndexedCall` into `DrawIndexedCallRepr`.
+    #[cfg(target_os = "linux")]
+    fn dispatch_cmd_bind_and_draw_indexed_via_vtable(
+        &self,
+        command_buffer: vk::CommandBuffer,
+        frame_index: u32,
+        draw: &DrawIndexedCall,
+    ) -> Result<()> {
+        use vulkanalia::vk::Handle;
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "cmd_bind_and_draw_indexed: graphics kernel methods vtable is null"
+                    .into(),
+            ));
+        }
+        let draw_repr = draw_indexed_call_to_repr(draw);
+        let cb_handle: u64 = command_buffer.as_raw() as u64;
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).cmd_bind_and_draw_indexed)(
+                self.handle,
+                cb_handle,
+                frame_index,
                 &draw_repr,
                 err_buf.as_mut_ptr(),
                 err_buf.len(),

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -539,15 +539,15 @@ pub const RHI_COLOR_CONVERTER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 2;
 ///   the asymmetry would force the next "first indexed-draw cdylib
 ///   consumer" to re-derive the same engine work mid-task. Same
 ///   wire shape as `record_draw` but takes a `DrawIndexedCallRepr`.
-/// - v5: #1065 — appends `submit` and `submit_and_wait` (siblings
-///   of v1 `submit_signaling_timeline`). `RhiToneMapper::apply_with_layouts`
+/// - v5: appends `submit` and `submit_and_wait` (siblings of v1
+///   `submit_signaling_timeline`). `RhiToneMapper::apply_with_layouts`
 ///   creates its own recorder + calls `submit_and_wait()`; when
 ///   engine SDK code that reaches the tone-mapper is compiled into
-///   a cdylib (the `camera-python-display-effects`
-///   `BlendingCompositor::normalize_layer` path is the first
-///   in-tree consumer), the bare-submit calls trip the recorder's
-///   `host_inner_mut()` panic guard. Same wire shape as
-///   `submit_signaling_timeline` minus the timeline parameters.
+///   a cdylib (the per-input working-space conversion path in
+///   graphics-kernel wrappers is the first in-tree consumer), the
+///   bare-submit calls trip the recorder's `host_inner_mut()`
+///   panic guard. Same wire shape as `submit_signaling_timeline`
+///   minus the timeline parameters.
 pub const RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 5;
 
 /// Layout version of [`OutputWriterVTable`].
@@ -6182,7 +6182,7 @@ mod layout_tests {
             offset_of!(RhiCommandRecorderMethodsVTable, record_draw_indexed),
             112
         );
-        // v5 entries (#1065).
+        // v5 entries.
         assert_eq!(
             offset_of!(RhiCommandRecorderMethodsVTable, submit),
             120

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -421,7 +421,19 @@ pub const VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 5;
 ///
 /// - v3: appended the `bindings` introspection slot — same shape as
 ///   the compute-kernel v4 slot but writes `GraphicsBindingSpecRepr`.
-pub const VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 3;
+///
+/// - v4: appended the raw-vulkanalia-handle slots
+///   `cmd_bind_and_draw` / `cmd_bind_and_draw_indexed` so cdylib
+///   graphics consumers that mint their own `vk::CommandBuffer` can
+///   record bind + push + draw without tripping the kernel's
+///   `host_inner()` panic guard. Same shape as the
+///   `VulkanComputeKernelMethodsVTable` v5 `record` slot —
+///   `command_buffer_handle: u64` wraps `vk::CommandBuffer`'s
+///   `repr(transparent)` `usize` payload (lossless on 64-bit Linux,
+///   the only platform that ships); the draw call travels as the
+///   existing [`DrawCallRepr`] / [`DrawIndexedCallRepr`] shapes
+///   already wired for `offscreen_render`.
+pub const VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 4;
 
 /// Layout version of [`VulkanRayTracingKernelMethodsVTable`].
 ///
@@ -527,7 +539,16 @@ pub const RHI_COLOR_CONVERTER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 2;
 ///   the asymmetry would force the next "first indexed-draw cdylib
 ///   consumer" to re-derive the same engine work mid-task. Same
 ///   wire shape as `record_draw` but takes a `DrawIndexedCallRepr`.
-pub const RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 4;
+/// - v5: #1065 — appends `submit` and `submit_and_wait` (siblings
+///   of v1 `submit_signaling_timeline`). `RhiToneMapper::apply_with_layouts`
+///   creates its own recorder + calls `submit_and_wait()`; when
+///   engine SDK code that reaches the tone-mapper is compiled into
+///   a cdylib (the `camera-python-display-effects`
+///   `BlendingCompositor::normalize_layer` path is the first
+///   in-tree consumer), the bare-submit calls trip the recorder's
+///   `host_inner_mut()` panic guard. Same wire shape as
+///   `submit_signaling_timeline` minus the timeline parameters.
+pub const RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 5;
 
 /// Layout version of [`OutputWriterVTable`].
 ///
@@ -4084,6 +4105,30 @@ pub struct RhiCommandRecorderMethodsVTable {
         err_buf_cap: usize,
         err_len: *mut usize,
     ) -> i32,
+
+    /// End recording and submit without semaphore signaling. Sibling
+    /// of v1 [`Self::submit_signaling_timeline`] — that slot covered
+    /// the timeline-signal case the camera processor needed; this
+    /// covers the bare-submit case `RhiToneMapper::apply_with_layouts`
+    /// uses for its private recorder. (Available since v5.)
+    pub submit: unsafe extern "C" fn(
+        recorder_handle: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// End recording, submit, and block until the GPU completes.
+    /// Sibling of [`Self::submit`] — caller-side `vkWaitForFences`
+    /// after submit. Used by
+    /// `RhiToneMapper::apply_with_layouts` for its self-contained
+    /// dispatch-then-wait flow. (Available since v5.)
+    pub submit_and_wait: unsafe extern "C" fn(
+        recorder_handle: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
 }
 
 unsafe impl Send for RhiCommandRecorderMethodsVTable {}
@@ -4287,21 +4332,28 @@ unsafe impl Sync for InputMailboxesVTable {}
 /// `VulkanComputeKernelMethodsVTable` v3 shape and the production
 /// cross-DSO patterns in Dawn / WebGPU + Unreal RHI.
 ///
-/// **Coverage today** (v2):
+/// **Coverage today** (v4):
 /// - Binding slots: `set_storage_buffer_pixel`,
 ///   `set_storage_buffer_storage`, `set_uniform_buffer`,
 ///   `set_sampled_texture`, `set_storage_image`,
 ///   `set_vertex_buffer`, `set_index_buffer`.
 /// - Primitive-argument slots: `set_push_constants`,
 ///   `offscreen_render`.
+/// - Introspection slots: `bindings` (v3).
+/// - Raw-vulkanalia-handle slots: `cmd_bind_and_draw`,
+///   `cmd_bind_and_draw_indexed` (v4). Mirror the
+///   `VulkanComputeKernelMethodsVTable` v5 `record` slot — they
+///   accept a `command_buffer_handle: u64` carrying
+///   `vk::CommandBuffer`'s `repr(transparent)` `usize` payload from
+///   cdylib graphics consumers that mint and manage their own
+///   command buffer (the example
+///   `camera-python-display-effects` kernel wrappers, plus future
+///   pre-RDG cdylib pass authors). The host wrapper reconstructs
+///   the handle via `vk::CommandBuffer::from_raw` before dispatch.
 ///
-/// **Engine-only methods** (NOT on this vtable): `cmd_bind_and_draw`
-/// and `cmd_bind_and_draw_indexed` accept a raw `vk::CommandBuffer`
-/// from a caller-managed render-pass scope. They stay
-/// `host_inner`-routed; cdylib code cannot mint a `vk::CommandBuffer`
-/// without an `RhiCommandRecorder` β-shape (a separate concern). The
-/// `bindings()` / `pipeline_state()` accessors return host-internal
-/// types and stay `host_inner`-routed for the same reason.
+/// **Engine-only methods** (NOT on this vtable): `bindings()` /
+/// `pipeline_state()` accessors return host-internal types and
+/// stay `host_inner`-routed for that reason.
 #[repr(C)]
 pub struct VulkanGraphicsKernelMethodsVTable {
     /// Vtable layout version. Must equal
@@ -4459,6 +4511,36 @@ pub struct VulkanGraphicsKernelMethodsVTable {
         out_specs_buf: *mut GraphicsBindingSpecRepr,
         out_specs_cap: usize,
         out_specs_len: *mut usize,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Record bind + push + draw into a caller-owned command buffer.
+    /// `command_buffer_handle` carries `vk::CommandBuffer`'s
+    /// `repr(transparent)` `usize` payload as a `u64` (lossless on
+    /// 64-bit Linux). `draw` is the [`DrawCallRepr`] mirror of
+    /// `streamlib::core::rhi::DrawCall` already wired for
+    /// `offscreen_render`. Returns 0 on success; non-zero with UTF-8
+    /// message in `err_buf` on failure. (Available since v4.)
+    pub cmd_bind_and_draw: unsafe extern "C" fn(
+        kernel_handle: *const c_void,
+        command_buffer_handle: u64,
+        frame_index: u32,
+        draw: *const DrawCallRepr,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Indexed variant of [`Self::cmd_bind_and_draw`]. Caller must
+    /// have set an index buffer at `frame_index` via
+    /// [`Self::set_index_buffer`]. (Available since v4.)
+    pub cmd_bind_and_draw_indexed: unsafe extern "C" fn(
+        kernel_handle: *const c_void,
+        command_buffer_handle: u64,
+        frame_index: u32,
+        draw: *const DrawIndexedCallRepr,
         err_buf: *mut u8,
         err_buf_cap: usize,
         err_len: *mut usize,
@@ -5446,7 +5528,7 @@ mod layout_tests {
         assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 10);
         assert_eq!(TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION, 2);
         assert_eq!(VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 5);
-        assert_eq!(VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 3);
+        assert_eq!(VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 4);
         assert_eq!(VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 3);
         assert_eq!(VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION, 2);
         assert_eq!(RHI_COLOR_CONVERTER_METHODS_VTABLE_LAYOUT_VERSION, 2);
@@ -5454,7 +5536,7 @@ mod layout_tests {
         // (`record_pixel_buffer_barrier`,
         // `record_copy_image_to_pixel_buffer`) for cdylib camera
         // per-frame copy into pooled `PixelBuffer` destinations.
-        assert_eq!(RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION, 4);
+        assert_eq!(RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION, 5);
         // v1 (issue #894): initial shape — `write_raw`, `has_port`,
         // `clone_arc`, `drop_arc`.
         assert_eq!(OUTPUT_WRITER_VTABLE_LAYOUT_VERSION, 1);
@@ -5723,8 +5805,19 @@ mod layout_tests {
             offset_of!(VulkanGraphicsKernelMethodsVTable, bindings),
             80
         );
-        // v3: 10 fn pointers @ 8 bytes each + 2 u32 = 88 bytes.
-        assert_eq!(size_of::<VulkanGraphicsKernelMethodsVTable>(), 88);
+        // v4 appended slots:
+        //   cmd_bind_and_draw           @ 88
+        //   cmd_bind_and_draw_indexed   @ 96
+        assert_eq!(
+            offset_of!(VulkanGraphicsKernelMethodsVTable, cmd_bind_and_draw),
+            88
+        );
+        assert_eq!(
+            offset_of!(VulkanGraphicsKernelMethodsVTable, cmd_bind_and_draw_indexed),
+            96
+        );
+        // v4: 12 fn pointers @ 8 bytes each + 2 u32 = 104 bytes.
+        assert_eq!(size_of::<VulkanGraphicsKernelMethodsVTable>(), 104);
     }
 
     #[test]
@@ -5998,9 +6091,9 @@ mod layout_tests {
         //   record_pixel_buffer_barrier          @ 56  (8 bytes, fn pointer, v2)
         //   record_copy_image_to_pixel_buffer    @ 64  (8 bytes, fn pointer, v2)
         // Total = 72 bytes, align = 8.
-        // layout_version (u32) + _reserved_padding (u32) + 14 fn
-        // pointers (8 bytes each) = 4 + 4 + 112 = 120 bytes, align = 8.
-        assert_eq!(size_of::<RhiCommandRecorderMethodsVTable>(), 120);
+        // layout_version (u32) + _reserved_padding (u32) + 16 fn
+        // pointers (8 bytes each) = 4 + 4 + 128 = 136 bytes, align = 8.
+        assert_eq!(size_of::<RhiCommandRecorderMethodsVTable>(), 136);
         assert_eq!(align_of::<RhiCommandRecorderMethodsVTable>(), 8);
         assert_eq!(
             offset_of!(RhiCommandRecorderMethodsVTable, layout_version),
@@ -6088,6 +6181,15 @@ mod layout_tests {
         assert_eq!(
             offset_of!(RhiCommandRecorderMethodsVTable, record_draw_indexed),
             112
+        );
+        // v5 entries (#1065).
+        assert_eq!(
+            offset_of!(RhiCommandRecorderMethodsVTable, submit),
+            120
+        );
+        assert_eq!(
+            offset_of!(RhiCommandRecorderMethodsVTable, submit_and_wait),
+            128
         );
     }
 

--- a/xtask/src/check_cdylib_reach.rs
+++ b/xtask/src/check_cdylib_reach.rs
@@ -2,22 +2,35 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //! CI gate enforcing the cdylib-reachability invariant on the engine's
-//! `Host*` Vulkan RHI primitives.
+//! `Host*` Vulkan RHI primitives plus every workspace cdylib's
+//! dispatch paths.
 //!
-//! The invariant: every constructor-class method (`new*`, `create*`,
-//! `from_*`) on a `HostVulkan*` impl in the engine's RHI files must be
-//! reachable from workspace plugin cdylibs without dispatching through
-//! the `host_inner()` β-shape deref or the `host_callbacks()` guard.
-//! Adding either inside a constructor body silently breaks the
-//! cdylib's direct-call path documented on each type's
-//! "Cdylib reachability" docstring (see
-//! `docs/architecture/cdylib-reachability.md`).
+//! Two scans run, each catching one direction of the same boundary
+//! violation:
 //!
-//! The check parses each target file with `syn` and walks the AST of
-//! every constructor-class method's body, flagging any method-call
-//! whose method is `host_inner` and any path expression whose last
-//! segment is `host_inner` or `host_callbacks`. Comments and string
-//! literals are skipped automatically by `syn`'s tokenization.
+//! 1. **Engine-side (`scan_workspace`)**: every constructor-class
+//!    method (`new*`, `create*`, `from_*`) on a `HostVulkan*` impl in
+//!    the engine's RHI files must stay clear of `host_inner()` and
+//!    `host_callbacks()`. Adding either inside a constructor body
+//!    silently breaks the cdylib direct-call path the
+//!    "Cdylib reachability" docstrings on each type document.
+//!
+//! 2. **Cdylib-side (`scan_cdylib_dispatch_paths`)**: every
+//!    workspace crate with `crate-type` containing `"cdylib"` (every
+//!    `packages/*` plugin, every `examples/**/plugin` plugin, the
+//!    `examples/camera-python-display/effects` graphics-kernel
+//!    package, and the subprocess bridges in `libs/streamlib-*-native`)
+//!    has its non-test fn / method bodies scanned for `vulkan_inner`,
+//!    `host_inner`, and `host_callbacks`. Hitting any of those from
+//!    cdylib-resident code lands on `Texture::host_inner()`'s
+//!    panic-guard at runtime: `vulkan_inner` on a `Texture` derefs
+//!    `host_inner`, and `host_inner` / `host_callbacks` are the
+//!    panic sites themselves. Tests (`#[cfg(test)]` items and the
+//!    `mod tests` they live under) run host-side via `cargo test --lib`
+//!    and don't hit the panic, so the visitor skips them.
+//!
+//! Both scans use `syn` AST walks; comments and string literals are
+//! skipped automatically.
 //!
 //! See `docs/architecture/cdylib-reachability.md` for the decision
 //! tree this check enforces.
@@ -35,8 +48,30 @@ use walkdir::WalkDir;
 /// — the check tracks the directory, not a curated file list.
 const TARGET_DIR: &str = "libs/streamlib-engine/src/vulkan/rhi";
 
-/// Identifiers banned inside constructor-class function bodies.
+/// Identifiers banned inside engine-side constructor-class function
+/// bodies.
 const BANNED_IDENTS: &[&str] = &["host_inner", "host_callbacks"];
+
+/// Identifiers banned inside cdylib-resident dispatch paths
+/// (non-test fn / method bodies in any crate with `crate-type =
+/// [..., "cdylib", ...]`).
+///
+/// - `vulkan_inner`: `Texture::vulkan_inner()` derefs `host_inner()`,
+///   which panics under the cdylib-side `host_callbacks().is_some()`
+///   guard. `PixelBufferRef::vulkan_inner` reads its `pub inner`
+///   field directly and is technically safe, but no cdylib code in
+///   the tree calls it today; banning the name everywhere avoids
+///   the false-negative class where a future migration silently
+///   reintroduces the `Texture` pattern.
+/// - `host_inner`: the panic site directly. `pub(crate)` so cdylib
+///   code can't reach it through typed Rust anyway, but matching
+///   the bare identifier is belt-and-suspenders for path
+///   expressions and qualified calls.
+/// - `host_callbacks`: the cdylib-mode sentinel. Cdylib code that
+///   needs to know "am I in cdylib mode?" should not use this —
+///   the architecture is type-system enforcement, not runtime
+///   branching.
+const BANNED_DISPATCH_IDENTS: &[&str] = &["vulkan_inner", "host_inner", "host_callbacks"];
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Violation {
@@ -47,44 +82,107 @@ pub struct Violation {
     pub line: usize,
 }
 
+/// Cdylib-side dispatch-path violation: a fn or method body in a
+/// crate that ships as a cdylib reached for one of the
+/// host-only / panic-guarded identifiers.
+#[derive(Debug, PartialEq, Eq)]
+pub struct DispatchViolation {
+    pub file: PathBuf,
+    pub crate_name: String,
+    /// Enclosing fn / method name. `None` for free-standing call
+    /// sites at module scope (rare; syn still records them).
+    pub method: Option<String>,
+    pub offending_ident: String,
+    pub line: usize,
+}
+
 pub fn run(workspace_root: &Path) -> Result<()> {
-    let violations = scan_workspace(workspace_root)?;
-    if violations.is_empty() {
+    let engine_violations = scan_workspace(workspace_root)?;
+    let dispatch_violations = scan_cdylib_dispatch_paths(workspace_root)?;
+    let total = engine_violations.len() + dispatch_violations.len();
+
+    if total == 0 {
         println!(
             "✓ check-cdylib-reach: every Host* constructor in the engine RHI \
-             stays clear of host_inner() / host_callbacks() — cdylib direct-call \
-             path intact."
+             stays clear of host_inner() / host_callbacks(), and every \
+             workspace cdylib's dispatch paths stay clear of vulkan_inner() / \
+             host_inner() / host_callbacks() — cdylib panic-guard path intact."
         );
         return Ok(());
     }
 
-    eprintln!(
-        "✗ check-cdylib-reach: {} violation(s) — Host* constructor reached for \
-         a host-private guard, breaking the cdylib direct-call path:",
-        violations.len()
-    );
-    for v in &violations {
+    if !engine_violations.is_empty() {
         eprintln!(
-            "  {}:{}: impl {} :: fn {} references `{}`",
-            v.file.display(),
-            v.line,
-            v.impl_type,
-            v.method,
-            v.offending_ident,
+            "✗ check-cdylib-reach: {} engine-side violation(s) — Host* \
+             constructor reached for a host-private guard, breaking the \
+             cdylib direct-call path:",
+            engine_violations.len()
+        );
+        for v in &engine_violations {
+            eprintln!(
+                "  {}:{}: impl {} :: fn {} references `{}`",
+                v.file.display(),
+                v.line,
+                v.impl_type,
+                v.method,
+                v.offending_ident,
+            );
+        }
+        eprintln!(
+            "\nFix (engine-side):\n  \
+             A `Host*::new*` / `create*` / `from_*` method body called `host_inner()` \
+             or `host_callbacks()`. The cdylib direct-call path (see\n  \
+             `docs/architecture/cdylib-reachability.md`) requires constructors to \
+             touch only `pub` accessors on `HostVulkanDevice` plus `vulkanalia-vma`.\n  \
+             Options:\n    \
+               1. Re-route the body through a `pub` accessor (preferred).\n    \
+               2. Promote the construction path to a FullAccess vtable slot \
+                  (route 1) — bump `GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION`, \
+                  update the layout regression test, add a tier-1 wire-format test."
         );
     }
-    eprintln!(
-        "\nFix:\n  \
-         A `Host*::new*` / `create*` / `from_*` method body called `host_inner()` \
-         or `host_callbacks()`. The cdylib direct-call path (see\n  \
-         `docs/architecture/cdylib-reachability.md`) requires constructors to \
-         touch only `pub` accessors on `HostVulkanDevice` plus `vulkanalia-vma`.\n  \
-         Options:\n    \
-           1. Re-route the body through a `pub` accessor (preferred).\n    \
-           2. Promote the construction path to a FullAccess vtable slot \
-              (route 1) — bump `GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION`, \
-              update the layout regression test, add a tier-1 wire-format test."
-    );
+
+    if !dispatch_violations.is_empty() {
+        if !engine_violations.is_empty() {
+            eprintln!();
+        }
+        eprintln!(
+            "✗ check-cdylib-reach: {} cdylib-side violation(s) — non-test \
+             dispatch path in a cdylib crate reached for a host-only / \
+             panic-guarded identifier:",
+            dispatch_violations.len()
+        );
+        for v in &dispatch_violations {
+            let method = v.method.as_deref().unwrap_or("<module scope>");
+            eprintln!(
+                "  {}:{}: crate {} :: fn {} references `{}`",
+                v.file.display(),
+                v.line,
+                v.crate_name,
+                method,
+                v.offending_ident,
+            );
+        }
+        eprintln!(
+            "\nFix (cdylib-side):\n  \
+             A non-test fn / method in a cdylib crate called `vulkan_inner()`, \
+             `host_inner()`, or `host_callbacks()`. `Texture::vulkan_inner()` \
+             derefs `Texture::host_inner()`, which panics under the cdylib-side \
+             `host_callbacks().is_some()` guard (see\n  \
+             `docs/architecture/cdylib-reachability.md`).\n  \
+             Options:\n    \
+               1. For raw `VkImage` / `VkImageView` access from a `Texture`, \
+                  use `HostTextureExt::host_vulkan_texture_arc()` (the v10 \
+                  FullAccess vtable slot — already in use by \
+                  `packages/camera/src/camera_to_cuda_copy.rs`, \
+                  `packages/h264/src/linux/encoder.rs`, \
+                  `packages/h265/src/linux/encoder.rs`).\n    \
+               2. If the call genuinely belongs in a host-only path (a \
+                  `#[test]` or `#[cfg(test)]` helper), move it under \
+                  `#[cfg(test)]` / `mod tests` so the lint skips it."
+        );
+    }
+
     anyhow::bail!("check-cdylib-reach failed");
 }
 
@@ -118,6 +216,152 @@ pub fn scan_workspace(workspace_root: &Path) -> Result<Vec<Violation>> {
         visitor.visit_file(&file);
     }
     Ok(all)
+}
+
+/// Scan every workspace crate whose Cargo.toml declares
+/// `crate-type` containing `"cdylib"`. For each such crate, walk
+/// every `.rs` file under `src/` and flag dispatch-path uses of
+/// [`BANNED_DISPATCH_IDENTS`]. `#[cfg(test)]` items and modules are
+/// skipped (those run host-side via `cargo test --lib`, where the
+/// `host_callbacks()` guard returns `None` and the panic never
+/// fires).
+pub fn scan_cdylib_dispatch_paths(workspace_root: &Path) -> Result<Vec<DispatchViolation>> {
+    let mut all = Vec::new();
+    for (crate_dir, crate_name) in discover_cdylib_crates(workspace_root)? {
+        let src_dir = crate_dir.join("src");
+        if !src_dir.exists() {
+            continue;
+        }
+        for entry in WalkDir::new(&src_dir).into_iter().filter_map(|e| e.ok()) {
+            let abs = entry.path();
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            if abs.extension().map(|e| e != "rs").unwrap_or(true) {
+                continue;
+            }
+            let relpath = abs
+                .strip_prefix(workspace_root)
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|_| abs.to_path_buf());
+            let src = fs::read_to_string(abs)
+                .with_context(|| format!("reading {}", abs.display()))?;
+            // Files that fail to parse (proc-macro-heavy generated
+            // code, partial includes) are skipped — the lint can't
+            // reason about them and false-negatives there are
+            // strictly safer than false-positives on shape-mismatches.
+            let Ok(file) = syn::parse_file(&src) else {
+                continue;
+            };
+            let mut visitor = DispatchFileVisitor {
+                file_path: relpath,
+                crate_name: crate_name.clone(),
+                current_method: None,
+                violations: &mut all,
+            };
+            visitor.visit_file(&file);
+        }
+    }
+    Ok(all)
+}
+
+/// True iff any attribute on `attrs` is `#[cfg(test)]` (or
+/// `#[cfg(all(..., test, ...))]` / `#[cfg(any(test, ...))]` containing
+/// a bare `test` identifier anywhere in the token stream). An
+/// `#[cfg(any(test, ...))]` is treated the same way — the surrounding
+/// item compiles only when `test` is set in at least one branch, so
+/// it's a test-only item by the rule we care about.
+fn has_cfg_test(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        if !attr.path().is_ident("cfg") {
+            return false;
+        }
+        let Ok(list) = attr.meta.require_list() else {
+            return false;
+        };
+        token_stream_contains_test_ident(list.tokens.clone())
+    })
+}
+
+/// Recursively walk a token stream looking for the bare identifier
+/// `test`. Descends into `Group`s so `cfg(all(test, ...))` and
+/// `cfg(any(test, ...))` both match. Identifiers nested inside name=value
+/// pairs (e.g. `target_family = "test"`) are intentionally not matched —
+/// only `test` as a standalone ident counts.
+fn token_stream_contains_test_ident(tokens: proc_macro2::TokenStream) -> bool {
+    tokens.into_iter().any(|tt| match tt {
+        proc_macro2::TokenTree::Ident(i) => i == "test",
+        proc_macro2::TokenTree::Group(g) => {
+            token_stream_contains_test_ident(g.stream())
+        }
+        _ => false,
+    })
+}
+
+/// Read the `[package].name` field from a `Cargo.toml`. Returns
+/// `None` for non-package manifests (workspace-only roots, etc.).
+fn cargo_toml_package_name(toml_str: &str) -> Option<String> {
+    let v: toml::Value = toml::from_str(toml_str).ok()?;
+    v.get("package")?.get("name")?.as_str().map(String::from)
+}
+
+/// True iff the manifest's `[lib].crate-type` array contains
+/// `"cdylib"`. Returns `false` for manifests with no `[lib]` table
+/// or no `crate-type` array.
+fn cargo_toml_has_cdylib(toml_str: &str) -> bool {
+    let Ok(v) = toml::from_str::<toml::Value>(toml_str) else {
+        return false;
+    };
+    let Some(arr) = v.get("lib").and_then(|l| l.get("crate-type")).and_then(|c| c.as_array())
+    else {
+        return false;
+    };
+    arr.iter().any(|e| e.as_str() == Some("cdylib"))
+}
+
+/// Walk the workspace and collect `(crate_dir, crate_name)` for
+/// every crate whose Cargo.toml declares a cdylib crate-type. Skips
+/// `target/`, hidden directories (`.claude/`, `.git/`), and the
+/// workspace-root Cargo.toml itself.
+fn discover_cdylib_crates(workspace_root: &Path) -> Result<Vec<(PathBuf, String)>> {
+    let mut out = Vec::new();
+    let walker = WalkDir::new(workspace_root)
+        .into_iter()
+        .filter_entry(|e| {
+            // Prune target/, hidden dirs (`.git`, `.claude`), and
+            // anything not a directory at this level — `.rs` files
+            // and Cargo.toml files are kept.
+            let name = e.file_name().to_string_lossy();
+            if e.file_type().is_dir() {
+                name != "target" && !name.starts_with('.')
+            } else {
+                true
+            }
+        });
+    for entry in walker.filter_map(|e| e.ok()) {
+        if entry.file_name() != "Cargo.toml" {
+            continue;
+        }
+        let manifest = entry.path();
+        let crate_dir = manifest.parent().unwrap_or(workspace_root);
+        // Skip the workspace-root manifest (no [lib]; no crate-type).
+        if crate_dir == workspace_root {
+            continue;
+        }
+        let toml_str = fs::read_to_string(manifest)
+            .with_context(|| format!("reading {}", manifest.display()))?;
+        if !cargo_toml_has_cdylib(&toml_str) {
+            continue;
+        }
+        let crate_name = cargo_toml_package_name(&toml_str).unwrap_or_else(|| {
+            crate_dir
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "<unknown>".into())
+        });
+        out.push((crate_dir.to_path_buf(), crate_name));
+    }
+    Ok(out)
 }
 
 fn is_constructor_name(name: &str) -> bool {
@@ -204,6 +448,102 @@ impl<'ast> Visit<'ast> for BodyVisitor {
         if let Some(seg) = path.path.segments.last() {
             let n = seg.ident.to_string();
             if BANNED_IDENTS.contains(&n.as_str()) {
+                self.hits.push(Hit {
+                    ident: n,
+                    line: seg.ident.span().start().line,
+                });
+            }
+        }
+        syn::visit::visit_expr_path(self, path);
+    }
+}
+
+/// Visitor for the cdylib-side scan. Walks every fn / method body
+/// in a cdylib crate's source files (excluding `#[cfg(test)]`
+/// items) and pushes a [`DispatchViolation`] for each banned
+/// identifier found in non-test bodies.
+struct DispatchFileVisitor<'a> {
+    file_path: PathBuf,
+    crate_name: String,
+    current_method: Option<String>,
+    violations: &'a mut Vec<DispatchViolation>,
+}
+
+impl<'ast, 'a> Visit<'ast> for DispatchFileVisitor<'a> {
+    fn visit_item_mod(&mut self, m: &'ast syn::ItemMod) {
+        if has_cfg_test(&m.attrs) {
+            return;
+        }
+        syn::visit::visit_item_mod(self, m);
+    }
+
+    fn visit_item_impl(&mut self, i: &'ast syn::ItemImpl) {
+        if has_cfg_test(&i.attrs) {
+            return;
+        }
+        syn::visit::visit_item_impl(self, i);
+    }
+
+    fn visit_impl_item_fn(&mut self, f: &'ast syn::ImplItemFn) {
+        if has_cfg_test(&f.attrs) {
+            return;
+        }
+        let prev = self.current_method.replace(f.sig.ident.to_string());
+        let mut body = DispatchBodyVisitor::default();
+        body.visit_block(&f.block);
+        for hit in body.hits {
+            self.violations.push(DispatchViolation {
+                file: self.file_path.clone(),
+                crate_name: self.crate_name.clone(),
+                method: Some(f.sig.ident.to_string()),
+                offending_ident: hit.ident,
+                line: hit.line,
+            });
+        }
+        self.current_method = prev;
+    }
+
+    fn visit_item_fn(&mut self, f: &'ast syn::ItemFn) {
+        if has_cfg_test(&f.attrs) {
+            return;
+        }
+        let prev = self.current_method.replace(f.sig.ident.to_string());
+        let mut body = DispatchBodyVisitor::default();
+        body.visit_block(&f.block);
+        for hit in body.hits {
+            self.violations.push(DispatchViolation {
+                file: self.file_path.clone(),
+                crate_name: self.crate_name.clone(),
+                method: Some(f.sig.ident.to_string()),
+                offending_ident: hit.ident,
+                line: hit.line,
+            });
+        }
+        self.current_method = prev;
+    }
+}
+
+#[derive(Default)]
+struct DispatchBodyVisitor {
+    hits: Vec<Hit>,
+}
+
+impl<'ast> Visit<'ast> for DispatchBodyVisitor {
+    fn visit_expr_method_call(&mut self, call: &'ast syn::ExprMethodCall) {
+        let m = call.method.to_string();
+        if BANNED_DISPATCH_IDENTS.contains(&m.as_str()) {
+            self.hits.push(Hit {
+                ident: m,
+                line: call.method.span().start().line,
+            });
+        }
+        syn::visit::visit_expr_method_call(self, call);
+    }
+
+    fn visit_expr_path(&mut self, path: &'ast syn::ExprPath) {
+        if let Some(seg) = path.path.segments.last() {
+            let n = seg.ident.to_string();
+            if BANNED_DISPATCH_IDENTS.contains(&n.as_str()) {
                 self.hits.push(Hit {
                     ident: n,
                     line: seg.ident.span().start().line,
@@ -380,5 +720,263 @@ mod tests {
         let v = scan_source(src);
         assert_eq!(v.len(), 1);
         assert_eq!(v[0].method, "from_dma_buf_fd");
+    }
+
+    // ---- Cdylib-side dispatch-path scan tests ------------------------------
+    //
+    // These exercise `DispatchFileVisitor` directly against in-memory
+    // source, bypassing the Cargo.toml discovery step. The discovery
+    // helpers (`cargo_toml_has_cdylib`, `cargo_toml_package_name`) have
+    // their own focused tests below.
+
+    fn scan_dispatch(src: &str) -> Vec<DispatchViolation> {
+        let file = syn::parse_file(src).expect("parse");
+        let mut violations = Vec::new();
+        let mut visitor = DispatchFileVisitor {
+            file_path: PathBuf::from("test.rs"),
+            crate_name: "test-cdylib".into(),
+            current_method: None,
+            violations: &mut violations,
+        };
+        visitor.visit_file(&file);
+        violations
+    }
+
+    #[test]
+    fn dispatch_flags_vulkan_inner_in_method() {
+        // The actual #1065 bug shape — a kernel wrapper's dispatch
+        // method reaches `tex.vulkan_inner().image()` to grab the
+        // raw `VkImage`. Panics under the cdylib `host_callbacks()`
+        // guard at runtime.
+        let src = r#"
+            impl SandboxedBlendingCompositor {
+                pub fn dispatch(&self, tex: &Texture) -> Result<()> {
+                    let image = tex.vulkan_inner().image().ok_or_else(|| Error::E)?;
+                    Ok(())
+                }
+            }
+        "#;
+        let v = scan_dispatch(src);
+        assert_eq!(v.len(), 1, "expected one violation, got {v:?}");
+        assert_eq!(v[0].offending_ident, "vulkan_inner");
+        assert_eq!(v[0].method.as_deref(), Some("dispatch"));
+    }
+
+    #[test]
+    fn dispatch_flags_multiple_sites() {
+        // Mirrors the actual count in
+        // `blending_compositor_kernel.rs::dispatch` — three reaches
+        // (input image, output image, output image_view).
+        let src = r#"
+            impl Kernel {
+                pub fn dispatch(&self, t: &Texture, out: &Texture) -> Result<()> {
+                    let _a = t.vulkan_inner().image();
+                    let _b = out.vulkan_inner().image();
+                    let _c = out.vulkan_inner().image_view();
+                    Ok(())
+                }
+            }
+        "#;
+        let v = scan_dispatch(src);
+        assert_eq!(v.len(), 3, "expected three violations, got {v:?}");
+        assert!(v.iter().all(|x| x.offending_ident == "vulkan_inner"));
+    }
+
+    #[test]
+    fn dispatch_skips_cfg_test_modules() {
+        // Test-only fill / readback helpers in a `mod tests` block
+        // run host-side under `cargo test --lib`, where
+        // `host_callbacks()` is `None` and the panic never fires.
+        // The lint must not flag them.
+        let src = r#"
+            impl Kernel {
+                pub fn dispatch(&self, t: &Texture) -> Result<()> {
+                    // Real dispatch — would normally be a violation,
+                    // but this test only checks that the cfg(test)
+                    // module below is skipped.
+                    Ok(())
+                }
+            }
+
+            #[cfg(test)]
+            mod tests {
+                use super::*;
+
+                fn fill_solid(texture: &Texture) {
+                    let _image = texture.vulkan_inner().image().expect("image");
+                }
+
+                #[test]
+                fn visual_smoke() {
+                    let _image = input.vulkan_inner().image().expect("image");
+                }
+            }
+        "#;
+        let v = scan_dispatch(src);
+        assert!(
+            v.is_empty(),
+            "cfg(test) module bodies must not be flagged, got {v:?}"
+        );
+    }
+
+    #[test]
+    fn dispatch_skips_cfg_test_methods() {
+        // Per-method `#[cfg(test)]` annotation must skip the body
+        // even when the enclosing module isn't gated.
+        let src = r#"
+            impl Kernel {
+                pub fn dispatch(&self, t: &Texture) -> Result<()> {
+                    Ok(())
+                }
+
+                #[cfg(test)]
+                fn test_helper(&self, t: &Texture) {
+                    let _image = t.vulkan_inner().image().expect("image");
+                }
+            }
+        "#;
+        let v = scan_dispatch(src);
+        assert!(v.is_empty(), "cfg(test) method bodies must not be flagged");
+    }
+
+    #[test]
+    fn dispatch_flags_host_inner_path_expr() {
+        // Path expression matching `crate::path::host_inner` —
+        // belt-and-suspenders for fully-qualified call shapes.
+        let src = r#"
+            fn outer(x: &T) -> u32 {
+                if crate::plugin::host_callbacks().is_some() {
+                    return 0;
+                }
+                x.host_inner();
+                0
+            }
+        "#;
+        let v = scan_dispatch(src);
+        assert_eq!(v.len(), 2);
+        let idents: Vec<&str> = v.iter().map(|x| x.offending_ident.as_str()).collect();
+        assert!(idents.contains(&"host_callbacks"));
+        assert!(idents.contains(&"host_inner"));
+    }
+
+    #[test]
+    fn dispatch_ignores_docstring_and_string_literal() {
+        let src = r#"
+            impl Kernel {
+                /// This dispatch does NOT call vulkan_inner() or
+                /// host_inner() — see the rule in CLAUDE.md.
+                pub fn dispatch(&self) -> Result<(), String> {
+                    Err("vulkan_inner failed (just a message)".into())
+                }
+            }
+        "#;
+        let v = scan_dispatch(src);
+        assert!(v.is_empty(), "comments and strings must not be flagged");
+    }
+
+    #[test]
+    fn dispatch_flags_free_fn_at_module_scope() {
+        let src = r#"
+            fn helper(t: &Texture) -> u32 {
+                let _i = t.vulkan_inner().image();
+                0
+            }
+        "#;
+        let v = scan_dispatch(src);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].method.as_deref(), Some("helper"));
+    }
+
+    // ---- Cargo.toml discovery helpers ---------------------------------------
+
+    #[test]
+    fn cargo_toml_has_cdylib_detects_workspace_plugin() {
+        let toml = r#"
+            [package]
+            name = "streamlib-camera"
+            version = "0.0.0"
+            edition = "2024"
+
+            [lib]
+            crate-type = ["rlib", "cdylib"]
+        "#;
+        assert!(cargo_toml_has_cdylib(toml));
+        assert_eq!(
+            cargo_toml_package_name(toml).as_deref(),
+            Some("streamlib-camera")
+        );
+    }
+
+    #[test]
+    fn cargo_toml_has_cdylib_skips_pure_rlib() {
+        let toml = r#"
+            [package]
+            name = "streamlib-jtd-codegen"
+            version = "0.0.0"
+            edition = "2024"
+        "#;
+        // No [lib] section at all — falls back to default rlib.
+        assert!(!cargo_toml_has_cdylib(toml));
+    }
+
+    #[test]
+    fn cargo_toml_has_cdylib_skips_rlib_only_lib_section() {
+        let toml = r#"
+            [package]
+            name = "streamlib-misc"
+            version = "0.0.0"
+            edition = "2024"
+
+            [lib]
+            crate-type = ["rlib"]
+        "#;
+        assert!(!cargo_toml_has_cdylib(toml));
+    }
+
+    #[test]
+    fn cargo_toml_has_cdylib_handles_workspace_root() {
+        // Workspace-root manifests have no [package] / [lib].
+        let toml = r#"
+            [workspace]
+            members = ["packages/*"]
+        "#;
+        assert!(!cargo_toml_has_cdylib(toml));
+        assert!(cargo_toml_package_name(toml).is_none());
+    }
+
+    #[test]
+    fn has_cfg_test_detects_bare_form() {
+        let attrs: syn::ItemFn = syn::parse_str(
+            "#[cfg(test)] fn x() {}",
+        )
+        .expect("parse");
+        assert!(has_cfg_test(&attrs.attrs));
+    }
+
+    #[test]
+    fn has_cfg_test_detects_all_combinator() {
+        let attrs: syn::ItemFn = syn::parse_str(
+            "#[cfg(all(test, target_os = \"linux\"))] fn x() {}",
+        )
+        .expect("parse");
+        assert!(has_cfg_test(&attrs.attrs));
+    }
+
+    #[test]
+    fn has_cfg_test_ignores_non_test_cfg() {
+        let attrs: syn::ItemFn = syn::parse_str(
+            "#[cfg(target_os = \"linux\")] fn x() {}",
+        )
+        .expect("parse");
+        assert!(!has_cfg_test(&attrs.attrs));
+    }
+
+    #[test]
+    fn has_cfg_test_ignores_non_cfg_attrs() {
+        let attrs: syn::ItemFn = syn::parse_str(
+            "#[allow(dead_code)] fn x() {}",
+        )
+        .expect("parse");
+        assert!(!has_cfg_test(&attrs.attrs));
     }
 }

--- a/xtask/src/check_cdylib_reach.rs
+++ b/xtask/src/check_cdylib_reach.rs
@@ -744,10 +744,11 @@ mod tests {
 
     #[test]
     fn dispatch_flags_vulkan_inner_in_method() {
-        // The actual #1065 bug shape — a kernel wrapper's dispatch
-        // method reaches `tex.vulkan_inner().image()` to grab the
-        // raw `VkImage`. Panics under the cdylib `host_callbacks()`
-        // guard at runtime.
+        // The original-shape bug this scan exists to catch — a
+        // kernel wrapper's dispatch method reaches
+        // `tex.vulkan_inner().image()` to grab the raw `VkImage`.
+        // Panics under the cdylib `host_callbacks()` guard at
+        // runtime; the scan flags it before the panic fires.
         let src = r#"
             impl SandboxedBlendingCompositor {
                 pub fn dispatch(&self, tex: &Texture) -> Result<()> {


### PR DESCRIPTION
## Summary

Closes the engine-layer cdylib-reachability gaps that prevented `cargo run -p camera-python-display` from producing frames. The original symptom — `Camera vivid: Stopped (0 frames)` — was caused by an unconditional `host_inner()` reach in the effects package's graphics-kernel wrappers (BlendingCompositor's render thread panicked on its first dispatch). Fix lives at the engine layer per CLAUDE.md "Engine-wide bugs get fixed at the engine layer":

- **Effects-kernel call-site sweep** — `examples/camera-python-display/effects/src/{blending_compositor,crt_film_grain}_kernel.rs` migrated from `tex.vulkan_inner().image()` (host-only, panic-guarded) to `tex.host_vulkan_texture_arc()?.image()` (the v10 cdylib-safe FullAccess vtable slot already in use by `camera_to_cuda_copy.rs` / `h264/encoder.rs` / `h265/encoder.rs`). 6 sites across 2 files; test-only `#[cfg(test)] mod tests` sites left untouched since they run host-side.
- **`xtask check-cdylib-reach` lint extension** — added `scan_cdylib_dispatch_paths` that walks every workspace crate whose Cargo.toml declares `crate-type = [..., "cdylib", ...]` and flags `vulkan_inner` / `host_inner` / `host_callbacks` identifiers in non-test fn/method bodies via a `syn` AST walk. `#[cfg(test)]` items + modules are skipped via recursive token-stream walk. **Verified the extension catches the original-shape bug** (ran against the pre-fix tree: 6 violations matching exactly the sites the runtime panic fired on; post-fix: clean).
- **`VulkanGraphicsKernel` v4** — bumped `VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION` 3 → 4. Added `cmd_bind_and_draw` + `cmd_bind_and_draw_indexed` slots (the kernel wrappers minted their own `vk::CommandBuffer` under the transitional vulkanalia exception and called the engine's `cmd_bind_and_draw`, which was the next layer's panic site). Indexed variant added eagerly alongside non-indexed (same call as #1066 made for `record_draw_indexed` — avoids forcing the next consumer to re-derive the engine work).
- **`RhiCommandRecorder` v5** — bumped `RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION` 4 → 5. Added `submit` + `submit_and_wait` slots (`RhiToneMapper::apply_with_layouts` creates a private recorder + submits-and-waits; vivid's `Smpte170m` matrix mismatches the default sRGB BT.709 working space and engages tone-mapping, hitting the last remaining cdylib-mode panic site on the recorder β-shape's public surface).

Layout regression tests + tier-1 null-handle wire-format tests added alongside each new slot. Layout-version assertions in plugin-abi updated together with the slot additions so the bump can't silently regress.

## Closes

Closes #1065

## Exit criteria

(Updated in issue body to reflect what shipped vs what's deferred to follow-up #1082.)

- [x] Engine-layer cdylib-reachability gap closed. No more `Texture::host_inner() reached from cdylib code` panic on the camera-python-display path.
- [x] `cargo run -p camera-display` (negative-control baseline) still works after the fix — 34 frames in 6.8 s.
- [x] Fix lives at the engine layer (engine vtable mode-routing + lint extension); the example-side sweep is the canonical "no bad patterns left behind" closure.
- [ ] Full pipeline (camera → CameraToCudaCopy → AvatarCharacter / BlendingCompositor / CrtFilmGrain / Glitch / Display) reaches display with PNG samples. **Not fully closed by this PR** — engine fix unblocks ~21 frames in 700 ms, then pipeline stalls on iceoryx2 backpressure downstream of BlendingCompositor (most likely the Python OpenGL Glitch processor). Tracked as #1082; the bisection plan + `SkipToLatest` / queue-depth options are documented there.

## Test plan

Tier-1 layout + wire-format tests (no GPU required):

- [x] `cargo test -p streamlib-plugin-abi layout_tests` — 53 layout tests pass, including the new `vulkan_graphics_kernel_methods_vtable_layout` (104-byte v4 size + offsets at 88 / 96) and the updated `rhi_command_recorder_methods_vtable_layout` (136-byte v5 size + offsets at 120 / 128).
- [x] `cargo test -p streamlib-engine --lib graphics_kernel_methods_vtable_null_tests` — 11 tests pass, including the new `cmd_bind_and_draw_rejects_null_kernel_handle` + `cmd_bind_and_draw_indexed_rejects_null_kernel_handle`.
- [x] `cargo test -p streamlib-engine --lib gpu_rhi_command_recorder_methods_vtable_null_tests` — 10 tests pass, including the new `submit_rejects_null_recorder_handle` + `submit_and_wait_rejects_null_recorder_handle`.
- [x] `cargo test -p xtask check_cdylib_reach` — 24 tests pass, including 14 new tests covering the cdylib dispatch-path scan (mode-routing detection, `cfg(test)` skipping, Cargo.toml discovery).
- [x] `cargo xtask check-cdylib-reach` runtime — clean.

Reviewer note: tier-1 tests lock the wire-format shape and layout-version invariants. Mode-routing behavior is exercised end-to-end by the camera-python-display reproducer + caught by the xtask lint's pattern check at the cdylib call-site. Matches the established pattern for every prior `*MethodsVTable` v1–v4 slot.

E2E:

- [x] camera-display baseline post-fix: `cargo run -q -p camera-display` against vivid `/dev/video0` → 34 frames in 6.8 s, 3 PNG samples landed (`display_001_frame_000000_input_000001.png`, …).
- [ ] camera-python-display full pipeline post-fix: **partially working** — engine no longer panics; pipeline composites ~21 frames in 700 ms; downstream backpressure stalls the chain. Documented in #1082 with reproducer + bisection plan.

## Follow-ups

- **#1082** — residual backpressure wedge after engine fix. Bisection + `SkipToLatest` / queue-depth investigation.
- **#1081** — pub-lift for `RhiCommandRecorder::cmd_begin_dynamic_rendering` / `cmd_end_dynamic_rendering` (gap noted during this work — the cdylib mode-routing for these is already in place via the v3 slots; only the visibility modifier is pub(crate)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)