### PR TITLE
feat(idents): prerelease (-dev.N) support in package SemVer

### DIFF
--- a/libs/streamlib-deno/decorators.ts
+++ b/libs/streamlib-deno/decorators.ts
@@ -169,11 +169,16 @@ export function processor(shortName: string, moduleUrl: string) {
       );
     }
 
+    // Schema idents are release-only by invariant: a package may carry a
+    // `-dev.N` / `-rc.N` prerelease version, but its schema idents project
+    // onto the release core (mirrors Rust's `SemVer::release_core`). The
+    // 3-part `SchemaIdent` validator would otherwise reject a legitimately
+    // dev-versioned package's processors.
     const ident = new SchemaIdent(
       summary.package.org,
       summary.package.name,
       shortName,
-      summary.package.version,
+      releaseCore(summary.package.version),
     );
 
     // Attach as static fields. Mirrors Python's
@@ -277,6 +282,18 @@ export function output(opts: PortOptions = {}) {
 // =============================================================================
 // Internal helpers
 // =============================================================================
+
+/**
+ * Project a package version onto its release core `MAJOR.MINOR.PATCH`.
+ *
+ * Package versions may carry a `-dev.N` / `-rc.N` prerelease, but schema
+ * idents are release-only by invariant. Mirrors Rust's
+ * `streamlib_idents::SemVer::release_core`.
+ */
+function releaseCore(version: string): string {
+  const dash = version.indexOf("-");
+  return dash === -1 ? version : version.slice(0, dash);
+}
 
 function locateSiblingManifest(
   moduleUrl: string,

--- a/libs/streamlib-deno/decorators.ts
+++ b/libs/streamlib-deno/decorators.ts
@@ -284,15 +284,30 @@ export function output(opts: PortOptions = {}) {
 // =============================================================================
 
 /**
+ * Package-version grammar: 3-part core + optional closed `-dev.N` / `-rc.N`
+ * prerelease. Mirrors Rust's `SemVer::from_dotted` so all three runtimes
+ * accept and reject the same manifests.
+ */
+const PACKAGE_VERSION_PATTERN = /^(\d+\.\d+\.\d+)(?:-(?:dev|rc)\.\d+)?$/;
+
+/**
  * Project a package version onto its release core `MAJOR.MINOR.PATCH`.
  *
  * Package versions may carry a `-dev.N` / `-rc.N` prerelease, but schema
- * idents are release-only by invariant. Mirrors Rust's
- * `streamlib_idents::SemVer::release_core`.
+ * idents are release-only by invariant. Anything outside that closed grammar
+ * (`-alpha.1`, `+build`, malformed ordinals) throws — identical posture to
+ * Rust's manifest parsing, never a silent projection of an invalid version.
+ * Mirrors Rust's `streamlib_idents::SemVer::release_core`.
  */
 function releaseCore(version: string): string {
-  const dash = version.indexOf("-");
-  return dash === -1 ? version : version.slice(0, dash);
+  const match = PACKAGE_VERSION_PATTERN.exec(version);
+  if (match === null) {
+    throw new Error(
+      `invalid package version ${JSON.stringify(version)}: must be ` +
+        `MAJOR.MINOR.PATCH with an optional -dev.N / -rc.N prerelease`,
+    );
+  }
+  return match[1];
 }
 
 function locateSiblingManifest(

--- a/libs/streamlib-deno/decorators_test.ts
+++ b/libs/streamlib-deno/decorators_test.ts
@@ -191,6 +191,38 @@ Deno.test("@processor attaches structured SchemaIdent from manifest", async () =
   }
 });
 
+Deno.test("@processor projects a prerelease package version to release core", async () => {
+  // A `-dev.N` / `-rc.N` package version is legal; the minted schema ident
+  // must project onto the release core (the 3-part SchemaIdent validator
+  // would otherwise reject the dev-versioned package).
+  const fixture = await makeFixture(
+    [
+      "package:",
+      "  org: tatolab",
+      "  name: camera",
+      "  version: 0.4.33-dev.2",
+      "",
+      "processors:",
+      "  - name: Camera",
+      "    runtime: deno",
+      "    execution: reactive",
+      "",
+    ].join("\n"),
+    moduleHeader() +
+      `@processor("Camera", import.meta.url)\n` +
+      `export default class Camera {}\n`,
+  );
+  try {
+    const mod = await import(`file://${fixture.modulePath}`);
+    const cls = mod.default as unknown as StreamlibClassMetadata;
+    const ident = cls.streamlibSchemaIdent;
+    assertEquals(ident.version, "0.4.33");
+    assertEquals(String(ident), "@tatolab/camera/Camera@0.4.33");
+  } finally {
+    await Deno.remove(fixture.dir, { recursive: true });
+  }
+});
+
 Deno.test("@processor errors with expected path when manifest missing", async () => {
   const dir = await Deno.makeTempDir({ prefix: "streamlib-decorator-" });
   const modulePath = join(dir, "fixture.ts");

--- a/libs/streamlib-deno/decorators_test.ts
+++ b/libs/streamlib-deno/decorators_test.ts
@@ -11,6 +11,7 @@
 import {
   assert,
   assertEquals,
+  assertRejects,
   assertThrows,
 } from "@std/assert";
 import { join } from "@std/path";
@@ -218,6 +219,38 @@ Deno.test("@processor projects a prerelease package version to release core", as
     const ident = cls.streamlibSchemaIdent;
     assertEquals(ident.version, "0.4.33");
     assertEquals(String(ident), "@tatolab/camera/Camera@0.4.33");
+  } finally {
+    await Deno.remove(fixture.dir, { recursive: true });
+  }
+});
+
+Deno.test("@processor rejects unknown prerelease channels", async () => {
+  // Only `-dev.N` / `-rc.N` project; an alpha (or any foreign channel) must
+  // throw — the same manifest is rejected by Rust's parser, and silently
+  // projecting here would let the runtimes disagree.
+  const fixture = await makeFixture(
+    [
+      "package:",
+      "  org: tatolab",
+      "  name: camera",
+      "  version: 0.4.33-alpha.1",
+      "",
+      "processors:",
+      "  - name: Camera",
+      "    runtime: deno",
+      "    execution: reactive",
+      "",
+    ].join("\n"),
+    moduleHeader() +
+      `@processor("Camera", import.meta.url)\n` +
+      `export default class Camera {}\n`,
+  );
+  try {
+    await assertRejects(
+      () => import(`file://${fixture.modulePath}`),
+      Error,
+      "invalid package version",
+    );
   } finally {
     await Deno.remove(fixture.dir, { recursive: true });
   }

--- a/libs/streamlib-engine/src/core/config/project_config.rs
+++ b/libs/streamlib-engine/src/core/config/project_config.rs
@@ -378,6 +378,40 @@ env:
     }
 
     #[test]
+    fn resolve_named_to_ident_projects_prerelease_owner_to_release_core() {
+        // Runtime mirror of the macro-side bare-name resolution. The ident it
+        // mints flows onto `PortSchemaSpec`'s wire form, which carries only
+        // major/minor/patch — `SchemaIdent::new`'s release-core projection is
+        // what prevents a dev-versioned owner from silently truncating there.
+        let dir = TempDir::new().unwrap();
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(root.join("schemas")).unwrap();
+        std::fs::write(
+            root.join("streamlib.yaml"),
+            r#"
+package:
+  org: tatolab
+  name: camera
+  version: 0.4.33-dev.2
+schemas:
+  VideoFrame:
+    file: schemas/video_frame.yaml
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("schemas/video_frame.yaml"),
+            "metadata:\n  type: VideoFrame\nproperties: {}\n",
+        )
+        .unwrap();
+        let resolved = streamlib_idents::resolve(&root).unwrap();
+        let name = streamlib_processor_schema::TypeName::new("VideoFrame").unwrap();
+        let ident = resolve_named_to_ident(&resolved, &name).unwrap();
+        assert_eq!(ident.version, streamlib_idents::SemVer::new(0, 4, 33));
+        assert_eq!(ident.to_string(), "@tatolab/camera/VideoFrame@0.4.33");
+    }
+
+    #[test]
     fn test_load_with_path_dependency() {
         let dir = TempDir::new().unwrap();
         let config_path = dir.path().join("streamlib.yaml");

--- a/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
+++ b/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
@@ -268,12 +268,11 @@ pub(crate) fn strip_semver_suffix(name: &str) -> &str {
     name
 }
 
+/// Whether `s` is a canonical `SemVer` string (`X.Y.Z`, optionally with a
+/// `-dev.N` / `-rc.N` prerelease). Delegates to the canonical parser so the
+/// suffix-stripping grammar stays in lock-step with `streamlib_idents::SemVer`.
 fn is_semver(s: &str) -> bool {
-    let parts: Vec<&str> = s.split('.').collect();
-    if parts.len() != 3 {
-        return false;
-    }
-    parts.iter().all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit()))
+    s.parse::<streamlib_idents::SemVer>().is_ok()
 }
 
 #[cfg(test)]
@@ -713,6 +712,22 @@ mod tests {
         assert_eq!(
             strip_semver_suffix("@tatolab/core/VideoFrame"),
             "@tatolab/core/VideoFrame"
+        );
+        // Prerelease-suffixed idents strip cleanly now that `is_semver`
+        // delegates to the canonical parser (#1215). Schema idents are
+        // release-only by invariant, but the stripper stays robust regardless.
+        assert_eq!(
+            strip_semver_suffix("@tatolab/core/VideoFrame@0.4.33-dev.2"),
+            "@tatolab/core/VideoFrame"
+        );
+        assert_eq!(
+            strip_semver_suffix("@tatolab/core/VideoFrame@1.0.0-rc.1"),
+            "@tatolab/core/VideoFrame"
+        );
+        // A non-semver trailing `@segment` is left intact.
+        assert_eq!(
+            strip_semver_suffix("@tatolab/core/VideoFrame@latest"),
+            "@tatolab/core/VideoFrame@latest"
         );
     }
 

--- a/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
+++ b/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
@@ -714,7 +714,7 @@ mod tests {
             "@tatolab/core/VideoFrame"
         );
         // Prerelease-suffixed idents strip cleanly now that `is_semver`
-        // delegates to the canonical parser (#1215). Schema idents are
+        // delegates to the canonical parser. Schema idents are
         // release-only by invariant, but the stripper stays robust regardless.
         assert_eq!(
             strip_semver_suffix("@tatolab/core/VideoFrame@0.4.33-dev.2"),

--- a/libs/streamlib-engine/src/core/runtime/module_loader/processor_registration.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/processor_registration.rs
@@ -121,8 +121,8 @@ pub(super) fn register_manifest_processors(
     for proc_schema in &config.processors {
         // Compose the structured processor ident from the manifest's
         // package metadata + the processor's PascalCase short name.
-        let proc_type_name = streamlib_processor_schema::TypeName::new(&proc_schema.name)
-            .map_err(|e| {
+        let proc_schema_ident =
+            compose_processor_schema_ident(package_metadata, &proc_schema.name).map_err(|e| {
                 Error::Configuration(format!(
                     "processor short name `{}` in {} is not valid PascalCase: {}",
                     proc_schema.name,
@@ -130,12 +130,6 @@ pub(super) fn register_manifest_processors(
                     e
                 ))
             })?;
-        let proc_schema_ident = crate::core::descriptors::SchemaIdent::new(
-            package_metadata.org.clone(),
-            package_metadata.name.clone(),
-            proc_type_name,
-            package_metadata.version.clone(),
-        );
 
         // Map runtime language to ProcessorRuntime
         let runtime = match proc_schema.runtime.language {
@@ -434,4 +428,48 @@ pub(super) fn register_manifest_processors(
     );
 
     Ok(())
+}
+
+/// Compose a processor's structured schema ident from its package's metadata
+/// + PascalCase short name. `SchemaIdent::new` projects a prerelease package
+/// version onto its release core (constructor invariant), so a dev-versioned
+/// package registers release-core processor idents — matching the idents the
+/// Python / Deno decorator side mints for the same processors.
+fn compose_processor_schema_ident(
+    package_metadata: &crate::core::config::PackageMetadata,
+    short_name: &str,
+) -> std::result::Result<crate::core::descriptors::SchemaIdent, streamlib_idents::IdentError> {
+    let type_name = streamlib_processor_schema::TypeName::new(short_name)?;
+    Ok(crate::core::descriptors::SchemaIdent::new(
+        package_metadata.org.clone(),
+        package_metadata.name.clone(),
+        type_name,
+        package_metadata.version,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn processor_ident_from_dev_versioned_package_is_release_core() {
+        // The module-load registration path must register the same identity
+        // the Python / Deno decorators mint — a dev-versioned package's
+        // processor idents carry the release core, or full-ident comparisons
+        // and registry map keys split across the host/subprocess boundary.
+        let meta: crate::core::config::PackageMetadata = serde_yaml::from_str(
+            "org: tatolab\nname: camera\nversion: 0.4.33-dev.2\n",
+        )
+        .unwrap();
+        let ident = compose_processor_schema_ident(&meta, "Camera").unwrap();
+        assert_eq!(
+            ident.version,
+            streamlib_idents::SemVer::new(0, 4, 33),
+            "prerelease must not survive into the registered processor ident"
+        );
+        assert_eq!(ident.to_string(), "@tatolab/camera/Camera@0.4.33");
+        // Invalid short names still surface as errors.
+        assert!(compose_processor_schema_ident(&meta, "not-pascal").is_err());
+    }
 }

--- a/libs/streamlib-engine/src/core/runtime/module_loader/schema_registration.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/schema_registration.rs
@@ -171,18 +171,13 @@ fn canonical_identifier_for_schema(
     )))
 }
 
-/// Strip a trailing `@MAJOR.MINOR.PATCH` semver suffix. Mirrors
-/// `embedded_schemas::strip_semver_suffix` (kept private here to avoid
-/// introducing a cross-module dep on a tiny string helper).
+/// Strip a trailing `@MAJOR.MINOR.PATCH` semver suffix (optionally with a
+/// `-dev.N` / `-rc.N` prerelease). Mirrors `embedded_schemas::strip_semver_suffix`
+/// by delegating to the canonical `streamlib_idents::SemVer` parser, so the
+/// suffix grammar can't drift between the two strippers.
 fn strip_legacy_semver_suffix(name: &str) -> &str {
     if let Some(at_pos) = name.rfind('@') {
-        let suffix = &name[at_pos + 1..];
-        let parts: Vec<&str> = suffix.split('.').collect();
-        if parts.len() == 3
-            && parts
-                .iter()
-                .all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit()))
-        {
+        if name[at_pos + 1..].parse::<streamlib_idents::SemVer>().is_ok() {
             return &name[..at_pos];
         }
     }

--- a/libs/streamlib-engine/src/core/runtime/module_loader/schema_registration.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/schema_registration.rs
@@ -107,17 +107,22 @@ pub(super) fn resolve_config_schema_canonical_id(
         .get("metadata")
         .ok_or_else(|| format!("schema {} missing `metadata` block", schema_path.display()))?;
 
+    // Release-only projection — this path formats the version into an id
+    // string without constructing a `SchemaIdent`, so the constructor
+    // invariant does not cover it and the explicit `release_core()` is
+    // load-bearing. Mirrors the macro-side config-id composition.
+    let owner_version = owner_pkg.version.release_core();
     if let Some(type_str) = metadata.get("type").and_then(|t| t.as_str()) {
         Ok(format!(
             "@{}/{}/{}@{}",
             owner_pkg.org.as_str(),
             owner_pkg.name.as_str(),
             type_str,
-            owner_pkg.version,
+            owner_version,
         ))
     } else if let Some(name_str) = metadata.get("name").and_then(|n| n.as_str()) {
         // Legacy reverse-DNS form — append the owning package's semver.
-        Ok(format!("{}@{}", name_str, owner_pkg.version))
+        Ok(format!("{}@{}", name_str, owner_version))
     } else {
         Err(format!(
             "schema {} declares neither `metadata.type` nor `metadata.name`",
@@ -182,4 +187,97 @@ fn strip_legacy_semver_suffix(name: &str) -> &str {
         }
     }
     name
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_file(path: &std::path::Path, body: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body).unwrap();
+    }
+
+    /// Build a resolved package fixture whose owning package carries a
+    /// prerelease version, with one schema declaring `metadata.<key>`.
+    fn dev_versioned_fixture(
+        metadata_line: &str,
+    ) -> (tempfile::TempDir, streamlib_idents::ResolvedPackages) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("project");
+        write_file(
+            &root.join("streamlib.yaml"),
+            r#"
+package:
+  org: tatolab
+  name: camera
+  version: 0.4.33-dev.2
+schemas:
+  CameraConfig:
+    file: schemas/camera_config.yaml
+"#,
+        );
+        write_file(
+            &root.join("schemas/camera_config.yaml"),
+            &format!("metadata:\n  {metadata_line}\nproperties: {{}}\n"),
+        );
+        let resolved = streamlib_idents::resolve(&root).unwrap();
+        (tmp, resolved)
+    }
+
+    #[test]
+    fn config_schema_canonical_id_projects_prerelease_owner_to_release_core() {
+        // Runtime mirror of the macro-side config-id composition: a
+        // dev-versioned owner package must yield a release-core id. Mentally
+        // revert the `release_core()` in `resolve_config_schema_canonical_id`
+        // and this fails with `...@0.4.33-dev.2`.
+        let (_tmp, resolved) = dev_versioned_fixture("type: CameraConfig");
+        let config = streamlib_processor_schema::ProcessorConfigSchema {
+            name: "config".to_string(),
+            schema: streamlib_processor_schema::TypeName::new("CameraConfig").unwrap(),
+        };
+        let id = resolve_config_schema_canonical_id(
+            std::path::Path::new("/nonexistent-project"),
+            &config,
+            &Some(resolved),
+        )
+        .unwrap();
+        assert_eq!(id, "@tatolab/camera/CameraConfig@0.4.33");
+    }
+
+    #[test]
+    fn config_schema_canonical_id_legacy_arm_projects_too() {
+        let (_tmp, resolved) = dev_versioned_fixture("name: com.example.camera.config");
+        let config = streamlib_processor_schema::ProcessorConfigSchema {
+            name: "config".to_string(),
+            schema: streamlib_processor_schema::TypeName::new("CameraConfig").unwrap(),
+        };
+        let id = resolve_config_schema_canonical_id(
+            std::path::Path::new("/nonexistent-project"),
+            &config,
+            &Some(resolved),
+        )
+        .unwrap();
+        assert_eq!(id, "com.example.camera.config@0.4.33");
+    }
+
+    #[test]
+    fn strip_legacy_semver_suffix_handles_release_and_prerelease() {
+        assert_eq!(
+            strip_legacy_semver_suffix("com.example.camera.config@1.0.0"),
+            "com.example.camera.config"
+        );
+        assert_eq!(
+            strip_legacy_semver_suffix("com.example.camera.config@0.4.33-dev.2"),
+            "com.example.camera.config"
+        );
+        assert_eq!(
+            strip_legacy_semver_suffix("com.example.camera.config@latest"),
+            "com.example.camera.config@latest"
+        );
+        assert_eq!(
+            strip_legacy_semver_suffix("no-version-marker"),
+            "no-version-marker"
+        );
+    }
 }

--- a/libs/streamlib-idents/src/ident.rs
+++ b/libs/streamlib-idents/src/ident.rs
@@ -313,6 +313,7 @@ pub struct SchemaIdent {
     pub package: Package,
     #[serde(rename = "type")]
     pub r#type: TypeName,
+    #[serde(deserialize_with = "deserialize_release_only_semver")]
     pub version: SemVer,
 }
 
@@ -320,14 +321,35 @@ impl SchemaIdent {
     /// Construct from already-validated structured fields. Callers in
     /// non-codegen positions should use [`Org::new`], [`Package::new`],
     /// [`TypeName::new`] to validate the inputs first.
+    ///
+    /// Schema idents are release-only by invariant: `version` is projected
+    /// onto its release core (`-dev.N` / `-rc.N` stripped). The flat global
+    /// schema registry is version-lookup-blind and the IPC wire form carries
+    /// only major/minor/patch, so prerelease fidelity here has no meaning —
+    /// packages iterate prereleases; their schema identities do not.
     pub fn new(org: Org, package: Package, r#type: TypeName, version: SemVer) -> Self {
         Self {
             org,
             package,
             r#type,
-            version,
+            version: version.release_core(),
         }
     }
+}
+
+/// Deserialize a [`SchemaIdent`] version, rejecting prereleases. Input text
+/// carrying `-dev.N` / `-rc.N` in a schema-ident position is an upstream bug
+/// (the producing side should have projected via [`SemVer::release_core`]) —
+/// surface it rather than silently projecting.
+fn deserialize_release_only_semver<'de, D: Deserializer<'de>>(d: D) -> Result<SemVer, D::Error> {
+    let version = SemVer::deserialize(d)?;
+    if version.prerelease.is_some() {
+        return Err(serde::de::Error::custom(format!(
+            "schema-ident version `{version}` must be a release `MAJOR.MINOR.PATCH`; \
+             prerelease (`-dev.N` / `-rc.N`) versions are not valid for schema idents"
+        )));
+    }
+    Ok(version)
 }
 
 impl fmt::Display for SchemaIdent {
@@ -419,8 +441,9 @@ impl JsonSchema for ModuleIdent {
         ident_string_schema(
             "Imperative-API module identifier of the form `@org/name@<range>` \
              where `<range>` is a SemVerRange (`*`, `=1.2.3`, `>=1.2.3`, `^1.2.3`, \
-             `~1.2.3`, or bare `1.2.3`).",
-            r"^@[a-z][a-z0-9-]*/[a-z][a-z0-9-]*@(\*|(\^|~|>=|=)?[0-9]+\.[0-9]+\.[0-9]+)$",
+             `~1.2.3`, or bare `1.2.3`; versions may carry an optional `-dev.N` / \
+             `-rc.N` prerelease).",
+            r"^@[a-z][a-z0-9-]*/[a-z][a-z0-9-]*@(\*|(\^|~|>=|=)?[0-9]+\.[0-9]+\.[0-9]+(-(dev|rc)\.[0-9]+)?)$",
         )
     }
 }
@@ -580,6 +603,50 @@ version: 1.0.0
         assert_eq!(id.package.as_str(), "core");
         assert_eq!(id.r#type.as_str(), "VideoFrame");
         assert_eq!(id.version, SemVer::new(1, 0, 0));
+    }
+
+    #[test]
+    fn schema_ident_constructor_projects_prerelease_to_release_core() {
+        // The release-only invariant lives in the constructor — a prerelease
+        // version cannot survive construction.
+        use crate::semver::PrereleaseKind;
+        let id = SchemaIdent::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("camera").unwrap(),
+            TypeName::new("Camera").unwrap(),
+            SemVer::new_prerelease(0, 4, 33, PrereleaseKind::Dev, 2),
+        );
+        assert_eq!(id.version, SemVer::new(0, 4, 33));
+        assert_eq!(id.to_string(), "@tatolab/camera/Camera@0.4.33");
+    }
+
+    #[test]
+    fn schema_ident_deserialize_rejects_prerelease_version() {
+        // Parse paths REJECT (not project) — prerelease text in a schema-ident
+        // position is an upstream bug that must surface.
+        let yaml = "
+org: tatolab
+package: camera
+type: Camera
+version: 0.4.33-dev.2
+";
+        let err = serde_yaml::from_str::<SchemaIdent>(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("release") && msg.contains("dev"),
+            "error must name the release-only rule: {msg}"
+        );
+    }
+
+    #[test]
+    fn module_ident_wire_parses_prerelease_range() {
+        use crate::semver::PrereleaseKind;
+        let wire = "\"@tatolab/camera@>=0.4.33-dev.2\"";
+        let id: ModuleIdent = serde_yaml::from_str(wire).unwrap();
+        assert_eq!(
+            id.version,
+            SemVerRange::AtLeast(SemVer::new_prerelease(0, 4, 33, PrereleaseKind::Dev, 2))
+        );
     }
 
     #[test]

--- a/libs/streamlib-idents/src/lib.rs
+++ b/libs/streamlib-idents/src/lib.rs
@@ -38,4 +38,4 @@ pub use resolver::{
     resolve, resolve_bare_schema_name, resolve_with, ResolvedPackage, ResolvedPackages,
     ResolvedSource, ResolverOptions,
 };
-pub use semver::{SemVer, SemVerRange};
+pub use semver::{Prerelease, PrereleaseKind, SemVer, SemVerRange};

--- a/libs/streamlib-idents/src/lockfile.rs
+++ b/libs/streamlib-idents/src/lockfile.rs
@@ -150,10 +150,16 @@ packages:
       url: https://github.com/tatolab/moq
       rev: abc123def456
     content_hash: "sha256:1111222233334444"
+  "@tatolab/camera":
+    version: 0.4.33-dev.2
+    source:
+      kind: registry
+      url: https://packages.streamlib.dev
+    content_hash: "sha256:5555666677778888"
 "#;
         let lock: Lockfile = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(lock.version, 1);
-        assert_eq!(lock.packages.len(), 3);
+        assert_eq!(lock.packages.len(), 4);
 
         let core = lock.packages.get("@tatolab/core").unwrap();
         assert_eq!(core.version, SemVer::new(1, 0, 0));
@@ -171,9 +177,22 @@ packages:
             other => panic!("expected Git source, got {:?}", other),
         }
 
+        // A prerelease package version survives the lockfile round-trip.
+        use crate::semver::PrereleaseKind;
+        let camera = lock.packages.get("@tatolab/camera").unwrap();
+        assert_eq!(
+            camera.version,
+            SemVer::new_prerelease(0, 4, 33, PrereleaseKind::Dev, 2)
+        );
+
         let s = serde_yaml::to_string(&lock).unwrap();
+        assert!(s.contains("0.4.33-dev.2"), "serialized: {s}");
         let back: Lockfile = serde_yaml::from_str(&s).unwrap();
-        assert_eq!(back.packages.len(), 3);
+        assert_eq!(back.packages.len(), 4);
+        assert_eq!(
+            back.packages.get("@tatolab/camera").unwrap().version,
+            SemVer::new_prerelease(0, 4, 33, PrereleaseKind::Dev, 2)
+        );
     }
 
     #[test]

--- a/libs/streamlib-idents/src/manifest.rs
+++ b/libs/streamlib-idents/src/manifest.rs
@@ -498,6 +498,33 @@ dependencies: {}
     }
 
     #[test]
+    fn package_flavor_round_trips_prerelease_version() {
+        // A package may carry a `-dev.N` / `-rc.N` prerelease version (#1215).
+        let yaml = "
+package:
+  org: tatolab
+  name: camera
+  version: 0.4.33-dev.2
+dependencies:
+  \"@tatolab/core\": \">=1.0.0-rc.1\"
+";
+        let m: Manifest = serde_yaml::from_str(yaml).unwrap();
+        let pkg = m.package.as_ref().unwrap();
+        assert_eq!(
+            pkg.version,
+            SemVer::new_prerelease(0, 4, 33, crate::semver::PrereleaseKind::Dev, 2)
+        );
+        // Serializes back to the canonical dotted-plus-suffix form.
+        let out = serde_yaml::to_string(&m).unwrap();
+        assert!(out.contains("0.4.33-dev.2"), "serialized: {out}");
+        // A prerelease range dep round-trips too.
+        match m.dependencies.get(&pkg_ref("tatolab", "core")).unwrap() {
+            DependencySpec::Registry(r) => assert_eq!(r.version.to_string(), ">=1.0.0-rc.1"),
+            other => panic!("expected Registry, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn project_flavor_with_three_dep_sources() {
         let yaml = r#"
 dependencies:

--- a/libs/streamlib-idents/src/manifest.rs
+++ b/libs/streamlib-idents/src/manifest.rs
@@ -499,7 +499,7 @@ dependencies: {}
 
     #[test]
     fn package_flavor_round_trips_prerelease_version() {
-        // A package may carry a `-dev.N` / `-rc.N` prerelease version (#1215).
+        // A package may carry a `-dev.N` / `-rc.N` prerelease version.
         let yaml = "
 package:
   org: tatolab

--- a/libs/streamlib-idents/src/registry.rs
+++ b/libs/streamlib-idents/src/registry.rs
@@ -728,13 +728,22 @@ mod tests {
     }
 
     /// NDJSON render → parse is a faithful round-trip, name-filtered.
+    /// Includes a prerelease entry — the index is how a published `-dev.N`
+    /// becomes listable, so the round-trip must carry it.
     #[test]
     fn index_ndjson_render_parse_round_trip() {
-        let versions = vec![SemVer::new(0, 4, 32), SemVer::new(0, 4, 33), SemVer::new(1, 0, 0)];
+        use crate::semver::PrereleaseKind;
+        let versions = vec![
+            SemVer::new(0, 4, 32),
+            SemVer::new_prerelease(0, 4, 33, PrereleaseKind::Dev, 2),
+            SemVer::new(0, 4, 33),
+            SemVer::new(1, 0, 0),
+        ];
         let rendered = render_index_ndjson("camera", &versions);
         // One line per version, trailing newline, cargo-sparse `vers` field.
-        assert_eq!(rendered.lines().count(), 3);
+        assert_eq!(rendered.lines().count(), 4);
         assert!(rendered.contains("\"vers\":\"0.4.33\""));
+        assert!(rendered.contains("\"vers\":\"0.4.33-dev.2\""));
         assert!(rendered.ends_with('\n'));
         let parsed = parse_index_ndjson(rendered.as_bytes(), "camera");
         assert_eq!(parsed, versions);

--- a/libs/streamlib-idents/src/registry.rs
+++ b/libs/streamlib-idents/src/registry.rs
@@ -523,6 +523,66 @@ mod tests {
     }
 
     #[test]
+    fn select_version_prefers_release_over_prerelease() {
+        // A release-req range must pick the release even when higher-ordinal
+        // prereleases share or exceed the core. No logic change in
+        // `select_version` — the new Ord + npm range policy carry this.
+        use crate::semver::PrereleaseKind;
+        let pr = pkg_ref("tatolab", "camera");
+        let avail = vec![
+            SemVer::new_prerelease(1, 2, 0, PrereleaseKind::Dev, 9),
+            SemVer::new(1, 2, 0),
+            SemVer::new_prerelease(1, 2, 1, PrereleaseKind::Dev, 1),
+        ];
+        let range = SemVerRange::from_str("^1.2.0").unwrap();
+        assert_eq!(select_version(&pr, &range, &avail).unwrap(), SemVer::new(1, 2, 0));
+    }
+
+    #[test]
+    fn select_version_picks_highest_prerelease_for_prerelease_range() {
+        // A prerelease-req range selects the highest same-core prerelease when
+        // no release is available.
+        use crate::semver::PrereleaseKind;
+        let pr = pkg_ref("tatolab", "camera");
+        let avail = vec![
+            SemVer::new_prerelease(1, 2, 0, PrereleaseKind::Dev, 3),
+            SemVer::new_prerelease(1, 2, 0, PrereleaseKind::Dev, 9),
+            SemVer::new_prerelease(1, 2, 0, PrereleaseKind::Rc, 1),
+        ];
+        let range = SemVerRange::from_str(">=1.2.0-dev.3").unwrap();
+        assert_eq!(
+            select_version(&pr, &range, &avail).unwrap(),
+            SemVer::new_prerelease(1, 2, 0, PrereleaseKind::Rc, 1)
+        );
+    }
+
+    #[test]
+    fn list_versions_file_parses_prerelease_dir_names() {
+        // Directory-name version parsing must accept `-dev.N` / `-rc.N` dirs
+        // so a prerelease publish is listable from the file:// mirror.
+        use crate::semver::PrereleaseKind;
+        let tmp = std::env::temp_dir().join(format!("slpkg-pre-{}", std::process::id()));
+        let pkg_dir = tmp.join("camera");
+        std::fs::create_dir_all(pkg_dir.join("0.4.33-dev.2")).unwrap();
+        std::fs::create_dir_all(pkg_dir.join("0.4.33")).unwrap();
+        let cfg = RegistryConfig {
+            base_url: format!("file://{}", tmp.display()),
+            token: None,
+        };
+        let client = RegistryClient::new(&cfg);
+        let mut versions = client.list_versions(&pkg_ref("tatolab", "camera")).unwrap();
+        versions.sort();
+        assert_eq!(
+            versions,
+            vec![
+                SemVer::new_prerelease(0, 4, 33, PrereleaseKind::Dev, 2),
+                SemVer::new(0, 4, 33),
+            ]
+        );
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
     fn select_version_errors_when_none_match() {
         let pr = pkg_ref("tatolab", "escalate");
         let avail = vec![SemVer::new(2, 0, 0), SemVer::new(3, 1, 0)];

--- a/libs/streamlib-idents/src/semver.rs
+++ b/libs/streamlib-idents/src/semver.rs
@@ -157,10 +157,18 @@ fn parse_prerelease(full: &str, suffix: &str) -> IdentResult<Prerelease> {
             ))
         }
     };
+    // Digits-only, not `u32::from_str` leniency — `+4` would otherwise parse
+    // and round-trip asymmetrically (`1.2.3-dev.+4` would display `1.2.3-dev.4`).
+    if n_str.is_empty() || !n_str.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(IdentError::InvalidSemVer(
+            full.to_string(),
+            format!("prerelease ordinal `{n_str}` is not a non-negative integer"),
+        ));
+    }
     let n = n_str.parse::<u32>().map_err(|_| {
         IdentError::InvalidSemVer(
             full.to_string(),
-            format!("prerelease ordinal `{n_str}` is not a non-negative integer"),
+            format!("prerelease ordinal `{n_str}` is out of range"),
         )
     })?;
     Ok(Prerelease { kind, n })
@@ -243,8 +251,9 @@ impl JsonSchema for SemVer {
 /// additionally admits same-core prereleases at or above it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SemVerRange {
-    /// `*` — matches every version. The imperative module API uses this when
-    /// the caller doesn't pin a version range.
+    /// `*` — matches every release version (prereleases excluded per the npm
+    /// policy above). The imperative module API uses this when the caller
+    /// doesn't pin a version range.
     Any,
     Exact(SemVer),
     AtLeast(SemVer),
@@ -325,8 +334,11 @@ fn caret_matches(req: SemVer, v: SemVer) -> bool {
         // ^0.minor.patch → same minor
         v.major == 0 && v.minor == req.minor
     } else {
-        // ^0.0.patch → exact
-        v == req
+        // ^0.0.patch → exact core. Comparing full versions here would reject
+        // the release for a prerelease req (`^0.0.3-dev.2` must match `0.0.3`
+        // — npm range is `>=0.0.3-dev.2 <0.0.4`); the `v >= req` guard above
+        // already enforces ordering, so core equality is the only bound left.
+        same_core(req, v)
     }
 }
 
@@ -472,7 +484,7 @@ mod tests {
     }
 
     #[test]
-    fn range_any_matches_every_version() {
+    fn range_any_matches_every_release() {
         let r = SemVerRange::from_str("*").unwrap();
         assert_eq!(r, SemVerRange::Any);
         assert!(r.matches(SemVer::new(0, 0, 0)));
@@ -489,7 +501,7 @@ mod tests {
         assert_eq!(r, back);
     }
 
-    // ---- prerelease support (#1215) ----
+    // ---- prerelease support ----
 
     #[test]
     fn prerelease_parse_display_round_trip() {
@@ -514,6 +526,8 @@ mod tests {
             "1.2.3-alpha.1", // unknown channel
             "1.2.3-dev",     // missing ordinal
             "1.2.3-dev.x",   // non-numeric ordinal
+            "1.2.3-dev.+4",  // sign prefix — u32::from_str leniency must not leak in
+            "1.2.3-dev.",    // empty ordinal
             "1.2.3+build",   // build metadata unsupported
             "1.2.3-dev.1.2", // ordinal must be a single integer
             "1.2.3-rc",      // missing ordinal
@@ -600,6 +614,47 @@ mod tests {
         assert!(r.matches(SemVer::new(0, 4, 33)));
         assert!(!r.matches(SemVer::new_prerelease(0, 5, 0, PrereleaseKind::Dev, 1)));
         assert!(!r.matches(SemVer::new_prerelease(0, 4, 33, PrereleaseKind::Dev, 1)));
+    }
+
+    #[test]
+    fn range_caret_pre_1_0_patch_prerelease_req() {
+        // `^0.0.3-dev.2` — npm range `>=0.0.3-dev.2 <0.0.4`. The same-core
+        // RELEASE must match (mentally revert the `same_core` fix in
+        // `caret_matches`'s ^0.0.patch branch: `v == req` can never hold for
+        // a release vs a prerelease req and this fails).
+        let r = SemVerRange::from_str("^0.0.3-dev.2").unwrap();
+        assert!(r.matches(SemVer::new(0, 0, 3)));
+        assert!(r.matches(SemVer::new_prerelease(0, 0, 3, PrereleaseKind::Dev, 5)));
+        assert!(!r.matches(SemVer::new(0, 0, 4)));
+        assert!(!r.matches(SemVer::new_prerelease(0, 0, 3, PrereleaseKind::Dev, 1)));
+        // Release preference is not inverted: mixed candidates pick the release.
+        let avail = [
+            SemVer::new_prerelease(0, 0, 3, PrereleaseKind::Dev, 5),
+            SemVer::new(0, 0, 3),
+        ];
+        let best = avail.iter().filter(|v| r.matches(**v)).max().copied();
+        assert_eq!(best, Some(SemVer::new(0, 0, 3)));
+        // The ^0.minor.patch branch is unaffected.
+        let minor = SemVerRange::from_str("^0.2.3-dev.1").unwrap();
+        assert!(minor.matches(SemVer::new(0, 2, 4)));
+        assert!(!minor.matches(SemVer::new(0, 3, 0)));
+    }
+
+    #[test]
+    fn range_tilde_prerelease_policy() {
+        // Release tilde req excludes all prereleases.
+        let release_req = SemVerRange::from_str("~1.2.3").unwrap();
+        assert!(!release_req.matches(SemVer::new_prerelease(1, 2, 4, PrereleaseKind::Dev, 1)));
+        // Prerelease tilde req admits same-core prereleases >= req and the
+        // release line per the core rule; foreign-core prereleases excluded.
+        let r = SemVerRange::from_str("~1.2.3-rc.4").unwrap();
+        assert!(r.matches(SemVer::new_prerelease(1, 2, 3, PrereleaseKind::Rc, 4)));
+        assert!(r.matches(SemVer::new_prerelease(1, 2, 3, PrereleaseKind::Rc, 9)));
+        assert!(r.matches(SemVer::new(1, 2, 3)));
+        assert!(r.matches(SemVer::new(1, 2, 9)));
+        assert!(!r.matches(SemVer::new_prerelease(1, 2, 3, PrereleaseKind::Rc, 3))); // below req
+        assert!(!r.matches(SemVer::new_prerelease(1, 2, 4, PrereleaseKind::Dev, 1))); // other core
+        assert!(!r.matches(SemVer::new(1, 3, 0))); // outside minor
     }
 
     #[test]

--- a/libs/streamlib-idents/src/semver.rs
+++ b/libs/streamlib-idents/src/semver.rs
@@ -11,32 +11,97 @@ use std::fmt;
 
 use crate::error::{IdentError, IdentResult};
 
-/// Three-part semantic version. Pre-release / build metadata not supported in
-/// v1 — re-introduce when a real consumer needs them.
+/// Prerelease channel of a [`SemVer`]. Ordered `Dev` < `Rc`, matching the
+/// SemVer 2.0 ASCII ordering of the `dev` / `rc` identifiers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum PrereleaseKind {
+    Dev,
+    Rc,
+}
+
+impl PrereleaseKind {
+    /// The identifier as it appears in the version string (`dev` / `rc`).
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Dev => "dev",
+            Self::Rc => "rc",
+        }
+    }
+}
+
+/// Prerelease component of a [`SemVer`] — a channel plus an ordinal, e.g.
+/// `-dev.4` or `-rc.1`. Ordered by `(kind, n)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Prerelease {
+    pub kind: PrereleaseKind,
+    pub n: u32,
+}
+
+/// Three-part semantic version with an optional `-dev.N` / `-rc.N` prerelease.
+/// The prerelease grammar is deliberately closed: only `dev` and `rc` channels
+/// are accepted, and `+build` metadata is rejected.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SemVer {
     pub major: u32,
     pub minor: u32,
     pub patch: u32,
+    pub prerelease: Option<Prerelease>,
 }
 
 impl SemVer {
+    /// A release version (no prerelease).
     pub const fn new(major: u32, minor: u32, patch: u32) -> Self {
         Self {
             major,
             minor,
             patch,
+            prerelease: None,
+        }
+    }
+
+    /// A prerelease version (`X.Y.Z-<kind>.N`).
+    pub const fn new_prerelease(
+        major: u32,
+        minor: u32,
+        patch: u32,
+        kind: PrereleaseKind,
+        n: u32,
+    ) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+            prerelease: Some(Prerelease { kind, n }),
+        }
+    }
+
+    /// This version with any prerelease stripped — the release core `X.Y.Z`.
+    /// Used to project a package's (possibly prerelease) version onto the
+    /// schema-ident axis, which is release-only by invariant.
+    pub const fn release_core(self) -> Self {
+        Self {
+            major: self.major,
+            minor: self.minor,
+            patch: self.patch,
+            prerelease: None,
         }
     }
 
     /// Internal string conversion. Public on the crate boundary so YAML/JSON
     /// deserialization (the typed-deserialization pathway) can construct a
-    /// `SemVer` from `"1.2.3"`. Not a workaround of the `SchemaIdent`
-    /// "no parse API" rule — `SchemaIdent` glues multiple structured fields
-    /// with punctuation; `SemVer` has a single canonical string form
-    /// universally agreed across cargo / npm / pip.
+    /// `SemVer` from `"1.2.3"` / `"1.2.3-dev.4"`. Not a workaround of the
+    /// `SchemaIdent` "no parse API" rule — `SchemaIdent` glues multiple
+    /// structured fields with punctuation; `SemVer` has a single canonical
+    /// string form universally agreed across cargo / npm / pip.
     pub(crate) fn from_dotted(s: &str) -> IdentResult<Self> {
-        let mut parts = s.split('.');
+        // Split the `MAJOR.MINOR.PATCH` core from an optional `-<prerelease>`
+        // on the first `-`. A `+build` suffix has no `-`, so it stays in the
+        // core and fails the integer parse below — rejecting build metadata.
+        let (core, prerelease) = match s.split_once('-') {
+            Some((core, suffix)) => (core, Some(parse_prerelease(s, suffix)?)),
+            None => (s, None),
+        };
+        let mut parts = core.split('.');
         let major = parse_part(s, parts.next())?;
         let minor = parse_part(s, parts.next())?;
         let patch = parse_part(s, parts.next())?;
@@ -50,7 +115,16 @@ impl SemVer {
             major,
             minor,
             patch,
+            prerelease,
         })
+    }
+}
+
+impl std::str::FromStr for SemVer {
+    type Err = IdentError;
+
+    fn from_str(s: &str) -> IdentResult<Self> {
+        Self::from_dotted(s)
     }
 }
 
@@ -65,9 +139,40 @@ fn parse_part(full: &str, part: Option<&str>) -> IdentResult<u32> {
         .map_err(|e| IdentError::InvalidSemVer(full.to_string(), e.to_string()))
 }
 
+/// Parse a `-` suffix into a [`Prerelease`]. Only `dev.N` / `rc.N` are valid.
+fn parse_prerelease(full: &str, suffix: &str) -> IdentResult<Prerelease> {
+    let (kind_str, n_str) = suffix.split_once('.').ok_or_else(|| {
+        IdentError::InvalidSemVer(
+            full.to_string(),
+            "prerelease must be `-dev.N` or `-rc.N` (e.g. `1.2.3-dev.4`)".into(),
+        )
+    })?;
+    let kind = match kind_str {
+        "dev" => PrereleaseKind::Dev,
+        "rc" => PrereleaseKind::Rc,
+        other => {
+            return Err(IdentError::InvalidSemVer(
+                full.to_string(),
+                format!("unknown prerelease channel `{other}` (only `dev` and `rc` are valid)"),
+            ))
+        }
+    };
+    let n = n_str.parse::<u32>().map_err(|_| {
+        IdentError::InvalidSemVer(
+            full.to_string(),
+            format!("prerelease ordinal `{n_str}` is not a non-negative integer"),
+        )
+    })?;
+    Ok(Prerelease { kind, n })
+}
+
 impl fmt::Display for SemVer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)?;
+        if let Some(pre) = self.prerelease {
+            write!(f, "-{}.{}", pre.kind.as_str(), pre.n)?;
+        }
+        Ok(())
     }
 }
 
@@ -79,7 +184,16 @@ impl PartialOrd for SemVer {
 
 impl Ord for SemVer {
     fn cmp(&self, other: &Self) -> Ordering {
-        (self.major, self.minor, self.patch).cmp(&(other.major, other.minor, other.patch))
+        // Cores compare numerically; on equal cores a release (None) outranks
+        // any prerelease (Some), and two prereleases compare by `(kind, n)`.
+        (self.major, self.minor, self.patch)
+            .cmp(&(other.major, other.minor, other.patch))
+            .then_with(|| match (self.prerelease, other.prerelease) {
+                (None, None) => Ordering::Equal,
+                (None, Some(_)) => Ordering::Greater,
+                (Some(_), None) => Ordering::Less,
+                (Some(a), Some(b)) => a.cmp(&b),
+            })
     }
 }
 
@@ -105,8 +219,8 @@ impl JsonSchema for SemVer {
     }
     fn json_schema(_: &mut SchemaGenerator) -> Schema {
         semver_string_schema(
-            "Three-part semantic version `MAJOR.MINOR.PATCH` (no pre-release / build metadata).",
-            r"^[0-9]+\.[0-9]+\.[0-9]+$",
+            "Three-part semantic version `MAJOR.MINOR.PATCH` with an optional `-dev.N` / `-rc.N` prerelease (no `+build` metadata).",
+            r"^[0-9]+\.[0-9]+\.[0-9]+(-(dev|rc)\.[0-9]+)?$",
         )
     }
 }
@@ -122,6 +236,11 @@ impl JsonSchema for SemVer {
 ///
 /// Pre-1.0 caret (`^0.x.y`) follows npm: `^0.2.3` matches `>=0.2.3 <0.3.0`,
 /// and `^0.0.3` matches exactly `0.0.3`.
+///
+/// Prerelease policy (npm semantics): a prerelease candidate is selected only
+/// when the range is written against a prerelease. `*` and release-req ranges
+/// match releases only; a prerelease req (`>=1.2.0-dev.3`, `^0.4.33-dev.2`)
+/// additionally admits same-core prereleases at or above it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SemVerRange {
     /// `*` — matches every version. The imperative module API uses this when
@@ -161,12 +280,38 @@ impl SemVerRange {
 
     pub fn matches(&self, v: SemVer) -> bool {
         match *self {
-            Self::Any => true,
+            // npm prerelease policy: a prerelease is only ever selected when
+            // the range explicitly asks for one. `Any` and release-req ranges
+            // match releases only; a prerelease req additionally admits
+            // same-core prereleases at or above it.
+            Self::Any => v.prerelease.is_none(),
             Self::Exact(req) => v == req,
-            Self::AtLeast(req) => v >= req,
-            Self::Caret(req) => caret_matches(req, v),
-            Self::Tilde(req) => v >= req && v.major == req.major && v.minor == req.minor,
+            Self::AtLeast(req) => prerelease_gated(req, v, |req, v| v >= req),
+            Self::Caret(req) => prerelease_gated(req, v, caret_matches),
+            Self::Tilde(req) => prerelease_gated(req, v, |req, v| {
+                v >= req && v.major == req.major && v.minor == req.minor
+            }),
         }
+    }
+}
+
+/// Same `(major, minor, patch)` core, ignoring prerelease.
+fn same_core(a: SemVer, b: SemVer) -> bool {
+    a.major == b.major && a.minor == b.minor && a.patch == b.patch
+}
+
+/// Apply the npm-style prerelease policy on top of an operator's release-core
+/// rule. `core_rule` decides membership per the operator's existing semantics.
+///
+/// - Release req: releases per `core_rule`; all prereleases excluded.
+/// - Prerelease req, release candidate: `core_rule` (a release outranks the
+///   prerelease req at equal core, and higher cores pass too).
+/// - Prerelease req, prerelease candidate: only same-core and `>= req`.
+fn prerelease_gated(req: SemVer, v: SemVer, core_rule: impl Fn(SemVer, SemVer) -> bool) -> bool {
+    match (req.prerelease, v.prerelease) {
+        (None, _) => v.prerelease.is_none() && core_rule(req, v),
+        (Some(_), None) => core_rule(req, v),
+        (Some(_), Some(_)) => same_core(req, v) && v >= req,
     }
 }
 
@@ -219,8 +364,8 @@ impl JsonSchema for SemVerRange {
     }
     fn json_schema(_: &mut SchemaGenerator) -> Schema {
         semver_string_schema(
-            "SemVer range matcher: `*` (any), `=1.2.3` exact, `>=1.2.3` lower bound, `^1.2.3` caret (npm), `~1.2.3` tilde, or bare `1.2.3` (exact).",
-            r"^(\*|(\^|~|>=|=)?[0-9]+\.[0-9]+\.[0-9]+)$",
+            "SemVer range matcher: `*` (any), `=1.2.3` exact, `>=1.2.3` lower bound, `^1.2.3` caret (npm), `~1.2.3` tilde, or bare `1.2.3` (exact). Versions may carry an optional `-dev.N` / `-rc.N` prerelease.",
+            r"^(\*|(\^|~|>=|=)?[0-9]+\.[0-9]+\.[0-9]+(-(dev|rc)\.[0-9]+)?)$",
         )
     }
 }
@@ -341,6 +486,153 @@ mod tests {
         let r = SemVerRange::Any;
         let s = serde_yaml::to_string(&r).unwrap();
         let back: SemVerRange = serde_yaml::from_str(&s).unwrap();
+        assert_eq!(r, back);
+    }
+
+    // ---- prerelease support (#1215) ----
+
+    #[test]
+    fn prerelease_parse_display_round_trip() {
+        for (s, expected) in [
+            ("1.2.3-dev.4", SemVer::new_prerelease(1, 2, 3, PrereleaseKind::Dev, 4)),
+            ("0.4.33-rc.1", SemVer::new_prerelease(0, 4, 33, PrereleaseKind::Rc, 1)),
+            ("1.2.3", SemVer::new(1, 2, 3)),
+            ("1.1.3-dev.0", SemVer::new_prerelease(1, 1, 3, PrereleaseKind::Dev, 0)),
+        ] {
+            let parsed = SemVer::from_dotted(s).unwrap();
+            assert_eq!(parsed, expected, "parse `{s}`");
+            assert_eq!(parsed.to_string(), s, "display round-trip `{s}`");
+            // FromStr is the public canonical parse and must agree.
+            assert_eq!(s.parse::<SemVer>().unwrap(), expected, "FromStr `{s}`");
+        }
+    }
+
+    #[test]
+    fn prerelease_grammar_is_closed() {
+        // Only `dev` / `rc`, exactly one dotted ordinal, no `+build`.
+        for bad in [
+            "1.2.3-alpha.1", // unknown channel
+            "1.2.3-dev",     // missing ordinal
+            "1.2.3-dev.x",   // non-numeric ordinal
+            "1.2.3+build",   // build metadata unsupported
+            "1.2.3-dev.1.2", // ordinal must be a single integer
+            "1.2.3-rc",      // missing ordinal
+            "1.2.3-",        // empty suffix
+        ] {
+            assert!(
+                SemVer::from_dotted(bad).is_err(),
+                "`{bad}` must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn release_core_strips_prerelease() {
+        let v = SemVer::new_prerelease(1, 2, 3, PrereleaseKind::Rc, 5);
+        assert_eq!(v.release_core(), SemVer::new(1, 2, 3));
+        // Idempotent on a release.
+        assert_eq!(SemVer::new(1, 2, 3).release_core(), SemVer::new(1, 2, 3));
+    }
+
+    #[test]
+    fn prerelease_ordering_matrix() {
+        // The load-bearing ordering: dev < rc, ordinal ascending, and a
+        // release outranks every prerelease of the same core. Mentally revert
+        // the hand-written Ord's None/Some arms and this fails.
+        let dev2 = SemVer::new_prerelease(1, 1, 3, PrereleaseKind::Dev, 2);
+        let dev10 = SemVer::new_prerelease(1, 1, 3, PrereleaseKind::Dev, 10);
+        let rc1 = SemVer::new_prerelease(1, 1, 3, PrereleaseKind::Rc, 1);
+        let release = SemVer::new(1, 1, 3);
+        assert!(dev2 < dev10, "dev.2 < dev.10");
+        assert!(dev10 < rc1, "dev.10 < rc.1");
+        assert!(rc1 < release, "rc.1 < release");
+        // Full chain.
+        assert!(dev2 < dev10 && dev10 < rc1 && rc1 < release);
+        // A prerelease of a lower core is below a prerelease of a higher core.
+        let rc9 = SemVer::new_prerelease(1, 1, 3, PrereleaseKind::Rc, 9);
+        let next_dev1 = SemVer::new_prerelease(1, 1, 4, PrereleaseKind::Dev, 1);
+        assert!(rc9 < next_dev1, "1.1.3-rc.9 < 1.1.4-dev.1");
+        // Sorting yields the spec order.
+        let mut all = vec![release, rc1, dev10, dev2];
+        all.sort();
+        assert_eq!(all, vec![dev2, dev10, rc1, release]);
+    }
+
+    #[test]
+    fn range_any_excludes_prereleases() {
+        let r = SemVerRange::from_str("*").unwrap();
+        assert!(r.matches(SemVer::new(1, 2, 3)));
+        assert!(!r.matches(SemVer::new_prerelease(1, 2, 3, PrereleaseKind::Dev, 1)));
+    }
+
+    #[test]
+    fn range_release_req_excludes_all_prereleases() {
+        // `^1.2.0` must not select `1.2.5-dev.1` (release req, npm policy).
+        let caret = SemVerRange::from_str("^1.2.0").unwrap();
+        assert!(caret.matches(SemVer::new(1, 2, 5)));
+        assert!(!caret.matches(SemVer::new_prerelease(1, 2, 5, PrereleaseKind::Dev, 1)));
+        // `>=1.2.0` likewise excludes prereleases of higher cores.
+        let at_least = SemVerRange::from_str(">=1.2.0").unwrap();
+        assert!(at_least.matches(SemVer::new(1, 3, 0)));
+        assert!(!at_least.matches(SemVer::new_prerelease(1, 3, 0, PrereleaseKind::Rc, 1)));
+    }
+
+    #[test]
+    fn range_prerelease_req_admits_same_core_prereleases() {
+        // `>=1.2.0-dev.3`: same-core prereleases >= req, and releases per the
+        // core rule; prereleases of a different core are excluded.
+        let r = SemVerRange::from_str(">=1.2.0-dev.3").unwrap();
+        assert!(r.matches(SemVer::new_prerelease(1, 2, 0, PrereleaseKind::Dev, 5)));
+        assert!(r.matches(SemVer::new(1, 2, 0)));
+        assert!(r.matches(SemVer::new(1, 2, 1)));
+        assert!(!r.matches(SemVer::new_prerelease(1, 2, 0, PrereleaseKind::Dev, 1))); // below req
+        assert!(!r.matches(SemVer::new_prerelease(1, 3, 0, PrereleaseKind::Dev, 1))); // other core
+        assert!(!r.matches(SemVer::new(1, 1, 9))); // below core
+    }
+
+    #[test]
+    fn range_caret_prerelease_req() {
+        // `^0.4.33-dev.2`: pre-1.0 caret pins the minor; same-core dev/rc >=
+        // req match, release 0.4.33 matches, 0.5.0 does not.
+        let r = SemVerRange::from_str("^0.4.33-dev.2").unwrap();
+        assert!(r.matches(SemVer::new_prerelease(0, 4, 33, PrereleaseKind::Dev, 2)));
+        assert!(r.matches(SemVer::new_prerelease(0, 4, 33, PrereleaseKind::Rc, 1)));
+        assert!(r.matches(SemVer::new(0, 4, 33)));
+        assert!(!r.matches(SemVer::new_prerelease(0, 5, 0, PrereleaseKind::Dev, 1)));
+        assert!(!r.matches(SemVer::new_prerelease(0, 4, 33, PrereleaseKind::Dev, 1)));
+    }
+
+    #[test]
+    fn range_exact_prerelease_matches_only_itself() {
+        let r = SemVerRange::from_str("1.2.3-rc.1").unwrap();
+        assert_eq!(
+            r,
+            SemVerRange::Exact(SemVer::new_prerelease(1, 2, 3, PrereleaseKind::Rc, 1))
+        );
+        assert!(r.matches(SemVer::new_prerelease(1, 2, 3, PrereleaseKind::Rc, 1)));
+        assert!(!r.matches(SemVer::new(1, 2, 3)));
+        assert!(!r.matches(SemVer::new_prerelease(1, 2, 3, PrereleaseKind::Rc, 2)));
+        assert!(!r.matches(SemVer::new_prerelease(1, 2, 3, PrereleaseKind::Dev, 1)));
+    }
+
+    #[test]
+    fn range_operator_prefixes_parse_with_prerelease() {
+        assert_eq!(
+            SemVerRange::from_str(">=1.2.0-dev.3").unwrap(),
+            SemVerRange::AtLeast(SemVer::new_prerelease(1, 2, 0, PrereleaseKind::Dev, 3))
+        );
+        assert_eq!(
+            SemVerRange::from_str("^0.4.33-dev.2").unwrap(),
+            SemVerRange::Caret(SemVer::new_prerelease(0, 4, 33, PrereleaseKind::Dev, 2))
+        );
+        assert_eq!(
+            SemVerRange::from_str("~1.2.3-rc.4").unwrap(),
+            SemVerRange::Tilde(SemVer::new_prerelease(1, 2, 3, PrereleaseKind::Rc, 4))
+        );
+        // Round-trips through Display + YAML.
+        let r = SemVerRange::from_str(">=1.2.0-dev.3").unwrap();
+        assert_eq!(r.to_string(), ">=1.2.0-dev.3");
+        let back: SemVerRange = serde_yaml::from_str(&serde_yaml::to_string(&r).unwrap()).unwrap();
         assert_eq!(r, back);
     }
 }

--- a/libs/streamlib-jtd-codegen/src/lib.rs
+++ b/libs/streamlib-jtd-codegen/src/lib.rs
@@ -613,19 +613,9 @@ fn run_jtd_codegen_python(tasks: &[SchemaTask], output_dir: &Path) -> Result<()>
         // authors who reference them construct `SchemaIdent` directly until
         // #702 migrates them off reverse-DNS.
         let schema_ident_emit: Option<SchemaIdentEmit> = if identity.package_subdir.is_some() {
-            task.package.as_ref().map(|p| SchemaIdentEmit {
-                org: p.org.clone(),
-                package: p.name.clone(),
-                type_name: identity.struct_name.clone(),
-                // Schema idents are release-only by invariant (#1215): project
-                // the package's (possibly `-dev.N` / `-rc.N`) version onto its
-                // release core so the emitted Python SchemaIdent literal
-                // validates against the 3-part version regex the SDK enforces.
-                // (The TypeScript codegen emits no version literal — a Deno
-                // package's ident is minted by its `@processor` decorator,
-                // which applies the same projection.)
-                version: p.version.release_core().to_string(),
-            })
+            task.package
+                .as_ref()
+                .map(|p| SchemaIdentEmit::from_package_context(p, &identity.struct_name))
         } else {
             None
         };
@@ -1124,6 +1114,25 @@ struct SchemaIdentEmit {
     version: String,
 }
 
+impl SchemaIdentEmit {
+    /// Build the emit record from the enclosing package context. The version
+    /// text is projected onto its release core — this writes version TEXT into
+    /// generated Python sources without constructing a Rust `SchemaIdent`, so
+    /// the constructor's release-only invariant does not cover it and the
+    /// explicit `release_core()` here is load-bearing (the emitted literal must
+    /// validate against the Python SDK's 3-part version regex). The TypeScript
+    /// codegen emits no version literal — a Deno package's ident is minted by
+    /// its `@processor` decorator, which applies the same projection.
+    fn from_package_context(p: &PackageContext, struct_name: &str) -> Self {
+        Self {
+            org: p.org.clone(),
+            package: p.name.clone(),
+            type_name: struct_name.to_string(),
+            version: p.version.release_core().to_string(),
+        }
+    }
+}
+
 /// Post-process jtd-codegen Python output.
 ///
 /// Always strips the `ROOT_NAME_SENTINEL` placeholder and prepends the
@@ -1610,6 +1619,30 @@ fn pascal_to_snake(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn schema_ident_emit_projects_prerelease_to_release_core() {
+        // The emit writes version TEXT into generated sources without a Rust
+        // `SchemaIdent`, so the constructor invariant doesn't cover it —
+        // mentally revert the `release_core()` in `from_package_context` and
+        // this fails (and the emitted Python literal would be rejected by the
+        // SDK's 3-part version regex).
+        use streamlib_idents::{PrereleaseKind, SemVer};
+        let ctx = PackageContext {
+            org: "tatolab".to_string(),
+            name: "camera".to_string(),
+            version: SemVer::new_prerelease(0, 4, 33, PrereleaseKind::Dev, 2),
+        };
+        let emit = SchemaIdentEmit::from_package_context(&ctx, "VideoFrame");
+        assert_eq!(emit.version, "0.4.33");
+        // A release version passes through unchanged.
+        let release_ctx = PackageContext {
+            version: SemVer::new(1, 2, 3),
+            ..ctx
+        };
+        let emit = SchemaIdentEmit::from_package_context(&release_ctx, "VideoFrame");
+        assert_eq!(emit.version, "1.2.3");
+    }
 
     #[test]
     fn post_process_python_substitutes_root_sentinel() {

--- a/libs/streamlib-jtd-codegen/src/lib.rs
+++ b/libs/streamlib-jtd-codegen/src/lib.rs
@@ -617,7 +617,11 @@ fn run_jtd_codegen_python(tasks: &[SchemaTask], output_dir: &Path) -> Result<()>
                 org: p.org.clone(),
                 package: p.name.clone(),
                 type_name: identity.struct_name.clone(),
-                version: p.version.to_string(),
+                // Schema idents are release-only by invariant (#1215): project
+                // the package's (possibly `-dev.N` / `-rc.N`) version onto its
+                // release core so the emitted Python/Deno SchemaIdent literal
+                // validates against the 3-part version regex those SDKs enforce.
+                version: p.version.release_core().to_string(),
             })
         } else {
             None

--- a/libs/streamlib-jtd-codegen/src/lib.rs
+++ b/libs/streamlib-jtd-codegen/src/lib.rs
@@ -619,8 +619,11 @@ fn run_jtd_codegen_python(tasks: &[SchemaTask], output_dir: &Path) -> Result<()>
                 type_name: identity.struct_name.clone(),
                 // Schema idents are release-only by invariant (#1215): project
                 // the package's (possibly `-dev.N` / `-rc.N`) version onto its
-                // release core so the emitted Python/Deno SchemaIdent literal
-                // validates against the 3-part version regex those SDKs enforce.
+                // release core so the emitted Python SchemaIdent literal
+                // validates against the 3-part version regex the SDK enforces.
+                // (The TypeScript codegen emits no version literal — a Deno
+                // package's ident is minted by its `@processor` decorator,
+                // which applies the same projection.)
                 version: p.version.release_core().to_string(),
             })
         } else {

--- a/libs/streamlib-jtd-codegen/src/sentinel.rs
+++ b/libs/streamlib-jtd-codegen/src/sentinel.rs
@@ -142,11 +142,23 @@ fn parse_schema_ident_from_value(value: &Value, alias: &str) -> anyhow::Result<S
         )
     })?;
 
+    let version = SemVer::deserialize_from_str(&raw.version)?;
+    // Schema idents are release-only by invariant. User-authored import text
+    // carrying a prerelease is malformed input — reject it here rather than
+    // letting `SchemaIdent::new` silently project it (the author referenced a
+    // schema identity that cannot exist).
+    if version.prerelease.is_some() {
+        anyhow::bail!(
+            "imports[{alias}] version `{version}` must be a release `MAJOR.MINOR.PATCH`; \
+             prerelease (`-dev.N` / `-rc.N`) versions are not valid for schema idents"
+        );
+    }
+
     Ok(SchemaIdent::new(
         Org::new(raw.org)?,
         Package::new(raw.package)?,
         TypeName::new(raw.r#type)?,
-        SemVer::deserialize_from_str(&raw.version)?,
+        version,
     ))
 }
 
@@ -686,6 +698,35 @@ mod tests {
         assert_ne!(sentinel_name(&a), sentinel_name(&b));
         assert_ne!(sentinel_name(&a), sentinel_name(&c));
         assert_ne!(sentinel_name(&a), sentinel_name(&d));
+    }
+
+    #[test]
+    fn substitute_rejects_prerelease_import_version() {
+        // Schema-import versions are a parse path for schema idents:
+        // prerelease text must be rejected as malformed, not projected.
+        let yaml = r#"
+imports:
+  EncodedVideoFrame:
+    org: tatolab
+    package: core
+    type: EncodedVideoFrame
+    version: "1.0.0-dev.2"
+
+metadata:
+  name: JtdCodegenFixtureA
+
+properties:
+  source:
+    ref: EncodedVideoFrame
+"#;
+        let mut value: Value = yaml_from_str(yaml).unwrap();
+        let mut table = SentinelTable::default();
+        let err = substitute(&mut value, &mut table).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("release") && msg.contains("dev"),
+            "error must name the release-only rule: {msg}"
+        );
     }
 
     #[test]

--- a/libs/streamlib-macros/src/lib.rs
+++ b/libs/streamlib-macros/src/lib.rs
@@ -238,11 +238,17 @@ fn load_processor_schema(
         )
     })?;
 
+    // Schema idents are release-only by invariant (#1215): a package may carry
+    // a `-dev.N` / `-rc.N` version, but its schema idents project onto the
+    // release core. The flat global schema registry is version-lookup-blind
+    // (see `strip_semver_suffix`), so prerelease fidelity on the wire carries
+    // no compat meaning; prerelease iteration of schemas happens locally via
+    // link mode, not via published idents.
     let ident = SchemaIdent::new(
         pkg.org.clone(),
         pkg.name.clone(),
         type_name,
-        pkg.version,
+        pkg.version.release_core(),
     );
 
     // Resolve bare-name port + config schema references against the
@@ -353,11 +359,12 @@ fn resolve_named_to_ident(
     // that only declare `metadata.name`.
     let type_segment = read_schema_metadata_type(&schema_path).unwrap_or_else(|| name.clone());
 
+    // Release-only projection (#1215) — see the note in `expand_processor`.
     Ok(SchemaIdent::new(
         owner_pkg.org.clone(),
         owner_pkg.name.clone(),
         type_segment,
-        owner_pkg.version,
+        owner_pkg.version.release_core(),
     ))
 }
 
@@ -385,19 +392,22 @@ fn resolve_config_schema_to_canonical_id(
         .as_ref()
         .ok_or_else(|| "owning package has no `package:` block".to_string())?;
 
+    // Release-only projection (#1215) — schema-ident versions carry the
+    // package's release core, never its `-dev.N` / `-rc.N` prerelease.
+    let owner_version = owner_pkg.version.release_core();
     if let Some(type_segment) = read_schema_metadata_type(&schema_path) {
         Ok(format!(
             "@{}/{}/{}@{}",
             owner_pkg.org.as_str(),
             owner_pkg.name.as_str(),
             type_segment.as_str(),
-            owner_pkg.version,
+            owner_version,
         ))
     } else if let Some(legacy_name) = read_schema_metadata_name(&schema_path) {
         // Legacy reverse-DNS — the metadata.name carries the canonical
         // unversioned id; append the owning package's semver to match
         // the long-form `<dotted>.config@<version>` codegen helper expects.
-        Ok(format!("{}@{}", legacy_name, owner_pkg.version))
+        Ok(format!("{}@{}", legacy_name, owner_version))
     } else {
         Err(format!(
             "schema {} declares neither `metadata.type` nor `metadata.name`",
@@ -868,7 +878,17 @@ fn emit_module_ident(
     })
 }
 
+/// Parse a `schema_ident!` version string. Schema-ident versions are
+/// release-only by invariant (#1215) — a `-dev.N` / `-rc.N` prerelease is
+/// rejected here (the package-dependency axis accepts prereleases via
+/// `SemVerRange::from_str`, not this parser).
 fn parse_semver(s: &str) -> Result<(u32, u32, u32), String> {
+    if s.contains('-') {
+        return Err(format!(
+            "schema-ident version `{s}` must be a release `MAJOR.MINOR.PATCH`; \
+             prerelease (`-dev.N` / `-rc.N`) versions are not valid for schema idents"
+        ));
+    }
     let mut parts = s.split('.');
     let major = parse_part(parts.next())?;
     let minor = parse_part(parts.next())?;

--- a/libs/streamlib-macros/src/lib.rs
+++ b/libs/streamlib-macros/src/lib.rs
@@ -238,17 +238,13 @@ fn load_processor_schema(
         )
     })?;
 
-    // Schema idents are release-only by invariant (#1215): a package may carry
-    // a `-dev.N` / `-rc.N` version, but its schema idents project onto the
-    // release core. The flat global schema registry is version-lookup-blind
-    // (see `strip_semver_suffix`), so prerelease fidelity on the wire carries
-    // no compat meaning; prerelease iteration of schemas happens locally via
-    // link mode, not via published idents.
+    // `SchemaIdent::new` projects a prerelease package version onto its
+    // release core — schema idents are release-only by constructor invariant.
     let ident = SchemaIdent::new(
         pkg.org.clone(),
         pkg.name.clone(),
         type_name,
-        pkg.version.release_core(),
+        pkg.version,
     );
 
     // Resolve bare-name port + config schema references against the
@@ -359,12 +355,12 @@ fn resolve_named_to_ident(
     // that only declare `metadata.name`.
     let type_segment = read_schema_metadata_type(&schema_path).unwrap_or_else(|| name.clone());
 
-    // Release-only projection (#1215) — see the note in `expand_processor`.
+    // `SchemaIdent::new` projects to the release core (constructor invariant).
     Ok(SchemaIdent::new(
         owner_pkg.org.clone(),
         owner_pkg.name.clone(),
         type_segment,
-        owner_pkg.version.release_core(),
+        owner_pkg.version,
     ))
 }
 
@@ -392,8 +388,9 @@ fn resolve_config_schema_to_canonical_id(
         .as_ref()
         .ok_or_else(|| "owning package has no `package:` block".to_string())?;
 
-    // Release-only projection (#1215) — schema-ident versions carry the
-    // package's release core, never its `-dev.N` / `-rc.N` prerelease.
+    // Release-only projection — this path formats the version into a string
+    // without constructing a `SchemaIdent`, so the constructor invariant does
+    // not cover it and the explicit `release_core()` is load-bearing.
     let owner_version = owner_pkg.version.release_core();
     if let Some(type_segment) = read_schema_metadata_type(&schema_path) {
         Ok(format!(
@@ -879,7 +876,7 @@ fn emit_module_ident(
 }
 
 /// Parse a `schema_ident!` version string. Schema-ident versions are
-/// release-only by invariant (#1215) — a `-dev.N` / `-rc.N` prerelease is
+/// release-only by invariant — a `-dev.N` / `-rc.N` prerelease is
 /// rejected here (the package-dependency axis accepts prereleases via
 /// `SemVerRange::from_str`, not this parser).
 fn parse_semver(s: &str) -> Result<(u32, u32, u32), String> {

--- a/libs/streamlib-python/python/streamlib/decorators.py
+++ b/libs/streamlib-python/python/streamlib/decorators.py
@@ -43,8 +43,9 @@ human-facing display.
 from __future__ import annotations
 
 import inspect
+import re
 from pathlib import Path
-from typing import Optional, Type, Union
+from typing import Optional, Pattern, Type, Union
 
 from ._manifest import ManifestParseError, read_manifest_summary
 from .schema_ident import SchemaIdent
@@ -152,14 +153,30 @@ def processor(short_name: str):
     return decorator
 
 
+# Package-version grammar: 3-part core + optional closed `-dev.N` / `-rc.N`
+# prerelease. Mirrors Rust's `SemVer::from_dotted` so all three runtimes
+# accept and reject the same manifests.
+_PACKAGE_VERSION_PATTERN: Pattern[str] = re.compile(
+    r"^(\d+\.\d+\.\d+)(?:-(?:dev|rc)\.\d+)?$"
+)
+
+
 def _release_core(version: str) -> str:
     """Project a package version onto its release core `MAJOR.MINOR.PATCH`.
 
     Package versions may carry a `-dev.N` / `-rc.N` prerelease, but schema
-    idents are release-only by invariant. Mirrors Rust's
-    `streamlib_idents::SemVer::release_core`.
+    idents are release-only by invariant. Anything outside that closed
+    grammar (`-alpha.1`, `+build`, malformed ordinals) raises — identical
+    posture to Rust's manifest parsing, never a silent projection of an
+    invalid version. Mirrors Rust's `streamlib_idents::SemVer::release_core`.
     """
-    return version.split("-", 1)[0]
+    match = _PACKAGE_VERSION_PATTERN.match(version)
+    if match is None:
+        raise ValueError(
+            f"invalid package version {version!r}: must be MAJOR.MINOR.PATCH "
+            f"with an optional -dev.N / -rc.N prerelease"
+        )
+    return match.group(1)
 
 
 def _locate_sibling_manifest(cls) -> Path:

--- a/libs/streamlib-python/python/streamlib/decorators.py
+++ b/libs/streamlib-python/python/streamlib/decorators.py
@@ -120,11 +120,16 @@ def processor(short_name: str):
                 f"{available}"
             )
 
+        # Schema idents are release-only by invariant: a package may carry a
+        # `-dev.N` / `-rc.N` prerelease version, but its schema idents project
+        # onto the release core (mirrors Rust's `SemVer::release_core`). The
+        # 3-part `SchemaIdent` validator would otherwise reject a legitimately
+        # dev-versioned package's processors.
         ident = SchemaIdent(
             org=summary.package.org,
             package=summary.package.name,
             type_=short_name,
-            version=summary.package.version,
+            version=_release_core(summary.package.version),
         )
         cls.__streamlib_schema_ident__ = ident
 
@@ -145,6 +150,16 @@ def processor(short_name: str):
         return cls
 
     return decorator
+
+
+def _release_core(version: str) -> str:
+    """Project a package version onto its release core `MAJOR.MINOR.PATCH`.
+
+    Package versions may carry a `-dev.N` / `-rc.N` prerelease, but schema
+    idents are release-only by invariant. Mirrors Rust's
+    `streamlib_idents::SemVer::release_core`.
+    """
+    return version.split("-", 1)[0]
 
 
 def _locate_sibling_manifest(cls) -> Path:

--- a/libs/streamlib-python/python/streamlib/tests/test_processor_decorator.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_processor_decorator.py
@@ -126,6 +126,41 @@ class TestProcessorDecorator:
         assert ident.version == "0.1.0"
         assert str(ident) == "@tatolab/cyberpunk-processor/CyberpunkProcessor@0.1.0"
 
+    def test_prerelease_package_version_projects_to_release_core(
+        self, tmp_path: Path
+    ) -> None:
+        # A `-dev.N` / `-rc.N` package version is legal; the schema ident it
+        # mints must project onto the release core (the 3-part SchemaIdent
+        # validator would otherwise reject the dev-versioned package).
+        _write_manifest(
+            tmp_path,
+            """
+            package:
+              org: tatolab
+              name: camera
+              version: 0.4.33-dev.2
+
+            processors:
+              - name: Camera
+                runtime: python
+                execution: reactive
+            """,
+        )
+        module = _import_class_from_dir(
+            tmp_path,
+            "decorator_prerelease_module",
+            """
+            from streamlib import processor
+
+            @processor("Camera")
+            class Camera:
+                pass
+            """,
+        )
+        ident = module.Camera.__streamlib_schema_ident__
+        assert ident.version == "0.4.33"
+        assert str(ident) == "@tatolab/camera/Camera@0.4.33"
+
     def test_missing_manifest_errors_with_expected_path(self, tmp_path: Path) -> None:
         # No streamlib.yaml in tmp_path
         with pytest.raises(FileNotFoundError, match="streamlib.yaml"):

--- a/libs/streamlib-python/python/streamlib/tests/test_processor_decorator.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_processor_decorator.py
@@ -161,6 +161,39 @@ class TestProcessorDecorator:
         assert ident.version == "0.4.33"
         assert str(ident) == "@tatolab/camera/Camera@0.4.33"
 
+    def test_unknown_prerelease_channel_rejected_not_projected(
+        self, tmp_path: Path
+    ) -> None:
+        # Only `-dev.N` / `-rc.N` project; an alpha (or any foreign channel)
+        # must raise — the same manifest is rejected by Rust's parser, and
+        # silently projecting here would let the runtimes disagree.
+        _write_manifest(
+            tmp_path,
+            """
+            package:
+              org: tatolab
+              name: camera
+              version: 0.4.33-alpha.1
+
+            processors:
+              - name: Camera
+                runtime: python
+                execution: reactive
+            """,
+        )
+        with pytest.raises(ValueError, match="invalid package version"):
+            _import_class_from_dir(
+                tmp_path,
+                "decorator_alpha_module",
+                """
+                from streamlib import processor
+
+                @processor("Camera")
+                class Camera:
+                    pass
+                """,
+            )
+
     def test_missing_manifest_errors_with_expected_path(self, tmp_path: Path) -> None:
         # No streamlib.yaml in tmp_path
         with pytest.raises(FileNotFoundError, match="streamlib.yaml"):

--- a/schemas/streamlib.schema.json
+++ b/schemas/streamlib.schema.json
@@ -536,14 +536,14 @@
       ]
     },
     "SemVer": {
-      "description": "Three-part semantic version `MAJOR.MINOR.PATCH` (no pre-release / build metadata).",
+      "description": "Three-part semantic version `MAJOR.MINOR.PATCH` with an optional `-dev.N` / `-rc.N` prerelease (no `+build` metadata).",
       "type": "string",
-      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(-(dev|rc)\\.[0-9]+)?$"
     },
     "SemVerRange": {
-      "description": "SemVer range matcher: `*` (any), `=1.2.3` exact, `>=1.2.3` lower bound, `^1.2.3` caret (npm), `~1.2.3` tilde, or bare `1.2.3` (exact).",
+      "description": "SemVer range matcher: `*` (any), `=1.2.3` exact, `>=1.2.3` lower bound, `^1.2.3` caret (npm), `~1.2.3` tilde, or bare `1.2.3` (exact). Versions may carry an optional `-dev.N` / `-rc.N` prerelease.",
       "type": "string",
-      "pattern": "^(\\*|(\\^|~|>=|=)?[0-9]+\\.[0-9]+\\.[0-9]+)$"
+      "pattern": "^(\\*|(\\^|~|>=|=)?[0-9]+\\.[0-9]+\\.[0-9]+(-(dev|rc)\\.[0-9]+)?)$"
     },
     "ThreadPriority": {
       "description": "Thread scheduling priority.\n\nSerializes as `\"realtime\"` / `\"high\"` / `\"normal\"` so YAML manifests can declare `scheduling: { priority: high }` without PascalCase noise.",


### PR DESCRIPTION
## What changed

Adds `-dev.N` / `-rc.N` prerelease support to the package `SemVer` type so a package can publish work-in-progress versions the same way the engine crates already do via cargo.

**Core type (`libs/streamlib-idents/src/semver.rs`)**
- New typed, `Copy` prerelease: `PrereleaseKind { Dev, Rc }` (Dev < Rc), `Prerelease { kind, n }`, and `prerelease: Option<Prerelease>` on `SemVer`. `SemVer` stays `Copy`.
- `new_prerelease(...)` + `release_core()` constructors (both `const`); `from_dotted` / new public `FromStr` parse the **closed** grammar — only `-dev.N` / `-rc.N` with a digits-only ordinal; everything else rejected (`+build`, unknown channels, `1.2.3-dev.+4` sign leniency, missing/garbage ordinals, `1.2.3-dev.1.2`).
- Hand-written `Ord`: a release outranks any prerelease of the same core; two prereleases order by `(kind, n)`. Gives `1.1.3-dev.2 < 1.1.3-dev.10 < 1.1.3-rc.1 < 1.1.3`.
- `SemVerRange` npm prerelease policy: `*` and release-req ranges match releases only; a prerelease req (`>=1.2.0-dev.3`, `^0.4.33-dev.2`) additionally admits same-core prereleases `>= req`. Includes the `^0.0.X-dev.N` caret fix (the exact-match branch could never admit the same-core release and inverted release preference; now compares cores, with ordering carried by the `v >= req` guard).
- JsonSchema regexes extended (`SemVer`, `SemVerRange`, `ModuleIdent` ranges); committed `schemas/streamlib.schema.json` regenerated.

**Consumers migrated**
- `select_version` / `list_versions_file` need no logic change — the new `Ord` + range policy carry release-over-prerelease selection (locked with tests, not code changes).
- Engine `is_semver` and both `strip_*_semver_suffix` helpers delegate to the canonical `SemVer` parser so the suffix grammar can't drift.
- Manifest, lockfile, and registry NDJSON index all round-trip prerelease versions (tests).

## Design decisions

- **Prerelease is a typed `Copy` field**, not a string — the type stays trivially copyable and the grammar is enforced at parse time.
- **npm-style range policy** — a prerelease is only ever selected when the range explicitly asks for one, preventing `^1.2.0` from silently jumping onto `1.2.5-dev.1`.

## Schema-ident release-core projection (scoping decision)

`SemVer` backs two decoupled version axes: **package** versions (this issue) and **schema-ident** versions (`SchemaIdent.version`, which flows over the 128-byte `#[repr(C)]` `SchemaIdentWire` mirrored byte-exact across Rust/Python/Deno, carrying only major/minor/patch). Rather than plumb prerelease through that ABI-locked wire (rejected — schema and package versions are decoupled and no consumer publishes prerelease *schemas*), **schema idents are release-only by invariant**: a package may be `0.4.33-dev.2`, but its schema idents carry the release core `0.4.33`.

**Enforcement is constructor-enforced + parse-rejected + two grep-auditable format sites** (per architecture review — not per-site convention):

1. **Constructor-enforced**: `SchemaIdent::new` projects its version onto the release core internally. Every Rust mint site — proc-macros, `ProjectConfig` bare-name resolution (whose ident flows onto `PortSchemaSpec`'s 3-field wire form and previously truncated silently), and module-load processor registration (which previously registered `...@0.4.33-dev.2` while the decorators minted `...@0.4.33` — two identities for one processor) — is covered by the type's semantics, unviolable from construction.
2. **Parse-rejected**: schema-ident parse/deserialize paths reject prerelease text as malformed input rather than projecting — `SchemaIdent` serde deserialization, jtd-codegen schema-import parsing, the `schema_ident!` macro parser, and the Python/Deno `SchemaIdent` 3-part validators (unchanged). A prerelease in a schema-ident position is an upstream bug and surfaces.
3. **Two grep-auditable format sites**: paths that format a version into a string without constructing a `SchemaIdent` keep an explicit `.release_core()` — the runtime config-id composition (`resolve_config_schema_canonical_id`, both arms) and its macro-side mirror, plus jtd-codegen's Python `SchemaIdentEmit::from_package_context`.
4. **Polyglot decorators**: Python `_release_core` / Deno `releaseCore` project valid `dev|rc` prereleases and **raise/throw on foreign channels** (`-alpha.1`) — identical accept/reject posture to Rust manifest parsing across all three runtimes.

The `SchemaIdentWire` ABI, `frame_payload.py`, `native.ts`, and the FFI are deliberately untouched.

## Test evidence

- `cargo test -p streamlib-idents --lib` — **107 passed** (parse/Display round-trip; rejection matrix incl. `-alpha.1`/`-dev`/`-dev.x`/`-dev.+4`/`+build`/`-dev.1.2`; ordering matrix; range policy matrix incl. tilde + `^0.0.X-dev.N` cells with mixed-candidate release preference; `select_version` mixed sets; prerelease dir-name listing; NDJSON + lockfile + manifest prerelease round-trips; constructor-projection, deserialize-rejection, and ModuleIdent prerelease-range tests).
- `cargo test -p streamlib-jtd-codegen --lib` — **56 passed** (incl. `SchemaIdentEmit` projection test and sentinel prerelease-import rejection).
- `cargo test -p streamlib-macros --lib` — 12 passed. **Note**: these are pre-existing tests; the macro-side compile-time mint paths would need trybuild infra to test directly, which this PR does not add. The runtime mirrors of those paths (`resolve_config_schema_canonical_id`, `resolve_named_to_ident`, `compose_processor_schema_ident`) are unit-tested against dev-versioned package fixtures instead.
- `cargo test -p streamlib-engine --lib` (targeted) — runtime-path tests green: config-schema canonical id (both arms) from a dev-versioned owner → release-core id; `resolve_named_to_ident` → release-core ident; processor-ident composition → release-core; `strip_semver_suffix` / `strip_legacy_semver_suffix` prerelease cases.
- `python3 -m pytest test_processor_decorator.py` — **23 passed, 2 failed**. The 2 failures are **pre-existing and environmental**, not from this PR: `TestGeneratedSchemaIdents` requires `streamlib._generated_` codegen artifacts that don't exist on a fresh checkout (the suite is not hermetic). All decorator tests including the new prerelease-projection and alpha-rejection tests pass.
- `deno test decorators_test.ts` — **27 passed** (incl. new prerelease-projection and alpha-rejection tests).
- `cargo check --workspace` clean; `cargo doc -p streamlib-idents --no-deps` clean.

## Known pre-existing issues (not fixed here)

- **`compare_semver` in `project_config.rs` mishandles prerelease**: the string-split comparator parses `"0.5.1-dev.2"` as `[0,5,0,2]` (the `1-dev` part fails `u64` parse → 0), so a dev-versioned runtime can falsely fail `streamlib_version: >=` constraints. Pre-existing string-comparator defect, adjacent to the version-handshake work tracked in #1218 — will be handled there.
- `cargo xtask check-manifest-schema` fails on `packages/{h264,moq,debug-utilities}/streamlib.yaml` missing the `# yaml-language-server: $schema=…` header — independent of this PR.

Closes #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wr1VLKMBbFpsmU7zAcniU2