### PR TITLE
feat(deno-sdk): publish to Gitea npm + bare-specifier resolution + protocol handshake (#1118)

### DIFF
--- a/docs/architecture/gitea-registry-distribution.md
+++ b/docs/architecture/gitea-registry-distribution.md
@@ -87,7 +87,7 @@ streamlib-engine = { path = "../streamlib-engine", version = "0.4.30", registry 
 - The repo `.cargo/config.toml` declares `[registries.gitea]`; read is
   anonymous (publish needs a token).
 
-### Python (shipped) / Deno (finalized in #1118)
+### Python / Deno
 
 - Python: a package **declares** `streamlib` like any dependency; the build
   orchestrator provisions a **per-package venv** as the tail of `materialize`
@@ -109,9 +109,28 @@ streamlib-engine = { path = "../streamlib-engine", version = "0.4.30", registry 
   on mismatch — the replacement for the old compatibility-by-injection
   guarantee. The engine satisfies a range (`MIN..=CURRENT`), so a newer engine
   keeps accepting SDKs that speak an older-but-supported protocol.
-- Deno: a stable bare `import "streamlib"` resolves from Gitea's npm registry
-  (`.npmrc`) or a container-level import map — no relative `../../../libs/...`.
-  The same protocol-version handshake coordinate applies to the Deno SDK.
+- Deno: a package's `deno.json` **declares** `streamlib`
+  (`npm:@tatolab/streamlib-deno@^0.4`) and a sibling `.npmrc` points the
+  `@tatolab` scope at Gitea's npm registry (read is anonymous; the localhost
+  URL is the dev default, overridden for a hosted backend). A processor then
+  imports a stable bare `import "streamlib"` / `import "streamlib/adapters/…"`
+  — no relative `../../../libs/...`. The engine launches the SDK's runner the
+  same way (`deno run --config <package>/deno.json
+  streamlib/subprocess_runner.ts`), so the runner and the processor resolve
+  the same registry-pinned SDK; there is no workspace path and no env
+  path-injection escape hatch (parity with the Python venv loop — dev
+  iteration is publish-a-dev-version + bump the declared `streamlib`). Unlike
+  the source-shipping cargo/pypi SDKs, the **npm artifact is built JS + `.d.ts`**
+  (produced by `deno pack` — `scripts/gitea/publish-deno-sdk.sh`): Deno cannot
+  consume a `.ts` package through the `npm:` protocol (node_modules forbids
+  type-stripping and `jsr:` schemes), so the npm idiom of shipping transpiled
+  JS applies. The SDK source is therefore kept free of `jsr:` deps (`node:`
+  builtins + plain npm deps), and the protocol-locked escalate wire-vocabulary
+  is regenerated and baked into the published JS (there is no post-install
+  codegen hook for an npm consumer the way Python regenerates into its venv).
+  The same protocol-version handshake coordinate
+  (`STREAMLIB_SUBPROCESS_PROTOCOL_VERSION` ↔ the SDK's `PROTOCOL_VERSION`)
+  applies to the Deno SDK.
 
 ### vulkanalia fork
 
@@ -246,7 +265,7 @@ Notes the scripts encode:
 | cargo-publish manifest path-strip *wiring* (dev-publish script + manifest migration) | ✅ shipped | #1105 |
 | full-engine codegen consumer build (engine `build.rs` resolves `@tatolab/escalate` from the generic registry) | ✅ shipped | #1105 |
 | Python SDK publish (source-only) + declare/install-from-registry, protocol-version handshake, codegen-into-venv | ✅ shipped | #1117 |
-| Deno SDK publish | ⏳ | #1118 |
+| Deno SDK publish (built JS via `deno pack`) + declare/resolve-from-npm, protocol-version handshake | ✅ shipped | #1118 |
 | packages as source-only `.slpkg` + `streamlib pack` source-only | ⏳ | #1119 |
 | repo migration committed (`{ path, version, registry }`, `.cargo/config`, dev-publish script) | ✅ shipped | #1105 |
 

--- a/examples/camera-deno-subprocess/deno/.npmrc
+++ b/examples/camera-deno-subprocess/deno/.npmrc
@@ -1,0 +1,6 @@
+; StreamLib Deno SDK — resolved from the self-hosted Gitea npm registry by
+; version (@tatolab scope). Read is anonymous (no token). The localhost URL
+; is the local dev-registry default; override for a hosted backend by
+; pointing the @tatolab scope at the hosted Gitea.
+; See docs/architecture/gitea-registry-distribution.md.
+@tatolab:registry=http://localhost:3300/api/packages/tatolab/npm/

--- a/examples/camera-deno-subprocess/deno/deno.json
+++ b/examples/camera-deno-subprocess/deno/deno.json
@@ -3,6 +3,8 @@
     "setup": "cd ../../.. && cargo run --release --quiet -p streamlib-cli -- generate --runtime typescript --project-dir examples/camera-deno-subprocess/deno --output examples/camera-deno-subprocess/deno/_generated_"
   },
   "imports": {
+    "streamlib": "npm:@tatolab/streamlib-deno@^0.4",
+    "streamlib/": "npm:/@tatolab/streamlib-deno@^0.4/",
     "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2",
     "typegpu": "npm:typegpu@0.8.2",
     "typegpu/data": "npm:typegpu@0.8.2/data"

--- a/examples/camera-deno-subprocess/deno/grayscale_processor.ts
+++ b/examples/camera-deno-subprocess/deno/grayscale_processor.ts
@@ -13,7 +13,7 @@ import {
   type ReactiveProcessor,
   type RuntimeContextFullAccess,
   type RuntimeContextLimitedAccess,
-} from "../../../libs/streamlib-deno/mod.ts";
+} from "streamlib";
 import type { VideoFrame } from "./_generated_/tatolab__core/video_frame.ts";
 
 @processor("GrayscaleProcessor", import.meta.url)

--- a/examples/camera-deno-subprocess/deno/halftone_processor.ts
+++ b/examples/camera-deno-subprocess/deno/halftone_processor.ts
@@ -19,7 +19,7 @@ import {
   type ReactiveProcessor,
   type RuntimeContextFullAccess,
   type RuntimeContextLimitedAccess,
-} from "../../../libs/streamlib-deno/mod.ts";
+} from "streamlib";
 import type { VideoFrame } from "./_generated_/tatolab__core/video_frame.ts";
 
 const HALFTONE_WGSL = /* wgsl */`

--- a/examples/polyglot-continuous-processor/deno/.npmrc
+++ b/examples/polyglot-continuous-processor/deno/.npmrc
@@ -1,0 +1,6 @@
+; StreamLib Deno SDK — resolved from the self-hosted Gitea npm registry by
+; version (@tatolab scope). Read is anonymous (no token). The localhost URL
+; is the local dev-registry default; override for a hosted backend by
+; pointing the @tatolab scope at the hosted Gitea.
+; See docs/architecture/gitea-registry-distribution.md.
+@tatolab:registry=http://localhost:3300/api/packages/tatolab/npm/

--- a/examples/polyglot-continuous-processor/deno/continuous_processor.ts
+++ b/examples/polyglot-continuous-processor/deno/continuous_processor.ts
@@ -31,7 +31,7 @@ import {
   processor,
   type RuntimeContextFullAccess,
   type RuntimeContextLimitedAccess,
-} from "../../../libs/streamlib-deno/mod.ts";
+} from "streamlib";
 
 @processor("PolyglotContinuousProcessor", import.meta.url)
 export default class PolyglotContinuousProcessor

--- a/examples/polyglot-continuous-processor/deno/deno.json
+++ b/examples/polyglot-continuous-processor/deno/deno.json
@@ -1,5 +1,7 @@
 {
   "imports": {
+    "streamlib": "npm:@tatolab/streamlib-deno@^0.4",
+    "streamlib/": "npm:/@tatolab/streamlib-deno@^0.4/",
     "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2"
   }
 }

--- a/examples/polyglot-cpu-readback-blur/deno/.npmrc
+++ b/examples/polyglot-cpu-readback-blur/deno/.npmrc
@@ -1,0 +1,6 @@
+; StreamLib Deno SDK — resolved from the self-hosted Gitea npm registry by
+; version (@tatolab scope). Read is anonymous (no token). The localhost URL
+; is the local dev-registry default; override for a hosted backend by
+; pointing the @tatolab scope at the hosted Gitea.
+; See docs/architecture/gitea-registry-distribution.md.
+@tatolab:registry=http://localhost:3300/api/packages/tatolab/npm/

--- a/examples/polyglot-cpu-readback-blur/deno/cpu_readback_blur.ts
+++ b/examples/polyglot-cpu-readback-blur/deno/cpu_readback_blur.ts
@@ -31,8 +31,8 @@ import {
   type ReactiveProcessor,
   type RuntimeContextFullAccess,
   type RuntimeContextLimitedAccess,
-} from "../../../libs/streamlib-deno/mod.ts";
-import { CpuReadbackContext } from "../../../libs/streamlib-deno/adapters/cpu_readback.ts";
+} from "streamlib";
+import { CpuReadbackContext } from "streamlib/adapters/cpu_readback.ts";
 
 @processor("CpuReadbackBlurProcessor", import.meta.url)
 export default class CpuReadbackBlurProcessor implements ReactiveProcessor {

--- a/examples/polyglot-cpu-readback-blur/deno/deno.json
+++ b/examples/polyglot-cpu-readback-blur/deno/deno.json
@@ -1,5 +1,7 @@
 {
   "imports": {
+    "streamlib": "npm:@tatolab/streamlib-deno@^0.4",
+    "streamlib/": "npm:/@tatolab/streamlib-deno@^0.4/",
     "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2"
   }
 }

--- a/examples/polyglot-cuda-inference/deno/.npmrc
+++ b/examples/polyglot-cuda-inference/deno/.npmrc
@@ -1,0 +1,6 @@
+; StreamLib Deno SDK — resolved from the self-hosted Gitea npm registry by
+; version (@tatolab scope). Read is anonymous (no token). The localhost URL
+; is the local dev-registry default; override for a hosted backend by
+; pointing the @tatolab scope at the hosted Gitea.
+; See docs/architecture/gitea-registry-distribution.md.
+@tatolab:registry=http://localhost:3300/api/packages/tatolab/npm/

--- a/examples/polyglot-cuda-inference/deno/cuda_inference.ts
+++ b/examples/polyglot-cuda-inference/deno/cuda_inference.ts
@@ -37,8 +37,8 @@ import {
   type ReactiveProcessor,
   type RuntimeContextFullAccess,
   type RuntimeContextLimitedAccess,
-} from "../../../libs/streamlib-deno/mod.ts";
-import { CudaContext } from "../../../libs/streamlib-deno/adapters/cuda.ts";
+} from "streamlib";
+import { CudaContext } from "streamlib/adapters/cuda.ts";
 
 interface CudaInferenceConfig {
   cuda_surface_id: bigint | number;

--- a/examples/polyglot-cuda-inference/deno/deno.json
+++ b/examples/polyglot-cuda-inference/deno/deno.json
@@ -1,5 +1,7 @@
 {
   "imports": {
+    "streamlib": "npm:@tatolab/streamlib-deno@^0.4",
+    "streamlib/": "npm:/@tatolab/streamlib-deno@^0.4/",
     "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2"
   }
 }

--- a/examples/polyglot-dma-buf-consumer/deno/.npmrc
+++ b/examples/polyglot-dma-buf-consumer/deno/.npmrc
@@ -1,0 +1,6 @@
+; StreamLib Deno SDK — resolved from the self-hosted Gitea npm registry by
+; version (@tatolab scope). Read is anonymous (no token). The localhost URL
+; is the local dev-registry default; override for a hosted backend by
+; pointing the @tatolab scope at the hosted Gitea.
+; See docs/architecture/gitea-registry-distribution.md.
+@tatolab:registry=http://localhost:3300/api/packages/tatolab/npm/

--- a/examples/polyglot-dma-buf-consumer/deno/deno.json
+++ b/examples/polyglot-dma-buf-consumer/deno/deno.json
@@ -3,6 +3,8 @@
     "setup": "cd ../../.. && cargo run --release --quiet -p streamlib-cli -- generate --runtime typescript --project-dir examples/polyglot-dma-buf-consumer/deno --output examples/polyglot-dma-buf-consumer/deno/_generated_"
   },
   "imports": {
+    "streamlib": "npm:@tatolab/streamlib-deno@^0.4",
+    "streamlib/": "npm:/@tatolab/streamlib-deno@^0.4/",
     "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2"
   }
 }

--- a/examples/polyglot-dma-buf-consumer/deno/dma_buf_consumer.ts
+++ b/examples/polyglot-dma-buf-consumer/deno/dma_buf_consumer.ts
@@ -31,7 +31,7 @@ import {
   type ReactiveProcessor,
   type RuntimeContextFullAccess,
   type RuntimeContextLimitedAccess,
-} from "../../../libs/streamlib-deno/mod.ts";
+} from "streamlib";
 import type { VideoFrame } from "./_generated_/tatolab__core/video_frame.ts";
 
 const BOGUS_SURFACE_ID = "00000000-0000-0000-0000-000000000000";

--- a/examples/polyglot-manual-source/deno/.npmrc
+++ b/examples/polyglot-manual-source/deno/.npmrc
@@ -1,0 +1,6 @@
+; StreamLib Deno SDK — resolved from the self-hosted Gitea npm registry by
+; version (@tatolab scope). Read is anonymous (no token). The localhost URL
+; is the local dev-registry default; override for a hosted backend by
+; pointing the @tatolab scope at the hosted Gitea.
+; See docs/architecture/gitea-registry-distribution.md.
+@tatolab:registry=http://localhost:3300/api/packages/tatolab/npm/

--- a/examples/polyglot-manual-source/deno/deno.json
+++ b/examples/polyglot-manual-source/deno/deno.json
@@ -1,5 +1,7 @@
 {
   "imports": {
+    "streamlib": "npm:@tatolab/streamlib-deno@^0.4",
+    "streamlib/": "npm:/@tatolab/streamlib-deno@^0.4/",
     "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2"
   }
 }

--- a/examples/polyglot-manual-source/deno/manual_source.ts
+++ b/examples/polyglot-manual-source/deno/manual_source.ts
@@ -38,8 +38,8 @@ import {
   MonotonicTimer,
   processor,
   type RuntimeContextFullAccess,
-} from "../../../libs/streamlib-deno/mod.ts";
-import type { OutputPorts } from "../../../libs/streamlib-deno/types.ts";
+} from "streamlib";
+import type { OutputPorts } from "streamlib/types.ts";
 
 @processor("PolyglotManualSource", import.meta.url)
 export default class PolyglotManualSource implements ManualProcessor {

--- a/examples/polyglot-opengl-fragment-shader/deno/.npmrc
+++ b/examples/polyglot-opengl-fragment-shader/deno/.npmrc
@@ -1,0 +1,6 @@
+; StreamLib Deno SDK — resolved from the self-hosted Gitea npm registry by
+; version (@tatolab scope). Read is anonymous (no token). The localhost URL
+; is the local dev-registry default; override for a hosted backend by
+; pointing the @tatolab scope at the hosted Gitea.
+; See docs/architecture/gitea-registry-distribution.md.
+@tatolab:registry=http://localhost:3300/api/packages/tatolab/npm/

--- a/examples/polyglot-opengl-fragment-shader/deno/deno.json
+++ b/examples/polyglot-opengl-fragment-shader/deno/deno.json
@@ -1,5 +1,7 @@
 {
   "imports": {
+    "streamlib": "npm:@tatolab/streamlib-deno@^0.4",
+    "streamlib/": "npm:/@tatolab/streamlib-deno@^0.4/",
     "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2"
   }
 }

--- a/examples/polyglot-opengl-fragment-shader/deno/opengl_fragment_shader.ts
+++ b/examples/polyglot-opengl-fragment-shader/deno/opengl_fragment_shader.ts
@@ -40,12 +40,12 @@ import {
   type ReactiveProcessor,
   type RuntimeContextFullAccess,
   type RuntimeContextLimitedAccess,
-} from "../../../libs/streamlib-deno/mod.ts";
-import { OpenGLContext } from "../../../libs/streamlib-deno/adapters/opengl.ts";
+} from "streamlib";
+import { OpenGLContext } from "streamlib/adapters/opengl.ts";
 import {
   VkImageLayout,
   VulkanContext,
-} from "../../../libs/streamlib-deno/adapters/vulkan.ts";
+} from "streamlib/adapters/vulkan.ts";
 
 // =============================================================================
 // Minimal libGL.so.1 binding via Deno.dlopen

--- a/examples/polyglot-vulkan-compute/deno/.npmrc
+++ b/examples/polyglot-vulkan-compute/deno/.npmrc
@@ -1,0 +1,6 @@
+; StreamLib Deno SDK — resolved from the self-hosted Gitea npm registry by
+; version (@tatolab scope). Read is anonymous (no token). The localhost URL
+; is the local dev-registry default; override for a hosted backend by
+; pointing the @tatolab scope at the hosted Gitea.
+; See docs/architecture/gitea-registry-distribution.md.
+@tatolab:registry=http://localhost:3300/api/packages/tatolab/npm/

--- a/examples/polyglot-vulkan-compute/deno/deno.json
+++ b/examples/polyglot-vulkan-compute/deno/deno.json
@@ -1,5 +1,7 @@
 {
   "imports": {
+    "streamlib": "npm:@tatolab/streamlib-deno@^0.4",
+    "streamlib/": "npm:/@tatolab/streamlib-deno@^0.4/",
     "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2"
   }
 }

--- a/examples/polyglot-vulkan-compute/deno/vulkan_compute.ts
+++ b/examples/polyglot-vulkan-compute/deno/vulkan_compute.ts
@@ -34,11 +34,11 @@ import {
   type ReactiveProcessor,
   type RuntimeContextFullAccess,
   type RuntimeContextLimitedAccess,
-} from "../../../libs/streamlib-deno/mod.ts";
+} from "streamlib";
 import {
   VkImageLayout,
   VulkanContext,
-} from "../../../libs/streamlib-deno/adapters/vulkan.ts";
+} from "streamlib/adapters/vulkan.ts";
 
 function hexToBytes(hex: string): Uint8Array {
   const out = new Uint8Array(hex.length / 2);

--- a/examples/polyglot-vulkan-graphics/deno/.npmrc
+++ b/examples/polyglot-vulkan-graphics/deno/.npmrc
@@ -1,0 +1,6 @@
+; StreamLib Deno SDK — resolved from the self-hosted Gitea npm registry by
+; version (@tatolab scope). Read is anonymous (no token). The localhost URL
+; is the local dev-registry default; override for a hosted backend by
+; pointing the @tatolab scope at the hosted Gitea.
+; See docs/architecture/gitea-registry-distribution.md.
+@tatolab:registry=http://localhost:3300/api/packages/tatolab/npm/

--- a/examples/polyglot-vulkan-graphics/deno/deno.json
+++ b/examples/polyglot-vulkan-graphics/deno/deno.json
@@ -1,5 +1,7 @@
 {
   "imports": {
+    "streamlib": "npm:@tatolab/streamlib-deno@^0.4",
+    "streamlib/": "npm:/@tatolab/streamlib-deno@^0.4/",
     "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2"
   }
 }

--- a/examples/polyglot-vulkan-graphics/deno/vulkan_graphics.ts
+++ b/examples/polyglot-vulkan-graphics/deno/vulkan_graphics.ts
@@ -30,12 +30,12 @@ import {
   type ReactiveProcessor,
   type RuntimeContextFullAccess,
   type RuntimeContextLimitedAccess,
-} from "../../../libs/streamlib-deno/mod.ts";
+} from "streamlib";
 import {
   VkImageLayout,
   VulkanContext,
-} from "../../../libs/streamlib-deno/adapters/vulkan.ts";
-import type { EscalateRequestRegisterGraphicsKernelPipelineState } from "../../../libs/streamlib-deno/escalate.ts";
+} from "streamlib/adapters/vulkan.ts";
+import type { EscalateRequestRegisterGraphicsKernelPipelineState } from "streamlib/escalate.ts";
 
 function hexToBytes(hex: string): Uint8Array {
   const out = new Uint8Array(hex.length / 2);

--- a/examples/polyglot-vulkan-ray-tracing/deno/.npmrc
+++ b/examples/polyglot-vulkan-ray-tracing/deno/.npmrc
@@ -1,0 +1,6 @@
+; StreamLib Deno SDK — resolved from the self-hosted Gitea npm registry by
+; version (@tatolab scope). Read is anonymous (no token). The localhost URL
+; is the local dev-registry default; override for a hosted backend by
+; pointing the @tatolab scope at the hosted Gitea.
+; See docs/architecture/gitea-registry-distribution.md.
+@tatolab:registry=http://localhost:3300/api/packages/tatolab/npm/

--- a/examples/polyglot-vulkan-ray-tracing/deno/deno.json
+++ b/examples/polyglot-vulkan-ray-tracing/deno/deno.json
@@ -1,5 +1,7 @@
 {
   "imports": {
+    "streamlib": "npm:@tatolab/streamlib-deno@^0.4",
+    "streamlib/": "npm:/@tatolab/streamlib-deno@^0.4/",
     "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2"
   }
 }

--- a/examples/polyglot-vulkan-ray-tracing/deno/vulkan_ray_tracing.ts
+++ b/examples/polyglot-vulkan-ray-tracing/deno/vulkan_ray_tracing.ts
@@ -30,8 +30,8 @@ import {
   type ReactiveProcessor,
   type RuntimeContextFullAccess,
   type RuntimeContextLimitedAccess,
-} from "../../../libs/streamlib-deno/mod.ts";
-import { VulkanContext } from "../../../libs/streamlib-deno/adapters/vulkan.ts";
+} from "streamlib";
+import { VulkanContext } from "streamlib/adapters/vulkan.ts";
 
 function hexToBytes(hex: string): Uint8Array {
   const out = new Uint8Array(hex.length / 2);

--- a/libs/streamlib-deno/_manifest.ts
+++ b/libs/streamlib-deno/_manifest.ts
@@ -13,12 +13,15 @@
  * the host loads it; this reader only needs enough fields to validate
  * the decorator's short name and compose a structured `SchemaIdent`.
  *
- * Uses `@std/yaml` (Deno's standard library YAML parser) — no npm shim.
+ * Uses the npm `yaml` parser (declared as a registry dependency) rather
+ * than a `jsr:` import: the SDK is published to npm via `deno pack`, and
+ * Deno cannot resolve `jsr:` specifiers from inside a published npm
+ * package — so the wire-vocabulary deps must be plain npm / `node:`.
  *
  * @module
  */
 
-import { parse as parseYaml } from "@std/yaml";
+import { parse as parseYaml } from "yaml";
 
 /** Resolved `package:` block from streamlib.yaml. */
 export interface ManifestPackage {

--- a/libs/streamlib-deno/_protocol.ts
+++ b/libs/streamlib-deno/_protocol.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Engine↔SDK subprocess protocol-version handshake.
+ *
+ * The single coordinate the engine and this SDK agree on so a
+ * `@tatolab/streamlib-deno` resolved from a registry *by version* refuses to
+ * run against an incompatible engine — instead of failing deep in the FFI /
+ * escalate / lifecycle path with a cryptic crash. Mirrors the engine-side
+ * `STREAMLIB_SUBPROCESS_PROTOCOL_VERSION`; covers the three lockstep runtime
+ * surfaces (native-lib FFI symbol contract, escalate IPC schema,
+ * stdin/stdout lifecycle-command protocol). This is the Deno-subprocess
+ * analogue of the cdylib plugin ABI's `STREAMLIB_ABI_VERSION`, and the twin
+ * of the Python SDK's `streamlib._protocol`.
+ *
+ * The contract is a **monotonic range, not strict equality** (the Cloudflare
+ * `compatibility_date` shape): this SDK can speak any engine protocol in
+ * `[MIN_ENGINE_PROTOCOL, PROTOCOL_VERSION]`, so a newer SDK keeps working
+ * against a range of older engines. Bump `PROTOCOL_VERSION` (in lockstep with
+ * the engine constant) when any of the three surfaces changes incompatibly;
+ * raise `MIN_ENGINE_PROTOCOL` only when dropping support for an old engine
+ * protocol.
+ *
+ * @module
+ */
+
+/** The subprocess protocol version this SDK implements. */
+export const PROTOCOL_VERSION = 1;
+
+/** Oldest engine protocol version this SDK can still speak. */
+export const MIN_ENGINE_PROTOCOL = 1;
+
+/** Env var the engine sets to advertise its protocol version to the subprocess. */
+export const ENGINE_PROTOCOL_ENV = "STREAMLIB_PROTOCOL_VERSION";
+
+/** The engine's subprocess protocol version is one this SDK can't speak. */
+export class ProtocolMismatchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProtocolMismatchError";
+  }
+}
+
+/**
+ * Read the engine's advertised protocol version from the environment.
+ *
+ * Throws [`ProtocolMismatchError`] when unset (the host doesn't speak the
+ * streamlib subprocess protocol — an engine older than this SDK, or a process
+ * not launched by streamlib) or non-integer.
+ */
+export function engineProtocolFromEnv(): number {
+  const raw = Deno.env.get(ENGINE_PROTOCOL_ENV);
+  if (!raw) {
+    throw new ProtocolMismatchError(
+      `${ENGINE_PROTOCOL_ENV} not set — the host does not speak the streamlib ` +
+        `subprocess protocol (this SDK implements v${PROTOCOL_VERSION}). The ` +
+        `engine is older than this streamlib, or this process was not launched ` +
+        `by a streamlib runtime.`,
+    );
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed)) {
+    throw new ProtocolMismatchError(
+      `${ENGINE_PROTOCOL_ENV}=${JSON.stringify(raw)} is not an integer protocol version`,
+    );
+  }
+  return parsed;
+}
+
+/** Fail loud when the engine's protocol version is outside this SDK's range. */
+export function assertEngineCompatible(engineVersion: number): void {
+  if (
+    !(MIN_ENGINE_PROTOCOL <= engineVersion &&
+      engineVersion <= PROTOCOL_VERSION)
+  ) {
+    throw new ProtocolMismatchError(
+      `engine speaks subprocess protocol v${engineVersion}, this ` +
+        `streamlib SDK speaks v${MIN_ENGINE_PROTOCOL}..v${PROTOCOL_VERSION}. ` +
+        `The installed streamlib is incompatible with this engine — align ` +
+        `the package's declared streamlib version to the engine's.`,
+    );
+  }
+}

--- a/libs/streamlib-deno/_protocol_test.ts
+++ b/libs/streamlib-deno/_protocol_test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import {
+  assertEngineCompatible,
+  ENGINE_PROTOCOL_ENV,
+  engineProtocolFromEnv,
+  MIN_ENGINE_PROTOCOL,
+  PROTOCOL_VERSION,
+  ProtocolMismatchError,
+} from "./_protocol.ts";
+
+// The handshake exists so an incompatible installed SDK is refused before it
+// runs, not deep in the FFI/escalate path. Mentally revert `assertEngineCompatible`
+// to a no-op and the too-new / too-old assertions below go green for the wrong
+// reason — so these lock the gate, not just exercise it.
+
+Deno.test("PROTOCOL_VERSION and MIN are a coherent integer range", () => {
+  assert(Number.isInteger(PROTOCOL_VERSION));
+  assert(Number.isInteger(MIN_ENGINE_PROTOCOL));
+  assert(MIN_ENGINE_PROTOCOL <= PROTOCOL_VERSION);
+});
+
+Deno.test("engineProtocolFromEnv reads the advertised version", () => {
+  const prev = Deno.env.get(ENGINE_PROTOCOL_ENV);
+  try {
+    Deno.env.set(ENGINE_PROTOCOL_ENV, String(PROTOCOL_VERSION));
+    assertEquals(engineProtocolFromEnv(), PROTOCOL_VERSION);
+  } finally {
+    if (prev === undefined) Deno.env.delete(ENGINE_PROTOCOL_ENV);
+    else Deno.env.set(ENGINE_PROTOCOL_ENV, prev);
+  }
+});
+
+Deno.test("engineProtocolFromEnv throws when the env var is unset", () => {
+  const prev = Deno.env.get(ENGINE_PROTOCOL_ENV);
+  try {
+    Deno.env.delete(ENGINE_PROTOCOL_ENV);
+    assertThrows(() => engineProtocolFromEnv(), ProtocolMismatchError);
+  } finally {
+    if (prev !== undefined) Deno.env.set(ENGINE_PROTOCOL_ENV, prev);
+  }
+});
+
+Deno.test("engineProtocolFromEnv throws on a non-integer version", () => {
+  const prev = Deno.env.get(ENGINE_PROTOCOL_ENV);
+  try {
+    Deno.env.set(ENGINE_PROTOCOL_ENV, "not-a-number");
+    assertThrows(() => engineProtocolFromEnv(), ProtocolMismatchError);
+  } finally {
+    if (prev === undefined) Deno.env.delete(ENGINE_PROTOCOL_ENV);
+    else Deno.env.set(ENGINE_PROTOCOL_ENV, prev);
+  }
+});
+
+Deno.test("assertEngineCompatible accepts versions in range", () => {
+  assertEngineCompatible(PROTOCOL_VERSION);
+  assertEngineCompatible(MIN_ENGINE_PROTOCOL);
+});
+
+Deno.test("assertEngineCompatible refuses an engine newer than this SDK", () => {
+  assertThrows(
+    () => assertEngineCompatible(PROTOCOL_VERSION + 1),
+    ProtocolMismatchError,
+  );
+});
+
+Deno.test("assertEngineCompatible refuses an engine older than the minimum", () => {
+  assertThrows(
+    () => assertEngineCompatible(MIN_ENGINE_PROTOCOL - 1),
+    ProtocolMismatchError,
+  );
+});

--- a/libs/streamlib-deno/decorators.ts
+++ b/libs/streamlib-deno/decorators.ts
@@ -43,7 +43,8 @@
  * @module
  */
 
-import { dirname, fromFileUrl, join } from "@std/path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   type ManifestSummary,
@@ -288,7 +289,7 @@ function locateSiblingManifest(
         `regular .ts module file.`,
     );
   }
-  const filePath = fromFileUrl(moduleUrl);
+  const filePath = fileURLToPath(moduleUrl);
   return join(dirname(filePath), "streamlib.yaml");
 }
 

--- a/libs/streamlib-deno/deno.json
+++ b/libs/streamlib-deno/deno.json
@@ -7,9 +7,9 @@
   },
   "imports": {
     "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2",
+    "yaml": "npm:yaml@^2",
     "@std/assert": "jsr:@std/assert@^1.0.19",
-    "@std/path": "jsr:@std/path@^1",
-    "@std/yaml": "jsr:@std/yaml@^1"
+    "@std/path": "jsr:@std/path@^1"
   },
   "compilerOptions": {
     "strict": true

--- a/libs/streamlib-deno/deno.json
+++ b/libs/streamlib-deno/deno.json
@@ -1,7 +1,16 @@
 {
   "name": "@tatolab/streamlib-deno",
-  "version": "0.3.0",
-  "exports": "./mod.ts",
+  "version": "0.4.33",
+  "exports": {
+    ".": "./mod.ts",
+    "./subprocess_runner.ts": "./subprocess_runner.ts",
+    "./escalate.ts": "./escalate.ts",
+    "./types.ts": "./types.ts",
+    "./adapters/vulkan.ts": "./adapters/vulkan.ts",
+    "./adapters/opengl.ts": "./adapters/opengl.ts",
+    "./adapters/cuda.ts": "./adapters/cuda.ts",
+    "./adapters/cpu_readback.ts": "./adapters/cpu_readback.ts"
+  },
   "tasks": {
     "setup": "cd ../.. && cargo run --release --quiet -p streamlib-cli -- generate --runtime typescript --project-dir libs/streamlib-deno --output libs/streamlib-deno/_generated_"
   },

--- a/libs/streamlib-deno/deno.lock
+++ b/libs/streamlib-deno/deno.lock
@@ -5,9 +5,9 @@
     "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.13",
     "jsr:@std/path@1": "1.1.4",
-    "jsr:@std/yaml@1": "1.1.0",
     "npm:@msgpack/msgpack@3.0.0-beta2": "3.0.0-beta2",
-    "npm:typegpu@0.8.2": "0.8.2"
+    "npm:typegpu@0.8.2": "0.8.2",
+    "npm:yaml@2": "2.9.0"
   },
   "jsr": {
     "@std/assert@1.0.19": {
@@ -24,9 +24,6 @@
       "dependencies": [
         "jsr:@std/internal"
       ]
-    },
-    "@std/yaml@1.1.0": {
-      "integrity": "fc1c5c63e05c4c5eb6118355f557958035d41940d6c29d35b306ef7155d6edb0"
     }
   },
   "npm": {
@@ -46,14 +43,18 @@
         "tinyest",
         "typed-binary"
       ]
+    },
+    "yaml@2.9.0": {
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "bin": true
     }
   },
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@^1.0.19",
       "jsr:@std/path@1",
-      "jsr:@std/yaml@1",
-      "npm:@msgpack/msgpack@3.0.0-beta2"
+      "npm:@msgpack/msgpack@3.0.0-beta2",
+      "npm:yaml@2"
     ]
   }
 }

--- a/libs/streamlib-deno/log.ts
+++ b/libs/streamlib-deno/log.ts
@@ -150,7 +150,11 @@ let _channel: EscalateChannel | null = null;
 // avoid a timer leak (the Deno test runner flags any unresolved
 // setTimeout as a leak).
 let _writerSleepResolve: (() => void) | null = null;
-let _writerSleepTimer: number = -1;
+// Typed as the timer handle (not `number`) so the module stays portable: once
+// the SDK pulls a `node:` builtin into its graph, `setTimeout` resolves to the
+// Node typing (`Timeout`) rather than Deno's `number`. `null` is the unset
+// sentinel.
+let _writerSleepTimer: ReturnType<typeof setTimeout> | null = null;
 
 // ============================================================================
 // Hot path — build payload and enqueue
@@ -296,15 +300,15 @@ function writerSleep(ms: number): Promise<void> {
   return new Promise<void>((resolve) => {
     _writerSleepResolve = () => {
       _writerSleepResolve = null;
-      if (_writerSleepTimer >= 0) {
+      if (_writerSleepTimer !== null) {
         clearTimeout(_writerSleepTimer);
-        _writerSleepTimer = -1;
+        _writerSleepTimer = null;
       }
       resolve();
     };
     _writerSleepTimer = setTimeout(() => {
       _writerSleepResolve = null;
-      _writerSleepTimer = -1;
+      _writerSleepTimer = null;
       resolve();
     }, ms);
   });
@@ -386,12 +390,12 @@ export async function shutdown(timeoutMs = 2000): Promise<void> {
   // Deno's test runner reports as a leak.
   wakeWriterSleep();
   if (_writerDone) {
-    let timeoutId = -1;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
     const timer = new Promise<void>((resolve) => {
       timeoutId = setTimeout(resolve, timeoutMs);
     });
     await Promise.race([_writerDone, timer]);
-    if (timeoutId >= 0) clearTimeout(timeoutId);
+    if (timeoutId !== null) clearTimeout(timeoutId);
   }
   _writerDone = null;
   _writerActive = false;

--- a/libs/streamlib-deno/subprocess_runner.ts
+++ b/libs/streamlib-deno/subprocess_runner.ts
@@ -32,6 +32,12 @@ import {
 } from "./escalate_fd.ts";
 import * as clock from "./clock.ts";
 import * as log from "./log.ts";
+import {
+  assertEngineCompatible,
+  engineProtocolFromEnv,
+  ProtocolMismatchError,
+  PROTOCOL_VERSION,
+} from "./_protocol.ts";
 import type {
   ContinuousProcessor,
   ManualProcessor,
@@ -175,6 +181,22 @@ async function main(): Promise<void> {
 
   if (!entrypoint) {
     fatalPreInstall("STREAMLIB_ENTRYPOINT not set");
+  }
+
+  // Protocol handshake (engine → SDK direction). The engine advertises its
+  // subprocess protocol version via the environment; refuse to run — before
+  // loading the native lib or touching the bridge — if this installed SDK
+  // can't speak it. This replaces the old compatibility-by-injection
+  // guarantee now that the SDK is resolved from a registry by version. The
+  // SDK → engine direction is validated host-side from the `protocol_version`
+  // echoed in the `ready` response below.
+  try {
+    assertEngineCompatible(engineProtocolFromEnv());
+  } catch (e) {
+    if (e instanceof ProtocolMismatchError) {
+      fatalPreInstall(`subprocess protocol handshake failed: ${e.message}`);
+    }
+    throw e;
   }
 
   // Escalate channel — requests from the TS processor go out on stdout,
@@ -461,7 +483,12 @@ async function main(): Promise<void> {
               await processor.setup(fullCtx);
             }
 
-            await bridgeSendJson({ rpc: "ready" });
+            // Echo this SDK's protocol version so the host can validate the
+            // SDK → engine direction of the handshake.
+            await bridgeSendJson({
+              rpc: "ready",
+              protocol_version: PROTOCOL_VERSION,
+            });
           } catch (e) {
             log.error("Setup failed", { error: String(e) });
             await bridgeSendJson({ rpc: "error", error: String(e) });

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_deno_subprocess_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_deno_subprocess_op.rs
@@ -14,7 +14,10 @@ use crate::core::{
     ProcessorDescriptor, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
 };
 
-use super::subprocess_bridge::{spawn_fd_line_reader, EscalateTransport, SubprocessBridge};
+use super::subprocess_bridge::{
+    spawn_fd_line_reader, validate_subprocess_protocol, EscalateTransport, SubprocessBridge,
+    PROTOCOL_VERSION_ENV, STREAMLIB_SUBPROCESS_PROTOCOL_VERSION,
+};
 
 // ============================================================================
 // DenoSubprocessHostProcessor — Rust host for Deno subprocess processors
@@ -141,7 +144,15 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
                 )
                 .env("STREAMLIB_NATIVE_LIB_PATH", &native_lib_path)
                 .env("STREAMLIB_PROCESSOR_ID", &self.processor_id)
-                .env("STREAMLIB_EXECUTION_MODE", execution_mode);
+                .env("STREAMLIB_EXECUTION_MODE", execution_mode)
+                // Advertise the engine's subprocess protocol version. The SDK
+                // refuses to run at startup if it can't speak it — the engine →
+                // SDK handshake direction (the reverse is validated from the
+                // `ready` response below).
+                .env(
+                    PROTOCOL_VERSION_ENV,
+                    STREAMLIB_SUBPROCESS_PROTOCOL_VERSION.to_string(),
+                );
 
             #[cfg(target_os = "linux")]
             command.env("STREAMLIB_SURFACE_SOCKET", ctx.host_base().surface_socket_path());
@@ -237,6 +248,16 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
                     self.processor_id, error
                 )));
             }
+
+            // Validate the SDK → engine handshake direction: the `ready`
+            // response echoes the SDK's protocol version. An incompatible
+            // installed SDK is caught here, at setup, rather than as a deep
+            // FFI/escalate crash later.
+            let sdk_protocol = response
+                .get("protocol_version")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as u32);
+            validate_subprocess_protocol(sdk_protocol, &self.processor_id)?;
 
             tracing::info!(
                 "[{}] Deno subprocess setup complete (pid={})",

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_deno_subprocess_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_deno_subprocess_op.rs
@@ -96,8 +96,28 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
                 )?
             };
 
-            // Resolve the SDK path (subprocess_runner.ts location)
-            let sdk_path = resolve_deno_sdk_path()?;
+            // The SDK is resolved from the registry by version, never from a
+            // workspace path: the Deno package's deno.json declares `streamlib`
+            // (npm:@tatolab/streamlib-deno@<version>) and a sibling .npmrc
+            // points the @tatolab scope at Gitea. The engine launches the SDK's
+            // runner as the bare specifier `streamlib/subprocess_runner.ts`,
+            // resolved through that config — the direct mirror of how the
+            // Python op runs `-m streamlib.subprocess_runner` from the
+            // registry-installed venv. The processor's own `import "streamlib"`
+            // resolves through the same config. Deno fetches + caches the SDK on
+            // first run, so no separate install step is needed. Dev iteration is
+            // publish-a-dev-version + bump the package's declared `streamlib`
+            // (no path escape hatch, by design — parity with the Python loop).
+            let project_deno_config = project_path.join("deno.json");
+            if !project_deno_config.exists() {
+                return Err(Error::Runtime(format!(
+                    "Deno package at '{}' has no deno.json — it must declare \
+                     `streamlib` (npm:@tatolab/streamlib-deno@<version>) plus a \
+                     sibling .npmrc pointing the @tatolab scope at the registry, \
+                     so the engine can resolve the SDK runner by version.",
+                    project_path.display()
+                )));
+            }
 
             // Determine the original TypeScript execution mode for the subprocess
             let execution_mode = match &self.execution_config.execution {
@@ -107,14 +127,12 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
             };
 
             tracing::info!(
-                "[{}] Spawning Deno subprocess: binary='{}', sdk='{}', native_lib='{}'",
+                "[{}] Spawning Deno subprocess: binary='{}', config='{}', native_lib='{}'",
                 self.processor_id,
                 deno_binary,
-                sdk_path.display(),
+                project_deno_config.display(),
                 native_lib_path
             );
-
-            let runner_path = sdk_path.join("subprocess_runner.ts");
 
             let mut command = Command::new(&deno_binary);
             command
@@ -133,7 +151,12 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
                 .arg("--allow-all")
                 .arg("--no-prompt")
                 .arg("--unstable-webgpu")
-                .arg(runner_path.to_str().unwrap_or(""))
+                // Resolve `streamlib` (the runner here, and `import "streamlib"`
+                // inside the dynamically-imported processor) through the
+                // package's deno.json + sibling .npmrc.
+                .arg("--config")
+                .arg(&project_deno_config)
+                .arg("streamlib/subprocess_runner.ts")
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
@@ -640,30 +663,6 @@ fn which_deno() -> Result<String> {
 
     Err(Error::Runtime(
         "deno binary not found on PATH. Install with: curl -fsSL https://deno.land/install.sh | sh"
-            .to_string(),
-    ))
-}
-
-/// Resolve the path to the StreamLib Deno SDK (where subprocess_runner.ts lives).
-fn resolve_deno_sdk_path() -> Result<PathBuf> {
-    // Check env var first
-    if let Ok(path) = std::env::var("STREAMLIB_DENO_SDK_PATH") {
-        let p = PathBuf::from(path);
-        if p.exists() {
-            return Ok(p);
-        }
-    }
-
-    // Dev mode: SDK lives at libs/streamlib-deno/ relative to workspace root
-    let dev_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../libs/streamlib-deno");
-    if dev_path.exists() {
-        return dev_path
-            .canonicalize()
-            .map_err(|e| Error::Runtime(format!("Failed to canonicalize SDK path: {}", e)));
-    }
-
-    Err(Error::Runtime(
-        "StreamLib Deno SDK not found. Set STREAMLIB_DENO_SDK_PATH or build from workspace."
             .to_string(),
     ))
 }

--- a/scripts/gitea/publish-deno-sdk.sh
+++ b/scripts/gitea/publish-deno-sdk.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Publish the `@tatolab/streamlib-deno` SDK to the Gitea npm registry by
+# version. The Deno twin of publish-python-sdk.sh / publish-crates.sh: a local
+# engine change becomes a published version a Deno consumer resolves from Gitea
+# by version (a bare `import "streamlib"` mapped to
+# `npm:@tatolab/streamlib-deno`) — never a relative `../../../libs/...` import.
+# See docs/architecture/gitea-registry-distribution.md.
+#
+#   ./publish-deno-sdk.sh            # publish the base [workspace.package].version
+#   ./publish-deno-sdk.sh --dev 3    # publish <base>-dev.3
+#
+# Version is derived from the Rust workspace's [workspace.package].version
+# (single source of truth) so the Deno SDK rides the same train as the cargo
+# closure. Deno/npm use semver, so the `-dev.N` prerelease grammar matches
+# cargo's exactly (unlike Python's PEP 440 `.devN` translation).
+#
+# Why a BUILT artifact (not source like cargo/pypi): Deno cannot consume a
+# `.ts` package through the `npm:` protocol (node_modules → no type-stripping;
+# `jsr:` deps → unsupported scheme), so the npm channel ships transpiled JS +
+# `.d.ts`. `deno pack` (Deno 2.8+) is the purpose-built tool: it transpiles,
+# emits declarations, rewrites import specifiers, and synthesizes package.json
+# from the SDK's `deno.json` `exports`. The SDK's `_generated_` escalate
+# wire-vocabulary is regenerated fresh and baked into the artifact (it is
+# protocol-locked to the SDK version; there is no post-install codegen hook
+# for an npm consumer the way Python regenerates into its venv).
+#
+# Configure-by-env (all optional except the token + user):
+#   GITEA_URL              default http://localhost:3300
+#   GITEA_ORG              default tatolab
+#   GITEA_PUBLISH_TOKEN    REQUIRED — a Gitea token with write:package
+#   GITEA_PUBLISH_USER     REQUIRED — the Gitea username the token belongs to
+set -euo pipefail
+
+GITEA_URL="${GITEA_URL:-http://localhost:3300}"
+GITEA_ORG="${GITEA_ORG:-tatolab}"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PROJECT="$ROOT/libs/streamlib-deno"
+PY="${PYTHON:-python3}"
+
+DEV_N=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dev) DEV_N="${2:?--dev needs a number}"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+log()  { printf '[publish-deno-sdk] %s\n' "$*"; }
+fail() { printf '[publish-deno-sdk] ERROR: %s\n' "$*" >&2; exit 1; }
+
+[ -n "${GITEA_PUBLISH_TOKEN:-}" ] || fail "set GITEA_PUBLISH_TOKEN (write:package)"
+[ -n "${GITEA_PUBLISH_USER:-}" ]  || fail "set GITEA_PUBLISH_USER (the token's owner)"
+command -v deno >/dev/null || fail "deno not found (the SDK's build + pack toolchain)"
+command -v npm  >/dev/null || fail "npm not found (publishes the packed tarball)"
+# `deno pack` landed in Deno 2.8. Fail loud rather than emit a cryptic
+# "Module not found 'pack'" on an older toolchain.
+deno_ver="$(deno --version | head -1 | awk '{print $2}')"
+case "$deno_ver" in
+  2.[0-7].*|1.*|0.*) fail "deno $deno_ver too old — \`deno pack\` needs >= 2.8 (run: deno upgrade)" ;;
+esac
+
+# --- derive the target version from the workspace (single source of truth) ----
+base_version="$("$PY" - "$ROOT/Cargo.toml" <<'PY'
+import sys, tomllib
+with open(sys.argv[1], "rb") as f:
+    print(tomllib.load(f)["workspace"]["package"]["version"])
+PY
+)"
+target_version="$base_version"
+[ -n "$DEV_N" ] && target_version="${base_version}-dev.${DEV_N}"
+log "publishing @tatolab/streamlib-deno@$target_version to $GITEA_ORG on $GITEA_URL"
+
+# --- regenerate the escalate wire vocabulary so the artifact is current -------
+# `_generated_/` is a build artifact (gitignored); the published JS bakes it in.
+# `deno task setup` resolves the SDK's schema deps from the local path patches.
+log "regenerating _generated_ (deno task setup)"
+( cd "$PROJECT" && deno task setup ) >/dev/null 2>&1 \
+  || fail "deno task setup (codegen) failed"
+
+# --- pack the SDK into an npm tarball (built JS + .d.ts + package.json) --------
+out="$(mktemp -d)"
+tgz="$out/streamlib-deno.tgz"
+cleanup() { rm -rf "$out"; }
+trap cleanup EXIT
+log "packing (deno pack --set-version $target_version)"
+( cd "$PROJECT" && deno pack --set-version "$target_version" --allow-dirty -o "$tgz" ) \
+  >/dev/null 2>&1 || fail "deno pack failed"
+log "packed: $(cd "$out" && echo *.tgz)"
+
+# --- publish to Gitea's npm registry ------------------------------------------
+# Gitea npm upload is token auth via a scoped .npmrc. A duplicate version
+# returns HTTP 409, which npm surfaces as EPUBLISHCONFLICT — treat as already
+# published and continue (idempotent re-runs, mirrors publish-crates.sh).
+npm_registry="${GITEA_URL}/api/packages/${GITEA_ORG}/npm/"
+# Auth key is the registry URL minus scheme, with a trailing slash.
+auth_host="$(printf '%s' "$npm_registry" | sed -E 's#^https?:##')"
+npmrc="$out/.npmrc"
+cat > "$npmrc" <<EOF
+@${GITEA_ORG}:registry=${npm_registry}
+${auth_host}:_authToken=${GITEA_PUBLISH_TOKEN}
+EOF
+
+# npm refuses to publish a prerelease (`-dev.N`) under the default `latest`
+# dist-tag — route dev publishes to a `dev` tag so `latest` keeps pointing at
+# the newest stable release.
+publish_tag=(--tag latest)
+case "$target_version" in *-*) publish_tag=(--tag dev) ;; esac
+
+if out_log="$(npm publish "$tgz" --userconfig "$npmrc" --registry "$npm_registry" "${publish_tag[@]}" 2>&1)"; then
+  log "  ✓ @tatolab/streamlib-deno@$target_version published"
+elif printf '%s' "$out_log" | grep -qiE 'already exist|conflict|409|EPUBLISHCONFLICT|cannot publish over'; then
+  log "  • @tatolab/streamlib-deno@$target_version already present — skipping"
+else
+  printf '%s\n' "$out_log" >&2
+  fail "npm publish failed"
+fi
+
+log "done — @tatolab/streamlib-deno@$target_version on ${GITEA_ORG} at ${GITEA_URL}"
+log "consumers resolve it via deno.json: \"streamlib\": \"npm:@tatolab/streamlib-deno@^${base_version%%-*}\""
+log "  + .npmrc: @${GITEA_ORG}:registry=${npm_registry}"

--- a/scripts/gitea/smoke-test-deno-sdk.sh
+++ b/scripts/gitea/smoke-test-deno-sdk.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Smoke-test the Deno SDK npm round-trip: publish the SDK to the Gitea npm
+# registry, resolve a bare `import "streamlib"` (+ a subpath) from Gitea in a
+# throwaway consumer, run it, and assert it loaded SDK code from the registry.
+# Then remove the published version.
+#
+# This is the executable form of #1118's exit criterion: "a throwaway Deno
+# module resolves a bare `import "streamlib"` from Gitea and runs." It needs a
+# live Gitea + a Deno toolchain, so it is a local gate (no GPU/registry CI),
+# the Deno sibling of smoke-test-registry.sh.
+#
+# Self-cleaning: publishes a unique throwaway dev version and deletes it.
+#
+# Env:
+#   GITEA_URL              default http://localhost:3300
+#   GITEA_ORG              default tatolab
+#   GITEA_PUBLISH_TOKEN    REQUIRED — a token with write:package (+ delete)
+#   GITEA_PUBLISH_USER     REQUIRED — the token's owner
+#
+# Exit codes: 0 = pass, 1 = fail, 77 = skip (deno/npm unavailable).
+set -euo pipefail
+
+GITEA_URL="${GITEA_URL:-http://localhost:3300}"
+GITEA_ORG="${GITEA_ORG:-tatolab}"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+log()  { printf '[smoke-deno-sdk] %s\n' "$*"; }
+fail() { printf '[smoke-deno-sdk] ERROR: %s\n' "$*" >&2; exit 1; }
+
+[ -n "${GITEA_PUBLISH_TOKEN:-}" ] || fail "set GITEA_PUBLISH_TOKEN (write:package)"
+[ -n "${GITEA_PUBLISH_USER:-}" ]  || fail "set GITEA_PUBLISH_USER (the token's owner)"
+command -v deno >/dev/null 2>&1 || { log "deno not available — skipping"; exit 77; }
+command -v npm  >/dev/null 2>&1 || { log "npm not available — skipping"; exit 77; }
+
+base_version="$(python3 -c "import tomllib;print(tomllib.load(open('$ROOT/Cargo.toml','rb'))['workspace']['package']['version'])")"
+# A throwaway dev tier unlikely to collide with real dev publishes.
+dev_n="99$$"; dev_n="${dev_n:0:6}"
+version="${base_version}-dev.${dev_n}"
+npm_registry="${GITEA_URL}/api/packages/${GITEA_ORG}/npm/"
+auth_host="$(printf '%s' "$npm_registry" | sed -E 's#^https?:##')"
+
+WORK="$(mktemp -d /tmp/deno-sdk-smoke-XXXXXX)"
+cleanup() {
+  curl -s -o /dev/null -X DELETE -H "Authorization: token $GITEA_PUBLISH_TOKEN" \
+    "$GITEA_URL/api/v1/packages/$GITEA_ORG/npm/@${GITEA_ORG}%2Fstreamlib-deno/$version" 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+log "publishing @${GITEA_ORG}/streamlib-deno@$version"
+"$ROOT/scripts/gitea/publish-deno-sdk.sh" --dev "$dev_n" >/dev/null 2>&1 \
+  || fail "publish-deno-sdk.sh failed"
+
+log "resolving a bare \`import \"streamlib\"\` (+ subpath) from Gitea"
+cat > "$WORK/.npmrc" <<EOF
+@${GITEA_ORG}:registry=${npm_registry}
+${auth_host}:_authToken=${GITEA_PUBLISH_TOKEN}
+EOF
+cat > "$WORK/deno.json" <<EOF
+{ "imports": {
+  "streamlib": "npm:@${GITEA_ORG}/streamlib-deno@${version}",
+  "streamlib/": "npm:/@${GITEA_ORG}/streamlib-deno@${version}/"
+} }
+EOF
+cat > "$WORK/use.ts" <<'EOF'
+import { processor, SchemaIdent } from "streamlib";
+import { VulkanContext } from "streamlib/adapters/vulkan.ts";
+// Exercise a pure SDK code path to prove the Gitea-resolved module runs.
+const id = new SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0");
+if (id.toString() !== "@tatolab/core/VideoFrame@1.0.0") throw new Error("SchemaIdent mismatch");
+if (typeof processor !== "function") throw new Error("processor not a function");
+if (typeof VulkanContext !== "function") throw new Error("VulkanContext not resolved");
+console.log("STREAMLIB-FROM-GITEA-OK");
+EOF
+
+out="$(cd "$WORK" && deno run --allow-all --reload use.ts 2>&1)" || {
+  printf '%s\n' "$out" >&2; fail "consumer failed to resolve/run streamlib from Gitea";
+}
+printf '%s' "$out" | grep -q "STREAMLIB-FROM-GITEA-OK" \
+  || { printf '%s\n' "$out" >&2; fail "expected STREAMLIB-FROM-GITEA-OK marker"; }
+
+log "PASS — bare \`import \"streamlib\"\` resolved from Gitea and ran"


### PR DESCRIPTION
## Description

Moves the Deno SDK off the relative `../../../libs/streamlib-deno/...` import baked into every processor `.ts` onto a **declare-and-resolve** model: `@tatolab/streamlib-deno` is published to the self-hosted Gitea **npm** registry by version, a package's `deno.json` declares it, and processors import a stable bare `streamlib` / `streamlib/adapters/…` specifier. Also lands the **engine↔SDK subprocess protocol-version handshake** for Deno (explicitly deferred to this ticket by the Python SDK, #1125). Closes #1118.

## What changed (5 commits — one per checkpoint)

**1 — De-jsr the SDK source.** `@std/path`→`node:path`/`node:url`, `@std/yaml`→npm `yaml`. Required because the npm artifact can't carry `jsr:` deps (see below). `decorators_test` (25) stays green.

**2 — Protocol handshake.** `_protocol.ts` (1:1 port of Python's `_protocol.py`: `PROTOCOL_VERSION=1`, `MIN_ENGINE_PROTOCOL=1`, monotonic range). `subprocess_runner.ts` asserts engine-compat at startup + echoes `protocol_version` in `ready`. `spawn_deno_subprocess_op.rs` injects `STREAMLIB_PROTOCOL_VERSION` + validates the echo via the shared `validate_subprocess_protocol` — identical wiring to the Python-native op; the gate is locked by the existing `subprocess_bridge` test.

**3 — Package + publish.** `scripts/gitea/publish-deno-sdk.sh` (twin of `publish-python-sdk.sh`): version from the workspace `Cargo.toml`, regenerate the escalate wire-vocab, `deno pack --set-version`, `npm publish` the tarball to Gitea (prerelease → `dev` dist-tag, idempotent on 409, deno≥2.8 gate). `deno.json` `exports` expanded to the full public surface. Plus `scripts/gitea/smoke-test-deno-sdk.sh` — the executable form of the exit criterion.

**4 — Engine resolves the runner from the registry.** `spawn_deno_subprocess_op.rs` launches `deno run --config <package>/deno.json streamlib/subprocess_runner.ts` — `streamlib` (the runner *and* the processor's `import "streamlib"`) resolves through the package's `deno.json` + sibling `.npmrc`. Replaces the workspace-path resolution (the Deno equivalent of the old PYTHONPATH magic); `resolve_deno_sdk_path` is removed. Direct mirror of the Python op running `-m streamlib.subprocess_runner` from the registry-installed venv — no workspace path, no env escape hatch.

**5 — Sweep + docs.** All 11 Deno example processors → bare `streamlib`; each `deno.json` declares `streamlib` + a sibling `.npmrc`. The arch doc's Deno row → shipped, with the built-JS rationale.

## Why a built-JS npm artifact (not source like cargo/pypi)

Empirically verified: **Deno cannot consume a `.ts` package via the `npm:` protocol** — `node_modules` forbids type-stripping (`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`) and `jsr:` schemes (`ERR_UNSUPPORTED_ESM_URL_SCHEME`). So the npm channel ships transpiled JS + `.d.ts` via Deno's purpose-built `deno pack` (Deno 2.8+, publish-host only — consumers/runtime get plain JS on any Deno). `@tatolab` resolves from Gitea; external deps (`@msgpack/msgpack`, `yaml`) from public npm — the same split Rust uses.

## Tests / validation

- **Unit:** 7 Deno `_protocol` tests; 25 `decorators` tests; 110 SDK unit tests pass (7 `clock_test` need the built native cdylib — environmental); 78 engine `subprocess` tests incl. the handshake gate `subprocess_protocol_gate_accepts_supported_and_rejects_others`. `cargo check -p streamlib` clean (on this `main`-rebased branch).
- **Round-trip (live local Gitea):** `smoke-test-deno-sdk.sh` — publish → resolve a bare `import "streamlib"` (+ subpath) → run → `STREAMLIB-FROM-GITEA-OK` → cleanup. Exit 0. (`@tatolab/streamlib-deno` from `localhost:3300`; `@msgpack`/`yaml` from npmjs.)
- **Type-level:** `deno check` on a swept example resolves bare `streamlib` from Gitea and type-checks against the published `.d.ts`.
- **Runner launch:** `deno run --config <proj>/deno.json streamlib/subprocess_runner.ts` resolves the runner from Gitea and runs.

Pre-open review gate (independent Opus reviewer): **PASS**, no issues — verified de-jsr semantic equivalence, the `log.ts` timer-type change, the handshake being genuinely locked (both directions, mental-revert check), publish-script mirroring, the clean `resolve_deno_sdk_path` removal, and exports coverage.

## Scope boundary / deferrals

- **Deno *package* distribution** (`streamlib pkg publish` bundling a Deno source tree, orchestrator `provision_deno_sdk` / `deno install`, `add_module` materialization) is **out of scope** — that's the package concern, a separate issue. This PR is the SDK *library*.
- **Full in-engine pipeline E2E** (engine spawns the Deno subprocess end-to-end) isn't runnable in-workspace: examples are de-workspaced (standalone, registry-resolved) — a known milestone state, not a regression. The handshake + runner-launch + resolution are validated by the unit tests + smoke test + direct runner-launch run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)