### PR TITLE
docs(architecture): two-loop package manager + dev model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,35 +332,57 @@ Run `cargo doc -p streamlib --no-deps` - fix any unresolved link warnings.
 ### Dependencies
 - **Git dependencies must be pinned** with `rev = "<commit sha>"` (or `tag = "..."`). Never use a bare `git = "..."` or `branch = "..."` — Cargo resolves those against the remote's current HEAD, so fresh clones drift out of sync with the lockfile and stop compiling. This applies to every `Cargo.toml` in the workspace, including `[patch.crates-io]` entries.
 
-### Dependency resolution & distribution — unified Gitea registry
+### Dependency resolution & distribution — two loops over one substrate
 
-**Decided architecture, validated by POC, in active migration** (the "Gitea
-Package Registry" milestone). Documented ahead of full implementation on
-purpose — follow it; do **not** reimplement resolution a different way. Full
-model + which issue finalizes each piece: @docs/architecture/gitea-registry-distribution.md.
+To the best of our current knowledge streamlib runs **two loops** over one
+package substrate, with **install** as the seam between them. Full shipped
+model: @docs/architecture/package-development-model.md. The two distribution
+backends and the catalog: @docs/architecture/static-registry.md (static file
+tree) and @docs/architecture/gitea-registry-distribution.md (hosted Gitea +
+the shared by-version resolution shape).
 
-Every StreamLib-authored **or customized** artifact is published to a single
-self-hosted **Gitea** instance under the **`tatolab`** org and resolved **by
-version** — never by relative `path` or git `[patch]` in anything a consumer
-sees:
+**Distribution loop — resolve by version, never by path/patch.** Every
+StreamLib-authored **or customized** artifact is resolved **by version** —
+never by relative `path` or git `[patch]` in anything a consumer sees:
 
 - **SDK libraries** (rust `streamlib` crate chain, python pkg, deno module) →
-  Gitea's cargo / pypi / npm registries.
+  the backend's cargo / pypi / npm registries.
 - **Packages** (polyglot streamlib packages) → **source-only `.slpkg`** via
-  `streamlib pack` → Gitea's generic registry.
+  `streamlib pack` → the generic store.
 - **`streamlib.yaml` schema deps** (e.g. `@tatolab/escalate`) → resolved from
-  the generic registry (schema-package `.slpkg`), not a dev path patch.
+  the generic store (schema-package `.slpkg`), not a dev path patch.
 - **Truly-external untouched deps** (serde, tokio, …) keep resolving from
   their normal public registries.
 
-Rust internal cross-crate deps use `{ path = "../foo", version = "x.y",
-registry = "gitea" }` — the `path` is a dev-only affordance cargo strips from
-the published manifest (standard workspace-publish pattern); `registry =
-"gitea"` is required or cargo defaults to crates.io. A local engine change is
-published as a `0.4.x-dev.N` version the consumer bumps to — **never** a new
-relative-path dep or `[patch]`. Don't introduce new relative-path / git-`[patch]`
-cross-crate deps. The monorepo still builds itself in-place (the dev `path`
-wins locally); publishing is a release step.
+Distribution has **two backends behind one tokenless read shape**: a hosted
+Gitea registry and a plain static file tree (sparse index + tarballs +
+`.slpkg` + catalog). The static tree is what CI and local `file://`
+resolution use. Rust internal cross-crate deps use `{ path = "../foo",
+version = "x.y", registry = "gitea" }` — the `path` is a dev-only affordance
+cargo strips from the published manifest; `registry` is required or cargo
+defaults to crates.io. Releases are **atomic** (`compute_release_closure` is
+the one definition of "what a release publishes"; the release manifest is
+written last as the completion marker) and a consumer **detects a partial
+release** up front rather than failing deep in version unification.
+
+**Dev loop — two intents.** Don't introduce new persistent relative-path /
+git-`[patch]` cross-crate deps in a manifest. For local development use one of
+the sanctioned loops instead:
+
+- **All-local WIP against one checkout** → `streamlib link <checkout>` emits
+  whole-tree cargo `[patch]` / uv-source / deno-import-map overrides at the
+  toolchain layer; it is transactional, greppable, restored byte-identically
+  by `streamlib unlink`, and refused entry into any published `.slpkg`.
+- **Against a specific *published* version** → publish a `-dev.N` version the
+  consumer bumps to. The monorepo still builds itself in-place (the dev
+  `path` wins locally); publishing is a release step.
+
+**Install seam.** `streamlib install` resolves range→concrete, materializes,
+and writes `streamlib-app.lock`; a locked run (`add_modules_from_lockfile`)
+loads that pinned set offline (five network/build touchpoints unreachable),
+content-hash-verified. Range logic lives only at install, concrete
+enforcement only at run — the two resolvers stay separate; the lockfile is
+the handoff.
 
 ### Vulkan RHI Boundary — ABSOLUTE RULE
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ They do NOT need to agree on:
 
 **Where the dream currently leaks**: Phase D (#906) and Phase C2 (#905) shipped some FullAccess methods that return `Arc<HostInternalType>` via `Arc::into_raw` / `Arc::from_raw` raw-pointer transit. Those code paths DO require rustc-version coupling because the host-internal types aren't `#[repr(C)]`. Issue #917 closes that gap by refactoring the affected return types into `#[repr(C)] { handle, vtable }` PluginAbiObject pairs (mirroring `RhiCommandQueue` / `CommandBuffer`). After #917 lands, no plugin ABI return type leaks host layout, and the cross-repo dream is fully real.
 
-**What's NOT in scope** (deferred to its own milestone): a hosted marketplace / registry / index. Today's distribution model is "package author hands you an `.slpkg` directly, or you clone the repo and run `streamlib pack` yourself". A managed registry where you'd run `streamlib install @tatolab/camera` is a separate future deliverable.
+**What's NOT in scope** (deferred to its own milestone): a hosted marketplace / registry / index. Today's distribution model is "package author hands you an `.slpkg` directly, or you clone the repo and run `streamlib pkg build` yourself". A managed registry where you'd run `streamlib install @tatolab/camera` is a separate future deliverable.
 
 **Implication for new architectural work**: any plugin ABI surface added in this codebase MUST be `#[repr(C)]` end-to-end. If you're tempted to return `Arc<SomeHostInternalType>` from a cdylib-callable method, stop — the answer is to expose the type as a PluginAbiObject. The dormant `clone_*` / `drop_*` slots already present on the FullAccess vtable are infrastructure for this. The "rustc-version coupling stays" framing that previously appeared in the All-Dynamic Package Loading milestone body was a permissive fallback while PluginAbiObject coverage was incomplete; it's superseded as of 2026-05-22.
 
@@ -348,7 +348,7 @@ never by relative `path` or git `[patch]` in anything a consumer sees:
 - **SDK libraries** (rust `streamlib` crate chain, python pkg, deno module) →
   the backend's cargo / pypi / npm registries.
 - **Packages** (polyglot streamlib packages) → **source-only `.slpkg`** via
-  `streamlib pack` → the generic store.
+  `streamlib pkg build` / `streamlib pkg publish` → the generic store.
 - **`streamlib.yaml` schema deps** (e.g. `@tatolab/escalate`) → resolved from
   the generic store (schema-package `.slpkg`), not a dev path patch.
 - **Truly-external untouched deps** (serde, tokio, …) keep resolving from

--- a/docs/architecture/gitea-registry-distribution.md
+++ b/docs/architecture/gitea-registry-distribution.md
@@ -1,18 +1,42 @@
-# Unified Gitea registry — distribution & dependency resolution
+# Gitea registry — the hosted distribution backend
 
 > **Living document.** Validate, update, critique freely per
 > [CLAUDE.md's markdown editing rules](../../CLAUDE.md#editing-markdown-documentation).
 
+> **Scope.** This doc describes the **hosted-registry backend** and the
+> by-version resolution model both backends share. Distribution has two
+> backends behind one tokenless read shape: this hosted Gitea one and a
+> plain static file tree ([`static-registry.md`](static-registry.md)) — the
+> static tree is what CI and local `file://` resolution use. The overall
+> two-loop model (dev loop = `streamlib link`; distribution loop =
+> publish/install/run) is
+> [`package-development-model.md`](package-development-model.md). The
+> `{ path, version, registry }` cargo shape, schema-package resolution, and
+> the anonymous version index below apply to both backends.
+
+> ~~Every StreamLib-authored **or customized** artifact is distributed and
+> resolved through a *single* self-hosted Gitea instance.~~ — Superseded
+> 2026-07-12: distribution now has two backends behind one read shape (this
+> hosted Gitea one and the static file tree in
+> [`static-registry.md`](static-registry.md)). The by-version resolution
+> model below is unchanged and shared by both; only the "single Gitea
+> instance is the sole backend" framing is superseded.
+
 Every StreamLib-authored **or customized** artifact is distributed and resolved
-through a single self-hosted Gitea instance, by version — never by relative
-`path` or git `[patch]` in anything a consumer sees. SDK libraries resolve from
-Gitea's cargo / pypi / npm registries; packages are source-only `.slpkg`s in
-its generic registry.
+**by version** — never by relative `path` or git `[patch]` in anything a
+consumer sees. SDK libraries resolve from the backend's cargo / pypi / npm
+registries; packages are source-only `.slpkg`s in its generic store.
 
 ## The model in one picture
 
+> ~~The self-hosted Gitea lifts to a *cloud Gitea* for the public / hosted
+> backend.~~ — Superseded 2026-07-12: the public / fresh-clone / CDN path is
+> the static file tree ([`static-registry.md`](static-registry.md)), not a
+> hosted Gitea. A self-hosted Gitea remains a valid backend for the
+> by-version read/publish model below; a *hosted* one is no longer the plan.
+
 ```
-                self-hosted Gitea  (org: tatolab)   ──lifts to──▶  cloud Gitea (hosted backend)
+                self-hosted Gitea  (org: tatolab)
    ┌───────────────────────────────────────────────────────────┐
    │  cargo registry     pypi registry     npm registry         │  ← SDK libraries
    │  (rust SDK crates)  (python SDK)      (deno SDK)            │    resolved by version
@@ -220,15 +244,30 @@ mirroring cargo:
 This is the schema-tier twin of the cargo-crate resolution. The resolver is
 shared by all three runtimes' codegen, so the one fix covers rust/python/deno.
 
-## The dev loop — one knob, publish-by-version
+## The dev loop — publish-by-version, or whole-tree link
 
-A change to an internal crate becomes a **published `0.4.x-dev.N` version** the
-consumer bumps to — never a new path dep or `[patch]`. In the monorepo, the
-dev-only `path` makes local edits instant; publishing is a release step. For
-co-developing the engine against a separate-repo package, the same applies:
-publish a dev version and bump — there is no relative-path escape hatch by
-design (that "purity" is what makes splitting crates into their own repos a
-no-op later).
+There are two local dev loops, for two different intents (full model:
+[`package-development-model.md`](package-development-model.md)):
+
+- **Develop against a specific *published* version.** A change to an
+  internal crate becomes a **published `-dev.N` version** the consumer bumps
+  to — never a persistent path dep or `[patch]` in a manifest. In the
+  monorepo the dev-only `path` makes local edits instant; publishing is a
+  release step. This is the loop for co-developing the engine against a
+  separate-repo package: publish a dev version and bump.
+
+- **Develop all-local against one checkout.** `streamlib link <checkout>`
+  points a consumer's *entire* streamlib surface at a working tree
+  (whole-tree cargo `[patch]` / uv-source / deno-import-map overrides), for
+  the instant edit→run WIP loop.
+
+> ~~There is no relative-path escape hatch by design.~~ — Reconciled
+> 2026-07-12: `streamlib link` *does* emit a whole-tree path override, but it
+> is transactional, greppable, restored byte-identically by `streamlib
+> unlink`, and **refused entry into any published `.slpkg`**
+> (`PackRefusedWhileLinked`). So the "purity" the original claim protects —
+> no persistent relative-path dep leaking into a distributed artifact — still
+> holds; link is a dev-only toolchain override, not a manifest path dep.
 
 ## Operational notes
 
@@ -249,8 +288,11 @@ self-hosted instance:
 Notes the scripts encode:
 
 - One Gitea container hosts all four registries (cargo/pypi/npm/generic) — a
-  single lightweight Go binary, no JVM. Local dev registry today; lifts to a
-  cloud Gitea for the hosted/centralized backend unchanged.
+  single lightweight Go binary, no JVM. Used as a local dev registry.
+  > ~~Lifts to a cloud Gitea for the hosted/centralized backend
+  > unchanged.~~ — Superseded 2026-07-12: the public / centralized path is
+  > the static file tree ([`static-registry.md`](static-registry.md)) served
+  > from a dumb HTTP mount / object store, not a hosted Gitea.
 - cargo token must be stored as `Bearer <token>` in `credentials.toml`
   (`cargo login` stores it bare → 401).
 - The **sparse** cargo index needs no setup: the registry is reachable once
@@ -273,8 +315,12 @@ Notes the scripts encode:
 
 ## Reference
 
+- `docs/architecture/package-development-model.md` — the two loops (dev =
+  `streamlib link`; distribution = publish/install/run), the version model,
+  and the install/run seam this backend feeds.
+- `docs/architecture/static-registry.md` — the other backend behind the same
+  read shape (static file tree + catalog).
 - `docs/architecture/runtime-module-materialization.md` — how `add_module`
-  builds a source module, resolving its SDK dependencies from the Gitea
-  registry.
+  builds a source module, resolving its SDK dependencies from the registry.
 - `docs/learnings/polyglot-venv-gitea-registry-env.md` — failure symptoms when
   the registry env channels aren't set for a polyglot build.

--- a/docs/architecture/package-development-model.md
+++ b/docs/architecture/package-development-model.md
@@ -1,0 +1,335 @@
+# Package development & distribution — the two loops
+
+> **Living document.** Validate, update, critique freely per
+> [CLAUDE.md's markdown editing rules](../../CLAUDE.md#editing-markdown-documentation).
+
+## What this is
+
+streamlib is one substrate — an engine that resolves *where* a package's
+source lives, materializes it, and loads the staged result (see
+[`runtime-module-materialization.md`](runtime-module-materialization.md)).
+Two loops run over that substrate, and the seam between them is a single
+operation: **install**.
+
+- **The dev loop** — `streamlib link` points a consumer's *entire*
+  streamlib surface at one local checkout, so edits resolve to working-tree
+  source with no publish. Instant edit→run; deliberately all-local.
+- **The distribution loop** — `streamlib pkg publish` releases a package
+  by version into a registry; a consumer resolves it back by version.
+  Releases are atomic and a consumer can detect a partial one.
+
+The two loops never blur: a link override is refused entry into any
+published artifact, and a locked run does zero live re-resolution. The
+version model in the middle makes both consistent — one version axis per
+package, one version per package in a running process.
+
+```
+   dev loop                         install seam                 distribution loop
+   ────────                         ────────────                 ─────────────────
+   streamlib link <checkout>                                     streamlib pkg publish
+     whole-tree toolchain            streamlib install            compute_release_closure
+     overrides (cargo/uv/deno)   ─▶    resolve range→concrete  ◀─   → atomic staged release
+     → working-tree source            materialize + lock            (manifest written last)
+                                       → streamlib-app.lock
+                                            │
+                                            ▼
+                                     Runner::add_modules_from_lockfile
+                                       locked run — offline, pinned,
+                                       content-hash verified
+```
+
+## The dev loop — whole-tree link
+
+`streamlib link <CHECKOUT>` points a consumer at a local streamlib checkout;
+`streamlib unlink` restores every touched file byte-identically; bare
+`streamlib link` prints status. Implementation:
+[`libs/streamlib-cli/src/commands/link.rs`](../../libs/streamlib-cli/src/commands/link.rs)
+plus the shared marker in
+[`libs/streamlib-pack/src/link_marker.rs`](../../libs/streamlib-pack/src/link_marker.rs).
+
+**Whole-tree, not per-dep.** Link mode is a *toolchain-emission* concern —
+it does not add a resolution path (the engine already resolves a local
+package via `Strategy::Path`). `plan_edits` computes three language-native
+overrides in one plan, so a checkout's SDK libraries *and* sibling packages
+all resolve to that one tree:
+
+| Toolchain | Override | Written to |
+|---|---|---|
+| cargo | `[patch."<index>"]` with one `path = "<member>"` per crate | `.cargo/config.toml` |
+| Python (uv) | `[tool.uv.sources] streamlib = { path = "libs/streamlib-python", editable = true }` | `pyproject.toml` (only if present) |
+| Deno | import-map `imports.streamlib` → `libs/streamlib-deno/mod.ts` | `deno.json(c)` (only if present) |
+
+The cargo registry index is discovered live (`discover_registry_index`
+reads `registries.gitea.index` from the consumer's cargo config), never
+hardcoded; each emitted table carries a greppable
+`# streamlib-link — managed by streamlib link` marker. The crate set is
+derived from the checkout via `compute_release_closure` — the **same**
+definition a release uses — so a whole-tree link and a release always agree
+on which crates exist. Whole-tree consistency is by construction: a single
+checkout never mixes published versions.
+
+**Manifest-first transaction.** `establish_link` plans every edit in memory,
+persists the full plan to `.streamlib/link.json` with state `Applying` via
+`O_EXCL` (`create_new`) *before* touching a file — a concurrent link fails
+`LinkMarkerAlreadyExists` — then backs each pre-existing file up under
+`.streamlib/link-backup/` and writes. Any apply error triggers a
+*verified* rollback (each restore is re-read and hash-checked); only a
+provably-restored tree removes the state dir, otherwise `RollbackIncomplete`
+leaves the backups for `unlink` recovery. The marker records per-file
+`pre_edit_sha256` / `post_edit_sha256` / `existed_before` for byte-exact
+teardown. A crash mid-apply leaves state `Applying`; a later `link` refuses
+with `TornLinkState` pointing at `unlink`.
+
+**Post-link verification.** Unless `--skip-verify`, `link` runs
+`cargo metadata --offline` and asserts every `streamlib*` / `vulkan-jpeg`
+package resolves to a path source under the checkout; if a
+semver-incompatible consumer requirement made cargo silently ignore the
+`[patch]`, verification names the offending crates, the whole link rolls
+back, and `LinkVerificationFailed` tells the user to fix the requirement or
+re-run with `--skip-verify`.
+
+**Tri-state.** Link state is `LinkTransactionState::{Applying, Active}` plus
+marker-absence (three states, surfaced by `status`). Per-file, `unlink`
+classifies each touched file into `RestoreAction::{Skip, RestoreOriginal,
+RemoveCreated}`; a file the user modified while linked refuses with
+`UnlinkRefusedModifiedFile` unless `--force`.
+
+**Overrides never leak into an artifact.** All three edits land in
+*toolchain config* files — never a lockfile. `streamlib pkg build` /
+`publish` refuse while any link marker exists up-tree
+(`ensure_no_active_link_for_pack` → `PackRefusedWhileLinked`), and the build
+orchestrator re-injects the same uv-source override from the marker when it
+provisions a linked package's venv (`apply_link_override_if_active`), so a
+cargo-patched-but-venv-from-registry mixed state can't occur.
+
+**What link deliberately does not solve.** Developing against one *specific
+published* version — link is all-or-nothing against a single checkout. That
+case is the version model + a `patch:` entry, not link.
+
+## The version model
+
+One version axis per package, one version per package in a process.
+
+**SemVer with a closed prerelease grammar.** The `SemVer` type
+([`libs/streamlib-idents/src/semver.rs`](../../libs/streamlib-idents/src/semver.rs))
+carries `major.minor.patch` plus an optional `Prerelease { kind, n }` where
+`kind` is `Dev` or `Rc` only — no `+build` metadata. Ordering within one
+release core is `dev.k < rc.j < release`: a release (no prerelease) outranks
+any prerelease of the same core; two prereleases compare by `(kind, n)`.
+Range matching (`SemVerRange::{Any, Exact, AtLeast, Caret, Tilde}`) is
+npm-style: a release requirement admits only releases, `*` excludes
+prereleases, and a prerelease requirement admits a prerelease candidate only
+when it shares the release core and is at-or-above the requirement.
+
+**One version, stamped — no redundant crate-version axis.** The canonical
+version is `streamlib.yaml`'s `package.version`. At pack time
+`assemble_artifact` stamps the artifact's `Cargo.toml` `[package].version`
+from it (`stamped_cargo_toml_bytes` → `rewrite_cargo_package_version`,
+format-preserving, handles `version.workspace = true`), so a package's crate
+version can't drift from its manifest version in a distributed artifact. The
+in-tree copy is kept honest by the `cargo xtask check-package-version-drift`
+lint; `--fix` rewrites the in-tree `Cargo.toml` through the same routine.
+The intended bump workflow is "edit `streamlib.yaml`, run `--fix`" — never
+hand-edit `Cargo.toml`.
+
+**Schema idents are release-core.** A `SchemaIdent`
+([`libs/streamlib-idents/src/ident.rs`](../../libs/streamlib-idents/src/ident.rs))
+carries `@org/package/Type@version` where `version` is *release-core* —
+the prerelease channel stripped, `major.minor.patch` preserved
+(`SemVer::release_core()`). So `1.2.3-dev.4` and `1.2.3` share one schema
+identity. Three enforcement prongs keep the invariant total:
+
+1. **Constructor projects** — `SchemaIdent::new` stores
+   `version.release_core()`.
+2. **Parser rejects** — the `version` field deserializes through
+   `deserialize_release_only_semver`, a hard error on any prerelease on the
+   wire.
+3. **Two grep-auditable format sites** — `Display for SchemaIdent` and
+   `CatalogClient::fetch_schema_type_definition` both emit the `version`
+   field verbatim, trusting (1)+(2). They are the only places a schema-ident
+   version is formatted, so the invariant is auditable by inspecting two
+   call sites.
+
+**Single version per package, enforced at resolution.** `ResolutionMemo`
+([`libs/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs`](../../libs/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs))
+is a runtime-lifetime `Mutex<HashMap<PackageRef, PackageResolutionState>>`
+held as `Arc<ResolutionMemo>` on `Runner`. Its `gate` classifies-and-inserts
+under one lock: the first resolver to reach a package inserts an
+`InFlightPlaceholder`; a second load that observes the placeholder skips and
+waits on a `PackageResolutionCompletionSignal` at the *end* of the walk
+(600s timeout) rather than blocking inside the gate — so the design is
+deadlock-free (no thread blocks holding the packages lock). A concrete
+version mismatch raises `SingleVersionConflict { package, existing_version,
+existing_required_by, conflicting_version, conflicting_required_by }`.
+`InFlightPlaceholderGuard` is RAII: commit on success, remove-and-publish-
+`Failed` on drop.
+
+**Flat-global by IPC necessity.** The shared msgpack wire vocabulary means
+two packages on different `@tatolab/core` schema versions would emit
+incompatible bytes on the same IPC fabric, so npm-style nested duplicates
+are physically impossible in one process. The schema registry
+([`libs/streamlib-engine/src/core/embedded_schemas/mod.rs`](../../libs/streamlib-engine/src/core/embedded_schemas/mod.rs))
+is one flat `LazyLock<RwLock<HashMap<String, Arc<str>>>>` keyed by the
+*unversioned* canonical id: `strip_semver_suffix` drops any trailing
+`@version` before lookup and registration composes `@org/name/Type` using
+`owner.version.release_core()`, so versioned and unversioned references
+collapse to one slot (last-write-wins). The static is per-loaded-artifact,
+but plugin cdylibs forward through the host's single map via
+`install_host_services` function pointers, so at runtime every consumer
+reads and writes the host's one vocabulary. Single-version-per-package is
+the invariant that keeps that flat map coherent.
+
+**`patch:` is per-manifest-local.** A `Manifest.patch` table
+([`libs/streamlib-idents/src/manifest.rs`](../../libs/streamlib-idents/src/manifest.rs))
+lives in the consumer's own `streamlib.yaml` — there is *no* workspace
+walk-up. Resolution consults the same consumer's patch
+(`effective_spec = patch.get(dep_ref).unwrap_or(spec)`) before the installed
+cache. A root-level override reaches a *locked run* only because the install
+resolve applied it and materialized the result into the lockfile pins — a
+locked run bypasses `patch:` entirely and resolves from the lockfile.
+
+## The distribution loop — atomic release
+
+**Closure by definition.** `compute_release_closure(workspace_root)`
+([`libs/streamlib-pack/src/lib.rs`](../../libs/streamlib-pack/src/lib.rs))
+is the *single* definition of "the set of crates a release publishes":
+workspace member ∧ linkable name (`streamlib*` or `vulkan-jpeg`) ∧ has a
+library target ∧ publishable, returned in topological publish order. There
+is no "SDK-subset vs. all-libs" switch — `streamlib-plugin-sdk` /
+`vulkan-jpeg` are members by definition, so a release can't silently omit a
+crate a human forgot to flag.
+
+**Manifest-last atomicity.** A `ReleaseManifest`
+([`libs/streamlib-idents/src/release.rs`](../../libs/streamlib-idents/src/release.rs))
+lands at `streamlib-release/<V>/manifest.json` and is written **last**, so
+its presence is the release's completion marker (`upload_release_manifest`
+is the atomicity flip the publisher runs after every crate / SDK / package
+has landed).
+
+**Consumers detect a partial release.** `assert_release_complete`
+([`libs/streamlib-build-orchestrator/src/release_check.rs`](../../libs/streamlib-build-orchestrator/src/release_check.rs))
+picks the newest release manifest satisfying each pin's range and runs
+`crates_missing_from_release`; any gap raises `IncompleteRelease { package,
+release_version, missing, hint }` — an actionable, up-front error instead of
+a cryptic "failed to select a version for `streamlib-plugin-sdk`" deep in
+cargo / `streamlib-macros` version unification (the symptom this replaces).
+The check rides *inside* materialize, so install fails before cargo runs.
+
+**Two backends, one read shape.** Distribution has a hosted-registry backend
+and a plain static-file-tree backend behind one tokenless read shape (sparse
+index + tarballs + `.slpkg` generic store + catalog). The static tree —
+what CI and local `file://` resolution use — is documented in
+[`static-registry.md`](static-registry.md); its catalog surface (a queryable
+processor / port / schema index a visual editor browses without downloading
+packages) is documented there too. The hosted-Gitea backend is documented in
+[`gitea-registry-distribution.md`](gitea-registry-distribution.md); the
+by-version resolution model (`{ path, version, registry }`, schema-package
+resolution, the anonymous version index) is shared by both.
+
+One gap the static path closes: on a hosted-registry read path, a partial
+crate set uploaded at a version *above* the newest manifest'd version — with
+no manifest of its own — is invisible to `assert_release_complete` (which
+keys on manifest'd versions and proceeds when no manifest covers a pin), yet
+cargo's sparse index could still resolve a caret pin up to that higher
+partial version. The static tree removes the window entirely: crates and the
+release manifest land in one atomic whole-tree `renameat2(RENAME_EXCHANGE)`
+staged swap (`publish_staged_tree`), so no state ever exists where partial
+crate versions sit above the newest manifest.
+
+## The install seam — install / run split
+
+Install and run are distinct operations with the application lockfile as the
+only handoff.
+
+**`install` — resolve + materialize + lock.**
+`install(root_dir, orchestrator, sink, options)`
+([`libs/streamlib-engine/src/core/runtime/install.rs`](../../libs/streamlib-engine/src/core/runtime/install.rs),
+CLI `streamlib install`) runs the shared `resolve_with` (range→concrete),
+materializes each resolved package through the orchestrator, and writes the
+lockfile. The release-completeness check *rides* materialize — a partial
+registry release fails install before any lockfile is written. Network at
+install time is expected.
+
+**Locked run — offline, pinned, verified.**
+`Runner::add_modules_from_lockfile` builds a `LockedResolution` from the
+lockfile and forces every dependency edge through it: each edge becomes a
+`Strategy::Path { build: NeverBuild }` at `SemVerRange::Exact(pin.version)`.
+Five network / build touchpoints are unreachable in locked mode — **registry
+list, registry download, git fetch, `.slpkg` re-fetch, and build** — the run
+loads strictly from the pre-materialized cache and is offline by
+construction; a dep absent from the lockfile is a hard `LockfileMiss`, never
+a live fetch. At load, a **content-hash integrity gate** re-hashes each
+slot's manifest + schema set (`content_hash_for_package_dir`, SHA-256) and
+refuses on mismatch (`LockedSlotContentMismatch`), closing the
+tampered / republished-in-place hole. Slot paths are re-derived by the shared
+`get_cached_package_dir_for_name_version` helper
+([`libs/streamlib-engine/src/core/streamlib_home.rs`](../../libs/streamlib-engine/src/core/streamlib_home.rs)) —
+the single `cache/packages/{name}-{version}` convention also used by `.slpkg`
+extraction, registry resolution, and orchestrator staging.
+
+**Two lockfiles, two lifecycles.** Both serialize the same `Lockfile` wire
+shape ([`libs/streamlib-idents/src/lockfile.rs`](../../libs/streamlib-idents/src/lockfile.rs))
+but are distinct files with distinct headers:
+
+| File | Written by | Pins |
+|---|---|---|
+| `streamlib.lock` (`LOCKFILE_NAME`) | `streamlib generate` / jtd-codegen | the *schema* set that reconstructs generated bindings byte-for-byte |
+| `streamlib-app.lock` (`APP_LOCKFILE_NAME`) | `streamlib install` | the *runtime package* set an installed app loads offline |
+
+**Resolver handoff — deliberately two resolvers.** Range logic lives only at
+install (`resolve_with`); concrete enforcement lives only at run
+(`LockedResolution`, which does zero range resolution). The two resolvers
+stay physically separate; the lockfile is the only artifact between them.
+They are not merged on purpose — the picker (install) and the enforcer (run)
+have different jobs.
+
+## Known limitations
+
+Stated honestly; verify against current code before relying on any.
+
+- **Polyglot spawn-time offline is unproven.** The locked run's five-
+  touchpoint offline guarantee is proven for the Rust module-load path. The
+  Python venv provisioning / Deno subprocess spawn behavior under a strictly
+  offline locked run is not separately gated, so "an installed polyglot app
+  runs fully offline at process spawn" is, to the best of our current
+  knowledge, unverified.
+- **pypi / npm emit has narrower CI coverage than cargo / slpkg.** The
+  daemon-free registry gate resolves `.slpkg` (`file://`) and the cargo fork
+  tree end-to-end and exercises the completeness negative gate, but the xtask
+  emit smoke runs `--no-pypi --no-npm --no-slpkg`; the pypi-simple and npm
+  renderers are exercised by unit tests, not a full `file://` resolve in CI.
+- **Deploy lockfiles don't pin checkouts.** Link-mode registry-dep
+  redirection lives at the toolchain layer. A lockfile produced from a linked
+  or path-declared tree records `path:` sources (a working-tree path), not an
+  immutable content-pinned slot — so an app lockfile captured over a link is
+  not a reproducible pin of the checkout's contents.
+
+## Reference
+
+- **Link mode**: `libs/streamlib-cli/src/commands/link.rs`,
+  `libs/streamlib-pack/src/link_marker.rs`.
+- **Version model**: `libs/streamlib-idents/src/semver.rs` (SemVer +
+  ranges), `ident.rs` (`SchemaIdent` release-core invariant),
+  `manifest.rs` (`patch:` locality),
+  `libs/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs`
+  (`ResolutionMemo`),
+  `libs/streamlib-engine/src/core/embedded_schemas/mod.rs` (flat-global
+  registry).
+- **Version stamping**: `libs/streamlib-pack/src/lib.rs`
+  (`rewrite_cargo_package_version`), `xtask/src/check_package_version_drift.rs`.
+- **Atomic release**: `libs/streamlib-pack/src/lib.rs`
+  (`compute_release_closure`), `libs/streamlib-idents/src/release.rs`,
+  `libs/streamlib-build-orchestrator/src/release_check.rs`.
+- **Install / run**: `libs/streamlib-engine/src/core/runtime/install.rs`,
+  `libs/streamlib-engine/src/core/runtime/module_loader/locked.rs`,
+  `libs/streamlib-idents/src/lockfile.rs`,
+  `libs/streamlib-engine/src/core/streamlib_home.rs`.
+- **Related docs**: [`runtime-module-materialization.md`](runtime-module-materialization.md)
+  (the one materialize path), [`static-registry.md`](static-registry.md)
+  (static backend + catalog),
+  [`gitea-registry-distribution.md`](gitea-registry-distribution.md)
+  (hosted backend + by-version resolution),
+  [`schema-identity-and-packaging.md`](schema-identity-and-packaging.md)
+  (schema-ident grammar + packaging),
+  [`package-staging-layout.md`](package-staging-layout.md) (what a staged /
+  published package contains).

--- a/docs/architecture/package-development-model.md
+++ b/docs/architecture/package-development-model.md
@@ -19,9 +19,12 @@ operation: **install**.
   Releases are atomic and a consumer can detect a partial one.
 
 The two loops never blur: a link override is refused entry into any
-published artifact, and a locked run does zero live re-resolution. The
-version model in the middle makes both consistent — one version axis per
-package, one version per package in a running process.
+published artifact, and a locked run does zero live re-resolution. Both
+loops feed the same install seam — installing over a linked / path-declared
+tree records `path:` sources in the lockfile, while installing from a
+registry records content-pinned slots. The version model in the middle makes
+both consistent — one version axis per package, one version per package in a
+running process.
 
 ```
    dev loop                         install seam                 distribution loop
@@ -190,6 +193,12 @@ locked run bypasses `patch:` entirely and resolves from the lockfile.
 
 ## The distribution loop — atomic release
 
+A release is cut with `streamlib pkg publish` (one package to the registry)
+or, for the whole workspace surface (crate chain, SDKs, packages, static
+tree), the publish tooling under `scripts/gitea/` and `cargo xtask
+static-registry emit`; everything below is what those commands do under the
+hood.
+
 **Closure by definition.** `compute_release_closure(workspace_root)`
 ([`libs/streamlib-pack/src/lib.rs`](../../libs/streamlib-pack/src/lib.rs))
 is the *single* definition of "the set of crates a release publishes":
@@ -224,7 +233,10 @@ processor / port / schema index a visual editor browses without downloading
 packages) is documented there too. The hosted-Gitea backend is documented in
 [`gitea-registry-distribution.md`](gitea-registry-distribution.md); the
 by-version resolution model (`{ path, version, registry }`, schema-package
-resolution, the anonymous version index) is shared by both.
+resolution, the anonymous version index) is shared by both. CI resolves
+against the static file tree; to reproduce a CI resolve locally, serve an
+emitted tree per [`static-registry.md` § Consuming a
+tree](static-registry.md#consuming-a-tree).
 
 One gap the static path closes: on a hosted-registry read path, a partial
 crate set uploaded at a version *above* the newest manifest'd version — with

--- a/docs/architecture/static-registry.md
+++ b/docs/architecture/static-registry.md
@@ -45,8 +45,12 @@ does **not** ship a server binary.
                                         # a static server decodes to this path)
     tarballs/streamlib-deno-<version>.tgz  # dist.tarball points here
   slpkg/
-    <pkg>/<version>/<pkg>.slpkg         # generic store (RegistryClient file:// layout)
-    streamlib-release/<V>/manifest.json # the release manifest — completion marker
+    <pkg>/<version>/<pkg>.slpkg          # generic store (RegistryClient file:// layout)
+    <pkg>/<version>/<pkg>.catalog.json   # per-package catalog — keyed by FULL version
+    <pkg>/<core>/schemas/<Type>.jtd.json # per-schema JTD — keyed by RELEASE-CORE version
+    streamlib-release/<V>/manifest.json  # the release manifest — completion marker
+  catalog/
+    index.ndjson                         # processor palette — one NDJSON line per processor
 ```
 
 The cargo `config.json` `dl`/`api` and the npm `dist.tarball` are absolute URLs
@@ -100,6 +104,77 @@ sees the previous *complete* release; the flip is the only mutation of the
 served path. This closes the mid-publish window where a consumer could cargo-
 resolve a higher partial version before its release manifest landed.
 
+## Catalog — queryable processor / port / schema metadata
+
+Alongside the resolvable artifacts, an emit writes a **catalog**: the
+processor / port / schema metadata a visual graph editor (or any tool
+building a node palette) browses without downloading every `.slpkg`. The
+protocol surface — types plus the read client — lives in `streamlib-idents`
+([`catalog.rs`](../../libs/streamlib-idents/src/catalog.rs)), the crate that
+owns the registry protocol; assembly lives in `streamlib-pack`
+([`catalog.rs`](../../libs/streamlib-pack/src/catalog.rs),
+`build_package_catalog`).
+
+Three on-disk shapes, all written during the same atomic emit:
+
+| Path | Contents |
+|---|---|
+| `catalog/index.ndjson` | Aggregate processor palette — one `CatalogIndexLine` per processor across all packages (`CATALOG_INDEX_PATH`). |
+| `slpkg/<name>/<version>/<name>.catalog.json` | One package's `PackageCatalog` (its processors, ports, config), keyed by **full** published version. |
+| `slpkg/<name>/<core>/schemas/<Type>.jtd.json` | One schema's JTD document, keyed by **release-core** version. |
+
+### The version asymmetry
+
+`catalog.json` is keyed by the **full** package version (`2.1.0-dev.3`);
+the `schemas/` JTD directory is keyed by the **release-core** version
+(`2.1.0` — prerelease stripped, patch preserved). The asymmetry is
+deliberate: a schema `SchemaIdent` is release-core by invariant (see
+[`package-development-model.md`](package-development-model.md#the-version-model)),
+so the reader derives a JTD path from the ident's already-projected version.
+A `-dev.N` publisher whose JTDs sat under the full prerelease dir would be
+silently unfetchable, because no consumer ever holds a prerelease-versioned
+schema ident to look them up by.
+
+### Query surface
+
+`CatalogClient::new(base_url, token)` exposes exactly three fetches (each
+tolerates an absent tree as "empty / none", so a pre-catalog registry
+degrades cleanly):
+
+- `fetch_processor_index() -> Vec<CatalogIndexLine>` — the whole palette.
+- `fetch_package_catalog(package, version) -> Option<PackageCatalog>` — one
+  package's processors / ports / config at an exact version.
+- `fetch_schema_type_definition(ident) -> Option<Value>` — the JTD for one
+  schema, from the owning package's dir.
+
+There is no "list all packages" or "query by processor type" call by design —
+palette-by-type is served client-side by scanning `fetch_processor_index()`,
+each line of which carries a full `CatalogProcessor`.
+
+### External refs carry the owner's version
+
+When a package's port / config references a schema owned by *another*
+package, the recorded `SchemaIdent` carries **that owner's** version, not the
+referencing package's. Catalog assembly resolves a manifest's `schemas:`
+external entry by recursing into the dependency with the dependency's own
+version (a missing dep is `ExternalDepMissing`, a cycle is
+`SchemaResolutionCycle`). So a camera package at `2.1.0` referencing
+`@tatolab/core`'s `Frame` at `1.4.0` records the ref as core's `1.4.0`.
+
+### Deliberate omissions
+
+`CatalogPort` carries `name`, `description`, `schema`, `read_mode` only. Two
+classes of manifest field are intentionally dropped:
+
+- `overflow` / `buffer_size` — present on the authored manifest port, but
+  they are per-edge *buffering knobs*, not wiring topology, so they don't
+  belong in a palette the editor wires graphs from.
+- `required` — has no authored-manifest source at all; it exists only on the
+  runtime port descriptors, not on the `streamlib.yaml` port.
+
+The omission is structural (the fields simply aren't on `CatalogPort` and
+aren't copied by the assembler), not gated by a runtime check.
+
 ## Emitting a tree
 
 ```
@@ -142,8 +217,12 @@ export CARGO_REGISTRIES_GITEA_INDEX="sparse+http://127.0.0.1:8799/cargo/"
 ## Reference
 
 - **Renderers + atomic swap**: `libs/streamlib-pack/src/static_registry.rs`.
+- **Catalog**: `libs/streamlib-idents/src/catalog.rs` (protocol surface +
+  `CatalogClient`), `libs/streamlib-pack/src/catalog.rs` (assembly).
 - **Fork bootstrap**: `scripts/gitea/emit-static-fork.sh`,
   `scripts/gitea/render_cargo_index_line.py`.
 - **Generator CLI**: `cargo xtask static-registry emit`.
 - **`.slpkg` `file://` transport**: `libs/streamlib-idents/src/registry.rs`.
 - **CI**: `.github/actions/serve-static-fork`, `.github/workflows/static-registry.yml`.
+- **The two loops** this backend serves:
+  [`package-development-model.md`](package-development-model.md).

--- a/docs/architecture/static-registry.md
+++ b/docs/architecture/static-registry.md
@@ -187,8 +187,8 @@ cargo xtask static-registry emit --out <dir> [--dev N] \
 - `--cargo-closure` additionally packages every workspace release-closure crate
   into the cargo tree (heavy).
 - pypi (uv sdist) and npm (deno pack) reuse the SDK build toolchains; `.slpkg`
-  packages are assembled via `streamlib pack` semantics and the release manifest
-  is written last.
+  packages are assembled via `streamlib pkg build` semantics and the release
+  manifest is written last.
 
 ## Consuming a tree
 

--- a/docs/learnings/polyglot-venv-gitea-registry-env.md
+++ b/docs/learnings/polyglot-venv-gitea-registry-env.md
@@ -67,11 +67,28 @@ learning.
 If you hit either symptom above, set the three env vars first — don't
 go debugging the codegen step or the example's Python.
 
+## Static-file-tree backend: same two channels, no token
+
+The two-channel story above is the **hosted Gitea** backend. The static
+file-tree backend (`docs/architecture/static-registry.md`) reads the same
+two channels — `UV_INDEX` for the pypi-simple install, `STREAMLIB_REGISTRY_URL`
+for the codegen resolver — but is **tokenless**: `STREAMLIB_REGISTRY_URL`
+points at a `file://…/slpkg` tree and no `STREAMLIB_REGISTRY_TOKEN` is needed
+(static reads are anonymous). So if you're resolving against a static tree
+and hit the step-2 `streamlib.yaml dependency graph` failure, the fix is
+`STREAMLIB_REGISTRY_URL` (+ `UV_INDEX`), not the token —
+`scripts/gitea/serve-static-registry.sh` prints the exact exports. The token
+is only load-bearing on a Gitea instance whose generic read endpoint requires
+auth.
+
 ## Reference
 
-- Model (which registry backs which dependency kind, and the env each
-  reads): `docs/architecture/gitea-registry-distribution.md` — consume
-  side. `UV_INDEX` / `pip.conf` for the pypi install;
+- Two-loop model + where each backend fits:
+  `docs/architecture/package-development-model.md`.
+- Which registry backs which dependency kind, and the env each reads
+  (consume side): `docs/architecture/gitea-registry-distribution.md`
+  (hosted Gitea) and `docs/architecture/static-registry.md` (static tree,
+  tokenless). `UV_INDEX` / `pip.conf` for the pypi install;
   `ResolverOptions::from_env` → `STREAMLIB_REGISTRY_URL` /
   `STREAMLIB_REGISTRY_TOKEN` for the generic registry.
 - The provisioning step that emits the symptom:


### PR DESCRIPTION
## What this does

Final issue of the *Simplified Package Manager & Development* milestone: moves the shipped two-loop model out of the milestone/issue bodies into the architecture docs, in current tense.

- **New** `docs/architecture/package-development-model.md` — the two loops (dev = whole-tree `streamlib link`; distribution = publish-by-version), the install/run seam, the version model, the atomic-release model, and honestly-stated known limitations.
- **Extended** `docs/architecture/static-registry.md` — a **Catalog** section (tree paths, the full-version-vs-release-core asymmetry, the `CatalogClient` query surface, external-refs-carry-owner's-version, deliberate omissions).
- **Reconciled** `docs/architecture/gitea-registry-distribution.md`, the CLAUDE.md distribution section, and the polyglot-venv learning (details below).

No code changes. Docs + CLAUDE.md only.

## Claim → evidence (every load-bearing claim verified against merged code, HEAD `db18893e`)

### Link mode (`package-development-model.md`)
| Claim | Evidence |
|---|---|
| `streamlib link [<CHECKOUT>] [--skip-verify]` / `streamlib unlink [--force]`; bare `link` = status | `libs/streamlib-cli/src/main.rs` (`Commands::Link/Unlink`), `commands/link.rs` (`link`/`unlink`/`status`) |
| Whole-tree = cargo `[patch]` (`.cargo/config.toml`) + uv `[tool.uv.sources]` (`pyproject.toml`) + deno import-map (`deno.json(c)`), one plan | `link.rs` `plan_edits` → `plan_cargo_config_edit`/`plan_pyproject_edit`/`plan_deno_edit`; py/deno presence-gated |
| Index discovered live, not hardcoded; greppable marker comment | `discover_registry_index` reads `registries.gitea.index`; `CARGO_PATCH_MARKER` |
| Crate set = `compute_release_closure` (same as release) | `link.rs` `derive_linkable_crates` → `streamlib_pack::compute_release_closure` |
| Manifest-first transaction; `.streamlib/link.json` `Applying` via O_EXCL before any edit; verified rollback; `Applying`→`Active` | `establish_link`, `write_manifest_excl` (`create_new`), `apply_transaction`, `rollback`; `LinkMarkerAlreadyExists`, `RollbackIncomplete`, `TornLinkState` |
| Post-link verify via `cargo metadata --offline`; rollback on failure | `verify_cargo_patch_resolution`; `LinkVerificationFailed` |
| Tri-state | `LinkTransactionState::{Applying,Active}` + absence; per-file `RestoreAction::{Skip,RestoreOriginal,RemoveCreated}`; `UnlinkRefusedModifiedFile` |
| Overrides at toolchain layer only; refused into artifacts | writes `.cargo/config.toml`/`pyproject.toml`/`deno.json` only; `ensure_no_active_link_for_pack`→`PackRefusedWhileLinked`; orchestrator `apply_link_override_if_active` |

### Version model
| Claim | Evidence |
|---|---|
| `SemVer{major,minor,patch,Option<Prerelease{kind,n}>}`, `PrereleaseKind{Dev,Rc}`, closed grammar | `libs/streamlib-idents/src/semver.rs` |
| Ordering `dev.k < rc.j < release` within a core; release outranks any prerelease | `impl Ord for SemVer`; test `prerelease_ordering_matrix` |
| npm-style range gating | `SemVerRange`, `prerelease_gated` (same-core + at-or-above; `*` excludes prereleases) |
| One version axis: crate version stamped from `streamlib.yaml` **`package.version`** at pack | `streamlib-pack/src/lib.rs` `assemble_artifact`→`stamped_cargo_toml_bytes`→`rewrite_cargo_package_version` |
| Drift lint `cargo xtask check-package-version-drift [--fix]` | `xtask/src/check_package_version_drift.rs` (`--fix` calls same rewrite) |
| Release-core schema-ident invariant (prerelease-stripped, patch preserved) via 3 prongs | `SchemaIdent::new` projects; `deserialize_release_only_semver` rejects; two format sites (`Display`, `CatalogClient::fetch_schema_type_definition`) |
| Single-version gate `ResolutionMemo` + placeholders + deadlock-free concurrency; `SingleVersionConflict` | `recursive_walker.rs` `ResolutionMemo`/`gate`, `PackageResolutionState::{InFlightPlaceholder,Committed}`, `PackageResolutionCompletionSignal` |
| Flat-global by IPC necessity: one map, strips version suffix | `embedded_schemas/mod.rs` `SCHEMA_REGISTRY` `LazyLock<RwLock<HashMap>>`, `strip_semver_suffix`; registration uses `owner.version.release_core()` |
| `patch:` per-manifest-local; root override reaches locked run via lockfile | `manifest.rs` `Manifest.patch` (no walk-up); `resolve_dep_strategy` `unwrap_or(spec)`; locked run bypasses patch (`locked.rs`) |

### Atomic release + install/run
| Claim | Evidence |
|---|---|
| Closure-by-definition | `streamlib-pack/src/lib.rs` `compute_release_closure`→`ReleaseClosure` (single `is_internal` predicate, topo order) |
| Manifest-last atomicity | `libs/streamlib-idents/src/release.rs` `ReleaseManifest` at `streamlib-release/<V>/manifest.json`; `RegistryClient::upload_release_manifest` "written LAST" |
| Consumer partial-release detection replacing deep version-unification failure | `release_check.rs` `assert_release_complete`→`crates_missing_from_release`→`IncompleteRelease`; rides inside `materialize` |
| Manifestless-partials window closed by static staged swap | http path `list_release_versions` manifest-gated + `Ok(None)`-proceed; `static_registry.rs` `publish_staged_tree`→`exchange_paths` `renameat2(RENAME_EXCHANGE)` |
| `install` = resolve+materialize+lock; completeness rides materialize | `install.rs` `install()`; CLI `streamlib install`→`streamlib-app.lock` |
| Two lockfiles, same wire shape: `streamlib.lock` (codegen) vs `streamlib-app.lock` (app) | `lockfile.rs` `LOCKFILE_NAME`/`APP_LOCKFILE_NAME` |
| Locked run: pinned slots, **five** touchpoints unreachable (registry list, registry download, git fetch, `.slpkg` re-fetch, build), content-hash gate, shared slot helper | `locked.rs` (`LockedResolution`, doc lines 10-12; `content_hash_for_package_dir` sha256 → `LockedSlotContentMismatch`); `streamlib_home.rs` `get_cached_package_dir_for_name_version` |
| Resolver handoff — two resolvers deliberately separate | `install.rs` doc 14-17; `locked.rs` doc 19-23 |

### Catalog (`static-registry.md`)
| Claim | Evidence |
|---|---|
| Home = `streamlib-idents` (protocol surface) + `streamlib-pack` (assembly) | `libs/streamlib-idents/src/catalog.rs`, `libs/streamlib-pack/src/catalog.rs` |
| Paths: `catalog/index.ndjson`; `slpkg/<n>/<v>/<n>.catalog.json`; `slpkg/<n>/<core>/schemas/<Type>.jtd.json` | `CATALOG_INDEX_PATH`, `package_catalog_file_name`, `schema_jtd_file_name`; emitter `write_package_catalog` |
| Asymmetry: catalog.json keyed by FULL version, JTD dir by RELEASE-CORE (`.release_core()`) | `static_registry.rs` `write_package_catalog`; test `prerelease_package_catalog_keeps_prerelease_but_idents_are_release_core` |
| CatalogClient: `fetch_processor_index`/`fetch_package_catalog`/`fetch_schema_type_definition`; no list/by-type (client-side scan) | `catalog.rs` (idents) |
| External refs carry owner's version | `resolve_named_internal` recurses with `dep.version`; `ExternalDepMissing`/`SchemaResolutionCycle`; test `external_ref_version_is_the_dependencys_not_the_importers` |
| Omissions: `overflow`/`buffer_size` (buffering knobs), `required` (no manifest source) — structural | `CatalogPort` vs `ProcessorPortSchema` field diff (no explanatory comment) |

### Known limitations (verified real)
| Limitation | Evidence |
|---|---|
| Polyglot spawn-time offline unproven | offline guarantee proven for Rust module-load path only; venv/deno spawn not separately gated |
| pypi/npm emit narrower CI than cargo/slpkg | `.github/workflows/static-registry.yml` emit smoke runs `--no-pypi --no-npm --no-slpkg`; slpkg + cargo resolved e2e |
| Deploy lockfiles don't pin checkouts | `install.rs` records `path:` sources for linked/path trees (line ~299) |

## Corrections to the content plan (the code is truth)
- Version field is **`package.version`** in `streamlib.yaml`, **not** `metadata.version` (that's a schema-file field).
- Release-core = **prerelease-stripped MAJOR.MINOR.PATCH** (patch preserved), not major.minor.0.
- "Manifestless-partials blind spot" is a real **mechanism** but not a literal code comment — documented as the mechanism (manifest-gated list + `Ok(None)`-proceed vs. atomic staged swap), not attributed to a named comment.
- Flat-global "one process-global map" is literally per-loaded-artifact static with host-forwarding via `install_host_services` fn pointers — net one map in practice; phrased accordingly.
- CatalogClient exposes exactly three fetches; there is no "list packages" / "query by processor type" method (palette-by-type is a client-side scan of the index).

## Supersession decisions (markdown-editing rules: strikethrough + dated annotation, preserve disagreement)
- **`gitea-registry-distribution.md`** — *reconciled, not deleted.* Its by-version resolution model (`{path,version,registry}`, schema-package resolution, anonymous version index, operational notes) is still accurate and load-bearing, so I reframed the doc as **the hosted-registry backend (one of two behind one read shape)** and annotated only the specifically-stale claims: (1) "single self-hosted Gitea instance is the sole backend"; (2) the "lifts to cloud Gitea" diagram + operational note (public/CDN path is now the static tree per the retired-cloud-hosting decision); (3) "there is no relative-path escape hatch" (reconciled: `streamlib link` is a sanctioned dev-only whole-tree override that's refused into artifacts). Cross-linked to the new doc + static-registry.md.
- **CLAUDE.md** distribution section — rewritten from "unified Gitea registry, in active migration" to the shipped two-loop model, learning-style ("to the best of our current knowledge"), cross-linking all three docs. (Markdown edit authored on Opus per the editing rules.)
- **`polyglot-venv-gitea-registry-env.md`** — core two-channel story unchanged (accurate for the Gitea backend); added a note that the **static-tree path is tokenless** (`UV_INDEX` + `STREAMLIB_REGISTRY_URL`, no token) and repointed the Reference cross-links.

## Validation
- All intra-repo links in the new/edited docs resolve (checked programmatically — every `../../libs/...` and `../…md` target exists).
- No Rust source touched → `cargo doc` structurally unaffected.
- `cargo xtask check-manifest-schema` fails only on the **pre-existing standing CI-red** (workspace has no committed `Cargo.lock`; can't reach the vulkanalia fork registry at `localhost:3300`) — unrelated to this markdown-only change.

Closes #1222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wr1VLKMBbFpsmU7zAcniU2
