### PR TITLE
feat(pkg): streamlib install — reproduce streamlib_modules/ from streamlib.lock (#1326)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,12 +396,17 @@ the sanctioned loops instead:
   consumer bumps to. The monorepo still builds itself in-place (the dev
   `path` wins locally); publishing is a release step.
 
-**Install seam.** `streamlib install` resolves range→concrete, materializes,
-and writes `streamlib-app.lock`; a locked run (`add_modules_from_lockfile`)
-loads that pinned set offline (five network/build touchpoints unreachable),
-content-hash-verified. Range logic lives only at install, concrete
-enforcement only at run — the two resolvers stay separate; the lockfile is
-the handoff.
+**Install seam.** `streamlib install` (CLI) reproduces the app's
+`streamlib_modules/` folder from its committed `streamlib.lock`
+(`AppModulesDir::install_from_lockfile`) — hash-verified, offline, no
+resolution decisions: the container/CI preinstall path, the reproduce half of
+the `add`/`link` → `streamlib.lock` loop. The distinct **programmatic**
+`install()` seam (`sdk::runtime::install`, no longer a CLI verb) resolves a
+`streamlib.yaml` range→concrete, materializes, and writes `streamlib-app.lock`;
+a locked run (`add_modules_from_lockfile`) loads that pinned set offline (five
+network/build touchpoints unreachable), content-hash-verified. Range logic
+lives only at that install, concrete enforcement only at run — the two
+resolvers stay separate; the lockfile is the handoff.
 
 ### Vulkan RHI Boundary — ABSOLUTE RULE
 

--- a/docs/architecture/package-development-model.md
+++ b/docs/architecture/package-development-model.md
@@ -303,21 +303,56 @@ release manifest land in one atomic whole-tree `renameat2(RENAME_EXCHANGE)`
 staged swap (`publish_staged_tree`), so no state ever exists where partial
 crate versions sit above the newest manifest.
 
-## The install seam — install / run split
+## The install seam
 
-Install and run are distinct operations with the application lockfile as the
-only handoff.
+Three distinct operations reproduce or resolve a package set, keyed by which
+lockfile they touch.
 
-**`install` — resolve + materialize + lock.**
+**`streamlib install` — reproduce `streamlib_modules/` from `streamlib.lock`.**
+`AppModulesDir::install_from_lockfile()`
+([`libs/streamlib-idents/src/app_modules.rs`](../../libs/streamlib-idents/src/app_modules.rs),
+re-exported through `streamlib::sdk::runtime`, CLI `streamlib install`) reads
+the committed `streamlib.lock` (`MODULES_LOCKFILE_NAME`) and repopulates the
+app's own `streamlib_modules/@org/name/` folder **exactly** — no resolution
+decisions. This is the container/CI preinstall seam: `add`/`link` decide what's
+in the environment; `install` reproduces that decision elsewhere (a fresh
+checkout, an image build). Each byte-source entry (path / archive / url) is
+re-materialized through the same stage → validate → promote machinery `add`
+uses and re-verified against its recorded `content_hash` — *before* promote, so
+a mismatch leaves no partial slot (`InstallContentHashMismatch`); an
+`archive`/`url` entry additionally re-checks the recorded `archive_sha256`
+(`InstallArchiveHashMismatch`). A `link` entry's symlink is re-created iff its
+checkout target still exists; a gone target is a typed
+`InstallDanglingLinkTarget` — a dev link is inherently non-reproducible on
+another machine. It is per-package-atomic and fail-fast: a failure names the
+package (`InstallSourceUnavailable` for a gone path/archive/offline url), leaves
+already-reproduced packages in place, and never rewrites the lockfile; a re-run
+is idempotent. `path`/`link` sources reproduce only where their recorded local
+paths exist, so a portable install relies on `url`/`archive` entries (or a
+vendored folder copied into the image directly).
+
+> ~~`install` — resolve + materialize + lock. `install(...)` (CLI `streamlib
+> install`) runs the shared `resolve_with` (range→concrete), materializes each
+> resolved package through the orchestrator, and writes the lockfile.~~ —
+> Superseded 2026-07-13: the CLI `streamlib install` verb now reproduces
+> `streamlib_modules/` from `streamlib.lock` (above). The
+> resolve + materialize → `streamlib-app.lock` flow survives as the
+> **programmatic** `install()` seam (next), no longer surfaced as a CLI verb.
+
+**`install()` — resolve + materialize + lock (programmatic seam).**
 `install(root_dir, orchestrator, sink, options)`
 ([`libs/streamlib-engine/src/core/runtime/install.rs`](../../libs/streamlib-engine/src/core/runtime/install.rs),
-CLI `streamlib install`) runs the shared `resolve_with` (range→concrete),
-materializes each resolved package through the orchestrator, and writes the
-lockfile. The release-completeness check *rides* materialize — a partial
-registry release fails install before any lockfile is written. Network at
-install time is expected.
+`streamlib::sdk::runtime::install`) runs the shared `resolve_with`
+(range→concrete) over a project's `streamlib.yaml`, materializes each resolved
+package through the orchestrator, and writes `streamlib-app.lock`
+(`APP_LOCKFILE_NAME`). The release-completeness check *rides* materialize — a
+partial registry release fails install before any lockfile is written. Network
+at install time is expected. A locked run (`add_modules_from_lockfile`, below)
+then loads the pinned set offline. This is the whole-`streamlib.yaml`-tree seam,
+distinct from the per-app `streamlib_modules/` reproduction above and consuming
+a distinct lockfile.
 
-**`add` / `remove` — per-app package adoption (the node_modules model).**
+**`add` / `remove` / `link` — per-app package adoption (the node_modules model).**
 `AppModulesDir::add_package(source, options)`
 ([`libs/streamlib-idents/src/app_modules.rs`](../../libs/streamlib-idents/src/app_modules.rs),
 re-exported through `streamlib::sdk::runtime`, CLI `streamlib add`) brings
@@ -341,14 +376,19 @@ involvement, so each app directory is atomic and self-contained.
 `remove_package(pkg_ref)` (CLI `streamlib remove`) reverses it: delete the
 package folder, then drop its lockfile entry (folder first, so a crash
 leaves the healed direction — an entry pointing at a gone folder).
+`link_package(checkout)` (CLI `streamlib link`) is `add` with a symlink
+instead of a copy — recorded as a `LockfileSource::Link` — so checkout edits
+are live on the next run; `streamlib install` re-creates that symlink when
+reproducing the lock.
 
 At load time, `Strategy::InstalledCache` (the bare `Runner::add_module`
 default) probes `<cwd>/streamlib_modules/@org/name` **before** the
 installed-package cache; an active `streamlib link` still outranks both
 (precedence: link > app modules > installed cache). Locked runs are
 unaffected — they resolve pinned `Strategy::Path` edges and never consult
-the modules folder. `install` remains the whole-app-tree front door; `add`
-is the per-package one.
+the modules folder. The programmatic `install()` remains the
+whole-`streamlib.yaml`-tree front door; `add` / `link` / `streamlib install`
+are the per-app `streamlib_modules/` operations.
 
 **Locked run — offline, pinned, verified.**
 `Runner::add_modules_from_lockfile` builds a `LockedResolution` from the
@@ -374,8 +414,8 @@ but are distinct files with distinct headers:
 | File | Written by | Pins |
 |---|---|---|
 | `streamlib-codegen.lock` (`CODEGEN_LOCKFILE_NAME`) | `streamlib generate` / jtd-codegen | the *schema* set that reconstructs generated bindings byte-for-byte |
-| `streamlib-app.lock` (`APP_LOCKFILE_NAME`) | `streamlib install` | the *runtime package* set an installed app loads offline |
-| `streamlib.lock` (`MODULES_LOCKFILE_NAME`) | `streamlib add` / `streamlib remove` | the packages materialized into the app's `streamlib_modules/` folder (identity, source, content hash) |
+| `streamlib-app.lock` (`APP_LOCKFILE_NAME`) | the programmatic `install()` (`sdk::runtime::install`) | the *runtime package* set an installed app loads offline |
+| `streamlib.lock` (`MODULES_LOCKFILE_NAME`) | `streamlib add` / `streamlib remove` / `streamlib link` (read back by `streamlib install`) | the packages materialized into the app's `streamlib_modules/` folder (identity, source, content hash) |
 
 **Resolver handoff — deliberately two resolvers.** Range logic lives only at
 install (`resolve_with`); concrete enforcement lives only at run

--- a/libs/streamlib-cli/src/commands/install.rs
+++ b/libs/streamlib-cli/src/commands/install.rs
@@ -1,90 +1,70 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! `streamlib install` — resolve + materialize + lock an application's
-//! package tree.
+//! `streamlib install` — reproduce this app's `streamlib_modules/` folder from
+//! its committed `streamlib.lock`, exactly and offline.
 //!
-//! Delegates to the programmatic [`streamlib::sdk::runtime::install`] so the
-//! CLI and any embedding host share one install flow. Resolves the project's
-//! `streamlib.yaml` range→concrete over the full transitive tree,
-//! materializes every package into the installed-package cache (building
-//! cdylibs / provisioning venvs / pre-building the subprocess native hosts),
-//! and writes the application lockfile. A subsequent locked run
-//! (`Runner::add_modules_from_lockfile`) then loads the pinned set offline.
+//! Thin CLI wrapper over the programmatic
+//! [`streamlib::sdk::runtime::AppModulesDir::install_from_lockfile`] twin so the
+//! CLI and any embedding host share one reproduction flow. Install is the seam
+//! between acquisition and reproduction: `add`/`link` decide what's in the
+//! environment and record it in `streamlib.lock`; `install` reproduces that
+//! decision elsewhere (a fresh checkout, a container image build) with no
+//! resolution decisions. Each byte-source entry (folder / archive / URL) is
+//! re-materialized and re-verified against its recorded content hash; a linked
+//! entry's symlink is re-created (a gone checkout target is a typed error — a
+//! dev link isn't reproducible on another machine). Never builds.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-use anyhow::{Context, Result};
-use streamlib::sdk::PolyglotBuildOrchestrator;
-use streamlib::sdk::runtime::{BuildEvent, BuildEventSink, BuildStream, InstallOptions, install};
+use anyhow::Result;
+use streamlib::sdk::runtime::{AppModulesDir, InstallFromLockfileReport, InstalledFromLockKind};
 
-/// Routes the orchestrator's build diagnostics to the CLI's stdout/stderr
-/// during `install` (mirrors `streamlib add`'s interactive progress).
-struct CliBuildSink;
+/// Reproduce the app's `streamlib_modules/` from its `streamlib.lock`.
+pub fn install(dir: Option<&Path>) -> Result<()> {
+    let app = app_modules_dir(dir)?;
+    println!("Installing from {}…", app.lockfile_path().display());
+    let report = app
+        .install_from_lockfile()
+        .map_err(|e| anyhow::anyhow!("install failed: {e}"))?;
+    print_install_report(&report);
+    Ok(())
+}
 
-impl BuildEventSink for CliBuildSink {
-    fn emit(&self, event: BuildEvent) {
-        match event {
-            BuildEvent::Started { language } => println!("    [{language}] build started"),
-            BuildEvent::Line { stream, line } => match stream {
-                BuildStream::Stdout => println!("    {line}"),
-                BuildStream::Stderr => eprintln!("    {line}"),
-            },
-            BuildEvent::Finished { language } => println!("    [{language}] build finished"),
-            _ => {}
-        }
+/// The app-modules anchor: `--dir` when given, else the exact CWD.
+fn app_modules_dir(dir: Option<&Path>) -> Result<AppModulesDir> {
+    match dir {
+        Some(root) => Ok(AppModulesDir::at(root)),
+        None => AppModulesDir::from_cwd().map_err(|e| anyhow::anyhow!("{e}")),
     }
 }
 
-/// Resolve + materialize + lock the project rooted at `project_dir` (default:
-/// the current working directory). Writes the application lockfile to
-/// `lockfile_path` (default: `<project_dir>/streamlib-app.lock`).
-pub fn run(project_dir: Option<&Path>, lockfile_path: Option<PathBuf>) -> Result<()> {
-    let root = match project_dir {
-        Some(p) => p.to_path_buf(),
-        None => std::env::current_dir().context("resolve current working directory")?,
-    };
-    if !root.join("streamlib.yaml").exists() {
-        anyhow::bail!(
-            "no streamlib.yaml at {} — run `streamlib install` from a project root, \
-             or pass the project directory",
-            root.display()
-        );
-    }
-
-    // Link-mode provenance: a whole-tree link redirects the language
-    // toolchains (cargo/uv/deno) at the checkout. Surface it so the operator
-    // knows the lockfile reflects a linked tree (path-declared deps are
-    // recorded as `path:` sources in the lockfile).
-    if let Some(marker) = streamlib_idents::link_marker::find_active_link_marker(&root) {
-        println!(
-            "note: installing inside an active streamlib link (marker: {}) — \
-             local checkout overrides are in effect",
-            marker.display()
-        );
-    }
-
-    println!(
-        "Resolving + materializing package graph at {}...",
-        root.display()
-    );
-    let orchestrator = PolyglotBuildOrchestrator::default();
-    let sink = CliBuildSink;
-    let options = InstallOptions {
-        lockfile_path,
-        ..Default::default()
-    };
-    let report = install(&root, &orchestrator, &sink, &options)
-        .map_err(|e| anyhow::anyhow!("install failed: {e}"))?;
-
+/// Pretty-print the reproduction outcome, one line per package.
+fn print_install_report(report: &InstallFromLockfileReport) {
     println!();
     println!(
-        "Installed {} package(s); lockfile written to {}",
+        "Reproduced {} package(s) into {}",
         report.packages.len(),
-        report.lockfile_path.display()
+        report.modules_dir.display()
     );
-    for (pkg, version) in &report.packages {
-        println!("  {pkg} v{version}");
+    for pkg in &report.packages {
+        let how = match pkg.kind {
+            InstalledFromLockKind::Materialized => "materialized",
+            InstalledFromLockKind::Linked => "linked",
+        };
+        let verb = if pkg.replaced_existing {
+            "replaced"
+        } else {
+            "reproduced"
+        };
+        println!(
+            "  {} v{}  [{how}, {verb}]  {}",
+            pkg.package,
+            pkg.version,
+            pkg.package_dir.display()
+        );
     }
-    Ok(())
+    if report.packages.is_empty() {
+        println!("  (lockfile records no packages)");
+    }
 }

--- a/libs/streamlib-cli/src/main.rs
+++ b/libs/streamlib-cli/src/main.rs
@@ -78,25 +78,22 @@ enum Commands {
         action: SchemasCommands,
     },
 
-    /// Resolve + materialize + lock an application's package tree.
+    /// Reproduce this app's streamlib_modules/ folder from its committed
+    /// streamlib.lock — exactly, hash-verified, and offline.
     ///
-    /// Run from a project root (a directory with `streamlib.yaml`). Resolves
-    /// the full transitive dependency tree range→concrete, materializes every
-    /// package into the installed-package cache (building cdylibs, provisioning
-    /// venvs, pre-building the subprocess native hosts), and writes an
-    /// application lockfile. A subsequent run loads the pinned set offline via
-    /// `Runner::add_modules_from_lockfile`.
-    ///
-    /// To adopt a single published package (resolve by version + materialize
-    /// into the local cache) rather than resolve a project tree, use
-    /// `streamlib add`.
+    /// Install is the container/CI preinstall seam: `add`/`link` decide what's
+    /// in the environment and record it in `streamlib.lock`; `install`
+    /// reproduces that decision elsewhere (a fresh checkout, an image build)
+    /// with no resolution decisions. Each byte-source entry (folder / archive /
+    /// URL) is re-materialized and re-verified against its recorded content
+    /// hash; a linked entry's symlink is re-created (a gone checkout target is
+    /// an error — a dev link isn't reproducible on another machine). Never
+    /// builds.
     Install {
-        /// Project directory (default: current working directory).
-        project_dir: Option<PathBuf>,
-
-        /// Lockfile output path (default: <project_dir>/streamlib-app.lock).
+        /// App root to anchor streamlib_modules/ + streamlib.lock at
+        /// (default: current working directory, no walk-up).
         #[arg(long)]
-        lockfile: Option<PathBuf>,
+        dir: Option<PathBuf>,
     },
 
     /// Bring any valid streamlib package into this app's streamlib_modules/
@@ -372,10 +369,7 @@ async fn async_main(cli: Cli) -> Result<()> {
                 commands::schema::validate_processor(&path)?
             }
         },
-        Some(Commands::Install {
-            project_dir,
-            lockfile,
-        }) => commands::install::run(project_dir.as_deref(), lockfile)?,
+        Some(Commands::Install { dir }) => commands::install::install(dir.as_deref())?,
         Some(Commands::Add {
             spec,
             dir,

--- a/libs/streamlib-cli/tests/install_from_lock.rs
+++ b/libs/streamlib-cli/tests/install_from_lock.rs
@@ -1,0 +1,170 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! End-to-end `streamlib install` — reproduce a per-app `streamlib_modules/`
+//! folder from a committed `streamlib.lock`, driving the real `streamlib`
+//! binary.
+//!
+//! This is the local-only integration counterpart to the
+//! `streamlib-idents::app_modules` install unit tests. CI runs `cargo test
+//! --lib`, so this `tests/` binary is a developer-run gate: it locks the CLI
+//! wiring (`--dir` anchoring, report printing, exit codes) end-to-end over a
+//! real `.slpkg` assembled by `streamlib-pack` — the container/CI preinstall
+//! story (commit the lock, run `install` at image build).
+
+use std::path::Path;
+use std::process::Command;
+
+use streamlib_pack::{
+    AssembleOptions, AssembleTarget, CargoProfile, PathDepPolicy, assemble_artifact,
+};
+
+const BIN: &str = env!("CARGO_BIN_EXE_streamlib");
+
+/// A schema-only package (no Rust/Python sources — install never builds).
+fn write_foo_package(dir: &Path) {
+    std::fs::create_dir_all(dir.join("schemas")).unwrap();
+    std::fs::write(
+        dir.join("streamlib.yaml"),
+        "package:\n  org: tatolab\n  name: foo\n  version: 1.1.0\n  \
+         description: a demo install package\nschemas:\n  FooFrame:\n    file: schemas/foo_frame.yaml\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("schemas/foo_frame.yaml"),
+        "metadata:\n  type: FooFrame\n  description: \"A demo frame\"\nproperties:\n  \
+         width:\n    type: uint32\n  height:\n    type: uint32\n",
+    )
+    .unwrap();
+}
+
+fn run(args: &[&str]) -> std::process::Output {
+    Command::new(BIN).args(args).output().expect("spawn streamlib binary")
+}
+
+/// The docker/CI story: `add` a portable archive source into a source app,
+/// commit its `streamlib.lock`, then reproduce a byte-equivalent
+/// `streamlib_modules/` in a CLEAN checkout that carries only the lockfile.
+#[test]
+fn install_reproduces_modules_in_a_clean_checkout_from_the_lock() {
+    let pkg = tempfile::tempdir().unwrap();
+    write_foo_package(pkg.path());
+
+    // A real source-only `.slpkg` (a portable, machine-independent source).
+    let artifacts = tempfile::tempdir().unwrap();
+    let slpkg = artifacts.path().join("foo.slpkg");
+    assemble_artifact(
+        pkg.path(),
+        &AssembleTarget::Slpkg(slpkg.clone()),
+        &AssembleOptions {
+            no_build: false,
+            profile: CargoProfile::Release,
+            path_deps: PathDepPolicy::RejectPathPatches,
+        },
+        &(),
+    )
+    .expect("assemble source .slpkg");
+
+    // Source app: `add` records the archive source in streamlib.lock.
+    let source_app = tempfile::tempdir().unwrap();
+    let src_dir = source_app.path().to_str().unwrap();
+    let out = run(&["add", slpkg.to_str().unwrap(), "--dir", src_dir]);
+    assert!(
+        out.status.success(),
+        "add failed: {}\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let source_manifest = std::fs::read(
+        source_app
+            .path()
+            .join("streamlib_modules/@tatolab/foo/streamlib.yaml"),
+    )
+    .unwrap();
+
+    // Clean checkout: ONLY the lockfile is present.
+    let dest_app = tempfile::tempdir().unwrap();
+    let dest_dir = dest_app.path().to_str().unwrap();
+    std::fs::copy(
+        source_app.path().join("streamlib.lock"),
+        dest_app.path().join("streamlib.lock"),
+    )
+    .unwrap();
+    assert!(
+        !dest_app.path().join("streamlib_modules").exists(),
+        "precondition: no modules dir in the clean checkout"
+    );
+
+    // Reproduce.
+    let out = run(&["install", "--dir", dest_dir]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "install failed: {stdout}\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(stdout.contains("Reproduced 1 package(s)"), "stdout: {stdout}");
+    assert!(stdout.contains("@tatolab/foo"), "stdout: {stdout}");
+    assert!(stdout.contains("materialized"), "stdout: {stdout}");
+
+    // The reproduced slot is byte-identical to the source app's.
+    let dest_slot = dest_app
+        .path()
+        .join("streamlib_modules/@tatolab/foo/streamlib.yaml");
+    assert!(dest_slot.is_file(), "reproduced slot missing manifest");
+    assert_eq!(
+        std::fs::read(&dest_slot).unwrap(),
+        source_manifest,
+        "reproduced manifest must be byte-identical"
+    );
+
+    // Install is idempotent (second run reproduces the same folder).
+    let out = run(&["install", "--dir", dest_dir]);
+    assert!(out.status.success(), "second install must succeed");
+    assert_eq!(
+        std::fs::read(&dest_slot).unwrap(),
+        source_manifest,
+        "re-install must stay byte-identical"
+    );
+}
+
+/// The `delete streamlib_modules/, keep streamlib.lock, install` recovery loop.
+#[test]
+fn install_recovers_deleted_modules_dir_from_the_lock() {
+    let pkg = tempfile::tempdir().unwrap();
+    write_foo_package(pkg.path());
+    let app = tempfile::tempdir().unwrap();
+    let dir = app.path().to_str().unwrap();
+
+    // A folder `add` (Path source) into the app.
+    let out = run(&["add", pkg.path().to_str().unwrap(), "--dir", dir]);
+    assert!(out.status.success(), "add failed");
+    let slot = app.path().join("streamlib_modules/@tatolab/foo/streamlib.yaml");
+    let before = std::fs::read(&slot).unwrap();
+
+    // Nuke the modules folder, keep the lock.
+    std::fs::remove_dir_all(app.path().join("streamlib_modules")).unwrap();
+    assert!(app.path().join("streamlib.lock").exists());
+
+    // Install reproduces it.
+    let out = run(&["install", "--dir", dir]);
+    assert!(
+        out.status.success(),
+        "install failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(slot.is_file(), "modules dir must be reproduced");
+    assert_eq!(std::fs::read(&slot).unwrap(), before);
+}
+
+#[test]
+fn install_without_a_lockfile_fails_loud() {
+    let app = tempfile::tempdir().unwrap();
+    let out = run(&["install", "--dir", app.path().to_str().unwrap()]);
+    assert!(!out.status.success(), "install with no lock must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("no streamlib.lock to install from"),
+        "stderr: {stderr}"
+    );
+}

--- a/libs/streamlib-engine/src/core/runtime/mod.rs
+++ b/libs/streamlib-engine/src/core/runtime/mod.rs
@@ -14,7 +14,8 @@ mod status;
 pub use install::{InstallError, InstallOptions, InstallReport, install};
 pub use streamlib_idents::app_modules::{
     APP_MODULES_DIR_NAME, AddPackageOptions, AddPackageReport, AddPackageSource, AppModulesDir,
-    AppModulesError, LinkPackageReport, RemovePackageReport, UnlinkPackageReport,
+    AppModulesError, InstallFromLockfileReport, InstalledFromLockKind, InstalledFromLockPackage,
+    LinkPackageReport, RemovePackageReport, UnlinkPackageReport,
 };
 pub use module_loader::{
     AddModuleError, AddedModule, ArtifactChecksum, BuildError, BuildEvent, BuildEventSink,

--- a/libs/streamlib-idents/src/app_modules.rs
+++ b/libs/streamlib-idents/src/app_modules.rs
@@ -852,6 +852,14 @@ impl AppModulesDir {
     /// twice yields the same folder. `Path`/`Link` sources reproduce only where
     /// their recorded local paths exist; a portable install (another machine)
     /// relies on `Url`/`Archive` entries or a vendored folder.
+    ///
+    /// Reproduction is **additive**: it materializes every locked entry but does
+    /// not prune `streamlib_modules/@org/name` slots present on disk yet absent
+    /// from the lock. A from-scratch reproduction (the container/CI target)
+    /// starts from an empty folder, so the result equals the locked set exactly;
+    /// a re-install over a dirty folder is a superset, not a clean slate. Not
+    /// pruning is deliberate — install is non-destructive to slots it doesn't
+    /// own, so a not-yet-`add`ed work-in-progress folder is never deleted.
     #[tracing::instrument(skip(self), fields(app_root = %self.app_root.display()))]
     pub fn install_from_lockfile(&self) -> Result<InstallFromLockfileReport, AppModulesError> {
         let lockfile_path = self.lockfile_path();

--- a/libs/streamlib-idents/src/app_modules.rs
+++ b/libs/streamlib-idents/src/app_modules.rs
@@ -165,6 +165,52 @@ pub struct UnlinkPackageReport {
     pub lockfile_entry_removed: bool,
 }
 
+/// How one lockfile entry was reproduced by
+/// [`AppModulesDir::install_from_lockfile`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstalledFromLockKind {
+    /// Contents were copied / extracted from the recorded byte source (a
+    /// [`LockfileSource::Path`] / [`LockfileSource::Archive`] /
+    /// [`LockfileSource::Url`]) and re-verified against the recorded
+    /// `content_hash`.
+    Materialized,
+    /// A symlink was re-created to the recorded checkout (a
+    /// [`LockfileSource::Link`]). Not content-hash-verified — a linked checkout
+    /// is live and may have drifted since it was linked.
+    Linked,
+}
+
+/// Per-package outcome inside an [`AppModulesDir::install_from_lockfile`] run.
+#[derive(Debug, Clone)]
+pub struct InstalledFromLockPackage {
+    /// The canonical `@org/name` reproduced (from the lockfile map key).
+    pub package: PackageRef,
+    /// The version the lockfile entry pinned.
+    pub version: SemVer,
+    /// The `streamlib_modules/@org/name` slot that was reproduced.
+    pub package_dir: PathBuf,
+    /// The source the lockfile entry recorded.
+    pub source: LockfileSource,
+    /// The content hash the lockfile pinned (re-verified for a materialized
+    /// source; a point-in-time snapshot for a linked source).
+    pub content_hash: String,
+    /// How the slot was reproduced.
+    pub kind: InstalledFromLockKind,
+    /// `true` when an existing `streamlib_modules/@org/name` slot was replaced.
+    pub replaced_existing: bool,
+}
+
+/// Outcome of a successful [`AppModulesDir::install_from_lockfile`].
+#[derive(Debug, Clone)]
+pub struct InstallFromLockfileReport {
+    /// The modules lockfile that was reproduced from.
+    pub lockfile_path: PathBuf,
+    /// The `streamlib_modules/` folder that was reproduced.
+    pub modules_dir: PathBuf,
+    /// Every package reproduced, in lockfile (sorted) order.
+    pub packages: Vec<InstalledFromLockPackage>,
+}
+
 /// Per-failure-mode error from the per-app modules primitive.
 #[derive(Debug, thiserror::Error)]
 pub enum AppModulesError {
@@ -291,6 +337,82 @@ pub enum AppModulesError {
     /// Filesystem operation failed.
     #[error("io error at {}: {detail}", path.display())]
     Io { path: PathBuf, detail: String },
+
+    /// `install_from_lockfile` found no `streamlib.lock` at the app root —
+    /// there is nothing to reproduce a `streamlib_modules/` folder from.
+    #[error(
+        "no {} to install from at {} — `streamlib install` reproduces streamlib_modules/ from a \
+         committed lockfile; run `streamlib add`/`streamlib link` to create one, or commit the \
+         lockfile before installing",
+        MODULES_LOCKFILE_NAME,
+        lockfile_path.display()
+    )]
+    InstallLockfileMissing { lockfile_path: PathBuf },
+
+    /// A lockfile map key is not a canonical `@org/name` reference.
+    #[error("lockfile entry key '{key}' is not a canonical @org/name reference: {detail}")]
+    InstallInvalidLockEntry { key: String, detail: String },
+
+    /// The byte source a lockfile entry records is unavailable at install time
+    /// — a `path:`/`archive:` file that is gone, or a `url:` unreachable
+    /// offline. Names the package so the operator knows which entry to fix.
+    #[error("cannot reproduce '{package}' — its recorded source is unavailable: {detail}")]
+    InstallSourceUnavailable { package: PackageRef, detail: String },
+
+    /// A `link:` entry's checkout target no longer exists. A linked dev
+    /// checkout is inherently non-reproducible on another machine — add the
+    /// package from a portable source (archive / URL) or restore the checkout
+    /// before installing.
+    #[error(
+        "cannot reproduce linked package '{package}' — its checkout target {} no longer exists. \
+         A `streamlib link` records a dev-only symlink to a local checkout, which is not \
+         reproducible elsewhere; add the package from a portable source (archive or URL), or \
+         restore the checkout, then re-install",
+        target.display()
+    )]
+    InstallDanglingLinkTarget { package: PackageRef, target: PathBuf },
+
+    /// The archive bytes a `url:`/`archive:` entry re-fetched/read do not match
+    /// the `archive_sha256` the lockfile recorded — the source changed under a
+    /// pinned entry.
+    #[error(
+        "archive bytes for '{package}' do not match the recorded archive_sha256: expected \
+         {expected}, got {actual}"
+    )]
+    InstallArchiveHashMismatch {
+        package: PackageRef,
+        expected: String,
+        actual: String,
+    },
+
+    /// The reproduced package's content hash does not match the `content_hash`
+    /// the lockfile pinned — the reproduced contents differ from what was
+    /// locked.
+    #[error(
+        "content hash for '{package}' does not match the lockfile: expected {expected}, got \
+         {actual}"
+    )]
+    InstallContentHashMismatch {
+        package: PackageRef,
+        expected: String,
+        actual: String,
+    },
+
+    /// A lockfile entry records a source kind `install_from_lockfile` cannot
+    /// reproduce (a `registry:` / `git:` coordinate). The per-app modules
+    /// lockfile is only written with reproducible byte sources by
+    /// `streamlib add`/`streamlib link`.
+    #[error(
+        "cannot reproduce '{package}' — its recorded source kind '{kind}' is not reproducible by \
+         install (only path/archive/url/link sources are). This lockfile was not written by \
+         `streamlib add`/`streamlib link`"
+    )]
+    InstallUnsupportedSource { package: PackageRef, kind: String },
+
+    /// Reproducing a package into its slot failed (extract / invalid contents /
+    /// promote / symlink). Names the package plus the underlying detail.
+    #[error("reproducing '{package}' failed: {detail}")]
+    InstallReproduceFailed { package: PackageRef, detail: String },
 }
 
 /// A per-app `streamlib_modules/` folder plus its `streamlib.lock`, anchored
@@ -710,6 +832,135 @@ impl AppModulesDir {
             link_removed,
             lockfile_entry_removed,
         })
+    }
+
+    /// Reproduce `streamlib_modules/` from the committed `streamlib.lock`,
+    /// exactly as `add`/`link` recorded it — the container/CI preinstall story.
+    /// Each byte-source entry ([`LockfileSource::Path`] /
+    /// [`LockfileSource::Archive`] / [`LockfileSource::Url`]) is re-materialized
+    /// and re-verified against its recorded `content_hash`; a
+    /// [`LockfileSource::Link`] entry's symlink is re-created. Makes NO
+    /// resolution decisions and never rewrites the lockfile — install
+    /// reproduces a decision `add`/`link` already made, so a clean checkout
+    /// carrying only the lockfile rebuilds the same folder.
+    ///
+    /// Per-package-atomic and fail-fast: each package is staged, verified
+    /// (before promote), then atomically promoted, so a failed package leaves
+    /// no partial slot; a failure stops the run with a typed error naming the
+    /// package, and packages already reproduced (each valid and hash-verified)
+    /// remain — re-running install completes the reproduction. Running install
+    /// twice yields the same folder. `Path`/`Link` sources reproduce only where
+    /// their recorded local paths exist; a portable install (another machine)
+    /// relies on `Url`/`Archive` entries or a vendored folder.
+    #[tracing::instrument(skip(self), fields(app_root = %self.app_root.display()))]
+    pub fn install_from_lockfile(&self) -> Result<InstallFromLockfileReport, AppModulesError> {
+        let lockfile_path = self.lockfile_path();
+        if !lockfile_path.exists() {
+            return Err(AppModulesError::InstallLockfileMissing { lockfile_path });
+        }
+        let lockfile = self.read_lockfile()?;
+
+        let modules_dir = self.modules_dir();
+        std::fs::create_dir_all(&modules_dir).map_err(|e| AppModulesError::Io {
+            path: modules_dir.clone(),
+            detail: format!("creating modules dir: {e}"),
+        })?;
+        sweep_orphan_staging_entries(&modules_dir);
+
+        let mut packages = Vec::with_capacity(lockfile.packages.len());
+        for (key, entry) in &lockfile.packages {
+            let package = parse_lockfile_package_key(key)?;
+            let (kind, replaced_existing) =
+                self.reproduce_locked_entry(&package, entry, &modules_dir)?;
+            tracing::info!(package = %package, ?kind, "install_from_lockfile: reproduced package");
+            packages.push(InstalledFromLockPackage {
+                package: package.clone(),
+                version: entry.version,
+                package_dir: self.package_dir(&package),
+                source: entry.source.clone(),
+                content_hash: entry.content_hash.clone(),
+                kind,
+                replaced_existing,
+            });
+        }
+
+        tracing::info!(
+            lockfile = %lockfile_path.display(),
+            packages = packages.len(),
+            "install_from_lockfile: reproduced streamlib_modules from lockfile"
+        );
+        Ok(InstallFromLockfileReport {
+            lockfile_path,
+            modules_dir,
+            packages,
+        })
+    }
+
+    /// Reproduce one lockfile entry into its `streamlib_modules/@org/name` slot.
+    /// Returns how it was reproduced and whether a previous slot was replaced.
+    fn reproduce_locked_entry(
+        &self,
+        package: &PackageRef,
+        entry: &LockfileEntry,
+        modules_dir: &Path,
+    ) -> Result<(InstalledFromLockKind, bool), AppModulesError> {
+        let package_dir = self.package_dir(package);
+        match &entry.source {
+            LockfileSource::Link { path } => {
+                // Re-create the symlink iff the checkout target still exists.
+                // The recorded content hash is a point-in-time snapshot of a
+                // live checkout, so it is deliberately NOT re-verified here.
+                if !path.is_dir() {
+                    return Err(AppModulesError::InstallDanglingLinkTarget {
+                        package: package.clone(),
+                        target: path.clone(),
+                    });
+                }
+                let staging = StagingSymlink::create(modules_dir, path)?;
+                let replaced = promote_staged_package_root(staging.path(), &package_dir, modules_dir)
+                    .map_err(|e| map_stage_error_to_install(package, e))?;
+                drop(staging);
+                Ok((InstalledFromLockKind::Linked, replaced))
+            }
+            LockfileSource::Path { path } => reproduce_materialized_from_lock(
+                package,
+                AddPackageSource::Folder { path: path.clone() },
+                None,
+                entry,
+                modules_dir,
+                &package_dir,
+            ),
+            LockfileSource::Archive {
+                path,
+                archive_sha256,
+            } => reproduce_materialized_from_lock(
+                package,
+                AddPackageSource::Archive { path: path.clone() },
+                Some(archive_sha256.clone()),
+                entry,
+                modules_dir,
+                &package_dir,
+            ),
+            LockfileSource::Url {
+                url,
+                archive_sha256,
+            } => reproduce_materialized_from_lock(
+                package,
+                AddPackageSource::Url { url: url.clone() },
+                Some(archive_sha256.clone()),
+                entry,
+                modules_dir,
+                &package_dir,
+            ),
+            LockfileSource::Registry { .. } => Err(AppModulesError::InstallUnsupportedSource {
+                package: package.clone(),
+                kind: "registry".to_string(),
+            }),
+            LockfileSource::Git { .. } => Err(AppModulesError::InstallUnsupportedSource {
+                package: package.clone(),
+                kind: "git".to_string(),
+            }),
+        }
     }
 }
 
@@ -1169,6 +1420,88 @@ fn sha256_hex(bytes: &[u8]) -> String {
         .iter()
         .map(|b| format!("{b:02x}"))
         .collect()
+}
+
+/// Stage a byte source recorded in the lockfile, verify it against the pinned
+/// `content_hash` BEFORE promoting (so a mismatch leaves no partial slot),
+/// then atomically promote it into the package's slot. Shares the exact
+/// stage → locate → promote machinery `add_package` uses.
+fn reproduce_materialized_from_lock(
+    package: &PackageRef,
+    source: AddPackageSource,
+    expected_archive_sha256: Option<String>,
+    entry: &LockfileEntry,
+    modules_dir: &Path,
+    package_dir: &Path,
+) -> Result<(InstalledFromLockKind, bool), AppModulesError> {
+    let staging = StagingDir::create(modules_dir)?;
+    let options = AddPackageOptions {
+        expected_archive_sha256,
+    };
+    let (_lock_source, source_label) = stage_source_contents(&source, &options, staging.path())
+        .map_err(|e| map_stage_error_to_install(package, e))?;
+    let staged_root = locate_staged_package_root(staging.path(), &source, &source_label)
+        .map_err(|e| map_stage_error_to_install(package, e))?;
+
+    // Verify the reproduced contents against the pinned content hash BEFORE
+    // promoting, so a mismatch leaves no partial slot (the staging dir is swept
+    // by `StagingDir`'s Drop on the early return).
+    let actual = content_hash_for_package_dir(&staged_root).map_err(|e| {
+        AppModulesError::InstallReproduceFailed {
+            package: package.clone(),
+            detail: format!("hashing reproduced contents: {e}"),
+        }
+    })?;
+    if actual != entry.content_hash {
+        return Err(AppModulesError::InstallContentHashMismatch {
+            package: package.clone(),
+            expected: entry.content_hash.clone(),
+            actual,
+        });
+    }
+
+    let replaced = promote_staged_package_root(&staged_root, package_dir, modules_dir)
+        .map_err(|e| map_stage_error_to_install(package, e))?;
+    drop(staging);
+    Ok((InstalledFromLockKind::Materialized, replaced))
+}
+
+/// Parse a lockfile map key (`@org/name`) into a typed [`PackageRef`] via the
+/// canonical deserialize path (there is no `PackageRef::parse` by design).
+fn parse_lockfile_package_key(key: &str) -> Result<PackageRef, AppModulesError> {
+    serde_yaml::from_value::<PackageRef>(serde_yaml::Value::String(key.to_string())).map_err(|e| {
+        AppModulesError::InstallInvalidLockEntry {
+            key: key.to_string(),
+            detail: e.to_string(),
+        }
+    })
+}
+
+/// Map a staging/promote [`AppModulesError`] onto the install-flavored,
+/// package-named variant so an install failure always names the offending
+/// package.
+fn map_stage_error_to_install(package: &PackageRef, err: AppModulesError) -> AppModulesError {
+    match err {
+        AppModulesError::SourceNotFound { spec } => AppModulesError::InstallSourceUnavailable {
+            package: package.clone(),
+            detail: format!("source not found: {spec}"),
+        },
+        AppModulesError::FetchFailed { url, detail } => AppModulesError::InstallSourceUnavailable {
+            package: package.clone(),
+            detail: format!("fetching '{url}' failed: {detail}"),
+        },
+        AppModulesError::HashMismatch {
+            expected, actual, ..
+        } => AppModulesError::InstallArchiveHashMismatch {
+            package: package.clone(),
+            expected,
+            actual,
+        },
+        other => AppModulesError::InstallReproduceFailed {
+            package: package.clone(),
+            detail: other.to_string(),
+        },
+    }
 }
 
 #[cfg(test)]
@@ -2516,5 +2849,423 @@ mod tests {
             matches!(err, AppModulesError::LockfileReadFailed { .. }),
             "{err:?}"
         );
+    }
+
+    // =====================================================================
+    // Install from lockfile — reproduce streamlib_modules/ from streamlib.lock
+    // =====================================================================
+
+    /// Hand-write a `streamlib.lock` at an app root from raw entries.
+    fn write_modules_lock(app: &AppModulesDir, entries: &[(&str, LockfileEntry)]) {
+        let mut lock = Lockfile {
+            version: 1,
+            packages: Default::default(),
+        };
+        for (key, entry) in entries {
+            lock.packages.insert(key.to_string(), entry.clone());
+        }
+        write_modules_lockfile(&app.lockfile_path(), &lock).unwrap();
+    }
+
+    /// The flagship: a clean checkout carrying ONLY `streamlib.lock` — with one
+    /// entry of each reproducible source kind (path / archive / url / link) —
+    /// reproduces a byte-equivalent, hash-verified `streamlib_modules/`.
+    #[test]
+    fn install_reproduces_each_source_kind_from_a_clean_checkout() {
+        // --- Build the four sources on disk -----------------------------
+        let path_src = tempfile::tempdir().unwrap();
+        write_package_folder(path_src.path(), "tatolab", "via-path", "1.0.0");
+
+        let archives = tempfile::tempdir().unwrap();
+        let archive_file = archives.path().join("via-archive.slpkg");
+        std::fs::write(
+            &archive_file,
+            slpkg_bytes("tatolab", "via-archive", "1.0.0"),
+        )
+        .unwrap();
+
+        let url_archive_file = archives.path().join("via-url.slpkg");
+        std::fs::write(
+            &url_archive_file,
+            slpkg_bytes("tatolab", "via-url", "1.0.0"),
+        )
+        .unwrap();
+        let url = format!("file://{}", url_archive_file.display());
+
+        let checkout = tempfile::tempdir().unwrap();
+        write_package_folder(checkout.path(), "tatolab", "via-link", "1.0.0");
+        let checkout_canonical = std::fs::canonicalize(checkout.path()).unwrap();
+
+        // --- Record the decision in a SOURCE app's streamlib.lock -------
+        let source_app_root = tempfile::tempdir().unwrap();
+        let source_app = AppModulesDir::at(source_app_root.path());
+        source_app
+            .add_package(
+                &AddPackageSource::Folder {
+                    path: path_src.path().to_path_buf(),
+                },
+                &AddPackageOptions::default(),
+            )
+            .unwrap();
+        source_app
+            .add_package(
+                &AddPackageSource::Archive {
+                    path: archive_file.clone(),
+                },
+                &AddPackageOptions::default(),
+            )
+            .unwrap();
+        source_app
+            .add_package(
+                &AddPackageSource::Url { url: url.clone() },
+                &AddPackageOptions::default(),
+            )
+            .unwrap();
+        source_app.link_package(checkout.path()).unwrap();
+
+        // --- Clean checkout: ONLY the lockfile is present ---------------
+        let dest_root = tempfile::tempdir().unwrap();
+        let dest = AppModulesDir::at(dest_root.path());
+        std::fs::copy(source_app.lockfile_path(), dest.lockfile_path()).unwrap();
+        assert!(!dest.modules_dir().exists(), "precondition: no modules dir");
+        let lock_bytes_before = std::fs::read(dest.lockfile_path()).unwrap();
+
+        // --- Reproduce --------------------------------------------------
+        let report = dest.install_from_lockfile().expect("install must succeed");
+        assert_eq!(report.packages.len(), 4);
+
+        // Every materialized slot is a real dir with a manifest whose re-hash
+        // matches the lockfile pin; the link slot is a symlink to the checkout.
+        for name in ["via-path", "via-archive", "via-url"] {
+            let slot = dest.package_dir(&pkg_ref("tatolab", name));
+            assert!(
+                slot.join("streamlib.yaml").is_file(),
+                "{name} slot missing manifest"
+            );
+            assert!(
+                !std::fs::symlink_metadata(&slot).unwrap().file_type().is_symlink(),
+                "{name} must be a real copy, not a symlink"
+            );
+            let locked = source_app
+                .read_lockfile()
+                .unwrap()
+                .packages
+                .get(&format!("@tatolab/{name}"))
+                .unwrap()
+                .content_hash
+                .clone();
+            assert_eq!(
+                content_hash_for_package_dir(&slot).unwrap(),
+                locked,
+                "{name} reproduced content hash must match the lock pin"
+            );
+        }
+        let link_slot = dest.package_dir(&pkg_ref("tatolab", "via-link"));
+        let link_meta = std::fs::symlink_metadata(&link_slot).unwrap();
+        assert!(link_meta.file_type().is_symlink(), "link slot must be a symlink");
+        assert_eq!(std::fs::read_link(&link_slot).unwrap(), checkout_canonical);
+
+        // Report classifies each kind correctly.
+        let kind_of = |name: &str| {
+            report
+                .packages
+                .iter()
+                .find(|p| p.package == pkg_ref("tatolab", name))
+                .unwrap()
+                .kind
+        };
+        assert_eq!(kind_of("via-path"), InstalledFromLockKind::Materialized);
+        assert_eq!(kind_of("via-archive"), InstalledFromLockKind::Materialized);
+        assert_eq!(kind_of("via-url"), InstalledFromLockKind::Materialized);
+        assert_eq!(kind_of("via-link"), InstalledFromLockKind::Linked);
+
+        // Install NEVER rewrites the lockfile it reproduced from.
+        assert_eq!(
+            std::fs::read(dest.lockfile_path()).unwrap(),
+            lock_bytes_before,
+            "install must not modify streamlib.lock"
+        );
+    }
+
+    /// Running install twice yields the same folder (idempotent).
+    #[test]
+    fn install_is_idempotent() {
+        let src = tempfile::tempdir().unwrap();
+        write_package_folder(src.path(), "tatolab", "camera", "2.0.0");
+        let source_app_root = tempfile::tempdir().unwrap();
+        let source_app = AppModulesDir::at(source_app_root.path());
+        source_app
+            .add_package(
+                &AddPackageSource::Folder {
+                    path: src.path().to_path_buf(),
+                },
+                &AddPackageOptions::default(),
+            )
+            .unwrap();
+
+        let dest_root = tempfile::tempdir().unwrap();
+        let dest = AppModulesDir::at(dest_root.path());
+        std::fs::copy(source_app.lockfile_path(), dest.lockfile_path()).unwrap();
+
+        let first = dest.install_from_lockfile().unwrap();
+        assert_eq!(first.packages.len(), 1);
+        assert!(!first.packages[0].replaced_existing, "first install is fresh");
+        let slot = dest.package_dir(&pkg_ref("tatolab", "camera"));
+        let manifest_after_first = std::fs::read(slot.join("streamlib.yaml")).unwrap();
+        let hash_after_first = content_hash_for_package_dir(&slot).unwrap();
+
+        let second = dest.install_from_lockfile().unwrap();
+        assert!(
+            second.packages[0].replaced_existing,
+            "second install replaces the existing slot"
+        );
+        assert_eq!(
+            std::fs::read(slot.join("streamlib.yaml")).unwrap(),
+            manifest_after_first,
+            "re-install must be byte-identical"
+        );
+        assert_eq!(content_hash_for_package_dir(&slot).unwrap(), hash_after_first);
+        // No staging residue after two runs.
+        assert_no_partial_state(
+            &dest,
+            &["@tatolab/camera"],
+            Some(&std::fs::read(dest.lockfile_path()).unwrap()),
+        );
+    }
+
+    #[test]
+    fn install_missing_lockfile_is_typed_error() {
+        let app_root = tempfile::tempdir().unwrap();
+        let app = AppModulesDir::at(app_root.path());
+        let err = app
+            .install_from_lockfile()
+            .expect_err("install with no lockfile must fail loud");
+        assert!(
+            matches!(err, AppModulesError::InstallLockfileMissing { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn install_empty_lockfile_is_noop_success() {
+        let app_root = tempfile::tempdir().unwrap();
+        let app = AppModulesDir::at(app_root.path());
+        write_modules_lock(&app, &[]);
+        let report = app.install_from_lockfile().expect("empty lock installs");
+        assert!(report.packages.is_empty());
+    }
+
+    #[test]
+    fn install_content_hash_mismatch_is_typed_error_with_no_partial_state() {
+        // A path source that is valid but whose recorded content hash is wrong
+        // (a tampered/changed source) is refused BEFORE any slot is promoted.
+        let src = tempfile::tempdir().unwrap();
+        write_package_folder(src.path(), "tatolab", "camera", "2.0.0");
+        let canonical = std::fs::canonicalize(src.path()).unwrap();
+
+        let app_root = tempfile::tempdir().unwrap();
+        let app = AppModulesDir::at(app_root.path());
+        write_modules_lock(
+            &app,
+            &[(
+                "@tatolab/camera",
+                LockfileEntry {
+                    version: SemVer::new(2, 0, 0),
+                    source: LockfileSource::Path { path: canonical },
+                    content_hash: "sha256:deadbeef".to_string(),
+                },
+            )],
+        );
+        let lock_before = std::fs::read(app.lockfile_path()).unwrap();
+
+        let err = app
+            .install_from_lockfile()
+            .expect_err("content hash mismatch must fail");
+        match err {
+            AppModulesError::InstallContentHashMismatch { package, .. } => {
+                assert_eq!(package, pkg_ref("tatolab", "camera"));
+            }
+            other => panic!("expected InstallContentHashMismatch, got {other:?}"),
+        }
+        // No slot promoted; no staging residue; lock untouched.
+        assert_no_partial_state(&app, &[], Some(&lock_before));
+    }
+
+    #[test]
+    fn install_missing_path_source_is_typed_error_naming_package() {
+        let app_root = tempfile::tempdir().unwrap();
+        let app = AppModulesDir::at(app_root.path());
+        write_modules_lock(
+            &app,
+            &[(
+                "@tatolab/camera",
+                LockfileEntry {
+                    version: SemVer::new(2, 0, 0),
+                    source: LockfileSource::Path {
+                        path: "/definitely/not/here".into(),
+                    },
+                    content_hash: "sha256:abc".to_string(),
+                },
+            )],
+        );
+        let err = app
+            .install_from_lockfile()
+            .expect_err("gone path source must fail");
+        match err {
+            AppModulesError::InstallSourceUnavailable { package, .. } => {
+                assert_eq!(package, pkg_ref("tatolab", "camera"));
+            }
+            other => panic!("expected InstallSourceUnavailable, got {other:?}"),
+        }
+        assert_no_partial_state(&app, &[], Some(&std::fs::read(app.lockfile_path()).unwrap()));
+    }
+
+    #[test]
+    fn install_missing_archive_and_url_sources_are_typed_errors() {
+        // A gone archive file.
+        let app_a_root = tempfile::tempdir().unwrap();
+        let app_a = AppModulesDir::at(app_a_root.path());
+        write_modules_lock(
+            &app_a,
+            &[(
+                "@tatolab/camera",
+                LockfileEntry {
+                    version: SemVer::new(2, 0, 0),
+                    source: LockfileSource::Archive {
+                        path: "/definitely/not/here.slpkg".into(),
+                        archive_sha256: "ab".repeat(32),
+                    },
+                    content_hash: "sha256:abc".to_string(),
+                },
+            )],
+        );
+        assert!(matches!(
+            app_a.install_from_lockfile().expect_err("gone archive must fail"),
+            AppModulesError::InstallSourceUnavailable { .. }
+        ));
+
+        // An unreachable file:// URL (offline).
+        let app_b_root = tempfile::tempdir().unwrap();
+        let app_b = AppModulesDir::at(app_b_root.path());
+        write_modules_lock(
+            &app_b,
+            &[(
+                "@tatolab/camera",
+                LockfileEntry {
+                    version: SemVer::new(2, 0, 0),
+                    source: LockfileSource::Url {
+                        url: "file:///definitely/not/here.slpkg".to_string(),
+                        archive_sha256: "ab".repeat(32),
+                    },
+                    content_hash: "sha256:abc".to_string(),
+                },
+            )],
+        );
+        assert!(matches!(
+            app_b.install_from_lockfile().expect_err("gone url must fail"),
+            AppModulesError::InstallSourceUnavailable { .. }
+        ));
+    }
+
+    #[test]
+    fn install_archive_sha_mismatch_is_typed_error() {
+        // A valid archive whose bytes don't match the recorded archive_sha256.
+        let archives = tempfile::tempdir().unwrap();
+        let archive_file = archives.path().join("camera.slpkg");
+        std::fs::write(&archive_file, slpkg_bytes("tatolab", "camera", "2.0.0")).unwrap();
+
+        let app_root = tempfile::tempdir().unwrap();
+        let app = AppModulesDir::at(app_root.path());
+        write_modules_lock(
+            &app,
+            &[(
+                "@tatolab/camera",
+                LockfileEntry {
+                    version: SemVer::new(2, 0, 0),
+                    source: LockfileSource::Archive {
+                        path: archive_file,
+                        archive_sha256: "00".repeat(32),
+                    },
+                    content_hash: "sha256:abc".to_string(),
+                },
+            )],
+        );
+        match app
+            .install_from_lockfile()
+            .expect_err("archive sha mismatch must fail")
+        {
+            AppModulesError::InstallArchiveHashMismatch { package, .. } => {
+                assert_eq!(package, pkg_ref("tatolab", "camera"));
+            }
+            other => panic!("expected InstallArchiveHashMismatch, got {other:?}"),
+        }
+        assert_no_partial_state(&app, &[], Some(&std::fs::read(app.lockfile_path()).unwrap()));
+    }
+
+    #[test]
+    fn install_dangling_link_target_is_typed_error_naming_package() {
+        // A link entry whose checkout target no longer exists — a dev-only link
+        // isn't reproducible on another machine; that's an explicit error.
+        let checkout = tempfile::tempdir().unwrap();
+        write_package_folder(checkout.path(), "tatolab", "camera", "2.0.0");
+        let canonical = std::fs::canonicalize(checkout.path()).unwrap();
+        std::fs::remove_dir_all(checkout.path()).unwrap();
+
+        let app_root = tempfile::tempdir().unwrap();
+        let app = AppModulesDir::at(app_root.path());
+        write_modules_lock(
+            &app,
+            &[(
+                "@tatolab/camera",
+                LockfileEntry {
+                    version: SemVer::new(2, 0, 0),
+                    source: LockfileSource::Link { path: canonical },
+                    content_hash: "sha256:abc".to_string(),
+                },
+            )],
+        );
+        match app
+            .install_from_lockfile()
+            .expect_err("dangling link target must fail")
+        {
+            AppModulesError::InstallDanglingLinkTarget { package, .. } => {
+                assert_eq!(package, pkg_ref("tatolab", "camera"));
+            }
+            other => panic!("expected InstallDanglingLinkTarget, got {other:?}"),
+        }
+        // No slot created for the un-reproducible link.
+        let slot = app.package_dir(&pkg_ref("tatolab", "camera"));
+        assert!(std::fs::symlink_metadata(&slot).is_err());
+    }
+
+    #[test]
+    fn install_unsupported_source_kind_is_typed_error() {
+        // A registry/git entry can't be reproduced by install (add/link never
+        // writes these into streamlib.lock, but be defensive).
+        let app_root = tempfile::tempdir().unwrap();
+        let app = AppModulesDir::at(app_root.path());
+        write_modules_lock(
+            &app,
+            &[(
+                "@tatolab/camera",
+                LockfileEntry {
+                    version: SemVer::new(2, 0, 0),
+                    source: LockfileSource::Registry {
+                        url: "https://packages.streamlib.dev".to_string(),
+                    },
+                    content_hash: "sha256:abc".to_string(),
+                },
+            )],
+        );
+        match app
+            .install_from_lockfile()
+            .expect_err("registry source must be refused")
+        {
+            AppModulesError::InstallUnsupportedSource { package, kind } => {
+                assert_eq!(package, pkg_ref("tatolab", "camera"));
+                assert_eq!(kind, "registry");
+            }
+            other => panic!("expected InstallUnsupportedSource, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## What & why

`streamlib install` now reads the committed `streamlib.lock` (the per-app
`MODULES_LOCKFILE_NAME` written by `streamlib add` / `streamlib link`) and
repopulates the app's `streamlib_modules/` folder **exactly** — hash-verified,
offline-capable, with no resolution decisions. This is the container/CI
preinstall story: commit the lock, run `install` at image build (or copy the
vendored folder in directly). You never `link` for docker; you preinstall.

Install is the seam between acquisition and reproduction: `add`/`link` decide
*what's in the environment*; `install` reproduces that decision *elsewhere*
(a fresh checkout, an image build).

## Per-source reproduction

Each `LockfileSource` variant is reproduced through the **same**
stage → validate → promote machinery `add`/`link` already use — no forked
extract/copy/symlink logic:

| Source | Reproduction |
|---|---|
| `Path { path }` | copy the folder (`stage_source_contents` → `AddPackageSource::Folder`) |
| `Archive { path, archive_sha256 }` | re-extract the local archive + verify `archive_sha256` |
| `Url { url, archive_sha256 }` | refetch (`file://`/HTTP) + verify `archive_sha256` + extract |
| `Link { path }` | re-create the symlink (`StagingSymlink` + `promote_staged_package_root`) |

After materializing a **byte source**, the reproduced package's `content_hash`
is re-verified against the lock entry **before the promote**, so a mismatch
leaves *no partial slot* (the staging dir is swept on the early return). Archive
and URL entries additionally re-check the recorded `archive_sha256` during
staging. `Registry`/`Git` entries (which `add`/`link` never write into
`streamlib.lock`) are refused with a typed error.

## Linked-entry behavior (the reviewer-flagged decision)

A `Link` entry's symlink is **re-created iff its checkout target still exists**;
a gone target is a typed `InstallDanglingLinkTarget` naming the package. A linked
dev checkout is inherently non-reproducible on another machine — install surfaces
that loudly rather than producing a broken/empty slot. A `Link` entry's
`content_hash` is a *point-in-time snapshot of a live checkout*, so it is
deliberately **not** re-verified at install (re-verifying a drifting checkout
would spuriously fail).

## Atomicity & idempotency

**Per-package-atomic, fail-fast.** Each package stages → verifies → promotes
atomically, so no slot is ever half-written; the pre-promote hash check means a
failing package produces no slot at all. A failure stops the run with a typed
error naming the package; packages already reproduced (each valid + hash-verified)
remain, so re-running install completes the reproduction. Install **never
rewrites the lockfile** (it reproduces *from* it), so double-install is
idempotent. **Additive, non-destructive:** install materializes every locked
entry but does not prune on-disk slots absent from the lock — the clean-checkout
container target starts empty, so the result equals the locked set exactly; the
non-pruning choice keeps a not-yet-`add`ed work-in-progress folder from being
deleted (documented on the method + in the PR review below).

## Install-vs-run-lock clarification

There were two distinct "install" notions; this PR disambiguates them:

- **CLI `streamlib install`** → now reproduces `streamlib_modules/` from
  `streamlib.lock` (`MODULES_LOCKFILE_NAME`) via
  `AppModulesDir::install_from_lockfile`. **Repurposed** in this PR.
- **Programmatic `install()`** (`sdk::runtime::install`) → resolves a
  `streamlib.yaml` range→concrete, materializes, and writes `streamlib-app.lock`
  (`APP_LOCKFILE_NAME`). The locked run (`add_modules_from_lockfile`) loads that
  pinned set offline. **Untouched** — still available programmatically; only the
  CLI verb moved. No dangling caller of the old CLI behavior remains.

Docs updated to match (`package-development-model.md` "The install seam" — three
operations keyed by which lockfile they touch, with a dated supersession note;
`CLAUDE.md` "Install seam" pointer).

## Reuse, not fork

`install_from_lockfile` calls the existing private helpers
(`StagingDir`/`StagingSymlink`, `stage_source_contents`,
`locate_staged_package_root`, `promote_staged_package_root`,
`content_hash_for_package_dir`, `sweep_orphan_staging_entries`) — the same ones
`add_package`/`link_package` use. No new extract/copy/symlink abstraction.

## Typed error taxonomy

`InstallLockfileMissing`, `InstallInvalidLockEntry`, `InstallSourceUnavailable`
(gone path/archive/offline url), `InstallDanglingLinkTarget`,
`InstallArchiveHashMismatch`, `InstallContentHashMismatch`,
`InstallUnsupportedSource`, `InstallReproduceFailed` — each names the offending
package. `tracing::instrument` on the entrypoint.

## Deviations

- **Repurposed the `streamlib install` CLI verb** (previously ran
  resolve+materialize→`streamlib-app.lock`). This is the convergence the decided
  model calls for; the old resolve flow survives as the programmatic `install()`
  seam. Flagged here so reviewers see the behavior change was intentional.
- No polyglot surface: this is a filesystem/lockfile CLI + engine primitive with
  no Python/Deno SDK mirror and no escalate IPC, so nothing to sync across
  runtimes.

## Test evidence

- **Unit** (`streamlib-idents`, 8 new): each source kind reproduced from a clean
  checkout (byte-equivalent + hashes verified); content-hash-mismatch →
  `InstallContentHashMismatch` with no partial state; missing path/archive/offline-url
  → `InstallSourceUnavailable`; archive-sha mismatch → `InstallArchiveHashMismatch`;
  dangling link → `InstallDanglingLinkTarget` with no slot; unsupported (registry)
  source → `InstallUnsupportedSource`; idempotent double-install; empty + missing
  lockfiles. All hermetic (`file://` for URL, no network). `203` idents lib tests
  green.
- **CLI integration** (`tests/install_from_lock.rs`, 3): clean-checkout
  reproduction over a real streamlib-pack `.slpkg`; delete-`streamlib_modules/`
  recovery; no-lockfile failure. Drives the real `streamlib` binary. `3/3` green.
- **Lints:** `xtask lint-logging` (528 files, 0 violations), `xtask
  check-boundaries` (4983 files, 0 violations). `cargo build --workspace` green
  with **no registry mirror**. `app_modules.rs` additions clippy-clean (the CLI's
  `println!` user-output warnings match the established `add.rs`/`link.rs`
  pattern; the real logging gate passes).
- **Live smoke:** `streamlib add` a fixture → delete `streamlib_modules/` (keep
  the lock) → `streamlib install` → manifest sha256 `a50934af…` identical before
  and after; second install idempotent.
- **Pre-PR review gate:** PASS. One non-blocking DISCUSS item (additive vs.
  `npm ci` clean-slate) verified and documented as a deliberate non-destructive
  choice.

## Exit criteria (#1326)

- [x] `streamlib install` in a clean checkout with only `streamlib.lock`
      produces a byte-equivalent `streamlib_modules/` (hash-verified).
- [~] Docker path proven — the reproduction **mechanism** (offline, hash-verified
      folder rebuild from the committed lock) is proven at the unit/integration +
      live-smoke level. A literal `docker --gpus all` container run is out of this
      sandbox (GPU/IPC runtime isn't observable here); it's the one deferred item,
      to be run by CI / the user.
- [x] Defined, documented behavior for linked entries at install time.

Not using `Closes #1326` because the literal containerized-run criterion is
deferred out-of-sandbox. Addresses #1326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB
