### PR TITLE
fix(registry): emit-skip predicate matches the full assemble-rejection set

### DIFF
--- a/docs/architecture/static-registry.md
+++ b/docs/architecture/static-registry.md
@@ -282,12 +282,17 @@ cargo xtask static-registry emit --out <dir> [--dev N] \
 - pypi (uv sdist) and npm (deno pack) reuse the SDK build toolchains; `.slpkg`
   packages are assembled via `streamlib pkg build` semantics and the release
   manifest is written last.
-- The whole-tree `.slpkg` emit **skips** any `packages/*` that carries a dev
-  path-`patch:` block (the test-only fixtures) with a `warn!` naming every
-  offender — such a package is non-distributable by construction, so it is
-  excluded from the release manifest and the catalog rather than failing the
-  whole emit. The single-package `streamlib pkg build` / `pkg publish` still
-  hard-fails on the same condition so an author sees the error.
+- The whole-tree `.slpkg` emit **skips** any `packages/*` that is
+  non-distributable — one carrying a `streamlib.yaml` path-`patch:` block OR a
+  Cargo.toml dependency-table `path` dep (the test-only fixtures) — with a
+  `warn!` naming every offender, so it is excluded from the release manifest
+  and the catalog rather than failing the whole emit. The skip predicate
+  (`decide_package_emit`) keys on exactly the set `ensure_no_path_artifacts`
+  rejects for the `Slpkg` target, so the skip set equals the rejection set: a
+  package the emit would hard-fail on is always skipped instead. TARGET paths
+  (`[[bin]].path` / `[lib].path`) are not dependency paths and never count. The
+  single-package `streamlib pkg build` / `pkg publish` still hard-fails on the
+  same condition so an author sees the error.
 
 ## Consuming a tree
 

--- a/libs/streamlib-pack/src/lib.rs
+++ b/libs/streamlib-pack/src/lib.rs
@@ -610,48 +610,50 @@ fn dylib_filename(path: &Path) -> Result<String> {
 /// the registry, so a stray path would ship and break the consumer's off-tree
 /// build. Called only for the `Slpkg` target (`pkg build` / `pkg publish`).
 fn ensure_no_path_artifacts(pkg_dir: &Path) -> Result<()> {
-    let manifest_path = pkg_dir.join(Manifest::FILE_NAME);
-    if manifest_path.exists() {
-        let body = std::fs::read_to_string(&manifest_path)
-            .with_context(|| format!("read {}", manifest_path.display()))?;
-        let manifest: streamlib_processor_schema::StreamlibYaml =
-            serde_yaml::from_str(&body).context("parse streamlib.yaml")?;
-        let path_patches: Vec<String> = manifest
-            .patch
-            .iter()
-            .filter(|(_, spec)| matches!(spec, DependencySpec::Path(_)))
-            .map(|(dep, _)| dep.to_string())
-            .collect();
-        if !path_patches.is_empty() {
-            anyhow::bail!(
-                "{} carries path `patch:` override(s) for [{}] — a published package \
-                 must be standalone (registry-only). Remove the `patch:` block; each \
-                 dependency resolves from the registry by the version in `dependencies:`.",
-                manifest_path.display(),
-                path_patches.join(", "),
-            );
-        }
+    // Both halves flow through the SAME helpers the whole-tree emit's skip
+    // predicate ([`non_distributable_path_offenders`]) is built from, so the
+    // rejection set and the skip set are identical by construction — neither
+    // half can drift into a "skip misses what reject catches" gap.
+    let patch_offenders = path_patch_offenders(pkg_dir)?;
+    if !patch_offenders.is_empty() {
+        anyhow::bail!(
+            "{} carries path `patch:` override(s) for [{}] — a published package \
+             must be standalone (registry-only). Remove the `patch:` block; each \
+             dependency resolves from the registry by the version in `dependencies:`.",
+            pkg_dir.join(Manifest::FILE_NAME).display(),
+            patch_offenders.join(", "),
+        );
     }
 
-    let cargo_path = pkg_dir.join("Cargo.toml");
-    if cargo_path.exists() {
-        let body = std::fs::read_to_string(&cargo_path)
-            .with_context(|| format!("read {}", cargo_path.display()))?;
-        let doc: toml::Value =
-            toml::from_str(&body).with_context(|| format!("parse {}", cargo_path.display()))?;
-        let offenders = cargo_path_dep_names(&doc);
-        if !offenders.is_empty() {
-            anyhow::bail!(
-                "{} declares path dependenc(ies) [{}] — a published package must be \
-                 standalone (registry-only). Replace each with \
-                 `{{ version = \"…\", registry = \"tatolab\" }}` so the crate resolves \
-                 from the registry.",
-                cargo_path.display(),
-                offenders.join(", "),
-            );
-        }
+    let cargo_offenders = cargo_path_dep_offenders(pkg_dir)?;
+    if !cargo_offenders.is_empty() {
+        anyhow::bail!(
+            "{} declares path dependenc(ies) [{}] — a published package must be \
+             standalone (registry-only). Replace each with \
+             `{{ version = \"…\", registry = \"tatolab\" }}` so the crate resolves \
+             from the registry.",
+            pkg_dir.join("Cargo.toml").display(),
+            cargo_offenders.join(", "),
+        );
     }
     Ok(())
+}
+
+/// Names of dependency-table `path` deps in `<pkg_dir>/Cargo.toml` — the same
+/// scan [`ensure_no_path_artifacts`] rejects on. Empty when the Cargo.toml is
+/// absent or carries only registry-resolved deps. Reads + parses the Cargo.toml
+/// then defers to [`cargo_path_dep_names`], so a `[[bin]].path` / `[lib].path`
+/// TARGET path never counts — only dependency tables are scanned.
+fn cargo_path_dep_offenders(pkg_dir: &Path) -> Result<Vec<String>> {
+    let cargo_path = pkg_dir.join("Cargo.toml");
+    if !cargo_path.exists() {
+        return Ok(Vec::new());
+    }
+    let body = std::fs::read_to_string(&cargo_path)
+        .with_context(|| format!("read {}", cargo_path.display()))?;
+    let doc: toml::Value =
+        toml::from_str(&body).with_context(|| format!("parse {}", cargo_path.display()))?;
+    Ok(cargo_path_dep_names(&doc))
 }
 
 /// Names of dependencies carrying a `path` key across every dependency table
@@ -945,6 +947,22 @@ pub(crate) fn path_patch_offenders(pkg_dir: &Path) -> Result<Vec<String>> {
             _ => None,
         })
         .collect())
+}
+
+/// Every non-distributable path artifact in a package dir — the union of
+/// `streamlib.yaml` path-`patch:` overrides ([`path_patch_offenders`]) and
+/// Cargo.toml dependency-table `path` deps ([`cargo_path_dep_offenders`]).
+///
+/// [`ensure_no_path_artifacts`] rejects on these exact same two helpers for
+/// the [`AssembleTarget::Slpkg`] target, so the whole-tree static-registry
+/// emit's skip predicate keys on the same condition it would otherwise
+/// hard-fail on: the skip set equals the rejection set, sound by construction
+/// (one shared definition per half) rather than a proxy. TARGET paths
+/// (`[[bin]].path` / `[lib].path`) are not dependency paths and never count.
+pub(crate) fn non_distributable_path_offenders(pkg_dir: &Path) -> Result<Vec<String>> {
+    let mut offenders = path_patch_offenders(pkg_dir)?;
+    offenders.extend(cargo_path_dep_offenders(pkg_dir)?);
+    Ok(offenders)
 }
 
 /// Reject path-flavor `patch:` entries (dev-time overrides that don't

--- a/libs/streamlib-pack/src/static_registry.rs
+++ b/libs/streamlib-pack/src/static_registry.rs
@@ -689,24 +689,26 @@ fn emit_npm(opts: &EmitOptions, staging: &Path, target: &str) -> Result<()> {
 enum PackageEmitDecision {
     /// Publishable — assemble + upload + catalog + release-manifest membership.
     Emit,
-    /// Non-publishable: carries a dev path-`patch:` block (the test-only
-    /// fixtures). Skipped from the whole-tree emit, naming every offender.
-    SkipDevPatch(Vec<String>),
+    /// Non-distributable: carries a `streamlib.yaml` path-`patch:` block OR a
+    /// Cargo.toml dependency-table `path` dep (the test-only fixtures).
+    /// Skipped from the whole-tree emit, naming every offender.
+    SkipNonDistributable(Vec<String>),
 }
 
 /// Classify a `packages/*` dir for the whole-tree emit. A package carrying a
-/// dev path-`patch:` block is non-distributable by construction — the exact
-/// condition [`PathDepPolicy::RejectPathPatches`](crate::PathDepPolicy)
-/// refuses inside [`assemble_slpkg_bytes`] — so the whole-tree emit skips it
-/// rather than hard-failing the whole release. The predicate is shared with
-/// the CLI gate (`crate::path_patch_offenders`), so the skip is the same
-/// condition, sound by construction rather than a proxy.
+/// `streamlib.yaml` path-`patch:` block OR a Cargo.toml dependency-table `path`
+/// dep is non-distributable by construction — the exact set
+/// `ensure_no_path_artifacts` rejects inside [`assemble_slpkg_bytes`] for the
+/// `Slpkg` target — so the whole-tree emit skips it rather than hard-failing
+/// the whole release. The predicate is shared with that gate via
+/// [`crate::non_distributable_path_offenders`], so the skip set equals the
+/// rejection set, sound by construction rather than a proxy.
 fn decide_package_emit(pkg_dir: &Path) -> Result<PackageEmitDecision> {
-    let offenders = crate::path_patch_offenders(pkg_dir)?;
+    let offenders = crate::non_distributable_path_offenders(pkg_dir)?;
     if offenders.is_empty() {
         Ok(PackageEmitDecision::Emit)
     } else {
-        Ok(PackageEmitDecision::SkipDevPatch(offenders))
+        Ok(PackageEmitDecision::SkipNonDistributable(offenders))
     }
 }
 
@@ -750,20 +752,21 @@ fn emit_slpkg_and_manifest(
             if !yaml.is_file() {
                 continue;
             }
-            // A package carrying a dev path-`patch:` block is non-distributable
-            // by construction (the same condition
-            // `PathDepPolicy::RejectPathPatches` refuses inside
-            // `assemble_slpkg_bytes`). The whole-tree emit skips it — with a
-            // warning naming every offender — rather than hard-failing the
-            // whole release; the single-package `streamlib pkg build/publish`
-            // still hard-fails so an author sees the error. Skipping here means
-            // no upload, no release-manifest membership, and no catalog entry.
+            // A package carrying a `streamlib.yaml` path-`patch:` block OR a
+            // Cargo.toml dependency-table `path` dep is non-distributable by
+            // construction (the same set `ensure_no_path_artifacts` rejects
+            // inside `assemble_slpkg_bytes` for the `Slpkg` target). The
+            // whole-tree emit skips it — with a warning naming every offender —
+            // rather than hard-failing the whole release; the single-package
+            // `streamlib pkg build/publish` still hard-fails so an author sees
+            // the error. Skipping here means no upload, no release-manifest
+            // membership, and no catalog entry.
             match decide_package_emit(pkg_dir)? {
-                PackageEmitDecision::SkipDevPatch(offenders) => {
+                PackageEmitDecision::SkipNonDistributable(offenders) => {
                     tracing::warn!(
                         package = %pkg_dir.display(),
                         offenders = %offenders.join(", "),
-                        "skipping non-publishable package (dev path patch) from static-registry .slpkg emit"
+                        "skipping non-distributable package (path patch or cargo path dep) from static-registry .slpkg emit"
                     );
                     skipped += 1;
                     continue;
@@ -1294,7 +1297,7 @@ mod tests {
     }
 
     /// A manifest carrying a dev path-`patch:` block (the test-fixtures shape)
-    /// classifies as `SkipDevPatch`, naming the offending dependency.
+    /// classifies as `SkipNonDistributable`, naming the offending dependency.
     ///
     /// Mental revert: change `decide_package_emit`'s non-empty arm to
     /// `PackageEmitDecision::Emit` and this test fails — the classification is
@@ -1308,7 +1311,7 @@ mod tests {
              patch:\n  \"@tatolab/core\":\n    path: ../core\n",
         );
         match decide_package_emit(dir.path()).unwrap() {
-            PackageEmitDecision::SkipDevPatch(offenders) => {
+            PackageEmitDecision::SkipNonDistributable(offenders) => {
                 assert_eq!(offenders.len(), 1);
                 assert!(
                     offenders[0].contains("@tatolab/core") && offenders[0].contains("../core"),
@@ -1317,6 +1320,70 @@ mod tests {
             }
             PackageEmitDecision::Emit => panic!("path-patch-carrying package must be skipped"),
         }
+    }
+
+    /// A clean `streamlib.yaml` (no path `patch:`) paired with a Cargo.toml
+    /// carrying a dependency-table `path` dep classifies as
+    /// `SkipNonDistributable`. This is the case #1285's streamlib.yaml-only
+    /// predicate missed: `ensure_no_path_artifacts` would hard-fail the whole
+    /// emit on the Cargo path dep, so the skip predicate must detect it too —
+    /// the skip set must equal the rejection set.
+    ///
+    /// Mental revert: drop the `cargo_path_dep_offenders` half of
+    /// `non_distributable_path_offenders` and this package classifies `Emit`
+    /// (its streamlib.yaml carries no patch), reintroducing the "one
+    /// non-publishable package fails the whole release" mode via the other
+    /// gate.
+    #[test]
+    fn decide_package_emit_cargo_path_dep_skips_and_names_offender() {
+        let dir = package_dir_with_manifest(
+            "package:\n  org: tatolab\n  name: cargo-path-pkg\n  version: 1.0.0\n\
+             dependencies:\n  \"@tatolab/core\": \"^1.0.0\"\n",
+        );
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"cargo-path-pkg\"\nversion = \"1.0.0\"\n\
+             [dependencies]\nsibling = { path = \"../sibling\", version = \"1.0\" }\n",
+        )
+        .unwrap();
+        match decide_package_emit(dir.path()).unwrap() {
+            PackageEmitDecision::SkipNonDistributable(offenders) => {
+                assert!(
+                    offenders.iter().any(|o| o.contains("sibling")),
+                    "offender should name the Cargo path dep: {offenders:?}"
+                );
+            }
+            PackageEmitDecision::Emit => {
+                panic!("a Cargo.toml dependency-table path dep must be skipped")
+            }
+        }
+    }
+
+    /// A Cargo.toml TARGET path (`[[bin]].path` / `[lib].path`) is NOT a
+    /// dependency path — a package whose only Cargo path keys are target
+    /// paths (and whose streamlib.yaml carries no patch, and whose deps
+    /// resolve from the registry) still classifies `Emit`. Guards against an
+    /// over-broad scan that would skip a publishable package for declaring a
+    /// non-default `src/` layout.
+    #[test]
+    fn decide_package_emit_cargo_target_path_still_emits() {
+        let dir = package_dir_with_manifest(
+            "package:\n  org: tatolab\n  name: target-path-pkg\n  version: 1.0.0\n\
+             dependencies:\n  \"@tatolab/core\": \"^1.0.0\"\n",
+        );
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"target-path-pkg\"\nversion = \"1.0.0\"\n\
+             [lib]\npath = \"src/lib.rs\"\n\
+             [[bin]]\nname = \"tool\"\npath = \"src/bin/tool.rs\"\n\
+             [dependencies]\nserde = { version = \"1\", registry = \"tatolab\" }\n",
+        )
+        .unwrap();
+        assert!(
+            matches!(decide_package_emit(dir.path()).unwrap(), PackageEmitDecision::Emit),
+            "Cargo target paths ([[bin]].path / [lib].path) are not dependency \
+             paths and must not trigger skip"
+        );
     }
 
     /// A non-path (git) `patch:` override is a legitimate distributable


### PR DESCRIPTION
## What changed

The whole-tree static-registry `.slpkg` emit's skip predicate (`decide_package_emit`) now skips **exactly** the set that `assemble_artifact` would reject for the `Slpkg` target — the union of a `streamlib.yaml` path-`patch:` block **and** a Cargo.toml dependency-table `path` dep. Before this PR (post-#1285) it only detected the streamlib.yaml half.

## Why (skip set == rejection set)

#1285 taught the bulk emit to *skip* a non-distributable fixture instead of hard-failing the whole release. But the gate that actually fires first inside `assemble_artifact` for the `Slpkg` target is `ensure_no_path_artifacts` (`streamlib-pack/src/lib.rs`), which rejects **both** a streamlib.yaml path-`patch:` **and** a Cargo.toml dependency-table `path` dep. #1285's predicate only saw the first. Today the two conditions coincide (the only non-publishable packages carry both), so #1285 works — but a future package carrying *only* a Cargo.toml `path` dep would classify `Emit`, then hard-fail the whole emit at `ensure_no_path_artifacts`, reintroducing via the other gate the exact "one non-publishable package fails the release" mode #1284 fixed.

This PR makes the skip set equal the rejection set **by construction** — both sides are now built from the same two per-half helpers, so neither half can drift into a "skip misses what reject catches" gap:

- `non_distributable_path_offenders` = `path_patch_offenders` (streamlib.yaml patch) ∪ `cargo_path_dep_offenders` (Cargo path deps). `decide_package_emit` keys on the union.
- `ensure_no_path_artifacts` is refactored to reject on those **same two helpers** rather than a parallel inline `StreamlibYaml` scan — one shared definition per half. Keeps its two tailored author-facing bail messages; drops a now-redundant manifest parse (the `Manifest` parse already runs later in the same `assemble_artifact` flow via `reject_path_patches`).
- Cargo.toml `[[bin]].path` / `[lib].path` are **TARGET** paths, not dependency paths — `cargo_path_dep_names` only scans dependency tables, so target paths never trigger skip.
- `SkipDevPatch` → `SkipNonDistributable` (the condition is no longer patch-only).
- The single-package `streamlib pkg build` / `pkg publish` still **hard-fails** (unchanged) — only the bulk emit tolerates-and-skips.

Doc precision: `static-registry.md` and the `decide_package_emit` doc now name `ensure_no_path_artifacts` as the gate that fires first (the #1285-era `reject_path_patches` / `PathDepPolicy::RejectPathPatches` reference was streamlib.yaml-only and fired later in the flow).

No schema/CLI/ABI change. Three files: `libs/streamlib-pack/src/lib.rs`, `libs/streamlib-pack/src/static_registry.rs`, `docs/architecture/static-registry.md`.

## Test evidence

`cargo test -p streamlib-pack --lib` → **76 passed, 0 failed**. New + existing coverage of interest:

| Test | Asserts |
|---|---|
| `decide_package_emit_cargo_path_dep_skips_and_names_offender` (new) | Cargo.toml dep-table `path` dep, no streamlib.yaml patch → `SkipNonDistributable` |
| `decide_package_emit_cargo_target_path_still_emits` (new) | Cargo `[[bin]].path`/`[lib].path` target paths, no dep-path → `Emit` |
| `decide_package_emit_path_patch_skips_and_names_offender` | streamlib.yaml patch → `SkipNonDistributable` |
| `decide_package_emit_clean_manifest_emits` / `..._git_patch_still_emits` | clean + git-patch → `Emit` |
| `slpkg_rejects_path_patch` / `slpkg_rejects_path_cargo_dependency` | single-package CLI still hard-fails (refactored gate preserves both messages) |

**Mental-revert (locks the fix):** dropping the `cargo_path_dep_offenders` half of `non_distributable_path_offenders` makes `decide_package_emit_cargo_path_dep_skips_and_names_offender` fail — the package classifies `Emit` (its streamlib.yaml carries no patch), which is precisely the hard-fail-the-whole-emit bug this PR closes. Confirmed by running the reverted variant: `FAILED. 1 passed; 1 failed` (the target-path test still passes, since it doesn't rely on the cargo scan).

No new clippy or `cargo doc` warnings introduced. `Cargo.lock` untouched.

Closes #1286

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB