### PR TITLE
feat(registry): consistent atomic release + partial-release detection

### DIFF
--- a/docker/build-stage1.sh
+++ b/docker/build-stage1.sh
@@ -140,23 +140,21 @@ export STREAMLIB_BIN="$SRC/target/release/streamlib"
 [ -x "$SRC/target/release/streamlib-runtime" ] || fail "streamlib-runtime not built"
 
 # ---------------------------------------------------------------------------
-# 8. Publish ALL internal library crates so the in-container registry matches
-#    the local build and every package can cargo-resolve any in-tree lib
-#    (e.g. api-server -> streamlib-moq). STREAMLIB_PUBLISH_ALL_LIBS widens
-#    publish-crates' closure from the SDK set to the full internal lib set
-#    (binaries + test fixtures excluded).
+# 8. Publish a CONSISTENT, ATOMIC release: the full crate closure (the single
+#    canonical release closure — every publishable streamlib* / vulkan-jpeg
+#    library crate, incl. the easy-to-skip streamlib-plugin-sdk + vulkan-jpeg,
+#    by definition — plus the subprocess native hosts), the polyglot SDKs, the
+#    packages, and finally the release manifest (the atomicity flip). The
+#    manifest marks the in-container registry as a complete release, so a
+#    consumer resolving against it detects a partial set up front. The
+#    SKIP_* guards below are honored by publish-release.sh.
 # ---------------------------------------------------------------------------
-log "publishing all internal library crates"
-( cd "$SRC" && STREAMLIB_PUBLISH_ALL_LIBS=1 ./scripts/gitea/publish-crates.sh )
-if [ "$SKIP_PYTHON_SDK" != 1 ]; then
-  log "publishing python SDK"; ( cd "$SRC" && ./scripts/gitea/publish-python-sdk.sh )
-else log "SKIP python SDK"; fi
-if [ "$SKIP_DENO_SDK" != 1 ]; then
-  log "publishing deno SDK"; ( cd "$SRC" && ./scripts/gitea/publish-deno-sdk.sh )
-else log "SKIP deno SDK"; fi
-if [ "$SKIP_PACKAGES" != 1 ]; then
-  log "publishing packages (.slpkg)"; ( cd "$SRC" && ./scripts/gitea/publish-packages.sh )
-else log "SKIP packages"; fi
+log "publishing consistent release (crates + SDKs + packages + manifest)"
+( cd "$SRC" \
+  && SKIP_PYTHON_SDK="$SKIP_PYTHON_SDK" \
+     SKIP_DENO_SDK="$SKIP_DENO_SDK" \
+     SKIP_PACKAGES="$SKIP_PACKAGES" \
+     ./scripts/gitea/publish-release.sh )
 
 # ---------------------------------------------------------------------------
 # 9. Assemble the /opt/streamlib app dir (binaries + package source + registry

--- a/libs/streamlib-build-orchestrator/Cargo.toml
+++ b/libs/streamlib-build-orchestrator/Cargo.toml
@@ -19,6 +19,7 @@ ureq = { workspace = true }
 streamlib-engine = { path = "../streamlib-engine", version = "0.5.0", registry = "gitea" }
 streamlib-cargo-build = { path = "../streamlib-cargo-build", version = "0.5.0", registry = "gitea" }
 streamlib-pack = { path = "../streamlib-pack", version = "0.5.0", registry = "gitea" }
+streamlib-idents = { path = "../streamlib-idents", version = "0.5.0", registry = "gitea" }
 streamlib-plugin-abi = { path = "../streamlib-plugin-abi", version = "0.5.0", registry = "gitea" }
 streamlib-jtd-codegen = { path = "../streamlib-jtd-codegen", version = "0.5.0", registry = "gitea" }
 

--- a/libs/streamlib-build-orchestrator/src/lib.rs
+++ b/libs/streamlib-build-orchestrator/src/lib.rs
@@ -894,4 +894,167 @@ mod tests {
             assert!(matches!(err, BuildError::UnsupportedSource(_)));
         }
     }
+
+    /// Point the registry env at a `file://` scratch dir for the duration of
+    /// `f`, restoring prior values after, and shielding the native-host env
+    /// override. SAFETY: callers are `#[serial]` — no other thread races the
+    /// process-global env.
+    fn with_scratch_registry<T>(dir: &Path, f: impl FnOnce() -> T) -> T {
+        let prev_url = std::env::var("STREAMLIB_REGISTRY_URL").ok();
+        let prev_gitea = std::env::var("GITEA_URL").ok();
+        let prev_py_lib = std::env::var("STREAMLIB_PYTHON_NATIVE_LIB").ok();
+        unsafe {
+            std::env::set_var("STREAMLIB_REGISTRY_URL", format!("file://{}", dir.display()));
+            std::env::remove_var("GITEA_URL");
+            std::env::remove_var("STREAMLIB_PYTHON_NATIVE_LIB");
+        }
+        let out = f();
+        unsafe {
+            match prev_url {
+                Some(v) => std::env::set_var("STREAMLIB_REGISTRY_URL", v),
+                None => std::env::remove_var("STREAMLIB_REGISTRY_URL"),
+            }
+            if let Some(v) = prev_gitea {
+                std::env::set_var("GITEA_URL", v);
+            }
+            if let Some(v) = prev_py_lib {
+                std::env::set_var("STREAMLIB_PYTHON_NATIVE_LIB", v);
+            }
+        }
+        out
+    }
+
+    /// Publish a PARTIAL release manifest (macros only — plugin-sdk absent)
+    /// at `version` into the scratch `file://` registry dir.
+    fn publish_partial_manifest(dir: &Path, version: &str) {
+        let cfg = streamlib_idents::RegistryConfig {
+            base_url: format!("file://{}", dir.display()),
+            token: None,
+        };
+        let manifest = streamlib_idents::ReleaseManifest::new(
+            version,
+            vec![streamlib_idents::ReleaseManifestMember::new(
+                "streamlib-macros",
+                version,
+            )],
+        );
+        streamlib_idents::RegistryClient::new(&cfg)
+            .upload_release_manifest("tatolab", &manifest)
+            .unwrap();
+    }
+
+    /// Rust-runtime source package whose Cargo.toml pins streamlib-plugin-sdk
+    /// from the gitea registry — the shape every published Rust package has.
+    fn rust_source_pkg(dir: &Path) {
+        std::fs::write(
+            dir.join("streamlib.yaml"),
+            r#"package:
+  org: tatolab
+  name: rust-source
+  version: 0.1.0
+processors:
+  - name: RustProc
+    version: 1.0.0
+    description: "rust processor fixture (never built - pre-check fires first)"
+    runtime: rust
+    execution: manual
+    inputs:
+      - name: in0
+        schema: any
+    outputs:
+      - name: out0
+        schema: any
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            r#"[package]
+name = "rust-source"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+streamlib-plugin-sdk = {version = "0.5.0", registry = "gitea"}
+"#,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn materialize_fails_fast_on_incomplete_release_before_cargo() {
+        // WIRING lock for the package path: `materialize` on a Rust package
+        // whose registry release is partial must surface IncompleteRelease
+        // BEFORE any cargo build runs. Mentally delete the
+        // `assert_release_complete` call in `materialize_package_dir` and
+        // this test fails (materialize would proceed into assemble/cargo and
+        // die on the unresolvable fixture crate instead).
+        let _home = HomeGuard::new();
+        let src = tempfile::tempdir().unwrap();
+        rust_source_pkg(src.path());
+        let registry = tempfile::tempdir().unwrap();
+        // Partial release ABOVE the pin's floor — production keying.
+        publish_partial_manifest(registry.path(), "0.5.1");
+
+        let orch = PolyglotBuildOrchestrator::default();
+        let req = BuildRequest {
+            package: pkg_ref("tatolab", "rust-source"),
+            source: BuildSource::PackageDir(src.path().to_path_buf()),
+            policy: BuildPolicy::IfStale,
+            host_triple: build::host_target_triple().to_string(),
+        };
+        let err = with_scratch_registry(registry.path(), || {
+            orch.materialize(&req, &NoopSink)
+                .expect_err("partial release must fail the materialize pre-check")
+        });
+        match err {
+            BuildError::IncompleteRelease { missing, release_version, .. } => {
+                assert_eq!(release_version, "0.5.1");
+                assert!(
+                    missing.contains("streamlib-plugin-sdk"),
+                    "must name the missing crate; got: {missing}"
+                );
+            }
+            other => panic!("expected IncompleteRelease from materialize, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn native_host_build_fails_fast_on_incomplete_release() {
+        // WIRING lock for the native-host path: `ensure_native_host` against
+        // a registry whose release manifest omits the host crate must surface
+        // IncompleteRelease before attempting the crate download. Mentally
+        // delete the `assert_release_complete` call in `ensure_native_host`
+        // and this fails differently (a download error against the file://
+        // URL) — the match arm below pins the typed error.
+        let _home = HomeGuard::new();
+        let registry = tempfile::tempdir().unwrap();
+        // Partial release at the exact requested host version, missing
+        // streamlib-python-native.
+        publish_partial_manifest(registry.path(), "0.5.1");
+
+        let err = with_scratch_registry(registry.path(), || {
+            native_host::ensure_native_host(
+                native_host::NativeRuntime::Python,
+                "0.5.1",
+                build::CargoProfile::Dev,
+            )
+            .expect_err("partial release must fail the native-host pre-check")
+        });
+        match err {
+            BuildError::IncompleteRelease { missing, release_version, .. } => {
+                assert_eq!(release_version, "0.5.1");
+                assert!(
+                    missing.contains("streamlib-python-native"),
+                    "must name the missing host crate; got: {missing}"
+                );
+            }
+            other => panic!("expected IncompleteRelease from ensure_native_host, got {other:?}"),
+        }
+    }
 }

--- a/libs/streamlib-build-orchestrator/src/lib.rs
+++ b/libs/streamlib-build-orchestrator/src/lib.rs
@@ -252,9 +252,7 @@ impl PolyglotBuildOrchestrator {
         if has_rust {
             let pins = build::read_gitea_registry_pins(pkg_dir)
                 .map_err(|e| other(&pkg_label, format!("reading gitea-registry pins: {e}")))?;
-            let required: Vec<(String, String)> =
-                pins.into_iter().map(|p| (p.name, p.version)).collect();
-            release_check::assert_release_complete(&pkg_label, &required)?;
+            release_check::assert_release_complete(&pkg_label, &pins)?;
         }
 
         // ---- Assemble + stage to the package cache ----

--- a/libs/streamlib-build-orchestrator/src/lib.rs
+++ b/libs/streamlib-build-orchestrator/src/lib.rs
@@ -38,6 +38,7 @@
 mod deno_codegen;
 mod native_host;
 mod python_venv;
+mod release_check;
 
 #[cfg(test)]
 mod test_support;
@@ -239,6 +240,21 @@ impl PolyglotBuildOrchestrator {
                     });
                 }
             }
+        }
+
+        // ---- Consumer-side release-completeness pre-check ----
+        // A Rust package resolves its gitea-registry deps via cargo below. If
+        // the configured registry holds a partial/mid-publish release of the
+        // pinned version, fail fast here naming the missing artifacts instead
+        // of surfacing it as a cryptic cargo `failed to select a version …`
+        // deep in the build. No-op for dev/path builds (no registry) and
+        // pre-atomic-release registries (no manifest) — see `release_check`.
+        if has_rust {
+            let pins = build::read_gitea_registry_pins(pkg_dir)
+                .map_err(|e| other(&pkg_label, format!("reading gitea-registry pins: {e}")))?;
+            let required: Vec<(String, String)> =
+                pins.into_iter().map(|p| (p.name, p.version)).collect();
+            release_check::assert_release_complete(&pkg_label, &required)?;
         }
 
         // ---- Assemble + stage to the package cache ----

--- a/libs/streamlib-build-orchestrator/src/native_host.rs
+++ b/libs/streamlib-build-orchestrator/src/native_host.rs
@@ -118,7 +118,11 @@ pub(crate) fn ensure_native_host(
     // for pre-atomic-release registries (no manifest) — see `release_check`.
     crate::release_check::assert_release_complete(
         runtime.crate_name(),
-        &[(runtime.crate_name().to_string(), version.to_string())],
+        &[streamlib_cargo_build::GiteaRegistryPin {
+            name: runtime.crate_name().to_string(),
+            req: format!("={version}"),
+            version: version.to_string(),
+        }],
     )?;
 
     tracing::info!(

--- a/libs/streamlib-build-orchestrator/src/native_host.rs
+++ b/libs/streamlib-build-orchestrator/src/native_host.rs
@@ -111,6 +111,16 @@ pub(crate) fn ensure_native_host(
         return Ok(dest);
     }
 
+    // Consumer-side release-completeness pre-check: the native host crate is
+    // itself a member of the engine release closure. If the registry holds a
+    // partial release of `version`, fail fast naming the gap instead of a
+    // cryptic cargo resolve error inside the standalone build below. No-op
+    // for pre-atomic-release registries (no manifest) — see `release_check`.
+    crate::release_check::assert_release_complete(
+        runtime.crate_name(),
+        &[(runtime.crate_name().to_string(), version.to_string())],
+    )?;
+
     tracing::info!(
         crate_name = runtime.crate_name(),
         %version,

--- a/libs/streamlib-build-orchestrator/src/release_check.rs
+++ b/libs/streamlib-build-orchestrator/src/release_check.rs
@@ -4,13 +4,21 @@
 //! Consumer-side release-completeness pre-check.
 //!
 //! Before a package's Rust build resolves its gitea-registry dependencies via
-//! cargo, this checks the registry's **release manifest** for the pinned
-//! version. A partial / mid-publish registry — the historical `0.4.36`
+//! cargo, this checks the registry's **release manifests** against the
+//! package's pins. A partial / mid-publish registry — the historical `0.4.36`
 //! `streamlib-plugin-sdk` + `vulkan-jpeg` foot-gun — fails fast here with a
 //! typed [`BuildError::IncompleteRelease`] naming the exact missing artifacts,
 //! instead of surfacing much later as a cryptic
 //! `failed to select a version for streamlib-plugin-sdk = ^0.5.1` deep in
 //! cargo / `streamlib-macros` version unification.
+//!
+//! Resolution is **range-aware**: consumer pins are floor reqs (`0.5.0`
+//! means `^0.5.0` per cargo) that typically lag the released version
+//! (`0.5.1`), so each pin is validated against the *newest listed release
+//! whose version satisfies the pin's range* — the release cargo's own
+//! max-satisfying-version resolution will predominantly land on. When no
+//! listed release satisfies (older exact pins, pre-index registries), the
+//! check falls back to fetching the manifest at the pin's floor version.
 //!
 //! The check is deliberately conservative — it only ever *adds* an
 //! actionable early failure for a provably-partial release. It is a no-op
@@ -18,16 +26,19 @@
 //!
 //! - no registry is configured (in-tree / dev builds resolve deps by `path`);
 //! - the package declares no gitea-registry pins;
-//! - the registry has no release manifest for a pinned version (a
-//!   pre-atomic-release registry — logged, then proceed); or
-//! - the manifest fetch hits a transient transport error (the real cargo
-//!   resolve remains the hard gate — a network blip must not manufacture a
-//!   build failure).
+//! - no release manifest covers a pin's range (a pre-atomic-release
+//!   registry — logged, then proceed); or
+//! - the manifest fetch / listing hits a transient transport error (the real
+//!   cargo resolve remains the hard gate — a network blip must not
+//!   manufacture a build failure).
 
 use std::collections::BTreeMap;
 
+use streamlib_cargo_build::GiteaRegistryPin;
 use streamlib_engine::core::runtime::BuildError;
-use streamlib_idents::{crates_missing_from_release, RegistryClient, RegistryConfig};
+use streamlib_idents::{
+    crates_missing_from_release, RegistryClient, RegistryConfig, SemVer, SemVerRange,
+};
 
 /// Registry org the release manifest lives under. Matches the publish
 /// scripts' `GITEA_ORG` default.
@@ -38,18 +49,30 @@ fn registry_org() -> String {
         .unwrap_or_else(|| "tatolab".to_string())
 }
 
+/// Map a raw cargo version req to a [`SemVerRange`]. Cargo's bare `0.5.0`
+/// means caret; explicit `^` / `~` / `>=` / `=` prefixes parse as-is.
+/// `None` for req shapes the range parser doesn't cover (multi-clause
+/// reqs) — those pins are skipped rather than misjudged.
+fn cargo_req_to_range(req: &str) -> Option<SemVerRange> {
+    let req = req.trim();
+    let normalized = if req.starts_with(['^', '~', '=', '>', '<', '*']) {
+        req.to_string()
+    } else {
+        // Bare version → caret, per cargo semantics.
+        format!("^{req}")
+    };
+    SemVerRange::from_str(&normalized).ok()
+}
+
 /// Fail fast with [`BuildError::IncompleteRelease`] when the configured
-/// registry holds a partial release for any of `required`'s pinned versions.
-///
-/// `required` is the consumer's direct gitea-registry pins as
-/// `(crate name, exact version)`. Grouped by version, each version's release
-/// manifest is fetched once; a pin absent from a *present* manifest is the
-/// gap. See the module docs for the no-op cases.
+/// registry's release manifests cannot satisfy the package's direct
+/// gitea-registry `pins`. See the module docs for the resolution model and
+/// the no-op cases.
 pub(crate) fn assert_release_complete(
     package_label: &str,
-    required: &[(String, String)],
+    pins: &[GiteaRegistryPin],
 ) -> Result<(), BuildError> {
-    if required.is_empty() {
+    if pins.is_empty() {
         return Ok(());
     }
     // No registry configured ⇒ deps resolve by path (dev / in-tree); nothing
@@ -60,33 +83,62 @@ pub(crate) fn assert_release_complete(
     let client = RegistryClient::new(&config);
     let org = registry_org();
 
-    // Group pins by their pinned version so each release manifest is fetched
-    // once. A coherent release shares one version across every engine pin;
-    // multiple versions here would itself be the skew this catches.
-    let mut by_version: BTreeMap<String, Vec<(String, String)>> = BTreeMap::new();
-    for (name, version) in required {
-        by_version
-            .entry(version.clone())
-            .or_default()
-            .push((name.clone(), version.clone()));
+    // Available releases (newest-satisfying selection below). A listing
+    // failure degrades to the exact-floor fallback per pin.
+    let releases: Vec<SemVer> = match client.list_release_versions(&org) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                package = %package_label,
+                error = %e,
+                "release-version listing failed — falling back to exact-pin manifest lookups"
+            );
+            Vec::new()
+        }
+    };
+
+    // Resolve each pin to the release manifest that should cover it, then
+    // group so each manifest is fetched once.
+    let mut by_release: BTreeMap<String, Vec<(String, SemVerRange)>> = BTreeMap::new();
+    for pin in pins {
+        let Some(range) = cargo_req_to_range(&pin.req) else {
+            tracing::warn!(
+                package = %package_label,
+                crate_name = %pin.name,
+                req = %pin.req,
+                "unsupported version-req shape — skipping release-completeness check for this pin"
+            );
+            continue;
+        };
+        // Newest listed release satisfying the pin's range — the release
+        // cargo's max-satisfying resolution will predominantly land on.
+        // Fall back to the pin's floor version (covers exact pins on
+        // registries whose release predates the listing index).
+        let target = releases
+            .iter()
+            .filter(|v| range.matches(**v))
+            .max()
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| pin.version.clone());
+        by_release.entry(target).or_default().push((pin.name.clone(), range));
     }
 
     let mut missing_all: Vec<String> = Vec::new();
     let mut incomplete_versions: Vec<String> = Vec::new();
-    for (version, pins) in &by_version {
-        match client.fetch_release_manifest(&org, version) {
+    for (release_version, required) in &by_release {
+        match client.fetch_release_manifest(&org, release_version) {
             Ok(Some(manifest)) => {
-                let missing = crates_missing_from_release(&manifest, pins);
+                let missing = crates_missing_from_release(&manifest, required);
                 if !missing.is_empty() {
-                    incomplete_versions.push(version.clone());
+                    incomplete_versions.push(release_version.clone());
                     missing_all.extend(missing);
                 }
             }
             Ok(None) => {
                 tracing::warn!(
                     package = %package_label,
-                    %version,
-                    "registry has no release manifest for {version} — pre-atomic-release \
+                    version = %release_version,
+                    "registry has no release manifest for {release_version} — pre-atomic-release \
                      registry; proceeding without completeness check (a partial release will \
                      surface as a cargo resolve error)"
                 );
@@ -96,7 +148,7 @@ pub(crate) fn assert_release_complete(
                 // failure — the cargo resolve that follows is the real gate.
                 tracing::warn!(
                     package = %package_label,
-                    %version,
+                    version = %release_version,
                     error = %e,
                     "release manifest fetch failed — skipping completeness check for this version"
                 );
@@ -127,12 +179,18 @@ mod tests {
     use super::*;
     use streamlib_idents::{ReleaseManifest, ReleaseManifestMember};
 
-    /// Serialize env mutation across the tests in this module — they set /
-    /// clear `STREAMLIB_REGISTRY_URL` process-wide.
+    fn pin(name: &str, req: &str) -> GiteaRegistryPin {
+        GiteaRegistryPin {
+            name: name.to_string(),
+            req: req.to_string(),
+            version: req.trim_start_matches(['=', '^', '~', '>', '<']).trim().to_string(),
+        }
+    }
+
+    /// Point the registry env at `dir` for the duration of `f`, restoring the
+    /// prior values after. SAFETY: callers are `#[serial]`, so no other
+    /// thread races these process-global env writes.
     fn with_file_registry<T>(dir: &std::path::Path, f: impl FnOnce() -> T) -> T {
-        // Snapshot + restore the registry env so tests don't leak into each
-        // other or the wider suite. SAFETY: callers are `#[serial]`, so no
-        // other thread races these process-global env writes.
         let prev_url = std::env::var("STREAMLIB_REGISTRY_URL").ok();
         let prev_fallback = std::env::var("GITEA_URL").ok();
         unsafe {
@@ -163,6 +221,14 @@ mod tests {
     }
 
     #[test]
+    fn cargo_req_mapping_bare_is_caret_and_operators_pass_through() {
+        assert_eq!(cargo_req_to_range("0.5.0"), SemVerRange::from_str("^0.5.0").ok());
+        assert_eq!(cargo_req_to_range("=0.4.36"), SemVerRange::from_str("=0.4.36").ok());
+        assert_eq!(cargo_req_to_range("^0.5.1"), SemVerRange::from_str("^0.5.1").ok());
+        assert_eq!(cargo_req_to_range(">=0.5.0"), SemVerRange::from_str(">=0.5.0").ok());
+    }
+
+    #[test]
     #[serial_test::serial]
     fn no_registry_configured_is_a_noop() {
         // Clear the env entirely; the check must pass vacuously (dev / path).
@@ -173,8 +239,8 @@ mod tests {
             std::env::remove_var("STREAMLIB_REGISTRY_URL");
             std::env::remove_var("GITEA_URL");
         }
-        let required = vec![("streamlib-plugin-sdk".to_string(), "0.5.1".to_string())];
-        assert!(assert_release_complete("pkg", &required).is_ok());
+        let pins = vec![pin("streamlib-plugin-sdk", "0.5.1")];
+        assert!(assert_release_complete("pkg", &pins).is_ok());
         unsafe {
             if let Some(v) = prev {
                 std::env::set_var("STREAMLIB_REGISTRY_URL", v);
@@ -187,56 +253,80 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn partial_release_fails_fast_naming_the_gap() {
+    fn floor_pin_resolves_against_newest_satisfying_release() {
+        // The production steady state: consumer pins floor `0.5.0` (bare =
+        // caret) while the registry's release is `0.5.1`. The check must key
+        // on the NEWEST satisfying release, not the pin's floor — mentally
+        // revert to exact-floor keying and the fetch at 0.5.0 finds nothing,
+        // the partial 0.5.1 release sails through, and this test fails.
         let tmp = tempfile::tempdir().unwrap();
-        // Manifest omits vulkan-jpeg + streamlib-plugin-sdk — the foot-gun.
-        let manifest = ReleaseManifest::new(
+        // Partial 0.5.1 release: macros present, plugin-sdk missing.
+        let partial = ReleaseManifest::new(
             "0.5.1",
             vec![ReleaseManifestMember::new("streamlib-macros", "0.5.1")],
         );
-        publish_manifest(tmp.path(), &manifest);
-        let required = vec![
-            ("streamlib-plugin-sdk".to_string(), "0.5.1".to_string()),
-            ("streamlib-macros".to_string(), "0.5.1".to_string()),
-            ("vulkan-jpeg".to_string(), "0.5.1".to_string()),
+        publish_manifest(tmp.path(), &partial);
+        let pins = vec![
+            pin("streamlib-plugin-sdk", "0.5.0"),
+            pin("streamlib-macros", "0.5.0"),
         ];
         let err = with_file_registry(tmp.path(), || {
-            assert_release_complete("streamlib-jpeg", &required).unwrap_err()
+            assert_release_complete("pkg", &pins).unwrap_err()
         });
         match err {
-            BuildError::IncompleteRelease {
-                release_version,
-                missing,
-                ..
-            } => {
+            BuildError::IncompleteRelease { release_version, missing, .. } => {
                 assert_eq!(release_version, "0.5.1");
-                assert!(missing.contains("streamlib-plugin-sdk@0.5.1"), "missing: {missing}");
-                assert!(missing.contains("vulkan-jpeg@0.5.1"), "missing: {missing}");
-                assert!(!missing.contains("streamlib-macros"), "macros is present: {missing}");
+                assert!(missing.contains("streamlib-plugin-sdk@^0.5.0"), "missing: {missing}");
+                assert!(!missing.contains("streamlib-macros"), "macros satisfied: {missing}");
             }
             other => panic!("expected IncompleteRelease, got {other:?}"),
         }
+
+        // Complete 0.5.1 release ⇒ the same floor pins pass.
+        let complete = ReleaseManifest::new(
+            "0.5.1",
+            vec![
+                ReleaseManifestMember::new("streamlib-macros", "0.5.1"),
+                ReleaseManifestMember::new("streamlib-plugin-sdk", "0.5.1"),
+            ],
+        );
+        publish_manifest(tmp.path(), &complete);
+        let out = with_file_registry(tmp.path(), || assert_release_complete("pkg", &pins));
+        assert!(out.is_ok(), "complete newest release must pass: {out:?}");
     }
 
     #[test]
     #[serial_test::serial]
-    fn complete_release_passes() {
+    fn exact_pin_checks_its_own_release() {
+        // An exact `=` pin (the jpeg-package shape) validates against the
+        // release at that exact version, not the newest one.
         let tmp = tempfile::tempdir().unwrap();
-        let manifest = ReleaseManifest::new(
+        let old = ReleaseManifest::new(
+            "0.4.36",
+            vec![ReleaseManifestMember::new("streamlib-macros", "0.4.36")],
+        );
+        let newest = ReleaseManifest::new(
             "0.5.1",
             vec![
-                ReleaseManifestMember::new("streamlib-plugin-sdk", "0.5.1"),
                 ReleaseManifestMember::new("streamlib-macros", "0.5.1"),
-                ReleaseManifestMember::new("vulkan-jpeg", "0.5.1"),
+                ReleaseManifestMember::new("streamlib-plugin-sdk", "0.5.1"),
             ],
         );
-        publish_manifest(tmp.path(), &manifest);
-        let required = vec![
-            ("streamlib-plugin-sdk".to_string(), "0.5.1".to_string()),
-            ("vulkan-jpeg".to_string(), "0.5.1".to_string()),
-        ];
-        let out = with_file_registry(tmp.path(), || assert_release_complete("pkg", &required));
-        assert!(out.is_ok(), "complete release must pass: {out:?}");
+        publish_manifest(tmp.path(), &old);
+        publish_manifest(tmp.path(), &newest);
+        // plugin-sdk pinned exactly at 0.4.36 — absent from the 0.4.36
+        // release even though the newest release carries it.
+        let pins = vec![pin("streamlib-plugin-sdk", "=0.4.36")];
+        let err = with_file_registry(tmp.path(), || {
+            assert_release_complete("streamlib-jpeg", &pins).unwrap_err()
+        });
+        match err {
+            BuildError::IncompleteRelease { release_version, missing, .. } => {
+                assert_eq!(release_version, "0.4.36");
+                assert!(missing.contains("streamlib-plugin-sdk@=0.4.36"), "missing: {missing}");
+            }
+            other => panic!("expected IncompleteRelease, got {other:?}"),
+        }
     }
 
     #[test]
@@ -245,9 +335,12 @@ mod tests {
         // The live #1213 failure class, hermetically: the real
         // packages/mavlink Cargo.toml pins streamlib-plugin-sdk from the gitea
         // registry — the exact crate the 0.4.36 partial publish silently
-        // skipped. Against a registry whose manifest OMITS plugin-sdk (a
-        // partial release that "looks complete"), the pre-check must fast-fail
-        // naming plugin-sdk; against a COMPLETE manifest it resolves clean.
+        // skipped. Against a registry whose newest release manifest OMITS
+        // plugin-sdk (a partial release that "looks complete"), the pre-check
+        // must fast-fail naming plugin-sdk; against a COMPLETE manifest it
+        // resolves clean. The manifest is deliberately published at a HIGHER
+        // patch than the pins' floor, mirroring the real tree (pins 0.5.0,
+        // release 0.5.1).
         let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .and_then(|p| p.parent())
@@ -262,58 +355,49 @@ mod tests {
             "packages/mavlink must pin streamlib-plugin-sdk from gitea (the #1213 crate); \
              got {pins:?}"
         );
-        // All engine pins share the release version in a coherent release.
-        let version = pins
+        let floor: SemVer = pins
             .iter()
             .find(|p| p.name == "streamlib-plugin-sdk")
-            .map(|p| p.version.clone())
-            .unwrap();
-        let required: Vec<(String, String)> =
-            pins.iter().map(|p| (p.name.clone(), p.version.clone())).collect();
+            .and_then(|p| p.version.parse().ok())
+            .expect("plugin-sdk floor version parses");
+        // Release at floor + one patch — the version cargo would resolve the
+        // caret floor pins up to.
+        let release_version = SemVer::new(floor.major, floor.minor, floor.patch + 1).to_string();
 
         let tmp = tempfile::tempdir().unwrap();
-        let cfg = RegistryConfig {
-            base_url: format!("file://{}", tmp.path().display()),
-            token: None,
-        };
 
-        // Partial manifest: every mavlink pin EXCEPT plugin-sdk.
-        let partial_members: Vec<ReleaseManifestMember> = required
+        // Partial release: every mavlink pin EXCEPT plugin-sdk.
+        let partial_members: Vec<ReleaseManifestMember> = pins
             .iter()
-            .filter(|(name, _)| name != "streamlib-plugin-sdk")
-            .map(|(n, v)| ReleaseManifestMember::new(n.clone(), v.clone()))
+            .filter(|p| p.name != "streamlib-plugin-sdk")
+            .map(|p| ReleaseManifestMember::new(p.name.clone(), release_version.clone()))
             .collect();
-        let partial = ReleaseManifest::new(version.clone(), partial_members);
-        RegistryClient::new(&cfg)
-            .upload_release_manifest("tatolab", &partial)
-            .unwrap();
+        let partial = ReleaseManifest::new(release_version.clone(), partial_members);
+        publish_manifest(tmp.path(), &partial);
 
         let err = with_file_registry(tmp.path(), || {
-            assert_release_complete("@tatolab/mavlink", &required).unwrap_err()
+            assert_release_complete("@tatolab/mavlink", &pins).unwrap_err()
         });
         match err {
             BuildError::IncompleteRelease { missing, .. } => {
                 assert!(
-                    missing.contains(&format!("streamlib-plugin-sdk@{version}")),
+                    missing.contains("streamlib-plugin-sdk@"),
                     "the #1213 gap (streamlib-plugin-sdk) must be named; got: {missing}"
                 );
             }
             other => panic!("expected IncompleteRelease naming plugin-sdk, got {other:?}"),
         }
 
-        // Complete manifest: now includes plugin-sdk ⇒ clean resolve.
+        // Complete release ⇒ clean resolve.
         let complete = ReleaseManifest::new(
-            version.clone(),
-            required
-                .iter()
-                .map(|(n, v)| ReleaseManifestMember::new(n.clone(), v.clone()))
+            release_version.clone(),
+            pins.iter()
+                .map(|p| ReleaseManifestMember::new(p.name.clone(), release_version.clone()))
                 .collect(),
         );
-        RegistryClient::new(&cfg)
-            .upload_release_manifest("tatolab", &complete)
-            .unwrap();
+        publish_manifest(tmp.path(), &complete);
         let out = with_file_registry(tmp.path(), || {
-            assert_release_complete("@tatolab/mavlink", &required)
+            assert_release_complete("@tatolab/mavlink", &pins)
         });
         assert!(out.is_ok(), "a complete release must resolve clean: {out:?}");
     }
@@ -321,12 +405,12 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn absent_manifest_proceeds_back_compat() {
-        // No manifest published for the pinned version ⇒ pre-atomic-release
-        // registry ⇒ warn + proceed (Ok). Mentally revert the Ok(None) arm to
-        // an error and this would wrongly block every pre-#1218 registry.
+        // No release manifest anywhere ⇒ pre-atomic-release registry ⇒ warn +
+        // proceed (Ok). Mentally revert the Ok(None) arm to an error and this
+        // would wrongly block every pre-atomic-release registry.
         let tmp = tempfile::tempdir().unwrap();
-        let required = vec![("streamlib-plugin-sdk".to_string(), "0.5.1".to_string())];
-        let out = with_file_registry(tmp.path(), || assert_release_complete("pkg", &required));
+        let pins = vec![pin("streamlib-plugin-sdk", "0.5.1")];
+        let out = with_file_registry(tmp.path(), || assert_release_complete("pkg", &pins));
         assert!(out.is_ok(), "absent manifest must proceed (back-compat): {out:?}");
     }
 }

--- a/libs/streamlib-build-orchestrator/src/release_check.rs
+++ b/libs/streamlib-build-orchestrator/src/release_check.rs
@@ -404,6 +404,97 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn unreachable_registry_degrades_to_proceed() {
+        // The module-doc promise: a network blip must not manufacture a
+        // build failure. Point the registry at a connection-refused endpoint
+        // — both the release listing and the fallback manifest fetch error,
+        // and the check must degrade to Ok (cargo remains the hard gate).
+        // Mentally revert the Err arms to hard failures and this fails.
+        // SAFETY: `#[serial]` — no other thread races these env writes.
+        let prev_url = std::env::var("STREAMLIB_REGISTRY_URL").ok();
+        let prev_g = std::env::var("GITEA_URL").ok();
+        unsafe {
+            std::env::set_var("STREAMLIB_REGISTRY_URL", "http://127.0.0.1:1");
+            std::env::remove_var("GITEA_URL");
+        }
+        let pins = vec![pin("streamlib-plugin-sdk", "0.5.0")];
+        let out = assert_release_complete("pkg", &pins);
+        unsafe {
+            match prev_url {
+                Some(v) => std::env::set_var("STREAMLIB_REGISTRY_URL", v),
+                None => std::env::remove_var("STREAMLIB_REGISTRY_URL"),
+            }
+            if let Some(v) = prev_g {
+                std::env::set_var("GITEA_URL", v);
+            }
+        }
+        assert!(out.is_ok(), "transport errors must degrade to proceed: {out:?}");
+    }
+
+    #[test]
+    fn incomplete_release_error_renders_version_missing_and_hint() {
+        // The error string is the user-facing artifact — it must carry the
+        // release version, every missing name@req, and the actionable hint.
+        let err = BuildError::IncompleteRelease {
+            package: "@tatolab/mavlink".to_string(),
+            release_version: "0.5.1".to_string(),
+            missing: "streamlib-plugin-sdk@^0.5.0, vulkan-jpeg@^0.5.0".to_string(),
+            hint: "re-run the release publish (scripts/gitea/publish-release.sh)".to_string(),
+        };
+        let rendered = err.to_string();
+        assert!(rendered.contains("incomplete release of 0.5.1"), "{rendered}");
+        assert!(rendered.contains("streamlib-plugin-sdk@^0.5.0"), "{rendered}");
+        assert!(rendered.contains("vulkan-jpeg@^0.5.0"), "{rendered}");
+        assert!(rendered.contains("@tatolab/mavlink"), "{rendered}");
+        assert!(rendered.contains("publish-release.sh"), "{rendered}");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn prerelease_pin_keys_against_dev_release_manifest() {
+        // The -dev.N prerelease train interacting with the gate: a
+        // prerelease floor pin (bare `0.5.1-dev.3` = caret per cargo) must
+        // key against the newest same-core dev release at-or-above it, per
+        // the npm prerelease policy SemVerRange carries. Partial dev release
+        // ⇒ typed fast-fail; complete ⇒ clean.
+        let tmp = tempfile::tempdir().unwrap();
+        let partial = ReleaseManifest::new(
+            "0.5.1-dev.5",
+            vec![ReleaseManifestMember::new("streamlib-macros", "0.5.1-dev.5")],
+        );
+        publish_manifest(tmp.path(), &partial);
+        let pins = vec![
+            pin("streamlib-plugin-sdk", "0.5.1-dev.3"),
+            pin("streamlib-macros", "0.5.1-dev.3"),
+        ];
+        let err = with_file_registry(tmp.path(), || {
+            assert_release_complete("pkg", &pins).unwrap_err()
+        });
+        match err {
+            BuildError::IncompleteRelease { release_version, missing, .. } => {
+                assert_eq!(release_version, "0.5.1-dev.5");
+                assert!(
+                    missing.contains("streamlib-plugin-sdk@^0.5.1-dev.3"),
+                    "missing: {missing}"
+                );
+            }
+            other => panic!("expected IncompleteRelease, got {other:?}"),
+        }
+
+        let complete = ReleaseManifest::new(
+            "0.5.1-dev.5",
+            vec![
+                ReleaseManifestMember::new("streamlib-macros", "0.5.1-dev.5"),
+                ReleaseManifestMember::new("streamlib-plugin-sdk", "0.5.1-dev.5"),
+            ],
+        );
+        publish_manifest(tmp.path(), &complete);
+        let out = with_file_registry(tmp.path(), || assert_release_complete("pkg", &pins));
+        assert!(out.is_ok(), "complete dev release must pass: {out:?}");
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn absent_manifest_proceeds_back_compat() {
         // No release manifest anywhere ⇒ pre-atomic-release registry ⇒ warn +
         // proceed (Ok). Mentally revert the Ok(None) arm to an error and this

--- a/libs/streamlib-build-orchestrator/src/release_check.rs
+++ b/libs/streamlib-build-orchestrator/src/release_check.rs
@@ -1,0 +1,332 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Consumer-side release-completeness pre-check.
+//!
+//! Before a package's Rust build resolves its gitea-registry dependencies via
+//! cargo, this checks the registry's **release manifest** for the pinned
+//! version. A partial / mid-publish registry — the historical `0.4.36`
+//! `streamlib-plugin-sdk` + `vulkan-jpeg` foot-gun — fails fast here with a
+//! typed [`BuildError::IncompleteRelease`] naming the exact missing artifacts,
+//! instead of surfacing much later as a cryptic
+//! `failed to select a version for streamlib-plugin-sdk = ^0.5.1` deep in
+//! cargo / `streamlib-macros` version unification.
+//!
+//! The check is deliberately conservative — it only ever *adds* an
+//! actionable early failure for a provably-partial release. It is a no-op
+//! (build proceeds) when:
+//!
+//! - no registry is configured (in-tree / dev builds resolve deps by `path`);
+//! - the package declares no gitea-registry pins;
+//! - the registry has no release manifest for a pinned version (a
+//!   pre-atomic-release registry — logged, then proceed); or
+//! - the manifest fetch hits a transient transport error (the real cargo
+//!   resolve remains the hard gate — a network blip must not manufacture a
+//!   build failure).
+
+use std::collections::BTreeMap;
+
+use streamlib_engine::core::runtime::BuildError;
+use streamlib_idents::{crates_missing_from_release, RegistryClient, RegistryConfig};
+
+/// Registry org the release manifest lives under. Matches the publish
+/// scripts' `GITEA_ORG` default.
+fn registry_org() -> String {
+    std::env::var("GITEA_ORG")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "tatolab".to_string())
+}
+
+/// Fail fast with [`BuildError::IncompleteRelease`] when the configured
+/// registry holds a partial release for any of `required`'s pinned versions.
+///
+/// `required` is the consumer's direct gitea-registry pins as
+/// `(crate name, exact version)`. Grouped by version, each version's release
+/// manifest is fetched once; a pin absent from a *present* manifest is the
+/// gap. See the module docs for the no-op cases.
+pub(crate) fn assert_release_complete(
+    package_label: &str,
+    required: &[(String, String)],
+) -> Result<(), BuildError> {
+    if required.is_empty() {
+        return Ok(());
+    }
+    // No registry configured ⇒ deps resolve by path (dev / in-tree); nothing
+    // to validate against.
+    let Some(config) = RegistryConfig::from_env() else {
+        return Ok(());
+    };
+    let client = RegistryClient::new(&config);
+    let org = registry_org();
+
+    // Group pins by their pinned version so each release manifest is fetched
+    // once. A coherent release shares one version across every engine pin;
+    // multiple versions here would itself be the skew this catches.
+    let mut by_version: BTreeMap<String, Vec<(String, String)>> = BTreeMap::new();
+    for (name, version) in required {
+        by_version
+            .entry(version.clone())
+            .or_default()
+            .push((name.clone(), version.clone()));
+    }
+
+    let mut missing_all: Vec<String> = Vec::new();
+    let mut incomplete_versions: Vec<String> = Vec::new();
+    for (version, pins) in &by_version {
+        match client.fetch_release_manifest(&org, version) {
+            Ok(Some(manifest)) => {
+                let missing = crates_missing_from_release(&manifest, pins);
+                if !missing.is_empty() {
+                    incomplete_versions.push(version.clone());
+                    missing_all.extend(missing);
+                }
+            }
+            Ok(None) => {
+                tracing::warn!(
+                    package = %package_label,
+                    %version,
+                    "registry has no release manifest for {version} — pre-atomic-release \
+                     registry; proceeding without completeness check (a partial release will \
+                     surface as a cargo resolve error)"
+                );
+            }
+            Err(e) => {
+                // A transient fetch failure must not turn into a hard build
+                // failure — the cargo resolve that follows is the real gate.
+                tracing::warn!(
+                    package = %package_label,
+                    %version,
+                    error = %e,
+                    "release manifest fetch failed — skipping completeness check for this version"
+                );
+            }
+        }
+    }
+
+    if missing_all.is_empty() {
+        return Ok(());
+    }
+    missing_all.sort();
+    missing_all.dedup();
+    incomplete_versions.sort();
+    incomplete_versions.dedup();
+    Err(BuildError::IncompleteRelease {
+        package: package_label.to_string(),
+        release_version: incomplete_versions.join(", "),
+        missing: missing_all.join(", "),
+        hint: "the registry has a partial or inconsistent release — re-run the release publish \
+               (scripts/gitea/publish-release.sh) so the full closure lands, or pin a version \
+               whose release manifest lists every dependency"
+            .to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use streamlib_idents::{ReleaseManifest, ReleaseManifestMember};
+
+    /// Serialize env mutation across the tests in this module — they set /
+    /// clear `STREAMLIB_REGISTRY_URL` process-wide.
+    fn with_file_registry<T>(dir: &std::path::Path, f: impl FnOnce() -> T) -> T {
+        // Snapshot + restore the registry env so tests don't leak into each
+        // other or the wider suite. SAFETY: callers are `#[serial]`, so no
+        // other thread races these process-global env writes.
+        let prev_url = std::env::var("STREAMLIB_REGISTRY_URL").ok();
+        let prev_fallback = std::env::var("GITEA_URL").ok();
+        unsafe {
+            std::env::set_var("STREAMLIB_REGISTRY_URL", format!("file://{}", dir.display()));
+            std::env::remove_var("GITEA_URL");
+        }
+        let out = f();
+        unsafe {
+            match prev_url {
+                Some(v) => std::env::set_var("STREAMLIB_REGISTRY_URL", v),
+                None => std::env::remove_var("STREAMLIB_REGISTRY_URL"),
+            }
+            if let Some(v) = prev_fallback {
+                std::env::set_var("GITEA_URL", v);
+            }
+        }
+        out
+    }
+
+    fn publish_manifest(dir: &std::path::Path, m: &ReleaseManifest) {
+        let cfg = RegistryConfig {
+            base_url: format!("file://{}", dir.display()),
+            token: None,
+        };
+        RegistryClient::new(&cfg)
+            .upload_release_manifest("tatolab", m)
+            .unwrap();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn no_registry_configured_is_a_noop() {
+        // Clear the env entirely; the check must pass vacuously (dev / path).
+        // SAFETY: `#[serial]` — no other thread races these env writes.
+        let prev = std::env::var("STREAMLIB_REGISTRY_URL").ok();
+        let prev_g = std::env::var("GITEA_URL").ok();
+        unsafe {
+            std::env::remove_var("STREAMLIB_REGISTRY_URL");
+            std::env::remove_var("GITEA_URL");
+        }
+        let required = vec![("streamlib-plugin-sdk".to_string(), "0.5.1".to_string())];
+        assert!(assert_release_complete("pkg", &required).is_ok());
+        unsafe {
+            if let Some(v) = prev {
+                std::env::set_var("STREAMLIB_REGISTRY_URL", v);
+            }
+            if let Some(v) = prev_g {
+                std::env::set_var("GITEA_URL", v);
+            }
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn partial_release_fails_fast_naming_the_gap() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Manifest omits vulkan-jpeg + streamlib-plugin-sdk — the foot-gun.
+        let manifest = ReleaseManifest::new(
+            "0.5.1",
+            vec![ReleaseManifestMember::new("streamlib-macros", "0.5.1")],
+        );
+        publish_manifest(tmp.path(), &manifest);
+        let required = vec![
+            ("streamlib-plugin-sdk".to_string(), "0.5.1".to_string()),
+            ("streamlib-macros".to_string(), "0.5.1".to_string()),
+            ("vulkan-jpeg".to_string(), "0.5.1".to_string()),
+        ];
+        let err = with_file_registry(tmp.path(), || {
+            assert_release_complete("streamlib-jpeg", &required).unwrap_err()
+        });
+        match err {
+            BuildError::IncompleteRelease {
+                release_version,
+                missing,
+                ..
+            } => {
+                assert_eq!(release_version, "0.5.1");
+                assert!(missing.contains("streamlib-plugin-sdk@0.5.1"), "missing: {missing}");
+                assert!(missing.contains("vulkan-jpeg@0.5.1"), "missing: {missing}");
+                assert!(!missing.contains("streamlib-macros"), "macros is present: {missing}");
+            }
+            other => panic!("expected IncompleteRelease, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn complete_release_passes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = ReleaseManifest::new(
+            "0.5.1",
+            vec![
+                ReleaseManifestMember::new("streamlib-plugin-sdk", "0.5.1"),
+                ReleaseManifestMember::new("streamlib-macros", "0.5.1"),
+                ReleaseManifestMember::new("vulkan-jpeg", "0.5.1"),
+            ],
+        );
+        publish_manifest(tmp.path(), &manifest);
+        let required = vec![
+            ("streamlib-plugin-sdk".to_string(), "0.5.1".to_string()),
+            ("vulkan-jpeg".to_string(), "0.5.1".to_string()),
+        ];
+        let out = with_file_registry(tmp.path(), || assert_release_complete("pkg", &required));
+        assert!(out.is_ok(), "complete release must pass: {out:?}");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn mavlink_1213_scenario_against_file_registry() {
+        // The live #1213 failure class, hermetically: the real
+        // packages/mavlink Cargo.toml pins streamlib-plugin-sdk from the gitea
+        // registry — the exact crate the 0.4.36 partial publish silently
+        // skipped. Against a registry whose manifest OMITS plugin-sdk (a
+        // partial release that "looks complete"), the pre-check must fast-fail
+        // naming plugin-sdk; against a COMPLETE manifest it resolves clean.
+        let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("workspace root two levels above the orchestrator crate")
+            .to_path_buf();
+        let mavlink_dir = workspace_root.join("packages").join("mavlink");
+
+        let pins = streamlib_cargo_build::read_gitea_registry_pins(&mavlink_dir)
+            .expect("read mavlink gitea pins");
+        assert!(
+            pins.iter().any(|p| p.name == "streamlib-plugin-sdk"),
+            "packages/mavlink must pin streamlib-plugin-sdk from gitea (the #1213 crate); \
+             got {pins:?}"
+        );
+        // All engine pins share the release version in a coherent release.
+        let version = pins
+            .iter()
+            .find(|p| p.name == "streamlib-plugin-sdk")
+            .map(|p| p.version.clone())
+            .unwrap();
+        let required: Vec<(String, String)> =
+            pins.iter().map(|p| (p.name.clone(), p.version.clone())).collect();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = RegistryConfig {
+            base_url: format!("file://{}", tmp.path().display()),
+            token: None,
+        };
+
+        // Partial manifest: every mavlink pin EXCEPT plugin-sdk.
+        let partial_members: Vec<ReleaseManifestMember> = required
+            .iter()
+            .filter(|(name, _)| name != "streamlib-plugin-sdk")
+            .map(|(n, v)| ReleaseManifestMember::new(n.clone(), v.clone()))
+            .collect();
+        let partial = ReleaseManifest::new(version.clone(), partial_members);
+        RegistryClient::new(&cfg)
+            .upload_release_manifest("tatolab", &partial)
+            .unwrap();
+
+        let err = with_file_registry(tmp.path(), || {
+            assert_release_complete("@tatolab/mavlink", &required).unwrap_err()
+        });
+        match err {
+            BuildError::IncompleteRelease { missing, .. } => {
+                assert!(
+                    missing.contains(&format!("streamlib-plugin-sdk@{version}")),
+                    "the #1213 gap (streamlib-plugin-sdk) must be named; got: {missing}"
+                );
+            }
+            other => panic!("expected IncompleteRelease naming plugin-sdk, got {other:?}"),
+        }
+
+        // Complete manifest: now includes plugin-sdk ⇒ clean resolve.
+        let complete = ReleaseManifest::new(
+            version.clone(),
+            required
+                .iter()
+                .map(|(n, v)| ReleaseManifestMember::new(n.clone(), v.clone()))
+                .collect(),
+        );
+        RegistryClient::new(&cfg)
+            .upload_release_manifest("tatolab", &complete)
+            .unwrap();
+        let out = with_file_registry(tmp.path(), || {
+            assert_release_complete("@tatolab/mavlink", &required)
+        });
+        assert!(out.is_ok(), "a complete release must resolve clean: {out:?}");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn absent_manifest_proceeds_back_compat() {
+        // No manifest published for the pinned version ⇒ pre-atomic-release
+        // registry ⇒ warn + proceed (Ok). Mentally revert the Ok(None) arm to
+        // an error and this would wrongly block every pre-#1218 registry.
+        let tmp = tempfile::tempdir().unwrap();
+        let required = vec![("streamlib-plugin-sdk".to_string(), "0.5.1".to_string())];
+        let out = with_file_registry(tmp.path(), || assert_release_complete("pkg", &required));
+        assert!(out.is_ok(), "absent manifest must proceed (back-compat): {out:?}");
+    }
+}

--- a/libs/streamlib-cargo-build/src/lib.rs
+++ b/libs/streamlib-cargo-build/src/lib.rs
@@ -94,6 +94,93 @@ pub fn read_cargo_package_name(package_dir: &Path) -> Result<String> {
     Ok(name.to_string())
 }
 
+/// A direct gitea-registry cargo dependency pin: the crate `name` and the
+/// concrete `version` its manifest floor-pins it at (leading range operators
+/// `=` / `^` / `~` / `>=` stripped). The unit the release-completeness check
+/// validates against a release manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GiteaRegistryPin {
+    pub name: String,
+    pub version: String,
+}
+
+/// Strip a cargo version-req's leading range operator, yielding the concrete
+/// floor version string (`=0.5.0` / `^0.5.0` / `>=0.5.0` → `0.5.0`).
+fn strip_version_req_operator(req: &str) -> String {
+    req.trim()
+        .trim_start_matches(['=', '^', '~', '>', '<'])
+        .trim()
+        .to_string()
+}
+
+/// Collect gitea-registry pins from one `[dependencies]`-shaped table into
+/// `out`. The dep key is the crate name unless a `package = "..."` rename
+/// overrides it.
+fn collect_gitea_pins_from_table(table: &toml::value::Table, out: &mut Vec<GiteaRegistryPin>) {
+    for (key, value) in table {
+        let Some(dep) = value.as_table() else {
+            continue;
+        };
+        let is_gitea = dep.get("registry").and_then(|r| r.as_str()) == Some("gitea");
+        if !is_gitea {
+            continue;
+        }
+        let Some(version) = dep.get("version").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let name = dep
+            .get("package")
+            .and_then(|p| p.as_str())
+            .unwrap_or(key.as_str())
+            .to_string();
+        out.push(GiteaRegistryPin {
+            name,
+            version: strip_version_req_operator(version),
+        });
+    }
+}
+
+/// Read a package's **direct** gitea-registry cargo dependency pins from its
+/// `Cargo.toml` — every `[dependencies]` / `[build-dependencies]` /
+/// `[target.*.dependencies]` / `[target.*.build-dependencies]` entry declaring
+/// `registry = "gitea"`. `dev-dependencies` are excluded (they don't
+/// participate in the release closure).
+///
+/// Returns `(name, floor-version)` pairs. `Ok(vec![])` when the package has no
+/// `Cargo.toml` (schema-only package) — the check simply has nothing to
+/// validate in that case.
+pub fn read_gitea_registry_pins(package_dir: &Path) -> Result<Vec<GiteaRegistryPin>> {
+    let cargo_toml_path = package_dir.join("Cargo.toml");
+    if !cargo_toml_path.exists() {
+        return Ok(Vec::new());
+    }
+    let body = std::fs::read_to_string(&cargo_toml_path)
+        .with_context(|| format!("Failed to read {}", cargo_toml_path.display()))?;
+    let parsed: toml::Value = toml::from_str(&body)
+        .with_context(|| format!("Failed to parse {}", cargo_toml_path.display()))?;
+
+    let mut pins = Vec::new();
+    for section in ["dependencies", "build-dependencies"] {
+        if let Some(table) = parsed.get(section).and_then(|v| v.as_table()) {
+            collect_gitea_pins_from_table(table, &mut pins);
+        }
+    }
+    // `[target.'cfg(...)'.{dependencies,build-dependencies}]`.
+    if let Some(targets) = parsed.get("target").and_then(|v| v.as_table()) {
+        for cfg_tbl in targets.values() {
+            let Some(cfg_tbl) = cfg_tbl.as_table() else {
+                continue;
+            };
+            for section in ["dependencies", "build-dependencies"] {
+                if let Some(table) = cfg_tbl.get(section).and_then(|v| v.as_table()) {
+                    collect_gitea_pins_from_table(table, &mut pins);
+                }
+            }
+        }
+    }
+    Ok(pins)
+}
+
 /// Cargo build profile selector for [`run_cargo_build`].
 ///
 /// `Release` is the production-distribution shape (`streamlib pack`
@@ -405,6 +492,64 @@ crate-type = ["cdylib"]
         let dylib_only = collect_host_dylibs_in_lib(&lib, "dylib").unwrap();
         assert_eq!(dylib_only.len(), 1);
         assert!(dylib_only[0].ends_with("libfoo.dylib"));
+    }
+
+    #[test]
+    fn read_gitea_registry_pins_collects_direct_pins_and_strips_operators() {
+        // Mixed dep table: gitea pins (with `=` / bare / cfg-target /
+        // build-dep / renamed) must be collected with operators stripped;
+        // non-gitea deps (serde) and dev-deps must be excluded. Reverting the
+        // `registry == "gitea"` filter would slurp serde; reverting the
+        // operator strip would leave `=` on the version and mismatch the
+        // manifest's stamped string.
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            r#"
+[package]
+name = "streamlib-jpeg"
+version = "1.0.7"
+
+[build-dependencies]
+streamlib-jtd-codegen = {version = "=0.5.1", registry = "gitea"}
+
+[dependencies]
+streamlib-plugin-sdk = {version = "0.5.1", registry = "gitea"}
+streamlib-macros = {version = "^0.5.1", registry = "gitea"}
+serde = {version = "1.0", features = ["derive"]}
+renamed-dep = {version = "=0.5.1", registry = "gitea", package = "streamlib-plugin-abi"}
+
+[dev-dependencies]
+streamlib-test-fixtures = {version = "0.5.1", registry = "gitea"}
+
+[target.'cfg(target_os = "linux")'.dependencies]
+vulkan-jpeg = {version = ">=0.5.1", registry = "gitea"}
+"#,
+        )
+        .unwrap();
+
+        let mut pins = read_gitea_registry_pins(dir.path()).unwrap();
+        pins.sort_by(|a, b| a.name.cmp(&b.name));
+        let got: Vec<(String, String)> =
+            pins.into_iter().map(|p| (p.name, p.version)).collect();
+        assert_eq!(
+            got,
+            vec![
+                ("streamlib-jtd-codegen".to_string(), "0.5.1".to_string()),
+                ("streamlib-macros".to_string(), "0.5.1".to_string()),
+                ("streamlib-plugin-abi".to_string(), "0.5.1".to_string()), // renamed
+                ("streamlib-plugin-sdk".to_string(), "0.5.1".to_string()),
+                ("vulkan-jpeg".to_string(), "0.5.1".to_string()),
+            ],
+            "gitea pins must include normal/build/cfg-target deps (renamed via \
+             `package`), strip range operators, and exclude serde + dev-deps"
+        );
+    }
+
+    #[test]
+    fn read_gitea_registry_pins_empty_without_cargo_toml() {
+        let dir = tempdir().unwrap();
+        assert!(read_gitea_registry_pins(dir.path()).unwrap().is_empty());
     }
 
     #[test]

--- a/libs/streamlib-cargo-build/src/lib.rs
+++ b/libs/streamlib-cargo-build/src/lib.rs
@@ -94,13 +94,18 @@ pub fn read_cargo_package_name(package_dir: &Path) -> Result<String> {
     Ok(name.to_string())
 }
 
-/// A direct gitea-registry cargo dependency pin: the crate `name` and the
-/// concrete `version` its manifest floor-pins it at (leading range operators
+/// A direct gitea-registry cargo dependency pin: the crate `name`, the raw
+/// cargo version requirement `req` (cargo semantics — a bare `0.5.0` means
+/// caret), and the concrete floor `version` (leading range operators
 /// `=` / `^` / `~` / `>=` stripped). The unit the release-completeness check
 /// validates against a release manifest.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GiteaRegistryPin {
     pub name: String,
+    /// Raw cargo version requirement as written in the manifest
+    /// (`"0.5.0"`, `"=0.4.36"`, `"^0.5.1"`, …).
+    pub req: String,
+    /// Floor version with the range operator stripped.
     pub version: String,
 }
 
@@ -135,6 +140,7 @@ fn collect_gitea_pins_from_table(table: &toml::value::Table, out: &mut Vec<Gitea
             .to_string();
         out.push(GiteaRegistryPin {
             name,
+            req: version.trim().to_string(),
             version: strip_version_req_operator(version),
         });
     }
@@ -530,19 +536,23 @@ vulkan-jpeg = {version = ">=0.5.1", registry = "gitea"}
 
         let mut pins = read_gitea_registry_pins(dir.path()).unwrap();
         pins.sort_by(|a, b| a.name.cmp(&b.name));
-        let got: Vec<(String, String)> =
-            pins.into_iter().map(|p| (p.name, p.version)).collect();
+        let got: Vec<(String, String, String)> = pins
+            .into_iter()
+            .map(|p| (p.name, p.req, p.version))
+            .collect();
         assert_eq!(
             got,
             vec![
-                ("streamlib-jtd-codegen".to_string(), "0.5.1".to_string()),
-                ("streamlib-macros".to_string(), "0.5.1".to_string()),
-                ("streamlib-plugin-abi".to_string(), "0.5.1".to_string()), // renamed
-                ("streamlib-plugin-sdk".to_string(), "0.5.1".to_string()),
-                ("vulkan-jpeg".to_string(), "0.5.1".to_string()),
+                ("streamlib-jtd-codegen".to_string(), "=0.5.1".to_string(), "0.5.1".to_string()),
+                ("streamlib-macros".to_string(), "^0.5.1".to_string(), "0.5.1".to_string()),
+                // renamed via `package = "streamlib-plugin-abi"`
+                ("streamlib-plugin-abi".to_string(), "=0.5.1".to_string(), "0.5.1".to_string()),
+                ("streamlib-plugin-sdk".to_string(), "0.5.1".to_string(), "0.5.1".to_string()),
+                ("vulkan-jpeg".to_string(), ">=0.5.1".to_string(), "0.5.1".to_string()),
             ],
             "gitea pins must include normal/build/cfg-target deps (renamed via \
-             `package`), strip range operators, and exclude serde + dev-deps"
+             `package`), carry the raw req, strip range operators for the floor, \
+             and exclude serde + dev-deps"
         );
     }
 

--- a/libs/streamlib-cli/src/commands/link.rs
+++ b/libs/streamlib-cli/src/commands/link.rs
@@ -485,87 +485,23 @@ fn run_cargo_metadata(
 }
 
 /// Derive the linkable crate set (`name` → checkout member dir) from the
-/// checkout live via `cargo metadata` — same selection as the publish closure
-/// with `STREAMLIB_PUBLISH_ALL_LIBS=1`: every workspace member named
-/// `streamlib*` (or `vulkan-jpeg`) with a library target that is publishable.
+/// checkout via the single canonical release-closure definition
+/// ([`streamlib_pack::compute_release_closure`]): every publishable workspace
+/// library crate named `streamlib*` / `vulkan-jpeg`. This is the exact set a
+/// release publishes, so a whole-tree link and a release always agree on the
+/// crate set by construction.
 fn derive_linkable_crates(checkout: &Path) -> Result<BTreeMap<String, PathBuf>, LinkError> {
-    let manifest_path = checkout.join("Cargo.toml");
-    let manifest_path_str = manifest_path.to_string_lossy().into_owned();
-    let md = run_cargo_metadata(
-        &[
-            "metadata",
-            "--format-version",
-            "1",
-            "--no-deps",
-            "--manifest-path",
-            &manifest_path_str,
-        ],
-        None,
-    )
-    .map_err(|detail| LinkError::CrateSetDerivation {
-        checkout: checkout.to_path_buf(),
-        detail,
+    let closure = streamlib_pack::compute_release_closure(checkout).map_err(|e| {
+        LinkError::CrateSetDerivation {
+            checkout: checkout.to_path_buf(),
+            detail: format!("{e}"),
+        }
     })?;
-
-    let members: std::collections::HashSet<&str> = md
-        .get("workspace_members")
-        .and_then(|m| m.as_array())
-        .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
-        .unwrap_or_default();
-
-    let mut crates = BTreeMap::new();
-    let empty = Vec::new();
-    let packages = md
-        .get("packages")
-        .and_then(|p| p.as_array())
-        .unwrap_or(&empty);
-    for pkg in packages {
-        let id = pkg.get("id").and_then(|v| v.as_str()).unwrap_or_default();
-        if !members.contains(id) {
-            continue;
-        }
-        let name = pkg.get("name").and_then(|v| v.as_str()).unwrap_or_default();
-        if !is_linkable_crate_name(name) {
-            continue;
-        }
-        // `publish == []` ⇒ publish = false ⇒ not a linkable SDK crate.
-        if pkg.get("publish").and_then(|v| v.as_array()).is_some_and(|a| a.is_empty()) {
-            continue;
-        }
-        if !has_library_target(pkg) {
-            continue;
-        }
-        let manifest = pkg
-            .get("manifest_path")
-            .and_then(|v| v.as_str())
-            .unwrap_or_default();
-        if let Some(dir) = Path::new(manifest).parent() {
-            crates.insert(name.to_string(), dir.to_path_buf());
-        }
-    }
-    Ok(crates)
-}
-
-fn is_linkable_crate_name(name: &str) -> bool {
-    name.starts_with("streamlib") || name == "vulkan-jpeg"
-}
-
-fn has_library_target(pkg: &serde_json::Value) -> bool {
-    const LIB_KINDS: &[&str] = &["lib", "rlib", "cdylib", "proc-macro", "dylib", "staticlib"];
-    pkg.get("targets")
-        .and_then(|t| t.as_array())
-        .is_some_and(|targets| {
-            targets.iter().any(|t| {
-                t.get("kind")
-                    .and_then(|k| k.as_array())
-                    .is_some_and(|kinds| {
-                        kinds
-                            .iter()
-                            .filter_map(|k| k.as_str())
-                            .any(|k| LIB_KINDS.contains(&k))
-                    })
-            })
-        })
+    Ok(closure
+        .crates
+        .into_iter()
+        .map(|c| (c.name, c.manifest_dir))
+        .collect())
 }
 
 /// Verify the consumer's cargo resolution honors the link: every resolved

--- a/libs/streamlib-engine/src/core/runtime/module_loader/build_orchestrator.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/build_orchestrator.rs
@@ -163,6 +163,25 @@ pub enum BuildError {
         detail: String,
     },
 
+    /// The registry holds an **incomplete / inconsistent release** of the
+    /// pinned version: the package depends on crates that the release
+    /// manifest for `release_version` does not list as published. Surfaced
+    /// *before* cargo runs, so a half-published registry fails fast with the
+    /// exact missing artifacts named — instead of a cryptic
+    /// `failed to select a version for …` deep in cargo / `streamlib-macros`
+    /// version unification.
+    #[error(
+        "incomplete release of {release_version}: the registry is missing \
+         {missing} (required by '{package}'). {hint}"
+    )]
+    IncompleteRelease {
+        package: String,
+        release_version: String,
+        /// Comma-joined `name@version` of the pins absent from the release.
+        missing: String,
+        hint: String,
+    },
+
     /// I/O, staging, or any other materialization failure.
     #[error("materialize failed for '{package}': {detail}")]
     Other { package: String, detail: String },

--- a/libs/streamlib-idents/src/lib.rs
+++ b/libs/streamlib-idents/src/lib.rs
@@ -14,6 +14,7 @@ mod ident;
 mod lockfile;
 mod manifest;
 mod registry;
+mod release;
 mod resolver;
 mod semver;
 
@@ -32,7 +33,11 @@ pub use manifest::{
     SchemaEntry,
 };
 pub use registry::{
-    select_version, RegistryClient, RegistryConfig, REGISTRY_TOKEN_ENV, REGISTRY_URL_ENV,
+    select_version, RegistryClient, RegistryConfig, RELEASE_MANIFEST_CHANNEL,
+    RELEASE_MANIFEST_FILE, REGISTRY_TOKEN_ENV, REGISTRY_URL_ENV,
+};
+pub use release::{
+    crates_missing_from_release, ReleaseManifest, ReleaseManifestMember, RELEASE_MANIFEST_FORMAT,
 };
 pub use resolver::{
     resolve, resolve_bare_schema_name, resolve_with, ResolvedPackage, ResolvedPackages,

--- a/libs/streamlib-idents/src/registry.rs
+++ b/libs/streamlib-idents/src/registry.rs
@@ -32,7 +32,15 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{ResolverError, ResolverResult};
 use crate::ident::PackageRef;
+use crate::release::ReleaseManifest;
 use crate::semver::SemVer;
+
+/// Generic-registry "package name" the release manifest is published under.
+/// Reserved channel — a `@org/name` package can never collide with it
+/// because package names never equal this literal.
+pub const RELEASE_MANIFEST_CHANNEL: &str = "streamlib-release";
+/// File name of the release manifest inside its per-version directory.
+pub const RELEASE_MANIFEST_FILE: &str = "manifest.json";
 
 /// Environment variable carrying the Gitea base URL (e.g.
 /// `http://localhost:3000`). Falls back to `GITEA_URL` to match the
@@ -220,6 +228,105 @@ impl<'a> RegistryClient<'a> {
         http_put_bytes(&self.index_url(pkg_ref), self.config.token.as_deref(), body.as_bytes())
             .map_err(|detail| upload_err(format!("publishing version index: {detail}")))?;
         Ok(())
+    }
+
+    /// Canonical URL of the release manifest for `release_version` — a plain
+    /// generic file under the reserved [`RELEASE_MANIFEST_CHANNEL`].
+    fn release_manifest_url(&self, org: &str, release_version: &str) -> String {
+        format!(
+            "{}/api/packages/{}/generic/{}/{}/{}",
+            self.config.base_url,
+            org,
+            RELEASE_MANIFEST_CHANNEL,
+            release_version,
+            RELEASE_MANIFEST_FILE,
+        )
+    }
+
+    /// `file://` mirror layout for the release manifest:
+    /// `<base>/streamlib-release/<V>/manifest.json`.
+    fn release_manifest_path(&self, release_version: &str) -> PathBuf {
+        self.file_base_dir()
+            .join(RELEASE_MANIFEST_CHANNEL)
+            .join(release_version)
+            .join(RELEASE_MANIFEST_FILE)
+    }
+
+    /// Publish the release `manifest` for its `release_version`, returning the
+    /// canonical URL it was written to. This is the **atomicity flip** — the
+    /// caller runs it *last*, after every crate / SDK / package has landed, so
+    /// the manifest's presence marks the release complete. `file://` writes
+    /// the mirror layout; `http(s)://` deletes-then-PUTs (Gitea generic files
+    /// are immutable per (name, version, file), so a bare re-PUT 409s). `org`
+    /// is the registry org the release lives under (e.g. `tatolab`).
+    pub fn upload_release_manifest(
+        &self,
+        org: &str,
+        manifest: &ReleaseManifest,
+    ) -> ResolverResult<String> {
+        let upload_err = |detail: String| ResolverError::RegistryFetchFailed {
+            name: format!("{}/{}", RELEASE_MANIFEST_CHANNEL, manifest.release_version),
+            detail,
+        };
+        let body = serde_json::to_vec_pretty(manifest)
+            .map_err(|e| upload_err(format!("serializing release manifest: {e}")))?;
+        let url = self.release_manifest_url(org, &manifest.release_version);
+        if self.is_file_scheme() {
+            let path = self.release_manifest_path(&manifest.release_version);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| upload_err(format!("creating {} : {e}", parent.display())))?;
+            }
+            std::fs::write(&path, &body)
+                .map_err(|e| upload_err(format!("writing {} : {e}", path.display())))?;
+        } else {
+            // Overwrite-on-republish: drop the existing version before the PUT.
+            let version_url = format!(
+                "{}/api/v1/packages/{}/generic/{}/{}",
+                self.config.base_url,
+                org,
+                RELEASE_MANIFEST_CHANNEL,
+                manifest.release_version,
+            );
+            http_delete(&version_url, self.config.token.as_deref());
+            http_put_bytes(&url, self.config.token.as_deref(), &body).map_err(upload_err)?;
+        }
+        Ok(url)
+    }
+
+    /// Fetch the release manifest for `release_version`. `Ok(None)` when no
+    /// manifest is published for that version — the back-compat case for a
+    /// pre-atomic-release registry, which the consumer treats as "no
+    /// completeness signal, proceed". `Err` only on a real transport / parse
+    /// failure.
+    pub fn fetch_release_manifest(
+        &self,
+        org: &str,
+        release_version: &str,
+    ) -> ResolverResult<Option<ReleaseManifest>> {
+        let fetch_err = |detail: String| ResolverError::RegistryFetchFailed {
+            name: format!("{}/{}", RELEASE_MANIFEST_CHANNEL, release_version),
+            detail,
+        };
+        let bytes = if self.is_file_scheme() {
+            let path = self.release_manifest_path(release_version);
+            match std::fs::read(&path) {
+                Ok(b) => b,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+                Err(e) => return Err(fetch_err(format!("reading {} : {e}", path.display()))),
+            }
+        } else {
+            let url = self.release_manifest_url(org, release_version);
+            match http_get_optional(&url, self.config.token.as_deref())
+                .map_err(|detail| fetch_err(format!("fetching release manifest: {detail}")))?
+            {
+                Some(b) => b,
+                None => return Ok(None),
+            }
+        };
+        let manifest = serde_json::from_slice(&bytes)
+            .map_err(|e| fetch_err(format!("parsing release manifest JSON: {e}")))?;
+        Ok(Some(manifest))
     }
 
     /// Canonical generic-registry download URL (recorded in the lockfile).
@@ -870,5 +977,46 @@ mod tests {
                 && p.ends_with("/generic/camera/0.4.33/camera.slpkg")),
             "the .slpkg PUT must be recorded; saw {reqs:?}"
         );
+    }
+
+    /// The release-manifest publish/fetch round-trip over the `file://`
+    /// transport — the hermetic path CI and the scratch-registry integration
+    /// test ride. Mentally revert `upload_release_manifest` to a no-op and
+    /// `fetch_release_manifest` returns `None`, so this locks the write→read
+    /// contract, not merely a happy path.
+    #[test]
+    fn release_manifest_file_scheme_round_trip() {
+        use crate::release::{ReleaseManifest, ReleaseManifestMember};
+
+        let tmp = std::env::temp_dir().join(format!("slpkg-relman-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let cfg = RegistryConfig {
+            base_url: format!("file://{}", tmp.display()),
+            token: None,
+        };
+        let client = RegistryClient::new(&cfg);
+
+        // Missing manifest ⇒ None (the pre-atomic-release back-compat case).
+        assert!(client.fetch_release_manifest("tatolab", "0.5.1").unwrap().is_none());
+
+        let mut manifest = ReleaseManifest::new(
+            "0.5.1",
+            vec![
+                ReleaseManifestMember::new("streamlib-plugin-sdk", "0.5.1"),
+                ReleaseManifestMember::new("vulkan-jpeg", "0.5.1"),
+            ],
+        );
+        manifest.python = Some("0.5.1".to_string());
+        manifest.packages = vec![ReleaseManifestMember::new("@tatolab/jpeg", "1.0.7")];
+
+        let url = client.upload_release_manifest("tatolab", &manifest).unwrap();
+        assert!(url.ends_with("/generic/streamlib-release/0.5.1/manifest.json"), "url: {url}");
+        // The mirror layout must be `<base>/streamlib-release/<V>/manifest.json`.
+        assert!(tmp.join("streamlib-release").join("0.5.1").join("manifest.json").is_file());
+
+        let back = client.fetch_release_manifest("tatolab", "0.5.1").unwrap().unwrap();
+        assert_eq!(back, manifest);
+
+        std::fs::remove_dir_all(&tmp).ok();
     }
 }

--- a/libs/streamlib-idents/src/registry.rs
+++ b/libs/streamlib-idents/src/registry.rs
@@ -1018,8 +1018,8 @@ mod tests {
     fn release_manifest_file_scheme_round_trip() {
         use crate::release::{ReleaseManifest, ReleaseManifestMember};
 
-        let tmp = std::env::temp_dir().join(format!("slpkg-relman-{}", std::process::id()));
-        std::fs::create_dir_all(&tmp).unwrap();
+        let tmp_guard = tempfile::tempdir().unwrap();
+        let tmp = tmp_guard.path().to_path_buf();
         let cfg = RegistryConfig {
             base_url: format!("file://{}", tmp.display()),
             token: None,
@@ -1053,7 +1053,5 @@ mod tests {
             client.list_release_versions("tatolab").unwrap(),
             vec![SemVer::new(0, 5, 1)]
         );
-
-        std::fs::remove_dir_all(&tmp).ok();
     }
 }

--- a/libs/streamlib-idents/src/registry.rs
+++ b/libs/streamlib-idents/src/registry.rs
@@ -252,13 +252,34 @@ impl<'a> RegistryClient<'a> {
             .join(RELEASE_MANIFEST_FILE)
     }
 
+    /// [`PackageRef`] for the reserved release-manifest channel under `org`,
+    /// so the channel rides the same list/index machinery as any generic
+    /// package.
+    fn release_channel_ref(&self, org: &str) -> ResolverResult<PackageRef> {
+        let org = crate::ident::Org::new(org)?;
+        let name = crate::ident::Package::new(RELEASE_MANIFEST_CHANNEL)?;
+        Ok(PackageRef::new(org, name))
+    }
+
+    /// List every release version that has a published release manifest.
+    /// `file://` enumerates the mirror directory; `http(s)://` reads the
+    /// channel's anonymous version index (maintained by
+    /// [`Self::upload_release_manifest`]). An empty list is the
+    /// pre-atomic-release back-compat case.
+    pub fn list_release_versions(&self, org: &str) -> ResolverResult<Vec<SemVer>> {
+        let channel = self.release_channel_ref(org)?;
+        self.list_versions(&channel)
+    }
+
     /// Publish the release `manifest` for its `release_version`, returning the
     /// canonical URL it was written to. This is the **atomicity flip** — the
     /// caller runs it *last*, after every crate / SDK / package has landed, so
     /// the manifest's presence marks the release complete. `file://` writes
     /// the mirror layout; `http(s)://` deletes-then-PUTs (Gitea generic files
-    /// are immutable per (name, version, file), so a bare re-PUT 409s). `org`
-    /// is the registry org the release lives under (e.g. `tatolab`).
+    /// are immutable per (name, version, file), so a bare re-PUT 409s) and
+    /// rewrites the channel's anonymous version index so consumers can list
+    /// available releases tokenlessly. `org` is the registry org the release
+    /// lives under (e.g. `tatolab`).
     pub fn upload_release_manifest(
         &self,
         org: &str,
@@ -268,6 +289,10 @@ impl<'a> RegistryClient<'a> {
             name: format!("{}/{}", RELEASE_MANIFEST_CHANNEL, manifest.release_version),
             detail,
         };
+        let release_semver: SemVer = manifest
+            .release_version
+            .parse()
+            .map_err(|e| upload_err(format!("release_version is not a semver: {e}")))?;
         let body = serde_json::to_vec_pretty(manifest)
             .map_err(|e| upload_err(format!("serializing release manifest: {e}")))?;
         let url = self.release_manifest_url(org, &manifest.release_version);
@@ -290,6 +315,11 @@ impl<'a> RegistryClient<'a> {
             );
             http_delete(&version_url, self.config.token.as_deref());
             http_put_bytes(&url, self.config.token.as_deref(), &body).map_err(upload_err)?;
+            // Maintain the channel's anonymous version index so the consumer
+            // read path can list release versions tokenlessly (mirrors the
+            // upload_slpkg ordering: artifact first, index last).
+            let channel = self.release_channel_ref(org)?;
+            self.write_version_index(&channel, release_semver)?;
         }
         Ok(url)
     }
@@ -1016,6 +1046,13 @@ mod tests {
 
         let back = client.fetch_release_manifest("tatolab", "0.5.1").unwrap().unwrap();
         assert_eq!(back, manifest);
+
+        // The release channel is listable — the consumer's range-aware
+        // completeness check discovers available releases this way.
+        assert_eq!(
+            client.list_release_versions("tatolab").unwrap(),
+            vec![SemVer::new(0, 5, 1)]
+        );
 
         std::fs::remove_dir_all(&tmp).ok();
     }

--- a/libs/streamlib-idents/src/release.rs
+++ b/libs/streamlib-idents/src/release.rs
@@ -1,0 +1,211 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The **release manifest** — the record that makes a published version
+//! surface an *atomic, detectable* release.
+//!
+//! A release publishes a defined closure (all engine library crates + the
+//! polyglot SDKs + all packages) as one unit. Individual crate/package
+//! uploads are a loose pile until the manifest lands: the manifest is
+//! written **last**, so its presence at `streamlib-release/<V>/manifest.json`
+//! is the completion marker — a consumer that finds it knows every member it
+//! lists is published, and a consumer that resolves a pin absent from it gets
+//! an actionable "incomplete release" error up front instead of a cryptic
+//! cargo/`streamlib-macros` version-unification failure deep in the build.
+//!
+//! The manifest is transport-agnostic: [`crate::RegistryClient`] writes/reads
+//! it over `http(s)://` (Gitea generic registry) and `file://` (hermetic
+//! local mirror) identically.
+
+/// One published member of a release — a crate or a package, named and
+/// versioned. Extra fields a future manifest revision might carry are
+/// ignored on read, so the shape can grow without breaking older readers.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ReleaseManifestMember {
+    pub name: String,
+    pub version: String,
+}
+
+impl ReleaseManifestMember {
+    pub fn new(name: impl Into<String>, version: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            version: version.into(),
+        }
+    }
+}
+
+/// Current [`ReleaseManifest`] schema version. Bumped only on a
+/// breaking-shape change; readers ignore unknown fields, so additive
+/// growth does not require a bump.
+pub const RELEASE_MANIFEST_FORMAT: u32 = 1;
+
+/// The complete set of artifacts that constitute release version `V`.
+///
+/// Serialized to `streamlib-release/<V>/manifest.json` in the generic
+/// registry and written **last** in the publish sequence — its presence
+/// means the release is complete by protocol.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ReleaseManifest {
+    /// Manifest schema version (forward-compat marker).
+    pub manifest_format: u32,
+    /// The release version `V` (the workspace `[workspace.package].version`,
+    /// with a `-dev.N` suffix for a dev publish). The manifest lives under
+    /// this exact string in the registry.
+    pub release_version: String,
+    /// The engine crate closure — every `streamlib*` / `vulkan-jpeg` library
+    /// crate published for this release (the `compute_release_closure`
+    /// output). This is the load-bearing set the consumer completeness check
+    /// validates against.
+    pub crates: Vec<ReleaseManifestMember>,
+    /// Python SDK version published for this release, if the SDK was part of
+    /// the release.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub python: Option<String>,
+    /// Deno SDK version published for this release, if the SDK was part of
+    /// the release.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deno: Option<String>,
+    /// Polyglot packages (`.slpkg`) published for this release, by their
+    /// own independent semver.
+    #[serde(default)]
+    pub packages: Vec<ReleaseManifestMember>,
+}
+
+impl ReleaseManifest {
+    /// Build a manifest for release `release_version` from its crate closure.
+    /// `python` / `deno` / `packages` are filled in by the caller.
+    pub fn new(release_version: impl Into<String>, crates: Vec<ReleaseManifestMember>) -> Self {
+        Self {
+            manifest_format: RELEASE_MANIFEST_FORMAT,
+            release_version: release_version.into(),
+            crates,
+            python: None,
+            deno: None,
+            packages: Vec::new(),
+        }
+    }
+
+    /// Whether the manifest lists a crate member named `name` at exactly
+    /// `version`.
+    pub fn contains_crate(&self, name: &str, version: &str) -> bool {
+        self.crates
+            .iter()
+            .any(|m| m.name == name && m.version == version)
+    }
+}
+
+/// Given the direct crate pins a consumer declares (`(name, exact version)`),
+/// return the `name@version` of each pin the release `manifest` does **not**
+/// list as a crate member. An empty result means every pin is covered by the
+/// release — a partial/mid-publish registry yields the missing names so the
+/// caller can name the gap.
+///
+/// The pins are the consumer's *direct* gitea-registry cargo deps at the
+/// release version; the manifest's `crates` set is the full published
+/// closure. A pin absent from the closure is exactly the `0.4.36`
+/// `streamlib-plugin-sdk` / `vulkan-jpeg` foot-gun this manifest exists to
+/// catch.
+pub fn crates_missing_from_release(
+    manifest: &ReleaseManifest,
+    required: &[(String, String)],
+) -> Vec<String> {
+    let mut missing: Vec<String> = required
+        .iter()
+        .filter(|(name, version)| !manifest.contains_crate(name, version))
+        .map(|(name, version)| format!("{name}@{version}"))
+        .collect();
+    missing.sort();
+    missing.dedup();
+    missing
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest_with(crates: &[(&str, &str)]) -> ReleaseManifest {
+        ReleaseManifest::new(
+            "0.5.1",
+            crates
+                .iter()
+                .map(|(n, v)| ReleaseManifestMember::new(*n, *v))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn complete_release_reports_no_missing() {
+        let m = manifest_with(&[
+            ("streamlib-plugin-sdk", "0.5.1"),
+            ("streamlib-macros", "0.5.1"),
+            ("vulkan-jpeg", "0.5.1"),
+        ]);
+        let required = vec![
+            ("streamlib-plugin-sdk".to_string(), "0.5.1".to_string()),
+            ("streamlib-macros".to_string(), "0.5.1".to_string()),
+        ];
+        assert!(crates_missing_from_release(&m, &required).is_empty());
+    }
+
+    #[test]
+    fn partial_release_names_the_gap() {
+        // The historical foot-gun: a closure that published streamlib-macros
+        // but silently skipped streamlib-plugin-sdk + vulkan-jpeg. The check
+        // must name exactly the pins that aren't in the manifest.
+        let m = manifest_with(&[("streamlib-macros", "0.5.1")]);
+        let required = vec![
+            ("streamlib-plugin-sdk".to_string(), "0.5.1".to_string()),
+            ("streamlib-macros".to_string(), "0.5.1".to_string()),
+            ("vulkan-jpeg".to_string(), "0.5.1".to_string()),
+        ];
+        let missing = crates_missing_from_release(&m, &required);
+        assert_eq!(
+            missing,
+            vec![
+                "streamlib-plugin-sdk@0.5.1".to_string(),
+                "vulkan-jpeg@0.5.1".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn version_mismatch_counts_as_missing() {
+        // A pin at a version the release doesn't carry (skew) is missing —
+        // string-exact match, since the manifest records stamped versions.
+        let m = manifest_with(&[("streamlib-macros", "0.5.1")]);
+        let required = vec![("streamlib-macros".to_string(), "0.4.36".to_string())];
+        assert_eq!(
+            crates_missing_from_release(&m, &required),
+            vec!["streamlib-macros@0.4.36".to_string()]
+        );
+    }
+
+    #[test]
+    fn manifest_json_round_trips_both_optional_and_packages() {
+        let mut m = manifest_with(&[("streamlib-plugin-sdk", "0.5.1")]);
+        m.python = Some("0.5.1".to_string());
+        m.deno = Some("0.5.1".to_string());
+        m.packages = vec![ReleaseManifestMember::new("@tatolab/jpeg", "1.0.7")];
+        let json = serde_json::to_string_pretty(&m).unwrap();
+        let back: ReleaseManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(m, back);
+    }
+
+    #[test]
+    fn manifest_read_ignores_unknown_fields() {
+        // Forward-compat: an older reader must tolerate a newer manifest that
+        // grew a field. Reverting `#[serde(default)]` / unknown-field
+        // tolerance would break older consumers against a newer registry.
+        let json = r#"{
+            "manifest_format": 1,
+            "release_version": "0.5.1",
+            "crates": [{"name":"streamlib-macros","version":"0.5.1"}],
+            "future_field": {"whatever": true}
+        }"#;
+        let m: ReleaseManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(m.release_version, "0.5.1");
+        assert!(m.contains_crate("streamlib-macros", "0.5.1"));
+        assert!(m.packages.is_empty());
+    }
+}

--- a/libs/streamlib-idents/src/release.rs
+++ b/libs/streamlib-idents/src/release.rs
@@ -93,27 +93,40 @@ impl ReleaseManifest {
             .iter()
             .any(|m| m.name == name && m.version == version)
     }
+
+    /// Whether the manifest lists a crate member named `name` at a version
+    /// satisfying `range`. Members with an unparseable version never match.
+    pub fn contains_crate_satisfying(&self, name: &str, range: &crate::SemVerRange) -> bool {
+        self.crates.iter().any(|m| {
+            m.name == name
+                && m.version
+                    .parse::<crate::SemVer>()
+                    .is_ok_and(|v| range.matches(v))
+        })
+    }
 }
 
-/// Given the direct crate pins a consumer declares (`(name, exact version)`),
-/// return the `name@version` of each pin the release `manifest` does **not**
-/// list as a crate member. An empty result means every pin is covered by the
-/// release — a partial/mid-publish registry yields the missing names so the
-/// caller can name the gap.
+/// Given the direct crate pins a consumer declares (`(name, version range)`),
+/// return the `name@range` of each pin the release `manifest` does **not**
+/// satisfy — no crate member with that name whose version matches the range.
+/// An empty result means every pin is covered by the release; a
+/// partial/mid-publish registry yields the missing names so the caller can
+/// name the gap.
 ///
-/// The pins are the consumer's *direct* gitea-registry cargo deps at the
-/// release version; the manifest's `crates` set is the full published
-/// closure. A pin absent from the closure is exactly the `0.4.36`
-/// `streamlib-plugin-sdk` / `vulkan-jpeg` foot-gun this manifest exists to
-/// catch.
+/// The pins are the consumer's *direct* gitea-registry cargo dep reqs
+/// (cargo's bare `0.5.0` maps to `^0.5.0` before calling this); the
+/// manifest's `crates` set is the full published closure at the release
+/// version. A pin whose range the closure can't satisfy is exactly the
+/// `0.4.36` `streamlib-plugin-sdk` / `vulkan-jpeg` foot-gun this manifest
+/// exists to catch.
 pub fn crates_missing_from_release(
     manifest: &ReleaseManifest,
-    required: &[(String, String)],
+    required: &[(String, crate::SemVerRange)],
 ) -> Vec<String> {
     let mut missing: Vec<String> = required
         .iter()
-        .filter(|(name, version)| !manifest.contains_crate(name, version))
-        .map(|(name, version)| format!("{name}@{version}"))
+        .filter(|(name, range)| !manifest.contains_crate_satisfying(name, range))
+        .map(|(name, range)| format!("{name}@{range}"))
         .collect();
     missing.sort();
     missing.dedup();
@@ -123,6 +136,7 @@ pub fn crates_missing_from_release(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::SemVerRange;
 
     fn manifest_with(crates: &[(&str, &str)]) -> ReleaseManifest {
         ReleaseManifest::new(
@@ -134,6 +148,10 @@ mod tests {
         )
     }
 
+    fn req(name: &str, range: &str) -> (String, SemVerRange) {
+        (name.to_string(), SemVerRange::from_str(range).unwrap())
+    }
+
     #[test]
     fn complete_release_reports_no_missing() {
         let m = manifest_with(&[
@@ -142,8 +160,10 @@ mod tests {
             ("vulkan-jpeg", "0.5.1"),
         ]);
         let required = vec![
-            ("streamlib-plugin-sdk".to_string(), "0.5.1".to_string()),
-            ("streamlib-macros".to_string(), "0.5.1".to_string()),
+            req("streamlib-plugin-sdk", "=0.5.1"),
+            // Caret floor pin below the release version — the real-tree
+            // steady state (pins floor 0.5.0, release 0.5.1) must satisfy.
+            req("streamlib-macros", "^0.5.0"),
         ];
         assert!(crates_missing_from_release(&m, &required).is_empty());
     }
@@ -152,32 +172,32 @@ mod tests {
     fn partial_release_names_the_gap() {
         // The historical foot-gun: a closure that published streamlib-macros
         // but silently skipped streamlib-plugin-sdk + vulkan-jpeg. The check
-        // must name exactly the pins that aren't in the manifest.
+        // must name exactly the pins the manifest can't satisfy.
         let m = manifest_with(&[("streamlib-macros", "0.5.1")]);
         let required = vec![
-            ("streamlib-plugin-sdk".to_string(), "0.5.1".to_string()),
-            ("streamlib-macros".to_string(), "0.5.1".to_string()),
-            ("vulkan-jpeg".to_string(), "0.5.1".to_string()),
+            req("streamlib-plugin-sdk", "^0.5.0"),
+            req("streamlib-macros", "^0.5.0"),
+            req("vulkan-jpeg", "^0.5.0"),
         ];
         let missing = crates_missing_from_release(&m, &required);
         assert_eq!(
             missing,
             vec![
-                "streamlib-plugin-sdk@0.5.1".to_string(),
-                "vulkan-jpeg@0.5.1".to_string(),
+                "streamlib-plugin-sdk@^0.5.0".to_string(),
+                "vulkan-jpeg@^0.5.0".to_string(),
             ]
         );
     }
 
     #[test]
-    fn version_mismatch_counts_as_missing() {
-        // A pin at a version the release doesn't carry (skew) is missing —
-        // string-exact match, since the manifest records stamped versions.
+    fn version_out_of_range_counts_as_missing() {
+        // An exact pin at a version the release doesn't carry (skew) is
+        // missing — the manifest's 0.5.1 member does not satisfy =0.4.36.
         let m = manifest_with(&[("streamlib-macros", "0.5.1")]);
-        let required = vec![("streamlib-macros".to_string(), "0.4.36".to_string())];
+        let required = vec![req("streamlib-macros", "=0.4.36")];
         assert_eq!(
             crates_missing_from_release(&m, &required),
-            vec!["streamlib-macros@0.4.36".to_string()]
+            vec!["streamlib-macros@=0.4.36".to_string()]
         );
     }
 

--- a/libs/streamlib-pack/src/lib.rs
+++ b/libs/streamlib-pack/src/lib.rs
@@ -1203,6 +1203,16 @@ mod tests {
             );
         }
 
+        // Never-published crates (publish = false) must be excluded — the
+        // test-fixture packages are workspace members with library targets
+        // and linkable names, so only the publishable filter keeps them out.
+        // Mentally revert `json_is_publishable` and they leak in, and
+        // publish-crates.sh would try (and fail) to publish them.
+        assert!(
+            !names.iter().any(|n| n.contains("test-fixtures")),
+            "publish = false crates leaked into the closure: {names:?}"
+        );
+
         // Topological order: a dependency precedes its dependents. The plugin
         // ABI is a low-level dep of the SDK facade, so it must come first.
         let pos = |name: &str| closure.names().iter().position(|n| *n == name);

--- a/libs/streamlib-pack/src/lib.rs
+++ b/libs/streamlib-pack/src/lib.rs
@@ -47,6 +47,226 @@ pub use streamlib_cargo_build::CargoProfile;
 
 pub mod link_marker;
 
+/// One member of the engine release closure: a publishable workspace library
+/// crate, with its version and manifest directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseCrate {
+    pub name: String,
+    pub version: String,
+    /// Directory holding the crate's `Cargo.toml` (its manifest dir).
+    pub manifest_dir: PathBuf,
+}
+
+/// The engine **release closure** — every publishable `streamlib*` /
+/// `vulkan-jpeg` library crate in the workspace, in dependency (topological)
+/// publish order (a crate always precedes its dependents).
+///
+/// This is the single, only definition of "the set of crates a release
+/// publishes." There is deliberately no "SDK-subset vs. all-libs" switch: the
+/// closure is the full linkable set by construction, so the easy-to-skip
+/// libraries (`streamlib-plugin-sdk`, `vulkan-jpeg`) are members by definition
+/// — the foot-gun a human-remembered "publish everything" flag used to hide.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseClosure {
+    pub crates: Vec<ReleaseCrate>,
+}
+
+impl ReleaseClosure {
+    /// The closure member names in topological publish order.
+    pub fn names(&self) -> Vec<&str> {
+        self.crates.iter().map(|c| c.name.as_str()).collect()
+    }
+}
+
+/// Whether a crate name belongs to the streamlib release closure *by name*:
+/// every workspace library crate named `streamlib*` (SDK, engine, macros,
+/// plugin ABI, adapters, consumer-rhi, …) plus `vulkan-jpeg`. The full
+/// closure predicate also requires a library target and a publishable
+/// `publish` setting — see [`compute_release_closure`].
+pub fn is_linkable_crate_name(name: &str) -> bool {
+    name.starts_with("streamlib") || name == "vulkan-jpeg"
+}
+
+/// The library-target kinds a publishable crate must expose. A crate with
+/// only a `bin` target (the CLI / runtime binaries) is excluded.
+const RELEASE_CLOSURE_LIB_KINDS: &[&str] =
+    &["lib", "rlib", "cdylib", "proc-macro", "dylib", "staticlib"];
+
+fn json_has_library_target(pkg: &serde_json::Value) -> bool {
+    pkg.get("targets")
+        .and_then(|t| t.as_array())
+        .is_some_and(|targets| {
+            targets.iter().any(|t| {
+                t.get("kind")
+                    .and_then(|k| k.as_array())
+                    .is_some_and(|kinds| {
+                        kinds
+                            .iter()
+                            .filter_map(|k| k.as_str())
+                            .any(|k| RELEASE_CLOSURE_LIB_KINDS.contains(&k))
+                    })
+            })
+        })
+}
+
+/// `publish == []` in cargo metadata means `publish = false` — cargo refuses
+/// to publish it, so it's excluded from the closure.
+fn json_is_publishable(pkg: &serde_json::Value) -> bool {
+    !pkg.get("publish")
+        .and_then(|v| v.as_array())
+        .is_some_and(|a| a.is_empty())
+}
+
+/// Compute the engine release closure from a live `cargo metadata` run at
+/// `workspace_root`. The predicate — workspace member, [`is_linkable_crate_name`],
+/// a library target, and a publishable `publish` setting — is the *only*
+/// definition of the closure; the topological ordering is derived from the
+/// resolved dependency graph so it stays correct as the graph shifts.
+pub fn compute_release_closure(workspace_root: &Path) -> Result<ReleaseClosure> {
+    let manifest_path = workspace_root.join("Cargo.toml");
+    let output = Command::new("cargo")
+        .args(["metadata", "--format-version", "1"])
+        .arg("--manifest-path")
+        .arg(&manifest_path)
+        .output()
+        .with_context(|| format!("running cargo metadata at {}", manifest_path.display()))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "cargo metadata failed at {}: {}",
+            manifest_path.display(),
+            String::from_utf8_lossy(&output.stderr).trim(),
+        );
+    }
+    let md: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .context("parsing cargo metadata JSON")?;
+
+    let members: std::collections::HashSet<&str> = md
+        .get("workspace_members")
+        .and_then(|m| m.as_array())
+        .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+
+    let empty = Vec::new();
+    let packages = md.get("packages").and_then(|p| p.as_array()).unwrap_or(&empty);
+    // id → package json, and id → name, for the members we care about.
+    let mut pkg_by_id: std::collections::HashMap<&str, &serde_json::Value> =
+        std::collections::HashMap::new();
+    for pkg in packages {
+        if let Some(id) = pkg.get("id").and_then(|v| v.as_str()) {
+            pkg_by_id.insert(id, pkg);
+        }
+    }
+    let name_of = |id: &str| -> &str {
+        pkg_by_id
+            .get(id)
+            .and_then(|p| p.get("name"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+    };
+    // An id is "internal" (walked + publishable) when it's a workspace member
+    // that satisfies the full closure predicate.
+    let is_internal = |id: &str| -> bool {
+        if !members.contains(id) {
+            return false;
+        }
+        let Some(pkg) = pkg_by_id.get(id) else {
+            return false;
+        };
+        is_linkable_crate_name(name_of(id)) && json_has_library_target(pkg) && json_is_publishable(pkg)
+    };
+
+    // Resolved dependency graph: id → its normal/build dep ids.
+    let resolve_nodes = md
+        .get("resolve")
+        .and_then(|r| r.get("nodes"))
+        .and_then(|n| n.as_array())
+        .ok_or_else(|| anyhow::anyhow!("cargo metadata has no resolve graph (ran with --no-deps?)"))?;
+    let mut deps_by_id: std::collections::HashMap<&str, Vec<&str>> =
+        std::collections::HashMap::new();
+    for node in resolve_nodes {
+        let Some(id) = node.get("id").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let mut deps = Vec::new();
+        if let Some(dep_arr) = node.get("deps").and_then(|d| d.as_array()) {
+            for dep in dep_arr {
+                // Keep normal + build deps (kind null | "build"); drop dev-only
+                // deps, which don't participate in the publish closure.
+                let keep = dep
+                    .get("dep_kinds")
+                    .and_then(|k| k.as_array())
+                    .map(|kinds| {
+                        kinds.iter().any(|k| {
+                            matches!(
+                                k.get("kind").and_then(|v| v.as_str()),
+                                None | Some("build")
+                            )
+                        })
+                    })
+                    .unwrap_or(true);
+                if keep && let Some(pkg) = dep.get("pkg").and_then(|v| v.as_str()) {
+                    deps.push(pkg);
+                }
+            }
+        }
+        deps_by_id.insert(id, deps);
+    }
+
+    // Post-order DFS over internal deps ⇒ topological publish order.
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut order: Vec<&str> = Vec::new();
+    // Iterative DFS to avoid recursion-depth concerns on large graphs.
+    let mut roots: Vec<&str> = members.iter().copied().filter(|id| is_internal(id)).collect();
+    roots.sort_by_key(|id| name_of(id).to_string());
+    for root in roots {
+        let mut stack: Vec<(&str, bool)> = vec![(root, false)];
+        while let Some((id, expanded)) = stack.pop() {
+            if expanded {
+                if !order.contains(&id) {
+                    order.push(id);
+                }
+                continue;
+            }
+            if seen.contains(id) {
+                continue;
+            }
+            seen.insert(id);
+            stack.push((id, true));
+            if let Some(deps) = deps_by_id.get(id) {
+                for &dep in deps {
+                    if is_internal(dep) && !seen.contains(dep) {
+                        stack.push((dep, false));
+                    }
+                }
+            }
+        }
+    }
+
+    let crates = order
+        .into_iter()
+        .map(|id| {
+            let pkg = pkg_by_id[id];
+            let name = name_of(id).to_string();
+            let version = pkg
+                .get("version")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let manifest_dir = pkg
+                .get("manifest_path")
+                .and_then(|v| v.as_str())
+                .and_then(|m| Path::new(m).parent().map(|p| p.to_path_buf()))
+                .unwrap_or_default();
+            ReleaseCrate {
+                name,
+                version,
+                manifest_dir,
+            }
+        })
+        .collect();
+    Ok(ReleaseClosure { crates })
+}
+
 /// Which child-process stream a build-log line came from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PackStream {
@@ -931,6 +1151,66 @@ mod tests {
             no_build,
             profile: CargoProfile::Release,
             path_deps: PathDepPolicy::RejectPathPatches,
+        }
+    }
+
+    #[test]
+    fn is_linkable_crate_name_covers_streamlib_and_vulkan_jpeg() {
+        assert!(is_linkable_crate_name("streamlib-plugin-sdk"));
+        assert!(is_linkable_crate_name("streamlib"));
+        assert!(is_linkable_crate_name("vulkan-jpeg"));
+        assert!(!is_linkable_crate_name("serde"));
+        assert!(!is_linkable_crate_name("tokio"));
+    }
+
+    #[test]
+    fn release_closure_includes_the_easy_to_skip_libs_by_definition() {
+        // The whole point of the closure-by-definition model: the libraries a
+        // human-remembered flag used to skip (streamlib-plugin-sdk,
+        // vulkan-jpeg) are members by construction. Runs against the real
+        // workspace so it cross-checks cargo metadata ground truth. Mentally
+        // revert the predicate to the old SDK-subset roots and
+        // streamlib-plugin-sdk / vulkan-jpeg drop out — the exact 0.4.36
+        // foot-gun.
+        let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("workspace root two levels above streamlib-pack")
+            .to_path_buf();
+        let closure = compute_release_closure(&workspace_root).expect("compute closure");
+        let names: std::collections::HashSet<&str> = closure.names().into_iter().collect();
+
+        for required in [
+            "streamlib-plugin-sdk",
+            "vulkan-jpeg",
+            "streamlib-macros",
+            "streamlib-plugin-abi",
+            "streamlib-engine",
+            "streamlib",
+        ] {
+            assert!(
+                names.contains(required),
+                "release closure must contain {required} by definition; got {names:?}"
+            );
+        }
+
+        // Every member is a linkable name (predicate holds for the whole set).
+        for c in &closure.crates {
+            assert!(
+                is_linkable_crate_name(&c.name),
+                "non-linkable crate {} leaked into the closure",
+                c.name
+            );
+        }
+
+        // Topological order: a dependency precedes its dependents. The plugin
+        // ABI is a low-level dep of the SDK facade, so it must come first.
+        let pos = |name: &str| closure.names().iter().position(|n| *n == name);
+        if let (Some(abi), Some(sdk)) = (pos("streamlib-plugin-abi"), pos("streamlib")) {
+            assert!(
+                abi < sdk,
+                "topo order violated: streamlib-plugin-abi ({abi}) must precede streamlib ({sdk})"
+            );
         }
     }
 

--- a/packages/test-fixtures-abi-mismatch/Cargo.toml
+++ b/packages/test-fixtures-abi-mismatch/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 authors.workspace = true
 license-file.workspace = true
 repository.workspace = true
+# Never published — test fixture. Also keeps this crate out of the release
+# closure (`compute_release_closure` requires a publishable crate).
+publish = false
 description = "Test-only cdylib emitting STREAMLIB_PLUGIN with a tampered abi_version — drives the load_project rejection-path integration test."
 keywords = ["streamlib", "test-fixtures", "abi"]
 categories = ["development-tools::testing"]

--- a/packages/test-fixtures/Cargo.toml
+++ b/packages/test-fixtures/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 authors.workspace = true
 license-file.workspace = true
 repository.workspace = true
+# Never published — test fixture. Also keeps this crate out of the release
+# closure (`compute_release_closure` requires a publishable crate).
+publish = false
 description = "Attribute-macro test fixtures (TestConfiguredProcessor) for streamlib SDK macro contract tests."
 keywords = ["streamlib", "test-fixtures", "macros"]
 categories = ["development-tools::testing"]

--- a/scripts/gitea/README.md
+++ b/scripts/gitea/README.md
@@ -11,7 +11,8 @@ a local dev container and a hosted backend. Architecture:
 | `provision-registry.sh` | Ensure the admin owner + `GITEA_ORG` exist; verify cargo/pypi/npm/generic are reachable. | One-time / idempotent. |
 | `smoke-test-registry.sh` | Publish→resolve→remove a throwaway crate + a generic round-trip. | Verify a live registry. |
 | `publish-vulkanalia.sh` | Publish the `tatolab/vulkanalia` fork (`-sys`, `vulkanalia`, `-vma`) to the cargo registry. | One-time bootstrap (fork rarely changes). |
-| `publish-crates.sh [--dev N]` | Publish the `streamlib` SDK crate closure by version, in topo order. | The recurring dev-loop publish. |
+| `publish-crates.sh [--dev N]` | Publish the full engine crate closure by version, in topo order (the closure `cargo xtask release-closure` computes — every publishable `streamlib*` / `vulkan-jpeg` library crate). | The recurring dev-loop publish. |
+| `publish-release.sh [--dev N]` | Publish a **consistent, atomic release**: crate closure + polyglot SDKs + packages, then the release manifest LAST. | A full release (honors `SKIP_PYTHON_SDK` / `SKIP_DENO_SDK` / `SKIP_PACKAGES`). |
 | `migrate-internal-deps.py` | Idempotent tomlkit sweep that put internal deps in the `{ path, version, registry }` form. | One-shot migration (kept for re-derivation / drift check). |
 
 The Python helpers need **tomlkit** (`pip install tomlkit`, or run with
@@ -52,17 +53,28 @@ export CARGO_REGISTRIES_GITEA_TOKEN="Bearer <token>"
 # VULKANALIA_DIR, default ~/Repositories/tatolab/vulkanalia)
 CARGO_REGISTRIES_GITEA_TOKEN="Bearer <token>" scripts/gitea/publish-vulkanalia.sh
 
-# then publish the streamlib SDK closure at the base [workspace.package].version
+# then publish the full engine crate closure at the base [workspace.package].version
 CARGO_REGISTRIES_GITEA_TOKEN="Bearer <token>" scripts/gitea/publish-crates.sh
 
 # dev loop: publish 0.4.x-dev.N so a consumer can bump to it without a path dep
 CARGO_REGISTRIES_GITEA_TOKEN="Bearer <token>" scripts/gitea/publish-crates.sh --dev 3
+
+# full atomic release: crates + SDKs + packages, then the release manifest LAST.
+# The manifest at streamlib-release/<V>/manifest.json is the completion marker —
+# a consumer resolving against a partial registry fails fast naming the gap
+# instead of a cryptic cargo version-unification error. Also needs
+# STREAMLIB_REGISTRY_URL (or GITEA_URL) + STREAMLIB_REGISTRY_TOKEN for the
+# manifest upload.
+CARGO_REGISTRIES_GITEA_TOKEN="Bearer <token>" STREAMLIB_REGISTRY_TOKEN="<token>" \
+  scripts/gitea/publish-release.sh
 ```
 
 `--no-verify` publishes source without compiling (the consumer verifies by
 building); both scripts treat an already-published version as success, so they
-are safe to re-run. The closure + topo order is derived live from
-`cargo metadata`. `publish-crates.sh` strips the dev `path:` patch from any
+are safe to re-run. The crate closure + topo order is the single canonical
+`streamlib-pack::compute_release_closure` set, emitted by `cargo xtask
+release-closure --json` — there is no "publish everything" flag to forget.
+`publish-crates.sh` strips the dev `path:` patch from any
 bundled `streamlib.yaml` (today: `streamlib-engine` →`@tatolab/escalate`) and
 restores the tree afterward, so the published manifest is path-free and the
 consumer resolves schema deps from the registry.

--- a/scripts/gitea/publish-crates.sh
+++ b/scripts/gitea/publish-crates.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
-# Publish the `streamlib` SDK crate closure (the 14-crate chain `streamlib`
-# transitively needs) to the Gitea cargo registry by version, in dependency
-# (topological) order. This is the recurring dev-loop publish: a local engine
-# change becomes a published 0.4.x-dev.N version a consumer bumps to — never a
-# new path dep or [patch]. See docs/architecture/gitea-registry-distribution.md.
+# Publish the engine RELEASE CLOSURE — every publishable `streamlib*` /
+# `vulkan-jpeg` workspace library crate — to the Gitea cargo registry by
+# version, in dependency (topological) order. This is the recurring dev-loop
+# publish: a local engine change becomes a published <base>-dev.N version a
+# consumer bumps to — never a new path dep or [patch]. See
+# docs/architecture/gitea-registry-distribution.md.
 #
 #   ./publish-crates.sh            # publish the base [workspace.package].version
 #   ./publish-crates.sh --dev 3    # publish <base>-dev.3 (workspace + dep reqs
 #                                  #   bumped in place, then restored)
 #
-# The closure + topo order is derived live from `cargo metadata`, so it stays
-# correct as the dependency graph shifts — nothing is hard-coded.
+# The closure + topo order come from `cargo xtask release-closure --json` —
+# the single canonical closure definition (streamlib-pack's
+# compute_release_closure), shared with `streamlib link`. It is derived live
+# from `cargo metadata`, so it stays correct as the dependency graph shifts —
+# nothing is hard-coded, and there is no "publish everything" flag to forget.
 #
 # Two in-place rewrites are applied before publish and restored after (the tree
 # is left exactly as found, clean or not):

--- a/scripts/gitea/publish-crates.sh
+++ b/scripts/gitea/publish-crates.sh
@@ -97,13 +97,15 @@ snapshot() {
 if [ -n "$DEV_N" ]; then
   log "bumping in place: $base_version -> $target_version (restored on exit)"
   # collect member manifests + root, snapshot, then rewrite with tomlkit.
-  # Only libs/ + plugin/ carry the workspace-versioned engine crates the
-  # closure publishes; packages/ own INDEPENDENT semver (.slpkg version, per
-  # #1239) and are published by publish-packages.sh, so bumping their crate
-  # version here would be semantically wrong (a transient bump/restore that
-  # doesn't belong to the engine dev-version axis).
+  # packages/ is deliberately INCLUDED even though packages own independent
+  # .slpkg semver: bump_member below only rewrites internal path-dep VERSION
+  # REQS (deps with both `path` and `version`), never [package].version — so
+  # package semver is untouched either way. The workspace-member test-fixture
+  # packages carry path+version deps into libs/, and those reqs must track
+  # the transient dev version or cargo's workspace resolution breaks during
+  # the publish (caret reqs exclude prereleases).
   while IFS= read -r m; do snapshot "$m"; done < <(
-    { echo Cargo.toml; find libs plugin -name Cargo.toml -not -path '*/target/*'; }
+    { echo Cargo.toml; find libs packages plugin -name Cargo.toml -not -path '*/target/*'; }
   )
   BASE="$base_version" TARGET="$target_version" "$PY" - <<'PY'
 import os, glob, tomlkit
@@ -141,9 +143,11 @@ def bump_member(path):
     if changed:
         open(path, "w").write(tomlkit.dumps(doc))
 bump_workspace()
-# libs/ + plugin/ only — packages/ own independent .slpkg semver (#1239) and
-# are not part of the engine dev-version bump.
+# packages/ included on purpose: bump_member only rewrites path+version dep
+# reqs (never [package].version), and the workspace-member test-fixture
+# packages' path deps into libs/ must track the transient dev version.
 for m in (glob.glob("libs/**/Cargo.toml", recursive=True)
+          + glob.glob("packages/**/Cargo.toml", recursive=True)
           + glob.glob("plugin/**/Cargo.toml", recursive=True)):
     if "/target/" in m: continue
     bump_member(m)

--- a/scripts/gitea/publish-crates.sh
+++ b/scripts/gitea/publish-crates.sh
@@ -62,56 +62,20 @@ PY
 target_version="$base_version"
 [ -n "$DEV_N" ] && target_version="${base_version}-dev.${DEV_N}"
 
-# --- derive the streamlib closure in topological order -----------------------
-mapfile -t ORDER < <("$PY" - <<'PY'
-import json, os, subprocess
-md = json.loads(subprocess.check_output(["cargo","metadata","--format-version","1"]))
-pkgs = {p["id"]: p for p in md["packages"]}
-members = set(md["workspace_members"])
-resolve = {n["id"]: n for n in md["resolve"]["nodes"]}
-name = lambda i: pkgs[i]["name"]
-# Publish-closure roots: the `streamlib` SDK crate a consumer deps, PLUS the
-# subprocess native hosts the build orchestrator fetches from the registry by
-# exact version (streamlib-python-native / streamlib-deno-native). The hosts
-# pull adapters + consumer-rhi the SDK closure alone doesn't, so the union of
-# the three roots' closures (topo-ordered) is what a polyglot consumer needs.
-root_names = ("streamlib", "streamlib-python-native", "streamlib-deno-native")
-internal = lambda i: i in members and (name(i).startswith("streamlib") or name(i) == "vulkan-jpeg")
-# STREAMLIB_PUBLISH_ALL_LIBS=1 widens the closure from "what the streamlib SDK
-# needs" to "every internal library crate", so a package can cargo-depend on any
-# in-tree lib (e.g. api-server -> streamlib-moq) and resolve it from the
-# registry. Binaries (streamlib-cli / -runtime) and test fixtures are excluded.
-# Used by the container's registry-fill (docker/build-stage1.sh).
-if os.environ.get("STREAMLIB_PUBLISH_ALL_LIBS") == "1":
-    skip = {"streamlib-test-fixtures", "streamlib-test-fixtures-abi-mismatch"}
-    lib_kinds = {"lib", "rlib", "cdylib", "proc-macro", "dylib", "staticlib"}
-    has_lib = lambda i: any(set(t["kind"]) & lib_kinds for t in pkgs[i]["targets"])
-    # Respect each crate's own publish setting: cargo metadata reports
-    # `publish == []` for `publish = false` crates (internal adapter helpers),
-    # which `cargo publish` refuses. Only publishable libs go to the registry.
-    publishable = lambda i: pkgs[i].get("publish") != []
-    roots = [i for i in members
-             if internal(i) and has_lib(i) and publishable(i) and name(i) not in skip]
-else:
-    roots = [i for i in members if name(i) in root_names]
-def deps(i):
-    out = []
-    for d in resolve[i]["deps"]:
-        if {k["kind"] for k in d["dep_kinds"]} & {None, "build"}:
-            out.append(d["pkg"])
-    return out
-seen, order = set(), []
-def visit(i):
-    if i in seen: return
-    seen.add(i)
-    for d in deps(i):
-        if internal(d): visit(d)
-    if internal(i): order.append(name(i))
-for r in roots:
-    visit(r)
-print("\n".join(order))
-PY
-)
+# --- derive the streamlib release closure in topological order ---------------
+# The closure is the SINGLE canonical set of crates a release publishes,
+# defined once in streamlib-pack (`compute_release_closure`) and emitted by
+# `cargo xtask release-closure --json`. There is deliberately NO "SDK-subset vs
+# all-libs" switch: the easy-to-skip libs (streamlib-plugin-sdk, vulkan-jpeg)
+# and the subprocess native hosts (streamlib-python-native / -deno-native) are
+# all members by definition, in dependency (topological) publish order.
+closure_json="$(cargo run -q -p xtask -- release-closure)" \
+  || fail "could not compute the release closure (cargo xtask release-closure)"
+mapfile -t ORDER < <(printf '%s' "$closure_json" | "$PY" -c '
+import json, sys
+for c in json.load(sys.stdin)["crates"]:
+    print(c["name"])
+')
 [ "${#ORDER[@]}" -gt 0 ] || fail "could not derive the streamlib closure"
 log "closure (${#ORDER[@]} crates): ${ORDER[*]}"
 log "publishing version: $target_version"
@@ -132,9 +96,14 @@ snapshot() {
 # --- optional dev-version bump (workspace version + internal dep reqs) --------
 if [ -n "$DEV_N" ]; then
   log "bumping in place: $base_version -> $target_version (restored on exit)"
-  # collect member manifests + root, snapshot, then rewrite with tomlkit
+  # collect member manifests + root, snapshot, then rewrite with tomlkit.
+  # Only libs/ + plugin/ carry the workspace-versioned engine crates the
+  # closure publishes; packages/ own INDEPENDENT semver (.slpkg version, per
+  # #1239) and are published by publish-packages.sh, so bumping their crate
+  # version here would be semantically wrong (a transient bump/restore that
+  # doesn't belong to the engine dev-version axis).
   while IFS= read -r m; do snapshot "$m"; done < <(
-    { echo Cargo.toml; find libs packages plugin -name Cargo.toml -not -path '*/target/*'; }
+    { echo Cargo.toml; find libs plugin -name Cargo.toml -not -path '*/target/*'; }
   )
   BASE="$base_version" TARGET="$target_version" "$PY" - <<'PY'
 import os, glob, tomlkit
@@ -172,8 +141,9 @@ def bump_member(path):
     if changed:
         open(path, "w").write(tomlkit.dumps(doc))
 bump_workspace()
+# libs/ + plugin/ only — packages/ own independent .slpkg semver (#1239) and
+# are not part of the engine dev-version bump.
 for m in (glob.glob("libs/**/Cargo.toml", recursive=True)
-          + glob.glob("packages/**/Cargo.toml", recursive=True)
           + glob.glob("plugin/**/Cargo.toml", recursive=True)):
     if "/target/" in m: continue
     bump_member(m)

--- a/scripts/gitea/publish-release.sh
+++ b/scripts/gitea/publish-release.sh
@@ -52,14 +52,17 @@ cd "$ROOT"
 log "publishing crate closure"
 "$HERE/publish-crates.sh" "${dev_args[@]}"
 
-# 2. Polyglot SDKs.
+# 2. Polyglot SDKs — same --dev train as the crates so the manifest's
+#    recorded SDK versions match what was actually published (Python spells
+#    the same dev train `<base>.devN` per PEP 440; the manifest records the
+#    canonical semver form).
 if [ "${SKIP_PYTHON_SDK:-0}" != 1 ]; then
-  log "publishing python SDK"; "$HERE/publish-python-sdk.sh"
+  log "publishing python SDK"; "$HERE/publish-python-sdk.sh" "${dev_args[@]}"
 else
   log "SKIP python SDK"; manifest_args+=(--skip-python)
 fi
 if [ "${SKIP_DENO_SDK:-0}" != 1 ]; then
-  log "publishing deno SDK"; "$HERE/publish-deno-sdk.sh"
+  log "publishing deno SDK"; "$HERE/publish-deno-sdk.sh" "${dev_args[@]}"
 else
   log "SKIP deno SDK"; manifest_args+=(--skip-deno)
 fi

--- a/scripts/gitea/publish-release.sh
+++ b/scripts/gitea/publish-release.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Publish a CONSISTENT, ATOMIC release of the streamlib version surface to the
+# Gitea registry: the full crate closure, the polyglot SDKs, and the packages
+# — then the release manifest, written LAST as the atomicity flip.
+#
+# The manifest at `streamlib-release/<V>/manifest.json` is the completion
+# marker: it is written only after every other artifact lands, so a consumer
+# that finds it knows the release is complete, and a consumer resolving against
+# a mid-publish registry (no manifest yet, or a manifest that doesn't list a
+# pinned crate) fails fast with an actionable "incomplete release" error
+# instead of a cryptic cargo version-unification failure.
+#
+#   ./publish-release.sh            # publish the base [workspace.package].version
+#   ./publish-release.sh --dev 3    # publish <base>-dev.3
+#
+# Honors the same SKIP_* guards as docker/build-stage1.sh so a partial release
+# (e.g. crates-only in a fast CI lane) records exactly what was published:
+#   SKIP_PYTHON_SDK=1   skip the Python SDK publish (manifest omits `python`)
+#   SKIP_DENO_SDK=1     skip the Deno SDK publish   (manifest omits `deno`)
+#   SKIP_PACKAGES=1     skip the package publish    (manifest omits `packages`)
+#
+# Registry config is by-env (shared with the other publish scripts):
+#   GITEA_URL / STREAMLIB_REGISTRY_URL   registry base URL
+#   GITEA_ORG                            org (default tatolab)
+#   CARGO_REGISTRIES_GITEA_TOKEN         cargo publish token ("Bearer <token>")
+#   STREAMLIB_REGISTRY_TOKEN             manifest-upload token (raw token)
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+DEV_N=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dev) DEV_N="${2:?--dev needs a number}"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+log()  { printf '[publish-release] %s\n' "$*"; }
+fail() { printf '[publish-release] ERROR: %s\n' "$*" >&2; exit 1; }
+
+dev_args=()
+[ -n "$DEV_N" ] && dev_args=(--dev "$DEV_N")
+
+manifest_args=()
+[ -n "$DEV_N" ] && manifest_args+=(--dev "$DEV_N")
+
+cd "$ROOT"
+
+# 1. Crate closure (the single canonical release closure — no ALL_LIBS flag).
+log "publishing crate closure"
+"$HERE/publish-crates.sh" "${dev_args[@]}"
+
+# 2. Polyglot SDKs.
+if [ "${SKIP_PYTHON_SDK:-0}" != 1 ]; then
+  log "publishing python SDK"; "$HERE/publish-python-sdk.sh"
+else
+  log "SKIP python SDK"; manifest_args+=(--skip-python)
+fi
+if [ "${SKIP_DENO_SDK:-0}" != 1 ]; then
+  log "publishing deno SDK"; "$HERE/publish-deno-sdk.sh"
+else
+  log "SKIP deno SDK"; manifest_args+=(--skip-deno)
+fi
+
+# 3. Packages (.slpkg).
+if [ "${SKIP_PACKAGES:-0}" != 1 ]; then
+  log "publishing packages (.slpkg)"; "$HERE/publish-packages.sh"
+else
+  log "SKIP packages"; manifest_args+=(--skip-packages)
+fi
+
+# 4. Release manifest — LAST. This is the atomicity flip: the release is not
+#    consumable-as-complete until this lands.
+log "publishing release manifest (marks the release complete)"
+cargo run -q -p xtask -- release-manifest-publish "${manifest_args[@]}" \
+  || fail "release manifest publish failed — the release is published but NOT marked complete"
+
+log "done — consistent release published"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -26,6 +26,7 @@ pub mod check_processor_spec_new;
 pub mod check_schema_versions;
 pub mod lint_logging;
 pub mod manifest_schema;
+pub mod release;
 
 #[derive(Parser)]
 #[command(name = "xtask")]
@@ -187,6 +188,40 @@ enum Commands {
         #[arg(long)]
         dir: PathBuf,
     },
+
+    /// Emit the engine **release closure** as JSON — the single canonical set
+    /// of crates a release publishes (every publishable `streamlib*` /
+    /// `vulkan-jpeg` library crate), in topological publish order.
+    /// `scripts/gitea/publish-crates.sh` consumes this instead of a
+    /// human-remembered "publish everything" flag.
+    ReleaseClosure {
+        /// Stamp the `-dev.N` prerelease suffix on the emitted versions (matches
+        /// `publish-crates.sh --dev N`).
+        #[arg(long)]
+        dev: Option<u32>,
+    },
+
+    /// Publish the **release manifest** for the current workspace to the
+    /// configured registry — the atomicity flip, run LAST in the release
+    /// sequence (after crates + SDKs + packages land). Its presence marks the
+    /// release complete; a consumer resolving against a partial registry
+    /// detects the gap. Requires `STREAMLIB_REGISTRY_URL` (or `GITEA_URL`) +
+    /// `STREAMLIB_REGISTRY_TOKEN`.
+    ReleaseManifestPublish {
+        /// Stamp the `-dev.N` prerelease suffix (matches `--dev N` on the
+        /// crate publish).
+        #[arg(long)]
+        dev: Option<u32>,
+        /// Record no Python SDK in the manifest (the SDK publish was skipped).
+        #[arg(long)]
+        skip_python: bool,
+        /// Record no Deno SDK in the manifest (the SDK publish was skipped).
+        #[arg(long)]
+        skip_deno: bool,
+        /// Record no packages in the manifest (the package publish was skipped).
+        #[arg(long)]
+        skip_packages: bool,
+    },
 }
 
 fn main() -> Result<()> {
@@ -245,6 +280,23 @@ fn main() -> Result<()> {
             })?;
             tracing::info!(dir = %dir.display(), "stripped path-flavor patch entries from streamlib.yaml");
         }
+        Commands::ReleaseClosure { dev } => {
+            release::emit_closure_json(&workspace_root()?, dev)?
+        }
+        Commands::ReleaseManifestPublish {
+            dev,
+            skip_python,
+            skip_deno,
+            skip_packages,
+        } => release::publish_manifest(
+            &workspace_root()?,
+            &release::PublishManifestOptions {
+                dev,
+                skip_python,
+                skip_deno,
+                skip_packages,
+            },
+        )?,
     }
 
     Ok(())

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -1,0 +1,179 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Release-closure emission + release-manifest publish.
+//!
+//! Two verbs back the atomic-release publish flow:
+//!
+//! - `release-closure --json` — the single canonical definition of "the
+//!   crates a release publishes," emitted for `scripts/gitea/publish-crates.sh`
+//!   to consume so the closure is defined once, in code, not in a script.
+//! - `release-manifest-publish` — writes the [`ReleaseManifest`] to the
+//!   registry **last**, after every crate / SDK / package has landed. Its
+//!   presence marks the release complete; a consumer resolving against a
+//!   half-published registry detects the gap up front.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use streamlib_idents::{
+    RegistryClient, RegistryConfig, ReleaseManifest, ReleaseManifestMember,
+};
+use streamlib_pack::compute_release_closure;
+
+/// Read `[workspace.package].version` from the workspace `Cargo.toml`.
+fn workspace_version(workspace_root: &Path) -> Result<String> {
+    let path = workspace_root.join("Cargo.toml");
+    let body = std::fs::read_to_string(&path)
+        .with_context(|| format!("reading {}", path.display()))?;
+    let doc: toml::Value =
+        toml::from_str(&body).with_context(|| format!("parsing {}", path.display()))?;
+    doc.get("workspace")
+        .and_then(|w| w.get("package"))
+        .and_then(|p| p.get("version"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .context("[workspace.package].version missing from workspace Cargo.toml")
+}
+
+/// Apply the `-dev.N` suffix to a base version when `dev` is set.
+fn target_version(base: &str, dev: Option<u32>) -> String {
+    match dev {
+        Some(n) => format!("{base}-dev.{n}"),
+        None => base.to_string(),
+    }
+}
+
+/// The registry org the release lives under (`GITEA_ORG`, default `tatolab`).
+fn registry_org() -> String {
+    std::env::var("GITEA_ORG")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "tatolab".to_string())
+}
+
+/// Emit the release closure as JSON on stdout for the publish scripts.
+/// Shape: `{"release_version","crates":[{"name","version","manifest_dir"}]}`,
+/// with `crates` in topological publish order.
+pub fn emit_closure_json(workspace_root: &Path, dev: Option<u32>) -> Result<()> {
+    let base = workspace_version(workspace_root)?;
+    let target = target_version(&base, dev);
+    let closure = compute_release_closure(workspace_root)?;
+    let crates: Vec<serde_json::Value> = closure
+        .crates
+        .iter()
+        .map(|c| {
+            // All closure crates inherit the workspace version, so a --dev
+            // publish stamps every one at the target; record what's published.
+            let version = if dev.is_some() { target.clone() } else { c.version.clone() };
+            serde_json::json!({
+                "name": c.name,
+                "version": version,
+                "manifest_dir": c.manifest_dir,
+            })
+        })
+        .collect();
+    let out = serde_json::json!({
+        "release_version": target,
+        "crates": crates,
+    });
+    println!("{}", serde_json::to_string_pretty(&out)?);
+    Ok(())
+}
+
+/// A polyglot package's release member (`@org/name` @ version), read from its
+/// `streamlib.yaml`.
+fn enumerate_packages(workspace_root: &Path) -> Result<Vec<ReleaseManifestMember>> {
+    #[derive(serde::Deserialize)]
+    struct Pkg {
+        org: String,
+        name: String,
+        version: String,
+    }
+    #[derive(serde::Deserialize)]
+    struct Yaml {
+        package: Option<Pkg>,
+    }
+
+    let packages_dir = workspace_root.join("packages");
+    let mut members = Vec::new();
+    if !packages_dir.is_dir() {
+        return Ok(members);
+    }
+    for entry in std::fs::read_dir(&packages_dir)
+        .with_context(|| format!("reading {}", packages_dir.display()))?
+    {
+        let entry = entry?;
+        let yaml_path = entry.path().join("streamlib.yaml");
+        if !yaml_path.is_file() {
+            continue;
+        }
+        let body = std::fs::read_to_string(&yaml_path)
+            .with_context(|| format!("reading {}", yaml_path.display()))?;
+        let parsed: Yaml = serde_yaml::from_str(&body)
+            .with_context(|| format!("parsing {}", yaml_path.display()))?;
+        if let Some(p) = parsed.package {
+            members.push(ReleaseManifestMember::new(
+                format!("@{}/{}", p.org, p.name),
+                p.version,
+            ));
+        }
+    }
+    members.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(members)
+}
+
+/// Options for [`publish_manifest`], mirroring the publish scripts' `SKIP_*`
+/// guards so the manifest records exactly what was published.
+pub struct PublishManifestOptions {
+    pub dev: Option<u32>,
+    pub skip_python: bool,
+    pub skip_deno: bool,
+    pub skip_packages: bool,
+}
+
+/// Build the [`ReleaseManifest`] for the current workspace and publish it to
+/// the configured registry — the atomicity flip run **last** in the release
+/// sequence.
+pub fn publish_manifest(workspace_root: &Path, opts: &PublishManifestOptions) -> Result<()> {
+    let base = workspace_version(workspace_root)?;
+    let target = target_version(&base, opts.dev);
+
+    let closure = compute_release_closure(workspace_root)?;
+    let crate_members: Vec<ReleaseManifestMember> = closure
+        .crates
+        .iter()
+        .map(|c| {
+            let version = if opts.dev.is_some() { target.clone() } else { c.version.clone() };
+            ReleaseManifestMember::new(c.name.clone(), version)
+        })
+        .collect();
+
+    let mut manifest = ReleaseManifest::new(target.clone(), crate_members);
+    if !opts.skip_python {
+        manifest.python = Some(target.clone());
+    }
+    if !opts.skip_deno {
+        manifest.deno = Some(target.clone());
+    }
+    if !opts.skip_packages {
+        manifest.packages = enumerate_packages(workspace_root)?;
+    }
+
+    let config = RegistryConfig::from_env().context(
+        "no registry configured — set STREAMLIB_REGISTRY_URL (or GITEA_URL) and \
+         STREAMLIB_REGISTRY_TOKEN to publish the release manifest",
+    )?;
+    let org = registry_org();
+    let url = RegistryClient::new(&config)
+        .upload_release_manifest(&org, &manifest)
+        .context("uploading release manifest")?;
+    tracing::info!(
+        release_version = %target,
+        crates = manifest.crates.len(),
+        packages = manifest.packages.len(),
+        url = %url,
+        "published release manifest (release marked complete)"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Implements the atomic-release model from #1218: a release is a **defined closure published as one unit**, marked complete by a **release manifest written last**, with **consumer-side pre-cargo detection** of partial registries. This closes the `0.4.36` failure class where `streamlib-plugin-sdk` + `vulkan-jpeg` were silently skipped and the consumer failed cryptically deep in cargo / `streamlib-macros` version unification (#1213).

## Architecture

**1. Closure by definition — the `STREAMLIB_PUBLISH_ALL_LIBS` foot-gun is deleted.**
- `streamlib_pack::compute_release_closure` is the single canonical definition of "the crates a release publishes": every publishable `streamlib*` / `vulkan-jpeg` workspace library crate, in topological publish order, derived live from `cargo metadata`. There is no "SDK-subset vs all-libs" switch to get wrong — the easy-to-skip libs are members by construction (30 crates today, incl. `streamlib-plugin-sdk`, `vulkan-jpeg`, both subprocess native hosts).
- `streamlib-cli`'s `link.rs` `derive_linkable_crates` migrated to it (no-bad-patterns sweep — one predicate, not two).
- New `cargo xtask release-closure --json`; `scripts/gitea/publish-crates.sh` consumes it, replacing its inline Python closure. `STREAMLIB_PUBLISH_ALL_LIBS` is gone from the script and from `docker/build-stage1.sh`.
- The test-fixture packages now declare `publish = false` — the old name-based skip list becomes config-enforced by the closure predicate.

**2. Atomic-enough publish — the manifest flips last.**
- `ReleaseManifest` (serde, forward-compatible) in `streamlib-idents`, published to the reserved generic channel `streamlib-release/<V>/manifest.json` via `RegistryClient::upload_release_manifest` / `fetch_release_manifest` / `list_release_versions` — identical on `file://` and `http(s)://` (the http upload also maintains the channel's anonymous version index, mirroring `upload_slpkg`).
- `scripts/gitea/publish-release.sh` orchestrates crates → Python SDK → Deno SDK → packages → **manifest last** (via `cargo xtask release-manifest-publish`). `SKIP_*` guards are honored and recorded in the manifest; `--dev N` rides through to the SDK publishes so the manifest records what was actually published.
- Manifest presence == release complete, by protocol. A publish that dies mid-way leaves no manifest → consumers treat it as pre-release-model (warn + proceed) rather than trusting a half-published set.

**3. Consumer-side detection — typed, pre-cargo, range-aware.**
- `streamlib_cargo_build::read_gitea_registry_pins` reads a package's direct `registry = "gitea"` cargo pins (normal/build/cfg-target deps, renamed via `package =`, dev-deps excluded), carrying the raw cargo req.
- The build orchestrator (both the package materialize path and the native-host build) runs `release_check::assert_release_complete` **before cargo**. Resolution is range-aware: pins are floor reqs (`0.5.0` = `^0.5.0` per cargo) that lag the released version, so each pin validates against the **newest listed release satisfying its range** — the release cargo's own max-satisfying resolution lands on. Exact `=` pins validate their own release.
- A provably-partial release fires the new typed `BuildError::IncompleteRelease { package, release_version, missing, hint }` naming every missing `name@req` — replacing the opaque `cargo build … failed. See cargo's output above.` for this failure class.
- Back-compat: manifest absent for a version → `tracing::warn` + proceed (pre-atomic-release registries); transient transport errors also degrade to warn + proceed (cargo remains the hard gate).

## #1213 revalidation — what was and wasn't proven

The `mavlink_over_udp` scenario is revalidated **hermetically against a `file://` scratch registry** (`mavlink_1213_scenario_against_file_registry`): the real `packages/mavlink/Cargo.toml` pins (which include `streamlib-plugin-sdk`, the exact #1213 crate) are checked against a release manifest published at **floor+1 patch** (mirroring the real tree where pins floor `0.5.0` and the release is `0.5.1`). Partial manifest (plugin-sdk omitted) → typed fast-fail naming `streamlib-plugin-sdk`; complete manifest → clean pass.

**Not proven:** a run against a live Gitea daemon (registry-only CI is intentionally down pending the static-file registry work), and the standalone drone-racer build itself (separate repo). The `file://` transport shares the same `RegistryClient` code paths as http except the wire (locked separately by the localhost http tests), so the equivalence is code-level, not deployment-level.

## Independent review round

An Opus review flagged (all verified against code, all addressed):
- **[FIX] Version-keying drift** — the initial pre-check keyed on the pin's floor version while releases publish at the workspace version, making the gate a no-op in steady state (86 pins at `0.5.0` vs release `0.5.1`). Fixed with range-aware newest-satisfying-release resolution + a test that fails under exact-floor keying.
- **[FIX] Feel-good mavlink test** — originally built the manifest from the pins themselves. Now publishes at floor+1 so it exercises production keying.
- **[DISCUSS] `--dev` glob narrowing** — reverted: `bump_member` only rewrites path+version dep *reqs* (never `[package].version`, so package semver was never at risk), and the workspace-member test-fixture packages' path deps into `libs/` must track the transient dev version or workspace resolution breaks during a `--dev` publish. The plan's fold-in premise was misdiagnosed; comments corrected in place. (Deviation from the task plan, with evidence.)
- **[DISCUSS] SDK version mismatch on `--dev` releases** — `publish-release.sh` now passes `--dev` to the SDK publish scripts (both already support it), so the manifest records reality.

## Negative-revert evidence

- `floor_pin_resolves_against_newest_satisfying_release`: revert range-aware keying to exact-floor → `fetch(0.5.0)` finds nothing → partial `0.5.1` release sails through → test fails.
- `release_closure_includes_the_easy_to_skip_libs_by_definition`: revert the closure predicate to the old SDK-subset roots → `streamlib-plugin-sdk` / `vulkan-jpeg` drop out (the exact 0.4.36 foot-gun) → test fails; revert the publishable filter → test-fixtures leak in → test fails.
- `absent_manifest_proceeds_back_compat`: revert the `Ok(None)` arm to an error → every pre-atomic-release registry wrongly blocks → test fails.
- Removing the pre-check entirely returns the exact pre-#1218 behavior: the opaque cargo `failed to select a version for streamlib-plugin-sdk = ^0.5.1` deep in the build.

## Tests / validation

- `cargo check --workspace --offline` — clean (0 errors).
- `cargo test -p streamlib-idents -p streamlib-pack -p streamlib-cargo-build -p streamlib-build-orchestrator -p streamlib-cli -p xtask --offline` — all green (418 tests across the six crates; incl. 6 new release_check tests, 5 release-manifest tests, closure + pins tests).
- End-to-end: `cargo xtask release-manifest-publish` against a `file://` scratch registry writes `streamlib-release/0.5.1/manifest.json` with 30 crates + both SDKs + 22 packages; `release-closure --json` emits the topo-ordered closure.
- `shellcheck` clean on `publish-release.sh`, `publish-crates.sh` (one pre-existing SC2034), `build-stage1.sh`.

## Known blind spot (structural, closed by the static tree)

The consumer net **cannot see manifestless partials ABOVE the newest complete release**: if a publish aborts after some crates land in the cargo index but before the release manifest flips, those newer crate versions are invisible to the completeness check (no manifest exists at that version to validate against — the check keys on published release manifests, and cargo's own index still serves the orphaned crates). Cargo remains the hard gate for that window. This is closed structurally by the static registry tree's staged-swap publish in #1219 (already in that plan): a staged tree swap makes crates and manifest appear atomically, so an aborted publish leaves nothing visible at all.

## Pre-merge test batch

A final review batch added wiring-level locks (both `assert_release_complete` call sites are now covered by tests that drive `materialize` / `ensure_native_host` against a partial file:// registry — deleting either call fails a test), a transport-error degradation test (unreachable registry ⇒ proceed), an `IncompleteRelease` Display render test, a prerelease-pin (`-dev.N`) keying test, tempdir RAII in the registry round-trip test, and the `publish-crates.sh` header rewrite off the stale "14-crate chain" description.

## Findings for adjacent issues

- **#1219 (static-file registry tree):** the release manifest is written last through the same `RegistryClient` seam on both transports — the static tree's write side can ride this ordering directly (`streamlib-release/<V>/manifest.json` is already a plain file in the `file://` layout). The manifest-absent → warn back-compat should be revisited for strictness when the index format lands.
- **#1221 (application lockfile):** the completeness-checked sets (release manifest members) are exactly what a lockfile should pin against — a locked install can record the release version and skip the per-build manifest fetch.

Closes #1218

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wr1VLKMBbFpsmU7zAcniU2

