### PR TITLE
chore(972): sweep plugin-system vocabulary to canonical 5-term set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,11 +38,11 @@ The engine is a pure substrate. It ships with **no processors, no schemas, no `s
 
 **The target distribution shape**: a plugin author in a completely separate GitHub repo, building on a completely different machine with a different rustc version and different transitive Cargo dep graph, can publish a `.slpkg` file. A streamlib host (e.g. tatolab/drone-racer, or any third-party host that Cargo-deps `streamlib`) loads that `.slpkg` at runtime via `dlopen` and the plugin's processors register cleanly into the host's runtime graph. The plugin author and the host author **never coordinate toolchains**.
 
-What makes this work: every type that crosses the plugin / engine FFI boundary is `#[repr(C)]`, with its byte layout pinned by a layout regression test in `streamlib-plugin-abi`. The plugin and the host must agree on:
+What makes this work: every type that crosses the plugin ABI is `#[repr(C)]`, with its byte layout pinned by a layout regression test in `streamlib-plugin-abi`. The plugin and the host must agree on:
 
 - Target triple (`x86_64-unknown-linux-gnu`, etc.) — for the obvious reasons
 - `streamlib-plugin-abi` version — the C-ABI vtable contract
-- `streamlib-consumer-rhi` version — the consumer-side carve-out (β-shape texture / buffer / device types)
+- `streamlib-consumer-rhi` version — the consumer-side carve-out (PluginAbiObject texture / buffer / device types)
 
 They do NOT need to agree on:
 
@@ -51,11 +51,11 @@ They do NOT need to agree on:
 - Feature flags on shared transitive deps
 - Optimization profile
 
-**Where the dream currently leaks**: Phase D (#906) and Phase C2 (#905) shipped some FullAccess methods that return `Arc<HostInternalType>` via `Arc::into_raw` / `Arc::from_raw` raw-pointer transit. Those code paths DO require rustc-version coupling because the host-internal types aren't `#[repr(C)]`. Issue #917 closes that gap by β-shape-refactoring the affected return types into `#[repr(C)] { handle, vtable }` pairs (mirroring `RhiCommandQueue` / `CommandBuffer`). After #917 lands, no FFI return type leaks host layout, and the cross-repo dream is fully real.
+**Where the dream currently leaks**: Phase D (#906) and Phase C2 (#905) shipped some FullAccess methods that return `Arc<HostInternalType>` via `Arc::into_raw` / `Arc::from_raw` raw-pointer transit. Those code paths DO require rustc-version coupling because the host-internal types aren't `#[repr(C)]`. Issue #917 closes that gap by refactoring the affected return types into `#[repr(C)] { handle, vtable }` PluginAbiObject pairs (mirroring `RhiCommandQueue` / `CommandBuffer`). After #917 lands, no plugin ABI return type leaks host layout, and the cross-repo dream is fully real.
 
 **What's NOT in scope** (deferred to its own milestone): a hosted marketplace / registry / index. Today's distribution model is "package author hands you an `.slpkg` directly, or you clone the repo and run `streamlib pack` yourself". A managed registry where you'd run `streamlib install @tatolab/camera` is a separate future deliverable.
 
-**Implication for new architectural work**: any cross-FFI surface added in this codebase MUST be `#[repr(C)]` end-to-end. If you're tempted to return `Arc<SomeHostInternalType>` from a cdylib-callable method, stop — the answer is to β-shape the type. The dormant `clone_*` / `drop_*` slots already present on the FullAccess vtable are infrastructure for this. The "rustc-version coupling stays" framing that previously appeared in the All-Dynamic Package Loading milestone body was a permissive fallback while β-shape coverage was incomplete; it's superseded as of 2026-05-22.
+**Implication for new architectural work**: any plugin ABI surface added in this codebase MUST be `#[repr(C)]` end-to-end. If you're tempted to return `Arc<SomeHostInternalType>` from a cdylib-callable method, stop — the answer is to expose the type as a PluginAbiObject. The dormant `clone_*` / `drop_*` slots already present on the FullAccess vtable are infrastructure for this. The "rustc-version coupling stays" framing that previously appeared in the All-Dynamic Package Loading milestone body was a permissive fallback while PluginAbiObject coverage was incomplete; it's superseded as of 2026-05-22.
 
 ### Before Creating Any New Abstraction
 
@@ -620,10 +620,10 @@ make sense if the surrounding files were renamed or restructured.
   pipeline runs end-to-end with zero errors / zero panics / zero
   validation complaints but produces all-zero / black output. Trigger:
   a host-side `make_*_borrow` helper constructed a `ManuallyDrop`'d
-  β-shape borrow with the cached POD fields zeroed; host-side code
+  PluginAbiObject borrow with the cached POD fields zeroed; host-side code
   then read a cached field off the borrow (`.width()` / `.byte_size()`
   / etc.) and got zero. Read before adding a new host wrapper that
-  reconstructs a borrowed β-shape from a `*const c_void` handle.
+  reconstructs a borrowed PluginAbiObject from a `*const c_void` handle.
 - @docs/learnings/cross-process-vkimage-layout.md — Cross-process
   `VkImage` layout coordination. `VkImageLayout` is independent state
   per `VkDevice` by Vulkan spec — no shared mutable tracker. The

--- a/docs/architecture/cdylib-reachability.md
+++ b/docs/architecture/cdylib-reachability.md
@@ -24,7 +24,7 @@ five disconnected precedents.
 Two known traps:
 
 1. **Constructor-bridge trap.** Seeing a `host_inner()` panic on one
-   `Host*` β-shape (e.g., `Texture::host_inner()`) and assuming by
+   `Host*` PluginAbiObject (e.g., `Texture::host_inner()`) and assuming by
    analogy that every other `Host*` constructor on the engine needs a
    bridge. That assumption is wrong by default — most `Host*`
    constructors take only `&Arc<HostVulkanDevice>` plus primitives
@@ -90,14 +90,15 @@ something on the host side.
                     │
      ┌──────────────┼──────────────┬─────────────────────┐
      │              │              │                     │
-  one-time     per-frame      need a β-shape       need a host-Arc
-  privileged   hot-path       binding (set_X       (Arc<HostVulkanX>)
-  setup        binding/work   on compute kernel)
+  one-time     per-frame      need a              need a host-Arc
+  privileged   hot-path       PluginAbiObject     (Arc<HostVulkanX>)
+  setup        binding/work   binding (set_X
+                              on compute kernel)
      │              │              │                     │
      ▼              ▼              ▼                     ▼
    Pattern 4     Pattern 5      Pattern 3             Pattern 2
-   escalate +    per-method     per-method            β-shape Arc-
-   FullAccess    vtable slot    vtable slot           transit slot
+   escalate +    per-method     per-method            PluginAbiObject
+   FullAccess    vtable slot    vtable slot           Arc-transit slot
    work in       w/ raw         (set_storage_         (host_vulkan_
    closure       vulkanalia     buffer_pixel etc)    X_arc — #1066/
                  handle wire                          68/69/70/71)
@@ -125,19 +126,19 @@ The five patterns:
   through them. This restores the historical contract
   ("`FullAccess` in signature → direct access in body") for every
   runtime variant.
-- **Pattern 2: β-shape Arc-transit vtable slot** —
+- **Pattern 2: PluginAbiObject Arc-transit vtable slot** —
   `host_vulkan_device_arc`, `host_vulkan_texture_arc`,
   `host_vulkan_pixel_buffer_arc`, etc. Hands cdylib an
   `Arc<HostVulkan*>` raw pointer it can call host-public accessors
   on. Use for accessor returns where the engine-internal type can
-  cross the FFI as an Arc handle (#1066/68/69/70/71).
+  cross the plugin ABI as an Arc handle (#1066/68/69/70/71).
 - **Pattern 3: per-method vtable slot** — `set_storage_buffer_pixel`
   and siblings on `VulkanComputeKernel` (and the equivalent on
   `VulkanGraphicsKernel`, `VulkanRayTracingKernel`,
   `RhiCommandRecorder`). Each binding/dispatch method that takes
-  engine-public β-shapes gets its own typed vtable slot with the
+  engine-public PluginAbiObjects gets its own typed vtable slot with the
   same shape on both sides. Use for hot-path binding work where the
-  method args ARE cross-DSO-safe types.
+  method args ARE plugin-ABI-safe types.
 - **Pattern 4: escalate to FullAccess** — `gpu_limited_access().escalate(|full| ...)`
   from a **LimitedAccess context** (`process()`, `on_pause()`,
   `on_resume()`, Reactive `start()`). The historical primitive for
@@ -160,7 +161,7 @@ The five patterns:
   reconstructs the typed handle via `Handle::from_raw` before
   forwarding. Same structural shape as Pattern 3 — the asymmetry
   is that the binding payload here is a raw vulkanalia integer
-  rather than an engine-public β-shape. The host method stays
+  rather than an engine-public PluginAbiObject. The host method stays
   `pub(crate)` because subprocess (Python/Deno) cdylibs don't
   link the engine SDK code that reaches it; only workspace plugin
   cdylibs (h264/h265/camera) hit this path. This pattern landed
@@ -180,7 +181,7 @@ new constructor on an existing type).
 
   ┌─────────────────────────────────────────────────────────┐
   │ Q1: Does the constructor / extractor body reach for     │
-  │     `host_inner()` (β-shape deref) or                   │
+  │     `host_inner()` (PluginAbiObject deref) or           │
   │     `host_callbacks()` (cdylib-mode guard)?             │
   └───────────────┬─────────────────────────────────────────┘
                   │
@@ -203,7 +204,7 @@ Applies when:
   `dma_buf_image_pool*`, `opaque_fd_buffer_pool*`,
   `opaque_fd_image_pool*`, `drm_modifier_table`, etc.) plus
   `vulkanalia-vma`.
-- No `host_inner()` deref, no `host_callbacks()` check, no β-shape
+- No `host_inner()` deref, no `host_callbacks()` check, no PluginAbiObject
   indirection.
 
 Cdylib path:
@@ -245,9 +246,9 @@ The existing route-2 paths today (verified at the docstring sites):
 Applies when:
 
 - The constructor / extractor must touch host-private state
-  (`host_inner()` for β-shape deref, host-only registries, etc.).
-- Or: the resource crosses the FFI as a non-`Arc` opaque handle
-  (β-shape with `(handle, vtable, POD)` layout, like `Texture` /
+  (`host_inner()` for PluginAbiObject deref, host-only registries, etc.).
+- Or: the resource crosses the plugin ABI as a non-`Arc` opaque handle
+  (PluginAbiObject with `(handle, vtable, POD)` layout, like `Texture` /
   `PixelBuffer` / `StorageBuffer`).
 
 Existing route-1 bridges:
@@ -255,7 +256,7 @@ Existing route-1 bridges:
 - **v9 `host_vulkan_device_arc`** — hands a cloned
   `Arc<HostVulkanDevice>` raw pointer to the cdylib.
 - **v10 `host_vulkan_texture_arc`** — extracts an
-  `Arc<HostVulkanTexture>` from a `Texture` β-shape (the β-shape's
+  `Arc<HostVulkanTexture>` from a `Texture` PluginAbiObject (the PluginAbiObject's
   `host_inner()` panics in cdylib mode, hence the bridge).
 
 When adding a new slot:
@@ -278,7 +279,7 @@ whether the constructor bodies actually need bridges. To the best
 of our current knowledge, the historical case that motivated this
 doc had three of four "bridges" proposed defensively turn out to
 be already-working via route 2 — only one extractor (the
-`Texture` β-shape's `host_inner()` deref) needed a real bridge.
+`Texture` PluginAbiObject's `host_inner()` deref) needed a real bridge.
 
 Before filing a "bridge needed for X" issue:
 
@@ -318,7 +319,7 @@ in this codebase before being caught.
    `feedback_examples_no_underscore_reachthrough` memory documents.
 
 3. ❌ **`unsafe { &*(handle as *const SomeHostType) }` from cdylib
-   code.** Cdylib code lives in a different DSO with a separately-
+   code.** Cdylib code lives in a different plugin with a separately-
    compiled (potentially different rustc-version) view of
    `SomeHostType`'s layout. Even when the dlopen happens to share
    layout today, a routine `cargo update` on either side breaks

--- a/docs/architecture/plugin-abi.md
+++ b/docs/architecture/plugin-abi.md
@@ -37,7 +37,7 @@ coupling leak.
 | `streamlib-plugin-abi` | Pure `#[repr(C)]` wire shapes + ABI version constants. No methods, no engine internals. Layout regression tests pin every struct's byte layout. | Host engine AND every cdylib. |
 | `streamlib-consumer-rhi` | Consumer-side carve-out of the Vulkan RHI. Holds `ConsumerVulkanDevice`, `ConsumerVulkanTexture`, `ConsumerVulkanBuffer`, `ConsumerVulkanTimelineSemaphore`, `VulkanLayout`, `TextureFormat`, `TextureUsages`, `PixelFormat`, and the `VulkanRhiDevice` / `DevicePrivilege` / `VulkanTextureLike` / `VulkanTimelineSemaphoreLike` trait machinery. | Host engine AND every cdylib that touches GPU. |
 | `streamlib-engine` (host-side) | Privileged engine internals: `HostVulkanDevice`, VMA pools, queue mutex, modifier probe, kernel construction, swapchain. Plus the host implementations of every vtable callback (in `core/plugin/host_services.rs`). | Host process only. Cdylibs CANNOT Cargo-dep this. |
-| `streamlib-sdk` | Thin re-export façade. Cdylibs Cargo-dep `streamlib = "..."` and get the β-shape types, the `processor` macro, the lifecycle traits — without reaching `HostVulkanDevice` etc. | Host AND cdylibs (re-exports the safe surface from `streamlib-engine`). |
+| `streamlib-sdk` | Thin re-export façade. Cdylibs Cargo-dep `streamlib = "..."` and get the PluginAbiObject types, the `processor` macro, the lifecycle traits — without reaching `HostVulkanDevice` etc. | Host AND cdylibs (re-exports the safe surface from `streamlib-engine`). |
 
 The capability boundary is enforced by the type system: a cdylib's
 `cargo tree` excludes `streamlib-engine` and therefore physically
@@ -47,7 +47,7 @@ returns 0 — that's the lock.
 
 ## The vtable catalog
 
-Every cross-DSO call dispatches through a `#[repr(C)]` vtable whose
+Every plugin ABI call dispatches through a `#[repr(C)]` vtable whose
 layout is pinned by a regression test in `streamlib-plugin-abi`. To
 the best of our current knowledge the in-tree set as of this doc is:
 
@@ -108,10 +108,10 @@ the best of our current knowledge the in-tree set as of this doc is:
   (register, lookup, update layout, unregister) for cdylibs that own
   publishable surfaces.
 
-### β-shape methods vtables
+### PluginAbiObject methods vtables
 
 Per-type vtables that carry the method dispatch for an Arc-handle
-β-shape (the `(handle, vtable, methods_vtable, cached POD)` layout):
+PluginAbiObject (the `(handle, vtable, methods_vtable, cached POD)` layout):
 
 - **`TextureRingMethodsVTable`** — `acquire_next`, slot accessor.
 - **`VulkanComputeKernelMethodsVTable`** — `bindings`, the various
@@ -145,27 +145,27 @@ wrapper. Adapter ABI is its own audit boundary — see
 [`adapter-runtime-integration.md`](adapter-runtime-integration.md)
 for the runtime integration shape.
 
-## β-shape pattern
+## PluginAbiObject pattern
 
-Every Arc-holding type that crosses the cdylib boundary has the same
+Every Arc-holding type that crosses the plugin ABI has the same
 shape: a fixed `(handle, vtable)` prefix for clone/drop dispatch
-plus cached POD fields read by `&self` getters with no FFI hop.
+plus cached POD fields read by `&self` getters with no plugin ABI hop.
 Types that expose methods beyond POD getters (the kernel +
-recorder + color converter β-shapes) carry an additional
+recorder + color converter PluginAbiObjects) carry an additional
 `methods_vtable` pointer between the parent vtable and the cached
-POD; pure resource-handle β-shapes (`Texture`, `PixelBuffer`,
+POD; pure resource-handle PluginAbiObjects (`Texture`, `PixelBuffer`,
 buffer types, `TextureRegistration`) skip it.
 
-Reference layout for a POD-only β-shape (no methods_vtable):
+Reference layout for a POD-only PluginAbiObject (no methods_vtable):
 
 ```rust
 #[repr(C)]
 pub struct Texture {
     /// Opaque handle to host's `Arc<TextureInner>::into_raw()`.
     handle: *const c_void,
-    /// Vtable for cross-DSO clone/drop dispatch.
+    /// Vtable for plugin ABI clone/drop dispatch.
     vtable: *const GpuContextLimitedAccessVTable,
-    /// Cached POD fields read by `&self` getters with no FFI hop.
+    /// Cached POD fields read by `&self` getters with no plugin ABI hop.
     width_cached: u32,
     height_cached: u32,
     format_raw: u32,
@@ -173,18 +173,18 @@ pub struct Texture {
 }
 ```
 
-Reference layout for a method-bearing β-shape (has methods_vtable):
+Reference layout for a method-bearing PluginAbiObject (has methods_vtable):
 
 ```rust
 #[repr(C)]
 pub struct VulkanComputeKernel {
     /// Opaque handle to host's `Arc<VulkanComputeKernelInner>`.
     handle: *const c_void,
-    /// Parent vtable for cross-DSO clone/drop dispatch.
+    /// Parent vtable for plugin ABI clone/drop dispatch.
     vtable: *const GpuContextFullAccessVTable,
     /// Per-type vtable for method dispatch.
     methods_vtable: *const VulkanComputeKernelMethodsVTable,
-    /// Cached POD fields read by `&self` getters with no FFI hop.
+    /// Cached POD fields read by `&self` getters with no plugin ABI hop.
     cached_push_constant_size: u32,
     _reserved_padding: u32,
 }
@@ -198,21 +198,21 @@ Three invariants the pattern locks:
    host's `Arc` directly. Both slots short-circuit cleanly on null
    handles.
 2. **POD getters read from cached fields.** `texture.width()` returns
-   `self.width_cached` with no FFI hop; this is what makes the
+   `self.width_cached` with no plugin ABI hop; this is what makes the
    per-frame hot path cheap. The cached fields are populated at
    construction by `from_arc_into_raw` and never mutate over the
    handle's lifetime (the underlying resource is immutable in size /
    format).
-3. **Methods dispatch through `methods_vtable`** when the β-shape
+3. **Methods dispatch through `methods_vtable`** when the PluginAbiObject
    exposes more than just POD getters. A consumer-side `&self` method
-   either reads a cached field (no FFI) or calls
-   `(*methods_vtable).slot(handle, args...)` (one FFI hop). The
+   either reads a cached field (no plugin ABI hop) or calls
+   `(*methods_vtable).slot(handle, args...)` (one plugin ABI hop). The
    host-mode and cdylib-mode codepaths produce identical observable
    behavior.
 
 ## Mode routing — host vs cdylib
 
-The same β-shape struct serves both host and cdylib callers. The
+The same PluginAbiObject struct serves both host and cdylib callers. The
 deciding factor at runtime is:
 
 ```rust
@@ -272,9 +272,9 @@ layout (via the guarded `host_inner` family), ONE way to call into
 host code from cdylib (via vtable dispatch), and the guards make
 the second always visible at compile time when violated.
 
-## The cross-DSO refcount contract
+## The plugin ABI refcount contract
 
-When the host hands a β-shape across the FFI boundary, the wire
+When the host hands a PluginAbiObject across the plugin ABI, the wire
 encoding is `Arc::into_raw(inner) as *const c_void`. The cdylib
 holds the resulting opaque `handle` and uses it for:
 
@@ -291,7 +291,7 @@ inner. The host owns Arc lifecycle end-to-end.
 ### The `make_*_borrow` trap
 
 The host-side vtable callbacks routinely need to reconstruct a
-`ManuallyDrop<β-shape>` from a `*const c_void` handle the cdylib
+`ManuallyDrop<PluginAbiObject>` from a `*const c_void` handle the cdylib
 passed back to invoke a method on. The `make_*_borrow(handle)`
 helpers in `host_services.rs` build that borrow.
 
@@ -330,7 +330,7 @@ The `make_borrow_cached_field_regression_tests` module in
 host-side resource of known dimensions, constructs the borrow, and
 asserts the borrow's POD getters return the real values.
 
-## Cross-DSO contracts the ABI commits to
+## Plugin ABI contracts the ABI commits to
 
 ### Wire constants
 
@@ -384,7 +384,7 @@ which catches Rust panics with `catch_unwind` and converts them into
 a clean error to the cdylib caller — typed by the slot's return
 shape (`-2` for `i32` returns, a default-`""` for `&str` returns,
 etc.). A panic in a host-side vtable implementation NEVER unwinds
-across the FFI boundary; that would be undefined behavior since the
+across the plugin ABI; that would be undefined behavior since the
 cdylib was compiled with a potentially different panic strategy.
 
 The wrapper itself is locked by the
@@ -470,15 +470,15 @@ Revisit this doc and the structural decisions when:
    placement starts to matter; consider whether a field belongs on
    the struct or behind a pointer.
 4. **A new vtable would have more than ~30 slots.** Either group
-   into per-domain vtables (see the `*MethodsVTable` per-β-shape
-   split) or reconsider whether all slots really need separate FFI
+   into per-domain vtables (see the `*MethodsVTable` per-PluginAbiObject
+   split) or reconsider whether all slots really need separate plugin ABI
    crossings.
 5. **A `make_*_borrow` helper is added.** Mirror the two-step dance
    from the existing helpers (read inner via minimal borrow, then
    construct final borrow with cached fields populated) and add a
    matching test in `make_borrow_cached_field_regression_tests`.
 6. **A non-Linux platform grows real cdylib coverage.** The current
-   ABI is Linux-rich; macOS / Windows variants of several β-shape
+   ABI is Linux-rich; macOS / Windows variants of several PluginAbiObject
    methods (Metal command buffer, IOSurface texture, etc.) ship
    stubs to keep the vtable layout unconditional. When a real
    non-Linux consumer arrives, those stubs need to grow real
@@ -495,7 +495,7 @@ Revisit this doc and the structural decisions when:
   `run_host_extern_c` panic safety net, the
   `make_borrow_cached_field_regression_tests` module.
 - **Cdylib-side dispatch shims**: `libs/streamlib-engine/src/core/`
-  for the β-shapes (`rhi/texture.rs`, `rhi/pixel_buffer.rs`,
+  for the PluginAbiObjects (`rhi/texture.rs`, `rhi/pixel_buffer.rs`,
   `rhi/storage_buffer.rs`, etc.) and per-type method dispatch
   (`vulkan/rhi/vulkan_compute_kernel.rs`,
   `vulkan/rhi/vulkan_graphics_kernel.rs`, etc.). Each carries the

--- a/docs/learnings/README.md
+++ b/docs/learnings/README.md
@@ -63,8 +63,8 @@ Avoid the two failure modes:
 - [@docs/learnings/pubsub-lazy-init-silent-noop.md](pubsub-lazy-init-silent-noop.md) —
   Test hangs indefinitely because PUBSUB silently no-ops without `init()`
 - [@docs/learnings/cdylib-make-borrow-cached-fields.md](cdylib-make-borrow-cached-fields.md) —
-  Cdylib pipeline runs end-to-end clean but produces zero/black output
-  when host-side `make_*_borrow` helpers leave the β-shape's cached
+  Plugin pipeline runs end-to-end clean but produces zero/black output
+  when host-side `make_*_borrow` helpers leave the PluginAbiObject's cached
   POD fields zeroed instead of mirroring the inner
 - [@docs/learnings/nvidia-dual-vulkan-device-crash.md](nvidia-dual-vulkan-device-crash.md) —
   SIGSEGV when two Vulkan devices have concurrent GPU work on NVIDIA Linux

--- a/docs/learnings/cdylib-make-borrow-cached-fields.md
+++ b/docs/learnings/cdylib-make-borrow-cached-fields.md
@@ -1,4 +1,4 @@
-# Cdylib β-shape `make_*_borrow` MUST populate cached POD fields
+# PluginAbiObject `make_*_borrow` MUST populate cached POD fields
 
 ## Symptom
 
@@ -18,9 +18,9 @@ that surfaces the bug.
 ## Trigger condition
 
 You added a new cdylib-callable code path that hands a host-side
-β-shape resource (`Texture`, `PixelBuffer`, `StorageBuffer`,
+PluginAbiObject resource (`Texture`, `PixelBuffer`, `StorageBuffer`,
 `UniformBuffer`) back through a vtable callback. The host wrapper
-constructs a borrowed β-shape via one of the
+constructs a borrowed PluginAbiObject via one of the
 `make_*_borrow(handle: *const c_void)` helpers in
 `libs/streamlib-engine/src/core/plugin/host_services.rs` and passes
 that borrow to host-side code (e.g. a recorder method, a kernel
@@ -30,14 +30,14 @@ borrow.
 
 ## Root cause
 
-The cdylib β-shape carries cached POD fields (`width_cached`,
+The cdylib PluginAbiObject carries cached POD fields (`width_cached`,
 `height_cached`, `format_raw`, `byte_size_cached`,
 `mapped_ptr_cached`, `plane_count_cached`, ...) so the cdylib's
-public POD getters resolve as pure field reads with no FFI hop. The
+public POD getters resolve as pure field reads with no plugin ABI hop. The
 fields are populated at construction time via `from_arc_into_raw`
 from the underlying inner.
 
-A `make_*_borrow` helper reconstructs a `ManuallyDrop<β-shape>`
+A `make_*_borrow` helper reconstructs a `ManuallyDrop<PluginAbiObject>`
 that wraps the SAME inner via `handle`. The deref still works for
 methods that route through `host_inner()` / `buffer_ref()` /
 `vulkan_inner()` — but the **cached POD fields are zero-initialized
@@ -136,6 +136,6 @@ on the cached-field reads, with no error path firing.
 - Regression tests: `make_borrow_cached_field_regression_tests` in
   the same file. Covers all four borrow helpers (texture,
   pixel_buffer, storage_buffer, uniform_buffer).
-- The cdylib β-shape's `from_arc_into_raw` constructors populate
+- The cdylib PluginAbiObject's `from_arc_into_raw` constructors populate
   cached fields at construction — the borrow helpers must mirror
   that contract.

--- a/examples/camera-python-display/effects/src/blending_compositor.rs
+++ b/examples/camera-python-display/effects/src/blending_compositor.rs
@@ -792,7 +792,7 @@ fn color_info_matches_working_space(input: Option<&ColorInfo>, working: &ColorIn
 
 /// One resolved input layer — texture + the registration its
 /// `current_layout` came from. Holding the [`TextureRegistration`]
-/// (β-shape, cheap Clone via vtable refcount bump) lets the
+/// (PluginAbiObject, cheap Clone via vtable refcount bump) lets the
 /// compositor update layout state via
 /// [`TextureRegistration::update_layout`] after the render submit
 /// completes.

--- a/examples/polyglot-vulkan-ray-tracing/src/main.rs
+++ b/examples/polyglot-vulkan-ray-tracing/src/main.rs
@@ -152,7 +152,7 @@ impl RuntimeKind {
 /// Holds three caches:
 /// - UUID → `Texture` for resolving non-AS run-time bindings to
 ///   host-side images (storage_image, sampled_texture).
-/// - `as_id` → `VulkanAccelerationStructure` (β-shape) for resolving AS
+/// - `as_id` → `VulkanAccelerationStructure` (PluginAbiObject) for resolving AS
 ///   bindings AND for chaining BLAS → TLAS construction (TLAS instance
 ///   `blas_id` lookup).
 /// - SHA-256 over canonical kernel descriptor bytes →

--- a/libs/streamlib-adapter-cpu-readback-abi/Cargo.toml
+++ b/libs/streamlib-adapter-cpu-readback-abi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "streamlib-adapter-cpu-readback-abi"
-description = "Cross-DSO callback table for streamlib-adapter-cpu-readback. Sibling of streamlib-adapter-vulkan-abi: pure extern \"C\" vtable + #[repr(C)] payloads consumed by host wiring (delegating to CpuReadbackSurfaceAdapter) and cdylib shims. No runtime Rust types cross the DSO boundary on the cdylib-callable surface."
+description = "Plugin ABI callback table for streamlib-adapter-cpu-readback. Sibling of streamlib-adapter-vulkan-abi: pure extern \"C\" vtable + #[repr(C)] payloads consumed by host wiring (delegating to CpuReadbackSurfaceAdapter) and cdylib shims. No runtime Rust types cross the plugin ABI on the cdylib-callable surface."
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 # Pure ABI crate — same dep posture as streamlib-adapter-vulkan-abi:
 # no streamlib-engine, no vulkanalia, no streamlib-adapter-cpu-readback,
 # no tokio. Keeps layout regression tests trivially runnable on any
-# host and the crate cross-DSO-safe.
+# host and the crate safe across the plugin ABI.
 [dependencies]
 
 [lints]

--- a/libs/streamlib-adapter-cpu-readback-abi/src/lib.rs
+++ b/libs/streamlib-adapter-cpu-readback-abi/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Cross-DSO callback table for `streamlib-adapter-cpu-readback`.
+//! Plugin ABI callback table for `streamlib-adapter-cpu-readback`.
 //!
 //! Sibling of [`streamlib-adapter-vulkan-abi`]'s
 //! `VulkanSurfaceAdapterVTable` (issue #887) — same shape applied to
@@ -14,10 +14,10 @@
 //! `CpuReadbackSurfaceAdapter<D>` to a cdylib plugin without sharing
 //! any Rust types beyond `#[repr(C)]` payloads and
 //! `unsafe extern "C" fn` pointers. The cdylib carries a
-//! `(handle, vtable)` β-shape; the host dispatches every method
+//! `(handle, vtable)` PluginAbiObject; the host dispatches every method
 //! through host-compiled code so layout drift between rustc-minor
 //! versions and divergent dep graphs is contained inside the host
-//! DSO.
+//! plugin.
 //!
 //! Dep posture mirrors [`streamlib-plugin-abi`] /
 //! [`streamlib-adapter-vulkan-abi`]: zero streamlib crates pulled,
@@ -136,7 +136,7 @@ pub const MAX_PLANES: usize = 4;
 /// into a `#[repr(C)]` record. The `mapped_ptr` is the host's
 /// staging-buffer `vk::DeviceMemory` mapped address — for cpu-
 /// readback this is HOST_VISIBLE / HOST_COHERENT, so the cdylib
-/// reads / writes the bytes directly without any further FFI hop.
+/// reads / writes the bytes directly without any further plugin ABI hop.
 /// `byte_size` is `width * height * bytes_per_pixel`, the tightly-
 /// packed plane byte count.
 ///
@@ -188,7 +188,7 @@ impl CpuReadbackPlaneRepr {
 /// `[CpuReadbackPlaneRepr; MAX_PLANES]` array of per-plane records,
 /// with the live plane count in `plane_count`. Slots beyond
 /// `plane_count` MUST be left zeroed by the host. The cdylib's
-/// `CpuReadbackReadView` / `CpuReadbackWriteView` β-shapes deref
+/// `CpuReadbackReadView` / `CpuReadbackWriteView` PluginAbiObjects deref
 /// these fields directly as POD reads.
 ///
 /// Lifetime: valid for the duration of the matching acquire scope —
@@ -336,7 +336,7 @@ impl HostSurfaceRegistrationRepr {
 /// `Arc::into_raw(Arc<CpuReadbackSurfaceAdapter<D>>)`-shaped pointer
 /// produced by the host) plus a
 /// `*const CpuReadbackSurfaceAdapterVTable` it reads from the
-/// `HostServices` payload when the cdylib β-shape lift lands
+/// `HostServices` payload when the cdylib PluginAbiObject lift lands
 /// (sibling slice to this trunk PR — see scope note below).
 /// Method-dispatch callbacks cover every cdylib-callable inherent
 /// method on `CpuReadbackSurfaceAdapter` plus the `SurfaceAdapter`
@@ -390,7 +390,7 @@ pub struct CpuReadbackSurfaceAdapterVTable {
 
     /// Take a borrowed handle (typically minted by the host's
     /// runtime context when wiring the cdylib-side
-    /// `CpuReadbackContext` β-shape) and return a new owned handle
+    /// `CpuReadbackContext` PluginAbiObject) and return a new owned handle
     /// with an Arc refcount bump on the underlying
     /// `Arc<CpuReadbackSurfaceAdapter<D>>`. The owned handle
     /// remains valid even after the originating context is

--- a/libs/streamlib-adapter-cpu-readback/src/host_vtable.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/host_vtable.rs
@@ -11,14 +11,14 @@
 //!    side (wire the in-process trigger, allocate the per-plane
 //!    staging buffers + timeline, register surfaces — same as
 //!    today).
-//! 2. Hand the cdylib a `(handle, vtable)` β-shape pair where:
+//! 2. Hand the cdylib a `(handle, vtable)` PluginAbiObject pair where:
 //!    - `handle = Arc::into_raw(arc.clone())`
 //!    - `vtable = host_cpu_readback_surface_adapter_vtable::<D>()`
 //! 3. The cdylib invokes the vtable methods exactly as if it held
 //!    a Rust `&CpuReadbackSurfaceAdapter<D>` — every method
 //!    dispatches through host-compiled code, so layout drift
 //!    between rustc-minor versions and divergent dep graphs is
-//!    contained inside the host DSO.
+//!    contained inside the host plugin.
 //!
 //! Generic over `D: VulkanRhiDevice + 'static` so the same wiring
 //! works whether the host is exposing a host-flavor or
@@ -40,7 +40,7 @@
 //!
 //! Panic guards inside each fn body mirror the
 //! `streamlib-plugin-abi` `run_host_extern_c` shape: any panic in
-//! host code is caught at the FFI boundary and converted to a
+//! host code is caught at the plugin ABI and converted to a
 //! clean error return instead of corrupting the cdylib's stack.
 //! Tier-1 null-handle tests next to this module verify the guards
 //! fire correctly without an actual
@@ -105,7 +105,7 @@ impl<D: VulkanRhiDevice + 'static> MonoVTable<D> {
 }
 
 // =============================================================================
-// FFI helpers — error buffer writer + panic guard
+// Plugin ABI helpers — error buffer writer + panic guard
 // =============================================================================
 
 // Panic-safety net wrapping every `host_*` extern "C" callback is the

--- a/libs/streamlib-adapter-cuda-abi/Cargo.toml
+++ b/libs/streamlib-adapter-cuda-abi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "streamlib-adapter-cuda-abi"
-description = "Cross-DSO callback table for streamlib-adapter-cuda. Sibling of streamlib-plugin-abi: pure extern \"C\" vtable + #[repr(C)] payloads consumed by host wiring (delegating to CudaSurfaceAdapter) and cdylib shims. No runtime Rust types cross the DSO boundary on the cdylib-callable surface."
+description = "Plugin ABI callback table for streamlib-adapter-cuda. Sibling of streamlib-plugin-abi: pure extern \"C\" vtable + #[repr(C)] payloads consumed by host wiring (delegating to CudaSurfaceAdapter) and cdylib shims. No runtime Rust types cross the plugin ABI on the cdylib-callable surface."
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 # streamlib-adapter-vulkan-abi: no streamlib-engine, no vulkanalia, no
 # streamlib-adapter-cuda, no cudarc, no dlpark, no tokio. Keeps layout
 # regression tests trivially runnable on any host and the crate
-# cross-DSO-safe.
+# safe across the plugin ABI.
 [dependencies]
 
 [lints]

--- a/libs/streamlib-adapter-cuda-abi/src/lib.rs
+++ b/libs/streamlib-adapter-cuda-abi/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Cross-DSO callback table for `streamlib-adapter-cuda`.
+//! Plugin ABI callback table for `streamlib-adapter-cuda`.
 //!
 //! Sibling of `streamlib-adapter-vulkan-abi` (#887) following the same
 //! shape mechanically. Per-adapter sibling of the umbrella callback-
@@ -13,16 +13,16 @@
 //! exposes its `CudaSurfaceAdapter` to a cdylib plugin without sharing
 //! any Rust types beyond `#[repr(C)]` payloads and
 //! `unsafe extern "C" fn` pointers. The cdylib carries a
-//! `(handle, vtable)` β-shape; the host dispatches every method
+//! `(handle, vtable)` PluginAbiObject; the host dispatches every method
 //! through host-compiled code so layout drift between rustc-minor
 //! versions and divergent dep graphs is contained inside the host
-//! DSO.
+//! plugin.
 //!
 //! Dep posture mirrors [`streamlib-plugin-abi`] and
 //! `streamlib-adapter-vulkan-abi`: zero streamlib crates pulled, zero
 //! vulkanalia, zero cudarc, zero dlpark, zero rustc-version-coupled
 //! types. This keeps layout regression tests trivially runnable on
-//! any host and the crate cross-DSO-safe.
+//! any host and the crate safe across the plugin ABI.
 //!
 //! # Audited cdylib-callable surface
 //!
@@ -174,7 +174,7 @@ pub struct TextureFormatRepr(pub u32);
 /// `cudaImportExternalMemory(OPAQUE_FD)` +
 /// `cudaExternalMemoryGetMappedBuffer` and construct a DLPack
 /// `ManagedTensor` over the resulting flat device pointer. The
-/// cdylib's `CudaReadView` / `CudaWriteView` β-shapes deref these
+/// cdylib's `CudaReadView` / `CudaWriteView` PluginAbiObjects deref these
 /// fields directly as POD reads.
 ///
 /// Lifetime: valid for the duration of the matching acquire scope
@@ -200,7 +200,7 @@ pub struct CudaBufferViewRepr {
 /// `cudaExternalMemoryGetMappedMipmappedArray` and construct a
 /// `cudaTextureObject_t` (read-only) or `cudaSurfaceObject_t`
 /// (read-write). The cdylib's `CudaTextureView` / `CudaSurfaceView`
-/// β-shapes deref these fields directly as POD reads.
+/// PluginAbiObjects deref these fields directly as POD reads.
 ///
 /// `format` is the [`TextureFormatRepr`] enumerant; the adapter
 /// guarantees it's in the CUDA-mappable subset (`Rgba8Unorm`,
@@ -231,7 +231,7 @@ pub struct CudaImageViewRepr {
 /// The cdylib holds an opaque `*const c_void` handle (an
 /// `Arc::into_raw(Arc<CudaSurfaceAdapter<D>>)`-shaped pointer
 /// produced by the host) plus a `*const CudaSurfaceAdapterVTable`
-/// it reads from the `HostServices` payload when the cdylib β-shape
+/// it reads from the `HostServices` payload when the cdylib PluginAbiObject
 /// lift lands (sibling slice to this trunk PR). Method-dispatch
 /// callbacks cover every cdylib-callable inherent method on
 /// `CudaSurfaceAdapter` plus the `SurfaceAdapter` trait methods.
@@ -295,7 +295,7 @@ pub struct CudaSurfaceAdapterVTable {
 
     /// Take a borrowed handle (typically minted by the host's
     /// runtime context when wiring the cdylib-side `CudaContext`
-    /// β-shape) and return a new owned handle with an Arc refcount
+    /// PluginAbiObject) and return a new owned handle with an Arc refcount
     /// bump on the underlying `Arc<CudaSurfaceAdapter<D>>`. The
     /// owned handle remains valid even after the originating
     /// context is dropped and MUST be released exactly once via

--- a/libs/streamlib-adapter-cuda/src/host_vtable.rs
+++ b/libs/streamlib-adapter-cuda/src/host_vtable.rs
@@ -9,14 +9,14 @@
 //! 1. Construct an `Arc<CudaSurfaceAdapter<D>>` on the host side
 //!    (allocate OPAQUE_FD-exportable buffers / images, register
 //!    surfaces, install setup hook — same as today).
-//! 2. Hand the cdylib a `(handle, vtable)` β-shape pair where:
+//! 2. Hand the cdylib a `(handle, vtable)` PluginAbiObject pair where:
 //!    - `handle = Arc::into_raw(arc.clone())`
 //!    - `vtable = host_cuda_surface_adapter_vtable::<D>()`
 //! 3. The cdylib invokes the vtable methods exactly as if it held
 //!    a Rust `&CudaSurfaceAdapter<D>` — every method dispatches
 //!    through host-compiled code, so layout drift between
 //!    rustc-minor versions and divergent dep graphs is contained
-//!    inside the host DSO.
+//!    inside the host plugin.
 //!
 //! Generic over `D: VulkanRhiDevice + 'static` so the same wiring
 //! works whether the host is exposing a
@@ -29,7 +29,7 @@
 //!
 //! Panic guards inside each fn body mirror the
 //! `streamlib-plugin-abi` `run_host_extern_c` shape: any panic in
-//! host code is caught at the FFI boundary and converted to a
+//! host code is caught at the plugin ABI and converted to a
 //! clean error return instead of corrupting the cdylib's stack.
 //! Tier-1 null-handle tests next to this module verify the guards
 //! fire correctly without an actual `Arc<CudaSurfaceAdapter>`.
@@ -93,7 +93,7 @@ impl<D: VulkanRhiDevice + 'static> MonoVTable<D> {
 }
 
 // =============================================================================
-// FFI helpers — error buffer writer + panic guard
+// Plugin ABI helpers — error buffer writer + panic guard
 // =============================================================================
 
 // Panic-safety net wrapping every `host_*` extern "C" callback is the
@@ -578,7 +578,7 @@ where
 /// and `mem::forget` the guard so the cdylib's mirror RAII fires
 /// `end_read_access` / `end_write_access` itself.
 ///
-/// Calling Drop here would double-signal — the cdylib's β-shape
+/// Calling Drop here would double-signal — the cdylib's PluginAbiObject
 /// guard will issue the release through the vtable's
 /// `end_*_access` slot when it's dropped.
 fn read_guard_to_buffer_repr<D: VulkanRhiDevice + 'static>(

--- a/libs/streamlib-adapter-opengl-abi/Cargo.toml
+++ b/libs/streamlib-adapter-opengl-abi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "streamlib-adapter-opengl-abi"
-description = "Cross-DSO callback table for streamlib-adapter-opengl. Sibling of streamlib-plugin-abi: pure extern \"C\" vtable + #[repr(C)] payloads consumed by host wiring (delegating to OpenGlSurfaceAdapter) and cdylib shims. No runtime Rust types cross the DSO boundary on the cdylib-callable surface."
+description = "Plugin ABI callback table for streamlib-adapter-opengl. Sibling of streamlib-plugin-abi: pure extern \"C\" vtable + #[repr(C)] payloads consumed by host wiring (delegating to OpenGlSurfaceAdapter) and cdylib shims. No runtime Rust types cross the plugin ABI on the cdylib-callable surface."
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 # sibling streamlib-adapter-vulkan-abi: no streamlib-engine, no glow,
 # no streamlib-adapter-opengl, no khronos-egl, no tokio. Keeps layout
 # regression tests trivially runnable on any host and the crate
-# cross-DSO-safe.
+# safe across the plugin ABI.
 [dependencies]
 
 [lints]

--- a/libs/streamlib-adapter-opengl-abi/src/lib.rs
+++ b/libs/streamlib-adapter-opengl-abi/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Cross-DSO callback table for `streamlib-adapter-opengl`.
+//! Plugin ABI callback table for `streamlib-adapter-opengl`.
 //!
 //! Sibling of [`streamlib-plugin-abi`]'s
 //! `GpuContextLimitedAccessVTable` (issue #886) and
@@ -15,15 +15,15 @@
 //! exposes its `OpenGlSurfaceAdapter` to a cdylib plugin without
 //! sharing any Rust types beyond `#[repr(C)]` payloads and
 //! `unsafe extern "C" fn` pointers. The cdylib carries a
-//! `(handle, vtable)` β-shape; the host dispatches every method
+//! `(handle, vtable)` PluginAbiObject; the host dispatches every method
 //! through host-compiled code so layout drift between rustc-minor
 //! versions and divergent dep graphs is contained inside the host
-//! DSO.
+//! plugin.
 //!
 //! Dep posture mirrors [`streamlib-plugin-abi`]: zero streamlib
 //! crates pulled, zero EGL/GL bindings, zero rustc-version-coupled
 //! types. This keeps layout regression tests trivially runnable on
-//! any host and the crate cross-DSO-safe.
+//! any host and the crate safe across the plugin ABI.
 //!
 //! # Audited cdylib-callable surface
 //!
@@ -52,13 +52,13 @@
 //! `OpenGlContext` is a thin Clone-able convenience wrapper around
 //! `Arc<OpenGlSurfaceAdapter>` — every method forwards to the same
 //! adapter trait methods covered above. The vtable's handle is the
-//! adapter Arc directly; the cdylib's `OpenGlContext` β-shape holds
+//! adapter Arc directly; the cdylib's `OpenGlContext` PluginAbiObject holds
 //! the `(handle, vtable)` pair without an extra indirection.
 //!
 //! The `EglRuntime` accessor (`OpenGlSurfaceAdapter::runtime`) is
 //! NOT cdylib-callable — every subprocess constructs its own
 //! `EglRuntime` (the runtime owns thread-bound OpenGL contexts and
-//! cannot meaningfully cross a DSO boundary even within one
+//! cannot meaningfully cross the plugin ABI even within one
 //! process). No slot.
 
 #![no_std]
@@ -92,7 +92,7 @@ pub const OPENGL_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION: u32 = 1;
 ///
 /// Carries the live GL texture id and the binding target
 /// (`GL_TEXTURE_2D` or `GL_TEXTURE_EXTERNAL_OES`). The cdylib's
-/// `OpenGlReadView` / `OpenGlWriteView` β-shapes deref these
+/// `OpenGlReadView` / `OpenGlWriteView` PluginAbiObjects deref these
 /// fields directly as POD reads (mirrors the cached-fields pattern
 /// on `Texture` / `PixelBuffer` from `streamlib-plugin-abi` and
 /// `VulkanViewRepr` from `streamlib-adapter-vulkan-abi`).
@@ -152,7 +152,7 @@ pub struct HostSurfaceRegistrationRepr {
 /// The cdylib holds an opaque `*const c_void` handle (an
 /// `Arc::into_raw(Arc<OpenGlSurfaceAdapter>)`-shaped pointer produced
 /// by the host) plus a `*const OpenGlSurfaceAdapterVTable` it reads
-/// from the `HostServices` payload when the cdylib β-shape lift
+/// from the `HostServices` payload when the cdylib PluginAbiObject lift
 /// lands (sibling slice to this trunk PR). Method-dispatch callbacks
 /// cover every cdylib-callable inherent method on
 /// `OpenGlSurfaceAdapter` plus the `SurfaceAdapter` trait methods.
@@ -206,7 +206,7 @@ pub struct OpenGlSurfaceAdapterVTable {
 
     /// Take a borrowed handle (typically minted by the host's
     /// runtime context when wiring the cdylib-side `OpenGlContext`
-    /// β-shape) and return a new owned handle with an Arc refcount
+    /// PluginAbiObject) and return a new owned handle with an Arc refcount
     /// bump on the underlying `Arc<OpenGlSurfaceAdapter>`. The
     /// owned handle remains valid even after the originating
     /// context is dropped and MUST be released exactly once via
@@ -379,7 +379,7 @@ mod tests {
     use core::mem::{align_of, offset_of, size_of};
 
     /// `OpenGlViewRepr` carries (`gl_texture_id: u32`, `target: u32`).
-    /// 8 bytes, align 4 — the smallest cross-DSO view payload in the
+    /// 8 bytes, align 4 — the smallest plugin ABI view payload in the
     /// adapter family.
     #[test]
     fn opengl_view_repr_layout() {

--- a/libs/streamlib-adapter-opengl/src/host_vtable.rs
+++ b/libs/streamlib-adapter-opengl/src/host_vtable.rs
@@ -9,14 +9,14 @@
 //! 1. Construct an `Arc<OpenGlSurfaceAdapter>` on the host side
 //!    (allocate the EglRuntime, register surfaces, install setup
 //!    hook — same as today).
-//! 2. Hand the cdylib a `(handle, vtable)` β-shape pair where:
+//! 2. Hand the cdylib a `(handle, vtable)` PluginAbiObject pair where:
 //!    - `handle = Arc::into_raw(arc.clone())`
 //!    - `vtable = host_opengl_surface_adapter_vtable()`
 //! 3. The cdylib invokes the vtable methods exactly as if it held
 //!    a Rust `&OpenGlSurfaceAdapter` — every method dispatches
 //!    through host-compiled code, so layout drift between
 //!    rustc-minor versions and divergent dep graphs is contained
-//!    inside the host DSO.
+//!    inside the host plugin.
 //!
 //! `OpenGlSurfaceAdapter` is not generic over a `DevicePrivilege`
 //! type the way `VulkanSurfaceAdapter<D>` is — the OpenGL adapter
@@ -26,7 +26,7 @@
 //!
 //! Panic guards inside each fn body mirror the
 //! `streamlib-plugin-abi` `run_host_extern_c` shape: any panic in
-//! host code is caught at the FFI boundary and converted to a
+//! host code is caught at the plugin ABI and converted to a
 //! clean error return instead of corrupting the cdylib's stack.
 //! Tier-1 null-handle tests next to this module verify the guards
 //! fire correctly without an actual `Arc<OpenGlSurfaceAdapter>`.
@@ -70,7 +70,7 @@ static HOST_VTABLE: OpenGlSurfaceAdapterVTable = OpenGlSurfaceAdapterVTable {
 };
 
 // =============================================================================
-// FFI helpers — error buffer writer + panic guard
+// Plugin ABI helpers — error buffer writer + panic guard
 // =============================================================================
 
 // Panic-safety net wrapping every `host_*` extern "C" callback is the

--- a/libs/streamlib-adapter-skia-abi/Cargo.toml
+++ b/libs/streamlib-adapter-skia-abi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "streamlib-adapter-skia-abi"
-description = "Cross-DSO callback table for streamlib-adapter-skia. Sibling of streamlib-plugin-abi / streamlib-adapter-vulkan-abi: pure extern \"C\" vtable + #[repr(C)] payloads consumed by host wiring (delegating to SkiaSurfaceAdapter / SkiaGlSurfaceAdapter) and cdylib shims. Skia is host-side-only — its view types (skia_safe::Surface / Image) cannot cross DSO, so the vtable surface covers only the SurfaceAdapter trait scoping contract."
+description = "Plugin ABI callback table for streamlib-adapter-skia. Sibling of streamlib-plugin-abi / streamlib-adapter-vulkan-abi: pure extern \"C\" vtable + #[repr(C)] payloads consumed by host wiring (delegating to SkiaSurfaceAdapter / SkiaGlSurfaceAdapter) and cdylib shims. Skia is host-side-only — its view types (skia_safe::Surface / Image) cannot cross the plugin ABI, so the vtable surface covers only the SurfaceAdapter trait scoping contract."
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 # streamlib-adapter-vulkan-abi: no streamlib-engine, no vulkanalia,
 # no skia-safe, no streamlib-adapter-skia, no tokio. Keeps layout
 # regression tests trivially runnable on any host and the crate
-# cross-DSO-safe.
+# safe across the plugin ABI.
 [dependencies]
 
 [lints]

--- a/libs/streamlib-adapter-skia-abi/src/lib.rs
+++ b/libs/streamlib-adapter-skia-abi/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Cross-DSO callback table for `streamlib-adapter-skia`.
+//! Plugin ABI callback table for `streamlib-adapter-skia`.
 //!
 //! Sibling of [`streamlib-adapter-vulkan-abi`] and
 //! [`streamlib-plugin-abi`] in the per-adapter vtable lift family
@@ -64,7 +64,7 @@
 //!   single-thread-affine `GrDirectContext`. Their internal layout
 //!   is **rustc-version-coupled and skia-safe-version-coupled** —
 //!   crossing them through an extern "C" boundary would defeat the
-//!   purpose of this ABI. Adding cross-DSO Skia view access is
+//!   purpose of this ABI. Adding Skia view access across the plugin ABI is
 //!   future work (the Option C msgpack display-list shape recorded
 //!   on issue #889's body is a candidate; a per-method canvas
 //!   vtable is another).
@@ -77,8 +77,8 @@
 //! # What this vtable does cover
 //!
 //! The scoping contract — acquire / release on a `StreamlibSurface`
-//! — is identical across every surface adapter and IS cross-DSO
-//! safe via the `surface_id`-only [`SkiaViewRepr`] payload. The
+//! — is identical across every surface adapter and IS safe across
+//! the plugin ABI via the `surface_id`-only [`SkiaViewRepr`] payload. The
 //! vtable carries the trunk-pattern `clone_handle` /
 //! `drop_handle` lifetime slots plus all 6 `SurfaceAdapter` trait
 //! methods plus the informational `registered_count` projection.
@@ -172,7 +172,7 @@ pub struct SkiaViewRepr {
 /// `Arc::into_raw(Arc<SkiaSurfaceAdapter<D>>)`-shaped pointer
 /// produced by the host) plus a
 /// `*const SkiaSurfaceAdapterVTable` it reads from the
-/// `HostServices` payload when the cdylib β-shape lift lands
+/// `HostServices` payload when the cdylib PluginAbiObject lift lands
 /// (sibling slice to this trunk PR). Method-dispatch callbacks
 /// cover every cdylib-callable `SurfaceAdapter` trait method.
 ///

--- a/libs/streamlib-adapter-skia/src/host_vtable.rs
+++ b/libs/streamlib-adapter-skia/src/host_vtable.rs
@@ -11,7 +11,7 @@
 //! 1. Construct an `Arc<SkiaSurfaceAdapter<D>>` or
 //!    `Arc<SkiaGlSurfaceAdapter>` on the host side (compose on the
 //!    inner Vulkan / OpenGL adapter — same as today).
-//! 2. Hand the cdylib a `(handle, vtable)` β-shape pair where:
+//! 2. Hand the cdylib a `(handle, vtable)` PluginAbiObject pair where:
 //!    - `handle = Arc::into_raw(arc.clone())`
 //!    - `vtable = host_skia_surface_adapter_vtable::<D>()` (Vulkan
 //!      flavor) or `host_skia_gl_surface_adapter_vtable()` (GL
@@ -20,7 +20,7 @@
 //!    a Rust `&SkiaSurfaceAdapter<D>` — every method dispatches
 //!    through host-compiled code, so layout drift between
 //!    rustc-minor versions and divergent dep graphs is contained
-//!    inside the host DSO.
+//!    inside the host plugin.
 //!
 //! The Vulkan-flavor wiring is generic over
 //! `D: VulkanRhiDevice + 'static` so the same vtable works whether
@@ -34,7 +34,7 @@
 //!
 //! Panic guards inside each fn body mirror the
 //! `streamlib-plugin-abi` `run_host_extern_c` shape: any panic in
-//! host code is caught at the FFI boundary and converted to a
+//! host code is caught at the plugin ABI and converted to a
 //! clean error return instead of corrupting the cdylib's stack.
 //! Tier-1 null-handle tests next to this module verify the guards
 //! fire correctly without an actual `Arc<SkiaSurfaceAdapter>`.
@@ -53,7 +53,7 @@
 //! `RCHandle<…>` types are tied to the host's `skia-safe` version
 //! and single-thread-affine `GrDirectContext`; projecting them
 //! through an extern "C" boundary would defeat the purpose of this
-//! ABI. Future cross-DSO Skia draw support is its own design
+//! ABI. Future plugin ABI Skia draw support is its own design
 //! problem (e.g. the msgpack display-list pattern recorded on
 //! issue #889's body, a per-method canvas vtable, etc.).
 
@@ -148,7 +148,7 @@ static GL_VTABLE: SkiaGlSurfaceAdapterVTable = SkiaGlSurfaceAdapterVTable {
 };
 
 // =============================================================================
-// FFI helpers — error buffer writer + panic guard
+// Plugin ABI helpers — error buffer writer + panic guard
 // =============================================================================
 
 // Panic-safety net wrapping every `host_*` extern "C" callback is the
@@ -281,7 +281,7 @@ unsafe extern "C" fn host_vk_registered_count<D: VulkanRhiDevice + 'static>(
 ///                                never produce Ok(None))
 ///   - `Err(msg)`               → status 1, error message written
 ///
-/// Skia's view types are not cross-DSO-safe (see module docs), so
+/// Skia's view types are not safe to expose across the plugin ABI (see module docs), so
 /// the returned view payload only carries `surface_id` + width +
 /// height — the host's actual `WriteGuard` is dropped at the end
 /// of the host-side acquire callback (the scope is the callback
@@ -398,7 +398,7 @@ fn run_skia_vk_write_scope<D: VulkanRhiDevice + 'static>(
     let guard = adapter.acquire_write(surface)?;
     let surface_id = guard.surface_id();
     // Drop the guard explicitly so the flush + inner release runs
-    // synchronously inside the FFI scope. The cdylib customer's
+    // synchronously inside the plugin ABI scope. The cdylib customer's
     // SurfaceAdapter trait contract guarantees that on `Ok` return
     // the surface has been written (and synchronized) — same as a
     // synchronous Rust-side `acquire_write` followed by drop.

--- a/libs/streamlib-adapter-vulkan-abi/Cargo.toml
+++ b/libs/streamlib-adapter-vulkan-abi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "streamlib-adapter-vulkan-abi"
-description = "Cross-DSO callback table for streamlib-adapter-vulkan. Sibling of streamlib-plugin-abi: pure extern \"C\" vtable + #[repr(C)] payloads consumed by host wiring (delegating to VulkanSurfaceAdapter) and cdylib shims. No runtime Rust types cross the DSO boundary on the cdylib-callable surface."
+description = "Plugin ABI callback table for streamlib-adapter-vulkan. Sibling of streamlib-plugin-abi: pure extern \"C\" vtable + #[repr(C)] payloads consumed by host wiring (delegating to VulkanSurfaceAdapter) and cdylib shims. No runtime Rust types cross the plugin ABI on the cdylib-callable surface."
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 # Pure ABI crate — same dep posture as streamlib-plugin-abi: no
 # streamlib-engine, no vulkanalia, no streamlib-adapter-vulkan, no
 # tokio. Keeps layout regression tests trivially runnable on any host
-# and the crate cross-DSO-safe.
+# and the crate safe across the plugin ABI.
 [dependencies]
 
 [lints]

--- a/libs/streamlib-adapter-vulkan-abi/src/lib.rs
+++ b/libs/streamlib-adapter-vulkan-abi/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Cross-DSO callback table for `streamlib-adapter-vulkan`.
+//! Plugin ABI callback table for `streamlib-adapter-vulkan`.
 //!
 //! Trunk piece of the per-adapter vtable lift kicked off by
 //! [`streamlib-plugin-abi`]'s `GpuContextLimitedAccessVTable`
@@ -14,15 +14,15 @@
 //! exposes its `VulkanSurfaceAdapter` to a cdylib plugin without
 //! sharing any Rust types beyond `#[repr(C)]` payloads and
 //! `unsafe extern "C" fn` pointers. The cdylib carries a
-//! `(handle, vtable)` β-shape; the host dispatches every method
+//! `(handle, vtable)` PluginAbiObject; the host dispatches every method
 //! through host-compiled code so layout drift between rustc-minor
 //! versions and divergent dep graphs is contained inside the host
-//! DSO.
+//! plugin.
 //!
 //! Dep posture mirrors [`streamlib-plugin-abi`]: zero streamlib
 //! crates pulled, zero vulkanalia, zero rustc-version-coupled
 //! types. This keeps layout regression tests trivially runnable on
-//! any host and the crate cross-DSO-safe.
+//! any host and the crate safe across the plugin ABI.
 //!
 //! # Audited cdylib-callable surface
 //!
@@ -98,7 +98,7 @@ pub struct VkImageLayoutValueRepr(pub i32);
 /// Layout MUST match `VkImageInfo` byte-for-byte — the host
 /// implementation populates this struct directly from the existing
 /// adapter and the cdylib reads the same offsets through its
-/// β-shape view payload. Adding fields requires a coordinated bump
+/// PluginAbiObject view payload. Adding fields requires a coordinated bump
 /// in both this crate AND `streamlib-adapter-abi`.
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
@@ -137,7 +137,7 @@ pub struct VkImageInfoRepr {
 /// Carries the live `VkImage` handle, the post-transition layout
 /// the adapter left the image in, and the per-image
 /// [`VkImageInfoRepr`] descriptor. The cdylib's `VulkanReadView`
-/// / `VulkanWriteView` β-shapes deref these fields directly as
+/// / `VulkanWriteView` PluginAbiObjects deref these fields directly as
 /// POD reads (mirrors the cached-fields pattern on `Texture` /
 /// `PixelBuffer` from `streamlib-plugin-abi`).
 ///
@@ -202,7 +202,7 @@ pub struct RawVulkanHandlesRepr {
 /// The cdylib holds an opaque `*const c_void` handle (an
 /// `Arc::into_raw(Arc<VulkanSurfaceAdapter<D>>)`-shaped pointer
 /// produced by the host) plus a `*const VulkanSurfaceAdapterVTable`
-/// it reads from the `HostServices` payload when the cdylib β-shape
+/// it reads from the `HostServices` payload when the cdylib PluginAbiObject
 /// lift lands (sibling slice to this trunk PR). Method-dispatch
 /// callbacks cover every cdylib-callable inherent method on
 /// `VulkanSurfaceAdapter` plus the `SurfaceAdapter` trait methods.
@@ -255,7 +255,7 @@ pub struct VulkanSurfaceAdapterVTable {
 
     /// Take a borrowed handle (typically minted by the host's
     /// runtime context when wiring the cdylib-side `VulkanContext`
-    /// β-shape) and return a new owned handle with an Arc refcount
+    /// PluginAbiObject) and return a new owned handle with an Arc refcount
     /// bump on the underlying `Arc<VulkanSurfaceAdapter<D>>`. The
     /// owned handle remains valid even after the originating
     /// context is dropped and MUST be released exactly once via
@@ -462,7 +462,7 @@ mod tests {
     use core::mem::{align_of, offset_of, size_of};
 
     /// `VkImageInfoRepr` mirrors `streamlib_adapter_abi::VkImageInfo`
-    /// byte-for-byte. Locks the contract one of the four cross-DSO
+    /// byte-for-byte. Locks the contract one of the four plugin ABI
     /// payloads in this crate rides on.
     #[test]
     fn vk_image_info_repr_layout() {

--- a/libs/streamlib-adapter-vulkan/src/host_vtable.rs
+++ b/libs/streamlib-adapter-vulkan/src/host_vtable.rs
@@ -9,14 +9,14 @@
 //! 1. Construct an `Arc<VulkanSurfaceAdapter<D>>` on the host side
 //!    (allocate textures, register surfaces, install setup hook —
 //!    same as today).
-//! 2. Hand the cdylib a `(handle, vtable)` β-shape pair where:
+//! 2. Hand the cdylib a `(handle, vtable)` PluginAbiObject pair where:
 //!    - `handle = Arc::into_raw(arc.clone())`
 //!    - `vtable = host_vulkan_surface_adapter_vtable::<D>()`
 //! 3. The cdylib invokes the vtable methods exactly as if it held
 //!    a Rust `&VulkanSurfaceAdapter<D>` — every method dispatches
 //!    through host-compiled code, so layout drift between
 //!    rustc-minor versions and divergent dep graphs is contained
-//!    inside the host DSO.
+//!    inside the host plugin.
 //!
 //! Generic over `D: VulkanRhiDevice + 'static` so the same wiring
 //! works whether the host is exposing a
@@ -29,7 +29,7 @@
 //!
 //! Panic guards inside each fn body mirror the
 //! `streamlib-plugin-abi` `run_host_extern_c` shape: any panic in
-//! host code is caught at the FFI boundary and converted to a
+//! host code is caught at the plugin ABI and converted to a
 //! clean error return instead of corrupting the cdylib's stack.
 //! Tier-1 null-handle tests next to this module verify the guards
 //! fire correctly without an actual `Arc<VulkanSurfaceAdapter>`.
@@ -92,7 +92,7 @@ impl<D: VulkanRhiDevice + 'static> MonoVTable<D> {
 }
 
 // =============================================================================
-// FFI helpers — error buffer writer + panic guard
+// Plugin ABI helpers — error buffer writer + panic guard
 // =============================================================================
 
 // Panic-safety net wrapping every `host_*` extern "C" callback is the

--- a/libs/streamlib-consumer-rhi/src/vulkan_layout.rs
+++ b/libs/streamlib-consumer-rhi/src/vulkan_layout.rs
@@ -18,13 +18,13 @@ use vulkanalia::vk;
 /// without depending on `vulkanalia`.
 ///
 /// `#[repr(transparent)]` so the newtype is byte-equivalent to its
-/// inner `i32` across the plugin FFI boundary — adapter vtables (see
+/// inner `i32` across the plugin ABI — adapter vtables (see
 /// `streamlib-adapter-{vulkan,cuda,cpu-readback}`) carry
 /// `initial_layout_raw: i32` / `post_release_layout_raw: i32` fields
 /// that get reconstituted as `VulkanLayout(raw)` on the receiving
 /// side. Pinning the repr means a cdylib compiled with a different
 /// rustc / dep-graph than the host still observes the same byte
-/// layout for any cross-DSO traffic.
+/// layout for any plugin ABI traffic.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 #[repr(transparent)]
 pub struct VulkanLayout(pub i32);
@@ -51,7 +51,7 @@ impl VulkanLayout {
 
 #[cfg(test)]
 mod layout_tests {
-    //! Layout regression tests for the FFI-crossing layout primitive.
+    //! Layout regression tests for the plugin-ABI-crossing layout primitive.
     //!
     //! `#[repr(transparent)]` over the `i32` `VkImageLayout` value, so
     //! the newtype is byte-equivalent to its inner field — adapter

--- a/libs/streamlib-cross-rustc-fixture/Cargo.toml
+++ b/libs/streamlib-cross-rustc-fixture/Cargo.toml
@@ -9,9 +9,10 @@
 # graph diverges from the host's by construction.
 #
 # This is the empirical fixture for issue #927: the add_module
-# dlopen integration test exercises that the layout-stable β-shape
-# FFI established in #917 is sufficient for cross-rustc-version /
-# cross-dep-graph plugin distribution. Plugin authors building in a
+# dlopen integration test exercises that the layout-stable
+# PluginAbiObject plugin ABI established in #917 is sufficient for
+# cross-rustc-version / cross-dep-graph plugin distribution. Plugin
+# authors building in a
 # separate repo with a different Cargo dep graph should produce a
 # .slpkg that loads cleanly into any streamlib host depending on the
 # same `streamlib-plugin-abi` + `streamlib-consumer-rhi` versions.
@@ -25,7 +26,7 @@ name = "streamlib-cross-rustc-fixture"
 version = "0.1.0"
 edition = "2024"
 publish = false
-description = "Cross-rustc-version / cross-dep-graph dlopen fixture for issue #927 (#917 β-shape gate)"
+description = "Cross-rustc-version / cross-dep-graph dlopen fixture for issue #927 (#917 PluginAbiObject gate)"
 
 [lib]
 name = "streamlib_cross_rustc_fixture"
@@ -35,8 +36,9 @@ crate-type = ["cdylib"]
 streamlib-jtd-codegen = { path = "../streamlib-jtd-codegen" }
 
 [dependencies]
-# Engine substrate — runtime context, processor traits, β-shape
-# return types under `streamlib::sdk::*`. Path-dep so the fixture
+# Engine substrate — runtime context, processor traits,
+# PluginAbiObject return types under `streamlib::sdk::*`. Path-dep so
+# the fixture
 # rebuilds the SDK against THIS workspace's resolver pass, not the
 # host workspace's. Same source, different transitive resolution.
 streamlib = { path = "../streamlib-sdk" }
@@ -54,9 +56,10 @@ streamlib-plugin-abi = { path = "../streamlib-plugin-abi" }
 # Cargo.lock). The pin forces this sibling workspace to compile
 # streamlib-sdk against demonstrably-different transitive versions —
 # net effect is at least two divergent crates between this fixture's
-# Cargo.lock and the host's. The β-shape FFI never traffics serde or
-# tracing types across the DSO boundary, so the test proves
-# layout-stable interop survives divergent transitive resolutions.
+# Cargo.lock and the host's. The PluginAbiObject plugin ABI never
+# traffics serde or tracing types across the plugin ABI, so the test
+# proves layout-stable interop survives divergent transitive
+# resolutions.
 #
 # 1.0.225 is the minimum compatible with iceoryx2 0.8.1's transitive
 # `serde_core ^1.0.225`; older pins fail resolution.

--- a/libs/streamlib-cross-rustc-fixture/build.rs
+++ b/libs/streamlib-cross-rustc-fixture/build.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::disallowed_macros)] // build.rs uses println!/eprintln! for `cargo:` directives
 
 //! Builds the JTD config dataclass shim and (on Linux) compiles every
-//! shader the fixture's β-shape round-trip needs via the system
+//! shader the fixture's PluginAbiObject round-trip needs via the system
 //! `glslc`. Matches the streamlib-engine crate's own build.rs shader
 //! pipeline so the fixture compiles in the same toolchain shape
 //! consumers see.

--- a/libs/streamlib-cross-rustc-fixture/schemas/plugin_abi_object_round_trip_processor_config.yaml
+++ b/libs/streamlib-cross-rustc-fixture/schemas/plugin_abi_object_round_trip_processor_config.yaml
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 metadata:
-  type: BetaShapeRoundTripProcessorConfig
+  type: PluginAbiObjectRoundTripProcessorConfig
   description: "Config schema for the #927 cross-rustc dlopen fixture."
 
 properties:
   output_path:
     metadata:
-      description: "Filesystem path where the processor writes its result. Format: 'OK\\n<summary>' on success, 'ERR:<message>' on first-failing β-shape."
+      description: "Filesystem path where the processor writes its result. Format: 'OK\\n<summary>' on success, 'ERR:<message>' on first-failing PluginAbiObject."
     type: string

--- a/libs/streamlib-cross-rustc-fixture/src/lib.rs
+++ b/libs/streamlib-cross-rustc-fixture/src/lib.rs
@@ -3,8 +3,8 @@
 
 //! Cross-rustc / cross-dep-graph dlopen fixture for issue #927.
 //!
-//! Companion to PR #918's β-shape Phase D work. The fixture builds in
-//! a standalone Cargo workspace (own `[workspace]` table → own
+//! Companion to PR #918's PluginAbiObject Phase D work. The fixture
+//! builds in a standalone Cargo workspace (own `[workspace]` table → own
 //! `Cargo.lock`) with `=`-pinned older `serde` / `tracing` transitive
 //! deps, so cargo resolves the cdylib against a deliberately
 //! divergent crate graph from the host streamlib workspace.
@@ -18,20 +18,20 @@
 //!   with the host.
 //! - **Load-level**: `Runner::add_module_with(...)` dlopens that `.so`
 //!   and the host's `STREAMLIB_PLUGIN` ABI accepts the cdylib's
-//!   exported symbol shape — proves the FFI surface from #918 is
+//!   exported symbol shape — proves the plugin ABI from #918 is
 //!   layout-stable across the divergent compiles.
-//! - **Dispatch-level**: each #918 β-shape return type
+//! - **Dispatch-level**: each #918 PluginAbiObject return type
 //!   (`VulkanComputeKernel`, `VulkanGraphicsKernel`,
 //!   `VulkanRayTracingKernel`, `TextureRing`, `RhiColorConverter`,
 //!   `VulkanAccelerationStructure`, `RhiCommandRecorder`) is
 //!   constructed via the FullAccess vtable inside an escalate scope,
-//!   cloned (or — for the Box-handle `RhiCommandRecorder` β-shape —
-//!   only dropped, since the type is `!Clone`), and dropped from
-//!   cdylib code. Every Create / Clone / Drop transits through the
-//!   per-type host-installed `clone_<type>` / `drop_<type>` vtable
-//!   slot. A FFI-boundary panic surfaces as `ERR:` in the result
-//!   file; correct dispatch surfaces as `OK` + a per-type status
-//!   line.
+//!   cloned (or — for the Box-handle `RhiCommandRecorder`
+//!   PluginAbiObject — only dropped, since the type is `!Clone`), and
+//!   dropped from cdylib code. Every Create / Clone / Drop transits
+//!   through the per-type host-installed `clone_<type>` /
+//!   `drop_<type>` vtable slot. A plugin ABI panic surfaces as `ERR:`
+//!   in the result file; correct dispatch surfaces as `OK` + a
+//!   per-type status line.
 //!
 //! What this test does NOT prove on its own — these are locked
 //! elsewhere:
@@ -88,18 +88,19 @@ const TRIVIAL_RCHIT_SPV: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/trivi
 const TRIVIAL_COMPUTE_BINDINGS: &[ComputeBindingSpec] =
     &[ComputeBindingSpec::storage_buffer(0)];
 
-#[streamlib::sdk::processor("BetaShapeRoundTripProcessor")]
-pub struct BetaShapeRoundTrip {}
+#[streamlib::sdk::processor("PluginAbiObjectRoundTripProcessor")]
+pub struct PluginAbiObjectRoundTrip {}
 
-/// Run a Create+Clone+Drop sweep over every #918 β-shape return type
-/// inside an escalate scope so FullAccess methods route through the
-/// FFI vtable (not the in-process `Boxed` handle). Called once from
+/// Run a Create+Clone+Drop sweep over every #918 PluginAbiObject
+/// return type inside an escalate scope so FullAccess methods route
+/// through the plugin vtable (not the in-process `Boxed` handle).
+/// Called once from
 /// `start()` — setup() leaves the sweep alone because the FullAccess
 /// vtable instance is the same across both lifecycles, and BLAS +
 /// RT-kernel construction make doubling the sweep expensive without
 /// adding distinct vtable-surface coverage.
 #[cfg(target_os = "linux")]
-fn run_beta_shape_round_trip(ctx: &RuntimeContextFullAccess<'_>) -> Result<String> {
+fn run_plugin_abi_object_round_trip(ctx: &RuntimeContextFullAccess<'_>) -> Result<String> {
     let gpu_limited = ctx.gpu_limited_access();
     // FullAccess lifecycle bodies (this runs from Manual `start()`) already
     // hold the escalate gate via the cdylib spawn-op scope (#1072/#1075), so
@@ -116,9 +117,9 @@ fn run_beta_shape_round_trip(ctx: &RuntimeContextFullAccess<'_>) -> Result<Strin
         2,
     )?;
 
-    // -------- TextureRing slot β-shape end-to-end (#947) --------
+    // -------- TextureRing slot PluginAbiObject end-to-end (#947) --------
     //
-    // The slot β-shape's per-method dispatch (acquire_next /
+    // The slot PluginAbiObject's per-method dispatch (acquire_next /
     // copy_pixel_buffer_to_slot / slot) routes through the per-type
     // TextureRingMethodsVTable in cdylib mode. This block exercises
     // every slot from cdylib code, asserts cached POD fields round-
@@ -281,13 +282,13 @@ fn run_beta_shape_round_trip(ctx: &RuntimeContextFullAccess<'_>) -> Result<Strin
         // Both ride the same `VK_KHR_ray_tracing_pipeline` /
         // `VK_KHR_acceleration_structure` feature gate. On hosts that
         // lack RT (or where the engine's RT probe declined to enable
-        // it), record SKIP without failing — the structural β-shape
+        // it), record SKIP without failing — the structural PluginAbiObject
         // argument from #918 is identical for these types as for
         // VulkanComputeKernel which IS exercised on every host.
         if full.supports_ray_tracing_pipeline() {
             // VulkanAccelerationStructure: trivial single-triangle BLAS.
             // Exercises the #955 v8 build_triangles_blas out-params:
-            // the cdylib-minted β-shape must carry real device_address,
+            // the cdylib-minted PluginAbiObject must carry real device_address,
             // storage_size, and kind (no placeholder zeros), and its
             // label() method must round-trip through the new
             // VulkanAccelerationStructureMethodsVTable::label slot.
@@ -387,7 +388,7 @@ fn run_beta_shape_round_trip(ctx: &RuntimeContextFullAccess<'_>) -> Result<Strin
         // -------- streamlib-consumer-rhi POD round-trip (#1039) --------
         //
         // The POD types in consumer-rhi (TextureFormat / TextureUsages /
-        // PixelFormat / VulkanLayout) cross the plugin FFI boundary as
+        // PixelFormat / VulkanLayout) cross the plugin ABI as
         // bare scalars: adapter and FullAccess vtables carry `u32` /
         // `i32` payloads that get reconstituted on the receiving side
         // via the type's `as`/`from_bits_truncate`/`VulkanLayout(raw)`
@@ -467,17 +468,17 @@ fn run_beta_shape_round_trip(ctx: &RuntimeContextFullAccess<'_>) -> Result<Strin
     }
 }
 
-impl ManualProcessor for BetaShapeRoundTrip::Processor {
+impl ManualProcessor for PluginAbiObjectRoundTrip::Processor {
     fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        // Setup intentionally empty. Running the full β-shape sweep
+        // Setup intentionally empty. Running the full PluginAbiObject sweep
         // here too would double the GPU work (BLAS build + RT
         // kernel pipeline construction each take real time) and
         // duplicate coverage that doesn't differ between lifecycles —
         // the `RuntimeContextFullAccess` handed to setup() and start()
-        // wrap the same `GpuContextFullAccess` β-shape with the same
+        // wrap the same `GpuContextFullAccess` PluginAbiObject with the same
         // host-side vtable instance. The single sweep in `start()` is
         // sufficient to exercise the FullAccess vtable surface and
-        // the per-β-shape clone/drop slots.
+        // the per-PluginAbiObject clone/drop slots.
         Ok(())
     }
 
@@ -487,7 +488,7 @@ impl ManualProcessor for BetaShapeRoundTrip::Processor {
         let start_result: Result<String> = (|| {
             #[cfg(target_os = "linux")]
             {
-                run_beta_shape_round_trip(ctx)
+                run_plugin_abi_object_round_trip(ctx)
             }
             #[cfg(not(target_os = "linux"))]
             {
@@ -502,7 +503,7 @@ impl ManualProcessor for BetaShapeRoundTrip::Processor {
         };
         std::fs::write(&output_path, &body).map_err(|e| {
             Error::Runtime(format!(
-                "BetaShapeRoundTripProcessor: write {output_path}: {e}"
+                "PluginAbiObjectRoundTripProcessor: write {output_path}: {e}"
             ))
         })?;
         Ok(())
@@ -525,4 +526,4 @@ impl ManualProcessor for BetaShapeRoundTrip::Processor {
     }
 }
 
-streamlib_plugin_abi::export_plugin!(crate::BetaShapeRoundTrip::Processor);
+streamlib_plugin_abi::export_plugin!(crate::PluginAbiObjectRoundTrip::Processor);

--- a/libs/streamlib-cross-rustc-fixture/src/shaders/trivial_compute.comp
+++ b/libs/streamlib-cross-rustc-fixture/src/shaders/trivial_compute.comp
@@ -4,8 +4,8 @@
 // Minimal compute shader: one storage buffer binding, single-threaded
 // workgroup, no-op body. Just enough for SPIR-V reflection to discover
 // a real descriptor and validate the kernel binding declaration —
-// enough to round-trip a `VulkanComputeKernel` β-shape through Create
-// + Clone + Drop across the cdylib boundary.
+// enough to round-trip a `VulkanComputeKernel` PluginAbiObject through
+// Create + Clone + Drop across the plugin ABI.
 
 #version 450
 

--- a/libs/streamlib-cross-rustc-fixture/src/shaders/trivial_frag.frag
+++ b/libs/streamlib-cross-rustc-fixture/src/shaders/trivial_frag.frag
@@ -3,7 +3,7 @@
 
 // Minimal fragment shader: outputs constant color. No bindings, no
 // push constants. Pairs with trivial_vert.vert for the
-// `VulkanGraphicsKernel` β-shape Create+Clone+Drop round-trip.
+// `VulkanGraphicsKernel` PluginAbiObject Create+Clone+Drop round-trip.
 
 #version 450
 

--- a/libs/streamlib-cross-rustc-fixture/src/shaders/trivial_rgen.rgen
+++ b/libs/streamlib-cross-rustc-fixture/src/shaders/trivial_rgen.rgen
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 // Minimal ray-generation shader for the `VulkanRayTracingKernel`
-// β-shape Create+Clone+Drop round-trip. Declares the AS + storage-
+// PluginAbiObject Create+Clone+Drop round-trip. Declares the AS + storage-
 // image bindings the test's `RayTracingKernelDescriptor` mirrors so
 // SPIR-V reflection at kernel-construction time succeeds. The kernel
 // is never dispatched in the fixture.

--- a/libs/streamlib-cross-rustc-fixture/src/shaders/trivial_vert.vert
+++ b/libs/streamlib-cross-rustc-fixture/src/shaders/trivial_vert.vert
@@ -3,7 +3,7 @@
 
 // Minimal vertex shader: fullscreen triangle from gl_VertexIndex, no
 // vertex inputs, no descriptor bindings. Paired with trivial_frag.frag
-// to construct a `VulkanGraphicsKernel` for the cross-rustc β-shape
+// to construct a `VulkanGraphicsKernel` for the cross-rustc PluginAbiObject
 // Create+Clone+Drop round-trip — kernel construction is what we
 // exercise; the pipeline is never actually drawn from.
 

--- a/libs/streamlib-cross-rustc-fixture/streamlib.yaml
+++ b/libs/streamlib-cross-rustc-fixture/streamlib.yaml
@@ -6,7 +6,7 @@ package:
   org: tatolab
   name: cross-rustc-fixture
   version: 1.0.0
-  description: "Cross-rustc / cross-dep-graph dlopen fixture for #927 (#917 β-shape gate)"
+  description: "Cross-rustc / cross-dep-graph dlopen fixture for #927 (#917 PluginAbiObject gate)"
 
 dependencies:
   "@tatolab/core": "^1.0.0"
@@ -18,14 +18,14 @@ patch:
     path: ../../packages/core
 
 schemas:
-  BetaShapeRoundTripProcessorConfig:
-    file: schemas/beta_shape_round_trip_processor_config.yaml
+  PluginAbiObjectRoundTripProcessorConfig:
+    file: schemas/plugin_abi_object_round_trip_processor_config.yaml
 
 processors:
-  - name: BetaShapeRoundTripProcessor
+  - name: PluginAbiObjectRoundTripProcessor
     version: 1.0.0
-    description: "Cdylib processor that creates + clones + drops every #917 β-shape return type and writes a sentinel result file. Locks the cross-rustc-version FFI contract end-to-end."
+    description: "Cdylib processor that creates + clones + drops every #917 PluginAbiObject return type and writes a sentinel result file. Locks the cross-rustc-version plugin ABI contract end-to-end."
     execution: manual
     config:
       name: config
-      schema: BetaShapeRoundTripProcessorConfig
+      schema: PluginAbiObjectRoundTripProcessorConfig

--- a/libs/streamlib-engine/benches/output_writer_ffi_hop.rs
+++ b/libs/streamlib-engine/benches/output_writer_ffi_hop.rs
@@ -1,10 +1,10 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Microbench for the issue #894 `OutputWriter::write_raw` FFI hop.
+//! Microbench for the issue #894 `OutputWriter::write_raw` plugin ABI hop.
 //!
 //! Two arms compare the per-call cost of the pre-#894 direct-method
-//! shape against the post-#894 vtable-dispatch β-shape. A third bench
+//! shape against the post-#894 vtable-dispatch PluginAbiObject. A third bench
 //! varies payload size so the report shows how the hop cost scales
 //! with the data length:
 //!
@@ -12,18 +12,18 @@
 //!   called directly (pre-#894 shape from the cdylib's perspective:
 //!   the cdylib's struct held `Arc<OutputWriter>` and called methods
 //!   on it via direct Rust dispatch, with `OutputWriter` being the
-//!   real impl, not a β-shape). Includes the full iceoryx2 publish
+//!   real impl, not a PluginAbiObject). Includes the full iceoryx2 publish
 //!   + notify step.
-//! - `vtable_dispatch` — `OutputWriter::write_raw` on the β-shape,
+//! - `vtable_dispatch` — `OutputWriter::write_raw` on the PluginAbiObject,
 //!   which dispatches through the host-installed vtable to the
 //!   host-side `OutputWriterInner::write_raw`. In host mode (this
-//!   bench) the fn pointer resolves to the same DSO; in cdylib mode
-//!   it resolves to the host's DSO via the same fn pointer planted
+//!   bench) the fn pointer resolves to the same plugin; in cdylib mode
+//!   it resolves to the host via the same fn pointer planted
 //!   by `HostServices`. The PER-CALL machine cost is identical
 //!   between the two modes — both pay the indirect-call overhead;
 //!   neither pays any extra marshaling beyond pointer + length pairs
 //!   on the stack. The delta vs `baseline_direct_inner` is the cost
-//!   of the FFI hop the #894 design adds.
+//!   of the plugin ABI hop the #894 design adds.
 //! - `payload_sweep_vtable` — vtable-dispatch arm at 64 B / 256 B /
 //!   1 KiB / 8 KiB / 64 KiB payloads. Tells the reader whether the
 //!   hop's per-call cost is dominated by the fixed overhead (call
@@ -165,7 +165,7 @@ fn bench_vtable_dispatch(c: &mut Criterion) {
     });
 }
 
-/// Vary payload size to characterize how the FFI hop cost scales
+/// Vary payload size to characterize how the plugin ABI hop cost scales
 /// with the data length. Useful for the drone-racing JPEG path
 /// (typical 30-100 KB JPEG payloads per frame) vs the control-path
 /// (sub-100 byte messages).

--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -381,7 +381,7 @@ impl PixelBufferPoolManager {
 /// [`GpuContextFullAccess::gpu_capabilities`].
 ///
 /// Plain owned data — the cdylib bridge populates this from the
-/// [`streamlib_plugin_abi::GpuCapabilitiesRepr`] FFI struct (decoding
+/// [`streamlib_plugin_abi::GpuCapabilitiesRepr`] plugin ABI struct (decoding
 /// the fixed-size device_name byte buffer into an owned `String`).
 /// In-process callers get it directly from the host-side getters.
 #[cfg(target_os = "linux")]
@@ -444,14 +444,14 @@ pub struct GpuContext {
     /// Serializes [`GpuContextLimitedAccess::escalate`] scopes across
     /// threads (and across the in-process and vtable dispatch paths —
     /// engine-internal callers using `host_inner` direct dispatch and
-    /// cdylib plugin callers using vtable FFI dispatch serialize
+    /// cdylib plugin callers using vtable plugin ABI dispatch serialize
     /// against each other) so concurrent GPU resource creation (video
     /// sessions, DPB images, swapchain) can't race on the device. The
     /// compiler acquires this during Phase 4 of spawn_processor and
     /// releases it after waiting for the device to go idle. Replaces
     /// the older `std::sync::Mutex<()>`-based `processor_setup_lock`
     /// — a [`Mutex`] guard can't cross thread boundaries (the cdylib
-    /// FFI escalate_begin / escalate_end pair may run on different
+    /// plugin ABI escalate_begin / escalate_end pair may run on different
     /// threads), so this gate uses a flag + Condvar that enter and
     /// exit can hit independently.
     escalate_gate: Arc<super::escalate_gate::EscalateGate>,
@@ -554,11 +554,11 @@ impl GpuContext {
     /// dispatch paths — engine-internal in-process escalate (the
     /// host-mode caller; uses
     /// [`super::escalate_gate::EscalateGate::enter_scoped`] for RAII
-    /// release) and cdylib FFI-dispatched escalate (the plugin
+    /// release) and cdylib plugin-ABI-dispatched escalate (the plugin
     /// caller; uses bare `enter` / `exit` through
     /// [`super::escalate_scope_registry::begin_escalate_scope`] /
     /// [`super::escalate_scope_registry::end_escalate_scope`] because
-    /// the FFI boundary precludes RAII across it).
+    /// the plugin ABI precludes RAII across it).
     pub(crate) fn escalate_gate(&self) -> &super::escalate_gate::EscalateGate {
         &self.escalate_gate
     }
@@ -1340,7 +1340,7 @@ impl GpuContext {
         dst: PixelFormat,
     ) -> Result<RhiColorConverter> {
         // Fast path: read lock; cache stores Arc<Inner> so we can build
-        // a fresh β-shape via from_arc_into_raw per request.
+        // a fresh PluginAbiObject via from_arc_into_raw per request.
         {
             let cache = self.color_converter_cache.read().unwrap();
             if let Some(c) = cache.get(&(src, dst)) {
@@ -2037,7 +2037,7 @@ impl std::fmt::Debug for GpuContext {
 /// operations; heavier work must go through [`GpuContextLimitedAccess::escalate`].
 ///
 /// Restricted GPU capability shim with ABI-stable `(handle, vtable)`
-/// shape. Both fields cross the cdylib DSO boundary unchanged:
+/// shape. Both fields cross the plugin ABI unchanged:
 ///
 /// - `handle`: opaque `*const c_void` pointing at a host-leaked
 ///   `Box<Arc<GpuContext>>`. Cdylib code passes this pointer to
@@ -2067,13 +2067,13 @@ pub struct GpuContextLimitedAccess {
 // fields are themselves Send + Sync via their Arc wrappers). The
 // vtable pointer is `&'static` and pinned for the host's lifetime.
 // Every method (engine and cdylib) reaches the GpuContext through
-// the handle, gated on DSO mode by `host_inner()`'s `host_callbacks()`
+// the handle, gated on plugin mode by `host_inner()`'s `host_callbacks()`
 // check.
 unsafe impl Send for GpuContextLimitedAccess {}
 unsafe impl Sync for GpuContextLimitedAccess {}
 
 impl Clone for GpuContextLimitedAccess {
-    /// Cross-DSO-safe Clone. Dispatches through
+    /// plugin-ABI-safe Clone. Dispatches through
     /// [`GpuContextLimitedAccessVTable::clone_handle`] to bump the
     /// host's `Arc<GpuContext>` refcount.
     fn clone(&self) -> Self {
@@ -2130,7 +2130,7 @@ impl Drop for GpuContextLimitedAccess {
 /// # In-process vs vtable dispatch (Phase C3)
 ///
 /// Two construction paths populate this struct depending on which
-/// side of the FFI boundary the caller lives on; the same surface
+/// side of the plugin ABI the caller lives on; the same surface
 /// methods work from either:
 ///
 /// - **In-process dispatch** ([`Self::new`], `pub(in
@@ -2139,7 +2139,7 @@ impl Drop for GpuContextLimitedAccess {
 ///   can construct it). `handle` is a host-allocated
 ///   `Box<Arc<GpuContext>>` and `handle_kind` is
 ///   [`HandleKind::Boxed`]. Every method routes through
-///   [`Self::host_inner`] for direct dispatch — no FFI hop, no
+///   [`Self::host_inner`] for direct dispatch — no plugin ABI hop, no
 ///   scope-registry lookup. Drop runs
 ///   [`std::boxed::Box::from_raw`] on the boxed Arc.
 /// - **Vtable dispatch** ([`Self::from_scope_token`], reached from
@@ -2209,7 +2209,7 @@ pub(crate) enum HandleKind {
     /// Handle is a host-allocated `Box<Arc<GpuContext>>` from
     /// [`GpuContextFullAccess::new`]. Methods on the cdylib-facing
     /// `GpuContextFullAccess` surface dispatch through `host_inner`
-    /// directly (no FFI hop). Used by engine-internal escalate
+    /// directly (no plugin ABI hop). Used by engine-internal escalate
     /// scopes.
     Boxed = 0,
     /// Handle is an opaque scope token from the host's
@@ -2238,7 +2238,7 @@ impl Drop for GpuContextFullAccess {
     ///
     /// - [`HandleKind::Boxed`] (in-process dispatch shape): runs
     ///   `Box::from_raw` on the boxed `Arc<GpuContext>` directly,
-    ///   without going through the vtable. No FFI hop;
+    ///   without going through the vtable. No plugin ABI hop;
     ///   engine-internal cleanup.
     /// - [`HandleKind::ScopeToken`] (vtable-dispatched shape):
     ///   no-op. The cdylib's escalate wrapper that constructed this
@@ -2279,7 +2279,7 @@ impl GpuContextLimitedAccess {
     /// `Box<Arc<GpuContext>>` as the opaque handle, then resolves
     /// the vtable through
     /// [`crate::core::plugin::host_services::host_gpu_context_limited_access_vtable`]
-    /// (DSO-routed: host static in host mode, cdylib-installed
+    /// (plugin-ABI-routed: host static in host mode, cdylib-installed
     /// pointer in cdylib mode).
     pub(crate) fn new(inner: GpuContext) -> Self {
         // Leak a fresh `Arc<GpuContext>` to back the opaque handle.
@@ -2308,7 +2308,7 @@ impl GpuContextLimitedAccess {
     /// instead — every cdylib-callable method on
     /// [`GpuContextLimitedAccess`] is wired through the vtable.
     ///
-    /// The panic is caught by `run_host_extern_c` at the FFI
+    /// The panic is caught by `run_host_extern_c` at the plugin ABI
     /// boundary (host extern "C" callbacks all route through
     /// `catch_unwind`), so a misconfigured cdylib path gets a clean
     /// "callback panicked" log entry instead of UB.
@@ -2319,7 +2319,7 @@ impl GpuContextLimitedAccess {
             panic!(
                 "GpuContextLimitedAccess::host_inner() reached from cdylib code; \
                  this method must dispatch through the GpuContextLimitedAccessVTable. \
-                 The panic is caught by run_host_extern_c at the FFI boundary."
+                 The panic is caught by run_host_extern_c at the plugin ABI."
             );
         }
         // SAFETY: `self.handle` was produced by `Self::new` or
@@ -2360,7 +2360,7 @@ impl GpuContextLimitedAccess {
     /// - **In-process dispatch** (engine-internal callers): acquires
     ///   the gate directly, constructs [`GpuContextFullAccess::new`]
     ///   (Boxed), runs the closure with method dispatch via
-    ///   [`GpuContextFullAccess::host_inner`] (no FFI hop), then
+    ///   [`GpuContextFullAccess::host_inner`] (no plugin ABI hop), then
     ///   waits device idle and releases the gate.
     /// - **Vtable dispatch** (cdylib callers): dispatches through
     ///   the [`GpuContextLimitedAccessVTable`]'s `escalate_begin` /
@@ -2392,7 +2392,7 @@ impl GpuContextLimitedAccess {
     }
 
     /// Engine-internal escalate path. Direct in-process dispatch —
-    /// no FFI hop. See [`Self::escalate`] for the mode router.
+    /// no plugin ABI hop. See [`Self::escalate`] for the mode router.
     fn escalate_in_process<F, T>(&self, f: F) -> Result<T>
     where
         F: FnOnce(&GpuContextFullAccess) -> Result<T>,
@@ -2434,7 +2434,7 @@ impl GpuContextLimitedAccess {
     /// Cdylib escalate path. Dispatches through the LimitedAccess
     /// vtable's `escalate_begin` / `escalate_end` pair; constructs
     /// `GpuContextFullAccess::from_scope_token` so the closure's
-    /// FullAccess method calls cross the FFI boundary through the
+    /// FullAccess method calls cross the plugin ABI through the
     /// FullAccess vtable. See [`Self::escalate`] for the mode router.
     fn escalate_via_vtable<F, T>(&self, f: F) -> Result<T>
     where
@@ -2629,7 +2629,7 @@ impl GpuContextFullAccess {
     /// `escalate_begin` callback) as a full-access capability whose
     /// methods route through the
     /// [`GpuContextFullAccessVTable`](streamlib_plugin_abi::GpuContextFullAccessVTable)
-    /// for cross-DSO dispatch.
+    /// for plugin ABI dispatch.
     ///
     /// Used by the cdylib-mode path of
     /// [`GpuContextLimitedAccess::escalate`]; the matching cleanup
@@ -2669,20 +2669,20 @@ impl GpuContextFullAccess {
     /// [`GpuContextLimitedAccess::host_inner`]'s contract: cdylib code
     /// must dispatch through the
     /// [`GpuContextFullAccessVTable`](streamlib_plugin_abi::GpuContextFullAccessVTable)
-    /// instead. The panic is caught by `run_host_extern_c` at the FFI
+    /// instead. The panic is caught by `run_host_extern_c` at the plugin ABI
     /// boundary.
     pub(crate) fn host_inner(&self) -> &GpuContext {
         if crate::core::plugin::host_services::host_callbacks().is_some() {
             panic!(
                 "GpuContextFullAccess::host_inner() reached from cdylib code; \
                  this method must dispatch through the GpuContextFullAccessVTable. \
-                 The panic is caught by run_host_extern_c at the FFI boundary. \
+                 The panic is caught by run_host_extern_c at the plugin ABI. \
                  \
                  Read docs/architecture/cdylib-reachability.md before workarounds — \
                  the right pattern depends on the lifecycle stage and the type \
                  shape. For setup()/teardown() bodies, ctx.gpu_full_access() now \
                  dispatches through the vtable (Pattern 1, #1072). For accessor \
-                 returns, see β-shape Arc-transit slots (Pattern 2). For per- \
+                 returns, see PluginAbiObject Arc-transit slots (Pattern 2). For per- \
                  method binding work, see per-method vtable slots (Pattern 3). \
                  DO NOT call gpu_limited_access().escalate(...) from setup() / \
                  teardown() — the gate is already held and re-entry panics."
@@ -2818,11 +2818,11 @@ impl GpuContextLimitedAccess {
     /// allocates — nonzero sustained rates will fire the escalation-rate
     /// warning, indicating a pre-reservation gap.
     ///
-    /// Dispatches through the cross-DSO vtable's
+    /// Dispatches through the plugin ABI vtable's
     /// `acquire_pixel_buffer` callback. The tuple return is encoded
     /// via paired out-params: the pool id's string bytes land in a
     /// fixed-size stack buffer (1 KiB; UUID strings are well under
-    /// 128 bytes), and the β-shape PixelBuffer goes into a
+    /// 128 bytes), and the PluginAbiObject PixelBuffer goes into a
     /// MaybeUninit slot.
     pub fn acquire_pixel_buffer(
         &self,
@@ -2873,7 +2873,7 @@ impl GpuContextLimitedAccess {
     /// Acquire a HOST_VISIBLE storage buffer for CPU→GPU SSBO upload.
     /// See [`GpuContext::acquire_storage_buffer`].
     ///
-    /// Dispatches through the cross-DSO vtable's
+    /// Dispatches through the plugin ABI vtable's
     /// `acquire_storage_buffer` callback.
     #[cfg(target_os = "linux")]
     pub fn acquire_storage_buffer(
@@ -2891,7 +2891,7 @@ impl GpuContextLimitedAccess {
     /// Acquire a HOST_VISIBLE uniform buffer.
     /// See [`GpuContext::acquire_uniform_buffer`].
     ///
-    /// Dispatches through the cross-DSO vtable's
+    /// Dispatches through the plugin ABI vtable's
     /// `acquire_uniform_buffer` callback.
     #[cfg(target_os = "linux")]
     pub fn acquire_uniform_buffer(
@@ -2909,7 +2909,7 @@ impl GpuContextLimitedAccess {
     /// Acquire a HOST_VISIBLE vertex buffer.
     /// See [`GpuContext::acquire_vertex_buffer`].
     ///
-    /// Dispatches through the cross-DSO vtable's
+    /// Dispatches through the plugin ABI vtable's
     /// `acquire_vertex_buffer` callback.
     #[cfg(target_os = "linux")]
     pub fn acquire_vertex_buffer(
@@ -2927,7 +2927,7 @@ impl GpuContextLimitedAccess {
     /// Acquire a HOST_VISIBLE index buffer.
     /// See [`GpuContext::acquire_index_buffer`].
     ///
-    /// Dispatches through the cross-DSO vtable's
+    /// Dispatches through the plugin ABI vtable's
     /// `acquire_index_buffer` callback.
     #[cfg(target_os = "linux")]
     pub fn acquire_index_buffer(
@@ -2944,7 +2944,7 @@ impl GpuContextLimitedAccess {
 
     /// Get a pixel buffer by its pool id (Split: local cache).
     ///
-    /// Dispatches through the cross-DSO vtable's `get_pixel_buffer`
+    /// Dispatches through the plugin ABI vtable's `get_pixel_buffer`
     /// callback.
     pub fn get_pixel_buffer(&self, pool_id: &PixelBufferPoolId) -> Result<PixelBuffer> {
         if self.handle.is_null() || self.vtable.is_null() {
@@ -2978,7 +2978,7 @@ impl GpuContextLimitedAccess {
 
     /// Resolve a VideoFrame's buffer from its surface_id.
     ///
-    /// Dispatches through the cross-DSO vtable's
+    /// Dispatches through the plugin ABI vtable's
     /// `resolve_pixel_buffer_by_surface_id` callback.
     pub fn resolve_pixel_buffer_by_surface_id(&self, surface_id: &str) -> Result<PixelBuffer> {
         if self.handle.is_null() || self.vtable.is_null() {
@@ -3011,7 +3011,7 @@ impl GpuContextLimitedAccess {
 
     /// Register a texture in the same-process texture cache.
     ///
-    /// Dispatches through the cross-DSO
+    /// Dispatches through the plugin ABI
     /// [`GpuContextLimitedAccessVTable::register_texture`](streamlib_plugin_abi::GpuContextLimitedAccessVTable::register_texture)
     /// callback. The host-side impl bumps the
     /// `Arc<TextureInner>` refcount before stashing a clone in the
@@ -3037,7 +3037,7 @@ impl GpuContextLimitedAccess {
     /// Register a texture with a declared initial Vulkan image layout.
     /// See [`GpuContext::register_texture_with_layout`].
     ///
-    /// Dispatches through the cross-DSO vtable's `register_texture`
+    /// Dispatches through the plugin ABI vtable's `register_texture`
     /// callback with the layout's `i32` enumerant.
     #[cfg(target_os = "linux")]
     pub fn register_texture_with_layout(
@@ -3065,7 +3065,7 @@ impl GpuContextLimitedAccess {
     /// Update a registered texture's tracked layout after a transition.
     /// See [`GpuContext::update_texture_registration_layout`].
     ///
-    /// Dispatches through the cross-DSO vtable's
+    /// Dispatches through the plugin ABI vtable's
     /// `update_texture_registration_layout` callback.
     #[cfg(target_os = "linux")]
     pub fn update_texture_registration_layout(&self, id: &str, layout: VulkanLayout) {
@@ -3085,7 +3085,7 @@ impl GpuContextLimitedAccess {
 
     /// Resolve a VideoFrame's full registration record (texture + layout).
     ///
-    /// Dispatches through the cross-DSO vtable's
+    /// Dispatches through the plugin ABI vtable's
     /// `resolve_texture_registration_by_surface_id` callback. Returns
     /// a β-reshaped [`TextureRegistration`] value (handle + vtable);
     /// Clone is cheap (refcount bump via vtable), Drop releases the
@@ -3141,7 +3141,7 @@ impl GpuContextLimitedAccess {
 
     /// Resolve a VideoFrame's texture (Split: cache hit).
     ///
-    /// Dispatches through the cross-DSO vtable's
+    /// Dispatches through the plugin ABI vtable's
     /// `resolve_texture_by_surface_id` callback.
     pub fn resolve_texture_by_surface_id(
         &self,
@@ -3194,7 +3194,7 @@ impl GpuContextLimitedAccess {
 
     /// See [`GpuContext::set_video_source_timeline_semaphore`].
     ///
-    /// Dispatches through the cross-DSO
+    /// Dispatches through the plugin ABI
     /// [`GpuContextLimitedAccessVTable::set_video_source_timeline_semaphore`](streamlib_plugin_abi::GpuContextLimitedAccessVTable::set_video_source_timeline_semaphore)
     /// callback. The cdylib passes
     /// `Arc::as_ptr(timeline) as *const c_void` — a **borrowed**
@@ -3209,7 +3209,7 @@ impl GpuContextLimitedAccess {
     /// [`GpuContextFullAccess::create_timeline_semaphore`]'s docs on
     /// the same rustc-version-coupling caveat. In-tree consumers
     /// (camera, display) ride this freely; cross-repo distribution
-    /// awaits a β-shape lift of `HostVulkanTimelineSemaphore`.
+    /// awaits a PluginAbiObject lift of `HostVulkanTimelineSemaphore`.
     #[cfg(target_os = "linux")]
     pub fn set_video_source_timeline_semaphore(
         &self,
@@ -3234,7 +3234,7 @@ impl GpuContextLimitedAccess {
 
     /// See [`GpuContext::clear_video_source_timeline_semaphore`].
     ///
-    /// Dispatches through the cross-DSO
+    /// Dispatches through the plugin ABI
     /// [`GpuContextLimitedAccessVTable::clear_video_source_timeline_semaphore`](streamlib_plugin_abi::GpuContextLimitedAccessVTable::clear_video_source_timeline_semaphore)
     /// callback. Pairs with
     /// [`Self::set_video_source_timeline_semaphore`].
@@ -3253,7 +3253,7 @@ impl GpuContextLimitedAccess {
     ///
     /// **Engine-only** — return type
     /// `Option<Arc<HostVulkanTimelineSemaphore>>` borrows into
-    /// host-private state, so the borrow can't cross the FFI
+    /// host-private state, so the borrow can't cross the plugin ABI
     /// boundary. Calling from a cdylib panics at the explicit guard
     /// below. **Cdylib callers** must use
     /// [`Self::host_video_source_timeline_arc`] instead — it returns
@@ -3271,7 +3271,7 @@ impl GpuContextLimitedAccess {
                  `host_video_source_timeline_arc()` instead. The legacy method \
                  returns `Option<Arc<HostVulkanTimelineSemaphore>>` from \
                  `host_inner()` which borrows host-private state and cannot \
-                 cross the FFI boundary."
+                 cross the plugin ABI."
             );
         }
         self.host_inner().video_source_timeline_semaphore()
@@ -3329,7 +3329,7 @@ impl GpuContextLimitedAccess {
     /// because allocating a new RT-capable image is a privileged op
     /// that goes through escalate.
     ///
-    /// Dispatches through the cross-DSO vtable's `acquire_texture`
+    /// Dispatches through the plugin ABI vtable's `acquire_texture`
     /// callback. The descriptor's `label` field is currently dropped
     /// on the wire (debugging-only, never load-bearing).
     pub fn acquire_texture(&self, desc: &TexturePoolDescriptor) -> Result<PooledTextureHandle> {
@@ -3377,7 +3377,7 @@ impl GpuContextLimitedAccess {
     /// See [`GpuContext::copy_pixel_buffer_to_texture`] for the full
     /// contract.
     ///
-    /// Dispatches through the cross-DSO vtable's
+    /// Dispatches through the plugin ABI vtable's
     /// `copy_pixel_buffer_to_texture` callback.
     #[cfg(target_os = "linux")]
     pub fn copy_pixel_buffer_to_texture(
@@ -3420,7 +3420,7 @@ impl GpuContextLimitedAccess {
 
     /// See [`GpuContext::unregister_texture`].
     ///
-    /// Dispatches through the cross-DSO vtable's `unregister_texture`
+    /// Dispatches through the plugin ABI vtable's `unregister_texture`
     /// callback.
     pub fn unregister_texture(&self, id: &str) {
         if self.handle.is_null() || self.vtable.is_null() {
@@ -3438,12 +3438,12 @@ impl GpuContextLimitedAccess {
     /// images/buffers a Sandbox caller can construct are pool-backed and
     /// pre-reserved. See design doc §8 Q5.
     ///
-    /// Dispatches through the cross-DSO vtable's `command_queue`
-    /// callback. Returns an owned [`RhiCommandQueue`] β-shape with the
+    /// Dispatches through the plugin ABI vtable's `command_queue`
+    /// callback. Returns an owned [`RhiCommandQueue`] PluginAbiObject with the
     /// host's `Arc<RhiCommandQueueInner>` refcount bumped.
     pub fn command_queue(&self) -> RhiCommandQueue {
         if self.handle.is_null() || self.vtable.is_null() {
-            // Construct a null-handle β-shape that's safe to Drop
+            // Construct a null-handle PluginAbiObject that's safe to Drop
             // (Drop short-circuits on null). Caller's subsequent
             // method calls on the queue will fail cleanly.
             return RhiCommandQueue {
@@ -3457,7 +3457,7 @@ impl GpuContextLimitedAccess {
         let mut err_len: usize = 0;
         // SAFETY: handle + vtable were paired at construction. The
         // host writes a valid RhiCommandQueue into `out_q` on success.
-        // On failure we still produce a null-handle β-shape so the
+        // On failure we still produce a null-handle PluginAbiObject so the
         // method's signature stays infallible.
         let status = unsafe {
             ((*self.vtable).command_queue)(
@@ -3481,7 +3481,7 @@ impl GpuContextLimitedAccess {
 
     /// Create a CPU-side command buffer from the shared queue.
     ///
-    /// Dispatches through the cross-DSO vtable's
+    /// Dispatches through the plugin ABI vtable's
     /// `create_command_buffer` callback.
     pub fn create_command_buffer(&self) -> Result<CommandBuffer> {
         if self.handle.is_null() || self.vtable.is_null() {
@@ -3512,7 +3512,7 @@ impl GpuContextLimitedAccess {
 
     /// Copy pixels between same-format, same-size buffers (Split: cache hit).
     ///
-    /// Dispatches through the cross-DSO vtable's `blit_copy` callback.
+    /// Dispatches through the plugin ABI vtable's `blit_copy` callback.
     pub fn blit_copy(&self, src: &PixelBuffer, dest: &PixelBuffer) -> Result<()> {
         if self.handle.is_null() || self.vtable.is_null() {
             return Err(Error::GpuError(
@@ -3546,7 +3546,7 @@ impl GpuContextLimitedAccess {
     /// - `src` must be a valid IOSurfaceRef pointer
     /// - The IOSurface must remain valid for the duration of the blit
     ///
-    /// Dispatches through the cross-DSO vtable's `blit_copy_iosurface`
+    /// Dispatches through the plugin ABI vtable's `blit_copy_iosurface`
     /// callback. macOS-only; non-macOS hosts return an error.
     #[cfg(target_os = "macos")]
     pub unsafe fn blit_copy_iosurface(
@@ -3587,9 +3587,9 @@ impl GpuContextLimitedAccess {
 
     /// Get the surface store, if initialized.
     ///
-    /// Dispatches through the cross-DSO vtable's `surface_store`
-    /// callback. Returns `Some(SurfaceStore)` (β-shape, refcount
-    /// bumped) when the host has one, else `None`. The β-shape's
+    /// Dispatches through the plugin ABI vtable's `surface_store`
+    /// callback. Returns `Some(SurfaceStore)` (PluginAbiObject, refcount
+    /// bumped) when the host has one, else `None`. The PluginAbiObject's
     /// own Clone/Drop dispatch through the
     /// [`streamlib_plugin_abi::SurfaceStoreVTable`] reached via
     /// [`HostServices::surface_store_vtable`].
@@ -3601,18 +3601,18 @@ impl GpuContextLimitedAccess {
             std::mem::MaybeUninit::uninit();
         // SAFETY: handle + vtable were paired at construction. The
         // callback always writes a SurfaceStore — either a real
-        // β-shape (Some) or a null-handle β-shape (None sentinel).
+        // PluginAbiObject (Some) or a null-handle PluginAbiObject (None sentinel).
         unsafe {
             ((*self.vtable).surface_store)(
                 self.handle,
                 out_store.as_mut_ptr() as *mut std::ffi::c_void,
             );
         }
-        // SAFETY: the callback wrote either a real β-shape or a
-        // null-handle β-shape; either way `out_store` is initialized.
+        // SAFETY: the callback wrote either a real PluginAbiObject or a
+        // null-handle PluginAbiObject; either way `out_store` is initialized.
         let store = unsafe { out_store.assume_init() };
         if store.is_none() {
-            // Null-handle β-shape — Drop is a no-op (short-circuits
+            // Null-handle PluginAbiObject — Drop is a no-op (short-circuits
             // on null), so we can safely drop here without affecting
             // any Arc refcount.
             drop(store);
@@ -3624,7 +3624,7 @@ impl GpuContextLimitedAccess {
 
     /// Check out a surface by ID (Split: cache hit).
     ///
-    /// Dispatches through the cross-DSO vtable's `check_out_surface`
+    /// Dispatches through the plugin ABI vtable's `check_out_surface`
     /// callback.
     pub fn check_out_surface(&self, surface_id: &str) -> Result<PixelBuffer> {
         if self.handle.is_null() || self.vtable.is_null() {
@@ -4152,13 +4152,13 @@ impl GpuContextFullAccess {
                                 .into(),
                         ));
                     }
-                    // β-shape: bundle the raw handle
+                    // PluginAbiObject: bundle the raw handle
                     // (`Arc::into_raw(Arc<TextureRingInner>)`-shaped)
                     // with the host vtables + cached POD descriptors.
                     // The cached values come from the caller's own
                     // inputs (we know `width` / `height` / `format` /
                     // `count` — these are the args we just passed
-                    // through the FFI), avoiding an extra round-trip
+                    // through the plugin ABI), avoiding an extra round-trip
                     // for the getters. Cross-rustc-version safe because
                     // cdylib never derefs the Inner layout.
                     let methods_vtable =
@@ -4200,7 +4200,7 @@ impl GpuContextFullAccess {
     /// **Engine-only** — parameter is `&Arc<HostVulkanTimelineSemaphore>`
     /// (host-internal type from `crate::vulkan::rhi`). Calling from a
     /// cdylib panics inside [`Self::host_inner`]; the panic is caught by
-    /// `run_host_extern_c` at the FFI boundary, so it surfaces as a
+    /// `run_host_extern_c` at the plugin ABI, so it surfaces as a
     /// clean "callback panicked" log rather than UB.
     #[cfg(target_os = "linux")]
     pub fn set_video_source_timeline_semaphore(
@@ -4211,7 +4211,7 @@ impl GpuContextFullAccess {
             panic!(
                 "GpuContextFullAccess::set_video_source_timeline_semaphore(): \
                  parameter `&Arc<HostVulkanTimelineSemaphore>` is host-internal \
-                 (crate::vulkan::rhi) and cannot cross the FFI boundary; this \
+                 (crate::vulkan::rhi) and cannot cross the plugin ABI; this \
                  method is engine-only and cdylib code must not call it."
             );
         }
@@ -4250,7 +4250,7 @@ impl GpuContextFullAccess {
             panic!(
                 "GpuContextFullAccess::video_source_timeline_semaphore(): \
                  return type `Option<Arc<HostVulkanTimelineSemaphore>>` is \
-                 host-internal (crate::vulkan::rhi) and cannot cross the FFI \
+                 host-internal (crate::vulkan::rhi) and cannot cross the plugin ABI \
                  boundary; engine-only — cdylib code must not call it."
             );
         }
@@ -4261,7 +4261,7 @@ impl GpuContextFullAccess {
     ///
     /// **Engine-only** — returns `&Arc<GpuDevice>` which borrows into
     /// host-private state (the `Box<Arc<GpuContext>>` behind the
-    /// handle). The borrow can't cross the FFI boundary; cdylib code
+    /// handle). The borrow can't cross the plugin ABI; cdylib code
     /// that needs GPU device capabilities should use the higher-level
     /// FullAccess methods (kernel construction, buffer/texture
     /// allocation, etc.) which dispatch through the vtable. Calling
@@ -4270,7 +4270,7 @@ impl GpuContextFullAccess {
         if crate::core::plugin::host_services::host_callbacks().is_some() {
             panic!(
                 "GpuContextFullAccess::device(): return type `&Arc<GpuDevice>` \
-                 borrows into host-private state and cannot cross the FFI \
+                 borrows into host-private state and cannot cross the plugin ABI \
                  boundary; engine-only. Cdylib code that needs GPU device \
                  capabilities must use higher-level FullAccess methods (kernel \
                  construction, buffer/texture allocation) which dispatch \
@@ -4292,7 +4292,7 @@ impl GpuContextFullAccess {
     /// caller's `Drop` decrements the host's count.
     ///
     /// **Rustc-version coupling.** `HostVulkanDevice` is not
-    /// `#[repr(C)]` — the cross-DSO Arc transit is safe only when the
+    /// `#[repr(C)]` — the plugin ABI Arc transit is safe only when the
     /// cdylib shares the host's rustc version and the engine's dep
     /// graph (workspace plugin cdylibs do; subprocess cdylibs
     /// — `streamlib-python-native`, `streamlib-deno-native` — don't dep
@@ -4346,7 +4346,7 @@ impl GpuContextFullAccess {
             panic!(
                 "GpuContextFullAccess::texture_pool(): return type \
                  `&TexturePool` borrows into host-private state and cannot \
-                 cross the FFI boundary; engine-only. Cdylib code uses \
+                 cross the plugin ABI; engine-only. Cdylib code uses \
                  acquire_texture() which dispatches through the FullAccess \
                  vtable."
             );
@@ -4369,11 +4369,11 @@ impl GpuContextFullAccess {
 
     /// Get the shared command queue.
     ///
-    /// Phase D adopts the owned β-shape return that matches
+    /// Phase D adopts the owned PluginAbiObject return that matches
     /// [`GpuContextLimitedAccess::command_queue`] — borrowed
-    /// references can't cross the FFI boundary, so a cdylib-callable
+    /// references can't cross the plugin ABI, so a cdylib-callable
     /// `command_queue` must hand out a refcount-bumped owned
-    /// [`RhiCommandQueue`] regardless of mode. The β-shape's Drop
+    /// [`RhiCommandQueue`] regardless of mode. The PluginAbiObject's Drop
     /// dispatches through the LimitedAccess vtable's
     /// `drop_rhi_command_queue` callback.
     pub fn command_queue(&self) -> RhiCommandQueue {
@@ -4432,7 +4432,7 @@ impl GpuContextFullAccess {
                             "color_converter: host signaled success but out_converter is null".into(),
                         ));
                     }
-                    // β-shape: bundle the raw handle with the parent
+                    // PluginAbiObject: bundle the raw handle with the parent
                     // vtable + per-type methods vtable (Phase E sub-
                     // lift slice A). The methods vtable comes from
                     // `host_callbacks()` — populated at plugin
@@ -4509,14 +4509,14 @@ impl GpuContextFullAccess {
                             "create_compute_kernel: host signaled success but out_kernel is null".into(),
                         ));
                     }
-                    // β-shape: bundle the raw handle (an
+                    // PluginAbiObject: bundle the raw handle (an
                     // `Arc::into_raw(Arc<VulkanComputeKernelInner>)`
                     // pointer host-side, opaque to the cdylib) with
                     // the host's parent vtable + per-type methods
                     // vtable + cached `push_constant_size` POD
                     // (#907 PR 2/5). The cached value comes from the
                     // descriptor input the cdylib just handed across
-                    // — we know it without needing an FFI round-trip
+                    // — we know it without needing a plugin ABI round-trip
                     // to read it back.
                     let methods_vtable =
                         crate::core::plugin::host_services::host_callbacks()
@@ -4756,9 +4756,9 @@ impl GpuContextFullAccess {
                             "create_graphics_kernel: host signaled success but out_kernel is null".into(),
                         ));
                     }
-                    // β-shape: see compute_kernel above. Cached PODs
+                    // PluginAbiObject: see compute_kernel above. Cached PODs
                     // come from the caller's descriptor — we know
-                    // them without an FFI round-trip (#907 PR 3/5).
+                    // them without a plugin ABI round-trip (#907 PR 3/5).
                     let methods_vtable =
                         crate::core::plugin::host_services::host_callbacks()
                             .map(|c| c.vulkan_graphics_kernel_methods_vtable)
@@ -4823,7 +4823,7 @@ impl GpuContextFullAccess {
                             "create_ray_tracing_kernel: host signaled success but out_kernel is null".into(),
                         ));
                     }
-                    // β-shape: see compute_kernel above. Cached PODs
+                    // PluginAbiObject: see compute_kernel above. Cached PODs
                     // come from the caller's descriptor (#907 PR 4/5).
                     let methods_vtable =
                         crate::core::plugin::host_services::host_callbacks()
@@ -4896,10 +4896,10 @@ impl GpuContextFullAccess {
                             "build_triangles_blas: host signaled success but out_blas is null".into(),
                         ));
                     }
-                    // β-shape: bundle the raw handle (`Arc::into_raw(Arc<Inner>)`-shaped)
+                    // PluginAbiObject: bundle the raw handle (`Arc::into_raw(Arc<Inner>)`-shaped)
                     // with the host vtables. The cached POD descriptors
                     // (`device_address`, `storage_size`, `kind`) come
-                    // from the host's β-shape post-mint (see
+                    // from the host's PluginAbiObject post-mint (see
                     // `host_gpu_full_build_triangles_blas`); they are
                     // always real values, never placeholder zeros.
                     let methods_vtable =
@@ -4969,8 +4969,8 @@ impl GpuContextFullAccess {
                             "build_tlas: host signaled success but out_tlas is null".into(),
                         ));
                     }
-                    // β-shape: see build_triangles_blas above. Cached
-                    // PODs come from the host's β-shape post-mint via
+                    // PluginAbiObject: see build_triangles_blas above. Cached
+                    // PODs come from the host's PluginAbiObject post-mint via
                     // the v8 out-params; always real values.
                     let methods_vtable =
                         crate::core::plugin::host_services::host_callbacks()
@@ -5022,7 +5022,7 @@ impl GpuContextFullAccess {
         }
     }
 
-    /// Import a DMA-BUF FD as a `StorageBuffer` (β-shape). Camera
+    /// Import a DMA-BUF FD as a `StorageBuffer` (PluginAbiObject). Camera
     /// V4L2 zero-copy path. **Consumes `fd` on success** — on success
     /// the host's `vkImportMemoryFdInfoKHR` takes ownership of the
     /// kernel-side fd transfer; on failure the caller retains the fd
@@ -5061,7 +5061,7 @@ impl GpuContextFullAccess {
                 };
                 if status == 0 {
                     // SAFETY: host signaled success and wrote the
-                    // StorageBuffer β-shape struct into the slot.
+                    // StorageBuffer PluginAbiObject struct into the slot.
                     Ok(unsafe { out_buffer.assume_init() })
                 } else {
                     let msg = String::from_utf8_lossy(
@@ -5083,10 +5083,10 @@ impl GpuContextFullAccess {
     ///
     /// **Note**: this slot transits `Arc<HostVulkanTimelineSemaphore>`
     /// via Arc-raw-pointer pattern — same hazard as the kernel paths
-    /// pre-#917 Phase 8. Arc internals leak across DSO for now.
+    /// pre-#917 Phase 8. Arc internals leak across the plugin ABI for now.
     /// In-tree consumers (camera, display) are built in the same
     /// workspace as engine; the layout matches by construction.
-    /// Cross-repo plugin distribution will need a β-shape lift for
+    /// Cross-repo plugin distribution will need a PluginAbiObject lift for
     /// `HostVulkanTimelineSemaphore` — tracked as a future follow-up.
     #[cfg(target_os = "linux")]
     pub fn create_timeline_semaphore(
@@ -5143,7 +5143,7 @@ impl GpuContextFullAccess {
     /// Read-once GPU capability snapshot. Backs the camera processor's
     /// vendor-name / external-memory / cross-device-DMA-BUF-probe
     /// branching without exposing host-internal `HostVulkanDevice`
-    /// across the FFI. Mode-routed: host-mode dispatches through
+    /// across the plugin ABI. Mode-routed: host-mode dispatches through
     /// `host_inner()`; cdylib-mode reads a `#[repr(C)]`
     /// [`GpuCapabilitiesRepr`](streamlib_plugin_abi::GpuCapabilitiesRepr)
     /// via the vtable's `gpu_capabilities` slot and decodes the
@@ -5158,7 +5158,7 @@ impl GpuContextFullAccess {
                         "gpu_capabilities: GpuContextFullAccess has null vtable".into(),
                     ));
                 }
-                // Stack-allocate the FFI repr; the host populates it
+                // Stack-allocate the plugin ABI repr; the host populates it
                 // via *out_caps. We then decode into an owned snapshot.
                 let mut out: std::mem::MaybeUninit<
                     streamlib_plugin_abi::GpuCapabilitiesRepr,
@@ -5327,7 +5327,7 @@ impl GpuContextFullAccess {
     ///
     /// **Engine-only** — return type is `Option<Arc<dyn CpuReadbackBridge>>`,
     /// a trait object whose vtable layout is rustc-private (no `#[repr(C)]`
-    /// shape that crosses the FFI boundary). The bridge is registered by
+    /// shape that crosses the plugin ABI). The bridge is registered by
     /// host code via `set_cpu_readback_bridge` and read by host adapter
     /// machinery; cdylib code doesn't need to read it. Calling from a
     /// cdylib panics at the explicit guard below.
@@ -5337,7 +5337,7 @@ impl GpuContextFullAccess {
             panic!(
                 "GpuContextFullAccess::cpu_readback_bridge(): return type \
                  `Option<Arc<dyn CpuReadbackBridge>>` is a trait object whose \
-                 vtable layout is rustc-private and cannot cross the FFI \
+                 vtable layout is rustc-private and cannot cross the plugin ABI \
                  boundary; engine-only — cdylib code must not call it."
             );
         }
@@ -5355,7 +5355,7 @@ impl GpuContextFullAccess {
             panic!(
                 "GpuContextFullAccess::compute_kernel_bridge(): return type \
                  `Option<Arc<dyn ComputeKernelBridge>>` is a trait object whose \
-                 vtable layout is rustc-private and cannot cross the FFI \
+                 vtable layout is rustc-private and cannot cross the plugin ABI \
                  boundary; engine-only — cdylib code must not call it."
             );
         }
@@ -5373,7 +5373,7 @@ impl GpuContextFullAccess {
             panic!(
                 "GpuContextFullAccess::graphics_kernel_bridge(): return type \
                  `Option<Arc<dyn GraphicsKernelBridge>>` is a trait object \
-                 whose vtable layout is rustc-private and cannot cross the FFI \
+                 whose vtable layout is rustc-private and cannot cross the plugin ABI \
                  boundary; engine-only — cdylib code must not call it."
             );
         }
@@ -5391,7 +5391,7 @@ impl GpuContextFullAccess {
             panic!(
                 "GpuContextFullAccess::ray_tracing_kernel_bridge(): return type \
                  `Option<Arc<dyn RayTracingKernelBridge>>` is a trait object \
-                 whose vtable layout is rustc-private and cannot cross the FFI \
+                 whose vtable layout is rustc-private and cannot cross the plugin ABI \
                  boundary; engine-only — cdylib code must not call it."
             );
         }
@@ -5857,7 +5857,7 @@ mod tests {
     ///
     /// A kernel constructed inside `escalate(|full| ...)` and returned
     /// out of the closure must Drop cleanly after the scope ends. The
-    /// kernel β-shape's Drop dispatches through its own per-vtable
+    /// kernel PluginAbiObject's Drop dispatches through its own per-vtable
     /// `drop_compute_kernel` callback — independent of any active
     /// escalate scope (the scope token only validates FullAccess CALL
     /// dispatch; drop is a refcount decrement on an opaque handle).

--- a/libs/streamlib-engine/src/core/context/runtime_context.rs
+++ b/libs/streamlib-engine/src/core/context/runtime_context.rs
@@ -597,7 +597,7 @@ impl RuntimeContext {
 
 // Shim shape: `(handle, vtable)`-driven dispatch. The shim stores the
 // raw host pointer + the [`RuntimeContextVTable`] reference, and every
-// accessor calls through the vtable. This matches the cross-DSO ABI
+// accessor calls through the vtable. This matches the plugin ABI
 // the cdylib uses.
 //
 // Host-internal compiler ops that still need direct access to the
@@ -718,7 +718,7 @@ impl<'a> RuntimeContextFullAccess<'a> {
         unsafe { ((*self.vtable).should_process)(self.handle) }
     }
 
-    /// Host-owned audio clock as a typed FFI shim. Backed by the
+    /// Host-owned audio clock as a typed plugin ABI shim. Backed by the
     /// per-RuntimeContext audio-clock handle returned from
     /// [`RuntimeContextVTable::audio_clock_handle`] paired with the
     /// host's [`AudioClockVTable`](streamlib_plugin_abi::AudioClockVTable)
@@ -736,7 +736,7 @@ impl<'a> RuntimeContextFullAccess<'a> {
         AudioClockShim::from_ffi(handle, acv)
     }
 
-    /// Host-owned runtime operations as a typed FFI shim. Implements
+    /// Host-owned runtime operations as a typed plugin ABI shim. Implements
     /// [`RuntimeOperations`] so existing call sites
     /// (`ctx.runtime().add_processor_async(...).await`) keep working
     /// transparently against a plugin-owned tokio runtime.
@@ -762,7 +762,7 @@ impl<'a> RuntimeContextFullAccess<'a> {
     ///
     /// The cdylib-shaped sibling's
     /// [`GpuContextFullAccess`] methods dispatch through the
-    /// FullAccess vtable (cross-DSO via fn pointers in cdylib
+    /// FullAccess vtable (plugin ABI via fn pointers in cdylib
     /// address space, direct via host callbacks in host address
     /// space) instead of the host-only direct-deref `host_inner`
     /// path the Boxed shape uses. That makes `ctx.gpu_full_access()`
@@ -925,7 +925,7 @@ impl<'a> RuntimeContextLimitedAccess<'a> {
         unsafe { ((*self.vtable).should_process)(self.handle) }
     }
 
-    /// Host-owned audio clock as a typed FFI shim. See
+    /// Host-owned audio clock as a typed plugin ABI shim. See
     /// [`RuntimeContextFullAccess::audio_clock`].
     pub fn audio_clock(&self) -> AudioClockShim<'a> {
         let handle = unsafe { ((*self.vtable).audio_clock_handle)(self.handle) };
@@ -933,7 +933,7 @@ impl<'a> RuntimeContextLimitedAccess<'a> {
         AudioClockShim::from_ffi(handle, acv)
     }
 
-    /// Host-owned runtime operations as a typed FFI shim. See
+    /// Host-owned runtime operations as a typed plugin ABI shim. See
     /// [`RuntimeContextFullAccess::runtime`].
     pub fn runtime(&self) -> Arc<dyn RuntimeOperations> {
         let borrowed_handle = unsafe { ((*self.vtable).runtime_ops_handle)(self.handle) };

--- a/libs/streamlib-engine/src/core/context/surface_store.rs
+++ b/libs/streamlib-engine/src/core/context/surface_store.rs
@@ -117,11 +117,11 @@ impl CheckedInSurfaces {
 /// Caches resolved surfaces locally to minimize XPC round-trips.
 /// Host-only rich data backing a [`SurfaceStore`]. Cdylib code never
 /// sees this type; it reaches the public [`SurfaceStore`] surface
-/// through the `(handle, vtable)` β-shape.
+/// through the `(handle, vtable)` PluginAbiObject.
 ///
 /// All cross-platform and Linux-specific surface-share IPC methods
 /// (`connect`, `check_in`, `check_out`, `register_texture`, etc.)
-/// live on this type. The β-shape `SurfaceStore` dispatches each
+/// live on this type. The PluginAbiObject `SurfaceStore` dispatches each
 /// method through the [`streamlib_plugin_abi::SurfaceStoreVTable`].
 pub(crate) struct SurfaceStoreInner {
     /// XPC connection to the surface-share service (macOS only).
@@ -148,7 +148,7 @@ pub(crate) struct SurfaceStoreInner {
 impl SurfaceStoreInner {
     /// Create a new surface store (not yet connected). Returns an
     /// `Arc<SurfaceStoreInner>` so the engine can store it directly
-    /// and hand β-shape [`SurfaceStore`] wrappers to consumers on
+    /// and hand PluginAbiObject [`SurfaceStore`] wrappers to consumers on
     /// demand.
     pub fn new(service_name: String, runtime_id: String) -> Arc<Self> {
         Arc::new(SurfaceStoreInner {
@@ -1866,7 +1866,7 @@ impl std::fmt::Debug for SurfaceStoreInner {
 }
 
 // =============================================================================
-// β-shape `SurfaceStore`
+// PluginAbiObject `SurfaceStore`
 // =============================================================================
 //
 // Cdylib-facing layout-stable wrapper around
@@ -1888,7 +1888,7 @@ use streamlib_plugin_abi::SurfaceStoreVTable;
 pub struct SurfaceStore {
     /// Opaque handle to the host's `Arc<SurfaceStoreInner>`.
     pub(crate) handle: *const ss_c_void,
-    /// Vtable for cross-DSO Clone/Drop and method dispatch.
+    /// Vtable for plugin ABI Clone/Drop and method dispatch.
     pub(crate) vtable: *const SurfaceStoreVTable,
 }
 
@@ -1900,9 +1900,9 @@ unsafe impl Send for SurfaceStore {}
 unsafe impl Sync for SurfaceStore {}
 
 impl SurfaceStore {
-    /// Create a new SurfaceStore β-shape (not yet connected). The
+    /// Create a new SurfaceStore PluginAbiObject (not yet connected). The
     /// underlying [`SurfaceStoreInner`] is allocated as an
-    /// `Arc<SurfaceStoreInner>` and wrapped in the β-shape with a
+    /// `Arc<SurfaceStoreInner>` and wrapped in the PluginAbiObject with a
     /// freshly-resolved host-mode vtable. Engine and integration
     /// tests use this; the runtime's `start()` path uses the
     /// `from_arc_into_raw` helper directly so it can share the Arc
@@ -1913,14 +1913,14 @@ impl SurfaceStore {
 
     /// Internal helper: leak an initial Arc strong count via
     /// `Arc::into_raw`, resolve the host-mode vtable, and assemble
-    /// the cross-DSO shape.
+    /// the plugin ABI shape.
     pub(crate) fn from_arc_into_raw(arc: Arc<SurfaceStoreInner>) -> Self {
         let handle = Arc::into_raw(arc) as *const ss_c_void;
         let vtable = crate::core::plugin::host_services::host_surface_store_vtable();
         Self { handle, vtable }
     }
 
-    /// Build a null-handle β-shape ("None" sentinel) for the
+    /// Build a null-handle PluginAbiObject ("None" sentinel) for the
     /// `GpuContext::surface_store()` API's `Option<SurfaceStore>`
     /// shape. The cdylib's `SurfaceStore::is_none()` returns `true`
     /// for such a value and `Drop` short-circuits on null handle.
@@ -1931,7 +1931,7 @@ impl SurfaceStore {
         }
     }
 
-    /// Whether this is a null-handle β-shape (the "None" branch of
+    /// Whether this is a null-handle PluginAbiObject (the "None" branch of
     /// the `Option<SurfaceStore>` return shape).
     pub(crate) fn is_none(&self) -> bool {
         self.handle.is_null() || self.vtable.is_null()

--- a/libs/streamlib-engine/src/core/context/texture_pool.rs
+++ b/libs/streamlib-engine/src/core/context/texture_pool.rs
@@ -222,7 +222,7 @@ impl TexturePoolInner {
 /// `Arc<TexturePoolInner>` reference plus the `PoolSlotId` so Drop
 /// can release the slot exactly once. Cdylib code never sees this
 /// type; it reaches `PooledTextureHandle` through the
-/// `(handle, vtable, Texture, POD)` β-shape.
+/// `(handle, vtable, Texture, POD)` PluginAbiObject.
 pub(crate) struct PooledTextureHandleInner {
     pub(crate) pool_inner: Arc<TexturePoolInner>,
     pub(crate) slot_id: PoolSlotId,
@@ -249,9 +249,9 @@ impl Drop for PooledTextureHandleInner {
 pub struct PooledTextureHandle {
     /// Opaque host handle (`Box::into_raw(Box<PooledTextureHandleInner>)`).
     pub(crate) handle: *const c_void,
-    /// Vtable for cross-DSO Drop dispatch.
+    /// Vtable for plugin ABI Drop dispatch.
     pub(crate) vtable: *const GpuContextLimitedAccessVTable,
-    /// The pooled texture. Already β-shape (`#[repr(C)]`, 32 bytes);
+    /// The pooled texture. Already PluginAbiObject (`#[repr(C)]`, 32 bytes);
     /// embedding by value keeps the wire ABI flat without an
     /// indirection through another `Arc`.
     pub(crate) texture: Texture,
@@ -278,7 +278,7 @@ impl PooledTextureHandle {
     /// Constructor for non-macOS platforms (Linux/Windows). The
     /// host's pool allocator builds a `PooledTextureHandleInner`,
     /// leaks it via `Box::into_raw`, resolves the host-mode vtable,
-    /// and assembles the cross-DSO shape.
+    /// and assembles the plugin ABI shape.
     ///
     /// On macOS, handles are created via
     /// `texture_pool_macos::allocate_iosurface_slot`.
@@ -610,7 +610,7 @@ impl std::fmt::Debug for TexturePool {
 // Layout regression tests
 // =============================================================================
 //
-// `PooledTextureHandle` crosses the cdylib DSO boundary as a
+// `PooledTextureHandle` crosses the plugin ABI as a
 // `#[repr(C)]` struct. Drift in its byte-level shape would silently
 // corrupt every `acquire_texture` return-path: the cdylib's Drop
 // impl reads `vtable` and `handle` at fixed offsets to call

--- a/libs/streamlib-engine/src/core/context/texture_registration.rs
+++ b/libs/streamlib-engine/src/core/context/texture_registration.rs
@@ -4,7 +4,7 @@
 //! Engine-wide per-surface texture registration record.
 //!
 //! Layout-stable `(handle, vtable)` shape so the type crosses the
-//! cdylib DSO boundary. The handle is
+//! plugin ABI. The handle is
 //! `Arc::into_raw(Arc<TextureRegistrationInner>)`; the vtable's
 //! `clone_texture_registration` / `drop_texture_registration`
 //! callbacks manage the Arc refcount in host-compiled code.
@@ -37,7 +37,7 @@ use streamlib_consumer_rhi::VulkanLayout;
 
 /// Host-only rich data backing a [`TextureRegistration`]. Cdylib code
 /// never sees this type; it reaches the public [`TextureRegistration`]
-/// surface through the `(handle, vtable)` β-shape.
+/// surface through the `(handle, vtable)` PluginAbiObject.
 pub(crate) struct TextureRegistrationInner {
     pub(crate) texture: Texture,
     /// Last-known Vulkan image layout. Producers update after their
@@ -62,13 +62,13 @@ pub(crate) struct TextureRegistrationInner {
 /// through `drop_texture_registration`. Cheap to clone — the same
 /// shape as `Arc::clone` semantically, just with the refcount
 /// bookkeeping running in host-compiled code regardless of caller
-/// DSO.
+/// plugin.
 #[repr(C)]
 pub struct TextureRegistration {
     /// Opaque handle to the host's `Arc<TextureRegistrationInner>`
     /// (produced by `Arc::into_raw`).
     pub(crate) handle: *const c_void,
-    /// Vtable for cross-DSO Clone/Drop and method dispatch.
+    /// Vtable for plugin ABI Clone/Drop and method dispatch.
     pub(crate) vtable: *const GpuContextLimitedAccessVTable,
 }
 
@@ -100,7 +100,7 @@ impl TextureRegistration {
 
     /// Internal helper: leak an initial Arc strong count via
     /// `Arc::into_raw`, resolve the host-mode vtable, and assemble
-    /// the cross-DSO shape.
+    /// the plugin ABI shape.
     pub(crate) fn from_arc_into_raw(arc: Arc<TextureRegistrationInner>) -> Self {
         let handle = Arc::into_raw(arc) as *const c_void;
         let vtable = crate::core::plugin::host_services::host_gpu_context_limited_access_vtable();
@@ -114,7 +114,7 @@ impl TextureRegistration {
             panic!(
                 "TextureRegistration::host_inner() reached from cdylib code; this \
                  method must dispatch through the GpuContextLimitedAccessVTable. \
-                 The panic is caught by run_host_extern_c at the FFI boundary."
+                 The panic is caught by run_host_extern_c at the plugin ABI."
             );
         }
         // SAFETY: `self.handle` is `Arc::into_raw(Arc<TextureRegistrationInner>)`.
@@ -138,7 +138,7 @@ impl TextureRegistration {
         }
         // SAFETY: vtable + handle were paired at construction; the
         // callback returns a `*const Texture` pointer (typed as
-        // `*const c_void` at the FFI boundary) into the Arc's heap
+        // `*const c_void` at the plugin ABI) into the Arc's heap
         // allocation. The pointer is alive as long as `self` is —
         // the Arc's strong count keeps the inner alive. `Texture` is
         // a layout-stable `#[repr(C)]` value (locked by the

--- a/libs/streamlib-engine/src/core/context/texture_ring.rs
+++ b/libs/streamlib-engine/src/core/context/texture_ring.rs
@@ -30,15 +30,15 @@ use streamlib_consumer_rhi::VulkanLayout;
 
 /// Maximum on-the-wire `surface_id` length in bytes — fits any UUID
 /// representation (canonical 36-byte form plus generous headroom for
-/// future identifier shapes) without crossing the DSO boundary as a
+/// future identifier shapes) without crossing the plugin ABI as a
 /// heap `String`.
 pub const TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES: usize = 64;
 
 /// A single slot in a [`TextureRing`].
 ///
-/// Layout-stable `#[repr(C)]` β-shape — cdylibs can hold, copy, and
+/// Layout-stable `#[repr(C)]` PluginAbiObject — cdylibs can hold, copy, and
 /// drop slots safely without sharing rustc-version or dep-graph with
-/// the host. The `Texture` is itself a `(handle, vtable, POD)` β-shape
+/// the host. The `Texture` is itself a `(handle, vtable, POD)` PluginAbiObject
 /// (Clone bumps its Arc through the parent limited-access vtable;
 /// Drop balances). The `surface_id` is stored inline as a fixed
 /// 64-byte buffer plus a length — UUIDs are pure ASCII so a single
@@ -51,7 +51,7 @@ pub const TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES: usize = 64;
 /// texture's Arc; the inline bytes have no destructor.
 #[repr(C)]
 pub struct TextureRingSlot {
-    /// Pre-allocated texture handle for this slot. β-shape
+    /// Pre-allocated texture handle for this slot. PluginAbiObject
     /// `(handle, vtable, POD)` triple; Clone/Drop dispatch through
     /// the parent limited-access vtable.
     pub texture: Texture,
@@ -72,7 +72,7 @@ pub struct TextureRingSlot {
     pub(crate) slot_index: u32,
 }
 
-// SAFETY: `Texture` is `Send + Sync` (β-shape over an Arc); the
+// SAFETY: `Texture` is `Send + Sync` (PluginAbiObject over an Arc); the
 // inline POD bytes carry no thread-state. `TextureRingSlot` is Send
 // + Sync because every field is.
 unsafe impl Send for TextureRingSlot {}
@@ -99,7 +99,7 @@ impl TextureRingSlot {
             "TextureRingSlot::new: surface_id length {} exceeds \
              TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES = {} \
              (UUIDs are 36 bytes; a longer id needs an explicit \
-             budget bump in the β-shape, not silent truncation)",
+             budget bump in the PluginAbiObject, not silent truncation)",
             bytes.len(),
             TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES,
         );
@@ -118,7 +118,7 @@ impl TextureRingSlot {
     /// `surface_id_len`. Uses `from_utf8_unchecked` because the
     /// invariant is locked at construction: [`Self::new`] always
     /// passes the bytes through `str::as_bytes()` (which produces
-    /// valid UTF-8 by construction), and the FFI ingestion path
+    /// valid UTF-8 by construction), and the plugin ABI ingestion path
     /// (`acquire_next` / `slot` host wrappers) likewise sources
     /// from a host-side `&str`.
     pub fn surface_id(&self) -> &str {
@@ -145,7 +145,7 @@ impl TextureRingSlot {
 
 impl Clone for TextureRingSlot {
     fn clone(&self) -> Self {
-        // `Texture::clone` runs the texture's β-shape Clone (Arc-
+        // `Texture::clone` runs the texture's PluginAbiObject Clone (Arc-
         // bumped through its parent limited-access vtable);
         // remaining fields are POD bytes.
         Self {
@@ -193,7 +193,7 @@ impl std::fmt::Debug for TextureRingSlot {
 /// [`GpuContext`]'s texture cache.
 /// Host-only rich data backing a [`TextureRing`]. Cdylib code never
 /// sees this type; it reaches the public surface through the
-/// `(handle, vtable)` β-shape.
+/// `(handle, vtable)` PluginAbiObject.
 pub struct TextureRingInner {
     slots: Vec<TextureRingSlot>,
     /// Per-slot pre-allocated upload resources (command pool + command
@@ -328,7 +328,7 @@ impl TextureRingInner {
     /// pre-allocated texture, identified by `(slot_index, surface_id)`
     /// rather than a [`TextureRingSlot`] reference. Used by the cdylib
     /// dispatch path so the slot's POD identity bytes flow across the
-    /// FFI without reconstituting a borrow on the host side.
+    /// plugin ABI without reconstituting a borrow on the host side.
     #[cfg(target_os = "linux")]
     pub(crate) fn copy_pixel_buffer_to_slot_by_index(
         &self,
@@ -423,18 +423,18 @@ impl Drop for TextureRingInner {
 }
 
 // =============================================================================
-// β-shape implementation
+// PluginAbiObject implementation
 // =============================================================================
 
 /// Pre-allocated ring of textures rotated per-frame on the decode hot
-/// path. Layout-stable `#[repr(C)]` β-shape so cdylibs can hold,
+/// path. Layout-stable `#[repr(C)]` PluginAbiObject so cdylibs can hold,
 /// refcount, drop, and read POD descriptors without sharing
 /// rustc-version or dep-graph with the host.
 ///
 /// The opaque handle points at an `Arc<TextureRingInner>`; lifecycle
 /// (Clone / Drop) dispatches through the host-installed parent
 /// [`GpuContextFullAccessVTable`]'s `clone_texture_ring` /
-/// `drop_texture_ring` callbacks (locked by PR #918's β-shape Phase D
+/// `drop_texture_ring` callbacks (locked by PR #918's PluginAbiObject Phase D
 /// work). Per-method dispatch is reached through the dedicated
 /// [`streamlib_plugin_abi::TextureRingMethodsVTable`] pointed at by
 /// `methods_vtable` — the v2 vtable wires `acquire_next` /
@@ -442,16 +442,16 @@ impl Drop for TextureRingInner {
 /// caller-provided POD out-parameters.
 ///
 /// The four POD getters (`len`, `width`, `height`, `format`) read
-/// directly from cached fields on this struct — no FFI hop. The
+/// directly from cached fields on this struct — no plugin ABI hop. The
 /// values are captured by [`Self::from_arc_into_raw`] at construction
 /// and never mutate over the ring's lifetime.
 #[repr(C)]
 pub struct TextureRing {
     /// Opaque handle to the host's `Arc<TextureRingInner>`.
     pub(crate) handle: *const c_void,
-    /// Parent vtable for cross-DSO Clone/Drop dispatch (#918 Phase D).
+    /// Parent vtable for plugin ABI Clone/Drop dispatch (#918 Phase D).
     pub(crate) vtable: *const GpuContextFullAccessVTable,
-    /// Per-type vtable for cross-DSO method dispatch (#907 Phase E).
+    /// Per-type vtable for plugin ABI method dispatch (#907 Phase E).
     pub(crate) methods_vtable: *const streamlib_plugin_abi::TextureRingMethodsVTable,
     /// Cached slot count. Set at construction; ring depth is fixed.
     pub(crate) cached_len: u32,
@@ -460,7 +460,7 @@ pub struct TextureRing {
     /// Cached pixel height every slot's texture was allocated with.
     pub(crate) cached_height: u32,
     /// Cached pixel format every slot's texture was allocated with.
-    /// Stored as the FFI-stable `u32` discriminant (matches
+    /// Stored as the plugin-ABI-stable `u32` discriminant (matches
     /// `TextureFormat`'s `#[repr(u32)]`).
     pub(crate) cached_format: u32,
 }
@@ -476,7 +476,7 @@ impl TextureRing {
     /// `Arc::into_raw`, resolve the host-mode FullAccess vtable +
     /// per-type methods vtable, snapshot the ring's POD descriptors
     /// (len / width / height / format — fixed across the ring's
-    /// lifetime), and assemble the cross-DSO shape.
+    /// lifetime), and assemble the plugin ABI shape.
     pub(crate) fn from_arc_into_raw(arc: Arc<TextureRingInner>) -> Self {
         let cached_len = arc.len() as u32;
         let cached_width = arc.width();
@@ -532,7 +532,7 @@ impl TextureRing {
     ///
     /// In cdylib mode, dispatches through the per-type methods
     /// vtable; the slot's `(slot_index, surface_id)` POD identity is
-    /// what crosses the FFI, not a slot borrow.
+    /// what crosses the plugin ABI, not a slot borrow.
     #[cfg(target_os = "linux")]
     pub fn copy_pixel_buffer_to_slot(
         &self,
@@ -553,31 +553,31 @@ impl TextureRing {
             .copy_pixel_buffer_to_slot(slot, pixel_buffer, width, height)
     }
 
-    /// Number of slots in the ring. Cached POD — no FFI hop.
+    /// Number of slots in the ring. Cached POD — no plugin ABI hop.
     pub fn len(&self) -> usize {
         self.cached_len as usize
     }
 
     /// Ring is always non-empty in practice (construction rejects 0).
-    /// Cached POD — no FFI hop.
+    /// Cached POD — no plugin ABI hop.
     pub fn is_empty(&self) -> bool {
         self.cached_len == 0
     }
 
-    /// Width of every slot's texture, in pixels. Cached POD — no FFI
+    /// Width of every slot's texture, in pixels. Cached POD — no plugin ABI
     /// hop.
     pub fn width(&self) -> u32 {
         self.cached_width
     }
 
     /// Height of every slot's texture, in pixels. Cached POD — no
-    /// FFI hop.
+    /// plugin ABI hop.
     pub fn height(&self) -> u32 {
         self.cached_height
     }
 
     /// Format every slot's texture was allocated with. Cached POD —
-    /// no FFI hop. Decoded from the FFI-stable `u32` discriminant via
+    /// no plugin ABI hop. Decoded from the plugin-ABI-stable `u32` discriminant via
     /// `match` (matches `TextureFormat`'s `#[repr(u32)]` layout).
     pub fn format(&self) -> TextureFormat {
         match self.cached_format {
@@ -768,7 +768,7 @@ fn slot_from_out_params(
     surface_id_len: u32,
     slot_index: u32,
 ) -> TextureRingSlot {
-    // Build the Texture β-shape directly from the host-returned
+    // Build the Texture PluginAbiObject directly from the host-returned
     // handle. Use the limited-access vtable installed in cdylib mode
     // (or the host's static for in-process tests of this helper) —
     // the host wrapper paired the Arc bump with that same vtable's
@@ -837,7 +837,7 @@ mod layout_tests {
 
     #[test]
     fn texture_ring_layout() {
-        // β-shape struct as of #907 PR 1/5:
+        // PluginAbiObject struct as of #907 PR 1/5:
         //   handle              @ 0  (8 bytes, *const c_void)
         //   vtable              @ 8  (8 bytes, *const GpuContextFullAccessVTable)
         //   methods_vtable      @ 16 (8 bytes, *const TextureRingMethodsVTable)
@@ -859,8 +859,8 @@ mod layout_tests {
 
     #[test]
     fn texture_ring_slot_layout() {
-        // β-shape struct (issue #947):
-        //   texture            @ 0   (32 bytes, Texture β-shape)
+        // PluginAbiObject struct (issue #947):
+        //   texture            @ 0   (32 bytes, Texture PluginAbiObject)
         //   surface_id_bytes   @ 32  (64 bytes, [u8; 64])
         //   surface_id_len     @ 96  (4 bytes, u32)
         //   slot_index         @ 100 (4 bytes, u32)
@@ -876,7 +876,7 @@ mod layout_tests {
     #[test]
     fn texture_ring_slot_surface_id_max_bytes_constant() {
         // The constant must match the in-line buffer length on the
-        // β-shape and the FFI vtable's `out_surface_id_bytes` slot.
+        // PluginAbiObject and the plugin vtable's `out_surface_id_bytes` slot.
         assert_eq!(TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES, 64);
     }
 

--- a/libs/streamlib-engine/src/core/descriptors.rs
+++ b/libs/streamlib-engine/src/core/descriptors.rs
@@ -10,7 +10,7 @@ pub use streamlib_processor_schema::{
 };
 
 /// Lossless wire-format mirror of [`PortSchemaSpec`] used at the cdylib
-/// FFI msgpack boundary.
+/// plugin ABI msgpack boundary.
 ///
 /// `PortSchemaSpec`'s default serde impl
 /// (`streamlib_processor_schema::PortSchemaSpec`) is intentionally
@@ -23,7 +23,7 @@ pub use streamlib_processor_schema::{
 /// `Named → Specific` against the enclosing manifest's `schemas:` map.
 ///
 /// It does NOT hold when [`ProcessorDescriptor`] crosses the cdylib
-/// dlopen FFI seam via `rmp_serde`. The proc-macro pre-resolves
+/// dlopen plugin ABI seam via `rmp_serde`. The proc-macro pre-resolves
 /// `Named → Specific` at the cdylib's compile time and embeds the
 /// fully-qualified [`SchemaIdent`] in the cdylib's `descriptor()`
 /// constant. When `host_processor_register` deserializes the msgpack
@@ -133,7 +133,7 @@ pub struct PortDescriptor {
     /// Structured schema spec — `Any` (wildcard for MoQ-style ports) or a
     /// fully-qualified [`SchemaIdent`].
     ///
-    /// Serialized via [`port_schema_spec_wire`] so the cdylib FFI msgpack
+    /// Serialized via [`port_schema_spec_wire`] so the cdylib plugin ABI msgpack
     /// boundary preserves `Specific(SchemaIdent)` round-trip. The default
     /// `PortSchemaSpec` serde impl is YAML-shaped (lossy on `Specific`)
     /// and stays in place for `streamlib.yaml` manifest parsing where
@@ -355,10 +355,10 @@ mod tests {
     use super::*;
 
     /// `PortDescriptor::schema` must round-trip every `PortSchemaSpec`
-    /// variant losslessly through `rmp_serde` — that's the cdylib FFI
+    /// variant losslessly through `rmp_serde` — that's the cdylib plugin ABI
     /// wire format. A regression here would silently degrade
-    /// `Specific(SchemaIdent)` to `Named(bare_type)` at the host /
-    /// plugin boundary; the WIRE phase would then panic at
+    /// `Specific(SchemaIdent)` to `Named(bare_type)` at the
+    /// plugin ABI; the WIRE phase would then panic at
     /// `open_iceoryx2_service_op::schema_ident_wire_for_producer`.
     /// Mentally revert the `#[serde(with = "port_schema_spec_wire")]`
     /// attribute on `PortDescriptor::schema` and this test fails on
@@ -389,7 +389,7 @@ mod tests {
             }
             other => panic!(
                 "Specific(SchemaIdent) downgraded to {:?} on msgpack round-trip — the \
-                 cdylib FFI is silently destroying schema identity",
+                 cdylib plugin ABI is silently destroying schema identity",
                 other
             ),
         }
@@ -397,7 +397,7 @@ mod tests {
 
     /// `Named` variant must also round-trip — exercised by the YAML
     /// parser path that produces unresolved `Named` for in-process
-    /// `ProjectConfig::load` consumers; if the cdylib FFI hop ever
+    /// `ProjectConfig::load` consumers; if the cdylib plugin ABI hop ever
     /// hands a `Named` across, it stays `Named`.
     #[test]
     fn port_descriptor_schema_msgpack_round_trip_preserves_named() {
@@ -432,9 +432,9 @@ mod tests {
     }
 
     /// End-to-end through `ProcessorDescriptor` — the actual envelope
-    /// that crosses the cdylib FFI boundary at
+    /// that crosses the cdylib plugin ABI at
     /// `register_via_callback` / `host_processor_register`. Locks the
-    /// invariant at the type the FFI actually serializes, not just
+    /// invariant at the type the plugin ABI actually serializes, not just
     /// the inner port descriptor.
     #[test]
     fn processor_descriptor_msgpack_round_trip_preserves_port_specific() {
@@ -464,7 +464,7 @@ mod tests {
                 assert_eq!(round_tripped, &ident);
             }
             other => panic!(
-                "ProcessorDescriptor.outputs[0].schema downgraded to {:?} on FFI \
+                "ProcessorDescriptor.outputs[0].schema downgraded to {:?} on plugin ABI \
                  msgpack round-trip — cdylib registration silently destroying identity",
                 other
             ),

--- a/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
+++ b/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
@@ -31,14 +31,14 @@ pub type SchemaRegistryStorage = RwLock<HashMap<String, Arc<str>>>;
 
 /// Process-wide schema registry.
 ///
-/// **Per-DSO instance.** Same shape as [`crate::core::pubsub::PUBSUB`]
+/// **Per-loaded-artifact instance.** Same shape as [`crate::core::pubsub::PUBSUB`]
 /// — each linked copy of streamlib-engine has its own
-/// `LazyLock<SchemaRegistryStorage>`. Cross-DSO bridging happens
-/// inside the public functions below: when this DSO is a plugin
+/// `LazyLock<SchemaRegistryStorage>`. Plugin ABI bridging happens
+/// inside the public functions below: when this artifact is a plugin
 /// cdylib whose `install_host_services` has run,
 /// [`register_schema`] and [`get_embedded_schema_definition`] route
 /// through the host's `schema_register` / `schema_lookup` fn
-/// pointers; otherwise they read/write the local DSO's instance
+/// pointers; otherwise they read/write the local artifact's instance
 /// directly.
 static SCHEMA_REGISTRY: LazyLock<SchemaRegistryStorage> =
     LazyLock::new(|| RwLock::new(HashMap::new()));

--- a/libs/streamlib-engine/src/core/logging/iceoryx2_log_bridge.rs
+++ b/libs/streamlib-engine/src/core/logging/iceoryx2_log_bridge.rs
@@ -15,15 +15,15 @@
 //! - Plugin cdylib-side: the cdylib's `STREAMLIB_PLUGIN` register
 //!   callback receives the host's `&'static dyn Log` pointer via
 //!   [`crate::core::plugin::HostServices::iceoryx2_logger`] and
-//!   installs it in the cdylib's `iceoryx2-log` static. Each DSO has
-//!   its own `iceoryx2-log` static; both end up pointing at the same
-//!   bridge value living in host memory.
+//!   installs it in the cdylib's `iceoryx2-log` static. The host and
+//!   each plugin have their own `iceoryx2-log` static; both end up
+//!   pointing at the same bridge value living in host memory.
 //!
-//! Cross-DSO safety: both DSOs link the same `iceoryx2-log-types`
-//! version (workspace pin), so the `&'static dyn Log` fat pointer's
-//! vtable is layout-compatible on both sides. Logging through the
-//! pointer dispatches through the host's vtable, which calls back
-//! into the host's tracing pipeline.
+//! Plugin ABI safety: the host and the plugin link the same
+//! `iceoryx2-log-types` version (workspace pin), so the
+//! `&'static dyn Log` trait object's vtable is layout-compatible
+//! on both sides. Logging through the pointer dispatches through the
+//! host's vtable, which calls back into the host's tracing pipeline.
 
 use iceoryx2_log::Log;
 use iceoryx2_log::LogLevel;
@@ -66,26 +66,26 @@ impl Log for IceoryxLogBridge {
 }
 
 /// Process-wide bridge value. Lives in `.rodata` (zero-sized) per
-/// DSO; the host's copy is the one shared with plugin cdylibs via
+/// loaded artifact; the host's copy is the one shared with plugin cdylibs via
 /// [`crate::core::plugin::HostServices::iceoryx2_logger`]. Both
 /// host's and cdylib's copies impl `Log` against the same workspace-
 /// pinned `iceoryx2-log-types::Log` vtable.
 pub static HOST_BRIDGE: IceoryxLogBridge = IceoryxLogBridge;
 
-/// Install [`HOST_BRIDGE`] as this DSO's iceoryx2 process-wide
+/// Install [`HOST_BRIDGE`] as this artifact's iceoryx2 process-wide
 /// logger. Idempotent — `iceoryx2_log::set_logger` is `Once`-guarded
 /// and returns false on subsequent calls, which we treat as success.
 pub fn install_iceoryx2_log_bridge_for_self() {
     let _ = iceoryx2_log::set_logger(&HOST_BRIDGE);
 }
 
-/// Install a foreign `&'static dyn Log` into this DSO's iceoryx2
+/// Install a foreign `&'static dyn Log` into this plugin's iceoryx2
 /// process-wide logger. Used by plugin cdylibs receiving the host's
 /// bridge pointer through `HostServices`.
 ///
 /// # Safety
 ///
-/// `logger` must remain valid for the lifetime of this DSO. The
+/// `logger` must remain valid for the lifetime of this plugin. The
 /// host's [`HOST_BRIDGE`] is `'static` by construction, so passing
 /// `&HOST_BRIDGE` from the host satisfies this.
 pub unsafe fn install_foreign_iceoryx2_logger(logger: &'static dyn Log) {

--- a/libs/streamlib-engine/src/core/plugin/forwarding_subscriber.rs
+++ b/libs/streamlib-engine/src/core/plugin/forwarding_subscriber.rs
@@ -5,8 +5,8 @@
 //! the host via [`HostCallbacks::tracing_emit`].
 //!
 //! Loosely mirrors the `tracing-ext-ffi-subscriber` pattern: rather
-//! than passing the host's `Dispatch` across the FFI (which doesn't
-//! reach the host's subscriber chain cross-DSO — empirically
+//! than passing the host's `Dispatch` across the plugin ABI (which doesn't
+//! reach the host's subscriber chain across the plugin ABI — empirically
 //! verified during #877's pickup), the cdylib installs a thin
 //! `Subscriber` impl whose `event` method serializes the event's
 //! target / level / message / fields into primitive payloads and
@@ -32,7 +32,7 @@ use super::host_services::{
     host_callbacks, host_interest_to_tracing, tracing_level_to_host,
 };
 
-/// Forwarding subscriber installed in cdylib-linked DSOs at
+/// Forwarding subscriber installed in cdylib-linked plugins at
 /// `install_host_services` time.
 pub struct ForwardingSubscriber {
     /// Monotonic span-id source. Spans aren't bridged today; the id
@@ -176,7 +176,7 @@ fn strip_debug_quotes(s: String) -> String {
     }
 }
 
-/// Install the forwarding subscriber as this DSO's global tracing
+/// Install the forwarding subscriber as this plugin's global tracing
 /// dispatcher. Called by `install_host_services` after the callback
 /// table is cached. The cdylib's `set_global_default` succeeds on
 /// first call; subsequent calls are silent no-ops.

--- a/libs/streamlib-engine/src/core/plugin/host_services/acceleration_structure.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/acceleration_structure.rs
@@ -6,7 +6,7 @@
 //!
 //! The per-type vtable currently carries one method slot (`label`).
 //! POD getters (`device_address`, `storage_size`, `kind`) are
-//! served from cached fields populated at β-shape construction
+//! served from cached fields populated at PluginAbiObject construction
 //! time and never round-trip through the vtable.
 
 use std::ffi::c_void;
@@ -23,7 +23,7 @@ use super::shared::wire::{slice_from_raw, write_err};
 // because:
 //   * POD getters (`device_address`, `storage_size`, `kind`) are
 //     populated at mint time via the v8 build_triangles_blas /
-//     build_tlas out-params; the β-shape's cached fields are always
+//     build_tlas out-params; the PluginAbiObject's cached fields are always
 //     real values, no vtable dispatch needed.
 //   * `vk_handle` stays host-only (vulkanalia handle layout couples
 //     to vulkanalia minor version; no in-tree cdylib consumer reads
@@ -137,7 +137,7 @@ pub static HOST_VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE:
 /// Accessor for the host's static
 /// `VulkanAccelerationStructureMethodsVTable` — used by
 /// `VulkanAccelerationStructure::from_arc_into_raw` to populate the
-/// β-shape's `methods_vtable` field.
+/// PluginAbiObject's `methods_vtable` field.
 pub fn host_vulkan_acceleration_structure_methods_vtable(
 ) -> *const streamlib_plugin_abi::VulkanAccelerationStructureMethodsVTable {
     &HOST_VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE

--- a/libs/streamlib-engine/src/core/plugin/host_services/color_converter.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/color_converter.rs
@@ -9,7 +9,7 @@
 //! passes, reconstructs the buffer + texture borrows via the same
 //! `make_*_borrow` ManuallyDrop pattern the compute / graphics
 //! kernel wrappers use, runs the inner method, and converts the
-//! `Result<Arc<VulkanComputeKernel>>` into the FFI's `i32 + out
+//! `Result<Arc<VulkanComputeKernel>>` into the plugin ABI's `i32 + out
 //! param + err_buf` shape. All bodies wrapped in
 //! `run_host_extern_c` so a panic in the inner method becomes a
 //! non-zero return.
@@ -32,7 +32,7 @@ use super::shared::wire::write_err;
 // reconstructs the buffer + texture borrows via the same
 // `make_*_borrow` ManuallyDrop pattern the compute / graphics kernel
 // wrappers use, runs the inner method, and converts the
-// `Result<Arc<VulkanComputeKernel>>` into the FFI's `i32 + out
+// `Result<Arc<VulkanComputeKernel>>` into the plugin ABI's `i32 + out
 // param + err_buf` shape. All bodies are wrapped in
 // `run_host_extern_c` so a panic in the inner method becomes a
 // non-zero return.
@@ -289,14 +289,14 @@ unsafe extern "C" fn host_color_converter_prepare_buffer_to_image_storage(
             ) {
                 Ok(arc_kernel) => {
                     // `arc_kernel.handle` is the inner Arc-into-raw'd
-                    // pointer baked into the β-shape at construction.
+                    // pointer baked into the PluginAbiObject at construction.
                     // The cdylib needs its own strong count on the
-                    // inner Arc so its β-shape can outlive our return
+                    // inner Arc so its PluginAbiObject can outlive our return
                     // (the converter's kernel cache + the inner Arc
                     // chain it sits behind keep their own strong
                     // counts). Bump the inner refcount by 1; the
                     // returned `Arc<VulkanComputeKernel>` drops
-                    // naturally at end-of-block — its β-shape's Drop
+                    // naturally at end-of-block — its PluginAbiObject's Drop
                     // decrements the inner by 1, but only if this Arc
                     // was the last strong ref, which it isn't because
                     // the converter cache still holds one. Net effect:
@@ -960,7 +960,7 @@ pub static HOST_RHI_COLOR_CONVERTER_METHODS_VTABLE:
 
 /// Accessor for the host's static `RhiColorConverterMethodsVTable` —
 /// used by `RhiColorConverter::from_arc_into_raw` to populate the
-/// β-shape's `methods_vtable` field.
+/// PluginAbiObject's `methods_vtable` field.
 pub fn host_rhi_color_converter_methods_vtable(
 ) -> *const streamlib_plugin_abi::RhiColorConverterMethodsVTable {
     &HOST_RHI_COLOR_CONVERTER_METHODS_VTABLE
@@ -1188,7 +1188,7 @@ mod rhi_color_converter_methods_vtable_tier1_wire_format_tests {
         let mut out_size: u32 = 0;
         // Use a non-null fake converter handle so we reach the
         // out-ptr null check. Casting a stack reference to *const
-        // is safe here because the FFI wrapper only reaches handle_as_*
+        // is safe here because the plugin ABI wrapper only reaches handle_as_*
         // (a transmute) if other null-checks pass — the out_kernel
         // check runs after the converter null-check but before the
         // handle deref.

--- a/libs/streamlib-engine/src/core/plugin/host_services/command_recorder.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/command_recorder.rs
@@ -10,7 +10,7 @@
 //! same `make_*_borrow` ManuallyDrop pattern the compute / graphics
 //! kernel wrappers use, decodes the typed integer enum payloads
 //! (`VulkanLayout` / `VulkanStage` / `VulkanAccess`), runs the inner
-//! method, and converts the `Result<()>` into the FFI's `i32 +
+//! method, and converts the `Result<()>` into the plugin ABI's `i32 +
 //! err_buf` shape. All bodies wrapped in `run_host_extern_c` so a
 //! panic in the inner method becomes a non-zero return.
 
@@ -35,13 +35,13 @@ use super::shared::wire::write_err;
 // same `make_*_borrow` ManuallyDrop pattern the compute / graphics
 // kernel wrappers use, decodes the typed integer enum payloads
 // (`VulkanLayout` / `VulkanStage` / `VulkanAccess`), runs the inner
-// method, and converts the `Result<()>` into the FFI's `i32 +
+// method, and converts the `Result<()>` into the plugin ABI's `i32 +
 // err_buf` shape. All bodies are wrapped in `run_host_extern_c` so a
 // panic in the inner method becomes a non-zero return.
 // =============================================================================
 
 /// SAFETY: caller must hand a `handle` that came from
-/// `Box::into_raw(Box<RhiCommandRecorderInner>)` (the β-shape's
+/// `Box::into_raw(Box<RhiCommandRecorderInner>)` (the PluginAbiObject's
 /// `handle` field). The host borrows mutably for the call's duration;
 /// the cdylib retains ownership and the next `Drop` runs
 /// `Box::from_raw + drop` via the parent vtable's
@@ -58,7 +58,7 @@ unsafe fn handle_as_command_recorder_mut(
     })
 }
 
-/// Reconstruct a stack-allocated `VulkanComputeKernel` β-shape
+/// Reconstruct a stack-allocated `VulkanComputeKernel` PluginAbiObject
 /// borrow from an `Arc::into_raw(Arc<VulkanComputeKernelInner>)`
 /// handle. Same ManuallyDrop contract as `make_storage_buffer_borrow`
 /// / `make_texture_borrow` — the borrow's Drop must NOT run, or it
@@ -728,7 +728,7 @@ unsafe extern "C" fn host_command_recorder_submit_signaling_timeline(
             // the cdylib's
             // `RhiCommandRecorder::dispatch_submit_signaling_timeline_via_vtable`
             // (which gets it via `self as *const Self` on the
-            // β-shape's outer `HostVulkanTimelineSemaphore` borrow,
+            // PluginAbiObject's outer `HostVulkanTimelineSemaphore` borrow,
             // same convention as the v13
             // `wait_timeline_semaphore` slot). The borrow lasts
             // only for the duration of this call.
@@ -1447,11 +1447,11 @@ pub static HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE:
 
 /// Accessor for the host's static `RhiCommandRecorderMethodsVTable`
 /// — used by `RhiCommandRecorder::from_inner` to populate the
-/// β-shape's `methods_vtable` field.
+/// PluginAbiObject's `methods_vtable` field.
 ///
 /// See [`host_vulkan_compute_kernel_methods_vtable`] for the routing
-/// rationale — cdylib β-shape constructors must store the host's
-/// vtable pointer so dispatches actually cross DSO boundaries.
+/// rationale — cdylib PluginAbiObject constructors must store the host's
+/// vtable pointer so dispatches actually cross the plugin ABI.
 pub fn host_rhi_command_recorder_methods_vtable(
 ) -> *const streamlib_plugin_abi::RhiCommandRecorderMethodsVTable {
     match host_callbacks() {

--- a/libs/streamlib-engine/src/core/plugin/host_services/compute_kernel.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/compute_kernel.rs
@@ -6,8 +6,8 @@
 //!
 //! Each wrapper reconstructs the kernel borrow from the raw `Arc`
 //! handle the cdylib passes (`Arc::into_raw(Arc<VulkanComputeKernelInner>)`
-//! per the β-shape's `from_arc_into_raw`), runs the inner method,
-//! and converts the `Result<()>` into the FFI's `i32 + err_buf`
+//! per the PluginAbiObject's `from_arc_into_raw`), runs the inner method,
+//! and converts the `Result<()>` into the plugin ABI's `i32 + err_buf`
 //! shape. All bodies wrapped in `run_host_extern_c` so a panic in
 //! the inner method becomes a non-zero return.
 
@@ -28,15 +28,15 @@ use super::shared::wire::{slice_from_raw, write_err};
 //
 // Each wrapper reconstructs the kernel borrow from the raw `Arc`
 // handle the cdylib passes (`Arc::into_raw(Arc<VulkanComputeKernelInner>)`
-// per the β-shape's `from_arc_into_raw`), runs the inner method,
-// and converts the `Result<()>` into the FFI's `i32 + err_buf`
+// per the PluginAbiObject's `from_arc_into_raw`), runs the inner method,
+// and converts the `Result<()>` into the plugin ABI's `i32 + err_buf`
 // shape. All bodies are wrapped in `run_host_extern_c` so a panic
 // in the inner method becomes a non-zero return.
 //
 // First slice (this PR): `set_push_constants` + `dispatch`. The
 // buffer/texture-input variants need a small trait redesign (the
 // inner method's `B: VulkanStorageBindable` generic can't cross the
-// FFI as-is — concrete β-shape inputs need a separate accessor on
+// plugin ABI as-is — concrete PluginAbiObject inputs need a separate accessor on
 // the trait) and land in a follow-up sub-issue.
 
 /// SAFETY: caller must hand a `handle` that came from
@@ -635,7 +635,7 @@ unsafe extern "C" fn host_compute_kernel_bindings(
 // Wire shape: `vk::ImageView` is `#[repr(transparent)] pub struct
 // ImageView(u64)` and `vk::CommandBuffer` is `#[repr(transparent)]
 // pub struct CommandBuffer(usize)` (vulkanalia-sys handles.rs). The
-// FFI carries the raw integer as `u64`; the host reconstructs via
+// plugin ABI carries the raw integer as `u64`; the host reconstructs via
 // `Handle::from_raw` before forwarding.
 
 // The four callbacks below dispatch through `*_raw` shim methods on
@@ -910,17 +910,17 @@ pub static HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE:
 
 /// Accessor for the host's static `VulkanComputeKernelMethodsVTable`
 /// — used by `VulkanComputeKernel::from_arc_into_raw` to populate
-/// the β-shape's `methods_vtable` field.
+/// the PluginAbiObject's `methods_vtable` field.
 pub fn host_vulkan_compute_kernel_methods_vtable(
 ) -> *const streamlib_plugin_abi::VulkanComputeKernelMethodsVTable {
     // Same routing as `host_gpu_context_limited_access_vtable`:
-    // cdylib β-shape constructors must store the host's vtable
+    // cdylib PluginAbiObject constructors must store the host's vtable
     // pointer so dispatches actually cross to host code (whose
     // `host_callbacks()` returns `None`). Without this routing, the
-    // β-shape stored the cdylib's local static and dispatched to the
+    // PluginAbiObject stored the cdylib's local static and dispatched to the
     // cdylib's own copy of the wrapper — where `host_callbacks()`
     // returns `Some` and any reach through `Texture::host_inner()` or
-    // sibling β-shape `host_inner()` accessors panics.
+    // sibling PluginAbiObject `host_inner()` accessors panics.
     match host_callbacks() {
         Some(c) if !c.vulkan_compute_kernel_methods_vtable.is_null() => {
             c.vulkan_compute_kernel_methods_vtable

--- a/libs/streamlib-engine/src/core/plugin/host_services/gpu_context/full/kernel_construction.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/gpu_context/full/kernel_construction.rs
@@ -67,11 +67,11 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_cr
             );
             match result {
                 Some(Ok(kernel)) => {
-                    // `kernel` is the β-shape; its `handle` is the
+                    // `kernel` is the PluginAbiObject; its `handle` is the
                     // `Arc::into_raw(Arc<<Type>Inner>)` raw pointer
-                    // already. Forget the β-shape so the strong ref
+                    // already. Forget the PluginAbiObject so the strong ref
                     // transfers to cdylib; the cdylib reconstructs its
-                    // own β-shape from { handle: raw, vtable } and
+                    // own PluginAbiObject from { handle: raw, vtable } and
                     // never sees the `Arc<X>` internal layout.
                     let raw = kernel.handle;
                     std::mem::forget(kernel);
@@ -126,11 +126,11 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_cr
             );
             match result {
                 Some(Ok(kernel)) => {
-                    // β-shape: extract the opaque handle (which is
+                    // PluginAbiObject: extract the opaque handle (which is
                     // already `Arc::into_raw(Arc<<Type>Inner>)`-shaped)
                     // and `mem::forget` the wrapper so the strong ref
                     // transfers to cdylib. The cdylib reconstructs a
-                    // fresh β-shape from { handle, vtable } and never
+                    // fresh PluginAbiObject from { handle, vtable } and never
                     // sees the host's `Arc<X>` allocation header.
                     let raw = kernel.handle;
                     std::mem::forget(kernel);
@@ -185,11 +185,11 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_cr
             );
             match result {
                 Some(Ok(kernel)) => {
-                    // β-shape: extract the opaque handle (which is
+                    // PluginAbiObject: extract the opaque handle (which is
                     // already `Arc::into_raw(Arc<<Type>Inner>)`-shaped)
                     // and `mem::forget` the wrapper so the strong ref
                     // transfers to cdylib. The cdylib reconstructs a
-                    // fresh β-shape from { handle, vtable } and never
+                    // fresh PluginAbiObject from { handle, vtable } and never
                     // sees the host's `Arc<X>` allocation header.
                     let raw = kernel.handle;
                     std::mem::forget(kernel);
@@ -262,7 +262,7 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_cr
             );
             match result {
                 Some(Ok(ring)) => {
-                    // `ring` is the β-shape; its handle is
+                    // `ring` is the PluginAbiObject; its handle is
                     // `Arc::into_raw(Arc<TextureRingInner>)`-shaped.
                     let raw = ring.handle;
                     std::mem::forget(ring);

--- a/libs/streamlib-engine/src/core/plugin/host_services/gpu_context/full/kernel_lifecycle.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/gpu_context/full/kernel_lifecycle.rs
@@ -3,13 +3,13 @@
 
 //! `GpuContextFullAccessVTable` kernel Arc-handle lifecycle (Linux-only).
 //!
-//! `clone_*` / `drop_*` pairs for each kernel β-shape the cdylib
+//! `clone_*` / `drop_*` pairs for each kernel PluginAbiObject the cdylib
 //! carries: compute kernel, graphics kernel, ray-tracing kernel,
 //! texture ring, color converter (v4 #917), acceleration structure
 //! (v4 #917), command recorder (v5 #984). Each pair routes
 //! `Arc::increment_strong_count` / `decrement_strong_count` through
 //! host-compiled code so the cdylib never has to know the inner
-//! β-shape's layout.
+//! PluginAbiObject's layout.
 //!
 //! On non-Linux hosts the kernel types don't exist; each callback ships a
 //! `#[cfg(not(target_os = "linux"))]` defensive-no-op stub so the parent
@@ -171,10 +171,10 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_dr
     )
 }
 
-// β-shape v4 (#917) lifecycle callbacks. The handle is
+// PluginAbiObject v4 (#917) lifecycle callbacks. The handle is
 // `Arc::into_raw(Arc<<Type>Inner>)`-shaped on the host side; cdylib
 // code never sees the Inner layout, only the opaque handle paired
-// with its β-shape vtable. Increment/decrement runs in host-compiled
+// with its PluginAbiObject vtable. Increment/decrement runs in host-compiled
 // code where the Inner layout is known statically.
 
 #[cfg(target_os = "linux")]

--- a/libs/streamlib-engine/src/core/plugin/host_services/gpu_context/full/methods.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/gpu_context/full/methods.rs
@@ -298,7 +298,7 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_co
             );
             match result {
                 Some(Ok(converter)) => {
-                    // `converter` is the β-shape; its `handle` is the
+                    // `converter` is the PluginAbiObject; its `handle` is the
                     // `Arc::into_raw(Arc<RhiColorConverterInner>)` pointer.
                     let raw = converter.handle;
                     std::mem::forget(converter);
@@ -381,7 +381,7 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_cr
             );
             match result {
                 Some(Ok(recorder)) => {
-                    // SAFETY: `recorder` is the β-shape — a
+                    // SAFETY: `recorder` is the PluginAbiObject — a
                     // `#[repr(C)] { handle: *const c_void, vtable: *const VTable }`
                     // 16-byte POD. Layout is byte-identical
                     // by `#[repr(C)]` invariant, not by rustc-version
@@ -496,15 +496,15 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_bu
             );
             match result {
                 Some(Ok(blas)) => {
-                    // `blas` is the β-shape — its `handle` is already
+                    // `blas` is the PluginAbiObject — its `handle` is already
                     // `Arc::into_raw(Arc<VulkanAccelerationStructureInner>)`-shaped
                     // and its cached POD fields were populated by
                     // `VulkanAccelerationStructure::from_arc_into_raw`
                     // (host-mode mint path). Write them through the
-                    // out-params so the cdylib's β-shape carries the
+                    // out-params so the cdylib's PluginAbiObject carries the
                     // real values instead of placeholder zeros. Forget
-                    // the β-shape to keep the Arc strong count bumped;
-                    // cdylib reconstructs its own β-shape from the
+                    // the PluginAbiObject to keep the Arc strong count bumped;
+                    // cdylib reconstructs its own PluginAbiObject from the
                     // handle + vtable + cached PODs.
                     let raw = blas.handle;
                     let device_address = blas.cached_device_address;
@@ -629,10 +629,10 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_bu
             match result {
                 Some(Ok(tlas)) => {
                     // Same shape as `host_gpu_full_build_triangles_blas`:
-                    // the β-shape's cached PODs are real (populated by
+                    // the PluginAbiObject's cached PODs are real (populated by
                     // `from_arc_into_raw` host-side); write them
                     // through the out-params so the cdylib's reassembled
-                    // β-shape carries real values.
+                    // PluginAbiObject carries real values.
                     let raw = tlas.handle;
                     let device_address = tlas.cached_device_address;
                     let storage_size = tlas.cached_storage_size;
@@ -1033,7 +1033,7 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_ho
 }
 
 /// Clone the host's `Arc<HostVulkanTexture>` backing a `Texture`
-/// β-shape and return the raw `Arc::into_raw` pointer. Second bridge
+/// PluginAbiObject and return the raw `Arc::into_raw` pointer. Second bridge
 /// of the cdylib-side adapter-construction chain: cdylibs can't
 /// reach `Texture::host_inner()` (panics in cdylib mode), so they
 /// dispatch through this slot to obtain a real
@@ -1052,10 +1052,10 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_ho
             }
             // SAFETY: `texture_handle` is the same opaque
             // `Arc::into_raw(Arc<TextureInner>)` pointer cached on the
-            // `Texture` β-shape's `handle` field (see
+            // `Texture` PluginAbiObject's `handle` field (see
             // `Texture::from_arc_into_raw`). The leaked strong count
             // keeps the `TextureInner` alive at least until the
-            // β-shape's `Drop` runs. We borrow without taking
+            // PluginAbiObject's `Drop` runs. We borrow without taking
             // ownership, clone the inner `Arc<HostVulkanTexture>`, and
             // return its raw pointer with the strong count bumped by 1.
             let inner = unsafe {

--- a/libs/streamlib-engine/src/core/plugin/host_services/gpu_context/full/render_target.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/gpu_context/full/render_target.rs
@@ -8,7 +8,7 @@
 //! through the engine's privileged
 //! `GpuContext::acquire_render_target_dma_buf_image` path: picks a
 //! tiled DRM modifier via the EGL probe and runs the host RHI's
-//! exportable allocator. The resulting `Texture` β-shape is written
+//! exportable allocator. The resulting `Texture` PluginAbiObject is written
 //! into `*out_texture` so the cdylib can take ownership.
 
 use std::ffi::c_void;
@@ -24,7 +24,7 @@ use super::super::super::shared::wire::write_err;
 /// [`crate::core::context::GpuContext::acquire_render_target_dma_buf_image`]
 /// (which picks a tiled DRM modifier via the EGL probe and allocates
 /// through the privileged RHI path), and writes the resulting
-/// `Texture` β-shape into `*out_texture` on success.
+/// `Texture` PluginAbiObject into `*out_texture` on success.
 #[cfg(target_os = "linux")]
 pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_acquire_render_target_dma_buf_image(
     scope_token: *const c_void,

--- a/libs/streamlib-engine/src/core/plugin/host_services/gpu_context/limited/command.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/gpu_context/limited/command.rs
@@ -273,7 +273,7 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_lim_com
             }
             // `gpu.command_queue()` returns `&RhiCommandQueue` (a borrow
             // from GpuContext's stored field). Clone into a fresh owned
-            // β-shape for the caller — the Clone impl runs the host's
+            // PluginAbiObject for the caller — the Clone impl runs the host's
             // `clone_rhi_command_queue` callback (Arc refcount bump).
             let owned = gpu.command_queue().clone();
             // SAFETY: out_queue points at caller-allocated stack storage.
@@ -372,7 +372,7 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_lim_cop
                 );
                 return 1;
             }
-            // SAFETY: pixel_buffer / texture point at β-shape values
+            // SAFETY: pixel_buffer / texture point at PluginAbiObject values
             // whose layouts are locked by per-type regression tests.
             let pb = unsafe { &*(pixel_buffer as *const crate::core::rhi::PixelBuffer) };
             let tex = unsafe { &*(texture as *const crate::core::rhi::Texture) };
@@ -442,7 +442,7 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_lim_bli
                 write_err("blit_copy: null src or dst", err_buf, err_buf_cap, err_len);
                 return 1;
             }
-            // SAFETY: src / dst point at β-shape PixelBuffer values.
+            // SAFETY: src / dst point at PluginAbiObject PixelBuffer values.
             let src_pb = unsafe { &*(src as *const crate::core::rhi::PixelBuffer) };
             let dst_pb = unsafe { &*(dst as *const crate::core::rhi::PixelBuffer) };
             match gpu.blit_copy(src_pb, dst_pb) {

--- a/libs/streamlib-engine/src/core/plugin/host_services/gpu_context/limited/surface_store.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/gpu_context/limited/surface_store.rs
@@ -4,7 +4,7 @@
 //! `GpuContextLimitedAccessVTable` surface_store accessors.
 //!
 //! - `surface_store` returns the host's `SurfaceStore` `Arc::into_raw`
-//!   pointer (the cdylib reconstitutes into a borrow), or a null β-shape
+//!   pointer (the cdylib reconstitutes into a borrow), or a null PluginAbiObject
 //!   when no store is registered.
 //! - `check_out_surface` resolves a surface_id via the store, packaging
 //!   the resulting FD-bearing record for the cdylib's
@@ -27,7 +27,7 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_lim_sur
     run_host_extern_c(
         "host_gpu_lim_surface_store",
         || {
-            // Always-clear: write a null-handle β-shape first so the
+            // Always-clear: write a null-handle PluginAbiObject first so the
             // caller has a defined state even on error paths.
             if !out_store.is_null() {
                 unsafe {
@@ -44,7 +44,7 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_lim_sur
                 return;
             }
             // `gpu.surface_store()` returns `Option<SurfaceStore>` —
-            // a fresh β-shape with Arc refcount already bumped when
+            // a fresh PluginAbiObject with Arc refcount already bumped when
             // Some. We write it into the out-param; the caller (cdylib
             // or host) takes ownership.
             if let Some(store) = gpu.surface_store() {
@@ -55,7 +55,7 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_lim_sur
                     );
                 }
             }
-            // else: out_store already holds the null-handle β-shape.
+            // else: out_store already holds the null-handle PluginAbiObject.
         },
         (),
     )

--- a/libs/streamlib-engine/src/core/plugin/host_services/gpu_context/limited/texture.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/gpu_context/limited/texture.rs
@@ -401,7 +401,7 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_lim_unr
 mod tier1_wire_format_tests {
     //! Tier-1 wire-format test for the Phase F
     //! `texture_native_dma_buf_fd` slot (#908 / #957). The slot is the
-    //! cross-DSO landing for `Texture::native_handle` on Linux and
+    //! plugin ABI landing for `Texture::native_handle` on Linux and
     //! returns the DMA-BUF FD widened to `i64`; sentinel `-1` encodes
     //! the `Option::None` case. A null texture handle must be a clean
     //! `-1` (no panic, no UB) — the wrapper short-circuits before any

--- a/libs/streamlib-engine/src/core/plugin/host_services/gpu_context/mod.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/gpu_context/mod.rs
@@ -174,7 +174,7 @@ pub static HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE: GpuContextFullAccessVTable =
         drop_ray_tracing_kernel: host_gpu_full_drop_ray_tracing_kernel,
         clone_texture_ring: host_gpu_full_clone_texture_ring,
         drop_texture_ring: host_gpu_full_drop_texture_ring,
-        // v4 β-shape lifecycle slots (#917).
+        // v4 PluginAbiObject lifecycle slots (#917).
         clone_color_converter: host_gpu_full_clone_color_converter,
         drop_color_converter: host_gpu_full_drop_color_converter,
         clone_acceleration_structure: host_gpu_full_clone_acceleration_structure,
@@ -204,8 +204,8 @@ pub static HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE: GpuContextFullAccessVTable =
         host_vulkan_texture_arc: host_gpu_full_host_vulkan_texture_arc,
     };
 
-/// Pointer to the [`GpuContextFullAccessVTable`] this DSO should
-/// dispatch through. Same DSO-routing rule as
+/// Pointer to the [`GpuContextFullAccessVTable`] this plugin should
+/// dispatch through. Same plugin-routing rule as
 /// [`host_gpu_context_limited_access_vtable`]: host mode resolves to
 /// the local `&HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE` static, cdylib
 /// mode resolves to the host-installed pointer cached on
@@ -286,8 +286,8 @@ pub static HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE: GpuContextLimitedAccessVTable
             host_gpu_lim_host_video_source_timeline_arc,
     };
 
-/// Pointer to the [`GpuContextLimitedAccessVTable`] this DSO should
-/// dispatch through. Same DSO-routing rule as
+/// Pointer to the [`GpuContextLimitedAccessVTable`] this plugin should
+/// dispatch through. Same plugin-routing rule as
 /// [`host_runtime_context_vtable`].
 pub fn host_gpu_context_limited_access_vtable() -> *const GpuContextLimitedAccessVTable {
     match host_callbacks() {
@@ -314,7 +314,7 @@ mod gpu_lim_tier1_wire_format_tests {
     //!   `command_queue`, `create_command_buffer*`, `blit_copy*`, ...)
     //!   return rc=1 with a callback-prefixed UTF-8 error in `err_buf`
     //!   and leave their out-slot unwritten.
-    //! - `surface_store` writes a null-handle β-shape (the "None"
+    //! - `surface_store` writes a null-handle PluginAbiObject (the "None"
     //!   sentinel) regardless of input.
     //!
     //! `escalate_begin` / `escalate_end` are covered by
@@ -538,12 +538,12 @@ mod gpu_lim_tier1_wire_format_tests {
     }
 
     // ------------------------------------------------------------------
-    // surface_store — always writes a defined β-shape; null gpu_handle
+    // surface_store — always writes a defined PluginAbiObject; null gpu_handle
     // yields the "None" sentinel (null handle + null vtable)
     // ------------------------------------------------------------------
 
     #[test]
-    fn surface_store_writes_null_beta_shape_on_null_gpu_handle() {
+    fn surface_store_writes_null_plugin_abi_object_on_null_gpu_handle() {
         // SAFETY: SurfaceStore is `#[repr(C)] (handle, vtable)`; the
         // callback always writes through the out-pointer first, so a
         // zero-init landing slot is safe to read after the call.
@@ -554,7 +554,7 @@ mod gpu_lim_tier1_wire_format_tests {
                 &mut out as *mut _ as *mut c_void,
             );
         }
-        assert!(out.is_none(), "null gpu_handle must produce a None β-shape");
+        assert!(out.is_none(), "null gpu_handle must produce a None PluginAbiObject");
     }
 
     #[test]

--- a/libs/streamlib-engine/src/core/plugin/host_services/mod.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Cross-DSO host-services callback table.
+//! Plugin ABI host-services callback table.
 //!
 //! Companion to `streamlib-plugin-abi`'s [`HostServices`] ABI
 //! contract. This module owns:
@@ -14,7 +14,7 @@
 //!   `STREAMLIB_PLUGIN.register` callback.
 //! - **Cdylib-side `install_host_services` helper** that the cdylib's
 //!   `export_plugin!` macro calls at register time. The helper
-//!   validates layout, stores the callback table in a per-DSO
+//!   validates layout, stores the callback table in a per-plugin
 //!   [`HOST_CALLBACKS`] static, caches the host's tokio handle in
 //!   [`HOST_TOKIO_HANDLE`] for cdylib-side async-lifecycle wrappers,
 //!   installs the cdylib's tracing `ForwardingSubscriber` and
@@ -27,8 +27,8 @@
 //! copy of streamlib-engine (host binary, every dlopen'd cdylib) has
 //! its own [`PUBSUB`], its own schema registry, its own
 //! `tracing-core::GLOBAL_DISPATCH`, its own `iceoryx2_log::LOGGER`.
-//! Passing `&'static T` references across the FFI would couple
-//! every consumer to byte-identical type layouts across DSOs,
+//! Passing `&'static T` references across the plugin ABI would couple
+//! every consumer to byte-identical type layouts across plugins,
 //! breaking streamlib's multi-builder deployment model.
 //!
 //! The callback-table shape removes that coupling: only `extern "C"
@@ -37,7 +37,7 @@
 //! paths through them (`PUBSUB.publish`, `register_schema`,
 //! `get_embedded_schema_definition`, `tracing::*!`,
 //! `iceoryx2_log::*`) route through the host's fn pointers instead
-//! of through the local DSO's state.
+//! of through the local plugin's state.
 //!
 //! Processor registration follows the same shape: cdylib's
 //! `RegisterHelper::register::<P>()` monomorphizes a [`ProcessorVTable`]
@@ -125,7 +125,7 @@ pub use vulkan_kernels::{
 };
 
 // =============================================================================
-// HostCallbacks — per-DSO cache of the host's fn pointers
+// HostCallbacks — per-plugin cache of the host's fn pointers
 // =============================================================================
 
 /// Cached copy of the host's callback table, stored in
@@ -278,7 +278,7 @@ pub struct HostCallbacks {
         *const streamlib_plugin_abi::RhiCommandRecorderMethodsVTable,
     /// Host-installed [`OutputWriterVTable`] pointer. May be null
     /// when the host doesn't wire iceoryx2 transport; cdylib's
-    /// `OutputWriter` β-shape methods short-circuit cleanly when
+    /// `OutputWriter` PluginAbiObject methods short-circuit cleanly when
     /// the vtable is null. Sourced from
     /// [`HostServices::output_writer_vtable`] at install time
     /// (issue #894).
@@ -286,7 +286,7 @@ pub struct HostCallbacks {
         *const streamlib_plugin_abi::OutputWriterVTable,
     /// Host-installed [`InputMailboxesVTable`] pointer. May be
     /// null when the host doesn't wire iceoryx2 transport; cdylib's
-    /// `InputMailboxes` β-shape methods short-circuit cleanly when
+    /// `InputMailboxes` PluginAbiObject methods short-circuit cleanly when
     /// the vtable is null. Sourced from
     /// [`HostServices::input_mailboxes_vtable`] at install time
     /// (issue #894).
@@ -299,16 +299,16 @@ pub struct HostCallbacks {
 unsafe impl Send for HostCallbacks {}
 unsafe impl Sync for HostCallbacks {}
 
-/// Per-DSO cache of the host's callback table. `OnceLock` semantics:
+/// Per-plugin cache of the host's callback table. `OnceLock` semantics:
 /// the cdylib's `install_host_services` writes once at register
 /// time; subsequent reads from `PUBSUB.publish`, `register_schema`,
 /// the tracing `ForwardingSubscriber`, and the iceoryx2 forwarder
-/// retrieve the same value. **The host's DSO never populates this**
+/// retrieve the same value. **The host binary never populates this**
 /// — host-side code reads its local statics directly, bypassing the
 /// callback table.
 static HOST_CALLBACKS: OnceLock<HostCallbacks> = OnceLock::new();
 
-/// Returns this DSO's callback table if a cdylib's
+/// Returns this plugin's callback table if a cdylib's
 /// `install_host_services` has populated it. `None` in the host
 /// binary; `Some(_)` in any cdylib that has registered.
 pub fn host_callbacks() -> Option<&'static HostCallbacks> {
@@ -319,14 +319,14 @@ pub fn host_callbacks() -> Option<&'static HostCallbacks> {
 // install_host_services — cdylib entry point
 // =============================================================================
 
-/// Wire the host's services into this DSO. Called by a plugin
+/// Wire the host's services into this plugin. Called by a plugin
 /// cdylib's `STREAMLIB_PLUGIN.register` callback via the
 /// [`streamlib_plugin_abi::export_plugin!`] macro.
 ///
 /// Validates [`HostServices::abi_layout_version`] against
 /// [`HOST_SERVICES_LAYOUT_VERSION`], stores the callback table in
 /// [`HOST_CALLBACKS`], installs the cdylib's tracing
-/// [`ForwardingSubscriber`] as the per-DSO `GLOBAL_DISPATCH`,
+/// [`ForwardingSubscriber`] as the per-plugin `GLOBAL_DISPATCH`,
 /// installs the cdylib's iceoryx2 `Log` forwarder, and returns a
 /// [`RegisterHelper`] the macro uses to register processor types
 /// with the host's registry.
@@ -606,12 +606,12 @@ impl RegisterHelper {
         // process (where this code path also runs when a processor
         // is registered inline via `PROCESSOR_REGISTRY.register::<P>()`),
         // `HOST_CALLBACKS` is empty — the host-static path bypasses
-        // FFI and registers directly with the factory.
+        // the plugin ABI and registers directly with the factory.
         if let Some(callbacks) = host_callbacks() {
             register_via_callback::<P>(callbacks);
         } else {
             // Host-static path: same vtable shape, but registered
-            // directly with the in-process factory (no FFI hop).
+            // directly with the in-process factory (no plugin ABI hop).
             crate::core::processors::PROCESSOR_REGISTRY.register::<P>();
         }
     }
@@ -649,7 +649,7 @@ where
 
     let vtable = crate::core::plugin::processor_vtable::vtable_for::<P>();
 
-    // SAFETY: msgpack bytes and vtable pointer live in this DSO's
+    // SAFETY: msgpack bytes and vtable pointer live in this plugin's
     // process address space for the duration of the call. The host's
     // implementation copies any data it needs to retain (the
     // descriptor is decoded into a `ProcessorDescriptor`; the vtable
@@ -695,7 +695,7 @@ unsafe impl Sync for HostServiceImpls {}
 // Every host-side callback below routes its body through
 // [`run_host_extern_c`] so a panic in host code is caught and
 // converted to a logged error plus a sensible default return value
-// at the FFI boundary, instead of corrupting the cdylib's stack.
+// at the plugin ABI, instead of corrupting the cdylib's stack.
 //
 // The default-on-panic value per callback type:
 //   - void                  → `()`
@@ -707,14 +707,14 @@ unsafe impl Sync for HostServiceImpls {}
 //   - `*const c_void` / `*mut u8` / `*const ProcessorVTable` → `null` / `null_mut`
 
 /// Run an extern "C" callback body inside [`std::panic::catch_unwind`].
-/// Panics are logged and converted to `default_on_panic` so the FFI
-/// boundary stays sound. `callback_name` is included in the error
+/// Panics are logged and converted to `default_on_panic` so the plugin
+/// ABI stays sound. `callback_name` is included in the error
 /// log to make the source obvious in mixed-callback traces.
 ///
 /// Uses [`std::panic::AssertUnwindSafe`] internally because callback
 /// bodies routinely touch raw pointers and `*mut` outputs that aren't
 /// `UnwindSafe` by default — the pointer dereferences are sound under
-/// the FFI contract regardless of unwinding.
+/// the plugin ABI contract regardless of unwinding.
 ///
 /// Re-export of the canonical panic-safety helper in
 /// [`streamlib_adapter_abi::ffi`]. Every extern "C" boundary
@@ -740,7 +740,7 @@ unsafe extern "C" fn host_tracing_register_callsite(
             // every event reaches `host_tracing_emit`, where the
             // host's filter actually decides.
             //
-            // Trade-off: cdylib pays for the FFI hop even on
+            // Trade-off: cdylib pays for the plugin ABI hop even on
             // filtered-out events, plus a string copy of the
             // message. A future refinement could push a (target,
             // level)-keyed pre-filter here; the current ABI shape
@@ -1028,7 +1028,7 @@ unsafe extern "C" fn host_processor_register(
 }
 
 // =============================================================================
-// FFI conversions
+// Plugin ABI conversions
 // =============================================================================
 
 pub(crate) fn tracing_level_to_host(level: tracing::Level) -> HostLogLevel {
@@ -1133,7 +1133,7 @@ fn emit_via_host_dispatch(
 
 /// Host-facing helpers used by `Runner::add_module` (and the
 /// `streamlib-runtime` binary's plugin loader) to assemble a
-/// [`HostServices`] payload pointing at this DSO's callback
+/// [`HostServices`] payload pointing at this plugin's callback
 /// implementations.
 pub mod runtime_facing {
     use super::{

--- a/libs/streamlib-engine/src/core/plugin/host_services/runtime_context.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/runtime_context.rs
@@ -127,7 +127,7 @@ unsafe extern "C" fn host_rcv_gpu_full_access(_ctx: *const c_void) -> *const c_v
             // shim embeds `GpuContextFullAccess` by value alongside
             // its handle/vtable pair, so the cdylib never reaches
             // through this callback. Returns null until a future
-            // phase wires cross-DSO FullAccess dispatch.
+            // phase wires plugin ABI FullAccess dispatch.
             std::ptr::null()
         },
         std::ptr::null(),
@@ -199,7 +199,7 @@ pub static HOST_RUNTIME_CONTEXT_VTABLE: RuntimeContextVTable = RuntimeContextVTa
     runtime_ops_handle: host_rcv_runtime_ops_handle,
 };
 
-/// Pointer to the [`RuntimeContextVTable`] this DSO should dispatch
+/// Pointer to the [`RuntimeContextVTable`] this plugin should dispatch
 /// through. In the host process this returns the host's local
 /// `&HOST_RUNTIME_CONTEXT_VTABLE` static (the canonical vtable). In
 /// a cdylib `install_host_services` has populated the cached pointer
@@ -281,7 +281,7 @@ mod runtime_context_vtable_null_handle_guards {
 
     /// Locks the documented placeholder behaviour of
     /// `gpu_full_access`: the wrapper ignores `ctx` and returns null
-    /// unconditionally because cross-DSO FullAccess wiring lives on
+    /// unconditionally because plugin ABI FullAccess wiring lives on
     /// the inline-by-value shim today, not through this callback.
     /// This is NOT a null-handle-guard lock (no guard to revert);
     /// it's a placeholder-shape lock — if a future change wires

--- a/libs/streamlib-engine/src/core/plugin/host_services/shared/borrow.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/shared/borrow.rs
@@ -1,12 +1,12 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Host-side helpers that reconstruct borrowed β-shapes from the raw
+//! Host-side helpers that reconstruct borrowed PluginAbiObjects from the raw
 //! handle pointers that cross the vtable.
 //!
 //! Each `make_*_borrow` populates the cached POD fields on the
-//! reconstructed β-shape from the host-side inner we hold via
-//! `handle`. Cdylib β-shapes carry these cached for free-on-deref
+//! reconstructed PluginAbiObject from the host-side inner we hold via
+//! `handle`. Cdylib PluginAbiObjects carry these cached for free-on-deref
 //! POD getters (`width()`, `height()`, `mapped_ptr()`, etc.); when
 //! the host reconstructs a borrow inside a vtable callback for code
 //! that reads those getters host-side, the borrow's cached fields
@@ -98,7 +98,7 @@ pub(in crate::core::plugin::host_services) fn make_texture_borrow(
     handle: *const c_void,
 ) -> std::mem::ManuallyDrop<crate::core::rhi::Texture> {
     // Populate the cached POD fields from the host-side TextureInner
-    // we already have via `handle`. Cdylib β-shapes carry these cached
+    // we already have via `handle`. Cdylib PluginAbiObjects carry these cached
     // for free-on-deref POD getters (`Texture::width()`, etc.); when
     // the host reconstructs a borrow inside a vtable callback for
     // host-side code that reads `Texture::width()` / `height()`, the
@@ -171,7 +171,7 @@ pub(in crate::core::plugin::host_services) fn make_acceleration_structure_borrow
     handle: *const c_void,
 ) -> std::mem::ManuallyDrop<crate::vulkan::rhi::VulkanAccelerationStructure> {
     // Read the cached POD descriptors directly from the host-internal
-    // Inner. With #955 the β-shape's `kind()` / `device_address()` /
+    // Inner. With #955 the PluginAbiObject's `kind()` / `device_address()` /
     // `storage_size()` getters read the cached fields (no host_inner()
     // fallback), so the borrow MUST carry real values — the
     // ray-tracing kernel's `set_acceleration_structure` check reads
@@ -206,7 +206,7 @@ pub(in crate::core::plugin::host_services) fn make_acceleration_structure_borrow
     })
 }
 
-/// Reconstruct a borrowed `VulkanComputeKernel` β-shape from its
+/// Reconstruct a borrowed `VulkanComputeKernel` PluginAbiObject from its
 /// `Arc::into_raw`-shaped handle. Cached POD fields are populated by
 /// reading the host-side inner.
 ///
@@ -235,7 +235,7 @@ pub(in crate::core::plugin::host_services) fn make_compute_kernel_borrow(
     })
 }
 
-/// Reconstruct a borrowed `VulkanGraphicsKernel` β-shape from its
+/// Reconstruct a borrowed `VulkanGraphicsKernel` PluginAbiObject from its
 /// `Arc::into_raw`-shaped handle. Same pattern as
 /// `make_compute_kernel_borrow` — cached POD fields are populated by
 /// reading the host-side inner.
@@ -263,7 +263,7 @@ pub(in crate::core::plugin::host_services) fn make_graphics_kernel_borrow(
 #[cfg(all(test, target_os = "linux"))]
 mod make_borrow_cached_field_regression_tests {
     //! Locks the issue #988 bug: `make_*_borrow` helpers MUST populate
-    //! the β-shape's cached POD fields from the host-side inner —
+    //! the PluginAbiObject's cached POD fields from the host-side inner —
     //! NOT leave them zeroed. Reverting any `make_*_borrow` to
     //! `width_cached: 0` / `byte_size_cached: 0` / etc. trips these
     //! assertions.

--- a/libs/streamlib-engine/src/core/plugin/host_services/texture_ring.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/texture_ring.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //! Host-side `TextureRingMethodsVTable` callbacks + static vtable +
-//! accessor (issue #947 — slot β-shape + method dispatch).
+//! accessor (issue #947 — slot PluginAbiObject + method dispatch).
 //!
 //! Each wrapper reconstructs the ring borrow from the raw
 //! `Arc::into_raw(Arc<TextureRingInner>)` handle the cdylib passes,
-//! runs the inner method, and serializes the result into the FFI's
+//! runs the inner method, and serializes the result into the plugin ABI's
 //! out-parameter buffers + `i32 + err_buf` shape. All bodies wrapped
 //! in `run_host_extern_c` so a panic in the inner method becomes a
 //! non-zero return.
@@ -21,10 +21,10 @@ use super::shared::wire::write_err;
 
 
 // =============================================================================
-// TextureRingMethodsVTable wrappers (issue #947 — slot β-shape + method
+// TextureRingMethodsVTable wrappers (issue #947 — slot PluginAbiObject + method
 // dispatch). Each wrapper reconstructs the ring borrow from the raw
 // `Arc::into_raw(Arc<TextureRingInner>)` handle the cdylib passes,
-// runs the inner method, and serializes the result into the FFI's
+// runs the inner method, and serializes the result into the plugin ABI's
 // out-parameter buffers + `i32 + err_buf` shape. All bodies are
 // wrapped in `run_host_extern_c` so a panic in the inner method
 // becomes a non-zero return.
@@ -46,7 +46,7 @@ unsafe fn handle_as_texture_ring(
 /// Write the slot's POD identity bytes into the caller-provided
 /// out-parameter buffers. The texture handle is bumped through the
 /// host's limited-access `clone_texture` slot so the resulting
-/// cdylib-side `Texture` β-shape owns the matching `Drop`-side
+/// cdylib-side `Texture` PluginAbiObject owns the matching `Drop`-side
 /// decrement.
 #[cfg(target_os = "linux")]
 unsafe fn write_slot_out_params(
@@ -60,9 +60,9 @@ unsafe fn write_slot_out_params(
     out_slot_index: *mut u32,
 ) {
     // Bump the texture's Arc through the parent limited-access
-    // vtable's `clone_texture` slot — same contract every cross-DSO
-    // Texture-bearing FFI return uses. The cdylib-side `Texture`
-    // β-shape's `Drop` will fire `drop_texture` to balance.
+    // vtable's `clone_texture` slot — same contract every plugin ABI
+    // Texture-bearing return uses. The cdylib-side `Texture`
+    // PluginAbiObject's `Drop` will fire `drop_texture` to balance.
     if !slot.texture.handle.is_null() && !slot.texture.vtable.is_null() {
         unsafe {
             ((*slot.texture.vtable).clone_texture)(slot.texture.handle);
@@ -376,7 +376,7 @@ unsafe extern "C" fn host_texture_ring_slot(
 }
 
 /// Host-side `TextureRingMethodsVTable` wired to the per-method
-/// wrappers above (issue #947 — `TextureRingSlot` β-shape +
+/// wrappers above (issue #947 — `TextureRingSlot` PluginAbiObject +
 /// method dispatch).
 pub static HOST_TEXTURE_RING_METHODS_VTABLE: streamlib_plugin_abi::TextureRingMethodsVTable =
     streamlib_plugin_abi::TextureRingMethodsVTable {
@@ -388,7 +388,7 @@ pub static HOST_TEXTURE_RING_METHODS_VTABLE: streamlib_plugin_abi::TextureRingMe
     };
 
 /// Accessor for the host's static `TextureRingMethodsVTable` — used
-/// by `TextureRing::from_arc_into_raw` to populate the β-shape's
+/// by `TextureRing::from_arc_into_raw` to populate the PluginAbiObject's
 /// `methods_vtable` field.
 pub fn host_texture_ring_methods_vtable() -> *const streamlib_plugin_abi::TextureRingMethodsVTable {
     &HOST_TEXTURE_RING_METHODS_VTABLE

--- a/libs/streamlib-engine/src/core/plugin/host_services/vulkan_kernels.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/vulkan_kernels.rs
@@ -9,7 +9,7 @@
 //! Linux callback bodies and the non-Linux platform stubs are
 //! interleaved in the source layout. Both share the same shape:
 //! reconstruct the kernel borrow from `Arc::into_raw(Arc<...Inner>)`,
-//! run the inner method, convert `Result<()>` into the FFI's
+//! run the inner method, convert `Result<()>` into the plugin ABI's
 //! `i32 + err_buf` shape, with `run_host_extern_c` catching any
 //! panic in the inner method.
 
@@ -30,8 +30,8 @@ use super::shared::wire::{slice_from_raw, write_err};
 //
 // Each wrapper reconstructs the kernel borrow from the raw `Arc`
 // handle the cdylib passes (`Arc::into_raw(Arc<VulkanGraphicsKernelInner>)`
-// per the β-shape's `from_arc_into_raw`), runs the inner method,
-// and converts the `Result<()>` into the FFI's `i32 + err_buf`
+// per the PluginAbiObject's `from_arc_into_raw`), runs the inner method,
+// and converts the `Result<()>` into the plugin ABI's `i32 + err_buf`
 // shape. All bodies are wrapped in `run_host_extern_c` so a panic
 // in the inner method becomes a non-zero return.
 //
@@ -692,8 +692,8 @@ unsafe extern "C" fn host_graphics_kernel_offscreen_render(
 //
 // Each wrapper reconstructs the kernel borrow from the raw `Arc`
 // handle the cdylib passes (`Arc::into_raw(Arc<VulkanRayTracingKernelInner>)`
-// per the β-shape's `from_arc_into_raw`), runs the inner method,
-// and converts the `Result<()>` into the FFI's `i32 + err_buf`
+// per the PluginAbiObject's `from_arc_into_raw`), runs the inner method,
+// and converts the `Result<()>` into the plugin ABI's `i32 + err_buf`
 // shape. All bodies are wrapped in `run_host_extern_c` so a panic
 // in the inner method becomes a non-zero return.
 //
@@ -706,7 +706,7 @@ unsafe extern "C" fn host_graphics_kernel_offscreen_render(
 //
 // The AS-binding wrapper reconstructs an AS borrow via
 // `make_acceleration_structure_borrow` — same `ManuallyDrop` shape
-// as the buffer/texture helpers. The β-shape's `kind()` /
+// as the buffer/texture helpers. The PluginAbiObject's `kind()` /
 // `device_address()` / `storage_size()` getters read the cached
 // fields on the borrow directly (no vtable dispatch); the helper
 // populates those fields at construction time from the host-internal
@@ -1548,12 +1548,12 @@ pub static HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE:
 
 /// Accessor for the host's static `VulkanGraphicsKernelMethodsVTable`
 /// — used by `VulkanGraphicsKernel::from_arc_into_raw` to populate
-/// the β-shape's `methods_vtable` field.
+/// the PluginAbiObject's `methods_vtable` field.
 pub fn host_vulkan_graphics_kernel_methods_vtable(
 ) -> *const streamlib_plugin_abi::VulkanGraphicsKernelMethodsVTable {
     // See [`host_vulkan_compute_kernel_methods_vtable`] for the routing
-    // rationale — cdylib β-shape constructors must store the host's
-    // vtable pointer so dispatches actually cross DSO boundaries.
+    // rationale — cdylib PluginAbiObject constructors must store the host's
+    // vtable pointer so dispatches actually cross the plugin ABI.
     match host_callbacks() {
         Some(c) if !c.vulkan_graphics_kernel_methods_vtable.is_null() => {
             c.vulkan_graphics_kernel_methods_vtable
@@ -1818,7 +1818,7 @@ pub static HOST_VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE:
 /// Accessor for the host's static
 /// `VulkanRayTracingKernelMethodsVTable` — used by
 /// `VulkanRayTracingKernel::from_arc_into_raw` to populate the
-/// β-shape's `methods_vtable` field.
+/// PluginAbiObject's `methods_vtable` field.
 pub fn host_vulkan_ray_tracing_kernel_methods_vtable(
 ) -> *const streamlib_plugin_abi::VulkanRayTracingKernelMethodsVTable {
     &HOST_VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE

--- a/libs/streamlib-engine/src/core/plugin/mod.rs
+++ b/libs/streamlib-engine/src/core/plugin/mod.rs
@@ -1,14 +1,14 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Cross-DSO plugin bridging.
+//! Plugin ABI bridging.
 //!
 //! Rust plugin cdylibs loaded via `Runner::add_module` (or the
 //! standalone `streamlib-runtime` binary's `--plugin` flag)
 //! statically embed their entire transitive
 //! dep tree. Without bridging, every process-wide static the engine
 //! relies on (tracing dispatch, [`PUBSUB`], the schema registry,
-//! iceoryx2's logger) exists as a per-DSO copy with no
+//! iceoryx2's logger) exists as a per-plugin copy with no
 //! dynamic-linker dedup — Rust mangled statics aren't in the dynsym
 //! table.
 //!

--- a/libs/streamlib-engine/src/core/plugin/processor_vtable.rs
+++ b/libs/streamlib-engine/src/core/plugin/processor_vtable.rs
@@ -22,7 +22,7 @@
 //! (`RegisterHelper::register::<P>()` in `host_services`) and the
 //! host-static path (`ProcessorInstanceFactory::register::<P>()`)
 //! call [`vtable_for::<P>()`] — the resulting vtable lives in the
-//! DSO of the caller, but the shape is identical.
+//! caller's binary, but the shape is identical.
 
 use std::any::TypeId;
 use std::collections::HashMap;
@@ -37,7 +37,7 @@ use crate::core::processors::{Config, GeneratedProcessor};
 
 /// Map from `TypeId::of::<P>()` to the leaked `&'static
 /// ProcessorVTable` for that P. One vtable per processor type in
-/// the DSO's process address space; rebuilt only on the first
+/// the caller's binary process address space; rebuilt only on the first
 /// `vtable_for::<P>()` call (subsequent calls hit the cache).
 static VTABLES: OnceLock<Mutex<HashMap<TypeId, &'static ProcessorVTable>>> = OnceLock::new();
 
@@ -148,7 +148,7 @@ where
             || {
                 if !instance.is_null() {
                     // SAFETY: instance was produced by Box::into_raw above on this
-                    // DSO's heap. Box::from_raw + drop releases on the same heap.
+                    // binary's heap. Box::from_raw + drop releases on the same heap.
                     unsafe {
                         drop(Box::from_raw(instance as *mut P));
                     }
@@ -383,7 +383,7 @@ where
             "ProcessorWrappers::set_iceoryx2_resources",
             || {
                 let processor = unsafe { &mut *(instance as *mut P) };
-                // Reconstruct β-shapes from the (handle, vtable)
+                // Reconstruct PluginAbiObjects from the (handle, vtable)
                 // pairs the host hands us. Null handle/vtable =
                 // "this processor has no outputs/inputs" — pass
                 // None to the trait method.

--- a/libs/streamlib-engine/src/core/processors/__generated_private/generated_processor.rs
+++ b/libs/streamlib-engine/src/core/processors/__generated_private/generated_processor.rs
@@ -67,7 +67,7 @@ pub trait GeneratedProcessor: Send + 'static {
     /// Called by the host once after `from_config` returns and
     /// before any connections are wired. Default impl is a no-op
     /// for processors that declare no input/output ports; the macro
-    /// emits an override that writes the β-shapes into `self.outputs`
+    /// emits an override that writes the PluginAbiObjects into `self.outputs`
     /// / `self.inputs` for processors that do.
     fn set_iceoryx2_resources(
         &mut self,
@@ -78,13 +78,13 @@ pub trait GeneratedProcessor: Send + 'static {
     }
 
     /// Borrow the (now host-side) `OutputWriterInner` Arc the
-    /// processor's β-shape is wired to, if any. Default `None`;
+    /// processor's PluginAbiObject is wired to, if any. Default `None`;
     /// the macro emits an override for processors with outputs.
     ///
     /// Used by the host's connection-wiring path to mutate the
     /// inner directly (add_connection, etc.) without crossing
-    /// the cdylib boundary. The returned Arc is cloned from the
-    /// β-shape's stored Arc, so it's safe to retain.
+    /// the plugin ABI. The returned Arc is cloned from the
+    /// PluginAbiObject's stored Arc, so it's safe to retain.
     fn iceoryx2_output_writer_inner(
         &self,
     ) -> Option<std::sync::Arc<crate::iceoryx2::OutputWriterInner>> {
@@ -92,7 +92,7 @@ pub trait GeneratedProcessor: Send + 'static {
     }
 
     /// Borrow the (now host-side) `InputMailboxesInner` Arc the
-    /// processor's β-shape is wired to, if any. Default `None`;
+    /// processor's PluginAbiObject is wired to, if any. Default `None`;
     /// the macro emits an override for processors with inputs.
     fn iceoryx2_input_mailboxes_inner(
         &self,

--- a/libs/streamlib-engine/src/core/processors/processor_instance_factory.rs
+++ b/libs/streamlib-engine/src/core/processors/processor_instance_factory.rs
@@ -31,7 +31,7 @@ const VTABLE_ERR_BUF_CAP: usize = 512;
 /// the dyn-trait crossing class); legacy non-generic registrations
 /// (subprocess host wrappers via [`ProcessorInstanceFactory::register_dynamic`])
 /// land in [`Self::LegacyDyn`] (dispatch via Rust trait-object
-/// methods, host-DSO-only).
+/// methods, host-only).
 ///
 /// # Iceoryx2 resource ownership (issue #894)
 ///
@@ -39,16 +39,16 @@ const VTABLE_ERR_BUF_CAP: usize = 512;
 /// `InputMailboxesInner` Arcs at instance-construction time and
 /// retains them on the `VTable` variant via the
 /// `iceoryx2_output_writer_inner` / `iceoryx2_input_mailboxes_inner`
-/// fields. The cdylib's `outputs` / `inputs` β-shape fields receive
+/// fields. The cdylib's `outputs` / `inputs` PluginAbiObject fields receive
 /// `Arc::into_raw`-cloned handles via `set_iceoryx2_resources`.
 /// Connection-wiring code on the host operates on the inner Arc
-/// directly (no FFI hop).
+/// directly (no plugin ABI hop).
 pub enum ProcessorInstance {
     /// Vtable-dispatched processor — cdylib registrations (via
     /// `STREAMLIB_PLUGIN`) and in-process `register::<P>()` calls
     /// both land here. `instance_ptr` is a
     /// `Box::into_raw(Box::<P>::new(...))` allocation on the
-    /// registering DSO's heap (cdylib for cross-DSO loads, host for
+    /// registering artifact's heap (cdylib for plugin loads, host for
     /// in-process registration). Dropped via `vtable.destroy`.
     ///
     /// `any_placeholder` is a ZST anchor whose `&mut` reference
@@ -81,12 +81,12 @@ pub enum ProcessorInstance {
     /// Host-static dyn-trait registration. Used by subprocess host
     /// wrappers (Python / Deno) that register a `Box<dyn Fn>`
     /// constructor via [`ProcessorInstanceFactory::register_dynamic`].
-    /// No cross-DSO crossing — these live in the host's DSO and
+    /// No plugin ABI crossing — these live in the host and
     /// dispatch via standard Rust trait objects.
     LegacyDyn(Box<dyn DynGeneratedProcessor + Send>),
 }
 
-// Safety: VTable's `*mut c_void` is bound to the registering DSO's
+// Safety: VTable's `*mut c_void` is bound to the registering artifact's
 // process address space, which lives for the process lifetime
 // (cdylibs are pinned via `LOADED_PLUGIN_LIBRARIES`). LegacyDyn's
 // inner Box<dyn ... + Send> is already Send.
@@ -101,9 +101,9 @@ impl Drop for ProcessorInstance {
         } = self
         {
             if !instance_ptr.is_null() {
-                // SAFETY: instance_ptr came from the same DSO's
+                // SAFETY: instance_ptr came from the same artifact's
                 // Box::into_raw via vtable.construct; destroy
-                // performs Box::from_raw + drop on that DSO's heap.
+                // performs Box::from_raw + drop on that artifact's heap.
                 unsafe {
                     (vtable.destroy)(*instance_ptr);
                 }
@@ -463,7 +463,7 @@ impl ProcessorInstance {
     /// Used by the host's connection-wiring path (compiler ops) to
     /// mutate the inner directly via
     /// [`crate::iceoryx2::OutputWriterInner::add_connection`] —
-    /// no FFI hop to the cdylib.
+    /// no plugin ABI hop to the cdylib.
     pub fn iceoryx2_output_writer_inner(
         &self,
     ) -> Option<Arc<crate::iceoryx2::OutputWriterInner>> {
@@ -483,7 +483,7 @@ impl ProcessorInstance {
     /// Used by the host's wiring + scheduler paths to call
     /// `add_port`, `set_subscriber`, `set_listener`, `listener_fd`,
     /// `drain_listener`, `any_port_has_data`, etc. directly — all
-    /// host-side, no FFI hop to the cdylib.
+    /// host-side, no plugin ABI hop to the cdylib.
     pub fn iceoryx2_input_mailboxes_inner(
         &self,
     ) -> Option<Arc<crate::iceoryx2::InputMailboxesInner>> {
@@ -756,9 +756,9 @@ pub type DynamicProcessorConstructorFn = Box<
 /// Per-type registration entry the factory stores.
 enum RegistrationKind {
     /// VTable-based dispatch. Used by both cdylib registrations
-    /// (extern "C" wrappers landing in the cdylib's DSO) and
+    /// (extern "C" wrappers landing in the cdylib's address space) and
     /// inventory-registered host processors (extern "C" wrappers
-    /// landing in the host's DSO).
+    /// landing in the host's address space).
     ///
     /// `cdylib_resident` distinguishes the two — `true` when the
     /// vtable's function pointers target a cdylib's address space
@@ -851,7 +851,7 @@ impl ProcessorInstanceFactory {
 
         // In-process registration — vtable's function pointers
         // target the host's address space; lifecycle dispatch uses
-        // the Boxed FullAccess directly (no FFI hop).
+        // the Boxed FullAccess directly (no plugin ABI hop).
         if let Err(e) = self.register_via_vtable(descriptor, vtable, /* cdylib_resident */ false) {
             tracing::warn!(
                 "Processor registration for {} failed: {}",
@@ -1161,7 +1161,7 @@ impl ProcessorInstanceFactory {
                     cdylib_resident: *cdylib_resident,
                 };
                 // Issue #894: host-allocates iceoryx2 inner Arcs +
-                // hands the cdylib opaque (handle, vtable) β-shapes
+                // hands the cdylib opaque (handle, vtable) PluginAbiObjects
                 // via the new `set_iceoryx2_resources` slot.
                 instance.install_iceoryx2_resources()?;
                 Ok(instance)

--- a/libs/streamlib-engine/src/core/pubsub/bus.rs
+++ b/libs/streamlib-engine/src/core/pubsub/bus.rs
@@ -25,16 +25,16 @@ thread_local! {
 
 /// Process-wide pub/sub handle.
 ///
-/// **Per-DSO instance.** Each linked copy of streamlib-engine (host
+/// **Per-loaded-artifact instance.** Each linked copy of streamlib-engine (host
 /// binary + every dlopen'd cdylib plugin) gets its own `LazyLock<PubSub>`
 /// — Rust mangled statics aren't in the dynsym table, the dynamic
 /// linker doesn't dedupe them, and trying to share the same `PubSub`
-/// reference across DSOs would couple the cdylib to byte-identical
+/// reference across the host and plugins would couple the cdylib to byte-identical
 /// internal layouts of `Iceoryx2Node`, parking_lot::Mutex, etc.
 ///
-/// Cross-DSO bridging happens **inside the methods**: when
+/// Plugin ABI bridging happens **inside the methods**: when
 /// `crate::core::plugin::host_services::host_callbacks()` returns
-/// `Some` (i.e. this DSO is a plugin cdylib whose
+/// `Some` (i.e. this artifact is a plugin cdylib whose
 /// `install_host_services` has run), `publish` serializes the event
 /// and forwards it through the host's `pubsub_publish` fn pointer.
 /// The host's installed `PUBSUB` performs the actual iceoryx2 work,
@@ -204,7 +204,7 @@ impl PubSub {
     /// In a plugin cdylib whose `install_host_services` has run,
     /// short-circuits to the host's `pubsub_publish` callback —
     /// the event is serialized once and the host's `PUBSUB`
-    /// performs the actual iceoryx2 work. In the host DSO,
+    /// performs the actual iceoryx2 work. In the host,
     /// runs the local iceoryx2 path below.
     ///
     /// Events are dispatched to:
@@ -217,7 +217,7 @@ impl PubSub {
             let bytes = match rmp_serde::to_vec_named(event) {
                 Ok(b) => b,
                 Err(e) => {
-                    tracing::warn!("Failed to serialize event for FFI forwarding: {}", e);
+                    tracing::warn!("Failed to serialize event for plugin ABI forwarding: {}", e);
                     return;
                 }
             };

--- a/libs/streamlib-engine/src/core/rhi/color_converter.rs
+++ b/libs/streamlib-engine/src/core/rhi/color_converter.rs
@@ -201,7 +201,7 @@ pub fn pixel_format_color_kind(format: PixelFormat) -> ColorSpaceKind {
 
 /// Host-only rich data backing a [`RhiColorConverter`]. Cdylib code
 /// never sees this type; it reaches the public surface through the
-/// `(handle, vtable)` β-shape.
+/// `(handle, vtable)` PluginAbiObject.
 pub struct RhiColorConverterInner {
     #[cfg(target_os = "linux")]
     pub(crate) inner: crate::vulkan::rhi::VulkanColorConverter,
@@ -329,7 +329,7 @@ impl std::fmt::Debug for RhiColorConverterInner {
 }
 
 // =============================================================================
-// β-shape implementation
+// PluginAbiObject implementation
 // =============================================================================
 
 /// Stateless color converter — a `(src, dst)`-keyed handle that knows
@@ -349,15 +349,15 @@ impl std::fmt::Debug for RhiColorConverterInner {
 pub struct RhiColorConverter {
     /// Opaque handle to the host's `Arc<RhiColorConverterInner>`.
     pub(crate) handle: *const std::ffi::c_void,
-    /// Parent vtable for cross-DSO Clone/Drop dispatch.
+    /// Parent vtable for plugin ABI Clone/Drop dispatch.
     pub(crate) vtable: *const streamlib_plugin_abi::GpuContextFullAccessVTable,
-    /// Per-type vtable for cross-DSO method dispatch.
+    /// Per-type vtable for plugin ABI method dispatch.
     pub(crate) methods_vtable:
         *const streamlib_plugin_abi::RhiColorConverterMethodsVTable,
     /// Cached `#[repr(u32)]` `PixelFormat` discriminant for the source
     /// format. Set at construction; fixed for the converter's lifetime.
     /// Mirrors `Texture::format_raw` so the cdylib's `src_format()`
-    /// getter is a pure field read with no FFI hop.
+    /// getter is a pure field read with no plugin ABI hop.
     pub(crate) cached_src_format_raw: u32,
     /// Cached `#[repr(u32)]` `PixelFormat` discriminant for the
     /// destination format. Same shape as `cached_src_format_raw`.
@@ -373,7 +373,7 @@ unsafe impl Sync for RhiColorConverter {}
 impl RhiColorConverter {
     /// Internal helper: leak an initial Arc strong count via
     /// `Arc::into_raw`, resolve the host-mode FullAccess vtable +
-    /// per-type methods vtable, and assemble the cross-DSO shape.
+    /// per-type methods vtable, and assemble the plugin ABI shape.
     pub(crate) fn from_arc_into_raw(arc: std::sync::Arc<RhiColorConverterInner>) -> Self {
         let cached_src_format_raw = arc.src_format() as u32;
         let cached_dst_format_raw = arc.dst_format() as u32;
@@ -451,7 +451,7 @@ impl RhiColorConverter {
     /// Mode-routed: in-process callers dispatch through `host_inner`;
     /// cdylib callers dispatch through the per-type methods vtable
     /// (Phase E sub-lift slice A). The cdylib-side return reconstructs
-    /// a `VulkanComputeKernel` β-shape from the host-handed-out
+    /// a `VulkanComputeKernel` PluginAbiObject from the host-handed-out
     /// `Arc<VulkanComputeKernelInner>`-shaped opaque handle + cached
     /// `push_constant_size`, sourcing the parent / per-type vtables
     /// from `host_callbacks()`.
@@ -495,7 +495,7 @@ impl RhiColorConverter {
         }
         // The cdylib needs the parent FullAccess vtable and the per-
         // type VulkanComputeKernel methods vtable to assemble its own
-        // β-shape from the host-returned inner handle. Both come from
+        // PluginAbiObject from the host-returned inner handle. Both come from
         // `host_callbacks()` — populated at plugin install time.
         let callbacks =
             crate::core::plugin::host_services::host_callbacks().ok_or_else(|| {
@@ -559,12 +559,12 @@ impl RhiColorConverter {
                     .into(),
             ));
         }
-        // β-shape: bundle the raw handle (an
+        // PluginAbiObject: bundle the raw handle (an
         // `Arc::into_raw(Arc<VulkanComputeKernelInner>)` pointer host-
         // side, opaque to the cdylib) with the parent vtable + per-
         // type methods vtable + cached `push_constant_size` POD. The
         // cdylib owns the inner Arc strong count the host bumped
-        // before returning; the β-shape's Drop releases it via
+        // before returning; the PluginAbiObject's Drop releases it via
         // `drop_compute_kernel`.
         let kernel = crate::vulkan::rhi::VulkanComputeKernel {
             handle: out_kernel,
@@ -801,7 +801,7 @@ impl RhiColorConverter {
     }
 
     /// Source pixel format this converter accepts. Cached POD —
-    /// no FFI hop. The value is captured by [`Self::from_arc_into_raw`]
+    /// no plugin ABI hop. The value is captured by [`Self::from_arc_into_raw`]
     /// (host-mode) or the FullAccess `color_converter` slot (cdylib-
     /// mode) at construction and never mutates.
     pub fn src_format(&self) -> PixelFormat {
@@ -899,7 +899,7 @@ mod layout_tests {
         // The cached `cached_*_format_raw` fields mirror the
         // `Texture::format_raw` cached POD pattern so the cdylib's
         // `src_format()` / `dst_format()` getters are pure field reads
-        // with no FFI hop.
+        // with no plugin ABI hop.
         assert_eq!(size_of::<RhiColorConverter>(), 32);
         assert_eq!(align_of::<RhiColorConverter>(), 8);
         assert_eq!(offset_of!(RhiColorConverter, handle), 0);

--- a/libs/streamlib-engine/src/core/rhi/command_buffer.rs
+++ b/libs/streamlib-engine/src/core/rhi/command_buffer.rs
@@ -23,7 +23,7 @@ use super::texture::Texture;
 
 /// Host-only rich data backing a [`CommandBuffer`]. Cdylib code
 /// never sees this type; it reaches the public [`CommandBuffer`]
-/// surface through the `(handle, vtable)` β-shape.
+/// surface through the `(handle, vtable)` PluginAbiObject.
 ///
 /// Holds the platform-specific command buffer by value (no Arc —
 /// command buffers are single-use, not shared).
@@ -67,7 +67,7 @@ pub(crate) struct CommandBufferInner {
 pub struct CommandBuffer {
     /// Opaque handle to the host's `Box<CommandBufferInner>`.
     pub(crate) handle: *const c_void,
-    /// Vtable for cross-DSO Drop and method dispatch.
+    /// Vtable for plugin ABI Drop and method dispatch.
     pub(crate) vtable: *const GpuContextLimitedAccessVTable,
 }
 
@@ -104,7 +104,7 @@ impl CommandBuffer {
 
     /// Copy one texture to another.
     ///
-    /// Dispatches through the cross-DSO vtable's
+    /// Dispatches through the plugin ABI vtable's
     /// `copy_texture_command_buffer` callback.
     pub fn copy_texture(&mut self, src: &Texture, dst: &Texture) {
         if self.handle.is_null() || self.vtable.is_null() {
@@ -125,7 +125,7 @@ impl CommandBuffer {
 
     /// Commit the command buffer for execution.
     ///
-    /// Dispatches through the cross-DSO vtable's
+    /// Dispatches through the plugin ABI vtable's
     /// `commit_command_buffer` callback. The host's impl runs
     /// `Box::from_raw + commit + drop` so the underlying platform
     /// resources are committed exactly once. The cdylib's local
@@ -150,7 +150,7 @@ impl CommandBuffer {
 
     /// Commit and wait for completion.
     ///
-    /// Dispatches through the cross-DSO vtable's
+    /// Dispatches through the plugin ABI vtable's
     /// `commit_and_wait_command_buffer` callback. Same lifetime
     /// contract as [`Self::commit`].
     pub fn commit_and_wait(mut self) {

--- a/libs/streamlib-engine/src/core/rhi/command_queue.rs
+++ b/libs/streamlib-engine/src/core/rhi/command_queue.rs
@@ -22,7 +22,7 @@ use super::CommandBuffer;
 
 /// Host-only rich data backing a [`RhiCommandQueue`]. Cdylib code
 /// never sees this type; it reaches the public [`RhiCommandQueue`]
-/// surface through the `(handle, vtable)` β-shape.
+/// surface through the `(handle, vtable)` PluginAbiObject.
 pub(crate) struct RhiCommandQueueInner {
     // Metal backend: explicit feature OR macOS/iOS default (when vulkan not requested)
     #[cfg(all(
@@ -64,7 +64,7 @@ pub(crate) struct RhiCommandQueueInner {
 pub struct RhiCommandQueue {
     /// Opaque handle to the host's `Arc<RhiCommandQueueInner>`.
     pub(crate) handle: *const c_void,
-    /// Vtable for cross-DSO Clone/Drop and method dispatch.
+    /// Vtable for plugin ABI Clone/Drop and method dispatch.
     pub(crate) vtable: *const GpuContextLimitedAccessVTable,
 }
 
@@ -78,7 +78,7 @@ unsafe impl Sync for RhiCommandQueue {}
 impl RhiCommandQueue {
     /// Internal helper: leak an initial Arc strong count via
     /// `Arc::into_raw`, resolve the host-mode vtable, and assemble
-    /// the cross-DSO shape.
+    /// the plugin ABI shape.
     pub(crate) fn from_arc_into_raw(arc: std::sync::Arc<RhiCommandQueueInner>) -> Self {
         let handle = std::sync::Arc::into_raw(arc) as *const c_void;
         let vtable = crate::core::plugin::host_services::host_gpu_context_limited_access_vtable();
@@ -104,7 +104,7 @@ impl RhiCommandQueue {
     /// Command buffers are single-use: create, record commands, commit.
     /// This is the standard pattern for GPU work submission.
     ///
-    /// Dispatches through the cross-DSO vtable's
+    /// Dispatches through the plugin ABI vtable's
     /// `create_command_buffer_from_queue` callback.
     pub fn create_command_buffer(&self) -> Result<CommandBuffer> {
         if self.handle.is_null() || self.vtable.is_null() {

--- a/libs/streamlib-engine/src/core/rhi/index_buffer.rs
+++ b/libs/streamlib-engine/src/core/rhi/index_buffer.rs
@@ -25,7 +25,7 @@ use streamlib_plugin_abi::GpuContextLimitedAccessVTable;
 pub struct IndexBuffer {
     /// Opaque handle to the host's `Arc<HostVulkanBuffer>`.
     pub(crate) handle: *const c_void,
-    /// Vtable for cross-DSO Clone/Drop dispatch.
+    /// Vtable for plugin ABI Clone/Drop dispatch.
     pub(crate) vtable: *const GpuContextLimitedAccessVTable,
     /// Cached byte size.
     pub(crate) byte_size_cached: u64,

--- a/libs/streamlib-engine/src/core/rhi/pixel_buffer.rs
+++ b/libs/streamlib-engine/src/core/rhi/pixel_buffer.rs
@@ -5,7 +5,7 @@
 //!
 //! Layout-stable `(handle, vtable, cached POD)` shape: every field
 //! is either a primitive or an opaque pointer, so the type
-//! round-trips across the cdylib DSO boundary unchanged. The
+//! round-trips across the plugin ABI unchanged. The
 //! handle is `Arc::into_raw(Arc<PixelBufferRef>)` produced by host
 //! code; the vtable's `clone_pixel_buffer` / `drop_pixel_buffer`
 //! callbacks manage the Arc refcount in host-compiled code, so
@@ -43,7 +43,7 @@ pub struct PixelBuffer {
     /// `*const PixelBufferRef` via [`PixelBuffer::buffer_ref`];
     /// cdylib callers treat it as opaque.
     pub(crate) handle: *const c_void,
-    /// Vtable for cross-DSO Clone/Drop dispatch. In host mode this
+    /// Vtable for plugin ABI Clone/Drop dispatch. In host mode this
     /// points at `&HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE`; in
     /// cdylib mode it's the host-installed pointer from
     /// `HostServices::gpu_context_limited_access_vtable`.
@@ -146,7 +146,7 @@ impl PixelBuffer {
     }
 
     /// Cached pixel format. Captured at construction; pure field
-    /// read with no cross-DSO dispatch.
+    /// read with no plugin ABI dispatch.
     pub fn format(&self) -> PixelFormat {
         // SAFETY: `format_raw` is the `#[repr(u32)]` discriminant of
         // a `PixelFormat` value that was alive at construction time
@@ -187,7 +187,7 @@ impl PixelBuffer {
             panic!(
                 "PixelBuffer::buffer_ref() reached from cdylib code; \
                  PixelBufferRef is a host-internal type and its layout \
-                 is not cross-DSO safe. Cdylibs reach platform-specific \
+                 is not plugin ABI safe. Cdylibs reach platform-specific \
                  data through vtable callbacks (plane_base_address, \
                  plane_size, plane_count, format)."
             );
@@ -203,7 +203,7 @@ impl PixelBuffer {
 
     /// Number of DMA-BUF planes backing this pixel buffer. Always `>= 1`.
     /// Mirror of `slpn_gpu_surface_plane_count` on the polyglot shims.
-    /// Cached at construction; pure field read with no cross-DSO
+    /// Cached at construction; pure field read with no plugin ABI
     /// dispatch.
     pub fn plane_count(&self) -> u32 {
         self.plane_count_cached
@@ -259,7 +259,7 @@ impl PixelBuffer {
     /// Dispatches through the vtable's
     /// [`strong_count_pixel_buffer`](GpuContextLimitedAccessVTable::strong_count_pixel_buffer)
     /// callback so the host's `Arc<PixelBufferRef>` accounting runs
-    /// in host-compiled code regardless of caller DSO.
+    /// in host-compiled code regardless of caller plugin.
     pub(crate) fn strong_count(&self) -> usize {
         if self.handle.is_null() || self.vtable.is_null() {
             return 0;
@@ -323,7 +323,7 @@ impl std::fmt::Debug for PixelBuffer {
 // =============================================================================
 //
 // `PixelBuffer` is the load-bearing β-reshape type that crosses the
-// cdylib DSO boundary. A drift in its `#[repr(C)]` layout would
+// plugin ABI. A drift in its `#[repr(C)]` layout would
 // silently corrupt every `acquire_pixel_buffer` / `release_pixel_buffer`
 // / `resolve_pixel_buffer_by_surface_id` round-trip — the host's
 // pixel-buffer accessors would read the cdylib's stale field offsets.
@@ -342,7 +342,7 @@ mod layout_tests {
 
     #[test]
     fn pixel_buffer_layout() {
-        // Pin the byte-level shape of the cross-DSO `PixelBuffer`. Fields:
+        // Pin the byte-level shape of the plugin ABI `PixelBuffer`. Fields:
         //   handle              : *const c_void  → offset 0,  size 8
         //   vtable              : *const VTable  → offset 8,  size 8
         //   width               : u32            → offset 16, size 4

--- a/libs/streamlib-engine/src/core/rhi/storage_buffer.rs
+++ b/libs/streamlib-engine/src/core/rhi/storage_buffer.rs
@@ -37,7 +37,7 @@ pub struct StorageBuffer {
     /// Opaque handle to the host's `Arc<HostVulkanBuffer>` (produced
     /// by `Arc::into_raw`).
     pub(crate) handle: *const c_void,
-    /// Vtable for cross-DSO Clone/Drop dispatch.
+    /// Vtable for plugin ABI Clone/Drop dispatch.
     pub(crate) vtable: *const GpuContextLimitedAccessVTable,
     /// Cached byte size (captured at construction).
     pub(crate) byte_size_cached: u64,
@@ -99,7 +99,7 @@ impl StorageBuffer {
             panic!(
                 "StorageBuffer::host_inner() reached from cdylib code; this method \
                  must dispatch through the GpuContextLimitedAccessVTable. The panic \
-                 is caught by run_host_extern_c at the FFI boundary."
+                 is caught by run_host_extern_c at the plugin ABI."
             );
         }
         // SAFETY: `self.handle` is `Arc::into_raw(Arc<HostVulkanBuffer>)`
@@ -109,13 +109,13 @@ impl StorageBuffer {
     }
 
     /// Total buffer size in bytes. Cached at construction; pure POD
-    /// read with no cross-DSO dispatch.
+    /// read with no plugin ABI dispatch.
     pub fn byte_size(&self) -> u64 {
         self.byte_size_cached
     }
 
     /// Persistently mapped CPU pointer for HOST_VISIBLE allocations.
-    /// Cached at construction; pure POD read with no cross-DSO
+    /// Cached at construction; pure POD read with no plugin ABI
     /// dispatch. Returns null for DEVICE_LOCAL imports (DMA-BUF
     /// without HOST_VISIBLE).
     pub fn mapped_ptr(&self) -> *mut u8 {
@@ -127,7 +127,7 @@ impl StorageBuffer {
     /// cdylib-mode dispatch paths
     /// (`RhiCommandRecorder::record_buffer_barrier` /
     /// `record_copy_image_to_buffer`) that need to forward the
-    /// underlying Arc-shaped pointer across the FFI without
+    /// underlying Arc-shaped pointer across the plugin ABI without
     /// reaching for `self.handle` directly.
     pub(crate) fn cdylib_handle(&self) -> *const c_void {
         self.handle

--- a/libs/streamlib-engine/src/core/rhi/texture.rs
+++ b/libs/streamlib-engine/src/core/rhi/texture.rs
@@ -5,7 +5,7 @@
 //!
 //! Layout-stable `(handle, vtable, cached POD)` shape: every field
 //! is either a primitive or an opaque pointer, so the type
-//! round-trips across the cdylib DSO boundary unchanged. The
+//! round-trips across the plugin ABI unchanged. The
 //! handle is `Arc::into_raw(Arc<TextureInner>)` produced by host
 //! code; the vtable's `clone_texture` / `drop_texture` callbacks
 //! manage the Arc refcount in host-compiled code, so Clone/Drop
@@ -91,7 +91,7 @@ impl<'a> TextureDescriptor<'a> {
 
 /// Host-only rich data backing a [`Texture`]. Cdylib code never sees
 /// this type; it reaches the public [`Texture`] surface through the
-/// `(handle, vtable, POD)` β-shape.
+/// `(handle, vtable, POD)` PluginAbiObject.
 ///
 /// Holds the platform-specific Arc(s) the engine RHI and surface
 /// adapters need (raw `VkImage`, `MTLTexture`, IOSurface, etc.).
@@ -161,14 +161,14 @@ impl TextureInner {
 /// Clone bumps the host's `Arc<TextureInner>` strong count via
 /// [`GpuContextLimitedAccessVTable::clone_texture`]; Drop decrements
 /// via [`GpuContextLimitedAccessVTable::drop_texture`]. Both run in
-/// host-compiled code regardless of the calling DSO.
+/// host-compiled code regardless of the calling plugin.
 #[repr(C)]
 pub struct Texture {
     /// Opaque handle to the host's `Arc<TextureInner>` (produced by
     /// `Arc::into_raw`).
     pub(crate) handle: *const c_void,
-    /// Vtable for cross-DSO Clone/Drop dispatch. Resolved through the
-    /// DSO-routed accessor at construction; host mode points at
+    /// Vtable for plugin ABI Clone/Drop dispatch. Resolved through the
+    /// plugin-ABI-routed accessor at construction; host mode points at
     /// `&HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE`, cdylib mode at the
     /// host-installed pointer from
     /// `HostServices::gpu_context_limited_access_vtable`.
@@ -228,17 +228,17 @@ impl Texture {
         }
     }
 
-    /// Assemble a [`Texture`] β-shape from a raw `Arc::into_raw`-
+    /// Assemble a [`Texture`] PluginAbiObject from a raw `Arc::into_raw`-
     /// shaped handle plus cached POD bytes. Used by cdylib-side
     /// dispatch paths that receive a freshly-cloned handle through
-    /// an FFI out-parameter (e.g.
+    /// a plugin ABI out-parameter (e.g.
     /// [`crate::core::context::TextureRing::acquire_next`] in cdylib
     /// mode) — the host wrapper bumped the texture's Arc through
     /// the limited-access vtable's `clone_texture` slot, and the
     /// returned [`Texture`] owns the matching `Drop`-side decrement
     /// when it falls out of scope.
     ///
-    /// The vtable pointer is resolved through the DSO-routed
+    /// The vtable pointer is resolved through the plugin-ABI-routed
     /// accessor [`crate::core::plugin::host_services::host_gpu_context_limited_access_vtable`]
     /// so cdylib code reaches the host's pointer (matching the
     /// `clone_texture` slot used to mint the handle) and host code
@@ -279,7 +279,7 @@ impl Texture {
     /// `TextureInner`'s layout, which is UB under the deployment model
     /// the plugin ABI supports.
     ///
-    /// The panic is caught by `run_host_extern_c` at the FFI boundary
+    /// The panic is caught by `run_host_extern_c` at the plugin ABI
     /// (host extern "C" callbacks all route through `catch_unwind`),
     /// so a misconfigured cdylib reaching this method gets a clean
     /// "callback panicked" log entry instead of UB.
@@ -288,7 +288,7 @@ impl Texture {
             panic!(
                 "Texture::host_inner() reached from cdylib code; this method must \
                  dispatch through the GpuContextLimitedAccessVTable. The panic is \
-                 caught by run_host_extern_c at the FFI boundary."
+                 caught by run_host_extern_c at the plugin ABI."
             );
         }
         // SAFETY: `self.handle` is `Arc::into_raw(Arc<TextureInner>)`
@@ -298,19 +298,19 @@ impl Texture {
     }
 
     /// Texture width in pixels. Cached at construction; pure field
-    /// read with no cross-DSO dispatch.
+    /// read with no plugin ABI dispatch.
     pub fn width(&self) -> u32 {
         self.width_cached
     }
 
     /// Texture height in pixels. Cached at construction; pure field
-    /// read with no cross-DSO dispatch.
+    /// read with no plugin ABI dispatch.
     pub fn height(&self) -> u32 {
         self.height_cached
     }
 
     /// Texture format. Cached at construction; pure field read with
-    /// no cross-DSO dispatch.
+    /// no plugin ABI dispatch.
     pub fn format(&self) -> TextureFormat {
         // SAFETY: `format_raw` is the `#[repr(u32)]` discriminant of a
         // `TextureFormat` value captured at construction. The mapping
@@ -338,7 +338,7 @@ impl Texture {
     /// Engine-internal: reads the host's `TextureInner` directly; cdylib
     /// callers reach this through future per-method vtable callbacks
     /// (not wired today — `host_inner()` panics with `catch_unwind` at
-    /// the FFI boundary).
+    /// the plugin ABI).
     pub fn iosurface_id(&self) -> Option<u32> {
         #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
@@ -357,7 +357,7 @@ impl Texture {
     ///
     /// Returns the appropriate handle type for the current platform:
     /// - macOS/iOS: `IOSurface { id }`
-    /// - Linux: `DmaBuf { fd }` (cross-DSO safe — dispatches through
+    /// - Linux: `DmaBuf { fd }` (plugin ABI safe — dispatches through
     ///   [`GpuContextLimitedAccessVTable::texture_native_dma_buf_fd`]
     ///   so cdylib subprocess adapters can export DMA-BUF FDs to a
     ///   different GPU API — CUDA, OpenGL, downstream IPC — without
@@ -373,7 +373,7 @@ impl Texture {
             // macOS cdylib adapter work resumes (#908 deferred list).
             // `host_inner()` panics in cdylib mode; the panic
             // propagates through the cdylib's Rust stack until it
-            // crosses the next FFI boundary (the plugin entry point
+            // crosses the next plugin ABI (the plugin entry point
             // or any host vtable callback the cdylib calls), where
             // `catch_unwind` converts it to a "callback panicked"
             // log entry instead of UB.
@@ -385,7 +385,7 @@ impl Texture {
         }
         #[cfg(target_os = "linux")]
         {
-            // Linux DMA-BUF export is cross-DSO safe: the slot returns
+            // Linux DMA-BUF export is plugin ABI safe: the slot returns
             // the FD as a primitive `i64` (sentinel `-1` encodes
             // `None`), which never crosses an Arc<TextureInner>
             // layout boundary. Host mode resolves the slot pointer
@@ -541,7 +541,7 @@ mod layout_tests {
 
     #[test]
     fn texture_layout() {
-        // Pin the byte-level shape of the cross-DSO
+        // Pin the byte-level shape of the plugin ABI
         // `Texture`. Fields:
         //   handle       : *const c_void  → offset 0,  size 8
         //   vtable       : *const VTable  → offset 8,  size 8

--- a/libs/streamlib-engine/src/core/rhi/uniform_buffer.rs
+++ b/libs/streamlib-engine/src/core/rhi/uniform_buffer.rs
@@ -24,7 +24,7 @@ use streamlib_plugin_abi::GpuContextLimitedAccessVTable;
 pub struct UniformBuffer {
     /// Opaque handle to the host's `Arc<HostVulkanBuffer>`.
     pub(crate) handle: *const c_void,
-    /// Vtable for cross-DSO Clone/Drop dispatch.
+    /// Vtable for plugin ABI Clone/Drop dispatch.
     pub(crate) vtable: *const GpuContextLimitedAccessVTable,
     /// Cached byte size.
     pub(crate) byte_size_cached: u64,

--- a/libs/streamlib-engine/src/core/rhi/vertex_buffer.rs
+++ b/libs/streamlib-engine/src/core/rhi/vertex_buffer.rs
@@ -23,7 +23,7 @@ use streamlib_plugin_abi::GpuContextLimitedAccessVTable;
 pub struct VertexBuffer {
     /// Opaque handle to the host's `Arc<HostVulkanBuffer>`.
     pub(crate) handle: *const c_void,
-    /// Vtable for cross-DSO Clone/Drop dispatch.
+    /// Vtable for plugin ABI Clone/Drop dispatch.
     pub(crate) vtable: *const GpuContextLimitedAccessVTable,
     /// Cached byte size.
     pub(crate) byte_size_cached: u64,

--- a/libs/streamlib-engine/src/core/runtime/runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/runtime.rs
@@ -219,8 +219,8 @@ impl Runner {
         // construction time lands in the unified JSONL pipeline. The
         // host's bridge value is the same `&'static dyn Log` that
         // [`crate::core::plugin::host_services`] hands to plugin cdylibs
-        // via `HostServices.iceoryx2_logger_ptr` so every DSO converges
-        // on a single logger.
+        // via `HostServices.iceoryx2_logger_ptr` so the host and every
+        // plugin converge on a single logger.
         crate::core::logging::iceoryx2_log_bridge::install_iceoryx2_log_bridge_for_self();
 
         // Create iceoryx2 Node early so PUBSUB can initialize before start().
@@ -479,7 +479,7 @@ impl Runner {
                 "[start] Initializing SurfaceStore against runtime-internal Unix socket '{}'...",
                 socket_path
             );
-            // `SurfaceStore::new` constructs the β-shape from a fresh
+            // `SurfaceStore::new` constructs the PluginAbiObject from a fresh
             // `Arc<SurfaceStoreInner>`. Method dispatch goes through
             // the host's `SurfaceStoreVTable`.
             let surface_store = SurfaceStore::new(

--- a/libs/streamlib-engine/src/host_rhi.rs
+++ b/libs/streamlib-engine/src/host_rhi.rs
@@ -99,11 +99,11 @@ pub trait HostTextureExt {
     /// in host mode reaches `vulkan_inner()` directly. Used by
     /// workspace plugin cdylibs that need to call
     /// `XxxSurfaceAdapter::register_host_surface` with a real
-    /// `Arc<HostVulkanTexture>` from a `Texture` β-shape (the
+    /// `Arc<HostVulkanTexture>` from a `Texture` PluginAbiObject (the
     /// `host_inner()` path panics in cdylib mode).
     ///
     /// **Rustc-version coupling.** `HostVulkanTexture` is not
-    /// `#[repr(C)]`; the cross-DSO Arc transit is safe only when the
+    /// `#[repr(C)]`; the plugin ABI Arc transit is safe only when the
     /// cdylib shares the host's rustc version and the engine's dep
     /// graph (workspace plugin cdylibs do; subprocess cdylibs
     /// — `streamlib-python-native`, `streamlib-deno-native` — don't
@@ -221,7 +221,7 @@ impl HostGpuDeviceExt for GpuDevice {
 /// # Boundary lock
 ///
 /// Without the trait in scope, the privileged accessors are
-/// unreachable from the [`SurfaceStore`] β-shape's inherent impl:
+/// unreachable from the [`SurfaceStore`] PluginAbiObject's inherent impl:
 ///
 /// ```compile_fail
 /// # #[cfg(target_os = "linux")]

--- a/libs/streamlib-engine/src/iceoryx2/input.rs
+++ b/libs/streamlib-engine/src/iceoryx2/input.rs
@@ -3,28 +3,28 @@
 
 //! Input mailboxes for receiving frames from upstream processors.
 //!
-//! # Two-type split: β-shape vs. inner
+//! # Two-type split: PluginAbiObject vs. inner
 //!
-//! Issue #894 retires the last shared-Rust-type plugin-ABI crossing
+//! Issue #894 retires the last shared-Rust-type plugin ABI crossing
 //! by splitting this module's public surface into two types:
 //!
 //! - [`InputMailboxesInner`] holds the actual state — the
 //!   `HashMap<port, PortConfig>` of per-port mailboxes plus the
 //!   thread-local `Subscriber` and `Listener` wrappers. All
 //!   per-frame `receive_pending` + mailbox push/pop work runs
-//!   here; only the host DSO references this type directly.
+//!   here; only the host references this type directly.
 //! - [`InputMailboxes`] is the public `#[repr(C)] { handle, vtable }`
-//!   β-shape that processor structs hold via the macro-emitted
+//!   PluginAbiObject that processor structs hold via the macro-emitted
 //!   `inputs: InputMailboxes` field. From inside `process()` the
 //!   cdylib reaches input data exclusively through `read` /
-//!   `read_raw` / `has_data` on this β-shape; the vtable dispatches
+//!   `read_raw` / `has_data` on this PluginAbiObject; the vtable dispatches
 //!   to the host-allocated inner.
 //!
 //! Host-side wiring code that needs to mutate the inner
 //! (`add_port`, `set_subscriber`, `set_listener`, `listener_fd`,
 //! `drain_listener`, etc.) operates on `Arc<InputMailboxesInner>`
 //! directly via the methods declared on the inner type — no
-//! β-shape, no FFI hop.
+//! PluginAbiObject, no plugin ABI hop.
 
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
@@ -133,9 +133,9 @@ struct PortConfig {
 /// mailbox map plus the per-thread subscriber + listener. All
 /// per-frame `receive_pending` + queue-pop work runs here.
 ///
-/// Never crosses the cdylib boundary. Held by the host via
+/// Never crosses the plugin ABI. Held by the host via
 /// `Arc<InputMailboxesInner>`; the cdylib's [`InputMailboxes`]
-/// β-shape stores a separate `Arc::into_raw`-encoded strong
+/// PluginAbiObject stores a separate `Arc::into_raw`-encoded strong
 /// reference to the same inner.
 pub struct InputMailboxesInner {
     ports: parking_lot::Mutex<HashMap<String, PortConfig>>,
@@ -395,10 +395,10 @@ impl Default for InputMailboxesInner {
 }
 
 // =============================================================================
-// InputMailboxes β-shape
+// InputMailboxes PluginAbiObject
 // =============================================================================
 
-/// Public input mailboxes β-shape. The macro emits
+/// Public input mailboxes PluginAbiObject. The macro emits
 /// `pub inputs: InputMailboxes` on every processor struct that
 /// declares input ports.
 ///
@@ -409,7 +409,7 @@ impl Default for InputMailboxesInner {
 /// `Clone` bumps the host-side `Arc<InputMailboxesInner>` strong
 /// count via [`InputMailboxesVTable::clone_arc`]; `Drop` decrements
 /// via [`InputMailboxesVTable::drop_arc`]. Both run in host-
-/// compiled code regardless of which DSO holds this β-shape.
+/// compiled code regardless of which artifact holds this PluginAbiObject.
 #[repr(C)]
 pub struct InputMailboxes {
     /// Opaque handle. In host mode: `Arc::into_raw(Arc<InputMailboxesInner>)`.
@@ -430,15 +430,15 @@ pub struct InputMailboxes {
 // SAFETY: `handle` points at an `Arc<InputMailboxesInner>` whose
 // interior is Send+Sync (the inner uses parking_lot::Mutex for
 // `ports` and the SendableSubscriber/SendableListener wrappers
-// declare Send+Sync above). Refcount management crosses the cdylib
-// boundary through the host-installed refcount fn pointers; the
+// declare Send+Sync above). Refcount management crosses the plugin
+// ABI through the host-installed refcount fn pointers; the
 // underlying Arc bookkeeping runs in host-compiled code.
 unsafe impl Send for InputMailboxes {}
 unsafe impl Sync for InputMailboxes {}
 
 impl InputMailboxes {
-    /// Build a host-mode β-shape from an `Arc<InputMailboxesInner>`.
-    /// The strong reference is consumed; the β-shape owns it for
+    /// Build a host-mode PluginAbiObject from an `Arc<InputMailboxesInner>`.
+    /// The strong reference is consumed; the PluginAbiObject owns it for
     /// its lifetime and releases on Drop.
     pub fn from_inner_arc(inner: Arc<InputMailboxesInner>) -> Self {
         let handle = Arc::into_raw(inner) as *const c_void;
@@ -446,7 +446,7 @@ impl InputMailboxes {
         Self { handle, vtable }
     }
 
-    /// Build an empty pre-wiring β-shape with null handle and
+    /// Build an empty pre-wiring PluginAbiObject with null handle and
     /// null vtable. The host patches in real values via
     /// `ProcessorVTable::set_iceoryx2_resources`.
     pub fn empty() -> Self {
@@ -465,14 +465,14 @@ impl InputMailboxes {
         Self { handle, vtable }
     }
 
-    /// Returns true iff this β-shape has been wired to a real
+    /// Returns true iff this PluginAbiObject has been wired to a real
     /// host-allocated inner.
     pub fn is_configured(&self) -> bool {
         !self.handle.is_null() && !self.vtable.is_null()
     }
 
     /// Borrow the host-side `Arc<InputMailboxesInner>` this
-    /// β-shape points at. Returns `None` for unwired β-shapes.
+    /// PluginAbiObject points at. Returns `None` for unwired PluginAbiObjects.
     /// Bumps the strong count via the vtable's `clone_arc`; the
     /// returned Arc balances with one Drop on the inner.
     pub fn inner_arc(&self) -> Option<Arc<InputMailboxesInner>> {
@@ -771,7 +771,7 @@ mod tests {
         );
     }
 
-    /// Empty (unwired) β-shape should return Ok(None) from read_raw
+    /// Empty (unwired) PluginAbiObject should return Ok(None) from read_raw
     /// rather than crash. Mentally revert the is_configured guard
     /// and the test panics dereferencing a null vtable.
     #[test]

--- a/libs/streamlib-engine/src/iceoryx2/output.rs
+++ b/libs/streamlib-engine/src/iceoryx2/output.rs
@@ -3,30 +3,30 @@
 
 //! Output writer for sending frames to downstream processors.
 //!
-//! # Two-type split: β-shape vs. inner
+//! # Two-type split: PluginAbiObject vs. inner
 //!
-//! Issue #894 retires the last shared-Rust-type plugin-ABI crossing
+//! Issue #894 retires the last shared-Rust-type plugin ABI crossing
 //! by splitting this module's public surface into two types:
 //!
 //! - [`OutputWriterInner`] holds the actual state — the
 //!   `Mutex<HashMap<port, Vec<DownstreamConnection>>>` and the
 //!   iceoryx2 publish + notify logic. It runs entirely in the
-//!   host DSO; cdylib code never references this type directly.
+//!   host; cdylib code never references this type directly.
 //! - [`OutputWriter`] is the public `#[repr(C)] { handle, vtable }`
-//!   β-shape that processor structs hold via the macro-emitted
+//!   PluginAbiObject that processor structs hold via the macro-emitted
 //!   `outputs: OutputWriter` field. In host mode the vtable
 //!   resolves to the host's static
 //!   `HOST_OUTPUT_WRITER_VTABLE`; in cdylib mode it points at the
 //!   host-installed pointer from
 //!   `HostServices::output_writer_vtable`. Either way the methods
-//!   on the β-shape (`write`, `write_raw`, `has_port`, `clone`,
+//!   on the PluginAbiObject (`write`, `write_raw`, `has_port`, `clone`,
 //!   `drop`) dispatch through the vtable to the host-allocated
 //!   inner.
 //!
 //! Host-side code that needs to mutate the inner (e.g. compiler ops
 //! adding downstream connections at wiring time) operates on
 //! `Arc<OutputWriterInner>` directly via
-//! [`OutputWriterInner::add_connection`] — no β-shape, no FFI hop.
+//! [`OutputWriterInner::add_connection`] — no PluginAbiObject, no plugin ABI hop.
 //! The cdylib's per-frame `write` calls cross extern "C" exactly
 //! once per emit (sub-microsecond on amd64; see the PR microbench
 //! for issue #894).
@@ -61,8 +61,8 @@ struct DownstreamConnection {
 /// per-port-name `HashMap` and the iceoryx2 publishers and
 /// notifiers; all per-frame publish + notify work runs here.
 ///
-/// Never crosses the cdylib boundary. Held by the host via
-/// `Arc<OutputWriterInner>`; the cdylib's [`OutputWriter`] β-shape
+/// Never crosses the plugin ABI. Held by the host via
+/// `Arc<OutputWriterInner>`; the cdylib's [`OutputWriter`] PluginAbiObject
 /// stores a separate `Arc::into_raw`-encoded strong reference to
 /// the same inner.
 pub struct OutputWriterInner {
@@ -116,7 +116,7 @@ impl OutputWriterInner {
     /// Write raw bytes to the specified output port without serialization.
     ///
     /// The data is assumed to be pre-serialized (e.g., msgpack from a
-    /// subprocess bridge OR the β-shape's serialize-then-FFI path).
+    /// subprocess bridge OR the PluginAbiObject's serialize-then-plugin-ABI path).
     pub fn write_raw(&self, port: &str, data: &[u8], timestamp_ns: i64) -> Result<()> {
         let connections = self.connections.lock();
         let port_connections = connections
@@ -175,10 +175,10 @@ impl Default for OutputWriterInner {
 }
 
 // =============================================================================
-// OutputWriter β-shape
+// OutputWriter PluginAbiObject
 // =============================================================================
 
-/// Public output writer β-shape. The macro emits
+/// Public output writer PluginAbiObject. The macro emits
 /// `pub outputs: OutputWriter` on every processor struct that
 /// declares output ports.
 ///
@@ -189,7 +189,7 @@ impl Default for OutputWriterInner {
 /// `Clone` bumps the host-side `Arc<OutputWriterInner>` strong
 /// count via [`OutputWriterVTable::clone_arc`]; `Drop` decrements
 /// via [`OutputWriterVTable::drop_arc`]. Both run in host-compiled
-/// code regardless of which DSO holds this β-shape.
+/// code regardless of which artifact holds this PluginAbiObject.
 #[repr(C)]
 pub struct OutputWriter {
     /// Opaque handle. In host mode: `Arc::into_raw(Arc<OutputWriterInner>)`.
@@ -210,15 +210,15 @@ pub struct OutputWriter {
 
 // SAFETY: `handle` points at an `Arc<OutputWriterInner>` whose
 // interior is Send+Sync (OutputWriterInner declares both above).
-// Refcount management crosses the cdylib boundary through the
+// Refcount management crosses the plugin ABI through the
 // vtable but the underlying Arc bookkeeping runs in host-compiled
 // code regardless.
 unsafe impl Send for OutputWriter {}
 unsafe impl Sync for OutputWriter {}
 
 impl OutputWriter {
-    /// Build a host-mode β-shape from an `Arc<OutputWriterInner>`.
-    /// The strong reference is consumed; the β-shape owns it for
+    /// Build a host-mode PluginAbiObject from an `Arc<OutputWriterInner>`.
+    /// The strong reference is consumed; the PluginAbiObject owns it for
     /// its lifetime and releases on Drop.
     ///
     /// Engine-only — used by the host's processor wiring path
@@ -231,11 +231,11 @@ impl OutputWriter {
         Self { handle, vtable }
     }
 
-    /// Build an empty pre-wiring β-shape with null handle and
+    /// Build an empty pre-wiring PluginAbiObject with null handle and
     /// null vtable. The host patches in real values via
     /// `ProcessorVTable::set_iceoryx2_resources` before any
     /// downstream connection wiring runs. Method calls on the
-    /// empty β-shape return cleanly with no-op semantics
+    /// empty PluginAbiObject return cleanly with no-op semantics
     /// (matches today's pre-wiring behaviour of an empty
     /// `OutputWriter::new()`).
     pub fn empty() -> Self {
@@ -247,7 +247,7 @@ impl OutputWriter {
 
     /// Raw-pointer construction used by
     /// `ProcessorVTable::set_iceoryx2_resources` host wiring to
-    /// patch an existing β-shape's fields without owning a typed
+    /// patch an existing PluginAbiObject's fields without owning a typed
     /// `Arc<OutputWriterInner>`.
     pub(crate) fn from_raw_parts(
         handle: *const c_void,
@@ -256,14 +256,14 @@ impl OutputWriter {
         Self { handle, vtable }
     }
 
-    /// Returns true iff this β-shape has been wired to a real
+    /// Returns true iff this PluginAbiObject has been wired to a real
     /// host-allocated inner.
     pub fn is_configured(&self) -> bool {
         !self.handle.is_null() && !self.vtable.is_null()
     }
 
-    /// Borrow the host-side `Arc<OutputWriterInner>` this β-shape
-    /// points at. Returns `None` for unwired β-shapes. Bumps the
+    /// Borrow the host-side `Arc<OutputWriterInner>` this PluginAbiObject
+    /// points at. Returns `None` for unwired PluginAbiObjects. Bumps the
     /// strong count via the vtable's `clone_arc`; the returned
     /// Arc balances with one Drop on the inner.
     ///
@@ -291,7 +291,7 @@ impl OutputWriter {
     /// Write a frame to the specified output port.
     ///
     /// Source-compatible with the pre-#894 `OutputWriter::write` —
-    /// the cdylib serializes `T` to msgpack in its own DSO then
+    /// the cdylib serializes `T` to msgpack in its own plugin then
     /// crosses extern "C" once with the bytes. Thread-safe.
     pub fn write<T: Serialize>(&self, port: &str, value: &T) -> Result<()> {
         let timestamp_ns = MediaClock::now().as_nanos() as i64;
@@ -388,7 +388,7 @@ impl Drop for OutputWriter {
         // SAFETY: vtable + handle are non-null per is_configured().
         // After dispatch, null out the local fields so a double-
         // drop becomes a no-op (mirrors the Texture / PixelBuffer
-        // β-shape pattern).
+        // PluginAbiObject pattern).
         unsafe {
             ((*self.vtable).drop_arc)(self.handle);
         }

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_acceleration_structure.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_acceleration_structure.rs
@@ -39,7 +39,7 @@ pub enum AccelerationStructureKind {
 /// the hit shader can read via `gl_InstanceCustomIndexEXT`, a visibility
 /// mask, an SBT record offset, and the BLAS this instance points to.
 ///
-/// The BLAS reference is by `VulkanAccelerationStructure` β-shape so the
+/// The BLAS reference is by `VulkanAccelerationStructure` PluginAbiObject so the
 /// lifetime contract is "the TLAS holds a strong reference to every
 /// referenced BLAS for as long as the TLAS lives."
 #[derive(Clone)]
@@ -87,7 +87,7 @@ pub const IDENTITY_TRANSFORM: [[f32; 4]; 3] = [
 
 /// Host-only rich data backing a [`VulkanAccelerationStructure`].
 /// Cdylib code never sees this type; it reaches the public surface
-/// through the `(handle, vtable)` β-shape.
+/// through the `(handle, vtable)` PluginAbiObject.
 pub(crate) struct VulkanAccelerationStructureInner {
     label: String,
     kind: AccelerationStructureKind,
@@ -120,9 +120,9 @@ pub(crate) struct VulkanAccelerationStructureInner {
 pub struct VulkanAccelerationStructure {
     /// Opaque handle to the host's `Arc<VulkanAccelerationStructureInner>`.
     pub(crate) handle: *const c_void,
-    /// Parent vtable for cross-DSO Clone/Drop dispatch (#918 Phase D).
+    /// Parent vtable for plugin ABI Clone/Drop dispatch (#918 Phase D).
     pub(crate) vtable: *const GpuContextFullAccessVTable,
-    /// Per-type vtable for cross-DSO method dispatch (#907 Phase E).
+    /// Per-type vtable for plugin ABI method dispatch (#907 Phase E).
     pub(crate) methods_vtable:
         *const streamlib_plugin_abi::VulkanAccelerationStructureMethodsVTable,
     /// Cached AS kind discriminant (0 = BottomLevel, 1 = TopLevel).
@@ -515,8 +515,8 @@ impl VulkanAccelerationStructureInner {
             }
 
             // vulkanalia's `cmd_build_acceleration_structures_khr` wrapper has
-            // a Rust→C ABI mismatch: it accepts `&[&[T]]` (slice of fat-pointer
-            // slots, 16 bytes each on 64-bit) where the C signature is
+            // a Rust→C ABI mismatch: it accepts `&[&[T]]` (slice of two-word
+            // slice-reference slots, 16 bytes each on 64-bit) where the C signature is
             // `*const *const T` (array of thin pointers, 8 bytes each), and
             // casts the Rust slice pointer directly without rebuilding the
             // thin-pointer array. Workaround: build the thin-pointer array by
@@ -677,13 +677,13 @@ impl std::fmt::Debug for VulkanAccelerationStructureInner {
 }
 
 // =============================================================================
-// β-shape implementation
+// PluginAbiObject implementation
 // =============================================================================
 
 impl VulkanAccelerationStructure {
     /// Internal helper: leak an initial Arc strong count via
     /// `Arc::into_raw`, resolve the host-mode FullAccess vtable, and
-    /// assemble the cross-DSO shape.
+    /// assemble the plugin ABI shape.
     pub(crate) fn from_arc_into_raw(arc: Arc<VulkanAccelerationStructureInner>) -> Self {
         let cached_kind = match arc.kind() {
             AccelerationStructureKind::BottomLevel => 0u32,
@@ -751,7 +751,7 @@ impl VulkanAccelerationStructure {
 
     /// `VkAccelerationStructureKHR` handle. **Engine-internal** — the
     /// vulkanalia handle layout couples to the vulkanalia minor
-    /// version and isn't safe to surface across a DSO boundary.
+    /// version and isn't safe to surface across the plugin ABI.
     /// There is no in-tree cdylib consumer that reads this; every
     /// binding flows through the ray-tracing kernel's
     /// `set_acceleration_structure` slot, which dereferences the AS
@@ -883,7 +883,7 @@ mod layout_tests {
 
     #[test]
     fn vulkan_acceleration_structure_layout() {
-        // β-shape struct as of #907 PR 5/5:
+        // PluginAbiObject struct as of #907 PR 5/5:
         //   handle                @ 0  (8 bytes, *const c_void)
         //   vtable                @ 8  (8 bytes, *const GpuContextFullAccessVTable)
         //   methods_vtable        @ 16 (8 bytes, *const VulkanAccelerationStructureMethodsVTable)

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_buffer_binding.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_buffer_binding.rs
@@ -37,9 +37,9 @@ pub trait VulkanBufferLike {
     fn vk_buffer_size(&self) -> vk::DeviceSize;
 
     /// Cdylib-mode handle accessor: if this buffer flavor is
-    /// reachable as a [`crate::core::rhi::StorageBuffer`] β-shape,
+    /// reachable as a [`crate::core::rhi::StorageBuffer`] PluginAbiObject,
     /// return the underlying `Arc::into_raw(Arc<HostVulkanBufferInner>)`
-    /// pointer for cross-DSO dispatch (Phase E sub-lift slice B —
+    /// pointer for plugin ABI dispatch (Phase E sub-lift slice B —
     /// #984). Default is `None`; only [`crate::core::rhi::StorageBuffer`]
     /// overrides today. The cdylib-side
     /// [`crate::vulkan::rhi::RhiCommandRecorder::record_buffer_barrier`]
@@ -49,7 +49,7 @@ pub trait VulkanBufferLike {
         None
     }
 
-    /// Cdylib-mode handle accessor for the [`PixelBuffer`] β-shape
+    /// Cdylib-mode handle accessor for the [`PixelBuffer`] PluginAbiObject
     /// (issue #988 sibling-slot extension of Phase E sub-lift slice
     /// B). Returns the underlying
     /// `Arc::into_raw(Arc<PixelBufferRef>)` pointer when this buffer

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
@@ -107,7 +107,7 @@ enum RecorderState {
 /// in-flight slot.
 /// Host-only rich data backing a [`RhiCommandRecorder`]. Cdylib code
 /// never sees this type; it reaches the public surface through the
-/// `(handle, vtable)` β-shape.
+/// `(handle, vtable)` PluginAbiObject.
 pub struct RhiCommandRecorderInner {
     label: String,
     vulkan_device: Arc<HostVulkanDevice>,
@@ -650,7 +650,7 @@ impl RhiCommandRecorderInner {
 
     /// Record a layout transition on a raw `VkImage` handle.
     /// Distinct from [`Self::record_image_barrier`] which takes a
-    /// `Texture` β-shape; this variant is used by
+    /// `Texture` PluginAbiObject; this variant is used by
     /// [`VulkanPresentTarget`](super::vulkan_present_target::VulkanPresentTarget)
     /// for swapchain images (which are never wrapped in a `Texture`).
     /// COLOR aspect, single mip / single layer, QUEUE_FAMILY_IGNORED
@@ -893,12 +893,12 @@ impl std::fmt::Debug for RhiCommandRecorderInner {
 }
 
 // =============================================================================
-// β-shape implementation
+// PluginAbiObject implementation
 // =============================================================================
 
 /// Multi-step command-buffer recorder.
 ///
-/// Layout-stable `#[repr(C)] (handle, vtable)` β-shape. The opaque
+/// Layout-stable `#[repr(C)] (handle, vtable)` PluginAbiObject. The opaque
 /// handle points at a `Box<RhiCommandRecorderInner>`; lifecycle
 /// dispatches through the host-installed FullAccess vtable's
 /// `drop_command_recorder` callback (Box::from_raw + drop host-side).
@@ -907,7 +907,7 @@ impl std::fmt::Debug for RhiCommandRecorderInner {
 /// mutable state (`begin()` → `record_*(&mut self)` → `submit_*(&mut
 /// self)`) that doesn't survive duplication. The
 /// `clone_command_recorder` vtable slot is reserved but never invoked
-/// — calling `.clone()` on the public β-shape is a compile error,
+/// — calling `.clone()` on the public PluginAbiObject is a compile error,
 /// locked by the `compile_fail` doctest below:
 ///
 /// ```compile_fail
@@ -937,9 +937,9 @@ impl std::fmt::Debug for RhiCommandRecorderInner {
 pub struct RhiCommandRecorder {
     /// Opaque handle to the host's `Box<RhiCommandRecorderInner>`.
     pub(crate) handle: *const c_void,
-    /// Parent vtable for cross-DSO Drop dispatch.
+    /// Parent vtable for plugin ABI Drop dispatch.
     pub(crate) vtable: *const GpuContextFullAccessVTable,
-    /// Per-type vtable for cross-DSO method dispatch (Phase E
+    /// Per-type vtable for plugin ABI method dispatch (Phase E
     /// sub-lift slice B — #984). Null in host mode; populated by
     /// [`Self::from_inner`] via
     /// [`crate::core::plugin::host_services::host_rhi_command_recorder_methods_vtable`].
@@ -1976,9 +1976,9 @@ mod layout_tests {
     #[test]
     fn rhi_command_recorder_layout() {
         // Phase E sub-lift slice B (#984) appended `methods_vtable`
-        // (16 → 24 bytes); the β-shape now mirrors the
+        // (16 → 24 bytes); the PluginAbiObject now mirrors the
         // `(handle, vtable, methods_vtable)` triple used by every
-        // per-type kernel β-shape and `RhiColorConverter`.
+        // per-type kernel PluginAbiObject and `RhiColorConverter`.
         assert_eq!(size_of::<RhiCommandRecorder>(), 24);
         assert_eq!(align_of::<RhiCommandRecorder>(), 8);
         assert_eq!(offset_of!(RhiCommandRecorder, handle), 0);
@@ -2294,7 +2294,7 @@ mod tests {
             submit_and_wait: stub_submit_and_wait,
         };
 
-        // Synthetic β-shape with our fake vtable. handle/vtable can stay null
+        // Synthetic PluginAbiObject with our fake vtable. handle/vtable can stay null
         // because the capture function never dereferences them.
         let beta = RhiCommandRecorder {
             handle: std::ptr::null(),

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
@@ -48,7 +48,7 @@ use super::HostVulkanDevice;
 /// this abstraction targets.
 /// Host-only rich data backing a [`VulkanComputeKernel`]. Cdylib code
 /// never sees this type; it reaches the public surface through the
-/// `(handle, vtable)` β-shape.
+/// `(handle, vtable)` PluginAbiObject.
 pub struct VulkanComputeKernelInner {
     label: String,
     vulkan_device: Arc<HostVulkanDevice>,
@@ -992,17 +992,17 @@ impl std::fmt::Debug for VulkanComputeKernelInner {
 }
 
 // =============================================================================
-// β-shape implementation (#917)
+// PluginAbiObject implementation (#917)
 // =============================================================================
 
-/// Compute kernel — layout-stable `#[repr(C)]` β-shape so cdylibs
+/// Compute kernel — layout-stable `#[repr(C)]` PluginAbiObject so cdylibs
 /// can hold, refcount, drop, and read POD descriptors without
 /// sharing rustc-version or dep-graph with the host.
 ///
 /// The opaque handle points at an `Arc<VulkanComputeKernelInner>`;
 /// lifecycle (Clone / Drop) dispatches through the host-installed
 /// parent [`GpuContextFullAccessVTable`]'s `clone_compute_kernel` /
-/// `drop_compute_kernel` callbacks (locked by PR #918's β-shape
+/// `drop_compute_kernel` callbacks (locked by PR #918's PluginAbiObject
 /// Phase D work). Per-method dispatch is reached through the
 /// dedicated
 /// [`streamlib_plugin_abi::VulkanComputeKernelMethodsVTable`] pointed
@@ -1013,16 +1013,16 @@ impl std::fmt::Debug for VulkanComputeKernelInner {
 /// test.
 ///
 /// The `push_constant_size()` POD getter reads from the cached
-/// field — no FFI hop. The value is captured by
+/// field — no plugin ABI hop. The value is captured by
 /// [`Self::from_arc_into_raw`] at construction and never mutates
 /// over the kernel's lifetime.
 #[repr(C)]
 pub struct VulkanComputeKernel {
     /// Opaque handle to the host's `Arc<VulkanComputeKernelInner>`.
     pub(crate) handle: *const c_void,
-    /// Parent vtable for cross-DSO Clone/Drop dispatch (#918 Phase D).
+    /// Parent vtable for plugin ABI Clone/Drop dispatch (#918 Phase D).
     pub(crate) vtable: *const GpuContextFullAccessVTable,
-    /// Per-type vtable for cross-DSO method dispatch (#907 Phase E).
+    /// Per-type vtable for plugin ABI method dispatch (#907 Phase E).
     pub(crate) methods_vtable:
         *const streamlib_plugin_abi::VulkanComputeKernelMethodsVTable,
     /// Cached push-constant size in bytes. Set at construction; fixed
@@ -1105,9 +1105,9 @@ impl VulkanComputeKernel {
     /// buffer allocations carry `STORAGE_BUFFER` usage from birth.
     ///
     /// Per-input-type concrete shape (no generic) so the cdylib path
-    /// can dispatch via the matching typed FFI slot
+    /// can dispatch via the matching typed plugin ABI slot
     /// (`set_storage_buffer_pixel`) without a kind discriminator.
-    /// Mirrors the production cross-DSO pattern in Dawn / WebGPU
+    /// Mirrors the production plugin ABI pattern in Dawn / WebGPU
     /// (`wgpuComputePassEncoderSetBindGroup` family) and Unreal RHI
     /// (typed `SetShaderResourceViewParameter`).
     pub fn set_storage_buffer_pixel(
@@ -1235,7 +1235,7 @@ impl VulkanComputeKernel {
     pub fn set_push_constants_value<T: Copy>(&self, value: &T) -> Result<()> {
         if crate::core::plugin::host_services::host_callbacks().is_some() {
             // SAFETY: T is Copy + Sized so its layout is stable; the
-            // byte view is read-only and consumed inside the FFI call.
+            // byte view is read-only and consumed inside the plugin ABI call.
             let bytes = unsafe {
                 std::slice::from_raw_parts(
                     value as *const T as *const u8,
@@ -1664,7 +1664,7 @@ impl VulkanComputeKernel {
     /// Kernel's declared binding shape. Mode-routed: host-mode reads
     /// directly from `host_inner`; cdylib-mode dispatches through the
     /// v4 `bindings` slot on the per-type methods vtable. On cdylib-
-    /// side FFI errors (null vtable, malformed err_buf, host panic) the
+    /// side plugin ABI errors (null vtable, malformed err_buf, host panic) the
     /// method emits a `tracing::warn` and returns an empty Vec — the
     /// public signature predates the introspection vtable and isn't
     /// fallible at the type level.
@@ -1757,7 +1757,7 @@ impl VulkanComputeKernel {
             .collect()
     }
 
-    /// Push-constant range size in bytes. Cached POD — no FFI hop.
+    /// Push-constant range size in bytes. Cached POD — no plugin ABI hop.
     pub fn push_constant_size(&self) -> u32 {
         self.cached_push_constant_size
     }
@@ -1797,13 +1797,13 @@ impl std::fmt::Debug for VulkanComputeKernel {
 }
 
 #[cfg(all(test, target_pointer_width = "64"))]
-mod beta_shape_layout_tests {
+mod plugin_abi_object_layout_tests {
     use super::*;
     use core::mem::{align_of, offset_of, size_of};
 
     #[test]
     fn vulkan_compute_kernel_layout() {
-        // β-shape struct as of #907 PR 2/5:
+        // PluginAbiObject struct as of #907 PR 2/5:
         //   handle                       @ 0  (8 bytes, *const c_void)
         //   vtable                       @ 8  (8 bytes, *const GpuContextFullAccessVTable)
         //   methods_vtable               @ 16 (8 bytes, *const VulkanComputeKernelMethodsVTable)

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_graphics_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_graphics_kernel.rs
@@ -65,7 +65,7 @@ pub const PIPELINE_CACHE_DIR_ENV: &str = "STREAMLIB_PIPELINE_CACHE_DIR";
 
 /// Host-only rich data backing a [`VulkanGraphicsKernel`]. Cdylib code
 /// never sees this type; it reaches the public surface through the
-/// `(handle, vtable)` β-shape.
+/// `(handle, vtable)` PluginAbiObject.
 pub struct VulkanGraphicsKernelInner {
     label: String,
     vulkan_device: Arc<HostVulkanDevice>,
@@ -1265,19 +1265,19 @@ impl std::fmt::Debug for VulkanGraphicsKernelInner {
 }
 
 // =============================================================================
-// β-shape implementation (#917)
+// PluginAbiObject implementation (#917)
 // =============================================================================
 
-/// Graphics kernel — layout-stable `#[repr(C)]` β-shape (#907 Phase
+/// Graphics kernel — layout-stable `#[repr(C)]` PluginAbiObject (#907 Phase
 /// E PR 3/5). Mirrors `VulkanComputeKernel`'s shape: handle + parent
 /// vtable + per-type methods vtable + cached PODs.
 #[repr(C)]
 pub struct VulkanGraphicsKernel {
     /// Opaque handle to the host's `Arc<VulkanGraphicsKernelInner>`.
     pub(crate) handle: *const c_void,
-    /// Parent vtable for cross-DSO Clone/Drop dispatch (#918 Phase D).
+    /// Parent vtable for plugin ABI Clone/Drop dispatch (#918 Phase D).
     pub(crate) vtable: *const GpuContextFullAccessVTable,
-    /// Per-type vtable for cross-DSO method dispatch (#907 Phase E).
+    /// Per-type vtable for plugin ABI method dispatch (#907 Phase E).
     pub(crate) methods_vtable:
         *const streamlib_plugin_abi::VulkanGraphicsKernelMethodsVTable,
     /// Cached push-constant size in bytes. Set at construction.
@@ -1328,7 +1328,7 @@ impl VulkanGraphicsKernel {
     /// Kernel's declared binding shape. Mode-routed: host-mode reads
     /// directly from `host_inner`; cdylib-mode dispatches through the
     /// v3 `bindings` slot on the per-type methods vtable. On cdylib-
-    /// side FFI errors the method emits a `tracing::warn` and returns
+    /// side plugin ABI errors the method emits a `tracing::warn` and returns
     /// an empty Vec.
     pub fn bindings(&self) -> Vec<GraphicsBindingSpec> {
         if crate::core::plugin::host_services::host_callbacks().is_some() {
@@ -1416,12 +1416,12 @@ impl VulkanGraphicsKernel {
             .collect()
     }
 
-    /// Push-constant range size in bytes. Cached POD — no FFI hop.
+    /// Push-constant range size in bytes. Cached POD — no plugin ABI hop.
     pub fn push_constant_size(&self) -> u32 {
         self.cached_push_constant_size
     }
 
-    /// Descriptor-set ring depth. Cached POD — no FFI hop.
+    /// Descriptor-set ring depth. Cached POD — no plugin ABI hop.
     pub fn descriptor_sets_in_flight(&self) -> u32 {
         self.cached_descriptor_sets_in_flight
     }
@@ -1445,7 +1445,7 @@ impl VulkanGraphicsKernel {
     /// Bind a [`crate::core::rhi::PixelBuffer`]-shaped storage
     /// buffer (SSBO) at `(frame_index, binding)`. Per-input-type
     /// concrete shape (no generic) so the cdylib path can dispatch
-    /// via the matching typed FFI slot
+    /// via the matching typed plugin ABI slot
     /// (`set_storage_buffer_pixel`) without a kind discriminator.
     /// Mirrors `VulkanComputeKernel::set_storage_buffer_pixel`.
     pub fn set_storage_buffer_pixel(
@@ -1532,7 +1532,7 @@ impl VulkanGraphicsKernel {
     ) -> Result<()> {
         if crate::core::plugin::host_services::host_callbacks().is_some() {
             // SAFETY: T is Copy + Sized — the byte view is read-only
-            // and consumed inside the FFI call. Caller is responsible
+            // and consumed inside the plugin ABI call. Caller is responsible
             // for ensuring T is POD (no padding holding `uninit`
             // bytes, no internal references, no Drop) since the
             // push-constant slot the bytes land in is read verbatim
@@ -1949,7 +1949,7 @@ impl VulkanGraphicsKernel {
             ));
         }
 
-        // Marshal color targets into the FFI's parallel-array shape.
+        // Marshal color targets into the plugin ABI's parallel-array shape.
         let mut handles: Vec<*const c_void> = Vec::with_capacity(color_targets.len());
         let mut present_flags: Vec<u32> = Vec::with_capacity(color_targets.len());
         let mut clear_values: Vec<[f32; 4]> = Vec::with_capacity(color_targets.len());
@@ -2298,13 +2298,13 @@ impl std::fmt::Debug for VulkanGraphicsKernel {
 }
 
 #[cfg(all(test, target_pointer_width = "64"))]
-mod beta_shape_layout_tests {
+mod plugin_abi_object_layout_tests {
     use super::*;
     use core::mem::{align_of, offset_of, size_of};
 
     #[test]
     fn vulkan_graphics_kernel_layout() {
-        // β-shape struct as of #907 PR 3/5:
+        // PluginAbiObject struct as of #907 PR 3/5:
         //   handle                              @ 0  (8 bytes, *const c_void)
         //   vtable                              @ 8  (8 bytes, *const GpuContextFullAccessVTable)
         //   methods_vtable                      @ 16 (8 bytes, *const VulkanGraphicsKernelMethodsVTable)

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_ray_tracing_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_ray_tracing_kernel.rs
@@ -44,7 +44,7 @@ use super::{HostVulkanDevice, VulkanAccelerationStructure};
 
 /// Host-only rich data backing a [`VulkanRayTracingKernel`]. Cdylib code
 /// never sees this type; it reaches the public surface through the
-/// `(handle, vtable)` β-shape.
+/// `(handle, vtable)` PluginAbiObject.
 pub struct VulkanRayTracingKernelInner {
     label: String,
     vulkan_device: Arc<HostVulkanDevice>,
@@ -100,8 +100,8 @@ enum BindingResource {
     },
     AccelerationStructure {
         handle: vk::AccelerationStructureKHR,
-        // The β-shape clone keeps the AS alive while bound (β-shape's
-        // Clone bumps the underlying Arc strong count via vtable).
+        // The PluginAbiObject clone keeps the AS alive while bound (the
+        // PluginAbiObject's Clone bumps the underlying Arc strong count via vtable).
         _keep_alive: VulkanAccelerationStructure,
     },
 }
@@ -909,18 +909,18 @@ impl std::fmt::Debug for VulkanRayTracingKernelInner {
 }
 
 // =============================================================================
-// β-shape implementation (#917)
+// PluginAbiObject implementation (#917)
 // =============================================================================
 
-/// Ray-tracing kernel — layout-stable `#[repr(C)]` β-shape (#907
+/// Ray-tracing kernel — layout-stable `#[repr(C)]` PluginAbiObject (#907
 /// Phase E PR 4/5). Mirrors the compute kernel shape.
 #[repr(C)]
 pub struct VulkanRayTracingKernel {
     /// Opaque handle to the host's `Arc<VulkanRayTracingKernelInner>`.
     pub(crate) handle: *const c_void,
-    /// Parent vtable for cross-DSO Clone/Drop dispatch (#918 Phase D).
+    /// Parent vtable for plugin ABI Clone/Drop dispatch (#918 Phase D).
     pub(crate) vtable: *const GpuContextFullAccessVTable,
-    /// Per-type vtable for cross-DSO method dispatch (#907 Phase E).
+    /// Per-type vtable for plugin ABI method dispatch (#907 Phase E).
     pub(crate) methods_vtable:
         *const streamlib_plugin_abi::VulkanRayTracingKernelMethodsVTable,
     /// Cached push-constant size in bytes. Set at construction.
@@ -982,7 +982,7 @@ impl VulkanRayTracingKernel {
     /// Bind a [`crate::core::rhi::PixelBuffer`]-shaped storage
     /// buffer (SSBO) at `binding`. Per-input-type concrete shape
     /// (no generic) so the cdylib path can dispatch via the
-    /// matching typed FFI slot (`set_storage_buffer_pixel`)
+    /// matching typed plugin ABI slot (`set_storage_buffer_pixel`)
     /// without a kind discriminator. Mirrors
     /// `VulkanComputeKernel::set_storage_buffer_pixel`.
     pub fn set_storage_buffer_pixel(
@@ -1048,7 +1048,7 @@ impl VulkanRayTracingKernel {
     pub fn set_push_constants_value<T: Copy>(&self, value: &T) -> Result<()> {
         if crate::core::plugin::host_services::host_callbacks().is_some() {
             // SAFETY: T is Copy + Sized so its layout is stable; the
-            // byte view is read-only and consumed inside the FFI call.
+            // byte view is read-only and consumed inside the plugin ABI call.
             let bytes = unsafe {
                 std::slice::from_raw_parts(
                     value as *const T as *const u8,
@@ -1070,7 +1070,7 @@ impl VulkanRayTracingKernel {
     /// Kernel's declared binding shape. Mode-routed: host-mode reads
     /// directly from `host_inner`; cdylib-mode dispatches through the
     /// v3 `bindings` slot on the per-type methods vtable. On cdylib-
-    /// side FFI errors the method emits a `tracing::warn` and returns
+    /// side plugin ABI errors the method emits a `tracing::warn` and returns
     /// an empty Vec.
     pub fn bindings(&self) -> Vec<RayTracingBindingSpec> {
         if crate::core::plugin::host_services::host_callbacks().is_some() {
@@ -1157,7 +1157,7 @@ impl VulkanRayTracingKernel {
             .collect()
     }
 
-    /// Push-constant range size in bytes. Cached POD — no FFI hop.
+    /// Push-constant range size in bytes. Cached POD — no plugin ABI hop.
     pub fn push_constant_size(&self) -> u32 {
         self.cached_push_constant_size
     }
@@ -1451,13 +1451,13 @@ impl std::fmt::Debug for VulkanRayTracingKernel {
 }
 
 #[cfg(all(test, target_pointer_width = "64"))]
-mod beta_shape_layout_tests {
+mod plugin_abi_object_layout_tests {
     use super::*;
     use core::mem::{align_of, offset_of, size_of};
 
     #[test]
     fn vulkan_ray_tracing_kernel_layout() {
-        // β-shape struct as of #907 PR 4/5:
+        // PluginAbiObject struct as of #907 PR 4/5:
         //   handle                       @ 0  (8 bytes, *const c_void)
         //   vtable                       @ 8  (8 bytes, *const GpuContextFullAccessVTable)
         //   methods_vtable               @ 16 (8 bytes, *const VulkanRayTracingKernelMethodsVTable)

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_texture.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_texture.rs
@@ -165,7 +165,7 @@ impl Default for HostVkImageMeta {
 ///    use):** call
 ///    `GpuContextFullAccess::acquire_render_target_dma_buf_image(w, h, format)`
 ///    — backed by the FullAccess `acquire_render_target_dma_buf_image`
-///    vtable slot. Returns a `Texture` β-shape. Extract the underlying
+///    vtable slot. Returns a `Texture` PluginAbiObject. Extract the underlying
 ///    `Arc<HostVulkanTexture>` via the v10 `host_vulkan_texture_arc`
 ///    bridge (`HostTextureExt::host_vulkan_texture_arc`). The slot's
 ///    host-side body does FOURCC mapping, queries the device's RT-capable
@@ -188,7 +188,7 @@ impl Default for HostVkImageMeta {
 ///    `HostVulkanTexture::new_render_target_dma_buf(device_arc.device(), &desc, &modifiers)`
 ///    directly. The constructor body uses only `pub` accessors on
 ///    `HostVulkanDevice` (`allocator`, `dma_buf_image_pool_tiled`, …)
-///    plus `vulkanalia-vma` — no `host_inner()`, no β-shape deref.
+///    plus `vulkanalia-vma` — no `host_inner()`, no PluginAbiObject deref.
 ///
 /// Adding a `host_inner()` or `host_callbacks()` guard inside any of
 /// the `new*` constructor bodies (`new`, `new_render_target_dma_buf`,

--- a/libs/streamlib-engine/tests/load_project_dylib_camera_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_camera_smoke.rs
@@ -35,7 +35,7 @@
 //! What this test does NOT lock — guarded separately:
 //!
 //! > ~~End-to-end per-frame capture through the color converter +
-//! > command recorder. Those β-shape return-type methods
+//! > command recorder. Those PluginAbiObject return-type methods
 //! > (`RhiColorConverter::prepare_buffer_to_image_storage`,
 //! > `RhiCommandRecorder::record_*` / `submit_*`,
 //! > `HostVulkanTimelineSemaphore::wait`) still panic in cdylib mode

--- a/libs/streamlib-engine/tests/load_project_dylib_cross_rustc.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_cross_rustc.rs
@@ -4,7 +4,7 @@
 //! Cross-rustc-version / cross-dep-graph dlopen integration test for
 //! issue #927.
 //!
-//! Companion to PR #918's β-shape Phase D work. The fixture under
+//! Companion to PR #918's PluginAbiObject Phase D work. The fixture under
 //! `libs/streamlib-cross-rustc-fixture/` is a standalone Cargo
 //! workspace (own `[workspace]` table, own `Cargo.lock`) that pins
 //! older transitive `serde` / `tracing` than the host workspace
@@ -19,19 +19,19 @@
 //! - `cargo build` against that fixture produces a `.so`.
 //! - `Runner::add_module_with(...)` accepts the `STREAMLIB_PLUGIN`
 //!   symbol from the divergently-compiled cdylib.
-//! - Each #918 β-shape return type (`TextureRing`,
+//! - Each #918 PluginAbiObject return type (`TextureRing`,
 //!   `RhiColorConverter`, `RhiCommandRecorder`, `VulkanComputeKernel`,
 //!   `VulkanGraphicsKernel`, plus `VulkanAccelerationStructure` and
 //!   `VulkanRayTracingKernel` when the host supports ray tracing) is
 //!   constructed, cloned (where applicable — `RhiCommandRecorder` is
 //!   the Box-handle `!Clone` shape), and dropped from cdylib code
-//!   without panic — running through the FFI vtable, not the
+//!   without panic — running through the plugin vtable, not the
 //!   in-process Boxed path, by wrapping the sweep in
 //!   `gpu_limited_access().escalate(...)`.
 //! - The sweep runs once in `start()`. `setup()` is intentionally
 //!   empty: both lifecycles wrap the same `GpuContextFullAccess`
-//!   β-shape with the same host-vtable instance, so doubling the
-//!   sweep adds ~15s of BLAS + RT-kernel construction without
+//!   PluginAbiObject with the same host-vtable instance, so doubling
+//!   the sweep adds ~15s of BLAS + RT-kernel construction without
 //!   exercising a distinct vtable surface.
 //!
 //! What this test does NOT lock on its own — these are guarded
@@ -153,7 +153,7 @@ fn assert_dep_graph_divergence(workspace_root: &Path, fixture_lock: &Path) {
 
 #[test]
 #[serial]
-fn dlopen_cross_rustc_fixture_round_trips_every_beta_shape() {
+fn dlopen_cross_rustc_fixture_round_trips_every_plugin_abi_object() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()
@@ -241,7 +241,7 @@ fn dlopen_cross_rustc_fixture_round_trips_every_beta_shape() {
     std::fs::create_dir_all(&triple_dir).unwrap();
     std::fs::copy(&built_dylib, triple_dir.join(&dylib_name)).unwrap();
 
-    let output_path = tmp.path().join("beta_shape_round_trip.txt");
+    let output_path = tmp.path().join("plugin_abi_object_round_trip.txt");
     let output_path_str = output_path.to_string_lossy().to_string();
 
     let runtime = Runner::with_auto_build().unwrap();
@@ -255,7 +255,7 @@ fn dlopen_cross_rustc_fixture_round_trips_every_beta_shape() {
     let ident = schema_ident!(
         "tatolab",
         "cross-rustc-fixture",
-        "BetaShapeRoundTripProcessor",
+        "PluginAbiObjectRoundTripProcessor",
         "1.0.0"
     );
 
@@ -264,13 +264,13 @@ fn dlopen_cross_rustc_fixture_round_trips_every_beta_shape() {
             ident,
             json!({ "output_path": output_path_str }),
         ))
-        .expect("add_processor must succeed for the dlopened BetaShapeRoundTripProcessor");
+        .expect("add_processor must succeed for the dlopened PluginAbiObjectRoundTripProcessor");
 
     runtime
         .start()
         .expect("runtime.start() must succeed (requires Vulkan device on this host)");
 
-    // Manual-processor `setup()` runs the first β-shape sweep; the
+    // Manual-processor `setup()` runs the first PluginAbiObject sweep; the
     // result is stashed on the processor instance and combined with
     // `start()`'s sweep into the output file. Poll briefly for the
     // file to absorb scheduling jitter.
@@ -283,23 +283,23 @@ fn dlopen_cross_rustc_fixture_round_trips_every_beta_shape() {
 
     assert!(
         output_path.exists(),
-        "BetaShapeRoundTripProcessor did not write {} within 15s — \
+        "PluginAbiObjectRoundTripProcessor did not write {} within 15s — \
          either the cdylib's setup/start lifecycle didn't fire, or the \
-         β-shape Create/Clone/Drop path panicked at the FFI boundary",
+         PluginAbiObject Create/Clone/Drop path panicked at the plugin ABI",
         output_path.display()
     );
 
     let contents = std::fs::read_to_string(&output_path).unwrap();
     assert!(
         !contents.starts_with("ERR:"),
-        "BetaShapeRoundTripProcessor reported an error from the β-shape round-trip:\n{contents}"
+        "PluginAbiObjectRoundTripProcessor reported an error from the PluginAbiObject round-trip:\n{contents}"
     );
     assert!(
         contents.starts_with("OK\n"),
         "first line must be 'OK', got: {contents}"
     );
 
-    // The five unconditional β-shapes run on every test host.
+    // The five unconditional PluginAbiObjects run on every test host.
     for ty in [
         "TextureRing",
         "RhiColorConverter",
@@ -310,7 +310,7 @@ fn dlopen_cross_rustc_fixture_round_trips_every_beta_shape() {
         let needle = format!("{ty}:OK");
         assert!(
             contents.contains(&needle),
-            "missing β-shape round-trip line {needle:?} — full body:\n{contents}"
+            "missing PluginAbiObject round-trip line {needle:?} — full body:\n{contents}"
         );
     }
 
@@ -345,7 +345,7 @@ fn dlopen_cross_rustc_fixture_round_trips_every_beta_shape() {
         let skipped = "Texture::native_handle:SKIPPED_NO_DMA_BUF";
         assert!(
             contents.contains(ok) || contents.contains(skipped),
-            "missing β-shape round-trip line for Texture::native_handle: \
+            "missing PluginAbiObject round-trip line for Texture::native_handle: \
              expected one of {ok:?} or {skipped:?} — full body:\n{contents}"
         );
     }
@@ -358,7 +358,7 @@ fn dlopen_cross_rustc_fixture_round_trips_every_beta_shape() {
         let skipped = format!("{ty}:SKIPPED_NO_RT_SUPPORT");
         assert!(
             contents.contains(&ok) || contents.contains(&skipped),
-            "missing β-shape round-trip line for {ty}: expected one of \
+            "missing PluginAbiObject round-trip line for {ty}: expected one of \
              {ok:?} or {skipped:?} — full body:\n{contents}"
         );
     }

--- a/libs/streamlib-engine/tests/load_project_dylib_gpu_acquire.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_gpu_acquire.rs
@@ -10,7 +10,7 @@
 //!   2. Acquires a `PixelBuffer` — exercises `acquire_pixel_buffer`
 //!      (paired-out-param tuple).
 //!   3. Reads `pixel_buffer.width` / `.height` — cached POD reads,
-//!      no cross-DSO dispatch.
+//!      no plugin ABI dispatch.
 //!   4. Reads `plane_base_address(0)` — exercises
 //!      `plane_base_address_pixel_buffer`.
 //!   5. Writes a sentinel byte through the returned pointer — proves
@@ -184,7 +184,7 @@ fn dlopen_processor_round_trips_gpu_vtable_callbacks() {
     // Parse the three-line "OK\n<w>x<h>\nsentinel_addr=0x<hex>" body
     // and verify the cached width/height match the configured values
     // (proves the POD-read path from the cdylib's `PixelBuffer`
-    // β-shape is intact).
+    // PluginAbiObject is intact).
     let mut lines = contents.lines();
     let first = lines.next().unwrap_or("");
     assert_eq!(
@@ -194,7 +194,7 @@ fn dlopen_processor_round_trips_gpu_vtable_callbacks() {
     let dims = lines.next().unwrap_or("");
     assert_eq!(
         dims, "64x64",
-        "cached width/height must round-trip from the cdylib's PixelBuffer β-shape, got {dims:?}"
+        "cached width/height must round-trip from the cdylib's PixelBuffer PluginAbiObject, got {dims:?}"
     );
     let addr_line = lines.next().unwrap_or("");
     assert!(

--- a/libs/streamlib-engine/tests/load_project_dylib_lifecycle.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_lifecycle.rs
@@ -8,7 +8,7 @@
 //! registered `TestConfiguredProcessor` through `factory.create(&node)`
 //! to confirm the cdylib-side `extern "C" fn construct(...)` wrapper
 //! returns a non-null instance pointer, then drops it to exercise
-//! `extern "C" fn destroy(...)` — the cross-DSO heap dance that the
+//! `extern "C" fn destroy(...)` — the plugin ABI heap dance that the
 //! vtable shape introduces.
 //!
 //! Mentally revert the `Drop` impl in

--- a/libs/streamlib-engine/tests/load_project_dylib_vulkan_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_vulkan_smoke.rs
@@ -10,7 +10,7 @@
 //!   1. `host_vulkan_device_arc()` (v9 bridge) →
 //!      `Arc<HostVulkanDevice>`.
 //!   2. `acquire_render_target_dma_buf_image()` →
-//!      `Texture` β-shape; `host_vulkan_texture_arc()` (v10) →
+//!      `Texture` PluginAbiObject; `host_vulkan_texture_arc()` (v10) →
 //!      `Arc<HostVulkanTexture>`.
 //!   3. `HostVulkanTimelineSemaphore::new(device_arc.device(), 0)` —
 //!      cdylib-reachable direct constructor.

--- a/libs/streamlib-macros/src/codegen.rs
+++ b/libs/streamlib-macros/src/codegen.rs
@@ -392,10 +392,10 @@ fn generate_processor_struct_from_schema(
         quote! { pub #name: Config, }
     });
 
-    // Generate iceoryx2 β-shape fields if ports are defined.
+    // Generate iceoryx2 PluginAbiObject fields if ports are defined.
     // Issue #894 retires the shared-Rust-type crossings — the
     // processor's `outputs` / `inputs` fields are now layout-stable
-    // `#[repr(C)] { handle, vtable }` β-shapes; the host patches
+    // `#[repr(C)] { handle, vtable }` PluginAbiObjects; the host patches
     // them up via `ProcessorVTable::set_iceoryx2_resources` after
     // `from_config` returns.
     let ipc_input_field = if !schema.inputs.is_empty() {
@@ -685,7 +685,7 @@ fn generate_from_config_from_schema(
     custom_fields: &[CustomField],
 ) -> TokenStream {
     // Issue #894: host-allocates iceoryx2 inner Arcs. The macro
-    // emits empty β-shapes; the host's
+    // emits empty PluginAbiObjects; the host's
     // `ProcessorInstance::install_iceoryx2_resources` patches in
     // real handles via `ProcessorVTable::set_iceoryx2_resources`
     // immediately after `from_config` returns. Per-port read_mode
@@ -874,7 +874,7 @@ fn generate_iceoryx2_accessors_from_schema(schema: &ProcessorSchema) -> TokenStr
     };
 
     // Issue #894: emit `set_iceoryx2_resources` to receive host-
-    // allocated β-shapes + the `iceoryx2_output_writer_inner` /
+    // allocated PluginAbiObjects + the `iceoryx2_output_writer_inner` /
     // `iceoryx2_input_mailboxes_inner` accessors so the host's
     // wiring path can mutate the inner Arc directly.
     let add_port_calls: Vec<TokenStream> = if has_iceoryx2_inputs {

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -123,10 +123,10 @@ pub const STREAMLIB_ABI_VERSION: u32 = 4;
 ///   check before dispatching). Reachable from cdylib code only
 ///   inside an `escalate(|full| ...)` scope (the scope-token
 ///   machinery lands in C3 — Phase C2 ships the vtable layout +
-///   host wiring + cdylib β-shape, locking the wire format before
+///   host wiring + cdylib PluginAbiObject, locking the wire format before
 ///   the scope machinery turns it on).
 /// - v12: [`RhiColorConverterMethodsVTable`] reference appended.
-///   The cdylib-side `RhiColorConverter` β-shape's `methods_vtable`
+///   The cdylib-side `RhiColorConverter` PluginAbiObject's `methods_vtable`
 ///   field sources its pointer from this field. Non-null for hosts
 ///   that ship a GpuContext; null otherwise (cdylib code must check
 ///   before dispatching). Phase E sub-lift slice A wires the
@@ -134,7 +134,7 @@ pub const STREAMLIB_ABI_VERSION: u32 = 4;
 ///   camera processors can prepare a color-conversion kernel without
 ///   tripping the host-mode-only `host_inner()` panic.
 /// - v13: [`RhiCommandRecorderMethodsVTable`] reference appended.
-///   The cdylib-side `RhiCommandRecorder` β-shape's `methods_vtable`
+///   The cdylib-side `RhiCommandRecorder` PluginAbiObject's `methods_vtable`
 ///   field sources its pointer from this field. Non-null for hosts
 ///   that ship a GpuContext; null otherwise (cdylib code must check
 ///   before dispatching). Phase E sub-lift slice B wires the six
@@ -146,7 +146,7 @@ pub const STREAMLIB_ABI_VERSION: u32 = 4;
 ///   host-mode-only `host_inner_mut()` panic.
 /// - v14: [`OutputWriterVTable`] + [`InputMailboxesVTable`]
 ///   references appended (issue #894 — LAST shared-Rust-type
-///   crossings in the plugin ABI). The cdylib's β-shape
+///   crossings in the plugin ABI). The cdylib's PluginAbiObject
 ///   `OutputWriter` / `InputMailboxes` field types source their
 ///   vtable pointers from these slots; per-frame `write_raw` /
 ///   `read_raw` dispatch through them. Paired with the
@@ -238,7 +238,7 @@ pub struct HostServices {
     /// Publish a serialized `Event` to a topic. The event is encoded
     /// the same way `PubSub::publish` encodes today (msgpack-named
     /// via `rmp_serde::to_vec_named`), so host-side
-    /// deserialization is identical regardless of caller DSO.
+    /// deserialization is identical regardless of caller plugin.
     ///
     /// Subscribe is intentionally absent: cdylib code does not
     /// currently subscribe; if a future plugin shape needs it, add a
@@ -382,7 +382,7 @@ pub struct HostServices {
     /// callback returns. Set once at install time; non-null for hosts
     /// that ship a GpuContext, null otherwise (cdylib must check
     /// before dispatching). Phase C2 lands the layout + host wiring +
-    /// cdylib β-shape; Phase C3 wires the scope-token machinery that
+    /// cdylib PluginAbiObject; Phase C3 wires the scope-token machinery that
     /// makes the methods reachable from `escalate(|full| ...)` call
     /// sites.
     pub gpu_context_full_access_vtable: *const GpuContextFullAccessVTable,
@@ -391,9 +391,9 @@ pub struct HostServices {
     // TextureRingMethodsVTable surface (v7 — issue #907 Phase E PR 1/5)
     // -------------------------------------------------------------------------
 
-    /// Static dispatch table for `TextureRing` β-shape method
+    /// Static dispatch table for `TextureRing` PluginAbiObject method
     /// dispatch. Paired with the per-`TextureRing` handle the
-    /// cdylib carries on its β-shape struct (`methods_vtable`
+    /// cdylib carries on its PluginAbiObject struct (`methods_vtable`
     /// field). Set once at install time; non-null for hosts that
     /// ship a GpuContext, null otherwise (cdylib must check before
     /// dispatching). PR 1 of issue #907 lands the empty-shell
@@ -405,9 +405,9 @@ pub struct HostServices {
     // VulkanComputeKernelMethodsVTable surface (v8 — issue #907 Phase E PR 2/5)
     // -------------------------------------------------------------------------
 
-    /// Static dispatch table for `VulkanComputeKernel` β-shape
+    /// Static dispatch table for `VulkanComputeKernel` PluginAbiObject
     /// method dispatch. Paired with the per-`VulkanComputeKernel`
-    /// handle the cdylib carries on its β-shape struct
+    /// handle the cdylib carries on its PluginAbiObject struct
     /// (`methods_vtable` field). Set once at install time; non-null
     /// for hosts that ship a GpuContext, null otherwise (cdylib
     /// must check before dispatching). PR 2 of issue #907 lands the
@@ -419,9 +419,9 @@ pub struct HostServices {
     // VulkanGraphicsKernelMethodsVTable surface (v9 — issue #907 Phase E PR 3/5)
     // -------------------------------------------------------------------------
 
-    /// Static dispatch table for `VulkanGraphicsKernel` β-shape
+    /// Static dispatch table for `VulkanGraphicsKernel` PluginAbiObject
     /// method dispatch. Paired with the per-`VulkanGraphicsKernel`
-    /// handle the cdylib carries on its β-shape struct
+    /// handle the cdylib carries on its PluginAbiObject struct
     /// (`methods_vtable` field). Set once at install time; non-null
     /// for hosts that ship a GpuContext, null otherwise (cdylib
     /// must check before dispatching). PR 3 of issue #907 lands the
@@ -433,9 +433,9 @@ pub struct HostServices {
     // VulkanRayTracingKernelMethodsVTable surface (v10 — issue #907 Phase E PR 4/5)
     // -------------------------------------------------------------------------
 
-    /// Static dispatch table for `VulkanRayTracingKernel` β-shape
+    /// Static dispatch table for `VulkanRayTracingKernel` PluginAbiObject
     /// method dispatch. Paired with the per-`VulkanRayTracingKernel`
-    /// handle the cdylib carries on its β-shape struct
+    /// handle the cdylib carries on its PluginAbiObject struct
     /// (`methods_vtable` field). Set once at install time; non-null
     /// for hosts that ship a GpuContext, null otherwise (cdylib
     /// must check before dispatching). PR 4 of issue #907 lands the
@@ -449,7 +449,7 @@ pub struct HostServices {
     // -------------------------------------------------------------------------
 
     /// Static dispatch table for `VulkanAccelerationStructure`
-    /// β-shape method dispatch. Set once at install time; non-null
+    /// PluginAbiObject method dispatch. Set once at install time; non-null
     /// for hosts that ship a GpuContext, null otherwise. PR 5 of
     /// issue #907 lands the empty-shell vtable + pointer plumbing;
     /// follow-up PRs append the actual method slots.
@@ -460,15 +460,15 @@ pub struct HostServices {
     // RhiColorConverterMethodsVTable surface (v12 — Phase E sub-lift slice A)
     // -------------------------------------------------------------------------
 
-    /// Static dispatch table for `RhiColorConverter` β-shape method
+    /// Static dispatch table for `RhiColorConverter` PluginAbiObject method
     /// dispatch. Paired with the per-`RhiColorConverter` handle the
-    /// cdylib carries on its β-shape struct (`methods_vtable` field).
+    /// cdylib carries on its PluginAbiObject struct (`methods_vtable` field).
     /// Set once at install time; non-null for hosts that ship a
     /// GpuContext, null otherwise (cdylib must check before
     /// dispatching). Phase E sub-lift slice A lands the
     /// `prepare_buffer_to_image_storage` slot so cdylib camera
     /// processors can prepare color-conversion kernels without
-    /// tripping the β-shape's host-mode-only `host_inner()` panic.
+    /// tripping the PluginAbiObject's host-mode-only `host_inner()` panic.
     pub rhi_color_converter_methods_vtable:
         *const RhiColorConverterMethodsVTable,
 
@@ -476,9 +476,9 @@ pub struct HostServices {
     // RhiCommandRecorderMethodsVTable surface (v13 — Phase E sub-lift slice B)
     // -------------------------------------------------------------------------
 
-    /// Static dispatch table for `RhiCommandRecorder` β-shape
+    /// Static dispatch table for `RhiCommandRecorder` PluginAbiObject
     /// method dispatch. Paired with the per-`RhiCommandRecorder`
-    /// handle the cdylib carries on its β-shape struct
+    /// handle the cdylib carries on its PluginAbiObject struct
     /// (`methods_vtable` field). Set once at install time; non-null
     /// for hosts that ship a GpuContext, null otherwise (cdylib
     /// must check before dispatching). Phase E sub-lift slice B
@@ -487,7 +487,7 @@ pub struct HostServices {
     /// `record_dispatch`, `record_copy_image_to_buffer`,
     /// `submit_signaling_timeline`) so cdylib camera processors
     /// can drive the host-owned recorder per frame without
-    /// tripping the β-shape's host-mode-only `host_inner_mut()`
+    /// tripping the PluginAbiObject's host-mode-only `host_inner_mut()`
     /// panic.
     pub rhi_command_recorder_methods_vtable:
         *const RhiCommandRecorderMethodsVTable,
@@ -496,7 +496,7 @@ pub struct HostServices {
     // OutputWriterVTable + InputMailboxesVTable references (v14 — issue #894)
     // -------------------------------------------------------------------------
 
-    /// Static dispatch table for the cdylib's `OutputWriter` β-shape
+    /// Static dispatch table for the cdylib's `OutputWriter` PluginAbiObject
     /// method dispatch. Paired with the per-instance opaque handle
     /// the cdylib stores on its `outputs` field after the host
     /// invokes `ProcessorVTable::set_iceoryx2_resources`. Non-null
@@ -507,7 +507,7 @@ pub struct HostServices {
     pub output_writer_vtable: *const OutputWriterVTable,
 
     /// Static dispatch table for the cdylib's `InputMailboxes`
-    /// β-shape method dispatch. Paired with the per-instance opaque
+    /// PluginAbiObject method dispatch. Paired with the per-instance opaque
     /// handle the cdylib stores on its `inputs` field after the host
     /// invokes `ProcessorVTable::set_iceoryx2_resources`. Non-null
     /// for every host that wires processors with input ports.
@@ -562,7 +562,7 @@ pub struct PluginDeclaration {
     pub abi_version: u32,
 
     /// Register callback. Receives the host-services pointer; the
-    /// cdylib's macro expansion uses it to install every per-DSO
+    /// cdylib's macro expansion uses it to install every per-plugin
     /// static's forwarder before registering processors.
     pub register: PluginRegisterFn,
 }

--- a/libs/streamlib-plugin-abi/src/vtables/gpu_context_full.rs
+++ b/libs/streamlib-plugin-abi/src/vtables/gpu_context_full.rs
@@ -17,7 +17,7 @@ use crate::repr::{
 /// and `acquire_render_target_dma_buf_image`. Each kernel-construction
 /// callback consumes a `#[repr(C)]` descriptor mirror
 /// ([`crate::ComputeKernelDescriptorRepr`], [`crate::GraphicsKernelDescriptorRepr`],
-/// [`crate::RayTracingKernelDescriptorRepr`]) and returns an Arc-handle β-shape
+/// [`crate::RayTracingKernelDescriptorRepr`]) and returns an Arc-handle PluginAbiObject
 /// for the resulting kernel; the matching Arc-lifecycle pairs
 /// (`clone_*` / `drop_*`) live on this vtable.
 ///
@@ -47,11 +47,11 @@ use crate::repr::{
 ///   inherit through the originating LimitedAccess vtable per the
 ///   `inherited_lim_*` fields on `GpuContextFullAccess` — they do
 ///   not get parallel slots here.
-/// - v4: β-shape Phase D return types (`RhiColorConverter`,
+/// - v4: PluginAbiObject Phase D return types (`RhiColorConverter`,
 ///   `VulkanAccelerationStructure`, `RhiCommandRecorder`) gain
 ///   `clone_*` / `drop_*` slot pairs alongside the existing kernel +
 ///   texture-ring pairs. The slots activate the layout-stable
-///   `(handle, vtable)` β-shape pattern so cdylibs can hold +
+///   `(handle, vtable)` PluginAbiObject pattern so cdylibs can hold +
 ///   refcount + drop these handles without rustc-version coupling.
 /// - v5: `gpu_capabilities` slot returning a `#[repr(C)]`
 ///   `GpuCapabilitiesRepr` struct (vendor name + capability bools
@@ -61,22 +61,22 @@ use crate::repr::{
 ///   amortizes better than per-method slots.
 /// - v6: `create_timeline_semaphore(initial_value)` slot returning
 ///   an `Arc::into_raw(Arc<HostVulkanTimelineSemaphore>)` opaque
-///   handle (Arc-raw-pointer transit, NOT β-shape — the timeline
-///   semaphore's β-shape is its own future lift). Camera processor
+///   handle (Arc-raw-pointer transit, NOT PluginAbiObject — the timeline
+///   semaphore's PluginAbiObject is its own future lift). Camera processor
 ///   needs this to drop the `full.device().vulkan_device().device()`
 ///   reach-through for `HostVulkanTimelineSemaphore::new(...)`.
 /// - v7: `import_dma_buf_storage_buffer(fd, byte_size)` slot writing
-///   a `StorageBuffer` β-shape (already layout-stable from C1)
+///   a `StorageBuffer` PluginAbiObject (already layout-stable from C1)
 ///   into `*out_buffer`. Camera processor's V4L2 zero-copy path
 ///   uses this; the host consumes the fd on success.
 /// - v8: `build_triangles_blas` and `build_tlas` signatures extended
 ///   with three new out-params each (`out_device_address: *mut u64`,
 ///   `out_storage_size: *mut u64`, `out_kind: *mut u32`). Prior to
 ///   v8 cdylib mint paths populated the `VulkanAccelerationStructure`
-///   β-shape's cached POD fields with placeholder zeros; the β-shape
+///   PluginAbiObject's cached POD fields with placeholder zeros; the PluginAbiObject
 ///   getters (`device_address()`, `storage_size()`, `kind()`) then
 ///   fell back to `host_inner()` which panics in cdylib mode. v8
-///   surfaces the real values across the FFI so the cached fields
+///   surfaces the real values across the plugin ABI so the cached fields
 ///   are populated correctly at mint time. **ABI-breaking** — plugins
 ///   built against v7 are not load-compatible with a v8 host (the fn
 ///   pointer signatures differ).
@@ -90,7 +90,7 @@ use crate::repr::{
 ///   `Arc::into_raw(Arc<HostVulkanTexture>)` raw pointer. Second
 ///   bridge of the cdylib-side adapter-construction chain — gives
 ///   workspace plugin cdylibs a non-panicking path to
-///   `Arc<HostVulkanTexture>` from a `Texture` β-shape (the existing
+///   `Arc<HostVulkanTexture>` from a `Texture` PluginAbiObject (the existing
 ///   `Texture::host_inner()` and `HostTextureExt::vulkan_inner()`
 ///   panic in cdylib mode). Same rustc-version-coupling caveat as
 ///   v9: `HostVulkanTexture` is not `#[repr(C)]`, so the Arc-raw
@@ -106,7 +106,7 @@ pub const GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 10;
 /// [`crate::HostServices::gpu_context_full_access_vtable`].
 ///
 /// C2 lands the descriptor wire format + host-side dispatch + cdylib-
-/// side β-shape. C3 wires the `escalate_begin` / `escalate_end` scope-
+/// side PluginAbiObject. C3 wires the `escalate_begin` / `escalate_end` scope-
 /// token machinery that makes the methods reachable from cdylib
 /// `escalate(|full| { ... })` call sites.
 ///
@@ -147,14 +147,14 @@ pub struct GpuContextFullAccessVTable {
     // VulkanComputeKernel return-type lifetime
     // -------------------------------------------------------------------------
 
-    /// Bump the refcount on a `VulkanComputeKernel` β-shape handle.
+    /// Bump the refcount on a `VulkanComputeKernel` PluginAbiObject handle.
     /// Called by the cdylib's `Clone for VulkanComputeKernel`. Host
     /// runs `Arc::increment_strong_count(handle as *const VulkanComputeKernelInner)`
     /// against the host-internal Inner type — cdylib never sees the
     /// Inner layout.
     pub clone_compute_kernel: unsafe extern "C" fn(handle: *const c_void),
 
-    /// Decrement the refcount on a `VulkanComputeKernel` β-shape handle.
+    /// Decrement the refcount on a `VulkanComputeKernel` PluginAbiObject handle.
     /// Host runs `Arc::decrement_strong_count` against the Inner type.
     pub drop_compute_kernel: unsafe extern "C" fn(handle: *const c_void),
 
@@ -162,33 +162,33 @@ pub struct GpuContextFullAccessVTable {
     // VulkanGraphicsKernel return-type lifetime
     // -------------------------------------------------------------------------
 
-    /// Bump the refcount on a `VulkanGraphicsKernel` β-shape handle.
+    /// Bump the refcount on a `VulkanGraphicsKernel` PluginAbiObject handle.
     /// Host runs `Arc::increment_strong_count(handle as *const VulkanGraphicsKernelInner)`.
     pub clone_graphics_kernel: unsafe extern "C" fn(handle: *const c_void),
 
-    /// Decrement the refcount on a `VulkanGraphicsKernel` β-shape handle.
+    /// Decrement the refcount on a `VulkanGraphicsKernel` PluginAbiObject handle.
     pub drop_graphics_kernel: unsafe extern "C" fn(handle: *const c_void),
 
     // -------------------------------------------------------------------------
     // VulkanRayTracingKernel return-type lifetime
     // -------------------------------------------------------------------------
 
-    /// Bump the refcount on a `VulkanRayTracingKernel` β-shape handle.
+    /// Bump the refcount on a `VulkanRayTracingKernel` PluginAbiObject handle.
     /// Host runs `Arc::increment_strong_count(handle as *const VulkanRayTracingKernelInner)`.
     pub clone_ray_tracing_kernel: unsafe extern "C" fn(handle: *const c_void),
 
-    /// Decrement the refcount on a `VulkanRayTracingKernel` β-shape handle.
+    /// Decrement the refcount on a `VulkanRayTracingKernel` PluginAbiObject handle.
     pub drop_ray_tracing_kernel: unsafe extern "C" fn(handle: *const c_void),
 
     // -------------------------------------------------------------------------
     // TextureRing return-type lifetime
     // -------------------------------------------------------------------------
 
-    /// Bump the refcount on a `TextureRing` β-shape handle.
+    /// Bump the refcount on a `TextureRing` PluginAbiObject handle.
     /// Host runs `Arc::increment_strong_count(handle as *const TextureRingInner)`.
     pub clone_texture_ring: unsafe extern "C" fn(handle: *const c_void),
 
-    /// Decrement the refcount on a `TextureRing` β-shape handle.
+    /// Decrement the refcount on a `TextureRing` PluginAbiObject handle.
     pub drop_texture_ring: unsafe extern "C" fn(handle: *const c_void),
 
     // -------------------------------------------------------------------------
@@ -298,7 +298,7 @@ pub struct GpuContextFullAccessVTable {
     /// dispatches through this slot inside an active escalate scope;
     /// the host picks a tiled DRM modifier via the EGL probe, runs the
     /// allocation through the RHI's render-target pool, and writes a
-    /// fresh `Texture` β-shape into `*out_texture` on success.
+    /// fresh `Texture` PluginAbiObject into `*out_texture` on success.
     ///
     /// `format_raw` is the `#[repr(u32)]` discriminant of
     /// `streamlib_consumer_rhi::TextureFormat`. Linux-only; non-Linux
@@ -336,7 +336,7 @@ pub struct GpuContextFullAccessVTable {
     /// register the texture in the same-process texture cache, and
     /// return both. `out_id_buf` receives the UTF-8 surface id (
     /// `out_id_len` records the byte count; truncation is an error);
-    /// `out_texture` receives the [`crate::Texture`] β-shape.
+    /// `out_texture` receives the [`crate::Texture`] PluginAbiObject.
     pub acquire_output_texture: unsafe extern "C" fn(
         gpu_handle: *const c_void,
         width: u32,
@@ -399,7 +399,7 @@ pub struct GpuContextFullAccessVTable {
     /// from CPU-side vertex + index data. Writes an
     /// `Arc::into_raw(Arc<VulkanAccelerationStructure>)` raw pointer
     /// into `*out_blas` on success, plus the cached POD descriptors
-    /// the cdylib's `VulkanAccelerationStructure` β-shape carries:
+    /// the cdylib's `VulkanAccelerationStructure` PluginAbiObject carries:
     /// `*out_device_address` (BLAS device address — used as the
     /// `accelerationStructureReference` when wiring into a TLAS),
     /// `*out_storage_size` (build-time storage allocation), and
@@ -429,7 +429,7 @@ pub struct GpuContextFullAccessVTable {
     /// `Arc::into_raw(Arc<VulkanAccelerationStructure>)` raw pointer
     /// into `*out_tlas` on success, plus the cached POD descriptors
     /// (`*out_device_address`, `*out_storage_size`, `*out_kind`) the
-    /// cdylib's β-shape carries — same shape as
+    /// cdylib's PluginAbiObject carries — same shape as
     /// `build_triangles_blas`; `*out_kind` is always 1 (`TopLevel`)
     /// for `build_tlas`. Linux-only.
     pub build_tlas: unsafe extern "C" fn(
@@ -500,10 +500,10 @@ pub struct GpuContextFullAccessVTable {
     /// `Arc::into_raw(Arc<HostVulkanTimelineSemaphore>)` into
     /// `*out_handle` and returns 0.
     ///
-    /// **Arc-raw-pointer transit** — not a layout-stable β-shape.
+    /// **Arc-raw-pointer transit** — not a layout-stable PluginAbiObject.
     /// In-tree consumers (camera, display) ride this freely because
     /// they're built in the same workspace as the engine. Cross-repo
-    /// plugin distribution will need a β-shape lift for
+    /// plugin distribution will need a PluginAbiObject lift for
     /// `HostVulkanTimelineSemaphore`; tracked as a future follow-up.
     /// Linux-only on the host side; non-Linux stubs return non-zero.
     pub create_timeline_semaphore: unsafe extern "C" fn(
@@ -521,7 +521,7 @@ pub struct GpuContextFullAccessVTable {
 
     /// Import a V4L2 (or otherwise externally-allocated) DMA-BUF FD
     /// as a `StorageBuffer` (SSBO-shaped). On success writes the
-    /// `StorageBuffer` β-shape struct (32 bytes, layout-stable from
+    /// `StorageBuffer` PluginAbiObject struct (32 bytes, layout-stable from
     /// C1) into `*out_buffer` and returns 0.
     ///
     /// **The host consumes `fd` on success** (`vkImportMemoryFdInfoKHR`
@@ -568,7 +568,7 @@ pub struct GpuContextFullAccessVTable {
     /// `acquire_write` → `view_mut` → release path. Production
     /// processor code shouldn't reach for this — the higher-level
     /// FullAccess vtable methods (kernel construction, buffer/texture
-    /// allocation) cover the supported cross-DSO surface.
+    /// allocation) cover the supported plugin ABI surface.
     pub host_vulkan_device_arc:
         unsafe extern "C" fn(gpu_handle: *const c_void) -> *const c_void,
 
@@ -577,10 +577,10 @@ pub struct GpuContextFullAccessVTable {
     // -------------------------------------------------------------------------
 
     /// Clone the host's `Arc<HostVulkanTexture>` backing a `Texture`
-    /// β-shape and return the raw `Arc::into_raw` pointer on success.
+    /// PluginAbiObject and return the raw `Arc::into_raw` pointer on success.
     ///
     /// `texture_handle` is the same opaque `Arc::into_raw(Arc<TextureInner>)`
-    /// pointer cached on the `Texture` β-shape's `handle` field; the
+    /// pointer cached on the `Texture` PluginAbiObject's `handle` field; the
     /// host dereferences it without taking ownership, clones the
     /// inner `Arc<HostVulkanTexture>`, and returns its raw pointer
     /// with the strong count bumped by 1. The caller is responsible
@@ -617,7 +617,7 @@ mod tests {
         // pointers (8 bytes each) = 4 + 4 + 272 = 280 bytes, align = 8.
         //
         // 34 entries = 1 drop_handle + 7 clone/drop pairs (14 fn
-        // pointers for the 7 β-shape return types: compute / graphics /
+        // pointers for the 7 PluginAbiObject return types: compute / graphics /
         // ray-tracing kernels, texture ring, color converter,
         // acceleration structure, command recorder) + 4 create_* method
         // callbacks (compute / graphics / ray-tracing / texture_ring)
@@ -666,7 +666,7 @@ mod tests {
             offset_of!(GpuContextFullAccessVTable, drop_texture_ring),
             72
         );
-        // v4-added β-shape clone/drop pairs (#917).
+        // v4-added PluginAbiObject clone/drop pairs (#917).
         assert_eq!(
             offset_of!(GpuContextFullAccessVTable, clone_color_converter),
             80

--- a/libs/streamlib-plugin-abi/src/vtables/gpu_context_limited.rs
+++ b/libs/streamlib-plugin-abi/src/vtables/gpu_context_limited.rs
@@ -13,7 +13,7 @@ use core::ffi::c_void;
 /// buffer types, `TextureRegistration`, `RhiCommandQueue`,
 /// `CommandBuffer`, `SurfaceStore`) carries its own clone/drop
 /// callback pair so refcount accounting runs in host-compiled
-/// code regardless of caller DSO. Method-dispatch callbacks
+/// code regardless of caller plugin. Method-dispatch callbacks
 /// cover every cdylib-callable inherent method on
 /// `GpuContextLimitedAccess`.
 ///
@@ -73,7 +73,7 @@ use core::ffi::c_void;
 ///   read-side counterpart of v12's `set_/clear_` pair: cdylib
 ///   consumers (the in-tree consumer is `LinuxDisplayProcessor`'s
 ///   render loop) clone the host's published
-///   `Arc<HostVulkanTimelineSemaphore>` across the FFI to GPU-wait
+///   `Arc<HostVulkanTimelineSemaphore>` across the plugin ABI to GPU-wait
 ///   on the producer's writeback timeline. Mirrors the v9
 ///   `host_vulkan_device_arc` FullAccess pattern: the host callback
 ///   `Arc::into_raw`s a fresh clone (or returns null when no
@@ -162,7 +162,7 @@ pub struct GpuContextLimitedAccessVTable {
     pub drop_pixel_buffer: unsafe extern "C" fn(handle: *const c_void),
 
     // -------------------------------------------------------------------------
-    // PixelBuffer method-dispatch (eliminates cross-DSO Arc::from_raw)
+    // PixelBuffer method-dispatch (eliminates plugin ABI Arc::from_raw)
     // -------------------------------------------------------------------------
     //
     // The remaining non-cached `PixelBuffer` methods dispatch through
@@ -178,7 +178,7 @@ pub struct GpuContextLimitedAccessVTable {
     /// locking. Cdylib callers technically can call it through the
     /// vtable today, but the engine restricts the cdylib-facing
     /// `PixelBuffer::strong_count` API to `pub(crate)` so the
-    /// cross-DSO path is host-only by visibility. Calling on a null
+    /// plugin ABI path is host-only by visibility. Calling on a null
     /// pointer returns `0`.
     pub strong_count_pixel_buffer: unsafe extern "C" fn(handle: *const c_void) -> usize,
 
@@ -507,7 +507,7 @@ pub struct GpuContextLimitedAccessVTable {
     pub drop_rhi_command_queue: unsafe extern "C" fn(handle: *const c_void),
 
     /// Create a new `CommandBuffer` from a queue. On success writes a
-    /// fresh `CommandBuffer` (Box-handle β-shape) into `*out_cb` and
+    /// fresh `CommandBuffer` (Box-handle PluginAbiObject) into `*out_cb` and
     /// returns 0; on failure writes a UTF-8 error message into
     /// `err_buf` and returns non-zero.
     pub create_command_buffer_from_queue: unsafe extern "C" fn(
@@ -560,7 +560,7 @@ pub struct GpuContextLimitedAccessVTable {
     /// Return an owned `RhiCommandQueue` view of the host's shared
     /// command queue (refcount bumped on the underlying
     /// `Arc<RhiCommandQueueInner>`). Cdylib's caller releases via
-    /// `drop_rhi_command_queue`. Writes the β-shape into
+    /// `drop_rhi_command_queue`. Writes the PluginAbiObject into
     /// `*out_queue`; returns 0 on success, non-zero on internal
     /// failure (e.g. null gpu handle).
     pub command_queue: unsafe extern "C" fn(
@@ -587,7 +587,7 @@ pub struct GpuContextLimitedAccessVTable {
     /// Copy a host-visible pixel buffer's contents into a
     /// pre-allocated device-local texture. Linux-only on the host
     /// side; non-Linux stubs return non-zero. `pixel_buffer` and
-    /// `texture` are `*const PixelBuffer` / `*const Texture` β-shape
+    /// `texture` are `*const PixelBuffer` / `*const Texture` PluginAbiObject
     /// pointers.
     pub copy_pixel_buffer_to_texture: unsafe extern "C" fn(
         gpu_handle: *const c_void,
@@ -635,10 +635,10 @@ pub struct GpuContextLimitedAccessVTable {
     // SurfaceStoreVTable; these two callbacks bridge from
     // GpuContextLimitedAccess to that subsystem.
 
-    /// Return an owned [`SurfaceStore`] β-shape if the host has one,
-    /// or a null-handle β-shape ("None") otherwise. Always returns 0;
+    /// Return an owned [`SurfaceStore`] PluginAbiObject if the host has one,
+    /// or a null-handle PluginAbiObject ("None") otherwise. Always returns 0;
     /// callers branch on whether the written `SurfaceStore`'s handle
-    /// is null. Writes a fresh β-shape (Arc refcount bumped) into
+    /// is null. Writes a fresh PluginAbiObject (Arc refcount bumped) into
     /// `*out_store`.
     pub surface_store: unsafe extern "C" fn(
         gpu_handle: *const c_void,
@@ -647,7 +647,7 @@ pub struct GpuContextLimitedAccessVTable {
 
     /// Convenience method: check out a surface from the engine's
     /// `SurfaceStore` by `surface_id` (assumes the store exists).
-    /// Writes a fresh `PixelBuffer` β-shape into `*out_pixel_buffer`
+    /// Writes a fresh `PixelBuffer` PluginAbiObject into `*out_pixel_buffer`
     /// on success.
     pub check_out_surface: unsafe extern "C" fn(
         gpu_handle: *const c_void,
@@ -669,7 +669,7 @@ pub struct GpuContextLimitedAccessVTable {
     /// `PixelBufferPoolId`'s string bytes (capped at
     /// `out_pool_id_cap`; `*out_pool_id_len` receives the actual
     /// length, truncated to fit). `*out_pixel_buffer` receives a
-    /// fresh `PixelBuffer` β-shape on success.
+    /// fresh `PixelBuffer` PluginAbiObject on success.
     ///
     /// `format_raw` is the `#[repr(u32)]` discriminant of
     /// [`streamlib_consumer_rhi::PixelFormat`].
@@ -831,10 +831,10 @@ pub struct GpuContextLimitedAccessVTable {
     /// Mirrors the Arc-borrow-+-strong-count-bump pattern
     /// [`Self::register_texture`] uses for `Arc<TextureInner>`.
     ///
-    /// **Arc-raw-pointer transit** — not a layout-stable β-shape.
+    /// **Arc-raw-pointer transit** — not a layout-stable PluginAbiObject.
     /// In-tree consumers (camera) ride this freely because they're
     /// built in the same workspace as the engine. Cross-repo plugin
-    /// distribution will need a β-shape lift for
+    /// distribution will need a PluginAbiObject lift for
     /// `HostVulkanTimelineSemaphore`; tracked as a future follow-up
     /// alongside `create_timeline_semaphore`'s identical caveat.
     ///
@@ -913,7 +913,7 @@ pub struct GpuContextLimitedAccessVTable {
     /// independent strong count.
     ///
     /// Returns `*const c_void` carrying the leaked Arc pointer (a
-    /// `*const HostVulkanTimelineSemaphore` widened to the FFI
+    /// `*const HostVulkanTimelineSemaphore` widened to the plugin ABI
     /// type), or null when no producer has published a timeline
     /// yet, when the slot was cleared via
     /// [`Self::clear_video_source_timeline_semaphore`], when
@@ -924,7 +924,7 @@ pub struct GpuContextLimitedAccessVTable {
     /// `HostVulkanTimelineSemaphore` is not `#[repr(C)]`; in-tree
     /// workspace plugin cdylibs share the host's rustc + dep graph
     /// and ride this freely. Cross-repo plugin distribution awaits
-    /// a β-shape lift of `HostVulkanTimelineSemaphore` (the same
+    /// a PluginAbiObject lift of `HostVulkanTimelineSemaphore` (the same
     /// dormant work the v12 set/clear pair flagged).
     ///
     /// Linux-only on the host side; non-Linux stubs return null.

--- a/libs/streamlib-plugin-abi/src/vtables/input_mailboxes.rs
+++ b/libs/streamlib-plugin-abi/src/vtables/input_mailboxes.rs
@@ -1,18 +1,18 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! `InputMailboxesVTable` — extern "C" dispatch for the cdylib's `InputMailboxes` β-shape.
+//! `InputMailboxesVTable` — extern "C" dispatch for the cdylib's `InputMailboxes` PluginAbiObject.
 
 use core::ffi::c_void;
 
 /// Layout version of [`crate::InputMailboxesVTable`].
 ///
 /// - v1: ships four slots — the two cdylib processor's
-///   `InputMailboxes` β-shape needs from inside `process()`
+///   `InputMailboxes` PluginAbiObject needs from inside `process()`
 ///   (`read_raw` returns the next raw frame for a port with
 ///   `has_data` distinguishing "no data" from "error"; `has_data`
 ///   queries without consuming), plus the Arc lifecycle pair
-///   (`clone_arc` / `drop_arc`) every Arc-handle β-shape on this
+///   (`clone_arc` / `drop_arc`) every Arc-handle PluginAbiObject on this
 ///   ABI carries for refcount accounting in host-compiled code.
 /// - v2: appends `max_payload_for_port` so the cdylib can allocate
 ///   exactly the schema-declared `metadata.max_payload_bytes` for
@@ -27,7 +27,7 @@ use core::ffi::c_void;
 pub const INPUT_MAILBOXES_VTABLE_LAYOUT_VERSION: u32 = 2;
 
 /// `extern "C" fn` dispatch table for the cdylib's `InputMailboxes`
-/// β-shape. Replaces the shared-Rust-type `&mut InputMailboxes`
+/// PluginAbiObject. Replaces the shared-Rust-type `&mut InputMailboxes`
 /// crossing the cdylib used to expose to the host via
 /// `ProcessorVTable::get_iceoryx2_input_mailboxes_mut`.
 ///

--- a/libs/streamlib-plugin-abi/src/vtables/output_writer.rs
+++ b/libs/streamlib-plugin-abi/src/vtables/output_writer.rs
@@ -1,31 +1,31 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! `OutputWriterVTable` — extern "C" dispatch for the cdylib's `OutputWriter` β-shape.
+//! `OutputWriterVTable` — extern "C" dispatch for the cdylib's `OutputWriter` PluginAbiObject.
 
 use core::ffi::c_void;
 
 /// Layout version of [`crate::OutputWriterVTable`].
 ///
 /// - v1: ships the four slots a cdylib processor's `OutputWriter`
-///   β-shape needs to dispatch every public-API call through the
+///   PluginAbiObject needs to dispatch every public-API call through the
 ///   host: `write_raw` (the per-frame hot-path emit), `has_port`
 ///   (configuration query), `clone_arc` / `drop_arc`
-///   (refcount-managed handle lifetime so the cdylib-side β-shape
+///   (refcount-managed handle lifetime so the cdylib-side PluginAbiObject
 ///   can implement `Clone` + `Drop` without crossing the inner
 ///   `Arc<OutputWriterInner>` source layout).
 pub const OUTPUT_WRITER_VTABLE_LAYOUT_VERSION: u32 = 1;
 
 /// `extern "C" fn` dispatch table for the cdylib's `OutputWriter`
-/// β-shape. Replaces the shared-Rust-type `Arc<OutputWriter>`
+/// PluginAbiObject. Replaces the shared-Rust-type `Arc<OutputWriter>`
 /// crossing the cdylib used to expose to the host via
 /// `ProcessorVTable::get_iceoryx2_output_writer_arc`.
 ///
 /// Today the host allocates an `Arc<OutputWriterInner>` and hands
-/// the cdylib a `(handle, vtable)` β-shape that delegates every
+/// the cdylib a `(handle, vtable)` PluginAbiObject that delegates every
 /// public-API call through this vtable. Hot-path emits cross extern
 /// "C" once per `write` call; the bytes carry msgpack-encoded
-/// frames the cdylib serialized in its own DSO.
+/// frames the cdylib serialized in its own plugin.
 ///
 /// # Layout discipline
 ///
@@ -57,7 +57,7 @@ pub struct OutputWriterVTable {
 
     /// Write a raw msgpack-encoded frame to the named output port at
     /// the given timestamp. The cdylib serializes `T` to msgpack in
-    /// its own DSO and passes the bytes through; the host then runs
+    /// its own plugin and passes the bytes through; the host then runs
     /// the underlying iceoryx2 publish + notify. Returns `0` on
     /// success, non-zero on failure.
     pub write_raw: unsafe extern "C" fn(

--- a/libs/streamlib-plugin-abi/src/vtables/processor.rs
+++ b/libs/streamlib-plugin-abi/src/vtables/processor.rs
@@ -20,7 +20,7 @@ use crate::{InputMailboxesVTable, OutputWriterVTable};
 ///   `get_iceoryx2_*` slots are removed and a single
 ///   `set_iceoryx2_resources` slot is added. The host now allocates
 ///   `OutputWriterInner` and `InputMailboxesInner` and hands the
-///   cdylib `(handle, vtable)` β-shapes via the new slot; the
+///   cdylib `(handle, vtable)` PluginAbiObjects via the new slot; the
 ///   per-frame `write_raw` / `read_raw` calls dispatch through
 ///   [`crate::OutputWriterVTable`] / [`crate::InputMailboxesVTable`]. **ABI-
 ///   breaking** — plugins built against v1 are not load-compatible
@@ -185,7 +185,7 @@ pub struct ProcessorVTable {
     // The shared-Rust-type crossings (`Arc<OutputWriter>` /
     // `&mut InputMailboxes`) are retired. The host allocates the
     // `OutputWriterInner` and `InputMailboxesInner` and hands the
-    // cdylib opaque `(handle, vtable)` β-shapes via
+    // cdylib opaque `(handle, vtable)` PluginAbiObjects via
     // `set_iceoryx2_resources`. Per-frame `write_raw` / `read_raw`
     // dispatch through the new
     // [`crate::OutputWriterVTable`] / [`crate::InputMailboxesVTable`] slots.
@@ -195,12 +195,12 @@ pub struct ProcessorVTable {
     pub has_iceoryx2_inputs: unsafe extern "C" fn(instance: *const c_void) -> bool,
 
     /// Install host-allocated `OutputWriter` and `InputMailboxes`
-    /// β-shape handles into the cdylib's processor instance.
+    /// PluginAbiObject handles into the cdylib's processor instance.
     ///
     /// Called by the host once per processor instance after
     /// `construct` returns and before any port connections are
     /// wired. The cdylib's `from_config` initializes its `outputs`
-    /// / `inputs` β-shape fields with null `handle` + null `vtable`;
+    /// / `inputs` PluginAbiObject fields with null `handle` + null `vtable`;
     /// this callback patches in the host-allocated handles so the
     /// per-frame `write_raw` / `read_raw` calls in `process()` see
     /// non-null handles.
@@ -209,7 +209,7 @@ pub struct ProcessorVTable {
     /// opaque pointer; the cdylib owns one strong reference and
     /// balances it via `OutputWriterVTable::drop_arc` on Drop. Null
     /// when the processor has no outputs (the cdylib then keeps
-    /// the field's null β-shape and never dispatches through it).
+    /// the field's null PluginAbiObject and never dispatches through it).
     ///
     /// `input_mailboxes_handle` is an `Arc::into_raw(Arc<InputMailboxesInner>)`
     /// opaque pointer with the same lifetime contract. Null when

--- a/libs/streamlib-plugin-abi/src/vtables/rhi_color_converter.rs
+++ b/libs/streamlib-plugin-abi/src/vtables/rhi_color_converter.rs
@@ -12,11 +12,11 @@ use crate::repr::{ResolvedColorInfoRepr, SourceLayoutInfoRepr};
 /// - v1: ships the `prepare_buffer_to_image_storage` slot — the
 ///   minimum surface a cdylib camera processor needs to dispatch
 ///   YCbCr→RGBA conversion through the host's cached buffer→image
-///   kernel without panicking at the β-shape's host-mode-only
+///   kernel without panicking at the PluginAbiObject's host-mode-only
 ///   `host_inner()` access. Out-params return an opaque
 ///   `Arc<VulkanComputeKernelInner>`-shaped handle plus the kernel's
 ///   `push_constant_size` POD so the cdylib can reconstruct a
-///   `VulkanComputeKernel` β-shape via the parent FullAccess vtable's
+///   `VulkanComputeKernel` PluginAbiObject via the parent FullAccess vtable's
 ///   per-type methods vtable lookup.
 ///
 /// - v2: appends three sibling slots completing the Phase E sub-lift —
@@ -28,17 +28,17 @@ use crate::repr::{ResolvedColorInfoRepr, SourceLayoutInfoRepr};
 pub const RHI_COLOR_CONVERTER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 2;
 
 /// Per-type method-dispatch vtable for the `RhiColorConverter`
-/// β-shape (Phase E sub-lift slice A).
+/// PluginAbiObject (Phase E sub-lift slice A).
 ///
 /// `RhiColorConverter` keeps `clone_color_converter` /
 /// `drop_color_converter` dispatch on the parent
 /// [`crate::GpuContextFullAccessVTable`]; this vtable carries the
 /// `prepare_buffer_to_image_storage` slot so cdylib camera processors
 /// can prepare the host's cached buffer→image kernel without tripping
-/// the β-shape's host-mode-only `host_inner()` access. The slot
+/// the PluginAbiObject's host-mode-only `host_inner()` access. The slot
 /// returns an opaque `Arc<VulkanComputeKernelInner>`-shaped handle
 /// plus the kernel's `push_constant_size`; the cdylib reconstructs a
-/// `VulkanComputeKernel` β-shape via the host_callbacks() per-type
+/// `VulkanComputeKernel` PluginAbiObject via the host_callbacks() per-type
 /// methods vtable lookup.
 #[repr(C)]
 pub struct RhiColorConverterMethodsVTable {
@@ -53,7 +53,7 @@ pub struct RhiColorConverterMethodsVTable {
     /// Bind source / destination / push-constants on the converter's
     /// buffer→image kernel and return a fresh
     /// `Arc<VulkanComputeKernelInner>`-shaped opaque handle the cdylib
-    /// wraps into its `VulkanComputeKernel` β-shape via the
+    /// wraps into its `VulkanComputeKernel` PluginAbiObject via the
     /// `host_callbacks().vulkan_compute_kernel_methods_vtable` lookup.
     ///
     /// - `converter_handle` is
@@ -61,11 +61,11 @@ pub struct RhiColorConverterMethodsVTable {
     ///   the host does not bump the converter's refcount).
     /// - `src_buffer_handle` is
     ///   `Arc::into_raw(Arc<HostVulkanBufferInner>)`-shaped from the
-    ///   `StorageBuffer` β-shape's `handle` field (borrowed; the
+    ///   `StorageBuffer` PluginAbiObject's `handle` field (borrowed; the
     ///   cdylib retains ownership).
     /// - `dst_texture_handle` is
     ///   `Arc::into_raw(Arc<TextureInner>)`-shaped from the `Texture`
-    ///   β-shape's `handle` field (borrowed; the cdylib retains
+    ///   PluginAbiObject's `handle` field (borrowed; the cdylib retains
     ///   ownership).
     /// - `dst_transfer_raw` is the `#[repr(u32)]` discriminant of
     ///   `streamlib::core::color::TransferId`.
@@ -95,7 +95,7 @@ pub struct RhiColorConverterMethodsVTable {
     /// `PixelBuffer`-shape source variant of
     /// [`Self::prepare_buffer_to_image_storage`]. Identical contract;
     /// `src_buffer_handle` is `Arc::into_raw(Arc<HostVulkanBufferInner>)`-
-    /// shaped from a `PixelBuffer` β-shape's `handle` field (borrowed;
+    /// shaped from a `PixelBuffer` PluginAbiObject's `handle` field (borrowed;
     /// the cdylib retains ownership). v2 (Phase E sub-lift completion).
     pub prepare_buffer_to_image_pixel: unsafe extern "C" fn(
         converter_handle: *const c_void,

--- a/libs/streamlib-plugin-abi/src/vtables/rhi_command_recorder.rs
+++ b/libs/streamlib-plugin-abi/src/vtables/rhi_command_recorder.rs
@@ -13,7 +13,7 @@ use crate::repr::{DrawCallRepr, DrawIndexedCallRepr, ImageCopyRegionRepr, Semaph
 ///   to drive the host-owned `RhiCommandRecorder` per frame —
 ///   `begin`, `record_image_barrier`, `record_buffer_barrier`,
 ///   `record_dispatch`, `record_copy_image_to_buffer`,
-///   `submit_signaling_timeline`. Without these the β-shape's
+///   `submit_signaling_timeline`. Without these the PluginAbiObject's
 ///   `host_inner()` / `host_inner_mut()` panic-guards fire from
 ///   cdylib code on every per-frame call.
 /// - v2: appends two PixelBuffer-flavored sibling slots —
@@ -33,7 +33,7 @@ use crate::repr::{DrawCallRepr, DrawIndexedCallRepr, ImageCopyRegionRepr, Semaph
 ///   `vulkan_device_ref()` / `host_inner_mut()` directly:
 ///   `record_swapchain_image_barrier` (raw `VkImage` layout
 ///   transitions on swapchain images — distinct from the v1
-///   `record_image_barrier` which takes a `Texture` β-shape),
+///   `record_image_barrier` which takes a `Texture` PluginAbiObject),
 ///   `cmd_begin_dynamic_rendering` and `cmd_end_dynamic_rendering`
 ///   (dynamic-rendering pass bracketing against a caller-owned
 ///   `VkImageView` — no `VkRenderPass` / `VkFramebuffer` needed),
@@ -65,7 +65,7 @@ use crate::repr::{DrawCallRepr, DrawIndexedCallRepr, ImageCopyRegionRepr, Semaph
 pub const RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 5;
 
 /// Per-type method-dispatch vtable for the `RhiCommandRecorder`
-/// β-shape (Phase E sub-lift slice B — #984).
+/// PluginAbiObject (Phase E sub-lift slice B — #984).
 ///
 /// `RhiCommandRecorder` keeps `clone_command_recorder` /
 /// `drop_command_recorder` dispatch on the parent
@@ -74,7 +74,7 @@ pub const RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 5;
 /// dispatch through (`begin`, `record_image_barrier`,
 /// `record_buffer_barrier`, `record_dispatch`,
 /// `record_copy_image_to_buffer`, `submit_signaling_timeline`).
-/// Without these the β-shape's `host_inner_mut()` / `host_inner()`
+/// Without these the PluginAbiObject's `host_inner_mut()` / `host_inner()`
 /// panic-guards fire from cdylib code on every per-frame call.
 ///
 /// v3 (#1066) appends `record_swapchain_image_barrier`,
@@ -112,7 +112,7 @@ pub struct RhiCommandRecorderMethodsVTable {
 
     /// Begin a new recording. `recorder_handle` is the
     /// `Box::into_raw(Box<RhiCommandRecorderInner>)` pointer from
-    /// the β-shape's `handle` field. Returns 0 on success; non-zero
+    /// the PluginAbiObject's `handle` field. Returns 0 on success; non-zero
     /// with UTF-8 message in `err_buf` on failure. Linux-only on the
     /// host side; non-Linux stubs return non-zero.
     pub begin: unsafe extern "C" fn(
@@ -133,7 +133,7 @@ pub struct RhiCommandRecorderMethodsVTable {
     ///   `Box::into_raw(Box<RhiCommandRecorderInner>)` pointer.
     /// - `texture_handle` is
     ///   `Arc::into_raw(Arc<TextureInner>)`-shaped from the
-    ///   `Texture` β-shape's `handle` field (borrowed).
+    ///   `Texture` PluginAbiObject's `handle` field (borrowed).
     pub record_image_barrier: unsafe extern "C" fn(
         recorder_handle: *const c_void,
         texture_handle: *const c_void,
@@ -158,7 +158,7 @@ pub struct RhiCommandRecorderMethodsVTable {
     ///
     /// - `storage_buffer_handle` is
     ///   `Arc::into_raw(Arc<HostVulkanBufferInner>)`-shaped from
-    ///   the `StorageBuffer` β-shape's `handle` field (borrowed).
+    ///   the `StorageBuffer` PluginAbiObject's `handle` field (borrowed).
     pub record_buffer_barrier: unsafe extern "C" fn(
         recorder_handle: *const c_void,
         storage_buffer_handle: *const c_void,
@@ -174,7 +174,7 @@ pub struct RhiCommandRecorderMethodsVTable {
     /// Record a compute dispatch via
     /// `VulkanComputeKernel::record`. `kernel_handle` is the
     /// `Arc::into_raw(Arc<VulkanComputeKernelInner>)` pointer from
-    /// the kernel β-shape's `handle` field (borrowed).
+    /// the kernel PluginAbiObject's `handle` field (borrowed).
     pub record_dispatch: unsafe extern "C" fn(
         recorder_handle: *const c_void,
         kernel_handle: *const c_void,
@@ -192,10 +192,10 @@ pub struct RhiCommandRecorderMethodsVTable {
     ///
     /// - `src_texture_handle` is
     ///   `Arc::into_raw(Arc<TextureInner>)`-shaped from the source
-    ///   `Texture` β-shape's `handle` field (borrowed).
+    ///   `Texture` PluginAbiObject's `handle` field (borrowed).
     /// - `dst_storage_buffer_handle` is
     ///   `Arc::into_raw(Arc<HostVulkanBufferInner>)`-shaped from the
-    ///   destination `StorageBuffer` β-shape's `handle` field
+    ///   destination `StorageBuffer` PluginAbiObject's `handle` field
     ///   (borrowed).
     /// - `region` points at an [`crate::ImageCopyRegionRepr`] the host
     ///   reads once at call time.
@@ -233,7 +233,7 @@ pub struct RhiCommandRecorderMethodsVTable {
     ///
     /// - `pixel_buffer_handle` is
     ///   `Arc::into_raw(Arc<PixelBufferRef>)`-shaped from the
-    ///   `PixelBuffer` β-shape's `handle` field (borrowed).
+    ///   `PixelBuffer` PluginAbiObject's `handle` field (borrowed).
     pub record_pixel_buffer_barrier: unsafe extern "C" fn(
         recorder_handle: *const c_void,
         pixel_buffer_handle: *const c_void,
@@ -254,10 +254,10 @@ pub struct RhiCommandRecorderMethodsVTable {
     ///
     /// - `src_texture_handle` is
     ///   `Arc::into_raw(Arc<TextureInner>)`-shaped from the source
-    ///   `Texture` β-shape's `handle` field (borrowed).
+    ///   `Texture` PluginAbiObject's `handle` field (borrowed).
     /// - `dst_pixel_buffer_handle` is
     ///   `Arc::into_raw(Arc<PixelBufferRef>)`-shaped from the
-    ///   destination `PixelBuffer` β-shape's `handle` field
+    ///   destination `PixelBuffer` PluginAbiObject's `handle` field
     ///   (borrowed).
     /// - `region` points at an [`crate::ImageCopyRegionRepr`] the host
     ///   reads once at call time.
@@ -278,7 +278,7 @@ pub struct RhiCommandRecorderMethodsVTable {
 
     /// Record a layout transition on a raw `VkImage` handle —
     /// distinct from v1 [`Self::record_image_barrier`] which takes
-    /// a `Texture` β-shape. Used by `VulkanPresentTarget` to
+    /// a `Texture` PluginAbiObject. Used by `VulkanPresentTarget` to
     /// transition swapchain images (UNDEFINED →
     /// COLOR_ATTACHMENT_OPTIMAL and COLOR_ATTACHMENT_OPTIMAL →
     /// PRESENT_SRC_KHR) between cdylib-driven render-frame
@@ -369,7 +369,7 @@ pub struct RhiCommandRecorderMethodsVTable {
     ///
     /// - `kernel_handle` is the
     ///   `Arc::into_raw(Arc<VulkanGraphicsKernelInner>)` pointer
-    ///   from the kernel β-shape's `handle` field (borrowed).
+    ///   from the kernel PluginAbiObject's `handle` field (borrowed).
     /// - `draw` points at a [`crate::DrawCallRepr`] the host reads once
     ///   at call time.
     pub record_draw: unsafe extern "C" fn(

--- a/libs/streamlib-plugin-abi/src/vtables/runtime_context.rs
+++ b/libs/streamlib-plugin-abi/src/vtables/runtime_context.rs
@@ -83,7 +83,7 @@ pub struct RuntimeContextVTable {
     /// `RuntimeContextFullAccess` shim. Paired with the methods
     /// reached via [`crate::HostServices::gpu_context_limited_access_vtable`]
     /// for the limited-access surface (FullAccess is engine-only
-    /// today; cross-DSO FullAccess wiring is future-phase work).
+    /// today; plugin ABI FullAccess wiring is future-phase work).
     pub gpu_full_access: unsafe extern "C" fn(ctx: *const c_void) -> *const c_void,
 
     /// Returns an opaque handle to the restricted [`GpuContextLimitedAccess`].

--- a/libs/streamlib-plugin-abi/src/vtables/surface_store.rs
+++ b/libs/streamlib-plugin-abi/src/vtables/surface_store.rs
@@ -100,7 +100,7 @@ pub struct SurfaceStoreVTable {
     ) -> i32,
 
     /// Check out a surface by its `surface_id`. On success writes a
-    /// `PixelBuffer` β-shape into `*out_pixel_buffer` and returns 0.
+    /// `PixelBuffer` PluginAbiObject into `*out_pixel_buffer` and returns 0.
     pub check_out: unsafe extern "C" fn(
         handle: *const c_void,
         id_ptr: *const u8,
@@ -123,7 +123,7 @@ pub struct SurfaceStoreVTable {
     ) -> i32,
 
     /// Look up a previously-registered buffer by its pool id. Writes
-    /// a `PixelBuffer` β-shape into `*out_pixel_buffer` on success.
+    /// a `PixelBuffer` PluginAbiObject into `*out_pixel_buffer` on success.
     pub lookup_buffer: unsafe extern "C" fn(
         handle: *const c_void,
         pool_id_ptr: *const u8,
@@ -155,7 +155,7 @@ pub struct SurfaceStoreVTable {
     // error message.
 
     /// Register a texture for cross-process sharing. `texture` is a
-    /// `*const Texture` β-shape pointer; `produce_done_handle` and
+    /// `*const Texture` PluginAbiObject pointer; `produce_done_handle` and
     /// `consume_done_handle` are opaque `Arc<HostVulkanTimelineSemaphore>`
     /// pointers (null for "no timeline") that carry the
     /// single-writer-per-edge pair documented in
@@ -191,7 +191,7 @@ pub struct SurfaceStoreVTable {
     ) -> i32,
 
     /// Look up a registered texture by `surface_id`. Writes a
-    /// `Texture` β-shape into `*out_texture` and the producer's
+    /// `Texture` PluginAbiObject into `*out_texture` and the producer's
     /// last-published `VkImageLayout` (raw i32) into `*out_layout_raw`.
     pub lookup_texture: unsafe extern "C" fn(
         handle: *const c_void,

--- a/libs/streamlib-plugin-abi/src/vtables/texture_ring.rs
+++ b/libs/streamlib-plugin-abi/src/vtables/texture_ring.rs
@@ -8,31 +8,31 @@ use core::ffi::c_void;
 /// Layout version of [`crate::TextureRingMethodsVTable`].
 ///
 /// - v1: empty shell — pointer plumbing only.
-/// - v2: `TextureRingSlot` β-shape lands (fixed-size POD
+/// - v2: `TextureRingSlot` PluginAbiObject lands (fixed-size POD
 ///   `surface_id_bytes: [u8; 64]` + `surface_id_len: u32` +
 ///   `slot_index: u32`, replacing the heap `String` surface_id) and
 ///   the method slots `acquire_next` / `copy_pixel_buffer_to_slot` /
-///   `slot` get wired through. Each cross-DSO call uses caller-
+///   `slot` get wired through. Each plugin ABI call uses caller-
 ///   provided out-parameter buffers for the slot's typed POD bytes;
-///   the slot's `texture` β-shape is itself a `(handle, vtable,
+///   the slot's `texture` PluginAbiObject is itself a `(handle, vtable,
 ///   POD)` triple cloned through its own per-type Clone vtable.
 pub const TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION: u32 = 2;
 
-/// Per-type method-dispatch vtable for the `TextureRing` β-shape
-/// (issue #907 Phase E + #947 slot β-shape + method dispatch).
+/// Per-type method-dispatch vtable for the `TextureRing` PluginAbiObject
+/// (issue #907 Phase E + #947 slot PluginAbiObject + method dispatch).
 ///
 /// `TextureRing` keeps `clone_*` / `drop_*` dispatch on the parent
 /// [`crate::GpuContextFullAccessVTable`] (PR #918's Phase D shape); this
-/// vtable adds per-method slots for everything *else* the β-shape
+/// vtable adds per-method slots for everything *else* the PluginAbiObject
 /// exposes — `acquire_next`, `copy_pixel_buffer_to_slot`, `slot`.
 /// POD getters (`len`, `is_empty`, `width`, `height`, `format`) are
-/// cached on the β-shape struct itself and don't need vtable slots.
+/// cached on the PluginAbiObject struct itself and don't need vtable slots.
 ///
 /// **Slot-return shape (v2):** `acquire_next` and `slot` return the
 /// slot's owned typed POD bytes via caller-provided out-parameter
 /// buffers (`out_texture_handle` + cached POD slot for the slot's
 /// `Texture`, plus `out_surface_id_bytes` + `out_surface_id_len` +
-/// `out_slot_index`). The slot's `Texture` β-shape itself manages
+/// `out_slot_index`). The slot's `Texture` PluginAbiObject itself manages
 /// its Arc lifetime through the parent
 /// [`crate::GpuContextLimitedAccessVTable`]'s `clone_texture` /
 /// `drop_texture` slots — when the host wrapper hands a cloned
@@ -40,7 +40,7 @@ pub const TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION: u32 = 2;
 /// `drop_texture` to balance the clone. Surface IDs travel inline
 /// as fixed 64-byte buffers (UUIDs are 36 ASCII chars; the 64-byte
 /// budget leaves headroom for the bytes + length without a heap
-/// allocation crossing the DSO boundary).
+/// allocation crossing the plugin ABI).
 ///
 /// **`copy_pixel_buffer_to_slot` (v2):** the caller passes the
 /// slot's `slot_index` (looks up the slot's pre-allocated upload
@@ -136,7 +136,7 @@ mod tests {
 
     #[test]
     fn texture_ring_methods_vtable_layout() {
-        // v2 (slot β-shape + method-dispatch slots added):
+        // v2 (slot PluginAbiObject + method-dispatch slots added):
         //   layout_version              @ 0   (4 bytes, u32)
         //   _reserved_padding           @ 4   (4 bytes, u32)
         //   acquire_next                @ 8   (8 bytes, fn pointer)

--- a/libs/streamlib-plugin-abi/src/vtables/vulkan_acceleration_structure.rs
+++ b/libs/streamlib-plugin-abi/src/vtables/vulkan_acceleration_structure.rs
@@ -14,7 +14,7 @@ use core::ffi::c_void;
 ///   `TextureRingSlot.surface_id` from #947 — `String` layout
 ///   isn't cdylib-safe). `vk_handle` stays host-only — the
 ///   `vk::AccelerationStructureKHR` is a vulkanalia handle that
-///   can't safely cross a DSO boundary without vulkanalia
+///   can't safely cross the plugin ABI without vulkanalia
 ///   version coupling, and no in-tree cdylib consumer reads it.
 ///   The POD getters (`device_address`, `storage_size`, `kind`)
 ///   are populated at mint time via the v8
@@ -23,14 +23,14 @@ use core::ffi::c_void;
 pub const VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION: u32 = 2;
 
 /// Per-type method-dispatch vtable for the
-/// `VulkanAccelerationStructure` β-shape (issue #907 Phase E PR 5/5
+/// `VulkanAccelerationStructure` PluginAbiObject (issue #907 Phase E PR 5/5
 /// + #955 method dispatch).
 ///
 /// Mirrors the kernel methods-vtable shape. POD getters
 /// (`device_address`, `kind`, `storage_size`) are populated at mint
 /// time via the v8 [`crate::GpuContextFullAccessVTable::build_triangles_blas`]
 /// / `build_tlas` out-params and don't need vtable slots — the
-/// cached values on the β-shape struct are always real, never
+/// cached values on the PluginAbiObject struct are always real, never
 /// placeholder zeros.
 ///
 /// The single vtable slot is `label`, which uses the same byte-

--- a/libs/streamlib-plugin-abi/src/vtables/vulkan_compute_kernel.rs
+++ b/libs/streamlib-plugin-abi/src/vtables/vulkan_compute_kernel.rs
@@ -26,7 +26,7 @@ use crate::repr::ComputeBindingSpecRepr;
 ///   `[ComputeBindingSpecRepr]` buffer and reports the actual count.
 ///   Status code 2 signals "buffer too small" with the required count
 ///   in `out_specs_len`; callers reallocate and retry. Replaces the
-///   β-shape's bare `host_inner().bindings()` call which panicked
+///   PluginAbiObject's bare `host_inner().bindings()` call which panicked
 ///   from cdylib code.
 ///
 /// - v5: appended four raw-vulkanalia-handle slots —
@@ -36,14 +36,14 @@ use crate::repr::ComputeBindingSpecRepr;
 ///   (vulkanalia's handles are `#[repr(transparent)] pub struct
 ///   ImageView(u64)` / `CommandBuffer(usize)`, so the wire form is the
 ///   raw integer the host reconstructs via `Handle::from_raw`).
-///   Replaces the β-shape's bare `host_inner().set_*_view(...)` /
+///   Replaces the PluginAbiObject's bare `host_inner().set_*_view(...)` /
 ///   `host_inner().record(...)` calls that engine SDK code
 ///   (`RgbToNv12Converter::convert`, `Nv12ToRgbConverter::convert`)
 ///   reaches per-frame from cdylib-resident processor bodies (#1073).
 pub const VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 5;
 
 /// Per-type method-dispatch vtable for the `VulkanComputeKernel`
-/// β-shape (issue #907 Phase E + #949 method-dispatch first slice).
+/// PluginAbiObject (issue #907 Phase E + #949 method-dispatch first slice).
 ///
 /// `VulkanComputeKernel` keeps `clone_*` / `drop_*` dispatch on the
 /// parent [`crate::GpuContextFullAccessVTable`] (PR #918's Phase D shape);
@@ -52,7 +52,7 @@ pub const VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 5;
 ///
 /// **Binding-method shape:** typed-by-input-wrapper (one slot per
 /// kernel-method × buffer-or-texture wrapper). This mirrors the
-/// production cross-DSO pattern used by Dawn / WebGPU (`WGPUBuffer`
+/// production plugin ABI pattern used by Dawn / WebGPU (`WGPUBuffer`
 /// + per-binding-kind method) and Unreal RHI (typed
 /// `SetShaderResourceViewParameter` methods) while honoring
 /// streamlib's existing typed-wrapper allocation layer (separate

--- a/libs/streamlib-plugin-abi/src/vtables/vulkan_graphics_kernel.rs
+++ b/libs/streamlib-plugin-abi/src/vtables/vulkan_graphics_kernel.rs
@@ -41,7 +41,7 @@ use crate::repr::{
 pub const VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 4;
 
 /// Per-type method-dispatch vtable for the `VulkanGraphicsKernel`
-/// β-shape (issue #907 Phase E PR 3/5 + #951 method-dispatch slice).
+/// PluginAbiObject (issue #907 Phase E PR 3/5 + #951 method-dispatch slice).
 ///
 /// `VulkanGraphicsKernel` keeps `clone_*` / `drop_*` dispatch on the
 /// parent [`crate::GpuContextFullAccessVTable`] (PR #918's Phase D shape);
@@ -51,7 +51,7 @@ pub const VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 4;
 /// **Binding-method shape:** typed-by-input-wrapper (one slot per
 /// kernel-method × buffer-or-texture wrapper). Mirrors the
 /// `VulkanComputeKernelMethodsVTable` v3 shape and the production
-/// cross-DSO patterns in Dawn / WebGPU + Unreal RHI.
+/// plugin ABI patterns in Dawn / WebGPU + Unreal RHI.
 ///
 /// **Coverage today** (v4):
 /// - Binding slots: `set_storage_buffer_pixel`,

--- a/libs/streamlib-plugin-abi/src/vtables/vulkan_ray_tracing_kernel.rs
+++ b/libs/streamlib-plugin-abi/src/vtables/vulkan_ray_tracing_kernel.rs
@@ -29,7 +29,7 @@ use crate::repr::RayTracingBindingSpecRepr;
 pub const VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 3;
 
 /// Per-type method-dispatch vtable for the `VulkanRayTracingKernel`
-/// β-shape.
+/// PluginAbiObject.
 ///
 /// Mirrors the compute-kernel vtable shape (serial dispatch — one
 /// command buffer + fence owned by the kernel, no `frame_index`

--- a/packages/test-fixtures/src/concurrent_escalate_test_processor.rs
+++ b/packages/test-fixtures/src/concurrent_escalate_test_processor.rs
@@ -21,7 +21,7 @@
 //! Mirrors the in-process `test_escalate_serializes_concurrent_callers`
 //! test (`libs/streamlib-engine/src/core/context/gpu_context.rs`) but
 //! drives the cdylib path through `escalate_via_vtable` — the
-//! cross-DSO contract the audit flagged as previously uncovered.
+//! plugin ABI contract the audit flagged as previously uncovered.
 
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;

--- a/packages/test-fixtures/src/escalate_smoke_test_processor.rs
+++ b/packages/test-fixtures/src/escalate_smoke_test_processor.rs
@@ -3,8 +3,8 @@
 
 //! Phase C3 + Phase D dlopen-cdylib escalate smoke test fixture.
 //!
-//! Proves the scope-token machinery fires end-to-end through the FFI
-//! boundary AND that representative `GpuContextFullAccess` vtable
+//! Proves the scope-token machinery fires end-to-end through the
+//! plugin ABI AND that representative `GpuContextFullAccess` vtable
 //! slots — both Phase D Bucket B (new FullAccess slots) and Bucket C
 //! (Option B Limited-vtable inheritance) — dispatch correctly from
 //! cdylib code. The processor's `start()` runs an escalate scope that
@@ -20,7 +20,7 @@
 //!        `with_full_scope_or_err`.
 //!      - `full.acquire_pixel_buffer(...)` — Phase D Bucket C
 //!        (Option B inherited LimitedAccess vtable dispatch).
-//!        Returns a `PixelBuffer` β-shape through the FFI.
+//!        Returns a `PixelBuffer` PluginAbiObject through the plugin ABI.
 //!      - `full.acquire_output_texture(...)` — Phase D Bucket B
 //!        (new FullAccess vtable slot returning `(String, Texture)`).
 //!      - `full.register_texture_with_layout(...)` — Phase D Bucket C

--- a/packages/test-fixtures/src/gpu_acquire_test_processor.rs
+++ b/packages/test-fixtures/src/gpu_acquire_test_processor.rs
@@ -12,7 +12,7 @@
 //!   2. `start()` — acquires a `PixelBuffer` via the stashed
 //!      `GpuContextLimitedAccess::acquire_pixel_buffer`. Exercises
 //!      `acquire_pixel_buffer` (paired-out-param tuple return). Reads
-//!      the cached `width`/`height` (POD; no cross-DSO dispatch).
+//!      the cached `width`/`height` (POD; no plugin ABI dispatch).
 //!      Calls `plane_base_address(0)` — exercises
 //!      `plane_base_address_pixel_buffer`. Writes a sentinel byte
 //!      through the returned pointer to prove the host-allocated
@@ -38,12 +38,12 @@ pub struct GpuAcquireTest {
 
 impl ManualProcessor for GpuAcquireTest::Processor {
     fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        // Clone the GpuContextLimitedAccess across the cdylib DSO
-        // boundary. The `Clone` impl dispatches through the
+        // Clone the GpuContextLimitedAccess across the plugin ABI.
+        // The `Clone` impl dispatches through the
         // `clone_handle` vtable callback (Arc refcount bump on
         // `Arc<GpuContext>`); dropping the clone in `teardown()`
         // fires `drop_handle`. Both refcount ops run in host-compiled
-        // code regardless of caller DSO.
+        // code regardless of caller plugin.
         self.gpu = Some(ctx.gpu_limited_access().clone());
         Ok(())
     }
@@ -64,7 +64,7 @@ impl ManualProcessor for GpuAcquireTest::Processor {
                 gpu.acquire_pixel_buffer(width, height, PixelFormat::Bgra32)?;
 
             // Read the cached POD width/height (pure field reads,
-            // no cross-DSO dispatch).
+            // no plugin ABI dispatch).
             let observed_w = pixel_buffer.width;
             let observed_h = pixel_buffer.height;
 

--- a/packages/test-fixtures/src/opengl_smoke_test_processor.rs
+++ b/packages/test-fixtures/src/opengl_smoke_test_processor.rs
@@ -8,7 +8,7 @@
 //!   1. Cdylib's `start()` enters `gpu.escalate(|full| ...)`.
 //!   2. `host_vulkan_device_arc()` (v9) → `Arc<HostVulkanDevice>`.
 //!   3. `full.acquire_render_target_dma_buf_image()` → `Texture`
-//!      β-shape; `host_vulkan_texture_arc()` (v10) →
+//!      PluginAbiObject; `host_vulkan_texture_arc()` (v10) →
 //!      `Arc<HostVulkanTexture>`.
 //!   4. Pub methods on the texture Arc — `export_dma_buf_fd()`,
 //!      `dma_buf_plane_layout()`, `chosen_drm_format_modifier()` —

--- a/packages/test-fixtures/src/surface_share_escalate_consistency_test_processor.rs
+++ b/packages/test-fixtures/src/surface_share_escalate_consistency_test_processor.rs
@@ -175,7 +175,7 @@ fn run_smoke(
 
     // Step 3: dual-register via the in-process texture_cache
     // channel so the Path-1 resolve below hits the fast path.
-    // Cloning the Texture β-shape bumps the underlying
+    // Cloning the Texture PluginAbiObject bumps the underlying
     // Arc<TextureInner> via the LimitedAccess `clone_texture` slot.
     let texture_cache_clone = texture.clone();
     full.register_texture_with_layout(
@@ -203,7 +203,7 @@ fn run_smoke(
         })?;
 
     // Step 5: look up via the cross-process (surface-share daemon)
-    // path. Returns a fresh Texture β-shape over the same imported
+    // path. Returns a fresh Texture PluginAbiObject over the same imported
     // VkImage. Both texture handles release on scope exit; the
     // host-side Arcs drop in inverse-construction order.
     let (looked_up_texture, looked_up_layout) =

--- a/packages/test-fixtures/src/vulkan_smoke_test_processor.rs
+++ b/packages/test-fixtures/src/vulkan_smoke_test_processor.rs
@@ -8,7 +8,7 @@
 //!   1. Cdylib's `start()` enters `gpu.escalate(|full| ...)`.
 //!   2. `host_vulkan_device_arc()` (v9) → `Arc<HostVulkanDevice>`.
 //!   3. `full.acquire_render_target_dma_buf_image(...)` → `Texture`
-//!      β-shape; `host_vulkan_texture_arc()` (v10) →
+//!      PluginAbiObject; `host_vulkan_texture_arc()` (v10) →
 //!      `Arc<HostVulkanTexture>`.
 //!   4. `HostVulkanTimelineSemaphore::new(device_arc.device(), 0)` —
 //!      cdylib-reachable direct constructor (non-exportable variant


### PR DESCRIPTION
Closes #972.

Consolidates plugin-system terminology to the canonical five-term set — **host**, **plugin**, **plugin ABI**, **vtable**, **PluginAbiObject**, **handle** — across comments, doc-comments, markdown docs, CLAUDE.md, and string literals so a fresh reader greps one canonical reference per concept with no synonym false-positives. **Naming only; no behavior change** (112 files, +885/−880 — the balanced delta of an in-place rename sweep).

## What changed

| Banned synonym | → canonical | count |
|---|---|---|
| `β-shape` / `β-shaped` | `PluginAbiObject` | 453 |
| `cross-DSO` / `cross-ABI` | `plugin ABI` | 134 |
| `fat-pointer` (the object shape) | `PluginAbiObject` | — |
| `plugin boundary` | `plugin ABI` | — |
| prose `FFI` / `DSO` / `dylib` meaning the boundary | `plugin ABI` / `plugin` | — |

Plus identifier renames (the "major offenders"):
- test modules `beta_shape_layout_tests` → `plugin_abi_object_layout_tests` (3 vulkan/rhi kernel files) + two test fns carrying `beta_shape`.
- cross-rustc fixture processor/schema `BetaShapeRoundTrip*` → `PluginAbiObjectRoundTrip*`, including the schema YAML file rename — `build.rs` JTD codegen regenerated, cdylib + integration test compile clean.

### Deliberately preserved / not touched
- **Existing `~~strikethrough~~` / "Superseded" historical blocks** — left byte-for-byte (the only place banned terms may legitimately remain, per the markdown editing rules). CLAUDE.md edits were active-prose only.
- A genuine Rust `&'static dyn Log` **trait-object fat pointer** (iceoryx2 log bridge) and a `&[&[T]]` slice-of-slices ABI mismatch (acceleration structure) were reworded to accurate neutral wording — **not** mislabeled "PluginAbiObject" (a `dyn` fat pointer ≠ a `#[repr(C)]{handle,vtable}` object).
- `cdylib` in `crate-type = [...]` lines, std `ffi` module paths, file/link paths, and vendored `.venv/` third-party headers (pybind11/torch — gitignored, out of scope).

## How it was done
Bounded grep discovery → shared rules spec → 8 file-disjoint parallel sub-agents (each scoped to one file group) → 4 missed `tests/load_project_dylib_*.rs` swept directly. No single context read the whole tree.

## Validation
- ✅ Issue's gate grep (`β-shape|beta-shape|cross-ABI|cross-DSO|COM-style|fat-pointer|plugin boundary|plugin-loadable`) over all git-tracked files: **zero matches**. Identifier-form (`beta_shape`/`BetaShape`/`cross_dso`): **zero**.
- ✅ `cargo test --workspace` (canonical baseline, 5 example-crate exclusions): all 116 test binaries `ok`.
- ⚠️ Pre-existing/environmental: `load_project_dylib_camera_smoke::…_against_vivid` fails with `BuildRequiredButNoOrchestrator { @tatolab/core, IfStale }` — **reproduces identically on clean `main`** (needs `@tatolab/core` pre-built in the local slpkg cache or an injected `BuildOrchestrator`, neither present in a bare `cargo test`; stems from recent runtime-module-materialization work). Not caused by this sweep.

## Exit criteria
- [x] CLAUDE.md canonical vocab; superseded blocks preserved
- [x] `docs/architecture/*` + `docs/learnings/*` canonical
- [x] Rust source comments/doc-comments canonical
- [x] Major identifier offenders renamed; non-offenders untouched
- [x] Milestone-20 body updated (active prose); only open milestone-20 issue with banned terms is #972 itself (the ban spec — correctly left)

🤖 Generated with [Claude Code](https://claude.com/claude-code)