### PR TITLE
feat(idents): schema-package registry resolution + cargo-publish manifest strip capability

### DIFF
--- a/docs/architecture/gitea-registry-distribution.md
+++ b/docs/architecture/gitea-registry-distribution.md
@@ -115,20 +115,42 @@ Gitea by version.
 > on the consuming host to build the rust cdylib — weigh against the
 > compiler-free-deployment goal.
 
-## Schema-package resolution (finalized in #1116)
+## Schema-package resolution (resolver + strip capability shipped in #1116; cargo-publish wiring in #1105)
 
 `streamlib.yaml` schema dependencies (e.g. `@tatolab/escalate`) are themselves
-packages — they resolve from Gitea's **generic** registry: fetch the schema
-package's `.slpkg` by name+version, extract, resolve (the `extract_slpkg`
-plumbing already exists; today `streamlib-idents`' resolver returns
-`RegistryNotImplemented` for the `Registry` arm). Two halves, mirroring cargo:
+packages — they resolve from Gitea's **generic** registry: list the schema
+package's versions, select the highest satisfying the declared semver range,
+fetch that version's `.slpkg`, extract, resolve. The flat generic registry
+has no semver-range query, so range → concrete version happens client-side
+(cargo/npm/pip shape) via Gitea's package-management API
+(`GET /api/v1/packages/{org}?type=generic`), and the resolved concrete
+version is pinned in `streamlib.lock` via `ResolvedSource::Registry`. Two
+halves, mirroring cargo:
 
-1. **Publish side (already exists):** `streamlib pack`'s `RejectPathPatches`
-   strips the dev `path:` patch from a distributed `streamlib.yaml`. The gap is
-   that **`cargo publish` bundles `streamlib.yaml` verbatim** (patch included),
-   so the same strip must run when a crate's manifest is bundled by cargo.
-2. **Consume side (new code):** implement the resolver's `Registry` arm to
-   fetch+extract the schema package's `.slpkg` from Gitea.
+1. **Consume side:** `streamlib-idents`' resolver implements the `Registry`
+   arm — list → select-highest-in-range → fetch + `extract_slpkg` → load. The
+   registry base URL threads through `ResolverOptions::registry`, falling back
+   to `STREAMLIB_REGISTRY_URL` / `GITEA_URL` so build-script codegen picks it
+   up transparently; `file://` is the hermetic local-mirror / test transport.
+   A `Registry` dep with no registry configured fails loud with
+   `RegistryNotConfigured`.
+2. **Publish side:** a crate's bundled `streamlib.yaml` must be path-free so a
+   registry-cached consumer hits the `Registry` arm (not a dangling
+   `../../packages/...` path patch). `streamlib_pack::strip_path_patches`
+   drops dev path-flavor `patch:` entries, exposed as `xtask
+   strip-publish-manifest --dir <crate-dir>`. Because **`cargo publish`
+   bundles `streamlib.yaml` verbatim** with no file-rewrite hook, the strip
+   runs against a scratch copy before publish — that wiring (plus the
+   ~28-crate manifest migration and the out-of-repo build) lands with the
+   dev-publish script in #1105.
+
+   > ~~`streamlib pack`'s `RejectPathPatches` strips the dev `path:` patch.~~
+   > — Corrected 2026-05-30 (#1116): `RejectPathPatches` *rejects* a path
+   > patch with a hard error (a distributed source `.slpkg` must not carry a
+   > dev override); it never stripped. The cargo-publish case genuinely needs
+   > a *strip* — the path patch is a legitimate dev affordance locally but
+   > must be removed from the published manifest — so `strip_path_patches` is
+   > new code, the publish-side counterpart to `RejectPathPatches`.
 
 This is the schema-tier twin of the cargo-crate resolution. The resolver is
 shared by all three runtimes' codegen, so the one fix covers rust/python/deno.
@@ -194,7 +216,8 @@ Notes the scripts encode:
 | cargo publish → resolve-by-version (real SDK chain + vulkanalia/VMA) | ✅ validated (POC) | #1105 |
 | `.slpkg` round-trip through the generic registry | ✅ validated (POC) | #1119 |
 | `tatolab` org namespace + POC cleanup | ✅ shipped | #1115 |
-| schema-package registry resolution + cargo-publish path-strip | ⏳ | #1116 |
+| schema-package registry resolution (resolver `Registry` arm) + `strip_path_patches` capability | ✅ shipped | #1116 |
+| cargo-publish manifest path-strip *wiring* (dev-publish script + manifest migration) | ⏳ | #1105 |
 | Python SDK publish | ⏳ | #1117 |
 | Deno SDK publish | ⏳ | #1118 |
 | packages as source-only `.slpkg` + `streamlib pack` source-only | ⏳ | #1119 |

--- a/docs/architecture/gitea-registry-distribution.md
+++ b/docs/architecture/gitea-registry-distribution.md
@@ -129,11 +129,13 @@ halves, mirroring cargo:
 
 1. **Consume side:** `streamlib-idents`' resolver implements the `Registry`
    arm — list → select-highest-in-range → fetch + `extract_slpkg` → load. The
-   registry base URL threads through `ResolverOptions::registry`, falling back
-   to `STREAMLIB_REGISTRY_URL` / `GITEA_URL` so build-script codegen picks it
-   up transparently; `file://` is the hermetic local-mirror / test transport.
-   A `Registry` dep with no registry configured fails loud with
-   `RegistryNotConfigured`.
+   registry base URL is carried on `ResolverOptions::registry`; `resolve_with`
+   is pure (it never reads the process environment). The codegen boundary —
+   build scripts and `streamlib generate` — populates it via
+   `ResolverOptions::from_env`, which reads `STREAMLIB_REGISTRY_URL` /
+   `GITEA_URL` (plus optional `STREAMLIB_REGISTRY_TOKEN`); `file://` is the
+   hermetic local-mirror / test transport. A `Registry` dep with no registry
+   configured fails loud with `RegistryNotConfigured`.
 2. **Publish side:** a crate's bundled `streamlib.yaml` must be path-free so a
    registry-cached consumer hits the `Registry` arm (not a dangling
    `../../packages/...` path patch). `streamlib_pack::strip_path_patches`

--- a/libs/streamlib-idents/Cargo.toml
+++ b/libs/streamlib-idents/Cargo.toml
@@ -19,6 +19,7 @@ sha2 = { workspace = true }
 zip = "2.2"
 tracing = { workspace = true }
 schemars = "0.8"  # JSON Schema generation for streamlib.yaml editor support
+ureq = { workspace = true }  # Blocking HTTP for Gitea generic-registry schema-package fetch
 
 [dev-dependencies]
 serde_yaml = { workspace = true }

--- a/libs/streamlib-idents/src/error.rs
+++ b/libs/streamlib-idents/src/error.rs
@@ -114,8 +114,24 @@ pub enum ResolverError {
     #[error("`.slpkg` archive `{path}` failed to extract: {message}")]
     SlpkgExtractFailed { path: PathBuf, message: String },
 
-    #[error("registry dependency `{name}` requires a registry, but the v1 resolver does not yet ship one")]
-    RegistryNotImplemented { name: String },
+    #[error(
+        "registry dependency `{name}` cannot be resolved: no registry is configured. \
+         Set `{env}` (or `GITEA_URL`) to the Gitea base URL, or add a `patch:` override."
+    )]
+    RegistryNotConfigured { name: String, env: String },
+
+    #[error("registry dependency `{name}` fetch failed: {detail}")]
+    RegistryFetchFailed { name: String, detail: String },
+
+    #[error(
+        "registry dependency `{name}` has no version satisfying range `{range}` \
+         (available: {available})"
+    )]
+    RegistryNoMatchingVersion {
+        name: String,
+        range: String,
+        available: String,
+    },
 
     #[error("io error at `{path}`: {source}")]
     Io {

--- a/libs/streamlib-idents/src/lib.rs
+++ b/libs/streamlib-idents/src/lib.rs
@@ -13,6 +13,7 @@ mod git;
 mod ident;
 mod lockfile;
 mod manifest;
+mod registry;
 mod resolver;
 mod semver;
 
@@ -30,6 +31,7 @@ pub use manifest::{
     DependencySpec, GitDependency, Manifest, PackageMetadata, PathDependency, RegistryDependency,
     SchemaEntry,
 };
+pub use registry::{RegistryConfig, REGISTRY_TOKEN_ENV, REGISTRY_URL_ENV};
 pub use resolver::{
     resolve, resolve_bare_schema_name, resolve_with, ResolvedPackage, ResolvedPackages,
     ResolvedSource, ResolverOptions,

--- a/libs/streamlib-idents/src/registry.rs
+++ b/libs/streamlib-idents/src/registry.rs
@@ -1,0 +1,339 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Gitea generic-registry client for schema-package resolution.
+//!
+//! Schema packages (`@tatolab/escalate` and friends) are distributed as
+//! source-only `.slpkg`s in Gitea's **generic** registry. Resolving a
+//! `Registry` dependency by a semver *range* requires two steps the flat
+//! generic registry can't do in one request:
+//!
+//! 1. **List** the available concrete versions of the package
+//!    (Gitea's package-management API), then select the highest one that
+//!    satisfies the declared range — cargo/npm/pip semantics.
+//! 2. **Download** that version's `.slpkg` from the generic registry's
+//!    by-version download namespace.
+//!
+//! `http(s)://` is the production transport; `file://` is the hermetic
+//! local-mirror / test transport (mirroring the engine's remote-`.slpkg`
+//! fetch), where the base URL points at a directory laid out as
+//! `<base>/<name>/<version>/<name>.slpkg`.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::{ResolverError, ResolverResult};
+use crate::ident::PackageRef;
+use crate::semver::SemVer;
+
+/// Environment variable carrying the Gitea base URL (e.g.
+/// `http://localhost:3000`). Falls back to `GITEA_URL` to match the
+/// provisioning scripts' convention.
+pub const REGISTRY_URL_ENV: &str = "STREAMLIB_REGISTRY_URL";
+const REGISTRY_URL_ENV_FALLBACK: &str = "GITEA_URL";
+
+/// Environment variable carrying an optional read token for the
+/// package-management API (private registries). Read is anonymous on a
+/// public registry, so this is usually unset.
+pub const REGISTRY_TOKEN_ENV: &str = "STREAMLIB_REGISTRY_TOKEN";
+
+/// Resolved configuration for the Gitea generic registry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistryConfig {
+    /// Base URL — `http(s)://host[:port]` for production, or
+    /// `file:///abs/dir` for a hermetic local mirror.
+    pub base_url: String,
+    /// Optional bearer/`token` credential for the management API.
+    pub token: Option<String>,
+}
+
+impl RegistryConfig {
+    /// Build from the environment. Returns `None` when no base URL is set,
+    /// so default callers (e.g. `ResolverOptions::default()` in a build
+    /// script) transparently pick up a configured registry without one.
+    pub fn from_env() -> Option<Self> {
+        let base_url = std::env::var(REGISTRY_URL_ENV)
+            .ok()
+            .or_else(|| std::env::var(REGISTRY_URL_ENV_FALLBACK).ok())
+            .map(|s| s.trim_end_matches('/').to_string())
+            .filter(|s| !s.is_empty())?;
+        let token = std::env::var(REGISTRY_TOKEN_ENV).ok().filter(|s| !s.is_empty());
+        Some(Self { base_url, token })
+    }
+}
+
+/// One entry in Gitea's `GET /api/v1/packages/{owner}` response.
+#[derive(Debug, serde::Deserialize)]
+struct GiteaPackageEntry {
+    name: String,
+    version: String,
+    #[serde(rename = "type")]
+    package_type: String,
+}
+
+/// Client over a single [`RegistryConfig`].
+pub struct RegistryClient<'a> {
+    config: &'a RegistryConfig,
+}
+
+impl<'a> RegistryClient<'a> {
+    pub fn new(config: &'a RegistryConfig) -> Self {
+        Self { config }
+    }
+
+    fn is_file_scheme(&self) -> bool {
+        self.config.base_url.starts_with("file://")
+    }
+
+    /// The on-disk directory a `file://` base URL points at.
+    fn file_base_dir(&self) -> PathBuf {
+        PathBuf::from(self.config.base_url.trim_start_matches("file://"))
+    }
+
+    /// List every concrete version of `pkg_ref` the registry holds.
+    pub fn list_versions(&self, pkg_ref: &PackageRef) -> ResolverResult<Vec<SemVer>> {
+        if self.is_file_scheme() {
+            self.list_versions_file(pkg_ref)
+        } else {
+            self.list_versions_http(pkg_ref)
+        }
+    }
+
+    /// Download the `.slpkg` bytes for an exact `version` of `pkg_ref`.
+    /// Returns the bytes plus the canonical URL they came from (recorded in
+    /// the lockfile as the resolved source).
+    pub fn download_slpkg(
+        &self,
+        pkg_ref: &PackageRef,
+        version: SemVer,
+    ) -> ResolverResult<(Vec<u8>, String)> {
+        let url = self.download_url(pkg_ref, version);
+        let bytes = if self.is_file_scheme() {
+            let path = self.download_path(pkg_ref, version);
+            std::fs::read(&path).map_err(|e| ResolverError::RegistryFetchFailed {
+                name: pkg_ref.to_string(),
+                detail: format!("reading {} : {e}", path.display()),
+            })?
+        } else {
+            http_get_bytes(&url, self.config.token.as_deref()).map_err(|detail| {
+                ResolverError::RegistryFetchFailed {
+                    name: pkg_ref.to_string(),
+                    detail,
+                }
+            })?
+        };
+        Ok((bytes, url))
+    }
+
+    /// Canonical generic-registry download URL (recorded in the lockfile).
+    fn download_url(&self, pkg_ref: &PackageRef, version: SemVer) -> String {
+        let name = pkg_ref.name.as_str();
+        format!(
+            "{}/api/packages/{}/generic/{}/{}/{}.slpkg",
+            self.config.base_url,
+            pkg_ref.org.as_str(),
+            name,
+            version,
+            name,
+        )
+    }
+
+    /// `file://` mirror layout: `<base>/<name>/<version>/<name>.slpkg`.
+    fn download_path(&self, pkg_ref: &PackageRef, version: SemVer) -> PathBuf {
+        let name = pkg_ref.name.as_str();
+        self.file_base_dir()
+            .join(name)
+            .join(version.to_string())
+            .join(format!("{name}.slpkg"))
+    }
+
+    fn list_versions_http(&self, pkg_ref: &PackageRef) -> ResolverResult<Vec<SemVer>> {
+        let name = pkg_ref.name.as_str();
+        let url = format!(
+            "{}/api/v1/packages/{}?type=generic&q={}",
+            self.config.base_url,
+            pkg_ref.org.as_str(),
+            name,
+        );
+        let body = http_get_bytes(&url, self.config.token.as_deref()).map_err(|detail| {
+            ResolverError::RegistryFetchFailed {
+                name: pkg_ref.to_string(),
+                detail: format!("listing versions: {detail}"),
+            }
+        })?;
+        let entries: Vec<GiteaPackageEntry> =
+            serde_json::from_slice(&body).map_err(|e| ResolverError::RegistryFetchFailed {
+                name: pkg_ref.to_string(),
+                detail: format!("parsing package list JSON: {e}"),
+            })?;
+        Ok(entries
+            .into_iter()
+            .filter(|e| e.package_type == "generic" && e.name == name)
+            .filter_map(|e| SemVer::from_dotted(&e.version).ok())
+            .collect())
+    }
+
+    fn list_versions_file(&self, pkg_ref: &PackageRef) -> ResolverResult<Vec<SemVer>> {
+        let dir = self.file_base_dir().join(pkg_ref.name.as_str());
+        if !dir.is_dir() {
+            return Ok(Vec::new());
+        }
+        let mut versions = Vec::new();
+        let entries = std::fs::read_dir(&dir).map_err(|e| ResolverError::RegistryFetchFailed {
+            name: pkg_ref.to_string(),
+            detail: format!("reading {} : {e}", dir.display()),
+        })?;
+        for entry in entries {
+            let entry = entry.map_err(|e| ResolverError::RegistryFetchFailed {
+                name: pkg_ref.to_string(),
+                detail: format!("reading {} : {e}", dir.display()),
+            })?;
+            if !entry.path().is_dir() {
+                continue;
+            }
+            if let Some(v) = entry
+                .file_name()
+                .to_str()
+                .and_then(|s| SemVer::from_dotted(s).ok())
+            {
+                versions.push(v);
+            }
+        }
+        Ok(versions)
+    }
+}
+
+/// Select the highest version in `available` that satisfies `range`.
+pub(crate) fn select_version(
+    pkg_ref: &PackageRef,
+    range: &crate::semver::SemVerRange,
+    available: &[SemVer],
+) -> ResolverResult<SemVer> {
+    available
+        .iter()
+        .filter(|v| range.matches(**v))
+        .max()
+        .copied()
+        .ok_or_else(|| {
+            let mut sorted: Vec<String> = available.iter().map(|v| v.to_string()).collect();
+            sorted.sort();
+            ResolverError::RegistryNoMatchingVersion {
+                name: pkg_ref.to_string(),
+                range: range.to_string(),
+                available: sorted.join(", "),
+            }
+        })
+}
+
+/// Blocking GET of `url`'s raw body. `token` is sent as a Gitea
+/// `Authorization: token <t>` header when present.
+fn http_get_bytes(url: &str, token: Option<&str>) -> Result<Vec<u8>, String> {
+    let mut req = ureq::get(url);
+    if let Some(t) = token {
+        req = req.set("Authorization", &format!("token {t}"));
+    }
+    let response = req
+        .call()
+        .map_err(|e| format!("HTTP request to {url} failed: {e}"))?;
+    let mut bytes = Vec::new();
+    std::io::Read::read_to_end(&mut response.into_reader(), &mut bytes)
+        .map_err(|e| format!("reading HTTP response body from {url}: {e}"))?;
+    Ok(bytes)
+}
+
+/// Persist downloaded `.slpkg` bytes into the resolver cache as a file
+/// `extract_slpkg` can read. Content-addressed by the bytes' hash so a
+/// re-resolve reuses the artifact, with an atomic temp-then-rename publish.
+pub(crate) fn cache_slpkg_bytes(
+    pkg_ref: &PackageRef,
+    bytes: &[u8],
+    cache_dir: &Path,
+) -> ResolverResult<PathBuf> {
+    let dir = cache_dir.join("registry");
+    std::fs::create_dir_all(&dir).map_err(|e| ResolverError::Io {
+        path: dir.clone(),
+        source: e,
+    })?;
+    let hash = crate::lockfile::hash_content(bytes).replace(':', "_");
+    let target = dir.join(format!("{}_{hash}.slpkg", pkg_ref.name.as_str()));
+    if target.exists() {
+        return Ok(target);
+    }
+    let tmp = dir.join(format!("{}_{hash}.slpkg.partial", pkg_ref.name.as_str()));
+    std::fs::write(&tmp, bytes).map_err(|e| ResolverError::Io {
+        path: tmp.clone(),
+        source: e,
+    })?;
+    std::fs::rename(&tmp, &target).map_err(|e| ResolverError::Io {
+        path: target.clone(),
+        source: e,
+    })?;
+    Ok(target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ident::{Org, Package};
+    use crate::semver::SemVerRange;
+
+    fn pkg_ref(org: &str, name: &str) -> PackageRef {
+        PackageRef::new(Org::new(org).unwrap(), Package::new(name).unwrap())
+    }
+
+    #[test]
+    fn select_version_picks_highest_in_range() {
+        let pr = pkg_ref("tatolab", "escalate");
+        let avail = vec![
+            SemVer::new(1, 0, 0),
+            SemVer::new(1, 2, 0),
+            SemVer::new(1, 1, 5),
+            SemVer::new(2, 0, 0),
+        ];
+        let range = SemVerRange::from_str("^1.0.0").unwrap();
+        assert_eq!(select_version(&pr, &range, &avail).unwrap(), SemVer::new(1, 2, 0));
+    }
+
+    #[test]
+    fn select_version_errors_when_none_match() {
+        let pr = pkg_ref("tatolab", "escalate");
+        let avail = vec![SemVer::new(2, 0, 0), SemVer::new(3, 1, 0)];
+        let range = SemVerRange::from_str("^1.0.0").unwrap();
+        let err = select_version(&pr, &range, &avail).unwrap_err();
+        match err {
+            ResolverError::RegistryNoMatchingVersion { range, available, .. } => {
+                assert_eq!(range, "^1.0.0");
+                assert!(available.contains("2.0.0"));
+                assert!(available.contains("3.1.0"));
+            }
+            other => panic!("expected RegistryNoMatchingVersion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_env_reads_url_and_token() {
+        // No env set in this process by default — the round-trip is exercised
+        // by the resolver's file:// integration test. Here we only assert the
+        // None-when-unset contract holds for a name unlikely to be set.
+        // (Avoid mutating process env in a parallel test run.)
+        let cfg = RegistryConfig {
+            base_url: "http://localhost:3000".into(),
+            token: Some("abc".into()),
+        };
+        assert!(!RegistryClient::new(&cfg).is_file_scheme());
+    }
+
+    #[test]
+    fn file_scheme_layout_paths() {
+        let cfg = RegistryConfig {
+            base_url: "file:///tmp/mirror".into(),
+            token: None,
+        };
+        let client = RegistryClient::new(&cfg);
+        assert!(client.is_file_scheme());
+        let pr = pkg_ref("tatolab", "escalate");
+        assert_eq!(
+            client.download_path(&pr, SemVer::new(1, 2, 0)),
+            PathBuf::from("/tmp/mirror/escalate/1.2.0/escalate.slpkg")
+        );
+    }
+}

--- a/libs/streamlib-idents/src/registry.rs
+++ b/libs/streamlib-idents/src/registry.rs
@@ -310,16 +310,22 @@ mod tests {
     }
 
     #[test]
-    fn from_env_reads_url_and_token() {
-        // No env set in this process by default — the round-trip is exercised
-        // by the resolver's file:// integration test. Here we only assert the
-        // None-when-unset contract holds for a name unlikely to be set.
-        // (Avoid mutating process env in a parallel test run.)
-        let cfg = RegistryConfig {
+    fn scheme_detection_http_vs_file() {
+        // The client routes list/download by URL scheme. `from_env`'s env
+        // parsing is intentionally NOT unit-tested here — mutating process
+        // env would race the resolver's `registry: None` tests that rely on
+        // an unset registry env; it's covered via the resolver's default
+        // path in real usage and the file:// integration tests.
+        let http = RegistryConfig {
             base_url: "http://localhost:3000".into(),
             token: Some("abc".into()),
         };
-        assert!(!RegistryClient::new(&cfg).is_file_scheme());
+        assert!(!RegistryClient::new(&http).is_file_scheme());
+        let file = RegistryConfig {
+            base_url: "file:///tmp/mirror".into(),
+            token: None,
+        };
+        assert!(RegistryClient::new(&file).is_file_scheme());
     }
 
     #[test]
@@ -335,5 +341,71 @@ mod tests {
             client.download_path(&pr, SemVer::new(1, 2, 0)),
             PathBuf::from("/tmp/mirror/escalate/1.2.0/escalate.slpkg")
         );
+    }
+
+    /// Locks the production `http://` path end-to-end against a one-shot
+    /// localhost server: the management-API list URL + Gitea JSON shape
+    /// (`list_versions_http`) and the generic download URL
+    /// (`download_slpkg`). A typo in either URL or in the `GiteaPackageEntry`
+    /// field names would only surface against a real Gitea without this.
+    #[test]
+    fn http_list_and_download_against_localhost() {
+        use std::io::{Read, Write};
+
+        let slpkg_body = b"slpkg-zip-bytes".to_vec();
+        // Gitea `GET /api/v1/packages/{owner}?type=generic` response shape.
+        let list_json = r#"[
+            {"name":"escalate","version":"1.0.0","type":"generic"},
+            {"name":"escalate","version":"1.2.0","type":"generic"},
+            {"name":"other","version":"9.9.9","type":"generic"}
+        ]"#
+        .to_string();
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let slpkg_for_server = slpkg_body.clone();
+        let server = std::thread::spawn(move || {
+            // Serve exactly two requests: the version list, then the download.
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut buf = [0u8; 2048];
+                let n = stream.read(&mut buf).unwrap();
+                let req = String::from_utf8_lossy(&buf[..n]);
+                let request_line = req.lines().next().unwrap_or("");
+                let body: Vec<u8> = if request_line.contains("/api/v1/packages/") {
+                    list_json.clone().into_bytes()
+                } else {
+                    slpkg_for_server.clone()
+                };
+                let header = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                stream.write_all(header.as_bytes()).unwrap();
+                stream.write_all(&body).unwrap();
+                stream.flush().unwrap();
+            }
+        });
+
+        let cfg = RegistryConfig {
+            base_url: format!("http://127.0.0.1:{port}"),
+            token: None,
+        };
+        let client = RegistryClient::new(&cfg);
+        let pr = pkg_ref("tatolab", "escalate");
+
+        // Management API: only matching-name generic entries are returned.
+        let versions = client.list_versions(&pr).unwrap();
+        assert_eq!(versions, vec![SemVer::new(1, 0, 0), SemVer::new(1, 2, 0)]);
+
+        // Generic download by exact version returns the bytes + canonical URL.
+        let (bytes, url) = client.download_slpkg(&pr, SemVer::new(1, 2, 0)).unwrap();
+        assert_eq!(bytes, slpkg_body);
+        assert!(
+            url.ends_with("/api/packages/tatolab/generic/escalate/1.2.0/escalate.slpkg"),
+            "unexpected download url: {url}"
+        );
+
+        server.join().unwrap();
     }
 }

--- a/libs/streamlib-idents/src/resolver.rs
+++ b/libs/streamlib-idents/src/resolver.rs
@@ -21,7 +21,8 @@ use crate::error::{ResolverError, ResolverResult};
 use crate::git::fetch_git;
 use crate::ident::{PackageRef, TypeName};
 use crate::lockfile::{compute_content_hash, Lockfile, LockfileEntry, LockfileSource};
-use crate::manifest::{DependencySpec, Manifest, SchemaEntry};
+use crate::manifest::{DependencySpec, Manifest, RegistryDependency, SchemaEntry};
+use crate::registry::{cache_slpkg_bytes, select_version, RegistryClient, RegistryConfig};
 
 /// Outcome of resolving a `streamlib.yaml` graph: the root project + every
 /// transitive package, keyed by canonical `"@org/name"` lockfile key.
@@ -125,6 +126,13 @@ pub struct ResolverOptions {
     /// Override the cache directory for git clones and `.slpkg` extractions.
     /// `None` falls back to `$HOME/.streamlib/resolver-cache/`.
     pub cache_dir: Option<PathBuf>,
+    /// Gitea generic-registry configuration for resolving `Registry` schema
+    /// dependencies. `None` falls back to [`RegistryConfig::from_env`], so a
+    /// build script using `ResolverOptions::default()` transparently picks up
+    /// `STREAMLIB_REGISTRY_URL` / `GITEA_URL` when set. When neither the
+    /// field nor the environment configures a registry, a `Registry`
+    /// dependency surfaces [`ResolverError::RegistryNotConfigured`].
+    pub registry: Option<RegistryConfig>,
 }
 
 /// Resolve a `streamlib.yaml` at `root_dir` and every transitive dependency
@@ -145,6 +153,15 @@ pub fn resolve_with(
         Some(p) => p.clone(),
         None => default_cache_dir()?,
     };
+
+    // Effective registry config: explicit option wins; otherwise read the
+    // environment so default callers (build scripts) pick up a configured
+    // registry. `None` means "no registry" — a `Registry` dep then fails
+    // loud with `RegistryNotConfigured`.
+    let registry = options
+        .registry
+        .clone()
+        .or_else(RegistryConfig::from_env);
 
     let root = build_resolved_package(
         root_manifest,
@@ -193,8 +210,15 @@ pub fn resolve_with(
                 return Err(ResolverError::CircularDependency { chain: dep_id });
             }
 
-            let resolved =
-                resolve_one(&consumer_dir, &dep_ref, &dep_id, &spec, &patch, &cache_dir)?;
+            let resolved = resolve_one(
+                &consumer_dir,
+                &dep_ref,
+                &dep_id,
+                &spec,
+                &patch,
+                &cache_dir,
+                registry.as_ref(),
+            )?;
 
             check_resolved_id_matches(&resolved, &dep_id, &consumer_dir)?;
             check_resolved_satisfies_spec(&resolved, &spec, &consumer_dir, &dep_id)?;
@@ -225,6 +249,7 @@ fn resolve_one(
     spec: &DependencySpec,
     patch: &BTreeMap<PackageRef, DependencySpec>,
     cache_dir: &Path,
+    registry: Option<&RegistryConfig>,
 ) -> ResolverResult<ResolvedPackage> {
     // Consumer's `patch:` table overrides the dep declaration when present.
     // Mirrors Cargo's `[patch.crates-io]` semantics: dependencies declare
@@ -249,10 +274,38 @@ fn resolve_one(
                 },
             )
         }
-        DependencySpec::Registry(_) => Err(ResolverError::RegistryNotImplemented {
-            name: dep_id.to_string(),
-        }),
+        DependencySpec::Registry(reg) => {
+            resolve_registry_dependency(dep_ref, dep_id, reg, cache_dir, registry)
+        }
     }
+}
+
+/// Resolve a `Registry` schema dependency from Gitea's generic registry:
+/// list the package's available versions, select the highest satisfying the
+/// declared range, fetch + extract that version's `.slpkg`, and load it.
+///
+/// The flat generic registry has no semver-range query, so range → concrete
+/// version happens client-side (cargo/npm/pip shape). The resolved concrete
+/// version is recorded in the lockfile via [`ResolvedSource::Registry`].
+fn resolve_registry_dependency(
+    dep_ref: &PackageRef,
+    dep_id: &str,
+    reg: &RegistryDependency,
+    cache_dir: &Path,
+    registry: Option<&RegistryConfig>,
+) -> ResolverResult<ResolvedPackage> {
+    let config = registry.ok_or_else(|| ResolverError::RegistryNotConfigured {
+        name: dep_id.to_string(),
+        env: crate::registry::REGISTRY_URL_ENV.to_string(),
+    })?;
+    let client = RegistryClient::new(config);
+    let available = client.list_versions(dep_ref)?;
+    let selected = select_version(dep_ref, &reg.version, &available)?;
+    let (bytes, url) = client.download_slpkg(dep_ref, selected)?;
+    let archive = cache_slpkg_bytes(dep_ref, &bytes, cache_dir)?;
+    let extracted = extract_slpkg(&archive, cache_dir)?;
+    let manifest = Manifest::load(&extracted)?;
+    build_resolved_package(manifest, extracted, ResolvedSource::Registry { url })
 }
 
 fn resolve_path_dependency(
@@ -843,7 +896,10 @@ dependencies:
     }
 
     #[test]
-    fn registry_dependency_not_implemented() {
+    fn registry_dependency_without_config_errors() {
+        // A bare registry range with no registry configured (no option, no
+        // env) fails loud with RegistryNotConfigured — the actionable
+        // successor to the old RegistryNotImplemented.
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path().join("project");
         write_streamlib_yaml(
@@ -853,8 +909,129 @@ dependencies:
   "@tatolab/core": "^1.0.0"
 "#,
         );
-        let err = resolve(&root).unwrap_err();
-        assert!(matches!(err, ResolverError::RegistryNotImplemented { .. }));
+        // Explicit empty options + no env override. (If the ambient env sets
+        // STREAMLIB_REGISTRY_URL/GITEA_URL this would instead attempt a
+        // fetch; the CI/dev shell does not set them for unit-test runs.)
+        let opts = ResolverOptions {
+            cache_dir: Some(tmp.path().join("cache")),
+            registry: None,
+        };
+        match resolve_with(&root, &opts) {
+            Err(ResolverError::RegistryNotConfigured { .. }) => {}
+            // Tolerate an ambient registry env by accepting a fetch failure
+            // too — either way the not-implemented path is gone.
+            Err(ResolverError::RegistryFetchFailed { .. })
+            | Err(ResolverError::RegistryNoMatchingVersion { .. }) => {}
+            other => panic!("expected RegistryNotConfigured, got {other:?}"),
+        }
+    }
+
+    /// End-to-end registry resolution over the hermetic `file://` mirror:
+    /// build a real schema `.slpkg`, lay it out in a versioned mirror dir,
+    /// declare a bare semver-range registry dep (NO path patch), and assert
+    /// the resolver lists → selects-highest-in-range → fetches → extracts →
+    /// loads it. This is exactly the path `build.rs` codegen drives for a
+    /// registry-cached crate. Mirrors the broken case the issue fixes: with
+    /// the patch stripped, the bare range MUST resolve from the registry.
+    #[test]
+    fn registry_dependency_resolves_from_file_mirror() {
+        use std::io::Write;
+        let tmp = tempfile::tempdir().unwrap();
+        let mirror = tmp.path().join("mirror");
+        let cache = tmp.path().join("cache");
+
+        // Two versions present; the ^1.0.0 range must select 1.2.0 over
+        // 1.0.0 (and ignore the out-of-range 2.0.0).
+        let make_slpkg = |dir: &Path, version: &str| {
+            std::fs::create_dir_all(dir).unwrap();
+            let archive = dir.join("escalate.slpkg");
+            let mut zip = zip::ZipWriter::new(std::fs::File::create(&archive).unwrap());
+            let opts = zip::write::SimpleFileOptions::default();
+            zip.start_file(Manifest::FILE_NAME, opts).unwrap();
+            zip.write_all(
+                format!(
+                    "package:\n  org: tatolab\n  name: escalate\n  version: {version}\nschemas:\n  EscalateRequest:\n    file: schemas/EscalateRequest.yaml\n"
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+            zip.start_file("schemas/EscalateRequest.yaml", opts).unwrap();
+            zip.write_all(b"metadata:\n  name: EscalateRequest\nproperties: {}\n")
+                .unwrap();
+            zip.finish().unwrap();
+        };
+        make_slpkg(&mirror.join("escalate").join("1.0.0"), "1.0.0");
+        make_slpkg(&mirror.join("escalate").join("1.2.0"), "1.2.0");
+        make_slpkg(&mirror.join("escalate").join("2.0.0"), "2.0.0");
+
+        let root = tmp.path().join("project");
+        write_streamlib_yaml(
+            &root,
+            r#"
+dependencies:
+  "@tatolab/escalate": "^1.0.0"
+"#,
+        );
+
+        let opts = ResolverOptions {
+            cache_dir: Some(cache),
+            registry: Some(crate::RegistryConfig {
+                base_url: format!("file://{}", mirror.display()),
+                token: None,
+            }),
+        };
+        let res = resolve_with(&root, &opts).unwrap();
+        let escalate = res.packages.get("@tatolab/escalate").unwrap();
+        assert!(matches!(escalate.source, ResolvedSource::Registry { .. }));
+        // Highest-in-range selected.
+        assert_eq!(
+            escalate.manifest.package.as_ref().unwrap().version.to_string(),
+            "1.2.0"
+        );
+        assert_eq!(escalate.schema_files.len(), 1);
+
+        // Lockfile records the registry source + concrete version.
+        let lock = res.to_lockfile();
+        let entry = lock.packages.get("@tatolab/escalate").unwrap();
+        assert_eq!(entry.version.to_string(), "1.2.0");
+        assert!(matches!(entry.source, LockfileSource::Registry { .. }));
+    }
+
+    #[test]
+    fn registry_dependency_no_matching_version_errors() {
+        use std::io::Write;
+        let tmp = tempfile::tempdir().unwrap();
+        let mirror = tmp.path().join("mirror");
+        let dir = mirror.join("escalate").join("2.0.0");
+        std::fs::create_dir_all(&dir).unwrap();
+        let archive = dir.join("escalate.slpkg");
+        let mut zip = zip::ZipWriter::new(std::fs::File::create(&archive).unwrap());
+        let zopts = zip::write::SimpleFileOptions::default();
+        zip.start_file(Manifest::FILE_NAME, zopts).unwrap();
+        zip.write_all(b"package:\n  org: tatolab\n  name: escalate\n  version: 2.0.0\n")
+            .unwrap();
+        zip.finish().unwrap();
+
+        let root = tmp.path().join("project");
+        write_streamlib_yaml(
+            &root,
+            r#"
+dependencies:
+  "@tatolab/escalate": "^1.0.0"
+"#,
+        );
+        let opts = ResolverOptions {
+            cache_dir: Some(tmp.path().join("cache")),
+            registry: Some(crate::RegistryConfig {
+                base_url: format!("file://{}", mirror.display()),
+                token: None,
+            }),
+        };
+        let err = resolve_with(&root, &opts).unwrap_err();
+        assert!(
+            matches!(err, ResolverError::RegistryNoMatchingVersion { .. }),
+            "expected RegistryNoMatchingVersion, got {err:?}"
+        );
     }
 
     #[test]
@@ -887,6 +1064,7 @@ dependencies:
 
         let opts = ResolverOptions {
             cache_dir: Some(cache),
+            registry: None,
         };
         let res = resolve_with(&root, &opts).unwrap();
         let core = res.packages.get("@tatolab/core").unwrap();

--- a/libs/streamlib-idents/src/resolver.rs
+++ b/libs/streamlib-idents/src/resolver.rs
@@ -127,12 +127,28 @@ pub struct ResolverOptions {
     /// `None` falls back to `$HOME/.streamlib/resolver-cache/`.
     pub cache_dir: Option<PathBuf>,
     /// Gitea generic-registry configuration for resolving `Registry` schema
-    /// dependencies. `None` falls back to [`RegistryConfig::from_env`], so a
-    /// build script using `ResolverOptions::default()` transparently picks up
-    /// `STREAMLIB_REGISTRY_URL` / `GITEA_URL` when set. When neither the
-    /// field nor the environment configures a registry, a `Registry`
-    /// dependency surfaces [`ResolverError::RegistryNotConfigured`].
+    /// dependencies. `None` means no registry is configured — a `Registry`
+    /// dependency then surfaces [`ResolverError::RegistryNotConfigured`].
+    /// [`resolve_with`] reads this field only; it never consults the process
+    /// environment. Codegen entry points (build scripts, `streamlib
+    /// generate`) populate it via [`ResolverOptions::from_env`].
     pub registry: Option<RegistryConfig>,
+}
+
+impl ResolverOptions {
+    /// Options with the registry config read from the environment
+    /// (`STREAMLIB_REGISTRY_URL` / `GITEA_URL`, optional
+    /// `STREAMLIB_REGISTRY_TOKEN`) and the default cache dir. This is the
+    /// codegen-boundary constructor — build scripts and `streamlib generate`
+    /// use it so a registry-cached crate resolves its schema deps from the
+    /// configured registry. Unit tests construct [`ResolverOptions`] directly
+    /// to stay hermetic.
+    pub fn from_env() -> Self {
+        Self {
+            cache_dir: None,
+            registry: RegistryConfig::from_env(),
+        }
+    }
 }
 
 /// Resolve a `streamlib.yaml` at `root_dir` and every transitive dependency
@@ -154,14 +170,14 @@ pub fn resolve_with(
         None => default_cache_dir()?,
     };
 
-    // Effective registry config: explicit option wins; otherwise read the
-    // environment so default callers (build scripts) pick up a configured
-    // registry. `None` means "no registry" — a `Registry` dep then fails
-    // loud with `RegistryNotConfigured`.
-    let registry = options
-        .registry
-        .clone()
-        .or_else(RegistryConfig::from_env);
+    // `resolve_with` is pure: it reads the registry config from `options`
+    // only, never from the process environment. The env read lives at the
+    // codegen boundary (`ResolverOptions::from_env`, used by build scripts
+    // and `streamlib generate`) so unit tests fully control resolution and
+    // a stray `GITEA_URL` in the shell can't redirect a resolve into a live
+    // fetch. `None` means "no registry" — a `Registry` dep then fails loud
+    // with `RegistryNotConfigured`.
+    let registry = options.registry.as_ref();
 
     let root = build_resolved_package(
         root_manifest,
@@ -217,7 +233,7 @@ pub fn resolve_with(
                 &spec,
                 &patch,
                 &cache_dir,
-                registry.as_ref(),
+                registry,
             )?;
 
             check_resolved_id_matches(&resolved, &dep_id, &consumer_dir)?;
@@ -897,9 +913,11 @@ dependencies:
 
     #[test]
     fn registry_dependency_without_config_errors() {
-        // A bare registry range with no registry configured (no option, no
-        // env) fails loud with RegistryNotConfigured — the actionable
-        // successor to the old RegistryNotImplemented.
+        // A bare registry range with `registry: None` fails loud with
+        // RegistryNotConfigured — the actionable successor to the old
+        // RegistryNotImplemented. `resolve_with` is pure (it never reads the
+        // process env), so this is deterministic regardless of any ambient
+        // STREAMLIB_REGISTRY_URL / GITEA_URL in the shell.
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path().join("project");
         write_streamlib_yaml(
@@ -909,21 +927,15 @@ dependencies:
   "@tatolab/core": "^1.0.0"
 "#,
         );
-        // Explicit empty options + no env override. (If the ambient env sets
-        // STREAMLIB_REGISTRY_URL/GITEA_URL this would instead attempt a
-        // fetch; the CI/dev shell does not set them for unit-test runs.)
         let opts = ResolverOptions {
             cache_dir: Some(tmp.path().join("cache")),
             registry: None,
         };
-        match resolve_with(&root, &opts) {
-            Err(ResolverError::RegistryNotConfigured { .. }) => {}
-            // Tolerate an ambient registry env by accepting a fetch failure
-            // too — either way the not-implemented path is gone.
-            Err(ResolverError::RegistryFetchFailed { .. })
-            | Err(ResolverError::RegistryNoMatchingVersion { .. }) => {}
-            other => panic!("expected RegistryNotConfigured, got {other:?}"),
-        }
+        let err = resolve_with(&root, &opts).unwrap_err();
+        assert!(
+            matches!(err, ResolverError::RegistryNotConfigured { .. }),
+            "expected RegistryNotConfigured, got {err:?}"
+        );
     }
 
     /// End-to-end registry resolution over the hermetic `file://` mirror:

--- a/libs/streamlib-jtd-codegen/Cargo.toml
+++ b/libs/streamlib-jtd-codegen/Cargo.toml
@@ -34,5 +34,9 @@ anyhow = { workspace = true }
 # Temp directory for jtd-codegen invocation
 tempfile = "3.15"
 
+[dev-dependencies]
+# Building schema-package `.slpkg`s for the registry-resolved codegen E2E.
+zip = "2.2"
+
 [lints]
 workspace = true

--- a/libs/streamlib-jtd-codegen/src/build_rs.rs
+++ b/libs/streamlib-jtd-codegen/src/build_rs.rs
@@ -66,7 +66,11 @@ fn run_for_rust_crate_inner() -> Result<()> {
         );
     }
 
-    let resolved = streamlib_idents::resolve_with(&crate_dir, &ResolverOptions::default())
+    // `from_env` reads STREAMLIB_REGISTRY_URL / GITEA_URL so a registry-cached
+    // crate resolves its schema deps (e.g. `@tatolab/escalate`) from the
+    // configured Gitea registry — the env read lives here at the build-script
+    // boundary, not inside the pure resolver.
+    let resolved = streamlib_idents::resolve_with(&crate_dir, &ResolverOptions::from_env())
         .context("Failed to resolve streamlib.yaml dependency graph")?;
 
     emit_rerun_directives(&crate_dir, &resolved);

--- a/libs/streamlib-jtd-codegen/src/lib.rs
+++ b/libs/streamlib-jtd-codegen/src/lib.rs
@@ -110,7 +110,10 @@ pub fn generate(opts: GenerateOptions) -> Result<()> {
     } = opts;
 
     if let Some(project_dir) = project_dir {
-        let resolved = streamlib_idents::resolve_with(&project_dir, &ResolverOptions::default())
+        // `from_env` picks up the Gitea registry config (STREAMLIB_REGISTRY_URL
+        // / GITEA_URL) so `streamlib generate` resolves registry schema deps;
+        // the pure resolver itself never reads env.
+        let resolved = streamlib_idents::resolve_with(&project_dir, &ResolverOptions::from_env())
             .context("Failed to resolve streamlib.yaml dependency graph")?;
 
         if write_lockfile && !resolved.packages.is_empty() {

--- a/libs/streamlib-jtd-codegen/tests/registry_resolved_codegen.rs
+++ b/libs/streamlib-jtd-codegen/tests/registry_resolved_codegen.rs
@@ -1,0 +1,130 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! End-to-end: a registry-cached crate's codegen resolves a schema
+//! dependency from a (hermetic `file://`) Gitea generic registry and
+//! generates bindings — the exact pipeline `build.rs` drives, minus the
+//! cargo build.
+//!
+//! This is the faithful E2E for issue #1116's "a registry-cached
+//! `streamlib-engine` codegen resolves `@tatolab/escalate` from Gitea and
+//! builds." The consumer manifest declares the dep as a bare semver range
+//! with **no `patch:` override** — exactly the published shape after the
+//! cargo-publish path-strip. Before #1116 the resolver returned
+//! `RegistryNotImplemented` here; now it lists → selects-highest-in-range →
+//! fetches + extracts the schema package's `.slpkg`, and codegen emits the
+//! imported type under the dep's owning-package context.
+//!
+//! Skipped (with a clear stderr message) when `jtd-codegen` is not on PATH.
+
+mod common;
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use common::{collect_files, skip_unless_jtd_codegen_available};
+use streamlib_idents::{resolve_with, RegistryConfig, ResolverOptions};
+use streamlib_jtd_codegen::{generate_from_resolved, RuntimeTarget};
+use tempfile::TempDir;
+
+/// Build a schema-package `.slpkg` at `<mirror>/<name>/<version>/<name>.slpkg`
+/// laid out the way the `file://` registry transport expects.
+fn write_slpkg(mirror: &Path, name: &str, version: &str, schema_type: &str) {
+    let dir = mirror.join(name).join(version);
+    fs::create_dir_all(&dir).expect("create mirror version dir");
+    let archive = dir.join(format!("{name}.slpkg"));
+    let mut zip = zip::ZipWriter::new(fs::File::create(&archive).expect("create slpkg"));
+    let opts = zip::write::SimpleFileOptions::default();
+    zip.start_file("streamlib.yaml", opts).unwrap();
+    zip.write_all(
+        format!(
+            "package:\n  org: tatolab\n  name: {name}\n  version: {version}\nschemas:\n  {schema_type}:\n    file: schemas/{schema_type}.yaml\n"
+        )
+        .as_bytes(),
+    )
+    .unwrap();
+    zip.start_file(format!("schemas/{schema_type}.yaml"), opts).unwrap();
+    zip.write_all(
+        format!(
+            "metadata:\n  type: {schema_type}\noptionalProperties:\n  request_id:\n    type: string\n"
+        )
+        .as_bytes(),
+    )
+    .unwrap();
+    zip.finish().unwrap();
+}
+
+#[test]
+fn registry_resolved_schema_codegen_emits_imported_type() {
+    let test_name = "registry_resolved_schema_codegen_emits_imported_type";
+    if skip_unless_jtd_codegen_available(test_name) {
+        return;
+    }
+
+    let tmp = TempDir::new().expect("temp dir");
+    let mirror = tmp.path().join("mirror");
+
+    // Three versions in the registry; the ^1.0.0 range must select 1.2.0.
+    write_slpkg(&mirror, "escalate", "1.0.0", "EscalateRequest");
+    write_slpkg(&mirror, "escalate", "1.2.0", "EscalateRequest");
+    write_slpkg(&mirror, "escalate", "2.0.0", "EscalateRequest");
+
+    // Consumer manifest: bare registry range + External schema import, NO
+    // path patch — the published shape after the cargo-publish strip.
+    let root_dir = tmp.path().join("consumer");
+    fs::create_dir_all(&root_dir).unwrap();
+    fs::write(
+        root_dir.join("streamlib.yaml"),
+        r#"
+package:
+  org: tatolab
+  name: consumer
+  version: 0.4.30
+dependencies:
+  "@tatolab/escalate": "^1.0.0"
+schemas:
+  EscalateRequest:
+    package: "@tatolab/escalate"
+"#,
+    )
+    .unwrap();
+
+    let resolved = resolve_with(
+        &root_dir,
+        &ResolverOptions {
+            cache_dir: Some(tmp.path().join("cache")),
+            registry: Some(RegistryConfig {
+                base_url: format!("file://{}", mirror.display()),
+                token: None,
+            }),
+        },
+    )
+    .expect("registry resolution must succeed without a path patch");
+
+    // Highest-in-range version selected from the registry.
+    let escalate = resolved
+        .packages
+        .get("@tatolab/escalate")
+        .expect("escalate resolved from registry");
+    assert_eq!(
+        escalate.manifest.package.as_ref().unwrap().version.to_string(),
+        "1.2.0"
+    );
+
+    let output = TempDir::new().expect("output temp dir");
+    generate_from_resolved(&resolved, RuntimeTarget::Rust, output.path())
+        .expect("codegen from registry-resolved packages");
+
+    let files: Vec<String> = collect_files(output.path(), &[])
+        .into_iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+
+    assert!(
+        files
+            .iter()
+            .any(|f| f.contains("tatolab__escalate") && f.ends_with("escalate_request.rs")),
+        "expected escalate_request.rs under tatolab__escalate/ (registry-resolved External owner context); got files: {files:?}"
+    );
+}

--- a/libs/streamlib-pack/src/lib.rs
+++ b/libs/streamlib-pack/src/lib.rs
@@ -587,6 +587,49 @@ fn reject_path_patches(pkg_dir: &Path) -> Result<()> {
     );
 }
 
+/// Strip dev-time path-flavor `patch:` entries from a `streamlib.yaml`
+/// body, returning the rewritten YAML. `dependencies:`, git/registry
+/// `patch:` overrides, and every other manifest field pass through
+/// unchanged.
+///
+/// This is the publish-side counterpart to
+/// [`PathDepPolicy::RejectPathPatches`]. Where `streamlib pack` *rejects* a
+/// path patch (a distributed source `.slpkg` must not carry a dev override),
+/// `cargo publish` must *strip* it: the path patch is a legitimate dev
+/// affordance inside the monorepo (it redirects a dep to local source for
+/// instant edits), but the published manifest must be path-free so a
+/// registry-cached consumer resolves the dep from the registry instead of a
+/// dangling `../../packages/...` path. The schema-tier analog of cargo
+/// stripping `path` from a `[dependencies]` path dep on publish.
+///
+/// Idempotent: a manifest with no path patches round-trips unchanged in
+/// content (modulo serializer normalization).
+pub fn strip_path_patches(manifest_yaml: &str) -> Result<String> {
+    let mut manifest: streamlib_processor_schema::StreamlibYaml =
+        serde_yaml::from_str(manifest_yaml).context("parse streamlib.yaml")?;
+    manifest
+        .patch
+        .retain(|_dep_ref, spec| !matches!(spec, DependencySpec::Path(_)));
+    serde_yaml::to_string(&manifest).context("serialize streamlib.yaml")
+}
+
+/// In-place [`strip_path_patches`] on `<dir>/streamlib.yaml`. Intended to run
+/// against a scratch copy of a crate at `cargo publish` time (cargo bundles
+/// `streamlib.yaml` verbatim, with no file-rewrite hook, so the strip happens
+/// before publishing the staged copy). No-op when the file is absent.
+pub fn strip_path_patches_in_dir(dir: &Path) -> Result<()> {
+    let manifest_path = dir.join(Manifest::FILE_NAME);
+    if !manifest_path.exists() {
+        return Ok(());
+    }
+    let body = std::fs::read_to_string(&manifest_path)
+        .with_context(|| format!("read {}", manifest_path.display()))?;
+    let stripped = strip_path_patches(&body)?;
+    std::fs::write(&manifest_path, stripped)
+        .with_context(|| format!("write {}", manifest_path.display()))?;
+    Ok(())
+}
+
 /// Serialize `streamlib.yaml` with every relative `path:` dep/patch
 /// rewritten to absolute, anchored at `pkg_dir`. Registry / git entries
 /// pass through unchanged.
@@ -950,6 +993,69 @@ mod tests {
         .expect_err("RejectPathPatches must reject a path-flavor patch");
         let msg = format!("{err}");
         assert!(msg.contains("@tatolab/core") && msg.contains("not publishable"));
+    }
+
+    #[test]
+    fn strip_path_patches_removes_path_patch_keeps_dependencies() {
+        // Engine-shaped manifest: a registry dep + a dev path patch. The
+        // strip must drop the patch entry but leave the dependency range,
+        // schemas, package block, and everything else intact.
+        let yaml = "package:\n  org: tatolab\n  name: engine\n  version: 0.4.30\ndependencies:\n  \"@tatolab/escalate\": \"^1.0.0\"\npatch:\n  \"@tatolab/escalate\":\n    path: ../../packages/escalate\nschemas:\n  EscalateRequest:\n    package: \"@tatolab/escalate\"\n";
+        let stripped = strip_path_patches(yaml).unwrap();
+        // No path patch survives.
+        assert!(!stripped.contains("../../packages/escalate"));
+        assert!(!stripped.contains("patch:") || !stripped.contains("path:"));
+        // The dependency range + schema import are preserved.
+        assert!(stripped.contains("@tatolab/escalate"));
+        assert!(stripped.contains("^1.0.0"));
+        // Re-parse to prove it's still a valid, path-free manifest.
+        let manifest: streamlib_idents::Manifest = serde_yaml::from_str(&stripped).unwrap();
+        assert!(manifest.patch.is_empty());
+        assert_eq!(manifest.dependencies.len(), 1);
+    }
+
+    #[test]
+    fn strip_path_patches_preserves_non_path_patches() {
+        // A git-flavor patch override is NOT a dev path affordance — it must
+        // survive the strip (only `path:` patches are dev-only).
+        let yaml = "package:\n  org: tatolab\n  name: foo\n  version: 1.0.0\ndependencies:\n  \"@tatolab/core\": \"^1.0.0\"\n  \"@tatolab/bar\": \"^2.0.0\"\npatch:\n  \"@tatolab/core\":\n    path: ../core\n  \"@tatolab/bar\":\n    git: https://example.com/bar\n    rev: abc123\n";
+        let stripped = strip_path_patches(yaml).unwrap();
+        let manifest: streamlib_idents::Manifest = serde_yaml::from_str(&stripped).unwrap();
+        // The git patch survives; the path patch is gone.
+        assert_eq!(manifest.patch.len(), 1);
+        let (dep_ref, bar) = manifest.patch.iter().next().unwrap();
+        assert_eq!(dep_ref.to_string(), "@tatolab/bar");
+        assert!(matches!(bar, DependencySpec::Git(_)));
+    }
+
+    #[test]
+    fn strip_path_patches_idempotent_when_no_path_patch() {
+        // A manifest with no path patch round-trips through parse+serialize
+        // (content equal modulo serializer normalization — re-stripping a
+        // stripped manifest is a no-op on the dependency graph).
+        let yaml = "package:\n  org: tatolab\n  name: leaf\n  version: 1.0.0\ndependencies:\n  \"@tatolab/core\": \"^1.0.0\"\n";
+        let once = strip_path_patches(yaml).unwrap();
+        let twice = strip_path_patches(&once).unwrap();
+        assert_eq!(once, twice);
+        let manifest: streamlib_idents::Manifest = serde_yaml::from_str(&once).unwrap();
+        assert!(manifest.patch.is_empty());
+        assert_eq!(manifest.dependencies.len(), 1);
+    }
+
+    #[test]
+    fn strip_path_patches_in_dir_rewrites_file() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: engine\n  version: 0.4.30\ndependencies:\n  \"@tatolab/escalate\": \"^1.0.0\"\npatch:\n  \"@tatolab/escalate\":\n    path: ../../packages/escalate\n",
+        )
+        .unwrap();
+        strip_path_patches_in_dir(dir.path()).unwrap();
+        let body = std::fs::read_to_string(dir.path().join("streamlib.yaml")).unwrap();
+        assert!(!body.contains("../../packages/escalate"));
+        let manifest: streamlib_idents::Manifest = serde_yaml::from_str(&body).unwrap();
+        assert!(manifest.patch.is_empty());
+        assert_eq!(manifest.dependencies.len(), 1);
     }
 
     #[test]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,6 +15,10 @@ streamlib-jtd-codegen = { path = "../libs/streamlib-jtd-codegen" }
 # `schemars::schema_for!(StreamlibYaml)` from this crate (#714).
 streamlib-processor-schema = { path = "../libs/streamlib-processor-schema" }
 
+# Package-artifact assembly — backs `strip-publish-manifest`, the publish-side
+# path-patch strip for the Gitea registry distribution.
+streamlib-pack = { path = "../libs/streamlib-pack" }
+
 # Logging — needed to surface tracing::info! output from streamlib-jtd-codegen.
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -150,6 +150,19 @@ enum Commands {
     /// `streamlib.yaml` carries the `# yaml-language-server: $schema=...`
     /// header, (3) every `streamlib.yaml` validates against the schema.
     CheckManifestSchema,
+
+    /// Strip dev-time path-flavor `patch:` entries from a crate's
+    /// `streamlib.yaml` so the published manifest is path-free. Intended to
+    /// run against a scratch copy of the crate before `cargo publish` (cargo
+    /// bundles `streamlib.yaml` verbatim with no file-rewrite hook). The
+    /// publish-side half of the Gitea registry distribution; the resolver's
+    /// `Registry` arm resolves the now-path-free dep from the registry. See
+    /// `docs/architecture/gitea-registry-distribution.md`.
+    StripPublishManifest {
+        /// Directory containing the `streamlib.yaml` to strip in place.
+        #[arg(long)]
+        dir: PathBuf,
+    },
 }
 
 fn main() -> Result<()> {
@@ -198,6 +211,12 @@ fn main() -> Result<()> {
         }
         Commands::EmitManifestSchema => manifest_schema::emit(&workspace_root()?)?,
         Commands::CheckManifestSchema => manifest_schema::check(&workspace_root()?)?,
+        Commands::StripPublishManifest { dir } => {
+            streamlib_pack::strip_path_patches_in_dir(&dir).with_context(|| {
+                format!("stripping path patches from {}", dir.display())
+            })?;
+            tracing::info!(dir = %dir.display(), "stripped path-flavor patch entries from streamlib.yaml");
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

- Implements the `streamlib-idents` resolver's `DependencySpec::Registry` arm (previously `RegistryNotImplemented`): list a schema package's versions via Gitea's package-management API, select the highest satisfying the declared semver range, fetch + extract that version's `.slpkg` from the generic registry, load it — the schema-tier twin of cargo-crate resolution. The resolved concrete version is pinned in the lockfile via the pre-existing `ResolvedSource::Registry`.
- Adds the publish-side **strip capability** (`streamlib_pack::strip_path_patches` / `strip_path_patches_in_dir`) that drops dev path-flavor `patch:` entries from a `streamlib.yaml`, exposed via `xtask strip-publish-manifest --dir <crate-dir>` for the dev-publish script to wire in.
- `resolve_with` is **pure** — registry config rides `ResolverOptions::registry`; the env read (`STREAMLIB_REGISTRY_URL` / `GITEA_URL`) lives in `ResolverOptions::from_env`, used by the codegen boundaries (build.rs, `streamlib generate`). `http(s)://` is the production transport; `file://` is the hermetic local-mirror / test transport.

The resolver is shared by all three runtimes' codegen, so this is **polyglot-by-construction** — one fix covers Rust/Python/Deno; no per-language code, no schema/wire-format change.

## Closes

Closes #1116

## Findings vs. the issue body

- The issue/doc claimed `streamlib pack`'s `RejectPathPatches` "strips" the dev patch — it actually **hard-errors** (rejects); no strip routine existed. The cargo-publish case genuinely needs a *strip* (the path patch is a legitimate dev affordance locally but must be removed on publish), so `strip_path_patches` is new code. `docs/architecture/gitea-registry-distribution.md` corrected.
- The cargo-publish **wiring** (scratch-copy strip in the dev-publish script + the ~28-crate manifest migration + the full out-of-repo build E2E) is **#1105's** deliverable; #1116 blocks #1105 and ships the capability it consumes. The "out-of-repo build" E2E criterion was rescoped to #1105 accordingly; #1116 proves the resolver+strip mechanism hermetically.
- Range→version via Gitea's management API; capability-in-#1116 / wiring-in-#1105 — both architect-confirmed.

## Exit criteria

- [x] `streamlib-idents` resolves a `Registry` schema dep by listing versions (Gitea management API), selecting highest in-range, fetching + extracting its `.slpkg`.
- [x] `streamlib-pack` exposes a tested `strip_path_patches` capability with a thin xtask invocation surface for #1105.
- [x] A registry-cached crate's codegen (hermetic fixture, registry dep + no path patch) resolves its schema from a local registry and builds.

## Test plan

All green (`cargo test -p <crate>`): streamlib-idents 98, streamlib-pack 15, streamlib-jtd-codegen 60, xtask 168.

- **Unit (resolver):** `registry_dependency_resolves_from_file_mirror` (list → select-highest-in-range → fetch → extract → load + lockfile `Registry` source), `select_version_picks_highest_in_range`, `registry_dependency_no_matching_version_errors`, `registry_dependency_without_config_errors` (deterministic `RegistryNotConfigured`, env-independent).
- **Unit (http path):** `http_list_and_download_against_localhost` — one-shot localhost server locks the management-API URL + `GiteaPackageEntry` JSON shape + generic download URL.
- **Unit (strip):** drops `Path` patches, preserves git/registry patches + `dependencies:` + schemas; idempotent; in-dir file rewrite.
- **Hermetic E2E:** `registry_resolved_codegen.rs` — a consumer manifest with a bare registry range and **no path patch** resolves `@tatolab/escalate` from a `file://` Gitea mirror and drives `generate_from_resolved` to emit the imported type (the build.rs pipeline minus the cargo build). Skips when `jtd-codegen` isn't on PATH.

Pre-PR review gate: PASS. Two DISCUSS items raised and resolved — (1) the impure-resolver env-leak was fixed by making `resolve_with` pure + moving the env read to `from_env` at the codegen boundary; (2) `strip_path_patches`' `deny_unknown_fields` parse was verified safe (`StreamlibYaml` is the canonical manifest type CI already validates against).

## Follow-ups

- #1105 wires `strip-publish-manifest` into the dev-publish script, migrates the ~28 crate manifests to path-free published form, and runs the full out-of-repo build against a live Gitea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)