### PR TITLE
fix(ci): rebuild test.yml as a minimal Linux-only cargo-fork-mirror gate; schemas.yml fork-hole is illusory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,59 +1,15 @@
 name: Test
 
-# DISABLED: Temporarily disabled to reduce GitHub Actions costs
-# To re-enable, uncomment the triggers below
 on:
-  workflow_dispatch:  # Manual trigger only
-  # pull_request:
-  # push:
-  #   branches: [main]
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  rust-tests:
-    name: Rust Tests (macOS)
-    runs-on: macos-14  # macOS for Apple-specific code
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install system dependencies
-        run: brew install opus pkg-config
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-
-      - name: Cache Cargo
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-
-      - name: Run clippy
-        run: cargo clippy --workspace --features debug-overlay --bins --lib -- -D warnings
-
-      - name: Build workspace
-        run: cargo build --workspace --features debug-overlay
-
-      - name: Run tests
-        run: cargo test --workspace --features debug-overlay --lib
-
-      - name: Build examples
-        run: |
-          cargo build -p camera-display
-          cargo build -p whep-player
-          cargo build -p microphone-reverb-speaker
-
   rust-tests-linux:
     name: Rust Tests (Linux)
     runs-on: ubuntu-latest
@@ -62,21 +18,27 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies
+        # `-p streamlib` pulls streamlib-engine, whose build.rs compiles GLSL
+        # compute shaders with glslc and generates JTD bindings; the Linux
+        # engine dep set links Vulkan. Minimal subset — no GPU/codec backends.
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             pkg-config \
             protobuf-compiler \
             libvulkan-dev \
-            libopus-dev \
-            libasound2-dev \
-            libavcodec-dev \
-            libavformat-dev \
-            libavutil-dev \
-            libswscale-dev \
-            libswresample-dev \
-            libavfilter-dev \
-            libavdevice-dev
+            glslc
+
+      - name: Install jtd-codegen
+        # The engine's build.rs invokes the upstream jtd-codegen binary
+        # (v0.4.1) to generate typed bindings from JTD schemas — see
+        # libs/streamlib-jtd-codegen/src/lib.rs for the version contract. The
+        # streamlib-engine build fails without it.
+        run: |
+          curl -sSL https://github.com/jsontypedef/json-typedef-codegen/releases/download/v0.4.1/x86_64-unknown-linux-gnu.zip -o /tmp/jtd-codegen.zip
+          unzip -q /tmp/jtd-codegen.zip -d /tmp/jtd-codegen
+          sudo install -m 0755 /tmp/jtd-codegen/jtd-codegen /usr/local/bin/jtd-codegen
+          jtd-codegen --version
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -84,25 +46,29 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache Cargo
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-
+
+      # Serverless registry: the workspace declares `vulkanalia = { registry =
+      # "tatolab" }`, so `-p streamlib` (→ engine → vulkanalia on Linux) cannot
+      # build without the fork fetchable. Emit it + reshape into a cargo
+      # local-registry `[source]` replacement (no HTTP server) so the `--locked`
+      # builds below resolve the fork offline. Runs before every cargo command.
+      - name: Mirror vulkanalia fork (serverless cargo [source] replacement)
+        uses: ./.github/actions/cargo-fork-mirror
 
       - name: Check formatting
         run: cargo fmt --all -- --check
 
       - name: Run clippy
-        run: cargo clippy -p streamlib --features ffmpeg -- -D warnings
-
-      - name: Check streamlib
-        run: cargo check -p streamlib
-
-      - name: Check streamlib with FFmpeg
-        run: cargo check -p streamlib --features ffmpeg
+        run: cargo clippy --locked -p streamlib -- -D warnings
 
       - name: Run unit tests
-        run: cargo test -p streamlib --lib
+        run: cargo test --locked -p streamlib --lib

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
 
       - name: Cache Cargo
         uses: actions/cache@v4
@@ -60,13 +58,10 @@ jobs:
       # "tatolab" }`, so `-p streamlib` (→ engine → vulkanalia on Linux) cannot
       # build without the fork fetchable. Emit it + reshape into a cargo
       # local-registry `[source]` replacement (no HTTP server) so the `--locked`
-      # builds below resolve the fork offline. Runs before every cargo command.
+      # build below resolves the fork offline.
       - name: Mirror vulkanalia fork (serverless cargo [source] replacement)
         uses: ./.github/actions/cargo-fork-mirror
 
       # The documented CI unit-test gate ("CI runs `cargo test --lib`").
       - name: Run unit tests
         run: cargo test --locked -p streamlib --lib
-
-      - name: Run clippy
-        run: cargo clippy --locked -p streamlib -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
+          components: clippy
 
       - name: Cache Cargo
         uses: actions/cache@v4
@@ -64,11 +64,9 @@ jobs:
       - name: Mirror vulkanalia fork (serverless cargo [source] replacement)
         uses: ./.github/actions/cargo-fork-mirror
 
-      - name: Check formatting
-        run: cargo fmt --all -- --check
+      # The documented CI unit-test gate ("CI runs `cargo test --lib`").
+      - name: Run unit tests
+        run: cargo test --locked -p streamlib --lib
 
       - name: Run clippy
         run: cargo clippy --locked -p streamlib -- -D warnings
-
-      - name: Run unit tests
-        run: cargo test --locked -p streamlib --lib


### PR DESCRIPTION
## What & why

Issue #1301 flagged two workflows (`schemas.yml`, `test.yml`) as building the workspace with no CI helper for the `vulkanalia` fork — falling back to the canonical `[registries.tatolab]` index (`sparse+https://registry.tatolab.com/cargo/`), which isn't guaranteed to be a live server. The task: fix `schemas.yml`'s fork resolution and decide `test.yml`'s fate. Grounding first showed the two need very different treatment.

## Empirical determination — schemas.yml's "hole" is illusory (no change)

`schemas.yml` runs on **`macos-14`**. Its `cargo run --bin generate_schemas` builds `libs/streamlib-engine`, whose vulkanalia deps are declared **only** under `[target.'cfg(target_os = "linux")'.dependencies]` (`vulkanalia` + `vulkanalia-vma`, hard). The macOS target block has no vulkanalia, and the optional `[dependencies]` `vulkanalia` is enabled solely by `backend-vulkan`, which is **not** in `default = []` and is not passed by `schemas.yml`. So on macOS the fork is **target-gated out** — the build never compiles or resolves it, and with the committed `Cargo.lock` in sync cargo does not re-resolve against the `tatolab` index. The SDK cross-crate deps resolve as workspace path members, not registry fetches.

Therefore `schemas.yml` has **no dependence on a live `registry.tatolab.com` for the fork**, and adding the `cargo-fork-mirror` step to it would be pointless — worse, that action is Linux-shaped (clones the fork, `cargo package`s it, reshapes a local-registry) and running it on a macOS job that never consumes the fork adds cost and fragility for zero benefit. **`schemas.yml` is intentionally unchanged.** Exit criterion #1 is met by determination, not code.

Honest caveats: the guarantee rests on target-gating **and** an in-sync committed lock; a Linux runner, an enabled `backend-vulkan`, or a stale lock would each re-introduce a real fork dependency. On `main` the lock is in-sync (asserted by `cargo-fork-mirror`'s own checksum gate; actively maintained, e.g. #1294), and the release-please trigger path regenerates it, so the current path is safe. `schemas.yml` also has a **separate, unrelated** staleness — `generate_openapi` lives in `packages/api-server`, which is no longer a workspace member, so `cargo run --bin generate_openapi` from the repo root can't find it. That's pre-existing rot outside this issue's fork-resolution scope, deferred to #1310.

## test.yml — rebuilt as a minimal Linux-only gate (option A)

`test.yml` was `# DISABLED` (workflow_dispatch only) and **multiply stale**: both macOS steps passed `--features debug-overlay` (a feature that exists in no manifest), the macOS job built `-p <example>` crates that are no longer workspace members, and the Linux job passed `--features ffmpeg` on `streamlib` (which has no such feature). Yet it was the **only** CI enforcement of the "CI runs `cargo test --lib`" strategy — otherwise unenforced.

Per the maintainer's cost decision, rebuilt as a **single `ubuntu-latest` job**:
- Triggers `pull_request` + `push:[main]`; the expensive `macos-14` job is dropped entirely.
- Re-homed onto the serverless `./.github/actions/cargo-fork-mirror` step (identical usage to the migrated workflows — bare `uses:`, no `CARGO_REGISTRIES_TATOLAB_INDEX` export), because `-p streamlib` → engine → `vulkanalia` on Linux genuinely needs the fork.
- Installs the engine `build.rs` prerequisites (`glslc`, `jtd-codegen` v0.4.1, `pkg-config` / `protobuf-compiler` / `libvulkan-dev`), mirroring the proven-good setup in `check-pack-load.yml` — the migrated workflow that builds `streamlib-engine` on ubuntu-latest through the same mirror.
- Gate: `cargo test --locked -p streamlib --lib` — the documented unit-test gate.

### Scoped down to green; fmt + clippy deferred to #1310

Re-enabling the full gate immediately surfaced **pre-existing** workspace debt (this PR touches only YAML — zero Rust changes), accumulated over the ~3 months `test.yml` was disabled:
- `cargo fmt --all -- --check`: ~4,300 rustfmt hunks across ~517 files.
- `cargo clippy --locked -p streamlib -- -D warnings`: pre-existing violations in the `streamlib-idents` path-dep (`clippy::for_kv_map` in `resolver.rs`, `clippy::should_implement_trait` in `semver.rs`).

`cargo test --locked -p streamlib --lib` itself is **green** on the mirror. Per option A, the gate ships with only what passes now — the mirror step + the `cargo test --lib` unit gate. The workspace `cargo fmt --all` + clippy cleanup and the restoration of the fmt/clippy gate steps (plus the `generate_openapi` staleness) are deferred to the workspace-cleanup sweep ticket #1310. This restores the documented `cargo test --lib` CI gate now, on the primary Linux platform, at low cost, without holding it hostage to a 517-file mechanical sweep.

## Validation (headless-CI caveat)

GitHub Actions can't be run locally, so validation is:
- `test.yml` is valid YAML (single `rust-tests-linux` job; `pull_request` + `push` triggers).
- The `cargo-fork-mirror` step is byte-identical to the reference migrated workflows (`check-boundaries.yml`, `check-pack-load.yml`).
- The rebuilt job's CI run **proved the mirror resolves the fork offline and `cargo test -p streamlib --lib` passes** — the earlier red runs were pre-existing fmt/clippy debt (now deferred), not a wiring defect. The final job (mirror + test-lib) runs green.

Only `.github/workflows/test.yml` changes; `schemas.yml` and `release-please.yml` are untouched.

Closes #1301

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB
