### PR TITLE
chore(gitea): registry namespace provisioning tooling + POC cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,8 @@ TASK-*.md
 # See docs/architecture/schema-identity-and-packaging.md.
 _generated_/
 
-# Local-only operator override scripts: machine-specific values, private
-# deployment targets, secrets. Convention is <name>.local.sh sitting next to a
-# committed generic <name>.sh. Never part of a PR.
+# Local-only operator override files (scripts + runbooks): machine-specific
+# values, private deployment targets, secrets. Convention is <name>.local.<ext>
+# sitting next to a committed generic <name>.<ext>. Never part of a PR.
 *.local.sh
+*.local.md

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,8 @@ TASK-*.md
 # build hook for the Python SDK; `deno task setup` for Deno projects).
 # See docs/architecture/schema-identity-and-packaging.md.
 _generated_/
+
+# Local-only operator override scripts: machine-specific values, private
+# deployment targets, secrets. Convention is <name>.local.sh sitting next to a
+# committed generic <name>.sh. Never part of a PR.
+*.local.sh

--- a/docs/architecture/gitea-registry-distribution.md
+++ b/docs/architecture/gitea-registry-distribution.md
@@ -45,7 +45,7 @@ The distinction is load-bearing: SDK libraries are versioned registry
 dependencies; packages are **source-only `.slpkg`s** in the generic registry
 whose code resolves the SDK libraries by version when built on the host.
 
-## Namespace — the `tatolab` org (finalized in #1115)
+## Namespace — the `tatolab` org
 
 Everything lives under a Gitea **org** named `tatolab`, matching the
 `@tatolab/...` package naming:
@@ -55,11 +55,15 @@ Everything lives under a Gitea **org** named `tatolab`, matching the
 - npm: scope `@tatolab` → `/api/packages/tatolab/npm`
 - generic (`.slpkg`): `/api/packages/tatolab/generic/<name>/<version>/<file>`
 
