### PR TITLE
feat(cli): streamlib add/remove — npm-style single-package adoption with catalog discovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
     # from the static registry by version, and each carries its own
     # `[workspace]` self-root. Only `libs/*` + `xtask` form this workspace.
     # Build a package/example with `cd <dir> && cargo build`, or via
-    # `streamlib pkg install` / runtime `Strategy::Registry` for packages.
+    # `streamlib add` / runtime `Strategy::Registry` for packages.
     # Exception to the "packages/* are not members" rule above: the
     # test-fixtures packages are INTERNAL test infrastructure, not
     # distributable units. The engine integration tests build them in-place

--- a/docs/architecture/package-development-model.md
+++ b/docs/architecture/package-development-model.md
@@ -262,6 +262,26 @@ lockfile. The release-completeness check *rides* materialize — a partial
 registry release fails install before any lockfile is written. Network at
 install time is expected.
 
+**`add` / `remove` — single-package adoption (the `npm install <pkg>`).**
+`add(pkg_ref, version_req, orchestrator, sink, options)`
+([`libs/streamlib-engine/src/core/runtime/add.rs`](../../libs/streamlib-engine/src/core/runtime/add.rs),
+CLI `streamlib add`) adopts ONE published package: it resolves the range to a
+concrete version from the registry, materializes that version into the
+installed-package cache (`cache/packages/<name>-<version>`), and records it in
+the installed-set record `packages.yaml` (`InstalledPackageManifest`). It does
+**not** touch app code, any app `streamlib.yaml`, or `streamlib-app.lock` —
+that is `install`'s job. Afterward a bare `Runner::add_module(ident)`
+(`Strategy::InstalledCache`) finds the package offline. `add` returns a
+catalog-backed report — the package's processors and their typed ports, read
+from the registry catalog artifacts (a catalog-less tree degrades to "no
+catalog metadata", the add still succeeds). It also accepts a local `.slpkg`
+(`add_slpkg`). Registry config resolves `options.registry → from_env →
+DEFAULT_REGISTRY_URL`, so the bare CLI works with zero configuration.
+`remove(pkg_ref)` (CLI `streamlib remove`) reverses it: un-record from
+`packages.yaml`, evict the cache slot. `add` / `remove` are the per-package
+front door; `install` is the whole-app-tree front door — both feed the same
+installed-package cache the runtime loads from.
+
 **Locked run — offline, pinned, verified.**
 `Runner::add_modules_from_lockfile` builds a `LockedResolution` from the
 lockfile and forces every dependency edge through it: each edge becomes a
@@ -336,6 +356,11 @@ Stated honestly; verify against current code before relying on any.
   `libs/streamlib-engine/src/core/runtime/module_loader/locked.rs`,
   `libs/streamlib-idents/src/lockfile.rs`,
   `libs/streamlib-engine/src/core/streamlib_home.rs`.
+- **Add / remove (single-package adoption)**:
+  `libs/streamlib-engine/src/core/runtime/add.rs`,
+  `libs/streamlib-engine/src/core/config/installed_packages_manifest.rs`
+  (`packages.yaml`), `libs/streamlib-cli/src/commands/add.rs` (CLI wrapper +
+  catalog summary), `libs/streamlib-idents/src/catalog.rs` (`CatalogClient`).
 - **Related docs**: [`runtime-module-materialization.md`](runtime-module-materialization.md)
   (the one materialize path), [`static-registry.md`](static-registry.md)
   (the static registry backend, by-version resolution + catalog),

--- a/libs/streamlib-cli/Cargo.toml
+++ b/libs/streamlib-cli/Cargo.toml
@@ -22,7 +22,7 @@ streamlib = { path = "../streamlib-sdk", version = "0.6.0", registry = "tatolab"
 streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.6.0", registry = "tatolab" }
 
 # Manifest + workspace + dependency-spec types for `streamlib pack` /
-# `pkg install` / `pkg remove` — typed PackageRef, Manifest schema, etc.
+# `streamlib add` / `streamlib remove` — typed PackageRef, Manifest schema, etc.
 streamlib-idents = { path = "../streamlib-idents", version = "0.6.0", registry = "tatolab" }
 
 # Cargo-build orchestration helpers — `streamlib pack`'s auto-build branch
@@ -40,7 +40,7 @@ clap = { version = "4.5", features = ["derive"] }
 # Async runtime
 tokio.workspace = true
 
-# HTTP client (used by `streamlib pkg install` for HTTP URL sources)
+# HTTP client (used by `streamlib add` for HTTP URL sources)
 reqwest = { version = "0.12", features = ["json"] }
 
 # Serialization

--- a/libs/streamlib-cli/src/commands/add.rs
+++ b/libs/streamlib-cli/src/commands/add.rs
@@ -1,0 +1,241 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib add` / `streamlib remove` — single-package adoption, the
+//! `npm install <pkg>` of streamlib.
+//!
+//! Thin CLI wrappers over the programmatic [`streamlib::sdk::runtime::add`] /
+//! [`remove`] so the CLI and any embedding host share one adoption flow. `add`
+//! resolves a package by version from the registry (or extracts a local
+//! `.slpkg`), materializes it into the installed-package cache, records it in
+//! `packages.yaml`, and prints a catalog-backed summary of the processors it
+//! contributes and their typed ports. `remove` reverses it.
+//!
+//! This is deliberately NOT `streamlib install`: it touches no app code, no
+//! app `streamlib.yaml`, and no application lockfile.
+
+use anyhow::{Context, Result};
+use streamlib::sdk::runtime::{
+    add as sdk_add, add_slpkg as sdk_add_slpkg, remove as sdk_remove, AddOptions, AddReport,
+    BuildEvent, BuildEventSink, BuildStream,
+};
+use streamlib::sdk::PolyglotBuildOrchestrator;
+use streamlib_idents::{CatalogSchemaRef, PackageRef, SemVerRange};
+
+/// Routes the orchestrator's build diagnostics to the CLI's stdout/stderr
+/// during `add` (mirrors `install`'s interactive progress).
+struct CliBuildSink;
+
+impl BuildEventSink for CliBuildSink {
+    fn emit(&self, event: BuildEvent) {
+        match event {
+            BuildEvent::Started { language } => println!("    [{language}] build started"),
+            BuildEvent::Line { stream, line } => match stream {
+                BuildStream::Stdout => println!("    {line}"),
+                BuildStream::Stderr => eprintln!("    {line}"),
+            },
+            BuildEvent::Finished { language } => println!("    [{language}] build finished"),
+            _ => {}
+        }
+    }
+}
+
+/// Add one package: a registry ref `@org/name[@version-req]` (resolved by
+/// version from the registry, with a catalog-backed summary), a local `.slpkg`
+/// path, or an HTTP URL.
+pub async fn add(spec: &str) -> Result<()> {
+    let orchestrator = PolyglotBuildOrchestrator::default();
+    let sink = CliBuildSink;
+
+    let report = if spec.starts_with('@') {
+        let (pkg_ref, version_req) = parse_registry_ref(spec)?;
+        println!("Adding {pkg_ref} ({version_req})…");
+        // Zero-env by default: AddOptions::default() resolves the registry from
+        // the environment, else the first-party DEFAULT_REGISTRY_URL.
+        sdk_add(&pkg_ref, &version_req, &orchestrator, &sink, &AddOptions::default())
+            .map_err(|e| anyhow::anyhow!("add failed: {e}"))?
+    } else if spec.starts_with("http://") || spec.starts_with("https://") {
+        let path = download_to_temp(spec).await?;
+        println!("Adding {}…", path.display());
+        let report = sdk_add_slpkg(&path, &orchestrator, &sink)
+            .map_err(|e| anyhow::anyhow!("add failed: {e}"))?;
+        let _ = std::fs::remove_file(&path);
+        report
+    } else {
+        let path = std::path::PathBuf::from(spec);
+        if !path.exists() {
+            anyhow::bail!("File not found: {spec}");
+        }
+        println!("Adding {}…", path.display());
+        sdk_add_slpkg(&path, &orchestrator, &sink)
+            .map_err(|e| anyhow::anyhow!("add failed: {e}"))?
+    };
+
+    print_add_report(&report);
+    Ok(())
+}
+
+/// Remove one installed package by its canonical `@org/name` ref — un-record it
+/// from `packages.yaml` and evict its cache slot.
+pub fn remove(name: &str) -> Result<()> {
+    let pkg_ref = parse_canonical_package_ref(name)?;
+    let report = sdk_remove(&pkg_ref).map_err(|e| anyhow::anyhow!("remove failed: {e}"))?;
+    println!("Removed {} v{}", report.package, report.version);
+    if report.cache_dir_removed {
+        println!("  Evicted cache: {}", report.cache_dir.display());
+    }
+    Ok(())
+}
+
+/// Pretty-print the add outcome plus the catalog-backed discovery summary.
+fn print_add_report(report: &AddReport) {
+    println!();
+    let verb = if report.already_present { "Already added" } else { "Added" };
+    println!("{verb} {} v{}", report.package, report.version);
+    println!("  Cache: {}", report.cache_dir.display());
+
+    match &report.catalog {
+        Some(catalog) if !catalog.processors.is_empty() => {
+            println!();
+            println!("Processors ({}):", catalog.processors.len());
+            for proc in &catalog.processors {
+                let desc = proc
+                    .description
+                    .as_deref()
+                    .map(|d| format!(" — {d}"))
+                    .unwrap_or_default();
+                println!("  {}{}  [{:?}]", proc.name, desc, proc.runtime);
+                if !proc.inputs.is_empty() {
+                    println!("    Inputs:");
+                    for port in &proc.inputs {
+                        println!("      - {} ({})", port.name, schema_label(&port.schema));
+                    }
+                }
+                if !proc.outputs.is_empty() {
+                    println!("    Outputs:");
+                    for port in &proc.outputs {
+                        println!("      - {} ({})", port.name, schema_label(&port.schema));
+                    }
+                }
+                if let Some(cfg) = &proc.config {
+                    println!("    Config: {} ({})", cfg.name, cfg.schema);
+                }
+            }
+        }
+        Some(_) => {
+            println!();
+            println!("Catalog present, but the package declares no processors.");
+        }
+        None => {
+            println!();
+            println!("No catalog metadata (this registry publishes no catalog for the package).");
+        }
+    }
+}
+
+/// A human-readable label for a catalog port schema: `any` for the wildcard,
+/// the fully-qualified `@org/name/Type@version` for a concrete schema.
+fn schema_label(schema: &CatalogSchemaRef) -> String {
+    match schema {
+        CatalogSchemaRef::Any => "any".to_string(),
+        CatalogSchemaRef::Schema(ident) => ident.to_string(),
+    }
+}
+
+/// Parse `@org/name[@version-req]` → `(PackageRef, SemVerRange)`. A missing
+/// version requirement means [`SemVerRange::Any`] (`*`, the newest release).
+fn parse_registry_ref(spec: &str) -> Result<(PackageRef, SemVerRange)> {
+    let body = &spec[1..]; // strip the leading '@'
+    let (ref_str, version_req) = match body.split_once('@') {
+        Some((r, v)) => (
+            format!("@{r}"),
+            SemVerRange::from_str(v)
+                .map_err(|e| anyhow::anyhow!("invalid version '{v}' in '{spec}': {e}"))?,
+        ),
+        None => (format!("@{body}"), SemVerRange::Any),
+    };
+    Ok((parse_canonical_package_ref(&ref_str)?, version_req))
+}
+
+/// Convert a canonical-form string (`@org/name`) into a typed [`PackageRef`]
+/// via the official Deserialize path, wrapping the round-trip with a
+/// CLI-friendly error.
+fn parse_canonical_package_ref(arg: &str) -> Result<PackageRef> {
+    serde_yaml::from_value::<PackageRef>(serde_yaml::Value::String(arg.to_string())).with_context(
+        || {
+            format!(
+                "Invalid canonical package reference '{arg}'. Expected `@org/name` form \
+                 (e.g. `@tatolab/core`)."
+            )
+        },
+    )
+}
+
+/// Download an HTTP(S) `.slpkg` to a temp file and return its path.
+async fn download_to_temp(url: &str) -> Result<std::path::PathBuf> {
+    println!("Downloading {url}…");
+    let response = reqwest::get(url)
+        .await
+        .with_context(|| format!("Failed to download {url}"))?;
+    if !response.status().is_success() {
+        anyhow::bail!("Download failed: HTTP {} for {url}", response.status());
+    }
+    let bytes = response
+        .bytes()
+        .await
+        .with_context(|| "Failed to read response body")?;
+    let temp_path = std::env::temp_dir().join("streamlib-add-download.slpkg");
+    std::fs::write(&temp_path, &bytes)
+        .with_context(|| format!("Failed to write temp file {}", temp_path.display()))?;
+    Ok(temp_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_registry_ref_without_version_is_any() {
+        let (pkg_ref, req) = parse_registry_ref("@tatolab/foo").unwrap();
+        assert_eq!(pkg_ref.org.as_str(), "tatolab");
+        assert_eq!(pkg_ref.name.as_str(), "foo");
+        // No `@version` suffix ⇒ the newest release.
+        assert_eq!(req, SemVerRange::Any);
+    }
+
+    #[test]
+    fn parse_registry_ref_with_version_parses_range() {
+        let (pkg_ref, req) = parse_registry_ref("@tatolab/foo@^1.2.0").unwrap();
+        assert_eq!(pkg_ref.name.as_str(), "foo");
+        assert_eq!(req, SemVerRange::from_str("^1.2.0").unwrap());
+    }
+
+    #[test]
+    fn parse_registry_ref_rejects_bad_version() {
+        // A malformed version requirement must fail loud, not silently become Any.
+        assert!(parse_registry_ref("@tatolab/foo@not-a-version").is_err());
+    }
+
+    #[test]
+    fn parse_canonical_package_ref_rejects_bare_name() {
+        // The canonical `@org/name` form is required — a bare short name is
+        // ambiguous across orgs and must be rejected.
+        assert!(parse_canonical_package_ref("foo").is_err());
+        assert!(parse_canonical_package_ref("@tatolab/foo").is_ok());
+    }
+
+    #[test]
+    fn schema_label_renders_any_and_concrete() {
+        assert_eq!(schema_label(&CatalogSchemaRef::Any), "any");
+        let ident = streamlib_idents::SchemaIdent::new(
+            streamlib_idents::Org::new("tatolab").unwrap(),
+            streamlib_idents::Package::new("core").unwrap(),
+            streamlib_idents::TypeName::new("VideoFrame").unwrap(),
+            streamlib_idents::SemVer::new(1, 0, 0),
+        );
+        assert_eq!(
+            schema_label(&CatalogSchemaRef::Schema(ident)),
+            "@tatolab/core/VideoFrame@1.0.0"
+        );
+    }
+}

--- a/libs/streamlib-cli/src/commands/install.rs
+++ b/libs/streamlib-cli/src/commands/install.rs
@@ -19,7 +19,7 @@ use streamlib::sdk::runtime::{install, BuildEvent, BuildEventSink, BuildStream, 
 use streamlib::sdk::PolyglotBuildOrchestrator;
 
 /// Routes the orchestrator's build diagnostics to the CLI's stdout/stderr
-/// during `install` (mirrors `pkg install`'s interactive progress).
+/// during `install` (mirrors `streamlib add`'s interactive progress).
 struct CliBuildSink;
 
 impl BuildEventSink for CliBuildSink {

--- a/libs/streamlib-cli/src/commands/mod.rs
+++ b/libs/streamlib-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+pub mod add;
 pub mod generate;
 pub mod install;
 pub mod link;

--- a/libs/streamlib-cli/src/commands/pkg.rs
+++ b/libs/streamlib-cli/src/commands/pkg.rs
@@ -2,180 +2,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //! Package management commands.
+//!
+//! Single-package adoption (installing a published package, removing one) lives
+//! in the top-level `streamlib add` / `streamlib remove` verbs
+//! ([`super::add`]); `pkg` here is scoped to authoring artifacts of THIS
+//! package — build, publish, clean, inspect — plus `list`.
 
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use streamlib::engine_internal::core::{InstalledPackageEntry, InstalledPackageManifest, ProjectConfig};
-use streamlib::sdk::runtime::{
-    extract_slpkg_to_cache, host_target_triple, BuildEvent, BuildEventSink, BuildOrchestrator,
-    BuildPolicy, BuildRequest, BuildSource, BuildStream,
-};
-use streamlib::sdk::PolyglotBuildOrchestrator;
-use streamlib_idents::{select_version, RegistryClient, RegistryConfig, SemVerRange};
+use streamlib::engine_internal::core::ProjectConfig;
+use streamlib::engine_internal::core::InstalledPackageManifest;
+use streamlib_idents::{RegistryClient, RegistryConfig};
 use streamlib_pack::{assemble_artifact, AssembleOptions, AssembleTarget, CargoProfile, PathDepPolicy};
-
-/// Routes the orchestrator's build diagnostics to the CLI's stdout/stderr
-/// during `pkg install` (the engine default sink re-emits via `tracing`,
-/// but the CLI prints progress directly for the interactive install flow).
-struct CliBuildSink;
-
-impl BuildEventSink for CliBuildSink {
-    fn emit(&self, event: BuildEvent) {
-        match event {
-            BuildEvent::Started { language } => {
-                println!("    [{language}] build started");
-            }
-            BuildEvent::Line { stream, line } => match stream {
-                BuildStream::Stdout => println!("    {line}"),
-                BuildStream::Stderr => eprintln!("    {line}"),
-            },
-            BuildEvent::Finished { language } => {
-                println!("    [{language}] build finished");
-            }
-            // `BuildEvent` is `#[non_exhaustive]`; a future variant prints nothing.
-            _ => {}
-        }
-    }
-}
-
-/// Install a package: a registry ref `@org/name[@version]`, a local `.slpkg`
-/// path, or an HTTP URL. A registry ref resolves + downloads the source-only
-/// `.slpkg` from the static generic store; the package is then built from
-/// source by the orchestrator (`AlwaysBuild`), identical to runtime
-/// `Strategy::Registry` resolution.
-pub async fn install(source: &str) -> Result<()> {
-    let slpkg_path = if source.starts_with('@') {
-        resolve_registry_ref_to_temp_slpkg(source)?
-    } else if source.starts_with("http://") || source.starts_with("https://") {
-        // Download to temp file
-        println!("Downloading {}...", source);
-        let response = reqwest::get(source)
-            .await
-            .with_context(|| format!("Failed to download {}", source))?;
-
-        if !response.status().is_success() {
-            anyhow::bail!("Download failed: HTTP {} for {}", response.status(), source);
-        }
-
-        let bytes = response
-            .bytes()
-            .await
-            .with_context(|| "Failed to read response body")?;
-
-        let temp_dir = std::env::temp_dir();
-        let temp_path = temp_dir.join("streamlib-pkg-download.slpkg");
-        std::fs::write(&temp_path, &bytes)
-            .with_context(|| format!("Failed to write temp file {}", temp_path.display()))?;
-        temp_path
-    } else {
-        let path = std::path::PathBuf::from(source);
-        if !path.exists() {
-            anyhow::bail!("File not found: {}", source);
-        }
-        path
-    };
-
-    println!("Installing {}...", slpkg_path.display());
-
-    // Extract to cache
-    let cache_dir = extract_slpkg_to_cache(&slpkg_path)
-        .map_err(|e| anyhow::anyhow!("Failed to extract package: {}", e))?;
-
-    // Load project config from extracted cache to get metadata
-    let config = ProjectConfig::load(&cache_dir)
-        .map_err(|e| anyhow::anyhow!("Failed to load package config: {}", e))?;
-
-    let package = config
-        .package
-        .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("Package missing [package] section in streamlib.yaml"))?;
-
-    // Provision the package's runtime via the build orchestrator — the same
-    // `materialize` path module-load drives at runtime. For a Python package
-    // this re-stages the extracted artifact and provisions its self-contained
-    // venv at `{staged_package_dir}/.venv/bin/python` as the tail of the
-    // materialize step. A package with no Python runtime is a no-op on the
-    // venv tail; a Rust package re-builds its cdylib (cargo short-circuits
-    // when clean). `AlwaysBuild` forces the venv provision regardless of any
-    // prior stale staging.
-    let has_python = config.processors.iter().any(|p| {
-        matches!(
-            p.runtime.language,
-            streamlib_processor_schema::ProcessorLanguage::Python
-        )
-    });
-    if has_python {
-        println!("  Provisioning Python venv via the build orchestrator...");
-    }
-    let request = BuildRequest {
-        package: streamlib_processor_schema::PackageRef::new(
-            package.org.clone(),
-            package.name.clone(),
-        ),
-        source: BuildSource::PackageDir(cache_dir.clone()),
-        policy: BuildPolicy::AlwaysBuild,
-        host_triple: host_target_triple().to_string(),
-    };
-    let orchestrator = PolyglotBuildOrchestrator::default();
-    let sink = CliBuildSink;
-    let staged = orchestrator
-        .materialize(&request, &sink)
-        .map_err(|e| anyhow::anyhow!("Failed to materialize package: {}", e))?;
-    // The orchestrator stages into the package cache slot
-    // (`cache/packages/<name>-<version>/`), the same slot
-    // `extract_slpkg_to_cache` wrote to. This is order-safe: `materialize`
-    // fully reads the source (assemble into a temp dir + provision the venv
-    // there) before its closing `atomic_swap` wipes-and-replaces the slot,
-    // so the extracted source is consumed before it's overwritten. Keep
-    // using the returned staged path below.
-    let cache_dir = staged.staged_dir;
-
-    // Add to installed packages manifest. Identity is the canonical
-    // `@org/name` PackageRef — the typed-key contract from #717 means
-    // entries with the same short name from different orgs no longer
-    // collide.
-    let mut manifest = InstalledPackageManifest::load()
-        .map_err(|e| anyhow::anyhow!("Failed to load packages manifest: {}", e))?;
-
-    let entry = InstalledPackageEntry {
-        name: streamlib_processor_schema::PackageRef::new(
-            package.org.clone(),
-            package.name.clone(),
-        ),
-        version: package.version,
-        description: package.description.clone(),
-        installed_from: source.to_string(),
-        installed_at: chrono::Utc::now().to_rfc3339(),
-        cache_dir: cache_dir
-            .file_name()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .to_string(),
-    };
-
-    manifest.add(entry);
-    manifest
-        .save()
-        .map_err(|e| anyhow::anyhow!("Failed to save packages manifest: {}", e))?;
-
-    println!();
-    println!("Installed {} v{}", package.name, package.version);
-    if let Some(desc) = &package.description {
-        println!("  {}", desc);
-    }
-    println!("  Cache: {}", cache_dir.display());
-
-    // Clean up the temp .slpkg we materialized (HTTP URL or registry ref).
-    if source.starts_with('@')
-        || source.starts_with("http://")
-        || source.starts_with("https://")
-    {
-        let _ = std::fs::remove_file(&slpkg_path);
-    }
-
-    Ok(())
-}
 
 /// Build THIS package (the current working directory) into a source-only
 /// `.slpkg`. Pure source bundling — no compilation, no prebuilt cdylib,
@@ -329,49 +168,6 @@ fn assemble_source_slpkg(
     .map_err(|e| anyhow::anyhow!("pack failed: {}", e))
 }
 
-/// Resolve a registry reference `@org/name[@version]` to a downloaded
-/// `.slpkg` in a temp file. Lists the package's published versions, selects
-/// the highest satisfying the (optional) version requirement, and downloads
-/// that version's source-only `.slpkg`. The caller's extract + materialize
-/// flow then builds it from source.
-fn resolve_registry_ref_to_temp_slpkg(source: &str) -> Result<std::path::PathBuf> {
-    let body = &source[1..]; // strip the leading '@'
-    let (ref_str, version_req) = match body.split_once('@') {
-        Some((r, v)) => (
-            format!("@{r}"),
-            SemVerRange::from_str(v)
-                .map_err(|e| anyhow::anyhow!("invalid version '{v}' in '{source}': {e}"))?,
-        ),
-        None => (format!("@{body}"), SemVerRange::Any),
-    };
-    let pkg_ref = parse_canonical_package_ref(&ref_str)?;
-    let registry = RegistryConfig::from_env().ok_or_else(|| {
-        anyhow::anyhow!(
-            "registry not configured: set STREAMLIB_REGISTRY_URL (e.g. file:///path/to/registry-tree) \
-             to install '{source}' from the registry"
-        )
-    })?;
-    let client = RegistryClient::new(&registry);
-    let available = client
-        .list_versions(&pkg_ref)
-        .map_err(|e| anyhow::anyhow!("listing versions of {ref_str}: {e}"))?;
-    let selected =
-        select_version(&pkg_ref, &version_req, &available).map_err(|e| anyhow::anyhow!("{e}"))?;
-    println!("Resolving {ref_str} → {selected} from {}…", registry.base_url);
-    let (bytes, url) = client
-        .download_slpkg(&pkg_ref, selected)
-        .map_err(|e| anyhow::anyhow!("downloading {ref_str}@{selected}: {e}"))?;
-    println!("  fetched {url} ({} bytes)", bytes.len());
-    let temp_path = std::env::temp_dir().join(format!(
-        "streamlib-install-{}-{}.slpkg",
-        pkg_ref.name.as_str(),
-        selected
-    ));
-    std::fs::write(&temp_path, &bytes)
-        .with_context(|| format!("writing downloaded slpkg to {}", temp_path.display()))?;
-    Ok(temp_path)
-}
-
 /// Inspect a .slpkg package without installing it.
 pub fn inspect(path: &std::path::Path) -> Result<()> {
     if !path.exists() {
@@ -457,8 +253,9 @@ pub fn list() -> Result<()> {
     if manifest.packages.is_empty() {
         println!("No packages installed.");
         println!();
-        println!("Install a package with:");
-        println!("  streamlib pkg install <path-to.slpkg>");
+        println!("Add a package with:");
+        println!("  streamlib add @org/name          # from the registry");
+        println!("  streamlib add ./path/to.slpkg    # from a local artifact");
         return Ok(());
     }
 
@@ -477,53 +274,3 @@ pub fn list() -> Result<()> {
     Ok(())
 }
 
-/// Remove an installed package. The argument must be the canonical
-/// `@org/name` form — the typed-key contract introduced in #717 means
-/// bare short names like `core` no longer disambiguate which package to
-/// remove.
-pub fn remove(name: &str) -> Result<()> {
-    let package_ref = parse_canonical_package_ref(name)?;
-
-    let mut manifest = InstalledPackageManifest::load()
-        .map_err(|e| anyhow::anyhow!("Failed to load packages manifest: {}", e))?;
-
-    let entry = match manifest.remove_by_ref(&package_ref) {
-        Some(e) => e,
-        None => {
-            anyhow::bail!("Package '{}' is not installed.", package_ref);
-        }
-    };
-
-    // Delete cache directory
-    let cache_dir = streamlib::engine_internal::core::get_cached_package_dir(&entry.cache_dir);
-    if cache_dir.exists() {
-        std::fs::remove_dir_all(&cache_dir)
-            .with_context(|| format!("Failed to remove cache dir {}", cache_dir.display()))?;
-        println!("Removed cache: {}", cache_dir.display());
-    }
-
-    // Save manifest
-    manifest
-        .save()
-        .map_err(|e| anyhow::anyhow!("Failed to save packages manifest: {}", e))?;
-
-    println!("Removed package '{}'.", package_ref);
-
-    Ok(())
-}
-
-/// Convert a CLI-supplied canonical-form string (`@org/name`) into a
-/// typed [`streamlib_processor_schema::PackageRef`] via the official
-/// Deserialize path. Wraps the round-trip with a CLI-friendly error so
-/// users see "expected `@org/name`" rather than a serde parse error.
-fn parse_canonical_package_ref(arg: &str) -> Result<streamlib_processor_schema::PackageRef> {
-    serde_yaml::from_value::<streamlib_processor_schema::PackageRef>(serde_yaml::Value::String(
-        arg.to_string(),
-    ))
-    .with_context(|| {
-        format!(
-            "Invalid canonical package reference '{}'. Expected `@org/name` form (e.g. `@tatolab/core`).",
-            arg
-        )
-    })
-}

--- a/libs/streamlib-cli/src/main.rs
+++ b/libs/streamlib-cli/src/main.rs
@@ -87,8 +87,9 @@ enum Commands {
     /// application lockfile. A subsequent run loads the pinned set offline via
     /// `Runner::add_modules_from_lockfile`.
     ///
-    /// To install a single package artifact (a `.slpkg`, URL, or registry
-    /// ref) rather than a project tree, use `streamlib pkg install`.
+    /// To adopt a single published package (resolve by version + materialize
+    /// into the local cache) rather than resolve a project tree, use
+    /// `streamlib add`.
     Install {
         /// Project directory (default: current working directory).
         project_dir: Option<PathBuf>,
@@ -96,6 +97,30 @@ enum Commands {
         /// Lockfile output path (default: <project_dir>/streamlib-app.lock).
         #[arg(long)]
         lockfile: Option<PathBuf>,
+    },
+
+    /// Add a single published package to the local installed set — the
+    /// `npm install <pkg>` of streamlib.
+    ///
+    /// Resolves `@org/name[@version-req]` to a concrete version from the
+    /// registry (zero config needed — it defaults to the first-party tree),
+    /// materializes it into the installed-package cache the runtime reads from,
+    /// records it in `packages.yaml`, and prints a catalog-backed summary of
+    /// the processors it contributes and their typed ports. Afterward a bare
+    /// `runtime.add_module(ident)` finds it offline. Also accepts a local
+    /// `.slpkg` path or an HTTP(S) URL. Touches no app code / app manifest /
+    /// app lockfile — for that, use `streamlib install`.
+    Add {
+        /// `@org/name[@version-req]` | path to a `.slpkg` | HTTP(S) URL
+        spec: String,
+    },
+
+    /// Remove a single package from the local installed set.
+    ///
+    /// Un-records `@org/name` from `packages.yaml` and evicts its cache slot.
+    Remove {
+        /// Canonical `@org/name` reference to remove.
+        name: String,
     },
 
     /// Manage installed packages
@@ -180,7 +205,7 @@ enum PkgCommands {
     ///
     /// Bundles source only — no compilation, no prebuilt cdylib, nothing
     /// path-related. The consumer builds it from source on their host
-    /// (`pkg install` / runtime registry resolution), pulling every dep
+    /// (`streamlib add` / runtime registry resolution), pulling every dep
     /// from the registry. The artifact is for hand-off (email it, hand it to
     /// a runtime); `publish` repacks independently.
     Build {
@@ -200,14 +225,6 @@ enum PkgCommands {
     /// Remove THIS package's build/pack artifacts (run inside the package):
     /// any `*.slpkg`, the prebuilt `lib/` dir, and generated `_generated_/` trees.
     Clean,
-    /// Install a package: a registry ref `@org/name[@version]` (resolved from
-    /// the registry and built from source), a local `.slpkg` path, or an HTTP URL.
-    /// To resolve + lock a whole project tree (with an application lockfile
-    /// for offline runs), use the top-level `streamlib install` instead.
-    Install {
-        /// `@org/name[@version]` | path to a `.slpkg` | HTTP URL
-        source: String,
-    },
     /// Inspect a .slpkg package (show manifest without installing)
     Inspect {
         /// Path to .slpkg file
@@ -215,11 +232,6 @@ enum PkgCommands {
     },
     /// List installed packages
     List,
-    /// Remove an installed package
-    Remove {
-        /// Package name to remove
-        name: String,
-    },
 }
 
 fn main() -> Result<()> {
@@ -278,14 +290,14 @@ async fn async_main(cli: Cli) -> Result<()> {
             project_dir,
             lockfile,
         }) => commands::install::run(project_dir.as_deref(), lockfile)?,
+        Some(Commands::Add { spec }) => commands::add::add(&spec).await?,
+        Some(Commands::Remove { name }) => commands::add::remove(&name)?,
         Some(Commands::Pkg { action }) => match action {
             PkgCommands::Build { output } => commands::pkg::build(output.as_deref())?,
             PkgCommands::Publish => commands::pkg::publish()?,
             PkgCommands::Clean => commands::pkg::clean()?,
-            PkgCommands::Install { source } => commands::pkg::install(&source).await?,
             PkgCommands::Inspect { path } => commands::pkg::inspect(&path)?,
             PkgCommands::List => commands::pkg::list()?,
-            PkgCommands::Remove { name } => commands::pkg::remove(&name)?,
         },
         Some(Commands::Link {
             checkout,

--- a/libs/streamlib-cli/tests/add_remove.rs
+++ b/libs/streamlib-cli/tests/add_remove.rs
@@ -1,0 +1,167 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! End-to-end `streamlib add` / `streamlib remove` against a scratch `file://`
+//! registry tree, driving the real `streamlib` binary and the real
+//! `PolyglotBuildOrchestrator`.
+//!
+//! This is the local-only integration counterpart to the engine's
+//! `core::runtime::add` unit tests (which inject a mock orchestrator). CI runs
+//! `cargo test --lib`, so this `tests/` binary is a developer-run gate: it
+//! locks the CLI wiring + the real materialize path + the catalog-summary
+//! print end-to-end, which the mock-orchestrator unit tests can't.
+//!
+//! It builds a real source-only schema `.slpkg` (no processors ⇒ the
+//! orchestrator's materialize is a cheap re-stage + schema codegen, no
+//! Rust/venv build), publishes it into a hand-built tree with a catalog, and
+//! shells the `streamlib` binary.
+
+use std::path::Path;
+use std::process::Command;
+
+use streamlib_pack::{assemble_artifact, AssembleOptions, AssembleTarget, CargoProfile, PathDepPolicy};
+
+const BIN: &str = env!("CARGO_BIN_EXE_streamlib");
+
+/// Create a schema-only `foo` package at `dir` (no processors, one owned
+/// schema — the smallest publishable package the orchestrator will materialize
+/// without a Rust/Python toolchain).
+fn write_foo_package(dir: &Path) {
+    std::fs::create_dir_all(dir.join("schemas")).unwrap();
+    std::fs::write(
+        dir.join("streamlib.yaml"),
+        "package:\n  org: tatolab\n  name: foo\n  version: 1.1.0\n  \
+         description: a demo add package\nschemas:\n  FooFrame:\n    file: schemas/foo_frame.yaml\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("schemas/foo_frame.yaml"),
+        "metadata:\n  type: FooFrame\n  description: \"A demo frame\"\nproperties:\n  \
+         width:\n    type: uint32\n  height:\n    type: uint32\n",
+    )
+    .unwrap();
+}
+
+/// Assemble `pkg_dir` into a source-only `.slpkg` under the tree, then write the
+/// version index + a valid catalog declaring one processor with typed ports.
+fn publish_foo_into_tree(pkg_dir: &Path, tree: &Path) {
+    let ver_dir = tree.join("slpkg/foo/1.1.0");
+    std::fs::create_dir_all(&ver_dir).unwrap();
+    assemble_artifact(
+        pkg_dir,
+        &AssembleTarget::Slpkg(ver_dir.join("foo.slpkg")),
+        &AssembleOptions {
+            no_build: false,
+            profile: CargoProfile::Release,
+            path_deps: PathDepPolicy::RejectPathPatches,
+        },
+        &(),
+    )
+    .expect("assemble source .slpkg");
+
+    std::fs::write(
+        tree.join("slpkg/foo/index.json"),
+        "{\"name\":\"foo\",\"vers\":\"1.1.0\"}\n",
+    )
+    .unwrap();
+    // `PackageCatalog.package` is the canonical `@org/name` STRING; a port's
+    // concrete schema is the structured `SchemaIdent` map.
+    std::fs::write(
+        ver_dir.join("foo.catalog.json"),
+        r#"{
+  "package": "@tatolab/foo",
+  "version": "1.1.0",
+  "processors": [
+    {
+      "name": "Foo", "description": "does foo", "runtime": "rust",
+      "inputs": [{"name": "video_in", "schema": "any", "read_mode": "skip_to_latest"}],
+      "outputs": [{"name": "video_out", "schema": {"org": "tatolab", "package": "foo", "type": "FooFrame", "version": "1.1.0"}}]
+    }
+  ]
+}"#,
+    )
+    .unwrap();
+}
+
+fn run(args: &[&str], registry: &str, home: &Path) -> std::process::Output {
+    Command::new(BIN)
+        .args(args)
+        .env("STREAMLIB_REGISTRY_URL", registry)
+        .env("STREAMLIB_HOME", home)
+        .output()
+        .expect("spawn streamlib binary")
+}
+
+#[test]
+fn add_records_prints_catalog_then_remove_evicts() {
+    let tree = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    let pkg = tempfile::tempdir().unwrap();
+    write_foo_package(pkg.path());
+    publish_foo_into_tree(pkg.path(), tree.path());
+
+    let registry = format!("file://{}", tree.path().display());
+
+    // --- add -----------------------------------------------------------
+    let out = run(&["add", "@tatolab/foo"], &registry, home.path());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "add failed: status={:?}\nstdout={stdout}\nstderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Catalog-backed discovery summary printed.
+    assert!(stdout.contains("Added @tatolab/foo v1.1.0"), "stdout: {stdout}");
+    assert!(stdout.contains("Processors (1):"), "stdout: {stdout}");
+    assert!(stdout.contains("Foo — does foo"), "stdout: {stdout}");
+    assert!(stdout.contains("video_in (any)"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("video_out (@tatolab/foo/FooFrame@1.1.0)"),
+        "stdout: {stdout}"
+    );
+
+    // Recorded in packages.yaml + materialized cache slot present.
+    let packages_yaml =
+        std::fs::read_to_string(home.path().join(".streamlib/packages.yaml")).unwrap();
+    assert!(packages_yaml.contains("@tatolab/foo"), "packages.yaml: {packages_yaml}");
+    let slot = home.path().join(".streamlib/cache/packages/foo-1.1.0");
+    assert!(slot.join("streamlib.yaml").is_file(), "cache slot missing manifest");
+
+    // `pkg list` reads packages.yaml offline (no registry) — proves the record
+    // is what a later offline consumer resolves against.
+    let list = run(&["pkg", "list"], "", home.path());
+    let list_out = String::from_utf8_lossy(&list.stdout);
+    assert!(list.status.success());
+    assert!(list_out.contains("@tatolab/foo"), "pkg list: {list_out}");
+
+    // --- remove --------------------------------------------------------
+    let out = run(&["remove", "@tatolab/foo"], &registry, home.path());
+    let rstdout = String::from_utf8_lossy(&out.stdout);
+    assert!(out.status.success(), "remove failed: {rstdout}");
+    assert!(rstdout.contains("Removed @tatolab/foo v1.1.0"), "stdout: {rstdout}");
+    assert!(!slot.exists(), "cache slot must be evicted");
+    let packages_yaml =
+        std::fs::read_to_string(home.path().join(".streamlib/packages.yaml")).unwrap();
+    assert!(!packages_yaml.contains("@tatolab/foo"), "still recorded: {packages_yaml}");
+
+    // Removing an absent package fails loud.
+    let out = run(&["remove", "@tatolab/foo"], &registry, home.path());
+    assert!(!out.status.success(), "remove of absent package must fail");
+}
+
+#[test]
+fn add_unsatisfiable_range_names_available_versions() {
+    let tree = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    let pkg = tempfile::tempdir().unwrap();
+    write_foo_package(pkg.path());
+    publish_foo_into_tree(pkg.path(), tree.path());
+
+    let registry = format!("file://{}", tree.path().display());
+    let out = run(&["add", "@tatolab/foo@^2.0.0"], &registry, home.path());
+    assert!(!out.status.success(), "^2 must not resolve");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    // The typed RegistryNoMatchingVersion names the available version.
+    assert!(stderr.contains("1.1.0"), "stderr should name available versions: {stderr}");
+}

--- a/libs/streamlib-engine/src/core/config/installed_packages_manifest.rs
+++ b/libs/streamlib-engine/src/core/config/installed_packages_manifest.rs
@@ -48,8 +48,8 @@ impl InstalledPackageManifest {
     ///   pre-#717 manifest with bare-name keys).
     ///
     /// In the latter two cases a warning is emitted; the on-disk slpkg
-    /// caches under `<STREAMLIB_HOME>/.streamlib/cache/` are preserved, so reinstalling
-    /// the relevant packages with `streamlib pkg install` repopulates the
+    /// caches under `<STREAMLIB_HOME>/.streamlib/cache/` are preserved, so re-adding
+    /// the relevant packages with `streamlib add` repopulates the
     /// manifest cleanly.
     pub fn load() -> Result<Self> {
         let path = get_installed_packages_manifest_path();
@@ -67,7 +67,7 @@ impl InstalledPackageManifest {
                 tracing::warn!(
                     "Installed-package manifest at {} has format_version={} but expected {}. \
                      Resetting (existing slpkg caches under <STREAMLIB_HOME>/.streamlib/cache/ are preserved; \
-                     reinstall packages with `streamlib pkg install` to repopulate).",
+                     re-add packages with `streamlib add` to repopulate).",
                     path.display(),
                     other.format_version,
                     CURRENT_FORMAT_VERSION,
@@ -79,7 +79,7 @@ impl InstalledPackageManifest {
                     "Installed-package manifest at {} could not be parsed against the \
                      current shape (likely a pre-#717 format with bare-name entries): {}. \
                      Resetting (existing slpkg caches under <STREAMLIB_HOME>/.streamlib/cache/ are preserved; \
-                     reinstall packages with `streamlib pkg install` to repopulate).",
+                     re-add packages with `streamlib add` to repopulate).",
                     path.display(),
                     e,
                 );

--- a/libs/streamlib-engine/src/core/runtime/add.rs
+++ b/libs/streamlib-engine/src/core/runtime/add.rs
@@ -1,0 +1,779 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `add` / `remove` — single-package adoption, the `npm install <pkg>` of
+//! streamlib.
+//!
+//! [`add`] takes ONE published package from "exists in the registry" to
+//! "usable by this runtime" in one step: resolve the caller's semver range to
+//! a concrete version from the registry, materialize that version into the
+//! installed-package cache the runtime reads from, and record it in the
+//! installed-set record (`packages.yaml`, [`InstalledPackageManifest`]).
+//! Afterward a bare `Runner::add_module(ident)` ([`Strategy::InstalledCache`])
+//! finds the package offline. [`add`] returns a catalog-backed
+//! [`AddReport`] — the processors the package contributes and their typed
+//! input/output ports, read from the registry catalog artifacts (not by
+//! opening the archive).
+//!
+//! [`remove`] is the inverse: un-record the package from `packages.yaml` and
+//! evict its cache slot.
+//!
+//! This is deliberately NOT [`install`](super::install): `install` resolves +
+//! locks a whole application *tree* (the app's `streamlib.yaml` →
+//! `streamlib-app.lock`). `add` touches neither app code, nor any app
+//! manifest, nor an application lockfile — it only mutates the local
+//! installed-set the runtime resolves bare `add_module` calls against.
+//!
+//! [`Strategy::InstalledCache`]: super::Strategy::InstalledCache
+//! [`InstalledPackageManifest`]: crate::core::config::InstalledPackageManifest
+
+use std::path::{Path, PathBuf};
+
+use streamlib_idents::{
+    select_version, CatalogClient, Manifest, PackageCatalog, PackageRef, RegistryClient,
+    RegistryConfig, ResolverError, SemVer, SemVerRange, DEFAULT_REGISTRY_URL,
+};
+
+use super::module_loader::host_target_triple;
+use super::{BuildEventSink, BuildOrchestrator, BuildPolicy, BuildRequest, BuildSource};
+use crate::core::config::{InstalledPackageEntry, InstalledPackageManifest};
+use crate::core::streamlib_home::{get_cached_package_dir, get_streamlib_data_dir};
+
+/// Knobs for [`add`]. Defaults are the ordinary "add this package" posture —
+/// resolve the registry with the zero-env default fallback, extract into the
+/// shared resolver cache, materialize with [`BuildPolicy::AlwaysBuild`].
+#[derive(Debug, Clone, Default)]
+pub struct AddOptions {
+    /// Registry to resolve from. Resolution order: this field, then
+    /// [`RegistryConfig::from_env`], then [`DEFAULT_REGISTRY_URL`]. So [`add`]
+    /// works with **zero environment variables** (it hits the first-party
+    /// default tree) or a `file://` override for tests / local mirrors. This is
+    /// the interim bridge until a persistent `streamlib registry use` config
+    /// lands.
+    pub registry: Option<RegistryConfig>,
+    /// Build policy for the materialize. Defaults to
+    /// [`BuildPolicy::AlwaysBuild`] — a freshly-downloaded registry `.slpkg`
+    /// is source-only, so the host build always runs.
+    pub materialize_policy: Option<BuildPolicy>,
+}
+
+/// Outcome of a successful [`add`].
+#[derive(Debug, Clone)]
+pub struct AddReport {
+    /// The canonical `@org/name` that was added.
+    pub package: PackageRef,
+    /// The concrete version the range resolved to.
+    pub version: SemVer,
+    /// `true` when the package was already recorded at exactly this version —
+    /// the add was a no-op materialize (idempotent). The catalog summary is
+    /// still fetched and returned.
+    pub already_present: bool,
+    /// The installed-package cache slot the package now lives in
+    /// (`cache/packages/<name>-<version>`).
+    pub cache_dir: PathBuf,
+    /// Catalog-backed summary of the package's processors + typed ports, read
+    /// from the registry catalog artifacts. `None` when the tree publishes no
+    /// catalog (a `pkg publish`-only tree) — the add still succeeds; discovery
+    /// simply degrades to "no catalog metadata".
+    pub catalog: Option<PackageCatalog>,
+}
+
+/// Per-failure-mode error from [`add`].
+#[derive(Debug, thiserror::Error)]
+pub enum AddError {
+    /// Listing the package's published versions, or selecting one satisfying
+    /// the requested range, failed. Wraps [`ResolverError`] — in particular
+    /// [`ResolverError::RegistryNoMatchingVersion`], which names the available
+    /// versions.
+    #[error("resolving '{package}' from the registry failed: {source}")]
+    Resolve {
+        package: PackageRef,
+        #[source]
+        source: ResolverError,
+    },
+
+    /// Downloading the resolved version's `.slpkg` failed.
+    #[error("downloading '{package}' v{version} failed: {source}")]
+    Download {
+        package: PackageRef,
+        version: SemVer,
+        #[source]
+        source: ResolverError,
+    },
+
+    /// Persisting the downloaded `.slpkg` bytes into the resolver cache failed.
+    #[error("persisting the downloaded .slpkg for '{package}' failed: {detail}")]
+    Persist { package: PackageRef, detail: String },
+
+    /// Extracting the `.slpkg` archive into the package cache failed.
+    #[error("extracting {} failed: {detail}", archive.display())]
+    Extract { archive: PathBuf, detail: String },
+
+    /// The materialized package's `streamlib.yaml` failed to parse or lacked a
+    /// `package:` block, so its identity/metadata couldn't be read.
+    #[error("reading the materialized manifest at {} failed: {detail}", dir.display())]
+    ManifestRead { dir: PathBuf, detail: String },
+
+    /// The injected [`BuildOrchestrator`] failed to materialize the package.
+    #[error("materializing '{package}' failed: {source}")]
+    Materialize {
+        package: PackageRef,
+        #[source]
+        source: super::BuildError,
+    },
+
+    /// Loading the installed-package manifest (`packages.yaml`) failed.
+    #[error("loading the installed-package manifest failed: {detail}")]
+    LoadManifest { detail: String },
+
+    /// Saving the installed-package manifest (`packages.yaml`) failed.
+    #[error("saving the installed-package manifest failed: {detail}")]
+    SaveManifest { detail: String },
+}
+
+/// Outcome of a successful [`remove`].
+#[derive(Debug, Clone)]
+pub struct RemoveReport {
+    /// The canonical `@org/name` that was removed.
+    pub package: PackageRef,
+    /// The version the removed entry was recorded at.
+    pub version: SemVer,
+    /// The cache slot that was evicted (`cache/packages/<name>-<version>`).
+    pub cache_dir: PathBuf,
+    /// `true` when the cache slot existed on disk and was deleted; `false`
+    /// when the record existed but the slot was already gone.
+    pub cache_dir_removed: bool,
+}
+
+/// Per-failure-mode error from [`remove`].
+#[derive(Debug, thiserror::Error)]
+pub enum RemoveError {
+    /// No installed-package record matches `@org/name` — nothing to remove.
+    #[error("'{package}' is not installed")]
+    NotInstalled { package: PackageRef },
+
+    /// Loading the installed-package manifest (`packages.yaml`) failed.
+    #[error("loading the installed-package manifest failed: {detail}")]
+    LoadManifest { detail: String },
+
+    /// Evicting the package's cache slot failed.
+    #[error("evicting the cache slot {} for '{package}' failed: {detail}", cache_dir.display())]
+    EvictCache {
+        package: PackageRef,
+        cache_dir: PathBuf,
+        detail: String,
+    },
+
+    /// Saving the installed-package manifest (`packages.yaml`) failed.
+    #[error("saving the installed-package manifest failed: {detail}")]
+    SaveManifest { detail: String },
+}
+
+/// Add ONE published package by semver range — resolve range→concrete from the
+/// registry, materialize into the installed-package cache, record in
+/// `packages.yaml`, and return a catalog-backed summary.
+///
+/// This does NOT touch app code, any app `streamlib.yaml`, or an application
+/// lockfile — it only mutates the local installed-set. Re-adding a package
+/// already recorded at the resolved version is idempotent
+/// ([`AddReport::already_present`] is `true`, no re-materialize).
+#[tracing::instrument(skip(orchestrator, sink, options), fields(package = %pkg_ref, req = %version_req))]
+pub fn add(
+    pkg_ref: &PackageRef,
+    version_req: &SemVerRange,
+    orchestrator: &dyn BuildOrchestrator,
+    sink: &dyn BuildEventSink,
+    options: &AddOptions,
+) -> std::result::Result<AddReport, AddError> {
+    let registry = resolve_registry(options);
+    tracing::info!(registry = %registry.base_url, "add: resolving package from registry");
+
+    let client = RegistryClient::new(&registry);
+    let available = client
+        .list_versions(pkg_ref)
+        .map_err(|source| AddError::Resolve {
+            package: pkg_ref.clone(),
+            source,
+        })?;
+    let selected =
+        select_version(pkg_ref, version_req, &available).map_err(|source| AddError::Resolve {
+            package: pkg_ref.clone(),
+            source,
+        })?;
+    tracing::info!(version = %selected, "add: selected version");
+
+    // Idempotency: an entry already pinned to exactly the selected version is a
+    // no-op materialize. Reuse the recorded slot; still fetch the catalog so
+    // the caller gets the same summary shape as a fresh add.
+    let existing_slot = InstalledPackageManifest::load()
+        .map_err(|e| AddError::LoadManifest {
+            detail: e.to_string(),
+        })?
+        .find_by_ref(pkg_ref)
+        .filter(|e| e.version == selected)
+        .map(|e| e.cache_dir.clone());
+
+    let (cache_dir, already_present) = if let Some(cache_key) = existing_slot {
+        tracing::info!(version = %selected, "add: already present at selected version — skipping materialize");
+        (get_cached_package_dir(&cache_key), true)
+    } else {
+        let policy = options.materialize_policy.unwrap_or(BuildPolicy::AlwaysBuild);
+        let extracted = download_and_extract(&client, pkg_ref, selected)?;
+        let (_ref, _version, staged_dir) = materialize_and_record(
+            extracted,
+            orchestrator,
+            sink,
+            policy,
+            format!("registry:{}", registry.base_url),
+        )?;
+        (staged_dir, false)
+    };
+
+    let catalog = fetch_catalog(&registry, pkg_ref, selected);
+
+    Ok(AddReport {
+        package: pkg_ref.clone(),
+        version: selected,
+        already_present,
+        cache_dir,
+        catalog,
+    })
+}
+
+/// Add ONE package from a local `.slpkg` archive (a hand-off bundle), rather
+/// than resolving it by version from the registry. Extracts, materializes, and
+/// records it exactly like [`add`], deriving the identity + version from the
+/// archive's own manifest. There is no catalog for a local artifact (the
+/// catalog lives in the registry tree), so [`AddReport::catalog`] is `None`.
+#[tracing::instrument(skip(orchestrator, sink), fields(archive = %archive.display()))]
+pub fn add_slpkg(
+    archive: &Path,
+    orchestrator: &dyn BuildOrchestrator,
+    sink: &dyn BuildEventSink,
+) -> std::result::Result<AddReport, AddError> {
+    let extracted = extract_slpkg(archive)?;
+    let (package, version, cache_dir) = materialize_and_record(
+        extracted,
+        orchestrator,
+        sink,
+        // A `.slpkg` may already carry a matching prebuilt; prefer it, else
+        // build the bundled source (identical to `Strategy::Slpkg`).
+        BuildPolicy::IfStale,
+        format!("slpkg:{}", archive.display()),
+    )?;
+    Ok(AddReport {
+        package,
+        version,
+        already_present: false,
+        cache_dir,
+        catalog: None,
+    })
+}
+
+/// Remove ONE installed package: un-record it from `packages.yaml` and evict
+/// its cache slot. Errors with [`RemoveError::NotInstalled`] when no record
+/// matches.
+#[tracing::instrument(fields(package = %pkg_ref))]
+pub fn remove(pkg_ref: &PackageRef) -> std::result::Result<RemoveReport, RemoveError> {
+    let mut manifest =
+        InstalledPackageManifest::load().map_err(|e| RemoveError::LoadManifest {
+            detail: e.to_string(),
+        })?;
+    let entry = manifest
+        .remove_by_ref(pkg_ref)
+        .ok_or_else(|| RemoveError::NotInstalled {
+            package: pkg_ref.clone(),
+        })?;
+
+    let cache_dir = get_cached_package_dir(&entry.cache_dir);
+    let cache_dir_removed = if cache_dir.exists() {
+        std::fs::remove_dir_all(&cache_dir).map_err(|e| RemoveError::EvictCache {
+            package: pkg_ref.clone(),
+            cache_dir: cache_dir.clone(),
+            detail: e.to_string(),
+        })?;
+        true
+    } else {
+        false
+    };
+
+    manifest.save().map_err(|e| RemoveError::SaveManifest {
+        detail: e.to_string(),
+    })?;
+
+    tracing::info!(version = %entry.version, removed_slot = cache_dir_removed, "remove: package un-recorded");
+    Ok(RemoveReport {
+        package: pkg_ref.clone(),
+        version: entry.version,
+        cache_dir,
+        cache_dir_removed,
+    })
+}
+
+/// Resolve the registry to use: an explicit `options.registry`, else the
+/// environment ([`RegistryConfig::from_env`]), else the first-party
+/// [`DEFAULT_REGISTRY_URL`]. Unlike [`install`](super::install) and
+/// [`Strategy::Registry`](super::Strategy::Registry) (which fail loud when no
+/// registry is configured), `add` defaults to the first-party tree so the bare
+/// `streamlib add @org/name` works with zero configuration.
+fn resolve_registry(options: &AddOptions) -> RegistryConfig {
+    options
+        .registry
+        .clone()
+        .or_else(RegistryConfig::from_env)
+        .unwrap_or_else(|| RegistryConfig {
+            base_url: DEFAULT_REGISTRY_URL.to_string(),
+        })
+}
+
+/// Download the selected version's `.slpkg`, persist it into the resolver
+/// cache, and extract it into the package cache slot. Returns the extracted
+/// directory.
+fn download_and_extract(
+    client: &RegistryClient<'_>,
+    pkg_ref: &PackageRef,
+    version: SemVer,
+) -> std::result::Result<PathBuf, AddError> {
+    let (bytes, url) = client
+        .download_slpkg(pkg_ref, version)
+        .map_err(|source| AddError::Download {
+            package: pkg_ref.clone(),
+            version,
+            source,
+        })?;
+    tracing::debug!(%url, bytes = bytes.len(), "add: downloaded .slpkg");
+    let archive = persist_slpkg(pkg_ref, version, &bytes)?;
+    extract_slpkg(&archive)
+}
+
+/// Persist downloaded `.slpkg` bytes into
+/// `<STREAMLIB_HOME>/.streamlib/resolver-cache/add/` so
+/// [`extract_slpkg`] can read them, with an atomic temp-then-rename publish.
+fn persist_slpkg(
+    pkg_ref: &PackageRef,
+    version: SemVer,
+    bytes: &[u8],
+) -> std::result::Result<PathBuf, AddError> {
+    let dir = get_streamlib_data_dir().join("resolver-cache").join("add");
+    let persist_err = |detail: String| AddError::Persist {
+        package: pkg_ref.clone(),
+        detail,
+    };
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| persist_err(format!("creating {} : {e}", dir.display())))?;
+    let target = dir.join(format!("{}-{}.slpkg", pkg_ref.name.as_str(), version));
+    let tmp = dir.join(format!("{}-{}.slpkg.partial", pkg_ref.name.as_str(), version));
+    std::fs::write(&tmp, bytes).map_err(|e| persist_err(format!("writing {} : {e}", tmp.display())))?;
+    std::fs::rename(&tmp, &target)
+        .map_err(|e| persist_err(format!("publishing {} : {e}", target.display())))?;
+    Ok(target)
+}
+
+/// Extract a `.slpkg` archive into its package cache slot, mapping the engine
+/// error into an [`AddError::Extract`] that names the archive.
+fn extract_slpkg(archive: &Path) -> std::result::Result<PathBuf, AddError> {
+    super::extract_slpkg_to_cache(archive).map_err(|e| AddError::Extract {
+        archive: archive.to_path_buf(),
+        detail: e.to_string(),
+    })
+}
+
+/// Materialize an extracted package directory through the orchestrator, then
+/// record it in `packages.yaml`. Reads the package's identity + metadata from
+/// its own `streamlib.yaml` (the authoritative source for what was
+/// materialized). Returns `(package, version, staged_dir)`.
+fn materialize_and_record(
+    extracted_dir: PathBuf,
+    orchestrator: &dyn BuildOrchestrator,
+    sink: &dyn BuildEventSink,
+    policy: BuildPolicy,
+    installed_from: String,
+) -> std::result::Result<(PackageRef, SemVer, PathBuf), AddError> {
+    let meta = Manifest::load(&extracted_dir)
+        .map_err(|e| AddError::ManifestRead {
+            dir: extracted_dir.clone(),
+            detail: e.to_string(),
+        })?
+        .package
+        .ok_or_else(|| AddError::ManifestRead {
+            dir: extracted_dir.clone(),
+            detail: "manifest has no `package:` block".into(),
+        })?;
+    let package = PackageRef::new(meta.org.clone(), meta.name.clone());
+    let version = meta.version;
+
+    let request = BuildRequest {
+        package: package.clone(),
+        source: BuildSource::PackageDir(extracted_dir),
+        policy,
+        host_triple: host_target_triple().to_string(),
+    };
+    let staged = orchestrator
+        .materialize(&request, sink)
+        .map_err(|source| AddError::Materialize {
+            package: package.clone(),
+            source,
+        })?;
+
+    let cache_key = staged
+        .staged_dir
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    let mut manifest =
+        InstalledPackageManifest::load().map_err(|e| AddError::LoadManifest {
+            detail: e.to_string(),
+        })?;
+    manifest.add(InstalledPackageEntry {
+        name: package.clone(),
+        version,
+        description: meta.description.clone(),
+        installed_from,
+        installed_at: super::install::rfc3339_utc_now(),
+        cache_dir: cache_key,
+    });
+    manifest.save().map_err(|e| AddError::SaveManifest {
+        detail: e.to_string(),
+    })?;
+
+    Ok((package, version, staged.staged_dir))
+}
+
+/// Fetch the catalog summary for `(pkg_ref, version)` from the registry tree.
+/// A missing catalog (or a transport error) degrades to `None` — an add never
+/// fails because discovery metadata is absent.
+fn fetch_catalog(
+    registry: &RegistryConfig,
+    pkg_ref: &PackageRef,
+    version: SemVer,
+) -> Option<PackageCatalog> {
+    let client = CatalogClient::new(registry.base_url.clone(), None);
+    match client.fetch_package_catalog(pkg_ref, &version) {
+        Ok(catalog) => catalog,
+        Err(e) => {
+            tracing::warn!(
+                package = %pkg_ref,
+                %version,
+                error = %e,
+                "add: catalog fetch failed — reporting no catalog metadata"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use streamlib_idents::{Org, Package};
+
+    // ---------------------------------------------------------------------
+    // Test harness: a mock orchestrator + a hand-built `file://` scratch tree.
+    //
+    // The mock orchestrator makes the extracted cache slot the staged dir
+    // WITHOUT compiling anything — the add flow (resolve → materialize →
+    // record → catalog → offline InstalledCache resolve) is exercised without
+    // a real Rust/Python build. `#[serial]` + a per-test `STREAMLIB_HOME`
+    // tempdir sandbox isolates `packages.yaml` and the cache between tests.
+    // ---------------------------------------------------------------------
+
+    /// Records the extracted slot as staged without building — enough to drive
+    /// the full add flow deterministically in-process.
+    struct MockOrchestrator;
+    impl BuildOrchestrator for MockOrchestrator {
+        fn materialize(
+            &self,
+            request: &BuildRequest,
+            _sink: &dyn BuildEventSink,
+        ) -> std::result::Result<super::super::StagedArtifact, super::super::BuildError> {
+            let dir = match &request.source {
+                BuildSource::PackageDir(p) => p.clone(),
+                other => {
+                    return Err(super::super::BuildError::UnsupportedSource(format!("{other:?}")))
+                }
+            };
+            Ok(super::super::StagedArtifact {
+                staged_dir: dir,
+                rebuilt: true,
+            })
+        }
+    }
+
+    struct NullSink;
+    impl BuildEventSink for NullSink {
+        fn emit(&self, _event: super::super::BuildEvent) {}
+    }
+
+    /// Restores `STREAMLIB_HOME` on drop so a sandboxed override doesn't leak
+    /// across `#[serial]` tests.
+    struct HomeGuard(Option<std::ffi::OsString>);
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: `#[serial]` makes these tests mutually exclusive.
+            unsafe {
+                match self.0.take() {
+                    Some(v) => std::env::set_var("STREAMLIB_HOME", v),
+                    None => std::env::remove_var("STREAMLIB_HOME"),
+                }
+            }
+        }
+    }
+    fn sandbox_home(dir: &Path) -> HomeGuard {
+        let prev = std::env::var_os("STREAMLIB_HOME");
+        unsafe {
+            std::env::set_var("STREAMLIB_HOME", dir);
+        }
+        HomeGuard(prev)
+    }
+
+    fn pkg_ref(org: &str, name: &str) -> PackageRef {
+        PackageRef::new(Org::new(org).unwrap(), Package::new(name).unwrap())
+    }
+
+    fn manifest_yaml(org: &str, name: &str, version: &str) -> String {
+        format!(
+            "package:\n  org: {org}\n  name: {name}\n  version: {version}\n  \
+             description: a test package\nprocessors:\n  - name: Foo\n    version: 1.0.0\n    \
+             description: does foo\n    runtime: rust\n    execution: manual\n    inputs: []\n    \
+             outputs: []\n"
+        )
+    }
+
+    /// Build a minimal source-only `.slpkg` (a zip with `streamlib.yaml`) at
+    /// `dest`. `extract_slpkg_to_cache` reads the manifest from it to derive
+    /// the cache slot, so a real archive is required (not just a stub file).
+    fn write_slpkg(dest: &Path, org: &str, name: &str, version: &str) {
+        let file = std::fs::File::create(dest).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let opts =
+            zip::write::FileOptions::<()>::default().compression_method(zip::CompressionMethod::Stored);
+        zip.start_file("streamlib.yaml", opts).unwrap();
+        std::io::Write::write_all(&mut zip, manifest_yaml(org, name, version).as_bytes()).unwrap();
+        zip.finish().unwrap();
+    }
+
+    /// Populate a `file://` registry tree with the package's `.slpkg` at each
+    /// version under `slpkg/<name>/<version>/<name>.slpkg`. Optionally write a
+    /// `.catalog.json` for the given `catalog_version`.
+    fn scratch_tree(
+        tree: &Path,
+        org: &str,
+        name: &str,
+        versions: &[&str],
+        catalog_version: Option<&str>,
+    ) {
+        for v in versions {
+            let dir = tree.join("slpkg").join(name).join(v);
+            std::fs::create_dir_all(&dir).unwrap();
+            write_slpkg(&dir.join(format!("{name}.slpkg")), org, name, v);
+        }
+        if let Some(cv) = catalog_version {
+            let catalog = PackageCatalog {
+                package: pkg_ref(org, name),
+                version: cv.parse().unwrap(),
+                processors: vec![streamlib_idents::CatalogProcessor {
+                    name: "Foo".into(),
+                    description: Some("does foo".into()),
+                    runtime: streamlib_idents::CatalogRuntime::Rust,
+                    entrypoint: None,
+                    config: None,
+                    inputs: vec![streamlib_idents::CatalogPort {
+                        name: "in".into(),
+                        description: None,
+                        schema: streamlib_idents::CatalogSchemaRef::Any,
+                        read_mode: None,
+                    }],
+                    outputs: vec![streamlib_idents::CatalogPort {
+                        name: "out".into(),
+                        description: None,
+                        schema: streamlib_idents::CatalogSchemaRef::Schema(
+                            streamlib_idents::SchemaIdent::new(
+                                Org::new(org).unwrap(),
+                                Package::new(name).unwrap(),
+                                streamlib_idents::TypeName::new("FooFrame").unwrap(),
+                                cv.parse().unwrap(),
+                            ),
+                        ),
+                        read_mode: None,
+                    }],
+                }],
+            };
+            let dir = tree.join("slpkg").join(name).join(cv);
+            std::fs::write(
+                dir.join(format!("{name}.catalog.json")),
+                serde_json::to_vec_pretty(&catalog).unwrap(),
+            )
+            .unwrap();
+        }
+    }
+
+    fn file_registry(tree: &Path) -> RegistryConfig {
+        RegistryConfig {
+            base_url: format!("file://{}", tree.display()),
+        }
+    }
+
+    fn opts(tree: &Path) -> AddOptions {
+        AddOptions {
+            registry: Some(file_registry(tree)),
+            materialize_policy: None,
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn add_selects_highest_records_and_resolves_offline() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = sandbox_home(home.path());
+        let tree = tempfile::tempdir().unwrap();
+        scratch_tree(tree.path(), "tatolab", "foo", &["1.0.0", "1.1.0"], Some("1.1.0"));
+
+        let pr = pkg_ref("tatolab", "foo");
+        let req = SemVerRange::from_str("^1.0.0").unwrap();
+        let report = add(&pr, &req, &MockOrchestrator, &NullSink, &opts(tree.path()))
+            .expect("add must succeed");
+
+        // Highest satisfying version selected.
+        assert_eq!(report.version, SemVer::new(1, 1, 0));
+        assert!(!report.already_present);
+        // Materialized into `cache/packages/foo-1.1.0/`.
+        assert!(report.cache_dir.ends_with("cache/packages/foo-1.1.0"));
+        assert!(report.cache_dir.join("streamlib.yaml").is_file());
+
+        // Recorded in packages.yaml under the canonical ref — AND the recorded
+        // slot exists on disk with its manifest. This is exactly what the
+        // `Strategy::InstalledCache` resolver's `lookup_installed_cache` step
+        // reads (`find_by_ref(pkg_ref).map(|e| get_cached_package_dir(&e.cache_dir))`),
+        // so it locks the offline-resolve contract without reaching into that
+        // private resolver. Mentally-revert `manifest.save()` in
+        // `materialize_and_record` and `find_by_ref` returns `None` here — the
+        // InstalledCache resolve would then miss with `ModuleNotFound`.
+        let manifest = InstalledPackageManifest::load().unwrap();
+        let entry = manifest.find_by_ref(&pr).expect("recorded");
+        assert_eq!(entry.version, SemVer::new(1, 1, 0));
+        assert_eq!(entry.cache_dir, "foo-1.1.0");
+        let offline_slot = get_cached_package_dir(&entry.cache_dir);
+        assert!(
+            offline_slot.join("streamlib.yaml").is_file(),
+            "the offline InstalledCache lookup must land a loadable slot"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn add_unsatisfiable_range_names_available_versions() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = sandbox_home(home.path());
+        let tree = tempfile::tempdir().unwrap();
+        scratch_tree(tree.path(), "tatolab", "foo", &["1.0.0", "1.1.0"], None);
+
+        let pr = pkg_ref("tatolab", "foo");
+        let req = SemVerRange::from_str("^2.0.0").unwrap();
+        let err = add(&pr, &req, &MockOrchestrator, &NullSink, &opts(tree.path()))
+            .expect_err("^2 matches nothing");
+        match err {
+            AddError::Resolve {
+                source: ResolverError::RegistryNoMatchingVersion { available, .. },
+                ..
+            } => {
+                assert!(available.contains("1.0.0"), "available: {available}");
+                assert!(available.contains("1.1.0"), "available: {available}");
+            }
+            other => panic!("expected Resolve(RegistryNoMatchingVersion), got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn add_is_idempotent_at_same_version() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = sandbox_home(home.path());
+        let tree = tempfile::tempdir().unwrap();
+        scratch_tree(tree.path(), "tatolab", "foo", &["1.1.0"], Some("1.1.0"));
+
+        let pr = pkg_ref("tatolab", "foo");
+        let req = SemVerRange::from_str("^1.0.0").unwrap();
+        let first = add(&pr, &req, &MockOrchestrator, &NullSink, &opts(tree.path())).unwrap();
+        assert!(!first.already_present);
+
+        let second = add(&pr, &req, &MockOrchestrator, &NullSink, &opts(tree.path())).unwrap();
+        assert!(second.already_present, "re-add at same version must be a no-op");
+        assert_eq!(second.version, SemVer::new(1, 1, 0));
+        // Still exactly one entry — `add` replaces same-ref, never duplicates.
+        let manifest = InstalledPackageManifest::load().unwrap();
+        assert_eq!(manifest.packages.iter().filter(|e| e.name == pr).count(), 1);
+        // Catalog still surfaced on the idempotent path.
+        assert!(second.catalog.is_some());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn add_surfaces_catalog_processors_and_ports() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = sandbox_home(home.path());
+        let tree = tempfile::tempdir().unwrap();
+        scratch_tree(tree.path(), "tatolab", "foo", &["1.1.0"], Some("1.1.0"));
+
+        let pr = pkg_ref("tatolab", "foo");
+        let req = SemVerRange::from_str("^1.0.0").unwrap();
+        let report = add(&pr, &req, &MockOrchestrator, &NullSink, &opts(tree.path())).unwrap();
+
+        // Mentally-revert the `fetch_catalog` call (return None) and this
+        // assertion fails — it locks that the summary is actually read.
+        let catalog = report.catalog.expect("catalog present on a catalog-carrying tree");
+        assert_eq!(catalog.processors.len(), 1);
+        let proc = &catalog.processors[0];
+        assert_eq!(proc.name, "Foo");
+        assert_eq!(proc.inputs.len(), 1);
+        assert_eq!(proc.outputs.len(), 1);
+        assert_eq!(proc.outputs[0].name, "out");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn add_degrades_gracefully_without_catalog() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = sandbox_home(home.path());
+        let tree = tempfile::tempdir().unwrap();
+        // No catalog written — a `pkg publish`-only tree.
+        scratch_tree(tree.path(), "tatolab", "foo", &["1.1.0"], None);
+
+        let pr = pkg_ref("tatolab", "foo");
+        let req = SemVerRange::from_str("^1.0.0").unwrap();
+        let report = add(&pr, &req, &MockOrchestrator, &NullSink, &opts(tree.path())).unwrap();
+        // Add still succeeds; discovery degrades to no metadata.
+        assert!(report.catalog.is_none());
+        assert_eq!(report.version, SemVer::new(1, 1, 0));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn remove_evicts_slot_and_unrecords() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = sandbox_home(home.path());
+        let tree = tempfile::tempdir().unwrap();
+        scratch_tree(tree.path(), "tatolab", "foo", &["1.1.0"], None);
+
+        let pr = pkg_ref("tatolab", "foo");
+        let req = SemVerRange::from_str("^1.0.0").unwrap();
+        let added = add(&pr, &req, &MockOrchestrator, &NullSink, &opts(tree.path())).unwrap();
+        assert!(added.cache_dir.is_dir());
+
+        let report = remove(&pr).expect("remove must succeed");
+        assert_eq!(report.version, SemVer::new(1, 1, 0));
+        assert!(report.cache_dir_removed);
+        assert!(!report.cache_dir.exists(), "cache slot must be gone");
+        assert!(InstalledPackageManifest::load().unwrap().find_by_ref(&pr).is_none());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn remove_absent_package_is_typed_error() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = sandbox_home(home.path());
+        let pr = pkg_ref("tatolab", "never-installed");
+        let err = remove(&pr).expect_err("removing an absent package must fail loud");
+        assert!(matches!(err, RemoveError::NotInstalled { .. }), "got {err:?}");
+    }
+}

--- a/libs/streamlib-engine/src/core/runtime/add.rs
+++ b/libs/streamlib-engine/src/core/runtime/add.rs
@@ -114,6 +114,21 @@ pub enum AddError {
     #[error("reading the materialized manifest at {} failed: {detail}", dir.display())]
     ManifestRead { dir: PathBuf, detail: String },
 
+    /// The registry served a `.slpkg` whose `package:` block declares a
+    /// different identity than the one requested (its store location and its
+    /// manifest disagree — a mis-published package). Fail loud instead of
+    /// recording a divergent identity in `packages.yaml`.
+    #[error(
+        "identity mismatch: requested '{requested}' v{requested_version} but the \
+         downloaded package declares '{found}' v{found_version}"
+    )]
+    IdentityMismatch {
+        requested: PackageRef,
+        requested_version: SemVer,
+        found: PackageRef,
+        found_version: SemVer,
+    },
+
     /// The injected [`BuildOrchestrator`] failed to materialize the package.
     #[error("materializing '{package}' failed: {source}")]
     Materialize {
@@ -202,29 +217,39 @@ pub fn add(
         })?;
     tracing::info!(version = %selected, "add: selected version");
 
-    // Idempotency: an entry already pinned to exactly the selected version is a
-    // no-op materialize. Reuse the recorded slot; still fetch the catalog so
-    // the caller gets the same summary shape as a fresh add.
+    // Idempotency: an entry already pinned to exactly the selected version whose
+    // cache slot still exists on disk is a no-op materialize. The `is_dir` guard
+    // is self-healing — a recorded-but-evicted slot (someone `rm -rf`'d the
+    // cache) falls through and re-materializes rather than reporting a present
+    // package whose slot is gone. Reuse fetches the catalog so the caller gets
+    // the same summary shape as a fresh add.
     let existing_slot = InstalledPackageManifest::load()
         .map_err(|e| AddError::LoadManifest {
             detail: e.to_string(),
         })?
         .find_by_ref(pkg_ref)
         .filter(|e| e.version == selected)
-        .map(|e| e.cache_dir.clone());
+        .map(|e| get_cached_package_dir(&e.cache_dir))
+        .filter(|dir| dir.is_dir());
 
-    let (cache_dir, already_present) = if let Some(cache_key) = existing_slot {
+    let (cache_dir, already_present) = if let Some(dir) = existing_slot {
         tracing::info!(version = %selected, "add: already present at selected version — skipping materialize");
-        (get_cached_package_dir(&cache_key), true)
+        (dir, true)
     } else {
         let policy = options.materialize_policy.unwrap_or(BuildPolicy::AlwaysBuild);
         let extracted = download_and_extract(&client, pkg_ref, selected)?;
+        // The registry download path is keyed by the requested `pkg_ref` + the
+        // selected version, so the materialized package's own manifest MUST
+        // declare that same identity — reconcile so a mis-published `.slpkg`
+        // (its `package:` block disagreeing with its store location) fails loud
+        // instead of silently recording a divergent identity.
         let (_ref, _version, staged_dir) = materialize_and_record(
             extracted,
             orchestrator,
             sink,
             policy,
             format!("registry:{}", registry.base_url),
+            Some((pkg_ref, selected)),
         )?;
         (staged_dir, false)
     };
@@ -252,6 +277,8 @@ pub fn add_slpkg(
     sink: &dyn BuildEventSink,
 ) -> std::result::Result<AddReport, AddError> {
     let extracted = extract_slpkg(archive)?;
+    // A local artifact has no external identity to reconcile against — its
+    // `package:` block IS the identity — so no `expected` check.
     let (package, version, cache_dir) = materialize_and_record(
         extracted,
         orchestrator,
@@ -260,6 +287,7 @@ pub fn add_slpkg(
         // build the bundled source (identical to `Strategy::Slpkg`).
         BuildPolicy::IfStale,
         format!("slpkg:{}", archive.display()),
+        None,
     )?;
     Ok(AddReport {
         package,
@@ -381,13 +409,19 @@ fn extract_slpkg(archive: &Path) -> std::result::Result<PathBuf, AddError> {
 /// Materialize an extracted package directory through the orchestrator, then
 /// record it in `packages.yaml`. Reads the package's identity + metadata from
 /// its own `streamlib.yaml` (the authoritative source for what was
-/// materialized). Returns `(package, version, staged_dir)`.
+/// materialized). When `expected` is `Some`, the manifest's identity must
+/// match it or [`AddError::IdentityMismatch`] is returned **before** anything
+/// is recorded — the registry path passes the requested `(pkg_ref, version)`
+/// so a mis-published `.slpkg` can't silently record a divergent identity; a
+/// local `.slpkg` passes `None` (its own manifest IS the identity). Returns
+/// `(package, version, staged_dir)`.
 fn materialize_and_record(
     extracted_dir: PathBuf,
     orchestrator: &dyn BuildOrchestrator,
     sink: &dyn BuildEventSink,
     policy: BuildPolicy,
     installed_from: String,
+    expected: Option<(&PackageRef, SemVer)>,
 ) -> std::result::Result<(PackageRef, SemVer, PathBuf), AddError> {
     let meta = Manifest::load(&extracted_dir)
         .map_err(|e| AddError::ManifestRead {
@@ -401,6 +435,17 @@ fn materialize_and_record(
         })?;
     let package = PackageRef::new(meta.org.clone(), meta.name.clone());
     let version = meta.version;
+
+    if let Some((expected_ref, expected_version)) = expected {
+        if &package != expected_ref || version != expected_version {
+            return Err(AddError::IdentityMismatch {
+                requested: expected_ref.clone(),
+                requested_version: expected_version,
+                found: package,
+                found_version: version,
+            });
+        }
+    }
 
     let request = BuildRequest {
         package: package.clone(),
@@ -775,5 +820,63 @@ mod tests {
         let pr = pkg_ref("tatolab", "never-installed");
         let err = remove(&pr).expect_err("removing an absent package must fail loud");
         assert!(matches!(err, RemoveError::NotInstalled { .. }), "got {err:?}");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn add_refetches_when_recorded_slot_is_evicted() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = sandbox_home(home.path());
+        let tree = tempfile::tempdir().unwrap();
+        scratch_tree(tree.path(), "tatolab", "foo", &["1.1.0"], None);
+        let pr = pkg_ref("tatolab", "foo");
+        let req = SemVerRange::from_str("^1.0.0").unwrap();
+
+        let first = add(&pr, &req, &MockOrchestrator, &NullSink, &opts(tree.path())).unwrap();
+        assert!(!first.already_present);
+        // Evict the cache slot out from under the recorded entry.
+        std::fs::remove_dir_all(&first.cache_dir).unwrap();
+        assert!(!first.cache_dir.exists());
+
+        // Mentally-revert the `.filter(|dir| dir.is_dir())` self-heal guard: the
+        // second add would report `already_present = true` pointing at a gone
+        // slot. With the guard it re-materializes and the slot is loadable again.
+        let second = add(&pr, &req, &MockOrchestrator, &NullSink, &opts(tree.path())).unwrap();
+        assert!(!second.already_present, "an evicted slot must re-materialize");
+        assert!(second.cache_dir.join("streamlib.yaml").is_file());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn add_identity_mismatch_fails_loud() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = sandbox_home(home.path());
+        let tree = tempfile::tempdir().unwrap();
+        // The store location says foo@1.1.0, but the `.slpkg`'s own manifest
+        // declares `bar` — a mis-published package.
+        let dir = tree.path().join("slpkg").join("foo").join("1.1.0");
+        std::fs::create_dir_all(&dir).unwrap();
+        write_slpkg(&dir.join("foo.slpkg"), "tatolab", "bar", "1.1.0");
+
+        let pr = pkg_ref("tatolab", "foo");
+        let req = SemVerRange::from_str("^1.0.0").unwrap();
+        // Mentally-revert the `expected` reconcile in `materialize_and_record`
+        // and this records `@tatolab/bar` under a `foo` request silently.
+        let err = add(&pr, &req, &MockOrchestrator, &NullSink, &opts(tree.path()))
+            .expect_err("a mis-published .slpkg must fail loud");
+        match err {
+            AddError::IdentityMismatch {
+                requested, found, ..
+            } => {
+                assert_eq!(requested.name.as_str(), "foo");
+                assert_eq!(found.name.as_str(), "bar");
+            }
+            other => panic!("expected IdentityMismatch, got {other:?}"),
+        }
+        // Nothing recorded on the failed add.
+        assert!(InstalledPackageManifest::load()
+            .unwrap()
+            .find_by_ref(&pr)
+            .is_none());
     }
 }

--- a/libs/streamlib-engine/src/core/runtime/install.rs
+++ b/libs/streamlib-engine/src/core/runtime/install.rs
@@ -258,8 +258,9 @@ fn package_ref_of(pkg: &ResolvedPackage) -> Option<PackageRef> {
 }
 
 /// Current UTC time as an RFC-3339 timestamp, dependency-free (the engine
-/// carries no `chrono` / `time` dep).
-fn rfc3339_utc_now() -> String {
+/// carries no `chrono` / `time` dep). Shared with [`super::add`] — both write
+/// the same `installed_at` field on `packages.yaml` entries.
+pub(super) fn rfc3339_utc_now() -> String {
     let secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())

--- a/libs/streamlib-engine/src/core/runtime/mod.rs
+++ b/libs/streamlib-engine/src/core/runtime/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+mod add;
 mod graph_change_listener;
 mod install;
 mod module_loader;
@@ -11,6 +12,9 @@ mod runtime;
 mod runtime_unique_id;
 mod status;
 
+pub use add::{
+    add, add_slpkg, remove, AddError, AddOptions, AddReport, RemoveError, RemoveReport,
+};
 pub use install::{install, InstallError, InstallOptions, InstallReport};
 pub use module_loader::{
     extract_slpkg_to_cache, host_target_triple, AddModuleError, AddedModule, ArtifactChecksum,

--- a/libs/streamlib-engine/src/core/runtime/module_loader/errors.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/errors.rs
@@ -16,8 +16,8 @@ pub enum AddModuleError {
     #[error(
         "Module '{package}' not found in the installed-package cache. \
          Load it from source with `add_module_with(_, Strategy::Path {{ build: \
-         BuildPolicy::IfStale, .. }})` (dev / runtime-authoring), or install it \
-         with `streamlib pkg install <slpkg>` (distribution)."
+         BuildPolicy::IfStale, .. }})` (dev / runtime-authoring), or add it \
+         with `streamlib add @org/name` (distribution)."
     )]
     ModuleNotFound {
         package: streamlib_idents::PackageRef,

--- a/libs/streamlib-engine/src/core/streamlib_home.rs
+++ b/libs/streamlib-engine/src/core/streamlib_home.rs
@@ -31,7 +31,7 @@ use std::path::PathBuf;
 ///     │   └── uv/                        # uv PyPI cache      (Python packages only)
 ///     ├── logs/<runtime_id>-<ts>.jsonl  # per-runtime JSONL logs
 ///     ├── resolver-cache/               # git / URL checkouts (Strategy::Git / Url)
-///     └── packages.yaml                 # installed-packages manifest (streamlib pkg install)
+///     └── packages.yaml                 # installed-packages manifest (streamlib add)
 /// ```
 ///
 /// Each subdir is created on demand by its consumer — an all-Rust,

--- a/libs/streamlib-pack/src/lib.rs
+++ b/libs/streamlib-pack/src/lib.rs
@@ -445,7 +445,7 @@ pub fn assemble_artifact(
     // A source-only `.slpkg` (the distribution artifact `streamlib pkg build`
     // / `publish` ships) carries NO prebuilt cdylib and NO local compilation —
     // the consumer builds it from the bundled source on their own host
-    // (`pkg install` / `Strategy::Registry`, AlwaysBuild), resolving every dep
+    // (`streamlib add` / `Strategy::Registry`, AlwaysBuild), resolving every dep
     // from the registry. Only the runtime orchestrator's `StagedDir` target
     // compiles the cdylib here, because that materialization IS the host build.
     if has_rust && matches!(target, AssembleTarget::StagedDir(_)) {

--- a/packages/network/Cargo.toml
+++ b/packages/network/Cargo.toml
@@ -5,7 +5,7 @@
 # independently to the static registry and resolves every dependency by
 # version from it — no workspace inheritance, no `path` deps. The empty
 # `[workspace]` table makes it its own workspace root so it builds off-tree
-# (e.g. inside the package cache during `pkg install`) without being mistaken
+# (e.g. inside the package cache during `streamlib add`) without being mistaken
 # for a stray member of an enclosing workspace.
 [package]
 name = "streamlib-network"


### PR DESCRIPTION
## What this delivers

`streamlib add @org/name[@version-req]` — the **`npm/pnpm install <pkg>`** of streamlib — plus a paired `streamlib remove`, with the real logic in an engine SDK function (`sdk::runtime::{add, add_slpkg, remove}`) and the CLI verbs as thin wrappers.

`add` takes ONE published package from "exists in the registry" to "usable by this runtime" in one step:
1. Resolve the semver range → a concrete version from the registry (`RegistryClient` list + `select_version`).
2. Materialize that version into the **installed-package cache the runtime reads from** (`cache/packages/<name>-<version>`), via the injected `BuildOrchestrator`.
3. Record it in the **installed-set record `packages.yaml`** (`InstalledPackageManifest`).
4. Print a **catalog-backed summary** — the package's processors and their typed input/output ports, read from the registry catalog artifacts (`CatalogClient`), not by opening the archive.

Afterward a bare `runtime.add_module(ident)` (`Strategy::InstalledCache`) finds the package offline. `remove` un-records it from `packages.yaml` and evicts the cache slot.

### The corrected model (this supersedes the stale issue body)

The original #1251 body described "write the dependency into the app manifest + run install + `streamlib-app.lock`". That was **wrong** and the prior attempt was halted for building it. The maintainer-confirmed model is npm-install:

| `add` / `remove` **touch** | `add` / `remove` **do NOT touch** |
|---|---|
| the local installed-package cache (`cache/packages/<name>-<version>`) | app code |
| the installed-set record `~/.streamlib/packages.yaml` | any app `streamlib.yaml` |
| | `streamlib-app.lock` (that stays `streamlib install`'s job) |

`streamlib install` (whole-app-tree resolve + lock) is untouched and unchanged; `add`/`remove` are the per-package front door. Both feed the same installed-package cache. The issue body has been updated in place (strikethrough + corrected model) per the issues-are-goals rule.

### Consolidation (pre-1.0, no back-compat)

- **Removed** `pkg install` / `pkg remove` (their registry-ref adoption folded into `streamlib add` / `remove`).
- **Kept** `pkg build` / `pkg publish` / `pkg clean` / `pkg inspect` / `pkg list`.
- `streamlib add` also accepts a **local `.slpkg` path** or an **HTTP(S) URL** (lifted from the old `pkg install`), via `sdk::runtime::add_slpkg`.
- Swept every stale `streamlib pkg install` reference (`ModuleNotFound` hint, `packages.yaml` warnings, several Cargo.toml / doc comments) to `streamlib add` per "no bad patterns left behind."

### Zero-env registry default + graceful catalog degradation

- Registry config resolves `options.registry → RegistryConfig::from_env → DEFAULT_REGISTRY_URL`, so the bare CLI works with **zero environment variables** (it hits the first-party default tree) or a `file://` override for tests / local mirrors.
- When the tree publishes no catalog (a `pkg publish`-only tree) or the catalog is malformed, the summary degrades to "No catalog metadata" and the add still succeeds.

## Robustness (from the review gate)

An independent Opus review flagged two edge-case gaps, both addressed in the second commit:
- **Fail loud on identity mismatch.** The registry download path is keyed by the requested `pkg_ref` + selected version, so the materialized package's own `package:` block must match; a mis-published `.slpkg` now returns the typed `AddError::IdentityMismatch` **before** recording, instead of silently recording a divergent identity. Mirrors the module loader's existing `ManifestIdentityMismatch` posture.
- **Self-heal an evicted slot.** The idempotency fast path now also requires the recorded cache slot to exist on disk; a recorded-but-`rm -rf`'d slot re-materializes rather than reporting a present package pointing at a gone slot (npm-style re-install-if-missing).

## Exit-criteria mapping (corrected)

- [x] **`streamlib add` resolves range→concrete, materializes into cache, records `packages.yaml`, prints catalog summary; does NOT touch app code / app manifest / app-lock. `streamlib remove` reverses it.** — `sdk::runtime::add`/`remove` + the CLI wrappers.
- [x] **The same operation is available programmatically with the same semantics** — the SDK functions are the primary API; the CLI is a thin wrapper.
- [x] **Zero environment variables** — satisfied via the `DEFAULT_REGISTRY_URL` fallback bridge (`options.registry → from_env → DEFAULT_REGISTRY_URL`). The *persistent* `streamlib registry use` config is **#1277**, out of scope here; this PR is the interim bridge.
- [x] **Bare `add_module` finds an added package offline afterward** — locked by unit test mirroring `lookup_installed_cache`; the CLI integration test shows `pkg list` reading `packages.yaml` offline.
- [x] **Catalog degrades gracefully; `pkg install`/`pkg remove` removed, `build/publish/clean/inspect/list` kept.**

## Tests

All run against a served static-fork registry (the workspace requires it to build).

- **9 engine unit tests** (`core::runtime::add::tests`) — mock orchestrator + hand-built `file://` scratch tree, `#[serial]` + `STREAMLIB_HOME` tempdir sandbox: select-highest + offline InstalledCache resolve (mental-revert `manifest.save` → offline resolve misses), unsatisfiable-range naming available versions, idempotency (one entry, no re-materialize), catalog surfaced (mental-revert `fetch_catalog` → fails) + graceful degradation on a catalog-less tree, remove + evict, remove-absent typed error, **identity-mismatch fails loud** (mental-revert the reconcile → records `bar` under a `foo` request), **evicted-slot re-materialize** (mental-revert the `is_dir` guard → reports present with a gone slot).
- **5 CLI parse unit tests** (`commands::add::tests`) — `parse_registry_ref` with/without version + bad version, canonical-ref rejects bare name, `schema_label` any + concrete.
- **2 CLI integration tests** (`tests/add_remove.rs`, local-only — CI runs `--lib`) — drive the real `streamlib` binary + real `PolyglotBuildOrchestrator` against a scratch tree: `add` prints the catalog summary (`Foo — does foo`, `video_in (any)`, `video_out (@tatolab/foo/FooFrame@1.1.0)`), records `packages.yaml`, materializes the slot, `pkg list` reads it offline; `remove` evicts + un-records; removing an absent package fails; unsatisfiable range names the available version.

Manual end-to-end run confirmed the full CLI flow (add → catalog print → remove → eviction) against a scratch `file://` tree.

## Review gate

Independent Opus review returned **DISCUSS** (three edge-case items). Item 3 (offline-resolve test coupling) the reviewer itself confirmed is NOT feel-good and acceptable given `--lib`-only CI — no change. Items 1 and 2 were real robustness gaps, addressed above with two new locking tests.

Closes #1251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB
