### PR TITLE
fix(1142): drop accidentally-committed yolov8n.pt weights

### DIFF
--- a/examples/polyglot-cuda-inference/.gitignore
+++ b/examples/polyglot-cuda-inference/.gitignore
@@ -1,0 +1,3 @@
+
+# Model weights auto-downloaded by ultralytics at runtime
+*.pt


### PR DESCRIPTION
## What

Remove `examples/polyglot-cuda-inference/yolov8n.pt` — a ~6 MB YOLO weights file auto-downloaded by ultralytics at runtime that was accidentally swept into the #1142 conversion commit by a directory-wide `git add`. Adds a `.gitignore` (`*.pt`) so the runtime download stays untracked.

Follow-up cleanup to #1142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
