### PR TITLE
feat(1156): convert vulkan-video-roundtrip-cdylib-camera to registry-only

### DIFF
--- a/examples/vulkan-video-roundtrip-cdylib-camera/Cargo.toml
+++ b/examples/vulkan-video-roundtrip-cdylib-camera/Cargo.toml
@@ -1,13 +1,24 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+# Standalone, registry-only example (headed to its own repo). Every dependency
+# resolves from the Gitea registry by version, and the empty `[workspace]` table
+# makes this its own workspace root so it builds off-tree. Loads
+# `@tatolab/camera` + `@tatolab/display` + `@tatolab/h264` + `@tatolab/h265`
+# at runtime via `Strategy::Registry`.
+#
+# Deliberately NOT taking streamlib-camera as a Rust dep. The camera is loaded
+# at runtime via `Runner::add_module(...)`; linking streamlib-camera as a Rust
+# dep would auto-register the `Camera` processor at link time, conflicting with
+# the cdylib's registration at load time.
 [package]
 name = "vulkan-video-roundtrip-cdylib-camera"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
-# Deliberately NOT taking streamlib-camera as a Rust dep. The camera
-# is loaded at runtime via `Runner::add_module(...)` against a
-# staged copy of `packages/camera/`. Linking streamlib-camera as a
-# Rust dep would auto-register the `Camera` processor at link time,
-# conflicting with the cdylib's registration at load time.
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib = { version = "0.4.33-dev.5", registry = "gitea" }
 serde_json = "1"
+
+[workspace]

--- a/examples/vulkan-video-roundtrip-cdylib-camera/src/main.rs
+++ b/examples/vulkan-video-roundtrip-cdylib-camera/src/main.rs
@@ -15,16 +15,16 @@
 //!   cargo run -p vulkan-video-roundtrip-cdylib-camera -- h264 [device] [seconds]
 //!   cargo run -p vulkan-video-roundtrip-cdylib-camera -- h265 /dev/video0 10
 //!
-//! Packages build automatically on `cargo run` via the build orchestrator.
-//!`
-//! so the runtime can resolve each cdylib at load time.
+//! Packages build automatically on `cargo run` via the build orchestrator,
+//! resolved from the Gitea generic registry by version so the runtime can
+//! resolve each cdylib at load time.
 
+use streamlib::sdk::RunnerAutoBuild;
 use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
-use streamlib::sdk::RunnerAutoBuild;
+use streamlib::sdk::runtime::{BuildPolicy, Runner, SemVerRange, Strategy};
 use streamlib::sdk::schema_ident;
 
 fn main() -> Result<()> {
@@ -43,11 +43,20 @@ fn main() -> Result<()> {
 
     let runtime = Runner::with_auto_build()?;
 
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "camera"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/camera"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "display"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/display"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "h264"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/h264"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "h265"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/h265"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    println!("+ Camera / Display / H264 / H265 loaded from target/streamlib-plugins/");
+    // Resolve every package from the Gitea generic registry by version — the
+    // cross-repo consumer path. The orchestrator pulls each `.slpkg` and builds
+    // it from source on the host. Registry endpoint comes from
+    // `STREAMLIB_REGISTRY_URL` (or `GITEA_URL`).
+    let registry = || Strategy::Registry {
+        version_req: SemVerRange::Any,
+        build: BuildPolicy::IfStale,
+    };
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "camera"), registry())?;
+    runtime
+        .add_module_with_blocking(module_ident_any_version!("tatolab", "display"), registry())?;
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "h264"), registry())?;
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "h265"), registry())?;
+    println!("+ Camera / Display / H264 / H265 resolved from the Gitea registry");
     println!("+ Wire vocabulary registered (via @tatolab/core dep walk)\n");
 
     let camera = runtime.add_processor(ProcessorSpec::new(
@@ -89,10 +98,8 @@ fn main() -> Result<()> {
     } else {
         schema_ident!("tatolab", "h264", "H264Decoder", "1.0.0")
     };
-    let decoder = runtime.add_processor(ProcessorSpec::new(
-        decoder_ident,
-        serde_json::json!({}),
-    ))?;
+    let decoder =
+        runtime.add_processor(ProcessorSpec::new(decoder_ident, serde_json::json!({})))?;
     println!("+ {}Decoder: {decoder}", codec.to_uppercase());
 
     let display = runtime.add_processor(ProcessorSpec::new(

--- a/examples/vulkan-video-roundtrip-cdylib-camera/streamlib.yaml
+++ b/examples/vulkan-video-roundtrip-cdylib-camera/streamlib.yaml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=../../schemas/streamlib.schema.json
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 #
@@ -20,10 +19,6 @@ package:
 
 dependencies:
   "@tatolab/core": "^1.0.0"
-
-patch:
-  "@tatolab/core":
-    path: ../../packages/core
 
 schemas:
   ColorInfo:


### PR DESCRIPTION
## What

Converts `examples/vulkan-video-roundtrip-cdylib-camera` to standalone registry-only (same shape as #1168/#1169).

- Drop `path` SDK dep → `streamlib = { version = "0.4.33-dev.5", registry = "gitea" }`; BUSL header; `publish = false`; empty `[workspace]` (the "deliberately not taking streamlib-camera as a Rust dep" rationale is preserved).
- Switch the four runtime loads (`camera`, `display`, `h264`, `h265`) from `Strategy::Path` to `Strategy::Registry`; fix a stale `target/streamlib-plugins/` println.
- streamlib.yaml: drop the dev `patch: @tatolab/core` block + relative `yaml-language-server` hint; keep `dependencies: @tatolab/core` + the `schemas:` wire-vocab mapping.

## Validation — end-to-end ✅

Built from `registry gitea`. Ran the **all-cdylib** h264 camera→encoder→decoder→display roundtrip against vivid (`/dev/video0`) — zero errors, decoded PNG shows correct full-color vivid SMPTE bars at 1920×1080.

CI red is the runner-can't-reach-`localhost:3300` state (same on main). Independent Opus review: PASS.

Closes #1156

🤖 Generated with [Claude Code](https://claude.com/claude-code)