### PR TITLE
fix(cli): streamlib add — clean up orphaned cache slots + unique download temp name

### DIFF
--- a/libs/streamlib-cli/src/commands/add.rs
+++ b/libs/streamlib-cli/src/commands/add.rs
@@ -184,10 +184,23 @@ async fn download_to_temp(url: &str) -> Result<std::path::PathBuf> {
         .bytes()
         .await
         .with_context(|| "Failed to read response body")?;
-    let temp_path = std::env::temp_dir().join("streamlib-add-download.slpkg");
+    let temp_path = std::env::temp_dir().join(unique_download_temp_filename());
     std::fs::write(&temp_path, &bytes)
         .with_context(|| format!("Failed to write temp file {}", temp_path.display()))?;
     Ok(temp_path)
+}
+
+/// A unique temp filename for a URL-add download — pid + a process-local
+/// counter so two concurrent URL-adds (even in the same process) never write
+/// to the same path and clobber each other.
+fn unique_download_temp_filename() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static DOWNLOAD_SEQ: AtomicU64 = AtomicU64::new(0);
+    format!(
+        "streamlib-add-download-{}-{}.slpkg",
+        std::process::id(),
+        DOWNLOAD_SEQ.fetch_add(1, Ordering::Relaxed)
+    )
 }
 
 #[cfg(test)]
@@ -222,6 +235,22 @@ mod tests {
         // ambiguous across orgs and must be rejected.
         assert!(parse_canonical_package_ref("foo").is_err());
         assert!(parse_canonical_package_ref("@tatolab/foo").is_ok());
+    }
+
+    #[test]
+    fn unique_download_temp_filename_is_distinct_and_pid_scoped() {
+        let a = unique_download_temp_filename();
+        let b = unique_download_temp_filename();
+        // Two successive calls must never collide — the whole point of the fix
+        // (two concurrent URL-adds must not clobber one download temp file).
+        // Mentally-revert to a fixed name and this fails.
+        assert_ne!(a, b, "concurrent URL-add downloads must not share a temp filename");
+        let pid = std::process::id().to_string();
+        assert!(
+            a.contains(&pid) && b.contains(&pid),
+            "temp filename must be pid-scoped: {a} / {b}"
+        );
+        assert!(a.ends_with(".slpkg") && b.ends_with(".slpkg"));
     }
 
     #[test]

--- a/libs/streamlib-engine/src/core/runtime/add.rs
+++ b/libs/streamlib-engine/src/core/runtime/add.rs
@@ -37,7 +37,9 @@ use streamlib_idents::{
 use super::module_loader::host_target_triple;
 use super::{BuildEventSink, BuildOrchestrator, BuildPolicy, BuildRequest, BuildSource};
 use crate::core::config::{InstalledPackageEntry, InstalledPackageManifest};
-use crate::core::streamlib_home::{get_cached_package_dir, get_streamlib_data_dir};
+use crate::core::streamlib_home::{
+    get_cached_package_dir, get_cached_package_dir_for_name_version, get_streamlib_data_dir,
+};
 
 /// Knobs for [`add`]. Defaults are the ordinary "add this package" posture —
 /// resolve the registry with the zero-env default fallback, extract into the
@@ -108,6 +110,18 @@ pub enum AddError {
     /// Extracting the `.slpkg` archive into the package cache failed.
     #[error("extracting {} failed: {detail}", archive.display())]
     Extract { archive: PathBuf, detail: String },
+
+    /// Promoting the temp-extracted package into its cache slot (the atomic
+    /// rename that runs only after the identity check passes) failed.
+    #[error(
+        "promoting the extracted package for '{package}' into its cache slot {} failed: {detail}",
+        cache_dir.display()
+    )]
+    Promote {
+        package: PackageRef,
+        cache_dir: PathBuf,
+        detail: String,
+    },
 
     /// The materialized package's `streamlib.yaml` failed to parse or lacked a
     /// `package:` block, so its identity/metadata couldn't be read.
@@ -242,7 +256,9 @@ pub fn add(
         // selected version, so the materialized package's own manifest MUST
         // declare that same identity — reconcile so a mis-published `.slpkg`
         // (its `package:` block disagreeing with its store location) fails loud
-        // instead of silently recording a divergent identity.
+        // instead of silently recording a divergent identity. The identity
+        // check gates promotion of the temp extraction into the cache slot, so
+        // a mismatch also leaves no orphaned slot behind.
         let (_ref, _version, staged_dir) = materialize_and_record(
             extracted,
             orchestrator,
@@ -276,7 +292,7 @@ pub fn add_slpkg(
     orchestrator: &dyn BuildOrchestrator,
     sink: &dyn BuildEventSink,
 ) -> std::result::Result<AddReport, AddError> {
-    let extracted = extract_slpkg(archive)?;
+    let extracted = extract_slpkg_to_temp(archive)?;
     // A local artifact has no external identity to reconcile against — its
     // `package:` block IS the identity — so no `expected` check.
     let (package, version, cache_dir) = materialize_and_record(
@@ -355,8 +371,9 @@ fn resolve_registry(options: &AddOptions) -> RegistryConfig {
 }
 
 /// Download the selected version's `.slpkg`, persist it into the resolver
-/// cache, and extract it into the package cache slot. Returns the extracted
-/// directory.
+/// cache, and extract it into a temp staging dir (promoted into the cache slot
+/// by [`materialize_and_record`] only after the identity check passes).
+/// Returns the temp dir.
 fn download_and_extract(
     client: &RegistryClient<'_>,
     pkg_ref: &PackageRef,
@@ -371,12 +388,13 @@ fn download_and_extract(
         })?;
     tracing::debug!(%url, bytes = bytes.len(), "add: downloaded .slpkg");
     let archive = persist_slpkg(pkg_ref, version, &bytes)?;
-    extract_slpkg(&archive)
+    extract_slpkg_to_temp(&archive)
 }
 
 /// Persist downloaded `.slpkg` bytes into
 /// `<STREAMLIB_HOME>/.streamlib/resolver-cache/add/` so
-/// [`extract_slpkg`] can read them, with an atomic temp-then-rename publish.
+/// [`extract_slpkg_to_temp`] can read them, with an atomic temp-then-rename
+/// publish.
 fn persist_slpkg(
     pkg_ref: &PackageRef,
     version: SemVer,
@@ -397,47 +415,110 @@ fn persist_slpkg(
     Ok(target)
 }
 
-/// Extract a `.slpkg` archive into its package cache slot, mapping the engine
-/// error into an [`AddError::Extract`] that names the archive.
-fn extract_slpkg(archive: &Path) -> std::result::Result<PathBuf, AddError> {
-    super::extract_slpkg_to_cache(archive).map_err(|e| AddError::Extract {
-        archive: archive.to_path_buf(),
-        detail: e.to_string(),
-    })
+/// Extract a `.slpkg` archive into a fresh temp staging dir under the
+/// package-cache parent — the same directory the final cache slots live in, so
+/// [`materialize_and_record`]'s later promotion is an atomic same-filesystem
+/// rename. The temp dir is NOT a cache slot; it is promoted into
+/// `cache/packages/<name>-<version>` only after the identity check passes, so a
+/// mis-published `.slpkg` never leaves an orphaned slot. The partial extraction
+/// is cleaned up on error.
+fn extract_slpkg_to_temp(archive: &Path) -> std::result::Result<PathBuf, AddError> {
+    let temp_dir = temp_stage_dir();
+    super::module_loader::extract_slpkg_to_dir(archive, &temp_dir).map_err(|e| {
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        AddError::Extract {
+            archive: archive.to_path_buf(),
+            detail: e.to_string(),
+        }
+    })?;
+    Ok(temp_dir)
 }
 
-/// Materialize an extracted package directory through the orchestrator, then
-/// record it in `packages.yaml`. Reads the package's identity + metadata from
-/// its own `streamlib.yaml` (the authoritative source for what was
-/// materialized). When `expected` is `Some`, the manifest's identity must
-/// match it or [`AddError::IdentityMismatch`] is returned **before** anything
-/// is recorded — the registry path passes the requested `(pkg_ref, version)`
-/// so a mis-published `.slpkg` can't silently record a divergent identity; a
-/// local `.slpkg` passes `None` (its own manifest IS the identity). Returns
+/// A unique temp staging directory under `cache/packages/` — pid + a
+/// process-local counter keep concurrent adds (including two in the same
+/// process) from colliding on the staging path.
+fn temp_stage_dir() -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static STAGE_SEQ: AtomicU64 = AtomicU64::new(0);
+    get_cached_package_dir(&format!(
+        ".tmp-add-{}-{}",
+        std::process::id(),
+        STAGE_SEQ.fetch_add(1, Ordering::Relaxed)
+    ))
+}
+
+/// Promote a temp-extracted package dir into its final cache slot with an
+/// atomic rename, clearing any pre-existing slot first. Cleans up the temp dir
+/// on failure so a promote error never strands it. Called only after the
+/// identity check has passed, so writing `cache/packages/<name>-<version>` is
+/// gated solely by that check — a rejected package leaves no cache slot.
+fn promote_extracted_dir(
+    temp_dir: &Path,
+    cache_slot: &Path,
+    package: &PackageRef,
+) -> std::result::Result<(), AddError> {
+    let promote_err = |detail: String| {
+        let _ = std::fs::remove_dir_all(temp_dir);
+        AddError::Promote {
+            package: package.clone(),
+            cache_dir: cache_slot.to_path_buf(),
+            detail,
+        }
+    };
+    if cache_slot.exists() {
+        std::fs::remove_dir_all(cache_slot)
+            .map_err(|e| promote_err(format!("clearing the existing slot: {e}")))?;
+    }
+    if let Some(parent) = cache_slot.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            promote_err(format!("creating the cache parent {}: {e}", parent.display()))
+        })?;
+    }
+    std::fs::rename(temp_dir, cache_slot)
+        .map_err(|e| promote_err(format!("renaming {} into place: {e}", temp_dir.display())))?;
+    Ok(())
+}
+
+/// Reconcile a temp-extracted package dir's identity, promote it into its cache
+/// slot, materialize it through the orchestrator, and record it in
+/// `packages.yaml`. Reads the package's identity + metadata from its own
+/// `streamlib.yaml` (the authoritative source for what was materialized).
+///
+/// When `expected` is `Some`, the manifest's identity must match it or
+/// [`AddError::IdentityMismatch`] is returned **before** the extraction is
+/// promoted into the cache — the registry path passes the requested
+/// `(pkg_ref, version)` so a mis-published `.slpkg` can't silently record a
+/// divergent identity, and the failed add leaves no orphan slot (the temp dir
+/// is removed). A local `.slpkg` passes `None` (its own manifest IS the
+/// identity). On a version-upgrade re-add the superseded version's cache slot
+/// is evicted after the new record is durable. Returns
 /// `(package, version, staged_dir)`.
 fn materialize_and_record(
-    extracted_dir: PathBuf,
+    temp_extracted_dir: PathBuf,
     orchestrator: &dyn BuildOrchestrator,
     sink: &dyn BuildEventSink,
     policy: BuildPolicy,
     installed_from: String,
     expected: Option<(&PackageRef, SemVer)>,
 ) -> std::result::Result<(PackageRef, SemVer, PathBuf), AddError> {
-    let meta = Manifest::load(&extracted_dir)
+    let meta = Manifest::load(&temp_extracted_dir)
         .map_err(|e| AddError::ManifestRead {
-            dir: extracted_dir.clone(),
+            dir: temp_extracted_dir.clone(),
             detail: e.to_string(),
         })?
         .package
         .ok_or_else(|| AddError::ManifestRead {
-            dir: extracted_dir.clone(),
+            dir: temp_extracted_dir.clone(),
             detail: "manifest has no `package:` block".into(),
         })?;
     let package = PackageRef::new(meta.org.clone(), meta.name.clone());
     let version = meta.version;
 
+    // Identity gate — the sole promotion gate. A mismatch removes the temp
+    // extraction and returns before anything lands in the cache slot.
     if let Some((expected_ref, expected_version)) = expected {
         if &package != expected_ref || version != expected_version {
+            let _ = std::fs::remove_dir_all(&temp_extracted_dir);
             return Err(AddError::IdentityMismatch {
                 requested: expected_ref.clone(),
                 requested_version: expected_version,
@@ -447,9 +528,14 @@ fn materialize_and_record(
         }
     }
 
+    // Promote the temp extraction into the package's cache slot now that the
+    // identity check has passed.
+    let cache_slot = get_cached_package_dir_for_name_version(package.name.as_str(), version);
+    promote_extracted_dir(&temp_extracted_dir, &cache_slot, &package)?;
+
     let request = BuildRequest {
         package: package.clone(),
-        source: BuildSource::PackageDir(extracted_dir),
+        source: BuildSource::PackageDir(cache_slot),
         policy,
         host_triple: host_target_triple().to_string(),
     };
@@ -466,10 +552,20 @@ fn materialize_and_record(
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_default();
 
+    // Record the new entry, then evict any superseded version's cache slot. A
+    // version-upgrade re-add replaces the `packages.yaml` entry (`add` replaces
+    // same-ref), so the previous version's slot would otherwise linger on disk.
+    // The evict is conditional on a *different* slot key so a same-version
+    // re-materialize (the evicted-slot self-heal path) never deletes the slot
+    // it just promoted.
     let mut manifest =
         InstalledPackageManifest::load().map_err(|e| AddError::LoadManifest {
             detail: e.to_string(),
         })?;
+    let superseded_slot = manifest
+        .find_by_ref(&package)
+        .filter(|e| e.cache_dir != cache_key)
+        .map(|e| get_cached_package_dir(&e.cache_dir));
     manifest.add(InstalledPackageEntry {
         name: package.clone(),
         version,
@@ -481,6 +577,26 @@ fn materialize_and_record(
     manifest.save().map_err(|e| AddError::SaveManifest {
         detail: e.to_string(),
     })?;
+
+    if let Some(old_slot) = superseded_slot {
+        if old_slot.is_dir() {
+            match std::fs::remove_dir_all(&old_slot) {
+                Ok(()) => tracing::info!(
+                    package = %package,
+                    slot = %old_slot.display(),
+                    "add: evicted superseded version cache slot"
+                ),
+                // Disk hygiene only — the new version is already recorded and
+                // durable, so a failed evict must not fail the add.
+                Err(e) => tracing::warn!(
+                    package = %package,
+                    slot = %old_slot.display(),
+                    error = %e,
+                    "add: failed to evict superseded version cache slot (leaving it in place)"
+                ),
+            }
+        }
+    }
 
     Ok((package, version, staged.staged_dir))
 }
@@ -878,5 +994,100 @@ mod tests {
             .unwrap()
             .find_by_ref(&pr)
             .is_none());
+    }
+
+    /// The list of `cache/packages/` slot names currently on disk.
+    fn cache_slots() -> Vec<String> {
+        let dir = get_streamlib_data_dir().join("cache").join("packages");
+        match std::fs::read_dir(&dir) {
+            Ok(rd) => {
+                let mut names: Vec<String> = rd
+                    .filter_map(|e| e.ok())
+                    .map(|e| e.file_name().to_string_lossy().into_owned())
+                    .collect();
+                names.sort();
+                names
+            }
+            Err(_) => Vec::new(),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn add_identity_mismatch_leaves_no_orphan_cache_slot() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = sandbox_home(home.path());
+        let tree = tempfile::tempdir().unwrap();
+        // Store location says foo@1.1.0, but the `.slpkg`'s manifest declares
+        // `bar` — a mis-published package (same setup as the fail-loud test).
+        let dir = tree.path().join("slpkg").join("foo").join("1.1.0");
+        std::fs::create_dir_all(&dir).unwrap();
+        write_slpkg(&dir.join("foo.slpkg"), "tatolab", "bar", "1.1.0");
+
+        let pr = pkg_ref("tatolab", "foo");
+        let req = SemVerRange::from_str("^1.0.0").unwrap();
+        let err = add(&pr, &req, &MockOrchestrator, &NullSink, &opts(tree.path()))
+            .expect_err("a mis-published .slpkg must fail loud");
+        assert!(matches!(err, AddError::IdentityMismatch { .. }), "got {err:?}");
+
+        // The identity check is the sole promotion gate: no slot may survive in
+        // cache/packages — not the `bar-1.1.0` orphan the old extract-to-slot
+        // path left, not a `foo-1.1.0` slot, not the `.tmp-add-*` staging dir.
+        // Mentally-revert the extract-to-temp-then-promote (extract straight
+        // into the cache slot) and `bar-1.1.0` reappears here → this fails.
+        let leftover = cache_slots();
+        assert!(
+            leftover.is_empty(),
+            "IdentityMismatch must leave no cache/packages slot, found: {leftover:?}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn add_version_upgrade_evicts_superseded_slot() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = sandbox_home(home.path());
+        let tree = tempfile::tempdir().unwrap();
+        scratch_tree(tree.path(), "tatolab", "foo", &["1.0.0", "2.0.0"], None);
+        let pr = pkg_ref("tatolab", "foo");
+
+        // First add pins 1.0.0 — caret `^1.0.0` excludes the 2.0.0 major bump.
+        let first = add(
+            &pr,
+            &SemVerRange::from_str("^1.0.0").unwrap(),
+            &MockOrchestrator,
+            &NullSink,
+            &opts(tree.path()),
+        )
+        .unwrap();
+        assert_eq!(first.version, SemVer::new(1, 0, 0));
+        assert!(first.cache_dir.ends_with("cache/packages/foo-1.0.0"));
+        assert_eq!(cache_slots(), vec!["foo-1.0.0".to_string()]);
+
+        // Upgrade to 2.0.0.
+        let second = add(
+            &pr,
+            &SemVerRange::from_str("^2.0.0").unwrap(),
+            &MockOrchestrator,
+            &NullSink,
+            &opts(tree.path()),
+        )
+        .unwrap();
+        assert_eq!(second.version, SemVer::new(2, 0, 0));
+        assert!(second.cache_dir.ends_with("cache/packages/foo-2.0.0"));
+
+        // Exactly one foo slot survives — the superseded foo-1.0.0 slot is
+        // evicted. Mentally-revert the evict and both foo-1.0.0 and foo-2.0.0
+        // remain → two slots → this fails.
+        assert_eq!(
+            cache_slots(),
+            vec!["foo-2.0.0".to_string()],
+            "the superseded version's cache slot must be evicted on upgrade"
+        );
+
+        // packages.yaml records the single upgraded entry.
+        let manifest = InstalledPackageManifest::load().unwrap();
+        assert_eq!(manifest.packages.iter().filter(|e| e.name == pr).count(), 1);
+        assert_eq!(manifest.find_by_ref(&pr).unwrap().version, SemVer::new(2, 0, 0));
     }
 }

--- a/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -62,7 +62,7 @@ pub use errors::{AddModuleError, RemoveModuleError};
 pub(crate) use locked::LockedResolution;
 pub use processor_registration::host_target_triple;
 pub(crate) use recursive_walker::ResolutionMemo;
-pub use slpkg::extract_slpkg_to_cache;
+pub use slpkg::{extract_slpkg_to_cache, extract_slpkg_to_dir};
 pub use source::{ArtifactChecksum, SemVerRange, Strategy};
 
 use added_module::MODULE_EVENT_CHANNEL_CAPACITY;

--- a/libs/streamlib-engine/src/core/runtime/module_loader/slpkg.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/slpkg.rs
@@ -44,25 +44,45 @@ pub fn extract_slpkg_to_cache(slpkg_path: &std::path::Path) -> Result<std::path:
         package.version,
     );
 
+    // Reuse the already-read bytes — extract into the derived cache slot.
+    extract_zip_bytes_to_dir(&slpkg_bytes, &cache_dir, slpkg_path)?;
+    Ok(cache_dir)
+}
+
+/// Extract a .slpkg ZIP archive into an explicit destination directory,
+/// overwriting it if present. Unlike [`extract_slpkg_to_cache`] the
+/// destination is caller-chosen (a final cache slot, or a temp staging dir a
+/// caller promotes into the cache only after an identity check passes), so the
+/// archive's own `package:` identity does not decide where the bytes land.
+/// Rejects path-traversal entries.
+pub fn extract_slpkg_to_dir(slpkg_path: &std::path::Path, dest_dir: &std::path::Path) -> Result<()> {
+    let slpkg_bytes = std::fs::read(slpkg_path).map_err(|e| {
+        Error::Configuration(format!("Failed to read {}: {}", slpkg_path.display(), e))
+    })?;
+    extract_zip_bytes_to_dir(&slpkg_bytes, dest_dir, slpkg_path)
+}
+
+/// Extract every entry of the in-memory `.slpkg` ZIP `slpkg_bytes` into
+/// `dest_dir` (cleared first, always-overwrite), rejecting path-traversal
+/// entries. `source_label` names the archive in `tracing` / error text only.
+fn extract_zip_bytes_to_dir(
+    slpkg_bytes: &[u8],
+    dest_dir: &std::path::Path,
+    source_label: &std::path::Path,
+) -> Result<()> {
     // Always overwrite
-    if cache_dir.exists() {
-        std::fs::remove_dir_all(&cache_dir)
+    if dest_dir.exists() {
+        std::fs::remove_dir_all(dest_dir)
             .map_err(|e| Error::Configuration(format!("Failed to clear cache dir: {}", e)))?;
     }
 
-    tracing::info!(
-        "Extracting {} to {}",
-        slpkg_path.display(),
-        cache_dir.display()
-    );
-    std::fs::create_dir_all(&cache_dir)
+    tracing::info!("Extracting {} to {}", source_label.display(), dest_dir.display());
+    std::fs::create_dir_all(dest_dir)
         .map_err(|e| Error::Configuration(format!("Failed to create cache dir: {}", e)))?;
 
-    // Re-open archive (cursor consumed by manifest read)
-    let cursor = std::io::Cursor::new(&slpkg_bytes);
-    let mut archive = zip::ZipArchive::new(cursor).map_err(|e| {
-        Error::Configuration(format!("Failed to re-open .slpkg archive: {}", e))
-    })?;
+    let cursor = std::io::Cursor::new(slpkg_bytes);
+    let mut archive = zip::ZipArchive::new(cursor)
+        .map_err(|e| Error::Configuration(format!("Failed to open .slpkg archive: {}", e)))?;
 
     for i in 0..archive.len() {
         let mut file = archive.by_index(i).map_err(|e| {
@@ -79,7 +99,7 @@ pub fn extract_slpkg_to_cache(slpkg_path: &std::path::Path) -> Result<std::path:
             )));
         }
 
-        let output_path = cache_dir.join(&file_name);
+        let output_path = dest_dir.join(&file_name);
 
         if let Some(parent) = output_path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
@@ -96,5 +116,5 @@ pub fn extract_slpkg_to_cache(slpkg_path: &std::path::Path) -> Result<std::path:
         })?;
     }
 
-    Ok(cache_dir)
+    Ok(())
 }


### PR DESCRIPTION
## What

Three low-severity hygiene fixes on the `streamlib add` surface shipped in #1292 (`sdk::runtime::add` + CLI wrapper), flagged independently by both #1292 review lenses. Nothing dangled in `packages.yaml`; these are on-disk cache hygiene + a temp-name concurrency edge.

### 1. IdentityMismatch orphan → extract-to-temp, promote after the identity check

Previously the downloaded `.slpkg` was extracted straight into `cache/packages/<found-name>-<ver>` **before** the identity check fired, so a mis-published package (its `package:` block disagreeing with its store location) left an unrecorded extracted slot on disk when the fail-loud path returned.

Now the archive is extracted into a **temp staging dir** under `cache/packages/` and promoted into the final slot with an **atomic rename only after the identity check passes**. The identity check is the sole promotion gate — a rejected package leaves no cache slot (the temp dir is removed on mismatch), and a promote failure never strands the temp dir.

### 2. Version-upgrade orphan → evict the superseded version's slot

Re-adding a newer version replaced the `packages.yaml` entry but left the previous version's cache slot on disk. Now, after the new record is durable, the superseded version's slot is evicted. The evict is conditional on a **different** slot key, so the evicted-slot self-heal path (a same-version re-materialize) never deletes the slot it just promoted. A failed evict is a `warn`, not a hard error — the new version is already recorded.

### 3. Fixed download temp name → pid + counter

The CLI URL-add path (`download_to_temp`) wrote a fixed `streamlib-add-download.slpkg`, so two concurrent URL-adds would clobber. It now uses a `pid + process-local-counter` filename (`streamlib-add-download-<pid>-<n>.slpkg`).

## Shape / scope

- `libs/streamlib-engine/src/core/runtime/add.rs` — the three-fix logic (extract-to-temp `extract_slpkg_to_temp` + `temp_stage_dir`, `promote_extracted_dir`, superseded-slot eviction in `materialize_and_record`), a new typed `AddError::Promote` variant, + 2 tests.
- `libs/streamlib-engine/src/core/runtime/module_loader/slpkg.rs` — a small **behavior-preserving** `extract_slpkg_to_dir(archive, dest)` primitive so `add.rs` can extract to an explicit temp dir without duplicating the security-checked (path-traversal-rejecting) zip extraction; `extract_slpkg_to_cache` now delegates to it (same overwrite semantics), and `module_loader/mod.rs` re-exports it.
- `libs/streamlib-cli/src/commands/add.rs` — unique download temp filename + 1 test.

Confined to the add surface — `commands/link.rs`, `commands/mod.rs`, `main.rs`, and `Cargo.lock` are untouched (no new subcommand; internal fixes only).

## Tests

New unit tests (3):

- `add.rs::tests::add_identity_mismatch_leaves_no_orphan_cache_slot` — a mis-published `.slpkg` add fails loud AND leaves `cache/packages/` empty (no `bar-<ver>` orphan, no leftover temp dir).
- `add.rs::tests::add_version_upgrade_evicts_superseded_slot` — add `foo@1.0.0` then upgrade to `foo@2.0.0`; exactly one `foo-*` cache slot remains (`foo-2.0.0`) and `packages.yaml` holds the single upgraded entry.
- `commands/add.rs::tests::unique_download_temp_filename_is_distinct_and_pid_scoped` — two successive calls yield distinct, pid-scoped `.slpkg` names.

**Mental-revert (verified empirically, not just claimed):**

| Fix reverted | Test | Result |
|---|---|---|
| Promote moved *before* the identity gate (pre-fix order) | `add_identity_mismatch_leaves_no_orphan_cache_slot` | **FAILED** — the `bar-1.1.0` orphan reappears |
| Superseded-slot eviction disabled | `add_version_upgrade_evicts_superseded_slot` | **FAILED** — `left: ["foo-1.0.0", "foo-2.0.0"]`, `right: ["foo-2.0.0"]` |

With both fixes reverted, the 9 pre-existing #1292 add tests still passed (2 failed, 9 passed) — confirming the reverts isolate to the new tests.

**Regression check:** `cargo test --lib -p streamlib-engine core::runtime::add::` → **11 passed, 0 failed** (my 2 new + all 9 #1292 tests: idempotency, offline InstalledCache resolve, evicted-slot self-heal, IdentityMismatch fail-loud-before-record, catalog, unsatisfiable-range, remove). `cargo test -p streamlib-cli` → all 6 `commands::add::tests` green (incl. the new one).

> Note: `cargo test -p streamlib-cli` also runs `commands::link::tests` (sibling #1248's untouched code); 2 of those fail in the sandbox because they spawn a child `cargo` that resolves the `vulkanalia` fork from the canonical `registry.tatolab.com` (unreachable here) — a pre-existing environmental failure, not a regression from this change.

Closes #1293

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB
