### PR TITLE
feat(1154): convert vulkan-video-psnr example to registry-only standalone

### DIFF
--- a/examples/vulkan-video-psnr/Cargo.toml
+++ b/examples/vulkan-video-psnr/Cargo.toml
@@ -1,9 +1,20 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+# Standalone, registry-only example (headed to its own repo). Every dependency
+# resolves from the Gitea registry by version, and the empty `[workspace]` table
+# makes this its own workspace root so it builds off-tree. Loads
+# `@tatolab/debug-utilities` + `@tatolab/display` + `@tatolab/h264` +
+# `@tatolab/h265` at runtime via `Strategy::Registry`.
 [package]
 name = "vulkan-video-psnr"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib = { version = "0.4.33-dev.5", registry = "gitea" }
 serde_json = "1"
 anyhow = "1.0.100"
+
+[workspace]

--- a/examples/vulkan-video-psnr/src/main.rs
+++ b/examples/vulkan-video-psnr/src/main.rs
@@ -11,25 +11,24 @@
 //! Usage:
 //!   vulkan-video-psnr <h264|h265> <bgra-path> <width> <height> <fps> <frame-count>
 //!
-//! Packages build automatically on `cargo run` via the build orchestrator.
-//!`
-//! so the runtime can resolve each cdylib at load time.
+//! Packages build automatically on `cargo run` via the build orchestrator,
+//! resolved from the Gitea generic registry by version so the runtime can
+//! resolve each cdylib at load time.
 
+use streamlib::sdk::RunnerAutoBuild;
 use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
-use streamlib::sdk::RunnerAutoBuild;
+use streamlib::sdk::runtime::{BuildPolicy, Runner, SemVerRange, Strategy};
 use streamlib::sdk::schema_ident;
 
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
     let codec = args.get(1).map(|s| s.as_str()).unwrap_or("h264");
-    let bgra_path = args
-        .get(2)
-        .cloned()
-        .expect("missing <bgra-path>: usage vulkan-video-psnr <codec> <bgra-path> <w> <h> <fps> <frames>");
+    let bgra_path = args.get(2).cloned().expect(
+        "missing <bgra-path>: usage vulkan-video-psnr <codec> <bgra-path> <w> <h> <fps> <frames>",
+    );
     let width: u32 = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(1920);
     let height: u32 = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(1080);
     let fps: u32 = args.get(5).and_then(|s| s.parse().ok()).unwrap_or(30);
@@ -42,10 +41,22 @@ fn main() -> Result<()> {
 
     let runtime = Runner::with_auto_build()?;
 
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "debug-utilities"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/debug-utilities"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "display"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/display"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "h264"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/h264"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "h265"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/h265"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
+    // Resolve every package from the Gitea generic registry by version — the
+    // cross-repo consumer path. The orchestrator pulls each `.slpkg` and builds
+    // it from source on the host. Registry endpoint comes from
+    // `STREAMLIB_REGISTRY_URL` (or `GITEA_URL`).
+    let registry = || Strategy::Registry {
+        version_req: SemVerRange::Any,
+        build: BuildPolicy::IfStale,
+    };
+    runtime.add_module_with_blocking(
+        module_ident_any_version!("tatolab", "debug-utilities"),
+        registry(),
+    )?;
+    runtime
+        .add_module_with_blocking(module_ident_any_version!("tatolab", "display"), registry())?;
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "h264"), registry())?;
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "h265"), registry())?;
 
     let source = runtime.add_processor(ProcessorSpec::new(
         schema_ident!("tatolab", "debug-utilities", "BgraFileSource", "1.0.0"),
@@ -86,10 +97,8 @@ fn main() -> Result<()> {
     } else {
         schema_ident!("tatolab", "h264", "H264Decoder", "1.0.0")
     };
-    let decoder = runtime.add_processor(ProcessorSpec::new(
-        decoder_ident,
-        serde_json::json!({}),
-    ))?;
+    let decoder =
+        runtime.add_processor(ProcessorSpec::new(decoder_ident, serde_json::json!({})))?;
     println!("+ {}Decoder: {decoder}", codec.to_uppercase());
 
     let display = runtime.add_processor(ProcessorSpec::new(

--- a/examples/vulkan-video-psnr/streamlib.yaml
+++ b/examples/vulkan-video-psnr/streamlib.yaml
@@ -20,10 +20,6 @@ package:
 dependencies:
   "@tatolab/core": "^1.0.0"
 
-patch:
-  "@tatolab/core":
-    path: ../../packages/core
-
 schemas:
   ColorInfo:
     package: "@tatolab/core"

--- a/examples/vulkan-video-psnr/streamlib.yaml
+++ b/examples/vulkan-video-psnr/streamlib.yaml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=../../schemas/streamlib.schema.json
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 #


### PR DESCRIPTION
## What

Converts `examples/vulkan-video-psnr` to standalone registry-only.

- Drop `path` SDK dep → `streamlib = { version = "0.4.33-dev.5", registry = "gitea" }`; BUSL header; `publish = false`; empty `[workspace]`.
- Switch the four runtime loads (`debug-utilities`, `display`, `h264`, `h265`) from `Strategy::Path` to `Strategy::Registry` via a shared closure.
- **streamlib.yaml:** remove the dev-only `patch: "@tatolab/core": path: ../../packages/core` block so the declared `@tatolab/core` schema dep resolves from the registry by version (the `schemas:` mapping that registers the wire vocabulary stays). Also drop the relative `yaml-language-server` `$schema` editor hint — a monorepo path that won't resolve in a standalone repo. **Precedent-setting for the other yaml-bearing example conversions** (camera-audio-recorder, moq-roundtrip, vulkan-video-roundtrip, etc.).

## Validation — end-to-end ✅

Built from `registry gitea`. Ran the **h264** `BgraFileSource → encoder → decoder → display` pipeline against a `testsrc2` BGRA fixture (320×240, 15 frames) — zero `OUT_OF_DEVICE_MEMORY`/`DEVICE_LOST`/`process() failed`/panic, PNG samples produced, and the decoded frame visually shows the correct color-bar pattern + timecode (`00:00:00.367`) + frame counter. h265 rides the identical load path.

CI red is the runner-can't-reach-`localhost:3300` state (same on main). Independent Opus review: PASS after addressing the schema-hint flag.

Closes #1154

🤖 Generated with [Claude Code](https://claude.com/claude-code)