### PR TITLE
feat(1144): convert polyglot-manual-source to registry-only standalone

### DIFF
--- a/examples/polyglot-manual-source/Cargo.toml
+++ b/examples/polyglot-manual-source/Cargo.toml
@@ -1,12 +1,40 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 
+# Standalone, registry-only example (headed to its own repo). Every dependency
+# resolves from the Gitea registry by version. This crate is its own workspace
+# root and includes the sibling `plugin/` cdylib (the counting-sink Rust
+# plugin) as a member so `cargo build -p polyglot-manual-source-counting-sink-plugin`
+# builds it for the example to stage. All three polyglot packages
+# (counting-sink plugin, python source, deno source) load at runtime via
+# `Strategy::Path` (example-local); the Python SDK resolves from the Gitea
+# pypi index and the Deno SDK (`@tatolab/streamlib-deno`) from the Gitea npm
+# registry.
 [package]
 name = "polyglot-manual-source-scenario"
-version = "0.1.0"
+version = "0.4.33-dev.5"
 edition = "2024"
+authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
+license = "BUSL-1.1"
 publish = false
 
 [dependencies]
-streamlib = { path = "../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
-serde_json = "1.0"
+streamlib = { workspace = true }
+serde_json = { workspace = true }
+
+[workspace]
+members = ["plugin"]
+
+[workspace.package]
+version = "0.4.33-dev.5"
+edition = "2024"
+authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
+license = "BUSL-1.1"
+
+[workspace.dependencies]
+streamlib = { version = "0.4.33-dev.5", registry = "gitea" }
+streamlib-jtd-codegen = { version = "0.4.33-dev.5", registry = "gitea" }
+streamlib-plugin-abi = { version = "0.4.33-dev.5", registry = "gitea" }
+tracing = { version = "0.1.41", features = ["release_max_level_debug"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/examples/polyglot-manual-source/deno/streamlib.yaml
+++ b/examples/polyglot-manual-source/deno/streamlib.yaml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=../../../schemas/streamlib.schema.json
 package:
   org: tatolab
   name: polyglot-manual-source-deno
@@ -9,10 +8,6 @@ dependencies:
   "@tatolab/core": "^1.0.0"
 
 # Dev-time path override; `streamlib pack` rejects this (#717).
-patch:
-  "@tatolab/core":
-    path: ../../../packages/core
-
 schemas:
   # Wire types imported from @tatolab/core (#767).
   ColorInfo:

--- a/examples/polyglot-manual-source/plugin/Cargo.toml
+++ b/examples/polyglot-manual-source/plugin/Cargo.toml
@@ -1,21 +1,26 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 
+# Member of the standalone `polyglot-manual-source` workspace — inherits its
+# `[workspace.package]` fields and resolves every dependency from the registry
+# via `[workspace.dependencies]`. No path deps.
 [package]
 name = "polyglot-manual-source-counting-sink-plugin"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
+streamlib-jtd-codegen = { workspace = true }
 
 [dependencies]
-streamlib = { path = "../../../libs/streamlib-sdk", version = "0.4.30", registry = "gitea" }
-streamlib-plugin-abi = { path = "../../../libs/streamlib-plugin-abi", version = "0.4.30", registry = "gitea" }
+streamlib = { workspace = true }
+streamlib-plugin-abi = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tracing = "0.1"
+tracing = { workspace = true }

--- a/examples/polyglot-manual-source/plugin/streamlib.yaml
+++ b/examples/polyglot-manual-source/plugin/streamlib.yaml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=../../../schemas/streamlib.schema.json
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 
@@ -12,10 +11,6 @@ dependencies:
   "@tatolab/core": "^1.0.0"
 
 # Dev-time path override; `streamlib pack` rejects this (#717).
-patch:
-  "@tatolab/core":
-    path: ../../../packages/core
-
 schemas:
   # Wire types imported from @tatolab/core (#767).
   ColorInfo:

--- a/examples/polyglot-manual-source/python/streamlib.yaml
+++ b/examples/polyglot-manual-source/python/streamlib.yaml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=../../../schemas/streamlib.schema.json
 package:
   org: tatolab
   name: polyglot-manual-source
@@ -9,10 +8,6 @@ dependencies:
   "@tatolab/core": "^1.0.0"
 
 # Dev-time path override; `streamlib pack` rejects this (#717).
-patch:
-  "@tatolab/core":
-    path: ../../../packages/core
-
 schemas:
   # Wire types imported from @tatolab/core (#767).
   ColorInfo:

--- a/examples/polyglot-manual-source/src/main.rs
+++ b/examples/polyglot-manual-source/src/main.rs
@@ -251,13 +251,11 @@ fn stage_plugin_dylib(plugin_dir: &std::path::Path) -> Result<()> {
         ))
     })?;
 
+    // This example is its own workspace root (the `plugin/` cdylib is a member),
+    // so `cargo build -p ...-counting-sink-plugin` writes the dylib into this
+    // crate's own `target/` dir.
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let workspace_root = manifest_dir
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| Error::Configuration("workspace root not found".into()))?;
-
-    let target_dir = workspace_root.join("target");
+    let target_dir = manifest_dir.join("target");
     let candidates = [
         target_dir.join("debug").join(COUNTING_SINK_PLUGIN_DYLIB),
         target_dir.join("release").join(COUNTING_SINK_PLUGIN_DYLIB),


### PR DESCRIPTION
## What

Convert `polyglot-manual-source` (Python/Deno manual source → Rust counting-sink cdylib plugin) to standalone registry-only. Workspace-root-with-member shape (mirrors camera-rust-plugin): runner + plugin Cargo.tomls drop all `path` deps for `[workspace.dependencies]` registry pins; plugin uses `{ workspace = true }` + `["rlib","cdylib"]`; plugin-staging `workspace_root` fixed to the example dir. All three polyglot packages stay `Strategy::Path` (example-local). yaml hints/patches removed.

## Validation — BOTH runtimes

Builds from `registry gitea`; counting-sink `.so` exports `STREAMLIB_PLUGIN`.
- `--runtime=python`: source emitted 60 frames, counting sink received 60, exit 0.
- `--runtime=deno`: counting sink received 54 frames, exit 0.

Closes #1144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
