### PR TITLE
feat(gitea): resolve Rust SDK + vulkanalia by version from the Gitea registry

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,12 @@
 
 [alias]
 xtask = "run --package xtask --"
+
+# Unified Gitea registry (org: tatolab). SDK crates + the vulkanalia fork
+# resolve by version from here; see docs/architecture/gitea-registry-distribution.md.
+# Sparse protocol — Gitea serves the index from its package DB (no _cargo-index
+# repo, no web-session init). Read is anonymous; publish needs a Bearer token in
+# credentials.toml. The localhost URL is the local dev-registry default; override
+# for a hosted backend with CARGO_REGISTRIES_GITEA_INDEX.
+[registries.gitea]
+index = "sparse+http://localhost:3300/api/packages/tatolab/cargo/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,9 +157,12 @@ objc2-core-graphics = "0.3.2"
 objc2-vision = "0.3.2"
 libc = "0.2.177"
 
-# Vulkan bindings (tatolab fork for VMA 3.3.0 patch)
-vulkanalia = { git = "https://github.com/tatolab/vulkanalia.git", rev = "982d32d293e5425753d595978776ee4fa4ded3a1", features = ["libloading", "provisional", "window"] }
-vulkanalia-vma = { git = "https://github.com/tatolab/vulkanalia.git", rev = "982d32d293e5425753d595978776ee4fa4ded3a1" }
+# Vulkan bindings (tatolab fork for the VMA 3.3.0 patch). Resolved by version
+# from the Gitea registry — the fork shares crates.io version numbers, so the
+# `registry = "gitea"` annotation (not a distinct version) is what selects the
+# fork over upstream. See docs/architecture/gitea-registry-distribution.md.
+vulkanalia = { version = "0.35.0", registry = "gitea", features = ["libloading", "provisional", "window"] }
+vulkanalia-vma = { version = "0.9.0", registry = "gitea" }
 
 # SPIR-V reflection for descriptor-set-layout validation in the compute-kernel RHI.
 rspirv-reflect = "0.9.0"
@@ -235,6 +238,3 @@ hyper = "1.7.0"
 # YUV/RGB conversion - REMOVED (now using GPU-accelerated VTPixelTransferSession)
 # yuv = "0.8"
 
-[patch.crates-io]
-vulkanalia = { git = "https://github.com/tatolab/vulkanalia.git", rev = "982d32d293e5425753d595978776ee4fa4ded3a1" }
-vulkanalia-sys = { git = "https://github.com/tatolab/vulkanalia.git", rev = "982d32d293e5425753d595978776ee4fa4ded3a1" }

--- a/docs/architecture/gitea-registry-distribution.md
+++ b/docs/architecture/gitea-registry-distribution.md
@@ -70,7 +70,7 @@ namespace up is scripted and idempotent — see
 No consumer ever sees a relative `path` dep or a git `[patch]`. Each language
 uses its native resolution, pointed at Gitea via container-level config:
 
-### Rust (finalized in #1105)
+### Rust
 
 Internal cross-crate deps use the standard cargo "publish a workspace" form:
 
@@ -94,7 +94,7 @@ streamlib-engine = { path = "../streamlib-engine", version = "0.4.30", registry 
 - Deno: a stable bare `import "streamlib"` resolves from Gitea's npm registry
   (`.npmrc`) or a container-level import map — no relative `../../../libs/...`.
 
-### vulkanalia fork (finalized in #1105)
+### vulkanalia fork
 
 The `tatolab/vulkanalia` fork (`vulkanalia` / `-sys` / `-vma`) is published to
 Gitea and resolved by `{ version, registry = "gitea" }`. The workspace's
@@ -115,7 +115,7 @@ Gitea by version.
 > on the consuming host to build the rust cdylib — weigh against the
 > compiler-free-deployment goal.
 
-## Schema-package resolution (resolver + strip capability shipped in #1116; cargo-publish wiring in #1105)
+## Schema-package resolution (resolver + strip capability + cargo-publish wiring shipped)
 
 `streamlib.yaml` schema dependencies (e.g. `@tatolab/escalate`) are themselves
 packages — they resolve from Gitea's **generic** registry: list the schema
@@ -141,10 +141,15 @@ halves, mirroring cargo:
    `../../packages/...` path patch). `streamlib_pack::strip_path_patches`
    drops dev path-flavor `patch:` entries, exposed as `xtask
    strip-publish-manifest --dir <crate-dir>`. Because **`cargo publish`
-   bundles `streamlib.yaml` verbatim** with no file-rewrite hook, the strip
-   runs against a scratch copy before publish — that wiring (plus the
-   ~28-crate manifest migration and the out-of-repo build) lands with the
-   dev-publish script in #1105.
+   bundles `streamlib.yaml` verbatim** with no file-rewrite hook,
+   `scripts/gitea/publish-crates.sh` runs the strip immediately before each
+   affected crate's publish and restores the tree afterward (today only
+   `streamlib-engine` →`@tatolab/escalate` carries a `patch:`); the companion
+   `scripts/gitea/publish-vulkanalia.sh` does the equivalent on a non-git
+   scratch copy of the fork. Verified end to end: an out-of-repo consumer
+   deps `streamlib` by version, and `streamlib-engine`'s `build.rs` codegen
+   resolves `@tatolab/escalate` from the generic registry (the schema package
+   published as a source `.slpkg`) and the engine compiles.
 
    > ~~`streamlib pack`'s `RejectPathPatches` strips the dev `path:` patch.~~
    > — Corrected 2026-05-30 (#1116): `RejectPathPatches` *rejects* a path
@@ -215,15 +220,16 @@ Notes the scripts encode:
 
 | Piece | Status | Issue |
 |---|---|---|
-| cargo publish → resolve-by-version (real SDK chain + vulkanalia/VMA) | ✅ validated (POC) | #1105 |
+| cargo publish → resolve-by-version (real SDK chain + vulkanalia/VMA) | ✅ shipped | #1105 |
 | `.slpkg` round-trip through the generic registry | ✅ validated (POC) | #1119 |
 | `tatolab` org namespace + POC cleanup | ✅ shipped | #1115 |
 | schema-package registry resolution (resolver `Registry` arm) + `strip_path_patches` capability | ✅ shipped | #1116 |
-| cargo-publish manifest path-strip *wiring* (dev-publish script + manifest migration) | ⏳ | #1105 |
+| cargo-publish manifest path-strip *wiring* (dev-publish script + manifest migration) | ✅ shipped | #1105 |
+| full-engine codegen consumer build (engine `build.rs` resolves `@tatolab/escalate` from the generic registry) | ✅ shipped | #1105 |
 | Python SDK publish | ⏳ | #1117 |
 | Deno SDK publish | ⏳ | #1118 |
 | packages as source-only `.slpkg` + `streamlib pack` source-only | ⏳ | #1119 |
-| repo migration committed (`{ path, version, registry }`, `.cargo/config`, dev-publish script) | ⏳ | #1105 |
+| repo migration committed (`{ path, version, registry }`, `.cargo/config`, dev-publish script) | ✅ shipped | #1105 |
 
 ## Reference
 

--- a/examples/api-server-demo/Cargo.toml
+++ b/examples/api-server-demo/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 # `@tatolab/api-server` and `@tatolab/debug-utilities` load at runtime
 # via `Runner::add_module` — no compile-time link.
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 tokio = { version = "1.48.0", features = ["full"] }
 reqwest = { version = "0.12", features = ["json"] }
 serde_json = "1.0"

--- a/examples/api-server/Cargo.toml
+++ b/examples/api-server/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2024"
 # `@tatolab/api-server` loaded at runtime via
 # `Runner::add_module` — no compile-time link.
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 serde_json = "1"
 tokio = { version = "1.48.0", features = ["full"] }

--- a/examples/audio-mixer-demo/Cargo.toml
+++ b/examples/audio-mixer-demo/Cargo.toml
@@ -9,5 +9,5 @@ edition = "2024"
 # `Runner::add_module_with` against the build orchestrator
 # output — no compile-time link.
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 serde_json = "1"

--- a/examples/camera-audio-recorder/Cargo.toml
+++ b/examples/camera-audio-recorder/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2024"
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-audio = { path = "../../packages/audio" }
-streamlib-camera = { path = "../../packages/camera" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-audio = { path = "../../packages/audio", version = "0.4.30", registry = "gitea" }
+streamlib-camera = { path = "../../packages/camera", version = "0.4.30", registry = "gitea" }
 tokio = { version = "1.48.0", features = ["full"] }
 anyhow = "1.0.100"
 libc = "0.2"

--- a/examples/camera-deno-subprocess/Cargo.toml
+++ b/examples/camera-deno-subprocess/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 serde_json = "1.0"

--- a/examples/camera-display/Cargo.toml
+++ b/examples/camera-display/Cargo.toml
@@ -8,7 +8,7 @@ default = []
 backend-vulkan = ["streamlib/backend-vulkan"]
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 tokio = { version = "1.48.0", features = ["full"] }
 anyhow = "1.0.100"
 serde_json = "1.0"

--- a/examples/camera-python-display/Cargo.toml
+++ b/examples/camera-python-display/Cargo.toml
@@ -14,16 +14,16 @@ default = []
 backend-vulkan = ["streamlib/backend-vulkan"]
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 tracing = { workspace = true }
 serde_json = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
+streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
 # `VulkanLayout` newtype used by `register_render_target_surface` when
 # dual-registering the Skia / OpenGL DMA-BUF outputs in
 # `texture_cache`. The runner never imports `vulkanalia` directly; the
 # `BlendingCompositor` / `CrtFilmGrain` graphics-kernel wrappers
 # (which DO ride `vulkanalia` as a transitional exception) live in the
 # sibling `effects/` package and load via `runtime.add_module_with`.
-streamlib-consumer-rhi = { path = "../../libs/streamlib-consumer-rhi" }
+streamlib-consumer-rhi = { path = "../../libs/streamlib-consumer-rhi", version = "0.4.30", registry = "gitea" }

--- a/examples/camera-python-display/effects/Cargo.toml
+++ b/examples/camera-python-display/effects/Cargo.toml
@@ -13,11 +13,11 @@ publish = false
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
-streamlib = { path = "../../../libs/streamlib-sdk" }
-streamlib-plugin-abi = { path = "../../../libs/streamlib-plugin-abi" }
+streamlib = { path = "../../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-plugin-abi = { path = "../../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -28,9 +28,9 @@ serde_json = { workspace = true }
 png = "0.17"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-adapter-abi = { path = "../../../libs/streamlib-adapter-abi" }
+streamlib-adapter-abi = { path = "../../../libs/streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
 # `VulkanLayout` newtype used by the BlendingCompositor / CrtFilmGrain
 # wrappers when issuing layout barriers via the `RhiCommandRecorder`.
 # Goes through the typed consumer-rhi interop type rather than reaching
 # for `vulkanalia::vk::ImageLayout` directly.
-streamlib-consumer-rhi = { path = "../../../libs/streamlib-consumer-rhi" }
+streamlib-consumer-rhi = { path = "../../../libs/streamlib-consumer-rhi", version = "0.4.30", registry = "gitea" }

--- a/examples/camera-python-subprocess/Cargo.toml
+++ b/examples/camera-python-subprocess/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 serde_json = "1.0"

--- a/examples/camera-rust-plugin/Cargo.toml
+++ b/examples/camera-rust-plugin/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 serde_json = "1.0"

--- a/examples/camera-rust-plugin/plugin/Cargo.toml
+++ b/examples/camera-rust-plugin/plugin/Cargo.toml
@@ -11,9 +11,9 @@ publish = false
 crate-type = ["cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
-streamlib = { path = "../../../libs/streamlib-sdk" }
-streamlib-plugin-abi = { path = "../../../libs/streamlib-plugin-abi" }
+streamlib = { path = "../../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-plugin-abi = { path = "../../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 tracing = "0.1"

--- a/examples/cuda-fisheye-detection/Cargo.toml
+++ b/examples/cuda-fisheye-detection/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
-streamlib-adapter-cuda = { path = "../../libs/streamlib-adapter-cuda" }
-streamlib-debug-utilities = { path = "../../packages/debug-utilities" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-cuda = { path = "../../libs/streamlib-adapter-cuda", version = "0.4.30", registry = "gitea" }
+streamlib-debug-utilities = { path = "../../packages/debug-utilities", version = "0.4.30", registry = "gitea" }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 serde_json = "1.0"

--- a/examples/jpeg-psnr/Cargo.toml
+++ b/examples/jpeg-psnr/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 serde_json = "1"
 anyhow = "1.0.100"

--- a/examples/microphone-reverb-speaker/Cargo.toml
+++ b/examples/microphone-reverb-speaker/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-audio = { path = "../../packages/audio" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-audio = { path = "../../packages/audio", version = "0.4.30", registry = "gitea" }
 tokio = { version = "1.48.0", features = ["full"] }
 anyhow = "1.0.100"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-streamlib-clap = { path = "../../packages/clap" }
+streamlib-clap = { path = "../../packages/clap", version = "0.4.30", registry = "gitea" }

--- a/examples/moq-roundtrip/Cargo.toml
+++ b/examples/moq-roundtrip/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 serde_json = "1"
 tokio = { version = "1.48.0", features = ["full"] }
 tracing = "0.1.41"

--- a/examples/polyglot-continuous-processor/Cargo.toml
+++ b/examples/polyglot-continuous-processor/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 serde_json = "1.0"

--- a/examples/polyglot-cpu-readback-blur/Cargo.toml
+++ b/examples/polyglot-cpu-readback-blur/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
-streamlib-adapter-cpu-readback = { path = "../../libs/streamlib-adapter-cpu-readback" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-cpu-readback = { path = "../../libs/streamlib-adapter-cpu-readback", version = "0.4.30", registry = "gitea" }
 serde_json = "1.0"
 png = "0.17"
 

--- a/examples/polyglot-cuda-inference/Cargo.toml
+++ b/examples/polyglot-cuda-inference/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
-streamlib-adapter-cuda = { path = "../../libs/streamlib-adapter-cuda" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-cuda = { path = "../../libs/streamlib-adapter-cuda", version = "0.4.30", registry = "gitea" }
 serde_json = "1.0"

--- a/examples/polyglot-dma-buf-consumer/Cargo.toml
+++ b/examples/polyglot-dma-buf-consumer/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 serde_json = "1.0"

--- a/examples/polyglot-manual-source/Cargo.toml
+++ b/examples/polyglot-manual-source/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 serde_json = "1.0"

--- a/examples/polyglot-manual-source/plugin/Cargo.toml
+++ b/examples/polyglot-manual-source/plugin/Cargo.toml
@@ -11,11 +11,11 @@ publish = false
 crate-type = ["cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
-streamlib = { path = "../../../libs/streamlib-sdk" }
-streamlib-plugin-abi = { path = "../../../libs/streamlib-plugin-abi" }
+streamlib = { path = "../../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-plugin-abi = { path = "../../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = "0.1"

--- a/examples/polyglot-opengl-fragment-shader/Cargo.toml
+++ b/examples/polyglot-opengl-fragment-shader/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
 serde_json = "1.0"
 png = "0.17"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-adapter-opengl = { path = "../../libs/streamlib-adapter-opengl" }
+streamlib-adapter-opengl = { path = "../../libs/streamlib-adapter-opengl", version = "0.4.30", registry = "gitea" }

--- a/examples/polyglot-skia-canvas/Cargo.toml
+++ b/examples/polyglot-skia-canvas/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
 serde_json = "1.0"
 png = "0.17"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-adapter-vulkan = { path = "../../libs/streamlib-adapter-vulkan" }
+streamlib-adapter-vulkan = { path = "../../libs/streamlib-adapter-vulkan", version = "0.4.30", registry = "gitea" }

--- a/examples/polyglot-vulkan-compute/Cargo.toml
+++ b/examples/polyglot-vulkan-compute/Cargo.toml
@@ -9,12 +9,12 @@ publish = false
 build = "build.rs"
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
 serde_json = "1.0"
 png = "0.17"
 parking_lot = "0.12"
 sha2 = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-adapter-vulkan = { path = "../../libs/streamlib-adapter-vulkan" }
+streamlib-adapter-vulkan = { path = "../../libs/streamlib-adapter-vulkan", version = "0.4.30", registry = "gitea" }

--- a/examples/polyglot-vulkan-graphics/Cargo.toml
+++ b/examples/polyglot-vulkan-graphics/Cargo.toml
@@ -9,12 +9,12 @@ publish = false
 build = "build.rs"
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
 serde_json = "1.0"
 png = "0.17"
 parking_lot = "0.12"
 sha2 = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-adapter-vulkan = { path = "../../libs/streamlib-adapter-vulkan" }
+streamlib-adapter-vulkan = { path = "../../libs/streamlib-adapter-vulkan", version = "0.4.30", registry = "gitea" }

--- a/examples/polyglot-vulkan-ray-tracing/Cargo.toml
+++ b/examples/polyglot-vulkan-ray-tracing/Cargo.toml
@@ -9,12 +9,12 @@ publish = false
 build = "build.rs"
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
 serde_json = "1.0"
 png = "0.17"
 parking_lot = "0.12"
 sha2 = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-adapter-vulkan = { path = "../../libs/streamlib-adapter-vulkan" }
+streamlib-adapter-vulkan = { path = "../../libs/streamlib-adapter-vulkan", version = "0.4.30", registry = "gitea" }

--- a/examples/raytracing-showcase/Cargo.toml
+++ b/examples/raytracing-showcase/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 anyhow = "1.0.100"

--- a/examples/runtime-graph-json-demo/Cargo.toml
+++ b/examples/runtime-graph-json-demo/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-camera = { path = "../../packages/camera" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-camera = { path = "../../packages/camera", version = "0.4.30", registry = "gitea" }
 serde_json = "1.0"

--- a/examples/screen-recorder/Cargo.toml
+++ b/examples/screen-recorder/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-streamlib-screen-capture = { path = "../../packages/screen-capture" }
+streamlib-screen-capture = { path = "../../packages/screen-capture", version = "0.4.30", registry = "gitea" }

--- a/examples/tokio-integration/Cargo.toml
+++ b/examples/tokio-integration/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 tokio = { version = "1", features = ["full"] }

--- a/examples/vulkan-video-psnr/Cargo.toml
+++ b/examples/vulkan-video-psnr/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 serde_json = "1"
 anyhow = "1.0.100"

--- a/examples/vulkan-video-roundtrip-cdylib-camera/Cargo.toml
+++ b/examples/vulkan-video-roundtrip-cdylib-camera/Cargo.toml
@@ -9,5 +9,5 @@ edition = "2024"
 # Rust dep would auto-register the `Camera` processor at link time,
 # conflicting with the cdylib's registration at load time.
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 serde_json = "1"

--- a/examples/vulkan-video-roundtrip/Cargo.toml
+++ b/examples/vulkan-video-roundtrip/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 serde_json = "1"
 anyhow = "1.0.100"

--- a/examples/webrtc-cloudflare-stream/Cargo.toml
+++ b/examples/webrtc-cloudflare-stream/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2024"
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 tokio = { version = "1.48.0", features = ["full"] }
 anyhow = "1.0.100"
 libc = "0.2"

--- a/examples/whep-player/Cargo.toml
+++ b/examples/whep-player/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-webrtc = { path = "../../packages/webrtc" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-webrtc = { path = "../../packages/webrtc", version = "0.4.30", registry = "gitea" }
 ctrlc = "3.4"

--- a/libs/streamlib-adapter-cpu-readback-helpers/Cargo.toml
+++ b/libs/streamlib-adapter-cpu-readback-helpers/Cargo.toml
@@ -27,12 +27,12 @@ publish = false
 path = "src/lib.rs"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib = { path = "../streamlib-sdk" }
-streamlib-engine = { path = "../streamlib-engine" }
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
-streamlib-adapter-cpu-readback = { path = "../streamlib-adapter-cpu-readback" }
-streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
-streamlib-surface-client = { path = "../streamlib-surface-client" }
+streamlib = { path = "../streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-engine = { path = "../streamlib-engine", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-cpu-readback = { path = "../streamlib-adapter-cpu-readback", version = "0.4.30", registry = "gitea" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.4.30", registry = "gitea" }
+streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.4.30", registry = "gitea" }
 vulkanalia.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/libs/streamlib-adapter-cpu-readback/Cargo.toml
+++ b/libs/streamlib-adapter-cpu-readback/Cargo.toml
@@ -15,14 +15,14 @@ name = "streamlib_adapter_cpu_readback"
 path = "src/lib.rs"
 
 [dependencies]
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
-streamlib-adapter-cpu-readback-abi = { path = "../streamlib-adapter-cpu-readback-abi" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-cpu-readback-abi = { path = "../streamlib-adapter-cpu-readback-abi", version = "0.4.30", registry = "gitea" }
 thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
-streamlib-surface-client = { path = "../streamlib-surface-client" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.4.30", registry = "gitea" }
+streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.4.30", registry = "gitea" }
 vulkanalia.workspace = true
 libc.workspace = true
 serde = { workspace = true }

--- a/libs/streamlib-adapter-cuda-helpers/Cargo.toml
+++ b/libs/streamlib-adapter-cuda-helpers/Cargo.toml
@@ -42,11 +42,11 @@ default = []
 cuda = ["dep:cudarc"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib = { path = "../streamlib-sdk" }
-streamlib-engine = { path = "../streamlib-engine" }
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
-streamlib-adapter-cuda = { path = "../streamlib-adapter-cuda" }
-streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
+streamlib = { path = "../streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-engine = { path = "../streamlib-engine", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-cuda = { path = "../streamlib-adapter-cuda", version = "0.4.30", registry = "gitea" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.4.30", registry = "gitea" }
 vulkanalia.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/libs/streamlib-adapter-cuda/Cargo.toml
+++ b/libs/streamlib-adapter-cuda/Cargo.toml
@@ -29,14 +29,14 @@ default = []
 cuda = []
 
 [dependencies]
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
-streamlib-adapter-cuda-abi = { path = "../streamlib-adapter-cuda-abi" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-cuda-abi = { path = "../streamlib-adapter-cuda-abi", version = "0.4.30", registry = "gitea" }
 thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
-streamlib-surface-client = { path = "../streamlib-surface-client" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.4.30", registry = "gitea" }
+streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.4.30", registry = "gitea" }
 vulkanalia.workspace = true
 libc.workspace = true
 # DLPack ABI mirrors only — `default-features = false` pulls in only

--- a/libs/streamlib-adapter-opengl/Cargo.toml
+++ b/libs/streamlib-adapter-opengl/Cargo.toml
@@ -15,15 +15,15 @@ name = "streamlib_adapter_opengl"
 path = "src/lib.rs"
 
 [dependencies]
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
-streamlib-adapter-opengl-abi = { path = "../streamlib-adapter-opengl-abi" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-opengl-abi = { path = "../streamlib-adapter-opengl-abi", version = "0.4.30", registry = "gitea" }
 parking_lot = "0.12"
 thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
-streamlib-surface-client = { path = "../streamlib-surface-client" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.4.30", registry = "gitea" }
+streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.4.30", registry = "gitea" }
 khronos-egl = { version = "6.0", features = ["dynamic"] }
 gl = "0.14"
 libc.workspace = true

--- a/libs/streamlib-adapter-skia/Cargo.toml
+++ b/libs/streamlib-adapter-skia/Cargo.toml
@@ -15,15 +15,15 @@ name = "streamlib_adapter_skia"
 path = "src/lib.rs"
 
 [dependencies]
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
-streamlib-adapter-skia-abi = { path = "../streamlib-adapter-skia-abi" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-skia-abi = { path = "../streamlib-adapter-skia-abi", version = "0.4.30", registry = "gitea" }
 thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan" }
-streamlib-adapter-opengl = { path = "../streamlib-adapter-opengl" }
-streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
+streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-opengl = { path = "../streamlib-adapter-opengl", version = "0.4.30", registry = "gitea" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.4.30", registry = "gitea" }
 vulkanalia.workspace = true
 skia-safe = { workspace = true }
 # vkGetInstanceProcAddr lives on vulkanalia's private StaticCommands;
@@ -37,7 +37,7 @@ libloading = "0.8"
 # live under regular `[dependencies]` rather than `[dev-dependencies]`
 # because Cargo's `[[bin]]` targets don't see dev-deps. Same shape as
 # `streamlib-adapter-opengl/Cargo.toml`.
-streamlib-surface-client = { path = "../streamlib-surface-client" }
+streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.4.30", registry = "gitea" }
 serde = { workspace = true }
 serde_json.workspace = true
 libc.workspace = true

--- a/libs/streamlib-adapter-vulkan-helpers/Cargo.toml
+++ b/libs/streamlib-adapter-vulkan-helpers/Cargo.toml
@@ -27,12 +27,12 @@ publish = false
 path = "src/lib.rs"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib = { path = "../streamlib-sdk" }
-streamlib-engine = { path = "../streamlib-engine" }
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
-streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan" }
-streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
-streamlib-surface-client = { path = "../streamlib-surface-client" }
+streamlib = { path = "../streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-engine = { path = "../streamlib-engine", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan", version = "0.4.30", registry = "gitea" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.4.30", registry = "gitea" }
+streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.4.30", registry = "gitea" }
 vulkanalia.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/libs/streamlib-adapter-vulkan/Cargo.toml
+++ b/libs/streamlib-adapter-vulkan/Cargo.toml
@@ -15,14 +15,14 @@ name = "streamlib_adapter_vulkan"
 path = "src/lib.rs"
 
 [dependencies]
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
-streamlib-adapter-vulkan-abi = { path = "../streamlib-adapter-vulkan-abi" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-vulkan-abi = { path = "../streamlib-adapter-vulkan-abi", version = "0.4.30", registry = "gitea" }
 thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
-streamlib-surface-client = { path = "../streamlib-surface-client" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.4.30", registry = "gitea" }
+streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.4.30", registry = "gitea" }
 vulkanalia.workspace = true
 libc.workspace = true
 serde = { workspace = true }

--- a/libs/streamlib-build-orchestrator/Cargo.toml
+++ b/libs/streamlib-build-orchestrator/Cargo.toml
@@ -14,10 +14,10 @@ repository.workspace = true
 anyhow = { workspace = true }
 tracing = { workspace = true }
 serde_json = { workspace = true }
-streamlib-engine = { path = "../streamlib-engine" }
-streamlib-cargo-build = { path = "../streamlib-cargo-build" }
-streamlib-pack = { path = "../streamlib-pack" }
-streamlib-plugin-abi = { path = "../streamlib-plugin-abi" }
+streamlib-engine = { path = "../streamlib-engine", version = "0.4.30", registry = "gitea" }
+streamlib-cargo-build = { path = "../streamlib-cargo-build", version = "0.4.30", registry = "gitea" }
+streamlib-pack = { path = "../streamlib-pack", version = "0.4.30", registry = "gitea" }
+streamlib-plugin-abi = { path = "../streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/libs/streamlib-cargo-build/Cargo.toml
+++ b/libs/streamlib-cargo-build/Cargo.toml
@@ -17,8 +17,8 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
-streamlib-idents = { path = "../streamlib-idents" }
-streamlib-processor-schema = { path = "../streamlib-processor-schema" }
+streamlib-idents = { path = "../streamlib-idents", version = "0.4.30", registry = "gitea" }
+streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.4.30", registry = "gitea" }
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/libs/streamlib-cli/Cargo.toml
+++ b/libs/streamlib-cli/Cargo.toml
@@ -16,23 +16,23 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library (bundles all Rust processors)
-streamlib = { path = "../streamlib-sdk" }
+streamlib = { path = "../streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 # Schema types (processor YAML parsing)
-streamlib-processor-schema = { path = "../streamlib-processor-schema" }
+streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.4.30", registry = "gitea" }
 
 # Manifest + workspace + dependency-spec types for `streamlib pack` /
 # `pkg install` / `pkg remove` — typed PackageRef, Manifest schema, etc.
-streamlib-idents = { path = "../streamlib-idents" }
+streamlib-idents = { path = "../streamlib-idents", version = "0.4.30", registry = "gitea" }
 
 # Cargo-build orchestration helpers — `streamlib pack`'s auto-build branch
 # routes through this crate so the same logic is reused by
 # `streamlib-build-orchestrator` without dragging in the full CLI surface.
-streamlib-cargo-build = { path = "../streamlib-cargo-build" }
-streamlib-pack = { path = "../streamlib-pack" }
+streamlib-cargo-build = { path = "../streamlib-cargo-build", version = "0.4.30", registry = "gitea" }
+streamlib-pack = { path = "../streamlib-pack", version = "0.4.30", registry = "gitea" }
 
 # JTD-codegen pipeline (drives `streamlib generate`)
-streamlib-jtd-codegen = { path = "../streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 # CLI framework
 clap = { version = "4.5", features = ["derive"] }

--- a/libs/streamlib-consumer-rhi/Cargo.toml
+++ b/libs/streamlib-consumer-rhi/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-surface-client = { path = "../streamlib-surface-client" }
+streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.4.30", registry = "gitea" }
 vulkanalia.workspace = true
 libc.workspace = true
 

--- a/libs/streamlib-cross-rustc-fixture/Cargo.toml
+++ b/libs/streamlib-cross-rustc-fixture/Cargo.toml
@@ -33,7 +33,7 @@ name = "streamlib_cross_rustc_fixture"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
 # Engine substrate — runtime context, processor traits,
@@ -41,14 +41,14 @@ streamlib-jtd-codegen = { path = "../streamlib-jtd-codegen" }
 # the fixture
 # rebuilds the SDK against THIS workspace's resolver pass, not the
 # host workspace's. Same source, different transitive resolution.
-streamlib = { path = "../streamlib-sdk" }
+streamlib = { path = "../streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 # Procedural macros — `#[streamlib::sdk::processor("...")]`.
-streamlib-macros = { path = "../streamlib-macros" }
+streamlib-macros = { path = "../streamlib-macros", version = "0.4.30", registry = "gitea" }
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol
 # the runtime dlopens at load time.
-streamlib-plugin-abi = { path = "../streamlib-plugin-abi" }
+streamlib-plugin-abi = { path = "../streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 # Serialization for the config dataclass + diagnostic tracing. Pinned
 # to specific OLDER patches than what the host workspace resolves

--- a/libs/streamlib-deno-native/Cargo.toml
+++ b/libs/streamlib-deno-native/Cargo.toml
@@ -14,7 +14,7 @@ description = "FFI cdylib for Deno subprocess processors to access iceoryx2 dire
 crate-type = ["cdylib"]
 
 [dependencies]
-streamlib-ipc-types = { path = "../streamlib-ipc-types" }
+streamlib-ipc-types = { path = "../streamlib-ipc-types", version = "0.4.30", registry = "gitea" }
 iceoryx2 = "0.8.1"
 libc.workspace = true
 rmp-serde = "1.3"
@@ -31,32 +31,32 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-surface-client = { path = "../streamlib-surface-client" }
+streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.4.30", registry = "gitea" }
 # Subprocess-side OpenGl runtime (#530). Reuses the host adapter crate's
 # EglRuntime + OpenGlSurfaceAdapter so subprocess code never re-derives EGL
 # bring-up or DMA-BUF → GL_TEXTURE_2D import.
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
-streamlib-adapter-opengl = { path = "../streamlib-adapter-opengl" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-opengl = { path = "../streamlib-adapter-opengl", version = "0.4.30", registry = "gitea" }
 # Subprocess-side Vulkan runtime (#531). Same shape as streamlib-python-native
 # — wraps the host `VulkanSurfaceAdapter` against a subprocess-local
 # `ConsumerVulkanDevice` so subprocess code never re-implements
 # layout-transition / timeline-wait / queue-mutex semantics.
-streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan" }
+streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan", version = "0.4.30", registry = "gitea" }
 # Consumer-side RHI carve-out — see streamlib-python-native/Cargo.toml
 # for the type-system-boundary rationale.
-streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.4.30", registry = "gitea" }
 # Subprocess-side cpu-readback runtime (#562). Same shape as the python
 # native — adapter generic over device flavor, instantiated here
 # against ConsumerVulkanDevice. Per-acquire `vkCmdCopyImageToBuffer`
 # runs host-side, triggered via the `run_cpu_readback_copy` escalate
 # IPC; the consumer waits on the imported timeline through the carve-out.
-streamlib-adapter-cpu-readback = { path = "../streamlib-adapter-cpu-readback" }
+streamlib-adapter-cpu-readback = { path = "../streamlib-adapter-cpu-readback", version = "0.4.30", registry = "gitea" }
 # Subprocess-side CUDA runtime (#590). Mirrors the Python sibling
 # (#589) — generic-over-device adapter, instantiated here against
 # `ConsumerVulkanDevice`, OPAQUE_FD VkBuffer + timeline imported into
 # CUDA via `cudaImportExternalMemory` / `cudaImportExternalSemaphore`,
 # DLPack capsule emitted across the FFI boundary.
-streamlib-adapter-cuda = { path = "../streamlib-adapter-cuda" }
+streamlib-adapter-cuda = { path = "../streamlib-adapter-cuda", version = "0.4.30", registry = "gitea" }
 # CUDA bindings — see streamlib-python-native/Cargo.toml for the
 # `fallback-dynamic-loading` rationale. Same workspace pin so the two
 # cdylibs stay lockstep on CUDA ABI.

--- a/libs/streamlib-engine/Cargo.toml
+++ b/libs/streamlib-engine/Cargo.toml
@@ -38,24 +38,24 @@ clear_bitstream_buffers_on_create = []
 
 [dependencies]
 # Processor schema types (shared with macros for code generation)
-streamlib-processor-schema = { path = "../streamlib-processor-schema" }
+streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.4.30", registry = "gitea" }
 
 # Schema identity + manifest types (one source of truth for the
 # structured `dependencies:` shape consumed at runtime).
-streamlib-idents = { path = "../streamlib-idents" }
+streamlib-idents = { path = "../streamlib-idents", version = "0.4.30", registry = "gitea" }
 
 # Procedural macros
-streamlib-macros = { path = "../streamlib-macros" }
+streamlib-macros = { path = "../streamlib-macros", version = "0.4.30", registry = "gitea" }
 
 # Plugin ABI wire-protocol header. Dep direction reversed in #877:
 # streamlib-plugin-abi no longer depends on streamlib (the SDK), so the
 # cyclic dep this dep used to dodge (engine → plugin-abi → sdk → engine)
 # is gone. The engine's dlopen loader uses `PluginDeclaration` and
 # `STREAMLIB_ABI_VERSION` from this crate directly.
-streamlib-plugin-abi = { path = "../streamlib-plugin-abi" }
+streamlib-plugin-abi = { path = "../streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 # Shared iceoryx2 payload types (for cross-process IPC)
-streamlib-ipc-types = { path = "../streamlib-ipc-types" }
+streamlib-ipc-types = { path = "../streamlib-ipc-types", version = "0.4.30", registry = "gitea" }
 
 # Consumer-side carve-out — owns the format primitives
 # (TextureFormat / TextureUsages / PixelFormat), the trait machinery
@@ -63,7 +63,7 @@ streamlib-ipc-types = { path = "../streamlib-ipc-types" }
 # Consumer* RHI types (Linux), and a slim ConsumerRhiError. streamlib
 # re-exports the primitives so existing in-tree call sites (e.g.
 # `crate::core::rhi::TextureFormat`) keep working unchanged.
-streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.4.30", registry = "gitea" }
 
 # Core dependencies (always included)
 thiserror.workspace = true
@@ -145,17 +145,17 @@ raw-window-handle = "0.6"  # Raw window handle types for Vulkan surface creation
 # privileged syscall on the requesting thread's behalf.
 zbus = "5"
 # Wire-format helpers for the per-runtime surface-sharing socket
-streamlib-surface-client = { path = "../streamlib-surface-client" }
+streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.4.30", registry = "gitea" }
 # Surface adapter ABI types referenced by the host-side CpuReadbackBridge
 # trait (linux-only; the cpu-readback adapter is linux-only).
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
 # Consumer-side carve-out — defines the trait machinery
 # (VulkanRhiDevice, DevicePrivilege, *Like, ConsumerMarker), the
 # Consumer* RHI types, and the format/error primitives shared with the
 # host side. streamlib re-exports for in-tree consumers; subprocess
 # cdylibs depend on it directly so the FullAccess capability boundary
 # is enforced by the type system.
-streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.4.30", registry = "gitea" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"
@@ -196,7 +196,7 @@ path = "tests/bin/surface_share_crash_helper.rs"
 required-features = []
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 # Build dependencies for protobuf compilation (surface-share service gRPC)
 [target.'cfg(target_os = "macos")'.build-dependencies]

--- a/libs/streamlib-jtd-codegen/Cargo.toml
+++ b/libs/streamlib-jtd-codegen/Cargo.toml
@@ -22,7 +22,7 @@ serde_yaml = { workspace = true }
 
 # Resolver + manifest types (the codegen pipeline ingests resolved package
 # sets produced by the streamlib-yaml resolver — Decision 7 of milestone 10).
-streamlib-idents = { path = "../streamlib-idents" }
+streamlib-idents = { path = "../streamlib-idents", version = "0.4.30", registry = "gitea" }
 
 # Logging — library crates emit through tracing per docs/logging.md;
 # binary callers (xtask, streamlib-cli) initialize a subscriber.

--- a/libs/streamlib-macros/Cargo.toml
+++ b/libs/streamlib-macros/Cargo.toml
@@ -19,11 +19,11 @@ serde = { workspace = true }
 serde_yaml = { workspace = true }
 
 # Execution types (shared with streamlib for code generation)
-streamlib-processor-schema = { path = "../streamlib-processor-schema" }
+streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.4.30", registry = "gitea" }
 # Manifest resolver — used to walk the enclosing manifest's `schemas:` map
 # and resolve bare-name `PortSchemaSpec::Named` references to fully-
 # qualified `SchemaIdent`s at proc-macro expansion time (#767).
-streamlib-idents = { path = "../streamlib-idents" }
+streamlib-idents = { path = "../streamlib-idents", version = "0.4.30", registry = "gitea" }
 
 
 [dev-dependencies]

--- a/libs/streamlib-pack/Cargo.toml
+++ b/libs/streamlib-pack/Cargo.toml
@@ -15,9 +15,9 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 serde_yaml = { workspace = true }
 zip = "2.2"
-streamlib-cargo-build = { path = "../streamlib-cargo-build" }
-streamlib-processor-schema = { path = "../streamlib-processor-schema" }
-streamlib-idents = { path = "../streamlib-idents" }
+streamlib-cargo-build = { path = "../streamlib-cargo-build", version = "0.4.30", registry = "gitea" }
+streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.4.30", registry = "gitea" }
+streamlib-idents = { path = "../streamlib-idents", version = "0.4.30", registry = "gitea" }
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/libs/streamlib-processor-schema/Cargo.toml
+++ b/libs/streamlib-processor-schema/Cargo.toml
@@ -15,7 +15,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }  # used by schemars for enum_values literals
 serde_yaml = { workspace = true }
 sha2 = { workspace = true }
-streamlib-idents = { path = "../streamlib-idents" }
+streamlib-idents = { path = "../streamlib-idents", version = "0.4.30", registry = "gitea" }
 thiserror = { workspace = true }
 schemars = "0.8"  # JSON Schema generation for streamlib.yaml editor support
 

--- a/libs/streamlib-python-native/Cargo.toml
+++ b/libs/streamlib-python-native/Cargo.toml
@@ -15,7 +15,7 @@ name = "streamlib_python_native"
 crate-type = ["cdylib"]
 
 [dependencies]
-streamlib-ipc-types = { path = "../streamlib-ipc-types" }
+streamlib-ipc-types = { path = "../streamlib-ipc-types", version = "0.4.30", registry = "gitea" }
 iceoryx2 = "0.8.1"
 libc.workspace = true
 rmp-serde = "1.3"
@@ -32,12 +32,12 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-surface-client = { path = "../streamlib-surface-client" }
+streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.4.30", registry = "gitea" }
 # Subprocess-side OpenGl runtime (#530). Reuses the host adapter crate's
 # EglRuntime + OpenGlSurfaceAdapter so subprocess code never re-derives EGL
 # bring-up or DMA-BUF → GL_TEXTURE_2D import.
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
-streamlib-adapter-opengl = { path = "../streamlib-adapter-opengl" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-opengl = { path = "../streamlib-adapter-opengl", version = "0.4.30", registry = "gitea" }
 # Subprocess-side Vulkan runtime (#531). Reuses the host adapter crate's
 # `VulkanSurfaceAdapter` against a subprocess-local `ConsumerVulkanDevice`
 # from the consumer RHI carve-out: same timeline-wait, same layout-transition,
@@ -45,13 +45,13 @@ streamlib-adapter-opengl = { path = "../streamlib-adapter-opengl" }
 # not apply because this VkDevice is created before any other in-process
 # Vulkan device has active GPU work — see
 # `docs/learnings/nvidia-dual-vulkan-device-crash.md`.
-streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan" }
+streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan", version = "0.4.30", registry = "gitea" }
 # Consumer-side RHI carve-out — `ConsumerVulkanDevice`,
 # `ConsumerVulkanTexture`, the `VulkanRhiDevice` trait, etc. The cdylib
 # does NOT depend on `streamlib` (full crate); the FullAccess capability
 # boundary is type-system enforced by what `streamlib-consumer-rhi`
 # exposes vs. what it doesn't.
-streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.4.30", registry = "gitea" }
 # Subprocess-side cpu-readback runtime (#562). Same shape as
 # adapter-vulkan / adapter-opengl: the adapter is generic over device
 # flavor, and this cdylib instantiates it against the consumer-side
@@ -59,7 +59,7 @@ streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
 # Per-acquire `vkCmdCopyImageToBuffer` runs host-side and is triggered
 # via a thin `run_cpu_readback_copy` escalate IPC; the consumer waits
 # on the imported timeline through the carve-out.
-streamlib-adapter-cpu-readback = { path = "../streamlib-adapter-cpu-readback" }
+streamlib-adapter-cpu-readback = { path = "../streamlib-adapter-cpu-readback", version = "0.4.30", registry = "gitea" }
 # Subprocess-side CUDA runtime (#589). Same single-pattern shape as the
 # other adapters: generic over `D: VulkanRhiDevice`, instantiated here
 # against `ConsumerVulkanDevice`. The cdylib re-imports the OPAQUE_FD
@@ -67,7 +67,7 @@ streamlib-adapter-cpu-readback = { path = "../streamlib-adapter-cpu-readback" }
 # `cudaImportExternalSemaphore` and hands DLPack capsules back to
 # Python. No per-acquire IPC; the host's pipeline writes into the
 # OPAQUE_FD `VkBuffer` and signals the shared timeline ambiently.
-streamlib-adapter-cuda = { path = "../streamlib-adapter-cuda" }
+streamlib-adapter-cuda = { path = "../streamlib-adapter-cuda", version = "0.4.30", registry = "gitea" }
 # CUDA bindings. Linux-only (the cuda module is `#[cfg(target_os =
 # "linux")]`), `fallback-dynamic-loading` means libcuda.so is dlopen'd
 # at runtime so a build host without a CUDA toolkit can still link the

--- a/libs/streamlib-runtime/Cargo.toml
+++ b/libs/streamlib-runtime/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 # Engine + SDK. The API server (and every other processor) is loaded at
 # runtime through the all-dynamic module loader, not linked here.
-streamlib = { path = "../streamlib-sdk" }
+streamlib = { path = "../streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 # CLI argument parsing
 clap = { version = "4.5", features = ["derive"] }

--- a/libs/streamlib-sdk/Cargo.toml
+++ b/libs/streamlib-sdk/Cargo.toml
@@ -34,5 +34,5 @@ strip_debug_logging = ["streamlib-engine/strip_debug_logging"]
 hardware-tests = ["streamlib-engine/hardware-tests"]
 
 [dependencies]
-streamlib-engine = { path = "../streamlib-engine" }
-streamlib-build-orchestrator = { path = "../streamlib-build-orchestrator", optional = true }
+streamlib-engine = { path = "../streamlib-engine", version = "0.4.30", registry = "gitea" }
+streamlib-build-orchestrator = { path = "../streamlib-build-orchestrator", version = "0.4.30", registry = "gitea", optional = true }

--- a/libs/vulkan-jpeg/Cargo.toml
+++ b/libs/vulkan-jpeg/Cargo.toml
@@ -13,7 +13,7 @@ tracing = { workspace = true }
 bytemuck = { version = "1.16", features = ["derive"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib = { path = "../streamlib-sdk" }
+streamlib = { path = "../streamlib-sdk", version = "0.4.30", registry = "gitea" }
 # Dynamic loading for libnvjpeg.so.12. nvJPEG is NVIDIA-only and not
 # always installed; resolving at runtime keeps the workspace building
 # cleanly on hosts without the CUDA Toolkit. See

--- a/packages/api-server/Cargo.toml
+++ b/packages/api-server/Cargo.toml
@@ -22,13 +22,13 @@ default = []
 moq = ["dep:streamlib-moq"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-macros = { path = "../../libs/streamlib-macros" }
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
-streamlib-moq = { path = "../moq", optional = true }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
+streamlib-moq = { path = "../moq", version = "0.4.30", registry = "gitea", optional = true }
 
 axum.workspace = true
 tower-http = { version = "0.6", features = ["trace"] }

--- a/packages/audio/Cargo.toml
+++ b/packages/audio/Cargo.toml
@@ -14,21 +14,21 @@ name = "streamlib_audio"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
 # Engine substrate — runtime context, processor traits, generated config
 # types under `crate::_generated_::tatolab__audio::*`, AudioFrame
 # wire type, audio utilities (resample, channel/format conversion).
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 # Procedural macros — `#[streamlib::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 # Cross-platform deps used by every audio processor.
 parking_lot = "0.12"

--- a/packages/camera/Cargo.toml
+++ b/packages/camera/Cargo.toml
@@ -14,21 +14,21 @@ name = "streamlib_camera"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
 # Engine substrate — runtime context, processor traits, generated config
 # types under `crate::_generated_::tatolab__camera::*`, VideoFrame
 # wire type, RHI primitives.
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 # Cross-platform deps used by the camera processor.
 parking_lot = "0.12"
@@ -51,17 +51,17 @@ libc.workspace = true
 # anything else from consumer-rhi (no `ConsumerVulkanDevice`, no imports);
 # this is the typed-layout interop type shared between the host RHI's
 # `RhiCommandRecorder` and the cross-process surface-share schema.
-streamlib-consumer-rhi = { path = "../../libs/streamlib-consumer-rhi" }
+streamlib-consumer-rhi = { path = "../../libs/streamlib-consumer-rhi", version = "0.4.30", registry = "gitea" }
 # CUDA host-side surface adapter — the `CameraToCudaCopy` processor
 # allocates a DEVICE_LOCAL OPAQUE_FD VkBuffer + exportable timeline
 # and runs the host-side `vkCmdCopyImageToBuffer` per frame for
 # cross-API CUDA interop. The adapter crate itself stays cudarc-free
 # (`cudarc` integration happens in the cdylib consumer); this dep
 # does NOT pull `libcuda.so` into the camera package's link surface.
-streamlib-adapter-cuda = { path = "../../libs/streamlib-adapter-cuda" }
+streamlib-adapter-cuda = { path = "../../libs/streamlib-adapter-cuda", version = "0.4.30", registry = "gitea" }
 # Adapter ABI — provides `SurfaceId` and `AdapterError` types the
 # CUDA adapter surface uses in its public API.
-streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
+streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 # Objective-C interop and Apple framework bindings.

--- a/packages/clap/Cargo.toml
+++ b/packages/clap/Cargo.toml
@@ -14,25 +14,25 @@ name = "streamlib_clap"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
 # Engine substrate — runtime context, processor traits, generated wire
 # types under `crate::_generated_::*` (AudioFrame).
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 # Audio domain package — owns `ProcessorAudioConverter` + `AudioResampler`
 # (carved out of the engine in #734). Consumers that need channel /
 # sample-rate / rechunk conversion reach for them here.
-streamlib-audio = { path = "../audio" }
+streamlib-audio = { path = "../audio", version = "0.4.30", registry = "gitea" }
 
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -13,7 +13,7 @@ name = "streamlib_core_schema_tests"
 path = "src/lib.rs"
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
 serde.workspace = true

--- a/packages/debug-utilities/Cargo.toml
+++ b/packages/debug-utilities/Cargo.toml
@@ -14,21 +14,21 @@ name = "streamlib_debug_utilities"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
 # Engine substrate — runtime context, processor traits, generated config
 # types under `crate::_generated_::tatolab__debug_utilities::*`, the
 # VideoFrame wire type, RHI primitives.
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/display/Cargo.toml
+++ b/packages/display/Cargo.toml
@@ -14,7 +14,7 @@ name = "streamlib_display"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
 # Engine substrate — runtime context, processor traits, generated config
@@ -22,15 +22,15 @@ streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 # wire type, host RHI types (HostVulkanDevice, VulkanGraphicsKernel,
 # VulkanPresentTarget, RhiCommandRecorder, OffscreenColorTarget,
 # TextureFormat).
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 tracing.workspace = true
 serde.workspace = true
@@ -45,7 +45,7 @@ raw-window-handle = "0.6"
 # Consumer-side RHI carve-out — typed `VulkanLayout` enum used in
 # producer/consumer surface-share interop. Camera uses the same dep
 # for the same reason.
-streamlib-consumer-rhi = { path = "../../libs/streamlib-consumer-rhi" }
+streamlib-consumer-rhi = { path = "../../libs/streamlib-consumer-rhi", version = "0.4.30", registry = "gitea" }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 # Apple module is ported into this package but DISABLED in `lib.rs` —

--- a/packages/h264/Cargo.toml
+++ b/packages/h264/Cargo.toml
@@ -14,21 +14,21 @@ name = "streamlib_h264"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
 # Engine substrate — runtime context, processor traits, generated config
 # types under `crate::_generated_::tatolab__h264::*`, EncodedVideoFrame /
 # VideoFrame wire types, host RHI bridge for queue handles + allocator.
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/h265/Cargo.toml
+++ b/packages/h265/Cargo.toml
@@ -14,21 +14,21 @@ name = "streamlib_h265"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
 # Engine substrate — runtime context, processor traits, generated config
 # types under `crate::_generated_::tatolab__h265::*`, EncodedVideoFrame /
 # VideoFrame wire types, host RHI bridge for queue handles + allocator.
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/jpeg/Cargo.toml
+++ b/packages/jpeg/Cargo.toml
@@ -14,21 +14,21 @@ name = "streamlib_jpeg"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
 # Engine substrate — runtime context, processor traits, generated config
 # types under `crate::_generated_::tatolab__jpeg::*`, VideoFrame wire
 # type, RHI texture / color primitives.
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true
@@ -43,7 +43,7 @@ tracing.workspace = true
 [target.'cfg(target_os = "linux")'.dependencies]
 # GPU JPEG decode primitive — fused Vulkan compute kernel + optional
 # nvJPEG fast path behind SimpleJpegDecoder. Owns its own texture ring.
-vulkan-jpeg = { path = "../../libs/vulkan-jpeg" }
+vulkan-jpeg = { path = "../../libs/vulkan-jpeg", version = "0.4.30", registry = "gitea" }
 
 [dev-dependencies]
 # Wire-shape regression test serializes generated `EncodedJpegFrame` through

--- a/packages/mavlink/Cargo.toml
+++ b/packages/mavlink/Cargo.toml
@@ -14,21 +14,21 @@ name = "streamlib_mavlink"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
 # Engine substrate — runtime context, processor traits, generated wire
 # types under `crate::_generated_::*` (NetworkPacket imported from
 # @tatolab/network; MavlinkMessage + Config types defined locally).
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/moq/Cargo.toml
+++ b/packages/moq/Cargo.toml
@@ -14,12 +14,12 @@ name = "streamlib_moq"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-macros = { path = "../../libs/streamlib-macros" }
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 serde.workspace = true
 # Generated `EncodedVideoFrame.data` rides msgpack `bin` instead of array.

--- a/packages/mp4/Cargo.toml
+++ b/packages/mp4/Cargo.toml
@@ -14,12 +14,12 @@ name = "streamlib_mp4"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-macros = { path = "../../libs/streamlib-macros" }
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 serde.workspace = true
 tracing.workspace = true

--- a/packages/network/Cargo.toml
+++ b/packages/network/Cargo.toml
@@ -14,20 +14,20 @@ name = "streamlib_network"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
 # Engine substrate — runtime context, processor traits, generated config
 # types under `crate::_generated_::*`.
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/opus/Cargo.toml
+++ b/packages/opus/Cargo.toml
@@ -14,21 +14,21 @@ name = "streamlib_opus"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
 # Engine substrate — runtime context, processor traits, generated wire
 # types under `crate::_generated_::*` (AudioFrame,
 # EncodedAudioFrame from `@tatolab/core`), error/result types.
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/screen-capture/Cargo.toml
+++ b/packages/screen-capture/Cargo.toml
@@ -14,20 +14,20 @@ name = "streamlib_screen_capture"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
 # Engine substrate — runtime context, processor traits, generated wire
 # types under `crate::_generated_::*` (VideoFrame), RHI primitives.
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/test-fixtures-abi-mismatch/Cargo.toml
+++ b/packages/test-fixtures-abi-mismatch/Cargo.toml
@@ -26,7 +26,7 @@ tamper-too-low = []
 tamper-too-high = []
 
 [dependencies]
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 [lints]
 workspace = true

--- a/packages/test-fixtures/Cargo.toml
+++ b/packages/test-fixtures/Cargo.toml
@@ -14,20 +14,20 @@ name = "streamlib_test_fixtures"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
 # Engine substrate — runtime context, processor traits, generated config
 # types under `crate::_generated_::tatolab__test_fixtures::*`.
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 # Serialization (config dataclass ships as serde-derived).
 serde.workspace = true
@@ -45,11 +45,11 @@ tokio = { workspace = true, features = ["rt", "net", "macros"] }
 # and the v10 `host_vulkan_texture_arc` bridge plus the existing
 # `acquire_render_target_dma_buf_image` slot).
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
-streamlib-adapter-cpu-readback = { path = "../../libs/streamlib-adapter-cpu-readback" }
-streamlib-adapter-cuda = { path = "../../libs/streamlib-adapter-cuda" }
-streamlib-adapter-opengl = { path = "../../libs/streamlib-adapter-opengl" }
-streamlib-adapter-vulkan = { path = "../../libs/streamlib-adapter-vulkan" }
+streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-cpu-readback = { path = "../../libs/streamlib-adapter-cpu-readback", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-cuda = { path = "../../libs/streamlib-adapter-cuda", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-opengl = { path = "../../libs/streamlib-adapter-opengl", version = "0.4.30", registry = "gitea" }
+streamlib-adapter-vulkan = { path = "../../libs/streamlib-adapter-vulkan", version = "0.4.30", registry = "gitea" }
 
 [lints]
 workspace = true

--- a/packages/vadr-vision/Cargo.toml
+++ b/packages/vadr-vision/Cargo.toml
@@ -14,22 +14,22 @@ name = "streamlib_vadr_vision"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
 # Engine substrate — runtime context, processor traits, generated wire
 # types under `crate::_generated_::*` (NetworkPacket imported from
 # @tatolab/network; EncodedJpegFrame imported from @tatolab/jpeg;
 # VadrVisionDepayloaderConfig defined locally).
-streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
 
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/webrtc/Cargo.toml
+++ b/packages/webrtc/Cargo.toml
@@ -14,12 +14,12 @@ name = "streamlib_webrtc"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-macros = { path = "../../libs/streamlib-macros" }
-streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib-macros = { path = "../../libs/streamlib-macros", version = "0.4.30", registry = "gitea" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
 
 serde.workspace = true
 # Generated `EncodedVideoFrame.data` / `EncodedAudioFrame.data` ride msgpack

--- a/scripts/gitea/README.md
+++ b/scripts/gitea/README.md
@@ -1,0 +1,106 @@
+# Gitea registry tooling
+
+Scripts for the unified self-hosted **Gitea** registry that distributes every
+StreamLib-authored / -customized artifact under the **`tatolab`** org. The
+committed scripts are **generic, configure-by-env** so the same tooling drives
+a local dev container and a hosted backend. Architecture:
+[`docs/architecture/gitea-registry-distribution.md`](../../docs/architecture/gitea-registry-distribution.md).
+
+| Script | What it does | When |
+|---|---|---|
+| `provision-registry.sh` | Ensure the admin owner + `GITEA_ORG` exist; verify cargo/pypi/npm/generic are reachable. | One-time / idempotent. |
+| `smoke-test-registry.sh` | Publish→resolve→remove a throwaway crate + a generic round-trip. | Verify a live registry. |
+| `publish-vulkanalia.sh` | Publish the `tatolab/vulkanalia` fork (`-sys`, `vulkanalia`, `-vma`) to the cargo registry. | One-time bootstrap (fork rarely changes). |
+| `publish-crates.sh [--dev N]` | Publish the `streamlib` SDK crate closure by version, in topo order. | The recurring dev-loop publish. |
+| `migrate-internal-deps.py` | Idempotent tomlkit sweep that put internal deps in the `{ path, version, registry }` form. | One-shot migration (kept for re-derivation / drift check). |
+
+The Python helpers need **tomlkit** (`pip install tomlkit`, or run with
+`PYTHON=/path/to/venv/bin/python`).
+
+## Config & secrets
+
+- The repo's [`.cargo/config.toml`](../../.cargo/config.toml) declares
+  `[registries.gitea]` with the **sparse** index URL. Read is anonymous; only
+  publishing needs a token. Override the URL for a hosted backend with
+  `CARGO_REGISTRIES_GITEA_INDEX`.
+- **Secrets never live in committed scripts.** Access topology (admin user,
+  port, token) goes in a gitignored `scripts/gitea/*.local.sh` wrapper that
+  exports env and `exec`s the generic script — see
+  `provision-registry.local.sh` for the pattern.
+
+### Minting a publish token
+
+Any token with `write:package` scope works. For the local dev container:
+
+```bash
+docker exec -u git streamlib-registry \
+  gitea admin user generate-access-token \
+  --username tatolab-admin --scopes write:package --token-name publish
+```
+
+cargo requires the token stored as **`Bearer <token>`** (a bare `cargo login`
+value → 401). Provide it via env:
+
+```bash
+export CARGO_REGISTRIES_GITEA_TOKEN="Bearer <token>"
+```
+
+## Publishing
+
+```bash
+# one-time: publish the vulkanalia fork first (needs the fork checked out at
+# VULKANALIA_DIR, default ~/Repositories/tatolab/vulkanalia)
+CARGO_REGISTRIES_GITEA_TOKEN="Bearer <token>" scripts/gitea/publish-vulkanalia.sh
+
+# then publish the streamlib SDK closure at the base [workspace.package].version
+CARGO_REGISTRIES_GITEA_TOKEN="Bearer <token>" scripts/gitea/publish-crates.sh
+
+# dev loop: publish 0.4.x-dev.N so a consumer can bump to it without a path dep
+CARGO_REGISTRIES_GITEA_TOKEN="Bearer <token>" scripts/gitea/publish-crates.sh --dev 3
+```
+
+`--no-verify` publishes source without compiling (the consumer verifies by
+building); both scripts treat an already-published version as success, so they
+are safe to re-run. The closure + topo order is derived live from
+`cargo metadata`. `publish-crates.sh` strips the dev `path:` patch from any
+bundled `streamlib.yaml` (today: `streamlib-engine` →`@tatolab/escalate`) and
+restores the tree afterward, so the published manifest is path-free and the
+consumer resolves schema deps from the registry.
+
+### Schema packages (`.slpkg`) for the full-engine codegen build
+
+A consumer compiling `streamlib-engine` runs its `build.rs` schema codegen,
+which resolves `@tatolab/escalate` from the **generic** registry. Publish the
+schema package(s) as source `.slpkg`s:
+
+```bash
+streamlib pack packages/escalate -o /tmp/escalate.slpkg
+curl -X PUT -H "Authorization: token <token>" --upload-file /tmp/escalate.slpkg \
+  http://localhost:3300/api/packages/tatolab/generic/escalate/1.0.0/escalate.slpkg
+```
+
+(Generalizing schema/processor `.slpkg` publishing across all `packages/*` is
+the source-only-`.slpkg` work tracked separately.)
+
+## Consuming from a separate repo
+
+```toml
+# consumer Cargo.toml
+[dependencies]
+streamlib = { version = "0.4.30", registry = "gitea" }
+```
+
+```toml
+# consumer .cargo/config.toml
+[registries.gitea]
+index = "sparse+http://localhost:3300/api/packages/tatolab/cargo/"
+```
+
+To compile the engine's schema codegen, the build needs the generic-registry
+URL + a read token in the environment:
+
+```bash
+STREAMLIB_REGISTRY_URL=http://localhost:3300 \
+STREAMLIB_REGISTRY_TOKEN=<token> \
+  cargo build
+```

--- a/scripts/gitea/README.md
+++ b/scripts/gitea/README.md
@@ -79,6 +79,12 @@ curl -X PUT -H "Authorization: token <token>" --upload-file /tmp/escalate.slpkg 
   http://localhost:3300/api/packages/tatolab/generic/escalate/1.0.0/escalate.slpkg
 ```
 
+Note the two distinct Gitea auth schemes: the **generic** registry (and the
+package-management API) takes `Authorization: token <token>`, whereas **cargo
+publish** requires the token stored as `Bearer <token>` (see above). Don't
+conflate them. Gitea's generic upload also needs a raw body (`--upload-file`,
+not `--data`).
+
 (Generalizing schema/processor `.slpkg` publishing across all `packages/*` is
 the source-only-`.slpkg` work tracked separately.)
 

--- a/scripts/gitea/migrate-internal-deps.py
+++ b/scripts/gitea/migrate-internal-deps.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Migrate internal cross-crate path deps to the canonical
+``{ path, version, registry = "gitea" }`` form — the standard cargo
+"publish a workspace" pattern (tokio et al.).
+
+What it does:
+
+* Targets ``[dependencies]``, ``[build-dependencies]`` and their
+  ``[target.<cfg>.dependencies]`` / ``[target.<cfg>.build-dependencies]``
+  variants in every member ``Cargo.toml``.
+* **Skips** ``[dev-dependencies]`` (and target dev-deps): cargo strips
+  bare-path dev-deps on publish, and annotating them creates publish-order
+  cycles — e.g. ``streamlib-engine`` dev-deps ``streamlib``.
+* ``version`` is read from each *target* crate's own ``[package].version``
+  (resolving ``version.workspace = true`` against the workspace root), so a
+  crate off the shared version (e.g. ``streamlib-cross-rustc-fixture`` at
+  ``0.1.0``) gets its real version, not a blanket stamp.
+* ``registry = "gitea"`` is required — without it cargo records the dep as
+  crates.io and ``cargo publish`` fails.
+* Inline tables are **rebuilt fresh** — appending keys in place corrupts the
+  ``,`` separators tomlkit tracks. Key order is ``package?, path, version,
+  registry, <rest>``.
+
+The ``path`` stays: it is a dev-only affordance cargo strips from the
+published manifest, so the monorepo keeps building in place (path wins
+locally) while consumers see only ``version`` + ``registry``.
+
+Idempotent. ``--check`` reports files that would change and exits non-zero if
+any do (CI drift guard). Needs ``tomlkit``.
+
+Usage:
+    python3 scripts/gitea/migrate-internal-deps.py [--check] [ROOT]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import tomlkit
+from tomlkit.items import InlineTable
+
+DEP_SECTIONS = ("dependencies", "build-dependencies")
+REGISTRY = "gitea"
+
+
+def workspace_root(start: Path) -> Path:
+    """Walk up from *start* to the dir whose Cargo.toml declares [workspace]."""
+    cur = start.resolve()
+    for cand in [cur, *cur.parents]:
+        manifest = cand / "Cargo.toml"
+        if manifest.is_file():
+            try:
+                doc = tomlkit.parse(manifest.read_text())
+            except Exception:
+                continue
+            if "workspace" in doc:
+                return cand
+    raise SystemExit(f"no workspace root found above {start}")
+
+
+def crate_version(manifest_dir: Path, ws_version: str, _cache: dict) -> str | None:
+    """[package].version of the crate at *manifest_dir*, resolving workspace inheritance."""
+    key = manifest_dir.resolve()
+    if key in _cache:
+        return _cache[key]
+    manifest = key / "Cargo.toml"
+    if not manifest.is_file():
+        _cache[key] = None
+        return None
+    pkg = tomlkit.parse(manifest.read_text()).get("package", {})
+    ver = pkg.get("version")
+    # version.workspace = true  →  inline table {"workspace": True}
+    if isinstance(ver, dict) and ver.get("workspace"):
+        resolved = ws_version
+    elif isinstance(ver, str):
+        resolved = ver
+    else:
+        resolved = None
+    _cache[key] = resolved
+    return resolved
+
+
+def _render_value(v) -> str:
+    """Serialize a single TOML value the way tomlkit would (quoted strings,
+    true/false, arrays) — used to assemble a padded inline-table fragment."""
+    doc = tomlkit.document()
+    doc["_"] = v
+    return tomlkit.dumps(doc).split("=", 1)[1].strip()
+
+
+def rebuild_dep(name: str, orig: InlineTable, version: str) -> InlineTable:
+    """Fresh inline table in canonical order: package?, path, version,
+    registry, <rest>. Built by parsing a padded fragment so the result
+    matches the repo's ``{ key = val }`` style instead of tomlkit's
+    unpadded programmatic default."""
+    pairs = []
+    if "package" in orig:
+        pairs.append(("package", orig["package"]))
+    pairs.append(("path", orig["path"]))
+    pairs.append(("version", version))
+    pairs.append(("registry", REGISTRY))
+    for k, v in orig.items():
+        if k in ("package", "path", "version", "registry"):
+            continue
+        pairs.append((k, v))
+    inner = ", ".join(f"{k} = {_render_value(v)}" for k, v in pairs)
+    return tomlkit.parse(f"dep = {{ {inner} }}")["dep"]
+
+
+def migrate_section(section, manifest_dir: Path, ws_version: str, vcache: dict) -> list[str]:
+    changed = []
+    for name in list(section.keys()):
+        dep = section[name]
+        if not isinstance(dep, (dict, InlineTable)):
+            continue
+        if "path" not in dep:
+            continue
+        target_dir = (manifest_dir / dep["path"]).resolve()
+        version = crate_version(target_dir, ws_version, vcache)
+        if version is None:
+            print(f"  WARN {name}: no version at {target_dir}, skipped", file=sys.stderr)
+            continue
+        if dep.get("version") == version and dep.get("registry") == REGISTRY:
+            continue  # already canonical
+        section[name] = rebuild_dep(name, dep, version)
+        changed.append(name)
+    return changed
+
+
+def iter_dep_sections(doc):
+    """Yield (section_table, label) for every non-dev dependency table."""
+    for sec in DEP_SECTIONS:
+        if sec in doc:
+            yield doc[sec], sec
+    target = doc.get("target")
+    if target:
+        for cfg, tbl in target.items():
+            for sec in DEP_SECTIONS:
+                if sec in tbl:
+                    yield tbl[sec], f"target.{cfg}.{sec}"
+
+
+def main() -> int:
+    args = [a for a in sys.argv[1:]]
+    check = "--check" in args
+    args = [a for a in args if a != "--check"]
+    root = Path(args[0]) if args else Path(__file__).resolve().parents[2]
+    root = workspace_root(root)
+    ws_version = tomlkit.parse((root / "Cargo.toml").read_text())["workspace"]["package"]["version"]
+    print(f"workspace root: {root}  (version {ws_version})")
+
+    vcache: dict = {}
+    dirty = []
+    for sub in ("libs", "packages", "examples"):
+        for manifest in sorted((root / sub).rglob("Cargo.toml")):
+            if "target" in manifest.parts:
+                continue
+            doc = tomlkit.parse(manifest.read_text())
+            changed = []
+            for section, _label in iter_dep_sections(doc):
+                changed += migrate_section(section, manifest.parent, ws_version, vcache)
+            if changed:
+                rel = manifest.relative_to(root)
+                dirty.append(rel)
+                print(f"  {rel}: {', '.join(sorted(set(changed)))}")
+                if not check:
+                    manifest.write_text(tomlkit.dumps(doc))
+
+    if check and dirty:
+        print(f"\n{len(dirty)} manifest(s) would change — run without --check", file=sys.stderr)
+        return 1
+    print(f"\n{'would migrate' if check else 'migrated'} {len(dirty)} manifest(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gitea/publish-crates.sh
+++ b/scripts/gitea/publish-crates.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Publish the `streamlib` SDK crate closure (the 14-crate chain `streamlib`
+# transitively needs) to the Gitea cargo registry by version, in dependency
+# (topological) order. This is the recurring dev-loop publish: a local engine
+# change becomes a published 0.4.x-dev.N version a consumer bumps to — never a
+# new path dep or [patch]. See docs/architecture/gitea-registry-distribution.md.
+#
+#   ./publish-crates.sh            # publish the base [workspace.package].version
+#   ./publish-crates.sh --dev 3    # publish <base>-dev.3 (workspace + dep reqs
+#                                  #   bumped in place, then restored)
+#
+# The closure + topo order is derived live from `cargo metadata`, so it stays
+# correct as the dependency graph shifts — nothing is hard-coded.
+#
+# Two in-place rewrites are applied before publish and restored after (the tree
+# is left exactly as found, clean or not):
+#   * --dev N bumps [workspace.package].version and every internal
+#     `version = "<base>"` dep requirement to "<base>-dev.N" (a plain "<base>"
+#     requirement is ^<base> and does NOT match a prerelease, so the reqs must
+#     move too).
+#   * streamlib-engine's streamlib.yaml carries a dev `path:` patch for
+#     @tatolab/escalate; `cargo publish` bundles streamlib.yaml verbatim, so we
+#     strip the path patch (xtask strip-publish-manifest) before publishing,
+#     leaving the consumer to resolve @tatolab/escalate from the registry.
+#
+# Configure-by-env (all optional except the token):
+#   GITEA_URL                     default http://localhost:3300
+#   GITEA_ORG                     default tatolab
+#   CARGO_REGISTRY                default gitea
+#   CARGO_REGISTRIES_GITEA_TOKEN  REQUIRED — must be "Bearer <token>"
+set -euo pipefail
+
+GITEA_URL="${GITEA_URL:-http://localhost:3300}"
+GITEA_ORG="${GITEA_ORG:-tatolab}"
+CARGO_REGISTRY="${CARGO_REGISTRY:-gitea}"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PY="${PYTHON:-python3}"
+
+DEV_N=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dev) DEV_N="${2:?--dev needs a number}"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+log()  { printf '[publish-crates] %s\n' "$*"; }
+fail() { printf '[publish-crates] ERROR: %s\n' "$*" >&2; exit 1; }
+
+[ -n "${CARGO_REGISTRIES_GITEA_TOKEN:-}" ] \
+  || fail "set CARGO_REGISTRIES_GITEA_TOKEN='Bearer <token>' to publish"
+upper="$(printf '%s' "$CARGO_REGISTRY" | tr '[:lower:]' '[:upper:]')"
+eval "export CARGO_REGISTRIES_${upper}_TOKEN='${CARGO_REGISTRIES_GITEA_TOKEN}'"
+
+cd "$ROOT"
+
+base_version="$("$PY" - <<'PY'
+import tomlkit
+print(tomlkit.parse(open("Cargo.toml").read())["workspace"]["package"]["version"])
+PY
+)"
+target_version="$base_version"
+[ -n "$DEV_N" ] && target_version="${base_version}-dev.${DEV_N}"
+
+# --- derive the streamlib closure in topological order -----------------------
+mapfile -t ORDER < <("$PY" - <<'PY'
+import json, subprocess
+md = json.loads(subprocess.check_output(["cargo","metadata","--format-version","1"]))
+pkgs = {p["id"]: p for p in md["packages"]}
+members = set(md["workspace_members"])
+resolve = {n["id"]: n for n in md["resolve"]["nodes"]}
+name = lambda i: pkgs[i]["name"]
+sdk = next(i for i in members if name(i) == "streamlib")
+internal = lambda i: i in members and (name(i).startswith("streamlib") or name(i) == "vulkan-jpeg")
+def deps(i):
+    out = []
+    for d in resolve[i]["deps"]:
+        if {k["kind"] for k in d["dep_kinds"]} & {None, "build"}:
+            out.append(d["pkg"])
+    return out
+seen, order = set(), []
+def visit(i):
+    if i in seen: return
+    seen.add(i)
+    for d in deps(i):
+        if internal(d): visit(d)
+    if internal(i): order.append(name(i))
+visit(sdk)
+print("\n".join(order))
+PY
+)
+[ "${#ORDER[@]}" -gt 0 ] || fail "could not derive the streamlib closure"
+log "closure (${#ORDER[@]} crates): ${ORDER[*]}"
+log "publishing version: $target_version"
+
+# --- back up every file we rewrite, restore on exit --------------------------
+backup_dir="$(mktemp -d)"
+declare -a TOUCHED=()
+trap 'for f in "${TOUCHED[@]}"; do cp -p "$backup_dir/$(echo "$f" | tr / _)" "$f"; done; rm -rf "$backup_dir"' EXIT
+snapshot() {  # snapshot a file so the EXIT trap restores it verbatim
+  local f="$1"
+  cp -p "$f" "$backup_dir/$(echo "$f" | tr / _)"
+  TOUCHED+=("$f")
+}
+
+# --- optional dev-version bump (workspace version + internal dep reqs) --------
+if [ -n "$DEV_N" ]; then
+  log "bumping in place: $base_version -> $target_version (restored on exit)"
+  # collect member manifests + root, snapshot, then rewrite with tomlkit
+  while IFS= read -r m; do snapshot "$m"; done < <(
+    { echo Cargo.toml; find libs packages -name Cargo.toml -not -path '*/target/*'; }
+  )
+  BASE="$base_version" TARGET="$target_version" "$PY" - <<'PY'
+import os, glob, tomlkit
+base, target = os.environ["BASE"], os.environ["TARGET"]
+def bump_workspace():
+    doc = tomlkit.parse(open("Cargo.toml").read())
+    doc["workspace"]["package"]["version"] = target
+    open("Cargo.toml", "w").write(tomlkit.dumps(doc))
+def bump_member(path):
+    doc = tomlkit.parse(open(path).read())
+    changed = False
+    for sec in ("dependencies", "build-dependencies"):
+        tbl = doc.get(sec, {})
+        for name in list(tbl.keys()):
+            dep = tbl[name]
+            if isinstance(dep, dict) and dep.get("version") == base and "path" in dep:
+                dep["version"] = target
+                changed = True
+    if changed:
+        open(path, "w").write(tomlkit.dumps(doc))
+bump_workspace()
+for m in glob.glob("libs/**/Cargo.toml", recursive=True) + glob.glob("packages/**/Cargo.toml", recursive=True):
+    if "/target/" in m: continue
+    bump_member(m)
+print("bumped")
+PY
+fi
+
+# --- strip dev path patches from any bundled streamlib.yaml in the closure ----
+for crate in "${ORDER[@]}"; do
+  dir="libs/$crate"
+  [ "$crate" = "streamlib" ] && dir="libs/streamlib-sdk"
+  yaml="$dir/streamlib.yaml"
+  if [ -f "$yaml" ] && grep -q '^patch:' "$yaml"; then
+    log "stripping path patches from $yaml (restored on exit)"
+    snapshot "$yaml"
+    cargo run -q -p xtask -- strip-publish-manifest --dir "$dir" >/dev/null 2>&1 \
+      || fail "strip-publish-manifest failed for $dir"
+  fi
+done
+
+# --- publish in topological order --------------------------------------------
+idx_path() {
+  local n="$1"
+  case ${#n} in
+    1) printf '1/%s' "$n" ;; 2) printf '2/%s' "$n" ;;
+    3) printf '3/%s/%s' "${n:0:1}" "$n" ;;
+    *) printf '%s/%s/%s' "${n:0:2}" "${n:2:2}" "$n" ;;
+  esac
+}
+wait_for_index() {
+  local crate="$1" version="$2" i
+  for i in $(seq 1 30); do
+    curl -fsS "${GITEA_URL}/api/packages/${GITEA_ORG}/cargo/$(idx_path "$crate")" 2>/dev/null \
+      | grep -q "\"vers\":\"${version}\"" && return 0
+    sleep 1
+  done
+  log "WARN: ${crate}@${version} not visible in index after 30s (continuing)"
+}
+for crate in "${ORDER[@]}"; do
+  log "publishing ${crate}@${target_version}"
+  # --allow-dirty: the strip / --dev rewrites mutate the tree on purpose
+  # (restored by the EXIT trap); publishing source with those edits is intended.
+  if out="$(cargo publish --no-verify --allow-dirty --registry "$CARGO_REGISTRY" -p "$crate" 2>&1)"; then
+    log "  ✓ ${crate} published"
+  elif printf '%s' "$out" | grep -qiE 'already exists|already uploaded|is already'; then
+    log "  • ${crate}@${target_version} already present — skipping"
+  else
+    printf '%s\n' "$out" >&2
+    fail "publish of ${crate} failed"
+  fi
+  wait_for_index "$crate" "$target_version"
+done
+
+log "done — streamlib closure @ ${target_version} published to ${GITEA_ORG} on ${GITEA_URL}"

--- a/scripts/gitea/publish-crates.sh
+++ b/scripts/gitea/publish-crates.sh
@@ -96,10 +96,13 @@ log "publishing version: $target_version"
 # --- back up every file we rewrite, restore on exit --------------------------
 backup_dir="$(mktemp -d)"
 declare -a TOUCHED=()
-trap 'for f in "${TOUCHED[@]}"; do cp -p "$backup_dir/$(echo "$f" | tr / _)" "$f"; done; rm -rf "$backup_dir"' EXIT
-snapshot() {  # snapshot a file so the EXIT trap restores it verbatim
+# Restore verbatim on exit. Backups mirror the relative path under $backup_dir
+# (not a flattened key) so no two snapshotted paths can ever collide.
+trap 'for f in "${TOUCHED[@]}"; do cp -p "$backup_dir/$f" "$f"; done; rm -rf "$backup_dir"' EXIT
+snapshot() {
   local f="$1"
-  cp -p "$f" "$backup_dir/$(echo "$f" | tr / _)"
+  mkdir -p "$backup_dir/$(dirname "$f")"
+  cp -p "$f" "$backup_dir/$f"
   TOUCHED+=("$f")
 }
 

--- a/scripts/gitea/publish-vulkanalia.sh
+++ b/scripts/gitea/publish-vulkanalia.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Publish the tatolab/vulkanalia fork (vulkanalia-sys, vulkanalia,
+# vulkanalia-vma) to the Gitea cargo registry, so the workspace resolves the
+# fork by version with `registry = "gitea"` instead of a git `[patch]`.
+#
+# One-time bootstrap, re-runnable: cargo rejects republishing an existing
+# version (HTTP 409 / "already exists"), which this script treats as success.
+#
+# Why a non-git scratch copy: vulkanalia-vma vendors VMA + Vulkan-Headers as
+# git submodules, and cargo *excludes submodule contents when packaging inside
+# a git repo*. Publishing from a plain (non-git) copy makes cargo bundle the
+# vendored C++ sources so a consumer can compile vulkanalia-vma. The same copy
+# is where we annotate the fork's inter-crate deps with `registry = "gitea"`
+# (the fork's own manifests use bare `version`/`path`, which would resolve the
+# fork's siblings from crates.io and silently pull upstream instead).
+#
+# Configure-by-env (all optional except the token):
+#   GITEA_URL                     default http://localhost:3300
+#   GITEA_ORG                     default tatolab
+#   CARGO_REGISTRY                default gitea   (name in .cargo/config.toml)
+#   VULKANALIA_DIR                default ~/Repositories/tatolab/vulkanalia
+#   CARGO_REGISTRIES_GITEA_TOKEN  REQUIRED to publish — must be "Bearer <token>"
+#                                 (cargo login stores it bare → 401).
+#
+# Secrets never live in this script — provide the token in the environment
+# (e.g. via the gitignored scripts/gitea/*.local.sh wrapper).
+set -euo pipefail
+
+GITEA_URL="${GITEA_URL:-http://localhost:3300}"
+GITEA_ORG="${GITEA_ORG:-tatolab}"
+CARGO_REGISTRY="${CARGO_REGISTRY:-gitea}"
+VULKANALIA_DIR="${VULKANALIA_DIR:-$HOME/Repositories/tatolab/vulkanalia}"
+INDEX="sparse+${GITEA_URL}/api/packages/${GITEA_ORG}/cargo/"
+
+log()  { printf '[publish-vulkanalia] %s\n' "$*"; }
+fail() { printf '[publish-vulkanalia] ERROR: %s\n' "$*" >&2; exit 1; }
+
+[ -n "${CARGO_REGISTRIES_GITEA_TOKEN:-}" ] \
+  || fail "set CARGO_REGISTRIES_GITEA_TOKEN='Bearer <token>' to publish"
+[ -d "$VULKANALIA_DIR" ] || fail "fork not found at VULKANALIA_DIR=$VULKANALIA_DIR"
+
+# cargo reads the registry index + token from the environment, so the scratch
+# copy (outside the monorepo) resolves `gitea` without a local .cargo/config.
+export CARGO_REGISTRIES_GITEA_INDEX="$INDEX"
+upper="$(printf '%s' "$CARGO_REGISTRY" | tr '[:lower:]' '[:upper:]')"
+eval "export CARGO_REGISTRIES_${upper}_INDEX='$INDEX'"
+eval "export CARGO_REGISTRIES_${upper}_TOKEN='${CARGO_REGISTRIES_GITEA_TOKEN}'"
+
+log "ensuring vendored submodules are checked out"
+git -C "$VULKANALIA_DIR" submodule update --init \
+  ext/vma/vendor/Vulkan-Headers ext/vma/vendor/VulkanMemoryAllocator >/dev/null 2>&1 || true
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+log "copying fork to non-git scratch: $scratch"
+rsync -a --exclude='.git' --exclude='target' "$VULKANALIA_DIR"/ "$scratch"/
+
+log "annotating inter-crate deps with registry = \"$CARGO_REGISTRY\""
+REGISTRY="$CARGO_REGISTRY" python3 - "$scratch" <<'PY'
+import os, sys, tomlkit
+scratch = sys.argv[1]
+reg = os.environ["REGISTRY"]
+def annotate(manifest, dep_names):
+    doc = tomlkit.parse(open(manifest).read())
+    deps = doc.get("dependencies", {})
+    changed = False
+    for name in dep_names:
+        d = deps.get(name)
+        if d is None:
+            continue
+        new = tomlkit.inline_table()
+        # keep version, drop dev-only path, force the fork's registry
+        if "version" in d:
+            new["version"] = d["version"]
+        else:
+            new["version"] = "*"
+        new["registry"] = reg
+        for k, v in d.items():
+            if k in ("version", "registry", "path"):
+                continue
+            new[k] = v
+        deps[name] = new
+        changed = True
+    if changed:
+        open(manifest, "w").write(tomlkit.dumps(doc))
+        print(f"  annotated {dep_names} in {manifest}")
+annotate(f"{scratch}/vulkanalia/Cargo.toml", ["vulkanalia-sys"])
+annotate(f"{scratch}/ext/vma/Cargo.toml", ["vulkanalia"])
+PY
+
+wait_for_index() {
+  local crate="$1" version="$2" i
+  for i in $(seq 1 30); do
+    if curl -fsS "${GITEA_URL}/api/packages/${GITEA_ORG}/cargo/$(idx_path "$crate")" 2>/dev/null \
+         | grep -q "\"vers\":\"${version}\""; then
+      return 0
+    fi
+    sleep 1
+  done
+  log "WARN: ${crate}@${version} not visible in index after 30s (continuing)"
+}
+# cargo sparse-index path: 1-char / 2-char / 3-char dirs for names >=4 chars
+idx_path() {
+  local n="$1"
+  case ${#n} in
+    1) printf '1/%s' "$n" ;;
+    2) printf '2/%s' "$n" ;;
+    3) printf '3/%s/%s' "${n:0:1}" "$n" ;;
+    *) printf '%s/%s/%s' "${n:0:2}" "${n:2:2}" "$n" ;;
+  esac
+}
+
+publish_one() {
+  local crate="$1" version="$2" manifest="$3"
+  log "publishing ${crate}@${version}"
+  if out="$(cargo publish --no-verify --allow-dirty \
+              --registry "$CARGO_REGISTRY" \
+              --manifest-path "$manifest" 2>&1)"; then
+    log "  ✓ ${crate}@${version} published"
+  elif printf '%s' "$out" | grep -qiE 'already exists|already uploaded|crate version .* is already'; then
+    log "  • ${crate}@${version} already present — skipping"
+  else
+    printf '%s\n' "$out" >&2
+    fail "publish of ${crate} failed"
+  fi
+  wait_for_index "$crate" "$version"
+}
+
+publish_one vulkanalia-sys 0.35.0 "$scratch/vulkanalia-sys/Cargo.toml"
+publish_one vulkanalia     0.35.0 "$scratch/vulkanalia/Cargo.toml"
+publish_one vulkanalia-vma 0.9.0  "$scratch/ext/vma/Cargo.toml"
+
+log "done — vulkanalia fork published to $GITEA_ORG on $GITEA_URL"

--- a/scripts/gitea/publish-vulkanalia.sh
+++ b/scripts/gitea/publish-vulkanalia.sh
@@ -62,28 +62,28 @@ scratch = sys.argv[1]
 reg = os.environ["REGISTRY"]
 def annotate(manifest, dep_names):
     doc = tomlkit.parse(open(manifest).read())
-    deps = doc.get("dependencies", {})
     changed = False
-    for name in dep_names:
-        d = deps.get(name)
-        if d is None:
-            continue
-        new = tomlkit.inline_table()
-        # keep version, drop dev-only path, force the fork's registry
-        if "version" in d:
-            new["version"] = d["version"]
-        else:
-            new["version"] = "*"
-        new["registry"] = reg
-        for k, v in d.items():
-            if k in ("version", "registry", "path"):
+    # cover normal + build deps so an inter-crate dep in either resolves the
+    # fork's sibling from Gitea, not crates.io (which would pull upstream).
+    for sec in ("dependencies", "build-dependencies"):
+        deps = doc.get(sec, {})
+        for name in dep_names:
+            d = deps.get(name)
+            if d is None:
                 continue
-            new[k] = v
-        deps[name] = new
-        changed = True
+            new = tomlkit.inline_table()
+            # keep version, drop dev-only path, force the fork's registry
+            new["version"] = d["version"] if "version" in d else "*"
+            new["registry"] = reg
+            for k, v in d.items():
+                if k in ("version", "registry", "path"):
+                    continue
+                new[k] = v
+            deps[name] = new
+            changed = True
+            print(f"  annotated [{sec}] {name} in {manifest}")
     if changed:
         open(manifest, "w").write(tomlkit.dumps(doc))
-        print(f"  annotated {dep_names} in {manifest}")
 annotate(f"{scratch}/vulkanalia/Cargo.toml", ["vulkanalia-sys"])
 annotate(f"{scratch}/ext/vma/Cargo.toml", ["vulkanalia"])
 PY


### PR DESCRIPTION
## Summary

The **Rust slice** of the unified Gitea registry distribution: the workspace now resolves the `streamlib` SDK crate chain and the `tatolab/vulkanalia` fork **by version from the self-hosted Gitea registry under `tatolab`** — no relative-path deps, no git `[patch]`.

- `.cargo/config.toml` declares `[registries.gitea]` (sparse, anonymous read).
- Every internal cross-crate dep across **78 member manifests** moves to the canonical cargo "publish a workspace" form `{ path, version = "0.4.30", registry = "gitea" }` — `path` wins locally (instant edits), cargo strips it on publish. `dev-dependencies` left bare (cargo strips bare-path dev-deps; annotating them creates publish-order cycles, e.g. engine dev-deps `streamlib`).
- `vulkanalia` / `-vma` switch from the git `[patch.crates-io]` override to `{ version, registry = "gitea" }`; `[patch.crates-io]` removed. The fork shares crates.io version numbers, so the `registry` annotation selects the fork.
- Publish tooling: `publish-vulkanalia.sh` (fork, one-time bootstrap), `publish-crates.sh [--dev N]` (SDK closure dev-loop), `migrate-internal-deps.py` (the idempotent migration sweep), and a runbook (`scripts/gitea/README.md`).

## Closes
Closes #1105

## Exit criteria

- [x] vulkanalia fork + `streamlib` closure published to Gitea under `tatolab`; the workspace git `[patch]` replaced by the registry version.
- [x] Internal deps migrated to `{ path, version, registry = "gitea" }`; the monorepo still builds in-place (path wins locally; vulkanalia resolves from Gitea).
- [x] Repo `.cargo/config.toml` carries the `tatolab` registry; a dev-publish script + runbook exist.
- [x] A pilot consumer resolves `streamlib = "0.4.30"` purely from Gitea and builds — **including the full-engine codegen build** (the part previously gated on #1116, now shipped).

## Test plan / validation

All run against the live local Gitea container (`:3300`, org `tatolab`):

- **Publish → resolve-by-version (out-of-repo consumer):** a fresh `cargo new` consumer with `streamlib = { version = "0.4.30", registry = "gitea" }` resolved **521 packages from Gitea, zero git/path sources**, and `cargo build` compiled the entire engine — `streamlib-engine`, `vulkanalia-vma` (VMA C++ from gitea-fetched source), `consumer-rhi`, the `streamlib` SDK — all `(registry gitea)`. The engine's `build.rs` codegen resolved `@tatolab/escalate` from the generic registry (published as a source `.slpkg`). Binary runs. ✅
- **Monorepo builds in-place:** `cargo check -p streamlib` / `-p streamlib-h264` (package) / `-p camera-display` (example) all green; internal crates via path, vulkanalia from Gitea. ✅
- **Migration idempotency:** `migrate-internal-deps.py --check` → 0 manifests would change. ✅
- **Boundary check:** `cargo xtask check-boundaries` → 4597 files, no violations (vulkanalia dep declarations intact). ✅
- **Published engine manifest is path-free:** the bundled `streamlib.yaml` in the published `streamlib-engine@0.4.30` `.crate` has its dev `patch:`/`path:` stripped (per #1116), `dependencies` + `schemas` retained. ✅

Pre-PR review gate: **PASS**; 3 advisory robustness/clarity items applied as follow-up commit (path-preserving backup, build-dep annotate coverage, README auth-scheme note).

## Follow-ups (sibling issues in the milestone, not this PR)

- #1117 Python SDK publish · #1118 Deno SDK publish · #1119 packages as source-only `.slpkg`s.
- Generalizing schema/processor `.slpkg` publishing across all `packages/*` (this PR publishes `@tatolab/escalate` ad-hoc to unblock the engine codegen build) is #1119's domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)