### PR TITLE
feat(runtime): transactional module registration + remove_module (#1328)

### DIFF
--- a/docs/architecture/package-development-model.md
+++ b/docs/architecture/package-development-model.md
@@ -214,8 +214,13 @@ waits on a `PackageResolutionCompletionSignal` at the *end* of the walk
 deadlock-free (no thread blocks holding the packages lock). A concrete
 version mismatch raises `SingleVersionConflict { package, existing_version,
 existing_required_by, conflicting_version, conflicting_required_by }`.
-`InFlightPlaceholderGuard` is RAII: commit on success, remove-and-publish-
-`Failed` on drop.
+`InFlightPlaceholderGuard` is RAII: flipped-to-committed by the load's
+whole-load commit on success (registration is transactional — see
+[`runtime-module-materialization.md`](runtime-module-materialization.md)),
+remove-and-publish-`Failed` on drop. A same-load re-encounter of its own
+in-flight placeholder (a diamond) skips with no wait entry;
+`Runner::remove_module` clears a removed package's committed entry so a
+later `add_module` re-resolves it.
 
 **Flat-global by IPC necessity.** The shared msgpack wire vocabulary means
 two packages on different `@tatolab/core` schema versions would emit

--- a/docs/architecture/plugin-abi.md
+++ b/docs/architecture/plugin-abi.md
@@ -431,6 +431,25 @@ version, different transitive resolution, same first-order layout"; the
 fully sound fix is the PluginAbiObject lift of the remaining raw-`Arc`
 slots, which removes the transit entirely.
 
+### Image lifetime — `dlclose` is never called
+
+A dlopen'd plugin image is retained for the **process lifetime**,
+unconditionally: on a successful load, on a load that fails after
+`register` ran, and on `Runner::remove_module`. Registered
+`&'static ProcessorVTable`s, `'static` descriptor strings handed
+across the plugin ABI, and the bridge state `install_host_services`
+wrote into the cdylib's statics all point into the mapped image —
+unmapping it would dangle them behind safe interfaces. "Unloading a
+module" therefore means **registration removal** (its processor types
+and package-owned schemas leave the host registries; the module loader's
+ledger and memo entries clear), never image unmapping. Retained images
+are recorded per (path, load) and never deduplicated by path — a
+rebuilt plugin at the same path is a new image, and dropping the
+"duplicate" handle would `dlclose` a live image out from under its
+vtables. A reload after `remove_module` dlopens the path again and
+re-runs `register`; `install_host_services` is idempotent, so
+re-installing over a retained image is safe.
+
 ### What crosses the wire
 
 - C primitives (`u32`, `i32`, `i64`, `u64`, `f32`, `f64`, `bool` as

--- a/docs/architecture/runtime-module-materialization.md
+++ b/docs/architecture/runtime-module-materialization.md
@@ -243,10 +243,24 @@ per-load staging buffer (`ModuleLoadRegistrationStaging`), and a single
 **whole-load commit** applies it after the ENTIRE transitive walk
 succeeded. The invariant: **visible ⇒ permanently committed**. A load
 that fails at any phase (manifest parse, schema read, dep walk, dlopen,
-declared-but-not-registered validation, processor construction) drops
-the staging buffer — the schema and processor registries are
-byte-equivalent to before the attempt, so a retried `add_module`
-re-runs the full resolution with zero "already registered" residue.
+declared-but-not-registered validation, processor construction, or the
+end-of-walk processor-collision gate below) drops the staging buffer —
+the schema and processor registries are byte-equivalent to before the
+attempt, so a retried `add_module` re-runs the full resolution with zero
+"already registered" residue.
+
+One end-of-walk gate runs before the commit lock is taken: a staged
+subprocess (Python / TypeScript) processor whose composed
+`processor_type` ident is **duplicated within the load** or **already
+present in the global registry** fails the whole load loud with a typed
+`AddModuleError` (`DuplicateProcessorTypeInModule` /
+`ProcessorTypeAlreadyRegistered`). Without it, a manifest declaring two
+same-named subprocess processors would stage the ident twice and the
+second `register_dynamic` would error mid-commit — after the first
+already applied — yielding a silently-incomplete load that returned Ok.
+(Rust/vtable duplicates are idempotently deduped at commit and need no
+gate.) This gate is what makes the commit itself
+infallible-by-construction.
 
 Cdylib registrations are intercepted at the host-services layer: the
 loader installs a thread-local staging sink around the plugin's
@@ -319,7 +333,13 @@ as it was — when:
   `add_processor` gets a registry miss, never a half-removed type),
   the graph is scanned, and on a hit the registrations are restored
   before the error returns. Nodes already marked pending-deletion are
-  excluded — the compiler never spawns one.
+  excluded — the compiler never spawns one. During the brief
+  unregister-scan-restore window of a *refused* in-use removal, a
+  concurrent same-type `add_processor` can transiently observe the
+  registry miss and fail with the typed `UnknownProcessorType` — a
+  recoverable `Err` (retry after the removal returns), consistent with
+  the same-process-registry multi-Runner limitation noted below, not a
+  registry corruption.
 
 The commit ledger (`LOADED_MODULE_REGISTRATION_LEDGER`, process-global,
 keyed by `@org/name`) records what each committed package registered —

--- a/docs/architecture/runtime-module-materialization.md
+++ b/docs/architecture/runtime-module-materialization.md
@@ -35,7 +35,8 @@ deployment chooses to wire (or not).
 │    resolve → ResolvedSource::Ready(dir)            (no build needed)                    │
 │            → ResolvedSource::NeedsBuild(BuildRequest)  (build required)                 │
 │    recursive transitive-dep walk (cycle-detected), identity + semver validation,       │
-│    schema + processor registration (dlopen the cdylib via STREAMLIB_PLUGIN).           │
+│    schema + processor STAGING (dlopen the cdylib via STREAMLIB_PLUGIN), then ONE        │
+│    whole-load commit into the global registries — see "Transactional registration".    │
 │                                                                                        │
 │  When NeedsBuild and an orchestrator IS wired → call materialize() (on spawn_blocking).│
 │  When NeedsBuild and NO orchestrator → fail loud (BuildRequiredButNoOrchestrator).     │
@@ -233,6 +234,103 @@ resolutions/builds before the caller awaits anything.
 - `start()` hard-errors `ModulesStillLoading { idents }` if the graph is
   run while any load is still in flight.
 
+## Transactional registration — staged commit
+
+A top-level load never writes the process-global registries mid-walk.
+Every registration the walk produces — schema bodies, processor
+descriptors + constructors/vtables, dlopen'd plugin images — lands in a
+per-load staging buffer (`ModuleLoadRegistrationStaging`), and a single
+**whole-load commit** applies it after the ENTIRE transitive walk
+succeeded. The invariant: **visible ⇒ permanently committed**. A load
+that fails at any phase (manifest parse, schema read, dep walk, dlopen,
+declared-but-not-registered validation, processor construction) drops
+the staging buffer — the schema and processor registries are
+byte-equivalent to before the attempt, so a retried `add_module`
+re-runs the full resolution with zero "already registered" residue.
+
+Cdylib registrations are intercepted at the host-services layer: the
+loader installs a thread-local staging sink around the plugin's
+`(decl.register)(...)` call (the registration prologue runs
+synchronously on the same thread), so the host's `schema_register` /
+`processor_register` callbacks stage into the active load instead of
+writing the global registries; `schema_lookup` overlays the active
+load's staged schemas so a prologue sees what its own load staged. No
+plugin ABI change — a cdylib registering outside a module load (no
+sink installed) still writes direct-to-global.
+
+The commit runs under a process-wide commit lock, in order: retained
+plugin images → schemas → processors → per-package ledger records +
+resolution-memo flips → concurrent-load completion signals. Schemas
+commit before processors so a racing reader can only ever observe
+"schemas without processors" (reads as module-not-loaded-yet, benign
+and retryable), never processors whose port schemas are missing. The
+commit itself is infallible by construction — everything fallible
+happened during the walk.
+
+The resolution memo's per-package placeholders also flip at the
+whole-load commit, which strengthens the concurrent-load contract: a
+load that skipped a package another load had in flight succeeds only
+when that owner's ENTIRE load commits. Two loads that each skip a
+package the other owns wait on each other after their own walks; that
+mutual skip is bounded by the skipped-in-flight timeout and surfaces
+as a typed error. A same-load diamond re-encounter (A→{B,C}→D) is
+recognized by owner-load-id and skipped with no wait entry — a load
+never waits on itself.
+
+### Dylib images are retained for the process lifetime
+
+`dlclose` is never called — on load failure or on `remove_module`.
+Registered processor vtables, `'static` descriptor strings handed
+across the plugin ABI, and the host-service bridge state installed by
+`install_host_services` all point into the mapped image; unmapping it
+would dangle them behind safe interfaces. Retained images are recorded
+(`RetainedPluginLibrary`: handle, path, first-loading package) and
+deliberately **never deduplicated by path** — a rebuilt plugin at the
+same path is a NEW image, and dropping the "duplicate" handle would
+dlclose a live image out from under its vtables. The cost is bounded:
+one mapped `.so` per (path, load) that actually dlopen'd, typically a
+handful per process lifetime. `install_host_services` is idempotent,
+so re-registering a retained image on a later load is safe.
+
+## `remove_module` — unload as registration removal
+
+`Runner::remove_module(ident)` unloads a committed package: its
+processor types leave the processor registry, its package-owned schemas
+(`@org/name/Type` ids) leave the schema registry, its ledger record and
+the calling Runner's resolution-memo entry are cleared so a later
+`add_module` re-resolves from scratch, and a
+`RuntimeDidUnregisterProcessorType` event publishes per removed
+processor type. The dylib image stays retained (above) — unload means
+registration removal, not image unmapping. Legacy reverse-DNS schema
+ids are deliberately left in place: they can be registered by multiple
+packages, so removal of one owner must not break the others.
+
+Removal is refused with a typed error — leaving every registry exactly
+as it was — when:
+
+- no committed load matches the ident (or the loaded version doesn't
+  satisfy the requested range; the error names what IS loaded),
+- a load of the module is still in flight (top-level or as a dependency
+  mid-walk),
+- other loaded modules still require it (removal never cascades —
+  remove the requirers first), or
+- graph processors still instantiate its types. This check is
+  TOCTOU-closing: the types are unregistered FIRST (a racing
+  `add_processor` gets a registry miss, never a half-removed type),
+  the graph is scanned, and on a hit the registrations are restored
+  before the error returns. Nodes already marked pending-deletion are
+  excluded — the compiler never spawns one.
+
+The commit ledger (`LOADED_MODULE_REGISTRATION_LEDGER`, process-global,
+keyed by `@org/name`) records what each committed package registered —
+schema ids, processor idents, dylib paths, and which loaded packages
+require it — and is the source of truth removal consumes. Note the
+registries and the ledger are process-global while the resolution memo
+is Runner-scoped: with multiple `Runner`s in one process, a removal on
+one Runner unregisters types globally but only clears the calling
+Runner's memo. Single-Runner-per-process is the supported shape today;
+the asymmetry is a documented limitation, not a designed feature.
+
 ## Build parallelism
 
 Parallelism is whatever the tools allow. Cross-package work runs
@@ -289,7 +387,10 @@ Engine ↔ plugin stay in lock-step on two complementary layers:
   (`source.rs` = `Strategy` + resolver, `build_orchestrator.rs` = the
   trait + request/result/event types, `added_module.rs` = the eager
   future, `recursive_walker.rs` = the transitive walk + materialize step,
-  `mod.rs` = the `Runner` API).
+  `staging.rs` = the per-load registration staging buffer + thread-local
+  cdylib sink + whole-load commit + plugin-image retention, `ledger.rs` =
+  the committed-load ledger `remove_module` consumes, `mod.rs` = the
+  `Runner` API incl. `remove_module`).
 - Default orchestrator: `libs/streamlib-build-orchestrator/` (calls
   `streamlib-pack` and stages into `cache/packages/<name>-<version>/`).
 - Shared assembly: `libs/streamlib-pack/` (`assemble_artifact` —

--- a/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
+++ b/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
@@ -70,6 +70,12 @@ pub fn register_schema(canonical_id: impl Into<String>, body: impl Into<Arc<str>
     guard.insert(canonical, body);
 }
 
+/// Remove a schema's registry entry by exact canonical identifier.
+/// Host-side only — used by `remove_module`; no-op when absent.
+pub(crate) fn unregister_schema(canonical_id: &str) {
+    SCHEMA_REGISTRY.write().remove(canonical_id);
+}
+
 /// Get the schema's YAML body for a canonical identifier.
 ///
 /// Accepts both unversioned (`@tatolab/core/VideoFrame`) and versioned

--- a/libs/streamlib-engine/src/core/plugin/host_services/mod.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/mod.rs
@@ -836,6 +836,17 @@ unsafe extern "C" fn host_schema_register(
             let yaml = unsafe {
                 std::str::from_utf8_unchecked(std::slice::from_raw_parts(yaml_ptr, yaml_len))
             };
+            // A cdylib registration prologue runs synchronously inside the
+            // module loader's `(decl.register)(...)` call, which installs a
+            // thread-local staging sink — registrations land in the load's
+            // staging buffer and only reach the global registry at the
+            // whole-load commit. No sink ⇒ direct-to-global (unchanged).
+            if crate::core::runtime::stage_schema_via_active_cdylib_sink(
+                canonical_id,
+                yaml,
+            ) {
+                return;
+            }
             crate::core::embedded_schemas::register_schema(canonical_id.to_string(), yaml);
         },
         (),
@@ -858,6 +869,18 @@ unsafe extern "C" fn host_schema_lookup(
                     canonical_id_len,
                 ))
             };
+            // Overlay the active load's staging buffer (if a cdylib
+            // registration is running on this thread) so a prologue sees
+            // schemas its own load staged but hasn't committed yet.
+            if let Some(staged_yaml) =
+                crate::core::runtime::lookup_schema_via_active_cdylib_sink(
+                    canonical_id,
+                )
+            {
+                let bytes = staged_yaml.as_bytes();
+                result_callback(result_userdata, bytes.as_ptr(), bytes.len());
+                return;
+            }
             match crate::core::embedded_schemas::get_embedded_schema_definition(canonical_id) {
                 Some(yaml) => {
                     let bytes = yaml.as_bytes();
@@ -972,6 +995,20 @@ unsafe extern "C" fn host_processor_register(
             // side; the cdylib is pinned via `LOADED_PLUGIN_LIBRARIES`, so
             // the pointer outlives the host's usage.
             let vtable_ref: &'static ProcessorVTable = unsafe { &*vtable };
+
+            // A cdylib registration prologue runs synchronously inside the
+            // module loader's `(decl.register)(...)` call, which installs a
+            // thread-local staging sink — the registration lands in the
+            // load's staging buffer and only reaches the global registry
+            // at the whole-load commit. No sink ⇒ direct-to-global
+            // (unchanged).
+            let descriptor = match crate::core::runtime::stage_processor_via_active_cdylib_sink(
+                descriptor, vtable_ref,
+            )
+            {
+                Ok(()) => return 0,
+                Err(descriptor) => descriptor,
+            };
 
             // Cdylib-resident registration — the vtable's function
             // pointers target the cdylib's address space, so

--- a/libs/streamlib-engine/src/core/plugin/host_services/mod.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services/mod.rs
@@ -841,10 +841,7 @@ unsafe extern "C" fn host_schema_register(
             // thread-local staging sink — registrations land in the load's
             // staging buffer and only reach the global registry at the
             // whole-load commit. No sink ⇒ direct-to-global (unchanged).
-            if crate::core::runtime::stage_schema_via_active_cdylib_sink(
-                canonical_id,
-                yaml,
-            ) {
+            if crate::core::runtime::stage_schema_via_active_cdylib_sink(canonical_id, yaml) {
                 return;
             }
             crate::core::embedded_schemas::register_schema(canonical_id.to_string(), yaml);
@@ -873,9 +870,7 @@ unsafe extern "C" fn host_schema_lookup(
             // registration is running on this thread) so a prologue sees
             // schemas its own load staged but hasn't committed yet.
             if let Some(staged_yaml) =
-                crate::core::runtime::lookup_schema_via_active_cdylib_sink(
-                    canonical_id,
-                )
+                crate::core::runtime::lookup_schema_via_active_cdylib_sink(canonical_id)
             {
                 let bytes = staged_yaml.as_bytes();
                 result_callback(result_userdata, bytes.as_ptr(), bytes.len());
@@ -1004,8 +999,7 @@ unsafe extern "C" fn host_processor_register(
             // (unchanged).
             let descriptor = match crate::core::runtime::stage_processor_via_active_cdylib_sink(
                 descriptor, vtable_ref,
-            )
-            {
+            ) {
                 Ok(()) => return 0,
                 Err(descriptor) => descriptor,
             };

--- a/libs/streamlib-engine/src/core/processors/processor_instance_factory.rs
+++ b/libs/streamlib-engine/src/core/processors/processor_instance_factory.rs
@@ -773,6 +773,16 @@ enum RegistrationKind {
     },
 }
 
+/// Everything the registry held for one processor type, removed by
+/// [`ProcessorInstanceFactory::unregister_processor_types`] and held so a
+/// refused `remove_module` can reinstate the registration exactly.
+pub(crate) struct UnregisteredProcessorTypeRecord {
+    processor_type: SchemaIdent,
+    registration: Option<RegistrationKind>,
+    port_info: Option<(Vec<PortInfo>, Vec<PortInfo>)>,
+    descriptor: Option<ProcessorDescriptor>,
+}
+
 /// Factory for compile-time registered Rust processors.
 pub struct ProcessorInstanceFactory {
     registrations: RwLock<HashMap<SchemaIdent, RegistrationKind>>,
@@ -877,6 +887,19 @@ impl ProcessorInstanceFactory {
     ) -> Result<()> {
         let type_name = descriptor.name.clone();
 
+        // Duplicate check FIRST — a duplicate must leave all four maps
+        // untouched. The previous ordering overwrote `port_info` /
+        // `schemas` / `descriptors` before checking `registrations`, so a
+        // duplicate re-registration could leave the four maps describing
+        // two different descriptors.
+        if self.registrations.read().contains_key(&type_name) {
+            tracing::debug!(
+                "Processor '{}' already registered, skipping duplicate",
+                type_name
+            );
+            return Ok(());
+        }
+
         let inputs: Vec<PortInfo> = descriptor
             .inputs
             .iter()
@@ -914,23 +937,13 @@ impl ProcessorInstanceFactory {
             .write()
             .insert(type_name.clone(), descriptor);
 
-        {
-            let mut registrations = self.registrations.write();
-            if registrations.contains_key(&type_name) {
-                tracing::debug!(
-                    "Processor '{}' already registered, skipping duplicate",
-                    type_name
-                );
-                return Ok(());
-            }
-            registrations.insert(
-                type_name.clone(),
-                RegistrationKind::VTable {
-                    vtable,
-                    cdylib_resident,
-                },
-            );
-        }
+        self.registrations.write().insert(
+            type_name.clone(),
+            RegistrationKind::VTable {
+                vtable,
+                cdylib_resident,
+            },
+        );
 
         tracing::info!("[register] new processor type registered '{}'", type_name);
 
@@ -1096,6 +1109,82 @@ impl ProcessorInstanceFactory {
         );
 
         Ok(())
+    }
+
+    /// Remove every registry entry for the given processor types across
+    /// all four maps (`registrations`, `port_info`, `descriptors`, plus a
+    /// rebuild of the port-schema universe). Returns the removed entries
+    /// so a refused `remove_module` can reinstate them exactly via
+    /// [`Self::reinstate_unregistered_processor_types`]. Idents with no
+    /// entry are skipped.
+    pub(crate) fn unregister_processor_types(
+        &self,
+        processor_type_idents: &[SchemaIdent],
+    ) -> Vec<UnregisteredProcessorTypeRecord> {
+        let mut removed = Vec::new();
+        for ident in processor_type_idents {
+            let registration = self.registrations.write().remove(ident);
+            let port_info = self.port_info.write().remove(ident);
+            let descriptor = self.descriptors.write().remove(ident);
+            if registration.is_none() && port_info.is_none() && descriptor.is_none() {
+                continue;
+            }
+            removed.push(UnregisteredProcessorTypeRecord {
+                processor_type: ident.clone(),
+                registration,
+                port_info,
+                descriptor,
+            });
+        }
+        if !removed.is_empty() {
+            self.rebuild_port_schema_universe_from_descriptors();
+        }
+        removed
+    }
+
+    /// Reinstate entries previously removed by
+    /// [`Self::unregister_processor_types`] — the restore half of
+    /// `remove_module`'s remove-then-check-then-restore in-use check.
+    pub(crate) fn reinstate_unregistered_processor_types(
+        &self,
+        unregistered: Vec<UnregisteredProcessorTypeRecord>,
+    ) {
+        if unregistered.is_empty() {
+            return;
+        }
+        for record in unregistered {
+            if let Some(registration) = record.registration {
+                self.registrations
+                    .write()
+                    .insert(record.processor_type.clone(), registration);
+            }
+            if let Some(port_info) = record.port_info {
+                self.port_info
+                    .write()
+                    .insert(record.processor_type.clone(), port_info);
+            }
+            if let Some(descriptor) = record.descriptor {
+                self.descriptors
+                    .write()
+                    .insert(record.processor_type.clone(), descriptor);
+            }
+        }
+        self.rebuild_port_schema_universe_from_descriptors();
+    }
+
+    /// Recompute the port-schema universe from the remaining descriptors.
+    /// The `schemas` set is additive-only on registration, so removal has
+    /// to rebuild it — a schema stays known only while some registered
+    /// processor still exposes it on a port.
+    fn rebuild_port_schema_universe_from_descriptors(&self) {
+        let rebuilt: HashSet<PortSchemaSpec> = self
+            .descriptors
+            .read()
+            .values()
+            .flat_map(|descriptor| descriptor.inputs.iter().chain(descriptor.outputs.iter()))
+            .map(|port| port.schema.clone())
+            .collect();
+        *self.schemas.write() = rebuilt;
     }
 
     pub fn can_create(&self, processor_type: &SchemaIdent) -> bool {

--- a/libs/streamlib-engine/src/core/pubsub/events.rs
+++ b/libs/streamlib-engine/src/core/pubsub/events.rs
@@ -319,6 +319,12 @@ pub enum RuntimeEvent {
     RuntimeDidRegisterProcessorType {
         processor_type: SchemaIdent,
     },
+    /// Emitted when a processor type is unregistered from the factory
+    /// (`remove_module`). Additive variant — appended so existing msgpack
+    /// consumers keep decoding earlier variants unchanged.
+    RuntimeDidUnregisterProcessorType {
+        processor_type: SchemaIdent,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/libs/streamlib-engine/src/core/runtime/mod.rs
+++ b/libs/streamlib-engine/src/core/runtime/mod.rs
@@ -20,7 +20,11 @@ pub use module_loader::{
     AddModuleError, AddedModule, ArtifactChecksum, BuildError, BuildEvent, BuildEventSink,
     BuildOrchestrator, BuildPolicy, BuildRequest, BuildSource, BuildStream, LoadedModule,
     ModuleLoadEvent, RemoveModuleError, SemVerRange, StagedArtifact, Strategy,
-    extract_slpkg_to_cache, host_target_triple,
+    extract_slpkg_to_cache, host_target_triple, loaded_plugin_library_count,
+};
+pub(crate) use module_loader::{
+    lookup_schema_via_active_cdylib_sink, stage_processor_via_active_cdylib_sink,
+    stage_schema_via_active_cdylib_sink,
 };
 pub use operations::{BoxFuture, RuntimeOperations};
 pub use runtime::Runner;

--- a/libs/streamlib-engine/src/core/runtime/module_loader/errors.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/errors.rs
@@ -416,26 +416,73 @@ impl From<AddModuleError> for Error {
     }
 }
 
-/// Per-failure-mode error returned by [`Runner::remove_module`].
-///
-/// Today the only variant is the milestone-deferral marker; new
-/// variants land when the hot-reload lifecycle work ships.
+/// Per-failure-mode error returned by [`Runner::remove_module`]. Every
+/// variant leaves the runtime's registries exactly as they were.
 ///
 /// [`Runner::remove_module`]: super::super::Runner::remove_module
 #[derive(Debug, thiserror::Error)]
 pub enum RemoveModuleError {
-    /// Module unload requires the hot-reload lifecycle work that's
-    /// explicitly out of scope for the current All-Dynamic Package
-    /// Loading milestone. Calling `remove_module` returns this without
-    /// altering any runtime state.
+    /// No committed load matches the requested module — either the
+    /// package was never loaded (`loaded_version: None`) or the loaded
+    /// version doesn't satisfy the requested range (`loaded_version`
+    /// names what IS loaded).
     #[error(
-        "remove_module('{module}') is not yet implemented — \
-         hot-reload lifecycle is deferred to a future milestone. \
-         The runtime currently supports load-only, runtime-lifetime \
-         module registration."
+        "remove_module('{module}'): {}. Load the module first via \
+         add_module, or request a range matching the loaded version.",
+        match loaded_version {
+            Some(v) => format!("the loaded version {v} does not satisfy the requested range"),
+            None => "no loaded module matches".to_string(),
+        }
     )]
-    HotReloadLifecycleNotYetImplemented {
+    ModuleNotLoaded {
         module: streamlib_idents::ModuleIdent,
+        loaded_version: Option<streamlib_idents::SemVer>,
+    },
+
+    /// A load of this module is still in flight — removal would race the
+    /// walk. Await the pending load (e.g. via [`Runner::await_modules`]),
+    /// then retry.
+    ///
+    /// [`Runner::await_modules`]: super::super::Runner::await_modules
+    #[error(
+        "remove_module('{module}'): a load of this module is still in \
+         flight. Await the pending load (Runner::await_modules), then \
+         retry the removal."
+    )]
+    LoadInFlight {
+        module: streamlib_idents::ModuleIdent,
+    },
+
+    /// Other loaded modules still declare this module as a dependency.
+    /// Removal never cascades — remove the requirers first, then retry.
+    #[error(
+        "remove_module('{module}'): still required by loaded module(s) {}. \
+         Removal never cascades — remove_module each requirer first, then \
+         retry.",
+        requirers.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(", ")
+    )]
+    RequiredByLoadedModules {
+        module: streamlib_idents::ModuleIdent,
+        requirers: Vec<streamlib_idents::PackageRef>,
+    },
+
+    /// Graph nodes still instantiate this module's processor types.
+    /// Remove those processors from the graph
+    /// ([`RuntimeOperations::remove_processor`]), then retry.
+    ///
+    /// [`RuntimeOperations::remove_processor`]: crate::core::runtime::RuntimeOperations::remove_processor
+    #[error(
+        "remove_module('{module}'): {} graph processor(s) still use its \
+         processor type(s): [{}] (types: [{}]). Remove those processors \
+         from the graph first, then retry.",
+        processor_ids.len(),
+        processor_ids.iter().map(|id| id.to_string()).collect::<Vec<_>>().join(", "),
+        processor_types.iter().map(|t| t.to_string()).collect::<Vec<_>>().join(", ")
+    )]
+    ProcessorsInUse {
+        module: streamlib_idents::ModuleIdent,
+        processor_ids: Vec<crate::core::graph::ProcessorUniqueId>,
+        processor_types: Vec<crate::core::descriptors::SchemaIdent>,
     },
 }
 

--- a/libs/streamlib-engine/src/core/runtime/module_loader/errors.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/errors.rs
@@ -405,6 +405,39 @@ pub enum AddModuleError {
         expected: String,
         actual: String,
     },
+
+    /// The manifest for `package` declares two subprocess (Python /
+    /// TypeScript) processors that compose the SAME structured
+    /// `processor_type` ident — a duplicate short name within one
+    /// `processors:` list. Refused at end-of-walk, before any staged
+    /// registration is committed, so the load leaves zero partial state.
+    /// Give each processor a distinct PascalCase short name.
+    #[error(
+        "Manifest for '{package}' declares processor type '{processor_type}' \
+         more than once (two subprocess processors compose the same ident). \
+         Give each processor a distinct PascalCase short name."
+    )]
+    DuplicateProcessorTypeInModule {
+        package: streamlib_idents::PackageRef,
+        processor_type: crate::core::descriptors::SchemaIdent,
+    },
+
+    /// A subprocess (Python / TypeScript) processor `package` declares
+    /// composes a `processor_type` ident that is ALREADY present in the
+    /// global processor registry (registered by other code — e.g. a
+    /// direct `register_dynamic`, or a prior load of the same ident that
+    /// wasn't removed). Refused at end-of-walk, before any staged
+    /// registration is committed, so the load leaves zero partial state.
+    /// Remove the existing registration first, or rename the processor.
+    #[error(
+        "Processor type '{processor_type}' declared by '{package}' is already \
+         registered in the runtime. Remove the existing registration \
+         (remove_module) or give the processor a distinct short name."
+    )]
+    ProcessorTypeAlreadyRegistered {
+        package: streamlib_idents::PackageRef,
+        processor_type: crate::core::descriptors::SchemaIdent,
+    },
 }
 
 impl From<AddModuleError> for Error {

--- a/libs/streamlib-engine/src/core/runtime/module_loader/ledger.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/ledger.rs
@@ -1,0 +1,94 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use parking_lot::Mutex;
+
+/// What one committed package registered — everything `remove_module`
+/// needs to unregister it and to refuse an unsafe removal.
+pub(crate) struct LoadedModuleRegistrationRecord {
+    /// The concrete version the package committed at.
+    pub version: streamlib_idents::SemVer,
+    /// Canonical schema ids this package registered.
+    pub schema_ids: Vec<String>,
+    /// Structured processor idents this package registered.
+    pub processor_idents: Vec<crate::core::descriptors::SchemaIdent>,
+    /// Dylib images this package's load retained.
+    pub dylib_paths: Vec<std::path::PathBuf>,
+    /// Loaded packages that declared this package as a dependency.
+    pub required_by: Vec<streamlib_idents::PackageRef>,
+}
+
+/// Process-global registry of committed module loads, keyed by
+/// `@org/name`. Written at commit under the module-registry commit lock;
+/// read + pruned by `remove_module` under the same lock.
+static LOADED_MODULE_REGISTRATION_LEDGER: LazyLock<
+    Mutex<HashMap<streamlib_idents::PackageRef, LoadedModuleRegistrationRecord>>,
+> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Insert (or replace) a package's committed-load record.
+pub(super) fn insert_loaded_module_registration_record(
+    package: streamlib_idents::PackageRef,
+    record: LoadedModuleRegistrationRecord,
+) {
+    LOADED_MODULE_REGISTRATION_LEDGER.lock().insert(package, record);
+}
+
+/// Append a requirer edge onto an already-committed package's record.
+pub(super) fn append_requirer_to_loaded_module_record(
+    dependency_package: &streamlib_idents::PackageRef,
+    requirer_package: streamlib_idents::PackageRef,
+) {
+    let mut ledger = LOADED_MODULE_REGISTRATION_LEDGER.lock();
+    match ledger.get_mut(dependency_package) {
+        Some(record) => {
+            if !record.required_by.contains(&requirer_package) {
+                record.required_by.push(requirer_package);
+            }
+        }
+        None => {
+            // The dependency was removed between this load's gate skip and
+            // its commit — the removal raced the walk. The requirer's graph
+            // proceeds without the dependency's registrations; loud so the
+            // operator sees the race rather than a later silent miss.
+            tracing::warn!(
+                dependency = %dependency_package,
+                requirer = %requirer_package,
+                "committed-dependency requirer edge targets a package that \
+                 was removed mid-walk; the requirer may be missing the \
+                 dependency's registrations — re-add the dependency",
+            );
+        }
+    }
+}
+
+/// Run `f` over the package's record, if committed.
+pub(super) fn with_loaded_module_registration_record<R>(
+    package: &streamlib_idents::PackageRef,
+    f: impl FnOnce(&LoadedModuleRegistrationRecord) -> R,
+) -> Option<R> {
+    LOADED_MODULE_REGISTRATION_LEDGER.lock().get(package).map(f)
+}
+
+/// Remove a package's record and prune it from every other record's
+/// `required_by`. Returns the removed record.
+pub(super) fn remove_loaded_module_registration_record(
+    package: &streamlib_idents::PackageRef,
+) -> Option<LoadedModuleRegistrationRecord> {
+    let mut ledger = LOADED_MODULE_REGISTRATION_LEDGER.lock();
+    let removed = ledger.remove(package);
+    if removed.is_some() {
+        for record in ledger.values_mut() {
+            record.required_by.retain(|requirer| requirer != package);
+        }
+    }
+    removed
+}
+
+/// Test observability: the set of committed package refs.
+#[cfg(test)]
+pub(crate) fn loaded_module_registration_ledger_packages() -> Vec<streamlib_idents::PackageRef> {
+    LOADED_MODULE_REGISTRATION_LEDGER.lock().keys().cloned().collect()
+}

--- a/libs/streamlib-engine/src/core/runtime/module_loader/ledger.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/ledger.rs
@@ -33,7 +33,9 @@ pub(super) fn insert_loaded_module_registration_record(
     package: streamlib_idents::PackageRef,
     record: LoadedModuleRegistrationRecord,
 ) {
-    LOADED_MODULE_REGISTRATION_LEDGER.lock().insert(package, record);
+    LOADED_MODULE_REGISTRATION_LEDGER
+        .lock()
+        .insert(package, record);
 }
 
 /// Append a requirer edge onto an already-committed package's record.
@@ -90,5 +92,9 @@ pub(super) fn remove_loaded_module_registration_record(
 /// Test observability: the set of committed package refs.
 #[cfg(test)]
 pub(crate) fn loaded_module_registration_ledger_packages() -> Vec<streamlib_idents::PackageRef> {
-    LOADED_MODULE_REGISTRATION_LEDGER.lock().keys().cloned().collect()
+    LOADED_MODULE_REGISTRATION_LEDGER
+        .lock()
+        .keys()
+        .cloned()
+        .collect()
 }

--- a/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -674,6 +674,7 @@ impl Runner {
             version = %record.version,
             processors = record.processor_idents.len(),
             schemas = record.schema_ids.len(),
+            retained_dylib_images = record.dylib_paths.len(),
             "remove_module: unloaded (dylib images retained for the \
              process lifetime)",
         );

--- a/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -235,6 +235,14 @@ fn run_module_load(
         }
         Ok(())
     });
+    // Fold the end-of-walk Dynamic-processor collision gate into the
+    // result BEFORE the commit lock: a manifest declaring two same-named
+    // subprocess processors (or one colliding with an already-registered
+    // ident) fails loud here with a typed error, so the whole load rolls
+    // back with zero residue instead of committing a partial set. This is
+    // what makes the commit itself infallible-by-construction.
+    let result =
+        result.and_then(|()| staging.validate_no_dynamic_processor_collisions());
     match result {
         Ok(()) => {
             // Whole-load commit: apply staged registrations, write the

--- a/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -12,6 +12,16 @@
 //! which lives outside the engine. Loads run eagerly on the runtime's
 //! existing tokio handle and surface as [`AddedModule`] futures.
 //!
+//! Registration is transactional per top-level load: the walk stages
+//! every schema / processor / dylib registration into a per-load
+//! [`staging::ModuleLoadRegistrationStaging`] buffer, and a single
+//! whole-load commit applies it under the module-registry commit lock.
+//! A failed load drops the staging — the global registries are
+//! byte-equivalent to before the attempt (dylib images are the one
+//! deliberate exception: retained for the process lifetime, never
+//! `dlclose`d). [`Runner::remove_module`] unloads a committed package
+//! via the [`ledger`].
+//!
 //! Files in this directory:
 //!
 //! - [`errors`] — `AddModuleError`, `RemoveModuleError` typed enums.
@@ -22,10 +32,16 @@
 //!   [`ModuleLoadEvent`].
 //! - [`recursive_walker`] — recursive transitive-dep walk, cycle
 //!   detection, per-dep strategy derivation, and the materialize step.
-//! - [`processor_registration`] — manifest-driven processor registration.
-//! - [`schema_registration`] — manifest-driven schema registration.
+//! - [`processor_registration`] — manifest-driven processor staging.
+//! - [`schema_registration`] — manifest-driven schema staging.
+//! - [`staging`] — per-load registration staging buffer, the
+//!   thread-local cdylib registration sink, the commit, and the
+//!   process-lifetime plugin-image retention.
+//! - [`ledger`] — process-global record of committed loads consumed by
+//!   [`Runner::remove_module`].
 //! - [`slpkg`] — `.slpkg` archive extraction.
 //!
+//! [`Runner::remove_module`]: super::Runner::remove_module
 //! [`Runner::add_module`]: super::Runner::add_module
 //! [`Runner::add_module_with`]: super::Runner::add_module_with
 //! [`Runner::await_modules`]: super::Runner::await_modules
@@ -43,12 +59,14 @@ use crate::iceoryx2::Iceoryx2Node;
 mod added_module;
 mod build_orchestrator;
 mod errors;
+mod ledger;
 mod locked;
 mod processor_registration;
 mod recursive_walker;
 mod schema_registration;
 mod slpkg;
 mod source;
+mod staging;
 
 #[cfg(test)]
 mod tests;
@@ -64,6 +82,11 @@ pub use processor_registration::host_target_triple;
 pub(crate) use recursive_walker::ResolutionMemo;
 pub use slpkg::extract_slpkg_to_cache;
 pub use source::{ArtifactChecksum, SemVerRange, Strategy};
+pub use staging::loaded_plugin_library_count;
+pub(crate) use staging::{
+    lookup_schema_via_active_cdylib_sink, stage_processor_via_active_cdylib_sink,
+    stage_schema_via_active_cdylib_sink,
+};
 
 use added_module::MODULE_EVENT_CHANNEL_CAPACITY;
 
@@ -114,8 +137,13 @@ static NEXT_MODULE_LOAD_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::At
 
 /// The blocking body of a single module load. Runs on `spawn_blocking`:
 /// it resolves the strategy, materializes via the orchestrator when a
-/// build is required (blocking), recursively loads transitive deps, and
-/// registers schemas + processors. Emits terminal events on `events`.
+/// build is required (blocking), recursively walks transitive deps
+/// staging every registration, and — only after the ENTIRE walk
+/// succeeded — commits the staged registrations to the global
+/// registries in one step. A failure at any point drops the staging:
+/// the registries are byte-equivalent to before the attempt (dylib
+/// images are retained for the process lifetime). Emits terminal events
+/// on `events`.
 fn run_module_load(
     iceoryx2_node: Iceoryx2Node,
     orchestrator: Option<Arc<dyn BuildOrchestrator>>,
@@ -134,9 +162,6 @@ fn run_module_load(
         ident: module.clone(),
         events: events.clone(),
     };
-    let mut seen: HashSet<streamlib_idents::PackageRef> = HashSet::new();
-    let mut path: Vec<streamlib_idents::PackageRef> = Vec::new();
-    let mut skipped_in_flight: Vec<recursive_walker::SkippedInFlightDependency> = Vec::new();
 
     // Discover an active `streamlib link` once per top-level load, from the
     // process working directory (the consumer's run dir, where `streamlib link`
@@ -155,31 +180,39 @@ fn run_module_load(
         }
     };
 
-    let result = recursive_walker::add_module_recursively(
-        &iceoryx2_node,
-        orchestrator.as_ref(),
-        &sink,
-        module.clone(),
-        strategy,
-        &mut seen,
-        &mut path,
-        &resolution_memo,
+    let staging = staging::ModuleLoadRegistrationStaging::new();
+    let mut walk_context = recursive_walker::ModuleLoadWalkContext {
+        iceoryx2_node: &iceoryx2_node,
+        orchestrator: orchestrator.as_ref(),
+        sink: &sink,
+        resolution_memo: &resolution_memo,
         load_id,
-        &mut skipped_in_flight,
-        locked.as_deref(),
-        link.as_ref(),
-    );
+        locked: locked.as_deref(),
+        link: link.as_ref(),
+        staging: &staging,
+        seen: HashSet::new(),
+        path: Vec::new(),
+        skipped_in_flight: Vec::new(),
+        armed_placeholder_guards: Vec::new(),
+        committed_dependency_requirer_edges: Vec::new(),
+    };
+
+    let result =
+        recursive_walker::add_module_recursively(&mut walk_context, module.clone(), strategy);
     // End-of-walk verification: this walk skipped some packages because a
     // CONCURRENT load had them in flight at the same version. Before
-    // reporting success, verify each owner actually committed — an owner
-    // that failed (or wedged) means this load's graph is missing a
-    // registration, and Ok would be a false success. Mid-walk nobody ever
-    // blocks; these waits depend only on other loads' per-package commits,
-    // which flip as their subtrees unwind without needing this waiter —
-    // structurally deadlock-free.
+    // committing, verify each owner actually committed — an owner that
+    // failed (or wedged) means this load's graph is missing a
+    // registration, and Ok would be a false success. Same-load diamond
+    // re-encounters never land here (the gate's SkipOwnedByThisLoad arm),
+    // so a load never waits on itself. Two loads that each skipped a
+    // package the OTHER owns wait on each other here — that mutual skip
+    // is bounded by the timeout and surfaces as the typed
+    // `ConcurrentLoadOfSkippedDependencyTimedOut`. The wait runs BEFORE
+    // the commit lock is taken — commit never blocks on another load.
     let result = result.and_then(|()| {
         use recursive_walker::{ConcurrentPackageLoadOutcome, SKIPPED_IN_FLIGHT_WAIT_TIMEOUT};
-        for skipped in skipped_in_flight {
+        for skipped in std::mem::take(&mut walk_context.skipped_in_flight) {
             match skipped
                 .completion_signal
                 .wait_for_outcome(SKIPPED_IN_FLIGHT_WAIT_TIMEOUT)
@@ -204,6 +237,14 @@ fn run_module_load(
     });
     match result {
         Ok(()) => {
+            // Whole-load commit: apply staged registrations, write the
+            // ledger, flip the memo placeholders, publish `Committed`.
+            staging::commit_module_load_registrations(
+                &staging,
+                walk_context.armed_placeholder_guards,
+                walk_context.committed_dependency_requirer_edges,
+                &resolution_memo,
+            );
             let _ = events.send(ModuleLoadEvent::Completed {
                 ident: module.clone(),
                 took: start.elapsed(),
@@ -211,6 +252,11 @@ fn run_module_load(
             Ok(LoadedModule { ident: module })
         }
         Err(e) => {
+            // Rollback = drop: the armed placeholder guards abandon their
+            // memo placeholders (publishing `Failed` to concurrent
+            // skippers) and the staging buffer discards schemas +
+            // processors while retaining dylib images.
+            drop(walk_context);
             let _ = events.send(ModuleLoadEvent::Failed {
                 ident: module.clone(),
                 error: e.to_string(),
@@ -481,18 +527,157 @@ impl Runner {
         }
     }
 
-    /// Unload a previously-added module.
+    /// Unload a previously-added module: remove its processor and schema
+    /// registrations from the global registries, drop its ledger record,
+    /// and clear its resolution-memo entry so a later [`Runner::add_module`]
+    /// re-resolves it from scratch. The module's dylib images stay
+    /// retained for the process lifetime (`dlclose` is never called) —
+    /// unload means registration removal, not image unmapping.
     ///
-    /// **Not yet implemented** — module-level unload requires the
-    /// hot-reload lifecycle work that's out of scope for the current
-    /// All-Dynamic Package Loading milestone. Returns
-    /// [`RemoveModuleError::HotReloadLifecycleNotYetImplemented`]
-    /// without altering runtime state.
+    /// Typed refusals ([`RemoveModuleError`]) leave every registry
+    /// exactly as it was: the module isn't loaded (or the loaded version
+    /// doesn't satisfy the requested range), a load of it is still in
+    /// flight, other loaded modules still require it (removal never
+    /// cascades), or graph processors still instantiate its types.
+    ///
+    /// [`Runner::add_module`]: Self::add_module
+    #[tracing::instrument(skip(self), fields(module = %module))]
     pub fn remove_module(
         &self,
         module: streamlib_idents::ModuleIdent,
     ) -> std::result::Result<(), RemoveModuleError> {
-        Err(RemoveModuleError::HotReloadLifecycleNotYetImplemented { module })
+        let pkg_ref = module.package_ref();
+
+        // Serialize against module-load commits and other removals. Every
+        // step below is brief; nothing here waits on another load.
+        let _commit_guard = staging::MODULE_REGISTRY_COMMIT_LOCK.lock();
+
+        // (1) A load of this module still in flight — as a top-level load
+        // on this Runner, or as a dependency mid-walk on any load sharing
+        // this Runner's resolution memo.
+        if self.loading_modules.lock().contains_key(&pkg_ref)
+            || self.resolution_memo.is_package_in_flight(&pkg_ref)
+        {
+            return Err(RemoveModuleError::LoadInFlight { module });
+        }
+
+        // Ledger lookup + version-range check.
+        let record_summary = ledger::with_loaded_module_registration_record(&pkg_ref, |record| {
+            (
+                record.version,
+                record.required_by.clone(),
+                record.processor_idents.clone(),
+            )
+        });
+        let Some((loaded_version, required_by, processor_idents)) = record_summary else {
+            return Err(RemoveModuleError::ModuleNotLoaded {
+                module,
+                loaded_version: None,
+            });
+        };
+        if !module.version.matches(loaded_version) {
+            return Err(RemoveModuleError::ModuleNotLoaded {
+                module,
+                loaded_version: Some(loaded_version),
+            });
+        }
+
+        // (2) Other loaded modules still require this one — no cascade.
+        if !required_by.is_empty() {
+            return Err(RemoveModuleError::RequiredByLoadedModules {
+                module,
+                requirers: required_by,
+            });
+        }
+
+        // (3) In-use check, TOCTOU-closing shape: FIRST unregister the
+        // module's processor types (so a racing `add_processor` gets a
+        // registry miss instead of instantiating a half-removed type),
+        // THEN scan this Runner's graph; if any node still carries one of
+        // the removed types, RESTORE the registrations and refuse. Nodes
+        // marked pending-deletion are excluded — the graph has committed
+        // to removing them and the compiler never spawns one.
+        let unregistered = crate::core::processors::PROCESSOR_REGISTRY
+            .unregister_processor_types(&processor_idents);
+        let removed_type_set: std::collections::HashSet<&crate::core::descriptors::SchemaIdent> =
+            processor_idents.iter().collect();
+        let processors_in_use: Vec<(
+            crate::core::graph::ProcessorUniqueId,
+            crate::core::descriptors::SchemaIdent,
+        )> = self.compiler.scope(|graph, _tx| {
+            use crate::core::graph::GraphNodeWithComponents;
+            graph
+                .traversal()
+                .v(())
+                .iter()
+                .filter(|node| {
+                    removed_type_set.contains(&node.processor_type)
+                        && !node.has::<crate::core::graph::PendingDeletionComponent>()
+                })
+                .map(|node| (node.id.clone(), node.processor_type.clone()))
+                .collect()
+        });
+        if !processors_in_use.is_empty() {
+            crate::core::processors::PROCESSOR_REGISTRY
+                .reinstate_unregistered_processor_types(unregistered);
+            let (processor_ids, mut processor_types): (Vec<_>, Vec<_>) =
+                processors_in_use.into_iter().unzip();
+            processor_types.sort_by_key(|t| t.to_string());
+            processor_types.dedup();
+            return Err(RemoveModuleError::ProcessorsInUse {
+                module,
+                processor_ids,
+                processor_types,
+            });
+        }
+
+        // Point of no return — the ledger record is consumed below and
+        // every remaining step is infallible.
+        let record = ledger::remove_loaded_module_registration_record(&pkg_ref)
+            .expect("ledger record present above; commit lock held throughout");
+
+        // (4) Schema removal. Legacy reverse-DNS ids (no `@org/name/`
+        // prefix) can be registered by multiple packages, so they are
+        // deliberately left in place; package-owned `@org/name/Type` ids
+        // are removed.
+        for schema_id in &record.schema_ids {
+            if schema_id.starts_with('@') {
+                crate::core::embedded_schemas::unregister_schema(schema_id);
+            } else {
+                tracing::debug!(
+                    schema = %schema_id,
+                    module = %pkg_ref,
+                    "remove_module: leaving legacy reverse-DNS schema id in \
+                     place (potentially shared across packages)",
+                );
+            }
+        }
+
+        // (5) Clear this Runner's resolution-memo entry so a later
+        // add_module re-resolves the package from scratch.
+        self.resolution_memo.remove_committed_resolution(&pkg_ref);
+
+        // (6) Announce each removed processor type.
+        for processor_type in &record.processor_idents {
+            crate::core::pubsub::PUBSUB.publish(
+                crate::core::pubsub::topics::RUNTIME_GLOBAL,
+                &crate::core::pubsub::Event::RuntimeGlobal(
+                    crate::core::pubsub::RuntimeEvent::RuntimeDidUnregisterProcessorType {
+                        processor_type: processor_type.clone(),
+                    },
+                ),
+            );
+        }
+
+        tracing::info!(
+            module = %pkg_ref,
+            version = %record.version,
+            processors = record.processor_idents.len(),
+            schemas = record.schema_ids.len(),
+            "remove_module: unloaded (dylib images retained for the \
+             process lifetime)",
+        );
+        Ok(())
     }
 
     /// The set of modules whose loads have not yet settled. Used by

--- a/libs/streamlib-engine/src/core/runtime/module_loader/processor_registration.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/processor_registration.rs
@@ -4,13 +4,6 @@
 use crate::core::{Error, Result};
 use crate::iceoryx2::Iceoryx2Node;
 
-/// Keeps loaded dylib plugin libraries alive for the process lifetime.
-///
-/// When a Rust dylib plugin is loaded, the `Library` handle must
-/// remain alive so that the registered processor vtables stay valid.
-static LOADED_PLUGIN_LIBRARIES: std::sync::LazyLock<parking_lot::Mutex<Vec<libloading::Library>>> =
-    std::sync::LazyLock::new(|| parking_lot::Mutex::new(Vec::new()));
-
 /// The rustc target triple this engine was compiled for, captured at
 /// build time via `build.rs`. Same string Cargo prints for `--target`
 /// (e.g. `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`). Used to
@@ -155,14 +148,17 @@ fn read_plugin_build_identity(decl: &streamlib_plugin_abi::PluginDeclaration) ->
     String::from_utf8_lossy(bytes).into_owned()
 }
 
-/// Register this package's processors with the global processor
-/// registry. Non-recursive — the caller is responsible for having
-/// walked any transitive deps first.
+/// Stage this package's processors into the load's registration staging
+/// buffer — applied to the global processor registry only at the
+/// whole-load commit. Non-recursive — the caller is responsible for
+/// having walked any transitive deps first.
 pub(super) fn register_manifest_processors(
     iceoryx2_node: &Iceoryx2Node,
     project_path: &std::path::Path,
     config: &crate::core::config::ProjectConfig,
     link_checkout: Option<&std::path::Path>,
+    staging: &std::sync::Arc<super::staging::ModuleLoadRegistrationStaging>,
+    owner_package: &streamlib_idents::PackageRef,
 ) -> Result<()> {
     use super::schema_registration::resolve_config_schema_canonical_id;
     use crate::core::ProcessorDescriptor;
@@ -370,31 +366,46 @@ pub(super) fn register_manifest_processors(
                         crate::core::plugin::host_services::runtime_facing::host_services_for_self(
                             iceoryx2_node,
                         );
-                    // SAFETY: `host_services` outlives the call;
-                    // the cdylib's callback returns before this
-                    // function frame is dropped.
-                    unsafe {
-                        (decl.register)(&host_services as *const _ as *const ::std::ffi::c_void);
+                    // The cdylib's registration prologue runs synchronously
+                    // on this thread and lands in the host's
+                    // `host_schema_register` / `host_processor_register`
+                    // callbacks — install the thread-local staging sink
+                    // around the call so those registrations stage into
+                    // this load instead of writing the global registries.
+                    // The RAII guard clears the sink on every exit.
+                    {
+                        let _cdylib_registration_sink_guard =
+                            super::staging::CdylibRegistrationSinkGuard::install(
+                                std::sync::Arc::clone(staging),
+                                owner_package.clone(),
+                            );
+                        // SAFETY: `host_services` outlives the call;
+                        // the cdylib's callback returns before this
+                        // function frame is dropped.
+                        unsafe {
+                            (decl.register)(
+                                &host_services as *const _ as *const ::std::ffi::c_void,
+                            );
+                        }
                     }
 
-                    // Keep the library alive for the process lifetime
-                    LOADED_PLUGIN_LIBRARIES.lock().push(lib);
+                    // Stage the image; retained for the process lifetime
+                    // whether this load commits or fails.
+                    staging.stage_plugin_library(lib, dylib_path.clone(), owner_package.clone());
 
                     rust_dylib_loaded = true;
                     tracing::info!(
-                        "Rust dylib plugin loaded and registered: {}",
+                        "Rust dylib plugin loaded and registrations staged: {}",
                         dylib_path.display()
                     );
                 }
 
                 // Validate the processor was registered by the dylib —
                 // compare by structured `SchemaIdent`, not bare PascalCase
-                // (two packages can declare the same short name).
-                let registered = crate::core::processors::PROCESSOR_REGISTRY
-                    .list_registered()
-                    .iter()
-                    .any(|desc| desc.name == proc_schema_ident);
-                if !registered {
+                // (two packages can declare the same short name). Reads the
+                // load's staging buffer: mid-walk, nothing has landed in
+                // the global registry yet.
+                if !staging.contains_staged_processor(&proc_schema_ident) {
                     return Err(Error::Configuration(format!(
                         "Processor '{}' declared in streamlib.yaml but not \
                          registered by the dylib. Ensure export_plugin!() \
@@ -526,19 +537,19 @@ pub(super) fn register_manifest_processors(
             _ => unreachable!(),
         };
 
-        crate::core::processors::PROCESSOR_REGISTRY.register_dynamic(descriptor, constructor)?;
-
-        tracing::info!(
-            "Registered processor '{}' ({:?})",
-            proc_schema.name,
-            runtime
+        staging.stage_processor(
+            descriptor,
+            super::staging::StagedProcessorRegistrationKind::Dynamic { constructor },
+            owner_package.clone(),
         );
+
+        tracing::info!("Staged processor '{}' ({:?})", proc_schema.name, runtime);
 
         registered_count += 1;
     }
 
     tracing::info!(
-        "Loaded {} processor(s) from {}",
+        "Staged {} processor(s) from {}",
         registered_count,
         project_path.display()
     );

--- a/libs/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
@@ -89,6 +89,12 @@ impl PackageResolutionCompletionSignal {
         self.outcome_published.notify_all();
     }
 
+    /// Publish [`ConcurrentPackageLoadOutcome::Committed`]. Called by the
+    /// whole-load commit after the ledger records are written.
+    pub(super) fn publish_committed(&self) {
+        self.publish(ConcurrentPackageLoadOutcome::Committed);
+    }
+
     /// Block until the outcome is published or `timeout` elapses.
     /// `None` means timeout — the caller surfaces a typed error.
     pub(crate) fn wait_for_outcome(
@@ -138,6 +144,11 @@ pub(super) enum SingleVersionGateOutcome {
     ProceedAsFirstResolution,
     /// Already committed at the same version — requirer recorded; skip.
     SkipAlreadyCommittedSameVersion,
+    /// In flight on THIS load (a same-load diamond re-encounter) —
+    /// requirer recorded; skip with no wait entry. Waiting on the owner
+    /// would be waiting on ourselves: this load's placeholders only flip
+    /// at its own whole-load commit, which runs after the wait phase.
+    SkipOwnedByThisLoad,
     /// In flight on a concurrent load at the same version — requirer
     /// recorded; skip locally and verify the owner's outcome at the end
     /// of this walk via the carried signal.
@@ -243,6 +254,16 @@ impl ResolutionMemo {
                 owner_load_id,
                 ..
             } => {
+                if *owner_load_id == load_id {
+                    tracing::debug!(
+                        package = %pkg_ref,
+                        version = %on_disk_version,
+                        "single-version gate: same version in flight on THIS \
+                         load (diamond re-encounter) — skipping with no wait \
+                         entry",
+                    );
+                    return Ok(SingleVersionGateOutcome::SkipOwnedByThisLoad);
+                }
                 tracing::debug!(
                     package = %pkg_ref,
                     version = %on_disk_version,
@@ -258,34 +279,59 @@ impl ResolutionMemo {
         }
     }
 
-    /// Flip this package's in-flight placeholder to a committed record
-    /// and publish [`ConcurrentPackageLoadOutcome::Committed`]. Requirers
-    /// accumulated on the placeholder while in flight are preserved.
-    fn commit_in_flight_resolution(&self, pkg_ref: &streamlib_idents::PackageRef) {
-        let signal = {
-            let mut packages = self.packages.lock();
-            match packages.remove(pkg_ref) {
-                Some(PackageResolutionState::InFlightPlaceholder {
-                    record,
-                    completion_signal,
-                    ..
-                }) => {
-                    packages.insert(
-                        pkg_ref.clone(),
-                        PackageResolutionState::Committed { record },
-                    );
-                    Some(completion_signal)
-                }
-                // Defensive: only the owning walk commits its placeholder.
-                Some(other) => {
-                    packages.insert(pkg_ref.clone(), other);
-                    None
-                }
-                None => None,
+    /// Flip this package's in-flight placeholder to a committed record.
+    /// Returns the record (final requirer list, read under the same lock
+    /// as the flip) plus the completion signal for the caller to publish
+    /// AFTER its ledger writes land — publishing is deliberately not done
+    /// here so a waiter never observes `Committed` before the ledger.
+    /// Requirers accumulated on the placeholder while in flight are
+    /// preserved on the committed record.
+    pub(super) fn flip_in_flight_placeholder_to_committed(
+        &self,
+        pkg_ref: &streamlib_idents::PackageRef,
+    ) -> Option<(
+        ResolvedPackageRecord,
+        Arc<PackageResolutionCompletionSignal>,
+    )> {
+        let mut packages = self.packages.lock();
+        match packages.remove(pkg_ref) {
+            Some(PackageResolutionState::InFlightPlaceholder {
+                record,
+                completion_signal,
+                ..
+            }) => {
+                let record_for_caller = record.clone();
+                packages.insert(pkg_ref.clone(), PackageResolutionState::Committed { record });
+                Some((record_for_caller, completion_signal))
             }
-        };
-        if let Some(signal) = signal {
-            signal.publish(ConcurrentPackageLoadOutcome::Committed);
+            // Defensive: only the owning load flips its placeholder.
+            Some(other) => {
+                packages.insert(pkg_ref.clone(), other);
+                None
+            }
+            None => None,
+        }
+    }
+
+    /// Whether the package is currently mid-resolution on some load.
+    pub(crate) fn is_package_in_flight(&self, pkg_ref: &streamlib_idents::PackageRef) -> bool {
+        matches!(
+            self.packages.lock().get(pkg_ref),
+            Some(PackageResolutionState::InFlightPlaceholder { .. })
+        )
+    }
+
+    /// Remove a package's committed resolution so a later `add_module`
+    /// re-resolves it from scratch. Used by `remove_module`; in-flight
+    /// placeholders are never removed here (removal refuses while a load
+    /// is in flight).
+    pub(crate) fn remove_committed_resolution(&self, pkg_ref: &streamlib_idents::PackageRef) {
+        let mut packages = self.packages.lock();
+        if matches!(
+            packages.get(pkg_ref),
+            Some(PackageResolutionState::Committed { .. })
+        ) {
+            packages.remove(pkg_ref);
         }
     }
 
@@ -345,13 +391,21 @@ impl ResolutionMemo {
             _ => None,
         }
     }
+
+    /// Test observability: every package ref with any resolution state.
+    #[cfg(test)]
+    pub(crate) fn resolved_package_refs(&self) -> Vec<streamlib_idents::PackageRef> {
+        self.packages.lock().keys().cloned().collect()
+    }
 }
 
 /// RAII cleanup for an armed in-flight placeholder: any failure exit
-/// between the gate and the commit drops this guard, which removes the
-/// placeholder and publishes `Failed` — the memo can never wedge in a
-/// permanent "resolving" state, and concurrent skippers fail loudly.
-struct InFlightPlaceholderGuard<'memo> {
+/// between the gate and the whole-load commit drops this guard, which
+/// removes the placeholder and publishes `Failed` — the memo can never
+/// wedge in a permanent "resolving" state, and concurrent skippers fail
+/// loudly. Guards accumulate on the walk context and are consumed by the
+/// whole-load commit, which flips each placeholder then disarms.
+pub(super) struct InFlightPlaceholderGuard<'memo> {
     resolution_memo: &'memo ResolutionMemo,
     package: Option<streamlib_idents::PackageRef>,
 }
@@ -364,10 +418,18 @@ impl<'memo> InFlightPlaceholderGuard<'memo> {
         }
     }
 
-    fn commit(mut self) {
-        if let Some(package) = self.package.take() {
-            self.resolution_memo.commit_in_flight_resolution(&package);
-        }
+    /// The package this guard's placeholder covers. `None` only after
+    /// [`Self::disarm`], which consumes the guard.
+    pub(super) fn package_ref(&self) -> &streamlib_idents::PackageRef {
+        self.package
+            .as_ref()
+            .expect("guard queried after disarm — commit consumes the guard")
+    }
+
+    /// Neutralize the guard after its placeholder has been flipped to
+    /// committed. Dropping without disarm publishes `Failed`.
+    pub(super) fn disarm(mut self) {
+        self.package.take();
     }
 }
 
@@ -400,80 +462,75 @@ fn describe_requirers(requirers: &[RequirerRecord]) -> String {
         .join(", ")
 }
 
+/// Everything one top-level module load threads through its recursive
+/// dependency walk: the immutable per-load inputs (node, orchestrator,
+/// memo, staging buffer, lockfile / link context) plus the mutable
+/// accumulation the whole-load commit consumes (armed placeholder
+/// guards, skipped-in-flight wait entries, committed-dependency requirer
+/// edges).
+pub(super) struct ModuleLoadWalkContext<'load> {
+    pub iceoryx2_node: &'load Iceoryx2Node,
+    pub orchestrator: Option<&'load Arc<dyn BuildOrchestrator>>,
+    pub sink: &'load dyn BuildEventSink,
+    pub resolution_memo: &'load ResolutionMemo,
+    pub load_id: u64,
+    pub locked: Option<&'load LockedResolution>,
+    pub link: Option<&'load ActiveLinkedCheckout>,
+    /// Per-load registration staging buffer — nothing lands in the
+    /// global registries until the whole-load commit.
+    pub staging: &'load Arc<super::staging::ModuleLoadRegistrationStaging>,
+    /// Every [`PackageRef`] currently on the recursion stack (O(1)
+    /// membership for cycle detection).
+    ///
+    /// [`PackageRef`]: streamlib_idents::PackageRef
+    pub seen: HashSet<streamlib_idents::PackageRef>,
+    /// Recursion path in insertion order, so the dependency-cycle error
+    /// carries the actual edge that re-entered.
+    pub path: Vec<streamlib_idents::PackageRef>,
+    /// Dependencies skipped because a CONCURRENT load had them in flight
+    /// — verified at the end of the top-level walk.
+    pub skipped_in_flight: Vec<SkippedInFlightDependency>,
+    /// Armed placeholder guards for every package THIS load resolved —
+    /// flipped + disarmed by the whole-load commit; dropped (abandon +
+    /// `Failed` published) on any failure exit.
+    pub armed_placeholder_guards: Vec<InFlightPlaceholderGuard<'load>>,
+    /// `(dependency, requirer)` edges into packages an EARLIER load
+    /// committed — appended onto their ledger records at commit.
+    pub committed_dependency_requirer_edges: Vec<(
+        streamlib_idents::PackageRef,
+        streamlib_idents::PackageRef,
+    )>,
+}
+
 /// Recursive worker: resolves the [`Strategy`] to a source, materializes
 /// via the injected [`BuildOrchestrator`] when a build is required,
-/// validates the manifest's identity + version range, registers the
+/// validates the manifest's identity + version range, stages the
 /// package's schemas, walks dependencies (each routed through this same
-/// helper), then registers the package's processors.
-///
-/// `seen` tracks every [`PackageRef`] currently on the recursion stack
-/// (O(1) membership); `path` preserves insertion order so the
-/// dependency-cycle error carries the actual edge that re-entered.
-/// `resolution_memo` is the runtime-lifetime single-version record
-/// shared across every `add_module` call — the gate that turns a
-/// diamond version divergence into a typed
-/// [`AddModuleError::SingleVersionConflict`] instead of a silent
-/// double-registration. `load_id` identifies the top-level load this
-/// walk belongs to; `skipped_in_flight` accumulates dependencies this
-/// walk skipped because a concurrent load had them in flight — verified
-/// at the end of the top-level walk.
-///
-/// [`PackageRef`]: streamlib_idents::PackageRef
-#[allow(clippy::too_many_arguments)]
+/// helper), then stages the package's processors. Nothing is applied to
+/// the global registries here — the whole-load commit does that after
+/// the entire walk succeeds.
 pub(super) fn add_module_recursively(
-    iceoryx2_node: &Iceoryx2Node,
-    orchestrator: Option<&Arc<dyn BuildOrchestrator>>,
-    sink: &dyn BuildEventSink,
+    walk_context: &mut ModuleLoadWalkContext<'_>,
     module: streamlib_idents::ModuleIdent,
     strategy: Strategy,
-    seen: &mut HashSet<streamlib_idents::PackageRef>,
-    path: &mut Vec<streamlib_idents::PackageRef>,
-    resolution_memo: &ResolutionMemo,
-    load_id: u64,
-    skipped_in_flight: &mut Vec<SkippedInFlightDependency>,
-    locked: Option<&LockedResolution>,
-    link: Option<&ActiveLinkedCheckout>,
 ) -> std::result::Result<(), AddModuleError> {
     let pkg_ref = module.package_ref();
-    if !seen.insert(pkg_ref.clone()) {
-        let mut cycle = path.clone();
+    if !walk_context.seen.insert(pkg_ref.clone()) {
+        let mut cycle = walk_context.path.clone();
         cycle.push(pkg_ref);
         return Err(AddModuleError::DependencyCycleDetected { cycle });
     }
-    path.push(pkg_ref.clone());
-    let result = add_module_recursive_body(
-        iceoryx2_node,
-        orchestrator,
-        sink,
-        module,
-        strategy,
-        seen,
-        path,
-        resolution_memo,
-        load_id,
-        skipped_in_flight,
-        locked,
-        link,
-    );
-    seen.remove(&pkg_ref);
-    path.pop();
+    walk_context.path.push(pkg_ref.clone());
+    let result = add_module_recursive_body(walk_context, module, strategy);
+    walk_context.seen.remove(&pkg_ref);
+    walk_context.path.pop();
     result
 }
 
-#[allow(clippy::too_many_arguments)]
 fn add_module_recursive_body(
-    iceoryx2_node: &Iceoryx2Node,
-    orchestrator: Option<&Arc<dyn BuildOrchestrator>>,
-    sink: &dyn BuildEventSink,
+    walk_context: &mut ModuleLoadWalkContext<'_>,
     module: streamlib_idents::ModuleIdent,
     strategy: Strategy,
-    seen: &mut HashSet<streamlib_idents::PackageRef>,
-    path: &mut Vec<streamlib_idents::PackageRef>,
-    resolution_memo: &ResolutionMemo,
-    load_id: u64,
-    skipped_in_flight: &mut Vec<SkippedInFlightDependency>,
-    locked: Option<&LockedResolution>,
-    link: Option<&ActiveLinkedCheckout>,
 ) -> std::result::Result<(), AddModuleError> {
     use crate::core::config::ProjectConfig;
 
@@ -484,12 +541,12 @@ fn add_module_recursive_body(
     // when present, redirects a checkout-present package to the linked
     // checkout regardless of `strategy` (npm-link semantics; locked runs pass
     // `None`).
-    let manifest_dir = match resolve_strategy_to_source(&strategy, &pkg_ref, link)? {
+    let manifest_dir = match resolve_strategy_to_source(&strategy, &pkg_ref, walk_context.link)? {
         ResolvedSource::Ready(dir) => dir,
-        ResolvedSource::NeedsBuild(request) => match orchestrator {
+        ResolvedSource::NeedsBuild(request) => match walk_context.orchestrator {
             // An orchestrator is wired — materialize (fetch/build/stage).
             Some(orch) => {
-                let staged = orch.materialize(&request, sink).map_err(|e| {
+                let staged = orch.materialize(&request, walk_context.sink).map_err(|e| {
                     AddModuleError::MaterializeFailed {
                         package: pkg_ref.clone(),
                         detail: e.to_string(),
@@ -521,7 +578,8 @@ fn add_module_recursive_body(
     // checkout from the checkout (the load-time half of the zero-registry dev
     // loop). `link` is `None` on locked runs / no active link → unchanged.
     let config =
-        ProjectConfig::load_with_link(&manifest_dir, link.map(|l| l.checkout())).map_err(|e| {
+        ProjectConfig::load_with_link(&manifest_dir, walk_context.link.map(|l| l.checkout()))
+            .map_err(|e| {
             AddModuleError::ManifestLoadFailed {
                 module: module.clone(),
                 source_path: manifest_dir.clone(),
@@ -584,14 +642,33 @@ fn add_module_recursive_body(
     // on a CONCURRENT load, the skip is recorded in `skipped_in_flight`
     // and the owner's outcome is verified at the end of this walk —
     // nobody ever blocks mid-walk, so concurrent walks cannot deadlock.
+    let requirer_package =
+        (walk_context.path.len() >= 2).then(|| walk_context.path[walk_context.path.len() - 2].clone());
     let requirer = RequirerRecord {
-        requirer: (path.len() >= 2).then(|| path[path.len() - 2].clone()),
+        requirer: requirer_package.clone(),
         declared_range: module.version.clone(),
     };
-    match resolution_memo.gate(load_id, &pkg_ref, on_disk_version, &manifest_dir, requirer)? {
-        SingleVersionGateOutcome::SkipAlreadyCommittedSameVersion => return Ok(()),
+    match walk_context.resolution_memo.gate(
+        walk_context.load_id,
+        &pkg_ref,
+        on_disk_version,
+        &manifest_dir,
+        requirer,
+    )? {
+        SingleVersionGateOutcome::SkipAlreadyCommittedSameVersion => {
+            // The package belongs to an EARLIER committed load; record the
+            // requirer edge so this load's commit appends it onto the
+            // dependency's ledger record.
+            if let Some(requirer_package) = requirer_package {
+                walk_context
+                    .committed_dependency_requirer_edges
+                    .push((pkg_ref.clone(), requirer_package));
+            }
+            return Ok(());
+        }
+        SingleVersionGateOutcome::SkipOwnedByThisLoad => return Ok(()),
         SingleVersionGateOutcome::SkipInFlightSameVersion(completion_signal) => {
-            skipped_in_flight.push(SkippedInFlightDependency {
+            walk_context.skipped_in_flight.push(SkippedInFlightDependency {
                 package: pkg_ref.clone(),
                 version: on_disk_version,
                 completion_signal,
@@ -601,19 +678,23 @@ fn add_module_recursive_body(
         SingleVersionGateOutcome::ProceedAsFirstResolution => {}
     }
 
-    // The placeholder is armed: any failure exit below drops the guard,
-    // which removes the placeholder and publishes `Failed` — a retried
-    // add_module re-runs the full resolution, and concurrent loads that
-    // skipped this package fail loudly instead of assuming it registered.
-    let placeholder_guard = InFlightPlaceholderGuard::arm(resolution_memo, pkg_ref.clone());
+    // The placeholder is armed: any failure exit below drops the guard
+    // (via the walk context), which removes the placeholder and publishes
+    // `Failed` — a retried add_module re-runs the full resolution, and
+    // concurrent loads that skipped this package fail loudly instead of
+    // assuming it registered. On success the whole-load commit flips the
+    // placeholder and disarms.
+    let placeholder_guard =
+        InFlightPlaceholderGuard::arm(walk_context.resolution_memo, pkg_ref.clone());
+    walk_context.armed_placeholder_guards.push(placeholder_guard);
 
-    // Schemas are leaves — register before recursing into deps.
-    register_package_schemas(&manifest_dir, &config).map_err(|e| {
-        AddModuleError::LoadProjectFailed {
+    // Schemas are leaves — stage before recursing into deps.
+    register_package_schemas(&manifest_dir, &config, walk_context.staging, &pkg_ref).map_err(
+        |e| AddModuleError::LoadProjectFailed {
             module: module.clone(),
             source: Box::new(e),
-        }
-    })?;
+        },
+    )?;
 
     // Walk transitive deps, each routed through this same helper.
     //
@@ -624,7 +705,7 @@ fn add_module_recursive_body(
     // doesn't pin is a stale-lockfile hard error, not a silent live
     // resolve.
     for (dep_ref, spec) in &config.dependencies {
-        let (dep_ident, dep_strategy) = match locked {
+        let (dep_ident, dep_strategy) = match walk_context.locked {
             Some(lock) => lock.resolve(dep_ref, &pkg_ref.to_string())?,
             None => derive_dep_strategy_and_ident(&manifest_dir, dep_ref, spec, &config.patch)
                 .map_err(|e| AddModuleError::LoadProjectFailed {
@@ -637,46 +718,24 @@ fn add_module_recursive_body(
             dep_ident,
             dep_strategy
         );
-        add_module_recursively(
-            iceoryx2_node,
-            orchestrator,
-            sink,
-            dep_ident,
-            dep_strategy,
-            seen,
-            path,
-            resolution_memo,
-            load_id,
-            skipped_in_flight,
-            locked,
-            link,
-        )?;
+        add_module_recursively(walk_context, dep_ident, dep_strategy)?;
     }
 
-    // Now register this package's own processors. Thread the active link so a
+    // Now stage this package's own processors. Thread the active link so a
     // config schema dep present in the checkout resolves from the checkout too
     // (load-time zero-registry dev loop); `None` off a link → unchanged.
     register_manifest_processors(
-        iceoryx2_node,
+        walk_context.iceoryx2_node,
         &manifest_dir,
         &config,
-        link.map(|l| l.checkout()),
+        walk_context.link.map(|l| l.checkout()),
+        walk_context.staging,
+        &pkg_ref,
     )
     .map_err(|e| AddModuleError::LoadProjectFailed {
         module: module.clone(),
         source: Box::new(e),
     })?;
-
-    // Registration + the transitive walk succeeded — flip the in-flight
-    // placeholder to a committed record and publish `Committed` to any
-    // concurrent loads that skipped this package. Note that registration
-    // itself is NOT transactional: schemas / processors registered before
-    // a later failure remain in the process-global registries (no module
-    // unload / rollback exists yet), so retrying a multi-processor
-    // package that failed partway can hit "already registered". The
-    // guard's commit-after-success still guarantees the memo never claims
-    // a package resolved when its load didn't complete.
-    placeholder_guard.commit();
 
     Ok(())
 }

--- a/libs/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
@@ -301,7 +301,10 @@ impl ResolutionMemo {
                 ..
             }) => {
                 let record_for_caller = record.clone();
-                packages.insert(pkg_ref.clone(), PackageResolutionState::Committed { record });
+                packages.insert(
+                    pkg_ref.clone(),
+                    PackageResolutionState::Committed { record },
+                );
                 Some((record_for_caller, completion_signal))
             }
             // Defensive: only the owning load flips its placeholder.
@@ -496,10 +499,8 @@ pub(super) struct ModuleLoadWalkContext<'load> {
     pub armed_placeholder_guards: Vec<InFlightPlaceholderGuard<'load>>,
     /// `(dependency, requirer)` edges into packages an EARLIER load
     /// committed — appended onto their ledger records at commit.
-    pub committed_dependency_requirer_edges: Vec<(
-        streamlib_idents::PackageRef,
-        streamlib_idents::PackageRef,
-    )>,
+    pub committed_dependency_requirer_edges:
+        Vec<(streamlib_idents::PackageRef, streamlib_idents::PackageRef)>,
 }
 
 /// Recursive worker: resolves the [`Strategy`] to a source, materializes
@@ -579,13 +580,11 @@ fn add_module_recursive_body(
     // loop). `link` is `None` on locked runs / no active link → unchanged.
     let config =
         ProjectConfig::load_with_link(&manifest_dir, walk_context.link.map(|l| l.checkout()))
-            .map_err(|e| {
-            AddModuleError::ManifestLoadFailed {
+            .map_err(|e| AddModuleError::ManifestLoadFailed {
                 module: module.clone(),
                 source_path: manifest_dir.clone(),
                 detail: e.to_string(),
-            }
-        })?;
+            })?;
 
     config
         .check_streamlib_version_compatibility()
@@ -642,8 +641,8 @@ fn add_module_recursive_body(
     // on a CONCURRENT load, the skip is recorded in `skipped_in_flight`
     // and the owner's outcome is verified at the end of this walk —
     // nobody ever blocks mid-walk, so concurrent walks cannot deadlock.
-    let requirer_package =
-        (walk_context.path.len() >= 2).then(|| walk_context.path[walk_context.path.len() - 2].clone());
+    let requirer_package = (walk_context.path.len() >= 2)
+        .then(|| walk_context.path[walk_context.path.len() - 2].clone());
     let requirer = RequirerRecord {
         requirer: requirer_package.clone(),
         declared_range: module.version.clone(),
@@ -668,11 +667,13 @@ fn add_module_recursive_body(
         }
         SingleVersionGateOutcome::SkipOwnedByThisLoad => return Ok(()),
         SingleVersionGateOutcome::SkipInFlightSameVersion(completion_signal) => {
-            walk_context.skipped_in_flight.push(SkippedInFlightDependency {
-                package: pkg_ref.clone(),
-                version: on_disk_version,
-                completion_signal,
-            });
+            walk_context
+                .skipped_in_flight
+                .push(SkippedInFlightDependency {
+                    package: pkg_ref.clone(),
+                    version: on_disk_version,
+                    completion_signal,
+                });
             return Ok(());
         }
         SingleVersionGateOutcome::ProceedAsFirstResolution => {}
@@ -686,7 +687,9 @@ fn add_module_recursive_body(
     // placeholder and disarms.
     let placeholder_guard =
         InFlightPlaceholderGuard::arm(walk_context.resolution_memo, pkg_ref.clone());
-    walk_context.armed_placeholder_guards.push(placeholder_guard);
+    walk_context
+        .armed_placeholder_guards
+        .push(placeholder_guard);
 
     // Schemas are leaves — stage before recursing into deps.
     register_package_schemas(&manifest_dir, &config, walk_context.staging, &pkg_ref).map_err(

--- a/libs/streamlib-engine/src/core/runtime/module_loader/schema_registration.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/schema_registration.rs
@@ -3,18 +3,20 @@
 
 use crate::core::{Error, Result};
 
-/// Iterate `config.schemas` map entries, registering each `Local` schema
-/// (the YAML body keyed by its canonical identifier) with the engine's
-/// runtime schema registry. `External` entries are import declarations
-/// owned by other packages and are skipped here — the dep's own
-/// `register_package_schemas` call handles them when its manifest loads.
-/// No-op when the manifest declares no `schemas:` map.
+/// Iterate `config.schemas` map entries, staging each `Local` schema
+/// (the YAML body keyed by its canonical identifier) into the load's
+/// registration staging buffer — applied to the engine's runtime schema
+/// registry only at the whole-load commit. `External` entries are import
+/// declarations owned by other packages and are skipped here — the dep's
+/// own `register_package_schemas` call handles them when its manifest
+/// loads. No-op when the manifest declares no `schemas:` map.
 pub(super) fn register_package_schemas(
     project_path: &std::path::Path,
     config: &crate::core::config::ProjectConfig,
+    staging: &super::staging::ModuleLoadRegistrationStaging,
+    owner_package: &streamlib_idents::PackageRef,
 ) -> Result<()> {
     use crate::core::config::ProjectConfig;
-    use crate::core::embedded_schemas;
     use streamlib_idents::SchemaEntry;
 
     let Some(schemas) = config.schemas.as_ref() else {
@@ -54,11 +56,11 @@ pub(super) fn register_package_schemas(
         })?;
         let canonical = canonical_identifier_for_schema(&body, pkg_meta, &schema_path)?;
         tracing::debug!(
-            "registering schema '{}' from {}",
+            "staging schema '{}' from {}",
             canonical,
             schema_path.display()
         );
-        embedded_schemas::register_schema(canonical, body);
+        staging.stage_schema(canonical, body.into(), owner_package.clone());
     }
     Ok(())
 }

--- a/libs/streamlib-engine/src/core/runtime/module_loader/staging.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/staging.rs
@@ -1,0 +1,455 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+use crate::core::descriptors::{ProcessorDescriptor, SchemaIdent};
+use crate::core::processors::DynamicProcessorConstructorFn;
+use streamlib_plugin_abi::ProcessorVTable;
+
+/// Serializes every module-load commit and every `remove_module` against
+/// each other. Held briefly — never while waiting on another load.
+pub(crate) static MODULE_REGISTRY_COMMIT_LOCK: Mutex<()> = Mutex::new(());
+
+/// A plugin dylib image retained for the process lifetime. `dlclose` is
+/// never called: registered vtables, `'static` descriptor strings, and
+/// host-service bridge state point into the image, so unloading it would
+/// dangle them. A rebuilt plugin at the same path is a NEW image — entries
+/// are never deduplicated by path.
+pub(crate) struct RetainedPluginLibrary {
+    /// The live `dlopen` handle. Present to keep the image mapped; never
+    /// read after retention.
+    #[allow(dead_code)]
+    pub library: libloading::Library,
+    /// Path the image was loaded from (diagnostics only).
+    pub dylib_path: std::path::PathBuf,
+    /// The package whose load first retained this image.
+    #[allow(dead_code)]
+    pub first_loaded_for: streamlib_idents::PackageRef,
+}
+
+/// Keeps loaded dylib plugin images alive for the process lifetime.
+static LOADED_PLUGIN_LIBRARIES: std::sync::LazyLock<Mutex<Vec<RetainedPluginLibrary>>> =
+    std::sync::LazyLock::new(|| Mutex::new(Vec::new()));
+
+/// Number of plugin dylib images retained for the process lifetime.
+pub fn loaded_plugin_library_count() -> usize {
+    LOADED_PLUGIN_LIBRARIES.lock().len()
+}
+
+/// One schema registration staged by a module load, pending commit.
+pub(super) struct StagedSchemaRegistration {
+    pub canonical_id: String,
+    pub body: Arc<str>,
+    pub owner_package: streamlib_idents::PackageRef,
+}
+
+/// How a staged processor registration dispatches once committed.
+pub(super) enum StagedProcessorRegistrationKind {
+    /// Cdylib / in-process vtable registration → `register_via_vtable`.
+    VTable {
+        vtable: &'static ProcessorVTable,
+        cdylib_resident: bool,
+    },
+    /// Subprocess host-wrapper registration → `register_dynamic`.
+    Dynamic {
+        constructor: DynamicProcessorConstructorFn,
+    },
+}
+
+/// One processor registration staged by a module load, pending commit.
+pub(super) struct StagedProcessorRegistration {
+    pub descriptor: ProcessorDescriptor,
+    pub kind: StagedProcessorRegistrationKind,
+    pub owner_package: streamlib_idents::PackageRef,
+}
+
+/// One dlopen'd plugin image staged by a module load. Retained for the
+/// process lifetime whether the load commits or fails.
+pub(super) struct StagedPluginLibrary {
+    pub library: libloading::Library,
+    pub dylib_path: std::path::PathBuf,
+    pub owner_package: streamlib_idents::PackageRef,
+}
+
+/// Per-top-level-load staging buffer for every registration a module load
+/// produces. Nothing here is visible to the global registries until
+/// [`commit_staged_registrations_locked`] runs; dropping the staging (the
+/// failure path) discards schemas + processors and retains dylib images.
+pub(crate) struct ModuleLoadRegistrationStaging {
+    schemas: Mutex<Vec<StagedSchemaRegistration>>,
+    processors: Mutex<Vec<StagedProcessorRegistration>>,
+    libraries: Mutex<Vec<StagedPluginLibrary>>,
+}
+
+impl ModuleLoadRegistrationStaging {
+    pub(super) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            schemas: Mutex::new(Vec::new()),
+            processors: Mutex::new(Vec::new()),
+            libraries: Mutex::new(Vec::new()),
+        })
+    }
+
+    pub(super) fn stage_schema(
+        &self,
+        canonical_id: String,
+        body: Arc<str>,
+        owner_package: streamlib_idents::PackageRef,
+    ) {
+        self.schemas.lock().push(StagedSchemaRegistration {
+            canonical_id,
+            body,
+            owner_package,
+        });
+    }
+
+    pub(super) fn stage_processor(
+        &self,
+        descriptor: ProcessorDescriptor,
+        kind: StagedProcessorRegistrationKind,
+        owner_package: streamlib_idents::PackageRef,
+    ) {
+        self.processors.lock().push(StagedProcessorRegistration {
+            descriptor,
+            kind,
+            owner_package,
+        });
+    }
+
+    pub(super) fn stage_plugin_library(
+        &self,
+        library: libloading::Library,
+        dylib_path: std::path::PathBuf,
+        owner_package: streamlib_idents::PackageRef,
+    ) {
+        self.libraries.lock().push(StagedPluginLibrary {
+            library,
+            dylib_path,
+            owner_package,
+        });
+    }
+
+    /// Whether a processor with this ident is staged (mid-walk
+    /// declared-but-not-registered validation reads this, not the global
+    /// registry — registrations are invisible globally until commit).
+    pub(super) fn contains_staged_processor(&self, ident: &SchemaIdent) -> bool {
+        self.processors
+            .lock()
+            .iter()
+            .any(|staged| staged.descriptor.name == *ident)
+    }
+
+    /// Latest staged body for a canonical schema id (cdylib registration
+    /// prologues may look up schemas their own package just staged).
+    pub(super) fn staged_schema_body(&self, canonical_id: &str) -> Option<Arc<str>> {
+        self.schemas
+            .lock()
+            .iter()
+            .rev()
+            .find(|staged| staged.canonical_id == canonical_id)
+            .map(|staged| Arc::clone(&staged.body))
+    }
+}
+
+impl Drop for ModuleLoadRegistrationStaging {
+    fn drop(&mut self) {
+        // Failure-path retention: `dlclose` is never called. The cdylib's
+        // register callback already ran (host-service bridge state points
+        // into the image), so the image is retained even when its load's
+        // registrations are discarded. Commit drains `libraries` first, so
+        // this is a no-op on the success path.
+        let mut staged_libraries = self.libraries.lock();
+        if staged_libraries.is_empty() {
+            return;
+        }
+        let mut retained = LOADED_PLUGIN_LIBRARIES.lock();
+        for staged in staged_libraries.drain(..) {
+            tracing::debug!(
+                dylib_path = %staged.dylib_path.display(),
+                package = %staged.owner_package,
+                "retaining plugin dylib image from a failed module load",
+            );
+            retained.push(RetainedPluginLibrary {
+                library: staged.library,
+                dylib_path: staged.dylib_path,
+                first_loaded_for: staged.owner_package,
+            });
+        }
+    }
+}
+
+// =============================================================================
+// Thread-local cdylib registration sink
+// =============================================================================
+
+/// TLS state installed around a cdylib's `(decl.register)(...)` call so
+/// the host's `host_schema_register` / `host_processor_register`
+/// callbacks — which run synchronously on the same thread — stage into
+/// the active load instead of writing the global registries.
+struct ActiveCdylibRegistrationScope {
+    staging: Arc<ModuleLoadRegistrationStaging>,
+    owner_package: streamlib_idents::PackageRef,
+}
+
+thread_local! {
+    static ACTIVE_CDYLIB_REGISTRATION_SINK: std::cell::RefCell<Option<ActiveCdylibRegistrationScope>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// RAII scope for [`ACTIVE_CDYLIB_REGISTRATION_SINK`] — installs on
+/// construction, clears on drop (all exits, including panic unwind).
+pub(super) struct CdylibRegistrationSinkGuard {
+    _not_send: std::marker::PhantomData<*const ()>,
+}
+
+impl CdylibRegistrationSinkGuard {
+    pub(super) fn install(
+        staging: Arc<ModuleLoadRegistrationStaging>,
+        owner_package: streamlib_idents::PackageRef,
+    ) -> Self {
+        ACTIVE_CDYLIB_REGISTRATION_SINK.with(|slot| {
+            *slot.borrow_mut() = Some(ActiveCdylibRegistrationScope {
+                staging,
+                owner_package,
+            });
+        });
+        Self {
+            _not_send: std::marker::PhantomData,
+        }
+    }
+}
+
+impl Drop for CdylibRegistrationSinkGuard {
+    fn drop(&mut self) {
+        ACTIVE_CDYLIB_REGISTRATION_SINK.with(|slot| {
+            *slot.borrow_mut() = None;
+        });
+    }
+}
+
+/// Stage a cdylib schema registration into the active sink, if one is
+/// installed on this thread. Returns `false` when no sink is active (the
+/// caller falls through to the direct-to-global path).
+pub(crate) fn stage_schema_via_active_cdylib_sink(canonical_id: &str, body: &str) -> bool {
+    ACTIVE_CDYLIB_REGISTRATION_SINK.with(|slot| {
+        let borrow = slot.borrow();
+        let Some(scope) = borrow.as_ref() else {
+            return false;
+        };
+        scope.staging.stage_schema(
+            canonical_id.to_string(),
+            Arc::from(body),
+            scope.owner_package.clone(),
+        );
+        true
+    })
+}
+
+/// Stage a cdylib processor registration into the active sink, if one is
+/// installed on this thread. Returns the descriptor back when no sink is
+/// active (the caller falls through to the direct-to-global path).
+pub(crate) fn stage_processor_via_active_cdylib_sink(
+    descriptor: ProcessorDescriptor,
+    vtable: &'static ProcessorVTable,
+) -> std::result::Result<(), ProcessorDescriptor> {
+    ACTIVE_CDYLIB_REGISTRATION_SINK.with(|slot| {
+        let borrow = slot.borrow();
+        let Some(scope) = borrow.as_ref() else {
+            return Err(descriptor);
+        };
+        scope.staging.stage_processor(
+            descriptor,
+            StagedProcessorRegistrationKind::VTable {
+                vtable,
+                cdylib_resident: true,
+            },
+            scope.owner_package.clone(),
+        );
+        Ok(())
+    })
+}
+
+/// Look up a schema body in the active sink's staging buffer, if a sink
+/// is installed on this thread. Overlay for `host_schema_lookup` so a
+/// cdylib registration prologue sees schemas its own load staged.
+pub(crate) fn lookup_schema_via_active_cdylib_sink(canonical_id: &str) -> Option<Arc<str>> {
+    ACTIVE_CDYLIB_REGISTRATION_SINK.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .and_then(|scope| scope.staging.staged_schema_body(canonical_id))
+    })
+}
+
+// =============================================================================
+// Commit
+// =============================================================================
+
+/// Apply a successful load's staged registrations to the global
+/// registries, write the ledger, flip the memo placeholders, and publish
+/// the `Committed` signals. Runs under [`MODULE_REGISTRY_COMMIT_LOCK`].
+///
+/// Commit is infallible by construction — everything fallible (manifest
+/// parsing, dlopen, ABI validation, schema reads) happened during the
+/// walk. An application error here is bug-grade: it is logged at error
+/// level and the remaining items still commit (visible ⇒ permanently
+/// committed; there is no partial-rollback of a commit).
+pub(super) fn commit_module_load_registrations(
+    staging: &ModuleLoadRegistrationStaging,
+    armed_placeholder_guards: Vec<super::recursive_walker::InFlightPlaceholderGuard<'_>>,
+    committed_dependency_requirer_edges: Vec<(
+        streamlib_idents::PackageRef,
+        streamlib_idents::PackageRef,
+    )>,
+    resolution_memo: &super::recursive_walker::ResolutionMemo,
+) {
+    use super::ledger;
+
+    let _commit_guard = MODULE_REGISTRY_COMMIT_LOCK.lock();
+
+    // (1) Staged plugin images → process-lifetime retention. First, so
+    // vtable pointers are backed by retained images before any processor
+    // registration referencing them becomes globally visible.
+    let staged_libraries: Vec<StagedPluginLibrary> =
+        staging.libraries.lock().drain(..).collect();
+    let mut dylib_paths_by_owner: std::collections::HashMap<
+        streamlib_idents::PackageRef,
+        Vec<std::path::PathBuf>,
+    > = std::collections::HashMap::new();
+    {
+        let mut retained = LOADED_PLUGIN_LIBRARIES.lock();
+        for staged in staged_libraries {
+            dylib_paths_by_owner
+                .entry(staged.owner_package.clone())
+                .or_default()
+                .push(staged.dylib_path.clone());
+            retained.push(RetainedPluginLibrary {
+                library: staged.library,
+                dylib_path: staged.dylib_path,
+                first_loaded_for: staged.owner_package,
+            });
+        }
+    }
+
+    // (2) Staged schemas → global schema registry (schemas BEFORE
+    // processors; a racing reader that sees processors without schemas
+    // would resolve port payloads against missing schemas, whereas
+    // schemas-without-processors reads as module-not-loaded-yet).
+    let staged_schemas: Vec<StagedSchemaRegistration> = staging.schemas.lock().drain(..).collect();
+    let mut schema_ids_by_owner: std::collections::HashMap<
+        streamlib_idents::PackageRef,
+        Vec<String>,
+    > = std::collections::HashMap::new();
+    for staged in staged_schemas {
+        schema_ids_by_owner
+            .entry(staged.owner_package.clone())
+            .or_default()
+            .push(staged.canonical_id.clone());
+        crate::core::embedded_schemas::register_schema(staged.canonical_id, staged.body);
+    }
+
+    // (3) Staged processors → global processor registry. The duplicate
+    // branches inside `register_via_vtable` / `register_dynamic` are
+    // defensive dead code on this path — the single-version gate skipped
+    // already-registered packages during the walk.
+    let staged_processors: Vec<StagedProcessorRegistration> =
+        staging.processors.lock().drain(..).collect();
+    let mut processor_idents_by_owner: std::collections::HashMap<
+        streamlib_idents::PackageRef,
+        Vec<SchemaIdent>,
+    > = std::collections::HashMap::new();
+    for staged in staged_processors {
+        let ident = staged.descriptor.name.clone();
+        let apply_result = match staged.kind {
+            StagedProcessorRegistrationKind::VTable {
+                vtable,
+                cdylib_resident,
+            } => crate::core::processors::PROCESSOR_REGISTRY.register_via_vtable(
+                staged.descriptor,
+                vtable,
+                cdylib_resident,
+            ),
+            StagedProcessorRegistrationKind::Dynamic { constructor } => {
+                crate::core::processors::PROCESSOR_REGISTRY
+                    .register_dynamic(staged.descriptor, constructor)
+            }
+        };
+        match apply_result {
+            Ok(()) => {
+                processor_idents_by_owner
+                    .entry(staged.owner_package.clone())
+                    .or_default()
+                    .push(ident);
+            }
+            Err(e) => {
+                // Bug-grade: the walk validated everything fallible.
+                tracing::error!(
+                    processor = %ident,
+                    package = %staged.owner_package,
+                    "module-load commit failed to apply a staged processor \
+                     registration (bug-grade — the walk should have caught \
+                     this): {e}",
+                );
+            }
+        }
+    }
+
+    // (4) Ledger records + memo flips, per package resolved by this load.
+    // The flip runs under the memo lock and returns the record's final
+    // requirer list, so a concurrent gate's requirer push can never be
+    // lost between the ledger write and the flip. Completion signals are
+    // published LAST so a waiter that proceeds observes complete state.
+    let mut completion_signals: Vec<
+        Arc<super::recursive_walker::PackageResolutionCompletionSignal>,
+    > = Vec::new();
+    for guard in armed_placeholder_guards {
+        let package = guard.package_ref().clone();
+        let Some((record, signal)) =
+            resolution_memo.flip_in_flight_placeholder_to_committed(&package)
+        else {
+            // Defensive: only the owning load holds an armed guard.
+            tracing::error!(
+                package = %package,
+                "module-load commit found no in-flight placeholder to flip \
+                 (bug-grade)",
+            );
+            guard.disarm();
+            continue;
+        };
+        guard.disarm();
+
+        let required_by: Vec<streamlib_idents::PackageRef> = record
+            .required_by
+            .iter()
+            .filter_map(|requirer| requirer.requirer.clone())
+            .collect();
+        ledger::insert_loaded_module_registration_record(
+            package.clone(),
+            ledger::LoadedModuleRegistrationRecord {
+                version: record.version,
+                schema_ids: schema_ids_by_owner.remove(&package).unwrap_or_default(),
+                processor_idents: processor_idents_by_owner
+                    .remove(&package)
+                    .unwrap_or_default(),
+                dylib_paths: dylib_paths_by_owner.remove(&package).unwrap_or_default(),
+                required_by,
+            },
+        );
+        completion_signals.push(signal);
+    }
+
+    // Requirer edges into packages some EARLIER load committed (this
+    // walk skipped them at the gate) — append onto their ledger records
+    // so `remove_module`'s RequiredByLoadedModules check stays accurate.
+    for (dependency_package, requirer_package) in committed_dependency_requirer_edges {
+        ledger::append_requirer_to_loaded_module_record(&dependency_package, requirer_package);
+    }
+
+    // (5) Publish `Committed` to concurrent loads that skipped these
+    // packages as in-flight.
+    for signal in completion_signals {
+        signal.publish_committed();
+    }
+}

--- a/libs/streamlib-engine/src/core/runtime/module_loader/staging.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/staging.rs
@@ -24,6 +24,7 @@ pub(crate) struct RetainedPluginLibrary {
     #[allow(dead_code)]
     pub library: libloading::Library,
     /// Path the image was loaded from (diagnostics only).
+    #[allow(dead_code)]
     pub dylib_path: std::path::PathBuf,
     /// The package whose load first retained this image.
     #[allow(dead_code)]

--- a/libs/streamlib-engine/src/core/runtime/module_loader/staging.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/staging.rs
@@ -143,6 +143,61 @@ impl ModuleLoadRegistrationStaging {
             .any(|staged| staged.descriptor.name == *ident)
     }
 
+    /// End-of-walk gate for subprocess (`Dynamic`-kind) processors:
+    /// reject a staged Dynamic processor ident that is duplicated within
+    /// this load OR already present in the global processor registry.
+    ///
+    /// Rust/VTable duplicates are silently deduped at commit
+    /// (`register_via_vtable` skips a duplicate ident), but a Dynamic
+    /// duplicate makes `register_dynamic` error at commit — after other
+    /// staged items already applied — which would yield a
+    /// silently-incomplete load that returned Ok. Catching it here, before
+    /// the commit lock is taken, keeps the whole load fail-loud with zero
+    /// residue (the walk-context guards abandon the staged state on the
+    /// error exit). This is what makes the commit genuinely
+    /// infallible-by-construction; the commit-time `register_dynamic` Err
+    /// path remains as defensive dead code.
+    pub(super) fn validate_no_dynamic_processor_collisions(
+        &self,
+    ) -> std::result::Result<(), super::errors::AddModuleError> {
+        let processors = self.processors.lock();
+        for (index, staged) in processors.iter().enumerate() {
+            if !matches!(
+                staged.kind,
+                StagedProcessorRegistrationKind::Dynamic { .. }
+            ) {
+                continue;
+            }
+            let ident = &staged.descriptor.name;
+            // (a) Duplicate within this load — collides with ANY other
+            // staged processor of the same ident (Dynamic or VTable),
+            // scanning only earlier entries so the collision is reported
+            // once, against the first occurrence.
+            if processors
+                .iter()
+                .take(index)
+                .any(|earlier| earlier.descriptor.name == *ident)
+            {
+                return Err(super::errors::AddModuleError::DuplicateProcessorTypeInModule {
+                    package: staged.owner_package.clone(),
+                    processor_type: ident.clone(),
+                });
+            }
+            // (b) Already globally registered by non-module-load code. A
+            // staged ident is never globally visible mid-walk (staging is
+            // per-load), and the single-version gate prevents re-staging a
+            // package's own already-committed idents, so a hit here is a
+            // genuine external collision `register_dynamic` would reject.
+            if crate::core::processors::PROCESSOR_REGISTRY.is_registered(ident) {
+                return Err(super::errors::AddModuleError::ProcessorTypeAlreadyRegistered {
+                    package: staged.owner_package.clone(),
+                    processor_type: ident.clone(),
+                });
+            }
+        }
+        Ok(())
+    }
+
     /// Latest staged body for a canonical schema id (cdylib registration
     /// prologues may look up schemas their own package just staged).
     pub(super) fn staged_schema_body(&self, canonical_id: &str) -> Option<Arc<str>> {

--- a/libs/streamlib-engine/src/core/runtime/module_loader/staging.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/staging.rs
@@ -312,8 +312,7 @@ pub(super) fn commit_module_load_registrations(
     // (1) Staged plugin images → process-lifetime retention. First, so
     // vtable pointers are backed by retained images before any processor
     // registration referencing them becomes globally visible.
-    let staged_libraries: Vec<StagedPluginLibrary> =
-        staging.libraries.lock().drain(..).collect();
+    let staged_libraries: Vec<StagedPluginLibrary> = staging.libraries.lock().drain(..).collect();
     let mut dylib_paths_by_owner: std::collections::HashMap<
         streamlib_idents::PackageRef,
         Vec<std::path::PathBuf>,

--- a/libs/streamlib-engine/src/core/runtime/module_loader/tests.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/tests.rs
@@ -2601,13 +2601,15 @@ processors:
     // =====================================================================
 
     /// Byte-equivalence snapshot of every registry a module load touches:
-    /// schema bodies, processor descriptors, ledger packages, and the
-    /// calling Runner's resolution-memo package set. Two snapshots compare
-    /// equal iff a failed load left zero residue.
+    /// schema bodies, processor descriptors, the processor factory's
+    /// port-schema universe, ledger packages, and the calling Runner's
+    /// resolution-memo package set. Two snapshots compare equal iff a
+    /// failed load left zero residue.
     #[derive(Debug, PartialEq, Eq)]
     struct RegistrySnapshot {
         schema_bodies_by_canonical_id: std::collections::BTreeMap<String, String>,
         processor_descriptor_debug_by_ident: std::collections::BTreeMap<String, String>,
+        port_schema_universe: std::collections::BTreeSet<String>,
         ledger_packages: std::collections::BTreeSet<String>,
         resolution_memo_packages: std::collections::BTreeSet<String>,
     }
@@ -2630,6 +2632,11 @@ processors:
                 .into_iter()
                 .map(|desc| (desc.name.to_string(), format!("{desc:?}")))
                 .collect();
+            let port_schema_universe = crate::core::processors::PROCESSOR_REGISTRY
+                .known_schemas()
+                .into_iter()
+                .map(|spec| format!("{spec:?}"))
+                .collect();
             let ledger_packages = ledger::loaded_module_registration_ledger_packages()
                 .into_iter()
                 .map(|p| p.to_string())
@@ -2642,6 +2649,7 @@ processors:
             Self {
                 schema_bodies_by_canonical_id,
                 processor_descriptor_debug_by_ident,
+                port_schema_universe,
                 ledger_packages,
                 resolution_memo_packages,
             }
@@ -2846,6 +2854,146 @@ processors:
             .is_none(),
             "the package's schema must not be visible after the failure"
         );
+    }
+
+    /// Two subprocess (TypeScript) processors declared with the SAME
+    /// short name compose the same `processor_type` ident. The end-of-walk
+    /// Dynamic-collision gate must fail the load loud with a typed
+    /// `DuplicateProcessorTypeInModule`, leaving zero residue — never a
+    /// silently-incomplete Ok (which the old commit-time `register_dynamic`
+    /// Err + bug-grade-log-and-continue would have produced). Mentally
+    /// revert `validate_no_dynamic_processor_collisions` and this fails:
+    /// the load returns Ok with only the first processor registered.
+    #[test]
+    #[serial]
+    fn duplicate_dynamic_processor_name_fails_loud_zero_residue() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        let tmp = tempfile::tempdir().unwrap();
+        let pkg = tmp.path().join("txn-dupname");
+        std::fs::create_dir_all(&pkg).unwrap();
+        // Both processors share the name TxnDupProcessor → identical ident.
+        std::fs::write(
+            pkg.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: txn-dupname\n  version: \"1.0.0\"\n\
+             processors:\n\
+             \x20 - name: TxnDupProcessor\n\
+             \x20   version: 1.0.0\n\
+             \x20   runtime: typescript\n\
+             \x20   entrypoint: main.ts\n\
+             \x20   execution: manual\n\
+             \x20 - name: TxnDupProcessor\n\
+             \x20   version: 1.0.0\n\
+             \x20   runtime: typescript\n\
+             \x20   entrypoint: main.ts\n\
+             \x20   execution: manual\n",
+        )
+        .unwrap();
+
+        let before = RegistrySnapshot::capture(&runtime.resolution_memo);
+        let err = runtime
+            .add_module_with_blocking(
+                tatolab_ident("txn-dupname"),
+                path_strategy_never_build(&pkg),
+            )
+            .expect_err("a duplicate subprocess processor name must fail the load");
+        assert!(
+            matches!(
+                err,
+                AddModuleError::DuplicateProcessorTypeInModule { ref package, ref processor_type }
+                    if package.name.as_str() == "txn-dupname"
+                        && processor_type.r#type.as_str() == "TxnDupProcessor"
+            ),
+            "expected DuplicateProcessorTypeInModule, got: {err:?}",
+        );
+        let after = RegistrySnapshot::capture(&runtime.resolution_memo);
+        assert_eq!(
+            before, after,
+            "a duplicate-name load must leave zero registry residue"
+        );
+        assert!(
+            !crate::core::processors::PROCESSOR_REGISTRY
+                .list_registered()
+                .iter()
+                .any(|d| d.name.r#type.as_str() == "TxnDupProcessor"),
+            "neither copy of the duplicated processor may be registered"
+        );
+    }
+
+    /// A subprocess processor whose composed ident is ALREADY globally
+    /// registered (by non-module-load code) must be refused with the typed
+    /// `ProcessorTypeAlreadyRegistered`, zero residue. Locks the (b) arm of
+    /// the collision gate.
+    #[test]
+    #[serial]
+    fn dynamic_processor_colliding_with_global_registration_fails_loud() {
+        use crate::core::descriptors::{ProcessorDescriptor, SchemaIdent, TypeName};
+
+        let home = tempfile::tempdir().unwrap();
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+
+        // Pre-register @tatolab/txn-global/TxnGlobalProcessor@1.0.0 out of
+        // band, so a later module load that composes the same ident collides.
+        let colliding_ident = SchemaIdent::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("txn-global").unwrap(),
+            TypeName::new("TxnGlobalProcessor").unwrap(),
+            SemVer::new(1, 0, 0),
+        );
+        crate::core::processors::PROCESSOR_REGISTRY
+            .register_dynamic(
+                ProcessorDescriptor::new(colliding_ident.clone(), "pre-registered collision"),
+                Box::new(|_node| {
+                    Err(crate::core::Error::Configuration(
+                        "test constructor never invoked".into(),
+                    ))
+                }),
+            )
+            .expect("out-of-band pre-registration must succeed");
+
+        let tmp = tempfile::tempdir().unwrap();
+        let pkg = tmp.path().join("txn-global");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(
+            pkg.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: txn-global\n  version: \"1.0.0\"\n\
+             processors:\n\
+             \x20 - name: TxnGlobalProcessor\n\
+             \x20   version: 1.0.0\n\
+             \x20   runtime: typescript\n\
+             \x20   entrypoint: main.ts\n\
+             \x20   execution: manual\n",
+        )
+        .unwrap();
+
+        let before = RegistrySnapshot::capture(&runtime.resolution_memo);
+        let err = runtime
+            .add_module_with_blocking(
+                tatolab_ident("txn-global"),
+                path_strategy_never_build(&pkg),
+            )
+            .expect_err("a globally-colliding subprocess processor must fail the load");
+        assert!(
+            matches!(
+                err,
+                AddModuleError::ProcessorTypeAlreadyRegistered { ref processor_type, .. }
+                    if processor_type.r#type.as_str() == "TxnGlobalProcessor"
+            ),
+            "expected ProcessorTypeAlreadyRegistered, got: {err:?}",
+        );
+        let after = RegistrySnapshot::capture(&runtime.resolution_memo);
+        assert_eq!(
+            before, after,
+            "a globally-colliding load must leave zero residue (the pre-registered \
+             ident stays, nothing new lands)"
+        );
+
+        // Cleanup: unregister the out-of-band ident so the process-global
+        // registry is clean for later #[serial] tests.
+        crate::core::processors::PROCESSOR_REGISTRY
+            .unregister_processor_types(std::slice::from_ref(&colliding_ident));
     }
 
     /// Same-load diamond regression: A→{B,C}→D resolves D once, with no
@@ -3187,8 +3335,6 @@ processors:
     #[test]
     #[serial]
     fn remove_module_processors_in_use_then_removable_after_graph_removal() {
-        use crate::core::runtime::RuntimeOperations;
-
         let home = tempfile::tempdir().unwrap();
         let _guard = HomeGuard::install(home.path());
         let runtime = Runner::new().expect("Runner::new");

--- a/libs/streamlib-engine/src/core/runtime/module_loader/tests.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/tests.rs
@@ -2577,19 +2577,20 @@ processors:
     }
 
     #[test]
-    fn remove_module_returns_hot_reload_lifecycle_deferral() {
+    #[serial]
+    fn remove_module_unknown_package_is_module_not_loaded() {
         let runtime = Runner::new().expect("Runner::new");
         let err = runtime
             .remove_module(ModuleIdent::any(
                 Org::new("tatolab").unwrap(),
-                Package::new("remove-module-stub").unwrap(),
+                Package::new("remove-module-unknown").unwrap(),
             ))
-            .expect_err("remove_module must error until hot-reload ships");
+            .expect_err("remove_module of a never-loaded package must error");
         assert!(
             matches!(
                 err,
-                RemoveModuleError::HotReloadLifecycleNotYetImplemented { ref module }
-                    if module.name.as_str() == "remove-module-stub"
+                RemoveModuleError::ModuleNotLoaded { ref module, loaded_version: None }
+                    if module.name.as_str() == "remove-module-unknown"
             ),
             "got: {err:?}",
         );

--- a/libs/streamlib-engine/src/core/runtime/module_loader/tests.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/tests.rs
@@ -2597,6 +2597,739 @@ processors:
     }
 
     // =====================================================================
+    // Transactional registration: a failed load leaves zero partial state
+    // =====================================================================
+
+    /// Byte-equivalence snapshot of every registry a module load touches:
+    /// schema bodies, processor descriptors, ledger packages, and the
+    /// calling Runner's resolution-memo package set. Two snapshots compare
+    /// equal iff a failed load left zero residue.
+    #[derive(Debug, PartialEq, Eq)]
+    struct RegistrySnapshot {
+        schema_bodies_by_canonical_id: std::collections::BTreeMap<String, String>,
+        processor_descriptor_debug_by_ident: std::collections::BTreeMap<String, String>,
+        ledger_packages: std::collections::BTreeSet<String>,
+        resolution_memo_packages: std::collections::BTreeSet<String>,
+    }
+
+    impl RegistrySnapshot {
+        fn capture(resolution_memo: &ResolutionMemo) -> Self {
+            let schema_bodies_by_canonical_id =
+                crate::core::embedded_schemas::list_embedded_schema_names()
+                    .into_iter()
+                    .map(|name| {
+                        let body =
+                            crate::core::embedded_schemas::get_embedded_schema_definition(&name)
+                                .map(|b| b.to_string())
+                                .unwrap_or_default();
+                        (name, body)
+                    })
+                    .collect();
+            let processor_descriptor_debug_by_ident = crate::core::processors::PROCESSOR_REGISTRY
+                .list_registered()
+                .into_iter()
+                .map(|desc| (desc.name.to_string(), format!("{desc:?}")))
+                .collect();
+            let ledger_packages = ledger::loaded_module_registration_ledger_packages()
+                .into_iter()
+                .map(|p| p.to_string())
+                .collect();
+            let resolution_memo_packages = resolution_memo
+                .resolved_package_refs()
+                .into_iter()
+                .map(|p| p.to_string())
+                .collect();
+            Self {
+                schema_bodies_by_canonical_id,
+                processor_descriptor_debug_by_ident,
+                ledger_packages,
+                resolution_memo_packages,
+            }
+        }
+    }
+
+    fn tatolab_ident(name: &str) -> ModuleIdent {
+        ModuleIdent::any(Org::new("tatolab").unwrap(), Package::new(name).unwrap())
+    }
+
+    fn path_strategy_never_build(dir: &std::path::Path) -> Strategy {
+        Strategy::Path {
+            path: dir.to_path_buf(),
+            build: BuildPolicy::NeverBuild,
+        }
+    }
+
+    /// Failure injected at the SCHEMA phase, after the first schema file
+    /// staged: the second schema file has no `metadata` block, so the walk
+    /// fails mid-schema-staging. Zero residue; the fixed package reloads.
+    #[test]
+    #[serial]
+    fn failed_load_at_schema_phase_leaves_zero_registry_residue() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        let tmp = tempfile::tempdir().unwrap();
+        let pkg = tmp.path().join("txn-schema-fail");
+        std::fs::create_dir_all(pkg.join("schemas")).unwrap();
+        // BTreeMap key order stages TxnAGoodSchema BEFORE TxnBBadSchema
+        // fails — the injection point sits after partial staging.
+        std::fs::write(
+            pkg.join("schemas/a_good.yaml"),
+            "metadata:\n  type: TxnAGoodSchema\n",
+        )
+        .unwrap();
+        std::fs::write(pkg.join("schemas/b_bad.yaml"), "properties: {}\n").unwrap();
+        std::fs::write(
+            pkg.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: txn-schema-fail\n  version: \"1.0.0\"\n\
+             schemas:\n  TxnAGoodSchema:\n    file: schemas/a_good.yaml\n\
+             \x20 TxnBBadSchema:\n    file: schemas/b_bad.yaml\n",
+        )
+        .unwrap();
+
+        let before = RegistrySnapshot::capture(&runtime.resolution_memo);
+        runtime
+            .add_module_with_blocking(
+                tatolab_ident("txn-schema-fail"),
+                path_strategy_never_build(&pkg),
+            )
+            .expect_err("a schema without a metadata block must fail the load");
+        let after = RegistrySnapshot::capture(&runtime.resolution_memo);
+        assert_eq!(
+            before, after,
+            "a failed load must leave the registries byte-equivalent to \
+             before the attempt"
+        );
+        assert!(
+            crate::core::embedded_schemas::get_embedded_schema_definition(
+                "@tatolab/txn-schema-fail/TxnAGoodSchema"
+            )
+            .is_none(),
+            "the schema staged before the failure must not be visible"
+        );
+
+        // Fix the broken schema; the same package must now load cleanly.
+        std::fs::write(
+            pkg.join("schemas/b_bad.yaml"),
+            "metadata:\n  type: TxnBBadSchema\n",
+        )
+        .unwrap();
+        runtime
+            .add_module_with_blocking(
+                tatolab_ident("txn-schema-fail"),
+                path_strategy_never_build(&pkg),
+            )
+            .expect("reload of the fixed package must succeed");
+        assert!(
+            crate::core::embedded_schemas::get_embedded_schema_definition(
+                "@tatolab/txn-schema-fail/TxnAGoodSchema"
+            )
+            .is_some(),
+            "both schemas must be visible after the successful reload"
+        );
+    }
+
+    /// Failure injected at the DEP-WALK phase: the root's schemas staged,
+    /// then a dependency with no manifest fails the walk. The root's
+    /// schemas must not be visible.
+    #[test]
+    #[serial]
+    fn failed_load_at_dep_walk_phase_rolls_back_root_schemas() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        runtime.set_build_orchestrator(LoadAsIsOrchestrator);
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("txn-depfail-root");
+        std::fs::create_dir_all(root.join("schemas")).unwrap();
+        std::fs::write(
+            root.join("schemas/root_schema.yaml"),
+            "metadata:\n  type: TxnDepFailRootSchema\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: txn-depfail-root\n  version: \"1.0.0\"\n\
+             schemas:\n  TxnDepFailRootSchema:\n    file: schemas/root_schema.yaml\n\
+             dependencies:\n  \"@tatolab/txn-depfail-missing\":\n    path: ../missing\n",
+        )
+        .unwrap();
+
+        let before = RegistrySnapshot::capture(&runtime.resolution_memo);
+        runtime
+            .add_module_with_blocking(
+                tatolab_ident("txn-depfail-root"),
+                path_strategy_never_build(&root),
+            )
+            .expect_err("a dep with no manifest must fail the load");
+        let after = RegistrySnapshot::capture(&runtime.resolution_memo);
+        assert_eq!(before, after, "dep-walk failure must leave zero residue");
+        assert!(
+            crate::core::embedded_schemas::get_embedded_schema_definition(
+                "@tatolab/txn-depfail-root/TxnDepFailRootSchema"
+            )
+            .is_none(),
+            "the root's schemas (staged before the dep walk) must not be visible"
+        );
+    }
+
+    /// Write a package with one schema + two TypeScript processors where
+    /// the SECOND processor's config schema is unresolvable — the walk
+    /// stages the schema and the first processor, then fails.
+    fn write_processor_phase_failure_package(pkg: &std::path::Path) {
+        std::fs::create_dir_all(pkg.join("schemas")).unwrap();
+        std::fs::write(
+            pkg.join("schemas/txn_proc_config.yaml"),
+            "metadata:\n  type: TxnProcConfigSchema\n",
+        )
+        .unwrap();
+        std::fs::write(
+            pkg.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: txn-procfail\n  version: \"1.0.0\"\n\
+             schemas:\n  TxnProcConfigSchema:\n    file: schemas/txn_proc_config.yaml\n\
+             processors:\n\
+             \x20 - name: TxnAlphaProcessor\n\
+             \x20   version: 1.0.0\n\
+             \x20   runtime: typescript\n\
+             \x20   entrypoint: main.ts\n\
+             \x20   execution: manual\n\
+             \x20   config:\n\
+             \x20     name: config\n\
+             \x20     schema: TxnProcConfigSchema\n\
+             \x20 - name: TxnBetaProcessor\n\
+             \x20   version: 1.0.0\n\
+             \x20   runtime: typescript\n\
+             \x20   entrypoint: main.ts\n\
+             \x20   execution: manual\n\
+             \x20   config:\n\
+             \x20     name: config\n\
+             \x20     schema: TxnMissingConfigSchema\n",
+        )
+        .unwrap();
+    }
+
+    /// Failure injected at the PROCESSOR phase, after the first processor
+    /// staged: no processors and no schemas may be visible.
+    #[test]
+    #[serial]
+    fn failed_load_at_processor_phase_rolls_back_schemas_and_processors() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        let tmp = tempfile::tempdir().unwrap();
+        let pkg = tmp.path().join("txn-procfail");
+        write_processor_phase_failure_package(&pkg);
+
+        let before = RegistrySnapshot::capture(&runtime.resolution_memo);
+        runtime
+            .add_module_with_blocking(
+                tatolab_ident("txn-procfail"),
+                path_strategy_never_build(&pkg),
+            )
+            .expect_err("an unresolvable config schema must fail the load");
+        let after = RegistrySnapshot::capture(&runtime.resolution_memo);
+        assert_eq!(
+            before, after,
+            "processor-phase failure must leave zero residue"
+        );
+        assert!(
+            !crate::core::processors::PROCESSOR_REGISTRY
+                .list_registered()
+                .iter()
+                .any(|d| d.name.r#type.as_str() == "TxnAlphaProcessor"),
+            "the processor staged before the failure must not be visible"
+        );
+        assert!(
+            crate::core::embedded_schemas::get_embedded_schema_definition(
+                "@tatolab/txn-procfail/TxnProcConfigSchema"
+            )
+            .is_none(),
+            "the package's schema must not be visible after the failure"
+        );
+    }
+
+    /// Same-load diamond regression: A→{B,C}→D resolves D once, with no
+    /// self-wait. With the whole-load memo commit, D's placeholder stays
+    /// in flight for the entire walk — the second encounter (via C) must
+    /// take the SkipOwnedByThisLoad arm. Mentally revert that arm and the
+    /// load records a wait entry against its OWN completion signal, which
+    /// only publishes after the wait phase — the timeout below fires.
+    #[test]
+    #[serial]
+    fn same_load_diamond_dependency_registers_once_without_self_wait() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        let counts = std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::<
+            std::path::PathBuf,
+            usize,
+        >::new()));
+        runtime.set_build_orchestrator(MaterializeCountingOrchestrator {
+            counts: std::sync::Arc::clone(&counts),
+        });
+        let tmp = tempfile::tempdir().unwrap();
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        let c = tmp.path().join("c");
+        let d = tmp.path().join("d");
+        let e = tmp.path().join("e");
+        for p in [&a, &b, &c, &d, &e] {
+            std::fs::create_dir_all(p).unwrap();
+        }
+        std::fs::write(
+            a.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: diamond-a\n  version: \"1.0.0\"\n\
+             dependencies:\n  \"@tatolab/diamond-b\":\n    path: ../b\n\
+             \x20 \"@tatolab/diamond-c\":\n    path: ../c\n",
+        )
+        .unwrap();
+        std::fs::write(
+            b.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: diamond-b\n  version: \"1.0.0\"\n\
+             dependencies:\n  \"@tatolab/diamond-d\":\n    path: ../d\n",
+        )
+        .unwrap();
+        std::fs::write(
+            c.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: diamond-c\n  version: \"1.0.0\"\n\
+             dependencies:\n  \"@tatolab/diamond-d\":\n    path: ../d\n",
+        )
+        .unwrap();
+        // D carries a sub-dependency E. Materialization runs BEFORE the
+        // single-version gate (the gate needs the resolved on-disk
+        // version), so D itself materializes once per encounter by
+        // design — E's materialize count is the "subtree walked once"
+        // witness.
+        std::fs::create_dir_all(d.join("schemas")).unwrap();
+        std::fs::write(
+            d.join("schemas/diamond_d_schema.yaml"),
+            "metadata:\n  type: DiamondDSchema\n",
+        )
+        .unwrap();
+        std::fs::write(
+            d.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: diamond-d\n  version: \"1.0.0\"\n\
+             schemas:\n  DiamondDSchema:\n    file: schemas/diamond_d_schema.yaml\n\
+             dependencies:\n  \"@tatolab/diamond-e\":\n    path: ../e\n",
+        )
+        .unwrap();
+        write_schemas_only_manifest(&e, "tatolab", "diamond-e", "1.0.0", None);
+
+        let added =
+            runtime.add_module_with(tatolab_ident("diamond-a"), path_strategy_never_build(&a));
+        let handle = runtime.tokio_runtime_variant.handle();
+        let result = handle
+            .block_on(async {
+                tokio::time::timeout(std::time::Duration::from_secs(30), added).await
+            })
+            .expect(
+                "diamond load must complete without waiting on itself — a \
+                 timeout here is the SkipOwnedByThisLoad regression",
+            );
+        result.expect("diamond load must succeed");
+
+        assert_eq!(
+            count_materializations_for_dir_named(&counts, "e"),
+            1,
+            "D's subtree must be walked exactly once"
+        );
+        let d_ref = streamlib_idents::PackageRef::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("diamond-d").unwrap(),
+        );
+        let record = runtime
+            .resolution_memo
+            .committed_record(&d_ref)
+            .expect("D must be committed");
+        assert_eq!(
+            record.required_by.len(),
+            2,
+            "both diamond branches must be recorded as requirers"
+        );
+        assert!(
+            crate::core::embedded_schemas::get_embedded_schema_definition(
+                "@tatolab/diamond-d/DiamondDSchema"
+            )
+            .is_some(),
+            "D's schema must be registered exactly once via the commit"
+        );
+    }
+
+    /// Semantic strengthening: a skipped dependency only counts as
+    /// committed when its owner's WHOLE load commits. The owner (TA) walks
+    /// shared dep D successfully, then fails at its OWN processor phase —
+    /// the waiter (TB) must get ConcurrentLoadOfSkippedDependencyFailed,
+    /// and D must be fully rolled back. Under the old per-subtree commit
+    /// semantics D would have committed when its subtree unwound and TB
+    /// would have succeeded over a registration that no longer exists.
+    #[test]
+    #[serial]
+    fn concurrent_load_root_failure_after_shared_dep_walked_fails_waiter() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = HomeGuard::install(home.path());
+        let pkg_root = tempfile::tempdir().unwrap();
+        let ta = pkg_root.path().join("ta");
+        let tb = pkg_root.path().join("tb");
+        let d = pkg_root.path().join("d");
+        let e = pkg_root.path().join("e");
+        for p in [&ta, &tb, &d, &e] {
+            std::fs::create_dir_all(p).unwrap();
+        }
+        // TA: deps {D, E} (D sorts before E), plus a processor whose
+        // config schema is unresolvable — TA's own processor phase fails
+        // AFTER both dep subtrees walked.
+        std::fs::write(
+            ta.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: conc-root-ta\n  version: \"0.1.0\"\n\
+             dependencies:\n  \"@tatolab/conc-root-d\":\n    path: ../d\n\
+             \x20 \"@tatolab/conc-root-e\":\n    path: ../e\n\
+             processors:\n\
+             \x20 - name: ConcRootFailingProcessor\n\
+             \x20   version: 1.0.0\n\
+             \x20   runtime: typescript\n\
+             \x20   entrypoint: main.ts\n\
+             \x20   execution: manual\n\
+             \x20   config:\n\
+             \x20     name: config\n\
+             \x20     schema: ConcRootNoSuchConfigSchema\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tb.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: conc-root-tb\n  version: \"0.1.0\"\n\
+             dependencies:\n  \"@tatolab/conc-root-d\":\n    path: ../d\n",
+        )
+        .unwrap();
+        write_schemas_only_manifest(
+            &d,
+            "tatolab",
+            "conc-root-d",
+            "1.0.0",
+            Some("ConcRootDSchema"),
+        );
+        write_schemas_only_manifest(&e, "tatolab", "conc-root-e", "1.0.0", None);
+
+        let runtime = Runner::new().expect("Runner::new");
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        runtime.set_build_orchestrator(GatedSubDependencyOrchestrator {
+            gated_dir_name: "e".to_string(),
+            release: parking_lot::Mutex::new(Some(release_rx)),
+            fail_after_release: false,
+        });
+
+        let d_ref = streamlib_idents::PackageRef::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("conc-root-d").unwrap(),
+        );
+        let added_ta = runtime.add_module_with(
+            tatolab_ident("conc-root-ta"),
+            path_strategy_never_build(&ta),
+        );
+        assert!(
+            poll_until(std::time::Duration::from_secs(10), || {
+                runtime.resolution_memo.in_flight_requirer_count(&d_ref) == Some(1)
+            }),
+            "TA must hold D in flight (whole-load commit) while blocked on E",
+        );
+        let added_tb = runtime.add_module_with(
+            tatolab_ident("conc-root-tb"),
+            path_strategy_never_build(&tb),
+        );
+        assert!(
+            poll_until(std::time::Duration::from_secs(10), || {
+                runtime.resolution_memo.in_flight_requirer_count(&d_ref) == Some(2)
+            }),
+            "TB must record its requirer on D's in-flight placeholder",
+        );
+        release_tx.send(()).unwrap();
+
+        let handle = runtime.tokio_runtime_variant.handle();
+        let (result_ta, result_tb) = handle.block_on(async { tokio::join!(added_ta, added_tb) });
+        let owner_err = result_ta
+            .expect_err("TA must fail at its own processor phase after D's subtree walked");
+        assert!(
+            matches!(owner_err, AddModuleError::LoadProjectFailed { .. }),
+            "TA must surface the config-schema resolution failure, got: {owner_err:?}",
+        );
+        let waiter_err = result_tb.expect_err(
+            "TB must fail loudly when the owner's WHOLE load fails — even \
+             though D's own subtree walked cleanly",
+        );
+        assert!(
+            matches!(
+                waiter_err,
+                AddModuleError::ConcurrentLoadOfSkippedDependencyFailed { ref package, version }
+                    if package.name.as_str() == "conc-root-d"
+                        && version == SemVer::new(1, 0, 0)
+            ),
+            "expected ConcurrentLoadOfSkippedDependencyFailed for D, got: {waiter_err:?}",
+        );
+        assert!(
+            !runtime.resolution_memo.contains_package(&d_ref),
+            "the failed owner's guards must clear D's placeholder",
+        );
+        assert!(
+            crate::core::embedded_schemas::get_embedded_schema_definition(
+                "@tatolab/conc-root-d/ConcRootDSchema"
+            )
+            .is_none(),
+            "D's schema must be rolled back with the owner's whole load",
+        );
+    }
+
+    // =====================================================================
+    // remove_module
+    // =====================================================================
+
+    #[test]
+    #[serial]
+    fn remove_module_version_range_mismatch_names_loaded_version() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        let tmp = tempfile::tempdir().unwrap();
+        let pkg = tmp.path().join("rm-range");
+        std::fs::create_dir_all(&pkg).unwrap();
+        write_schemas_only_manifest(&pkg, "tatolab", "rm-range", "1.0.0", None);
+        runtime
+            .add_module_with_blocking(tatolab_ident("rm-range"), path_strategy_never_build(&pkg))
+            .expect("load must succeed");
+
+        let err = runtime
+            .remove_module(ModuleIdent::new(
+                Org::new("tatolab").unwrap(),
+                Package::new("rm-range").unwrap(),
+                SemVerRange::Caret(SemVer::new(2, 0, 0)),
+            ))
+            .expect_err("a non-matching range must refuse");
+        assert!(
+            matches!(
+                err,
+                RemoveModuleError::ModuleNotLoaded { loaded_version: Some(v), .. }
+                    if v == SemVer::new(1, 0, 0)
+            ),
+            "got: {err:?}",
+        );
+
+        // Cleanup for later #[serial] tests: matching range removes.
+        runtime
+            .remove_module(tatolab_ident("rm-range"))
+            .expect("matching range must remove");
+    }
+
+    #[test]
+    #[serial]
+    fn remove_module_refuses_required_dependency_then_removes_in_order() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        runtime.set_build_orchestrator(LoadAsIsOrchestrator);
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("rm-root");
+        let dep = tmp.path().join("rm-dep");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&dep).unwrap();
+        std::fs::write(
+            root.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: rm-root\n  version: \"1.0.0\"\n\
+             dependencies:\n  \"@tatolab/rm-dep\":\n    path: ../rm-dep\n",
+        )
+        .unwrap();
+        write_schemas_only_manifest(&dep, "tatolab", "rm-dep", "1.0.0", Some("RmDepSchema"));
+
+        runtime
+            .add_module_with_blocking(tatolab_ident("rm-root"), path_strategy_never_build(&root))
+            .expect("root+dep load must succeed");
+
+        // Dep removal refused while the root requires it — no cascade.
+        let err = runtime
+            .remove_module(tatolab_ident("rm-dep"))
+            .expect_err("dep removal must refuse while the root requires it");
+        assert!(
+            matches!(
+                err,
+                RemoveModuleError::RequiredByLoadedModules { ref requirers, .. }
+                    if requirers.iter().any(|r| r.name.as_str() == "rm-root")
+            ),
+            "got: {err:?}",
+        );
+        assert!(
+            crate::core::embedded_schemas::get_embedded_schema_definition(
+                "@tatolab/rm-dep/RmDepSchema"
+            )
+            .is_some(),
+            "a refused removal must leave the dep's schema registered"
+        );
+
+        // Root first, then the dep — requirer pruning unblocks the dep.
+        runtime
+            .remove_module(tatolab_ident("rm-root"))
+            .expect("root removal must succeed");
+        runtime
+            .remove_module(tatolab_ident("rm-dep"))
+            .expect("dep removal must succeed after the root was removed");
+        assert!(
+            crate::core::embedded_schemas::get_embedded_schema_definition(
+                "@tatolab/rm-dep/RmDepSchema"
+            )
+            .is_none(),
+            "the removed dep's schema must be unregistered"
+        );
+
+        // The full graph reloads cleanly after removal.
+        runtime
+            .add_module_with_blocking(tatolab_ident("rm-root"), path_strategy_never_build(&root))
+            .expect("reload after removal must succeed");
+        runtime.remove_module(tatolab_ident("rm-root")).unwrap();
+        runtime.remove_module(tatolab_ident("rm-dep")).unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn remove_module_processors_in_use_then_removable_after_graph_removal() {
+        use crate::core::runtime::RuntimeOperations;
+
+        let home = tempfile::tempdir().unwrap();
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        let tmp = tempfile::tempdir().unwrap();
+        let pkg = tmp.path().join("rm-inuse");
+        std::fs::create_dir_all(pkg.join("schemas")).unwrap();
+        std::fs::write(
+            pkg.join("schemas/rm_inuse_config.yaml"),
+            "metadata:\n  type: RmInUseConfigSchema\n",
+        )
+        .unwrap();
+        std::fs::write(
+            pkg.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: rm-inuse\n  version: \"1.0.0\"\n\
+             schemas:\n  RmInUseConfigSchema:\n    file: schemas/rm_inuse_config.yaml\n\
+             processors:\n\
+             \x20 - name: RmInUseProcessor\n\
+             \x20   version: 1.0.0\n\
+             \x20   runtime: typescript\n\
+             \x20   entrypoint: main.ts\n\
+             \x20   execution: manual\n\
+             \x20   config:\n\
+             \x20     name: config\n\
+             \x20     schema: RmInUseConfigSchema\n",
+        )
+        .unwrap();
+
+        runtime
+            .add_module_with_blocking(tatolab_ident("rm-inuse"), path_strategy_never_build(&pkg))
+            .expect("processor package load must succeed");
+
+        let descriptor = crate::core::processors::PROCESSOR_REGISTRY
+            .list_registered()
+            .into_iter()
+            .find(|d| d.name.r#type.as_str() == "RmInUseProcessor")
+            .expect("RmInUseProcessor must be registered");
+        let spec = crate::core::processors::ProcessorSpec::new(
+            descriptor.name.clone(),
+            serde_json::json!({}),
+        );
+        let processor_id = runtime
+            .add_processor(spec.clone())
+            .expect("add_processor against the loaded type must succeed");
+
+        // In use: the graph node blocks removal, and the refusal restores
+        // the registration (a follow-up add_processor still works).
+        let err = runtime
+            .remove_module(tatolab_ident("rm-inuse"))
+            .expect_err("removal must refuse while a graph node uses the type");
+        match &err {
+            RemoveModuleError::ProcessorsInUse {
+                processor_ids,
+                processor_types,
+                ..
+            } => {
+                assert!(processor_ids.contains(&processor_id));
+                assert!(
+                    processor_types
+                        .iter()
+                        .any(|t| t.r#type.as_str() == "RmInUseProcessor")
+                );
+            }
+            other => panic!("expected ProcessorsInUse, got {other:?}"),
+        }
+        assert!(
+            crate::core::processors::PROCESSOR_REGISTRY.is_registered(&descriptor.name),
+            "a refused removal must restore the processor registration"
+        );
+
+        // Remove the graph node; module removal now succeeds.
+        runtime
+            .remove_processor(&processor_id)
+            .expect("remove_processor must succeed");
+        runtime
+            .remove_module(tatolab_ident("rm-inuse"))
+            .expect("module removal must succeed after the graph node is gone");
+
+        // Post-removal add_processor gets the typed registry miss.
+        let err = runtime
+            .add_processor(spec)
+            .expect_err("add_processor after removal must miss the registry");
+        assert!(
+            matches!(err, crate::core::Error::UnknownProcessorType { .. }),
+            "expected UnknownProcessorType, got: {err:?}",
+        );
+    }
+
+    /// Load/unload/reload ×2 of the same package on one Runner: the
+    /// registry snapshot after every reload equals the snapshot after the
+    /// first load.
+    #[test]
+    #[serial]
+    fn load_unload_reload_cycle_is_registry_idempotent() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        let tmp = tempfile::tempdir().unwrap();
+        let pkg = tmp.path().join("cycle-pkg");
+        std::fs::create_dir_all(&pkg).unwrap();
+        write_schemas_only_manifest(
+            &pkg,
+            "tatolab",
+            "cycle-pkg",
+            "1.0.0",
+            Some("CyclePkgSchema"),
+        );
+
+        runtime
+            .add_module_with_blocking(tatolab_ident("cycle-pkg"), path_strategy_never_build(&pkg))
+            .expect("first load must succeed");
+        let after_first_load = RegistrySnapshot::capture(&runtime.resolution_memo);
+
+        for cycle in 0..2 {
+            runtime
+                .remove_module(tatolab_ident("cycle-pkg"))
+                .unwrap_or_else(|e| panic!("cycle {cycle}: remove must succeed: {e:?}"));
+            assert!(
+                crate::core::embedded_schemas::get_embedded_schema_definition(
+                    "@tatolab/cycle-pkg/CyclePkgSchema"
+                )
+                .is_none(),
+                "cycle {cycle}: schema must be gone after removal"
+            );
+            runtime
+                .add_module_with_blocking(
+                    tatolab_ident("cycle-pkg"),
+                    path_strategy_never_build(&pkg),
+                )
+                .unwrap_or_else(|e| panic!("cycle {cycle}: reload must succeed: {e:?}"));
+            let after_reload = RegistrySnapshot::capture(&runtime.resolution_memo);
+            assert_eq!(
+                after_first_load, after_reload,
+                "cycle {cycle}: reload must reproduce the first load's registry state"
+            );
+        }
+
+        // Leave the process-global registries clean for later tests.
+        runtime.remove_module(tatolab_ident("cycle-pkg")).unwrap();
+    }
+
+    // =====================================================================
     // install / run split (#1221)
     //
     // Exercises the full resolver handoff: `install` resolves range→concrete,

--- a/libs/streamlib-engine/src/core/runtime/runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/runtime.rs
@@ -144,8 +144,9 @@ pub struct Runner {
     /// version divergence — or two successive / concurrent `add_module`s
     /// resolving different concrete versions of the same package —
     /// surfaces as [`AddModuleError::SingleVersionConflict`] instead of a
-    /// silent double-registration. Lives for the runtime's lifetime
-    /// (there is no module unload today); dropped with the [`Runner`].
+    /// silent double-registration. Lives for the runtime's lifetime;
+    /// [`Runner::remove_module`] clears a removed package's entry so a
+    /// later `add_module` re-resolves it from scratch.
     /// The memo is Runner-scoped while the schema / processor registries
     /// it protects are process-global statics — a second [`Runner`] in
     /// the same process carries its own memo and does not see this one's

--- a/libs/streamlib-engine/tests/load_project_dylib_remove_module.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_remove_module.rs
@@ -1,0 +1,166 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `remove_module` integration test for the dlopen path: load the real
+//! `packages/test-fixtures` cdylib, run a construct/destroy lifecycle
+//! smoke, remove the module (registrations gone, dylib image RETAINED —
+//! `dlclose` is never called), then `add_module` the same package again
+//! and prove the lifecycle runs again — the full load/unload/reload
+//! cycle on one runtime.
+
+use std::path::Path;
+
+use serial_test::serial;
+use streamlib::sdk::RunnerAutoBuild;
+use streamlib::sdk::module_ident_any_version;
+use streamlib::sdk::processors::{PROCESSOR_REGISTRY, ProcessorInstance};
+use streamlib::sdk::runtime::{BuildPolicy, Runner, Strategy};
+use streamlib_engine::core::graph::ProcessorNode;
+use streamlib_engine::core::runtime::{host_target_triple, loaded_plugin_library_count};
+
+fn copy_dir_contents(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dst_entry = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_contents(&entry.path(), &dst_entry);
+        } else {
+            std::fs::copy(entry.path(), &dst_entry).unwrap();
+        }
+    }
+}
+
+fn construct_destroy_lifecycle_smoke(context: &str) {
+    let descriptor = PROCESSOR_REGISTRY
+        .list_registered()
+        .into_iter()
+        .find(|d| d.name.r#type.as_str() == "TestConfiguredProcessor")
+        .unwrap_or_else(|| panic!("{context}: TestConfiguredProcessor must be registered"));
+    let node = ProcessorNode::new(
+        descriptor.name.clone(),
+        "TestConfiguredProcessor",
+        None,
+        Vec::new(),
+        Vec::new(),
+    );
+    let instance = PROCESSOR_REGISTRY
+        .create(&node)
+        .unwrap_or_else(|e| panic!("{context}: factory.create() must succeed: {e}"));
+    assert!(matches!(instance, ProcessorInstance::VTable { .. }));
+    drop(instance);
+}
+
+#[test]
+#[serial]
+fn remove_module_unloads_dlopen_module_and_reload_runs_lifecycle_again() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    let status = std::process::Command::new(env!("CARGO"))
+        .args(["build", "-p", "streamlib-test-fixtures"])
+        .status()
+        .expect("invoking cargo build");
+    assert!(
+        status.success(),
+        "cargo build -p streamlib-test-fixtures must succeed"
+    );
+
+    let dylib_ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else if cfg!(target_os = "windows") {
+        "dll"
+    } else {
+        "so"
+    };
+    let dylib_name = format!("libstreamlib_test_fixtures.{}", dylib_ext);
+    let built_dylib = workspace_root
+        .join("target")
+        .join("debug")
+        .join(&dylib_name);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let fixtures_src = workspace_root.join("packages/test-fixtures");
+    let core_src = workspace_root.join("packages/core");
+    let fixtures_dst = tmp.path().join("test-fixtures");
+    let core_dst = tmp.path().join("core");
+
+    std::fs::create_dir_all(&fixtures_dst).unwrap();
+    std::fs::copy(
+        fixtures_src.join("streamlib.yaml"),
+        fixtures_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&fixtures_src.join("schemas"), &fixtures_dst.join("schemas"));
+
+    std::fs::create_dir_all(&core_dst).unwrap();
+    std::fs::copy(
+        core_src.join("streamlib.yaml"),
+        core_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&core_src.join("schemas"), &core_dst.join("schemas"));
+
+    let triple_dir = fixtures_dst.join("lib").join(host_target_triple());
+    std::fs::create_dir_all(&triple_dir).unwrap();
+    std::fs::copy(&built_dylib, triple_dir.join(&dylib_name)).unwrap();
+
+    let strategy = || Strategy::Path {
+        path: fixtures_dst.clone(),
+        build: BuildPolicy::NeverBuild,
+    };
+
+    // Load + lifecycle.
+    let runtime = Runner::with_auto_build().unwrap();
+    runtime
+        .add_module_with_blocking(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            strategy(),
+        )
+        .expect("initial load must succeed");
+    construct_destroy_lifecycle_smoke("initial load");
+    let libraries_after_first_load = loaded_plugin_library_count();
+    assert!(
+        libraries_after_first_load >= 1,
+        "the dlopen'd image must be retained after the first load"
+    );
+
+    // Remove: registrations gone, dylib image retained.
+    runtime
+        .remove_module(module_ident_any_version!("tatolab", "test-fixtures"))
+        .expect("remove_module must succeed with no graph consumers");
+    assert!(
+        !PROCESSOR_REGISTRY
+            .list_registered()
+            .iter()
+            .any(|d| d.name.package.as_str() == "test-fixtures"),
+        "remove_module must unregister every fixture processor"
+    );
+    assert!(
+        !streamlib_engine::schemas::current_schema_idents()
+            .iter()
+            .any(|id| id.starts_with("@tatolab/test-fixtures/")),
+        "remove_module must unregister the fixture's package-owned schemas"
+    );
+    assert_eq!(
+        loaded_plugin_library_count(),
+        libraries_after_first_load,
+        "remove_module must RETAIN the dylib image (dlclose is never called)"
+    );
+
+    // Reload the same package on the same runtime; lifecycle runs again.
+    runtime
+        .add_module_with_blocking(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            strategy(),
+        )
+        .expect("reload after remove_module must succeed");
+    construct_destroy_lifecycle_smoke("reload after remove_module");
+    assert!(
+        loaded_plugin_library_count() > libraries_after_first_load,
+        "the reload dlopens a fresh image entry — retention never dedups by path"
+    );
+}

--- a/libs/streamlib-engine/tests/load_project_dylib_transactional.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_transactional.rs
@@ -1,0 +1,189 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Transactional-registration integration test for the dlopen path:
+//! stage the real `packages/test-fixtures` cdylib with a DOCTORED
+//! `streamlib.yaml` that declares one phantom Rust processor the dylib
+//! never registers. The load fails at the declared-but-not-registered
+//! validation AFTER the cdylib's real registrations ran through the
+//! host callbacks (into the load's staging buffer) — so a rollback
+//! regression would leave every real fixture processor + schema
+//! visible. Asserts zero residue in both the processor and schema
+//! registries, the process stays alive, and a reload with the
+//! corrected manifest succeeds end-to-end including a
+//! construct/destroy lifecycle smoke through the cdylib vtable.
+
+use std::path::Path;
+
+use serial_test::serial;
+use streamlib::sdk::RunnerAutoBuild;
+use streamlib::sdk::module_ident_any_version;
+use streamlib::sdk::processors::{PROCESSOR_REGISTRY, ProcessorInstance};
+use streamlib::sdk::runtime::{BuildPolicy, Runner, Strategy};
+use streamlib_engine::core::graph::ProcessorNode;
+use streamlib_engine::core::runtime::host_target_triple;
+
+fn copy_dir_contents(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dst_entry = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_contents(&entry.path(), &dst_entry);
+        } else {
+            std::fs::copy(entry.path(), &dst_entry).unwrap();
+        }
+    }
+}
+
+/// Every fixture-owned entry that must NOT survive a failed load.
+fn assert_zero_test_fixtures_residue(context: &str) {
+    let leaked_processors: Vec<String> = PROCESSOR_REGISTRY
+        .list_registered()
+        .into_iter()
+        .filter(|desc| desc.name.package.as_str() == "test-fixtures")
+        .map(|desc| desc.name.to_string())
+        .collect();
+    assert!(
+        leaked_processors.is_empty(),
+        "{context}: failed load leaked processor registrations: {leaked_processors:?}",
+    );
+    let leaked_schemas: Vec<String> = streamlib_engine::schemas::current_schema_idents()
+        .into_iter()
+        .filter(|id| id.starts_with("@tatolab/test-fixtures/"))
+        .collect();
+    assert!(
+        leaked_schemas.is_empty(),
+        "{context}: failed load leaked schema registrations: {leaked_schemas:?}",
+    );
+}
+
+#[test]
+#[serial]
+fn failing_dlopen_load_leaves_zero_residue_and_reload_succeeds() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    // Build test-fixtures so the cdylib carries `STREAMLIB_PLUGIN`.
+    // Idempotent: cargo's incremental machinery skips on a warm tree.
+    let status = std::process::Command::new(env!("CARGO"))
+        .args(["build", "-p", "streamlib-test-fixtures"])
+        .status()
+        .expect("invoking cargo build");
+    assert!(
+        status.success(),
+        "cargo build -p streamlib-test-fixtures must succeed"
+    );
+
+    let dylib_ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else if cfg!(target_os = "windows") {
+        "dll"
+    } else {
+        "so"
+    };
+    let dylib_name = format!("libstreamlib_test_fixtures.{}", dylib_ext);
+    let built_dylib = workspace_root
+        .join("target")
+        .join("debug")
+        .join(&dylib_name);
+    assert!(
+        built_dylib.exists(),
+        "cdylib expected at {} after cargo build",
+        built_dylib.display()
+    );
+
+    // Stage test-fixtures + its `@tatolab/core` dep in a tempdir so the
+    // `patch: path: ../core` entry resolves naturally.
+    let tmp = tempfile::tempdir().unwrap();
+    let fixtures_src = workspace_root.join("packages/test-fixtures");
+    let core_src = workspace_root.join("packages/core");
+    let fixtures_dst = tmp.path().join("test-fixtures");
+    let core_dst = tmp.path().join("core");
+
+    std::fs::create_dir_all(&fixtures_dst).unwrap();
+    let pristine_manifest = std::fs::read_to_string(fixtures_src.join("streamlib.yaml")).unwrap();
+    copy_dir_contents(&fixtures_src.join("schemas"), &fixtures_dst.join("schemas"));
+
+    std::fs::create_dir_all(&core_dst).unwrap();
+    std::fs::copy(
+        core_src.join("streamlib.yaml"),
+        core_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&core_src.join("schemas"), &core_dst.join("schemas"));
+
+    let triple_dir = fixtures_dst.join("lib").join(host_target_triple());
+    std::fs::create_dir_all(&triple_dir).unwrap();
+    std::fs::copy(&built_dylib, triple_dir.join(&dylib_name)).unwrap();
+
+    // DOCTOR the manifest: append a phantom Rust processor entry the
+    // dylib does not register. Appended LAST, so every real processor's
+    // declared-but-not-registered validation passes against the staged
+    // registrations first — the failure fires with the full real
+    // registration set already staged.
+    let doctored_manifest = format!(
+        "{pristine_manifest}\n  - name: PhantomUnregisteredProcessor\n    \
+         version: 1.0.0\n    description: \"phantom Rust processor the dylib \
+         does not register — transactional-rollback integration fixture\"\n    \
+         execution: manual\n"
+    );
+    std::fs::write(fixtures_dst.join("streamlib.yaml"), &doctored_manifest).unwrap();
+
+    let runtime = Runner::with_auto_build().unwrap();
+    let err = runtime
+        .add_module_with_blocking(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            Strategy::Path {
+                path: fixtures_dst.clone(),
+                build: BuildPolicy::NeverBuild,
+            },
+        )
+        .expect_err("the phantom processor must fail the load");
+    let message = err.to_string();
+    assert!(
+        message.contains("PhantomUnregisteredProcessor")
+            && message.contains("not") // "not registered by the dylib"
+            && message.contains("registered"),
+        "the failure must name the phantom processor, got: {message}",
+    );
+
+    // Zero residue: the cdylib's REAL registrations ran through the host
+    // callbacks into the staging buffer, and the failed load dropped it.
+    assert_zero_test_fixtures_residue("after doctored load");
+
+    // Reload with the corrected manifest on the SAME runtime — proves
+    // the failed attempt poisoned nothing (memo, registries, ledger).
+    std::fs::write(fixtures_dst.join("streamlib.yaml"), &pristine_manifest).unwrap();
+    runtime
+        .add_module_with_blocking(
+            module_ident_any_version!("tatolab", "test-fixtures"),
+            Strategy::Path {
+                path: fixtures_dst.clone(),
+                build: BuildPolicy::NeverBuild,
+            },
+        )
+        .expect("reload with the corrected manifest must succeed");
+
+    // Lifecycle smoke: construct + destroy round-trips the cdylib vtable.
+    let descriptor = PROCESSOR_REGISTRY
+        .list_registered()
+        .into_iter()
+        .find(|d| d.name.r#type.as_str() == "TestConfiguredProcessor")
+        .expect("TestConfiguredProcessor must be registered after the reload");
+    let node = ProcessorNode::new(
+        descriptor.name.clone(),
+        "TestConfiguredProcessor",
+        None,
+        Vec::new(),
+        Vec::new(),
+    );
+    let instance = PROCESSOR_REGISTRY
+        .create(&node)
+        .expect("factory.create() must succeed after the reload");
+    assert!(matches!(instance, ProcessorInstance::VTable { .. }));
+    drop(instance);
+}


### PR DESCRIPTION
## Summary

Makes module loading atomic and implements `remove_module`. A load that fails partway now leaves **zero** partial schema/processor registration; a loaded package can be cleanly unregistered. Together these are the engine substrate for graceful dynamic graph modification — `add_processor`-triggered load failures become recoverable `Err`s instead of poisoned runtime state (the contract #1325 lazy discovery builds on).

## Shape (approved plan)

- **Staging/commit** (not journal+rollback): a `ModuleLoadRegistrationStaging` per top-level load collects schema/processor/library registrations during the recursive walk; nothing touches the global registries until the whole load succeeds. Invariant: *visible ⇒ permanently committed*.
- **Cdylib interception**: a thread-local `ACTIVE_CDYLIB_REGISTRATION_SINK` scope guard set only around `(decl.register)`, so the eager `STREAMLIB_PLUGIN` register callbacks stage instead of writing global registries — no plugin ABI change.
- **Deferred memo commit** with the same-walk diamond fix (`SkipOwnedByThisLoad`) and a typed cross-load timeout; commit under a process-wide `MODULE_REGISTRY_COMMIT_LOCK` (libraries → schemas → processors → ledger → memo flip).
- **`remove_module`**: ledger-driven; ordered checks (LoadInFlight, RequiredByLoadedModules, in-use with a TOCTOU-closing remove-then-check-then-restore); **dlclose is never called** — images retained for process lifetime (plugins own tokio runtimes/TLS; already the codebase's de-facto behavior), unload = registration removal.
- Adjacent in-scope fix: tightened `register_via_vtable`'s map-consistency ordering.

## Tests

Staging residue tests at each registration phase (schema/dep-walk/processor) with a `RegistrySnapshot` byte-equivalence gate; diamond regression; concurrent-load semantics; `remove_module` (unknown / required-by / in-use / schemas-only / load-remove-reload); a failing-dlopen integration test using the real fixture cdylib with a doctored manifest declaring a phantom processor. Arch docs updated (runtime-module-materialization, plugin-abi retention).

## Review round 1

Both reviewers PASS; one substantive fix + one cheap doc note landed on top of the reviewed commits.

- **Fail-loud gap (reviewer A §5) — fixed.** The only duplicate guard was `contains_staged_processor`, covering just the Rust/VTable branch. A staged **Dynamic** (Python/TS) processor ident was checked for neither duplication-within-load nor prior global registration; `config.processors` is a `Vec` with no dedup, so a manifest with two same-named subprocess processors staged the ident twice → the second `register_dynamic` erred **at commit**, was logged "bug-grade," and the load **returned Ok with a silently-incomplete registration** (unrecoverable on retry via `SkipAlreadyCommittedSameVersion`). New `ModuleLoadRegistrationStaging::validate_no_dynamic_processor_collisions` runs **at end-of-walk, before the commit lock**, and rejects a staged Dynamic ident that is duplicated within the load (against *any* staged processor, so a Dynamic-vs-VTable same-name collision is caught too) or already globally registered — typed `AddModuleError::DuplicateProcessorTypeInModule` / `ProcessorTypeAlreadyRegistered`, each naming the ident + declaring package. The failed load drops the walk context → zero residue. This makes the commit genuinely infallible-by-construction; the commit-time `register_dynamic` Err path stays as defensive dead code. Two new unit tests (`duplicate_dynamic_processor_name_fails_loud_zero_residue`, `dynamic_processor_colliding_with_global_registration_fails_loud`) assert the typed error + `RegistrySnapshot` before==after; mentally-reverting the gate makes the dup test return Ok with one processor registered.
- **Doc note (reviewer B) — added.** `runtime-module-materialization.md` now records that during a **refused** in-use `remove_module`, a concurrent same-type `add_processor` can transiently observe the unregister-scan-restore window as an `UnknownProcessorType` miss — a recoverable `Err`, consistent with the same-process-registry multi-Runner limitation, not corruption.
- **Optional (reviewer B) — done, trivial.** `RegistrySnapshot` now also captures the processor factory's `known_schemas()` port-schema universe, so a refused removal's schema-survival is locked by the byte-equivalence gate too.

## Notes for reviewers

- Rebased onto current `origin/main` (`946ea4be`) — vendored-vulkanalia #1321 + streamlib-add #1324. Zero conflicts; the #1324 `app_modules` re-exports and my `module_loader` re-exports coexist, and #1324's `source.rs`/`slpkg.rs` are untouched by this branch. `Cargo.lock` is the vendored resolution (`grep -c registry.tatolab.com Cargo.lock` = 0). The #1316 `link_checkout` threading and the staging params were merged in an earlier rebase, not clobbered.
- Multi-Runner-per-process is a documented limitation (registries+ledger global, memo+in-use per-Runner).
- Pre-existing lint noted, not fixed (out of scope): `clippy::result_large_err` fires across `module_loader` because `AddModuleError` is a large enum (engine-wide, ~32 instances). The two new round-1 variants carry `PackageRef` + `SchemaIdent`, no larger than the existing `SingleVersionConflict` variant, so no function newly crosses the threshold; boxing the enum is an engine-wide API refactor out of scope here.

## Validation (on the vendored base, local Linux)

- `cargo test -p streamlib-engine --lib module_loader` → **99 passed / 0 failed** (includes the two new collision tests + all round-0 suites).
- `cargo test -p streamlib-engine --test load_project_dylib_transactional` → **1 passed** (~19s).
- `cargo test -p streamlib-engine --test load_project_dylib_remove_module` → **1 passed** (~62s; log confirms `retained_dylib_images=1`, registrations removed, reload lifecycle re-runs).
- `cargo build --workspace` (baseline exclusions) → **exit 0**.
- Existing `load_project_dylib_*` suite → all green (one pre-existing non-blocking anomaly: `load_project_dylib_camera_smoke` fails to resolve `-p streamlib-camera`, unrelated to this branch).

Closes #1328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)