### PR TITLE
feat(runtime): version-free processor references — reference a processor with no version (#1337)

### DIFF
--- a/docs/architecture/runtime-module-materialization.md
+++ b/docs/architecture/runtime-module-materialization.md
@@ -239,33 +239,50 @@ resolutions/builds before the caller awaits anything.
 ## Lazy plugin auto-discovery — no load call in app code
 
 App code never calls `add_module`. When `add_processor(ProcessorSpec::new(
-type, cfg))` references a processor type that isn't registered yet, the
+reference, cfg))` references a processor type that isn't registered yet, the
 runtime **discovers and loads the providing package on first reference**
 from the app's `streamlib_modules/` folder — the gstreamer plugin-host
 model applied to a per-app module folder. `add_module` /
 `add_module_with(Strategy)` survive as an embedding / power-caller escape
 hatch, not a step common app code takes.
 
-The trigger is the same registry miss `add_v` already detects. Before a
-processor node is added, `add_processor` checks
-`PROCESSOR_REGISTRY.port_info(&spec.name)`. On a hit the type is already
-available and nothing loads — which is exactly why a **second reference
-to a type from an already-loaded package never reloads** the plugin. On a
-miss the runtime runs lazy discovery:
+`ProcessorSpec::new` takes a `ProcessorTypeReference`, which is either
+**version-free** or **version-pinned**:
+
+- **Version-free** (`processor_type_ref!("org", "package", "Type")`) — the
+  canonical form for the no-`add_module` world. It carries only
+  `(org, package, type)`, runs **no registry lookup at the call site**, and
+  reaches the lazy hook to resolve against whatever version the installed
+  provider registers. This is what lets an app reference `@org/package/Type`
+  with **no version anywhere in its code**.
+- **Version-pinned** (`schema_ident!(...)`, or any `SchemaIdent` via `From`) —
+  a concrete `SchemaIdent` including a version; resolution is version-exact.
+
+(`schema_ident_any_version!` is a third, distinct tool: it resolves a
+`SchemaIdent` *now* against the **already-registered** types — for apps that
+called `add_module` first — and does not trigger lazy loading.)
+
+Before a processor node is added, `add_processor` runs the lazy hook, which
+asks whether the referenced type is already registered — the exact
+`SchemaIdent` for a version-pinned reference, or the installed
+`(org, package, type)` tuple for a version-free one. When it is, nothing
+loads — which is exactly why a **second reference to a type from an
+already-loaded package never reloads** the plugin. Otherwise the runtime runs
+lazy discovery:
 
 1. **Discover.** Scan `<app-modules-root>/streamlib_modules/@org/name/streamlib.yaml`,
    matching each manifest's `package:` org + name and its declared
-   processor short names against the referenced ident's `org` / `package`
-   / `type`. Discovery resolves the *provider package* by
-   `(org, package, type)` and ignores the reference-site version — the
-   installed version is pinned in `streamlib.lock` at `streamlib add`
-   time. The **terminal type resolution is still version-exact**, though:
-   `add_v` / `PROCESSOR_REGISTRY.port_info` match the referenced
-   `SchemaIdent` including its version. So a reference whose version
-   differs from the installed package's version loads the provider but
-   then resolves to `UnknownProcessorType`. A fully version-free
-   reference form is not available yet — a `SchemaIdent` at the
-   reference site still carries a concrete version.
+   processor short names against the referenced `org` / `package` / `type`.
+   Discovery resolves the *provider package* by `(org, package, type)` and
+   ignores any reference-site version — the installed version is pinned in
+   `streamlib.lock` at `streamlib add` time. **Terminal type resolution then
+   matches the reference form:** a version-free reference resolves to the
+   single installed provider's registered ident
+   (`resolve_installed_processor_type`), so it never loads-then-misses; a
+   version-pinned reference stays version-exact
+   (`PROCESSOR_REGISTRY.port_info` on the exact `SchemaIdent`), so a pin whose
+   version differs from the installed package's loads the provider but then
+   resolves to `UnknownProcessorType`.
 2. **Load.** Resolve the single matching package to
    `add_module_with(ModuleIdent, Strategy::InstalledCache)` and drive it
    through the **transactional load path** below. `InstalledCache` probes

--- a/libs/streamlib-engine/src/core/graph/traversal/mutation_ops/add_v_op.rs
+++ b/libs/streamlib-engine/src/core/graph/traversal/mutation_ops/add_v_op.rs
@@ -9,7 +9,9 @@ use crate::core::graph::{
     GraphNodeWithComponents, ProcessorNode, ProcessorTraversalMut, StateComponent,
     TraversalSourceMut,
 };
-use crate::core::processors::{PROCESSOR_REGISTRY, ProcessorSpec, ProcessorState};
+use crate::core::processors::{
+    PROCESSOR_REGISTRY, ProcessorSpec, ProcessorState, ProcessorTypeReference,
+};
 
 impl<'a> TraversalSourceMut<'a> {
     /// Add a new processor node to the graph.
@@ -22,8 +24,31 @@ impl<'a> TraversalSourceMut<'a> {
     /// why — runtime-dynamic systems prefer "load-and-mark-failed" over
     /// "silently-skip" so observability survives the misconfiguration.
     pub fn add_v(self, spec: ProcessorSpec) -> ProcessorTraversalMut<'a> {
-        let port_info = PROCESSOR_REGISTRY.port_info(&spec.name);
-        let registry_miss = port_info.is_none();
+        // Resolve the reference to the concrete registered ident + its ports.
+        // `VersionPinned` matches version-exact (the #1325 path); a version-free
+        // `ResolveToInstalled` resolves `(org, package, type)` to the single
+        // installed provider. Both gate on `port_info` presence — every
+        // registered processor has a `port_info` entry (subprocess-only
+        // descriptors register empty port lists), so both variants resolve any
+        // registered type and miss only a genuinely-unregistered one.
+        let resolved = match &spec.name {
+            ProcessorTypeReference::VersionPinned(ident) => PROCESSOR_REGISTRY
+                .port_info(ident)
+                .map(|ports| (ident.clone(), ports)),
+            ProcessorTypeReference::ResolveToInstalled {
+                org,
+                package,
+                r#type,
+            } => PROCESSOR_REGISTRY
+                .resolve_installed_processor_type(org, package, r#type)
+                .and_then(|ident| {
+                    PROCESSOR_REGISTRY
+                        .port_info(&ident)
+                        .map(|ports| (ident, ports))
+                }),
+        };
+
+        let registry_miss = resolved.is_none();
 
         if registry_miss {
             tracing::error!(
@@ -32,13 +57,17 @@ impl<'a> TraversalSourceMut<'a> {
             );
         }
 
-        let (inputs, outputs) = port_info.unwrap_or_else(|| (vec![], vec![]));
+        // On a miss, build the failed node with the reference's diagnostic
+        // ident (concrete for `VersionPinned`; `(org, package, type)@0.0.0` for
+        // a version-free reference) so it stays visible via `GET /api/graph`.
+        let (node_ident, (inputs, outputs)) =
+            resolved.unwrap_or_else(|| (spec.name.to_diagnostic_ident(), (vec![], vec![])));
 
         let display_name = spec
             .display_name
-            .unwrap_or_else(|| spec.name.r#type.as_str().to_string());
+            .unwrap_or_else(|| node_ident.r#type.as_str().to_string());
 
-        let node = ProcessorNode::new(spec.name, display_name, Some(spec.config), inputs, outputs);
+        let node = ProcessorNode::new(node_ident, display_name, Some(spec.config), inputs, outputs);
 
         let node_idx = self.graph.add_node(node);
 

--- a/libs/streamlib-engine/src/core/processors/mod.rs
+++ b/libs/streamlib-engine/src/core/processors/mod.rs
@@ -10,6 +10,7 @@ pub mod __generated_private;
 
 mod processor_instance_factory;
 mod processor_spec;
+mod processor_type_reference;
 // Re-export graph types — `ProcessorState` and `ProcessorStateComponent`
 // live in `core::graph` (#786); kept as a re-export here so the public
 // `streamlib::sdk::processors::ProcessorState` path stays stable.
@@ -28,6 +29,7 @@ pub use processor_instance_factory::{
     DynamicProcessorConstructorFn, PROCESSOR_REGISTRY, ProcessorInstance, ProcessorInstanceFactory,
 };
 pub use processor_spec::ProcessorSpec;
+pub use processor_type_reference::ProcessorTypeReference;
 
 /// Empty config type for processors that don't need configuration.
 #[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/libs/streamlib-engine/src/core/processors/processor_instance_factory.rs
+++ b/libs/streamlib-engine/src/core/processors/processor_instance_factory.rs
@@ -1281,38 +1281,71 @@ impl ProcessorInstanceFactory {
         self.descriptors.read().values().cloned().collect()
     }
 
-    /// Resolve `(org, package, type)` against the registry by picking the
-    /// highest-`SemVer` match across all registered idents. Returns
-    /// [`Error::UnknownProcessorType`] when nothing matches.
+    /// The highest-`SemVer` registered ident matching `(org, package, type)`,
+    /// or `None` when nothing matches. Shared tuple-scan behind
+    /// [`Self::resolve_any_version`] and
+    /// [`Self::resolve_installed_processor_type`].
     ///
     /// Iterates over `descriptors` (the truth for registered idents),
     /// not `registrations`, so subprocess-only processors registered via
     /// [`Self::register_descriptor_only`] participate in resolution.
+    fn highest_registered_for_tuple(
+        &self,
+        org: &crate::core::descriptors::Org,
+        package: &crate::core::descriptors::Package,
+        type_name: &crate::core::descriptors::TypeName,
+    ) -> Option<SchemaIdent> {
+        self.descriptors
+            .read()
+            .keys()
+            .filter(|id| &id.org == org && &id.package == package && &id.r#type == type_name)
+            .max_by_key(|id| id.version)
+            .cloned()
+    }
+
+    /// Resolve `(org, package, type)` against the registry by picking the
+    /// highest-`SemVer` match across all registered idents. Returns
+    /// [`Error::UnknownProcessorType`] when nothing matches.
     pub fn resolve_any_version(
         &self,
         org: &crate::core::descriptors::Org,
         package: &crate::core::descriptors::Package,
         type_name: &crate::core::descriptors::TypeName,
     ) -> Result<SchemaIdent> {
-        let descriptors = self.descriptors.read();
-        let highest = descriptors
-            .keys()
-            .filter(|id| &id.org == org && &id.package == package && &id.r#type == type_name)
-            .max_by_key(|id| id.version.clone())
-            .cloned();
-        highest.ok_or_else(|| Error::UnknownProcessorType {
-            // No version was supplied; we render the search target as
-            // `(org, package, type)@0.0.0` so the diagnostic still names
-            // the offending tuple. Callers who want the exact "any
-            // version" semantics in the message string should match on
-            // the variant and re-render.
-            ident: SchemaIdent::new(
-                org.clone(),
-                package.clone(),
-                type_name.clone(),
-                crate::core::descriptors::SemVer::new(0, 0, 0),
-            ),
-        })
+        self.highest_registered_for_tuple(org, package, type_name)
+            .ok_or_else(|| Error::UnknownProcessorType {
+                // No version was supplied; we render the search target as
+                // `(org, package, type)@0.0.0` so the diagnostic still names
+                // the offending tuple. Callers who want the exact "any
+                // version" semantics in the message string should match on
+                // the variant and re-render.
+                ident: SchemaIdent::new(
+                    org.clone(),
+                    package.clone(),
+                    type_name.clone(),
+                    crate::core::descriptors::SemVer::new(0, 0, 0),
+                ),
+            })
+    }
+
+    /// Resolve a version-free reference to the concrete [`SchemaIdent`] of the
+    /// single installed provider for `(org, package, type)`, or `None` when no
+    /// provider is registered.
+    ///
+    /// The one-installed-version-per-package invariant means at most one
+    /// version is registered for a tuple in a process; if more than one
+    /// somehow is, the highest `SemVer` wins deterministically. This is the
+    /// terminal resolution for a version-free
+    /// [`ProcessorTypeReference::ResolveToInstalled`](crate::core::processors::ProcessorTypeReference),
+    /// distinct from [`Self::resolve_any_version`] (which the version-omitting
+    /// call-site macro uses against already-registered types).
+    pub fn resolve_installed_processor_type(
+        &self,
+        org: &crate::core::descriptors::Org,
+        package: &crate::core::descriptors::Package,
+        type_name: &crate::core::descriptors::TypeName,
+    ) -> Option<SchemaIdent> {
+        self.highest_registered_for_tuple(org, package, type_name)
     }
 
     /// All known port-schema specs from registered processor ports,
@@ -1483,6 +1516,48 @@ mod tests {
             }
             other => panic!("expected UnknownProcessorType, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn resolve_installed_processor_type_returns_the_single_installed_version() {
+        // Terminal resolution for a version-free reference: with one installed
+        // version, resolve to it; with nothing registered, `None` (the
+        // genuinely-absent case the caller degrades to `UnknownProcessorType`).
+        let factory = ProcessorInstanceFactory::new();
+        let org = Org::new("acme").unwrap();
+        let pkg = Package::new("core").unwrap();
+        let ty = TypeName::new("Camera").unwrap();
+
+        // Nothing registered → None.
+        assert!(
+            factory
+                .resolve_installed_processor_type(&org, &pkg, &ty)
+                .is_none(),
+            "an absent tuple must resolve to None"
+        );
+
+        // Register the single installed version.
+        let installed = ident("acme", "core", "Camera", SemVer::new(2, 3, 4));
+        factory
+            .register_descriptor_only(unit_descriptor(installed.clone()))
+            .unwrap();
+
+        // A version-free resolve returns the concrete installed ident.
+        assert_eq!(
+            factory.resolve_installed_processor_type(&org, &pkg, &ty),
+            Some(installed),
+            "must resolve to the installed version's concrete ident"
+        );
+
+        // A different type in the same package still resolves to None — the
+        // resolve is tuple-scoped, not a loose match.
+        let other_ty = TypeName::new("Display").unwrap();
+        assert!(
+            factory
+                .resolve_installed_processor_type(&org, &pkg, &other_ty)
+                .is_none(),
+            "a different type must not resolve"
+        );
     }
 
     #[test]

--- a/libs/streamlib-engine/src/core/processors/processor_spec.rs
+++ b/libs/streamlib-engine/src/core/processors/processor_spec.rs
@@ -3,7 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::core::descriptors::SchemaIdent;
+use crate::core::processors::ProcessorTypeReference;
 
 /// Specification for creating a processor.
 ///
@@ -11,8 +11,9 @@ use crate::core::descriptors::SchemaIdent;
 /// Internal details (id, ports) are resolved by the runtime.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProcessorSpec {
-    /// Structured processor identity (matches the registered key in [`PROCESSOR_REGISTRY`](crate::core::processors::PROCESSOR_REGISTRY)).
-    pub name: SchemaIdent,
+    /// How the processor type is referenced: a version-pinned [`SchemaIdent`](crate::core::descriptors::SchemaIdent)
+    /// or a version-free reference resolved to the installed provider at add time.
+    pub name: ProcessorTypeReference,
     /// Configuration as JSON value.
     pub config: serde_json::Value,
     /// Display name override. If `None`, defaults to the processor's PascalCase short name.
@@ -21,9 +22,12 @@ pub struct ProcessorSpec {
 }
 
 impl ProcessorSpec {
-    pub fn new(name: SchemaIdent, config: serde_json::Value) -> Self {
+    /// Build a spec from a processor-type reference (a version-pinned
+    /// [`SchemaIdent`](crate::core::descriptors::SchemaIdent) via
+    /// [`From`], or a version-free [`ProcessorTypeReference`]) and a JSON config.
+    pub fn new(name: impl Into<ProcessorTypeReference>, config: serde_json::Value) -> Self {
         Self {
-            name,
+            name: name.into(),
             config,
             display_name: None,
         }
@@ -39,7 +43,7 @@ impl ProcessorSpec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::descriptors::{Org, Package, SemVer, TypeName};
+    use crate::core::descriptors::{Org, Package, SchemaIdent, SemVer, TypeName};
 
     fn ident(org: &str, pkg: &str, ty: &str, v: SemVer) -> SchemaIdent {
         SchemaIdent::new(
@@ -112,6 +116,60 @@ mod tests {
         )
         .with_display_name("Camera A");
         assert_eq!(spec.display_name.as_deref(), Some("Camera A"));
+    }
+
+    /// A `SchemaIdent` still constructs a spec (via `From<SchemaIdent>`),
+    /// landing as a version-pinned reference — the #1325 call-site shape is
+    /// unchanged.
+    #[test]
+    fn schema_ident_builds_version_pinned_spec() {
+        let spec = ProcessorSpec::new(
+            ident("tatolab", "core", "VideoFrame", SemVer::new(1, 0, 0)),
+            serde_json::Value::Null,
+        );
+        assert!(matches!(
+            spec.name,
+            ProcessorTypeReference::VersionPinned(_)
+        ));
+    }
+
+    /// A version-free reference builds a spec that carries no version at the
+    /// reference site — the shape that reaches the lazy hook.
+    #[test]
+    fn version_free_reference_builds_resolve_to_installed_spec() {
+        let spec = ProcessorSpec::new(
+            ProcessorTypeReference::ResolveToInstalled {
+                org: Org::new("tatolab").unwrap(),
+                package: Package::new("camera").unwrap(),
+                r#type: TypeName::new("Camera").unwrap(),
+            },
+            serde_json::json!({"fps": 30}),
+        );
+        assert!(matches!(
+            spec.name,
+            ProcessorTypeReference::ResolveToInstalled { .. }
+        ));
+        // The wire carries the three-key form, no version key.
+        let value = serde_json::to_value(&spec).unwrap();
+        assert!(value["name"].get("version").is_none());
+        assert_eq!(value["name"]["type"], "Camera");
+    }
+
+    /// The version-free spec round-trips over msgpack (the plugin-ABI wire)
+    /// with full value equality.
+    #[test]
+    fn version_free_spec_msgpack_round_trip() {
+        let spec = ProcessorSpec::new(
+            ProcessorTypeReference::ResolveToInstalled {
+                org: Org::new("tatolab").unwrap(),
+                package: Package::new("camera").unwrap(),
+                r#type: TypeName::new("Camera").unwrap(),
+            },
+            serde_json::json!({"width": 1920}),
+        );
+        let bytes = rmp_serde::to_vec_named(&spec).expect("encode");
+        let back: ProcessorSpec = rmp_serde::from_slice(&bytes).expect("decode");
+        assert_eq!(spec, back);
     }
 
     /// msgpack `to_vec_named` → `from_slice` round-trip preserves full

--- a/libs/streamlib-engine/src/core/processors/processor_type_reference.rs
+++ b/libs/streamlib-engine/src/core/processors/processor_type_reference.rs
@@ -1,0 +1,244 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::descriptors::{Org, Package, SchemaIdent, SemVer, TypeName};
+
+/// How a [`ProcessorSpec`](crate::core::processors::ProcessorSpec) names its
+/// processor type: either a fully version-pinned identity, or a version-free
+/// reference resolved to the single installed provider at add time.
+///
+/// The version-free [`Self::ResolveToInstalled`] form is what makes lazy
+/// plugin discovery reach the runtime hook: it carries only `(org, package,
+/// type)` and defers version resolution to `add_processor` time, so a
+/// reference to a not-yet-loaded package triggers the lazy load instead of
+/// failing at the call site. The version-pinned [`Self::VersionPinned`] form
+/// is the exact-`SchemaIdent` path.
+///
+/// Wire compatibility: `#[serde(untagged)]` with [`Self::VersionPinned`]
+/// first means a version-pinned reference serializes byte-identically to a
+/// bare [`SchemaIdent`] (a four-key `{org, package, type, version}` map), and
+/// a version-free reference serializes as the three-key `{org, package,
+/// type}` map. Deserialization tries [`Self::VersionPinned`] first (it
+/// requires `version`) and falls to [`Self::ResolveToInstalled`] when
+/// `version` is absent — order alone disambiguates.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ProcessorTypeReference {
+    /// Version-pinned — the exact [`SchemaIdent`] (including its version) must
+    /// be registered for the reference to resolve.
+    VersionPinned(SchemaIdent),
+    /// Version-free — resolve `(org, package, type)` to the single installed
+    /// provider's registered descriptor at add time.
+    ResolveToInstalled {
+        org: Org,
+        package: Package,
+        #[serde(rename = "type")]
+        r#type: TypeName,
+    },
+}
+
+impl ProcessorTypeReference {
+    /// The referenced org, common to both forms.
+    pub fn org(&self) -> &Org {
+        match self {
+            Self::VersionPinned(ident) => &ident.org,
+            Self::ResolveToInstalled { org, .. } => org,
+        }
+    }
+
+    /// The referenced package, common to both forms.
+    pub fn package(&self) -> &Package {
+        match self {
+            Self::VersionPinned(ident) => &ident.package,
+            Self::ResolveToInstalled { package, .. } => package,
+        }
+    }
+
+    /// The referenced processor type short name, common to both forms.
+    pub fn r#type(&self) -> &TypeName {
+        match self {
+            Self::VersionPinned(ident) => &ident.r#type,
+            Self::ResolveToInstalled { r#type, .. } => r#type,
+        }
+    }
+
+    /// The pinned [`SchemaIdent`] when this is a [`Self::VersionPinned`]
+    /// reference; `None` for the version-free form.
+    pub fn as_version_pinned(&self) -> Option<&SchemaIdent> {
+        match self {
+            Self::VersionPinned(ident) => Some(ident),
+            Self::ResolveToInstalled { .. } => None,
+        }
+    }
+
+    /// A concrete [`SchemaIdent`] for diagnostics (error messages, the failed
+    /// node's identity in the graph). The pinned form yields its real ident;
+    /// the version-free form renders `(org, package, type)@0.0.0` — the same
+    /// version-free placeholder convention
+    /// [`ProcessorInstanceFactory::resolve_any_version`](crate::core::processors::ProcessorInstanceFactory::resolve_any_version)
+    /// already uses. Never stored as a real registration key.
+    pub fn to_diagnostic_ident(&self) -> SchemaIdent {
+        match self {
+            Self::VersionPinned(ident) => ident.clone(),
+            Self::ResolveToInstalled {
+                org,
+                package,
+                r#type,
+            } => SchemaIdent::new(
+                org.clone(),
+                package.clone(),
+                r#type.clone(),
+                SemVer::new(0, 0, 0),
+            ),
+        }
+    }
+}
+
+impl From<SchemaIdent> for ProcessorTypeReference {
+    fn from(ident: SchemaIdent) -> Self {
+        Self::VersionPinned(ident)
+    }
+}
+
+impl fmt::Display for ProcessorTypeReference {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::VersionPinned(ident) => write!(f, "{ident}"),
+            Self::ResolveToInstalled {
+                org,
+                package,
+                r#type,
+            } => write!(f, "@{org}/{package}/{type} (version-free)", type = r#type),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pinned(org: &str, pkg: &str, ty: &str, v: SemVer) -> ProcessorTypeReference {
+        ProcessorTypeReference::VersionPinned(SchemaIdent::new(
+            Org::new(org).unwrap(),
+            Package::new(pkg).unwrap(),
+            TypeName::new(ty).unwrap(),
+            v,
+        ))
+    }
+
+    fn free(org: &str, pkg: &str, ty: &str) -> ProcessorTypeReference {
+        ProcessorTypeReference::ResolveToInstalled {
+            org: Org::new(org).unwrap(),
+            package: Package::new(pkg).unwrap(),
+            r#type: TypeName::new(ty).unwrap(),
+        }
+    }
+
+    #[test]
+    fn accessors_project_both_variants_to_the_same_triple() {
+        let p = pinned("tatolab", "camera", "Camera", SemVer::new(1, 2, 3));
+        let f = free("tatolab", "camera", "Camera");
+        for r in [&p, &f] {
+            assert_eq!(r.org().as_str(), "tatolab");
+            assert_eq!(r.package().as_str(), "camera");
+            assert_eq!(r.r#type().as_str(), "Camera");
+        }
+    }
+
+    #[test]
+    fn from_schema_ident_is_version_pinned() {
+        let ident = SchemaIdent::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("camera").unwrap(),
+            TypeName::new("Camera").unwrap(),
+            SemVer::new(4, 5, 6),
+        );
+        let r: ProcessorTypeReference = ident.clone().into();
+        assert_eq!(r.as_version_pinned(), Some(&ident));
+    }
+
+    #[test]
+    fn diagnostic_ident_uses_zero_version_for_version_free() {
+        assert_eq!(
+            free("tatolab", "camera", "Camera")
+                .to_diagnostic_ident()
+                .version,
+            SemVer::new(0, 0, 0)
+        );
+        // The pinned form keeps its real version in diagnostics.
+        assert_eq!(
+            pinned("tatolab", "camera", "Camera", SemVer::new(7, 0, 0))
+                .to_diagnostic_ident()
+                .version,
+            SemVer::new(7, 0, 0)
+        );
+    }
+
+    #[test]
+    fn version_pinned_serializes_byte_identically_to_bare_schema_ident() {
+        // Wire-compat lock: the untagged newtype variant must serialize
+        // exactly as the inner SchemaIdent — a four-key object — so existing
+        // engine-free plugins that send version-pinned specs are unaffected.
+        let ident = SchemaIdent::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("core").unwrap(),
+            TypeName::new("VideoFrame").unwrap(),
+            SemVer::new(1, 0, 0),
+        );
+        let via_ref = serde_json::to_value(ProcessorTypeReference::from(ident.clone())).unwrap();
+        let via_ident = serde_json::to_value(&ident).unwrap();
+        assert_eq!(via_ref, via_ident);
+        assert!(via_ref.is_object());
+        assert_eq!(via_ref["version"], "1.0.0");
+    }
+
+    #[test]
+    fn version_free_serializes_as_three_key_object_without_version() {
+        let value = serde_json::to_value(free("tatolab", "camera", "Camera")).unwrap();
+        assert!(value.is_object());
+        assert_eq!(value["org"], "tatolab");
+        assert_eq!(value["package"], "camera");
+        assert_eq!(value["type"], "Camera");
+        assert!(
+            value.get("version").is_none(),
+            "the version-free form must not carry a version key"
+        );
+    }
+
+    #[test]
+    fn untagged_round_trip_preserves_each_variant() {
+        for (label, r) in [
+            (
+                "pinned",
+                pinned("tatolab", "camera", "Camera", SemVer::new(2, 1, 0)),
+            ),
+            ("free", free("tatolab", "camera", "Camera")),
+        ] {
+            // JSON
+            let json = serde_json::to_string(&r).unwrap();
+            let back: ProcessorTypeReference = serde_json::from_str(&json).unwrap();
+            assert_eq!(r, back, "{label} lost equality over JSON");
+            // msgpack (the plugin-ABI wire) — untagged relies on the
+            // self-describing map, which msgpack is.
+            let bytes = rmp_serde::to_vec_named(&r).unwrap();
+            let back: ProcessorTypeReference = rmp_serde::from_slice(&bytes).unwrap();
+            assert_eq!(r, back, "{label} lost equality over msgpack");
+        }
+    }
+
+    #[test]
+    fn four_key_input_deserializes_as_version_pinned_not_version_free() {
+        // A wire object carrying `version` must resolve to VersionPinned —
+        // the ordering guarantee that keeps the version-pinned wire stable.
+        let json = r#"{"org":"tatolab","package":"camera","type":"Camera","version":"3.0.0"}"#;
+        let r: ProcessorTypeReference = serde_json::from_str(json).unwrap();
+        assert!(
+            matches!(r, ProcessorTypeReference::VersionPinned(_)),
+            "a four-key object must deserialize as VersionPinned, got {r:?}"
+        );
+    }
+}

--- a/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/libs/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -705,14 +705,14 @@ impl Runner {
 /// Build the recoverable [`Error::LazyModuleLoadFailed`] for a discovered
 /// package that failed to load, naming the type and its providing package.
 fn lazy_module_load_failed(
-    processor_type: &crate::core::descriptors::SchemaIdent,
+    processor_type: &crate::core::processors::ProcessorTypeReference,
     error: AddModuleError,
 ) -> crate::core::error::Error {
     crate::core::error::Error::LazyModuleLoadFailed {
-        processor_type: processor_type.clone(),
+        processor_type: processor_type.to_diagnostic_ident(),
         package: streamlib_idents::PackageRef::new(
-            processor_type.org.clone(),
-            processor_type.package.clone(),
+            processor_type.org().clone(),
+            processor_type.package().clone(),
         ),
         detail: error.to_string(),
     }
@@ -748,21 +748,39 @@ impl Runner {
     /// declares it). An ambiguous discovery is a typed `Err`.
     fn begin_lazy_provider_load(
         &self,
-        processor_type: &crate::core::descriptors::SchemaIdent,
+        processor_type: &crate::core::processors::ProcessorTypeReference,
     ) -> std::result::Result<Option<AddedModule>, crate::core::error::Error> {
-        if crate::core::processors::PROCESSOR_REGISTRY
-            .port_info(processor_type)
-            .is_some()
-        {
+        use crate::core::processors::{PROCESSOR_REGISTRY, ProcessorTypeReference};
+        // Fast path: already registered? A version-pinned reference checks the
+        // exact ident (unchanged #1325 behavior); a version-free reference
+        // checks the installed `(org, package, type)` tuple.
+        let already_registered = match processor_type {
+            ProcessorTypeReference::VersionPinned(ident) => {
+                PROCESSOR_REGISTRY.port_info(ident).is_some()
+            }
+            ProcessorTypeReference::ResolveToInstalled {
+                org,
+                package,
+                r#type,
+            } => PROCESSOR_REGISTRY
+                .resolve_installed_processor_type(org, package, r#type)
+                .is_some(),
+        };
+        if already_registered {
             return Ok(None);
         }
         let Some(app_modules_root) = source::app_modules_root() else {
             return Ok(None);
         };
-        match lazy_discovery::resolve_providing_module(&app_modules_root, processor_type)? {
-            Some(module_ident) => {
-                Ok(Some(self.add_module_with(module_ident, Strategy::InstalledCache)))
-            }
+        // Discovery ignores the reference-site version and matches on
+        // `(org, package, type)`; it takes a concrete `SchemaIdent` only for
+        // its diagnostics, so a version-free reference projects to
+        // `(org, package, type)@0.0.0`.
+        let discovery_ident = processor_type.to_diagnostic_ident();
+        match lazy_discovery::resolve_providing_module(&app_modules_root, &discovery_ident)? {
+            Some(module_ident) => Ok(Some(
+                self.add_module_with(module_ident, Strategy::InstalledCache),
+            )),
             None => Ok(None),
         }
     }
@@ -777,7 +795,7 @@ impl Runner {
     #[tracing::instrument(skip(self), fields(processor_type = %processor_type))]
     pub(crate) async fn lazily_load_provider_for_processor_type(
         &self,
-        processor_type: &crate::core::descriptors::SchemaIdent,
+        processor_type: &crate::core::processors::ProcessorTypeReference,
     ) -> Option<crate::core::error::Error> {
         match self.begin_lazy_provider_load(processor_type) {
             Ok(Some(added)) => match added.await {
@@ -794,7 +812,7 @@ impl Runner {
     /// where the load future cannot be `.await`ed inline.
     pub(crate) fn lazily_load_provider_for_processor_type_blocking(
         &self,
-        processor_type: &crate::core::descriptors::SchemaIdent,
+        processor_type: &crate::core::processors::ProcessorTypeReference,
     ) -> Option<crate::core::error::Error> {
         let added = match self.begin_lazy_provider_load(processor_type) {
             Ok(Some(added)) => added,
@@ -850,13 +868,15 @@ mod lazy_load_error_tests {
             streamlib_idents::TypeName::new("Camera").unwrap(),
             streamlib_idents::SemVer::new(1, 0, 0),
         );
+        let type_ref =
+            crate::core::processors::ProcessorTypeReference::from(processor_type.clone());
         let underlying = AddModuleError::ModuleNotFound {
             package: streamlib_idents::PackageRef::new(
                 streamlib_idents::Org::new("tatolab").unwrap(),
                 streamlib_idents::Package::new("camera").unwrap(),
             ),
         };
-        match lazy_module_load_failed(&processor_type, underlying) {
+        match lazy_module_load_failed(&type_ref, underlying) {
             crate::core::error::Error::LazyModuleLoadFailed {
                 processor_type: reported_type,
                 package,
@@ -865,6 +885,39 @@ mod lazy_load_error_tests {
                 assert_eq!(reported_type, processor_type);
                 assert_eq!(package.to_string(), "@tatolab/camera");
                 assert!(!detail.is_empty(), "the underlying reason must be carried");
+            }
+            other => panic!("expected LazyModuleLoadFailed, got {other:?}"),
+        }
+    }
+
+    /// A version-free reference still derives the providing package `@org/name`
+    /// from the reference's org + package, with the diagnostic type rendered at
+    /// the `0.0.0` version-free placeholder.
+    #[test]
+    fn lazy_module_load_failed_projects_version_free_reference() {
+        let type_ref = crate::core::processors::ProcessorTypeReference::ResolveToInstalled {
+            org: streamlib_idents::Org::new("tatolab").unwrap(),
+            package: streamlib_idents::Package::new("camera").unwrap(),
+            r#type: streamlib_idents::TypeName::new("Camera").unwrap(),
+        };
+        let underlying = AddModuleError::ModuleNotFound {
+            package: streamlib_idents::PackageRef::new(
+                streamlib_idents::Org::new("tatolab").unwrap(),
+                streamlib_idents::Package::new("camera").unwrap(),
+            ),
+        };
+        match lazy_module_load_failed(&type_ref, underlying) {
+            crate::core::error::Error::LazyModuleLoadFailed {
+                processor_type: reported_type,
+                package,
+                ..
+            } => {
+                assert_eq!(package.to_string(), "@tatolab/camera");
+                assert_eq!(reported_type.r#type.as_str(), "Camera");
+                assert_eq!(
+                    reported_type.version,
+                    streamlib_idents::SemVer::new(0, 0, 0)
+                );
             }
             other => panic!("expected LazyModuleLoadFailed, got {other:?}"),
         }

--- a/libs/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -52,9 +52,10 @@ async fn add_processor_impl(
         );
     };
 
-    // Hold the ident so we can surface a typed `UnknownProcessorType` error
-    // if the registry doesn't know this type — `spec` is moved into `add_v`.
-    let ident_for_err = spec.name.clone();
+    // Hold a diagnostic ident so we can surface a typed `UnknownProcessorType`
+    // error if the registry doesn't know this type — `spec` is moved into
+    // `add_v`. A version-free reference projects to `(org, package, type)@0.0.0`.
+    let ident_for_err = spec.name.to_diagnostic_ident();
 
     let processor_id = compiler.scope(|graph, tx| -> Result<ProcessorUniqueId> {
         let node_id = graph

--- a/libs/streamlib-engine/src/lib.rs
+++ b/libs/streamlib-engine/src/lib.rs
@@ -58,7 +58,8 @@ pub mod schemas {
 // - #[derive(ConfigDescriptor)] - Config field metadata derive macro
 pub use streamlib_macros::{
     ConfigDescriptor, module_ident, module_ident_any_version, module_ident_joined,
-    module_ident_joined_any_version, processor, schema_ident, schema_ident_any_version,
+    module_ident_joined_any_version, processor, processor_type_ref, schema_ident,
+    schema_ident_any_version,
 };
 
 pub use core::{
@@ -263,7 +264,8 @@ pub mod sdk {
 
     pub use streamlib_macros::{
         ConfigDescriptor, module_ident, module_ident_any_version, module_ident_joined,
-        module_ident_joined_any_version, processor, schema_ident, schema_ident_any_version,
+        module_ident_joined_any_version, processor, processor_type_ref, schema_ident,
+        schema_ident_any_version,
     };
 
     pub mod permissions {

--- a/libs/streamlib-engine/tests/load_project_dylib_version_free_ref.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_version_free_ref.rs
@@ -1,0 +1,212 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Version-free processor-reference integration test: reference a processor by
+//! `@org/package/Type` with **no version anywhere in the app code** and have
+//! the installed provider from `streamlib_modules/` lazily load, resolve, and
+//! run through its vtable lifecycle.
+//!
+//! The only reference form in this "app" is
+//! `processor_type_ref!("org", "package", "Type")` — grep this file for a
+//! version string and you will find none in the pipeline code.
+//!
+//! This lives in its own test binary (separate process) on purpose: the
+//! processor registry and the retained dlopen'd plugin images are
+//! process-global, so a sibling test that already loaded `@tatolab/test-fixtures`
+//! would defeat the "exactly one cold load" assertion. A fresh process gives a
+//! deterministic cold load.
+
+use std::path::Path;
+
+use serial_test::serial;
+use streamlib::sdk::error::Error;
+use streamlib::sdk::processors::{PROCESSOR_REGISTRY, ProcessorInstance, ProcessorSpec};
+use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::{RunnerAutoBuild, processor_type_ref};
+use streamlib_engine::core::graph::ProcessorNode;
+use streamlib_engine::core::runtime::{host_target_triple, loaded_plugin_library_count};
+
+fn copy_dir_contents(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dst_entry = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_contents(&entry.path(), &dst_entry);
+        } else {
+            std::fs::copy(entry.path(), &dst_entry).unwrap();
+        }
+    }
+}
+
+/// Clears the process-wide app-modules override on drop, so a panicking test
+/// can't leak a stale (deleted-tempdir) root into a later one.
+struct AppModulesDirGuard;
+impl Drop for AppModulesDirGuard {
+    fn drop(&mut self) {
+        Runner::clear_app_modules_dir();
+    }
+}
+
+/// Stage `packages/test-fixtures` (prebuilt cdylib) + its `@tatolab/core` dep
+/// into `<app_root>/streamlib_modules/@tatolab/{test-fixtures,core}`. The
+/// `patch: path: ../core` in test-fixtures' manifest resolves `@tatolab/core`
+/// to the sibling slot, which is exactly where core lands.
+fn stage_app_modules(app_root: &Path) {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    // Build test-fixtures so the cdylib carries `STREAMLIB_PLUGIN`. Idempotent
+    // — cargo's incremental machinery skips on a warm tree.
+    let status = std::process::Command::new(env!("CARGO"))
+        .args(["build", "-p", "streamlib-test-fixtures"])
+        .status()
+        .expect("invoking cargo build");
+    assert!(
+        status.success(),
+        "cargo build -p streamlib-test-fixtures must succeed"
+    );
+
+    let dylib_ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else if cfg!(target_os = "windows") {
+        "dll"
+    } else {
+        "so"
+    };
+    let dylib_name = format!("libstreamlib_test_fixtures.{}", dylib_ext);
+    let built_dylib = workspace_root
+        .join("target")
+        .join("debug")
+        .join(&dylib_name);
+    assert!(
+        built_dylib.exists(),
+        "cdylib expected at {} after cargo build",
+        built_dylib.display()
+    );
+
+    let modules_dir = app_root.join("streamlib_modules");
+    let fixtures_src = workspace_root.join("packages/test-fixtures");
+    let core_src = workspace_root.join("packages/core");
+    let fixtures_dst = modules_dir.join("@tatolab").join("test-fixtures");
+    let core_dst = modules_dir.join("@tatolab").join("core");
+
+    std::fs::create_dir_all(&fixtures_dst).unwrap();
+    std::fs::copy(
+        fixtures_src.join("streamlib.yaml"),
+        fixtures_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&fixtures_src.join("schemas"), &fixtures_dst.join("schemas"));
+
+    std::fs::create_dir_all(&core_dst).unwrap();
+    std::fs::copy(
+        core_src.join("streamlib.yaml"),
+        core_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&core_src.join("schemas"), &core_dst.join("schemas"));
+
+    // Stage the prebuilt cdylib under `lib/<host-triple>/` — the layout
+    // `Strategy::InstalledCache` prefers (compiler-free load, no orchestrator
+    // build needed).
+    let triple_dir = fixtures_dst.join("lib").join(host_target_triple());
+    std::fs::create_dir_all(&triple_dir).unwrap();
+    std::fs::copy(&built_dylib, triple_dir.join(&dylib_name)).unwrap();
+}
+
+#[test]
+#[serial]
+fn add_processor_lazily_loads_plugin_via_version_free_reference() {
+    // The headline goal: reference a processor with NO version at the reference
+    // site and have the installed provider lazily load + resolve + run. The
+    // pipeline code below carries no version string — only
+    // `processor_type_ref!("org", "package", "Type")`.
+    let app = tempfile::tempdir().unwrap();
+    stage_app_modules(app.path());
+
+    let _guard = AppModulesDirGuard;
+    Runner::set_app_modules_dir(app.path());
+    let runtime = Runner::with_auto_build().unwrap();
+
+    // (1) A version-free reference lazily discovers + loads the provider. This
+    // process is fresh, so the load is genuinely cold: exactly one dlopen.
+    let libraries_before = loaded_plugin_library_count();
+    runtime
+        .add_processor(ProcessorSpec::new(
+            processor_type_ref!("tatolab", "test-fixtures", "TestConfiguredProcessor"),
+            serde_json::json!({}),
+        ))
+        .expect("a version-free reference must lazily load @tatolab/test-fixtures and resolve");
+
+    let registered = PROCESSOR_REGISTRY
+        .list_registered()
+        .into_iter()
+        .any(|desc| desc.name.r#type.as_str() == "TestConfiguredProcessor");
+    assert!(
+        registered,
+        "TestConfiguredProcessor must be registered after the version-free lazy load"
+    );
+    let libraries_after_first = loaded_plugin_library_count();
+    assert_eq!(
+        libraries_after_first,
+        libraries_before + 1,
+        "the version-free reference must dlopen the provider exactly once"
+    );
+
+    // (2) A second version-free reference to the now-loaded type must NOT
+    // reload the plugin — the installed-tuple fast path short-circuits.
+    runtime
+        .add_processor(ProcessorSpec::new(
+            processor_type_ref!("tatolab", "test-fixtures", "TestConfiguredProcessor"),
+            serde_json::json!({}),
+        ))
+        .expect("a second version-free reference to an already-loaded type must succeed");
+    assert_eq!(
+        loaded_plugin_library_count(),
+        libraries_after_first,
+        "a repeat version-free reference must NOT reload the plugin"
+    );
+
+    // (3) A version-free reference to an absent type returns the recoverable
+    // typed error, and the runtime keeps operating.
+    let absent = runtime.add_processor(ProcessorSpec::new(
+        processor_type_ref!("tatolab", "definitely-not-installed", "Ghost"),
+        serde_json::json!({}),
+    ));
+    assert!(
+        matches!(absent, Err(Error::UnknownProcessorType { .. })),
+        "an absent version-free type must return a typed recoverable error, got {absent:?}"
+    );
+    // Runtime keeps operating: a subsequent valid version-free add succeeds.
+    runtime
+        .add_processor(ProcessorSpec::new(
+            processor_type_ref!("tatolab", "test-fixtures", "TestConfiguredProcessor"),
+            serde_json::json!({}),
+        ))
+        .expect("the runtime must keep operating after a failed version-free add_processor");
+
+    // (4) Lifecycle smoke: the lazily-loaded cdylib constructs through its
+    // vtable and destroys cleanly — resolved via the version-free path.
+    let descriptor = PROCESSOR_REGISTRY
+        .list_registered()
+        .into_iter()
+        .find(|d| d.name.r#type.as_str() == "TestConfiguredProcessor")
+        .expect("TestConfiguredProcessor descriptor must be present");
+    let node = ProcessorNode::new(
+        descriptor.name.clone(),
+        "TestConfiguredProcessor",
+        None,
+        Vec::new(),
+        Vec::new(),
+    );
+    let instance = PROCESSOR_REGISTRY
+        .create(&node)
+        .expect("factory.create() must construct the version-free lazily-loaded processor");
+    assert!(matches!(instance, ProcessorInstance::VTable { .. }));
+    drop(instance);
+    // `_guard` clears the process-wide override on drop.
+}

--- a/libs/streamlib-macros/src/codegen.rs
+++ b/libs/streamlib-macros/src/codegen.rs
@@ -641,12 +641,15 @@ fn generate_processor_impl_from_schema(
             /// Create a [`ProcessorSpec`](__streamlib_sdk::processors::ProcessorSpec)
             /// for adding this processor to a runtime.
             pub fn node(config: #config_type) -> __streamlib_sdk::processors::ProcessorSpec {
-                __streamlib_sdk::processors::ProcessorSpec {
-                    name: Self::schema_ident(),
-                    config: __streamlib_sdk::serde_json::to_value(&config)
+                // Version-pinned reference to this processor's own compiled-in
+                // version. `ProcessorSpec::new` takes the SchemaIdent directly
+                // on the engine-free SDK and via `From<SchemaIdent>` on the
+                // engine SDK (where `name` is a `ProcessorTypeReference`).
+                __streamlib_sdk::processors::ProcessorSpec::new(
+                    Self::schema_ident(),
+                    __streamlib_sdk::serde_json::to_value(&config)
                         .expect("Config serialization failed"),
-                    display_name: None,
-                }
+                )
             }
 
             /// Returns the execution mode for this processor.

--- a/libs/streamlib-macros/src/lib.rs
+++ b/libs/streamlib-macros/src/lib.rs
@@ -549,6 +549,71 @@ fn expand_schema_ident_any_version(
     })
 }
 
+/// `processor_type_ref!("org", "package", "Type")` — a **version-free**
+/// processor-type reference for the lazy-discovery world (app code that never
+/// calls `add_module`).
+///
+/// Expands to a `ProcessorTypeReference::ResolveToInstalled` value with no
+/// version and **no registry lookup at the call site**, so the reference
+/// reaches `add_processor`'s lazy hook and resolves to the single installed
+/// provider — loading its package from `streamlib_modules/` on first
+/// reference. This is the canonical form for referencing a processor by
+/// `@org/package/Type` with no version.
+///
+/// Distinct from [`schema_ident_any_version!`], which resolves a `SchemaIdent`
+/// *now* against the already-registered processor types (the post-`add_module`
+/// / power-caller form). Reach for `processor_type_ref!` when you want lazy
+/// loading; reach for `schema_ident_any_version!` when the provider is already
+/// registered.
+///
+/// ```ignore
+/// // No version at the reference site, no `?`, no add_module call:
+/// runtime.add_processor(streamlib::sdk::processors::ProcessorSpec::new(
+///     streamlib::sdk::processor_type_ref!("tatolab", "camera", "Camera"),
+///     serde_json::json!({}),
+/// ))?;
+/// ```
+#[proc_macro]
+pub fn processor_type_ref(input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(input as SchemaIdentAnyVersionArgs);
+    match expand_processor_type_ref(&args) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+fn expand_processor_type_ref(
+    args: &SchemaIdentAnyVersionArgs,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let org_str = args.org.value();
+    let package_str = args.package.value();
+    let type_str = args.type_name.value();
+
+    Org::new(&org_str).map_err(|e| {
+        syn::Error::new(args.org.span(), format!("invalid org `{}`: {}", org_str, e))
+    })?;
+    Package::new(&package_str).map_err(|e| {
+        syn::Error::new(
+            args.package.span(),
+            format!("invalid package `{}`: {}", package_str, e),
+        )
+    })?;
+    TypeName::new(&type_str).map_err(|e| {
+        syn::Error::new(
+            args.type_name.span(),
+            format!("invalid type name `{}`: {}", type_str, e),
+        )
+    })?;
+
+    Ok(quote! {
+        ::streamlib::sdk::processors::ProcessorTypeReference::ResolveToInstalled {
+            org: ::streamlib::sdk::descriptors::Org::new(#org_str).expect("validated by macro"),
+            package: ::streamlib::sdk::descriptors::Package::new(#package_str).expect("validated by macro"),
+            r#type: ::streamlib::sdk::descriptors::TypeName::new(#type_str).expect("validated by macro"),
+        }
+    })
+}
+
 struct SchemaIdentArgs {
     org: LitStr,
     package: LitStr,

--- a/libs/streamlib-sdk/src/lib.rs
+++ b/libs/streamlib-sdk/src/lib.rs
@@ -189,11 +189,14 @@ pub mod sdk {
     pub use streamlib_engine::ConfigDescriptor;
 
     /// `streamlib::sdk::schema_ident_any_version!("org", "package", "Type")` —
-    /// **canonical, default form** for naming a processor at a call site.
+    /// resolve a `SchemaIdent` **now** against the **already-registered**
+    /// processor types (the post-`add_module` / power-caller form).
     /// Validates `(org, package, type)` at compile time; resolves the
     /// version at runtime against the global processor registry,
     /// picking the highest registered `SemVer` (Cargo / npm convention).
-    /// Returns `Result<SchemaIdent, streamlib::sdk::error::Error>`.
+    /// Returns `Result<SchemaIdent, streamlib::sdk::error::Error>`. For a
+    /// version-free reference that lazily loads its provider from
+    /// `streamlib_modules/`, use [`processor_type_ref!`] instead.
     pub use streamlib_engine::schema_ident_any_version;
 
     /// `streamlib::sdk::schema_ident!("org", "package", "Type", "1.0.0")` —
@@ -203,6 +206,19 @@ pub mod sdk {
     /// newer-but-compatible registered versions; otherwise prefer
     /// [`schema_ident_any_version!`].
     pub use streamlib_engine::schema_ident;
+
+    /// `streamlib::sdk::processor_type_ref!("org", "package", "Type")` — a
+    /// **version-free** processor-type reference for the lazy-discovery world
+    /// (app code that never calls `add_module`). Validates `(org, package,
+    /// type)` at compile time and expands to a
+    /// [`ProcessorTypeReference::ResolveToInstalled`](processors::ProcessorTypeReference)
+    /// with no version and **no registry lookup at the call site**, so the
+    /// reference reaches `add_processor`'s lazy hook and resolves to the
+    /// single installed provider — loading its package from
+    /// `streamlib_modules/` on first reference. This is the canonical form for
+    /// referencing a processor by `@org/package/Type` with no version; prefer
+    /// it over [`schema_ident_any_version!`] when you want lazy loading.
+    pub use streamlib_engine::processor_type_ref;
 
     /// `streamlib::sdk::module_ident!("org", "name", "^1.0.0")` —
     /// imperative-API module identifier with a pinned semver range.


### PR DESCRIPTION
## What & why

Delivers the headline goal of the lazy-discovery work (#1325): an app can reference a processor by `@org/package/Type` with **no version at the reference site**, and the runtime lazily loads the installed provider from `streamlib_modules/` and resolves it. Post-#1325 the lazy-load mechanism existed but only fired for references carrying the *exact* installed version.

The design was checked in with and approved by the maintainer (resolve-to-installed model; `processor_type_ref!` macro name; leave `schema_ident_any_version!` additive rather than repurposing it).

## The two-part gap, closed

**1. Reference form.** `ProcessorSpec.name` becomes a `ProcessorTypeReference` enum:

```rust
#[serde(untagged)]
pub enum ProcessorTypeReference {
    VersionPinned(SchemaIdent),                              // exact-version (the #1325 path)
    ResolveToInstalled { org, package, r#type },             // version-free
}
```

- New infallible, compile-time-validated macro `processor_type_ref!("org","package","Type")` expands to `ResolveToInstalled` with **no registry lookup at the call site**, so the reference reaches `add_processor`'s lazy hook instead of failing before it. (The old `schema_ident_any_version!` pre-resolves against the registry — it `?`-bails for a not-yet-loaded package.)
- `ProcessorSpec::new` now takes `impl Into<ProcessorTypeReference>` with `From<SchemaIdent>`, so **every existing `ProcessorSpec::new(schema_ident!(...), cfg)` call site compiles unchanged** (203 of them). The only struct-literal construction (`#[processor]` macro's `node()` in `codegen.rs`) was migrated to `::new()`, which stays compatible with the engine-free plugin-sdk `ProcessorSpec` too.

**2. Terminal resolution.** `add_v` resolves the reference to a concrete registered ident before building the node:
- `VersionPinned(id)` → `port_info(id)` version-EXACT (the untouched #1325 path).
- `ResolveToInstalled{…}` → new `ProcessorInstanceFactory::resolve_installed_processor_type(org,package,type)` returns the single installed provider's ident (shares a private tuple-scan helper with `resolve_any_version`), then `port_info`. A version-free reference never loads-then-misses.
- Genuinely-absent type → recoverable `Error::UnknownProcessorType` (diagnostic ident rendered as `(org,package,type)@0.0.0`, the convention `resolve_any_version` already uses).

The lazy hook (`begin_lazy_provider_load` / `lazily_load_provider_for_processor_type[_blocking]`) is now variant-aware: version-pinned checks the exact ident (unchanged), version-free checks the installed tuple. Discovery itself (`lazy_discovery.rs`) is **untouched** — the hook builds a discovery `SchemaIdent` internally.

## Wire compatibility (engine-free plugins / polyglot unaffected)

`#[serde(untagged)]` with `VersionPinned` first ⇒ a version-pinned reference serializes **byte-identically to a bare `SchemaIdent`** (the four-key map). `SchemaIdent.version` is a required field, so a 4-key input deserializes as `VersionPinned` and a 3-key input falls to `ResolveToInstalled` — ordering alone disambiguates (locked by tests in both directions). The engine-free `streamlib-plugin-sdk::ProcessorSpec` mirror is **not touched**; version-free is host-app-only, so no Python/Deno change is required (not a polyglot-labeled issue).

## Proof the version-EXACT (#1325) path still works

The `VersionPinned` branch in `add_v` and the hook is the untouched #1325 code path (version-exact `port_info`). The existing dlopen suite `load_project_dylib_lazy_discovery.rs` (version-exact `schema_ident!` references) stays green — **3/3 pass** including `add_processor_lazily_loads_plugin_from_streamlib_modules_with_no_load_call`, the ambiguous-providers case, and the unbuildable-package case.

## Test evidence

- **Integration (no version anywhere in app code):** new `tests/load_project_dylib_version_free_ref.rs` — in its own test binary (own process ⇒ deterministic cold load) drives a **`processor_type_ref!`** reference through discovery → dlopen (exactly one, `+1` count) → resolve → vtable-lifecycle construct/destroy; asserts a repeat reference does NOT reload; asserts a version-free absent type → `UnknownProcessorType` and the runtime keeps operating. **1/1 pass.**
- **Unit (24 pass):** `resolve_installed_processor_type` returns the installed version and `None` for an absent tuple; `resolve_any_version` still resolves (non-regression); untagged JSON+msgpack round-trips for both variants; a 4-key wire object deserializes as `VersionPinned`; version-free wire has no `version` key; diagnostic-ident projection for both forms (`@…@0.0.0` for version-free); `lazy_module_load_failed` projection for both forms; `ProcessorSpec::new(SchemaIdent)` builds `VersionPinned`, `processor_type_ref` value builds `ResolveToInstalled`.

## Validation gates

- `cargo build --workspace` — green (no registry mirror), all members incl. examples/CLI/adapters.
- `cargo xtask check-boundaries` — 5003 files, no violations. `cargo xtask lint-logging` — 530 files, no violations.
- clippy on touched crates — no new warnings from this change (my new file is clean; the pre-existing workspace-wide `result_large_err` lint fires unchanged).
- Docs: `runtime-module-materialization.md` lazy-discovery section rewritten to the shipped version-free reality (current-tense, no tracker refs), documenting the distinct roles of `processor_type_ref!` (version-free, lazy) vs `schema_ident_any_version!` (resolve-now against already-registered); macro doc-comments show the canonical call-site shape. The published app-guide HTML artifact is a separate follow-up the maintainer owns.
- pr-review-gate: independent Opus review returned **PASS**; one misleading code comment corrected after verification.

## Scope / fence

Stays in the engine runtime type-resolution path + macros + `SchemaIdent`/`ProcessorSpec`. Does **not** touch the registry / `streamlib-pack` / CLI / scripts (the parallel registry-deletion work). The engine-free plugin-sdk `ProcessorSpec` mirror is intentionally untouched (wire back-compat).

Closes #1337

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB
