### PR TITLE
feat(1155): convert vulkan-video-roundtrip example to registry-only standalone

### DIFF
--- a/examples/vulkan-video-roundtrip/Cargo.toml
+++ b/examples/vulkan-video-roundtrip/Cargo.toml
@@ -1,9 +1,20 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+# Standalone, registry-only example (headed to its own repo). Every dependency
+# resolves from the Gitea registry by version, and the empty `[workspace]` table
+# makes this its own workspace root so it builds off-tree. Loads
+# `@tatolab/camera` + `@tatolab/display` + `@tatolab/h264` + `@tatolab/h265`
+# at runtime via `Strategy::Registry`.
 [package]
 name = "vulkan-video-roundtrip"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib = { version = "0.4.33-dev.5", registry = "gitea" }
 serde_json = "1"
 anyhow = "1.0.100"
+
+[workspace]

--- a/examples/vulkan-video-roundtrip/src/main.rs
+++ b/examples/vulkan-video-roundtrip/src/main.rs
@@ -13,16 +13,16 @@
 //!   cargo run -p vulkan-video-roundtrip -- h264 [device] [seconds]
 //!   cargo run -p vulkan-video-roundtrip -- h265 /dev/video2 10
 //!
-//! Packages build automatically on `cargo run` via the build orchestrator.
-//!`
-//! so the runtime can find each cdylib at load time.
+//! Packages build automatically on `cargo run` via the build orchestrator,
+//! resolved from the Gitea generic registry by version so the runtime can
+//! find each cdylib at load time.
 
+use streamlib::sdk::RunnerAutoBuild;
 use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
-use streamlib::sdk::RunnerAutoBuild;
+use streamlib::sdk::runtime::{BuildPolicy, Runner, SemVerRange, Strategy};
 use streamlib::sdk::schema_ident;
 
 fn main() -> Result<()> {
@@ -38,14 +38,21 @@ fn main() -> Result<()> {
 
     let runtime = Runner::with_auto_build()?;
 
-    // Load all four processor packages at runtime. `@tatolab/core` is
-    // pulled in transitively by each — its wire-vocabulary schemas
-    // (`EncodedVideoFrame.max_payload_bytes` in particular) are
-    // load-bearing for iceoryx2 publisher sizing.
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "camera"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/camera"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "display"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/display"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "h264"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/h264"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "h265"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/h265"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
+    // Resolve every package from the Gitea generic registry by version — the
+    // cross-repo consumer path. The orchestrator pulls each `.slpkg` and builds
+    // it from source on the host. `@tatolab/core` is pulled in transitively by
+    // each — its wire-vocabulary schemas (`EncodedVideoFrame.max_payload_bytes`
+    // in particular) are load-bearing for iceoryx2 publisher sizing. Registry
+    // endpoint comes from `STREAMLIB_REGISTRY_URL` (or `GITEA_URL`).
+    let registry = || Strategy::Registry {
+        version_req: SemVerRange::Any,
+        build: BuildPolicy::IfStale,
+    };
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "camera"), registry())?;
+    runtime
+        .add_module_with_blocking(module_ident_any_version!("tatolab", "display"), registry())?;
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "h264"), registry())?;
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "h265"), registry())?;
 
     // --- Camera ---
     // STREAMLIB_CAMERA_MAX_WIDTH / STREAMLIB_CAMERA_MAX_HEIGHT cap V4L2
@@ -58,7 +65,10 @@ fn main() -> Result<()> {
         .ok()
         .and_then(|s| s.parse().ok());
     let mut camera_config = serde_json::Map::new();
-    camera_config.insert("device_id".into(), serde_json::Value::String(device.to_string()));
+    camera_config.insert(
+        "device_id".into(),
+        serde_json::Value::String(device.to_string()),
+    );
     if let Some(w) = max_width {
         camera_config.insert("max_width".into(), serde_json::Value::from(w));
     }
@@ -98,10 +108,8 @@ fn main() -> Result<()> {
     } else {
         schema_ident!("tatolab", "h264", "H264Decoder", "1.0.0")
     };
-    let decoder = runtime.add_processor(ProcessorSpec::new(
-        decoder_ident,
-        serde_json::json!({}),
-    ))?;
+    let decoder =
+        runtime.add_processor(ProcessorSpec::new(decoder_ident, serde_json::json!({})))?;
     println!("+ {}Decoder: {decoder}", codec.to_uppercase());
 
     // --- Display ---

--- a/examples/vulkan-video-roundtrip/streamlib.yaml
+++ b/examples/vulkan-video-roundtrip/streamlib.yaml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=../../schemas/streamlib.schema.json
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 #
@@ -20,10 +19,6 @@ package:
 
 dependencies:
   "@tatolab/core": "^1.0.0"
-
-patch:
-  "@tatolab/core":
-    path: ../../packages/core
 
 schemas:
   ColorInfo:


### PR DESCRIPTION
## What

Converts `examples/vulkan-video-roundtrip` to standalone registry-only (same shape as #1168).

- Drop `path` SDK dep → `streamlib = { version = "0.4.33-dev.5", registry = "gitea" }`; BUSL header; `publish = false`; empty `[workspace]`.
- Switch the four runtime loads (`camera`, `display`, `h264`, `h265`) from `Strategy::Path` to `Strategy::Registry` via a shared closure.
- **streamlib.yaml:** remove the dev-only `patch: "@tatolab/core": path: ../../packages/core` block and the relative `yaml-language-server` `$schema` hint (per the #1168 precedent); keep `dependencies: @tatolab/core ^1.0.0` + the `schemas:` wire-vocabulary mapping.

## Validation — end-to-end ✅

Built from `registry gitea`. Ran the **h264** `camera → encoder → decoder → display` roundtrip against the **vivid** virtual camera (`/dev/video0`) — zero `OUT_OF_DEVICE_MEMORY`/`DEVICE_LOST`/`process() failed`/panic, PNG sample produced, decoded frame visually shows the correct vivid SMPTE color-bar pattern + overlay text at 1920×1080. h265 rides the identical load path.

CI red is the runner-can't-reach-`localhost:3300` state (same on main). Independent Opus review: PASS.

Closes #1155

🤖 Generated with [Claude Code](https://claude.com/claude-code)