### PR TITLE
feat(1137): convert jpeg-psnr example to registry-only standalone

### DIFF
--- a/examples/jpeg-psnr/Cargo.toml
+++ b/examples/jpeg-psnr/Cargo.toml
@@ -1,9 +1,20 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+# Standalone, registry-only example (headed to its own repo). Every dependency
+# resolves from the Gitea registry by version, and the empty `[workspace]` table
+# makes this its own workspace root so it builds off-tree. Loads
+# `@tatolab/debug-utilities` + `@tatolab/jpeg` + `@tatolab/display` at runtime
+# via `Strategy::Registry`.
 [package]
 name = "jpeg-psnr"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib = { version = "0.4.33-dev.5", registry = "gitea" }
 serde_json = "1"
 anyhow = "1.0.100"
+
+[workspace]

--- a/examples/jpeg-psnr/src/main.rs
+++ b/examples/jpeg-psnr/src/main.rs
@@ -11,16 +11,16 @@
 //! Usage:
 //!   jpeg-psnr <jpeg-path> <width> <height> <fps> <frame-count>
 //!
-//! Packages build automatically on `cargo run` via the build orchestrator.
-//!` so the runtime can
+//! Packages build automatically on `cargo run` via the build orchestrator,
+//! resolved from the Gitea generic registry by version so the runtime can
 //! resolve each cdylib at load time.
 
+use streamlib::sdk::RunnerAutoBuild;
 use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
-use streamlib::sdk::RunnerAutoBuild;
+use streamlib::sdk::runtime::{BuildPolicy, Runner, SemVerRange, Strategy};
 use streamlib::sdk::schema_ident;
 
 fn main() -> Result<()> {
@@ -40,9 +40,21 @@ fn main() -> Result<()> {
 
     let runtime = Runner::with_auto_build()?;
 
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "debug-utilities"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/debug-utilities"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "jpeg"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/jpeg"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "display"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/display"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
+    // Resolve every package from the Gitea generic registry by version — the
+    // cross-repo consumer path. The orchestrator pulls each `.slpkg` and builds
+    // it from source on the host. Registry endpoint comes from
+    // `STREAMLIB_REGISTRY_URL` (or `GITEA_URL`).
+    let registry = || Strategy::Registry {
+        version_req: SemVerRange::Any,
+        build: BuildPolicy::IfStale,
+    };
+    runtime.add_module_with_blocking(
+        module_ident_any_version!("tatolab", "debug-utilities"),
+        registry(),
+    )?;
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "jpeg"), registry())?;
+    runtime
+        .add_module_with_blocking(module_ident_any_version!("tatolab", "display"), registry())?;
 
     let source = runtime.add_processor(ProcessorSpec::new(
         schema_ident!("tatolab", "debug-utilities", "JpegBytesSource", "1.0.0"),


### PR DESCRIPTION
## What

Converts `examples/jpeg-psnr` to the standalone, registry-only shape, following the merged `camera-display` / `api-server` (#1165) template.

- Drop `path` SDK dep → `streamlib = { version = "0.4.33-dev.5", registry = "gitea" }`; BUSL header + `publish = false`; empty `[workspace]` self-root.
- Switch the three runtime loads (`debug-utilities`, `jpeg`, `display`) from `Strategy::Path` to `Strategy::Registry { version_req: SemVerRange::Any, build: IfStale }` via a shared `registry` closure.

## Validation — end-to-end ✅

Built from `registry gitea` (no path deps). Ran with a generated JPEG fixture: `Strategy::Registry` resolved all three packages + transitive `@tatolab/core`, loaded `libstreamlib_{debug_utilities,jpeg,display}.so`, registered the `JpegBytesSource` / `JpegDecoder` / `Display` processors, pipeline started and stopped clean — zero errors/panics.

CI red is the runner-can't-reach-`localhost:3300` state (same on main). Independent Opus review: PASS.

Closes #1137

🤖 Generated with [Claude Code](https://claude.com/claude-code)