-> The validating POC published under a Gitea *user* named `streamlib` by
-> mistake (`streamlib/_cargo-index`). `_cargo-index` is Gitea's internal
-> per-owner sparse-index repo — normal mechanism; under the org it becomes
-> `tatolab/_cargo-index`. #1115 stands up the org, re-publishes under it, and
-> removes the POC artifacts.
+The org is owned by a dedicated admin user; all four registries are reachable
+as soon as the org exists and Gitea's package feature is on. The cargo
+registry uses the **sparse** protocol
+(`sparse+.../api/packages/tatolab/cargo/`) — Gitea serves the index from its
+package database, so there is **no `_cargo-index` repo to create and no
+web-session "initialize" step**: the registry is reachable immediately and
+the first `cargo publish` populates the DB-backed index. Standing the
+namespace up is scripted and idempotent — see
+[Operational notes](#operational-notes).
 
 ## Resolution: by version, never paths
 
@@ -139,14 +143,40 @@ publish a dev version and bump — there is no relative-path escape hatch by
 design (that "purity" is what makes splitting crates into their own repos a
 no-op later).
 
-## Operational notes (carry into #1115 runbook)
+## Operational notes
+
+Standing up / verifying a registry namespace is scripted and idempotent. The
+committed scripts are generic — configure the org / admin / URL via the
+environment, so the same tooling provisions the central registry and any
+self-hosted instance:
+
+- `scripts/gitea/provision-registry.sh` — ensures the admin owner + `GITEA_ORG`
+  exist and that cargo/pypi/npm/generic are reachable. API mode
+  (`GITEA_ADMIN_TOKEN=…`) targets any Gitea — local container or a hosted
+  backend — unchanged; bootstrap mode creates the admin via the local
+  container CLI when no token exists yet.
+- `scripts/gitea/smoke-test-registry.sh` — publishes a throwaway crate,
+  resolves it by version, removes it, and round-trips the generic registry;
+  self-cleaning, safe to re-run against a live registry.
+
+Notes the scripts encode:
 
 - One Gitea container hosts all four registries (cargo/pypi/npm/generic) — a
   single lightweight Go binary, no JVM. Local dev registry today; lifts to a
   cloud Gitea for the hosted/centralized backend unchanged.
-- cargo gotchas: token stored `Bearer <token>` in `credentials.toml`
-  (`cargo login` stores it bare → 401); cargo index needs a one-time
-  web-session init (`/user/settings/packages/cargo/initialize`).
+- cargo token must be stored as `Bearer <token>` in `credentials.toml`
+  (`cargo login` stores it bare → 401).
+- The **sparse** cargo index needs no setup: the registry is reachable once
+  the org exists and the first publish populates the DB-backed index.
+
+  > ~~cargo index needs a one-time web-session init
+  > (`/user/settings/packages/cargo/initialize`).~~ — Superseded 2026-05-29.
+  > That step belongs to Gitea's older **git-based** cargo index. The
+  > committed shape uses the sparse protocol (`sparse+…`), which Gitea serves
+  > from the package DB with no `_cargo-index` repo and no initialize call.
+- The generic registry (the `.slpkg` home) requires a **raw** request body on
+  upload (`curl --upload-file`); a urlencoded body (`curl --data`) is rejected
+  with HTTP 500.
 - `cargo publish --no-verify` publishes source without compiling — the lever
   that makes the heavy engine chain tractable; consumers verify by building.
 - Submodule-vendored crates (`vulkanalia-vma`'s VMA/Vulkan-Headers) must be
@@ -163,7 +193,7 @@ no-op later).
 |---|---|---|
 | cargo publish → resolve-by-version (real SDK chain + vulkanalia/VMA) | ✅ validated (POC) | #1105 |
 | `.slpkg` round-trip through the generic registry | ✅ validated (POC) | #1119 |
-| `tatolab` org namespace + POC cleanup | ⏳ | #1115 |
+| `tatolab` org namespace + POC cleanup | ✅ shipped | #1115 |
 | schema-package registry resolution + cargo-publish path-strip | ⏳ | #1116 |
 | Python SDK publish | ⏳ | #1117 |
 | Deno SDK publish | ⏳ | #1118 |

--- a/scripts/gitea/provision-registry.sh
+++ b/scripts/gitea/provision-registry.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# Provision a Gitea registry namespace for a self-hosted StreamLib package
+# registry — your own admin owner + org with all four package registries
+# (cargo / pypi / npm / generic) reachable under it.
+#
+# Point it at any Gitea instance you control and pass your own org / admin via
+# the environment; the script bakes in no specific namespace. Standing up a
+# StreamLib registry for your team is the same one command whether it runs
+# against a local dev container or a hosted Gitea.
+#
+# Stands up (idempotently):
+#   - a surviving admin/owner user (GITEA_ADMIN_USER)
+#   - the GITEA_ORG org that owns all four package registries
+#   - verifies cargo / pypi / npm / generic registries are reachable under it
+#
+# The four registries are reachable as soon as the org exists and Gitea's
+# package feature is enabled. The cargo registry uses the SPARSE protocol
+# (`sparse+<url>/api/packages/<org>/cargo/`), which Gitea serves from the
+# package DB — there is NO `_cargo-index` repo to create and NO web-session
+# "initialize" step. The first `cargo publish` populates the DB-backed index.
+#
+# Two modes:
+#   API mode (preferred, works against any Gitea including a hosted one):
+#     export GITEA_ADMIN_TOKEN=<token for an existing admin>
+#     GITEA_ORG=<your-org> ./provision-registry.sh
+#   Bootstrap mode (local dev container, no token yet):
+#     creates the admin user + token via the container CLI, then proceeds.
+#     Requires docker access to $GITEA_CONTAINER. On a host where your shell
+#     is not yet in the docker group, run under: sg docker -c '...'.
+#
+# Env:
+#   GITEA_ORG            REQUIRED — the org namespace to stand up
+#   GITEA_URL            default http://localhost:3000
+#   GITEA_ADMIN_USER     default registry-admin
+#   GITEA_ADMIN_TOKEN    if set, API mode; else bootstrap mode
+#   GITEA_ADMIN_EMAIL    default ${GITEA_ADMIN_USER}@example.com
+#   GITEA_ADMIN_PASSWORD bootstrap mode only; required to create the admin user
+#   GITEA_CONTAINER      default gitea (bootstrap mode only)
+#   RUN_SMOKE            if "1", run smoke-test-registry.sh at the end
+#
+# Exit codes: 0 = provisioned & verified, 1 = failure.
+
+set -euo pipefail
+
+GITEA_ORG="${GITEA_ORG:-}"
+GITEA_URL="${GITEA_URL:-http://localhost:3000}"
+GITEA_ADMIN_USER="${GITEA_ADMIN_USER:-registry-admin}"
+GITEA_ADMIN_TOKEN="${GITEA_ADMIN_TOKEN:-}"
+GITEA_ADMIN_EMAIL="${GITEA_ADMIN_EMAIL:-${GITEA_ADMIN_USER}@example.com}"
+GITEA_ADMIN_PASSWORD="${GITEA_ADMIN_PASSWORD:-}"
+GITEA_CONTAINER="${GITEA_CONTAINER:-gitea}"
+RUN_SMOKE="${RUN_SMOKE:-0}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+log()  { printf '[provision-registry] %s\n' "$*"; }
+fail() { printf '[provision-registry] ERROR: %s\n' "$*" >&2; exit 1; }
+
+[ -n "$GITEA_ORG" ] || fail "set GITEA_ORG to the org namespace you want to stand up"
+
+http_code() {
+  # http_code METHOD URL [auth]  -> prints the status code
+  local method="$1" url="$2" auth="${3:-}"
+  if [ -n "$auth" ]; then
+    curl -s -o /dev/null -w '%{http_code}' -X "$method" \
+      -H "Authorization: token $GITEA_ADMIN_TOKEN" "$url"
+  else
+    curl -s -o /dev/null -w '%{http_code}' -X "$method" "$url"
+  fi
+}
+
+gitea_cli() {
+  docker exec -u git "$GITEA_CONTAINER" gitea "$@"
+}
+
+bootstrap_admin() {
+  command -v docker >/dev/null 2>&1 \
+    || fail "no GITEA_ADMIN_TOKEN set and 'docker' unavailable for bootstrap; set GITEA_ADMIN_TOKEN instead"
+  [ -n "$GITEA_ADMIN_PASSWORD" ] \
+    || fail "bootstrap mode needs GITEA_ADMIN_PASSWORD to create the '$GITEA_ADMIN_USER' admin user"
+
+  if gitea_cli admin user list 2>/dev/null | awk '{print $2}' | grep -qx "$GITEA_ADMIN_USER"; then
+    log "Admin user '$GITEA_ADMIN_USER' already exists"
+  else
+    log "Creating admin user '$GITEA_ADMIN_USER'"
+    gitea_cli admin user create \
+      --username "$GITEA_ADMIN_USER" \
+      --password "$GITEA_ADMIN_PASSWORD" \
+      --email "$GITEA_ADMIN_EMAIL" \
+      --admin --must-change-password=false >/dev/null \
+      || fail "failed to create admin user"
+  fi
+
+  log "Generating an access token for '$GITEA_ADMIN_USER'"
+  local out
+  out="$(gitea_cli admin user generate-access-token \
+    --username "$GITEA_ADMIN_USER" \
+    --token-name "provision-$(date +%s)" \
+    --scopes all 2>&1)" || fail "failed to generate token: $out"
+  GITEA_ADMIN_TOKEN="$(printf '%s\n' "$out" | grep -oE '[0-9a-f]{40}' | tail -1)"
+  [ -n "$GITEA_ADMIN_TOKEN" ] || fail "could not parse generated token from: $out"
+}
+
+ensure_org() {
+  local code
+  code="$(http_code GET "$GITEA_URL/api/v1/orgs/$GITEA_ORG")"
+  if [ "$code" = "200" ]; then
+    log "Org '$GITEA_ORG' already exists"
+    return
+  fi
+  log "Creating org '$GITEA_ORG'"
+  code="$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+    -H "Authorization: token $GITEA_ADMIN_TOKEN" -H 'Content-Type: application/json' \
+    "$GITEA_URL/api/v1/orgs" \
+    -d "{\"username\":\"$GITEA_ORG\",\"visibility\":\"public\"}")"
+  [ "$code" = "201" ] || fail "org creation returned HTTP $code"
+}
+
+verify_registries() {
+  local ok=1
+  # cargo: the computed sparse-index config endpoint must serve this org's URLs
+  local cfg
+  cfg="$(curl -s "$GITEA_URL/api/packages/$GITEA_ORG/cargo/config.json")"
+  if printf '%s' "$cfg" | grep -q "/api/packages/$GITEA_ORG/cargo"; then
+    log "cargo    reachable (sparse config.json OK)"
+  else
+    log "cargo    NOT reachable: $cfg"; ok=0
+  fi
+  # generic: a definitive write→read→delete round-trip.
+  # NB: Gitea's generic upload needs a raw body (--upload-file); a urlencoded
+  # body (curl --data) is rejected with HTTP 500.
+  local probe="provision-probe/0.0.0/probe.txt" code tmpf
+  tmpf="$(mktemp)"; printf 'probe' > "$tmpf"
+  code="$(curl -s -o /dev/null -w '%{http_code}' -X PUT \
+    -H "Authorization: token $GITEA_ADMIN_TOKEN" \
+    --upload-file "$tmpf" "$GITEA_URL/api/packages/$GITEA_ORG/generic/$probe")"
+  rm -f "$tmpf"
+  if [ "$code" = "201" ]; then
+    curl -s -o /dev/null -X DELETE -H "Authorization: token $GITEA_ADMIN_TOKEN" \
+      "$GITEA_URL/api/packages/$GITEA_ORG/generic/$probe" || true
+    log "generic  reachable (PUT/DELETE round-trip OK)"
+  else
+    log "generic  NOT reachable: PUT HTTP $code"; ok=0
+  fi
+  # npm: a present registry returns npm-shaped JSON ({"error":...}) for a
+  # missing package; a route-missing path returns Gitea's generic 404 page.
+  # Inspect the body, not just the status, so this assertion can actually fail.
+  local npm_body
+  npm_body="$(curl -s "$GITEA_URL/api/packages/$GITEA_ORG/npm/@$GITEA_ORG%2Fprobe")"
+  if printf '%s' "$npm_body" | grep -q '"error"'; then
+    log "npm      reachable (npm-shaped empty-index response)"
+  else
+    log "npm      NOT reachable: ${npm_body:0:80}"; ok=0
+  fi
+  # pypi: an authed empty upload to a present route is rejected with a 4xx
+  # (400 on Gitea 1.22); a missing route returns 404. Accept any non-404 4xx as
+  # "route present" so this isn't pinned to one Gitea version's exact code.
+  code="$(http_code POST "$GITEA_URL/api/packages/$GITEA_ORG/pypi" auth)"
+  if [ "$code" != "404" ] && [ "$code" -ge 400 ] 2>/dev/null && [ "$code" -lt 500 ]; then
+    log "pypi     reachable (upload route responds: HTTP $code)"
+  else
+    log "pypi     NOT reachable: HTTP $code"; ok=0
+  fi
+  [ "$ok" = "1" ] || fail "one or more registries are not reachable under '$GITEA_ORG'"
+}
+
+main() {
+  log "Target Gitea: $GITEA_URL  org: $GITEA_ORG  admin: $GITEA_ADMIN_USER"
+  # -f fails on HTTP >=400 so an up-but-broken Gitea fails fast here, not later.
+  curl -fsS -o /dev/null "$GITEA_URL/api/v1/version" \
+    || fail "cannot reach Gitea at $GITEA_URL (no response or error status)"
+
+  if [ -z "$GITEA_ADMIN_TOKEN" ]; then
+    log "No GITEA_ADMIN_TOKEN — entering bootstrap mode via container '$GITEA_CONTAINER'"
+    bootstrap_admin
+  else
+    log "Using provided GITEA_ADMIN_TOKEN (API mode)"
+  fi
+
+  ensure_org
+  verify_registries
+  log "Provisioned: org '$GITEA_ORG' with cargo/pypi/npm/generic reachable."
+
+  if [ "$RUN_SMOKE" = "1" ]; then
+    log "Running smoke test…"
+    GITEA_URL="$GITEA_URL" GITEA_ORG="$GITEA_ORG" GITEA_ADMIN_TOKEN="$GITEA_ADMIN_TOKEN" \
+      "$SCRIPT_DIR/smoke-test-registry.sh"
+  fi
+  log "Done."
+}
+
+main "$@"

--- a/scripts/gitea/smoke-test-registry.sh
+++ b/scripts/gitea/smoke-test-registry.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Smoke-test a Gitea registry namespace: publish a throwaway crate, resolve it
+# by version, then remove it — plus a generic-registry round-trip (the generic
+# registry is where `.slpkg` packages live).
+#
+# Self-contained and self-cleaning: uses a temp CARGO_HOME so it never touches
+# the operator's cargo config, and deletes everything it publishes. Safe to run
+# repeatedly against a live registry.
+#
+# Env:
+#   GITEA_ORG          REQUIRED — the org namespace to test
+#   GITEA_URL          default http://localhost:3000
+#   GITEA_ADMIN_TOKEN  required — a token that can publish to the org
+#
+# Exit codes: 0 = pass, 1 = fail, 77 = skip (cargo unavailable).
+
+set -euo pipefail
+
+GITEA_ORG="${GITEA_ORG:-}"
+GITEA_URL="${GITEA_URL:-http://localhost:3000}"
+GITEA_ADMIN_TOKEN="${GITEA_ADMIN_TOKEN:-}"
+
+CRATE_NAME="smoke-test-$$"
+CRATE_VERSION="0.0.1"
+
+log()  { printf '[smoke-registry] %s\n' "$*"; }
+fail() { printf '[smoke-registry] ERROR: %s\n' "$*" >&2; exit 1; }
+
+[ -n "$GITEA_ORG" ] || fail "set GITEA_ORG to the org namespace to test"
+[ -n "$GITEA_ADMIN_TOKEN" ] || fail "GITEA_ADMIN_TOKEN is required"
+command -v cargo >/dev/null 2>&1 || { log "cargo not available — skipping"; exit 77; }
+
+WORK="$(mktemp -d /tmp/gitea-smoke-XXXXXX)"
+cleanup() {
+  # best-effort: remove the published crate version and the temp dir.
+  # NB: package *deletion* is the management API (/api/v1/packages/...), NOT the
+  # registry-download namespace (/api/packages/...) used for publish/resolve.
+  curl -s -o /dev/null -X DELETE -H "Authorization: token $GITEA_ADMIN_TOKEN" \
+    "$GITEA_URL/api/v1/packages/$GITEA_ORG/cargo/$CRATE_NAME/$CRATE_VERSION" 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+export CARGO_HOME="$WORK/cargohome"
+mkdir -p "$CARGO_HOME"
+cat > "$CARGO_HOME/config.toml" <<EOF
+[registries.$GITEA_ORG]
+index = "sparse+$GITEA_URL/api/packages/$GITEA_ORG/cargo/"
+EOF
+# The token MUST be stored as "Bearer <token>"; a bare token yields HTTP 401.
+cat > "$CARGO_HOME/credentials.toml" <<EOF
+[registries.$GITEA_ORG]
+token = "Bearer $GITEA_ADMIN_TOKEN"
+EOF
+
+# --- generic registry round-trip (the .slpkg home) -------------------------
+# NB: Gitea's generic upload needs a raw body (--upload-file); a urlencoded
+# body (curl --data) is rejected with HTTP 500.
+log "generic: PUT → GET → DELETE round-trip"
+GEN="smoke-$$/0.0.1/probe.txt"
+printf 'smoke' > "$WORK/gen-probe.txt"
+code="$(curl -s -o /dev/null -w '%{http_code}' -X PUT \
+  -H "Authorization: token $GITEA_ADMIN_TOKEN" --upload-file "$WORK/gen-probe.txt" \
+  "$GITEA_URL/api/packages/$GITEA_ORG/generic/$GEN")"
+[ "$code" = "201" ] || fail "generic PUT returned HTTP $code"
+body="$(curl -s "$GITEA_URL/api/packages/$GITEA_ORG/generic/$GEN")"
+[ "$body" = "smoke" ] || fail "generic GET returned unexpected body: '$body'"
+curl -s -o /dev/null -X DELETE -H "Authorization: token $GITEA_ADMIN_TOKEN" \
+  "$GITEA_URL/api/packages/$GITEA_ORG/generic/$GEN"
+log "generic OK"
+
+# --- cargo publish → resolve-by-version → remove ---------------------------
+cd "$WORK"
+cargo new --lib --vcs none "$CRATE_NAME" -q
+cd "$CRATE_NAME"
+cat > Cargo.toml <<EOF
+[package]
+name = "$CRATE_NAME"
+version = "$CRATE_VERSION"
+edition = "2021"
+description = "Throwaway smoke-test crate for a StreamLib Gitea registry namespace."
+license = "BUSL-1.1"
+
+[dependencies]
+EOF
+
+log "cargo: publishing $CRATE_NAME v$CRATE_VERSION to '$GITEA_ORG'"
+cargo publish --registry "$GITEA_ORG" --no-verify --allow-dirty >/dev/null 2>&1 \
+  || fail "cargo publish failed"
+
+# resolve by version: sparse-index metadata entry + .crate download.
+# Sparse index sharding has length-based cases (1/2/3/4+ char names); CRATE_NAME
+# is always "smoke-test-<pid>" (4+ chars), which shards as <ab>/<cd>/<name>.
+# This only implements that branch — correct for the fixed prefix above.
+p1="${CRATE_NAME:0:2}"; p2="${CRATE_NAME:2:2}"
+meta="$(curl -s "$GITEA_URL/api/packages/$GITEA_ORG/cargo/$p1/$p2/$CRATE_NAME")"
+printf '%s' "$meta" | grep -q "\"vers\":\"$CRATE_VERSION\"" \
+  || fail "sparse index entry missing version $CRATE_VERSION: $meta"
+code="$(curl -s -o "$WORK/dl.crate" -w '%{http_code}' \
+  "$GITEA_URL/api/packages/$GITEA_ORG/cargo/api/v1/crates/$CRATE_NAME/$CRATE_VERSION/download")"
+[ "$code" = "200" ] || fail "crate download returned HTTP $code"
+tar tzf "$WORK/dl.crate" >/dev/null 2>&1 || fail "downloaded .crate is not a valid tarball"
+log "cargo resolve-by-version OK (index entry + .crate download)"
+
+# remove it (also handled by the EXIT trap, but assert success here).
+# Deletion is the management API (/api/v1/packages/...), distinct from the
+# /api/packages/... registry namespace used to publish and resolve above.
+code="$(curl -s -o /dev/null -w '%{http_code}' -X DELETE \
+  -H "Authorization: token $GITEA_ADMIN_TOKEN" \
+  "$GITEA_URL/api/v1/packages/$GITEA_ORG/cargo/$CRATE_NAME/$CRATE_VERSION")"
+[ "$code" = "204" ] || fail "crate delete returned HTTP $code"
+log "cargo remove OK"
+
+log "PASS — registry publish/resolve/remove smoke test green"


### PR DESCRIPTION
## Summary

- Stood up the **`tatolab` Gitea org** as the single namespace for all StreamLib artifacts; **cargo / pypi / npm / generic** registries all reachable under it.
- **Removed the throwaway POC artifacts** that registry validation published under the wrong (user) namespace — the POC toys and the real crates that landed in the wrong place — leaving a clean namespace for the SDK-publish work to fill.
- Added **generic, configure-by-env provisioning + smoke-test scripts** under `scripts/gitea/` and updated the architecture doc to current shipped state.

The scripts bake in **no** specific namespace or deployment target — org / admin / URL come from the environment, so the same tooling provisions the central registry and any self-hosted instance. A `*.local.sh` gitignore convention covers machine-local override wrappers that carry concrete values; none are committed.

## Closes
Closes #1115

## Exit criteria
- [x] `tatolab` org exists; cargo/npm/pypi/generic reachable under it.
- [x] POC artifacts removed; namespace created fresh.
- [x] Publish/resolve/remove smoke test passes under the namespace.
- [x] Architecture-doc section completed; in-flight marker dropped, status row flipped to shipped.

## Test plan
- `scripts/gitea/provision-registry.sh` (idempotent re-run) — green: org present, all four registries reachable.
- `scripts/gitea/smoke-test-registry.sh` — green: generic PUT/GET/DELETE round-trip + cargo publish → resolve-by-version (sparse index `vers` assertion + `.crate` tarball validation) → remove; zero residue.
- Negative check: the hardened npm probe correctly **fails** against a missing org.
- `bash -n` clean on all scripts.

## Notes
- Discovered empirically: the **sparse** cargo protocol needs no `_cargo-index` repo and no web-session `initialize` (the issue's AI-note about `/cargo/initialize` was for Gitea's older git-based index); the doc's operational notes are corrected.
- Operator-specific values (admin identity, deployment URL/port, container name) are intentionally kept out of the committed scripts and this description.

## Follow-ups
None. (Publishing the real SDK crate chain under the namespace is #1105's scope; schema-package resolution is #1116.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)