### PR TITLE
feat(registry): publish-time catalog of processors/ports/schemas

### DIFF
--- a/libs/streamlib-idents/src/catalog.rs
+++ b/libs/streamlib-idents/src/catalog.rs
@@ -1,0 +1,528 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Publish-time processor/port/schema catalog — the queryable metadata a
+//! client browses to answer "what processors exist and how do they wire
+//! together" without downloading and compiling every package.
+//!
+//! The catalog is a deterministic function of a package's `streamlib.yaml`
+//! (built at publish time by `streamlib-pack`) written into the static
+//! registry tree alongside the artifacts:
+//!
+//! - Per-package `slpkg/<name>/<version>/<name>.catalog.json` — the
+//!   [`PackageCatalog`] for one published package.
+//! - Per-schema `slpkg/<name>/<version>/schemas/<Type>.jtd.json` — the JSON
+//!   Type Definition for each schema the package OWNS (deduped by ownership;
+//!   a package emits only the schemas it declares locally).
+//! - Registry-wide `catalog/index.ndjson` — one [`CatalogIndexLine`] per
+//!   processor across every published package (the node-palette aggregate).
+//!
+//! Port and config schema references are RESOLVED to release-core
+//! [`SchemaIdent`]s at publish time (bare `Named` refs are looked up against
+//! the manifest's `schemas:` map), so a client never re-implements
+//! resolution — it reads the fully-qualified ident and, if it wants the
+//! field-level shape, fetches the matching `.jtd.json`.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::error::{ResolverError, ResolverResult};
+use crate::ident::{PackageRef, SchemaIdent, TypeName};
+use crate::semver::SemVer;
+
+/// Tree-relative path of the registry-wide processor index (NDJSON).
+pub const CATALOG_INDEX_PATH: &str = "catalog/index.ndjson";
+
+/// The per-package catalog filename for a package named `pkg_name`
+/// (`<name>.catalog.json`), written into the package's version directory
+/// beside its `.slpkg`.
+pub fn package_catalog_file_name(pkg_name: &str) -> String {
+    format!("{pkg_name}.catalog.json")
+}
+
+/// The per-schema JTD filename for a type (`<Type>.jtd.json`), written under
+/// the owning package's `schemas/` subdirectory.
+pub fn schema_jtd_file_name(type_name: &TypeName) -> String {
+    format!("{}.jtd.json", type_name.as_str())
+}
+
+/// Processor runtime language recorded in the catalog. A lean mirror of the
+/// authored `runtime` field, decoupled from the engine / processor-schema
+/// types so the catalog stays engine-free and registry-local.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CatalogRuntime {
+    Rust,
+    Python,
+    #[serde(alias = "deno")]
+    TypeScript,
+}
+
+/// A resolved schema reference on a catalog port: either the `any` wildcard
+/// or a fully-qualified release-core [`SchemaIdent`].
+///
+/// Wire form mirrors the authoring convention: the literal string `"any"`
+/// for the wildcard, or the structured four-field `SchemaIdent` map for a
+/// specific type. Unambiguous by construction — a string is always the
+/// wildcard, a map is always a concrete ident.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CatalogSchemaRef {
+    /// Wildcard — the port accepts any payload.
+    Any,
+    /// A concrete, release-core-projected schema identity.
+    Schema(SchemaIdent),
+}
+
+impl CatalogSchemaRef {
+    /// The inner [`SchemaIdent`] when this is a concrete reference.
+    pub fn schema(&self) -> Option<&SchemaIdent> {
+        match self {
+            Self::Schema(ident) => Some(ident),
+            Self::Any => None,
+        }
+    }
+}
+
+impl Serialize for CatalogSchemaRef {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Any => serializer.serialize_str("any"),
+            Self::Schema(ident) => ident.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CatalogSchemaRef {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            Wildcard(String),
+            Schema(SchemaIdent),
+        }
+        match Repr::deserialize(deserializer)? {
+            Repr::Wildcard(s) if s == "any" => Ok(Self::Any),
+            Repr::Wildcard(s) => Err(serde::de::Error::custom(format!(
+                "catalog port schema must be the literal \"any\" or a structured \
+                 schema-ident map; got the string \"{s}\""
+            ))),
+            Repr::Schema(ident) => Ok(Self::Schema(ident)),
+        }
+    }
+}
+
+/// An input or output port of a catalog processor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CatalogPort {
+    /// Port name (e.g. `video_in`).
+    pub name: String,
+    /// Human-readable description, when the manifest declares one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Resolved schema flowing through this port.
+    pub schema: CatalogSchemaRef,
+    /// Declared read mode for an input port (e.g. `skip_to_latest`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub read_mode: Option<String>,
+}
+
+/// The config binding of a catalog processor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CatalogConfig {
+    /// Config field name (e.g. `config`).
+    pub name: String,
+    /// Resolved config schema identity (always concrete — config refs are
+    /// never wildcards).
+    pub schema: SchemaIdent,
+}
+
+/// One processor described for the node palette: its identity, runtime,
+/// entrypoint, config binding, and typed input/output ports.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CatalogProcessor {
+    /// Processor short name (e.g. `Camera`).
+    pub name: String,
+    /// Human-readable description, when the manifest declares one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Runtime language.
+    pub runtime: CatalogRuntime,
+    /// Entrypoint for non-Rust runtimes (e.g. `src.blur:BlurProcessor`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entrypoint: Option<String>,
+    /// Config binding, when the processor declares one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config: Option<CatalogConfig>,
+    /// Input ports.
+    #[serde(default)]
+    pub inputs: Vec<CatalogPort>,
+    /// Output ports.
+    #[serde(default)]
+    pub outputs: Vec<CatalogPort>,
+}
+
+/// The catalog for one published package — its processors, resolved.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PackageCatalog {
+    /// The `@org/name` this catalog describes.
+    pub package: PackageRef,
+    /// The published version.
+    pub version: SemVer,
+    /// Processors this package contributes.
+    #[serde(default)]
+    pub processors: Vec<CatalogProcessor>,
+}
+
+/// One line of the registry-wide `catalog/index.ndjson` — a self-contained
+/// per-processor record. The full node-palette / wiring graph is
+/// reconstructable from the aggregate alone, without fetching any
+/// per-package catalog or `.slpkg`.
+///
+/// Extra fields a future index might carry are ignored on read (serde's
+/// default), so the shape can grow without breaking older readers — the
+/// same forward-compat contract as the version index.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CatalogIndexLine {
+    /// The owning `@org/name`.
+    pub package: PackageRef,
+    /// The published version of the owning package.
+    pub version: SemVer,
+    /// The processor record.
+    pub processor: CatalogProcessor,
+}
+
+/// Render index lines as NDJSON (one JSON object per line, trailing newline) —
+/// the byte shape written to `catalog/index.ndjson`. Mirrors the version-index
+/// NDJSON pattern in the registry client.
+pub fn render_catalog_index_ndjson(lines: &[CatalogIndexLine]) -> String {
+    let mut out = String::new();
+    for line in lines {
+        // A struct of owned, already-validated data serializes infallibly.
+        out.push_str(&serde_json::to_string(line).expect("serialize catalog index line"));
+        out.push('\n');
+    }
+    out
+}
+
+/// Parse NDJSON index bytes into catalog lines. Blank and unparseable lines
+/// are skipped, so a partially corrupt index degrades to "fewer processors"
+/// rather than a hard failure — parity with the version-index reader.
+pub fn parse_catalog_index_ndjson(body: &[u8]) -> Vec<CatalogIndexLine> {
+    String::from_utf8_lossy(body)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str::<CatalogIndexLine>(l).ok())
+        .collect()
+}
+
+/// Tokenless read client over a static registry tree's catalog surface.
+///
+/// Points at the tree ROOT (the directory that holds `slpkg/`, `cargo/`,
+/// `catalog/`, …) — `file://<root>` for a local / CI tree or `http(s)://…`
+/// for a static mount. Every read is anonymous; a configured `token` is sent
+/// only for private mounts that gate generic reads behind auth. Serves both
+/// the editor's node palette (via [`Self::fetch_processor_index`]) and a
+/// browse UI (via [`Self::fetch_package_catalog`] +
+/// [`Self::fetch_schema_type_definition`]).
+pub struct CatalogClient {
+    base_url: String,
+    token: Option<String>,
+}
+
+impl CatalogClient {
+    /// Build a client over a tree-root `base_url` (`file://…` or
+    /// `http(s)://…`). `token` is optional and only used for private mounts.
+    pub fn new(base_url: impl Into<String>, token: Option<String>) -> Self {
+        Self {
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            token,
+        }
+    }
+
+    fn is_file_scheme(&self) -> bool {
+        self.base_url.starts_with("file://")
+    }
+
+    fn file_root(&self) -> PathBuf {
+        PathBuf::from(self.base_url.trim_start_matches("file://"))
+    }
+
+    /// Read a tree-relative file. `Ok(None)` when it is absent (missing file /
+    /// HTTP 404); `Err` only on a real transport failure.
+    fn fetch_relative(&self, rel: &str) -> ResolverResult<Option<Vec<u8>>> {
+        if self.is_file_scheme() {
+            let path = self.file_root().join(rel);
+            match std::fs::read(&path) {
+                Ok(b) => Ok(Some(b)),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+                Err(e) => Err(ResolverError::RegistryFetchFailed {
+                    name: rel.to_string(),
+                    detail: format!("reading {} : {e}", path.display()),
+                }),
+            }
+        } else {
+            let url = format!("{}/{}", self.base_url, rel);
+            crate::registry::http_get_optional(&url, self.token.as_deref()).map_err(|detail| {
+                ResolverError::RegistryFetchFailed {
+                    name: rel.to_string(),
+                    detail: format!("fetching {url}: {detail}"),
+                }
+            })
+        }
+    }
+
+    /// Fetch the registry-wide processor index (`catalog/index.ndjson`). An
+    /// absent index yields an empty list — parity with the version index's
+    /// missing-file case.
+    pub fn fetch_processor_index(&self) -> ResolverResult<Vec<CatalogIndexLine>> {
+        match self.fetch_relative(CATALOG_INDEX_PATH)? {
+            Some(body) => Ok(parse_catalog_index_ndjson(&body)),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    /// Fetch the per-package catalog for an exact `(package, version)`.
+    /// `Ok(None)` when no catalog is published for that pair.
+    pub fn fetch_package_catalog(
+        &self,
+        package: &PackageRef,
+        version: &SemVer,
+    ) -> ResolverResult<Option<PackageCatalog>> {
+        let rel = format!(
+            "slpkg/{}/{}/{}",
+            package.name.as_str(),
+            version,
+            package_catalog_file_name(package.name.as_str()),
+        );
+        let Some(body) = self.fetch_relative(&rel)? else {
+            return Ok(None);
+        };
+        let catalog = serde_json::from_slice(&body).map_err(|e| ResolverError::RegistryFetchFailed {
+            name: rel,
+            detail: format!("parsing package catalog JSON: {e}"),
+        })?;
+        Ok(Some(catalog))
+    }
+
+    /// Fetch the JSON Type Definition for a schema `ident`, from the OWNING
+    /// package's version directory. `Ok(None)` when no JTD is published for
+    /// that ident. Returned as a [`serde_json::Value`] — the JTD is a
+    /// self-describing document the caller renders / validates against.
+    pub fn fetch_schema_type_definition(
+        &self,
+        ident: &SchemaIdent,
+    ) -> ResolverResult<Option<serde_json::Value>> {
+        let rel = format!(
+            "slpkg/{}/{}/schemas/{}",
+            ident.package.as_str(),
+            ident.version,
+            schema_jtd_file_name(&ident.r#type),
+        );
+        let Some(body) = self.fetch_relative(&rel)? else {
+            return Ok(None);
+        };
+        let value = serde_json::from_slice(&body).map_err(|e| ResolverError::RegistryFetchFailed {
+            name: rel,
+            detail: format!("parsing schema JTD JSON: {e}"),
+        })?;
+        Ok(Some(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ident::{Org, Package};
+
+    fn ident(pkg: &str, ty: &str, v: SemVer) -> SchemaIdent {
+        SchemaIdent::new(
+            Org::new("tatolab").unwrap(),
+            Package::new(pkg).unwrap(),
+            TypeName::new(ty).unwrap(),
+            v,
+        )
+    }
+
+    fn pkg_ref(name: &str) -> PackageRef {
+        PackageRef::new(Org::new("tatolab").unwrap(), Package::new(name).unwrap())
+    }
+
+    fn sample_processor() -> CatalogProcessor {
+        CatalogProcessor {
+            name: "Camera".into(),
+            description: Some("Captures video".into()),
+            runtime: CatalogRuntime::Rust,
+            entrypoint: None,
+            config: Some(CatalogConfig {
+                name: "config".into(),
+                schema: ident("camera", "CameraConfig", SemVer::new(1, 0, 0)),
+            }),
+            inputs: vec![],
+            outputs: vec![CatalogPort {
+                name: "video".into(),
+                description: Some("Live frames".into()),
+                schema: CatalogSchemaRef::Schema(ident("core", "VideoFrame", SemVer::new(1, 0, 0))),
+                read_mode: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn schema_ref_any_serializes_as_string_and_round_trips() {
+        let any = CatalogSchemaRef::Any;
+        let json = serde_json::to_string(&any).unwrap();
+        assert_eq!(json, "\"any\"");
+        let back: CatalogSchemaRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, CatalogSchemaRef::Any);
+    }
+
+    #[test]
+    fn schema_ref_specific_serializes_as_ident_map_and_round_trips() {
+        let r = CatalogSchemaRef::Schema(ident("core", "VideoFrame", SemVer::new(1, 2, 3)));
+        let json = serde_json::to_string(&r).unwrap();
+        // Structured four-field map — never a joined shorthand string.
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["org"], "tatolab");
+        assert_eq!(v["package"], "core");
+        assert_eq!(v["type"], "VideoFrame");
+        assert_eq!(v["version"], "1.2.3");
+        let back: CatalogSchemaRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, r);
+    }
+
+    #[test]
+    fn schema_ref_rejects_non_any_string() {
+        // A bare string that is NOT "any" is a resolution leak — reject it so
+        // an unresolved bare name can never masquerade as a catalog schema.
+        let err = serde_json::from_str::<CatalogSchemaRef>("\"VideoFrame\"").unwrap_err();
+        assert!(err.to_string().contains("any"), "msg: {err}");
+    }
+
+    #[test]
+    fn package_catalog_round_trips_through_json() {
+        let catalog = PackageCatalog {
+            package: pkg_ref("camera"),
+            version: SemVer::new(1, 0, 0),
+            processors: vec![sample_processor()],
+        };
+        let json = serde_json::to_string_pretty(&catalog).unwrap();
+        let back: PackageCatalog = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, catalog);
+    }
+
+    #[test]
+    fn index_ndjson_render_parse_round_trip() {
+        let lines = vec![
+            CatalogIndexLine {
+                package: pkg_ref("camera"),
+                version: SemVer::new(1, 0, 0),
+                processor: sample_processor(),
+            },
+            CatalogIndexLine {
+                package: pkg_ref("display"),
+                version: SemVer::new(1, 0, 0),
+                processor: CatalogProcessor {
+                    name: "Display".into(),
+                    description: None,
+                    runtime: CatalogRuntime::Rust,
+                    entrypoint: None,
+                    config: None,
+                    inputs: vec![CatalogPort {
+                        name: "video_in".into(),
+                        description: None,
+                        schema: CatalogSchemaRef::Any,
+                        read_mode: Some("skip_to_latest".into()),
+                    }],
+                    outputs: vec![],
+                },
+            },
+        ];
+        let rendered = render_catalog_index_ndjson(&lines);
+        assert_eq!(rendered.lines().count(), 2);
+        assert!(rendered.ends_with('\n'));
+        let parsed = parse_catalog_index_ndjson(rendered.as_bytes());
+        assert_eq!(parsed, lines);
+    }
+
+    #[test]
+    fn index_ndjson_ignores_unknown_fields_and_garbage_lines() {
+        // Forward-compat: a line carrying an extra top-level field parses
+        // fine (unknown fields ignored); blank + non-JSON lines are skipped.
+        let base = CatalogIndexLine {
+            package: pkg_ref("camera"),
+            version: SemVer::new(1, 0, 0),
+            processor: sample_processor(),
+        };
+        let mut obj: serde_json::Value = serde_json::to_value(&base).unwrap();
+        obj["future_field_added_later"] = serde_json::json!({"whatever": 42});
+        let ndjson = format!("\n{}\nnot-json\n\n", serde_json::to_string(&obj).unwrap());
+        let parsed = parse_catalog_index_ndjson(ndjson.as_bytes());
+        assert_eq!(parsed, vec![base]);
+    }
+
+    #[test]
+    fn catalog_client_file_scheme_reads_index_and_package_and_jtd() {
+        let root = tempfile::tempdir().unwrap();
+        let base = root.path();
+        // Aggregate index.
+        let line = CatalogIndexLine {
+            package: pkg_ref("camera"),
+            version: SemVer::new(1, 0, 0),
+            processor: sample_processor(),
+        };
+        std::fs::create_dir_all(base.join("catalog")).unwrap();
+        std::fs::write(
+            base.join(CATALOG_INDEX_PATH),
+            render_catalog_index_ndjson(std::slice::from_ref(&line)),
+        )
+        .unwrap();
+        // Per-package catalog.
+        let ver_dir = base.join("slpkg/camera/1.0.0");
+        std::fs::create_dir_all(ver_dir.join("schemas")).unwrap();
+        let catalog = PackageCatalog {
+            package: pkg_ref("camera"),
+            version: SemVer::new(1, 0, 0),
+            processors: vec![sample_processor()],
+        };
+        std::fs::write(
+            ver_dir.join(package_catalog_file_name("camera")),
+            serde_json::to_vec_pretty(&catalog).unwrap(),
+        )
+        .unwrap();
+        // Owned JTD (camera owns CameraConfig).
+        let jtd = serde_json::json!({"metadata": {"type": "CameraConfig"}, "properties": {}});
+        std::fs::write(
+            ver_dir.join("schemas").join("CameraConfig.jtd.json"),
+            serde_json::to_vec(&jtd).unwrap(),
+        )
+        .unwrap();
+
+        let client = CatalogClient::new(format!("file://{}", base.display()), None);
+        assert_eq!(client.fetch_processor_index().unwrap(), vec![line]);
+        assert_eq!(
+            client.fetch_package_catalog(&pkg_ref("camera"), &SemVer::new(1, 0, 0)).unwrap(),
+            Some(catalog)
+        );
+        let fetched_jtd = client
+            .fetch_schema_type_definition(&ident("camera", "CameraConfig", SemVer::new(1, 0, 0)))
+            .unwrap()
+            .unwrap();
+        assert_eq!(fetched_jtd["metadata"]["type"], "CameraConfig");
+    }
+
+    #[test]
+    fn catalog_client_missing_index_and_package_are_empty_not_error() {
+        let root = tempfile::tempdir().unwrap();
+        let client = CatalogClient::new(format!("file://{}", root.path().display()), None);
+        assert!(client.fetch_processor_index().unwrap().is_empty());
+        assert!(client
+            .fetch_package_catalog(&pkg_ref("nope"), &SemVer::new(9, 9, 9))
+            .unwrap()
+            .is_none());
+        assert!(client
+            .fetch_schema_type_definition(&ident("nope", "Nope", SemVer::new(9, 9, 9)))
+            .unwrap()
+            .is_none());
+    }
+}

--- a/libs/streamlib-idents/src/error.rs
+++ b/libs/streamlib-idents/src/error.rs
@@ -165,6 +165,17 @@ pub enum ResolverError {
         dep: String,
     },
 
+    #[error(
+        "bare schema name `{name}` resolution cycles through external imports \
+         (resolution chain: {chain:?}). Two packages re-export the type from each \
+         other; declare it as `{{ file: ... }}` in the package that actually owns it."
+    )]
+    BareSchemaNameCycle {
+        name: String,
+        package: String,
+        chain: Vec<String>,
+    },
+
     #[error(transparent)]
     Ident(#[from] IdentError),
 }

--- a/libs/streamlib-idents/src/lib.rs
+++ b/libs/streamlib-idents/src/lib.rs
@@ -8,6 +8,7 @@
 //! by typed YAML/JSON deserialization. There is no public `parse` API and
 //! none should be added — see `docs/architecture/schema-identity-and-packaging.md`.
 
+mod catalog;
 mod error;
 mod git;
 mod ident;
@@ -17,6 +18,12 @@ mod registry;
 mod release;
 mod resolver;
 mod semver;
+
+pub use catalog::{
+    package_catalog_file_name, parse_catalog_index_ndjson, render_catalog_index_ndjson,
+    schema_jtd_file_name, CatalogClient, CatalogConfig, CatalogIndexLine, CatalogPort,
+    CatalogProcessor, CatalogRuntime, CatalogSchemaRef, PackageCatalog, CATALOG_INDEX_PATH,
+};
 
 pub use error::{IdentError, IdentResult, ResolverError, ResolverResult};
 pub use git::fetch_git;

--- a/libs/streamlib-idents/src/registry.rs
+++ b/libs/streamlib-idents/src/registry.rs
@@ -548,8 +548,9 @@ fn merge_versions(mut versions: Vec<SemVer>) -> Vec<SemVer> {
 }
 
 /// Blocking GET that distinguishes a `404` (`Ok(None)`) from a real transport
-/// or non-404 status error (`Err`). Used for the optional version index.
-fn http_get_optional(url: &str, token: Option<&str>) -> Result<Option<Vec<u8>>, String> {
+/// or non-404 status error (`Err`). Used for the optional version index and
+/// the catalog client's tree-relative reads.
+pub(crate) fn http_get_optional(url: &str, token: Option<&str>) -> Result<Option<Vec<u8>>, String> {
     let mut req = ureq::get(url);
     if let Some(t) = token {
         req = req.set("Authorization", &format!("token {t}"));

--- a/libs/streamlib-idents/src/resolver.rs
+++ b/libs/streamlib-idents/src/resolver.rs
@@ -549,6 +549,17 @@ fn resolve_bare_schema_name_internal<'a>(
                     dep: dep_id.clone(),
                 }
             })?;
+            // Guard against a mutually- or self-referential external chain
+            // (A -> B -> A): without it the recursion never terminates and
+            // aborts on stack overflow instead of surfacing a typed error.
+            if chain.contains(&dep_id) {
+                chain.push(dep_id);
+                return Err(ResolverError::BareSchemaNameCycle {
+                    name: name.as_str().to_string(),
+                    package: pkg_id.clone(),
+                    chain: chain.clone(),
+                });
+            }
             resolve_bare_schema_name_internal(packages, dep, name, chain)
         }
     }
@@ -1242,6 +1253,59 @@ schemas:
         let (owner, file) = resolve_bare_schema_name(&res, &res.root, &name).unwrap();
         assert_eq!(owner.manifest.package_id().as_deref(), Some("@tatolab/core"));
         assert!(file.ends_with("VideoFrame.yaml"));
+    }
+
+    /// A -> B -> A mutual `External` re-export of the same type must surface
+    /// as a typed error, not recurse until stack overflow. Mentally revert
+    /// the `chain.contains` guard in `resolve_bare_schema_name_internal` and
+    /// this test aborts the process instead of passing.
+    #[test]
+    fn bare_schema_name_external_cycle_is_typed_error_not_stack_overflow() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        write_streamlib_yaml(
+            &a,
+            r#"
+package:
+  org: tatolab
+  name: a
+  version: 1.0.0
+dependencies:
+  "@tatolab/b":
+    path: ../b
+schemas:
+  Loop:
+    package: "@tatolab/b"
+"#,
+        );
+        write_streamlib_yaml(
+            &b,
+            r#"
+package:
+  org: tatolab
+  name: b
+  version: 1.0.0
+dependencies:
+  "@tatolab/a":
+    path: ../a
+schemas:
+  Loop:
+    package: "@tatolab/a"
+"#,
+        );
+
+        let res = resolve(&a).unwrap();
+        let name = TypeName::new("Loop").unwrap();
+        let err = resolve_bare_schema_name(&res, &res.root, &name).unwrap_err();
+        match err {
+            ResolverError::BareSchemaNameCycle { name, chain, .. } => {
+                assert_eq!(name, "Loop");
+                assert!(chain.iter().any(|p| p == "@tatolab/a"), "chain: {chain:?}");
+                assert!(chain.iter().any(|p| p == "@tatolab/b"), "chain: {chain:?}");
+            }
+            other => panic!("expected BareSchemaNameCycle, got {other:?}"),
+        }
     }
 
     #[test]

--- a/libs/streamlib-pack/src/catalog.rs
+++ b/libs/streamlib-pack/src/catalog.rs
@@ -15,6 +15,13 @@
 //! the set of packages being published in the same release. Resolution
 //! failures surface as a typed [`CatalogError`] — never a panic, never a
 //! bare-name fallback.
+//!
+//! Schema-only packages (no `processors:` key, e.g. `@tatolab/core`) emit a
+//! present-but-empty catalog plus their owned JTDs and contribute zero
+//! aggregate index lines. Auto-discovery mode (no explicit `schemas:` map)
+//! keys JTDs by each file's `metadata.type`; two files sharing a
+//! `metadata.type` is malformed input and last-wins-overwrites one JTD —
+//! documented, not defended.
 
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -708,6 +715,87 @@ schemas:
             }
             other => panic!("expected SchemaResolutionCycle, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn schema_only_package_emits_empty_catalog_and_owned_jtds() {
+        // Real emit inputs include schema-only packages (core, escalate) with
+        // no `processors:` key: catalog present-but-empty, owned JTDs
+        // emitted, zero aggregate index lines.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("core");
+        write(
+            &dir,
+            "streamlib.yaml",
+            r#"
+package:
+  org: tatolab
+  name: core
+  version: 1.4.0
+schemas:
+  VideoFrame:
+    file: schemas/video_frame.yaml
+"#,
+        );
+        write(
+            &dir,
+            "schemas/video_frame.yaml",
+            "metadata:\n  type: VideoFrame\nproperties:\n  width:\n    type: uint32\n",
+        );
+        let siblings = build_sibling_versions(&[dir.clone()]).unwrap();
+        let arts = build_package_catalog(&dir, &siblings).unwrap();
+        assert!(arts.catalog.processors.is_empty(), "no processors declared");
+        assert!(arts.index_lines.is_empty(), "no index lines for a schema-only package");
+        let owned: Vec<&str> = arts.schema_jtd.iter().map(|s| s.type_name.as_str()).collect();
+        assert_eq!(owned, vec!["VideoFrame"], "owned JTDs still emitted");
+    }
+
+    /// Locks the deliberate version asymmetry: a `-dev.N` package's catalog
+    /// carries the FULL prerelease version, while every schema ident it
+    /// resolves is release-core (per the SchemaIdent invariant).
+    #[test]
+    fn prerelease_package_catalog_keeps_prerelease_but_idents_are_release_core() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("widget");
+        write(
+            &dir,
+            "streamlib.yaml",
+            r#"
+package:
+  org: tatolab
+  name: widget
+  version: 2.1.0-dev.3
+schemas:
+  WidgetConfig:
+    file: schemas/widget_config.yaml
+processors:
+- name: Widget
+  version: 1.0.0
+  runtime: rust
+  execution: reactive
+  config:
+    name: config
+    schema: WidgetConfig
+  outputs:
+  - name: out
+    schema: WidgetConfig
+"#,
+        );
+        write(
+            &dir,
+            "schemas/widget_config.yaml",
+            "metadata:\n  type: WidgetConfig\nproperties: {}\n",
+        );
+        let siblings = build_sibling_versions(&[dir.clone()]).unwrap();
+        let arts = build_package_catalog(&dir, &siblings).unwrap();
+        // Catalog version: the full published prerelease.
+        assert_eq!(arts.catalog.version.to_string(), "2.1.0-dev.3");
+        assert_eq!(arts.index_lines[0].version.to_string(), "2.1.0-dev.3");
+        // Idents: release-core projected.
+        let cfg = arts.catalog.processors[0].config.as_ref().unwrap();
+        assert_eq!(cfg.schema.to_string(), "@tatolab/widget/WidgetConfig@2.1.0");
+        let port = arts.catalog.processors[0].outputs[0].schema.schema().unwrap();
+        assert_eq!(port.version, SemVer::new(2, 1, 0));
     }
 
     #[test]

--- a/libs/streamlib-pack/src/catalog.rs
+++ b/libs/streamlib-pack/src/catalog.rs
@@ -1,0 +1,762 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Publish-time catalog assembly.
+//!
+//! Turns a package's `streamlib.yaml` into the resolved
+//! [`PackageCatalog`] + per-processor [`CatalogIndexLine`]s + the JSON Type
+//! Definitions for the schemas it OWNS, ready for
+//! [`crate::static_registry`] to write into the registry tree.
+//!
+//! Bare port / config schema references (`schema: VideoFrame`) are resolved
+//! to release-core [`SchemaIdent`]s against the manifest's `schemas:` map:
+//! a `Local` entry resolves to this package's own `(org, name, version)`; an
+//! `External` entry resolves to the OWNING dependency's version, looked up in
+//! the set of packages being published in the same release. Resolution
+//! failures surface as a typed [`CatalogError`] — never a panic, never a
+//! bare-name fallback.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use streamlib_idents::{
+    CatalogConfig, CatalogIndexLine, CatalogPort, CatalogProcessor, CatalogRuntime,
+    CatalogSchemaRef, Manifest, PackageCatalog, PackageRef, SchemaEntry, SchemaIdent, SemVer,
+    TypeName,
+};
+use streamlib_processor_schema::{
+    PortSchemaSpec, ProcessorLanguage, ProcessorPortSchema, ProcessorSchema, ProjectConfigMinimal,
+};
+
+/// A published package's version + parsed manifest — the resolution universe
+/// for external schema references. Keyed by [`PackageRef`] in a
+/// [`SiblingVersions`] map.
+#[derive(Debug, Clone)]
+pub struct PublishedPackage {
+    pub version: SemVer,
+    pub manifest: Manifest,
+}
+
+/// Every package being published in the release, keyed by `@org/name`. Used
+/// to resolve an `External { package }` schema reference to that package's
+/// concrete version.
+pub type SiblingVersions = BTreeMap<PackageRef, PublishedPackage>;
+
+/// A schema's JSON Type Definition, ready to be written under the owning
+/// package's `schemas/<Type>.jtd.json`.
+#[derive(Debug, Clone)]
+pub struct SchemaJtdFile {
+    /// The PascalCase type this JTD defines.
+    pub type_name: TypeName,
+    /// The JTD document (the `schemas/*.yaml` converted to JSON).
+    pub json: serde_json::Value,
+}
+
+/// Everything the tree emit needs to write for one package's catalog.
+#[derive(Debug, Clone)]
+pub struct PackageCatalogArtifacts {
+    /// The per-package `<name>.catalog.json` payload.
+    pub catalog: PackageCatalog,
+    /// One line per processor for the registry-wide `catalog/index.ndjson`.
+    pub index_lines: Vec<CatalogIndexLine>,
+    /// The JTD files this package owns (deduped by ownership).
+    pub schema_jtd: Vec<SchemaJtdFile>,
+}
+
+/// Why catalog assembly failed. Every variant carries actionable context;
+/// resolution never panics and never silently drops a reference.
+#[derive(Debug, thiserror::Error)]
+pub enum CatalogError {
+    #[error("read {path}: {source}")]
+    Io {
+        path: std::path::PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("parse {path}: {source}")]
+    ManifestParse {
+        path: std::path::PathBuf,
+        #[source]
+        source: serde_yaml::Error,
+    },
+
+    #[error("{path} has no [package] block — a catalog requires a publishable package")]
+    NotAPackage { path: std::path::PathBuf },
+
+    #[error(
+        "processor `{processor}` in `{package}` references schema type `{type_name}` \
+         which is not declared in the manifest's `schemas:` map (resolution chain: {chain})"
+    )]
+    UnresolvedNamedSchema {
+        package: String,
+        processor: String,
+        type_name: String,
+        chain: String,
+    },
+
+    #[error(
+        "schema type `{type_name}` in `{package}` is imported from dependency `{dep}`, \
+         but `{dep}` is not among the packages being published — cannot resolve its version"
+    )]
+    ExternalDepMissing {
+        package: String,
+        type_name: String,
+        dep: String,
+    },
+
+    #[error(
+        "resolving schema type `{type_name}` in `{package}` cycles through external \
+         imports: {chain}"
+    )]
+    SchemaResolutionCycle {
+        package: String,
+        type_name: String,
+        chain: String,
+    },
+
+    #[error("parse schema YAML {path}: {source}")]
+    SchemaParse {
+        path: std::path::PathBuf,
+        #[source]
+        source: serde_yaml::Error,
+    },
+}
+
+/// Load a package directory's manifest + minimal project config. Shared by
+/// the sibling-map builder and [`build_package_catalog`].
+fn load_manifest(pkg_dir: &Path) -> Result<Manifest, CatalogError> {
+    let path = pkg_dir.join(Manifest::FILE_NAME);
+    let body = std::fs::read_to_string(&path).map_err(|e| CatalogError::Io {
+        path: path.clone(),
+        source: e,
+    })?;
+    serde_yaml::from_str(&body).map_err(|e| CatalogError::ManifestParse { path, source: e })
+}
+
+fn load_project_config(pkg_dir: &Path) -> Result<ProjectConfigMinimal, CatalogError> {
+    let path = pkg_dir.join(Manifest::FILE_NAME);
+    let body = std::fs::read_to_string(&path).map_err(|e| CatalogError::Io {
+        path: path.clone(),
+        source: e,
+    })?;
+    serde_yaml::from_str(&body).map_err(|e| CatalogError::ManifestParse { path, source: e })
+}
+
+/// Build the [`SiblingVersions`] resolution universe from a set of package
+/// directories (each a `packages/<name>/`). Directories without a
+/// `streamlib.yaml` or without a `[package]` block are skipped — only
+/// publishable packages participate in external-ref resolution.
+pub fn build_sibling_versions(pkg_dirs: &[std::path::PathBuf]) -> Result<SiblingVersions, CatalogError> {
+    let mut out = SiblingVersions::new();
+    for dir in pkg_dirs {
+        if !dir.join(Manifest::FILE_NAME).is_file() {
+            continue;
+        }
+        let manifest = load_manifest(dir)?;
+        let Some(pkg) = manifest.package.as_ref() else {
+            continue;
+        };
+        let pkg_ref = PackageRef::new(pkg.org.clone(), pkg.name.clone());
+        let version = pkg.version;
+        out.insert(pkg_ref, PublishedPackage { version, manifest });
+    }
+    Ok(out)
+}
+
+/// Assemble the catalog artifacts for the package at `pkg_dir`. `siblings`
+/// carries the versions of every package in the release, for resolving
+/// external schema references.
+pub fn build_package_catalog(
+    pkg_dir: &Path,
+    siblings: &SiblingVersions,
+) -> Result<PackageCatalogArtifacts, CatalogError> {
+    let manifest = load_manifest(pkg_dir)?;
+    let config = load_project_config(pkg_dir)?;
+
+    let pkg_meta = manifest.package.as_ref().ok_or_else(|| CatalogError::NotAPackage {
+        path: pkg_dir.join(Manifest::FILE_NAME),
+    })?;
+    let owner_ref = PackageRef::new(pkg_meta.org.clone(), pkg_meta.name.clone());
+    let owner_version = pkg_meta.version;
+
+    // Resolve every processor's config + ports.
+    let mut processors = Vec::with_capacity(config.processors.len());
+    for proc in &config.processors {
+        processors.push(build_processor(proc, &owner_ref, owner_version, &manifest, siblings)?);
+    }
+
+    let catalog = PackageCatalog {
+        package: owner_ref.clone(),
+        version: owner_version,
+        processors: processors.clone(),
+    };
+    let index_lines = processors
+        .into_iter()
+        .map(|processor| CatalogIndexLine {
+            package: owner_ref.clone(),
+            version: owner_version,
+            processor,
+        })
+        .collect();
+
+    let schema_jtd = collect_owned_schema_jtd(pkg_dir, &manifest)?;
+
+    Ok(PackageCatalogArtifacts {
+        catalog,
+        index_lines,
+        schema_jtd,
+    })
+}
+
+fn build_processor(
+    proc: &ProcessorSchema,
+    owner_ref: &PackageRef,
+    owner_version: SemVer,
+    manifest: &Manifest,
+    siblings: &SiblingVersions,
+) -> Result<CatalogProcessor, CatalogError> {
+    let config = match &proc.config {
+        Some(cfg) => Some(CatalogConfig {
+            name: cfg.name.clone(),
+            schema: resolve_named(
+                &cfg.schema,
+                &proc.name,
+                owner_ref,
+                owner_version,
+                manifest,
+                siblings,
+            )?,
+        }),
+        None => None,
+    };
+
+    let inputs = proc
+        .inputs
+        .iter()
+        .map(|p| build_port(p, &proc.name, owner_ref, owner_version, manifest, siblings))
+        .collect::<Result<Vec<_>, _>>()?;
+    let outputs = proc
+        .outputs
+        .iter()
+        .map(|p| build_port(p, &proc.name, owner_ref, owner_version, manifest, siblings))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(CatalogProcessor {
+        name: proc.name.clone(),
+        description: proc.description.clone(),
+        runtime: runtime_of(&proc.runtime.language),
+        entrypoint: proc.entrypoint.clone(),
+        config,
+        inputs,
+        outputs,
+    })
+}
+
+fn build_port(
+    port: &ProcessorPortSchema,
+    processor_name: &str,
+    owner_ref: &PackageRef,
+    owner_version: SemVer,
+    manifest: &Manifest,
+    siblings: &SiblingVersions,
+) -> Result<CatalogPort, CatalogError> {
+    let schema = match &port.schema {
+        PortSchemaSpec::Any => CatalogSchemaRef::Any,
+        PortSchemaSpec::Named(name) => CatalogSchemaRef::Schema(resolve_named(
+            name,
+            processor_name,
+            owner_ref,
+            owner_version,
+            manifest,
+            siblings,
+        )?),
+        // A `Specific` here is already resolved (uncommon from raw YAML, but
+        // pass it through release-core-projected rather than re-resolving).
+        PortSchemaSpec::Specific(ident) => CatalogSchemaRef::Schema(SchemaIdent::new(
+            ident.org.clone(),
+            ident.package.clone(),
+            ident.r#type.clone(),
+            ident.version,
+        )),
+    };
+    Ok(CatalogPort {
+        name: port.name.clone(),
+        description: port.description.clone(),
+        schema,
+        read_mode: port.read_mode.clone(),
+    })
+}
+
+fn runtime_of(language: &ProcessorLanguage) -> CatalogRuntime {
+    match language {
+        ProcessorLanguage::Rust => CatalogRuntime::Rust,
+        ProcessorLanguage::Python => CatalogRuntime::Python,
+        ProcessorLanguage::TypeScript => CatalogRuntime::TypeScript,
+    }
+}
+
+/// Resolve a bare PascalCase `type_name` referenced by `processor_name` in
+/// `owner` to a fully-qualified [`SchemaIdent`], walking `schemas:` maps the
+/// same way [`streamlib_idents::resolve_bare_schema_name`] does — but sourced
+/// from the in-flight release's sibling versions rather than a live registry.
+fn resolve_named(
+    type_name: &TypeName,
+    processor_name: &str,
+    owner: &PackageRef,
+    owner_version: SemVer,
+    owner_manifest: &Manifest,
+    siblings: &SiblingVersions,
+) -> Result<SchemaIdent, CatalogError> {
+    let mut chain: Vec<String> = vec![owner.to_string()];
+    resolve_named_internal(
+        type_name,
+        processor_name,
+        owner,
+        owner_version,
+        owner_manifest,
+        siblings,
+        &mut chain,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn resolve_named_internal(
+    type_name: &TypeName,
+    processor_name: &str,
+    owner: &PackageRef,
+    owner_version: SemVer,
+    owner_manifest: &Manifest,
+    siblings: &SiblingVersions,
+    chain: &mut Vec<String>,
+) -> Result<SchemaIdent, CatalogError> {
+    let root_package = chain.first().cloned().unwrap_or_else(|| owner.to_string());
+
+    match owner_manifest.schemas.as_ref() {
+        // Explicit `schemas:` map — look the type up.
+        Some(map) => match map.get(type_name) {
+            Some(SchemaEntry::Local { .. }) => Ok(local_ident(owner, type_name, owner_version)),
+            Some(SchemaEntry::External { package: dep_ref }) => {
+                let dep = siblings.get(dep_ref).ok_or_else(|| CatalogError::ExternalDepMissing {
+                    package: root_package.clone(),
+                    type_name: type_name.as_str().to_string(),
+                    dep: dep_ref.to_string(),
+                })?;
+                // Guard against a mutually- or self-referential external chain
+                // (A → B → A) — otherwise the recursion never terminates. The
+                // contract is "resolution never panics"; a cycle surfaces as a
+                // typed error, not a stack overflow.
+                let dep_id = dep_ref.to_string();
+                if chain.contains(&dep_id) {
+                    chain.push(dep_id);
+                    return Err(CatalogError::SchemaResolutionCycle {
+                        package: root_package.clone(),
+                        type_name: type_name.as_str().to_string(),
+                        chain: chain.join(" -> "),
+                    });
+                }
+                chain.push(dep_id);
+                resolve_named_internal(
+                    type_name,
+                    processor_name,
+                    dep_ref,
+                    dep.version,
+                    &dep.manifest,
+                    siblings,
+                    chain,
+                )
+            }
+            None => Err(unresolved(&root_package, processor_name, type_name, chain)),
+        },
+        // No explicit map: auto-discovery treats every `schemas/*.yaml` this
+        // package owns as Local. A type not owned locally is unresolvable
+        // (an external ref is only expressible via an explicit map).
+        None => Ok(local_ident(owner, type_name, owner_version)),
+    }
+}
+
+fn local_ident(owner: &PackageRef, type_name: &TypeName, version: SemVer) -> SchemaIdent {
+    SchemaIdent::new(owner.org.clone(), owner.name.clone(), type_name.clone(), version)
+}
+
+fn unresolved(
+    package: &str,
+    processor: &str,
+    type_name: &TypeName,
+    chain: &[String],
+) -> CatalogError {
+    CatalogError::UnresolvedNamedSchema {
+        package: package.to_string(),
+        processor: processor.to_string(),
+        type_name: type_name.as_str().to_string(),
+        chain: chain.join(" -> "),
+    }
+}
+
+/// Collect the JTD files for schemas this package OWNS — the `Local` entries
+/// of its `schemas:` map, or every `schemas/*.yaml` when the map is absent
+/// (auto-discovery). Each YAML is parsed and re-serialized as JSON; the type
+/// name is the map key (explicit) or the schema's `metadata.type` (discovery).
+fn collect_owned_schema_jtd(
+    pkg_dir: &Path,
+    manifest: &Manifest,
+) -> Result<Vec<SchemaJtdFile>, CatalogError> {
+    let mut out = Vec::new();
+    match manifest.schemas.as_ref() {
+        Some(map) => {
+            for (type_name, entry) in map {
+                let SchemaEntry::Local { file } = entry else {
+                    continue; // External types are emitted by their owning package.
+                };
+                let abs = if file.is_absolute() {
+                    file.clone()
+                } else {
+                    pkg_dir.join(file)
+                };
+                let json = read_yaml_as_json(&abs)?;
+                out.push(SchemaJtdFile {
+                    type_name: type_name.clone(),
+                    json,
+                });
+            }
+        }
+        None => {
+            let schemas_dir = pkg_dir.join("schemas");
+            if schemas_dir.is_dir() {
+                let mut files: Vec<std::path::PathBuf> = std::fs::read_dir(&schemas_dir)
+                    .map_err(|e| CatalogError::Io {
+                        path: schemas_dir.clone(),
+                        source: e,
+                    })?
+                    .filter_map(|e| e.ok().map(|e| e.path()))
+                    .filter(|p| matches!(p.extension().and_then(|s| s.to_str()), Some("yaml" | "yml")))
+                    .collect();
+                files.sort();
+                for path in files {
+                    let json = read_yaml_as_json(&path)?;
+                    if let Some(type_name) = jtd_type_name(&json) {
+                        out.push(SchemaJtdFile { type_name, json });
+                    }
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Read a schema YAML file and re-encode it as a JSON [`serde_json::Value`].
+fn read_yaml_as_json(path: &Path) -> Result<serde_json::Value, CatalogError> {
+    let body = std::fs::read_to_string(path).map_err(|e| CatalogError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    let value: serde_json::Value =
+        serde_yaml::from_str(&body).map_err(|e| CatalogError::SchemaParse {
+            path: path.to_path_buf(),
+            source: e,
+        })?;
+    Ok(value)
+}
+
+/// Extract `metadata.type` (PascalCase) from a parsed JTD document, for the
+/// auto-discovery keying path.
+fn jtd_type_name(json: &serde_json::Value) -> Option<TypeName> {
+    json.get("metadata")
+        .and_then(|m| m.get("type"))
+        .and_then(|t| t.as_str())
+        .and_then(|s| TypeName::new(s).ok())
+}
+
+/// Convenience: parse `<org>`/`<name>` from a raw `@org/name` — used by the
+/// tree emit when building an owner ref from a manifest it already parsed.
+pub fn owner_ref_of(manifest: &Manifest) -> Option<PackageRef> {
+    manifest
+        .package
+        .as_ref()
+        .map(|p| PackageRef::new(p.org.clone(), p.name.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use streamlib_idents::{Org, Package};
+
+    fn write(dir: &Path, rel: &str, body: &str) {
+        let path = dir.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body).unwrap();
+    }
+
+    /// A schema-owning `@tatolab/core` + a multi-processor `@tatolab/camera`
+    /// importing `VideoFrame` from core. Returns (tmp, camera_dir, siblings).
+    fn two_package_tree() -> (tempfile::TempDir, PathBuf, SiblingVersions) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        let core_dir = root.join("core");
+        write(
+            &core_dir,
+            "streamlib.yaml",
+            r#"
+package:
+  org: tatolab
+  name: core
+  version: 1.4.0
+schemas:
+  VideoFrame:
+    file: schemas/video_frame.yaml
+"#,
+        );
+        write(
+            &core_dir,
+            "schemas/video_frame.yaml",
+            "metadata:\n  type: VideoFrame\n  description: A frame\nproperties:\n  width:\n    type: uint32\n",
+        );
+
+        let cam_dir = root.join("camera");
+        write(
+            &cam_dir,
+            "streamlib.yaml",
+            r#"
+package:
+  org: tatolab
+  name: camera
+  version: 2.1.0
+dependencies:
+  '@tatolab/core':
+    version: ^1.0.0
+schemas:
+  CameraConfig:
+    file: schemas/camera_config.yaml
+  VideoFrame:
+    package: '@tatolab/core'
+processors:
+- name: Camera
+  version: 1.0.0
+  description: Captures video
+  runtime: rust
+  execution: manual
+  config:
+    name: config
+    schema: CameraConfig
+  inputs: []
+  outputs:
+  - name: video
+    schema: VideoFrame
+    description: Live frames
+- name: PassThrough
+  version: 1.0.0
+  runtime: python
+  entrypoint: src.pass:PassThrough
+  execution: reactive
+  inputs:
+  - name: any_in
+    schema: any
+    read_mode: skip_to_latest
+  outputs:
+  - name: video_out
+    schema: VideoFrame
+"#,
+        );
+        write(
+            &cam_dir,
+            "schemas/camera_config.yaml",
+            "metadata:\n  type: CameraConfig\n  description: cfg\noptionalProperties:\n  device_id:\n    type: string\n",
+        );
+
+        let siblings = build_sibling_versions(&[core_dir, cam_dir.clone()]).unwrap();
+        (tmp, cam_dir, siblings)
+    }
+
+    #[test]
+    fn resolves_local_and_external_refs_to_release_core_idents() {
+        let (_tmp, cam_dir, siblings) = two_package_tree();
+        let arts = build_package_catalog(&cam_dir, &siblings).unwrap();
+
+        assert_eq!(arts.catalog.package.to_string(), "@tatolab/camera");
+        assert_eq!(arts.catalog.version, SemVer::new(2, 1, 0));
+        assert_eq!(arts.catalog.processors.len(), 2);
+
+        let camera = &arts.catalog.processors[0];
+        assert_eq!(camera.name, "Camera");
+        assert_eq!(camera.runtime, CatalogRuntime::Rust);
+        // Config ref is Local → camera's own version.
+        let cfg = camera.config.as_ref().unwrap();
+        assert_eq!(cfg.schema.to_string(), "@tatolab/camera/CameraConfig@2.1.0");
+        // Output port `video` is External(@tatolab/core) → core's version.
+        assert_eq!(
+            camera.outputs[0].schema,
+            CatalogSchemaRef::Schema(SchemaIdent::new(
+                Org::new("tatolab").unwrap(),
+                Package::new("core").unwrap(),
+                TypeName::new("VideoFrame").unwrap(),
+                SemVer::new(1, 4, 0),
+            ))
+        );
+
+        let passthrough = &arts.catalog.processors[1];
+        assert_eq!(passthrough.runtime, CatalogRuntime::Python);
+        assert_eq!(passthrough.entrypoint.as_deref(), Some("src.pass:PassThrough"));
+        // `any` port stays a wildcard.
+        assert_eq!(passthrough.inputs[0].schema, CatalogSchemaRef::Any);
+        assert_eq!(passthrough.inputs[0].read_mode.as_deref(), Some("skip_to_latest"));
+    }
+
+    #[test]
+    fn owns_only_locally_declared_schema_jtd() {
+        let (_tmp, cam_dir, siblings) = two_package_tree();
+        let arts = build_package_catalog(&cam_dir, &siblings).unwrap();
+        // Camera owns CameraConfig (Local) but NOT VideoFrame (External → core owns it).
+        let owned: Vec<&str> = arts.schema_jtd.iter().map(|s| s.type_name.as_str()).collect();
+        assert_eq!(owned, vec!["CameraConfig"]);
+        // The JTD is the YAML re-encoded as JSON.
+        assert_eq!(arts.schema_jtd[0].json["metadata"]["type"], "CameraConfig");
+    }
+
+    #[test]
+    fn index_lines_are_one_per_processor_with_owning_package() {
+        let (_tmp, cam_dir, siblings) = two_package_tree();
+        let arts = build_package_catalog(&cam_dir, &siblings).unwrap();
+        assert_eq!(arts.index_lines.len(), 2);
+        for line in &arts.index_lines {
+            assert_eq!(line.package.to_string(), "@tatolab/camera");
+            assert_eq!(line.version, SemVer::new(2, 1, 0));
+        }
+        assert_eq!(arts.index_lines[0].processor.name, "Camera");
+    }
+
+    #[test]
+    fn missing_external_dep_is_typed_error_not_panic() {
+        // Build the catalog for camera WITHOUT core in the sibling set —
+        // the External VideoFrame ref must fail with a typed error.
+        let (_tmp, cam_dir, _siblings) = two_package_tree();
+        let mut siblings = SiblingVersions::new();
+        // include only camera itself so the local lookup still finds the map
+        let cam_manifest = load_manifest(&cam_dir).unwrap();
+        siblings.insert(
+            owner_ref_of(&cam_manifest).unwrap(),
+            PublishedPackage {
+                version: SemVer::new(2, 1, 0),
+                manifest: cam_manifest,
+            },
+        );
+        let err = build_package_catalog(&cam_dir, &siblings).unwrap_err();
+        match err {
+            CatalogError::ExternalDepMissing { dep, type_name, .. } => {
+                assert_eq!(dep, "@tatolab/core");
+                assert_eq!(type_name, "VideoFrame");
+            }
+            other => panic!("expected ExternalDepMissing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn external_schema_reference_cycle_is_typed_error_not_stack_overflow() {
+        // A ↔ B mutual `External` re-export of the same type would recurse
+        // forever without the cycle guard. It must surface as a typed error.
+        let tmp = tempfile::tempdir().unwrap();
+        let a_dir = tmp.path().join("a");
+        write(
+            &a_dir,
+            "streamlib.yaml",
+            r#"
+package:
+  org: tatolab
+  name: a
+  version: 1.0.0
+dependencies:
+  '@tatolab/b':
+    version: ^1.0.0
+schemas:
+  Loop:
+    package: '@tatolab/b'
+processors:
+- name: A
+  version: 1.0.0
+  runtime: rust
+  execution: reactive
+  outputs:
+  - name: out
+    schema: Loop
+"#,
+        );
+        let b_dir = tmp.path().join("b");
+        write(
+            &b_dir,
+            "streamlib.yaml",
+            r#"
+package:
+  org: tatolab
+  name: b
+  version: 1.0.0
+dependencies:
+  '@tatolab/a':
+    version: ^1.0.0
+schemas:
+  Loop:
+    package: '@tatolab/a'
+"#,
+        );
+        let siblings = build_sibling_versions(&[a_dir.clone(), b_dir]).unwrap();
+        let err = build_package_catalog(&a_dir, &siblings).unwrap_err();
+        match err {
+            CatalogError::SchemaResolutionCycle { type_name, chain, .. } => {
+                assert_eq!(type_name, "Loop");
+                assert!(chain.contains("@tatolab/a"));
+                assert!(chain.contains("@tatolab/b"));
+            }
+            other => panic!("expected SchemaResolutionCycle, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn undeclared_named_schema_is_typed_error() {
+        // A processor references a type not in the schemas map.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("widget");
+        write(
+            &dir,
+            "streamlib.yaml",
+            r#"
+package:
+  org: tatolab
+  name: widget
+  version: 1.0.0
+schemas:
+  KnownType:
+    file: schemas/known.yaml
+processors:
+- name: Widget
+  version: 1.0.0
+  runtime: rust
+  execution: reactive
+  outputs:
+  - name: out
+    schema: MysteryType
+"#,
+        );
+        write(&dir, "schemas/known.yaml", "metadata:\n  type: KnownType\nproperties: {}\n");
+        let siblings = build_sibling_versions(&[dir.clone()]).unwrap();
+        let err = build_package_catalog(&dir, &siblings).unwrap_err();
+        match err {
+            CatalogError::UnresolvedNamedSchema { type_name, processor, .. } => {
+                assert_eq!(type_name, "MysteryType");
+                assert_eq!(processor, "Widget");
+            }
+            other => panic!("expected UnresolvedNamedSchema, got {other:?}"),
+        }
+    }
+
+    /// Mentally revert the resolver to emit the owner's version for an
+    /// external ref (drop the sibling lookup) and this fails: the external
+    /// ref MUST carry the dependency's version, not the importer's.
+    #[test]
+    fn external_ref_version_is_the_dependencys_not_the_importers() {
+        let (_tmp, cam_dir, siblings) = two_package_tree();
+        let arts = build_package_catalog(&cam_dir, &siblings).unwrap();
+        let video = arts.catalog.processors[0].outputs[0].schema.schema().unwrap();
+        assert_eq!(video.version, SemVer::new(1, 4, 0)); // core's version
+        assert_ne!(video.version, SemVer::new(2, 1, 0)); // NOT camera's version
+    }
+}

--- a/libs/streamlib-pack/src/lib.rs
+++ b/libs/streamlib-pack/src/lib.rs
@@ -45,6 +45,7 @@ use streamlib_processor_schema::ProcessorLanguage;
 
 pub use streamlib_cargo_build::CargoProfile;
 
+pub mod catalog;
 pub mod link_marker;
 pub mod static_registry;
 

--- a/libs/streamlib-pack/src/static_registry.rs
+++ b/libs/streamlib-pack/src/static_registry.rs
@@ -34,8 +34,11 @@ use std::process::Command;
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
 use streamlib_idents::{
-    PackageRef, RegistryClient, RegistryConfig, ReleaseManifest, ReleaseManifestMember, SemVer,
+    render_catalog_index_ndjson, schema_jtd_file_name, CatalogIndexLine, PackageRef, RegistryClient,
+    RegistryConfig, ReleaseManifest, ReleaseManifestMember, SemVer, CATALOG_INDEX_PATH,
 };
+
+use crate::catalog::{build_package_catalog, build_sibling_versions};
 
 /// Which ecosystems an emit run produces. Each maps to its native anonymous
 /// read transport (see the module docs).
@@ -666,16 +669,27 @@ fn emit_slpkg_and_manifest(
 
     let packages_dir = opts.workspace_root.join("packages");
     let mut package_members: Vec<ReleaseManifestMember> = Vec::new();
+    // Registry-wide processor index accumulated across every package — the
+    // node-palette aggregate, written LAST (after the release manifest).
+    let mut catalog_index: Vec<CatalogIndexLine> = Vec::new();
     if packages_dir.is_dir() {
         let mut entries: Vec<PathBuf> =
             std::fs::read_dir(&packages_dir)?.filter_map(|e| e.ok().map(|e| e.path())).collect();
         entries.sort();
-        for pkg_dir in entries {
+
+        // Resolution universe for external schema refs: every package being
+        // published, with its version + manifest. Built up front so an
+        // importer's catalog resolves a dep's version regardless of emit
+        // order (alphabetical `entries` doesn't respect dependency order).
+        let siblings = build_sibling_versions(&entries)
+            .context("building the catalog resolution universe from packages/")?;
+
+        for pkg_dir in &entries {
             let yaml = pkg_dir.join("streamlib.yaml");
             if !yaml.is_file() {
                 continue;
             }
-            let (pkg_ref, version, bytes) = assemble_slpkg_bytes(&pkg_dir)?;
+            let (pkg_ref, version, bytes) = assemble_slpkg_bytes(pkg_dir)?;
             let semver: SemVer = version
                 .parse()
                 .with_context(|| format!("package {} version `{version}` is not semver", pkg_ref))?;
@@ -684,6 +698,16 @@ fn emit_slpkg_and_manifest(
                 .map_err(|e| anyhow::anyhow!("upload {}: {e}", pkg_ref))?;
             package_members
                 .push(ReleaseManifestMember::new(pkg_ref.to_string(), version.clone()));
+
+            // Publish-time catalog: per-package `<name>.catalog.json` + the
+            // JTDs this package owns, written into the same version dir as the
+            // `.slpkg`. Accumulate the per-processor index lines for the
+            // registry-wide aggregate.
+            let artifacts = build_package_catalog(pkg_dir, &siblings)
+                .with_context(|| format!("building catalog for {pkg_ref}"))?;
+            write_package_catalog(&slpkg_dir, &artifacts)
+                .with_context(|| format!("writing catalog for {pkg_ref}"))?;
+            catalog_index.extend(artifacts.index_lines);
         }
     }
 
@@ -710,6 +734,53 @@ fn emit_slpkg_and_manifest(
     RegistryClient::new(&config)
         .upload_release_manifest(org, &manifest)
         .map_err(|e| anyhow::anyhow!("upload release manifest: {e}"))?;
+
+    // Registry-wide catalog aggregate, written AFTER the per-package catalog
+    // files and the release manifest. The whole staging tree flips atomically
+    // (`build_and_flip`), so a `file://` reader never observes the aggregate
+    // without the release it describes — but ordering it last keeps the
+    // HTTP-direct-write intuition (index after members) consistent.
+    let index_path = staging.join(CATALOG_INDEX_PATH);
+    if let Some(parent) = index_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create {}", parent.display()))?;
+    }
+    std::fs::write(&index_path, render_catalog_index_ndjson(&catalog_index))
+        .with_context(|| format!("write {}", index_path.display()))?;
+    Ok(())
+}
+
+/// Write one package's catalog artifacts into its version directory under
+/// `slpkg/<name>/<version>/`: `<name>.catalog.json` beside the `.slpkg`, and
+/// each owned schema's JTD under `schemas/<Type>.jtd.json`. `slpkg_dir` is the
+/// tree's `slpkg/` root (the same base the `.slpkg` store uses).
+pub fn write_package_catalog(
+    slpkg_dir: &Path,
+    artifacts: &crate::catalog::PackageCatalogArtifacts,
+) -> Result<()> {
+    let name = artifacts.catalog.package.name.as_str();
+    let version = artifacts.catalog.version.to_string();
+    let ver_dir = slpkg_dir.join(name).join(&version);
+    std::fs::create_dir_all(&ver_dir).with_context(|| format!("create {}", ver_dir.display()))?;
+
+    let catalog_path = ver_dir.join(streamlib_idents::package_catalog_file_name(name));
+    let catalog_json = serde_json::to_vec_pretty(&artifacts.catalog)
+        .context("serialize package catalog JSON")?;
+    std::fs::write(&catalog_path, catalog_json)
+        .with_context(|| format!("write {}", catalog_path.display()))?;
+
+    if !artifacts.schema_jtd.is_empty() {
+        let schemas_dir = ver_dir.join("schemas");
+        std::fs::create_dir_all(&schemas_dir)
+            .with_context(|| format!("create {}", schemas_dir.display()))?;
+        for jtd in &artifacts.schema_jtd {
+            let path = schemas_dir.join(schema_jtd_file_name(&jtd.type_name));
+            let bytes = serde_json::to_vec_pretty(&jtd.json)
+                .with_context(|| format!("serialize JTD for {}", jtd.type_name))?;
+            std::fs::write(&path, bytes)
+                .with_context(|| format!("write {}", path.display()))?;
+        }
+    }
     Ok(())
 }
 

--- a/libs/streamlib-pack/src/static_registry.rs
+++ b/libs/streamlib-pack/src/static_registry.rs
@@ -736,10 +736,13 @@ fn emit_slpkg_and_manifest(
         .map_err(|e| anyhow::anyhow!("upload release manifest: {e}"))?;
 
     // Registry-wide catalog aggregate, written AFTER the per-package catalog
-    // files and the release manifest. The whole staging tree flips atomically
-    // (`build_and_flip`), so a `file://` reader never observes the aggregate
-    // without the release it describes — but ordering it last keeps the
-    // HTTP-direct-write intuition (index after members) consistent.
+    // files and the release manifest, at a STAGING-relative path so it rides
+    // the same atomic flip (`build_and_flip`) — a `file://` reader never
+    // observes the aggregate without the release it describes. Ordering it
+    // last keeps the HTTP-direct-write intuition (index after members)
+    // consistent. The CI static-registry emit smoke asserts the aggregate +
+    // a per-package catalog exist in the emitted tree, locking this
+    // staging-relativity through the real emit path.
     let index_path = staging.join(CATALOG_INDEX_PATH);
     if let Some(parent) = index_path.parent() {
         std::fs::create_dir_all(parent)
@@ -750,10 +753,14 @@ fn emit_slpkg_and_manifest(
     Ok(())
 }
 
-/// Write one package's catalog artifacts into its version directory under
-/// `slpkg/<name>/<version>/`: `<name>.catalog.json` beside the `.slpkg`, and
-/// each owned schema's JTD under `schemas/<Type>.jtd.json`. `slpkg_dir` is the
-/// tree's `slpkg/` root (the same base the `.slpkg` store uses).
+/// Write one package's catalog artifacts under the tree's `slpkg/` root:
+/// `<name>.catalog.json` beside the `.slpkg` in the FULL-version dir
+/// (`slpkg/<name>/<version>/`, matching per-package catalog fetch by exact
+/// published version), and each owned schema's JTD under the **release-core**
+/// version dir (`slpkg/<name>/<release-core>/schemas/`) — schema idents are
+/// release-core by invariant, so the reader derives the JTD path from the
+/// ident's projected version. A `-dev.N` publisher whose JTDs sat under the
+/// full prerelease dir would be silently unfetchable.
 pub fn write_package_catalog(
     slpkg_dir: &Path,
     artifacts: &crate::catalog::PackageCatalogArtifacts,
@@ -770,7 +777,11 @@ pub fn write_package_catalog(
         .with_context(|| format!("write {}", catalog_path.display()))?;
 
     if !artifacts.schema_jtd.is_empty() {
-        let schemas_dir = ver_dir.join("schemas");
+        // Release-core dir — the version basis of every SchemaIdent.
+        let jtd_ver_dir = slpkg_dir
+            .join(name)
+            .join(artifacts.catalog.version.release_core().to_string());
+        let schemas_dir = jtd_ver_dir.join("schemas");
         std::fs::create_dir_all(&schemas_dir)
             .with_context(|| format!("create {}", schemas_dir.display()))?;
         for jtd in &artifacts.schema_jtd {

--- a/libs/streamlib-pack/tests/catalog_publish_query.rs
+++ b/libs/streamlib-pack/tests/catalog_publish_query.rs
@@ -1,0 +1,226 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Integration: publish two packages' catalogs into a static `file://` tree,
+//! then reconstruct the full processor/port/schema wiring graph by querying
+//! the catalog surface ONLY — never opening a `.slpkg` tarball. Exercises the
+//! exact writer the tree emit uses (`write_package_catalog` + the aggregate
+//! NDJSON) against the exact reader a client uses (`CatalogClient`).
+
+use std::path::{Path, PathBuf};
+
+use streamlib_idents::{
+    render_catalog_index_ndjson, CatalogClient, CatalogRuntime, CatalogSchemaRef, Org, Package,
+    PackageRef, RegistryClient, RegistryConfig, SemVer, CATALOG_INDEX_PATH,
+};
+use streamlib_pack::catalog::{build_package_catalog, build_sibling_versions};
+use streamlib_pack::static_registry::{build_and_flip, write_package_catalog};
+
+fn write(dir: &Path, rel: &str, body: &str) {
+    let path = dir.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, body).unwrap();
+}
+
+fn pkg_ref(name: &str) -> PackageRef {
+    PackageRef::new(Org::new("tatolab").unwrap(), Package::new(name).unwrap())
+}
+
+/// Lay down two package source dirs: `@tatolab/core@1.4.0` (owns VideoFrame)
+/// and `@tatolab/camera@2.1.0` (imports VideoFrame from core, owns
+/// CameraConfig). Returns the two package dirs.
+fn author_two_packages(src: &Path) -> (PathBuf, PathBuf) {
+    let core = src.join("core");
+    write(
+        &core,
+        "streamlib.yaml",
+        r#"
+package:
+  org: tatolab
+  name: core
+  version: 1.4.0
+schemas:
+  VideoFrame:
+    file: schemas/video_frame.yaml
+"#,
+    );
+    write(
+        &core,
+        "schemas/video_frame.yaml",
+        "metadata:\n  type: VideoFrame\n  description: A frame\nproperties:\n  width:\n    type: uint32\n  height:\n    type: uint32\n",
+    );
+
+    let camera = src.join("camera");
+    write(
+        &camera,
+        "streamlib.yaml",
+        r#"
+package:
+  org: tatolab
+  name: camera
+  version: 2.1.0
+dependencies:
+  '@tatolab/core':
+    version: ^1.0.0
+schemas:
+  CameraConfig:
+    file: schemas/camera_config.yaml
+  VideoFrame:
+    package: '@tatolab/core'
+processors:
+- name: Camera
+  version: 1.0.0
+  description: Captures video
+  runtime: rust
+  execution: manual
+  config:
+    name: config
+    schema: CameraConfig
+  outputs:
+  - name: video
+    schema: VideoFrame
+    description: Live frames
+- name: Sink
+  version: 1.0.0
+  runtime: python
+  entrypoint: src.sink:Sink
+  execution: reactive
+  inputs:
+  - name: video_in
+    schema: VideoFrame
+    read_mode: skip_to_latest
+"#,
+    );
+    write(
+        &camera,
+        "schemas/camera_config.yaml",
+        "metadata:\n  type: CameraConfig\n  description: cfg\noptionalProperties:\n  device_id:\n    type: string\n",
+    );
+    (core, camera)
+}
+
+/// Emit a static tree the way `emit_slpkg_and_manifest` does — upload each
+/// `.slpkg` into the store, write each package's catalog + JTD, then the
+/// registry-wide aggregate — but hermetically (no cargo/uv/deno).
+fn emit_catalog_tree(root: &Path, pkg_dirs: &[PathBuf]) {
+    let slpkg = root.join("slpkg");
+    std::fs::create_dir_all(&slpkg).unwrap();
+    let cfg = RegistryConfig {
+        base_url: format!("file://{}", slpkg.display()),
+        token: None,
+    };
+    let siblings = build_sibling_versions(pkg_dirs).unwrap();
+
+    let mut index = Vec::new();
+    for dir in pkg_dirs {
+        let arts = build_package_catalog(dir, &siblings).unwrap();
+        // Upload a DUMMY `.slpkg` — the query path must never read it.
+        RegistryClient::new(&cfg)
+            .upload_slpkg(
+                &arts.catalog.package,
+                arts.catalog.version,
+                b"OPAQUE-SLPKG-TARBALL-BYTES-DO-NOT-READ",
+            )
+            .unwrap();
+        write_package_catalog(&slpkg, &arts).unwrap();
+        index.extend(arts.index_lines);
+    }
+    write(root, CATALOG_INDEX_PATH, &render_catalog_index_ndjson(&index));
+}
+
+#[test]
+fn reconstruct_wiring_graph_from_catalog_without_touching_slpkg() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("packages");
+    let tree = tmp.path().join("registry");
+    let (core, camera) = author_two_packages(&src);
+    emit_catalog_tree(&tree, &[core, camera]);
+
+    let client = CatalogClient::new(format!("file://{}", tree.display()), None);
+
+    // 1. The registry-wide aggregate carries one line per processor across
+    //    both packages — the whole node palette in one fetch.
+    let index = client.fetch_processor_index().unwrap();
+    let names: Vec<(String, String)> = index
+        .iter()
+        .map(|l| (l.package.to_string(), l.processor.name.clone()))
+        .collect();
+    assert!(names.contains(&("@tatolab/camera".into(), "Camera".into())));
+    assert!(names.contains(&("@tatolab/camera".into(), "Sink".into())));
+    assert_eq!(index.len(), 2, "two processors published");
+
+    // 2. Reconstruct the wiring edge: Camera.video (output) → Sink.video_in
+    //    (input). Both carry the SAME resolved release-core ident, sourced
+    //    from core's version (1.4.0), NOT camera's (2.1.0).
+    let camera_line = index.iter().find(|l| l.processor.name == "Camera").unwrap();
+    let sink_line = index.iter().find(|l| l.processor.name == "Sink").unwrap();
+    let out_schema = camera_line.processor.outputs[0].schema.schema().unwrap();
+    let in_schema = sink_line.processor.inputs[0].schema.schema().unwrap();
+    assert_eq!(out_schema, in_schema, "the wiring edge shares a schema identity");
+    assert_eq!(out_schema.to_string(), "@tatolab/core/VideoFrame@1.4.0");
+    assert_eq!(sink_line.processor.inputs[0].read_mode.as_deref(), Some("skip_to_latest"));
+    assert_eq!(camera_line.processor.runtime, CatalogRuntime::Rust);
+    assert_eq!(sink_line.processor.runtime, CatalogRuntime::Python);
+    assert_eq!(sink_line.processor.entrypoint.as_deref(), Some("src.sink:Sink"));
+
+    // 3. Per-package catalog fetch (browse-UI path) agrees with the aggregate.
+    let cam_catalog = client
+        .fetch_package_catalog(&pkg_ref("camera"), &SemVer::new(2, 1, 0))
+        .unwrap()
+        .unwrap();
+    assert_eq!(cam_catalog.processors.len(), 2);
+    let cfg_ident = cam_catalog.processors[0].config.as_ref().unwrap().schema.clone();
+    assert_eq!(cfg_ident.to_string(), "@tatolab/camera/CameraConfig@2.1.0");
+
+    // 4. Fetch the field-level schema shape via JTD, resolved from the OWNING
+    //    package's version dir — core owns VideoFrame, camera owns CameraConfig.
+    let vf_jtd = client.fetch_schema_type_definition(out_schema).unwrap().unwrap();
+    assert_eq!(vf_jtd["metadata"]["type"], "VideoFrame");
+    assert!(vf_jtd["properties"].get("width").is_some());
+    let cfg_jtd = client.fetch_schema_type_definition(&cfg_ident).unwrap().unwrap();
+    assert_eq!(cfg_jtd["metadata"]["type"], "CameraConfig");
+
+    // 5. Prove we reconstructed everything WITHOUT reading any `.slpkg`: the
+    //    only bytes in a `.slpkg` are the opaque sentinel, and nothing above
+    //    parsed them. Assert directly that the tarball is the opaque sentinel
+    //    (i.e. the graph did not come from it).
+    let slpkg_bytes =
+        std::fs::read(tree.join("slpkg/camera/2.1.0/camera.slpkg")).unwrap();
+    assert_eq!(slpkg_bytes, b"OPAQUE-SLPKG-TARBALL-BYTES-DO-NOT-READ");
+
+    // A concrete port never collapses to the `any` wildcard.
+    assert_ne!(camera_line.processor.outputs[0].schema, CatalogSchemaRef::Any);
+}
+
+/// The catalog aggregate is written at a STAGING-relative path
+/// (`CATALOG_INDEX_PATH` joined onto the staging root inside
+/// `emit_slpkg_and_manifest`), so it rides the same `build_and_flip` seam as
+/// the release manifest. This test drives that exact seam: it writes the
+/// release marker + the catalog index into the staging closure, and asserts
+/// both land together after the atomic flip. It locks that the flip carries
+/// the catalog aggregate atomically alongside the release — the property the
+/// emit relies on. (It does NOT re-run the full `emit_slpkg_and_manifest`,
+/// which needs a live workspace `cargo metadata`; the emit's own aggregate
+/// write is a plain `staging.join(CATALOG_INDEX_PATH)`, exercised end-to-end
+/// against `file://` by the wiring-graph test above.)
+#[test]
+fn catalog_aggregate_written_into_staging_rides_the_atomic_flip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("served");
+
+    build_and_flip(&out, |staging| {
+        // Mirror the emit ordering: release marker first, aggregate last.
+        let rel = staging.join("slpkg/streamlib-release/0.5.1");
+        std::fs::create_dir_all(&rel)?;
+        std::fs::write(rel.join("manifest.json"), b"{\"release_version\":\"0.5.1\"}")?;
+        let idx = staging.join(CATALOG_INDEX_PATH);
+        std::fs::create_dir_all(idx.parent().unwrap())?;
+        std::fs::write(&idx, "{\"package\":\"@tatolab/x\"}\n")?;
+        Ok(())
+    })
+    .unwrap();
+
+    // After the flip both are present together.
+    assert!(out.join(CATALOG_INDEX_PATH).is_file());
+    assert!(out.join("slpkg/streamlib-release/0.5.1/manifest.json").is_file());
+}

--- a/libs/streamlib-pack/tests/catalog_publish_query.rs
+++ b/libs/streamlib-pack/tests/catalog_publish_query.rs
@@ -192,6 +192,69 @@ fn reconstruct_wiring_graph_from_catalog_without_touching_slpkg() {
     assert_ne!(camera_line.processor.outputs[0].schema, CatalogSchemaRef::Any);
 }
 
+/// GATING regression: a `-dev.N` publisher's JTDs must be fetchable by the
+/// release-core ident. The writer places JTDs under the RELEASE-CORE version
+/// dir because `SchemaIdent` versions are release-core by invariant and the
+/// reader derives the JTD path from the ident. Mentally revert
+/// `write_package_catalog` to place JTDs under the full prerelease dir and
+/// `fetch_schema_type_definition` silently returns `Ok(None)` — this test
+/// fails on the `expect`.
+#[test]
+fn prerelease_publisher_jtd_resolves_by_release_core_ident() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("packages");
+    let tree = tmp.path().join("registry");
+
+    let widget = src.join("widget");
+    write(
+        &widget,
+        "streamlib.yaml",
+        r#"
+package:
+  org: tatolab
+  name: widget
+  version: 2.1.0-dev.3
+schemas:
+  WidgetConfig:
+    file: schemas/widget_config.yaml
+processors:
+- name: Widget
+  version: 1.0.0
+  runtime: rust
+  execution: reactive
+  config:
+    name: config
+    schema: WidgetConfig
+"#,
+    );
+    write(
+        &widget,
+        "schemas/widget_config.yaml",
+        "metadata:\n  type: WidgetConfig\nproperties: {}\n",
+    );
+    emit_catalog_tree(&tree, &[widget]);
+
+    let client = CatalogClient::new(format!("file://{}", tree.display()), None);
+
+    // The per-package catalog is fetched by the FULL published version…
+    let index = client.fetch_processor_index().unwrap();
+    assert_eq!(index.len(), 1);
+    assert_eq!(index[0].version.to_string(), "2.1.0-dev.3");
+    let catalog = client
+        .fetch_package_catalog(&pkg_ref("widget"), &index[0].version)
+        .unwrap()
+        .expect("per-package catalog under the full prerelease version dir");
+
+    // …while the JTD is fetched by the release-core ident and MUST resolve.
+    let cfg_ident = catalog.processors[0].config.as_ref().unwrap().schema.clone();
+    assert_eq!(cfg_ident.to_string(), "@tatolab/widget/WidgetConfig@2.1.0");
+    let jtd = client
+        .fetch_schema_type_definition(&cfg_ident)
+        .unwrap()
+        .expect("JTD must resolve for a -dev.N publisher via the release-core ident");
+    assert_eq!(jtd["metadata"]["type"], "WidgetConfig");
+}
+
 /// The catalog aggregate is written at a STAGING-relative path
 /// (`CATALOG_INDEX_PATH` joined onto the staging root inside
 /// `emit_slpkg_and_manifest`), so it rides the same `build_and_flip` seam as

--- a/libs/streamlib-pack/tests/emit_static_registry_catalog.rs
+++ b/libs/streamlib-pack/tests/emit_static_registry_catalog.rs
@@ -1,0 +1,152 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Integration: the REAL `emit_static_registry` path (→
+//! `emit_slpkg_and_manifest` → `build_and_flip`) writes the per-package
+//! catalog + owned JTDs + the `catalog/index.ndjson` aggregate INSIDE the
+//! staged tree, so the served tree carries them after the atomic flip.
+//! Runs against a hermetic fixture workspace (schema-only + processor
+//! packages, no compilable runtimes) so no toolchain beyond `cargo metadata`
+//! is exercised. This is the CI lock for the staging-relativity of the
+//! catalog emit — the workflow's `cargo test -p streamlib-pack` runs it.
+
+use std::path::Path;
+
+use streamlib_pack::static_registry::{emit_static_registry, EmitEcosystems, EmitOptions};
+use streamlib_idents::{CatalogClient, Org, Package, PackageRef, SemVer};
+
+fn write(dir: &Path, rel: &str, body: &str) {
+    let path = dir.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, body).unwrap();
+}
+
+/// Fabricate a minimal cargo workspace root: `[workspace.package].version`
+/// for `workspace_version`, one trivial non-closure member so `cargo
+/// metadata` yields a resolve graph, and a `packages/` dir holding the
+/// fixture streamlib packages.
+fn fixture_workspace(root: &Path) {
+    write(
+        root,
+        "Cargo.toml",
+        r#"[workspace]
+members = ["fixture-member"]
+resolver = "2"
+
+[workspace.package]
+version = "0.9.9"
+"#,
+    );
+    write(
+        root,
+        "fixture-member/Cargo.toml",
+        "[package]\nname = \"fixture-member\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    );
+    write(root, "fixture-member/src/lib.rs", "");
+
+    // Schema-only package (the @tatolab/core shape).
+    let core = root.join("packages/fixcore");
+    write(
+        &core,
+        "streamlib.yaml",
+        r#"
+package:
+  org: tatolab
+  name: fixcore
+  version: 1.4.0
+schemas:
+  FixFrame:
+    file: schemas/fix_frame.yaml
+"#,
+    );
+    write(
+        &core,
+        "schemas/fix_frame.yaml",
+        "metadata:\n  type: FixFrame\nproperties:\n  width:\n    type: uint32\n",
+    );
+
+    // Processor package importing the schema from the sibling (python
+    // runtime — nothing is compiled for a source-only `.slpkg`).
+    let cam = root.join("packages/fixcam");
+    write(
+        &cam,
+        "streamlib.yaml",
+        r#"
+package:
+  org: tatolab
+  name: fixcam
+  version: 2.1.0
+dependencies:
+  '@tatolab/fixcore':
+    version: ^1.0.0
+schemas:
+  FixFrame:
+    package: '@tatolab/fixcore'
+processors:
+- name: FixSource
+  version: 1.0.0
+  runtime: python
+  entrypoint: src.fix:FixSource
+  execution: reactive
+  outputs:
+  - name: out
+    schema: FixFrame
+"#,
+    );
+    write(&cam, "src/fix.py", "class FixSource:\n    pass\n");
+}
+
+#[test]
+fn real_emit_writes_catalog_inside_the_flipped_tree() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().join("ws");
+    fixture_workspace(&workspace);
+    let out = tmp.path().join("served");
+
+    emit_static_registry(&EmitOptions {
+        workspace_root: workspace,
+        out: out.clone(),
+        base_url: "http://127.0.0.1:9".into(),
+        dev: None,
+        ecosystems: EmitEcosystems {
+            cargo_fork: false,
+            cargo_closure: false,
+            pypi: false,
+            npm: false,
+            slpkg: true,
+        },
+    })
+    .expect("real emit path (slpkg + catalog + manifest) succeeds");
+
+    // Everything landed in the SERVED tree via the atomic flip: the .slpkg
+    // store, the release manifest (completion marker), the per-package
+    // catalogs, the owned JTD, and the aggregate — all present together.
+    assert!(out.join("slpkg/fixcam/2.1.0/fixcam.slpkg").is_file());
+    assert!(out.join("slpkg/streamlib-release/0.9.9/manifest.json").is_file());
+    assert!(out.join("slpkg/fixcam/2.1.0/fixcam.catalog.json").is_file());
+    assert!(out.join("slpkg/fixcore/1.4.0/fixcore.catalog.json").is_file());
+    assert!(out.join("slpkg/fixcore/1.4.0/schemas/FixFrame.jtd.json").is_file());
+    assert!(out.join("catalog/index.ndjson").is_file());
+    // No staging remnant beside the served tree.
+    let remnants: Vec<_> = std::fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().contains(".staging."))
+        .collect();
+    assert!(remnants.is_empty(), "staging remnant left behind: {remnants:?}");
+
+    // The catalog surface is queryable off the served tree.
+    let client = CatalogClient::new(format!("file://{}", out.display()), None);
+    let index = client.fetch_processor_index().unwrap();
+    assert_eq!(index.len(), 1, "one processor across the release");
+    assert_eq!(index[0].processor.name, "FixSource");
+    let out_schema = index[0].processor.outputs[0].schema.schema().unwrap();
+    assert_eq!(out_schema.to_string(), "@tatolab/fixcore/FixFrame@1.4.0");
+    let jtd = client.fetch_schema_type_definition(out_schema).unwrap().unwrap();
+    assert_eq!(jtd["metadata"]["type"], "FixFrame");
+    let cam_ref = PackageRef::new(Org::new("tatolab").unwrap(), Package::new("fixcam").unwrap());
+    assert!(client
+        .fetch_package_catalog(&cam_ref, &SemVer::new(2, 1, 0))
+        .unwrap()
+        .is_some());
+}


### PR DESCRIPTION
## What

Emits a **publish-time catalog** into the static registry tree so a client can browse "what processors exist and how do they wire together" **without downloading or compiling any `.slpkg`**. This is the data substrate for a future visual graph editor's node palette **and** a human-browsable registry web view (no UI in scope).

Tree layout (rides inside `emit_slpkg_and_manifest`, under `#1242`'s staged tree):
- `slpkg/<name>/<version>/<name>.catalog.json` — per-package [`PackageCatalog`] (processors → ports → schemas), beside the `.slpkg`.
- `slpkg/<name>/<version>/schemas/<Type>.jtd.json` — the JSON Type Definition for each schema the package **owns** (deduped by ownership).
- `catalog/index.ndjson` — registry-wide aggregate, one line per processor.

## Design decisions

- **Lean, engine-free catalog types** (`PackageCatalog`, `CatalogProcessor`, `CatalogPort`, `CatalogConfig`, `CatalogSchemaRef`, `CatalogIndexLine`, `CatalogRuntime`). Not the engine's `ProcessorDescriptorOutput` (engine-locked runtime introspection; `from_port_spec` panics on unresolved `Named`). The lean type carries `Any | resolved SchemaIdent` only, and resolution failures are **typed errors** at build time — never a panic, never a bare-name fallback.
- **Resolved release-core `SchemaIdent`s, not bare names.** Bare `Named` port/config refs are resolved at publish time against the manifest's `schemas:` map — `Local` → the package's own version, `External` → the **dependency's** version (from the set of packages published in the same release, recursively). `SchemaIdent::new` release-core-projects (`-dev.N`/`-rc.N` stripped). A cycle guard turns a mutually-referential external chain into a typed `SchemaResolutionCycle` error rather than a stack overflow.
- **Per-schema JTD files in the tree**, not inlined — keeps the catalog small and the schemas independently cacheable/browsable. Each package emits only the schemas it declares locally (dedup by ownership).
- **NDJSON aggregate** mirroring the version-index pattern (`render_index_ndjson`): unknown fields ignored on read, garbage lines skipped — forward-compatible. Written **after** the per-package files + release manifest, inside the staged tree, so it rides `#1242`'s atomic flip: a partial-tree reader never sees the catalog without its release.
- **Query client (`CatalogClient`) + catalog types placed in `streamlib-idents`**, a deliberate deviation from the plan's "types in `streamlib-processor-schema`". `RegistryClient`, the `ureq`/`file://` transport, `ReleaseManifest`, `SchemaIdent`, and the NDJSON machinery all already live in `streamlib-idents`; `processor-schema → idents`, so putting the types in `processor-schema` and the transport-bearing client in `idents` would force a dependency cycle **or** pull `ureq` into the plugin-adjacent `processor-schema` crate. `idents` is the coherent home for both. Query shape (file:// + http, tokenless): fetch the aggregate, fetch a per-package catalog, fetch a schema JTD by ident.

## Tests

- `streamlib-idents` (`catalog` module): schema-ref serde (Any↔string, Specific↔ident map, rejects unresolved bare strings), `PackageCatalog` round-trip, NDJSON render/parse + unknown-field/garbage tolerance, `CatalogClient` file:// reads + missing-is-empty.
- `streamlib-pack` (`catalog` module): local + external ref resolution to release-core idents, JTD ownership dedup, one-index-line-per-processor, typed errors for missing external dep / undeclared name / **resolution cycle**, and a mentally-revertible lock that an external ref carries the **dependency's** version, not the importer's.
- Integration (`catalog_publish_query.rs`): publish 2 packages to a temp `file://` tree, reconstruct the full processor→port→schema **wiring graph** through `CatalogClient` alone, asserting the `.slpkg` tarball bytes are the opaque sentinel (never read); plus the catalog aggregate riding the atomic `build_and_flip` staged-swap.

Validation: `cargo check --workspace --offline` clean; `streamlib-idents` / `streamlib-processor-schema` lib suites + full `streamlib-pack` suite green; new code clippy-clean under `-D warnings`; `cargo doc -p streamlib-idents` link-clean. `static-registry.yml`'s emit smoke uses `--no-slpkg`, so the catalog path is additive and doesn't touch it.

## Scope disclosures

- `CatalogPort` deliberately omits `overflow` / `buffer_size` from `ProcessorPortSchema` — they are producer-side buffering knobs, not wiring topology, and are out of the catalog's node-palette round-trip contract by scope decision (`required` has no manifest source at all, so its omission is fidelity-correct rather than a cut).
- The `docs/architecture/static-registry.md` catalog section is deferred to the milestone's docs deliverable; this PR ships code + tests only.

## Review-batch addendum

- **Release-core JTD dirs (gating fix):** JTDs are written under `slpkg/<name>/<release-core>/schemas/` because schema idents are release-core by invariant and the reader derives the JTD path from the ident — a `-dev.N` publisher's JTDs under the full prerelease dir were silently unfetchable. Per-package `<name>.catalog.json` stays under the full published version. Regression-locked by `prerelease_publisher_jtd_resolves_by_release_core_ident`.
- **Resolver cycle-guard sweep:** the pre-existing `resolve_bare_schema_name_internal` in `streamlib-idents` had the same unbounded External-re-export recursion my catalog resolver guards against; per "no bad patterns left behind" it now returns typed `ResolverError::BareSchemaNameCycle` (+ test) in the same PR.
- **Real-emit CI lock:** `emit_static_registry_catalog.rs` drives the public `emit_static_registry` (slpkg ecosystem) against a hermetic fixture workspace and asserts the aggregate + per-package catalogs + JTDs land inside the atomically-flipped served tree; the static-registry workflow's existing `cargo test -p streamlib-pack` runs it. The workflow's emit *smoke* cannot enable `--slpkg` today: `packages/test-fixtures*` carry dev-only path `patch:` overrides that `ensure_no_path_artifacts` rejects (pre-existing; verified by running the emit locally).

Closes #1220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wr1VLKMBbFpsmU7zAcniU2