### PR TITLE
feat(runtime): lazy plugin auto-discovery from streamlib_modules/ — no load call in app code (#1325)

### DIFF
--- a/docs/architecture/runtime-module-materialization.md
+++ b/docs/architecture/runtime-module-materialization.md
@@ -22,8 +22,10 @@ deployment chooses to wire (or not).
 ```
  caller (runner app / CLI / daemon / AI host)
    │
-   │  runtime.add_module(ident)                         ← conservative: InstalledCache only
-   │  runtime.add_module_with(ident, Strategy)          ← explicit source + build policy
+   │  runtime.add_processor(spec)                        ← common: lazily loads the providing
+   │                                                        package on first reference (below)
+   │  runtime.add_module(ident)                         ← escape hatch: InstalledCache only
+   │  runtime.add_module_with(ident, Strategy)          ← escape hatch: explicit source + build policy
    │     └─ returns AddedModule : Future (eager — work spawns at call time)
    │  runtime.await_modules([a, b, …], on_event).await  ← concurrent, interleaved progress
    │  runtime.add_module_blocking(ident)                ← sync convenience (typed err in async ctx)
@@ -233,6 +235,68 @@ resolutions/builds before the caller awaits anything.
   accidental fire-and-forget).
 - `start()` hard-errors `ModulesStillLoading { idents }` if the graph is
   run while any load is still in flight.
+
+## Lazy plugin auto-discovery — no load call in app code
+
+App code never calls `add_module`. When `add_processor(ProcessorSpec::new(
+type, cfg))` references a processor type that isn't registered yet, the
+runtime **discovers and loads the providing package on first reference**
+from the app's `streamlib_modules/` folder — the gstreamer plugin-host
+model applied to a per-app module folder. `add_module` /
+`add_module_with(Strategy)` survive as an embedding / power-caller escape
+hatch, not a step common app code takes.
+
+The trigger is the same registry miss `add_v` already detects. Before a
+processor node is added, `add_processor` checks
+`PROCESSOR_REGISTRY.port_info(&spec.name)`. On a hit the type is already
+available and nothing loads — which is exactly why a **second reference
+to a type from an already-loaded package never reloads** the plugin. On a
+miss the runtime runs lazy discovery:
+
+1. **Discover.** Scan `<app-modules-root>/streamlib_modules/@org/name/streamlib.yaml`,
+   matching each manifest's `package:` org + name and its declared
+   processor short names against the referenced ident's `org` / `package`
+   / `type`. Discovery resolves the *provider package* by
+   `(org, package, type)` and ignores the reference-site version — the
+   installed version is pinned in `streamlib.lock` at `streamlib add`
+   time. The **terminal type resolution is still version-exact**, though:
+   `add_v` / `PROCESSOR_REGISTRY.port_info` match the referenced
+   `SchemaIdent` including its version. So a reference whose version
+   differs from the installed package's version loads the provider but
+   then resolves to `UnknownProcessorType`. A fully version-free
+   reference form is not available yet — a `SchemaIdent` at the
+   reference site still carries a concrete version.
+2. **Load.** Resolve the single matching package to
+   `add_module_with(ModuleIdent, Strategy::InstalledCache)` and drive it
+   through the **transactional load path** below. `InstalledCache` probes
+   the same `streamlib_modules/` folder, so discovery and load agree on
+   the source.
+3. **Proceed.** After the load commits, the type is registered and
+   `add_processor` adds a healthy node.
+
+Because the lazy load rides transactional registration, a failure leaves
+**zero partial state** — the graph keeps being modified and the runtime
+keeps running. `add_processor` returns a typed, recoverable error rather
+than crashing:
+
+- **No package provides the type** → `Error::UnknownProcessorType` (the
+  pre-existing miss behavior; the failed node stays in the graph in
+  `Error` state for observability).
+- **Two folders declare the same type** → `Error::AmbiguousProcessorTypeProviders`
+  (a malformed install; discovery refuses to guess).
+- **A discovered package fails to load** → `Error::LazyModuleLoadFailed`
+  naming the type, the package, and the underlying reason.
+
+### The modules-dir
+
+The app-modules root defaults to the process working directory (so
+`<cwd>/streamlib_modules/` is the folder), matching where `streamlib add`
+writes. A daemon / host tells the runtime an explicit root — GST_PLUGIN_PATH-style
+— via `Runner::set_app_modules_dir(app_root)` (process-wide) or the
+`STREAMLIB_MODULES_DIR` env var; the runtime override wins over the env
+var, which wins over the working directory. Discovery and
+`Strategy::InstalledCache` resolution both read the same root, so they
+never disagree.
 
 ## Transactional registration — staged commit
 

--- a/libs/streamlib-engine/src/core/runtime/module_loader/lazy_discovery.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/lazy_discovery.rs
@@ -1,0 +1,351 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Lazy plugin auto-discovery: given a referenced processor-type
+//! [`SchemaIdent`] whose type is not yet registered, scan the app's
+//! `streamlib_modules/` folder to find the package that declares it, so the
+//! runtime can load that package on first reference without the app calling
+//! `add_module`.
+//!
+//! Discovery matches a manifest's `package:` block org + name and its
+//! declared processor short names against the referenced ident's `org` /
+//! `package` / `type`. The referenced version is deliberately ignored — the
+//! installed version is pinned in `streamlib.lock` at `streamlib add` time,
+//! not at the `add_processor` reference site.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use streamlib_idents::app_modules::APP_MODULES_DIR_NAME;
+use streamlib_idents::{ModuleIdent, PackageRef, SemVerRange};
+use streamlib_processor_schema::ProjectConfigMinimal;
+
+use crate::core::descriptors::SchemaIdent;
+use crate::core::error::{Error, Result};
+
+/// A `streamlib_modules/@org/name` package folder whose manifest declares a
+/// processor matching the referenced ident.
+struct ProviderMatch {
+    package: PackageRef,
+    package_dir: PathBuf,
+}
+
+/// Resolve the module that provides `processor_type` by scanning
+/// `<app_modules_root>/streamlib_modules/`.
+///
+/// - `Ok(Some(module_ident))` — exactly one package declares the type; load
+///   this module.
+/// - `Ok(None)` — no package in `streamlib_modules/` declares the type (or
+///   the folder is absent). The caller degrades to the existing
+///   [`Error::UnknownProcessorType`] path.
+/// - `Err(Error::AmbiguousProcessorTypeProviders)` — two or more package
+///   folders declare the same type; a malformed install the caller cannot
+///   resolve automatically.
+#[tracing::instrument(skip(app_modules_root), fields(processor_type = %processor_type))]
+pub(super) fn resolve_providing_module(
+    app_modules_root: &Path,
+    processor_type: &SchemaIdent,
+) -> Result<Option<ModuleIdent>> {
+    let modules_dir = app_modules_root.join(APP_MODULES_DIR_NAME);
+    if !modules_dir.is_dir() {
+        tracing::debug!(
+            modules_dir = %modules_dir.display(),
+            "no streamlib_modules/ folder — nothing to lazily discover"
+        );
+        return Ok(None);
+    }
+
+    let matches = scan_for_providers(&modules_dir, processor_type)?;
+
+    match matches.len() {
+        0 => {
+            tracing::debug!(
+                modules_dir = %modules_dir.display(),
+                "no package in streamlib_modules/ declares the referenced processor type"
+            );
+            Ok(None)
+        }
+        1 => {
+            let found = &matches[0];
+            tracing::info!(
+                package = %found.package,
+                source = %found.package_dir.display(),
+                "lazily discovered the package providing the referenced processor type"
+            );
+            // Load by @org/name at any version — the installed version is
+            // pinned in streamlib.lock, resolved by Strategy::InstalledCache
+            // against the same streamlib_modules/ folder.
+            Ok(Some(ModuleIdent::new(
+                found.package.org.clone(),
+                found.package.name.clone(),
+                SemVerRange::Any,
+            )))
+        }
+        _ => {
+            // Two or more folders declare the same type. Impossible for a
+            // well-formed install (a fully-qualified type embeds its package,
+            // and `streamlib add` writes one slot per @org/name), so this is a
+            // duplicate/malformed folder the caller must resolve by hand.
+            let mut packages: Vec<PackageRef> =
+                matches.iter().map(|m| m.package.clone()).collect();
+            packages.sort_by_key(|p| p.to_string());
+            tracing::warn!(
+                processor_type = %processor_type,
+                folders = matches.len(),
+                "ambiguous processor-type providers in streamlib_modules/"
+            );
+            Err(Error::AmbiguousProcessorTypeProviders {
+                processor_type: processor_type.clone(),
+                packages,
+            })
+        }
+    }
+}
+
+/// Walk `streamlib_modules/@org/name` and collect every package folder whose
+/// manifest declares a processor matching `processor_type`. A malformed or
+/// unreadable manifest is skipped (warned) rather than failing the scan — a
+/// single broken folder must not defeat discovery of a valid sibling.
+fn scan_for_providers(
+    modules_dir: &Path,
+    processor_type: &SchemaIdent,
+) -> Result<Vec<ProviderMatch>> {
+    let mut matches = Vec::new();
+    // Guard against a duplicate physical directory landing in the result twice.
+    let mut seen_dirs: BTreeSet<PathBuf> = BTreeSet::new();
+
+    let org_entries = std::fs::read_dir(modules_dir).map_err(|e| {
+        Error::Configuration(format!(
+            "scanning streamlib_modules/ at {} for lazy discovery: {e}",
+            modules_dir.display()
+        ))
+    })?;
+
+    for org_entry in org_entries.flatten() {
+        let org_dir = org_entry.path();
+        if !org_dir.is_dir() || is_ignored_entry(&org_entry.file_name()) {
+            continue;
+        }
+        let name_entries = match std::fs::read_dir(&org_dir) {
+            Ok(entries) => entries,
+            Err(e) => {
+                tracing::warn!(
+                    dir = %org_dir.display(),
+                    error = %e,
+                    "skipping unreadable streamlib_modules/ org folder during lazy discovery"
+                );
+                continue;
+            }
+        };
+        for name_entry in name_entries.flatten() {
+            let package_dir = name_entry.path();
+            if !package_dir.is_dir() || is_ignored_entry(&name_entry.file_name()) {
+                continue;
+            }
+            if !seen_dirs.insert(package_dir.clone()) {
+                continue;
+            }
+            if let Some(package) = package_declares_processor(&package_dir, processor_type) {
+                matches.push(ProviderMatch {
+                    package,
+                    package_dir,
+                });
+            }
+        }
+    }
+
+    Ok(matches)
+}
+
+/// Whether the `streamlib.yaml` at `package_dir` declares the referenced
+/// ident's owning package (matching org and name) AND a processor whose short
+/// name equals the referenced type name. Returns the owning [`PackageRef`] on
+/// a match; a missing / unreadable / malformed manifest is treated as "no
+/// match" (this folder just isn't the provider).
+fn package_declares_processor(
+    package_dir: &Path,
+    processor_type: &SchemaIdent,
+) -> Option<PackageRef> {
+    let manifest_path = package_dir.join(streamlib_idents::Manifest::FILE_NAME);
+    let content = std::fs::read_to_string(&manifest_path).ok()?;
+    let config: ProjectConfigMinimal = match serde_yaml::from_str(&content) {
+        Ok(config) => config,
+        Err(e) => {
+            tracing::warn!(
+                manifest = %manifest_path.display(),
+                error = %e,
+                "skipping unparseable streamlib.yaml during lazy discovery"
+            );
+            return None;
+        }
+    };
+    let package = config.package.as_ref()?;
+    if package.org.as_str() != processor_type.org.as_str()
+        || package.name.as_str() != processor_type.package.as_str()
+    {
+        return None;
+    }
+    let declares_type = config
+        .processors
+        .iter()
+        .any(|processor| processor.name == processor_type.r#type.as_str());
+    if declares_type {
+        Some(PackageRef::new(package.org.clone(), package.name.clone()))
+    } else {
+        None
+    }
+}
+
+/// Directory entries readers of `streamlib_modules/` must skip: dot-prefixed
+/// (in-flight `.staging-*` promotes and any hidden folder).
+fn is_ignored_entry(file_name: &std::ffi::OsStr) -> bool {
+    file_name
+        .to_str()
+        .map(|name| name.starts_with('.'))
+        .unwrap_or(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Write a `streamlib_modules/@org/name/streamlib.yaml` under `root`
+    /// declaring `processors` (short names) for package `@org/name`.
+    fn write_package(root: &Path, org: &str, name: &str, processors: &[&str]) {
+        write_package_at(root, &format!("@{org}"), name, org, name, processors);
+    }
+
+    /// Write a package at an arbitrary `<dir_org>/<dir_name>` slot whose
+    /// manifest declares `manifest_org`/`manifest_name` — lets a test build a
+    /// folder whose path disagrees with its declared identity (the malformed
+    /// duplicate case).
+    fn write_package_at(
+        root: &Path,
+        dir_org: &str,
+        dir_name: &str,
+        manifest_org: &str,
+        manifest_name: &str,
+        processors: &[&str],
+    ) {
+        let dir = root.join(APP_MODULES_DIR_NAME).join(dir_org).join(dir_name);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut yaml = format!(
+            "package:\n  org: {manifest_org}\n  name: {manifest_name}\n  version: 1.0.0\nprocessors:\n"
+        );
+        for proc in processors {
+            yaml.push_str(&format!(
+                "  - name: {proc}\n    version: 1.0.0\n    description: d\n    runtime: rust\n    \
+                 execution: manual\n    inputs: []\n    outputs: []\n"
+            ));
+        }
+        std::fs::write(dir.join("streamlib.yaml"), yaml).unwrap();
+    }
+
+    fn ident(org: &str, package: &str, type_name: &str) -> SchemaIdent {
+        SchemaIdent::new(
+            streamlib_idents::Org::new(org).unwrap(),
+            streamlib_idents::Package::new(package).unwrap(),
+            streamlib_idents::TypeName::new(type_name).unwrap(),
+            streamlib_idents::SemVer::new(1, 0, 0),
+        )
+    }
+
+    #[test]
+    fn resolves_single_provider() {
+        let root = tempfile::tempdir().unwrap();
+        write_package(root.path(), "tatolab", "camera", &["Camera", "Preview"]);
+        write_package(root.path(), "tatolab", "display", &["Display"]);
+
+        let resolved =
+            resolve_providing_module(root.path(), &ident("tatolab", "camera", "Camera")).unwrap();
+        let module = resolved.expect("Camera must resolve to the camera package");
+        assert_eq!(module.package_ref().to_string(), "@tatolab/camera");
+    }
+
+    #[test]
+    fn returns_none_when_no_package_declares_the_type() {
+        let root = tempfile::tempdir().unwrap();
+        write_package(root.path(), "tatolab", "camera", &["Camera"]);
+
+        // Package present, but no folder declares `Ghost`.
+        let resolved =
+            resolve_providing_module(root.path(), &ident("tatolab", "camera", "Ghost")).unwrap();
+        assert!(resolved.is_none(), "an undeclared type must resolve to None");
+
+        // Package absent entirely.
+        let resolved =
+            resolve_providing_module(root.path(), &ident("tatolab", "missing", "Thing")).unwrap();
+        assert!(resolved.is_none(), "an absent package must resolve to None");
+    }
+
+    #[test]
+    fn returns_none_when_modules_folder_absent() {
+        let root = tempfile::tempdir().unwrap();
+        // No streamlib_modules/ folder created at all.
+        let resolved =
+            resolve_providing_module(root.path(), &ident("tatolab", "camera", "Camera")).unwrap();
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn ambiguous_when_two_folders_declare_the_same_type() {
+        // Two folders whose manifests both declare @tatolab/dup/Thing — a
+        // malformed install (the second folder's path disagrees with its
+        // declared identity). Discovery must refuse rather than pick one.
+        let root = tempfile::tempdir().unwrap();
+        write_package(root.path(), "tatolab", "dup", &["Thing"]);
+        write_package_at(root.path(), "@tatolab", "dup-alias", "tatolab", "dup", &["Thing"]);
+
+        let err = resolve_providing_module(root.path(), &ident("tatolab", "dup", "Thing"))
+            .expect_err("two folders declaring the same type must be ambiguous");
+        match err {
+            Error::AmbiguousProcessorTypeProviders {
+                processor_type,
+                packages,
+            } => {
+                assert_eq!(processor_type.r#type.as_str(), "Thing");
+                assert_eq!(packages.len(), 2, "both folders must be reported");
+            }
+            other => panic!("expected AmbiguousProcessorTypeProviders, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn skips_staging_and_hidden_entries() {
+        let root = tempfile::tempdir().unwrap();
+        write_package(root.path(), "tatolab", "camera", &["Camera"]);
+        // A `.staging-` org-level entry must not be scanned even if it holds a
+        // manifest declaring the type.
+        write_package_at(
+            root.path(),
+            ".staging-tatolab",
+            "camera",
+            "tatolab",
+            "camera",
+            &["Camera"],
+        );
+
+        let resolved =
+            resolve_providing_module(root.path(), &ident("tatolab", "camera", "Camera")).unwrap();
+        // Only the real folder matches — the staging one is skipped, so it's a
+        // single (not ambiguous) match.
+        assert!(resolved.is_some(), "the real package must still resolve");
+    }
+
+    #[test]
+    fn version_at_reference_site_is_ignored() {
+        // The manifest declares version 1.0.0; a reference at 9.9.9 (different
+        // version) still resolves the package — the reference site carries no
+        // binding version, streamlib.lock pins it.
+        let root = tempfile::tempdir().unwrap();
+        write_package(root.path(), "tatolab", "camera", &["Camera"]);
+        let referenced = SchemaIdent::new(
+            streamlib_idents::Org::new("tatolab").unwrap(),
+            streamlib_idents::Package::new("camera").unwrap(),
+            streamlib_idents::TypeName::new("Camera").unwrap(),
+            streamlib_idents::SemVer::new(9, 9, 9),
+        );
+        let resolved = resolve_providing_module(root.path(), &referenced).unwrap();
+        assert!(resolved.is_some(), "version at reference site must not gate discovery");
+    }
+}

--- a/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -59,6 +59,7 @@ use crate::iceoryx2::Iceoryx2Node;
 mod added_module;
 mod build_orchestrator;
 mod errors;
+mod lazy_discovery;
 mod ledger;
 mod locked;
 mod processor_registration;
@@ -698,5 +699,174 @@ impl Runner {
             .values()
             .map(|(_, module)| module.clone())
             .collect()
+    }
+}
+
+/// Build the recoverable [`Error::LazyModuleLoadFailed`] for a discovered
+/// package that failed to load, naming the type and its providing package.
+fn lazy_module_load_failed(
+    processor_type: &crate::core::descriptors::SchemaIdent,
+    error: AddModuleError,
+) -> crate::core::error::Error {
+    crate::core::error::Error::LazyModuleLoadFailed {
+        processor_type: processor_type.clone(),
+        package: streamlib_idents::PackageRef::new(
+            processor_type.org.clone(),
+            processor_type.package.clone(),
+        ),
+        detail: error.to_string(),
+    }
+}
+
+impl Runner {
+    // =========================================================================
+    // Lazy plugin auto-discovery — the first-reference load hook
+    // =========================================================================
+
+    /// Set the directory that contains the app's `streamlib_modules/` folder,
+    /// used for lazy plugin discovery and every [`Strategy::InstalledCache`]
+    /// resolution (GST_PLUGIN_PATH-style). **Process-wide** — an associated
+    /// function, not a per-`Runner` setting: it overrides the resolution for
+    /// the whole process, and the last write wins. Unset, resolution falls
+    /// back to the `STREAMLIB_MODULES_DIR` env var, then the process working
+    /// directory.
+    pub fn set_app_modules_dir(app_root: impl Into<std::path::PathBuf>) {
+        source::set_app_modules_root_override(Some(app_root.into()));
+    }
+
+    /// Clear a previously-set [`Self::set_app_modules_dir`] override, restoring
+    /// the env-var / working-directory default. Process-wide.
+    pub fn clear_app_modules_dir() {
+        source::set_app_modules_root_override(None);
+    }
+
+    /// Begin a lazy load of the package that provides `processor_type`, when
+    /// the type isn't registered yet. Returns the in-flight [`AddedModule`] to
+    /// drive to completion, or `None` when nothing needs loading (the type is
+    /// already available — the fast path a second reference to an
+    /// already-loaded package takes — or no package in `streamlib_modules/`
+    /// declares it). An ambiguous discovery is a typed `Err`.
+    fn begin_lazy_provider_load(
+        &self,
+        processor_type: &crate::core::descriptors::SchemaIdent,
+    ) -> std::result::Result<Option<AddedModule>, crate::core::error::Error> {
+        if crate::core::processors::PROCESSOR_REGISTRY
+            .port_info(processor_type)
+            .is_some()
+        {
+            return Ok(None);
+        }
+        let Some(app_modules_root) = source::app_modules_root() else {
+            return Ok(None);
+        };
+        match lazy_discovery::resolve_providing_module(&app_modules_root, processor_type)? {
+            Some(module_ident) => {
+                Ok(Some(self.add_module_with(module_ident, Strategy::InstalledCache)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Lazily discover + load the plugin providing `processor_type` on first
+    /// reference, awaiting completion. Returns `Some(error)` — recoverable,
+    /// the runtime keeps running — when discovery is ambiguous or a discovered
+    /// package failed to load; `None` when the type is already available or no
+    /// package provides it (the caller then degrades to the existing
+    /// `UnknownProcessorType` path). The transactional load leaves zero
+    /// partial registration state on failure.
+    #[tracing::instrument(skip(self), fields(processor_type = %processor_type))]
+    pub(crate) async fn lazily_load_provider_for_processor_type(
+        &self,
+        processor_type: &crate::core::descriptors::SchemaIdent,
+    ) -> Option<crate::core::error::Error> {
+        match self.begin_lazy_provider_load(processor_type) {
+            Ok(Some(added)) => match added.await {
+                Ok(_) => None,
+                Err(e) => Some(lazy_module_load_failed(processor_type, e)),
+            },
+            Ok(None) => None,
+            Err(e) => Some(e),
+        }
+    }
+
+    /// Blocking sibling of [`Self::lazily_load_provider_for_processor_type`]
+    /// for the synchronous `add_processor` path on an external tokio handle,
+    /// where the load future cannot be `.await`ed inline.
+    pub(crate) fn lazily_load_provider_for_processor_type_blocking(
+        &self,
+        processor_type: &crate::core::descriptors::SchemaIdent,
+    ) -> Option<crate::core::error::Error> {
+        let added = match self.begin_lazy_provider_load(processor_type) {
+            Ok(Some(added)) => added,
+            Ok(None) => return None,
+            Err(e) => return Some(e),
+        };
+        match self.drive_added_module_to_completion_blocking(added) {
+            Ok(()) => None,
+            Err(e) => Some(lazy_module_load_failed(processor_type, e)),
+        }
+    }
+
+    /// Drive a single [`AddedModule`] to completion from a synchronous caller,
+    /// variant-aware: `block_on` on an owned runtime, spawn-and-channel on an
+    /// external handle (can't `block_on` from a worker thread).
+    fn drive_added_module_to_completion_blocking(
+        &self,
+        added: AddedModule,
+    ) -> std::result::Result<(), AddModuleError> {
+        match &self.tokio_runtime_variant {
+            TokioRuntimeVariant::OwnedTokioRuntime(rt) => rt.block_on(added).map(|_| ()),
+            TokioRuntimeVariant::ExternalTokioHandle(handle) => {
+                let ident = added.ident().clone();
+                let (tx, rx) = std::sync::mpsc::channel();
+                handle.spawn(async move {
+                    let _ = tx.send(added.await);
+                });
+                match rx.recv() {
+                    Ok(result) => result.map(|_| ()),
+                    Err(_) => Err(AddModuleError::LoadTaskPanicked {
+                        module: ident,
+                        detail: "lazy load task channel closed".into(),
+                    }),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod lazy_load_error_tests {
+    use super::*;
+
+    /// The recoverable lazy-load error names the referenced type, derives its
+    /// providing package `@org/name` from the type's own org + package, and
+    /// carries the underlying load-failure detail. Shared by the async and
+    /// blocking lazy paths.
+    #[test]
+    fn lazy_module_load_failed_names_type_package_and_detail() {
+        let processor_type = crate::core::descriptors::SchemaIdent::new(
+            streamlib_idents::Org::new("tatolab").unwrap(),
+            streamlib_idents::Package::new("camera").unwrap(),
+            streamlib_idents::TypeName::new("Camera").unwrap(),
+            streamlib_idents::SemVer::new(1, 0, 0),
+        );
+        let underlying = AddModuleError::ModuleNotFound {
+            package: streamlib_idents::PackageRef::new(
+                streamlib_idents::Org::new("tatolab").unwrap(),
+                streamlib_idents::Package::new("camera").unwrap(),
+            ),
+        };
+        match lazy_module_load_failed(&processor_type, underlying) {
+            crate::core::error::Error::LazyModuleLoadFailed {
+                processor_type: reported_type,
+                package,
+                detail,
+            } => {
+                assert_eq!(reported_type, processor_type);
+                assert_eq!(package.to_string(), "@tatolab/camera");
+                assert!(!detail.is_empty(), "the underlying reason must be carried");
+            }
+            other => panic!("expected LazyModuleLoadFailed, got {other:?}"),
+        }
     }
 }

--- a/libs/streamlib-engine/src/core/runtime/module_loader/source.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/source.rs
@@ -313,7 +313,7 @@ pub(super) fn resolve_strategy_to_source(
     }
     match strategy {
         Strategy::InstalledCache => {
-            resolve_installed_cache_strategy(pkg_ref, app_modules_probe_root().as_deref())
+            resolve_installed_cache_strategy(pkg_ref, app_modules_root().as_deref())
         }
         Strategy::Slpkg { path } => {
             let extracted = extract_slpkg_to_cache(path).map_err(|e| {
@@ -457,10 +457,44 @@ fn resolve_installed_cache_strategy(
     Ok(source_for_resolved_dir(pkg_ref, dir))
 }
 
-/// The app-modules probe anchor: the exact process working directory (no
-/// walk-up). `None` when the cwd is unresolvable — resolution then proceeds
-/// with the installed cache alone.
-fn app_modules_probe_root() -> Option<PathBuf> {
+/// Environment override for the directory that contains the app's
+/// `streamlib_modules/` folder — the GST_PLUGIN_PATH-style default a
+/// daemon/host sets. A runtime override ([`set_app_modules_root_override`])
+/// takes precedence.
+pub(crate) const APP_MODULES_DIR_ENV: &str = "STREAMLIB_MODULES_DIR";
+
+/// Process-wide override for the app-modules root, set via
+/// [`Runner::set_app_modules_dir`]. `None` falls back to the env var, then the
+/// process working directory.
+///
+/// [`Runner::set_app_modules_dir`]: super::super::Runner::set_app_modules_dir
+static APP_MODULES_ROOT_OVERRIDE: std::sync::RwLock<Option<PathBuf>> =
+    std::sync::RwLock::new(None);
+
+/// Tell the module loader which directory contains the app's
+/// `streamlib_modules/` folder for lazy discovery and [`Strategy::InstalledCache`]
+/// resolution. `None` clears the override (back to env / cwd).
+pub(crate) fn set_app_modules_root_override(root: Option<PathBuf>) {
+    *APP_MODULES_ROOT_OVERRIDE
+        .write()
+        .expect("app-modules root override lock poisoned") = root;
+}
+
+/// The app-modules root: the runtime-set override, else the
+/// `STREAMLIB_MODULES_DIR` env var, else the exact process working directory
+/// (no walk-up). `None` only when the cwd is unresolvable and neither override
+/// nor env is set — resolution then proceeds with the installed cache alone.
+pub(crate) fn app_modules_root() -> Option<PathBuf> {
+    if let Some(root) = APP_MODULES_ROOT_OVERRIDE
+        .read()
+        .expect("app-modules root override lock poisoned")
+        .clone()
+    {
+        return Some(root);
+    }
+    if let Some(env) = std::env::var_os(APP_MODULES_DIR_ENV).filter(|env| !env.is_empty()) {
+        return Some(PathBuf::from(env));
+    }
     std::env::current_dir().ok()
 }
 

--- a/libs/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -20,9 +20,19 @@ use crate::core::{Error, InputLinkPortRef, OutputLinkPortRef, PortDirection, Res
 // =============================================================================
 
 /// Core implementation for add_processor - takes owned Arcs for 'static lifetime.
+///
+/// `lazy_error` carries the outcome of the lazy plugin-discovery step the
+/// caller ran before this (see [`Runner::lazily_load_provider_for_processor_type`]):
+/// `Some` when discovery was ambiguous or a discovered package failed to load.
+/// On a registry miss it is returned in place of the generic
+/// [`Error::UnknownProcessorType`], so the app sees the specific recoverable
+/// reason while the failed node is still surfaced in the graph for
+/// observability. `None` (type available after the lazy load, or no package
+/// provided it) leaves the existing behavior unchanged.
 async fn add_processor_impl(
     compiler: Arc<Compiler>,
     spec: ProcessorSpec,
+    lazy_error: Option<Error>,
 ) -> Result<ProcessorUniqueId> {
     let emit_will_add = |id: &ProcessorUniqueId| {
         PUBSUB.publish(
@@ -70,9 +80,13 @@ async fn add_processor_impl(
         if registry_miss {
             emit_will_add(&node_id);
             emit_did_add(&node_id);
-            return Err(Error::UnknownProcessorType {
+            // A specific lazy-discovery failure (ambiguous providers, or a
+            // discovered package that failed to load) supersedes the generic
+            // unknown-type error; a plain "no package provides it" leaves
+            // `lazy_error` None and falls back to UnknownProcessorType.
+            return Err(lazy_error.unwrap_or(Error::UnknownProcessorType {
                 ident: ident_for_err,
-            });
+            }));
         }
 
         emit_will_add(&node_id);
@@ -274,7 +288,16 @@ impl RuntimeOperations for Runner {
 
     fn add_processor_async(&self, spec: ProcessorSpec) -> BoxFuture<'_, Result<ProcessorUniqueId>> {
         let compiler = Arc::clone(&self.compiler);
-        Box::pin(add_processor_impl(compiler, spec))
+        Box::pin(async move {
+            // Lazy plugin auto-discovery: if the referenced processor type
+            // isn't registered, discover + load the providing package from
+            // streamlib_modules/ on first reference. A recoverable failure is
+            // threaded into add_processor_impl (the runtime keeps running).
+            let lazy_error = self
+                .lazily_load_provider_for_processor_type(&spec.name)
+                .await;
+            add_processor_impl(compiler, spec, lazy_error).await
+        })
     }
 
     fn remove_processor_async(&self, processor_id: ProcessorUniqueId) -> BoxFuture<'_, Result<()>> {
@@ -307,13 +330,19 @@ impl RuntimeOperations for Runner {
     fn add_processor(&self, spec: ProcessorSpec) -> Result<ProcessorUniqueId> {
         match &self.tokio_runtime_variant {
             TokioRuntimeVariant::OwnedTokioRuntime(rt) => {
+                // The async path runs the lazy plugin-discovery step itself.
                 rt.block_on(self.add_processor_async(spec))
             }
             TokioRuntimeVariant::ExternalTokioHandle(handle) => {
+                // Can't `.await` the borrowing lazy-load future in the spawned
+                // 'static task, so drive lazy discovery to completion here
+                // (blocking) and hand the outcome to the owned add_processor_impl.
+                let lazy_error =
+                    self.lazily_load_provider_for_processor_type_blocking(&spec.name);
                 let compiler = Arc::clone(&self.compiler);
                 let (tx, rx) = std::sync::mpsc::channel();
                 handle.spawn(async move {
-                    let result = add_processor_impl(compiler, spec).await;
+                    let result = add_processor_impl(compiler, spec, lazy_error).await;
                     let _ = tx.send(result);
                 });
                 rx.recv()

--- a/libs/streamlib-engine/tests/load_project_dylib_lazy_discovery.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_lazy_discovery.rs
@@ -1,0 +1,320 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Lazy plugin auto-discovery integration test: stage the real
+//! `packages/test-fixtures` cdylib inside a temp app's `streamlib_modules/`
+//! folder, tell the runtime where that folder is, then drive the whole thing
+//! through `add_processor` ALONE — no `add_module` call in the "app" code.
+//!
+//! Locks the shipped contract of #1325:
+//! 1. `add_processor(<type>)` for a type whose package sits in
+//!    `streamlib_modules/` lazily loads the providing plugin on first
+//!    reference and the processor lands healthy.
+//! 2. A second reference to a type from the already-loaded package does NOT
+//!    reload the plugin (the retained-image count stays flat).
+//! 3. `add_processor` for an absent package returns a typed error AND the
+//!    runtime keeps operating — a subsequent valid `add_processor` succeeds.
+//! 4. The lazily-loaded cdylib constructs through its vtable
+//!    (construct/destroy lifecycle smoke).
+
+use std::path::Path;
+
+use serial_test::serial;
+use streamlib::sdk::error::Error;
+use streamlib::sdk::processors::{PROCESSOR_REGISTRY, ProcessorInstance, ProcessorSpec};
+use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::{RunnerAutoBuild, schema_ident};
+use streamlib_engine::core::graph::ProcessorNode;
+use streamlib_engine::core::runtime::{host_target_triple, loaded_plugin_library_count};
+
+fn copy_dir_contents(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dst_entry = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_contents(&entry.path(), &dst_entry);
+        } else {
+            std::fs::copy(entry.path(), &dst_entry).unwrap();
+        }
+    }
+}
+
+/// Clears the process-wide app-modules override on drop, so a panicking test
+/// can't leak a stale (deleted-tempdir) root into a later one.
+struct AppModulesDirGuard;
+impl Drop for AppModulesDirGuard {
+    fn drop(&mut self) {
+        Runner::clear_app_modules_dir();
+    }
+}
+
+/// Stage a manifest-only package at
+/// `<app_root>/streamlib_modules/<dir_org>/<dir_name>/streamlib.yaml` declaring
+/// `<pkg_org>/<pkg_name>` and one Rust processor `<proc>`. When `with_cargo` is
+/// set, drop a `Cargo.toml` beside it so the loader classifies it as buildable
+/// Rust source (no prebuilt) — an unbuildable package under a no-orchestrator
+/// runtime.
+fn write_manifest_package(
+    app_root: &Path,
+    dir_org: &str,
+    dir_name: &str,
+    pkg_org: &str,
+    pkg_name: &str,
+    proc: &str,
+    with_cargo: bool,
+) {
+    let dir = app_root
+        .join("streamlib_modules")
+        .join(dir_org)
+        .join(dir_name);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("streamlib.yaml"),
+        format!(
+            "package:\n  org: {pkg_org}\n  name: {pkg_name}\n  version: 1.0.0\nprocessors:\n  \
+             - name: {proc}\n    version: 1.0.0\n    description: d\n    runtime: rust\n    \
+             execution: manual\n    inputs: []\n    outputs: []\n"
+        ),
+    )
+    .unwrap();
+    if with_cargo {
+        std::fs::write(dir.join("Cargo.toml"), b"[package]\nname='x'\nversion='0.0.0'\n").unwrap();
+    }
+}
+
+/// Stage `packages/test-fixtures` (prebuilt cdylib) + its `@tatolab/core` dep
+/// into `<app_root>/streamlib_modules/@tatolab/{test-fixtures,core}` and return
+/// the app root. The `patch: path: ../core` in test-fixtures' manifest resolves
+/// `@tatolab/core` to the sibling slot, which is exactly where core lands.
+fn stage_app_modules(app_root: &Path) {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    // Build test-fixtures so the cdylib carries `STREAMLIB_PLUGIN`. Idempotent
+    // — cargo's incremental machinery skips on a warm tree.
+    let status = std::process::Command::new(env!("CARGO"))
+        .args(["build", "-p", "streamlib-test-fixtures"])
+        .status()
+        .expect("invoking cargo build");
+    assert!(
+        status.success(),
+        "cargo build -p streamlib-test-fixtures must succeed"
+    );
+
+    let dylib_ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else if cfg!(target_os = "windows") {
+        "dll"
+    } else {
+        "so"
+    };
+    let dylib_name = format!("libstreamlib_test_fixtures.{}", dylib_ext);
+    let built_dylib = workspace_root
+        .join("target")
+        .join("debug")
+        .join(&dylib_name);
+    assert!(
+        built_dylib.exists(),
+        "cdylib expected at {} after cargo build",
+        built_dylib.display()
+    );
+
+    let modules_dir = app_root.join("streamlib_modules");
+    let fixtures_src = workspace_root.join("packages/test-fixtures");
+    let core_src = workspace_root.join("packages/core");
+    let fixtures_dst = modules_dir.join("@tatolab").join("test-fixtures");
+    let core_dst = modules_dir.join("@tatolab").join("core");
+
+    std::fs::create_dir_all(&fixtures_dst).unwrap();
+    std::fs::copy(
+        fixtures_src.join("streamlib.yaml"),
+        fixtures_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&fixtures_src.join("schemas"), &fixtures_dst.join("schemas"));
+
+    std::fs::create_dir_all(&core_dst).unwrap();
+    std::fs::copy(
+        core_src.join("streamlib.yaml"),
+        core_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&core_src.join("schemas"), &core_dst.join("schemas"));
+
+    // Stage the prebuilt cdylib under `lib/<host-triple>/` — the layout
+    // `Strategy::InstalledCache` prefers (compiler-free load, no orchestrator
+    // build needed).
+    let triple_dir = fixtures_dst.join("lib").join(host_target_triple());
+    std::fs::create_dir_all(&triple_dir).unwrap();
+    std::fs::copy(&built_dylib, triple_dir.join(&dylib_name)).unwrap();
+}
+
+#[test]
+#[serial]
+fn add_processor_lazily_loads_plugin_from_streamlib_modules_with_no_load_call() {
+    let app = tempfile::tempdir().unwrap();
+    stage_app_modules(app.path());
+
+    // The runtime is TOLD which directory holds streamlib_modules/ — the
+    // daemon/host modules-dir form (process-wide, GST_PLUGIN_PATH-style). No
+    // add_module / add_module_with anywhere in this "app" code.
+    let _guard = AppModulesDirGuard;
+    Runner::set_app_modules_dir(app.path());
+    let runtime = Runner::with_auto_build().unwrap();
+
+    let fixtures_ident = || schema_ident!("tatolab", "test-fixtures", "TestConfiguredProcessor", "1.0.0");
+
+    // (1) First reference lazily discovers + loads the providing package.
+    let libraries_before = loaded_plugin_library_count();
+    let processor_id = runtime
+        .add_processor(ProcessorSpec::new(fixtures_ident(), serde_json::json!({})))
+        .expect("add_processor must lazily load @tatolab/test-fixtures and succeed");
+    let _ = processor_id;
+
+    let registered = PROCESSOR_REGISTRY
+        .list_registered()
+        .into_iter()
+        .any(|desc| desc.name.r#type.as_str() == "TestConfiguredProcessor");
+    assert!(
+        registered,
+        "TestConfiguredProcessor must be registered after the lazy load"
+    );
+    let libraries_after_first = loaded_plugin_library_count();
+    assert_eq!(
+        libraries_after_first,
+        libraries_before + 1,
+        "the lazy load must dlopen the plugin exactly once"
+    );
+
+    // (2) A second reference to a type from the ALREADY-loaded package must NOT
+    // reload the plugin — the registry fast path short-circuits discovery.
+    runtime
+        .add_processor(ProcessorSpec::new(fixtures_ident(), serde_json::json!({})))
+        .expect("a second reference to an already-loaded type must succeed");
+    assert_eq!(
+        loaded_plugin_library_count(),
+        libraries_after_first,
+        "a repeat reference must NOT reload the plugin (single lazy load)"
+    );
+
+    // (3) Referencing an ABSENT package returns a typed error, and the runtime
+    // keeps operating.
+    let absent = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "definitely-not-installed", "Ghost", "1.0.0"),
+        serde_json::json!({}),
+    ));
+    assert!(
+        matches!(absent, Err(Error::UnknownProcessorType { .. })),
+        "an absent package must return a typed recoverable error, got {absent:?}"
+    );
+    // The graph keeps operating: a subsequent valid add still succeeds.
+    runtime
+        .add_processor(ProcessorSpec::new(fixtures_ident(), serde_json::json!({})))
+        .expect("the runtime must keep operating after a failed add_processor");
+
+    // (4) Lifecycle smoke: the lazily-loaded cdylib constructs through its
+    // vtable and destroys cleanly.
+    let descriptor = PROCESSOR_REGISTRY
+        .list_registered()
+        .into_iter()
+        .find(|d| d.name.r#type.as_str() == "TestConfiguredProcessor")
+        .expect("TestConfiguredProcessor descriptor must be present");
+    let node = ProcessorNode::new(
+        descriptor.name.clone(),
+        "TestConfiguredProcessor",
+        None,
+        Vec::new(),
+        Vec::new(),
+    );
+    let instance = PROCESSOR_REGISTRY
+        .create(&node)
+        .expect("factory.create() must construct the lazily-loaded processor");
+    assert!(matches!(instance, ProcessorInstance::VTable { .. }));
+    drop(instance);
+    // `_guard` clears the process-wide override on drop.
+}
+
+#[test]
+#[serial]
+fn add_processor_returns_ambiguous_error_for_duplicate_providers() {
+    // Two folders whose manifests both declare @tatolab/dup/Thing — a
+    // malformed install. add_processor must surface the typed ambiguity error
+    // end-to-end (through the lazy hook into add_processor_impl), and the
+    // runtime must keep operating afterward.
+    let app = tempfile::tempdir().unwrap();
+    write_manifest_package(app.path(), "@tatolab", "dup", "tatolab", "dup", "Thing", false);
+    write_manifest_package(
+        app.path(),
+        "@tatolab",
+        "dup-alias",
+        "tatolab",
+        "dup",
+        "Thing",
+        false,
+    );
+
+    let _guard = AppModulesDirGuard;
+    Runner::set_app_modules_dir(app.path());
+    let runtime = Runner::new().unwrap();
+
+    let result = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "dup", "Thing", "1.0.0"),
+        serde_json::json!({}),
+    ));
+    assert!(
+        matches!(result, Err(Error::AmbiguousProcessorTypeProviders { .. })),
+        "duplicate providers must surface a typed ambiguity error, got {result:?}"
+    );
+
+    // Runtime keeps operating: a subsequent reference to an absent package
+    // returns a typed error rather than wedging.
+    let after = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "not-there", "Nope", "1.0.0"),
+        serde_json::json!({}),
+    ));
+    assert!(matches!(after, Err(Error::UnknownProcessorType { .. })));
+}
+
+#[test]
+#[serial]
+fn add_processor_returns_lazy_load_failed_for_unbuildable_package() {
+    // A package that discovers cleanly but fails to load: a Rust package with
+    // source (Cargo.toml) but no prebuilt cdylib, loaded under a runtime with
+    // NO build orchestrator → the lazy load fails and add_processor returns the
+    // recoverable LazyModuleLoadFailed while the runtime keeps operating.
+    let app = tempfile::tempdir().unwrap();
+    write_manifest_package(
+        app.path(),
+        "@tatolab",
+        "broken",
+        "tatolab",
+        "broken",
+        "BrokenProcessor",
+        true,
+    );
+
+    let _guard = AppModulesDirGuard;
+    Runner::set_app_modules_dir(app.path());
+    let runtime = Runner::new().unwrap(); // no orchestrator wired
+
+    let result = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "broken", "BrokenProcessor", "1.0.0"),
+        serde_json::json!({}),
+    ));
+    assert!(
+        matches!(result, Err(Error::LazyModuleLoadFailed { .. })),
+        "a discovered-but-unbuildable package must surface LazyModuleLoadFailed, got {result:?}"
+    );
+
+    // The failed lazy load left zero partial state and the runtime keeps
+    // operating.
+    let after = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "still-absent", "Nope", "1.0.0"),
+        serde_json::json!({}),
+    ));
+    assert!(matches!(after, Err(Error::UnknownProcessorType { .. })));
+}

--- a/plugin/streamlib-error/src/lib.rs
+++ b/plugin/streamlib-error/src/lib.rs
@@ -10,7 +10,7 @@
 //! (from `streamlib-processor-schema`) and, on Linux, the engine-free
 //! `ConsumerRhiError` conversion.
 
-use streamlib_processor_schema::SchemaIdent;
+use streamlib_processor_schema::{PackageRef, SchemaIdent};
 
 /// The StreamLib error type.
 #[derive(thiserror::Error, Debug)]
@@ -62,6 +62,26 @@ pub enum Error {
 
     #[error("Unknown processor type: {ident} (not registered)")]
     UnknownProcessorType { ident: SchemaIdent },
+
+    #[error(
+        "Processor type {processor_type} is provided by more than one package in \
+         streamlib_modules/: {packages:?} — lazy discovery cannot pick one; remove \
+         the duplicate package folder"
+    )]
+    AmbiguousProcessorTypeProviders {
+        processor_type: SchemaIdent,
+        packages: Vec<PackageRef>,
+    },
+
+    #[error(
+        "Lazy load of package {package} providing processor type {processor_type} \
+         failed: {detail}"
+    )]
+    LazyModuleLoadFailed {
+        processor_type: SchemaIdent,
+        package: PackageRef,
+        detail: String,
+    },
 
     #[error("Processor '{processor_id}' has no {direction} port named '{port_name}'")]
     ProcessorPortNotFound {


### PR DESCRIPTION
## What & why

App code no longer calls `add_module`. When `add_processor(ProcessorSpec::new(type, cfg))` references a processor type that isn't registered, the runtime **discovers and lazily loads the providing package from the app's `streamlib_modules/` folder on first reference** — the gstreamer plugin-host model applied to a per-app module folder. Acquisition (`streamlib add` → `streamlib_modules/` + `streamlib.lock`) is fully separated from loading, and loading is implicit. `add_module` / `add_module_with(Strategy)` survive as an embedding / power-caller escape hatch.

Closes #1325.

## The lazy-trigger mechanism + where it hooks `add_processor`

The trigger is the same registry miss `add_v` already detects. Before a node is added, `add_processor` checks `PROCESSOR_REGISTRY.port_info(&spec.name)` (the exact condition `add_v_op.rs` uses to decide the miss — deliberately `port_info`, not `is_registered`, so subprocess descriptor-only processors count as hits):

- **Hit** → the type is available; nothing loads. This is exactly why a **second reference to a type from an already-loaded package never reloads** the plugin.
- **Miss** → `Runner::lazily_load_provider_for_processor_type` runs:
  1. **Discover** — scan `<app-modules-root>/streamlib_modules/@org/name/streamlib.yaml`, matching each manifest's `package:` org+name and its declared processor short names against the referenced ident's `org`/`package`/`type`. The reference-site version is deliberately ignored (the installed version is pinned in `streamlib.lock` at `streamlib add`).
  2. **Load** — resolve the single provider to `add_module_with(ModuleIdent, Strategy::InstalledCache)` through the **transactional load path** (#1328). `InstalledCache` probes the same `streamlib_modules/` root, so discovery and load agree.
  3. **Proceed** — the type is now registered and `add_processor` adds a healthy node.

The lazy step is threaded into `add_processor_impl` as an `Option<Error>` (`lazy_error`): the async `add_processor_async` awaits it inline; the synchronous `ExternalTokioHandle` arm drives it to completion *before* the `'static` spawn (which can't borrow `&self`), then hands the outcome to `add_processor_impl`. On a registry miss `add_processor_impl` returns `lazy_error` if present, else the pre-existing `Error::UnknownProcessorType`.

## The recoverable-failure contract (leaning on #1328)

Because the lazy load rides transactional registration, a failure leaves **zero partial schema/processor state** — the graph keeps being modified and the runtime keeps running. `add_processor` returns a typed, recoverable error rather than crashing:

| Situation | Error | Node in graph? |
|---|---|---|
| No package provides the type | `UnknownProcessorType` (pre-existing behavior preserved) | yes, `Error` state (observability) |
| Two folders declare the same type | `AmbiguousProcessorTypeProviders` (new) | yes, `Error` state |
| Discovered package fails to load | `LazyModuleLoadFailed` (new) | yes, `Error` state |

"No provider found" degrades to the existing `UnknownProcessorType` + error-node behavior, so `unknown_processor_type_test` passes unchanged.

## Discovery / index approach chosen

There is **no local catalog file** in `streamlib_modules/` — `.catalog.json` exists only in a published registry tree, and `streamlib add` writes "no network, no catalog." So discovery builds an **in-memory index on first need by scanning each package's `streamlib.yaml`** (via `streamlib_processor_schema::ProjectConfigMinimal`, a light package+processors parse with no schema resolution / network). A full scan (not just the deterministic `@org/name` slot) is what lets it detect the ambiguous case and validate that the folder actually declares the type.

## Modules-dir

Defaults to the process working directory (`<cwd>/streamlib_modules/`, where `streamlib add` writes). A daemon/host sets an explicit root — GST_PLUGIN_PATH-style — via `Runner::set_app_modules_dir(app_root)` (an **associated function**: process-wide, honestly signalling it isn't a per-`Runner` setting) or the `STREAMLIB_MODULES_DIR` env var; override > env > cwd. Discovery and every `InstalledCache` load read the same root.

## Deviations / notes for reviewers

- **`set_app_modules_dir` is an associated function, not `&self`.** The modules-dir is process-global (like `GST_PLUGIN_PATH`, and like the pre-existing cwd probe), so the associated-fn shape signals that honestly and lets tests clean up via an RAII guard. If a per-`Runner` modules dir is ever wanted, that's a separate change.
- **Version at the reference site.** `SchemaIdent` carries a concrete version and the terminal `port_info` lookup is version-exact (pre-existing `add_v` behavior). Discovery matches (org, package, type) ignoring the version, so it finds and loads the package regardless of the reference-site version; but if the referenced version ≠ the installed version, `add_v` still misses after the load and returns `UnknownProcessorType`. Fully realizing "no version anywhere at the reference site" would require version-agnostic resolution at `add_v` (`resolve_any_version`), which changes `add_v`'s public exact-match semantics — out of scope here, flagged for a follow-up.
- **Discovery/load asymmetry (malformed installs only).** Discovery matches by manifest content (path-independent, so ambiguity is detectable); `InstalledCache` loads by the canonical `@org/name` path. A sole provider in a mis-named folder is discoverable-but-not-loadable → `LazyModuleLoadFailed` rather than a clean miss. Well-formed installs from `streamlib add` always use canonical slots, so this only affects hand-broken layouts.

## Test evidence

- **Unit (`cargo test -p streamlib-engine --lib`)** — 7 lazy-specific pass: 6 discovery (`found` / `not-found` / `ambiguous` / `staging-and-hidden skipped` / `version-at-reference-site-ignored` / modules-folder-absent) plus the `lazy_module_load_failed` error-mapping (type + `@org/name` package derivation + detail). module_loader suite: **106 pass, 0 fail** (no regression to the existing InstalledCache/source tests after the `app_modules_probe_root → app_modules_root` change).
- **Integration (`tests/load_project_dylib_lazy_discovery.rs`, real dlopen)** — 3 pass, all driving `add_processor` **only** (no `add_module`):
  - lazily loads the real `test-fixtures` cdylib from `streamlib_modules/@tatolab/test-fixtures`, processor lands healthy, retained-image count `+1`; a **repeat reference does not reload** (count stays flat); an **absent package** returns `UnknownProcessorType` and the runtime keeps operating.
  - two duplicate-provider folders → `AmbiguousProcessorTypeProviders`, runtime keeps operating.
  - discovered-but-unbuildable Rust package under a no-orchestrator runtime → `LazyModuleLoadFailed`, runtime keeps operating.
- **Regression** — `unknown_processor_type_test` (3 pass): unknown type still returns `UnknownProcessorType` + leaves the failed node in `Error` state.
- **Gates** — `cargo build --workspace` green (no registry mirror); `cargo run -p xtask -- check-boundaries` and `lint-logging` clean; clippy clean on touched files (remaining `result_large_err` is the codebase-wide accepted pattern; the two actionable nits I introduced were fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB

