### PR TITLE
ci(test): gate the engine-free ABI crates' lib tests (plugin-abi + plugin-sdk)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-test-
 
-      # The documented CI unit-test gate ("CI runs `cargo test --lib`").
+      # Unit-test gate. Runs the facade + the engine-free ABI crates' lib tests:
+      # streamlib-plugin-abi / -plugin-sdk carry the layout-regression, fingerprint,
+      # twin-drift and tier-1 wire-format locks — the guards against silent ABI
+      # layout drift (which corrupts the driver only in a separately-built .slpkg).
+      # These crates are pure-repr / engine-free, so they add no flaky or GPU tests.
+      # streamlib-engine's lib tests (host-body tier-1 + engine twin) are a tracked
+      # follow-up, pending a fix to a parallel-run test flake.
       - name: Run unit tests
-        run: cargo test --locked -p streamlib --lib
+        run: cargo test --locked -p streamlib -p streamlib-plugin-abi -p streamlib-plugin-sdk --lib


### PR DESCRIPTION
## What & why
The CI unit-test gate ran `cargo test -p streamlib --lib` — the **facade crate, ~0 tests**. So the **plugin-ABI layout-regression, fingerprint, twin-drift, and tier-1 wire-format tests** — the guards against silent ABI layout drift (the class that corrupts the NVIDIA driver only when a *separately-built* `.slpkg` loads) — were **not actually running in CI**. This milestone is heavily ABI-layout-dependent, so that was the load-bearing safety net not wired to the gate.

This adds `streamlib-plugin-abi` + `streamlib-plugin-sdk` to the unit-test command. Both are pure-repr / engine-free — no flaky, no GPU tests (verified on `main`: 33 tests, 0 failed, instant).

## Deferred (filed separately)
`streamlib-engine`'s lib tests (host-body tier-1 + engine twin) are **not** added here — that expansion reds on the `audio_clock` parallel-run flake, so it's blocked on that fix. Both are filed into the CI & Test Infrastructure milestone.

Covers the critical part now; the rest is filed.
