### PR TITLE
fix(registry): skip non-publishable (path-patch) packages in whole-tree emit

### DIFF
--- a/docs/architecture/static-registry.md
+++ b/docs/architecture/static-registry.md
@@ -239,6 +239,12 @@ cargo xtask static-registry emit --out <dir> [--dev N] \
 - pypi (uv sdist) and npm (deno pack) reuse the SDK build toolchains; `.slpkg`
   packages are assembled via `streamlib pkg build` semantics and the release
   manifest is written last.
+- The whole-tree `.slpkg` emit **skips** any `packages/*` that carries a dev
+  path-`patch:` block (the test-only fixtures) with a `warn!` naming every
+  offender — such a package is non-distributable by construction, so it is
+  excluded from the release manifest and the catalog rather than failing the
+  whole emit. The single-package `streamlib pkg build` / `pkg publish` still
+  hard-fails on the same condition so an author sees the error.
 
 ## Consuming a tree
 

--- a/libs/streamlib-pack/src/lib.rs
+++ b/libs/streamlib-pack/src/lib.rs
@@ -918,32 +918,46 @@ fn manifest_bytes_for(pkg_dir: &Path, policy: PathDepPolicy) -> Result<Vec<u8>> 
     }
 }
 
-/// Reject path-flavor `patch:` entries (dev-time overrides that don't
-/// generalize to a distributed artifact). Names every offender.
-fn reject_path_patches(pkg_dir: &Path) -> Result<()> {
+/// Names every path-flavor `patch:` entry in `<pkg_dir>/streamlib.yaml` —
+/// dev-time overrides that don't generalize to a distributed artifact. An
+/// empty result means the package is publishable through this gate; a
+/// non-empty one lists each offender (`` `dep` → `path` ``). A missing
+/// manifest is treated as no offenders.
+///
+/// The predicate the whole-tree static-registry emit skips on and the CLI
+/// `.slpkg` gate rejects on share this one definition — the skip is the same
+/// condition, sound by construction rather than a proxy. Filters exactly
+/// [`DependencySpec::Path`], so git/registry `patch:` overrides never count.
+pub(crate) fn path_patch_offenders(pkg_dir: &Path) -> Result<Vec<String>> {
     let manifest_path = pkg_dir.join(Manifest::FILE_NAME);
     if !manifest_path.exists() {
-        return Ok(());
+        return Ok(Vec::new());
     }
     let body = std::fs::read_to_string(&manifest_path)
         .with_context(|| format!("read {}", manifest_path.display()))?;
     let manifest: Manifest = serde_yaml::from_str(&body)
         .with_context(|| format!("parse {}", manifest_path.display()))?;
-    let offenders: Vec<String> = manifest
+    Ok(manifest
         .patch
         .iter()
         .filter_map(|(dep_ref, spec)| match spec {
             DependencySpec::Path(p) => Some(format!("`{}` → `{}`", dep_ref, p.path.display())),
             _ => None,
         })
-        .collect();
+        .collect())
+}
+
+/// Reject path-flavor `patch:` entries (dev-time overrides that don't
+/// generalize to a distributed artifact). Names every offender.
+fn reject_path_patches(pkg_dir: &Path) -> Result<()> {
+    let offenders = path_patch_offenders(pkg_dir)?;
     if offenders.is_empty() {
         return Ok(());
     }
     anyhow::bail!(
         "{} carries path-flavor `patch:` entries which are dev-time overrides and not \
          publishable: {}. Remove them — or convert to a git/registry override — before packing.",
-        manifest_path.display(),
+        pkg_dir.join(Manifest::FILE_NAME).display(),
         offenders.join(", "),
     );
 }

--- a/libs/streamlib-pack/src/static_registry.rs
+++ b/libs/streamlib-pack/src/static_registry.rs
@@ -685,6 +685,31 @@ fn emit_npm(opts: &EmitOptions, staging: &Path, target: &str) -> Result<()> {
     Ok(())
 }
 
+/// Whether a `packages/*` dir participates in the whole-tree `.slpkg` emit.
+enum PackageEmitDecision {
+    /// Publishable — assemble + upload + catalog + release-manifest membership.
+    Emit,
+    /// Non-publishable: carries a dev path-`patch:` block (the test-only
+    /// fixtures). Skipped from the whole-tree emit, naming every offender.
+    SkipDevPatch(Vec<String>),
+}
+
+/// Classify a `packages/*` dir for the whole-tree emit. A package carrying a
+/// dev path-`patch:` block is non-distributable by construction — the exact
+/// condition [`PathDepPolicy::RejectPathPatches`](crate::PathDepPolicy)
+/// refuses inside [`assemble_slpkg_bytes`] — so the whole-tree emit skips it
+/// rather than hard-failing the whole release. The predicate is shared with
+/// the CLI gate (`crate::path_patch_offenders`), so the skip is the same
+/// condition, sound by construction rather than a proxy.
+fn decide_package_emit(pkg_dir: &Path) -> Result<PackageEmitDecision> {
+    let offenders = crate::path_patch_offenders(pkg_dir)?;
+    if offenders.is_empty() {
+        Ok(PackageEmitDecision::Emit)
+    } else {
+        Ok(PackageEmitDecision::SkipDevPatch(offenders))
+    }
+}
+
 /// Assemble each workspace package into a `.slpkg`, write it into the `file://`
 /// generic store, and write the [`ReleaseManifest`] LAST (the atomicity flip
 /// within the staging tree; the whole staging tree then flips atomically).
@@ -718,10 +743,32 @@ fn emit_slpkg_and_manifest(
         let siblings = build_sibling_versions(&entries)
             .context("building the catalog resolution universe from packages/")?;
 
+        let mut emitted = 0usize;
+        let mut skipped = 0usize;
         for pkg_dir in &entries {
             let yaml = pkg_dir.join("streamlib.yaml");
             if !yaml.is_file() {
                 continue;
+            }
+            // A package carrying a dev path-`patch:` block is non-distributable
+            // by construction (the same condition
+            // `PathDepPolicy::RejectPathPatches` refuses inside
+            // `assemble_slpkg_bytes`). The whole-tree emit skips it — with a
+            // warning naming every offender — rather than hard-failing the
+            // whole release; the single-package `streamlib pkg build/publish`
+            // still hard-fails so an author sees the error. Skipping here means
+            // no upload, no release-manifest membership, and no catalog entry.
+            match decide_package_emit(pkg_dir)? {
+                PackageEmitDecision::SkipDevPatch(offenders) => {
+                    tracing::warn!(
+                        package = %pkg_dir.display(),
+                        offenders = %offenders.join(", "),
+                        "skipping non-publishable package (dev path patch) from static-registry .slpkg emit"
+                    );
+                    skipped += 1;
+                    continue;
+                }
+                PackageEmitDecision::Emit => {}
             }
             let (pkg_ref, version, bytes) = assemble_slpkg_bytes(pkg_dir)?;
             let semver: SemVer = version
@@ -742,7 +789,9 @@ fn emit_slpkg_and_manifest(
             write_package_catalog(&slpkg_dir, &artifacts)
                 .with_context(|| format!("writing catalog for {pkg_ref}"))?;
             catalog_index.extend(artifacts.index_lines);
+            emitted += 1;
         }
+        tracing::info!(emitted, skipped, "static-registry .slpkg emit complete");
     }
 
     // Crate closure members at their ACTUAL manifest versions — the same
@@ -1222,5 +1271,67 @@ mod tests {
         assert!(served.join("only-in-new").is_file());
         assert!(!served.join("only-in-old").exists(), "old tree fully replaced");
         assert!(!staging.exists(), "staging (old tree after swap) removed");
+    }
+
+    /// Write a `streamlib.yaml` into a fresh temp package dir and return it.
+    fn package_dir_with_manifest(manifest_yaml: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("streamlib.yaml"), manifest_yaml).unwrap();
+        dir
+    }
+
+    /// A publishable manifest (no `patch:` block) classifies as `Emit`.
+    #[test]
+    fn decide_package_emit_clean_manifest_emits() {
+        let dir = package_dir_with_manifest(
+            "package:\n  org: tatolab\n  name: clean-pkg\n  version: 1.0.0\n\
+             dependencies:\n  \"@tatolab/core\": \"^1.0.0\"\n",
+        );
+        assert!(matches!(
+            decide_package_emit(dir.path()).unwrap(),
+            PackageEmitDecision::Emit
+        ));
+    }
+
+    /// A manifest carrying a dev path-`patch:` block (the test-fixtures shape)
+    /// classifies as `SkipDevPatch`, naming the offending dependency.
+    ///
+    /// Mental revert: change `decide_package_emit`'s non-empty arm to
+    /// `PackageEmitDecision::Emit` and this test fails — the classification is
+    /// what the whole-tree emit's skip branch keys on, so the test locks the
+    /// decision, not just the parse.
+    #[test]
+    fn decide_package_emit_path_patch_skips_and_names_offender() {
+        let dir = package_dir_with_manifest(
+            "package:\n  org: tatolab\n  name: fixture-pkg\n  version: 1.0.0\n\
+             dependencies:\n  \"@tatolab/core\": \"^1.0.0\"\n\
+             patch:\n  \"@tatolab/core\":\n    path: ../core\n",
+        );
+        match decide_package_emit(dir.path()).unwrap() {
+            PackageEmitDecision::SkipDevPatch(offenders) => {
+                assert_eq!(offenders.len(), 1);
+                assert!(
+                    offenders[0].contains("@tatolab/core") && offenders[0].contains("../core"),
+                    "offender should name the dep and the path: {offenders:?}"
+                );
+            }
+            PackageEmitDecision::Emit => panic!("path-patch-carrying package must be skipped"),
+        }
+    }
+
+    /// A non-path (git) `patch:` override is a legitimate distributable
+    /// override, not a dev path affordance — the skip is path-only, so the
+    /// package still classifies as `Emit`.
+    #[test]
+    fn decide_package_emit_git_patch_still_emits() {
+        let dir = package_dir_with_manifest(
+            "package:\n  org: tatolab\n  name: git-pkg\n  version: 1.0.0\n\
+             dependencies:\n  \"@tatolab/bar\": \"^2.0.0\"\n\
+             patch:\n  \"@tatolab/bar\":\n    git: https://example.com/bar\n    rev: abc123\n",
+        );
+        assert!(
+            matches!(decide_package_emit(dir.path()).unwrap(), PackageEmitDecision::Emit),
+            "a git-flavor patch is not a dev path override and must not be skipped"
+        );
     }
 }


### PR DESCRIPTION
## What & why

The full static-registry `.slpkg` emit (`emit_slpkg_and_manifest` in `streamlib-pack`) enumerated **every** `packages/*` and ran the patch-rejecting `assemble_slpkg_bytes`, so it hard-failed the moment it hit a **test-only / non-publishable** package that deliberately carries a dev path-`patch:` block — `packages/test-fixtures` and `packages/test-fixtures-abi-mismatch` (both patch `@tatolab/core → ../core`; a grep of all 22 package manifests confirms exactly these two). CI never hit it because it emits the cargo closure with `--no-slpkg`; the reworked Docker full-emit is the first `.slpkg` consumer to surface it.

## Option A — skip path-patch-carrying packages (locked)

A package carrying a dev path-`patch:` block is **non-distributable by construction** — the exact condition `PathDepPolicy::RejectPathPatches` already refuses. So the whole-tree emit now **skips** such a package with a `warn!` naming every offender, excluding it from both the release manifest and the catalog rather than failing the whole release. The single-package `streamlib pkg build` / `pkg publish` CLI **keeps hard-failing** on the same condition, so a package author still sees the error.

Rationale for Option A over an explicit `publish: false` marker: the skip predicate is *identical* to the `RejectPathPatches` condition — sound by construction, not a proxy — and needs zero schema change.

## What changed

- **`libs/streamlib-pack/src/lib.rs`** — extracted the shared predicate `path_patch_offenders(pkg_dir) -> Result<Vec<String>>` (`pub(crate)`); `reject_path_patches` now delegates to it and is **behavior-identical** for the CLI (same offender format `` `dep` → `path` ``, same bail message, same missing-manifest handling). Filters exactly `DependencySpec::Path`, so git/registry `patch:` overrides never count.
- **`libs/streamlib-pack/src/static_registry.rs`** — added a `PackageEmitDecision { Emit, SkipDevPatch(Vec<String>) }` enum + `decide_package_emit(pkg_dir)` seam that classifies via the shared predicate; the emit loop matches on it and `continue`s past upload + release-manifest membership + catalog for a `SkipDevPatch`, with a `warn!` per skip and an `info!(emitted, skipped)` summary. No change to `assemble_slpkg_bytes`, `RejectPathPatches`, `compute_release_closure`, atomicity (manifest still written last), or `--no-slpkg`.
- **`docs/architecture/static-registry.md`** — one current-tense sentence under "Emitting a tree".

No schema regen, no CLI change, no new dependency.

## Exit-criteria mapping

- [x] A full `.slpkg` emit skips non-publishable packages and completes; the two test fixtures are excluded, not fatal — implemented via `decide_package_emit` at the top of the emit loop.
- [ ] The reworked Docker image build (#1276) completes through the `.slpkg` stage — **unblocks #1276**; its own build-verification stays with that issue (this PR does not close it).

## Tests / validation

Three unit tests in `static_registry.rs` driving the `decide_package_emit` seam (the plan's chosen test seam — a full `emit_slpkg_and_manifest` test is deliberately out of scope, it runs cargo metadata + builds cdylibs):

- `decide_package_emit_clean_manifest_emits` — no `patch:` → `Emit`.
- `decide_package_emit_path_patch_skips_and_names_offender` — path patch → `SkipDevPatch`, offender names the dep + path.
- `decide_package_emit_git_patch_still_emits` — a git-flavor `patch:` → `Emit` (skip is path-only).

The CLI-gate locks (`slpkg_reject_path_patches_fails`, `slpkg_rejects_path_patch`) are unchanged and still pass, confirming the extraction preserved the hard-fail behavior.

```
test result: ok. 74 passed; 0 failed; 0 ignored (cargo test -p streamlib-pack --lib)
```

**Mental revert**: forcing `decide_package_emit`'s non-empty arm to `Emit` makes `decide_package_emit_path_patch_skips_and_names_offender` FAIL while the clean + git-patch tests still pass — the test locks the skip decision, not just the parse. Verified:

```
test decide_package_emit_path_patch_skips_and_names_offender ... FAILED   (with skip arm reverted)
test result: FAILED. 2 passed; 1 failed
```

Independent pr-review-gate verdict: **PASS** (one non-blocking DISCUSS noting the loop `continue` wiring is exercised by the #1276 full-emit path rather than a heavy in-repo integration test — the locked scope-cut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB