### PR TITLE
fix(resolver): dev path patch falls back to by-version registry resolution when absent

### DIFF
--- a/libs/streamlib-idents/src/manifest.rs
+++ b/libs/streamlib-idents/src/manifest.rs
@@ -49,8 +49,12 @@ pub struct Manifest {
     /// Path-flavor entries are dev-time overrides only — `streamlib pack`
     /// rejects yamls whose `patch:` table contains any `path:` entries
     /// (mirrors `npm publish` / `cargo publish` rejecting path deps).
-    /// Path patches are validated strictly at parse time: a missing path
-    /// is a hard error so the dev knows immediately to fix the manifest.
+    /// A path patch is a dev-loop-only affordance: at resolve time the
+    /// resolver uses it only when its target exists on disk (the monorepo
+    /// dev loop) and otherwise falls back to resolving the declared
+    /// `dependencies:` version from the registry, so a path patch that
+    /// ships in a published artifact never breaks a standalone consumer
+    /// (the two-loops distribution model).
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub patch: BTreeMap<PackageRef, DependencySpec>,
 

--- a/libs/streamlib-idents/src/resolver.rs
+++ b/libs/streamlib-idents/src/resolver.rs
@@ -266,13 +266,38 @@ fn resolve_one(
     cache_dir: &Path,
     registry: Option<&RegistryConfig>,
 ) -> ResolverResult<ResolvedPackage> {
-    // Consumer's `patch:` table overrides the dep declaration when present.
-    // Mirrors Cargo's `[patch.crates-io]` semantics: dependencies declare
-    // *what* the consumer needs, the patch table declares *which copy* to
-    // use. Path-flavor patches resolve relative to the consumer's manifest
-    // dir; missing paths fail loudly so the dev knows to fix the
-    // declaration (npm/wrangler-style strict validation).
-    let effective_spec = patch.get(dep_ref).unwrap_or(spec);
+    // Consumer's `patch:` table overrides the dep declaration when present —
+    // Cargo `[patch.crates-io]` semantics: `dependencies:` declares *what* the
+    // consumer needs, `patch:` declares *which copy* to use.
+    //
+    // A path patch is a **dev-loop-only** affordance (the two-loops model in
+    // docs/architecture/package-development-model.md). It ships inside the
+    // published artifact, but its monorepo-relative target only exists in a dev
+    // checkout:
+    //   * dev loop     — target exists → the patch wins (byte-identical to an
+    //                    in-tree resolve).
+    //   * distribution — target absent (a standalone consumer of the published
+    //                    crate) → fall back to the declared `spec`, resolving
+    //                    the dep by version from the configured registry /
+    //                    `.slpkg` store.
+    // A path declared directly in `dependencies:` (no patch) still fails loud
+    // with `PathDependencyNotFound` when absent — there is no version range to
+    // fall back to, and a missing direct path source is a genuine error.
+    let effective_spec = match patch.get(dep_ref) {
+        Some(DependencySpec::Path(path_dep))
+            if !path_dependency_absolute_path(consumer_dir, path_dep).exists() =>
+        {
+            tracing::debug!(
+                dependency = dep_id,
+                patch_path = %path_dependency_absolute_path(consumer_dir, path_dep).display(),
+                "dev path patch target absent; falling back to declared version spec \
+                 (two-loops distribution resolution)"
+            );
+            spec
+        }
+        Some(patched) => patched,
+        None => spec,
+    };
     match effective_spec {
         DependencySpec::Path(path_dep) => {
             resolve_path_dependency(consumer_dir, dep_id, path_dep, cache_dir)
@@ -323,17 +348,28 @@ fn resolve_registry_dependency(
     build_resolved_package(manifest, extracted, ResolvedSource::Registry { url })
 }
 
+/// Absolute path a [`PathDependency`] resolves to, relative to `consumer_dir`
+/// (an absolute `path:` value passes through unchanged). Shared by
+/// [`resolve_path_dependency`] and the dev-patch-fallback existence check in
+/// [`resolve_one`] so both agree on exactly which path a patch names.
+fn path_dependency_absolute_path(
+    consumer_dir: &Path,
+    path_dep: &crate::manifest::PathDependency,
+) -> PathBuf {
+    if path_dep.path.is_absolute() {
+        path_dep.path.clone()
+    } else {
+        consumer_dir.join(&path_dep.path)
+    }
+}
+
 fn resolve_path_dependency(
     consumer_dir: &Path,
     dep_id: &str,
     path_dep: &crate::manifest::PathDependency,
     cache_dir: &Path,
 ) -> ResolverResult<ResolvedPackage> {
-    let abs = if path_dep.path.is_absolute() {
-        path_dep.path.clone()
-    } else {
-        consumer_dir.join(&path_dep.path)
-    };
+    let abs = path_dependency_absolute_path(consumer_dir, path_dep);
     if !abs.exists() {
         return Err(ResolverError::PathDependencyNotFound {
             name: dep_id.to_string(),
@@ -1039,6 +1075,118 @@ dependencies:
         let entry = lock.packages.get("@tatolab/escalate").unwrap();
         assert_eq!(entry.version.to_string(), "1.2.0");
         assert!(matches!(entry.source, LockfileSource::Registry { .. }));
+    }
+
+    /// Write a minimal escalate schema `.slpkg` into a `file://` mirror's
+    /// generic store at `<mirror>/slpkg/escalate/<version>/escalate.slpkg`.
+    fn write_escalate_slpkg(mirror: &Path, version: &str) {
+        use std::io::Write;
+        let dir = mirror.join("slpkg").join("escalate").join(version);
+        std::fs::create_dir_all(&dir).unwrap();
+        let archive = dir.join("escalate.slpkg");
+        let mut zip = zip::ZipWriter::new(std::fs::File::create(&archive).unwrap());
+        let opts = zip::write::SimpleFileOptions::default();
+        zip.start_file(Manifest::FILE_NAME, opts).unwrap();
+        zip.write_all(
+            format!(
+                "package:\n  org: tatolab\n  name: escalate\n  version: {version}\nschemas:\n  EscalateRequest:\n    file: schemas/EscalateRequest.yaml\n"
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+        zip.start_file("schemas/EscalateRequest.yaml", opts).unwrap();
+        zip.write_all(b"metadata:\n  name: EscalateRequest\nproperties: {}\n")
+            .unwrap();
+        zip.finish().unwrap();
+    }
+
+    /// Distribution loop: a dev path patch whose target is absent (the shape
+    /// `streamlib-engine`'s manifest ships — a bare registry range in
+    /// `dependencies:` overridden by a monorepo-relative `patch: { path }`
+    /// that doesn't exist for a standalone consumer) falls back to resolving
+    /// the declared version from the registry rather than failing with
+    /// `PathDependencyNotFound`. This is the regression lock for the fix:
+    /// reverting the fallback makes the patched Path spec authoritative and
+    /// the resolve panics on the missing path.
+    #[test]
+    fn dev_path_patch_absent_falls_back_to_registry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mirror = tmp.path().join("mirror");
+        write_escalate_slpkg(&mirror, "1.0.0");
+        write_escalate_slpkg(&mirror, "1.2.0");
+
+        let root = tmp.path().join("project");
+        write_streamlib_yaml(
+            &root,
+            r#"
+dependencies:
+  "@tatolab/escalate": "^1.0.0"
+patch:
+  "@tatolab/escalate":
+    path: ../packages/escalate
+"#,
+        );
+
+        let opts = ResolverOptions {
+            cache_dir: Some(tmp.path().join("cache")),
+            registry: Some(crate::RegistryConfig {
+                base_url: format!("file://{}", mirror.display()),
+            }),
+        };
+        let res = resolve_with(&root, &opts).unwrap();
+        let escalate = res.packages.get("@tatolab/escalate").unwrap();
+        // Resolved from the registry (patch path was absent), highest-in-range.
+        assert!(matches!(escalate.source, ResolvedSource::Registry { .. }));
+        assert_eq!(
+            escalate.manifest.package.as_ref().unwrap().version.to_string(),
+            "1.2.0"
+        );
+    }
+
+    /// Dev loop: when the path patch's target DOES exist (the monorepo
+    /// checkout), the patch still wins over the registry — byte-identical to
+    /// pre-fix behavior. A different local version proves the local path, not
+    /// the registry copy, was resolved.
+    #[test]
+    fn dev_path_patch_present_wins_over_registry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mirror = tmp.path().join("mirror");
+        // Registry holds 1.2.0; the local dev checkout is a different version
+        // so the source of truth is unambiguous.
+        write_escalate_slpkg(&mirror, "1.2.0");
+
+        let local = tmp.path().join("packages").join("escalate");
+        write_streamlib_yaml(
+            &local,
+            "package:\n  org: tatolab\n  name: escalate\n  version: 1.5.0\n",
+        );
+
+        let root = tmp.path().join("project");
+        write_streamlib_yaml(
+            &root,
+            r#"
+dependencies:
+  "@tatolab/escalate": "^1.0.0"
+patch:
+  "@tatolab/escalate":
+    path: ../packages/escalate
+"#,
+        );
+
+        let opts = ResolverOptions {
+            cache_dir: Some(tmp.path().join("cache")),
+            registry: Some(crate::RegistryConfig {
+                base_url: format!("file://{}", mirror.display()),
+            }),
+        };
+        let res = resolve_with(&root, &opts).unwrap();
+        let escalate = res.packages.get("@tatolab/escalate").unwrap();
+        // Local path patch won; the registry's 1.2.0 was NOT consulted.
+        assert!(matches!(escalate.source, ResolvedSource::Path { .. }));
+        assert_eq!(
+            escalate.manifest.package.as_ref().unwrap().version.to_string(),
+            "1.5.0"
+        );
     }
 
     #[test]

--- a/libs/streamlib-jtd-codegen/tests/registry_resolved_codegen.rs
+++ b/libs/streamlib-jtd-codegen/tests/registry_resolved_codegen.rs
@@ -128,3 +128,85 @@ schemas:
         "expected escalate_request.rs under tatolab__escalate/ (registry-resolved External owner context); got files: {files:?}"
     );
 }
+
+/// The faithful standalone-consumption E2E for issue #1307: a consumer
+/// manifest carries the EXACT shape `streamlib-engine`'s `streamlib.yaml`
+/// ships — a bare registry range in `dependencies:` PLUS a monorepo-relative
+/// `patch: { path }` dev override PLUS an `External` schema import. For a
+/// standalone consumer the patch target does not exist, so the resolver must
+/// fall back to resolving the declared version from the registry and codegen
+/// must still emit the imported type. This is the #1276 docker container's
+/// runtime path minus the cargo build. Before the fix, the absent dev path
+/// patch made the resolve fail with `PathDependencyNotFound`.
+#[test]
+fn registry_resolved_codegen_falls_back_when_dev_path_patch_absent() {
+    let test_name = "registry_resolved_codegen_falls_back_when_dev_path_patch_absent";
+    if skip_unless_jtd_codegen_available(test_name) {
+        return;
+    }
+
+    let tmp = TempDir::new().expect("temp dir");
+    let mirror = tmp.path().join("mirror");
+    write_slpkg(&mirror, "escalate", "1.0.0", "EscalateRequest");
+    write_slpkg(&mirror, "escalate", "1.2.0", "EscalateRequest");
+
+    // Consumer manifest with the engine's exact shape: bare range dep +
+    // dev-time path patch (whose target is absent for a standalone consumer)
+    // + External schema import.
+    let root_dir = tmp.path().join("consumer");
+    fs::create_dir_all(&root_dir).unwrap();
+    fs::write(
+        root_dir.join("streamlib.yaml"),
+        r#"
+package:
+  org: tatolab
+  name: consumer
+  version: 0.6.0
+dependencies:
+  "@tatolab/escalate": "^1.0.0"
+patch:
+  "@tatolab/escalate":
+    path: ../packages/escalate
+schemas:
+  EscalateRequest:
+    package: "@tatolab/escalate"
+"#,
+    )
+    .unwrap();
+
+    let resolved = resolve_with(
+        &root_dir,
+        &ResolverOptions {
+            cache_dir: Some(tmp.path().join("cache")),
+            registry: Some(RegistryConfig {
+                base_url: format!("file://{}", mirror.display()),
+            }),
+        },
+    )
+    .expect("absent dev path patch must fall back to registry resolution");
+
+    let escalate = resolved
+        .packages
+        .get("@tatolab/escalate")
+        .expect("escalate resolved from registry despite the path patch");
+    assert_eq!(
+        escalate.manifest.package.as_ref().unwrap().version.to_string(),
+        "1.2.0"
+    );
+
+    let output = TempDir::new().expect("output temp dir");
+    generate_from_resolved(&resolved, RuntimeTarget::Rust, output.path())
+        .expect("codegen from registry-resolved packages");
+
+    let files: Vec<String> = collect_files(output.path(), &[])
+        .into_iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+
+    assert!(
+        files
+            .iter()
+            .any(|f| f.contains("tatolab__escalate") && f.ends_with("escalate_request.rs")),
+        "expected escalate_request.rs under tatolab__escalate/ after path-patch fallback; got files: {files:?}"
+    );
+}


### PR DESCRIPTION
## What & why

Published `streamlib-engine` cannot build standalone from the registry. Its `libs/streamlib-engine/streamlib.yaml` declares its escalate schema dep by version — `@tatolab/escalate: "^1.0.0"` under `dependencies:` — but resolves it through a dev-time `patch: { path: ../../packages/escalate }`. That monorepo-relative path ships in the published cargo crate yet only exists in the monorepo, so the crate's `streamlib_jtd_codegen` build.rs fails when the crate is consumed standalone (surfaced by #1276's docker rework — the first real standalone consumption):

```
streamlib_jtd_codegen build.rs helper failed: Failed to resolve streamlib.yaml dependency graph
Caused by: path dependency @tatolab/escalate at .../streamlib-engine-0.6.0/../../packages/escalate not found
```

`@tatolab/escalate` 1.0.0 **does** ship as a `.slpkg` in the registry generic store, so the by-version resolution target exists — the leak is that a dev path patch was consulted (and hard-failed) at the published artifact's build time. This is the two-loops distribution model: the dev loop may use `path`/`patch`, but the distribution loop must resolve schema deps **by version** from the generic store.

## The fix (bounded resolver change)

The resolver already resolves `Registry` schema deps by version from the generic store (`resolve_registry_dependency`, wired to `STREAMLIB_REGISTRY_URL` via `ResolverOptions::from_env`). The only missing piece: a `patch:` path was **unconditionally authoritative** — a missing patch path hard-failed instead of falling back.

In `resolve_one`, a path patch is now treated as a **dev-loop-only affordance**:

- **dev loop** — patch target exists on disk → the patch wins, byte-identical to the prior in-tree resolve.
- **distribution loop** — patch target absent (a standalone consumer of the published crate) → fall back to the declared `spec`, resolving the dep by version from the configured registry / `.slpkg` store.

A path declared directly in `dependencies:` (not `patch:`) still fails loud with `PathDependencyNotFound` when absent — there is no version range to fall back to, and a missing direct path source is a genuine error. `Git`/`Registry` patches are untouched. The existence check and the real resolution share one `path_dependency_absolute_path` helper so the fallback predicate and the resolver agree on exactly which path a patch names.

`resolve_with` → `resolve_one` is the single chokepoint every consumer routes through (Rust build.rs, `streamlib-macros`, `project_config`, `install`, and the orchestrator's Deno/Python codegen via `streamlib generate`), so this one change fixes standalone consumption for all runtimes — no orchestrator changes needed. No engine-manifest restructure: escalate legitimately belongs in the engine manifest (the engine owns the escalate IPC protocol, per the manifest's own comment); the defect was the path-patch leak, not the dep.

No `Cargo.toml` / `Cargo.lock` changes — no new dep edges (`tracing`/`zip` already deps of `streamlib-idents`; `streamlib-idents` already a dep of the codegen crate).

## Tests

- `dev_path_patch_absent_falls_back_to_registry` (resolver unit) — **regression lock.** Mirrors the engine's manifest shape (bare range + absent path patch); reverting the fallback re-triggers the exact `PathDependencyNotFound` from the issue (verified: reverting the arm to `patch.get().unwrap_or(spec)` makes this test panic on the missing path).
- `dev_path_patch_present_wins_over_registry` (resolver unit) — dev loop preserved. A different local version (1.5.0) vs the registry copy (1.2.0) proves the local path, not the registry, was resolved. (Complementary lock — guards against a wrong unconditional-fallback fix; not the regression lock itself.)
- `registry_resolved_codegen_falls_back_when_dev_path_patch_absent` (jtd-codegen integration) — faithful standalone E2E: the engine's exact manifest shape (bare range + absent path patch + `External` schema import) resolves from the `file://` registry AND codegen emits `escalate_request.rs` under the External owner's context. This is #1276's runtime resolution+codegen path minus the cargo build.

`cargo test -p streamlib-idents --lib` (128 passed) and `cargo test -p streamlib-jtd-codegen --test registry_resolved_codegen` (2 passed) both green.

## Validation status

- **Unit/fixture-proven:** the resolution + codegen path that was failing (the build.rs codegen step).
- **Not runnable in this environment:** EC3 — a full standalone `streamlib-engine` cargo build + runtime `add_module` inside the #1276 docker container. Recommended maintainer confirmation once #1276's image is available:

  ```bash
  # inside the #1276 container (STREAMLIB_REGISTRY_URL already set to file:///opt/streamlib/registry)
  # build streamlib-engine from the registry and run add_module for a registry package;
  # confirm no "path dependency @tatolab/escalate ... not found" failure.
  ```

Filed as `Refs #1307` (not `Closes`) pending that docker EC3 run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB