### PR TITLE
fix(docker): align in-container fork resolution with the serverless cargo [source] mirror (#1298)

### DIFF
--- a/docker/build-stage1.sh
+++ b/docker/build-stage1.sh
@@ -2,9 +2,12 @@
 # Stage-1 (builder) orchestration for the multi-stage GPU Docker distribution.
 #
 # Runs inside the `builder` image (full toolchain, GPU-free). It:
-#   1. bootstraps the tatolab/vulkanalia fork as a STATIC cargo sparse tree and
-#      serves it on a throwaway localhost mount, so the workspace (xtask
-#      included) resolves `vulkanalia = { registry = "tatolab" }` daemon-free,
+#   1. mirrors the tatolab/vulkanalia fork as a SERVERLESS cargo local-registry
+#      `[source]` replacement (emit-static-fork.sh + emit-cargo-local-registry.sh,
+#      no running HTTP server), so the workspace (xtask included) resolves
+#      `vulkanalia = { registry = "tatolab" }` OFFLINE while keeping the
+#      canonical source id in every Cargo.lock — the exact shape the
+#      .github/actions/cargo-fork-mirror CI action uses,
 #   2. builds the streamlib CLI + streamlib-runtime binaries in-place,
 #   3. emits the full image-local static registry tree (cargo closure + fork +
 #      pypi + npm + `.slpkg` generic store + catalog + release manifest) via
@@ -13,12 +16,14 @@
 #   5. writes the runtime cargo `[source]`-replacement + npm config pointing at
 #      the image-local tree, and runs an api-server resolution preflight.
 #
-# There is NO registry daemon. The tree is plain files: cargo + npm resolve over
-# a dumb `python3 -m http.server` mount (sparse + npm are HTTP-only by spec);
-# pypi + `.slpkg` read the same tree straight off `file://`. The final stage
-# COPYs /opt/streamlib (carrying the tree) + /usr/local/cargo (carrying the
-# `[source]` config) and docker/entrypoint.sh re-serves the mount at runtime.
-# See docs/architecture/static-registry.md.
+# There is NO registry daemon. The build-time fork resolve is serverless (a
+# cargo local-registry read straight off disk); the RUNTIME tree is plain files
+# the entrypoint re-serves for cargo + npm over a dumb `python3 -m http.server`
+# mount (sparse + npm are HTTP-only by spec), while pypi + `.slpkg` read it
+# straight off `file://`. The final stage COPYs /opt/streamlib (carrying the
+# tree) + /usr/local/cargo (carrying the runtime `[source]` config) and
+# docker/entrypoint.sh re-serves the mount at runtime.
+# See docs/architecture/static-registry.md and .github/actions/cargo-fork-mirror.
 #
 # Configure-by-env (Dockerfile ARGs -> ENV): SRC, APP_DIR, REGISTRY_DIR,
 # REGISTRY_PORT, CARGO_HOME, and the SKIP_* toggles.
@@ -29,8 +34,11 @@ APP_DIR="${APP_DIR:-/opt/streamlib}"
 REGISTRY_DIR="${REGISTRY_DIR:-${APP_DIR}/registry}"
 REGISTRY_PORT="${REGISTRY_PORT:-8799}"
 REGISTRY_BASE_URL="http://127.0.0.1:${REGISTRY_PORT}"
+# Port for emit-static-fork.sh's OWN ~2s throwaway packaging server (it starts
+# and kills it internally to resolve fork siblings during `cargo package`); no
+# long-lived server lives on it. Distinct from REGISTRY_PORT so it can never
+# race the xtask emit's internal fork server or the preflight mount.
 BOOTSTRAP_PORT="${BOOTSTRAP_PORT:-8798}"
-BOOTSTRAP_BASE_URL="http://127.0.0.1:${BOOTSTRAP_PORT}"
 CARGO_HOME="${CARGO_HOME:?CARGO_HOME must be set}"
 
 # Map the fast-iteration skip toggles to the emit's per-ecosystem skip flags.
@@ -42,19 +50,17 @@ log()  { printf '\n[stage1] %s\n' "$*"; }
 fail() { printf '\n[stage1] ERROR: %s\n' "$*" >&2; exit 1; }
 
 BOOTSTRAP_DIR=""
-BOOTSTRAP_PID=""
 PREFLIGHT_PID=""
 cleanup() {
-  [ -n "$BOOTSTRAP_PID" ]  && kill "$BOOTSTRAP_PID"  2>/dev/null || true
-  [ -n "$PREFLIGHT_PID" ]  && kill "$PREFLIGHT_PID"  2>/dev/null || true
-  [ -n "$BOOTSTRAP_DIR" ]  && rm -rf "$BOOTSTRAP_DIR" || true
+  if [ -n "$PREFLIGHT_PID" ]; then kill "$PREFLIGHT_PID" 2>/dev/null || true; fi
+  if [ -n "$BOOTSTRAP_DIR" ]; then rm -rf "$BOOTSTRAP_DIR"; fi
 }
 trap cleanup EXIT
 
 # ---------------------------------------------------------------------------
 # 0. Clone the vulkanalia fork (registry dep). VULKANALIA_DIR is reused by both
-#    the bootstrap fork emit and the xtask emit's internal fork step (no
-#    re-clone). The pinned rev is sourced from the workspace, not hardcoded.
+#    the build-time fork mirror (step 1) and the xtask emit's internal fork step
+#    (no re-clone). The pinned rev is sourced from the workspace, not hardcoded.
 # ---------------------------------------------------------------------------
 VULKANALIA_REV="$(grep -oE 'rev = "[0-9a-f]{40}"' "$SRC/libs/streamlib-cross-rustc-fixture/Cargo.toml" | head -1 | grep -oE '[0-9a-f]{40}')"
 [ -n "$VULKANALIA_REV" ] || fail "could not derive the vulkanalia rev from the workspace"
@@ -67,31 +73,50 @@ git -C /tmp/vulkanalia submodule update --init --quiet \
 export VULKANALIA_DIR=/tmp/vulkanalia
 
 # ---------------------------------------------------------------------------
-# 1. Bootstrap: emit + serve the vulkanalia fork static cargo tree so the
-#    workspace (and xtask itself) resolves the `tatolab` registry daemon-free.
-#    The mount stays up for the whole build stage; cargo reaches it via the
-#    CARGO_REGISTRIES_TATOLAB_INDEX override. On a DIFFERENT port than the final
-#    tree's base URL so the xtask emit's own fork step can bind that port.
+# 1. Build-time fork mirror (SERVERLESS): emit the vulkanalia fork static cargo
+#    tree, reshape it into a cargo local-registry, and point cargo at it via a
+#    `[source]` replacement in $CARGO_HOME/config.toml — so the workspace (and
+#    xtask itself) resolves `vulkanalia = { registry = "tatolab" }` OFFLINE with
+#    NO running HTTP server. This mirrors .github/actions/cargo-fork-mirror
+#    exactly; do NOT export CARGO_REGISTRIES_TATOLAB_INDEX — an env index
+#    override shadows the `[source]` replacement and rewrites the fork's source
+#    id in Cargo.lock (it wins over `replace-with`), defeating the canonical-id
+#    preservation. emit-static-fork.sh starts its OWN ~2s throwaway packaging
+#    server on $BOOTSTRAP_PORT (to resolve fork siblings during `cargo package`)
+#    and kills it before returning; normalize_fork_crate.py (run inside it)
+#    rewrites the baked port URL to the canonical index so the emitted checksums
+#    match the committed Cargo.lock. VULKANALIA_DIR (exported above) is reused by
+#    the xtask emit's internal fork step below — no re-clone.
 # ---------------------------------------------------------------------------
-log "bootstrapping the vulkanalia fork static cargo tree ($BOOTSTRAP_BASE_URL)"
+log "mirroring the vulkanalia fork as a serverless cargo local-registry [source] replacement"
 BOOTSTRAP_DIR="$(mktemp -d)"
-python3 -m http.server "$BOOTSTRAP_PORT" --bind 127.0.0.1 --directory "$BOOTSTRAP_DIR" \
-  >/tmp/bootstrap-httpd.log 2>&1 &
-BOOTSTRAP_PID=$!
-for i in $(seq 1 30); do
-  curl -fsS "$BOOTSTRAP_BASE_URL/" >/dev/null 2>&1 && break
-  kill -0 "$BOOTSTRAP_PID" 2>/dev/null || { cat /tmp/bootstrap-httpd.log; fail "bootstrap static server exited"; }
-  [ "$i" = 30 ] && { cat /tmp/bootstrap-httpd.log; fail "bootstrap static server did not come up on $BOOTSTRAP_BASE_URL"; }
-  sleep 1
-done
-export CARGO_REGISTRIES_TATOLAB_INDEX="sparse+${BOOTSTRAP_BASE_URL}/cargo/"
-STATIC_FORK_URL="$BOOTSTRAP_BASE_URL" \
-  "$SRC/scripts/registry/emit-static-fork.sh" "$BOOTSTRAP_DIR" --base-url "$BOOTSTRAP_BASE_URL"
-curl -fsS "$BOOTSTRAP_BASE_URL/cargo/config.json" >/dev/null || fail "bootstrap fork tree not fetchable"
+"$SRC/scripts/registry/emit-static-fork.sh" "$BOOTSTRAP_DIR" \
+  --base-url "http://127.0.0.1:${BOOTSTRAP_PORT}"
+"$SRC/scripts/registry/emit-cargo-local-registry.sh" \
+  "$BOOTSTRAP_DIR" "$BOOTSTRAP_DIR/cargo-local-registry"
+[ -f "$BOOTSTRAP_DIR/cargo-local-registry/index/vu/lk/vulkanalia" ] \
+  || fail "vulkanalia fork not present in the local-registry mirror"
+
+# The serverless [source] replacement. GLOBAL cargo config (not the workspace
+# .cargo/config.toml) so an out-of-tree `cargo package` — the xtask closure
+# emit's inner packaging — also sees it. Overwritten by the RUNTIME served
+# config in step 6; the build-time mirror dir is throwaway (dropped in step 4).
+mkdir -p "$CARGO_HOME"
+cat > "$CARGO_HOME/config.toml" <<EOF
+[registries.tatolab]
+index = "sparse+https://registry.tatolab.com/cargo/"
+
+[source.tatolab]
+registry = "sparse+https://registry.tatolab.com/cargo/"
+replace-with = "tatolab-local-registry"
+
+[source.tatolab-local-registry]
+local-registry = "${BOOTSTRAP_DIR}/cargo-local-registry"
+EOF
 
 # ---------------------------------------------------------------------------
 # 2. Build the streamlib CLI + runtime binaries in-place (resolves the fork
-#    from the bootstrap mount).
+#    serverless via the step-1 local-registry [source] replacement).
 # ---------------------------------------------------------------------------
 log "building streamlib CLI + runtime (release)"
 ( cd "$SRC" && cargo build --release -p streamlib-cli -p streamlib-runtime )
@@ -102,27 +127,38 @@ log "building streamlib CLI + runtime (release)"
 # 3. Emit the full image-local static registry tree. --cargo-closure packages
 #    every workspace release-closure crate; the fork + pypi + npm + `.slpkg`
 #    store + catalog + release manifest (the atomicity flip) ride the same emit.
-#    The emit manages its own transient sub-servers (a throwaway fork server on
-#    $REGISTRY_PORT, an ephemeral closure-packaging server on a random port);
-#    the bootstrap mount on $BOOTSTRAP_PORT satisfies the outer xtask build.
+#    The OUTER `cargo run -p xtask` resolves the fork via the serverless
+#    [source] replacement from step 1; the emit then manages its OWN transient
+#    sub-servers internally (its inner `cargo package` points
+#    CARGO_REGISTRIES_TATOLAB_INDEX at an ephemeral staging server, which wins
+#    over the [source] replacement for those subprocesses). That inner override
+#    dirties /src/Cargo.lock's fork source, but /src is discarded after stage 1
+#    (never COPYed into the final image) and nothing downstream resolves in it,
+#    so no lock restore is needed here — unlike the CI reference, which runs a
+#    post-emit `cargo test --locked` in the same workspace.
 # ---------------------------------------------------------------------------
 EMIT_ARGS=(--out "$REGISTRY_DIR" --cargo-closure --base-url "$REGISTRY_BASE_URL")
 [ "$SKIP_PYTHON_SDK" = 1 ] && EMIT_ARGS+=(--no-pypi)
 [ "$SKIP_DENO_SDK" = 1 ]   && EMIT_ARGS+=(--no-npm)
 [ "$SKIP_PACKAGES" = 1 ]   && EMIT_ARGS+=(--no-slpkg)
+# Belt-and-suspenders: force a fresh `cargo package` for every closure crate.
+# The emitter already always repackages from source (target/package is cargo
+# scratch, not a trusted content cache), so this is redundant on a fresh builder
+# layer — kept for parity with the CI emit and to stay correct if a build cache
+# mount is ever added.
+rm -rf "$SRC/target/package"
 log "emitting static registry tree at $REGISTRY_DIR (base $REGISTRY_BASE_URL)"
 ( cd "$SRC" && cargo run --release -q -p xtask -- static-registry emit "${EMIT_ARGS[@]}" )
 [ -f "$REGISTRY_DIR/cargo/config.json" ] || fail "static registry emit did not produce cargo/config.json"
 
 # ---------------------------------------------------------------------------
-# 4. Stop the bootstrap mount + drop its env override. Everything below resolves
-#    the `tatolab` registry through the final $CARGO_HOME/config.toml source
-#    replacement against the emitted tree served on $REGISTRY_PORT.
+# 4. Drop the build-time serverless fork mirror. Everything below resolves the
+#    `tatolab` registry through the RUNTIME $CARGO_HOME/config.toml source
+#    replacement (written in step 6) against the emitted tree served on
+#    $REGISTRY_PORT — the build-time local-registry dir is no longer referenced.
 # ---------------------------------------------------------------------------
-kill "$BOOTSTRAP_PID" 2>/dev/null || true
-wait "$BOOTSTRAP_PID" 2>/dev/null || true
-BOOTSTRAP_PID=""
-unset CARGO_REGISTRIES_TATOLAB_INDEX
+rm -rf "$BOOTSTRAP_DIR"
+BOOTSTRAP_DIR=""
 
 # ---------------------------------------------------------------------------
 # 5. Assemble the /opt/streamlib app dir (binaries + package source). packages/


### PR DESCRIPTION
## What

Rework `docker/build-stage1.sh` step 1 so the in-container `cargo xtask
static-registry emit --cargo-closure` (and the CLI/runtime build that
precedes it) resolves the `tatolab/vulkanalia` fork via the **#1298
serverless cargo `[source]`-replacement mirror** instead of the deleted
`serve-static-fork` shape.

Refs #1276 (not `Closes` — see [Exit-criteria status](#exit-criteria-status)).

## Static audit — what was stale

The Docker rework (`4f7b1c0f`) predates #1294 (byte-stable vulkanalia fork)
and #1298 (serverless cargo `[source]` mirror). Its stage-1 **step 1** was
the last place in the repo still mirroring the shape #1298 **deleted**
(`.github/actions/serve-static-fork/action.yml`, −132 lines):

- a long-lived `python3 -m http.server` fork mount, plus
- `export CARGO_REGISTRIES_TATOLAB_INDEX="sparse+http://127.0.0.1:8798/cargo/"`.

That env override is exactly what #1298's `cargo-fork-mirror` action header
calls out as **load-bearing to avoid**: an env index override *shadows* a
`[source]` replacement and rewrites the fork's source id in `Cargo.lock`
(it wins over `replace-with`), and it leaks into the closure emit's
internal `cargo package` fork resolution.

The rest of the docker surface was already correct: the **runtime** cargo
config (step 6) and the api-server preflight (step 7) already use the
#1298 *served* `[source]` shape (`sparse+http://127.0.0.1:8799/cargo/`,
no env override), and the gitea-removal half of #1276 was already fully
done (repo-wide `git grep -ilE 'gitea|localhost:3300|GITEA_'` outside
docs/md returns zero; `docker/gitea/` deleted; no dead links to the
removed `gitea-registry-distribution.md`).

## The fix

Step 1 now mirrors `.github/actions/cargo-fork-mirror` + the
`check-pack-load.yml` sequence, **reusing the #1294/#1298 scripts verbatim**
(no parallel fork-emit):

1. `scripts/registry/emit-static-fork.sh` — emits the fork; it runs its own
   ~2s throwaway packaging server internally and `normalize_fork_crate.py`
   rewrites the baked port URL to the canonical index so checksums match the
   committed `Cargo.lock`.
2. `scripts/registry/emit-cargo-local-registry.sh` — reshapes the sparse
   tree into a serverless cargo `local-registry`.
3. A `[source]` replacement written to `$CARGO_HOME/config.toml`
   (`replace-with = "tatolab-local-registry"` → `local-registry = <dir>`),
   **no `CARGO_REGISTRIES_TATOLAB_INDEX`**. Overwritten by the unchanged
   runtime served config in step 6 before the image ships.

Scope is confined to `docker/build-stage1.sh` (83+/47−, mostly the step-1
rewrite + comment updates). shellcheck-clean. The lock-restore that
`check-pack-load.yml` runs post-emit is intentionally omitted: `/src`
(where the emit dirties `Cargo.lock`) is builder-only and discarded, and
nothing downstream in stage 1 resolves in `/src` (the preflight `cargo
fetch` runs in an isolated `/tmp/apisrv-diag` copy).

## Build result — GREEN

Full `docker build` completed rc=0 (`streamlib:verify-1276`, 8.66 GB). The
fork-wiring fix is validated **end-to-end at both build time and runtime**:

- Stage-1 build resolved the fork serverless: `Compiling vulkanalia v0.35.0
  (registry tatolab)` — via the local-registry `[source]` replacement, no
  env override.
- **EC1** — the emitted `/opt/streamlib/registry` ships all 5 ecosystems
  (`cargo`, `pypi`, `npm`, `slpkg`, `catalog`) + the release manifest
  `slpkg/streamlib-release/0.6.0/manifest.json`. Shipped runtime cargo
  config is the clean served `[source]` shape (no gitea, no env override,
  no dangling local-registry path); fork + closure crates
  (`streamlib-plugin-sdk`, `vulkanalia*`) present in the sparse tree.
- **EC3 (resolution half)** — the build-time preflight resolved
  api-server's full dependency graph from the image-local tree.
- **EC3 (runtime half, in action)** — booting the container (`--gpus all`)
  enumerates the GPU (RTX 3090), serves the registry mount, and the runtime
  resolves + **compiles the entire SDK closure + fork from the image-local
  tree** (`Compiling streamlib-ipc-types … (registry tatolab)`,
  `streamlib-macros …`, `vulkanalia …`, `streamlib-engine …`) before
  hitting the separate blocker below.

## #1284 evidence — `.slpkg` stage passes

The full emit gets past **and passes** the `.slpkg` stage:

```
static-registry .slpkg emit complete emitted=20 skipped=2
  skip: /src/packages/test-fixtures            (path patch / cargo path dep)
  skip: /src/packages/test-fixtures-abi-mismatch (path patch)
static registry emitted out=/opt/streamlib/registry release=0.6.0
```

The 2 skips are exactly the test-only fixtures — the #1284/#1285/#1289
skip-non-publishable behavior working as designed. This proves both of
#1284's exit criteria in the docker context (the full emit skips
non-publishable + completes, and the docker build passes the `.slpkg`
stage). The escalate blocker below is **downstream** of the `.slpkg` stage
(in the api-server build), so it doesn't touch #1284's scope — #1284 can be
closed once this fork-wiring fix is on `main` (the `.slpkg`-stage-pass
evidence is reproducible only with this fix).

## Exit-criteria status

| # | Criterion | Status |
|---|---|---|
| EC1 | Image builds; emits/serves a static tree (no in-container Gitea) | ✅ proven (green build, 5-ecosystem tree + release manifest) |
| EC2 | Zero gitea / localhost:3300 / GITEA_ residue | ✅ already done (repo-wide grep = 0) |
| EC3 | Container can `add_module` a registry package from the image-local tree | ⚠️ resolution proven (preflight + runtime resolve/compile the closure+fork); **runtime add_module blocked by #1307** |

**EC3 runtime blocker → #1307** (not introduced by this diff; `git diff
HEAD~1` = only `docker/build-stage1.sh`). The container's api-server build
fails in `streamlib-engine`'s `build.rs`:

```
error: streamlib_jtd_codegen build.rs helper failed: Failed to resolve streamlib.yaml dependency graph
Caused by: path dependency `@tatolab/escalate` at
  `.../streamlib-engine-0.6.0/../../packages/escalate` not found
```

`libs/streamlib-engine/streamlib.yaml` resolves its `@tatolab/escalate`
schema dep via a dev `patch: { path: ../../packages/escalate }` (comment:
"Dev-time path override; streamlib pack rejects this") that only exists in
the monorepo — but it ships in the published `streamlib-engine` cargo crate,
so its build.rs fails when the crate is consumed standalone from the
registry, even though escalate **does** ship as a `.slpkg` (`1.0.0`) in the
emitted tree. This is the two-loops distribution-model leak (schema deps
must resolve by version from the `.slpkg` store, not a dev path-patch),
tracked as #1307.

## Maintainer smoke (once #1307 lands)

```bash
sg docker -c "cd <repo> && docker build -t streamlib:latest ."
sg docker -c "docker run --rm --gpus all -e NVIDIA_DRIVER_CAPABILITIES=all -p 9000:9000 streamlib:latest"
# in another shell:
curl -sf http://127.0.0.1:9000/health   # expect 200 once api-server builds+loads from the image-local tree
```

## Tests / validation

Docker builds are not CI-gated (local validation per #1276). Validated by
the full green `docker build` + a container boot inspecting the shipped
tree, cargo config, and the runtime's fork/closure resolution (above). No
container smoke script added — the runtime `/health` boot is the canonical
smoke and is gated on #1307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB
