### PR TITLE
feat(packaging): derive package crate version from .slpkg semver

### DIFF
--- a/.github/workflows/check-package-version-drift.yml
+++ b/.github/workflows/check-package-version-drift.yml
@@ -1,0 +1,49 @@
+name: Check Package Version Drift
+
+# CI gate that every publishable package's crate version matches its
+# `.slpkg` semver.
+#
+# `cargo xtask check-package-version-drift` asserts that every
+# `packages/*/Cargo.toml` `[package].version` equals its `streamlib.yaml`
+# `package.version` (the single source of truth). Schema-only packages (no
+# `Cargo.toml`) and workspace-inherited versions are skipped. A drift means
+# a stale crate version could reach the registry; the remedy is
+# `cargo xtask check-package-version-drift --fix`.
+#
+# See also `docs/architecture/gitea-registry-distribution.md`.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  xtask-check-package-version-drift:
+    name: xtask check-package-version-drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-xtask-${{ hashFiles('xtask/Cargo.toml', 'Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-xtask-
+
+      - name: cargo xtask check-package-version-drift
+        run: cargo xtask check-package-version-drift
+
+      - name: cargo test -p xtask check_package_version_drift (unit tests)
+        run: cargo test -p xtask check_package_version_drift

--- a/libs/streamlib-pack/Cargo.toml
+++ b/libs/streamlib-pack/Cargo.toml
@@ -18,6 +18,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 toml = { workspace = true }
+toml_edit = { workspace = true }
 zip = "2.2"
 streamlib-cargo-build = { path = "../streamlib-cargo-build", version = "0.5.0", registry = "gitea" }
 streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.5.0", registry = "gitea" }

--- a/libs/streamlib-pack/src/lib.rs
+++ b/libs/streamlib-pack/src/lib.rs
@@ -798,16 +798,36 @@ fn rewrite_manifest_path_deps_absolute(pkg_dir: &Path) -> Result<Vec<u8>> {
     Ok(out.into_bytes())
 }
 
+/// Rewrite `[package].version` in a `Cargo.toml` body to `version`,
+/// format-preserving via [`toml_edit`] — comments and every other field pass
+/// through unchanged. Handles the standard `[package]` table AND the inline
+/// `package = { version = … }` form; replaces whatever `version` shape is
+/// present (a literal string OR a `version.workspace = true` inheritance)
+/// with the literal. Returns `Ok(None)` when there's no `[package]` table or
+/// no `version` key.
+pub fn rewrite_cargo_package_version(cargo_toml: &str, version: &str) -> Result<Option<String>> {
+    let mut doc: toml_edit::DocumentMut =
+        cargo_toml.parse().context("parse Cargo.toml")?;
+    let Some(package) = doc.get_mut("package").and_then(|p| p.as_table_like_mut()) else {
+        return Ok(None);
+    };
+    if package.get("version").is_none() {
+        return Ok(None);
+    }
+    package.insert("version", toml_edit::value(version));
+    Ok(Some(doc.to_string()))
+}
+
 /// Compute the `Cargo.toml` bytes to ship in the artifact with
 /// `[package].version` stamped to `package_version` (the `.slpkg` semver
-/// from `streamlib.yaml`'s `package.version`). Format-preserving via
-/// [`toml_edit`] — comments and every other field pass through unchanged.
+/// from `streamlib.yaml`'s `package.version`) via
+/// [`rewrite_cargo_package_version`].
 ///
 /// Returns `Ok(None)` (ship the in-tree `Cargo.toml` verbatim) when there's
 /// nothing to stamp: no `Cargo.toml`, no `[package]` table, or no `version`
-/// key. A `version.workspace = true` inheritance IS stamped to a literal —
-/// the artifact is built standalone (no defining workspace root travels), so
-/// the inherited form would fail to resolve.
+/// key. A `version.workspace = true` inheritance is stamped to a literal —
+/// defensive for artifact copies assembled without the defining workspace
+/// root.
 fn stamped_cargo_toml_bytes(pkg_dir: &Path, package_version: &str) -> Result<Option<Vec<u8>>> {
     let cargo_path = pkg_dir.join("Cargo.toml");
     if !cargo_path.exists() {
@@ -815,19 +835,9 @@ fn stamped_cargo_toml_bytes(pkg_dir: &Path, package_version: &str) -> Result<Opt
     }
     let body = std::fs::read_to_string(&cargo_path)
         .with_context(|| format!("read {}", cargo_path.display()))?;
-    let mut doc: toml_edit::DocumentMut = body
-        .parse()
-        .with_context(|| format!("parse {}", cargo_path.display()))?;
-    let Some(package) = doc.get_mut("package").and_then(|p| p.as_table_mut()) else {
-        return Ok(None);
-    };
-    if !package.contains_key("version") {
-        return Ok(None);
-    }
-    // Replace whatever `version` shape is present — a literal string OR a
-    // `version.workspace = true` inheritance — with the derived literal.
-    package["version"] = toml_edit::value(package_version);
-    Ok(Some(doc.to_string().into_bytes()))
+    let stamped = rewrite_cargo_package_version(&body, package_version)
+        .with_context(|| format!("stamp version into {}", cargo_path.display()))?;
+    Ok(stamped.map(String::into_bytes))
 }
 
 /// Write the `.slpkg` zip: the manifest bytes as `streamlib.yaml`, the
@@ -1714,5 +1724,116 @@ mod tests {
         let cargo = std::fs::read_to_string(staged.path().join("Cargo.toml")).unwrap();
         assert!(cargo.contains("version = \"1.1.3-dev.4\""), "got: {cargo}");
         assert!(!cargo.contains("0.4.30"), "stale version must not reach the staged build, got: {cargo}");
+    }
+
+    #[test]
+    fn stamp_handles_inline_package_table() {
+        // The inline `package = { … }` form is valid TOML that
+        // `as_table_mut` silently misses (it's an inline table, not a
+        // standard table) — the stamp must cover it via `as_table_like_mut`
+        // or the stale version ships verbatim.
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "package = { name = \"rp\", version = \"0.4.30\", edition = \"2024\" }\n",
+        )
+        .unwrap();
+        let out = String::from_utf8(
+            stamped_cargo_toml_bytes(dir.path(), "1.0.0")
+                .unwrap()
+                .expect("inline package table must be stamped"),
+        )
+        .unwrap();
+        assert!(out.contains("\"1.0.0\""), "got: {out}");
+        assert!(!out.contains("0.4.30"), "stale inline version must be gone, got: {out}");
+    }
+
+    #[test]
+    fn malformed_cargo_toml_is_a_typed_error_not_a_panic() {
+        // StagedDir assembly reaches the stamp parse (prebuilt lib +
+        // no_build skips the cargo invocation); garbage TOML must surface
+        // as a typed error naming the file, never a panic.
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: rp\n  version: 1.0.0\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), ":::: not toml ::::\n").unwrap();
+        std::fs::create_dir(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/lib.rs"), b"// crate source").unwrap();
+        let triple_dir = dir.path().join("lib").join(host_target_triple());
+        std::fs::create_dir_all(&triple_dir).unwrap();
+        std::fs::write(
+            triple_dir.join(format!("librp.{}", host_dylib_extension())),
+            b"prebuilt",
+        )
+        .unwrap();
+
+        let staged = tempdir().unwrap();
+        let err = assemble_artifact(
+            dir.path(),
+            &AssembleTarget::StagedDir(staged.path().to_path_buf()),
+            &AssembleOptions {
+                no_build: true,
+                profile: CargoProfile::Dev,
+                path_deps: PathDepPolicy::RewriteRelativeToAbsolute,
+            },
+            &(),
+        )
+        .expect_err("malformed Cargo.toml must be a typed error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Cargo.toml") && msg.contains("parse"),
+            "error must name the file and the parse failure, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn staged_dir_stamps_workspace_inherited_version_to_literal() {
+        // Inherited→literal asserted through an emitted artifact: a
+        // `version.workspace = true` source stages with a literal derived
+        // from streamlib.yaml. The artifact lacks the defining workspace
+        // root, so the stamped literal is what makes `[package].version`
+        // resolvable there at all.
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: rp\n  version: 1.0.0\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"rp\"\nversion.workspace = true\nedition = \"2024\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/lib.rs"), b"// crate source").unwrap();
+        let triple_dir = dir.path().join("lib").join(host_target_triple());
+        std::fs::create_dir_all(&triple_dir).unwrap();
+        std::fs::write(
+            triple_dir.join(format!("librp.{}", host_dylib_extension())),
+            b"prebuilt",
+        )
+        .unwrap();
+
+        let staged = tempdir().unwrap();
+        assemble_artifact(
+            dir.path(),
+            &AssembleTarget::StagedDir(staged.path().to_path_buf()),
+            &AssembleOptions {
+                no_build: true,
+                profile: CargoProfile::Dev,
+                path_deps: PathDepPolicy::RewriteRelativeToAbsolute,
+            },
+            &(),
+        )
+        .unwrap();
+        let cargo = std::fs::read_to_string(staged.path().join("Cargo.toml")).unwrap();
+        assert!(cargo.contains("version = \"1.0.0\""), "got: {cargo}");
+        assert!(
+            !cargo.contains("version.workspace"),
+            "version inheritance must be replaced with the literal, got: {cargo}"
+        );
     }
 }

--- a/libs/streamlib-pack/src/lib.rs
+++ b/libs/streamlib-pack/src/lib.rs
@@ -325,10 +325,25 @@ pub fn assemble_artifact(
     // Manifest bytes (possibly rewritten).
     let manifest_bytes = manifest_bytes_for(pkg_dir, opts.path_deps)?;
 
+    // Derive the crate version from the `.slpkg` semver. A Rust package's
+    // `Cargo.toml` `[package].version` is stamped to match
+    // `streamlib.yaml`'s `package.version` so a stale in-tree crate version
+    // can never reach the registry via the artifact. `None` when there's
+    // nothing to stamp (no `Cargo.toml`, no `[package].version`).
+    let stamped_cargo_toml = if has_rust {
+        stamped_cargo_toml_bytes(pkg_dir, &pkg_version)?
+    } else {
+        None
+    };
+
     // Emit.
     match target {
-        AssembleTarget::Slpkg(zip_path) => emit_slpkg(zip_path, &files, &manifest_bytes)?,
-        AssembleTarget::StagedDir(dir) => emit_staged_dir(dir, &files, &manifest_bytes)?,
+        AssembleTarget::Slpkg(zip_path) => {
+            emit_slpkg(zip_path, &files, &manifest_bytes, stamped_cargo_toml.as_deref())?
+        }
+        AssembleTarget::StagedDir(dir) => {
+            emit_staged_dir(dir, &files, &manifest_bytes, stamped_cargo_toml.as_deref())?
+        }
     }
 
     Ok(AssembleOutcome {
@@ -783,9 +798,48 @@ fn rewrite_manifest_path_deps_absolute(pkg_dir: &Path) -> Result<Vec<u8>> {
     Ok(out.into_bytes())
 }
 
-/// Write the `.slpkg` zip: the manifest bytes as `streamlib.yaml`, then
-/// every collected file at its archive path. Duplicate paths skipped.
-fn emit_slpkg(zip_path: &Path, files: &[(String, PathBuf)], manifest_bytes: &[u8]) -> Result<()> {
+/// Compute the `Cargo.toml` bytes to ship in the artifact with
+/// `[package].version` stamped to `package_version` (the `.slpkg` semver
+/// from `streamlib.yaml`'s `package.version`). Format-preserving via
+/// [`toml_edit`] — comments and every other field pass through unchanged.
+///
+/// Returns `Ok(None)` (ship the in-tree `Cargo.toml` verbatim) when there's
+/// nothing to stamp: no `Cargo.toml`, no `[package]` table, or no `version`
+/// key. A `version.workspace = true` inheritance IS stamped to a literal —
+/// the artifact is built standalone (no defining workspace root travels), so
+/// the inherited form would fail to resolve.
+fn stamped_cargo_toml_bytes(pkg_dir: &Path, package_version: &str) -> Result<Option<Vec<u8>>> {
+    let cargo_path = pkg_dir.join("Cargo.toml");
+    if !cargo_path.exists() {
+        return Ok(None);
+    }
+    let body = std::fs::read_to_string(&cargo_path)
+        .with_context(|| format!("read {}", cargo_path.display()))?;
+    let mut doc: toml_edit::DocumentMut = body
+        .parse()
+        .with_context(|| format!("parse {}", cargo_path.display()))?;
+    let Some(package) = doc.get_mut("package").and_then(|p| p.as_table_mut()) else {
+        return Ok(None);
+    };
+    if !package.contains_key("version") {
+        return Ok(None);
+    }
+    // Replace whatever `version` shape is present — a literal string OR a
+    // `version.workspace = true` inheritance — with the derived literal.
+    package["version"] = toml_edit::value(package_version);
+    Ok(Some(doc.to_string().into_bytes()))
+}
+
+/// Write the `.slpkg` zip: the manifest bytes as `streamlib.yaml`, the
+/// version-stamped `Cargo.toml` (when present), then every collected file at
+/// its archive path. Duplicate paths skipped — writing the stamped
+/// `Cargo.toml` first means the verbatim copy from the source tree is deduped.
+fn emit_slpkg(
+    zip_path: &Path,
+    files: &[(String, PathBuf)],
+    manifest_bytes: &[u8],
+    stamped_cargo_toml: Option<&[u8]>,
+) -> Result<()> {
     use zip::write::FileOptions;
     use zip::ZipWriter;
 
@@ -799,6 +853,12 @@ fn emit_slpkg(zip_path: &Path, files: &[(String, PathBuf)], manifest_bytes: &[u8
     zip.start_file("streamlib.yaml", options)?;
     zip.write_all(manifest_bytes)?;
     seen.insert("streamlib.yaml".to_string());
+
+    if let Some(bytes) = stamped_cargo_toml {
+        zip.start_file("Cargo.toml", options)?;
+        zip.write_all(bytes)?;
+        seen.insert("Cargo.toml".to_string());
+    }
 
     for (name, path) in files {
         if !seen.insert(name.clone()) {
@@ -816,14 +876,25 @@ fn emit_slpkg(zip_path: &Path, files: &[(String, PathBuf)], manifest_bytes: &[u8
 }
 
 /// Write the extracted layout into `dir`: the manifest bytes as
-/// `streamlib.yaml`, then every collected file at its archive path
-/// (parents created). Duplicate paths skipped.
-fn emit_staged_dir(dir: &Path, files: &[(String, PathBuf)], manifest_bytes: &[u8]) -> Result<()> {
+/// `streamlib.yaml`, the version-stamped `Cargo.toml` (when present), then
+/// every collected file at its archive path (parents created). Duplicate
+/// paths skipped — the stamped `Cargo.toml` is written first so the verbatim
+/// source-tree copy is deduped.
+fn emit_staged_dir(
+    dir: &Path,
+    files: &[(String, PathBuf)],
+    manifest_bytes: &[u8],
+    stamped_cargo_toml: Option<&[u8]>,
+) -> Result<()> {
     std::fs::create_dir_all(dir).with_context(|| format!("create {}", dir.display()))?;
     std::fs::write(dir.join("streamlib.yaml"), manifest_bytes).context("write streamlib.yaml")?;
 
     let mut seen = std::collections::HashSet::new();
     seen.insert("streamlib.yaml".to_string());
+    if let Some(bytes) = stamped_cargo_toml {
+        std::fs::write(dir.join("Cargo.toml"), bytes).context("write stamped Cargo.toml")?;
+        seen.insert("Cargo.toml".to_string());
+    }
     for (name, src) in files {
         if !seen.insert(name.clone()) {
             continue;
@@ -859,6 +930,16 @@ mod tests {
         (0..zip.len())
             .map(|i| zip.by_index(i).unwrap().name().to_string())
             .collect()
+    }
+
+    fn zip_file_contents(slpkg: &Path, name: &str) -> String {
+        use std::io::Read as _;
+        let bytes = std::fs::read(slpkg).unwrap();
+        let mut zip = zip::ZipArchive::new(std::io::Cursor::new(bytes)).unwrap();
+        let mut f = zip.by_name(name).unwrap();
+        let mut s = String::new();
+        f.read_to_string(&mut s).unwrap();
+        s
     }
 
     #[test]
@@ -1483,5 +1564,155 @@ mod tests {
             staged_yaml.contains(core_abs.to_str().unwrap()),
             "manifest must carry the absolute core path, got: {staged_yaml}"
         );
+    }
+
+    // ---- Version-stamp: derive crate version from the .slpkg semver ----
+
+    #[test]
+    fn stamp_replaces_literal_crate_version_with_manifest_version() {
+        // In-tree Cargo.toml pins a stale crate version; the stamp derives
+        // the version from streamlib.yaml. Mentally revert the stamp and the
+        // stale literal survives.
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"rp\"\nversion = \"0.4.30\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+        let bytes = stamped_cargo_toml_bytes(dir.path(), "1.1.3-dev.4")
+            .unwrap()
+            .expect("a literal [package].version must be stamped");
+        let out = String::from_utf8(bytes).unwrap();
+        assert!(out.contains("version = \"1.1.3-dev.4\""), "got: {out}");
+        assert!(!out.contains("0.4.30"), "stale literal must be gone, got: {out}");
+        // Other fields + shape preserved.
+        assert!(out.contains("name = \"rp\""));
+        assert!(out.contains("edition = \"2024\""));
+    }
+
+    #[test]
+    fn stamp_replaces_workspace_inherited_version_with_literal() {
+        // `version.workspace = true` cannot resolve in a standalone artifact
+        // build (no defining workspace root travels), so it must become a
+        // literal. Revert this branch and a staged workspace-member package
+        // fails to `cargo build`.
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"rp\"\nversion.workspace = true\nedition = \"2024\"\n",
+        )
+        .unwrap();
+        let bytes = stamped_cargo_toml_bytes(dir.path(), "1.0.0")
+            .unwrap()
+            .expect("a workspace-inherited version must be stamped to a literal");
+        let out = String::from_utf8(bytes).unwrap();
+        assert!(out.contains("version = \"1.0.0\""), "got: {out}");
+        assert!(!out.contains("workspace = true"), "inheritance must be gone, got: {out}");
+    }
+
+    #[test]
+    fn stamp_preserves_comments_and_unrelated_fields() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "# top comment\n[package]\nname = \"rp\"\nversion = \"0.1.0\" # inline\nedition = \"2024\"\n\n[dependencies]\nserde = \"1.0\"\n",
+        )
+        .unwrap();
+        let out = String::from_utf8(
+            stamped_cargo_toml_bytes(dir.path(), "2.5.0").unwrap().unwrap(),
+        )
+        .unwrap();
+        assert!(out.contains("# top comment"), "comment preserved, got: {out}");
+        assert!(out.contains("[dependencies]") && out.contains("serde = \"1.0\""));
+        assert!(out.contains("version = \"2.5.0\""), "got: {out}");
+    }
+
+    #[test]
+    fn stamp_is_noop_without_cargo_toml_or_version() {
+        // No Cargo.toml → nothing to stamp.
+        let dir = tempdir().unwrap();
+        assert!(stamped_cargo_toml_bytes(dir.path(), "1.0.0").unwrap().is_none());
+        // A [package] with no version key → nothing to stamp (ship verbatim).
+        std::fs::write(dir.path().join("Cargo.toml"), "[package]\nname = \"rp\"\n").unwrap();
+        assert!(stamped_cargo_toml_bytes(dir.path(), "1.0.0").unwrap().is_none());
+    }
+
+    #[test]
+    fn slpkg_stamps_crate_version_from_manifest_semver() {
+        // Integration: the emitted `.slpkg` carries a `Cargo.toml` whose
+        // `[package].version` equals streamlib.yaml's `package.version`,
+        // regardless of the stale in-tree value. Revert the stamp step and
+        // the verbatim copy would carry `0.4.30`.
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: rp\n  version: 1.1.3-dev.4\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"rp\"\nversion = \"0.4.30\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/lib.rs"), b"// crate source").unwrap();
+
+        let out = dir.path().join("o.slpkg");
+        assemble_artifact(dir.path(), &AssembleTarget::Slpkg(out.clone()), &slpkg_opts(false), &())
+            .unwrap();
+        let entries = zip_entries(&out);
+        // Exactly one Cargo.toml (the stamped one; verbatim copy deduped).
+        assert_eq!(
+            entries.iter().filter(|e| e.as_str() == "Cargo.toml").count(),
+            1,
+            "exactly one Cargo.toml must ship, got {entries:?}"
+        );
+        let cargo = zip_file_contents(&out, "Cargo.toml");
+        assert!(cargo.contains("version = \"1.1.3-dev.4\""), "got: {cargo}");
+        assert!(!cargo.contains("0.4.30"), "stale version must not reach the artifact, got: {cargo}");
+    }
+
+    #[test]
+    fn staged_dir_stamps_crate_version_from_manifest_semver() {
+        // Same lock for the StagedDir target (orchestrator load-time build):
+        // the stale in-tree crate version cannot reach the built artifact.
+        // A prebuilt lib/<triple>/ is pre-populated so the rust path takes the
+        // prebuilt branch and no cargo build runs in the test.
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: rp\n  version: 1.1.3-dev.4\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"rp\"\nversion = \"0.4.30\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/lib.rs"), b"// crate source").unwrap();
+        let triple_dir = dir.path().join("lib").join(host_target_triple());
+        std::fs::create_dir_all(&triple_dir).unwrap();
+        std::fs::write(
+            triple_dir.join(format!("librp.{}", host_dylib_extension())),
+            b"prebuilt",
+        )
+        .unwrap();
+
+        let staged = tempdir().unwrap();
+        assemble_artifact(
+            dir.path(),
+            &AssembleTarget::StagedDir(staged.path().to_path_buf()),
+            &AssembleOptions {
+                no_build: true,
+                profile: CargoProfile::Dev,
+                path_deps: PathDepPolicy::RewriteRelativeToAbsolute,
+            },
+            &(),
+        )
+        .unwrap();
+        let cargo = std::fs::read_to_string(staged.path().join("Cargo.toml")).unwrap();
+        assert!(cargo.contains("version = \"1.1.3-dev.4\""), "got: {cargo}");
+        assert!(!cargo.contains("0.4.30"), "stale version must not reach the staged build, got: {cargo}");
     }
 }

--- a/packages/api-server/Cargo.toml
+++ b/packages/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamlib-api-server"
-version = "0.4.30"
+version = "1.0.0"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 description = "HTTP control-plane processor for streamlib runtimes — graph mutation, registry browsing, WebSocket event streaming, OpenAPI spec."

--- a/packages/audio/Cargo.toml
+++ b/packages/audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamlib-audio"
-version = "0.4.30"
+version = "1.0.0"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 description = "Audio processors carved out of the streamlib engine — capture, output, mixer, channel converter, resampler, buffer rechunker, chord generator"

--- a/packages/camera/Cargo.toml
+++ b/packages/camera/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamlib-camera"
-version = "0.4.30"
+version = "1.0.0"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 description = "Camera capture processor — V4L2 on Linux, AVFoundation on macOS/iOS — carved out of the streamlib engine."

--- a/packages/clap/Cargo.toml
+++ b/packages/clap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamlib-clap"
-version = "0.4.30"
+version = "1.0.0"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 description = "CLAP audio plugin host processor for streamlib (macOS / iOS)."

--- a/packages/debug-utilities/Cargo.toml
+++ b/packages/debug-utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamlib-debug-utilities"
-version = "0.4.30"
+version = "1.0.0"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 description = "Utility processors for development, demos, and rigorous-input testing (BgraFileSource, SimplePassthrough)."

--- a/packages/display/Cargo.toml
+++ b/packages/display/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamlib-display"
-version = "0.4.30"
+version = "1.0.0"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 description = "Display processor — renders video frames to a window via the engine's host RHI presentation primitive. Linux first; macOS port is in the package but disabled (rewrite on top of a Metal present target tracked separately)."

--- a/packages/frame-tap/Cargo.toml
+++ b/packages/frame-tap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamlib-frame-tap"
-version = "0.4.30"
+version = "1.0.0"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 description = "Frame tap — a sink processor that fans out from any video output and samples frames to disk (JPEG) on a configurable strategy, off the hot path. The seed for streamlib's general tap behavior."

--- a/packages/h264/Cargo.toml
+++ b/packages/h264/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamlib-h264"
-version = "0.4.30"
+version = "1.0.0"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 description = "H.264 encoder + decoder via Vulkan Video — carved out of the streamlib engine. Linux-only today; macOS VideoToolbox is a future addition."

--- a/packages/h265/Cargo.toml
+++ b/packages/h265/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamlib-h265"
-version = "0.4.30"
+version = "1.0.0"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 description = "H.265 encoder + decoder processors for streamlib, via Vulkan Video. Linux-only today; macOS VideoToolbox is a future addition."

--- a/packages/jpeg/Cargo.toml
+++ b/packages/jpeg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamlib-jpeg"
-version = "0.4.35-dev.5"
+version = "1.0.7"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 description = "JPEG decoder processor — thin wrapper around vulkan-jpeg::SimpleJpegDecoder (cross-vendor Vulkan compute)."

--- a/packages/mavlink/Cargo.toml
+++ b/packages/mavlink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamlib-mavlink"
-version = "0.4.30"
+version = "1.1.4"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 description = "MAVLink2 encoder + decoder processors for streamlib — wraps rust-mavlink (common dialect). Pairs with @tatolab/network for MAVLink-over-UDP."

--- a/packages/moq/Cargo.toml
+++ b/packages/moq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamlib-moq-processors"
-version = "0.4.30"
+version = "1.0.0"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 description = "MoQ (Media over QUIC) publish/subscribe track processors for streamlib — the @tatolab/moq package, built on the streamlib-moq transport library."

--- a/packages/mp4/Cargo.toml
+++ b/packages/mp4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamlib-mp4"
-version = "0.4.30"
+version = "1.0.0"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 description = "MP4 file writer processors for streamlib."

--- a/packages/network/Cargo.toml
+++ b/packages/network/Cargo.toml
@@ -9,7 +9,7 @@
 # for a stray member of an enclosing workspace.
 [package]
 name = "streamlib-network"
-version = "0.4.30"
+version = "1.0.2"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 license = "BUSL-1.1"

--- a/packages/opus/Cargo.toml
+++ b/packages/opus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamlib-opus"
-version = "0.4.30"
+version = "1.0.0"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 description = "Opus audio encoder + decoder processors via libopus. Cross-platform Rust (macOS / iOS / Linux)."

--- a/packages/screen-capture/Cargo.toml
+++ b/packages/screen-capture/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamlib-screen-capture"
-version = "0.4.30"
+version = "1.0.0"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 description = "Screen capture processor for streamlib (macOS / iOS via ScreenCaptureKit)."

--- a/packages/vadr-vision/Cargo.toml
+++ b/packages/vadr-vision/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamlib-vadr-vision"
-version = "0.4.30"
+version = "1.0.2"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 description = "VADR-TS-002 §4.6 vision-stream depayloader — parses the 24-byte AGP chunk header, reassembles JPEG frames, drops incomplete frames on timeout, emits EncodedJpegFrame to @tatolab/jpeg."

--- a/packages/webrtc/Cargo.toml
+++ b/packages/webrtc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamlib-webrtc"
-version = "0.4.30"
+version = "1.0.0"
 edition = "2024"
 authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 description = "WebRTC WHIP/WHEP transport processors for streamlib."

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -31,6 +31,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_yaml = "0.9"
 toml = "0.8"
+toml_edit = "0.22"
 
 # JSON Schema generation (#714) — same major as the rest of the workspace.
 schemars = "0.8"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,9 +15,14 @@ streamlib-jtd-codegen = { path = "../libs/streamlib-jtd-codegen" }
 # `schemars::schema_for!(StreamlibYaml)` from this crate (#714).
 streamlib-processor-schema = { path = "../libs/streamlib-processor-schema" }
 
-# Package-artifact assembly — backs `strip-publish-manifest`, the publish-side
-# path-patch strip for the Gitea registry distribution.
+# Package-artifact assembly — backs `strip-publish-manifest` (publish-side
+# path-patch strip) and `check-package-version-drift --fix` (shared
+# Cargo.toml version rewrite).
 streamlib-pack = { path = "../libs/streamlib-pack" }
+
+# SemVer parsing for check-package-version-drift — the manifest version is
+# validated through the same SemVer type the pack stamp derives from.
+streamlib-idents = { path = "../libs/streamlib-idents" }
 
 # Logging — needed to surface tracing::info! output from streamlib-jtd-codegen.
 tracing = "0.1"
@@ -31,7 +36,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_yaml = "0.9"
 toml = "0.8"
-toml_edit = "0.22"
 
 # JSON Schema generation (#714) — same major as the rest of the workspace.
 schemars = "0.8"

--- a/xtask/src/check_package_version_drift.rs
+++ b/xtask/src/check_package_version_drift.rs
@@ -128,35 +128,49 @@ fn cargo_literal_version(cargo_path: &Path) -> Result<Option<String>> {
     Ok(version.map(|s| s.to_string()))
 }
 
-/// The `package.version` string in a `streamlib.yaml`, or `None` when the
-/// manifest declares no `package.version`.
+/// The canonical `package.version` of a `streamlib.yaml` — parsed through
+/// [`streamlib_idents::SemVer`] and rendered via its Display, so the
+/// comparison target is exactly what the pack-time stamp writes. A malformed
+/// version (2-part, numeric YAML scalar, bad prerelease) is a loud error, not
+/// a silent skip. `None` when the manifest declares no `package.version`.
 fn manifest_package_version(manifest_path: &Path) -> Result<Option<String>> {
     let body = fs::read_to_string(manifest_path)
         .with_context(|| format!("read {}", manifest_path.display()))?;
     let value: serde_yaml::Value = serde_yaml::from_str(&body)
         .with_context(|| format!("parse {}", manifest_path.display()))?;
-    let version = value.get("package").and_then(|p| p.get("version"));
-    Ok(match version {
-        Some(serde_yaml::Value::String(s)) => Some(s.clone()),
-        Some(serde_yaml::Value::Number(n)) => Some(n.to_string()),
-        _ => None,
-    })
+    let raw = match value.get("package").and_then(|p| p.get("version")) {
+        Some(serde_yaml::Value::String(s)) => s.clone(),
+        // A bare `version: 1.0` parses as a YAML float — feed its string
+        // form to the SemVer parser so it fails loudly below instead of
+        // slipping through as CI-green-but-pack-fails.
+        Some(serde_yaml::Value::Number(n)) => n.to_string(),
+        _ => return Ok(None),
+    };
+    let semver = raw.parse::<streamlib_idents::SemVer>().map_err(|e| {
+        anyhow::anyhow!(
+            "{}: invalid `package.version` `{raw}`: {e}",
+            manifest_path.display()
+        )
+    })?;
+    Ok(Some(semver.to_string()))
 }
 
-/// Rewrite `[package].version` in the drifting `Cargo.toml` to the manifest
-/// version, preserving formatting and comments via [`toml_edit`].
+/// Rewrite `[package].version` in the drifting `Cargo.toml` to the canonical
+/// manifest version, via the same format-preserving rewrite the pack-time
+/// stamp uses ([`streamlib_pack::rewrite_cargo_package_version`]).
 fn apply_fix(drift: &VersionDrift) -> Result<()> {
     let body = fs::read_to_string(&drift.cargo_path)
         .with_context(|| format!("read {}", drift.cargo_path.display()))?;
-    let mut doc: toml_edit::DocumentMut = body
-        .parse()
-        .with_context(|| format!("parse {}", drift.cargo_path.display()))?;
-    let package = doc
-        .get_mut("package")
-        .and_then(|p| p.as_table_mut())
-        .ok_or_else(|| anyhow::anyhow!("{}: no [package] table", drift.cargo_path.display()))?;
-    package["version"] = toml_edit::value(drift.manifest_version.clone());
-    fs::write(&drift.cargo_path, doc.to_string())
+    let rewritten =
+        streamlib_pack::rewrite_cargo_package_version(&body, &drift.manifest_version)
+            .with_context(|| format!("rewrite {}", drift.cargo_path.display()))?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "{}: no `[package].version` to rewrite",
+                    drift.cargo_path.display()
+                )
+            })?;
+    fs::write(&drift.cargo_path, rewritten)
         .with_context(|| format!("write {}", drift.cargo_path.display()))?;
     Ok(())
 }
@@ -269,6 +283,37 @@ mod tests {
     }
 
     #[test]
+    fn malformed_cargo_toml_is_a_typed_error_not_a_panic() {
+        let root = TempDir::new().unwrap();
+        write_pkg(root.path(), "foo", ":::: not toml ::::\n", MANIFEST_1_0_0);
+        let err = scan(root.path()).expect_err("garbage Cargo.toml must be a loud error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Cargo.toml") && msg.contains("parse"),
+            "error must name the file and the parse failure, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn malformed_manifest_version_is_a_loud_error_not_a_silent_pass() {
+        // `version: 1.0` parses as a YAML float; the SemVer gate must turn
+        // it into a hard error instead of a CI-green-but-pack-fails skip.
+        let root = TempDir::new().unwrap();
+        write_pkg(
+            root.path(),
+            "foo",
+            "[package]\nname = \"streamlib-foo\"\nversion = \"1.0.0\"\n",
+            "package:\n  org: tatolab\n  name: foo\n  version: 1.0\n",
+        );
+        let err = scan(root.path()).expect_err("2-part version must fail the lint loudly");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("invalid `package.version`") && msg.contains("1.0"),
+            "error must name the invalid version, got: {msg}"
+        );
+    }
+
+    #[test]
     fn current_workspace_has_no_drift() {
         // Smoke test: after the sweep, no real package drifts. Locks the
         // sweep in place — a future package with a stale crate version fails
@@ -277,7 +322,7 @@ mod tests {
         let drifts = scan(&workspace).unwrap();
         assert!(
             drifts.is_empty(),
-            "current workspace has package version drift: {drifts:?}"
+            "current workspace has package version drift: {drifts:?} — run `cargo xtask check-package-version-drift --fix`"
         );
     }
 

--- a/xtask/src/check_package_version_drift.rs
+++ b/xtask/src/check_package_version_drift.rs
@@ -1,0 +1,290 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! CI lint enforcing that every publishable package's crate version matches
+//! its `.slpkg` semver.
+//!
+//! A package's version lives in `streamlib.yaml` (`package.version`) — the
+//! single source of truth. Its `Cargo.toml` `[package].version` (the crate
+//! version the registry resolves) must equal it, so a stale in-tree crate
+//! version can never reach the registry. `streamlib pack` stamps the artifact
+//! copy at pack time; this lint keeps the *in-tree* `Cargo.toml` honest so the
+//! bump workflow is "edit streamlib.yaml, run `--fix`" — never hand-edit
+//! `Cargo.toml`.
+//!
+//! Skipped by construction:
+//! - Packages with no `Cargo.toml` (schema-only, e.g. `@tatolab/escalate`).
+//! - `Cargo.toml`s that inherit `version.workspace = true` — the version comes
+//!   from the workspace root, not the crate, so there's nothing to drift
+//!   against in-tree (the pack-time stamp handles the artifact copy).
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Parent directory holding the publishable packages.
+const PACKAGES_DIR: &str = "packages";
+
+/// A package whose in-tree `Cargo.toml` crate version disagrees with its
+/// `streamlib.yaml` package version.
+#[derive(Debug, PartialEq, Eq)]
+pub struct VersionDrift {
+    pub package: String,
+    pub cargo_path: PathBuf,
+    pub cargo_version: String,
+    pub manifest_version: String,
+}
+
+pub fn run(workspace_root: &Path, fix: bool) -> Result<()> {
+    let drifts = scan(workspace_root)?;
+
+    if fix {
+        for d in &drifts {
+            apply_fix(d)?;
+            println!(
+                "✓ fixed {}: {} → {}",
+                d.package, d.cargo_version, d.manifest_version
+            );
+        }
+        if drifts.is_empty() {
+            println!("✓ check-package-version-drift --fix: nothing to fix");
+        } else {
+            println!("✓ check-package-version-drift --fix: {} package(s) synced", drifts.len());
+        }
+        return Ok(());
+    }
+
+    if drifts.is_empty() {
+        println!("✓ check-package-version-drift: every package Cargo.toml matches its streamlib.yaml version");
+        return Ok(());
+    }
+
+    eprintln!("✗ check-package-version-drift: {} package(s) drift", drifts.len());
+    for d in &drifts {
+        eprintln!(
+            "  {}: Cargo.toml `[package].version` = {} but streamlib.yaml `package.version` = {} — run `cargo xtask check-package-version-drift --fix`",
+            d.package, d.cargo_version, d.manifest_version
+        );
+    }
+    anyhow::bail!("check-package-version-drift failed");
+}
+
+/// Scan `packages/*` for crate-version drift against `streamlib.yaml`.
+pub fn scan(workspace_root: &Path) -> Result<Vec<VersionDrift>> {
+    let packages_dir = workspace_root.join(PACKAGES_DIR);
+    let mut drifts = Vec::new();
+    if !packages_dir.is_dir() {
+        return Ok(drifts);
+    }
+
+    let mut entries: Vec<PathBuf> = fs::read_dir(&packages_dir)
+        .with_context(|| format!("read {}", packages_dir.display()))?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.is_dir())
+        .collect();
+    entries.sort();
+
+    for pkg_dir in entries {
+        let cargo_path = pkg_dir.join("Cargo.toml");
+        let manifest_path = pkg_dir.join("streamlib.yaml");
+        // Schema-only packages carry no Cargo.toml — nothing to check.
+        if !cargo_path.exists() || !manifest_path.exists() {
+            continue;
+        }
+        // Workspace-inherited versions have no in-tree literal to drift.
+        let Some(cargo_version) = cargo_literal_version(&cargo_path)? else {
+            continue;
+        };
+        let Some(manifest_version) = manifest_package_version(&manifest_path)? else {
+            continue;
+        };
+        if cargo_version != manifest_version {
+            let package = pkg_dir
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| pkg_dir.display().to_string());
+            drifts.push(VersionDrift {
+                package,
+                cargo_path,
+                cargo_version,
+                manifest_version,
+            });
+        }
+    }
+    Ok(drifts)
+}
+
+/// The literal `[package].version` string in a `Cargo.toml`, or `None` when
+/// the version is workspace-inherited (`version.workspace = true`) or absent.
+fn cargo_literal_version(cargo_path: &Path) -> Result<Option<String>> {
+    let body = fs::read_to_string(cargo_path)
+        .with_context(|| format!("read {}", cargo_path.display()))?;
+    let doc: toml::Value =
+        toml::from_str(&body).with_context(|| format!("parse {}", cargo_path.display()))?;
+    let version = doc
+        .get("package")
+        .and_then(|p| p.get("version"))
+        .and_then(|v| v.as_str());
+    Ok(version.map(|s| s.to_string()))
+}
+
+/// The `package.version` string in a `streamlib.yaml`, or `None` when the
+/// manifest declares no `package.version`.
+fn manifest_package_version(manifest_path: &Path) -> Result<Option<String>> {
+    let body = fs::read_to_string(manifest_path)
+        .with_context(|| format!("read {}", manifest_path.display()))?;
+    let value: serde_yaml::Value = serde_yaml::from_str(&body)
+        .with_context(|| format!("parse {}", manifest_path.display()))?;
+    let version = value.get("package").and_then(|p| p.get("version"));
+    Ok(match version {
+        Some(serde_yaml::Value::String(s)) => Some(s.clone()),
+        Some(serde_yaml::Value::Number(n)) => Some(n.to_string()),
+        _ => None,
+    })
+}
+
+/// Rewrite `[package].version` in the drifting `Cargo.toml` to the manifest
+/// version, preserving formatting and comments via [`toml_edit`].
+fn apply_fix(drift: &VersionDrift) -> Result<()> {
+    let body = fs::read_to_string(&drift.cargo_path)
+        .with_context(|| format!("read {}", drift.cargo_path.display()))?;
+    let mut doc: toml_edit::DocumentMut = body
+        .parse()
+        .with_context(|| format!("parse {}", drift.cargo_path.display()))?;
+    let package = doc
+        .get_mut("package")
+        .and_then(|p| p.as_table_mut())
+        .ok_or_else(|| anyhow::anyhow!("{}: no [package] table", drift.cargo_path.display()))?;
+    package["version"] = toml_edit::value(drift.manifest_version.clone());
+    fs::write(&drift.cargo_path, doc.to_string())
+        .with_context(|| format!("write {}", drift.cargo_path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_pkg(root: &Path, name: &str, cargo: &str, manifest: &str) {
+        let dir = root.join(PACKAGES_DIR).join(name);
+        fs::create_dir_all(&dir).unwrap();
+        if !cargo.is_empty() {
+            fs::write(dir.join("Cargo.toml"), cargo).unwrap();
+        }
+        if !manifest.is_empty() {
+            fs::write(dir.join("streamlib.yaml"), manifest).unwrap();
+        }
+    }
+
+    const MANIFEST_1_0_0: &str =
+        "package:\n  org: tatolab\n  name: foo\n  version: 1.0.0\n";
+
+    #[test]
+    fn detects_and_names_drift() {
+        let root = TempDir::new().unwrap();
+        write_pkg(
+            root.path(),
+            "foo",
+            "[package]\nname = \"streamlib-foo\"\nversion = \"0.4.30\"\n",
+            MANIFEST_1_0_0,
+        );
+        let drifts = scan(root.path()).unwrap();
+        assert_eq!(drifts.len(), 1);
+        assert_eq!(drifts[0].package, "foo");
+        assert_eq!(drifts[0].cargo_version, "0.4.30");
+        assert_eq!(drifts[0].manifest_version, "1.0.0");
+    }
+
+    #[test]
+    fn matching_versions_are_not_drift() {
+        let root = TempDir::new().unwrap();
+        write_pkg(
+            root.path(),
+            "foo",
+            "[package]\nname = \"streamlib-foo\"\nversion = \"1.0.0\"\n",
+            MANIFEST_1_0_0,
+        );
+        assert!(scan(root.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn prerelease_drift_is_detected_and_fixed() {
+        let root = TempDir::new().unwrap();
+        write_pkg(
+            root.path(),
+            "jpeg",
+            "[package]\nname = \"streamlib-jpeg\"\nversion = \"0.4.35-dev.5\"\n",
+            "package:\n  org: tatolab\n  name: jpeg\n  version: 1.0.7\n",
+        );
+        let drifts = scan(root.path()).unwrap();
+        assert_eq!(drifts.len(), 1);
+        assert_eq!(drifts[0].manifest_version, "1.0.7");
+        run(root.path(), true).unwrap();
+        assert!(scan(root.path()).unwrap().is_empty(), "--fix must converge");
+    }
+
+    #[test]
+    fn workspace_inherited_version_is_skipped() {
+        let root = TempDir::new().unwrap();
+        write_pkg(
+            root.path(),
+            "core",
+            "[package]\nname = \"streamlib-core\"\nversion.workspace = true\n",
+            MANIFEST_1_0_0,
+        );
+        assert!(
+            scan(root.path()).unwrap().is_empty(),
+            "workspace-inherited versions have no in-tree literal to drift"
+        );
+    }
+
+    #[test]
+    fn schema_only_package_without_cargo_toml_is_skipped() {
+        let root = TempDir::new().unwrap();
+        write_pkg(root.path(), "escalate", "", MANIFEST_1_0_0);
+        assert!(scan(root.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn fix_converges_and_is_idempotent() {
+        let root = TempDir::new().unwrap();
+        write_pkg(
+            root.path(),
+            "foo",
+            "# keep me\n[package]\nname = \"streamlib-foo\"\nversion = \"0.4.30\" # inline\nedition = \"2024\"\n\n[dependencies]\nserde = \"1.0\"\n",
+            MANIFEST_1_0_0,
+        );
+        run(root.path(), true).unwrap();
+        let cargo =
+            fs::read_to_string(root.path().join(PACKAGES_DIR).join("foo").join("Cargo.toml"))
+                .unwrap();
+        assert!(cargo.contains("version = \"1.0.0\""), "got: {cargo}");
+        assert!(cargo.contains("# keep me"), "comment preserved, got: {cargo}");
+        assert!(cargo.contains("[dependencies]"), "unrelated tables preserved");
+        assert!(scan(root.path()).unwrap().is_empty());
+        // Second --fix is a no-op (idempotent).
+        run(root.path(), true).unwrap();
+        assert!(scan(root.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn current_workspace_has_no_drift() {
+        // Smoke test: after the sweep, no real package drifts. Locks the
+        // sweep in place — a future package with a stale crate version fails
+        // here.
+        let workspace = workspace_root();
+        let drifts = scan(&workspace).unwrap();
+        assert!(
+            drifts.is_empty(),
+            "current workspace has package version drift: {drifts:?}"
+        );
+    }
+
+    fn workspace_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("xtask has a parent")
+            .to_path_buf()
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -21,6 +21,7 @@ pub mod check_no_escalate_in_lifecycle;
 pub mod check_no_inventory_submit;
 pub mod check_no_reverse_dns;
 pub mod check_no_streamlib_metadata;
+pub mod check_package_version_drift;
 pub mod check_processor_spec_new;
 pub mod check_schema_versions;
 pub mod lint_logging;
@@ -161,6 +162,19 @@ enum Commands {
     /// header, (3) every `streamlib.yaml` validates against the schema.
     CheckManifestSchema,
 
+    /// CI gate that every publishable package's `Cargo.toml`
+    /// `[package].version` matches its `streamlib.yaml` `package.version`
+    /// (the `.slpkg` semver — the single source of truth). Packages with no
+    /// `Cargo.toml` (schema-only) and workspace-inherited versions are
+    /// skipped. `--fix` rewrites each drifting `Cargo.toml` from its
+    /// `streamlib.yaml`, so the bump workflow is "edit streamlib.yaml, run
+    /// `--fix`" — never hand-edit `Cargo.toml`.
+    CheckPackageVersionDrift {
+        /// Rewrite each drifting `Cargo.toml` from its `streamlib.yaml`.
+        #[arg(long)]
+        fix: bool,
+    },
+
     /// Strip dev-time path-flavor `patch:` entries from a crate's
     /// `streamlib.yaml` so the published manifest is path-free. Intended to
     /// run against a scratch copy of the crate before `cargo publish` (cargo
@@ -220,6 +234,9 @@ fn main() -> Result<()> {
             check_consumer_rhi_repr::run(&workspace_root()?)?
         }
         Commands::CheckDeviceWaitIdle => check_device_wait_idle::run(&workspace_root()?)?,
+        Commands::CheckPackageVersionDrift { fix } => {
+            check_package_version_drift::run(&workspace_root()?, fix)?
+        }
         Commands::EmitManifestSchema => manifest_schema::emit(&workspace_root()?)?,
         Commands::CheckManifestSchema => manifest_schema::check(&workspace_root()?)?,
         Commands::StripPublishManifest { dir } => {


### PR DESCRIPTION
## Summary

Collapses the third, redundant version axis (#1217): a Rust package's `Cargo.toml` `[package].version` is now **derived from its `.slpkg` semver** (`streamlib.yaml`'s `package.version`) at pack time, so a stale in-tree crate version can never reach the registry through the artifact. A package author bumps one number — the `streamlib.yaml` package version — and the artifact carries the matching crate version.

## Design — pack-time stamp at the assemble seam

`streamlib pack` and the orchestrator's `StagedDir` load-time build both route through `streamlib_pack::assemble_artifact`, so **one insertion covers both targets**. When a package `has_rust` and its `Cargo.toml` carries a `[package].version`, the stamp rewrites that version to the `streamlib.yaml` `package.version` (prerelease carries through verbatim — `1.1.3-dev.4` is cargo-valid) using `toml_edit` for a format-preserving edit (comments and every other field untouched; `as_table_like_mut` also covers the inline `package = { version = … }` form). The stamped bytes are written first in `emit_slpkg` / `emit_staged_dir`; the emit dedup-by-archive-path then skips the verbatim source-tree copy. **In-tree files are never touched** — the stamp is artifact-only.

The rewrite itself is one public helper, `streamlib_pack::rewrite_cargo_package_version`, deliberately shared with the lint's `--fix` (xtask already deps streamlib-pack) so the stamp and the fix can never diverge in edit semantics.

- `version.workspace = true` → the version inheritance is replaced with the literal in the staged/packed copy. This branch is **defensive, not a standalone-build enabler**: packages/core never hits it (schema-only manifest, `has_rust` false, so its test-only Cargo.toml is never stamped), and a staged test-fixtures copy would still carry other dangling `*.workspace = true` keys (`edition`, `authors`, …) that the stamp deliberately doesn't touch. What the branch guarantees is narrower — the version field specifically can't survive as an unresolvable inheritance or a stale literal in any artifact the stamp produces.
- No `Cargo.toml` (schema-only, `@tatolab/escalate`) or no `[package].version` → no-op, ship verbatim.

## Drift lint — one-command sync, never hand-edit Cargo.toml

New `cargo xtask check-package-version-drift` (+ `--fix`) asserts every `packages/*/Cargo.toml` literal `[package].version` equals its `streamlib.yaml` `package.version`, skipping schema-only packages (no `Cargo.toml`) and workspace-inherited versions (no in-tree literal to drift; the pack stamp handles the artifact copy). The manifest version is parsed through `streamlib_idents::SemVer` and compared as its canonical Display string — exactly what the pack stamp writes — so a malformed 2-part/numeric YAML version fails the lint loudly instead of passing CI and failing at pack. `--fix` rewrites each drifting `Cargo.toml` to the canonical form via the shared `rewrite_cargo_package_version` helper. The bump workflow becomes: **edit `streamlib.yaml`, run `--fix`** (or let CI tell you — the failure message names the remedy). CI workflow modeled on `check-manifest-schema.yml`.

## One-time sweep — 18 packages jumped to their `.slpkg` semver

| jump | packages |
|---|---|
| `0.4.30 → 1.0.0` | api-server, audio, camera, clap, debug-utilities, display, frame-tap, h264, h265, moq, mp4, opus, screen-capture, webrtc |
| `0.4.35-dev.5 → 1.0.7` | jpeg |
| `0.4.30 → 1.1.4` | mavlink |
| `0.4.30 → 1.0.2` | network, vadr-vision |

No cross-package sibling **path** pins exist (siblings resolve by registry version, e.g. `streamlib-clap`'s `streamlib-audio = { version = "0.5.0", registry = "gitea" }`), and packages are standalone workspaces — so no build ordering breaks from the version jumps; a crate's own `[package].version` doesn't gate its build.

## Tests

- **Pack unit**: literal `0.4.30` → derived `1.1.3-dev.4`; `version.workspace = true` → literal; inline `package = { … }` table stamped; comments/unrelated fields preserved; no `[package].version` / no `Cargo.toml` → no-op.
- **Pack integration** (both targets): `slpkg_stamps_crate_version_from_manifest_semver` + `staged_dir_stamps_crate_version_from_manifest_semver` assemble a Rust package with in-tree `0.4.30` + manifest `1.1.3-dev.4`, read back the emitted `Cargo.toml`, assert the derived version is present and `0.4.30` is absent (mentally-revert bar: removing the stamp ships the verbatim `0.4.30` and fails). The `.slpkg` test also asserts exactly one `Cargo.toml` (dedup lock). `staged_dir_stamps_workspace_inherited_version_to_literal` locks the inherited→literal path through an emitted artifact.
- **Pack negative**: malformed `Cargo.toml` → typed error naming the file and the parse failure (StagedDir reaches the stamp parse first), never a panic.
- **Lint unit**: drift detected + named; `--fix` converges (second scan clean) + idempotent + preserves comments; workspace-inherited skipped; schema-only skipped; prerelease drift; malformed `Cargo.toml` → typed error; malformed manifest version (`1.0` YAML float) → loud error, not a silent skip; `current_workspace_has_no_drift` smoke test locks the sweep and its failure message names the `--fix` remedy.

### Validation

- `cargo check --workspace --offline` — clean.
- `cargo test -p streamlib-pack -p xtask --offline` — 32 + 185 green.
- `cargo test -p streamlib-build-orchestrator --offline` — 19 green (emit signature change kept StagedDir assembly intact).
- `cargo xtask check-package-version-drift` — passes post-sweep.
- `cargo doc -p streamlib-pack --no-deps` — one **pre-existing** warning (`is_non_source_artifact` → private `collect_source_tree`, untouched by this PR); no new warnings.

Sets up #1218 (release closure) which builds on this derive step.

Closes #1217

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wr1VLKMBbFpsmU7zAcniU2