### PR TITLE
feat(runtime): enforce single-version-per-package at module resolution

### DIFF
--- a/libs/streamlib-engine/src/core/runtime/module_loader/errors.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/errors.rs
@@ -298,6 +298,37 @@ pub enum AddModuleError {
         conflicting_version: streamlib_idents::SemVer,
         conflicting_required_by: String,
     },
+
+    /// This load skipped registering `package` because a concurrent
+    /// `add_module` load was already resolving the same version — and
+    /// that concurrent load subsequently failed, so the package never
+    /// registered. Fails loudly rather than reporting a false success
+    /// over an unregistered dependency.
+    #[error(
+        "Concurrent load of '{package}' (version {version}) failed after \
+         this load skipped it as already-in-flight — the package never \
+         registered. Retry this add_module call."
+    )]
+    ConcurrentLoadOfSkippedDependencyFailed {
+        package: streamlib_idents::PackageRef,
+        version: streamlib_idents::SemVer,
+    },
+
+    /// This load skipped `package` as already-in-flight on a concurrent
+    /// `add_module` load, and that load neither committed nor failed
+    /// within the wait window. Defensive bound — a wedged concurrent
+    /// load surfaces as this typed error, never as a hang.
+    #[error(
+        "Timed out after {waited_secs}s waiting for a concurrent load of \
+         '{package}' (version {version}) that this load skipped as \
+         already-in-flight. The concurrent load may be wedged; retry this \
+         add_module call once it settles."
+    )]
+    ConcurrentLoadOfSkippedDependencyTimedOut {
+        package: streamlib_idents::PackageRef,
+        version: streamlib_idents::SemVer,
+        waited_secs: u64,
+    },
 }
 
 impl From<AddModuleError> for Error {

--- a/libs/streamlib-engine/src/core/runtime/module_loader/errors.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/errors.rs
@@ -271,6 +271,33 @@ pub enum AddModuleError {
     DependencyCycleDetected {
         cycle: Vec<streamlib_idents::PackageRef>,
     },
+
+    /// Two requirers resolved the same `@org/name` package to different
+    /// concrete versions within the runtime's lifetime — a diamond
+    /// version conflict. The engine enforces a single version per package
+    /// across the whole module graph (and across successive `add_module`
+    /// calls), so this is a hard error rather than a silent
+    /// double-registration. Resolve it by pinning a single version via a
+    /// `patch:` entry in the requiring `streamlib.yaml` that redirects the
+    /// package to one `path:` / `git:` source, or by aligning the two
+    /// requirers on a single declared version.
+    #[error(
+        "Single-version conflict for package '{package}': version \
+         {existing_version} (required by {existing_required_by}) conflicts \
+         with version {conflicting_version} (required by \
+         {conflicting_required_by}). streamlib enforces one version per \
+         package across the module graph — pin a single version via a \
+         `patch:` entry in the requiring streamlib.yaml (redirecting \
+         '{package}' to one path/git source), or align the two requirers \
+         on the same version."
+    )]
+    SingleVersionConflict {
+        package: streamlib_idents::PackageRef,
+        existing_version: streamlib_idents::SemVer,
+        existing_required_by: String,
+        conflicting_version: streamlib_idents::SemVer,
+        conflicting_required_by: String,
+    },
 }
 
 impl From<AddModuleError> for Error {

--- a/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -59,6 +59,7 @@ pub use build_orchestrator::{
 };
 pub use errors::{AddModuleError, RemoveModuleError};
 pub use processor_registration::host_target_triple;
+pub(crate) use recursive_walker::ResolutionMemo;
 pub use slpkg::extract_slpkg_to_cache;
 pub use source::{ArtifactChecksum, SemVerRange, Strategy};
 
@@ -113,6 +114,7 @@ fn run_module_load(
     module: streamlib_idents::ModuleIdent,
     strategy: Strategy,
     events: broadcast::Sender<ModuleLoadEvent>,
+    resolution_memo: Arc<parking_lot::Mutex<ResolutionMemo>>,
 ) -> std::result::Result<LoadedModule, AddModuleError> {
     let start = Instant::now();
     let _ = events.send(ModuleLoadEvent::Started {
@@ -132,6 +134,7 @@ fn run_module_load(
         strategy,
         &mut seen,
         &mut path,
+        &resolution_memo,
     );
     match result {
         Ok(()) => {
@@ -201,13 +204,14 @@ impl Runner {
         let node = self.iceoryx2_node.clone();
         let orchestrator = self.build_orchestrator.lock().clone();
         let loading = Arc::clone(&self.loading_modules);
+        let memo = Arc::clone(&self.resolution_memo);
         let events = tx.clone();
         let module_for_task = module.clone();
         let pkg_for_task = pkg_ref;
 
         let join = self.tokio_runtime_variant.handle().spawn_blocking(move || {
             let result =
-                run_module_load(node, orchestrator, module_for_task, strategy, events);
+                run_module_load(node, orchestrator, module_for_task, strategy, events, memo);
             loading.lock().remove(&pkg_for_task);
             result
         });

--- a/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -104,6 +104,12 @@ impl BuildEventSink for ModuleEventSink {
     }
 }
 
+/// Monotonic id for each top-level `add_module` load. Identifies the
+/// load in the resolution memo's in-flight placeholders and guards the
+/// `loading_modules` completion-removal against a same-package overwrite
+/// by a later load.
+static NEXT_MODULE_LOAD_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// The blocking body of a single module load. Runs on `spawn_blocking`:
 /// it resolves the strategy, materializes via the orchestrator when a
 /// build is required (blocking), recursively loads transitive deps, and
@@ -114,7 +120,8 @@ fn run_module_load(
     module: streamlib_idents::ModuleIdent,
     strategy: Strategy,
     events: broadcast::Sender<ModuleLoadEvent>,
-    resolution_memo: Arc<parking_lot::Mutex<ResolutionMemo>>,
+    resolution_memo: Arc<ResolutionMemo>,
+    load_id: u64,
 ) -> std::result::Result<LoadedModule, AddModuleError> {
     let start = Instant::now();
     let _ = events.send(ModuleLoadEvent::Started {
@@ -126,6 +133,7 @@ fn run_module_load(
     };
     let mut seen: HashSet<streamlib_idents::PackageRef> = HashSet::new();
     let mut path: Vec<streamlib_idents::PackageRef> = Vec::new();
+    let mut skipped_in_flight: Vec<recursive_walker::SkippedInFlightDependency> = Vec::new();
     let result = recursive_walker::add_module_recursively(
         &iceoryx2_node,
         orchestrator.as_ref(),
@@ -135,7 +143,42 @@ fn run_module_load(
         &mut seen,
         &mut path,
         &resolution_memo,
+        load_id,
+        &mut skipped_in_flight,
     );
+    // End-of-walk verification: this walk skipped some packages because a
+    // CONCURRENT load had them in flight at the same version. Before
+    // reporting success, verify each owner actually committed — an owner
+    // that failed (or wedged) means this load's graph is missing a
+    // registration, and Ok would be a false success. Mid-walk nobody ever
+    // blocks; these waits depend only on other loads' per-package commits,
+    // which flip as their subtrees unwind without needing this waiter —
+    // structurally deadlock-free.
+    let result = result.and_then(|()| {
+        use recursive_walker::{ConcurrentPackageLoadOutcome, SKIPPED_IN_FLIGHT_WAIT_TIMEOUT};
+        for skipped in skipped_in_flight {
+            match skipped
+                .completion_signal
+                .wait_for_outcome(SKIPPED_IN_FLIGHT_WAIT_TIMEOUT)
+            {
+                Some(ConcurrentPackageLoadOutcome::Committed) => {}
+                Some(ConcurrentPackageLoadOutcome::Failed) => {
+                    return Err(AddModuleError::ConcurrentLoadOfSkippedDependencyFailed {
+                        package: skipped.package,
+                        version: skipped.version,
+                    });
+                }
+                None => {
+                    return Err(AddModuleError::ConcurrentLoadOfSkippedDependencyTimedOut {
+                        package: skipped.package,
+                        version: skipped.version,
+                        waited_secs: SKIPPED_IN_FLIGHT_WAIT_TIMEOUT.as_secs(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    });
     match result {
         Ok(()) => {
             let _ = events.send(ModuleLoadEvent::Completed {
@@ -192,14 +235,17 @@ impl Runner {
         strategy: Strategy,
     ) -> AddedModule {
         let pkg_ref = module.package_ref();
+        let load_id = NEXT_MODULE_LOAD_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         // Subscribe BEFORE spawning so a driver can't miss early events.
         let (tx, initial_rx) = broadcast::channel(MODULE_EVENT_CHANNEL_CAPACITY);
 
         // Mark in-flight so `start()` can refuse to run the graph while
-        // loads are pending.
+        // loads are pending. Keyed by package ref; the load id lets the
+        // completion below remove only ITS OWN entry — a later load of
+        // the same package ref that overwrote this entry stays tracked.
         self.loading_modules
             .lock()
-            .insert(pkg_ref.clone(), module.clone());
+            .insert(pkg_ref.clone(), (load_id, module.clone()));
 
         let node = self.iceoryx2_node.clone();
         let orchestrator = self.build_orchestrator.lock().clone();
@@ -210,9 +256,24 @@ impl Runner {
         let pkg_for_task = pkg_ref;
 
         let join = self.tokio_runtime_variant.handle().spawn_blocking(move || {
-            let result =
-                run_module_load(node, orchestrator, module_for_task, strategy, events, memo);
-            loading.lock().remove(&pkg_for_task);
+            let result = run_module_load(
+                node,
+                orchestrator,
+                module_for_task,
+                strategy,
+                events,
+                memo,
+                load_id,
+            );
+            {
+                let mut loading = loading.lock();
+                if loading
+                    .get(&pkg_for_task)
+                    .is_some_and(|(owner_load_id, _)| *owner_load_id == load_id)
+                {
+                    loading.remove(&pkg_for_task);
+                }
+            }
             result
         });
 
@@ -337,6 +398,10 @@ impl Runner {
     /// [`Runner::start`] to refuse running the graph while loads are
     /// pending.
     pub(crate) fn pending_module_loads(&self) -> Vec<streamlib_idents::ModuleIdent> {
-        self.loading_modules.lock().values().cloned().collect()
+        self.loading_modules
+            .lock()
+            .values()
+            .map(|(_, module)| module.clone())
+            .collect()
     }
 }

--- a/libs/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
@@ -233,24 +233,22 @@ fn add_module_recursive_body(
     // range-only check would never fire. A same-version re-encounter
     // short-circuits before re-registration + re-recursion, which also
     // fixes the historical silent double-registration.
+    //
+    // The commit into the memo is deferred to *after* this package's
+    // registration + transitive walk succeed (see the end of the
+    // function). A same-package re-entry within the current subtree is a
+    // dependency cycle already caught by the `seen` guard above, so
+    // deferring the commit never weakens conflict detection — but it does
+    // keep a load that fails mid-registration from poisoning the memo and
+    // making a retried `add_module` silently skip an unregistered package.
     let requirer = RequirerRecord {
         requirer: (path.len() >= 2).then(|| path[path.len() - 2].clone()),
         declared_range: module.version.clone(),
     };
     {
         let mut memo = resolution_memo.lock();
-        match memo.get_mut(&pkg_ref) {
-            None => {
-                memo.insert(
-                    pkg_ref.clone(),
-                    ResolvedPackageRecord {
-                        version: on_disk_version,
-                        source_path: manifest_dir.clone(),
-                        required_by: vec![requirer],
-                    },
-                );
-            }
-            Some(existing) if existing.version == on_disk_version => {
+        if let Some(existing) = memo.get_mut(&pkg_ref) {
+            if existing.version == on_disk_version {
                 existing.required_by.push(requirer);
                 tracing::debug!(
                     package = %pkg_ref,
@@ -260,23 +258,21 @@ fn add_module_recursive_body(
                 );
                 return Ok(());
             }
-            Some(existing) => {
-                return Err(AddModuleError::SingleVersionConflict {
-                    package: pkg_ref.clone(),
-                    existing_version: existing.version,
-                    existing_required_by: format!(
-                        "{} [resolved from {}]",
-                        describe_requirers(&existing.required_by),
-                        existing.source_path.display(),
-                    ),
-                    conflicting_version: on_disk_version,
-                    conflicting_required_by: format!(
-                        "{} [resolved from {}]",
-                        describe_requirer(&requirer),
-                        manifest_dir.display(),
-                    ),
-                });
-            }
+            return Err(AddModuleError::SingleVersionConflict {
+                package: pkg_ref.clone(),
+                existing_version: existing.version,
+                existing_required_by: format!(
+                    "{} [resolved from {}]",
+                    describe_requirers(&existing.required_by),
+                    existing.source_path.display(),
+                ),
+                conflicting_version: on_disk_version,
+                conflicting_required_by: format!(
+                    "{} [resolved from {}]",
+                    describe_requirer(&requirer),
+                    manifest_dir.display(),
+                ),
+            });
         }
     }
 
@@ -321,6 +317,20 @@ fn add_module_recursive_body(
             source: Box::new(e),
         }
     })?;
+
+    // Registration + the transitive walk succeeded — commit this package's
+    // resolved version to the runtime-lifetime memo now (not at the gate
+    // check above), so a load that fails mid-registration leaves no entry
+    // and a retry re-runs the full registration rather than silently
+    // skipping.
+    resolution_memo.lock().insert(
+        pkg_ref.clone(),
+        ResolvedPackageRecord {
+            version: on_disk_version,
+            source_path: manifest_dir.clone(),
+            required_by: vec![requirer],
+        },
+    );
 
     Ok(())
 }

--- a/libs/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
@@ -1,10 +1,11 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
-use parking_lot::Mutex;
+use parking_lot::{Condvar, Mutex};
 
 use super::build_orchestrator::{BuildEventSink, BuildOrchestrator, BuildPolicy};
 use super::errors::AddModuleError;
@@ -13,6 +14,12 @@ use super::schema_registration::register_package_schemas;
 use super::source::{read_version_from_manifest_dir, resolve_strategy_to_source, ResolvedSource, Strategy};
 use crate::core::{Error, Result};
 use crate::iceoryx2::Iceoryx2Node;
+
+/// How long a load waits, after its own walk succeeds, for a concurrent
+/// load that owned a skipped in-flight dependency to commit or fail.
+/// Generous (builds can take minutes); the timeout exists so a wedged
+/// concurrent load surfaces as a typed error, never a hang.
+pub(super) const SKIPPED_IN_FLIGHT_WAIT_TIMEOUT: Duration = Duration::from_secs(600);
 
 /// A single requirer edge into a resolved package: the parent
 /// [`PackageRef`] that declared the dependency (or `None` for a
@@ -31,16 +38,14 @@ pub(crate) struct RequirerRecord {
     pub declared_range: streamlib_idents::SemVerRange,
 }
 
-/// The persistent single-version resolution record for one `@org/name`
-/// package across the whole runtime lifetime. Keyed by [`PackageRef`] in
-/// the loader's [`ResolutionMemo`]; the concrete resolved [`SemVer`] is
-/// authoritative and every subsequent encounter is checked against it.
+/// The single-version resolution record for one `@org/name` package.
+/// The concrete resolved [`SemVer`] is authoritative; every subsequent
+/// encounter is checked against it.
 ///
-/// [`PackageRef`]: streamlib_idents::PackageRef
 /// [`SemVer`]: streamlib_idents::SemVer
 #[derive(Debug, Clone)]
 pub(crate) struct ResolvedPackageRecord {
-    /// The concrete on-disk version this package first resolved to.
+    /// The concrete on-disk version this package resolved to.
     pub version: streamlib_idents::SemVer,
     /// Where that version's manifest was resolved from.
     pub source_path: std::path::PathBuf,
@@ -48,16 +53,330 @@ pub(crate) struct ResolvedPackageRecord {
     pub required_by: Vec<RequirerRecord>,
 }
 
+/// Terminal outcome of an in-flight package resolution, published via
+/// [`PackageResolutionCompletionSignal`] when the owning load commits
+/// (registration + transitive walk succeeded) or fails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConcurrentPackageLoadOutcome {
+    /// The owning load flipped the placeholder to a committed record.
+    Committed,
+    /// The owning load failed; the placeholder was removed.
+    Failed,
+}
+
+/// One-shot completion signal for an in-flight package resolution.
+/// Loads that skipped the package mid-walk wait on this at the end of
+/// their own walk to verify the owner actually finished registering.
+pub(crate) struct PackageResolutionCompletionSignal {
+    outcome: Mutex<Option<ConcurrentPackageLoadOutcome>>,
+    outcome_published: Condvar,
+}
+
+impl PackageResolutionCompletionSignal {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: Mutex::new(None),
+            outcome_published: Condvar::new(),
+        })
+    }
+
+    fn publish(&self, published_outcome: ConcurrentPackageLoadOutcome) {
+        *self.outcome.lock() = Some(published_outcome);
+        self.outcome_published.notify_all();
+    }
+
+    /// Block until the outcome is published or `timeout` elapses.
+    /// `None` means timeout — the caller surfaces a typed error.
+    pub(crate) fn wait_for_outcome(
+        &self,
+        timeout: Duration,
+    ) -> Option<ConcurrentPackageLoadOutcome> {
+        let deadline = Instant::now() + timeout;
+        let mut outcome = self.outcome.lock();
+        while outcome.is_none() {
+            if self
+                .outcome_published
+                .wait_until(&mut outcome, deadline)
+                .timed_out()
+            {
+                return *outcome;
+            }
+        }
+        *outcome
+    }
+}
+
+/// Per-package resolution state in the [`ResolutionMemo`].
+pub(crate) enum PackageResolutionState {
+    /// A load is mid-resolution for this package: the gate passed but
+    /// registration + the transitive walk have not completed yet.
+    InFlightPlaceholder {
+        record: ResolvedPackageRecord,
+        owner_load_id: u64,
+        completion_signal: Arc<PackageResolutionCompletionSignal>,
+    },
+    /// Registration + transitive walk completed; the version is final.
+    Committed { record: ResolvedPackageRecord },
+}
+
+/// A dependency this walk skipped because a concurrent load already had
+/// it in flight at the same version. Verified at the end of the top-level
+/// walk: the owner must have committed, or this load fails loudly.
+pub(crate) struct SkippedInFlightDependency {
+    pub package: streamlib_idents::PackageRef,
+    pub version: streamlib_idents::SemVer,
+    pub completion_signal: Arc<PackageResolutionCompletionSignal>,
+}
+
+/// Gate decision for one package encounter.
+pub(super) enum SingleVersionGateOutcome {
+    /// First encounter — placeholder inserted; register + recurse.
+    ProceedAsFirstResolution,
+    /// Already committed at the same version — requirer recorded; skip.
+    SkipAlreadyCommittedSameVersion,
+    /// In flight on a concurrent load at the same version — requirer
+    /// recorded; skip locally and verify the owner's outcome at the end
+    /// of this walk via the carried signal.
+    SkipInFlightSameVersion(Arc<PackageResolutionCompletionSignal>),
+}
+
 /// Runtime-lifetime memo of every package resolved by the live module
 /// walker, keyed by `@org/name`. Persists across every `add_module` call
-/// on a [`Runner`] so two independently-rooted diamond branches — or two
-/// successive `add_module` calls — that resolve the same package to
-/// different concrete versions conflict instead of silently
-/// double-registering.
+/// on a [`Runner`] so two independently-rooted diamond branches, two
+/// successive `add_module` calls, or two concurrent loads that resolve
+/// the same package to different concrete versions conflict instead of
+/// silently double-registering.
 ///
 /// [`Runner`]: crate::core::runtime::Runner
-pub(crate) type ResolutionMemo =
-    std::collections::HashMap<streamlib_idents::PackageRef, ResolvedPackageRecord>;
+pub(crate) struct ResolutionMemo {
+    packages: Mutex<HashMap<streamlib_idents::PackageRef, PackageResolutionState>>,
+}
+
+impl ResolutionMemo {
+    pub(crate) fn new() -> Self {
+        Self {
+            packages: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// The single-version gate: classify this package encounter under one
+    /// lock acquisition. Inserts the in-flight placeholder on first
+    /// encounter so concurrent loads observe the resolution immediately —
+    /// nobody ever blocks inside the gate.
+    fn gate(
+        &self,
+        load_id: u64,
+        pkg_ref: &streamlib_idents::PackageRef,
+        on_disk_version: streamlib_idents::SemVer,
+        manifest_dir: &std::path::Path,
+        requirer: RequirerRecord,
+    ) -> std::result::Result<SingleVersionGateOutcome, AddModuleError> {
+        let mut packages = self.packages.lock();
+        let Some(state) = packages.get_mut(pkg_ref) else {
+            packages.insert(
+                pkg_ref.clone(),
+                PackageResolutionState::InFlightPlaceholder {
+                    record: ResolvedPackageRecord {
+                        version: on_disk_version,
+                        source_path: manifest_dir.to_path_buf(),
+                        required_by: vec![requirer],
+                    },
+                    owner_load_id: load_id,
+                    completion_signal: PackageResolutionCompletionSignal::new(),
+                },
+            );
+            return Ok(SingleVersionGateOutcome::ProceedAsFirstResolution);
+        };
+
+        {
+            let record = match state {
+                PackageResolutionState::InFlightPlaceholder { record, .. } => record,
+                PackageResolutionState::Committed { record } => record,
+            };
+            if record.version != on_disk_version {
+                return Err(AddModuleError::SingleVersionConflict {
+                    package: pkg_ref.clone(),
+                    existing_version: record.version,
+                    existing_required_by: format!(
+                        "{} [resolved from {}]",
+                        describe_requirers(&record.required_by),
+                        record.source_path.display(),
+                    ),
+                    conflicting_version: on_disk_version,
+                    conflicting_required_by: format!(
+                        "{} [resolved from {}]",
+                        describe_requirer(&requirer),
+                        manifest_dir.display(),
+                    ),
+                });
+            }
+            if record.source_path != manifest_dir {
+                tracing::warn!(
+                    package = %pkg_ref,
+                    version = %on_disk_version,
+                    resolved_from = %record.source_path.display(),
+                    skipped_source = %manifest_dir.display(),
+                    "single-version gate: package already resolved at this \
+                     version from a different source path — this source is \
+                     skipped; edits to it will not take effect in this runtime",
+                );
+            }
+            record.required_by.push(requirer);
+        }
+
+        match state {
+            PackageResolutionState::Committed { .. } => {
+                tracing::debug!(
+                    package = %pkg_ref,
+                    version = %on_disk_version,
+                    "single-version gate: already resolved at this version — \
+                     skipping re-registration and re-recursion",
+                );
+                Ok(SingleVersionGateOutcome::SkipAlreadyCommittedSameVersion)
+            }
+            PackageResolutionState::InFlightPlaceholder {
+                completion_signal,
+                owner_load_id,
+                ..
+            } => {
+                tracing::debug!(
+                    package = %pkg_ref,
+                    version = %on_disk_version,
+                    owner_load_id = *owner_load_id,
+                    "single-version gate: same version in flight on a \
+                     concurrent load — skipping locally; outcome verified at \
+                     end of walk",
+                );
+                Ok(SingleVersionGateOutcome::SkipInFlightSameVersion(
+                    Arc::clone(completion_signal),
+                ))
+            }
+        }
+    }
+
+    /// Flip this package's in-flight placeholder to a committed record
+    /// and publish [`ConcurrentPackageLoadOutcome::Committed`]. Requirers
+    /// accumulated on the placeholder while in flight are preserved.
+    fn commit_in_flight_resolution(&self, pkg_ref: &streamlib_idents::PackageRef) {
+        let signal = {
+            let mut packages = self.packages.lock();
+            match packages.remove(pkg_ref) {
+                Some(PackageResolutionState::InFlightPlaceholder {
+                    record,
+                    completion_signal,
+                    ..
+                }) => {
+                    packages.insert(
+                        pkg_ref.clone(),
+                        PackageResolutionState::Committed { record },
+                    );
+                    Some(completion_signal)
+                }
+                // Defensive: only the owning walk commits its placeholder.
+                Some(other) => {
+                    packages.insert(pkg_ref.clone(), other);
+                    None
+                }
+                None => None,
+            }
+        };
+        if let Some(signal) = signal {
+            signal.publish(ConcurrentPackageLoadOutcome::Committed);
+        }
+    }
+
+    /// Remove this package's in-flight placeholder after a failed load
+    /// and publish [`ConcurrentPackageLoadOutcome::Failed`], so concurrent
+    /// loads that skipped it fail loudly instead of assuming it registered.
+    fn abandon_in_flight_resolution(&self, pkg_ref: &streamlib_idents::PackageRef) {
+        let signal = {
+            let mut packages = self.packages.lock();
+            match packages.remove(pkg_ref) {
+                Some(PackageResolutionState::InFlightPlaceholder {
+                    completion_signal, ..
+                }) => Some(completion_signal),
+                // Defensive: never remove a committed record on abandon.
+                Some(other) => {
+                    packages.insert(pkg_ref.clone(), other);
+                    None
+                }
+                None => None,
+            }
+        };
+        if let Some(signal) = signal {
+            signal.publish(ConcurrentPackageLoadOutcome::Failed);
+        }
+    }
+
+    /// Test observability: the committed record for a package, if its
+    /// resolution has completed. `None` while absent or still in flight.
+    #[cfg(test)]
+    pub(crate) fn committed_record(
+        &self,
+        pkg_ref: &streamlib_idents::PackageRef,
+    ) -> Option<ResolvedPackageRecord> {
+        match self.packages.lock().get(pkg_ref) {
+            Some(PackageResolutionState::Committed { record }) => Some(record.clone()),
+            _ => None,
+        }
+    }
+
+    /// Test observability: whether any resolution state (in-flight or
+    /// committed) exists for a package.
+    #[cfg(test)]
+    pub(crate) fn contains_package(&self, pkg_ref: &streamlib_idents::PackageRef) -> bool {
+        self.packages.lock().contains_key(pkg_ref)
+    }
+
+    /// Test observability: requirer count on an in-flight placeholder.
+    #[cfg(test)]
+    pub(crate) fn in_flight_requirer_count(
+        &self,
+        pkg_ref: &streamlib_idents::PackageRef,
+    ) -> Option<usize> {
+        match self.packages.lock().get(pkg_ref) {
+            Some(PackageResolutionState::InFlightPlaceholder { record, .. }) => {
+                Some(record.required_by.len())
+            }
+            _ => None,
+        }
+    }
+}
+
+/// RAII cleanup for an armed in-flight placeholder: any failure exit
+/// between the gate and the commit drops this guard, which removes the
+/// placeholder and publishes `Failed` — the memo can never wedge in a
+/// permanent "resolving" state, and concurrent skippers fail loudly.
+struct InFlightPlaceholderGuard<'memo> {
+    resolution_memo: &'memo ResolutionMemo,
+    package: Option<streamlib_idents::PackageRef>,
+}
+
+impl<'memo> InFlightPlaceholderGuard<'memo> {
+    fn arm(
+        resolution_memo: &'memo ResolutionMemo,
+        package: streamlib_idents::PackageRef,
+    ) -> Self {
+        Self {
+            resolution_memo,
+            package: Some(package),
+        }
+    }
+
+    fn commit(mut self) {
+        if let Some(package) = self.package.take() {
+            self.resolution_memo.commit_in_flight_resolution(&package);
+        }
+    }
+}
+
+impl Drop for InFlightPlaceholderGuard<'_> {
+    fn drop(&mut self) {
+        if let Some(package) = self.package.take() {
+            self.resolution_memo.abandon_in_flight_resolution(&package);
+        }
+    }
+}
 
 /// Render one requirer edge for a
 /// [`AddModuleError::SingleVersionConflict`] message.
@@ -90,7 +409,10 @@ fn describe_requirers(requirers: &[RequirerRecord]) -> String {
 /// shared across every `add_module` call — the gate that turns a
 /// diamond version divergence into a typed
 /// [`AddModuleError::SingleVersionConflict`] instead of a silent
-/// double-registration.
+/// double-registration. `load_id` identifies the top-level load this
+/// walk belongs to; `skipped_in_flight` accumulates dependencies this
+/// walk skipped because a concurrent load had them in flight — verified
+/// at the end of the top-level walk.
 ///
 /// [`PackageRef`]: streamlib_idents::PackageRef
 #[allow(clippy::too_many_arguments)]
@@ -102,7 +424,9 @@ pub(super) fn add_module_recursively(
     strategy: Strategy,
     seen: &mut HashSet<streamlib_idents::PackageRef>,
     path: &mut Vec<streamlib_idents::PackageRef>,
-    resolution_memo: &Mutex<ResolutionMemo>,
+    resolution_memo: &ResolutionMemo,
+    load_id: u64,
+    skipped_in_flight: &mut Vec<SkippedInFlightDependency>,
 ) -> std::result::Result<(), AddModuleError> {
     let pkg_ref = module.package_ref();
     if !seen.insert(pkg_ref.clone()) {
@@ -120,6 +444,8 @@ pub(super) fn add_module_recursively(
         seen,
         path,
         resolution_memo,
+        load_id,
+        skipped_in_flight,
     );
     seen.remove(&pkg_ref);
     path.pop();
@@ -135,7 +461,9 @@ fn add_module_recursive_body(
     strategy: Strategy,
     seen: &mut HashSet<streamlib_idents::PackageRef>,
     path: &mut Vec<streamlib_idents::PackageRef>,
-    resolution_memo: &Mutex<ResolutionMemo>,
+    resolution_memo: &ResolutionMemo,
+    load_id: u64,
+    skipped_in_flight: &mut Vec<SkippedInFlightDependency>,
 ) -> std::result::Result<(), AddModuleError> {
     use crate::core::config::ProjectConfig;
 
@@ -226,55 +554,41 @@ fn add_module_recursive_body(
 
     // Single-version-per-package gate. The memo persists across the whole
     // runtime lifetime (not per walk), so two independently-rooted diamond
-    // branches — or two successive `add_module` calls — that resolve the
-    // same package to different concrete versions conflict here instead of
-    // silently double-registering. Compares concrete resolved `SemVer`s,
-    // never ranges: path / git deps enter with range `Any`, so a
-    // range-only check would never fire. A same-version re-encounter
-    // short-circuits before re-registration + re-recursion, which also
-    // fixes the historical silent double-registration.
+    // branches, two successive `add_module` calls, or two concurrent
+    // loads that resolve the same package to different concrete versions
+    // conflict here instead of silently double-registering. Compares
+    // concrete resolved `SemVer`s, never ranges: path / git deps enter
+    // with range `Any`, so a range-only check would never fire.
     //
-    // The commit into the memo is deferred to *after* this package's
-    // registration + transitive walk succeed (see the end of the
-    // function). A same-package re-entry within the current subtree is a
-    // dependency cycle already caught by the `seen` guard above, so
-    // deferring the commit never weakens conflict detection — but it does
-    // keep a load that fails mid-registration from poisoning the memo and
-    // making a retried `add_module` silently skip an unregistered package.
+    // First encounter inserts an in-flight placeholder under the same
+    // lock as the check (no check-then-commit window for a concurrent
+    // load to slip through). A same-version re-encounter skips
+    // re-registration + re-recursion; when the same version is in flight
+    // on a CONCURRENT load, the skip is recorded in `skipped_in_flight`
+    // and the owner's outcome is verified at the end of this walk —
+    // nobody ever blocks mid-walk, so concurrent walks cannot deadlock.
     let requirer = RequirerRecord {
         requirer: (path.len() >= 2).then(|| path[path.len() - 2].clone()),
         declared_range: module.version.clone(),
     };
-    {
-        let mut memo = resolution_memo.lock();
-        if let Some(existing) = memo.get_mut(&pkg_ref) {
-            if existing.version == on_disk_version {
-                existing.required_by.push(requirer);
-                tracing::debug!(
-                    package = %pkg_ref,
-                    version = %on_disk_version,
-                    "single-version gate: already resolved at this version — \
-                     skipping re-registration and re-recursion",
-                );
-                return Ok(());
-            }
-            return Err(AddModuleError::SingleVersionConflict {
+    match resolution_memo.gate(load_id, &pkg_ref, on_disk_version, &manifest_dir, requirer)? {
+        SingleVersionGateOutcome::SkipAlreadyCommittedSameVersion => return Ok(()),
+        SingleVersionGateOutcome::SkipInFlightSameVersion(completion_signal) => {
+            skipped_in_flight.push(SkippedInFlightDependency {
                 package: pkg_ref.clone(),
-                existing_version: existing.version,
-                existing_required_by: format!(
-                    "{} [resolved from {}]",
-                    describe_requirers(&existing.required_by),
-                    existing.source_path.display(),
-                ),
-                conflicting_version: on_disk_version,
-                conflicting_required_by: format!(
-                    "{} [resolved from {}]",
-                    describe_requirer(&requirer),
-                    manifest_dir.display(),
-                ),
+                version: on_disk_version,
+                completion_signal,
             });
+            return Ok(());
         }
+        SingleVersionGateOutcome::ProceedAsFirstResolution => {}
     }
+
+    // The placeholder is armed: any failure exit below drops the guard,
+    // which removes the placeholder and publishes `Failed` — a retried
+    // add_module re-runs the full resolution, and concurrent loads that
+    // skipped this package fail loudly instead of assuming it registered.
+    let placeholder_guard = InFlightPlaceholderGuard::arm(resolution_memo, pkg_ref.clone());
 
     // Schemas are leaves — register before recursing into deps.
     register_package_schemas(&manifest_dir, &config).map_err(|e| {
@@ -307,6 +621,8 @@ fn add_module_recursive_body(
             seen,
             path,
             resolution_memo,
+            load_id,
+            skipped_in_flight,
         )?;
     }
 
@@ -318,19 +634,16 @@ fn add_module_recursive_body(
         }
     })?;
 
-    // Registration + the transitive walk succeeded — commit this package's
-    // resolved version to the runtime-lifetime memo now (not at the gate
-    // check above), so a load that fails mid-registration leaves no entry
-    // and a retry re-runs the full registration rather than silently
-    // skipping.
-    resolution_memo.lock().insert(
-        pkg_ref.clone(),
-        ResolvedPackageRecord {
-            version: on_disk_version,
-            source_path: manifest_dir.clone(),
-            required_by: vec![requirer],
-        },
-    );
+    // Registration + the transitive walk succeeded — flip the in-flight
+    // placeholder to a committed record and publish `Committed` to any
+    // concurrent loads that skipped this package. Note that registration
+    // itself is NOT transactional: schemas / processors registered before
+    // a later failure remain in the process-global registries (no module
+    // unload / rollback exists yet), so retrying a multi-processor
+    // package that failed partway can hit "already registered". The
+    // guard's commit-after-success still guarantees the memo never claims
+    // a package resolved when its load didn't complete.
+    placeholder_guard.commit();
 
     Ok(())
 }

--- a/libs/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
@@ -4,6 +4,8 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use parking_lot::Mutex;
+
 use super::build_orchestrator::{BuildEventSink, BuildOrchestrator, BuildPolicy};
 use super::errors::AddModuleError;
 use super::processor_registration::register_manifest_processors;
@@ -11,6 +13,69 @@ use super::schema_registration::register_package_schemas;
 use super::source::{read_version_from_manifest_dir, resolve_strategy_to_source, ResolvedSource, Strategy};
 use crate::core::{Error, Result};
 use crate::iceoryx2::Iceoryx2Node;
+
+/// A single requirer edge into a resolved package: the parent
+/// [`PackageRef`] that declared the dependency (or `None` for a
+/// top-level `add_module` call) plus the version range it declared.
+///
+/// [`PackageRef`]: streamlib_idents::PackageRef
+#[derive(Debug, Clone)]
+pub(crate) struct RequirerRecord {
+    /// The parent package that pulled this dependency in, or `None` when
+    /// the package was the root of a top-level `add_module` call.
+    pub requirer: Option<streamlib_idents::PackageRef>,
+    /// The [`SemVerRange`] the requirer declared for this package (`Any`
+    /// for path / git deps, which carry no range).
+    ///
+    /// [`SemVerRange`]: streamlib_idents::SemVerRange
+    pub declared_range: streamlib_idents::SemVerRange,
+}
+
+/// The persistent single-version resolution record for one `@org/name`
+/// package across the whole runtime lifetime. Keyed by [`PackageRef`] in
+/// the loader's [`ResolutionMemo`]; the concrete resolved [`SemVer`] is
+/// authoritative and every subsequent encounter is checked against it.
+///
+/// [`PackageRef`]: streamlib_idents::PackageRef
+/// [`SemVer`]: streamlib_idents::SemVer
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedPackageRecord {
+    /// The concrete on-disk version this package first resolved to.
+    pub version: streamlib_idents::SemVer,
+    /// Where that version's manifest was resolved from.
+    pub source_path: std::path::PathBuf,
+    /// Every requirer that has pulled this package in so far.
+    pub required_by: Vec<RequirerRecord>,
+}
+
+/// Runtime-lifetime memo of every package resolved by the live module
+/// walker, keyed by `@org/name`. Persists across every `add_module` call
+/// on a [`Runner`] so two independently-rooted diamond branches — or two
+/// successive `add_module` calls — that resolve the same package to
+/// different concrete versions conflict instead of silently
+/// double-registering.
+///
+/// [`Runner`]: crate::core::runtime::Runner
+pub(crate) type ResolutionMemo =
+    std::collections::HashMap<streamlib_idents::PackageRef, ResolvedPackageRecord>;
+
+/// Render one requirer edge for a
+/// [`AddModuleError::SingleVersionConflict`] message.
+fn describe_requirer(requirer: &RequirerRecord) -> String {
+    match &requirer.requirer {
+        Some(pkg) => format!("{pkg} (declared `{}`)", requirer.declared_range),
+        None => format!("top-level add_module (declared `{}`)", requirer.declared_range),
+    }
+}
+
+/// Render the accumulated requirers of an already-resolved package.
+fn describe_requirers(requirers: &[RequirerRecord]) -> String {
+    requirers
+        .iter()
+        .map(describe_requirer)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
 
 /// Recursive worker: resolves the [`Strategy`] to a source, materializes
 /// via the injected [`BuildOrchestrator`] when a build is required,
@@ -21,6 +86,11 @@ use crate::iceoryx2::Iceoryx2Node;
 /// `seen` tracks every [`PackageRef`] currently on the recursion stack
 /// (O(1) membership); `path` preserves insertion order so the
 /// dependency-cycle error carries the actual edge that re-entered.
+/// `resolution_memo` is the runtime-lifetime single-version record
+/// shared across every `add_module` call — the gate that turns a
+/// diamond version divergence into a typed
+/// [`AddModuleError::SingleVersionConflict`] instead of a silent
+/// double-registration.
 ///
 /// [`PackageRef`]: streamlib_idents::PackageRef
 #[allow(clippy::too_many_arguments)]
@@ -32,6 +102,7 @@ pub(super) fn add_module_recursively(
     strategy: Strategy,
     seen: &mut HashSet<streamlib_idents::PackageRef>,
     path: &mut Vec<streamlib_idents::PackageRef>,
+    resolution_memo: &Mutex<ResolutionMemo>,
 ) -> std::result::Result<(), AddModuleError> {
     let pkg_ref = module.package_ref();
     if !seen.insert(pkg_ref.clone()) {
@@ -40,8 +111,16 @@ pub(super) fn add_module_recursively(
         return Err(AddModuleError::DependencyCycleDetected { cycle });
     }
     path.push(pkg_ref.clone());
-    let result =
-        add_module_recursive_body(iceoryx2_node, orchestrator, sink, module, strategy, seen, path);
+    let result = add_module_recursive_body(
+        iceoryx2_node,
+        orchestrator,
+        sink,
+        module,
+        strategy,
+        seen,
+        path,
+        resolution_memo,
+    );
     seen.remove(&pkg_ref);
     path.pop();
     result
@@ -56,6 +135,7 @@ fn add_module_recursive_body(
     strategy: Strategy,
     seen: &mut HashSet<streamlib_idents::PackageRef>,
     path: &mut Vec<streamlib_idents::PackageRef>,
+    resolution_memo: &Mutex<ResolutionMemo>,
 ) -> std::result::Result<(), AddModuleError> {
     use crate::core::config::ProjectConfig;
 
@@ -144,6 +224,62 @@ fn add_module_recursive_body(
         on_disk_version,
     );
 
+    // Single-version-per-package gate. The memo persists across the whole
+    // runtime lifetime (not per walk), so two independently-rooted diamond
+    // branches — or two successive `add_module` calls — that resolve the
+    // same package to different concrete versions conflict here instead of
+    // silently double-registering. Compares concrete resolved `SemVer`s,
+    // never ranges: path / git deps enter with range `Any`, so a
+    // range-only check would never fire. A same-version re-encounter
+    // short-circuits before re-registration + re-recursion, which also
+    // fixes the historical silent double-registration.
+    let requirer = RequirerRecord {
+        requirer: (path.len() >= 2).then(|| path[path.len() - 2].clone()),
+        declared_range: module.version.clone(),
+    };
+    {
+        let mut memo = resolution_memo.lock();
+        match memo.get_mut(&pkg_ref) {
+            None => {
+                memo.insert(
+                    pkg_ref.clone(),
+                    ResolvedPackageRecord {
+                        version: on_disk_version,
+                        source_path: manifest_dir.clone(),
+                        required_by: vec![requirer],
+                    },
+                );
+            }
+            Some(existing) if existing.version == on_disk_version => {
+                existing.required_by.push(requirer);
+                tracing::debug!(
+                    package = %pkg_ref,
+                    version = %on_disk_version,
+                    "single-version gate: already resolved at this version — \
+                     skipping re-registration and re-recursion",
+                );
+                return Ok(());
+            }
+            Some(existing) => {
+                return Err(AddModuleError::SingleVersionConflict {
+                    package: pkg_ref.clone(),
+                    existing_version: existing.version,
+                    existing_required_by: format!(
+                        "{} [resolved from {}]",
+                        describe_requirers(&existing.required_by),
+                        existing.source_path.display(),
+                    ),
+                    conflicting_version: on_disk_version,
+                    conflicting_required_by: format!(
+                        "{} [resolved from {}]",
+                        describe_requirer(&requirer),
+                        manifest_dir.display(),
+                    ),
+                });
+            }
+        }
+    }
+
     // Schemas are leaves — register before recursing into deps.
     register_package_schemas(&manifest_dir, &config).map_err(|e| {
         AddModuleError::LoadProjectFailed {
@@ -174,6 +310,7 @@ fn add_module_recursive_body(
             dep_strategy,
             seen,
             path,
+            resolution_memo,
         )?;
     }
 

--- a/libs/streamlib-engine/src/core/runtime/module_loader/tests.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/tests.rs
@@ -35,6 +35,142 @@ impl BuildOrchestrator for LoadAsIsOrchestrator {
     }
 }
 
+/// [`LoadAsIsOrchestrator`] plus a per-directory materialize-call counter,
+/// letting tests assert a skipped package's subtree was not re-walked.
+struct MaterializeCountingOrchestrator {
+    counts: std::sync::Arc<
+        parking_lot::Mutex<std::collections::HashMap<std::path::PathBuf, usize>>,
+    >,
+}
+impl BuildOrchestrator for MaterializeCountingOrchestrator {
+    fn materialize(
+        &self,
+        request: &BuildRequest,
+        _sink: &dyn BuildEventSink,
+    ) -> std::result::Result<StagedArtifact, BuildError> {
+        match &request.source {
+            BuildSource::PackageDir(dir) => {
+                *self.counts.lock().entry(dir.clone()).or_insert(0) += 1;
+                Ok(StagedArtifact {
+                    staged_dir: dir.clone(),
+                    rebuilt: false,
+                })
+            }
+            other => Err(BuildError::UnsupportedSource(format!("{other:?}"))),
+        }
+    }
+}
+
+/// Sum of materialize calls across all dirs whose final path component
+/// matches `dir_name`.
+fn count_materializations_for_dir_named(
+    counts: &std::sync::Arc<
+        parking_lot::Mutex<std::collections::HashMap<std::path::PathBuf, usize>>,
+    >,
+    dir_name: &str,
+) -> usize {
+    counts
+        .lock()
+        .iter()
+        .filter(|(dir, _)| dir.file_name().is_some_and(|name| name == dir_name))
+        .map(|(_, count)| *count)
+        .sum()
+}
+
+/// [`MaterializeCountingOrchestrator`] plus a rendezvous barrier on dirs
+/// whose final path component is in `rendezvous_dir_names` —
+/// deterministically overlaps two concurrent walks at the shared
+/// dependency (both walks must arrive before either proceeds to the
+/// single-version gate).
+struct RendezvousLoadAsIsOrchestrator {
+    rendezvous_dir_names: Vec<String>,
+    rendezvous: std::sync::Barrier,
+    counts: std::sync::Arc<
+        parking_lot::Mutex<std::collections::HashMap<std::path::PathBuf, usize>>,
+    >,
+}
+impl BuildOrchestrator for RendezvousLoadAsIsOrchestrator {
+    fn materialize(
+        &self,
+        request: &BuildRequest,
+        _sink: &dyn BuildEventSink,
+    ) -> std::result::Result<StagedArtifact, BuildError> {
+        match &request.source {
+            BuildSource::PackageDir(dir) => {
+                *self.counts.lock().entry(dir.clone()).or_insert(0) += 1;
+                let matches = dir
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| {
+                        self.rendezvous_dir_names.iter().any(|r| r == name)
+                    });
+                if matches {
+                    self.rendezvous.wait();
+                }
+                Ok(StagedArtifact {
+                    staged_dir: dir.clone(),
+                    rebuilt: false,
+                })
+            }
+            other => Err(BuildError::UnsupportedSource(format!("{other:?}"))),
+        }
+    }
+}
+
+/// [`LoadAsIsOrchestrator`] that BLOCKS materialization of the dir whose
+/// final path component matches `gated_dir_name` until the test releases
+/// it (then optionally fails it) — deterministically holds the gated
+/// package's parent in flight while a concurrent walk gates on it.
+struct GatedSubDependencyOrchestrator {
+    gated_dir_name: String,
+    release: parking_lot::Mutex<Option<std::sync::mpsc::Receiver<()>>>,
+    fail_after_release: bool,
+}
+impl BuildOrchestrator for GatedSubDependencyOrchestrator {
+    fn materialize(
+        &self,
+        request: &BuildRequest,
+        _sink: &dyn BuildEventSink,
+    ) -> std::result::Result<StagedArtifact, BuildError> {
+        match &request.source {
+            BuildSource::PackageDir(dir) => {
+                let gated = dir
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name == self.gated_dir_name);
+                if gated {
+                    if let Some(release_receiver) = self.release.lock().take() {
+                        let _ = release_receiver.recv();
+                    }
+                    if self.fail_after_release {
+                        return Err(BuildError::UnsupportedSource(
+                            "injected gated sub-dependency failure".into(),
+                        ));
+                    }
+                }
+                Ok(StagedArtifact {
+                    staged_dir: dir.clone(),
+                    rebuilt: false,
+                })
+            }
+            other => Err(BuildError::UnsupportedSource(format!("{other:?}"))),
+        }
+    }
+}
+
+/// Poll `condition` until it holds or `timeout` elapses; returns the
+/// final evaluation.
+fn poll_until(timeout: std::time::Duration, mut condition: impl FnMut() -> bool) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if condition() {
+            return true;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    condition()
+}
+
 // =========================================================================
 // list_available_triples
 // =========================================================================
@@ -746,6 +882,17 @@ processors:
         msg.contains(wrong_triple),
         "error must list the triples that ARE present, got: {msg}"
     );
+    // Placeholder drop-guard witness: the processor-registration failure
+    // exit must clear the armed single-version placeholder.
+    assert!(
+        !runtime
+            .resolution_memo
+            .contains_package(&streamlib_idents::PackageRef::new(
+                streamlib_idents::Org::new("tatolab").unwrap(),
+                streamlib_idents::Package::new("triple-mismatch-pkg").unwrap(),
+            )),
+        "processor-registration failure must clear the in-flight placeholder",
+    );
 }
 
 #[test]
@@ -854,6 +1001,8 @@ package:
 // =========================================================================
 
 mod add_module_tests {
+    use std::sync::Arc;
+
     use super::*;
     use streamlib_idents::{ModuleIdent, Org, Package, SemVer, SemVerRange};
 
@@ -1354,6 +1503,15 @@ processors:
             }
             other => panic!("expected DependencyCycleDetected, got: {other:?}"),
         }
+        // Placeholder drop-guard witness: the dep-recursion failure exit
+        // must clear the armed placeholder — the memo never wedges.
+        assert!(
+            !runtime.resolution_memo.contains_package(&streamlib_idents::PackageRef::new(
+                Org::new("tatolab").unwrap(),
+                Package::new("cycle-self").unwrap(),
+            )),
+            "cycle failure must clear the in-flight placeholder",
+        );
     }
 
     #[test]
@@ -1400,6 +1558,17 @@ processors:
                 );
             }
             other => panic!("expected DependencyCycleDetected, got: {other:?}"),
+        }
+        // Placeholder drop-guard witness: BOTH armed placeholders (a and
+        // b) must be cleared as the failure unwinds through them.
+        for name in ["cycle-a", "cycle-b"] {
+            assert!(
+                !runtime.resolution_memo.contains_package(&streamlib_idents::PackageRef::new(
+                    Org::new("tatolab").unwrap(),
+                    Package::new(name).unwrap(),
+                )),
+                "cycle failure must clear the in-flight placeholder for {name}",
+            );
         }
     }
 
@@ -1537,17 +1706,19 @@ processors:
     }
 
     /// A diamond where both branches agree on the shared dependency's
-    /// version (B→D@1.0.0, C→D@1.0.0) resolves cleanly and D's schema is
-    /// registered. The single-registration invariant is locked by the
-    /// memo assertion: D is recorded exactly once at 1.0.0 with C added as
-    /// a *second requirer of the same resolution* (`required_by.len() ==
-    /// 2`), which proves C took the same-version skip path instead of
-    /// re-registering + re-walking D. (Schema presence alone can't witness
-    /// this — schema registration is an idempotent map overwrite, so a
-    /// double-walk would leave the same observable schema; the requirer
-    /// count is what the skip drives.) Reverting the same-version
-    /// record-and-skip branch drops the second requirer (or removes the
-    /// memo entirely), failing the assertion.
+    /// version (B→D@1.0.0, C→D@1.0.0, D→E) resolves cleanly and D's
+    /// schema is registered. Two independent witnesses lock the skip:
+    ///
+    /// 1. `required_by.len() == 2` — C is recorded as a second requirer
+    ///    of D's single resolution. NOTE: the commit preserves requirers
+    ///    accumulated on the record (it never overwrite-resets them), so
+    ///    this assertion locks the requirer-push in the skip arm, not the
+    ///    absence of a re-walk.
+    /// 2. E materialized exactly once — the re-walk witness. Reverting
+    ///    the same-version skip makes C re-walk D's subtree, which
+    ///    materializes E a second time and fails the count assertion.
+    ///    (Schema presence can't witness this: registration is an
+    ///    idempotent map overwrite.)
     #[test]
     #[serial]
     fn diamond_agreeing_versions_resolve_and_register_once() {
@@ -1558,7 +1729,8 @@ processors:
         let b = pkg_root.path().join("b");
         let c = pkg_root.path().join("c");
         let d = pkg_root.path().join("d");
-        for p in [&a, &b, &c, &d] {
+        let e = pkg_root.path().join("e");
+        for p in [&a, &b, &c, &d, &e] {
             std::fs::create_dir(p).unwrap();
         }
         std::fs::create_dir(d.join("schemas")).unwrap();
@@ -1590,14 +1762,25 @@ processors:
             d.join("streamlib.yaml"),
             format!(
                 "package:\n  org: tatolab\n  name: diamond-agree-d\n  version: \"1.0.0\"\n\
+                 dependencies:\n  \"@tatolab/diamond-agree-e\":\n    path: ../e\n\
                  schemas:\n  {TYPE_D}:\n    file: schemas/diamondagreedschema.yaml\n"
             ),
+        )
+        .unwrap();
+        std::fs::write(
+            e.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: diamond-agree-e\n  version: \"1.0.0\"\n",
         )
         .unwrap();
 
         let _guard = HomeGuard::install(home.path());
         let runtime = Runner::new().expect("Runner::new");
-        runtime.set_build_orchestrator(LoadAsIsOrchestrator);
+        let materialize_counts = Arc::new(parking_lot::Mutex::new(
+            std::collections::HashMap::<std::path::PathBuf, usize>::new(),
+        ));
+        runtime.set_build_orchestrator(MaterializeCountingOrchestrator {
+            counts: Arc::clone(&materialize_counts),
+        });
         runtime
             .add_module_with_blocking(
                 ModuleIdent::any(
@@ -1621,15 +1804,25 @@ processors:
             Org::new("tatolab").unwrap(),
             Package::new("diamond-agree-d").unwrap(),
         );
-        let memo = runtime.resolution_memo.lock();
-        let record = memo
-            .get(&d_ref)
-            .expect("D must be recorded in the resolution memo");
+        let record = runtime
+            .resolution_memo
+            .committed_record(&d_ref)
+            .expect("D must be committed in the resolution memo");
         assert_eq!(record.version, SemVer::new(1, 0, 0));
+        // Locks the requirer-push in the same-version skip arm; the commit
+        // preserves accumulated requirers (never overwrite-resets them).
         assert_eq!(
             record.required_by.len(),
             2,
             "both B and C must be recorded as requirers of the single D resolution",
+        );
+        // Re-walk witness: reverting the skip re-walks D's subtree from C
+        // and materializes E a second time.
+        let e_materializations = count_materializations_for_dir_named(&materialize_counts, "e");
+        assert_eq!(
+            e_materializations, 1,
+            "D's subtree must be walked exactly once — a second E \
+             materialization means the same-version skip was bypassed",
         );
     }
 
@@ -1697,12 +1890,18 @@ processors:
             AddModuleError::SingleVersionConflict {
                 package,
                 existing_version,
+                existing_required_by,
                 conflicting_version,
                 ..
             } => {
                 assert_eq!(package.name.as_str(), "crosscall-x");
                 assert_eq!(existing_version, SemVer::new(1, 0, 0));
                 assert_eq!(conflicting_version, SemVer::new(2, 0, 0));
+                assert!(
+                    existing_required_by.contains("top-level add_module"),
+                    "existing requirer must name the top-level add_module call, \
+                     got: {existing_required_by}",
+                );
             }
             other => panic!("expected SingleVersionConflict, got: {other:?}"),
         }
@@ -1747,8 +1946,10 @@ processors:
             Org::new("tatolab").unwrap(),
             Package::new("readd-x").unwrap(),
         );
-        let memo = runtime.resolution_memo.lock();
-        let record = memo.get(&x_ref).expect("X must be recorded");
+        let record = runtime
+            .resolution_memo
+            .committed_record(&x_ref)
+            .expect("X must be committed");
         assert_eq!(record.version, SemVer::new(1, 0, 0));
         assert_eq!(
             record.required_by.len(),
@@ -1758,43 +1959,48 @@ processors:
     }
 
     /// A load that fails mid-registration must NOT poison the memo: the
-    /// version commit is deferred until registration + the transitive walk
-    /// succeed, so a failed package leaves no entry and a retry re-runs the
-    /// full registration instead of hitting the same-version skip and
-    /// silently returning `Ok` for a never-registered package. Here X
-    /// declares a schema whose file is missing, so `add_module` fails
-    /// before the deferred commit. Mentally reverting to commit-before-
-    /// registration would leave X in the memo and fail the `!contains_key`
-    /// assertion.
+    /// in-flight placeholder guard clears the entry on the failure exit,
+    /// so a retry re-runs the full registration instead of hitting the
+    /// same-version skip and silently returning `Ok` for a
+    /// never-registered package. Here X declares a schema whose file is
+    /// missing, so `add_module` fails between the gate and the commit;
+    /// after fixing the file, the retry succeeds and the schema actually
+    /// registers — the user-facing retry property. Mentally reverting the
+    /// guard (commit-at-gate) leaves X in the memo and makes the retry a
+    /// silent no-op with no schema registered.
     #[test]
     #[serial]
-    fn failed_load_does_not_poison_the_memo() {
+    fn failed_load_does_not_poison_the_memo_and_retry_succeeds() {
+        const TYPE_POISON: &str = "PoisonRetrySchema";
         let home = tempfile::tempdir().unwrap();
         let pkg = tempfile::tempdir().unwrap();
         // Declares a schema pointing at a file that does not exist →
-        // `register_package_schemas` errors before the deferred memo
+        // `register_package_schemas` errors between the gate and the
         // commit at the end of the walk body.
         std::fs::write(
             pkg.path().join("streamlib.yaml"),
-            "package:\n  org: tatolab\n  name: poison-x\n  version: \"1.0.0\"\n\
-             schemas:\n  PoisonSchema:\n    file: schemas/does-not-exist.yaml\n",
+            format!(
+                "package:\n  org: tatolab\n  name: poison-x\n  version: \"1.0.0\"\n\
+                 schemas:\n  {TYPE_POISON}:\n    file: schemas/poisonretryschema.yaml\n"
+            ),
         )
         .unwrap();
 
         let _guard = HomeGuard::install(home.path());
         let runtime = Runner::new().expect("Runner::new");
         runtime.set_build_orchestrator(LoadAsIsOrchestrator);
-        let err = runtime
-            .add_module_with_blocking(
-                ModuleIdent::any(
-                    Org::new("tatolab").unwrap(),
-                    Package::new("poison-x").unwrap(),
-                ),
-                Strategy::Path {
-                    path: pkg.path().to_path_buf(),
-                    build: BuildPolicy::NeverBuild,
-                },
+        let ident = || {
+            ModuleIdent::any(
+                Org::new("tatolab").unwrap(),
+                Package::new("poison-x").unwrap(),
             )
+        };
+        let strategy = || Strategy::Path {
+            path: pkg.path().to_path_buf(),
+            build: BuildPolicy::NeverBuild,
+        };
+        let err = runtime
+            .add_module_with_blocking(ident(), strategy())
             .expect_err("missing schema file must fail the load");
         assert!(
             matches!(err, AddModuleError::LoadProjectFailed { .. }),
@@ -1806,8 +2012,474 @@ processors:
             Package::new("poison-x").unwrap(),
         );
         assert!(
-            !runtime.resolution_memo.lock().contains_key(&x_ref),
+            !runtime.resolution_memo.contains_package(&x_ref),
             "a failed load must not leave a resolution-memo entry",
+        );
+
+        // Fix the package and retry on the SAME runtime — the retry must
+        // re-run registration (not skip), so the schema becomes visible.
+        std::fs::create_dir(pkg.path().join("schemas")).unwrap();
+        std::fs::write(
+            pkg.path().join("schemas/poisonretryschema.yaml"),
+            format!("metadata:\n  type: {TYPE_POISON}\n  max_payload_bytes: 4096\n"),
+        )
+        .unwrap();
+        runtime
+            .add_module_with_blocking(ident(), strategy())
+            .expect("retry after fixing the schema file must succeed");
+        let canonical = format!("@tatolab/poison-x/{TYPE_POISON}");
+        assert!(
+            crate::core::embedded_schemas::get_embedded_schema_definition(&canonical).is_some(),
+            "retry must actually register the schema {canonical}",
+        );
+        assert!(
+            runtime.resolution_memo.committed_record(&x_ref).is_some(),
+            "retry must commit the resolution",
+        );
+    }
+
+    // =====================================================================
+    // Concurrent loads — single-version gate under overlap. Deterministic:
+    // orchestrator barriers / gates control the overlap window, never
+    // timing luck.
+    // =====================================================================
+
+    /// Two CONCURRENT top-level loads sharing a transitive dep at the
+    /// same version (TA→D, TB→D, D→E) both succeed with a single
+    /// resolution of D. The rendezvous barrier forces both walks past
+    /// D's materialize before either reaches the gate, so the two gate
+    /// calls overlap deterministically: exactly one wins the placeholder
+    /// insert; the other skips (in-flight or committed — both correct).
+    /// E's materialize count == 1 witnesses that D's subtree was walked
+    /// exactly once — the double-registration TOCTOU this gate closes.
+    #[test]
+    #[serial]
+    fn concurrent_loads_agreeing_shared_dep_register_once() {
+        const TYPE_D: &str = "ConcAgreeDSchema";
+        let home = tempfile::tempdir().unwrap();
+        let pkg_root = tempfile::tempdir().unwrap();
+        let ta = pkg_root.path().join("ta");
+        let tb = pkg_root.path().join("tb");
+        let d = pkg_root.path().join("d");
+        let e = pkg_root.path().join("e");
+        for p in [&ta, &tb, &d, &e] {
+            std::fs::create_dir(p).unwrap();
+        }
+        std::fs::create_dir(d.join("schemas")).unwrap();
+        std::fs::write(
+            d.join("schemas/concagreedschema.yaml"),
+            format!("metadata:\n  type: {TYPE_D}\n  max_payload_bytes: 4096\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            ta.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: conc-agree-ta\n  version: \"0.1.0\"\n\
+             dependencies:\n  \"@tatolab/conc-agree-d\":\n    path: ../d\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tb.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: conc-agree-tb\n  version: \"0.1.0\"\n\
+             dependencies:\n  \"@tatolab/conc-agree-d\":\n    path: ../d\n",
+        )
+        .unwrap();
+        std::fs::write(
+            d.join("streamlib.yaml"),
+            format!(
+                "package:\n  org: tatolab\n  name: conc-agree-d\n  version: \"1.0.0\"\n\
+                 dependencies:\n  \"@tatolab/conc-agree-e\":\n    path: ../e\n\
+                 schemas:\n  {TYPE_D}:\n    file: schemas/concagreedschema.yaml\n"
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            e.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: conc-agree-e\n  version: \"1.0.0\"\n",
+        )
+        .unwrap();
+
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        let materialize_counts = Arc::new(parking_lot::Mutex::new(
+            std::collections::HashMap::<std::path::PathBuf, usize>::new(),
+        ));
+        runtime.set_build_orchestrator(RendezvousLoadAsIsOrchestrator {
+            rendezvous_dir_names: vec!["d".to_string()],
+            rendezvous: std::sync::Barrier::new(2),
+            counts: Arc::clone(&materialize_counts),
+        });
+
+        let strategy = |path: &std::path::Path| Strategy::Path {
+            path: path.to_path_buf(),
+            build: BuildPolicy::NeverBuild,
+        };
+        let added_ta = runtime.add_module_with(
+            ModuleIdent::any(
+                Org::new("tatolab").unwrap(),
+                Package::new("conc-agree-ta").unwrap(),
+            ),
+            strategy(&ta),
+        );
+        let added_tb = runtime.add_module_with(
+            ModuleIdent::any(
+                Org::new("tatolab").unwrap(),
+                Package::new("conc-agree-tb").unwrap(),
+            ),
+            strategy(&tb),
+        );
+        let handle = runtime.tokio_runtime_variant.handle();
+        let (result_ta, result_tb) =
+            handle.block_on(async { tokio::join!(added_ta, added_tb) });
+        result_ta.expect("TA load must succeed");
+        result_tb.expect("TB load must succeed");
+
+        let d_ref = streamlib_idents::PackageRef::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("conc-agree-d").unwrap(),
+        );
+        let record = runtime
+            .resolution_memo
+            .committed_record(&d_ref)
+            .expect("D must be committed");
+        assert_eq!(record.version, SemVer::new(1, 0, 0));
+        assert_eq!(
+            record.required_by.len(),
+            2,
+            "both concurrent loads must be recorded as requirers of D",
+        );
+        assert_eq!(
+            count_materializations_for_dir_named(&materialize_counts, "e"),
+            1,
+            "D's subtree must be walked exactly once across both concurrent loads",
+        );
+        let canonical = format!("@tatolab/conc-agree-d/{TYPE_D}");
+        assert!(
+            crate::core::embedded_schemas::get_embedded_schema_definition(&canonical).is_some(),
+            "expected D's schema {canonical} registered",
+        );
+    }
+
+    /// Two CONCURRENT top-level loads pulling DIFFERENT versions of the
+    /// same package (TA→D@1.0.0, TB→D@1.1.0) produce exactly one
+    /// SingleVersionConflict — never a silent last-commit-wins
+    /// double-registration. The rendezvous barrier guarantees both walks
+    /// hit the gate window together; whichever loses the insert race
+    /// conflicts against the winner's placeholder or committed record.
+    #[test]
+    #[serial]
+    fn concurrent_loads_conflicting_shared_dep_exactly_one_conflict() {
+        let home = tempfile::tempdir().unwrap();
+        let pkg_root = tempfile::tempdir().unwrap();
+        let ta = pkg_root.path().join("ta");
+        let tb = pkg_root.path().join("tb");
+        let d1 = pkg_root.path().join("d1");
+        let d2 = pkg_root.path().join("d2");
+        for p in [&ta, &tb, &d1, &d2] {
+            std::fs::create_dir(p).unwrap();
+        }
+        std::fs::write(
+            ta.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: conc-conflict-ta\n  version: \"0.1.0\"\n\
+             dependencies:\n  \"@tatolab/conc-conflict-d\":\n    path: ../d1\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tb.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: conc-conflict-tb\n  version: \"0.1.0\"\n\
+             dependencies:\n  \"@tatolab/conc-conflict-d\":\n    path: ../d2\n",
+        )
+        .unwrap();
+        std::fs::write(
+            d1.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: conc-conflict-d\n  version: \"1.0.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            d2.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: conc-conflict-d\n  version: \"1.1.0\"\n",
+        )
+        .unwrap();
+
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        let materialize_counts = Arc::new(parking_lot::Mutex::new(
+            std::collections::HashMap::<std::path::PathBuf, usize>::new(),
+        ));
+        runtime.set_build_orchestrator(RendezvousLoadAsIsOrchestrator {
+            rendezvous_dir_names: vec!["d1".to_string(), "d2".to_string()],
+            rendezvous: std::sync::Barrier::new(2),
+            counts: Arc::clone(&materialize_counts),
+        });
+
+        let added_ta = runtime.add_module_with(
+            ModuleIdent::any(
+                Org::new("tatolab").unwrap(),
+                Package::new("conc-conflict-ta").unwrap(),
+            ),
+            Strategy::Path {
+                path: ta.clone(),
+                build: BuildPolicy::NeverBuild,
+            },
+        );
+        let added_tb = runtime.add_module_with(
+            ModuleIdent::any(
+                Org::new("tatolab").unwrap(),
+                Package::new("conc-conflict-tb").unwrap(),
+            ),
+            Strategy::Path {
+                path: tb.clone(),
+                build: BuildPolicy::NeverBuild,
+            },
+        );
+        let handle = runtime.tokio_runtime_variant.handle();
+        let (result_ta, result_tb) =
+            handle.block_on(async { tokio::join!(added_ta, added_tb) });
+
+        let results = [result_ta.map(|_| ()), result_tb.map(|_| ())];
+        let conflict_count = results
+            .iter()
+            .filter(|r| {
+                matches!(
+                    r,
+                    Err(AddModuleError::SingleVersionConflict { package, .. })
+                        if package.name.as_str() == "conc-conflict-d"
+                )
+            })
+            .count();
+        let ok_count = results.iter().filter(|r| r.is_ok()).count();
+        assert_eq!(
+            (ok_count, conflict_count),
+            (1, 1),
+            "exactly one load must succeed and one must conflict on D, got: {results:?}",
+        );
+        // The winner's resolution of D is committed; the loser's own
+        // top-level placeholder was cleared by its drop-guard.
+        let d_ref = streamlib_idents::PackageRef::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("conc-conflict-d").unwrap(),
+        );
+        assert!(
+            runtime.resolution_memo.committed_record(&d_ref).is_some(),
+            "the winning load's D resolution must be committed",
+        );
+    }
+
+    /// Deterministic in-flight skip: TA owns D (held in flight because
+    /// D's dep E blocks in the orchestrator), TB gates D, sees the
+    /// same-version placeholder, skips locally, and verifies at the end
+    /// of its walk. After the owner commits, the waiter returns Ok. The
+    /// requirer-count poll makes the interleaving deterministic — TB is
+    /// PROVEN to have gated against the in-flight placeholder before the
+    /// release.
+    #[test]
+    #[serial]
+    fn concurrent_load_waiter_succeeds_after_owner_commits() {
+        let home = tempfile::tempdir().unwrap();
+        let pkg_root = tempfile::tempdir().unwrap();
+        let ta = pkg_root.path().join("ta");
+        let tb = pkg_root.path().join("tb");
+        let d = pkg_root.path().join("d");
+        let e = pkg_root.path().join("e");
+        for p in [&ta, &tb, &d, &e] {
+            std::fs::create_dir(p).unwrap();
+        }
+        std::fs::write(
+            ta.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: conc-wait-ta\n  version: \"0.1.0\"\n\
+             dependencies:\n  \"@tatolab/conc-wait-d\":\n    path: ../d\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tb.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: conc-wait-tb\n  version: \"0.1.0\"\n\
+             dependencies:\n  \"@tatolab/conc-wait-d\":\n    path: ../d\n",
+        )
+        .unwrap();
+        std::fs::write(
+            d.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: conc-wait-d\n  version: \"1.0.0\"\n\
+             dependencies:\n  \"@tatolab/conc-wait-e\":\n    path: ../e\n",
+        )
+        .unwrap();
+        std::fs::write(
+            e.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: conc-wait-e\n  version: \"1.0.0\"\n",
+        )
+        .unwrap();
+
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        runtime.set_build_orchestrator(GatedSubDependencyOrchestrator {
+            gated_dir_name: "e".to_string(),
+            release: parking_lot::Mutex::new(Some(release_rx)),
+            fail_after_release: false,
+        });
+
+        let d_ref = streamlib_idents::PackageRef::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("conc-wait-d").unwrap(),
+        );
+        let added_ta = runtime.add_module_with(
+            ModuleIdent::any(
+                Org::new("tatolab").unwrap(),
+                Package::new("conc-wait-ta").unwrap(),
+            ),
+            Strategy::Path {
+                path: ta.clone(),
+                build: BuildPolicy::NeverBuild,
+            },
+        );
+        // TA holds D in flight (blocked inside E's materialize).
+        assert!(
+            poll_until(std::time::Duration::from_secs(10), || {
+                runtime.resolution_memo.in_flight_requirer_count(&d_ref) == Some(1)
+            }),
+            "TA must reach D's in-flight placeholder before TB starts",
+        );
+        let added_tb = runtime.add_module_with(
+            ModuleIdent::any(
+                Org::new("tatolab").unwrap(),
+                Package::new("conc-wait-tb").unwrap(),
+            ),
+            Strategy::Path {
+                path: tb.clone(),
+                build: BuildPolicy::NeverBuild,
+            },
+        );
+        // TB gated against the IN-FLIGHT placeholder (its requirer landed
+        // while D was still in flight) — the deterministic skip witness.
+        assert!(
+            poll_until(std::time::Duration::from_secs(10), || {
+                runtime.resolution_memo.in_flight_requirer_count(&d_ref) == Some(2)
+            }),
+            "TB must record its requirer on D's in-flight placeholder",
+        );
+        release_tx.send(()).unwrap();
+
+        let handle = runtime.tokio_runtime_variant.handle();
+        let (result_ta, result_tb) =
+            handle.block_on(async { tokio::join!(added_ta, added_tb) });
+        result_ta.expect("owner load must succeed");
+        result_tb.expect("waiter load must succeed after the owner commits");
+
+        let record = runtime
+            .resolution_memo
+            .committed_record(&d_ref)
+            .expect("D must be committed");
+        assert_eq!(record.required_by.len(), 2);
+    }
+
+    /// Owner-failure verification: same shape as the success twin, but
+    /// E's materialize fails after release. The owner load fails; the
+    /// waiter — which skipped D as in-flight — must fail LOUDLY with the
+    /// typed concurrent-load error (never Ok over an unregistered
+    /// package, never a hang), and the drop-guard must have cleared D.
+    #[test]
+    #[serial]
+    fn concurrent_load_owner_failure_fails_waiter_loudly() {
+        let home = tempfile::tempdir().unwrap();
+        let pkg_root = tempfile::tempdir().unwrap();
+        let ta = pkg_root.path().join("ta");
+        let tb = pkg_root.path().join("tb");
+        let d = pkg_root.path().join("d");
+        let e = pkg_root.path().join("e");
+        for p in [&ta, &tb, &d, &e] {
+            std::fs::create_dir(p).unwrap();
+        }
+        std::fs::write(
+            ta.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: conc-fail-ta\n  version: \"0.1.0\"\n\
+             dependencies:\n  \"@tatolab/conc-fail-d\":\n    path: ../d\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tb.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: conc-fail-tb\n  version: \"0.1.0\"\n\
+             dependencies:\n  \"@tatolab/conc-fail-d\":\n    path: ../d\n",
+        )
+        .unwrap();
+        std::fs::write(
+            d.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: conc-fail-d\n  version: \"1.0.0\"\n\
+             dependencies:\n  \"@tatolab/conc-fail-e\":\n    path: ../e\n",
+        )
+        .unwrap();
+        std::fs::write(
+            e.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: conc-fail-e\n  version: \"1.0.0\"\n",
+        )
+        .unwrap();
+
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        runtime.set_build_orchestrator(GatedSubDependencyOrchestrator {
+            gated_dir_name: "e".to_string(),
+            release: parking_lot::Mutex::new(Some(release_rx)),
+            fail_after_release: true,
+        });
+
+        let d_ref = streamlib_idents::PackageRef::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("conc-fail-d").unwrap(),
+        );
+        let added_ta = runtime.add_module_with(
+            ModuleIdent::any(
+                Org::new("tatolab").unwrap(),
+                Package::new("conc-fail-ta").unwrap(),
+            ),
+            Strategy::Path {
+                path: ta.clone(),
+                build: BuildPolicy::NeverBuild,
+            },
+        );
+        assert!(
+            poll_until(std::time::Duration::from_secs(10), || {
+                runtime.resolution_memo.in_flight_requirer_count(&d_ref) == Some(1)
+            }),
+            "TA must reach D's in-flight placeholder before TB starts",
+        );
+        let added_tb = runtime.add_module_with(
+            ModuleIdent::any(
+                Org::new("tatolab").unwrap(),
+                Package::new("conc-fail-tb").unwrap(),
+            ),
+            Strategy::Path {
+                path: tb.clone(),
+                build: BuildPolicy::NeverBuild,
+            },
+        );
+        assert!(
+            poll_until(std::time::Duration::from_secs(10), || {
+                runtime.resolution_memo.in_flight_requirer_count(&d_ref) == Some(2)
+            }),
+            "TB must record its requirer on D's in-flight placeholder",
+        );
+        release_tx.send(()).unwrap();
+
+        let handle = runtime.tokio_runtime_variant.handle();
+        let (result_ta, result_tb) =
+            handle.block_on(async { tokio::join!(added_ta, added_tb) });
+        let owner_err = result_ta.expect_err("owner load must fail (injected E failure)");
+        assert!(
+            matches!(owner_err, AddModuleError::MaterializeFailed { .. }),
+            "owner must surface the injected materialize failure, got: {owner_err:?}",
+        );
+        let waiter_err =
+            result_tb.expect_err("waiter must fail loudly when the owner fails");
+        assert!(
+            matches!(
+                waiter_err,
+                AddModuleError::ConcurrentLoadOfSkippedDependencyFailed { ref package, version }
+                    if package.name.as_str() == "conc-fail-d"
+                        && version == SemVer::new(1, 0, 0)
+            ),
+            "expected ConcurrentLoadOfSkippedDependencyFailed for D, got: {waiter_err:?}",
+        );
+        assert!(
+            !runtime.resolution_memo.contains_package(&d_ref),
+            "the failed owner's drop-guard must clear D's placeholder",
         );
     }
 
@@ -1827,7 +2499,7 @@ processors:
         );
         let ident =
             ModuleIdent::any(Org::new("tatolab").unwrap(), Package::new("guard-pkg").unwrap());
-        runtime.loading_modules.lock().insert(pkg, ident);
+        runtime.loading_modules.lock().insert(pkg, (0, ident));
 
         let err = runtime
             .start()

--- a/libs/streamlib-engine/src/core/runtime/module_loader/tests.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/tests.rs
@@ -1443,6 +1443,315 @@ processors:
         );
     }
 
+    // =========================================================================
+    // Single-version-per-package gate (#1216)
+    // =========================================================================
+
+    /// A diamond where the two branches resolve the shared dependency to
+    /// *different* concrete versions (B→D@1.0.0, C→D@1.1.0) must surface a
+    /// typed [`AddModuleError::SingleVersionConflict`] naming both versions
+    /// and both requirers — not a silent double-registration. Path deps
+    /// enter with range `Any`, so the gate must compare concrete `SemVer`s.
+    #[test]
+    #[serial]
+    fn diamond_conflicting_versions_error_single_version_conflict() {
+        let home = tempfile::tempdir().unwrap();
+        let pkg_root = tempfile::tempdir().unwrap();
+        let a = pkg_root.path().join("a");
+        let b = pkg_root.path().join("b");
+        let c = pkg_root.path().join("c");
+        let d1 = pkg_root.path().join("d1");
+        let d2 = pkg_root.path().join("d2");
+        for p in [&a, &b, &c, &d1, &d2] {
+            std::fs::create_dir(p).unwrap();
+        }
+        std::fs::write(
+            a.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: diamond-a\n  version: \"0.1.0\"\n\
+             dependencies:\n  \"@tatolab/diamond-b\":\n    path: ../b\n\
+             \x20 \"@tatolab/diamond-c\":\n    path: ../c\n",
+        )
+        .unwrap();
+        std::fs::write(
+            b.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: diamond-b\n  version: \"0.1.0\"\n\
+             dependencies:\n  \"@tatolab/diamond-d\":\n    path: ../d1\n",
+        )
+        .unwrap();
+        std::fs::write(
+            c.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: diamond-c\n  version: \"0.1.0\"\n\
+             dependencies:\n  \"@tatolab/diamond-d\":\n    path: ../d2\n",
+        )
+        .unwrap();
+        std::fs::write(
+            d1.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: diamond-d\n  version: \"1.0.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            d2.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: diamond-d\n  version: \"1.1.0\"\n",
+        )
+        .unwrap();
+
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        runtime.set_build_orchestrator(LoadAsIsOrchestrator);
+        let err = runtime
+            .add_module_with_blocking(
+                ModuleIdent::any(
+                    Org::new("tatolab").unwrap(),
+                    Package::new("diamond-a").unwrap(),
+                ),
+                Strategy::Path {
+                    path: a.clone(),
+                    build: BuildPolicy::NeverBuild,
+                },
+            )
+            .expect_err("diamond version conflict must error");
+        match err {
+            AddModuleError::SingleVersionConflict {
+                package,
+                existing_version,
+                existing_required_by,
+                conflicting_version,
+                conflicting_required_by,
+            } => {
+                assert_eq!(package.name.as_str(), "diamond-d");
+                // B is walked before C (BTreeMap key order), so D@1.0.0 lands
+                // in the memo first and D@1.1.0 is the conflicting encounter.
+                assert_eq!(existing_version, SemVer::new(1, 0, 0));
+                assert_eq!(conflicting_version, SemVer::new(1, 1, 0));
+                assert!(
+                    existing_required_by.contains("diamond-b"),
+                    "existing requirer should name diamond-b, got: {existing_required_by}",
+                );
+                assert!(
+                    conflicting_required_by.contains("diamond-c"),
+                    "conflicting requirer should name diamond-c, got: {conflicting_required_by}",
+                );
+            }
+            other => panic!("expected SingleVersionConflict, got: {other:?}"),
+        }
+    }
+
+    /// A diamond where both branches agree on the shared dependency's
+    /// version (B→D@1.0.0, C→D@1.0.0) resolves cleanly, D's schema is
+    /// registered, and the memo records D exactly once at 1.0.0 with BOTH
+    /// requirers — the single-registration invariant. Reverting the
+    /// same-version record-and-skip branch drops the second requirer (or
+    /// removes the memo entirely), failing the `required_by.len() == 2`
+    /// assertion.
+    #[test]
+    #[serial]
+    fn diamond_agreeing_versions_resolve_and_register_once() {
+        const TYPE_D: &str = "DiamondAgreeDSchema";
+        let home = tempfile::tempdir().unwrap();
+        let pkg_root = tempfile::tempdir().unwrap();
+        let a = pkg_root.path().join("a");
+        let b = pkg_root.path().join("b");
+        let c = pkg_root.path().join("c");
+        let d = pkg_root.path().join("d");
+        for p in [&a, &b, &c, &d] {
+            std::fs::create_dir(p).unwrap();
+        }
+        std::fs::create_dir(d.join("schemas")).unwrap();
+        std::fs::write(
+            d.join("schemas/diamondagreedschema.yaml"),
+            format!("metadata:\n  type: {TYPE_D}\n  max_payload_bytes: 4096\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            a.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: diamond-agree-a\n  version: \"0.1.0\"\n\
+             dependencies:\n  \"@tatolab/diamond-agree-b\":\n    path: ../b\n\
+             \x20 \"@tatolab/diamond-agree-c\":\n    path: ../c\n",
+        )
+        .unwrap();
+        std::fs::write(
+            b.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: diamond-agree-b\n  version: \"0.1.0\"\n\
+             dependencies:\n  \"@tatolab/diamond-agree-d\":\n    path: ../d\n",
+        )
+        .unwrap();
+        std::fs::write(
+            c.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: diamond-agree-c\n  version: \"0.1.0\"\n\
+             dependencies:\n  \"@tatolab/diamond-agree-d\":\n    path: ../d\n",
+        )
+        .unwrap();
+        std::fs::write(
+            d.join("streamlib.yaml"),
+            format!(
+                "package:\n  org: tatolab\n  name: diamond-agree-d\n  version: \"1.0.0\"\n\
+                 schemas:\n  {TYPE_D}:\n    file: schemas/diamondagreedschema.yaml\n"
+            ),
+        )
+        .unwrap();
+
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        runtime.set_build_orchestrator(LoadAsIsOrchestrator);
+        runtime
+            .add_module_with_blocking(
+                ModuleIdent::any(
+                    Org::new("tatolab").unwrap(),
+                    Package::new("diamond-agree-a").unwrap(),
+                ),
+                Strategy::Path {
+                    path: a.clone(),
+                    build: BuildPolicy::NeverBuild,
+                },
+            )
+            .expect("agreeing diamond must resolve cleanly");
+
+        let canonical = format!("@tatolab/diamond-agree-d/{TYPE_D}");
+        assert!(
+            crate::core::embedded_schemas::get_embedded_schema_definition(&canonical).is_some(),
+            "expected D's schema {canonical} registered",
+        );
+
+        let d_ref = streamlib_idents::PackageRef::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("diamond-agree-d").unwrap(),
+        );
+        let memo = runtime.resolution_memo.lock();
+        let record = memo
+            .get(&d_ref)
+            .expect("D must be recorded in the resolution memo");
+        assert_eq!(record.version, SemVer::new(1, 0, 0));
+        assert_eq!(
+            record.required_by.len(),
+            2,
+            "both B and C must be recorded as requirers of the single D resolution",
+        );
+    }
+
+    /// The memo persists across successive `add_module` calls on the same
+    /// runtime: adding X@1.0.0, then adding Y (which depends on X@2.0.0),
+    /// conflicts even though the two loads are independent top-level calls.
+    #[test]
+    #[serial]
+    fn cross_call_conflicting_versions_error() {
+        let home = tempfile::tempdir().unwrap();
+        let pkg_root = tempfile::tempdir().unwrap();
+        let xa = pkg_root.path().join("xa");
+        let xb = pkg_root.path().join("xb");
+        let y = pkg_root.path().join("y");
+        for p in [&xa, &xb, &y] {
+            std::fs::create_dir(p).unwrap();
+        }
+        std::fs::write(
+            xa.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: crosscall-x\n  version: \"1.0.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            xb.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: crosscall-x\n  version: \"2.0.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            y.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: crosscall-y\n  version: \"0.1.0\"\n\
+             dependencies:\n  \"@tatolab/crosscall-x\":\n    path: ../xb\n",
+        )
+        .unwrap();
+
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        runtime.set_build_orchestrator(LoadAsIsOrchestrator);
+
+        runtime
+            .add_module_with_blocking(
+                ModuleIdent::any(
+                    Org::new("tatolab").unwrap(),
+                    Package::new("crosscall-x").unwrap(),
+                ),
+                Strategy::Path {
+                    path: xa.clone(),
+                    build: BuildPolicy::NeverBuild,
+                },
+            )
+            .expect("first add_module (x@1.0.0) must succeed");
+
+        let err = runtime
+            .add_module_with_blocking(
+                ModuleIdent::any(
+                    Org::new("tatolab").unwrap(),
+                    Package::new("crosscall-y").unwrap(),
+                ),
+                Strategy::Path {
+                    path: y.clone(),
+                    build: BuildPolicy::NeverBuild,
+                },
+            )
+            .expect_err("second add_module pulling x@2.0.0 must conflict");
+        match err {
+            AddModuleError::SingleVersionConflict {
+                package,
+                existing_version,
+                conflicting_version,
+                ..
+            } => {
+                assert_eq!(package.name.as_str(), "crosscall-x");
+                assert_eq!(existing_version, SemVer::new(1, 0, 0));
+                assert_eq!(conflicting_version, SemVer::new(2, 0, 0));
+            }
+            other => panic!("expected SingleVersionConflict, got: {other:?}"),
+        }
+    }
+
+    /// Re-adding the same package at the same version is a cheap idempotent
+    /// no-op: both calls succeed, and the memo records the single X
+    /// resolution with both top-level `add_module` calls as requirers.
+    #[test]
+    #[serial]
+    fn idempotent_re_add_same_version_succeeds() {
+        let home = tempfile::tempdir().unwrap();
+        let pkg = tempfile::tempdir().unwrap();
+        std::fs::write(
+            pkg.path().join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: readd-x\n  version: \"1.0.0\"\n",
+        )
+        .unwrap();
+
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        runtime.set_build_orchestrator(LoadAsIsOrchestrator);
+
+        let ident = || {
+            ModuleIdent::any(
+                Org::new("tatolab").unwrap(),
+                Package::new("readd-x").unwrap(),
+            )
+        };
+        let strategy = || Strategy::Path {
+            path: pkg.path().to_path_buf(),
+            build: BuildPolicy::NeverBuild,
+        };
+        runtime
+            .add_module_with_blocking(ident(), strategy())
+            .expect("first add_module must succeed");
+        runtime
+            .add_module_with_blocking(ident(), strategy())
+            .expect("idempotent re-add at same version must succeed");
+
+        let x_ref = streamlib_idents::PackageRef::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("readd-x").unwrap(),
+        );
+        let memo = runtime.resolution_memo.lock();
+        let record = memo.get(&x_ref).expect("X must be recorded");
+        assert_eq!(record.version, SemVer::new(1, 0, 0));
+        assert_eq!(
+            record.required_by.len(),
+            2,
+            "both top-level add_module calls must be recorded as requirers",
+        );
+    }
+
     /// `start()` must refuse to run the graph while a module load is
     /// still in flight. The loading set is `pub(crate)` and is populated
     /// by `add_module_with` at call time; simulating an in-flight entry

--- a/libs/streamlib-engine/src/core/runtime/module_loader/tests.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/tests.rs
@@ -1537,12 +1537,17 @@ processors:
     }
 
     /// A diamond where both branches agree on the shared dependency's
-    /// version (B→D@1.0.0, C→D@1.0.0) resolves cleanly, D's schema is
-    /// registered, and the memo records D exactly once at 1.0.0 with BOTH
-    /// requirers — the single-registration invariant. Reverting the
-    /// same-version record-and-skip branch drops the second requirer (or
-    /// removes the memo entirely), failing the `required_by.len() == 2`
-    /// assertion.
+    /// version (B→D@1.0.0, C→D@1.0.0) resolves cleanly and D's schema is
+    /// registered. The single-registration invariant is locked by the
+    /// memo assertion: D is recorded exactly once at 1.0.0 with C added as
+    /// a *second requirer of the same resolution* (`required_by.len() ==
+    /// 2`), which proves C took the same-version skip path instead of
+    /// re-registering + re-walking D. (Schema presence alone can't witness
+    /// this — schema registration is an idempotent map overwrite, so a
+    /// double-walk would leave the same observable schema; the requirer
+    /// count is what the skip drives.) Reverting the same-version
+    /// record-and-skip branch drops the second requirer (or removes the
+    /// memo entirely), failing the assertion.
     #[test]
     #[serial]
     fn diamond_agreeing_versions_resolve_and_register_once() {
@@ -1749,6 +1754,60 @@ processors:
             record.required_by.len(),
             2,
             "both top-level add_module calls must be recorded as requirers",
+        );
+    }
+
+    /// A load that fails mid-registration must NOT poison the memo: the
+    /// version commit is deferred until registration + the transitive walk
+    /// succeed, so a failed package leaves no entry and a retry re-runs the
+    /// full registration instead of hitting the same-version skip and
+    /// silently returning `Ok` for a never-registered package. Here X
+    /// declares a schema whose file is missing, so `add_module` fails
+    /// before the deferred commit. Mentally reverting to commit-before-
+    /// registration would leave X in the memo and fail the `!contains_key`
+    /// assertion.
+    #[test]
+    #[serial]
+    fn failed_load_does_not_poison_the_memo() {
+        let home = tempfile::tempdir().unwrap();
+        let pkg = tempfile::tempdir().unwrap();
+        // Declares a schema pointing at a file that does not exist →
+        // `register_package_schemas` errors before the deferred memo
+        // commit at the end of the walk body.
+        std::fs::write(
+            pkg.path().join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: poison-x\n  version: \"1.0.0\"\n\
+             schemas:\n  PoisonSchema:\n    file: schemas/does-not-exist.yaml\n",
+        )
+        .unwrap();
+
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        runtime.set_build_orchestrator(LoadAsIsOrchestrator);
+        let err = runtime
+            .add_module_with_blocking(
+                ModuleIdent::any(
+                    Org::new("tatolab").unwrap(),
+                    Package::new("poison-x").unwrap(),
+                ),
+                Strategy::Path {
+                    path: pkg.path().to_path_buf(),
+                    build: BuildPolicy::NeverBuild,
+                },
+            )
+            .expect_err("missing schema file must fail the load");
+        assert!(
+            matches!(err, AddModuleError::LoadProjectFailed { .. }),
+            "expected LoadProjectFailed from the missing schema, got: {err:?}",
+        );
+
+        let x_ref = streamlib_idents::PackageRef::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("poison-x").unwrap(),
+        );
+        assert!(
+            !runtime.resolution_memo.lock().contains_key(&x_ref),
+            "a failed load must not leave a resolution-memo entry",
         );
     }
 

--- a/libs/streamlib-engine/src/core/runtime/runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/runtime.rs
@@ -127,26 +127,30 @@ pub struct Runner {
         Mutex<Option<Arc<dyn crate::core::runtime::module_loader::BuildOrchestrator>>>,
     >,
     /// Modules whose loads have not yet settled, keyed by canonical
-    /// `@org/name`. Inserted when [`Runner::add_module`] spawns a load,
-    /// removed when the load task finishes. [`Runner::start`] refuses to
-    /// run the graph while any entry remains.
+    /// `@org/name` with the owning load's id. Inserted when
+    /// [`Runner::add_module`] spawns a load; removed when that same
+    /// load's task finishes (id-guarded so an earlier load's completion
+    /// can't untrack a later load of the same package ref).
+    /// [`Runner::start`] refuses to run the graph while any entry remains.
     pub(crate) loading_modules: Arc<
-        Mutex<std::collections::HashMap<streamlib_idents::PackageRef, streamlib_idents::ModuleIdent>>,
+        Mutex<std::collections::HashMap<streamlib_idents::PackageRef, (u64, streamlib_idents::ModuleIdent)>>,
     >,
     /// Runtime-lifetime single-version-per-package resolution memo, keyed
     /// by `@org/name`. Populated by the live module walker on every
     /// [`Runner::add_module`] call; persists across calls so a diamond
-    /// version divergence — or two successive `add_module`s resolving
-    /// different concrete versions of the same package — surfaces as
-    /// [`AddModuleError::SingleVersionConflict`] instead of a silent
-    /// double-registration. Lives for the runtime's lifetime (there is no
-    /// module unload today); dropped with the [`Runner`].
+    /// version divergence — or two successive / concurrent `add_module`s
+    /// resolving different concrete versions of the same package —
+    /// surfaces as [`AddModuleError::SingleVersionConflict`] instead of a
+    /// silent double-registration. Lives for the runtime's lifetime
+    /// (there is no module unload today); dropped with the [`Runner`].
+    /// The memo is Runner-scoped while the schema / processor registries
+    /// it protects are process-global statics — a second [`Runner`] in
+    /// the same process carries its own memo and does not see this one's
+    /// resolutions (pre-existing registry topology, unchanged here).
     ///
     /// [`Runner::add_module`]: Self::add_module
     /// [`AddModuleError::SingleVersionConflict`]: crate::core::runtime::module_loader::AddModuleError::SingleVersionConflict
-    pub(crate) resolution_memo: Arc<
-        Mutex<crate::core::runtime::module_loader::ResolutionMemo>,
-    >,
+    pub(crate) resolution_memo: Arc<crate::core::runtime::module_loader::ResolutionMemo>,
 }
 
 impl Runner {
@@ -289,7 +293,9 @@ impl Runner {
             pipeline_name: Arc::new(Mutex::new(None)),
             build_orchestrator: Arc::new(Mutex::new(None)),
             loading_modules: Arc::new(Mutex::new(std::collections::HashMap::new())),
-            resolution_memo: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            resolution_memo: Arc::new(
+                crate::core::runtime::module_loader::ResolutionMemo::new(),
+            ),
         }))
     }
 

--- a/libs/streamlib-engine/src/core/runtime/runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/runtime.rs
@@ -133,6 +133,20 @@ pub struct Runner {
     pub(crate) loading_modules: Arc<
         Mutex<std::collections::HashMap<streamlib_idents::PackageRef, streamlib_idents::ModuleIdent>>,
     >,
+    /// Runtime-lifetime single-version-per-package resolution memo, keyed
+    /// by `@org/name`. Populated by the live module walker on every
+    /// [`Runner::add_module`] call; persists across calls so a diamond
+    /// version divergence — or two successive `add_module`s resolving
+    /// different concrete versions of the same package — surfaces as
+    /// [`AddModuleError::SingleVersionConflict`] instead of a silent
+    /// double-registration. Lives for the runtime's lifetime (there is no
+    /// module unload today); dropped with the [`Runner`].
+    ///
+    /// [`Runner::add_module`]: Self::add_module
+    /// [`AddModuleError::SingleVersionConflict`]: crate::core::runtime::module_loader::AddModuleError::SingleVersionConflict
+    pub(crate) resolution_memo: Arc<
+        Mutex<crate::core::runtime::module_loader::ResolutionMemo>,
+    >,
 }
 
 impl Runner {
@@ -275,6 +289,7 @@ impl Runner {
             pipeline_name: Arc::new(Mutex::new(None)),
             build_orchestrator: Arc::new(Mutex::new(None)),
             loading_modules: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            resolution_memo: Arc::new(Mutex::new(std::collections::HashMap::new())),
         }))
     }
 


### PR DESCRIPTION
## Summary

Enforces **single-version-per-package** at the live module-load walker (`add_module_recursively`), turning a diamond version divergence into a typed `AddModuleError::SingleVersionConflict` instead of the silent double-registration that happens today. Concurrent-safe: the gate holds under overlapping `add_module` loads via in-flight placeholders with end-of-walk verification.

Closes #1216.

## Why the gate lands in the live walker (the two-resolvers finding)

streamlib has **two** transitive resolvers:

1. `streamlib_idents::resolver::resolve_with` — a BFS resolver that already dedupes by `@org/name` and errors `VersionRangeConflict`. It's used for schema/bare-name resolution, **not** for the runtime module load.
2. The engine's **live-load walker** `add_module_recursively` (`module_loader/recursive_walker.rs`) — a DFS with only a stack-scoped cycle guard (`seen`), **no cross-branch version tracking**. A diamond's shared dep is registered **twice**.

This PR gates **the live walker only**. Unifying the two resolvers is deliberately **out of scope** (deferred to the install/run-split work). The two resolvers **agree on first-wins semantics; range-satisfaction acceptance differs — the walker is stricter**: it requires concrete-version equality with the already-resolved version, whereas the idents resolver's `check_existing_satisfies_spec` accepts any existing version that matches the new edge's range. Safe-direction divergence (the walker never accepts something the resolver would reject).

## Design

- A runtime-lifetime **resolution memo** (`ResolutionMemo` on `Runner`) keyed by `PackageRef` **persists across `add_module` calls** — two independent top-level loads that diverge on a shared package also conflict, not just a single diamond walk.
- The gate sits after the on-disk-version + identity/range checks, before schema registration, and classifies each encounter **under one lock acquisition**:
  - **absent** → insert an **in-flight placeholder** (same lock as the check — no check-then-commit TOCTOU window for a concurrent load), then register + recurse;
  - **same concrete version, committed** → record the extra requirer, **skip** re-registration + re-recursion (this also fixes today's silent double-registration);
  - **same concrete version, in flight on a concurrent load** → record the requirer, skip locally, and append to the walk's `skipped_in_flight` list — **nobody ever blocks mid-walk**, so concurrent walks are structurally deadlock-free;
  - **different concrete version** (vs placeholder or committed) → `SingleVersionConflict { package, existing_version, existing_required_by, conflicting_version, conflicting_required_by }` naming both versions, both requirers, and both resolved source paths.
- The gate compares **concrete `SemVer`s, never ranges** — path/git deps enter with range `Any`, so a range-only check would never fire.
- **Commit-after-success via RAII drop-guard**: the placeholder flips to a committed record (publishing `Committed` on its completion signal) only after the package's registration + transitive walk succeed. Every failure exit — schema registration, dep recursion, processor registration — drops the guard, which removes the placeholder and publishes `Failed`: the memo can never wedge in a permanent "resolving" state, and a retry re-runs the full resolution.
- **End-of-walk verification**: before a top-level load resolves `Ok`, it waits on every skipped in-flight entry (10-minute defensive timeout — a wedged concurrent load surfaces as typed `ConcurrentLoadOfSkippedDependencyTimedOut`, never a hang). Owner committed → fine; owner failed → typed `ConcurrentLoadOfSkippedDependencyFailed` naming the package ("retry the add") — no false success over an unregistered dependency.
- `loading_modules` entries now carry the owning load id, and completion removes only its own entry — an earlier load's completion can no longer untrack a later load of the same package ref (pre-existing hole, ~10-line fix).

### Known limitation (registration is not transactional)

Schema/processor registration into the process-global registries has no unload/rollback. A multi-processor package that fails on its second processor leaves the first processor registered; a retry of that package can then hit "already registered". Commit-after-success still guarantees the memo never *claims* an unregistered package resolved — but full retry-cleanliness for partially-registered packages needs module unload/rollback, which is out of scope here. (The schema-only retry path is clean and test-locked.) The memo is also `Runner`-scoped while the registries are process-global — a second `Runner` in the same process carries its own memo (pre-existing registry topology, unchanged).

## Escape hatch — `patch:` verification (honest finding)

The error message directs the user to pin one version via a `patch:` entry in **the requiring `streamlib.yaml`**. I verified this empirically:

- A `patch:` on the **root** app does **NOT** unify a *transitive* diamond — `patch:` is per-manifest-local (only consulted for that manifest's own direct deps). Probe result: conflict still fires.
- A `patch:` in **each direct-requirer** manifest (the manifests that directly declare the shared dep) **DOES** unify the diamond — both branches resolve to the pinned source → agreement → clean. Probe result: `Ok(())`.

So the message's "the requiring streamlib.yaml" is accurate as long as "requiring" is read as the **direct-parent** manifest, not the root app. This per-manifest-local behavior is a relevant input for #1218/#1221 (resolver unification): a truly root-level override needs the unified resolver, which this issue does not build.

## Tests (`module_loader/tests.rs`, all `#[serial]`)

Sequential gate behavior:

- **Diamond conflict** — A→{B,C}, B→D@1.0.0, C→D@1.1.0 → typed `SingleVersionConflict` asserting on the variant fields. Requires concrete-SemVer comparison — both deps enter range `Any`, so a range check would never fire.
- **Diamond agreement** — B→D@1.0.0, C→D@1.0.0, D→E → clean; two witnesses: `required_by.len() == 2` (locks the requirer-push in the skip arm; the commit merge-preserves requirers, never overwrite-resets) and **E materialized exactly once** (the re-walk witness — verified to FAIL under a skip-bypass revert probe, output below).
- **Cross-call conflict** — `add_module(X@1.0)` then `add_module(Y)` where Y→X@2.0 → conflict; asserts the "top-level add_module" requirer text.
- **Idempotent re-add** — same version twice → both succeed, both top-level calls recorded as requirers.
- **No-poison + full retry** — schema-file failure leaves no memo entry; after fixing the file, retry on the same runtime succeeds and the schema actually registers.
- **Drop-guard on every failure exit** — schema registration (test above), dep recursion (both cycle tests assert the placeholder cleared), processor registration (triple-mismatch test asserts the placeholder cleared).

Concurrency (deterministic — orchestrator barriers/gates control the overlap window, never timing luck):

- **Agreeing shared dep** (rendezvous barrier forces both walks into the gate window together) → both loads succeed, D committed once with both requirers, **D's subtree walked exactly once** (materialize-count witness — the TOCTOU double-registration this fix closes).
- **Conflicting shared dep** (same barrier, D@1.0 vs D@1.1) → exactly one `SingleVersionConflict`, one success, winner's resolution committed.
- **Waiter verifies owner commit** (D's sub-dep E blocked in the orchestrator holds D in flight; requirer-count poll PROVES the second load gated against the in-flight placeholder before release) → owner commits, waiter returns Ok.
- **Owner failure fails waiter loudly** (same shape, E fails after release) → owner gets `MaterializeFailed`, waiter gets typed `ConcurrentLoadOfSkippedDependencyFailed` for D (not Ok, not a hang), drop-guard cleared D.

Negative-revert probe output (skip branch bypassed):

```
assertion `left == right` failed: D's subtree must be walked exactly once —
a second E materialization means the same-version skip was bypassed
test result: FAILED. 0 passed; 1 failed
```

## Validation

- `cargo check -p streamlib-engine --offline` clean (no new warnings from this change).
- `cargo test -p streamlib-engine --lib module_loader` — 53 passed. Full `core::runtime::` group — 64 passed.
- `cargo doc -p streamlib-engine --no-deps` — no new unresolved-link warnings from this change.
- Registry-dependent workspace crates couldn't resolve offline (gitea registry at `localhost:3300` down in this environment); all changed code is in `streamlib-engine`, which builds + tests clean.

## Notes for #1218 / #1221

- The two-resolver split is the load-bearing constraint: the runtime walker and `resolve_with` are independent and **not unified**. They agree on first-wins; **range-satisfaction acceptance differs — the walker is stricter** (concrete-version equality vs `check_existing_satisfies_spec`'s existing-version-matches-new-range). Unification should reconcile this deliberately (the walker's stricter rule is the safe direction to keep).
- `patch:` is per-manifest-local in the walker. Root-level override of a transitive diamond is not achievable without the unified resolver.
- Registration non-transactionality (partial processor registration surviving a failed load) is the retry gap that module unload/rollback would close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wr1VLKMBbFpsmU7zAcniU2
