### PR TITLE
feat(1140): convert polyglot-continuous-processor to registry-only standalone

### DIFF
--- a/examples/polyglot-continuous-processor/Cargo.toml
+++ b/examples/polyglot-continuous-processor/Cargo.toml
@@ -1,6 +1,12 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 
+# Standalone, registry-only example (headed to its own repo). The SDK resolves
+# from the Gitea registry by version, and the empty `[workspace]` table makes
+# this its own workspace root so it builds off-tree. Its sibling `python/` and
+# `deno/` polyglot packages load at runtime via `Strategy::Path` (selected by
+# `--runtime=python|deno`); the Python SDK resolves from the Gitea pypi index
+# and the Deno SDK (`@tatolab/streamlib-deno`) from the Gitea npm registry.
 [package]
 name = "polyglot-continuous-processor-scenario"
 version = "0.1.0"
@@ -8,5 +14,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib = { version = "0.4.33-dev.5", registry = "gitea" }
 serde_json = "1.0"
+
+[workspace]

--- a/examples/polyglot-continuous-processor/deno/streamlib.yaml
+++ b/examples/polyglot-continuous-processor/deno/streamlib.yaml
@@ -1,17 +1,13 @@
-# yaml-language-server: $schema=../../../schemas/streamlib.schema.json
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
 package:
   org: tatolab
   name: polyglot-continuous-processor-deno
   version: "0.1.0"
-  description: "Polyglot continuous processor (#542) — Deno process() driven by monotonic-clock timerfd"
+  description: "Polyglot continuous processor — Deno process() driven by monotonic-clock timerfd"
 
 dependencies:
   "@tatolab/core": "^1.0.0"
-
-# Dev-time path override; `streamlib pack` rejects this (#717).
-patch:
-  "@tatolab/core":
-    path: ../../../packages/core
 
 processors:
   - name: PolyglotContinuousProcessor

--- a/examples/polyglot-continuous-processor/python/streamlib.yaml
+++ b/examples/polyglot-continuous-processor/python/streamlib.yaml
@@ -1,9 +1,10 @@
-# yaml-language-server: $schema=../../../schemas/streamlib.schema.json
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
 package:
   org: tatolab
   name: polyglot-continuous-processor
   version: "0.1.0"
-  description: "Polyglot continuous processor (#542) — Python process() driven by monotonic-clock timerfd"
+  description: "Polyglot continuous processor — Python process() driven by monotonic-clock timerfd"
 
 processors:
   - name: PolyglotContinuousProcessor


### PR DESCRIPTION
## What

First polyglot conversion of the batch — `polyglot-continuous-processor` (python + deno) to standalone registry-only.

- Cargo.toml: drop path SDK dep → `{ version = "0.4.33-dev.5", registry = "gitea" }`; empty `[workspace]` self-root; standalone header.
- `python/streamlib.yaml` + `deno/streamlib.yaml`: remove the relative `yaml-language-server` hint; deno drops the dev `patch: @tatolab/core` block; strip stale `(#542)`/`(#717)` tracker refs.
- pyproject.toml (`streamlib>=0.4,<0.5`) + deno.json (`npm:@tatolab/streamlib-deno@^0.4`) + `.npmrc` were already registry-shaped.
- main.rs unchanged — its only `add_module` loads are the example-**local** `python/`/`deno/` packages via `Strategy::Path` (correctly stays Path).

## Validation — BOTH runtimes end-to-end ✅

- `--runtime=python`: venv provisioned (streamlib SDK from Gitea **pypi**), Python subprocess spawned, continuous execution loop, clean stop/teardown, exit 0.
- `--runtime=deno`: Deno subprocess spawned (`@tatolab/streamlib-deno` resolved from Gitea **npm**), continuous loop, clean teardown, exit 0.

Independent Opus review: PASS.

Closes #1140

🤖 Generated with [Claude Code](https://claude.com/claude-code)
