### PR TITLE
feat(1131): convert api-server example to registry-only standalone

### DIFF
--- a/examples/api-server/Cargo.toml
+++ b/examples/api-server/Cargo.toml
@@ -1,11 +1,19 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+# Standalone, registry-only example (headed to its own repo). Every dependency
+# resolves from the Gitea registry by version, and the empty `[workspace]` table
+# makes this its own workspace root so it builds off-tree. Loads
+# `@tatolab/api-server` at runtime via `Strategy::Registry`.
 [package]
 name = "api-server"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
-# `@tatolab/api-server` loaded at runtime via
-# `Runner::add_module` — no compile-time link.
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib = { version = "0.4.33-dev.5", registry = "gitea" }
 serde_json = "1"
 tokio = { version = "1.48.0", features = ["full"] }
+
+[workspace]

--- a/examples/api-server/src/main.rs
+++ b/examples/api-server/src/main.rs
@@ -16,9 +16,8 @@
 //! - DELETE /api/connections/:id - Remove a connection
 //! - WS /ws/events - WebSocket event stream
 //!
-//! Packages build automatically on `cargo run` via the build orchestrator.
-//! so the runtime can find the staged cdylib at
-//! `target/streamlib-plugins/tatolab__api-server/`.
+//! Packages build automatically on `cargo run` via the build orchestrator,
+//! resolved from the Gitea generic registry by version.
 //!
 //! Loads `@tatolab/api-server` through the imperative
 //! [`Runner::add_module`] API. The fully spelled out
@@ -28,21 +27,30 @@
 //! resolve to the same `ModuleIdent::new(...)` expression at
 //! expansion time.
 
+use streamlib::sdk::RunnerAutoBuild;
 use streamlib::sdk::module_ident;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
-use streamlib::sdk::RunnerAutoBuild;
+use streamlib::sdk::runtime::{BuildPolicy, Runner, SemVerRange, Strategy};
 use streamlib::sdk::schema_ident;
 
 #[tokio::main]
 async fn main() -> streamlib::sdk::error::Result<()> {
     let runtime = Runner::with_auto_build()?;
 
-    // Imperative module load — the runtime resolves the ident
-    // from its package source (built on demand by the orchestrator),
-    // verifies the semver range, then drives the internal
-    // module-loading machinery.
-    runtime.add_module_with(module_ident!("tatolab", "api-server", "^1.0.0"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/api-server"), build: streamlib::sdk::runtime::BuildPolicy::IfStale }).await?;
+    // Imperative module load — the runtime resolves the ident from the Gitea
+    // generic registry by version (the orchestrator pulls each `.slpkg` and
+    // builds it from source on the host), verifies the semver range, then
+    // drives the internal module-loading machinery. Registry endpoint comes
+    // from `STREAMLIB_REGISTRY_URL` (or `GITEA_URL`).
+    runtime
+        .add_module_with(
+            module_ident!("tatolab", "api-server", "^1.0.0"),
+            Strategy::Registry {
+                version_req: SemVerRange::Any,
+                build: BuildPolicy::IfStale,
+            },
+        )
+        .await?;
 
     let config = serde_json::json!({
         "host": "127.0.0.1",


### PR DESCRIPTION
## What

Converts `examples/api-server` to the standalone, registry-only shape (headed to its own repo), following the already-merged `camera-display` / `camera-deno-subprocess` template (#1128, #1162).

- Drop `path = "../../libs/streamlib-sdk"` → `streamlib = { version = "0.4.33-dev.5", registry = "gitea" }` (pin matches the freshest merged conversion).
- Add the BUSL copyright header + `publish = false`.
- Add an empty `[workspace]` self-root so the example builds off-tree.
- Switch the runtime `add_module_with` load from `Strategy::Path` to `Strategy::Registry { version_req: SemVerRange::Any, build: IfStale }`.

## Validation

End-to-end registry-only build is deferred until the hosted Gitea registry is live (per the issue and #1130) — the local registry isn't populated with the SDK. Validated structurally: TOML well-formed, no `path =` deps remain, Rust syntax + rustfmt clean, `Strategy::Registry` in place, scope limited to the two files. Independent Opus review: PASS.

Closes #1131

🤖 Generated with [Claude Code](https://claude.com/claude-code)