### PR TITLE
fix(engine): tone-mapper layout-tracker desync (VUID-01197)

### DIFF
--- a/examples/camera-python-display/effects/src/blending_compositor.rs
+++ b/examples/camera-python-display/effects/src/blending_compositor.rs
@@ -876,6 +876,19 @@ fn normalize_layer(
         return Ok(());
     }
 
+    // Already-normalized short-circuit. `refresh_layer` resets
+    // `normalized_layout` to `None` whenever a fresh upstream frame
+    // lands; if it's still `Some` here, the per-port intermediate
+    // already holds tone-mapped content for the current source frame
+    // (BlendingCompositor ticks faster than upstream producers, so
+    // many ticks reuse the cached layer). Re-running the tone-mapper
+    // on the same source would call `apply_with_layouts(intermediate,
+    // intermediate)` — src == dst — which trips VUID-01197 twice per
+    // submit on the 4-barrier sequence.
+    if layer.normalized_layout.is_some() {
+        return Ok(());
+    }
+
     let width = layer.texture.width();
     let height = layer.texture.height();
 

--- a/libs/streamlib-engine/src/core/rhi/tone_mapper.rs
+++ b/libs/streamlib-engine/src/core/rhi/tone_mapper.rs
@@ -201,6 +201,18 @@ impl RhiToneMapper {
     /// engine-owned command buffer; submits and waits before returning.
     /// Both `src` and `dst` are left in `SHADER_READ_ONLY_OPTIMAL` on
     /// success.
+    ///
+    /// Caller contract:
+    /// - `src` and `dst` must reference **distinct VkImages**. In-place
+    ///   tone-map is not supported — the kernel binds src + dst as two
+    ///   storage images, and the 4-barrier sequence would emit
+    ///   conflicting layout claims on the same image. Passing the same
+    ///   handle for both returns `Err`.
+    /// - This helper does **not** read or write
+    ///   [`crate::core::context::TextureRegistration`]. The caller is
+    ///   responsible for `update_layout`ing any associated registration
+    ///   after the call (the helper leaves both textures in
+    ///   `SHADER_READ_ONLY_OPTIMAL`, so the writeback is a constant).
     #[cfg(target_os = "linux")]
     pub fn apply_with_layouts(
         &self,

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_tone_mapper.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_tone_mapper.rs
@@ -19,7 +19,8 @@ use crate::core::rhi::{
     ComputeBindingSpec, ComputeKernelDescriptor, Texture, ToneMapperPushConstants, VulkanLayout,
     TONE_MAPPER_PUSH_CONSTANT_SIZE,
 };
-use crate::core::Result;
+use crate::core::{Error, Result};
+use crate::host_rhi::HostTextureExt;
 
 use super::{
     HostVulkanDevice, RhiCommandRecorder, VulkanAccess, VulkanComputeKernel, VulkanStage,
@@ -100,6 +101,14 @@ impl VulkanToneMapper {
     /// already own a surrounding [`RhiCommandRecorder`] but do need
     /// honest layout management around the dispatch.
     ///
+    /// Caller contract:
+    /// - `src` and `dst` must reference distinct VkImages — in-place
+    ///   tone-map is not supported; passing the same handle returns
+    ///   `Err(Error::Configuration)`.
+    /// - The helper does not touch
+    ///   [`crate::core::context::TextureRegistration`]; the caller
+    ///   updates any associated registration after the call.
+    ///
     /// For consumers that already drive their own recorder, prefer
     /// [`Self::prepare`] + their recorder's `record_image_barrier` +
     /// `record_dispatch` to avoid the extra submit/wait round-trip.
@@ -111,6 +120,24 @@ impl VulkanToneMapper {
         dst_current_layout: VulkanLayout,
         push: &ToneMapperPushConstants,
     ) -> Result<()> {
+        // Reject in-place tone-map. The kernel binds src + dst as
+        // distinct storage images and the barrier sequence (src →
+        // GENERAL, dst → GENERAL, dispatch, src → SROO, dst → SROO)
+        // emits conflicting layout claims on the same VkImage when
+        // the caller passes the same handle for both, which trips
+        // VUID-VkImageMemoryBarrier2-oldLayout-01197 twice per submit.
+        // Catch the misuse here rather than as validation noise 60
+        // frames downstream.
+        if let (Some(src_image), Some(dst_image)) =
+            (src.vulkan_inner().image(), dst.vulkan_inner().image())
+        {
+            if src_image == dst_image {
+                return Err(Error::Configuration(
+                    "VulkanToneMapper::apply_with_layouts: src and dst must be distinct VkImages (in-place tone-map is not supported)".into(),
+                ));
+            }
+        }
+
         let kernel = self.prepare(src, dst, push)?;
         let dispatch_x = push.width.div_ceil(TONE_MAPPER_WORKGROUP_SIZE);
         let dispatch_y = push.height.div_ceil(TONE_MAPPER_WORKGROUP_SIZE);
@@ -545,5 +572,45 @@ mod tests {
         assert_eq!(byte, 255, "round-trip should land at byte 255");
         // Suppress unused-import warnings if the GPU test is skipped.
         let _ = srgb_to_linear(0.5);
+    }
+
+    /// `apply_with_layouts` rejects `src == dst` with an `Err`. Catches
+    /// the caller-side cache-reuse bug class (a layer's `texture`
+    /// referring to the same VkImage as the per-port intermediate)
+    /// directly, instead of surfacing it as VUID-01197 validation
+    /// noise on every per-frame submit downstream. Mentally revert
+    /// the new precondition check at the top of
+    /// `VulkanToneMapper::apply_with_layouts` and this test fails.
+    #[test]
+    #[ignore = "hardware integration — requires a working Vulkan device + queue"]
+    fn apply_with_layouts_rejects_same_image_for_src_and_dst() {
+        let Some(device) = try_vulkan_device() else { return };
+        let texture = make_general_texture(&device, 8, 8, |_, _| [0; 4]);
+        let push = ToneMapperPushConstants::new(
+            8,
+            8,
+            TransferId::Pq,
+            TransferId::Srgb,
+            ToneCurveId::Bt2390,
+            1000.0,
+            100.0,
+        );
+        let mapper = VulkanToneMapper::new(&device);
+        let result = mapper.apply_with_layouts(
+            &texture,
+            VulkanLayout::GENERAL,
+            &texture, // same VkImage handle as src
+            VulkanLayout::GENERAL,
+            &push,
+        );
+        match result {
+            Err(crate::core::Error::Configuration(msg)) => {
+                assert!(
+                    msg.contains("distinct VkImages"),
+                    "expected distinct-VkImages diagnostic, got: {msg}"
+                );
+            }
+            other => panic!("expected Err(Configuration), got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Consumer fix in `BlendingCompositor::normalize_layer`: short-circuit when `layer.normalized_layout.is_some()` so a cached intermediate isn't re-tone-mapped with itself as both src and dst on ticks where no fresh camera frame arrived.
- Engine-layer hardening in `RhiToneMapper::apply_with_layouts`: reject `src == dst` (same VkImage) with a typed `Err(Configuration)` — catches the misuse class at the call site instead of as VUID-01197 validation noise downstream.
- Document the tone-mapper contract: src/dst must be distinct VkImages, helper does not touch `TextureRegistration` (caller updates if needed).

## Closes
Closes #1088

## Root cause

Bug body in #1088 fingered `TextureRegistration::update_layout` desync — superseded after reproduction. Actual sequence:

1. Tick T: `refresh_layer` populates `state.last_video.texture` from the camera ring slot. `normalize_layer` engages (`Smpte170m` ≠ `Identity` working space), tone-maps camera → intermediate, sets `layer.texture = intermediate.texture` (line 969).
2. Tick T+1: BC runs ~60fps, camera ~30fps — `refresh_layer` returns early when no new IPC frame is queued. `state.last_video.texture` is still the cached intermediate.
3. `normalize_layer` runs again, calls `apply_with_layouts(&layer.texture /* = intermediate */, &intermediate.texture /* = same VkImage */)`. The 4-barrier sequence (src → GENERAL, dst → GENERAL, src → SROO, dst → SROO) issues conflicting layout claims on the single image — `VUID-VkImageMemoryBarrier2-oldLayout-01197` trips twice per submit.

Reproduction (pre-fix): 20 VUID-01197 errors on one VkImage, alternating "SROO when prev=GENERAL" and "GENERAL when prev=SROO" pairs at the same timestamps.

## Exit criteria

- [x] No `VUID-VkImageMemoryBarrier2-oldLayout-01197` errors during camera-python-display E2E with `VK_LOADER_LAYERS_ENABLE=*validation*` (verified: 20 → 0).
- [x] Tone-mapper's contract for layout-state synchronization documented (rustdoc on `core/rhi/tone_mapper.rs::apply_with_layouts` + `vulkan/rhi/vulkan_tone_mapper.rs::apply_with_layouts`).

## Test plan

- [x] `cargo test -p streamlib-engine --lib vulkan_tone_mapper` — 3 passed (2 ignored, GPU-integration).
- [x] `cargo test -p streamlib-engine --lib vulkan_tone_mapper -- --ignored` (with GPU) — 2 passed, including the new `apply_with_layouts_rejects_same_image_for_src_and_dst` regression test.
- [x] `cargo test -p camera-python-display-effects --lib` — 14 passed.
- [x] E2E: `VK_LOADER_LAYERS_ENABLE=*validation*` camera-python-display run, 60 frame limit.
  - Pre-fix: 20× VUID-VkImageMemoryBarrier2-oldLayout-01197 on a single VkImage.
  - Post-fix: 0× VUID-01197. No `OUT_OF_DEVICE_MEMORY`, `DEVICE_LOST`, or `process() failed`.

## Follow-ups

- Two pre-existing validation classes (`VUID-VkImageMemoryBarrier2-srcAccessMask-03913` + `VUID-VkImageMemoryBarrier2-dstAccessMask-03911`) still fire from the tone-mapper's first-tick barrier dance — separate access-mask bug, unrelated to layout-tracker desync. Worth its own issue; out of scope here.
- Two pre-existing test failures in `core::compiler::compiler_ops::subprocess_escalate::tests::deno_subprocess` (`deno_log_burst_preserves_order`, `deno_log_surfaces_in_host_jsonl`) fail on `main` too — confirmed by re-running with my changes stashed. Unrelated to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)