### PR TITLE
chore(ci): remove invalid disabled Release workflow that reds every push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,0 @@
-name: Release
-
-# DISABLED: Release workflow needs redesign after PyO3 removal.
-# The old workflow built maturin/PyO3 wheels which are no longer applicable.
-# Future: build .slpkg bundles per #136
-on:
-  workflow_dispatch: # Manual trigger only


### PR DESCRIPTION
## Root cause — why it failed on every push

`.github/workflows/release.yml` was gutted in a prior refactor (PyO3 removal) from 114 lines of maturin/PyO3 wheel-build logic down to a 7-line placeholder — but that placeholder **dropped the `jobs:` key entirely**:

```yaml
name: Release

# DISABLED: Release workflow needs redesign after PyO3 removal.
# The old workflow built maturin/PyO3 wheels which are no longer applicable.
# Future: build .slpkg bundles per #136
on:
  workflow_dispatch: # Manual trigger only
```

A GitHub Actions workflow with no `jobs:` mapping is **structurally invalid**. GitHub creates a failed check run for an invalid workflow file on *every push*, regardless of the declared `on:` trigger — which is why, despite the `on: workflow_dispatch:`-only header, every run showed up as `event=push`, `status=failure`, `duration=0s`, with the message *"This run likely failed because of a workflow file issue."* That produced a permanent red check on `main`.

Note there are two workflows named `Release`: the valid `.github/workflows/release-please.yml` (the real passing "Release" check) and this invalid `.github/workflows/release.yml`. `gh workflow list` even shows the invalid one by its file path rather than its `name:` — GitHub's fallback for a workflow it can't parse. **`release-please.yml` is untouched.**

## What changed and why

Deleted `.github/workflows/release.yml`.

- Its entire historical payload was maturin/PyO3 wheel builds — dead code since PyO3 was removed.
- The intended future replacement (`.slpkg`-bundle release, tracked in #136) is a redesign and **out of scope** for this issue, which is narrowly "stop the red check."
- Even gating to `workflow_dispatch`-only wouldn't help — the redness comes from the missing `jobs:`, not the trigger. There is nothing worth keeping in the stub, so deletion is the minimal correct fix.

The `.slpkg` release-artifact redesign remains future work (#136); this PR does not attempt it.

## Confirmation it won't red on push

With the file removed, GitHub Actions has no `.github/workflows/release.yml` to parse, so no invalid-workflow check run is created on push. The failing run named `.github/workflows/release.yml` was produced solely by this file; nothing else in the repo references it as a reusable workflow. The only remaining mentions of `release.yml` are in a `check_schema_versions.rs` unit test that writes its **own** throwaway file into a `TempDir` fixture — unaffected by this deletion. The passing "Release" check (`release-please.yml`) is preserved.

Closes #1280

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB