### PR TITLE
feat(1134): convert camera-rust-plugin to registry-only + Linux GrayscaleRust

### DIFF
--- a/examples/camera-rust-plugin/Cargo.toml
+++ b/examples/camera-rust-plugin/Cargo.toml
@@ -1,12 +1,37 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 
+# Standalone, registry-only example (headed to its own repo). Every dependency
+# resolves from the Gitea registry by version. This crate is its own workspace
+# root and includes the sibling `plugin/` cdylib (the grayscale Rust plugin) as
+# a member so `cargo build -p grayscale-plugin` builds it for the example to
+# stage. `@tatolab/camera` + `@tatolab/display` load at runtime via
+# `Strategy::Registry`; the example-local plugin loads via `Strategy::Path`.
 [package]
 name = "camera-rust-plugin"
-version = "0.1.0"
+version = "0.4.33-dev.5"
 edition = "2024"
+authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
+license = "BUSL-1.1"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
-serde_json = "1.0"
+streamlib = { workspace = true }
+serde_json = { workspace = true }
+
+[workspace]
+members = ["plugin"]
+
+[workspace.package]
+version = "0.4.33-dev.5"
+edition = "2024"
+authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
+license = "BUSL-1.1"
+
+[workspace.dependencies]
+streamlib = { version = "0.4.33-dev.5", registry = "gitea" }
+streamlib-jtd-codegen = { version = "0.4.33-dev.5", registry = "gitea" }
+streamlib-plugin-abi = { version = "0.4.33-dev.5", registry = "gitea" }
+tracing = { version = "0.1.41", features = ["release_max_level_debug"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/examples/camera-rust-plugin/plugin/Cargo.toml
+++ b/examples/camera-rust-plugin/plugin/Cargo.toml
@@ -1,19 +1,25 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 
+# Member of the standalone `camera-rust-plugin` workspace — inherits its
+# `[workspace.package]` fields and resolves every dependency from the registry
+# via `[workspace.dependencies]`. No path deps.
 [package]
 name = "grayscale-plugin"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
+streamlib-jtd-codegen = { workspace = true }
 
 [dependencies]
-streamlib = { path = "../../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
-streamlib-plugin-abi = { path = "../../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
-tracing = "0.1"
+streamlib = { workspace = true }
+streamlib-plugin-abi = { workspace = true }
+tracing = { workspace = true }
+serde = { workspace = true }

--- a/examples/camera-rust-plugin/plugin/build.rs
+++ b/examples/camera-rust-plugin/plugin/build.rs
@@ -1,6 +1,60 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+#![allow(clippy::disallowed_macros)] // build.rs uses println! for `cargo:` directives
+
+//! Codegen + Vulkan shader compilation for the grayscale plugin.
+//!
+//! The Linux grayscale processor drives its dispatch through the engine
+//! RHI's cdylib-safe `VulkanGraphicsKernel::offscreen_render` +
+//! `RhiCommandRecorder` surfaces, so this crate stays inside the
+//! boundary-check rule — no `vulkanalia` dep, no allowlist exception.
+//! `grayscale_kernel.rs` embeds the resulting SPIR-V via
+//! `include_bytes!(concat!(env!("OUT_DIR"), …))`.
+
 fn main() {
     streamlib_jtd_codegen::build_rs::run_for_rust_crate();
+    #[cfg(target_os = "linux")]
+    compile_shaders();
+}
+
+#[cfg(target_os = "linux")]
+fn compile_shaders() {
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    let shaders: &[(&str, &str, &str)] = &[
+        ("shaders/grayscale.vert", "grayscale.vert.spv", "vertex"),
+        ("shaders/grayscale.frag", "grayscale.frag.spv", "fragment"),
+    ];
+
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
+
+    for (src, dst, stage) in shaders {
+        let src_path = Path::new(src);
+        let dst_path: PathBuf = Path::new(&out_dir).join(dst);
+
+        println!("cargo:rerun-if-changed={}", src);
+
+        let glslc = std::env::var("GLSLC").unwrap_or_else(|_| "glslc".to_string());
+        let status = Command::new(&glslc)
+            .arg(format!("-fshader-stage={stage}"))
+            .arg("-O")
+            .arg(src_path)
+            .arg("-o")
+            .arg(&dst_path)
+            .status()
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Failed to invoke `{}` to compile {}: {}. Install shaderc-tools / vulkan-tools.",
+                    glslc, src, e
+                );
+            });
+        assert!(
+            status.success(),
+            "{} compilation failed (exit: {:?})",
+            src,
+            status.code()
+        );
+    }
 }

--- a/examples/camera-rust-plugin/plugin/shaders/grayscale.frag
+++ b/examples/camera-rust-plugin/plugin/shaders/grayscale.frag
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+// Grayscale fragment shader. Samples the input texture (descriptor-set 0,
+// binding 0) and writes the BT.601 luma of each texel to all three color
+// channels, matching the macOS CoreVideo CPU path
+// (gray = 0.299*R + 0.587*G + 0.114*B). The hardware sampler handles
+// tiled-format access. Output goes to the bound color attachment.
+
+#version 450
+
+layout(location = 0) in vec2 inUV;
+layout(location = 0) out vec4 outColor;
+
+layout(set = 0, binding = 0) uniform sampler2D inputTex;
+
+void main() {
+    vec4 src = texture(inputTex, inUV);
+    float luma = dot(src.rgb, vec3(0.299, 0.587, 0.114));
+    outColor = vec4(luma, luma, luma, 1.0);
+}

--- a/examples/camera-rust-plugin/plugin/shaders/grayscale.vert
+++ b/examples/camera-rust-plugin/plugin/shaders/grayscale.vert
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+// Fullscreen-triangle vertex shader for the grayscale fragment pass.
+// Three vertices cover the entire viewport with no vertex buffer; UVs
+// derive from gl_VertexIndex. Identical pattern to the engine's
+// display_blit.vert and camera-python-display's crt_film_grain.vert.
+
+#version 450
+
+layout(location = 0) out vec2 outUV;
+
+void main() {
+    //   vertex 0: pos(-1,-1), uv(0,0)  — bottom-left
+    //   vertex 1: pos( 3,-1), uv(2,0)  — far right
+    //   vertex 2: pos(-1, 3), uv(0,2)  — far top
+    outUV = vec2((gl_VertexIndex << 1) & 2, gl_VertexIndex & 2);
+    gl_Position = vec4(outUV * 2.0 - 1.0, 0.0, 1.0);
+}

--- a/examples/camera-rust-plugin/plugin/src/grayscale_apple.rs
+++ b/examples/camera-rust-plugin/plugin/src/grayscale_apple.rs
@@ -1,0 +1,189 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Grayscale processor (macOS / iOS).
+//!
+//! Reads pixels directly from `CVPixelBuffer` memory via CoreVideo,
+//! applies a BT.601 luma grayscale conversion on the CPU, and forwards
+//! the result on a freshly-acquired pixel buffer. CoreVideo is Apple-only;
+//! the Linux path lives in [`crate::grayscale_linux`] and runs the same
+//! effect on the GPU via a sandboxed graphics kernel.
+
+use crate::_generated_::VideoFrame;
+use std::ffi::c_void;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::JoinHandle;
+use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess};
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::processors::ManualProcessor;
+use streamlib::sdk::rhi::PixelFormat;
+
+#[link(name = "CoreVideo", kind = "framework")]
+unsafe extern "C" {
+    fn CVPixelBufferLockBaseAddress(pixel_buffer: *mut c_void, lock_flags: u64) -> i32;
+    fn CVPixelBufferUnlockBaseAddress(pixel_buffer: *mut c_void, lock_flags: u64) -> i32;
+    fn CVPixelBufferGetBaseAddress(pixel_buffer: *mut c_void) -> *mut c_void;
+    fn CVPixelBufferGetBytesPerRow(pixel_buffer: *mut c_void) -> usize;
+}
+
+#[streamlib::sdk::processor("GrayscaleRust")]
+pub struct GrayscaleProcessor {
+    gpu_context: Option<GpuContextLimitedAccess>,
+    running: Arc<AtomicBool>,
+    processing_thread: Option<JoinHandle<()>>,
+}
+
+impl ManualProcessor for GrayscaleProcessor::Processor {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.gpu_context = Some(ctx.gpu_limited_access().clone());
+        self.running = Arc::new(AtomicBool::new(false));
+        tracing::info!("GrayscaleProcessor: setup complete");
+        Ok(())
+    }
+
+    fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let inputs = std::mem::take(&mut self.inputs);
+        let outputs = std::mem::take(&mut self.outputs);
+        let gpu = self
+            .gpu_context
+            .clone()
+            .ok_or_else(|| Error::Configuration("GpuContext not initialized".into()))?;
+        let running = Arc::clone(&self.running);
+
+        running.store(true, Ordering::Release);
+
+        let handle = std::thread::Builder::new()
+            .name("grayscale-processing".into())
+            .spawn(move || {
+                tracing::info!("GrayscaleProcessor: processing thread started");
+
+                while running.load(Ordering::Acquire) {
+                    if !inputs.has_data("video_in") {
+                        std::thread::sleep(std::time::Duration::from_millis(1));
+                        continue;
+                    }
+
+                    let frame: VideoFrame = match inputs.read("video_in") {
+                        Ok(f) => f,
+                        Err(e) => {
+                            tracing::warn!("GrayscaleProcessor: failed to read frame: {}", e);
+                            continue;
+                        }
+                    };
+
+                    let input_buffer = match gpu.check_out_surface(&frame.surface_id) {
+                        Ok(b) => b,
+                        Err(e) => {
+                            tracing::warn!("GrayscaleProcessor: check_out_surface failed: {}", e);
+                            continue;
+                        }
+                    };
+
+                    let w = input_buffer.width;
+                    let h = input_buffer.height;
+
+                    let (pool_id, output_buffer) =
+                        match gpu.acquire_pixel_buffer(w, h, PixelFormat::Bgra32) {
+                            Ok(r) => r,
+                            Err(e) => {
+                                tracing::warn!(
+                                    "GrayscaleProcessor: acquire_pixel_buffer failed: {}",
+                                    e
+                                );
+                                continue;
+                            }
+                        };
+
+                    let input_ptr = input_buffer.as_ptr();
+                    let output_ptr = output_buffer.as_ptr();
+
+                    // Lock both buffers for CPU access (kCVPixelBufferLock_ReadOnly = 1)
+                    let lock_result = unsafe { CVPixelBufferLockBaseAddress(input_ptr, 1) };
+                    if lock_result != 0 {
+                        tracing::warn!(
+                            "GrayscaleProcessor: failed to lock input buffer: {}",
+                            lock_result
+                        );
+                        continue;
+                    }
+
+                    let lock_result = unsafe { CVPixelBufferLockBaseAddress(output_ptr, 0) };
+                    if lock_result != 0 {
+                        unsafe { CVPixelBufferUnlockBaseAddress(input_ptr, 1) };
+                        tracing::warn!(
+                            "GrayscaleProcessor: failed to lock output buffer: {}",
+                            lock_result
+                        );
+                        continue;
+                    }
+
+                    let input_base = unsafe { CVPixelBufferGetBaseAddress(input_ptr) };
+                    let input_bytes_per_row = unsafe { CVPixelBufferGetBytesPerRow(input_ptr) };
+                    let output_base = unsafe { CVPixelBufferGetBaseAddress(output_ptr) };
+                    let output_bytes_per_row = unsafe { CVPixelBufferGetBytesPerRow(output_ptr) };
+
+                    // Grayscale conversion (BGRA order): gray = 0.114*B + 0.587*G + 0.299*R
+                    for row in 0..h as usize {
+                        let in_row_ptr =
+                            unsafe { (input_base as *const u8).add(row * input_bytes_per_row) };
+                        let out_row_ptr =
+                            unsafe { (output_base as *mut u8).add(row * output_bytes_per_row) };
+
+                        for col in 0..w as usize {
+                            let pixel_offset = col * 4;
+                            unsafe {
+                                let b = *in_row_ptr.add(pixel_offset) as f32;
+                                let g = *in_row_ptr.add(pixel_offset + 1) as f32;
+                                let r = *in_row_ptr.add(pixel_offset + 2) as f32;
+
+                                let gray = (0.114 * b + 0.587 * g + 0.299 * r) as u8;
+
+                                *out_row_ptr.add(pixel_offset) = gray; // B
+                                *out_row_ptr.add(pixel_offset + 1) = gray; // G
+                                *out_row_ptr.add(pixel_offset + 2) = gray; // R
+                                *out_row_ptr.add(pixel_offset + 3) = 255; // A
+                            }
+                        }
+                    }
+
+                    // Unlock both buffers
+                    unsafe {
+                        CVPixelBufferUnlockBaseAddress(output_ptr, 0);
+                        CVPixelBufferUnlockBaseAddress(input_ptr, 1);
+                    }
+
+                    // Forward frame with new surface_id
+                    let output_frame = VideoFrame {
+                        surface_id: pool_id.to_string(),
+                        ..frame
+                    };
+                    if let Err(e) = outputs.write("video_out", &output_frame) {
+                        tracing::warn!("GrayscaleProcessor: failed to write output: {}", e);
+                    }
+                }
+
+                tracing::info!("GrayscaleProcessor: processing thread stopped");
+            })
+            .map_err(|e| {
+                Error::Configuration(format!("Failed to spawn processing thread: {}", e))
+            })?;
+
+        self.processing_thread = Some(handle);
+        tracing::info!("GrayscaleProcessor: started");
+        Ok(())
+    }
+
+    fn stop(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.running.store(false, Ordering::Release);
+
+        if let Some(handle) = self.processing_thread.take() {
+            handle
+                .join()
+                .map_err(|_| Error::Runtime("Processing thread panicked".into()))?;
+        }
+
+        tracing::info!("GrayscaleProcessor: stopped");
+        Ok(())
+    }
+}

--- a/examples/camera-rust-plugin/plugin/src/grayscale_kernel.rs
+++ b/examples/camera-rust-plugin/plugin/src/grayscale_kernel.rs
@@ -1,0 +1,195 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Grayscale post-effect graphics kernel — sandboxed scenario content.
+//!
+//! ## Why this lives in the example, not the engine
+//!
+//! The grayscale effect is example content: the BT.601 luma weights are
+//! baked into the fragment shader, so it doesn't belong in the engine.
+//! It rides the engine RHI's cdylib-safe
+//! [`VulkanGraphicsKernel::offscreen_render`] + [`RhiCommandRecorder`]
+//! surfaces, so the crate stays inside the boundary-check rule — no
+//! `vulkanalia` dep, no allowlist exception. Every queue-mutex / fence /
+//! Drop / barrier bug the engine has fixed propagates here for free.
+//!
+//! ## Lifecycle
+//!
+//! The caller pre-allocates a ring of output `Texture`s, hands one to
+//! [`SandboxedGrayscale::dispatch`] per frame along with the input texture
+//! + its current Vulkan layout, and `dispatch` returns once the GPU has
+//! signaled the underlying submits. After return, both input and output
+//! textures are in `SHADER_READ_ONLY_OPTIMAL`, ready for the next
+//! consumer to sample without re-barriering.
+
+use std::sync::{Arc, Mutex};
+
+use streamlib::sdk::engine::host_rhi::{
+    HostVulkanDevice, OffscreenColorTarget, OffscreenDraw, RhiCommandRecorder, VulkanAccess,
+    VulkanGraphicsKernel, VulkanStage,
+};
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::rhi::{
+    AttachmentFormats, ColorBlendState, ColorWriteMask, DepthStencilState, DrawCall,
+    GraphicsBindingSpec, GraphicsDynamicState, GraphicsKernelDescriptor, GraphicsPipelineState,
+    GraphicsPushConstants, GraphicsShaderStageFlags, GraphicsStage, MultisampleState,
+    PrimitiveTopology, RasterizationState, ScissorRect, Texture, TextureFormat, VertexInputState,
+    Viewport, VulkanLayout,
+};
+
+/// Single input layer (the pre-effect texture) + its current Vulkan
+/// layout. The kernel barriers from `current_layout` to
+/// `SHADER_READ_ONLY_OPTIMAL` before the draw and leaves it there.
+#[derive(Clone, Copy)]
+pub struct GrayscaleInput<'a> {
+    pub texture: &'a Texture,
+    pub current_layout: VulkanLayout,
+}
+
+/// Render target for one grayscale dispatch. No `current_layout` is
+/// required — [`VulkanGraphicsKernel::offscreen_render`] transitions the
+/// output from `UNDEFINED` internally (content discard is permitted and
+/// the full-screen triangle overwrites every pixel).
+#[derive(Clone, Copy)]
+pub struct GrayscaleOutput<'a> {
+    pub texture: &'a Texture,
+}
+
+pub struct GrayscaleInputs<'a> {
+    pub input: GrayscaleInput<'a>,
+    pub output: GrayscaleOutput<'a>,
+}
+
+/// Grayscale post-effect graphics kernel.
+pub struct SandboxedGrayscale {
+    label: &'static str,
+    kernel: VulkanGraphicsKernel,
+    /// Reused across dispatches for the input pre-pass barrier (when the
+    /// input is not already `SHADER_READ_ONLY_OPTIMAL`) and the post-pass
+    /// output `COLOR_ATTACHMENT_OPTIMAL → SHADER_READ_ONLY_OPTIMAL`
+    /// barrier that follows [`VulkanGraphicsKernel::offscreen_render`].
+    recorder: Mutex<RhiCommandRecorder>,
+}
+
+impl SandboxedGrayscale {
+    pub fn new(vulkan_device: &Arc<HostVulkanDevice>) -> Result<Self> {
+        let label = "grayscale";
+
+        let vert = include_bytes!(concat!(env!("OUT_DIR"), "/grayscale.vert.spv"));
+        let frag = include_bytes!(concat!(env!("OUT_DIR"), "/grayscale.frag.spv"));
+
+        let stages = [GraphicsStage::vertex(vert), GraphicsStage::fragment(frag)];
+        let bindings = [GraphicsBindingSpec::sampled_texture(
+            0,
+            GraphicsShaderStageFlags::FRAGMENT,
+        )];
+        let descriptor = GraphicsKernelDescriptor {
+            label,
+            stages: &stages,
+            bindings: &bindings,
+            push_constants: GraphicsPushConstants::NONE,
+            pipeline_state: GraphicsPipelineState {
+                topology: PrimitiveTopology::TriangleList,
+                vertex_input: VertexInputState::None,
+                rasterization: RasterizationState::default(),
+                multisample: MultisampleState::default(),
+                depth_stencil: DepthStencilState::Disabled,
+                color_blend: ColorBlendState::Disabled {
+                    color_write_mask: ColorWriteMask::RGBA,
+                },
+                attachment_formats: AttachmentFormats::color_only(TextureFormat::Bgra8Unorm),
+                dynamic_state: GraphicsDynamicState::ViewportScissor,
+            },
+            descriptor_sets_in_flight: 1,
+        };
+        let kernel = VulkanGraphicsKernel::new(vulkan_device, &descriptor)?;
+
+        let recorder = RhiCommandRecorder::new(vulkan_device, "grayscale_recorder")?;
+
+        Ok(Self {
+            label,
+            kernel,
+            recorder: Mutex::new(recorder),
+        })
+    }
+
+    /// Convert `inputs.input.texture` to grayscale into
+    /// `inputs.output.texture`. Input must match the output 1:1 (the
+    /// shader samples at the same screen UV).
+    pub fn dispatch(&self, inputs: GrayscaleInputs<'_>) -> Result<()> {
+        let width = inputs.output.texture.width();
+        let height = inputs.output.texture.height();
+
+        if inputs.input.texture.width() != width || inputs.input.texture.height() != height {
+            return Err(Error::GpuError(format!(
+                "{}: input is {}×{}, expected {width}×{height} (must match output)",
+                self.label,
+                inputs.input.texture.width(),
+                inputs.input.texture.height(),
+            )));
+        }
+
+        self.kernel
+            .set_sampled_texture(0, 0, inputs.input.texture)?;
+
+        let mut recorder = self.recorder.lock().map_err(|e| {
+            Error::GpuError(format!("{}: recorder mutex poisoned: {e}", self.label))
+        })?;
+
+        // Pre-pass: barrier the input into SHADER_READ_ONLY_OPTIMAL when
+        // it isn't already there. Tolerant src masks (ALL_COMMANDS +
+        // MEMORY_WRITE) cover every upstream producer (camera compute,
+        // adapters, future encoders) without per-producer tuning.
+        if inputs.input.current_layout != VulkanLayout::SHADER_READ_ONLY_OPTIMAL {
+            recorder.begin()?;
+            recorder.record_image_barrier(
+                inputs.input.texture,
+                inputs.input.current_layout,
+                VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+                VulkanStage::ALL_COMMANDS,
+                VulkanStage::FRAGMENT_SHADER,
+                VulkanAccess::MEMORY_WRITE,
+                VulkanAccess::SHADER_SAMPLED_READ,
+            )?;
+            recorder.submit_and_wait()?;
+        }
+
+        // Render pass. `offscreen_render` transitions output
+        // `UNDEFINED → COLOR_ATTACHMENT_OPTIMAL` internally; the
+        // full-screen triangle covers every pixel so `clear_color = None`
+        // (LOAD) is sufficient. Output is left in
+        // `COLOR_ATTACHMENT_OPTIMAL`.
+        self.kernel.offscreen_render(
+            0,
+            &[OffscreenColorTarget {
+                texture: inputs.output.texture,
+                clear_color: None,
+            }],
+            (width, height),
+            OffscreenDraw::Draw(DrawCall {
+                vertex_count: 3,
+                instance_count: 1,
+                first_vertex: 0,
+                first_instance: 0,
+                viewport: Some(Viewport::full(width, height)),
+                scissor: Some(ScissorRect::full(width, height)),
+            }),
+        )?;
+
+        // Post-pass: output COLOR_ATTACHMENT_OPTIMAL →
+        // SHADER_READ_ONLY_OPTIMAL.
+        recorder.begin()?;
+        recorder.record_image_barrier(
+            inputs.output.texture,
+            VulkanLayout::COLOR_ATTACHMENT_OPTIMAL,
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+            VulkanStage::COLOR_ATTACHMENT_OUTPUT,
+            VulkanStage::ALL_COMMANDS,
+            VulkanAccess::COLOR_ATTACHMENT_WRITE,
+            VulkanAccess::SHADER_SAMPLED_READ,
+        )?;
+        recorder.submit_and_wait()?;
+
+        Ok(())
+    }
+}

--- a/examples/camera-rust-plugin/plugin/src/grayscale_linux.rs
+++ b/examples/camera-rust-plugin/plugin/src/grayscale_linux.rs
@@ -1,0 +1,174 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Grayscale processor (Linux).
+//!
+//! Samples the input camera texture through a sandboxed graphics kernel
+//! ([`SandboxedGrayscale`]) and writes a BT.601-luma grayscale frame into
+//! a ring of output render-target textures, then forwards the slot's
+//! `surface_id` downstream. The in-process `Display` consumer resolves the
+//! slot via Path 1 (`texture_cache`), so no surface-share registration is
+//! needed — [`GpuContextFullAccess::create_texture_ring`] registers every
+//! slot in the texture cache at construction.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use streamlib::sdk::context::{
+    GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
+};
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::rhi::{TextureUsages, VulkanLayout};
+
+use crate::_generated_::VideoFrame;
+use crate::grayscale_kernel::{
+    GrayscaleInput, GrayscaleInputs, GrayscaleOutput, SandboxedGrayscale,
+};
+
+/// Output texture ring depth — the engine's `MAX_FRAMES_IN_FLIGHT = 2`
+/// per `docs/learnings/vulkan-frames-in-flight.md`. The prior slot may
+/// still be sampled by `Display` while we render into the next one.
+const OUTPUT_RING_DEPTH: usize = 2;
+
+struct LinuxBackend {
+    kernel: Arc<SandboxedGrayscale>,
+    output_ring: streamlib::sdk::context::TextureRing,
+}
+
+#[streamlib::sdk::processor("GrayscaleRust")]
+pub struct GrayscaleProcessor {
+    gpu_context: Option<GpuContextLimitedAccess>,
+    frame_count: AtomicU64,
+    backend: Option<LinuxBackend>,
+}
+
+impl streamlib::sdk::processors::ReactiveProcessor for GrayscaleProcessor::Processor {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.setup_inner(ctx)
+    }
+
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        tracing::info!(
+            "GrayscaleProcessor: shutdown ({} frames)",
+            self.frame_count.load(Ordering::Relaxed)
+        );
+        Ok(())
+    }
+
+    fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        if !self.inputs.has_data("video_in") {
+            return Ok(());
+        }
+        let frame: VideoFrame = self.inputs.read("video_in")?;
+
+        let gpu_ctx = self
+            .gpu_context
+            .as_ref()
+            .ok_or_else(|| Error::Configuration("GPU context not initialized".into()))?
+            .clone();
+
+        let backend = self.backend.as_mut().ok_or_else(|| {
+            Error::Configuration("GrayscaleProcessor: backend not initialized".into())
+        })?;
+
+        // Resolve input texture + its current_layout. The upstream camera
+        // publishes a texture-backed surface_id dual-registered in
+        // texture_cache (Path 1) + surface_store (Path 2).
+        let input_registration = gpu_ctx.resolve_texture_registration_by_surface_id(
+            &frame.surface_id,
+            frame.texture_layout,
+            frame.width,
+            frame.height,
+        )?;
+        let input_texture = input_registration.texture().clone();
+        let input_layout = input_registration.current_layout();
+
+        // Rotate to the next ring slot.
+        let slot = backend.output_ring.acquire_next();
+        let slot_surface_id = slot.surface_id().to_string();
+
+        // Resolve the slot registration so we can update its layout after
+        // the dispatch. The ring registered every slot in texture_cache at
+        // construction, so Path 1 resolves it without IPC.
+        let slot_registration = gpu_ctx.resolve_texture_registration_by_surface_id(
+            &slot_surface_id,
+            None,
+            slot.texture.width(),
+            slot.texture.height(),
+        )?;
+
+        backend.kernel.dispatch(GrayscaleInputs {
+            input: GrayscaleInput {
+                texture: &input_texture,
+                current_layout: input_layout,
+            },
+            output: GrayscaleOutput {
+                texture: &slot.texture,
+            },
+        })?;
+
+        // The kernel leaves both input and output in
+        // SHADER_READ_ONLY_OPTIMAL — update both registrations so the next
+        // consumer's barrier reads a current_layout matching reality.
+        slot_registration.update_layout(VulkanLayout::SHADER_READ_ONLY_OPTIMAL);
+        input_registration.update_layout(VulkanLayout::SHADER_READ_ONLY_OPTIMAL);
+
+        let output_frame = VideoFrame {
+            surface_id: slot_surface_id,
+            width: slot.texture.width(),
+            height: slot.texture.height(),
+            timestamp_ns: frame.timestamp_ns.clone(),
+            fps: frame.fps,
+            texture_layout: None,
+            color_info: frame.color_info.clone(),
+            mastering_display: frame.mastering_display.clone(),
+            content_light: frame.content_light.clone(),
+        };
+        self.outputs.write("video_out", &output_frame)?;
+        self.frame_count.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+impl GrayscaleProcessor::Processor {
+    fn setup_inner(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        tracing::info!("GrayscaleProcessor: setup (Vulkan graphics kernel)");
+        let gpu_context = ctx.gpu_limited_access().clone();
+        self.gpu_context = Some(gpu_context.clone());
+
+        // setup() runs inside the engine's privileged lifecycle dispatch,
+        // so `ctx.gpu_full_access()` is already privileged — calling
+        // `gpu_limited_access().escalate(...)` here would re-enter the
+        // escalate gate on the same thread and trip its re-entry panic.
+        let full = ctx.gpu_full_access();
+        let vulkan_device = full.host_vulkan_device_arc()?;
+        let kernel = Arc::new(SandboxedGrayscale::new(&vulkan_device)?);
+
+        // Camera in this example emits 1920×1080. The grayscale kernel
+        // validates input/output dimensions match per dispatch, so a
+        // mismatched frame surfaces as a clean error rather than silently
+        // mis-rendering.
+        let width = 1920;
+        let height = 1080;
+        let output_ring = full.create_texture_ring(
+            width,
+            height,
+            streamlib::sdk::rhi::TextureFormat::Bgra8Unorm,
+            TextureUsages::RENDER_ATTACHMENT
+                | TextureUsages::TEXTURE_BINDING
+                | TextureUsages::COPY_SRC,
+            OUTPUT_RING_DEPTH,
+        )?;
+
+        tracing::info!(
+            "GrayscaleProcessor: pre-allocated {OUTPUT_RING_DEPTH} output ring slots \
+             ({width}x{height} BGRA8)"
+        );
+
+        self.backend = Some(LinuxBackend {
+            kernel,
+            output_ring,
+        });
+        Ok(())
+    }
+}

--- a/examples/camera-rust-plugin/plugin/src/lib.rs
+++ b/examples/camera-rust-plugin/plugin/src/lib.rs
@@ -1,195 +1,35 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-// The grayscale plugin reads pixels directly from CVPixelBuffer memory via
-// CoreVideo, which is Apple-only. On non-Apple targets the crate builds as an
-// empty cdylib; a Linux port (using GPU buffer mapping or a compute shader) is
-// tracked as a follow-up to issue #358.
-#![cfg(any(target_os = "macos", target_os = "ios"))]
+//! Grayscale video-effect package — a Rust-backed processor loaded as a
+//! cdylib via `runtime.add_module_with(..., Strategy::Path)` against this
+//! crate's `streamlib.yaml`. The cdylib's `STREAMLIB_PLUGIN` callback
+//! registers the `GrayscaleRust` processor with the host registry.
+//!
+//! The Linux implementation ([`grayscale_linux`]) samples the input
+//! camera texture through a sandboxed graphics kernel and writes a
+//! BT.601-luma grayscale frame into a ring of output render-target
+//! textures. The macOS implementation ([`grayscale_apple`]) reads pixels
+//! directly from `CVPixelBuffer` memory via CoreVideo.
 
 #[allow(non_snake_case, unused_imports, dead_code, clippy::all)]
 mod _generated_ {
     include!(concat!(env!("OUT_DIR"), "/_generated_shim.rs"));
 }
 
-use std::ffi::c_void;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::thread::JoinHandle;
-use crate::_generated_::VideoFrame;
-use streamlib::sdk::rhi::PixelFormat;
-use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess};
-use streamlib::sdk::processors::ManualProcessor;
-use streamlib::sdk::error::{Result, Error};
+#[cfg(target_os = "linux")]
+mod grayscale_kernel;
+#[cfg(target_os = "linux")]
+mod grayscale_linux;
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+mod grayscale_apple;
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))]
 use streamlib_plugin_abi::export_plugin;
 
-#[link(name = "CoreVideo", kind = "framework")]
-unsafe extern "C" {
-    fn CVPixelBufferLockBaseAddress(pixel_buffer: *mut c_void, lock_flags: u64) -> i32;
-    fn CVPixelBufferUnlockBaseAddress(pixel_buffer: *mut c_void, lock_flags: u64) -> i32;
-    fn CVPixelBufferGetBaseAddress(pixel_buffer: *mut c_void) -> *mut c_void;
-    fn CVPixelBufferGetBytesPerRow(pixel_buffer: *mut c_void) -> usize;
-}
+#[cfg(target_os = "linux")]
+export_plugin!(grayscale_linux::GrayscaleProcessor::Processor);
 
-#[streamlib::sdk::processor("GrayscaleRust")]
-pub struct GrayscaleProcessor {
-    gpu_context: Option<GpuContextLimitedAccess>,
-    running: Arc<AtomicBool>,
-    processing_thread: Option<JoinHandle<()>>,
-}
-
-impl ManualProcessor for GrayscaleProcessor::Processor {
-    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        self.gpu_context = Some(ctx.gpu_limited_access().clone());
-        self.running = Arc::new(AtomicBool::new(false));
-        tracing::info!("GrayscaleProcessor: setup complete");
-        Ok(())
-    }
-
-    fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        let inputs = std::mem::take(&mut self.inputs);
-        let outputs = std::mem::take(&mut self.outputs);
-        let gpu = self
-            .gpu_context
-            .clone()
-            .ok_or_else(|| Error::Configuration("GpuContext not initialized".into()))?;
-        let running = Arc::clone(&self.running);
-
-        running.store(true, Ordering::Release);
-
-        let handle = std::thread::Builder::new()
-            .name("grayscale-processing".into())
-            .spawn(move || {
-                tracing::info!("GrayscaleProcessor: processing thread started");
-
-                while running.load(Ordering::Acquire) {
-                    if !inputs.has_data("video_in") {
-                        std::thread::sleep(std::time::Duration::from_millis(1));
-                        continue;
-                    }
-
-                    let frame: VideoFrame = match inputs.read("video_in") {
-                        Ok(f) => f,
-                        Err(e) => {
-                            tracing::warn!("GrayscaleProcessor: failed to read frame: {}", e);
-                            continue;
-                        }
-                    };
-
-                    let input_buffer = match gpu.check_out_surface(&frame.surface_id) {
-                        Ok(b) => b,
-                        Err(e) => {
-                            tracing::warn!("GrayscaleProcessor: check_out_surface failed: {}", e);
-                            continue;
-                        }
-                    };
-
-                    let w = input_buffer.width;
-                    let h = input_buffer.height;
-
-                    let (pool_id, output_buffer) =
-                        match gpu.acquire_pixel_buffer(w, h, PixelFormat::Bgra32) {
-                            Ok(r) => r,
-                            Err(e) => {
-                                tracing::warn!(
-                                    "GrayscaleProcessor: acquire_pixel_buffer failed: {}",
-                                    e
-                                );
-                                continue;
-                            }
-                        };
-
-                    let input_ptr = input_buffer.as_ptr();
-                    let output_ptr = output_buffer.as_ptr();
-
-                    // Lock both buffers for CPU access (kCVPixelBufferLock_ReadOnly = 1)
-                    let lock_result = unsafe { CVPixelBufferLockBaseAddress(input_ptr, 1) };
-                    if lock_result != 0 {
-                        tracing::warn!(
-                            "GrayscaleProcessor: failed to lock input buffer: {}",
-                            lock_result
-                        );
-                        continue;
-                    }
-
-                    let lock_result = unsafe { CVPixelBufferLockBaseAddress(output_ptr, 0) };
-                    if lock_result != 0 {
-                        unsafe { CVPixelBufferUnlockBaseAddress(input_ptr, 1) };
-                        tracing::warn!(
-                            "GrayscaleProcessor: failed to lock output buffer: {}",
-                            lock_result
-                        );
-                        continue;
-                    }
-
-                    let input_base = unsafe { CVPixelBufferGetBaseAddress(input_ptr) };
-                    let input_bytes_per_row = unsafe { CVPixelBufferGetBytesPerRow(input_ptr) };
-                    let output_base = unsafe { CVPixelBufferGetBaseAddress(output_ptr) };
-                    let output_bytes_per_row = unsafe { CVPixelBufferGetBytesPerRow(output_ptr) };
-
-                    // Grayscale conversion (BGRA order): gray = 0.114*B + 0.587*G + 0.299*R
-                    for row in 0..h as usize {
-                        let in_row_ptr =
-                            unsafe { (input_base as *const u8).add(row * input_bytes_per_row) };
-                        let out_row_ptr =
-                            unsafe { (output_base as *mut u8).add(row * output_bytes_per_row) };
-
-                        for col in 0..w as usize {
-                            let pixel_offset = col * 4;
-                            unsafe {
-                                let b = *in_row_ptr.add(pixel_offset) as f32;
-                                let g = *in_row_ptr.add(pixel_offset + 1) as f32;
-                                let r = *in_row_ptr.add(pixel_offset + 2) as f32;
-
-                                let gray = (0.114 * b + 0.587 * g + 0.299 * r) as u8;
-
-                                *out_row_ptr.add(pixel_offset) = gray; // B
-                                *out_row_ptr.add(pixel_offset + 1) = gray; // G
-                                *out_row_ptr.add(pixel_offset + 2) = gray; // R
-                                *out_row_ptr.add(pixel_offset + 3) = 255; // A
-                            }
-                        }
-                    }
-
-                    // Unlock both buffers
-                    unsafe {
-                        CVPixelBufferUnlockBaseAddress(output_ptr, 0);
-                        CVPixelBufferUnlockBaseAddress(input_ptr, 1);
-                    }
-
-                    // Forward frame with new surface_id
-                    let output_frame = VideoFrame {
-                        surface_id: pool_id.to_string(),
-                        ..frame
-                    };
-                    if let Err(e) = outputs.write("video_out", &output_frame) {
-                        tracing::warn!("GrayscaleProcessor: failed to write output: {}", e);
-                    }
-                }
-
-                tracing::info!("GrayscaleProcessor: processing thread stopped");
-            })
-            .map_err(|e| {
-                Error::Configuration(format!("Failed to spawn processing thread: {}", e))
-            })?;
-
-        self.processing_thread = Some(handle);
-        tracing::info!("GrayscaleProcessor: started");
-        Ok(())
-    }
-
-    fn stop(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        self.running.store(false, Ordering::Release);
-
-        if let Some(handle) = self.processing_thread.take() {
-            handle
-                .join()
-                .map_err(|_| Error::Runtime("Processing thread panicked".into()))?;
-        }
-
-        tracing::info!("GrayscaleProcessor: stopped");
-        Ok(())
-    }
-}
-
-export_plugin!(GrayscaleProcessor::Processor);
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+export_plugin!(grayscale_apple::GrayscaleProcessor::Processor);

--- a/examples/camera-rust-plugin/plugin/streamlib.yaml
+++ b/examples/camera-rust-plugin/plugin/streamlib.yaml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=../../../schemas/streamlib.schema.json
 package:
   org: tatolab
   name: camera-rust-plugin
@@ -8,13 +7,8 @@ package:
 dependencies:
   "@tatolab/core": "^1.0.0"
 
-# Dev-time path override; `streamlib pack` rejects this (#717).
-patch:
-  "@tatolab/core":
-    path: ../../../packages/core
-
 schemas:
-  # Wire types imported from @tatolab/core (#767).
+  # Wire types imported from @tatolab/core.
   ColorInfo:
     package: "@tatolab/core"
   ContentLight:
@@ -29,7 +23,7 @@ processors:
     version: 1.0.0
     description: "Grayscale video effect (Rust dylib plugin)"
     runtime: rust
-    execution: manual
+    execution: reactive
     inputs:
       - name: video_in
         schema: VideoFrame

--- a/examples/camera-rust-plugin/src/main.rs
+++ b/examples/camera-rust-plugin/src/main.rs
@@ -3,26 +3,23 @@
 
 //! Camera → Rust Grayscale Plugin → Display Pipeline Example
 //!
-//! Demonstrates the in-tree cdylib plugin pattern: the example owns a
-//! sibling `plugin/` crate that builds as a cdylib carrying the
-//! `GrayscaleRust` processor, and the host manually stages that cdylib
-//! into `plugin/lib/<host_triple>/` before calling
-//! `runtime.add_module_with_blocking(..., Strategy::Path)`
-//! to register it. This is the "build from source + load from path"
-//! shape, distinct from the `the build orchestrator` +
-//! `runtime.add_module_blocking(...)` flow that the other examples use for
-//! canonical workspace packages.
+//! Demonstrates the local cdylib plugin pattern: the example owns a
+//! sibling `plugin/` crate (a workspace member) that builds as a cdylib
+//! carrying the `GrayscaleRust` processor, and the host manually stages
+//! that cdylib into `plugin/lib/<host_triple>/` before calling
+//! `runtime.add_module_with_blocking(..., Strategy::Path)` to register it.
+//! This is the "build from source + load from path" shape for an
+//! example-local plugin.
 //!
-//! `@tatolab/camera` and `@tatolab/display` themselves load via
-//! `add_module` against the workspace-staged plugin dir — only the
-//! example-local plugin subdir goes through the manual stage path.
+//! `@tatolab/camera` and `@tatolab/display` instead resolve from the Gitea
+//! registry by version via `Strategy::Registry` — only the example-local
+//! plugin goes through the manual stage + `Strategy::Path`.
 //!
 //! ## Prerequisites
 //!
-//! Build the plugin cdylib + stage the canonical packages:
+//! Build the plugin cdylib (a member of this example's workspace):
 //! ```bash
 //! cargo build -p grayscale-plugin
-//! the build orchestrator
 //! ```
 //!
 //! ## Usage
@@ -32,22 +29,29 @@
 //! ```
 
 use std::path::PathBuf;
+use streamlib::sdk::RunnerAutoBuild;
 use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::{BuildPolicy, Strategy, Runner};
-use streamlib::sdk::RunnerAutoBuild;
+use streamlib::sdk::runtime::{BuildPolicy, Runner, SemVerRange, Strategy};
 use streamlib::sdk::schema_ident;
 
 fn main() -> Result<()> {
     let runtime = Runner::with_auto_build()?;
 
-    // 1. Load `@tatolab/camera` and `@tatolab/display` via the canonical
-    //    package source. `the build orchestrator --package
-    //    @tatolab/camera`.
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "camera"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/camera"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "display"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/display"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
+    // 1. Resolve `@tatolab/camera` and `@tatolab/display` from the Gitea
+    //    generic registry by version — the cross-repo consumer path. The
+    //    orchestrator pulls each `.slpkg` and builds it from source on the
+    //    host. Registry endpoint comes from `STREAMLIB_REGISTRY_URL` (or
+    //    `GITEA_URL`).
+    let registry = || Strategy::Registry {
+        version_req: SemVerRange::Any,
+        build: BuildPolicy::IfStale,
+    };
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "camera"), registry())?;
+    runtime
+        .add_module_with_blocking(module_ident_any_version!("tatolab", "display"), registry())?;
 
     // 2. Stage the example-local grayscale plugin cdylib at
     //    `plugin/lib/<triple>/` so the explicit `Path`
@@ -63,12 +67,10 @@ fn main() -> Result<()> {
         streamlib::sdk::error::Error::Configuration(format!("Failed to create lib dir: {}", e))
     })?;
 
-    // Derive workspace target dir: CARGO_MANIFEST_DIR is examples/camera-rust-plugin/,
-    // workspace root is 2 levels up, target dir is workspace_root/target/
-    let workspace_root = manifest_dir
-        .parent()
-        .and_then(|p| p.parent())
-        .expect("Failed to find workspace root");
+    // This example is its own workspace root (the `plugin/` cdylib is a member),
+    // so `cargo build -p grayscale-plugin` writes the dylib into this crate's
+    // own `target/` dir.
+    let workspace_root = &manifest_dir;
     let dylib_name = if cfg!(target_os = "macos") {
         "libgrayscale_plugin.dylib"
     } else if cfg!(target_os = "windows") {
@@ -114,11 +116,14 @@ fn main() -> Result<()> {
     //    grayscale processor from the staged cdylib). The
     //    `Path` strategy preserves the recursive
     //    dep-walker shape — it reads `plugin/streamlib.yaml`, walks
-    //    declared deps (`@tatolab/core` patched to a workspace path),
-    //    and registers the local plugin's processors + schemas.
+    //    declared deps (`@tatolab/core` resolved from the registry by
+    //    version), and registers the local plugin's processors + schemas.
     runtime.add_module_with_blocking(
         module_ident_any_version!("tatolab", "camera-rust-plugin"),
-        Strategy::Path { path: plugin_dir.clone(), build: BuildPolicy::IfStale },
+        Strategy::Path {
+            path: plugin_dir.clone(),
+            build: BuildPolicy::IfStale,
+        },
     )?;
 
     // 4. Add processors


### PR DESCRIPTION
## What

Converts `examples/camera-rust-plugin` to standalone registry-only, **and** (with explicit approval) implements a Linux `GrayscaleRust` processor — the example was Apple-only and non-functional on Linux before.

### Part A — registry conversion
- Example Cargo.toml → workspace root with the `plugin/` cdylib as a member; `[workspace.dependencies]` registry-pin `streamlib`/`streamlib-plugin-abi`/`streamlib-jtd-codegen` at `0.4.33-dev.5` (matches the merged `camera-python-display` shape); all `path` deps dropped.
- main.rs: `@tatolab/camera` + `@tatolab/display` load via `Strategy::Registry`; the example-local grayscale plugin stays `Strategy::Path`; plugin-staging path fixed (example is now its own workspace root → builds into its own `target/`).
- plugin/streamlib.yaml: drop the dev `patch: @tatolab/core` block, the relative `yaml-language-server` hint, and a stale tracker-ref comment.

### Part B — Linux GrayscaleRust (was Apple-only)
The plugin carried a crate-level `#![cfg(macos/ios)]`, so on Linux the whole crate — including `export_plugin!` — compiled away, producing a stub `.so` with no `STREAMLIB_PLUGIN` symbol that the runtime rejects (the symbol-missing failure). The grayscale processor was CoreVideo/Apple-only.

Fix: per-module gating + a Linux `GrayscaleRust` `ReactiveProcessor` — resolves the input camera texture, dispatches a BT.601-luma graphics kernel (`VulkanGraphicsKernel::offscreen_render` + `RhiCommandRecorder`, **no raw vulkanalia**) into a 2-slot `create_texture_ring` output, forwards the slot `surface_id`. Mirrors the `effects`/`crt_film_grain` pattern. New: `grayscale_linux.rs`, `grayscale_kernel.rs`, `shaders/grayscale.{vert,frag}`; the original CoreVideo path moves to `grayscale_apple.rs` behind `#[cfg(macos/ios)]`.

## Validation — end-to-end ✅

Built from `registry gitea`; plugin `.so` exports `STREAMLIB_PLUGIN`. Ran vivid → `GrayscaleRust` → display: the SMPTE color bars render as a correct luma gradient (light-gray → black) — verified by reading the sampled PNG — zero errors. Apple path is `#[cfg]`-gated (unbuildable/validated on Linux, code preserved verbatim).

CI red is the runner-can't-reach-`localhost:3300` state (same on main). Independent Opus review: PASS (RHI boundary, capability tier, texture-ring/registration, shaders, gating all clean).

Closes #1134

🤖 Generated with [Claude Code](https://claude.com/claude-code)