### PR TITLE
feat(1158): whep-player → registry-only no-op (deferred)

### DIFF
--- a/examples/whep-player/Cargo.toml
+++ b/examples/whep-player/Cargo.toml
@@ -1,9 +1,23 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+# Standalone, registry-only example (headed to its own repo). The SDK resolves
+# from the Gitea registry by version and the empty `[workspace]` table makes
+# this its own workspace root.
+#
+# DEFERRED, not in scope: this example is a no-op at HEAD. The WHEP player
+# decodes received H.264 with VideoToolbox (macOS hardware decode) and is
+# macOS-only as written; it also uses the deprecated compile-time typed-struct
+# API. A Linux version would rewire WHEP → `@tatolab/h264` (Vulkan) decoder →
+# display via runtime `add_module`, which is future work. The real pipeline
+# lives in git history; see `src/main.rs` for the deferral note.
 [package]
 name = "whep-player"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
-streamlib-webrtc = { path = "../../packages/webrtc", version = "0.4.30", registry = "gitea" }
-ctrlc = "3.4"
+streamlib = { version = "0.4.33-dev.5", registry = "gitea" }
+
+[workspace]

--- a/examples/whep-player/src/main.rs
+++ b/examples/whep-player/src/main.rs
@@ -1,107 +1,25 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! WHEP Player using StreamLib's WebRtcWhepProcessor
+//! WHEP Player Example — receive H.264 + Opus from a WHEP endpoint and play it.
 //!
-//! This example demonstrates receiving H.264 video and Opus audio from a WHEP endpoint
-//! using StreamLib's integrated WHEP processor with VideoToolbox hardware decoding.
+//! # Registry-only migration status — DEFERRED, not in scope
+//!
+//! This example is intentionally a no-op at HEAD. Its real implementation
+//! (preserved in git history before the registry-only migration) is
+//! macOS-only: it decodes the received H.264 with VideoToolbox (macOS
+//! hardware decode) and uses the deprecated compile-time typed-struct API.
+//!
+//! A Linux WHEP player is future work — it would wire
+//! `WebRtcWhepProcessor → @tatolab/h264 (Vulkan) H264Decoder → @tatolab/display`
+//! via runtime `add_module` / `ProcessorSpec` and load every package through
+//! `Strategy::Registry` like the other examples. Restore the pipeline shape
+//! from git history when building that.
 
-use streamlib::sdk::error::Result;
-use streamlib::sdk::runtime::Runner;
-
-#[cfg(target_os = "macos")]
-use streamlib::sdk::DisplayConfig;
-
-#[cfg(target_os = "macos")]
-use streamlib::sdk::processors::DisplayProcessor;
-use streamlib::sdk::processors::{input, output, AudioOutputProcessor};
-
-fn main() -> Result<()> {
-
-    tracing::info!("=== WHEP Player - StreamLib Edition ===\n");
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        tracing::error!("This example currently only supports macOS");
-        return Ok(());
-    }
-
-    #[cfg(target_os = "macos")]
-    {
-        run_whep_player()
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn run_whep_player() -> Result<()> {
-    use streamlib_webrtc::streaming::WhepConfig;
-    use streamlib_webrtc::WebRtcWhepProcessor;
-
-    // Get WHEP endpoint URL from environment or use Cloudflare Stream default
-    let whep_url = std::env::var("WHEP_URL").unwrap_or_else(|_| {
-        "https://customer-5xiy6nkciicmt85v.cloudflarestream.com/0072e99f6ddb152545830a794d165fce/webRTC/play".to_string()
-    });
-
-    tracing::info!("📡 Connecting to WHEP endpoint:");
-    tracing::info!("   {}\n", whep_url);
-
-    // Create Runner
-    let runtime = Runner::new()?;
-
-    // Configure WHEP processor
-    let whep_config = WebRtcWhepConfig {
-        whep: WhepConfig {
-            endpoint_url: whep_url.clone(),
-            auth_token: None,
-            timeout_ms: 10000,
-        },
-    };
-
-    // Create WHEP processor
-    tracing::info!("🎬 Creating WHEP processor...");
-    let whep_processor =
-        runtime.add_processor(WebRtcWhepProcessor::Processor::node(whep_config))?;
-    tracing::info!("✅ WHEP processor created\n");
-
-    // Create display processor for video output
-    tracing::info!("📺 Creating display processor...");
-    let display = runtime.add_processor(DisplayProcessor::Processor::node(DisplayConfig {
-        width: 1920,
-        height: 1080,
-        title: Some("WHEP Player".to_string()),
-        ..Default::default()
-    }))?;
-    tracing::info!("✅ Display processor created\n");
-
-    // Create audio output processor
-    tracing::info!("🔊 Creating audio output processor...");
-    let audio_output =
-        runtime.add_processor(AudioOutputProcessor::Processor::node(Default::default()))?;
-    tracing::info!("✅ Audio output processor created\n");
-
-    // Connect processors using type-safe port markers
-    tracing::info!("🔗 Connecting processors...");
-    runtime.connect(
-        output::<WebRtcWhepProcessor::OutputLink::video_out>(&whep_processor),
-        input::<DisplayProcessor::InputLink::video>(&display),
-    )?;
-
-    runtime.connect(
-        output::<WebRtcWhepProcessor::OutputLink::audio_out>(&whep_processor),
-        input::<AudioOutputProcessor::InputLink::audio>(&audio_output),
-    )?;
-    tracing::info!("✅ Processors connected\n");
-
-    tracing::info!("🚀 Starting WHEP playback pipeline...\n");
-    tracing::info!("📺 WHEP stream is now playing!");
-    tracing::info!("Press Cmd+Q to stop.\n");
-
-    // start() blocks on macOS standalone (runs NSApplication event loop)
-    runtime.start()?;
-
-    runtime.wait_for_signal()?;
-
-    tracing::info!("✅ WHEP player stopped");
-
-    Ok(())
+fn main() {
+    eprintln!(
+        "whep-player is deferred and currently a no-op — WHEP playback decodes \
+         with VideoToolbox (macOS-only) and has no Linux registry-only path \
+         yet. See the module-level note in src/main.rs."
+    );
 }


### PR DESCRIPTION
## What

Per the decision to defer macOS-only examples without a Linux path, reduce `whep-player` to a **registry-only no-op** with a deferral note.

The WHEP player decodes received H.264 with **VideoToolbox** (macOS hardware decode) and is macOS-only as written; it also uses the deprecated typed-struct API.

Change: SDK resolves from `registry gitea`, empty `[workspace]` self-root, BUSL header, `publish = false`; `main()` prints the deferral message. A Linux WHEP player (`WHEP → @tatolab/h264` Vulkan decoder `→ display` via runtime `add_module`) is future work; the real pipeline is preserved in git history (`src/main.rs` documents the path back).

## Validation

Builds standalone from `registry gitea`; runs (prints the deferral message).

Closes #1158

🤖 Generated with [Claude Code](https://claude.com/claude-code)
