### PR TITLE
feat(1157): convert webrtc-cloudflare-stream to registry-only standalone

### DIFF
--- a/examples/webrtc-cloudflare-stream/Cargo.toml
+++ b/examples/webrtc-cloudflare-stream/Cargo.toml
@@ -1,16 +1,28 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+# Standalone, registry-only example (headed to its own repo). Every dependency
+# resolves from the Gitea registry by version, and the empty `[workspace]` table
+# makes this its own workspace root so it builds off-tree. Loads
+# `@tatolab/{audio,camera,h264,opus,webrtc}` at runtime via `Strategy::Registry`;
+# the build-time jtd-codegen generates typed configs from the schemas declared
+# in `streamlib.yaml` (Linux-only example — WHIP streaming to Cloudflare Stream).
 [package]
 name = "webrtc-cloudflare-stream"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
+streamlib-jtd-codegen = { version = "0.4.33-dev.5", registry = "gitea" }
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib = { version = "0.4.33-dev.5", registry = "gitea" }
 tokio = { version = "1.48.0", features = ["full"] }
 anyhow = "1.0.100"
 libc = "0.2"
 rustls = { version = "0.23", features = ["ring"] }
-serde = { workspace = true }
-serde_json = { workspace = true }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", features = ["preserve_order"] }
+
+[workspace]

--- a/examples/webrtc-cloudflare-stream/src/main.rs
+++ b/examples/webrtc-cloudflare-stream/src/main.rs
@@ -21,8 +21,7 @@ mod _generated_ {
     include!(concat!(env!("OUT_DIR"), "/_generated_shim.rs"));
 }
 
-#[cfg(target_os = "linux")]
-use streamlib::sdk::permissions::{request_audio_permission, request_camera_permission};
+use streamlib::sdk::RunnerAutoBuild;
 #[cfg(target_os = "linux")]
 use streamlib::sdk::error::Result;
 #[cfg(target_os = "linux")]
@@ -30,13 +29,22 @@ use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 #[cfg(target_os = "linux")]
 use streamlib::sdk::module_ident_any_version;
 #[cfg(target_os = "linux")]
-use streamlib::sdk::runtime::Runner;
-use streamlib::sdk::RunnerAutoBuild;
+use streamlib::sdk::permissions::{request_audio_permission, request_camera_permission};
 #[cfg(target_os = "linux")]
 use streamlib::sdk::processors::ProcessorSpec;
 #[cfg(target_os = "linux")]
+use streamlib::sdk::runtime::{BuildPolicy, Runner, SemVerRange, Strategy};
+#[cfg(target_os = "linux")]
 use streamlib::sdk::schema_ident_any_version;
 
+#[cfg(target_os = "linux")]
+use crate::_generated_::tatolab__audio::audio_channel_converter_config::Mode;
+#[cfg(target_os = "linux")]
+use crate::_generated_::tatolab__audio::audio_resampler_config::Quality;
+#[cfg(target_os = "linux")]
+use crate::_generated_::tatolab__audio::{
+    AudioCaptureConfig, AudioChannelConverterConfig, AudioResamplerConfig, BufferRechunkerConfig,
+};
 #[cfg(target_os = "linux")]
 use crate::_generated_::tatolab__camera::CameraConfig;
 #[cfg(target_os = "linux")]
@@ -44,18 +52,9 @@ use crate::_generated_::tatolab__h264::H264EncoderConfig;
 #[cfg(target_os = "linux")]
 use crate::_generated_::tatolab__opus::OpusEncoderConfig;
 #[cfg(target_os = "linux")]
-use crate::_generated_::tatolab__webrtc::webrtc_whip_config::{Audio, Video, Whip};
-#[cfg(target_os = "linux")]
 use crate::_generated_::tatolab__webrtc::WebrtcWhipConfig;
 #[cfg(target_os = "linux")]
-use crate::_generated_::tatolab__audio::audio_channel_converter_config::Mode;
-#[cfg(target_os = "linux")]
-use crate::_generated_::tatolab__audio::audio_resampler_config::Quality;
-#[cfg(target_os = "linux")]
-use crate::_generated_::tatolab__audio::{
-    AudioCaptureConfig, AudioChannelConverterConfig, AudioResamplerConfig,
-    BufferRechunkerConfig,
-};
+use crate::_generated_::tatolab__webrtc::webrtc_whip_config::{Audio, Video, Whip};
 
 #[cfg(target_os = "linux")]
 fn main() -> Result<()> {
@@ -66,11 +65,19 @@ fn main() -> Result<()> {
 
     let runtime = Runner::with_auto_build()?;
 
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "audio"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/audio"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "camera"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/camera"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "h264"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/h264"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "opus"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/opus"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
-    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "webrtc"), streamlib::sdk::runtime::Strategy::Path { path: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/webrtc"), build: streamlib::sdk::runtime::BuildPolicy::IfStale })?;
+    // Resolve every package from the Gitea generic registry by version — the
+    // cross-repo consumer path. The orchestrator pulls each `.slpkg` and builds
+    // it from source on the host. Registry endpoint comes from
+    // `STREAMLIB_REGISTRY_URL` (or `GITEA_URL`).
+    let registry = || Strategy::Registry {
+        version_req: SemVerRange::Any,
+        build: BuildPolicy::IfStale,
+    };
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "audio"), registry())?;
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "camera"), registry())?;
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "h264"), registry())?;
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "opus"), registry())?;
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "webrtc"), registry())?;
 
     println!("🔒 Requesting camera permission...");
     if !request_camera_permission()? {
@@ -100,7 +107,10 @@ fn main() -> Result<()> {
         serde_json::to_value(CameraConfig::default())
             .map_err(|e| streamlib::sdk::error::Error::Configuration(e.to_string()))?,
     ))?;
-    println!("✓ Camera added (capturing video @ {}x{})\n", video_width, video_height);
+    println!(
+        "✓ Camera added (capturing video @ {}x{})\n",
+        video_width, video_height
+    );
 
     println!("🎬 Adding H.264 encoder...");
     let h264_encoder = runtime.add_processor(ProcessorSpec::new(
@@ -115,7 +125,10 @@ fn main() -> Result<()> {
         })
         .map_err(|e| streamlib::sdk::error::Error::Configuration(e.to_string()))?,
     ))?;
-    println!("✓ H.264 encoder added (Vulkan Video, baseline @ {} bps)\n", video_bitrate);
+    println!(
+        "✓ H.264 encoder added (Vulkan Video, baseline @ {} bps)\n",
+        video_bitrate
+    );
 
     // Audio pipeline is optional — skip if no audio device is available.
     println!("🎤 Adding audio capture processor...");
@@ -162,10 +175,19 @@ fn main() -> Result<()> {
                 .map_err(|e| streamlib::sdk::error::Error::Configuration(e.to_string()))?,
             ))?;
 
-            Some((audio_capture, resampler, channel_converter, rechunker, opus_encoder))
+            Some((
+                audio_capture,
+                resampler,
+                channel_converter,
+                rechunker,
+                opus_encoder,
+            ))
         }
         Err(e) => {
-            println!("⚠️  Audio capture unavailable ({}), streaming video only\n", e);
+            println!(
+                "⚠️  Audio capture unavailable ({}), streaming video only\n",
+                e
+            );
             None
         }
     };

--- a/examples/webrtc-cloudflare-stream/streamlib.yaml
+++ b/examples/webrtc-cloudflare-stream/streamlib.yaml
@@ -1,4 +1,5 @@
-# yaml-language-server: $schema=../../schemas/streamlib.schema.json
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
 package:
   org: tatolab
   name: webrtc-cloudflare-stream
@@ -12,20 +13,6 @@ dependencies:
   "@tatolab/h264": "^1.0.0"
   "@tatolab/opus": "^1.0.0"
   "@tatolab/webrtc": "^1.0.0"
-
-patch:
-  "@tatolab/core":
-    path: ../../packages/core
-  "@tatolab/audio":
-    path: ../../packages/audio
-  "@tatolab/camera":
-    path: ../../packages/camera
-  "@tatolab/h264":
-    path: ../../packages/h264
-  "@tatolab/opus":
-    path: ../../packages/opus
-  "@tatolab/webrtc":
-    path: ../../packages/webrtc
 
 schemas:
   AudioFrame:


### PR DESCRIPTION
## What

Converts `examples/webrtc-cloudflare-stream` (Linux-only WebRTC WHIP → Cloudflare Stream) to standalone registry-only. **First converted example with a `build.rs` jtd-codegen step.**

- Cargo.toml: BUSL header, `publish = false`, empty `[workspace]`; drop path deps for `streamlib` + the `streamlib-jtd-codegen` **build-dep** → `{ version = "0.4.33-dev.5", registry = "gitea" }`; replace `serde`/`serde_json` `{ workspace = true }` with explicit versions (no workspace root to inherit from now).
- main.rs: 5 loads (audio/camera/h264/opus/webrtc) `Strategy::Path` → `Strategy::Registry`; cfg(linux) gating + the `_generated_` codegen'd-config usage unchanged; macOS error-exit stub unchanged.
- streamlib.yaml: drop the `patch:` block (6 path overrides) + the relative `yaml-language-server` hint; keep `dependencies` + `schemas` (the codegen reads them).

## Validation ✅

Builds standalone from `registry gitea` — **the build-time jtd-codegen resolved its declared schemas from the registry with the patch removed** (the key new finding for codegen-bearing examples). Ran the Linux pipeline against vivid: all 5 packages register from the registry, codegen'd configs deserialize cleanly (zero config-deser errors), 50s clean run. The WHIP publish to **Cloudflare Stream** is the external boundary (hardcoded endpoint).

> Note (pre-existing, unchanged): `src/main.rs` carries a hardcoded Cloudflare WHIP URL with an embedded key. Out of scope for this conversion, but worth scrubbing before this example ships to a public repo.

Independent Opus review: PASS.

Closes #1157

🤖 Generated with [Claude Code](https://claude.com/claude-code)
