### PR TITLE
feat(1119): anonymous generic-registry version index + bulk package publish

### DIFF
--- a/docs/architecture/gitea-registry-distribution.md
+++ b/docs/architecture/gitea-registry-distribution.md
@@ -1,16 +1,13 @@
 # Unified Gitea registry — distribution & dependency resolution
 
-> **Decided architecture, validated by POC, in active migration.** This is the
-> committed shape for how every StreamLib-authored and -customized artifact is
-> distributed and resolved. It is documented ahead of full implementation **on
-> purpose** — so the issues that land it follow one design instead of
-> re-inventing resolution. Sections tagged **(finalized in #N)** are being
-> implemented by that issue, which completes the corresponding section as it
-> merges. Work lives under the **"Gitea Package Registry"** milestone.
->
-> This doc is an explicit exception to the "architecture docs describe merged
-> code only" discipline — granted by the principal architect so the design is
-> known up front. Validated-vs-in-flight status is tracked in the last section.
+> **Living document.** Validate, update, critique freely per
+> [CLAUDE.md's markdown editing rules](../../CLAUDE.md#editing-markdown-documentation).
+
+Every StreamLib-authored **or customized** artifact is distributed and resolved
+through a single self-hosted Gitea instance, by version — never by relative
+`path` or git `[patch]` in anything a consumer sees. SDK libraries resolve from
+Gitea's cargo / pypi / npm registries; packages are source-only `.slpkg`s in
+its generic registry.
 
 ## The model in one picture
 
@@ -20,7 +17,7 @@
    │  cargo registry     pypi registry     npm registry         │  ← SDK libraries
    │  (rust SDK crates)  (python SDK)      (deno SDK)            │    resolved by version
    │                                                            │
-   │  generic registry  ── source-only .slpkg (via streamlib pack) ─┐ ← packages
+   │  generic registry  ── source-only .slpkg (streamlib pkg publish) ─┐ ← packages
    └───────────────────────────────────────────────────────────┘  │   (polyglot)
             ▲ publish (release step)            ▲ resolve by version │
             │                                   │                     │
@@ -39,7 +36,7 @@ go through Gitea.
 | Kind | What | Registry | Produced by |
 |---|---|---|---|
 | **SDK library** | the code a package compiles/runs *against*: rust `streamlib` crate chain, python `streamlib` pkg, deno `@tatolab/streamlib-deno` | cargo / pypi / npm | normal per-language publish |
-| **Package** | a streamlib package (polyglot: rust + python + deno), loaded by `runtime.add_module` | **generic** (as `.slpkg`) | **`streamlib pack`, source-only** |
+| **Package** | a streamlib package (polyglot: rust + python + deno), loaded by `runtime.add_module` | **generic** (as `.slpkg`) | **`streamlib pkg publish`, source-only** |
 
 The distinction is load-bearing: SDK libraries are versioned registry
 dependencies; packages are **source-only `.slpkg`s** in the generic registry
@@ -100,10 +97,13 @@ streamlib-engine = { path = "../streamlib-engine", version = "0.4.30", registry 
   after install via in-process JTD codegen, with schema deps (`@tatolab/core`,
   `@tatolab/escalate`) resolved from the generic registry. Running an example or
   `streamlib pkg install` therefore needs **both** registry env channels set
-  (`UV_INDEX` for the pypi install; `STREAMLIB_REGISTRY_URL` +
-  `STREAMLIB_REGISTRY_TOKEN` for the codegen's generic-registry resolution) —
-  see [`../learnings/polyglot-venv-gitea-registry-env.md`](../learnings/polyglot-venv-gitea-registry-env.md)
-  for the failure symptoms when they're missing. Engine and SDK agree on a monotonic, language-agnostic
+  (`UV_INDEX` for the pypi install; `STREAMLIB_REGISTRY_URL` for the codegen's
+  generic-registry resolution) — see
+  [`../learnings/polyglot-venv-gitea-registry-env.md`](../learnings/polyglot-venv-gitea-registry-env.md)
+  for the failure symptoms when they're missing. The generic-registry read path
+  (version index + `.slpkg` download) is anonymous, so no
+  `STREAMLIB_REGISTRY_TOKEN` is needed to resolve — the token is publish-only.
+  Engine and SDK agree on a monotonic, language-agnostic
   **subprocess protocol version** (`STREAMLIB_SUBPROCESS_PROTOCOL_VERSION` ↔
   `streamlib.PROTOCOL_VERSION`), handshaken at subprocess startup and fail-loud
   on mismatch — the replacement for the old compatibility-by-injection
@@ -174,7 +174,7 @@ index (`list_versions_http`); the management API is used only on the publish
 path. Generic *download* was already anonymous, so the whole read path (list
 + download) is tokenless and the registry token is publish-only.
 
-## Schema-package resolution (resolver + strip capability + cargo-publish wiring shipped)
+## Schema-package resolution
 
 `streamlib.yaml` schema dependencies (e.g. `@tatolab/escalate`) are themselves
 packages — they resolve from Gitea's **generic** registry: list the schema
@@ -211,13 +211,11 @@ mirroring cargo:
    resolves `@tatolab/escalate` from the generic registry (the schema package
    published as a source `.slpkg`) and the engine compiles.
 
-   > ~~`streamlib pack`'s `RejectPathPatches` strips the dev `path:` patch.~~
-   > — Corrected 2026-05-30 (#1116): `RejectPathPatches` *rejects* a path
-   > patch with a hard error (a distributed source `.slpkg` must not carry a
-   > dev override); it never stripped. The cargo-publish case genuinely needs
-   > a *strip* — the path patch is a legitimate dev affordance locally but
-   > must be removed from the published manifest — so `strip_path_patches` is
-   > new code, the publish-side counterpart to `RejectPathPatches`.
+   `strip_path_patches` is distinct from `streamlib-pack`'s `RejectPathPatches`:
+   the latter *rejects* a path patch with a hard error (a distributed source
+   `.slpkg` must not carry a dev override), while the cargo-publish case needs a
+   *strip* — the path patch is a legitimate dev affordance locally but must be
+   removed from the published manifest.
 
 This is the schema-tier twin of the cargo-crate resolution. The resolver is
 shared by all three runtimes' codegen, so the one fix covers rust/python/deno.
@@ -256,13 +254,10 @@ Notes the scripts encode:
 - cargo token must be stored as `Bearer <token>` in `credentials.toml`
   (`cargo login` stores it bare → 401).
 - The **sparse** cargo index needs no setup: the registry is reachable once
-  the org exists and the first publish populates the DB-backed index.
-
-  > ~~cargo index needs a one-time web-session init
-  > (`/user/settings/packages/cargo/initialize`).~~ — Superseded 2026-05-29.
-  > That step belongs to Gitea's older **git-based** cargo index. The
-  > committed shape uses the sparse protocol (`sparse+…`), which Gitea serves
-  > from the package DB with no `_cargo-index` repo and no initialize call.
+  the org exists and the first publish populates the DB-backed index. (The
+  one-time web-session init `/user/settings/packages/cargo/initialize` belongs
+  to Gitea's older **git-based** cargo index — the sparse protocol Gitea serves
+  from the package DB needs no `_cargo-index` repo and no initialize call.)
 - The generic registry (the `.slpkg` home) requires a **raw** request body on
   upload (`curl --upload-file`); a urlencoded body (`curl --data`) is rejected
   with HTTP 500.
@@ -276,27 +271,10 @@ Notes the scripts encode:
   exclude `dev-dependencies` (cargo strips bare-path dev-deps on publish;
   annotating them creates publish-order cycles, e.g. engine dev-deps streamlib).
 
-## Validated vs in-flight
-
-| Piece | Status | Issue |
-|---|---|---|
-| cargo publish → resolve-by-version (real SDK chain + vulkanalia/VMA) | ✅ shipped | #1105 |
-| `.slpkg` round-trip through the generic registry | ✅ validated (POC) | #1119 |
-| `tatolab` org namespace + POC cleanup | ✅ shipped | #1115 |
-| schema-package registry resolution (resolver `Registry` arm) + `strip_path_patches` capability | ✅ shipped | #1116 |
-| cargo-publish manifest path-strip *wiring* (dev-publish script + manifest migration) | ✅ shipped | #1105 |
-| full-engine codegen consumer build (engine `build.rs` resolves `@tatolab/escalate` from the generic registry) | ✅ shipped | #1105 |
-| Python SDK publish (source-only) + declare/install-from-registry, protocol-version handshake, codegen-into-venv | ✅ shipped | #1117 |
-| Deno SDK publish (built JS via `deno pack`) + declare/resolve-from-npm, protocol-version handshake | ✅ shipped | #1118 |
-| packages as source-only `.slpkg` (`streamlib pkg build`/`publish`, bulk publish script) + anonymous version index (tokenless read) | ✅ shipped | #1119 |
-| repo migration committed (`{ path, version, registry }`, `.cargo/config`, dev-publish script) | ✅ shipped | #1105 |
-
 ## Reference
 
-- Milestone: **Gitea Package Registry**.
-- Downstream: #1114 (package/example repo split — packages become version
-  consumers of the published `streamlib`); the `.deb`/Docker work syncs
-  against Gitea.
-- Related: `docs/architecture/runtime-module-materialization.md` (how
-  `add_module` builds a source module — its SDK-resolution role becomes
-  "resolve from the Gitea registry" under this model).
+- `docs/architecture/runtime-module-materialization.md` — how `add_module`
+  builds a source module, resolving its SDK dependencies from the Gitea
+  registry.
+- `docs/learnings/polyglot-venv-gitea-registry-env.md` — failure symptoms when
+  the registry env channels aren't set for a polyglot build.

--- a/docs/architecture/gitea-registry-distribution.md
+++ b/docs/architecture/gitea-registry-distribution.md
@@ -140,18 +140,39 @@ Gitea and resolved by `{ version, registry = "gitea" }`. The workspace's
 shares crates.io version numbers, so the `registry` annotation (not a distinct
 version) is what selects the fork over upstream.
 
-## Packages: source-only `.slpkg`s (finalized in #1119)
+## Packages: source-only `.slpkg`s
 
-`streamlib pack` produces **source-only** `.slpkg`s — the prebuilt per-triple
-cdylib it bundles today is dropped, because a package is polyglot and source
-is the uniform shape. Every `packages/*` is published as a source `.slpkg` to
-Gitea's generic registry under `tatolab`. A host `add_module`s one, and its
-rust/python/deno code builds on the host resolving the SDK libraries from
-Gitea by version.
+`streamlib pkg build` / `streamlib pkg publish` produce **source-only**
+`.slpkg`s — no prebuilt per-triple cdylib, because a package is polyglot and
+source is the uniform shape. The `Slpkg` assemble target ships source only
+(`streamlib-pack`); only the runtime orchestrator's `StagedDir` target
+compiles a cdylib, because that materialization *is* the host build. Every
+`packages/*` is published as a source `.slpkg` to Gitea's generic registry
+under `tatolab` (`scripts/gitea/publish-packages.sh` loops the set, shelling
+out to `streamlib pkg publish`). A host `add_module`s one via
+`Strategy::Registry`, and its rust/python/deno code builds on the host
+resolving the SDK libraries from Gitea by version.
 
-> Trade-off to confirm in #1119: a source-only `.slpkg` requires a toolchain
-> on the consuming host to build the rust cdylib — weigh against the
-> compiler-free-deployment goal.
+A source-only `.slpkg` requires a Rust toolchain on the consuming host to
+build the cdylib — the accepted trade-off for the polyglot/uniform-source
+shape; compiler-free deployment is a separate prebuilt-distribution concern,
+not the package-registry path.
+
+### Anonymous version index
+
+Reads are tokenless, matching cargo's sparse index. The generic registry has
+no native version-listing query — Gitea's `/api/v1/packages` management API
+`401`s anonymously — so each publish writes a **cargo-sparse-shaped version
+index** as a plain generic file at
+`/api/packages/{org}/generic/{name}/index/index.json` (NDJSON, one
+`{"name","vers"}` line per version), anonymously downloadable like any
+generic file. `streamlib pkg publish` recomputes that index from the authed
+management listing unioned with the just-published version — every publish
+rewrites the full correct index, so a stale or missing index self-heals on
+the next publish. `streamlib_idents`' resolver lists versions by reading the
+index (`list_versions_http`); the management API is used only on the publish
+path. Generic *download* was already anonymous, so the whole read path (list
++ download) is tokenless and the registry token is publish-only.
 
 ## Schema-package resolution (resolver + strip capability + cargo-publish wiring shipped)
 
@@ -160,10 +181,11 @@ packages — they resolve from Gitea's **generic** registry: list the schema
 package's versions, select the highest satisfying the declared semver range,
 fetch that version's `.slpkg`, extract, resolve. The flat generic registry
 has no semver-range query, so range → concrete version happens client-side
-(cargo/npm/pip shape) via Gitea's package-management API
-(`GET /api/v1/packages/{org}?type=generic`), and the resolved concrete
-version is pinned in `streamlib.lock` via `ResolvedSource::Registry`. Two
-halves, mirroring cargo:
+(cargo/npm/pip shape) by reading the package's anonymous version index
+(`/api/packages/{org}/generic/{name}/index/index.json`, see [Anonymous
+version index](#anonymous-version-index)), and the resolved concrete version
+is pinned in `streamlib.lock` via `ResolvedSource::Registry`. Two halves,
+mirroring cargo:
 
 1. **Consume side:** `streamlib-idents`' resolver implements the `Registry`
    arm — list → select-highest-in-range → fetch + `extract_slpkg` → load. The
@@ -266,7 +288,7 @@ Notes the scripts encode:
 | full-engine codegen consumer build (engine `build.rs` resolves `@tatolab/escalate` from the generic registry) | ✅ shipped | #1105 |
 | Python SDK publish (source-only) + declare/install-from-registry, protocol-version handshake, codegen-into-venv | ✅ shipped | #1117 |
 | Deno SDK publish (built JS via `deno pack`) + declare/resolve-from-npm, protocol-version handshake | ✅ shipped | #1118 |
-| packages as source-only `.slpkg` + `streamlib pack` source-only | ⏳ | #1119 |
+| packages as source-only `.slpkg` (`streamlib pkg build`/`publish`, bulk publish script) + anonymous version index (tokenless read) | ✅ shipped | #1119 |
 | repo migration committed (`{ path, version, registry }`, `.cargo/config`, dev-publish script) | ✅ shipped | #1105 |
 
 ## Reference

--- a/libs/streamlib-engine/src/core/runtime/module_loader/source.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/source.rs
@@ -93,16 +93,19 @@ pub enum Strategy {
 
     /// Resolve from the configured Gitea **generic** registry by semver
     /// requirement — the cross-repo consumer path. Lists the package's
-    /// published versions (`GET /api/v1/packages/{org}?type=generic`),
+    /// published versions from its anonymous, cargo-sparse-shaped version
+    /// index (`/api/packages/{org}/generic/{name}/index/index.json`),
     /// selects the highest satisfying `version_req` (cargo/npm semantics),
     /// downloads that version's `.slpkg`, then resolves it exactly like
     /// [`Strategy::Url`]: prefer a matching prebuilt, else build the bundled
     /// source per `build`.
     ///
-    /// The registry endpoint + optional read token come from the
-    /// environment (`STREAMLIB_REGISTRY_URL`, falling back to `GITEA_URL`;
-    /// optional `STREAMLIB_REGISTRY_TOKEN`) — the same config the engine's
-    /// schema codegen reads, via [`RegistryConfig::from_env`]. The package
+    /// The registry endpoint comes from the environment
+    /// (`STREAMLIB_REGISTRY_URL`, falling back to `GITEA_URL`) — the same
+    /// config the engine's schema codegen reads, via
+    /// [`RegistryConfig::from_env`]. The read path (list + download) is
+    /// anonymous; `STREAMLIB_REGISTRY_TOKEN` is only needed to publish (and
+    /// is sent on reads when set, for private registries). The package
     /// org + name come from the requested module ident. Absent registry
     /// config fails loud with [`AddModuleError::RegistryNotConfigured`]
     /// rather than silently falling back to a local source.

--- a/libs/streamlib-idents/src/registry.rs
+++ b/libs/streamlib-idents/src/registry.rs
@@ -8,16 +8,25 @@
 //! `Registry` dependency by a semver *range* requires two steps the flat
 //! generic registry can't do in one request:
 //!
-//! 1. **List** the available concrete versions of the package
-//!    (Gitea's package-management API), then select the highest one that
-//!    satisfies the declared range — cargo/npm/pip semantics.
+//! 1. **List** the available concrete versions of the package, then select
+//!    the highest one that satisfies the declared range — cargo/npm/pip
+//!    semantics.
 //! 2. **Download** that version's `.slpkg` from the generic registry's
 //!    by-version download namespace.
+//!
+//! Both steps are **anonymous** on a public registry, matching cargo's
+//! sparse index. The generic registry has no native version-listing query
+//! (Gitea's `/api/v1/packages` management API `401`s anonymously), so each
+//! publish writes a cargo-sparse-shaped **version index** as a plain generic
+//! file at `<base>/api/packages/<org>/generic/<name>/index/index.json`
+//! (anonymously downloadable like any generic file). The list step reads
+//! that index; the only token-requiring path is **publish**.
 //!
 //! `http(s)://` is the production transport; `file://` is the hermetic
 //! local-mirror / test transport (mirroring the engine's remote-`.slpkg`
 //! fetch), where the base URL points at a directory laid out as
-//! `<base>/<name>/<version>/<name>.slpkg`.
+//! `<base>/<name>/<version>/<name>.slpkg` (the `file://` list step
+//! enumerates the per-version subdirectories directly — no index file).
 
 use std::path::{Path, PathBuf};
 
@@ -31,9 +40,10 @@ use crate::semver::SemVer;
 pub const REGISTRY_URL_ENV: &str = "STREAMLIB_REGISTRY_URL";
 const REGISTRY_URL_ENV_FALLBACK: &str = "GITEA_URL";
 
-/// Environment variable carrying an optional read token for the
-/// package-management API (private registries). Read is anonymous on a
-/// public registry, so this is usually unset.
+/// Environment variable carrying the registry credential. The read path
+/// (list + download) is anonymous on a public registry, so this is **only**
+/// required to *publish*; it is also sent on reads when set, for private
+/// registries that gate generic downloads behind auth.
 pub const REGISTRY_TOKEN_ENV: &str = "STREAMLIB_REGISTRY_TOKEN";
 
 /// Resolved configuration for the Gitea generic registry.
@@ -163,8 +173,53 @@ impl<'a> RegistryClient<'a> {
             );
             http_delete(&version_url, self.config.token.as_deref());
             http_put_bytes(&url, self.config.token.as_deref(), bytes).map_err(upload_err)?;
+            // Maintain the anonymous version index so the read path lists
+            // versions tokenless. Recompute from the authed management
+            // listing unioned with the just-published version — every publish
+            // rewrites the full correct index, so a missed or stale index
+            // self-heals on the next publish.
+            self.write_version_index(pkg_ref, version)?;
         }
         Ok(url)
+    }
+
+    /// Rewrite the anonymous version index for `pkg_ref` after a publish.
+    /// The index is the union of the authed management-API listing and the
+    /// `just_published` version (covers any management-API propagation lag),
+    /// serialized as cargo-sparse-shaped NDJSON and uploaded (delete-then-PUT,
+    /// since the `index` pseudo-version is immutable per generic-file rules).
+    ///
+    /// Ordering note: [`Self::upload_slpkg`] PUTs the artifact *before* calling
+    /// this, so a failure here surfaces as an `Err` even though the `.slpkg` is
+    /// already published and downloadable — the package just isn't *listable*
+    /// until its index lands. This is deliberately a hard failure (the index is
+    /// the read path; an unlistable artifact isn't resolvable) and is fully
+    /// recoverable: re-running publish is idempotent and rewrites the full
+    /// correct index from the management listing.
+    fn write_version_index(
+        &self,
+        pkg_ref: &PackageRef,
+        just_published: SemVer,
+    ) -> ResolverResult<()> {
+        let upload_err = |detail: String| ResolverError::RegistryFetchFailed {
+            name: pkg_ref.to_string(),
+            detail,
+        };
+        let mut versions = self.list_versions_via_management_api(pkg_ref)?;
+        versions.push(just_published);
+        let versions = merge_versions(versions);
+        let body = render_index_ndjson(pkg_ref.name.as_str(), &versions);
+        // Drop the prior `index` pseudo-version, then PUT the fresh index.
+        let index_version_url = format!(
+            "{}/api/v1/packages/{}/generic/{}/index",
+            self.config.base_url,
+            pkg_ref.org.as_str(),
+            pkg_ref.name.as_str(),
+        );
+        http_delete(&index_version_url, self.config.token.as_deref());
+        http_put_bytes(&self.index_url(pkg_ref), self.config.token.as_deref(), body.as_bytes())
+            .map_err(|detail| upload_err(format!("publishing version index: {detail}")))?;
+        Ok(())
     }
 
     /// Canonical generic-registry download URL (recorded in the lockfile).
@@ -189,7 +244,49 @@ impl<'a> RegistryClient<'a> {
             .join(format!("{name}.slpkg"))
     }
 
+    /// Anonymous version-index URL — a plain generic file under the literal
+    /// `index` pseudo-version. Downloaded tokenless like any generic file;
+    /// the `index` segment is not a semver, so the `.slpkg` version namespace
+    /// can never collide with it.
+    fn index_url(&self, pkg_ref: &PackageRef) -> String {
+        format!(
+            "{}/api/packages/{}/generic/{}/index/index.json",
+            self.config.base_url,
+            pkg_ref.org.as_str(),
+            pkg_ref.name.as_str(),
+        )
+    }
+
+    /// List versions by reading the anonymous, cargo-sparse-shaped version
+    /// index (`index/index.json`). No token is required on a public registry;
+    /// the configured token is still sent when set, for private registries
+    /// that gate generic downloads. A `404` (no index published yet) yields
+    /// an empty list — parity with `file://`'s missing-directory case — so
+    /// `select_version` reports `RegistryNoMatchingVersion` rather than a
+    /// transport error.
     fn list_versions_http(&self, pkg_ref: &PackageRef) -> ResolverResult<Vec<SemVer>> {
+        let url = self.index_url(pkg_ref);
+        let body = match http_get_optional(&url, self.config.token.as_deref()) {
+            Ok(Some(body)) => body,
+            Ok(None) => return Ok(Vec::new()),
+            Err(detail) => {
+                return Err(ResolverError::RegistryFetchFailed {
+                    name: pkg_ref.to_string(),
+                    detail: format!("listing versions: {detail}"),
+                })
+            }
+        };
+        Ok(parse_index_ndjson(&body, pkg_ref.name.as_str()))
+    }
+
+    /// List versions via Gitea's **authed** package-management API. Used only
+    /// on the publish path to recompute the anonymous index — never on the
+    /// read path (the management API `401`s anonymously). `index` and any
+    /// other non-semver pseudo-version is dropped by the semver parse.
+    fn list_versions_via_management_api(
+        &self,
+        pkg_ref: &PackageRef,
+    ) -> ResolverResult<Vec<SemVer>> {
         let name = pkg_ref.name.as_str();
         let url = format!(
             "{}/api/v1/packages/{}?type=generic&q={}",
@@ -265,6 +362,71 @@ pub fn select_version(
                 available: sorted.join(", "),
             }
         })
+}
+
+/// One line of the cargo-sparse-shaped version index — `{"name","vers"}`
+/// per version. Extra fields a future index might carry (checksum, yanked)
+/// are ignored on read, so the shape can grow without breaking older readers.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct VersionIndexLine {
+    name: String,
+    vers: String,
+}
+
+/// Render a sorted version list as NDJSON (one `{"name","vers"}` object per
+/// line, trailing newline) — the byte shape published to `index/index.json`.
+fn render_index_ndjson(name: &str, versions: &[SemVer]) -> String {
+    let mut out = String::new();
+    for v in versions {
+        let line = VersionIndexLine {
+            name: name.to_string(),
+            vers: v.to_string(),
+        };
+        // Serializing a struct of two owned strings is infallible.
+        out.push_str(&serde_json::to_string(&line).expect("serialize version index line"));
+        out.push('\n');
+    }
+    out
+}
+
+/// Parse NDJSON index bytes into the semvers whose `name` matches `name`.
+/// Blank lines and unparseable lines/versions are skipped, so a partially
+/// corrupt index degrades to "fewer versions" rather than a hard failure.
+fn parse_index_ndjson(body: &[u8], name: &str) -> Vec<SemVer> {
+    String::from_utf8_lossy(body)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str::<VersionIndexLine>(l).ok())
+        .filter(|e| e.name == name)
+        .filter_map(|e| SemVer::from_dotted(&e.vers).ok())
+        .collect()
+}
+
+/// Sort ascending + dedup a version list (the index is canonicalized this way
+/// before publish so republishes are byte-stable and reads are ordered).
+fn merge_versions(mut versions: Vec<SemVer>) -> Vec<SemVer> {
+    versions.sort();
+    versions.dedup();
+    versions
+}
+
+/// Blocking GET that distinguishes a `404` (`Ok(None)`) from a real transport
+/// or non-404 status error (`Err`). Used for the optional version index.
+fn http_get_optional(url: &str, token: Option<&str>) -> Result<Option<Vec<u8>>, String> {
+    let mut req = ureq::get(url);
+    if let Some(t) = token {
+        req = req.set("Authorization", &format!("token {t}"));
+    }
+    match req.call() {
+        Ok(response) => {
+            let mut bytes = Vec::new();
+            std::io::Read::read_to_end(&mut response.into_reader(), &mut bytes)
+                .map_err(|e| format!("reading HTTP response body from {url}: {e}"))?;
+            Ok(Some(bytes))
+        }
+        Err(ureq::Error::Status(404, _)) => Ok(None),
+        Err(e) => Err(format!("HTTP request to {url} failed: {e}")),
+    }
 }
 
 /// Blocking GET of `url`'s raw body. `token` is sent as a Gitea
@@ -410,37 +572,39 @@ mod tests {
         );
     }
 
-    /// Locks the production `http://` path end-to-end against a one-shot
-    /// localhost server: the management-API list URL + Gitea JSON shape
-    /// (`list_versions_http`) and the generic download URL
-    /// (`download_slpkg`). A typo in either URL or in the `GiteaPackageEntry`
-    /// field names would only surface against a real Gitea without this.
+    /// Locks the production `http://` **read** path end-to-end against a
+    /// one-shot localhost server, with **no token configured** — the
+    /// tokenless read the sparse index exists to enable. The list step reads
+    /// the anonymous `index/index.json` (NDJSON) and the download step reads
+    /// the generic-file URL. Mentally revert `list_versions_http` to the
+    /// authed `/api/v1/packages` management API: against a real public Gitea
+    /// the no-token list `401`s, so this locks the tokenless contract rather
+    /// than merely exercising a happy path.
     #[test]
     fn http_list_and_download_against_localhost() {
         use std::io::{Read, Write};
 
         let slpkg_body = b"slpkg-zip-bytes".to_vec();
-        // Gitea `GET /api/v1/packages/{owner}?type=generic` response shape.
-        let list_json = r#"[
-            {"name":"escalate","version":"1.0.0","type":"generic"},
-            {"name":"escalate","version":"1.2.0","type":"generic"},
-            {"name":"other","version":"9.9.9","type":"generic"}
-        ]"#
-        .to_string();
+        // Anonymous version-index (NDJSON) body. A foreign-named line is
+        // included to prove the name filter drops it.
+        let index_ndjson = "{\"name\":\"escalate\",\"vers\":\"1.0.0\"}\n\
+             {\"name\":\"escalate\",\"vers\":\"1.2.0\"}\n\
+             {\"name\":\"other\",\"vers\":\"9.9.9\"}\n"
+            .to_string();
 
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         let slpkg_for_server = slpkg_body.clone();
         let server = std::thread::spawn(move || {
-            // Serve exactly two requests: the version list, then the download.
+            // Serve exactly two requests: the index read, then the download.
             for _ in 0..2 {
                 let (mut stream, _) = listener.accept().unwrap();
                 let mut buf = [0u8; 2048];
                 let n = stream.read(&mut buf).unwrap();
                 let req = String::from_utf8_lossy(&buf[..n]);
                 let request_line = req.lines().next().unwrap_or("");
-                let body: Vec<u8> = if request_line.contains("/api/v1/packages/") {
-                    list_json.clone().into_bytes()
+                let body: Vec<u8> = if request_line.contains("/index/index.json") {
+                    index_ndjson.clone().into_bytes()
                 } else {
                     slpkg_for_server.clone()
                 };
@@ -456,12 +620,12 @@ mod tests {
 
         let cfg = RegistryConfig {
             base_url: format!("http://127.0.0.1:{port}"),
-            token: None,
+            token: None, // <-- no token: the whole point of the sparse index.
         };
         let client = RegistryClient::new(&cfg);
         let pr = pkg_ref("tatolab", "escalate");
 
-        // Management API: only matching-name generic entries are returned.
+        // Index read: only matching-name lines are returned, sorted-as-served.
         let versions = client.list_versions(&pr).unwrap();
         assert_eq!(versions, vec![SemVer::new(1, 0, 0), SemVer::new(1, 2, 0)]);
 
@@ -474,5 +638,168 @@ mod tests {
         );
 
         server.join().unwrap();
+    }
+
+    /// A `404` on the index (no version published yet) yields an empty list,
+    /// not a transport error — parity with `file://`'s missing-directory case.
+    #[test]
+    fn http_list_missing_index_yields_empty() {
+        use std::io::{Read, Write};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 1024];
+            let _ = stream.read(&mut buf).unwrap();
+            let resp = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+            stream.write_all(resp.as_bytes()).unwrap();
+            stream.flush().unwrap();
+        });
+
+        let cfg = RegistryConfig {
+            base_url: format!("http://127.0.0.1:{port}"),
+            token: None,
+        };
+        let client = RegistryClient::new(&cfg);
+        let versions = client.list_versions(&pkg_ref("tatolab", "nope")).unwrap();
+        assert!(versions.is_empty(), "404 index must list as empty, got {versions:?}");
+        server.join().unwrap();
+    }
+
+    /// NDJSON render → parse is a faithful round-trip, name-filtered.
+    #[test]
+    fn index_ndjson_render_parse_round_trip() {
+        let versions = vec![SemVer::new(0, 4, 32), SemVer::new(0, 4, 33), SemVer::new(1, 0, 0)];
+        let rendered = render_index_ndjson("camera", &versions);
+        // One line per version, trailing newline, cargo-sparse `vers` field.
+        assert_eq!(rendered.lines().count(), 3);
+        assert!(rendered.contains("\"vers\":\"0.4.33\""));
+        assert!(rendered.ends_with('\n'));
+        let parsed = parse_index_ndjson(rendered.as_bytes(), "camera");
+        assert_eq!(parsed, versions);
+        // A line for a different package name is dropped by the filter.
+        let mixed = format!("{rendered}{{\"name\":\"display\",\"vers\":\"9.9.9\"}}\n");
+        assert_eq!(parse_index_ndjson(mixed.as_bytes(), "camera"), versions);
+        // Blank lines and garbage degrade gracefully (skipped, not fatal).
+        let dirty = format!("\n{rendered}not-json\n");
+        assert_eq!(parse_index_ndjson(dirty.as_bytes(), "camera"), versions);
+    }
+
+    #[test]
+    fn merge_versions_sorts_and_dedups() {
+        let merged = merge_versions(vec![
+            SemVer::new(1, 2, 0),
+            SemVer::new(1, 0, 0),
+            SemVer::new(1, 2, 0),
+            SemVer::new(0, 9, 9),
+        ]);
+        assert_eq!(
+            merged,
+            vec![SemVer::new(0, 9, 9), SemVer::new(1, 0, 0), SemVer::new(1, 2, 0)]
+        );
+    }
+
+    /// Locks the **publish** path: `upload_slpkg` PUTs the `.slpkg`, then
+    /// recomputes the version index from the authed management listing unioned
+    /// with the just-published version and PUTs it to `index/index.json`. A
+    /// stateful localhost server records every request; we assert the index
+    /// PUT body is canonical NDJSON containing both the pre-existing version
+    /// and the new one. Mentally revert the `write_version_index` call in
+    /// `upload_slpkg`: no index PUT is recorded and the assertion fails.
+    #[test]
+    fn upload_writes_version_index_round_trip() {
+        use std::io::{Read, Write};
+        use std::sync::mpsc;
+
+        // The management API reports one pre-existing version; the publish is
+        // a new, higher version. The index must end up holding the union.
+        let mgmt_json = r#"[{"name":"camera","version":"0.4.32","type":"generic"}]"#;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (tx, rx) = mpsc::channel::<(String, String, Vec<u8>)>();
+        let mgmt = mgmt_json.to_string();
+        let server = std::thread::spawn(move || {
+            // upload_slpkg → 5 requests: DELETE slpkg ver, PUT slpkg,
+            // GET mgmt list, DELETE index ver, PUT index.
+            for _ in 0..5 {
+                let (mut stream, _) = listener.accept().unwrap();
+                // Read the full request: headers, then exactly Content-Length
+                // body bytes (a single `read` can split header from body).
+                let mut raw = Vec::new();
+                let mut chunk = [0u8; 4096];
+                let header_end = loop {
+                    let n = stream.read(&mut chunk).unwrap();
+                    if n == 0 {
+                        break raw.windows(4).position(|w| w == b"\r\n\r\n");
+                    }
+                    raw.extend_from_slice(&chunk[..n]);
+                    if let Some(pos) = raw.windows(4).position(|w| w == b"\r\n\r\n") {
+                        let header_str = String::from_utf8_lossy(&raw[..pos]).to_lowercase();
+                        let want = header_str
+                            .split("content-length:")
+                            .nth(1)
+                            .and_then(|s| s.split("\r\n").next())
+                            .and_then(|s| s.trim().parse::<usize>().ok())
+                            .unwrap_or(0);
+                        if raw.len() - (pos + 4) >= want {
+                            break Some(pos);
+                        }
+                    }
+                };
+                let pos = header_end.unwrap_or(raw.len().saturating_sub(0));
+                let head = String::from_utf8_lossy(&raw[..pos]).to_string();
+                let request_line = head.lines().next().unwrap_or("").to_string();
+                let method = request_line.split(' ').next().unwrap_or("").to_string();
+                let path = request_line.split(' ').nth(1).unwrap_or("").to_string();
+                let body: Vec<u8> = raw.get(pos + 4..).map(|b| b.to_vec()).unwrap_or_default();
+                tx.send((method.clone(), path.clone(), body)).unwrap();
+
+                let resp_body: &[u8] = if method == "GET" {
+                    mgmt.as_bytes()
+                } else {
+                    b""
+                };
+                let header = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    resp_body.len()
+                );
+                stream.write_all(header.as_bytes()).unwrap();
+                stream.write_all(resp_body).unwrap();
+                stream.flush().unwrap();
+            }
+        });
+
+        let cfg = RegistryConfig {
+            base_url: format!("http://127.0.0.1:{port}"),
+            token: Some("publish-token".into()),
+        };
+        let client = RegistryClient::new(&cfg);
+        let pr = pkg_ref("tatolab", "camera");
+        client
+            .upload_slpkg(&pr, SemVer::new(0, 4, 33), b"new-slpkg-bytes")
+            .unwrap();
+        server.join().unwrap();
+
+        let reqs: Vec<(String, String, Vec<u8>)> = rx.try_iter().collect();
+        // The index PUT carries the union of {0.4.32 (mgmt), 0.4.33 (new)}.
+        let index_put = reqs
+            .iter()
+            .find(|(m, p, _)| m == "PUT" && p.ends_with("/index/index.json"))
+            .expect("an index PUT must be recorded");
+        let body = String::from_utf8_lossy(&index_put.2);
+        let parsed = parse_index_ndjson(body.as_bytes(), "camera");
+        assert_eq!(
+            parsed,
+            vec![SemVer::new(0, 4, 32), SemVer::new(0, 4, 33)],
+            "index body must hold the management-listing ∪ published version, got {body:?}"
+        );
+        // The .slpkg itself was PUT too.
+        assert!(
+            reqs.iter().any(|(m, p, _)| m == "PUT"
+                && p.ends_with("/generic/camera/0.4.33/camera.slpkg")),
+            "the .slpkg PUT must be recorded; saw {reqs:?}"
+        );
     }
 }

--- a/scripts/gitea/publish-packages.sh
+++ b/scripts/gitea/publish-packages.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Publish every streamlib package under packages/* to the Gitea **generic**
+# registry as a source-only `.slpkg`, by version. The package twin of
+# publish-crates.sh / publish-python-sdk.sh: each package's `streamlib.yaml`
+# version becomes a published `.slpkg` a cross-repo host resolves via
+# `Strategy::Registry` (`add_module`) — never a relative path or git patch.
+# See docs/architecture/gitea-registry-distribution.md.
+#
+# Each publish repacks a fresh source-only `.slpkg` (no prebuilt cdylib) and,
+# as part of `streamlib pkg publish`, (re)writes the package's anonymous
+# cargo-sparse-shaped version index so the read path lists versions tokenless.
+#
+#   ./publish-packages.sh                 # publish all packages/* (skip test fixtures)
+#   ./publish-packages.sh camera display  # publish only the named packages
+#
+# Configure-by-env (all optional except the token):
+#   GITEA_URL              default http://localhost:3300
+#   GITEA_ORG              default tatolab
+#   GITEA_PUBLISH_TOKEN    REQUIRED — a Gitea token with write:package
+#   STREAMLIB_PKG_SKIP     space-separated package names to skip
+#                          (default: the test-fixture packages)
+#   STREAMLIB_BIN          path to a prebuilt `streamlib` binary (skips the
+#                          in-repo build when set)
+set -euo pipefail
+
+GITEA_URL="${GITEA_URL:-http://localhost:3300}"
+GITEA_ORG="${GITEA_ORG:-tatolab}"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PKG_DIR="$ROOT/packages"
+SKIP="${STREAMLIB_PKG_SKIP:-test-fixtures test-fixtures-abi-mismatch}"
+
+log()  { printf '[publish-packages] %s\n' "$*"; }
+fail() { printf '[publish-packages] ERROR: %s\n' "$*" >&2; exit 1; }
+
+[ -n "${GITEA_PUBLISH_TOKEN:-}" ] || fail "set GITEA_PUBLISH_TOKEN (write:package)"
+
+# `streamlib pkg publish` reads the registry endpoint + credential from the
+# resolver's env channel (RegistryConfig::from_env). Map the publish token
+# onto it; the read path is anonymous, so the token is publish-only.
+export STREAMLIB_REGISTRY_URL="${STREAMLIB_REGISTRY_URL:-$GITEA_URL}"
+export STREAMLIB_REGISTRY_TOKEN="$GITEA_PUBLISH_TOKEN"
+
+# Resolve the `streamlib` CLI: a caller-provided binary, else build it once.
+if [ -n "${STREAMLIB_BIN:-}" ]; then
+  BIN="$STREAMLIB_BIN"
+else
+  log "building the streamlib CLI (release)…"
+  cargo build --release -p streamlib-cli --bin streamlib --manifest-path "$ROOT/Cargo.toml" >&2
+  BIN="$ROOT/target/release/streamlib"
+fi
+[ -x "$BIN" ] || fail "streamlib binary not found/executable: $BIN"
+
+# Pick the package set: explicit args, else every packages/* with a manifest.
+if [ "$#" -gt 0 ]; then
+  names=("$@")
+else
+  names=()
+  for d in "$PKG_DIR"/*/; do
+    [ -f "$d/streamlib.yaml" ] || continue
+    names+=("$(basename "$d")")
+  done
+fi
+# Guard the empty set explicitly: `"${names[@]}"` on an empty array trips
+# `set -u` ("unbound variable") on bash < 4.4 (e.g. macOS's default 3.2).
+[ "${#names[@]}" -gt 0 ] || fail "no packages to publish under $PKG_DIR"
+
+published=0 skipped=0 failed=0
+for name in "${names[@]}"; do
+  case " $SKIP " in *" $name "*) log "skip $name (in STREAMLIB_PKG_SKIP)"; skipped=$((skipped+1)); continue ;; esac
+  dir="$PKG_DIR/$name"
+  [ -f "$dir/streamlib.yaml" ] || { log "skip $name (no streamlib.yaml)"; skipped=$((skipped+1)); continue; }
+  log "publishing $name → $STREAMLIB_REGISTRY_URL"
+  if ( cd "$dir" && "$BIN" pkg publish ); then
+    published=$((published+1))
+  else
+    log "FAILED to publish $name"
+    failed=$((failed+1))
+  fi
+done
+
+log "done: $published published, $skipped skipped, $failed failed"
+[ "$failed" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #1119.

## What & why

#1119 was filed before the unified-registry work landed and was ~half-done by later PRs (notably #1128). Audited at pickup; this PR closes the **two remaining pieces**, both verified against current code:

| #1119 exit criterion | Where it landed |
|---|---|
| 1. `streamlib pack` source-only `.slpkg` | already shipped (#1128) — command is now `streamlib pkg build`/`publish`; `Slpkg` assemble target skips the cdylib |
| 3. host `add_module`s a registry package and it builds | already shipped (#1128) — `Strategy::Registry` + registry-only examples |
| **2. every `packages/*` published as source `.slpkg`** | **this PR** — bulk `publish-packages.sh` |
| **4. anonymous, tokenless version-index read** | **this PR** — cargo-sparse-shaped index |

## The tokenless read path

Reads are now anonymous, matching cargo's sparse index. The generic registry has no native version query — Gitea's `/api/v1/packages` management API **401s anonymously** (confirmed live) — so each publish writes a cargo-sparse-shaped version index as a plain generic file at `/api/packages/{org}/generic/{name}/index/index.json` (NDJSON, one `{"name","vers"}` line per version), anonymously downloadable like any generic file.

- `RegistryClient::upload_slpkg` recomputes the index from the authed management listing ∪ the just-published version — **self-healing**: every publish rewrites the full correct index, so a stale/missing index repairs on next publish.
- `RegistryClient::list_versions_http` reads that index anonymously; the management API is now used only on the publish path (`list_versions_via_management_api`). A 404 ⇒ empty (parity with `file://`'s missing-dir case).
- The registry token is **publish-only**; the whole read path (list + download) is tokenless on a public registry (still sent when set, for private registries). This removes the read-side token #1117 hit.
- `file://` transport is unchanged (its `list_versions_file` enumerates per-version dirs — no index file needed).

## Bulk publish

`scripts/gitea/publish-packages.sh` — generic configure-by-env loop over every `packages/*` with a manifest, shelling out to `streamlib pkg publish` (which now also writes the index). Central-registry topology stays in the gitignored `.local.sh` wrapper.

## Validation

**Unit (streamlib-idents, all pass):**
- `http_list_and_download_against_localhost` — tokenless (`token: None`) index read + download; reverting `list_versions_http` to the authed `/api/v1` path makes it request the wrong URL and fail.
- `http_list_missing_index_yields_empty` — 404 ⇒ empty, not a transport error.
- `index_ndjson_render_parse_round_trip`, `merge_versions_sorts_and_dedups` — format + canonicalization.
- `upload_writes_version_index_round_trip` — stateful mock server captures the publish sequence and asserts the index PUT body is the management-listing ∪ published version; reverting the `write_version_index` call records no index PUT and fails.

**Live (local Gitea :3300):**
- `publish-packages.sh escalate` → published.
- Anonymous (no token) `GET …/generic/escalate/index/index.json` → `{"name":"escalate","vers":"1.0.0"}`, **HTTP 200**.
- Authed `/api/v1/packages/tatolab?type=generic` → **401** anonymously (the path we replaced).
- Republish self-heals: index stays `1.0.0`, no dupes; the `index` pseudo-version that appears in the authed listing is correctly filtered (non-semver, dropped by `from_dotted`).

No GPU/E2E pipeline scenarios apply (pure resolver + script change).

## Notes

- `polyglot`-labeled, but the per-runtime SDK surface was already handled in #1117 (Python) / #1118 (Deno); this change is the language-agnostic resolver + a bash script, so there's no Python/Deno-specific work here.
- Docs: `docs/architecture/gitea-registry-distribution.md` collapsed to a current-state arch doc — with the migration's last piece shipped, the "documented ahead of implementation" exception framing is shed (in-flight intro + status table + all `(finalized in #N)`/milestone/issue refs removed; the two dated `~~strikethrough~~` supersession blocks converted to plain current tense). Also dropped the now-false read-side `STREAMLIB_REGISTRY_TOKEN` requirement from the Python codegen note (this branch makes generic reads anonymous).
- Pre-existing `clippy -D warnings --all-targets` findings in `resolver.rs` / `semver.rs` are untouched (not introduced here; `registry.rs` is clippy-clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
