### PR TITLE
fix(pack): defer Python/TS entrypoint resolution to the runtime (PyPA)

### DIFF
--- a/libs/streamlib-pack/src/lib.rs
+++ b/libs/streamlib-pack/src/lib.rs
@@ -188,43 +188,22 @@ pub fn assemble_artifact(
         files.push((schema_rel.to_string_lossy().replace('\\', "/"), abs));
     }
 
-    // Per-processor entrypoint validation. Python `.py` and Deno `.ts`
-    // both live at the package root (the authored layout); the archive
-    // path mirrors the source path verbatim — no language relocates the
-    // developer's files. Rust has no source to bundle here (the cdylib
-    // is the artifact). The full source tree (these entrypoints plus
-    // helpers, `.npmrc`, assets) is bundled below via
-    // `collect_source_tree`; the dedup in the emitters drops the overlap.
-    for proc in &config.processors {
-        if let Some(entrypoint) = &proc.entrypoint {
-            let (source_file, archive_path) = match proc.runtime.language {
-                ProcessorLanguage::Python => {
-                    let module = entrypoint.split(':').next().unwrap_or(entrypoint);
-                    let source = format!("{module}.py");
-                    (source.clone(), source)
-                }
-                ProcessorLanguage::TypeScript => {
-                    let source = entrypoint
-                        .split(':')
-                        .next()
-                        .unwrap_or(entrypoint)
-                        .to_string();
-                    (source.clone(), source)
-                }
-                ProcessorLanguage::Rust => continue,
-            };
-            let source_path = pkg_dir.join(&source_file);
-            if source_path.exists() {
-                files.push((archive_path, source_path));
-            } else {
-                anyhow::bail!(
-                    "Processor '{}' entrypoint file not found: {}",
-                    proc.name,
-                    source_path.display()
-                );
-            }
-        }
-    }
+    // Entrypoint resolution is the runtime's job, not the packer's.
+    //
+    // A processor's `entrypoint` (`module:Class` for Python, `file.ts:export`
+    // for Deno) is resolved at load time by the language's own import system —
+    // Python via `importlib.import_module` (the PyPA entry-point object-reference
+    // algorithm), Deno via its module loader. Reimplementing that resolution
+    // here as a build-time path-stat is lossy and gap-prone: a dotted Python
+    // module path (`pkg.module`) maps to `pkg/module.py` OR
+    // `pkg/module/__init__.py` OR a PEP 420 namespace-package directory, and can
+    // also be provided via a zip / `.pth` / editable layout — none of which a
+    // naive `"{module}.py"` check resolves (it looks for the literal file
+    // `pkg.module.py`). So we do NOT validate or relocate entrypoints here: the
+    // FULL authored source tree (every entrypoint + helper module + asset) ships
+    // verbatim via `collect_source_tree` below, and a genuinely-bad entrypoint
+    // surfaces at load with a precise `importlib` / loader error instead of a
+    // guessed "entrypoint file not found" at pack time.
 
     let mut rebuilt = false;
 
@@ -1101,6 +1080,45 @@ mod tests {
         assert!(
             !entries.iter().any(|e| e.ends_with(".whl")),
             "no wheel should be produced, got {entries:?}"
+        );
+    }
+
+    #[test]
+    fn nested_and_namespace_python_entrypoint_packs_without_path_stat() {
+        // Regression lock for the build-time entrypoint-resolution bug: a PyPA
+        // object-reference entrypoint (`module:Class`) is a dotted *module
+        // path*, not a filename. `cuda_fisheye.processor` maps to
+        // `cuda_fisheye/processor.py` — here a PEP 420 namespace package (no
+        // `__init__.py`) — which the old `format!("{module}.py")` path-stat
+        // mis-resolved to the literal `cuda_fisheye.processor.py` and aborted.
+        // Assembly must NOT reimplement import resolution: it ships the full
+        // tree and lets the runtime's `importlib` resolve the entrypoint.
+        // Mentally restore the per-processor path-stat and this bails on a
+        // valid layout — even a `replace('.', "/")`-plus-`__init__.py` check
+        // would still reject this namespace-package case.
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: py\n  version: 0.1.0\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: python\n    execution: manual\n    entrypoint: \"cuda_fisheye.processor:P\"\n    inputs: []\n    outputs: []\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("pyproject.toml"), b"[project]\nname='py'\nversion='0.1.0'\n").unwrap();
+        std::fs::create_dir(dir.path().join("cuda_fisheye")).unwrap();
+        std::fs::write(dir.path().join("cuda_fisheye/processor.py"), b"class P:\n    pass\n").unwrap();
+
+        let out = dir.path().join("o.slpkg");
+        // Must NOT bail on the dotted/nested entrypoint.
+        assemble_artifact(
+            dir.path(),
+            &AssembleTarget::Slpkg(out.clone()),
+            &slpkg_opts(false),
+            &(),
+        )
+        .unwrap();
+        let entries = zip_entries(&out);
+        assert!(
+            entries.contains(&"cuda_fisheye/processor.py".to_string()),
+            "nested entrypoint module must ship via the source tree, got {entries:?}"
         );
     }
 


### PR DESCRIPTION
## What

`streamlib pack` validated each processor's entrypoint by computing the Python source file as `format!("{module}.py")` from the dotted module path and aborting if that literal file was absent. A PyPA object-reference entrypoint (`module:Class`) is a dotted **import module path**, not a filename — so a nested module like `cuda_fisheye.processor` was looked up as the literal `cuda_fisheye.processor.py` instead of `cuda_fisheye/processor.py`, and pack bailed "entrypoint file not found". **Any Python processor organized as a sub-package** (a folder of modules) failed to pack; only flat top-level modules worked.

**Fix: remove the build-time entrypoint file-existence check.** It was a lossy hand-rolled reimplementation of Python import resolution — even a `replace('.', "/")` patch would still miss `pkg/module/__init__.py` (regular package) and PEP 420 namespace packages (no `__init__.py`), plus zip/`.pth`/editable layouts. We don't need it:
- The **full authored source tree already ships** via `collect_source_tree` (the removed loop's file-add was deduped overlap — `slpkg_python_ships_full_source_tree_not_entrypoint_subset` proves the tree ships entrypoint + helpers).
- The **runtime resolves the entrypoint via `importlib.import_module`** (`subprocess_runner.py:99`) — the exact PyPA algorithm, gap-free.

A genuinely-bad entrypoint now surfaces at load with a precise `importlib` error instead of a guessed pack-time path. This matches how setuptools/hatchling/AWS SAM treat entry points (record the string; resolve at runtime). Adds a regression test that packs a nested **namespace-package** entrypoint (the case even a careful path-stat would still reject).

## Why this (3 research angles)

PyPA's [entry-points spec](https://packaging.python.org/en/latest/specifications/entry-points/) defines the object reference as `importable.module:object`, resolved by `importlib.import_module` — never a `.py` file lookup. Compiled ecosystems (JVM/.NET) use dotted FQ class names; script/serverless (Lambda/Node/Actions) use file paths; build tools generally don't validate entry-point targets at build time. Our runtime already does the spec-correct thing; the packer was the only place reimplementing (lossily) resolution.

## Validation

- `cargo test -p streamlib-pack` — all 19 pass, incl. the new `nested_and_namespace_python_entrypoint_packs_without_path_stat` (fails under the old code).
- E2E: published the fixed chain at `0.4.34-dev.6`, bumped `examples/cuda-fisheye-detection` to it — the example now gets **past** the original "entrypoint file not found" (nested module resolves). (Its full run is then blocked by *separate, pre-existing* registry-migration gaps — #1119 generic version-indexes incomplete + a `packages/core` test-crate path dep that breaks its publish — which are unrelated to this fix; the cuda-fisheye bump is **not** included here, left at dev.5 with its siblings.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
