### PR TITLE
fix(registry): always repackage closure crates, never trust a stale target/package tarball

### DIFF
--- a/docs/architecture/static-registry.md
+++ b/docs/architecture/static-registry.md
@@ -92,21 +92,26 @@ at package time). Versions always follow the crates' actual manifests — a
 `--dev` emit expects the workspace manifests already bumped (the publish
 scripts' bump/restore convention).
 
-Per-crate `.crate` tarballs are **reused across emits, but only after
-integrity verification** (`streamlib_pack::crate_tarball`): a previously
-packaged `target/package/<crate>-<version>.crate` is structurally checked —
-its gzip stream fully decodes, every tar entry enumerates to EOF, and the
-`<crate>-<version>/Cargo.toml` entry is present — before the emit trusts it.
-A tarball that passes is reused (skipping a redundant `cargo package`); one
-that fails — a truncated leftover from an aborted emit is the motivating
-case — is logged, deleted, and repackaged automatically, so a stale artifact
-never poisons the emitted tree and no manual cache-clearing is needed. A
-freshly packaged tarball is verified too; a still-invalid result is a hard
-error. Reuse treats a `(crate, version)` tarball as immutable, so a verified
-reuse skips that crate's `cargo package` registry-dep validation for the run
-— acceptable because the emitted sparse-index line is rendered from the
-reused tarball's own bundled manifest, so the tree stays internally
-consistent.
+Per-crate `.crate` tarballs are **always repackaged, never reused from a
+content cache** (`streamlib_pack::crate_tarball::obtain_crate_tarball`).
+`cargo package` is the single source of truth for crate bytes:
+`target/package/<crate>-<version>.crate` is cargo scratch, not a
+streamlib-managed cache, so any pre-existing artifact is dropped up front and
+`cargo package` re-runs for every closure crate. This guarantees the emitted
+`.crate` reflects current source at that version — a structurally-valid but
+content-stale leftover (e.g. an old-ABI `streamlib-plugin-abi` tarball cached
+under a version whose source has since moved to a new ABI) can never be handed
+back verbatim. The freshly packaged tarball is then structurally verified
+(`verify_crate_tarball`: gzip stream fully decodes, every tar entry enumerates
+to EOF, the `<crate>-<version>/Cargo.toml` entry is present); a still-invalid
+result is a hard error. Each fresh `cargo package` validates its own live
+`registry = "tatolab"` dep set, and the emitted sparse-index line is rendered
+from that tarball's bundled manifest, so the tree stays internally consistent.
+(Source-tree-hash-keyed reuse was rejected: 35 member manifests inherit
+`workspace = true` and the committed workspace `Cargo.lock` is packaged into
+each crate, so inputs live outside a crate's own directory and a source-dir
+hash would silently miss a central dep / lock bump — reintroducing the exact
+stale-emit bug.)
 
 ## Atomic release — the staged swap
 
@@ -139,8 +144,8 @@ suppresses that entry, so `emit_cargo_closure` normalizes each tarball after
 packaging (`crate_tarball::finalize_crate_tarball`): strip
 `.cargo_vcs_info.json`, re-tar the survivors (cargo's headers cloned
 verbatim), and re-gzip with a fixed header. Normalization is idempotent, so
-the reuse path (a cached `target/package/<crate>.crate` across emits) stays
-stable.
+re-emitting a crate at an unchanged version yields byte-identical output even
+though each emit repackages from source.
 
 The immutability guard compares a **content fingerprint** — the sha256 of
 the canonical, vcs-stripped, *uncompressed* tar, so it's independent of gzip
@@ -182,14 +187,15 @@ edits:
    --cargo-closure`), which republishes every SDK crate so a package resolves
    the new-ABI SDK.
 
-A new version also sidesteps the crate-tarball reuse cache: `emit_cargo_closure`
-reuses a `target/package/<crate>-<version>.crate` after **structural** (not
-content) verification, so a same-version re-emit can hand back a stale-content
-tarball (e.g. an old-ABI `streamlib-plugin-abi` cached under a version whose
-source has since moved) while the host compiles the new source. A fresh version
-is a fresh filename — a cache miss that forces a fresh `cargo package` at the
-current source. (Clearing `target/package` before an emit is the CI
-belt-and-suspenders; content-addressed verification is the durable fix.)
+The version bump is what lets a consumer pin the new-ABI SDK (the load
+handshake refuses an ABI-mismatched cdylib) and what the immutability guard
+requires to change published source — a silent same-version source change is
+refused. The emit itself carries no stale-cache risk at any version:
+`emit_cargo_closure` always repackages each closure crate from current source
+(`target/package` is cargo scratch, not a trusted content cache — see [the
+fork section](#the-vulkanalia-fork-is-mandatory)), so even a same-version
+re-emit reflects current source. Clearing `target/package` before a CI emit is
+therefore redundant belt-and-suspenders, not a correctness requirement.
 
 The `cargo xtask check-abi-republish` CI gate enforces the first, mechanical
 half at PR time: a change to `STREAMLIB_ABI_VERSION` without a matching
@@ -335,7 +341,7 @@ consumer never hand-writes any of the above — is **planned**.
 ## Reference
 
 - **Renderers + atomic swap**: `libs/streamlib-pack/src/static_registry.rs`.
-- **Verified crate-tarball reuse + byte-stable normalization**:
+- **Always-repackage crate emission + byte-stable normalization**:
   `libs/streamlib-pack/src/crate_tarball.rs` (`verify_crate_tarball`,
   `obtain_crate_tarball`, `normalize_crate_tarball`,
   `crate_content_fingerprint`, `finalize_crate_tarball`).

--- a/docs/learnings/cargo-crate-vcs-info-nondeterminism.md
+++ b/docs/learnings/cargo-crate-vcs-info-nondeterminism.md
@@ -49,11 +49,20 @@ mode / uid / gid and GNU long-name handling are inherited, not
 synthesized), and re-gzip with a fixed header (MTIME 0, no embedded
 filename). The result is a pure function of source content.
 
-The normalize step must be **idempotent** — a registry emit reuses a
-previously-packaged `.crate` from `target/package/` across runs, so
-normalize re-runs on an already-stripped crate and must reproduce
+The normalize step must be **idempotent** — re-emitting a crate at an
+unchanged version must reproduce byte-identical output (no sparse-index or
+consumer-lockfile churn), and the same-version immutability guard fingerprints
+both the freshly packaged crate and the prior *served* crate through the same
+normalization, so a legacy already-stripped served crate must re-normalize to
 identical bytes. Cloning cargo's headers and re-emitting through the same
 `tar` writer each time makes it a fixed point.
+
+> ~~a registry emit reuses a previously-packaged `.crate` from `target/package/`
+> across runs, so normalize re-runs on an already-stripped crate~~ — Superseded
+> 2026-07-12: the closure emit no longer reuses `target/package` as a content
+> cache; `obtain_crate_tarball` always repackages each crate from source
+> (`target/package` is cargo scratch). Idempotency is still required, but for
+> the served-tree fingerprint comparison above, not for a cross-run reuse path.
 
 Two consequences worth pinning with tests:
 

--- a/libs/streamlib-pack/src/crate_tarball.rs
+++ b/libs/streamlib-pack/src/crate_tarball.rs
@@ -1,11 +1,13 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Integrity-verified reuse + byte-stable normalization of `cargo package`
+//! Integrity-verified emission + byte-stable normalization of `cargo package`
 //! crate tarballs.
 //!
-//! - [`verify_crate_tarball`] structurally validates a `.crate` before reuse,
-//!   [`obtain_crate_tarball`] reuses a verified one or repackages on failure.
+//! - [`verify_crate_tarball`] structurally validates a `.crate`;
+//!   [`obtain_crate_tarball`] always repackages via `cargo package` — the
+//!   source of truth for crate bytes — and verifies the fresh artifact, so a
+//!   content-stale `target/package` leftover is never emitted.
 //! - [`normalize_crate_tarball`] rewrites a `.crate` into a form whose bytes are
 //!   a pure function of source content, and [`finalize_crate_tarball`] pairs
 //!   that with an immutability guard so re-emitting an unchanged release yields
@@ -54,8 +56,8 @@ pub enum CrateTarballIntegrityError {
 /// trailer check), every tar entry enumerates to EOF, the crate's
 /// `{name}-{version}/Cargo.toml` entry is present, and — when `expected_sha256`
 /// is given — the tarball bytes hash to it. The checksum arm is exercised by
-/// the tests and reserved for the byte-stable-emission follow-up; the emit
-/// reuse path calls with `None`.
+/// the tests and reserved for the byte-stable-emission follow-up; the emit's
+/// post-repackage integrity check calls with `None`.
 pub fn verify_crate_tarball(
     path: &Path,
     name: &str,
@@ -115,63 +117,40 @@ pub fn verify_crate_tarball(
     Ok(())
 }
 
-/// How [`obtain_crate_tarball`] produced the verified tarball.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CrateTarballProvenance {
-    /// A pre-existing candidate verified and was reused — `repackage` never ran.
-    ReusedVerified,
-    /// The tarball was (re)packaged via `repackage`. `discarded_corrupt` is
-    /// true when a pre-existing candidate failed verification and was deleted
-    /// first.
-    Repackaged { discarded_corrupt: bool },
-}
-
-/// Ensure a verified `.crate` exists at `candidate` for `(name, version)`,
-/// reusing a structurally-valid pre-existing tarball or invoking `repackage`
-/// to produce a fresh one.
+/// Produce a fresh, structurally-verified `.crate` at `candidate` for
+/// `(name, version)` by always invoking `repackage` (`cargo package`).
 ///
-/// - candidate verifies → reuse, `repackage` is skipped.
-/// - candidate exists but fails → log the typed reason, delete it, `repackage`,
-///   and verify the fresh artifact.
-/// - candidate absent → `repackage` and verify the fresh artifact.
+/// `cargo package` is the single source of truth for crate bytes:
+/// `target/package/<crate>-<version>.crate` is cargo scratch, **not** a
+/// streamlib-managed content cache. Any pre-existing artifact is dropped up
+/// front and `repackage` always runs, so the emitted `.crate` always reflects
+/// current source at that version — a structurally-valid but content-stale
+/// leftover (e.g. an old-ABI tarball cached under a version whose source has
+/// since moved) can never be handed back verbatim. Dropping the leftover first
+/// also means a `repackage` that returns `Ok` without writing surfaces as a
+/// hard verification error rather than silently verifying stale bytes.
 ///
-/// A freshly-packaged artifact that still fails verification is a hard error
-/// (a `cargo package` / toolchain bug), surfaced loudly rather than emitted
-/// into the tree.
+/// A freshly-packaged artifact that fails verification is a hard error (a
+/// `cargo package` / toolchain bug), surfaced loudly rather than emitted into
+/// the tree.
 pub fn obtain_crate_tarball(
     candidate: &Path,
     name: &str,
     version: &str,
     repackage: impl FnOnce() -> anyhow::Result<()>,
-) -> anyhow::Result<CrateTarballProvenance> {
-    let discarded_corrupt = if candidate.is_file() {
-        match verify_crate_tarball(candidate, name, version, None) {
-            Ok(()) => {
-                tracing::debug!(
-                    crate_name = name,
-                    version,
-                    path = %candidate.display(),
-                    "reusing verified crate tarball"
-                );
-                return Ok(CrateTarballProvenance::ReusedVerified);
-            }
-            Err(error) => {
-                tracing::warn!(
-                    crate_name = name,
-                    version,
-                    path = %candidate.display(),
-                    %error,
-                    "cached crate tarball failed integrity verification; repackaging"
-                );
-                std::fs::remove_file(candidate).with_context(|| {
-                    format!("remove corrupt crate tarball {}", candidate.display())
-                })?;
-                true
-            }
+) -> anyhow::Result<()> {
+    // `target/package` is cargo scratch, never a trusted cache: drop any
+    // pre-existing artifact so `repackage` owns the bytes we verify and a
+    // no-write repackage can't be masked by a stale leftover.
+    match std::fs::remove_file(candidate) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("remove stale crate scratch tarball {}", candidate.display())
+            });
         }
-    } else {
-        false
-    };
+    }
 
     repackage().with_context(|| format!("repackage crate {name} {version}"))?;
 
@@ -182,7 +161,7 @@ pub fn obtain_crate_tarball(
         )
     })?;
 
-    Ok(CrateTarballProvenance::Repackaged { discarded_corrupt })
+    Ok(())
 }
 
 /// The vcs-info entry cargo embeds inside a `.crate` when packaging from a git
@@ -235,8 +214,8 @@ fn canonical_tar_bytes(path: &Path, name: &str, version: &str) -> anyhow::Result
 /// Rewrite the `.crate` at `path` into its byte-stable canonical form for
 /// `(name, version)`: strip `.cargo_vcs_info.json` and re-gzip with a fixed
 /// header (MTIME 0, no embedded filename). Idempotent — re-normalizing an
-/// already-normalized crate reproduces identical bytes, so the emit reuse path
-/// can re-run it on a cached tarball.
+/// already-normalized crate reproduces identical bytes, so re-emitting a crate
+/// at an unchanged version yields byte-identical output.
 pub fn normalize_crate_tarball(path: &Path, name: &str, version: &str) -> anyhow::Result<()> {
     let canonical = canonical_tar_bytes(path, name, version)?;
     let mut encoder = GzBuilder::new()
@@ -339,16 +318,42 @@ mod tests {
         format!("[package]\nname = \"{name}\"\nversion = \"{version}\"\n")
     }
 
-    /// Write a valid `.crate` (Cargo.toml + a source file) at `path`.
-    fn write_valid_crate(path: &Path, name: &str, version: &str) {
+    /// Write a valid `.crate` (Cargo.toml + a source file) at `path` whose
+    /// `src/lib.rs` carries `lib_contents` — the distinguishing marker used to
+    /// prove which source a `.crate` was built from.
+    fn write_valid_crate_with_lib(path: &Path, name: &str, version: &str, lib_contents: &[u8]) {
         let manifest = manifest_bytes(name, version);
         let manifest_entry = format!("{name}-{version}/Cargo.toml");
         let lib_entry = format!("{name}-{version}/src/lib.rs");
         let raw = build_tar_bytes(&[
             (manifest_entry.as_str(), manifest.as_bytes()),
-            (lib_entry.as_str(), b"// lib\n"),
+            (lib_entry.as_str(), lib_contents),
         ]);
         gzip_to_file(path, &raw);
+    }
+
+    /// Write a valid `.crate` (Cargo.toml + a source file) at `path`.
+    fn write_valid_crate(path: &Path, name: &str, version: &str) {
+        write_valid_crate_with_lib(path, name, version, b"// lib\n");
+    }
+
+    /// Read back the `{name}-{version}/src/lib.rs` bytes from a `.crate` — the
+    /// source marker, for asserting which source a `.crate` was built from.
+    fn crate_lib_contents(path: &Path, name: &str, version: &str) -> Vec<u8> {
+        let want = format!("{name}-{version}/src/lib.rs");
+        let bytes = std::fs::read(path).unwrap();
+        let mut decoded = Vec::new();
+        GzDecoder::new(&bytes[..]).read_to_end(&mut decoded).unwrap();
+        let mut archive = tar::Archive::new(&decoded[..]);
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            if entry.path().unwrap().to_string_lossy() == want {
+                let mut data = Vec::new();
+                entry.read_to_end(&mut data).unwrap();
+                return data;
+            }
+        }
+        panic!("crate {} missing lib entry {want}", path.display());
     }
 
     fn candidate_path(dir: &Path, name: &str, version: &str) -> PathBuf {
@@ -418,27 +423,54 @@ mod tests {
         verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap();
     }
 
+    /// KEY (exit criterion): a structurally-VALID but content-STALE cached
+    /// tarball is NOT trusted — `repackage` always runs and the final artifact
+    /// is the fresh source, never the stale cache. This is the exact defect
+    /// that turned `pack → load` red (an ABI-4 `.crate` cached under a version
+    /// whose source moved to ABI 5, re-emitted verbatim).
+    ///
+    /// Mental revert: restore the `if candidate.is_file() { verify → return }`
+    /// fast-path and the closure never runs — `repackaged` stays false and the
+    /// final bytes equal the stale cache — so both assertions fail.
     #[test]
-    fn obtain_reuses_verified_without_repackaging() {
+    fn obtain_always_repackages_ignoring_valid_cached_tarball() {
         let dir = tempdir().unwrap();
         let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
-        write_valid_crate(&path, "streamlib-x", "0.5.0");
+        // A pre-existing candidate that is structurally VALID (verifies clean)
+        // but built from STALE source.
+        write_valid_crate_with_lib(&path, "streamlib-x", "0.5.0", b"// STALE source\n");
+        verify_crate_tarball(&path, "streamlib-x", "0.5.0", None)
+            .expect("sanity: the stale cache is structurally valid, so the old fast-path WOULD reuse it");
+        let stale_bytes = std::fs::read(&path).unwrap();
 
         let repackaged = Cell::new(false);
-        let provenance = obtain_crate_tarball(&path, "streamlib-x", "0.5.0", || {
+        obtain_crate_tarball(&path, "streamlib-x", "0.5.0", || {
             repackaged.set(true);
+            // Fresh `cargo package` writes DIFFERENT bytes at the same version.
+            write_valid_crate_with_lib(&path, "streamlib-x", "0.5.0", b"// FRESH source\n");
             Ok(())
         })
         .unwrap();
 
-        assert_eq!(provenance, CrateTarballProvenance::ReusedVerified);
-        assert!(!repackaged.get(), "repackage closure must NOT run for a verified reuse");
+        assert!(
+            repackaged.get(),
+            "a structurally-valid cached tarball must NOT be trusted — repackage always runs"
+        );
+        let final_bytes = std::fs::read(&path).unwrap();
+        assert_ne!(
+            final_bytes, stale_bytes,
+            "the emitted artifact must be the fresh package, never the stale cache"
+        );
+        assert_eq!(
+            crate_lib_contents(&path, "streamlib-x", "0.5.0"),
+            b"// FRESH source\n",
+            "the emitted artifact must carry current source"
+        );
+        verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap();
     }
 
-    /// Core negative test: a truncated cached tarball is discarded and
-    /// repackaged. Mentally reverting the fix (verify → `is_file()`) makes the
-    /// truncated file "trusted", so `repackage` would never run and this test
-    /// fails.
+    /// A corrupt pre-existing candidate is likewise dropped and repackaged into
+    /// a valid fresh artifact (no error from the leftover).
     #[test]
     fn obtain_repackages_truncated_cached_tarball() {
         let dir = tempdir().unwrap();
@@ -454,12 +486,10 @@ mod tests {
             .unwrap()
             .set_len(20)
             .unwrap();
-
-        // The truncated file is genuinely rejected by the verifier.
         assert!(verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).is_err());
 
         let repackaged = Cell::new(false);
-        let provenance = obtain_crate_tarball(&path, "streamlib-x", "0.5.0", || {
+        obtain_crate_tarball(&path, "streamlib-x", "0.5.0", || {
             repackaged.set(true);
             write_valid_crate(&path, "streamlib-x", "0.5.0");
             Ok(())
@@ -467,10 +497,6 @@ mod tests {
         .unwrap();
 
         assert!(repackaged.get(), "repackage MUST run for a corrupt cached tarball");
-        assert_eq!(
-            provenance,
-            CrateTarballProvenance::Repackaged { discarded_corrupt: true }
-        );
         // Final artifact is valid.
         verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap();
     }
@@ -534,7 +560,7 @@ mod tests {
         assert!(!path.exists());
 
         let repackaged = Cell::new(false);
-        let provenance = obtain_crate_tarball(&path, "streamlib-x", "0.5.0", || {
+        obtain_crate_tarball(&path, "streamlib-x", "0.5.0", || {
             repackaged.set(true);
             write_valid_crate(&path, "streamlib-x", "0.5.0");
             Ok(())
@@ -542,10 +568,6 @@ mod tests {
         .unwrap();
 
         assert!(repackaged.get());
-        assert_eq!(
-            provenance,
-            CrateTarballProvenance::Repackaged { discarded_corrupt: false }
-        );
         verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap();
     }
 

--- a/libs/streamlib-pack/src/static_registry.rs
+++ b/libs/streamlib-pack/src/static_registry.rs
@@ -491,14 +491,14 @@ fn emit_cargo_closure(opts: &EmitOptions, staging: &Path) -> Result<()> {
             .workspace_root
             .join("target/package")
             .join(crate_artifact_filename(&c.name, &version));
-        // Reuse a previously-packaged `.crate` only after structural
-        // verification (a truncated leftover from an aborted emit is
-        // discarded + repackaged, never trusted). A verified reuse skips
-        // `cargo package` — and with it that crate's live registry-dep
-        // validation — but the emitted index line is rendered from the
-        // reused tarball's own manifest, so the tree stays correct; a
-        // per-version tarball is treated as immutable for reuse.
-        let provenance = crate::crate_tarball::obtain_crate_tarball(
+        // Always repackage: freshness is owned by `cargo package`, the single
+        // source of truth for crate bytes. `target/package` is cargo scratch,
+        // not a trusted content cache — so a structurally-valid but
+        // content-stale leftover (e.g. an old-ABI tarball cached under a
+        // version whose source has since moved) is never emitted verbatim.
+        // The fresh package validates its own live registry-dep set, and the
+        // emitted index line is rendered from its bundled manifest.
+        crate::crate_tarball::obtain_crate_tarball(
             &crate_file,
             &c.name,
             &version,
@@ -522,8 +522,7 @@ fn emit_cargo_closure(opts: &EmitOptions, staging: &Path) -> Result<()> {
         tracing::info!(
             crate_name = %c.name,
             version = %version,
-            ?provenance,
-            "static-registry cargo-closure crate tarball obtained"
+            "static-registry cargo-closure crate tarball repackaged"
         );
         // Normalize the tarball to a byte-stable, source-only form (strip the
         // git-HEAD-derived `.cargo_vcs_info.json`, re-gzip with a fixed header)


### PR DESCRIPTION
## What & why

The static-registry cargo-closure emit trusted a **structurally-valid but content-STALE** `target/package/<crate>-<version>.crate`. `obtain_crate_tarball`'s `ReusedVerified` fast-path verified a pre-existing tarball *structurally only* (gzip decodes, tar enumerates, `Cargo.toml` present) and reused it — so a tarball whose bytes predated current source at the same version could be emitted verbatim. This is exactly what turned `pack → load` red after the ABI bump: a cached **ABI-4** `streamlib-plugin-abi-0.5.1.crate` was reused while source was **ABI-5** `0.5.1`, so the emitted registry crate disagreed with the compiled host. #1279's `rm -rf target/package` is the CI stop-gap; this is the durable engine-layer fix.

## The decision — approach (a1), "make the wrong way impossible"

Rather than making reuse *content-aware* (fingerprint the cached tarball vs a fresh package), **drop the reuse fast-path entirely**. `obtain_crate_tarball` now:

1. drops any pre-existing `target/package` artifact,
2. **always** runs `repackage` (`cargo package`),
3. verifies the fresh output.

`cargo package` is the single source of truth for crate bytes; `target/package` is cargo scratch, **not** a streamlib-managed content cache — so there is no reuse cache left to go stale. Dropping the leftover first also means a `repackage` that returns `Ok` without writing surfaces as a hard verification error instead of silently verifying stale bytes.

### Why source-hash-keyed reuse was rejected as fragile

The obvious alternative — keep reuse but key it on a source hash — is a trap: 35 member manifests inherit `workspace = true`, and the committed workspace `Cargo.lock` is packaged into each crate. A crate's real inputs therefore live **outside its own directory**, so a source-tree hash would silently miss a central dep / lock bump and reintroduce the exact stale-emit bug this fixes.

### Narrowing #1249's just-landed reuse arm

`ReusedVerified` is the reuse arm that landed in #1249. Since `obtain_crate_tarball` no longer reuses, the `CrateTarballProvenance` enum's only remaining variant would be a degenerate `Repackaged` — so the enum is **dropped as dead surface** and the fn returns `Result<()>`. This is a visible narrowing of just-landed code; surfacing it explicitly. `verify_crate_tarball`, `normalize_crate_tarball`, `crate_content_fingerprint`, and `finalize_crate_tarball`'s byte-stability + same-version *served-tree* immutability guard are **untouched** — they keep their value (a same-source repackage still normalizes to an identical checksum, so no index/lockfile churn).

The load-time ABI handshake (#1247) is **not touched** — the emit reuse was the defect, not the handshake.

## Files

- `libs/streamlib-pack/src/crate_tarball.rs` — reshape `obtain_crate_tarball` (always repackage + verify), drop `CrateTarballProvenance`, add the exit-criterion negative test + updated tests.
- `libs/streamlib-pack/src/static_registry.rs` — update the call site (drop the `provenance` binding) + the reuse comment to the always-repackage contract.
- `docs/architecture/static-registry.md` — sweep the three sections that described the now-removed reuse cache to current shipped state.
- `docs/learnings/cargo-crate-vcs-info-nondeterminism.md` — supersede the stale "emit reuses `target/package` across runs" rationale (strikethrough + dated marker); normalize idempotency now hangs off the served-tree fingerprint compare.

## Tests

`cargo test -p streamlib-pack --lib` — **76 passed, 0 failed**.

New KEY test (the exit criterion) `obtain_always_repackages_ignoring_valid_cached_tarball`: places a structurally-VALID but content-STALE candidate, invokes `obtain_crate_tarball` with a closure that writes DIFFERENT bytes at the same version, and asserts the closure RAN and the final artifact is the fresh source (not the stale cache).

**Mental-revert (run, not just reasoned):** temporarily restoring the `if candidate.is_file() { verify → return }` fast-path makes the KEY test FAIL at `"a structurally-valid cached tarball must NOT be trusted — repackage always runs"` — the stale candidate short-circuits, the closure never runs. Reverted; suite green again.

Independent pr-review-gate (Opus): **PASS**, no issues — confirmed the mental-revert holds, the enum drop is grep-clean, CI + the #1247 ABI handshake are untouched, and the byte-stable machinery has no false-positive immutability refusal.

## Follow-up (not done here)

`rm -rf target/package` in `.github/workflows/static-registry.yml` and `check-pack-load.yml` is now **redundant** for correctness (exit criterion 2 permits it staying as defense-in-depth). Removing it coordinates with the CI owners (exec-1278 / plan-1290) — intentionally **not** touched in this PR.

Closes #1282

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB
