### PR TITLE
fix(registry): byte-stable vulkanalia fork emission at the canonical URL + regenerate Cargo.lock fork checksums

### DIFF
--- a/.github/actions/serve-static-fork/action.yml
+++ b/.github/actions/serve-static-fork/action.yml
@@ -87,3 +87,46 @@ runs:
         # The emitted tree is complete and fetchable through the live server.
         curl -fsS "http://127.0.0.1:${{ inputs.port }}/cargo/config.json" >/dev/null \
           || { echo "emitted tree not fetchable"; exit 1; }
+
+    - name: Assert emitted fork checksums match the committed Cargo.lock
+      shell: bash
+      run: |
+        set -euo pipefail
+        # The fork `.crate`s are byte-stable at the canonical URL (see
+        # scripts/registry/normalize_fork_crate.py), so each emitted sparse-index
+        # cksum must equal the checksum frozen in the committed root Cargo.lock.
+        # A mismatch means the fork rev moved without a lock regen — fail fast
+        # rather than let a downstream `--locked` resolve brick on it.
+        python3 - "${{ inputs.out }}/cargo" Cargo.lock <<'PY'
+        import json, re, sys
+        tree, lock = sys.argv[1], sys.argv[2]
+        # crate -> sparse-index shard path (fixed: the fork is these 3 crates).
+        forks = {
+            "vulkanalia": "vu/lk/vulkanalia",
+            "vulkanalia-sys": "vu/lk/vulkanalia-sys",
+            "vulkanalia-vma": "vu/lk/vulkanalia-vma",
+        }
+        locktext = open(lock).read()
+        def lock_cksum(name):
+            for blk in locktext.split("[[package]]"):
+                if re.search(rf'^name = "{re.escape(name)}"$', blk, re.MULTILINE):
+                    m = re.search(r'^checksum = "([0-9a-f]+)"$', blk, re.MULTILINE)
+                    return m.group(1) if m else None
+            return None
+        bad = False
+        for name, idx in forks.items():
+            emitted = json.loads(open(f"{tree}/{idx}").read().strip().splitlines()[-1])["cksum"]
+            locked = lock_cksum(name)
+            ok = emitted == locked
+            print(f"  {name:16} emit={emitted} lock={locked} [{'ok' if ok else 'MISMATCH'}]")
+            bad = bad or not ok
+        if bad:
+            sys.stderr.write(
+                "\nEmitted vulkanalia-fork checksum(s) diverge from the committed "
+                "Cargo.lock. Re-run scripts/registry/emit-static-fork.sh and update "
+                "the fork checksums in Cargo.lock "
+                "(see docs/architecture/static-registry.md).\n"
+            )
+            sys.exit(1)
+        print("All fork checksums match the committed Cargo.lock.")
+        PY

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6135,7 +6135,7 @@ dependencies = [
 name = "vulkanalia"
 version = "0.35.0"
 source = "sparse+https://registry.tatolab.com/cargo/"
-checksum = "316c22f54860d801fb0df291632d22684f4e02ffd0eece60c9546260ef4733cf"
+checksum = "59a05e8bcc40826ee0f28ed2d8f01c4cd7091e95f4bf93720df96c4040b890f6"
 dependencies = [
  "cocoa",
  "libloading 0.8.9",
@@ -6158,7 +6158,7 @@ dependencies = [
 name = "vulkanalia-vma"
 version = "0.9.0"
 source = "sparse+https://registry.tatolab.com/cargo/"
-checksum = "e5b7ad23b56a6078cdf89d871330263e00571bd02e17aa5132358d3837f57cdc"
+checksum = "0109fcf80379939a817ff7787a4f57c1775a11f5515f9acfc57e88f9fd341bed"
 dependencies = [
  "bitflags 2.11.0",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6135,7 +6135,7 @@ dependencies = [
 name = "vulkanalia"
 version = "0.35.0"
 source = "sparse+https://registry.tatolab.com/cargo/"
-checksum = "59a05e8bcc40826ee0f28ed2d8f01c4cd7091e95f4bf93720df96c4040b890f6"
+checksum = "4de872d936f05cf1616c798ccfda8ea3947b30576e45c999f4d981887ee741ef"
 dependencies = [
  "cocoa",
  "libloading 0.8.9",
@@ -6158,7 +6158,7 @@ dependencies = [
 name = "vulkanalia-vma"
 version = "0.9.0"
 source = "sparse+https://registry.tatolab.com/cargo/"
-checksum = "0109fcf80379939a817ff7787a4f57c1775a11f5515f9acfc57e88f9fd341bed"
+checksum = "ab1de2d3cfecf285a8675d17112fcaa97a5db378ad97373732f60e9c9930898d"
 dependencies = [
  "bitflags 2.11.0",
  "cc",

--- a/docs/architecture/static-registry.md
+++ b/docs/architecture/static-registry.md
@@ -83,6 +83,33 @@ siblings, closure crates) omit the `registry` key — detected data-driven from
 the packaged manifest's `registry-index` key; crates.io deps name
 `https://github.com/rust-lang/crates.io-index`.
 
+The fork `.crate` tarballs are **byte-stable at the canonical URL**, so their
+checksums are frozen in the committed root `Cargo.lock`. `cargo package` bakes
+the ephemeral serving-port index into each fork-sibling reference — the
+`registry-index` of `Cargo.toml` and the `source` of the bundled `Cargo.lock`
+both record `sparse+http://127.0.0.1:PORT/cargo/`, which makes the tarball's
+checksum port-coupled. `scripts/registry/normalize_fork_crate.py` rewrites those
+URLs to the canonical `[registries.tatolab]` index
+(`sparse+https://registry.tatolab.com/cargo/`, the single source of truth, read
+from `.cargo/config.toml`), drops any `.cargo_vcs_info.json`, re-tars (GNU
+format, cargo's headers cloned verbatim), and re-gzips as a **hand-framed** gzip
+stream — fixed 10-byte header (OS=0xff "unknown", XFL=0, MTIME=0), raw level-0
+(STORED) DEFLATE body, CRC32/ISIZE trailer. Hand-framing (rather than
+`gzip.compress`, whose OS byte is the emit host's zlib OS_CODE — `0x03` on
+Linux, other values elsewhere) makes the two rewritten crates byte-identical
+across operating system, zlib version, and Python version, so their committed
+checksums reproduce on any emit host. `emit-static-fork.sh` runs the normalizer
+on each emitted crate before rendering its sparse-index line, so the index
+checksum equals the served `.crate`'s sha256. `vulkanalia-sys` has no fork
+sibling → no port-coupled URL → it is left exactly as `cargo package` emits it
+(cargo's own byte-deterministic output on the Linux emit target); only
+`vulkanalia` and `vulkanalia-vma` are rewritten. The `serve-static-fork` CI
+action asserts each emitted fork index checksum equals the committed root
+`Cargo.lock`, so a fork-rev bump without a lock regen fails fast. The result: a
+canonical-source-preserving `[source]`-replacement `local-registry` mirror
+resolves the fork `--locked --offline` with no `CARGO_REGISTRIES_TATOLAB_INDEX`
+override.
+
 The **workspace release closure** rides the same tree via
 `cargo xtask static-registry emit --cargo-closure`: each closure crate is
 `cargo package`d in topo order against an ephemeral static server on the
@@ -342,7 +369,9 @@ consumer never hand-writes any of the above — is **planned**.
 - **Catalog**: `libs/streamlib-idents/src/catalog.rs` (protocol surface +
   `CatalogClient`), `libs/streamlib-pack/src/catalog.rs` (assembly).
 - **Fork bootstrap**: `scripts/registry/emit-static-fork.sh`,
-  `scripts/registry/render_cargo_index_line.py`.
+  `scripts/registry/render_cargo_index_line.py`,
+  `scripts/registry/normalize_fork_crate.py` (canonical-URL byte-stable
+  rewrite).
 - **Generator CLI**: `cargo xtask static-registry emit`.
 - **`.slpkg` `file://` transport**: `libs/streamlib-idents/src/registry.rs`.
 - **CI**: `.github/actions/serve-static-fork`, `.github/workflows/static-registry.yml`.

--- a/scripts/registry/emit-static-fork.sh
+++ b/scripts/registry/emit-static-fork.sh
@@ -69,6 +69,28 @@ command -v rsync  >/dev/null || fail "rsync not found"
 command -v git    >/dev/null || fail "git not found"
 command -v tar    >/dev/null || fail "tar not found"
 
+# The canonical registry-index URL the fork `.crate`s must bake — the single
+# source of truth is the workspace's [registries.tatolab] index, which is
+# identical to the lockfile `source` id. `cargo package` records the ephemeral
+# serving-port index in each fork-sibling dep instead; the normalize step
+# (below, per crate) rewrites it to this canonical URL so the emit is byte-
+# stable and port-independent. Never hardcode the URL here.
+CANON_INDEX="$("$PY" - "$ROOT/.cargo/config.toml" <<'PY'
+import sys
+path = sys.argv[1]
+try:
+    import tomllib  # py3.11+ stdlib
+    with open(path, "rb") as fh:
+        cfg = tomllib.load(fh)
+except ModuleNotFoundError:
+    import tomlkit  # dev/CI fallback for py<3.11
+    with open(path) as fh:
+        cfg = tomlkit.parse(fh.read())
+print(cfg["registries"]["tatolab"]["index"])
+PY
+)"
+[ -n "$CANON_INDEX" ] || fail "could not derive the canonical tatolab registry index from .cargo/config.toml"
+
 # --- obtain the fork checkout -------------------------------------------------
 scratch_root="$(mktemp -d)"
 trap 'rm -rf "$scratch_root"' EXIT
@@ -189,19 +211,33 @@ emit_one() {
   crate_file="$(find "$pkg_root" "$scratch" -type f -name "${name}-${version}.crate" 2>/dev/null | head -1)"
   [ -n "$crate_file" ] || fail "could not locate ${name}-${version}.crate after packaging"
 
-  local dest_dir="$CARGO_DIR/crates/${name}"
+  local dest_dir crate_dest
+  dest_dir="$CARGO_DIR/crates/${name}"
   mkdir -p "$dest_dir"
-  cp "$crate_file" "$dest_dir/${name}-${version}.crate"
+  crate_dest="$dest_dir/${name}-${version}.crate"
+  cp "$crate_file" "$crate_dest"
 
+  # Normalize the emitted crate (in place, not the scratch original) so its
+  # packaged Cargo.toml bakes the canonical registry-index URL rather than the
+  # ephemeral serving-port URL cargo recorded — byte-stable + port-independent.
+  # vulkanalia-sys has no fork-sibling dep, so the normalizer leaves it exactly
+  # as cargo emitted it; vulkanalia / vulkanalia-vma get their sibling
+  # registry-index rewritten and are re-gzipped deterministically (STORED).
+  "$PY" "$ROOT/scripts/registry/normalize_fork_crate.py" \
+    "$crate_dest" "$name" "$version" "$CANON_INDEX" \
+    || fail "normalize_fork_crate failed for ${name}"
+
+  # Checksum + index line come from the NORMALIZED dest (what consumers fetch),
+  # not the scratch original.
   local cksum
-  cksum="$(sha256sum "$crate_file" | awk '{print $1}')"
+  cksum="$(sha256sum "$crate_dest" | awk '{print $1}')"
 
   # Render the sparse index NDJSON line from the packaged Cargo.toml deps.
   local idx_rel idx_abs
   idx_rel="$(cargo_idx_path "$name")"
   idx_abs="$CARGO_DIR/$idx_rel"
   mkdir -p "$(dirname "$idx_abs")"
-  NAME="$name" VERSION="$version" CKSUM="$cksum" CRATE="$crate_file" \
+  NAME="$name" VERSION="$version" CKSUM="$cksum" CRATE="$crate_dest" \
     "$PY" "$ROOT/scripts/registry/render_cargo_index_line.py" >> "$idx_abs"
 }
 

--- a/scripts/registry/normalize_fork_crate.py
+++ b/scripts/registry/normalize_fork_crate.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Normalize a vulkanalia-fork `.crate` so the tatolab-registry URLs it embeds
+# are the CANONICAL registry-index instead of the ephemeral serving-port URL
+# that `cargo package` records. `cargo package` bakes the port it happened to
+# resolve fork siblings from into two files inside the `.crate`, and both make
+# the tarball's checksum port-coupled:
+#
+#   1. `<name>-<version>/Cargo.toml` — a fork-sibling dep (`registry = "tatolab"`)
+#      is normalized into `registry-index = "sparse+http://127.0.0.1:PORT/cargo/"`.
+#   2. `<name>-<version>/Cargo.lock` — the bundled lockfile records each
+#      fork-sibling package with `source = "sparse+http://127.0.0.1:PORT/cargo/"`.
+#      (The sibling checksums in it are already canonical, because each sibling
+#      is normalized before the next crate is packaged.)
+#
+# Rewriting both to the canonical `sparse+https://registry.tatolab.com/cargo/`
+# (the workspace's [registries.tatolab] index, identical to the committed
+# lockfile `source`) makes the `.crate` a pure function of source content:
+# port-independent and reproducible, so its checksum can be frozen in the
+# committed root `Cargo.lock`.
+#
+# `vulkanalia-sys` has NO fork-sibling dep → no `registry-index` line and no
+# `sparse+` source in its bundled lock → already byte-stable and cargo-native;
+# this normalizer leaves it untouched (exit without writing) so its
+# committed-lock checksum stays exactly as cargo emits it. crates.io sources
+# (`registry+https://.../crates.io-index`, or a `sparse+https://index.crates.io/`)
+# are never rewritten.
+#
+#   normalize_fork_crate.py <crate-path> <name> <version> <canonical_index_url>
+#
+# Behavior:
+#   * Decode the `.crate` gzip → tar; read `<name>-<version>/Cargo.toml`.
+#   * If it has no `registry-index = "sparse+..."` line, do nothing (exit 0) —
+#     the crate has no fork-sibling dep and is already byte-stable.
+#   * Otherwise rewrite the manifest's `registry-index` and the bundled
+#     lockfile's fork `source` URLs to <canonical_index_url>, drop any
+#     `.cargo_vcs_info.json` entry, re-tar (GNU format, original member order,
+#     every header field cloned verbatim from cargo's output), and re-gzip as a
+#     hand-framed gzip stream: a fixed 10-byte header (OS=0xff "unknown",
+#     XFL=0, MTIME=0, no embedded filename) + a raw level-0 (STORED) DEFLATE
+#     body + CRC32/ISIZE trailer. Overwrite the crate in place.
+#
+# The gzip output is byte-identical across operating systems, zlib versions,
+# AND Python versions: the STORED DEFLATE framing is zlib-standardized, and the
+# header/trailer are constructed by hand rather than by `gzip.compress` (whose
+# OS byte is the platform's zlib OS_CODE — 0x03 on Linux, other values
+# elsewhere — which would otherwise couple the frozen checksum to the emit
+# host's OS). So the committed-lock checksum reproduces on any emit host.
+#
+# Idempotent: re-running on an already-normalized crate reproduces identical
+# bytes (the URLs are already canonical, headers are preserved, the gzip framing
+# is deterministic).
+
+import io
+import re
+import struct
+import sys
+import tarfile
+import zlib
+
+# Fixed gzip header: magic, CM=deflate(8), FLG=0, MTIME=0 (4 bytes), XFL=0,
+# OS=0xff ("unknown" — platform-independent, NOT the host's zlib OS_CODE).
+GZIP_FIXED_HEADER = b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff"
+
+
+def gzip_stored_fixed(data: bytes) -> bytes:
+    """Deterministic gzip of `data`: fixed header + raw STORED DEFLATE + trailer.
+
+    Independent of OS, zlib version, and Python version (unlike
+    `gzip.compress`, whose OS byte tracks the platform's zlib OS_CODE).
+    """
+    compressor = zlib.compressobj(0, zlib.DEFLATED, -zlib.MAX_WBITS)
+    body = compressor.compress(data) + compressor.flush()
+    trailer = struct.pack("<II", zlib.crc32(data) & 0xFFFFFFFF, len(data) & 0xFFFFFFFF)
+    return GZIP_FIXED_HEADER + body + trailer
+
+
+def gzip_decompress(blob: bytes) -> bytes:
+    """Decompress a gzip stream (any header), returning the raw tar bytes."""
+    return zlib.decompress(blob, zlib.MAX_WBITS | 16)
+
+REGISTRY_INDEX_RE = re.compile(r'registry-index = "sparse\+[^"]*"')
+# A bundled-lockfile fork source: any `sparse+` registry that is NOT crates.io's
+# own sparse index. crates.io in these locks uses the git-index form
+# (`registry+https://.../crates.io-index`), so this matches only the tatolab fork.
+LOCK_SOURCE_RE = re.compile(r'source = "sparse\+(?!https://index\.crates\.io/)[^"]*"')
+
+
+def normalize(crate_path: str, name: str, version: str, canonical_index: str) -> bool:
+    manifest_member = f"{name}-{version}/Cargo.toml"
+    lock_member = f"{name}-{version}/Cargo.lock"
+    vcs_member = f"{name}-{version}/.cargo_vcs_info.json"
+
+    with open(crate_path, "rb") as fh:
+        raw = gzip_decompress(fh.read())
+
+    with tarfile.open(fileobj=io.BytesIO(raw), mode="r") as src:
+        members = src.getmembers()
+        manifest_ti = next((m for m in members if m.name == manifest_member), None)
+        if manifest_ti is None:
+            # Not a manifest-bearing crate we recognize — leave untouched.
+            return False
+
+        manifest_text = src.extractfile(manifest_ti).read().decode("utf-8")
+        if not REGISTRY_INDEX_RE.search(manifest_text):
+            # No fork-sibling registry-index (e.g. vulkanalia-sys) — already
+            # byte-stable and cargo-native; do not rewrite.
+            return False
+
+        # Cache every regular member's payload while the source archive is open.
+        payloads = {
+            m.name: src.extractfile(m).read() for m in members if m.isreg()
+        }
+
+    # Per-member body rewrites: manifest registry-index + bundled-lock fork source.
+    rewritten = {
+        manifest_member: REGISTRY_INDEX_RE.sub(
+            f'registry-index = "{canonical_index}"',
+            payloads[manifest_member].decode("utf-8"),
+        ).encode("utf-8")
+    }
+    if lock_member in payloads:
+        rewritten[lock_member] = LOCK_SOURCE_RE.sub(
+            f'source = "{canonical_index}"',
+            payloads[lock_member].decode("utf-8"),
+        ).encode("utf-8")
+
+    out = io.BytesIO()
+    with tarfile.open(fileobj=out, mode="w", format=tarfile.GNU_FORMAT) as dst:
+        for member in members:
+            if member.name == vcs_member:
+                # Drop the git-HEAD vcs-info entry if cargo ever emits one.
+                continue
+            # Reuse the source TarInfo verbatim (mtime / mode / uid / gid /
+            # uname / gname / type all preserved) so only the rewritten bodies
+            # change.
+            if member.name in rewritten:
+                body = rewritten[member.name]
+                member.size = len(body)
+                dst.addfile(member, io.BytesIO(body))
+            elif member.isreg():
+                dst.addfile(member, io.BytesIO(payloads[member.name]))
+            else:
+                dst.addfile(member)
+
+    # Hand-framed STORED gzip: byte-identical regardless of OS / zlib / Python
+    # version, so the emitted checksum reproduces on any emit host.
+    gzipped = gzip_stored_fixed(out.getvalue())
+    with open(crate_path, "wb") as fh:
+        fh.write(gzipped)
+    return True
+
+
+def main() -> None:
+    if len(sys.argv) != 5:
+        sys.stderr.write(
+            "usage: normalize_fork_crate.py <crate-path> <name> <version> "
+            "<canonical_index_url>\n"
+        )
+        sys.exit(2)
+    crate_path, name, version, canonical_index = sys.argv[1:5]
+    normalize(crate_path, name, version, canonical_index)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Makes the vulkanalia-fork `.crate`s that `scripts/registry/emit-static-fork.sh`
emits **byte-stable and port-independent at the canonical URL**, and regenerates
the 2 stale fork checksums in the committed root `Cargo.lock` to match. A
canonical-source-preserving `[source]`-replacement `local-registry` mirror now
resolves the fork `--locked --offline` with **no** `CARGO_REGISTRIES_TATOLAB_INDEX`
override — the prerequisite for #1278.

## Root cause — URL/port coupling

`cargo package` bakes the ephemeral serving-port index it resolved fork siblings
from into **two** files inside each `.crate`, both of which make the tarball
checksum port-coupled:

1. packaged `Cargo.toml` — a `registry = "tatolab"` fork-sibling dep normalizes
   to `registry-index = "sparse+http://127.0.0.1:PORT/cargo/"`.
2. bundled `Cargo.lock` — each fork-sibling package records
   `source = "sparse+http://127.0.0.1:PORT/cargo/"`.

`vulkanalia-sys` has no fork sibling → carries neither → already byte-stable and
cargo-native (its committed-lock checksum `876995ec…` matched a fresh emit
unchanged). `vulkanalia` / `vulkanalia-vma` carried both vectors, so their
committed checksums were frozen from the now-dead port-coupled backend.

## Approach

New `scripts/registry/normalize_fork_crate.py` (stdlib only) rewrites both URLs
to the canonical `[registries.tatolab]` index
(`sparse+https://registry.tatolab.com/cargo/`, read from `.cargo/config.toml` —
never hardcoded; the SoT identical to the lockfile `source`), drops any
`.cargo_vcs_info.json`, re-tars (GNU format, cargo's headers cloned verbatim),
and re-gzips as a **hand-framed** stream — fixed 10-byte header (OS=0xff, XFL=0,
MTIME=0) + raw level-0 (STORED) DEFLATE + CRC32/ISIZE trailer. Hand-framing
(rather than `gzip.compress`, whose OS byte is the host's zlib OS_CODE — `0x03`
on Linux) makes the two rewritten crates byte-identical across OS, zlib version,
and Python version. `emit-static-fork.sh` derives the canonical index once and
normalizes each emitted crate before rendering its sparse-index line, so the
index cksum equals the served `.crate` sha256. `vulkanalia-sys` is skipped
(returns without writing), so it stays exactly as cargo emits it.

The shared `serve-static-fork` CI action now asserts each emitted fork index
checksum equals the committed root `Cargo.lock` — a fork-rev bump without a lock
regen fails fast instead of bricking a downstream `--locked` resolve.

## The 2-line lock diff

```
 name = "vulkanalia"
-checksum = "316c22f5…4733cf"
+checksum = "4de872d936f05cf1616c798ccfda8ea3947b30576e45c999f4d981887ee741ef"
 name = "vulkanalia-vma"
-checksum = "e5b7ad23…57cdc"
+checksum = "ab1de2d3cfecf285a8675d17112fcaa97a5db378ad97373732f60e9c9930898d"
```

`vulkanalia-sys` (`876995ec…`) is unchanged — exactly 2 lines change, matching
the issue premise.

## Validation

**Byte-stability** — emitting at ports 9201/9202/9300/9400 yields byte-identical
`.crate`s + checksums (`cmp` clean); the normalizer is idempotent; the fixed
gzip header is `1f8b08000000000000ff` (OS=0xff, platform-independent).

**Brick gate** — fresh `CARGO_HOME`, `[source]`-replacement `local-registry`
mirror preserving the canonical source id, `CARGO_REGISTRIES_TATOLAB_INDEX`
**unset**:

```
[1/4] generate-lockfile --offline   → canonical source id preserved:
        vulkanalia      source=sparse+https://registry.tatolab.com/cargo/  checksum=4de872d9…
        vulkanalia-sys  source=sparse+https://registry.tatolab.com/cargo/  checksum=876995ec…
        vulkanalia-vma  source=sparse+https://registry.tatolab.com/cargo/  checksum=ab1de2d3…
[3/4] POSITIVE: cargo fetch --locked --offline → PASS (all 3 resolved + checksum-verified)
[4/4] NEGATIVE: corrupt one .crate → "failed to verify the checksum" → PASS (non-vacuous)
```

A fresh emit reproduces the exact committed-lock checksums. The CI-guard
assertion passes on a matching emit and fails on a port-coupled one.

**Toolchain**: `cargo 1.94.0 (85eff7c80 2026-01-15)`. The Python re-tar / STORED
hand-framed gzip is toolchain-independent by construction; only `vulkanalia-sys`
(left cargo-native) depends on cargo's own byte-deterministic output on the
Linux emit target — the same coupling the committed lock already had. No
`rust-toolchain.toml` pin is added here (see follow-ups).

## Follow-up candidates (not filed — surfacing for triage)

1. **Closure `.crate` stale `registry-index`** — the workspace release-closure
   crates (`static_registry.rs` `finalize_crate_tarball`) don't rewrite the
   ephemeral `registry-index` cargo bakes; harmless for a `--locked` resolve
   (source id preserved), but wrong for a non-locked external SDK resolve. The
   fork normalizer here fixes the fork; the closure path has the same shape.
2. **`rust-toolchain.toml` pin** — so cargo-package-derived checksums
   (`vulkanalia-sys`, closure crates) reproduce deterministically across CI
   runners.
3. **Option-(a) spike** — verify whether a cargo `[source]`-replacement at
   *package* time makes cargo bake the canonical `registry-index` natively; if
   so it would retire the normalizer and fix (1) in one mechanism.
4. **Normalize `vulkanalia-sys` too** — it's left cargo-native (Linux/cargo-gzip
   coupled) to keep the lock diff at exactly 2 lines per the issue plan; routing
   it through the fixed-header path would make all three fully
   platform-independent at the cost of a 3-line lock diff.

Closes #1290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB
