### PR TITLE
feat(registry): byte-stable crate emission — re-emitting an unchanged release keeps checksums

### DIFF
--- a/docs/architecture/static-registry.md
+++ b/docs/architecture/static-registry.md
@@ -120,6 +120,38 @@ sees the previous *complete* release; the flip is the only mutation of the
 served path. This closes the mid-publish window where a consumer could cargo-
 resolve a higher partial version before its release manifest landed.
 
+## Byte-stable crate emission
+
+Each emitted `.crate` is a pure function of source content per
+`(crate, version)`: re-emitting an unchanged release yields byte-identical
+tarballs and checksums (no sparse-index or consumer-lockfile churn), and a
+crate whose source changed under an already-published version is **refused**
+rather than silently swapped.
+
+`cargo package` is already byte-deterministic on a fixed toolchain (gzip
+MTIME zeroed, fixed tar mtimes / modes, stable entry order, deterministic
+DEFLATE) *except* for the `{name}-{version}/.cargo_vcs_info.json` entry,
+whose `{"git":{"sha1":...}}` payload tracks git HEAD, not source — so the
+raw `.crate` checksum was a function of the commit. No stable cargo flag
+suppresses that entry, so `emit_cargo_closure` normalizes each tarball after
+packaging (`crate_tarball::finalize_crate_tarball`): strip
+`.cargo_vcs_info.json`, re-tar the survivors (cargo's headers cloned
+verbatim), and re-gzip with a fixed header. Normalization is idempotent, so
+the reuse path (a cached `target/package/<crate>.crate` across emits) stays
+stable.
+
+The immutability guard compares a **content fingerprint** — the sha256 of
+the canonical, vcs-stripped, *uncompressed* tar, so it's independent of gzip
+level too — of the freshly packaged crate against the prior served crate,
+which is still present at `opts.out` during the staged build (the flip
+happens after the emit closure returns). The served side is fingerprinted
+through the same normalization, so a legacy un-normalized served tree does
+not false-positive during the transition. A benign commit bump (identical
+source, new git HEAD) passes and yields the same checksum; a real source
+change under the same version fails the emit with an explicit "bump the
+version" error. See
+[`../learnings/cargo-crate-vcs-info-nondeterminism.md`](../learnings/cargo-crate-vcs-info-nondeterminism.md).
+
 ## Catalog — queryable processor / port / schema metadata
 
 Alongside the resolvable artifacts, an emit writes a **catalog**: the
@@ -233,8 +265,10 @@ export CARGO_REGISTRIES_GITEA_INDEX="sparse+http://127.0.0.1:8799/cargo/"
 ## Reference
 
 - **Renderers + atomic swap**: `libs/streamlib-pack/src/static_registry.rs`.
-- **Verified crate-tarball reuse**: `libs/streamlib-pack/src/crate_tarball.rs`
-  (`verify_crate_tarball`, `obtain_crate_tarball`).
+- **Verified crate-tarball reuse + byte-stable normalization**:
+  `libs/streamlib-pack/src/crate_tarball.rs` (`verify_crate_tarball`,
+  `obtain_crate_tarball`, `normalize_crate_tarball`,
+  `crate_content_fingerprint`, `finalize_crate_tarball`).
 - **Catalog**: `libs/streamlib-idents/src/catalog.rs` (protocol surface +
   `CatalogClient`), `libs/streamlib-pack/src/catalog.rs` (assembly).
 - **Fork bootstrap**: `scripts/gitea/emit-static-fork.sh`,

--- a/docs/learnings/README.md
+++ b/docs/learnings/README.md
@@ -114,3 +114,10 @@ Avoid the two failure modes:
   gdb/api_dump/validation overhead shifts *which* crash you hit, so never use
   them to decide the production failure mode; re-verify the symptom after each
   fix
+- [@docs/learnings/cargo-crate-vcs-info-nondeterminism.md](cargo-crate-vcs-info-nondeterminism.md) —
+  Re-emitting an unchanged release changes `.crate` checksums (churning the
+  cargo sparse index + consumer lockfiles). `cargo package` is byte-deterministic
+  EXCEPT `{name}-{version}/.cargo_vcs_info.json`, which embeds the git HEAD sha1,
+  making the checksum a function of the commit not the source. No stable cargo
+  flag suppresses it; strip the entry post-hoc + re-gzip with a fixed header for
+  byte-stable, source-only `.crate`s

--- a/docs/learnings/cargo-crate-vcs-info-nondeterminism.md
+++ b/docs/learnings/cargo-crate-vcs-info-nondeterminism.md
@@ -1,0 +1,83 @@
+# `cargo package` is byte-deterministic EXCEPT `.cargo_vcs_info.json`
+
+## Symptom
+
+Emitting the static registry tree twice from the same source produces
+**different `.crate` checksums for identical `(crate, version)`** — the
+cargo sparse-index `cksum` line changes, and any consumer lockfile that
+recorded the previous bytes churns. The crate source did not change; only
+the checksum did. Nothing in the build log explains it.
+
+## Root cause
+
+`cargo package` is *almost* fully reproducible. On a fixed toolchain the
+`.crate` (a gzip'd tar) has:
+
+- gzip header MTIME zeroed (`1f 8b 08 08 00 00 00 00` — the four MTIME
+  bytes are `0`),
+- fixed tar entry mtimes / modes / uid / gid,
+- stable (alphabetical) entry order,
+- deterministic DEFLATE output.
+
+Two `cargo package` runs of identical source differ in **exactly one
+entry**: `{name}-{version}/.cargo_vcs_info.json`. When packaging from a
+git checkout with commits, cargo embeds
+
+```json
+{ "git": { "sha1": "<git HEAD sha1>" }, "path_in_vcs": "" }
+```
+
+So the `.crate` checksum is a function of **git HEAD**, not of source. A
+benign commit that doesn't touch a crate still moves HEAD, so the crate's
+bytes — and its checksum — change on the next emit.
+
+Empirically verified (throwaway crate, two commits, identical source):
+the two `.crate`s differ starting at byte 33 (inside the first tar entry,
+`.cargo_vcs_info.json`); decompress both, drop that one entry, and the
+remaining tar bytes are byte-identical.
+
+**No stable cargo flag suppresses vcs-info emission.** `--allow-dirty`
+governs the *dirty-tree check*, not whether vcs-info is written; there is
+no `--no-vcs-info` on stable. Stripping the entry post-hoc is the fix.
+
+## Fix
+
+Normalize the `.crate` after `cargo package`: gzip-decode, drop the
+`{name}-{version}/.cargo_vcs_info.json` tar entry, re-tar the survivors
+(cloning cargo's existing headers verbatim so their canonical mtime /
+mode / uid / gid and GNU long-name handling are inherited, not
+synthesized), and re-gzip with a fixed header (MTIME 0, no embedded
+filename). The result is a pure function of source content.
+
+The normalize step must be **idempotent** — a registry emit reuses a
+previously-packaged `.crate` from `target/package/` across runs, so
+normalize re-runs on an already-stripped crate and must reproduce
+identical bytes. Cloning cargo's headers and re-emitting through the same
+`tar` writer each time makes it a fixed point.
+
+Two consequences worth pinning with tests:
+
+- Two crates with identical source but different git HEAD sha1 normalize
+  to byte-identical `.crate`s (equal checksum) — the byte-stability
+  contract.
+- A source-content fingerprint used for an immutability guard should hash
+  the *canonical uncompressed* tar (not the gzip'd `.crate`), so it's
+  independent of the gzip level too — a future flate2 bump shifts the
+  emitted `.crate` bytes uniformly but must not falsely trip the guard.
+
+Stripping `.cargo_vcs_info.json` loses git-provenance metadata, but it is
+informational only (no consumer requires it), and reproducible-build
+tooling routinely strips it for exactly this reason.
+
+## Reference
+
+- Implementation: `libs/streamlib-pack/src/crate_tarball.rs`
+  (`normalize_crate_tarball`, `crate_content_fingerprint`,
+  `finalize_crate_tarball`); wired into `emit_cargo_closure` in
+  `libs/streamlib-pack/src/static_registry.rs`.
+- Architecture: `docs/architecture/static-registry.md` (the
+  atomic-release / byte-stable-emission section).
+- Sibling concern: pypi sdist (`uv build --sdist`) and npm tgz
+  (`deno pack`) almost certainly carry their own reproducibility vectors
+  (file mtimes) and are candidates for the same immutable-per-version
+  normalization — verify before assuming they're stable.

--- a/libs/streamlib-pack/src/crate_tarball.rs
+++ b/libs/streamlib-pack/src/crate_tarball.rs
@@ -1,15 +1,27 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Integrity-verified reuse of `cargo package` crate tarballs:
-//! [`verify_crate_tarball`] structurally validates a `.crate` before reuse,
-//! [`obtain_crate_tarball`] reuses a verified one or repackages on failure.
+//! Integrity-verified reuse + byte-stable normalization of `cargo package`
+//! crate tarballs.
+//!
+//! - [`verify_crate_tarball`] structurally validates a `.crate` before reuse,
+//!   [`obtain_crate_tarball`] reuses a verified one or repackages on failure.
+//! - [`normalize_crate_tarball`] rewrites a `.crate` into a form whose bytes are
+//!   a pure function of source content, and [`finalize_crate_tarball`] pairs
+//!   that with an immutability guard so re-emitting an unchanged release yields
+//!   identical checksums while a source change under a published version is
+//!   refused. `cargo package` is already byte-deterministic *except* for the
+//!   `{name}-{version}/.cargo_vcs_info.json` entry, whose embedded git-HEAD
+//!   sha1 makes the checksum a function of the commit rather than the source;
+//!   normalization strips it (see
+//!   `docs/learnings/cargo-crate-vcs-info-nondeterminism.md`).
 
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::Path;
 
 use anyhow::Context;
 use flate2::read::GzDecoder;
+use flate2::{Compression, GzBuilder};
 use sha2::{Digest, Sha256};
 
 /// Why a `.crate` tarball failed integrity verification.
@@ -173,6 +185,126 @@ pub fn obtain_crate_tarball(
     Ok(CrateTarballProvenance::Repackaged { discarded_corrupt })
 }
 
+/// The vcs-info entry cargo embeds inside a `.crate` when packaging from a git
+/// checkout with commits: `{name}-{version}/.cargo_vcs_info.json`. Its
+/// `{"git":{"sha1":...}}` payload tracks git HEAD, not source, and is the sole
+/// per-commit non-determinism vector in an otherwise byte-deterministic
+/// `cargo package`.
+fn vcs_info_entry_name(name: &str, version: &str) -> String {
+    format!("{name}-{version}/.cargo_vcs_info.json")
+}
+
+/// Decode a `.crate` at `path`, drop the `.cargo_vcs_info.json` entry, and
+/// re-serialize the surviving entries — headers cloned verbatim from cargo's
+/// output, in cargo's original order — into canonical *uncompressed* tar bytes.
+/// The result is a pure function of the crate's source content: independent of
+/// git HEAD (vcs-info removed) and of gzip settings (uncompressed).
+fn canonical_tar_bytes(path: &Path, name: &str, version: &str) -> anyhow::Result<Vec<u8>> {
+    let bytes =
+        std::fs::read(path).with_context(|| format!("read crate tarball {}", path.display()))?;
+    let mut decoded = Vec::new();
+    GzDecoder::new(&bytes[..])
+        .read_to_end(&mut decoded)
+        .with_context(|| format!("gzip-decode crate tarball {}", path.display()))?;
+
+    let vcs_entry = vcs_info_entry_name(name, version);
+    let mut archive = tar::Archive::new(&decoded[..]);
+    let mut builder = tar::Builder::new(Vec::new());
+    let entries = archive
+        .entries()
+        .with_context(|| format!("read crate tar entries {}", path.display()))?;
+    for entry in entries {
+        let mut entry = entry.context("read crate tar entry")?;
+        let entry_path = entry.path().context("read crate tar entry path")?.into_owned();
+        if entry_path.to_string_lossy() == vcs_entry {
+            continue;
+        }
+        // Clone cargo's header verbatim (inherits its canonical mtime / mode /
+        // uid / gid / entry type / size), then re-emit via `append_data` so the
+        // long-name (GNU extension) handling is applied for the resolved path.
+        let mut header = entry.header().clone();
+        let mut data = Vec::new();
+        entry.read_to_end(&mut data).context("read crate tar entry data")?;
+        builder
+            .append_data(&mut header, &entry_path, &data[..])
+            .context("re-append crate tar entry")?;
+    }
+    builder.into_inner().context("finalize canonical crate tar")
+}
+
+/// Rewrite the `.crate` at `path` into its byte-stable canonical form for
+/// `(name, version)`: strip `.cargo_vcs_info.json` and re-gzip with a fixed
+/// header (MTIME 0, no embedded filename). Idempotent — re-normalizing an
+/// already-normalized crate reproduces identical bytes, so the emit reuse path
+/// can re-run it on a cached tarball.
+pub fn normalize_crate_tarball(path: &Path, name: &str, version: &str) -> anyhow::Result<()> {
+    let canonical = canonical_tar_bytes(path, name, version)?;
+    let mut encoder = GzBuilder::new()
+        .mtime(0)
+        .write(Vec::new(), Compression::default());
+    encoder
+        .write_all(&canonical)
+        .context("gzip canonical crate tar")?;
+    let gzipped = encoder.finish().context("finish gzip canonical crate tar")?;
+    std::fs::write(path, &gzipped)
+        .with_context(|| format!("write normalized crate tarball {}", path.display()))?;
+    Ok(())
+}
+
+/// The sha256 of the crate's canonical (vcs-stripped, uncompressed) tar bytes —
+/// a compression-independent fingerprint of source content. Two crates built
+/// from identical source but a different git HEAD (or a different gzip level)
+/// share a fingerprint; a real source change is a different fingerprint.
+pub fn crate_content_fingerprint(
+    path: &Path,
+    name: &str,
+    version: &str,
+) -> anyhow::Result<String> {
+    let canonical = canonical_tar_bytes(path, name, version)?;
+    let mut hasher = Sha256::new();
+    hasher.update(&canonical);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Normalize the `.crate` at `path` into byte-stable form, refuse a source
+/// change under an already-published `(name, version)`, and return the
+/// normalized tarball's sha256 for the sparse-index line.
+///
+/// `previously_served` is the same crate's `.crate` in the prior complete
+/// served tree (still present during a staged emit). When it exists, its
+/// content fingerprint — normalized on the fly, so a legacy un-normalized
+/// served tree does not false-positive during the transition — must equal the
+/// new crate's; a mismatch means the source changed without a version bump and
+/// is refused. A benign commit bump (identical source, new git HEAD) passes and
+/// yields the same checksum, so it neither churns the index nor trips the guard.
+pub fn finalize_crate_tarball(
+    path: &Path,
+    name: &str,
+    version: &str,
+    previously_served: Option<&Path>,
+) -> anyhow::Result<String> {
+    normalize_crate_tarball(path, name, version)?;
+
+    if let Some(served) = previously_served {
+        let new_fingerprint = crate_content_fingerprint(path, name, version)?;
+        let served_fingerprint = crate_content_fingerprint(served, name, version)?;
+        if new_fingerprint != served_fingerprint {
+            anyhow::bail!(
+                "crate `{name}` `{version}` changed at the same version \
+                 (content fingerprint {new_fingerprint} != published \
+                 {served_fingerprint}) — bump the version; re-emitting different \
+                 source under a published version is refused"
+            );
+        }
+    }
+
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("read normalized crate tarball {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,6 +353,61 @@ mod tests {
 
     fn candidate_path(dir: &Path, name: &str, version: &str) -> PathBuf {
         dir.join(format!("{name}-{version}.crate"))
+    }
+
+    /// gzip `raw` into a `.crate`-shaped file at `path` at an explicit
+    /// compression level (for the compression-independence fingerprint test).
+    fn gzip_to_file_at_level(path: &Path, raw: &[u8], level: Compression) {
+        let file = std::fs::File::create(path).unwrap();
+        let mut enc = GzEncoder::new(file, level);
+        enc.write_all(raw).unwrap();
+        enc.finish().unwrap();
+    }
+
+    /// Write a `.crate` that mirrors what `cargo package` emits from a git
+    /// checkout: a `.cargo_vcs_info.json` entry (carrying `vcs_sha1`) plus the
+    /// manifest and a source file whose bytes are `lib_contents`.
+    fn write_crate_with_vcs(
+        path: &Path,
+        name: &str,
+        version: &str,
+        lib_contents: &[u8],
+        vcs_sha1: &str,
+    ) {
+        let manifest = manifest_bytes(name, version);
+        let vcs_json =
+            format!("{{\n  \"git\": {{\n    \"sha1\": \"{vcs_sha1}\"\n  }},\n  \"path_in_vcs\": \"\"\n}}");
+        let vcs_entry = format!("{name}-{version}/.cargo_vcs_info.json");
+        let manifest_entry = format!("{name}-{version}/Cargo.toml");
+        let lib_entry = format!("{name}-{version}/src/lib.rs");
+        // Match cargo's alphabetical entry order (.cargo_vcs_info.json sorts
+        // before Cargo.toml sorts before src/lib.rs).
+        let raw = build_tar_bytes(&[
+            (vcs_entry.as_str(), vcs_json.as_bytes()),
+            (manifest_entry.as_str(), manifest.as_bytes()),
+            (lib_entry.as_str(), lib_contents),
+        ]);
+        gzip_to_file(path, &raw);
+    }
+
+    /// The set of entry paths inside a `.crate` (for asserting vcs-info removal).
+    fn crate_entry_names(path: &Path) -> Vec<String> {
+        let bytes = std::fs::read(path).unwrap();
+        let mut decoded = Vec::new();
+        GzDecoder::new(&bytes[..]).read_to_end(&mut decoded).unwrap();
+        let mut archive = tar::Archive::new(&decoded[..]);
+        archive
+            .entries()
+            .unwrap()
+            .map(|e| e.unwrap().path().unwrap().to_string_lossy().into_owned())
+            .collect()
+    }
+
+    fn sha256_of_file(path: &Path) -> String {
+        let bytes = std::fs::read(path).unwrap();
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        format!("{:x}", hasher.finalize())
     }
 
     #[test]
@@ -425,5 +612,160 @@ mod tests {
             .unwrap();
         let err = verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap_err();
         assert!(matches!(err, CrateTarballIntegrityError::GzipInvalid(_)), "got {err:?}");
+    }
+
+    /// Normalizing strips `.cargo_vcs_info.json`, leaves a still-valid `.crate`,
+    /// and is idempotent (a second normalize reproduces byte-identical output).
+    #[test]
+    fn normalize_strips_vcs_info_and_is_idempotent() {
+        let dir = tempdir().unwrap();
+        let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        write_crate_with_vcs(&path, "streamlib-x", "0.5.0", b"// lib A\n", "aaaaaaaa");
+        assert!(
+            crate_entry_names(&path)
+                .iter()
+                .any(|n| n.ends_with("/.cargo_vcs_info.json")),
+            "sanity: the pre-normalize crate carries a vcs-info entry"
+        );
+
+        normalize_crate_tarball(&path, "streamlib-x", "0.5.0").unwrap();
+
+        let names = crate_entry_names(&path);
+        assert!(
+            !names.iter().any(|n| n.ends_with("/.cargo_vcs_info.json")),
+            "vcs-info entry must be stripped, got {names:?}"
+        );
+        // The normalized crate is still structurally valid (manifest present).
+        verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap();
+
+        let after_first = std::fs::read(&path).unwrap();
+        normalize_crate_tarball(&path, "streamlib-x", "0.5.0").unwrap();
+        let after_second = std::fs::read(&path).unwrap();
+        assert_eq!(
+            after_first, after_second,
+            "normalize must be idempotent — a second pass reproduces identical bytes"
+        );
+    }
+
+    /// KEY (exit-criterion 1): two crates with identical source but different
+    /// git HEAD sha1 normalize to byte-identical `.crate`s with equal checksums.
+    /// Mentally revert the vcs-strip and the two would differ at the vcs entry.
+    #[test]
+    fn two_vcs_variants_normalize_identical() {
+        let dir = tempdir().unwrap();
+        let a = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        let b = dir.path().join("streamlib-x-0.5.0-b.crate");
+        write_crate_with_vcs(&a, "streamlib-x", "0.5.0", b"// same source\n", "aaaaaaaa");
+        write_crate_with_vcs(&b, "streamlib-x", "0.5.0", b"// same source\n", "bbbbbbbb");
+        // Sanity: the two raw crates differ (the vcs sha1 is baked in).
+        assert_ne!(
+            std::fs::read(&a).unwrap(),
+            std::fs::read(&b).unwrap(),
+            "sanity: differing git HEAD makes the raw crates differ"
+        );
+
+        normalize_crate_tarball(&a, "streamlib-x", "0.5.0").unwrap();
+        normalize_crate_tarball(&b, "streamlib-x", "0.5.0").unwrap();
+
+        assert_eq!(
+            std::fs::read(&a).unwrap(),
+            std::fs::read(&b).unwrap(),
+            "identical source must normalize to byte-identical crates"
+        );
+        assert_eq!(sha256_of_file(&a), sha256_of_file(&b));
+    }
+
+    /// NEGATIVE (exit-criterion 2): a changed source under the same version is
+    /// refused. Mentally revert the guard (drop the fingerprint compare) and
+    /// this returns Ok instead of Err.
+    #[test]
+    fn guard_refuses_changed_source_same_version() {
+        let dir = tempdir().unwrap();
+        let served = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        let fresh = dir.path().join("streamlib-x-0.5.0-fresh.crate");
+        write_crate_with_vcs(&served, "streamlib-x", "0.5.0", b"// source A\n", "aaaaaaaa");
+        write_crate_with_vcs(&fresh, "streamlib-x", "0.5.0", b"// source B - CHANGED\n", "bbbbbbbb");
+
+        let err = finalize_crate_tarball(&fresh, "streamlib-x", "0.5.0", Some(served.as_path()))
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("changed at the same version"),
+            "expected the immutability-guard message, got: {msg}"
+        );
+    }
+
+    /// A benign commit bump (identical source, different git HEAD) passes the
+    /// guard even when the served tree is a legacy *un-normalized* crate, and
+    /// the returned checksum is the stable normalized one.
+    #[test]
+    fn guard_allows_same_source_different_vcs() {
+        let dir = tempdir().unwrap();
+        let served = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        let served_copy = dir.path().join("streamlib-x-0.5.0-servedcopy.crate");
+        let fresh = dir.path().join("streamlib-x-0.5.0-fresh.crate");
+        // Served tree is legacy (un-normalized: still carries vcs-info).
+        write_crate_with_vcs(&served, "streamlib-x", "0.5.0", b"// stable source\n", "aaaaaaaa");
+        std::fs::copy(&served, &served_copy).unwrap();
+        write_crate_with_vcs(&fresh, "streamlib-x", "0.5.0", b"// stable source\n", "bbbbbbbb");
+
+        // The normalized checksum the served tree *should* carry.
+        normalize_crate_tarball(&served_copy, "streamlib-x", "0.5.0").unwrap();
+        let served_normalized_cksum = sha256_of_file(&served_copy);
+
+        let cksum = finalize_crate_tarball(&fresh, "streamlib-x", "0.5.0", Some(served.as_path()))
+            .expect("identical source under a legacy served tree must pass the guard");
+        assert_eq!(
+            cksum, served_normalized_cksum,
+            "a benign commit bump must yield the same normalized checksum (no index churn)"
+        );
+    }
+
+    /// A first emit into a fresh tree (no prior served crate) is always allowed
+    /// and still returns the normalized checksum.
+    #[test]
+    fn guard_absent_served_is_ok() {
+        let dir = tempdir().unwrap();
+        let fresh = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        write_crate_with_vcs(&fresh, "streamlib-x", "0.5.0", b"// lib\n", "aaaaaaaa");
+
+        let cksum = finalize_crate_tarball(&fresh, "streamlib-x", "0.5.0", None).unwrap();
+        assert_eq!(cksum, sha256_of_file(&fresh));
+        verify_crate_tarball(&fresh, "streamlib-x", "0.5.0", None).unwrap();
+    }
+
+    /// The content fingerprint ignores both the git-HEAD sha1 and the gzip
+    /// compression level — it is a function of source content only.
+    #[test]
+    fn crate_content_fingerprint_ignores_vcs_and_compression() {
+        let dir = tempdir().unwrap();
+        // Same source, vcs "aaaa", default compression.
+        let a = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        write_crate_with_vcs(&a, "streamlib-x", "0.5.0", b"// identical source\n", "aaaaaaaa");
+        // Same source, vcs "bbbb", a DIFFERENT compression level → different bytes.
+        let raw_b = build_tar_bytes(&[
+            (
+                "streamlib-x-0.5.0/.cargo_vcs_info.json",
+                b"{\n  \"git\": {\n    \"sha1\": \"bbbbbbbb\"\n  },\n  \"path_in_vcs\": \"\"\n}",
+            ),
+            (
+                "streamlib-x-0.5.0/Cargo.toml",
+                manifest_bytes("streamlib-x", "0.5.0").as_bytes(),
+            ),
+            ("streamlib-x-0.5.0/src/lib.rs", b"// identical source\n"),
+        ]);
+        let b = dir.path().join("streamlib-x-0.5.0-b.crate");
+        gzip_to_file_at_level(&b, &raw_b, Compression::best());
+
+        assert_ne!(
+            std::fs::read(&a).unwrap(),
+            std::fs::read(&b).unwrap(),
+            "sanity: differing vcs + compression level make the raw crates differ"
+        );
+        assert_eq!(
+            crate_content_fingerprint(&a, "streamlib-x", "0.5.0").unwrap(),
+            crate_content_fingerprint(&b, "streamlib-x", "0.5.0").unwrap(),
+            "the fingerprint must be independent of git HEAD and gzip level"
+        );
     }
 }

--- a/libs/streamlib-pack/src/static_registry.rs
+++ b/libs/streamlib-pack/src/static_registry.rs
@@ -525,11 +525,29 @@ fn emit_cargo_closure(opts: &EmitOptions, staging: &Path) -> Result<()> {
             ?provenance,
             "static-registry cargo-closure crate tarball obtained"
         );
+        // Normalize the tarball to a byte-stable, source-only form (strip the
+        // git-HEAD-derived `.cargo_vcs_info.json`, re-gzip with a fixed header)
+        // and refuse a source change under an already-published version.
+        // `opts.out` still holds the PREVIOUS complete served tree during this
+        // staged emit (the flip runs after the closure returns), so the prior
+        // `.crate` is the immutability reference; `cksum` is the normalized
+        // tarball's checksum for the sparse-index line.
+        let served_crate = opts
+            .out
+            .join("cargo")
+            .join("crates")
+            .join(&c.name)
+            .join(crate_artifact_filename(&c.name, &version));
+        let cksum = crate::crate_tarball::finalize_crate_tarball(
+            &crate_file,
+            &c.name,
+            &version,
+            served_crate.exists().then_some(served_crate.as_path()),
+        )?;
         let dest = cargo_dir.join("crates").join(&c.name);
         std::fs::create_dir_all(&dest)?;
         std::fs::copy(&crate_file, dest.join(crate_artifact_filename(&c.name, &version)))?;
 
-        let cksum = sha256_hex(&crate_file)?;
         let idx = cargo_dir.join(cargo_index_path(&c.name));
         if let Some(parent) = idx.parent() {
             std::fs::create_dir_all(parent)?;


### PR DESCRIPTION
## What changed

Makes each emitted `.crate` a **pure function of source content per (crate, version)**: re-emitting an unchanged release yields byte-identical tarballs + checksums (no cargo sparse-index or consumer-lockfile churn), and a crate whose source changed under an already-published version is **refused** rather than silently swapped.

All logic is contained in `libs/streamlib-pack/src/crate_tarball.rs`; `emit_cargo_closure` in `static_registry.rs` gains a ~5-line wire-in.

New in `crate_tarball.rs`:

- **`normalize_crate_tarball`** — gzip-decode, drop `{name}-{version}/.cargo_vcs_info.json`, re-tar the survivors (cargo's headers cloned verbatim, in cargo's original order), re-gzip with a fixed header (MTIME 0, no embedded filename). Idempotent, so the emit reuse path can re-run it on a cached tarball.
- **`crate_content_fingerprint`** — sha256 of the canonical (vcs-stripped, **uncompressed**) tar. Compression-independent, so a future flate2 change can't false-trip the guard.
- **`finalize_crate_tarball`** — the single seam `emit_cargo_closure` calls: normalize, then (when the prior served `.crate` exists) refuse a source change under the same version, returning the normalized checksum for the index line. Fingerprints the served side through the same normalization, so a **legacy un-normalized served tree does not false-positive** during the transition.

`emit_cargo_closure` reads the prior served `.crate` from `opts.out` (which still holds the previous complete tree during the staged emit — the flip runs after the closure returns) as the immutability reference, and uses `finalize_crate_tarball`'s return value as the sparse-index `cksum` (replacing the raw `sha256_hex`).

## The empirical staleness finding

The issue framed re-emit non-reproducibility as an archive-format problem and hypothesized reuse-verified-only might suffice with normalization as a "fallback". **Verified empirically that this is wrong** (issue body corrected in place):

`cargo package` is **already byte-deterministic** on a fixed toolchain — gzip header MTIME zeroed (`1f 8b 08 08 00 00 00 00`), fixed tar mtimes/modes/uid/gid, stable entry order, deterministic DEFLATE. Two `cargo package` runs of identical source at different git HEAD differ in **exactly one entry**: `.cargo_vcs_info.json`, whose `{"git":{"sha1":...}}` payload embeds git HEAD. Confirmed with a throwaway crate (two commits, identical source):

```
/tmp/a.crate /tmp/b.crate differ: byte 33, line 1        # inside .cargo_vcs_info.json
# decompress both, drop that one entry -> remaining tar bytes byte-identical
```

So the `.crate` checksum was a function of the *commit*, not the source. No stable cargo flag suppresses vcs-info (`--allow-dirty` governs the dirty check, not emission), so the strip is post-hoc. Normalization is the **primary** fix (byte-stable even on a first emit into a fresh CI dir with no prior `target/package`, and subsumes reuse), not a fallback.

## Exit-criteria mapping

- **"Two emits of the same unchanged release produce identical index entries and tarball checksums."** -> `normalize_crate_tarball` makes two `cargo package` outputs of identical source (different git HEAD) byte-identical; `finalize` returns that normalized checksum for the index line. Locked by `two_vcs_variants_normalize_identical` (equal bytes + equal sha256) and `guard_allows_same_source_different_vcs` (a benign commit bump yields the same normalized checksum).
- **"A changed crate at the same version is refused — never a silent checksum swap."** -> `finalize_crate_tarball`'s content-fingerprint guard. Locked by `guard_refuses_changed_source_same_version` (a changed source at the same version returns `Err`).

## Test evidence

`cargo test --lib -p streamlib-pack` — **71 passed, 0 failed** (11 pre-existing `crate_tarball` tests + 6 new + the rest of the crate). New tests:

- `normalize_strips_vcs_info_and_is_idempotent` — vcs entry gone, still verifies, second normalize byte-identical.
- `two_vcs_variants_normalize_identical` *(KEY, exit-crit 1)* — identical source, git HEAD `aaaa` vs `bbbb` -> byte-identical + equal sha256.
- `guard_refuses_changed_source_same_version` *(NEGATIVE, exit-crit 2)* — served source A, fresh source B, same version -> `Err`.
- `guard_allows_same_source_different_vcs` — identical source, different vcs, **legacy un-normalized served tree** -> `Ok`, returned cksum == served's normalized cksum.
- `guard_absent_served_is_ok` — first emit (no prior served) -> `Ok`.
- `crate_content_fingerprint_ignores_vcs_and_compression` — same source, different vcs **and** different gzip level -> equal fingerprint.

**Mental-revert checks** (each load-bearing test fails when its fix is reverted):

- Drop the vcs-strip (`continue`) -> `two_vcs_variants_normalize_identical` (and 3 others) FAIL.
- Drop the guard (`if false && ...`) -> `guard_refuses_changed_source_same_version` FAILs (`unwrap_err()` on `Ok`).

**Real-cargo validation** (temporary `#[ignore]` test, run then removed — too fragile for CI as it reads `/tmp`): ran `normalize_crate_tarball` on two **genuine** `cargo package` crates built from identical source at different git HEAD. Result: byte-identical output, equal sha256, `.cargo_vcs_info.json` stripped, `Cargo.lock` / `.gitignore` / `Cargo.toml.orig` preserved — proving the re-tar handles real cargo headers, not just synthesized tars.

```
REAL-CARGO OK: normalized entries = ["vcstest-0.1.0/.gitignore", "vcstest-0.1.0/Cargo.lock",
 "vcstest-0.1.0/Cargo.toml", "vcstest-0.1.0/Cargo.toml.orig", "vcstest-0.1.0/src/lib.rs"]
```

`cargo clippy -p streamlib-pack` — zero new warnings (the 6 reported are pre-existing in `lib.rs` / `streamlib-idents`, none in touched files). `cargo doc -p streamlib-pack --no-deps` — clean (intra-doc links resolve).

## Docs

- `docs/architecture/static-registry.md` — new "Byte-stable crate emission" section (current-tense, shipped state) + Reference bullet updated.
- New learning `docs/learnings/cargo-crate-vcs-info-nondeterminism.md` (symptom / root cause / fix / reference) + README index entry.

## Deliberate scope choices

- **No emit-once-reuse-from-served-tree.** Normalization is strictly more robust (byte-stable on a first emit into a fresh dir, and subsumes reuse), so it's the whole fix.
- **Full double-`emit_static_registry` integration test not committed.** It cargo-packages the entire workspace closure (heavy, needs the fork/registry) — out of place for `cargo test --lib`. The unit tests exercise `finalize_crate_tarball` end-to-end with real gzip/tar round-trips; the real-cargo validation above closes the "does it handle genuine cargo output" gap.
- **`.cargo_vcs_info.json` provenance is dropped.** It's informational only (no consumer requires it) and reproducible-build tooling routinely strips it. Noted in the learning.
- **A real dep change at the same version correctly trips the guard** — `Cargo.lock` is in the crate and thus in the fingerprint. Intended, not surprising.

## Follow-up (not filed — reporting per instructions)

- **pypi sdist + npm tgz share this reproducibility class.** `emit_pypi` (`uv build --sdist`) and `emit_npm` (`deno pack`) almost certainly carry their own non-determinism vectors (file mtimes) and are candidates for the same immutable-per-version normalization + guard. A sibling issue to verify and normalize those would complete the "emit is the publish; every artifact is immutable per version" contract across all three ecosystems. Not confirmed empirically in this PR (scope was cargo `.crate`s); flagged for verification.

Closes #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB
