### PR TITLE
refactor(engine): test schema-registry on synthetic fixtures, not embedded package schemas

### DIFF
--- a/libs/streamlib-engine/src/core/embedded_schemas/integration_tests.rs
+++ b/libs/streamlib-engine/src/core/embedded_schemas/integration_tests.rs
@@ -24,11 +24,15 @@ use iceoryx2::prelude::*;
 use streamlib_idents::{Org, Package, SchemaIdent, SemVer, TypeName};
 use streamlib_processor_schema::PortSchemaSpec;
 
-/// Build a `PortSchemaSpec::Specific` for a `@tatolab/core/<Type>@1.0.0` lookup.
-fn core_spec(type_name: &str) -> PortSchemaSpec {
+/// Build a `PortSchemaSpec::Specific` for a synthetic `@test/wire/<Type>@1.0.0`
+/// lookup. The engine has no compile-time knowledge of any package's real wire
+/// vocabulary — these tests register their own synthetic schemas (see
+/// [`test_support`]) and exercise the resolver + publisher-sizing mechanics
+/// against them.
+fn test_wire_spec(type_name: &str) -> PortSchemaSpec {
     PortSchemaSpec::Specific(SchemaIdent::new(
-        Org::new("tatolab").unwrap(),
-        Package::new("core").unwrap(),
+        Org::new("test").unwrap(),
+        Package::new("wire").unwrap(),
         TypeName::new(type_name).unwrap(),
         SemVer::new(1, 0, 0),
     ))
@@ -125,19 +129,24 @@ fn test_loan_256kb_succeeds_with_512kb_publisher_limit() {
 // =============================================================================
 
 #[test]
-fn test_schema_max_payload_bytes_audioframe() {
-    test_support::register_core_wire_vocabulary();
-    let bytes = max_payload_bytes_for_port_spec(&core_spec("AudioFrame")).unwrap();
-    assert_eq!(bytes, 65536, "audioframe should declare 64 KB");
+fn test_schema_max_payload_bytes_small_frame() {
+    test_support::register_test_wire_vocabulary();
+    let bytes = max_payload_bytes_for_port_spec(&test_wire_spec("SmallFrame")).unwrap();
+    assert_eq!(
+        bytes,
+        test_support::SMALL_FRAME_MAX_PAYLOAD_BYTES,
+        "resolver returns the declared 128 KiB payload bound (a non-default value)"
+    );
 }
 
 #[test]
-fn test_schema_max_payload_bytes_videoframe() {
-    test_support::register_core_wire_vocabulary();
-    let bytes = max_payload_bytes_for_port_spec(&core_spec("VideoFrame")).unwrap();
+fn test_schema_max_payload_bytes_large_frame() {
+    test_support::register_test_wire_vocabulary();
+    let bytes = max_payload_bytes_for_port_spec(&test_wire_spec("LargeFrame")).unwrap();
     assert_eq!(
-        bytes, 65536,
-        "videoframe carries surface IDs only — 64 KB default is correct"
+        bytes,
+        test_support::LARGE_FRAME_MAX_PAYLOAD_BYTES,
+        "resolver returns the declared 16 MiB payload bound"
     );
 }
 
@@ -169,15 +178,15 @@ fn test_schema_max_payload_bytes_unknown_schema_errors_with_add_module_hint() {
 }
 
 #[test]
-fn test_encodedvideoframe_larger_than_audioframe() {
-    test_support::register_core_wire_vocabulary();
-    let audio = max_payload_bytes_for_port_spec(&core_spec("AudioFrame")).unwrap();
-    let video = max_payload_bytes_for_port_spec(&core_spec("EncodedVideoFrame")).unwrap();
+fn test_large_frame_larger_than_small_frame() {
+    test_support::register_test_wire_vocabulary();
+    let small = max_payload_bytes_for_port_spec(&test_wire_spec("SmallFrame")).unwrap();
+    let large = max_payload_bytes_for_port_spec(&test_wire_spec("LargeFrame")).unwrap();
     assert!(
-        video > audio,
-        "encodedvideoframe ({} bytes) should declare more capacity than audioframe ({} bytes)",
-        video,
-        audio
+        large > small,
+        "large frame ({} bytes) should declare more capacity than small frame ({} bytes)",
+        large,
+        small
     );
 }
 
@@ -189,53 +198,53 @@ fn test_encodedvideoframe_larger_than_audioframe() {
 // and verify that large payloads actually transit end-to-end.
 // =============================================================================
 
-/// Publisher sized from the audioframe schema (64 KB) rejects a 256 KB payload.
-/// This mirrors the pre-fix failure mode for any connection carrying audioframes.
+/// Publisher sized from the small-frame schema (128 KiB) rejects a 256 KiB
+/// payload — mirrors the pre-fix failure mode for any sub-256-KiB connection.
 #[test]
-fn test_audioframe_schema_publisher_rejects_256kb() {
-    test_support::register_core_wire_vocabulary();
+fn test_small_frame_schema_publisher_rejects_256kb() {
+    test_support::register_test_wire_vocabulary();
     let node = Iceoryx2Node::new().unwrap();
     let service = node
         .open_or_create_service(
-            "streamlib/test/schema-audio-reject",
+            "streamlib/test/schema-small-reject",
             crate::iceoryx2::DEFAULT_MAX_QUEUED_MESSAGES,
             true,
         )
         .unwrap();
 
-    let max_bytes = max_payload_bytes_for_port_spec(&core_spec("AudioFrame")).unwrap();
+    let max_bytes = max_payload_bytes_for_port_spec(&test_wire_spec("SmallFrame")).unwrap();
     let publisher = service.create_publisher(max_bytes).unwrap();
 
-    // 256 KB exceeds the 64 KB audioframe limit.
+    // 256 KiB exceeds the 64 KiB small-frame limit.
     let result = publisher.loan_slice_uninit(256 * 1024);
     assert!(
         result.is_err(),
-        "Expected 256 KB loan to fail on audioframe-sized publisher ({} bytes)",
+        "Expected 256 KB loan to fail on small-frame-sized publisher ({} bytes)",
         max_bytes
     );
 }
 
-/// Publisher sized from the encodedvideoframe schema accepts a 256 KB payload.
+/// Publisher sized from the large-frame schema accepts a 256 KiB payload.
 /// This is the GREEN-after-fix test: before the fix all publishers used ~64 KB.
 #[test]
-fn test_encodedvideoframe_schema_publisher_accepts_256kb() {
-    test_support::register_core_wire_vocabulary();
+fn test_large_frame_schema_publisher_accepts_256kb() {
+    test_support::register_test_wire_vocabulary();
     let node = Iceoryx2Node::new().unwrap();
     let service = node
         .open_or_create_service(
-            "streamlib/test/schema-video-ok",
+            "streamlib/test/schema-large-ok",
             crate::iceoryx2::DEFAULT_MAX_QUEUED_MESSAGES,
             true,
         )
         .unwrap();
 
-    let max_bytes = max_payload_bytes_for_port_spec(&core_spec("EncodedVideoFrame")).unwrap();
+    let max_bytes = max_payload_bytes_for_port_spec(&test_wire_spec("LargeFrame")).unwrap();
     let publisher = service.create_publisher(max_bytes).unwrap();
 
     let result = publisher.loan_slice_uninit(256 * 1024);
     assert!(
         result.is_ok(),
-        "Expected 256 KB loan to succeed on encodedvideoframe-sized publisher ({} bytes), got: {:?}",
+        "Expected 256 KB loan to succeed on large-frame-sized publisher ({} bytes), got: {:?}",
         max_bytes,
         result.err()
     );
@@ -250,7 +259,7 @@ fn test_encodedvideoframe_schema_publisher_accepts_256kb() {
 /// have been silently truncated on receipt.
 #[test]
 fn test_frame_header_plus_256kb_roundtrip_through_slice_service() {
-    test_support::register_core_wire_vocabulary();
+    test_support::register_test_wire_vocabulary();
     let node = Iceoryx2Node::new().unwrap();
     let service = node
         .open_or_create_service(
@@ -261,7 +270,7 @@ fn test_frame_header_plus_256kb_roundtrip_through_slice_service() {
         .unwrap();
 
     let data_size = 256 * 1024;
-    let max_bytes = max_payload_bytes_for_port_spec(&core_spec("EncodedVideoFrame")).unwrap();
+    let max_bytes = max_payload_bytes_for_port_spec(&test_wire_spec("LargeFrame")).unwrap();
     // Publisher sized like the FFI layer: schema max + header.
     let publisher = service.create_publisher(max_bytes).unwrap();
     let subscriber = service.create_subscriber().unwrap();
@@ -273,9 +282,8 @@ fn test_frame_header_plus_256kb_roundtrip_through_slice_service() {
 
     let total_len = FRAME_HEADER_SIZE + data_size;
     let mut frame = vec![0u8; total_len];
-    let schema_ident =
-        SchemaIdentWire::from_segments("tatolab", "core", "EncodedVideoFrame", 1, 0, 0)
-            .expect("EncodedVideoFrame segments fit SchemaIdentWire bounds");
+    let schema_ident = SchemaIdentWire::from_segments("test", "wire", "LargeFrame", 1, 0, 0)
+        .expect("LargeFrame segments fit SchemaIdentWire bounds");
     FrameHeader::new("dest_port", schema_ident, 42, data_size as u32)
         .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
     frame[FRAME_HEADER_SIZE..].copy_from_slice(&data);
@@ -306,8 +314,8 @@ fn test_frame_header_plus_256kb_roundtrip_through_slice_service() {
 
     let header = FrameHeader::read_from_slice(&buf);
     assert_eq!(header.port(), "dest_port");
-    let expected_ident = SchemaIdentWire::from_segments("tatolab", "core", "EncodedVideoFrame", 1, 0, 0)
-        .unwrap();
+    let expected_ident =
+        SchemaIdentWire::from_segments("test", "wire", "LargeFrame", 1, 0, 0).unwrap();
     assert_eq!(header.schema(), &expected_ident);
     assert_eq!(header.timestamp_ns, 42);
     assert_eq!(header.len as usize, data_size);
@@ -323,18 +331,18 @@ fn test_frame_header_plus_256kb_roundtrip_through_slice_service() {
 /// Full publish/subscribe round-trip: publisher sized from encodedvideoframe schema,
 /// 256 KB payload written and received on the same service.
 #[test]
-fn test_encodedvideoframe_schema_publisher_subscriber_roundtrip_256kb() {
-    test_support::register_core_wire_vocabulary();
+fn test_large_frame_schema_publisher_subscriber_roundtrip_256kb() {
+    test_support::register_test_wire_vocabulary();
     let node = Iceoryx2Node::new().unwrap();
     let service = node
         .open_or_create_service(
-            "streamlib/test/schema-video-roundtrip",
+            "streamlib/test/schema-large-roundtrip",
             crate::iceoryx2::DEFAULT_MAX_QUEUED_MESSAGES,
             true,
         )
         .unwrap();
 
-    let max_bytes = max_payload_bytes_for_port_spec(&core_spec("EncodedVideoFrame")).unwrap();
+    let max_bytes = max_payload_bytes_for_port_spec(&test_wire_spec("LargeFrame")).unwrap();
     let publisher = service.create_publisher(max_bytes).unwrap();
     let subscriber = service.create_subscriber().unwrap();
 

--- a/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
+++ b/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
@@ -278,41 +278,49 @@ fn is_semver(s: &str) -> bool {
 
 #[cfg(test)]
 pub(crate) mod test_support {
-    //! Test helpers: register the `@tatolab/core` wire vocabulary
-    //! against the live registry so consumers exercising VideoFrame /
-    //! AudioFrame / EncodedVideoFrame lookups can run without spinning
-    //! up a full `Runner::add_module` chain. Mirrors what
-    //! `Runner::add_module(@tatolab/core)` would do in production.
+    //! Synthetic in-test schema fixtures for exercising the registry +
+    //! metadata-resolver mechanics.
     //!
-    //! Schemas are embedded via `include_str!` at compile time — the
-    //! engine doesn't depend on `@tatolab/core` as a Cargo crate, the
-    //! linkage is through `streamlib.yaml` and the schemas live on disk
-    //! at the workspace-relative path below.
+    //! The engine registry starts empty and learns every real schema only
+    //! at runtime via `Runner::add_module`. These tests therefore register
+    //! their own synthetic schemas under a neutral `@test/wire/*` namespace
+    //! rather than reaching into any package's real schema files — the
+    //! engine has no compile-time knowledge of `@tatolab/core`,
+    //! `@tatolab/mavlink`, or any other package's wire vocabulary. Locking a
+    //! package's own declarations (e.g. core's payload bounds, mavlink's
+    //! queue depth) belongs in that package's tests, not the engine's.
 
     use super::register_schema;
     use std::sync::Once;
 
-    const AUDIO_FRAME_YAML: &str =
-        include_str!("../../../../../packages/core/schemas/audio_frame.yaml");
-    const ENCODED_AUDIO_FRAME_YAML: &str =
-        include_str!("../../../../../packages/core/schemas/encoded_audio_frame.yaml");
-    const ENCODED_VIDEO_FRAME_YAML: &str =
-        include_str!("../../../../../packages/core/schemas/encoded_video_frame.yaml");
-    const VIDEO_FRAME_YAML: &str =
-        include_str!("../../../../../packages/core/schemas/video_frame.yaml");
+    /// Synthetic "small" wire schema — 128 KiB payload bound. Deliberately
+    /// NOT the iceoryx2 default ([`MAX_PAYLOAD_SIZE`] = 64 KiB) so that
+    /// asserting the resolved value distinguishes "read the declared
+    /// metadata" from "fell back to the default".
+    ///
+    /// [`MAX_PAYLOAD_SIZE`]: crate::iceoryx2::MAX_PAYLOAD_SIZE
+    pub const SMALL_FRAME_ID: &str = "@test/wire/SmallFrame";
+    /// Declared `max_payload_bytes` for [`SMALL_FRAME_ID`] (128 KiB).
+    pub const SMALL_FRAME_MAX_PAYLOAD_BYTES: usize = 131072;
+    /// Synthetic "large" wire schema — 16 MiB payload bound, sized for the
+    /// 256 KiB publish/subscribe roundtrip tests.
+    pub const LARGE_FRAME_ID: &str = "@test/wire/LargeFrame";
+    /// Declared `max_payload_bytes` for [`LARGE_FRAME_ID`] (16 MiB).
+    pub const LARGE_FRAME_MAX_PAYLOAD_BYTES: usize = 16 * 1024 * 1024;
 
-    /// Register the four wire-vocabulary schemas. Idempotent across
-    /// tests in the same process.
-    pub fn register_core_wire_vocabulary() {
+    /// Register the synthetic wire schemas. Idempotent across tests in the
+    /// same process.
+    pub fn register_test_wire_vocabulary() {
         static INIT: Once = Once::new();
         INIT.call_once(|| {
-            register_schema("@tatolab/core/AudioFrame", AUDIO_FRAME_YAML);
-            register_schema("@tatolab/core/EncodedAudioFrame", ENCODED_AUDIO_FRAME_YAML);
             register_schema(
-                "@tatolab/core/EncodedVideoFrame",
-                ENCODED_VIDEO_FRAME_YAML,
+                SMALL_FRAME_ID,
+                "metadata:\n  type: SmallFrame\n  max_payload_bytes: 131072\n  max_queued_messages: 32\n",
             );
-            register_schema("@tatolab/core/VideoFrame", VIDEO_FRAME_YAML);
+            register_schema(
+                LARGE_FRAME_ID,
+                "metadata:\n  type: LargeFrame\n  max_payload_bytes: 16777216\n  max_queued_messages: 16\n",
+            );
         });
     }
 }
@@ -321,18 +329,19 @@ pub(crate) mod test_support {
 mod tests {
     //! Tests mutate the global `SCHEMA_REGISTRY` and do NOT clean up
     //! after themselves — every registration uses a canonical id
-    //! unique to its test. The `register_core_wire_vocabulary()` setup
-    //! helper is `Once`-guarded, so wire-vocabulary entries are
-    //! registered at most once per test process.
+    //! unique to its test. The `register_test_wire_vocabulary()` setup
+    //! helper is `Once`-guarded, so the synthetic fixtures are registered
+    //! at most once per test process.
     use super::*;
     use streamlib_idents::{Org, Package, SchemaIdent, SemVer, TypeName};
     use streamlib_processor_schema::PortSchemaSpec;
 
-    /// Construct a `PortSchemaSpec::Specific` for a `@tatolab/core/<Type>` lookup.
-    fn core_spec(type_name: &str) -> PortSchemaSpec {
+    /// Construct a `PortSchemaSpec::Specific` for a synthetic
+    /// `@test/wire/<Type>` lookup.
+    fn test_wire_spec(type_name: &str) -> PortSchemaSpec {
         PortSchemaSpec::Specific(SchemaIdent::new(
-            Org::new("tatolab").unwrap(),
-            Package::new("core").unwrap(),
+            Org::new("test").unwrap(),
+            Package::new("wire").unwrap(),
             TypeName::new(type_name).unwrap(),
             SemVer::new(1, 0, 0),
         ))
@@ -340,11 +349,11 @@ mod tests {
 
     #[test]
     fn lookup_finds_wire_vocabulary_via_new_identifier() {
-        test_support::register_core_wire_vocabulary();
-        let yaml = get_embedded_schema_definition("@tatolab/core/VideoFrame");
+        test_support::register_test_wire_vocabulary();
+        let yaml = get_embedded_schema_definition(test_support::SMALL_FRAME_ID);
         assert!(
             yaml.is_some(),
-            "wire vocabulary VideoFrame must be registered before lookup"
+            "registered schema must be found before lookup"
         );
         assert!(
             yaml.unwrap().contains("metadata"),
@@ -354,9 +363,10 @@ mod tests {
 
     #[test]
     fn lookup_strips_version_suffix() {
-        test_support::register_core_wire_vocabulary();
-        let unversioned = get_embedded_schema_definition("@tatolab/core/AudioFrame");
-        let versioned = get_embedded_schema_definition("@tatolab/core/AudioFrame@1.0.0");
+        test_support::register_test_wire_vocabulary();
+        let unversioned = get_embedded_schema_definition(test_support::SMALL_FRAME_ID);
+        let versioned =
+            get_embedded_schema_definition(&format!("{}@1.0.0", test_support::SMALL_FRAME_ID));
         assert!(unversioned.is_some());
         assert_eq!(unversioned.as_deref(), versioned.as_deref());
     }
@@ -374,11 +384,11 @@ mod tests {
         // walking the manifest at build time would seed
         // `@tatolab/escalate/EscalateRequest` into the registry.
         // No test in this crate's test binary registers it (the
-        // wire-vocabulary setup helper only covers `@tatolab/core/*`,
-        // and the `add_module` regression tests build fresh tempdir
-        // packages with no `@tatolab/escalate` dep). So if this lookup
-        // ever returns Some, someone has reintroduced a build-time
-        // seeding path.
+        // synthetic wire-vocabulary setup helper only registers
+        // `@test/wire/*` fixtures, and the `add_module` regression tests
+        // build fresh tempdir packages with no `@tatolab/escalate` dep).
+        // So if this lookup ever returns Some, someone has reintroduced a
+        // build-time seeding path.
         assert!(
             get_embedded_schema_definition("@tatolab/escalate/EscalateRequest").is_none(),
             "registry must start empty — `@tatolab/escalate/EscalateRequest` would only \
@@ -448,11 +458,22 @@ mod tests {
     }
 
     #[test]
-    fn max_payload_bytes_resolves_video_frame() {
-        test_support::register_core_wire_vocabulary();
-        let spec = core_spec("VideoFrame");
-        let bytes = max_payload_bytes_for_port_spec(&spec).unwrap();
-        assert!(bytes >= 65536, "VideoFrame should declare a generous payload bound");
+    fn max_payload_bytes_resolves_declared_value() {
+        use crate::iceoryx2::MAX_PAYLOAD_SIZE;
+        test_support::register_test_wire_vocabulary();
+        let bytes = max_payload_bytes_for_port_spec(&test_wire_spec("SmallFrame")).unwrap();
+        assert_eq!(
+            bytes,
+            test_support::SMALL_FRAME_MAX_PAYLOAD_BYTES,
+            "resolver must return the schema's declared metadata.max_payload_bytes"
+        );
+        // Guard against a reverted resolver that ignores metadata and always
+        // returns the default: the declared value is deliberately not the default.
+        assert_ne!(
+            test_support::SMALL_FRAME_MAX_PAYLOAD_BYTES,
+            MAX_PAYLOAD_SIZE as usize,
+            "test fixture must declare a non-default payload bound to be meaningful"
+        );
     }
 
     #[test]
@@ -545,25 +566,6 @@ mod tests {
             max_queued_messages_for_port_spec(&spec).unwrap(),
             DEFAULT_MAX_QUEUED_MESSAGES
         );
-    }
-
-    /// The MAVLink wire schema declares `max_queued_messages: 64` for
-    /// 200 Hz burst tolerance. Locks the live in-tree declaration so a
-    /// silent edit to the YAML (back to 16, or to a lower value)
-    /// trips this test rather than silently regressing the AGP pipeline.
-    #[test]
-    fn max_queued_messages_resolves_mavlink_at_64() {
-        register_schema(
-            "@tatolab/mavlink/MavlinkMessage",
-            include_str!("../../../../../packages/mavlink/schemas/mavlink_message.yaml"),
-        );
-        let spec = PortSchemaSpec::Specific(SchemaIdent::new(
-            Org::new("tatolab").unwrap(),
-            Package::new("mavlink").unwrap(),
-            TypeName::new("MavlinkMessage").unwrap(),
-            SemVer::new(1, 0, 0),
-        ));
-        assert_eq!(max_queued_messages_for_port_spec(&spec).unwrap(), 64);
     }
 
     /// Locks the default-fallback path: a processor type that isn't


### PR DESCRIPTION
## What

The engine schema registry starts empty and learns every real schema only at runtime via `Runner::add_module` — but two `#[cfg(test)]` modules under `core/embedded_schemas/` were `include_str!`-embedding real package schema YAMLs at **compile time** to drive their lookups:

- `packages/core/schemas/{audio,encoded_audio,encoded_video,video}_frame.yaml` via a `register_core_wire_vocabulary()` helper, and
- `packages/mavlink/schemas/mavlink_message.yaml` in a test value-locking mavlink's declared `max_queued_messages: 64`.

That's a layering violation: the engine substrate baking in package wire vocabulary at build time, contradicting its own design (the registry is empty until runtime registration).

## Change

Replace the embeds with **synthetic schemas** registered under a neutral `@test/wire/*` namespace:

- `SmallFrame` — `max_payload_bytes: 131072` (128 KiB, deliberately **not** the 65536 default, so the assertion distinguishes "read declared metadata" from "fell back to default") + `max_queued_messages: 32`.
- `LargeFrame` — `max_payload_bytes: 16777216` (16 MiB, sized for the 256 KiB publish/subscribe roundtrips) + `max_queued_messages: 16`.

The registry + metadata-resolver mechanics (payload/queue lookup, version-suffix stripping, registry-miss → `add_module` hint, the iceoryx2 publisher-sizing roundtrips) are exercised exactly as before — now without reaching into any package's schema files. The mavlink value-lock test is removed; that lock belongs in the mavlink package's own tests, not the engine's.

## Why it locks behavior (not feel-good)

Mentally reverting the resolver to ignore metadata and always return the default fails: `max_payload_bytes_resolves_declared_value`, both `_small_frame`/`_large_frame` payload tests (non-default values), `large > small`, and the 256 KiB publisher **accept** test (a default-sized 64 KiB publisher can't loan 256 KiB). The accept/reject pair genuinely distinguishes a 128 KiB-sized publisher from a 16 MiB one.

## Validation

`cargo test -p streamlib-engine --lib core::embedded_schemas` → **32 passed, 0 failed**.

## Context

This is the one keeper from the reverted repo-split spike (#1114) — the split was rejected in favor of staying monorepo with the existing `consumer-rhi` + `check-boundaries` separation enforcement, but the spike surfaced this real embed bug, which holds regardless of repo structure. Partially addresses the reframed #1114 (engine carries no compile-time embed of any package schema).

Relates to #1114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)