### PR TITLE
feat(cli): whole-tree link mode for instant local package dev loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ serde_yaml = "0.9"
 # array of integers (~1.5× footprint for ≥128 byte values).
 serde_bytes = "0.11"
 toml = "0.8"
+toml_edit = "0.22"
 rmp-serde = "1.3"
 
 # Hashing

--- a/libs/streamlib-build-orchestrator/Cargo.toml
+++ b/libs/streamlib-build-orchestrator/Cargo.toml
@@ -14,6 +14,7 @@ repository.workspace = true
 anyhow = { workspace = true }
 tracing = { workspace = true }
 serde_json = { workspace = true }
+toml_edit = { workspace = true }
 ureq = { workspace = true }
 streamlib-engine = { path = "../streamlib-engine", version = "0.5.0", registry = "gitea" }
 streamlib-cargo-build = { path = "../streamlib-cargo-build", version = "0.5.0", registry = "gitea" }

--- a/libs/streamlib-build-orchestrator/src/lib.rs
+++ b/libs/streamlib-build-orchestrator/src/lib.rs
@@ -272,7 +272,7 @@ impl PolyglotBuildOrchestrator {
         // (no-op when the package has no Python runtime). Building it into
         // `temp_dir` means the atomic rename below carries the venv into
         // place — no second rename. On failure, drop the half-staged temp.
-        python_venv::provision_python_venv(&temp_dir, &pkg_label).map_err(|e| {
+        python_venv::provision_python_venv(&temp_dir, pkg_dir, &pkg_label).map_err(|e| {
             let _ = std::fs::remove_dir_all(&temp_dir);
             e
         })?;

--- a/libs/streamlib-build-orchestrator/src/python_venv.rs
+++ b/libs/streamlib-build-orchestrator/src/python_venv.rs
@@ -319,24 +319,28 @@ fn build_failed(package: &str, detail: String) -> BuildError {
     }
 }
 
-/// Checkout-relative path of the Python SDK the link override targets. Must
-/// stay in sync with the CLI's `streamlib link` emission.
-const LINKED_PYTHON_SDK_REL: &str = "libs/streamlib-python";
-
-/// If a `streamlib link` is active for `source_pkg_dir`, rewrite the staged
-/// `pyproject`'s `streamlib` dependency to resolve from the linked checkout's
-/// Python SDK via `[tool.uv.sources]`.
+/// If a `streamlib link` is active for `source_pkg_dir` (discovered via the
+/// shared marker primitive in `streamlib_pack::link_marker`), rewrite the
+/// staged `pyproject`'s `streamlib` dependency to resolve from the linked
+/// checkout's Python SDK via `[tool.uv.sources]`. A corrupt marker is a loud
+/// error — silently ignoring it would produce a mixed state (cargo patched,
+/// venv from registry).
 fn apply_link_override_if_active(
     pyproject: &Path,
     source_pkg_dir: &Path,
     package_label: &str,
 ) -> Result<(), BuildError> {
-    let Some(checkout) = active_link_checkout(source_pkg_dir) else {
+    let link = streamlib_pack::link_marker::find_and_load_active_link(source_pkg_dir)
+        .map_err(|e| build_failed(package_label, e.to_string()))?;
+    let Some((marker, manifest)) = link else {
         return Ok(());
     };
-    let sdk_path = checkout.join(LINKED_PYTHON_SDK_REL);
+    // The marker carries the resolved absolute SDK path — read data, don't
+    // re-derive a checkout-relative convention.
+    let sdk_path = manifest.python_sdk_path;
     tracing::info!(
-        checkout = %checkout.display(),
+        marker = %marker.display(),
+        checkout = %manifest.checkout.display(),
         sdk = %sdk_path.display(),
         "streamlib link active — pointing staged pyproject's streamlib dep at the linked checkout"
     );
@@ -355,42 +359,35 @@ fn apply_link_override_if_active(
     );
     source.insert("editable", toml_edit::Value::from(true));
 
-    if !doc.contains_key("tool") {
-        doc.insert("tool", toml_edit::Item::Table(toml_edit::Table::new()));
-    }
-    let tool = doc["tool"].as_table_mut().unwrap();
-    if !tool.contains_key("uv") {
-        tool.insert("uv", toml_edit::Item::Table(toml_edit::Table::new()));
-    }
-    let uv = doc["tool"]["uv"].as_table_mut().unwrap();
-    if !uv.contains_key("sources") {
-        uv.insert("sources", toml_edit::Item::Table(toml_edit::Table::new()));
-    }
-    uv["sources"]["streamlib"] = toml_edit::Item::Value(toml_edit::Value::InlineTable(source));
+    let tool = ensure_pyproject_table(doc.as_table_mut(), "tool", package_label)?;
+    let uv = ensure_pyproject_table(tool, "uv", package_label)?;
+    let sources = ensure_pyproject_table(uv, "sources", package_label)?;
+    sources.insert(
+        "streamlib",
+        toml_edit::Item::Value(toml_edit::Value::InlineTable(source)),
+    );
 
     std::fs::write(pyproject, doc.to_string()).map_err(|e| {
         build_failed(package_label, format!("write staged pyproject.toml: {e}"))
     })
 }
 
-/// Walk up from `source_pkg_dir` to the filesystem root looking for an active
-/// `streamlib link` marker (`.streamlib/link.json`) and return its `checkout`.
-/// Reads only the one field it needs; the CLI owns the full marker schema.
-fn active_link_checkout(source_pkg_dir: &Path) -> Option<PathBuf> {
-    let mut dir = Some(source_pkg_dir);
-    while let Some(d) = dir {
-        let marker = d.join(".streamlib").join("link.json");
-        if marker.is_file() {
-            let body = std::fs::read_to_string(&marker).ok()?;
-            let value: serde_json::Value = serde_json::from_str(&body).ok()?;
-            return value
-                .get("checkout")
-                .and_then(|v| v.as_str())
-                .map(PathBuf::from);
-        }
-        dir = d.parent();
+/// Get-or-create `key` as a table, with a typed error when an existing
+/// non-table value occupies the key (a malformed pyproject must never panic).
+fn ensure_pyproject_table<'a>(
+    table: &'a mut toml_edit::Table,
+    key: &str,
+    package_label: &str,
+) -> Result<&'a mut toml_edit::Table, BuildError> {
+    if !table.contains_key(key) {
+        table.insert(key, toml_edit::Item::Table(toml_edit::Table::new()));
     }
-    None
+    table[key].as_table_mut().ok_or_else(|| {
+        build_failed(
+            package_label,
+            format!("staged pyproject.toml: `{key}` exists but is not a table"),
+        )
+    })
 }
 
 #[cfg(test)]
@@ -530,18 +527,35 @@ packages = ["python"]
         assert!(has_pyc, "compileall must have produced at least one .pyc in the venv");
     }
 
-    #[test]
-    fn link_override_redirects_staged_pyproject_at_the_checkout_python_sdk() {
-        // A source tree carrying an active `streamlib link` marker; the staged
-        // pyproject's streamlib dep must be redirected at the checkout's SDK.
-        let src = tempfile::tempdir().unwrap();
-        let marker_dir = src.path().join(".streamlib");
+    /// Write a full-schema link marker whose `python_sdk_path` points at `sdk`.
+    fn write_link_marker(source_root: &Path, sdk: &Path) {
+        let marker_dir = source_root.join(".streamlib");
         std::fs::create_dir_all(&marker_dir).unwrap();
         std::fs::write(
             marker_dir.join("link.json"),
-            r#"{ "checkout": "/opt/streamlib-checkout", "files": [] }"#,
+            format!(
+                r#"{{
+  "checkout": "/opt/streamlib-checkout",
+  "python_sdk_path": "{sdk}",
+  "deno_sdk_entrypoint_path": "/opt/streamlib-checkout/libs/streamlib-deno/mod.ts",
+  "linked_at": "2026-01-01T00:00:00Z",
+  "linked_crate_count": 1,
+  "state": "active",
+  "files": []
+}}"#,
+                sdk = sdk.display()
+            ),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn link_override_redirects_staged_pyproject_at_the_marker_python_sdk_path() {
+        // A source tree carrying an active `streamlib link` marker; the staged
+        // pyproject's streamlib dep must be redirected at the marker's
+        // recorded absolute python_sdk_path (data, not re-derived).
+        let src = tempfile::tempdir().unwrap();
+        write_link_marker(src.path(), Path::new("/opt/streamlib-checkout/libs/streamlib-python"));
 
         let staged = tempfile::tempdir().unwrap();
         let pyproject = staged.path().join("pyproject.toml");
@@ -574,6 +588,96 @@ packages = ["python"]
 
         // No marker ⇒ pyproject untouched.
         assert_eq!(std::fs::read_to_string(&pyproject).unwrap(), original);
+    }
+
+    #[test]
+    fn corrupt_link_marker_is_a_loud_error_not_a_silent_skip() {
+        // A corrupt link.json must fail the provision — silently ignoring it
+        // produces a mixed state (cargo patched to the checkout, venv built
+        // from the registry).
+        let src = tempfile::tempdir().unwrap();
+        let marker_dir = src.path().join(".streamlib");
+        std::fs::create_dir_all(&marker_dir).unwrap();
+        std::fs::write(marker_dir.join("link.json"), "{ definitely not json").unwrap();
+
+        let staged = tempfile::tempdir().unwrap();
+        let pyproject = staged.path().join("pyproject.toml");
+        let original = "[project]\nname = \"p\"\nversion = \"0.1.0\"\ndependencies = [\"streamlib\"]\n";
+        std::fs::write(&pyproject, original).unwrap();
+
+        let err = apply_link_override_if_active(&pyproject, src.path(), "tatolab/p")
+            .expect_err("corrupt marker must be a loud error");
+        assert!(
+            format!("{err}").contains("corrupt"),
+            "error must name the corruption, got: {err}"
+        );
+        // And the staged pyproject was not half-mutated.
+        assert_eq!(std::fs::read_to_string(&pyproject).unwrap(), original);
+    }
+
+    #[test]
+    fn non_table_tool_key_in_staged_pyproject_is_a_typed_error_not_a_panic() {
+        let src = tempfile::tempdir().unwrap();
+        write_link_marker(src.path(), Path::new("/opt/sdk"));
+        let staged = tempfile::tempdir().unwrap();
+        let pyproject = staged.path().join("pyproject.toml");
+        std::fs::write(&pyproject, "tool = 3\n").unwrap();
+
+        let err = apply_link_override_if_active(&pyproject, src.path(), "tatolab/p")
+            .expect_err("non-table `tool` must be a typed error");
+        assert!(
+            format!("{err}").contains("not a table"),
+            "error must name the malformed key, got: {err}"
+        );
+    }
+
+    #[test]
+    fn provision_applies_link_override_end_to_end_against_marked_source_tree() {
+        // T4: drive the override through `provision_python_venv` itself — a
+        // marked SOURCE tree whose python_sdk_path points at the offline
+        // fixture SDK; the STAGED pyproject (no uv source of its own) must be
+        // rewritten and the venv must install the linked SDK. Requires `uv`.
+        if which_uv().is_none() {
+            eprintln!("skipping: `uv` not on PATH");
+            return;
+        }
+
+        let root = tempfile::tempdir().unwrap();
+        let sdk = write_fixture_streamlib_sdk(root.path());
+
+        // Source tree with an active link marker pointing at the fixture SDK.
+        let src = tempfile::tempdir().unwrap();
+        write_link_marker(src.path(), &sdk);
+
+        // Staged package WITHOUT any uv source — resolution must come from
+        // the injected link override.
+        let staged = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(staged.path().join("python")).unwrap();
+        std::fs::write(staged.path().join("python").join("__init__.py"), "").unwrap();
+        std::fs::write(
+            staged.path().join("pyproject.toml"),
+            r#"[project]
+name = "mypkg"
+version = "0.1.0"
+dependencies = ["streamlib"]
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+[tool.hatch.build.targets.wheel]
+packages = ["python"]
+"#,
+        )
+        .unwrap();
+
+        provision_python_venv(staged.path(), src.path(), "tatolab/mypkg")
+            .expect("provision must succeed against the linked fixture SDK");
+
+        // The staged pyproject got the override injected…
+        let body = std::fs::read_to_string(staged.path().join("pyproject.toml")).unwrap();
+        assert!(body.contains("[tool.uv.sources]"), "override missing:\n{body}");
+        assert!(body.contains(&sdk.display().to_string()), "sdk path missing:\n{body}");
+        // …and the venv exists (streamlib resolved from the linked SDK).
+        assert!(staged.path().join(".venv").join("bin").join("python").exists());
     }
 
     fn find_any_pyc(dir: &Path) -> bool {

--- a/libs/streamlib-build-orchestrator/src/python_venv.rs
+++ b/libs/streamlib-build-orchestrator/src/python_venv.rs
@@ -33,9 +33,18 @@ use streamlib_engine::core::runtime::BuildError;
 /// (Windows) — so that after the orchestrator's atomic rename it lands at
 /// `{staged_package_dir}/.venv/bin/python`.
 ///
+/// `source_pkg_dir` is the on-disk package source the artifact was assembled
+/// from; it is walked upward for an active `streamlib link` marker so the venv
+/// can build against a linked checkout's Python SDK. Pass the staged dir when
+/// there is no distinct source tree.
+///
 /// No-op (returns `Ok(())`) when the staged package has no Python runtime.
-#[tracing::instrument(skip(temp_dir), fields(temp_dir = %temp_dir.display(), package = %package_label))]
-pub fn provision_python_venv(temp_dir: &Path, package_label: &str) -> Result<(), BuildError> {
+#[tracing::instrument(skip(temp_dir, source_pkg_dir), fields(temp_dir = %temp_dir.display(), package = %package_label))]
+pub fn provision_python_venv(
+    temp_dir: &Path,
+    source_pkg_dir: &Path,
+    package_label: &str,
+) -> Result<(), BuildError> {
     if !staged_package_has_python(temp_dir) {
         tracing::debug!("no Python runtime in staged package — skipping venv provisioning");
         return Ok(());
@@ -66,6 +75,15 @@ pub fn provision_python_venv(temp_dir: &Path, package_label: &str) -> Result<(),
             None
         }
     };
+
+    // ---- link-mode override ----
+    // When a `streamlib link` is active for the source tree this package was
+    // built from, redirect the staged pyproject's `streamlib` dependency at the
+    // linked checkout's Python SDK before installing, so the venv resolves the
+    // SDK from local source (mirrors the cargo `[patch]` the CLI emits).
+    if let Some(pyproject) = &pyproject_path {
+        apply_link_override_if_active(pyproject, source_pkg_dir, package_label)?;
+    }
 
     // ---- uv venv ----
     let venv_dir_str = path_to_str(&venv_dir, package_label)?;
@@ -301,6 +319,80 @@ fn build_failed(package: &str, detail: String) -> BuildError {
     }
 }
 
+/// Checkout-relative path of the Python SDK the link override targets. Must
+/// stay in sync with the CLI's `streamlib link` emission.
+const LINKED_PYTHON_SDK_REL: &str = "libs/streamlib-python";
+
+/// If a `streamlib link` is active for `source_pkg_dir`, rewrite the staged
+/// `pyproject`'s `streamlib` dependency to resolve from the linked checkout's
+/// Python SDK via `[tool.uv.sources]`.
+fn apply_link_override_if_active(
+    pyproject: &Path,
+    source_pkg_dir: &Path,
+    package_label: &str,
+) -> Result<(), BuildError> {
+    let Some(checkout) = active_link_checkout(source_pkg_dir) else {
+        return Ok(());
+    };
+    let sdk_path = checkout.join(LINKED_PYTHON_SDK_REL);
+    tracing::info!(
+        checkout = %checkout.display(),
+        sdk = %sdk_path.display(),
+        "streamlib link active — pointing staged pyproject's streamlib dep at the linked checkout"
+    );
+
+    let body = std::fs::read_to_string(pyproject).map_err(|e| {
+        build_failed(package_label, format!("read staged pyproject.toml: {e}"))
+    })?;
+    let mut doc: toml_edit::DocumentMut = body.parse().map_err(|e: toml_edit::TomlError| {
+        build_failed(package_label, format!("parse staged pyproject.toml: {e}"))
+    })?;
+
+    let mut source = toml_edit::InlineTable::new();
+    source.insert(
+        "path",
+        toml_edit::Value::from(sdk_path.to_string_lossy().into_owned()),
+    );
+    source.insert("editable", toml_edit::Value::from(true));
+
+    if !doc.contains_key("tool") {
+        doc.insert("tool", toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+    let tool = doc["tool"].as_table_mut().unwrap();
+    if !tool.contains_key("uv") {
+        tool.insert("uv", toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+    let uv = doc["tool"]["uv"].as_table_mut().unwrap();
+    if !uv.contains_key("sources") {
+        uv.insert("sources", toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+    uv["sources"]["streamlib"] = toml_edit::Item::Value(toml_edit::Value::InlineTable(source));
+
+    std::fs::write(pyproject, doc.to_string()).map_err(|e| {
+        build_failed(package_label, format!("write staged pyproject.toml: {e}"))
+    })
+}
+
+/// Walk up from `source_pkg_dir` to the filesystem root looking for an active
+/// `streamlib link` marker (`.streamlib/link.json`) and return its `checkout`.
+/// Reads only the one field it needs; the CLI owns the full marker schema.
+fn active_link_checkout(source_pkg_dir: &Path) -> Option<PathBuf> {
+    let mut dir = Some(source_pkg_dir);
+    while let Some(d) = dir {
+        let marker = d.join(".streamlib").join("link.json");
+        if marker.is_file() {
+            let body = std::fs::read_to_string(&marker).ok()?;
+            let value: serde_json::Value = serde_json::from_str(&body).ok()?;
+            return value
+                .get("checkout")
+                .and_then(|v| v.as_str())
+                .map(PathBuf::from);
+        }
+        dir = d.parent();
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -381,7 +473,8 @@ packages = ["python"]
         // schemas-only or Rust-only package.
         let temp = tempfile::tempdir().unwrap();
         std::fs::write(temp.path().join("streamlib.yaml"), "package:\n  name: x\n").unwrap();
-        provision_python_venv(temp.path(), "tatolab/x").expect("no-python must be a no-op");
+        provision_python_venv(temp.path(), temp.path(), "tatolab/x")
+            .expect("no-python must be a no-op");
         assert!(
             !temp.path().join(".venv").exists(),
             "no venv must be created for a non-Python staged package"
@@ -407,7 +500,7 @@ packages = ["python"]
         let temp = tempfile::tempdir().unwrap();
         write_staged_python_package(temp.path(), &sdk);
 
-        provision_python_venv(temp.path(), "tatolab/mypkg")
+        provision_python_venv(temp.path(), temp.path(), "tatolab/mypkg")
             .expect("provision must succeed offline against the fixture SDK");
 
         // Contract: interpreter at exactly {temp_dir}/.venv/bin/python.
@@ -435,6 +528,52 @@ packages = ["python"]
         // compileall: at least one .pyc somewhere under the venv.
         let has_pyc = find_any_pyc(&temp.path().join(".venv"));
         assert!(has_pyc, "compileall must have produced at least one .pyc in the venv");
+    }
+
+    #[test]
+    fn link_override_redirects_staged_pyproject_at_the_checkout_python_sdk() {
+        // A source tree carrying an active `streamlib link` marker; the staged
+        // pyproject's streamlib dep must be redirected at the checkout's SDK.
+        let src = tempfile::tempdir().unwrap();
+        let marker_dir = src.path().join(".streamlib");
+        std::fs::create_dir_all(&marker_dir).unwrap();
+        std::fs::write(
+            marker_dir.join("link.json"),
+            r#"{ "checkout": "/opt/streamlib-checkout", "files": [] }"#,
+        )
+        .unwrap();
+
+        let staged = tempfile::tempdir().unwrap();
+        let pyproject = staged.path().join("pyproject.toml");
+        std::fs::write(
+            &pyproject,
+            "[project]\nname = \"p\"\nversion = \"0.1.0\"\ndependencies = [\"streamlib\"]\n",
+        )
+        .unwrap();
+
+        apply_link_override_if_active(&pyproject, src.path(), "tatolab/p").unwrap();
+
+        let body = std::fs::read_to_string(&pyproject).unwrap();
+        assert!(body.contains("[tool.uv.sources]"), "sources table missing:\n{body}");
+        assert!(
+            body.contains("/opt/streamlib-checkout/libs/streamlib-python"),
+            "override path missing:\n{body}"
+        );
+        assert!(body.contains("editable = true"), "editable flag missing:\n{body}");
+    }
+
+    #[test]
+    fn link_override_is_a_noop_without_an_active_marker() {
+        let src = tempfile::tempdir().unwrap();
+        let staged = tempfile::tempdir().unwrap();
+        let pyproject = staged.path().join("pyproject.toml");
+        let original = "[project]\nname = \"p\"\nversion = \"0.1.0\"\ndependencies = [\"streamlib\"]\n";
+        std::fs::write(&pyproject, original).unwrap();
+
+        apply_link_override_if_active(&pyproject, src.path(), "tatolab/p").unwrap();
+
+        // No marker ⇒ pyproject untouched.
+        assert_eq!(std::fs::read_to_string(&pyproject).unwrap(), original);
     }
 
     fn find_any_pyc(dir: &Path) -> bool {

--- a/libs/streamlib-cli/Cargo.toml
+++ b/libs/streamlib-cli/Cargo.toml
@@ -49,8 +49,16 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 toml.workspace = true
 
+# Format-preserving TOML editing for `streamlib link` (cargo config + pyproject
+# override emission that survives an idempotent byte-clean unlink).
+toml_edit.workspace = true
+
+# Content hashing for the `streamlib link` backup manifest.
+sha2.workspace = true
+
 # Error handling
 anyhow.workspace = true
+thiserror.workspace = true
 
 # Load .env files for development environment
 dotenvy = "0.15"

--- a/libs/streamlib-cli/src/commands/link.rs
+++ b/libs/streamlib-cli/src/commands/link.rs
@@ -1,0 +1,719 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib link` / `streamlib unlink` — whole-tree local dev override.
+//!
+//! Points the entire streamlib surface a consumer resolves (all SDK cargo
+//! crates + the Python SDK + the Deno SDK) at a local streamlib checkout via
+//! language-native overrides, so an edit in the checkout is picked up by the
+//! consumer's next build with no publish step. `unlink` restores every touched
+//! manifest byte-identically. Emission is whole-tree and transactional: either
+//! all overrides land or none do.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Consumer-root-relative directory holding all link state.
+const LINK_STATE_DIR: &str = ".streamlib";
+/// Manifest recording the active link (checkout + every touched file).
+const LINK_MANIFEST_FILE: &str = "link.json";
+/// Directory under [`LINK_STATE_DIR`] mirroring pre-edit backups by relative path.
+const LINK_BACKUP_DIR: &str = "link-backup";
+/// Human-facing greppability marker on the emitted cargo `[patch]` block.
+const CARGO_PATCH_MARKER: &str =
+    "# streamlib-link — managed by `streamlib link`; removed by `streamlib unlink`";
+/// Checkout-relative path of the Python SDK (uv editable source target).
+const PYTHON_SDK_REL: &str = "libs/streamlib-python";
+/// Checkout-relative path of the Deno SDK entrypoint module.
+const DENO_SDK_ENTRYPOINT_REL: &str = "libs/streamlib-deno/mod.ts";
+
+/// Failure modes of `streamlib link` / `streamlib unlink`.
+#[derive(Debug, thiserror::Error)]
+pub enum LinkError {
+    /// The checkout path does not exist or is not a streamlib workspace.
+    #[error("`{0}` is not a streamlib checkout (no Cargo.toml workspace at that path)")]
+    NotAStreamlibCheckout(PathBuf),
+
+    /// A link to a different checkout is already active; refuse to clobber it.
+    #[error(
+        "a link to `{active}` is already active in this consumer; run `streamlib unlink` before \
+         linking `{requested}`"
+    )]
+    AlreadyLinkedElsewhere { active: PathBuf, requested: PathBuf },
+
+    /// No `[registries.gitea].index` is discoverable from the consumer's cargo config.
+    #[error(
+        "no `[registries.gitea]` registry index found in this consumer's cargo config (looked in \
+         `.cargo/config.toml` walking up from the consumer root and in `~/.cargo/config.toml`); a \
+         streamlib consumer must configure the gitea registry before linking"
+    )]
+    RegistryIndexNotConfigured,
+
+    /// `cargo metadata` on the checkout failed or produced no linkable crates.
+    #[error("could not derive the linkable crate set from `{checkout}`: {detail}")]
+    CrateSetDerivation { checkout: PathBuf, detail: String },
+
+    /// A manifest we planned to edit could not be parsed.
+    #[error("failed to parse `{path}`: {detail}")]
+    ManifestParse { path: PathBuf, detail: String },
+
+    /// The recorded link manifest is corrupt / unreadable.
+    #[error("link state at `{path}` is corrupt: {detail}")]
+    CorruptLinkState { path: PathBuf, detail: String },
+
+    /// A pack/publish was attempted while a link is active.
+    #[error(
+        "this package cannot be packed or published while a streamlib link is active (marker: \
+         {marker}). Local link overrides are dev-only and must not leak into a distributed \
+         artifact — run `streamlib unlink` first"
+    )]
+    PackRefusedWhileLinked { marker: PathBuf },
+
+    /// A filesystem operation failed.
+    #[error("filesystem error at `{path}`: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+impl LinkError {
+    fn io(path: impl Into<PathBuf>, source: std::io::Error) -> Self {
+        LinkError::Io {
+            path: path.into(),
+            source,
+        }
+    }
+}
+
+/// One manifest file the active link overrode, recorded for byte-clean teardown.
+#[derive(Debug, Serialize, Deserialize)]
+struct TouchedFile {
+    /// Path relative to the consumer root.
+    path: PathBuf,
+    /// Whether the file existed before linking. `false` ⇒ unlink deletes it.
+    existed_before: bool,
+    /// Hex SHA-256 of the pre-edit content (empty when `!existed_before`).
+    pre_edit_sha256: String,
+}
+
+/// Persisted record of the active whole-tree link.
+#[derive(Debug, Serialize, Deserialize)]
+struct LinkManifest {
+    /// Canonicalized path of the linked streamlib checkout.
+    checkout: PathBuf,
+    /// RFC-3339 timestamp of when the link was established.
+    linked_at: String,
+    /// Number of cargo crates redirected to the checkout.
+    linked_crate_count: usize,
+    /// Every manifest file the link touched (in apply order).
+    files: Vec<TouchedFile>,
+}
+
+/// A computed manifest edit, not yet applied.
+#[derive(Debug)]
+struct PlannedEdit {
+    /// Path relative to the consumer root (e.g. `.cargo/config.toml`).
+    rel_path: PathBuf,
+    /// Absolute path of the file to write.
+    abs_path: PathBuf,
+    /// The full post-edit content to write.
+    new_content: String,
+    /// Pre-edit bytes when the file already existed, else `None`.
+    original: Option<Vec<u8>>,
+}
+
+/// Establish (or refresh) a whole-tree link from `consumer_root` to `checkout`.
+#[tracing::instrument(skip_all, fields(consumer_root = %consumer_root.display(), checkout = %checkout.display()))]
+pub fn link(consumer_root: &Path, checkout: &Path) -> Result<(), LinkError> {
+    let checkout = canonicalize_checkout(checkout)?;
+    let consumer_root = consumer_root
+        .canonicalize()
+        .map_err(|e| LinkError::io(consumer_root, e))?;
+
+    // Idempotency: identical checkout ⇒ refresh; different checkout ⇒ refuse.
+    if let Some(existing) = load_active_manifest(&consumer_root)? {
+        if existing.checkout == checkout {
+            tracing::info!("refreshing existing link (same checkout) — re-deriving crate set");
+            println!(
+                "Refreshing active link to {} (re-deriving overrides).",
+                checkout.display()
+            );
+            unlink(&consumer_root)?;
+        } else {
+            return Err(LinkError::AlreadyLinkedElsewhere {
+                active: existing.checkout,
+                requested: checkout,
+            });
+        }
+    }
+
+    let index_url = discover_registry_index(&consumer_root)?;
+    let crates = derive_linkable_crates(&checkout)?;
+    if crates.is_empty() {
+        return Err(LinkError::CrateSetDerivation {
+            checkout: checkout.clone(),
+            detail: "no workspace members matched the streamlib linkable set".into(),
+        });
+    }
+
+    let edits = plan_edits(&consumer_root, &checkout, &index_url, &crates)?;
+    let touched = apply_transaction(&consumer_root, &edits)?;
+
+    write_manifest(
+        &consumer_root,
+        &LinkManifest {
+            checkout: checkout.clone(),
+            linked_at: chrono::Utc::now().to_rfc3339(),
+            linked_crate_count: crates.len(),
+            files: touched,
+        },
+    )?;
+
+    println!("Linked streamlib → {}", checkout.display());
+    println!("  Cargo crates redirected: {}", crates.len());
+    for edit in &edits {
+        println!("  Overrode: {}", edit.rel_path.display());
+    }
+    println!("Run `streamlib unlink` to restore.");
+    Ok(())
+}
+
+/// Tear down the active link, restoring every touched manifest byte-identically.
+#[tracing::instrument(skip_all, fields(consumer_root = %consumer_root.display()))]
+pub fn unlink(consumer_root: &Path) -> Result<(), LinkError> {
+    let consumer_root = consumer_root
+        .canonicalize()
+        .map_err(|e| LinkError::io(consumer_root, e))?;
+
+    let manifest = match load_active_manifest(&consumer_root)? {
+        Some(m) => m,
+        None => {
+            println!("No active streamlib link — nothing to do.");
+            return Ok(());
+        }
+    };
+
+    let state_dir = consumer_root.join(LINK_STATE_DIR);
+    let backup_dir = state_dir.join(LINK_BACKUP_DIR);
+
+    // Restore in reverse apply order so partial states unwind predictably.
+    for tf in manifest.files.iter().rev() {
+        let abs = consumer_root.join(&tf.path);
+        if tf.existed_before {
+            let backup = backup_dir.join(&tf.path);
+            let bytes = std::fs::read(&backup).map_err(|e| LinkError::io(&backup, e))?;
+            std::fs::write(&abs, &bytes).map_err(|e| LinkError::io(&abs, e))?;
+        } else {
+            // We created this file — remove it, then prune any now-empty parent
+            // dirs we introduced (e.g. `.cargo/`), up to the consumer root.
+            if abs.exists() {
+                std::fs::remove_file(&abs).map_err(|e| LinkError::io(&abs, e))?;
+            }
+            prune_empty_parents(&abs, &consumer_root);
+        }
+    }
+
+    std::fs::remove_dir_all(&state_dir).map_err(|e| LinkError::io(&state_dir, e))?;
+    println!("Unlinked streamlib — {} file(s) restored.", manifest.files.len());
+    Ok(())
+}
+
+/// Print the active link status (or that none is active).
+#[tracing::instrument(skip_all, fields(consumer_root = %consumer_root.display()))]
+pub fn status(consumer_root: &Path) -> Result<(), LinkError> {
+    let consumer_root = consumer_root
+        .canonicalize()
+        .map_err(|e| LinkError::io(consumer_root, e))?;
+    match load_active_manifest(&consumer_root)? {
+        None => println!("No active streamlib link."),
+        Some(m) => {
+            println!("streamlib linked → {}", m.checkout.display());
+            println!("  Linked at: {}", m.linked_at);
+            println!("  Cargo crates redirected: {}", m.linked_crate_count);
+            for tf in &m.files {
+                println!("  Overrode: {}", tf.path.display());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Walk up from `start` to the filesystem root looking for an active link
+/// marker (`.streamlib/link.json`). Returns the marker path when found.
+pub fn find_active_link_marker(start: &Path) -> Option<PathBuf> {
+    let mut dir = Some(start);
+    while let Some(d) = dir {
+        let marker = d.join(LINK_STATE_DIR).join(LINK_MANIFEST_FILE);
+        if marker.is_file() {
+            return Some(marker);
+        }
+        dir = d.parent();
+    }
+    None
+}
+
+/// Refuse a pack/publish while a link is active anywhere above `package_dir`.
+pub fn ensure_no_active_link_for_pack(package_dir: &Path) -> Result<(), LinkError> {
+    if let Some(marker) = find_active_link_marker(package_dir) {
+        return Err(LinkError::PackRefusedWhileLinked { marker });
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+fn canonicalize_checkout(checkout: &Path) -> Result<PathBuf, LinkError> {
+    let canonical = checkout
+        .canonicalize()
+        .map_err(|_| LinkError::NotAStreamlibCheckout(checkout.to_path_buf()))?;
+    if !canonical.join("Cargo.toml").is_file() {
+        return Err(LinkError::NotAStreamlibCheckout(canonical));
+    }
+    Ok(canonical)
+}
+
+/// Load the active link manifest from `consumer_root/.streamlib/link.json`.
+fn load_active_manifest(consumer_root: &Path) -> Result<Option<LinkManifest>, LinkError> {
+    let path = consumer_root
+        .join(LINK_STATE_DIR)
+        .join(LINK_MANIFEST_FILE);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let body = std::fs::read_to_string(&path).map_err(|e| LinkError::io(&path, e))?;
+    let manifest: LinkManifest = serde_json::from_str(&body).map_err(|e| {
+        LinkError::CorruptLinkState {
+            path: path.clone(),
+            detail: e.to_string(),
+        }
+    })?;
+    Ok(Some(manifest))
+}
+
+fn write_manifest(consumer_root: &Path, manifest: &LinkManifest) -> Result<(), LinkError> {
+    let state_dir = consumer_root.join(LINK_STATE_DIR);
+    std::fs::create_dir_all(&state_dir).map_err(|e| LinkError::io(&state_dir, e))?;
+    let path = state_dir.join(LINK_MANIFEST_FILE);
+    let body = serde_json::to_string_pretty(manifest).map_err(|e| LinkError::CorruptLinkState {
+        path: path.clone(),
+        detail: e.to_string(),
+    })?;
+    std::fs::write(&path, body).map_err(|e| LinkError::io(&path, e))
+}
+
+/// Discover the consumer's effective `[registries.gitea].index` string the way
+/// cargo does: closest `.cargo/config.toml` (walking up) wins, then
+/// `~/.cargo/config.toml`.
+fn discover_registry_index(consumer_root: &Path) -> Result<String, LinkError> {
+    let mut dir = Some(consumer_root);
+    while let Some(d) = dir {
+        for name in [".cargo/config.toml", ".cargo/config"] {
+            let candidate = d.join(name);
+            if let Some(idx) = read_gitea_index(&candidate)? {
+                return Ok(idx);
+            }
+        }
+        dir = d.parent();
+    }
+    if let Some(home) = dirs::home_dir() {
+        for name in [".cargo/config.toml", ".cargo/config"] {
+            if let Some(idx) = read_gitea_index(&home.join(name))? {
+                return Ok(idx);
+            }
+        }
+    }
+    Err(LinkError::RegistryIndexNotConfigured)
+}
+
+/// Read `registries.gitea.index` from a cargo config file, if present.
+fn read_gitea_index(path: &Path) -> Result<Option<String>, LinkError> {
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let body = std::fs::read_to_string(path).map_err(|e| LinkError::io(path, e))?;
+    let doc: toml::Value = toml::from_str(&body).map_err(|e| LinkError::ManifestParse {
+        path: path.to_path_buf(),
+        detail: e.to_string(),
+    })?;
+    Ok(doc
+        .get("registries")
+        .and_then(|r| r.get("gitea"))
+        .and_then(|g| g.get("index"))
+        .and_then(|i| i.as_str())
+        .map(|s| s.to_string()))
+}
+
+/// Derive the linkable crate set (`name` → checkout-relative member dir) from
+/// the checkout live via `cargo metadata` — same selection as the publish
+/// closure with `STREAMLIB_PUBLISH_ALL_LIBS=1`: every workspace member whose
+/// name starts with `streamlib` (or is `vulkan-jpeg`), that produces a library
+/// target and is publishable.
+fn derive_linkable_crates(checkout: &Path) -> Result<BTreeMap<String, PathBuf>, LinkError> {
+    let manifest_path = checkout.join("Cargo.toml");
+    let output = std::process::Command::new("cargo")
+        .args(["metadata", "--format-version", "1", "--no-deps", "--manifest-path"])
+        .arg(&manifest_path)
+        .output()
+        .map_err(|e| LinkError::CrateSetDerivation {
+            checkout: checkout.to_path_buf(),
+            detail: format!("failed to run cargo metadata: {e}"),
+        })?;
+    if !output.status.success() {
+        return Err(LinkError::CrateSetDerivation {
+            checkout: checkout.to_path_buf(),
+            detail: format!(
+                "cargo metadata failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+        });
+    }
+    let md: serde_json::Value =
+        serde_json::from_slice(&output.stdout).map_err(|e| LinkError::CrateSetDerivation {
+            checkout: checkout.to_path_buf(),
+            detail: format!("cargo metadata is not valid JSON: {e}"),
+        })?;
+
+    let members: std::collections::HashSet<&str> = md
+        .get("workspace_members")
+        .and_then(|m| m.as_array())
+        .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+
+    let mut crates = BTreeMap::new();
+    let empty = Vec::new();
+    let packages = md
+        .get("packages")
+        .and_then(|p| p.as_array())
+        .unwrap_or(&empty);
+    for pkg in packages {
+        let id = pkg.get("id").and_then(|v| v.as_str()).unwrap_or_default();
+        if !members.contains(id) {
+            continue;
+        }
+        let name = pkg.get("name").and_then(|v| v.as_str()).unwrap_or_default();
+        if !(name.starts_with("streamlib") || name == "vulkan-jpeg") {
+            continue;
+        }
+        // `publish == []` ⇒ publish = false ⇒ not a linkable SDK crate.
+        if pkg.get("publish").and_then(|v| v.as_array()).is_some_and(|a| a.is_empty()) {
+            continue;
+        }
+        if !has_library_target(pkg) {
+            continue;
+        }
+        let manifest = pkg
+            .get("manifest_path")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        if let Some(dir) = Path::new(manifest).parent() {
+            crates.insert(name.to_string(), dir.to_path_buf());
+        }
+    }
+    Ok(crates)
+}
+
+fn has_library_target(pkg: &serde_json::Value) -> bool {
+    const LIB_KINDS: &[&str] = &["lib", "rlib", "cdylib", "proc-macro", "dylib", "staticlib"];
+    pkg.get("targets")
+        .and_then(|t| t.as_array())
+        .is_some_and(|targets| {
+            targets.iter().any(|t| {
+                t.get("kind")
+                    .and_then(|k| k.as_array())
+                    .is_some_and(|kinds| {
+                        kinds
+                            .iter()
+                            .filter_map(|k| k.as_str())
+                            .any(|k| LIB_KINDS.contains(&k))
+                    })
+            })
+        })
+}
+
+/// Compute every planned edit (cargo config always; pyproject / deno.json only
+/// when the consumer has one).
+fn plan_edits(
+    consumer_root: &Path,
+    checkout: &Path,
+    index_url: &str,
+    crates: &BTreeMap<String, PathBuf>,
+) -> Result<Vec<PlannedEdit>, LinkError> {
+    let mut edits = Vec::new();
+
+    // 1. Cargo config `[patch."<index>"]` — always emitted.
+    edits.push(plan_cargo_config_edit(consumer_root, index_url, crates)?);
+
+    // 2. Python SDK via `[tool.uv.sources]` — only when the consumer has a pyproject.
+    let pyproject = consumer_root.join("pyproject.toml");
+    if pyproject.is_file() {
+        edits.push(plan_pyproject_edit(&pyproject, consumer_root, checkout)?);
+    }
+
+    // 3. Deno SDK import rewrite — only when the consumer has a deno.json(c).
+    for name in ["deno.json", "deno.jsonc"] {
+        let deno = consumer_root.join(name);
+        if deno.is_file() {
+            edits.push(plan_deno_edit(&deno, consumer_root, checkout)?);
+            break;
+        }
+    }
+
+    Ok(edits)
+}
+
+fn plan_cargo_config_edit(
+    consumer_root: &Path,
+    index_url: &str,
+    crates: &BTreeMap<String, PathBuf>,
+) -> Result<PlannedEdit, LinkError> {
+    let abs_path = consumer_root.join(".cargo").join("config.toml");
+    let rel_path = PathBuf::from(".cargo").join("config.toml");
+    let original = read_optional_bytes(&abs_path)?;
+
+    let existing = match &original {
+        Some(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        None => String::new(),
+    };
+    let mut doc: toml_edit::DocumentMut =
+        existing.parse().map_err(|e: toml_edit::TomlError| LinkError::ManifestParse {
+            path: abs_path.clone(),
+            detail: e.to_string(),
+        })?;
+
+    // Build `[patch."<index>"]` with one path entry per crate. `patch` is an
+    // implicit parent table so only the `[patch."url"]` header is emitted.
+    let mut patch_target = toml_edit::Table::new();
+    for (name, dir) in crates {
+        let mut entry = toml_edit::InlineTable::new();
+        entry.insert("path", toml_edit::Value::from(dir.to_string_lossy().into_owned()));
+        patch_target.insert(name, toml_edit::Item::Value(toml_edit::Value::InlineTable(entry)));
+    }
+    patch_target
+        .decor_mut()
+        .set_prefix(format!("\n{CARGO_PATCH_MARKER}\n"));
+
+    if !doc.contains_key("patch") {
+        let mut patch = toml_edit::Table::new();
+        patch.set_implicit(true);
+        doc.insert("patch", toml_edit::Item::Table(patch));
+    }
+    doc["patch"][index_url] = toml_edit::Item::Table(patch_target);
+
+    Ok(PlannedEdit {
+        rel_path,
+        abs_path,
+        new_content: doc.to_string(),
+        original,
+    })
+}
+
+fn plan_pyproject_edit(
+    pyproject: &Path,
+    consumer_root: &Path,
+    checkout: &Path,
+) -> Result<PlannedEdit, LinkError> {
+    let original = read_optional_bytes(pyproject)?;
+    let existing = match &original {
+        Some(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        None => String::new(),
+    };
+    let mut doc: toml_edit::DocumentMut =
+        existing.parse().map_err(|e: toml_edit::TomlError| LinkError::ManifestParse {
+            path: pyproject.to_path_buf(),
+            detail: e.to_string(),
+        })?;
+
+    // [tool.uv.sources] streamlib = { path = "<checkout>/libs/streamlib-python", editable = true }
+    let sdk_path = checkout.join(PYTHON_SDK_REL);
+    let mut source = toml_edit::InlineTable::new();
+    source.insert(
+        "path",
+        toml_edit::Value::from(sdk_path.to_string_lossy().into_owned()),
+    );
+    source.insert("editable", toml_edit::Value::from(true));
+
+    ensure_table(&mut doc, "tool");
+    ensure_subtable(doc["tool"].as_table_mut().unwrap(), "uv");
+    let uv = doc["tool"]["uv"].as_table_mut().unwrap();
+    ensure_subtable(uv, "sources");
+    uv["sources"]["streamlib"] = toml_edit::Item::Value(toml_edit::Value::InlineTable(source));
+
+    Ok(PlannedEdit {
+        rel_path: rel_of(pyproject, consumer_root),
+        abs_path: pyproject.to_path_buf(),
+        new_content: doc.to_string(),
+        original,
+    })
+}
+
+fn plan_deno_edit(
+    deno: &Path,
+    consumer_root: &Path,
+    checkout: &Path,
+) -> Result<PlannedEdit, LinkError> {
+    let original = read_optional_bytes(deno)?;
+    let body = match &original {
+        Some(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        None => String::new(),
+    };
+    let mut value: serde_json::Value =
+        serde_json::from_str(&body).map_err(|e| LinkError::ManifestParse {
+            path: deno.to_path_buf(),
+            detail: format!(
+                "{e} (deno.jsonc with comments is not supported for link override; use plain JSON)"
+            ),
+        })?;
+    if !value.is_object() {
+        value = serde_json::json!({});
+    }
+    let entry = checkout.join(DENO_SDK_ENTRYPOINT_REL);
+    let obj = value.as_object_mut().unwrap();
+    let imports = obj
+        .entry("imports")
+        .or_insert_with(|| serde_json::json!({}));
+    if !imports.is_object() {
+        *imports = serde_json::json!({});
+    }
+    imports.as_object_mut().unwrap().insert(
+        "streamlib".to_string(),
+        serde_json::Value::String(entry.to_string_lossy().into_owned()),
+    );
+
+    let mut new_content = serde_json::to_string_pretty(&value).map_err(|e| {
+        LinkError::ManifestParse {
+            path: deno.to_path_buf(),
+            detail: e.to_string(),
+        }
+    })?;
+    new_content.push('\n');
+
+    Ok(PlannedEdit {
+        rel_path: rel_of(deno, consumer_root),
+        abs_path: deno.to_path_buf(),
+        new_content,
+        original,
+    })
+}
+
+/// Apply every planned edit transactionally: back up pre-existing files, write
+/// the new content, and roll back all applied edits on any failure.
+fn apply_transaction(
+    consumer_root: &Path,
+    edits: &[PlannedEdit],
+) -> Result<Vec<TouchedFile>, LinkError> {
+    let backup_dir = consumer_root.join(LINK_STATE_DIR).join(LINK_BACKUP_DIR);
+    std::fs::create_dir_all(&backup_dir).map_err(|e| LinkError::io(&backup_dir, e))?;
+
+    let mut applied: Vec<&PlannedEdit> = Vec::new();
+    let mut touched: Vec<TouchedFile> = Vec::new();
+
+    for edit in edits {
+        let result = (|| -> Result<(), LinkError> {
+            if let Some(orig) = &edit.original {
+                let backup = backup_dir.join(&edit.rel_path);
+                if let Some(parent) = backup.parent() {
+                    std::fs::create_dir_all(parent).map_err(|e| LinkError::io(parent, e))?;
+                }
+                std::fs::write(&backup, orig).map_err(|e| LinkError::io(&backup, e))?;
+            }
+            if let Some(parent) = edit.abs_path.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| LinkError::io(parent, e))?;
+            }
+            std::fs::write(&edit.abs_path, &edit.new_content)
+                .map_err(|e| LinkError::io(&edit.abs_path, e))
+        })();
+
+        if let Err(e) = result {
+            rollback(&applied);
+            let state_dir = consumer_root.join(LINK_STATE_DIR);
+            let _ = std::fs::remove_dir_all(&state_dir);
+            return Err(e);
+        }
+
+        touched.push(TouchedFile {
+            path: edit.rel_path.clone(),
+            existed_before: edit.original.is_some(),
+            pre_edit_sha256: edit
+                .original
+                .as_ref()
+                .map(|b| hex_sha256(b))
+                .unwrap_or_default(),
+        });
+        applied.push(edit);
+    }
+
+    Ok(touched)
+}
+
+/// Undo applied edits in reverse order: restore originals, delete created files.
+fn rollback(applied: &[&PlannedEdit]) {
+    for edit in applied.iter().rev() {
+        match &edit.original {
+            Some(orig) => {
+                let _ = std::fs::write(&edit.abs_path, orig);
+            }
+            None => {
+                let _ = std::fs::remove_file(&edit.abs_path);
+            }
+        }
+    }
+}
+
+/// Remove now-empty parent directories of `removed_file` up to (but excluding)
+/// `stop_at`. Best-effort — a non-empty dir halts the walk.
+fn prune_empty_parents(removed_file: &Path, stop_at: &Path) {
+    let mut dir = removed_file.parent();
+    while let Some(d) = dir {
+        if d == stop_at || !d.starts_with(stop_at) {
+            break;
+        }
+        // `remove_dir` only succeeds on an empty directory.
+        if std::fs::remove_dir(d).is_err() {
+            break;
+        }
+        dir = d.parent();
+    }
+}
+
+fn read_optional_bytes(path: &Path) -> Result<Option<Vec<u8>>, LinkError> {
+    match std::fs::read(path) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(LinkError::io(path, e)),
+    }
+}
+
+fn rel_of(abs: &Path, root: &Path) -> PathBuf {
+    abs.strip_prefix(root).unwrap_or(abs).to_path_buf()
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut s = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+fn ensure_table(doc: &mut toml_edit::DocumentMut, key: &str) {
+    if !doc.contains_key(key) {
+        doc.insert(key, toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+}
+
+fn ensure_subtable(table: &mut toml_edit::Table, key: &str) {
+    if !table.contains_key(key) {
+        table.insert(key, toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/libs/streamlib-cli/src/commands/link.rs
+++ b/libs/streamlib-cli/src/commands/link.rs
@@ -1,27 +1,17 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! `streamlib link` / `streamlib unlink` — whole-tree local dev override.
-//!
-//! Points the entire streamlib surface a consumer resolves (all SDK cargo
-//! crates + the Python SDK + the Deno SDK) at a local streamlib checkout via
-//! language-native overrides, so an edit in the checkout is picked up by the
-//! consumer's next build with no publish step. `unlink` restores every touched
-//! manifest byte-identically. Emission is whole-tree and transactional: either
-//! all overrides land or none do.
+//! `streamlib link` / `streamlib unlink` — whole-tree local checkout override.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use streamlib_pack::link_marker::{
+    LinkManifest, LinkMarkerError, LinkTransactionState, LinkedManifestFile, LINK_BACKUP_DIR,
+    LINK_MANIFEST_FILE, LINK_STATE_DIR,
+};
 
-/// Consumer-root-relative directory holding all link state.
-const LINK_STATE_DIR: &str = ".streamlib";
-/// Manifest recording the active link (checkout + every touched file).
-const LINK_MANIFEST_FILE: &str = "link.json";
-/// Directory under [`LINK_STATE_DIR`] mirroring pre-edit backups by relative path.
-const LINK_BACKUP_DIR: &str = "link-backup";
 /// Human-facing greppability marker on the emitted cargo `[patch]` block.
 const CARGO_PATCH_MARKER: &str =
     "# streamlib-link — managed by `streamlib link`; removed by `streamlib unlink`";
@@ -44,6 +34,20 @@ pub enum LinkError {
     )]
     AlreadyLinkedElsewhere { active: PathBuf, requested: PathBuf },
 
+    /// A previous link run crashed mid-apply and left torn state behind.
+    #[error(
+        "a previous `streamlib link` was interrupted mid-apply (marker: {path}); run \
+         `streamlib unlink` to restore before linking again"
+    )]
+    TornLinkState { path: PathBuf },
+
+    /// The link marker already exists at creation time (concurrent link run).
+    #[error(
+        "link state already exists at `{path}` — another `streamlib link` may be running \
+         concurrently, or a previous link was interrupted; run `streamlib unlink` first"
+    )]
+    LinkMarkerAlreadyExists { path: PathBuf },
+
     /// No `[registries.gitea].index` is discoverable from the consumer's cargo config.
     #[error(
         "no `[registries.gitea]` registry index found in this consumer's cargo config (looked in \
@@ -60,17 +64,33 @@ pub enum LinkError {
     #[error("failed to parse `{path}`: {detail}")]
     ManifestParse { path: PathBuf, detail: String },
 
-    /// The recorded link manifest is corrupt / unreadable.
+    /// The recorded link manifest / a backup is corrupt.
     #[error("link state at `{path}` is corrupt: {detail}")]
     CorruptLinkState { path: PathBuf, detail: String },
 
-    /// A pack/publish was attempted while a link is active.
+    /// Unlink found a file the user modified while the link was active.
     #[error(
-        "this package cannot be packed or published while a streamlib link is active (marker: \
-         {marker}). Local link overrides are dev-only and must not leak into a distributed \
-         artifact — run `streamlib unlink` first"
+        "`{path}` was modified while the link was active; refusing to clobber it — re-apply your \
+         edit after unlinking, or run `streamlib unlink --force` to discard it and restore the \
+         pre-link original"
     )]
-    PackRefusedWhileLinked { marker: PathBuf },
+    UnlinkRefusedModifiedFile { path: PathBuf },
+
+    /// A rollback after a failed link could not restore every file.
+    #[error(
+        "link failed and rollback could not restore every file; originals are preserved under \
+         `{backup_dir}` — resolve the filesystem issue and run `streamlib unlink` to finish \
+         restoring. {detail}"
+    )]
+    RollbackIncomplete { backup_dir: PathBuf, detail: String },
+
+    /// Post-link cargo resolution check failed; the link was rolled back.
+    #[error(
+        "post-link verification failed and the link was rolled back: {detail}. Fix the \
+         consumer's version requirements so the checkout's crate versions satisfy them, or \
+         re-run with `--skip-verify` to keep the link unverified"
+    )]
+    LinkVerificationFailed { detail: String },
 
     /// A filesystem operation failed.
     #[error("filesystem error at `{path}`: {source}")]
@@ -90,28 +110,23 @@ impl LinkError {
     }
 }
 
-/// One manifest file the active link overrode, recorded for byte-clean teardown.
-#[derive(Debug, Serialize, Deserialize)]
-struct TouchedFile {
-    /// Path relative to the consumer root.
-    path: PathBuf,
-    /// Whether the file existed before linking. `false` ⇒ unlink deletes it.
-    existed_before: bool,
-    /// Hex SHA-256 of the pre-edit content (empty when `!existed_before`).
-    pre_edit_sha256: String,
-}
-
-/// Persisted record of the active whole-tree link.
-#[derive(Debug, Serialize, Deserialize)]
-struct LinkManifest {
-    /// Canonicalized path of the linked streamlib checkout.
-    checkout: PathBuf,
-    /// RFC-3339 timestamp of when the link was established.
-    linked_at: String,
-    /// Number of cargo crates redirected to the checkout.
-    linked_crate_count: usize,
-    /// Every manifest file the link touched (in apply order).
-    files: Vec<TouchedFile>,
+impl From<LinkMarkerError> for LinkError {
+    fn from(e: LinkMarkerError) -> Self {
+        match e {
+            LinkMarkerError::CorruptLinkState { path, detail } => {
+                LinkError::CorruptLinkState { path, detail }
+            }
+            LinkMarkerError::Io { path, source } => LinkError::Io { path, source },
+            LinkMarkerError::PackRefusedWhileLinked { marker } => {
+                // Not produced by link/unlink flows; map to corrupt-state shape
+                // for completeness.
+                LinkError::CorruptLinkState {
+                    path: marker,
+                    detail: "unexpected pack refusal in link flow".to_string(),
+                }
+            }
+        }
+    }
 }
 
 /// A computed manifest edit, not yet applied.
@@ -128,30 +143,32 @@ struct PlannedEdit {
 }
 
 /// Establish (or refresh) a whole-tree link from `consumer_root` to `checkout`.
-#[tracing::instrument(skip_all, fields(consumer_root = %consumer_root.display(), checkout = %checkout.display()))]
-pub fn link(consumer_root: &Path, checkout: &Path) -> Result<(), LinkError> {
+#[tracing::instrument(skip_all, fields(consumer_root = %consumer_root.display(), checkout = %checkout.display(), skip_verify))]
+pub fn link(consumer_root: &Path, checkout: &Path, skip_verify: bool) -> Result<(), LinkError> {
     let checkout = canonicalize_checkout(checkout)?;
     let consumer_root = consumer_root
         .canonicalize()
         .map_err(|e| LinkError::io(consumer_root, e))?;
 
-    // Idempotency: identical checkout ⇒ refresh; different checkout ⇒ refuse.
-    if let Some(existing) = load_active_manifest(&consumer_root)? {
-        if existing.checkout == checkout {
-            tracing::info!("refreshing existing link (same checkout) — re-deriving crate set");
-            println!(
-                "Refreshing active link to {} (re-deriving overrides).",
-                checkout.display()
-            );
-            unlink(&consumer_root)?;
-        } else {
+    // Idempotency gates: different checkout ⇒ refuse; torn state ⇒ point at
+    // `unlink`; identical active checkout ⇒ refresh (below).
+    let existing = load_active_manifest(&consumer_root)?;
+    if let Some(m) = &existing {
+        if m.checkout != checkout {
             return Err(LinkError::AlreadyLinkedElsewhere {
-                active: existing.checkout,
+                active: m.checkout.clone(),
                 requested: checkout,
+            });
+        }
+        if m.state == LinkTransactionState::Applying {
+            return Err(LinkError::TornLinkState {
+                path: consumer_root.join(LINK_STATE_DIR).join(LINK_MANIFEST_FILE),
             });
         }
     }
 
+    // Derive everything failure-prone BEFORE tearing down an existing link, so
+    // a failed derivation preserves the working link on a refresh.
     let index_url = discover_registry_index(&consumer_root)?;
     let crates = derive_linkable_crates(&checkout)?;
     if crates.is_empty() {
@@ -161,32 +178,58 @@ pub fn link(consumer_root: &Path, checkout: &Path) -> Result<(), LinkError> {
         });
     }
 
-    let edits = plan_edits(&consumer_root, &checkout, &index_url, &crates)?;
-    let touched = apply_transaction(&consumer_root, &edits)?;
+    if existing.is_some() {
+        tracing::info!("refreshing existing link (same checkout) — re-deriving crate set");
+        println!(
+            "Refreshing active link to {} (re-deriving overrides).",
+            checkout.display()
+        );
+        unlink(&consumer_root, false)?;
+    }
 
-    // Persisting the manifest is the final transactional step: if it fails, the
-    // overrides are already on disk, so roll them all back and clear the link
-    // state — the all-or-nothing contract holds through this step too.
-    let manifest = LinkManifest {
-        checkout: checkout.clone(),
-        linked_at: chrono::Utc::now().to_rfc3339(),
-        linked_crate_count: crates.len(),
-        files: touched,
-    };
-    finalize_link(&consumer_root, &edits, &manifest)?;
+    let edits = establish_link(&consumer_root, &checkout, &index_url, &crates)?;
 
     println!("Linked streamlib → {}", checkout.display());
     println!("  Cargo crates redirected: {}", crates.len());
     for edit in &edits {
         println!("  Overrode: {}", edit.rel_path.display());
     }
+
+    // Post-link verification: prove the [patch] actually took effect in the
+    // consumer's cargo resolution. A semver-incompatible consumer requirement
+    // makes cargo silently ignore the patch — roll the whole link back rather
+    // than leave a "linked" tree that still resolves from the registry.
+    if skip_verify {
+        println!("  Verification skipped (--skip-verify).");
+    } else if let Err(detail) = verify_cargo_patch_resolution(&consumer_root, &checkout, &crates) {
+        unlink(&consumer_root, false)?;
+        return Err(LinkError::LinkVerificationFailed { detail });
+    } else if consumer_root.join("Cargo.toml").is_file() {
+        // Count is re-derived inside the verify; recompute cheaply for the
+        // success message.
+        println!("  Verified: streamlib crates resolve to the checkout via cargo metadata.");
+    }
+
     println!("Run `streamlib unlink` to restore.");
     Ok(())
 }
 
+/// The teardown action pass 1 of `unlink` decides for one touched file.
+enum RestoreAction {
+    /// Live content already matches the pre-link original — nothing to do.
+    Skip,
+    /// Write the (hash-verified) backup bytes back over the live file.
+    RestoreOriginal(Vec<u8>),
+    /// Delete a file the link created, then prune empty parents.
+    RemoveCreated,
+}
+
 /// Tear down the active link, restoring every touched manifest byte-identically.
-#[tracing::instrument(skip_all, fields(consumer_root = %consumer_root.display()))]
-pub fn unlink(consumer_root: &Path) -> Result<(), LinkError> {
+///
+/// Recovers torn (`applying`) state from a crashed link run. Refuses to
+/// clobber a file the user modified while the link was active unless `force`.
+#[tracing::instrument(skip_all, fields(consumer_root = %consumer_root.display(), force))]
+pub fn unlink(consumer_root: &Path, force: bool) -> Result<(), LinkError> {
     let consumer_root = consumer_root
         .canonicalize()
         .map_err(|e| LinkError::io(consumer_root, e))?;
@@ -202,39 +245,74 @@ pub fn unlink(consumer_root: &Path) -> Result<(), LinkError> {
     let state_dir = consumer_root.join(LINK_STATE_DIR);
     let backup_dir = state_dir.join(LINK_BACKUP_DIR);
 
-    // Restore in reverse apply order so partial states unwind predictably.
+    // Pass 1 — classify every file (tri-state per file) and verify every
+    // needed backup BEFORE mutating anything, so a refusal or a corrupt
+    // backup leaves the tree untouched.
+    let mut actions: Vec<(&LinkedManifestFile, RestoreAction)> = Vec::new();
     for tf in manifest.files.iter().rev() {
         let abs = consumer_root.join(&tf.path);
-        if tf.existed_before {
-            let backup = backup_dir.join(&tf.path);
-            let bytes = std::fs::read(&backup).map_err(|e| LinkError::io(&backup, e))?;
-            // Integrity guard: the backup must still hash to the value recorded
-            // when the link was established. A mismatch means the backup was
-            // corrupted/tampered — refuse to restore wrong bytes over the
-            // consumer's file rather than silently clobber it.
-            if hex_sha256(&bytes) != tf.pre_edit_sha256 {
-                return Err(LinkError::CorruptLinkState {
-                    path: backup.clone(),
-                    detail: format!(
-                        "backup content hash does not match the pre-edit hash recorded for `{}`; \
-                         refusing to restore a corrupted backup",
-                        tf.path.display()
-                    ),
-                });
+        let live = read_optional_bytes(&abs)?;
+        let live_hash = live.as_deref().map(hex_sha256);
+
+        let action = if tf.existed_before {
+            if live_hash.as_deref() == Some(tf.pre_edit_sha256.as_str()) {
+                // Already the original (e.g. crash before this edit applied).
+                RestoreAction::Skip
+            } else {
+                let is_linked_content =
+                    live_hash.as_deref() == Some(tf.post_edit_sha256.as_str());
+                if !(live.is_none() || is_linked_content || force) {
+                    return Err(LinkError::UnlinkRefusedModifiedFile { path: abs.clone() });
+                }
+                let backup = backup_dir.join(&tf.path);
+                let bytes = std::fs::read(&backup).map_err(|e| LinkError::io(&backup, e))?;
+                // Integrity guard: the backup must still hash to the value
+                // recorded at link time — never restore corrupted bytes.
+                if hex_sha256(&bytes) != tf.pre_edit_sha256 {
+                    return Err(LinkError::CorruptLinkState {
+                        path: backup.clone(),
+                        detail: format!(
+                            "backup content hash does not match the pre-edit hash recorded for \
+                             `{}`; refusing to restore a corrupted backup",
+                            tf.path.display()
+                        ),
+                    });
+                }
+                RestoreAction::RestoreOriginal(bytes)
             }
-            std::fs::write(&abs, &bytes).map_err(|e| LinkError::io(&abs, e))?;
         } else {
-            // We created this file — remove it, then prune any now-empty parent
-            // dirs we introduced (e.g. `.cargo/`), up to the consumer root.
-            if abs.exists() {
-                std::fs::remove_file(&abs).map_err(|e| LinkError::io(&abs, e))?;
+            match live_hash.as_deref() {
+                None => RestoreAction::Skip,
+                Some(h) if h == tf.post_edit_sha256 => RestoreAction::RemoveCreated,
+                Some(_) if force => RestoreAction::RemoveCreated,
+                Some(_) => {
+                    return Err(LinkError::UnlinkRefusedModifiedFile { path: abs.clone() });
+                }
             }
-            prune_empty_parents(&abs, &consumer_root);
+        };
+        actions.push((tf, action));
+    }
+
+    // Pass 2 — apply the restores (already in reverse apply order).
+    let mut restored = 0usize;
+    for (tf, action) in actions {
+        let abs = consumer_root.join(&tf.path);
+        match action {
+            RestoreAction::Skip => {}
+            RestoreAction::RestoreOriginal(bytes) => {
+                std::fs::write(&abs, &bytes).map_err(|e| LinkError::io(&abs, e))?;
+                restored += 1;
+            }
+            RestoreAction::RemoveCreated => {
+                std::fs::remove_file(&abs).map_err(|e| LinkError::io(&abs, e))?;
+                prune_empty_parents(&abs, &consumer_root);
+                restored += 1;
+            }
         }
     }
 
     std::fs::remove_dir_all(&state_dir).map_err(|e| LinkError::io(&state_dir, e))?;
-    println!("Unlinked streamlib — {} file(s) restored.", manifest.files.len());
+    println!("Unlinked streamlib — {restored} file(s) restored.");
     Ok(())
 }
 
@@ -249,33 +327,19 @@ pub fn status(consumer_root: &Path) -> Result<(), LinkError> {
         Some(m) => {
             println!("streamlib linked → {}", m.checkout.display());
             println!("  Linked at: {}", m.linked_at);
+            println!(
+                "  State: {}",
+                match m.state {
+                    LinkTransactionState::Active => "active",
+                    LinkTransactionState::Applying =>
+                        "applying (torn — run `streamlib unlink` to restore)",
+                }
+            );
             println!("  Cargo crates redirected: {}", m.linked_crate_count);
             for tf in &m.files {
                 println!("  Overrode: {}", tf.path.display());
             }
         }
-    }
-    Ok(())
-}
-
-/// Walk up from `start` to the filesystem root looking for an active link
-/// marker (`.streamlib/link.json`). Returns the marker path when found.
-pub fn find_active_link_marker(start: &Path) -> Option<PathBuf> {
-    let mut dir = Some(start);
-    while let Some(d) = dir {
-        let marker = d.join(LINK_STATE_DIR).join(LINK_MANIFEST_FILE);
-        if marker.is_file() {
-            return Some(marker);
-        }
-        dir = d.parent();
-    }
-    None
-}
-
-/// Refuse a pack/publish while a link is active anywhere above `package_dir`.
-pub fn ensure_no_active_link_for_pack(package_dir: &Path) -> Result<(), LinkError> {
-    if let Some(marker) = find_active_link_marker(package_dir) {
-        return Err(LinkError::PackRefusedWhileLinked { marker });
     }
     Ok(())
 }
@@ -294,7 +358,7 @@ fn canonicalize_checkout(checkout: &Path) -> Result<PathBuf, LinkError> {
     Ok(canonical)
 }
 
-/// Load the active link manifest from `consumer_root/.streamlib/link.json`.
+/// Load the link manifest from `consumer_root/.streamlib/link.json` (any state).
 fn load_active_manifest(consumer_root: &Path) -> Result<Option<LinkManifest>, LinkError> {
     let path = consumer_root
         .join(LINK_STATE_DIR)
@@ -302,31 +366,63 @@ fn load_active_manifest(consumer_root: &Path) -> Result<Option<LinkManifest>, Li
     if !path.is_file() {
         return Ok(None);
     }
-    let body = std::fs::read_to_string(&path).map_err(|e| LinkError::io(&path, e))?;
-    let manifest: LinkManifest = serde_json::from_str(&body).map_err(|e| {
-        LinkError::CorruptLinkState {
-            path: path.clone(),
-            detail: e.to_string(),
-        }
-    })?;
-    Ok(Some(manifest))
+    Ok(Some(streamlib_pack::link_marker::load_link_manifest(
+        &path,
+    )?))
 }
 
-fn write_manifest(consumer_root: &Path, manifest: &LinkManifest) -> Result<(), LinkError> {
+fn manifest_json(manifest: &LinkManifest, path: &Path) -> Result<String, LinkError> {
+    serde_json::to_string_pretty(manifest).map_err(|e| LinkError::CorruptLinkState {
+        path: path.to_path_buf(),
+        detail: e.to_string(),
+    })
+}
+
+/// Create `link.json` with O_EXCL semantics — fails if the marker already
+/// exists, closing the concurrent-link race.
+fn write_manifest_excl(consumer_root: &Path, manifest: &LinkManifest) -> Result<(), LinkError> {
+    use std::io::Write;
     let state_dir = consumer_root.join(LINK_STATE_DIR);
     std::fs::create_dir_all(&state_dir).map_err(|e| LinkError::io(&state_dir, e))?;
     let path = state_dir.join(LINK_MANIFEST_FILE);
-    let body = serde_json::to_string_pretty(manifest).map_err(|e| LinkError::CorruptLinkState {
-        path: path.clone(),
-        detail: e.to_string(),
-    })?;
+    let body = manifest_json(manifest, &path)?;
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::AlreadyExists {
+                LinkError::LinkMarkerAlreadyExists { path: path.clone() }
+            } else {
+                LinkError::io(&path, e)
+            }
+        })?;
+    file.write_all(body.as_bytes())
+        .map_err(|e| LinkError::io(&path, e))
+}
+
+/// Overwrite `link.json` in place (used for the `applying → active` flip).
+fn overwrite_manifest(consumer_root: &Path, manifest: &LinkManifest) -> Result<(), LinkError> {
+    let path = consumer_root
+        .join(LINK_STATE_DIR)
+        .join(LINK_MANIFEST_FILE);
+    let body = manifest_json(manifest, &path)?;
     std::fs::write(&path, body).map_err(|e| LinkError::io(&path, e))
 }
 
 /// Discover the consumer's effective `[registries.gitea].index` string the way
-/// cargo does: closest `.cargo/config.toml` (walking up) wins, then
-/// `~/.cargo/config.toml`.
+/// cargo does: closest `.cargo/config.toml` (walking up) wins, then the home
+/// cargo config.
 fn discover_registry_index(consumer_root: &Path) -> Result<String, LinkError> {
+    discover_registry_index_with_home(consumer_root, dirs::home_dir().as_deref())
+}
+
+/// [`discover_registry_index`] with an injectable home dir (`None` disables
+/// the home fallback) so tests are environment-independent.
+fn discover_registry_index_with_home(
+    consumer_root: &Path,
+    home: Option<&Path>,
+) -> Result<String, LinkError> {
     let mut dir = Some(consumer_root);
     while let Some(d) = dir {
         for name in [".cargo/config.toml", ".cargo/config"] {
@@ -337,7 +433,7 @@ fn discover_registry_index(consumer_root: &Path) -> Result<String, LinkError> {
         }
         dir = d.parent();
     }
-    if let Some(home) = dirs::home_dir() {
+    if let Some(home) = home {
         for name in [".cargo/config.toml", ".cargo/config"] {
             if let Some(idx) = read_gitea_index(&home.join(name))? {
                 return Ok(idx);
@@ -365,35 +461,51 @@ fn read_gitea_index(path: &Path) -> Result<Option<String>, LinkError> {
         .map(|s| s.to_string()))
 }
 
-/// Derive the linkable crate set (`name` → checkout-relative member dir) from
-/// the checkout live via `cargo metadata` — same selection as the publish
-/// closure with `STREAMLIB_PUBLISH_ALL_LIBS=1`: every workspace member whose
-/// name starts with `streamlib` (or is `vulkan-jpeg`), that produces a library
-/// target and is publishable.
+/// Run `cargo metadata` and parse its JSON output.
+fn run_cargo_metadata(
+    args: &[&str],
+    cwd: Option<&Path>,
+) -> Result<serde_json::Value, String> {
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args(args);
+    if let Some(cwd) = cwd {
+        cmd.current_dir(cwd);
+    }
+    let output = cmd
+        .output()
+        .map_err(|e| format!("failed to run cargo metadata: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "cargo metadata failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("cargo metadata is not valid JSON: {e}"))
+}
+
+/// Derive the linkable crate set (`name` → checkout member dir) from the
+/// checkout live via `cargo metadata` — same selection as the publish closure
+/// with `STREAMLIB_PUBLISH_ALL_LIBS=1`: every workspace member named
+/// `streamlib*` (or `vulkan-jpeg`) with a library target that is publishable.
 fn derive_linkable_crates(checkout: &Path) -> Result<BTreeMap<String, PathBuf>, LinkError> {
     let manifest_path = checkout.join("Cargo.toml");
-    let output = std::process::Command::new("cargo")
-        .args(["metadata", "--format-version", "1", "--no-deps", "--manifest-path"])
-        .arg(&manifest_path)
-        .output()
-        .map_err(|e| LinkError::CrateSetDerivation {
-            checkout: checkout.to_path_buf(),
-            detail: format!("failed to run cargo metadata: {e}"),
-        })?;
-    if !output.status.success() {
-        return Err(LinkError::CrateSetDerivation {
-            checkout: checkout.to_path_buf(),
-            detail: format!(
-                "cargo metadata failed: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            ),
-        });
-    }
-    let md: serde_json::Value =
-        serde_json::from_slice(&output.stdout).map_err(|e| LinkError::CrateSetDerivation {
-            checkout: checkout.to_path_buf(),
-            detail: format!("cargo metadata is not valid JSON: {e}"),
-        })?;
+    let manifest_path_str = manifest_path.to_string_lossy().into_owned();
+    let md = run_cargo_metadata(
+        &[
+            "metadata",
+            "--format-version",
+            "1",
+            "--no-deps",
+            "--manifest-path",
+            &manifest_path_str,
+        ],
+        None,
+    )
+    .map_err(|detail| LinkError::CrateSetDerivation {
+        checkout: checkout.to_path_buf(),
+        detail,
+    })?;
 
     let members: std::collections::HashSet<&str> = md
         .get("workspace_members")
@@ -413,7 +525,7 @@ fn derive_linkable_crates(checkout: &Path) -> Result<BTreeMap<String, PathBuf>, 
             continue;
         }
         let name = pkg.get("name").and_then(|v| v.as_str()).unwrap_or_default();
-        if !(name.starts_with("streamlib") || name == "vulkan-jpeg") {
+        if !is_linkable_crate_name(name) {
             continue;
         }
         // `publish == []` ⇒ publish = false ⇒ not a linkable SDK crate.
@@ -434,6 +546,10 @@ fn derive_linkable_crates(checkout: &Path) -> Result<BTreeMap<String, PathBuf>, 
     Ok(crates)
 }
 
+fn is_linkable_crate_name(name: &str) -> bool {
+    name.starts_with("streamlib") || name == "vulkan-jpeg"
+}
+
 fn has_library_target(pkg: &serde_json::Value) -> bool {
     const LIB_KINDS: &[&str] = &["lib", "rlib", "cdylib", "proc-macro", "dylib", "staticlib"];
     pkg.get("targets")
@@ -450,6 +566,155 @@ fn has_library_target(pkg: &serde_json::Value) -> bool {
                     })
             })
         })
+}
+
+/// Verify the consumer's cargo resolution honors the link: every resolved
+/// `streamlib*` / `vulkan-jpeg` package must be a path source under the
+/// checkout. Returns `Err(detail)` naming the offending crates. `Ok(())`
+/// (vacuously) when the consumer has no `Cargo.toml`.
+fn verify_cargo_patch_resolution(
+    consumer_root: &Path,
+    checkout: &Path,
+    crates: &BTreeMap<String, PathBuf>,
+) -> Result<(), String> {
+    if !consumer_root.join("Cargo.toml").is_file() {
+        return Ok(());
+    }
+
+    // Offline first (the whole point of link mode); fall back to online when
+    // offline resolution fails for unrelated reasons (cold cache).
+    let md = match run_cargo_metadata(
+        &["metadata", "--format-version", "1", "--offline"],
+        Some(consumer_root),
+    ) {
+        Ok(md) => md,
+        Err(offline_err) => run_cargo_metadata(
+            &["metadata", "--format-version", "1"],
+            Some(consumer_root),
+        )
+        .map_err(|online_err| {
+            format!(
+                "cargo could not resolve the consumer's dependency graph — offline: \
+                 {offline_err}; online: {online_err}"
+            )
+        })?,
+    };
+
+    let empty = Vec::new();
+    let packages = md
+        .get("packages")
+        .and_then(|p| p.as_array())
+        .unwrap_or(&empty);
+    let mut verified = 0usize;
+    let mut not_patched: Vec<String> = Vec::new();
+    for pkg in packages {
+        let name = pkg.get("name").and_then(|v| v.as_str()).unwrap_or_default();
+        if !crates.contains_key(name) {
+            continue;
+        }
+        let is_path_source = pkg.get("source").is_none_or(|s| s.is_null());
+        let at_checkout = pkg
+            .get("manifest_path")
+            .and_then(|v| v.as_str())
+            .is_some_and(|mp| Path::new(mp).starts_with(checkout));
+        if is_path_source && at_checkout {
+            verified += 1;
+        } else {
+            let version = pkg.get("version").and_then(|v| v.as_str()).unwrap_or("?");
+            not_patched.push(format!("{name}@{version}"));
+        }
+    }
+
+    if !not_patched.is_empty() {
+        return Err(format!(
+            "these streamlib crates still resolve from the registry (the consumer's version \
+             requirements don't admit the checkout's versions, so cargo ignored the [patch]): {}",
+            not_patched.join(", ")
+        ));
+    }
+    tracing::info!(verified, "post-link cargo resolution verified");
+    Ok(())
+}
+
+/// Run the full link transaction against a computed crate set: plan every
+/// edit, persist the plan as `link.json` (state `applying`, O_EXCL), apply the
+/// edits with backups, then flip the state to `active`. Returns the applied
+/// edits for reporting.
+fn establish_link(
+    consumer_root: &Path,
+    checkout: &Path,
+    index_url: &str,
+    crates: &BTreeMap<String, PathBuf>,
+) -> Result<Vec<PlannedEdit>, LinkError> {
+    let edits = plan_edits(consumer_root, checkout, index_url, crates)?;
+    let mut manifest = build_link_manifest(checkout, crates.len(), &edits);
+
+    // Manifest-first: the full plan is on disk (O_EXCL) before any edit, so a
+    // crash at any later point is recoverable by a plain `streamlib unlink`,
+    // and a concurrent second `link` run fails the exclusive create.
+    write_manifest_excl(consumer_root, &manifest)?;
+
+    if let Err(e) = apply_transaction(consumer_root, &edits) {
+        return Err(unwind_failed_transaction(consumer_root, &edits, e));
+    }
+
+    manifest.state = LinkTransactionState::Active;
+    if let Err(e) = overwrite_manifest(consumer_root, &manifest) {
+        return Err(unwind_failed_transaction(consumer_root, &edits, e));
+    }
+
+    Ok(edits)
+}
+
+/// Build the persisted link manifest (state `applying`) from the edit plan.
+fn build_link_manifest(
+    checkout: &Path,
+    linked_crate_count: usize,
+    edits: &[PlannedEdit],
+) -> LinkManifest {
+    let files: Vec<LinkedManifestFile> = edits
+        .iter()
+        .map(|edit| LinkedManifestFile {
+            path: edit.rel_path.clone(),
+            existed_before: edit.original.is_some(),
+            pre_edit_sha256: edit
+                .original
+                .as_deref()
+                .map(hex_sha256)
+                .unwrap_or_default(),
+            post_edit_sha256: hex_sha256(edit.new_content.as_bytes()),
+        })
+        .collect();
+    LinkManifest {
+        checkout: checkout.to_path_buf(),
+        python_sdk_path: checkout.join(PYTHON_SDK_REL),
+        deno_sdk_entrypoint_path: checkout.join(DENO_SDK_ENTRYPOINT_REL),
+        linked_at: chrono::Utc::now().to_rfc3339(),
+        linked_crate_count,
+        state: LinkTransactionState::Applying,
+        files,
+    }
+}
+
+/// Roll back a failed link transaction. Removes the link state only when the
+/// verified rollback restored every file; otherwise the state dir (manifest +
+/// backups) is left intact for `streamlib unlink` recovery and the error says
+/// so.
+fn unwind_failed_transaction(
+    consumer_root: &Path,
+    edits: &[PlannedEdit],
+    cause: LinkError,
+) -> LinkError {
+    let refs: Vec<&PlannedEdit> = edits.iter().collect();
+    if rollback(&refs) {
+        let _ = std::fs::remove_dir_all(consumer_root.join(LINK_STATE_DIR));
+        cause
+    } else {
+        LinkError::RollbackIncomplete {
+            backup_dir: consumer_root.join(LINK_STATE_DIR).join(LINK_BACKUP_DIR),
+            detail: format!("original failure: {cause}"),
+        }
+    }
 }
 
 /// Compute every planned edit (cargo config always; pyproject / deno.json only
@@ -519,7 +784,13 @@ fn plan_cargo_config_edit(
         patch.set_implicit(true);
         doc.insert("patch", toml_edit::Item::Table(patch));
     }
-    doc["patch"][index_url] = toml_edit::Item::Table(patch_target);
+    let patch = doc["patch"]
+        .as_table_mut()
+        .ok_or_else(|| LinkError::ManifestParse {
+            path: abs_path.clone(),
+            detail: "`patch` exists but is not a table".to_string(),
+        })?;
+    patch.insert(index_url, toml_edit::Item::Table(patch_target));
 
     Ok(PlannedEdit {
         rel_path,
@@ -527,6 +798,24 @@ fn plan_cargo_config_edit(
         new_content: doc.to_string(),
         original,
     })
+}
+
+/// Get-or-create `key` as a table on `table`, with a typed error when an
+/// existing non-table value occupies the key.
+fn ensure_table_mut<'a>(
+    table: &'a mut toml_edit::Table,
+    key: &str,
+    file: &Path,
+) -> Result<&'a mut toml_edit::Table, LinkError> {
+    if !table.contains_key(key) {
+        table.insert(key, toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+    table[key]
+        .as_table_mut()
+        .ok_or_else(|| LinkError::ManifestParse {
+            path: file.to_path_buf(),
+            detail: format!("`{key}` exists but is not a table"),
+        })
 }
 
 fn plan_pyproject_edit(
@@ -554,11 +843,13 @@ fn plan_pyproject_edit(
     );
     source.insert("editable", toml_edit::Value::from(true));
 
-    ensure_table(&mut doc, "tool");
-    ensure_subtable(doc["tool"].as_table_mut().unwrap(), "uv");
-    let uv = doc["tool"]["uv"].as_table_mut().unwrap();
-    ensure_subtable(uv, "sources");
-    uv["sources"]["streamlib"] = toml_edit::Item::Value(toml_edit::Value::InlineTable(source));
+    let tool = ensure_table_mut(doc.as_table_mut(), "tool", pyproject)?;
+    let uv = ensure_table_mut(tool, "uv", pyproject)?;
+    let sources = ensure_table_mut(uv, "sources", pyproject)?;
+    sources.insert(
+        "streamlib",
+        toml_edit::Item::Value(toml_edit::Value::InlineTable(source)),
+    );
 
     Ok(PlannedEdit {
         rel_path: rel_of(pyproject, consumer_root),
@@ -617,90 +908,51 @@ fn plan_deno_edit(
     })
 }
 
-/// Apply every planned edit transactionally: back up pre-existing files, write
-/// the new content, and roll back all applied edits on any failure.
-fn apply_transaction(
-    consumer_root: &Path,
-    edits: &[PlannedEdit],
-) -> Result<Vec<TouchedFile>, LinkError> {
+/// Apply every planned edit: back up pre-existing files, then write the new
+/// content. The caller (`establish_link`) owns rollback on failure — the plan
+/// is already persisted in `link.json` (state `applying`) before this runs.
+fn apply_transaction(consumer_root: &Path, edits: &[PlannedEdit]) -> Result<(), LinkError> {
     let backup_dir = consumer_root.join(LINK_STATE_DIR).join(LINK_BACKUP_DIR);
     std::fs::create_dir_all(&backup_dir).map_err(|e| LinkError::io(&backup_dir, e))?;
 
-    let mut applied: Vec<&PlannedEdit> = Vec::new();
-    let mut touched: Vec<TouchedFile> = Vec::new();
-
     for edit in edits {
-        let result = (|| -> Result<(), LinkError> {
-            if let Some(orig) = &edit.original {
-                let backup = backup_dir.join(&edit.rel_path);
-                if let Some(parent) = backup.parent() {
-                    std::fs::create_dir_all(parent).map_err(|e| LinkError::io(parent, e))?;
-                }
-                std::fs::write(&backup, orig).map_err(|e| LinkError::io(&backup, e))?;
-            }
-            if let Some(parent) = edit.abs_path.parent() {
+        if let Some(orig) = &edit.original {
+            let backup = backup_dir.join(&edit.rel_path);
+            if let Some(parent) = backup.parent() {
                 std::fs::create_dir_all(parent).map_err(|e| LinkError::io(parent, e))?;
             }
-            std::fs::write(&edit.abs_path, &edit.new_content)
-                .map_err(|e| LinkError::io(&edit.abs_path, e))
-        })();
-
-        if let Err(e) = result {
-            // Restore the failing edit too — its target may already be
-            // truncated and its backup is about to be wiped with the state dir
-            // — then unwind every previously-applied edit.
-            let mut to_undo = applied.clone();
-            to_undo.push(edit);
-            rollback(&to_undo);
-            let state_dir = consumer_root.join(LINK_STATE_DIR);
-            let _ = std::fs::remove_dir_all(&state_dir);
-            return Err(e);
+            std::fs::write(&backup, orig).map_err(|e| LinkError::io(&backup, e))?;
         }
-
-        touched.push(TouchedFile {
-            path: edit.rel_path.clone(),
-            existed_before: edit.original.is_some(),
-            pre_edit_sha256: edit
-                .original
-                .as_ref()
-                .map(|b| hex_sha256(b))
-                .unwrap_or_default(),
-        });
-        applied.push(edit);
-    }
-
-    Ok(touched)
-}
-
-/// Persist the link manifest as the final transactional step. On failure, roll
-/// every applied edit back and clear the link state so the consumer is left
-/// exactly as it was before `link` ran.
-fn finalize_link(
-    consumer_root: &Path,
-    edits: &[PlannedEdit],
-    manifest: &LinkManifest,
-) -> Result<(), LinkError> {
-    if let Err(e) = write_manifest(consumer_root, manifest) {
-        let refs: Vec<&PlannedEdit> = edits.iter().collect();
-        rollback(&refs);
-        let _ = std::fs::remove_dir_all(consumer_root.join(LINK_STATE_DIR));
-        return Err(e);
+        if let Some(parent) = edit.abs_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| LinkError::io(parent, e))?;
+        }
+        std::fs::write(&edit.abs_path, &edit.new_content)
+            .map_err(|e| LinkError::io(&edit.abs_path, e))?;
     }
     Ok(())
 }
 
-/// Undo applied edits in reverse order: restore originals, delete created files.
-fn rollback(applied: &[&PlannedEdit]) {
+/// Undo edits in reverse order and VERIFY each outcome: an `existed_before`
+/// file must read back byte-identical to its original, a created file must be
+/// gone. Returns `true` only when every file verifiably reached its pre-link
+/// state.
+fn rollback(applied: &[&PlannedEdit]) -> bool {
+    let mut ok = true;
     for edit in applied.iter().rev() {
         match &edit.original {
             Some(orig) => {
                 let _ = std::fs::write(&edit.abs_path, orig);
+                ok &= std::fs::read(&edit.abs_path)
+                    .map(|live| &live == orig)
+                    .unwrap_or(false);
             }
             None => {
                 let _ = std::fs::remove_file(&edit.abs_path);
+                ok &= !edit.abs_path.exists();
             }
         }
     }
+    ok
 }
 
 /// Remove now-empty parent directories of `removed_file` up to (but excluding)
@@ -738,18 +990,6 @@ fn hex_sha256(bytes: &[u8]) -> String {
         s.push_str(&format!("{b:02x}"));
     }
     s
-}
-
-fn ensure_table(doc: &mut toml_edit::DocumentMut, key: &str) {
-    if !doc.contains_key(key) {
-        doc.insert(key, toml_edit::Item::Table(toml_edit::Table::new()));
-    }
-}
-
-fn ensure_subtable(table: &mut toml_edit::Table, key: &str) {
-    if !table.contains_key(key) {
-        table.insert(key, toml_edit::Item::Table(toml_edit::Table::new()));
-    }
 }
 
 #[cfg(test)]

--- a/libs/streamlib-cli/src/commands/link.rs
+++ b/libs/streamlib-cli/src/commands/link.rs
@@ -164,15 +164,16 @@ pub fn link(consumer_root: &Path, checkout: &Path) -> Result<(), LinkError> {
     let edits = plan_edits(&consumer_root, &checkout, &index_url, &crates)?;
     let touched = apply_transaction(&consumer_root, &edits)?;
 
-    write_manifest(
-        &consumer_root,
-        &LinkManifest {
-            checkout: checkout.clone(),
-            linked_at: chrono::Utc::now().to_rfc3339(),
-            linked_crate_count: crates.len(),
-            files: touched,
-        },
-    )?;
+    // Persisting the manifest is the final transactional step: if it fails, the
+    // overrides are already on disk, so roll them all back and clear the link
+    // state — the all-or-nothing contract holds through this step too.
+    let manifest = LinkManifest {
+        checkout: checkout.clone(),
+        linked_at: chrono::Utc::now().to_rfc3339(),
+        linked_crate_count: crates.len(),
+        files: touched,
+    };
+    finalize_link(&consumer_root, &edits, &manifest)?;
 
     println!("Linked streamlib → {}", checkout.display());
     println!("  Cargo crates redirected: {}", crates.len());
@@ -207,6 +208,20 @@ pub fn unlink(consumer_root: &Path) -> Result<(), LinkError> {
         if tf.existed_before {
             let backup = backup_dir.join(&tf.path);
             let bytes = std::fs::read(&backup).map_err(|e| LinkError::io(&backup, e))?;
+            // Integrity guard: the backup must still hash to the value recorded
+            // when the link was established. A mismatch means the backup was
+            // corrupted/tampered — refuse to restore wrong bytes over the
+            // consumer's file rather than silently clobber it.
+            if hex_sha256(&bytes) != tf.pre_edit_sha256 {
+                return Err(LinkError::CorruptLinkState {
+                    path: backup.clone(),
+                    detail: format!(
+                        "backup content hash does not match the pre-edit hash recorded for `{}`; \
+                         refusing to restore a corrupted backup",
+                        tf.path.display()
+                    ),
+                });
+            }
             std::fs::write(&abs, &bytes).map_err(|e| LinkError::io(&abs, e))?;
         } else {
             // We created this file — remove it, then prune any now-empty parent
@@ -631,7 +646,12 @@ fn apply_transaction(
         })();
 
         if let Err(e) = result {
-            rollback(&applied);
+            // Restore the failing edit too — its target may already be
+            // truncated and its backup is about to be wiped with the state dir
+            // — then unwind every previously-applied edit.
+            let mut to_undo = applied.clone();
+            to_undo.push(edit);
+            rollback(&to_undo);
             let state_dir = consumer_root.join(LINK_STATE_DIR);
             let _ = std::fs::remove_dir_all(&state_dir);
             return Err(e);
@@ -650,6 +670,23 @@ fn apply_transaction(
     }
 
     Ok(touched)
+}
+
+/// Persist the link manifest as the final transactional step. On failure, roll
+/// every applied edit back and clear the link state so the consumer is left
+/// exactly as it was before `link` ran.
+fn finalize_link(
+    consumer_root: &Path,
+    edits: &[PlannedEdit],
+    manifest: &LinkManifest,
+) -> Result<(), LinkError> {
+    if let Err(e) = write_manifest(consumer_root, manifest) {
+        let refs: Vec<&PlannedEdit> = edits.iter().collect();
+        rollback(&refs);
+        let _ = std::fs::remove_dir_all(consumer_root.join(LINK_STATE_DIR));
+        return Err(e);
+    }
+    Ok(())
 }
 
 /// Undo applied edits in reverse order: restore originals, delete created files.

--- a/libs/streamlib-cli/src/commands/link/tests.rs
+++ b/libs/streamlib-cli/src/commands/link/tests.rs
@@ -10,8 +10,7 @@ const INDEX_URL: &str = "sparse+http://localhost:3300/api/packages/tatolab/cargo
 
 /// Absolute path of the real streamlib workspace this test binary was built in
 /// (`<root>/libs/streamlib-cli` → `<root>`). It is a genuine streamlib
-/// checkout, so `derive_linkable_crates` and `canonicalize_checkout` exercise
-/// real behavior offline.
+/// checkout, so checkout-facing paths exercise real behavior offline.
 fn workspace_checkout() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .ancestors()
@@ -57,22 +56,14 @@ fn fake_crate_set() -> BTreeMap<String, PathBuf> {
     m
 }
 
-/// Drive the emission internals with a fixed crate set (no cargo metadata), so
-/// the transactional apply + teardown are exercised deterministically.
+/// Drive the full transaction (manifest-first, apply, flip) with a fixed
+/// crate set — the real flow minus cargo-metadata derivation + verification.
 fn link_with_fixed_crates(consumer_root: &Path, checkout: &Path) {
-    let crates = fake_crate_set();
-    let edits = plan_edits(consumer_root, checkout, INDEX_URL, &crates).unwrap();
-    let touched = apply_transaction(consumer_root, &edits).unwrap();
-    write_manifest(
-        consumer_root,
-        &LinkManifest {
-            checkout: checkout.to_path_buf(),
-            linked_at: "2026-01-01T00:00:00Z".to_string(),
-            linked_crate_count: crates.len(),
-            files: touched,
-        },
-    )
-    .unwrap();
+    establish_link(consumer_root, checkout, INDEX_URL, &fake_crate_set()).unwrap();
+}
+
+fn marker_path(consumer: &Path) -> PathBuf {
+    consumer.join(LINK_STATE_DIR).join(LINK_MANIFEST_FILE)
 }
 
 #[test]
@@ -93,8 +84,14 @@ fn link_then_unlink_is_byte_clean_and_idempotent_across_cycles() {
     for cycle in 0..2 {
         link_with_fixed_crates(&consumer, &checkout);
 
-        // During link: overrides present, marker present.
-        assert!(consumer.join(LINK_STATE_DIR).join(LINK_MANIFEST_FILE).is_file());
+        // During link: overrides present, marker present + flipped to active.
+        let manifest = load_active_manifest(&consumer).unwrap().unwrap();
+        assert_eq!(manifest.state, LinkTransactionState::Active, "cycle {cycle}");
+        assert_eq!(
+            manifest.python_sdk_path,
+            PathBuf::from("/some/checkout/libs/streamlib-python"),
+            "cycle {cycle}: manifest must carry the resolved absolute python sdk path"
+        );
         let linked_cargo = std::fs::read_to_string(&cargo).unwrap();
         assert!(
             linked_cargo.contains(&format!("[patch.\"{INDEX_URL}\"]")),
@@ -102,7 +99,6 @@ fn link_then_unlink_is_byte_clean_and_idempotent_across_cycles() {
         );
         assert!(linked_cargo.contains("streamlib-idents"));
         assert!(linked_cargo.contains(CARGO_PATCH_MARKER));
-        // The pre-existing registry block survives.
         assert!(linked_cargo.contains("[registries.gitea]"));
         assert!(std::fs::read_to_string(&pyproject)
             .unwrap()
@@ -111,7 +107,7 @@ fn link_then_unlink_is_byte_clean_and_idempotent_across_cycles() {
             .unwrap()
             .contains("libs/streamlib-deno/mod.ts"));
 
-        unlink(&consumer).unwrap();
+        unlink(&consumer, false).unwrap();
 
         // After unlink: byte-identical + zero residue.
         assert_eq!(std::fs::read(&cargo).unwrap(), orig_cargo, "cycle {cycle}: cargo");
@@ -142,13 +138,16 @@ fn unlink_deletes_a_cargo_config_it_created_and_prunes_the_dir() {
     let consumer = outer.join("app");
     std::fs::create_dir_all(&consumer).unwrap();
 
-    // Discovery must find the parent's index.
-    assert_eq!(discover_registry_index(&consumer).unwrap(), INDEX_URL);
+    // Discovery must find the parent's index (no home fallback involved).
+    assert_eq!(
+        discover_registry_index_with_home(&consumer, None).unwrap(),
+        INDEX_URL
+    );
 
     link_with_fixed_crates(&consumer, &PathBuf::from("/checkout"));
     assert!(consumer.join(".cargo").join("config.toml").is_file());
 
-    unlink(&consumer).unwrap();
+    unlink(&consumer, false).unwrap();
     assert!(!consumer.join(".cargo").exists(), ".cargo we created must be pruned");
     assert!(!consumer.join(LINK_STATE_DIR).exists());
     // Parent config untouched.
@@ -159,8 +158,7 @@ fn unlink_deletes_a_cargo_config_it_created_and_prunes_the_dir() {
 fn unlink_with_no_active_link_is_a_friendly_noop() {
     let tmp = tempfile::tempdir().unwrap();
     let consumer = tmp.path().canonicalize().unwrap();
-    // No .streamlib at all.
-    unlink(&consumer).expect("unlink with no link must be Ok");
+    unlink(&consumer, false).expect("unlink with no link must be Ok");
 }
 
 #[test]
@@ -170,7 +168,7 @@ fn link_to_a_nonexistent_checkout_modifies_nothing() {
     write_full_consumer(&consumer);
     let before = std::fs::read(consumer.join(".cargo").join("config.toml")).unwrap();
 
-    let err = link(&consumer, &consumer.join("does-not-exist")).unwrap_err();
+    let err = link(&consumer, &consumer.join("does-not-exist"), true).unwrap_err();
     assert!(matches!(err, LinkError::NotAStreamlibCheckout(_)), "got {err:?}");
     assert!(!consumer.join(LINK_STATE_DIR).exists());
     assert_eq!(
@@ -185,28 +183,24 @@ fn link_to_a_dir_without_cargo_toml_is_rejected() {
     let consumer = tmp.path().canonicalize().unwrap();
     write_full_consumer(&consumer);
     let bogus = tempfile::tempdir().unwrap();
-    let err = link(&consumer, bogus.path()).unwrap_err();
+    let err = link(&consumer, bogus.path(), true).unwrap_err();
     assert!(matches!(err, LinkError::NotAStreamlibCheckout(_)), "got {err:?}");
 }
 
 #[test]
 fn missing_registry_index_errors_actionably() {
+    // Injectable home (None) makes this assertion environment-independent.
     let tmp = tempfile::tempdir().unwrap();
     let consumer = tmp.path().canonicalize().unwrap();
-    // A consumer with a cargo config but NO gitea registry.
     let cargo = consumer.join(".cargo");
     std::fs::create_dir_all(&cargo).unwrap();
     std::fs::write(cargo.join("config.toml"), "[alias]\nb = \"build\"\n").unwrap();
-    // Discovery from here should fail (assuming ~/.cargo has no gitea either;
-    // if it does, the walk finds it — so only assert the walk-local negative).
-    let err = discover_registry_index(&consumer);
-    // On dev boxes ~/.cargo may define gitea; only assert when it doesn't.
-    if dirs::home_dir()
-        .map(|h| read_gitea_index(&h.join(".cargo/config.toml")).ok().flatten().is_none())
-        .unwrap_or(true)
-    {
-        assert!(matches!(err, Err(LinkError::RegistryIndexNotConfigured)), "got {err:?}");
-    }
+
+    let err = discover_registry_index_with_home(&consumer, None);
+    assert!(
+        matches!(err, Err(LinkError::RegistryIndexNotConfigured)),
+        "got {err:?}"
+    );
 }
 
 #[test]
@@ -232,12 +226,9 @@ fn linking_a_different_checkout_over_an_active_link_is_refused() {
     let tmp = tempfile::tempdir().unwrap();
     let consumer = tmp.path().canonicalize().unwrap();
     write_full_consumer(&consumer);
-    // Simulate an active link to checkout A.
     link_with_fixed_crates(&consumer, &PathBuf::from("/checkout-A"));
 
-    // link() to a DIFFERENT real checkout must refuse (the workspace root is a
-    // valid checkout, distinct from /checkout-A).
-    let err = link(&consumer, &workspace_checkout()).unwrap_err();
+    let err = link(&consumer, &workspace_checkout(), true).unwrap_err();
     assert!(matches!(err, LinkError::AlreadyLinkedElsewhere { .. }), "got {err:?}");
 }
 
@@ -263,60 +254,211 @@ fn deno_jsonc_with_comments_is_rejected_cleanly() {
 }
 
 #[test]
-fn pack_is_refused_while_a_link_is_active_above_the_package() {
+fn non_table_pyproject_tool_key_is_a_typed_error_not_a_panic() {
+    // `tool = 3` occupies the key with a non-table — planning must return
+    // ManifestParse, never panic on an unchecked as_table_mut.
     let tmp = tempfile::tempdir().unwrap();
     let consumer = tmp.path().canonicalize().unwrap();
-    write_full_consumer(&consumer);
-    link_with_fixed_crates(&consumer, &PathBuf::from("/checkout"));
-
-    // From the consumer root and from a nested package dir, pack must refuse.
-    assert!(matches!(
-        ensure_no_active_link_for_pack(&consumer),
-        Err(LinkError::PackRefusedWhileLinked { .. })
-    ));
-    let nested = consumer.join("packages").join("thing");
-    std::fs::create_dir_all(&nested).unwrap();
-    assert!(matches!(
-        ensure_no_active_link_for_pack(&nested),
-        Err(LinkError::PackRefusedWhileLinked { .. })
-    ));
-
-    // After unlink, pack is allowed again.
-    unlink(&consumer).unwrap();
-    assert!(ensure_no_active_link_for_pack(&consumer).is_ok());
+    let pyproject = consumer.join("pyproject.toml");
+    std::fs::write(&pyproject, "tool = 3\n").unwrap();
+    let err = plan_pyproject_edit(&pyproject, &consumer, &PathBuf::from("/checkout")).unwrap_err();
+    assert!(matches!(err, LinkError::ManifestParse { .. }), "got {err:?}");
 }
 
 #[test]
-fn manifest_write_failure_rolls_back_the_overrides() {
-    // If persisting link.json fails after the overrides are written, every
-    // override must be rolled back and the link state cleared — the all-or-
-    // nothing contract holds through the final step.
+fn concurrent_second_link_is_refused_by_exclusive_marker_create() {
+    // Simulates the race window after the caller's existing-manifest check:
+    // a marker landed in between — the exclusive create must refuse.
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    write_full_consumer(&consumer);
+    let state_dir = consumer.join(LINK_STATE_DIR);
+    std::fs::create_dir_all(&state_dir).unwrap();
+    std::fs::write(state_dir.join(LINK_MANIFEST_FILE), "{}").unwrap();
+
+    let err = establish_link(&consumer, &PathBuf::from("/checkout"), INDEX_URL, &fake_crate_set())
+        .unwrap_err();
+    assert!(matches!(err, LinkError::LinkMarkerAlreadyExists { .. }), "got {err:?}");
+}
+
+#[test]
+fn torn_applying_state_refuses_relink_and_plain_unlink_recovers() {
+    // Crash window (a): manifest persisted (state=applying), NO edits applied.
     let tmp = tempfile::tempdir().unwrap();
     let consumer = tmp.path().canonicalize().unwrap();
     write_full_consumer(&consumer);
     let cargo = consumer.join(".cargo").join("config.toml");
     let orig_cargo = std::fs::read(&cargo).unwrap();
 
-    let crates = fake_crate_set();
-    let edits = plan_edits(&consumer, &PathBuf::from("/checkout"), INDEX_URL, &crates).unwrap();
-    let touched = apply_transaction(&consumer, &edits).unwrap();
-    // Overrides are on disk now.
-    assert_ne!(std::fs::read(&cargo).unwrap(), orig_cargo);
+    // Torn state against a real (canonicalizable) checkout so `link()` reaches
+    // the state gate.
+    let real_checkout = workspace_checkout();
+    let edits = plan_edits(&consumer, &real_checkout, INDEX_URL, &fake_crate_set()).unwrap();
+    let manifest = build_link_manifest(&real_checkout, 2, &edits);
+    write_manifest_excl(&consumer, &manifest).unwrap();
+    // (crash here — no edits, no backups)
 
-    // Force `write_manifest` to fail by occupying link.json with a directory.
-    let link_json = consumer.join(LINK_STATE_DIR).join(LINK_MANIFEST_FILE);
-    std::fs::create_dir_all(&link_json).unwrap();
+    let err = link(&consumer, &real_checkout, true).unwrap_err();
+    assert!(matches!(err, LinkError::TornLinkState { .. }), "got {err:?}");
 
-    let manifest = LinkManifest {
-        checkout: PathBuf::from("/checkout"),
-        linked_at: "t".into(),
-        linked_crate_count: crates.len(),
-        files: touched,
-    };
-    let err = finalize_link(&consumer, &edits, &manifest).unwrap_err();
-    assert!(matches!(err, LinkError::CorruptLinkState { .. } | LinkError::Io { .. }), "got {err:?}");
+    // Plain unlink recovers: all files still pre-edit → skipped; state gone.
+    unlink(&consumer, false).unwrap();
+    assert_eq!(std::fs::read(&cargo).unwrap(), orig_cargo);
+    assert!(!consumer.join(LINK_STATE_DIR).exists());
+}
 
-    // Rolled back byte-clean, zero residue.
+#[test]
+fn crash_after_edits_before_state_flip_is_recovered_by_unlink() {
+    // Crash window (b): manifest persisted, ALL edits applied, state never
+    // flipped to active.
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    write_full_consumer(&consumer);
+    let cargo = consumer.join(".cargo").join("config.toml");
+    let orig_cargo = std::fs::read(&cargo).unwrap();
+
+    let checkout = PathBuf::from("/checkout");
+    let edits = plan_edits(&consumer, &checkout, INDEX_URL, &fake_crate_set()).unwrap();
+    let manifest = build_link_manifest(&checkout, 2, &edits);
+    write_manifest_excl(&consumer, &manifest).unwrap();
+    apply_transaction(&consumer, &edits).unwrap();
+    // (crash here — state still `applying`)
+
+    assert_eq!(
+        load_active_manifest(&consumer).unwrap().unwrap().state,
+        LinkTransactionState::Applying
+    );
+    unlink(&consumer, false).unwrap();
+    assert_eq!(std::fs::read(&cargo).unwrap(), orig_cargo);
+    assert!(!consumer.join(LINK_STATE_DIR).exists());
+}
+
+#[test]
+fn apply_failure_on_the_last_edit_rolls_back_earlier_edits_byte_identically() {
+    // T1: force the LAST planned edit (deno.json) to fail via read-only
+    // permissions; cargo + pyproject edits must roll back byte-identically
+    // and the verified rollback clears all link state.
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    write_full_consumer(&consumer);
+    let cargo = consumer.join(".cargo").join("config.toml");
+    let pyproject = consumer.join("pyproject.toml");
+    let deno = consumer.join("deno.json");
+    let orig_cargo = std::fs::read(&cargo).unwrap();
+    let orig_py = std::fs::read(&pyproject).unwrap();
+    let orig_deno = std::fs::read(&deno).unwrap();
+
+    // Make deno.json unwritable. Skip when the environment ignores file modes
+    // (running as root), probed by attempting the write.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&deno, std::fs::Permissions::from_mode(0o444)).unwrap();
+    }
+    if std::fs::write(&deno, &orig_deno).is_ok() {
+        eprintln!("skipping: file modes not enforced (running as root?)");
+        return;
+    }
+
+    let err = establish_link(&consumer, &PathBuf::from("/checkout"), INDEX_URL, &fake_crate_set())
+        .unwrap_err();
+    assert!(matches!(err, LinkError::Io { .. }), "got {err:?}");
+
+    // Earlier edits rolled back byte-identically; failing target unmodified;
+    // verified rollback cleared the state dir.
+    assert_eq!(std::fs::read(&cargo).unwrap(), orig_cargo);
+    assert_eq!(std::fs::read(&pyproject).unwrap(), orig_py);
+    assert_eq!(std::fs::read(&deno).unwrap(), orig_deno);
+    assert!(!consumer.join(LINK_STATE_DIR).exists());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&deno, std::fs::Permissions::from_mode(0o644)).unwrap();
+    }
+}
+
+#[test]
+fn incomplete_rollback_preserves_backups_and_link_state() {
+    // Dir-occupation on deno.json between plan and apply: the apply fails AND
+    // the rollback cannot restore that file → RollbackIncomplete, state dir
+    // (manifest + backups) preserved for `streamlib unlink` recovery.
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    write_full_consumer(&consumer);
+    let cargo = consumer.join(".cargo").join("config.toml");
+    let orig_cargo = std::fs::read(&cargo).unwrap();
+    let deno = consumer.join("deno.json");
+
+    let checkout = PathBuf::from("/checkout");
+    let edits = plan_edits(&consumer, &checkout, INDEX_URL, &fake_crate_set()).unwrap();
+    let manifest = build_link_manifest(&checkout, 2, &edits);
+    write_manifest_excl(&consumer, &manifest).unwrap();
+
+    // Occupy deno.json with a directory — the write fails and so does the
+    // rollback write.
+    std::fs::remove_file(&deno).unwrap();
+    std::fs::create_dir(&deno).unwrap();
+
+    let apply_err = apply_transaction(&consumer, &edits).unwrap_err();
+    let err = unwind_failed_transaction(&consumer, &edits, apply_err);
+    assert!(matches!(err, LinkError::RollbackIncomplete { .. }), "got {err:?}");
+
+    // Earlier edits still restored; backups + manifest preserved.
+    assert_eq!(std::fs::read(&cargo).unwrap(), orig_cargo);
+    assert!(marker_path(&consumer).is_file(), "link state must be preserved");
+    assert!(
+        consumer
+            .join(LINK_STATE_DIR)
+            .join(LINK_BACKUP_DIR)
+            .join("deno.json")
+            .is_file(),
+        "the failing file's backup must be preserved"
+    );
+}
+
+#[test]
+fn unlink_tristate_refuses_user_edits_without_force_and_restores_with_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    write_full_consumer(&consumer);
+    let cargo = consumer.join(".cargo").join("config.toml");
+    let orig_cargo = std::fs::read(&cargo).unwrap();
+
+    link_with_fixed_crates(&consumer, &PathBuf::from("/checkout"));
+
+    // User hand-edits the linked cargo config during the link window.
+    let mut edited = std::fs::read(&cargo).unwrap();
+    edited.extend_from_slice(b"\n# user edit during link window\n");
+    std::fs::write(&cargo, &edited).unwrap();
+
+    // Without --force: refuse, tree untouched.
+    let err = unlink(&consumer, false).unwrap_err();
+    assert!(matches!(err, LinkError::UnlinkRefusedModifiedFile { .. }), "got {err:?}");
+    assert_eq!(std::fs::read(&cargo).unwrap(), edited, "refusal must not mutate");
+    assert!(marker_path(&consumer).is_file(), "link state preserved on refusal");
+
+    // With --force: discard the user edit, restore the pre-link original.
+    unlink(&consumer, true).unwrap();
+    assert_eq!(std::fs::read(&cargo).unwrap(), orig_cargo);
+    assert!(!consumer.join(LINK_STATE_DIR).exists());
+}
+
+#[test]
+fn unlink_skips_files_the_user_already_reverted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    write_full_consumer(&consumer);
+    let cargo = consumer.join(".cargo").join("config.toml");
+    let orig_cargo = std::fs::read(&cargo).unwrap();
+
+    link_with_fixed_crates(&consumer, &PathBuf::from("/checkout"));
+
+    // User manually reverts the cargo config to the original bytes.
+    std::fs::write(&cargo, &orig_cargo).unwrap();
+
+    // Unlink skips it (live == pre-edit hash) and still restores the rest.
+    unlink(&consumer, false).unwrap();
     assert_eq!(std::fs::read(&cargo).unwrap(), orig_cargo);
     assert!(!consumer.join(LINK_STATE_DIR).exists());
 }
@@ -336,12 +478,45 @@ fn unlink_refuses_to_restore_a_corrupted_backup() {
         .join("config.toml");
     std::fs::write(&backup, b"tampered content").unwrap();
 
-    let err = unlink(&consumer).unwrap_err();
+    let err = unlink(&consumer, false).unwrap_err();
     assert!(matches!(err, LinkError::CorruptLinkState { .. }), "got {err:?}");
-    // Refused restore ⇒ the live (linked) config was NOT clobbered with the
-    // corrupted backup.
+    // Refused restore ⇒ the live (linked) config was NOT clobbered.
     let live = std::fs::read_to_string(consumer.join(".cargo").join("config.toml")).unwrap();
     assert!(live.contains("[patch."), "live config must be untouched by the refused restore");
+}
+
+#[test]
+fn failed_refresh_derivation_preserves_the_active_link() {
+    // F7 ordering lock: on a same-checkout refresh, crate-set derivation runs
+    // BEFORE the unlink — a checkout whose metadata breaks between links must
+    // leave the working link fully intact.
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    write_full_consumer(&consumer);
+
+    // A "checkout" that canonicalizes + has a Cargo.toml, but whose metadata
+    // is broken.
+    let broken = tempfile::tempdir().unwrap();
+    std::fs::write(broken.path().join("Cargo.toml"), "not toml at all [").unwrap();
+    let broken_checkout = broken.path().canonicalize().unwrap();
+
+    link_with_fixed_crates(&consumer, &broken_checkout);
+    let linked_cargo = std::fs::read(consumer.join(".cargo").join("config.toml")).unwrap();
+
+    let err = link(&consumer, &broken_checkout, true).unwrap_err();
+    assert!(matches!(err, LinkError::CrateSetDerivation { .. }), "got {err:?}");
+
+    // The active link survived the failed refresh.
+    assert!(marker_path(&consumer).is_file(), "link state must survive");
+    assert_eq!(
+        std::fs::read(consumer.join(".cargo").join("config.toml")).unwrap(),
+        linked_cargo,
+        "linked cargo config must be untouched by the failed refresh"
+    );
+    assert_eq!(
+        load_active_manifest(&consumer).unwrap().unwrap().state,
+        LinkTransactionState::Active
+    );
 }
 
 #[test]
@@ -372,4 +547,70 @@ fn derive_linkable_crates_selects_the_streamlib_sdk_closure() {
     );
     // Binaries and test fixtures are excluded (no lib target / publish=false).
     assert!(!crates.contains_key("streamlib-cli"));
+}
+
+#[test]
+fn real_link_offline_e2e_link_refresh_unlink_roundtrip() {
+    // T3: the real `link()` composition path — index discovery, live crate
+    // derivation, transactional emission, post-link cargo verification,
+    // same-checkout refresh (derive-before-unlink), byte-clean unlink —
+    // against the actual workspace checkout, fully offline.
+    let checkout = workspace_checkout();
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    let cargo_dir = consumer.join(".cargo");
+    std::fs::create_dir_all(&cargo_dir).unwrap();
+    std::fs::write(
+        cargo_dir.join("config.toml"),
+        format!("[registries.gitea]\nindex = \"{INDEX_URL}\"\n"),
+    )
+    .unwrap();
+    std::fs::create_dir_all(consumer.join("src")).unwrap();
+    std::fs::write(consumer.join("src").join("main.rs"), "fn main(){}\n").unwrap();
+    std::fs::write(
+        consumer.join("Cargo.toml"),
+        "[package]\nname = \"link-e2e-consumer\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\
+         publish = false\n[dependencies]\nstreamlib-idents = { version = \"0.5\", registry = \"gitea\" }\n[workspace]\n",
+    )
+    .unwrap();
+    let orig_config = std::fs::read(cargo_dir.join("config.toml")).unwrap();
+
+    match link(&consumer, &checkout, false) {
+        Ok(()) => {}
+        // Environment-dependent skips: no cargo, or a cold cargo cache that
+        // can't resolve offline AND no registry online.
+        Err(LinkError::CrateSetDerivation { detail, .. })
+            if detail.contains("failed to run cargo") =>
+        {
+            eprintln!("skipping: cargo unavailable");
+            return;
+        }
+        Err(LinkError::LinkVerificationFailed { detail }) => {
+            eprintln!("skipping: offline verification not possible in this environment: {detail}");
+            return;
+        }
+        Err(e) => panic!("real link() failed: {e}"),
+    }
+
+    let linked = std::fs::read_to_string(cargo_dir.join("config.toml")).unwrap();
+    assert!(linked.contains("[patch."), "patch section must be emitted:\n{linked}");
+    assert!(linked.contains("libs/streamlib-sdk"), "sdk path must appear");
+
+    // Same-checkout re-link = refresh (exercises derive-before-unlink + the
+    // full re-emission).
+    link(&consumer, &checkout, false).expect("same-checkout refresh must succeed");
+    assert_eq!(
+        load_active_manifest(&consumer).unwrap().unwrap().state,
+        LinkTransactionState::Active
+    );
+
+    unlink(&consumer, false).unwrap();
+    assert_eq!(
+        std::fs::read(cargo_dir.join("config.toml")).unwrap(),
+        orig_config,
+        "cargo config must be byte-identical after unlink"
+    );
+    assert!(!consumer.join(LINK_STATE_DIR).exists());
+    // Cargo.lock may be created by the verification resolve — it's a build
+    // artifact of the consumer, not a link-managed manifest.
 }

--- a/libs/streamlib-cli/src/commands/link/tests.rs
+++ b/libs/streamlib-cli/src/commands/link/tests.rs
@@ -287,6 +287,64 @@ fn pack_is_refused_while_a_link_is_active_above_the_package() {
 }
 
 #[test]
+fn manifest_write_failure_rolls_back_the_overrides() {
+    // If persisting link.json fails after the overrides are written, every
+    // override must be rolled back and the link state cleared — the all-or-
+    // nothing contract holds through the final step.
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    write_full_consumer(&consumer);
+    let cargo = consumer.join(".cargo").join("config.toml");
+    let orig_cargo = std::fs::read(&cargo).unwrap();
+
+    let crates = fake_crate_set();
+    let edits = plan_edits(&consumer, &PathBuf::from("/checkout"), INDEX_URL, &crates).unwrap();
+    let touched = apply_transaction(&consumer, &edits).unwrap();
+    // Overrides are on disk now.
+    assert_ne!(std::fs::read(&cargo).unwrap(), orig_cargo);
+
+    // Force `write_manifest` to fail by occupying link.json with a directory.
+    let link_json = consumer.join(LINK_STATE_DIR).join(LINK_MANIFEST_FILE);
+    std::fs::create_dir_all(&link_json).unwrap();
+
+    let manifest = LinkManifest {
+        checkout: PathBuf::from("/checkout"),
+        linked_at: "t".into(),
+        linked_crate_count: crates.len(),
+        files: touched,
+    };
+    let err = finalize_link(&consumer, &edits, &manifest).unwrap_err();
+    assert!(matches!(err, LinkError::CorruptLinkState { .. } | LinkError::Io { .. }), "got {err:?}");
+
+    // Rolled back byte-clean, zero residue.
+    assert_eq!(std::fs::read(&cargo).unwrap(), orig_cargo);
+    assert!(!consumer.join(LINK_STATE_DIR).exists());
+}
+
+#[test]
+fn unlink_refuses_to_restore_a_corrupted_backup() {
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    write_full_consumer(&consumer);
+    link_with_fixed_crates(&consumer, &PathBuf::from("/checkout"));
+
+    // Tamper with the cargo config backup so its hash no longer matches.
+    let backup = consumer
+        .join(LINK_STATE_DIR)
+        .join(LINK_BACKUP_DIR)
+        .join(".cargo")
+        .join("config.toml");
+    std::fs::write(&backup, b"tampered content").unwrap();
+
+    let err = unlink(&consumer).unwrap_err();
+    assert!(matches!(err, LinkError::CorruptLinkState { .. }), "got {err:?}");
+    // Refused restore ⇒ the live (linked) config was NOT clobbered with the
+    // corrupted backup.
+    let live = std::fs::read_to_string(consumer.join(".cargo").join("config.toml")).unwrap();
+    assert!(live.contains("[patch."), "live config must be untouched by the refused restore");
+}
+
+#[test]
 fn derive_linkable_crates_selects_the_streamlib_sdk_closure() {
     // Runs `cargo metadata --no-deps` against the real workspace this test was
     // built in — offline, no registry required.

--- a/libs/streamlib-cli/src/commands/link/tests.rs
+++ b/libs/streamlib-cli/src/commands/link/tests.rs
@@ -1,0 +1,317 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use super::*;
+
+const INDEX_URL: &str = "sparse+http://localhost:3300/api/packages/tatolab/cargo/";
+
+/// Absolute path of the real streamlib workspace this test binary was built in
+/// (`<root>/libs/streamlib-cli` → `<root>`). It is a genuine streamlib
+/// checkout, so `derive_linkable_crates` and `canonicalize_checkout` exercise
+/// real behavior offline.
+fn workspace_checkout() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root above libs/streamlib-cli")
+        .to_path_buf()
+}
+
+/// A consumer dir carrying its own gitea registry config, a pyproject, and a
+/// deno.json — the three manifest types link mode overrides.
+fn write_full_consumer(root: &Path) {
+    let cargo_dir = root.join(".cargo");
+    std::fs::create_dir_all(&cargo_dir).unwrap();
+    std::fs::write(
+        cargo_dir.join("config.toml"),
+        format!(
+            "# consumer cargo config\n[registries.gitea]\nindex = \"{INDEX_URL}\"\n\n[alias]\nb = \"build\"\n"
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("pyproject.toml"),
+        "[project]\nname = \"consumer\"\nversion = \"0.1.0\"\ndependencies = [\"streamlib\"]\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("deno.json"),
+        "{\n  \"imports\": {\n    \"streamlib\": \"npm:@tatolab/streamlib-deno@^0.4\"\n  }\n}\n",
+    )
+    .unwrap();
+}
+
+fn fake_crate_set() -> BTreeMap<String, PathBuf> {
+    let mut m = BTreeMap::new();
+    m.insert(
+        "streamlib".to_string(),
+        PathBuf::from("/checkout/libs/streamlib-sdk"),
+    );
+    m.insert(
+        "streamlib-idents".to_string(),
+        PathBuf::from("/checkout/libs/streamlib-idents"),
+    );
+    m
+}
+
+/// Drive the emission internals with a fixed crate set (no cargo metadata), so
+/// the transactional apply + teardown are exercised deterministically.
+fn link_with_fixed_crates(consumer_root: &Path, checkout: &Path) {
+    let crates = fake_crate_set();
+    let edits = plan_edits(consumer_root, checkout, INDEX_URL, &crates).unwrap();
+    let touched = apply_transaction(consumer_root, &edits).unwrap();
+    write_manifest(
+        consumer_root,
+        &LinkManifest {
+            checkout: checkout.to_path_buf(),
+            linked_at: "2026-01-01T00:00:00Z".to_string(),
+            linked_crate_count: crates.len(),
+            files: touched,
+        },
+    )
+    .unwrap();
+}
+
+#[test]
+fn link_then_unlink_is_byte_clean_and_idempotent_across_cycles() {
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    write_full_consumer(&consumer);
+
+    let cargo = consumer.join(".cargo").join("config.toml");
+    let pyproject = consumer.join("pyproject.toml");
+    let deno = consumer.join("deno.json");
+    let orig_cargo = std::fs::read(&cargo).unwrap();
+    let orig_py = std::fs::read(&pyproject).unwrap();
+    let orig_deno = std::fs::read(&deno).unwrap();
+
+    let checkout = PathBuf::from("/some/checkout");
+
+    for cycle in 0..2 {
+        link_with_fixed_crates(&consumer, &checkout);
+
+        // During link: overrides present, marker present.
+        assert!(consumer.join(LINK_STATE_DIR).join(LINK_MANIFEST_FILE).is_file());
+        let linked_cargo = std::fs::read_to_string(&cargo).unwrap();
+        assert!(
+            linked_cargo.contains(&format!("[patch.\"{INDEX_URL}\"]")),
+            "cycle {cycle}: cargo config must carry the patch section:\n{linked_cargo}"
+        );
+        assert!(linked_cargo.contains("streamlib-idents"));
+        assert!(linked_cargo.contains(CARGO_PATCH_MARKER));
+        // The pre-existing registry block survives.
+        assert!(linked_cargo.contains("[registries.gitea]"));
+        assert!(std::fs::read_to_string(&pyproject)
+            .unwrap()
+            .contains("[tool.uv.sources]"));
+        assert!(std::fs::read_to_string(&deno)
+            .unwrap()
+            .contains("libs/streamlib-deno/mod.ts"));
+
+        unlink(&consumer).unwrap();
+
+        // After unlink: byte-identical + zero residue.
+        assert_eq!(std::fs::read(&cargo).unwrap(), orig_cargo, "cycle {cycle}: cargo");
+        assert_eq!(std::fs::read(&pyproject).unwrap(), orig_py, "cycle {cycle}: pyproject");
+        assert_eq!(std::fs::read(&deno).unwrap(), orig_deno, "cycle {cycle}: deno");
+        assert!(
+            !consumer.join(LINK_STATE_DIR).exists(),
+            "cycle {cycle}: .streamlib state must be gone"
+        );
+    }
+}
+
+#[test]
+fn unlink_deletes_a_cargo_config_it_created_and_prunes_the_dir() {
+    // Registry index lives in a PARENT dir; the consumer has no .cargo of its
+    // own, so link CREATES consumer/.cargo/config.toml and unlink must remove
+    // it and prune the empty .cargo dir.
+    let tmp = tempfile::tempdir().unwrap();
+    let outer = tmp.path().canonicalize().unwrap();
+    let outer_cargo = outer.join(".cargo");
+    std::fs::create_dir_all(&outer_cargo).unwrap();
+    std::fs::write(
+        outer_cargo.join("config.toml"),
+        format!("[registries.gitea]\nindex = \"{INDEX_URL}\"\n"),
+    )
+    .unwrap();
+
+    let consumer = outer.join("app");
+    std::fs::create_dir_all(&consumer).unwrap();
+
+    // Discovery must find the parent's index.
+    assert_eq!(discover_registry_index(&consumer).unwrap(), INDEX_URL);
+
+    link_with_fixed_crates(&consumer, &PathBuf::from("/checkout"));
+    assert!(consumer.join(".cargo").join("config.toml").is_file());
+
+    unlink(&consumer).unwrap();
+    assert!(!consumer.join(".cargo").exists(), ".cargo we created must be pruned");
+    assert!(!consumer.join(LINK_STATE_DIR).exists());
+    // Parent config untouched.
+    assert!(outer_cargo.join("config.toml").is_file());
+}
+
+#[test]
+fn unlink_with_no_active_link_is_a_friendly_noop() {
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    // No .streamlib at all.
+    unlink(&consumer).expect("unlink with no link must be Ok");
+}
+
+#[test]
+fn link_to_a_nonexistent_checkout_modifies_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    write_full_consumer(&consumer);
+    let before = std::fs::read(consumer.join(".cargo").join("config.toml")).unwrap();
+
+    let err = link(&consumer, &consumer.join("does-not-exist")).unwrap_err();
+    assert!(matches!(err, LinkError::NotAStreamlibCheckout(_)), "got {err:?}");
+    assert!(!consumer.join(LINK_STATE_DIR).exists());
+    assert_eq!(
+        std::fs::read(consumer.join(".cargo").join("config.toml")).unwrap(),
+        before
+    );
+}
+
+#[test]
+fn link_to_a_dir_without_cargo_toml_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    write_full_consumer(&consumer);
+    let bogus = tempfile::tempdir().unwrap();
+    let err = link(&consumer, bogus.path()).unwrap_err();
+    assert!(matches!(err, LinkError::NotAStreamlibCheckout(_)), "got {err:?}");
+}
+
+#[test]
+fn missing_registry_index_errors_actionably() {
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    // A consumer with a cargo config but NO gitea registry.
+    let cargo = consumer.join(".cargo");
+    std::fs::create_dir_all(&cargo).unwrap();
+    std::fs::write(cargo.join("config.toml"), "[alias]\nb = \"build\"\n").unwrap();
+    // Discovery from here should fail (assuming ~/.cargo has no gitea either;
+    // if it does, the walk finds it — so only assert the walk-local negative).
+    let err = discover_registry_index(&consumer);
+    // On dev boxes ~/.cargo may define gitea; only assert when it doesn't.
+    if dirs::home_dir()
+        .map(|h| read_gitea_index(&h.join(".cargo/config.toml")).ok().flatten().is_none())
+        .unwrap_or(true)
+    {
+        assert!(matches!(err, Err(LinkError::RegistryIndexNotConfigured)), "got {err:?}");
+    }
+}
+
+#[test]
+fn pyproject_and_deno_overrides_are_presence_gated() {
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    // Cargo config only — no pyproject, no deno.json.
+    let cargo = consumer.join(".cargo");
+    std::fs::create_dir_all(&cargo).unwrap();
+    std::fs::write(
+        cargo.join("config.toml"),
+        format!("[registries.gitea]\nindex = \"{INDEX_URL}\"\n"),
+    )
+    .unwrap();
+
+    let edits = plan_edits(&consumer, &PathBuf::from("/checkout"), INDEX_URL, &fake_crate_set()).unwrap();
+    assert_eq!(edits.len(), 1, "only the cargo config should be planned");
+    assert_eq!(edits[0].rel_path, PathBuf::from(".cargo").join("config.toml"));
+}
+
+#[test]
+fn linking_a_different_checkout_over_an_active_link_is_refused() {
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    write_full_consumer(&consumer);
+    // Simulate an active link to checkout A.
+    link_with_fixed_crates(&consumer, &PathBuf::from("/checkout-A"));
+
+    // link() to a DIFFERENT real checkout must refuse (the workspace root is a
+    // valid checkout, distinct from /checkout-A).
+    let err = link(&consumer, &workspace_checkout()).unwrap_err();
+    assert!(matches!(err, LinkError::AlreadyLinkedElsewhere { .. }), "got {err:?}");
+}
+
+#[test]
+fn deno_jsonc_with_comments_is_rejected_cleanly() {
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    let cargo = consumer.join(".cargo");
+    std::fs::create_dir_all(&cargo).unwrap();
+    std::fs::write(
+        cargo.join("config.toml"),
+        format!("[registries.gitea]\nindex = \"{INDEX_URL}\"\n"),
+    )
+    .unwrap();
+    std::fs::write(
+        consumer.join("deno.jsonc"),
+        "{\n  // a comment breaks strict JSON\n  \"imports\": {}\n}\n",
+    )
+    .unwrap();
+    let err = plan_edits(&consumer, &PathBuf::from("/checkout"), INDEX_URL, &fake_crate_set())
+        .unwrap_err();
+    assert!(matches!(err, LinkError::ManifestParse { .. }), "got {err:?}");
+}
+
+#[test]
+fn pack_is_refused_while_a_link_is_active_above_the_package() {
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    write_full_consumer(&consumer);
+    link_with_fixed_crates(&consumer, &PathBuf::from("/checkout"));
+
+    // From the consumer root and from a nested package dir, pack must refuse.
+    assert!(matches!(
+        ensure_no_active_link_for_pack(&consumer),
+        Err(LinkError::PackRefusedWhileLinked { .. })
+    ));
+    let nested = consumer.join("packages").join("thing");
+    std::fs::create_dir_all(&nested).unwrap();
+    assert!(matches!(
+        ensure_no_active_link_for_pack(&nested),
+        Err(LinkError::PackRefusedWhileLinked { .. })
+    ));
+
+    // After unlink, pack is allowed again.
+    unlink(&consumer).unwrap();
+    assert!(ensure_no_active_link_for_pack(&consumer).is_ok());
+}
+
+#[test]
+fn derive_linkable_crates_selects_the_streamlib_sdk_closure() {
+    // Runs `cargo metadata --no-deps` against the real workspace this test was
+    // built in — offline, no registry required.
+    let checkout = workspace_checkout();
+    let crates = match derive_linkable_crates(&checkout) {
+        Ok(c) => c,
+        Err(LinkError::CrateSetDerivation { detail, .. }) if detail.contains("failed to run cargo") => {
+            eprintln!("skipping: cargo not available to run metadata");
+            return;
+        }
+        Err(e) => panic!("cargo metadata failed: {e}"),
+    };
+
+    let sdk = crates.get("streamlib").expect("the `streamlib` SDK crate must be linkable");
+    assert!(
+        sdk.ends_with("libs/streamlib-sdk"),
+        "streamlib SDK member dir should be libs/streamlib-sdk, got {}",
+        sdk.display()
+    );
+    assert!(crates.contains_key("streamlib-idents"));
+    assert!(
+        crates.len() > 10,
+        "the whole-tree closure should be broad, got {} crates",
+        crates.len()
+    );
+    // Binaries and test fixtures are excluded (no lib target / publish=false).
+    assert!(!crates.contains_key("streamlib-cli"));
+}

--- a/libs/streamlib-cli/src/commands/mod.rs
+++ b/libs/streamlib-cli/src/commands/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 pub mod generate;
+pub mod link;
 pub mod logs;
 pub mod pkg;
 pub mod schema;

--- a/libs/streamlib-cli/src/commands/pkg.rs
+++ b/libs/streamlib-cli/src/commands/pkg.rs
@@ -183,6 +183,7 @@ pub async fn install(source: &str) -> Result<()> {
 /// artifact is a hand-off bundle; the consumer builds it from source.
 pub fn build(output: Option<&Path>) -> Result<()> {
     let package_dir = std::env::current_dir().context("resolve current working directory")?;
+    crate::commands::link::ensure_no_active_link_for_pack(&package_dir)?;
     let output_path = resolve_slpkg_output(&package_dir, output)?;
     let outcome = assemble_source_slpkg(&package_dir, &output_path)?;
     println!("Built source-only package: {}", output_path.display());
@@ -203,6 +204,7 @@ pub fn build(output: Option<&Path>) -> Result<()> {
 /// `STREAMLIB_REGISTRY_TOKEN` (falling back to `GITEA_URL`).
 pub fn publish() -> Result<()> {
     let package_dir = std::env::current_dir().context("resolve current working directory")?;
+    crate::commands::link::ensure_no_active_link_for_pack(&package_dir)?;
     // Lightweight manifest read — package metadata only, NO dependency
     // resolution (which would require the registry just to read name/version).
     let config = streamlib_cargo_build::read_minimal_project_config(&package_dir)

--- a/libs/streamlib-cli/src/commands/pkg.rs
+++ b/libs/streamlib-cli/src/commands/pkg.rs
@@ -183,7 +183,9 @@ pub async fn install(source: &str) -> Result<()> {
 /// artifact is a hand-off bundle; the consumer builds it from source.
 pub fn build(output: Option<&Path>) -> Result<()> {
     let package_dir = std::env::current_dir().context("resolve current working directory")?;
-    crate::commands::link::ensure_no_active_link_for_pack(&package_dir)?;
+    // Early friendly check; the load-bearing guard runs again inside
+    // `assemble_artifact`'s Slpkg branch (streamlib-pack owns the seam).
+    streamlib_pack::link_marker::ensure_no_active_link_for_pack(&package_dir)?;
     let output_path = resolve_slpkg_output(&package_dir, output)?;
     let outcome = assemble_source_slpkg(&package_dir, &output_path)?;
     println!("Built source-only package: {}", output_path.display());
@@ -204,7 +206,9 @@ pub fn build(output: Option<&Path>) -> Result<()> {
 /// `STREAMLIB_REGISTRY_TOKEN` (falling back to `GITEA_URL`).
 pub fn publish() -> Result<()> {
     let package_dir = std::env::current_dir().context("resolve current working directory")?;
-    crate::commands::link::ensure_no_active_link_for_pack(&package_dir)?;
+    // Early friendly check; the load-bearing guard runs again inside
+    // `assemble_artifact`'s Slpkg branch (streamlib-pack owns the seam).
+    streamlib_pack::link_marker::ensure_no_active_link_for_pack(&package_dir)?;
     // Lightweight manifest read — package metadata only, NO dependency
     // resolution (which would require the registry just to read name/version).
     let config = streamlib_cargo_build::read_minimal_project_config(&package_dir)

--- a/libs/streamlib-cli/src/main.rs
+++ b/libs/streamlib-cli/src/main.rs
@@ -93,10 +93,18 @@ enum Commands {
     Link {
         /// Path to a local streamlib checkout. Omit to print status.
         checkout: Option<PathBuf>,
+
+        /// Skip the post-link cargo resolution verification.
+        #[arg(long)]
+        skip_verify: bool,
     },
 
     /// Remove the active streamlib link, restoring every manifest byte-identically.
-    Unlink,
+    Unlink {
+        /// Discard files modified while the link was active instead of refusing.
+        #[arg(long)]
+        force: bool,
+    },
 
     /// Generate typed bindings from JTD schemas via the JTD-codegen pipeline.
     ///
@@ -252,16 +260,19 @@ async fn async_main(cli: Cli) -> Result<()> {
             PkgCommands::List => commands::pkg::list()?,
             PkgCommands::Remove { name } => commands::pkg::remove(&name)?,
         },
-        Some(Commands::Link { checkout }) => {
+        Some(Commands::Link {
+            checkout,
+            skip_verify,
+        }) => {
             let consumer_root = std::env::current_dir()?;
             match checkout {
-                Some(checkout) => commands::link::link(&consumer_root, &checkout)?,
+                Some(checkout) => commands::link::link(&consumer_root, &checkout, skip_verify)?,
                 None => commands::link::status(&consumer_root)?,
             }
         }
-        Some(Commands::Unlink) => {
+        Some(Commands::Unlink { force }) => {
             let consumer_root = std::env::current_dir()?;
-            commands::link::unlink(&consumer_root)?;
+            commands::link::unlink(&consumer_root, force)?;
         }
         Some(Commands::Generate {
             runtime,

--- a/libs/streamlib-cli/src/main.rs
+++ b/libs/streamlib-cli/src/main.rs
@@ -84,6 +84,20 @@ enum Commands {
         action: PkgCommands,
     },
 
+    /// Point this consumer's entire streamlib surface at a local checkout.
+    ///
+    /// Run from a consumer root (app or package dir). Emits whole-tree
+    /// language-native overrides (cargo `[patch]`, uv sources, Deno import map)
+    /// so an edit in the checkout is picked up by the next build with no
+    /// publish. Omit `<CHECKOUT>` to print the active link status.
+    Link {
+        /// Path to a local streamlib checkout. Omit to print status.
+        checkout: Option<PathBuf>,
+    },
+
+    /// Remove the active streamlib link, restoring every manifest byte-identically.
+    Unlink,
+
     /// Generate typed bindings from JTD schemas via the JTD-codegen pipeline.
     ///
     /// Same pipeline contributors run as `cargo xtask generate-schemas`,
@@ -238,6 +252,17 @@ async fn async_main(cli: Cli) -> Result<()> {
             PkgCommands::List => commands::pkg::list()?,
             PkgCommands::Remove { name } => commands::pkg::remove(&name)?,
         },
+        Some(Commands::Link { checkout }) => {
+            let consumer_root = std::env::current_dir()?;
+            match checkout {
+                Some(checkout) => commands::link::link(&consumer_root, &checkout)?,
+                None => commands::link::status(&consumer_root)?,
+            }
+        }
+        Some(Commands::Unlink) => {
+            let consumer_root = std::env::current_dir()?;
+            commands::link::unlink(&consumer_root)?;
+        }
         Some(Commands::Generate {
             runtime,
             output,

--- a/libs/streamlib-pack/Cargo.toml
+++ b/libs/streamlib-pack/Cargo.toml
@@ -12,7 +12,10 @@ repository.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 toml = { workspace = true }
 zip = "2.2"

--- a/libs/streamlib-pack/src/lib.rs
+++ b/libs/streamlib-pack/src/lib.rs
@@ -45,6 +45,8 @@ use streamlib_processor_schema::ProcessorLanguage;
 
 pub use streamlib_cargo_build::CargoProfile;
 
+pub mod link_marker;
+
 /// Which child-process stream a build-log line came from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PackStream {
@@ -160,6 +162,11 @@ pub fn assemble_artifact(
     // `RewriteRelativeToAbsolute` policy, which is the dev-resolution path.
     if matches!(target, AssembleTarget::Slpkg(_)) {
         ensure_no_path_artifacts(pkg_dir)?;
+        // Same rationale as the path check: a distributable `.slpkg` must not
+        // be assembled from a tree whose dependency resolution is redirected
+        // by an active `streamlib link`. `StagedDir` stays exempt so
+        // orchestrator load-time builds keep working while linked.
+        link_marker::ensure_no_active_link_for_pack(pkg_dir)?;
     }
 
     // (archive_path, source_path) pairs for every file EXCEPT the
@@ -886,6 +893,63 @@ mod tests {
             !entries.iter().any(|e| e.starts_with("lib/")),
             "schemas-only must not carry lib/, got {entries:?}"
         );
+    }
+
+    #[test]
+    fn slpkg_assembly_refuses_under_an_active_link_but_staged_dir_is_exempt() {
+        // The load-bearing pack-seam guard: a distributable `.slpkg` must not
+        // assemble while a `streamlib link` marker exists above the package
+        // dir. StagedDir (orchestrator load-time build) stays exempt so
+        // linked dev trees keep running pipelines.
+        let root = tempdir().unwrap();
+        let marker_dir = root.path().join(link_marker::LINK_STATE_DIR);
+        std::fs::create_dir_all(&marker_dir).unwrap();
+        std::fs::write(
+            marker_dir.join(link_marker::LINK_MANIFEST_FILE),
+            r#"{"checkout":"/opt/sl","python_sdk_path":"/opt/sl/libs/streamlib-python","deno_sdk_entrypoint_path":"/opt/sl/libs/streamlib-deno/mod.ts","linked_at":"t","linked_crate_count":1,"state":"active","files":[]}"#,
+        )
+        .unwrap();
+
+        let pkg = root.path().join("pkg");
+        std::fs::create_dir_all(pkg.join("schemas")).unwrap();
+        std::fs::write(
+            pkg.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: linked-pkg\n  version: 0.1.0\nschemas:\n  T:\n    file: schemas/t.yaml\n",
+        )
+        .unwrap();
+        std::fs::write(
+            pkg.join("schemas/t.yaml"),
+            "metadata:\n  type: T\n  max_payload_bytes: 16\n",
+        )
+        .unwrap();
+
+        // Slpkg target → typed refusal.
+        let err = assemble_artifact(
+            &pkg,
+            &AssembleTarget::Slpkg(pkg.join("o.slpkg")),
+            &slpkg_opts(false),
+            &(),
+        )
+        .unwrap_err();
+        assert!(
+            err.downcast_ref::<link_marker::LinkMarkerError>()
+                .is_some_and(|e| matches!(e, link_marker::LinkMarkerError::PackRefusedWhileLinked { .. })),
+            "expected PackRefusedWhileLinked, got {err:?}"
+        );
+
+        // StagedDir target → exempt, assembles fine while linked.
+        let staged = tempdir().unwrap();
+        assemble_artifact(
+            &pkg,
+            &AssembleTarget::StagedDir(staged.path().to_path_buf()),
+            &AssembleOptions {
+                no_build: false,
+                profile: CargoProfile::Release,
+                path_deps: PathDepPolicy::RewriteRelativeToAbsolute,
+            },
+            &(),
+        )
+        .expect("StagedDir assembly must stay exempt while linked");
     }
 
     #[test]

--- a/libs/streamlib-pack/src/link_marker.rs
+++ b/libs/streamlib-pack/src/link_marker.rs
@@ -1,0 +1,217 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Shared `streamlib link` marker schema (`.streamlib/link.json`) + discovery.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Consumer-root-relative directory holding all link state.
+pub const LINK_STATE_DIR: &str = ".streamlib";
+/// Manifest recording the link transaction (checkout + every touched file).
+pub const LINK_MANIFEST_FILE: &str = "link.json";
+/// Directory under [`LINK_STATE_DIR`] mirroring pre-edit backups by relative path.
+pub const LINK_BACKUP_DIR: &str = "link-backup";
+
+/// Failure modes of link-marker discovery and the pack/publish guard.
+#[derive(Debug, thiserror::Error)]
+pub enum LinkMarkerError {
+    /// The link manifest exists but cannot be parsed — never silently ignored.
+    #[error("link state at `{path}` is corrupt: {detail}")]
+    CorruptLinkState { path: PathBuf, detail: String },
+
+    /// A filesystem operation on the marker failed.
+    #[error("filesystem error at `{path}`: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// A distributable pack/publish was attempted while a link is active.
+    #[error(
+        "this package cannot be packed or published while a streamlib link is active (marker: \
+         {marker}). Local link overrides are dev-only and must not leak into a distributed \
+         artifact — run `streamlib unlink` first"
+    )]
+    PackRefusedWhileLinked { marker: PathBuf },
+}
+
+/// Transaction state of a recorded link.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LinkTransactionState {
+    /// Manifest persisted; edits may be partially applied. Recoverable via `streamlib unlink`.
+    Applying,
+    /// Every edit and backup landed; the link is fully established.
+    Active,
+}
+
+/// One manifest file the link plan covers, recorded for byte-clean teardown.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LinkedManifestFile {
+    /// Path relative to the consumer root.
+    pub path: PathBuf,
+    /// Whether the file existed before linking. `false` ⇒ unlink deletes it.
+    pub existed_before: bool,
+    /// Hex SHA-256 of the pre-edit content (empty when `!existed_before`).
+    pub pre_edit_sha256: String,
+    /// Hex SHA-256 of the planned post-edit content.
+    pub post_edit_sha256: String,
+}
+
+/// Persisted record of a `streamlib link` transaction.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LinkManifest {
+    /// Canonicalized path of the linked streamlib checkout.
+    pub checkout: PathBuf,
+    /// Resolved absolute path of the checkout's Python SDK (uv source target).
+    pub python_sdk_path: PathBuf,
+    /// Resolved absolute path of the checkout's Deno SDK entrypoint module.
+    pub deno_sdk_entrypoint_path: PathBuf,
+    /// RFC-3339 timestamp of when the link was established.
+    pub linked_at: String,
+    /// Number of cargo crates redirected to the checkout.
+    pub linked_crate_count: usize,
+    /// Transaction state — `applying` until every edit lands, then `active`.
+    pub state: LinkTransactionState,
+    /// Every manifest file the link plan covers (in apply order).
+    pub files: Vec<LinkedManifestFile>,
+}
+
+/// Walk up from `start` to the filesystem root looking for a link marker
+/// (`.streamlib/link.json`) in ANY state. Returns the marker path when found.
+#[tracing::instrument(skip_all, fields(start = %start.display()))]
+pub fn find_active_link_marker(start: &Path) -> Option<PathBuf> {
+    let mut dir = Some(start);
+    while let Some(d) = dir {
+        let marker = d.join(LINK_STATE_DIR).join(LINK_MANIFEST_FILE);
+        if marker.is_file() {
+            return Some(marker);
+        }
+        dir = d.parent();
+    }
+    None
+}
+
+/// Load and parse the link manifest at `marker_path`. Corruption is a loud
+/// typed error, never a silent `None`.
+#[tracing::instrument(skip_all, fields(marker = %marker_path.display()))]
+pub fn load_link_manifest(marker_path: &Path) -> Result<LinkManifest, LinkMarkerError> {
+    let body = std::fs::read_to_string(marker_path).map_err(|e| LinkMarkerError::Io {
+        path: marker_path.to_path_buf(),
+        source: e,
+    })?;
+    serde_json::from_str(&body).map_err(|e| LinkMarkerError::CorruptLinkState {
+        path: marker_path.to_path_buf(),
+        detail: e.to_string(),
+    })
+}
+
+/// Find (upward walk from `start`) and load the link manifest, if any.
+pub fn find_and_load_active_link(
+    start: &Path,
+) -> Result<Option<(PathBuf, LinkManifest)>, LinkMarkerError> {
+    match find_active_link_marker(start) {
+        Some(marker) => {
+            let manifest = load_link_manifest(&marker)?;
+            Ok(Some((marker, manifest)))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Refuse a distributable pack/publish while a link marker exists (any state)
+/// anywhere above `package_dir`.
+#[tracing::instrument(skip_all, fields(package_dir = %package_dir.display()))]
+pub fn ensure_no_active_link_for_pack(package_dir: &Path) -> Result<(), LinkMarkerError> {
+    if let Some(marker) = find_active_link_marker(package_dir) {
+        return Err(LinkMarkerError::PackRefusedWhileLinked { marker });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_marker(root: &Path, body: &str) -> PathBuf {
+        let dir = root.join(LINK_STATE_DIR);
+        std::fs::create_dir_all(&dir).unwrap();
+        let marker = dir.join(LINK_MANIFEST_FILE);
+        std::fs::write(&marker, body).unwrap();
+        marker
+    }
+
+    fn valid_manifest_json() -> String {
+        r#"{
+  "checkout": "/opt/streamlib",
+  "python_sdk_path": "/opt/streamlib/libs/streamlib-python",
+  "deno_sdk_entrypoint_path": "/opt/streamlib/libs/streamlib-deno/mod.ts",
+  "linked_at": "2026-01-01T00:00:00Z",
+  "linked_crate_count": 3,
+  "state": "active",
+  "files": []
+}"#
+        .to_string()
+    }
+
+    #[test]
+    fn corrupt_link_json_is_a_loud_typed_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let marker = write_marker(tmp.path(), "{ not json at all");
+        let err = load_link_manifest(&marker).unwrap_err();
+        assert!(matches!(err, LinkMarkerError::CorruptLinkState { .. }), "got {err:?}");
+        // And the find-and-load composite surfaces it too (no silent None).
+        let err = find_and_load_active_link(tmp.path()).unwrap_err();
+        assert!(matches!(err, LinkMarkerError::CorruptLinkState { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn upward_walk_finds_marker_in_parent_and_pack_guard_trips_in_any_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_marker(tmp.path(), &valid_manifest_json());
+        let nested = tmp.path().join("packages").join("thing");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        assert!(find_active_link_marker(&nested).is_some());
+        assert!(matches!(
+            ensure_no_active_link_for_pack(&nested),
+            Err(LinkMarkerError::PackRefusedWhileLinked { .. })
+        ));
+
+        // `applying` state trips the guard identically (marker presence gates).
+        write_marker(
+            tmp.path(),
+            &valid_manifest_json().replace("\"active\"", "\"applying\""),
+        );
+        assert!(matches!(
+            ensure_no_active_link_for_pack(&nested),
+            Err(LinkMarkerError::PackRefusedWhileLinked { .. })
+        ));
+    }
+
+    #[test]
+    fn manifest_round_trips_through_serde() {
+        let manifest = LinkManifest {
+            checkout: PathBuf::from("/opt/streamlib"),
+            python_sdk_path: PathBuf::from("/opt/streamlib/libs/streamlib-python"),
+            deno_sdk_entrypoint_path: PathBuf::from("/opt/streamlib/libs/streamlib-deno/mod.ts"),
+            linked_at: "t".into(),
+            linked_crate_count: 2,
+            state: LinkTransactionState::Applying,
+            files: vec![LinkedManifestFile {
+                path: PathBuf::from(".cargo/config.toml"),
+                existed_before: true,
+                pre_edit_sha256: "aa".into(),
+                post_edit_sha256: "bb".into(),
+            }],
+        };
+        let json = serde_json::to_string(&manifest).unwrap();
+        let back: LinkManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.state, LinkTransactionState::Applying);
+        assert_eq!(back.files.len(), 1);
+        assert_eq!(back.python_sdk_path, manifest.python_sdk_path);
+    }
+}


### PR DESCRIPTION
## What

`streamlib link <checkout>` run from a **consumer root** (app or package dir) points the entire streamlib surface a consumer resolves at a local checkout via language-native overrides, so an edit in the checkout is picked up by the next build with **no publish step**. `streamlib unlink` restores every touched manifest **byte-identically**. Pack/publish of a distributable `.slpkg` refuses while a link is active. Whole-tree or nothing.

Closes #1214.

## Design

### Manifest-first transaction

The full edit plan is persisted to `.streamlib/link.json` **before any manifest is touched** — created with O_EXCL (closing the concurrent-link race), recording per file: relative path, `existed_before`, pre-edit SHA-256, post-edit SHA-256, plus a `state` field (`applying` → `active` only after every backup + edit lands). Consequences:

- A crash in **any** window (before edits, mid-edits, before the state flip) is recoverable by a plain `streamlib unlink` — the tri-state restore below handles originals and patched content alike.
- Rollback after a failed apply is **outcome-verified** (restored file must read back byte-identical; created file must be gone). Link state is removed only on full rollback success; otherwise `RollbackIncomplete` preserves the manifest + backups and names the recovery path.
- A same-checkout re-link refreshes, and it **derives the new crate set before unlinking** — a failed derivation preserves the working link. A different checkout, torn state, or racing marker each refuse with a dedicated typed error.

### Tri-state unlink

Per file: live content == post-edit hash → restore the (hash-verified) backup; == pre-edit hash → skip (already original); **neither → refuse** naming the file — silent reversion of user edits made during the link window is not acceptable. `streamlib unlink --force` is the documented clobber escape. Classification and backup verification run fully before any mutation.

### Shared marker primitive (`streamlib-pack::link_marker`)

The link.json schema, the upward-walk discovery, and the pack/publish guard live once in `streamlib-pack`; the CLI and the build orchestrator both consume it. The manifest carries the resolved **absolute** `python_sdk_path` / `deno_sdk_entrypoint_path`, so downstream consumers read data instead of re-deriving checkout-relative conventions. A corrupt link.json is a **loud typed error** everywhere (never a silent skip that would leave cargo patched but the venv resolving from the registry).

### Guard at the ownership seam

The load-bearing pack/publish refusal lives inside `assemble_artifact`'s `Slpkg` branch, right next to `ensure_no_path_artifacts` (same rationale: a distributable artifact must not be shaped by dev-only overrides). `StagedDir` stays exempt, so orchestrator load-time builds keep working while linked. The CLI verbs keep an early friendly check via the shared primitive.

### Post-link verification

After emission succeeds, `link` runs `cargo metadata --offline` (online fallback) in the consumer and requires every streamlib crate in the resolved graph to be a **path source at the checkout**. On failure — e.g. a semver-incompatible consumer requirement, where cargo *silently ignores* `[patch]` — the entire link is rolled back and the error names the crates whose requirements don't admit the checkout's versions. This converts "your edit is what runs" from hope into a per-link guarantee; `--skip-verify` is the escape hatch.

### Overrides emitted

- **Cargo** — config-level `[patch."<gitea-index-url>"]` in `.cargo/config.toml`, one path entry per linkable crate. The crate set is derived **live via `cargo metadata`** on the checkout (same selection as the publish closure with `STREAMLIB_PUBLISH_ALL_LIBS=1`); the index URL is discovered from the consumer's effective cargo config (walk-up + home), never hardcoded.
- **Python** — `[tool.uv.sources] streamlib = { path = "<checkout>/libs/streamlib-python", editable = true }` (presence-gated). The build orchestrator's venv tail injects the same override into the **staged** pyproject when a link is active for the package's source tree, reading the SDK path from the marker.
- **Deno** — import-map `streamlib` entry rewritten to the checkout's `libs/streamlib-deno/mod.ts` (presence-gated; strict JSON only). No orchestrator-side Deno hook is needed today: Deno resolves its import map at runtime from the consumer-root override, whereas Python bakes resolution into the staged venv at install time.

### Scope note — Python/Deno sibling packages

`packages/*` are Rust-only today, so only the SDK override has a real target on those toolchains right now; the emission is shaped so package entries slot in later.

## Proven E2E (gitea daemon down throughout — the milestone's whole point)

- `streamlib link <checkout>` from a registry-only consumer emits the patch for all 32 crates; `cargo metadata` / `cargo tree --offline` resolve `streamlib` to the checkout's `libs/streamlib-sdk` path source; post-link verification reports `verified=15` (the crates present in that consumer's resolve graph).
- Negative verification: consumer pinned to `=0.4.33` → cargo ignores the patch → verification fails → **link fully rolled back**, byte-clean, zero residue.
- `pkg build` refuses via the pack-seam guard; hand-edited config → `unlink` refuses; `unlink --force` restores the pre-link original byte-identically with zero residue.
- Not exercised: a full GPU pipeline run of the linked consumer (link mode is toolchain-emission only and does not touch the engine's runtime resolver; the cargo path-source proof + standing verification is the honest gate).

## Tests

`cargo test -p streamlib-cli -p streamlib-pack -p streamlib-build-orchestrator` green (32 + 23 + 19). Coverage highlights:

- Byte-clean idempotent link/unlink cycles; created-config teardown + dir prune; live crate-set derivation.
- **Crash windows**: manifest-written-no-edits and all-edits-no-flip both recovered by plain `unlink`; torn state refuses re-link.
- **O_EXCL**: racing second link refused by the exclusive marker create.
- **T1**: last-edit apply failure (read-only deno.json) → earlier edits rolled back byte-identically, verified rollback clears state; dir-occupation variant → `RollbackIncomplete` with backups + manifest preserved.
- **Tri-state**: hand-edit refused without `--force`, restored with it; user-reverted file skipped; corrupted backup refused (hash guard).
- **T3**: one real `link()` offline E2E — index discovery → derivation → emission → post-link verification → same-checkout refresh (locking derive-before-unlink via a companion broken-checkout test) → byte-clean unlink.
- **Pack seam**: `Slpkg` assembly refuses under a marker above the package dir; `StagedDir` exempt. Corrupt link.json is a loud typed error in pack and in the orchestrator.
- **T4**: orchestrator `provision_python_venv` end-to-end against a marked source tree (real `uv` install of the linked fixture SDK) + staged-pyproject override assertion; injectable-home makes the missing-registry negative environment-independent.

## Known limitations

- **No version-compat pre-check on the cargo `[patch]`** before emission — instead, the post-link verification catches the silent-ignore case after the fact and rolls back (cargo itself also warns "Patch ... was not used" at build time). Pre-checking would duplicate cargo's resolver.
- **The upward marker walk has no repo-boundary stop** — a marker in any ancestor directory trips link discovery and the pack guard. The marker path is printed on every refusal, so a surprising trip is immediately diagnosable.
- **deno.jsonc with comments** is rejected (strict JSON only) rather than comment-preserving-rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wr1VLKMBbFpsmU7zAcniU2
