### PR TITLE
fix(core): make @tatolab/core package registry-only (drop path dep)

### DIFF
--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -13,7 +13,7 @@ name = "streamlib_core_schema_tests"
 path = "src/lib.rs"
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen", version = "0.4.30", registry = "gitea" }
+streamlib-jtd-codegen = { version = "0.4.30", registry = "gitea" }
 
 [dependencies]
 serde.workspace = true


### PR DESCRIPTION
## What

`packages/core/Cargo.toml` was the last *publishable* package still carrying a `path = "../../libs/streamlib-jtd-codegen"` dep, so `streamlib pack`s no-path-deps gate rejected it — `@tatolab/core` failed to publish to Gitea and never got the #1119 tokenless version `@index`, which broke registry resolution for every package depending on `@tatolab/core`.

Drop the path (keep `{ version = "0.4.30", registry = "gitea" }`), matching every sibling package. Verified: core now packs + publishes + carries `core@index`.

## Note

The only remaining path deps under `packages/` are in `test-fixtures` / `test-fixtures-abi-mismatch`, which are *deliberately* workspace-member internal test infra (not published; skipped from pack) that build against the in-tree engine — converting those would break the engine load tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
