### PR TITLE
feat(1147): convert polyglot-venv-isolation to registry-only standalone

### DIFF
--- a/examples/polyglot-venv-isolation/Cargo.toml
+++ b/examples/polyglot-venv-isolation/Cargo.toml
@@ -8,5 +8,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
+streamlib = { version = "0.4.33-dev.5", registry = "gitea" }
 serde_json = "1.0"
+
+[workspace]

--- a/examples/polyglot-venv-isolation/pkg-a/python/streamlib.yaml
+++ b/examples/polyglot-venv-isolation/pkg-a/python/streamlib.yaml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=../../../../schemas/streamlib.schema.json
 package:
   org: tatolab
   name: polyglot-venv-isolation-pkg-a

--- a/examples/polyglot-venv-isolation/pkg-b/python/streamlib.yaml
+++ b/examples/polyglot-venv-isolation/pkg-b/python/streamlib.yaml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=../../../../schemas/streamlib.schema.json
 package:
   org: tatolab
   name: polyglot-venv-isolation-pkg-b


### PR DESCRIPTION
## What

Convert `polyglot-venv-isolation` (two Python packages pinning different numpy versions) to standalone registry-only.

- Cargo.toml: drop path SDK dep → `{ version = "0.4.33-dev.5", registry = "gitea" }`; empty `[workspace]`.
- pkg-a + pkg-b `python/streamlib.yaml`: remove the relative `yaml-language-server` hint.
- main.rs unchanged — both packages are example-local, correctly loaded via `Strategy::Path`.

## Validation ✅

Builds from `registry gitea`. Ran the demo: **pkg-a resolved numpy 1.26.4, pkg-b numpy 2.1.3** in separate venvs (each from the Gitea pypi index), both subprocesses set up + tore down clean, "✓ per-package venv isolation verified", exit 0.

Closes #1147

🤖 Generated with [Claude Code](https://claude.com/claude-code)
