### PR TITLE
feat(1152): convert runtime-graph-json-demo to registry-only standalone

### DIFF
--- a/examples/runtime-graph-json-demo/Cargo.toml
+++ b/examples/runtime-graph-json-demo/Cargo.toml
@@ -1,9 +1,19 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+# Standalone, registry-only example (headed to its own repo). Every dependency
+# resolves from the Gitea registry by version, and the empty `[workspace]` table
+# makes this its own workspace root so it builds off-tree. Loads
+# `@tatolab/camera` + `@tatolab/display` + `@tatolab/mp4` at runtime via
+# `Strategy::Registry`.
 [package]
 name = "runtime-graph-json-demo"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
-streamlib-camera = { path = "../../packages/camera", version = "0.4.30", registry = "gitea" }
+streamlib = { version = "0.4.33-dev.5", registry = "gitea" }
 serde_json = "1.0"
+
+[workspace]

--- a/examples/runtime-graph-json-demo/src/main.rs
+++ b/examples/runtime-graph-json-demo/src/main.rs
@@ -1,55 +1,76 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-use std::path::PathBuf;
-use streamlib::sdk::{DisplayConfig, Mp4WriterConfig};
-use streamlib::sdk::processors::{DisplayProcessor, Mp4WriterProcessor};
-use streamlib_camera::{CameraConfig, CameraProcessor};
+//! Runtime graph → JSON demo.
+//!
+//! Builds a camera → display + camera → MP4-writer (fan-out) graph from
+//! registry-resolved packages and prints the serialized graph as JSON via
+//! [`Runner::to_json`]. No pipeline is started — this only exercises graph
+//! construction and serialization.
+
+use streamlib::sdk::RunnerAutoBuild;
 use streamlib::sdk::error::Result;
-use streamlib::sdk::runtime::Runner;
-use streamlib::sdk::processors::{input, output};
+use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib::sdk::module_ident_any_version;
+use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::runtime::{BuildPolicy, Runner, SemVerRange, Strategy};
+use streamlib::sdk::schema_ident;
 
 fn main() -> Result<()> {
-    let runtime = Runner::new()?;
+    let runtime = Runner::with_auto_build()?;
+
+    // Resolve every package from the Gitea generic registry by version — the
+    // cross-repo consumer path. The orchestrator pulls each `.slpkg` and builds
+    // it from source on the host. Registry endpoint comes from
+    // `STREAMLIB_REGISTRY_URL` (or `GITEA_URL`).
+    let registry = || Strategy::Registry {
+        version_req: SemVerRange::Any,
+        build: BuildPolicy::IfStale,
+    };
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "camera"), registry())?;
+    runtime
+        .add_module_with_blocking(module_ident_any_version!("tatolab", "display"), registry())?;
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "mp4"), registry())?;
 
     // Add a camera processor
-    let camera = runtime.add_processor(CameraProcessor::Processor::node(CameraConfig {
-        device_id: Some("device-abc-123".to_string()),
-        ..Default::default()
-    }))?;
+    let camera = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "camera", "Camera", "1.0.0"),
+        serde_json::json!({ "device_id": "device-abc-123" }),
+    ))?;
 
     // Add a display processor
-    let display = runtime.add_processor(DisplayProcessor::Processor::node(DisplayConfig {
-        width: 1920,
-        height: 1080,
-        title: Some("My Display".to_string()),
-        ..Default::default()
-    }))?;
+    let display = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "display", "Display", "1.0.0"),
+        serde_json::json!({
+            "width": 1920,
+            "height": 1080,
+            "title": "My Display",
+        }),
+    ))?;
 
     // Add an MP4 writer processor
-    let recorder = runtime.add_processor(Mp4WriterProcessor::Processor::node(Mp4WriterConfig {
-        output_path: PathBuf::from("/tmp/recording.mp4"),
-        video_bitrate: Some(5_000_000),
-        audio_bitrate: Some(128_000),
-        ..Default::default()
-    }))?;
+    let recorder = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "mp4", "LinuxMp4Writer", "1.0.0"),
+        serde_json::json!({
+            "output_path": "/tmp/recording.mp4",
+            "fps": 30,
+        }),
+    ))?;
 
     // Connect camera to display
     runtime.connect(
-        output::<CameraProcessor::OutputLink::video>(&camera),
-        input::<DisplayProcessor::InputLink::video>(&display),
+        OutputLinkPortRef::new(&camera, "video"),
+        InputLinkPortRef::new(&display, "video"),
     )?;
 
     // Connect camera to recorder (fan-out)
     runtime.connect(
-        output::<CameraProcessor::OutputLink::video>(&camera),
-        input::<Mp4WriterProcessor::InputLink::video>(&recorder),
+        OutputLinkPortRef::new(&camera, "video"),
+        InputLinkPortRef::new(&recorder, "video_in"),
     )?;
 
     // Print the graph as JSON
-
     let json_str = runtime.to_json().expect("Failed to serialize graph");
-
     println!("{}", json_str);
 
     Ok(())


### PR DESCRIPTION
## What

Converts `examples/runtime-graph-json-demo` to standalone registry-only. This example used the **deprecated compile-time typed-struct API** (`CameraProcessor::Processor::node`, `output::<…::OutputLink::video>`, typed configs, a `streamlib-camera` compile-time dep) that no longer exists in the registry SDK, so it's **rewritten** to the runtime registry pattern (matching the merged `camera-display` reference):

- Load `@tatolab/{camera,display,mp4}` via `Strategy::Registry`.
- Add processors via `ProcessorSpec::new(schema_ident!(...), json)`; wire links via `OutputLinkPortRef`/`InputLinkPortRef`.
- MP4 writer maps to the registry `LinuxMp4Writer` (input port `video_in`, config `{output_path, fps}` — the old `video_bitrate`/`audio_bitrate` belonged to the deleted typed `Mp4WriterConfig`).
- Drop `path` SDK + camera deps → `{ version = "0.4.33-dev.5", registry = "gitea" }`; BUSL header; empty `[workspace]`; `publish = false`.
- Demo intent preserved: same 3 processors, same 2 connections incl. the camera→{display,mp4} fan-out, still prints `to_json()` (no `start()`).

## Validation — end-to-end ✅

Built from `registry gitea`. Ran: the orchestrator **pulled + built `@tatolab/mp4` fresh** from the registry, loaded all three packages via `Strategy::Registry`, registered `Camera`/`Display`/`LinuxMp4Writer`, and `to_json()` emitted the intended graph — 3 nodes + 2 links (camera→display, camera→mp4 fan-out) with correct ports. Zero errors.

CI red is the runner-can't-reach-`localhost:3300` state (same on main). Independent Opus review: PASS.

Closes #1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)