### PR TITLE
fix(cli): streamlib link detects and remedies a stale consumer Cargo.lock that defeats the patch

### DIFF
--- a/docs/architecture/package-development-model.md
+++ b/docs/architecture/package-development-model.md
@@ -115,13 +115,27 @@ leaves the backups for `unlink` recovery. The marker records per-file
 teardown. A crash mid-apply leaves state `Applying`; a later `link` refuses
 with `TornLinkState` pointing at `unlink`.
 
-**Post-link verification.** Unless `--skip-verify`, `link` runs
-`cargo metadata --offline` and asserts every `streamlib*` / `vulkan-jpeg`
-package resolves to a path source under the checkout; if a
-semver-incompatible consumer requirement made cargo silently ignore the
-`[patch]`, verification names the offending crates, the whole link rolls
-back, and `LinkVerificationFailed` tells the user to fix the requirement or
-re-run with `--skip-verify`.
+**Post-link verification + stale-lock remedy.** Unless `--skip-verify`,
+`link` runs `cargo metadata --offline` and asserts every `streamlib*` /
+`vulkan-jpeg` package resolves to a path source under the checkout. Two
+things can make cargo ignore the freshly-emitted `[patch]`, and they need
+opposite remedies:
+
+- *A pre-existing consumer `Cargo.lock`.* Cargo honors an existing lock over
+  a newly-added `[patch]`, so the streamlib crates keep resolving to their
+  registry pins — a re-lock, not a version-requirement change, is the fix.
+  `link` owns that step: it transparently re-locks exactly the crates that
+  failed to redirect (`cargo update -p <each>`), records the mutated
+  `Cargo.lock` as a link-managed file (`record_relocked_lockfile` — snapshot
+  + backup + manifest entry, so `unlink` restores it byte-identically), and
+  re-verifies. If the automatic re-lock itself can't run, `link` leaves the
+  patch applied (unchanged lock) and returns `StaleConsumerLockRelockFailed`
+  naming the lockfile and the exact `cargo update` command to finish it.
+- *A semver-incompatible consumer requirement.* When the crates STILL resolve
+  from the registry after re-locking (or there is no lock to blame), the
+  checkout's versions genuinely don't satisfy the requirements — the whole
+  link rolls back and `LinkVerificationFailed` names the offending crates and
+  points at the version requirements (or `--skip-verify`).
 
 **Tri-state.** Link state is `LinkTransactionState::{Applying, Active}` plus
 marker-absence (three states, surfaced by `status`). Per-file, `unlink`
@@ -129,14 +143,17 @@ classifies each touched file into `RestoreAction::{Skip, RestoreOriginal,
 RemoveCreated}`; a file the user modified while linked refuses with
 `UnlinkRefusedModifiedFile` unless `--force`.
 
-**Overrides never leak into an artifact.** All three edits land in
-*toolchain config* files — never a lockfile. `streamlib pkg build` /
-`publish` refuse while any link marker exists up-tree
-(`ensure_no_active_link_for_pack` → `PackRefusedWhileLinked`), and the build
-orchestrator re-injects the checkout overrides when it materializes a linked
-package — the consumer's `[patch]` cargo config into the cdylib build and the
-uv-source override (`apply_link_override`) into the venv — so a
-cargo-patched-but-venv-from-registry mixed state can't occur.
+**Overrides never leak into an artifact.** The three toolchain-config edits
+land in *config* files — never a lockfile. The only lockfile `link` may write
+is the consumer's own `Cargo.lock`, transparently re-locked to make the
+`[patch]` take effect (above) and restored byte-identically by `unlink`.
+Neither escapes the dev tree: `streamlib pkg build` / `publish` refuse while
+any link marker exists up-tree (`ensure_no_active_link_for_pack` →
+`PackRefusedWhileLinked`), and the build orchestrator re-injects the checkout
+overrides when it materializes a linked package — the consumer's `[patch]`
+cargo config into the cdylib build and the uv-source override
+(`apply_link_override`) into the venv — so a cargo-patched-but-venv-from-registry
+mixed state can't occur.
 
 **What link deliberately does not solve.** Developing against one *specific
 published* version — link is all-or-nothing against a single checkout. That

--- a/libs/streamlib-cli/src/commands/link.rs
+++ b/libs/streamlib-cli/src/commands/link.rs
@@ -84,13 +84,35 @@ pub enum LinkError {
     )]
     RollbackIncomplete { backup_dir: PathBuf, detail: String },
 
-    /// Post-link cargo resolution check failed; the link was rolled back.
+    /// Post-link cargo resolution check failed; the link was rolled back. Only
+    /// reached after the stale-lock cause has been ruled out (a transparent
+    /// re-lock was attempted when a `Cargo.lock` was present), so the remaining
+    /// cause is a genuine version-requirement mismatch or an unresolvable graph.
     #[error(
-        "post-link verification failed and the link was rolled back: {detail}. Fix the \
-         consumer's version requirements so the checkout's crate versions satisfy them, or \
+        "post-link verification failed and the link was rolled back: {detail}. Adjust the \
+         consumer's `streamlib*` version requirements to admit the checkout's versions, or \
          re-run with `--skip-verify` to keep the link unverified"
     )]
     LinkVerificationFailed { detail: String },
+
+    /// A pre-existing consumer `Cargo.lock` pins the streamlib crates to
+    /// registry versions — cargo honors an existing lockfile over a newly-added
+    /// `[patch]`, so the link's patch is silently ignored — and the transparent
+    /// re-lock could not run. The link is left applied (the patch IS on disk) so
+    /// the named command finishes it directly.
+    #[error(
+        "the consumer's Cargo.lock (`{lockfile}`) pins {crates} to registry versions, which \
+         defeats the link's `[patch]` — cargo honors an existing lockfile over a newly-added \
+         `[patch]`. The link is applied but unverified because the automatic re-lock could not \
+         run ({detail}). Finish it by re-locking the streamlib crate set:\n\n    {command}\n\n\
+         Or run `streamlib unlink` to remove the link"
+    )]
+    StaleConsumerLockRelockFailed {
+        lockfile: PathBuf,
+        crates: String,
+        command: String,
+        detail: String,
+    },
 
     /// A filesystem operation failed.
     #[error("filesystem error at `{path}`: {source}")]
@@ -187,6 +209,12 @@ pub fn link(consumer_root: &Path, checkout: &Path, skip_verify: bool) -> Result<
         unlink(&consumer_root, false)?;
     }
 
+    // Snapshot the consumer's pre-link `Cargo.lock` — taken *after* a refresh's
+    // unlink has restored the tree, so it is the true pre-link state. A
+    // transparent re-lock during verification (below) mutates this file; the
+    // snapshot is what `unlink` restores it to, keeping teardown byte-clean.
+    let original_cargo_lock = read_optional_bytes(&consumer_root.join("Cargo.lock"))?;
+
     let edits = establish_link(&consumer_root, &checkout, &index_url, &crates)?;
 
     println!("Linked streamlib → {}", checkout.display());
@@ -196,18 +224,54 @@ pub fn link(consumer_root: &Path, checkout: &Path, skip_verify: bool) -> Result<
     }
 
     // Post-link verification: prove the [patch] actually took effect in the
-    // consumer's cargo resolution. A semver-incompatible consumer requirement
-    // makes cargo silently ignore the patch — roll the whole link back rather
-    // than leave a "linked" tree that still resolves from the registry.
+    // consumer's cargo resolution. Two ways it can fail to redirect:
+    //   1. A pre-existing `Cargo.lock` pins the streamlib crates to registry
+    //      versions — cargo honors an existing lock over a newly-added [patch],
+    //      so the patch is silently ignored. The fix is a re-lock, not a
+    //      version-requirement change. `link` owns that step transparently.
+    //   2. A semver-incompatible consumer requirement genuinely doesn't admit
+    //      the checkout's versions. Roll the whole link back.
     if skip_verify {
         println!("  Verification skipped (--skip-verify).");
-    } else if let Err(detail) = verify_cargo_patch_resolution(&consumer_root, &checkout, &crates) {
-        unlink(&consumer_root, false)?;
-        return Err(LinkError::LinkVerificationFailed { detail });
     } else if consumer_root.join("Cargo.toml").is_file() {
-        // Count is re-derived inside the verify; recompute cheaply for the
-        // success message.
-        println!("  Verified: streamlib crates resolve to the checkout via cargo metadata.");
+        match verify_and_remedy_patch_resolution(
+            &consumer_root,
+            &checkout,
+            &crates,
+            original_cargo_lock,
+        )? {
+            VerifyOutcome::Verified { relocked: 0 } => {
+                println!(
+                    "  Verified: streamlib crates resolve to the checkout via cargo metadata."
+                );
+            }
+            VerifyOutcome::Verified { relocked } => {
+                println!(
+                    "  Re-locked the consumer's Cargo.lock ({relocked} crate(s)) so the \
+                     [patch] takes effect; verified: streamlib crates resolve to the checkout."
+                );
+            }
+            VerifyOutcome::RollBack { detail } => {
+                unlink(&consumer_root, false)?;
+                return Err(LinkError::LinkVerificationFailed { detail });
+            }
+            VerifyOutcome::RelockUnavailable {
+                lockfile,
+                crates,
+                command,
+                detail,
+            } => {
+                // Leave the link applied (the patch IS on disk) — the named
+                // command finishes the re-lock directly. `Cargo.lock` was not
+                // mutated, so teardown stays byte-clean.
+                return Err(LinkError::StaleConsumerLockRelockFailed {
+                    lockfile,
+                    crates,
+                    command,
+                    detail,
+                });
+            }
+        }
     }
 
     println!("Run `streamlib unlink` to restore.");
@@ -484,6 +548,27 @@ fn run_cargo_metadata(
         .map_err(|e| format!("cargo metadata is not valid JSON: {e}"))
 }
 
+/// Run a `cargo` subcommand for its exit status only (no JSON), returning a
+/// diagnostic string on failure.
+fn run_cargo_status(args: &[&str], cwd: Option<&Path>) -> Result<(), String> {
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args(args);
+    if let Some(cwd) = cwd {
+        cmd.current_dir(cwd);
+    }
+    let output = cmd
+        .output()
+        .map_err(|e| format!("failed to run cargo {}: {e}", args.join(" ")))?;
+    if !output.status.success() {
+        return Err(format!(
+            "cargo {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(())
+}
+
 /// Derive the linkable crate set (`name` → checkout member dir) from the
 /// checkout via the single canonical release-closure definition
 /// ([`streamlib_pack::compute_release_closure`]): every publishable workspace
@@ -504,17 +589,26 @@ fn derive_linkable_crates(checkout: &Path) -> Result<BTreeMap<String, PathBuf>, 
         .collect())
 }
 
+/// One streamlib crate that resolves from the registry instead of the checkout
+/// — i.e. failed to redirect through the link's `[patch]`.
+#[derive(Debug, Clone)]
+struct UnpatchedCrate {
+    name: String,
+    version: String,
+}
+
 /// Verify the consumer's cargo resolution honors the link: every resolved
 /// `streamlib*` / `vulkan-jpeg` package must be a path source under the
-/// checkout. Returns `Err(detail)` naming the offending crates. `Ok(())`
-/// (vacuously) when the consumer has no `Cargo.toml`.
+/// checkout. Returns the crates that still resolve from the registry (empty ⇒
+/// fully patched); `Err(detail)` when cargo can't resolve the graph at all.
+/// `Ok(vec![])` (vacuously) when the consumer has no `Cargo.toml`.
 fn verify_cargo_patch_resolution(
     consumer_root: &Path,
     checkout: &Path,
     crates: &BTreeMap<String, PathBuf>,
-) -> Result<(), String> {
+) -> Result<Vec<UnpatchedCrate>, String> {
     if !consumer_root.join("Cargo.toml").is_file() {
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     // Offline first (the whole point of link mode); fall back to online when
@@ -542,7 +636,7 @@ fn verify_cargo_patch_resolution(
         .and_then(|p| p.as_array())
         .unwrap_or(&empty);
     let mut verified = 0usize;
-    let mut not_patched: Vec<String> = Vec::new();
+    let mut not_patched: Vec<UnpatchedCrate> = Vec::new();
     for pkg in packages {
         let name = pkg.get("name").and_then(|v| v.as_str()).unwrap_or_default();
         if !crates.contains_key(name) {
@@ -557,19 +651,181 @@ fn verify_cargo_patch_resolution(
             verified += 1;
         } else {
             let version = pkg.get("version").and_then(|v| v.as_str()).unwrap_or("?");
-            not_patched.push(format!("{name}@{version}"));
+            not_patched.push(UnpatchedCrate {
+                name: name.to_string(),
+                version: version.to_string(),
+            });
         }
     }
 
-    if !not_patched.is_empty() {
-        return Err(format!(
-            "these streamlib crates still resolve from the registry (the consumer's version \
-             requirements don't admit the checkout's versions, so cargo ignored the [patch]): {}",
-            not_patched.join(", ")
-        ));
+    tracing::info!(verified, unpatched = not_patched.len(), "post-link cargo resolution checked");
+    Ok(not_patched)
+}
+
+/// Result of verifying (and, when a stale lock is at fault, remedying) that the
+/// link's `[patch]` took effect in the consumer's cargo resolution.
+enum VerifyOutcome {
+    /// The `[patch]` resolves. `relocked` is the number of crates whose lock
+    /// entries were transparently refreshed to make it take effect (0 ⇒ the
+    /// patch was honored without touching the lock).
+    Verified { relocked: usize },
+    /// The `[patch]` is genuinely ignored (version-requirement mismatch) or the
+    /// graph is unresolvable — the caller rolls the whole link back.
+    RollBack { detail: String },
+    /// A stale lock defeats the `[patch]` and the automatic re-lock could not
+    /// run — the caller leaves the link applied and surfaces the exact command.
+    RelockUnavailable {
+        lockfile: PathBuf,
+        crates: String,
+        command: String,
+        detail: String,
+    },
+}
+
+/// Verify the link's `[patch]` resolves; if a pre-existing `Cargo.lock` defeats
+/// it, transparently re-lock exactly the crates that failed to redirect and
+/// re-verify. The re-lock mutates `Cargo.lock`, which is recorded as a
+/// link-managed file (`record_relocked_lockfile`) so `unlink` restores it
+/// byte-identically. Returns `Err` only for a filesystem failure while
+/// recording; every resolution outcome is a [`VerifyOutcome`].
+fn verify_and_remedy_patch_resolution(
+    consumer_root: &Path,
+    checkout: &Path,
+    crates: &BTreeMap<String, PathBuf>,
+    original_cargo_lock: Option<Vec<u8>>,
+) -> Result<VerifyOutcome, LinkError> {
+    let unpatched = match verify_cargo_patch_resolution(consumer_root, checkout, crates) {
+        Ok(u) => u,
+        Err(detail) => return Ok(VerifyOutcome::RollBack { detail }),
+    };
+    if unpatched.is_empty() {
+        return Ok(VerifyOutcome::Verified { relocked: 0 });
     }
-    tracing::info!(verified, "post-link cargo resolution verified");
-    Ok(())
+
+    let lockfile = consumer_root.join("Cargo.lock");
+    if !lockfile.is_file() {
+        // No lock to blame — the checkout's versions don't satisfy the
+        // consumer's requirements, so cargo ignored the [patch].
+        return Ok(VerifyOutcome::RollBack {
+            detail: format!(
+                "these streamlib crates resolve from the registry, not the checkout — the \
+                 checkout's versions don't satisfy the consumer's version requirements: {}",
+                render_unpatched(&unpatched)
+            ),
+        });
+    }
+
+    // Stale lock: cargo honored the existing lock over the new [patch]. Refresh
+    // exactly the crates that failed to redirect so the patch takes effect.
+    let targets: Vec<&str> = unpatched.iter().map(|c| c.name.as_str()).collect();
+    let command = relock_command_string(consumer_root, &targets);
+    tracing::info!(
+        crates = %targets.join(", "),
+        "consumer Cargo.lock defeats the [patch]; re-locking to make it take effect"
+    );
+    if let Err(detail) = relock_streamlib_crates(consumer_root, &targets) {
+        return Ok(VerifyOutcome::RelockUnavailable {
+            lockfile,
+            crates: targets.join(", "),
+            command,
+            detail,
+        });
+    }
+
+    // Record the re-locked Cargo.lock before re-verifying, so a roll-back on the
+    // (rare) still-unresolved path also restores the lock byte-identically.
+    record_relocked_lockfile(consumer_root, &lockfile, original_cargo_lock)?;
+
+    match verify_cargo_patch_resolution(consumer_root, checkout, crates) {
+        Ok(still) if still.is_empty() => Ok(VerifyOutcome::Verified {
+            relocked: targets.len(),
+        }),
+        Ok(still) => Ok(VerifyOutcome::RollBack {
+            detail: format!(
+                "after re-locking the consumer's Cargo.lock, these streamlib crates still \
+                 resolve from the registry — the checkout's versions don't satisfy the \
+                 consumer's version requirements: {}",
+                render_unpatched(&still)
+            ),
+        }),
+        Err(detail) => Ok(VerifyOutcome::RollBack { detail }),
+    }
+}
+
+/// Render an unpatched-crate list as `name@version, name@version` for messages.
+fn render_unpatched(crates: &[UnpatchedCrate]) -> String {
+    crates
+        .iter()
+        .map(|c| format!("{}@{}", c.name, c.version))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// The exact `cargo update` command that re-locks `targets` for the consumer —
+/// surfaced to the operator when the automatic re-lock can't run.
+fn relock_command_string(consumer_root: &Path, targets: &[&str]) -> String {
+    let mut s = format!(
+        "cargo update --manifest-path {}",
+        consumer_root.join("Cargo.toml").display()
+    );
+    for t in targets {
+        s.push_str(" -p ");
+        s.push_str(t);
+    }
+    s
+}
+
+/// Re-lock exactly `targets` in the consumer's `Cargo.lock` so the link's
+/// `[patch]` takes effect. `cargo update -p <name>` re-resolves that package,
+/// which redirects it to the patched path source. Offline first (link mode is
+/// offline-by-design); fall back to online when offline resolution can't run.
+fn relock_streamlib_crates(consumer_root: &Path, targets: &[&str]) -> Result<(), String> {
+    let mut base: Vec<&str> = vec!["update"];
+    for t in targets {
+        base.push("-p");
+        base.push(t);
+    }
+    let mut offline = base.clone();
+    offline.push("--offline");
+    match run_cargo_status(&offline, Some(consumer_root)) {
+        Ok(()) => Ok(()),
+        Err(offline_err) => run_cargo_status(&base, Some(consumer_root)).map_err(|online_err| {
+            format!("offline: {offline_err}; online: {online_err}")
+        }),
+    }
+}
+
+/// Record the transparently re-locked `Cargo.lock` as a link-managed file so
+/// `unlink` restores it byte-identically. Backs the pre-link bytes up (when the
+/// lock existed) and appends a [`LinkedManifestFile`] entry to the persisted
+/// manifest. When the lock did not exist pre-link, the entry is `!existed_before`
+/// so `unlink` removes the file the link created.
+fn record_relocked_lockfile(
+    consumer_root: &Path,
+    lockfile: &Path,
+    original: Option<Vec<u8>>,
+) -> Result<(), LinkError> {
+    let current = std::fs::read(lockfile).map_err(|e| LinkError::io(lockfile, e))?;
+    let backup_dir = consumer_root.join(LINK_STATE_DIR).join(LINK_BACKUP_DIR);
+    std::fs::create_dir_all(&backup_dir).map_err(|e| LinkError::io(&backup_dir, e))?;
+    if let Some(orig) = &original {
+        let backup = backup_dir.join("Cargo.lock");
+        std::fs::write(&backup, orig).map_err(|e| LinkError::io(&backup, e))?;
+    }
+
+    let mut manifest = load_active_manifest(consumer_root)?.ok_or_else(|| {
+        LinkError::CorruptLinkState {
+            path: consumer_root.join(LINK_STATE_DIR).join(LINK_MANIFEST_FILE),
+            detail: "link manifest missing while recording the re-locked Cargo.lock".to_string(),
+        }
+    })?;
+    manifest.files.push(LinkedManifestFile {
+        path: PathBuf::from("Cargo.lock"),
+        existed_before: original.is_some(),
+        pre_edit_sha256: original.as_deref().map(hex_sha256).unwrap_or_default(),
+        post_edit_sha256: hex_sha256(&current),
+    });
+    overwrite_manifest(consumer_root, &manifest)
 }
 
 /// Run the full link transaction against a computed crate set: plan every

--- a/libs/streamlib-cli/src/commands/link/tests.rs
+++ b/libs/streamlib-cli/src/commands/link/tests.rs
@@ -611,6 +611,167 @@ fn real_link_offline_e2e_link_refresh_unlink_roundtrip() {
         "cargo config must be byte-identical after unlink"
     );
     assert!(!consumer.join(LINK_STATE_DIR).exists());
-    // Cargo.lock may be created by the verification resolve — it's a build
-    // artifact of the consumer, not a link-managed manifest.
+    // Cargo.lock may be created by the verification resolve; when the [patch]
+    // is honored without a re-lock (as here) it is not link-managed. The
+    // stale-lock re-lock path that DOES manage it is covered by the focused
+    // tests below.
+}
+
+// ---------------------------------------------------------------------------
+// Stale-lock remedy: transparent re-lock + byte-clean lockfile management.
+// ---------------------------------------------------------------------------
+
+/// Simulate the re-lock outcome without a live cargo invocation: establish the
+/// link, then hand `record_relocked_lockfile` a mutated `Cargo.lock`. The
+/// managed lockfile must restore byte-identically across cycles.
+#[test]
+fn relocked_cargo_lock_is_recorded_and_restored_byte_clean_across_cycles() {
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    write_full_consumer(&consumer);
+    let lockfile = consumer.join("Cargo.lock");
+    let original_lock = b"# registry-born lock\nversion = 4\n".to_vec();
+    std::fs::write(&lockfile, &original_lock).unwrap();
+
+    let cargo = consumer.join(".cargo").join("config.toml");
+    let orig_cargo = std::fs::read(&cargo).unwrap();
+
+    for cycle in 0..2 {
+        // Pre-link snapshot (what unlink must restore the lock to).
+        let snapshot = std::fs::read(&lockfile).unwrap();
+        assert_eq!(snapshot, original_lock, "cycle {cycle}: lock must be original pre-link");
+
+        link_with_fixed_crates(&consumer, &PathBuf::from("/checkout"));
+
+        // A real `cargo update -p …` would rewrite the lock; simulate that.
+        std::fs::write(&lockfile, format!("# re-locked cycle {cycle}\nversion = 4\n")).unwrap();
+        record_relocked_lockfile(&consumer, &lockfile, Some(snapshot)).unwrap();
+
+        // The manifest now carries a Cargo.lock entry alongside the 3 configs.
+        let manifest = load_active_manifest(&consumer).unwrap().unwrap();
+        assert!(
+            manifest.files.iter().any(|f| f.path == PathBuf::from("Cargo.lock")),
+            "cycle {cycle}: manifest must record the re-locked Cargo.lock"
+        );
+
+        unlink(&consumer, false).unwrap();
+
+        // Byte-clean: the lock AND the config are back to their pre-link bytes.
+        assert_eq!(
+            std::fs::read(&lockfile).unwrap(),
+            original_lock,
+            "cycle {cycle}: Cargo.lock must be restored byte-identically"
+        );
+        assert_eq!(std::fs::read(&cargo).unwrap(), orig_cargo, "cycle {cycle}: cargo config");
+        assert!(!consumer.join(LINK_STATE_DIR).exists(), "cycle {cycle}: state gone");
+    }
+}
+
+/// A `Cargo.lock` that did not exist pre-link (created by the verify resolve +
+/// re-lock) is recorded as `!existed_before` and removed on unlink.
+#[test]
+fn relocked_cargo_lock_created_by_link_is_removed_on_unlink() {
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    // Cargo config only — no pre-existing Cargo.lock.
+    let cargo = consumer.join(".cargo");
+    std::fs::create_dir_all(&cargo).unwrap();
+    std::fs::write(
+        cargo.join("config.toml"),
+        format!("[registries.tatolab]\nindex = \"{INDEX_URL}\"\n"),
+    )
+    .unwrap();
+    let lockfile = consumer.join("Cargo.lock");
+    assert!(!lockfile.exists());
+
+    link_with_fixed_crates(&consumer, &PathBuf::from("/checkout"));
+
+    // verify's `cargo metadata` + the re-lock create the lock; record with no
+    // pre-link original.
+    std::fs::write(&lockfile, "# freshly created + re-locked\nversion = 4\n").unwrap();
+    record_relocked_lockfile(&consumer, &lockfile, None).unwrap();
+
+    unlink(&consumer, false).unwrap();
+    assert!(!lockfile.exists(), "a Cargo.lock the link created must be removed on unlink");
+    assert!(!consumer.join(LINK_STATE_DIR).exists());
+}
+
+/// A user edit to the re-locked `Cargo.lock` during the link window is refused
+/// without `--force` and discarded (restored to pre-link) with it — the lock
+/// rides the same tri-state teardown as every other managed file.
+#[test]
+fn unlink_refuses_a_user_modified_relocked_lock_without_force() {
+    let tmp = tempfile::tempdir().unwrap();
+    let consumer = tmp.path().canonicalize().unwrap();
+    write_full_consumer(&consumer);
+    let lockfile = consumer.join("Cargo.lock");
+    let original_lock = b"# original\nversion = 4\n".to_vec();
+    std::fs::write(&lockfile, &original_lock).unwrap();
+
+    link_with_fixed_crates(&consumer, &PathBuf::from("/checkout"));
+    std::fs::write(&lockfile, "# re-locked\nversion = 4\n").unwrap();
+    record_relocked_lockfile(&consumer, &lockfile, Some(original_lock.clone())).unwrap();
+
+    // User hand-edits the lock while linked.
+    std::fs::write(&lockfile, "# user edit\nversion = 4\n").unwrap();
+
+    let err = unlink(&consumer, false).unwrap_err();
+    assert!(matches!(err, LinkError::UnlinkRefusedModifiedFile { .. }), "got {err:?}");
+    assert!(marker_path(&consumer).is_file(), "refusal must preserve link state");
+
+    unlink(&consumer, true).unwrap();
+    assert_eq!(std::fs::read(&lockfile).unwrap(), original_lock, "force restores pre-link lock");
+    assert!(!consumer.join(LINK_STATE_DIR).exists());
+}
+
+/// The re-lock command surfaced to the operator names the consumer's manifest
+/// and each crate that failed to redirect.
+#[test]
+fn relock_command_string_names_manifest_and_each_target() {
+    let cmd = relock_command_string(Path::new("/app"), &["streamlib", "streamlib-idents"]);
+    assert_eq!(
+        cmd,
+        "cargo update --manifest-path /app/Cargo.toml -p streamlib -p streamlib-idents"
+    );
+}
+
+/// When the transparent re-lock can't run, the error names the lockfile and the
+/// exact command — not a version-requirement misdiagnosis.
+#[test]
+fn stale_lock_relock_failed_error_names_lockfile_and_command() {
+    let err = LinkError::StaleConsumerLockRelockFailed {
+        lockfile: PathBuf::from("/app/Cargo.lock"),
+        crates: "streamlib, streamlib-idents".to_string(),
+        command: "cargo update --manifest-path /app/Cargo.toml -p streamlib -p streamlib-idents"
+            .to_string(),
+        detail: "offline: cargo update failed; online: no network".to_string(),
+    };
+    let msg = err.to_string();
+    assert!(msg.contains("/app/Cargo.lock"), "names the lockfile: {msg}");
+    assert!(
+        msg.contains("cargo update --manifest-path /app/Cargo.toml -p streamlib -p streamlib-idents"),
+        "names the exact command: {msg}"
+    );
+    assert!(msg.contains("streamlib unlink"), "offers the escape: {msg}");
+    // The whole point: the cause is the lock, not the version requirements.
+    assert!(!msg.contains("version requirement"), "must not misdiagnose: {msg}");
+}
+
+/// The rolled-back verification error carries the accurate cause and the
+/// `--skip-verify` escape, and drops the old stale-lock misdiagnosis.
+#[test]
+fn link_verification_failed_message_is_actionable_and_not_the_old_misdiagnosis() {
+    let err = LinkError::LinkVerificationFailed {
+        detail: "these streamlib crates resolve from the registry, not the checkout — the \
+                 checkout's versions don't satisfy the consumer's version requirements: \
+                 streamlib@0.6.0"
+            .to_string(),
+    };
+    let msg = err.to_string();
+    assert!(msg.contains("--skip-verify"), "offers the escape: {msg}");
+    assert!(msg.contains("streamlib@0.6.0"), "names the offending crate: {msg}");
+    assert!(
+        !msg.contains("Fix the consumer's version requirements so the checkout's crate versions"),
+        "must drop the old misdiagnosing phrasing: {msg}"
+    );
 }


### PR DESCRIPTION
## What & why

A consumer whose `Cargo.lock` was born under registry resolution keeps resolving the `streamlib*` crates from the registry *after* `streamlib link` — because **cargo honors an existing lock over a newly-added `[patch]`** (standard cargo behavior; a `[patch]` only takes effect after a re-lock). The old post-link verification caught the symptom but its rollback message **misdiagnosed** the cause: it told the operator to *"fix the consumer's version requirements"* when the real fix is refreshing the lock. Observed twice during end-to-end validation. Closes the gap for #1248.

## Shape: transparent re-lock (chosen default) + fail-with-precise-remedy fallback

`link` now owns the re-lock step:

1. **Verify** resolves the graph and returns *exactly the set of crates that failed to redirect* (`verify_cargo_patch_resolution` now returns `Vec<UnpatchedCrate>` instead of a pre-formatted string).
2. **If that set is non-empty AND a `Cargo.lock` is present** → the lock is the culprit. `link` **transparently re-locks exactly that set** (`cargo update -p <each>`, offline-first with an online fallback) and **re-verifies**.
3. **The mutated `Cargo.lock` is recorded as a link-managed file** (`record_relocked_lockfile`: pre-link snapshot + backup + `LinkManifest` entry) so **`unlink` restores it byte-identically** — the same tri-state teardown (`Skip` / `RestoreOriginal` / `RemoveCreated`, user-edit refusal without `--force`) the cargo-config / pyproject / deno overrides already ride. The snapshot is taken *after* a refresh's `unlink`, so it is the true pre-link state.
4. **Only when the crates STILL resolve from the registry after re-locking** — a genuine version-requirement mismatch — does the whole link roll back (which now *also* restores the lock), with a **corrected** `LinkVerificationFailed` message.
5. **If the automatic re-lock itself can't run**, the link is left applied (patch on disk, lock untouched → byte-clean) and a typed `StaleConsumerLockRelockFailed` **names the lockfile and the exact `cargo update` command** the operator runs to finish it.

**Why transparent re-lock as the default** (surfaced per the issue): it is cleanly byte-clean-reversible via the *existing* managed-file machinery — no new teardown path — and it's the ergonomic "super easy dev loop" behavior the milestone intends. Fail-with-precise-remedy is the fallback for the rare case the re-lock tooling can't run, and it directly names the lockfile + command.

The misdiagnosing message is fixed regardless: a stale-lock consumer is now re-locked, never told to change version requirements; the `LinkVerificationFailed` message only fires once the stale-lock cause is ruled out, so its "adjust version requirements" guidance is accurate by construction.

## Byte-clean unlink preserved

`record_relocked_lockfile` reuses the same `LinkedManifestFile` (`existed_before` / `pre_edit_sha256` / `post_edit_sha256`) + backup-dir machinery every other link-touched file uses. `unlink` restores the pre-link `Cargo.lock` byte-identically (or deletes a lock the link created), refuses a user-modified lock without `--force`, and hash-verifies the backup — identical semantics to the config overrides.

## Scope

Confined to the link machinery: `libs/streamlib-cli/src/commands/link.rs` (+ its tests) and the `docs/architecture/package-development-model.md` link section (updated to the shipped behavior). No change to `main.rs`/`commands/mod.rs` (the `link` command and signature are unchanged), no new subcommand, no `add.rs`, no `static_registry.rs`, no `scripts/`. Workspace root `Cargo.lock` unchanged.

## Tests

`cargo test -p streamlib-cli --bins` → **43 passed, 0 failed** (37 pre-existing + 6 new). New deterministic tests:

- `relocked_cargo_lock_is_recorded_and_restored_byte_clean_across_cycles` — link → simulate re-lock → record → `unlink` restores the lock byte-identically, twice.
- `relocked_cargo_lock_created_by_link_is_removed_on_unlink` — a lock the link created (`existed_before = false`) is removed on `unlink`.
- `unlink_refuses_a_user_modified_relocked_lock_without_force` — the lock rides the same tri-state teardown as every managed file.
- `relock_command_string_names_manifest_and_each_target` — the surfaced command is exact.
- `stale_lock_relock_failed_error_names_lockfile_and_command` — names the lockfile + command, **not** a version-requirement misdiagnosis.
- `link_verification_failed_message_is_actionable_and_not_the_old_misdiagnosis` — corrected message; drops the old phrasing.

**Mental-revert:** neutering `record_relocked_lockfile`'s manifest-push makes all three byte-clean lockfile tests fail at their assertions (`"Cargo.lock must be restored byte-identically"` / `"must be removed on unlink"` / the force-restore assert) — confirmed, so they genuinely lock the contract.

The real-cargo e2e (`real_link_offline_e2e_link_refresh_unlink_roundtrip`) exercises the live `verify_and_remedy_patch_resolution` path (happy no-relock branch) and passes. The full stale-lock → transparent-relock loop needs a registry-born lock, which can't be reproduced offline without the registry, so it isn't a CI-locked test — the byte-clean *management* (the part that could silently break `unlink`) is unit-tested, and the `cargo update` invocation is exercised in real use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB