### PR TITLE
fix(runtime): link-aware streamlib.yaml schema-dep resolution — true zero-registry dev loop (#1315)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5238,6 +5238,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "sha2",
  "tempfile",
  "thiserror 2.0.18",

--- a/libs/streamlib-build-orchestrator/src/lib.rs
+++ b/libs/streamlib-build-orchestrator/src/lib.rs
@@ -282,6 +282,7 @@ impl PolyglotBuildOrchestrator {
         if let Some(link) = &active_link {
             tracing::info!(
                 package = %pkg_label,
+                checkout = %link.checkout.display(),
                 cargo_config = ?link.consumer_cargo_config,
                 python_sdk = %link.python_sdk_path.display(),
                 "streamlib link active — building staged package against the linked checkout"
@@ -292,6 +293,11 @@ impl PolyglotBuildOrchestrator {
             .and_then(|l| l.consumer_cargo_config.clone())
             .into_iter()
             .collect();
+        // The checkout is threaded to the package's `build.rs` schema-dep
+        // codegen (via `STREAMLIB_LINK_CHECKOUT`) so schema deps resolve from
+        // the checkout too — the schema half of the dev loop that the cargo
+        // `[patch]` above covers for crate deps. `None` off a link ⇒ unchanged.
+        let link_checkout = active_link.as_ref().map(|l| l.checkout.as_path());
 
         let adapter = EngineSinkAdapter(sink);
         let outcome = assemble_artifact_with_cargo_config(
@@ -307,6 +313,7 @@ impl PolyglotBuildOrchestrator {
             },
             &adapter,
             &cargo_config_files,
+            link_checkout,
         )
         .map_err(|e| {
             let _ = std::fs::remove_dir_all(&temp_dir);
@@ -521,6 +528,12 @@ fn atomic_swap(temp: &Path, final_path: &Path) -> anyhow::Result<()> {
 /// checkout instead of the registry.
 #[derive(Debug)]
 struct ActiveBuildLink {
+    /// The canonicalized linked checkout root. Threaded to the staged package's
+    /// `cargo build` via [`streamlib_idents::LINK_CHECKOUT_ENV`] so the
+    /// package's `build.rs` schema-dep codegen resolves a dep present in
+    /// `<checkout>/packages/<name>` from the checkout — the schema half of the
+    /// zero-registry dev loop, mirroring the cargo `[patch]` (crate half) below.
+    checkout: PathBuf,
     /// The consumer's `streamlib link`-emitted `.cargo/config.toml`, when
     /// present — carries the `[patch."<index>"]` block redirecting every
     /// `streamlib*` crate at the checkout. `None` when the consumer has no
@@ -565,6 +578,7 @@ fn discover_active_build_link_from(
         .map(|consumer_root| consumer_root.join(".cargo").join("config.toml"))
         .filter(|cfg| cfg.is_file());
     Ok(Some(ActiveBuildLink {
+        checkout: manifest.checkout,
         consumer_cargo_config,
         python_sdk_path: manifest.python_sdk_path,
     }))
@@ -1026,6 +1040,12 @@ mod tests {
         let link = discover_active_build_link_from(consumer.path(), "tatolab/x")
             .unwrap()
             .expect("active link must be discovered");
+        assert_eq!(
+            link.checkout.as_path(),
+            checkout.path(),
+            "must carry the checkout root — threaded to build.rs schema-dep codegen \
+             via STREAMLIB_LINK_CHECKOUT so schema deps resolve from the checkout"
+        );
         assert_eq!(
             link.consumer_cargo_config,
             Some(consumer.path().join(".cargo").join("config.toml")),

--- a/libs/streamlib-engine/src/core/config/project_config.rs
+++ b/libs/streamlib-engine/src/core/config/project_config.rs
@@ -88,6 +88,21 @@ impl ProjectConfig {
     /// Downstream consumers (graph wiring, iceoryx2 service open,
     /// json-schema render) operate on `Specific` only.
     pub fn load(project_path: &Path) -> Result<Self> {
+        Self::load_with_link(project_path, None)
+    }
+
+    /// [`Self::load`], made link-aware for the runtime package-load path.
+    ///
+    /// When `link_checkout` is `Some` (a non-locked run under an active
+    /// `streamlib link`), the bare-name schema-resolution pass resolves a
+    /// schema dep present in `<checkout>/packages/<name>` from the checkout —
+    /// the load-time mirror of the build-time redirect, so a linked package
+    /// loaded from its staged cache dir with `STREAMLIB_REGISTRY_URL` unset
+    /// still resolves `@tatolab/core` (the zero-registry dev loop). `None`
+    /// (every other caller, and every locked run) is byte-identical to before.
+    /// The module loader threads its already-discovered, `is_locked`-gated
+    /// checkout here.
+    pub fn load_with_link(project_path: &Path, link_checkout: Option<&Path>) -> Result<Self> {
         let config_path = project_path.join(Self::FILE_NAME);
 
         let content = std::fs::read_to_string(&config_path).map_err(|e| {
@@ -98,7 +113,7 @@ impl ProjectConfig {
             Error::Configuration(format!("Failed to parse {}: {}", config_path.display(), e))
         })?;
 
-        config.resolve_bare_schema_refs(project_path)?;
+        config.resolve_bare_schema_refs(project_path, link_checkout)?;
 
         tracing::info!("Loaded project config from {}", config_path.display());
         Ok(config)
@@ -110,7 +125,11 @@ impl ProjectConfig {
     /// against the manifest's `schemas:` map (#767). No-op when there
     /// are no `Named` references in scope (saves the resolver invocation
     /// cost on `any`-only / config-less manifests).
-    fn resolve_bare_schema_refs(&mut self, project_path: &Path) -> Result<()> {
+    fn resolve_bare_schema_refs(
+        &mut self,
+        project_path: &Path,
+        link_checkout: Option<&Path>,
+    ) -> Result<()> {
         use streamlib_processor_schema::PortSchemaSpec;
 
         let needs_resolution = self.processors.iter().any(|p| {
@@ -126,21 +145,25 @@ impl ProjectConfig {
         }
 
         // Runtime package-load boundary: read the registry config from the
-        // environment (STREAMLIB_REGISTRY_URL / STREAMLIB_REGISTRY_URL) so a standalone,
-        // registry-only package resolves its schema deps (e.g. @tatolab/core)
-        // from the registry instead of failing as RegistryNotConfigured.
-        let resolved = streamlib_idents::resolve_with(
-            project_path,
-            &streamlib_idents::ResolverOptions::from_env(),
-        )
-        .map_err(|e| {
-            Error::Configuration(format!(
-                "failed to resolve manifest dependencies for bare-name \
+        // environment (STREAMLIB_REGISTRY_URL) so a standalone, registry-only
+        // package resolves its schema deps (e.g. @tatolab/core) from the
+        // registry instead of failing as RegistryNotConfigured. An active
+        // `streamlib link` (threaded by the module loader) additionally
+        // redirects a schema dep present in the checkout to the checkout — the
+        // load-time half of the zero-registry dev loop; `None` is unchanged.
+        let mut resolver_options = streamlib_idents::ResolverOptions::from_env();
+        if let Some(checkout) = link_checkout {
+            resolver_options.link_checkout = Some(checkout.to_path_buf());
+        }
+        let resolved =
+            streamlib_idents::resolve_with(project_path, &resolver_options).map_err(|e| {
+                Error::Configuration(format!(
+                    "failed to resolve manifest dependencies for bare-name \
                  schema lookup at {}: {}",
-                project_path.display(),
-                e
-            ))
-        })?;
+                    project_path.display(),
+                    e
+                ))
+            })?;
 
         for proc in &mut self.processors {
             for port in proc.inputs.iter_mut().chain(proc.outputs.iter_mut()) {
@@ -589,5 +612,147 @@ processors:
         assert_eq!(config.processors[0].name, "Grayscale");
         assert_eq!(config.processors[0].inputs.len(), 1);
         assert_eq!(config.processors[0].outputs.len(), 1);
+    }
+
+    /// Removes the resolution-driving env for a test's duration and restores it
+    /// after, so a stray `STREAMLIB_REGISTRY_URL` / `STREAMLIB_LINK_CHECKOUT` in
+    /// the shell can't make the load-time link tests non-deterministic.
+    struct CleanResolutionEnv {
+        prev_registry: Option<std::ffi::OsString>,
+        prev_link: Option<std::ffi::OsString>,
+    }
+    impl CleanResolutionEnv {
+        fn new() -> Self {
+            let prev_registry = std::env::var_os("STREAMLIB_REGISTRY_URL");
+            let prev_link = std::env::var_os("STREAMLIB_LINK_CHECKOUT");
+            // SAFETY: the tests using this guard are `#[serial]`, so no other
+            // thread races the process-global environment for its lifetime.
+            unsafe {
+                std::env::remove_var("STREAMLIB_REGISTRY_URL");
+                std::env::remove_var("STREAMLIB_LINK_CHECKOUT");
+            }
+            Self {
+                prev_registry,
+                prev_link,
+            }
+        }
+    }
+    impl Drop for CleanResolutionEnv {
+        fn drop(&mut self) {
+            unsafe {
+                match self.prev_registry.take() {
+                    Some(v) => std::env::set_var("STREAMLIB_REGISTRY_URL", v),
+                    None => std::env::remove_var("STREAMLIB_REGISTRY_URL"),
+                }
+                match self.prev_link.take() {
+                    Some(v) => std::env::set_var("STREAMLIB_LINK_CHECKOUT", v),
+                    None => std::env::remove_var("STREAMLIB_LINK_CHECKOUT"),
+                }
+            }
+        }
+    }
+
+    /// Write a consumer manifest whose port declares a `Named` `VideoFrame`
+    /// imported from `@tatolab/core` (a bare version dep, NO patch) — the shape
+    /// that forces the load-time bare-name resolution to walk the dep graph.
+    fn write_named_port_consumer(dir: &Path) {
+        std::fs::write(
+            dir.join("streamlib.yaml"),
+            r#"
+package:
+  org: tatolab
+  name: consumer
+  version: 1.0.0
+dependencies:
+  "@tatolab/core":
+    version: ^1.0.0
+schemas:
+  VideoFrame:
+    package: "@tatolab/core"
+processors:
+  - name: Consumer
+    version: 1.0.0
+    description: d
+    runtime: rust
+    execution: manual
+    inputs:
+      - name: in0
+        schema: VideoFrame
+    outputs: []
+"#,
+        )
+        .unwrap();
+    }
+
+    /// Write `<checkout>/packages/core` declaring the `VideoFrame` Local schema.
+    fn write_checkout_core(checkout: &Path) {
+        let core = checkout.join("packages").join("core");
+        std::fs::create_dir_all(core.join("schemas")).unwrap();
+        std::fs::write(
+            core.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: core\n  version: 1.0.0\nschemas:\n  VideoFrame:\n    file: schemas/video_frame.yaml\n",
+        )
+        .unwrap();
+        std::fs::write(
+            core.join("schemas/video_frame.yaml"),
+            "metadata:\n  type: VideoFrame\nproperties: {}\n",
+        )
+        .unwrap();
+    }
+
+    /// Load-time dev loop: `load_with_link` with an active checkout resolves a
+    /// bare-name schema dep from the checkout's `packages/core` with ZERO
+    /// registry configured — the load-time half of the zero-registry loop. The
+    /// `Named` port is rewritten to a `Specific` ident owned by `@tatolab/core`.
+    /// Mentally revert the `link_checkout` threading in `resolve_bare_schema_refs`
+    /// (or pass `None`, as the sibling test does) and this fails
+    /// `RegistryNotConfigured` — locking that the checkout is what resolved it.
+    #[test]
+    #[serial_test::serial]
+    fn load_with_link_resolves_bare_schema_from_checkout_zero_registry() {
+        use streamlib_processor_schema::PortSchemaSpec;
+        let _env = CleanResolutionEnv::new();
+        let tmp = TempDir::new().unwrap();
+        let consumer = tmp.path().join("consumer");
+        std::fs::create_dir_all(&consumer).unwrap();
+        write_named_port_consumer(&consumer);
+        let checkout = tmp.path().join("checkout");
+        write_checkout_core(&checkout);
+
+        let config = ProjectConfig::load_with_link(&consumer, Some(checkout.as_path())).expect(
+            "linked load must resolve the bare-name schema from the checkout, zero registry",
+        );
+        let port = &config.processors[0].inputs[0];
+        match &port.schema {
+            PortSchemaSpec::Specific(ident) => {
+                assert_eq!(ident.to_string(), "@tatolab/core/VideoFrame@1.0.0")
+            }
+            other => panic!("port schema must be resolved to a Specific ident, got {other:?}"),
+        }
+    }
+
+    /// Load-time distribution guardrail: with NO link (`None`) and no registry,
+    /// the same manifest fails `RegistryNotConfigured` — the checkout on disk is
+    /// ignored without a link, so the no-link path is byte-identical to before.
+    /// This is also the mental-revert of the positive test above.
+    #[test]
+    #[serial_test::serial]
+    fn load_without_link_ignores_checkout_and_needs_registry() {
+        let _env = CleanResolutionEnv::new();
+        let tmp = TempDir::new().unwrap();
+        let consumer = tmp.path().join("consumer");
+        std::fs::create_dir_all(&consumer).unwrap();
+        write_named_port_consumer(&consumer);
+        // A checkout carrying core exists on disk, but no link is threaded.
+        let checkout = tmp.path().join("checkout");
+        write_checkout_core(&checkout);
+
+        let err = ProjectConfig::load_with_link(&consumer, None)
+            .expect_err("without a link + no registry, the bare version dep must fail loud");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no registry is configured") || msg.contains("cannot be resolved"),
+            "expected a registry-not-configured failure, got: {msg}"
+        );
     }
 }

--- a/libs/streamlib-engine/src/core/runtime/install.rs
+++ b/libs/streamlib-engine/src/core/runtime/install.rs
@@ -124,6 +124,10 @@ pub fn install(
     let resolver_options = ResolverOptions {
         cache_dir: options.resolver_cache_dir.clone(),
         registry,
+        // Install is the reproducible distribution seam: it resolves range →
+        // concrete and pins a lockfile, so it is deliberately NOT link-aware — a
+        // dev-loop `streamlib link` override must never leak into a lockfile.
+        link_checkout: None,
     };
 
     tracing::info!(root = %root_dir.display(), "install: resolving package graph");

--- a/libs/streamlib-engine/src/core/runtime/module_loader/processor_registration.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/processor_registration.rs
@@ -162,6 +162,7 @@ pub(super) fn register_manifest_processors(
     iceoryx2_node: &Iceoryx2Node,
     project_path: &std::path::Path,
     config: &crate::core::config::ProjectConfig,
+    link_checkout: Option<&std::path::Path>,
 ) -> Result<()> {
     use super::schema_registration::resolve_config_schema_canonical_id;
     use crate::core::ProcessorDescriptor;
@@ -206,15 +207,18 @@ pub(super) fn register_manifest_processors(
     // declares a config block.
     let config_resolved: Option<streamlib_idents::ResolvedPackages> =
         if config.processors.iter().any(|p| p.config.is_some()) {
+            // Runtime package-load boundary — read the registry config from the
+            // environment so a registry-only package resolves its schema deps
+            // from the registry (not a dev path patch). An active `streamlib
+            // link` (threaded by the module loader) additionally redirects a
+            // schema dep present in the checkout to the checkout — the load-time
+            // half of the zero-registry dev loop; `None` leaves this unchanged.
+            let mut resolver_options = streamlib_idents::ResolverOptions::from_env();
+            if let Some(checkout) = link_checkout {
+                resolver_options.link_checkout = Some(checkout.to_path_buf());
+            }
             Some(
-                streamlib_idents::resolve_with(
-                    project_path,
-                    // Runtime package-load boundary — read the registry config
-                    // from the environment so a registry-only package resolves
-                    // its schema deps from the registry (not a dev path patch).
-                    &streamlib_idents::ResolverOptions::from_env(),
-                )
-                .map_err(|e| {
+                streamlib_idents::resolve_with(project_path, &resolver_options).map_err(|e| {
                     Error::Configuration(format!(
                         "failed to resolve manifest dependencies for bare-name \
                          config schema lookup at {}: {}",

--- a/libs/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
@@ -516,12 +516,17 @@ fn add_module_recursive_body(
     let on_disk_version = read_version_from_manifest_dir(&manifest_dir)?;
 
     // Read the manifest; authoritative source of identity for the
-    // package at the resolved location.
+    // package at the resolved location. Thread the active link so the
+    // manifest's bare-name schema-dep resolution resolves a dep present in the
+    // checkout from the checkout (the load-time half of the zero-registry dev
+    // loop). `link` is `None` on locked runs / no active link → unchanged.
     let config =
-        ProjectConfig::load(&manifest_dir).map_err(|e| AddModuleError::ManifestLoadFailed {
-            module: module.clone(),
-            source_path: manifest_dir.clone(),
-            detail: e.to_string(),
+        ProjectConfig::load_with_link(&manifest_dir, link.map(|l| l.checkout())).map_err(|e| {
+            AddModuleError::ManifestLoadFailed {
+                module: module.clone(),
+                source_path: manifest_dir.clone(),
+                detail: e.to_string(),
+            }
         })?;
 
     config
@@ -648,12 +653,18 @@ fn add_module_recursive_body(
         )?;
     }
 
-    // Now register this package's own processors.
-    register_manifest_processors(iceoryx2_node, &manifest_dir, &config).map_err(|e| {
-        AddModuleError::LoadProjectFailed {
-            module: module.clone(),
-            source: Box::new(e),
-        }
+    // Now register this package's own processors. Thread the active link so a
+    // config schema dep present in the checkout resolves from the checkout too
+    // (load-time zero-registry dev loop); `None` off a link → unchanged.
+    register_manifest_processors(
+        iceoryx2_node,
+        &manifest_dir,
+        &config,
+        link.map(|l| l.checkout()),
+    )
+    .map_err(|e| AddModuleError::LoadProjectFailed {
+        module: module.clone(),
+        source: Box::new(e),
     })?;
 
     // Registration + the transitive walk succeeded — flip the in-flight

--- a/libs/streamlib-idents/Cargo.toml
+++ b/libs/streamlib-idents/Cargo.toml
@@ -25,6 +25,7 @@ ureq = { workspace = true }  # Blocking HTTP for static generic-registry schema-
 serde_yaml = { workspace = true }
 serde_json = { workspace = true }
 tempfile = "3.14"
+serial_test = "3.2"
 
 [lints]
 workspace = true

--- a/libs/streamlib-idents/src/lib.rs
+++ b/libs/streamlib-idents/src/lib.rs
@@ -41,8 +41,8 @@ pub use manifest::{
     SchemaEntry,
 };
 pub use registry::{
-    DEFAULT_REGISTRY_URL, REGISTRY_URL_ENV, RELEASE_MANIFEST_CHANNEL, RELEASE_MANIFEST_FILE,
-    RegistryClient, RegistryConfig, select_version,
+    DEFAULT_REGISTRY_URL, LINK_CHECKOUT_ENV, REGISTRY_URL_ENV, RELEASE_MANIFEST_CHANNEL,
+    RELEASE_MANIFEST_FILE, RegistryClient, RegistryConfig, select_version,
 };
 pub use release::{
     RELEASE_MANIFEST_FORMAT, ReleaseManifest, ReleaseManifestMember, crates_missing_from_release,

--- a/libs/streamlib-idents/src/registry.rs
+++ b/libs/streamlib-idents/src/registry.rs
@@ -50,6 +50,17 @@ const VERSION_INDEX_FILE: &str = "index.json";
 /// for a local / offline mirror, or `http(s)://…` for a static HTTP mount.
 pub const REGISTRY_URL_ENV: &str = "STREAMLIB_REGISTRY_URL";
 
+/// Environment variable carrying the absolute path of an active `streamlib
+/// link` checkout. Set by the build orchestrator on the staged package's
+/// `cargo build` when a link is active, so a package's `build.rs` schema-dep
+/// codegen resolves a dep present in `<checkout>/packages/<name>` from the
+/// checkout (the zero-registry dev loop) instead of the by-version store.
+/// Unset — the dominant case — leaves resolution byte-identical to before.
+/// Read by [`ResolverOptions::from_env`], never on the pure resolution path.
+///
+/// [`ResolverOptions::from_env`]: crate::ResolverOptions::from_env
+pub const LINK_CHECKOUT_ENV: &str = "STREAMLIB_LINK_CHECKOUT";
+
 /// Default tree-root URL for the first-party static registry — the sensible
 /// default the CLI writes into a consumer's configuration (`streamlib
 /// registry use` / `streamlib install`) when no tree is named. It is a

--- a/libs/streamlib-idents/src/resolver.rs
+++ b/libs/streamlib-idents/src/resolver.rs
@@ -133,6 +133,17 @@ pub struct ResolverOptions {
     /// environment. Codegen entry points (build scripts, `streamlib
     /// generate`) populate it via [`ResolverOptions::from_env`].
     pub registry: Option<RegistryConfig>,
+    /// Active `streamlib link` checkout, when a link is in effect. `Some`
+    /// redirects any dependency present in `<checkout>/packages/<name>` to that
+    /// checkout source — the schema-dep mirror of the module loader's link
+    /// redirect, completing the zero-registry dev loop. `None` (the dominant
+    /// case) leaves resolution byte-identical to a non-linked build: absent
+    /// packages, and every dep when no link is active, resolve by version from
+    /// the store / registry (or via a dev path patch). Populated from
+    /// [`crate::LINK_CHECKOUT_ENV`] by [`ResolverOptions::from_env`]; locked
+    /// runs never set it (the orchestrator withholds it), preserving
+    /// reproducibility.
+    pub link_checkout: Option<PathBuf>,
 }
 
 impl ResolverOptions {
@@ -146,8 +157,21 @@ impl ResolverOptions {
         Self {
             cache_dir: None,
             registry: RegistryConfig::from_env(),
+            link_checkout: link_checkout_from_env(),
         }
     }
+}
+
+/// Read the active `streamlib link` checkout from [`crate::LINK_CHECKOUT_ENV`],
+/// returning `None` when unset/empty — the codegen-boundary read that makes
+/// `resolve_with` link-aware without the pure resolver ever touching the
+/// environment. The orchestrator sets this env on a linked package's `cargo
+/// build` (and withholds it for locked/distribution builds), so a `build.rs`
+/// schema-dep codegen redirects to the checkout only when a link is active.
+fn link_checkout_from_env() -> Option<PathBuf> {
+    std::env::var_os(crate::LINK_CHECKOUT_ENV)
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
 }
 
 /// Resolve a `streamlib.yaml` at `root_dir` and every transitive dependency
@@ -177,6 +201,13 @@ pub fn resolve_with(
     // into a live fetch. `None` means "no registry" — a `Registry` dep then
     // fails loud with `RegistryNotConfigured`.
     let registry = options.registry.as_ref();
+
+    // Active `streamlib link` checkout (a non-locked build only; the
+    // orchestrator withholds it for locked/distribution builds). When `Some`, a
+    // dep present in the checkout's `packages/` tree resolves from there — the
+    // schema-dep mirror of the module loader's link redirect. `None` (the
+    // dominant case) ⇒ resolution byte-identical to before.
+    let link_checkout = options.link_checkout.as_deref();
 
     let root = build_resolved_package(root_manifest, root_dir.to_path_buf(), ResolvedSource::Root)?;
 
@@ -229,6 +260,7 @@ pub fn resolve_with(
                 &patch,
                 &cache_dir,
                 registry,
+                link_checkout,
             )?;
 
             check_resolved_id_matches(&resolved, &dep_id, &consumer_dir)?;
@@ -253,6 +285,7 @@ struct QueueEntry {
     patch: BTreeMap<PackageRef, DependencySpec>,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn resolve_one(
     consumer_dir: &Path,
     dep_ref: &PackageRef,
@@ -261,7 +294,35 @@ fn resolve_one(
     patch: &BTreeMap<PackageRef, DependencySpec>,
     cache_dir: &Path,
     registry: Option<&RegistryConfig>,
+    link_checkout: Option<&Path>,
 ) -> ResolverResult<ResolvedPackage> {
+    // Link-aware short-circuit — the schema-dep mirror of the module loader's
+    // `streamlib link` redirect (npm-link precedence): when a link is active
+    // and this dep is present in the checkout's `packages/<name>` tree, resolve
+    // it from the checkout, overriding whatever `dependencies:` / `patch:`
+    // declared. Absent-from-checkout falls through to the by-version / patch
+    // path below, and `link_checkout` is `None` for every non-linked build
+    // (and every locked run), so this branch changes nothing off the dev loop.
+    // Discovery of the link itself (the `.streamlib/link.json` marker) happens
+    // once in the build orchestrator; here we only look a dep up within the
+    // already-resolved checkout path.
+    if let Some(checkout) = link_checkout
+        && let Some(pkg_dir) = checkout_package_dir(checkout, dep_ref)?
+    {
+        tracing::info!(
+            dependency = dep_id,
+            checkout = %checkout.display(),
+            source = %pkg_dir.display(),
+            "streamlib link active — resolving schema dep from linked checkout \
+             (overriding declared spec)"
+        );
+        let manifest = Manifest::load(&pkg_dir)?;
+        return build_resolved_package(
+            manifest,
+            pkg_dir.clone(),
+            ResolvedSource::Path { relative: pkg_dir },
+        );
+    }
     // Consumer's `patch:` table overrides the dep declaration when present —
     // Cargo `[patch.crates-io]` semantics: `dependencies:` declares *what* the
     // consumer needs, `patch:` declares *which copy* to use.
@@ -313,6 +374,66 @@ fn resolve_one(
         DependencySpec::Registry(reg) => {
             resolve_registry_dependency(dep_ref, dep_id, reg, cache_dir, registry)
         }
+    }
+}
+
+/// If `dep_ref` (`@org/name`) is present in the linked checkout's `packages/`
+/// tree, return its source dir. The match is by the manifest's declared
+/// `package.org` + `package.name` (not the directory name), so a package whose
+/// directory differs from its name still resolves. `Ok(None)` when the dep is
+/// absent — the caller then resolves it by version / patch, unchanged.
+///
+/// This mirrors the module loader's `ActiveLinkedCheckout::checkout_package_dir`
+/// (`core/runtime/module_loader/source.rs`); the two live in different crates
+/// (engine vs. idents) and can't share the type, but the lookup shape is the
+/// same so a linked package and its linked schema deps resolve from one tree.
+fn checkout_package_dir(checkout: &Path, dep_ref: &PackageRef) -> ResolverResult<Option<PathBuf>> {
+    let packages_root = checkout.join("packages");
+    if !packages_root.is_dir() {
+        return Ok(None);
+    }
+    // Fast path: the standard monorepo layout is `packages/<name>`.
+    let by_name = packages_root.join(dep_ref.name.as_str());
+    if manifest_declares_package(&by_name, dep_ref) {
+        return Ok(Some(by_name));
+    }
+    // Fallback: scan for a package dir whose manifest declares this ident
+    // (covers a package whose directory name differs from its package name).
+    let entries = std::fs::read_dir(&packages_root).map_err(|e| ResolverError::Io {
+        path: packages_root.clone(),
+        source: e,
+    })?;
+    for entry in entries {
+        let dir = entry
+            .map_err(|e| ResolverError::Io {
+                path: packages_root.clone(),
+                source: e,
+            })?
+            .path();
+        if dir == by_name || !dir.is_dir() {
+            continue;
+        }
+        if manifest_declares_package(&dir, dep_ref) {
+            return Ok(Some(dir));
+        }
+    }
+    Ok(None)
+}
+
+/// Whether the `streamlib.yaml` at `dir` declares a package whose org + name
+/// equal `dep_ref`. A missing / unreadable / malformed manifest is treated as
+/// "no match" — this dir just isn't the package we're looking for; a genuine
+/// manifest error surfaces on the real resolve path with a precise message.
+fn manifest_declares_package(dir: &Path, dep_ref: &PackageRef) -> bool {
+    if !dir.join(Manifest::FILE_NAME).exists() {
+        return false;
+    }
+    match Manifest::load(dir) {
+        Ok(m) => m
+            .package
+            .as_ref()
+            .is_some_and(|p| p.org == dep_ref.org && p.name == dep_ref.name),
+        Err(_) => false,
     }
 }
 
@@ -995,6 +1116,7 @@ dependencies:
         let opts = ResolverOptions {
             cache_dir: Some(tmp.path().join("cache")),
             registry: None,
+            link_checkout: None,
         };
         let err = resolve_with(&root, &opts).unwrap_err();
         assert!(
@@ -1057,6 +1179,7 @@ dependencies:
             registry: Some(crate::RegistryConfig {
                 base_url: format!("file://{}", mirror.display()),
             }),
+            link_checkout: None,
         };
         let res = resolve_with(&root, &opts).unwrap();
         let escalate = res.packages.get("@tatolab/escalate").unwrap();
@@ -1137,6 +1260,7 @@ patch:
             registry: Some(crate::RegistryConfig {
                 base_url: format!("file://{}", mirror.display()),
             }),
+            link_checkout: None,
         };
         let res = resolve_with(&root, &opts).unwrap();
         let escalate = res.packages.get("@tatolab/escalate").unwrap();
@@ -1189,6 +1313,7 @@ patch:
             registry: Some(crate::RegistryConfig {
                 base_url: format!("file://{}", mirror.display()),
             }),
+            link_checkout: None,
         };
         let res = resolve_with(&root, &opts).unwrap();
         let escalate = res.packages.get("@tatolab/escalate").unwrap();
@@ -1234,6 +1359,7 @@ dependencies:
             registry: Some(crate::RegistryConfig {
                 base_url: format!("file://{}", mirror.display()),
             }),
+            link_checkout: None,
         };
         let err = resolve_with(&root, &opts).unwrap_err();
         assert!(
@@ -1273,6 +1399,7 @@ dependencies:
         let opts = ResolverOptions {
             cache_dir: Some(cache),
             registry: None,
+            link_checkout: None,
         };
         let res = resolve_with(&root, &opts).unwrap();
         let core = res.packages.get("@tatolab/core").unwrap();
@@ -1503,5 +1630,276 @@ schemas: {}
             err,
             ResolverError::BareSchemaNameUnresolved { .. }
         ));
+    }
+
+    // =====================================================================
+    // Link-aware schema-dep resolution (`ResolverOptions::link_checkout`)
+    //
+    // The schema-dep mirror of the module loader's `streamlib link` redirect:
+    // when a link is active, a dep present in the checkout's `packages/<name>`
+    // tree resolves from the checkout (dev loop, zero-registry); absent-from-
+    // checkout and no-link resolve by version from the store (distribution).
+    // =====================================================================
+
+    /// Write a minimal `@tatolab/<name>` schema `.slpkg` into a `file://`
+    /// mirror's generic store at `<mirror>/slpkg/<name>/<version>/<name>.slpkg`.
+    fn write_pkg_slpkg(mirror: &Path, name: &str, version: &str) {
+        use std::io::Write;
+        let dir = mirror.join("slpkg").join(name).join(version);
+        std::fs::create_dir_all(&dir).unwrap();
+        let archive = dir.join(format!("{name}.slpkg"));
+        let mut zip = zip::ZipWriter::new(std::fs::File::create(&archive).unwrap());
+        let opts = zip::write::SimpleFileOptions::default();
+        zip.start_file(Manifest::FILE_NAME, opts).unwrap();
+        zip.write_all(
+            format!("package:\n  org: tatolab\n  name: {name}\n  version: {version}\n").as_bytes(),
+        )
+        .unwrap();
+        zip.finish().unwrap();
+    }
+
+    /// Write `<checkout>/packages/<dir_name>/streamlib.yaml` declaring the
+    /// package `@tatolab/<pkg_name>` at `version` — the linked-checkout layout
+    /// the resolver looks a dep up in.
+    fn write_checkout_package(checkout: &Path, dir_name: &str, pkg_name: &str, version: &str) {
+        let pkg = checkout.join("packages").join(dir_name);
+        write_streamlib_yaml(
+            &pkg,
+            &format!("package:\n  org: tatolab\n  name: {pkg_name}\n  version: {version}\n"),
+        );
+    }
+
+    fn registry_opts(
+        cache: &Path,
+        mirror: &Path,
+        link_checkout: Option<PathBuf>,
+    ) -> ResolverOptions {
+        ResolverOptions {
+            cache_dir: Some(cache.to_path_buf()),
+            registry: Some(crate::RegistryConfig {
+                base_url: format!("file://{}", mirror.display()),
+            }),
+            link_checkout,
+        }
+    }
+
+    /// Dev loop, link active: a schema dep present in the linked checkout's
+    /// `packages/<name>` resolves FROM the checkout, overriding the declared
+    /// version range — even though the registry holds a *different* version.
+    /// This is the zero-registry dev loop for schema deps. Mentally revert the
+    /// link-aware short-circuit in `resolve_one` and the resolve falls back to
+    /// the registry (1.2.0, `Registry` source), failing both assertions.
+    #[test]
+    fn link_active_resolves_schema_dep_from_checkout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mirror = tmp.path().join("mirror");
+        // Registry holds a DIFFERENT version so the source-of-truth is unambiguous.
+        write_pkg_slpkg(&mirror, "core", "1.2.0");
+        // The linked checkout carries @tatolab/core at 1.0.0.
+        let checkout = tmp.path().join("checkout");
+        write_checkout_package(&checkout, "core", "core", "1.0.0");
+
+        let root = tmp.path().join("project");
+        write_streamlib_yaml(&root, "dependencies:\n  \"@tatolab/core\": \"^1.0.0\"\n");
+
+        let opts = registry_opts(&tmp.path().join("cache"), &mirror, Some(checkout.clone()));
+        let res = resolve_with(&root, &opts).unwrap();
+        let core = res.packages.get("@tatolab/core").unwrap();
+        assert!(
+            matches!(core.source, ResolvedSource::Path { .. }),
+            "linked dep must resolve from the checkout (Path), got {:?}",
+            core.source
+        );
+        assert_eq!(
+            core.manifest.package.as_ref().unwrap().version.to_string(),
+            "1.0.0",
+            "must be the checkout's version, not the registry's 1.2.0"
+        );
+        assert!(
+            core.root_dir.starts_with(&checkout),
+            "resolved root_dir must be inside the checkout: {}",
+            core.root_dir.display()
+        );
+    }
+
+    /// No link (`link_checkout: None`): even with a checkout present on disk,
+    /// resolution is byte-identical to before — the dep resolves by version
+    /// from the store, never the checkout. Locks the link-GATING guardrail
+    /// (the checkout is consulted ONLY when a link is active).
+    #[test]
+    fn no_link_ignores_checkout_and_resolves_from_store() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mirror = tmp.path().join("mirror");
+        write_pkg_slpkg(&mirror, "core", "1.2.0");
+        // A checkout exists on disk and carries core, but no link is active.
+        let checkout = tmp.path().join("checkout");
+        write_checkout_package(&checkout, "core", "core", "1.0.0");
+
+        let root = tmp.path().join("project");
+        write_streamlib_yaml(&root, "dependencies:\n  \"@tatolab/core\": \"^1.0.0\"\n");
+
+        let opts = registry_opts(&tmp.path().join("cache"), &mirror, None);
+        let res = resolve_with(&root, &opts).unwrap();
+        let core = res.packages.get("@tatolab/core").unwrap();
+        assert!(
+            matches!(core.source, ResolvedSource::Registry { .. }),
+            "without a link the dep must resolve from the store, got {:?}",
+            core.source
+        );
+        assert_eq!(
+            core.manifest.package.as_ref().unwrap().version.to_string(),
+            "1.2.0",
+            "must be the registry's version — the on-disk checkout is ignored with no link"
+        );
+    }
+
+    /// Link active but the dep is ABSENT from the checkout's `packages/` tree:
+    /// resolution falls through to the by-version store (distribution loop),
+    /// unchanged. A checkout that doesn't carry a given dep must not break it.
+    #[test]
+    fn link_active_dep_absent_from_checkout_falls_back_to_store() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mirror = tmp.path().join("mirror");
+        write_pkg_slpkg(&mirror, "core", "1.2.0");
+        // Checkout exists and has a packages/ tree, but carries a DIFFERENT
+        // package (not core).
+        let checkout = tmp.path().join("checkout");
+        write_checkout_package(&checkout, "camera", "camera", "1.0.0");
+
+        let root = tmp.path().join("project");
+        write_streamlib_yaml(&root, "dependencies:\n  \"@tatolab/core\": \"^1.0.0\"\n");
+
+        let opts = registry_opts(&tmp.path().join("cache"), &mirror, Some(checkout));
+        let res = resolve_with(&root, &opts).unwrap();
+        let core = res.packages.get("@tatolab/core").unwrap();
+        assert!(
+            matches!(core.source, ResolvedSource::Registry { .. }),
+            "a dep absent from the checkout must fall back to the store, got {:?}",
+            core.source
+        );
+        assert_eq!(
+            core.manifest.package.as_ref().unwrap().version.to_string(),
+            "1.2.0"
+        );
+    }
+
+    /// The checkout lookup matches by the manifest's declared package ident,
+    /// not the directory name: a dep whose checkout directory differs from its
+    /// package name still resolves from the checkout (the scan-fallback branch
+    /// of `checkout_package_dir`).
+    #[test]
+    fn link_checkout_matches_by_manifest_ident_not_dir_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mirror = tmp.path().join("mirror");
+        write_pkg_slpkg(&mirror, "core", "1.2.0");
+        // Directory is `wire-vocab`, but the manifest declares @tatolab/core.
+        let checkout = tmp.path().join("checkout");
+        write_checkout_package(&checkout, "wire-vocab", "core", "1.0.0");
+
+        let root = tmp.path().join("project");
+        write_streamlib_yaml(&root, "dependencies:\n  \"@tatolab/core\": \"^1.0.0\"\n");
+
+        let opts = registry_opts(&tmp.path().join("cache"), &mirror, Some(checkout.clone()));
+        let res = resolve_with(&root, &opts).unwrap();
+        let core = res.packages.get("@tatolab/core").unwrap();
+        assert!(
+            matches!(core.source, ResolvedSource::Path { .. }),
+            "got {:?}",
+            core.source
+        );
+        assert_eq!(
+            core.manifest.package.as_ref().unwrap().version.to_string(),
+            "1.0.0"
+        );
+        assert!(
+            core.root_dir.ends_with("wire-vocab"),
+            "must resolve the scan-matched dir, got {}",
+            core.root_dir.display()
+        );
+    }
+
+    /// The link redirect threads through the whole dependency walk: a linked
+    /// package AND its transitive schema deps all resolve from the checkout.
+    #[test]
+    fn link_checkout_threads_through_transitive_deps() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mirror = tmp.path().join("mirror");
+        // Registry holds different versions of both, so the source is unambiguous.
+        write_pkg_slpkg(&mirror, "core", "1.2.0");
+        write_pkg_slpkg(&mirror, "h264", "0.9.0");
+
+        let checkout = tmp.path().join("checkout");
+        write_checkout_package(&checkout, "core", "core", "1.0.0");
+        // h264 (in the checkout) depends on core.
+        write_streamlib_yaml(
+            &checkout.join("packages").join("h264"),
+            r#"
+package:
+  org: tatolab
+  name: h264
+  version: 0.4.0
+dependencies:
+  "@tatolab/core": "^1.0.0"
+"#,
+        );
+
+        let root = tmp.path().join("project");
+        write_streamlib_yaml(&root, "dependencies:\n  \"@tatolab/h264\": \"^0.4.0\"\n");
+
+        let opts = registry_opts(&tmp.path().join("cache"), &mirror, Some(checkout.clone()));
+        let res = resolve_with(&root, &opts).unwrap();
+
+        let h264 = res.packages.get("@tatolab/h264").unwrap();
+        let core = res.packages.get("@tatolab/core").unwrap();
+        assert!(
+            matches!(h264.source, ResolvedSource::Path { .. }),
+            "h264: {:?}",
+            h264.source
+        );
+        assert!(
+            matches!(core.source, ResolvedSource::Path { .. }),
+            "core: {:?}",
+            core.source
+        );
+        assert_eq!(
+            h264.manifest.package.as_ref().unwrap().version.to_string(),
+            "0.4.0"
+        );
+        assert_eq!(
+            core.manifest.package.as_ref().unwrap().version.to_string(),
+            "1.0.0"
+        );
+        assert!(core.root_dir.starts_with(&checkout));
+    }
+
+    /// `ResolverOptions::from_env` reads the checkout from
+    /// [`crate::LINK_CHECKOUT_ENV`]; unset/empty ⇒ `None`. Locks the
+    /// codegen-boundary env read the build orchestrator threads through.
+    #[test]
+    #[serial_test::serial]
+    fn from_env_reads_link_checkout() {
+        // SAFETY: `#[serial]` makes the env-mutating tests mutually exclusive.
+        let prev = std::env::var_os(crate::LINK_CHECKOUT_ENV);
+        unsafe {
+            std::env::set_var(crate::LINK_CHECKOUT_ENV, "/opt/streamlib-checkout");
+        }
+        assert_eq!(
+            ResolverOptions::from_env().link_checkout,
+            Some(PathBuf::from("/opt/streamlib-checkout"))
+        );
+        unsafe {
+            std::env::set_var(crate::LINK_CHECKOUT_ENV, "");
+        }
+        assert_eq!(
+            ResolverOptions::from_env().link_checkout,
+            None,
+            "empty env must read as None"
+        );
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(crate::LINK_CHECKOUT_ENV, v),
+                None => std::env::remove_var(crate::LINK_CHECKOUT_ENV),
+            }
+        }
     }
 }

--- a/libs/streamlib-jtd-codegen/src/build_rs.rs
+++ b/libs/streamlib-jtd-codegen/src/build_rs.rs
@@ -69,10 +69,26 @@ fn run_for_rust_crate_inner() -> Result<()> {
         );
     }
 
-    // `from_env` reads STREAMLIB_REGISTRY_URL / STREAMLIB_REGISTRY_URL so a registry-cached
-    // crate resolves its schema deps (e.g. `@tatolab/escalate`) from the
-    // configured static registry — the env read lives here at the build-script
-    // boundary, not inside the pure resolver.
+    // Re-run codegen when the resolution-driving environment changes: toggling
+    // an active `streamlib link` (STREAMLIB_LINK_CHECKOUT) or the registry
+    // (STREAMLIB_REGISTRY_URL) must re-resolve schema deps rather than reuse a
+    // resolution cargo cached under the prior environment.
+    println!(
+        "cargo:rerun-if-env-changed={}",
+        streamlib_idents::LINK_CHECKOUT_ENV
+    );
+    println!(
+        "cargo:rerun-if-env-changed={}",
+        streamlib_idents::REGISTRY_URL_ENV
+    );
+
+    // `from_env` reads STREAMLIB_REGISTRY_URL so a registry-cached crate
+    // resolves its schema deps (e.g. `@tatolab/escalate`) from the configured
+    // static registry, and STREAMLIB_LINK_CHECKOUT so a package built under an
+    // active `streamlib link` resolves a dep present in the checkout's
+    // `packages/` tree from the checkout (the zero-registry dev loop). The env
+    // read lives here at the build-script boundary, not inside the pure
+    // resolver.
     let resolved = streamlib_idents::resolve_with(&crate_dir, &ResolverOptions::from_env())
         .context("Failed to resolve streamlib.yaml dependency graph")?;
 

--- a/libs/streamlib-jtd-codegen/tests/registry_resolved_codegen.rs
+++ b/libs/streamlib-jtd-codegen/tests/registry_resolved_codegen.rs
@@ -99,6 +99,7 @@ schemas:
             registry: Some(RegistryConfig {
                 base_url: format!("file://{}", mirror.display()),
             }),
+            link_checkout: None,
         },
     )
     .expect("registry resolution must succeed without a path patch");
@@ -188,6 +189,7 @@ schemas:
             registry: Some(RegistryConfig {
                 base_url: format!("file://{}", mirror.display()),
             }),
+            link_checkout: None,
         },
     )
     .expect("absent dev path patch must fall back to registry resolution");

--- a/libs/streamlib-pack/src/lib.rs
+++ b/libs/streamlib-pack/src/lib.rs
@@ -369,21 +369,29 @@ pub fn assemble_artifact(
     opts: &AssembleOptions,
     sink: &dyn PackEventSink,
 ) -> Result<AssembleOutcome> {
-    assemble_artifact_with_cargo_config(pkg_dir, target, opts, sink, &[])
+    assemble_artifact_with_cargo_config(pkg_dir, target, opts, sink, &[], None)
 }
 
-/// [`assemble_artifact`], plus extra cargo `--config <file>` TOML files merged
-/// into the Rust cdylib build. The build orchestrator passes the consumer's
-/// `streamlib link`-emitted `.cargo/config.toml` here so a staged package
-/// cdylib resolves its `streamlib*` crate deps from the linked checkout (the
-/// `[patch."<index>"]` block) instead of the registry — host + plugin built
-/// from one source tree. Empty slice ⇒ identical to [`assemble_artifact`].
+/// [`assemble_artifact`], plus the two `streamlib link` toolchain overrides the
+/// build orchestrator threads when a link is active:
+///
+/// - `cargo_config_files` — extra cargo `--config <file>` TOML files (the
+///   consumer's `streamlib link`-emitted `.cargo/config.toml`) so a staged
+///   package cdylib resolves its `streamlib*` **crate** deps from the linked
+///   checkout (the `[patch."<index>"]` block) instead of the registry.
+/// - `link_checkout` — the linked checkout path, threaded to the package's
+///   `build.rs` via [`streamlib_idents::LINK_CHECKOUT_ENV`] so its **schema**
+///   deps resolve from `<checkout>/packages/<name>` too — completing the
+///   zero-registry dev loop (host + plugin + schemas from one source tree).
+///
+/// Empty slice + `None` ⇒ identical to [`assemble_artifact`].
 pub fn assemble_artifact_with_cargo_config(
     pkg_dir: &Path,
     target: &AssembleTarget,
     opts: &AssembleOptions,
     sink: &dyn PackEventSink,
     cargo_config_files: &[PathBuf],
+    link_checkout: Option<&Path>,
 ) -> Result<AssembleOutcome> {
     let config = streamlib_cargo_build::read_minimal_project_config(pkg_dir)
         .context("Failed to read streamlib.yaml")?
@@ -524,6 +532,7 @@ pub fn assemble_artifact_with_cargo_config(
                 opts.profile,
                 sink,
                 cargo_config_files,
+                link_checkout,
             )?;
             sink.finished("rust");
             rebuilt = true;
@@ -834,6 +843,7 @@ fn cargo_build_streaming(
     profile: CargoProfile,
     sink: &dyn PackEventSink,
     cargo_config_files: &[PathBuf],
+    link_checkout: Option<&Path>,
 ) -> Result<PathBuf> {
     let mut command = Command::new("cargo");
     command.arg("build");
@@ -847,6 +857,17 @@ fn cargo_build_streaming(
     // build dir, so the injected patch wins.
     for config_file in cargo_config_files {
         command.arg("--config").arg(config_file);
+    }
+    // Thread the active `streamlib link` checkout to the package's `build.rs`
+    // schema-dep codegen, which reads it via `ResolverOptions::from_env` and
+    // resolves a dep present in `<checkout>/packages/<name>` from the checkout —
+    // the schema-dep half of the zero-registry dev loop, mirroring the cargo
+    // `[patch]` above for the crate half. `build.rs` runs as a child of this
+    // `cargo build`, so an env var set here reaches it. `None` (every
+    // non-linked / locked / distribution build) sets nothing, leaving schema
+    // resolution byte-identical to before.
+    if let Some(checkout) = link_checkout {
+        command.env(streamlib_idents::LINK_CHECKOUT_ENV, checkout);
     }
     command
         .arg("--message-format=json-render-diagnostics")
@@ -1289,6 +1310,7 @@ mod tests {
             &slpkg_opts(false),
             &(),
             &[PathBuf::from("/nonexistent/cargo-override.toml")],
+            None,
         )
         .expect("with-cargo-config assemble must succeed (config ignored, no Rust)");
 


### PR DESCRIPTION
Makes `streamlib link` redirect a package's `streamlib.yaml` SCHEMA deps (e.g. `@tatolab/core`) to the checkout's `packages/`, so the dev loop is truly zero-registry (nothing configured). Before this, link redirected the code (cargo `[patch]`) but NOT schema deps, so a linked build with `STREAMLIB_REGISTRY_URL` unset hard-failed `no registry is configured`.

Design A (link-gated, mirrors #1300's link-awareness — reviewed + approved):
- **Build-time** (`0bd4512c`): the orchestrator threads the linked checkout to the cargo child via an explicit `STREAMLIB_LINK_CHECKOUT` env on the Command (streamlib-pack); `ResolverOptions.link_checkout` (read by `build_rs`); `resolve_one` resolves a dep present in `<checkout>/packages/<name>` from the checkout, else unchanged (by-version store / #1312 path-patch fallback intact).
- **Load-time** (`2145f491`): the E2E surfaced a SECOND resolution domain — the runtime's load-time schema-registration resolves (`ProjectConfig::load` → `resolve_bare_schema_refs`, `register_manifest_processors`) also use the resolver in the host process. Threaded the module loader's already-discovered, `is_locked`-gated link into both via explicit params (`ProjectConfig::load_with_link`, plain `load` delegates `None` — 14 callers unchanged).

Guardrails: link-gated only (no-link path byte-identical); present-in-checkout-only (dep absent → by-version fallback); locked runs pass `None` (`install.rs` unchanged, reproducible); distribution/monorepo/emit unchanged. Reuses #1300's `link_marker` discovery — no parallel machinery.

**Tests:** streamlib-idents 136 + 6 new link tests + 2 load-time tests, all **mental-revert-verified**; pack/orchestrator green; fmt/clippy clean. Cargo.lock = single `serial_test` dev-dep edge.

**3090 E2E status:** the BUILD-time path is PROVEN on the 3090 (linked api-server cdylib built with `STREAMLIB_REGISTRY_URL` unset — build.rs resolved `@tatolab/core` from the checkout). The final literal-zero-registry runtime run (`curl /health` → edit marker, proving the load-time fix at runtime) was interrupted by an account monthly-spend-limit hit before completion; image `streamlib:ec3-1315` is built and ready to re-run.

Refs #1315 (Closes once the literal-zero-registry /health E2E confirms on the 3090). Unblocks #1246 EC3.