### PR TITLE
feat(cli,runtime): link-aware module resolution + package builds — the zero-registry dev loop (#1246)

### DIFF
--- a/docs/architecture/package-development-model.md
+++ b/docs/architecture/package-development-model.md
@@ -48,13 +48,16 @@ running process.
 `streamlib link` prints status. Implementation:
 [`libs/streamlib-cli/src/commands/link.rs`](../../libs/streamlib-cli/src/commands/link.rs)
 plus the shared marker in
-[`libs/streamlib-pack/src/link_marker.rs`](../../libs/streamlib-pack/src/link_marker.rs).
+[`libs/streamlib-idents/src/link_marker.rs`](../../libs/streamlib-idents/src/link_marker.rs)
+(the marker schema lives in `streamlib-idents`, alongside the manifest /
+lockfile types, so the engine module loader can reach it without depending
+on `streamlib-pack`).
 
-**Whole-tree, not per-dep.** Link mode is a *toolchain-emission* concern —
-it does not add a resolution path (the engine already resolves a local
-package via `Strategy::Path`). `plan_edits` computes three language-native
-overrides in one plan, so a checkout's SDK libraries *and* sibling packages
-all resolve to that one tree:
+**Two effects: consumer-manifest overrides + link-aware resolution.**
+
+*Consumer-manifest overrides.* `plan_edits` computes three language-native
+overrides in one plan, so a checkout's SDK libraries resolve to that one tree
+for the consumer's **own** build:
 
 | Toolchain | Override | Written to |
 |---|---|---|
@@ -70,6 +73,35 @@ derived from the checkout via `compute_release_closure` — the **same**
 definition a release uses — so a whole-tree link and a release always agree
 on which crates exist. Whole-tree consistency is by construction: a single
 checkout never mixes published versions.
+
+*Link-aware module resolution (npm-link semantics).* With an active link, the
+engine module loader resolves any `@org/name` present in the linked checkout's
+`packages/` tree **from the checkout, regardless of the caller's
+[`Strategy`]** — including an explicit `add_module(ident, registry())`. A
+linked name takes precedence (the dominant example shape calls
+`registry()`; overriding only the *default* strategy would miss it, so editing
+a linked package and re-running would not reflect the edit). A package **not**
+in the checkout is untouched — it resolves from its declared strategy — so
+registry strategies stay available for everything the checkout doesn't
+provide. Discovery is from the process working directory (the run dir, where
+the marker sits); a corrupt marker is a loud `AddModuleError::LinkStateCorrupt`,
+never a silent skip. A **locked run** (`add_modules_from_lockfile`) ignores
+links by contract (reproducible / offline). Implementation:
+`ActiveLinkedCheckout` +
+`resolve_strategy_to_source` in
+[`module_loader/source.rs`](../../libs/streamlib-engine/src/core/runtime/module_loader/source.rs).
+
+*Link-aware staged builds.* When the orchestrator materializes a package under
+an active link, it builds against the checkout so host + plugin come from one
+source tree (removing the mixed-build plugin-ABI hazard from the dev loop by
+construction): the Rust cdylib build is passed the consumer's `[patch]` cargo
+config via `cargo build --config <file>`
+(`assemble_artifact_with_cargo_config`), and the Python venv installs the
+checkout's SDK via `[tool.uv.sources]` (`apply_link_override`). Discovery is
+resolved once per build in `discover_active_build_link`
+([`streamlib-build-orchestrator`](../../libs/streamlib-build-orchestrator/src/lib.rs)).
+
+[`Strategy`]: ../../libs/streamlib-engine/src/core/runtime/module_loader/source.rs
 
 **Manifest-first transaction.** `establish_link` plans every edit in memory,
 persists the full plan to `.streamlib/link.json` with state `Applying` via
@@ -101,8 +133,9 @@ RemoveCreated}`; a file the user modified while linked refuses with
 *toolchain config* files — never a lockfile. `streamlib pkg build` /
 `publish` refuse while any link marker exists up-tree
 (`ensure_no_active_link_for_pack` → `PackRefusedWhileLinked`), and the build
-orchestrator re-injects the same uv-source override from the marker when it
-provisions a linked package's venv (`apply_link_override_if_active`), so a
+orchestrator re-injects the checkout overrides when it materializes a linked
+package — the consumer's `[patch]` cargo config into the cdylib build and the
+uv-source override (`apply_link_override`) into the venv — so a
 cargo-patched-but-venv-from-registry mixed state can't occur.
 
 **What link deliberately does not solve.** Developing against one *specific
@@ -339,7 +372,11 @@ Stated honestly; verify against current code before relying on any.
 ## Reference
 
 - **Link mode**: `libs/streamlib-cli/src/commands/link.rs`,
-  `libs/streamlib-pack/src/link_marker.rs`.
+  `libs/streamlib-idents/src/link_marker.rs` (marker schema + discovery),
+  `libs/streamlib-engine/src/core/runtime/module_loader/source.rs`
+  (`ActiveLinkedCheckout`, link-aware resolution),
+  `libs/streamlib-build-orchestrator/src/lib.rs`
+  (`discover_active_build_link`, staged-build overrides).
 - **Version model**: `libs/streamlib-idents/src/semver.rs` (SemVer +
   ranges), `ident.rs` (`SchemaIdent` release-core invariant),
   `manifest.rs` (`patch:` locality),

--- a/libs/streamlib-build-orchestrator/src/lib.rs
+++ b/libs/streamlib-build-orchestrator/src/lib.rs
@@ -53,7 +53,8 @@ use streamlib_engine::core::runtime::{
     BuildSource, BuildStream, StagedArtifact,
 };
 use streamlib_pack::{
-    assemble_artifact, AssembleOptions, AssembleTarget, PackEventSink, PackStream, PathDepPolicy,
+    assemble_artifact_with_cargo_config, AssembleOptions, AssembleTarget, PackEventSink, PackStream,
+    PathDepPolicy,
 };
 
 /// Monotonic counter for unique per-build temp dir names (process-local;
@@ -266,8 +267,31 @@ impl PolyglotBuildOrchestrator {
         std::fs::create_dir_all(&temp_dir)
             .map_err(|e| other(&pkg_label, format!("create temp stage dir: {e}")))?;
 
+        // Discover the active `streamlib link` once (from the process working
+        // directory — the consumer's run dir). Under an active link every
+        // staged build resolves its streamlib crates from the linked checkout:
+        // the Rust cdylib via the consumer's `streamlib link`-emitted
+        // `[patch]` cargo config, and the Python venv via the checkout's
+        // Python SDK. Host + plugin then come from one source tree, which is
+        // what removes the mixed host/plugin ABI hazard from the dev loop. A
+        // corrupt marker is a loud error, never a silent mixed state.
+        let active_link = discover_active_build_link(&pkg_label)?;
+        if let Some(link) = &active_link {
+            tracing::info!(
+                package = %pkg_label,
+                cargo_config = ?link.consumer_cargo_config,
+                python_sdk = %link.python_sdk_path.display(),
+                "streamlib link active — building staged package against the linked checkout"
+            );
+        }
+        let cargo_config_files: Vec<PathBuf> = active_link
+            .as_ref()
+            .and_then(|l| l.consumer_cargo_config.clone())
+            .into_iter()
+            .collect();
+
         let adapter = EngineSinkAdapter(sink);
-        let outcome = assemble_artifact(
+        let outcome = assemble_artifact_with_cargo_config(
             pkg_dir,
             &AssembleTarget::StagedDir(temp_dir.clone()),
             &AssembleOptions {
@@ -279,6 +303,7 @@ impl PolyglotBuildOrchestrator {
                 path_deps: PathDepPolicy::RewriteRelativeToAbsolute,
             },
             &adapter,
+            &cargo_config_files,
         )
         .map_err(|e| {
             let _ = std::fs::remove_dir_all(&temp_dir);
@@ -289,7 +314,13 @@ impl PolyglotBuildOrchestrator {
         // (no-op when the package has no Python runtime). Building it into
         // `temp_dir` means the atomic rename below carries the venv into
         // place — no second rename. On failure, drop the half-staged temp.
-        python_venv::provision_python_venv(&temp_dir, pkg_dir, &pkg_label).map_err(|e| {
+        // Under an active link the venv installs the checkout's Python SDK.
+        python_venv::provision_python_venv(
+            &temp_dir,
+            active_link.as_ref().map(|l| l.python_sdk_path.as_path()),
+            &pkg_label,
+        )
+        .map_err(|e| {
             let _ = std::fs::remove_dir_all(&temp_dir);
             e
         })?;
@@ -480,6 +511,56 @@ fn atomic_swap(temp: &Path, final_path: &Path) -> anyhow::Result<()> {
     }
     std::fs::rename(temp, final_path).with_context(|| "rename temp into cache slot")?;
     Ok(())
+}
+
+/// An active `streamlib link` resolved for a staged package build: the
+/// checkout-derived toolchain overrides that redirect the build at the linked
+/// checkout instead of the registry.
+#[derive(Debug)]
+struct ActiveBuildLink {
+    /// The consumer's `streamlib link`-emitted `.cargo/config.toml`, when
+    /// present — carries the `[patch."<index>"]` block redirecting every
+    /// `streamlib*` crate at the checkout. `None` when the consumer has no
+    /// cargo config (a Python/Deno-only consumer); the Rust build then falls
+    /// back to registry resolution.
+    consumer_cargo_config: Option<PathBuf>,
+    /// The linked checkout's Python SDK path (uv editable source target).
+    python_sdk_path: PathBuf,
+}
+
+/// Discover the active `streamlib link` for the current build from the process
+/// working directory (the consumer's run dir, where `streamlib link` wrote
+/// `.streamlib/link.json`). `Ok(None)` when no link is active; a corrupt marker
+/// is a loud error — silently ignoring it would produce a mixed build (some
+/// crates from the checkout, some from the registry), the exact failure mode
+/// link mode exists to prevent.
+fn discover_active_build_link(pkg_label: &str) -> Result<Option<ActiveBuildLink>, BuildError> {
+    let cwd = std::env::current_dir()
+        .map_err(|e| other(pkg_label, format!("resolving current working directory: {e}")))?;
+    discover_active_build_link_from(&cwd, pkg_label)
+}
+
+/// [`discover_active_build_link`] anchored at an explicit start dir (test seam).
+fn discover_active_build_link_from(
+    start: &Path,
+    pkg_label: &str,
+) -> Result<Option<ActiveBuildLink>, BuildError> {
+    let link = streamlib_idents::link_marker::find_and_load_active_link(start)
+        .map_err(|e| build_failed(pkg_label, format!("reading streamlib link state: {e}")))?;
+    let Some((marker, manifest)) = link else {
+        return Ok(None);
+    };
+    // marker = <consumer_root>/.streamlib/link.json → the consumer's cargo
+    // config sits at <consumer_root>/.cargo/config.toml (written by the link).
+    let consumer_cargo_config = marker
+        .parent()
+        .and_then(|state_dir| state_dir.parent())
+        .map(|consumer_root| consumer_root.join(".cargo").join("config.toml"))
+        .filter(|cfg| cfg.is_file());
+    Ok(Some(ActiveBuildLink {
+        consumer_cargo_config,
+        python_sdk_path: manifest.python_sdk_path,
+    }))
 }
 
 pub(crate) fn other(package: &str, detail: String) -> BuildError {
@@ -884,6 +965,89 @@ mod tests {
                 "generated file `{rel}` must match standalone codegen byte-for-byte"
             );
         }
+    }
+
+    /// Write a `streamlib link` marker under `consumer_root/.streamlib/link.json`
+    /// pointing at `checkout`, and a consumer cargo config next to it.
+    fn write_link_marker(consumer_root: &Path, checkout: &Path, with_cargo_config: bool) {
+        let state = consumer_root.join(".streamlib");
+        std::fs::create_dir_all(&state).unwrap();
+        std::fs::write(
+            state.join("link.json"),
+            format!(
+                r#"{{"checkout":"{c}","python_sdk_path":"{c}/libs/streamlib-python","deno_sdk_entrypoint_path":"{c}/libs/streamlib-deno/mod.ts","linked_at":"t","linked_crate_count":1,"state":"active","files":[]}}"#,
+                c = checkout.display()
+            ),
+        )
+        .unwrap();
+        if with_cargo_config {
+            let cargo = consumer_root.join(".cargo");
+            std::fs::create_dir_all(&cargo).unwrap();
+            std::fs::write(cargo.join("config.toml"), "[patch.\"x\"]\n").unwrap();
+        }
+    }
+
+    #[test]
+    fn discover_build_link_none_without_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(discover_active_build_link_from(dir.path(), "tatolab/x")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn discover_build_link_resolves_cargo_config_and_sdk_path() {
+        // An active link with a consumer cargo config: discovery returns the
+        // config path (the [patch] injected into the cdylib build) and the
+        // checkout's python_sdk_path (the venv override). Reverting the
+        // parent().parent() derivation would miss the consumer cargo config.
+        let consumer = tempfile::tempdir().unwrap();
+        let checkout = tempfile::tempdir().unwrap();
+        write_link_marker(consumer.path(), checkout.path(), true);
+
+        let link = discover_active_build_link_from(consumer.path(), "tatolab/x")
+            .unwrap()
+            .expect("active link must be discovered");
+        assert_eq!(
+            link.consumer_cargo_config,
+            Some(consumer.path().join(".cargo").join("config.toml")),
+            "must locate the consumer's link-emitted cargo config"
+        );
+        assert_eq!(
+            link.python_sdk_path,
+            checkout.path().join("libs").join("streamlib-python"),
+            "must carry the checkout's python SDK path from the marker"
+        );
+    }
+
+    #[test]
+    fn discover_build_link_without_cargo_config_still_resolves_sdk() {
+        // A Python/Deno-only consumer has no cargo config; discovery still
+        // returns the link (sdk path present, cargo config None) so the venv
+        // override fires even when the cargo override can't.
+        let consumer = tempfile::tempdir().unwrap();
+        let checkout = tempfile::tempdir().unwrap();
+        write_link_marker(consumer.path(), checkout.path(), false);
+
+        let link = discover_active_build_link_from(consumer.path(), "tatolab/x")
+            .unwrap()
+            .expect("active link must be discovered");
+        assert!(link.consumer_cargo_config.is_none());
+        assert_eq!(
+            link.python_sdk_path,
+            checkout.path().join("libs").join("streamlib-python")
+        );
+    }
+
+    #[test]
+    fn discover_build_link_corrupt_marker_is_a_loud_error() {
+        let consumer = tempfile::tempdir().unwrap();
+        let state = consumer.path().join(".streamlib");
+        std::fs::create_dir_all(&state).unwrap();
+        std::fs::write(state.join("link.json"), "{ not json").unwrap();
+        let err = discover_active_build_link_from(consumer.path(), "tatolab/x")
+            .expect_err("corrupt marker must fail loudly");
+        assert!(matches!(err, BuildError::BuildFailed { .. }), "got {err:?}");
     }
 
     #[test]

--- a/libs/streamlib-build-orchestrator/src/python_venv.rs
+++ b/libs/streamlib-build-orchestrator/src/python_venv.rs
@@ -33,16 +33,17 @@ use streamlib_engine::core::runtime::BuildError;
 /// (Windows) — so that after the orchestrator's atomic rename it lands at
 /// `{staged_package_dir}/.venv/bin/python`.
 ///
-/// `source_pkg_dir` is the on-disk package source the artifact was assembled
-/// from; it is walked upward for an active `streamlib link` marker so the venv
-/// can build against a linked checkout's Python SDK. Pass the staged dir when
-/// there is no distinct source tree.
+/// `link_python_sdk`, when `Some`, is the linked checkout's Python SDK path
+/// (resolved once by the orchestrator from the active `streamlib link`); the
+/// staged pyproject's `streamlib` dependency is redirected at it so the venv
+/// resolves the SDK from the checkout instead of the registry — the cargo
+/// `[patch]` mirror on the Python side. `None` ⇒ registry resolution.
 ///
 /// No-op (returns `Ok(())`) when the staged package has no Python runtime.
-#[tracing::instrument(skip(temp_dir, source_pkg_dir), fields(temp_dir = %temp_dir.display(), package = %package_label))]
+#[tracing::instrument(skip(temp_dir, link_python_sdk), fields(temp_dir = %temp_dir.display(), package = %package_label))]
 pub fn provision_python_venv(
     temp_dir: &Path,
-    source_pkg_dir: &Path,
+    link_python_sdk: Option<&Path>,
     package_label: &str,
 ) -> Result<(), BuildError> {
     if !staged_package_has_python(temp_dir) {
@@ -77,12 +78,12 @@ pub fn provision_python_venv(
     };
 
     // ---- link-mode override ----
-    // When a `streamlib link` is active for the source tree this package was
-    // built from, redirect the staged pyproject's `streamlib` dependency at the
-    // linked checkout's Python SDK before installing, so the venv resolves the
-    // SDK from local source (mirrors the cargo `[patch]` the CLI emits).
-    if let Some(pyproject) = &pyproject_path {
-        apply_link_override_if_active(pyproject, source_pkg_dir, package_label)?;
+    // When a `streamlib link` is active (the orchestrator resolved the
+    // checkout's Python SDK), redirect the staged pyproject's `streamlib`
+    // dependency at it before installing, so the venv resolves the SDK from the
+    // checkout (mirrors the cargo `[patch]` injected into the cdylib build).
+    if let (Some(pyproject), Some(sdk_path)) = (&pyproject_path, link_python_sdk) {
+        apply_link_override(pyproject, sdk_path, package_label)?;
     }
 
     // ---- uv venv ----
@@ -319,28 +320,17 @@ fn build_failed(package: &str, detail: String) -> BuildError {
     }
 }
 
-/// If a `streamlib link` is active for `source_pkg_dir` (discovered via the
-/// shared marker primitive in `streamlib_pack::link_marker`), rewrite the
-/// staged `pyproject`'s `streamlib` dependency to resolve from the linked
-/// checkout's Python SDK via `[tool.uv.sources]`. A corrupt marker is a loud
-/// error — silently ignoring it would produce a mixed state (cargo patched,
-/// venv from registry).
-fn apply_link_override_if_active(
+/// Rewrite the staged `pyproject`'s `streamlib` dependency to resolve from the
+/// linked checkout's Python SDK at `sdk_path` via `[tool.uv.sources]`. Called
+/// only when the orchestrator resolved an active `streamlib link` — the
+/// discovery + corrupt-marker handling live there, so this is a pure
+/// manifest rewrite.
+fn apply_link_override(
     pyproject: &Path,
-    source_pkg_dir: &Path,
+    sdk_path: &Path,
     package_label: &str,
 ) -> Result<(), BuildError> {
-    let link = streamlib_pack::link_marker::find_and_load_active_link(source_pkg_dir)
-        .map_err(|e| build_failed(package_label, e.to_string()))?;
-    let Some((marker, manifest)) = link else {
-        return Ok(());
-    };
-    // The marker carries the resolved absolute SDK path — read data, don't
-    // re-derive a checkout-relative convention.
-    let sdk_path = manifest.python_sdk_path;
     tracing::info!(
-        marker = %marker.display(),
-        checkout = %manifest.checkout.display(),
         sdk = %sdk_path.display(),
         "streamlib link active — pointing staged pyproject's streamlib dep at the linked checkout"
     );
@@ -470,7 +460,7 @@ packages = ["python"]
         // schemas-only or Rust-only package.
         let temp = tempfile::tempdir().unwrap();
         std::fs::write(temp.path().join("streamlib.yaml"), "package:\n  name: x\n").unwrap();
-        provision_python_venv(temp.path(), temp.path(), "tatolab/x")
+        provision_python_venv(temp.path(), None, "tatolab/x")
             .expect("no-python must be a no-op");
         assert!(
             !temp.path().join(".venv").exists(),
@@ -497,7 +487,7 @@ packages = ["python"]
         let temp = tempfile::tempdir().unwrap();
         write_staged_python_package(temp.path(), &sdk);
 
-        provision_python_venv(temp.path(), temp.path(), "tatolab/mypkg")
+        provision_python_venv(temp.path(), None, "tatolab/mypkg")
             .expect("provision must succeed offline against the fixture SDK");
 
         // Contract: interpreter at exactly {temp_dir}/.venv/bin/python.
@@ -527,35 +517,13 @@ packages = ["python"]
         assert!(has_pyc, "compileall must have produced at least one .pyc in the venv");
     }
 
-    /// Write a full-schema link marker whose `python_sdk_path` points at `sdk`.
-    fn write_link_marker(source_root: &Path, sdk: &Path) {
-        let marker_dir = source_root.join(".streamlib");
-        std::fs::create_dir_all(&marker_dir).unwrap();
-        std::fs::write(
-            marker_dir.join("link.json"),
-            format!(
-                r#"{{
-  "checkout": "/opt/streamlib-checkout",
-  "python_sdk_path": "{sdk}",
-  "deno_sdk_entrypoint_path": "/opt/streamlib-checkout/libs/streamlib-deno/mod.ts",
-  "linked_at": "2026-01-01T00:00:00Z",
-  "linked_crate_count": 1,
-  "state": "active",
-  "files": []
-}}"#,
-                sdk = sdk.display()
-            ),
-        )
-        .unwrap();
-    }
-
     #[test]
-    fn link_override_redirects_staged_pyproject_at_the_marker_python_sdk_path() {
-        // A source tree carrying an active `streamlib link` marker; the staged
-        // pyproject's streamlib dep must be redirected at the marker's
-        // recorded absolute python_sdk_path (data, not re-derived).
-        let src = tempfile::tempdir().unwrap();
-        write_link_marker(src.path(), Path::new("/opt/streamlib-checkout/libs/streamlib-python"));
+    fn link_override_redirects_staged_pyproject_at_the_sdk_path() {
+        // Given the linked checkout's Python SDK path (resolved by the
+        // orchestrator), the staged pyproject's streamlib dep is redirected at
+        // it via `[tool.uv.sources]`. Reverting the rewrite would leave the dep
+        // resolving from the registry.
+        let sdk = Path::new("/opt/streamlib-checkout/libs/streamlib-python");
 
         let staged = tempfile::tempdir().unwrap();
         let pyproject = staged.path().join("pyproject.toml");
@@ -565,7 +533,7 @@ packages = ["python"]
         )
         .unwrap();
 
-        apply_link_override_if_active(&pyproject, src.path(), "tatolab/p").unwrap();
+        apply_link_override(&pyproject, sdk, "tatolab/p").unwrap();
 
         let body = std::fs::read_to_string(&pyproject).unwrap();
         assert!(body.contains("[tool.uv.sources]"), "sources table missing:\n{body}");
@@ -577,53 +545,12 @@ packages = ["python"]
     }
 
     #[test]
-    fn link_override_is_a_noop_without_an_active_marker() {
-        let src = tempfile::tempdir().unwrap();
-        let staged = tempfile::tempdir().unwrap();
-        let pyproject = staged.path().join("pyproject.toml");
-        let original = "[project]\nname = \"p\"\nversion = \"0.1.0\"\ndependencies = [\"streamlib\"]\n";
-        std::fs::write(&pyproject, original).unwrap();
-
-        apply_link_override_if_active(&pyproject, src.path(), "tatolab/p").unwrap();
-
-        // No marker ⇒ pyproject untouched.
-        assert_eq!(std::fs::read_to_string(&pyproject).unwrap(), original);
-    }
-
-    #[test]
-    fn corrupt_link_marker_is_a_loud_error_not_a_silent_skip() {
-        // A corrupt link.json must fail the provision — silently ignoring it
-        // produces a mixed state (cargo patched to the checkout, venv built
-        // from the registry).
-        let src = tempfile::tempdir().unwrap();
-        let marker_dir = src.path().join(".streamlib");
-        std::fs::create_dir_all(&marker_dir).unwrap();
-        std::fs::write(marker_dir.join("link.json"), "{ definitely not json").unwrap();
-
-        let staged = tempfile::tempdir().unwrap();
-        let pyproject = staged.path().join("pyproject.toml");
-        let original = "[project]\nname = \"p\"\nversion = \"0.1.0\"\ndependencies = [\"streamlib\"]\n";
-        std::fs::write(&pyproject, original).unwrap();
-
-        let err = apply_link_override_if_active(&pyproject, src.path(), "tatolab/p")
-            .expect_err("corrupt marker must be a loud error");
-        assert!(
-            format!("{err}").contains("corrupt"),
-            "error must name the corruption, got: {err}"
-        );
-        // And the staged pyproject was not half-mutated.
-        assert_eq!(std::fs::read_to_string(&pyproject).unwrap(), original);
-    }
-
-    #[test]
     fn non_table_tool_key_in_staged_pyproject_is_a_typed_error_not_a_panic() {
-        let src = tempfile::tempdir().unwrap();
-        write_link_marker(src.path(), Path::new("/opt/sdk"));
         let staged = tempfile::tempdir().unwrap();
         let pyproject = staged.path().join("pyproject.toml");
         std::fs::write(&pyproject, "tool = 3\n").unwrap();
 
-        let err = apply_link_override_if_active(&pyproject, src.path(), "tatolab/p")
+        let err = apply_link_override(&pyproject, Path::new("/opt/sdk"), "tatolab/p")
             .expect_err("non-table `tool` must be a typed error");
         assert!(
             format!("{err}").contains("not a table"),
@@ -632,11 +559,11 @@ packages = ["python"]
     }
 
     #[test]
-    fn provision_applies_link_override_end_to_end_against_marked_source_tree() {
-        // T4: drive the override through `provision_python_venv` itself — a
-        // marked SOURCE tree whose python_sdk_path points at the offline
-        // fixture SDK; the STAGED pyproject (no uv source of its own) must be
-        // rewritten and the venv must install the linked SDK. Requires `uv`.
+    fn provision_applies_link_override_end_to_end_against_linked_sdk() {
+        // Drive the override through `provision_python_venv` itself: passing the
+        // offline fixture SDK as the link SDK path, the STAGED pyproject (no uv
+        // source of its own) must be rewritten and the venv must install the
+        // linked SDK. Requires `uv`.
         if which_uv().is_none() {
             eprintln!("skipping: `uv` not on PATH");
             return;
@@ -644,10 +571,6 @@ packages = ["python"]
 
         let root = tempfile::tempdir().unwrap();
         let sdk = write_fixture_streamlib_sdk(root.path());
-
-        // Source tree with an active link marker pointing at the fixture SDK.
-        let src = tempfile::tempdir().unwrap();
-        write_link_marker(src.path(), &sdk);
 
         // Staged package WITHOUT any uv source — resolution must come from
         // the injected link override.
@@ -669,7 +592,7 @@ packages = ["python"]
         )
         .unwrap();
 
-        provision_python_venv(staged.path(), src.path(), "tatolab/mypkg")
+        provision_python_venv(staged.path(), Some(&sdk), "tatolab/mypkg")
             .expect("provision must succeed against the linked fixture SDK");
 
         // The staged pyproject got the override injected…

--- a/libs/streamlib-cli/src/commands/install.rs
+++ b/libs/streamlib-cli/src/commands/install.rs
@@ -56,7 +56,7 @@ pub fn run(project_dir: Option<&Path>, lockfile_path: Option<PathBuf>) -> Result
     // toolchains (cargo/uv/deno) at the checkout. Surface it so the operator
     // knows the lockfile reflects a linked tree (path-declared deps are
     // recorded as `path:` sources in the lockfile).
-    if let Some(marker) = streamlib_pack::link_marker::find_active_link_marker(&root) {
+    if let Some(marker) = streamlib_idents::link_marker::find_active_link_marker(&root) {
         println!(
             "note: installing inside an active streamlib link (marker: {}) — \
              local checkout overrides are in effect",

--- a/libs/streamlib-cli/src/commands/link.rs
+++ b/libs/streamlib-cli/src/commands/link.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
-use streamlib_pack::link_marker::{
+use streamlib_idents::link_marker::{
     LinkManifest, LinkMarkerError, LinkTransactionState, LinkedManifestFile, LINK_BACKUP_DIR,
     LINK_MANIFEST_FILE, LINK_STATE_DIR,
 };
@@ -366,7 +366,7 @@ fn load_active_manifest(consumer_root: &Path) -> Result<Option<LinkManifest>, Li
     if !path.is_file() {
         return Ok(None);
     }
-    Ok(Some(streamlib_pack::link_marker::load_link_manifest(
+    Ok(Some(streamlib_idents::link_marker::load_link_manifest(
         &path,
     )?))
 }

--- a/libs/streamlib-cli/src/commands/pkg.rs
+++ b/libs/streamlib-cli/src/commands/pkg.rs
@@ -24,7 +24,7 @@ pub fn build(output: Option<&Path>) -> Result<()> {
     let package_dir = std::env::current_dir().context("resolve current working directory")?;
     // Early friendly check; the load-bearing guard runs again inside
     // `assemble_artifact`'s Slpkg branch (streamlib-pack owns the seam).
-    streamlib_pack::link_marker::ensure_no_active_link_for_pack(&package_dir)?;
+    streamlib_idents::link_marker::ensure_no_active_link_for_pack(&package_dir)?;
     let output_path = resolve_slpkg_output(&package_dir, output)?;
     let outcome = assemble_source_slpkg(&package_dir, &output_path)?;
     println!("Built source-only package: {}", output_path.display());
@@ -48,7 +48,7 @@ pub fn publish() -> Result<()> {
     let package_dir = std::env::current_dir().context("resolve current working directory")?;
     // Early friendly check; the load-bearing guard runs again inside
     // `assemble_artifact`'s Slpkg branch (streamlib-pack owns the seam).
-    streamlib_pack::link_marker::ensure_no_active_link_for_pack(&package_dir)?;
+    streamlib_idents::link_marker::ensure_no_active_link_for_pack(&package_dir)?;
     // Lightweight manifest read — package metadata only, NO dependency
     // resolution (which would require the registry just to read name/version).
     let config = streamlib_cargo_build::read_minimal_project_config(&package_dir)

--- a/libs/streamlib-engine/src/core/runtime/module_loader/errors.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/errors.rs
@@ -186,6 +186,23 @@ pub enum AddModuleError {
         detail: String,
     },
 
+    /// An active `streamlib link` marker exists but its `.streamlib/link.json`
+    /// could not be parsed. Never silently ignored — a corrupt marker would
+    /// leave resolution in a mixed state (some modules from the checkout, some
+    /// from the registry), the exact failure mode link mode exists to prevent.
+    /// Run `streamlib unlink` to clear the torn state, then re-link.
+    #[error(
+        "active streamlib link marker is corrupt, refusing to resolve modules \
+         against an ambiguous link: {detail}. Run `streamlib unlink` and re-link."
+    )]
+    LinkStateCorrupt { detail: String },
+
+    /// Discovering the active `streamlib link` for the current run failed at
+    /// the filesystem level (working directory unreadable, or the linked
+    /// checkout's `packages/` tree could not be enumerated).
+    #[error("could not read streamlib link state for module resolution: {detail}")]
+    LinkStateUnreadable { detail: String },
+
     /// A graph-mutating call ([`Runner::add_processor`] / `connect` /
     /// `start`) ran while one or more modules were still loading. Await
     /// the pending loads (e.g. via [`Runner::await_modules`]) before

--- a/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -137,6 +137,24 @@ fn run_module_load(
     let mut seen: HashSet<streamlib_idents::PackageRef> = HashSet::new();
     let mut path: Vec<streamlib_idents::PackageRef> = Vec::new();
     let mut skipped_in_flight: Vec<recursive_walker::SkippedInFlightDependency> = Vec::new();
+
+    // Discover an active `streamlib link` once per top-level load, from the
+    // process working directory (the consumer's run dir, where `streamlib link`
+    // wrote `.streamlib/link.json`). A locked run IGNORES links by contract —
+    // it is reproducible / offline — via `discover_active_link_for_load`. A
+    // corrupt marker fails the load loudly rather than silently mixing checkout
+    // + registry resolution.
+    let link = match source::discover_active_link_for_load(locked.is_some()) {
+        Ok(link) => link,
+        Err(e) => {
+            let _ = events.send(ModuleLoadEvent::Failed {
+                ident: module.clone(),
+                error: e.to_string(),
+            });
+            return Err(e);
+        }
+    };
+
     let result = recursive_walker::add_module_recursively(
         &iceoryx2_node,
         orchestrator.as_ref(),
@@ -149,6 +167,7 @@ fn run_module_load(
         load_id,
         &mut skipped_in_flight,
         locked.as_deref(),
+        link.as_ref(),
     );
     // End-of-walk verification: this walk skipped some packages because a
     // CONCURRENT load had them in flight at the same version. Before

--- a/libs/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
@@ -12,7 +12,10 @@ use super::errors::AddModuleError;
 use super::locked::LockedResolution;
 use super::processor_registration::register_manifest_processors;
 use super::schema_registration::register_package_schemas;
-use super::source::{read_version_from_manifest_dir, resolve_strategy_to_source, ResolvedSource, Strategy};
+use super::source::{
+    read_version_from_manifest_dir, resolve_strategy_to_source, ActiveLinkedCheckout,
+    ResolvedSource, Strategy,
+};
 use crate::core::{Error, Result};
 use crate::iceoryx2::Iceoryx2Node;
 
@@ -429,6 +432,7 @@ pub(super) fn add_module_recursively(
     load_id: u64,
     skipped_in_flight: &mut Vec<SkippedInFlightDependency>,
     locked: Option<&LockedResolution>,
+    link: Option<&ActiveLinkedCheckout>,
 ) -> std::result::Result<(), AddModuleError> {
     let pkg_ref = module.package_ref();
     if !seen.insert(pkg_ref.clone()) {
@@ -449,6 +453,7 @@ pub(super) fn add_module_recursively(
         load_id,
         skipped_in_flight,
         locked,
+        link,
     );
     seen.remove(&pkg_ref);
     path.pop();
@@ -468,14 +473,18 @@ fn add_module_recursive_body(
     load_id: u64,
     skipped_in_flight: &mut Vec<SkippedInFlightDependency>,
     locked: Option<&LockedResolution>,
+    link: Option<&ActiveLinkedCheckout>,
 ) -> std::result::Result<(), AddModuleError> {
     use crate::core::config::ProjectConfig;
 
     let pkg_ref = module.package_ref();
 
     // Resolve where the source lives (pure filesystem / cache / git),
-    // then materialize via the orchestrator if a build is required.
-    let manifest_dir = match resolve_strategy_to_source(&strategy, &pkg_ref)? {
+    // then materialize via the orchestrator if a build is required. `link`,
+    // when present, redirects a checkout-present package to the linked
+    // checkout regardless of `strategy` (npm-link semantics; locked runs pass
+    // `None`).
+    let manifest_dir = match resolve_strategy_to_source(&strategy, &pkg_ref, link)? {
         ResolvedSource::Ready(dir) => dir,
         ResolvedSource::NeedsBuild(request) => match orchestrator {
             // An orchestrator is wired — materialize (fetch/build/stage).
@@ -636,6 +645,7 @@ fn add_module_recursive_body(
             load_id,
             skipped_in_flight,
             locked,
+            link,
         )?;
     }
 

--- a/libs/streamlib-engine/src/core/runtime/module_loader/source.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/source.rs
@@ -140,13 +140,177 @@ pub(super) enum ResolvedSource {
     NeedsBuild(BuildRequest),
 }
 
+/// An active `streamlib link` discovered for the current run, carrying the
+/// linked checkout so the resolver can redirect module resolution to the
+/// checkout's `packages/` tree.
+///
+/// npm-link semantics: a package present in the checkout takes precedence over
+/// whatever [`Strategy`] the caller declared (registry / path / url / …), so
+/// editing a linked package and re-running picks up the edit even for the
+/// dominant `add_module(ident, registry())` app shape. A package NOT in the
+/// checkout is unaffected and resolves from its declared strategy.
+#[derive(Debug, Clone)]
+pub(super) struct ActiveLinkedCheckout {
+    /// Canonicalized path of the linked streamlib checkout.
+    checkout: PathBuf,
+}
+
+impl ActiveLinkedCheckout {
+    /// Discover an active link from the process working directory — the
+    /// consumer's run dir, where `streamlib link` wrote `.streamlib/link.json`.
+    /// `Ok(None)` when no link is active; a corrupt marker is a loud typed
+    /// error, never a silent skip.
+    #[tracing::instrument]
+    pub(super) fn discover_from_cwd() -> std::result::Result<Option<Self>, AddModuleError> {
+        let cwd =
+            std::env::current_dir().map_err(|e| AddModuleError::LinkStateUnreadable {
+                detail: format!("resolving current working directory: {e}"),
+            })?;
+        Self::discover_from(&cwd)
+    }
+
+    /// [`Self::discover_from_cwd`] anchored at an explicit start dir (test seam).
+    pub(super) fn discover_from(
+        start: &std::path::Path,
+    ) -> std::result::Result<Option<Self>, AddModuleError> {
+        match streamlib_idents::link_marker::find_and_load_active_link(start) {
+            Ok(Some((_marker, manifest))) => Ok(Some(Self {
+                checkout: manifest.checkout,
+            })),
+            Ok(None) => Ok(None),
+            Err(e) => Err(AddModuleError::LinkStateCorrupt {
+                detail: e.to_string(),
+            }),
+        }
+    }
+
+    /// The linked checkout path.
+    pub(super) fn checkout(&self) -> &std::path::Path {
+        &self.checkout
+    }
+
+    /// If `pkg_ref` (`@org/name`) is present in the checkout's `packages/`
+    /// tree, return its source dir. The match is by the manifest's declared
+    /// `package.org` + `package.name` (not the directory name), so a package
+    /// whose directory differs from its name still resolves. `Ok(None)` when
+    /// the package is absent — the caller then resolves it from its declared
+    /// strategy, unchanged.
+    pub(super) fn checkout_package_dir(
+        &self,
+        pkg_ref: &streamlib_idents::PackageRef,
+    ) -> std::result::Result<Option<PathBuf>, AddModuleError> {
+        let packages_root = self.checkout.join("packages");
+        if !packages_root.is_dir() {
+            return Ok(None);
+        }
+        // Fast path: the standard monorepo layout is `packages/<name>`.
+        let by_name = packages_root.join(pkg_ref.name.as_str());
+        if manifest_declares_package(&by_name, pkg_ref) {
+            return Ok(Some(by_name));
+        }
+        // Fallback: scan for a package dir whose manifest declares this ident
+        // (covers a package whose directory name differs from its package name).
+        let entries =
+            std::fs::read_dir(&packages_root).map_err(|e| AddModuleError::LinkStateUnreadable {
+                detail: format!(
+                    "reading linked checkout packages dir {}: {e}",
+                    packages_root.display()
+                ),
+            })?;
+        for entry in entries.flatten() {
+            let dir = entry.path();
+            if dir == by_name || !dir.is_dir() {
+                continue;
+            }
+            if manifest_declares_package(&dir, pkg_ref) {
+                return Ok(Some(dir));
+            }
+        }
+        Ok(None)
+    }
+}
+
+/// Resolve the active link to thread into a top-level module load, honoring
+/// the locked-run contract: a **locked** run (`add_modules_from_lockfile`)
+/// IGNORES links — it must be reproducible / offline — so it always resolves
+/// to `None`. A live run discovers the link from the process working directory.
+/// This is the single gate that keeps locked runs link-free.
+pub(super) fn discover_active_link_for_load(
+    is_locked: bool,
+) -> std::result::Result<Option<ActiveLinkedCheckout>, AddModuleError> {
+    if is_locked {
+        Ok(None)
+    } else {
+        ActiveLinkedCheckout::discover_from_cwd()
+    }
+}
+
+/// [`discover_active_link_for_load`] with the discovery anchored at an explicit
+/// start dir (test seam) so the locked gate can be locked without touching the
+/// process working directory.
+#[cfg(test)]
+pub(super) fn discover_active_link_for_load_from(
+    is_locked: bool,
+    start: &std::path::Path,
+) -> std::result::Result<Option<ActiveLinkedCheckout>, AddModuleError> {
+    if is_locked {
+        Ok(None)
+    } else {
+        ActiveLinkedCheckout::discover_from(start)
+    }
+}
+
+/// Whether the `streamlib.yaml` at `dir` declares a package whose org + name
+/// equal `pkg_ref`. A missing / unreadable / malformed manifest is treated as
+/// "no match" — this dir just isn't the package we're looking for; a genuine
+/// manifest error surfaces on the real load path with a precise message.
+fn manifest_declares_package(
+    dir: &std::path::Path,
+    pkg_ref: &streamlib_idents::PackageRef,
+) -> bool {
+    use streamlib_idents::Manifest;
+    if !dir.join(Manifest::FILE_NAME).exists() {
+        return false;
+    }
+    match Manifest::load(dir) {
+        Ok(m) => m
+            .package
+            .as_ref()
+            .is_some_and(|p| p.org == pkg_ref.org && p.name == pkg_ref.name),
+        Err(_) => false,
+    }
+}
+
 /// Resolve a [`Strategy`] to a [`ResolvedSource`]. Pure source-location
 /// logic (cache lookup, `.slpkg` extract, git checkout); never invokes a
 /// build tool.
+///
+/// When `link` is `Some` (a non-locked run with an active `streamlib link`), a
+/// package present in the linked checkout's `packages/` tree is resolved from
+/// there regardless of `strategy` — see [`ActiveLinkedCheckout`]. Locked runs
+/// pass `None` (reproducible / offline by contract), and a package absent from
+/// the checkout falls through to `strategy` unchanged.
 pub(super) fn resolve_strategy_to_source(
     strategy: &Strategy,
     pkg_ref: &streamlib_idents::PackageRef,
+    link: Option<&ActiveLinkedCheckout>,
 ) -> std::result::Result<ResolvedSource, AddModuleError> {
+    // Link-aware short-circuit (npm-link semantics): an active link redirects
+    // resolution of ANY package present in the linked checkout, overriding the
+    // caller's strategy. This is what makes `streamlib link` → edit → re-run
+    // reflect a checkout edit for the dominant `add_module(ident, registry())`
+    // app shape. IfStale rebuilds on edit via the build tool's own fingerprint.
+    if let Some(link) = link {
+        if let Some(pkg_dir) = link.checkout_package_dir(pkg_ref)? {
+            tracing::info!(
+                package = %pkg_ref,
+                checkout = %link.checkout().display(),
+                source = %pkg_dir.display(),
+                "streamlib link active — resolving module from linked checkout (overriding strategy)"
+            );
+            return Ok(source_for_dir(pkg_ref, pkg_dir, BuildPolicy::IfStale));
+        }
+    }
     match strategy {
         Strategy::InstalledCache => {
             let (dir, _version) = lookup_installed_cache(pkg_ref)?
@@ -886,5 +1050,218 @@ mod tests {
         let cached = fetch_remote_slpkg(&pkg_ref(), &url, None).expect("http fetch must succeed");
         assert_eq!(std::fs::read(&cached).unwrap(), body);
         server.join().unwrap();
+    }
+
+    // =====================================================================
+    // ActiveLinkedCheckout — link-aware resolution (npm-link semantics)
+    // =====================================================================
+
+    fn pkg_ref_named(name: &str) -> streamlib_idents::PackageRef {
+        streamlib_idents::PackageRef::new(
+            streamlib_idents::Org::new("tatolab").unwrap(),
+            streamlib_idents::Package::new(name).unwrap(),
+        )
+    }
+
+    /// Build a fake linked checkout containing `packages/<dir_name>/streamlib.yaml`
+    /// declaring `@tatolab/<pkg_name>`. `dir_name` and `pkg_name` differ only in
+    /// the scan-fallback test.
+    fn fake_checkout_with_package(dir_name: &str, pkg_name: &str) -> tempfile::TempDir {
+        let checkout = tempfile::tempdir().unwrap();
+        let pkg = checkout.path().join("packages").join(dir_name);
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(
+            pkg.join("streamlib.yaml"),
+            format!(
+                "package:\n  org: tatolab\n  name: {pkg_name}\n  version: 0.1.0\nprocessors:\n  \
+                 - name: P\n    version: 1.0.0\n    description: d\n    runtime: python\n    \
+                 execution: manual\n    entrypoint: \"p:P\"\n    inputs: []\n    outputs: []\n"
+            ),
+        )
+        .unwrap();
+        checkout
+    }
+
+    /// Write a link marker under `consumer_root/.streamlib/link.json` pointing at
+    /// `checkout`, then discover it. The discovery walks up from `consumer_root`
+    /// (no CWD dependency — hermetic).
+    fn active_link_for(
+        consumer_root: &std::path::Path,
+        checkout: &std::path::Path,
+    ) -> ActiveLinkedCheckout {
+        let marker_dir = consumer_root.join(".streamlib");
+        std::fs::create_dir_all(&marker_dir).unwrap();
+        std::fs::write(
+            marker_dir.join("link.json"),
+            format!(
+                r#"{{"checkout":"{c}","python_sdk_path":"{c}/libs/streamlib-python","deno_sdk_entrypoint_path":"{c}/libs/streamlib-deno/mod.ts","linked_at":"t","linked_crate_count":1,"state":"active","files":[]}}"#,
+                c = checkout.display()
+            ),
+        )
+        .unwrap();
+        ActiveLinkedCheckout::discover_from(consumer_root)
+            .expect("discovery must not error")
+            .expect("an active link must be found")
+    }
+
+    fn assert_builds_from(resolved: ResolvedSource, expected_dir: &std::path::Path) {
+        match resolved {
+            ResolvedSource::NeedsBuild(req) => match req.source {
+                BuildSource::PackageDir(dir) => assert_eq!(
+                    dir, expected_dir,
+                    "must build from the checkout package dir"
+                ),
+                other => panic!("expected PackageDir source, got {other:?}"),
+            },
+            other => panic!("expected NeedsBuild(checkout), got {other:?}"),
+        }
+    }
+
+    /// CRUX (issue #1246): an active link redirects a `Strategy::Registry` load
+    /// of a checkout-present package to the checkout, OVERRIDING the explicit
+    /// registry strategy (npm-link semantics — a linked name takes precedence).
+    /// Mentally revert the link short-circuit at the top of
+    /// `resolve_strategy_to_source` and this resolves from the registry instead
+    /// (RegistryNotConfigured), failing the assertion.
+    #[test]
+    fn active_link_overrides_registry_strategy_for_checkout_present_package() {
+        let checkout = fake_checkout_with_package("foo", "foo");
+        let consumer = tempfile::tempdir().unwrap();
+        let link = active_link_for(consumer.path(), checkout.path());
+
+        let resolved = resolve_strategy_to_source(
+            &Strategy::Registry {
+                version_req: SemVerRange::Any,
+                build: BuildPolicy::IfStale,
+            },
+            &pkg_ref_named("foo"),
+            Some(&link),
+        )
+        .expect("linked checkout-present package must resolve from the checkout, not error");
+        assert_builds_from(resolved, &checkout.path().join("packages").join("foo"));
+    }
+
+    /// A package ABSENT from the checkout falls through to its declared strategy
+    /// even under an active link — registry strategies stay available. Using
+    /// `Strategy::Path` to a nonexistent dir gives an env-independent signal
+    /// that the strategy dispatch (not the link branch) ran.
+    #[test]
+    fn active_link_leaves_absent_package_on_its_declared_strategy() {
+        let checkout = fake_checkout_with_package("foo", "foo");
+        let consumer = tempfile::tempdir().unwrap();
+        let link = active_link_for(consumer.path(), checkout.path());
+
+        let missing = consumer.path().join("nope");
+        let err = resolve_strategy_to_source(
+            &Strategy::Path {
+                path: missing.clone(),
+                build: BuildPolicy::IfStale,
+            },
+            &pkg_ref_named("bar"), // NOT in the checkout
+            Some(&link),
+        )
+        .expect_err("absent-from-checkout package must use its declared strategy");
+        assert!(
+            matches!(err, AddModuleError::ManifestDirectoryMissing { .. }),
+            "expected the Path strategy to run unchanged, got {err:?}"
+        );
+    }
+
+    /// UNLINKED regression: with `link = None`, resolution is byte-for-byte the
+    /// pre-change behavior — a checkout-present package name resolves from its
+    /// declared strategy, NOT any checkout. Mentally revert nothing; this must
+    /// pass on both the pre- and post-change code (the `None` path is untouched).
+    #[test]
+    fn no_link_resolution_is_unchanged() {
+        // Same package name ("foo") that the linked test redirects — but with no
+        // link, the strategy is authoritative. A nonexistent Path errors exactly
+        // as before.
+        let consumer = tempfile::tempdir().unwrap();
+        let missing = consumer.path().join("nope");
+        let err = resolve_strategy_to_source(
+            &Strategy::Path {
+                path: missing,
+                build: BuildPolicy::IfStale,
+            },
+            &pkg_ref_named("foo"),
+            None,
+        )
+        .expect_err("without a link the declared strategy is authoritative");
+        assert!(
+            matches!(err, AddModuleError::ManifestDirectoryMissing { .. }),
+            "unlinked resolution must be unchanged, got {err:?}"
+        );
+    }
+
+    /// The scan fallback matches a package whose directory name differs from its
+    /// declared package name (match is by manifest org+name, not dir name).
+    #[test]
+    fn active_link_scan_fallback_matches_by_manifest_not_dir_name() {
+        // dir = "weird-dir", but the manifest declares @tatolab/camera.
+        let checkout = fake_checkout_with_package("weird-dir", "camera");
+        let consumer = tempfile::tempdir().unwrap();
+        let link = active_link_for(consumer.path(), checkout.path());
+
+        let resolved = resolve_strategy_to_source(
+            &Strategy::Registry {
+                version_req: SemVerRange::Any,
+                build: BuildPolicy::IfStale,
+            },
+            &pkg_ref_named("camera"),
+            Some(&link),
+        )
+        .expect("scan fallback must find the package by manifest identity");
+        assert_builds_from(resolved, &checkout.path().join("packages").join("weird-dir"));
+    }
+
+    /// A corrupt link marker is a loud typed error at discovery, never a silent
+    /// skip that would leave resolution in a mixed checkout/registry state.
+    #[test]
+    fn corrupt_link_marker_is_a_loud_error() {
+        let consumer = tempfile::tempdir().unwrap();
+        let marker_dir = consumer.path().join(".streamlib");
+        std::fs::create_dir_all(&marker_dir).unwrap();
+        std::fs::write(marker_dir.join("link.json"), "{ not json at all").unwrap();
+
+        let err = ActiveLinkedCheckout::discover_from(consumer.path())
+            .expect_err("a corrupt marker must fail loudly");
+        assert!(
+            matches!(err, AddModuleError::LinkStateCorrupt { .. }),
+            "expected LinkStateCorrupt, got {err:?}"
+        );
+    }
+
+    /// No marker anywhere above the start dir ⇒ no active link ⇒ resolution is
+    /// unaffected.
+    #[test]
+    fn no_marker_yields_no_active_link() {
+        let empty = tempfile::tempdir().unwrap();
+        let link = ActiveLinkedCheckout::discover_from(empty.path())
+            .expect("no marker is not an error");
+        assert!(link.is_none(), "no marker must yield no active link");
+    }
+
+    /// A LOCKED run ignores an active link (reproducible / offline by
+    /// contract), while an unlocked run over the SAME marker discovers it.
+    /// Mentally revert the `is_locked` gate in `discover_active_link_for_load`
+    /// (always discover) and the locked case would return `Some`, failing the
+    /// `is_none` assertion.
+    #[test]
+    fn locked_run_ignores_active_link() {
+        let checkout = fake_checkout_with_package("foo", "foo");
+        let consumer = tempfile::tempdir().unwrap();
+        // Writes an active marker under `consumer`.
+        active_link_for(consumer.path(), checkout.path());
+
+        let locked = discover_active_link_for_load_from(true, consumer.path())
+            .expect("locked discovery must not error");
+        assert!(locked.is_none(), "a locked run must ignore the active link");
+
+        let unlocked = discover_active_link_for_load_from(false, consumer.path())
+            .expect("unlocked discovery must not error");
+        assert!(
+            unlocked.is_some(),
+            "an unlocked run over the same marker must discover the link"
+        );
     }
 }

--- a/libs/streamlib-idents/src/lib.rs
+++ b/libs/streamlib-idents/src/lib.rs
@@ -12,6 +12,7 @@ mod catalog;
 mod error;
 mod git;
 mod ident;
+pub mod link_marker;
 mod lockfile;
 mod manifest;
 mod registry;

--- a/libs/streamlib-idents/src/link_marker.rs
+++ b/libs/streamlib-idents/src/link_marker.rs
@@ -2,6 +2,17 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //! Shared `streamlib link` marker schema (`.streamlib/link.json`) + discovery.
+//!
+//! The link marker is a manifest-adjacent record: it lives here in
+//! `streamlib-idents` (alongside [`Manifest`] / [`Lockfile`]) so every layer
+//! that must reason about an active whole-tree link can reach it without a
+//! heavier dependency — the CLI that writes it, the packer that refuses to
+//! distribute while it's present, the build orchestrator that redirects staged
+//! toolchains at the linked checkout, and the engine module loader that
+//! resolves `@org/name` modules from the linked checkout's packages tree.
+//!
+//! [`Manifest`]: crate::Manifest
+//! [`Lockfile`]: crate::Lockfile
 
 use std::path::{Path, PathBuf};
 

--- a/libs/streamlib-pack/src/lib.rs
+++ b/libs/streamlib-pack/src/lib.rs
@@ -47,8 +47,14 @@ pub use streamlib_cargo_build::CargoProfile;
 
 pub mod catalog;
 pub mod crate_tarball;
-pub mod link_marker;
 pub mod static_registry;
+
+// The `streamlib link` marker schema + discovery moved to `streamlib-idents`
+// (its natural home alongside the manifest/lockfile types) so the engine module
+// loader — which deps `streamlib-idents` but not `streamlib-pack` — can reach
+// it. `streamlib-pack` still uses it for the pack/publish "refuse while linked"
+// guard.
+use streamlib_idents::link_marker;
 
 /// One member of the engine release closure: a publishable workspace library
 /// crate, with its version and manifest directory.
@@ -354,6 +360,22 @@ pub fn assemble_artifact(
     opts: &AssembleOptions,
     sink: &dyn PackEventSink,
 ) -> Result<AssembleOutcome> {
+    assemble_artifact_with_cargo_config(pkg_dir, target, opts, sink, &[])
+}
+
+/// [`assemble_artifact`], plus extra cargo `--config <file>` TOML files merged
+/// into the Rust cdylib build. The build orchestrator passes the consumer's
+/// `streamlib link`-emitted `.cargo/config.toml` here so a staged package
+/// cdylib resolves its `streamlib*` crate deps from the linked checkout (the
+/// `[patch."<index>"]` block) instead of the registry — host + plugin built
+/// from one source tree. Empty slice ⇒ identical to [`assemble_artifact`].
+pub fn assemble_artifact_with_cargo_config(
+    pkg_dir: &Path,
+    target: &AssembleTarget,
+    opts: &AssembleOptions,
+    sink: &dyn PackEventSink,
+    cargo_config_files: &[PathBuf],
+) -> Result<AssembleOutcome> {
     let config = streamlib_cargo_build::read_minimal_project_config(pkg_dir)
         .context("Failed to read streamlib.yaml")?
         .ok_or_else(|| anyhow::anyhow!("no streamlib.yaml at {}", pkg_dir.display()))?;
@@ -486,7 +508,14 @@ pub fn assemble_artifact(
                     )
                 })?;
             sink.started("rust");
-            let built = cargo_build_streaming(pkg_dir, &cargo_name, dylib_ext, opts.profile, sink)?;
+            let built = cargo_build_streaming(
+                pkg_dir,
+                &cargo_name,
+                dylib_ext,
+                opts.profile,
+                sink,
+                cargo_config_files,
+            )?;
             sink.finished("rust");
             rebuilt = true;
             let filename = dylib_filename(&built)?;
@@ -781,11 +810,20 @@ fn cargo_build_streaming(
     dylib_ext: &str,
     profile: CargoProfile,
     sink: &dyn PackEventSink,
+    cargo_config_files: &[PathBuf],
 ) -> Result<PathBuf> {
     let mut command = Command::new("cargo");
     command.arg("build");
     if matches!(profile, CargoProfile::Release) {
         command.arg("--release");
+    }
+    // Merge extra cargo config TOML files (each a `cargo build --config <file>`).
+    // The orchestrator uses this to inject the `streamlib link` `[patch]` block
+    // so a linked package's cdylib builds against the checkout's crates. Cargo
+    // merges these on top of the config it discovers by walking up from the
+    // build dir, so the injected patch wins.
+    for config_file in cargo_config_files {
+        command.arg("--config").arg(config_file);
     }
     command
         .arg("--message-format=json-render-diagnostics")
@@ -1186,6 +1224,62 @@ mod tests {
             no_build,
             profile: CargoProfile::Release,
             path_deps: PathDepPolicy::RejectPathPatches,
+        }
+    }
+
+    fn write_schemas_only_pkg(dir: &Path) {
+        std::fs::create_dir_all(dir.join("schemas")).unwrap();
+        std::fs::write(
+            dir.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: cfg-pkg\n  version: 0.1.0\nschemas:\n  T:\n    file: schemas/t.yaml\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("schemas/t.yaml"),
+            "metadata:\n  type: T\n  max_payload_bytes: 16\n",
+        )
+        .unwrap();
+    }
+
+    /// `assemble_artifact` delegates to `assemble_artifact_with_cargo_config`
+    /// with an empty slice — an unlinked build is byte-for-byte the same as
+    /// before. And extra cargo-config files are harmlessly ignored for a
+    /// non-Rust package (no `cargo build` runs). This locks that the new entry
+    /// point doesn't change the no-Rust path. Mentally revert the delegation
+    /// and this drifts.
+    #[test]
+    fn cargo_config_entry_point_matches_plain_assemble_for_non_rust_pkg() {
+        let src = tempdir().unwrap();
+        write_schemas_only_pkg(src.path());
+
+        let plain_dir = tempdir().unwrap();
+        assemble_artifact(
+            src.path(),
+            &AssembleTarget::StagedDir(plain_dir.path().to_path_buf()),
+            &slpkg_opts(false),
+            &(),
+        )
+        .expect("plain assemble must succeed");
+
+        let with_cfg_dir = tempdir().unwrap();
+        // A nonexistent cargo-config path would make cargo error IF it were
+        // consulted — proving it is safely ignored for a non-Rust package.
+        assemble_artifact_with_cargo_config(
+            src.path(),
+            &AssembleTarget::StagedDir(with_cfg_dir.path().to_path_buf()),
+            &slpkg_opts(false),
+            &(),
+            &[PathBuf::from("/nonexistent/cargo-override.toml")],
+        )
+        .expect("with-cargo-config assemble must succeed (config ignored, no Rust)");
+
+        // The staged manifest + schema are identical either way.
+        for rel in ["streamlib.yaml", "schemas/t.yaml"] {
+            assert_eq!(
+                std::fs::read(plain_dir.path().join(rel)).unwrap(),
+                std::fs::read(with_cfg_dir.path().join(rel)).unwrap(),
+                "staged {rel} must match between the two entry points"
+            );
         }
     }
 


### PR DESCRIPTION
## What this delivers

The last consumer-core piece of the milestone: with an active `streamlib link`, the dev loop is literally `streamlib link` → build → run — **no registry, no env vars, host + plugin built from one source tree**.

- **Module resolution** — the engine module loader resolves any `@org/name` present in the linked checkout's `packages/` tree from the checkout.
- **Staged builds** — a linked package's Rust cdylib resolves its `streamlib*` crate deps from the checkout (cargo `[patch]`), and its Python venv installs the checkout's SDK (uv source). This is what removes the mixed host/plugin ABI hazard from the dev loop *by construction*.

## ★ CRUX design decision — maintainer-vetoable

**An active link redirects module resolution for any package present in the linked checkout's `packages/` tree, REGARDLESS of the caller's resolution strategy** — including explicit `add_module(ident, registry())` calls.

- **Rationale:** 33 of 36 example apps call `add_module(ident, registry())` with an explicit registry strategy. If link only overrode the *default* strategy, editing a linked package and re-running would NOT pick up the edit for the dominant app shape, defeating the dev loop. This is standard **npm-link semantics** — a linked name takes precedence.
- **Consistent with "registry strategies still available explicitly":** a package **not** in the checkout still resolves from the registry via its explicit strategy. Only checkout-present packages are redirected.
- So: checkout-present + active link ⇒ resolve from checkout (any strategy); absent from checkout ⇒ unchanged (explicit strategy resolves from registry).
- A **locked run** (`add_modules_from_lockfile`) **ignores links** — locked runs are reproducible/offline by contract.

If you'd rather link only override the *default* `InstalledCache` strategy, this is the knob to veto — it's isolated to the short-circuit at the top of `resolve_strategy_to_source`.

## Changes

**Module side (engine):**
- Moved the link-marker schema + discovery from `streamlib-pack` to `streamlib-idents` (its natural home alongside the manifest/lockfile types) so the engine module loader — which deps `streamlib-idents`, not `streamlib-pack` — can reach it. All consumers swept (cli, orchestrator, pack). Detected by git as a rename.
- `ActiveLinkedCheckout` + a link-aware short-circuit in `resolve_strategy_to_source`, threaded through the recursive walker. Discovery is once-per-top-level-load from the process CWD (the run dir, where the marker sits), centralized behind `discover_active_link_for_load(is_locked)` — the single gate that keeps locked runs link-free. Corrupt marker ⇒ typed `AddModuleError::LinkStateCorrupt`, never a silent skip. Package match is by manifest `org`+`name` (fast path `packages/<name>`, scan fallback for dir-name ≠ pkg-name).

**Cargo side (pack + orchestrator):**
- Pack: new `assemble_artifact_with_cargo_config` threads extra `cargo build --config <file>` TOML files to the cdylib build (existing `assemble_artifact` signature **unchanged** — deliberately, to avoid touching `static_registry.rs`, owned by a concurrent agent).
- Orchestrator: `discover_active_build_link` resolves the consumer's link-emitted `.cargo/config.toml` (the `[patch]` block) + the checkout's Python SDK once per build; the cdylib build gets the `[patch]` via `--config`, the venv gets the SDK via `[tool.uv.sources]`.
- The venv hook now takes the orchestrator-resolved SDK path instead of re-discovering from `source_pkg_dir` — a **correctness fix**: under the new redirect the package source lives in the checkout, so the old source-dir-anchored discovery would have looked in the checkout tree and missed the consumer's marker.

## Per-language coverage (explicit)

- **Rust** — module resolution (checkout source) ✅ + staged cdylib build resolves `streamlib*` crates from the checkout via `cargo build --config <consumer .cargo/config.toml>` ✅. Validated: workspace build green + resolution-level tests + an empirical `cargo build --config <patch-file>` proving cargo honors a config-provided `[patch]`.
- **Python** — module resolution (checkout source) ✅ + venv installs the checkout SDK via `[tool.uv.sources]` ✅. Validated: an offline venv E2E test (`provision_applies_link_override_end_to_end_against_linked_sdk`) runs with `uv` present and asserts the linked SDK is installed.
- **Deno** — module resolution (checkout source) ✅ (the engine redirect is language-agnostic). SDK resolution at runtime rides the **consumer-root `deno.json` import-map override** already emitted by `streamlib link` (per the issue's stated model); **no new staged-build Deno override was added**, because Deno runs from source and has no build-time SDK-resolution step. This is the honest state — if a Deno package needs a staged-build SDK override, that's a follow-up.

## Regression + mental-revert evidence

- **Unlinked resolution is byte-for-byte unchanged.** `no_link_resolution_is_unchanged` passes on both the pre- and post-change code (the `link = None` path is untouched). Mentally reverting the link short-circuit (forcing `link = None`): the **linked** test `active_link_overrides_registry_strategy_for_checkout_present_package` **FAILS** (falls to the registry path → `RegistryNotConfigured`), while `no_link_resolution_is_unchanged` **still PASSES** — proving the tests lock the link behavior and the unlinked path is unaffected. Verified empirically.
- **Locked runs ignore links.** `locked_run_ignores_active_link` is revert-sensitive: neutralizing the `is_locked` gate makes it FAIL (verified empirically).
- **Unlinked builds unchanged:** `assemble_artifact` delegates to `assemble_artifact_with_cargo_config(..., &[])` — the empty-slice path is byte-identical, locked by `cargo_config_entry_point_matches_plain_assemble_for_non_rust_pkg`.

## Cargo `[patch]` soundness note (for review)

The staged cdylib build is passed the consumer's whole `.cargo/config.toml` via `--config`. The `[patch."<index>"]` key must equal the index the checkout package resolves `registry = "tatolab"` from — which holds when the consumer and checkout share the same tatolab index config (the canonical setup). If the key mismatches, cargo *silently ignores the patch* and the package builds against the registry SDK — **degradation-safe**: the ABI build-fingerprint handshake then refuses the mismatched cdylib at load with `PluginBuildMismatch`, never silent driver corruption. (An edge case: a consumer config carrying a conflicting `[source]` replacement could hard-error the merge; the canonical link config carries only `[registries.tatolab].index` + `[patch]`, no `[source]`.)

## Tests / counts

| Crate | Result |
|---|---|
| `streamlib-idents` | 126 passed (incl. 3 moved link_marker tests) |
| `streamlib-pack` | 74 passed (incl. `cargo_config_entry_point_matches_plain_assemble_for_non_rust_pkg`) |
| `streamlib-build-orchestrator` | 32 passed (incl. 4 `discover_active_build_link` tests + refactored venv link tests) |
| `streamlib-engine` (lib) | 1483 passed, 2 failed |
| `streamlib-cli` | 37 + 2 passed (link command + add_remove integration) |

The 2 `streamlib-engine` failures (`deno_subprocess::deno_log_surfaces_in_host_jsonl`, `deno_log_burst_preserves_order`) are **pre-existing** — they fail identically on `main` with my changes stashed (verified), are Deno-subprocess log-surfacing integration tests in an area this PR does not touch. `cargo check --workspace` is clean; no broken intra-doc links from these changes.

## Maintainer-terminal E2E (couldn't complete headless — sandbox kills GPU/IPC runtime)

The resolution + build layers are locked by unit tests + the empirical `--config [patch]` check above. The full runtime run needs a live GPU/IPC pipeline the sandbox can't observe. To validate end-to-end on your terminal:

```bash
# From a consumer checkout (e.g. an example app dir), link this streamlib checkout:
cd <consumer-app-dir>
streamlib link /path/to/streamlib
# Edit an observable output in a linked package processor IN THE CHECKOUT, e.g.:
#   /path/to/streamlib/packages/debug-utilities/src/bgra_file_source.rs  (change a fill color)
# Run with ZERO registry env configured; observe the edit reflected:
unset STREAMLIB_REGISTRY_URL
cargo run -q -p <the-app>        # Rust: cdylib rebuilt from the checkout, host+plugin one tree
streamlib unlink                  # restores every touched file byte-identically
```
Expect the linked-package edit to show up in the output PNG/frame without any registry configured, and the build logs to show `streamlib link active — building staged package against the linked checkout`.

## Docs

`docs/architecture/package-development-model.md` updated to describe the shipped state: the moved marker path, link-aware module resolution (replacing the now-superseded "link does not add a resolution path" claim), and the staged-build overrides.

Closes #1246

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB
