### PR TITLE
test(plugin): refresh twin-drift-guard hash constants after the fmt sweep

### DIFF
--- a/runtime/streamlib-engine/src/core/plugin/twin_drift_guard.rs
+++ b/runtime/streamlib-engine/src/core/plugin/twin_drift_guard.rs
@@ -106,8 +106,8 @@ fn divergent_processor_vtable_twin_is_tripwired() {
     // Updated whenever processor_vtable.rs is intentionally edited in either
     // copy — and updating it is the moment to confirm the matching logic landed
     // in the other copy too.
-    const EXPECTED_ENGINE: u64 = 0xd35f_5cb9_a23a_b197;
-    const EXPECTED_SDK: u64 = 0xdbcd_b43d_7cbc_8b5e;
+    const EXPECTED_ENGINE: u64 = 0xbee1_89ef_1526_2cef;
+    const EXPECTED_SDK: u64 = 0xe2bd_4f8b_ade2_bdf6;
     let eng = fnv1a(&normalize(&read(ENGINE_DIR, "processor_vtable.rs")));
     let sdk = fnv1a(&normalize(&read(SDK_DIR, "processor_vtable.rs")));
     assert!(


### PR DESCRIPTION
## Summary

`divergent_processor_vtable_twin_is_tripwired` has been red on `main`: the workspace-wide `cargo fmt` sweep (#1314) reformatted both `processor_vtable.rs` twins, shifting their normalized-logic hashes without the matching `EXPECTED_*` bump.

Followed the trip-wire's own protocol before refreshing: `logic_identical_twins_stay_in_sync` **passes** (the engine and plugin-sdk copies are in sync with each other), and `git log --follow` shows the only content-touching commit since the last bump is the fmt sweep — no logic change went missing in either copy. Two-constant refresh; the trip-wire itself is the regression lock (it was failing before, passes after, and any future unbumped edit re-fires it).

## Validation

`cargo test --locked -p streamlib-engine --lib twin_drift_guard` — 2 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w7Tw9EYuEvniYzGgFakrB