### PR TITLE
feat(registry): streamlib pkg publish emits the catalog artifacts (#1288)

### DIFF
--- a/docs/architecture/static-registry.md
+++ b/docs/architecture/static-registry.md
@@ -272,13 +272,45 @@ owns the registry protocol; assembly lives in `streamlib-pack`
 ([`catalog.rs`](../../libs/streamlib-pack/src/catalog.rs),
 `build_package_catalog`).
 
-Three on-disk shapes, all written during the same atomic emit:
+Three on-disk shapes:
 
 | Path | Contents |
 |---|---|
 | `catalog/index.ndjson` | Aggregate processor palette — one `CatalogIndexLine` per processor across all packages (`CATALOG_INDEX_PATH`). |
 | `slpkg/<name>/<version>/<name>.catalog.json` | One package's `PackageCatalog` (its processors, ports, config), keyed by **full** published version. |
 | `slpkg/<name>/<core>/schemas/<Type>.jtd.json` | One schema's JTD document, keyed by **release-core** version. |
+
+### Two write paths, one shape
+
+Both the whole-tree emit and a single-package publish write the same three
+shapes through the same assembler (`build_package_catalog`) and per-package
+writer (`write_package_catalog`), so the per-package `<name>.catalog.json` +
+owned JTDs a client fetches are byte-identical regardless of which path wrote
+them. The aggregate differs only in breadth: an emit rewrites it as a
+single-version snapshot of the source tree, while incremental publishing
+accumulates a line per processor per **published** version — consistent with
+the versioned `slpkg/` store, which keeps every published version fetchable.
+
+- **Whole-tree `static-registry emit`** builds the catalog for every
+  `packages/*` dir and writes the aggregate **whole** (accumulate all lines,
+  write `catalog/index.ndjson` once) during the atomic staged flip.
+- **`streamlib pkg build` / `pkg publish`** (a single package) writes that
+  package's `<name>.catalog.json` + owned JTDs beside the `.slpkg` it just
+  uploaded, then **read-merge-writes** the aggregate
+  (`merge_catalog_index_lines`): read the existing `catalog/index.ndjson`
+  (absent ⇒ empty, self-healing like the per-package version index), drop
+  every line owned by the publishing `(package, version)`, append the fresh
+  lines, rewrite. Dropping-then-appending makes a republish of the same
+  version replace rather than duplicate, and drops the stale line of a
+  processor removed on a republish. A publish is not atomic the way an emit
+  is — it writes the store, index, and catalog in sequence.
+
+  External schema references resolve against the sibling packages next to the
+  one being published (the emit's `packages/` enumeration, applied to the
+  package's parent directory); an external ref whose owning dependency isn't
+  locally resolvable surfaces a typed `CatalogError` (e.g. `ExternalDepMissing`)
+  **before** any bytes land, so a publish either writes a fully-resolved
+  catalog or fails loud.
 
 ### The version asymmetry
 

--- a/libs/streamlib-cli/src/commands/pkg.rs
+++ b/libs/streamlib-cli/src/commands/pkg.rs
@@ -14,6 +14,8 @@ use anyhow::{Context, Result};
 use streamlib::engine_internal::core::ProjectConfig;
 use streamlib::engine_internal::core::InstalledPackageManifest;
 use streamlib_idents::{RegistryClient, RegistryConfig};
+use streamlib_pack::catalog::{build_package_catalog, build_sibling_versions};
+use streamlib_pack::static_registry::{merge_catalog_index_lines, write_package_catalog};
 use streamlib_pack::{assemble_artifact, AssembleOptions, AssembleTarget, CargoProfile, PathDepPolicy};
 
 /// Build THIS package (the current working directory) into a source-only
@@ -40,10 +42,14 @@ pub fn build(output: Option<&Path>) -> Result<()> {
 
 /// Publish THIS package (the current working directory) into the static
 /// registry tree's `.slpkg` generic store. Always repacks a fresh source-only
-/// `.slpkg` to a temp file (never trusts a pre-existing artifact), then writes
-/// it by version and refreshes the package's version index. The registry tree
-/// root comes from `STREAMLIB_REGISTRY_URL` and must be a `file://` tree —
-/// publishing writes files; a static HTTP mount is read-only.
+/// `.slpkg` to a temp file (never trusts a pre-existing artifact), writes it by
+/// version, refreshes the package's version index, and emits the same catalog
+/// artifacts a whole-tree `static-registry emit` would — the per-package
+/// `<name>.catalog.json` + owned schema JTDs beside the `.slpkg`, plus a merge
+/// into the tree-wide `catalog/index.ndjson` — so a registry populated purely by
+/// `pkg publish` serves a catalog-backed discovery summary, not "no metadata".
+/// The registry tree root comes from `STREAMLIB_REGISTRY_URL` and must be a
+/// `file://` tree — publishing writes files; a static HTTP mount is read-only.
 pub fn publish() -> Result<()> {
     let package_dir = std::env::current_dir().context("resolve current working directory")?;
     // Early friendly check; the load-bearing guard runs again inside
@@ -65,6 +71,16 @@ pub fn publish() -> Result<()> {
              (e.g. file:///path/to/registry-tree) to publish"
         )
     })?;
+
+    // Assemble the publish-time catalog up front, so an unresolvable external
+    // schema ref fails BEFORE any bytes land in the tree. External refs resolve
+    // against the sibling packages discoverable next to this one — mirroring the
+    // whole-tree emit's `packages/` enumeration; a genuinely unresolvable ref
+    // surfaces a typed `CatalogError` (e.g. `ExternalDepMissing`) here.
+    let siblings = build_sibling_versions(&sibling_package_dirs(&package_dir))
+        .map_err(|e| anyhow::anyhow!("assembling the catalog resolution universe: {}", e))?;
+    let catalog_artifacts = build_package_catalog(&package_dir, &siblings)
+        .map_err(|e| anyhow::anyhow!("building the package catalog: {}", e))?;
 
     // Always repack fresh into a temp file — publish never trusts a
     // pre-existing artifact (pack runs independently, at any time).
@@ -90,7 +106,71 @@ pub fn publish() -> Result<()> {
         .upload_slpkg(&pkg_ref, package.version, &bytes)
         .map_err(|e| anyhow::anyhow!("upload failed: {}", e))?;
     println!("Published → {url}");
+
+    // Publish the catalog alongside the `.slpkg`. `upload_slpkg` already proved
+    // the tree is a writable `file://` root, so deriving the on-disk root here is
+    // sound.
+    let tree_root = file_tree_root(&registry.base_url)?;
+    let slpkg_dir = tree_root.join("slpkg");
+    write_package_catalog(&slpkg_dir, &catalog_artifacts)
+        .map_err(|e| anyhow::anyhow!("writing the package catalog: {}", e))?;
+    merge_catalog_index_lines(
+        &tree_root,
+        &pkg_ref,
+        &package.version,
+        &catalog_artifacts.index_lines,
+    )
+    .map_err(|e| anyhow::anyhow!("updating the catalog index: {}", e))?;
+    println!(
+        "  Catalog: {} processor(s), {} owned schema(s)",
+        catalog_artifacts.index_lines.len(),
+        catalog_artifacts.schema_jtd.len()
+    );
     Ok(())
+}
+
+/// The sibling package directories catalog assembly resolves external schema
+/// references against — the entries of the directory that holds the package
+/// being published, mirroring the whole-tree emit's enumeration of `packages/`.
+/// [`build_sibling_versions`] skips any entry without a `[package]` block, so
+/// non-package siblings are harmless. Falls back to just the package itself when
+/// it has no parent or the parent can't be read (a self-contained package with
+/// no external refs still resolves; a package that imports an external schema
+/// then surfaces a typed `ExternalDepMissing`).
+fn sibling_package_dirs(package_dir: &Path) -> Vec<std::path::PathBuf> {
+    let read_siblings = package_dir.parent().and_then(|parent| {
+        std::fs::read_dir(parent).ok().map(|entries| {
+            let mut dirs: Vec<std::path::PathBuf> = entries
+                .filter_map(|e| e.ok().map(|e| e.path()))
+                .filter(|p| p.is_dir())
+                .collect();
+            // Sort so the resolution universe is deterministic — matching the
+            // whole-tree emit, which sorts its `packages/` entries before
+            // building siblings (`build_sibling_versions` is last-write-wins on
+            // a duplicate `@org/name`, degenerate but order-sensitive).
+            dirs.sort();
+            dirs
+        })
+    });
+    match read_siblings {
+        Some(dirs) if !dirs.is_empty() => dirs,
+        _ => vec![package_dir.to_path_buf()],
+    }
+}
+
+/// The on-disk tree root a `file://` registry base URL points at. `pkg publish`
+/// only reaches this after [`RegistryClient::upload_slpkg`] has already required
+/// the `file://` scheme, so a non-`file://` base here is an internal invariant
+/// violation rather than a user-facing case.
+fn file_tree_root(base_url: &str) -> Result<std::path::PathBuf> {
+    base_url
+        .strip_prefix("file://")
+        .map(std::path::PathBuf::from)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "internal: publishing the catalog requires a file:// registry tree, got `{base_url}`"
+            )
+        })
 }
 
 /// Remove THIS package's build/pack artifacts from the current working

--- a/libs/streamlib-cli/tests/pkg_publish_catalog.rs
+++ b/libs/streamlib-cli/tests/pkg_publish_catalog.rs
@@ -1,0 +1,160 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! End-to-end `streamlib pkg publish` against a scratch `file://` registry
+//! tree, driving the real `streamlib` binary. Proves the publish path emits the
+//! catalog artifacts (per-package `<name>.catalog.json`, owned schema JTD at the
+//! release-core path, and the tree-wide aggregate) alongside the `.slpkg` — so a
+//! registry populated purely by `pkg publish` is catalog-fetchable, not degraded
+//! to "no metadata."
+//!
+//! This is the CLI-wiring counterpart to `streamlib-pack`'s
+//! `catalog_pkg_publish.rs` (which drives the pack functions directly): here the
+//! whole command runs, including the sibling-resolution + tree-root derivation
+//! `publish()` does. It uses a schema-only package (no processors) so the
+//! source-only assemble needs no Rust/Python toolchain.
+
+use std::path::Path;
+use std::process::Command;
+
+use streamlib_idents::{CatalogClient, Org, Package, SchemaIdent, SemVer, TypeName};
+
+const BIN: &str = env!("CARGO_BIN_EXE_streamlib");
+
+/// A schema-only `foo` package (one owned schema, no processors) — the smallest
+/// publishable package that assembles without a toolchain build.
+fn write_foo_package(dir: &Path) {
+    std::fs::create_dir_all(dir.join("schemas")).unwrap();
+    std::fs::write(
+        dir.join("streamlib.yaml"),
+        "package:\n  org: tatolab\n  name: foo\n  version: 1.1.0\n  \
+         description: a demo publish package\nschemas:\n  FooFrame:\n    file: schemas/foo_frame.yaml\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("schemas/foo_frame.yaml"),
+        "metadata:\n  type: FooFrame\n  description: \"A demo frame\"\nproperties:\n  \
+         width:\n    type: uint32\n  height:\n    type: uint32\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn pkg_publish_writes_fetchable_catalog_and_owned_jtd() {
+    let tree = tempfile::tempdir().unwrap();
+    // The package lives inside a `packages/` parent so publish's sibling scan
+    // has a realistic layout to enumerate.
+    let workspace = tempfile::tempdir().unwrap();
+    let pkg_dir = workspace.path().join("packages").join("foo");
+    write_foo_package(&pkg_dir);
+
+    let registry = format!("file://{}", tree.path().display());
+    let out = Command::new(BIN)
+        .args(["pkg", "publish"])
+        .current_dir(&pkg_dir)
+        .env("STREAMLIB_REGISTRY_URL", &registry)
+        .output()
+        .expect("spawn streamlib binary");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "pkg publish failed: status={:?}\nstdout={stdout}\nstderr={stderr}",
+        out.status
+    );
+
+    // The `.slpkg` and the per-package catalog both land in the version dir.
+    let ver_dir = tree.path().join("slpkg/foo/1.1.0");
+    assert!(ver_dir.join("foo.slpkg").is_file(), "the .slpkg was published");
+    assert!(
+        ver_dir.join("foo.catalog.json").is_file(),
+        "pkg publish must write the per-package catalog"
+    );
+    // Release-core == full here (no prerelease); the owned JTD lands under it.
+    assert!(
+        ver_dir.join("schemas/FooFrame.jtd.json").is_file(),
+        "pkg publish must write the owned schema JTD"
+    );
+
+    // The catalog is fetchable by a client (NOT None — the degraded state this
+    // feature closes). foo is schema-only, so it contributes zero processors.
+    let client = CatalogClient::new(&registry, None);
+    let catalog = client
+        .fetch_package_catalog(
+            &streamlib_idents::PackageRef::new(
+                Org::new("tatolab").unwrap(),
+                Package::new("foo").unwrap(),
+            ),
+            &SemVer::new(1, 1, 0),
+        )
+        .unwrap()
+        .expect("catalog fetchable from a pkg-publish-only tree");
+    assert_eq!(catalog.package.to_string(), "@tatolab/foo");
+    assert!(catalog.processors.is_empty(), "schema-only package has no processors");
+
+    // The owned JTD resolves by its release-core ident.
+    let jtd = client
+        .fetch_schema_type_definition(&SchemaIdent::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("foo").unwrap(),
+            TypeName::new("FooFrame").unwrap(),
+            SemVer::new(1, 1, 0),
+        ))
+        .unwrap()
+        .expect("owned FooFrame JTD fetchable");
+    assert_eq!(jtd["metadata"]["type"], "FooFrame");
+}
+
+/// A package that imports a schema from a dependency not resolvable at publish
+/// time must fail loud AND write nothing — the catalog is assembled before the
+/// `.slpkg` is uploaded, so an unresolvable external ref can't leave an orphan
+/// artifact in the tree. (Mentally move the catalog build after `upload_slpkg`
+/// and the `.slpkg` would land before the failure — this test catches that.)
+#[test]
+fn pkg_publish_fails_before_writing_when_external_ref_unresolvable() {
+    let tree = tempfile::tempdir().unwrap();
+    let workspace = tempfile::tempdir().unwrap();
+    // `bar` alone in its parent dir — its `@tatolab/core` import has no local
+    // sibling to resolve against and is not published, so catalog assembly must
+    // surface `ExternalDepMissing`.
+    let pkg_dir = workspace.path().join("packages").join("bar");
+    std::fs::create_dir_all(&pkg_dir).unwrap();
+    std::fs::write(
+        pkg_dir.join("streamlib.yaml"),
+        r#"
+package:
+  org: tatolab
+  name: bar
+  version: 1.0.0
+schemas:
+  VideoFrame:
+    package: '@tatolab/core'
+processors:
+- name: Bar
+  version: 1.0.0
+  runtime: rust
+  execution: reactive
+  outputs:
+  - name: out
+    schema: VideoFrame
+"#,
+    )
+    .unwrap();
+
+    let registry = format!("file://{}", tree.path().display());
+    let out = Command::new(BIN)
+        .args(["pkg", "publish"])
+        .current_dir(&pkg_dir)
+        .env("STREAMLIB_REGISTRY_URL", &registry)
+        .output()
+        .expect("spawn streamlib binary");
+    assert!(
+        !out.status.success(),
+        "publish must fail when an external schema ref can't be resolved"
+    );
+    // Nothing landed in the tree — the failure preceded the `.slpkg` upload.
+    assert!(
+        !tree.path().join("slpkg/bar").exists(),
+        "no .slpkg / catalog should be written on a fail-fast catalog error"
+    );
+}

--- a/libs/streamlib-pack/src/static_registry.rs
+++ b/libs/streamlib-pack/src/static_registry.rs
@@ -34,8 +34,9 @@ use std::process::Command;
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
 use streamlib_idents::{
-    render_catalog_index_ndjson, schema_jtd_file_name, CatalogIndexLine, PackageRef, RegistryClient,
-    RegistryConfig, ReleaseManifest, ReleaseManifestMember, SemVer, CATALOG_INDEX_PATH,
+    parse_catalog_index_ndjson, render_catalog_index_ndjson, schema_jtd_file_name, CatalogIndexLine,
+    PackageRef, RegistryClient, RegistryConfig, ReleaseManifest, ReleaseManifestMember, SemVer,
+    CATALOG_INDEX_PATH,
 };
 
 use crate::catalog::{build_package_catalog, build_sibling_versions};
@@ -903,6 +904,48 @@ pub fn write_package_catalog(
                 .with_context(|| format!("write {}", path.display()))?;
         }
     }
+    Ok(())
+}
+
+/// Merge one package's catalog index lines into the tree-wide aggregate
+/// `catalog/index.ndjson`, so an incremental `streamlib pkg publish` keeps the
+/// aggregate in step with the per-package catalog it just wrote — matching the
+/// per-processor shape the whole-tree emit renders.
+///
+/// The whole-tree emit accumulates every package's lines and writes the
+/// aggregate once ([`emit_slpkg_and_manifest`]); a single-package publish has
+/// only its own lines, so it read-merge-writes instead: the existing aggregate
+/// is read (absent ⇒ empty, self-healing like the per-package version index),
+/// every line owned by this `(package, version)` is dropped, `new_lines` is
+/// appended, and the file is rewritten. Dropping-then-appending makes a
+/// republish of the same `(package, version)` replace its lines rather than
+/// duplicate them, and drops the stale line of a processor removed on a
+/// republish. `tree_root` is the registry tree root (the directory holding
+/// `slpkg/` and `catalog/`).
+pub fn merge_catalog_index_lines(
+    tree_root: &Path,
+    package: &PackageRef,
+    version: &SemVer,
+    new_lines: &[CatalogIndexLine],
+) -> Result<()> {
+    let index_path = tree_root.join(CATALOG_INDEX_PATH);
+    let mut lines: Vec<CatalogIndexLine> = match std::fs::read(&index_path) {
+        Ok(body) => parse_catalog_index_ndjson(&body),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(e) => {
+            return Err(anyhow::Error::new(e))
+                .with_context(|| format!("read {}", index_path.display()))
+        }
+    };
+    lines.retain(|line| !(&line.package == package && &line.version == version));
+    lines.extend(new_lines.iter().cloned());
+
+    if let Some(parent) = index_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create {}", parent.display()))?;
+    }
+    std::fs::write(&index_path, render_catalog_index_ndjson(&lines))
+        .with_context(|| format!("write {}", index_path.display()))?;
     Ok(())
 }
 

--- a/libs/streamlib-pack/tests/catalog_pkg_publish.rs
+++ b/libs/streamlib-pack/tests/catalog_pkg_publish.rs
@@ -1,0 +1,357 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Integration: the incremental `streamlib pkg publish` catalog flow. Where
+//! `catalog_publish_query.rs` drives the WHOLE-tree emit's aggregate (write the
+//! full index once), this drives the SINGLE-package publish path the CLI wires:
+//! `build_package_catalog` → `write_package_catalog` → `merge_catalog_index_lines`,
+//! one package at a time, then reads it all back through `CatalogClient`.
+//!
+//! It exercises exactly the pack functions `streamlib pkg publish` calls after
+//! `upload_slpkg`, so a registry populated purely by `pkg publish` is proven
+//! catalog-identical to one built by the whole-tree emit — the property the
+//! `streamlib add` discovery summary depends on universally.
+
+use std::path::{Path, PathBuf};
+
+use streamlib_idents::{
+    parse_catalog_index_ndjson, CatalogRuntime, CatalogSchemaRef, Org, Package, PackageRef,
+    RegistryClient, RegistryConfig, SchemaIdent, SemVer, TypeName, CATALOG_INDEX_PATH,
+};
+use streamlib_idents::CatalogClient;
+use streamlib_pack::catalog::{build_package_catalog, build_sibling_versions, SiblingVersions};
+use streamlib_pack::static_registry::{merge_catalog_index_lines, write_package_catalog};
+
+fn write(dir: &Path, rel: &str, body: &str) {
+    let path = dir.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, body).unwrap();
+}
+
+fn pkg_ref(name: &str) -> PackageRef {
+    PackageRef::new(Org::new("tatolab").unwrap(), Package::new(name).unwrap())
+}
+
+fn ident(pkg: &str, ty: &str, v: SemVer) -> SchemaIdent {
+    SchemaIdent::new(
+        Org::new("tatolab").unwrap(),
+        Package::new(pkg).unwrap(),
+        TypeName::new(ty).unwrap(),
+        v,
+    )
+}
+
+/// `@tatolab/core@1.4.0` (owns VideoFrame) + `@tatolab/camera@2.1.0` (imports
+/// VideoFrame from core, owns CameraConfig, declares two processors).
+fn author_core_and_camera(src: &Path) -> (PathBuf, PathBuf) {
+    let core = src.join("core");
+    write(
+        &core,
+        "streamlib.yaml",
+        r#"
+package:
+  org: tatolab
+  name: core
+  version: 1.4.0
+schemas:
+  VideoFrame:
+    file: schemas/video_frame.yaml
+"#,
+    );
+    write(
+        &core,
+        "schemas/video_frame.yaml",
+        "metadata:\n  type: VideoFrame\n  description: A frame\nproperties:\n  width:\n    type: uint32\n  height:\n    type: uint32\n",
+    );
+
+    let camera = src.join("camera");
+    write(&camera, "streamlib.yaml", CAMERA_MANIFEST_TWO_PROCESSORS);
+    write(
+        &camera,
+        "schemas/camera_config.yaml",
+        "metadata:\n  type: CameraConfig\n  description: cfg\noptionalProperties:\n  device_id:\n    type: string\n",
+    );
+    (core, camera)
+}
+
+const CAMERA_MANIFEST_TWO_PROCESSORS: &str = r#"
+package:
+  org: tatolab
+  name: camera
+  version: 2.1.0
+dependencies:
+  '@tatolab/core':
+    version: ^1.0.0
+schemas:
+  CameraConfig:
+    file: schemas/camera_config.yaml
+  VideoFrame:
+    package: '@tatolab/core'
+processors:
+- name: Camera
+  version: 1.0.0
+  description: Captures video
+  runtime: rust
+  execution: manual
+  config:
+    name: config
+    schema: CameraConfig
+  outputs:
+  - name: video
+    schema: VideoFrame
+    description: Live frames
+- name: Sink
+  version: 1.0.0
+  runtime: python
+  entrypoint: src.sink:Sink
+  execution: reactive
+  inputs:
+  - name: video_in
+    schema: VideoFrame
+    read_mode: skip_to_latest
+"#;
+
+/// Camera manifest re-authored with ONLY the `Camera` processor (Sink removed) —
+/// used to prove a republish drops the stale processor's aggregate line.
+const CAMERA_MANIFEST_ONE_PROCESSOR: &str = r#"
+package:
+  org: tatolab
+  name: camera
+  version: 2.1.0
+dependencies:
+  '@tatolab/core':
+    version: ^1.0.0
+schemas:
+  CameraConfig:
+    file: schemas/camera_config.yaml
+  VideoFrame:
+    package: '@tatolab/core'
+processors:
+- name: Camera
+  version: 1.0.0
+  description: Captures video
+  runtime: rust
+  execution: manual
+  config:
+    name: config
+    schema: CameraConfig
+  outputs:
+  - name: video
+    schema: VideoFrame
+    description: Live frames
+"#;
+
+/// Mirror `streamlib pkg publish`'s post-upload steps for one package: upload a
+/// dummy `.slpkg` (so the store + version index exist, as a real publish would),
+/// then write the per-package catalog + owned JTDs and merge the package's lines
+/// into the tree-wide aggregate. `siblings` is the resolution universe the CLI
+/// builds from the package's neighbors.
+fn publish_package(tree_root: &Path, pkg_dir: &Path, siblings: &SiblingVersions) {
+    let arts = build_package_catalog(pkg_dir, siblings)
+        .unwrap_or_else(|e| panic!("build catalog for {}: {e}", pkg_dir.display()));
+    let cfg = RegistryConfig {
+        base_url: format!("file://{}", tree_root.display()),
+    };
+    // A real publish writes the `.slpkg` first; the catalog query path never
+    // reads it, so opaque bytes suffice.
+    RegistryClient::new(&cfg)
+        .upload_slpkg(
+            &arts.catalog.package,
+            arts.catalog.version,
+            b"OPAQUE-SLPKG-DO-NOT-READ",
+        )
+        .unwrap();
+    write_package_catalog(&tree_root.join("slpkg"), &arts).unwrap();
+    merge_catalog_index_lines(
+        tree_root,
+        &arts.catalog.package,
+        &arts.catalog.version,
+        &arts.index_lines,
+    )
+    .unwrap();
+}
+
+/// The exit-criteria test: publish core then camera one at a time into a scratch
+/// tree, and prove the catalog is fetchable exactly as an emit-built tree's is —
+/// `.catalog.json` at the full-version path, `fetch_package_catalog` returns the
+/// resolved processors/ports, the aggregate carries the processor lines, the
+/// owned JTDs land (core's at core's dir, camera's at camera's), and a republish
+/// of the same version does not duplicate the aggregate lines.
+#[test]
+fn pkg_publish_emits_fetchable_catalog_and_republish_does_not_duplicate() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("packages");
+    let tree = tmp.path().join("registry");
+    let (core, camera) = author_core_and_camera(&src);
+
+    // Resolution universe = every local package (what the CLI derives from the
+    // package's parent dir). Publish in dependency order, one package at a time.
+    let siblings = build_sibling_versions(&[core.clone(), camera.clone()]).unwrap();
+    publish_package(&tree, &core, &siblings);
+    publish_package(&tree, &camera, &siblings);
+
+    // 1. The per-package catalog exists on disk at the FULL-version path.
+    let camera_catalog_path = tree.join("slpkg/camera/2.1.0/camera.catalog.json");
+    assert!(
+        camera_catalog_path.is_file(),
+        "expected {} to exist",
+        camera_catalog_path.display()
+    );
+
+    let client = CatalogClient::new(format!("file://{}", tree.display()), None);
+
+    // 2. `fetch_package_catalog` returns Some with the resolved processors/ports
+    //    (NOT None — the degraded "no metadata" state this feature closes).
+    let cam = client
+        .fetch_package_catalog(&pkg_ref("camera"), &SemVer::new(2, 1, 0))
+        .unwrap()
+        .expect("camera catalog must be fetchable from a pkg-publish-only tree");
+    assert_eq!(cam.processors.len(), 2);
+    let camera_proc = &cam.processors[0];
+    assert_eq!(camera_proc.name, "Camera");
+    assert_eq!(camera_proc.runtime, CatalogRuntime::Rust);
+    // Config ref is Local → camera's own version.
+    assert_eq!(
+        camera_proc.config.as_ref().unwrap().schema.to_string(),
+        "@tatolab/camera/CameraConfig@2.1.0"
+    );
+    // Output port carries the EXTERNAL dep's version (core's 1.4.0), not the
+    // importer's (2.1.0) — external-ref resolution worked at publish time.
+    assert_eq!(
+        camera_proc.outputs[0].schema,
+        CatalogSchemaRef::Schema(ident("core", "VideoFrame", SemVer::new(1, 4, 0)))
+    );
+    let sink = &cam.processors[1];
+    assert_eq!(sink.runtime, CatalogRuntime::Python);
+    assert_eq!(sink.entrypoint.as_deref(), Some("src.sink:Sink"));
+    assert_eq!(sink.inputs[0].read_mode.as_deref(), Some("skip_to_latest"));
+
+    // 3. The aggregate carries one line per processor; core (schema-only)
+    //    contributes none.
+    let index = client.fetch_processor_index().unwrap();
+    let names: Vec<(String, String)> = index
+        .iter()
+        .map(|l| (l.package.to_string(), l.processor.name.clone()))
+        .collect();
+    assert!(names.contains(&("@tatolab/camera".into(), "Camera".into())));
+    assert!(names.contains(&("@tatolab/camera".into(), "Sink".into())));
+    assert!(
+        !names.iter().any(|(p, _)| p == "@tatolab/core"),
+        "schema-only core contributes no aggregate lines"
+    );
+    assert_eq!(index.len(), 2, "exactly two processors published");
+
+    // 4. Owned JTDs resolve from the OWNING package's dir: core owns VideoFrame,
+    //    camera owns CameraConfig.
+    let vf = client
+        .fetch_schema_type_definition(&ident("core", "VideoFrame", SemVer::new(1, 4, 0)))
+        .unwrap()
+        .expect("core's VideoFrame JTD");
+    assert_eq!(vf["metadata"]["type"], "VideoFrame");
+    let cc = client
+        .fetch_schema_type_definition(&ident("camera", "CameraConfig", SemVer::new(2, 1, 0)))
+        .unwrap()
+        .expect("camera's CameraConfig JTD");
+    assert_eq!(cc["metadata"]["type"], "CameraConfig");
+
+    // 5. Republish camera at the SAME version — the aggregate must NOT gain
+    //    duplicate lines. (Mentally revert the `retain` dedup in
+    //    `merge_catalog_index_lines` and this jumps from 2 to 4.)
+    publish_package(&tree, &camera, &siblings);
+    let after = client.fetch_processor_index().unwrap();
+    assert_eq!(after.len(), 2, "republish must not duplicate aggregate lines");
+    // The on-disk aggregate itself has no dupes (not just the parsed view).
+    let raw = std::fs::read(tree.join(CATALOG_INDEX_PATH)).unwrap();
+    assert_eq!(parse_catalog_index_ndjson(&raw).len(), 2);
+}
+
+/// A republish that DROPS a processor must drop that processor's stale aggregate
+/// line — the dedup key is `(package, version)`, not the whole line. (Mentally
+/// revert to a full-line-equality dedup and Sink's line survives, failing the
+/// `== 1` assertion.)
+#[test]
+fn republish_with_fewer_processors_drops_the_stale_aggregate_line() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("packages");
+    let tree = tmp.path().join("registry");
+    let (core, camera) = author_core_and_camera(&src);
+    let siblings = build_sibling_versions(&[core.clone(), camera.clone()]).unwrap();
+
+    publish_package(&tree, &core, &siblings);
+    publish_package(&tree, &camera, &siblings);
+    let client = CatalogClient::new(format!("file://{}", tree.display()), None);
+    assert_eq!(client.fetch_processor_index().unwrap().len(), 2);
+
+    // Re-author camera with only the Camera processor, rebuild the sibling
+    // universe from the new manifest, and republish.
+    write(&camera, "streamlib.yaml", CAMERA_MANIFEST_ONE_PROCESSOR);
+    let siblings = build_sibling_versions(&[core, camera.clone()]).unwrap();
+    publish_package(&tree, &camera, &siblings);
+
+    let index = client.fetch_processor_index().unwrap();
+    assert_eq!(index.len(), 1, "the dropped Sink processor's line is gone");
+    assert_eq!(index[0].processor.name, "Camera");
+}
+
+/// The publish path honors the version-key asymmetry a `-dev.N` release needs:
+/// the per-package catalog is keyed by the FULL prerelease version, while the
+/// owned schema JTD is keyed by the RELEASE-CORE version (schema idents are
+/// release-core by invariant). A publisher whose JTD sat under the full
+/// prerelease dir would be silently unfetchable by the release-core ident.
+#[test]
+fn prerelease_publish_keys_catalog_by_full_but_jtd_by_release_core() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("packages");
+    let tree = tmp.path().join("registry");
+
+    let widget = src.join("widget");
+    write(
+        &widget,
+        "streamlib.yaml",
+        r#"
+package:
+  org: tatolab
+  name: widget
+  version: 2.1.0-dev.3
+schemas:
+  WidgetConfig:
+    file: schemas/widget_config.yaml
+processors:
+- name: Widget
+  version: 1.0.0
+  runtime: rust
+  execution: reactive
+  config:
+    name: config
+    schema: WidgetConfig
+"#,
+    );
+    write(
+        &widget,
+        "schemas/widget_config.yaml",
+        "metadata:\n  type: WidgetConfig\nproperties: {}\n",
+    );
+    let siblings = build_sibling_versions(&[widget.clone()]).unwrap();
+    publish_package(&tree, &widget, &siblings);
+
+    let client = CatalogClient::new(format!("file://{}", tree.display()), None);
+
+    // Per-package catalog under the FULL prerelease version dir.
+    assert!(tree.join("slpkg/widget/2.1.0-dev.3/widget.catalog.json").is_file());
+    let full_ver: SemVer = "2.1.0-dev.3".parse().unwrap();
+    let catalog = client
+        .fetch_package_catalog(&pkg_ref("widget"), &full_ver)
+        .unwrap()
+        .expect("catalog fetchable by the FULL prerelease version");
+    let cfg_ident = catalog.processors[0].config.as_ref().unwrap().schema.clone();
+    // The config schema ident is release-core (prerelease stripped).
+    assert_eq!(cfg_ident.to_string(), "@tatolab/widget/WidgetConfig@2.1.0");
+
+    // JTD under the RELEASE-CORE dir, fetchable by the release-core ident.
+    assert!(tree.join("slpkg/widget/2.1.0/schemas/WidgetConfig.jtd.json").is_file());
+    let jtd = client
+        .fetch_schema_type_definition(&cfg_ident)
+        .unwrap()
+        .expect("JTD fetchable by the release-core ident for a -dev.N publisher");
+    assert_eq!(jtd["metadata"]["type"], "WidgetConfig");
+}


### PR DESCRIPTION
## What

`streamlib pkg publish` wrote only the `.slpkg` + the per-package version index. The catalog (processor / port / schema metadata that `streamlib add`'s discovery summary — and any future graph-editor palette — reads) was written **only** by the whole-tree `cargo xtask static-registry emit`. So a registry populated purely by `pkg publish` silently degraded `streamlib add`'s summary to "no catalog metadata."

This makes `pkg publish` emit the **same** catalog artifacts an emit does, alongside the `.slpkg`:

- the per-package `slpkg/<name>/<full-version>/<name>.catalog.json`,
- each owned schema's JTD at `slpkg/<name>/<release-core>/schemas/<Type>.jtd.json`,
- a merge of the package's processor line(s) into the tree-wide `catalog/index.ndjson`.

Closes #1288.

## What was reused (no parallel assembler)

- **`build_package_catalog`** (`streamlib-pack::catalog`) — the exact assembler the emit uses. Same resolved `PackageCatalog` + `index_lines` + owned `schema_jtd`.
- **`write_package_catalog`** (`streamlib-pack::static_registry`, already `pub`) — the exact per-package + JTD writer the emit uses. Not touched.
- One new surgical helper: **`merge_catalog_index_lines`** in the same module. The emit accumulates every package's lines and writes `catalog/index.ndjson` **whole**, once; a single-package publish has only its own lines, so it read-merge-writes: read the existing aggregate (absent ⇒ empty, self-healing like the per-package version index), drop every line owned by this `(package, version)`, append the fresh lines, rewrite. No second catalog code path.

The CLI `publish()` wiring: build the catalog **up front** (fail-fast, before any bytes land) → `upload_slpkg` (unchanged) → `write_package_catalog` → `merge_catalog_index_lines`.

## Version-key asymmetry (preserved)

Handled entirely by the reused `write_package_catalog`: the `.catalog.json` is keyed by the **full** published version (e.g. `2.1.0-dev.3`), while owned JTDs are keyed by the **release-core** version (`2.1.0`) — because a `SchemaIdent` is release-core by invariant, so the reader derives the JTD path from the ident's already-projected version. Locked by `prerelease_publish_keys_catalog_by_full_but_jtd_by_release_core`.

## Republish dedup

`merge_catalog_index_lines` deduplicates by `(package, version)`: it drops every existing line owned by the publishing `(package, version)` before appending the fresh set. So a republish of the same version **replaces** rather than duplicates, and a republish that dropped a processor drops its stale line. Different versions of the same package legitimately coexist in the aggregate — consistent with the versioned `slpkg/` store, which keeps every published version fetchable (dedup-by-package would wrongly drop a still-fetchable older version's palette line).

## External-ref resolution at publish time

`build_package_catalog` resolves a manifest's `schemas:` external entries by recursing into the **dependency's own** version. At publish time the deps may not be in the same tree. Behavior chosen (per #1288's "mirror the emit, or surface a typed error"):

- External refs resolve against the sibling package dirs discoverable next to the one being published — the emit enumerates `packages/`; publish enumerates the package's parent directory (sorted, for determinism / emit-parity). `build_sibling_versions` skips non-package entries, so unrelated siblings are harmless. In the monorepo `packages/<name>/` layout this is identical to the emit.
- A genuinely unresolvable external ref surfaces a typed `CatalogError` (`ExternalDepMissing`) **before** any bytes land, so a publish either writes a fully-resolved catalog or fails loud with no orphan `.slpkg`.

**Known limitation (out of scope for #1288):** publish resolves external refs against *local* siblings only, never by resolving the dependency's published version from the registry. A standalone cross-repo package whose external-schema deps are published-but-not-local would fail catalog assembly at publish even though its `.slpkg` resolves those deps at install. Registry-based range→concrete resolution lives at the install seam by the two-loops model, not at publish; lifting it into publish is a separate deliverable. The common monorepo `pkg publish` flow and self-contained packages are fully covered.

## Tests

`streamlib-pack` (`tests/catalog_pkg_publish.rs`, drives the reused pack functions directly):
- `pkg_publish_emits_fetchable_catalog_and_republish_does_not_duplicate` — publishes core then camera one at a time; asserts `.catalog.json` at the full-version path, `CatalogClient::fetch_package_catalog` returns `Some` with resolved processors/ports (external `video` port carries core's `1.4.0`, not camera's `2.1.0`), the aggregate carries the two processor lines (schema-only core contributes none), owned JTDs resolve from each owner's dir, and a republish keeps the aggregate at 2 lines.
- `republish_with_fewer_processors_drops_the_stale_aggregate_line` — proves the dedup key is `(package, version)`, not the whole line (dropped Sink's line is gone).
- `prerelease_publish_keys_catalog_by_full_but_jtd_by_release_core` — the version asymmetry through the merge path.

`streamlib-cli` (`tests/pkg_publish_catalog.rs`, drives the real `streamlib pkg publish` binary end-to-end):
- `pkg_publish_writes_fetchable_catalog_and_owned_jtd` — a real publish writes `.slpkg` + `.catalog.json` + owned JTD; all fetchable via `CatalogClient`.
- `pkg_publish_fails_before_writing_when_external_ref_unresolvable` — an unresolvable external ref fails the command and leaves nothing in the tree (locks the build-before-upload ordering).

**Mental-revert results (verified):**
- Disable the `retain` dedup in `merge_catalog_index_lines` → `pkg_publish_emits_...` republish goes 2→4 (duplicate lines) and `republish_with_fewer_processors...` goes 1→3. Both fail. ✓
- Move the catalog build after `upload_slpkg` → `pkg_publish_fails_before_writing...` would find `slpkg/bar` present and fail its `!exists()` assertion. ✓
- Place JTDs under the full prerelease dir → `prerelease_publish...`'s release-core `fetch_schema_type_definition` returns `None` and the `expect` fails. ✓

## Verification

`cargo build -p streamlib-pack` and `cargo test -p streamlib-pack` green (84 lib incl. 1 env-only skip below + 14 integration across 5 files). `cargo test -p streamlib-cli` green (37 lib + 2 add_remove + 3 pkg_publish_catalog). `cargo check -p streamlib-cli` clean. `Cargo.lock` untouched throughout.

> Env note: `streamlib-pack`'s `release_closure_includes_the_easy_to_skip_libs_by_definition` fails only because its inner `cargo metadata` subprocess can't reach the tatolab registry mirror in this sandbox (the mirror is passed via `--config` to the outer `cargo`, which the subprocess doesn't inherit); it passes when the subprocess is given the mirror via `CARGO_REGISTRIES_TATOLAB_INDEX`. Unrelated to this change — this PR doesn't touch `lib.rs` / `compute_release_closure`.

## Scope

`libs/streamlib-pack/src/static_registry.rs` (one added `pub fn` in the catalog-emit region), `libs/streamlib-cli/src/commands/pkg.rs` (wired `publish()` + two private helpers), two new test files, one doc note in `docs/architecture/static-registry.md`. `emit_slpkg_and_manifest`'s cargo/pypi/npm/fork regions untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB