### PR TITLE
feat(codegen): build.rs discovers the streamlib link marker — retire the STREAMLIB_LINK_CHECKOUT papercut (#1341)

### DIFF
--- a/libs/streamlib-build-orchestrator/src/deno_codegen.rs
+++ b/libs/streamlib-build-orchestrator/src/deno_codegen.rs
@@ -30,10 +30,22 @@ use crate::build_failed;
 
 /// Generate the staged Deno package's `_generated_/` wire vocabulary.
 ///
+/// `link_checkout` is the orchestrator's authoritative active-link checkout
+/// (checkout when linked, `None` on distribution), threaded to codegen so the
+/// package's schema deps resolve from the checkout under a link. It is NOT
+/// re-derived from the marker — `project_dir` here is the relocated staged cache
+/// dir, so a marker walk-up could cross into a stray `.streamlib/link.json` and
+/// redirect a distribution build to a dev checkout (see
+/// [`streamlib_jtd_codegen::generate`]).
+///
 /// No-op (returns `Ok(())`) when the staged package declares no TypeScript
 /// runtime processors.
-#[tracing::instrument(skip(temp_dir), fields(temp_dir = %temp_dir.display(), package = %package_label))]
-pub fn provision_deno_typescript(temp_dir: &Path, package_label: &str) -> Result<(), BuildError> {
+#[tracing::instrument(skip(temp_dir, link_checkout), fields(temp_dir = %temp_dir.display(), package = %package_label))]
+pub fn provision_deno_typescript(
+    temp_dir: &Path,
+    link_checkout: Option<&Path>,
+    package_label: &str,
+) -> Result<(), BuildError> {
     let config = match build::read_minimal_project_config(temp_dir) {
         Ok(Some(config)) => config,
         Ok(None) => return Ok(()),
@@ -78,6 +90,10 @@ pub fn provision_deno_typescript(temp_dir: &Path, package_label: &str) -> Result
         // here is byproduct (the per-package fingerprint is the staleness
         // oracle, not a lockfile).
         write_lockfile: false,
+        // Authoritative link state from the orchestrator (checkout when linked,
+        // `None` on distribution) — never marker-re-derived from this relocated
+        // `temp_dir`.
+        link_checkout: link_checkout.map(|p| p.to_path_buf()),
     })
     .map_err(|e| {
         build_failed(
@@ -147,7 +163,7 @@ mod tests {
             "package:\n  org: tatolab\n  name: schemas-only\n  version: 0.1.0\nschemas:\n  T:\n    file: schemas/t.yaml\n",
         )
         .unwrap();
-        provision_deno_typescript(dir.path(), "schemas-only").unwrap();
+        provision_deno_typescript(dir.path(), None, "schemas-only").unwrap();
         assert!(
             !dir.path().join("_generated_").exists(),
             "non-Deno package must not get a _generated_ directory"
@@ -178,7 +194,7 @@ mod tests {
         .unwrap();
         std::fs::write(dir.path().join("t.ts"), b"export default class {}").unwrap();
 
-        provision_deno_typescript(dir.path(), "ts").unwrap();
+        provision_deno_typescript(dir.path(), None, "ts").unwrap();
 
         let generated = dir.path().join("_generated_");
         assert!(generated.is_dir(), "_generated_ must be created");

--- a/libs/streamlib-build-orchestrator/src/lib.rs
+++ b/libs/streamlib-build-orchestrator/src/lib.rs
@@ -327,6 +327,7 @@ impl PolyglotBuildOrchestrator {
         python_venv::provision_python_venv(
             &temp_dir,
             active_link.as_ref().map(|l| l.python_sdk_path.as_path()),
+            active_link.as_ref().map(|l| l.checkout.as_path()),
             &pkg_label,
         )
         .map_err(|e| {
@@ -339,7 +340,12 @@ impl PolyglotBuildOrchestrator {
         // bundled source as a per-consumer artifact, so it must be rebuilt
         // here — the Deno mirror of the Python venv codegen above. Building
         // into `temp_dir` lets the atomic rename below carry it into place.
-        deno_codegen::provision_deno_typescript(&temp_dir, &pkg_label).map_err(|e| {
+        deno_codegen::provision_deno_typescript(
+            &temp_dir,
+            active_link.as_ref().map(|l| l.checkout.as_path()),
+            &pkg_label,
+        )
+        .map_err(|e| {
             let _ = std::fs::remove_dir_all(&temp_dir);
             e
         })?;
@@ -971,6 +977,7 @@ mod tests {
             schema_dir: None,
             workspace_root: streamlib_dir.clone(),
             write_lockfile: false,
+            link_checkout: None,
         })
         .expect("standalone codegen must succeed against the same installed manifest");
 
@@ -1023,6 +1030,121 @@ mod tests {
             discover_active_build_link_from(dir.path(), "tatolab/x")
                 .unwrap()
                 .is_none()
+        );
+    }
+
+    /// The orchestrator's in-process `generate()` codegen (the venv +
+    /// deno_codegen paths) is LINK-AUTHORITATIVE: it resolves the checkout from
+    /// the caller-supplied `link_checkout`, NEVER by walking up from
+    /// `project_dir` to a marker. This is the polyglot mirror of the Rust
+    /// suppression boundary — a relocated venv/deno codegen runs in the
+    /// orchestrator's own process (so the child-env sentinel that guards the
+    /// Rust `build.rs` can't reach it), and `project_dir` sits under the staged
+    /// cache whose `.streamlib` dir name collides with the link-state dir, so an
+    /// unconditional marker walk-up would redirect a distribution build to a dev
+    /// checkout.
+    ///
+    /// Setup: a stray `.streamlib/link.json` marker sits UP-TREE of
+    /// `project_dir`, pointing at a checkout that provides `@tatolab/core`; no
+    /// registry is configured. Case A (`link_checkout = None`, the distribution /
+    /// non-linked build) must NOT redirect — with no registry the bare range is
+    /// unresolvable, so `generate` errors. Mentally-revert the explicit-link
+    /// threading (fall back to `from_env_or_marker(&project_dir)` inside
+    /// `generate`) and Case A resolves `@tatolab/core` from the marker's checkout
+    /// and SUCCEEDS — failing the `is_err()` assertion. Case B
+    /// (`link_checkout = Some(checkout)`) must keep resolving from the checkout so
+    /// the linked polyglot path is not regressed.
+    #[test]
+    #[serial]
+    fn generate_is_link_authoritative_not_marker_discovered() {
+        // A checkout providing @tatolab/core. Schema-less: it resolves cleanly,
+        // and the schema-less project below yields an empty codegen task set, so
+        // the whole test is independent of the external jtd-codegen binary.
+        let checkout = tempfile::tempdir().unwrap();
+        let core = checkout.path().join("packages").join("core");
+        std::fs::create_dir_all(&core).unwrap();
+        std::fs::write(
+            core.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: core\n  version: 1.0.0\n",
+        )
+        .unwrap();
+
+        // Consumer root carrying a stray link marker UP-TREE of the project dir.
+        let consumer = tempfile::tempdir().unwrap();
+        write_link_marker(consumer.path(), checkout.path(), false);
+        let project_dir = consumer.path().join("app").join("proj");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(
+            project_dir.join("streamlib.yaml"),
+            "dependencies:\n  \"@tatolab/core\": \"^1.0.0\"\n",
+        )
+        .unwrap();
+
+        // Precondition: the marker IS discoverable up-tree, so a redirect (if the
+        // code walked up) would resolve @tatolab/core from the checkout — this is
+        // what makes Case A's Err prove suppression, not mere absence.
+        assert!(
+            streamlib_idents::link_marker::find_active_link_marker(&project_dir).is_some(),
+            "test setup: a stray marker must be discoverable up-tree of project_dir"
+        );
+
+        let out = tempfile::tempdir().unwrap();
+
+        // Control the env: no registry (so a non-link resolve of the bare range
+        // fails loud) and no ambient link env. SAFETY: `#[serial]` serializes the
+        // env-mutating tests.
+        let prev_registry = std::env::var_os("STREAMLIB_REGISTRY_URL");
+        let prev_link = std::env::var_os(streamlib_idents::LINK_CHECKOUT_ENV);
+        unsafe {
+            std::env::remove_var("STREAMLIB_REGISTRY_URL");
+            std::env::remove_var(streamlib_idents::LINK_CHECKOUT_ENV);
+        }
+
+        // Case A — authoritative NO link (distribution / non-linked build).
+        let no_link = streamlib_jtd_codegen::generate(streamlib_jtd_codegen::GenerateOptions {
+            runtime: streamlib_jtd_codegen::RuntimeTarget::Rust,
+            output: out.path().join("no_link"),
+            project_dir: Some(project_dir.clone()),
+            schema_file: None,
+            schema_dir: None,
+            workspace_root: project_dir.clone(),
+            write_lockfile: false,
+            link_checkout: None,
+        });
+
+        // Case B — authoritative link ACTIVE (the caller supplies the checkout).
+        let with_link = streamlib_jtd_codegen::generate(streamlib_jtd_codegen::GenerateOptions {
+            runtime: streamlib_jtd_codegen::RuntimeTarget::Rust,
+            output: out.path().join("with_link"),
+            project_dir: Some(project_dir.clone()),
+            schema_file: None,
+            schema_dir: None,
+            workspace_root: project_dir,
+            write_lockfile: false,
+            link_checkout: Some(checkout.path().to_path_buf()),
+        });
+
+        unsafe {
+            match prev_registry {
+                Some(v) => std::env::set_var("STREAMLIB_REGISTRY_URL", v),
+                None => std::env::remove_var("STREAMLIB_REGISTRY_URL"),
+            }
+            match prev_link {
+                Some(v) => std::env::set_var(streamlib_idents::LINK_CHECKOUT_ENV, v),
+                None => std::env::remove_var(streamlib_idents::LINK_CHECKOUT_ENV),
+            }
+        }
+
+        assert!(
+            no_link.is_err(),
+            "link_checkout=None must NOT resolve @tatolab/core from a stray up-tree \
+             marker (no registry ⇒ unresolvable). Reverting to marker discovery makes \
+             this Ok and reintroduces the distribution→dev-checkout redirect."
+        );
+        assert!(
+            with_link.is_ok(),
+            "link_checkout=Some(checkout) must resolve @tatolab/core from the checkout — \
+             the linked polyglot path must not regress: {with_link:?}"
         );
     }
 

--- a/libs/streamlib-build-orchestrator/src/python_venv.rs
+++ b/libs/streamlib-build-orchestrator/src/python_venv.rs
@@ -39,11 +39,19 @@ use streamlib_engine::core::runtime::BuildError;
 /// resolves the SDK from the checkout instead of the registry — the cargo
 /// `[patch]` mirror on the Python side. `None` ⇒ registry resolution.
 ///
+/// `link_checkout` is that same active-link checkout root, threaded to the
+/// in-venv `_generated_` codegen so the SDK's schema deps resolve from the
+/// checkout under a link. It is the orchestrator's authoritative link state,
+/// NOT re-derived from the marker — a relocated venv codegen must not walk up
+/// out of the staged cache into a stray marker (see
+/// [`streamlib_jtd_codegen::generate`]). `None` ⇒ registry resolution.
+///
 /// No-op (returns `Ok(())`) when the staged package has no Python runtime.
-#[tracing::instrument(skip(temp_dir, link_python_sdk), fields(temp_dir = %temp_dir.display(), package = %package_label))]
+#[tracing::instrument(skip(temp_dir, link_python_sdk, link_checkout), fields(temp_dir = %temp_dir.display(), package = %package_label))]
 pub fn provision_python_venv(
     temp_dir: &Path,
     link_python_sdk: Option<&Path>,
+    link_checkout: Option<&Path>,
     package_label: &str,
 ) -> Result<(), BuildError> {
     if !staged_package_has_python(temp_dir) {
@@ -138,7 +146,7 @@ pub fn provision_python_venv(
     }
 
     // ---- codegen: populate streamlib/_generated_ in the venv ----
-    ensure_streamlib_generated_in_venv(&venv_python, package_label)?;
+    ensure_streamlib_generated_in_venv(&venv_python, link_checkout, package_label)?;
 
     // ---- compileall: pre-warm .pyc ----
     precompile_venv(&venv_python, &venv_dir, package_label)?;
@@ -168,6 +176,7 @@ pub(crate) fn staged_package_has_python(temp_dir: &Path) -> bool {
 /// dependency.
 fn ensure_streamlib_generated_in_venv(
     venv_python: &Path,
+    link_checkout: Option<&Path>,
     package_label: &str,
 ) -> Result<(), BuildError> {
     let probe = Command::new(venv_python)
@@ -235,6 +244,10 @@ fn ensure_streamlib_generated_in_venv(
         schema_dir: None,
         workspace_root: streamlib_dir,
         write_lockfile: false,
+        // Authoritative link state from the orchestrator (checkout when linked,
+        // `None` on distribution) — never marker-re-derived from this relocated
+        // venv dir.
+        link_checkout: link_checkout.map(|p| p.to_path_buf()),
     })
     .map_err(|e| {
         build_failed(
@@ -520,7 +533,8 @@ packages = ["python"]
         // schemas-only or Rust-only package.
         let temp = tempfile::tempdir().unwrap();
         std::fs::write(temp.path().join("streamlib.yaml"), "package:\n  name: x\n").unwrap();
-        provision_python_venv(temp.path(), None, "tatolab/x").expect("no-python must be a no-op");
+        provision_python_venv(temp.path(), None, None, "tatolab/x")
+            .expect("no-python must be a no-op");
         assert!(
             !temp.path().join(".venv").exists(),
             "no venv must be created for a non-Python staged package"
@@ -546,7 +560,7 @@ packages = ["python"]
         let temp = tempfile::tempdir().unwrap();
         write_staged_python_package(temp.path(), &sdk);
 
-        provision_python_venv(temp.path(), None, "tatolab/mypkg")
+        provision_python_venv(temp.path(), None, None, "tatolab/mypkg")
             .expect("provision must succeed offline against the fixture SDK");
 
         // Contract: interpreter at exactly {temp_dir}/.venv/bin/python.
@@ -660,7 +674,7 @@ packages = ["python"]
         )
         .unwrap();
 
-        provision_python_venv(staged.path(), Some(&sdk), "tatolab/mypkg")
+        provision_python_venv(staged.path(), Some(&sdk), None, "tatolab/mypkg")
             .expect("provision must succeed against the linked fixture SDK");
 
         // The staged pyproject got the override injected…

--- a/libs/streamlib-cargo-build/src/lib.rs
+++ b/libs/streamlib-cargo-build/src/lib.rs
@@ -239,6 +239,17 @@ pub fn run_cargo_build(
     if matches!(profile, CargoProfile::Release) {
         command.arg("--release");
     }
+    // Suppress `streamlib link` marker discovery for this build. Every caller
+    // builds a relocated, link-unaware artifact (the native FFI host from an
+    // extracted registry `.crate`), so its `build.rs` schema-dep codegen must
+    // never redirect to a dev checkout. Setting the env to empty is the
+    // suppression sentinel `ResolverOptions::from_env_or_marker` honors: env
+    // present ⇒ authoritative, empty ⇒ no marker walk-up. Scoped to this child
+    // command (mirroring `streamlib_pack::cargo_build_streaming`), so it is
+    // safe under the orchestrator's concurrent materialization — unlike a
+    // process-global `set_var`. Harmless today (these cdylibs carry no
+    // jtd-codegen `build.rs`); it closes the footgun if one is ever added.
+    command.env(streamlib_idents::LINK_CHECKOUT_ENV, "");
     let output = command
         .arg("--message-format=json")
         .arg("-p")

--- a/libs/streamlib-cli/src/commands/generate.rs
+++ b/libs/streamlib-cli/src/commands/generate.rs
@@ -21,6 +21,15 @@ pub fn run(
     schema_file: Option<PathBuf>,
     schema_dir: Option<PathBuf>,
 ) -> Result<()> {
+    // The user-facing `streamlib generate` resolves the active `streamlib link`
+    // checkout MARKER-FIRST from the project dir (with STREAMLIB_LINK_CHECKOUT as
+    // an override) — a dev running `streamlib generate` in their linked app dir
+    // picks up the link with no env exported. (The build orchestrator's
+    // in-process codegen supplies its own authoritative link state instead of
+    // marker discovery; see `streamlib_jtd_codegen::generate`.)
+    let link_checkout = project_dir
+        .as_deref()
+        .and_then(|dir| streamlib_idents::ResolverOptions::from_env_or_marker(dir).link_checkout);
     generate(GenerateOptions {
         runtime,
         output,
@@ -29,6 +38,7 @@ pub fn run(
         schema_dir,
         workspace_root: workspace_root()?,
         write_lockfile: true,
+        link_checkout,
     })
 }
 

--- a/libs/streamlib-idents/src/resolver.rs
+++ b/libs/streamlib-idents/src/resolver.rs
@@ -139,10 +139,16 @@ pub struct ResolverOptions {
     /// redirect, completing the zero-registry dev loop. `None` (the dominant
     /// case) leaves resolution byte-identical to a non-linked build: absent
     /// packages, and every dep when no link is active, resolve by version from
-    /// the store / registry (or via a dev path patch). Populated from
-    /// [`crate::LINK_CHECKOUT_ENV`] by [`ResolverOptions::from_env`]; locked
-    /// runs never set it (the orchestrator withholds it), preserving
-    /// reproducibility.
+    /// the store / registry (or via a dev path patch). Populated at the
+    /// compile-time codegen boundary by [`ResolverOptions::from_env_or_marker`]
+    /// — **marker-first** (the `.streamlib/link.json` a `streamlib link` wrote,
+    /// discovered by walking up from the crate dir) with
+    /// [`crate::LINK_CHECKOUT_ENV`] as an explicit override. A locked run or an
+    /// orchestrator-driven distribution build stays `None`: locked runs never
+    /// build (so no codegen boundary runs), and the orchestrator sets the env
+    /// to empty to suppress marker discovery for a relocated build, preserving
+    /// reproducibility. [`resolve_with`] reads this field only; it never
+    /// consults the marker or the environment.
     pub link_checkout: Option<PathBuf>,
 }
 
@@ -160,18 +166,109 @@ impl ResolverOptions {
             link_checkout: link_checkout_from_env(),
         }
     }
+
+    /// The compile-time codegen-boundary constructor: like [`from_env`], but
+    /// resolves the active `streamlib link` checkout **marker-first** — walking
+    /// up from `manifest_dir` for the `.streamlib/link.json` a `streamlib link`
+    /// wrote — with [`crate::LINK_CHECKOUT_ENV`] as an explicit override. Build
+    /// scripts, the `#[processor]` macro, and `streamlib generate` use this so a
+    /// directly-`cargo build`-ed linked app resolves its schema deps from the
+    /// checkout with no env var to export by hand.
+    ///
+    /// Env precedence over the marker is what preserves the load-bearing
+    /// suppression boundary: the build orchestrator sets the env for every
+    /// relocated build (the checkout path when a link is active, empty to
+    /// suppress otherwise), so a distribution / locked-materialization build
+    /// never re-derives link state from a stray marker up-tree of the
+    /// relocated crate dir. Unit tests construct [`ResolverOptions`] directly to
+    /// stay hermetic.
+    ///
+    /// [`from_env`]: ResolverOptions::from_env
+    pub fn from_env_or_marker(manifest_dir: &Path) -> Self {
+        Self {
+            cache_dir: None,
+            registry: RegistryConfig::from_env(),
+            link_checkout: link_checkout_env_or_marker(manifest_dir),
+        }
+    }
 }
 
 /// Read the active `streamlib link` checkout from [`crate::LINK_CHECKOUT_ENV`],
 /// returning `None` when unset/empty — the codegen-boundary read that makes
 /// `resolve_with` link-aware without the pure resolver ever touching the
 /// environment. The orchestrator sets this env on a linked package's `cargo
-/// build` (and withholds it for locked/distribution builds), so a `build.rs`
-/// schema-dep codegen redirects to the checkout only when a link is active.
+/// build` (and sets it to empty for locked/distribution builds), so a
+/// `build.rs` schema-dep codegen redirects to the checkout only when a link is
+/// active. Used by [`ResolverOptions::from_env`]; the marker-first boundary
+/// ([`ResolverOptions::from_env_or_marker`]) layers `.streamlib/link.json`
+/// discovery under an absent env.
 fn link_checkout_from_env() -> Option<PathBuf> {
     std::env::var_os(crate::LINK_CHECKOUT_ENV)
         .map(PathBuf::from)
         .filter(|p| !p.as_os_str().is_empty())
+}
+
+/// Resolve the active `streamlib link` checkout for a compile-time codegen
+/// boundary — **marker-first with env override**, `var_os` distinguishing
+/// unset from set-empty:
+///
+/// * [`crate::LINK_CHECKOUT_ENV`] **set to a non-empty path** ⇒ that path (an
+///   explicit override — a dev exporting it, or the build orchestrator
+///   threading the discovered checkout for a relocated build).
+/// * [`crate::LINK_CHECKOUT_ENV`] **set to empty** ⇒ `None` (suppression) with
+///   NO marker discovery. The orchestrator sets this for a locked / distribution
+///   build so a relocated `cargo build` never re-derives link state from a stray
+///   `.streamlib/link.json` up-tree of the relocated crate dir — the
+///   streamlib-home cache the orchestrator relocates into shares the
+///   `.streamlib` dir name with the link-state dir, so an unconditional walk-up
+///   would otherwise collide.
+/// * [`crate::LINK_CHECKOUT_ENV`] **unset** ⇒ walk up from `manifest_dir` for
+///   `.streamlib/link.json` and take its checkout — the direct-`cargo build`
+///   path with no env exported.
+///
+/// The env read still keeps the pure resolver env-free: this runs at the
+/// codegen boundary only ([`ResolverOptions::from_env_or_marker`]).
+fn link_checkout_env_or_marker(manifest_dir: &Path) -> Option<PathBuf> {
+    match std::env::var_os(crate::LINK_CHECKOUT_ENV) {
+        Some(raw) => {
+            let path = PathBuf::from(raw);
+            if path.as_os_str().is_empty() {
+                None
+            } else {
+                Some(path)
+            }
+        }
+        None => link_checkout_from_marker(manifest_dir),
+    }
+}
+
+/// Walk up from `manifest_dir` for a `streamlib link` marker
+/// (`.streamlib/link.json`) and return its recorded checkout. `None` when no
+/// marker is found; a corrupt marker is logged and treated as no link (never a
+/// silent redirect to a suspect checkout — the resolve then fails loud if the
+/// dep is otherwise unresolvable).
+fn link_checkout_from_marker(manifest_dir: &Path) -> Option<PathBuf> {
+    match crate::link_marker::find_and_load_active_link(manifest_dir) {
+        Ok(Some((marker, manifest))) => {
+            tracing::debug!(
+                marker = %marker.display(),
+                checkout = %manifest.checkout.display(),
+                "streamlib link marker discovered at codegen boundary — resolving \
+                 schema deps from the linked checkout"
+            );
+            Some(manifest.checkout)
+        }
+        Ok(None) => None,
+        Err(e) => {
+            tracing::warn!(
+                start = %manifest_dir.display(),
+                error = %e,
+                "streamlib link marker present but unreadable — ignoring for schema \
+                 resolution (run `streamlib unlink` then re-link to repair)"
+            );
+            None
+        }
+    }
 }
 
 /// Resolve a `streamlib.yaml` at `root_dir` and every transitive dependency
@@ -1901,5 +1998,204 @@ dependencies:
                 None => std::env::remove_var(crate::LINK_CHECKOUT_ENV),
             }
         }
+    }
+
+    /// Write a `.streamlib/link.json` marker at `root` recording `checkout` —
+    /// the shape `streamlib link --engine` persists, enough for
+    /// `find_and_load_active_link` walk-up discovery.
+    fn write_link_marker(root: &Path, checkout: &Path) {
+        use crate::link_marker::{
+            LINK_MANIFEST_FILE, LINK_STATE_DIR, LinkManifest, LinkTransactionState,
+        };
+        let dir = root.join(LINK_STATE_DIR);
+        std::fs::create_dir_all(&dir).unwrap();
+        let manifest = LinkManifest {
+            checkout: checkout.to_path_buf(),
+            python_sdk_path: checkout.join("libs/streamlib-python"),
+            deno_sdk_entrypoint_path: checkout.join("libs/streamlib-deno/mod.ts"),
+            linked_at: "2026-01-01T00:00:00Z".into(),
+            linked_crate_count: 1,
+            state: LinkTransactionState::Active,
+            files: Vec::new(),
+        };
+        std::fs::write(
+            dir.join(LINK_MANIFEST_FILE),
+            serde_json::to_string(&manifest).unwrap(),
+        )
+        .unwrap();
+    }
+
+    /// Run `f` with `STREAMLIB_LINK_CHECKOUT` forced to `value` (`None` ⇒
+    /// unset), restoring the prior value afterward. Restores BEFORE returning
+    /// the computed value so a later failed assert can't leak the env.
+    fn with_link_checkout_env<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        // SAFETY: every caller is `#[serial]`, so the env-mutating tests are
+        // mutually exclusive and no other thread reads the env concurrently.
+        let prev = std::env::var_os(crate::LINK_CHECKOUT_ENV);
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var(crate::LINK_CHECKOUT_ENV, v),
+                None => std::env::remove_var(crate::LINK_CHECKOUT_ENV),
+            }
+        }
+        let out = f();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(crate::LINK_CHECKOUT_ENV, v),
+                None => std::env::remove_var(crate::LINK_CHECKOUT_ENV),
+            }
+        }
+        out
+    }
+
+    /// Marker-first discovery: with `STREAMLIB_LINK_CHECKOUT` unset, a
+    /// `.streamlib/link.json` up-tree of the manifest dir supplies the checkout
+    /// — the direct-`cargo build` fix (no env to export by hand).
+    #[test]
+    #[serial_test::serial]
+    fn from_env_or_marker_discovers_marker_when_env_unset() {
+        let tmp = tempfile::tempdir().unwrap();
+        let checkout = tmp.path().join("streamlib-checkout");
+        write_link_marker(tmp.path(), &checkout);
+        let nested = tmp.path().join("app").join("crate-dir");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let got = with_link_checkout_env(None, || {
+            ResolverOptions::from_env_or_marker(&nested).link_checkout
+        });
+        assert_eq!(
+            got,
+            Some(checkout),
+            "an up-tree marker must supply the checkout when the env is unset"
+        );
+    }
+
+    /// Explicit env overrides the marker: a set (non-empty) env wins, so a dev
+    /// who exports `STREAMLIB_LINK_CHECKOUT` (or the orchestrator threading the
+    /// discovered checkout for a relocated build) is authoritative.
+    #[test]
+    #[serial_test::serial]
+    fn from_env_or_marker_env_overrides_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let marker_checkout = tmp.path().join("marker-checkout");
+        write_link_marker(tmp.path(), &marker_checkout);
+        let nested = tmp.path().join("app");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let got = with_link_checkout_env(Some("/explicit/override"), || {
+            ResolverOptions::from_env_or_marker(&nested).link_checkout
+        });
+        assert_eq!(
+            got,
+            Some(PathBuf::from("/explicit/override")),
+            "a non-empty env must win over the marker"
+        );
+        assert_ne!(
+            got,
+            Some(marker_checkout),
+            "the override must not defer to the marker's checkout"
+        );
+    }
+
+    /// THE suppression boundary. The orchestrator sets the env to EMPTY for a
+    /// relocated / locked / distribution build. Even with a stray
+    /// `.streamlib/link.json` up-tree (the streamlib-home cache the orchestrator
+    /// relocates into shares the `.streamlib` dir name with the link-state dir),
+    /// an empty env must NOT redirect to the checkout. Mentally-revert the
+    /// empty-suppression branch — fall through to marker discovery — and this
+    /// asserts `Some(checkout)` and fails, proving the fix did not reintroduce
+    /// the mixed-build hazard.
+    #[test]
+    #[serial_test::serial]
+    fn from_env_or_marker_empty_env_suppresses_stray_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let checkout = tmp.path().join("stray-checkout");
+        write_link_marker(tmp.path(), &checkout);
+        // Mimic the relocated-build crate dir under a streamlib-home cache whose
+        // own `.streamlib` dir sits beneath the marker's `.streamlib`.
+        let relocated = tmp
+            .path()
+            .join("home")
+            .join(".streamlib")
+            .join("cache")
+            .join("packages")
+            .join("pkg-1.0.0");
+        std::fs::create_dir_all(&relocated).unwrap();
+        // Precondition: the marker IS discoverable up-tree, so suppression (not
+        // absence) is what yields `None`.
+        assert!(
+            crate::link_marker::find_active_link_marker(&relocated).is_some(),
+            "test setup: a marker must be present up-tree"
+        );
+
+        let got = with_link_checkout_env(Some(""), || {
+            ResolverOptions::from_env_or_marker(&relocated).link_checkout
+        });
+        assert_eq!(
+            got, None,
+            "empty env is the suppression sentinel — a relocated/locked/distribution \
+             build must not redirect to a checkout even with a marker up-tree"
+        );
+    }
+
+    /// Neither channel active: no marker up-tree and no env ⇒ no redirect. The
+    /// dominant non-linked build stays byte-identical to before.
+    #[test]
+    #[serial_test::serial]
+    fn from_env_or_marker_no_marker_no_env_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nested = tmp.path().join("app");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let got = with_link_checkout_env(None, || {
+            ResolverOptions::from_env_or_marker(&nested).link_checkout
+        });
+        assert_eq!(
+            got, None,
+            "no marker and no env must leave link_checkout unset"
+        );
+    }
+
+    /// End-to-end: marker discovery → `from_env_or_marker` → `resolve_with`
+    /// resolves a by-version dep from the linked checkout's `packages/` tree
+    /// with NO env exported — the full direct-`cargo build` path the fix
+    /// delivers (mirrors the codegen boundary `build.rs` drives). Mentally-revert
+    /// marker discovery (`link_checkout_from_marker` returns `None`) and the dep
+    /// falls through to the by-version path with no registry configured, so the
+    /// resolve errors and `.expect` panics — the redirect is locked.
+    #[test]
+    #[serial_test::serial]
+    fn marker_first_resolves_dep_from_linked_checkout_without_env() {
+        let tmp = tempfile::tempdir().unwrap();
+        let checkout = tmp.path().join("checkout");
+        write_checkout_package(&checkout, "core", "core", "1.0.0");
+
+        // The app root carries the marker; a nested crate dir builds under it.
+        let app_root = tmp.path().join("app");
+        write_link_marker(&app_root, &checkout);
+        let crate_dir = app_root.join("crates").join("app-lib");
+        write_streamlib_yaml(&crate_dir, "dependencies:\n  \"@tatolab/core\": \"^1.0.0\"\n");
+
+        let res = with_link_checkout_env(None, || {
+            let opts = ResolverOptions::from_env_or_marker(&crate_dir);
+            resolve_with(&crate_dir, &opts)
+        })
+        .expect("marker-discovered checkout must resolve the by-version dep");
+
+        let core = res.packages.get("@tatolab/core").unwrap();
+        assert!(
+            matches!(core.source, ResolvedSource::Path { .. }),
+            "core must resolve from the linked checkout, got {:?}",
+            core.source
+        );
+        assert!(
+            core.root_dir.starts_with(&checkout),
+            "core.root_dir must be under the checkout, got {}",
+            core.root_dir.display()
+        );
+        assert_eq!(
+            core.manifest.package.as_ref().unwrap().version.to_string(),
+            "1.0.0"
+        );
     }
 }

--- a/libs/streamlib-idents/src/resolver.rs
+++ b/libs/streamlib-idents/src/resolver.rs
@@ -2176,11 +2176,26 @@ dependencies:
         let crate_dir = app_root.join("crates").join("app-lib");
         write_streamlib_yaml(&crate_dir, "dependencies:\n  \"@tatolab/core\": \"^1.0.0\"\n");
 
+        // Clear the registry env too so the mentally-revert is deterministic:
+        // with marker discovery reverted, the bare `^1.0.0` dep would fall
+        // through to by-version resolution and — with no registry — fail
+        // `RegistryNotConfigured`, so `.expect` panics. Without this, a stray
+        // `STREAMLIB_REGISTRY_URL` in the shell could send the reverted path to a
+        // live fetch instead. The positive assertion (Path from the checkout)
+        // holds regardless, since the link short-circuit precedes the registry.
+        // SAFETY: `#[serial]` + `with_link_checkout_env` serialize env mutation.
+        let prev_registry = std::env::var_os(crate::REGISTRY_URL_ENV);
+        unsafe { std::env::remove_var(crate::REGISTRY_URL_ENV) };
         let res = with_link_checkout_env(None, || {
             let opts = ResolverOptions::from_env_or_marker(&crate_dir);
             resolve_with(&crate_dir, &opts)
-        })
-        .expect("marker-discovered checkout must resolve the by-version dep");
+        });
+        unsafe {
+            if let Some(v) = prev_registry {
+                std::env::set_var(crate::REGISTRY_URL_ENV, v);
+            }
+        }
+        let res = res.expect("marker-discovered checkout must resolve the by-version dep");
 
         let core = res.packages.get("@tatolab/core").unwrap();
         assert!(

--- a/libs/streamlib-jtd-codegen/src/build_rs.rs
+++ b/libs/streamlib-jtd-codegen/src/build_rs.rs
@@ -82,15 +82,32 @@ fn run_for_rust_crate_inner() -> Result<()> {
         streamlib_idents::REGISTRY_URL_ENV
     );
 
-    // `from_env` reads STREAMLIB_REGISTRY_URL so a registry-cached crate
-    // resolves its schema deps (e.g. `@tatolab/escalate`) from the configured
-    // static registry, and STREAMLIB_LINK_CHECKOUT so a package built under an
-    // active `streamlib link` resolves a dep present in the checkout's
-    // `packages/` tree from the checkout (the zero-registry dev loop). The env
-    // read lives here at the build-script boundary, not inside the pure
-    // resolver.
-    let resolved = streamlib_idents::resolve_with(&crate_dir, &ResolverOptions::from_env())
-        .context("Failed to resolve streamlib.yaml dependency graph")?;
+    // For a direct `cargo build` (env unset), the link is discovered from the
+    // `.streamlib/link.json` marker below, not the env — so also watch the
+    // marker so `streamlib unlink` (marker removed) or a re-link (checkout
+    // changed) re-runs codegen. `streamlib link` also rewrites the consumer's
+    // `.cargo/config.toml`, which forces a rebuild on its own, so this is
+    // belt-and-suspenders for the marker file itself.
+    if let Some(marker) =
+        streamlib_idents::link_marker::find_active_link_marker(&crate_dir)
+    {
+        println!("cargo:rerun-if-changed={}", marker.display());
+    }
+
+    // `from_env_or_marker` reads STREAMLIB_REGISTRY_URL so a registry-cached
+    // crate resolves its schema deps (e.g. `@tatolab/escalate`) from the
+    // configured static registry, and resolves the active `streamlib link`
+    // checkout MARKER-FIRST — walking up from `CARGO_MANIFEST_DIR` for
+    // `.streamlib/link.json` — with STREAMLIB_LINK_CHECKOUT as an explicit
+    // override. So a directly-`cargo build`-ed linked app resolves a dep present
+    // in the checkout's `packages/` tree from the checkout (the zero-registry
+    // dev loop) with NO env exported; the orchestrator still sets the env
+    // (checkout, or empty to suppress) for a relocated build so it stays
+    // authoritative. The env / marker read lives here at the build-script
+    // boundary, not inside the pure resolver.
+    let resolved =
+        streamlib_idents::resolve_with(&crate_dir, &ResolverOptions::from_env_or_marker(&crate_dir))
+            .context("Failed to resolve streamlib.yaml dependency graph")?;
 
     emit_rerun_directives(&crate_dir, &resolved);
 

--- a/libs/streamlib-jtd-codegen/src/lib.rs
+++ b/libs/streamlib-jtd-codegen/src/lib.rs
@@ -111,11 +111,17 @@ pub fn generate(opts: GenerateOptions) -> Result<()> {
     } = opts;
 
     if let Some(project_dir) = project_dir {
-        // `from_env` picks up the static registry config (STREAMLIB_REGISTRY_URL
-        // / STREAMLIB_REGISTRY_URL) so `streamlib generate` resolves registry schema deps;
-        // the pure resolver itself never reads env.
-        let resolved = streamlib_idents::resolve_with(&project_dir, &ResolverOptions::from_env())
-            .context("Failed to resolve streamlib.yaml dependency graph")?;
+        // `from_env_or_marker` picks up the static registry config
+        // (STREAMLIB_REGISTRY_URL) so `streamlib generate` resolves registry
+        // schema deps, and resolves the active `streamlib link` checkout
+        // marker-first (walking up from `project_dir`) with STREAMLIB_LINK_CHECKOUT
+        // as an explicit override — so `streamlib generate` on a linked app
+        // resolves its schema deps from the checkout with no env exported, the
+        // same boundary `build.rs` uses. The pure resolver itself never reads
+        // env or the marker.
+        let resolved =
+            streamlib_idents::resolve_with(&project_dir, &ResolverOptions::from_env_or_marker(&project_dir))
+                .context("Failed to resolve streamlib.yaml dependency graph")?;
 
         if write_lockfile && !resolved.packages.is_empty() {
             let lockfile = resolved.to_lockfile();

--- a/libs/streamlib-jtd-codegen/src/lib.rs
+++ b/libs/streamlib-jtd-codegen/src/lib.rs
@@ -82,6 +82,15 @@ pub struct GenerateOptions {
     /// write `streamlib-codegen.lock` next to `streamlib.yaml`. Defaults to
     /// `true`.
     pub write_lockfile: bool,
+    /// Active `streamlib link` checkout for schema-dep resolution, supplied
+    /// EXPLICITLY by the caller — NOT re-derived from the marker inside
+    /// [`generate`]. The user-facing `streamlib generate` CLI passes the
+    /// marker-discovered checkout ([`streamlib_idents::ResolverOptions::from_env_or_marker`],
+    /// CWD/project-anchored); the build orchestrator's in-process codegen passes
+    /// its own authoritative link state (the checkout when a link is active,
+    /// `None` on a distribution build) so a relocated codegen never walks up out
+    /// of the staged cache dir into a stray marker. `None` ⇒ no link redirect.
+    pub link_checkout: Option<PathBuf>,
 }
 
 impl Default for GenerateOptions {
@@ -94,6 +103,7 @@ impl Default for GenerateOptions {
             schema_dir: None,
             workspace_root: PathBuf::new(),
             write_lockfile: true,
+            link_checkout: None,
         }
     }
 }
@@ -108,20 +118,26 @@ pub fn generate(opts: GenerateOptions) -> Result<()> {
         schema_dir,
         workspace_root: _,
         write_lockfile,
+        link_checkout,
     } = opts;
 
     if let Some(project_dir) = project_dir {
-        // `from_env_or_marker` picks up the static registry config
-        // (STREAMLIB_REGISTRY_URL) so `streamlib generate` resolves registry
-        // schema deps, and resolves the active `streamlib link` checkout
-        // marker-first (walking up from `project_dir`) with STREAMLIB_LINK_CHECKOUT
-        // as an explicit override — so `streamlib generate` on a linked app
-        // resolves its schema deps from the checkout with no env exported, the
-        // same boundary `build.rs` uses. The pure resolver itself never reads
-        // env or the marker.
-        let resolved =
-            streamlib_idents::resolve_with(&project_dir, &ResolverOptions::from_env_or_marker(&project_dir))
-                .context("Failed to resolve streamlib.yaml dependency graph")?;
+        // `from_env` picks up the static registry config (STREAMLIB_REGISTRY_URL)
+        // so a registry-cached crate resolves registry schema deps. The active
+        // `streamlib link` checkout is supplied EXPLICITLY by the caller
+        // (`link_checkout`), NOT re-derived from the marker here: the user-facing
+        // `streamlib generate` CLI passes the marker-discovered checkout
+        // (CWD/project-anchored via `ResolverOptions::from_env_or_marker`), while
+        // the build orchestrator's in-process codegen passes its own
+        // authoritative link state (checkout when linked, `None` on a
+        // distribution build). That authority split keeps a relocated
+        // orchestrator codegen from walking up out of the staged cache dir into a
+        // stray `.streamlib/link.json` and redirecting a distribution build to a
+        // dev checkout. The pure resolver never reads env or the marker.
+        let mut resolver_options = ResolverOptions::from_env();
+        resolver_options.link_checkout = link_checkout;
+        let resolved = streamlib_idents::resolve_with(&project_dir, &resolver_options)
+            .context("Failed to resolve streamlib.yaml dependency graph")?;
 
         if write_lockfile && !resolved.packages.is_empty() {
             let lockfile = resolved.to_lockfile();

--- a/libs/streamlib-jtd-codegen/tests/common/mod.rs
+++ b/libs/streamlib-jtd-codegen/tests/common/mod.rs
@@ -69,6 +69,7 @@ pub fn run_project_codegen(runtime: RuntimeTarget, output: &Path) {
         schema_dir: None,
         workspace_root: workspace_root(),
         write_lockfile: false,
+        link_checkout: None,
     })
     .expect("generate project codegen");
 }
@@ -84,6 +85,7 @@ pub fn run_single_schema_codegen(runtime: RuntimeTarget, schema_file: &Path, out
         schema_dir: None,
         workspace_root: workspace_root(),
         write_lockfile: false,
+        link_checkout: None,
     })
     .expect("generate single-schema codegen");
 }

--- a/libs/streamlib-jtd-codegen/tests/tree_shaking.rs
+++ b/libs/streamlib-jtd-codegen/tests/tree_shaking.rs
@@ -112,6 +112,7 @@ fn tree_shake_emits_only_root_declared_schemas() {
         schema_dir: None,
         workspace_root: tmp.path().to_path_buf(),
         write_lockfile: false,
+        link_checkout: None,
     })
     .expect("generate root codegen");
 

--- a/libs/streamlib-macros/src/lib.rs
+++ b/libs/streamlib-macros/src/lib.rs
@@ -261,14 +261,19 @@ fn load_processor_schema(
         || schema.config.is_some();
 
     let config_schema_id = if needs_resolution {
-        // Macro expansion is a build-time codegen boundary: read the registry
-        // config from the environment (STREAMLIB_REGISTRY_URL / STREAMLIB_REGISTRY_URL) so a
-        // standalone, registry-only package resolves its bare-name schema deps
-        // (e.g. @tatolab/core) from the registry instead of failing as
-        // RegistryNotConfigured.
+        // Macro expansion is a compile-time codegen boundary: read the registry
+        // config from the environment (STREAMLIB_REGISTRY_URL) so a standalone,
+        // registry-only package resolves its bare-name schema deps (e.g.
+        // @tatolab/core) from the registry instead of failing as
+        // RegistryNotConfigured, AND resolve the active `streamlib link` checkout
+        // marker-first (from `manifest_dir_path`) so a directly-`cargo build`-ed
+        // linked app resolves those bare-name deps from the checkout with no env
+        // exported — the macro half of the fix `build.rs` gets, needed whenever
+        // the app defines a Rust `#[processor]` with a bare-name config/port
+        // schema owned by a linked dep.
         let resolved = streamlib_idents::resolve_with(
             manifest_dir_path,
-            &streamlib_idents::ResolverOptions::from_env(),
+            &streamlib_idents::ResolverOptions::from_env_or_marker(manifest_dir_path),
         )
         .map_err(|e| {
             syn::Error::new_spanned(

--- a/libs/streamlib-pack/src/lib.rs
+++ b/libs/streamlib-pack/src/lib.rs
@@ -835,18 +835,21 @@ fn collect_source_tree(pkg_dir: &Path, files: &mut Vec<(String, PathBuf)>) -> Re
 /// stream to locate the produced cdylib. Cargo's own fingerprint
 /// short-circuits when nothing changed — and catches out-of-package /
 /// transitive changes a package-local check cannot.
-/// The `STREAMLIB_LINK_CHECKOUT` value a relocated build threads to its package
-/// `build.rs`: the checkout path when a link is active, or EMPTY (the
-/// suppression sentinel [`streamlib_idents::ResolverOptions::from_env_or_marker`]
-/// honors) when not. Setting it unconditionally keeps the orchestrator
-/// authoritative over link state — the relocated `build.rs` trusts this env and
-/// never re-derives the link from a stray `.streamlib/link.json` up-tree of the
-/// staged crate dir.
-fn link_checkout_env_value(link_checkout: Option<&Path>) -> &std::ffi::OsStr {
-    match link_checkout {
+/// Set `STREAMLIB_LINK_CHECKOUT` on `command` for a relocated `cargo build` —
+/// the checkout path when a link is active, or EMPTY (the suppression sentinel
+/// [`streamlib_idents::ResolverOptions::from_env_or_marker`] honors) when not.
+/// BOTH arms call `command.env`, so the env is set UNCONDITIONALLY: that keeps
+/// the orchestrator authoritative over link state, so the relocated `build.rs`
+/// trusts this env and never re-derives the link from a stray
+/// `.streamlib/link.json` up-tree of the staged crate dir. Reverting the `None`
+/// arm to "leave the env unset" reintroduces the mixed-build hazard — locked by
+/// `cargo_build_sets_link_checkout_env_unconditionally`.
+fn apply_link_checkout_env(command: &mut Command, link_checkout: Option<&Path>) {
+    let value: &std::ffi::OsStr = match link_checkout {
         Some(checkout) => checkout.as_os_str(),
         None => std::ffi::OsStr::new(""),
-    }
+    };
+    command.env(streamlib_idents::LINK_CHECKOUT_ENV, value);
 }
 
 fn cargo_build_streaming(
@@ -878,19 +881,14 @@ fn cargo_build_streaming(
     // cargo `[patch]` above for the crate half. `build.rs` runs as a child of
     // this `cargo build`, so an env var set here reaches it.
     //
-    // The env is set UNCONDITIONALLY so the orchestrator stays authoritative
-    // over link state: this is a relocated build (the package is staged into the
-    // streamlib-home cache, whose `.streamlib` dir name collides with the
-    // link-state dir), so `build.rs`'s marker walk-up from `CARGO_MANIFEST_DIR`
-    // could otherwise cross into a stray `.streamlib/link.json` up-tree and
-    // silently redirect a locked / distribution build to a dev checkout. Setting
-    // the checkout when a link is active, and EMPTY (the suppression sentinel
-    // `from_env_or_marker` honors) when not, means the relocated `build.rs`
-    // trusts this env and never re-derives link state from the marker.
-    command.env(
-        streamlib_idents::LINK_CHECKOUT_ENV,
-        link_checkout_env_value(link_checkout),
-    );
+    // The env is set UNCONDITIONALLY (see `apply_link_checkout_env`) so the
+    // orchestrator stays authoritative over link state: this is a relocated
+    // build (the package is staged into the streamlib-home cache, whose
+    // `.streamlib` dir name collides with the link-state dir), so `build.rs`'s
+    // marker walk-up from `CARGO_MANIFEST_DIR` could otherwise cross into a stray
+    // `.streamlib/link.json` up-tree and silently redirect a locked /
+    // distribution build to a dev checkout.
+    apply_link_checkout_env(&mut command, link_checkout);
     command
         .arg("--message-format=json-render-diagnostics")
         .arg("-p")
@@ -1281,24 +1279,39 @@ mod tests {
     use streamlib_cargo_build::{host_dylib_extension, host_target_triple};
     use tempfile::tempdir;
 
-    /// A relocated build sets `STREAMLIB_LINK_CHECKOUT` UNCONDITIONALLY — the
-    /// checkout when a link is active, EMPTY (never absent) otherwise — so the
-    /// orchestrator stays authoritative and the staged `build.rs` never
-    /// re-derives the link from a stray marker up-tree. Mentally-revert the
-    /// `None => ""` arm (leave the env unset for a non-linked build) and the
-    /// empty-assert fails, proving the suppression sentinel is emitted.
+    /// A relocated `cargo build` gets `STREAMLIB_LINK_CHECKOUT` set on its
+    /// `Command` UNCONDITIONALLY — the checkout when a link is active, EMPTY
+    /// (present, never absent) otherwise — so the orchestrator stays
+    /// authoritative and the staged `build.rs` never re-derives the link from a
+    /// stray marker up-tree. Inspecting the built `Command`'s env via
+    /// `get_envs()` locks the CALL SITE, not just a value mapping: mentally-revert
+    /// `apply_link_checkout_env`'s `None` arm to "leave the env unset" (the exact
+    /// mixed-build regression) and the `Some(Some(""))` assertion below fails,
+    /// because the env would be absent from `get_envs()` rather than present-empty.
     #[test]
-    fn relocated_build_link_env_value_is_checkout_or_empty_never_absent() {
+    fn cargo_build_sets_link_checkout_env_unconditionally() {
+        use std::ffi::OsStr;
+        let key = OsStr::new(streamlib_idents::LINK_CHECKOUT_ENV);
+
+        // No active link ⇒ env PRESENT and EMPTY (the suppression sentinel).
+        let mut no_link = Command::new("true");
+        apply_link_checkout_env(&mut no_link, None);
+        let got = no_link.get_envs().find(|(k, _)| *k == key).map(|(_, v)| v);
         assert_eq!(
-            link_checkout_env_value(None),
-            std::ffi::OsStr::new(""),
-            "a non-linked relocated build must set the EMPTY suppression sentinel, \
-             not leave the env unset"
+            got,
+            Some(Some(OsStr::new(""))),
+            "a non-linked relocated build must SET the EMPTY sentinel on the \
+             command, not leave the env unset"
         );
+
+        // Active link ⇒ the checkout path is threaded through as the override.
+        let mut linked = Command::new("true");
         let checkout = Path::new("/opt/streamlib-checkout");
+        apply_link_checkout_env(&mut linked, Some(checkout));
+        let got = linked.get_envs().find(|(k, _)| *k == key).map(|(_, v)| v);
         assert_eq!(
-            link_checkout_env_value(Some(checkout)),
-            checkout.as_os_str(),
+            got,
+            Some(Some(checkout.as_os_str())),
             "an active link threads the checkout path through as the override"
         );
     }

--- a/libs/streamlib-pack/src/lib.rs
+++ b/libs/streamlib-pack/src/lib.rs
@@ -835,6 +835,20 @@ fn collect_source_tree(pkg_dir: &Path, files: &mut Vec<(String, PathBuf)>) -> Re
 /// stream to locate the produced cdylib. Cargo's own fingerprint
 /// short-circuits when nothing changed — and catches out-of-package /
 /// transitive changes a package-local check cannot.
+/// The `STREAMLIB_LINK_CHECKOUT` value a relocated build threads to its package
+/// `build.rs`: the checkout path when a link is active, or EMPTY (the
+/// suppression sentinel [`streamlib_idents::ResolverOptions::from_env_or_marker`]
+/// honors) when not. Setting it unconditionally keeps the orchestrator
+/// authoritative over link state — the relocated `build.rs` trusts this env and
+/// never re-derives the link from a stray `.streamlib/link.json` up-tree of the
+/// staged crate dir.
+fn link_checkout_env_value(link_checkout: Option<&Path>) -> &std::ffi::OsStr {
+    match link_checkout {
+        Some(checkout) => checkout.as_os_str(),
+        None => std::ffi::OsStr::new(""),
+    }
+}
+
 fn cargo_build_streaming(
     pkg_dir: &Path,
     cargo_name: &str,
@@ -858,16 +872,25 @@ fn cargo_build_streaming(
         command.arg("--config").arg(config_file);
     }
     // Thread the active `streamlib link` checkout to the package's `build.rs`
-    // schema-dep codegen, which reads it via `ResolverOptions::from_env` and
-    // resolves a dep present in `<checkout>/packages/<name>` from the checkout —
-    // the schema-dep half of the zero-registry dev loop, mirroring the cargo
-    // `[patch]` above for the crate half. `build.rs` runs as a child of this
-    // `cargo build`, so an env var set here reaches it. `None` (every
-    // non-linked / locked / distribution build) sets nothing, leaving schema
-    // resolution byte-identical to before.
-    if let Some(checkout) = link_checkout {
-        command.env(streamlib_idents::LINK_CHECKOUT_ENV, checkout);
-    }
+    // schema-dep codegen, which reads it via `ResolverOptions::from_env_or_marker`
+    // and resolves a dep present in `<checkout>/packages/<name>` from the
+    // checkout — the schema-dep half of the zero-registry dev loop, mirroring the
+    // cargo `[patch]` above for the crate half. `build.rs` runs as a child of
+    // this `cargo build`, so an env var set here reaches it.
+    //
+    // The env is set UNCONDITIONALLY so the orchestrator stays authoritative
+    // over link state: this is a relocated build (the package is staged into the
+    // streamlib-home cache, whose `.streamlib` dir name collides with the
+    // link-state dir), so `build.rs`'s marker walk-up from `CARGO_MANIFEST_DIR`
+    // could otherwise cross into a stray `.streamlib/link.json` up-tree and
+    // silently redirect a locked / distribution build to a dev checkout. Setting
+    // the checkout when a link is active, and EMPTY (the suppression sentinel
+    // `from_env_or_marker` honors) when not, means the relocated `build.rs`
+    // trusts this env and never re-derives link state from the marker.
+    command.env(
+        streamlib_idents::LINK_CHECKOUT_ENV,
+        link_checkout_env_value(link_checkout),
+    );
     command
         .arg("--message-format=json-render-diagnostics")
         .arg("-p")
@@ -1257,6 +1280,28 @@ mod tests {
     use super::*;
     use streamlib_cargo_build::{host_dylib_extension, host_target_triple};
     use tempfile::tempdir;
+
+    /// A relocated build sets `STREAMLIB_LINK_CHECKOUT` UNCONDITIONALLY — the
+    /// checkout when a link is active, EMPTY (never absent) otherwise — so the
+    /// orchestrator stays authoritative and the staged `build.rs` never
+    /// re-derives the link from a stray marker up-tree. Mentally-revert the
+    /// `None => ""` arm (leave the env unset for a non-linked build) and the
+    /// empty-assert fails, proving the suppression sentinel is emitted.
+    #[test]
+    fn relocated_build_link_env_value_is_checkout_or_empty_never_absent() {
+        assert_eq!(
+            link_checkout_env_value(None),
+            std::ffi::OsStr::new(""),
+            "a non-linked relocated build must set the EMPTY suppression sentinel, \
+             not leave the env unset"
+        );
+        let checkout = Path::new("/opt/streamlib-checkout");
+        assert_eq!(
+            link_checkout_env_value(Some(checkout)),
+            checkout.as_os_str(),
+            "an active link threads the checkout path through as the override"
+        );
+    }
 
     fn slpkg_opts(no_build: bool) -> AssembleOptions {
         AssembleOptions {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -250,15 +250,23 @@ fn main() -> Result<()> {
             project_dir,
             schema_file,
             schema_dir,
-        } => generate(GenerateOptions {
-            runtime,
-            output,
-            project_dir,
-            schema_file,
-            schema_dir,
-            workspace_root: workspace_root()?,
-            write_lockfile: true,
-        })?,
+        } => {
+            // Human-run codegen (like the `streamlib generate` CLI): resolve the
+            // active `streamlib link` checkout marker-first from the project dir.
+            let link_checkout = project_dir
+                .as_deref()
+                .and_then(|d| streamlib_idents::ResolverOptions::from_env_or_marker(d).link_checkout);
+            generate(GenerateOptions {
+                runtime,
+                output,
+                project_dir,
+                schema_file,
+                schema_dir,
+                workspace_root: workspace_root()?,
+                write_lockfile: true,
+                link_checkout,
+            })?
+        }
         Commands::LintLogging => lint_logging::run(&workspace_root()?)?,
         Commands::CheckBoundaries => check_boundaries::run(&workspace_root()?)?,
         Commands::CheckSchemaVersions => check_schema_versions::run(&workspace_root()?)?,


### PR DESCRIPTION
## What

Make a linked app's schema codegen work from a plain `cargo build` with no env
var to remember. Today `streamlib link --engine` writes both a cargo
`[patch.crates-io]` (for SDK crate resolution) **and** a `.streamlib/link.json`
marker (carrying the checkout path), but the jtd-codegen `build.rs` learned the
checkout **only** from `STREAMLIB_LINK_CHECKOUT` — set by the build-orchestrator
when *it* drives a build — so a developer running `cargo build`/`cargo run`
directly on a linked app had to export the env by hand.

This resolves the link checkout **marker-first, env-as-override** at the
compile-time codegen boundary.

## The change

- **`ResolverOptions::from_env_or_marker(manifest_dir)`** (new; `streamlib-idents`):
  walks up from the crate dir for `.streamlib/link.json` via
  `link_marker::find_and_load_active_link`, taking the marker's checkout;
  `STREAMLIB_LINK_CHECKOUT` remains an explicit override. The pure resolver
  (`resolve_with`) is untouched — it still reads the `link_checkout` field only,
  never the marker or the env. `from_env` is untouched too, so the **runtime**
  callers (module loader → `project_config` / `processor_registration`) that
  thread the checkout themselves are unaffected.
- Routed the **three compile-time codegen boundaries** through it: the
  jtd-codegen `build.rs`, the `#[processor]` macro (bare-name schema
  resolution — needed whenever a linked app defines a Rust processor, the
  common case), and `streamlib generate`. `build.rs` also emits
  `rerun-if-changed` for the discovered marker so `streamlib unlink` re-runs
  codegen.

## The load-bearing correctness boundary (and how it's preserved)

The current design deliberately keeps locked / distribution / `.slpkg`-pack
builds from resolving schemas out of a dev checkout. Marker-discovery must not
silently break that — and the hazard is real and specific:

**The `.streamlib` name collision.** The build orchestrator relocates every
package build into the streamlib-home cache
(`<home>/.streamlib/cache/packages/<name>-<ver>/`), whose `.streamlib` dir name
is the same as the link-state dir. So a naive `build.rs` walk-up from
`CARGO_MANIFEST_DIR` would cross into an app's `.streamlib/link.json` up-tree
and redirect a distribution build to a dev checkout — a mixed-build. The
orchestrator discovers the link from **CWD**; `build.rs` would discover from
**CARGO_MANIFEST_DIR** — two anchors that can disagree.

**Preserved three ways:**

1. **Locked runs** use `BuildPolicy::NeverBuild` → no `cargo`, no `build.rs`,
   so marker discovery never runs. (Confirmed, not assumed.)
2. **`.slpkg` pack** refuses while a marker is present up-tree
   (`ensure_no_active_link_for_pack`), so a distributable is never assembled
   under a link.
3. **Relocated builds** (the orchestrator materializing a package into the
   cache): the design makes the **orchestrator authoritative**. `from_env_or_marker`
   treats the env as authoritative *when present* — `var_os` distinguishes
   unset (→ marker discovery) from set-empty (→ suppression). The orchestrator
   (`streamlib-pack::cargo_build_streaming` via `apply_link_checkout_env`) now
   sets `STREAMLIB_LINK_CHECKOUT` **unconditionally** for every relocated build
   — the checkout when a link is active, **EMPTY** (the suppression sentinel)
   otherwise — so a relocated `build.rs` trusts the env and never re-derives
   link state from a stray marker. `streamlib-cargo-build::run_cargo_build`
   (the native-host relocated build) sets the empty sentinel too, so the
   invariant holds universally.

**Invariant audit (grepped every cargo-invocation site):** the only relocated
build that compiles a jtd-codegen-bearing crate is `cargo_build_streaming`;
`run_cargo_build` (native FFI host) builds crates with **no `build.rs`** so it
was a benign latent gap — closed anyway with the empty sentinel. No relocated
build path leaves the env unset.

**The test that locks it:** `from_env_or_marker_empty_env_suppresses_stray_marker`
(resolver) — a relocated crate dir under a `<home>/.streamlib/cache/...` layout
with a marker discoverable up-tree, `STREAMLIB_LINK_CHECKOUT=""` → resolves to
`None`. Mentally-revert the empty-suppression branch (fall through to marker
discovery) and it asserts `Some(checkout)` and fails.
`cargo_build_sets_link_checkout_env_unconditionally` (pack) inspects the built
`Command` via `get_envs()` and asserts the non-linked case is present-empty
(`Some(Some(""))`), not absent — so reverting the call site to
`if let Some(...)` (leaving the env unset) fails at the call site, not just a
value mapping.

## Tests

Unit + e2e, all in-tree, hermetic (`#[serial]` env control, restore-before-assert):

- Marker present, env unset → checkout resolved.
- Env set (non-empty) → env wins over marker (override).
- Env set empty → suppressed, no redirect (the boundary above).
- Neither → `None`.
- Full `marker → from_env_or_marker → resolve_with` e2e: a by-version dep
  resolves from the checkout's `packages/` tree with no env.
- Pack: `get_envs()` locks the unconditional call-site env-set.

## Mini end-to-end proof (real `cargo build`)

A throwaway crate (`build.rs` using jtd-codegen + a `@tatolab/core` schema dep)
under a fake `.streamlib/link.json` marker, built with **no**
`STREAMLIB_LINK_CHECKOUT` and **no** `STREAMLIB_REGISTRY_URL`:

| Scenario | Result |
|---|---|
| Marker present, no env | **builds** — `Frame` codegen resolved from the marker's checkout |
| Marker removed, no env | **fails** — `Failed to resolve streamlib.yaml dependency graph` (proves the marker drove the success) |
| Marker present, `STREAMLIB_LINK_CHECKOUT=""` | **fails / suppressed** — the orchestrator's empty sentinel wins even with a marker up-tree (the mixed-build hazard lock, in a real build) |
| `STREAMLIB_LINK_CHECKOUT=<checkout>` | **builds** — env override works |

## Validation

- `cargo build --workspace` — green (no registry mirror).
- `cargo test -p streamlib-idents -p streamlib-jtd-codegen -p streamlib-macros -p streamlib-cargo-build -p streamlib-pack` — green (idents lib 208, pack lib 51, incl. the new tests).
- `cargo xtask check-boundaries` / `lint-logging` — no violations.
- Clippy on touched files clean (the remaining workspace clippy warnings are pre-existing baseline, none in edited regions).

## Docs

No `docs/architecture` doc described the **build-time schema-codegen**
resolution mechanism (`package-development-model.md`'s link section covers the
cargo `[patch.crates-io]` overrides and the **runtime** module-loader
resolution, not build.rs), so nothing there went stale. The relevant Rust
doc-comments (the `link_checkout` field, `from_env` family, `build.rs`, the
macro, `streamlib generate`, the pack helper) were updated to marker-first +
env-override.

Closes #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB

---

## Review round 1 — the `generate()` orchestrator-path fix

Review flagged a real hole the child-env mechanism couldn't cover, and it's a
FIX (not a DISCUSS-accept): it violated exit criterion #3 on the **polyglot**
codegen path.

**The hole.** This PR switched `streamlib_jtd_codegen::generate()` (used by
`streamlib generate`) from `from_env` to `from_env_or_marker`. But `generate()`
has a SECOND caller: the build orchestrator's **in-process** Python-venv +
Deno `_generated_` codegen (`python_venv.rs`, `deno_codegen.rs`). That runs in
the orchestrator's own process — *not* a child of `cargo_build_streaming`, so
the empty-env sentinel (which only reaches build.rs / the `#[processor]` macro
as `cargo build` children) never touches it — against a `project_dir` under the
relocated staged cache (`<home>/.streamlib/cache/...`, the same `.streamlib`
name collision). So a relocated in-process codegen could walk up out of the
cache into a stray `.streamlib/link.json` and redirect a distribution / locked
build to a dev checkout. The orchestrator discovers the link from CWD;
`generate()` would discover from `project_dir` — two anchors that can disagree
(the mixed-build hazard). `StagedDir` materialization is exempt from
`ensure_no_active_link_for_pack`, so the pack guard doesn't backstop it.

**The fix — make `generate()` link-authoritative.** `GenerateOptions` gains an
explicit `link_checkout: Option<PathBuf>` mapping straight to
`ResolverOptions.link_checkout` (registry still from env); `generate()` no
longer re-derives the link from the marker. Callers supply it:

- **Orchestrator** threads its own authoritative `active_link.checkout`
  (checkout when linked, `None` on distribution) into the Python-venv + Deno
  codegen — never marker-re-derived from the relocated dir.
- **CLI `streamlib generate`** (and `cargo xtask generate-schemas`) compute the
  marker-first checkout via `ResolverOptions::from_env_or_marker` —
  CWD/project-anchored, correct for a dev running it in their linked app.

Net: orchestrator authoritative, CLI marker-discovers, the in-process path never
marker-re-derived. The linked polyglot path still resolves schema deps from the
checkout via the threaded `active_link`, so it isn't regressed.

**Test that locks it** (`generate_is_link_authoritative_not_marker_discovered`,
`streamlib-build-orchestrator`): a stray marker sits up-tree of `project_dir`;
`link_checkout=None` must NOT redirect to the checkout (no registry ⇒
unresolvable ⇒ `generate` errors), while `link_checkout=Some(checkout)` resolves
from it. Mentally-revert to `from_env_or_marker(&project_dir)` inside
`generate()` → Case A resolves from the marker's checkout and succeeds → the
test fails.

Re-verified: idents lib / pack lib / jtd-codegen / cli / build-orchestrator
tests green (incl. the new lock); `cargo build --workspace` green;
check-boundaries + lint-logging clean; clippy clean on edited regions.