### PR TITLE
feat(1139): convert moq-roundtrip to registry-only standalone

### DIFF
--- a/examples/moq-roundtrip/Cargo.toml
+++ b/examples/moq-roundtrip/Cargo.toml
@@ -1,11 +1,22 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+# Standalone, registry-only example (headed to its own repo). Every dependency
+# resolves from the Gitea registry by version, and the empty `[workspace]` table
+# makes this its own workspace root so it builds off-tree. Loads
+# `@tatolab/{audio,camera,display,h264,moq,opus}` at runtime via
+# `Strategy::Registry`.
 [package]
 name = "moq-roundtrip"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib = { version = "0.4.33-dev.5", registry = "gitea" }
 serde_json = "1"
 tokio = { version = "1.48.0", features = ["full"] }
 tracing = "0.1.41"
 rustls = { version = "0.23", features = ["ring"] }
+
+[workspace]

--- a/examples/moq-roundtrip/src/main.rs
+++ b/examples/moq-roundtrip/src/main.rs
@@ -18,17 +18,16 @@
 //! All MoQ config is automatic — Cloudflare draft-14 relay, auto-generated
 //! namespace.
 //!
-//! Packages build automatically on `cargo run` via the build orchestrator.
-//!
-//!` so the runtime can resolve
-//! each cdylib at load time.
+//! Packages build automatically on `cargo run` via the build orchestrator,
+//! resolved from the Gitea generic registry by version so the runtime can
+//! resolve each cdylib at load time.
 
+use streamlib::sdk::RunnerAutoBuild;
 use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::module_ident_any_version;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::runtime::Runner;
-use streamlib::sdk::RunnerAutoBuild;
+use streamlib::sdk::runtime::{BuildPolicy, Runner, SemVerRange, Strategy};
 use streamlib::sdk::schema_ident;
 
 fn main() -> Result<()> {
@@ -42,12 +41,21 @@ fn main() -> Result<()> {
 
     let runtime = Runner::with_auto_build()?;
 
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "audio"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/audio"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "camera"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/camera"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "display"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/display"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "h264"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/h264"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "moq"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/moq"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "opus"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/opus"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
+    // Resolve every package from the Gitea generic registry by version — the
+    // cross-repo consumer path. The orchestrator pulls each `.slpkg` and builds
+    // it from source on the host. Registry endpoint comes from
+    // `STREAMLIB_REGISTRY_URL` (or `GITEA_URL`).
+    let registry = || Strategy::Registry {
+        version_req: SemVerRange::Any,
+        build: BuildPolicy::IfStale,
+    };
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "audio"), registry())?;
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "camera"), registry())?;
+    runtime
+        .add_module_with_blocking(module_ident_any_version!("tatolab", "display"), registry())?;
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "h264"), registry())?;
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "moq"), registry())?;
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "opus"), registry())?;
 
     // ---- PUBLISH SIDE ----
 
@@ -79,7 +87,13 @@ fn main() -> Result<()> {
     ))?;
     let resampler = runtime.add_processor(ProcessorSpec::new(
         schema_ident!("tatolab", "audio", "AudioResampler", "1.0.0"),
-        serde_json::json!({ "target_sample_rate": 48000 }),
+        // `source_sample_rate` is required by the config schema but advisory —
+        // the resampler derives the real source rate from each input frame.
+        serde_json::json!({
+            "source_sample_rate": 48000,
+            "target_sample_rate": 48000,
+            "quality": "High",
+        }),
     ))?;
     let rechunker = runtime.add_processor(ProcessorSpec::new(
         schema_ident!("tatolab", "audio", "BufferRechunker", "1.0.0"),
@@ -169,7 +183,11 @@ fn main() -> Result<()> {
     ))?;
     let sub_resampler = runtime.add_processor(ProcessorSpec::new(
         schema_ident!("tatolab", "audio", "AudioResampler", "1.0.0"),
-        serde_json::json!({ "target_sample_rate": 44100 }),
+        serde_json::json!({
+            "source_sample_rate": 48000,
+            "target_sample_rate": 44100,
+            "quality": "High",
+        }),
     ))?;
     let sub_rechunker = runtime.add_processor(ProcessorSpec::new(
         schema_ident!("tatolab", "audio", "BufferRechunker", "1.0.0"),

--- a/examples/moq-roundtrip/streamlib.yaml
+++ b/examples/moq-roundtrip/streamlib.yaml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=../../schemas/streamlib.schema.json
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 #
@@ -19,10 +18,6 @@ package:
 
 dependencies:
   "@tatolab/core": "^1.0.0"
-
-patch:
-  "@tatolab/core":
-    path: ../../packages/core
 
 schemas:
   AudioFrame:


### PR DESCRIPTION
## What

Converts `examples/moq-roundtrip` to standalone registry-only.

- Drop `path` SDK dep → `streamlib = { version = "0.4.33-dev.5", registry = "gitea" }`; BUSL header; `publish = false`; empty `[workspace]` (external deps serde_json/tokio/tracing/rustls retained).
- Switch the six runtime loads (`audio`, `camera`, `display`, `h264`, `moq`, `opus`) from `Strategy::Path` to `Strategy::Registry`; fix a garbled doc comment.
- streamlib.yaml: drop the dev `patch: @tatolab/core` block + relative `yaml-language-server` hint; keep `dependencies: @tatolab/core` + `schemas:`.
- **Fix two pre-existing stale `AudioResampler` configs** the registry resolution surfaced: the published `audio@1.0.0` schema requires `source_sample_rate` + `quality` (the example only set `target_sample_rate` → `config deser: missing field`). `source_sample_rate` is advisory (the resampler derives the real rate from each input frame per `audio_resampler.rs:59`); `quality: "High"` maps to the resampling quality. The old path build masked this.

## Validation ✅

Built from `registry gitea`. Short run: **all six packages resolve + load** via `Strategy::Registry` (audio's 7 processors, camera, display, h264, moq's 2 tracks, opus all register); **zero config-deser errors** after the fix; every processor sets up successfully and the pipeline starts (QUIC transport configured). The full MoQ roundtrip needs the external **Cloudflare draft-14 relay**, which isn't validatable on this host (MoQ is frozen pending a separate color issue) — that's the validation boundary.

CI red is the runner-can't-reach-`localhost:3300` state (same on main). Independent Opus review: PASS.

Closes #1139

🤖 Generated with [Claude Code](https://claude.com/claude-code)