### PR TITLE
refactor(adapter): lift surface-adapter timelines to single-writer-per-edge (#1087)

### DIFF
--- a/docs/architecture/adapter-authoring.md
+++ b/docs/architecture/adapter-authoring.md
@@ -42,32 +42,36 @@ The canonical recipe:
 2. **Host setup pre-allocates** whatever per-surface resources the
    adapter needs (an exportable `VkImage` for vulkan/opengl/skia,
    an exportable HOST_VISIBLE staging `VkBuffer` for cpu-readback,
-   an OPAQUE_FD-exportable `VkBuffer` for cuda) plus an exportable
-   timeline semaphore, and **registers them via surface-share**
-   under a UUID. The host RHI does the privileged work
-   (modifier discovery, VMA pool selection, cap-handling around
-   the swapchain).
+   an OPAQUE_FD-exportable `VkBuffer` for cuda) plus **two
+   exportable timeline semaphores** (`produce_done` + `consume_done`,
+   one per direction of the producer ↔ consumer edge — see
+   [`adapter-timeline-single-writer.md`](adapter-timeline-single-writer.md)
+   for the single-writer-per-edge contract), and **registers them
+   via surface-share** under a UUID. The host RHI does the
+   privileged work (modifier discovery, VMA pool selection,
+   cap-handling around the swapchain).
 
 3. **Subprocess setup looks up the registration** via surface-share
    and **imports the FDs through `streamlib-consumer-rhi`** —
    `ConsumerVulkanTexture::from_dma_buf_fd`,
    `ConsumerVulkanBuffer::from_dma_buf_fd` (single-plane) /
    `from_dma_buf_fds` (multi-plane) / `from_opaque_fd` (cuda's
-   OPAQUE_FD path), and
+   OPAQUE_FD path), and a pair of
    `ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd`
-   (timeline semaphores cross processes via OPAQUE_FD only,
-   regardless of whether the data resource is DMA-BUF or
+   (one per edge; timeline semaphores cross processes via OPAQUE_FD
+   only, regardless of whether the data resource is DMA-BUF or
    OPAQUE_FD). Then instantiates the **same** adapter type against
    a `ConsumerVulkanDevice`.
 
-4. **Per-acquire is timeline-wait + layout-transition**. Both run
-   through traits the carve-out exposes — no privileged ops. If
+4. **Per-acquire is `produce_done`-wait + layout-transition**. Both
+   run through traits the carve-out exposes — no privileged ops. If
    the host has work to do per acquire (cpu-readback's
    `vkCmdCopyImageToBuffer`, escalated compute / graphics /
    ray-tracing dispatch), it's a **thin trigger** — IPC publishes
-   a timeline value, the subprocess waits on the imported
-   timeline through the carve-out. No fresh FD-passing payload
-   per acquire.
+   the next `produce_done` value, the subprocess waits on the
+   imported `produce_done` through the carve-out, then signals
+   `consume_done` from `end_read_access` once the read completes.
+   No fresh FD-passing payload per acquire.
 
 5. **Runtime wiring is a single `install_setup_hook` call** at app
    startup (see [Runtime wiring](#runtime-wiring) below). The hook
@@ -140,8 +144,10 @@ The pattern every in-tree adapter follows:
   `streamlib-adapter-abi`. Don't roll your own `Mutex<HashMap<SurfaceId, _>>`
   — `Registry` already encodes the read/write contention machine.
 - `try_begin_read` / `try_begin_write` snapshot under the registry
-  lock and return everything `finalize_*` needs unlocked (timeline
-  Arc, current layout, image handle).
+  lock and return everything `finalize_*` needs unlocked (the
+  relevant timeline Arc — `produce_done` for reads, `consume_done`
+  for writers waiting on prior consumers — current layout, image
+  handle).
 - `finalize_*` does the timeline wait + layout transition outside
   the lock, with a rollback path on failure.
 - `acquire_*` returns `AdapterError::WriteContended` (with a
@@ -149,8 +155,11 @@ The pattern every in-tree adapter follows:
   blocked read, the contender's role from a blocked write) when
   `try_begin_*` returns `Ok(None)`; `try_acquire_*` returns
   `Ok(None)` instead.
-- `end_read_access` / `end_write_access` (sealed methods called
-  from the guard's `Drop`) signal the next timeline value.
+- `end_read_access` (sealed method called from the guard's `Drop`)
+  signals the next `consume_done` value; `end_write_access` signals
+  the next `produce_done` value. See
+  [`adapter-timeline-single-writer.md`](adapter-timeline-single-writer.md)
+  for the single-writer-per-edge contract.
 
 `streamlib-adapter-vulkan/src/adapter.rs` is the reference shape.
 Read it before you start.
@@ -396,12 +405,12 @@ impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for <Name>SurfaceAdapter<D> {
 
     fn end_read_access(&self, surface_id: SurfaceId) {
         // Decrement read_holders; if last reader, signal the next
-        // release timeline value.
+        // consume_done value.
         todo!()
     }
 
     fn end_write_access(&self, surface_id: SurfaceId) {
-        // Clear write_held; signal the next release timeline value.
+        // Clear write_held; signal the next produce_done value.
         todo!()
     }
 }
@@ -430,12 +439,18 @@ runtime.install_setup_hook(move |gpu| {
     let host_device = Arc::clone(gpu.device().vulkan_device());
     let adapter = Arc::new(<Name>SurfaceAdapter::new(Arc::clone(&host_device)));
 
-    // Allocate + register host surface(s) the adapter manages.
+    // Allocate + register host surface(s) the adapter manages, plus
+    // the two per-edge timelines (produce_done + consume_done) per
+    // adapter-timeline-single-writer.md.
     // For DMA-BUF GPU adapters: gpu.acquire_render_target_dma_buf_image
-    //   + gpu.surface_store().register_texture(uuid, &texture).
+    //   + gpu.surface_store().register_texture(uuid, &texture,
+    //     Some(produce_done.as_ref()), Some(consume_done.as_ref()),
+    //     current_image_layout).
     // For OPAQUE_FD (cuda): HostVulkanBuffer::new_opaque_fd_export
-    //   + register with handle_type: "opaque_fd".
-    // For cpu-readback: HOST_VISIBLE staging VkBuffer + timeline.
+    //   + register with handle_type: "opaque_fd" plus the two
+    //     OPAQUE_FD-exportable timelines.
+    // For cpu-readback: HOST_VISIBLE staging VkBuffer + the two
+    //   timelines via register_pixel_buffer_with_timeline.
 
     register_host_surface(&adapter, gpu)?;
 
@@ -532,19 +547,26 @@ when **all three** are true:
 ### Implementation pattern
 
 **Host setup hook** — register the surface with surface-share
-**including** an exportable `HostVulkanTimelineSemaphore`, even
-when the producer adapter doesn't use the timeline itself. The
-subprocess's `VulkanSurfaceAdapter::register_host_surface` requires
-a timeline; without it the dual-registration call fails:
+**including** the two exportable `HostVulkanTimelineSemaphore`s
+(`produce_done` + `consume_done`), even when the producer adapter
+doesn't drive them itself. The subprocess's
+`VulkanSurfaceAdapter::register_host_surface` requires both
+timelines; without them the dual-registration call fails. See
+[`adapter-timeline-single-writer.md`](adapter-timeline-single-writer.md)
+for the single-writer-per-edge contract.
 
 ```rust
-let timeline = Arc::new(
+let produce_done = Arc::new(
+    HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)?,
+);
+let consume_done = Arc::new(
     HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)?,
 );
 store.register_texture(
     SCENARIO_SURFACE_UUID,
     &texture,
-    Some(timeline.as_ref()),  // required for dual-registration
+    Some(produce_done.as_ref()),
+    Some(consume_done.as_ref()),
     VulkanLayout::GENERAL,    // the producer's post-write layout
 )?;
 ```
@@ -631,10 +653,10 @@ DLPack requires a flat `void*` device pointer, which forces
 `cudaExternalMemoryGetMappedBuffer`, which only accepts a
 `VkBuffer`. `VkBuffer`s have no `VkImageLayout`, so QFOT-for-layout
 is structurally meaningless. Cross-process correctness for this
-path is provided by the timeline-semaphore alone (the cuda.py
-docstring: *"there is no per-acquire IPC — the host's pipeline is
-expected to write into the OPAQUE_FD buffer and signal the shared
-timeline ambiently."*).
+path is provided by the `produce_done` + `consume_done` timeline
+pair alone (the host pipeline writes into the OPAQUE_FD buffer and
+signals `produce_done` ambiently; the cdylib waits on `produce_done`
+before reading and signals `consume_done` in `end_read_access`).
 
 **Tiled-image path (`VkImage`)** — inherits this dual-registration
 pattern. CUDA's
@@ -855,6 +877,10 @@ Read these, in this order, when authoring:
   — *how* a subprocess obtains an adapter context end-to-end;
   `install_setup_hook` mechanics; explicit-vs-Cargo-feature
   trade-off.
+- [`adapter-timeline-single-writer.md`](adapter-timeline-single-writer.md)
+  — single-writer-per-edge contract for the `produce_done` +
+  `consume_done` timeline pair every subprocess-wired adapter
+  registers with surface-share.
 - [`compute-kernel.md`](compute-kernel.md) — host's
   `VulkanComputeKernel`, the dispatch primitive any adapter that
   needs compute reaches through (via escalate IPC from

--- a/docs/architecture/adapter-runtime-integration.md
+++ b/docs/architecture/adapter-runtime-integration.md
@@ -98,11 +98,11 @@ Concretely:
 
 | Adapter | Pattern (single shape) |
 |---|---|
-| `streamlib-adapter-vulkan` | Generic over `D: VulkanRhiDevice`. Host pre-registers `VkImage` + timeline via surface-share; subprocess imports through `ConsumerVulkanTexture` + `ConsumerVulkanTimelineSemaphore`. Per-acquire is layout-transition + timeline wait, no IPC. |
-| `streamlib-adapter-opengl` | Same shape; subprocess imports the `VkImage` and binds it as a `GL_TEXTURE_2D` via EGL DMA-BUF import. |
-| `streamlib-adapter-skia` | Same shape; composes on the vulkan adapter's import path (and also offers a GL backend that composes on the opengl adapter). |
-| `streamlib-adapter-cpu-readback` | Same shape: host pre-registers a HOST_VISIBLE staging `VkBuffer` + a timeline semaphore via surface-share; subprocess imports through `ConsumerVulkanBuffer` + `ConsumerVulkanTimelineSemaphore`. Per-acquire is a thin `RunCpuReadbackCopy(surface_id)` IPC that triggers the host's `vkCmdCopyImageToBuffer` and returns the timeline value to wait on. Subprocess waits on the imported timeline through the carve-out, then mmaps the pre-imported staging buffer. |
-| `streamlib-adapter-cuda` | Same shape with one twist on the FD wire — two resource flavors: **(a)** the flat-tensor DLPack path: host pre-registers a HOST_VISIBLE OPAQUE_FD-exportable `VkBuffer` (`HostVulkanBuffer::new_opaque_fd_export`) + an OPAQUE_FD-exportable timeline semaphore via surface-share; subprocess imports through `ConsumerVulkanBuffer::from_opaque_fd` + `ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd`, then maps the same FDs into CUDA via `cudaImportExternalMemory(OPAQUE_FD)` + `cudaImportExternalSemaphore(TimelineSemaphoreFd)`. The OPAQUE_FD handle type (rather than DMA-BUF) is forced by the DLPack zero-copy contract: PyTorch / JAX / NumPy `from_dlpack` consume `DLTensor.data` as a flat `void*`, and only `cudaExternalMemoryGetMappedBuffer` (which requires the source memory to be a `VkBuffer` exported as OPAQUE_FD) yields the flat pointer. **(b)** the tiled-image path: host pre-registers a DEVICE_LOCAL OPAQUE_FD-exportable `VkImage` (`HostVulkanTexture::new_opaque_fd_export`) — `VK_IMAGE_TILING_OPTIMAL`, no DRM modifier, format restricted to the CUDA-mappable subset (`Rgba8Unorm` / `Rgba16Float` / `Rgba32Float`) — and the subprocess imports through `ConsumerVulkanTexture::from_opaque_fd`. The same FD is then handed to CUDA via `cudaImportExternalMemory(OPAQUE_FD)` → `cudaExternalMemoryGetMappedMipmappedArray` for `cudaSurfaceObject_t` / `cudaTextureObject_t` backings. The mipmapped-array handle is opaque (not DLPack-compatible) but unlocks hardware-bilinear sampling, mipmap LOD selection, and surface-write writes from CUDA kernels — the texture-shaped slice that complements (a)'s flat-tensor slice. Per-acquire is timeline wait + (when the host pipeline produces frames into a different layout) a host-pipeline copy / blit that signals the next timeline value — no per-acquire IPC, no CUDA bridge trait. |
+| `streamlib-adapter-vulkan` | Generic over `D: VulkanRhiDevice`. Host pre-registers `VkImage` + two timeline semaphores (`produce_done` + `consume_done`) via surface-share; subprocess imports through `ConsumerVulkanTexture` + a pair of `ConsumerVulkanTimelineSemaphore`s. Per-acquire is layout-transition + `produce_done` wait, no IPC. The writer process signals `produce_done` in `end_write_access`; the reader process signals `consume_done` in `end_read_access`. Both edges typically use host CPU `signal_host`. See [`adapter-timeline-single-writer.md`](adapter-timeline-single-writer.md) for the single-writer-per-edge contract. |
+| `streamlib-adapter-opengl` | Same shape; subprocess imports the `VkImage` and binds it as a `GL_TEXTURE_2D` via EGL DMA-BUF import. (Has not yet lifted to the dual-timeline shape — see [`adapter-timeline-single-writer.md`](adapter-timeline-single-writer.md); will migrate in a separate issue.) |
+| `streamlib-adapter-skia` | Same shape; composes on the vulkan adapter's import path (and also offers a GL backend that composes on the opengl adapter). (Has not yet lifted to the dual-timeline shape — see [`adapter-timeline-single-writer.md`](adapter-timeline-single-writer.md); will migrate in a separate issue.) |
+| `streamlib-adapter-cpu-readback` | Same shape: host pre-registers a HOST_VISIBLE staging `VkBuffer` + two timeline semaphores (`produce_done` + `consume_done`) via surface-share; subprocess imports through `ConsumerVulkanBuffer` + a pair of `ConsumerVulkanTimelineSemaphore`s. Per-acquire is a thin `RunCpuReadbackCopy(surface_id)` IPC that triggers the host's `vkCmdCopyImageToBuffer` and signals `produce_done` via the trigger's `vkQueueSubmit2::pSignalSemaphoreInfos` slot; the subprocess waits on `produce_done`, mmaps the pre-imported staging buffer, then signals `consume_done` via CPU `signal_host` in `end_read_access`. See [`adapter-timeline-single-writer.md`](adapter-timeline-single-writer.md) for the single-writer-per-edge contract. |
+| `streamlib-adapter-cuda` | Same shape with one twist on the FD wire — two resource flavors: **(a)** the flat-tensor DLPack path: host pre-registers a HOST_VISIBLE OPAQUE_FD-exportable `VkBuffer` (`HostVulkanBuffer::new_opaque_fd_export`) + two OPAQUE_FD-exportable timeline semaphores (`produce_done` + `consume_done`) via surface-share; subprocess imports through `ConsumerVulkanBuffer::from_opaque_fd` + a pair of `ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd`, then maps the same FDs into CUDA via `cudaImportExternalMemory(OPAQUE_FD)` + `cudaImportExternalSemaphore(TimelineSemaphoreFd)`. The OPAQUE_FD handle type (rather than DMA-BUF) is forced by the DLPack zero-copy contract: PyTorch / JAX / NumPy `from_dlpack` consume `DLTensor.data` as a flat `void*`, and only `cudaExternalMemoryGetMappedBuffer` (which requires the source memory to be a `VkBuffer` exported as OPAQUE_FD) yields the flat pointer. **(b)** the tiled-image path: host pre-registers a DEVICE_LOCAL OPAQUE_FD-exportable `VkImage` (`HostVulkanTexture::new_opaque_fd_export`) — `VK_IMAGE_TILING_OPTIMAL`, no DRM modifier, format restricted to the CUDA-mappable subset (`Rgba8Unorm` / `Rgba16Float` / `Rgba32Float`) — and the subprocess imports through `ConsumerVulkanTexture::from_opaque_fd`. The same FD is then handed to CUDA via `cudaImportExternalMemory(OPAQUE_FD)` → `cudaExternalMemoryGetMappedMipmappedArray` for `cudaSurfaceObject_t` / `cudaTextureObject_t` backings. The mipmapped-array handle is opaque (not DLPack-compatible) but unlocks hardware-bilinear sampling, mipmap LOD selection, and surface-write writes from CUDA kernels — the texture-shaped slice that complements (a)'s flat-tensor slice. The host-side trigger that produces frames into the staging buffer signals `produce_done` via `vkQueueSubmit2::pSignalSemaphoreInfos`; the subprocess waits on `produce_done` before consuming and signals `consume_done` via CPU `signal_host` in `end_read_access`. No per-acquire IPC, no CUDA bridge trait. See [`adapter-timeline-single-writer.md`](adapter-timeline-single-writer.md) for the single-writer-per-edge contract. |
 
 All adapters follow this shape — no outliers.
 
@@ -196,9 +196,11 @@ The crossing **is** the IPC wire. Subprocess holds
 runs `vkCmdCopyImageToBuffer` on the host VkDevice + queue
 (queue mutex, fence pool, submit instrumentation all covered)
 into the staging buffer that was pre-registered via surface-share
-at setup time, and returns the timeline value to wait on. The
-subprocess waits on the imported timeline through the carve-out,
-then reads the pre-imported staging buffer it already mmapped.
+at setup time, and returns the `produce_done` timeline value to
+wait on. The subprocess waits on the imported `produce_done`
+timeline through the carve-out, reads the pre-imported staging
+buffer it already mmapped, then signals `consume_done` from
+`end_read_access`.
 
 There is no in-process `LimitedAccess → FullAccess` upgrade ever.
 The typestate split is enforced by the IPC boundary itself, the
@@ -257,10 +259,14 @@ The shape of what the hook does varies by seam:
 - **Surface-share seam** (Vulkan, OpenGL, Skia). The hook allocates
   the host's `Texture` (via
   `gpu.acquire_render_target_dma_buf_image` for render-target-capable
-  DMA-BUF), registers it in surface-share with a known UUID via
-  `gpu.surface_store().register_texture(uuid, &texture, timeline,
-  current_image_layout)` — `timeline` is an
-  `Option<&HostVulkanTimelineSemaphore>` for cross-process sync,
+  DMA-BUF), allocates the per-edge timelines (typically each via
+  `HostVulkanTimelineSemaphore::new_exportable`), registers them in
+  surface-share with a known UUID via
+  `gpu.surface_store().register_texture(uuid, &texture,
+  Some(produce_done.as_ref()), Some(consume_done.as_ref()),
+  current_image_layout)` — `produce_done` and `consume_done` are the
+  two `&HostVulkanTimelineSemaphore` handles (writer/reader directions
+  per [`adapter-timeline-single-writer.md`](adapter-timeline-single-writer.md)),
   `current_image_layout` is the producer's post-write `VulkanLayout`
   consumed by Path 2 QFOT acquire — and stashes any per-runtime
   sync state the adapter needs (timeline semaphores, DRM modifier
@@ -270,19 +276,24 @@ The shape of what the hook does varies by seam:
   — see [Dual-registration for in-process
   consumers](#dual-registration-for-in-process-consumers) below. No
   bridge — every subprocess acquire is a one-shot `check_out`.
+  (Vulkan rides the dual-timeline shape today; OpenGL and Skia
+  haven't lifted yet and will migrate in a separate issue.)
 - **Escalate-IPC seam** (cpu-readback). The hook constructs the
   `CpuReadbackSurfaceAdapter`, allocates + registers the host
-  surface(s) it serves, and registers a `CpuReadbackBridge`
-  implementation on the GpuContext via
+  surface(s) it serves (passing both `produce_done` and `consume_done`
+  through `register_pixel_buffer_with_timeline`), and registers a
+  `CpuReadbackBridge` implementation on the GpuContext via
   `gpu.set_cpu_readback_bridge(...)`. The bridge is the dispatch
   target the escalate handler reaches when a subprocess sends
-  `run_cpu_readback_copy`.
+  `run_cpu_readback_copy`; the trigger signals `produce_done`, the
+  subprocess signals `consume_done` in `end_read_access`.
 - **Surface-share seam with OPAQUE_FD** (cuda). The hook allocates a
   HOST_VISIBLE OPAQUE_FD-exportable `VkBuffer` via
   `HostVulkanBuffer::new_opaque_fd_export` (rather than
-  `acquire_render_target_dma_buf_image`) plus an OPAQUE_FD-exportable
-  timeline via `HostVulkanTimelineSemaphore::new_exportable`,
-  registers them through the same surface-share API with
+  `acquire_render_target_dma_buf_image`) plus two OPAQUE_FD-exportable
+  timelines (`produce_done` + `consume_done`, each via
+  `HostVulkanTimelineSemaphore::new_exportable`), registers them
+  through the same surface-share API with
   `RhiExternalHandle::OpaqueFd { fd, size }` so the wire format
   carries `handle_type: "opaque_fd"`. No bridge; the cdylib does the
   CUDA-side work (`cudaImportExternalMemory(OPAQUE_FD)` →
@@ -291,7 +302,8 @@ The shape of what the hook does varies by seam:
   host-pipeline side, when it needs to write into the staging
   buffer per frame, runs `vkCmdCopyImageToBuffer` as a normal
   pipeline step authored by whoever wired the runtime — not by the
-  adapter.
+  adapter — and that submit signals `produce_done`. The cdylib
+  signals `consume_done` from `end_read_access`.
 
 The compute / graphics / ray-tracing kernel bridges follow the same
 shape (`gpu.set_compute_kernel_bridge`, `set_graphics_kernel_bridge`,
@@ -335,7 +347,8 @@ gpu.surface_store()
     .register_texture(
         SCENARIO_SURFACE_UUID,
         &texture,
-        Some(timeline.as_ref()),
+        Some(produce_done.as_ref()),
+        Some(consume_done.as_ref()),
         VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
     )?;
 
@@ -346,6 +359,11 @@ gpu.register_texture_with_layout(
     VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
 );
 ```
+
+`produce_done` and `consume_done` are typically each allocated via
+`HostVulkanTimelineSemaphore::new_exportable`; the writer/reader
+contract is documented in
+[`adapter-timeline-single-writer.md`](adapter-timeline-single-writer.md).
 
 Both calls take the same `current_layout`. The producer is
 responsible for keeping the two declarations consistent — one is
@@ -457,6 +475,10 @@ property is load-bearing.
 - `docs/architecture/adapter-authoring.md` — implementation
   contract for new surface adapters (checklist, crate skeleton,
   trip-wires, hypothetical walkthrough)
+- `docs/architecture/adapter-timeline-single-writer.md` —
+  single-writer-per-edge contract for the `produce_done` +
+  `consume_done` timeline pair every subprocess-wired adapter
+  registers with surface-share
 - `docs/architecture/subprocess-rhi-parity.md` — how the
   subprocess obtains a usable RHI surface beyond the import-side
   carve-out (the integration-shape view of how the carve-out

--- a/docs/architecture/adapter-timeline-single-writer.md
+++ b/docs/architecture/adapter-timeline-single-writer.md
@@ -84,20 +84,30 @@ two-timelines-one-writer-each is the conventional answer.
 ```
 
 **Per-process `SurfaceState<P>` fields** (the per-adapter state
-record):
+record). The v1 implementation chooses a single per-process signal
+counter — within ONE adapter instance, signals to `produce_done` and
+`consume_done` come from disjoint code paths (write-release vs.
+read-release) so a unified monotonic counter is sufficient. Each
+timeline still sees strictly monotonic values from its own writer
+site, which is all VUID-03258 requires:
 
 ```rust
 produce_done: Arc<P::TimelineSemaphore>,
 consume_done: Arc<P::TimelineSemaphore>,
 
-// Writer-side state. Only the writer process advances these.
-next_produce_value: u64,     // producer side
-next_consume_value: u64,     // consumer side
-
-// Reader-side state. The waiter records what value to wait for.
-last_produce_value_observed: u64,   // consumer waits >= this on read
-last_consume_value_observed: u64,   // producer waits >= this on reuse
+// Per-process monotonic counter — advanced on every signal
+// regardless of which timeline gets it (see comment above).
+current_signal_value: u64,
 ```
+
+Read-side wait targets are derived from the peer-timeline's
+`current_value()` at acquire time (see [Consumer rules](#consumer-rules)
+/ [Producer rules](#producer-rules) below), not from a separate
+locally-tracked field. Split counters (`next_produce_value` /
+`next_consume_value`) become useful if a future shape ever needs
+both edges to advance concurrently within the same adapter
+instance; the v1 single-counter shape locks correctness for the
+in-tree usage where the writer code paths are disjoint.
 
 The two timelines are independent kernel objects. The producer
 process owns the `produce_done` exportable handle and constructs the
@@ -179,10 +189,21 @@ consumer attests to needing it; don't pre-design.
    per-process.** Never read or write the producer's
    `next_produce_value`.
 
-2. **Wait on `produce_done` before reading.** The producer publishes
-   the `produce_done` value alongside the read-side data (typically
-   in the `VideoFrame` IPC payload or the adapter's acquire-acquired
-   record). The consumer waits on that value before issuing any read.
+2. **Wait on `produce_done` before reading.** Under v1 the consumer
+   reads `produce_done.current_value()` at acquire time and waits on
+   that snapshot — the peer-timeline's kernel counter is the source
+   of truth, no cross-process per-frame value publishing is required.
+   That covers steady-state ordering (each completed producer signal
+   advances `current_value()` so the next consumer's wait sees it).
+   If a future use case needs strict per-frame value publishing
+   (e.g. the consumer wants to wait for a specific future frame
+   that's already been queued but not yet signaled), the producer
+   publishes the `produce_done` value alongside the read-side data
+   (typically on the `VideoFrame` IPC payload or the adapter's
+   acquire-acquired record) and the consumer waits on that value
+   instead of `current_value()`. v1 deliberately doesn't ship that
+   IPC plumbing — the kernel-counter snapshot is good enough for
+   every in-tree consumer today.
 
 3. **Signal `consume_done` from exactly one site per release.** For
    subprocess consumers (cuda + cpu-readback), the signal site is
@@ -242,18 +263,25 @@ workaround that future agents would attempt without this doc.
 
 ## Cross-process coordination
 
-The producer publishes `produce_done` values to the consumer
-alongside the per-frame work item — typically as a field on the
-`VideoFrame` IPC payload or the adapter's per-acquire record. The
-consumer's wait is `produce_done.wait(published_value)`.
+Under v1, each side derives the wait value from the peer-timeline's
+kernel counter (`vkGetSemaphoreCounterValue`, exposed on consumer-rhi
+as `VulkanTimelineSemaphoreLike::current_value()`) at acquire time
+and waits on that snapshot. Steady-state ordering holds: a completed
+producer signal advances `current_value()`, so the next consumer's
+wait sees it; symmetric for `consume_done`.
 
-The consumer publishes `consume_done` values back to the producer
-the same way, when the producer needs to wait on consumer drain
-before re-writing.
+If a future use case needs strict per-frame value publishing — e.g.
+a consumer that wants to wait for a specific future frame the
+producer has already queued but not yet signaled — the producer
+publishes the `produce_done` value alongside the per-frame work item
+(a field on the `VideoFrame` IPC payload or the adapter's
+per-acquire record) and the consumer waits on that value instead of
+`current_value()`. v1 deliberately doesn't ship that IPC plumbing —
+no in-tree consumer needs it today.
 
-No shared-memory state is needed. Each side's wait reads the
-remote-published value once, waits on the local imported timeline,
-and proceeds.
+No shared-memory state is needed in either shape. Each side's wait
+reads the value (kernel counter or remote-published, depending on
+shape), waits on the local imported timeline, and proceeds.
 
 ## Race model
 

--- a/docs/architecture/adapter-timeline-single-writer.md
+++ b/docs/architecture/adapter-timeline-single-writer.md
@@ -1,0 +1,329 @@
+# Single-writer-per-edge surface-adapter timelines
+
+> **Living document.** Validate, update, critique freely per
+> [CLAUDE.md's markdown editing rules](../../CLAUDE.md#editing-markdown-documentation).
+> Verify against current code before generalizing.
+
+## What this is
+
+Every surface registered through a streamlib subprocess-wired surface
+adapter (`streamlib-adapter-cuda`, `streamlib-adapter-vulkan`,
+`streamlib-adapter-cpu-readback`) carries **two Vulkan timeline
+semaphores**, one per direction of the producer ↔ consumer edge:
+
+| Timeline | Single writer | Read by |
+|---|---|---|
+| `produce_done` | producer process | consumer process (waits before reading) |
+| `consume_done` | consumer process | producer process (waits before re-writing) |
+
+**Single-writer per timeline** is the load-bearing rule. The process
+that owns a timeline is the only process that ever issues a
+`vkSignalSemaphore` or `vkQueueSubmit2::pSignalSemaphoreInfos` against
+it. The other process only ever waits (`vkSemaphoreWaitInfo` /
+`vkQueueSubmit2::pWaitSemaphoreInfos`).
+
+With one writer per timeline, the next-value computation is a pure
+function of per-process state. No cross-process coordination is
+required for monotonicity, and `VUID-VkSemaphoreSignalInfo-value-03258`
+("signal value must be strictly greater than current value") holds by
+construction.
+
+## Why it exists
+
+Before this lift, every surface had **one** timeline kernel object with
+**two writers** racing on its next-value computation: the host
+producer signaled it (via `vkQueueSubmit2` or host CPU
+`signal_host`), and the subprocess consumer ALSO signaled it (via
+CPU `signal_host` against the imported timeline). Each side computed
+its next value as `state.current_release_value + 1` from a
+per-process counter; the timeline kernel object was shared. The two
+writers raced on value computation, tripping
+`VUID-VkSemaphoreSignalInfo-value-03258` in production.
+
+The "two timelines, one writer each" shape is what every production
+engine surveyed converged on:
+
+- **Unreal RHI** — fences are signaled by one queue submit per
+  fence; readers wait. No multi-writer pattern on a single fence.
+- **Granite** — `ExternalHandle` cross-process surfaces ride a
+  directional pair (Granite produces, vendor API consumes); the
+  signal side is always one writer.
+- **wgpu-core** — a single tracker in the hub serializes all
+  resource state; clients are passive.
+- **Chromium GPU process** — all GPU work runs in the GPU process;
+  the renderer is a passive client.
+- **Khronos `VK_EXT_external_memory_acquire_unmodified` proposal**
+  — states the underlying principle: "the kernel can't atomically
+  coordinate two writers, so application protocol picks one."
+
+None of these systems implement multi-writer-per-timeline. The
+streamlib pre-lift shape was an artifact of treating the timeline as
+shared mutable state across the process boundary; lifting to
+two-timelines-one-writer-each is the conventional answer.
+
+## The shape
+
+```
+                     ┌────────── Surface (surface_id) ──────────┐
+                     │                                          │
+   PRODUCER process  │   produce_done                           │   CONSUMER process
+   ────────────────► │   (timeline)         ─── waits on ────►  │   ────────────────►
+   signals ▲         │                                          │         ▼ reads
+           │         │   consume_done                           │
+   ◄─── waits on ─── │   (timeline)         ◄─── signals ───    │
+                     │                                          │
+                     └──────────────────────────────────────────┘
+
+   produce_done writer: the producer process — one writer
+     (either vkQueueSubmit2::pSignalSemaphoreInfos for GPU-side
+     producers, or host CPU signal_host for CPU-side producers).
+
+   consume_done writer: the consumer process — one writer
+     (host CPU signal_host on the imported timeline, from
+     within the consumer process's address space).
+```
+
+**Per-process `SurfaceState<P>` fields** (the per-adapter state
+record):
+
+```rust
+produce_done: Arc<P::TimelineSemaphore>,
+consume_done: Arc<P::TimelineSemaphore>,
+
+// Writer-side state. Only the writer process advances these.
+next_produce_value: u64,     // producer side
+next_consume_value: u64,     // consumer side
+
+// Reader-side state. The waiter records what value to wait for.
+last_produce_value_observed: u64,   // consumer waits >= this on read
+last_consume_value_observed: u64,   // producer waits >= this on reuse
+```
+
+The two timelines are independent kernel objects. The producer
+process owns the `produce_done` exportable handle and constructs the
+imported handle for the consumer process; the consumer process owns
+the `consume_done` exportable handle and constructs the imported
+handle for the producer. Both are passed through the surface-share
+IPC schema as OPAQUE_FD timeline semaphore handles.
+
+## Per-adapter mapping
+
+| Adapter | Producer side | Consumer side | `produce_done` writer | `consume_done` writer |
+|---|---|---|---|---|
+| **cuda** | host (`submit_host_copy_image_to_buffer` does the `vkCmdCopyImageToBuffer` into the OPAQUE_FD staging buffer) | subprocess (CUDA imports the buffer FD + reads via `cudaExternalMemoryGetMappedBuffer`) | host: `vkQueueSubmit2::pSignalSemaphoreInfos` from the trigger submit | subprocess: CPU `signal_host` in `end_read_access` (against the consumer-rhi imported timeline) |
+| **cpu-readback** | host (trigger's `vkCmdCopyImageToBuffer` in `acquire_inner`) | subprocess (mmap-reads the HOST_VISIBLE staging buffer) | host: `vkQueueSubmit2::pSignalSemaphoreInfos` from the trigger submit | subprocess: CPU `signal_host` in `end_read_access` (restored under this lift — was defanged pre-lift because the multi-writer race could not be sound) |
+| **vulkan** | the side that calls `begin_write` (host or subprocess, exclusive) | the side that calls `begin_read` | the writer process: CPU `signal_host` in `end_write_access` | the reader process: CPU `signal_host` in `end_read_access` |
+
+For the vulkan adapter, "the side that calls `begin_write`" is the
+process that holds the write lock at the time of release. The
+`write_held` mutual-exclusion guarantees only one process can write
+at a time; the writer process signals `produce_done` from its own
+state.
+
+## The v1 model: one producer process + one consumer process per surface
+
+This lift declares **one producer process and one consumer process
+per surface**, fixed at registration time. Multi-process concurrent
+consumers (two subprocesses concurrently reading the same surface)
+are out of scope for v1 — the producer process must publish to a
+single consumer process, with fan-out happening at a higher layer
+(pre-fan-out at the producer, or one subprocess with multiple
+internal readers).
+
+This is the model every production engine surveyed uses. The
+"multiple subprocesses concurrently reading the same VkImage"
+pattern that the pre-lift vulkan adapter's
+`concurrent_reads_two_subprocesses` test exercised isn't a pattern
+real engines design for; it was an emergent capability of the
+pre-lift shape, not a designed feature. Same-process concurrent
+reads (multiple Python threads, multiple in-process processors)
+remain fully supported via the existing `read_holders`
+last-reader-out semantics — only one `signal_host(consume_done)`
+fires per release-episode regardless of how many local readers
+participated.
+
+**If a future use case genuinely needs multi-process concurrent
+consumers**, the additive extension is N `consume_done` timelines
+(one per attached consumer process), with the producer waiting on
+ALL of them before re-writing. Lift to that shape when a real
+consumer attests to needing it; don't pre-design.
+
+## Producer rules
+
+1. **Allocate both timelines at registration.** The producer owns
+   `produce_done` (exportable, OPAQUE_FD) and creates the consumer's
+   `consume_done` (exportable, OPAQUE_FD) — both flow through
+   surface-share alongside the resource FDs.
+
+2. **Track `next_produce_value` and `last_consume_value_observed`
+   per-process.** Never read or write the consumer's
+   `next_consume_value`. The consumer's signal is observed only via
+   `vkSemaphoreWaitInfo` on `consume_done`.
+
+3. **Signal `produce_done` from exactly one site per release.** For
+   GPU-side producers (cuda + cpu-readback triggers), the signal is
+   the `vkQueueSubmit2::pSignalSemaphoreInfos` slot on the trigger's
+   submit. For CPU-side producers (vulkan adapter's
+   `end_write_access`), the signal is `signal_host(next_value)`.
+   Never both.
+
+4. **Wait on `consume_done` before re-writing.** A producer that
+   wants to re-use a surface must first confirm the consumer is done
+   with the prior content — `produce_done.wait(prev_value)` confirms
+   GPU drain of the prior write, but `consume_done.wait(...)` is the
+   contract that the consumer has actually consumed it.
+
+## Consumer rules
+
+1. **Track `next_consume_value` and `last_produce_value_observed`
+   per-process.** Never read or write the producer's
+   `next_produce_value`.
+
+2. **Wait on `produce_done` before reading.** The producer publishes
+   the `produce_done` value alongside the read-side data (typically
+   in the `VideoFrame` IPC payload or the adapter's acquire-acquired
+   record). The consumer waits on that value before issuing any read.
+
+3. **Signal `consume_done` from exactly one site per release.** For
+   subprocess consumers (cuda + cpu-readback), the signal site is
+   the subprocess-side `end_read_access` — `signal_host(next_value)`
+   on the consumer-rhi imported timeline. For the vulkan adapter's
+   consumer side, the same `end_read_access` shape applies whether
+   the consumer is in-process or out-of-process.
+
+4. **Last-reader-out semantics inside one consumer process.**
+   Multiple concurrent readers within the same process coordinate
+   via the existing `read_holders` counter; only the last reader to
+   release signals `consume_done`. This stays unchanged under the
+   lift.
+
+## Anti-patterns
+
+These are the failure modes the single-writer rule exists to
+prevent. Each was either tried and rejected, or is the foreseeable
+workaround that future agents would attempt without this doc.
+
+1. **Multi-writer per timeline.** The pre-lift shape. Two
+   processes signaling the same timeline kernel object from
+   independent per-process counters races on monotonicity. The lift
+   exists to make this unreachable; do not re-introduce it.
+
+2. **Cross-process atomic counter as next-value oracle.** The
+   alternative the issue body ruled out — use shared-memory atomic
+   state for the next-value computation. Adds non-Vulkan IPC,
+   doesn't match production engines, doesn't generalize to
+   additional consumers. Single-writer-per-timeline is the answer.
+
+3. **Safety-net clamp as architectural fallback.** The
+   `signal_host` clamp removed under this lift
+   (`consumer_vulkan_sync.rs` + `vulkan_sync.rs`, both pre-lift)
+   self-corrected to `max(value, current+1)` to dodge VUID-03258.
+   That was correct as a bridge while the multi-writer shape was in
+   place, but it's not an architecture; it's a fault-tolerance
+   patch. Don't re-add it as a "just in case" defense once the lift
+   lands — the right way to enforce single-writer-per-timeline is
+   the type system and the IPC schema, not runtime clamping.
+
+4. **Conflating `produce_done` with `consume_done` via a single
+   "current value" notion.** A surface has two independent monotonic
+   counters going forward, not one. Code that reaches for a single
+   `current_release_value` to satisfy both edges is re-introducing
+   the multi-writer race in disguise.
+
+5. **Producer signaling `consume_done` or consumer signaling
+   `produce_done`.** Each timeline has exactly one writer process.
+   "But just this once" is exactly the failure pattern; don't
+   special-case.
+
+6. **Multiple consumer processes attaching to one surface in v1.**
+   Out of scope. If you find yourself needing it, lift to the
+   N-`consume_done`-timelines extension cleanly; don't shoehorn it
+   into the v1 single-consumer shape.
+
+## Cross-process coordination
+
+The producer publishes `produce_done` values to the consumer
+alongside the per-frame work item — typically as a field on the
+`VideoFrame` IPC payload or the adapter's per-acquire record. The
+consumer's wait is `produce_done.wait(published_value)`.
+
+The consumer publishes `consume_done` values back to the producer
+the same way, when the producer needs to wait on consumer drain
+before re-writing.
+
+No shared-memory state is needed. Each side's wait reads the
+remote-published value once, waits on the local imported timeline,
+and proceeds.
+
+## Race model
+
+Each timeline has exactly one writer process; next-value computation
+is a pure function of that process's local state. There is no race
+on monotonicity.
+
+The cross-process IPC payload publishing `produce_done` /
+`consume_done` values can in principle be observed by the consumer
+before the corresponding signal has actually fired on the GPU — but
+that's what `wait` is for; the consumer's wait blocks until the
+signal materializes. No ordering primitive beyond the timeline
+itself is required.
+
+## Tests
+
+Per-adapter conformance:
+
+1. **Unit test** exercising concurrent producer + consumer
+   acquire/release cycles against a real Vulkan device. Asserts:
+   - Zero `VUID-VkSemaphoreSignalInfo-value-03258` occurrences (the
+     race the lift exists to fix).
+   - Zero `signal_host` clamp warnings (since the clamp is removed,
+     this collapses to "the test runs without the clamp's safety
+     net").
+   - `produce_done.current_value()` and `consume_done.current_value()`
+     advance monotonically and independently.
+
+2. **E2E** — `camera-python-display` through the full multi-process
+   polyglot pipeline with `VK_LOADER_LAYERS_ENABLE=*validation*`.
+   Zero timeline-monotonicity validation errors.
+
+When a new adapter lands, add the same dual-timeline conformance
+coverage to its tests; the contract is uniform across all three
+subprocess-wired adapters and any future siblings.
+
+## Reference
+
+- **Engine RHI primitives**:
+  - `HostVulkanTimelineSemaphore::new_exportable`,
+    `from_imported_opaque_fd`, `export_opaque_fd`, `wait`,
+    `signal_host`, `current_value` in
+    `libs/streamlib-engine/src/vulkan/rhi/vulkan_sync.rs`.
+  - `ConsumerVulkanTimelineSemaphore` mirror in
+    `libs/streamlib-consumer-rhi/src/consumer_vulkan_sync.rs`.
+  - `VulkanTimelineSemaphoreLike` trait in
+    `libs/streamlib-consumer-rhi/src/device_capability.rs`.
+- **Adapters**:
+  - `libs/streamlib-adapter-cuda/src/{state,adapter}.rs`
+  - `libs/streamlib-adapter-vulkan/src/{state,adapter}.rs`
+  - `libs/streamlib-adapter-cpu-readback/src/{state,adapter}.rs`
+- **IPC schema**:
+  - `libs/streamlib-engine/src/linux/surface_share/state.rs` —
+    `SurfaceMetadata.produce_done_fd` and
+    `SurfaceMetadata.consume_done_fd`.
+  - `libs/streamlib-engine/src/linux/surface_share/unix_socket_service.rs`
+    — wire register/lookup paths.
+- **Companion docs**:
+  - [`adapter-runtime-integration.md`](adapter-runtime-integration.md)
+    — how a subprocess obtains an adapter context.
+  - [`adapter-authoring.md`](adapter-authoring.md) —
+    implementation contract for new surface adapters.
+  - [`subprocess-rhi-parity.md`](subprocess-rhi-parity.md) — the
+    consumer-rhi carve-out the imported timelines ride.
+  - [`texture-registration.md`](texture-registration.md) —
+    engine-wide per-surface lifecycle state record.
+- **External references**:
+  - [Khronos `VK_EXT_external_memory_acquire_unmodified`
+    proposal](https://docs.vulkan.org/features/latest/features/proposals/VK_EXT_external_memory_acquire_unmodified.html)
+    — articulates the single-writer principle.
+  - [Unreal Engine RHI fence
+    overview](https://dev.epicgames.com/documentation/en-us/unreal-engine/rendering-hardware-interface)
+    — single-signaler-per-fence pattern.

--- a/docs/architecture/subprocess-rhi-parity.md
+++ b/docs/architecture/subprocess-rhi-parity.md
@@ -78,20 +78,28 @@ Every surface adapter rides the same shape:
 - **Host setup** instantiates the adapter against a host-flavor device;
   pre-allocates whatever per-surface resources the adapter needs (an
   exportable `VkImage` for vulkan/opengl/skia; an exportable HOST_VISIBLE
-  staging `VkBuffer` + a timeline semaphore for cpu-readback; an
-  OPAQUE_FD HOST_VISIBLE `VkBuffer` for cuda) via the host RHI;
-  registers via surface-share.
+  staging `VkBuffer` for cpu-readback; an OPAQUE_FD HOST_VISIBLE
+  `VkBuffer` for cuda) plus **two exportable timeline semaphores**
+  (`produce_done` + `consume_done`, one per direction of the
+  producer ↔ consumer edge) via the host RHI; registers via
+  surface-share. See
+  [`adapter-timeline-single-writer.md`](adapter-timeline-single-writer.md)
+  for the single-writer-per-edge contract that governs the two
+  timelines.
 - **Subprocess setup** looks the registration up via surface-share,
   imports the FDs through `ConsumerVulkanTexture` /
-  `ConsumerVulkanBuffer` / `ConsumerVulkanTimelineSemaphore`, and
+  `ConsumerVulkanBuffer` plus a pair of
+  `ConsumerVulkanTimelineSemaphore`s (one per edge), and
   instantiates the **same** adapter type against a consumer-flavor
   device. Same trait surface, same acquire/release shape.
 - **Per-acquire IPC**, if the adapter needs the host to do work
   (cpu-readback's `vkCmdCopyImageToBuffer`, escalated compute dispatch
   via `register_compute_kernel` + `run_compute_kernel`), is a **thin
-  trigger** — "do the work, signal this timeline value when done" — and
-  the subprocess waits on the imported timeline through the carve-out,
-  not on a fresh FD-passing payload.
+  trigger** — "do the work, signal `produce_done` when done" — and
+  the subprocess waits on the imported `produce_done` timeline through
+  the carve-out, not on a fresh FD-passing payload; the subprocess
+  signals `consume_done` from `end_read_access` when it finishes
+  reading.
 
 The single-pattern principle is the engine-model rule
 ([CLAUDE.md "The StreamLib Engine Model"](../../CLAUDE.md#the-streamlib-engine-model))
@@ -125,7 +133,7 @@ adapters.
 | `VulkanComputeKernel` SPIR-V reflection + dispatch | Escalate IPC | `register_compute_kernel` + `run_compute_kernel` |
 | Graphics-pipeline draw | Escalate IPC | `register_graphics_kernel` + `run_graphics_draw` |
 | Ray-tracing AS build + trace | Escalate IPC | `register_acceleration_structure_blas` / `_tlas` + `register_ray_tracing_kernel` + `run_ray_tracing_kernel` |
-| `vkCmdCopyImageToBuffer` for cpu-readback | Escalate IPC (thin trigger only; staging buffers + timeline pre-registered via surface-share) | Subprocess imports the staging buffer + timeline through `ConsumerVulkanBuffer` / `ConsumerVulkanTimelineSemaphore` once at registration, then per-acquire is `run_cpu_readback_copy(surface_id) → done(timeline_value)` plus a consumer-side wait |
+| `vkCmdCopyImageToBuffer` for cpu-readback | Escalate IPC (thin trigger only; staging buffers + `produce_done` / `consume_done` timelines pre-registered via surface-share) | Subprocess imports the staging buffer + both timelines through `ConsumerVulkanBuffer` / `ConsumerVulkanTimelineSemaphore` once at registration, then per-acquire is `run_cpu_readback_copy(surface_id) → done(produce_done_value)` plus a consumer-side wait; the subprocess signals `consume_done` in `end_read_access` |
 | Layout transitions / timeline waits beyond carve-out | Host-only | Adapter runs at acquire/release boundary |
 | Validation layers + tracing | Host-only | Subprocess uses `tracing::*!` macros via escalate `log` op |
 | Single `VkDevice` per process (NVIDIA dual-device crash) | Host has `FullAccess` device; subprocess has consumer-only device | Crash triggers on *concurrent submission*; subprocess submits nothing — provably safe ([learning](../learnings/nvidia-dual-vulkan-device-crash.md)) |
@@ -167,8 +175,9 @@ adapters.
 │  └───────┴──────┴────────┴──────┘                                    │
 │       ▲      ▲      ▲      ▲           Pre-registered surfaces via   │
 │       │ surface-share check_in (one-shot DMA-BUF / OPAQUE_FD +       │
-│       │ timeline FD passing); per-acquire IPC reduces to a thin      │
-│       │ trigger when host work is required.                          │
+│       │ paired produce_done + consume_done timeline FD passing);     │
+│       │ per-acquire IPC reduces to a thin trigger when host work     │
+│       │ is required.                                                 │
 │                                                                      │
 │  streamlib-adapter-skia is host-side only (composes on the OpenGL    │
 │  / Vulkan adapter per adapter-authoring's cross-process composition  │
@@ -217,6 +226,10 @@ Revisit when:
   *how* a subprocess obtains an adapter context.
 - [adapter-authoring.md](adapter-authoring.md) — implementation
   contract for new surface adapters.
+- [adapter-timeline-single-writer.md](adapter-timeline-single-writer.md)
+  — single-writer-per-edge contract for the `produce_done` +
+  `consume_done` timeline pair every subprocess-wired adapter
+  registers with surface-share.
 - [compute-kernel.md](compute-kernel.md) — host's `VulkanComputeKernel`.
 - [graphics-kernel.md](graphics-kernel.md) — host's
   `VulkanGraphicsKernel`.

--- a/docs/architecture/texture-registration.md
+++ b/docs/architecture/texture-registration.md
@@ -126,8 +126,13 @@ Examples that fit:
   frame.
 - ✓ `format`, `width`, `height` — could be hoisted from `Texture`
   for cheaper validation; arguably already covered by `texture`.
-- ✓ Exportable timeline-semaphore handle — for consumers that need to
-  GPU-wait without a side-channel.
+- ✓ Exportable timeline-semaphore handles — for consumers that need
+  to GPU-wait without a side-channel. Subprocess-wired adapter
+  surfaces today carry two timelines per surface (`produce_done` +
+  `consume_done`, one per direction of the producer ↔ consumer
+  edge); see
+  [`adapter-timeline-single-writer.md`](adapter-timeline-single-writer.md)
+  for the single-writer-per-edge contract.
 
 ### Out: state that doesn't fit any one of the criteria
 
@@ -492,6 +497,11 @@ When a new field lands on `TextureRegistration`:
   adapter scope, **not** parallel maps to `texture_cache` — see the
   [Scope](#scope-this-record-vs-adapter-internal-surfacestatep)
   section.
+- **Adapter timeline contract**:
+  [`adapter-timeline-single-writer.md`](adapter-timeline-single-writer.md)
+  — single-writer-per-edge contract for the `produce_done` +
+  `consume_done` timeline pair every subprocess-wired adapter
+  surface carries.
 - **External references**:
   - [Khronos `VK_EXT_external_memory_acquire_unmodified` proposal](https://docs.vulkan.org/features/latest/features/proposals/VK_EXT_external_memory_acquire_unmodified.html)
   - [Vulkan synchronization & queue-transfer chapter](https://docs.vulkan.org/spec/latest/chapters/synchronization.html)

--- a/examples/camera-python-display/effects/src/blending_compositor.rs
+++ b/examples/camera-python-display/effects/src/blending_compositor.rs
@@ -33,7 +33,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
-use streamlib::sdk::engine::host_rhi::HostVulkanTexture;
+use streamlib::sdk::engine::host_rhi::{HostVulkanTexture, HostVulkanTimelineSemaphore};
 use streamlib::sdk::engine::{HostSurfaceStoreExt, HostTextureExt};
 
 use streamlib::sdk::color::TransferId;
@@ -161,6 +161,14 @@ impl Default for BlendingCompositorConfig {
 struct OutputSlot {
     surface_id: String,
     texture: Texture,
+    // Per-slot single-writer-per-edge timeline pair held on the host
+    // side so cross-process consumers reaching the slot via
+    // `surface_store.lookup` see live timeline FDs (the registration
+    // duplicated them via SCM_RIGHTS but the host-side Arcs must
+    // outlive the surface). See
+    // `docs/architecture/adapter-timeline-single-writer.md`.
+    _produce_done: Arc<HostVulkanTimelineSemaphore>,
+    _consume_done: Arc<HostVulkanTimelineSemaphore>,
 }
 
 /// GPU backend bundle owned by the processor and moved into the
@@ -385,6 +393,29 @@ impl BlendingCompositorProcessor::Processor {
         let mut output_ring: Vec<OutputSlot> = Vec::with_capacity(OUTPUT_RING_DEPTH);
         for (slot_idx, (surface_id, texture)) in ring_descriptors.into_iter().enumerate()
         {
+            // Per-slot single-writer-per-edge exportable timelines —
+            // `produce_done` signaled by the host-side compositor,
+            // `consume_done` signaled by cross-process consumers (Glitch
+            // Python subprocess). See
+            // `docs/architecture/adapter-timeline-single-writer.md`.
+            let produce_done = Arc::new(
+                HostVulkanTimelineSemaphore::new_exportable(vulkan_device.device(), 0)
+                    .map_err(|e| {
+                        Error::Configuration(format!(
+                            "BlendingCompositor: HostVulkanTimelineSemaphore::new_exportable \
+                             (produce_done) slot {slot_idx}: {e}"
+                        ))
+                    })?,
+            );
+            let consume_done = Arc::new(
+                HostVulkanTimelineSemaphore::new_exportable(vulkan_device.device(), 0)
+                    .map_err(|e| {
+                        Error::Configuration(format!(
+                            "BlendingCompositor: HostVulkanTimelineSemaphore::new_exportable \
+                             (consume_done) slot {slot_idx}: {e}"
+                        ))
+                    })?,
+            );
             gpu_context.register_texture_with_layout(
                 &surface_id,
                 texture.clone(),
@@ -401,8 +432,8 @@ impl BlendingCompositorProcessor::Processor {
                 .register_texture(
                     &surface_id,
                     &texture,
-                    None,
-                    None,
+                    Some(produce_done.as_ref()),
+                    Some(consume_done.as_ref()),
                     VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
                 )
                 .map_err(|e| {
@@ -411,7 +442,12 @@ impl BlendingCompositorProcessor::Processor {
                          slot {slot_idx}: {e}"
                     ))
                 })?;
-            output_ring.push(OutputSlot { surface_id, texture });
+            output_ring.push(OutputSlot {
+                surface_id,
+                texture,
+                _produce_done: produce_done,
+                _consume_done: consume_done,
+            });
         }
         tracing::info!(
             "BlendingCompositor: pre-allocated {OUTPUT_RING_DEPTH} output ring slots ({width}x{height} BGRA8)"

--- a/examples/camera-python-display/effects/src/blending_compositor.rs
+++ b/examples/camera-python-display/effects/src/blending_compositor.rs
@@ -402,6 +402,7 @@ impl BlendingCompositorProcessor::Processor {
                     &surface_id,
                     &texture,
                     None,
+                    None,
                     VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
                 )
                 .map_err(|e| {

--- a/examples/camera-python-display/effects/src/crt_film_grain.rs
+++ b/examples/camera-python-display/effects/src/crt_film_grain.rs
@@ -288,6 +288,7 @@ impl CrtFilmGrainProcessor::Processor {
                     &surface_id,
                     &texture,
                     None,
+                    None,
                     VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
                 )
                 .map_err(|e| {

--- a/examples/camera-python-display/effects/src/crt_film_grain.rs
+++ b/examples/camera-python-display/effects/src/crt_film_grain.rs
@@ -24,6 +24,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use streamlib::sdk::engine::HostSurfaceStoreExt;
+use streamlib::sdk::engine::host_rhi::HostVulkanTimelineSemaphore;
 
 use streamlib::sdk::rhi::{Texture, TextureFormat, VulkanLayout};
 use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess};
@@ -51,6 +52,14 @@ const CRT_OUTPUT_SURFACE_UUIDS: [&str; OUTPUT_RING_DEPTH] = [
 struct OutputSlot {
     surface_id: String,
     texture: Texture,
+    // Per-slot single-writer-per-edge timeline pair held on the host
+    // side so cross-process consumers reaching the slot via
+    // `surface_store.lookup` see live timeline FDs (the registration
+    // duplicated them via SCM_RIGHTS but the host-side Arcs must
+    // outlive the surface). See
+    // `docs/architecture/adapter-timeline-single-writer.md`.
+    _produce_done: Arc<HostVulkanTimelineSemaphore>,
+    _consume_done: Arc<HostVulkanTimelineSemaphore>,
 }
 
 struct LinuxBackend {
@@ -271,6 +280,29 @@ impl CrtFilmGrainProcessor::Processor {
         let mut output_ring: Vec<OutputSlot> = Vec::with_capacity(OUTPUT_RING_DEPTH);
         for (slot_idx, (surface_id, texture)) in ring_descriptors.into_iter().enumerate()
         {
+            // Per-slot single-writer-per-edge exportable timelines —
+            // `produce_done` signaled by the host-side CRT kernel,
+            // `consume_done` signaled by cross-process consumers (Glitch
+            // Python subprocess). See
+            // `docs/architecture/adapter-timeline-single-writer.md`.
+            let produce_done = Arc::new(
+                HostVulkanTimelineSemaphore::new_exportable(vulkan_device.device(), 0)
+                    .map_err(|e| {
+                        Error::Configuration(format!(
+                            "CrtFilmGrain: HostVulkanTimelineSemaphore::new_exportable \
+                             (produce_done) slot {slot_idx}: {e}"
+                        ))
+                    })?,
+            );
+            let consume_done = Arc::new(
+                HostVulkanTimelineSemaphore::new_exportable(vulkan_device.device(), 0)
+                    .map_err(|e| {
+                        Error::Configuration(format!(
+                            "CrtFilmGrain: HostVulkanTimelineSemaphore::new_exportable \
+                             (consume_done) slot {slot_idx}: {e}"
+                        ))
+                    })?,
+            );
             gpu_context.register_texture_with_layout(
                 &surface_id,
                 texture.clone(),
@@ -287,8 +319,8 @@ impl CrtFilmGrainProcessor::Processor {
                 .register_texture(
                     &surface_id,
                     &texture,
-                    None,
-                    None,
+                    Some(produce_done.as_ref()),
+                    Some(consume_done.as_ref()),
                     VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
                 )
                 .map_err(|e| {
@@ -296,7 +328,12 @@ impl CrtFilmGrainProcessor::Processor {
                         "CrtFilmGrain: surface_store.register_texture slot {slot_idx}: {e}"
                     ))
                 })?;
-            output_ring.push(OutputSlot { surface_id, texture });
+            output_ring.push(OutputSlot {
+                surface_id,
+                texture,
+                _produce_done: produce_done,
+                _consume_done: consume_done,
+            });
         }
 
         tracing::info!(

--- a/examples/camera-python-display/src/linux.rs
+++ b/examples/camera-python-display/src/linux.rs
@@ -542,6 +542,7 @@ fn register_render_target_surface(
             uuid,
             &texture,
             None,
+            None,
             streamlib::sdk::rhi::VulkanLayout::GENERAL,
         )
         .map_err(|e| format!("{label}: surface_store.register_texture: {e}"))?;

--- a/examples/camera-python-display/src/linux.rs
+++ b/examples/camera-python-display/src/linux.rs
@@ -61,8 +61,13 @@
 
 use std::path::PathBuf;
 
+use std::sync::Arc;
+use std::sync::Mutex;
+
 use streamlib::sdk::context::GpuContext;
 use streamlib::sdk::engine::HostSurfaceStoreExt;
+use streamlib::sdk::engine::HostGpuDeviceExt;
+use streamlib::sdk::engine::host_rhi::HostVulkanTimelineSemaphore;
 use streamlib::sdk::rhi::TextureFormat;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::error::Error;
@@ -159,8 +164,20 @@ pub fn main() -> Result<()> {
     // and dual-registered (surface-share for cross-process consumers,
     // GpuContext::texture_cache for in-process Path 1 fast path — the
     // BlendingCompositor reads all three via Path 1).
+    //
+    // Each surface also carries a `produce_done` + `consume_done`
+    // exportable timeline pair per the single-writer-per-edge model;
+    // the host-side Arcs must outlive the surface so consumers can
+    // `lookup` them.
+    type TimelinePair = (
+        Arc<HostVulkanTimelineSemaphore>,
+        Arc<HostVulkanTimelineSemaphore>,
+    );
+    let timeline_slots: Arc<Mutex<Vec<TimelinePair>>> =
+        Arc::new(Mutex::new(Vec::with_capacity(4)));
+    let timeline_slots_hook = Arc::clone(&timeline_slots);
     runtime.install_setup_hook(move |gpu| {
-        register_render_target_surface(
+        let avatar_timelines = register_render_target_surface(
             gpu,
             AVATAR_OUTPUT_SURFACE_UUID,
             "avatar mesh-render output",
@@ -173,7 +190,7 @@ pub fn main() -> Result<()> {
         println!(
             "✓ Avatar OpenGL DMA-BUF output surface registered: uuid={AVATAR_OUTPUT_SURFACE_UUID}"
         );
-        register_render_target_surface(
+        let lower_third_timelines = register_render_target_surface(
             gpu,
             LOWER_THIRD_OUTPUT_SURFACE_UUID,
             "lower-third Skia output",
@@ -186,7 +203,7 @@ pub fn main() -> Result<()> {
         println!(
             "✓ Lower-third Skia DMA-BUF output surface registered: uuid={LOWER_THIRD_OUTPUT_SURFACE_UUID}"
         );
-        register_render_target_surface(
+        let watermark_timelines = register_render_target_surface(
             gpu,
             WATERMARK_OUTPUT_SURFACE_UUID,
             "watermark Skia output",
@@ -199,7 +216,7 @@ pub fn main() -> Result<()> {
         println!(
             "✓ Watermark Skia DMA-BUF output surface registered: uuid={WATERMARK_OUTPUT_SURFACE_UUID}"
         );
-        register_render_target_surface(
+        let glitch_timelines = register_render_target_surface(
             gpu,
             GLITCH_OUTPUT_SURFACE_UUID,
             "glitch OpenGL output",
@@ -212,8 +229,15 @@ pub fn main() -> Result<()> {
         println!(
             "✓ Glitch OpenGL DMA-BUF output surface registered: uuid={GLITCH_OUTPUT_SURFACE_UUID}"
         );
+        let mut slots = timeline_slots_hook.lock().unwrap();
+        slots.push(avatar_timelines);
+        slots.push(lower_third_timelines);
+        slots.push(watermark_timelines);
+        slots.push(glitch_timelines);
         Ok(())
     });
+    // Keep the timelines alive for the lifetime of the runtime.
+    let _runtime_timeline_slots = timeline_slots;
 
     // Camera processor (V4L2 on Linux). The camera config doesn't
     // expose width/height — the camera processor picks based on the
@@ -509,12 +533,20 @@ fn stage_effects_cdylib(effects_dir: &std::path::Path) -> Result<()> {
 /// watermark Skia) and dual-register it under `uuid`. The Skia adapter
 /// composes on the OpenGL adapter, so the host pre-allocation side is
 /// identical for both — same `acquire_render_target_dma_buf_image` +
-/// surface-share registration with no explicit timeline.
+/// surface-share registration.
+///
+/// Returns the `produce_done` + `consume_done` exportable timelines
+/// for the caller to stash; the surface-share registration duplicates
+/// their FDs via SCM_RIGHTS but the host-side Arcs must outlive the
+/// surface so consumers can `lookup` them.
 fn register_render_target_surface(
     gpu: &GpuContext,
     uuid: &str,
     label: &str,
-) -> std::result::Result<(), String> {
+) -> std::result::Result<
+    (Arc<HostVulkanTimelineSemaphore>, Arc<HostVulkanTimelineSemaphore>),
+    String,
+> {
     // `acquire_render_target_dma_buf_image` picks a tiled DRM modifier
     // — required on NVIDIA where linear DMA-BUFs are sampler-only when
     // imported through EGL (per
@@ -527,22 +559,43 @@ fn register_render_target_surface(
         )
         .map_err(|e| format!("{label}: acquire_render_target_dma_buf_image: {e}"))?;
 
+    // Single-writer-per-edge — two exportable timelines per
+    // `docs/architecture/adapter-timeline-single-writer.md`. The
+    // OpenGL/Skia adapters today don't drive Vulkan timeline signals
+    // (they rely on `glFinish` + DMA-BUF kernel-fence semantics) but
+    // the subprocess can dual-register the same surface with its
+    // `VulkanSurfaceAdapter` for cross-process QFOT release publishing
+    // (#644). The Vulkan adapter's `register_host_surface` requires
+    // both timelines; allocating them here keeps the registration
+    // forward-compatible when OpenGL/Skia gain dual-timeline support.
+    let host_device = Arc::clone(gpu.device().vulkan_device());
+    let produce_done = Arc::new(
+        HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+            .map_err(|e| format!(
+                "{label}: HostVulkanTimelineSemaphore::new_exportable (produce_done): {e}"
+            ))?,
+    );
+    let consume_done = Arc::new(
+        HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+            .map_err(|e| format!(
+                "{label}: HostVulkanTimelineSemaphore::new_exportable (consume_done): {e}"
+            ))?,
+    );
+
     let surface_store = gpu
         .surface_store()
         .ok_or_else(|| format!("{label}: GpuContext has no surface_store"))?;
-    // OpenGL/Skia adapters don't need an explicit Vulkan timeline:
-    // `glFinish` on release plus DMA-BUF kernel-fence semantics carry
-    // visibility for downstream consumers. GL writes leave the
-    // underlying DMA-BUF in GENERAL from Vulkan's perspective.
-    // Declaring it here means cross-process consumers reaching the
-    // surface via Path 2 issue their first QFOT acquire barrier from
-    // GENERAL — same convention as `polyglot-opengl-fragment-shader`.
+    // GL writes leave the underlying DMA-BUF in GENERAL from Vulkan's
+    // perspective. Declaring it here means cross-process consumers
+    // reaching the surface via Path 2 issue their first QFOT acquire
+    // barrier from GENERAL — same convention as
+    // `polyglot-opengl-fragment-shader`.
     surface_store
         .register_texture(
             uuid,
             &texture,
-            None,
-            None,
+            Some(produce_done.as_ref()),
+            Some(consume_done.as_ref()),
             streamlib::sdk::rhi::VulkanLayout::GENERAL,
         )
         .map_err(|e| format!("{label}: surface_store.register_texture: {e}"))?;
@@ -567,5 +620,5 @@ fn register_render_target_surface(
         VulkanLayout::UNDEFINED,
     );
 
-    Ok(())
+    Ok((produce_done, consume_done))
 }

--- a/examples/cuda-fisheye-detection/src/main.rs
+++ b/examples/cuda-fisheye-detection/src/main.rs
@@ -336,12 +336,22 @@ fn register_warped_host_surface(
     let texture: Texture = Texture::from_vulkan(host_texture);
     let texture_arc = Arc::clone(texture.vulkan_inner());
 
-    // 5. Exportable timeline. Initial value 0 — the first subprocess
-    //    `acquire_texture` waits on 0, which is satisfied immediately;
-    //    every release advances the counter by 1.
-    let timeline = Arc::new(
+    // 5. Exportable timelines — one per single-writer edge per
+    //    `docs/architecture/adapter-timeline-single-writer.md`. Initial
+    //    values 0; the first subprocess `acquire_texture` waits on 0,
+    //    which is satisfied immediately. Each release advances the
+    //    edge's writer-side counter by 1.
+    let produce_done = Arc::new(
         HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
-            .map_err(|e| format!("HostVulkanTimelineSemaphore::new_exportable: {e}"))?,
+            .map_err(|e| {
+                format!("HostVulkanTimelineSemaphore::new_exportable (produce_done): {e}")
+            })?,
+    );
+    let consume_done = Arc::new(
+        HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+            .map_err(|e| {
+                format!("HostVulkanTimelineSemaphore::new_exportable (consume_done): {e}")
+            })?,
     );
 
     // 6. One-shot upload + layout transition via the canonical
@@ -400,22 +410,23 @@ fn register_warped_host_surface(
         .register_texture(
             &SCENARIO_SURFACE_ID.to_string(),
             &texture,
-            Some(timeline.as_ref()),
-            None,
+            Some(produce_done.as_ref()),
+            Some(consume_done.as_ref()),
             VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
         )
         .map_err(|e| format!("surface_store.register_texture: {e}"))?;
 
     // 8. Cuda adapter registration. The adapter owns the host-side
-    //    `Arc<HostVulkanTexture>` + `Arc<HostVulkanTimelineSemaphore>`
-    //    for the surface's lifetime so the underlying GPU memory
-    //    stays alive while CUDA references the imported handle.
+    //    `Arc<HostVulkanTexture>` + per-edge timeline `Arc`s for the
+    //    surface's lifetime so the underlying GPU memory stays alive
+    //    while CUDA references the imported handles.
     adapter
         .register_host_image_surface(
             SCENARIO_SURFACE_ID,
             HostImageSurfaceRegistration::<HostMarker> {
                 texture: texture_arc,
-                timeline,
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
             },
         )

--- a/examples/cuda-fisheye-detection/src/main.rs
+++ b/examples/cuda-fisheye-detection/src/main.rs
@@ -401,6 +401,7 @@ fn register_warped_host_surface(
             &SCENARIO_SURFACE_ID.to_string(),
             &texture,
             Some(timeline.as_ref()),
+            None,
             VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
         )
         .map_err(|e| format!("surface_store.register_texture: {e}"))?;

--- a/examples/polyglot-cpu-readback-blur/src/main.rs
+++ b/examples/polyglot-cpu-readback-blur/src/main.rs
@@ -363,13 +363,23 @@ fn register_host_surface(
         PixelFormat::Bgra32,
     );
 
-    // 3. Allocate the exportable timeline semaphore.
-    let timeline = Arc::new(
+    // 3. Allocate the exportable timeline semaphores — one per
+    //    single-writer edge per
+    //    `docs/architecture/adapter-timeline-single-writer.md`.
+    let produce_done = Arc::new(
         HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
-            .map_err(|e| format!("HostVulkanTimelineSemaphore::new_exportable: {e}"))?,
+            .map_err(|e| {
+                format!("HostVulkanTimelineSemaphore::new_exportable (produce_done): {e}")
+            })?,
+    );
+    let consume_done = Arc::new(
+        HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+            .map_err(|e| {
+                format!("HostVulkanTimelineSemaphore::new_exportable (consume_done): {e}")
+            })?,
     );
 
-    // 4. Register staging + timeline with the surface-share service so
+    // 4. Register staging + timelines with the surface-share service so
     //    the subprocess can `check_out` the FDs in one shot.
     let surface_store = gpu
         .surface_store()
@@ -378,8 +388,8 @@ fn register_host_surface(
         .register_pixel_buffer_with_timeline(
             &SCENARIO_SURFACE_ID.to_string(),
             &staging_rhi,
-            Some(timeline.as_ref()),
-            None,
+            Some(produce_done.as_ref()),
+            Some(consume_done.as_ref()),
         )
         .map_err(|e| format!("register_pixel_buffer_with_timeline: {e}"))?;
 
@@ -390,7 +400,8 @@ fn register_host_surface(
             HostSurfaceRegistration::<HostMarker> {
                 texture: Some(texture_arc),
                 staging_planes: vec![staging_arc],
-                timeline,
+                produce_done,
+                consume_done,
                 initial_image_layout: VulkanLayout::UNDEFINED,
                 format: SurfaceFormat::Bgra8,
                 width: SURFACE_SIZE,

--- a/examples/polyglot-cpu-readback-blur/src/main.rs
+++ b/examples/polyglot-cpu-readback-blur/src/main.rs
@@ -379,6 +379,7 @@ fn register_host_surface(
             &SCENARIO_SURFACE_ID.to_string(),
             &staging_rhi,
             Some(timeline.as_ref()),
+            None,
         )
         .map_err(|e| format!("register_pixel_buffer_with_timeline: {e}"))?;
 

--- a/examples/polyglot-cuda-inference/src/main.rs
+++ b/examples/polyglot-cuda-inference/src/main.rs
@@ -342,6 +342,7 @@ fn register_host_surface(
             &SCENARIO_SURFACE_ID.to_string(),
             &pixel_buffer_rhi,
             Some(timeline.as_ref()),
+            None,
         )
         .map_err(|e| format!("register_pixel_buffer_with_timeline: {e}"))?;
 

--- a/examples/polyglot-cuda-inference/src/main.rs
+++ b/examples/polyglot-cuda-inference/src/main.rs
@@ -306,12 +306,20 @@ fn register_host_surface(
         PixelFormat::Bgra32,
     );
 
-    // 2. Allocate the exportable timeline semaphore (initial value 0).
-    //    First subprocess `acquire_*` will wait on 0 → satisfied
-    //    immediately; release advances to 1.
-    let timeline = Arc::new(
-        HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
-            .map_err(|e| format!("HostVulkanTimelineSemaphore::new_exportable: {e}"))?,
+    // 2. Allocate the exportable timeline semaphores (initial value 0)
+    //    — one per single-writer edge per
+    //    `docs/architecture/adapter-timeline-single-writer.md`. First
+    //    subprocess `acquire_*` waits on 0 → satisfied immediately;
+    //    each release advances the corresponding edge's counter by 1.
+    let produce_done = Arc::new(
+        HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0).map_err(
+            |e| format!("HostVulkanTimelineSemaphore::new_exportable (produce_done): {e}"),
+        )?,
+    );
+    let consume_done = Arc::new(
+        HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0).map_err(
+            |e| format!("HostVulkanTimelineSemaphore::new_exportable (consume_done): {e}"),
+        )?,
     );
 
     // 3. Pre-fill the buffer with a known sentinel pattern (all zeros)
@@ -341,8 +349,8 @@ fn register_host_surface(
         .register_pixel_buffer_with_timeline(
             &SCENARIO_SURFACE_ID.to_string(),
             &pixel_buffer_rhi,
-            Some(timeline.as_ref()),
-            None,
+            Some(produce_done.as_ref()),
+            Some(consume_done.as_ref()),
         )
         .map_err(|e| format!("register_pixel_buffer_with_timeline: {e}"))?;
 
@@ -352,7 +360,8 @@ fn register_host_surface(
             SCENARIO_SURFACE_ID,
             HostSurfaceRegistration::<HostMarker> {
                 pixel_buffer: pixel_buffer_arc,
-                timeline,
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout::UNDEFINED,
             },
         )

--- a/examples/polyglot-opengl-fragment-shader/src/main.rs
+++ b/examples/polyglot-opengl-fragment-shader/src/main.rs
@@ -122,14 +122,17 @@ fn main() -> Result<()> {
     let texture_slot: Arc<
         Mutex<Option<streamlib::sdk::rhi::Texture>>,
     > = Arc::new(Mutex::new(None));
-    let timeline_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
+    let produce_done_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
+        Arc::new(Mutex::new(None));
+    let consume_done_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
         Arc::new(Mutex::new(None));
     let readback_slot: Arc<Mutex<Option<Arc<VulkanTextureReadback>>>> =
         Arc::new(Mutex::new(None));
 
     {
         let texture_slot = Arc::clone(&texture_slot);
-        let timeline_slot = Arc::clone(&timeline_slot);
+        let produce_done_slot = Arc::clone(&produce_done_slot);
+        let consume_done_slot = Arc::clone(&consume_done_slot);
         let readback_slot = Arc::clone(&readback_slot);
         runtime.install_setup_hook(move |gpu| {
             let texture = gpu.acquire_render_target_dma_buf_image(
@@ -152,23 +155,38 @@ fn main() -> Result<()> {
             // The OpenGL adapter itself doesn't need a Vulkan timeline:
             // `glFinish` on release plus DMA-BUF kernel-fence semantics
             // carry visibility for the host's pre-stop readback. We
-            // register one anyway so the subprocess can dual-register
-            // the same surface with its `VulkanSurfaceAdapter` (#644)
-            // for producer-side QFOT release publishing — the engine-
-            // model answer for cross-process content preservation per
+            // register two (single-writer-per-edge per
+            // `docs/architecture/adapter-timeline-single-writer.md`)
+            // anyway so the subprocess can dual-register the same
+            // surface with its `VulkanSurfaceAdapter` (#644) for
+            // producer-side QFOT release publishing — the engine-model
+            // answer for cross-process content preservation per
             // `docs/architecture/adapter-authoring.md`. The Vulkan
-            // adapter's `register_host_surface` requires a timeline,
-            // so the host must allocate one even when the producer is
+            // adapter's `register_host_surface` requires both timelines,
+            // so the host must allocate both even when the producer is
             // OpenGL-only.
             let host_device = Arc::clone(gpu.device().vulkan_device());
-            let timeline = Arc::new(
+            let produce_done = Arc::new(
                 HostVulkanTimelineSemaphore::new_exportable(
                     host_device.device(),
                     0,
                 )
                 .map_err(|e| {
                     Error::Configuration(format!(
-                        "HostVulkanTimelineSemaphore::new_exportable: {e}"
+                        "HostVulkanTimelineSemaphore::new_exportable \
+                         (produce_done): {e}"
+                    ))
+                })?,
+            );
+            let consume_done = Arc::new(
+                HostVulkanTimelineSemaphore::new_exportable(
+                    host_device.device(),
+                    0,
+                )
+                .map_err(|e| {
+                    Error::Configuration(format!(
+                        "HostVulkanTimelineSemaphore::new_exportable \
+                         (consume_done): {e}"
                     ))
                 })?,
             );
@@ -188,8 +206,8 @@ fn main() -> Result<()> {
                 .register_texture(
                     SCENARIO_SURFACE_UUID,
                     &texture,
-                    Some(timeline.as_ref()),
-                    None,
+                    Some(produce_done.as_ref()),
+                    Some(consume_done.as_ref()),
                     streamlib::sdk::rhi::VulkanLayout::GENERAL,
                 )
                 .map_err(|e| {
@@ -209,10 +227,11 @@ fn main() -> Result<()> {
             })?;
 
             *texture_slot.lock().unwrap() = Some(texture);
-            *timeline_slot.lock().unwrap() = Some(timeline);
+            *produce_done_slot.lock().unwrap() = Some(produce_done);
+            *consume_done_slot.lock().unwrap() = Some(consume_done);
             *readback_slot.lock().unwrap() = Some(readback);
             println!(
-                "✓ render-target DMA-BUF + timeline registered as '{}'",
+                "✓ render-target DMA-BUF + timelines registered as '{}'",
                 SCENARIO_SURFACE_UUID
             );
             Ok(())

--- a/examples/polyglot-opengl-fragment-shader/src/main.rs
+++ b/examples/polyglot-opengl-fragment-shader/src/main.rs
@@ -189,6 +189,7 @@ fn main() -> Result<()> {
                     SCENARIO_SURFACE_UUID,
                     &texture,
                     Some(timeline.as_ref()),
+                    None,
                     streamlib::sdk::rhi::VulkanLayout::GENERAL,
                 )
                 .map_err(|e| {

--- a/examples/polyglot-skia-canvas/src/main.rs
+++ b/examples/polyglot-skia-canvas/src/main.rs
@@ -99,14 +99,17 @@ fn main() -> Result<()> {
     let texture_slot: Arc<
         Mutex<Option<streamlib::sdk::rhi::Texture>>,
     > = Arc::new(Mutex::new(None));
-    let timeline_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
+    let produce_done_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
+        Arc::new(Mutex::new(None));
+    let consume_done_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
         Arc::new(Mutex::new(None));
     let readback_slot: Arc<Mutex<Option<Arc<VulkanTextureReadback>>>> =
         Arc::new(Mutex::new(None));
 
     {
         let texture_slot = Arc::clone(&texture_slot);
-        let timeline_slot = Arc::clone(&timeline_slot);
+        let produce_done_slot = Arc::clone(&produce_done_slot);
+        let consume_done_slot = Arc::clone(&consume_done_slot);
         let readback_slot = Arc::clone(&readback_slot);
         runtime.install_setup_hook(move |gpu| {
             // BGRA8: the EGL DMA-BUF importer hands the subprocess a
@@ -120,14 +123,27 @@ fn main() -> Result<()> {
                 SURFACE_SIZE,
                 TextureFormat::Bgra8Unorm,
             )?;
-            let timeline = Arc::new(
+            let produce_done = Arc::new(
                 HostVulkanTimelineSemaphore::new_exportable(
                     gpu.device().vulkan_device().device(),
                     0,
                 )
                 .map_err(|e| {
                     Error::Configuration(format!(
-                        "HostVulkanTimelineSemaphore::new_exportable: {e}"
+                        "HostVulkanTimelineSemaphore::new_exportable \
+                         (produce_done): {e}"
+                    ))
+                })?,
+            );
+            let consume_done = Arc::new(
+                HostVulkanTimelineSemaphore::new_exportable(
+                    gpu.device().vulkan_device().device(),
+                    0,
+                )
+                .map_err(|e| {
+                    Error::Configuration(format!(
+                        "HostVulkanTimelineSemaphore::new_exportable \
+                         (consume_done): {e}"
                     ))
                 })?,
             );
@@ -147,8 +163,8 @@ fn main() -> Result<()> {
                 .register_texture(
                     SCENARIO_SURFACE_UUID,
                     &texture,
-                    Some(timeline.as_ref()),
-                    None,
+                    Some(produce_done.as_ref()),
+                    Some(consume_done.as_ref()),
                     VulkanLayout::GENERAL,
                 )
                 .map_err(|e| {
@@ -170,10 +186,11 @@ fn main() -> Result<()> {
             })?;
 
             *texture_slot.lock().unwrap() = Some(texture);
-            *timeline_slot.lock().unwrap() = Some(timeline);
+            *produce_done_slot.lock().unwrap() = Some(produce_done);
+            *consume_done_slot.lock().unwrap() = Some(consume_done);
             *readback_slot.lock().unwrap() = Some(readback);
             println!(
-                "✓ render-target DMA-BUF + timeline registered as '{}'",
+                "✓ render-target DMA-BUF + timelines registered as '{}'",
                 SCENARIO_SURFACE_UUID
             );
             Ok(())

--- a/examples/polyglot-skia-canvas/src/main.rs
+++ b/examples/polyglot-skia-canvas/src/main.rs
@@ -148,6 +148,7 @@ fn main() -> Result<()> {
                     SCENARIO_SURFACE_UUID,
                     &texture,
                     Some(timeline.as_ref()),
+                    None,
                     VulkanLayout::GENERAL,
                 )
                 .map_err(|e| {

--- a/examples/polyglot-vulkan-compute/src/main.rs
+++ b/examples/polyglot-vulkan-compute/src/main.rs
@@ -295,6 +295,7 @@ fn main() -> Result<()> {
                     SCENARIO_SURFACE_UUID,
                     &texture,
                     Some(timeline.as_ref()),
+                    None,
                     streamlib::sdk::rhi::VulkanLayout::GENERAL,
                 )
                 .map_err(|e| {

--- a/examples/polyglot-vulkan-compute/src/main.rs
+++ b/examples/polyglot-vulkan-compute/src/main.rs
@@ -247,14 +247,17 @@ fn main() -> Result<()> {
     let texture_slot: Arc<
         Mutex<Option<streamlib::sdk::rhi::Texture>>,
     > = Arc::new(Mutex::new(None));
-    let timeline_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
+    let produce_done_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
+        Arc::new(Mutex::new(None));
+    let consume_done_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
         Arc::new(Mutex::new(None));
     let readback_slot: Arc<Mutex<Option<Arc<VulkanTextureReadback>>>> =
         Arc::new(Mutex::new(None));
 
     {
         let texture_slot = Arc::clone(&texture_slot);
-        let timeline_slot = Arc::clone(&timeline_slot);
+        let produce_done_slot = Arc::clone(&produce_done_slot);
+        let consume_done_slot = Arc::clone(&consume_done_slot);
         let readback_slot = Arc::clone(&readback_slot);
         runtime.install_setup_hook(move |gpu| {
             let texture = gpu.acquire_render_target_dma_buf_image(
@@ -263,15 +266,26 @@ fn main() -> Result<()> {
                 TextureFormat::Rgba8Unorm,
             )?;
             let host_device = Arc::clone(gpu.device().vulkan_device());
-            // The Vulkan adapter on the host needs a per-surface
-            // exportable timeline. The host signals it after the
-            // subprocess release; the subprocess waits on it before
-            // every acquire.
-            let timeline = Arc::new(
+            // The Vulkan adapter needs two per-surface exportable
+            // timelines — one per single-writer edge per
+            // `docs/architecture/adapter-timeline-single-writer.md`. The
+            // host signals `produce_done` after each write; the
+            // subprocess signals `consume_done` after each release.
+            let produce_done = Arc::new(
                 HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
                     .map_err(|e| {
                         Error::Configuration(format!(
-                            "HostVulkanTimelineSemaphore::new_exportable: {e}"
+                            "HostVulkanTimelineSemaphore::new_exportable \
+                             (produce_done): {e}"
+                        ))
+                    })?,
+            );
+            let consume_done = Arc::new(
+                HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+                    .map_err(|e| {
+                        Error::Configuration(format!(
+                            "HostVulkanTimelineSemaphore::new_exportable \
+                             (consume_done): {e}"
                         ))
                     })?,
             );
@@ -294,8 +308,8 @@ fn main() -> Result<()> {
                 .register_texture(
                     SCENARIO_SURFACE_UUID,
                     &texture,
-                    Some(timeline.as_ref()),
-                    None,
+                    Some(produce_done.as_ref()),
+                    Some(consume_done.as_ref()),
                     streamlib::sdk::rhi::VulkanLayout::GENERAL,
                 )
                 .map_err(|e| {
@@ -326,10 +340,11 @@ fn main() -> Result<()> {
             })?;
 
             *texture_slot.lock().unwrap() = Some(texture);
-            *timeline_slot.lock().unwrap() = Some(timeline);
+            *produce_done_slot.lock().unwrap() = Some(produce_done);
+            *consume_done_slot.lock().unwrap() = Some(consume_done);
             *readback_slot.lock().unwrap() = Some(readback);
             println!(
-                "✓ render-target DMA-BUF + timeline registered as '{}'",
+                "✓ render-target DMA-BUF + timelines registered as '{}'",
                 SCENARIO_SURFACE_UUID
             );
             Ok(())

--- a/examples/polyglot-vulkan-graphics/src/main.rs
+++ b/examples/polyglot-vulkan-graphics/src/main.rs
@@ -626,6 +626,7 @@ fn main() -> Result<()> {
                     SCENARIO_SURFACE_UUID,
                     &texture,
                     Some(timeline.as_ref()),
+                    None,
                     streamlib::sdk::rhi::VulkanLayout::COLOR_ATTACHMENT_OPTIMAL,
                 )
                 .map_err(|e| {

--- a/examples/polyglot-vulkan-graphics/src/main.rs
+++ b/examples/polyglot-vulkan-graphics/src/main.rs
@@ -585,14 +585,17 @@ fn main() -> Result<()> {
     let runtime = Runner::new()?;
 
     let texture_slot: Arc<Mutex<Option<Texture>>> = Arc::new(Mutex::new(None));
-    let timeline_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
+    let produce_done_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
+        Arc::new(Mutex::new(None));
+    let consume_done_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
         Arc::new(Mutex::new(None));
     let readback_slot: Arc<Mutex<Option<Arc<VulkanTextureReadback>>>> =
         Arc::new(Mutex::new(None));
 
     {
         let texture_slot = Arc::clone(&texture_slot);
-        let timeline_slot = Arc::clone(&timeline_slot);
+        let produce_done_slot = Arc::clone(&produce_done_slot);
+        let consume_done_slot = Arc::clone(&consume_done_slot);
         let readback_slot = Arc::clone(&readback_slot);
         runtime.install_setup_hook(move |gpu| {
             let texture = gpu.acquire_render_target_dma_buf_image(
@@ -601,11 +604,23 @@ fn main() -> Result<()> {
                 TextureFormat::Rgba8Unorm,
             )?;
             let host_device = Arc::clone(gpu.device().vulkan_device());
-            let timeline = Arc::new(
+            // Single-writer-per-edge — one timeline per direction per
+            // `docs/architecture/adapter-timeline-single-writer.md`.
+            let produce_done = Arc::new(
                 HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
                     .map_err(|e| {
                         Error::Configuration(format!(
-                            "HostVulkanTimelineSemaphore::new_exportable: {e}"
+                            "HostVulkanTimelineSemaphore::new_exportable \
+                             (produce_done): {e}"
+                        ))
+                    })?,
+            );
+            let consume_done = Arc::new(
+                HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+                    .map_err(|e| {
+                        Error::Configuration(format!(
+                            "HostVulkanTimelineSemaphore::new_exportable \
+                             (consume_done): {e}"
                         ))
                     })?,
             );
@@ -625,8 +640,8 @@ fn main() -> Result<()> {
                 .register_texture(
                     SCENARIO_SURFACE_UUID,
                     &texture,
-                    Some(timeline.as_ref()),
-                    None,
+                    Some(produce_done.as_ref()),
+                    Some(consume_done.as_ref()),
                     streamlib::sdk::rhi::VulkanLayout::COLOR_ATTACHMENT_OPTIMAL,
                 )
                 .map_err(|e| {
@@ -647,10 +662,11 @@ fn main() -> Result<()> {
             })?;
 
             *texture_slot.lock().unwrap() = Some(texture);
-            *timeline_slot.lock().unwrap() = Some(timeline);
+            *produce_done_slot.lock().unwrap() = Some(produce_done);
+            *consume_done_slot.lock().unwrap() = Some(consume_done);
             *readback_slot.lock().unwrap() = Some(readback);
             println!(
-                "✓ render-target DMA-BUF + timeline registered as '{}'",
+                "✓ render-target DMA-BUF + timelines registered as '{}'",
                 SCENARIO_SURFACE_UUID
             );
             Ok(())

--- a/libs/streamlib-adapter-abi/src/surface.rs
+++ b/libs/streamlib-adapter-abi/src/surface.rs
@@ -190,73 +190,89 @@ impl SurfaceTransportHandle {
     }
 }
 
-/// Adapter-internal: timeline-semaphore handles, counters, and the
+/// Adapter-internal: dual-timeline semaphore handles, counters, and the
 /// current image layout.
 ///
-/// The release-side semaphore value advances inside `acquire_*` /
-/// `end_*_access` (sealed adapter methods called by guard `Drop`).
-/// Customers never touch these fields.
+/// Every subprocess-wired surface adapter (cuda, vulkan, cpu-readback)
+/// carries **two** timeline semaphores per surface — `produce_done`
+/// (signaled by the producer process, waited by the consumer before
+/// reading) and `consume_done` (signaled by the consumer process,
+/// waited by the producer before re-writing). See
+/// `docs/architecture/adapter-timeline-single-writer.md` for the
+/// single-writer-per-edge rule.
 ///
-/// Subprocess adapters cannot dereference `timeline_semaphore_handle`
-/// directly — it's a host-side `VkSemaphore`. They import
-/// `timeline_semaphore_sync_fd` via `vkImportSemaphoreFdKHR` to wait
-/// or signal on the same timeline. Host-Rust adapters typically use
-/// the handle and ignore the fd.
-///
-/// `_reserved` is 16 bytes of zeroed space for additive ABI extensions
-/// before the next major bump (additional fds, opaque per-vendor sync
-/// state, etc.).
+/// Subprocess adapters cannot dereference either `*_semaphore_handle`
+/// directly — those are host-side `VkSemaphore`s. They import
+/// `*_semaphore_sync_fd` via `vkImportSemaphoreFdKHR` to wait
+/// or signal on the same timeline kernel object. Host-Rust adapters
+/// typically use the handles and ignore the fds.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
 pub struct SurfaceSyncState {
-    /// Opaque host-side `VkSemaphore` handle.
-    pub(crate) timeline_semaphore_handle: u64,
-    /// Sync-fd exported via `vkGetSemaphoreFdKHR`; -1 when unset.
-    pub(crate) timeline_semaphore_sync_fd: i32,
+    /// Opaque host-side `VkSemaphore` handle for the `produce_done` timeline.
+    pub(crate) produce_done_semaphore_handle: u64,
+    /// `produce_done` sync-fd exported via `vkGetSemaphoreFdKHR`; -1 when unset.
+    pub(crate) produce_done_semaphore_sync_fd: i32,
     pub(crate) _pad_a: u32,
-    /// Last acquire-side wait value the host signaled.
+    /// Last `produce_done` value the consumer waited for.
     pub(crate) last_acquire_value: u64,
-    /// Last release-side signal value the host saw.
+    /// Last `produce_done` value the producer signaled.
     pub(crate) last_release_value: u64,
     /// Current `VkImageLayout` (i32 per Vulkan spec).
     pub(crate) current_image_layout: i32,
     pub(crate) _pad_b: u32,
-    /// Reserved bytes for additive ABI extensions. MUST be zeroed.
-    pub(crate) _reserved: [u8; 16],
+    /// Opaque host-side `VkSemaphore` handle for the `consume_done` timeline.
+    pub(crate) consume_done_semaphore_handle: u64,
+    /// `consume_done` sync-fd exported via `vkGetSemaphoreFdKHR`; -1 when unset.
+    pub(crate) consume_done_semaphore_sync_fd: i32,
+    pub(crate) _pad_c: u32,
 }
 
 impl SurfaceSyncState {
-    /// Construct from the host-side semaphore + sync-fd + initial layout.
+    /// Construct from both timeline handles + sync-fds + last
+    /// acquire/release snapshots + initial layout.
     ///
     /// Subprocess consumer adapters never call this — they receive the
     /// state in a [`StreamlibSurface`] over IPC and read fields via the
     /// accessors below. Only the host-side surface-share registration
     /// path constructs from raw values.
     pub const fn new(
-        timeline_semaphore_handle: u64,
-        timeline_semaphore_sync_fd: i32,
+        produce_done_semaphore_handle: u64,
+        produce_done_semaphore_sync_fd: i32,
         last_acquire_value: u64,
         last_release_value: u64,
         current_image_layout: i32,
+        consume_done_semaphore_handle: u64,
+        consume_done_semaphore_sync_fd: i32,
     ) -> Self {
         Self {
-            timeline_semaphore_handle,
-            timeline_semaphore_sync_fd,
+            produce_done_semaphore_handle,
+            produce_done_semaphore_sync_fd,
             _pad_a: 0,
             last_acquire_value,
             last_release_value,
             current_image_layout,
             _pad_b: 0,
-            _reserved: [0; 16],
+            consume_done_semaphore_handle,
+            consume_done_semaphore_sync_fd,
+            _pad_c: 0,
         }
     }
 
-    pub const fn timeline_semaphore_handle(&self) -> u64 {
-        self.timeline_semaphore_handle
+    pub const fn produce_done_semaphore_handle(&self) -> u64 {
+        self.produce_done_semaphore_handle
     }
 
-    pub const fn timeline_semaphore_sync_fd(&self) -> i32 {
-        self.timeline_semaphore_sync_fd
+    pub const fn produce_done_semaphore_sync_fd(&self) -> i32 {
+        self.produce_done_semaphore_sync_fd
+    }
+
+    pub const fn consume_done_semaphore_handle(&self) -> u64 {
+        self.consume_done_semaphore_handle
+    }
+
+    pub const fn consume_done_semaphore_sync_fd(&self) -> i32 {
+        self.consume_done_semaphore_sync_fd
     }
 
     pub const fn last_acquire_value(&self) -> u64 {
@@ -327,12 +343,14 @@ impl StreamlibSurface {
         &self.transport
     }
 
-    /// Adapter-facing: the host-side timeline-semaphore + initial layout.
+    /// Adapter-facing: the host-side dual-timeline semaphores + initial layout.
     ///
-    /// Subprocess adapters import `timeline_semaphore_sync_fd` via
-    /// `vkImportSemaphoreFdKHR` and wait/signal the same timeline values
-    /// the host advances; the opaque `timeline_semaphore_handle` is
-    /// host-only and not dereferenceable in another address space.
+    /// Subprocess adapters import the `produce_done` and `consume_done`
+    /// sync-fds via `vkImportSemaphoreFdKHR` and wait / signal on whichever
+    /// edge they own per the single-writer rule
+    /// (`docs/architecture/adapter-timeline-single-writer.md`). The
+    /// opaque semaphore handles are host-only and not dereferenceable in
+    /// another address space.
     pub const fn sync(&self) -> &SurfaceSyncState {
         &self.sync
     }
@@ -441,18 +459,23 @@ mod tests {
 
     #[test]
     fn surface_sync_state_layout() {
-        // timeline_semaphore_handle: u64 @ 0
-        // timeline_semaphore_sync_fd: i32 @ 8
+        // produce_done_semaphore_handle: u64 @ 0
+        // produce_done_semaphore_sync_fd: i32 @ 8
         // _pad_a: u32 @ 12
         // last_acquire_value: u64 @ 16
         // last_release_value: u64 @ 24
         // current_image_layout: i32 @ 32
         // _pad_b: u32 @ 36
-        // _reserved: [u8; 16] @ 40
+        // consume_done_semaphore_handle: u64 @ 40
+        // consume_done_semaphore_sync_fd: i32 @ 48
+        // _pad_c: u32 @ 52
         // total: 56 bytes, align 8
-        assert_eq!(offset_of!(SurfaceSyncState, timeline_semaphore_handle), 0);
         assert_eq!(
-            offset_of!(SurfaceSyncState, timeline_semaphore_sync_fd),
+            offset_of!(SurfaceSyncState, produce_done_semaphore_handle),
+            0
+        );
+        assert_eq!(
+            offset_of!(SurfaceSyncState, produce_done_semaphore_sync_fd),
             8
         );
         assert_eq!(offset_of!(SurfaceSyncState, _pad_a), 12);
@@ -460,7 +483,15 @@ mod tests {
         assert_eq!(offset_of!(SurfaceSyncState, last_release_value), 24);
         assert_eq!(offset_of!(SurfaceSyncState, current_image_layout), 32);
         assert_eq!(offset_of!(SurfaceSyncState, _pad_b), 36);
-        assert_eq!(offset_of!(SurfaceSyncState, _reserved), 40);
+        assert_eq!(
+            offset_of!(SurfaceSyncState, consume_done_semaphore_handle),
+            40
+        );
+        assert_eq!(
+            offset_of!(SurfaceSyncState, consume_done_semaphore_sync_fd),
+            48
+        );
+        assert_eq!(offset_of!(SurfaceSyncState, _pad_c), 52);
         assert_eq!(size_of::<SurfaceSyncState>(), 56);
         assert_eq!(align_of::<SurfaceSyncState>(), 8);
     }
@@ -484,9 +515,11 @@ mod tests {
         assert_eq!(transport.plane_strides(), &[1920, 1920, 0, 0]);
         assert_eq!(transport.drm_format_modifier(), 0x123_4567_89ab_cdef);
 
-        let sync = SurfaceSyncState::new(0xdead_beef, 42, 7, 5, 1);
-        assert_eq!(sync.timeline_semaphore_handle(), 0xdead_beef);
-        assert_eq!(sync.timeline_semaphore_sync_fd(), 42);
+        let sync = SurfaceSyncState::new(0xdead_beef, 42, 7, 5, 1, 0xcafe_d00d, 43);
+        assert_eq!(sync.produce_done_semaphore_handle(), 0xdead_beef);
+        assert_eq!(sync.produce_done_semaphore_sync_fd(), 42);
+        assert_eq!(sync.consume_done_semaphore_handle(), 0xcafe_d00d);
+        assert_eq!(sync.consume_done_semaphore_sync_fd(), 43);
         assert_eq!(sync.last_acquire_value(), 7);
         assert_eq!(sync.last_release_value(), 5);
         assert_eq!(sync.current_image_layout(), 1);
@@ -502,7 +535,8 @@ mod tests {
         );
         assert_eq!(surface.id, 99);
         assert_eq!(surface.transport().plane_count(), 2);
-        assert_eq!(surface.sync().timeline_semaphore_sync_fd(), 42);
+        assert_eq!(surface.sync().produce_done_semaphore_sync_fd(), 42);
+        assert_eq!(surface.sync().consume_done_semaphore_sync_fd(), 43);
     }
 
     #[test]

--- a/libs/streamlib-adapter-cpu-readback-abi/src/lib.rs
+++ b/libs/streamlib-adapter-cpu-readback-abi/src/lib.rs
@@ -288,9 +288,15 @@ pub struct HostSurfaceRegistrationRepr {
     /// only on host-flavor registrations).
     pub texture_handle: u64,
     /// `Arc::into_raw(Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>)`-shaped
-    /// opaque handle for the cross-process timeline semaphore the
-    /// adapter waits / signals against. MUST be non-zero.
-    pub timeline_handle: u64,
+    /// opaque handle for the `produce_done` timeline (the producer
+    /// process signals it via the trigger's GPU submit). MUST be
+    /// non-zero. Single-writer-per-edge per
+    /// `docs/architecture/adapter-timeline-single-writer.md`.
+    pub produce_done_handle: u64,
+    /// `Arc::into_raw(Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>)`-shaped
+    /// opaque handle for the `consume_done` timeline (the consumer
+    /// process signals it from `end_read_access`). MUST be non-zero.
+    pub consume_done_handle: u64,
     /// `Arc::into_raw(Arc<<D::Privilege as DevicePrivilege>::Buffer>)`-shaped
     /// opaque handles for each per-plane staging buffer. Logical
     /// layout matches the format's planes in declaration order.
@@ -301,8 +307,9 @@ pub struct HostSurfaceRegistrationRepr {
 impl HostSurfaceRegistrationRepr {
     /// Construct a zero-initialised registration repr. Callers
     /// populate `format_raw`, `width`, `height`, `plane_count`,
-    /// `initial_layout_raw`, `timeline_handle`, and the leading
-    /// `plane_count` entries of `staging_handles` before dispatch.
+    /// `initial_layout_raw`, `produce_done_handle`,
+    /// `consume_done_handle`, and the leading `plane_count` entries
+    /// of `staging_handles` before dispatch.
     pub const fn zeroed() -> Self {
         Self {
             format_raw: 0,
@@ -312,7 +319,8 @@ impl HostSurfaceRegistrationRepr {
             initial_layout_raw: 0,
             _padding: 0,
             texture_handle: 0,
-            timeline_handle: 0,
+            produce_done_handle: 0,
+            consume_done_handle: 0,
             staging_handles: [0; MAX_PLANES],
         }
     }
@@ -593,8 +601,10 @@ mod tests {
     }
 
     /// `HostSurfaceRegistrationRepr` — packed manifest layout.
-    /// `u32×4 + i32 + u32 + u64×6` =
-    /// `4+4+4+4 + 4+4 + 8+8 + 32` = 72 bytes, align 8.
+    /// `u32×4 + i32 + u32 + u64×7` =
+    /// `4+4+4+4 + 4+4 + 8+8+8 + 32` = 80 bytes, align 8. Dual-timeline
+    /// (`produce_done` + `consume_done`) per
+    /// `docs/architecture/adapter-timeline-single-writer.md`.
     #[test]
     fn host_surface_registration_repr_layout() {
         assert_eq!(offset_of!(HostSurfaceRegistrationRepr, format_raw), 0);
@@ -604,9 +614,10 @@ mod tests {
         assert_eq!(offset_of!(HostSurfaceRegistrationRepr, initial_layout_raw), 16);
         assert_eq!(offset_of!(HostSurfaceRegistrationRepr, _padding), 20);
         assert_eq!(offset_of!(HostSurfaceRegistrationRepr, texture_handle), 24);
-        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, timeline_handle), 32);
-        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, staging_handles), 40);
-        assert_eq!(size_of::<HostSurfaceRegistrationRepr>(), 72);
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, produce_done_handle), 32);
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, consume_done_handle), 40);
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, staging_handles), 48);
+        assert_eq!(size_of::<HostSurfaceRegistrationRepr>(), 80);
         assert_eq!(align_of::<HostSurfaceRegistrationRepr>(), 8);
     }
 
@@ -705,7 +716,8 @@ mod tests {
     fn host_surface_registration_repr_zeroed_clears_handles() {
         let r = HostSurfaceRegistrationRepr::zeroed();
         assert_eq!(r.texture_handle, 0);
-        assert_eq!(r.timeline_handle, 0);
+        assert_eq!(r.produce_done_handle, 0);
+        assert_eq!(r.consume_done_handle, 0);
         for h in &r.staging_handles {
             assert_eq!(*h, 0);
         }

--- a/libs/streamlib-adapter-cpu-readback-helpers/tests/consumer_carve_out.rs
+++ b/libs/streamlib-adapter-cpu-readback-helpers/tests/consumer_carve_out.rs
@@ -86,11 +86,15 @@ fn host_image_to_consumer_staging_byte_equal_round_trip() {
         .expect("HostVulkanBuffer::new");
     let staging_arc = Arc::new(staging);
 
-    // Allocate the exportable timeline. Keep our own Arc so we can
-    // export its OPAQUE_FD post-registration.
-    let timeline_arc = Arc::new(
+    // Allocate the exportable timelines. Keep our own Arcs so we can
+    // export their OPAQUE_FDs post-registration.
+    let produce_done_arc = Arc::new(
         HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
-            .expect("HostVulkanTimelineSemaphore::new_exportable"),
+            .expect("HostVulkanTimelineSemaphore::new_exportable (produce_done)"),
+    );
+    let consume_done_arc = Arc::new(
+        HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+            .expect("HostVulkanTimelineSemaphore::new_exportable (consume_done)"),
     );
 
     // Build the host adapter with the in-process trigger.
@@ -107,7 +111,8 @@ fn host_image_to_consumer_staging_byte_equal_round_trip() {
             HostSurfaceRegistration::<HostMarker> {
                 texture: Some(texture_arc),
                 staging_planes: vec![Arc::clone(&staging_arc)],
-                timeline: Arc::clone(&timeline_arc),
+                produce_done: Arc::clone(&produce_done_arc),
+                consume_done: Arc::clone(&consume_done_arc),
                 initial_image_layout: VulkanLayout::UNDEFINED,
                 format: SurfaceFormat::Bgra8,
                 width: W,
@@ -178,9 +183,14 @@ fn host_image_to_consumer_staging_byte_equal_round_trip() {
     let dma_buf_fd = staging_arc
         .export_dma_buf_fd()
         .expect("HostVulkanBuffer::export_dma_buf_fd");
-    let sync_fd = timeline_arc
+    let sync_fd = produce_done_arc
         .export_opaque_fd()
-        .expect("HostVulkanTimelineSemaphore::export_opaque_fd");
+        .expect("HostVulkanTimelineSemaphore::export_opaque_fd (produce_done)");
+    // Keep consume_done_arc alive across the test scope — the
+    // consumer-side test below only exercises produce_done's OPAQUE_FD
+    // import path; consume_done is part of the registration contract
+    // but isn't waited on here.
+    let _ = &consume_done_arc;
 
     let consumer = match ConsumerVulkanDevice::new() {
         Ok(d) => Arc::new(d),

--- a/libs/streamlib-adapter-cpu-readback/src/adapter.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/adapter.rs
@@ -82,11 +82,14 @@ pub struct CpuReadbackTriggerContext<'a, P: DevicePrivilege> {
     /// Pixel format. Drives the per-plane aspect masks and copy
     /// region geometry on the host side.
     pub format: SurfaceFormat,
-    /// Shared timeline semaphore (host-allocated as exportable;
-    /// consumer holds the imported handle). Both trigger flavors
-    /// signal a new value (host trigger via submit; subprocess
-    /// trigger via IPC) so the adapter's wait sees it.
-    pub timeline: &'a Arc<P::TimelineSemaphore>,
+    /// Producer's `produce_done` timeline — the host trigger signals
+    /// it via `vkQueueSubmit2::pSignalSemaphoreInfos` on the GPU copy
+    /// submit; the subprocess trigger signals it via the IPC bridge's
+    /// host-side counterpart. Consumer-flavor adapters wait on this
+    /// timeline post-trigger to confirm the copy completed before
+    /// reading the staging buffer. Single-writer-per-edge per
+    /// `docs/architecture/adapter-timeline-single-writer.md`.
+    pub produce_done: &'a Arc<P::TimelineSemaphore>,
     /// Per-plane staging buffer info. Trigger reads `buffer` and
     /// the geometry; mapped pointers are reached by the adapter
     /// when building the post-copy view.
@@ -243,11 +246,12 @@ impl<D: VulkanRhiDevice + 'static> CpuReadbackSurfaceAdapter<D> {
             surface_id: id,
             texture: registration.texture,
             planes,
-            timeline: registration.timeline,
+            produce_done: registration.produce_done,
+            consume_done: registration.consume_done,
             current_layout: registration.initial_image_layout,
             read_holders: 0,
             write_held: false,
-            current_release_value: 0,
+            current_signal_value: 0,
             format,
             width,
             height,
@@ -271,8 +275,9 @@ impl<D: VulkanRhiDevice + 'static> CpuReadbackSurfaceAdapter<D> {
     fn snapshot_for_acquire(
         state: &mut SurfaceState<D::Privilege>,
     ) -> AcquireSnapshot<D::Privilege> {
-        let timeline = Arc::clone(&state.timeline);
-        let wait_value = state.current_release_value;
+        let produce_done = Arc::clone(&state.produce_done);
+        let consume_done = Arc::clone(&state.consume_done);
+        let wait_value = state.current_signal_value;
         let image = state.texture.as_ref().and_then(|t| t.image());
         let from = state.current_layout;
         let format = state.format;
@@ -291,7 +296,8 @@ impl<D: VulkanRhiDevice + 'static> CpuReadbackSurfaceAdapter<D> {
             })
             .collect();
         AcquireSnapshot {
-            timeline,
+            produce_done,
+            consume_done,
             wait_value,
             image,
             from,
@@ -340,7 +346,7 @@ impl<D: VulkanRhiDevice + 'static> CpuReadbackSurfaceAdapter<D> {
             image: snap.image,
             from_layout: snap.from.as_vk(),
             format: snap.format,
-            timeline: &snap.timeline,
+            produce_done: &snap.produce_done,
             planes: trigger_planes,
             queue_family_index: self.device.queue_family_index(),
             suggested_signal_value,
@@ -428,7 +434,7 @@ impl<D: VulkanRhiDevice + 'static> CpuReadbackSurfaceAdapter<D> {
             BridgeDirection::BufferToImage => self.trigger.run_copy_buffer_to_image(&ctx)?,
         };
         self.surfaces.with_mut(surface_id, |state| {
-            state.current_release_value = signaled;
+            state.current_signal_value = signaled;
             state.current_layout = VulkanLayout::GENERAL;
         });
         Ok(signaled)
@@ -463,14 +469,22 @@ impl<D: VulkanRhiDevice + 'static> CpuReadbackSurfaceAdapter<D> {
         };
         self.log_acquire(surface_id, &snap, write);
 
-        // Wait for prior work to drain (last release-value the host
-        // signaled). Skipped on the first acquire since wait_value=0
-        // and a fresh timeline is already at counter 0.
-        if snap.wait_value > 0
-            && snap
-                .timeline
-                .wait(snap.wait_value, self.acquire_timeout.as_nanos() as u64)
-                .is_err()
+        // Pre-trigger wait: the producer trigger advances
+        // `produce_done`, so a read acquire confirms prior writes
+        // have drained on `produce_done`; a write acquire confirms
+        // prior reads have drained on `consume_done`. Both are no-ops
+        // on the first acquire (a fresh timeline is at value 0 and
+        // `wait(0)` returns immediately). Single-writer-per-edge per
+        // `docs/architecture/adapter-timeline-single-writer.md`.
+        let pre_wait_target = if write {
+            &snap.consume_done
+        } else {
+            &snap.produce_done
+        };
+        let pre_wait_value = pre_wait_target.current_value().unwrap_or(0);
+        if pre_wait_target
+            .wait(pre_wait_value, self.acquire_timeout.as_nanos() as u64)
+            .is_err()
         {
             self.rollback_acquire(surface_id, write);
             return Err(AdapterError::SyncTimeout {
@@ -499,9 +513,9 @@ impl<D: VulkanRhiDevice + 'static> CpuReadbackSurfaceAdapter<D> {
             }
         };
 
-        // Wait for the trigger's signaled value.
+        // Wait for the trigger's signaled `produce_done` value.
         if snap
-            .timeline
+            .produce_done
             .wait(signaled, self.acquire_timeout.as_nanos() as u64)
             .is_err()
         {
@@ -512,7 +526,7 @@ impl<D: VulkanRhiDevice + 'static> CpuReadbackSurfaceAdapter<D> {
         }
         self.surfaces.with_mut(surface_id, |state| {
             state.current_layout = VulkanLayout::GENERAL;
-            state.current_release_value = signaled;
+            state.current_signal_value = signaled;
         });
 
         Ok(Some(AcquireOutcome { snap }))
@@ -573,30 +587,40 @@ impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for CpuReadbackSurfaceAdapter<
     }
 
     fn end_read_access(&self, surface_id: SurfaceId) {
-        // Read release just decrements the holder counter — no GPU
-        // work to flush, and no `signal_host` to issue. The timeline
-        // is already at `current_release_value` from the trigger
-        // that ran on acquire; future acquires read that same value
-        // as their `wait_value` and pass through immediately.
+        // Consumer-side release: signal `consume_done` so the
+        // producer can wait on it before reusing the staging buffer.
+        // Single-writer-per-edge per
+        // `docs/architecture/adapter-timeline-single-writer.md` — the
+        // consumer process is the only writer of `consume_done`; the
+        // producer signals `produce_done` through the trigger's GPU
+        // submit. No multi-writer race (the pre-#562 defang fixed a
+        // shared-timeline race that no longer exists under
+        // dual-timeline).
         //
-        // Pre-#562 the consumer-flavor adapter would also call
-        // `timeline.signal_host(current + 1)` here. That works for
-        // the host-only in-process case but is unsound cross-process:
-        // the host adapter advances the shared timeline through its
-        // trigger's `vkQueueSubmit2` signal, the consumer adapter
-        // tracks an INDEPENDENT local counter, and a host-side
-        // `vkSignalSemaphore` from the consumer flavor races the
-        // host's queue-submit signals against the same kernel object —
-        // monotonically-increasing values aren't preserved across the
-        // two writers, tripping VUID-VkSemaphoreSignalInfo-value-03259.
-        // Dropping the call is also a no-op for the host case
-        // because the trigger already covered the timeline advance.
-        let outcome = self.surfaces.with_mut(surface_id, |state| {
-            debug_assert!(state.read_holders > 0, "read release without acquire");
-            state.dec_read_holders();
-        });
-        if outcome.is_none() {
-            tracing::warn!(?surface_id, "end_read_access on unknown surface");
+        // Inner Option: `None` means "not the last reader, skip signal".
+        // Outer Option: `None` means "surface raced an unregister".
+        let signal: Option<Option<(Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>, u64)>> =
+            self.surfaces.with_mut(surface_id, |state| {
+                debug_assert!(state.read_holders > 0, "read release without acquire");
+                state.dec_read_holders();
+                if state.read_holders > 0 {
+                    return None;
+                }
+                let next = state.current_signal_value + 1;
+                state.current_signal_value = next;
+                Some((Arc::clone(&state.consume_done), next))
+            });
+        let signal = match signal {
+            Some(s) => s,
+            None => {
+                tracing::warn!(?surface_id, "end_read_access on unknown surface");
+                return;
+            }
+        };
+        if let Some((consume_done, value)) = signal {
+            if let Err(e) = consume_done.signal_host(value) {
+                tracing::error!(?surface_id, %value, %e, "consume_done signal failed on read release");
+            }
         }
     }
 
@@ -605,8 +629,9 @@ impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for CpuReadbackSurfaceAdapter<
         // trigger unlocked.
         let snap = self.surfaces.with_mut(surface_id, |state| {
             debug_assert!(state.write_held, "write release without acquire");
-            let timeline = Arc::clone(&state.timeline);
-            let wait_value = state.current_release_value;
+            let produce_done = Arc::clone(&state.produce_done);
+            let consume_done = Arc::clone(&state.consume_done);
+            let wait_value = state.current_signal_value;
             let image = state.texture.as_ref().and_then(|t| t.image());
             let from = state.current_layout;
             let format = state.format;
@@ -623,7 +648,8 @@ impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for CpuReadbackSurfaceAdapter<
                 })
                 .collect();
             AcquireSnapshot {
-                timeline,
+                produce_done,
+                consume_done,
                 wait_value,
                 image,
                 from,
@@ -664,11 +690,11 @@ impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for CpuReadbackSurfaceAdapter<
             }
         };
         if snap
-            .timeline
+            .produce_done
             .wait(signaled, self.acquire_timeout.as_nanos() as u64)
             .is_err()
         {
-            tracing::error!(?surface_id, "timeline wait timed out on write flush");
+            tracing::error!(?surface_id, "produce_done wait timed out on write flush");
             self.surfaces.rollback_write(surface_id);
             return;
         }
@@ -676,7 +702,7 @@ impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for CpuReadbackSurfaceAdapter<
         self.surfaces.with_mut(surface_id, |state| {
             state.set_write_held(false);
             state.current_layout = VulkanLayout::GENERAL;
-            state.current_release_value = signaled;
+            state.current_signal_value = signaled;
         });
     }
 }
@@ -940,7 +966,7 @@ impl<D: VulkanRhiDevice + 'static> InProcessCpuReadbackCopyTrigger<D> {
             .command_buffer(cmd)
             .build()];
         let signal_infos = [vk::SemaphoreSubmitInfo::builder()
-            .semaphore(ctx.timeline.semaphore())
+            .semaphore(ctx.produce_done.semaphore())
             .value(ctx.suggested_signal_value)
             .stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
             .build()];
@@ -1082,7 +1108,16 @@ struct PlaneAcquireSlot {
 }
 
 struct AcquireSnapshot<P: DevicePrivilege> {
-    timeline: Arc<P::TimelineSemaphore>,
+    /// Producer's `produce_done` timeline — the trigger signals it
+    /// and the consumer waits on it. Single-writer-per-edge per
+    /// `docs/architecture/adapter-timeline-single-writer.md`.
+    produce_done: Arc<P::TimelineSemaphore>,
+    /// Consumer's `consume_done` timeline — signaled by
+    /// `end_read_access`. Snapshotted into the acquire path so the
+    /// producer's write-side waits can reach it.
+    consume_done: Arc<P::TimelineSemaphore>,
+    /// Snapshot of this process's monotonic counter; the trigger
+    /// derives `suggested_signal_value` as `wait_value + 1`.
     wait_value: u64,
     image: Option<vk::Image>,
     from: VulkanLayout,

--- a/libs/streamlib-adapter-cpu-readback/src/host_vtable.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/host_vtable.rs
@@ -349,10 +349,10 @@ unsafe extern "C" fn host_register_host_surface<D: VulkanRhiDevice + 'static>(
                 unsafe { write_err(&msg, err_buf, err_buf_cap, err_len) };
                 return 1;
             }
-            if r.timeline_handle == 0 {
+            if r.produce_done_handle == 0 || r.consume_done_handle == 0 {
                 unsafe {
                     write_err(
-                        "register_host_surface: null timeline handle",
+                        "register_host_surface: null produce_done or consume_done handle",
                         err_buf,
                         err_buf_cap,
                         err_len,
@@ -376,8 +376,14 @@ unsafe extern "C" fn host_register_host_surface<D: VulkanRhiDevice + 'static>(
                         Some(Arc::from_raw(ptr))
                     }
                 };
-            let timeline: Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore> = unsafe {
-                let ptr = r.timeline_handle
+            let produce_done: Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore> = unsafe {
+                let ptr = r.produce_done_handle
+                    as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore;
+                Arc::increment_strong_count(ptr);
+                Arc::from_raw(ptr)
+            };
+            let consume_done: Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore> = unsafe {
+                let ptr = r.consume_done_handle
                     as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore;
                 Arc::increment_strong_count(ptr);
                 Arc::from_raw(ptr)
@@ -402,7 +408,8 @@ unsafe extern "C" fn host_register_host_surface<D: VulkanRhiDevice + 'static>(
             let registration: HostSurfaceRegistration<D::Privilege> = HostSurfaceRegistration {
                 texture,
                 staging_planes,
-                timeline,
+                produce_done,
+                consume_done,
                 initial_image_layout: VulkanLayout(r.initial_layout_raw),
                 format,
                 width: r.width,
@@ -857,10 +864,10 @@ mod tier1_null_handle_tests {
     }
 
     /// Cross-crate sanity: `HostSurfaceRegistrationRepr` size/align
-    /// lock. 72 bytes.
+    /// lock. 80 bytes (dual-timeline: produce_done + consume_done).
     #[test]
     fn host_surface_registration_repr_size_align_locked() {
-        assert_eq!(size_of::<HostSurfaceRegistrationRepr>(), 72);
+        assert_eq!(size_of::<HostSurfaceRegistrationRepr>(), 80);
         assert_eq!(align_of::<HostSurfaceRegistrationRepr>(), 8);
     }
 

--- a/libs/streamlib-adapter-cpu-readback/src/state.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/state.rs
@@ -45,10 +45,19 @@ pub struct HostSurfaceRegistration<P: DevicePrivilege> {
     /// One staging buffer per plane (1 for BGRA/RGBA, 2 for NV12).
     /// HOST_VISIBLE / HOST_COHERENT linear `VkBuffer` on both flavors.
     pub staging_planes: Vec<Arc<P::Buffer>>,
-    /// Shared timeline semaphore. Host owns the export side; consumer
-    /// imports via OPAQUE_FD. Both flavors `wait` and `signal_host`
-    /// against the same kernel object after import.
-    pub timeline: Arc<P::TimelineSemaphore>,
+    /// `produce_done` timeline — signaled exclusively by the producer
+    /// process via the trigger's `vkQueueSubmit2::pSignalSemaphoreInfos`
+    /// after `vkCmdCopyImageToBuffer` / `vkCmdCopyBufferToImage`
+    /// completes. Subprocess consumers import via OPAQUE_FD and wait
+    /// on it before reading the staging buffer. Single-writer-per-edge
+    /// per `docs/architecture/adapter-timeline-single-writer.md`.
+    pub produce_done: Arc<P::TimelineSemaphore>,
+    /// `consume_done` timeline — signaled exclusively by the consumer
+    /// process from `end_read_access` (CPU `signal_host`) after the
+    /// subprocess has finished reading the staging buffer. The host
+    /// producer waits on it before reusing the staging buffer for the
+    /// next frame.
+    pub consume_done: Arc<P::TimelineSemaphore>,
     /// Initial `VkImageLayout` the host left the source image in.
     /// Consumer-side this is informational — layout transitions are
     /// host-only. Use [`VulkanLayout::UNDEFINED`] for freshly-allocated
@@ -94,13 +103,21 @@ pub(crate) struct SurfaceState<P: DevicePrivilege> {
     pub(crate) surface_id: SurfaceId,
     pub(crate) texture: Option<Arc<P::Texture>>,
     pub(crate) planes: Vec<PlaneSlot<P>>,
-    pub(crate) timeline: Arc<P::TimelineSemaphore>,
+    /// `produce_done` timeline — see
+    /// [`HostSurfaceRegistration::produce_done`].
+    pub(crate) produce_done: Arc<P::TimelineSemaphore>,
+    /// `consume_done` timeline — see
+    /// [`HostSurfaceRegistration::consume_done`].
+    pub(crate) consume_done: Arc<P::TimelineSemaphore>,
     pub(crate) current_layout: VulkanLayout,
     pub(crate) read_holders: u64,
     pub(crate) write_held: bool,
-    /// Last timeline value either signaled (host) or returned by an IPC
-    /// trigger (consumer). Subsequent acquires advance from here.
-    pub(crate) current_release_value: u64,
+    /// Per-process monotonic signal counter for whichever side this
+    /// adapter instance signals. The producer trigger advances this on
+    /// every `vkCmdCopy*` submit (producer-side); the
+    /// consumer-flavored `end_read_access` advances this on each
+    /// `signal_host(consume_done)` call.
+    pub(crate) current_signal_value: u64,
     pub(crate) format: SurfaceFormat,
     pub(crate) width: u32,
     pub(crate) height: u32,

--- a/libs/streamlib-adapter-cpu-readback/tests/common.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/common.rs
@@ -162,9 +162,13 @@ impl HostFixture {
             staging_planes.push(Arc::new(pb));
         }
 
-        let timeline = Arc::new(
+        let produce_done = Arc::new(
             HostVulkanTimelineSemaphore::new(self.adapter.device().device(), 0)
-                .map_err(|e| Error::GpuError(format!("create timeline: {e}")))?,
+                .map_err(|e| Error::GpuError(format!("create produce_done timeline: {e}")))?,
+        );
+        let consume_done = Arc::new(
+            HostVulkanTimelineSemaphore::new(self.adapter.device().device(), 0)
+                .map_err(|e| Error::GpuError(format!("create consume_done timeline: {e}")))?,
         );
         self.adapter
             .register_host_surface(
@@ -172,7 +176,8 @@ impl HostFixture {
                 HostSurfaceRegistration::<HostMarker> {
                     texture: Some(texture_arc),
                     staging_planes,
-                    timeline,
+                    produce_done,
+                    consume_done,
                     initial_image_layout: VulkanLayout::UNDEFINED,
                     format: surface_format,
                     width,

--- a/libs/streamlib-adapter-cpu-readback/tests/conformance.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/conformance.rs
@@ -92,16 +92,21 @@ fn duplicate_registration_returns_surface_already_registered() {
         HostVulkanBuffer::new(fixture.adapter.device(), (64 as u64) * (64 as u64) * (4 as u64))
             .expect("staging plane"),
     );
-    let timeline = Arc::new(
+    let produce_done = Arc::new(
         HostVulkanTimelineSemaphore::new(fixture.adapter.device().device(), 0)
-            .expect("timeline"),
+            .expect("produce_done timeline"),
+    );
+    let consume_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(fixture.adapter.device().device(), 0)
+            .expect("consume_done timeline"),
     );
     let result = fixture.adapter.register_host_surface(
         id,
         HostSurfaceRegistration::<HostMarker> {
             texture: Some(texture_arc),
             staging_planes: vec![staging],
-            timeline,
+            produce_done,
+            consume_done,
             initial_image_layout: VulkanLayout::UNDEFINED,
             format: SurfaceFormat::Bgra8,
             width: 64,

--- a/libs/streamlib-adapter-cuda-abi/src/lib.rs
+++ b/libs/streamlib-adapter-cuda-abi/src/lib.rs
@@ -323,9 +323,13 @@ pub struct CudaSurfaceAdapterVTable {
     /// caller's `pixel_buffer_handle` Arc remains owned by the
     /// caller.
     ///
-    /// `timeline_handle` is an
+    /// `produce_done_handle` and `consume_done_handle` are
     /// `Arc::into_raw(Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>)`-shaped
-    /// opaque pointer with identical ownership semantics.
+    /// opaque pointers with identical ownership semantics. They are
+    /// the two single-writer-per-edge timeline semaphores documented
+    /// in `docs/architecture/adapter-timeline-single-writer.md`:
+    /// `produce_done` is signaled exclusively by the producer
+    /// process, `consume_done` exclusively by the consumer process.
     ///
     /// `initial_layout_raw` is the i32 `VkImageLayout` enumerant
     /// — unused on the buffer path (buffers have no layout), pass
@@ -339,7 +343,8 @@ pub struct CudaSurfaceAdapterVTable {
         handle: *const c_void,
         surface_id: u64,
         pixel_buffer_handle: *const c_void,
-        timeline_handle: *const c_void,
+        produce_done_handle: *const c_void,
+        consume_done_handle: *const c_void,
         initial_layout_raw: i32,
         err_buf: *mut u8,
         err_buf_cap: usize,
@@ -352,9 +357,10 @@ pub struct CudaSurfaceAdapterVTable {
     /// `Arc::into_raw(Arc<<D::Privilege as DevicePrivilege>::Texture>)`-shaped
     /// opaque pointer produced by the host (the host's
     /// `HostVulkanTexture::new_opaque_fd_export` output).
-    /// `timeline_handle` is an
+    /// `produce_done_handle` and `consume_done_handle` are
     /// `Arc::into_raw(Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>)`-shaped
-    /// opaque pointer.
+    /// opaque pointers — see [`Self::register_host_surface`] for the
+    /// single-writer-per-edge contract.
     ///
     /// `initial_layout_raw` is the i32 `VkImageLayout` enumerant
     /// the image is in at registration time. Load-bearing for the
@@ -363,7 +369,7 @@ pub struct CudaSurfaceAdapterVTable {
     /// itself does not issue Vulkan-side barriers on imported
     /// images (CUDA's sync runs pairwise via
     /// `cudaWaitExternalSemaphoresAsync` /
-    /// `cudaSignalExternalSemaphoresAsync` on the timeline).
+    /// `cudaSignalExternalSemaphoresAsync` on each timeline).
     ///
     /// Returns 0 on success, non-zero on failure (e.g. surface_id
     /// already registered, OR the texture's format is not in the
@@ -374,7 +380,8 @@ pub struct CudaSurfaceAdapterVTable {
         handle: *const c_void,
         surface_id: u64,
         texture_handle: *const c_void,
-        timeline_handle: *const c_void,
+        produce_done_handle: *const c_void,
+        consume_done_handle: *const c_void,
         initial_layout_raw: i32,
         err_buf: *mut u8,
         err_buf_cap: usize,

--- a/libs/streamlib-adapter-cuda-helpers/tests/cuda_carve_out.rs
+++ b/libs/streamlib-adapter-cuda-helpers/tests/cuda_carve_out.rs
@@ -111,10 +111,19 @@ fn host_buffer_to_cuda_byte_equal_round_trip() {
             return;
         }
     };
-    let timeline = match HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0) {
+    let produce_done = match HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+    {
         Ok(s) => Arc::new(s),
         Err(e) => {
-            println!("cuda carve-out: timeline new_exportable failed: {e} — skipping");
+            println!("cuda carve-out: produce_done new_exportable failed: {e} — skipping");
+            return;
+        }
+    };
+    let consume_done = match HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+    {
+        Ok(s) => Arc::new(s),
+        Err(e) => {
+            println!("cuda carve-out: consume_done new_exportable failed: {e} — skipping");
             return;
         }
     };
@@ -134,7 +143,8 @@ fn host_buffer_to_cuda_byte_equal_round_trip() {
             SURFACE_ID,
             HostSurfaceRegistration {
                 pixel_buffer: Arc::clone(&pixel_buffer),
-                timeline: Arc::clone(&timeline),
+                produce_done: Arc::clone(&produce_done),
+                consume_done: Arc::clone(&consume_done),
                 initial_layout: VulkanLayout::UNDEFINED,
             },
         )
@@ -195,28 +205,38 @@ fn host_buffer_to_cuda_byte_equal_round_trip() {
     // ── Phase 3: export OPAQUE_FDs from the registered surface ─────
     // Round-trip through the adapter's registry accessors (rather than
     // the local Arcs) so this also exercises `surface_pixel_buffer` /
-    // `surface_timeline` — the production cdylib path will read FDs
-    // out of the registered surface, not from a local handle. Returning
-    // `None` here means the registry forgot the surface, which would be
-    // a regression in `register_host_surface`.
+    // `surface_produce_done` / `surface_consume_done` — the production
+    // cdylib path will read FDs out of the registered surface, not from
+    // a local handle. Returning `None` here means the registry forgot
+    // the surface, which would be a regression in `register_host_surface`.
     let registered_pixel_buffer = adapter
         .surface_pixel_buffer(SURFACE_ID)
         .expect("CudaSurfaceAdapter::surface_pixel_buffer must return registered buffer");
-    let registered_timeline = adapter
-        .surface_timeline(SURFACE_ID)
-        .expect("CudaSurfaceAdapter::surface_timeline must return registered timeline");
+    let registered_produce_done = adapter
+        .surface_produce_done(SURFACE_ID)
+        .expect("CudaSurfaceAdapter::surface_produce_done must return registered timeline");
+    let registered_consume_done = adapter
+        .surface_consume_done(SURFACE_ID)
+        .expect("CudaSurfaceAdapter::surface_consume_done must return registered timeline");
     assert!(
         Arc::ptr_eq(&registered_pixel_buffer, &pixel_buffer),
         "registry-returned pixel_buffer Arc must point at the originally-registered buffer"
     );
     assert!(
-        Arc::ptr_eq(&registered_timeline, &timeline),
-        "registry-returned timeline Arc must point at the originally-registered timeline"
+        Arc::ptr_eq(&registered_produce_done, &produce_done),
+        "registry-returned produce_done Arc must point at the originally-registered timeline"
+    );
+    assert!(
+        Arc::ptr_eq(&registered_consume_done, &consume_done),
+        "registry-returned consume_done Arc must point at the originally-registered timeline"
     );
     let memory_fd = registered_pixel_buffer
         .export_opaque_fd_memory()
         .expect("HostVulkanBuffer::export_opaque_fd_memory");
-    let timeline_fd = registered_timeline
+    // The CUDA carve-out below imports the producer-signaled timeline
+    // (`produce_done`) — the cdylib waits for the host's write to
+    // complete before reading.
+    let timeline_fd = registered_produce_done
         .export_opaque_fd()
         .expect("HostVulkanTimelineSemaphore::export_opaque_fd");
 

--- a/libs/streamlib-adapter-cuda-helpers/tests/opaque_fd_consumer_rhi_round_trip.rs
+++ b/libs/streamlib-adapter-cuda-helpers/tests/opaque_fd_consumer_rhi_round_trip.rs
@@ -114,13 +114,23 @@ fn opaque_fd_chain_host_export_to_consumer_import_to_adapter_acquire() {
             return;
         }
     };
-    let host_timeline = match HostVulkanTimelineSemaphore::new_exportable(
+    let host_produce_done = match HostVulkanTimelineSemaphore::new_exportable(
         host_device.device(),
         0,
     ) {
         Ok(t) => Arc::new(t),
         Err(e) => {
-            println!("stage6: timeline new_exportable failed: {e} — skipping");
+            println!("stage6: produce_done new_exportable failed: {e} — skipping");
+            return;
+        }
+    };
+    let host_consume_done = match HostVulkanTimelineSemaphore::new_exportable(
+        host_device.device(),
+        0,
+    ) {
+        Ok(t) => Arc::new(t),
+        Err(e) => {
+            println!("stage6: consume_done new_exportable failed: {e} — skipping");
             return;
         }
     };
@@ -138,10 +148,12 @@ fn opaque_fd_chain_host_export_to_consumer_import_to_adapter_acquire() {
             buffer_size,
         );
     }
-    // Signal timeline value 1 — represents "host has finished writing".
-    host_timeline
+    // Signal produce_done value 1 — represents "host has finished writing".
+    // produce_done is the producer-signaled timeline; consume_done stays at 0
+    // (no consumer has read yet).
+    host_produce_done
         .signal_host(1)
-        .expect("host_timeline.signal_host(1)");
+        .expect("host_produce_done.signal_host(1)");
 
     // ── Phase 2: stand up surface-share daemon ──────────────────────────
     let state = SurfaceShareState::new();
@@ -154,9 +166,12 @@ fn opaque_fd_chain_host_export_to_consumer_import_to_adapter_acquire() {
     let memory_fd = host_buffer
         .export_opaque_fd_memory()
         .expect("export_opaque_fd_memory");
-    let timeline_fd = host_timeline
+    let produce_done_fd = host_produce_done
         .export_opaque_fd()
-        .expect("export_opaque_fd");
+        .expect("export_opaque_fd produce_done");
+    let consume_done_fd = host_consume_done
+        .export_opaque_fd()
+        .expect("export_opaque_fd consume_done");
 
     let host_stream =
         connect_to_surface_share_socket(&socket_path).expect("host connect");
@@ -172,15 +187,21 @@ fn opaque_fd_chain_host_export_to_consumer_import_to_adapter_acquire() {
         "plane_sizes": [buffer_size as u64],
         "plane_offsets": [0u64],
         "plane_strides": [0u64],
-        "has_sync_fd": true,
+        "has_produce_done_fd": true,
+        "has_consume_done_fd": true,
     });
-    let (register_resp, _) =
-        send_request_with_fds(&host_stream, &register_req, &[memory_fd, timeline_fd], 0)
-            .expect("host register");
-    // Daemon dup'd both FDs — close the host's references.
+    let (register_resp, _) = send_request_with_fds(
+        &host_stream,
+        &register_req,
+        &[memory_fd, produce_done_fd, consume_done_fd],
+        0,
+    )
+    .expect("host register");
+    // Daemon dup'd all FDs — close the host's references.
     unsafe {
         libc::close(memory_fd);
-        libc::close(timeline_fd);
+        libc::close(produce_done_fd);
+        libc::close(consume_done_fd);
     }
     assert!(
         register_resp.get("error").is_none(),
@@ -199,7 +220,7 @@ fn opaque_fd_chain_host_export_to_consumer_import_to_adapter_acquire() {
         &consumer_stream,
         &lookup_req,
         &[],
-        MAX_DMA_BUF_PLANES + 1, // +1 for the timeline OPAQUE_FD
+        MAX_DMA_BUF_PLANES + 2, // +2 for produce_done + consume_done OPAQUE_FDs
     )
     .expect("consumer lookup");
 
@@ -209,27 +230,35 @@ fn opaque_fd_chain_host_export_to_consumer_import_to_adapter_acquire() {
         "Stage 4 wire-format: register/lookup must round-trip handle_type",
     );
     assert_eq!(
-        lookup_resp.get("has_sync_fd").and_then(|v| v.as_bool()),
+        lookup_resp.get("has_produce_done_fd").and_then(|v| v.as_bool()),
         Some(true),
-        "timeline FD must be advertised in the lookup response",
+        "produce_done FD must be advertised in the lookup response",
+    );
+    assert_eq!(
+        lookup_resp.get("has_consume_done_fd").and_then(|v| v.as_bool()),
+        Some(true),
+        "consume_done FD must be advertised in the lookup response",
     );
     assert_eq!(
         lookup_fds.len(),
-        2,
-        "lookup must deliver memory_fd + timeline_fd via SCM_RIGHTS"
+        3,
+        "lookup must deliver memory_fd + produce_done_fd + consume_done_fd via SCM_RIGHTS"
     );
 
-    // The daemon emits memory FDs first, then the optional sync FD.
+    // The daemon emits memory FDs first, then produce_done, then consume_done.
     let consumer_memory_fd: RawFd = lookup_fds[0];
-    let consumer_timeline_fd: RawFd = lookup_fds[1];
+    let consumer_produce_done_fd: RawFd = lookup_fds[1];
+    let consumer_consume_done_fd: RawFd = lookup_fds[2];
 
     // ── Phase 5: consumer side imports through consumer-rhi ────────────
     let consumer_device = match ConsumerVulkanDevice::new() {
         Ok(d) => Arc::new(d),
         Err(e) => {
+            // SAFETY: import paths haven't been called yet — close all FDs.
             unsafe {
                 libc::close(consumer_memory_fd);
-                libc::close(consumer_timeline_fd);
+                libc::close(consumer_produce_done_fd);
+                libc::close(consumer_consume_done_fd);
             }
             println!(
                 "stage6: ConsumerVulkanDevice::new failed: {e:?} — skipping \
@@ -248,21 +277,43 @@ fn opaque_fd_chain_host_export_to_consumer_import_to_adapter_acquire() {
             // FD ownership did NOT transfer on error — close it.
             unsafe {
                 libc::close(consumer_memory_fd);
-                libc::close(consumer_timeline_fd);
+                libc::close(consumer_produce_done_fd);
+                libc::close(consumer_consume_done_fd);
             }
             panic!("ConsumerVulkanBuffer::from_opaque_fd failed: {e:?}");
         }
     };
 
-    let consumer_timeline = ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+    let consumer_produce_done = ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
         &consumer_device,
-        consumer_timeline_fd,
+        consumer_produce_done_fd,
     );
-    let consumer_timeline = match consumer_timeline {
+    let consumer_produce_done = match consumer_produce_done {
         Ok(t) => Arc::new(t),
         Err(e) => {
-            unsafe { libc::close(consumer_timeline_fd) };
-            panic!("ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd failed: {e:?}");
+            unsafe {
+                libc::close(consumer_produce_done_fd);
+                libc::close(consumer_consume_done_fd);
+            }
+            panic!(
+                "ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd \
+                 (produce_done) failed: {e:?}"
+            );
+        }
+    };
+
+    let consumer_consume_done = ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+        &consumer_device,
+        consumer_consume_done_fd,
+    );
+    let consumer_consume_done = match consumer_consume_done {
+        Ok(t) => Arc::new(t),
+        Err(e) => {
+            unsafe { libc::close(consumer_consume_done_fd) };
+            panic!(
+                "ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd \
+                 (consume_done) failed: {e:?}"
+            );
         }
     };
 
@@ -290,7 +341,8 @@ fn opaque_fd_chain_host_export_to_consumer_import_to_adapter_acquire() {
             0xCDA0_0006,
             HostSurfaceRegistration {
                 pixel_buffer: Arc::clone(&consumer_buffer),
-                timeline: Arc::clone(&consumer_timeline),
+                produce_done: Arc::clone(&consumer_produce_done),
+                consume_done: Arc::clone(&consumer_consume_done),
                 initial_layout: VulkanLayout::UNDEFINED,
             },
         )

--- a/libs/streamlib-adapter-cuda/src/adapter.rs
+++ b/libs/streamlib-adapter-cuda/src/adapter.rs
@@ -144,11 +144,12 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
                 resource: SurfaceResource::Buffer {
                     pixel_buffer: registration.pixel_buffer,
                 },
-                timeline: registration.timeline,
+                produce_done: registration.produce_done,
+                consume_done: registration.consume_done,
                 current_layout: registration.initial_layout,
                 read_holders: 0,
                 write_held: false,
-                current_release_value: 0,
+                current_signal_value: 0,
             },
         );
         if !inserted {
@@ -198,11 +199,12 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
                 resource: SurfaceResource::Image {
                     texture: registration.texture,
                 },
-                timeline: registration.timeline,
+                produce_done: registration.produce_done,
+                consume_done: registration.consume_done,
                 current_layout: registration.initial_layout,
                 read_holders: 0,
                 write_held: false,
-                current_release_value: 0,
+                current_signal_value: 0,
             },
         );
         if !inserted {
@@ -261,16 +263,27 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
             .flatten()
     }
 
-    /// Power-user accessor: the registered timeline-semaphore Arc for
-    /// a surface (either flavor). Used by the carve-out test to call
+    /// Power-user accessor: the registered `produce_done` timeline Arc
+    /// for a surface (either flavor). Used by the carve-out test to call
     /// `export_opaque_fd()` on the underlying timeline; cdylib work
-    /// will route this through the surface-share service.
-    pub fn surface_timeline(
+    /// routes this through the surface-share service.
+    pub fn surface_produce_done(
         &self,
         id: SurfaceId,
     ) -> Option<Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>> {
         self.surfaces
-            .with(id, |state| Arc::clone(&state.timeline))
+            .with(id, |state| Arc::clone(&state.produce_done))
+    }
+
+    /// Power-user accessor: the registered `consume_done` timeline Arc
+    /// for a surface (either flavor). Symmetric counterpart to
+    /// [`Self::surface_produce_done`].
+    pub fn surface_consume_done(
+        &self,
+        id: SurfaceId,
+    ) -> Option<Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>> {
+        self.surfaces
+            .with(id, |state| Arc::clone(&state.consume_done))
     }
 
     /// Host-pipeline producer path: submit a `vkCmdCopyImageToBuffer`
@@ -370,21 +383,21 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
                     });
                 }
                 // Claim the signal_value atomically with `write_held`:
-                // advance `current_release_value` here, INSIDE the
-                // registry lock, so no other writer (host signal path
-                // or concurrent submit) can race on the value
-                // computation. The GPU submit at `signal_value`
-                // happens outside the lock; by then state.current is
-                // already the about-to-be-signaled value, so any
-                // concurrent `signal_host` path on the same timeline
-                // picks a strictly greater value. Closes the
-                // multi-writer race that surfaced as
-                // VUID-VkSemaphoreSignalInfo-value-03258 on the
-                // camera-python-display pipeline.
-                let signal_value = state.next_release_value();
-                state.current_release_value = signal_value;
+                // advance `current_signal_value` here, INSIDE the
+                // registry lock, so concurrent submits or
+                // `end_*_access` callers in the same process pick
+                // strictly greater values. The GPU submit at
+                // `signal_value` happens outside the lock; by then
+                // state.current is already the about-to-be-signaled
+                // value. Under single-writer-per-edge
+                // (`docs/architecture/adapter-timeline-single-writer.md`)
+                // this site is the producer signaling `produce_done`;
+                // the consumer's signals run on `consume_done` from a
+                // different process counter.
+                let signal_value = state.next_signal_value();
+                state.current_signal_value = signal_value;
                 Ok(HostCopySession {
-                    timeline: Arc::clone(&state.timeline),
+                    produce_done: Arc::clone(&state.produce_done),
                     buffer: pixel_buffer.buffer(),
                     signal_value,
                 })
@@ -399,7 +412,7 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
             image_layout.as_vk(),
             session.buffer,
             image_extent,
-            session.timeline.as_ref(),
+            session.produce_done.as_ref(),
             session.signal_value,
         ) {
             // Submit failed; clear write_held. State.current_release_value
@@ -438,9 +451,11 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
     ) -> Result<Option<ReadAcquired<D::Privilege>>, AdapterError> {
         let id = surface.id;
         self.surfaces.try_begin_read(id, |state| match &state.resource {
+            // Consumer-side acquire waits on `produce_done` — the
+            // peer-timeline's `current_value()` snapshot is taken inside
+            // `finalize_read` (outside the registry lock).
             SurfaceResource::Buffer { pixel_buffer } => Ok(ReadAcquired {
-                timeline: Arc::clone(&state.timeline),
-                wait_value: state.current_release_value,
+                peer_timeline: Arc::clone(&state.produce_done),
                 buffer: pixel_buffer.buffer(),
                 size: pixel_buffer.size(),
             }),
@@ -459,9 +474,10 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
     ) -> Result<Option<WriteAcquired<D::Privilege>>, AdapterError> {
         let id = surface.id;
         self.surfaces.try_begin_write(id, |state| match &state.resource {
+            // Producer-side acquire waits on `consume_done` — confirms
+            // the consumer has drained prior content before re-write.
             SurfaceResource::Buffer { pixel_buffer } => Ok(WriteAcquired {
-                timeline: Arc::clone(&state.timeline),
-                wait_value: state.current_release_value,
+                peer_timeline: Arc::clone(&state.consume_done),
                 buffer: pixel_buffer.buffer(),
                 size: pixel_buffer.size(),
             }),
@@ -487,8 +503,7 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
                     ),
                 })?;
                 Ok(ImageReadAcquired {
-                    timeline: Arc::clone(&state.timeline),
-                    wait_value: state.current_release_value,
+                    peer_timeline: Arc::clone(&state.produce_done),
                     image,
                     width: texture.width(),
                     height: texture.height(),
@@ -517,8 +532,7 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
                     ),
                 })?;
                 Ok(ImageWriteAcquired {
-                    timeline: Arc::clone(&state.timeline),
-                    wait_value: state.current_release_value,
+                    peer_timeline: Arc::clone(&state.consume_done),
                     image,
                     width: texture.width(),
                     height: texture.height(),
@@ -539,9 +553,18 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
         surface_id: SurfaceId,
         acquired: ImageReadAcquired<D::Privilege>,
     ) -> Result<CudaTextureView<'_>, AdapterError> {
+        // Wait for whatever value the peer (`produce_done`) has already
+        // been signaled to. The peer-timeline's kernel counter is the
+        // source of truth — no cross-process value publishing IPC
+        // needed for v1 (see
+        // `docs/architecture/adapter-timeline-single-writer.md`).
+        let wait_value = acquired
+            .peer_timeline
+            .current_value()
+            .unwrap_or(0);
         if acquired
-            .timeline
-            .wait(acquired.wait_value, self.acquire_timeout.as_nanos() as u64)
+            .peer_timeline
+            .wait(wait_value, self.acquire_timeout.as_nanos() as u64)
             .is_err()
         {
             self.surfaces.rollback_read(surface_id);
@@ -563,9 +586,15 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
         surface_id: SurfaceId,
         acquired: ImageWriteAcquired<D::Privilege>,
     ) -> Result<CudaSurfaceView<'_>, AdapterError> {
+        // Producer-side wait on `consume_done`'s current value — see
+        // `finalize_image_read` for the kernel-counter rationale.
+        let wait_value = acquired
+            .peer_timeline
+            .current_value()
+            .unwrap_or(0);
         if acquired
-            .timeline
-            .wait(acquired.wait_value, self.acquire_timeout.as_nanos() as u64)
+            .peer_timeline
+            .wait(wait_value, self.acquire_timeout.as_nanos() as u64)
             .is_err()
         {
             self.surfaces.rollback_write(surface_id);
@@ -672,9 +701,13 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
         surface_id: SurfaceId,
         acquired: ReadAcquired<D::Privilege>,
     ) -> Result<(vk::Buffer, vk::DeviceSize), AdapterError> {
+        let wait_value = acquired
+            .peer_timeline
+            .current_value()
+            .unwrap_or(0);
         if acquired
-            .timeline
-            .wait(acquired.wait_value, self.acquire_timeout.as_nanos() as u64)
+            .peer_timeline
+            .wait(wait_value, self.acquire_timeout.as_nanos() as u64)
             .is_err()
         {
             self.surfaces.rollback_read(surface_id);
@@ -690,9 +723,13 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
         surface_id: SurfaceId,
         acquired: WriteAcquired<D::Privilege>,
     ) -> Result<(vk::Buffer, vk::DeviceSize), AdapterError> {
+        let wait_value = acquired
+            .peer_timeline
+            .current_value()
+            .unwrap_or(0);
         if acquired
-            .timeline
-            .wait(acquired.wait_value, self.acquire_timeout.as_nanos() as u64)
+            .peer_timeline
+            .wait(wait_value, self.acquire_timeout.as_nanos() as u64)
             .is_err()
         {
             self.surfaces.rollback_write(surface_id);
@@ -706,8 +743,10 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
 
 /// Snapshot taken under the registry lock so the GPU submit can run
 /// unlocked. `write_held` is already set; the rollback path clears it.
+/// The producer signals `produce_done` at `signal_value` via the GPU
+/// submit's `pSignalSemaphoreInfos` slot per single-writer-per-edge.
 struct HostCopySession<P: DevicePrivilege> {
-    timeline: Arc<P::TimelineSemaphore>,
+    produce_done: Arc<P::TimelineSemaphore>,
     buffer: vk::Buffer,
     signal_value: u64,
 }
@@ -982,17 +1021,17 @@ fn build_color_image_barrier(
 
 /// Snapshot taken under the registry lock so the timeline wait can run
 /// unlocked. `read_holders` / `write_held` are already incremented;
-/// rollback paths decrement them on failure.
+/// rollback paths decrement them on failure. `peer_timeline` is the
+/// side this caller waits on (`produce_done` for read paths,
+/// `consume_done` for write paths) per single-writer-per-edge.
 struct ReadAcquired<P: DevicePrivilege> {
-    timeline: Arc<P::TimelineSemaphore>,
-    wait_value: u64,
+    peer_timeline: Arc<P::TimelineSemaphore>,
     buffer: vk::Buffer,
     size: vk::DeviceSize,
 }
 
 struct WriteAcquired<P: DevicePrivilege> {
-    timeline: Arc<P::TimelineSemaphore>,
-    wait_value: u64,
+    peer_timeline: Arc<P::TimelineSemaphore>,
     buffer: vk::Buffer,
     size: vk::DeviceSize,
 }
@@ -1002,8 +1041,7 @@ struct WriteAcquired<P: DevicePrivilege> {
 /// dimensions / format the cdylib needs to build a
 /// `cudaTextureObject_t`.
 struct ImageReadAcquired<P: DevicePrivilege> {
-    timeline: Arc<P::TimelineSemaphore>,
-    wait_value: u64,
+    peer_timeline: Arc<P::TimelineSemaphore>,
     image: vk::Image,
     width: u32,
     height: u32,
@@ -1013,8 +1051,7 @@ struct ImageReadAcquired<P: DevicePrivilege> {
 /// Image-flavored write snapshot — sibling of [`WriteAcquired`] for
 /// the `acquire_surface` path.
 struct ImageWriteAcquired<P: DevicePrivilege> {
-    timeline: Arc<P::TimelineSemaphore>,
-    wait_value: u64,
+    peer_timeline: Arc<P::TimelineSemaphore>,
     image: vk::Image,
     width: u32,
     height: u32,
@@ -1132,8 +1169,10 @@ impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for CudaSurfaceAdapter<D> {
     }
 
     fn end_read_access(&self, surface_id: SurfaceId) {
-        // Inner Option: `None` means "not the last reader, skip signal".
-        // Outer Option: `None` means "surface raced an unregister".
+        // Consumer-side release: signal `consume_done` so the producer
+        // can wait on it before re-writing. Inner Option: `None` means
+        // "not the last reader, skip signal". Outer Option: `None`
+        // means "surface raced an unregister".
         let signal: Option<Option<(Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>, u64)>> =
             self.surfaces.with_mut(surface_id, |state| {
                 debug_assert!(state.read_holders > 0, "read release without acquire");
@@ -1141,9 +1180,9 @@ impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for CudaSurfaceAdapter<D> {
                 if state.read_holders > 0 {
                     return None;
                 }
-                let next = state.next_release_value();
-                state.current_release_value = next;
-                Some((Arc::clone(&state.timeline), next))
+                let next = state.next_signal_value();
+                state.current_signal_value = next;
+                Some((Arc::clone(&state.consume_done), next))
             });
         let signal = match signal {
             Some(s) => s,
@@ -1155,23 +1194,25 @@ impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for CudaSurfaceAdapter<D> {
                 return;
             }
         };
-        if let Some((timeline, value)) = signal {
-            if let Err(e) = timeline.signal_host(value) {
-                tracing::error!(?surface_id, %value, %e, "timeline signal failed on read release");
+        if let Some((consume_done, value)) = signal {
+            if let Err(e) = consume_done.signal_host(value) {
+                tracing::error!(?surface_id, %value, %e, "consume_done signal failed on read release");
             }
         }
     }
 
     fn end_write_access(&self, surface_id: SurfaceId) {
+        // Producer-side release: signal `produce_done` so the consumer
+        // can wait on it before reading.
         let signal: Option<(Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>, u64)> =
             self.surfaces.with_mut(surface_id, |state| {
                 debug_assert!(state.write_held, "write release without acquire");
                 state.set_write_held(false);
-                let next = state.next_release_value();
-                state.current_release_value = next;
-                (Arc::clone(&state.timeline), next)
+                let next = state.next_signal_value();
+                state.current_signal_value = next;
+                (Arc::clone(&state.produce_done), next)
             });
-        let (timeline, value) = match signal {
+        let (produce_done, value) = match signal {
             Some(s) => s,
             None => {
                 tracing::warn!(
@@ -1181,8 +1222,8 @@ impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for CudaSurfaceAdapter<D> {
                 return;
             }
         };
-        if let Err(e) = timeline.signal_host(value) {
-            tracing::error!(?surface_id, %value, %e, "timeline signal failed on write release");
+        if let Err(e) = produce_done.signal_host(value) {
+            tracing::error!(?surface_id, %value, %e, "produce_done signal failed on write release");
         }
     }
 }

--- a/libs/streamlib-adapter-cuda/src/host_vtable.rs
+++ b/libs/streamlib-adapter-cuda/src/host_vtable.rs
@@ -187,7 +187,8 @@ unsafe extern "C" fn host_register_host_surface<D: VulkanRhiDevice + 'static>(
     handle: *const c_void,
     surface_id: u64,
     pixel_buffer_handle: *const c_void,
-    timeline_handle: *const c_void,
+    produce_done_handle: *const c_void,
+    consume_done_handle: *const c_void,
     initial_layout_raw: i32,
     err_buf: *mut u8,
     err_buf_cap: usize,
@@ -210,10 +211,14 @@ unsafe extern "C" fn host_register_host_surface<D: VulkanRhiDevice + 'static>(
                     return 1;
                 }
             };
-            if pixel_buffer_handle.is_null() || timeline_handle.is_null() {
+            if pixel_buffer_handle.is_null()
+                || produce_done_handle.is_null()
+                || consume_done_handle.is_null()
+            {
                 unsafe {
                     write_err(
-                        "register_host_surface: null pixel_buffer or timeline handle",
+                        "register_host_surface: null pixel_buffer, produce_done, \
+                         or consume_done handle",
                         err_buf,
                         err_buf_cap,
                         err_len,
@@ -224,7 +229,7 @@ unsafe extern "C" fn host_register_host_surface<D: VulkanRhiDevice + 'static>(
             // SAFETY: caller asserts the handles are
             // Arc::into_raw-shaped against the correct privilege
             // family for D. The host bumps the refcount and stashes
-            // a clone in the registry; the caller's Arcs remain
+            // clones in the registry; the caller's Arcs remain
             // owned by the caller.
             let pixel_buffer: Arc<<D::Privilege as DevicePrivilege>::Buffer> = unsafe {
                 Arc::increment_strong_count(
@@ -232,19 +237,30 @@ unsafe extern "C" fn host_register_host_surface<D: VulkanRhiDevice + 'static>(
                 );
                 Arc::from_raw(pixel_buffer_handle as *const <D::Privilege as DevicePrivilege>::Buffer)
             };
-            let timeline: Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore> = unsafe {
+            let produce_done: Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore> = unsafe {
                 Arc::increment_strong_count(
-                    timeline_handle
+                    produce_done_handle
                         as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore,
                 );
                 Arc::from_raw(
-                    timeline_handle
+                    produce_done_handle
+                        as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore,
+                )
+            };
+            let consume_done: Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore> = unsafe {
+                Arc::increment_strong_count(
+                    consume_done_handle
+                        as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore,
+                );
+                Arc::from_raw(
+                    consume_done_handle
                         as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore,
                 )
             };
             let registration = HostSurfaceRegistration {
                 pixel_buffer,
-                timeline,
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout(initial_layout_raw),
             };
             match adapter.register_host_surface(surface_id, registration) {
@@ -264,7 +280,8 @@ unsafe extern "C" fn host_register_host_image_surface<D: VulkanRhiDevice + 'stat
     handle: *const c_void,
     surface_id: u64,
     texture_handle: *const c_void,
-    timeline_handle: *const c_void,
+    produce_done_handle: *const c_void,
+    consume_done_handle: *const c_void,
     initial_layout_raw: i32,
     err_buf: *mut u8,
     err_buf_cap: usize,
@@ -287,10 +304,14 @@ unsafe extern "C" fn host_register_host_image_surface<D: VulkanRhiDevice + 'stat
                     return 1;
                 }
             };
-            if texture_handle.is_null() || timeline_handle.is_null() {
+            if texture_handle.is_null()
+                || produce_done_handle.is_null()
+                || consume_done_handle.is_null()
+            {
                 unsafe {
                     write_err(
-                        "register_host_image_surface: null texture or timeline handle",
+                        "register_host_image_surface: null texture, produce_done, \
+                         or consume_done handle",
                         err_buf,
                         err_buf_cap,
                         err_len,
@@ -307,19 +328,30 @@ unsafe extern "C" fn host_register_host_image_surface<D: VulkanRhiDevice + 'stat
                 );
                 Arc::from_raw(texture_handle as *const <D::Privilege as DevicePrivilege>::Texture)
             };
-            let timeline: Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore> = unsafe {
+            let produce_done: Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore> = unsafe {
                 Arc::increment_strong_count(
-                    timeline_handle
+                    produce_done_handle
                         as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore,
                 );
                 Arc::from_raw(
-                    timeline_handle
+                    produce_done_handle
+                        as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore,
+                )
+            };
+            let consume_done: Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore> = unsafe {
+                Arc::increment_strong_count(
+                    consume_done_handle
+                        as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore,
+                );
+                Arc::from_raw(
+                    consume_done_handle
                         as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore,
                 )
             };
             let registration = HostImageSurfaceRegistration {
                 texture,
-                timeline,
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout(initial_layout_raw),
             };
             match adapter.register_host_image_surface(surface_id, registration) {
@@ -930,6 +962,7 @@ mod tier1_null_handle_tests {
                 42,
                 core::ptr::null(),
                 core::ptr::null(),
+                core::ptr::null(),
                 0,
                 buf.as_mut_ptr(),
                 buf.len(),
@@ -951,6 +984,7 @@ mod tier1_null_handle_tests {
             (vtable().register_host_image_surface)(
                 core::ptr::null(),
                 42,
+                core::ptr::null(),
                 core::ptr::null(),
                 core::ptr::null(),
                 0,

--- a/libs/streamlib-adapter-cuda/src/state.rs
+++ b/libs/streamlib-adapter-cuda/src/state.rs
@@ -48,11 +48,17 @@ pub struct HostSurfaceRegistration<P: DevicePrivilege> {
     /// `cudaPointerGetAttributes` so the adapter doesn't need to know.
     /// Host- or consumer-flavored per `P`.
     pub pixel_buffer: Arc<P::Buffer>,
-    /// Timeline semaphore — host- or consumer-flavored per `P`. Both
-    /// flavors implement
-    /// [`streamlib_consumer_rhi::VulkanTimelineSemaphoreLike`] so the
-    /// adapter's wait + signal calls work uniformly.
-    pub timeline: Arc<P::TimelineSemaphore>,
+    /// `produce_done` timeline — signaled exclusively by the producer
+    /// process when a write completes (host: GPU submit from
+    /// `submit_host_copy_image_to_buffer` or CPU signal from
+    /// `end_write_access`). The consumer waits on this timeline before
+    /// reading. Single-writer-per-edge per
+    /// `docs/architecture/adapter-timeline-single-writer.md`.
+    pub produce_done: Arc<P::TimelineSemaphore>,
+    /// `consume_done` timeline — signaled exclusively by the consumer
+    /// process when a read completes (`end_read_access`). The producer
+    /// waits on this timeline before re-writing.
+    pub consume_done: Arc<P::TimelineSemaphore>,
     /// Unused on the buffer path (buffers have no `VkImageLayout`); kept
     /// for shape parity with [`HostImageSurfaceRegistration`]. Pass
     /// [`VulkanLayout::UNDEFINED`].
@@ -73,9 +79,12 @@ pub struct HostImageSurfaceRegistration<P: DevicePrivilege> {
     /// OPAQUE_FD-exportable image — the resource CUDA imports as a
     /// tiled mipmapped array. Host- or consumer-flavored per `P`.
     pub texture: Arc<P::Texture>,
-    /// Timeline semaphore — same role and constraints as
-    /// [`HostSurfaceRegistration::timeline`].
-    pub timeline: Arc<P::TimelineSemaphore>,
+    /// `produce_done` timeline — same single-writer contract as
+    /// [`HostSurfaceRegistration::produce_done`].
+    pub produce_done: Arc<P::TimelineSemaphore>,
+    /// `consume_done` timeline — same single-writer contract as
+    /// [`HostSurfaceRegistration::consume_done`].
+    pub consume_done: Arc<P::TimelineSemaphore>,
     /// Vulkan image layout the image is in at registration time. The
     /// cross-process release path (a `CudaContext.release_for_cross_process`
     /// SDK shim that delegates to `VulkanSurfaceAdapter::release_to_foreign`,
@@ -117,7 +126,12 @@ pub(crate) struct SurfaceState<P: DevicePrivilege> {
     #[allow(dead_code)] // kept for tracing / debug output, not read in hot paths
     pub(crate) surface_id: SurfaceId,
     pub(crate) resource: SurfaceResource<P>,
-    pub(crate) timeline: Arc<P::TimelineSemaphore>,
+    /// `produce_done` timeline — see
+    /// [`HostSurfaceRegistration::produce_done`].
+    pub(crate) produce_done: Arc<P::TimelineSemaphore>,
+    /// `consume_done` timeline — see
+    /// [`HostSurfaceRegistration::consume_done`].
+    pub(crate) consume_done: Arc<P::TimelineSemaphore>,
     /// Vulkan image layout the resource is in. Load-bearing for image
     /// surfaces (consumed by the cross-process release shim that
     /// composes `VulkanSurfaceAdapter::release_to_foreign`); ignored on
@@ -126,15 +140,20 @@ pub(crate) struct SurfaceState<P: DevicePrivilege> {
     pub(crate) current_layout: VulkanLayout,
     pub(crate) read_holders: u64,
     pub(crate) write_held: bool,
-    /// The value `signal_host` was last advanced to. The next acquire
-    /// waits on this value (so any prior writer's GPU work has drained)
-    /// and the next release advances it by one.
-    pub(crate) current_release_value: u64,
+    /// Per-process monotonic signal counter. This adapter instance only
+    /// writes ONE side's timeline per the single-writer-per-edge rule
+    /// (host instantiation = producer signaling `produce_done`; cdylib
+    /// instantiation = consumer signaling `consume_done`). Same-process
+    /// test code that exercises both sides increments this counter for
+    /// every signal regardless of which timeline — produce_done and
+    /// consume_done each see strictly monotonic values from their
+    /// respective writer code paths, which is all VUID-03258 requires.
+    pub(crate) current_signal_value: u64,
 }
 
 impl<P: DevicePrivilege> SurfaceState<P> {
-    pub(crate) fn next_release_value(&self) -> u64 {
-        self.current_release_value + 1
+    pub(crate) fn next_signal_value(&self) -> u64 {
+        self.current_signal_value + 1
     }
 }
 

--- a/libs/streamlib-adapter-cuda/tests/conformance.rs
+++ b/libs/streamlib-adapter-cuda/tests/conformance.rs
@@ -48,14 +48,17 @@ fn register_one(
     let host_device = Arc::clone(adapter.device());
     let pixel_buffer = HostVulkanBuffer::new_opaque_fd_export(&host_device, (W as u64) * (H as u64) * (4 as u64))
     .map_err(|e| format!("HostVulkanBuffer::new_opaque_fd_export: {e}"))?;
-    let timeline = HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+    let produce_done = HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+        .map_err(|e| format!("HostVulkanTimelineSemaphore::new_exportable: {e}"))?;
+    let consume_done = HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
         .map_err(|e| format!("HostVulkanTimelineSemaphore::new_exportable: {e}"))?;
     adapter
         .register_host_surface(
             id,
             HostSurfaceRegistration {
                 pixel_buffer: Arc::new(pixel_buffer),
-                timeline: Arc::new(timeline),
+                produce_done: Arc::new(produce_done),
+                consume_done: Arc::new(consume_done),
                 initial_layout: VulkanLayout::UNDEFINED,
             },
         )
@@ -142,14 +145,18 @@ fn duplicate_registration_returns_surface_already_registered() {
     // `register_one` helper wraps errors in `String` for ergonomics).
     let pixel_buffer = HostVulkanBuffer::new_opaque_fd_export(&host_device, (W as u64) * (H as u64) * (4 as u64))
     .expect("second pixel buffer");
-    let timeline =
+    let produce_done =
         HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
-            .expect("second timeline");
+            .expect("second produce_done");
+    let consume_done =
+        HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+            .expect("second consume_done");
     let result = adapter.register_host_surface(
         id,
         streamlib_adapter_cuda::HostSurfaceRegistration {
             pixel_buffer: Arc::new(pixel_buffer),
-            timeline: Arc::new(timeline),
+            produce_done: Arc::new(produce_done),
+            consume_done: Arc::new(consume_done),
             initial_layout: VulkanLayout::UNDEFINED,
         },
     );

--- a/libs/streamlib-adapter-cuda/tests/image_registration.rs
+++ b/libs/streamlib-adapter-cuda/tests/image_registration.rs
@@ -118,13 +118,15 @@ fn image_registration_round_trips_through_surface_texture_accessor() {
     let id: SurfaceId = 0x4001;
     let texture = make_image(&host_device, RhiTextureFormat::Rgba8Unorm)
         .expect("texture");
-    let timeline = make_timeline(&host_device).expect("timeline");
+    let produce_done = make_timeline(&host_device).expect("produce_done");
+    let consume_done = make_timeline(&host_device).expect("consume_done");
     adapter
         .register_host_image_surface(
             id,
             HostImageSurfaceRegistration {
                 texture: Arc::clone(&texture),
-                timeline: Arc::clone(&timeline),
+                produce_done: Arc::clone(&produce_done),
+                consume_done: Arc::clone(&consume_done),
                 initial_layout: VulkanLayout::GENERAL,
             },
         )
@@ -132,8 +134,20 @@ fn image_registration_round_trips_through_surface_texture_accessor() {
     assert_eq!(adapter.registered_count(), 1);
     let stored = adapter.surface_texture(id).expect("surface_texture Some");
     assert!(Arc::ptr_eq(&stored, &texture), "texture Arc round-trip");
-    let stored_tl = adapter.surface_timeline(id).expect("surface_timeline Some");
-    assert!(Arc::ptr_eq(&stored_tl, &timeline), "timeline Arc round-trip");
+    let stored_produce_done = adapter
+        .surface_produce_done(id)
+        .expect("surface_produce_done Some");
+    assert!(
+        Arc::ptr_eq(&stored_produce_done, &produce_done),
+        "produce_done Arc round-trip"
+    );
+    let stored_consume_done = adapter
+        .surface_consume_done(id)
+        .expect("surface_consume_done Some");
+    assert!(
+        Arc::ptr_eq(&stored_consume_done, &consume_done),
+        "consume_done Arc round-trip"
+    );
     // Buffer accessor must return None for image-flavored registrations.
     assert!(
         adapter.surface_pixel_buffer(id).is_none(),
@@ -172,13 +186,15 @@ fn image_registration_accepts_each_cuda_mappable_format() {
                 continue;
             }
         };
-        let timeline = make_timeline(&host_device).expect("timeline");
+        let produce_done = make_timeline(&host_device).expect("produce_done");
+        let consume_done = make_timeline(&host_device).expect("consume_done");
         adapter
             .register_host_image_surface(
                 id,
                 HostImageSurfaceRegistration {
                     texture,
-                    timeline,
+                    produce_done,
+                    consume_done,
                     initial_layout: VulkanLayout::UNDEFINED,
                 },
             )
@@ -198,24 +214,28 @@ fn buffer_then_image_registration_returns_surface_already_registered() {
     let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
     let id: SurfaceId = 0x6001;
     let buffer = make_buffer(&host_device).expect("buffer");
-    let timeline = make_timeline(&host_device).expect("timeline");
+    let produce_done = make_timeline(&host_device).expect("produce_done");
+    let consume_done = make_timeline(&host_device).expect("consume_done");
     adapter
         .register_host_surface(
             id,
             HostSurfaceRegistration {
                 pixel_buffer: buffer,
-                timeline,
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout::UNDEFINED,
             },
         )
         .expect("register buffer");
     let image = make_image(&host_device, RhiTextureFormat::Rgba8Unorm).expect("image");
-    let timeline2 = make_timeline(&host_device).expect("timeline2");
+    let produce_done2 = make_timeline(&host_device).expect("produce_done2");
+    let consume_done2 = make_timeline(&host_device).expect("consume_done2");
     let result = adapter.register_host_image_surface(
         id,
         HostImageSurfaceRegistration {
             texture: image,
-            timeline: timeline2,
+            produce_done: produce_done2,
+            consume_done: consume_done2,
             initial_layout: VulkanLayout::GENERAL,
         },
     );
@@ -243,13 +263,15 @@ fn acquire_texture_returns_view_with_correct_handles_and_releases_on_drop() {
     let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
     let id: SurfaceId = 0x7001;
     let texture = make_image(&host_device, RhiTextureFormat::Rgba16Float).expect("texture");
-    let timeline = make_timeline(&host_device).expect("timeline");
+    let produce_done = make_timeline(&host_device).expect("produce_done");
+    let consume_done = make_timeline(&host_device).expect("consume_done");
     adapter
         .register_host_image_surface(
             id,
             HostImageSurfaceRegistration {
                 texture: Arc::clone(&texture),
-                timeline,
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout::GENERAL,
             },
         )
@@ -282,13 +304,15 @@ fn acquire_surface_returns_view_with_correct_handles_and_releases_on_drop() {
     let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
     let id: SurfaceId = 0x7002;
     let texture = make_image(&host_device, RhiTextureFormat::Rgba32Float).expect("texture");
-    let timeline = make_timeline(&host_device).expect("timeline");
+    let produce_done = make_timeline(&host_device).expect("produce_done");
+    let consume_done = make_timeline(&host_device).expect("consume_done");
     adapter
         .register_host_image_surface(
             id,
             HostImageSurfaceRegistration {
                 texture: Arc::clone(&texture),
-                timeline,
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout::GENERAL,
             },
         )
@@ -322,13 +346,15 @@ fn buffer_path_rejects_image_surface_with_usage_correction_hint() {
     let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
     let id: SurfaceId = 0x8001;
     let texture = make_image(&host_device, RhiTextureFormat::Rgba8Unorm).expect("texture");
-    let timeline = make_timeline(&host_device).expect("timeline");
+    let produce_done = make_timeline(&host_device).expect("produce_done");
+    let consume_done = make_timeline(&host_device).expect("consume_done");
     adapter
         .register_host_image_surface(
             id,
             HostImageSurfaceRegistration {
                 texture,
-                timeline,
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout::GENERAL,
             },
         )
@@ -372,13 +398,15 @@ fn image_path_rejects_buffer_surface_with_usage_correction_hint() {
     let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
     let id: SurfaceId = 0x8101;
     let buffer = make_buffer(&host_device).expect("buffer");
-    let timeline = make_timeline(&host_device).expect("timeline");
+    let produce_done = make_timeline(&host_device).expect("produce_done");
+    let consume_done = make_timeline(&host_device).expect("consume_done");
     adapter
         .register_host_surface(
             id,
             HostSurfaceRegistration {
                 pixel_buffer: buffer,
-                timeline,
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout::UNDEFINED,
             },
         )
@@ -417,13 +445,15 @@ fn try_acquire_surface_returns_none_on_reader_contention() {
     let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
     let id: SurfaceId = 0x9001;
     let texture = make_image(&host_device, RhiTextureFormat::Rgba8Unorm).expect("texture");
-    let timeline = make_timeline(&host_device).expect("timeline");
+    let produce_done = make_timeline(&host_device).expect("produce_done");
+    let consume_done = make_timeline(&host_device).expect("consume_done");
     adapter
         .register_host_image_surface(
             id,
             HostImageSurfaceRegistration {
                 texture,
-                timeline,
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout::GENERAL,
             },
         )
@@ -450,13 +480,15 @@ fn try_acquire_texture_returns_none_on_writer_contention() {
     let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
     let id: SurfaceId = 0x9002;
     let texture = make_image(&host_device, RhiTextureFormat::Rgba8Unorm).expect("texture");
-    let timeline = make_timeline(&host_device).expect("timeline");
+    let produce_done = make_timeline(&host_device).expect("produce_done");
+    let consume_done = make_timeline(&host_device).expect("consume_done");
     adapter
         .register_host_image_surface(
             id,
             HostImageSurfaceRegistration {
                 texture,
-                timeline,
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout::GENERAL,
             },
         )

--- a/libs/streamlib-adapter-cuda/tests/persistent_command_pool.rs
+++ b/libs/streamlib-adapter-cuda/tests/persistent_command_pool.rs
@@ -81,10 +81,23 @@ fn persistent_pool_count_stays_at_one_across_repeated_submits() {
             return;
         }
     };
-    let timeline = match HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0) {
+    let produce_done = match HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+    {
         Ok(s) => Arc::new(s),
         Err(e) => {
-            println!("cuda persistent_pool: new_exportable timeline failed: {e} — skipping");
+            println!(
+                "cuda persistent_pool: new_exportable produce_done failed: {e} — skipping"
+            );
+            return;
+        }
+    };
+    let consume_done = match HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+    {
+        Ok(s) => Arc::new(s),
+        Err(e) => {
+            println!(
+                "cuda persistent_pool: new_exportable consume_done failed: {e} — skipping"
+            );
             return;
         }
     };
@@ -110,7 +123,8 @@ fn persistent_pool_count_stays_at_one_across_repeated_submits() {
             SURFACE_ID,
             HostSurfaceRegistration {
                 pixel_buffer,
-                timeline,
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout::UNDEFINED,
             },
         )

--- a/libs/streamlib-adapter-skia/tests/concurrent_skia_and_vulkan_read.rs
+++ b/libs/streamlib-adapter-skia/tests/concurrent_skia_and_vulkan_read.rs
@@ -66,8 +66,15 @@ fn skia_read_and_vulkan_read_share_surface() {
         .acquire_render_target_dma_buf_image(W, H, TextureFormat::Bgra8Unorm)
         .expect("acquire_render_target_dma_buf_image");
     let texture = stream_tex.vulkan_inner().clone();
-    let timeline = Arc::new(
-        HostVulkanTimelineSemaphore::new(host_device.device(), 0).expect("timeline"),
+    // Single-writer-per-edge per
+    // `docs/architecture/adapter-timeline-single-writer.md`.
+    let produce_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(host_device.device(), 0)
+            .expect("produce_done timeline"),
+    );
+    let consume_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(host_device.device(), 0)
+            .expect("consume_done timeline"),
     );
     let surface_id = 0xdada_dada;
     inner
@@ -75,7 +82,8 @@ fn skia_read_and_vulkan_read_share_surface() {
             surface_id,
             HostSurfaceRegistration {
                 texture: texture.clone(),
-                timeline: Arc::clone(&timeline),
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout::UNDEFINED,
             },
         )

--- a/libs/streamlib-adapter-skia/tests/conformance.rs
+++ b/libs/streamlib-adapter-skia/tests/conformance.rs
@@ -64,15 +64,23 @@ fn register_one(
     let raw_tex = HostVulkanTexture::new_device_local(inner.device(), &desc)
         .expect("HostVulkanTexture::new_device_local");
     let texture = Arc::new(raw_tex);
-    let timeline = Arc::new(
-        HostVulkanTimelineSemaphore::new(inner.device().device(), 0).expect("timeline"),
+    // Single-writer-per-edge per
+    // `docs/architecture/adapter-timeline-single-writer.md`.
+    let produce_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(inner.device().device(), 0)
+            .expect("produce_done timeline"),
+    );
+    let consume_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(inner.device().device(), 0)
+            .expect("consume_done timeline"),
     );
     inner
         .register_host_surface(
             id,
             HostSurfaceRegistration {
                 texture,
-                timeline,
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout::UNDEFINED,
             },
         )

--- a/libs/streamlib-adapter-skia/tests/round_trip_skia_canvas.rs
+++ b/libs/streamlib-adapter-skia/tests/round_trip_skia_canvas.rs
@@ -65,16 +65,27 @@ fn round_trip_skia_canvas() {
         .acquire_render_target_dma_buf_image(W, H, TextureFormat::Bgra8Unorm)
         .expect("acquire_render_target_dma_buf_image");
     let texture = stream_tex.vulkan_inner().clone();
-    let timeline = Arc::new(
-        HostVulkanTimelineSemaphore::new(host_device.device(), 0).expect("timeline"),
+    // Single-writer-per-edge per
+    // `docs/architecture/adapter-timeline-single-writer.md`: only
+    // `acquire_write` is exercised below, so `produce_done` tracks
+    // the assertion.
+    let produce_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(host_device.device(), 0)
+            .expect("produce_done timeline"),
     );
+    let consume_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(host_device.device(), 0)
+            .expect("consume_done timeline"),
+    );
+    let timeline = Arc::clone(&produce_done);
     let surface_id = 0x5e1a_5e1a;
     inner
         .register_host_surface(
             surface_id,
             HostSurfaceRegistration {
                 texture: texture.clone(),
-                timeline: Arc::clone(&timeline),
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout::UNDEFINED,
             },
         )

--- a/libs/streamlib-adapter-skia/tests/skia_animated_stress.rs
+++ b/libs/streamlib-adapter-skia/tests/skia_animated_stress.rs
@@ -109,16 +109,27 @@ fn skia_animated_stress() {
         .acquire_render_target_dma_buf_image(W, H, TextureFormat::Bgra8Unorm)
         .expect("acquire_render_target_dma_buf_image");
     let texture = stream_tex.vulkan_inner().clone();
-    let timeline = Arc::new(
-        HostVulkanTimelineSemaphore::new(host_device.device(), 0).expect("timeline"),
+    // Single-writer-per-edge per
+    // `docs/architecture/adapter-timeline-single-writer.md`: the test
+    // only exercises `acquire_write` so `produce_done` is the
+    // timeline whose counter tracks frames.
+    let produce_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(host_device.device(), 0)
+            .expect("produce_done timeline"),
     );
+    let consume_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(host_device.device(), 0)
+            .expect("consume_done timeline"),
+    );
+    let timeline = Arc::clone(&produce_done);
     let surface_id = 0xa11_a11a;
     inner
         .register_host_surface(
             surface_id,
             HostSurfaceRegistration {
                 texture: texture.clone(),
-                timeline: Arc::clone(&timeline),
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout::UNDEFINED,
             },
         )

--- a/libs/streamlib-adapter-skia/tests/skia_visual_evidence.rs
+++ b/libs/streamlib-adapter-skia/tests/skia_visual_evidence.rs
@@ -89,16 +89,27 @@ fn skia_visual_evidence() {
         .acquire_render_target_dma_buf_image(W, H, TextureFormat::Bgra8Unorm)
         .expect("acquire_render_target_dma_buf_image");
     let texture = stream_tex.vulkan_inner().clone();
-    let timeline = Arc::new(
-        HostVulkanTimelineSemaphore::new(host_device.device(), 0).expect("timeline"),
+    // Single-writer-per-edge per
+    // `docs/architecture/adapter-timeline-single-writer.md`: only
+    // `acquire_write` is exercised below, so `produce_done` is the
+    // timeline the assertion tracks.
+    let produce_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(host_device.device(), 0)
+            .expect("produce_done timeline"),
     );
+    let consume_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(host_device.device(), 0)
+            .expect("consume_done timeline"),
+    );
+    let timeline = Arc::clone(&produce_done);
     let surface_id = 0xe0e1_e0e1;
     inner
         .register_host_surface(
             surface_id,
             HostSurfaceRegistration {
                 texture: texture.clone(),
-                timeline: Arc::clone(&timeline),
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout::UNDEFINED,
             },
         )

--- a/libs/streamlib-adapter-vulkan-abi/src/lib.rs
+++ b/libs/streamlib-adapter-vulkan-abi/src/lib.rs
@@ -282,9 +282,14 @@ pub struct VulkanSurfaceAdapterVTable {
     /// stores a clone in the adapter's internal registry. The
     /// caller's `texture_handle` Arc remains owned by the caller.
     ///
-    /// `timeline_handle` is an
+    /// `produce_done_handle` and `consume_done_handle` are
     /// `Arc::into_raw(Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>)`-shaped
-    /// opaque pointer with identical ownership semantics.
+    /// opaque pointers with identical ownership semantics. They are
+    /// the two single-writer-per-edge timeline semaphores documented
+    /// in `docs/architecture/adapter-timeline-single-writer.md`:
+    /// `produce_done` is signaled exclusively by the producer
+    /// process (from `end_write_access`), `consume_done` exclusively
+    /// by the consumer process (from `end_read_access`).
     ///
     /// `initial_layout_raw` is the i32 `VkImageLayout` enumerant
     /// the texture is in at registration time.
@@ -296,7 +301,8 @@ pub struct VulkanSurfaceAdapterVTable {
         handle: *const c_void,
         surface_id: u64,
         texture_handle: *const c_void,
-        timeline_handle: *const c_void,
+        produce_done_handle: *const c_void,
+        consume_done_handle: *const c_void,
         initial_layout_raw: i32,
         err_buf: *mut u8,
         err_buf_cap: usize,

--- a/libs/streamlib-adapter-vulkan-helpers/src/bin/vulkan_adapter_subprocess_helper.rs
+++ b/libs/streamlib-adapter-vulkan-helpers/src/bin/vulkan_adapter_subprocess_helper.rs
@@ -3,24 +3,38 @@
 
 //! Subprocess test helper for round-trip and crash-mid-write tests.
 //!
-//! Receives DMA-BUF fds + a timeline-semaphore opaque-fd via SCM_RIGHTS
-//! over a socketpair the parent passed in `STREAMLIB_HELPER_SOCKET_FD`.
-//! Imports both into a fresh `VkDevice` (this process's own — sidestepping
-//! the dual-VkDevice crash because no GPU work is active in the parent
-//! when the subprocess starts), then performs the role specified in
-//! argv[1]:
+//! Receives DMA-BUF fds + two timeline-semaphore opaque-fds
+//! (`produce_done` first, then `consume_done` — per the
+//! single-writer-per-edge contract in
+//! `docs/architecture/adapter-timeline-single-writer.md`) via
+//! SCM_RIGHTS over a socketpair the parent passed in
+//! `STREAMLIB_HELPER_SOCKET_FD`. Imports both into a fresh `VkDevice`
+//! (this process's own — sidestepping the dual-VkDevice crash because
+//! no GPU work is active in the parent when the subprocess starts),
+//! then performs the role specified in argv[1].
 //!
-//! - `read`        — wait on timeline `wait_value`, vkCmdCopyImageToBuffer
-//!                   into a staging VkBuffer, send the bytes back over
-//!                   the socketpair, signal `wait_value + 1`.
-//! - `write`       — wait on `wait_value`, vkCmdClearColorImage with the
-//!                   provided RGBA tuple, signal `wait_value + 1`.
-//! - `wait-only`   — wait, signal +1, exit. Used by the concurrent-reads
-//!                   test (no GPU work, just contention shape).
-//! - `crash-mid-write` — begin a write (acquire timeline value + start
-//!                   command submission), then `abort()` mid-flight.
-//!                   Verifies host-side cleanup via the EPOLLHUP
-//!                   watchdog or `SubprocessCrashHarness`.
+//! Per the v1 single-writer-per-edge model, each role waits on the
+//! peer's timeline's kernel `current_value()` and signals its own
+//! edge:
+//!
+//! - `read`        — CONSUMER side: wait on
+//!                   `produce_done.current_value()`,
+//!                   vkCmdCopyImageToBuffer into a staging VkBuffer,
+//!                   send the bytes back, signal `consume_done` at
+//!                   its next monotonic value.
+//! - `write`       — PRODUCER side: wait on
+//!                   `consume_done.current_value()`,
+//!                   vkCmdClearColorImage with the provided RGBA
+//!                   tuple, signal `produce_done` at its next
+//!                   monotonic value.
+//! - `wait-only`   — CONSUMER-flavored: wait on `produce_done`,
+//!                   signal `consume_done`, exit. Used by contention-
+//!                   shape tests.
+//! - `crash-mid-write` — PRODUCER side: begin a write (acquire
+//!                   timeline value + start command submission), then
+//!                   `abort()` mid-flight. Verifies host-side cleanup
+//!                   via the EPOLLHUP watchdog or
+//!                   `SubprocessCrashHarness`.
 
 #![cfg(target_os = "linux")]
 
@@ -44,7 +58,14 @@ struct HelperRequest {
     plane_offsets: Vec<u64>,
     plane_strides: Vec<u64>,
     allocation_size: u64,
-    /// Timeline value the helper waits on.
+    /// Optional wait-target hint kept for compatibility; the helper
+    /// now derives wait targets from the peer timeline's kernel
+    /// `current_value()` per the v1 single-writer-per-edge model so
+    /// this field is effectively ignored. Tests still set it (often
+    /// to `1`) so the JSON payload remains stable across the
+    /// migration.
+    #[allow(dead_code)]
+    #[serde(default)]
     wait_value: u64,
     /// For `write`: 4 bytes of clear color.
     clear_color: Option<[f32; 4]>,
@@ -104,7 +125,7 @@ fn run() -> ExitCode {
     let (payload, fds) = match streamlib_surface_client::recv_message_with_fds(
         &socket,
         msg_len,
-        streamlib_surface_client::MAX_DMA_BUF_PLANES + 1,
+        streamlib_surface_client::MAX_DMA_BUF_PLANES + 2,
     ) {
         Ok(p) => p,
         Err(e) => return die(Some(&socket), format!("recv_message_with_fds: {e}")),
@@ -115,14 +136,21 @@ fn run() -> ExitCode {
         Err(e) => return die(Some(&socket), format!("parse request: {e}")),
     };
 
-    if fds.len() < 2 {
+    // Wire layout: [...dma_buf_fds, produce_done_fd, consume_done_fd]
+    // — the last two slots are the two single-writer timelines per
+    // `docs/architecture/adapter-timeline-single-writer.md`.
+    if fds.len() < 3 {
         return die(
             Some(&socket),
-            format!("expected ≥2 fds (DMA-BUF + sync), got {}", fds.len()),
+            format!(
+                "expected ≥3 fds (DMA-BUF + produce_done + consume_done), got {}",
+                fds.len()
+            ),
         );
     }
-    let sync_fd = *fds.last().unwrap();
-    let dma_buf_fds: Vec<RawFd> = fds[..fds.len() - 1].to_vec();
+    let consume_done_fd = fds[fds.len() - 1];
+    let produce_done_fd = fds[fds.len() - 2];
+    let dma_buf_fds: Vec<RawFd> = fds[..fds.len() - 2].to_vec();
 
     // Build our own VkDevice. The parent has no GPU work in flight when
     // it spawns us, so the dual-VkDevice crash on NVIDIA does not apply.
@@ -147,18 +175,31 @@ fn run() -> ExitCode {
         Err(e) => return die(Some(&socket), format!("import_render_target_dma_buf: {e}")),
     };
 
-    // Import the timeline semaphore. Vulkan takes ownership of `sync_fd`
-    // on success; we close every other fd.
-    let timeline = match HostVulkanTimelineSemaphore::from_imported_opaque_fd(
+    // Import both timeline semaphores. Vulkan takes ownership of each
+    // fd on success; we close every other fd ourselves.
+    let produce_done = match HostVulkanTimelineSemaphore::from_imported_opaque_fd(
         device.device(),
-        sync_fd,
+        produce_done_fd,
     ) {
         Ok(t) => t,
         Err(e) => {
             for f in &dma_buf_fds {
                 unsafe { libc::close(*f) };
             }
-            return die(Some(&socket), format!("import sync_fd: {e}"));
+            unsafe { libc::close(consume_done_fd) };
+            return die(Some(&socket), format!("import produce_done_fd: {e}"));
+        }
+    };
+    let consume_done = match HostVulkanTimelineSemaphore::from_imported_opaque_fd(
+        device.device(),
+        consume_done_fd,
+    ) {
+        Ok(t) => t,
+        Err(e) => {
+            for f in &dma_buf_fds {
+                unsafe { libc::close(*f) };
+            }
+            return die(Some(&socket), format!("import consume_done_fd: {e}"));
         }
     };
 
@@ -170,19 +211,26 @@ fn run() -> ExitCode {
         unsafe { libc::close(*f) };
     }
 
-    // Wait for the parent to finish writing / hand off.
-    if let Err(e) = timeline.wait(req.wait_value, 5_000_000_000u64) {
-        return die(
-            Some(&socket),
-            format!("timeline.wait({}): {e}", req.wait_value),
-        );
-    }
-
     let response = match role.as_str() {
         "wait-only" => {
-            // Just signal the next value and exit. Used by contention tests.
-            if let Err(e) = timeline.signal_host(req.wait_value + 1) {
-                return die(Some(&socket), format!("signal_host: {e}"));
+            // CONSUMER-flavored: wait on the producer's edge, signal
+            // the consumer's. Used by contention tests.
+            let wait_target = match produce_done.current_value() {
+                Ok(v) => v,
+                Err(e) => return die(Some(&socket), format!("produce_done.current_value: {e}")),
+            };
+            if let Err(e) = produce_done.wait(wait_target, 5_000_000_000u64) {
+                return die(
+                    Some(&socket),
+                    format!("produce_done.wait({wait_target}): {e}"),
+                );
+            }
+            let signal_value = match consume_done.current_value() {
+                Ok(v) => v.saturating_add(1),
+                Err(e) => return die(Some(&socket), format!("consume_done.current_value: {e}")),
+            };
+            if let Err(e) = consume_done.signal_host(signal_value) {
+                return die(Some(&socket), format!("consume_done.signal_host: {e}"));
             }
             HelperResponse {
                 ok: true,
@@ -191,6 +239,18 @@ fn run() -> ExitCode {
             }
         }
         "write" => {
+            // PRODUCER side: wait on consume_done (so we don't stomp
+            // a live reader), do the write, signal produce_done.
+            let wait_target = match consume_done.current_value() {
+                Ok(v) => v,
+                Err(e) => return die(Some(&socket), format!("consume_done.current_value: {e}")),
+            };
+            if let Err(e) = consume_done.wait(wait_target, 5_000_000_000u64) {
+                return die(
+                    Some(&socket),
+                    format!("consume_done.wait({wait_target}): {e}"),
+                );
+            }
             let color = req.clear_color.unwrap_or([1.0, 0.5, 0.25, 1.0]);
             if let Err(e) = subprocess_clear_image(
                 &device,
@@ -199,8 +259,15 @@ fn run() -> ExitCode {
             ) {
                 return die(Some(&socket), format!("subprocess_clear_image: {e}"));
             }
-            if let Err(e) = timeline.signal_host(req.wait_value + 1) {
-                return die(Some(&socket), format!("signal_host post-write: {e}"));
+            let signal_value = match produce_done.current_value() {
+                Ok(v) => v.saturating_add(1),
+                Err(e) => return die(Some(&socket), format!("produce_done.current_value: {e}")),
+            };
+            if let Err(e) = produce_done.signal_host(signal_value) {
+                return die(
+                    Some(&socket),
+                    format!("produce_done.signal_host: {e}"),
+                );
             }
             HelperResponse {
                 ok: true,
@@ -209,6 +276,18 @@ fn run() -> ExitCode {
             }
         }
         "read" => {
+            // CONSUMER side: wait on produce_done, read, signal
+            // consume_done.
+            let wait_target = match produce_done.current_value() {
+                Ok(v) => v,
+                Err(e) => return die(Some(&socket), format!("produce_done.current_value: {e}")),
+            };
+            if let Err(e) = produce_done.wait(wait_target, 5_000_000_000u64) {
+                return die(
+                    Some(&socket),
+                    format!("produce_done.wait({wait_target}): {e}"),
+                );
+            }
             let bytes = match subprocess_readback_image(
                 &device,
                 texture.image().expect("imported image"),
@@ -218,8 +297,15 @@ fn run() -> ExitCode {
                 Ok(b) => b,
                 Err(e) => return die(Some(&socket), format!("subprocess_readback_image: {e}")),
             };
-            if let Err(e) = timeline.signal_host(req.wait_value + 1) {
-                return die(Some(&socket), format!("signal_host post-read: {e}"));
+            let signal_value = match consume_done.current_value() {
+                Ok(v) => v.saturating_add(1),
+                Err(e) => return die(Some(&socket), format!("consume_done.current_value: {e}")),
+            };
+            if let Err(e) = consume_done.signal_host(signal_value) {
+                return die(
+                    Some(&socket),
+                    format!("consume_done.signal_host: {e}"),
+                );
             }
             HelperResponse {
                 ok: true,
@@ -228,7 +314,11 @@ fn run() -> ExitCode {
             }
         }
         "crash-mid-write" => {
-            // Spec'd to crash mid-flight; never reach the response send.
+            // PRODUCER side, spec'd to crash mid-flight; never reach
+            // the response send. Keep the imports alive until abort to
+            // exercise the host's epoll-hup cleanup against fully-
+            // imported state.
+            let _ = (&produce_done, &consume_done);
             std::process::abort();
         }
         other => {

--- a/libs/streamlib-adapter-vulkan/src/adapter.rs
+++ b/libs/streamlib-adapter-vulkan/src/adapter.rs
@@ -126,12 +126,13 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
             SurfaceState {
                 surface_id: id,
                 texture: registration.texture,
-                timeline: registration.timeline,
+                produce_done: registration.produce_done,
+                consume_done: registration.consume_done,
                 current_layout: registration.initial_layout,
                 read_holders: 0,
                 write_held: false,
                 last_acquire_value: 0,
-                current_release_value: 0,
+                current_signal_value: 0,
             },
         );
         if !inserted {
@@ -395,18 +396,20 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
     ) -> Result<Option<ReadAcquired<D::Privilege>>, AdapterError> {
         let id = surface.id;
         self.surfaces.try_begin_read(id, |state| {
-            let timeline = Arc::clone(&state.timeline);
-            let wait_value = state.current_release_value;
+            // Consumer-side acquire waits on `produce_done` — the
+            // peer-timeline's kernel `current_value()` snapshot is
+            // taken inside `finalize_read` (outside the registry
+            // lock) per
+            // `docs/architecture/adapter-timeline-single-writer.md`.
+            let peer_timeline = Arc::clone(&state.produce_done);
             let image = state
                 .texture
                 .image()
                 .ok_or(AdapterError::SurfaceNotFound { surface_id: id })?;
             let from = state.current_layout;
-            state.last_acquire_value = wait_value;
             let info = self.make_image_info(&state.texture);
             Ok(ReadAcquired {
-                timeline,
-                wait_value,
+                peer_timeline,
                 image,
                 from,
                 info,
@@ -420,18 +423,17 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
     ) -> Result<Option<WriteAcquired<D::Privilege>>, AdapterError> {
         let id = surface.id;
         self.surfaces.try_begin_write(id, |state| {
-            let timeline = Arc::clone(&state.timeline);
-            let wait_value = state.current_release_value;
+            // Producer-side acquire waits on `consume_done` — confirms
+            // the consumer has drained prior content before re-write.
+            let peer_timeline = Arc::clone(&state.consume_done);
             let image = state
                 .texture
                 .image()
                 .ok_or(AdapterError::SurfaceNotFound { surface_id: id })?;
             let from = state.current_layout;
-            state.last_acquire_value = wait_value;
             let info = self.make_image_info(&state.texture);
             Ok(WriteAcquired {
-                timeline,
-                wait_value,
+                peer_timeline,
                 image,
                 from,
                 info,
@@ -445,9 +447,13 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
         surface_id: SurfaceId,
         acquired: ReadAcquired<D::Privilege>,
     ) -> Result<vk::ImageLayout, AdapterError> {
+        let wait_value = acquired
+            .peer_timeline
+            .current_value()
+            .unwrap_or(0);
         if acquired
-            .timeline
-            .wait(acquired.wait_value, self.acquire_timeout.as_nanos() as u64)
+            .peer_timeline
+            .wait(wait_value, self.acquire_timeout.as_nanos() as u64)
             .is_err()
         {
             // Roll back: the acquire had bumped read_holders; undo it.
@@ -456,6 +462,9 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
                 duration: self.acquire_timeout,
             });
         }
+        self.surfaces.with_mut(surface_id, |state| {
+            state.last_acquire_value = wait_value;
+        });
 
         let to = vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL;
         if let Err(err) = self.transition_layout_sync(acquired.image, acquired.from.as_vk(), to) {
@@ -473,9 +482,13 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
         surface_id: SurfaceId,
         acquired: WriteAcquired<D::Privilege>,
     ) -> Result<vk::ImageLayout, AdapterError> {
+        let wait_value = acquired
+            .peer_timeline
+            .current_value()
+            .unwrap_or(0);
         if acquired
-            .timeline
-            .wait(acquired.wait_value, self.acquire_timeout.as_nanos() as u64)
+            .peer_timeline
+            .wait(wait_value, self.acquire_timeout.as_nanos() as u64)
             .is_err()
         {
             self.surfaces.rollback_write(surface_id);
@@ -483,6 +496,9 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
                 duration: self.acquire_timeout,
             });
         }
+        self.surfaces.with_mut(surface_id, |state| {
+            state.last_acquire_value = wait_value;
+        });
 
         // GENERAL covers compute, transfer, and color-attachment writes.
         // Picking COLOR_ATTACHMENT_OPTIMAL would force a re-transition
@@ -503,17 +519,18 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
 /// Snapshot taken under the registry lock so the timeline wait + layout
 /// transition can run unlocked. `read_holders` / `write_held` are
 /// already incremented; rollback paths decrement them on failure.
+/// `peer_timeline` is the side this caller waits on (`produce_done` for
+/// read paths, `consume_done` for write paths) per
+/// single-writer-per-edge.
 struct ReadAcquired<P: DevicePrivilege> {
-    timeline: Arc<P::TimelineSemaphore>,
-    wait_value: u64,
+    peer_timeline: Arc<P::TimelineSemaphore>,
     image: vk::Image,
     from: VulkanLayout,
     info: VkImageInfo,
 }
 
 struct WriteAcquired<P: DevicePrivilege> {
-    timeline: Arc<P::TimelineSemaphore>,
-    wait_value: u64,
+    peer_timeline: Arc<P::TimelineSemaphore>,
     image: vk::Image,
     from: VulkanLayout,
     info: VkImageInfo,
@@ -626,8 +643,10 @@ impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for VulkanSurfaceAdapter<D> {
     }
 
     fn end_read_access(&self, surface_id: SurfaceId) {
-        // Inner Option: `None` means "not the last reader, skip signal".
-        // Outer Option: `None` means "surface raced an unregister".
+        // Consumer-side release: signal `consume_done` so the producer
+        // can wait on it before re-writing. Inner Option: `None` means
+        // "not the last reader, skip signal". Outer Option: `None`
+        // means "surface raced an unregister".
         let signal: Option<Option<(Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>, u64)>> =
             self.surfaces.with_mut(surface_id, |state| {
                 debug_assert!(state.read_holders > 0, "read release without acquire");
@@ -635,9 +654,9 @@ impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for VulkanSurfaceAdapter<D> {
                 if state.read_holders > 0 {
                     return None;
                 }
-                let next = state.next_release_value();
-                state.current_release_value = next;
-                Some((Arc::clone(&state.timeline), next))
+                let next = state.next_signal_value();
+                state.current_signal_value = next;
+                Some((Arc::clone(&state.consume_done), next))
             });
         let signal = match signal {
             Some(s) => s,
@@ -649,23 +668,25 @@ impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for VulkanSurfaceAdapter<D> {
                 return;
             }
         };
-        if let Some((timeline, value)) = signal {
-            if let Err(e) = timeline.signal_host(value) {
-                tracing::error!(?surface_id, %value, %e, "timeline signal failed on read release");
+        if let Some((consume_done, value)) = signal {
+            if let Err(e) = consume_done.signal_host(value) {
+                tracing::error!(?surface_id, %value, %e, "consume_done signal failed on read release");
             }
         }
     }
 
     fn end_write_access(&self, surface_id: SurfaceId) {
+        // Producer-side release: signal `produce_done` so the consumer
+        // can wait on it before reading.
         let signal: Option<(Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>, u64)> =
             self.surfaces.with_mut(surface_id, |state| {
                 debug_assert!(state.write_held, "write release without acquire");
                 state.set_write_held(false);
-                let next = state.next_release_value();
-                state.current_release_value = next;
-                (Arc::clone(&state.timeline), next)
+                let next = state.next_signal_value();
+                state.current_signal_value = next;
+                (Arc::clone(&state.produce_done), next)
             });
-        let (timeline, value) = match signal {
+        let (produce_done, value) = match signal {
             Some(s) => s,
             None => {
                 tracing::warn!(
@@ -675,8 +696,8 @@ impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for VulkanSurfaceAdapter<D> {
                 return;
             }
         };
-        if let Err(e) = timeline.signal_host(value) {
-            tracing::error!(?surface_id, %value, %e, "timeline signal failed on write release");
+        if let Err(e) = produce_done.signal_host(value) {
+            tracing::error!(?surface_id, %value, %e, "produce_done signal failed on write release");
         }
     }
 }

--- a/libs/streamlib-adapter-vulkan/src/host_vtable.rs
+++ b/libs/streamlib-adapter-vulkan/src/host_vtable.rs
@@ -208,7 +208,8 @@ unsafe extern "C" fn host_register_host_surface<D: VulkanRhiDevice + 'static>(
     handle: *const c_void,
     surface_id: u64,
     texture_handle: *const c_void,
-    timeline_handle: *const c_void,
+    produce_done_handle: *const c_void,
+    consume_done_handle: *const c_void,
     initial_layout_raw: i32,
     err_buf: *mut u8,
     err_buf_cap: usize,
@@ -231,10 +232,14 @@ unsafe extern "C" fn host_register_host_surface<D: VulkanRhiDevice + 'static>(
                     return 1;
                 }
             };
-            if texture_handle.is_null() || timeline_handle.is_null() {
+            if texture_handle.is_null()
+                || produce_done_handle.is_null()
+                || consume_done_handle.is_null()
+            {
                 unsafe {
                     write_err(
-                        "register_host_surface: null texture or timeline handle",
+                        "register_host_surface: null texture, produce_done, \
+                         or consume_done handle",
                         err_buf,
                         err_buf_cap,
                         err_len,
@@ -245,7 +250,7 @@ unsafe extern "C" fn host_register_host_surface<D: VulkanRhiDevice + 'static>(
             // SAFETY: caller asserts the handles are
             // Arc::into_raw-shaped against the correct privilege
             // family for D. The host bumps the refcount and stashes
-            // a clone in the registry; the caller's Arcs remain
+            // clones in the registry; the caller's Arcs remain
             // owned by the caller.
             let texture: Arc<<D::Privilege as DevicePrivilege>::Texture> = unsafe {
                 Arc::increment_strong_count(
@@ -253,18 +258,30 @@ unsafe extern "C" fn host_register_host_surface<D: VulkanRhiDevice + 'static>(
                 );
                 Arc::from_raw(texture_handle as *const <D::Privilege as DevicePrivilege>::Texture)
             };
-            let timeline: Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore> = unsafe {
+            let produce_done: Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore> = unsafe {
                 Arc::increment_strong_count(
-                    timeline_handle as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore,
+                    produce_done_handle
+                        as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore,
                 );
                 Arc::from_raw(
-                    timeline_handle
+                    produce_done_handle
+                        as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore,
+                )
+            };
+            let consume_done: Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore> = unsafe {
+                Arc::increment_strong_count(
+                    consume_done_handle
+                        as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore,
+                );
+                Arc::from_raw(
+                    consume_done_handle
                         as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore,
                 )
             };
             let registration = crate::state::HostSurfaceRegistration {
                 texture,
-                timeline,
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout(initial_layout_raw),
             };
             match adapter.register_host_surface(surface_id, registration) {
@@ -876,6 +893,7 @@ mod tier1_null_handle_tests {
             (vtable().register_host_surface)(
                 core::ptr::null(),
                 42,
+                core::ptr::null(),
                 core::ptr::null(),
                 core::ptr::null(),
                 0,

--- a/libs/streamlib-adapter-vulkan/src/state.rs
+++ b/libs/streamlib-adapter-vulkan/src/state.rs
@@ -27,11 +27,17 @@ use streamlib_adapter_abi::{SurfaceId, SurfaceRegistration};
 pub struct HostSurfaceRegistration<P: DevicePrivilege> {
     /// Texture wrapper — host- or consumer-flavored per `P`.
     pub texture: Arc<P::Texture>,
-    /// Timeline semaphore — host- or consumer-flavored per `P`. Both
-    /// flavors implement
-    /// [`streamlib_consumer_rhi::VulkanTimelineSemaphoreLike`] so
-    /// the adapter's wait + signal calls work uniformly.
-    pub timeline: Arc<P::TimelineSemaphore>,
+    /// `produce_done` timeline — signaled exclusively by the producer
+    /// process when a write completes (CPU `signal_host` from
+    /// `end_write_access`). The consumer waits on this timeline before
+    /// reading. Single-writer-per-edge per
+    /// `docs/architecture/adapter-timeline-single-writer.md`.
+    pub produce_done: Arc<P::TimelineSemaphore>,
+    /// `consume_done` timeline — signaled exclusively by the consumer
+    /// process when a read completes (CPU `signal_host` from
+    /// `end_read_access`). The producer waits on this timeline before
+    /// re-writing.
+    pub consume_done: Arc<P::TimelineSemaphore>,
     /// Initial layout the texture is in at registration time. The first
     /// `acquire_*` will transition from here. For freshly-allocated
     /// images this is typically [`VulkanLayout::UNDEFINED`].
@@ -49,23 +55,32 @@ pub(crate) struct SurfaceState<P: DevicePrivilege> {
     #[allow(dead_code)] // kept for tracing / debug output, not read in hot paths
     pub(crate) surface_id: SurfaceId,
     pub(crate) texture: Arc<P::Texture>,
-    pub(crate) timeline: Arc<P::TimelineSemaphore>,
+    /// `produce_done` timeline — see
+    /// [`HostSurfaceRegistration::produce_done`].
+    pub(crate) produce_done: Arc<P::TimelineSemaphore>,
+    /// `consume_done` timeline — see
+    /// [`HostSurfaceRegistration::consume_done`].
+    pub(crate) consume_done: Arc<P::TimelineSemaphore>,
     pub(crate) current_layout: VulkanLayout,
     pub(crate) read_holders: u64,
     pub(crate) write_held: bool,
-    /// Last value the host *waited on* before handing access out. Used
-    /// only for telemetry; the canonical wait value is recomputed every
-    /// acquire from `current_release_value`.
+    /// Last peer-timeline value the adapter waited on before handing
+    /// access out. Telemetry only; the canonical wait value is the
+    /// peer-timeline's kernel `current_value()` taken at finalize time.
     pub(crate) last_acquire_value: u64,
-    /// The value `signal_host` was last advanced to. The next acquire
-    /// waits on this value (so any prior writer's GPU work has drained)
-    /// and the next release advances it by one.
-    pub(crate) current_release_value: u64,
+    /// Per-process monotonic signal counter. This adapter instance
+    /// only writes ONE side's timeline per acquire/release cycle
+    /// (`end_read_access` signals `consume_done`,
+    /// `end_write_access` signals `produce_done`). The counter
+    /// advances on every signal regardless of side — each timeline
+    /// sees strictly monotonic values from its respective writer code
+    /// path, which is all VUID-03258 requires.
+    pub(crate) current_signal_value: u64,
 }
 
 impl<P: DevicePrivilege> SurfaceState<P> {
-    pub(crate) fn next_release_value(&self) -> u64 {
-        self.current_release_value + 1
+    pub(crate) fn next_signal_value(&self) -> u64 {
+        self.current_signal_value + 1
     }
 }
 

--- a/libs/streamlib-adapter-vulkan/tests/common.rs
+++ b/libs/streamlib-adapter-vulkan/tests/common.rs
@@ -81,16 +81,26 @@ impl HostFixture {
             .gpu
             .acquire_render_target_dma_buf_image(width, height, TextureFormat::Bgra8Unorm)
             .expect("acquire_render_target_dma_buf_image");
-        let timeline = Arc::new(
+        // Single-writer-per-edge: each timeline has exactly one writer
+        // process. produce_done is signaled by the producer side
+        // (end_write_access); consume_done is signaled by the consumer
+        // side (end_read_access). See
+        // docs/architecture/adapter-timeline-single-writer.md.
+        let produce_done = Arc::new(
             HostVulkanTimelineSemaphore::new_exportable(self.adapter.device().device(), 0)
-                .expect("exportable timeline"),
+                .expect("exportable produce_done timeline"),
+        );
+        let consume_done = Arc::new(
+            HostVulkanTimelineSemaphore::new_exportable(self.adapter.device().device(), 0)
+                .expect("exportable consume_done timeline"),
         );
         self.adapter
             .register_host_surface(
                 surface_id,
                 HostSurfaceRegistration {
                     texture: texture.vulkan_inner().clone(),
-                    timeline: Arc::clone(&timeline),
+                    produce_done: Arc::clone(&produce_done),
+                    consume_done: Arc::clone(&consume_done),
                     initial_layout: VulkanLayout::UNDEFINED,
                 },
             )
@@ -107,7 +117,8 @@ impl HostFixture {
         RegisteredSurface {
             descriptor,
             texture,
-            timeline,
+            produce_done,
+            consume_done,
             width,
             height,
         }
@@ -117,7 +128,12 @@ impl HostFixture {
 pub struct RegisteredSurface {
     pub descriptor: StreamlibSurface,
     pub texture: Texture,
-    pub timeline: Arc<HostVulkanTimelineSemaphore>,
+    /// `produce_done` timeline — signaled by the producer side
+    /// (host's `end_write_access` or subprocess's write helper).
+    pub produce_done: Arc<HostVulkanTimelineSemaphore>,
+    /// `consume_done` timeline — signaled by the consumer side
+    /// (host's `end_read_access` or subprocess's read helper).
+    pub consume_done: Arc<HostVulkanTimelineSemaphore>,
     pub width: u32,
     pub height: u32,
 }
@@ -149,18 +165,24 @@ pub fn spawn_helper(role: &str) -> (Child, UnixStream) {
     (child_proc, parent)
 }
 
-/// Send the helper its descriptor + DMA-BUF fds + timeline sync_fd via
-/// SCM_RIGHTS. The fds passed in are dup'd by the kernel; the caller
-/// retains ownership of their copies (close after send).
+/// Send the helper its descriptor + DMA-BUF fds + dual timeline FDs
+/// (produce_done first, then consume_done) via SCM_RIGHTS. The fds
+/// passed in are dup'd by the kernel; the caller retains ownership of
+/// their copies (close after send). Single-writer-per-edge per
+/// `docs/architecture/adapter-timeline-single-writer.md`: the helper
+/// imports both timelines; whether it signals produce_done or
+/// consume_done depends on its role.
 pub fn send_helper_request(
     parent: &UnixStream,
     descriptor: &serde_json::Value,
     dma_buf_fds: &[RawFd],
-    sync_fd: RawFd,
+    produce_done_fd: RawFd,
+    consume_done_fd: RawFd,
 ) -> std::io::Result<()> {
     let body = serde_json::to_vec(descriptor).expect("serialize");
     let mut all_fds: Vec<RawFd> = dma_buf_fds.to_vec();
-    all_fds.push(sync_fd);
+    all_fds.push(produce_done_fd);
+    all_fds.push(consume_done_fd);
     // `send_message_with_fds` already prefixes with a 4-byte BE length;
     // the helper reads the prefix, then `recv_message_with_fds` for the
     // payload.

--- a/libs/streamlib-adapter-vulkan/tests/concurrent_reads_two_subprocesses.rs
+++ b/libs/streamlib-adapter-vulkan/tests/concurrent_reads_two_subprocesses.rs
@@ -2,8 +2,25 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //! Two subprocesses simultaneously hold read access on the same surface
-//! (each via its own imported VkImage + timeline). Asserts the host
-//! grants both reads concurrently and that both subprocesses progress.
+//! (each via its own imported VkImage + timeline). Exercises the
+//! emergent multi-process-concurrent-consumer pattern of the pre-lift
+//! single-timeline adapter shape.
+//!
+//! **Deferred under the single-writer-per-edge lift** per
+//! `docs/architecture/adapter-timeline-single-writer.md` — the v1
+//! model declares one producer process + one consumer process per
+//! surface, fixed at registration time. Two subprocesses concurrently
+//! holding read access on the same surface is the
+//! multi-process-concurrent-consumer pattern explicitly deferred for
+//! v1. The additive extension when it's needed is N `consume_done`
+//! timelines (one per attached consumer process), not a single
+//! shared timeline.
+//!
+//! Same-process concurrent reads (multiple threads inside one
+//! subprocess, or multiple in-process consumers in the host) remain
+//! fully supported via the existing `read_holders` last-reader-out
+//! semantics — see `conformance.rs` and `write_excludes_read.rs` for
+//! coverage that exercises them.
 
 #![cfg(target_os = "linux")]
 
@@ -13,12 +30,21 @@ mod common;
 use std::sync::Arc;
 use streamlib::sdk::engine::HostTextureExt;
 
+/// Two subprocesses concurrently reading the same surface — out of
+/// scope for v1 per the single-writer-per-edge model. Left in-tree as
+/// a `#[ignore]`d marker so the deferred capability is visible when
+/// re-reading the test suite; do not lift the `#[ignore]` without
+/// landing the N-`consume_done`-timelines extension first.
 #[test]
+#[ignore = "v1 single-writer-per-edge defers multi-process concurrent consumers — \
+            see docs/architecture/adapter-timeline-single-writer.md"]
 fn two_subprocesses_concurrently_read_same_surface() {
     let host = match common::HostFixture::try_new() {
         Some(h) => h,
         None => {
-            println!("concurrent_reads_two_subprocesses: skipping — no Vulkan");
+            tracing::info!(
+                "concurrent_reads_two_subprocesses: skipping — no Vulkan"
+            );
             return;
         }
     };
@@ -33,13 +59,16 @@ fn two_subprocesses_concurrently_read_same_surface() {
             .acquire_write(&surface.descriptor)
             .expect("warm-up write");
     }
-    assert_eq!(surface.timeline.current_value().unwrap(), 1);
+    assert_eq!(surface.produce_done.current_value().unwrap(), 1);
 
-    // Spawn two subprocesses, each waits on value 1 and signals 2.
+    // Spawn two subprocesses, each waits on produce_done and signals
+    // consume_done. Under single-writer-per-edge both subprocesses
+    // writing to the same consume_done timeline races VUID-03258 — this
+    // is exactly the pattern the v1 model defers.
     let (mut child_a, sock_a) = common::spawn_helper("wait-only");
     let (mut child_b, sock_b) = common::spawn_helper("wait-only");
 
-    // Each subprocess imports its own copy of the timeline and the
+    // Each subprocess imports its own copy of both timelines + the
     // DMA-BUF — fresh fds per spawn since SCM_RIGHTS dups by the kernel.
     for sock in [&sock_a, &sock_b] {
         let dma_buf_fd = surface
@@ -47,17 +76,23 @@ fn two_subprocesses_concurrently_read_same_surface() {
             .vulkan_inner()
             .export_dma_buf_fd()
             .expect("export DMA-BUF");
-        let sync_fd = Arc::clone(&surface.timeline)
+        let produce_done_fd = Arc::clone(&surface.produce_done)
             .export_opaque_fd()
-            .expect("export sync_fd");
+            .expect("export produce_done_fd");
+        let consume_done_fd = Arc::clone(&surface.consume_done)
+            .export_opaque_fd()
+            .expect("export consume_done_fd");
         let req = common::helper_descriptor("wait-only", &surface, 1, None);
-        common::send_helper_request(sock, &req, &[dma_buf_fd], sync_fd)
-            .expect("send helper request");
+        common::send_helper_request(
+            sock,
+            &req,
+            &[dma_buf_fd],
+            produce_done_fd,
+            consume_done_fd,
+        )
+        .expect("send helper request");
     }
 
-    // Both helpers should respond ok; the timeline signals from both
-    // are coalesced (same target value 2 — OPAQUE_FD timeline counter
-    // is monotonic so a redundant signal at value 2 is a no-op).
     let resp_a = common::recv_helper_response(&sock_a);
     let resp_b = common::recv_helper_response(&sock_b);
     assert_eq!(resp_a["ok"], true, "child A: {}", resp_a["note"]);
@@ -66,10 +101,8 @@ fn two_subprocesses_concurrently_read_same_surface() {
     assert_eq!(child_a.wait().expect("wait a").code(), Some(0));
     assert_eq!(child_b.wait().expect("wait b").code(), Some(0));
 
-    // Test that the host adapter ALSO permits two concurrent reads in
-    // process — `run_conformance` already covers this, but exercising
-    // it after the cross-process round-trip catches any state-leak that
-    // disturbed the in-process counter accounting.
+    // Same-process concurrent reads remain supported; exercise them
+    // here for parity with the deferred cross-process pattern.
     let r1 = host.ctx.acquire_read(&surface.descriptor).expect("read 1");
     let r2 = host.ctx.acquire_read(&surface.descriptor).expect("read 2");
     drop(r1);

--- a/libs/streamlib-adapter-vulkan/tests/conformance.rs
+++ b/libs/streamlib-adapter-vulkan/tests/conformance.rs
@@ -44,15 +44,25 @@ fn register_one(
         .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
         .expect("acquire_render_target_dma_buf_image");
     let texture = stream_tex.vulkan_inner().clone();
-    let timeline = Arc::new(
-        HostVulkanTimelineSemaphore::new(adapter.device().device(), 0).expect("timeline"),
+    // Single-writer-per-edge per
+    // `docs/architecture/adapter-timeline-single-writer.md`: two
+    // independent timelines, one per edge of the producer ↔ consumer
+    // pair.
+    let produce_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(adapter.device().device(), 0)
+            .expect("produce_done timeline"),
+    );
+    let consume_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(adapter.device().device(), 0)
+            .expect("consume_done timeline"),
     );
     adapter
         .register_host_surface(
             id,
             HostSurfaceRegistration {
                 texture,
-                timeline,
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout::UNDEFINED,
             },
         )
@@ -124,14 +134,20 @@ fn duplicate_registration_returns_surface_already_registered() {
         .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
         .expect("acquire_render_target_dma_buf_image");
     let texture = stream_tex.vulkan_inner().clone();
-    let timeline = Arc::new(
-        HostVulkanTimelineSemaphore::new(adapter.device().device(), 0).expect("timeline"),
+    let produce_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(adapter.device().device(), 0)
+            .expect("produce_done timeline"),
+    );
+    let consume_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(adapter.device().device(), 0)
+            .expect("consume_done timeline"),
     );
     let result = adapter.register_host_surface(
         id,
         HostSurfaceRegistration {
             texture,
-            timeline,
+            produce_done,
+            consume_done,
             initial_layout: VulkanLayout::UNDEFINED,
         },
     );

--- a/libs/streamlib-adapter-vulkan/tests/round_trip_host_writes_subprocess_reads.rs
+++ b/libs/streamlib-adapter-vulkan/tests/round_trip_host_writes_subprocess_reads.rs
@@ -35,7 +35,7 @@ fn host_writes_subprocess_reads_round_trip() {
     let (mut child, parent_sock) = common::spawn_helper("read");
 
     // Host write scope: clear the image to a known color via the
-    // adapter, release. Adapter advances timeline value 0 → 1.
+    // adapter, release. Adapter advances produce_done 0 → 1.
     {
         let _w = host
             .ctx
@@ -52,22 +52,33 @@ fn host_writes_subprocess_reads_round_trip() {
             cmd_color,
         );
     }
-    assert_eq!(surface.timeline.current_value().unwrap(), 1);
+    assert_eq!(surface.produce_done.current_value().unwrap(), 1);
+    assert_eq!(surface.consume_done.current_value().unwrap(), 0);
 
-    // Export the host-allocated surface for the subprocess. Timeline
-    // sync-fd + DMA-BUF fd both transferred via SCM_RIGHTS.
+    // Export the host-allocated surface for the subprocess. Both
+    // single-writer timelines (`produce_done` + `consume_done`) plus
+    // the DMA-BUF fd ride via SCM_RIGHTS, in that order.
     let dma_buf_fd = surface
         .texture
         .vulkan_inner()
         .export_dma_buf_fd()
         .expect("export DMA-BUF");
-    let sync_fd = Arc::clone(&surface.timeline)
+    let produce_done_fd = Arc::clone(&surface.produce_done)
         .export_opaque_fd()
-        .expect("export sync_fd");
+        .expect("export produce_done_fd");
+    let consume_done_fd = Arc::clone(&surface.consume_done)
+        .export_opaque_fd()
+        .expect("export consume_done_fd");
 
     let req = common::helper_descriptor("read", &surface, 1, None);
-    common::send_helper_request(&parent_sock, &req, &[dma_buf_fd], sync_fd)
-        .expect("send helper request");
+    common::send_helper_request(
+        &parent_sock,
+        &req,
+        &[dma_buf_fd],
+        produce_done_fd,
+        consume_done_fd,
+    )
+    .expect("send helper request");
 
     let resp = common::recv_helper_response(&parent_sock);
     assert_eq!(resp["ok"], true, "helper failed: {}", resp["note"]);
@@ -96,7 +107,8 @@ fn host_writes_subprocess_reads_round_trip() {
         "subprocess read unexpected pixel: {mismatch:?}"
     );
 
-    assert!(surface.timeline.current_value().unwrap() >= 2);
+    // The subprocess (consumer) signaled consume_done after reading.
+    assert!(surface.consume_done.current_value().unwrap() >= 1);
 }
 
 fn host_clear_image(

--- a/libs/streamlib-adapter-vulkan/tests/round_trip_subprocess_writes_host_reads.rs
+++ b/libs/streamlib-adapter-vulkan/tests/round_trip_subprocess_writes_host_reads.rs
@@ -36,7 +36,7 @@ fn subprocess_writes_host_reads_round_trip() {
             .acquire_write(&surface.descriptor)
             .expect("host warm-up acquire_write");
     }
-    assert_eq!(surface.timeline.current_value().unwrap(), 1);
+    assert_eq!(surface.produce_done.current_value().unwrap(), 1);
 
     let (mut child, parent_sock) = common::spawn_helper("write");
     let dma_buf_fd = surface
@@ -44,14 +44,23 @@ fn subprocess_writes_host_reads_round_trip() {
         .vulkan_inner()
         .export_dma_buf_fd()
         .expect("export DMA-BUF");
-    let sync_fd = Arc::clone(&surface.timeline)
+    let produce_done_fd = Arc::clone(&surface.produce_done)
         .export_opaque_fd()
-        .expect("export sync_fd");
+        .expect("export produce_done_fd");
+    let consume_done_fd = Arc::clone(&surface.consume_done)
+        .export_opaque_fd()
+        .expect("export consume_done_fd");
 
     let clear_color = [0.9_f32, 0.1, 0.4, 1.0];
     let req = common::helper_descriptor("write", &surface, 1, Some(clear_color));
-    common::send_helper_request(&parent_sock, &req, &[dma_buf_fd], sync_fd)
-        .expect("send helper request");
+    common::send_helper_request(
+        &parent_sock,
+        &req,
+        &[dma_buf_fd],
+        produce_done_fd,
+        consume_done_fd,
+    )
+    .expect("send helper request");
 
     let resp = common::recv_helper_response(&parent_sock);
     assert_eq!(resp["ok"], true, "helper failed: {}", resp["note"]);

--- a/libs/streamlib-adapter-vulkan/tests/subprocess_crash_mid_write.rs
+++ b/libs/streamlib-adapter-vulkan/tests/subprocess_crash_mid_write.rs
@@ -67,16 +67,25 @@ fn subprocess_crash_mid_write_does_not_break_host_adapter() {
         .vulkan_inner()
         .export_dma_buf_fd()
         .expect("export DMA-BUF");
-    let sync_fd = Arc::clone(&surface.timeline)
+    let produce_done_fd = Arc::clone(&surface.produce_done)
         .export_opaque_fd()
-        .expect("export sync_fd");
+        .expect("export produce_done_fd");
+    let consume_done_fd = Arc::clone(&surface.consume_done)
+        .export_opaque_fd()
+        .expect("export consume_done_fd");
     let req = common::helper_descriptor("crash-mid-write", &surface, 1, None);
 
     // Pre-send the request before the harness spawns; libc::sendmsg on
     // a socketpair is non-blocking under default buffer sizes for this
     // payload size.
-    common::send_helper_request(&parent_sock, &req, &[dma_buf_fd], sync_fd)
-        .expect("send helper request");
+    common::send_helper_request(
+        &parent_sock,
+        &req,
+        &[dma_buf_fd],
+        produce_done_fd,
+        consume_done_fd,
+    )
+    .expect("send helper request");
 
     let observed_disconnect = Arc::new(AtomicBool::new(false));
     let parent_fd = parent_sock.as_raw_fd();
@@ -128,19 +137,19 @@ fn subprocess_crash_mid_write_does_not_break_host_adapter() {
         outcome.cleanup_latency
     );
 
-    // The host's adapter should still function. The previous timeline
-    // value is whatever the host warmed up to (1); a fresh write
-    // advances it by one.
-    let before = surface.timeline.current_value().unwrap();
+    // The host's adapter should still function. The previous
+    // produce_done value is whatever the host warmed up to (1); a
+    // fresh write advances it by one.
+    let before = surface.produce_done.current_value().unwrap();
     {
         let _w = host
             .ctx
             .acquire_write(&surface.descriptor)
             .expect("post-crash acquire_write");
     }
-    let after = surface.timeline.current_value().unwrap();
+    let after = surface.produce_done.current_value().unwrap();
     assert!(
         after > before,
-        "timeline should advance after crash; before={before} after={after}"
+        "produce_done should advance after crash; before={before} after={after}"
     );
 }

--- a/libs/streamlib-adapter-vulkan/tests/sync_correctness.rs
+++ b/libs/streamlib-adapter-vulkan/tests/sync_correctness.rs
@@ -2,9 +2,15 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //! `streamlib_adapter_vulkan::tests::sync_correctness` — confirms that
-//! the adapter advances the timeline semaphore on guard drop and that
-//! a downstream consumer of the same timeline observes the post-release
-//! value.
+//! the adapter advances the appropriate timeline semaphore on guard
+//! drop and that downstream observers see the post-release value.
+//!
+//! Single-writer-per-edge per
+//! `docs/architecture/adapter-timeline-single-writer.md`: dropping a
+//! write guard signals `produce_done`; dropping the last read guard
+//! signals `consume_done`. Each timeline carries the shared
+//! `current_signal_value` counter, so signals across the two timelines
+//! advance the underlying counter in interleaving order.
 
 #![cfg(target_os = "linux")]
 
@@ -50,16 +56,21 @@ fn timeline_counter_advances_on_release_and_is_observable_by_next_acquire() {
         .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
         .expect("acquire_render_target_dma_buf_image");
     let texture = stream_tex.vulkan_inner().clone();
-    let timeline = Arc::new(
+    let produce_done = Arc::new(
         HostVulkanTimelineSemaphore::new(adapter.device().device(), 0)
-            .expect("create timeline"),
+            .expect("create produce_done"),
+    );
+    let consume_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(adapter.device().device(), 0)
+            .expect("create consume_done"),
     );
     adapter
         .register_host_surface(
             surface_id,
             HostSurfaceRegistration {
                 texture,
-                timeline: Arc::clone(&timeline),
+                produce_done: Arc::clone(&produce_done),
+                consume_done: Arc::clone(&consume_done),
                 initial_layout: VulkanLayout::UNDEFINED,
             },
         )
@@ -75,43 +86,71 @@ fn timeline_counter_advances_on_release_and_is_observable_by_next_acquire() {
         SurfaceSyncState::default(),
     );
 
-    // Initial counter is 0 and acquire/wait succeeds.
-    assert_eq!(timeline.current_value().unwrap(), 0);
+    // Initial counters are 0 and acquire/wait succeeds.
+    assert_eq!(produce_done.current_value().unwrap(), 0);
+    assert_eq!(consume_done.current_value().unwrap(), 0);
 
     {
         let _w = ctx.acquire_write(&descriptor).expect("acquire_write 1");
         assert_eq!(
-            timeline.current_value().unwrap(),
+            produce_done.current_value().unwrap(),
             0,
-            "no signal while guard is alive"
+            "no produce_done signal while write guard is alive"
         );
     }
-    assert_eq!(timeline.current_value().unwrap(), 1, "drop signals once");
+    // Write drop signals produce_done with the shared
+    // current_signal_value counter (now 1). consume_done is untouched.
+    assert_eq!(
+        produce_done.current_value().unwrap(),
+        1,
+        "write drop signals produce_done"
+    );
+    assert_eq!(
+        consume_done.current_value().unwrap(),
+        0,
+        "write drop does not touch consume_done"
+    );
 
     {
         let _r = ctx.acquire_read(&descriptor).expect("acquire_read after w1");
     }
-    assert_eq!(timeline.current_value().unwrap(), 2);
+    // Read drop signals consume_done with current_signal_value=2;
+    // produce_done is untouched.
+    assert_eq!(
+        consume_done.current_value().unwrap(),
+        2,
+        "read drop signals consume_done"
+    );
+    assert_eq!(
+        produce_done.current_value().unwrap(),
+        1,
+        "read drop does not touch produce_done"
+    );
 
-    // Two parallel readers share a release boundary — the counter
+    // Two parallel readers share a release boundary — consume_done
     // advances exactly once on the LAST reader's drop.
     let r1 = ctx.acquire_read(&descriptor).expect("acquire_read r1");
     let r2 = ctx.acquire_read(&descriptor).expect("acquire_read r2");
     assert_eq!(
-        timeline.current_value().unwrap(),
+        consume_done.current_value().unwrap(),
         2,
-        "no signal mid-concurrent-read"
+        "no consume_done signal mid-concurrent-read"
     );
     drop(r1);
     assert_eq!(
-        timeline.current_value().unwrap(),
+        consume_done.current_value().unwrap(),
         2,
         "first reader drop is silent"
     );
     drop(r2);
     assert_eq!(
-        timeline.current_value().unwrap(),
+        consume_done.current_value().unwrap(),
         3,
-        "last reader drop signals once"
+        "last reader drop signals consume_done once"
+    );
+    assert_eq!(
+        produce_done.current_value().unwrap(),
+        1,
+        "no read-path signal ever touched produce_done"
     );
 }

--- a/libs/streamlib-adapter-vulkan/tests/write_excludes_read.rs
+++ b/libs/streamlib-adapter-vulkan/tests/write_excludes_read.rs
@@ -54,15 +54,23 @@ fn live_write_guard_blocks_acquire_read_until_dropped() {
         .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
         .expect("acquire_render_target_dma_buf_image");
     let texture = stream_tex.vulkan_inner().clone();
-    let timeline = Arc::new(
-        HostVulkanTimelineSemaphore::new(adapter.device().device(), 0).expect("timeline"),
+    // Single-writer-per-edge per
+    // `docs/architecture/adapter-timeline-single-writer.md`.
+    let produce_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(adapter.device().device(), 0)
+            .expect("produce_done timeline"),
+    );
+    let consume_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(adapter.device().device(), 0)
+            .expect("consume_done timeline"),
     );
     adapter
         .register_host_surface(
             surface_id,
             HostSurfaceRegistration {
                 texture,
-                timeline,
+                produce_done,
+                consume_done,
                 initial_layout: VulkanLayout::UNDEFINED,
             },
         )

--- a/libs/streamlib-consumer-rhi/src/consumer_vulkan_sync.rs
+++ b/libs/streamlib-consumer-rhi/src/consumer_vulkan_sync.rs
@@ -93,47 +93,21 @@ impl ConsumerVulkanTimelineSemaphore {
             })
     }
 
-    /// Host-side signal: advance the counter to **at least** `value`
-    /// from the CPU.
+    /// Host-side signal: advance the counter to `value` from the CPU.
     ///
-    /// Self-correcting against cross-process timeline advancement. If
-    /// the shared `vk::Semaphore` has been advanced past `value` by
-    /// another writer (e.g. a host-process producer signaling via
-    /// `VkSubmitInfo2::pSignalSemaphoreInfos`), this call signals at
-    /// `current_value() + 1` instead of `value` so the timeline
-    /// always advances and the spec's strictly-greater rule is met
-    /// (`VUID-VkSemaphoreSignalInfo-value-03258`). The semantic
-    /// contract — "the timeline is at least `value` after this
-    /// returns" — is preserved whether we signal at the requested
-    /// value or at a higher clamped value.
-    ///
-    /// Emits a tracing warning when clamping engages so adapter-level
-    /// state desync (per-process `state.current_release_value`
-    /// lagging the shared vk timeline) is observable. The right
-    /// long-term fix is single-writer timelines per producer/consumer
-    /// edge (Unreal / Granite shape); this clamp is the consumer-rhi
-    /// safety net.
+    /// Single-writer-per-edge per
+    /// `docs/architecture/adapter-timeline-single-writer.md`: only
+    /// one process ever signals a given timeline, so `value` is
+    /// strictly greater than the current value by construction and
+    /// VUID-VkSemaphoreSignalInfo-value-03258 holds without runtime
+    /// clamping.
     pub fn signal_host(&self, value: u64) -> Result<()> {
-        let current = self.current_value().unwrap_or(0);
-        let actual_value = std::cmp::max(value, current.saturating_add(1));
-        if actual_value != value {
-            tracing::warn!(
-                target: "consumer_rhi::timeline",
-                requested_value = value,
-                current_value = current,
-                actual_value,
-                "signal_host: clamping to actual_value > requested (cross-process \
-                 advancement of shared timeline OR adapter-state lag). Timeline is \
-                 advanced; caller's per-process `current_release_value` may diverge \
-                 from vk reality until the next clamp."
-            );
-        }
         let info = vk::SemaphoreSignalInfo::builder()
             .semaphore(self.semaphore)
-            .value(actual_value)
+            .value(value)
             .build();
         unsafe { self.vulkan_device.device().signal_semaphore(&info) }.map_err(|e| {
-            ConsumerRhiError::Gpu(format!("signal_semaphore(value={actual_value}): {e}"))
+            ConsumerRhiError::Gpu(format!("signal_semaphore(value={value}): {e}"))
         })
     }
 

--- a/libs/streamlib-consumer-rhi/src/consumer_vulkan_sync.rs
+++ b/libs/streamlib-consumer-rhi/src/consumer_vulkan_sync.rs
@@ -170,6 +170,9 @@ impl VulkanTimelineSemaphoreLike for ConsumerVulkanTimelineSemaphore {
     fn signal_host(&self, value: u64) -> Result<()> {
         ConsumerVulkanTimelineSemaphore::signal_host(self, value)
     }
+    fn current_value(&self) -> Result<u64> {
+        ConsumerVulkanTimelineSemaphore::current_value(self)
+    }
     fn semaphore(&self) -> vk::Semaphore {
         ConsumerVulkanTimelineSemaphore::semaphore(self)
     }

--- a/libs/streamlib-consumer-rhi/src/device_capability.rs
+++ b/libs/streamlib-consumer-rhi/src/device_capability.rs
@@ -94,6 +94,15 @@ pub trait VulkanTimelineSemaphoreLike {
     fn wait(&self, value: u64, timeout_ns: u64) -> Result<()>;
     /// Host-side signal: advance the counter to `value`.
     fn signal_host(&self, value: u64) -> Result<()>;
+    /// Read the timeline's current kernel-side counter via
+    /// `vkGetSemaphoreCounterValue`. Adapters under the
+    /// single-writer-per-edge model (`docs/architecture/adapter-timeline-single-writer.md`)
+    /// query this to learn the peer process's last-signaled value
+    /// without IPC — the consumer reads `produce_done.current_value()`
+    /// to know how much producer work is visible, the producer reads
+    /// `consume_done.current_value()` to know how much consumer work
+    /// has retired.
+    fn current_value(&self) -> Result<u64>;
     /// Raw `vk::Semaphore` handle for inclusion in
     /// `VkSubmitInfo2::pSignalSemaphoreInfos` /
     /// `pWaitSemaphoreInfos`. Surfaces that need to schedule

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -4827,6 +4827,11 @@ mod cuda {
         // references). Drop order: this struct's fields drop in
         // declaration order, so put CUDA imports first.
         ext_mem: sys::cudaExternalMemory_t,
+        /// CUDA-side import of `produce_done` — the timeline the
+        /// producer signals so cuda can wait on it via
+        /// `cudaWaitExternalSemaphoresAsync_v2`. CUDA does NOT import
+        /// `consume_done` (the consumer signals via host CPU
+        /// `signal_host` through the adapter's `end_read_access`).
         ext_sem: sys::cudaExternalSemaphore_t,
         stream: sys::cudaStream_t,
         device_ptr: u64,
@@ -4839,7 +4844,10 @@ mod cuda {
         // is belt-and-suspenders.
         #[allow(dead_code)] // Arc held for lifetime; never read after register.
         pixel_buffer: Arc<ConsumerVulkanBuffer>,
-        timeline: Arc<ConsumerVulkanTimelineSemaphore>,
+        #[allow(dead_code)] // Arc held for lifetime; never read after register.
+        produce_done: Arc<ConsumerVulkanTimelineSemaphore>,
+        #[allow(dead_code)] // Arc held for lifetime; never read after register.
+        consume_done: Arc<ConsumerVulkanTimelineSemaphore>,
     }
 
     // SAFETY: `cudaExternalMemory_t`, `cudaExternalSemaphore_t`, and
@@ -5039,12 +5047,15 @@ mod cuda {
             }
         };
 
-        // ── Step 2: import the timeline semaphore into Vulkan ───────────
+        // ── Step 2: import the `produce_done` timeline into Vulkan ──────
+        // Single-writer-per-edge
+        // (`docs/architecture/adapter-timeline-single-writer.md`): the
+        // producer (host) signals this timeline, cuda waits on it.
         let raw_sync_fd: RawFd = match gpu.produce_done_fd.take() {
             Some(fd) => fd,
             None => {
                 tracing::error!(
-                    "sldn_cuda_register_surface: surface '{}' has no sync_fd — \
+                    "sldn_cuda_register_surface: surface '{}' has no produce_done_fd — \
                      the host must register it with an exportable timeline semaphore \
                      so cross-API sync (Vulkan ↔ CUDA) is well-defined",
                     surface_id
@@ -5056,7 +5067,7 @@ mod cuda {
         let vk_sync_fd = unsafe { libc::dup(raw_sync_fd) };
         if vk_sync_fd < 0 {
             tracing::error!(
-                "sldn_cuda_register_surface: dup sync_fd failed: {}",
+                "sldn_cuda_register_surface: dup produce_done_fd failed: {}",
                 std::io::Error::last_os_error()
             );
             // Restore the original fd onto the handle so its Drop closes it.
@@ -5070,11 +5081,55 @@ mod cuda {
             Ok(s) => Arc::new(s),
             Err(e) => {
                 tracing::error!(
-                    "sldn_cuda_register_surface: timeline from_imported_opaque_fd: {}",
+                    "sldn_cuda_register_surface: produce_done from_imported_opaque_fd: {}",
                     e
                 );
                 unsafe { libc::close(vk_sync_fd) };
                 gpu.produce_done_fd = Some(raw_sync_fd);
+                return SLDN_CUDA_ERR;
+            }
+        };
+
+        // ── Step 2b: import the `consume_done` timeline into Vulkan ─────
+        // The consumer signals this timeline from the adapter's
+        // `end_read_access` (host CPU `signal_host`). CUDA does not
+        // import this side — it doesn't signal anything.
+        let raw_consume_fd: RawFd = match gpu.consume_done_fd.take() {
+            Some(fd) => fd,
+            None => {
+                tracing::error!(
+                    "sldn_cuda_register_surface: surface '{}' has no consume_done_fd — \
+                     the host must register both produce_done and consume_done timeline \
+                     fds per the single-writer-per-edge contract",
+                    surface_id
+                );
+                gpu.produce_done_fd = Some(raw_sync_fd);
+                return SLDN_CUDA_ERR;
+            }
+        };
+        let vk_consume_fd = unsafe { libc::dup(raw_consume_fd) };
+        if vk_consume_fd < 0 {
+            tracing::error!(
+                "sldn_cuda_register_surface: dup consume_done_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            gpu.produce_done_fd = Some(raw_sync_fd);
+            gpu.consume_done_fd = Some(raw_consume_fd);
+            return SLDN_CUDA_ERR;
+        }
+        let consume_done = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+            &rt.device,
+            vk_consume_fd,
+        ) {
+            Ok(s) => Arc::new(s),
+            Err(e) => {
+                tracing::error!(
+                    "sldn_cuda_register_surface: consume_done from_imported_opaque_fd: {}",
+                    e
+                );
+                unsafe { libc::close(vk_consume_fd) };
+                gpu.produce_done_fd = Some(raw_sync_fd);
+                gpu.consume_done_fd = Some(raw_consume_fd);
                 return SLDN_CUDA_ERR;
             }
         };
@@ -5088,9 +5143,11 @@ mod cuda {
                 std::io::Error::last_os_error()
             );
             // Vulkan-side imports drop here via Arc — they own their own
-            // dups already. Restore sync_fd onto the handle so its Drop
-            // closes it (Vulkan timeline import owns its dup independently).
+            // dups already. Restore both timeline fds onto the handle so
+            // its Drop closes them (Vulkan timeline imports own their
+            // dups independently).
             gpu.produce_done_fd = Some(raw_sync_fd);
+            gpu.consume_done_fd = Some(raw_consume_fd);
             return SLDN_CUDA_ERR;
         }
         // SAFETY: `cudaImportExternalMemory` per CUDA docs:
@@ -5107,6 +5164,7 @@ mod cuda {
                     );
                     libc::close(cuda_mem_fd);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
@@ -5126,6 +5184,7 @@ mod cuda {
                     );
                     let _ = external_memory::destroy_external_memory(ext_mem);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
@@ -5149,6 +5208,7 @@ mod cuda {
                     );
                     let _ = external_memory::destroy_external_memory(ext_mem);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
@@ -5165,11 +5225,16 @@ mod cuda {
                 );
                 let _ = unsafe { external_memory::destroy_external_memory(ext_mem) };
                 gpu.produce_done_fd = Some(raw_sync_fd);
+                gpu.consume_done_fd = Some(raw_consume_fd);
                 return SLDN_CUDA_ERR;
             }
         };
 
-        // ── Step 5: import the timeline semaphore into CUDA ─────────────
+        // ── Step 5: import the `produce_done` timeline semaphore into CUDA ─
+        // CUDA only imports produce_done — it waits on it via
+        // `cudaWaitExternalSemaphoresAsync_v2`. consume_done is held
+        // Vulkan-side only; the adapter's `end_read_access` signals it
+        // via host CPU `signal_host`.
         let cuda_sync_fd = unsafe { libc::dup(raw_sync_fd) };
         if cuda_sync_fd < 0 {
             tracing::error!(
@@ -5178,6 +5243,7 @@ mod cuda {
             );
             let _ = unsafe { external_memory::destroy_external_memory(ext_mem) };
             gpu.produce_done_fd = Some(raw_sync_fd);
+            gpu.consume_done_fd = Some(raw_consume_fd);
             return SLDN_CUDA_ERR;
         }
         // Same descriptor-construction story as the carve-out test:
@@ -5210,6 +5276,7 @@ mod cuda {
                     libc::close(cuda_sync_fd);
                     let _ = external_memory::destroy_external_memory(ext_mem);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
@@ -5228,6 +5295,7 @@ mod cuda {
                     let _ = sys::cudaDestroyExternalSemaphore(ext_sem).result();
                     let _ = external_memory::destroy_external_memory(ext_mem);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
@@ -5243,7 +5311,8 @@ mod cuda {
         // pass `UNDEFINED`.
         let registration = HostSurfaceRegistration {
             pixel_buffer: Arc::clone(&pixel_buffer),
-            timeline: Arc::clone(&timeline),
+            produce_done: Arc::clone(&timeline),
+            consume_done: Arc::clone(&consume_done),
             initial_layout: VulkanLayout::UNDEFINED,
         };
         if let Err(e) = rt.adapter.register_host_surface(surface_id, registration) {
@@ -5258,15 +5327,19 @@ mod cuda {
                 let _ = external_memory::destroy_external_memory(ext_mem);
             };
             gpu.produce_done_fd = Some(raw_sync_fd);
+            gpu.consume_done_fd = Some(raw_consume_fd);
             return SLDN_CUDA_ERR;
         }
 
         // The original `raw_sync_fd` is owned by the SurfaceHandle's drop
         // path. We've already dup'd it twice (Vulkan + CUDA timeline), so
-        // returning it to the handle's `sync_fd` slot is the canonical
-        // ownership recovery — same pattern as cpu-readback's
-        // register_surface error paths.
+        // returning it to the handle's `produce_done_fd` slot is the
+        // canonical ownership recovery — same pattern as cpu-readback's
+        // register_surface error paths. `raw_consume_fd` is owned by the
+        // SurfaceHandle the same way after the Vulkan-side
+        // consume_done dup; restore it too.
         gpu.produce_done_fd = Some(raw_sync_fd);
+        gpu.consume_done_fd = Some(raw_consume_fd);
 
         let entry = Arc::new(RegisteredCudaSurface {
             ext_mem,
@@ -5277,7 +5350,8 @@ mod cuda {
             device_type,
             cuda_device_ordinal: rt.cuda_device_ordinal,
             pixel_buffer,
-            timeline,
+            produce_done: timeline,
+            consume_done,
         });
         rt.registered
             .lock()
@@ -5348,8 +5422,12 @@ mod cuda {
     /// the timeline's current Vulkan-observed value, then synchronizes.
     /// Returns `Ok(())` on success.
     fn cuda_sync_after_acquire(entry: &RegisteredCudaSurface) -> Result<(), String> {
+        // CUDA waits on `produce_done` — the timeline the host
+        // producer signals. The kernel counter snapshot is the
+        // peer-timeline source of truth per
+        // `docs/architecture/adapter-timeline-single-writer.md`.
         let wait_value = entry
-            .timeline
+            .produce_done
             .current_value()
             .map_err(|e| format!("get_semaphore_counter_value: {e}"))?;
 
@@ -5779,7 +5857,10 @@ mod cuda {
         // Vulkan-side imports — held to outlive the CUDA imports above.
         #[allow(dead_code)] // Arc held for lifetime; never read after register.
         texture: Arc<ConsumerVulkanTexture>,
-        timeline: Arc<ConsumerVulkanTimelineSemaphore>,
+        #[allow(dead_code)] // Arc held for lifetime; never read after register.
+        produce_done: Arc<ConsumerVulkanTimelineSemaphore>,
+        #[allow(dead_code)] // Arc held for lifetime; never read after register.
+        consume_done: Arc<ConsumerVulkanTimelineSemaphore>,
     }
 
     // SAFETY: same rationale as [`RegisteredCudaSurface`] — CUDA Runtime
@@ -5942,12 +6023,14 @@ mod cuda {
             }
         };
 
-        // ── Step 2: import the timeline semaphore into Vulkan ───────────
+        // ── Step 2: import the `produce_done` timeline into Vulkan ──────
+        // Single-writer-per-edge per
+        // `docs/architecture/adapter-timeline-single-writer.md`.
         let raw_sync_fd: RawFd = match gpu.produce_done_fd.take() {
             Some(fd) => fd,
             None => {
                 tracing::error!(
-                    "sldn_cuda_register_image_surface: surface '{}' has no sync_fd — \
+                    "sldn_cuda_register_image_surface: surface '{}' has no produce_done_fd — \
                      the host must register an exportable timeline semaphore so \
                      cross-API sync (Vulkan ↔ CUDA) is well-defined",
                     surface_id
@@ -5958,7 +6041,7 @@ mod cuda {
         let vk_sync_fd = unsafe { libc::dup(raw_sync_fd) };
         if vk_sync_fd < 0 {
             tracing::error!(
-                "sldn_cuda_register_image_surface: dup sync_fd failed: {}",
+                "sldn_cuda_register_image_surface: dup produce_done_fd failed: {}",
                 std::io::Error::last_os_error()
             );
             gpu.produce_done_fd = Some(raw_sync_fd);
@@ -5971,11 +6054,50 @@ mod cuda {
             Ok(s) => Arc::new(s),
             Err(e) => {
                 tracing::error!(
-                    "sldn_cuda_register_image_surface: timeline from_imported_opaque_fd: {}",
+                    "sldn_cuda_register_image_surface: produce_done from_imported_opaque_fd: {}",
                     e
                 );
                 unsafe { libc::close(vk_sync_fd) };
                 gpu.produce_done_fd = Some(raw_sync_fd);
+                return SLDN_CUDA_ERR;
+            }
+        };
+
+        // ── Step 2b: import the `consume_done` timeline into Vulkan ─────
+        let raw_consume_fd: RawFd = match gpu.consume_done_fd.take() {
+            Some(fd) => fd,
+            None => {
+                tracing::error!(
+                    "sldn_cuda_register_image_surface: surface '{}' has no consume_done_fd",
+                    surface_id
+                );
+                gpu.produce_done_fd = Some(raw_sync_fd);
+                return SLDN_CUDA_ERR;
+            }
+        };
+        let vk_consume_fd = unsafe { libc::dup(raw_consume_fd) };
+        if vk_consume_fd < 0 {
+            tracing::error!(
+                "sldn_cuda_register_image_surface: dup consume_done_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            gpu.produce_done_fd = Some(raw_sync_fd);
+            gpu.consume_done_fd = Some(raw_consume_fd);
+            return SLDN_CUDA_ERR;
+        }
+        let consume_done = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+            &rt.device,
+            vk_consume_fd,
+        ) {
+            Ok(s) => Arc::new(s),
+            Err(e) => {
+                tracing::error!(
+                    "sldn_cuda_register_image_surface: consume_done from_imported_opaque_fd: {}",
+                    e
+                );
+                unsafe { libc::close(vk_consume_fd) };
+                gpu.produce_done_fd = Some(raw_sync_fd);
+                gpu.consume_done_fd = Some(raw_consume_fd);
                 return SLDN_CUDA_ERR;
             }
         };
@@ -5988,6 +6110,7 @@ mod cuda {
                 std::io::Error::last_os_error()
             );
             gpu.produce_done_fd = Some(raw_sync_fd);
+            gpu.consume_done_fd = Some(raw_consume_fd);
             return SLDN_CUDA_ERR;
         }
         // SAFETY: see notes on the buffer path's import_external_memory_opaque_fd
@@ -6002,6 +6125,7 @@ mod cuda {
                     );
                     libc::close(cuda_mem_fd);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
@@ -6045,12 +6169,16 @@ mod cuda {
                     );
                     let _ = external_memory::destroy_external_memory(ext_mem);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
         };
 
-        // ── Step 5: import the timeline semaphore into CUDA ─────────────
+        // ── Step 5: import the `produce_done` timeline semaphore into CUDA ─
+        // CUDA only imports produce_done (waits via
+        // `cudaWaitExternalSemaphoresAsync_v2`); consume_done is held
+        // Vulkan-side and signaled by the adapter's `end_read_access`.
         let cuda_sync_fd = unsafe { libc::dup(raw_sync_fd) };
         if cuda_sync_fd < 0 {
             tracing::error!(
@@ -6062,6 +6190,7 @@ mod cuda {
                 let _ = external_memory::destroy_external_memory(ext_mem);
             };
             gpu.produce_done_fd = Some(raw_sync_fd);
+            gpu.consume_done_fd = Some(raw_consume_fd);
             return SLDN_CUDA_ERR;
         }
         let mut sem_desc = MaybeUninit::<sys::cudaExternalSemaphoreHandleDesc>::zeroed();
@@ -6089,6 +6218,7 @@ mod cuda {
                     let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
                     let _ = external_memory::destroy_external_memory(ext_mem);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
@@ -6108,6 +6238,7 @@ mod cuda {
                     let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
                     let _ = external_memory::destroy_external_memory(ext_mem);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
@@ -6116,7 +6247,8 @@ mod cuda {
         // ── Step 7: hand the registration to the Rust adapter ──────────
         let registration = HostImageSurfaceRegistration {
             texture: Arc::clone(&texture),
-            timeline: Arc::clone(&timeline),
+            produce_done: Arc::clone(&timeline),
+            consume_done: Arc::clone(&consume_done),
             initial_layout: VulkanLayout::UNDEFINED,
         };
         if let Err(e) = rt
@@ -6136,10 +6268,12 @@ mod cuda {
                 let _ = external_memory::destroy_external_memory(ext_mem);
             };
             gpu.produce_done_fd = Some(raw_sync_fd);
+            gpu.consume_done_fd = Some(raw_consume_fd);
             return SLDN_CUDA_ERR;
         }
 
         gpu.produce_done_fd = Some(raw_sync_fd);
+        gpu.consume_done_fd = Some(raw_consume_fd);
 
         let entry = Arc::new(RegisteredCudaImageSurface {
             ext_mem,
@@ -6152,7 +6286,8 @@ mod cuda {
             height: gpu.height,
             format: texture_format,
             texture,
-            timeline,
+            produce_done: timeline,
+            consume_done,
         });
         rt.registered_images
             .lock()
@@ -6300,8 +6435,10 @@ mod cuda {
     }
 
     fn cuda_sync_after_image_acquire(entry: &RegisteredCudaImageSurface) -> Result<(), String> {
+        // Wait on `produce_done` (the producer's edge) per single-writer-
+        // per-edge — same shape as `cuda_sync_after_acquire`.
         let wait_value = entry
-            .timeline
+            .produce_done
             .current_value()
             .map_err(|e| format!("get_semaphore_counter_value: {e}"))?;
 

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -1272,15 +1272,25 @@ mod gpu_surface {
         /// per plane, keyed by plane index; single-plane surfaces carry a
         /// one-element vec. Mirrors the Python-native twin.
         pub fds: Vec<RawFd>,
-        /// Optional OPAQUE_FD timeline-semaphore handle the host attached
-        /// when registering the surface (#531). Routed into the Vulkan
-        /// adapter's `ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd` so
-        /// the subprocess reuses the host adapter's timeline-wait + signal
-        /// path. `None` for surfaces without explicit Vulkan sync (OpenGL
-        /// adapter, CPU-readback, legacy DMA-BUF consumer flows). The fd is
-        /// closed when the handle is dropped, unless the import has taken
-        /// ownership.
-        pub sync_fd: Option<RawFd>,
+        /// Optional OPAQUE_FD `produce_done` timeline-semaphore handle the
+        /// host attached when registering the surface. Single-writer-per-
+        /// edge: the producer process signals this timeline, the consumer
+        /// waits before reading. The cdylib's `sldn_*_register_surface`
+        /// entry points import this FD via
+        /// `ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd` so
+        /// the subprocess reuses the host adapter's timeline-wait path.
+        /// `None` for surfaces without explicit Vulkan sync. The fd is
+        /// closed when the handle is dropped unless the import has taken
+        /// ownership (Vulkan import takes ownership on success). See
+        /// `docs/architecture/adapter-timeline-single-writer.md`.
+        pub produce_done_fd: Option<RawFd>,
+        /// Optional OPAQUE_FD `consume_done` timeline-semaphore handle.
+        /// Single-writer-per-edge: the consumer process signals this
+        /// timeline from its `end_read_access` path so the producer can
+        /// wait before re-writing. Same lifetime rules as
+        /// `produce_done_fd`. `None` until each per-adapter
+        /// `sldn_*_register_surface` migration claims it.
+        pub consume_done_fd: Option<RawFd>,
         pub plane_sizes: Vec<u64>,
         pub plane_offsets: Vec<u64>,
         /// Per-plane row pitch in bytes (source-of-truth from the host's
@@ -1360,11 +1370,18 @@ mod gpu_surface {
                     unsafe { libc::close(*fd) };
                 }
             }
-            // Close the sync FD if the Vulkan adapter import didn't take
-            // ownership. The adapter's `register_surface` takes the fd by
-            // value via `take_sync_fd` so a successful import zeros out
-            // this slot before drop runs.
-            if let Some(fd) = self.sync_fd {
+            // Close both timeline FDs if the per-adapter
+            // `sldn_*_register_surface` paths didn't take ownership. The
+            // adapter's register entry points `.take()` whichever slots
+            // they consume; a successful import zeroes the slot before
+            // drop runs. See
+            // `docs/architecture/adapter-timeline-single-writer.md`.
+            if let Some(fd) = self.produce_done_fd {
+                if fd >= 0 {
+                    unsafe { libc::close(fd) };
+                }
+            }
+            if let Some(fd) = self.consume_done_fd {
                 if fd >= 0 {
                     unsafe { libc::close(fd) };
                 }
@@ -2255,10 +2272,14 @@ mod surface_client {
         /// `SurfaceHandle` without another wire roundtrip.
         current_image_layout: i32,
         format: String,
-        /// Optional OPAQUE_FD timeline-semaphore handle the host attached at
-        /// register time. Stored so cache hits can hand a fresh dup to each
-        /// new `SurfaceHandle`; closed with the cache entry.
-        sync_fd: Option<RawFd>,
+        /// Optional OPAQUE_FD `produce_done` timeline-semaphore handle the
+        /// host attached at register time. Stored so cache hits can hand
+        /// a fresh dup to each new `SurfaceHandle`; closed with the cache
+        /// entry.
+        produce_done_fd: Option<RawFd>,
+        /// Optional OPAQUE_FD `consume_done` timeline-semaphore handle.
+        /// Same lifetime rules as `produce_done_fd`.
+        consume_done_fd: Option<RawFd>,
     }
 
     impl Drop for CachedSurface {
@@ -2268,7 +2289,12 @@ mod surface_client {
                     unsafe { libc::close(*fd) };
                 }
             }
-            if let Some(fd) = self.sync_fd {
+            if let Some(fd) = self.produce_done_fd {
+                if fd >= 0 {
+                    unsafe { libc::close(fd) };
+                }
+            }
+            if let Some(fd) = self.consume_done_fd {
                 if fd >= 0 {
                     unsafe { libc::close(fd) };
                 }
@@ -2446,28 +2472,51 @@ mod surface_client {
                     }
                     return std::ptr::null_mut();
                 }
-                let cached_sync_dup: Option<RawFd> = match cached.sync_fd {
-                    Some(src) => {
-                        let dup = unsafe { libc::dup(src) };
-                        if dup < 0 {
-                            tracing::error!(
-                                "surface_resolve_surface: dup cached sync_fd failed for '{}': {}",
-                                pool_id_str,
-                                std::io::Error::last_os_error()
-                            );
-                            for fd in &dup_fds {
-                                unsafe { libc::close(*fd) };
+                let dup_timeline = |src: Option<RawFd>, label: &str| -> Result<Option<RawFd>, ()> {
+                    match src {
+                        Some(s) => {
+                            let dup = unsafe { libc::dup(s) };
+                            if dup < 0 {
+                                tracing::error!(
+                                    "surface_resolve_surface: dup cached {} failed for '{}': {}",
+                                    label,
+                                    pool_id_str,
+                                    std::io::Error::last_os_error()
+                                );
+                                Err(())
+                            } else {
+                                Ok(Some(dup))
                             }
-                            return std::ptr::null_mut();
                         }
-                        Some(dup)
+                        None => Ok(None),
                     }
-                    None => None,
+                };
+                let cached_produce_dup = match dup_timeline(cached.produce_done_fd, "produce_done_fd") {
+                    Ok(o) => o,
+                    Err(_) => {
+                        for fd in &dup_fds {
+                            unsafe { libc::close(*fd) };
+                        }
+                        return std::ptr::null_mut();
+                    }
+                };
+                let cached_consume_dup = match dup_timeline(cached.consume_done_fd, "consume_done_fd") {
+                    Ok(o) => o,
+                    Err(_) => {
+                        for fd in &dup_fds {
+                            unsafe { libc::close(*fd) };
+                        }
+                        if let Some(fd) = cached_produce_dup {
+                            unsafe { libc::close(fd) };
+                        }
+                        return std::ptr::null_mut();
+                    }
                 };
                 let n_planes = dup_fds.len();
                 return Box::into_raw(Box::new(SurfaceHandle {
                     fds: dup_fds,
-                    sync_fd: cached_sync_dup,
+                    produce_done_fd: cached_produce_dup,
+                    consume_done_fd: cached_consume_dup,
                     plane_sizes: cached.plane_sizes.clone(),
                     plane_offsets: cached.plane_offsets.clone(),
                     plane_strides: cached.plane_strides.clone(),
@@ -2540,15 +2589,13 @@ mod surface_client {
             return std::ptr::null_mut();
         }
 
-        // Peel off the optional trailing producer-side `produce_done`
-        // timeline FD — same single-writer-per-edge wire shape as the
-        // Python-native twin (see
-        // `docs/architecture/adapter-timeline-single-writer.md`). The
-        // host signals each timeline's presence via
-        // `has_produce_done_fd` / `has_consume_done_fd`; FDs are
-        // appended in that order. Pre-migration: consume_done is
-        // closed here and the per-adapter migrations will reclaim it
-        // through a new wire hook.
+        // Peel off the trailing per-edge timeline FDs — same wire shape
+        // as the Python-native twin. The host signals each timeline's
+        // presence via `has_produce_done_fd` / `has_consume_done_fd`;
+        // FDs appear in that order so the subprocess can route each
+        // into the matching `ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd`.
+        // Single-writer-per-edge is documented in
+        // `docs/architecture/adapter-timeline-single-writer.md`.
         let has_produce_done_fd = response
             .get("has_produce_done_fd")
             .and_then(|v| v.as_bool())
@@ -2559,29 +2606,31 @@ mod surface_client {
             .unwrap_or(false);
         let trailing_count =
             (has_produce_done_fd as usize) + (has_consume_done_fd as usize);
-        let (received_fds, sync_fd): (Vec<RawFd>, Option<RawFd>) = if trailing_count > 0
-            && received_fds.len() >= trailing_count
-        {
+        let (received_fds, produce_done_fd, consume_done_fd): (
+            Vec<RawFd>,
+            Option<RawFd>,
+            Option<RawFd>,
+        ) = if trailing_count > 0 && received_fds.len() >= trailing_count {
             let split_at = received_fds.len() - trailing_count;
             let mut all = received_fds;
             let trailing: Vec<RawFd> = all.split_off(split_at);
             let mut iter = trailing.into_iter();
             let produce_fd = if has_produce_done_fd { iter.next() } else { None };
             let consume_fd = if has_consume_done_fd { iter.next() } else { None };
-            if let Some(fd) = consume_fd {
-                unsafe { libc::close(fd) };
-            }
-            (all, produce_fd)
+            (all, produce_fd, consume_fd)
         } else {
-            (received_fds, None)
+            (received_fds, None, None)
         };
 
         if received_fds.is_empty() {
             tracing::error!(
-                "surface_resolve_surface: no plane fds for '{}' after peeling sync_fd",
+                "surface_resolve_surface: no plane fds for '{}' after peeling timeline fds",
                 pool_id_str
             );
-            if let Some(s) = sync_fd {
+            if let Some(s) = produce_done_fd {
+                unsafe { libc::close(s) };
+            }
+            if let Some(s) = consume_done_fd {
                 unsafe { libc::close(s) };
             }
             return std::ptr::null_mut();
@@ -2651,18 +2700,22 @@ mod surface_client {
             }
             cache_fds.push(dup);
         }
-        let cache_sync_fd: Option<RawFd> = match sync_fd {
-            Some(src) if cache_dup_ok => {
-                let dup = unsafe { libc::dup(src) };
-                if dup < 0 {
-                    cache_dup_ok = false;
-                    None
-                } else {
-                    Some(dup)
+        let dup_for_cache = |src: Option<RawFd>, ok: &mut bool| -> Option<RawFd> {
+            match src {
+                Some(s) if *ok => {
+                    let dup = unsafe { libc::dup(s) };
+                    if dup < 0 {
+                        *ok = false;
+                        None
+                    } else {
+                        Some(dup)
+                    }
                 }
+                _ => None,
             }
-            _ => None,
         };
+        let cache_produce_done_fd = dup_for_cache(produce_done_fd, &mut cache_dup_ok);
+        let cache_consume_done_fd = dup_for_cache(consume_done_fd, &mut cache_dup_ok);
         if cache_dup_ok {
             let mut cache = handle.resolve_cache.lock().expect("poisoned");
             if cache.len() >= MAX_RESOLVE_CACHE {
@@ -2686,14 +2739,18 @@ mod surface_client {
                     drm_format_modifier,
                     current_image_layout,
                     format: format_str.to_string(),
-                    sync_fd: cache_sync_fd,
+                    produce_done_fd: cache_produce_done_fd,
+                    consume_done_fd: cache_consume_done_fd,
                 },
             );
         } else {
             for fd in &cache_fds {
                 unsafe { libc::close(*fd) };
             }
-            if let Some(fd) = cache_sync_fd {
+            if let Some(fd) = cache_produce_done_fd {
+                unsafe { libc::close(fd) };
+            }
+            if let Some(fd) = cache_consume_done_fd {
                 unsafe { libc::close(fd) };
             }
         }
@@ -2701,7 +2758,8 @@ mod surface_client {
         let n_planes = received_fds.len();
         Box::into_raw(Box::new(SurfaceHandle {
             fds: received_fds,
-            sync_fd,
+            produce_done_fd,
+            consume_done_fd,
             plane_sizes,
             plane_offsets,
             plane_strides,
@@ -3559,7 +3617,7 @@ mod vulkan {
                 return -1;
             }
         };
-        let raw_sync_fd: RawFd = match gpu.sync_fd.take() {
+        let raw_sync_fd: RawFd = match gpu.produce_done_fd.take() {
             Some(fd) => fd,
             None => {
                 tracing::error!(
@@ -3577,7 +3635,7 @@ mod vulkan {
         ) {
             Ok(s) => Arc::new(s),
             Err(e) => {
-                gpu.sync_fd = Some(raw_sync_fd);
+                gpu.produce_done_fd = Some(raw_sync_fd);
                 tracing::error!(
                     "sldn_vulkan_register_surface: from_imported_opaque_fd: {}",
                     e
@@ -4154,7 +4212,7 @@ mod cpu_readback {
             staging_planes.push(pb);
         }
 
-        let raw_sync_fd: RawFd = match gpu.sync_fd.take() {
+        let raw_sync_fd: RawFd = match gpu.produce_done_fd.take() {
             Some(fd) => fd,
             None => {
                 tracing::error!(
@@ -4172,7 +4230,7 @@ mod cpu_readback {
         ) {
             Ok(s) => Arc::new(s),
             Err(e) => {
-                gpu.sync_fd = Some(raw_sync_fd);
+                gpu.produce_done_fd = Some(raw_sync_fd);
                 tracing::error!(
                     "sldn_cpu_readback_register_surface: from_imported_opaque_fd: {}",
                     e
@@ -4982,7 +5040,7 @@ mod cuda {
         };
 
         // ── Step 2: import the timeline semaphore into Vulkan ───────────
-        let raw_sync_fd: RawFd = match gpu.sync_fd.take() {
+        let raw_sync_fd: RawFd = match gpu.produce_done_fd.take() {
             Some(fd) => fd,
             None => {
                 tracing::error!(
@@ -5002,7 +5060,7 @@ mod cuda {
                 std::io::Error::last_os_error()
             );
             // Restore the original fd onto the handle so its Drop closes it.
-            gpu.sync_fd = Some(raw_sync_fd);
+            gpu.produce_done_fd = Some(raw_sync_fd);
             return SLDN_CUDA_ERR;
         }
         let timeline = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
@@ -5016,7 +5074,7 @@ mod cuda {
                     e
                 );
                 unsafe { libc::close(vk_sync_fd) };
-                gpu.sync_fd = Some(raw_sync_fd);
+                gpu.produce_done_fd = Some(raw_sync_fd);
                 return SLDN_CUDA_ERR;
             }
         };
@@ -5032,7 +5090,7 @@ mod cuda {
             // Vulkan-side imports drop here via Arc — they own their own
             // dups already. Restore sync_fd onto the handle so its Drop
             // closes it (Vulkan timeline import owns its dup independently).
-            gpu.sync_fd = Some(raw_sync_fd);
+            gpu.produce_done_fd = Some(raw_sync_fd);
             return SLDN_CUDA_ERR;
         }
         // SAFETY: `cudaImportExternalMemory` per CUDA docs:
@@ -5048,7 +5106,7 @@ mod cuda {
                         e
                     );
                     libc::close(cuda_mem_fd);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
@@ -5067,7 +5125,7 @@ mod cuda {
                         e
                     );
                     let _ = external_memory::destroy_external_memory(ext_mem);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
@@ -5090,7 +5148,7 @@ mod cuda {
                         e
                     );
                     let _ = external_memory::destroy_external_memory(ext_mem);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
@@ -5106,7 +5164,7 @@ mod cuda {
                     other
                 );
                 let _ = unsafe { external_memory::destroy_external_memory(ext_mem) };
-                gpu.sync_fd = Some(raw_sync_fd);
+                gpu.produce_done_fd = Some(raw_sync_fd);
                 return SLDN_CUDA_ERR;
             }
         };
@@ -5119,7 +5177,7 @@ mod cuda {
                 std::io::Error::last_os_error()
             );
             let _ = unsafe { external_memory::destroy_external_memory(ext_mem) };
-            gpu.sync_fd = Some(raw_sync_fd);
+            gpu.produce_done_fd = Some(raw_sync_fd);
             return SLDN_CUDA_ERR;
         }
         // Same descriptor-construction story as the carve-out test:
@@ -5151,7 +5209,7 @@ mod cuda {
                     );
                     libc::close(cuda_sync_fd);
                     let _ = external_memory::destroy_external_memory(ext_mem);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
@@ -5169,7 +5227,7 @@ mod cuda {
                     );
                     let _ = sys::cudaDestroyExternalSemaphore(ext_sem).result();
                     let _ = external_memory::destroy_external_memory(ext_mem);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
@@ -5199,7 +5257,7 @@ mod cuda {
                 let _ = sys::cudaDestroyExternalSemaphore(ext_sem).result();
                 let _ = external_memory::destroy_external_memory(ext_mem);
             };
-            gpu.sync_fd = Some(raw_sync_fd);
+            gpu.produce_done_fd = Some(raw_sync_fd);
             return SLDN_CUDA_ERR;
         }
 
@@ -5208,7 +5266,7 @@ mod cuda {
         // returning it to the handle's `sync_fd` slot is the canonical
         // ownership recovery — same pattern as cpu-readback's
         // register_surface error paths.
-        gpu.sync_fd = Some(raw_sync_fd);
+        gpu.produce_done_fd = Some(raw_sync_fd);
 
         let entry = Arc::new(RegisteredCudaSurface {
             ext_mem,
@@ -5885,7 +5943,7 @@ mod cuda {
         };
 
         // ── Step 2: import the timeline semaphore into Vulkan ───────────
-        let raw_sync_fd: RawFd = match gpu.sync_fd.take() {
+        let raw_sync_fd: RawFd = match gpu.produce_done_fd.take() {
             Some(fd) => fd,
             None => {
                 tracing::error!(
@@ -5903,7 +5961,7 @@ mod cuda {
                 "sldn_cuda_register_image_surface: dup sync_fd failed: {}",
                 std::io::Error::last_os_error()
             );
-            gpu.sync_fd = Some(raw_sync_fd);
+            gpu.produce_done_fd = Some(raw_sync_fd);
             return SLDN_CUDA_ERR;
         }
         let timeline = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
@@ -5917,7 +5975,7 @@ mod cuda {
                     e
                 );
                 unsafe { libc::close(vk_sync_fd) };
-                gpu.sync_fd = Some(raw_sync_fd);
+                gpu.produce_done_fd = Some(raw_sync_fd);
                 return SLDN_CUDA_ERR;
             }
         };
@@ -5929,7 +5987,7 @@ mod cuda {
                 "sldn_cuda_register_image_surface: dup cuda_mem_fd failed: {}",
                 std::io::Error::last_os_error()
             );
-            gpu.sync_fd = Some(raw_sync_fd);
+            gpu.produce_done_fd = Some(raw_sync_fd);
             return SLDN_CUDA_ERR;
         }
         // SAFETY: see notes on the buffer path's import_external_memory_opaque_fd
@@ -5943,7 +6001,7 @@ mod cuda {
                         e
                     );
                     libc::close(cuda_mem_fd);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
@@ -5986,7 +6044,7 @@ mod cuda {
                         e
                     );
                     let _ = external_memory::destroy_external_memory(ext_mem);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
@@ -6003,7 +6061,7 @@ mod cuda {
                 let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
                 let _ = external_memory::destroy_external_memory(ext_mem);
             };
-            gpu.sync_fd = Some(raw_sync_fd);
+            gpu.produce_done_fd = Some(raw_sync_fd);
             return SLDN_CUDA_ERR;
         }
         let mut sem_desc = MaybeUninit::<sys::cudaExternalSemaphoreHandleDesc>::zeroed();
@@ -6030,7 +6088,7 @@ mod cuda {
                     libc::close(cuda_sync_fd);
                     let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
                     let _ = external_memory::destroy_external_memory(ext_mem);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
@@ -6049,7 +6107,7 @@ mod cuda {
                     let _ = sys::cudaDestroyExternalSemaphore(ext_sem).result();
                     let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
                     let _ = external_memory::destroy_external_memory(ext_mem);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLDN_CUDA_ERR;
                 }
             }
@@ -6077,11 +6135,11 @@ mod cuda {
                 let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
                 let _ = external_memory::destroy_external_memory(ext_mem);
             };
-            gpu.sync_fd = Some(raw_sync_fd);
+            gpu.produce_done_fd = Some(raw_sync_fd);
             return SLDN_CUDA_ERR;
         }
 
-        gpu.sync_fd = Some(raw_sync_fd);
+        gpu.produce_done_fd = Some(raw_sync_fd);
 
         let entry = Arc::new(RegisteredCudaImageSurface {
             ext_mem,

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -2540,18 +2540,38 @@ mod surface_client {
             return std::ptr::null_mut();
         }
 
-        // Peel off the optional trailing sync-FD (#531) — same wire shape
-        // as the Python-native twin.
-        let has_sync_fd = response
-            .get("has_sync_fd")
+        // Peel off the optional trailing producer-side `produce_done`
+        // timeline FD — same single-writer-per-edge wire shape as the
+        // Python-native twin (see
+        // `docs/architecture/adapter-timeline-single-writer.md`). The
+        // host signals each timeline's presence via
+        // `has_produce_done_fd` / `has_consume_done_fd`; FDs are
+        // appended in that order. Pre-migration: consume_done is
+        // closed here and the per-adapter migrations will reclaim it
+        // through a new wire hook.
+        let has_produce_done_fd = response
+            .get("has_produce_done_fd")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        let (received_fds, sync_fd): (Vec<RawFd>, Option<RawFd>) = if has_sync_fd
-            && !received_fds.is_empty()
+        let has_consume_done_fd = response
+            .get("has_consume_done_fd")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let trailing_count =
+            (has_produce_done_fd as usize) + (has_consume_done_fd as usize);
+        let (received_fds, sync_fd): (Vec<RawFd>, Option<RawFd>) = if trailing_count > 0
+            && received_fds.len() >= trailing_count
         {
+            let split_at = received_fds.len() - trailing_count;
             let mut all = received_fds;
-            let sync = all.pop();
-            (all, sync)
+            let trailing: Vec<RawFd> = all.split_off(split_at);
+            let mut iter = trailing.into_iter();
+            let produce_fd = if has_produce_done_fd { iter.next() } else { None };
+            let consume_fd = if has_consume_done_fd { iter.next() } else { None };
+            if let Some(fd) = consume_fd {
+                unsafe { libc::close(fd) };
+            }
+            (all, produce_fd)
         } else {
             (received_fds, None)
         };

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -3617,11 +3617,15 @@ mod vulkan {
                 return -1;
             }
         };
+        // Import the host's `produce_done` timeline. Single-writer-per-
+        // edge per `docs/architecture/adapter-timeline-single-writer.md`:
+        // the producer signals produce_done; we wait on it before
+        // reading.
         let raw_sync_fd: RawFd = match gpu.produce_done_fd.take() {
             Some(fd) => fd,
             None => {
                 tracing::error!(
-                    "sldn_vulkan_register_surface: surface '{}' has no sync_fd — \
+                    "sldn_vulkan_register_surface: surface '{}' has no produce_done_fd — \
                      the host must register the texture with an exportable \
                      `ConsumerVulkanTimelineSemaphore`.",
                     surface_id
@@ -3629,7 +3633,7 @@ mod vulkan {
                 return -1;
             }
         };
-        let timeline = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+        let produce_done = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
             &rt.device,
             raw_sync_fd,
         ) {
@@ -3637,7 +3641,39 @@ mod vulkan {
             Err(e) => {
                 gpu.produce_done_fd = Some(raw_sync_fd);
                 tracing::error!(
-                    "sldn_vulkan_register_surface: from_imported_opaque_fd: {}",
+                    "sldn_vulkan_register_surface: produce_done from_imported_opaque_fd: {}",
+                    e
+                );
+                return -1;
+            }
+        };
+
+        // Import the host's `consume_done` timeline. We (the consumer)
+        // signal this timeline from `end_read_access` so the producer
+        // can wait before re-writing.
+        let raw_consume_fd: RawFd = match gpu.consume_done_fd.take() {
+            Some(fd) => fd,
+            None => {
+                tracing::error!(
+                    "sldn_vulkan_register_surface: surface '{}' has no consume_done_fd — \
+                     the host must register both produce_done and consume_done timeline \
+                     fds per the single-writer-per-edge contract",
+                    surface_id
+                );
+                gpu.produce_done_fd = Some(raw_sync_fd);
+                return -1;
+            }
+        };
+        let consume_done = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+            &rt.device,
+            raw_consume_fd,
+        ) {
+            Ok(s) => Arc::new(s),
+            Err(e) => {
+                gpu.produce_done_fd = Some(raw_sync_fd);
+                gpu.consume_done_fd = Some(raw_consume_fd);
+                tracing::error!(
+                    "sldn_vulkan_register_surface: consume_done from_imported_opaque_fd: {}",
                     e
                 );
                 return -1;
@@ -3657,7 +3693,8 @@ mod vulkan {
         // producer's claim.
         let registration = HostSurfaceRegistration::<ConsumerMarker> {
             texture: Arc::new(texture),
-            timeline,
+            produce_done,
+            consume_done,
             initial_layout: VulkanLayout(gpu.current_image_layout),
         };
 

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -4249,11 +4249,17 @@ mod cpu_readback {
             staging_planes.push(pb);
         }
 
+        // Import both timeline semaphores. Required for every cpu-
+        // readback surface — the host triggers signal `produce_done`
+        // on every image_to_buffer / buffer_to_image copy; the
+        // consumer's `end_read_access` signals `consume_done` via host
+        // CPU `signal_host`. Single-writer-per-edge per
+        // `docs/architecture/adapter-timeline-single-writer.md`.
         let raw_sync_fd: RawFd = match gpu.produce_done_fd.take() {
             Some(fd) => fd,
             None => {
                 tracing::error!(
-                    "sldn_cpu_readback_register_surface: surface '{}' has no sync_fd — \
+                    "sldn_cpu_readback_register_surface: surface '{}' has no produce_done_fd — \
                      the host must register it via SurfaceStore::register_pixel_buffer_with_timeline \
                      with an exportable HostVulkanTimelineSemaphore.",
                     surface_id
@@ -4261,15 +4267,44 @@ mod cpu_readback {
                 return SLDN_CPU_READBACK_ERR;
             }
         };
-        let timeline = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+        let raw_consume_fd: RawFd = match gpu.consume_done_fd.take() {
+            Some(fd) => fd,
+            None => {
+                tracing::error!(
+                    "sldn_cpu_readback_register_surface: surface '{}' has no consume_done_fd — \
+                     the host must register both produce_done and consume_done timeline fds \
+                     per the single-writer-per-edge contract",
+                    surface_id
+                );
+                gpu.produce_done_fd = Some(raw_sync_fd);
+                return SLDN_CPU_READBACK_ERR;
+            }
+        };
+        let produce_done = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
             &rt.device,
             raw_sync_fd,
         ) {
             Ok(s) => Arc::new(s),
             Err(e) => {
                 gpu.produce_done_fd = Some(raw_sync_fd);
+                gpu.consume_done_fd = Some(raw_consume_fd);
                 tracing::error!(
-                    "sldn_cpu_readback_register_surface: from_imported_opaque_fd: {}",
+                    "sldn_cpu_readback_register_surface: produce_done from_imported_opaque_fd: {}",
+                    e
+                );
+                return SLDN_CPU_READBACK_ERR;
+            }
+        };
+        let consume_done = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+            &rt.device,
+            raw_consume_fd,
+        ) {
+            Ok(s) => Arc::new(s),
+            Err(e) => {
+                gpu.produce_done_fd = Some(raw_sync_fd);
+                gpu.consume_done_fd = Some(raw_consume_fd);
+                tracing::error!(
+                    "sldn_cpu_readback_register_surface: consume_done from_imported_opaque_fd: {}",
                     e
                 );
                 return SLDN_CPU_READBACK_ERR;
@@ -4295,7 +4330,8 @@ mod cpu_readback {
         let registration = HostSurfaceRegistration::<ConsumerMarker> {
             texture: None,
             staging_planes,
-            timeline,
+            produce_done,
+            consume_done,
             initial_image_layout: VulkanLayout::GENERAL,
             format,
             width: surface_width,

--- a/libs/streamlib-deno/surface_adapter.ts
+++ b/libs/streamlib-deno/surface_adapter.ts
@@ -152,14 +152,16 @@ export const SurfaceLayout = {
     Size: 56,
     Align: 8,
     Offsets: {
-      timelineSemaphoreHandle: 0,
-      timelineSemaphoreSyncFd: 8,
+      produceDoneSemaphoreHandle: 0,
+      produceDoneSemaphoreSyncFd: 8,
       padA: 12,
       lastAcquireValue: 16,
       lastReleaseValue: 24,
       currentImageLayout: 32,
       padB: 36,
-      reserved: 40,
+      consumeDoneSemaphoreHandle: 40,
+      consumeDoneSemaphoreSyncFd: 48,
+      padC: 52,
     },
   },
   /** StreamlibSurface (top-level) */
@@ -202,12 +204,16 @@ export interface SurfaceTransportHandle {
 }
 
 /**
- * Host-side timeline-semaphore + initial layout. Subprocess adapters
- * import `timelineSemaphoreSyncFd` via `vkImportSemaphoreFdKHR`.
+ * Host-side dual-timeline semaphores + initial layout. Subprocess
+ * adapters import the `produce_done` and `consume_done` sync-fds via
+ * `vkImportSemaphoreFdKHR` and wait/signal on whichever edge they own
+ * per `docs/architecture/adapter-timeline-single-writer.md`.
  */
 export interface SurfaceSyncState {
-  readonly timelineSemaphoreHandle: bigint;
-  readonly timelineSemaphoreSyncFd: number;
+  readonly produceDoneSemaphoreHandle: bigint;
+  readonly produceDoneSemaphoreSyncFd: number;
+  readonly consumeDoneSemaphoreHandle: bigint;
+  readonly consumeDoneSemaphoreSyncFd: number;
   readonly lastAcquireValue: bigint;
   readonly lastReleaseValue: bigint;
   readonly currentImageLayout: number;
@@ -296,8 +302,9 @@ export function readSurfaceTransportHandle(
 
 /**
  * Read the embedded `SurfaceSyncState` out of a `StreamlibSurface`
- * descriptor. Adapter implementations import the sync-fd to participate
- * in the host-side timeline.
+ * descriptor. Adapter implementations import the sync-fds to
+ * participate in the host-side dual-timeline (`produce_done` /
+ * `consume_done`).
  */
 export function readSurfaceSyncState(
   view: Deno.UnsafePointerView,
@@ -305,10 +312,18 @@ export function readSurfaceSyncState(
   const base = SurfaceLayout.Surface.Offsets.sync;
   const o = SurfaceLayout.SyncState.Offsets;
   return {
-    timelineSemaphoreHandle: view.getBigUint64(
-      base + o.timelineSemaphoreHandle,
+    produceDoneSemaphoreHandle: view.getBigUint64(
+      base + o.produceDoneSemaphoreHandle,
     ),
-    timelineSemaphoreSyncFd: view.getInt32(base + o.timelineSemaphoreSyncFd),
+    produceDoneSemaphoreSyncFd: view.getInt32(
+      base + o.produceDoneSemaphoreSyncFd,
+    ),
+    consumeDoneSemaphoreHandle: view.getBigUint64(
+      base + o.consumeDoneSemaphoreHandle,
+    ),
+    consumeDoneSemaphoreSyncFd: view.getInt32(
+      base + o.consumeDoneSemaphoreSyncFd,
+    ),
     lastAcquireValue: view.getBigUint64(base + o.lastAcquireValue),
     lastReleaseValue: view.getBigUint64(base + o.lastReleaseValue),
     currentImageLayout: view.getInt32(base + o.currentImageLayout),

--- a/libs/streamlib-deno/surface_adapter_test.ts
+++ b/libs/streamlib-deno/surface_adapter_test.ts
@@ -106,24 +106,28 @@ Deno.test("SurfaceTransportHandle layout matches Rust", () => {
 });
 
 Deno.test("SurfaceSyncState layout matches Rust", () => {
-  // timeline_semaphore_handle: u64 @ 0
-  // timeline_semaphore_sync_fd: i32 @ 8
+  // produce_done_semaphore_handle: u64 @ 0
+  // produce_done_semaphore_sync_fd: i32 @ 8
   // _pad_a: u32 @ 12
   // last_acquire_value: u64 @ 16
   // last_release_value: u64 @ 24
   // current_image_layout: i32 @ 32
   // _pad_b: u32 @ 36
-  // _reserved: [u8; 16] @ 40
+  // consume_done_semaphore_handle: u64 @ 40
+  // consume_done_semaphore_sync_fd: i32 @ 48
+  // _pad_c: u32 @ 52
   // total: 56, align 8
   const s = SurfaceLayout.SyncState;
-  assertEquals(s.Offsets.timelineSemaphoreHandle, 0);
-  assertEquals(s.Offsets.timelineSemaphoreSyncFd, 8);
+  assertEquals(s.Offsets.produceDoneSemaphoreHandle, 0);
+  assertEquals(s.Offsets.produceDoneSemaphoreSyncFd, 8);
   assertEquals(s.Offsets.padA, 12);
   assertEquals(s.Offsets.lastAcquireValue, 16);
   assertEquals(s.Offsets.lastReleaseValue, 24);
   assertEquals(s.Offsets.currentImageLayout, 32);
   assertEquals(s.Offsets.padB, 36);
-  assertEquals(s.Offsets.reserved, 40);
+  assertEquals(s.Offsets.consumeDoneSemaphoreHandle, 40);
+  assertEquals(s.Offsets.consumeDoneSemaphoreSyncFd, 48);
+  assertEquals(s.Offsets.padC, 52);
   assertEquals(s.Size, 56);
   assertEquals(s.Align, 8);
 });

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -434,6 +434,14 @@ fn open_iceoryx2_pubsub(
                 input_inner.add_port(dest_port, 1, Default::default());
             }
 
+            // Plumb the schema's `metadata.max_payload_bytes` to the
+            // destination port so the cdylib's v2
+            // `max_payload_for_port` vtable slot returns the same
+            // bound the publisher uses to size the iceoryx2 slot.
+            // The cdylib's read_raw then allocates exactly this
+            // size — no truncation, no retry, no silent drop.
+            input_inner.set_port_max_payload_bytes(dest_port, max_payload);
+
             // Only set subscriber+listener if this is the first connection to this destination
             // All subsequent connections reuse the same pair (max_listeners=1 enforces this).
             if !input_inner.has_subscriber() {
@@ -718,6 +726,13 @@ fn open_iceoryx2_subprocess_to_rust(
             if !input_inner.has_port(dest_port) {
                 input_inner.add_port(dest_port, 1, Default::default());
             }
+
+            // Plumb the schema's `metadata.max_payload_bytes` to the
+            // destination port so the cdylib's v2
+            // `max_payload_for_port` vtable slot honors the same
+            // bound the publisher uses. See the same call in the
+            // local-source branch above for full rationale.
+            input_inner.set_port_max_payload_bytes(dest_port, max_payload);
 
             if !input_inner.has_subscriber() {
                 let subscriber = service.create_subscriber()?;

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -673,6 +673,7 @@ fn assign_texture_handle_id(
                 &handle_id,
                 texture.texture(),
                 None,
+                None,
                 streamlib_consumer_rhi::VulkanLayout::UNDEFINED,
             )?;
         }
@@ -701,6 +702,7 @@ fn assign_image_handle_id(
         store.register_texture(
             &handle_id,
             texture,
+            None,
             None,
             streamlib_consumer_rhi::VulkanLayout::UNDEFINED,
         )?;

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -125,11 +125,34 @@ fn request_id(op: &EscalateRequest) -> Option<&str> {
 /// at startup and the subprocess imports them once via
 /// `streamlib-consumer-rhi`; per-acquire IPC reduces to a thin
 /// `run_cpu_readback_copy` trigger that returns a timeline value.
+///
+/// Timeline Arcs (when present) keep the per-edge single-writer
+/// timelines alive for the registration's lifetime — surface-share
+/// duplicates the FDs at register-time via SCM_RIGHTS, but the
+/// host-side `Arc<HostVulkanTimelineSemaphore>` must outlive the
+/// registration so the kernel objects backing the FDs aren't
+/// destroyed. See `docs/architecture/adapter-timeline-single-writer.md`.
 pub(crate) enum RegisteredHandle {
     #[allow(dead_code)]
     PixelBuffer(PixelBuffer),
     #[allow(dead_code)]
-    Texture(PooledTextureHandle),
+    Texture {
+        texture: PooledTextureHandle,
+        #[cfg(target_os = "linux")]
+        produce_done: Option<Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>>,
+        #[cfg(target_os = "linux")]
+        consume_done: Option<Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>>,
+    },
+    /// Render-target image handed out via `AcquireImage`. The texture
+    /// itself returns to its pool when the variant drops; the
+    /// timelines keep their FDs alive for surface-share consumers.
+    #[cfg(target_os = "linux")]
+    #[allow(dead_code)]
+    Image {
+        texture: crate::core::rhi::Texture,
+        produce_done: Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
+        consume_done: Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
+    },
 }
 
 /// Tracks resources acquired on behalf of a subprocess so `release_handle` —
@@ -153,9 +176,48 @@ impl EscalateHandleRegistry {
         map.insert(handle_id, RegisteredHandle::PixelBuffer(buffer));
     }
 
+    #[cfg(target_os = "linux")]
+    pub(crate) fn insert_texture(
+        &self,
+        handle_id: String,
+        texture: PooledTextureHandle,
+        produce_done: Option<Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>>,
+        consume_done: Option<Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>>,
+    ) {
+        let mut map = self.handles.lock().expect("poisoned");
+        map.insert(
+            handle_id,
+            RegisteredHandle::Texture {
+                texture,
+                produce_done,
+                consume_done,
+            },
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
     pub(crate) fn insert_texture(&self, handle_id: String, texture: PooledTextureHandle) {
         let mut map = self.handles.lock().expect("poisoned");
-        map.insert(handle_id, RegisteredHandle::Texture(texture));
+        map.insert(handle_id, RegisteredHandle::Texture { texture });
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn insert_image(
+        &self,
+        handle_id: String,
+        texture: crate::core::rhi::Texture,
+        produce_done: Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
+        consume_done: Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
+    ) {
+        let mut map = self.handles.lock().expect("poisoned");
+        map.insert(
+            handle_id,
+            RegisteredHandle::Image {
+                texture,
+                produce_done,
+                consume_done,
+            },
+        );
     }
 
     /// Remove a handle by id. Returns `true` when an entry was found
@@ -261,12 +323,39 @@ pub(crate) fn handle_escalate_op(
             };
             let desc = TexturePoolDescriptor::new(width, height, parsed_format)
                 .with_usage(parsed_usage);
+            #[cfg(target_os = "linux")]
             let acquired = sandbox.escalate(|full| {
                 let texture = full.acquire_texture(&desc)?;
-                let handle_id = assign_texture_handle_id(full, &texture)?;
+                let (handle_id, produce_done, consume_done) =
+                    assign_texture_handle_id(full, &texture)?;
+                Ok((handle_id, texture, produce_done, consume_done))
+            });
+            #[cfg(not(target_os = "linux"))]
+            let acquired = sandbox.escalate(|full| {
+                let texture = full.acquire_texture(&desc)?;
+                let (handle_id,) = assign_texture_handle_id(full, &texture)?;
                 Ok((handle_id, texture))
             });
             Some(match acquired {
+                #[cfg(target_os = "linux")]
+                Ok((handle_id, texture, produce_done, consume_done)) => {
+                    registry.insert_texture(
+                        handle_id.clone(),
+                        texture,
+                        produce_done,
+                        consume_done,
+                    );
+                    EscalateResponse::Ok(EscalateResponseOk {
+                        request_id: rid,
+                        handle_id,
+                        width: Some(width),
+                        height: Some(height),
+                        format: Some(texture_format_to_wire(parsed_format).to_string()),
+                        usage: Some(texture_usages_to_wire(parsed_usage)),
+                        timeline_value: None,
+                    })
+                }
+                #[cfg(not(target_os = "linux"))]
                 Ok((handle_id, texture)) => {
                     registry.insert_texture(handle_id.clone(), texture);
                     EscalateResponse::Ok(EscalateResponseOk {
@@ -313,23 +402,35 @@ pub(crate) fn handle_escalate_op(
                         height,
                         parsed_format,
                     )?;
-                    let handle_id = assign_image_handle_id(full, &texture)?;
-                    Ok((handle_id, texture))
+                    let (handle_id, produce_done, consume_done) =
+                        assign_image_handle_id(full, &texture)?;
+                    Ok((handle_id, texture, produce_done, consume_done))
                 });
                 Some(match acquired {
-                    Ok((handle_id, _texture)) => EscalateResponse::Ok(EscalateResponseOk {
-                        request_id: rid,
-                        handle_id,
-                        width: Some(width),
-                        height: Some(height),
-                        format: Some(texture_format_to_wire(parsed_format).to_string()),
-                        usage: Some(vec![
-                            "render_attachment".to_string(),
-                            "texture_binding".to_string(),
-                            "copy_src".to_string(),
-                        ]),
-                        timeline_value: None,
-                    }),
+                    Ok((handle_id, texture, produce_done, consume_done)) => {
+                        // Stash the texture + timeline pair in the
+                        // registry so the FDs handed to surface-share
+                        // stay valid for the registration's lifetime.
+                        registry.insert_image(
+                            handle_id.clone(),
+                            texture,
+                            produce_done,
+                            consume_done,
+                        );
+                        EscalateResponse::Ok(EscalateResponseOk {
+                            request_id: rid,
+                            handle_id,
+                            width: Some(width),
+                            height: Some(height),
+                            format: Some(texture_format_to_wire(parsed_format).to_string()),
+                            usage: Some(vec![
+                                "render_attachment".to_string(),
+                                "texture_binding".to_string(),
+                                "copy_src".to_string(),
+                            ]),
+                            timeline_value: None,
+                        })
+                    }
                     Err(e) => EscalateResponse::Err(EscalateResponseErr {
                         request_id: rid,
                         message: format!("acquire_image failed: {e}"),
@@ -650,35 +751,79 @@ fn assign_buffer_handle_id(
 ///
 /// On Linux, register the texture's DMA-BUF with the surface-share service under a fresh UUID
 /// so the subprocess can `check_out` it; on other platforms just mint a UUID.
-#[allow(unused_variables)]
+///
+/// On Linux, also allocates and registers a single-writer-per-edge
+/// timeline pair (`produce_done` + `consume_done` per
+/// `docs/architecture/adapter-timeline-single-writer.md`). The
+/// timelines are returned so the caller can stash them in the
+/// [`EscalateHandleRegistry`]; the surface-share registration
+/// duplicates the FDs via SCM_RIGHTS but the host-side Arcs must
+/// outlive the registration.
+#[cfg(target_os = "linux")]
 fn assign_texture_handle_id(
     full: &crate::core::context::GpuContextFullAccess,
     texture: &PooledTextureHandle,
-) -> crate::core::error::Result<String> {
+) -> crate::core::error::Result<(
+    String,
+    Option<Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>>,
+    Option<Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>>,
+)> {
     let handle_id = Uuid::new_v4().to_string();
-    #[cfg(target_os = "linux")]
-    {
-        if let Some(store) = full.surface_store() {
-            // No timeline semaphore — escalate-IPC consumers (CPU-readback
-            // bridge) handle sync via the per-acquire response, not via a
-            // shared host timeline.
-            //
-            // UNDEFINED at registration: pooled textures sit in the
-            // texture pool unowned until the first acquire. The host
-            // adapter or escalate-IPC bridge transitions to its
-            // workload-specific layout on first use; subsequent
-            // releases publish the post-release layout via
-            // `update_image_layout`.
-            store.register_texture(
-                &handle_id,
-                texture.texture(),
-                None,
-                None,
-                streamlib_consumer_rhi::VulkanLayout::UNDEFINED,
-            )?;
-        }
+    if let Some(store) = full.surface_store() {
+        let host_device = full.host_vulkan_device_arc()?;
+        // Single-writer-per-edge timelines. Escalate-IPC consumers
+        // (CPU-readback bridge today) handle sync via the
+        // per-acquire response and don't drive these timelines,
+        // but the surface-share IPC delivers both FDs to the
+        // cdylib so future consumers riding the dual-timeline
+        // contract see them.
+        let produce_done = Arc::new(
+            crate::vulkan::rhi::HostVulkanTimelineSemaphore::new_exportable(
+                host_device.device(),
+                0,
+            )
+            .map_err(|e| {
+                crate::core::error::Error::GpuError(format!(
+                    "assign_texture_handle_id: new_exportable (produce_done): {e}"
+                ))
+            })?,
+        );
+        let consume_done = Arc::new(
+            crate::vulkan::rhi::HostVulkanTimelineSemaphore::new_exportable(
+                host_device.device(),
+                0,
+            )
+            .map_err(|e| {
+                crate::core::error::Error::GpuError(format!(
+                    "assign_texture_handle_id: new_exportable (consume_done): {e}"
+                ))
+            })?,
+        );
+        // UNDEFINED at registration: pooled textures sit in the
+        // texture pool unowned until the first acquire. The host
+        // adapter or escalate-IPC bridge transitions to its
+        // workload-specific layout on first use; subsequent
+        // releases publish the post-release layout via
+        // `update_image_layout`.
+        store.register_texture(
+            &handle_id,
+            texture.texture(),
+            Some(produce_done.as_ref()),
+            Some(consume_done.as_ref()),
+            streamlib_consumer_rhi::VulkanLayout::UNDEFINED,
+        )?;
+        Ok((handle_id, Some(produce_done), Some(consume_done)))
+    } else {
+        Ok((handle_id, None, None))
     }
-    Ok(handle_id)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn assign_texture_handle_id(
+    _full: &crate::core::context::GpuContextFullAccess,
+    _texture: &PooledTextureHandle,
+) -> crate::core::error::Result<(String,)> {
+    Ok((Uuid::new_v4().to_string(),))
 }
 
 /// Resolve the `handle_id` for a render-target DMA-BUF image.
@@ -687,12 +832,43 @@ fn assign_texture_handle_id(
 /// per-plane row pitches) with the surface-share service under a fresh UUID
 /// so the subprocess can `check_out` it; the surface-share registration
 /// carries the modifier and strides the consumer-side EGL import requires.
+///
+/// Also allocates a single-writer-per-edge timeline pair and registers
+/// it with surface-share. Returns the timelines so the caller can
+/// stash them in the [`EscalateHandleRegistry`].
 #[cfg(target_os = "linux")]
 fn assign_image_handle_id(
     full: &crate::core::context::GpuContextFullAccess,
     texture: &crate::core::rhi::Texture,
-) -> crate::core::error::Result<String> {
+) -> crate::core::error::Result<(
+    String,
+    Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
+    Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
+)> {
     let handle_id = Uuid::new_v4().to_string();
+    let host_device = full.host_vulkan_device_arc()?;
+    let produce_done = Arc::new(
+        crate::vulkan::rhi::HostVulkanTimelineSemaphore::new_exportable(
+            host_device.device(),
+            0,
+        )
+        .map_err(|e| {
+            crate::core::error::Error::GpuError(format!(
+                "assign_image_handle_id: new_exportable (produce_done): {e}"
+            ))
+        })?,
+    );
+    let consume_done = Arc::new(
+        crate::vulkan::rhi::HostVulkanTimelineSemaphore::new_exportable(
+            host_device.device(),
+            0,
+        )
+        .map_err(|e| {
+            crate::core::error::Error::GpuError(format!(
+                "assign_image_handle_id: new_exportable (consume_done): {e}"
+            ))
+        })?,
+    );
     if let Some(store) = full.surface_store() {
         // Render-target images are freshly allocated and unwritten at
         // registration time — declare UNDEFINED and let the first
@@ -702,12 +878,12 @@ fn assign_image_handle_id(
         store.register_texture(
             &handle_id,
             texture,
-            None,
-            None,
+            Some(produce_done.as_ref()),
+            Some(consume_done.as_ref()),
             streamlib_consumer_rhi::VulkanLayout::UNDEFINED,
         )?;
     }
-    Ok(handle_id)
+    Ok((handle_id, produce_done, consume_done))
 }
 
 /// Map a wire-format `run_cpu_readback_copy` request through the

--- a/libs/streamlib-engine/src/core/context/surface_store.rs
+++ b/libs/streamlib-engine/src/core/context/surface_store.rs
@@ -1104,7 +1104,8 @@ impl SurfaceStoreInner {
         &self,
         surface_id: &str,
         texture: &crate::core::rhi::Texture,
-        timeline: Option<&crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
+        produce_done: Option<&crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
+        consume_done: Option<&crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
         current_image_layout: streamlib_consumer_rhi::VulkanLayout,
     ) -> Result<()> {
         let is_opaque_fd = texture.vulkan_inner().is_opaque_fd_export();
@@ -1120,16 +1121,36 @@ impl SurfaceStoreInner {
             texture.vulkan_inner().export_dma_buf_fd()?
         };
 
-        // Optionally export the timeline-semaphore as an OPAQUE_FD. The host
-        // retains ownership of the semaphore object; this fd is duplicated by
-        // the kernel during SCM_RIGHTS and we close our copy after send.
-        let sync_fd: Option<std::os::unix::io::RawFd> = match timeline {
+        // Optionally export the producer-side `produce_done` and
+        // consumer-side `consume_done` timeline-semaphores as
+        // OPAQUE_FDs (single-writer-per-edge model — see
+        // `docs/architecture/adapter-timeline-single-writer.md`). The
+        // host retains ownership of both semaphore objects; the FDs are
+        // duplicated by the kernel during SCM_RIGHTS and we close our
+        // copies after send.
+        let produce_done_fd: Option<std::os::unix::io::RawFd> = match produce_done {
             Some(t) => match t.export_opaque_fd() {
                 Ok(f) => Some(f),
                 Err(e) => {
                     unsafe { libc::close(fd) };
                     return Err(Error::Configuration(format!(
-                        "register_texture: failed to export timeline opaque fd: {}",
+                        "register_texture: failed to export produce_done opaque fd: {}",
+                        e
+                    )));
+                }
+            },
+            None => None,
+        };
+        let consume_done_fd: Option<std::os::unix::io::RawFd> = match consume_done {
+            Some(t) => match t.export_opaque_fd() {
+                Ok(f) => Some(f),
+                Err(e) => {
+                    unsafe { libc::close(fd) };
+                    if let Some(p) = produce_done_fd {
+                        unsafe { libc::close(p) };
+                    }
+                    return Err(Error::Configuration(format!(
+                        "register_texture: failed to export consume_done opaque fd: {}",
                         e
                     )));
                 }
@@ -1171,8 +1192,8 @@ impl SurfaceStoreInner {
                 "plane_offsets": [0u64],
                 "plane_strides": [0u64],
                 "drm_format_modifier": 0u64,
-                "has_produce_done_fd": sync_fd.is_some(),
-                "has_consume_done_fd": false,
+                "has_produce_done_fd": produce_done_fd.is_some(),
+                "has_consume_done_fd": consume_done_fd.is_some(),
                 "current_image_layout": current_image_layout.as_vk().as_raw(),
                 "vk_image_type": VK_IMAGE_TYPE_2D,
                 "vk_image_mip_levels": 1u32,
@@ -1211,9 +1232,9 @@ impl SurfaceStoreInner {
                 "plane_offsets": plane_offsets,
                 "plane_strides": plane_strides,
                 "drm_format_modifier": drm_format_modifier,
-                "has_produce_done_fd": sync_fd.is_some(),
-                "has_consume_done_fd": false,
-                // The producer's declared `VkImageLayout` (#633): the
+                "has_produce_done_fd": produce_done_fd.is_some(),
+                "has_consume_done_fd": consume_done_fd.is_some(),
+                // The producer's declared `VkImageLayout`: the
                 // layout the texture lives in immediately after
                 // registration, fed to host consumers as the source
                 // layout of their first QFOT acquire barrier. Encoded
@@ -1228,7 +1249,10 @@ impl SurfaceStoreInner {
         })?;
 
         let mut fds: Vec<std::os::unix::io::RawFd> = vec![fd];
-        if let Some(s) = sync_fd {
+        if let Some(s) = produce_done_fd {
+            fds.push(s);
+        }
+        if let Some(s) = consume_done_fd {
             fds.push(s);
         }
         let send_result =
@@ -1251,9 +1275,10 @@ impl SurfaceStoreInner {
         }
 
         tracing::debug!(
-            "SurfaceStore: Registered texture '{}' (sync_fd={})",
+            "SurfaceStore: Registered texture '{}' (produce_done={}, consume_done={})",
             surface_id,
-            timeline.is_some(),
+            produce_done.is_some(),
+            consume_done.is_some(),
         );
         Ok(())
     }
@@ -1280,7 +1305,8 @@ impl SurfaceStoreInner {
         &self,
         surface_id: &str,
         pixel_buffer: &PixelBuffer,
-        timeline: Option<&crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
+        produce_done: Option<&crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
+        consume_done: Option<&crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
     ) -> Result<()> {
         use crate::core::rhi::RhiPixelBufferExport;
 
@@ -1307,11 +1333,12 @@ impl SurfaceStoreInner {
             plane_offsets.push(0);
         }
 
-        // Optionally export the timeline as an OPAQUE_FD. Same
-        // SCM_RIGHTS-trailing-FD shape `register_texture` uses so the
-        // surface-share daemon's existing `has_sync_fd` parsing applies
-        // unchanged.
-        let sync_fd: Option<std::os::unix::io::RawFd> = match timeline {
+        // Export `produce_done` + `consume_done` as OPAQUE_FDs (the
+        // single-writer-per-edge pair documented in
+        // `docs/architecture/adapter-timeline-single-writer.md`). The
+        // surface-share daemon's wire format peels both trailing FDs
+        // in the published order.
+        let produce_done_fd: Option<std::os::unix::io::RawFd> = match produce_done {
             Some(t) => match t.export_opaque_fd() {
                 Ok(f) => Some(f),
                 Err(e) => {
@@ -1319,7 +1346,25 @@ impl SurfaceStoreInner {
                         unsafe { libc::close(*fd) };
                     }
                     return Err(Error::Configuration(format!(
-                        "register_pixel_buffer_with_timeline: failed to export timeline opaque fd: {}",
+                        "register_pixel_buffer_with_timeline: failed to export produce_done opaque fd: {}",
+                        e
+                    )));
+                }
+            },
+            None => None,
+        };
+        let consume_done_fd: Option<std::os::unix::io::RawFd> = match consume_done {
+            Some(t) => match t.export_opaque_fd() {
+                Ok(f) => Some(f),
+                Err(e) => {
+                    for fd in &plane_fds {
+                        unsafe { libc::close(*fd) };
+                    }
+                    if let Some(p) = produce_done_fd {
+                        unsafe { libc::close(p) };
+                    }
+                    return Err(Error::Configuration(format!(
+                        "register_pixel_buffer_with_timeline: failed to export consume_done opaque fd: {}",
                         e
                     )));
                 }
@@ -1338,7 +1383,8 @@ impl SurfaceStoreInner {
             "handle_type": handle_type,
             "plane_sizes": plane_sizes,
             "plane_offsets": plane_offsets,
-            "has_sync_fd": sync_fd.is_some(),
+            "has_produce_done_fd": produce_done_fd.is_some(),
+            "has_consume_done_fd": consume_done_fd.is_some(),
         });
 
         let connection = self.connection.lock();
@@ -1347,7 +1393,10 @@ impl SurfaceStoreInner {
         })?;
 
         let mut fds: Vec<std::os::unix::io::RawFd> = plane_fds.clone();
-        if let Some(s) = sync_fd {
+        if let Some(s) = produce_done_fd {
+            fds.push(s);
+        }
+        if let Some(s) = consume_done_fd {
             fds.push(s);
         }
         let send_result =
@@ -1373,10 +1422,11 @@ impl SurfaceStoreInner {
         }
 
         tracing::debug!(
-            "SurfaceStore: Registered pixel buffer '{}' ({} plane(s), sync_fd={})",
+            "SurfaceStore: Registered pixel buffer '{}' ({} plane(s), produce_done={}, consume_done={})",
             surface_id,
             plane_sizes.len(),
-            timeline.is_some(),
+            produce_done.is_some(),
+            consume_done.is_some(),
         );
         Ok(())
     }
@@ -2117,7 +2167,8 @@ impl SurfaceStore {
         &self,
         surface_id: &str,
         texture: &crate::core::rhi::Texture,
-        timeline: Option<&crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
+        produce_done: Option<&crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
+        consume_done: Option<&crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
         current_image_layout: streamlib_consumer_rhi::VulkanLayout,
     ) -> Result<()> {
         if self.is_none() {
@@ -2127,10 +2178,13 @@ impl SurfaceStore {
         }
         let mut err_buf = [0u8; 512];
         let mut err_len: usize = 0;
-        // timeline is an engine-only Arc; we pass the raw pointer to
-        // the underlying type. The host-side callback re-borrows it
-        // as `Option<&Arc<HostVulkanTimelineSemaphore>>`.
-        let timeline_ptr: *const ss_c_void = timeline
+        // produce_done / consume_done are engine-only references; we
+        // pass raw pointers to the underlying type. The host-side
+        // callback re-borrows them.
+        let produce_done_ptr: *const ss_c_void = produce_done
+            .map(|t| t as *const _ as *const ss_c_void)
+            .unwrap_or(std::ptr::null());
+        let consume_done_ptr: *const ss_c_void = consume_done
             .map(|t| t as *const _ as *const ss_c_void)
             .unwrap_or(std::ptr::null());
         let status = unsafe {
@@ -2139,7 +2193,8 @@ impl SurfaceStore {
                 surface_id.as_ptr(),
                 surface_id.len(),
                 texture as *const crate::core::rhi::Texture as *const ss_c_void,
-                timeline_ptr,
+                produce_done_ptr,
+                consume_done_ptr,
                 current_image_layout.0,
                 err_buf.as_mut_ptr(),
                 err_buf.len(),
@@ -2164,7 +2219,8 @@ impl SurfaceStore {
         &self,
         surface_id: &str,
         pixel_buffer: &PixelBuffer,
-        timeline: Option<&crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
+        produce_done: Option<&crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
+        consume_done: Option<&crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
     ) -> Result<()> {
         if self.is_none() {
             return Err(Error::Configuration(
@@ -2173,7 +2229,10 @@ impl SurfaceStore {
         }
         let mut err_buf = [0u8; 512];
         let mut err_len: usize = 0;
-        let timeline_ptr: *const ss_c_void = timeline
+        let produce_done_ptr: *const ss_c_void = produce_done
+            .map(|t| t as *const _ as *const ss_c_void)
+            .unwrap_or(std::ptr::null());
+        let consume_done_ptr: *const ss_c_void = consume_done
             .map(|t| t as *const _ as *const ss_c_void)
             .unwrap_or(std::ptr::null());
         let status = unsafe {
@@ -2182,7 +2241,8 @@ impl SurfaceStore {
                 surface_id.as_ptr(),
                 surface_id.len(),
                 pixel_buffer as *const PixelBuffer as *const ss_c_void,
-                timeline_ptr,
+                produce_done_ptr,
+                consume_done_ptr,
                 err_buf.as_mut_ptr(),
                 err_buf.len(),
                 &mut err_len as *mut usize,

--- a/libs/streamlib-engine/src/core/context/surface_store.rs
+++ b/libs/streamlib-engine/src/core/context/surface_store.rs
@@ -1171,7 +1171,8 @@ impl SurfaceStoreInner {
                 "plane_offsets": [0u64],
                 "plane_strides": [0u64],
                 "drm_format_modifier": 0u64,
-                "has_sync_fd": sync_fd.is_some(),
+                "has_produce_done_fd": sync_fd.is_some(),
+                "has_consume_done_fd": false,
                 "current_image_layout": current_image_layout.as_vk().as_raw(),
                 "vk_image_type": VK_IMAGE_TYPE_2D,
                 "vk_image_mip_levels": 1u32,
@@ -1210,7 +1211,8 @@ impl SurfaceStoreInner {
                 "plane_offsets": plane_offsets,
                 "plane_strides": plane_strides,
                 "drm_format_modifier": drm_format_modifier,
-                "has_sync_fd": sync_fd.is_some(),
+                "has_produce_done_fd": sync_fd.is_some(),
+                "has_consume_done_fd": false,
                 // The producer's declared `VkImageLayout` (#633): the
                 // layout the texture lives in immediately after
                 // registration, fed to host consumers as the source

--- a/libs/streamlib-engine/src/core/plugin/host_services/input_mailboxes.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/input_mailboxes.rs
@@ -91,29 +91,17 @@ unsafe extern "C" fn host_input_mailboxes_read_raw(
                     return 1;
                 }
             };
-            // The inner's read_raw consumes the frame from the
-            // per-port mailbox. We can't peek non-destructively,
-            // so when the consumer's `out_buf` is too small we
-            // need to either (a) refuse and signal the required
-            // size or (b) consume + lose the frame. Choice (a) is
-            // safer; today's iceoryx2 max payload is bounded so
-            // a 4 KiB initial buffer covers ~all real traffic.
-            //
-            // The pattern: pop, measure, if it fits copy + signal
-            // success; if not, push it back to the head of the
-            // mailbox and signal required size. Today's
-            // PortMailbox doesn't expose push-to-head — the
-            // simplest sound implementation is to drain via
-            // `InputMailboxesInner::read_raw` (which already pops
-            // and returns the bytes), then if the bytes fit copy
-            // them; if not, return the required size and CONSUME
-            // the frame (the consumer's retry sees the next frame
-            // or empty mailbox). Truncation on overflow is the
-            // documented contract; in practice the β-shape's
-            // `read_raw` caller starts with a 4 KiB buffer and
-            // resizes proactively when the host indicates a
-            // larger payload, so the truncation path triggers
-            // only on the rare oversized inbound frame.
+            // The cdylib sizes `out_buf` to the schema's
+            // `max_payload_bytes` (via the v2
+            // `max_payload_for_port` vtable slot) BEFORE calling
+            // read_raw. The iceoryx2 service is sized by the same
+            // bound on the publisher side — the publisher cannot
+            // loan a slot larger than `max_payload_bytes`. So any
+            // popped frame is guaranteed ≤ out_cap by service-
+            // creation invariant. The defensive truncation branch
+            // below surfaces a protocol violation if that
+            // invariant is ever broken (e.g. stale cached max
+            // after a schema change).
             match inner.read_raw(port) {
                 Ok(Some((bytes, ts))) => {
                     let required = bytes.len();
@@ -136,18 +124,25 @@ unsafe extern "C" fn host_input_mailboxes_read_raw(
                         unsafe {
                             std::ptr::copy_nonoverlapping(bytes.as_ptr(), out_buf, required);
                         }
+                        0
                     } else {
-                        // Truncation: indicate required size; the
-                        // consumer resizes and the next call sees
-                        // an empty mailbox (today's pop semantics
-                        // already consumed the frame). The
-                        // alternative (peek + non-destructive
-                        // size measurement) requires reworking
-                        // PortMailbox; deferred to a follow-up
-                        // when the truncation path is hit in
-                        // practice.
+                        // Protocol violation: cdylib's buffer is
+                        // smaller than the schema-declared max.
+                        // Surface loudly — silently dropping would
+                        // re-introduce the pre-v2 silent-loss bug.
+                        write_extern_err(
+                            &format!(
+                                "read_raw: frame ({required} bytes) \
+                                 exceeds cdylib buffer ({out_cap} bytes) \
+                                 — cdylib must size out_buf to \
+                                 max_payload_for_port(port)"
+                            ),
+                            err_buf,
+                            err_buf_cap,
+                            err_len,
+                        );
+                        1
                     }
-                    0
                 }
                 Ok(None) => 0, // has_data stays false
                 Err(e) => {
@@ -223,6 +218,35 @@ pub(crate) unsafe extern "C" fn host_input_mailboxes_drop_arc(handle: *const c_v
     )
 }
 
+unsafe extern "C" fn host_input_mailboxes_max_payload_for_port(
+    handle: *const c_void,
+    port_ptr: *const u8,
+    port_len: usize,
+) -> usize {
+    run_host_extern_c(
+        "host_input_mailboxes_max_payload_for_port",
+        || -> usize {
+            let Some(inner) = (unsafe { handle_as_input_mailboxes_inner(handle) }) else {
+                return 0;
+            };
+            if port_ptr.is_null() {
+                return 0;
+            }
+            let port_bytes = unsafe { std::slice::from_raw_parts(port_ptr, port_len) };
+            let Ok(port) = std::str::from_utf8(port_bytes) else {
+                return 0;
+            };
+            // Returns None for unknown ports → caller's wiring-
+            // error sentinel (0). Returns the per-port value the
+            // compiler op stored via set_port_max_payload_bytes
+            // (defaults to MAX_PAYLOAD_SIZE when wiring left the
+            // default in place).
+            inner.max_payload_for_port(port).unwrap_or(0)
+        },
+        0,
+    )
+}
+
 /// Per-DSO host-side static InputMailboxes dispatch table.
 pub(in crate::core::plugin::host_services) static HOST_INPUT_MAILBOXES_VTABLE:
     streamlib_plugin_abi::InputMailboxesVTable =
@@ -233,6 +257,7 @@ pub(in crate::core::plugin::host_services) static HOST_INPUT_MAILBOXES_VTABLE:
         has_data: host_input_mailboxes_has_data,
         clone_arc: host_input_mailboxes_clone_arc,
         drop_arc: host_input_mailboxes_drop_arc,
+        max_payload_for_port: host_input_mailboxes_max_payload_for_port,
     };
 
 /// Pointer to the [`streamlib_plugin_abi::InputMailboxesVTable`] this

--- a/libs/streamlib-engine/src/core/plugin/host_services/surface_store.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/surface_store.rs
@@ -377,7 +377,8 @@ unsafe extern "C" fn host_ss_register_texture(
     id_ptr: *const u8,
     id_len: usize,
     texture: *const c_void,
-    timeline_handle: *const c_void,
+    produce_done_handle: *const c_void,
+    consume_done_handle: *const c_void,
     layout_raw: i32,
     err_buf: *mut u8,
     err_buf_cap: usize,
@@ -418,21 +419,34 @@ unsafe extern "C" fn host_ss_register_texture(
                     return 1;
                 }
             };
-            // SAFETY: timeline_handle, when non-null, points at the
-            // engine-owned `Arc<HostVulkanTimelineSemaphore>` (passed
-            // by `&Arc<...>` from engine code through `&*` cast).
-            let timeline = unsafe {
-                if timeline_handle.is_null() {
+            // SAFETY: produce_done_handle / consume_done_handle, when
+            // non-null, each point at the engine-owned
+            // `Arc<HostVulkanTimelineSemaphore>` (passed by `&Arc<...>`
+            // from engine code through `&*` cast). The
+            // single-writer-per-edge model is documented in
+            // `docs/architecture/adapter-timeline-single-writer.md`.
+            let produce_done = unsafe {
+                if produce_done_handle.is_null() {
                     None
                 } else {
                     Some(
-                        &*(timeline_handle
+                        &*(produce_done_handle
+                            as *const crate::vulkan::rhi::HostVulkanTimelineSemaphore),
+                    )
+                }
+            };
+            let consume_done = unsafe {
+                if consume_done_handle.is_null() {
+                    None
+                } else {
+                    Some(
+                        &*(consume_done_handle
                             as *const crate::vulkan::rhi::HostVulkanTimelineSemaphore),
                     )
                 }
             };
             let layout = streamlib_consumer_rhi::VulkanLayout(layout_raw);
-            match inner.register_texture(id_str, tex, timeline, layout) {
+            match inner.register_texture(id_str, tex, produce_done, consume_done, layout) {
                 Ok(()) => 0,
                 Err(e) => {
                     write_err(&format!("{}", e), err_buf, err_buf_cap, err_len);
@@ -450,7 +464,8 @@ unsafe extern "C" fn host_ss_register_texture(
     _id_ptr: *const u8,
     _id_len: usize,
     _texture: *const c_void,
-    _timeline_handle: *const c_void,
+    _produce_done_handle: *const c_void,
+    _consume_done_handle: *const c_void,
     _layout_raw: i32,
     err_buf: *mut u8,
     err_buf_cap: usize,
@@ -471,7 +486,8 @@ unsafe extern "C" fn host_ss_register_pixel_buffer_with_timeline(
     id_ptr: *const u8,
     id_len: usize,
     pixel_buffer: *const c_void,
-    timeline_handle: *const c_void,
+    produce_done_handle: *const c_void,
+    consume_done_handle: *const c_void,
     err_buf: *mut u8,
     err_buf_cap: usize,
     err_len: *mut usize,
@@ -511,17 +527,28 @@ unsafe extern "C" fn host_ss_register_pixel_buffer_with_timeline(
                     return 1;
                 }
             };
-            let timeline = unsafe {
-                if timeline_handle.is_null() {
+            let produce_done = unsafe {
+                if produce_done_handle.is_null() {
                     None
                 } else {
                     Some(
-                        &*(timeline_handle
+                        &*(produce_done_handle
                             as *const crate::vulkan::rhi::HostVulkanTimelineSemaphore),
                     )
                 }
             };
-            match inner.register_pixel_buffer_with_timeline(id_str, pb, timeline) {
+            let consume_done = unsafe {
+                if consume_done_handle.is_null() {
+                    None
+                } else {
+                    Some(
+                        &*(consume_done_handle
+                            as *const crate::vulkan::rhi::HostVulkanTimelineSemaphore),
+                    )
+                }
+            };
+            match inner.register_pixel_buffer_with_timeline(id_str, pb, produce_done, consume_done)
+            {
                 Ok(()) => 0,
                 Err(e) => {
                     write_err(&format!("{}", e), err_buf, err_buf_cap, err_len);
@@ -539,7 +566,8 @@ unsafe extern "C" fn host_ss_register_pixel_buffer_with_timeline(
     _id_ptr: *const u8,
     _id_len: usize,
     _pixel_buffer: *const c_void,
-    _timeline_handle: *const c_void,
+    _produce_done_handle: *const c_void,
+    _consume_done_handle: *const c_void,
     err_buf: *mut u8,
     err_buf_cap: usize,
     err_len: *mut usize,
@@ -951,6 +979,7 @@ mod surface_store_vtable_tier1_wire_format_tests {
                 id.len(),
                 std::ptr::null(),
                 std::ptr::null(),
+                std::ptr::null(),
                 0,
                 buf.as_mut_ptr(),
                 buf.len(),
@@ -973,6 +1002,7 @@ mod surface_store_vtable_tier1_wire_format_tests {
                 std::ptr::null(),
                 id.as_ptr(),
                 id.len(),
+                std::ptr::null(),
                 std::ptr::null(),
                 std::ptr::null(),
                 buf.as_mut_ptr(),

--- a/libs/streamlib-engine/src/host_rhi.rs
+++ b/libs/streamlib-engine/src/host_rhi.rs
@@ -235,6 +235,7 @@ impl HostGpuDeviceExt for GpuDevice {
 ///     "id",
 ///     texture,
 ///     None,
+///     None,
 ///     streamlib::sdk::rhi::VulkanLayout::UNDEFINED,
 /// )?;
 /// # Ok(())
@@ -244,27 +245,28 @@ impl HostGpuDeviceExt for GpuDevice {
 /// [`SurfaceStore`]: crate::core::context::SurfaceStore
 #[cfg(target_os = "linux")]
 pub trait HostSurfaceStoreExt {
-    /// Register a texture for cross-process sharing with an optional
-    /// timeline-semaphore (host-side adapter `install_setup_hook`
-    /// path). See
-    /// [`crate::core::context::SurfaceStore`]'s former inherent
-    /// impl for the wire shape; the method body is unchanged, only
-    /// the visibility surface moved here.
+    /// Register a texture for cross-process sharing with the
+    /// single-writer-per-edge timeline pair (`produce_done` signaled
+    /// by the producer, `consume_done` signaled by the consumer).
+    /// See `docs/architecture/adapter-timeline-single-writer.md` for
+    /// the contract.
     fn register_texture(
         &self,
         surface_id: &str,
         texture: &Texture,
-        timeline: Option<&HostVulkanTimelineSemaphore>,
+        produce_done: Option<&HostVulkanTimelineSemaphore>,
+        consume_done: Option<&HostVulkanTimelineSemaphore>,
         current_image_layout: streamlib_consumer_rhi::VulkanLayout,
     ) -> crate::core::error::Result<()>;
 
-    /// Register a pixel buffer with an optional timeline-semaphore
-    /// (host-side adapter `install_setup_hook` path).
+    /// Register a pixel buffer with the single-writer-per-edge
+    /// timeline pair (host-side adapter `install_setup_hook` path).
     fn register_pixel_buffer_with_timeline(
         &self,
         surface_id: &str,
         pixel_buffer: &crate::core::rhi::PixelBuffer,
-        timeline: Option<&HostVulkanTimelineSemaphore>,
+        produce_done: Option<&HostVulkanTimelineSemaphore>,
+        consume_done: Option<&HostVulkanTimelineSemaphore>,
     ) -> crate::core::error::Result<()>;
 }
 
@@ -274,18 +276,31 @@ impl HostSurfaceStoreExt for crate::core::context::SurfaceStore {
         &self,
         surface_id: &str,
         texture: &Texture,
-        timeline: Option<&HostVulkanTimelineSemaphore>,
+        produce_done: Option<&HostVulkanTimelineSemaphore>,
+        consume_done: Option<&HostVulkanTimelineSemaphore>,
         current_image_layout: streamlib_consumer_rhi::VulkanLayout,
     ) -> crate::core::error::Result<()> {
-        self.host_register_texture(surface_id, texture, timeline, current_image_layout)
+        self.host_register_texture(
+            surface_id,
+            texture,
+            produce_done,
+            consume_done,
+            current_image_layout,
+        )
     }
 
     fn register_pixel_buffer_with_timeline(
         &self,
         surface_id: &str,
         pixel_buffer: &crate::core::rhi::PixelBuffer,
-        timeline: Option<&HostVulkanTimelineSemaphore>,
+        produce_done: Option<&HostVulkanTimelineSemaphore>,
+        consume_done: Option<&HostVulkanTimelineSemaphore>,
     ) -> crate::core::error::Result<()> {
-        self.host_register_pixel_buffer_with_timeline(surface_id, pixel_buffer, timeline)
+        self.host_register_pixel_buffer_with_timeline(
+            surface_id,
+            pixel_buffer,
+            produce_done,
+            consume_done,
+        )
     }
 }

--- a/libs/streamlib-engine/src/iceoryx2/input.rs
+++ b/libs/streamlib-engine/src/iceoryx2/input.rs
@@ -116,6 +116,17 @@ impl SendableListener {
 struct PortConfig {
     mailbox: PortMailbox,
     read_mode: ReadMode,
+    /// Schema-declared upper bound on serialized frame size for this
+    /// port — mirrors the value used by the publisher to size the
+    /// iceoryx2 service's slot. The cdylib's `read_raw` queries this
+    /// via the v2 `max_payload_for_port` vtable slot to allocate the
+    /// receive buffer exactly, eliminating the v1 4 KiB-then-retry
+    /// dance. Defaults to [`crate::iceoryx2::MAX_PAYLOAD_SIZE`] when
+    /// the port is added without an explicit max (test paths;
+    /// in-tree wire path overrides via
+    /// [`InputMailboxesInner::set_port_max_payload_bytes`] from the
+    /// compiler op).
+    max_payload_bytes: usize,
 }
 
 /// Host-side inner state for input mailboxes. Owns the per-port
@@ -147,7 +158,15 @@ impl InputMailboxesInner {
         self.ports.lock().contains_key(port)
     }
 
-    /// Add a mailbox for the given port with the specified buffer size and read mode.
+    /// Add a mailbox for the given port with the specified buffer
+    /// size and read mode.
+    ///
+    /// The port's `max_payload_bytes` is set to
+    /// [`crate::iceoryx2::MAX_PAYLOAD_SIZE`] by default — the
+    /// compiler op overrides it via
+    /// [`set_port_max_payload_bytes`] at wire time based on the
+    /// link's schema (`metadata.max_payload_bytes`). The cdylib's
+    /// v2 `max_payload_for_port` vtable slot reads this value.
     pub fn add_port(&self, port: &str, buffer_size: usize, read_mode: ReadMode) {
         tracing::debug!(
             port = port,
@@ -160,8 +179,32 @@ impl InputMailboxesInner {
             PortConfig {
                 mailbox: PortMailbox::new(buffer_size),
                 read_mode,
+                max_payload_bytes: crate::iceoryx2::MAX_PAYLOAD_SIZE,
             },
         );
+    }
+
+    /// Override the schema-declared `metadata.max_payload_bytes`
+    /// for a port that has already been added via [`add_port`].
+    /// Called by the compiler op at wire time after computing the
+    /// link's max via
+    /// `embedded_schemas::max_payload_bytes_for_port_spec`. The
+    /// cdylib's v2 `max_payload_for_port` vtable slot returns this
+    /// value so its `read_raw` allocates exactly.
+    ///
+    /// No-op for unknown ports (the compiler op calls this only
+    /// after [`add_port`] is known to have succeeded).
+    pub fn set_port_max_payload_bytes(&self, port: &str, max_payload_bytes: usize) {
+        if let Some(cfg) = self.ports.lock().get_mut(port) {
+            cfg.max_payload_bytes = max_payload_bytes;
+        }
+    }
+
+    /// Read the per-port `max_payload_bytes` set by the wire path.
+    /// Returns `None` for unknown ports (the v2 vtable callback
+    /// surfaces this as `0`, the caller's wiring-error sentinel).
+    pub fn max_payload_for_port(&self, port: &str) -> Option<usize> {
+        self.ports.lock().get(port).map(|cfg| cfg.max_payload_bytes)
     }
 
     /// Check if a subscriber has already been configured.
@@ -466,61 +509,82 @@ impl InputMailboxes {
     /// Read raw bytes and timestamp from the given port without
     /// deserialization. Returns `Ok(Some((data, timestamp_ns)))` on
     /// success, `Ok(None)` when the mailbox is empty.
+    ///
+    /// Allocates `out_buf` to the schema-declared
+    /// `metadata.max_payload_bytes` for the port (queried via the
+    /// v2 `max_payload_for_port` vtable slot). The iceoryx2 service
+    /// is sized by the same bound on the publisher side, so no
+    /// inbound frame can exceed `out_cap` — truncation is
+    /// structurally impossible and surfaces as a hard error
+    /// (protocol violation).
     pub fn read_raw(&self, port: &str) -> Result<Option<(Vec<u8>, i64)>> {
         if !self.is_configured() {
             return Ok(None);
         }
 
-        // Start with a buffer sized for typical frames (4 KiB —
-        // common audio/control payload size). On truncation we
-        // resize to the required size returned via `*out_len` and
-        // retry; iceoryx2's `MAX_PAYLOAD_SIZE` bounds the worst
-        // case.
-        let mut buf = vec![0u8; 4 * 1024];
-        loop {
-            let mut out_len = 0usize;
-            let mut out_timestamp = 0i64;
-            let mut has_data = false;
-            let mut err_buf = [0u8; 256];
-            let mut err_len = 0usize;
-            // SAFETY: vtable + handle are non-null per is_configured().
-            let rc = unsafe {
-                ((*self.vtable).read_raw)(
-                    self.handle,
-                    port.as_ptr(),
-                    port.len(),
-                    buf.as_mut_ptr(),
-                    buf.len(),
-                    &mut out_len as *mut usize,
-                    &mut out_timestamp as *mut i64,
-                    &mut has_data as *mut bool,
-                    err_buf.as_mut_ptr(),
-                    err_buf.len(),
-                    &mut err_len as *mut usize,
-                )
-            };
-            if rc != 0 {
-                let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
-                    .into_owned();
-                return Err(Error::Link(format!(
-                    "InputMailboxes::read_raw(port='{}') failed: {}",
-                    port, msg
-                )));
-            }
-            if !has_data {
-                return Ok(None);
-            }
-            if out_len > buf.len() {
-                // Caller's buffer too small; resize and retry. The
-                // host's `read_raw` host wrapper guarantees the
-                // frame is NOT consumed on truncation, so the retry
-                // sees the same frame.
-                buf = vec![0u8; out_len];
-                continue;
-            }
-            buf.truncate(out_len);
-            return Ok(Some((buf, out_timestamp)));
+        // SAFETY: vtable + handle are non-null per is_configured().
+        let max_payload = unsafe {
+            ((*self.vtable).max_payload_for_port)(self.handle, port.as_ptr(), port.len())
+        };
+        if max_payload == 0 {
+            return Err(Error::Link(format!(
+                "InputMailboxes::read_raw(port='{}'): max_payload_for_port \
+                 returned 0 — port is not registered (wiring error: was \
+                 add_port called on this side of the link?)",
+                port
+            )));
         }
+
+        let mut buf = vec![0u8; max_payload];
+        let mut out_len = 0usize;
+        let mut out_timestamp = 0i64;
+        let mut has_data = false;
+        let mut err_buf = [0u8; 256];
+        let mut err_len = 0usize;
+        // SAFETY: vtable + handle are non-null per is_configured().
+        let rc = unsafe {
+            ((*self.vtable).read_raw)(
+                self.handle,
+                port.as_ptr(),
+                port.len(),
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut out_len as *mut usize,
+                &mut out_timestamp as *mut i64,
+                &mut has_data as *mut bool,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if rc != 0 {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            return Err(Error::Link(format!(
+                "InputMailboxes::read_raw(port='{}') failed: {}",
+                port, msg
+            )));
+        }
+        if !has_data {
+            return Ok(None);
+        }
+        // Truncation is impossible by service-creation invariant
+        // (publisher can't loan slot > max_payload, and we sized
+        // our buffer to max_payload). Defensive check so a future
+        // protocol mismatch surfaces loudly rather than silently
+        // corrupting downstream deserialization.
+        if out_len > buf.len() {
+            return Err(Error::Link(format!(
+                "InputMailboxes::read_raw(port='{}'): host returned frame \
+                 of {} bytes exceeding the queried max_payload {} — \
+                 protocol violation",
+                port,
+                out_len,
+                buf.len()
+            )));
+        }
+        buf.truncate(out_len);
+        Ok(Some((buf, out_timestamp)))
     }
 
     /// Check if a port has any payloads available.

--- a/libs/streamlib-engine/src/linux/surface_share/state.rs
+++ b/libs/streamlib-engine/src/linux/surface_share/state.rs
@@ -55,15 +55,30 @@ pub struct SurfaceMetadata {
     /// from the EGL `external_only=FALSE` set; otherwise consumer-side
     /// FBO completeness will fail on NVIDIA.
     pub drm_format_modifier: u64,
-    /// Optional OPAQUE_FD timeline-semaphore handle owned by the table.
-    /// Set when the host registers the surface with an exportable
-    /// `HostVulkanTimelineSemaphore` (#531). `check_out` / `lookup` `dup`s it
-    /// alongside the DMA-BUF plane fds so the subprocess Vulkan adapter
-    /// can call `HostVulkanTimelineSemaphore::from_imported_opaque_fd` and
-    /// reuse the host adapter's timeline-wait + signal path. `None` for
-    /// surfaces that don't need explicit Vulkan sync (the OpenGL adapter
-    /// path, CPU-readback, legacy `VkBuffer` pixel buffers).
-    pub sync_fd: Option<RawFd>,
+    /// Optional OPAQUE_FD timeline-semaphore handle for the `produce_done`
+    /// edge — signaled by the producer process when GPU writes complete,
+    /// waited on by the consumer before reading. The host always owns the
+    /// underlying `HostVulkanTimelineSemaphore`; consumers import the FD
+    /// via `ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd` (in
+    /// subprocess adapters) or `HostVulkanTimelineSemaphore::from_imported_opaque_fd`
+    /// (host adapters consuming a peer surface). `None` for surfaces that
+    /// don't need explicit Vulkan sync (the OpenGL adapter path, legacy
+    /// `VkBuffer` pixel buffers without dual-timeline coordination).
+    ///
+    /// Half of the single-writer-per-edge pair documented in
+    /// `docs/architecture/adapter-timeline-single-writer.md`; the
+    /// consumer-side companion lives in [`Self::consume_done_fd`].
+    pub produce_done_fd: Option<RawFd>,
+    /// Optional OPAQUE_FD timeline-semaphore handle for the `consume_done`
+    /// edge — signaled by the consumer process when consumption completes,
+    /// waited on by the producer before re-writing. Host-allocated like
+    /// [`Self::produce_done_fd`] (cdylib consumers can't allocate exportable
+    /// memory per the import-side carve-out); the consumer process imports
+    /// the FD and signals it via host-CPU `vkSignalSemaphore`. `None` for
+    /// surfaces that don't need the producer-side drain-wait — typically
+    /// the same surfaces that have `produce_done_fd = None`, but they're
+    /// independent options.
+    pub consume_done_fd: Option<RawFd>,
     pub checkout_count: u64,
     /// Cross-process Vulkan-image-layout (i32 per `VkImageLayout`), the
     /// **single source of truth for cross-process layout state** — same
@@ -132,7 +147,8 @@ impl Clone for SurfaceMetadata {
             resource_type: self.resource_type.clone(),
             handle_type: self.handle_type.clone(),
             drm_format_modifier: self.drm_format_modifier,
-            sync_fd: self.sync_fd,
+            produce_done_fd: self.produce_done_fd,
+            consume_done_fd: self.consume_done_fd,
             checkout_count: self.checkout_count,
             current_image_layout: AtomicI32::new(
                 self.current_image_layout.load(Ordering::Acquire),
@@ -190,11 +206,16 @@ pub struct SurfacePlaneCheckout {
     /// on this value: `"dma_buf"` → `from_dma_buf_fds`, `"opaque_fd"` →
     /// `from_opaque_fd`.
     pub handle_type: String,
-    /// Optional OPAQUE_FD for the surface's exportable timeline semaphore.
-    /// `None` for surfaces registered without one. The table-owned fd is
-    /// returned as-is; callers that hand it out via SCM_RIGHTS must `dup`
-    /// it first, just like the memory fds.
-    pub sync_fd: Option<RawFd>,
+    /// Optional OPAQUE_FD for the producer-side `produce_done` timeline
+    /// semaphore — see [`SurfaceMetadata::produce_done_fd`]. `None` for
+    /// surfaces registered without one. The table-owned fd is returned
+    /// as-is; callers that hand it out via SCM_RIGHTS must `dup` it
+    /// first, just like the memory fds.
+    pub produce_done_fd: Option<RawFd>,
+    /// Optional OPAQUE_FD for the consumer-side `consume_done` timeline
+    /// semaphore — see [`SurfaceMetadata::consume_done_fd`]. Same
+    /// table-owned-fd semantics as [`Self::produce_done_fd`].
+    pub consume_done_fd: Option<RawFd>,
     /// Snapshot of the surface's [`SurfaceMetadata::current_image_layout`]
     /// at lookup time (i32 per `VkImageLayout`). Consumers feed this into
     /// the source layout of their first QFOT acquire barrier. `0`
@@ -239,11 +260,19 @@ pub struct SurfaceRegistration<'a> {
     /// DRM format modifier of the underlying VkImage. See
     /// [`SurfaceMetadata::drm_format_modifier`].
     pub drm_format_modifier: u64,
-    /// Optional OPAQUE_FD timeline-semaphore handle exported by the host
-    /// (`HostVulkanTimelineSemaphore::export_opaque_fd`). The table takes
-    /// ownership on success and closes it on `release_surface`. `None`
-    /// for adapters that don't need explicit Vulkan sync.
-    pub sync_fd: Option<RawFd>,
+    /// Optional OPAQUE_FD timeline-semaphore handle for the producer-side
+    /// `produce_done` edge (`HostVulkanTimelineSemaphore::export_opaque_fd`).
+    /// The table takes ownership on success and closes it on
+    /// `release_surface`. `None` for adapters that don't need explicit
+    /// Vulkan sync. See [`SurfaceMetadata::produce_done_fd`] for the
+    /// full single-writer-per-edge contract.
+    pub produce_done_fd: Option<RawFd>,
+    /// Optional OPAQUE_FD timeline-semaphore handle for the consumer-side
+    /// `consume_done` edge. Same ownership semantics as
+    /// [`Self::produce_done_fd`]. `None` for surfaces that don't carry a
+    /// consumer-side signal channel (e.g. one-shot setup surfaces, or
+    /// pre-single-writer-lift legacy registrations).
+    pub consume_done_fd: Option<RawFd>,
     /// Initial `VkImageLayout` (i32) to seed
     /// [`SurfaceMetadata::current_image_layout`]. Producers that publish
     /// in a known steady-state layout (camera, OpenGL adapter wiring,
@@ -286,19 +315,20 @@ impl SurfaceShareState {
 
     /// Insert a surface into the table.
     ///
-    /// On rejection (duplicate surface_id), ownership of `dma_buf_fds` AND
-    /// the optional `sync_fd` is returned to the caller (the latter as the
-    /// `Err` tuple's second slot) so it can decide whether to close them or
-    /// hand them to the next attempt. On success, the table owns every fd
-    /// passed in and closes them on [`Self::release_surface`].
+    /// On rejection (duplicate surface_id), ownership of `dma_buf_fds`,
+    /// `produce_done_fd`, and `consume_done_fd` is returned to the caller
+    /// (the timeline FDs as the `Err` tuple's second and third slots) so
+    /// it can decide whether to close them or hand them to the next
+    /// attempt. On success, the table owns every fd passed in and closes
+    /// them on [`Self::release_surface`].
     pub fn register_surface(
         &self,
         reg: SurfaceRegistration<'_>,
-    ) -> Result<(), (Vec<RawFd>, Option<RawFd>)> {
+    ) -> Result<(), (Vec<RawFd>, Option<RawFd>, Option<RawFd>)> {
         let mut surfaces = self.inner.surfaces.write();
 
         if surfaces.contains_key(reg.surface_id) {
-            return Err((reg.dma_buf_fds, reg.sync_fd));
+            return Err((reg.dma_buf_fds, reg.produce_done_fd, reg.consume_done_fd));
         }
 
         self.inner.surface_counter.fetch_add(1, Ordering::Relaxed);
@@ -318,7 +348,8 @@ impl SurfaceShareState {
                 resource_type: reg.resource_type.to_string(),
                 handle_type: reg.handle_type.to_string(),
                 drm_format_modifier: reg.drm_format_modifier,
-                sync_fd: reg.sync_fd,
+                produce_done_fd: reg.produce_done_fd,
+                consume_done_fd: reg.consume_done_fd,
                 checkout_count: 0,
                 current_image_layout: AtomicI32::new(reg.current_image_layout),
                 vk_image_type: reg.vk_image_type,
@@ -371,7 +402,8 @@ impl SurfaceShareState {
                 plane_strides: metadata.plane_strides.clone(),
                 drm_format_modifier: metadata.drm_format_modifier,
                 handle_type: metadata.handle_type.clone(),
-                sync_fd: metadata.sync_fd,
+                produce_done_fd: metadata.produce_done_fd,
+                consume_done_fd: metadata.consume_done_fd,
                 current_image_layout: metadata
                     .current_image_layout
                     .load(Ordering::Acquire),
@@ -393,8 +425,11 @@ impl SurfaceShareState {
                 for fd in &metadata.dma_buf_fds {
                     unsafe { libc::close(*fd) };
                 }
-                if let Some(sync_fd) = metadata.sync_fd {
-                    unsafe { libc::close(sync_fd) };
+                if let Some(fd) = metadata.produce_done_fd {
+                    unsafe { libc::close(fd) };
+                }
+                if let Some(fd) = metadata.consume_done_fd {
+                    unsafe { libc::close(fd) };
                 }
                 surfaces.remove(surface_id);
                 return true;
@@ -438,7 +473,8 @@ mod tests {
             resource_type,
             handle_type: "dma_buf",
             drm_format_modifier: 0,
-            sync_fd: None,
+            produce_done_fd: None,
+            consume_done_fd: None,
             current_image_layout: 0,
             vk_image_type: VK_IMAGE_TYPE_DEFAULT,
             vk_image_mip_levels: VK_IMAGE_MIP_LEVELS_DEFAULT,
@@ -472,11 +508,12 @@ mod tests {
     fn duplicate_surface_id_rejected() {
         let state = SurfaceShareState::new();
         assert!(state.register_surface(reg("dup", "rt", "texture")).is_ok());
-        let (rejected_planes, rejected_sync) = state
+        let (rejected_planes, rejected_produce, rejected_consume) = state
             .register_surface(reg("dup", "rt", "texture"))
             .expect_err("duplicate must be rejected");
         assert_eq!(rejected_planes, vec![-1], "rejected plane fds returned to caller");
-        assert_eq!(rejected_sync, None, "no sync fd was registered, none returned");
+        assert_eq!(rejected_produce, None, "no produce_done fd was registered, none returned");
+        assert_eq!(rejected_consume, None, "no consume_done fd was registered, none returned");
     }
 
     /// The watchdog uses `surface_ids_by_runtime` to discover what to
@@ -587,7 +624,8 @@ mod tests {
                 resource_type: "texture",
                 handle_type: "opaque_fd",
                 drm_format_modifier: 0,
-                sync_fd: None,
+                produce_done_fd: None,
+            consume_done_fd: None,
                 current_image_layout: 0,
                 vk_image_type: 2,        // VK_IMAGE_TYPE_3D
                 vk_image_mip_levels: 9,  // 256 = 2^8, plus base = 9 levels
@@ -649,7 +687,8 @@ mod tests {
                 resource_type: "pixel_buffer",
                 handle_type: "dma_buf",
                 drm_format_modifier: 0,
-                sync_fd: None,
+                produce_done_fd: None,
+            consume_done_fd: None,
                 current_image_layout: 0,
                 vk_image_type: VK_IMAGE_TYPE_DEFAULT,
                 vk_image_mip_levels: VK_IMAGE_MIP_LEVELS_DEFAULT,

--- a/libs/streamlib-engine/src/linux/surface_share/unix_socket_service.rs
+++ b/libs/streamlib-engine/src/linux/surface_share/unix_socket_service.rs
@@ -361,21 +361,34 @@ fn handle_register(
         .and_then(|v| v.as_str())
         .unwrap_or("unknown");
 
-    // Peel off the optional trailing sync-FD (#531). The host signals its
-    // presence via the JSON `has_sync_fd: true` flag; the FD itself sits
-    // last in the SCM_RIGHTS list, after every DMA-BUF plane FD.
-    let has_sync_fd = request
-        .get("has_sync_fd")
+    // Peel off the optional trailing timeline FDs in the order the host
+    // attached them: plane FDs first, then `produce_done` (if present),
+    // then `consume_done` (if present). The wire signals each timeline's
+    // presence via a JSON boolean (`has_produce_done_fd`,
+    // `has_consume_done_fd`); the SCM_RIGHTS slot count matches the sum.
+    // The single-writer-per-edge model is documented in
+    // `docs/architecture/adapter-timeline-single-writer.md`.
+    let has_produce_done_fd = request
+        .get("has_produce_done_fd")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
-    let plane_count = if has_sync_fd {
-        received_fds.len().saturating_sub(1)
-    } else {
-        received_fds.len()
-    };
+    let has_consume_done_fd = request
+        .get("has_consume_done_fd")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let trailing_fd_count = (has_produce_done_fd as usize) + (has_consume_done_fd as usize);
+    let plane_count = received_fds.len().saturating_sub(trailing_fd_count);
     let plane_fds: &[RawFd] = &received_fds[..plane_count];
-    let sync_src_fd: Option<RawFd> = if has_sync_fd {
-        received_fds.get(plane_count).copied()
+    let mut trailing_idx = plane_count;
+    let produce_done_src_fd: Option<RawFd> = if has_produce_done_fd {
+        let fd = received_fds.get(trailing_idx).copied();
+        trailing_idx += 1;
+        fd
+    } else {
+        None
+    };
+    let consume_done_src_fd: Option<RawFd> = if has_consume_done_fd {
+        received_fds.get(trailing_idx).copied()
     } else {
         None
     };
@@ -397,9 +410,19 @@ fn handle_register(
             Vec::new(),
         );
     }
-    if has_sync_fd && sync_src_fd.is_none() {
+    if has_produce_done_fd && produce_done_src_fd.is_none() {
         return (
-            serde_json::json!({"error": "has_sync_fd=true but no trailing sync FD attached"}),
+            serde_json::json!({
+                "error": "has_produce_done_fd=true but no trailing produce_done FD attached"
+            }),
+            Vec::new(),
+        );
+    }
+    if has_consume_done_fd && consume_done_src_fd.is_none() {
+        return (
+            serde_json::json!({
+                "error": "has_consume_done_fd=true but no trailing consume_done FD attached"
+            }),
             Vec::new(),
         );
     }
@@ -462,7 +485,7 @@ fn handle_register(
         dup_plane_fds.push(dup_fd);
     }
 
-    let dup_sync_fd: Option<RawFd> = match sync_src_fd {
+    let dup_produce_done_fd: Option<RawFd> = match produce_done_src_fd {
         Some(src) => {
             let dup = unsafe { libc::dup(src) };
             if dup < 0 {
@@ -470,7 +493,26 @@ fn handle_register(
                     unsafe { libc::close(*d) };
                 }
                 return (
-                    serde_json::json!({"error": "failed to dup sync FD"}),
+                    serde_json::json!({"error": "failed to dup produce_done FD"}),
+                    Vec::new(),
+                );
+            }
+            Some(dup)
+        }
+        None => None,
+    };
+    let dup_consume_done_fd: Option<RawFd> = match consume_done_src_fd {
+        Some(src) => {
+            let dup = unsafe { libc::dup(src) };
+            if dup < 0 {
+                for d in &dup_plane_fds {
+                    unsafe { libc::close(*d) };
+                }
+                if let Some(fd) = dup_produce_done_fd {
+                    unsafe { libc::close(fd) };
+                }
+                return (
+                    serde_json::json!({"error": "failed to dup consume_done FD"}),
                     Vec::new(),
                 );
             }
@@ -492,7 +534,8 @@ fn handle_register(
         resource_type,
         handle_type,
         drm_format_modifier,
-        sync_fd: dup_sync_fd,
+        produce_done_fd: dup_produce_done_fd,
+        consume_done_fd: dup_consume_done_fd,
         current_image_layout,
         vk_image_type: vk_image.vk_image_type,
         vk_image_mip_levels: vk_image.vk_image_mip_levels,
@@ -504,19 +547,24 @@ fn handle_register(
     }) {
         Ok(()) => {
             tracing::debug!(
-                "[Surface share] register: surface '{}' for runtime '{}' ({} plane(s), sync_fd={})",
+                "[Surface share] register: surface '{}' for runtime '{}' ({} plane(s), \
+                 produce_done={}, consume_done={})",
                 surface_id,
                 runtime_id,
                 plane_fds.len(),
-                has_sync_fd,
+                has_produce_done_fd,
+                has_consume_done_fd,
             );
             (serde_json::json!({"success": true}), Vec::new())
         }
-        Err((leftover_planes, leftover_sync)) => {
+        Err((leftover_planes, leftover_produce, leftover_consume)) => {
             for fd in &leftover_planes {
                 unsafe { libc::close(*fd) };
             }
-            if let Some(fd) = leftover_sync {
+            if let Some(fd) = leftover_produce {
+                unsafe { libc::close(fd) };
+            }
+            if let Some(fd) = leftover_consume {
                 unsafe { libc::close(fd) };
             }
             tracing::warn!(
@@ -545,7 +593,7 @@ fn handle_lookup(
     // Dup each stored fd so the kernel-delivered fds in the peer's table are
     // independent of the table's own copies. On partial failure, close every
     // dup we already took.
-    let mut dup_fds: Vec<RawFd> = Vec::with_capacity(checkout.dma_buf_fds.len() + 1);
+    let mut dup_fds: Vec<RawFd> = Vec::with_capacity(checkout.dma_buf_fds.len() + 2);
     for fd in &checkout.dma_buf_fds {
         let dup = unsafe { libc::dup(*fd) };
         if dup < 0 {
@@ -560,19 +608,35 @@ fn handle_lookup(
         dup_fds.push(dup);
     }
 
-    // Append a dup of the timeline-semaphore OPAQUE_FD when the surface
-    // was registered with one (#531). Subprocess clients detect its
-    // presence via `has_sync_fd` in the response JSON and peel the
-    // trailing FD off the SCM_RIGHTS list.
-    let has_sync_fd = checkout.sync_fd.is_some();
-    if let Some(src_sync) = checkout.sync_fd {
-        let dup = unsafe { libc::dup(src_sync) };
+    // Append dups of the producer-side `produce_done` and consumer-side
+    // `consume_done` timeline-semaphore OPAQUE_FDs in that order. Subprocess
+    // clients detect each one's presence via the matching boolean flag in
+    // the response JSON and peel the trailing FDs off the SCM_RIGHTS list
+    // in the same order. See
+    // `docs/architecture/adapter-timeline-single-writer.md`.
+    let has_produce_done_fd = checkout.produce_done_fd.is_some();
+    let has_consume_done_fd = checkout.consume_done_fd.is_some();
+    if let Some(src) = checkout.produce_done_fd {
+        let dup = unsafe { libc::dup(src) };
         if dup < 0 {
             for d in &dup_fds {
                 unsafe { libc::close(*d) };
             }
             return (
-                serde_json::json!({"error": "failed to dup sync FD"}),
+                serde_json::json!({"error": "failed to dup produce_done FD"}),
+                Vec::new(),
+            );
+        }
+        dup_fds.push(dup);
+    }
+    if let Some(src) = checkout.consume_done_fd {
+        let dup = unsafe { libc::dup(src) };
+        if dup < 0 {
+            for d in &dup_fds {
+                unsafe { libc::close(*d) };
+            }
+            return (
+                serde_json::json!({"error": "failed to dup consume_done FD"}),
                 Vec::new(),
             );
         }
@@ -597,7 +661,8 @@ fn handle_lookup(
             "plane_offsets": checkout.plane_offsets,
             "plane_strides": checkout.plane_strides,
             "drm_format_modifier": checkout.drm_format_modifier,
-            "has_sync_fd": has_sync_fd,
+            "has_produce_done_fd": has_produce_done_fd,
+            "has_consume_done_fd": has_consume_done_fd,
             "current_image_layout": checkout.current_image_layout,
             // VkImageCreateInfo round-trip for OPAQUE_FD VkImage
             // consumers. Always echoed; absent producers see the
@@ -741,40 +806,47 @@ fn handle_check_in(
         dup_fds.push(dup);
     }
 
-    if let Err((leftover_planes, leftover_sync)) = state.register_surface(SurfaceRegistration {
-        surface_id: &surface_id,
-        runtime_id,
-        dma_buf_fds: dup_fds,
-        plane_sizes,
-        plane_offsets,
-        plane_strides,
-        width,
-        height,
-        format,
-        resource_type,
-        handle_type,
-        drm_format_modifier,
-        // check_in is the subprocess-registers-pixel-buffer path used by
-        // CPU-readback / legacy DMA-BUF consumers. None of those need
-        // explicit Vulkan timeline sync — the wire format reserves the
-        // option for the host-registers-render-target-texture path.
-        sync_fd: None,
-        // check_in surfaces are pixel buffers — `VkBuffer`s have no
-        // image layout. Seed UNDEFINED; the field is unused for buffer
-        // surfaces but must be populated for the wire format.
-        current_image_layout: 0,
-        vk_image_type: vk_image.vk_image_type,
-        vk_image_mip_levels: vk_image.vk_image_mip_levels,
-        vk_image_array_layers: vk_image.vk_image_array_layers,
-        vk_image_samples: vk_image.vk_image_samples,
-        vk_image_tiling: vk_image.vk_image_tiling,
-        vk_image_usage: vk_image.vk_image_usage,
-        vk_image_allocation_size: vk_image.vk_image_allocation_size,
-    }) {
+    if let Err((leftover_planes, leftover_produce, leftover_consume)) =
+        state.register_surface(SurfaceRegistration {
+            surface_id: &surface_id,
+            runtime_id,
+            dma_buf_fds: dup_fds,
+            plane_sizes,
+            plane_offsets,
+            plane_strides,
+            width,
+            height,
+            format,
+            resource_type,
+            handle_type,
+            drm_format_modifier,
+            // check_in is the subprocess-registers-pixel-buffer path used by
+            // CPU-readback / legacy DMA-BUF consumers. None of those carry
+            // their own timelines through this op — host-registered
+            // render-target paths (`handle_register`) provide the
+            // single-writer-per-edge `produce_done` / `consume_done` FDs.
+            produce_done_fd: None,
+            consume_done_fd: None,
+            // check_in surfaces are pixel buffers — `VkBuffer`s have no
+            // image layout. Seed UNDEFINED; the field is unused for buffer
+            // surfaces but must be populated for the wire format.
+            current_image_layout: 0,
+            vk_image_type: vk_image.vk_image_type,
+            vk_image_mip_levels: vk_image.vk_image_mip_levels,
+            vk_image_array_layers: vk_image.vk_image_array_layers,
+            vk_image_samples: vk_image.vk_image_samples,
+            vk_image_tiling: vk_image.vk_image_tiling,
+            vk_image_usage: vk_image.vk_image_usage,
+            vk_image_allocation_size: vk_image.vk_image_allocation_size,
+        })
+    {
         for fd in &leftover_planes {
             unsafe { libc::close(*fd) };
         }
-        if let Some(fd) = leftover_sync {
+        if let Some(fd) = leftover_produce {
+            unsafe { libc::close(fd) };
+        }
+        if let Some(fd) = leftover_consume {
             unsafe { libc::close(fd) };
         }
     }
@@ -1344,7 +1416,8 @@ mod tests {
                     resource_type: "pixel_buffer",
                     handle_type: "dma_buf",
                     drm_format_modifier: 0,
-                    sync_fd: None,
+                    produce_done_fd: None,
+                    consume_done_fd: None,
                     current_image_layout: 0,
                     vk_image_type: VK_IMAGE_TYPE_DEFAULT,
                     vk_image_mip_levels: VK_IMAGE_MIP_LEVELS_DEFAULT,

--- a/libs/streamlib-engine/src/vulkan/rhi/host_marker.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/host_marker.rs
@@ -66,6 +66,9 @@ mod placeholder {
         fn signal_host(&self, _value: u64) -> streamlib_consumer_rhi::Result<()> {
             match *self {}
         }
+        fn current_value(&self) -> streamlib_consumer_rhi::Result<u64> {
+            match *self {}
+        }
         fn semaphore(&self) -> vulkanalia::vk::Semaphore {
             match *self {}
         }

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_sync.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_sync.rs
@@ -444,46 +444,23 @@ impl HostVulkanTimelineSemaphore {
         }
     }
 
-    /// Host-side signal: advance the counter to **at least** `value`
-    /// from the CPU. Used when the producer has finished writing on
-    /// the host side and wants to release the surface to the next
-    /// consumer.
+    /// Host-side signal: advance the counter to `value` from the CPU.
+    /// Used when the producer has finished writing on the host side
+    /// and wants to release the surface to the next consumer.
     ///
-    /// Self-correcting against cross-process timeline advancement.
-    /// Mirrors the consumer-rhi
-    /// [`ConsumerVulkanTimelineSemaphore::signal_host`](streamlib_consumer_rhi::ConsumerVulkanTimelineSemaphore::signal_host)
-    /// clamp: if the shared `vk::Semaphore` has been advanced past
-    /// `value` by another writer (the subprocess consumer signaling
-    /// via the imported timeline, or a different host queue submit),
-    /// this call signals at `current_value() + 1` so the timeline
-    /// always advances and the spec's strictly-greater rule
-    /// (`VUID-VkSemaphoreSignalInfo-value-03258`) is met. The
-    /// semantic contract — "the timeline is at least `value` after
-    /// this returns" — holds whether we signal at the requested value
-    /// or at a higher clamped value. Adapter-level per-process state
-    /// tracking (e.g. `state.current_release_value` in surface
-    /// adapters) may drift from vk reality across cross-process
-    /// timeline advancements; the clamp is the safety net until
-    /// single-writer timelines land per producer/consumer edge.
+    /// Single-writer-per-edge per
+    /// `docs/architecture/adapter-timeline-single-writer.md`: only
+    /// one process ever signals a given timeline, so `value` is
+    /// strictly greater than the current value by construction and
+    /// VUID-VkSemaphoreSignalInfo-value-03258 holds without runtime
+    /// clamping.
     pub fn signal_host(&self, value: u64) -> Result<()> {
-        let current = HostVulkanTimelineSemaphore::current_value(self).unwrap_or(0);
-        let actual_value = std::cmp::max(value, current.saturating_add(1));
-        if actual_value != value {
-            tracing::warn!(
-                target: "host_rhi::timeline",
-                requested_value = value,
-                current_value = current,
-                actual_value,
-                "signal_host: clamping to actual_value > requested (cross-process \
-                 advancement of shared timeline OR adapter-state lag)."
-            );
-        }
         let info = vk::SemaphoreSignalInfo::builder()
             .semaphore(self.semaphore)
-            .value(actual_value)
+            .value(value)
             .build();
         unsafe { self.device.signal_semaphore(&info) }.map_err(|e| {
-            Error::GpuError(format!("vkSignalSemaphore(value={actual_value}): {e}"))
+            Error::GpuError(format!("vkSignalSemaphore(value={value}): {e}"))
         })
     }
 

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_sync.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_sync.rs
@@ -528,6 +528,10 @@ impl super::VulkanTimelineSemaphoreLike for HostVulkanTimelineSemaphore {
         HostVulkanTimelineSemaphore::signal_host(self, value)
             .map_err(|e| streamlib_consumer_rhi::ConsumerRhiError::Gpu(e.to_string()))
     }
+    fn current_value(&self) -> streamlib_consumer_rhi::Result<u64> {
+        HostVulkanTimelineSemaphore::current_value(self)
+            .map_err(|e| streamlib_consumer_rhi::ConsumerRhiError::Gpu(e.to_string()))
+    }
     fn semaphore(&self) -> vulkanalia::vk::Semaphore {
         HostVulkanTimelineSemaphore::semaphore(self)
     }

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_tone_mapper.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_tone_mapper.rs
@@ -128,9 +128,20 @@ impl VulkanToneMapper {
         // VUID-VkImageMemoryBarrier2-oldLayout-01197 twice per submit.
         // Catch the misuse here rather than as validation noise 60
         // frames downstream.
-        if let (Some(src_image), Some(dst_image)) =
-            (src.vulkan_inner().image(), dst.vulkan_inner().image())
-        {
+        //
+        // `vulkan_inner()` routes through `Texture::host_inner()`,
+        // which panics in cdylib mode by design — the host owns the
+        // RHI and cdylib code must reach `HostVulkanTexture` through
+        // the FullAccess vtable. `host_vulkan_texture_arc()` is the
+        // documented cdylib-safe accessor: in host mode it
+        // `Arc::clone`s the inner directly; in cdylib mode it
+        // dispatches through the v10 FullAccess vtable slot so the
+        // host returns its own `Arc<HostVulkanTexture>` and the
+        // `VkImage` compare runs against the real host-side handles.
+        if let (Some(src_image), Some(dst_image)) = (
+            src.host_vulkan_texture_arc()?.image(),
+            dst.host_vulkan_texture_arc()?.image(),
+        ) {
             if src_image == dst_image {
                 return Err(Error::Configuration(
                     "VulkanToneMapper::apply_with_layouts: src and dst must be distinct VkImages (in-place tone-map is not supported)".into(),

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -699,8 +699,12 @@ mod layout_tests {
         // v1 (issue #894): initial shape — `write_raw`, `has_port`,
         // `clone_arc`, `drop_arc`.
         assert_eq!(OUTPUT_WRITER_VTABLE_LAYOUT_VERSION, 1);
-        // v1 (issue #894): initial shape — `read_raw`, `has_data`.
-        assert_eq!(INPUT_MAILBOXES_VTABLE_LAYOUT_VERSION, 1);
+        // v2 (#1097 audio-mixer-demo silent-output fix): appends
+        // `max_payload_for_port` so cdylib `read_raw` allocates
+        // exactly the schema-declared `metadata.max_payload_bytes`
+        // and never truncates. Slots: `read_raw`, `has_data`,
+        // `clone_arc`, `drop_arc`, `max_payload_for_port`.
+        assert_eq!(INPUT_MAILBOXES_VTABLE_LAYOUT_VERSION, 2);
     }
 
     #[test]

--- a/libs/streamlib-plugin-abi/src/vtables/input_mailboxes.rs
+++ b/libs/streamlib-plugin-abi/src/vtables/input_mailboxes.rs
@@ -14,12 +14,17 @@ use core::ffi::c_void;
 ///   queries without consuming), plus the Arc lifecycle pair
 ///   (`clone_arc` / `drop_arc`) every Arc-handle β-shape on this
 ///   ABI carries for refcount accounting in host-compiled code.
-///   All other `InputMailboxesInner` methods (`add_port`,
-///   `set_subscriber`, `set_listener`, `listener_fd`,
-///   `drain_listener`, `receive_pending`, `route`,
-///   `any_port_has_data`) are host-side only and don't need
-///   vtable slots.
-pub const INPUT_MAILBOXES_VTABLE_LAYOUT_VERSION: u32 = 1;
+/// - v2: appends `max_payload_for_port` so the cdylib can allocate
+///   exactly the schema-declared `metadata.max_payload_bytes` for
+///   each port up-front. The publisher side already honors this
+///   value (the iceoryx2 service is sized by it; the publisher
+///   can't loan a bigger slot), so the cdylib's read buffer is
+///   guaranteed sufficient by service-creation invariant — no
+///   truncation, no retry loop. Replaces the v1 4 KiB scratch +
+///   "resize and retry on truncation" dance that silently dropped
+///   every >4 KiB frame for ~4 days post-#894 (audio-mixer-demo
+///   silent-output bug).
+pub const INPUT_MAILBOXES_VTABLE_LAYOUT_VERSION: u32 = 2;
 
 /// `extern "C" fn` dispatch table for the cdylib's `InputMailboxes`
 /// β-shape. Replaces the shared-Rust-type `&mut InputMailboxes`
@@ -47,11 +52,16 @@ pub const INPUT_MAILBOXES_VTABLE_LAYOUT_VERSION: u32 = 1;
 /// On success, `*has_data` distinguishes "consumed a frame"
 /// (`true`) from "no frames queued" (`false`). When `*has_data ==
 /// true`, the callee writes the raw msgpack-encoded frame body to
-/// `out_buf` and the timestamp to `*out_timestamp`. Truncation is
-/// signaled by `*out_len > out_cap` and is treated as an error by
-/// the cdylib (it resizes the buffer and retries).
+/// `out_buf` and the timestamp to `*out_timestamp`. The cdylib is
+/// expected to size `out_buf` to the value returned by
+/// `max_payload_for_port` for the port — the iceoryx2 service is
+/// sized by the same schema-declared `metadata.max_payload_bytes`
+/// on the publisher side, so any actual frame body is guaranteed
+/// ≤ that bound by service-creation invariant. Truncation
+/// (`required > out_cap`) is now a protocol violation and surfaces
+/// as a non-zero return.
 ///
-/// `has_data` is infallible.
+/// `has_data` and `max_payload_for_port` are infallible.
 #[repr(C)]
 pub struct InputMailboxesVTable {
     /// Vtable layout version. Must equal
@@ -73,9 +83,11 @@ pub struct InputMailboxesVTable {
     ///   and the frame's monotonic timestamp to `*out_timestamp`.
     /// - `*has_data = false` if the mailbox was empty.
     ///
-    /// If the frame body is larger than `out_cap`, `*out_len` is
-    /// set to the **required** length and the data is not copied —
-    /// the cdylib resizes its buffer and retries.
+    /// The cdylib must size `out_buf` to the value returned by
+    /// `max_payload_for_port` for the port. If a frame body
+    /// exceeds `out_cap`, the call returns non-zero with an error
+    /// in `err_buf` — this indicates either a protocol violation
+    /// or a stale cached max from before a schema change.
     pub read_raw: unsafe extern "C" fn(
         handle: *const c_void,
         port_ptr: *const u8,
@@ -107,6 +119,25 @@ pub struct InputMailboxesVTable {
     /// Decrement the host-side `Arc<InputMailboxesInner>` strong
     /// count. Releases the inner when the count reaches zero.
     pub drop_arc: unsafe extern "C" fn(handle: *const c_void),
+
+    /// Return the schema-declared `metadata.max_payload_bytes` for
+    /// the named port — the upper bound on serialized frame size
+    /// guaranteed by the iceoryx2 service's publisher-side
+    /// configuration. The cdylib allocates `out_buf` to this size
+    /// before calling `read_raw`; the publisher cannot loan a
+    /// bigger slot, so truncation is structurally impossible.
+    ///
+    /// Returns the engine-wide `MAX_PAYLOAD_SIZE` default (64 KiB)
+    /// for ports without a registered schema or without an
+    /// explicit `max_payload_bytes` declaration. Returns `0` for
+    /// unknown ports — caller must treat as a wiring error.
+    ///
+    /// v2 addition.
+    pub max_payload_for_port: unsafe extern "C" fn(
+        handle: *const c_void,
+        port_ptr: *const u8,
+        port_len: usize,
+    ) -> usize,
 }
 
 // Safety: every field is a primitive or an `extern "C" fn` pointer.
@@ -122,9 +153,9 @@ mod tests {
 
     #[test]
     fn input_mailboxes_vtable_layout() {
-        // header (u32 + u32) + 4 fn pointers @ 8 bytes each =
-        // 4 + 4 + 4 * 8 = 40 bytes.
-        assert_eq!(size_of::<InputMailboxesVTable>(), 40);
+        // header (u32 + u32) + 5 fn pointers @ 8 bytes each =
+        // 4 + 4 + 5 * 8 = 48 bytes (v2 appended max_payload_for_port).
+        assert_eq!(size_of::<InputMailboxesVTable>(), 48);
         assert_eq!(align_of::<InputMailboxesVTable>(), 8);
         assert_eq!(offset_of!(InputMailboxesVTable, layout_version), 0);
         assert_eq!(offset_of!(InputMailboxesVTable, _reserved_padding), 4);
@@ -132,5 +163,11 @@ mod tests {
         assert_eq!(offset_of!(InputMailboxesVTable, has_data), 16);
         assert_eq!(offset_of!(InputMailboxesVTable, clone_arc), 24);
         assert_eq!(offset_of!(InputMailboxesVTable, drop_arc), 32);
+        assert_eq!(offset_of!(InputMailboxesVTable, max_payload_for_port), 40);
+    }
+
+    #[test]
+    fn input_mailboxes_vtable_layout_version_pinned_at_two() {
+        assert_eq!(INPUT_MAILBOXES_VTABLE_LAYOUT_VERSION, 2);
     }
 }

--- a/libs/streamlib-plugin-abi/src/vtables/surface_store.rs
+++ b/libs/streamlib-plugin-abi/src/vtables/surface_store.rs
@@ -155,31 +155,36 @@ pub struct SurfaceStoreVTable {
     // error message.
 
     /// Register a texture for cross-process sharing. `texture` is a
-    /// `*const Texture` β-shape pointer; `timeline_handle` is an
-    /// opaque `Arc<HostVulkanTimelineSemaphore>` pointer (null for
-    /// "no timeline") — engine-only, cdylibs pass null. `layout_raw`
-    /// is the i32 `VkImageLayout` enumerant.
+    /// `*const Texture` β-shape pointer; `produce_done_handle` and
+    /// `consume_done_handle` are opaque `Arc<HostVulkanTimelineSemaphore>`
+    /// pointers (null for "no timeline") that carry the
+    /// single-writer-per-edge pair documented in
+    /// `docs/architecture/adapter-timeline-single-writer.md` — both
+    /// engine-only, cdylibs pass null. `layout_raw` is the i32
+    /// `VkImageLayout` enumerant.
     pub register_texture: unsafe extern "C" fn(
         handle: *const c_void,
         id_ptr: *const u8,
         id_len: usize,
         texture: *const c_void,
-        timeline_handle: *const c_void,
+        produce_done_handle: *const c_void,
+        consume_done_handle: *const c_void,
         layout_raw: i32,
         err_buf: *mut u8,
         err_buf_cap: usize,
         err_len: *mut usize,
     ) -> i32,
 
-    /// Register a pixel buffer with an optional timeline-semaphore
-    /// sidecar. Same `timeline_handle` shape as
-    /// [`Self::register_texture`].
+    /// Register a pixel buffer with optional `produce_done` and
+    /// `consume_done` timeline-semaphore sidecars. Same handle shape
+    /// as [`Self::register_texture`].
     pub register_pixel_buffer_with_timeline: unsafe extern "C" fn(
         handle: *const c_void,
         id_ptr: *const u8,
         id_len: usize,
         pixel_buffer: *const c_void,
-        timeline_handle: *const c_void,
+        produce_done_handle: *const c_void,
+        consume_done_handle: *const c_void,
         err_buf: *mut u8,
         err_buf_cap: usize,
         err_len: *mut usize,

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -3932,22 +3932,26 @@ mod vulkan {
                 return -1;
             }
         };
-        // Import the host's timeline semaphore. The OPAQUE_FD on the
-        // SurfaceHandle is `take`n: Vulkan owns it on success.
+        // Import the host's `produce_done` timeline semaphore.
+        // Single-writer-per-edge per
+        // `docs/architecture/adapter-timeline-single-writer.md`: the
+        // producer signals this timeline; the consumer (us) waits on it
+        // before reading. The OPAQUE_FD on the SurfaceHandle is `take`n;
+        // Vulkan owns it on success.
         let raw_sync_fd: RawFd = match gpu.produce_done_fd.take() {
             Some(fd) => fd,
             None => {
                 tracing::error!(
-                    "slpn_vulkan_register_surface: surface '{}' has no sync_fd — \
+                    "slpn_vulkan_register_surface: surface '{}' has no produce_done_fd — \
                      the host must register the texture with an exportable \
                      `ConsumerVulkanTimelineSemaphore` (see SurfaceStore::register_texture's \
-                     `timeline` argument).",
+                     `produce_done` argument).",
                     surface_id
                 );
                 return -1;
             }
         };
-        let timeline = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+        let produce_done = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
             &rt.device,
             raw_sync_fd,
         ) {
@@ -3957,7 +3961,39 @@ mod vulkan {
                 // SurfaceHandle's slot so the caller can still close it.
                 gpu.produce_done_fd = Some(raw_sync_fd);
                 tracing::error!(
-                    "slpn_vulkan_register_surface: from_imported_opaque_fd: {}",
+                    "slpn_vulkan_register_surface: produce_done from_imported_opaque_fd: {}",
+                    e
+                );
+                return -1;
+            }
+        };
+
+        // Import the host's `consume_done` timeline. We (the consumer
+        // process) signal this timeline from `end_read_access` via host
+        // CPU `signal_host`; the producer waits on it before re-writing.
+        let raw_consume_fd: RawFd = match gpu.consume_done_fd.take() {
+            Some(fd) => fd,
+            None => {
+                tracing::error!(
+                    "slpn_vulkan_register_surface: surface '{}' has no consume_done_fd — \
+                     the host must register both produce_done and consume_done timeline \
+                     fds per the single-writer-per-edge contract",
+                    surface_id
+                );
+                gpu.produce_done_fd = Some(raw_sync_fd);
+                return -1;
+            }
+        };
+        let consume_done = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+            &rt.device,
+            raw_consume_fd,
+        ) {
+            Ok(s) => Arc::new(s),
+            Err(e) => {
+                gpu.produce_done_fd = Some(raw_sync_fd);
+                gpu.consume_done_fd = Some(raw_consume_fd);
+                tracing::error!(
+                    "slpn_vulkan_register_surface: consume_done from_imported_opaque_fd: {}",
                     e
                 );
                 return -1;
@@ -3979,7 +4015,8 @@ mod vulkan {
         // the adapter owns the imported VkImage's lifetime end-to-end.
         let registration = HostSurfaceRegistration::<ConsumerMarker> {
             texture: Arc::new(texture),
-            timeline,
+            produce_done,
+            consume_done,
             initial_layout: VulkanLayout(gpu.current_image_layout),
         };
 

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -1314,15 +1314,25 @@ mod gpu_surface {
         /// modifiers with disjoint Y/UV allocations) carry one per plane,
         /// keyed by plane index.
         pub fds: Vec<RawFd>,
-        /// Optional OPAQUE_FD timeline-semaphore handle the host attached
-        /// when registering the surface (#531). Routed into the Vulkan
-        /// adapter's `ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd` so
-        /// the subprocess reuses the host adapter's timeline-wait + signal
-        /// path. `None` for surfaces without explicit Vulkan sync (OpenGL
-        /// adapter, CPU-readback, legacy DMA-BUF consumer flows). The fd is
-        /// closed when the handle is dropped, unless the import has taken
-        /// ownership (Vulkan import takes ownership on success).
-        pub sync_fd: Option<RawFd>,
+        /// Optional OPAQUE_FD `produce_done` timeline-semaphore handle the
+        /// host attached when registering the surface. Single-writer-per-
+        /// edge: the producer process signals this timeline, the consumer
+        /// waits before reading. The cdylib's `slpn_*_register_surface`
+        /// entry points import this FD via
+        /// `ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd` so
+        /// the subprocess reuses the host adapter's timeline-wait path.
+        /// `None` for surfaces without explicit Vulkan sync. The fd is
+        /// closed when the handle is dropped unless the import has taken
+        /// ownership (Vulkan import takes ownership on success). See
+        /// `docs/architecture/adapter-timeline-single-writer.md`.
+        pub produce_done_fd: Option<RawFd>,
+        /// Optional OPAQUE_FD `consume_done` timeline-semaphore handle.
+        /// Single-writer-per-edge: the consumer process signals this
+        /// timeline from its `end_read_access` path so the producer can
+        /// wait before re-writing. Same lifetime rules as
+        /// `produce_done_fd`. `None` until each per-adapter
+        /// `slpn_*_register_surface` migration claims it.
+        pub consume_done_fd: Option<RawFd>,
         pub plane_sizes: Vec<u64>,
         pub plane_offsets: Vec<u64>,
         /// Per-plane row pitch in bytes, copied from the surface-share
@@ -1420,11 +1430,18 @@ mod gpu_surface {
                     unsafe { libc::close(*fd) };
                 }
             }
-            // Close the sync FD if the Vulkan adapter import didn't take
-            // ownership. The adapter's `register_surface` takes the fd by
-            // value via `take_sync_fd` so a successful import zeros out
-            // this slot before drop runs.
-            if let Some(fd) = self.sync_fd {
+            // Close both timeline FDs if the per-adapter
+            // `slpn_*_register_surface` paths didn't take ownership. The
+            // adapter's register entry points `.take()` whichever slots
+            // they consume; a successful import zeroes the slot before
+            // drop runs. See
+            // `docs/architecture/adapter-timeline-single-writer.md`.
+            if let Some(fd) = self.produce_done_fd {
+                if fd >= 0 {
+                    unsafe { libc::close(fd) };
+                }
+            }
+            if let Some(fd) = self.consume_done_fd {
                 if fd >= 0 {
                     unsafe { libc::close(fd) };
                 }
@@ -2402,10 +2419,14 @@ mod surface_client {
         /// `SurfaceHandle` without another wire roundtrip.
         current_image_layout: i32,
         format: String,
-        /// Optional OPAQUE_FD timeline-semaphore handle the host attached at
-        /// register time. Stored so cache hits can hand a fresh dup to each
-        /// new `SurfaceHandle`; closed with the cache entry.
-        sync_fd: Option<RawFd>,
+        /// Optional OPAQUE_FD `produce_done` timeline-semaphore handle the
+        /// host attached at register time. Stored so cache hits can hand a
+        /// fresh dup to each new `SurfaceHandle`; closed with the cache
+        /// entry.
+        produce_done_fd: Option<RawFd>,
+        /// Optional OPAQUE_FD `consume_done` timeline-semaphore handle.
+        /// Same lifetime rules as `produce_done_fd`.
+        consume_done_fd: Option<RawFd>,
     }
 
     impl Drop for CachedSurface {
@@ -2415,7 +2436,12 @@ mod surface_client {
                     unsafe { libc::close(*fd) };
                 }
             }
-            if let Some(fd) = self.sync_fd {
+            if let Some(fd) = self.produce_done_fd {
+                if fd >= 0 {
+                    unsafe { libc::close(fd) };
+                }
+            }
+            if let Some(fd) = self.consume_done_fd {
                 if fd >= 0 {
                     unsafe { libc::close(fd) };
                 }
@@ -2607,28 +2633,51 @@ mod surface_client {
                     }
                     return std::ptr::null_mut();
                 }
-                let cached_sync_dup: Option<RawFd> = match cached.sync_fd {
-                    Some(src) => {
-                        let dup = unsafe { libc::dup(src) };
-                        if dup < 0 {
-                            tracing::error!(
-                                "surface_resolve_surface: dup cached sync_fd failed for '{}': {}",
-                                pool_id_str,
-                                std::io::Error::last_os_error()
-                            );
-                            for fd in &dup_fds {
-                                unsafe { libc::close(*fd) };
+                let dup_timeline = |src: Option<RawFd>, label: &str| -> Result<Option<RawFd>, ()> {
+                    match src {
+                        Some(s) => {
+                            let dup = unsafe { libc::dup(s) };
+                            if dup < 0 {
+                                tracing::error!(
+                                    "surface_resolve_surface: dup cached {} failed for '{}': {}",
+                                    label,
+                                    pool_id_str,
+                                    std::io::Error::last_os_error()
+                                );
+                                Err(())
+                            } else {
+                                Ok(Some(dup))
                             }
-                            return std::ptr::null_mut();
                         }
-                        Some(dup)
+                        None => Ok(None),
                     }
-                    None => None,
+                };
+                let cached_produce_dup = match dup_timeline(cached.produce_done_fd, "produce_done_fd") {
+                    Ok(o) => o,
+                    Err(_) => {
+                        for fd in &dup_fds {
+                            unsafe { libc::close(*fd) };
+                        }
+                        return std::ptr::null_mut();
+                    }
+                };
+                let cached_consume_dup = match dup_timeline(cached.consume_done_fd, "consume_done_fd") {
+                    Ok(o) => o,
+                    Err(_) => {
+                        for fd in &dup_fds {
+                            unsafe { libc::close(*fd) };
+                        }
+                        if let Some(fd) = cached_produce_dup {
+                            unsafe { libc::close(fd) };
+                        }
+                        return std::ptr::null_mut();
+                    }
                 };
                 let n_planes = dup_fds.len();
                 return Box::into_raw(Box::new(SurfaceHandle {
                     fds: dup_fds,
-                    sync_fd: cached_sync_dup,
+                    produce_done_fd: cached_produce_dup,
+                    consume_done_fd: cached_consume_dup,
                     plane_sizes: cached.plane_sizes.clone(),
                     plane_offsets: cached.plane_offsets.clone(),
                     plane_strides: cached.plane_strides.clone(),
@@ -2702,17 +2751,14 @@ mod surface_client {
             return std::ptr::null_mut();
         }
 
-        // Peel off the optional trailing producer-side `produce_done`
-        // timeline FD when the response carries one. The host's
-        // surface-share service appends it to SCM_RIGHTS after the
-        // DMA-BUF plane FDs and signals its presence with
-        // `has_produce_done_fd: true` so subprocess code can route it
-        // into the adapter's timeline-semaphore import. The
-        // single-writer-per-edge model is documented in
-        // `docs/architecture/adapter-timeline-single-writer.md`. The
-        // consumer-side `consume_done` FD travels through the same
-        // wire shape but lands in per-adapter state, not on the
-        // generic SurfaceHandle (each adapter migration claims it).
+        // Peel off the trailing per-edge timeline FDs the host attached
+        // after the DMA-BUF plane FDs. The host's surface-share service
+        // signals presence via `has_produce_done_fd` and
+        // `has_consume_done_fd`; FDs appear in that order so the
+        // subprocess can route each into the matching
+        // `ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd`
+        // import. Single-writer-per-edge is documented in
+        // `docs/architecture/adapter-timeline-single-writer.md`.
         let has_produce_done_fd = response
             .get("has_produce_done_fd")
             .and_then(|v| v.as_bool())
@@ -2721,39 +2767,33 @@ mod surface_client {
             .get("has_consume_done_fd")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        // Peel trailing FDs in the order the host attached them:
-        // produce_done first, then consume_done. consume_done is closed
-        // here — per-adapter migrations will reclaim it through the
-        // wire-format hooks they add.
         let trailing_count =
             (has_produce_done_fd as usize) + (has_consume_done_fd as usize);
-        let (received_fds, sync_fd): (Vec<RawFd>, Option<RawFd>) = if trailing_count > 0
-            && received_fds.len() >= trailing_count
-        {
+        let (received_fds, produce_done_fd, consume_done_fd): (
+            Vec<RawFd>,
+            Option<RawFd>,
+            Option<RawFd>,
+        ) = if trailing_count > 0 && received_fds.len() >= trailing_count {
             let split_at = received_fds.len() - trailing_count;
             let mut all = received_fds;
             let trailing: Vec<RawFd> = all.split_off(split_at);
-            // trailing[0] = produce_done (if has_produce_done_fd), then
-            // trailing[1] = consume_done (if has_consume_done_fd).
             let mut iter = trailing.into_iter();
             let produce_fd = if has_produce_done_fd { iter.next() } else { None };
             let consume_fd = if has_consume_done_fd { iter.next() } else { None };
-            // Pre-migration: close consume_done here. Per-adapter
-            // migration will claim it through a new wire hook.
-            if let Some(fd) = consume_fd {
-                unsafe { libc::close(fd) };
-            }
-            (all, produce_fd)
+            (all, produce_fd, consume_fd)
         } else {
-            (received_fds, None)
+            (received_fds, None, None)
         };
 
         if received_fds.is_empty() {
             tracing::error!(
-                "surface_resolve_surface: no plane fds for '{}' after peeling sync_fd",
+                "surface_resolve_surface: no plane fds for '{}' after peeling timeline fds",
                 pool_id_str
             );
-            if let Some(s) = sync_fd {
+            if let Some(s) = produce_done_fd {
+                unsafe { libc::close(s) };
+            }
+            if let Some(s) = consume_done_fd {
                 unsafe { libc::close(s) };
             }
             return std::ptr::null_mut();
@@ -2820,8 +2860,8 @@ mod surface_client {
 
         // Cache: dup every plane for the cache's own copy so the returned
         // handle owns its own fds independently. Same for the optional
-        // sync_fd — the cache and the handed-out handle each get their
-        // own dup, so neither closes from underneath the other.
+        // timeline FDs — the cache and the handed-out handle each get
+        // their own dup, so neither closes from underneath the other.
         let mut cache_fds: Vec<RawFd> = Vec::with_capacity(received_fds.len());
         let mut cache_dup_ok = true;
         for fd in &received_fds {
@@ -2832,18 +2872,22 @@ mod surface_client {
             }
             cache_fds.push(dup);
         }
-        let cache_sync_fd: Option<RawFd> = match sync_fd {
-            Some(src) if cache_dup_ok => {
-                let dup = unsafe { libc::dup(src) };
-                if dup < 0 {
-                    cache_dup_ok = false;
-                    None
-                } else {
-                    Some(dup)
+        let dup_for_cache = |src: Option<RawFd>, ok: &mut bool| -> Option<RawFd> {
+            match src {
+                Some(s) if *ok => {
+                    let dup = unsafe { libc::dup(s) };
+                    if dup < 0 {
+                        *ok = false;
+                        None
+                    } else {
+                        Some(dup)
+                    }
                 }
+                _ => None,
             }
-            _ => None,
         };
+        let cache_produce_done_fd = dup_for_cache(produce_done_fd, &mut cache_dup_ok);
+        let cache_consume_done_fd = dup_for_cache(consume_done_fd, &mut cache_dup_ok);
         if cache_dup_ok {
             let mut cache = handle.resolve_cache.lock().expect("poisoned");
             if cache.len() >= MAX_RESOLVE_CACHE {
@@ -2867,14 +2911,18 @@ mod surface_client {
                     drm_format_modifier,
                     current_image_layout,
                     format: format_str.to_string(),
-                    sync_fd: cache_sync_fd,
+                    produce_done_fd: cache_produce_done_fd,
+                    consume_done_fd: cache_consume_done_fd,
                 },
             );
         } else {
             for fd in &cache_fds {
                 unsafe { libc::close(*fd) };
             }
-            if let Some(fd) = cache_sync_fd {
+            if let Some(fd) = cache_produce_done_fd {
+                unsafe { libc::close(fd) };
+            }
+            if let Some(fd) = cache_consume_done_fd {
                 unsafe { libc::close(fd) };
             }
         }
@@ -2882,7 +2930,8 @@ mod surface_client {
         let n_planes = received_fds.len();
         Box::into_raw(Box::new(SurfaceHandle {
             fds: received_fds,
-            sync_fd,
+            produce_done_fd,
+            consume_done_fd,
             plane_sizes,
             plane_offsets,
             plane_strides,
@@ -3885,7 +3934,7 @@ mod vulkan {
         };
         // Import the host's timeline semaphore. The OPAQUE_FD on the
         // SurfaceHandle is `take`n: Vulkan owns it on success.
-        let raw_sync_fd: RawFd = match gpu.sync_fd.take() {
+        let raw_sync_fd: RawFd = match gpu.produce_done_fd.take() {
             Some(fd) => fd,
             None => {
                 tracing::error!(
@@ -3906,7 +3955,7 @@ mod vulkan {
             Err(e) => {
                 // Vulkan retained ownership only on success; restore the
                 // SurfaceHandle's slot so the caller can still close it.
-                gpu.sync_fd = Some(raw_sync_fd);
+                gpu.produce_done_fd = Some(raw_sync_fd);
                 tracing::error!(
                     "slpn_vulkan_register_surface: from_imported_opaque_fd: {}",
                     e
@@ -4621,7 +4670,7 @@ mod cpu_readback {
 
         // Import the timeline semaphore. Required for every cpu-
         // readback surface — the host triggers signal it on every copy.
-        let raw_sync_fd: RawFd = match gpu.sync_fd.take() {
+        let raw_sync_fd: RawFd = match gpu.produce_done_fd.take() {
             Some(fd) => fd,
             None => {
                 tracing::error!(
@@ -4639,7 +4688,7 @@ mod cpu_readback {
         ) {
             Ok(s) => Arc::new(s),
             Err(e) => {
-                gpu.sync_fd = Some(raw_sync_fd);
+                gpu.produce_done_fd = Some(raw_sync_fd);
                 tracing::error!(
                     "slpn_cpu_readback_register_surface: from_imported_opaque_fd: {}",
                     e
@@ -5454,7 +5503,7 @@ mod cuda {
         };
 
         // ── Step 2: import the timeline semaphore into Vulkan ───────────
-        let raw_sync_fd: RawFd = match gpu.sync_fd.take() {
+        let raw_sync_fd: RawFd = match gpu.produce_done_fd.take() {
             Some(fd) => fd,
             None => {
                 tracing::error!(
@@ -5474,7 +5523,7 @@ mod cuda {
                 std::io::Error::last_os_error()
             );
             // Restore the original fd onto the handle so its Drop closes it.
-            gpu.sync_fd = Some(raw_sync_fd);
+            gpu.produce_done_fd = Some(raw_sync_fd);
             return SLPN_CUDA_ERR;
         }
         let timeline = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
@@ -5488,7 +5537,7 @@ mod cuda {
                     e
                 );
                 unsafe { libc::close(vk_sync_fd) };
-                gpu.sync_fd = Some(raw_sync_fd);
+                gpu.produce_done_fd = Some(raw_sync_fd);
                 return SLPN_CUDA_ERR;
             }
         };
@@ -5504,7 +5553,7 @@ mod cuda {
             // Vulkan-side imports drop here via Arc — they own their own
             // dups already. Restore sync_fd onto the handle so its Drop
             // closes it (Vulkan timeline import owns its dup independently).
-            gpu.sync_fd = Some(raw_sync_fd);
+            gpu.produce_done_fd = Some(raw_sync_fd);
             return SLPN_CUDA_ERR;
         }
         // SAFETY: `cudaImportExternalMemory` per CUDA docs:
@@ -5520,7 +5569,7 @@ mod cuda {
                         e
                     );
                     libc::close(cuda_mem_fd);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
@@ -5539,7 +5588,7 @@ mod cuda {
                         e
                     );
                     let _ = external_memory::destroy_external_memory(ext_mem);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
@@ -5562,7 +5611,7 @@ mod cuda {
                         e
                     );
                     let _ = external_memory::destroy_external_memory(ext_mem);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
@@ -5578,7 +5627,7 @@ mod cuda {
                     other
                 );
                 let _ = unsafe { external_memory::destroy_external_memory(ext_mem) };
-                gpu.sync_fd = Some(raw_sync_fd);
+                gpu.produce_done_fd = Some(raw_sync_fd);
                 return SLPN_CUDA_ERR;
             }
         };
@@ -5591,7 +5640,7 @@ mod cuda {
                 std::io::Error::last_os_error()
             );
             let _ = unsafe { external_memory::destroy_external_memory(ext_mem) };
-            gpu.sync_fd = Some(raw_sync_fd);
+            gpu.produce_done_fd = Some(raw_sync_fd);
             return SLPN_CUDA_ERR;
         }
         // Same descriptor-construction story as the carve-out test:
@@ -5623,7 +5672,7 @@ mod cuda {
                     );
                     libc::close(cuda_sync_fd);
                     let _ = external_memory::destroy_external_memory(ext_mem);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
@@ -5641,7 +5690,7 @@ mod cuda {
                     );
                     let _ = sys::cudaDestroyExternalSemaphore(ext_sem).result();
                     let _ = external_memory::destroy_external_memory(ext_mem);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
@@ -5671,7 +5720,7 @@ mod cuda {
                 let _ = sys::cudaDestroyExternalSemaphore(ext_sem).result();
                 let _ = external_memory::destroy_external_memory(ext_mem);
             };
-            gpu.sync_fd = Some(raw_sync_fd);
+            gpu.produce_done_fd = Some(raw_sync_fd);
             return SLPN_CUDA_ERR;
         }
 
@@ -5680,7 +5729,7 @@ mod cuda {
         // returning it to the handle's `sync_fd` slot is the canonical
         // ownership recovery — same pattern as cpu-readback's
         // register_surface error paths.
-        gpu.sync_fd = Some(raw_sync_fd);
+        gpu.produce_done_fd = Some(raw_sync_fd);
 
         let entry = Arc::new(RegisteredCudaSurface {
             ext_mem,
@@ -6358,7 +6407,7 @@ mod cuda {
         };
 
         // ── Step 2: import the timeline semaphore into Vulkan ───────────
-        let raw_sync_fd: RawFd = match gpu.sync_fd.take() {
+        let raw_sync_fd: RawFd = match gpu.produce_done_fd.take() {
             Some(fd) => fd,
             None => {
                 tracing::error!(
@@ -6376,7 +6425,7 @@ mod cuda {
                 "slpn_cuda_register_image_surface: dup sync_fd failed: {}",
                 std::io::Error::last_os_error()
             );
-            gpu.sync_fd = Some(raw_sync_fd);
+            gpu.produce_done_fd = Some(raw_sync_fd);
             return SLPN_CUDA_ERR;
         }
         let timeline = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
@@ -6390,7 +6439,7 @@ mod cuda {
                     e
                 );
                 unsafe { libc::close(vk_sync_fd) };
-                gpu.sync_fd = Some(raw_sync_fd);
+                gpu.produce_done_fd = Some(raw_sync_fd);
                 return SLPN_CUDA_ERR;
             }
         };
@@ -6402,7 +6451,7 @@ mod cuda {
                 "slpn_cuda_register_image_surface: dup cuda_mem_fd failed: {}",
                 std::io::Error::last_os_error()
             );
-            gpu.sync_fd = Some(raw_sync_fd);
+            gpu.produce_done_fd = Some(raw_sync_fd);
             return SLPN_CUDA_ERR;
         }
         // SAFETY: see notes on the buffer path's import_external_memory_opaque_fd
@@ -6416,7 +6465,7 @@ mod cuda {
                         e
                     );
                     libc::close(cuda_mem_fd);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
@@ -6459,7 +6508,7 @@ mod cuda {
                         e
                     );
                     let _ = external_memory::destroy_external_memory(ext_mem);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
@@ -6476,7 +6525,7 @@ mod cuda {
                 let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
                 let _ = external_memory::destroy_external_memory(ext_mem);
             };
-            gpu.sync_fd = Some(raw_sync_fd);
+            gpu.produce_done_fd = Some(raw_sync_fd);
             return SLPN_CUDA_ERR;
         }
         let mut sem_desc = MaybeUninit::<sys::cudaExternalSemaphoreHandleDesc>::zeroed();
@@ -6503,7 +6552,7 @@ mod cuda {
                     libc::close(cuda_sync_fd);
                     let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
                     let _ = external_memory::destroy_external_memory(ext_mem);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
@@ -6522,7 +6571,7 @@ mod cuda {
                     let _ = sys::cudaDestroyExternalSemaphore(ext_sem).result();
                     let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
                     let _ = external_memory::destroy_external_memory(ext_mem);
-                    gpu.sync_fd = Some(raw_sync_fd);
+                    gpu.produce_done_fd = Some(raw_sync_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
@@ -6550,11 +6599,11 @@ mod cuda {
                 let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
                 let _ = external_memory::destroy_external_memory(ext_mem);
             };
-            gpu.sync_fd = Some(raw_sync_fd);
+            gpu.produce_done_fd = Some(raw_sync_fd);
             return SLPN_CUDA_ERR;
         }
 
-        gpu.sync_fd = Some(raw_sync_fd);
+        gpu.produce_done_fd = Some(raw_sync_fd);
 
         let entry = Arc::new(RegisteredCudaImageSurface {
             ext_mem,

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -5290,6 +5290,11 @@ mod cuda {
         // references). Drop order: this struct's fields drop in
         // declaration order, so put CUDA imports first.
         ext_mem: sys::cudaExternalMemory_t,
+        /// CUDA-side import of `produce_done` — the timeline the
+        /// producer signals so cuda can wait on it via
+        /// `cudaWaitExternalSemaphoresAsync_v2`. CUDA does NOT import
+        /// `consume_done` (the consumer signals via host CPU
+        /// `signal_host` through the adapter's `end_read_access`).
         ext_sem: sys::cudaExternalSemaphore_t,
         stream: sys::cudaStream_t,
         device_ptr: u64,
@@ -5302,7 +5307,10 @@ mod cuda {
         // is belt-and-suspenders.
         #[allow(dead_code)] // Arc held for lifetime; never read after register.
         pixel_buffer: Arc<ConsumerVulkanBuffer>,
-        timeline: Arc<ConsumerVulkanTimelineSemaphore>,
+        #[allow(dead_code)] // Arc held for lifetime; never read after register.
+        produce_done: Arc<ConsumerVulkanTimelineSemaphore>,
+        #[allow(dead_code)] // Arc held for lifetime; never read after register.
+        consume_done: Arc<ConsumerVulkanTimelineSemaphore>,
     }
 
     // SAFETY: `cudaExternalMemory_t`, `cudaExternalSemaphore_t`, and
@@ -5502,12 +5510,15 @@ mod cuda {
             }
         };
 
-        // ── Step 2: import the timeline semaphore into Vulkan ───────────
+        // ── Step 2: import the `produce_done` timeline into Vulkan ──────
+        // Single-writer-per-edge
+        // (`docs/architecture/adapter-timeline-single-writer.md`): the
+        // producer (host) signals this timeline, cuda waits on it.
         let raw_sync_fd: RawFd = match gpu.produce_done_fd.take() {
             Some(fd) => fd,
             None => {
                 tracing::error!(
-                    "slpn_cuda_register_surface: surface '{}' has no sync_fd — \
+                    "slpn_cuda_register_surface: surface '{}' has no produce_done_fd — \
                      the host must register it with an exportable timeline semaphore \
                      so cross-API sync (Vulkan ↔ CUDA) is well-defined",
                     surface_id
@@ -5519,7 +5530,7 @@ mod cuda {
         let vk_sync_fd = unsafe { libc::dup(raw_sync_fd) };
         if vk_sync_fd < 0 {
             tracing::error!(
-                "slpn_cuda_register_surface: dup sync_fd failed: {}",
+                "slpn_cuda_register_surface: dup produce_done_fd failed: {}",
                 std::io::Error::last_os_error()
             );
             // Restore the original fd onto the handle so its Drop closes it.
@@ -5533,11 +5544,55 @@ mod cuda {
             Ok(s) => Arc::new(s),
             Err(e) => {
                 tracing::error!(
-                    "slpn_cuda_register_surface: timeline from_imported_opaque_fd: {}",
+                    "slpn_cuda_register_surface: produce_done from_imported_opaque_fd: {}",
                     e
                 );
                 unsafe { libc::close(vk_sync_fd) };
                 gpu.produce_done_fd = Some(raw_sync_fd);
+                return SLPN_CUDA_ERR;
+            }
+        };
+
+        // ── Step 2b: import the `consume_done` timeline into Vulkan ─────
+        // The consumer signals this timeline from the adapter's
+        // `end_read_access` (host CPU `signal_host`). CUDA does not
+        // import this side — it doesn't signal anything.
+        let raw_consume_fd: RawFd = match gpu.consume_done_fd.take() {
+            Some(fd) => fd,
+            None => {
+                tracing::error!(
+                    "slpn_cuda_register_surface: surface '{}' has no consume_done_fd — \
+                     the host must register both produce_done and consume_done timeline \
+                     fds per the single-writer-per-edge contract",
+                    surface_id
+                );
+                gpu.produce_done_fd = Some(raw_sync_fd);
+                return SLPN_CUDA_ERR;
+            }
+        };
+        let vk_consume_fd = unsafe { libc::dup(raw_consume_fd) };
+        if vk_consume_fd < 0 {
+            tracing::error!(
+                "slpn_cuda_register_surface: dup consume_done_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            gpu.produce_done_fd = Some(raw_sync_fd);
+            gpu.consume_done_fd = Some(raw_consume_fd);
+            return SLPN_CUDA_ERR;
+        }
+        let consume_done = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+            &rt.device,
+            vk_consume_fd,
+        ) {
+            Ok(s) => Arc::new(s),
+            Err(e) => {
+                tracing::error!(
+                    "slpn_cuda_register_surface: consume_done from_imported_opaque_fd: {}",
+                    e
+                );
+                unsafe { libc::close(vk_consume_fd) };
+                gpu.produce_done_fd = Some(raw_sync_fd);
+                gpu.consume_done_fd = Some(raw_consume_fd);
                 return SLPN_CUDA_ERR;
             }
         };
@@ -5551,9 +5606,11 @@ mod cuda {
                 std::io::Error::last_os_error()
             );
             // Vulkan-side imports drop here via Arc — they own their own
-            // dups already. Restore sync_fd onto the handle so its Drop
-            // closes it (Vulkan timeline import owns its dup independently).
+            // dups already. Restore both timeline fds onto the handle so
+            // its Drop closes them (Vulkan timeline imports own their
+            // dups independently).
             gpu.produce_done_fd = Some(raw_sync_fd);
+            gpu.consume_done_fd = Some(raw_consume_fd);
             return SLPN_CUDA_ERR;
         }
         // SAFETY: `cudaImportExternalMemory` per CUDA docs:
@@ -5570,6 +5627,7 @@ mod cuda {
                     );
                     libc::close(cuda_mem_fd);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
@@ -5589,6 +5647,7 @@ mod cuda {
                     );
                     let _ = external_memory::destroy_external_memory(ext_mem);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
@@ -5612,6 +5671,7 @@ mod cuda {
                     );
                     let _ = external_memory::destroy_external_memory(ext_mem);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
@@ -5628,11 +5688,16 @@ mod cuda {
                 );
                 let _ = unsafe { external_memory::destroy_external_memory(ext_mem) };
                 gpu.produce_done_fd = Some(raw_sync_fd);
+                gpu.consume_done_fd = Some(raw_consume_fd);
                 return SLPN_CUDA_ERR;
             }
         };
 
-        // ── Step 5: import the timeline semaphore into CUDA ─────────────
+        // ── Step 5: import the `produce_done` timeline semaphore into CUDA ─
+        // CUDA only imports produce_done — it waits on it via
+        // `cudaWaitExternalSemaphoresAsync_v2`. consume_done is held
+        // Vulkan-side only; the adapter's `end_read_access` signals it
+        // via host CPU `signal_host`.
         let cuda_sync_fd = unsafe { libc::dup(raw_sync_fd) };
         if cuda_sync_fd < 0 {
             tracing::error!(
@@ -5641,6 +5706,7 @@ mod cuda {
             );
             let _ = unsafe { external_memory::destroy_external_memory(ext_mem) };
             gpu.produce_done_fd = Some(raw_sync_fd);
+            gpu.consume_done_fd = Some(raw_consume_fd);
             return SLPN_CUDA_ERR;
         }
         // Same descriptor-construction story as the carve-out test:
@@ -5673,6 +5739,7 @@ mod cuda {
                     libc::close(cuda_sync_fd);
                     let _ = external_memory::destroy_external_memory(ext_mem);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
@@ -5691,6 +5758,7 @@ mod cuda {
                     let _ = sys::cudaDestroyExternalSemaphore(ext_sem).result();
                     let _ = external_memory::destroy_external_memory(ext_mem);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
@@ -5706,7 +5774,8 @@ mod cuda {
         // pass `UNDEFINED`.
         let registration = HostSurfaceRegistration {
             pixel_buffer: Arc::clone(&pixel_buffer),
-            timeline: Arc::clone(&timeline),
+            produce_done: Arc::clone(&timeline),
+            consume_done: Arc::clone(&consume_done),
             initial_layout: VulkanLayout::UNDEFINED,
         };
         if let Err(e) = rt.adapter.register_host_surface(surface_id, registration) {
@@ -5721,15 +5790,19 @@ mod cuda {
                 let _ = external_memory::destroy_external_memory(ext_mem);
             };
             gpu.produce_done_fd = Some(raw_sync_fd);
+            gpu.consume_done_fd = Some(raw_consume_fd);
             return SLPN_CUDA_ERR;
         }
 
         // The original `raw_sync_fd` is owned by the SurfaceHandle's drop
         // path. We've already dup'd it twice (Vulkan + CUDA timeline), so
-        // returning it to the handle's `sync_fd` slot is the canonical
-        // ownership recovery — same pattern as cpu-readback's
-        // register_surface error paths.
+        // returning it to the handle's `produce_done_fd` slot is the
+        // canonical ownership recovery — same pattern as cpu-readback's
+        // register_surface error paths. `raw_consume_fd` is owned by the
+        // SurfaceHandle the same way after the Vulkan-side
+        // consume_done dup; restore it too.
         gpu.produce_done_fd = Some(raw_sync_fd);
+        gpu.consume_done_fd = Some(raw_consume_fd);
 
         let entry = Arc::new(RegisteredCudaSurface {
             ext_mem,
@@ -5740,7 +5813,8 @@ mod cuda {
             device_type,
             cuda_device_ordinal: rt.cuda_device_ordinal,
             pixel_buffer,
-            timeline,
+            produce_done: timeline,
+            consume_done,
         });
         rt.registered
             .lock()
@@ -5811,8 +5885,12 @@ mod cuda {
     /// the timeline's current Vulkan-observed value, then synchronizes.
     /// Returns `Ok(())` on success.
     fn cuda_sync_after_acquire(entry: &RegisteredCudaSurface) -> Result<(), String> {
+        // CUDA waits on `produce_done` — the timeline the host
+        // producer signals. The kernel counter snapshot is the
+        // peer-timeline source of truth per
+        // `docs/architecture/adapter-timeline-single-writer.md`.
         let wait_value = entry
-            .timeline
+            .produce_done
             .current_value()
             .map_err(|e| format!("get_semaphore_counter_value: {e}"))?;
 
@@ -6243,7 +6321,10 @@ mod cuda {
         // Vulkan-side imports — held to outlive the CUDA imports above.
         #[allow(dead_code)] // Arc held for lifetime; never read after register.
         texture: Arc<ConsumerVulkanTexture>,
-        timeline: Arc<ConsumerVulkanTimelineSemaphore>,
+        #[allow(dead_code)] // Arc held for lifetime; never read after register.
+        produce_done: Arc<ConsumerVulkanTimelineSemaphore>,
+        #[allow(dead_code)] // Arc held for lifetime; never read after register.
+        consume_done: Arc<ConsumerVulkanTimelineSemaphore>,
     }
 
     // SAFETY: same rationale as [`RegisteredCudaSurface`] — CUDA Runtime
@@ -6406,12 +6487,14 @@ mod cuda {
             }
         };
 
-        // ── Step 2: import the timeline semaphore into Vulkan ───────────
+        // ── Step 2: import the `produce_done` timeline into Vulkan ──────
+        // Single-writer-per-edge per
+        // `docs/architecture/adapter-timeline-single-writer.md`.
         let raw_sync_fd: RawFd = match gpu.produce_done_fd.take() {
             Some(fd) => fd,
             None => {
                 tracing::error!(
-                    "slpn_cuda_register_image_surface: surface '{}' has no sync_fd — \
+                    "slpn_cuda_register_image_surface: surface '{}' has no produce_done_fd — \
                      the host must register an exportable timeline semaphore so \
                      cross-API sync (Vulkan ↔ CUDA) is well-defined",
                     surface_id
@@ -6422,7 +6505,7 @@ mod cuda {
         let vk_sync_fd = unsafe { libc::dup(raw_sync_fd) };
         if vk_sync_fd < 0 {
             tracing::error!(
-                "slpn_cuda_register_image_surface: dup sync_fd failed: {}",
+                "slpn_cuda_register_image_surface: dup produce_done_fd failed: {}",
                 std::io::Error::last_os_error()
             );
             gpu.produce_done_fd = Some(raw_sync_fd);
@@ -6435,11 +6518,50 @@ mod cuda {
             Ok(s) => Arc::new(s),
             Err(e) => {
                 tracing::error!(
-                    "slpn_cuda_register_image_surface: timeline from_imported_opaque_fd: {}",
+                    "slpn_cuda_register_image_surface: produce_done from_imported_opaque_fd: {}",
                     e
                 );
                 unsafe { libc::close(vk_sync_fd) };
                 gpu.produce_done_fd = Some(raw_sync_fd);
+                return SLPN_CUDA_ERR;
+            }
+        };
+
+        // ── Step 2b: import the `consume_done` timeline into Vulkan ─────
+        let raw_consume_fd: RawFd = match gpu.consume_done_fd.take() {
+            Some(fd) => fd,
+            None => {
+                tracing::error!(
+                    "slpn_cuda_register_image_surface: surface '{}' has no consume_done_fd",
+                    surface_id
+                );
+                gpu.produce_done_fd = Some(raw_sync_fd);
+                return SLPN_CUDA_ERR;
+            }
+        };
+        let vk_consume_fd = unsafe { libc::dup(raw_consume_fd) };
+        if vk_consume_fd < 0 {
+            tracing::error!(
+                "slpn_cuda_register_image_surface: dup consume_done_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            gpu.produce_done_fd = Some(raw_sync_fd);
+            gpu.consume_done_fd = Some(raw_consume_fd);
+            return SLPN_CUDA_ERR;
+        }
+        let consume_done = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+            &rt.device,
+            vk_consume_fd,
+        ) {
+            Ok(s) => Arc::new(s),
+            Err(e) => {
+                tracing::error!(
+                    "slpn_cuda_register_image_surface: consume_done from_imported_opaque_fd: {}",
+                    e
+                );
+                unsafe { libc::close(vk_consume_fd) };
+                gpu.produce_done_fd = Some(raw_sync_fd);
+                gpu.consume_done_fd = Some(raw_consume_fd);
                 return SLPN_CUDA_ERR;
             }
         };
@@ -6452,6 +6574,7 @@ mod cuda {
                 std::io::Error::last_os_error()
             );
             gpu.produce_done_fd = Some(raw_sync_fd);
+            gpu.consume_done_fd = Some(raw_consume_fd);
             return SLPN_CUDA_ERR;
         }
         // SAFETY: see notes on the buffer path's import_external_memory_opaque_fd
@@ -6466,6 +6589,7 @@ mod cuda {
                     );
                     libc::close(cuda_mem_fd);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
@@ -6509,12 +6633,16 @@ mod cuda {
                     );
                     let _ = external_memory::destroy_external_memory(ext_mem);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
         };
 
-        // ── Step 5: import the timeline semaphore into CUDA ─────────────
+        // ── Step 5: import the `produce_done` timeline semaphore into CUDA ─
+        // CUDA only imports produce_done (waits via
+        // `cudaWaitExternalSemaphoresAsync_v2`); consume_done is held
+        // Vulkan-side and signaled by the adapter's `end_read_access`.
         let cuda_sync_fd = unsafe { libc::dup(raw_sync_fd) };
         if cuda_sync_fd < 0 {
             tracing::error!(
@@ -6526,6 +6654,7 @@ mod cuda {
                 let _ = external_memory::destroy_external_memory(ext_mem);
             };
             gpu.produce_done_fd = Some(raw_sync_fd);
+            gpu.consume_done_fd = Some(raw_consume_fd);
             return SLPN_CUDA_ERR;
         }
         let mut sem_desc = MaybeUninit::<sys::cudaExternalSemaphoreHandleDesc>::zeroed();
@@ -6553,6 +6682,7 @@ mod cuda {
                     let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
                     let _ = external_memory::destroy_external_memory(ext_mem);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
@@ -6572,6 +6702,7 @@ mod cuda {
                     let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
                     let _ = external_memory::destroy_external_memory(ext_mem);
                     gpu.produce_done_fd = Some(raw_sync_fd);
+                    gpu.consume_done_fd = Some(raw_consume_fd);
                     return SLPN_CUDA_ERR;
                 }
             }
@@ -6580,7 +6711,8 @@ mod cuda {
         // ── Step 7: hand the registration to the Rust adapter ──────────
         let registration = HostImageSurfaceRegistration {
             texture: Arc::clone(&texture),
-            timeline: Arc::clone(&timeline),
+            produce_done: Arc::clone(&timeline),
+            consume_done: Arc::clone(&consume_done),
             initial_layout: VulkanLayout::UNDEFINED,
         };
         if let Err(e) = rt
@@ -6600,10 +6732,12 @@ mod cuda {
                 let _ = external_memory::destroy_external_memory(ext_mem);
             };
             gpu.produce_done_fd = Some(raw_sync_fd);
+            gpu.consume_done_fd = Some(raw_consume_fd);
             return SLPN_CUDA_ERR;
         }
 
         gpu.produce_done_fd = Some(raw_sync_fd);
+        gpu.consume_done_fd = Some(raw_consume_fd);
 
         let entry = Arc::new(RegisteredCudaImageSurface {
             ext_mem,
@@ -6616,7 +6750,8 @@ mod cuda {
             height: gpu.height,
             format: texture_format,
             texture,
-            timeline,
+            produce_done: timeline,
+            consume_done,
         });
         rt.registered_images
             .lock()
@@ -6781,8 +6916,10 @@ mod cuda {
     }
 
     fn cuda_sync_after_image_acquire(entry: &RegisteredCudaImageSurface) -> Result<(), String> {
+        // Wait on `produce_done` (the producer's edge) per single-writer-
+        // per-edge — same shape as `cuda_sync_after_acquire`.
         let wait_value = entry
-            .timeline
+            .produce_done
             .current_value()
             .map_err(|e| format!("get_semaphore_counter_value: {e}"))?;
 

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -4705,13 +4705,17 @@ mod cpu_readback {
             staging_planes.push(pb);
         }
 
-        // Import the timeline semaphore. Required for every cpu-
-        // readback surface — the host triggers signal it on every copy.
+        // Import both timeline semaphores. Required for every cpu-
+        // readback surface — the host triggers signal `produce_done` on
+        // every image_to_buffer / buffer_to_image copy; the consumer's
+        // `end_read_access` signals `consume_done` via host CPU
+        // `signal_host`. Single-writer-per-edge per
+        // `docs/architecture/adapter-timeline-single-writer.md`.
         let raw_sync_fd: RawFd = match gpu.produce_done_fd.take() {
             Some(fd) => fd,
             None => {
                 tracing::error!(
-                    "slpn_cpu_readback_register_surface: surface '{}' has no sync_fd — \
+                    "slpn_cpu_readback_register_surface: surface '{}' has no produce_done_fd — \
                      the host must register it via SurfaceStore::register_pixel_buffer_with_timeline \
                      with an exportable HostVulkanTimelineSemaphore.",
                     surface_id
@@ -4719,15 +4723,44 @@ mod cpu_readback {
                 return SLPN_CPU_READBACK_ERR;
             }
         };
-        let timeline = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+        let raw_consume_fd: RawFd = match gpu.consume_done_fd.take() {
+            Some(fd) => fd,
+            None => {
+                tracing::error!(
+                    "slpn_cpu_readback_register_surface: surface '{}' has no consume_done_fd — \
+                     the host must register both produce_done and consume_done timeline fds \
+                     per the single-writer-per-edge contract",
+                    surface_id
+                );
+                gpu.produce_done_fd = Some(raw_sync_fd);
+                return SLPN_CPU_READBACK_ERR;
+            }
+        };
+        let produce_done = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
             &rt.device,
             raw_sync_fd,
         ) {
             Ok(s) => Arc::new(s),
             Err(e) => {
                 gpu.produce_done_fd = Some(raw_sync_fd);
+                gpu.consume_done_fd = Some(raw_consume_fd);
                 tracing::error!(
-                    "slpn_cpu_readback_register_surface: from_imported_opaque_fd: {}",
+                    "slpn_cpu_readback_register_surface: produce_done from_imported_opaque_fd: {}",
+                    e
+                );
+                return SLPN_CPU_READBACK_ERR;
+            }
+        };
+        let consume_done = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+            &rt.device,
+            raw_consume_fd,
+        ) {
+            Ok(s) => Arc::new(s),
+            Err(e) => {
+                gpu.produce_done_fd = Some(raw_sync_fd);
+                gpu.consume_done_fd = Some(raw_consume_fd);
+                tracing::error!(
+                    "slpn_cpu_readback_register_surface: consume_done from_imported_opaque_fd: {}",
                     e
                 );
                 return SLPN_CPU_READBACK_ERR;
@@ -4755,11 +4788,13 @@ mod cpu_readback {
         let registration = HostSurfaceRegistration::<ConsumerMarker> {
             // Consumer-flavor cpu-readback surfaces don't import the
             // host's source VkImage — the host runs the copy on its
-            // own VkDevice and signals the shared timeline; the
-            // consumer only sees the staging buffers.
+            // own VkDevice and signals produce_done; the consumer
+            // only sees the staging buffers and signals consume_done
+            // via host CPU `signal_host` from end_read_access.
             texture: None,
             staging_planes,
-            timeline,
+            produce_done,
+            consume_done,
             initial_image_layout: VulkanLayout::GENERAL,
             format,
             width: surface_width,

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -2702,21 +2702,48 @@ mod surface_client {
             return std::ptr::null_mut();
         }
 
-        // Peel off the optional trailing sync-FD when the response carries
-        // one. The host's surface-share service appends it to SCM_RIGHTS
-        // after the DMA-BUF plane FDs and signals its presence with
-        // `has_sync_fd: true` so subprocess code can route it into the
-        // Vulkan adapter's timeline-semaphore import (#531).
-        let has_sync_fd = response
-            .get("has_sync_fd")
+        // Peel off the optional trailing producer-side `produce_done`
+        // timeline FD when the response carries one. The host's
+        // surface-share service appends it to SCM_RIGHTS after the
+        // DMA-BUF plane FDs and signals its presence with
+        // `has_produce_done_fd: true` so subprocess code can route it
+        // into the adapter's timeline-semaphore import. The
+        // single-writer-per-edge model is documented in
+        // `docs/architecture/adapter-timeline-single-writer.md`. The
+        // consumer-side `consume_done` FD travels through the same
+        // wire shape but lands in per-adapter state, not on the
+        // generic SurfaceHandle (each adapter migration claims it).
+        let has_produce_done_fd = response
+            .get("has_produce_done_fd")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        let (received_fds, sync_fd): (Vec<RawFd>, Option<RawFd>) = if has_sync_fd
-            && !received_fds.is_empty()
+        let has_consume_done_fd = response
+            .get("has_consume_done_fd")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        // Peel trailing FDs in the order the host attached them:
+        // produce_done first, then consume_done. consume_done is closed
+        // here — per-adapter migrations will reclaim it through the
+        // wire-format hooks they add.
+        let trailing_count =
+            (has_produce_done_fd as usize) + (has_consume_done_fd as usize);
+        let (received_fds, sync_fd): (Vec<RawFd>, Option<RawFd>) = if trailing_count > 0
+            && received_fds.len() >= trailing_count
         {
+            let split_at = received_fds.len() - trailing_count;
             let mut all = received_fds;
-            let sync = all.pop();
-            (all, sync)
+            let trailing: Vec<RawFd> = all.split_off(split_at);
+            // trailing[0] = produce_done (if has_produce_done_fd), then
+            // trailing[1] = consume_done (if has_consume_done_fd).
+            let mut iter = trailing.into_iter();
+            let produce_fd = if has_produce_done_fd { iter.next() } else { None };
+            let consume_fd = if has_consume_done_fd { iter.next() } else { None };
+            // Pre-migration: close consume_done here. Per-adapter
+            // migration will claim it through a new wire hook.
+            if let Some(fd) = consume_fd {
+                unsafe { libc::close(fd) };
+            }
+            (all, produce_fd)
         } else {
             (received_fds, None)
         };

--- a/libs/streamlib-python/python/streamlib/surface_adapter.py
+++ b/libs/streamlib-python/python/streamlib/surface_adapter.py
@@ -128,20 +128,25 @@ class _SurfaceTransportHandleC(ctypes.Structure):
 class _SurfaceSyncStateC(ctypes.Structure):
     """Mirror of Rust `SurfaceSyncState`.
 
-    Subprocess adapters wait/signal via the imported `SYNC_FD`
-    (`vkImportSemaphoreFdKHR`) — they cannot dereference
-    `timeline_semaphore_handle` (a host-side `VkSemaphore`).
+    Carries the dual `produce_done` + `consume_done` timeline
+    semaphores per the single-writer-per-edge rule in
+    `docs/architecture/adapter-timeline-single-writer.md`. Subprocess
+    adapters wait/signal via the imported sync_fds
+    (`vkImportSemaphoreFdKHR`) — they cannot dereference the host-side
+    `VkSemaphore` handles.
     """
 
     _fields_ = [
-        ("timeline_semaphore_handle", ctypes.c_uint64),
-        ("timeline_semaphore_sync_fd", ctypes.c_int32),
+        ("produce_done_semaphore_handle", ctypes.c_uint64),
+        ("produce_done_semaphore_sync_fd", ctypes.c_int32),
         ("_pad_a", ctypes.c_uint32),
         ("last_acquire_value", ctypes.c_uint64),
         ("last_release_value", ctypes.c_uint64),
         ("current_image_layout", ctypes.c_int32),
         ("_pad_b", ctypes.c_uint32),
-        ("_reserved", ctypes.c_uint8 * 16),
+        ("consume_done_semaphore_handle", ctypes.c_uint64),
+        ("consume_done_semaphore_sync_fd", ctypes.c_int32),
+        ("_pad_c", ctypes.c_uint32),
     ]
 
 

--- a/libs/streamlib-python/python/streamlib/tests/test_surface_adapter.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_surface_adapter.py
@@ -108,23 +108,27 @@ def test_surface_transport_handle_layout():
 
 
 def test_surface_sync_state_layout():
-    # timeline_semaphore_handle: u64 @ 0
-    # timeline_semaphore_sync_fd: i32 @ 8
+    # produce_done_semaphore_handle: u64 @ 0
+    # produce_done_semaphore_sync_fd: i32 @ 8
     # _pad_a: u32 @ 12
     # last_acquire_value: u64 @ 16
     # last_release_value: u64 @ 24
     # current_image_layout: i32 @ 32
     # _pad_b: u32 @ 36
-    # _reserved: [u8; 16] @ 40
+    # consume_done_semaphore_handle: u64 @ 40
+    # consume_done_semaphore_sync_fd: i32 @ 48
+    # _pad_c: u32 @ 52
     # total: 56, align 8
-    assert _SurfaceSyncStateC.timeline_semaphore_handle.offset == 0
-    assert _SurfaceSyncStateC.timeline_semaphore_sync_fd.offset == 8
+    assert _SurfaceSyncStateC.produce_done_semaphore_handle.offset == 0
+    assert _SurfaceSyncStateC.produce_done_semaphore_sync_fd.offset == 8
     assert _SurfaceSyncStateC._pad_a.offset == 12
     assert _SurfaceSyncStateC.last_acquire_value.offset == 16
     assert _SurfaceSyncStateC.last_release_value.offset == 24
     assert _SurfaceSyncStateC.current_image_layout.offset == 32
     assert _SurfaceSyncStateC._pad_b.offset == 36
-    assert _SurfaceSyncStateC._reserved.offset == 40
+    assert _SurfaceSyncStateC.consume_done_semaphore_handle.offset == 40
+    assert _SurfaceSyncStateC.consume_done_semaphore_sync_fd.offset == 48
+    assert _SurfaceSyncStateC._pad_c.offset == 52
     assert ctypes.sizeof(_SurfaceSyncStateC) == 56
     assert ctypes.alignment(_SurfaceSyncStateC) == 8
 

--- a/libs/streamlib-surface-client/src/linux.rs
+++ b/libs/streamlib-surface-client/src/linux.rs
@@ -16,11 +16,13 @@ use std::path::Path;
 pub const MAX_DMA_BUF_PLANES: usize = 4;
 
 /// Total SCM_RIGHTS fd budget for a single surface-share message:
-/// [`MAX_DMA_BUF_PLANES`] + 1 trailing slot for an optional timeline-semaphore
-/// OPAQUE_FD (host → subprocess Vulkan-adapter sync handoff, #531). Wire
-/// helpers validate against this ceiling; senders that aren't passing a sync
-/// FD simply leave the slot unused.
-pub const MAX_SCM_RIGHTS_FDS: usize = MAX_DMA_BUF_PLANES + 1;
+/// [`MAX_DMA_BUF_PLANES`] plane fds + 2 trailing slots for the optional
+/// `produce_done` and `consume_done` timeline-semaphore OPAQUE_FDs (the
+/// single-writer-per-edge model in
+/// `docs/architecture/adapter-timeline-single-writer.md`). Wire helpers
+/// validate against this ceiling; senders that aren't passing both
+/// timelines simply leave the trailing slots unused.
+pub const MAX_SCM_RIGHTS_FDS: usize = MAX_DMA_BUF_PLANES + 2;
 
 /// Connect to the per-runtime surface-share Unix socket.
 pub fn connect_to_surface_share_socket(socket_path: &Path) -> std::io::Result<UnixStream> {
@@ -82,9 +84,14 @@ pub fn send_message_with_fds(
     msg.msg_iov = &mut iov;
     msg.msg_iovlen = 1;
 
-    // Size the control buffer for the worst case we allow, so a late-arriving
-    // receiver that probed a smaller cap still parses our messages.
-    let cmsg_space = cmsg_space_for(MAX_DMA_BUF_PLANES);
+    // Size the control buffer for the worst case the wire allows
+    // ([`MAX_SCM_RIGHTS_FDS`]) so a sender that fills every plane slot plus
+    // both timeline-semaphore slots doesn't overrun `cmsg_buf`. The
+    // kernel reads `msg.msg_controllen` bytes from `cmsg_buf.as_mut_ptr()`
+    // during `sendmsg`; that count is computed from `fds.len()` below, so
+    // the buffer must always be large enough for the maximum allowed
+    // count even when the actual send is shorter.
+    let cmsg_space = cmsg_space_for(MAX_SCM_RIGHTS_FDS);
     let mut cmsg_buf = vec![0u8; cmsg_space];
 
     if !fds.is_empty() {
@@ -126,12 +133,14 @@ pub fn send_message_with_fds(
 /// response, or directly by the server's connection loop for each request).
 ///
 /// `max_fds` sizes the `cmsg` buffer allocated for the `recvmsg` call. It
-/// MUST be at least as large as the greatest plane count any peer will send
+/// MUST be at least as large as the greatest fd count any peer will send
 /// on this connection — if the kernel delivers more fds than the buffer
 /// holds, `MSG_CTRUNC` is set and **the surplus fds are silently leaked into
-/// the peer's table**; this helper treats that condition as an error. Callers
-/// that expect single-plane traffic can pass `1`; callers that accept
-/// multi-plane should pass `MAX_DMA_BUF_PLANES`.
+/// the peer's table**; this helper treats that condition as an error.
+/// Callers that expect single-plane traffic can pass `1`; callers that
+/// accept multi-plane should pass `MAX_DMA_BUF_PLANES`; callers that also
+/// receive trailing timeline-semaphore FDs (`produce_done` / `consume_done`)
+/// should pass [`MAX_SCM_RIGHTS_FDS`].
 ///
 /// On any failure all received fds (if any) are closed before the error is
 /// returned.
@@ -140,7 +149,7 @@ pub fn recv_message_with_fds(
     msg_len: usize,
     max_fds: usize,
 ) -> std::io::Result<(Vec<u8>, Vec<RawFd>)> {
-    let cap = max_fds.min(MAX_DMA_BUF_PLANES);
+    let cap = max_fds.min(MAX_SCM_RIGHTS_FDS);
     let cmsg_space = cmsg_space_for(cap.max(1));
     let mut cmsg_buf = vec![0u8; cmsg_space];
 
@@ -562,6 +571,75 @@ mod tests {
         assert_eq!(read_all_from_fd(response_fds[1]), b"reply-plane-1");
 
         server.join().expect("server thread");
+        let _ = std::fs::remove_file(&socket_path);
+    }
+
+    /// Round-trip exactly [`MAX_SCM_RIGHTS_FDS`] fds in a single SCM_RIGHTS
+    /// record. Exercises the new dual-timeline cap — every plane fd plus
+    /// both `produce_done` and `consume_done` OPAQUE_FD slots filled —
+    /// against the cmsg-buffer sizing on both send and recv. Mentally
+    /// revert either `cmsg_space = cmsg_space_for(MAX_SCM_RIGHTS_FDS)`
+    /// in `send_message_with_fds` or `cap = max_fds.min(MAX_SCM_RIGHTS_FDS)`
+    /// in `recv_message_with_fds` and this test fails on the last fd
+    /// (buffer overrun on send, `MSG_CTRUNC` error on recv).
+    #[test]
+    fn send_recv_round_trip_at_max_scm_rights_cap() {
+        let socket_path = tmp_socket_path("cap-edge");
+        let listener = UnixListener::bind(&socket_path).expect("bind");
+
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept");
+            let mut len_buf = [0u8; 4];
+            let mut total = 0;
+            while total < 4 {
+                let n = unsafe {
+                    libc::read(
+                        stream.as_raw_fd(),
+                        len_buf[total..].as_mut_ptr() as *mut libc::c_void,
+                        4 - total,
+                    )
+                };
+                assert!(n > 0, "server read len");
+                total += n as usize;
+            }
+            let payload_len = u32::from_be_bytes(len_buf) as usize;
+            recv_message_with_fds(&stream, payload_len, MAX_SCM_RIGHTS_FDS).expect("recv")
+        });
+
+        // Distinct contents per slot so a reordering or truncation regression
+        // is visible against an exact byte assert.
+        let patterns: Vec<Vec<u8>> = (0..MAX_SCM_RIGHTS_FDS)
+            .map(|i| format!("cap-edge-slot-{}", i).into_bytes())
+            .collect();
+        let send_fds: Vec<RawFd> = patterns
+            .iter()
+            .map(|p| make_memfd_with(p.as_slice()))
+            .collect();
+        let client = UnixStream::connect(&socket_path).expect("connect");
+        let payload = br#"{"op":"cap-edge"}"#;
+        send_message_with_fds(&client, payload, &send_fds).expect("send");
+        for fd in &send_fds {
+            unsafe { libc::close(*fd) };
+        }
+        drop(client);
+
+        let (received_payload, received_fds) = server.join().expect("server thread");
+        assert_eq!(received_payload, payload);
+        assert_eq!(
+            received_fds.len(),
+            MAX_SCM_RIGHTS_FDS,
+            "every slot delivered (no MSG_CTRUNC, no send-side buffer overrun)",
+        );
+        for (i, fd) in received_fds.iter().enumerate() {
+            assert!(*fd >= 0);
+            assert_eq!(
+                read_all_from_fd(*fd),
+                patterns[i],
+                "slot {} content preserved",
+                i
+            );
+        }
+
         let _ = std::fs::remove_file(&socket_path);
     }
 }

--- a/packages/camera/src/camera_to_cuda_copy.rs
+++ b/packages/camera/src/camera_to_cuda_copy.rs
@@ -218,6 +218,7 @@ impl CameraToCudaCopyProcessor::Processor {
                 &surface_key,
                 &pixel_buffer_rhi,
                 Some(timeline.as_ref()),
+                None,
             )
             .map_err(|e| {
                 Error::Configuration(format!(

--- a/packages/camera/src/camera_to_cuda_copy.rs
+++ b/packages/camera/src/camera_to_cuda_copy.rs
@@ -188,14 +188,27 @@ impl CameraToCudaCopyProcessor::Processor {
             PixelFormat::Bgra32,
         );
 
-        // 2. Exportable timeline. The cdylib imports it as a CUDA
-        //    timeline external semaphore so `acquire_read` blocks on
-        //    the GPU signal this processor emits per frame.
-        let timeline = Arc::new(
+        // 2. Exportable timelines — one per single-writer edge per
+        //    `docs/architecture/adapter-timeline-single-writer.md`. The
+        //    cdylib imports them as CUDA timeline external semaphores
+        //    so `acquire_read` blocks on the producer's GPU signal
+        //    (`produce_done`) and the host's next write waits on the
+        //    consumer's signal (`consume_done`).
+        let produce_done = Arc::new(
             HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
                 .map_err(|e| {
                     Error::Configuration(format!(
-                        "CameraToCudaCopy: HostVulkanTimelineSemaphore::new_exportable: {e}"
+                        "CameraToCudaCopy: HostVulkanTimelineSemaphore::new_exportable \
+                         (produce_done): {e}"
+                    ))
+                })?,
+        );
+        let consume_done = Arc::new(
+            HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+                .map_err(|e| {
+                    Error::Configuration(format!(
+                        "CameraToCudaCopy: HostVulkanTimelineSemaphore::new_exportable \
+                         (consume_done): {e}"
                     ))
                 })?,
         );
@@ -217,8 +230,8 @@ impl CameraToCudaCopyProcessor::Processor {
             .register_pixel_buffer_with_timeline(
                 &surface_key,
                 &pixel_buffer_rhi,
-                Some(timeline.as_ref()),
-                None,
+                Some(produce_done.as_ref()),
+                Some(consume_done.as_ref()),
             )
             .map_err(|e| {
                 Error::Configuration(format!(
@@ -238,7 +251,8 @@ impl CameraToCudaCopyProcessor::Processor {
                 CUDA_CAMERA_SURFACE_ID,
                 HostSurfaceRegistration::<HostMarker> {
                     pixel_buffer: pixel_buffer_arc,
-                    timeline,
+                    produce_done,
+                    consume_done,
                     initial_layout: VulkanLayout::UNDEFINED,
                 },
             )

--- a/packages/camera/src/linux/camera.rs
+++ b/packages/camera/src/linux/camera.rs
@@ -823,6 +823,7 @@ fn capture_thread_loop(
                 texture_id,
                 stream_texture,
                 None,
+                None,
                 VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
             ) {
                 tracing::warn!(

--- a/packages/camera/src/linux/camera.rs
+++ b/packages/camera/src/linux/camera.rs
@@ -391,6 +391,12 @@ struct CameraGpuResources {
     color_converter: RhiColorConverter,
     recorder: RhiCommandRecorder,
     timeline: Arc<HostVulkanTimelineSemaphore>,
+    // Per-ring-slot single-writer-per-edge exportable timeline pairs
+    // — `produce_done` signaled by the camera capture path,
+    // `consume_done` signaled by cross-process consumers. See
+    // `docs/architecture/adapter-timeline-single-writer.md`.
+    ring_produce_done: Vec<Arc<HostVulkanTimelineSemaphore>>,
+    ring_consume_done: Vec<Arc<HostVulkanTimelineSemaphore>>,
     input_storage_buffers: Vec<StorageBuffer>,
     input_mapped_ptrs: [*mut u8; 2],
     ring_textures: Vec<Texture>,
@@ -639,6 +645,16 @@ fn capture_thread_loop(
         // `docs/learnings/nvidia-dma-buf-after-swapchain.md`).
         let mut ring_textures: Vec<Texture> = Vec::with_capacity(RING_TEXTURE_COUNT);
         let mut ring_texture_ids: Vec<String> = Vec::with_capacity(RING_TEXTURE_COUNT);
+        let mut ring_produce_done: Vec<Arc<HostVulkanTimelineSemaphore>> =
+            Vec::with_capacity(RING_TEXTURE_COUNT);
+        let mut ring_consume_done: Vec<Arc<HostVulkanTimelineSemaphore>> =
+            Vec::with_capacity(RING_TEXTURE_COUNT);
+        // Per-ring-slot exportable timelines for single-writer-per-edge
+        // surface-share registration (see
+        // `docs/architecture/adapter-timeline-single-writer.md`). The
+        // `host_vulkan_device_arc()` bridge is the cdylib-safe v9
+        // accessor used elsewhere in the camera package.
+        let host_device = full.host_vulkan_device_arc()?;
         for _ in 0..RING_TEXTURE_COUNT {
             let stream_texture = full.acquire_render_target_dma_buf_image(
                 width,
@@ -646,8 +662,28 @@ fn capture_thread_loop(
                 TextureFormat::Rgba8Unorm,
             )?;
             let texture_id = uuid::Uuid::new_v4().to_string();
+            let produce_done = Arc::new(
+                HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+                    .map_err(|e| {
+                        Error::Configuration(format!(
+                            "camera: HostVulkanTimelineSemaphore::new_exportable \
+                             (produce_done): {e}"
+                        ))
+                    })?,
+            );
+            let consume_done = Arc::new(
+                HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+                    .map_err(|e| {
+                        Error::Configuration(format!(
+                            "camera: HostVulkanTimelineSemaphore::new_exportable \
+                             (consume_done): {e}"
+                        ))
+                    })?,
+            );
             ring_texture_ids.push(texture_id);
             ring_textures.push(stream_texture);
+            ring_produce_done.push(produce_done);
+            ring_consume_done.push(consume_done);
         }
 
         // DMA-BUF probe — VIDIOC_EXPBUF on each V4L2 buffer + Vulkan
@@ -746,6 +782,8 @@ fn capture_thread_loop(
             color_converter,
             recorder,
             timeline,
+            ring_produce_done,
+            ring_consume_done,
             input_storage_buffers,
             input_mapped_ptrs,
             ring_textures,
@@ -762,6 +800,8 @@ fn capture_thread_loop(
         color_converter,
         mut recorder,
         timeline: camera_timeline,
+        ring_produce_done,
+        ring_consume_done,
         input_storage_buffers,
         input_mapped_ptrs,
         ring_textures,
@@ -807,14 +847,16 @@ fn capture_thread_loop(
         "ring textures created (RGBA8 DEVICE_LOCAL DMA-BUF exportable, STORAGE | SAMPLED)",
     );
 
-    // Camera ring textures have no host-exported timeline: legacy DMA-BUF
-    // consumers read pixels via CPU mapping, not Vulkan compute, so
-    // cross-process timeline sync is unused. The post-compute barrier
-    // transitions the ring to `SHADER_READ_ONLY_OPTIMAL` before IPC publish,
-    // so the registered layout matches contents by the time any consumer
-    // dereferences `surface_id`. See
+    // Each ring slot carries a per-slot single-writer-per-edge
+    // exportable timeline pair (`produce_done` + `consume_done`); the
+    // post-compute barrier transitions the ring to
+    // `SHADER_READ_ONLY_OPTIMAL` before IPC publish, so the registered
+    // layout matches contents by the time any consumer dereferences
+    // `surface_id`. See
     // `docs/architecture/adapter-runtime-integration.md` →
-    // Dual-registration for the Path-1 / Path-2 contract.
+    // Dual-registration for the Path-1 / Path-2 contract, and
+    // `docs/architecture/adapter-timeline-single-writer.md` for the
+    // timeline pair semantics.
     for (i, (texture_id, stream_texture)) in
         ring_texture_ids.iter().zip(ring_textures.iter()).enumerate()
     {
@@ -822,8 +864,8 @@ fn capture_thread_loop(
             if let Err(e) = store.register_texture(
                 texture_id,
                 stream_texture,
-                None,
-                None,
+                Some(ring_produce_done[i].as_ref()),
+                Some(ring_consume_done[i].as_ref()),
                 VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
             ) {
                 tracing::warn!(
@@ -1264,6 +1306,8 @@ fn capture_thread_loop(
     gpu_context.clear_video_source_timeline_semaphore();
     drop(dmabuf_imported_buffers);
     drop(ring_textures);
+    drop(ring_produce_done);
+    drop(ring_consume_done);
     drop(input_storage_buffers);
     drop(recorder);
     drop(color_converter);

--- a/packages/test-fixtures/src/cpu_readback_smoke_test_processor.rs
+++ b/packages/test-fixtures/src/cpu_readback_smoke_test_processor.rs
@@ -146,18 +146,29 @@ fn run_smoke<const W: u32, const H: u32>(
         })?;
     let staging_arc = Arc::new(staging);
 
-    // Step 4: allocate exportable timeline semaphore through the
-    // cdylib-reachable constructor.
-    let timeline = HostVulkanTimelineSemaphore::new_exportable(
+    // Step 4: allocate two exportable timeline semaphores
+    // (produce_done + consume_done — single-writer-per-edge per
+    // `docs/architecture/adapter-timeline-single-writer.md`).
+    let produce_done = HostVulkanTimelineSemaphore::new_exportable(
         host_device.device(),
         0,
     )
     .map_err(|e| {
         Error::GpuError(format!(
-            "HostVulkanTimelineSemaphore::new_exportable: {e}"
+            "HostVulkanTimelineSemaphore::new_exportable (produce_done): {e}"
         ))
     })?;
-    let timeline_arc = Arc::new(timeline);
+    let produce_done_arc = Arc::new(produce_done);
+    let consume_done = HostVulkanTimelineSemaphore::new_exportable(
+        host_device.device(),
+        0,
+    )
+    .map_err(|e| {
+        Error::GpuError(format!(
+            "HostVulkanTimelineSemaphore::new_exportable (consume_done): {e}"
+        ))
+    })?;
+    let consume_done_arc = Arc::new(consume_done);
 
     // Step 5: construct CpuReadbackSurfaceAdapter against the same
     // device.
@@ -176,7 +187,8 @@ fn run_smoke<const W: u32, const H: u32>(
             HostSurfaceRegistration::<HostMarker> {
                 texture: Some(Arc::clone(&texture_arc)),
                 staging_planes: vec![Arc::clone(&staging_arc)],
-                timeline: Arc::clone(&timeline_arc),
+                produce_done: Arc::clone(&produce_done_arc),
+                consume_done: Arc::clone(&consume_done_arc),
                 initial_image_layout: VulkanLayout::UNDEFINED,
                 format: SurfaceFormat::Bgra8,
                 width: W,
@@ -218,11 +230,12 @@ fn run_smoke<const W: u32, const H: u32>(
     };
     drop(guard);
 
-    // Drop adapter + Arcs explicitly; the staging buffer / timeline
+    // Drop adapter + Arcs explicitly; the staging buffer / timelines
     // hold strong refs to the device_arc through their Drop impls
     // so the device cleanup runs at scope exit.
     drop(adapter);
-    drop(timeline_arc);
+    drop(produce_done_arc);
+    drop(consume_done_arc);
     drop(staging_arc);
     drop(texture_arc);
 

--- a/packages/test-fixtures/src/cuda_smoke_test_processor.rs
+++ b/packages/test-fixtures/src/cuda_smoke_test_processor.rs
@@ -149,16 +149,26 @@ fn run_smoke(
     })?;
     let staging_arc = Arc::new(staging);
 
-    let timeline = HostVulkanTimelineSemaphore::new_exportable(
+    let produce_done = HostVulkanTimelineSemaphore::new_exportable(
         host_device.device(),
         0,
     )
     .map_err(|e| {
         Error::GpuError(format!(
-            "HostVulkanTimelineSemaphore::new_exportable: {e}"
+            "HostVulkanTimelineSemaphore::new_exportable (produce_done): {e}"
         ))
     })?;
-    let timeline_arc = Arc::new(timeline);
+    let produce_done_arc = Arc::new(produce_done);
+    let consume_done = HostVulkanTimelineSemaphore::new_exportable(
+        host_device.device(),
+        0,
+    )
+    .map_err(|e| {
+        Error::GpuError(format!(
+            "HostVulkanTimelineSemaphore::new_exportable (consume_done): {e}"
+        ))
+    })?;
+    let consume_done_arc = Arc::new(consume_done);
 
     let adapter = Arc::new(CudaSurfaceAdapter::new(Arc::clone(&host_device)));
     adapter
@@ -166,7 +176,8 @@ fn run_smoke(
             surface_id,
             HostSurfaceRegistration::<HostMarker> {
                 pixel_buffer: Arc::clone(&staging_arc),
-                timeline: Arc::clone(&timeline_arc),
+                produce_done: Arc::clone(&produce_done_arc),
+                consume_done: Arc::clone(&consume_done_arc),
                 initial_layout: VulkanLayout::UNDEFINED,
             },
         )
@@ -201,7 +212,8 @@ fn run_smoke(
     }
     drop(guard);
     drop(adapter);
-    drop(timeline_arc);
+    drop(produce_done_arc);
+    drop(consume_done_arc);
     drop(staging_arc);
 
     Ok(SmokeOutcome::Ok(vk_buffer_debug))

--- a/packages/test-fixtures/src/surface_share_escalate_consistency_test_processor.rs
+++ b/packages/test-fixtures/src/surface_share_escalate_consistency_test_processor.rs
@@ -153,6 +153,7 @@ fn run_smoke(
             surface_id,
             &texture,
             Some(&timeline),
+            None,
             VulkanLayout::UNDEFINED,
         )
         .map_err(|e| {

--- a/packages/test-fixtures/src/surface_share_escalate_consistency_test_processor.rs
+++ b/packages/test-fixtures/src/surface_share_escalate_consistency_test_processor.rs
@@ -125,21 +125,32 @@ fn run_smoke(
     // engine-side replacement for the explicit `.escalate(|full|...)`.
     let full = ctx.gpu_full_access();
 
-    // Step 1: allocate texture + exportable timeline (the resource
-    // pair both registration paths bind to).
+    // Step 1: allocate texture + exportable timeline pair (the resource
+    // triple both registration paths bind to). Single-writer-per-edge:
+    // `produce_done` + `consume_done` per
+    // `docs/architecture/adapter-timeline-single-writer.md`.
     let host_device = full.host_vulkan_device_arc()?;
     let texture = full.acquire_render_target_dma_buf_image(
         width,
         height,
         TextureFormat::Bgra8Unorm,
     )?;
-    let timeline = HostVulkanTimelineSemaphore::new_exportable(
+    let produce_done = HostVulkanTimelineSemaphore::new_exportable(
         host_device.device(),
         0,
     )
     .map_err(|e| {
         Error::GpuError(format!(
-            "HostVulkanTimelineSemaphore::new_exportable: {e}"
+            "HostVulkanTimelineSemaphore::new_exportable (produce_done): {e}"
+        ))
+    })?;
+    let consume_done = HostVulkanTimelineSemaphore::new_exportable(
+        host_device.device(),
+        0,
+    )
+    .map_err(|e| {
+        Error::GpuError(format!(
+            "HostVulkanTimelineSemaphore::new_exportable (consume_done): {e}"
         ))
     })?;
 
@@ -152,8 +163,8 @@ fn run_smoke(
         .register_texture(
             surface_id,
             &texture,
-            Some(&timeline),
-            None,
+            Some(&produce_done),
+            Some(&consume_done),
             VulkanLayout::UNDEFINED,
         )
         .map_err(|e| {
@@ -232,7 +243,8 @@ fn run_smoke(
     drop(looked_up_texture);
     drop(_registration);
     drop(texture);
-    drop(timeline);
+    drop(produce_done);
+    drop(consume_done);
     drop(host_device);
 
     Ok(())

--- a/packages/test-fixtures/src/vulkan_smoke_test_processor.rs
+++ b/packages/test-fixtures/src/vulkan_smoke_test_processor.rs
@@ -127,11 +127,23 @@ fn run_smoke(
     )?;
     let texture_arc = stream_texture.host_vulkan_texture_arc()?;
 
-    let timeline = HostVulkanTimelineSemaphore::new(host_device.device(), 0)
-        .map_err(|e| {
-            Error::GpuError(format!("HostVulkanTimelineSemaphore::new: {e}"))
-        })?;
-    let timeline_arc = Arc::new(timeline);
+    // Single-writer-per-edge per
+    // `docs/architecture/adapter-timeline-single-writer.md`: two
+    // independent timelines, one per direction.
+    let produce_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(host_device.device(), 0).map_err(|e| {
+            Error::GpuError(format!(
+                "HostVulkanTimelineSemaphore::new (produce_done): {e}"
+            ))
+        })?,
+    );
+    let consume_done = Arc::new(
+        HostVulkanTimelineSemaphore::new(host_device.device(), 0).map_err(|e| {
+            Error::GpuError(format!(
+                "HostVulkanTimelineSemaphore::new (consume_done): {e}"
+            ))
+        })?,
+    );
 
     let adapter = Arc::new(VulkanSurfaceAdapter::new(Arc::clone(&host_device)));
     adapter
@@ -139,7 +151,8 @@ fn run_smoke(
             surface_id,
             HostSurfaceRegistration {
                 texture: Arc::clone(&texture_arc),
-                timeline: Arc::clone(&timeline_arc),
+                produce_done: Arc::clone(&produce_done),
+                consume_done: Arc::clone(&consume_done),
                 initial_layout: VulkanLayout::UNDEFINED,
             },
         )
@@ -172,7 +185,8 @@ fn run_smoke(
     }
     drop(guard);
     drop(adapter);
-    drop(timeline_arc);
+    drop(produce_done);
+    drop(consume_done);
     drop(texture_arc);
 
     Ok(vk_image_raw)


### PR DESCRIPTION
## Summary

Closes #1087. Lifts the cuda, vulkan, and cpu-readback surface adapters from "one shared timeline per surface with two writers (host producer + subprocess consumer)" to **two timelines per surface, one writer each**: `produce_done` signaled exclusively by the producer process, `consume_done` exclusively by the consumer process. Replaces the safety-net clamp from #1086 with the architectural fix the issue body called for.

Reference: `docs/architecture/adapter-timeline-single-writer.md` (committed in d0cf1a53).

## What's in the diff

14 logical-checkpoint commits, each builds clean and keeps the `streamlib-engine` lib suite at **1410 / 1410 passing**:

**Foundation (already on `main`-equivalent state at branch start):**
- `d0cf1a53` — architecture doc
- `60d39272` — `MAX_SCM_RIGHTS_FDS = MAX_DMA_BUF_PLANES + 2` (wire budget for both timeline FDs)
- `5a9842e1` — surface-share IPC carries `produce_done_fd` + `consume_done_fd`
- `571e2cb0` — `SurfaceStore::register_texture` + `register_pixel_buffer_with_timeline` take both timelines
- `8f738c41` — `VulkanTimelineSemaphoreLike::current_value()`

**This session:**
- `14684262` — `SurfaceSyncState` (adapter-abi) carries both timeline handles + sync_fds; polyglot Python ctypes + Deno UnsafePointerView mirrors in lockstep
- `d4ab1b5f` — cdylib `SurfaceHandle` carries both timeline FDs (rename `sync_fd` → `produce_done_fd`, add `consume_done_fd`; wire-parse + cache + Drop)
- `7a840373` — cuda adapter dual-timeline (state, adapter signal/wait split, plugin-abi vtable, cdylib import+register paths in both Python + Deno)
- `e1762c5e` — vulkan adapter dual-timeline (state, adapter signal/wait split, plugin-abi vtable, cdylib paths, helper bin, all tests + skia tests + `concurrent_reads_two_subprocesses` deferred under v1)
- `ba222805` — cpu-readback dual-timeline (state, trigger context, acquire/release flow, `HostSurfaceRegistrationRepr` ABI from 72→80 bytes, cdylib paths). Restores the consumer-side `signal_host` defanged in #562 — now sound under dual-timeline.
- `b4cc9dd1` — examples sweep: every `register_texture` / `register_pixel_buffer_with_timeline` call site now allocates two real exportable timelines
- `21bbf56c` — neighboring arch docs (adapter-runtime-integration, subprocess-rhi-parity, adapter-authoring, texture-registration) refreshed
- `2321e855` — remove the `signal_host` safety-net clamp (now dead by construction)
- `a111782b` — pr-review-gate follow-up: soften consumer protocol + SurfaceState code snippet in the architecture doc to match v1's kernel-counter wait shape
- `b6612b12` — **included engine fix #1 (see "Included engine fixes" section below):** route `VulkanToneMapper::apply_with_layouts` in-place check through the FullAccess vtable so cdylib-resident consumers (BlendingCompositor) don't trip the `host_inner()` cdylib panic-guard. Logically belongs against `main`; included here to unblock the E2E verification window.
- `c98b5920` — **included engine fix #2 (see "Included engine fixes" section below):** `InputMailboxesVTable` v1 → v2 with `max_payload_for_port` slot so the cdylib `read_raw` allocates exactly the schema-declared `metadata.max_payload_bytes` and never truncates. Replaces the 4 KiB-then-retry dance from #894 that was silently incinerating every >4 KiB frame at the FFI boundary (audio-mixer-demo silent-output bug). Logically belongs against `main`; same reason.

## Included engine fixes (out-of-scope but unblock E2E verification)

This branch includes two engine-level fixes that logically belong against `main`. Both surfaced during E2E testing of this PR's dual-timeline work and would have blocked verification if landed elsewhere first.

### Fix #1 — `b6612b12 fix(rhi): route tone-mapper in-place check through FullAccess vtable`

The in-place src/dst sanity check added in #1095 (`vulkan_tone_mapper.rs:131`) calls `src.vulkan_inner().image() == dst.vulkan_inner().image()`. `vulkan_inner()` routes through `Texture::host_inner()`, which panics under the cdylib panic-guard by design — the host owns the RHI and cdylib code must reach `HostVulkanTexture` through the FullAccess vtable, not by reading the host-private `TextureInner` layout directly.

The `BlendingCompositor` in `camera-python-display`'s effects cdylib is the first consumer to hit it: `normalize_layer` engages whenever a source frame's `ColorInfo` doesn't match the working-space (the default for camera frames, which don't stamp `ColorInfo`), `RhiToneMapper::apply_with_layouts` panics on first dispatch, and the pipeline limps along with a dead compositor edge until shutdown — blocking the `camera-python-display` E2E that verifies this PR's dual-timeline work.

The fix replaces both `vulkan_inner()` reaches with `host_vulkan_texture_arc()`, the documented cdylib-safe accessor (`host_rhi.rs:112-148`): in host mode it `Arc::clone`s the inner directly, in cdylib mode it dispatches through the v10 `GpuContextFullAccessVTable::host_vulkan_texture_arc` slot so the host returns its own `Arc<HostVulkanTexture>` and the `VkImage` comparison runs against the real host-resident handles. Host still owns the truth; cdylib gets capability-restricted dispatch — the engine-model separation #1095 was written under stays intact.

### Fix #2 — `c98b5920 fix(plugin-abi): per-port max_payload vtable slot — cdylib allocates exactly, no truncation`

#894 introduced the host-allocates `InputMailboxes` FFI ABI with a hardcoded 4 KiB scratch buffer on the cdylib side plus a "resize and retry on truncation" loop, paired with a host-side `read_raw` callback that **silently dropped the popped frame on truncation** (with a deferred-follow-up comment in the code: *"the alternative requires reworking PortMailbox; deferred to a follow-up when the truncation path is hit in practice"*). The truncation path was hit immediately by the `audio-mixer-demo`: an `AudioFrame` with 512 stereo f32 samples msgpack-serializes to ~5 KiB, exceeded the 4 KiB scratch, and every frame was silently incinerated at the FFI boundary — zero errors, zero log lines, just silence at the speaker.

The 4 KiB scratch was a hole in the all-dynamic-package-loading story. The publisher honors `metadata.max_payload_bytes`. The iceoryx2 service is sized by it. Schemas declare it. The cdylib's read side was the one place that ignored the same source of truth the rest of the system was already using. **v2 closes the hole: declared things are honored end-to-end.**

The fix bumps `INPUT_MAILBOXES_VTABLE_LAYOUT_VERSION` 1 → 2 with a new `max_payload_for_port` slot (5 slots @ 8 bytes + 8-byte header = 48 bytes). The cdylib's `read_raw` queries the schema-declared max via the new slot, allocates exactly, makes a single read attempt — no retry, no stash, no truncation path. The iceoryx2 service is sized by the same bound on the publisher side, so truncation is structurally impossible. The host-side truncation branch is converted from "silently drop" to "hard error" (protocol violation surfaces loudly) and the deferred-follow-up comment is deleted.

ABI break: v1 plugin `.slpkg`s are rejected at load time by the existing `vtable.layout_version` check. No third-party plugins exist yet, so this is a non-event in practice. Every in-tree plugin rebuilds via `cargo xtask build-plugins`.

### Lift plan for both fixes

Both commits are self-contained and cherry-pick cleanly onto a fresh branch off `main` as their own `fix(rhi):` / `fix(plugin-abi):` PRs whenever convenient post-merge (or before, if a reviewer prefers them split). The duplicates drop on rebase. Routed them here only to keep the testing window open for #1097.

## Exit criteria

- [x] Each surface in cuda + vulkan + cpu-readback adapters carries two timelines (`produce_done` + `consume_done`), each with one writer.
- [x] Surface-share IPC schema carries the second timeline FD per surface (OPAQUE_FD-exportable).
- [x] All three adapters' acquire/release paths route to the appropriate timeline; no multi-writer pattern remains.
- [x] Safety-net clamp removed from `signal_host` (consumer-rhi + host vulkan_sync).
- [x] Architecture doc defines the single-writer rule.

## v1 deferrals (explicit)

- **Multi-process concurrent consumers.** The vulkan adapter's `concurrent_reads_two_subprocesses` test is `#[ignore]`'d with a doc comment pointing at the v1 deferral. The architecture doc explicitly defers this — "lift to N `consume_done` timelines when a real consumer attests to needing it; don't pre-design." Same-process concurrent reads (multiple Python threads inside one subprocess) remain fully supported via the existing `read_holders` semantics.
- **Per-frame `produce_done` value publishing IPC.** v1 uses `peer.current_value()` (kernel counter) as the wait target — sufficient for steady-state ordering. Doc explicitly calls out the future shape (publish on `VideoFrame` IPC) for use cases that need to wait on a specific future frame.
- **`SurfaceSyncState.last_release_value`** is now dead in production code; preserved in the ABI struct for layout stability (renaming would be ABI-breaking). Followup cleanup if needed.
- **OpenGL + Skia adapter migration** is out of scope for #1087 (this issue is explicit about cuda + vulkan + cpu-readback). Those adapters still ride the single-timeline shape; examples that publish surfaces consumed by them allocate both timelines today so the second slot becomes load-bearing automatically when those adapters lift.

## Test plan

### Workspace gate (run by Claude)

```
cargo check --workspace --tests        # zero errors
cargo test -p streamlib-engine --lib    # 1410 / 1410 passing
cargo test -p streamlib-adapter-cuda --lib       # 30 passing
cargo test -p streamlib-adapter-vulkan --lib      # 17 passing
cargo test -p streamlib-adapter-cpu-readback --lib # 19 passing
cargo test -p streamlib-adapter-abi --lib         # 33 passing (ABI layout regression)
```

Python + Deno layout regression suites green:
```
pytest libs/streamlib-python/python/streamlib/tests/test_surface_adapter.py
cd libs/streamlib-deno && deno test surface_adapter_test.ts
```

### E2E — verified (with both included engine fixes)

After a clean rebuild (workspace `cargo clean`, all nested `target/` dirs, every `.slpkg`, Python + Deno `_generated_` codegen) + both included engine fixes (`b6612b12` + `c98b5920`):

| Scenario | Exit | PNGs | Failure signatures |
|---|---|---|---|
| `camera-display` | 0 | 3 | 0 |
| `camera-python-display` | 0 | 4 | 0 |
| `audio-mixer-demo` | 0 | n/a | 0 — C major chord audible end-to-end through PipeWire to RTX 3090 HDMI |

All runs grep'd for: `OUT_OF_DEVICE_MEMORY` / `DEVICE_LOST` / `SIGSEGV` / `signal_host: clamping` / `VUID-VkSemaphoreSignalInfo-value-03258` / `VUID-` / `reached from cdylib code` / `max_payload_for_port returned 0` / `protocol violation` — **zero matches across all three**.

`audio-mixer-demo` specifically: `[ProcessorAudioConverter] Initializing resampler: 48000Hz -> 44100Hz (2 channels, chunk_size=512)` log now fires — that log was absent in every prior run and was the smoking-gun signal of the data flow that was broken by the FFI truncation drop pre-v2. Pipeline: `ChordGenerator` audio-clock tick → polling-thread `read::<AudioFrame>` → `ProcessorAudioConverter` 48k→44.1k resampler → cpal ring buffer → ALSA `default` → PipeWire → RTX 3090 HDMI.

`camera-python-display` frame 90 PNG visually confirmed: vivid SMPTE bars (camera) + CRT scanlines/grain/vignette (effects cdylib) + "N54 NIGHT CITY NEWS" lower-third (Skia subprocess, Python) + "CL" watermark (Skia subprocess, Python) + glitch color-bleed at top-left (OpenGL subprocess, Python) + Breaking-News PiP slide-in at top-right (CUDA + OpenGL subprocess, Python — AvatarCharacter pose+render) all composited and displayed. Full dual-timeline single-writer-per-edge pipeline working end-to-end under live load.

Repro:

```
STREAMLIB_CAMERA_DEVICE=/dev/video0 \
STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=/tmp/cpd/png_samples \
STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30 \
STREAMLIB_DISPLAY_FRAME_LIMIT=120 \
  cargo run -p camera-python-display
```

### E2E Test Report

- **Scenario**: camera+display + Python subprocess effects via dual-timeline cuda + opengl + skia adapters
- **Example**: `camera-python-display`
- **Camera device**: `/dev/video0` (vivid)
- **Build profile**: debug
- **Outcome**: **Pass** — zero failure signatures across `camera-display` + `camera-python-display` + `audio-mixer-demo`; PNG visual verification confirms full pipeline rendering through the dual-timeline contract; audio confirms FFI data flow through the new v2 `max_payload_for_port` slot.

### Known residual (unrelated to #1097)

`camera-python-display`'s shutdown emits an `iceoryx2-bb-posix-0.8.1/src/file_descriptor.rs:216` panic during the vendor library's fd cleanup, *after* `[stop] Graceful shutdown complete` + `✓ Pipeline stopped gracefully`. Pipeline ran fully and shut down gracefully — the panic is teardown-only inside the iceoryx2 dependency. Not related to PR #1097 or either included engine fix. Worth a follow-up but doesn't gate this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

