### PR TITLE
feat(cli): registry serve/use verbs + npm localhost auto-serve + orchestrator UV_INDEX derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5047,6 +5047,7 @@ name = "streamlib-build-orchestrator"
 version = "0.6.0"
 dependencies = [
  "anyhow",
+ "libc",
  "serde_json",
  "serial_test",
  "streamlib-cargo-build",
@@ -5056,6 +5057,7 @@ dependencies = [
  "streamlib-pack",
  "streamlib-plugin-abi",
  "tempfile",
+ "thiserror 2.0.18",
  "toml_edit 0.22.27",
  "tracing",
  "ureq",

--- a/libs/streamlib-build-orchestrator/Cargo.toml
+++ b/libs/streamlib-build-orchestrator/Cargo.toml
@@ -13,9 +13,13 @@ repository.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 tracing = { workspace = true }
+thiserror = { workspace = true }
 serde_json = { workspace = true }
 toml_edit = { workspace = true }
 ureq = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
 streamlib-engine = { path = "../streamlib-engine", version = "0.6.0", registry = "tatolab" }
 streamlib-cargo-build = { path = "../streamlib-cargo-build", version = "0.6.0", registry = "tatolab" }
 streamlib-pack = { path = "../streamlib-pack", version = "0.6.0", registry = "tatolab" }

--- a/libs/streamlib-build-orchestrator/Cargo.toml
+++ b/libs/streamlib-build-orchestrator/Cargo.toml
@@ -17,15 +17,18 @@ thiserror = { workspace = true }
 serde_json = { workspace = true }
 toml_edit = { workspace = true }
 ureq = { workspace = true }
-
-[target.'cfg(unix)'.dependencies]
-libc = { workspace = true }
 streamlib-engine = { path = "../streamlib-engine", version = "0.6.0", registry = "tatolab" }
 streamlib-cargo-build = { path = "../streamlib-cargo-build", version = "0.6.0", registry = "tatolab" }
 streamlib-pack = { path = "../streamlib-pack", version = "0.6.0", registry = "tatolab" }
 streamlib-idents = { path = "../streamlib-idents", version = "0.6.0", registry = "tatolab" }
 streamlib-plugin-abi = { path = "../streamlib-plugin-abi", version = "0.6.0", registry = "tatolab" }
 streamlib-jtd-codegen = { path = "../streamlib-jtd-codegen", version = "0.6.0", registry = "tatolab" }
+
+# libc is unix-only (PR_SET_PDEATHSIG in the `registry serve` helper). Keep this
+# target table LAST so its header scopes only `libc` — the streamlib path deps
+# above must stay in the platform-agnostic [dependencies].
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/libs/streamlib-build-orchestrator/src/lib.rs
+++ b/libs/streamlib-build-orchestrator/src/lib.rs
@@ -39,6 +39,7 @@
 mod deno_codegen;
 mod native_host;
 mod python_venv;
+pub mod registry;
 mod release_check;
 
 #[cfg(test)]

--- a/libs/streamlib-build-orchestrator/src/python_venv.rs
+++ b/libs/streamlib-build-orchestrator/src/python_venv.rs
@@ -291,16 +291,31 @@ fn find_first_wheel(wheels_dir: &Path, package_label: &str) -> Result<Option<Pat
 /// raw process output (caller inspects `status`); the `Err` arm covers only
 /// the failure to spawn `uv` at all.
 fn run_uv(args: &[&str], uv_cache_dir: &Path) -> Result<std::process::Output, String> {
-    Command::new("uv")
-        .args(args)
-        .env("UV_CACHE_DIR", uv_cache_dir.to_str().unwrap_or(""))
-        .output()
-        .map_err(|e| {
-            format!(
-                "failed to run uv (is uv installed?): {e}. Install with: \
-                 curl -LsSf https://astral.sh/uv/install.sh | sh"
-            )
-        })
+    let mut cmd = Command::new("uv");
+    cmd.args(args)
+        .env("UV_CACHE_DIR", uv_cache_dir.to_str().unwrap_or(""));
+    // Resolve `streamlib` (and any other registry deps) from the SAME single
+    // registry location cargo / `.slpkg` use, deriving `UV_INDEX` from it
+    // rather than depending on an ambiently-set one. A link-mode build resolves
+    // `streamlib` from its injected `[tool.uv.sources]` path override, which
+    // wins over the index regardless of what is set here.
+    if let Some(index) = derive_uv_index() {
+        cmd.env("UV_INDEX", index);
+    }
+    cmd.output().map_err(|e| {
+        format!(
+            "failed to run uv (is uv installed?): {e}. Install with: \
+             curl -LsSf https://astral.sh/uv/install.sh | sh"
+        )
+    })
+}
+
+/// The `UV_INDEX` pypi simple-index URL derived from the single configured
+/// registry location (`STREAMLIB_REGISTRY_URL`), or `None` when no registry is
+/// configured — a link-mode / path-only build resolves `streamlib` from a
+/// `[tool.uv.sources]` override instead of an index.
+fn derive_uv_index() -> Option<String> {
+    streamlib_idents::RegistryConfig::from_env().map(|c| c.pypi_simple_index_url())
 }
 
 fn path_to_str(path: &Path, package_label: &str) -> Result<String, BuildError> {
@@ -411,6 +426,49 @@ packages = ["python"]
             ),
         )
         .unwrap();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn uv_index_derived_from_configured_registry_else_none() {
+        // The orchestrator derives `UV_INDEX` from the single configured
+        // registry location so the venv build no longer depends on an
+        // ambiently-set one. SAFETY: `#[serial]` — no other thread races these
+        // process-global env writes.
+        let prev = std::env::var("STREAMLIB_REGISTRY_URL").ok();
+
+        // A local `file://` tree derives its pypi simple-index sub-URL.
+        unsafe {
+            std::env::set_var("STREAMLIB_REGISTRY_URL", "file:///tmp/streamlib-tree");
+        }
+        assert_eq!(
+            derive_uv_index().as_deref(),
+            Some("file:///tmp/streamlib-tree/pypi/simple")
+        );
+
+        // An HTTP mount derives the same simple-index shape.
+        unsafe {
+            std::env::set_var("STREAMLIB_REGISTRY_URL", "http://127.0.0.1:8799");
+        }
+        assert_eq!(
+            derive_uv_index().as_deref(),
+            Some("http://127.0.0.1:8799/pypi/simple")
+        );
+
+        // Unset → no derived index (dev / link / path-only build). Mentally
+        // reverting the `from_env` gate to a hardcoded fallback would return
+        // Some here and reintroduce the ambient dependence this removes.
+        unsafe {
+            std::env::remove_var("STREAMLIB_REGISTRY_URL");
+        }
+        assert_eq!(derive_uv_index(), None);
+
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("STREAMLIB_REGISTRY_URL", v),
+                None => std::env::remove_var("STREAMLIB_REGISTRY_URL"),
+            }
+        }
     }
 
     #[test]

--- a/libs/streamlib-build-orchestrator/src/registry.rs
+++ b/libs/streamlib-build-orchestrator/src/registry.rs
@@ -1,0 +1,776 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Programmatic toolchain-config for pointing a consumer at a single static
+//! registry location — the library half of the `streamlib registry use` /
+//! `streamlib registry serve` CLI verbs.
+
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
+use std::time::Duration;
+
+use streamlib_idents::{RegistryConfig, DEFAULT_REGISTRY_URL};
+use thiserror::Error;
+
+/// The named cargo registry the streamlib SDK crate chain + vulkanalia fork
+/// resolve under (`registry = "tatolab"` in every published manifest).
+pub const TATOLAB_REGISTRY_NAME: &str = "tatolab";
+
+/// The replacement-source name the `[source]` stanza redirects `tatolab` to.
+/// Matches the CI `cargo-fork-mirror` action so a consumer's config and CI
+/// agree on the mirror source id.
+pub const TATOLAB_REPLACEMENT_SOURCE_NAME: &str = "tatolab-local-registry";
+
+/// Reshape-script basename inside a streamlib `scripts/registry/` dir — the
+/// single canonical sparse→local-registry reshape reused by `registry use`.
+const RESHAPE_SCRIPT_NAME: &str = "emit-cargo-local-registry.sh";
+
+/// Default localhost port for [`serve_registry`] when the caller pins none —
+/// matches `scripts/registry/serve-static-registry.sh` so a written `.npmrc`
+/// scope is stable across serve sessions.
+pub const DEFAULT_SERVE_PORT: u16 = 8799;
+
+/// Errors from [`use_registry`] and the cargo `[source]`-replacement emission.
+#[derive(Debug, Error)]
+pub enum RegistryUseError {
+    /// The named registry tree directory does not exist / is not a directory.
+    #[error("registry tree {path} is not a directory")]
+    TreeNotADirectory { path: PathBuf },
+    /// A local tree is missing the `cargo/` subtree the reshape needs.
+    #[error("no cargo/ subtree under registry tree {tree_root} (run `static-registry emit` first)")]
+    CargoSubtreeMissing { tree_root: PathBuf },
+    /// A local-tree reshape was requested but the reshape script could not be
+    /// located; the caller must supply the streamlib `scripts/registry/` dir.
+    #[error("cargo local-registry reshape script `{RESHAPE_SCRIPT_NAME}` not found (searched: {searched:?}); run from a streamlib checkout or pass a scripts dir")]
+    ReshapeScriptNotFound { searched: Vec<PathBuf> },
+    /// The reshape script ran but exited non-zero.
+    #[error("cargo local-registry reshape failed: {detail}")]
+    ReshapeFailed { detail: String },
+    /// Canonicalizing / resolving the tree directory failed.
+    #[error("resolve registry tree {path}: {detail}")]
+    TreeResolve { path: PathBuf, detail: String },
+    /// Reading the existing cargo config to merge into failed.
+    #[error("read {path}: {detail}")]
+    CargoConfigRead { path: PathBuf, detail: String },
+    /// The existing cargo config is not valid TOML.
+    #[error("parse {path}: {detail}")]
+    CargoConfigParse { path: PathBuf, detail: String },
+    /// A config key exists but is not a table, so the stanza can't be merged.
+    #[error("cargo config key `{key}` exists but is not a table")]
+    CargoConfigMalformed { key: String },
+    /// Writing the merged cargo config back failed.
+    #[error("write {path}: {detail}")]
+    CargoConfigWrite { path: PathBuf, detail: String },
+    /// Spawning the reshape script (`bash`) failed.
+    #[error("spawn reshape script: {detail}")]
+    Spawn { detail: String },
+}
+
+/// Errors from [`serve_registry`].
+#[derive(Debug, Error)]
+pub enum RegistryServeError {
+    /// The named registry tree directory does not exist / is not a directory.
+    #[error("registry tree {path} is not a directory")]
+    TreeNotADirectory { path: PathBuf },
+    /// Binding an ephemeral localhost port to serve on failed.
+    #[error("bind localhost serve port: {detail}")]
+    BindPort { detail: String },
+    /// Spawning `python3 -m http.server` failed.
+    #[error("spawn static server (is python3 installed?): {detail}")]
+    Spawn { detail: String },
+    /// The spawned server never began accepting connections.
+    #[error("static server did not come up on 127.0.0.1:{port}")]
+    ServerDidNotStart { port: u16 },
+    /// Writing the `.npmrc` scope line back failed.
+    #[error("write {path}: {detail}")]
+    NpmrcWrite { path: PathBuf, detail: String },
+}
+
+/// Where the `[source.tatolab-local-registry]` block points — the two
+/// serverless-vs-served cargo resolution shapes a consumer resolves through.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CargoReplacementSource {
+    /// A serverless cargo `local-registry` dir reshaped from a local `file://`
+    /// tree's sparse `cargo/` subtree. Resolves `--offline` with no server.
+    LocalRegistry(PathBuf),
+    /// A served `sparse+http(s)://…/cargo/` mount (the tree is already an HTTP
+    /// registry mount). No reshape.
+    SparseMirror(String),
+}
+
+/// Options for [`use_registry`].
+#[derive(Debug, Default)]
+pub struct UseRegistryOptions {
+    /// For a local `file://` tree, the dir the cargo `local-registry` mirror is
+    /// reshaped into. Default: `<consumer_root>/.streamlib/cargo-local-registry`.
+    pub cargo_local_registry_dir: Option<PathBuf>,
+    /// The `scripts/registry/` dir holding `emit-cargo-local-registry.sh`,
+    /// required to reshape a local tree's sparse cargo subtree. `None` errors
+    /// with [`RegistryUseError::ReshapeScriptNotFound`] when a reshape is needed.
+    pub reshape_scripts_dir: Option<PathBuf>,
+}
+
+/// What [`use_registry`] configured, for the CLI to present.
+#[derive(Debug)]
+pub struct UseRegistryReport {
+    /// The resolved single registry location every channel derives from.
+    pub registry: RegistryConfig,
+    /// Path the cargo `[source]`-replacement stanza was merged into.
+    pub cargo_config_path: PathBuf,
+    /// The cargo replacement source that was emitted.
+    pub cargo_replacement: CargoReplacementSource,
+    /// The `UV_INDEX` value pypi resolution uses (derived, `file://`/http).
+    pub pypi_index_url: String,
+    /// The `@tatolab:registry=` value npm resolution needs.
+    pub npm_registry_url: String,
+    /// True when the tree is a local `file://` folder, so npm needs
+    /// [`serve_registry`] before it is reachable (npm has no `file://` story).
+    pub npm_needs_serve: bool,
+}
+
+/// Point a consumer at a single registry location `tree_ref` (a local folder
+/// path, a `file://` URL, or an `http(s)://` mount), writing the cargo
+/// `[source]`-replacement into `<consumer_root>/.cargo/config.toml` and
+/// deriving the pypi / npm channels. A local folder is reshaped into a
+/// serverless cargo `local-registry` mirror (no running server); an HTTP mount
+/// is pointed at directly. Source replacement keeps the canonical `tatolab`
+/// source id in every `Cargo.lock`.
+#[tracing::instrument(skip(opts), fields(consumer_root = %consumer_root.display(), tree_ref = %tree_ref))]
+pub fn use_registry(
+    consumer_root: &Path,
+    tree_ref: &str,
+    opts: &UseRegistryOptions,
+) -> Result<UseRegistryReport, RegistryUseError> {
+    let registry = resolve_registry_ref(tree_ref)?;
+
+    let cargo_replacement = if let Some(tree_root) = registry.local_tree_root() {
+        // Local `file://` tree → serverless local-registry reshape.
+        if !tree_root.join("cargo").is_dir() {
+            return Err(RegistryUseError::CargoSubtreeMissing { tree_root });
+        }
+        let lr_dir = opts
+            .cargo_local_registry_dir
+            .clone()
+            .unwrap_or_else(|| consumer_root.join(".streamlib").join("cargo-local-registry"));
+        let scripts_dir = match &opts.reshape_scripts_dir {
+            Some(dir) => dir.clone(),
+            None => locate_reshape_scripts_dir()?,
+        };
+        reshape_sparse_cargo_to_local_registry(&tree_root, &lr_dir, &scripts_dir)?;
+        // The stanza records the absolute mirror dir so cargo resolves it from
+        // any working directory under the consumer root.
+        let abs_lr = lr_dir
+            .canonicalize()
+            .unwrap_or(lr_dir);
+        CargoReplacementSource::LocalRegistry(abs_lr)
+    } else {
+        // Served `http(s)://` mount → point the replacement at its sparse index.
+        CargoReplacementSource::SparseMirror(registry.cargo_sparse_index_url())
+    };
+
+    let cargo_config_path = write_cargo_source_replacement(consumer_root, &cargo_replacement)?;
+
+    Ok(UseRegistryReport {
+        pypi_index_url: registry.pypi_simple_index_url(),
+        npm_registry_url: registry.npm_registry_url(),
+        npm_needs_serve: registry.local_tree_root().is_some(),
+        registry,
+        cargo_config_path,
+        cargo_replacement,
+    })
+}
+
+/// Resolve a `tree_ref` (local dir path | `file://` | `http(s)://`) into a
+/// [`RegistryConfig`]. A bare path is canonicalized to a `file://` tree.
+fn resolve_registry_ref(tree_ref: &str) -> Result<RegistryConfig, RegistryUseError> {
+    if tree_ref.starts_with("http://")
+        || tree_ref.starts_with("https://")
+        || tree_ref.starts_with("file://")
+    {
+        return Ok(RegistryConfig {
+            base_url: tree_ref.trim_end_matches('/').to_string(),
+        });
+    }
+    let dir = Path::new(tree_ref);
+    if !dir.is_dir() {
+        return Err(RegistryUseError::TreeNotADirectory {
+            path: dir.to_path_buf(),
+        });
+    }
+    RegistryConfig::for_local_tree(dir).map_err(|e| RegistryUseError::TreeResolve {
+        path: dir.to_path_buf(),
+        detail: e.to_string(),
+    })
+}
+
+/// Render the cargo `[source]`-replacement stanza that redirects the canonical
+/// `tatolab` registry at `replacement`, keeping the canonical source id in
+/// every `Cargo.lock`. Pure — the string the CLI prints; [`use_registry`]
+/// merges the same three tables into a consumer's `.cargo/config.toml`.
+pub fn emit_cargo_source_replacement_stanza(replacement: &CargoReplacementSource) -> String {
+    let canonical = format!("sparse+{DEFAULT_REGISTRY_URL}/cargo/");
+    let replacement_body = match replacement {
+        CargoReplacementSource::LocalRegistry(dir) => {
+            format!("local-registry = \"{}\"", dir.display())
+        }
+        CargoReplacementSource::SparseMirror(index) => format!("registry = \"{index}\""),
+    };
+    format!(
+        "[registries.{name}]\n\
+         index = \"{canonical}\"\n\
+         \n\
+         [source.{name}]\n\
+         registry = \"{canonical}\"\n\
+         replace-with = \"{repl}\"\n\
+         \n\
+         [source.{repl}]\n\
+         {replacement_body}\n",
+        name = TATOLAB_REGISTRY_NAME,
+        repl = TATOLAB_REPLACEMENT_SOURCE_NAME,
+    )
+}
+
+/// Merge the cargo `[source]`-replacement (and the `[registries.tatolab]`
+/// declaration it replaces) into `<consumer_root>/.cargo/config.toml`,
+/// preserving any other config the consumer already has. Idempotent — a
+/// repeated `use` overwrites only the three `tatolab` tables. Returns the
+/// config path written.
+fn write_cargo_source_replacement(
+    consumer_root: &Path,
+    replacement: &CargoReplacementSource,
+) -> Result<PathBuf, RegistryUseError> {
+    let cargo_dir = consumer_root.join(".cargo");
+    let config_path = cargo_dir.join("config.toml");
+
+    let existing = match std::fs::read_to_string(&config_path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => {
+            return Err(RegistryUseError::CargoConfigRead {
+                path: config_path,
+                detail: e.to_string(),
+            })
+        }
+    };
+    let mut doc: toml_edit::DocumentMut =
+        existing
+            .parse()
+            .map_err(|e: toml_edit::TomlError| RegistryUseError::CargoConfigParse {
+                path: config_path.clone(),
+                detail: e.to_string(),
+            })?;
+
+    let canonical = format!("sparse+{DEFAULT_REGISTRY_URL}/cargo/");
+
+    // [registries.tatolab] index = <canonical>
+    {
+        let registries = ensure_implicit_table(doc.as_table_mut(), "registries")?;
+        let tatolab = ensure_table(registries, TATOLAB_REGISTRY_NAME)?;
+        tatolab.insert("index", toml_edit::value(canonical.clone()));
+    }
+    // [source.tatolab] registry = <canonical>, replace-with = <repl>
+    // [source.<repl>] local-registry|registry = ...
+    {
+        let source = ensure_implicit_table(doc.as_table_mut(), "source")?;
+        {
+            let tatolab_src = ensure_table(source, TATOLAB_REGISTRY_NAME)?;
+            tatolab_src.insert("registry", toml_edit::value(canonical.clone()));
+            tatolab_src.insert(
+                "replace-with",
+                toml_edit::value(TATOLAB_REPLACEMENT_SOURCE_NAME),
+            );
+        }
+        {
+            let repl_src = ensure_table(source, TATOLAB_REPLACEMENT_SOURCE_NAME)?;
+            match replacement {
+                CargoReplacementSource::LocalRegistry(dir) => {
+                    repl_src.remove("registry");
+                    repl_src.insert(
+                        "local-registry",
+                        toml_edit::value(dir.display().to_string()),
+                    );
+                }
+                CargoReplacementSource::SparseMirror(index) => {
+                    repl_src.remove("local-registry");
+                    repl_src.insert("registry", toml_edit::value(index.clone()));
+                }
+            }
+        }
+    }
+
+    std::fs::create_dir_all(&cargo_dir).map_err(|e| RegistryUseError::CargoConfigWrite {
+        path: config_path.clone(),
+        detail: e.to_string(),
+    })?;
+    std::fs::write(&config_path, doc.to_string()).map_err(|e| {
+        RegistryUseError::CargoConfigWrite {
+            path: config_path.clone(),
+            detail: e.to_string(),
+        }
+    })?;
+    Ok(config_path)
+}
+
+/// Get-or-create `key` as a table; error (never panic) when a non-table value
+/// already occupies the key.
+fn ensure_table<'a>(
+    table: &'a mut toml_edit::Table,
+    key: &str,
+) -> Result<&'a mut toml_edit::Table, RegistryUseError> {
+    if !table.contains_key(key) {
+        table.insert(key, toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+    table[key]
+        .as_table_mut()
+        .ok_or_else(|| RegistryUseError::CargoConfigMalformed { key: key.to_string() })
+}
+
+/// [`ensure_table`] plus mark the parent implicit so only the child header
+/// (`[registries.tatolab]`, not a bare `[registries]`) is rendered.
+fn ensure_implicit_table<'a>(
+    table: &'a mut toml_edit::Table,
+    key: &str,
+) -> Result<&'a mut toml_edit::Table, RegistryUseError> {
+    let t = ensure_table(table, key)?;
+    t.set_implicit(true);
+    Ok(t)
+}
+
+/// Reshape a local registry tree's sparse `cargo/` subtree into a serverless
+/// cargo `local-registry` mirror at `lr_out`, via the single canonical reshape
+/// script in `scripts_dir`. Deterministic file copies — no server, no cargo.
+pub fn reshape_sparse_cargo_to_local_registry(
+    tree_root: &Path,
+    lr_out: &Path,
+    scripts_dir: &Path,
+) -> Result<(), RegistryUseError> {
+    let script = scripts_dir.join(RESHAPE_SCRIPT_NAME);
+    if !script.is_file() {
+        return Err(RegistryUseError::ReshapeScriptNotFound {
+            searched: vec![script],
+        });
+    }
+    if let Some(parent) = lr_out.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| RegistryUseError::ReshapeFailed {
+            detail: format!("create mirror parent {}: {e}", parent.display()),
+        })?;
+    }
+    let output = Command::new("bash")
+        .arg(&script)
+        .arg(tree_root)
+        .arg(lr_out)
+        .output()
+        .map_err(|e| RegistryUseError::Spawn {
+            detail: e.to_string(),
+        })?;
+    if !output.status.success() {
+        return Err(RegistryUseError::ReshapeFailed {
+            detail: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Walk up from the current working directory and the running executable
+/// looking for a streamlib `scripts/registry/` dir holding the reshape script.
+fn locate_reshape_scripts_dir() -> Result<PathBuf, RegistryUseError> {
+    let mut searched = Vec::new();
+    let mut roots = Vec::new();
+    if let Ok(cwd) = std::env::current_dir() {
+        roots.push(cwd);
+    }
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(parent) = exe.parent()
+    {
+        roots.push(parent.to_path_buf());
+    }
+    for root in roots {
+        for ancestor in root.ancestors() {
+            let candidate = ancestor.join("scripts").join("registry");
+            if candidate.join(RESHAPE_SCRIPT_NAME).is_file() {
+                return Ok(candidate);
+            }
+            searched.push(candidate);
+        }
+    }
+    Err(RegistryUseError::ReshapeScriptNotFound { searched })
+}
+
+/// Options for [`serve_registry`].
+#[derive(Debug, Default)]
+pub struct ServeRegistryOptions {
+    /// Localhost port to serve on. `None` → [`DEFAULT_SERVE_PORT`].
+    pub port: Option<u16>,
+}
+
+/// A running localhost static server for a registry tree — kills the child on
+/// drop. Only npm needs this seam (it has no `file://` story); cargo resolves
+/// serverless via the `local-registry` mirror and pypi/`.slpkg` read `file://`.
+#[derive(Debug)]
+pub struct RegistryServeHandle {
+    child: Child,
+    /// The port the tree is served on.
+    pub port: u16,
+    /// The `.npmrc` scope line consumers point npm at.
+    pub npm_scope_line: String,
+    /// The localhost base URL the tree is served at.
+    pub base_url: String,
+}
+
+impl RegistryServeHandle {
+    /// Block until the server child exits (e.g. on Ctrl-C, which the child
+    /// receives with the foreground process group).
+    pub fn wait(&mut self) -> std::io::Result<std::process::ExitStatus> {
+        self.child.wait()
+    }
+}
+
+impl Drop for RegistryServeHandle {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Serve a local registry `tree_dir` over a dumb localhost static HTTP mount so
+/// npm can resolve `@tatolab` (the one ecosystem with no `file://` registry
+/// story). Returns a handle carrying the `.npmrc` scope; the caller writes /
+/// prints it and holds the handle for the serve session's lifetime.
+#[tracing::instrument(skip(opts), fields(tree_dir = %tree_dir.display()))]
+pub fn serve_registry(
+    tree_dir: &Path,
+    opts: &ServeRegistryOptions,
+) -> Result<RegistryServeHandle, RegistryServeError> {
+    if !tree_dir.is_dir() {
+        return Err(RegistryServeError::TreeNotADirectory {
+            path: tree_dir.to_path_buf(),
+        });
+    }
+    let port = match opts.port {
+        Some(p) => p,
+        None => DEFAULT_SERVE_PORT,
+    };
+    // Fail early with a typed error if the port is already taken, rather than
+    // letting python fail opaquely.
+    match TcpListener::bind(("127.0.0.1", port)) {
+        Ok(listener) => drop(listener),
+        Err(e) => {
+            return Err(RegistryServeError::BindPort {
+                detail: format!("127.0.0.1:{port}: {e}"),
+            })
+        }
+    }
+
+    let mut cmd = Command::new("python3");
+    cmd.args([
+        "-m",
+        "http.server",
+        &port.to_string(),
+        "--bind",
+        "127.0.0.1",
+        "--directory",
+    ])
+    .arg(tree_dir)
+    .stdout(std::process::Stdio::null())
+    .stderr(std::process::Stdio::null());
+    // Kill the server child when the parent (CLI / embedding host) dies, so a
+    // killed parent never orphans the static server — the Drop impl only covers
+    // a normal handle drop. `PR_SET_PDEATHSIG` is delivered on parent death and
+    // `prctl` is async-signal-safe, so it's legal from `pre_exec`; it survives
+    // the child's (non-setuid) `exec` of python.
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            cmd.pre_exec(|| {
+                if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM as libc::c_ulong) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+    let child = cmd.spawn().map_err(|e| RegistryServeError::Spawn {
+        detail: e.to_string(),
+    })?;
+
+    let base_url = format!("http://127.0.0.1:{port}");
+    let npm_scope_line = format!("@{TATOLAB_REGISTRY_NAME}:registry={base_url}/npm/");
+    let mut handle = RegistryServeHandle {
+        child,
+        port,
+        npm_scope_line,
+        base_url,
+    };
+
+    // Wait for the server to accept connections (its Drop kills the child if we
+    // give up).
+    for _ in 0..50 {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return Ok(handle);
+        }
+        // If the child already died (e.g. python3 missing), surface it.
+        if let Ok(Some(_)) = handle.child.try_wait() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    Err(RegistryServeError::ServerDidNotStart { port })
+}
+
+/// Merge the `@tatolab:registry=<npm-url>` scope line into `<consumer_root>/
+/// .npmrc`, replacing any prior `@tatolab:registry=` line and preserving the
+/// rest. Returns the `.npmrc` path written. This is what lets `registry serve`
+/// leave a consumer's npm config set without hand-editing.
+pub fn write_npmrc_scope(
+    consumer_root: &Path,
+    npm_scope_line: &str,
+) -> Result<PathBuf, RegistryServeError> {
+    let npmrc = consumer_root.join(".npmrc");
+    let existing = match std::fs::read_to_string(&npmrc) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => {
+            return Err(RegistryServeError::NpmrcWrite {
+                path: npmrc,
+                detail: e.to_string(),
+            })
+        }
+    };
+    let prefix = format!("@{TATOLAB_REGISTRY_NAME}:registry=");
+    let mut lines: Vec<String> = existing
+        .lines()
+        .filter(|l| !l.trim_start().starts_with(&prefix))
+        .map(|l| l.to_string())
+        .collect();
+    lines.push(npm_scope_line.to_string());
+    let mut body = lines.join("\n");
+    body.push('\n');
+    std::fs::write(&npmrc, body).map_err(|e| RegistryServeError::NpmrcWrite {
+        path: npmrc.clone(),
+        detail: e.to_string(),
+    })?;
+    Ok(npmrc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stanza_local_registry_emits_source_replacement_block() {
+        let repl = CargoReplacementSource::LocalRegistry(PathBuf::from("/home/u/.streamlib/clr"));
+        let stanza = emit_cargo_source_replacement_stanza(&repl);
+        // Canonical registry declared + replaced; the mirror is the local dir.
+        assert!(stanza.contains("[registries.tatolab]"), "{stanza}");
+        assert!(
+            stanza.contains("index = \"sparse+https://registry.tatolab.com/cargo/\""),
+            "{stanza}"
+        );
+        assert!(stanza.contains("[source.tatolab]"), "{stanza}");
+        assert!(
+            stanza.contains("registry = \"sparse+https://registry.tatolab.com/cargo/\""),
+            "{stanza}"
+        );
+        assert!(stanza.contains("replace-with = \"tatolab-local-registry\""), "{stanza}");
+        assert!(stanza.contains("[source.tatolab-local-registry]"), "{stanza}");
+        assert!(stanza.contains("local-registry = \"/home/u/.streamlib/clr\""), "{stanza}");
+        // Serverless mirror never emits a sparse+http replacement (the #1245 poison).
+        assert!(!stanza.contains("sparse+http://"), "{stanza}");
+    }
+
+    #[test]
+    fn stanza_sparse_mirror_points_replacement_at_served_index() {
+        let repl = CargoReplacementSource::SparseMirror(
+            "sparse+http://127.0.0.1:8799/cargo/".to_string(),
+        );
+        let stanza = emit_cargo_source_replacement_stanza(&repl);
+        // Canonical id preserved on the replaced source, replacement is the mount.
+        assert!(
+            stanza.contains("[source.tatolab]\nregistry = \"sparse+https://registry.tatolab.com/cargo/\""),
+            "{stanza}"
+        );
+        assert!(
+            stanza.contains("[source.tatolab-local-registry]\nregistry = \"sparse+http://127.0.0.1:8799/cargo/\""),
+            "{stanza}"
+        );
+        // A served mirror must NOT be written as a local-registry.
+        assert!(!stanza.contains("local-registry ="), "{stanza}");
+    }
+
+    #[test]
+    fn write_cargo_source_replacement_creates_and_merges_config() {
+        let consumer = tempfile::tempdir().unwrap();
+        let repl = CargoReplacementSource::LocalRegistry(PathBuf::from("/mnt/mirror"));
+        let path = write_cargo_source_replacement(consumer.path(), &repl).unwrap();
+        assert_eq!(path, consumer.path().join(".cargo").join("config.toml"));
+
+        let body = std::fs::read_to_string(&path).unwrap();
+        // Reverting the local-registry insert would drop this line.
+        assert!(body.contains("local-registry = \"/mnt/mirror\""), "{body}");
+        assert!(body.contains("replace-with = \"tatolab-local-registry\""), "{body}");
+
+        // Parses back as valid TOML with the expected structure.
+        let doc: toml_edit::DocumentMut = body.parse().unwrap();
+        assert_eq!(
+            doc["registries"]["tatolab"]["index"].as_str().unwrap(),
+            "sparse+https://registry.tatolab.com/cargo/"
+        );
+        assert_eq!(
+            doc["source"]["tatolab"]["replace-with"].as_str().unwrap(),
+            "tatolab-local-registry"
+        );
+        assert_eq!(
+            doc["source"]["tatolab-local-registry"]["local-registry"]
+                .as_str()
+                .unwrap(),
+            "/mnt/mirror"
+        );
+    }
+
+    #[test]
+    fn write_cargo_source_replacement_preserves_unrelated_config() {
+        let consumer = tempfile::tempdir().unwrap();
+        let cargo_dir = consumer.path().join(".cargo");
+        std::fs::create_dir_all(&cargo_dir).unwrap();
+        std::fs::write(
+            cargo_dir.join("config.toml"),
+            "[build]\njobs = 4\n\n[net]\nretry = 3\n",
+        )
+        .unwrap();
+
+        let repl = CargoReplacementSource::LocalRegistry(PathBuf::from("/mnt/mirror"));
+        write_cargo_source_replacement(consumer.path(), &repl).unwrap();
+
+        let body = std::fs::read_to_string(cargo_dir.join("config.toml")).unwrap();
+        let doc: toml_edit::DocumentMut = body.parse().unwrap();
+        // Pre-existing unrelated config survives the merge.
+        assert_eq!(doc["build"]["jobs"].as_integer().unwrap(), 4);
+        assert_eq!(doc["net"]["retry"].as_integer().unwrap(), 3);
+        // And the tatolab replacement landed.
+        assert_eq!(
+            doc["source"]["tatolab-local-registry"]["local-registry"]
+                .as_str()
+                .unwrap(),
+            "/mnt/mirror"
+        );
+    }
+
+    #[test]
+    fn write_cargo_source_replacement_is_idempotent() {
+        let consumer = tempfile::tempdir().unwrap();
+        let repl = CargoReplacementSource::LocalRegistry(PathBuf::from("/mnt/mirror"));
+        write_cargo_source_replacement(consumer.path(), &repl).unwrap();
+        write_cargo_source_replacement(consumer.path(), &repl).unwrap();
+        let body =
+            std::fs::read_to_string(consumer.path().join(".cargo").join("config.toml")).unwrap();
+        // Exactly one replacement source table — a repeated `use` overwrites,
+        // never duplicates.
+        assert_eq!(
+            body.matches("[source.tatolab-local-registry]").count(),
+            1,
+            "{body}"
+        );
+    }
+
+    #[test]
+    fn switching_from_sparse_mirror_to_local_registry_drops_stale_key() {
+        let consumer = tempfile::tempdir().unwrap();
+        // First point at a served mirror…
+        write_cargo_source_replacement(
+            consumer.path(),
+            &CargoReplacementSource::SparseMirror("sparse+http://127.0.0.1:9/cargo/".to_string()),
+        )
+        .unwrap();
+        // …then re-point at a serverless local-registry.
+        write_cargo_source_replacement(
+            consumer.path(),
+            &CargoReplacementSource::LocalRegistry(PathBuf::from("/mnt/mirror")),
+        )
+        .unwrap();
+        let body =
+            std::fs::read_to_string(consumer.path().join(".cargo").join("config.toml")).unwrap();
+        let doc: toml_edit::DocumentMut = body.parse().unwrap();
+        let repl = &doc["source"]["tatolab-local-registry"];
+        // The stale `registry = sparse+...` must be gone; only local-registry remains.
+        assert!(repl.get("registry").is_none(), "{body}");
+        assert!(repl.get("local-registry").is_some(), "{body}");
+    }
+
+    #[test]
+    fn non_table_registries_key_is_a_typed_error_not_a_panic() {
+        let consumer = tempfile::tempdir().unwrap();
+        let cargo_dir = consumer.path().join(".cargo");
+        std::fs::create_dir_all(&cargo_dir).unwrap();
+        std::fs::write(cargo_dir.join("config.toml"), "registries = 3\n").unwrap();
+        let err = write_cargo_source_replacement(
+            consumer.path(),
+            &CargoReplacementSource::LocalRegistry(PathBuf::from("/m")),
+        )
+        .expect_err("non-table registries must be a typed error");
+        assert!(matches!(err, RegistryUseError::CargoConfigMalformed { .. }));
+    }
+
+    #[test]
+    fn resolve_registry_ref_classifies_local_and_remote() {
+        // A `file://` and a plain dir path both resolve to a local tree.
+        let remote = resolve_registry_ref("https://registry.tatolab.com").unwrap();
+        assert!(remote.local_tree_root().is_none());
+        assert_eq!(remote.cargo_sparse_index_url(), "sparse+https://registry.tatolab.com/cargo/");
+
+        let tree = tempfile::tempdir().unwrap();
+        let local = resolve_registry_ref(tree.path().to_str().unwrap()).unwrap();
+        assert!(local.local_tree_root().is_some());
+        // Trailing slash trimmed on URL forms.
+        let file_url = resolve_registry_ref(&format!("file://{}/", tree.path().display())).unwrap();
+        assert!(!file_url.base_url.ends_with('/'));
+    }
+
+    #[test]
+    fn use_registry_missing_cargo_subtree_errors() {
+        // A local tree with no cargo/ subtree cannot be reshaped.
+        let consumer = tempfile::tempdir().unwrap();
+        let tree = tempfile::tempdir().unwrap();
+        let err = use_registry(
+            consumer.path(),
+            tree.path().to_str().unwrap(),
+            &UseRegistryOptions::default(),
+        )
+        .expect_err("no cargo/ subtree must error");
+        assert!(matches!(err, RegistryUseError::CargoSubtreeMissing { .. }));
+    }
+
+    #[test]
+    fn reshape_missing_script_is_a_typed_error() {
+        let tree = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tree.path().join("cargo")).unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let empty_scripts = tempfile::tempdir().unwrap();
+        let err = reshape_sparse_cargo_to_local_registry(
+            tree.path(),
+            &out.path().join("clr"),
+            empty_scripts.path(),
+        )
+        .expect_err("missing reshape script must be a typed error");
+        assert!(matches!(err, RegistryUseError::ReshapeScriptNotFound { .. }));
+    }
+
+    #[test]
+    fn write_npmrc_scope_replaces_prior_tatolab_line_only() {
+        let consumer = tempfile::tempdir().unwrap();
+        std::fs::write(
+            consumer.path().join(".npmrc"),
+            "@tatolab:registry=http://127.0.0.1:1111/npm/\nalways-auth=false\n",
+        )
+        .unwrap();
+        let line = "@tatolab:registry=http://127.0.0.1:8799/npm/";
+        write_npmrc_scope(consumer.path(), line).unwrap();
+        let body = std::fs::read_to_string(consumer.path().join(".npmrc")).unwrap();
+        // Old scope replaced, unrelated line kept, new scope present exactly once.
+        assert!(!body.contains(":1111/"), "{body}");
+        assert!(body.contains("always-auth=false"), "{body}");
+        assert_eq!(body.matches("@tatolab:registry=").count(), 1, "{body}");
+        assert!(body.contains(":8799/npm/"), "{body}");
+    }
+}

--- a/libs/streamlib-build-orchestrator/tests/registry_offline_resolve.rs
+++ b/libs/streamlib-build-orchestrator/tests/registry_offline_resolve.rs
@@ -1,0 +1,173 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Integration: a consumer resolves cargo **offline, with no server** via the
+//! stanza `streamlib registry use` emits. Reshapes a local sparse tree into a
+//! serverless cargo `local-registry`, writes the `[source]` replacement into
+//! the consumer's `.cargo/config.toml`, then `cargo generate-lockfile
+//! --offline` resolves a `registry = "tatolab"` dep with zero manual config —
+//! and the lockfile keeps the canonical source id (the #1245 no-localhost-poison
+//! invariant).
+//!
+//! Self-contained: builds a trivial synthetic crate into a hand-made sparse
+//! tree, so it needs neither the vulkanalia fork nor the network. Skips (does
+//! not fail) when `cargo` / `bash` / `tar` / `sha256sum` are unavailable so the
+//! suite stays green on a minimal box.
+
+use std::path::Path;
+use std::process::Command;
+
+use streamlib_build_orchestrator::registry::{self, CargoReplacementSource, UseRegistryOptions};
+
+fn tool_on_path(bin: &str, version_flag: &str) -> bool {
+    Command::new(bin)
+        .arg(version_flag)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// sha256 hex of a file, via `sha256sum` (avoids pulling a hashing crate into
+/// dev-deps just for this test).
+fn sha256_hex(path: &Path) -> String {
+    let out = Command::new("sha256sum").arg(path).output().unwrap();
+    assert!(out.status.success(), "sha256sum failed");
+    String::from_utf8(out.stdout)
+        .unwrap()
+        .split_whitespace()
+        .next()
+        .unwrap()
+        .to_string()
+}
+
+/// Build a minimal sparse cargo tree under `tree` holding one no-dep crate
+/// `probecrate` v0.1.0 — the exact on-disk shape the reshape script consumes:
+/// `cargo/config.json`, a sharded index line carrying `cksum`, and a nested
+/// `.crate` tarball.
+fn build_sparse_probecrate_tree(tree: &Path) {
+    let cargo = tree.join("cargo");
+    // 1. Stage the crate source and pack it as `<name>-<ver>.crate` (gzip tar
+    //    with the conventional `<name>-<ver>/` prefix).
+    let staging = tree.join("_staging");
+    let pkg = staging.join("probecrate-0.1.0");
+    std::fs::create_dir_all(pkg.join("src")).unwrap();
+    std::fs::write(
+        pkg.join("Cargo.toml"),
+        "[package]\nname = \"probecrate\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\
+         description = \"probe\"\nlicense = \"MIT\"\n",
+    )
+    .unwrap();
+    std::fs::write(pkg.join("src").join("lib.rs"), "// probe\n").unwrap();
+
+    let crate_dir = cargo.join("crates").join("probecrate");
+    std::fs::create_dir_all(&crate_dir).unwrap();
+    let crate_file = crate_dir.join("probecrate-0.1.0.crate");
+    let tar_ok = Command::new("tar")
+        .arg("czf")
+        .arg(&crate_file)
+        .arg("-C")
+        .arg(&staging)
+        .arg("probecrate-0.1.0")
+        .status()
+        .unwrap()
+        .success();
+    assert!(tar_ok, "tar pack failed");
+
+    // 2. Sparse index line (name len >= 4 → `<c1c2>/<c3c4>/<name>` shard).
+    let cksum = sha256_hex(&crate_file);
+    let shard = cargo.join("pr").join("ob");
+    std::fs::create_dir_all(&shard).unwrap();
+    std::fs::write(
+        shard.join("probecrate"),
+        format!(
+            "{{\"name\":\"probecrate\",\"vers\":\"0.1.0\",\"deps\":[],\"cksum\":\"{cksum}\",\"features\":{{}},\"yanked\":false}}\n"
+        ),
+    )
+    .unwrap();
+
+    // 3. config.json (present in a real tree; the reshape drops it).
+    std::fs::write(
+        cargo.join("config.json"),
+        "{\"dl\":\"http://example.invalid/cargo/crates/{crate}/{crate}-{version}.crate\",\"api\":\"http://example.invalid/cargo\"}\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn consumer_resolves_offline_via_emitted_stanza() {
+    for (bin, flag) in [("cargo", "--version"), ("bash", "--version"), ("tar", "--version"), ("sha256sum", "--version")] {
+        if !tool_on_path(bin, flag) {
+            eprintln!("skipping: `{bin}` not on PATH");
+            return;
+        }
+    }
+    let scripts_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts/registry");
+    if !scripts_dir.join("emit-cargo-local-registry.sh").is_file() {
+        eprintln!("skipping: reshape script not present at {}", scripts_dir.display());
+        return;
+    }
+
+    // A local `file://` registry tree with our synthetic crate.
+    let tree = tempfile::tempdir().unwrap();
+    build_sparse_probecrate_tree(tree.path());
+
+    // A consumer project that depends on it via the `tatolab` registry.
+    let consumer = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(consumer.path().join("src")).unwrap();
+    std::fs::write(
+        consumer.path().join("Cargo.toml"),
+        "[package]\nname = \"offline-consumer\"\nversion = \"0.0.0\"\nedition = \"2021\"\n\n\
+         [dependencies]\nprobecrate = { version = \"0.1\", registry = \"tatolab\" }\n\n\
+         [workspace]\n",
+    )
+    .unwrap();
+    std::fs::write(consumer.path().join("src").join("main.rs"), "fn main() {}\n").unwrap();
+
+    // `registry use <tree>` — reshape + write the [source] replacement. Zero
+    // manual config after this call.
+    let report = registry::use_registry(
+        consumer.path(),
+        tree.path().to_str().unwrap(),
+        &UseRegistryOptions {
+            cargo_local_registry_dir: Some(consumer.path().join(".streamlib").join("clr")),
+            reshape_scripts_dir: Some(scripts_dir.clone()),
+        },
+    )
+    .expect("use_registry must configure the consumer");
+    assert!(
+        matches!(report.cargo_replacement, CargoReplacementSource::LocalRegistry(_)),
+        "a local tree must yield a serverless local-registry replacement"
+    );
+
+    // Resolve OFFLINE — no server, no network. Reverting the [source]
+    // replacement (or emitting a sparse+http one) makes this fail: cargo would
+    // try the dead canonical / a non-running localhost mount.
+    let out = Command::new("cargo")
+        .arg("generate-lockfile")
+        .current_dir(consumer.path())
+        .env("CARGO_NET_OFFLINE", "true")
+        // Isolate from any ambient cargo/registry env the test runner set.
+        .env_remove("CARGO_REGISTRIES_TATOLAB_INDEX")
+        .output()
+        .expect("run cargo generate-lockfile");
+    assert!(
+        out.status.success(),
+        "offline resolve failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The lockfile resolved probecrate AND kept the CANONICAL source id (the
+    // localhost / local path never leaks into Cargo.lock).
+    let lock = std::fs::read_to_string(consumer.path().join("Cargo.lock")).unwrap();
+    assert!(lock.contains("name = \"probecrate\""), "probecrate not in lockfile:\n{lock}");
+    // A named registry records its canonical index URL directly (no
+    // `registry+` prefix, which is crates-io-only). The point is the same:
+    // source replacement kept the CANONICAL id, not the local mirror.
+    assert!(
+        lock.contains("source = \"sparse+https://registry.tatolab.com/cargo/\""),
+        "canonical source id not preserved in lockfile:\n{lock}"
+    );
+    assert!(!lock.contains("127.0.0.1"), "localhost leaked into lockfile:\n{lock}");
+    assert!(!lock.contains(".streamlib"), "local mirror path leaked into lockfile:\n{lock}");
+}

--- a/libs/streamlib-cli/src/commands/mod.rs
+++ b/libs/streamlib-cli/src/commands/mod.rs
@@ -7,5 +7,6 @@ pub mod install;
 pub mod link;
 pub mod logs;
 pub mod pkg;
+pub mod registry;
 pub mod schema;
 pub mod setup;

--- a/libs/streamlib-cli/src/commands/registry.rs
+++ b/libs/streamlib-cli/src/commands/registry.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib registry use` / `streamlib registry serve` — thin CLI wrappers
+//! over the programmatic [`streamlib::sdk::registry`] so the CLI and any
+//! embedding host share one toolchain-config flow.
+//!
+//! `use` points a consumer at a single registry location: it writes the cargo
+//! `[source]` replacement into `.cargo/config.toml` (serverless `local-registry`
+//! for a local folder, sparse mirror for an HTTP mount) and derives the pypi /
+//! npm channels. `serve` starts a localhost static mount so npm — the one
+//! ecosystem with no `file://` registry story — can resolve `@tatolab`, writing
+//! the `.npmrc` scope so it isn't hand-edited.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use streamlib::sdk::registry::{
+    self, CargoReplacementSource, ServeRegistryOptions, UseRegistryOptions,
+};
+
+/// `streamlib registry use <tree>` — configure this consumer's cargo/pypi/npm
+/// channels from one registry location (a local folder, `file://`, or
+/// `http(s)://` mount) with a single command.
+pub fn use_registry(tree_ref: &str) -> Result<()> {
+    let consumer_root = std::env::current_dir().context("resolve current working directory")?;
+    let report = registry::use_registry(&consumer_root, tree_ref, &UseRegistryOptions::default())?;
+
+    println!("Configured consumer against registry: {}", report.registry.base_url);
+    println!();
+    println!("cargo — wrote {}", report.cargo_config_path.display());
+    match &report.cargo_replacement {
+        CargoReplacementSource::LocalRegistry(dir) => {
+            println!("  serverless local-registry mirror: {}", dir.display());
+            println!("  resolves with `cargo build --offline` — no server needed.");
+        }
+        CargoReplacementSource::SparseMirror(index) => {
+            println!("  sparse mirror source: {index}");
+        }
+    }
+    println!();
+    println!("registry seed — export so `.slpkg` resolution + the build orchestrator's");
+    println!("UV_INDEX derivation + in-process schema codegen all key on this one tree:");
+    println!("  export STREAMLIB_REGISTRY_URL=\"{}\"", report.registry.base_url);
+    println!();
+    println!("pypi (uv) — the orchestrator derives this from the seed above; for a direct");
+    println!("`uv` invocation set it explicitly:");
+    println!("  export UV_INDEX=\"{}\"", report.pypi_index_url);
+    println!();
+    if report.npm_needs_serve {
+        println!("npm — a local `file://` tree has no npm registry story; serve it:");
+        println!("  streamlib registry serve {tree_ref}   # serves npm on localhost + writes .npmrc");
+    } else {
+        println!("npm — add to .npmrc:");
+        println!("  @tatolab:registry={}", report.npm_registry_url);
+    }
+    Ok(())
+}
+
+/// `streamlib registry serve <tree> [--port N]` — serve a local registry tree
+/// over a dumb localhost static mount for npm (`@tatolab`), write the `.npmrc`
+/// scope so it isn't hand-edited, and block until Ctrl-C.
+pub fn serve(tree_dir: &Path, port: Option<u16>) -> Result<()> {
+    let consumer_root = std::env::current_dir().context("resolve current working directory")?;
+    let mut handle = registry::serve_registry(tree_dir, &ServeRegistryOptions { port })?;
+    let npmrc = registry::write_npmrc_scope(&consumer_root, &handle.npm_scope_line)
+        .context("write .npmrc npm scope")?;
+
+    println!("Serving {} at {}", tree_dir.display(), handle.base_url);
+    println!("  npm scope written to {}:", npmrc.display());
+    println!("    {}", handle.npm_scope_line);
+    println!();
+    println!("cargo / pypi / .slpkg resolve serverless (local-registry + file://) —");
+    println!("this server is npm-only. Ctrl-C to stop.");
+
+    // Block for the serve session; Ctrl-C reaches the child via the foreground
+    // process group. The handle's Drop kills the child on any early return.
+    let _ = handle.wait();
+    Ok(())
+}

--- a/libs/streamlib-cli/src/main.rs
+++ b/libs/streamlib-cli/src/main.rs
@@ -129,6 +129,19 @@ enum Commands {
         action: PkgCommands,
     },
 
+    /// Point this consumer's toolchain at a single static registry location.
+    ///
+    /// `use <tree>` writes the cargo `[source]` replacement into
+    /// `.cargo/config.toml` (a serverless `local-registry` mirror for a local
+    /// folder, a sparse mirror for an HTTP mount) and derives the pypi / npm
+    /// channels — so a consumer resolves against a local tree with one command.
+    /// `serve <tree>` starts a localhost static mount for npm (the one ecosystem
+    /// with no `file://` registry story) and writes the `.npmrc` scope.
+    Registry {
+        #[command(subcommand)]
+        action: RegistryCommands,
+    },
+
     /// Point this consumer's entire streamlib surface at a local checkout.
     ///
     /// Run from a consumer root (app or package dir). Emits whole-tree
@@ -196,6 +209,27 @@ enum SchemasCommands {
     ValidateProcessor {
         /// Path to the processor YAML file
         path: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
+enum RegistryCommands {
+    /// Configure this consumer's cargo/pypi/npm channels from one registry
+    /// location (a local folder, `file://`, or `http(s)://` mount).
+    Use {
+        /// Registry tree: a local folder path, a `file://` URL, or an
+        /// `http(s)://` static mount.
+        tree: String,
+    },
+    /// Serve a local registry tree over a localhost static mount for npm and
+    /// write the `.npmrc` scope. Blocks until Ctrl-C.
+    Serve {
+        /// Local registry tree directory to serve.
+        tree: PathBuf,
+
+        /// Localhost port to serve on (default: 8799).
+        #[arg(long)]
+        port: Option<u16>,
     },
 }
 
@@ -298,6 +332,10 @@ async fn async_main(cli: Cli) -> Result<()> {
             PkgCommands::Clean => commands::pkg::clean()?,
             PkgCommands::Inspect { path } => commands::pkg::inspect(&path)?,
             PkgCommands::List => commands::pkg::list()?,
+        },
+        Some(Commands::Registry { action }) => match action {
+            RegistryCommands::Use { tree } => commands::registry::use_registry(&tree)?,
+            RegistryCommands::Serve { tree, port } => commands::registry::serve(&tree, port)?,
         },
         Some(Commands::Link {
             checkout,

--- a/libs/streamlib-idents/src/registry.rs
+++ b/libs/streamlib-idents/src/registry.rs
@@ -82,6 +82,54 @@ impl RegistryConfig {
             .filter(|s| !s.is_empty())?;
         Some(Self { base_url })
     }
+
+    /// Build a config for a local on-disk registry tree rooted at `dir` — the
+    /// `file://<canonical-abs-dir>` form a `file://` consumer / publisher uses.
+    /// `dir` is canonicalized so the derived channel URLs are absolute and
+    /// relocation-stable; a non-existent path is a
+    /// [`ResolverError::RegistryFetchFailed`].
+    pub fn for_local_tree(dir: &Path) -> ResolverResult<Self> {
+        let canonical = dir
+            .canonicalize()
+            .map_err(|e| ResolverError::RegistryFetchFailed {
+                name: "<local tree>".to_string(),
+                detail: format!("canonicalize registry tree dir {} : {e}", dir.display()),
+            })?;
+        Ok(Self {
+            base_url: format!("file://{}", canonical.display()),
+        })
+    }
+
+    /// The on-disk tree root when [`base_url`](Self::base_url) is a `file://`
+    /// URL, else `None` (an `http(s)://` mount has no local root). Consumers
+    /// locate the per-ecosystem subtrees (`cargo/`, `npm/`, `pypi/`) under it.
+    pub fn local_tree_root(&self) -> Option<PathBuf> {
+        self.base_url.strip_prefix("file://").map(PathBuf::from)
+    }
+
+    /// The pypi PEP-503 `simple/` index URL derived from the single registry
+    /// location — the value `uv` reads as `UV_INDEX`. `file://` and `http(s)://`
+    /// both work: uv consumes a PEP-503 `simple/` tree over either transport.
+    pub fn pypi_simple_index_url(&self) -> String {
+        format!("{}/pypi/simple", self.base_url)
+    }
+
+    /// The npm registry URL derived from the single registry location — the
+    /// value an `.npmrc` `@tatolab:registry=` scope points at. npm/Deno have no
+    /// `file://` registry story, so a `file://` tree must first be served over a
+    /// static HTTP mount before this is reachable; the string is derived
+    /// uniformly here regardless.
+    pub fn npm_registry_url(&self) -> String {
+        format!("{}/npm/", self.base_url)
+    }
+
+    /// The cargo **sparse** index URL derived from the single registry location
+    /// (`sparse+<base>/cargo/`). Valid as a `[source]`-replacement target only
+    /// for an `http(s)://` mount — cargo's sparse protocol is HTTP-only, so a
+    /// `file://` tree is instead consumed via a `local-registry` reshape.
+    pub fn cargo_sparse_index_url(&self) -> String {
+        format!("sparse+{}/cargo/", self.base_url)
+    }
 }
 
 /// Client over a single [`RegistryConfig`].
@@ -647,6 +695,44 @@ mod tests {
             }
             other => panic!("expected RegistryNoMatchingVersion, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn ecosystem_urls_derive_from_the_single_base() {
+        // Every channel derives from the one base URL — the "single registry
+        // location, toolchain-derived" contract.
+        let http = RegistryConfig {
+            base_url: "https://registry.tatolab.com".into(),
+        };
+        assert_eq!(http.pypi_simple_index_url(), "https://registry.tatolab.com/pypi/simple");
+        assert_eq!(http.npm_registry_url(), "https://registry.tatolab.com/npm/");
+        assert_eq!(
+            http.cargo_sparse_index_url(),
+            "sparse+https://registry.tatolab.com/cargo/"
+        );
+        assert!(http.local_tree_root().is_none());
+
+        let file = RegistryConfig {
+            base_url: "file:///srv/tree".into(),
+        };
+        assert_eq!(file.pypi_simple_index_url(), "file:///srv/tree/pypi/simple");
+        assert_eq!(file.npm_registry_url(), "file:///srv/tree/npm/");
+        assert_eq!(file.local_tree_root(), Some(PathBuf::from("/srv/tree")));
+    }
+
+    #[test]
+    fn for_local_tree_canonicalizes_and_errors_on_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = RegistryConfig::for_local_tree(tmp.path()).unwrap();
+        assert!(cfg.base_url.starts_with("file://"));
+        // The canonical root round-trips back to the dir.
+        assert_eq!(
+            cfg.local_tree_root().unwrap().canonicalize().unwrap(),
+            tmp.path().canonicalize().unwrap()
+        );
+        // A non-existent path is a typed error, not a silent bad URL.
+        let missing = tmp.path().join("does-not-exist");
+        assert!(RegistryConfig::for_local_tree(&missing).is_err());
     }
 
     #[test]

--- a/libs/streamlib-sdk/src/lib.rs
+++ b/libs/streamlib-sdk/src/lib.rs
@@ -103,6 +103,14 @@ pub mod sdk {
     #[cfg(feature = "auto-build")]
     pub use streamlib_build_orchestrator::PolyglotBuildOrchestrator;
 
+    /// Registry toolchain-config surface — the programmatic form of the
+    /// `streamlib registry use` / `streamlib registry serve` CLI verbs
+    /// ([`registry::use_registry`], [`registry::serve_registry`]). Behind the
+    /// `auto-build` feature (the orchestrator crate that owns the toolchain
+    /// integration).
+    #[cfg(feature = "auto-build")]
+    pub use streamlib_build_orchestrator::registry;
+
     /// Extension constructor (behind the `auto-build` feature) that builds
     /// a [`runtime::Runner`] with the default [`PolyglotBuildOrchestrator`]
     /// already wired — the common dev / runtime-authoring path. The engine


### PR DESCRIPTION
## What

Adds `streamlib registry use <tree>` / `streamlib registry serve <tree>` (programmatic-first: `streamlib::sdk::registry::{use_registry, serve_registry}`; the CLI verbs are thin wrappers) plus orchestrator `UV_INDEX` derivation — completing **exit criterion 4** of the Gitea removal: *"one registry location, toolchain-derived; nobody hand-runs a static server."*

## Shape (programmatic-first)

`streamlib::sdk::registry` (in `streamlib-build-orchestrator`, re-exported by the SDK facade) owns the logic; the CLI is a thin presentation wrapper. Named error enums (`RegistryUseError`, `RegistryServeError`, no `()` errors), `#[tracing::instrument]` on the public entrypoints, minimal docs.

### `registry use <tree>` — cargo, serverless

Writes the cargo `[source]`-replacement into the consumer's `.cargo/config.toml`:

- **Local `file://` folder** → reshaped into a serverless cargo `local-registry` mirror under `<consumer>/.streamlib/cargo-local-registry/` (reusing #1298's `scripts/registry/emit-cargo-local-registry.sh` — the single canonical sparse→local-registry reshape, no forked logic), then `[source.tatolab-local-registry] local-registry = <mirror>`. Cargo resolves `--offline`, **no server**.
- **HTTP mount** → `[source.tatolab-local-registry] registry = "sparse+<base>/cargo/"` (already served).

Both keep the canonical `tatolab` source id in every `Cargo.lock` via source replacement — the localhost / local-mirror path never leaks into a lockfile (the #1245 poison). The emitted stanza matches the CI `cargo-fork-mirror` action exactly (`[registries.tatolab]` + dual `[source]`).

Empirically confirmed while grounding: `sparse+file://` is parsed by cargo 1.94 but fails (its sparse client needs an HTTP 2xx; `file://` returns status 0), so `local-registry` is the correct serverless mechanism.

### `registry serve <tree>` — npm only

cargo (local-registry) + pypi / `.slpkg` (`file://`) resolve serverless. **npm / Deno have no `file://` registry story**, so `serve` is the *only* ecosystem needing a localhost mount. It serves the tree via `python3 -m http.server` (configurable `--port`, default 8799), writes the `.npmrc` scope so it isn't hand-edited, and blocks. The python child dies with the parent via `PR_SET_PDEATHSIG` (mirrors the engine's existing `pre_exec` pattern) so a killed CLI never orphans the server / leaks its port. **cargo is deliberately not auto-served** — baking `localhost:PORT` into a lockfile is the exact poison #1245 fixed.

### orchestrator `UV_INDEX` derivation

`run_uv` derives `UV_INDEX` from the single configured registry location (`STREAMLIB_REGISTRY_URL` → `pypi_simple_index_url()`) instead of depending on an ambiently-set one. A link-mode build still resolves `streamlib` from its injected `[tool.uv.sources]` override, which wins over the index.

### shared derivation

`RegistryConfig` (idents) gains `pypi_simple_index_url` / `npm_registry_url` / `cargo_sparse_index_url` / `for_local_tree` / `local_tree_root` — every channel derives from the one base URL. Reused by both the orchestrator and the SDK.

## Tests

- **idents** `registry::tests` (2 new; 15 pass total): `ecosystem_urls_derive_from_the_single_base`, `for_local_tree_canonicalizes_and_errors_on_missing`.
- **orchestrator** `registry::tests` (11): stanza content (local-registry + sparse-mirror), config create/merge/idempotency/unrelated-preservation/stale-key-drop, typed-error paths (missing cargo subtree, missing reshape script, non-table key), `.npmrc` scope merge. Plus `python_venv::tests::uv_index_derived_from_configured_registry_else_none`.
- **integration** `tests/registry_offline_resolve.rs` (1): builds a synthetic sparse crate, `use_registry` reshapes + writes the stanza, then **`cargo generate-lockfile --offline` resolves it with zero manual config** and the lockfile keeps the canonical source id (`sparse+https://registry.tatolab.com/cargo/`) — asserts no `127.0.0.1` / no local path leak. Self-contained (no fork/network); skips if `cargo`/`bash`/`tar`/`sha256sum` are absent.

**Mental-revert checks:** dropping the `[source]` replacement (or emitting a `sparse+http` one) makes the offline integration test fail; reverting the `from_env` gate in `derive_uv_index` to a hardcoded fallback flips the `None` assertion; reverting the local-registry insert / stale-key removal breaks the config-content + switch tests.

**Dogfooded end-to-end** against a real fork tree: `registry use` reshaped a serverless mirror + wrote the correct stanza and `streamlib-idents` built + tested through that exact `[source] local-registry` mirror `--offline`; `registry serve --port N` served + wrote `.npmrc`; a direct SIGTERM to the CLI released the server port (PDEATHSIG).

> Environment note: this box has no live canonical registry, so the workspace was built/tested against a `local-registry` mirror injected via a `--config` `[source]` replacement (dogfooding the exact mechanism this PR ships). Two pre-existing `commands::link::tests` E2E tests fail here on clean `main` too — their inner `cargo metadata` subprocess can't reach the dead canonical domain — unrelated to this change.

## Cargo.lock

The **only** Cargo.lock change is two new `streamlib-build-orchestrator` dependency edges — `+ "libc"` (unix, for `PR_SET_PDEATHSIG`) and `+ "thiserror 2.0.18"` (named error variants) — with **zero fork-source churn** (source replacement preserves vulkanalia's canonical id + checksums). Required for `--locked`.

## Follow-up (not in scope)

The reshape lives once as the merged #1298 shell script; `registry use` shells to it (locating it by walking up from cwd / the executable, or via an explicit `reshape_scripts_dir`). Lifting the reshape into a shared Rust helper — so a shipped binary needn't find the source-tree script — is a clean follow-up (deferred to keep the "one reshape implementation" invariant intact until it can be consolidated properly).

Closes #1277

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB
