### PR TITLE
feat(mavlink): surface all sim-emitted MAVLink messages (velocity, odometry, actuator, collision, command_ack)

### DIFF
--- a/packages/mavlink/schemas/mavlink_message.yaml
+++ b/packages/mavlink/schemas/mavlink_message.yaml
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # JSON Type Definition (RFC 8927) schema for a decoded MAVLink2 message,
-# represented as a tagged union over the six core navigation / telemetry /
-# control messages. The discriminator (`kind`) preserves the message-type
-# distinction across the iceoryx2 mailbox; consumers `match` on the
-# variant to dispatch typed payload handling.
+# represented as a tagged union over the common-dialect navigation /
+# telemetry / control messages the sim exchanges with the pilot. The
+# discriminator (`kind`) preserves the message-type distinction across the
+# iceoryx2 mailbox; consumers `match` on the variant to dispatch typed
+# payload handling.
 #
 # Each variant carries:
 #   - MAVLink header fields (system_id, component_id, sequence)
@@ -25,7 +26,7 @@
 
 metadata:
   type: MavlinkMessage
-  description: "Decoded MAVLink2 message as a tagged union over the core six common-dialect messages"
+  description: "Decoded MAVLink2 message as a tagged union over the supported common-dialect messages"
   read_mode: read_next_in_order
   max_queued_messages: 64
   # MAVLink2 max wire frame is 280 bytes (1 STX + 10 header + 255 payload
@@ -432,3 +433,220 @@ mapping:
           description: "Raw chunk payload (up to 253 bytes). Application-defined; the AGP sim packs its race-status / track structs here for the consumer to parse."
         elements:
           type: uint8
+
+  local_position_ned:
+    properties:
+      system_id:
+        metadata: { description: "MAVLink system ID of the sender." }
+        type: uint8
+      component_id:
+        metadata: { description: "MAVLink component ID of the sender." }
+        type: uint8
+      sequence:
+        metadata: { description: "MAVLink sequence counter." }
+        type: uint8
+      peer_addr:
+        metadata: { description: "Networking peer address (host:port). See heartbeat.peer_addr." }
+        type: string
+      timestamp_ns:
+        metadata: { description: "Monotonic timestamp from source NetworkPacket recv (int64 as string)." }
+        type: string
+      time_boot_ms:
+        metadata: { description: "Timestamp since system boot, milliseconds." }
+        type: uint32
+      x:
+        metadata: { description: "X position in local NED frame, m." }
+        type: float32
+      y:
+        metadata: { description: "Y position in local NED frame, m." }
+        type: float32
+      z:
+        metadata: { description: "Z position in local NED frame, m (positive down)." }
+        type: float32
+      vx:
+        metadata: { description: "X velocity in local NED (world) frame, m/s." }
+        type: float32
+      vy:
+        metadata: { description: "Y velocity in local NED (world) frame, m/s." }
+        type: float32
+      vz:
+        metadata: { description: "Z velocity in local NED (world) frame, m/s." }
+        type: float32
+
+  odometry:
+    properties:
+      system_id:
+        metadata: { description: "MAVLink system ID of the sender." }
+        type: uint8
+      component_id:
+        metadata: { description: "MAVLink component ID of the sender." }
+        type: uint8
+      sequence:
+        metadata: { description: "MAVLink sequence counter." }
+        type: uint8
+      peer_addr:
+        metadata: { description: "Networking peer address (host:port). See heartbeat.peer_addr." }
+        type: string
+      timestamp_ns:
+        metadata: { description: "Monotonic timestamp from source NetworkPacket recv (int64 as string)." }
+        type: string
+      time_usec:
+        metadata: { description: "Timestamp (UNIX Epoch or time since system boot), microseconds (uint64 as string)." }
+        type: string
+      x:
+        metadata: { description: "X position, m. Frame given by frame_id." }
+        type: float32
+      y:
+        metadata: { description: "Y position, m. Frame given by frame_id." }
+        type: float32
+      z:
+        metadata: { description: "Z position, m. Frame given by frame_id." }
+        type: float32
+      q:
+        metadata: { description: "Orientation quaternion [w, x, y, z] (1 0 0 0 is the null-rotation). Four elements." }
+        elements:
+          type: float32
+      vx:
+        metadata: { description: "X linear velocity, m/s. Frame given by child_frame_id (BODY_NED on the AGP sim)." }
+        type: float32
+      vy:
+        metadata: { description: "Y linear velocity, m/s. Frame given by child_frame_id." }
+        type: float32
+      vz:
+        metadata: { description: "Z linear velocity, m/s. Frame given by child_frame_id." }
+        type: float32
+      rollspeed:
+        metadata: { description: "Roll angular speed, rad/s (body frame)." }
+        type: float32
+      pitchspeed:
+        metadata: { description: "Pitch angular speed, rad/s (body frame)." }
+        type: float32
+      yawspeed:
+        metadata: { description: "Yaw angular speed, rad/s (body frame)." }
+        type: float32
+      pose_covariance:
+        metadata: { description: "Upper-right triangle of the 6x6 pose cross-covariance (x,y,z,roll,pitch,yaw), row-major; 21 elements. NaN in the first element if unknown." }
+        elements:
+          type: float32
+      velocity_covariance:
+        metadata: { description: "Upper-right triangle of the 6x6 velocity cross-covariance (vx,vy,vz,rollspeed,pitchspeed,yawspeed), row-major; 21 elements. NaN in the first element if unknown." }
+        elements:
+          type: float32
+      frame_id:
+        metadata: { description: "Coordinate frame of the pose data — MAV_FRAME enum (raw uint8). 1=LOCAL_NED." }
+        type: uint8
+      child_frame_id:
+        metadata: { description: "Coordinate frame of the velocity (twist) data — MAV_FRAME enum (raw uint8). 8=BODY_NED." }
+        type: uint8
+      reset_counter:
+        metadata: { description: "Estimate reset counter; incremented on any estimate reset/jump (SLAM loop-closure, sim teleport). Use to reject transient frames after a reset." }
+        type: uint8
+      estimator_type:
+        metadata: { description: "Estimator providing the odometry — MAV_ESTIMATOR_TYPE enum (raw uint8). 2=VISION." }
+        type: uint8
+      quality:
+        metadata: { description: "Optional odometry quality, percent. -1=failed, 0=unknown/unset, 1=worst, 100=best." }
+        type: int8
+
+  actuator_output_status:
+    properties:
+      system_id:
+        metadata: { description: "MAVLink system ID of the sender." }
+        type: uint8
+      component_id:
+        metadata: { description: "MAVLink component ID of the sender." }
+        type: uint8
+      sequence:
+        metadata: { description: "MAVLink sequence counter." }
+        type: uint8
+      peer_addr:
+        metadata: { description: "Networking peer address (host:port). See heartbeat.peer_addr." }
+        type: string
+      timestamp_ns:
+        metadata: { description: "Monotonic timestamp from source NetworkPacket recv (int64 as string)." }
+        type: string
+      time_usec:
+        metadata: { description: "Timestamp since system boot, microseconds (uint64 as string)." }
+        type: string
+      active:
+        metadata: { description: "Bitmap of active output channels (1 bit per actuator)." }
+        type: uint32
+      actuator:
+        metadata: { description: "Servo / motor output array values; 32 elements. Zero indicates an unused channel." }
+        elements:
+          type: float32
+
+  collision:
+    properties:
+      system_id:
+        metadata: { description: "MAVLink system ID of the sender." }
+        type: uint8
+      component_id:
+        metadata: { description: "MAVLink component ID of the sender." }
+        type: uint8
+      sequence:
+        metadata: { description: "MAVLink sequence counter." }
+        type: uint8
+      peer_addr:
+        metadata: { description: "Networking peer address (host:port). See heartbeat.peer_addr." }
+        type: string
+      timestamp_ns:
+        metadata: { description: "Monotonic timestamp from source NetworkPacket recv (int64 as string)." }
+        type: string
+      id:
+        metadata: { description: "Unique collision identifier; domain depends on src. On the AGP sim 1001=gate, 1002=environment." }
+        type: uint32
+      time_to_minimum_delta:
+        metadata: { description: "Estimated time until collision occurs, s." }
+        type: float32
+      altitude_minimum_delta:
+        metadata: { description: "Closest vertical distance to the object, m." }
+        type: float32
+      horizontal_minimum_delta:
+        metadata: { description: "Closest horizontal distance to the object, m (on the AGP sim this carries the impact impulse magnitude, kg*m/s)." }
+        type: float32
+      src:
+        metadata: { description: "Collision data source — MAV_COLLISION_SRC enum (raw uint8)." }
+        type: uint8
+      action:
+        metadata: { description: "Action taken to avoid the collision — MAV_COLLISION_ACTION enum (raw uint8)." }
+        type: uint8
+      threat_level:
+        metadata: { description: "Threat level — MAV_COLLISION_THREAT_LEVEL enum (raw uint8). 1..2, higher is a harder impact." }
+        type: uint8
+
+  command_ack:
+    properties:
+      system_id:
+        metadata: { description: "MAVLink system ID of the sender." }
+        type: uint8
+      component_id:
+        metadata: { description: "MAVLink component ID of the sender." }
+        type: uint8
+      sequence:
+        metadata: { description: "MAVLink sequence counter." }
+        type: uint8
+      peer_addr:
+        metadata: { description: "Networking peer address (host:port). See heartbeat.peer_addr." }
+        type: string
+      timestamp_ns:
+        metadata: { description: "Monotonic timestamp from source NetworkPacket recv (int64 as string)." }
+        type: string
+      command:
+        metadata: { description: "MAV_CMD id being acknowledged (uint16). 400=COMPONENT_ARM_DISARM." }
+        type: uint16
+      result:
+        metadata: { description: "Result of the command — MAV_RESULT enum (raw uint8). 0=ACCEPTED, 4=FAILED." }
+        type: uint8
+      progress:
+        metadata: { description: "Progress percent when result is IN_PROGRESS [0-100], or 255 if unknown." }
+        type: uint8
+      result_param2:
+        metadata: { description: "Additional command-specific result information (signed)." }
+        type: int32
+      target_system:
+        metadata: { description: "System ID of the recipient (the system that sent the acknowledged command)." }
+        type: uint8
+      target_component:
+        metadata: { description: "Component ID of the recipient." }
+        type: uint8

--- a/packages/mavlink/src/mavlink_decoder.rs
+++ b/packages/mavlink/src/mavlink_decoder.rs
@@ -17,8 +17,10 @@ use streamlib_plugin_sdk::sdk::error::Result;
 use streamlib_plugin_sdk::sdk::processors::ReactiveProcessor;
 
 use crate::_generated_::tatolab__mavlink::mavlink_message::{
-    MavlinkMessageAttitude, MavlinkMessageCommandLong, MavlinkMessageEncapsulatedData,
-    MavlinkMessageHeartbeat, MavlinkMessageHighresImu, MavlinkMessageSetAttitudeTarget,
+    MavlinkMessageActuatorOutputStatus, MavlinkMessageAttitude, MavlinkMessageCollision,
+    MavlinkMessageCommandAck, MavlinkMessageCommandLong, MavlinkMessageEncapsulatedData,
+    MavlinkMessageHeartbeat, MavlinkMessageHighresImu, MavlinkMessageLocalPositionNed,
+    MavlinkMessageOdometry, MavlinkMessageSetAttitudeTarget,
     MavlinkMessageSetPositionTargetLocalNed, MavlinkMessageTimesync,
 };
 use crate::_generated_::{MavlinkMessage, NetworkPacket};
@@ -84,8 +86,8 @@ impl ReactiveProcessor for MavlinkDecoderProcessor::Processor {
 
 /// Parse one MAVLink2 frame out of a byte slice and convert into the
 /// streamlib `MavlinkMessage` tagged union. Returns `Ok(None)` when the
-/// message is a valid MAVLink2 frame of a type outside our supported six;
-/// returns `Err` for wire-level corruption.
+/// message is a valid MAVLink2 frame of a common-dialect type this decoder
+/// does not surface; returns `Err` for wire-level corruption.
 pub(crate) fn decode_one(
     payload: &[u8],
     peer_addr: &str,
@@ -242,6 +244,84 @@ fn convert(
             seqnr: d.seqnr,
             data: d.data.to_vec(),
         }),
+        LOCAL_POSITION_NED(d) => MavlinkMessage::LocalPositionNed(MavlinkMessageLocalPositionNed {
+            system_id,
+            component_id,
+            sequence,
+            peer_addr,
+            timestamp_ns,
+            time_boot_ms: d.time_boot_ms,
+            x: d.x,
+            y: d.y,
+            z: d.z,
+            vx: d.vx,
+            vy: d.vy,
+            vz: d.vz,
+        }),
+        ODOMETRY(d) => MavlinkMessage::Odometry(MavlinkMessageOdometry {
+            system_id,
+            component_id,
+            sequence,
+            peer_addr,
+            timestamp_ns,
+            time_usec: d.time_usec.to_string(),
+            x: d.x,
+            y: d.y,
+            z: d.z,
+            q: d.q.to_vec(),
+            vx: d.vx,
+            vy: d.vy,
+            vz: d.vz,
+            rollspeed: d.rollspeed,
+            pitchspeed: d.pitchspeed,
+            yawspeed: d.yawspeed,
+            pose_covariance: d.pose_covariance.to_vec(),
+            velocity_covariance: d.velocity_covariance.to_vec(),
+            frame_id: d.frame_id as u8,
+            child_frame_id: d.child_frame_id as u8,
+            reset_counter: d.reset_counter,
+            estimator_type: d.estimator_type as u8,
+            quality: d.quality,
+        }),
+        ACTUATOR_OUTPUT_STATUS(d) => {
+            MavlinkMessage::ActuatorOutputStatus(MavlinkMessageActuatorOutputStatus {
+                system_id,
+                component_id,
+                sequence,
+                peer_addr,
+                timestamp_ns,
+                time_usec: d.time_usec.to_string(),
+                active: d.active,
+                actuator: d.actuator.to_vec(),
+            })
+        }
+        COLLISION(d) => MavlinkMessage::Collision(MavlinkMessageCollision {
+            system_id,
+            component_id,
+            sequence,
+            peer_addr,
+            timestamp_ns,
+            id: d.id,
+            time_to_minimum_delta: d.time_to_minimum_delta,
+            altitude_minimum_delta: d.altitude_minimum_delta,
+            horizontal_minimum_delta: d.horizontal_minimum_delta,
+            src: d.src as u8,
+            action: d.action as u8,
+            threat_level: d.threat_level as u8,
+        }),
+        COMMAND_ACK(d) => MavlinkMessage::CommandAck(MavlinkMessageCommandAck {
+            system_id,
+            component_id,
+            sequence,
+            peer_addr,
+            timestamp_ns,
+            command: d.command as u16,
+            result: d.result as u8,
+            progress: d.progress,
+            result_param2: d.result_param2,
+            target_system: d.target_system,
+            target_component: d.target_component,
+        }),
         _ => return None,
     })
 }
@@ -328,6 +408,189 @@ mod tests {
                 assert_eq!(d.mavlink_version, 3);
             }
             other => panic!("expected HEARTBEAT, got {other:?}"),
+        }
+    }
+
+    use mavlink::MavHeader;
+    use mavlink::dialects::common::{
+        ACTUATOR_OUTPUT_STATUS_DATA, COLLISION_DATA, COMMAND_ACK_DATA, LOCAL_POSITION_NED_DATA,
+        MavCmd, MavCollisionAction, MavCollisionSrc, MavCollisionThreatLevel, MavEstimatorType,
+        MavFrame, MavResult, ODOMETRY_DATA,
+    };
+
+    /// Build a MAVLink2 frame from a typed `MavMessage`, then run it back
+    /// through `decode_one` — the same wire path the sim drives.
+    fn build_and_decode(seq: u8, msg: MavMessage) -> MavlinkMessage {
+        let header = MavHeader {
+            system_id: 1,
+            component_id: 1,
+            sequence: seq,
+        };
+        let mut wire = Vec::new();
+        mavlink::write_v2_msg(&mut wire, header, &msg).expect("write_v2_msg");
+        decode_one(&wire, "10.0.0.5:14550", "1700000000")
+            .expect("frame must decode")
+            .expect("a surfaced variant")
+    }
+
+    #[test]
+    fn decodes_local_position_ned_velocity() {
+        let decoded = build_and_decode(
+            10,
+            MavMessage::LOCAL_POSITION_NED(LOCAL_POSITION_NED_DATA {
+                time_boot_ms: 12345,
+                x: 1.0,
+                y: 2.0,
+                z: -3.0,
+                vx: -20.6,
+                vy: 4.2,
+                vz: 4.7,
+            }),
+        );
+        match decoded {
+            MavlinkMessage::LocalPositionNed(d) => {
+                assert_eq!(d.system_id, 1);
+                assert_eq!(d.peer_addr, "10.0.0.5:14550");
+                assert_eq!(d.time_boot_ms, 12345);
+                assert_eq!(d.x.to_bits(), 1.0f32.to_bits());
+                assert_eq!(
+                    d.vx.to_bits(),
+                    (-20.6f32).to_bits(),
+                    "world-frame X velocity"
+                );
+                assert_eq!(d.vy.to_bits(), 4.2f32.to_bits());
+                assert_eq!(d.vz.to_bits(), 4.7f32.to_bits());
+            }
+            other => panic!("expected LocalPositionNed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    // MAV_FRAME_BODY_NED (8) is deprecated upstream but is exactly what the
+    // AGP sim sends as ODOMETRY.child_frame_id — assert against reality.
+    #[allow(deprecated)]
+    fn decodes_odometry_velocity_orientation_rates_and_reset() {
+        let decoded = build_and_decode(
+            11,
+            MavMessage::ODOMETRY(ODOMETRY_DATA {
+                time_usec: 1_234_567_890_123_456,
+                x: 1.0,
+                y: 2.0,
+                z: -3.0,
+                q: [0.0005, -0.155, 0.00004, -0.988],
+                vx: 7.565,
+                vy: -15.539,
+                vz: -12.839,
+                rollspeed: 0.1,
+                pitchspeed: -0.2,
+                yawspeed: 0.3,
+                pose_covariance: [0.0; 21],
+                velocity_covariance: [0.0; 21],
+                frame_id: MavFrame::MAV_FRAME_LOCAL_NED,
+                child_frame_id: MavFrame::MAV_FRAME_BODY_NED,
+                reset_counter: 6,
+                estimator_type: MavEstimatorType::MAV_ESTIMATOR_TYPE_VISION,
+                quality: 100,
+            }),
+        );
+        match decoded {
+            MavlinkMessage::Odometry(d) => {
+                assert_eq!(d.time_usec, "1234567890123456", "uint64 rides as a string");
+                assert_eq!(d.q.len(), 4);
+                assert_eq!(d.q[0].to_bits(), 0.0005f32.to_bits());
+                assert_eq!(d.vx.to_bits(), 7.565f32.to_bits(), "body-frame X velocity");
+                assert_eq!(d.vy.to_bits(), (-15.539f32).to_bits());
+                assert_eq!(d.vz.to_bits(), (-12.839f32).to_bits());
+                assert_eq!(d.rollspeed.to_bits(), 0.1f32.to_bits());
+                assert_eq!(d.frame_id, MavFrame::MAV_FRAME_LOCAL_NED as u8);
+                assert_eq!(d.child_frame_id, MavFrame::MAV_FRAME_BODY_NED as u8);
+                assert_eq!(d.reset_counter, 6, "reset counter for teleport rejection");
+                assert_eq!(
+                    d.estimator_type,
+                    MavEstimatorType::MAV_ESTIMATOR_TYPE_VISION as u8,
+                );
+                assert_eq!(d.quality, 100);
+                assert_eq!(d.pose_covariance.len(), 21);
+                assert_eq!(d.velocity_covariance.len(), 21);
+            }
+            other => panic!("expected Odometry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decodes_actuator_output_status() {
+        let mut actuator = [0.0f32; 32];
+        actuator[0] = 0.25;
+        actuator[3] = 0.75;
+        let decoded = build_and_decode(
+            12,
+            MavMessage::ACTUATOR_OUTPUT_STATUS(ACTUATOR_OUTPUT_STATUS_DATA {
+                time_usec: 999,
+                active: 0b1111,
+                actuator,
+            }),
+        );
+        match decoded {
+            MavlinkMessage::ActuatorOutputStatus(d) => {
+                assert_eq!(d.time_usec, "999");
+                assert_eq!(d.active, 0b1111);
+                assert_eq!(d.actuator.len(), 32);
+                assert_eq!(d.actuator[0].to_bits(), 0.25f32.to_bits());
+                assert_eq!(d.actuator[3].to_bits(), 0.75f32.to_bits());
+            }
+            other => panic!("expected ActuatorOutputStatus, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decodes_collision() {
+        let decoded = build_and_decode(
+            13,
+            MavMessage::COLLISION(COLLISION_DATA {
+                id: 1001,
+                time_to_minimum_delta: 0.5,
+                altitude_minimum_delta: 1.5,
+                horizontal_minimum_delta: 2.5,
+                src: MavCollisionSrc::MAV_COLLISION_SRC_ADSB,
+                action: MavCollisionAction::MAV_COLLISION_ACTION_NONE,
+                threat_level: MavCollisionThreatLevel::MAV_COLLISION_THREAT_LEVEL_HIGH,
+            }),
+        );
+        match decoded {
+            MavlinkMessage::Collision(d) => {
+                assert_eq!(d.id, 1001, "AGP gate collision id");
+                assert_eq!(d.horizontal_minimum_delta.to_bits(), 2.5f32.to_bits());
+                assert_eq!(
+                    d.threat_level,
+                    MavCollisionThreatLevel::MAV_COLLISION_THREAT_LEVEL_HIGH as u8,
+                );
+            }
+            other => panic!("expected Collision, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decodes_command_ack() {
+        let decoded = build_and_decode(
+            14,
+            MavMessage::COMMAND_ACK(COMMAND_ACK_DATA {
+                command: MavCmd::MAV_CMD_COMPONENT_ARM_DISARM,
+                result: MavResult::MAV_RESULT_ACCEPTED,
+                progress: 50,
+                result_param2: 7,
+                target_system: 1,
+                target_component: 1,
+            }),
+        );
+        match decoded {
+            MavlinkMessage::CommandAck(d) => {
+                assert_eq!(d.command, 400, "MAV_CMD_COMPONENT_ARM_DISARM");
+                assert_eq!(d.result, MavResult::MAV_RESULT_ACCEPTED as u8);
+                assert_eq!(d.progress, 50);
+                assert_eq!(d.result_param2, 7);
+                assert_eq!(d.target_system, 1);
+            }
+            other => panic!("expected CommandAck, got {other:?}"),
         }
     }
 }

--- a/packages/mavlink/src/mavlink_encoder.rs
+++ b/packages/mavlink/src/mavlink_encoder.rs
@@ -12,9 +12,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use mavlink::MavHeader;
 use mavlink::dialects::common::{
-    ATTITUDE_DATA, AttitudeTargetTypemask, COMMAND_LONG_DATA, ENCAPSULATED_DATA_DATA, HEARTBEAT_DATA,
-    HIGHRES_IMU_DATA, HighresImuUpdatedFlags, MavAutopilot, MavCmd, MavFrame, MavMessage,
-    MavModeFlag, MavState, MavType, PositionTargetTypemask, SET_ATTITUDE_TARGET_DATA,
+    ATTITUDE_DATA, AttitudeTargetTypemask, COMMAND_LONG_DATA, ENCAPSULATED_DATA_DATA,
+    HEARTBEAT_DATA, HIGHRES_IMU_DATA, HighresImuUpdatedFlags, MavAutopilot, MavCmd, MavFrame,
+    MavMessage, MavModeFlag, MavState, MavType, PositionTargetTypemask, SET_ATTITUDE_TARGET_DATA,
     SET_POSITION_TARGET_LOCAL_NED_DATA, TIMESYNC_DATA,
 };
 use num_traits::FromPrimitive;
@@ -109,7 +109,11 @@ impl ReactiveProcessor for MavlinkEncoderProcessor::Processor {
 
         let n = self.messages_encoded.fetch_add(1, Ordering::Relaxed) + 1;
         if n == 1 {
-            tracing::info!(system_id, component_id, "MavlinkEncoder: first message encoded");
+            tracing::info!(
+                system_id,
+                component_id,
+                "MavlinkEncoder: first message encoded"
+            );
         }
         Ok(())
     }
@@ -140,6 +144,13 @@ fn identity(msg: &MavlinkMessage, default_sys: u8, default_comp: u8) -> (u8, u8,
         MavlinkMessage::Timesync(d) => (d.system_id, d.component_id, d.peer_addr.clone()),
         MavlinkMessage::CommandLong(d) => (d.system_id, d.component_id, d.peer_addr.clone()),
         MavlinkMessage::EncapsulatedData(d) => (d.system_id, d.component_id, d.peer_addr.clone()),
+        MavlinkMessage::LocalPositionNed(d) => (d.system_id, d.component_id, d.peer_addr.clone()),
+        MavlinkMessage::Odometry(d) => (d.system_id, d.component_id, d.peer_addr.clone()),
+        MavlinkMessage::ActuatorOutputStatus(d) => {
+            (d.system_id, d.component_id, d.peer_addr.clone())
+        }
+        MavlinkMessage::Collision(d) => (d.system_id, d.component_id, d.peer_addr.clone()),
+        MavlinkMessage::CommandAck(d) => (d.system_id, d.component_id, d.peer_addr.clone()),
     };
     let sys = if sys == 0 { default_sys } else { sys };
     let comp = if comp == 0 { default_comp } else { comp };
@@ -288,6 +299,21 @@ fn convert_to_mavlink(msg: &MavlinkMessage) -> Result<MavMessage> {
             data[..n].copy_from_slice(&d.data[..n]);
             MavMessage::ENCAPSULATED_DATA(ENCAPSULATED_DATA_DATA { seqnr: d.seqnr, data })
         }
+        // SIM->PILOT telemetry the decoder surfaces for consumers but the
+        // pilot never transmits. They have no encode path on purpose: the
+        // racer receives these, it does not emit them.
+        MavlinkMessage::LocalPositionNed(_)
+        | MavlinkMessage::Odometry(_)
+        | MavlinkMessage::ActuatorOutputStatus(_)
+        | MavlinkMessage::Collision(_)
+        | MavlinkMessage::CommandAck(_) => {
+            return Err(Error::Configuration(
+                "MavlinkEncoder: LOCAL_POSITION_NED / ODOMETRY / ACTUATOR_OUTPUT_STATUS / \
+                 COLLISION / COMMAND_ACK are SIM->PILOT telemetry surfaced by the decoder but \
+                 never transmitted by the pilot — decode-only, not encodable"
+                    .to_string(),
+            ));
+        }
     })
 }
 
@@ -309,8 +335,9 @@ mod tests {
     use super::*;
     use crate::_generated_::tatolab__mavlink::mavlink_message::{
         MavlinkMessageAttitude, MavlinkMessageCommandLong, MavlinkMessageEncapsulatedData,
-        MavlinkMessageHeartbeat, MavlinkMessageHighresImu, MavlinkMessageSetAttitudeTarget,
-        MavlinkMessageSetPositionTargetLocalNed, MavlinkMessageTimesync,
+        MavlinkMessageHeartbeat, MavlinkMessageHighresImu, MavlinkMessageLocalPositionNed,
+        MavlinkMessageSetAttitudeTarget, MavlinkMessageSetPositionTargetLocalNed,
+        MavlinkMessageTimesync,
     };
 
     fn make_heartbeat(sys: u8, comp: u8) -> MavlinkMessage {
@@ -321,7 +348,7 @@ mod tests {
             peer_addr: String::new(),
             timestamp_ns: "0".to_string(),
             custom_mode: 0,
-            mavtype: 2, // MAV_TYPE_QUADROTOR
+            mavtype: 2,    // MAV_TYPE_QUADROTOR
             autopilot: 12, // MAV_AUTOPILOT_PX4
             base_mode: 0,
             system_status: 4, // MAV_STATE_ACTIVE
@@ -538,6 +565,35 @@ mod tests {
                     d.timestamp_ns = "0".to_string();
                     d.sequence = 0;
                 }
+                // Decode-only telemetry variants: convert_to_mavlink rejects
+                // them, so they never reach assert_round_trip — but normalize
+                // them anyway to keep the match exhaustive (so a future
+                // encodable variant can't silently skip normalization).
+                MavlinkMessage::LocalPositionNed(d) => {
+                    d.peer_addr.clear();
+                    d.timestamp_ns = "0".to_string();
+                    d.sequence = 0;
+                }
+                MavlinkMessage::Odometry(d) => {
+                    d.peer_addr.clear();
+                    d.timestamp_ns = "0".to_string();
+                    d.sequence = 0;
+                }
+                MavlinkMessage::ActuatorOutputStatus(d) => {
+                    d.peer_addr.clear();
+                    d.timestamp_ns = "0".to_string();
+                    d.sequence = 0;
+                }
+                MavlinkMessage::Collision(d) => {
+                    d.peer_addr.clear();
+                    d.timestamp_ns = "0".to_string();
+                    d.sequence = 0;
+                }
+                MavlinkMessage::CommandAck(d) => {
+                    d.peer_addr.clear();
+                    d.timestamp_ns = "0".to_string();
+                    d.sequence = 0;
+                }
             }
             msg
         };
@@ -651,9 +707,9 @@ mod tests {
                     "got: {s}"
                 );
             }
-            other => panic!(
-                "expected configuration error on thrust_body.len() != 3, got {other:?}"
-            ),
+            other => {
+                panic!("expected configuration error on thrust_body.len() != 3, got {other:?}")
+            }
         }
     }
 
@@ -698,9 +754,37 @@ mod tests {
                 assert!(s.contains("mavtype"), "expected mavtype in error: {s}");
                 assert!(s.contains("250"), "expected the bad value in error: {s}");
             }
-            other => panic!(
-                "expected configuration error on out-of-range mavtype, got {other:?}"
-            ),
+            other => panic!("expected configuration error on out-of-range mavtype, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn telemetry_messages_are_decode_only() {
+        // LOCAL_POSITION_NED (like ODOMETRY / ACTUATOR_OUTPUT_STATUS / COLLISION
+        // / COMMAND_ACK) is SIM->PILOT telemetry the decoder surfaces but the
+        // pilot never sends — encode must refuse rather than fabricate a frame.
+        let msg = MavlinkMessage::LocalPositionNed(MavlinkMessageLocalPositionNed {
+            system_id: 1,
+            component_id: 1,
+            sequence: 0,
+            peer_addr: String::new(),
+            timestamp_ns: "0".to_string(),
+            time_boot_ms: 0,
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            vx: 0.0,
+            vy: 0.0,
+            vz: 0.0,
+        });
+        match convert_to_mavlink(&msg) {
+            Err(Error::Configuration(s)) => {
+                assert!(
+                    s.contains("decode-only"),
+                    "expected decode-only rejection, got: {s}"
+                );
+            }
+            other => panic!("expected decode-only rejection, got {other:?}"),
         }
     }
 }

--- a/packages/mavlink/streamlib.yaml
+++ b/packages/mavlink/streamlib.yaml
@@ -1,7 +1,7 @@
 package:
   org: tatolab
   name: mavlink
-  version: 1.1.3
+  version: 1.1.4
   description: MAVLink2 encoder + decoder processors via rust-mavlink — pairs with @tatolab/network for MAVLink-over-UDP
 dependencies:
   '@tatolab/network':


### PR DESCRIPTION
## What

Surface every MAVLink message the DCL AI-Grand-Prix sim emits SIM→PILOT in the `@tatolab/mavlink` decoder, instead of a hand-picked subset. Closes #1230.

The `MavlinkDecoder` tagged union surfaced only 8 hand-listed messages and silently dropped the rest at `convert()`'s `_ => return None`. Five standard common-dialect messages the sim actually sends — verified on the wire from recorded `.aglog` and consumed by the official competition example pilot — were parsed by rust-mavlink and then thrown away. Most importantly **linear velocity** (`ODOMETRY` / `LOCAL_POSITION_NED`) never reached consumers, which blocks the drone-racer Phase-1 state estimator (tatolab/drone-racer#41).

## Messages added (decoder)

| msgid | Message | Carries |
|---|---|---|
| 32  | `LOCAL_POSITION_NED`     | world-NED velocity + position |
| 331 | `ODOMETRY`               | body velocity + orientation quaternion + body rates + `reset_counter` + estimator_type/quality |
| 375 | `ACTUATOR_OUTPUT_STATUS` | per-motor outputs |
| 247 | `COLLISION`              | collision events |
| 77  | `COMMAND_ACK`            | command acknowledgements |

Each gets a schema `mapping:` entry (full field set) + a `convert()` arm + a decoder unit test that builds a real frame (`write_v2_msg`) and asserts the typed fields survive `decode_one`. rust-mavlink already parsed these (the decoder reads the full `common` dialect); they only needed surfacing.

## Encoder: decode-only

These are **SIM→PILOT receive-only** telemetry — the pilot never transmits them. To keep the `MavlinkMessage` match exhaustive, `identity()` handles them and `convert_to_mavlink()` rejects them with a clear `Configuration` error rather than fabricating a telemetry frame (a test locks this). AGP-custom `ENCAPSULATED_DATA` payload parsing (race-status / track geometry) stays a consumer concern, not generic MAVLink.

## Tests

`cargo test --lib` → **23 passed** (6 new). `cargo clippy --lib` clean. The new messages are tested at the **decoder** level rather than the existing encode→decode loopback, since decode-only messages can't round-trip through the encoder.

## Out of scope (flagging, not fixing)

`tests/mavlink_over_udp.rs` does not compile standalone at HEAD — it references `streamlib`, `streamlib_network`, and `serial_test`, none declared in `[dev-dependencies]` (there is no such section). Pre-existing and untouched by this PR.

## Follow-up

Publish 1.1.4 to the Gitea registry (`scripts/gitea/publish-packages.sh mavlink`) so consumers resolve it via `Strategy::Registry`. The drone-racer estimator (tatolab/drone-racer#41) then consumes it by version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
