### PR TITLE
fix(flow): dead Write() deny rules + branch-shield cd-prefix false-deny

### DIFF
--- a/.claude/hooks/branch-shield.sh
+++ b/.claude/hooks/branch-shield.sh
@@ -17,13 +17,24 @@ stripped="$(printf '%s' "$cmd" | sed -E \
   -e "s/'[^']*'//g" \
   -e 's/"[^"]*"//g')"
 
-# Resolve the git target directory: `git -C <path>` wins over the payload cwd for
-# the on-main check, and is normalized out of the command so subcommand matchers
-# see `git commit` / `git push` directly.
+# Resolve the git target directory for the on-main check, in priority order:
+# 1. `git -C <path>` (normalized out of the command so subcommand matchers see
+#    `git commit` / `git push` directly);
+# 2. the last `cd <path>` preceding the git call — compound commands like
+#    `cd .claude/worktrees/x && git commit` run git in the cd'd directory, not
+#    the payload cwd (worktree-per-attempt makes this the canonical shape);
+# 3. the payload cwd.
 gitc_path="$(printf '%s' "$stripped" \
   | grep -oE 'git[[:space:]]+-C[[:space:]]+[^[:space:]]+' \
   | head -n1 | sed -E 's/^git[[:space:]]+-C[[:space:]]+//')"
-target_dir="${gitc_path:-${cwd:-.}}"
+cd_path="$(printf '%s' "$stripped" \
+  | grep -oE '(^|&&|;)[[:space:]]*cd[[:space:]]+[^[:space:];&|]+' \
+  | tail -n1 | sed -E 's/^.*cd[[:space:]]+//')"
+case "$cd_path" in
+  ""|/*) ;;
+  *) cd_path="${cwd:-.}/$cd_path" ;;
+esac
+target_dir="${gitc_path:-${cd_path:-${cwd:-.}}}"
 norm="$(printf '%s' "$stripped" | sed -E 's/git[[:space:]]+-C[[:space:]]+[^[:space:]]+[[:space:]]+/git /g')"
 
 deny() {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,19 +2,12 @@
   "permissions": {
     "deny": [
       "Edit(vendor/tatolab-vulkanalia*/**)",
-      "Write(vendor/tatolab-vulkanalia*/**)",
       "Edit(LICENSE)",
-      "Write(LICENSE)",
       "Edit(LICENSES/**)",
-      "Write(LICENSES/**)",
       "Edit(docs/license/**)",
-      "Write(docs/license/**)",
       "Edit(docs/logging-schema.md)",
-      "Write(docs/logging-schema.md)",
       "Edit(docs/testing-hardware.md)",
-      "Write(docs/testing-hardware.md)",
-      "Edit(docs/architecture/schema-identity-and-packaging.md)",
-      "Write(docs/architecture/schema-identity-and-packaging.md)"
+      "Edit(docs/architecture/schema-identity-and-packaging.md)"
     ]
   },
   "hooks": {
@@ -22,13 +15,19 @@
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/branch-shield.sh" }
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/branch-shield.sh"
+          }
         ]
       },
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/rig-brake.sh" }
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/rig-brake.sh"
+          }
         ]
       }
     ],
@@ -36,7 +35,10 @@
       {
         "matcher": "Write|Edit",
         "hooks": [
-          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/rs-sentinels.sh" }
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/rs-sentinels.sh"
+          }
         ]
       }
     ]


### PR DESCRIPTION
## What & why

Two fixes from the operating model's first hours in production:

1. **Dead deny rules.** Startup diagnostics flagged all seven `Write(path)` deny entries: the permission checker matches `Edit(path)` rules only, and those already cover every file-editing tool. The no-op `Write(...)` entries are removed; the protection surface is unchanged (the 7 `Edit(...)` rules remain).
2. **branch-shield false-deny on the canonical commit shape.** The hook judged `git commit` by the payload cwd's branch, so `cd .claude/worktrees/<x> && git commit` — the exact worktree-per-attempt pattern the constraints mandate — was refused when the shell's cwd was the main checkout. Target resolution is now `git -C` > last `cd <path>` prefix > payload cwd. (Found live: the hook's first real firing caught the session applying fix 1.)

## Validation

- `jq empty` clean; deny list = exactly the 7 effective `Edit(...)` rules.
- `bash -n` clean; regression payloads: cd-worktree commit → allow; plain commit on main cwd → deny; cd + push origin main → deny; `git -C <main-checkout> commit` → deny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167VuUR9tBcK4uSZv9XKfEj