### PR TITLE
feat(plugin-sdk): expose GPU surface-consumer + graphics-effect methods on the engine-free cdylib twin

### DIFF
--- a/examples/camera-plugin-sdk-compute/Cargo.toml
+++ b/examples/camera-plugin-sdk-compute/Cargo.toml
@@ -1,0 +1,50 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+# Standalone, registry-only example (headed to its own repo). Every dependency
+# resolves from the Gitea registry by version. This crate is its own workspace
+# root and includes the sibling `plugin/` cdylib (the engine-free grayscale
+# compute plugin) as a member so `cargo build -p grayscale-compute-plugin`
+# builds it for the example to stage. `@tatolab/camera` + `@tatolab/display`
+# load at runtime via `Strategy::Registry`; the example-local plugin loads via
+# `Strategy::Path`.
+#
+# The version pin below tracks the streamlib release that first shipped the
+# engine-free SDK surface-consumer API (resolve_texture_registration_by_surface_id
+# et al.). It is bumped to the published dev version during validation and to
+# the release version at publish.
+[package]
+name = "camera-plugin-sdk-compute"
+version = "0.4.36-dev.1"
+edition = "2024"
+authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
+license = "BUSL-1.1"
+publish = false
+
+[dependencies]
+streamlib = { workspace = true }
+serde_json = { workspace = true }
+
+[workspace]
+members = ["plugin"]
+
+[workspace.package]
+version = "0.4.36-dev.1"
+edition = "2024"
+authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
+license = "BUSL-1.1"
+
+[workspace.dependencies]
+# Engine facade — used ONLY by the runner (the host app), never the plugin.
+# Exact (`=`) pins so the dev prerelease is selected over the higher stable
+# `0.4.36` (which predates the engine-free surface-consumer API). At release
+# these bump to the published minor.
+streamlib = { version = "=0.4.36-dev.1", registry = "gitea" }
+# Engine-free authoring SDK chain — used by the plugin cdylib.
+streamlib-plugin-sdk = { version = "=0.4.36-dev.1", registry = "gitea" }
+streamlib-macros = { version = "=0.4.36-dev.1", registry = "gitea" }
+streamlib-plugin-abi = { version = "=0.4.36-dev.1", registry = "gitea" }
+streamlib-jtd-codegen = { version = "=0.4.36-dev.1", registry = "gitea" }
+tracing = { version = "0.1.41", features = ["release_max_level_debug"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/examples/camera-plugin-sdk-compute/plugin/.gitignore
+++ b/examples/camera-plugin-sdk-compute/plugin/.gitignore
@@ -1,0 +1,3 @@
+lib/*.dylib
+lib/*.so
+lib/*.dll

--- a/examples/camera-plugin-sdk-compute/plugin/Cargo.toml
+++ b/examples/camera-plugin-sdk-compute/plugin/Cargo.toml
@@ -1,0 +1,34 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+# Member of the standalone `camera-plugin-sdk-compute` workspace — inherits
+# its `[workspace.package]` fields and resolves every dependency from the
+# Gitea registry via `[workspace.dependencies]`. No path deps.
+#
+# This is the FIRST example whose plugin links ONLY the engine-free
+# `streamlib-plugin-sdk` (never the `streamlib` engine facade) — it proves a
+# cdylib built against the engine-free SDK can resolve an incoming
+# `VideoFrame` surface to a GPU `Texture` and run a SPIR-V compute kernel on
+# it, exactly the build configuration `tatolab/drone-racer` ships.
+[package]
+name = "grayscale-compute-plugin"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["rlib", "cdylib"]
+
+[build-dependencies]
+streamlib-jtd-codegen = { workspace = true }
+
+[dependencies]
+# Engine-free authoring SDK — the whole point of this example. NO `streamlib`
+# facade dependency: the plugin cdylib must not statically link the engine.
+streamlib-plugin-sdk = { workspace = true }
+streamlib-macros = { workspace = true }
+streamlib-plugin-abi = { workspace = true }
+tracing = { workspace = true }
+serde = { workspace = true }

--- a/examples/camera-plugin-sdk-compute/plugin/build.rs
+++ b/examples/camera-plugin-sdk-compute/plugin/build.rs
@@ -1,0 +1,57 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+#![allow(clippy::disallowed_macros)] // build.rs uses println! for `cargo:` directives
+
+//! Codegen + Vulkan compute-shader compilation for the engine-free
+//! grayscale-compute plugin.
+//!
+//! `grayscale_compute.rs` embeds the resulting SPIR-V via
+//! `include_bytes!(concat!(env!("OUT_DIR"), "/grayscale.comp.spv"))` and
+//! hands it to `GpuContextFullAccess::create_compute_kernel` — no raw
+//! `HostVulkanDevice`, so the plugin stays cdylib-safe as a
+//! separately-built `.slpkg`.
+
+fn main() {
+    streamlib_jtd_codegen::build_rs::run_for_rust_crate();
+    #[cfg(target_os = "linux")]
+    compile_shaders();
+}
+
+#[cfg(target_os = "linux")]
+fn compile_shaders() {
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    let shaders: &[(&str, &str, &str)] = &[("shaders/grayscale.comp", "grayscale.comp.spv", "compute")];
+
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
+
+    for (src, dst, stage) in shaders {
+        let src_path = Path::new(src);
+        let dst_path: PathBuf = Path::new(&out_dir).join(dst);
+
+        println!("cargo:rerun-if-changed={}", src);
+
+        let glslc = std::env::var("GLSLC").unwrap_or_else(|_| "glslc".to_string());
+        let status = Command::new(&glslc)
+            .arg(format!("-fshader-stage={stage}"))
+            .arg("-O")
+            .arg(src_path)
+            .arg("-o")
+            .arg(&dst_path)
+            .status()
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Failed to invoke `{}` to compile {}: {}. Install shaderc-tools / vulkan-tools.",
+                    glslc, src, e
+                );
+            });
+        assert!(
+            status.success(),
+            "{} compilation failed (exit: {:?})",
+            src,
+            status.code()
+        );
+    }
+}

--- a/examples/camera-plugin-sdk-compute/plugin/shaders/grayscale.comp
+++ b/examples/camera-plugin-sdk-compute/plugin/shaders/grayscale.comp
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+// Grayscale compute shader. Reads the input texture (descriptor-set 0,
+// binding 0) and writes the BT.601 luma of each texel to all three color
+// channels of the output storage image (binding 1), matching the
+// camera-rust-plugin graphics-kernel grayscale path
+// (gray = 0.299*R + 0.587*G + 0.114*B). Input and output are 1:1, so the
+// shader uses texelFetch at the global invocation coordinate (no filtering).
+
+#version 450
+
+layout(local_size_x = 8, local_size_y = 8) in;
+
+layout(set = 0, binding = 0) uniform sampler2D inputTex;
+layout(set = 0, binding = 1, rgba8) uniform writeonly image2D outputImg;
+
+void main() {
+    ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+    ivec2 size = imageSize(outputImg);
+    if (coord.x >= size.x || coord.y >= size.y) {
+        return;
+    }
+    vec4 src = texelFetch(inputTex, coord, 0);
+    float luma = dot(src.rgb, vec3(0.299, 0.587, 0.114));
+    imageStore(outputImg, coord, vec4(luma, luma, luma, 1.0));
+}

--- a/examples/camera-plugin-sdk-compute/plugin/src/grayscale_compute.rs
+++ b/examples/camera-plugin-sdk-compute/plugin/src/grayscale_compute.rs
@@ -1,0 +1,194 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Grayscale compute processor (Linux, engine-free).
+//!
+//! Resolves the incoming `VideoFrame` surface to a GPU [`Texture`], runs a
+//! BT.601-luma grayscale SPIR-V **compute** kernel that writes into the next
+//! slot of a pre-allocated output [`TextureRing`], and forwards the slot's
+//! `surface_id` downstream. The in-process `Display` consumer resolves the
+//! slot via Path 1 (`texture_cache`) — [`create_texture_ring`] registers
+//! every slot at construction, so no surface-share registration is needed.
+//!
+//! Everything here goes through the engine-free `streamlib-plugin-sdk`:
+//! kernel + ring are built on `GpuContextFullAccess` at setup (privileged),
+//! and `process()` resolves + dispatches on `GpuContextLimitedAccess` (the
+//! hot path never escalates). No raw `HostVulkanDevice`, so the cdylib stays
+//! sound as a separately-built `.slpkg`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use streamlib_plugin_sdk::sdk::context::{
+    GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
+};
+use streamlib_plugin_sdk::sdk::error::{Error, Result};
+use streamlib_plugin_sdk::sdk::rhi::{
+    ComputeBindingSpec, ComputeKernelDescriptor, TextureFormat, TextureRing, TextureUsages,
+    VulkanComputeKernel, VulkanLayout,
+};
+
+use crate::_generated_::VideoFrame;
+
+/// Output texture-ring depth — the engine's `MAX_FRAMES_IN_FLIGHT = 2` per
+/// `docs/learnings/vulkan-frames-in-flight.md`. The prior slot may still be
+/// sampled by `Display` while the kernel writes the next one.
+const OUTPUT_RING_DEPTH: usize = 2;
+
+/// Compute workgroup tile size; matches `local_size_x/y` in `grayscale.comp`.
+const WORKGROUP_SIZE: u32 = 8;
+
+/// Compiled grayscale compute SPIR-V (emitted by `build.rs` via `glslc`).
+const GRAYSCALE_SPV: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/grayscale.comp.spv"));
+
+/// Binding layout for `grayscale.comp` (descriptor set 0):
+///   0 = sampled input texture, 1 = storage output image.
+const BINDINGS: &[ComputeBindingSpec] = &[
+    ComputeBindingSpec::sampled_texture(0),
+    ComputeBindingSpec::storage_image(1),
+];
+
+struct ComputeBackend {
+    kernel: VulkanComputeKernel,
+    output_ring: TextureRing,
+    width: u32,
+    height: u32,
+}
+
+#[streamlib_plugin_sdk::sdk::processor("GrayscaleCompute")]
+pub struct GrayscaleComputeProcessor {
+    gpu_context: Option<GpuContextLimitedAccess>,
+    backend: Option<ComputeBackend>,
+    frame_count: AtomicU64,
+}
+
+impl streamlib_plugin_sdk::sdk::processors::ReactiveProcessor
+    for GrayscaleComputeProcessor::Processor
+{
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        tracing::info!("[GrayscaleCompute] setup (engine-free SPIR-V compute kernel)");
+        self.gpu_context = Some(ctx.gpu_limited_access().clone());
+
+        // setup() runs inside the engine's privileged lifecycle dispatch, so
+        // `ctx.gpu_full_access()` is already privileged — building the kernel
+        // + ring here (not via `gpu_limited_access().escalate(...)`) avoids
+        // re-entering the escalate gate on the same thread.
+        let full = ctx.gpu_full_access();
+
+        // Camera in this example emits 1920×1080. The compute shader bounds-
+        // checks against the output image size, and the kernel binds the
+        // resolved input 1:1, so a mismatched source still produces a clean
+        // (cropped) frame rather than reading out of bounds.
+        let width = 1920u32;
+        let height = 1080u32;
+
+        let kernel = full.create_compute_kernel(&ComputeKernelDescriptor {
+            label: "grayscale_compute",
+            spv: GRAYSCALE_SPV,
+            bindings: BINDINGS,
+            push_constant_size: 0,
+        })?;
+
+        // Rgba8Unorm is universally storage-image-capable; grayscale writes
+        // R=G=B so channel order is irrelevant to the result. STORAGE_BINDING
+        // for the compute write, TEXTURE_BINDING for Display to sample,
+        // COPY_SRC for the PNG sampler.
+        let output_ring = full.create_texture_ring(
+            width,
+            height,
+            TextureFormat::Rgba8Unorm,
+            TextureUsages::STORAGE_BINDING
+                | TextureUsages::TEXTURE_BINDING
+                | TextureUsages::COPY_SRC,
+            OUTPUT_RING_DEPTH,
+        )?;
+
+        tracing::info!(
+            "[GrayscaleCompute] pre-allocated {OUTPUT_RING_DEPTH} output ring slots \
+             ({width}x{height} RGBA8)"
+        );
+
+        self.backend = Some(ComputeBackend {
+            kernel,
+            output_ring,
+            width,
+            height,
+        });
+        Ok(())
+    }
+
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        tracing::info!(
+            "[GrayscaleCompute] shutdown ({} frames)",
+            self.frame_count.load(Ordering::Relaxed)
+        );
+        Ok(())
+    }
+
+    fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        if !self.inputs.has_data("video_in") {
+            return Ok(());
+        }
+        let frame: VideoFrame = self.inputs.read("video_in")?;
+
+        let gpu_ctx = self
+            .gpu_context
+            .as_ref()
+            .ok_or_else(|| Error::Configuration("GPU context not initialized".into()))?
+            .clone();
+
+        let backend = self.backend.as_ref().ok_or_else(|| {
+            Error::Configuration("GrayscaleCompute: backend not initialized".into())
+        })?;
+
+        // Resolve the incoming camera surface to its GPU texture. The camera
+        // dual-registers a texture-backed surface_id in texture_cache
+        // (Path 1) leaving it SHADER_READ_ONLY_OPTIMAL — exactly what the
+        // compute kernel samples.
+        let input_registration = gpu_ctx.resolve_texture_registration_by_surface_id(
+            &frame.surface_id,
+            frame.texture_layout,
+            frame.width,
+            frame.height,
+        )?;
+        let input_texture = input_registration.texture().clone();
+
+        // Rotate to the next output slot.
+        let slot = backend.output_ring.acquire_next();
+        let slot_surface_id = slot.surface_id().to_string();
+
+        // Bind input (sampled) + output (storage image) and dispatch one
+        // workgroup per 8×8 tile. `dispatch` submits + waits, so the slot is
+        // populated on return.
+        backend.kernel.set_sampled_texture(0, &input_texture)?;
+        backend.kernel.set_storage_image(1, &slot.texture)?;
+        let groups_x = backend.width.div_ceil(WORKGROUP_SIZE);
+        let groups_y = backend.height.div_ceil(WORKGROUP_SIZE);
+        backend.kernel.dispatch(groups_x, groups_y, 1)?;
+
+        // The compute kernel leaves the storage-image output in GENERAL.
+        // Update the slot registration so the downstream Display barriers
+        // from a current_layout that matches reality.
+        let slot_registration = gpu_ctx.resolve_texture_registration_by_surface_id(
+            &slot_surface_id,
+            None,
+            slot.texture.width(),
+            slot.texture.height(),
+        )?;
+        slot_registration.update_layout(VulkanLayout::GENERAL);
+
+        let output_frame = VideoFrame {
+            surface_id: slot_surface_id,
+            width: slot.texture.width(),
+            height: slot.texture.height(),
+            timestamp_ns: frame.timestamp_ns.clone(),
+            fps: frame.fps,
+            texture_layout: Some(VulkanLayout::GENERAL.0),
+            color_info: frame.color_info.clone(),
+            mastering_display: frame.mastering_display.clone(),
+            content_light: frame.content_light.clone(),
+        };
+        self.outputs.write("video_out", &output_frame)?;
+        self.frame_count.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}

--- a/examples/camera-plugin-sdk-compute/plugin/src/lib.rs
+++ b/examples/camera-plugin-sdk-compute/plugin/src/lib.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Engine-free grayscale-compute plugin — a Rust-backed processor loaded as
+//! a cdylib via `runtime.add_module_with(..., Strategy::Path)` against this
+//! crate's `streamlib.yaml`. The cdylib's `STREAMLIB_PLUGIN` callback
+//! registers the `GrayscaleCompute` processor with the host registry.
+//!
+//! Unlike `camera-rust-plugin` (which links the `streamlib` engine facade),
+//! this plugin depends ONLY on the engine-free `streamlib-plugin-sdk`. It
+//! resolves the incoming camera `VideoFrame` surface to a GPU `Texture` via
+//! [`GpuContextLimitedAccess::resolve_texture_registration_by_surface_id`],
+//! runs a BT.601-luma grayscale SPIR-V compute kernel built through
+//! [`GpuContextFullAccess::create_compute_kernel`], and writes the result
+//! into a ring of output textures — proving the engine-free surface-consumer
+//! path end-to-end.
+
+#[allow(non_snake_case, unused_imports, dead_code, clippy::all)]
+mod _generated_ {
+    include!(concat!(env!("OUT_DIR"), "/_generated_shim.rs"));
+}
+
+#[cfg(target_os = "linux")]
+mod grayscale_compute;
+
+#[cfg(target_os = "linux")]
+use streamlib_plugin_abi::export_plugin;
+
+#[cfg(target_os = "linux")]
+export_plugin!(grayscale_compute::GrayscaleComputeProcessor::Processor);

--- a/examples/camera-plugin-sdk-compute/plugin/streamlib.yaml
+++ b/examples/camera-plugin-sdk-compute/plugin/streamlib.yaml
@@ -1,0 +1,32 @@
+package:
+  org: tatolab
+  name: camera-plugin-sdk-compute
+  version: 0.1.0
+  description: "Engine-free grayscale compute effect (streamlib-plugin-sdk only)"
+
+dependencies:
+  "@tatolab/core": "^1.0.0"
+
+schemas:
+  # Wire types imported from @tatolab/core.
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
+  VideoFrame:
+    package: "@tatolab/core"
+
+processors:
+  - name: GrayscaleCompute
+    version: 1.0.0
+    description: "Grayscale video effect via an engine-free SPIR-V compute kernel"
+    runtime: rust
+    execution: reactive
+    inputs:
+      - name: video_in
+        schema: VideoFrame
+    outputs:
+      - name: video_out
+        schema: VideoFrame

--- a/examples/camera-plugin-sdk-compute/src/main.rs
+++ b/examples/camera-plugin-sdk-compute/src/main.rs
@@ -1,0 +1,155 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Camera → Engine-Free Grayscale **Compute** Plugin → Display Pipeline
+//!
+//! The first example whose plugin links ONLY the engine-free
+//! `streamlib-plugin-sdk` (never the `streamlib` engine facade). It proves a
+//! cdylib built against the engine-free SDK can:
+//!   1. resolve an incoming `VideoFrame` surface to a GPU `Texture`
+//!      (`resolve_texture_registration_by_surface_id`), and
+//!   2. run a SPIR-V **compute** kernel on it
+//!      (`create_compute_kernel` + `create_texture_ring`),
+//! then emit the transformed frame — the exact build configuration
+//! `tatolab/drone-racer` ships its on-GPU ONNX preprocessing under.
+//!
+//! The runner owns a sibling `plugin/` crate (a workspace member) that builds
+//! as a cdylib carrying the `GrayscaleCompute` processor; the host stages that
+//! cdylib into `plugin/lib/<host_triple>/` before calling
+//! `add_module_with_blocking(..., Strategy::Path)`. `@tatolab/camera` and
+//! `@tatolab/display` resolve from the Gitea registry via `Strategy::Registry`.
+//!
+//! ## Prerequisites
+//!
+//! Build the plugin cdylib (a member of this example's workspace):
+//! ```bash
+//! cargo build -p grayscale-compute-plugin
+//! ```
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p camera-plugin-sdk-compute
+//! ```
+
+use std::path::PathBuf;
+use streamlib::sdk::RunnerAutoBuild;
+use streamlib::sdk::error::Result;
+use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib::sdk::module_ident_any_version;
+use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::runtime::{BuildPolicy, Runner, SemVerRange, Strategy};
+use streamlib::sdk::schema_ident;
+
+fn main() -> Result<()> {
+    let runtime = Runner::with_auto_build()?;
+
+    // 1. Resolve `@tatolab/camera` and `@tatolab/display` from the Gitea
+    //    generic registry by version. Endpoint comes from
+    //    `STREAMLIB_REGISTRY_URL` (or `GITEA_URL`).
+    let registry = || Strategy::Registry {
+        version_req: SemVerRange::Any,
+        build: BuildPolicy::IfStale,
+    };
+    runtime.add_module_with_blocking(module_ident_any_version!("tatolab", "camera"), registry())?;
+    runtime
+        .add_module_with_blocking(module_ident_any_version!("tatolab", "display"), registry())?;
+
+    // 2. Stage the example-local grayscale-compute plugin cdylib at
+    //    `plugin/lib/<triple>/` so the `Path` resolver picks it up via the
+    //    same triple-keyed convention `streamlib pack` produces.
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let plugin_dir = manifest_dir.join("plugin");
+    let host_triple = streamlib::sdk::runtime::host_target_triple();
+    let triple_lib_dir = plugin_dir.join("lib").join(host_triple);
+    std::fs::create_dir_all(&triple_lib_dir).map_err(|e| {
+        streamlib::sdk::error::Error::Configuration(format!("Failed to create lib dir: {}", e))
+    })?;
+
+    // This example is its own workspace root (the `plugin/` cdylib is a
+    // member), so `cargo build -p grayscale-compute-plugin` writes the dylib
+    // into this crate's own `target/` dir.
+    let dylib_name = "libgrayscale_compute_plugin.so";
+    let debug_dylib = manifest_dir.join("target").join("debug").join(dylib_name);
+    let release_dylib = manifest_dir
+        .join("target")
+        .join("release")
+        .join(dylib_name);
+
+    let source_dylib = if debug_dylib.exists() {
+        &debug_dylib
+    } else if release_dylib.exists() {
+        &release_dylib
+    } else {
+        return Err(streamlib::sdk::error::Error::Configuration(format!(
+            "Grayscale-compute plugin dylib not found. Build it first: \
+             cargo build -p grayscale-compute-plugin\nLooked in:\n  {}\n  {}",
+            debug_dylib.display(),
+            release_dylib.display()
+        )));
+    };
+
+    let dest_dylib = triple_lib_dir.join(dylib_name);
+    std::fs::copy(source_dylib, &dest_dylib).map_err(|e| {
+        streamlib::sdk::error::Error::Configuration(format!(
+            "Failed to copy dylib from {} to {}: {}",
+            source_dylib.display(),
+            dest_dylib.display(),
+            e
+        ))
+    })?;
+    println!("Copied plugin dylib to {}", dest_dylib.display());
+
+    // 3. Load the example-local plugin project (registers the
+    //    `GrayscaleCompute` processor from the staged cdylib). The `Path`
+    //    strategy reads `plugin/streamlib.yaml`, walks declared deps
+    //    (`@tatolab/core` from the registry), and registers the local
+    //    plugin's processors + schemas.
+    runtime.add_module_with_blocking(
+        module_ident_any_version!("tatolab", "camera-plugin-sdk-compute"),
+        Strategy::Path {
+            path: plugin_dir.clone(),
+            build: BuildPolicy::IfStale,
+        },
+    )?;
+
+    // 4. Add processors.
+    let camera = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "camera", "Camera", "1.0.0"),
+        serde_json::json!({}),
+    ))?;
+
+    let grayscale = runtime.add_processor(ProcessorSpec::new(
+        streamlib::sdk::schema_ident_any_version!(
+            "tatolab",
+            "camera-plugin-sdk-compute",
+            "GrayscaleCompute"
+        )?,
+        serde_json::Value::Null,
+    ))?;
+
+    let display = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "display", "Display", "1.0.0"),
+        serde_json::json!({
+            "width": 1920,
+            "height": 1080,
+            "title": "Camera → Engine-Free Grayscale Compute → Display",
+        }),
+    ))?;
+
+    // 5. Connect: Camera → GrayscaleCompute → Display
+    runtime.connect(
+        OutputLinkPortRef::new(&camera, "video"),
+        InputLinkPortRef::new(&grayscale, "video_in"),
+    )?;
+    runtime.connect(
+        OutputLinkPortRef::new(&grayscale, "video_out"),
+        InputLinkPortRef::new(&display, "video"),
+    )?;
+
+    // 6. Run.
+    runtime.start()?;
+    runtime.wait_for_signal()?;
+
+    Ok(())
+}

--- a/plugin/streamlib-plugin-sdk/src/context.rs
+++ b/plugin/streamlib-plugin-sdk/src/context.rs
@@ -985,6 +985,62 @@ impl GpuContextFullAccess {
         })
     }
 
+    /// Create a graphics kernel from a multi-stage SPIR-V set, binding
+    /// declaration, and fixed-function pipeline state. Dispatches through
+    /// the [`GpuContextFullAccessVTable`]'s `create_graphics_kernel` slot;
+    /// the host reflects every stage's SPIR-V, validates the declared
+    /// bindings match the shaders, and allocates the Vulkan pipeline
+    /// host-side.
+    pub fn create_graphics_kernel(
+        &self,
+        descriptor: &crate::rhi::GraphicsKernelDescriptor<'_>,
+    ) -> Result<crate::rhi::VulkanGraphicsKernel> {
+        if self.vtable.is_null() {
+            return Err(Error::GpuError(
+                "create_graphics_kernel: GpuContextFullAccess has null vtable".into(),
+            ));
+        }
+        // Stage the descriptor into its repr + the keepalive backing Vecs;
+        // every backing Vec must stay alive for the vtable call because the
+        // repr's pointer fields borrow into them.
+        let (repr, _stage) = crate::rhi::stage_graphics_kernel_descriptor(descriptor);
+        let mut out_kernel: *const c_void = std::ptr::null();
+        let mut err_buf = [0u8; 512];
+        let mut err_len: usize = 0;
+        // SAFETY: vtable + handle (scope token) paired at construction;
+        // `repr` borrows into `_stage` / `descriptor`, both alive for the
+        // duration of the call.
+        let status = unsafe {
+            ((*self.vtable).create_graphics_kernel)(
+                self.handle,
+                &repr,
+                &mut out_kernel,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status != 0 {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())]).into_owned();
+            return Err(Error::GpuError(msg));
+        }
+        if out_kernel.is_null() {
+            return Err(Error::GpuError(
+                "create_graphics_kernel: host signaled success but out_kernel is null".into(),
+            ));
+        }
+        let methods_vtable = crate::plugin::host_callbacks()
+            .map(|c| c.vulkan_graphics_kernel_methods_vtable)
+            .unwrap_or(std::ptr::null());
+        Ok(crate::rhi::VulkanGraphicsKernel {
+            handle: out_kernel,
+            vtable: self.vtable,
+            methods_vtable,
+            cached_push_constant_size: descriptor.push_constants.size,
+            cached_descriptor_sets_in_flight: descriptor.descriptor_sets_in_flight,
+        })
+    }
+
     /// Build an engine-owned multi-step command-buffer recorder.
     /// Dispatches through the [`GpuContextFullAccessVTable`]'s
     /// `create_command_recorder` slot.

--- a/plugin/streamlib-plugin-sdk/src/context.rs
+++ b/plugin/streamlib-plugin-sdk/src/context.rs
@@ -139,6 +139,118 @@ impl GpuContextLimitedAccess {
             );
         }
     }
+
+    /// Resolve an incoming `VideoFrame`'s `surface_id` to a
+    /// [`TextureRegistration`](crate::rhi::TextureRegistration) — the GPU
+    /// texture plus its last-known layout. This is the engine-free
+    /// surface-consumer entry point: a plugin's `process()` calls it to read
+    /// a decoded frame on the GPU and run a compute/graphics kernel on it.
+    ///
+    /// Dispatches through the plugin ABI vtable's
+    /// `resolve_texture_registration_by_surface_id` callback. `texture_layout`
+    /// is the optional per-frame layout override carried on the `VideoFrame`
+    /// (raw `VkImageLayout`); pass `None` to use the per-surface default.
+    pub fn resolve_texture_registration_by_surface_id(
+        &self,
+        surface_id: &str,
+        texture_layout: Option<i32>,
+        width: u32,
+        height: u32,
+    ) -> Result<crate::rhi::TextureRegistration> {
+        if self.handle.is_null() || self.vtable.is_null() {
+            return Err(Error::GpuError(
+                "resolve_texture_registration_by_surface_id: GpuContextLimitedAccess has null handle/vtable".into(),
+            ));
+        }
+        let mut out_reg: std::mem::MaybeUninit<crate::rhi::TextureRegistration> =
+            std::mem::MaybeUninit::uninit();
+        let mut err_buf = [0u8; 512];
+        let mut err_len: usize = 0;
+        let (has_layout, layout_raw) = match texture_layout {
+            Some(v) => (1i32, v),
+            None => (0i32, 0i32),
+        };
+        // SAFETY: handle + vtable were paired at construction; `out_reg` is
+        // uninitialized stack storage the host writes a valid
+        // TextureRegistration into on success (status == 0) and nothing on
+        // failure.
+        let status = unsafe {
+            ((*self.vtable).resolve_texture_registration_by_surface_id)(
+                self.handle,
+                surface_id.as_ptr(),
+                surface_id.len(),
+                has_layout,
+                layout_raw,
+                width,
+                height,
+                out_reg.as_mut_ptr() as *mut c_void,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            // SAFETY: host signaled success and wrote a valid value.
+            Ok(unsafe { out_reg.assume_init() })
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())]).into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    /// Resolve an incoming `VideoFrame`'s `surface_id` directly to a
+    /// [`Texture`](crate::rhi::Texture) (the texture-cache fast path, without
+    /// the surrounding [`TextureRegistration`](crate::rhi::TextureRegistration)
+    /// layout metadata).
+    ///
+    /// Dispatches through the plugin ABI vtable's
+    /// `resolve_texture_by_surface_id` callback.
+    pub fn resolve_texture_by_surface_id(
+        &self,
+        surface_id: &str,
+        texture_layout: Option<i32>,
+        width: u32,
+        height: u32,
+    ) -> Result<crate::rhi::Texture> {
+        if self.handle.is_null() || self.vtable.is_null() {
+            return Err(Error::GpuError(
+                "resolve_texture_by_surface_id: GpuContextLimitedAccess has null handle/vtable".into(),
+            ));
+        }
+        let mut out_texture: std::mem::MaybeUninit<crate::rhi::Texture> =
+            std::mem::MaybeUninit::uninit();
+        let mut err_buf = [0u8; 512];
+        let mut err_len: usize = 0;
+        let (has_layout, layout_raw) = match texture_layout {
+            Some(v) => (1i32, v),
+            None => (0i32, 0i32),
+        };
+        // SAFETY: handle + vtable were paired at construction; `out_texture`
+        // points at uninitialized stack storage the host writes a valid
+        // `Texture` into on success (status == 0) and nothing on failure.
+        let status = unsafe {
+            ((*self.vtable).resolve_texture_by_surface_id)(
+                self.handle,
+                surface_id.as_ptr(),
+                surface_id.len(),
+                has_layout,
+                layout_raw,
+                width,
+                height,
+                out_texture.as_mut_ptr() as *mut c_void,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            // SAFETY: host signaled success and wrote a valid value.
+            Ok(unsafe { out_texture.assume_init() })
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())]).into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
 }
 
 // =============================================================================
@@ -278,6 +390,40 @@ impl GpuContextFullAccess {
     pub fn update_texture_registration_layout(&self, id: &str, layout: VulkanLayout) {
         self.inherited_limited_unchecked()
             .update_texture_registration_layout(id, layout);
+    }
+
+    /// Resolve an incoming `VideoFrame`'s `surface_id` to a
+    /// [`TextureRegistration`](crate::rhi::TextureRegistration).
+    ///
+    /// LimitedAccess mirror — cdylib dispatch inherits the
+    /// `resolve_texture_registration_by_surface_id` slot via
+    /// [`Self::inherited_limited_unchecked`].
+    pub fn resolve_texture_registration_by_surface_id(
+        &self,
+        surface_id: &str,
+        texture_layout: Option<i32>,
+        width: u32,
+        height: u32,
+    ) -> Result<crate::rhi::TextureRegistration> {
+        self.inherited_limited_unchecked()
+            .resolve_texture_registration_by_surface_id(surface_id, texture_layout, width, height)
+    }
+
+    /// Resolve an incoming `VideoFrame`'s `surface_id` directly to a
+    /// [`Texture`](crate::rhi::Texture).
+    ///
+    /// LimitedAccess mirror — cdylib dispatch inherits the
+    /// `resolve_texture_by_surface_id` slot via
+    /// [`Self::inherited_limited_unchecked`].
+    pub fn resolve_texture_by_surface_id(
+        &self,
+        surface_id: &str,
+        texture_layout: Option<i32>,
+        width: u32,
+        height: u32,
+    ) -> Result<crate::rhi::Texture> {
+        self.inherited_limited_unchecked()
+            .resolve_texture_by_surface_id(surface_id, texture_layout, width, height)
     }
 
     /// Allocate a render-target-capable DMA-BUF VkImage (privileged

--- a/plugin/streamlib-plugin-sdk/src/context.rs
+++ b/plugin/streamlib-plugin-sdk/src/context.rs
@@ -251,6 +251,265 @@ impl GpuContextLimitedAccess {
             Err(Error::GpuError(msg))
         }
     }
+
+    /// Check out a shared surface (CPU-readable [`PixelBuffer`](crate::rhi::PixelBuffer))
+    /// by its `surface_id`. Dispatches through the plugin ABI vtable's
+    /// `check_out_surface` callback.
+    pub fn check_out_surface(&self, surface_id: &str) -> Result<crate::rhi::PixelBuffer> {
+        if self.handle.is_null() || self.vtable.is_null() {
+            return Err(Error::GpuError(
+                "check_out_surface: GpuContextLimitedAccess has null handle/vtable".into(),
+            ));
+        }
+        let mut out_pb: std::mem::MaybeUninit<crate::rhi::PixelBuffer> =
+            std::mem::MaybeUninit::uninit();
+        let mut err_buf = [0u8; 512];
+        let mut err_len: usize = 0;
+        // SAFETY: handle + vtable paired at construction; the host writes a
+        // valid PixelBuffer into `out_pb` on success.
+        let status = unsafe {
+            ((*self.vtable).check_out_surface)(
+                self.handle,
+                surface_id.as_ptr(),
+                surface_id.len(),
+                out_pb.as_mut_ptr() as *mut c_void,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(unsafe { out_pb.assume_init() })
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())]).into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    /// Resolve an incoming `VideoFrame`'s `surface_id` to a CPU-readable
+    /// [`PixelBuffer`](crate::rhi::PixelBuffer). Dispatches through the plugin
+    /// ABI vtable's `resolve_pixel_buffer_by_surface_id` callback.
+    pub fn resolve_pixel_buffer_by_surface_id(
+        &self,
+        surface_id: &str,
+    ) -> Result<crate::rhi::PixelBuffer> {
+        if self.handle.is_null() || self.vtable.is_null() {
+            return Err(Error::GpuError(
+                "resolve_pixel_buffer_by_surface_id: GpuContextLimitedAccess has null handle/vtable".into(),
+            ));
+        }
+        let mut out_pb: std::mem::MaybeUninit<crate::rhi::PixelBuffer> =
+            std::mem::MaybeUninit::uninit();
+        let mut err_buf = [0u8; 512];
+        let mut err_len: usize = 0;
+        // SAFETY: handle + vtable paired at construction; the host writes a
+        // valid PixelBuffer into `out_pb` on success.
+        let status = unsafe {
+            ((*self.vtable).resolve_pixel_buffer_by_surface_id)(
+                self.handle,
+                surface_id.as_ptr(),
+                surface_id.len(),
+                out_pb.as_mut_ptr() as *mut c_void,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(unsafe { out_pb.assume_init() })
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())]).into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    /// Acquire a pooled [`PixelBuffer`](crate::rhi::PixelBuffer) for CPU→GPU
+    /// upload, returning its pool id (hand back to [`Self::get_pixel_buffer`]).
+    /// Dispatches through the plugin ABI vtable's `acquire_pixel_buffer`
+    /// callback.
+    pub fn acquire_pixel_buffer(
+        &self,
+        width: u32,
+        height: u32,
+        format: PixelFormat,
+    ) -> Result<(crate::rhi::PixelBufferPoolId, crate::rhi::PixelBuffer)> {
+        if self.handle.is_null() || self.vtable.is_null() {
+            return Err(Error::GpuError(
+                "acquire_pixel_buffer: GpuContextLimitedAccess has null handle/vtable".into(),
+            ));
+        }
+        let mut pool_id_buf = [0u8; 1024];
+        let mut pool_id_len: usize = 0;
+        let mut out_pb: std::mem::MaybeUninit<crate::rhi::PixelBuffer> =
+            std::mem::MaybeUninit::uninit();
+        let mut err_buf = [0u8; 512];
+        let mut err_len: usize = 0;
+        // SAFETY: handle + vtable paired at construction; the host writes the
+        // pool-id UTF-8 bytes into `pool_id_buf` and a valid PixelBuffer into
+        // `out_pb` on success.
+        let status = unsafe {
+            ((*self.vtable).acquire_pixel_buffer)(
+                self.handle,
+                width,
+                height,
+                format as u32,
+                pool_id_buf.as_mut_ptr(),
+                pool_id_buf.len(),
+                &mut pool_id_len as *mut usize,
+                out_pb.as_mut_ptr() as *mut c_void,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            let id_str =
+                String::from_utf8_lossy(&pool_id_buf[..pool_id_len.min(pool_id_buf.len())])
+                    .into_owned();
+            let pool_id = crate::rhi::PixelBufferPoolId::from_string(id_str);
+            let pb = unsafe { out_pb.assume_init() };
+            Ok((pool_id, pb))
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())]).into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    /// Look up a previously-acquired pooled
+    /// [`PixelBuffer`](crate::rhi::PixelBuffer) by its pool id. Dispatches
+    /// through the plugin ABI vtable's `get_pixel_buffer` callback.
+    pub fn get_pixel_buffer(
+        &self,
+        pool_id: &crate::rhi::PixelBufferPoolId,
+    ) -> Result<crate::rhi::PixelBuffer> {
+        if self.handle.is_null() || self.vtable.is_null() {
+            return Err(Error::GpuError(
+                "get_pixel_buffer: GpuContextLimitedAccess has null handle/vtable".into(),
+            ));
+        }
+        let id_str = pool_id.as_str();
+        let mut out_pb: std::mem::MaybeUninit<crate::rhi::PixelBuffer> =
+            std::mem::MaybeUninit::uninit();
+        let mut err_buf = [0u8; 512];
+        let mut err_len: usize = 0;
+        // SAFETY: handle + vtable paired at construction.
+        let status = unsafe {
+            ((*self.vtable).get_pixel_buffer)(
+                self.handle,
+                id_str.as_ptr(),
+                id_str.len(),
+                out_pb.as_mut_ptr() as *mut c_void,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(unsafe { out_pb.assume_init() })
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())]).into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    /// Register a texture under a `surface_id` (defaults to layout UNDEFINED).
+    /// Dispatches through the plugin ABI vtable's `register_texture` callback;
+    /// the host bumps the texture's Arc before stashing it, so the passed
+    /// [`Texture`](crate::rhi::Texture) is consumed.
+    pub fn register_texture(&self, id: &str, texture: crate::rhi::Texture) {
+        if self.handle.is_null() || self.vtable.is_null() {
+            return;
+        }
+        // SAFETY: handle + vtable paired at construction; `texture.handle` is
+        // a live `Arc::into_raw(Arc<TextureInner>)` the host re-bumps.
+        unsafe {
+            ((*self.vtable).register_texture)(
+                self.handle,
+                id.as_ptr(),
+                id.len(),
+                texture.handle,
+                0, // VulkanLayout::UNDEFINED.0 == 0
+            );
+        }
+        drop(texture);
+    }
+
+    /// Register a texture under a `surface_id` with an explicit initial layout.
+    /// Dispatches through the plugin ABI vtable's `register_texture` callback.
+    pub fn register_texture_with_layout(
+        &self,
+        id: &str,
+        texture: crate::rhi::Texture,
+        initial_layout: VulkanLayout,
+    ) {
+        if self.handle.is_null() || self.vtable.is_null() {
+            return;
+        }
+        // SAFETY: handle + vtable paired at construction; `texture.handle` is
+        // a live `Arc::into_raw(Arc<TextureInner>)` the host re-bumps.
+        unsafe {
+            ((*self.vtable).register_texture)(
+                self.handle,
+                id.as_ptr(),
+                id.len(),
+                texture.handle,
+                initial_layout.0,
+            );
+        }
+        drop(texture);
+    }
+
+    /// Unregister a texture by its `surface_id`. Dispatches through the plugin
+    /// ABI vtable's `unregister_texture` callback. Idempotent.
+    pub fn unregister_texture(&self, id: &str) {
+        if self.handle.is_null() || self.vtable.is_null() {
+            return;
+        }
+        // SAFETY: handle + vtable paired at construction.
+        unsafe {
+            ((*self.vtable).unregister_texture)(self.handle, id.as_ptr(), id.len());
+        }
+    }
+
+    /// Acquire a pooled scratch texture, returning a
+    /// [`PooledTextureHandle`](crate::rhi::PooledTextureHandle) that returns
+    /// the texture to the pool on Drop. Dispatches through the plugin ABI
+    /// vtable's `acquire_texture` callback.
+    pub fn acquire_texture(
+        &self,
+        desc: &crate::rhi::TexturePoolDescriptor,
+    ) -> Result<crate::rhi::PooledTextureHandle> {
+        if self.handle.is_null() || self.vtable.is_null() {
+            return Err(Error::GpuError(
+                "acquire_texture: GpuContextLimitedAccess has null handle/vtable".into(),
+            ));
+        }
+        let mut out_pooled: std::mem::MaybeUninit<crate::rhi::PooledTextureHandle> =
+            std::mem::MaybeUninit::uninit();
+        let mut err_buf = [0u8; 512];
+        let mut err_len: usize = 0;
+        // SAFETY: handle + vtable paired at construction; the host writes a
+        // valid PooledTextureHandle into `out_pooled` on success.
+        let status = unsafe {
+            ((*self.vtable).acquire_texture)(
+                self.handle,
+                desc.width,
+                desc.height,
+                desc.format as u32,
+                desc.usage.bits(),
+                out_pooled.as_mut_ptr() as *mut c_void,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(unsafe { out_pooled.assume_init() })
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())]).into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
 }
 
 // =============================================================================
@@ -424,6 +683,98 @@ impl GpuContextFullAccess {
     ) -> Result<crate::rhi::Texture> {
         self.inherited_limited_unchecked()
             .resolve_texture_by_surface_id(surface_id, texture_layout, width, height)
+    }
+
+    /// Check out a shared surface as a CPU-readable
+    /// [`PixelBuffer`](crate::rhi::PixelBuffer) by `surface_id`.
+    ///
+    /// LimitedAccess mirror — inherits the `check_out_surface` slot via
+    /// [`Self::inherited_limited_unchecked`].
+    pub fn check_out_surface(&self, surface_id: &str) -> Result<crate::rhi::PixelBuffer> {
+        self.inherited_limited_unchecked()
+            .check_out_surface(surface_id)
+    }
+
+    /// Resolve a `surface_id` to a CPU-readable
+    /// [`PixelBuffer`](crate::rhi::PixelBuffer).
+    ///
+    /// LimitedAccess mirror — inherits the `resolve_pixel_buffer_by_surface_id`
+    /// slot via [`Self::inherited_limited_unchecked`].
+    pub fn resolve_pixel_buffer_by_surface_id(
+        &self,
+        surface_id: &str,
+    ) -> Result<crate::rhi::PixelBuffer> {
+        self.inherited_limited_unchecked()
+            .resolve_pixel_buffer_by_surface_id(surface_id)
+    }
+
+    /// Acquire a pooled [`PixelBuffer`](crate::rhi::PixelBuffer) for CPU→GPU
+    /// upload.
+    ///
+    /// LimitedAccess mirror — inherits the `acquire_pixel_buffer` slot via
+    /// [`Self::inherited_limited_unchecked`].
+    pub fn acquire_pixel_buffer(
+        &self,
+        width: u32,
+        height: u32,
+        format: PixelFormat,
+    ) -> Result<(crate::rhi::PixelBufferPoolId, crate::rhi::PixelBuffer)> {
+        self.inherited_limited_unchecked()
+            .acquire_pixel_buffer(width, height, format)
+    }
+
+    /// Look up a pooled [`PixelBuffer`](crate::rhi::PixelBuffer) by its pool id.
+    ///
+    /// LimitedAccess mirror — inherits the `get_pixel_buffer` slot via
+    /// [`Self::inherited_limited_unchecked`].
+    pub fn get_pixel_buffer(
+        &self,
+        pool_id: &crate::rhi::PixelBufferPoolId,
+    ) -> Result<crate::rhi::PixelBuffer> {
+        self.inherited_limited_unchecked().get_pixel_buffer(pool_id)
+    }
+
+    /// Register a texture under a `surface_id` (defaults to layout UNDEFINED).
+    ///
+    /// LimitedAccess mirror — inherits the `register_texture` slot via
+    /// [`Self::inherited_limited_unchecked`].
+    pub fn register_texture(&self, id: &str, texture: crate::rhi::Texture) {
+        self.inherited_limited_unchecked()
+            .register_texture(id, texture);
+    }
+
+    /// Register a texture under a `surface_id` with an explicit initial layout.
+    ///
+    /// LimitedAccess mirror — inherits the `register_texture` slot via
+    /// [`Self::inherited_limited_unchecked`].
+    pub fn register_texture_with_layout(
+        &self,
+        id: &str,
+        texture: crate::rhi::Texture,
+        initial_layout: VulkanLayout,
+    ) {
+        self.inherited_limited_unchecked()
+            .register_texture_with_layout(id, texture, initial_layout);
+    }
+
+    /// Unregister a texture by its `surface_id`.
+    ///
+    /// LimitedAccess mirror — inherits the `unregister_texture` slot via
+    /// [`Self::inherited_limited_unchecked`].
+    pub fn unregister_texture(&self, id: &str) {
+        self.inherited_limited_unchecked().unregister_texture(id);
+    }
+
+    /// Acquire a pooled scratch texture as a
+    /// [`PooledTextureHandle`](crate::rhi::PooledTextureHandle).
+    ///
+    /// LimitedAccess mirror — inherits the `acquire_texture` slot via
+    /// [`Self::inherited_limited_unchecked`].
+    pub fn acquire_texture(
+        &self,
+        desc: &crate::rhi::TexturePoolDescriptor,
+    ) -> Result<crate::rhi::PooledTextureHandle> {
+        self.inherited_limited_unchecked().acquire_texture(desc)
     }
 
     /// Allocate a render-target-capable DMA-BUF VkImage (privileged

--- a/plugin/streamlib-plugin-sdk/src/lib.rs
+++ b/plugin/streamlib-plugin-sdk/src/lib.rs
@@ -98,11 +98,19 @@ pub mod sdk {
     #[cfg(target_os = "linux")]
     pub mod rhi {
         pub use crate::rhi::{
-            pixel_format_color_kind, ColorConverterPushConstants, ComputeBindingKind,
-            ComputeBindingSpec, ComputeKernelDescriptor, ImageCopyRegion, NativeTextureHandle,
-            PixelFormat, RhiColorConverter, RhiCommandRecorder, SourceLayoutInfo, StorageBuffer,
-            Texture, TextureDescriptor, TextureFormat, TextureRing, TextureRingSlot,
-            TextureUsages, VulkanAccess, VulkanComputeKernel, VulkanLayout, VulkanStage,
+            pixel_format_color_kind, AttachmentFormats, BlendFactor, BlendOp,
+            ColorBlendAttachment, ColorBlendState, ColorConverterPushConstants, ColorWriteMask,
+            ComputeBindingKind, ComputeBindingSpec, ComputeKernelDescriptor, CullMode,
+            DepthCompareOp, DepthFormat, DepthStencilState, DrawCall, DrawIndexedCall, FrontFace,
+            GraphicsBindingKind, GraphicsBindingSpec, GraphicsDynamicState, GraphicsKernelDescriptor,
+            GraphicsPipelineState, GraphicsPushConstants, GraphicsShaderStage,
+            GraphicsShaderStageFlags, GraphicsStage, ImageCopyRegion, IndexType, MultisampleState,
+            NativeTextureHandle, OffscreenColorTarget, OffscreenDraw, PixelFormat, PolygonMode,
+            PrimitiveTopology, RasterizationState, RhiColorConverter, RhiCommandRecorder,
+            ScissorRect, SourceLayoutInfo, StorageBuffer, Texture, TextureDescriptor, TextureFormat,
+            TextureRing, TextureRingSlot, TextureUsages, VertexAttributeFormat,
+            VertexInputAttribute, VertexInputBinding, VertexInputRate, VertexInputState, Viewport,
+            VulkanAccess, VulkanComputeKernel, VulkanGraphicsKernel, VulkanLayout, VulkanStage,
             COLOR_CONVERTER_PUSH_CONSTANT_SIZE, TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES,
         };
     }

--- a/plugin/streamlib-plugin-sdk/src/rhi.rs
+++ b/plugin/streamlib-plugin-sdk/src/rhi.rs
@@ -20,6 +20,7 @@ mod compute_kernel_descriptor;
 mod pipeline_flags;
 mod storage_buffer;
 mod texture;
+mod texture_registration;
 mod texture_ring;
 mod vulkan_compute_kernel;
 
@@ -34,6 +35,7 @@ pub use compute_kernel_descriptor::{
 pub use pipeline_flags::{VulkanAccess, VulkanStage};
 pub use storage_buffer::StorageBuffer;
 pub use texture::{NativeTextureHandle, Texture, TextureDescriptor};
+pub use texture_registration::TextureRegistration;
 pub use texture_ring::{
     TextureRing, TextureRingSlot, TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES,
 };

--- a/plugin/streamlib-plugin-sdk/src/rhi.rs
+++ b/plugin/streamlib-plugin-sdk/src/rhi.rs
@@ -17,6 +17,7 @@
 mod color_converter;
 mod command_recorder;
 mod compute_kernel_descriptor;
+mod graphics_kernel_descriptor;
 mod pipeline_flags;
 mod pixel_buffer;
 mod pooled_texture_handle;
@@ -25,6 +26,7 @@ mod texture;
 mod texture_registration;
 mod texture_ring;
 mod vulkan_compute_kernel;
+mod vulkan_graphics_kernel;
 
 pub use color_converter::{
     pixel_format_color_kind, ColorConverterPushConstants, RhiColorConverter, SourceLayoutInfo,
@@ -33,6 +35,15 @@ pub use color_converter::{
 pub use command_recorder::{ImageCopyRegion, RhiCommandRecorder};
 pub use compute_kernel_descriptor::{
     ComputeBindingKind, ComputeBindingSpec, ComputeKernelDescriptor,
+};
+pub use graphics_kernel_descriptor::{
+    AttachmentFormats, BlendFactor, BlendOp, ColorBlendAttachment, ColorBlendState, ColorWriteMask,
+    CullMode, DepthCompareOp, DepthFormat, DepthStencilState, DrawCall, DrawIndexedCall, FrontFace,
+    GraphicsBindingKind, GraphicsBindingSpec, GraphicsDynamicState, GraphicsKernelDescriptor,
+    GraphicsPipelineState, GraphicsPushConstants, GraphicsShaderStage, GraphicsShaderStageFlags,
+    GraphicsStage, IndexType, MultisampleState, OffscreenColorTarget, OffscreenDraw, PolygonMode,
+    PrimitiveTopology, RasterizationState, ScissorRect, VertexAttributeFormat, VertexInputAttribute,
+    VertexInputBinding, VertexInputRate, VertexInputState, Viewport,
 };
 pub use pipeline_flags::{VulkanAccess, VulkanStage};
 pub use pixel_buffer::{PixelBuffer, PixelBufferPoolId};
@@ -44,12 +55,15 @@ pub use texture_ring::{
     TextureRing, TextureRingSlot, TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES,
 };
 pub use vulkan_compute_kernel::VulkanComputeKernel;
+pub use vulkan_graphics_kernel::VulkanGraphicsKernel;
 
 // Format / layout primitives — already engine-free in consumer-rhi.
 pub use streamlib_consumer_rhi::{PixelFormat, TextureFormat, TextureUsages, VulkanLayout};
 
 // Internal staging helper for `create_compute_kernel`.
 pub(crate) use compute_kernel_descriptor::stage_compute_kernel_descriptor;
+// Internal staging helper for `create_graphics_kernel`.
+pub(crate) use graphics_kernel_descriptor::stage_graphics_kernel_descriptor;
 
 // =============================================================================
 // Cdylib vtable resolver

--- a/plugin/streamlib-plugin-sdk/src/rhi.rs
+++ b/plugin/streamlib-plugin-sdk/src/rhi.rs
@@ -18,6 +18,8 @@ mod color_converter;
 mod command_recorder;
 mod compute_kernel_descriptor;
 mod pipeline_flags;
+mod pixel_buffer;
+mod pooled_texture_handle;
 mod storage_buffer;
 mod texture;
 mod texture_registration;
@@ -33,6 +35,8 @@ pub use compute_kernel_descriptor::{
     ComputeBindingKind, ComputeBindingSpec, ComputeKernelDescriptor,
 };
 pub use pipeline_flags::{VulkanAccess, VulkanStage};
+pub use pixel_buffer::{PixelBuffer, PixelBufferPoolId};
+pub use pooled_texture_handle::{PooledTextureHandle, TexturePoolDescriptor};
 pub use storage_buffer::StorageBuffer;
 pub use texture::{NativeTextureHandle, Texture, TextureDescriptor};
 pub use texture_registration::TextureRegistration;

--- a/plugin/streamlib-plugin-sdk/src/rhi/graphics_kernel_descriptor.rs
+++ b/plugin/streamlib-plugin-sdk/src/rhi/graphics_kernel_descriptor.rs
@@ -1,0 +1,1243 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Public descriptor types for the graphics-kernel RHI abstraction.
+//!
+//! Pure-data twins of the engine's `core::rhi` graphics descriptor shapes
+//! (the engine's `graphics_kernel.rs` additionally hosts the
+//! `rspirv-reflect`-driven `derive_bindings_from_spirv_multistage` helper,
+//! which is host-only; the SDK carries only the byte-shaped declaration
+//! types a plugin hands to `create_graphics_kernel`). The kernel author
+//! declares the stages, binding shape, and fixed-function pipeline state
+//! once as data; the host reflects the SPIR-V at kernel creation and
+//! validates the declaration matches.
+
+use streamlib_consumer_rhi::TextureFormat;
+
+/// Shader stages that contribute to a graphics pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GraphicsShaderStage {
+    Vertex,
+    Fragment,
+}
+
+/// Bitflags for which shader stages a binding or push-constant range is
+/// visible to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GraphicsShaderStageFlags(u32);
+
+impl GraphicsShaderStageFlags {
+    pub const NONE: Self = Self(0);
+    pub const VERTEX: Self = Self(0b01);
+    pub const FRAGMENT: Self = Self(0b10);
+    pub const VERTEX_FRAGMENT: Self = Self(0b11);
+
+    pub const fn contains(self, other: Self) -> bool {
+        (self.0 & other.0) == other.0
+    }
+
+    pub const fn bits(self) -> u32 {
+        self.0
+    }
+
+    pub const fn intersects(self, other: Self) -> bool {
+        (self.0 & other.0) != 0
+    }
+}
+
+impl std::ops::BitOr for GraphicsShaderStageFlags {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl std::ops::BitOrAssign for GraphicsShaderStageFlags {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+/// One stage of a graphics pipeline: SPIR-V blob plus stage classification.
+#[derive(Debug, Clone, Copy)]
+pub struct GraphicsStage<'a> {
+    pub stage: GraphicsShaderStage,
+    pub spv: &'a [u8],
+    /// Entry point name. Defaults to `"main"`.
+    pub entry_point: &'a str,
+}
+
+impl<'a> GraphicsStage<'a> {
+    pub const fn vertex(spv: &'a [u8]) -> Self {
+        Self {
+            stage: GraphicsShaderStage::Vertex,
+            spv,
+            entry_point: "main",
+        }
+    }
+
+    pub const fn fragment(spv: &'a [u8]) -> Self {
+        Self {
+            stage: GraphicsShaderStage::Fragment,
+            spv,
+            entry_point: "main",
+        }
+    }
+}
+
+/// Resource kind bound at a particular slot in a graphics kernel's
+/// descriptor set 0.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphicsBindingKind {
+    SampledTexture,
+    StorageBuffer,
+    UniformBuffer,
+    StorageImage,
+}
+
+/// One binding declaration: (binding index, resource kind, visible stages).
+#[derive(Debug, Clone, Copy)]
+pub struct GraphicsBindingSpec {
+    pub binding: u32,
+    pub kind: GraphicsBindingKind,
+    pub stages: GraphicsShaderStageFlags,
+}
+
+impl GraphicsBindingSpec {
+    pub const fn sampled_texture(binding: u32, stages: GraphicsShaderStageFlags) -> Self {
+        Self {
+            binding,
+            kind: GraphicsBindingKind::SampledTexture,
+            stages,
+        }
+    }
+
+    pub const fn storage_buffer(binding: u32, stages: GraphicsShaderStageFlags) -> Self {
+        Self {
+            binding,
+            kind: GraphicsBindingKind::StorageBuffer,
+            stages,
+        }
+    }
+
+    pub const fn uniform_buffer(binding: u32, stages: GraphicsShaderStageFlags) -> Self {
+        Self {
+            binding,
+            kind: GraphicsBindingKind::UniformBuffer,
+            stages,
+        }
+    }
+
+    pub const fn storage_image(binding: u32, stages: GraphicsShaderStageFlags) -> Self {
+        Self {
+            binding,
+            kind: GraphicsBindingKind::StorageImage,
+            stages,
+        }
+    }
+}
+
+/// Push-constant range declaration. Set `size = 0` to opt out.
+#[derive(Debug, Clone, Copy)]
+pub struct GraphicsPushConstants {
+    pub size: u32,
+    pub stages: GraphicsShaderStageFlags,
+}
+
+impl GraphicsPushConstants {
+    pub const NONE: Self = Self {
+        size: 0,
+        stages: GraphicsShaderStageFlags::NONE,
+    };
+}
+
+/// Primitive topology for assembled vertices.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrimitiveTopology {
+    PointList,
+    LineList,
+    LineStrip,
+    TriangleList,
+    TriangleStrip,
+    TriangleFan,
+}
+
+/// Per-vertex format for a vertex attribute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VertexAttributeFormat {
+    R32Float,
+    Rg32Float,
+    Rgb32Float,
+    Rgba32Float,
+    R32Uint,
+    Rg32Uint,
+    Rgb32Uint,
+    Rgba32Uint,
+    R32Sint,
+    Rg32Sint,
+    Rgb32Sint,
+    Rgba32Sint,
+    Rgba8Unorm,
+    Rgba8Snorm,
+}
+
+/// Whether a vertex input binding advances per-vertex or per-instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VertexInputRate {
+    Vertex,
+    Instance,
+}
+
+/// One vertex buffer binding slot: stride and step rate.
+#[derive(Debug, Clone, Copy)]
+pub struct VertexInputBinding {
+    pub binding: u32,
+    pub stride: u32,
+    pub input_rate: VertexInputRate,
+}
+
+/// One vertex attribute pulled from a binding: shader location, source
+/// binding, element format, byte offset within the vertex.
+#[derive(Debug, Clone, Copy)]
+pub struct VertexInputAttribute {
+    pub location: u32,
+    pub binding: u32,
+    pub format: VertexAttributeFormat,
+    pub offset: u32,
+}
+
+/// Vertex input state. `None` means the vertex shader fabricates positions
+/// from `gl_VertexIndex` / `gl_InstanceIndex` (fullscreen-triangle pattern).
+#[derive(Debug, Clone)]
+pub enum VertexInputState {
+    None,
+    Buffers {
+        bindings: Vec<VertexInputBinding>,
+        attributes: Vec<VertexInputAttribute>,
+    },
+}
+
+/// Polygon fill mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolygonMode {
+    Fill,
+    Line,
+    Point,
+}
+
+/// Face-culling mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CullMode {
+    None,
+    Front,
+    Back,
+    FrontAndBack,
+}
+
+/// Front-face winding order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrontFace {
+    CounterClockwise,
+    Clockwise,
+}
+
+/// Rasterization fixed-function state.
+#[derive(Debug, Clone, Copy)]
+pub struct RasterizationState {
+    pub polygon_mode: PolygonMode,
+    pub cull_mode: CullMode,
+    pub front_face: FrontFace,
+    pub line_width: f32,
+}
+
+impl Default for RasterizationState {
+    fn default() -> Self {
+        Self {
+            polygon_mode: PolygonMode::Fill,
+            cull_mode: CullMode::None,
+            front_face: FrontFace::CounterClockwise,
+            line_width: 1.0,
+        }
+    }
+}
+
+/// Multisample state. Only `samples = 1` is supported today.
+#[derive(Debug, Clone, Copy)]
+pub struct MultisampleState {
+    pub samples: u32,
+}
+
+impl Default for MultisampleState {
+    fn default() -> Self {
+        Self { samples: 1 }
+    }
+}
+
+/// Depth comparison op.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DepthCompareOp {
+    Never,
+    Less,
+    Equal,
+    LessOrEqual,
+    Greater,
+    NotEqual,
+    GreaterOrEqual,
+    Always,
+}
+
+/// Depth/stencil test state. Stencil testing is not exposed today.
+#[derive(Debug, Clone, Copy)]
+pub enum DepthStencilState {
+    Disabled,
+    Enabled {
+        depth_test: DepthCompareOp,
+        depth_write: bool,
+    },
+}
+
+/// Source/destination blend factor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlendFactor {
+    Zero,
+    One,
+    SrcColor,
+    OneMinusSrcColor,
+    DstColor,
+    OneMinusDstColor,
+    SrcAlpha,
+    OneMinusSrcAlpha,
+    DstAlpha,
+    OneMinusDstAlpha,
+    ConstantColor,
+    OneMinusConstantColor,
+    ConstantAlpha,
+    OneMinusConstantAlpha,
+    SrcAlphaSaturate,
+}
+
+/// Blend equation op.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlendOp {
+    Add,
+    Subtract,
+    ReverseSubtract,
+    Min,
+    Max,
+}
+
+/// Color write-mask flags for a color attachment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ColorWriteMask(u32);
+
+impl ColorWriteMask {
+    pub const R: Self = Self(0b0001);
+    pub const G: Self = Self(0b0010);
+    pub const B: Self = Self(0b0100);
+    pub const A: Self = Self(0b1000);
+    pub const RGBA: Self = Self(0b1111);
+
+    pub const fn bits(self) -> u32 {
+        self.0
+    }
+}
+
+impl std::ops::BitOr for ColorWriteMask {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+/// Per-attachment color-blend description.
+#[derive(Debug, Clone, Copy)]
+pub struct ColorBlendAttachment {
+    pub src_color_blend_factor: BlendFactor,
+    pub dst_color_blend_factor: BlendFactor,
+    pub color_blend_op: BlendOp,
+    pub src_alpha_blend_factor: BlendFactor,
+    pub dst_alpha_blend_factor: BlendFactor,
+    pub alpha_blend_op: BlendOp,
+    pub color_write_mask: ColorWriteMask,
+}
+
+impl ColorBlendAttachment {
+    /// Standard alpha blend over the destination.
+    pub const ALPHA_OVER: Self = Self {
+        src_color_blend_factor: BlendFactor::SrcAlpha,
+        dst_color_blend_factor: BlendFactor::OneMinusSrcAlpha,
+        color_blend_op: BlendOp::Add,
+        src_alpha_blend_factor: BlendFactor::One,
+        dst_alpha_blend_factor: BlendFactor::OneMinusSrcAlpha,
+        alpha_blend_op: BlendOp::Add,
+        color_write_mask: ColorWriteMask::RGBA,
+    };
+}
+
+/// Color blend state. Targets a single color attachment today.
+#[derive(Debug, Clone, Copy)]
+pub enum ColorBlendState {
+    Disabled { color_write_mask: ColorWriteMask },
+    Enabled(ColorBlendAttachment),
+}
+
+impl Default for ColorBlendState {
+    fn default() -> Self {
+        Self::Disabled {
+            color_write_mask: ColorWriteMask::RGBA,
+        }
+    }
+}
+
+/// Depth attachment format for graphics-pipeline depth testing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DepthFormat {
+    D16Unorm,
+    D32Sfloat,
+    D24UnormS8Uint,
+}
+
+/// Color and depth attachment formats the graphics pipeline targets.
+#[derive(Debug, Clone)]
+pub struct AttachmentFormats {
+    pub color: Vec<TextureFormat>,
+    pub depth: Option<DepthFormat>,
+}
+
+impl AttachmentFormats {
+    /// Single color attachment, no depth.
+    pub fn color_only(format: TextureFormat) -> Self {
+        Self {
+            color: vec![format],
+            depth: None,
+        }
+    }
+}
+
+/// Which pipeline state is set dynamically per-draw vs baked at creation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphicsDynamicState {
+    None,
+    ViewportScissor,
+}
+
+/// Complete fixed-function state plus attachment formats for a graphics
+/// pipeline.
+#[derive(Debug, Clone)]
+pub struct GraphicsPipelineState {
+    pub topology: PrimitiveTopology,
+    pub vertex_input: VertexInputState,
+    pub rasterization: RasterizationState,
+    pub multisample: MultisampleState,
+    pub depth_stencil: DepthStencilState,
+    pub color_blend: ColorBlendState,
+    pub attachment_formats: AttachmentFormats,
+    pub dynamic_state: GraphicsDynamicState,
+}
+
+/// Graphics-kernel descriptor: stages + bindings + pipeline state +
+/// descriptor-set ring depth.
+///
+/// Pass to [`crate::context::GpuContextFullAccess::create_graphics_kernel`].
+/// The host reflects every stage's SPIR-V on creation, validates that
+/// `bindings` matches the merged shader declaration, and rejects
+/// mismatches loudly.
+#[derive(Debug, Clone)]
+pub struct GraphicsKernelDescriptor<'a> {
+    /// Human-readable label used in error messages and tracing.
+    pub label: &'a str,
+    /// One entry per shader stage (vertex + fragment minimum).
+    pub stages: &'a [GraphicsStage<'a>],
+    /// Binding declarations for descriptor set 0.
+    pub bindings: &'a [GraphicsBindingSpec],
+    /// Push-constant declaration. [`GraphicsPushConstants::NONE`] if unused.
+    pub push_constants: GraphicsPushConstants,
+    /// Fixed-function pipeline state + attachment formats.
+    pub pipeline_state: GraphicsPipelineState,
+    /// Number of descriptor sets in the ring. Must be ≥ 1.
+    pub descriptor_sets_in_flight: u32,
+}
+
+/// Type of indices for indexed draws.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexType {
+    Uint16,
+    Uint32,
+}
+
+/// Viewport rectangle for dynamic-viewport draws.
+#[derive(Debug, Clone, Copy)]
+pub struct Viewport {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+    pub min_depth: f32,
+    pub max_depth: f32,
+}
+
+impl Viewport {
+    /// Convenience: full-extent viewport with depth range \[0, 1\].
+    pub fn full(width: u32, height: u32) -> Self {
+        Self {
+            x: 0.0,
+            y: 0.0,
+            width: width as f32,
+            height: height as f32,
+            min_depth: 0.0,
+            max_depth: 1.0,
+        }
+    }
+}
+
+/// Scissor rectangle for dynamic-scissor draws.
+#[derive(Debug, Clone, Copy)]
+pub struct ScissorRect {
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
+}
+
+impl ScissorRect {
+    /// Convenience: full-extent scissor anchored at the origin.
+    pub fn full(width: u32, height: u32) -> Self {
+        Self {
+            x: 0,
+            y: 0,
+            width,
+            height,
+        }
+    }
+}
+
+/// One non-indexed draw call.
+#[derive(Debug, Clone, Copy)]
+pub struct DrawCall {
+    pub vertex_count: u32,
+    pub instance_count: u32,
+    pub first_vertex: u32,
+    pub first_instance: u32,
+    pub viewport: Option<Viewport>,
+    pub scissor: Option<ScissorRect>,
+}
+
+/// One indexed draw call. Caller must have set an index buffer first.
+#[derive(Debug, Clone, Copy)]
+pub struct DrawIndexedCall {
+    pub index_count: u32,
+    pub instance_count: u32,
+    pub first_index: u32,
+    pub vertex_offset: i32,
+    pub first_instance: u32,
+    pub viewport: Option<Viewport>,
+    pub scissor: Option<ScissorRect>,
+}
+
+/// One color attachment for
+/// [`crate::rhi::VulkanGraphicsKernel::offscreen_render`].
+pub struct OffscreenColorTarget<'a> {
+    pub texture: &'a crate::rhi::Texture,
+    /// `Some` clears the attachment to this RGBA value before drawing;
+    /// `None` loads existing contents.
+    pub clear_color: Option<[f32; 4]>,
+}
+
+/// Draw variant for
+/// [`crate::rhi::VulkanGraphicsKernel::offscreen_render`].
+pub enum OffscreenDraw {
+    Draw(DrawCall),
+    DrawIndexed(DrawIndexedCall),
+}
+
+// =============================================================================
+// Plugin-ABI repr conversions
+// =============================================================================
+
+use streamlib_plugin_abi::{
+    AttachmentFormatsRepr, BlendFactorRepr, BlendOpRepr, ColorBlendAttachmentRepr,
+    ColorBlendStateKindRepr, ColorBlendStateRepr, CullModeRepr, DepthCompareOpRepr,
+    DepthFormatRepr, DepthStencilStateKindRepr, DepthStencilStateRepr, FrontFaceRepr,
+    GraphicsBindingKindRepr, GraphicsBindingSpecRepr, GraphicsDynamicStateRepr,
+    GraphicsKernelDescriptorRepr, GraphicsPipelineStateRepr, GraphicsPushConstantsRepr,
+    GraphicsShaderStageRepr, GraphicsStageRepr, MultisampleStateRepr, PolygonModeRepr,
+    PrimitiveTopologyRepr, RasterizationStateRepr, VertexAttributeFormatRepr,
+    VertexInputAttributeRepr, VertexInputBindingRepr, VertexInputRateRepr, VertexInputStateKindRepr,
+    VertexInputStateRepr,
+};
+
+impl From<GraphicsShaderStage> for GraphicsShaderStageRepr {
+    fn from(value: GraphicsShaderStage) -> Self {
+        match value {
+            GraphicsShaderStage::Vertex => Self::Vertex,
+            GraphicsShaderStage::Fragment => Self::Fragment,
+        }
+    }
+}
+
+impl From<GraphicsBindingKind> for GraphicsBindingKindRepr {
+    fn from(value: GraphicsBindingKind) -> Self {
+        match value {
+            GraphicsBindingKind::SampledTexture => Self::SampledTexture,
+            GraphicsBindingKind::StorageBuffer => Self::StorageBuffer,
+            GraphicsBindingKind::UniformBuffer => Self::UniformBuffer,
+            GraphicsBindingKind::StorageImage => Self::StorageImage,
+        }
+    }
+}
+
+impl From<&GraphicsBindingSpec> for GraphicsBindingSpecRepr {
+    fn from(value: &GraphicsBindingSpec) -> Self {
+        Self {
+            binding: value.binding,
+            kind: GraphicsBindingKindRepr::from(value.kind) as u32,
+            stages: value.stages.bits(),
+            _reserved_padding: 0,
+        }
+    }
+}
+
+impl From<GraphicsPushConstants> for GraphicsPushConstantsRepr {
+    fn from(value: GraphicsPushConstants) -> Self {
+        Self {
+            size: value.size,
+            stages: value.stages.bits(),
+        }
+    }
+}
+
+impl From<PrimitiveTopology> for PrimitiveTopologyRepr {
+    fn from(value: PrimitiveTopology) -> Self {
+        match value {
+            PrimitiveTopology::PointList => Self::PointList,
+            PrimitiveTopology::LineList => Self::LineList,
+            PrimitiveTopology::LineStrip => Self::LineStrip,
+            PrimitiveTopology::TriangleList => Self::TriangleList,
+            PrimitiveTopology::TriangleStrip => Self::TriangleStrip,
+            PrimitiveTopology::TriangleFan => Self::TriangleFan,
+        }
+    }
+}
+
+impl From<VertexAttributeFormat> for VertexAttributeFormatRepr {
+    fn from(value: VertexAttributeFormat) -> Self {
+        match value {
+            VertexAttributeFormat::R32Float => Self::R32Float,
+            VertexAttributeFormat::Rg32Float => Self::Rg32Float,
+            VertexAttributeFormat::Rgb32Float => Self::Rgb32Float,
+            VertexAttributeFormat::Rgba32Float => Self::Rgba32Float,
+            VertexAttributeFormat::R32Uint => Self::R32Uint,
+            VertexAttributeFormat::Rg32Uint => Self::Rg32Uint,
+            VertexAttributeFormat::Rgb32Uint => Self::Rgb32Uint,
+            VertexAttributeFormat::Rgba32Uint => Self::Rgba32Uint,
+            VertexAttributeFormat::R32Sint => Self::R32Sint,
+            VertexAttributeFormat::Rg32Sint => Self::Rg32Sint,
+            VertexAttributeFormat::Rgb32Sint => Self::Rgb32Sint,
+            VertexAttributeFormat::Rgba32Sint => Self::Rgba32Sint,
+            VertexAttributeFormat::Rgba8Unorm => Self::Rgba8Unorm,
+            VertexAttributeFormat::Rgba8Snorm => Self::Rgba8Snorm,
+        }
+    }
+}
+
+impl From<VertexInputRate> for VertexInputRateRepr {
+    fn from(value: VertexInputRate) -> Self {
+        match value {
+            VertexInputRate::Vertex => Self::Vertex,
+            VertexInputRate::Instance => Self::Instance,
+        }
+    }
+}
+
+impl From<&VertexInputBinding> for VertexInputBindingRepr {
+    fn from(value: &VertexInputBinding) -> Self {
+        Self {
+            binding: value.binding,
+            stride: value.stride,
+            input_rate: VertexInputRateRepr::from(value.input_rate) as u32,
+            _reserved_padding: 0,
+        }
+    }
+}
+
+impl From<&VertexInputAttribute> for VertexInputAttributeRepr {
+    fn from(value: &VertexInputAttribute) -> Self {
+        Self {
+            location: value.location,
+            binding: value.binding,
+            format: VertexAttributeFormatRepr::from(value.format) as u32,
+            offset: value.offset,
+        }
+    }
+}
+
+impl From<PolygonMode> for PolygonModeRepr {
+    fn from(value: PolygonMode) -> Self {
+        match value {
+            PolygonMode::Fill => Self::Fill,
+            PolygonMode::Line => Self::Line,
+            PolygonMode::Point => Self::Point,
+        }
+    }
+}
+
+impl From<CullMode> for CullModeRepr {
+    fn from(value: CullMode) -> Self {
+        match value {
+            CullMode::None => Self::None,
+            CullMode::Front => Self::Front,
+            CullMode::Back => Self::Back,
+            CullMode::FrontAndBack => Self::FrontAndBack,
+        }
+    }
+}
+
+impl From<FrontFace> for FrontFaceRepr {
+    fn from(value: FrontFace) -> Self {
+        match value {
+            FrontFace::CounterClockwise => Self::CounterClockwise,
+            FrontFace::Clockwise => Self::Clockwise,
+        }
+    }
+}
+
+impl From<RasterizationState> for RasterizationStateRepr {
+    fn from(value: RasterizationState) -> Self {
+        Self {
+            polygon_mode: PolygonModeRepr::from(value.polygon_mode) as u32,
+            cull_mode: CullModeRepr::from(value.cull_mode) as u32,
+            front_face: FrontFaceRepr::from(value.front_face) as u32,
+            line_width: value.line_width,
+        }
+    }
+}
+
+impl From<MultisampleState> for MultisampleStateRepr {
+    fn from(value: MultisampleState) -> Self {
+        Self {
+            samples: value.samples,
+            _reserved_padding: 0,
+        }
+    }
+}
+
+impl From<DepthCompareOp> for DepthCompareOpRepr {
+    fn from(value: DepthCompareOp) -> Self {
+        match value {
+            DepthCompareOp::Never => Self::Never,
+            DepthCompareOp::Less => Self::Less,
+            DepthCompareOp::Equal => Self::Equal,
+            DepthCompareOp::LessOrEqual => Self::LessOrEqual,
+            DepthCompareOp::Greater => Self::Greater,
+            DepthCompareOp::NotEqual => Self::NotEqual,
+            DepthCompareOp::GreaterOrEqual => Self::GreaterOrEqual,
+            DepthCompareOp::Always => Self::Always,
+        }
+    }
+}
+
+impl From<DepthStencilState> for DepthStencilStateRepr {
+    fn from(value: DepthStencilState) -> Self {
+        match value {
+            DepthStencilState::Disabled => Self {
+                kind: DepthStencilStateKindRepr::Disabled as u32,
+                depth_test: 0,
+                depth_write: 0,
+                _reserved_padding: 0,
+            },
+            DepthStencilState::Enabled {
+                depth_test,
+                depth_write,
+            } => Self {
+                kind: DepthStencilStateKindRepr::Enabled as u32,
+                depth_test: DepthCompareOpRepr::from(depth_test) as u32,
+                depth_write: depth_write as u32,
+                _reserved_padding: 0,
+            },
+        }
+    }
+}
+
+impl From<BlendFactor> for BlendFactorRepr {
+    fn from(value: BlendFactor) -> Self {
+        match value {
+            BlendFactor::Zero => Self::Zero,
+            BlendFactor::One => Self::One,
+            BlendFactor::SrcColor => Self::SrcColor,
+            BlendFactor::OneMinusSrcColor => Self::OneMinusSrcColor,
+            BlendFactor::DstColor => Self::DstColor,
+            BlendFactor::OneMinusDstColor => Self::OneMinusDstColor,
+            BlendFactor::SrcAlpha => Self::SrcAlpha,
+            BlendFactor::OneMinusSrcAlpha => Self::OneMinusSrcAlpha,
+            BlendFactor::DstAlpha => Self::DstAlpha,
+            BlendFactor::OneMinusDstAlpha => Self::OneMinusDstAlpha,
+            BlendFactor::ConstantColor => Self::ConstantColor,
+            BlendFactor::OneMinusConstantColor => Self::OneMinusConstantColor,
+            BlendFactor::ConstantAlpha => Self::ConstantAlpha,
+            BlendFactor::OneMinusConstantAlpha => Self::OneMinusConstantAlpha,
+            BlendFactor::SrcAlphaSaturate => Self::SrcAlphaSaturate,
+        }
+    }
+}
+
+impl From<BlendOp> for BlendOpRepr {
+    fn from(value: BlendOp) -> Self {
+        match value {
+            BlendOp::Add => Self::Add,
+            BlendOp::Subtract => Self::Subtract,
+            BlendOp::ReverseSubtract => Self::ReverseSubtract,
+            BlendOp::Min => Self::Min,
+            BlendOp::Max => Self::Max,
+        }
+    }
+}
+
+impl From<ColorBlendAttachment> for ColorBlendAttachmentRepr {
+    fn from(value: ColorBlendAttachment) -> Self {
+        Self {
+            src_color_blend_factor: BlendFactorRepr::from(value.src_color_blend_factor) as u32,
+            dst_color_blend_factor: BlendFactorRepr::from(value.dst_color_blend_factor) as u32,
+            color_blend_op: BlendOpRepr::from(value.color_blend_op) as u32,
+            src_alpha_blend_factor: BlendFactorRepr::from(value.src_alpha_blend_factor) as u32,
+            dst_alpha_blend_factor: BlendFactorRepr::from(value.dst_alpha_blend_factor) as u32,
+            alpha_blend_op: BlendOpRepr::from(value.alpha_blend_op) as u32,
+            color_write_mask: value.color_write_mask.bits(),
+            _reserved_padding: 0,
+        }
+    }
+}
+
+impl From<ColorBlendState> for ColorBlendStateRepr {
+    fn from(value: ColorBlendState) -> Self {
+        match value {
+            ColorBlendState::Disabled { color_write_mask } => Self {
+                kind: ColorBlendStateKindRepr::Disabled as u32,
+                color_write_mask: color_write_mask.bits(),
+                attachment: ColorBlendAttachmentRepr {
+                    src_color_blend_factor: 0,
+                    dst_color_blend_factor: 0,
+                    color_blend_op: 0,
+                    src_alpha_blend_factor: 0,
+                    dst_alpha_blend_factor: 0,
+                    alpha_blend_op: 0,
+                    color_write_mask: 0,
+                    _reserved_padding: 0,
+                },
+            },
+            ColorBlendState::Enabled(att) => Self {
+                kind: ColorBlendStateKindRepr::Enabled as u32,
+                color_write_mask: 0,
+                attachment: ColorBlendAttachmentRepr::from(att),
+            },
+        }
+    }
+}
+
+impl From<DepthFormat> for DepthFormatRepr {
+    fn from(value: DepthFormat) -> Self {
+        match value {
+            DepthFormat::D16Unorm => Self::D16Unorm,
+            DepthFormat::D32Sfloat => Self::D32Sfloat,
+            DepthFormat::D24UnormS8Uint => Self::D24UnormS8Uint,
+        }
+    }
+}
+
+impl From<GraphicsDynamicState> for GraphicsDynamicStateRepr {
+    fn from(value: GraphicsDynamicState) -> Self {
+        match value {
+            GraphicsDynamicState::None => Self::None,
+            GraphicsDynamicState::ViewportScissor => Self::ViewportScissor,
+        }
+    }
+}
+
+/// Keepalive backing for [`stage_graphics_kernel_descriptor`].
+///
+/// The staged [`GraphicsKernelDescriptorRepr`]'s pointer fields borrow
+/// into these five Vecs (`Vec` moves don't reallocate, so the heap
+/// buffer addresses stay stable when the Vecs are moved into this struct
+/// after `as_ptr()` is taken). The caller MUST keep this struct alive for
+/// the lifetime of the repr.
+pub(crate) struct GraphicsKernelDescriptorReprStage {
+    #[allow(dead_code)]
+    pub stages_buf: Vec<GraphicsStageRepr>,
+    #[allow(dead_code)]
+    pub bindings_buf: Vec<GraphicsBindingSpecRepr>,
+    #[allow(dead_code)]
+    pub vertex_bindings_buf: Vec<VertexInputBindingRepr>,
+    #[allow(dead_code)]
+    pub vertex_attrs_buf: Vec<VertexInputAttributeRepr>,
+    #[allow(dead_code)]
+    pub color_formats_buf: Vec<u32>,
+}
+
+/// Stage a [`GraphicsKernelDescriptor`] to its `#[repr(C)]` mirror plus
+/// the backing buffers the repr's pointer fields borrow into, ready for
+/// the FullAccess `create_graphics_kernel` vtable call.
+///
+/// Returns `(repr, stage)`. The caller MUST keep `stage` alive for the
+/// lifetime of `repr` (the repr's `stages_ptr` / `bindings_ptr` /
+/// `vertex_input.bindings_ptr` / `vertex_input.attributes_ptr` /
+/// `attachment_formats.color_ptr` all point into `stage`'s Vecs).
+pub(crate) fn stage_graphics_kernel_descriptor(
+    desc: &GraphicsKernelDescriptor<'_>,
+) -> (GraphicsKernelDescriptorRepr, GraphicsKernelDescriptorReprStage) {
+    let stages_buf: Vec<GraphicsStageRepr> = desc
+        .stages
+        .iter()
+        .map(|s| GraphicsStageRepr {
+            stage: GraphicsShaderStageRepr::from(s.stage) as u32,
+            _reserved_padding: 0,
+            spv_ptr: s.spv.as_ptr(),
+            spv_len: s.spv.len(),
+            entry_point_ptr: s.entry_point.as_ptr(),
+            entry_point_len: s.entry_point.len(),
+        })
+        .collect();
+    let bindings_buf: Vec<GraphicsBindingSpecRepr> =
+        desc.bindings.iter().map(GraphicsBindingSpecRepr::from).collect();
+
+    let (vertex_input_repr, vertex_bindings_buf, vertex_attrs_buf) =
+        match &desc.pipeline_state.vertex_input {
+            VertexInputState::None => (
+                VertexInputStateRepr {
+                    kind: VertexInputStateKindRepr::None as u32,
+                    _reserved_padding: 0,
+                    bindings_ptr: std::ptr::null(),
+                    bindings_len: 0,
+                    attributes_ptr: std::ptr::null(),
+                    attributes_len: 0,
+                },
+                Vec::new(),
+                Vec::new(),
+            ),
+            VertexInputState::Buffers {
+                bindings,
+                attributes,
+            } => {
+                let b: Vec<VertexInputBindingRepr> =
+                    bindings.iter().map(VertexInputBindingRepr::from).collect();
+                let a: Vec<VertexInputAttributeRepr> =
+                    attributes.iter().map(VertexInputAttributeRepr::from).collect();
+                let repr = VertexInputStateRepr {
+                    kind: VertexInputStateKindRepr::Buffers as u32,
+                    _reserved_padding: 0,
+                    bindings_ptr: b.as_ptr(),
+                    bindings_len: b.len(),
+                    attributes_ptr: a.as_ptr(),
+                    attributes_len: a.len(),
+                };
+                (repr, b, a)
+            }
+        };
+
+    let color_formats_buf: Vec<u32> = desc
+        .pipeline_state
+        .attachment_formats
+        .color
+        .iter()
+        .map(|f| *f as u32)
+        .collect();
+    let attachment_formats_repr = AttachmentFormatsRepr {
+        color_ptr: color_formats_buf.as_ptr(),
+        color_len: color_formats_buf.len(),
+        has_depth: if desc.pipeline_state.attachment_formats.depth.is_some() {
+            1
+        } else {
+            0
+        },
+        depth: desc
+            .pipeline_state
+            .attachment_formats
+            .depth
+            .map(|d| DepthFormatRepr::from(d) as u32)
+            .unwrap_or(0),
+    };
+
+    let pipeline_state = GraphicsPipelineStateRepr {
+        topology: PrimitiveTopologyRepr::from(desc.pipeline_state.topology) as u32,
+        _reserved_padding1: 0,
+        vertex_input: vertex_input_repr,
+        rasterization: RasterizationStateRepr::from(desc.pipeline_state.rasterization),
+        multisample: MultisampleStateRepr::from(desc.pipeline_state.multisample),
+        depth_stencil: DepthStencilStateRepr::from(desc.pipeline_state.depth_stencil),
+        color_blend: ColorBlendStateRepr::from(desc.pipeline_state.color_blend),
+        attachment_formats: attachment_formats_repr,
+        dynamic_state: GraphicsDynamicStateRepr::from(desc.pipeline_state.dynamic_state) as u32,
+        _reserved_padding2: 0,
+    };
+
+    let repr = GraphicsKernelDescriptorRepr {
+        label_ptr: desc.label.as_ptr(),
+        label_len: desc.label.len(),
+        stages_ptr: stages_buf.as_ptr(),
+        stages_len: stages_buf.len(),
+        bindings_ptr: bindings_buf.as_ptr(),
+        bindings_len: bindings_buf.len(),
+        push_constants: GraphicsPushConstantsRepr::from(desc.push_constants),
+        pipeline_state,
+        descriptor_sets_in_flight: desc.descriptor_sets_in_flight,
+        _reserved_padding: 0,
+    };
+
+    let stage = GraphicsKernelDescriptorReprStage {
+        stages_buf,
+        bindings_buf,
+        vertex_bindings_buf,
+        vertex_attrs_buf,
+        color_formats_buf,
+    };
+    (repr, stage)
+}
+
+#[cfg(test)]
+mod staging_tests {
+    use super::*;
+    use streamlib_plugin_abi::{
+        ColorBlendStateKindRepr, DepthStencilStateKindRepr, GraphicsShaderStageRepr,
+        PrimitiveTopologyRepr, VertexInputStateKindRepr,
+    };
+
+    // Minimal non-empty SPIR-V-shaped byte blobs. Content is never
+    // reflected here (that happens host-side); the staging fn only reads
+    // the slice pointer + length.
+    const VERT_SPV: &[u8] = &[0x03, 0x02, 0x23, 0x07, 0xAA, 0xBB];
+    const FRAG_SPV: &[u8] = &[0x03, 0x02, 0x23, 0x07, 0xCC, 0xDD, 0xEE];
+
+    #[test]
+    fn fullscreen_effect_descriptor_stages_to_expected_repr() {
+        let stages = [GraphicsStage::vertex(VERT_SPV), GraphicsStage::fragment(FRAG_SPV)];
+        let bindings =
+            [GraphicsBindingSpec::sampled_texture(0, GraphicsShaderStageFlags::FRAGMENT)];
+        let pipeline_state = GraphicsPipelineState {
+            topology: PrimitiveTopology::TriangleList,
+            vertex_input: VertexInputState::None,
+            rasterization: RasterizationState::default(),
+            multisample: MultisampleState::default(),
+            depth_stencil: DepthStencilState::Disabled,
+            color_blend: ColorBlendState::default(),
+            attachment_formats: AttachmentFormats::color_only(TextureFormat::Rgba8Unorm),
+            dynamic_state: GraphicsDynamicState::ViewportScissor,
+        };
+        let desc = GraphicsKernelDescriptor {
+            label: "fullscreen_effect",
+            stages: &stages,
+            bindings: &bindings,
+            push_constants: GraphicsPushConstants {
+                size: 16,
+                stages: GraphicsShaderStageFlags::FRAGMENT,
+            },
+            pipeline_state,
+            descriptor_sets_in_flight: 2,
+        };
+
+        let (repr, stage) = stage_graphics_kernel_descriptor(&desc);
+
+        // Top-level scalars + lengths.
+        assert_eq!(repr.label_len, "fullscreen_effect".len());
+        assert_eq!(repr.stages_len, 2);
+        assert_eq!(repr.bindings_len, 1);
+        assert_eq!(repr.descriptor_sets_in_flight, 2);
+        assert_eq!(repr.push_constants.size, 16);
+        assert_eq!(
+            repr.push_constants.stages,
+            GraphicsShaderStageFlags::FRAGMENT.bits()
+        );
+
+        // Pointer fields point into the keepalive Vecs (not dangling / null).
+        assert_eq!(repr.stages_ptr, stage.stages_buf.as_ptr());
+        assert_eq!(repr.bindings_ptr, stage.bindings_buf.as_ptr());
+
+        // Stage discriminants + SPIR-V slice plumbing.
+        assert_eq!(stage.stages_buf[0].stage, GraphicsShaderStageRepr::Vertex as u32);
+        assert_eq!(stage.stages_buf[0].spv_len, VERT_SPV.len());
+        assert_eq!(stage.stages_buf[0].spv_ptr, VERT_SPV.as_ptr());
+        assert_eq!(stage.stages_buf[0].entry_point_len, "main".len());
+        assert_eq!(stage.stages_buf[1].stage, GraphicsShaderStageRepr::Fragment as u32);
+        assert_eq!(stage.stages_buf[1].spv_len, FRAG_SPV.len());
+
+        // Binding mapping: sampled-texture kind + fragment stage mask.
+        assert_eq!(
+            stage.bindings_buf[0].kind,
+            GraphicsBindingKindRepr::SampledTexture as u32
+        );
+        assert_eq!(stage.bindings_buf[0].binding, 0);
+        assert_eq!(
+            stage.bindings_buf[0].stages,
+            GraphicsShaderStageFlags::FRAGMENT.bits()
+        );
+
+        // Pipeline-state scalars.
+        assert_eq!(repr.pipeline_state.topology, PrimitiveTopologyRepr::TriangleList as u32);
+        assert_eq!(
+            repr.pipeline_state.dynamic_state,
+            GraphicsDynamicStateRepr::ViewportScissor as u32
+        );
+
+        // VertexInputState::None → null slice pointers + Buffers kind absent.
+        assert_eq!(
+            repr.pipeline_state.vertex_input.kind,
+            VertexInputStateKindRepr::None as u32
+        );
+        assert!(repr.pipeline_state.vertex_input.bindings_ptr.is_null());
+        assert_eq!(repr.pipeline_state.vertex_input.bindings_len, 0);
+        assert!(stage.vertex_bindings_buf.is_empty());
+        assert!(stage.vertex_attrs_buf.is_empty());
+
+        // DepthStencilState::Disabled.
+        assert_eq!(
+            repr.pipeline_state.depth_stencil.kind,
+            DepthStencilStateKindRepr::Disabled as u32
+        );
+
+        // ColorBlendState::default() == Disabled { RGBA }.
+        assert_eq!(
+            repr.pipeline_state.color_blend.kind,
+            ColorBlendStateKindRepr::Disabled as u32
+        );
+        assert_eq!(
+            repr.pipeline_state.color_blend.color_write_mask,
+            ColorWriteMask::RGBA.bits()
+        );
+
+        // AttachmentFormats: one color format, no depth.
+        assert_eq!(repr.pipeline_state.attachment_formats.color_len, 1);
+        assert_eq!(repr.pipeline_state.attachment_formats.has_depth, 0);
+        assert_eq!(
+            repr.pipeline_state.attachment_formats.color_ptr,
+            stage.color_formats_buf.as_ptr()
+        );
+        assert_eq!(
+            stage.color_formats_buf[0],
+            TextureFormat::Rgba8Unorm as u32
+        );
+    }
+
+    #[test]
+    fn vertex_buffers_and_depth_stage_into_repr() {
+        // Exercises the VertexInputState::Buffers + depth + enabled-blend
+        // arms so the keepalive Vecs for vertex bindings/attributes carry
+        // real data and the tagged-union discriminants map correctly.
+        let stages = [GraphicsStage::vertex(VERT_SPV), GraphicsStage::fragment(FRAG_SPV)];
+        let bindings: [GraphicsBindingSpec; 0] = [];
+        let vertex_input = VertexInputState::Buffers {
+            bindings: vec![VertexInputBinding {
+                binding: 0,
+                stride: 32,
+                input_rate: VertexInputRate::Vertex,
+            }],
+            attributes: vec![
+                VertexInputAttribute {
+                    location: 0,
+                    binding: 0,
+                    format: VertexAttributeFormat::Rgb32Float,
+                    offset: 0,
+                },
+                VertexInputAttribute {
+                    location: 1,
+                    binding: 0,
+                    format: VertexAttributeFormat::Rg32Float,
+                    offset: 12,
+                },
+            ],
+        };
+        let pipeline_state = GraphicsPipelineState {
+            topology: PrimitiveTopology::TriangleStrip,
+            vertex_input,
+            rasterization: RasterizationState {
+                polygon_mode: PolygonMode::Fill,
+                cull_mode: CullMode::Back,
+                front_face: FrontFace::Clockwise,
+                line_width: 2.0,
+            },
+            multisample: MultisampleState::default(),
+            depth_stencil: DepthStencilState::Enabled {
+                depth_test: DepthCompareOp::LessOrEqual,
+                depth_write: true,
+            },
+            color_blend: ColorBlendState::Enabled(ColorBlendAttachment::ALPHA_OVER),
+            attachment_formats: AttachmentFormats {
+                color: vec![TextureFormat::Bgra8Unorm],
+                depth: Some(DepthFormat::D32Sfloat),
+            },
+            dynamic_state: GraphicsDynamicState::ViewportScissor,
+        };
+        let desc = GraphicsKernelDescriptor {
+            label: "mesh",
+            stages: &stages,
+            bindings: &bindings,
+            push_constants: GraphicsPushConstants::NONE,
+            pipeline_state,
+            descriptor_sets_in_flight: 3,
+        };
+
+        let (repr, stage) = stage_graphics_kernel_descriptor(&desc);
+
+        assert_eq!(repr.bindings_len, 0);
+        assert_eq!(repr.descriptor_sets_in_flight, 3);
+        assert_eq!(repr.push_constants.size, 0);
+
+        // Buffers arm: two attributes, one binding, pointers into keepalive.
+        assert_eq!(
+            repr.pipeline_state.vertex_input.kind,
+            VertexInputStateKindRepr::Buffers as u32
+        );
+        assert_eq!(repr.pipeline_state.vertex_input.bindings_len, 1);
+        assert_eq!(repr.pipeline_state.vertex_input.attributes_len, 2);
+        assert_eq!(
+            repr.pipeline_state.vertex_input.bindings_ptr,
+            stage.vertex_bindings_buf.as_ptr()
+        );
+        assert_eq!(
+            repr.pipeline_state.vertex_input.attributes_ptr,
+            stage.vertex_attrs_buf.as_ptr()
+        );
+        assert_eq!(stage.vertex_bindings_buf[0].stride, 32);
+        assert_eq!(
+            stage.vertex_attrs_buf[1].format,
+            VertexAttributeFormatRepr::Rg32Float as u32
+        );
+        assert_eq!(stage.vertex_attrs_buf[1].offset, 12);
+
+        // Rasterization scalars round-trip.
+        assert_eq!(repr.pipeline_state.rasterization.cull_mode, CullModeRepr::Back as u32);
+        assert_eq!(
+            repr.pipeline_state.rasterization.front_face,
+            FrontFaceRepr::Clockwise as u32
+        );
+        assert_eq!(repr.pipeline_state.rasterization.line_width, 2.0);
+
+        // DepthStencilState::Enabled.
+        assert_eq!(
+            repr.pipeline_state.depth_stencil.kind,
+            DepthStencilStateKindRepr::Enabled as u32
+        );
+        assert_eq!(
+            repr.pipeline_state.depth_stencil.depth_test,
+            DepthCompareOpRepr::LessOrEqual as u32
+        );
+        assert_eq!(repr.pipeline_state.depth_stencil.depth_write, 1);
+
+        // ColorBlendState::Enabled(ALPHA_OVER).
+        assert_eq!(
+            repr.pipeline_state.color_blend.kind,
+            ColorBlendStateKindRepr::Enabled as u32
+        );
+        assert_eq!(
+            repr.pipeline_state.color_blend.attachment.src_color_blend_factor,
+            BlendFactorRepr::SrcAlpha as u32
+        );
+        assert_eq!(
+            repr.pipeline_state.color_blend.attachment.dst_color_blend_factor,
+            BlendFactorRepr::OneMinusSrcAlpha as u32
+        );
+
+        // AttachmentFormats: one color + depth present.
+        assert_eq!(repr.pipeline_state.attachment_formats.has_depth, 1);
+        assert_eq!(
+            repr.pipeline_state.attachment_formats.depth,
+            DepthFormatRepr::D32Sfloat as u32
+        );
+    }
+}

--- a/plugin/streamlib-plugin-sdk/src/rhi/pixel_buffer.rs
+++ b/plugin/streamlib-plugin-sdk/src/rhi/pixel_buffer.rs
@@ -1,0 +1,204 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cdylib-arm twin of the engine's RHI [`PixelBuffer`] PluginAbiObject.
+//!
+//! Layout-stable `(handle, vtable, cached POD)` shape mirroring the engine's
+//! `core/rhi/pixel_buffer.rs::PixelBuffer`. Arc refcount accounting runs in
+//! host-compiled code via the vtable's `clone_pixel_buffer` /
+//! `drop_pixel_buffer` callbacks; per-plane data reads route through
+//! `plane_base_address_pixel_buffer` / `plane_size_pixel_buffer`. The host
+//! `PixelBufferRef` backing + the `new` / `from_arc_into_raw` / `buffer_ref`
+//! constructors stay in the engine.
+
+use std::ffi::c_void;
+
+use streamlib_consumer_rhi::PixelFormat;
+use streamlib_plugin_abi::GpuContextLimitedAccessVTable;
+
+/// Platform-agnostic identifier for a pooled pixel buffer.
+///
+/// Engine-free mirror of the engine's `PixelBufferPoolId` — a UUID string
+/// returned by
+/// [`crate::context::GpuContextLimitedAccess::acquire_pixel_buffer`] and
+/// handed back to
+/// [`crate::context::GpuContextLimitedAccess::get_pixel_buffer`]. Crosses the
+/// plugin ABI as a UTF-8 byte buffer, not a `#[repr(C)]` value.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PixelBufferPoolId(String);
+
+impl PixelBufferPoolId {
+    /// Wrap an existing id string (e.g. one returned across the plugin ABI).
+    pub fn from_string(s: String) -> Self {
+        Self(s)
+    }
+
+    /// Wrap an id string slice.
+    pub fn from_str(s: &str) -> Self {
+        Self(s.to_string())
+    }
+
+    /// Borrow the id as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for PixelBufferPoolId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Pixel buffer with cached dimensions.
+///
+/// Layout-stable: every field is either a primitive or an opaque pointer.
+/// Clone bumps the host's `Arc<PixelBufferRef>` strong count via
+/// [`GpuContextLimitedAccessVTable::clone_pixel_buffer`]; Drop decrements via
+/// [`GpuContextLimitedAccessVTable::drop_pixel_buffer`]. Both run in
+/// host-compiled code regardless of the calling plugin.
+#[repr(C)]
+pub struct PixelBuffer {
+    /// Opaque handle to the host's `Arc<PixelBufferRef>` (produced by
+    /// `Arc::into_raw`).
+    pub(crate) handle: *const c_void,
+    /// Vtable for plugin ABI Clone/Drop + plane-accessor dispatch.
+    pub(crate) vtable: *const GpuContextLimitedAccessVTable,
+    /// Cached width in pixels (queried once at construction host-side).
+    pub width: u32,
+    /// Cached height in pixels (queried once at construction host-side).
+    pub height: u32,
+    /// Cached pixel format `#[repr(u32)]` FourCC discriminant.
+    pub(crate) format_raw: u32,
+    /// Cached plane count (always `>= 1`).
+    pub(crate) plane_count_cached: u32,
+}
+
+// SAFETY: `handle` points at an `Arc<PixelBufferRef>` whose interior is
+// Send+Sync. Refcount management crosses the plugin ABI through the vtable,
+// but the underlying Arc bookkeeping runs in host-compiled code regardless.
+unsafe impl Send for PixelBuffer {}
+unsafe impl Sync for PixelBuffer {}
+
+impl PixelBuffer {
+    /// Cached pixel format. Captured at construction; pure field read with no
+    /// plugin ABI dispatch.
+    pub fn format(&self) -> PixelFormat {
+        // Mirror of the engine `PixelBuffer::format()` FourCC mapping. There
+        // is no portable `PixelFormat::from_raw` on consumer-rhi (the named
+        // converter is macOS-only), so the canonical match is inlined.
+        match self.format_raw {
+            0x42475241 => PixelFormat::Bgra32,
+            0x52474241 => PixelFormat::Rgba32,
+            0x00000020 => PixelFormat::Argb32,
+            0x52476841 => PixelFormat::Rgba64,
+            0x34323076 => PixelFormat::Nv12VideoRange,
+            0x34323066 => PixelFormat::Nv12FullRange,
+            0x32767579 => PixelFormat::Uyvy422,
+            0x79757673 => PixelFormat::Yuyv422,
+            0x4C303038 => PixelFormat::Gray8,
+            _ => PixelFormat::Unknown,
+        }
+    }
+
+    /// Number of DMA-BUF planes backing this pixel buffer. Always `>= 1`.
+    /// Cached at construction; pure field read.
+    pub fn plane_count(&self) -> u32 {
+        self.plane_count_cached
+    }
+
+    /// Mapped base address for the given plane, or null if out of range.
+    /// Dispatches through the vtable's
+    /// [`GpuContextLimitedAccessVTable::plane_base_address_pixel_buffer`]
+    /// callback so the host's `PixelBufferRef` layout is never touched
+    /// cdylib-side.
+    pub fn plane_base_address(&self, plane_index: u32) -> *mut u8 {
+        if self.handle.is_null() || self.vtable.is_null() {
+            return core::ptr::null_mut();
+        }
+        // SAFETY: vtable + handle paired at construction.
+        unsafe { ((*self.vtable).plane_base_address_pixel_buffer)(self.handle, plane_index) }
+    }
+
+    /// Byte size of the given plane, or `0` if out of range. Dispatches
+    /// through the vtable's
+    /// [`GpuContextLimitedAccessVTable::plane_size_pixel_buffer`] callback.
+    pub fn plane_size(&self, plane_index: u32) -> u64 {
+        if self.handle.is_null() || self.vtable.is_null() {
+            return 0;
+        }
+        // SAFETY: vtable + handle paired at construction.
+        unsafe { ((*self.vtable).plane_size_pixel_buffer)(self.handle, plane_index) }
+    }
+}
+
+impl Clone for PixelBuffer {
+    fn clone(&self) -> Self {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            // SAFETY: vtable + handle paired at construction; the vtable's
+            // `clone_pixel_buffer` contract is `Arc::increment_strong_count`
+            // host-side. Balanced by Drop.
+            unsafe {
+                ((*self.vtable).clone_pixel_buffer)(self.handle);
+            }
+        }
+        Self {
+            handle: self.handle,
+            vtable: self.vtable,
+            width: self.width,
+            height: self.height,
+            format_raw: self.format_raw,
+            plane_count_cached: self.plane_count_cached,
+        }
+    }
+}
+
+impl Drop for PixelBuffer {
+    fn drop(&mut self) {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            // SAFETY: matched with the host's `Arc::into_raw` and any
+            // `clone_pixel_buffer` bumps.
+            unsafe {
+                ((*self.vtable).drop_pixel_buffer)(self.handle);
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for PixelBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PixelBuffer")
+            .field("width", &self.width)
+            .field("height", &self.height)
+            .field("format", &self.format())
+            .finish()
+    }
+}
+
+#[cfg(all(test, target_pointer_width = "64"))]
+mod layout_tests {
+    use super::*;
+    use core::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    fn pixel_buffer_layout() {
+        // Must match the engine's `core/rhi/pixel_buffer.rs::PixelBuffer`:
+        //   handle @ 0, vtable @ 8, width @ 16, height @ 20,
+        //   format_raw @ 24, plane_count_cached @ 28.
+        // Total 32 bytes, align 8.
+        assert_eq!(size_of::<PixelBuffer>(), 32);
+        assert_eq!(align_of::<PixelBuffer>(), 8);
+        assert_eq!(offset_of!(PixelBuffer, handle), 0);
+        assert_eq!(offset_of!(PixelBuffer, vtable), 8);
+        assert_eq!(offset_of!(PixelBuffer, width), 16);
+        assert_eq!(offset_of!(PixelBuffer, height), 20);
+        assert_eq!(offset_of!(PixelBuffer, format_raw), 24);
+        assert_eq!(offset_of!(PixelBuffer, plane_count_cached), 28);
+    }
+
+    #[test]
+    fn pixel_buffer_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<PixelBuffer>();
+    }
+}

--- a/plugin/streamlib-plugin-sdk/src/rhi/pooled_texture_handle.rs
+++ b/plugin/streamlib-plugin-sdk/src/rhi/pooled_texture_handle.rs
@@ -1,0 +1,197 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cdylib-arm twin of the engine's [`PooledTextureHandle`] PluginAbiObject.
+//!
+//! Layout-stable `#[repr(C)] (handle, vtable, Texture, cached POD)` shape
+//! mirroring the engine's `core/context/texture_pool.rs::PooledTextureHandle`.
+//! Deliberately **not** `Clone` — Drop releases the underlying pool slot via
+//! the vtable's `drop_pooled_texture_handle` callback exactly once, and the
+//! embedded [`Texture`]'s own Drop releases the texture Arc. The host
+//! `PooledTextureHandleInner` backing stays in the engine.
+
+use std::ffi::c_void;
+
+use streamlib_consumer_rhi::{TextureFormat, TextureUsages};
+use streamlib_plugin_abi::GpuContextLimitedAccessVTable;
+
+use crate::rhi::{NativeTextureHandle, Texture};
+
+/// Request descriptor for acquiring a pooled texture. Engine-free mirror of
+/// the engine's `TexturePoolDescriptor`.
+#[derive(Clone, Debug)]
+pub struct TexturePoolDescriptor {
+    pub width: u32,
+    pub height: u32,
+    pub format: TextureFormat,
+    pub usage: TextureUsages,
+    pub label: Option<&'static str>,
+}
+
+impl TexturePoolDescriptor {
+    /// Create a new pool descriptor (default usage:
+    /// `TEXTURE_BINDING | COPY_SRC`).
+    pub fn new(width: u32, height: u32, format: TextureFormat) -> Self {
+        Self {
+            width,
+            height,
+            format,
+            usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_SRC,
+            label: None,
+        }
+    }
+
+    /// Set usage flags.
+    pub fn with_usage(mut self, usage: TextureUsages) -> Self {
+        self.usage = usage;
+        self
+    }
+
+    /// Set a debug label.
+    pub fn with_label(mut self, label: &'static str) -> Self {
+        self.label = Some(label);
+        self
+    }
+}
+
+/// Handle to a pooled texture. Returns the texture to the pool on Drop.
+///
+/// Layout-stable: every field is a primitive, an opaque pointer, or the
+/// layout-stable [`Texture`] twin embedded by value.
+///
+/// Deliberately **not** `Clone`: Drop releases the underlying pool slot
+/// exactly once via [`GpuContextLimitedAccessVTable::drop_pooled_texture_handle`].
+/// Cloning would duplicate the raw `handle` and double-release the slot.
+/// Consumers needing shared access wrap the handle in `Arc<PooledTextureHandle>`.
+#[repr(C)]
+pub struct PooledTextureHandle {
+    /// Opaque host handle (`Box::into_raw(Box<PooledTextureHandleInner>)`).
+    pub(crate) handle: *const c_void,
+    /// Vtable for plugin ABI Drop dispatch.
+    pub(crate) vtable: *const GpuContextLimitedAccessVTable,
+    /// The pooled texture. Embedded by value (the [`Texture`] twin is itself
+    /// `#[repr(C)]`, 32 bytes); its own Drop releases the texture Arc.
+    pub(crate) texture: Texture,
+    /// Cached width (mirrors the pool key width at allocation time).
+    pub(crate) width_cached: u32,
+    /// Cached height (mirrors the pool key height).
+    pub(crate) height_cached: u32,
+    /// Cached `#[repr(u32)]` discriminant of [`TextureFormat`].
+    pub(crate) format_raw: u32,
+    /// Reserved padding (keeps total size at 64 bytes; zero, never read).
+    pub(crate) _padding: u32,
+}
+
+// SAFETY: `handle` points at a host-owned `Box<PooledTextureHandleInner>`
+// that is Send+Sync; the embedded `texture` is Send+Sync per its own unsafe
+// impls. Pool-slot release runs in host-compiled code via the vtable callback.
+unsafe impl Send for PooledTextureHandle {}
+unsafe impl Sync for PooledTextureHandle {}
+
+impl PooledTextureHandle {
+    /// Borrow the underlying texture.
+    pub fn texture(&self) -> &Texture {
+        &self.texture
+    }
+
+    /// Clone the underlying texture (bumps the host's texture Arc).
+    pub fn texture_clone(&self) -> Texture {
+        self.texture.clone()
+    }
+
+    /// Texture width in pixels. Cached at construction; pure field read.
+    pub fn width(&self) -> u32 {
+        self.width_cached
+    }
+
+    /// Texture height in pixels. Cached at construction; pure field read.
+    pub fn height(&self) -> u32 {
+        self.height_cached
+    }
+
+    /// Texture format. Cached at construction; pure field read.
+    pub fn format(&self) -> TextureFormat {
+        match self.format_raw {
+            0 => TextureFormat::Rgba8Unorm,
+            1 => TextureFormat::Rgba8UnormSrgb,
+            2 => TextureFormat::Bgra8Unorm,
+            3 => TextureFormat::Bgra8UnormSrgb,
+            4 => TextureFormat::Rgba16Float,
+            5 => TextureFormat::Rgba32Float,
+            6 => TextureFormat::Nv12,
+            _ => TextureFormat::Rgba8Unorm,
+        }
+    }
+
+    /// Platform-native sharing handle for the underlying texture (Linux
+    /// DMA-BUF FD). Delegates to [`Texture::native_handle`].
+    pub fn native_handle(&self) -> Option<NativeTextureHandle> {
+        self.texture.native_handle()
+    }
+}
+
+impl Drop for PooledTextureHandle {
+    fn drop(&mut self) {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            // SAFETY: matched with the host's `Box::into_raw`. The vtable's
+            // `drop_pooled_texture_handle` callback runs `Box::from_raw +
+            // drop` host-side, firing `Drop for PooledTextureHandleInner`
+            // which releases the pool slot exactly once. The embedded
+            // `texture` field's own Drop (running after this) decrements the
+            // texture Arc — mirroring the engine's two-drop shape.
+            unsafe {
+                ((*self.vtable).drop_pooled_texture_handle)(self.handle);
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for PooledTextureHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PooledTextureHandle")
+            .field("width", &self.width_cached)
+            .field("height", &self.height_cached)
+            .field("format", &self.format())
+            .finish()
+    }
+}
+
+#[cfg(all(test, target_pointer_width = "64"))]
+mod layout_tests {
+    use super::*;
+    use core::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    fn pooled_texture_handle_layout() {
+        // Must match the engine's
+        // `core/context/texture_pool.rs::PooledTextureHandle`:
+        //   handle @ 0, vtable @ 8, texture @ 16 (32B), width_cached @ 48,
+        //   height_cached @ 52, format_raw @ 56, _padding @ 60.
+        // Total 64 bytes, align 8.
+        assert_eq!(size_of::<PooledTextureHandle>(), 64);
+        assert_eq!(align_of::<PooledTextureHandle>(), 8);
+        assert_eq!(offset_of!(PooledTextureHandle, handle), 0);
+        assert_eq!(offset_of!(PooledTextureHandle, vtable), 8);
+        assert_eq!(offset_of!(PooledTextureHandle, texture), 16);
+        assert_eq!(offset_of!(PooledTextureHandle, width_cached), 48);
+        assert_eq!(offset_of!(PooledTextureHandle, height_cached), 52);
+        assert_eq!(offset_of!(PooledTextureHandle, format_raw), 56);
+        assert_eq!(offset_of!(PooledTextureHandle, _padding), 60);
+    }
+
+    #[test]
+    fn pooled_texture_handle_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<PooledTextureHandle>();
+    }
+
+    /// `PooledTextureHandle` must NOT be `Clone` — Drop releases the pool
+    /// slot exactly once.
+    ///
+    /// ```compile_fail
+    /// fn assert_not_clone<T: Clone>() {}
+    /// assert_not_clone::<streamlib_plugin_sdk::sdk::rhi::PooledTextureHandle>();
+    /// ```
+    #[allow(dead_code)]
+    fn not_clone_doctest_anchor() {}
+}

--- a/plugin/streamlib-plugin-sdk/src/rhi/texture_registration.rs
+++ b/plugin/streamlib-plugin-sdk/src/rhi/texture_registration.rs
@@ -1,0 +1,158 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cdylib-arm twin of the engine's [`TextureRegistration`] PluginAbiObject.
+//!
+//! Layout-stable `#[repr(C)] (handle, vtable)` shape mirroring the engine's
+//! `core/context/texture_registration.rs::TextureRegistration`. The host
+//! `TextureRegistrationInner` backing + the `new` / `from_arc_into_raw` /
+//! `host_inner` constructors stay in the engine; this twin carries only the
+//! vtable-dispatched `texture` / `current_layout` / `update_layout` / Clone /
+//! Drop methods a cdylib consumer needs after resolving an incoming
+//! `surface_id` via
+//! [`crate::context::GpuContextLimitedAccess::resolve_texture_registration_by_surface_id`].
+
+use std::ffi::c_void;
+
+use streamlib_plugin_abi::GpuContextLimitedAccessVTable;
+
+#[cfg(target_os = "linux")]
+use streamlib_consumer_rhi::VulkanLayout;
+
+use crate::rhi::Texture;
+
+/// Per-surface registration record resolved from a `surface_id` — the
+/// texture plus its last-known Vulkan image layout.
+///
+/// Layout-stable: `#[repr(C)] (handle, vtable)`. Clone bumps the host's
+/// `Arc<TextureRegistrationInner>` strong count via
+/// [`GpuContextLimitedAccessVTable::clone_texture_registration`]; Drop
+/// decrements via [`GpuContextLimitedAccessVTable::drop_texture_registration`].
+/// Both run in host-compiled code regardless of the calling plugin.
+#[repr(C)]
+pub struct TextureRegistration {
+    /// Opaque handle to the host's `Arc<TextureRegistrationInner>` (produced
+    /// by `Arc::into_raw`).
+    pub(crate) handle: *const c_void,
+    /// Vtable for plugin ABI Clone/Drop and method dispatch.
+    pub(crate) vtable: *const GpuContextLimitedAccessVTable,
+}
+
+// SAFETY: `handle` points at an `Arc<TextureRegistrationInner>` whose interior
+// is Send+Sync. Refcount management crosses the plugin ABI through the vtable,
+// but the underlying Arc bookkeeping runs in host-compiled code regardless.
+unsafe impl Send for TextureRegistration {}
+unsafe impl Sync for TextureRegistration {}
+
+impl TextureRegistration {
+    /// Borrow the underlying texture.
+    ///
+    /// Dispatches through the vtable's
+    /// [`GpuContextLimitedAccessVTable::texture_registration_texture`]
+    /// callback. The returned reference is valid for the lifetime of `self`
+    /// — the host's `Arc` keeps the inner alive.
+    pub fn texture(&self) -> &Texture {
+        if self.handle.is_null() || self.vtable.is_null() {
+            panic!("TextureRegistration::texture() called on a null-handle registration");
+        }
+        // SAFETY: vtable + handle were paired at construction; the callback
+        // returns a `*const Texture` (typed `*const c_void` at the plugin
+        // ABI) into the Arc's heap allocation, alive as long as `self`.
+        // [`Texture`] is a layout-stable `#[repr(C)]` value (locked by the
+        // `texture_layout` regression test) so cdylib and host see the same
+        // byte shape.
+        unsafe {
+            let ptr = ((*self.vtable).texture_registration_texture)(self.handle);
+            &*(ptr as *const Texture)
+        }
+    }
+
+    /// Last-known `VkImageLayout` the texture is in.
+    ///
+    /// Dispatches through the vtable's
+    /// [`GpuContextLimitedAccessVTable::texture_registration_current_layout`]
+    /// callback.
+    #[cfg(target_os = "linux")]
+    pub fn current_layout(&self) -> VulkanLayout {
+        if self.handle.is_null() || self.vtable.is_null() {
+            return VulkanLayout::UNDEFINED;
+        }
+        // SAFETY: vtable + handle were paired at construction.
+        let raw = unsafe { ((*self.vtable).texture_registration_current_layout)(self.handle) };
+        VulkanLayout(raw)
+    }
+
+    /// Record a new last-known layout after a transition.
+    ///
+    /// Dispatches through the vtable's
+    /// [`GpuContextLimitedAccessVTable::texture_registration_update_layout`]
+    /// callback.
+    #[cfg(target_os = "linux")]
+    pub fn update_layout(&self, new_layout: VulkanLayout) {
+        if self.handle.is_null() || self.vtable.is_null() {
+            return;
+        }
+        // SAFETY: vtable + handle were paired at construction.
+        unsafe {
+            ((*self.vtable).texture_registration_update_layout)(self.handle, new_layout.0);
+        }
+    }
+}
+
+impl Clone for TextureRegistration {
+    fn clone(&self) -> Self {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            // SAFETY: vtable + handle paired at construction; the vtable's
+            // `clone_texture_registration` contract is
+            // `Arc::increment_strong_count` host-side. Balanced by Drop.
+            unsafe {
+                ((*self.vtable).clone_texture_registration)(self.handle);
+            }
+        }
+        Self {
+            handle: self.handle,
+            vtable: self.vtable,
+        }
+    }
+}
+
+impl Drop for TextureRegistration {
+    fn drop(&mut self) {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            // SAFETY: matched with the host's `Arc::into_raw` and any
+            // `clone_texture_registration` bumps.
+            unsafe {
+                ((*self.vtable).drop_texture_registration)(self.handle);
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for TextureRegistration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TextureRegistration").finish()
+    }
+}
+
+#[cfg(all(test, target_pointer_width = "64"))]
+mod layout_tests {
+    use super::*;
+    use core::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    fn texture_registration_layout() {
+        // Must match the engine's
+        // `core/context/texture_registration.rs::TextureRegistration`:
+        //   handle @ 0, vtable @ 8. Total 16 bytes, align 8.
+        assert_eq!(size_of::<TextureRegistration>(), 16);
+        assert_eq!(align_of::<TextureRegistration>(), 8);
+        assert_eq!(offset_of!(TextureRegistration, handle), 0);
+        assert_eq!(offset_of!(TextureRegistration, vtable), 8);
+    }
+
+    #[test]
+    fn texture_registration_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<TextureRegistration>();
+    }
+}

--- a/plugin/streamlib-plugin-sdk/src/rhi/vulkan_graphics_kernel.rs
+++ b/plugin/streamlib-plugin-sdk/src/rhi/vulkan_graphics_kernel.rs
@@ -1,0 +1,517 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cdylib-arm twin of the engine's [`VulkanGraphicsKernel`] PluginAbiObject.
+//!
+//! Layout-stable `#[repr(C)] { handle, vtable, methods_vtable, cached
+//! POD }` so cdylibs can hold, refcount, drop, and read POD descriptors
+//! without sharing rustc-version or dep-graph with the host. The opaque
+//! handle points at the host's `Arc<VulkanGraphicsKernelInner>`; lifecycle
+//! (Clone / Drop) dispatches through the parent
+//! [`GpuContextFullAccessVTable`]'s `clone_graphics_kernel` /
+//! `drop_graphics_kernel` callbacks, and per-method dispatch is reached
+//! through the per-type
+//! [`streamlib_plugin_abi::VulkanGraphicsKernelMethodsVTable`].
+//!
+//! Engine-free coverage is the fullscreen-fragment-effect path: sampled-
+//! texture / storage-image / storage-buffer binding setters, push
+//! constants, and the owned-command-buffer `offscreen_render`. The
+//! vertex/index/uniform-buffer setters and the raw-`vk::CommandBuffer`
+//! `cmd_bind_and_draw*` slots stay engine-side — they name buffer twins
+//! the engine-free SDK doesn't carry, or `vulkanalia` types that can't
+//! cross the boundary.
+
+use std::ffi::c_void;
+
+use streamlib_error::{Error, Result};
+use streamlib_plugin_abi::{GpuContextFullAccessVTable, VulkanGraphicsKernelMethodsVTable};
+
+use crate::rhi::{OffscreenColorTarget, OffscreenDraw, PixelBuffer, StorageBuffer, Texture};
+
+/// Graphics kernel — layout-stable `#[repr(C)]` PluginAbiObject.
+///
+/// The `push_constant_size()` / `descriptor_sets_in_flight()` POD getters
+/// read cached fields with no plugin ABI hop. Binding setters,
+/// push-constants, and `offscreen_render` route through the per-type
+/// `methods_vtable`.
+#[repr(C)]
+pub struct VulkanGraphicsKernel {
+    /// Opaque handle to the host's `Arc<VulkanGraphicsKernelInner>`.
+    pub(crate) handle: *const c_void,
+    /// Parent vtable for plugin ABI Clone/Drop dispatch.
+    pub(crate) vtable: *const GpuContextFullAccessVTable,
+    /// Per-type vtable for plugin ABI method dispatch.
+    pub(crate) methods_vtable: *const VulkanGraphicsKernelMethodsVTable,
+    /// Cached push-constant size in bytes. Set at construction; fixed for
+    /// the kernel's lifetime.
+    pub(crate) cached_push_constant_size: u32,
+    /// Cached descriptor-set ring depth. Set at construction; fixed for
+    /// the kernel's lifetime.
+    pub(crate) cached_descriptor_sets_in_flight: u32,
+}
+
+// SAFETY: handle points at an `Arc<VulkanGraphicsKernelInner>` whose
+// interior is Send+Sync (the dispatch fence serializes GPU work; the
+// per-frame descriptor-set ring serializes setter writes). Refcount +
+// method dispatch run in host-compiled code through the vtables.
+unsafe impl Send for VulkanGraphicsKernel {}
+unsafe impl Sync for VulkanGraphicsKernel {}
+
+impl VulkanGraphicsKernel {
+    /// Bind a raw-bytes [`StorageBuffer`] at `(frame_index, binding)`.
+    /// Dispatches through the per-type methods vtable's
+    /// `set_storage_buffer_storage` slot.
+    pub fn set_storage_buffer_storage(
+        &self,
+        frame_index: u32,
+        binding: u32,
+        buffer: &StorageBuffer,
+    ) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "set_storage_buffer_storage: graphics kernel methods vtable is null".into(),
+            ));
+        }
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        // SAFETY: methods_vtable non-null per the guard above; handle was
+        // paired with it at mint time. The buffer handle is the borrowed
+        // `Arc::into_raw(Arc<HostVulkanBuffer>)` pointer the host
+        // reconstructs.
+        let status = unsafe {
+            ((*self.methods_vtable).set_storage_buffer_storage)(
+                self.handle,
+                frame_index,
+                binding,
+                buffer.handle,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        status_to_result(status, &err_buf, err_len)
+    }
+
+    /// Bind a [`PixelBuffer`]-shaped storage buffer (SSBO) at
+    /// `(frame_index, binding)`. Dispatches through the per-type methods
+    /// vtable's `set_storage_buffer_pixel` slot.
+    pub fn set_storage_buffer_pixel(
+        &self,
+        frame_index: u32,
+        binding: u32,
+        buffer: &PixelBuffer,
+    ) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "set_storage_buffer_pixel: graphics kernel methods vtable is null".into(),
+            ));
+        }
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        // SAFETY: see set_storage_buffer_storage.
+        let status = unsafe {
+            ((*self.methods_vtable).set_storage_buffer_pixel)(
+                self.handle,
+                frame_index,
+                binding,
+                buffer.handle,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        status_to_result(status, &err_buf, err_len)
+    }
+
+    /// Bind a sampled texture at `(frame_index, binding)`, using the
+    /// kernel's default linear-clamp sampler. Dispatches through the
+    /// per-type methods vtable's `set_sampled_texture` slot.
+    pub fn set_sampled_texture(
+        &self,
+        frame_index: u32,
+        binding: u32,
+        texture: &Texture,
+    ) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "set_sampled_texture: graphics kernel methods vtable is null".into(),
+            ));
+        }
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        // SAFETY: see set_storage_buffer_storage.
+        let status = unsafe {
+            ((*self.methods_vtable).set_sampled_texture)(
+                self.handle,
+                frame_index,
+                binding,
+                texture.handle,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        status_to_result(status, &err_buf, err_len)
+    }
+
+    /// Bind a storage image at `(frame_index, binding)`. Caller guarantees
+    /// the texture's `STORAGE_BINDING` usage was declared at creation.
+    /// Dispatches through the per-type methods vtable's `set_storage_image`
+    /// slot.
+    pub fn set_storage_image(
+        &self,
+        frame_index: u32,
+        binding: u32,
+        texture: &Texture,
+    ) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "set_storage_image: graphics kernel methods vtable is null".into(),
+            ));
+        }
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        // SAFETY: see set_storage_buffer_storage.
+        let status = unsafe {
+            ((*self.methods_vtable).set_storage_image)(
+                self.handle,
+                frame_index,
+                binding,
+                texture.handle,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        status_to_result(status, &err_buf, err_len)
+    }
+
+    /// Stage push-constant bytes for `frame_index`. Dispatches through the
+    /// per-type methods vtable's `set_push_constants` slot.
+    pub fn set_push_constants(&self, frame_index: u32, bytes: &[u8]) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "set_push_constants: graphics kernel methods vtable is null".into(),
+            ));
+        }
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        // SAFETY: see set_storage_buffer_storage; `bytes` is read-only and
+        // consumed inside the call.
+        let status = unsafe {
+            ((*self.methods_vtable).set_push_constants)(
+                self.handle,
+                frame_index,
+                bytes.as_ptr(),
+                bytes.len(),
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        status_to_result(status, &err_buf, err_len)
+    }
+
+    /// Convenience: re-interprets `&T` as a byte slice and forwards to
+    /// [`Self::set_push_constants`].
+    pub fn set_push_constants_value<T: Copy>(&self, frame_index: u32, value: &T) -> Result<()> {
+        // SAFETY: T is Copy + Sized so its layout is stable; the byte view
+        // is read-only and consumed inside the plugin ABI call.
+        let bytes = unsafe {
+            std::slice::from_raw_parts(value as *const T as *const u8, std::mem::size_of::<T>())
+        };
+        self.set_push_constants(frame_index, bytes)
+    }
+
+    /// Render into one or more offscreen color attachments using the
+    /// kernel's owned command buffer + fence. Dispatches through the
+    /// per-type methods vtable's `offscreen_render` slot.
+    ///
+    /// `color_targets` marshal into the plugin ABI's parallel-array shape
+    /// (texture handles / clear-present flags / clear values). `extent` is
+    /// the `(width, height)` render area. `draw` is the [`OffscreenDraw`]
+    /// tagged union.
+    pub fn offscreen_render(
+        &self,
+        frame_index: u32,
+        color_targets: &[OffscreenColorTarget<'_>],
+        extent: (u32, u32),
+        draw: OffscreenDraw,
+    ) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "offscreen_render: graphics kernel methods vtable is null".into(),
+            ));
+        }
+        // Marshal color targets into the plugin ABI's parallel-array shape.
+        let mut handles: Vec<*const c_void> = Vec::with_capacity(color_targets.len());
+        let mut present_flags: Vec<u32> = Vec::with_capacity(color_targets.len());
+        let mut clear_values: Vec<[f32; 4]> = Vec::with_capacity(color_targets.len());
+        for target in color_targets {
+            handles.push(target.texture.handle);
+            if let Some(c) = target.clear_color {
+                present_flags.push(1);
+                clear_values.push(c);
+            } else {
+                present_flags.push(0);
+                clear_values.push([0.0, 0.0, 0.0, 0.0]);
+            }
+        }
+
+        let draw_repr = encode_offscreen_draw_repr(&draw);
+
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        // SAFETY: methods_vtable non-null per the guard above; handle was
+        // paired with it at mint time. The parallel arrays each have
+        // length `handles.len()` and outlive the call; `draw_repr` lives
+        // on this stack frame across the call.
+        let status = unsafe {
+            ((*self.methods_vtable).offscreen_render)(
+                self.handle,
+                frame_index,
+                if handles.is_empty() {
+                    std::ptr::null()
+                } else {
+                    handles.as_ptr()
+                },
+                if present_flags.is_empty() {
+                    std::ptr::null()
+                } else {
+                    present_flags.as_ptr()
+                },
+                if clear_values.is_empty() {
+                    std::ptr::null()
+                } else {
+                    clear_values.as_ptr()
+                },
+                handles.len(),
+                extent.0,
+                extent.1,
+                &draw_repr,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        status_to_result(status, &err_buf, err_len)
+    }
+
+    /// Push-constant range size in bytes. Cached POD — no plugin ABI hop.
+    pub fn push_constant_size(&self) -> u32 {
+        self.cached_push_constant_size
+    }
+
+    /// Descriptor-set ring depth. Cached POD — no plugin ABI hop. Render-
+    /// loop callers pass `frame_index ∈ [0, descriptor_sets_in_flight())`
+    /// to the binding setters + `offscreen_render`.
+    pub fn descriptor_sets_in_flight(&self) -> u32 {
+        self.cached_descriptor_sets_in_flight
+    }
+}
+
+/// Decode a `(status, err_buf)` plugin-ABI return into `Result<()>`.
+fn status_to_result(status: i32, err_buf: &[u8], err_len: usize) -> Result<()> {
+    if status == 0 {
+        Ok(())
+    } else {
+        let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())]).into_owned();
+        Err(Error::GpuError(msg))
+    }
+}
+
+fn viewport_to_repr(v: super::Viewport) -> streamlib_plugin_abi::ViewportRepr {
+    streamlib_plugin_abi::ViewportRepr {
+        x: v.x,
+        y: v.y,
+        width: v.width,
+        height: v.height,
+        min_depth: v.min_depth,
+        max_depth: v.max_depth,
+    }
+}
+
+fn scissor_to_repr(s: super::ScissorRect) -> streamlib_plugin_abi::ScissorRectRepr {
+    streamlib_plugin_abi::ScissorRectRepr {
+        x: s.x,
+        y: s.y,
+        width: s.width,
+        height: s.height,
+    }
+}
+
+fn zero_viewport_repr() -> streamlib_plugin_abi::ViewportRepr {
+    streamlib_plugin_abi::ViewportRepr {
+        x: 0.0,
+        y: 0.0,
+        width: 0.0,
+        height: 0.0,
+        min_depth: 0.0,
+        max_depth: 0.0,
+    }
+}
+
+fn zero_scissor_repr() -> streamlib_plugin_abi::ScissorRectRepr {
+    streamlib_plugin_abi::ScissorRectRepr {
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+    }
+}
+
+fn draw_call_to_repr(d: &super::DrawCall) -> streamlib_plugin_abi::DrawCallRepr {
+    let (viewport_present, viewport) = match d.viewport {
+        Some(v) => (1u32, viewport_to_repr(v)),
+        None => (0u32, zero_viewport_repr()),
+    };
+    let (scissor_present, scissor) = match d.scissor {
+        Some(s) => (1u32, scissor_to_repr(s)),
+        None => (0u32, zero_scissor_repr()),
+    };
+    streamlib_plugin_abi::DrawCallRepr {
+        vertex_count: d.vertex_count,
+        instance_count: d.instance_count,
+        first_vertex: d.first_vertex,
+        first_instance: d.first_instance,
+        viewport_present,
+        scissor_present,
+        viewport,
+        scissor,
+    }
+}
+
+fn draw_indexed_call_to_repr(d: &super::DrawIndexedCall) -> streamlib_plugin_abi::DrawIndexedCallRepr {
+    let (viewport_present, viewport) = match d.viewport {
+        Some(v) => (1u32, viewport_to_repr(v)),
+        None => (0u32, zero_viewport_repr()),
+    };
+    let (scissor_present, scissor) = match d.scissor {
+        Some(s) => (1u32, scissor_to_repr(s)),
+        None => (0u32, zero_scissor_repr()),
+    };
+    streamlib_plugin_abi::DrawIndexedCallRepr {
+        index_count: d.index_count,
+        instance_count: d.instance_count,
+        first_index: d.first_index,
+        vertex_offset: d.vertex_offset,
+        first_instance: d.first_instance,
+        viewport_present,
+        scissor_present,
+        _reserved_padding: 0,
+        viewport,
+        scissor,
+    }
+}
+
+fn encode_offscreen_draw_repr(draw: &OffscreenDraw) -> streamlib_plugin_abi::OffscreenDrawRepr {
+    let zero_draw = streamlib_plugin_abi::DrawCallRepr {
+        vertex_count: 0,
+        instance_count: 0,
+        first_vertex: 0,
+        first_instance: 0,
+        viewport_present: 0,
+        scissor_present: 0,
+        viewport: zero_viewport_repr(),
+        scissor: zero_scissor_repr(),
+    };
+    let zero_draw_indexed = streamlib_plugin_abi::DrawIndexedCallRepr {
+        index_count: 0,
+        instance_count: 0,
+        first_index: 0,
+        vertex_offset: 0,
+        first_instance: 0,
+        viewport_present: 0,
+        scissor_present: 0,
+        _reserved_padding: 0,
+        viewport: zero_viewport_repr(),
+        scissor: zero_scissor_repr(),
+    };
+    match draw {
+        OffscreenDraw::Draw(d) => streamlib_plugin_abi::OffscreenDrawRepr {
+            kind: streamlib_plugin_abi::OffscreenDrawKindRepr::Draw as u32,
+            _reserved_padding: 0,
+            draw_call: draw_call_to_repr(d),
+            draw_indexed_call: zero_draw_indexed,
+        },
+        OffscreenDraw::DrawIndexed(d) => streamlib_plugin_abi::OffscreenDrawRepr {
+            kind: streamlib_plugin_abi::OffscreenDrawKindRepr::DrawIndexed as u32,
+            _reserved_padding: 0,
+            draw_call: zero_draw,
+            draw_indexed_call: draw_indexed_call_to_repr(d),
+        },
+    }
+}
+
+impl Clone for VulkanGraphicsKernel {
+    fn clone(&self) -> Self {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            // SAFETY: vtable + handle paired at mint time; the vtable's
+            // `clone_graphics_kernel` contract is
+            // `Arc::increment_strong_count` host-side.
+            unsafe {
+                ((*self.vtable).clone_graphics_kernel)(self.handle);
+            }
+        }
+        Self {
+            handle: self.handle,
+            vtable: self.vtable,
+            methods_vtable: self.methods_vtable,
+            cached_push_constant_size: self.cached_push_constant_size,
+            cached_descriptor_sets_in_flight: self.cached_descriptor_sets_in_flight,
+        }
+    }
+}
+
+impl Drop for VulkanGraphicsKernel {
+    fn drop(&mut self) {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            // SAFETY: matched with the host's `Arc::into_raw` and any
+            // `clone_graphics_kernel` bumps.
+            unsafe {
+                ((*self.vtable).drop_graphics_kernel)(self.handle);
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for VulkanGraphicsKernel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VulkanGraphicsKernel").finish()
+    }
+}
+
+#[cfg(all(test, target_pointer_width = "64"))]
+mod layout_tests {
+    use super::*;
+    use core::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    fn vulkan_graphics_kernel_layout() {
+        // Must match the engine's
+        // `vulkan/rhi/vulkan_graphics_kernel.rs::VulkanGraphicsKernel`:
+        //   handle @ 0, vtable @ 8, methods_vtable @ 16,
+        //   cached_push_constant_size @ 24,
+        //   cached_descriptor_sets_in_flight @ 28.
+        // Total 32 bytes, align 8.
+        assert_eq!(size_of::<VulkanGraphicsKernel>(), 32);
+        assert_eq!(align_of::<VulkanGraphicsKernel>(), 8);
+        assert_eq!(offset_of!(VulkanGraphicsKernel, handle), 0);
+        assert_eq!(offset_of!(VulkanGraphicsKernel, vtable), 8);
+        assert_eq!(offset_of!(VulkanGraphicsKernel, methods_vtable), 16);
+        assert_eq!(
+            offset_of!(VulkanGraphicsKernel, cached_push_constant_size),
+            24
+        );
+        assert_eq!(
+            offset_of!(VulkanGraphicsKernel, cached_descriptor_sets_in_flight),
+            28
+        );
+    }
+
+    #[test]
+    fn vulkan_graphics_kernel_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<VulkanGraphicsKernel>();
+    }
+}


### PR DESCRIPTION
## Summary

Brings the engine-free `streamlib-plugin-sdk` GPU context twins to parity for **surface consumption**: a cdylib that links **only** the SDK (never the `streamlib` engine facade) can now resolve an incoming `VideoFrame`'s `surface_id` to a GPU `Texture` and run compute/graphics kernels on it — the exact build configuration `tatolab/drone-racer` ships its on-GPU ONNX preprocessing under.

**Twin-only exposure.** Every plugin-ABI vtable slot already existed and was host-wired (Python/Deno already consume them as `resolve_surface`); this mirrors the engine's own cdylib-arm dispatch and adds `#[repr(C)]` handle twins that byte-mirror existing engine structs. **No engine / host / ABI changes** — `cargo xtask check-boundaries` is clean and the diff touches only `plugin/streamlib-plugin-sdk/` + `examples/camera-plugin-sdk-compute/`.

## Closes

Closes #1224

## What's exposed (on `GpuContextLimitedAccess` / `GpuContextFullAccess`)

- **P0 — unblocks tatolab/drone-racer#59:** `resolve_texture_registration_by_surface_id`, `resolve_texture_by_surface_id` + the `TextureRegistration` twin (16 B).
- **P1 — surface-consumer / buffer story:** `check_out_surface`, `resolve_pixel_buffer_by_surface_id`, `acquire_pixel_buffer`, `get_pixel_buffer`, `register_texture(_with_layout)`, `unregister_texture`, `acquire_texture` + the `PixelBuffer` (32 B) and `PooledTextureHandle` (64 B, `!Clone`) twins + `PixelBufferPoolId` / `TexturePoolDescriptor`.
- **Graphics-effect parity:** `create_graphics_kernel` + the `VulkanGraphicsKernel` twin (32 B) + the full engine-free graphics descriptor family (38 types) + `stage_graphics_kernel_descriptor`. Intentionally omits the vertex/index/uniform-buffer setters and `cmd_bind_and_draw*` (need buffer twins the SDK lacks / a raw `vk::CommandBuffer` the engine-free zone can't name) — cleanly absent, not stubbed.

Every new twin is layout-locked against the engine struct it mirrors and the descriptor staging is field-mapping-tested (non-vacuous).

**New engine-free example** `examples/camera-plugin-sdk-compute` — the first example whose plugin links only `streamlib-plugin-sdk`. It resolves the camera surface, runs a BT.601-luma grayscale **SPIR-V compute** kernel built via `create_compute_kernel` / `create_texture_ring` (no raw device → slpkg-safe), and emits the transformed frame.

## Exit criteria

- [x] Engine-free twin exposes the P0 surface→texture methods (+ `TextureRegistration` twin) and the P1 surface-consumer / buffer story; each dispatches through its existing ABI vtable slot, no engine/host changes.
- [x] New engine-free example resolves an incoming `VideoFrame` surface → runs a SPIR-V compute kernel → emits a transformed frame.
- [x] `#[repr(C)]` layout-lock tests for the `TextureRegistration` / `PixelBuffer` / `PooledTextureHandle` / `VulkanGraphicsKernel` twins.
- [ ] Published as the minor bump **`0.5.0`** — pending maintainer sign-off (see **Version**).

## Test plan

- `cargo test -p streamlib-plugin-sdk --lib` → **33 passed** (layout-lock + staging field-mapping; verified non-vacuous by reverting field maps).
- `cargo clippy -p streamlib-plugin-sdk --tests` → clean.
- `cargo xtask check-boundaries` → **5624 files scanned, no violations** (engine-free zone intact; example plugin pulls 0 facade/engine deps).
- Live E2E — report below.

### E2E Test Report

- **Scenario**: camera+display with an engine-free compute effect in between
- **Example**: `camera-plugin-sdk-compute` (links only `streamlib-plugin-sdk`)
- **Codec**: n/a
- **Camera device**: `/dev/video0` (vivid)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=60`
- **Build profile**: debug
- **Command**:
    ```
    STREAMLIB_CAMERA_DEVICE=/dev/video0 STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=… \
    STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=20 STREAMLIB_DISPLAY_FRAME_LIMIT=60 \
    cargo run -p camera-plugin-sdk-compute
    ```

#### Log signals
- `OUT_OF_DEVICE_MEMORY`: 0 · `DEVICE_LOST`: 0 · `process() failed`: 0 · `dumped core`/`SIGABRT`/`SIGSEGV`: 0 · `panic`: 0
- `[GrayscaleCompute] setup` → `create_compute_kernel` + `create_texture_ring` succeeded through the engine-free FullAccess vtable
- `[GrayscaleCompute] shutdown (82 frames)` — 82 frames processed end-to-end

#### PNG samples
- 3 samples (every 20 frames). Read with the Read tool.
- **What was in the image**: vivid colorbar test pattern rendered as a light→dark BT.601-luma gray gradient (white→yellow→cyan→green→magenta→red→blue→black mapped to descending grays), vivid overlay text ("00:00:34:202", "brightness 128, contrast 128…") crisp. No color, no garbage, no black frame — correct grayscale.
- Anomalies: none

#### PSNR
- Reference frame: n/a — parity vs `camera-rust-plugin` (which grayscales the same vivid source via a graphics kernel); both produce BT.601 luma, visually matching.

#### Outcome
- **Pass**

## Version

Repo workspace version is `0.4.36`; the original issue's "`0.47.0`" was a slip (no `0.46.0`/`0.47.0` exists in the line). This ships as a **minor bump to `0.5.0`** — the new public SDK surface warrants a minor — cut via a `Release-As: 0.5.0` override (release-please defaults to a *patch* for a `feat` pre-1.0). **The publish is gated on maintainer sign-off.** The example pins the validated `0.4.36-dev.1` dev version (same pattern as the other registry-only examples) and bumps to `0.5.0` at the release cut.

## Follow-ups

- **Engine-free package migration (separate milestone).** Only `jpeg`/`mavlink`/`network`/`vadr-vision` are engine-free today; ~14 packages still link the facade. `display` **cannot** be engine-free (it owns the host-only Vulkan swapchain). The live E2E required republishing camera/display source-only so they rebuild against the current engine; `camera-rust-plugin` (pinned to an older host) needs re-pinning under that migration.
- Wire the live E2E pixel-assert into CI once GPU runners land (no GPU CI today; CI runs the layout/staging unit tests).
- The Vulkan→CUDA→`ort` zero-copy tensor handoff for drone-racer's ONNX EP remains out of scope (flagged in the issue) — this PR gets frames onto a GPU `Texture` + enables on-GPU compute preprocessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Evidence

Live E2E frame 40 — camera(vivid) → **engine-free** GrayscaleCompute (links only `streamlib-plugin-sdk`) → display. The vivid colorbars render as a BT.601-luma gray gradient with crisp overlay text; correct grayscale, no color/garbage/black.

![engine-free grayscale compute E2E frame 40](https://gh-artifact.tatolab.com/pr-1225/grayscale_frame40.webp)
