### PR TITLE
feat(1151): convert raytracing-showcase to registry-only standalone

### DIFF
--- a/examples/raytracing-showcase/Cargo.toml
+++ b/examples/raytracing-showcase/Cargo.toml
@@ -1,8 +1,19 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+# Standalone, registry-only example (headed to its own repo). Every dependency
+# resolves from the Gitea registry by version, and the empty `[workspace]` table
+# makes this its own workspace root so it builds off-tree. Renders ray-traced
+# frames directly through the SDK's `VulkanRayTracingKernel` RHI — loads no
+# runtime packages.
 [package]
 name = "raytracing-showcase"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib = { version = "0.4.33-dev.5", registry = "gitea" }
 anyhow = "1.0.100"
+
+[workspace]


### PR DESCRIPTION
## What

Cargo.toml-only conversion of `examples/raytracing-showcase` to standalone registry-only. The example renders ray-traced frames directly through the SDK's `VulkanRayTracingKernel` RHI and loads **no** runtime packages, so there are no `Strategy::Path` loads to convert.

- Drop `path` SDK dep → `streamlib = { version = "0.4.33-dev.5", registry = "gitea" }`; BUSL header; `publish = false`; empty `[workspace]`.

## Validation — end-to-end ✅

Built from `registry gitea`. Ran the showcase → wrote 90 PNGs; sampled frame shows a correct ray-traced cube (per-face colors + BLAS triangle edges) against the gradient miss-shader sky. Zero errors.

CI red is the runner-can't-reach-`localhost:3300` state (same on main). Independent Opus review: PASS.

Closes #1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)