### PR TITLE
feat(mavlink): add command_long + encapsulated_data to MavlinkMessage union

### DIFF
--- a/packages/mavlink/schemas/mavlink_message.yaml
+++ b/packages/mavlink/schemas/mavlink_message.yaml
@@ -354,3 +354,81 @@ mapping:
         metadata:
           description: "Target component ID. Request: 0 (broadcast) or id of specific component. MAVLink2 extension field that defaults to 0."
         type: uint8
+
+  command_long:
+    properties:
+      system_id:
+        metadata: { description: "MAVLink system ID of the sender." }
+        type: uint8
+      component_id:
+        metadata: { description: "MAVLink component ID of the sender." }
+        type: uint8
+      sequence:
+        metadata: { description: "MAVLink sequence counter." }
+        type: uint8
+      peer_addr:
+        metadata: { description: "Networking peer address (host:port). See heartbeat.peer_addr." }
+        type: string
+      timestamp_ns:
+        metadata: { description: "Monotonic timestamp from source NetworkPacket recv (int64 as string)." }
+        type: string
+      target_system:
+        metadata: { description: "System ID of the command target." }
+        type: uint8
+      target_component:
+        metadata: { description: "Component ID of the command target." }
+        type: uint8
+      command:
+        metadata:
+          description: "MAV_CMD command id (uint16). 400 = MAV_CMD_COMPONENT_ARM_DISARM. The encoder lifts this to a typed MavCmd; ids outside the common dialect are rejected on encode."
+        type: uint16
+      confirmation:
+        metadata: { description: "0 for the first transmission of this command; incremented on retransmission." }
+        type: uint8
+      param1:
+        metadata: { description: "Command parameter 1 (meaning depends on command; for ARM_DISARM, 1=arm / 0=disarm)." }
+        type: float32
+      param2:
+        metadata: { description: "Command parameter 2." }
+        type: float32
+      param3:
+        metadata: { description: "Command parameter 3." }
+        type: float32
+      param4:
+        metadata: { description: "Command parameter 4." }
+        type: float32
+      param5:
+        metadata: { description: "Command parameter 5." }
+        type: float32
+      param6:
+        metadata: { description: "Command parameter 6." }
+        type: float32
+      param7:
+        metadata: { description: "Command parameter 7." }
+        type: float32
+
+  encapsulated_data:
+    properties:
+      system_id:
+        metadata: { description: "MAVLink system ID of the sender." }
+        type: uint8
+      component_id:
+        metadata: { description: "MAVLink component ID of the sender." }
+        type: uint8
+      sequence:
+        metadata: { description: "MAVLink sequence counter." }
+        type: uint8
+      peer_addr:
+        metadata: { description: "Networking peer address (host:port). See heartbeat.peer_addr." }
+        type: string
+      timestamp_ns:
+        metadata: { description: "Monotonic timestamp from source NetworkPacket recv (int64 as string)." }
+        type: string
+      seqnr:
+        metadata: { description: "Data-chunk sequence number. The AGP sim streams race-status + track data in the payload (see VADR-TS-002)." }
+        type: uint16
+      data:
+        metadata:
+          description: "Raw chunk payload (up to 253 bytes). Application-defined; the AGP sim packs its race-status / track structs here for the consumer to parse."
+        elements:
+          type: uint8

--- a/packages/mavlink/src/mavlink_decoder.rs
+++ b/packages/mavlink/src/mavlink_decoder.rs
@@ -17,8 +17,9 @@ use streamlib::sdk::error::Result;
 use streamlib::sdk::processors::ReactiveProcessor;
 
 use crate::_generated_::tatolab__mavlink::mavlink_message::{
-    MavlinkMessageAttitude, MavlinkMessageHeartbeat, MavlinkMessageHighresImu,
-    MavlinkMessageSetAttitudeTarget, MavlinkMessageSetPositionTargetLocalNed, MavlinkMessageTimesync,
+    MavlinkMessageAttitude, MavlinkMessageCommandLong, MavlinkMessageEncapsulatedData,
+    MavlinkMessageHeartbeat, MavlinkMessageHighresImu, MavlinkMessageSetAttitudeTarget,
+    MavlinkMessageSetPositionTargetLocalNed, MavlinkMessageTimesync,
 };
 use crate::_generated_::{MavlinkMessage, NetworkPacket};
 
@@ -213,6 +214,33 @@ fn convert(
             ts1: d.ts1.to_string(),
             target_system: d.target_system,
             target_component: d.target_component,
+        }),
+        COMMAND_LONG(d) => MavlinkMessage::CommandLong(MavlinkMessageCommandLong {
+            system_id,
+            component_id,
+            sequence,
+            peer_addr,
+            timestamp_ns,
+            target_system: d.target_system,
+            target_component: d.target_component,
+            command: d.command as u16,
+            confirmation: d.confirmation,
+            param1: d.param1,
+            param2: d.param2,
+            param3: d.param3,
+            param4: d.param4,
+            param5: d.param5,
+            param6: d.param6,
+            param7: d.param7,
+        }),
+        ENCAPSULATED_DATA(d) => MavlinkMessage::EncapsulatedData(MavlinkMessageEncapsulatedData {
+            system_id,
+            component_id,
+            sequence,
+            peer_addr,
+            timestamp_ns,
+            seqnr: d.seqnr,
+            data: d.data.to_vec(),
         }),
         _ => return None,
     })

--- a/packages/mavlink/src/mavlink_encoder.rs
+++ b/packages/mavlink/src/mavlink_encoder.rs
@@ -12,9 +12,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use mavlink::MavHeader;
 use mavlink::dialects::common::{
-    ATTITUDE_DATA, AttitudeTargetTypemask, HEARTBEAT_DATA, HIGHRES_IMU_DATA, HighresImuUpdatedFlags,
-    MavAutopilot, MavFrame, MavMessage, MavModeFlag, MavState, MavType, PositionTargetTypemask,
-    SET_ATTITUDE_TARGET_DATA, SET_POSITION_TARGET_LOCAL_NED_DATA, TIMESYNC_DATA,
+    ATTITUDE_DATA, AttitudeTargetTypemask, COMMAND_LONG_DATA, ENCAPSULATED_DATA_DATA, HEARTBEAT_DATA,
+    HIGHRES_IMU_DATA, HighresImuUpdatedFlags, MavAutopilot, MavCmd, MavFrame, MavMessage,
+    MavModeFlag, MavState, MavType, PositionTargetTypemask, SET_ATTITUDE_TARGET_DATA,
+    SET_POSITION_TARGET_LOCAL_NED_DATA, TIMESYNC_DATA,
 };
 use num_traits::FromPrimitive;
 use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
@@ -137,6 +138,8 @@ fn identity(msg: &MavlinkMessage, default_sys: u8, default_comp: u8) -> (u8, u8,
         }
         MavlinkMessage::SetAttitudeTarget(d) => (d.system_id, d.component_id, d.peer_addr.clone()),
         MavlinkMessage::Timesync(d) => (d.system_id, d.component_id, d.peer_addr.clone()),
+        MavlinkMessage::CommandLong(d) => (d.system_id, d.component_id, d.peer_addr.clone()),
+        MavlinkMessage::EncapsulatedData(d) => (d.system_id, d.component_id, d.peer_addr.clone()),
     };
     let sys = if sys == 0 { default_sys } else { sys };
     let comp = if comp == 0 { default_comp } else { comp };
@@ -259,6 +262,32 @@ fn convert_to_mavlink(msg: &MavlinkMessage) -> Result<MavMessage> {
                 target_component: d.target_component,
             })
         }
+        MavlinkMessage::CommandLong(d) => MavMessage::COMMAND_LONG(COMMAND_LONG_DATA {
+            target_system: d.target_system,
+            target_component: d.target_component,
+            command: MavCmd::from_u16(d.command).ok_or_else(|| {
+                Error::Configuration(format!(
+                    "MavlinkEncoder: COMMAND_LONG.command = {} is not a known MAV_CMD in the common dialect",
+                    d.command
+                ))
+            })?,
+            confirmation: d.confirmation,
+            param1: d.param1,
+            param2: d.param2,
+            param3: d.param3,
+            param4: d.param4,
+            param5: d.param5,
+            param6: d.param6,
+            param7: d.param7,
+        }),
+        MavlinkMessage::EncapsulatedData(d) => {
+            // ENCAPSULATED_DATA carries a fixed 253-byte payload on the wire;
+            // pad or truncate the variable-length schema bytes to fit.
+            let mut data = [0u8; 253];
+            let n = d.data.len().min(253);
+            data[..n].copy_from_slice(&d.data[..n]);
+            MavMessage::ENCAPSULATED_DATA(ENCAPSULATED_DATA_DATA { seqnr: d.seqnr, data })
+        }
     })
 }
 
@@ -279,9 +308,9 @@ fn lift_enum<E: FromPrimitive>(value: u8, ctx: &'static str) -> Result<E> {
 mod tests {
     use super::*;
     use crate::_generated_::tatolab__mavlink::mavlink_message::{
-        MavlinkMessageAttitude, MavlinkMessageHeartbeat, MavlinkMessageHighresImu,
-        MavlinkMessageSetAttitudeTarget, MavlinkMessageSetPositionTargetLocalNed,
-        MavlinkMessageTimesync,
+        MavlinkMessageAttitude, MavlinkMessageCommandLong, MavlinkMessageEncapsulatedData,
+        MavlinkMessageHeartbeat, MavlinkMessageHighresImu, MavlinkMessageSetAttitudeTarget,
+        MavlinkMessageSetPositionTargetLocalNed, MavlinkMessageTimesync,
     };
 
     fn make_heartbeat(sys: u8, comp: u8) -> MavlinkMessage {
@@ -403,6 +432,45 @@ mod tests {
         })
     }
 
+    fn make_command_long() -> MavlinkMessage {
+        MavlinkMessage::CommandLong(MavlinkMessageCommandLong {
+            system_id: 255,
+            component_id: 190,
+            sequence: 0,
+            peer_addr: String::new(),
+            timestamp_ns: "0".to_string(),
+            target_system: 1,
+            target_component: 1,
+            command: 400, // MAV_CMD_COMPONENT_ARM_DISARM
+            confirmation: 0,
+            param1: 1.0, // 1 = arm
+            param2: 0.0,
+            param3: 0.0,
+            param4: 0.0,
+            param5: 0.0,
+            param6: 0.0,
+            param7: 0.0,
+        })
+    }
+
+    fn make_encapsulated_data() -> MavlinkMessage {
+        // ENCAPSULATED_DATA carries a fixed 253-byte wire payload; build the
+        // full width so the round-trip compares equal (the encoder pads to 253).
+        let mut data = vec![0u8; 253];
+        data[0] = 1; // AGP race-status discriminator (data_type)
+        data[1] = 0xAB;
+        data[252] = 0xCD;
+        MavlinkMessage::EncapsulatedData(MavlinkMessageEncapsulatedData {
+            system_id: 1,
+            component_id: 1,
+            sequence: 0,
+            peer_addr: String::new(),
+            timestamp_ns: "0".to_string(),
+            seqnr: 7,
+            data,
+        })
+    }
+
     /// Encode → write_v2_msg → read_v2_msg → decode → compare. Exercises
     /// the encoder's typed lift, the wire framing, the decoder's typed
     /// drop, and the schema's discriminator path end-to-end. Mentally
@@ -460,6 +528,16 @@ mod tests {
                     d.timestamp_ns = "0".to_string();
                     d.sequence = 0;
                 }
+                MavlinkMessage::CommandLong(d) => {
+                    d.peer_addr.clear();
+                    d.timestamp_ns = "0".to_string();
+                    d.sequence = 0;
+                }
+                MavlinkMessage::EncapsulatedData(d) => {
+                    d.peer_addr.clear();
+                    d.timestamp_ns = "0".to_string();
+                    d.sequence = 0;
+                }
             }
             msg
         };
@@ -495,6 +573,29 @@ mod tests {
     #[test]
     fn round_trip_timesync() {
         assert_round_trip(make_timesync());
+    }
+
+    #[test]
+    fn round_trip_command_long() {
+        assert_round_trip(make_command_long());
+    }
+
+    #[test]
+    fn round_trip_encapsulated_data() {
+        assert_round_trip(make_encapsulated_data());
+    }
+
+    #[test]
+    fn command_long_sim_reset_roundtrips() {
+        // The AGP sim-reset (cmd 31000) is within rust-mavlink's MavCmd, so it
+        // encodes and survives the wire roundtrip — the attempt-cycle reset works
+        // through the same COMMAND_LONG path as arm (400).
+        let mut msg = make_command_long();
+        if let MavlinkMessage::CommandLong(d) = &mut msg {
+            d.command = 31000;
+            d.param1 = 0.0;
+        }
+        assert_round_trip(msg);
     }
 
     #[test]

--- a/packages/mavlink/streamlib.yaml
+++ b/packages/mavlink/streamlib.yaml
@@ -1,7 +1,7 @@
 package:
   org: tatolab
   name: mavlink
-  version: 1.0.0
+  version: 1.1.0
   description: MAVLink2 encoder + decoder processors via rust-mavlink — pairs with @tatolab/network for MAVLink-over-UDP
 dependencies:
   '@tatolab/network':


### PR DESCRIPTION
## Description

Extend `@tatolab/mavlink`'s `MavlinkMessage` tagged union with two variants — `command_long` and `encapsulated_data` — so a consumer can **arm a vehicle** and **read the AGP sim's race-status**, neither of which the prior six-message union supported.

## Context

The union covered `heartbeat`, `attitude`, `highres_imu`, `set_position_target_local_ned`, `set_attitude_target`, `timesync` — enough to read telemetry and send attitude/position setpoints. Building a full AGP control loop on streamlib surfaced two gaps:

- **No `COMMAND_LONG`** → can't send `MAV_CMD_COMPONENT_ARM_DISARM` (arm) or the sim-reset.
- **No `ENCAPSULATED_DATA`** → can't read race-status (`race_start_boot_time_ms`, `active_gate_index`), so a pilot can't gate control on race-start and would be disqualified for an early start.

The schema header already documents the extension path ("adding a new MAVLink message later means adding one entry to `mapping:`"); this is that, end to end.

## What changed

- **`schemas/mavlink_message.yaml`**: `command_long` (target sys/comp, `command: uint16`, `confirmation`, `param1..7`) + `encapsulated_data` (`seqnr: uint16`, `data: [uint8]`).
- **`src/mavlink_decoder.rs`**: decode arms for both (`COMMAND_LONG`, `ENCAPSULATED_DATA`).
- **`src/mavlink_encoder.rs`**: encode arms + `identity()` arms. `command` is lifted to a typed `MavCmd` via `FromPrimitive::from_u16` — `400` (arm) resolves; ids outside the common dialect are **rejected** (`Error::Configuration`) rather than silently mis-encoded. `encapsulated_data` pads/truncates the variable-length schema bytes to the fixed 253-byte wire payload.
- Both ride the existing `peer_addr` / `timestamp_ns` passthrough and per-`(system_id, component_id)` sequence auto-increment — no processor-surface change (still one input + one output port per direction).
- **Package `1.0.0` → `1.1.0`** (additive; consumers use `^1.0.0`).

## Tests / validation

- [x] Roundtrip (encode → `write_v2_msg` → `read_v2_msg` → decode → compare) for `command_long` and `encapsulated_data`.
- [x] `command_long_sim_reset_roundtrips` — confirms the AGP sim-reset `31000` is within rust-mavlink's `MavCmd` and roundtrips (the attempt-cycle reset works through the same path; this corrected an initial wrong assumption that `31000` would be rejected).
- [x] `cargo test --lib`: **17 passed, 0 failed**.

> Note: the pre-existing `tests/mavlink_over_udp.rs` integration test fails to build **standalone** (its dev-deps `serial_test` / `serde_json` / `streamlib_network` resolve only inside the full workspace). Unrelated to this change — flagging, not fixing here.

## Related

- Milestone: (mavlink / AGP) — assign as appropriate.
- Consumed by `tatolab/drone-racer`'s `racer-pilot` for the full vision + telemetry-in / control-out loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)