### PR TITLE
feat(1136): convert h264-opus-validator to standalone (registry-only)

### DIFF
--- a/examples/h264-opus-validator/Cargo.toml
+++ b/examples/h264-opus-validator/Cargo.toml
@@ -1,10 +1,20 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+# Standalone example (headed to its own repo). The empty `[workspace]` table
+# makes this its own workspace root so it builds off-tree. This is a
+# self-contained H.264/Opus/WebRTC validator built on public crates — it does
+# not depend on the streamlib SDK or any `@tatolab/*` package, so there is
+# nothing to resolve from the Gitea registry.
 [package]
 name = "h264-opus-validator"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
 anyhow = "1.0"
+tracing = "0.1.41"
 webrtc = "0.11"
 tokio = { version = "1", features = ["full"] }
 opus = "0.3"
@@ -23,3 +33,5 @@ objc2-core-media = "0.3.2"
 objc2-foundation = "0.3.2"
 core-foundation = "0.10"
 libc = "0.2"
+
+[workspace]

--- a/examples/h264-opus-validator/src/main.rs
+++ b/examples/h264-opus-validator/src/main.rs
@@ -34,7 +34,7 @@ fn main() -> Result<()> {
             "-b:v", "2M",
             "-g", "30", // Keyframe every 30 frames (1 second)
             "-pix_fmt", "yuv420p",
-            "examples/h264-opus-validator/temp_video.mp4",
+            "temp_video.mp4",
         ])
         .status()
         .context("Failed to generate video")?;
@@ -53,7 +53,7 @@ fn main() -> Result<()> {
             "-i", "sine=frequency=440:sample_rate=48000:duration=4[l];sine=frequency=880:sample_rate=48000:duration=4[r];[l][r]amerge=inputs=2",
             "-c:a", "aac",
             "-b:a", "128k",
-            "examples/h264-opus-validator/temp_audio.aac",
+            "temp_audio.aac",
         ])
         .status()
         .context("Failed to create audio")?;
@@ -65,12 +65,12 @@ fn main() -> Result<()> {
 
     // Step 3: Mux video and audio into final MP4
     println!("📦 Step 3: Muxing into MP4...");
-    let output_path = "examples/h264-opus-validator/output.mp4";
+    let output_path = "output.mp4";
     let mux_status = Command::new("ffmpeg")
         .args(&[
             "-y",
-            "-i", "examples/h264-opus-validator/temp_video.mp4",
-            "-i", "examples/h264-opus-validator/temp_audio.aac",
+            "-i", "temp_video.mp4",
+            "-i", "temp_audio.aac",
             "-c", "copy",
             "-shortest",
             output_path,


### PR DESCRIPTION
## What

`h264-opus-validator` is a self-contained H.264/Opus/WebRTC validator on public crates (webrtc, opus, hyper, ffmpeg subprocess) — it uses **no streamlib SDK / `@tatolab` package**, so there's nothing to resolve from the registry. Conversion:

- BUSL header, `publish = false`, empty `[workspace]` self-root.
- Add the missing `tracing` dep (used pervasively in source but never declared — 121 `E0433` errors once the crate became its own workspace root).
- Fix hardcoded monorepo-relative paths (`examples/h264-opus-validator/temp_video.mp4` → `temp_video.mp4`) so ffmpeg I/O works from the example's own cwd standalone.

## Validation

Builds standalone on Linux; runs to its ffmpeg step. Full runtime validation needs an ffmpeg with **libx264** (`-preset`) — this host's ffmpeg lacks the libx264 encoder (environment limitation, unrelated to the conversion). Self-verified (low-risk mechanical changes; non-streamlib example).

Closes #1136

🤖 Generated with [Claude Code](https://claude.com/claude-code)
