### PR TITLE
feat(plugin-sdk): OPAQUE_FD/CUDA producer mechanism over the plugin ABI (#1262)

### DIFF
--- a/runtime/streamlib-engine/src/core/context/gpu_context.rs
+++ b/runtime/streamlib-engine/src/core/context/gpu_context.rs
@@ -1791,9 +1791,17 @@ impl GpuContext {
         &self,
         buffer: &crate::core::rhi::StorageBuffer,
     ) -> Result<(std::os::unix::io::RawFd, u64, [u8; 16])> {
-        let fd = buffer.host_inner().export_opaque_fd_memory()?;
+        let host_inner = buffer.host_inner();
+        let fd = host_inner.export_opaque_fd_memory()?;
         let size = buffer.byte_size();
-        let uuid = self.device.inner.physical_device_uuid();
+        // The UUID is the entire CUDA device-binding contract: it MUST
+        // name the device that actually owns the exported memory, not the
+        // `GpuContext`'s own device. Under the single-GPU invariant these
+        // are the same, but sourcing from the buffer's owning
+        // `HostVulkanDevice` keeps the binding correct if a `StorageBuffer`
+        // ever originates from a different device (never a silent
+        // mismatch).
+        let uuid = host_inner.vulkan_device().physical_device_uuid();
         Ok((fd, size, uuid))
     }
 
@@ -1857,9 +1865,36 @@ impl GpuContext {
             source_texture.height(),
         );
         recorder.record_copy_image_to_buffer(source_texture, source_layout, dst, region)?;
+        // Every branch must leave the shared-buffer write with a defined
+        // completion contract before returning — the single-writer
+        // producer copy is unsound otherwise (a consumer could read a
+        // half-written buffer). Two contracts are valid: a `produce_done`
+        // GPU signal that the consumer waits on (the async per-frame
+        // path), or a host-side fence drain. Handle all four
+        // (consume, produce) combinations explicitly so none returns
+        // without one.
         match (consume_done, produce_done) {
+            // No timelines: bare submit + host-side fence drain. The copy
+            // is complete before return.
             (None, None) => recorder.submit_and_wait(),
-            (wait, signal) => recorder.submit_waiting_and_signaling_timeline(wait, signal),
+            // A `produce_done` signal is present (with or without a
+            // `consume_done` wait): the GPU-side signal IS the completion
+            // contract — the consumer waits on `produce_done` before its
+            // read — so the producer need not host-block. Covers
+            // (None, Some) and (Some, Some).
+            (consume, produce @ Some(_)) => {
+                recorder.submit_waiting_and_signaling_timeline(consume, produce)
+            }
+            // A `consume_done` wait but no `produce_done` signal: the copy
+            // GPU-waits on `consume_done`, but with no signal there is no
+            // GPU-side ordering for the consumer. Host-block on the
+            // recorder's completion fence so the shared-buffer write is
+            // guaranteed done before return, keeping the single-writer
+            // contract sound.
+            (consume @ Some(_), None) => {
+                recorder.submit_waiting_and_signaling_timeline(consume, None)?;
+                recorder.wait_for_completion()
+            }
         }
     }
 

--- a/runtime/streamlib-engine/src/core/context/gpu_context.rs
+++ b/runtime/streamlib-engine/src/core/context/gpu_context.rs
@@ -5878,6 +5878,208 @@ mod tests {
         println!("OPAQUE_FD mint/export/wrap OK — byte_size={BYTES} uuid={uuid:02x?}");
     }
 
+    /// #1262 followup #1 — the ONLY positive coverage of the batch's
+    /// riskiest FullAccess slot, `copy_texture_to_storage_buffer_and_signal`.
+    ///
+    /// Drives the REAL host vtable body
+    /// (`HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE`), not the plain
+    /// `GpuContext` method — that body reconstructs a borrowed source
+    /// `Texture` from a raw inner-Arc handle via
+    /// `Arc::increment_strong_count` + `Texture::from_arc_into_raw`,
+    /// records the image->buffer copy, and host-blocks on the
+    /// null-timeline submit path. Two locks:
+    ///   (a) the destination OPAQUE_FD `StorageBuffer` bytes equal the
+    ///       known source contents after the copy;
+    ///   (b) the source texture's inner-Arc strong count is identical
+    ///       before and after the call — the
+    ///       `increment_strong_count`/`from_arc_into_raw` borrow must be
+    ///       balanced by exactly one `Texture::Drop`.
+    ///
+    /// Mental-revert: if the host body leaked one strong count (dropped
+    /// the balancing `Texture::Drop`, or double-incremented), the
+    /// strong-count equality assertion fails — a use-after-free / leak
+    /// this test catches. GPU-gated: skips cleanly with no device (CI is
+    /// GPU-free), so it does not run in the sandbox — it is a
+    /// /verify-live regression.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn copy_texture_to_storage_buffer_and_signal_positive_and_refcount_balance() {
+        use std::ffi::c_void;
+        use std::sync::Arc;
+
+        let gpu = match GpuContext::init_for_platform() {
+            Ok(g) => Arc::new(g),
+            Err(_) => {
+                println!("Skipping - no GPU device available");
+                return;
+            }
+        };
+
+        const W: u32 = 32;
+        const H: u32 = 32;
+        const BPP: u32 = 4;
+        const BYTES: u64 = (W as u64) * (H as u64) * (BPP as u64);
+
+        // HOST_VISIBLE OPAQUE_FD staging + destination buffers. Skip the
+        // whole test if the pool is unavailable on this driver rather
+        // than failing the suite (mirrors the sibling OPAQUE_FD
+        // regression's skip-clean shape).
+        let staging = match gpu.create_opaque_fd_export_buffer(BYTES, false) {
+            Ok(s) => s,
+            Err(e) => {
+                println!("Skipping - OPAQUE_FD export pool unavailable: {e}");
+                return;
+            }
+        };
+        let dst = match gpu.create_opaque_fd_export_buffer(BYTES, false) {
+            Ok(s) => s,
+            Err(e) => {
+                println!("Skipping - OPAQUE_FD export pool unavailable: {e}");
+                return;
+            }
+        };
+
+        // Known source pattern written into the host-visible staging map.
+        let staging_ptr = staging.mapped_ptr();
+        assert!(
+            !staging_ptr.is_null(),
+            "HOST_VISIBLE staging buffer must expose a mapping"
+        );
+        for i in 0..BYTES as usize {
+            unsafe { *staging_ptr.add(i) = (i % 251) as u8 };
+        }
+
+        // Source texture, filled from the staging buffer and left in
+        // GENERAL — a legal copy-source layout (the landed slot copies
+        // directly from whatever `source_layout` the caller passes,
+        // recording no transition).
+        let desc = TextureDescriptor::new(W, H, TextureFormat::Rgba8Unorm).with_usage(
+            TextureUsages::COPY_DST | TextureUsages::COPY_SRC | TextureUsages::TEXTURE_BINDING,
+        );
+        let source_texture = match gpu.device().create_texture_local(&desc) {
+            Ok(t) => t,
+            Err(e) => {
+                println!("Skipping - source texture allocation failed: {e}");
+                return;
+            }
+        };
+
+        {
+            use crate::vulkan::rhi::{VulkanAccess, VulkanStage};
+            let mut fill = crate::vulkan::rhi::RhiCommandRecorderInner::new(
+                &gpu.device().inner,
+                "copy_slot_regression_fill_source",
+            )
+            .expect("fill recorder");
+            fill.begin().expect("fill begin");
+            fill.record_image_barrier(
+                &source_texture,
+                VulkanLayout::UNDEFINED,
+                VulkanLayout::TRANSFER_DST_OPTIMAL,
+                VulkanStage::TOP_OF_PIPE,
+                VulkanStage::ALL_TRANSFER,
+                VulkanAccess::NONE,
+                VulkanAccess::TRANSFER_WRITE,
+            )
+            .expect("barrier UNDEFINED -> TRANSFER_DST");
+            fill.record_copy_buffer_to_image(
+                &staging,
+                &source_texture,
+                VulkanLayout::TRANSFER_DST_OPTIMAL,
+                crate::vulkan::rhi::ImageCopyRegion::tightly_packed(W, H),
+            )
+            .expect("copy staging -> source image");
+            fill.record_image_barrier(
+                &source_texture,
+                VulkanLayout::TRANSFER_DST_OPTIMAL,
+                VulkanLayout::GENERAL,
+                VulkanStage::ALL_TRANSFER,
+                VulkanStage::ALL_TRANSFER,
+                VulkanAccess::TRANSFER_WRITE,
+                VulkanAccess::TRANSFER_READ,
+            )
+            .expect("barrier TRANSFER_DST -> GENERAL");
+            fill.submit_and_wait().expect("fill submit_and_wait");
+        }
+
+        // Measure the source texture's inner-Arc strong count without
+        // disturbing it (bump, reconstruct, read, drop — net zero). The
+        // absolute value is immaterial; only before == after is asserted.
+        let strong_count = |texture: &crate::core::rhi::Texture| -> usize {
+            let ptr = texture.handle as *const crate::core::rhi::texture::TextureInner;
+            unsafe {
+                Arc::increment_strong_count(ptr);
+                let arc = Arc::from_raw(ptr);
+                let count = Arc::strong_count(&arc);
+                drop(arc);
+                count
+            }
+        };
+        let count_before = strong_count(&source_texture);
+
+        // Mint a full escalate scope token bound to this context, then
+        // drive the REAL host vtable body so the dangerous
+        // Arc-reconstruction path actually runs (the plain `GpuContext`
+        // method borrows `&Texture` directly and would not exercise it).
+        let token =
+            crate::core::context::escalate_scope_registry::begin_escalate_scope(gpu.clone());
+
+        let mut err_buf = vec![0u8; 512];
+        let mut err_len: usize = 0;
+        let rc = unsafe {
+            (crate::core::plugin::host_services::HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE
+                .copy_texture_to_storage_buffer_and_signal)(
+                token as *const c_void,
+                source_texture.handle,
+                VulkanLayout::GENERAL.0,
+                &dst as *const crate::core::rhi::StorageBuffer as *const c_void,
+                std::ptr::null(), // consume_done: none -> host-blocking submit_and_wait
+                0,
+                std::ptr::null(), // produce_done: none
+                0,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len,
+            )
+        };
+
+        let count_after = strong_count(&source_texture);
+        crate::core::context::escalate_scope_registry::end_escalate_scope(token);
+
+        let err = String::from_utf8_lossy(&err_buf[..err_len]).into_owned();
+        assert_eq!(
+            rc, 0,
+            "copy_texture_to_storage_buffer_and_signal returned error: {err}"
+        );
+
+        // (b) THE crucial lock: host-side Arc reconstruction refcount
+        // balance. increment_strong_count + from_arc_into_raw must be
+        // balanced by exactly one Texture::Drop.
+        assert_eq!(
+            count_before, count_after,
+            "host-side Arc reconstruction (increment_strong_count + from_arc_into_raw) must be \
+             balanced by exactly one Texture::Drop; a leak or double-decrement is a \
+             use-after-free / leak bug"
+        );
+
+        // (a) destination bytes equal the known source contents.
+        let dst_ptr = dst.mapped_ptr();
+        assert!(
+            !dst_ptr.is_null(),
+            "HOST_VISIBLE destination buffer must expose a mapping"
+        );
+        for i in 0..BYTES as usize {
+            let got = unsafe { *dst_ptr.add(i) };
+            let want = (i % 251) as u8;
+            assert_eq!(got, want, "destination byte {i} mismatch: got {got}, want {want}");
+        }
+
+        println!(
+            "copy_texture_to_storage_buffer_and_signal OK — {BYTES} bytes copied, \
+             strong_count balanced ({count_before} -> {count_after})"
+        );
+    }
+
     #[test]
     #[cfg(target_os = "linux")]
     fn test_register_texture_with_layout_round_trip() {

--- a/runtime/streamlib-engine/src/core/context/gpu_context.rs
+++ b/runtime/streamlib-engine/src/core/context/gpu_context.rs
@@ -1752,6 +1752,117 @@ impl GpuContext {
         ))
     }
 
+    /// Allocate an OPAQUE_FD-exportable `VkBuffer` as a `StorageBuffer`.
+    /// `device_local = true` picks the VRAM-resident CUDA-visible pool
+    /// (`new_opaque_fd_export_device_local`); `false` picks the
+    /// HOST_VISIBLE pool (`new_opaque_fd_export`). Backs
+    /// [`GpuContextFullAccess::create_opaque_fd_export_buffer`], the
+    /// cdylib-safe OPAQUE_FD/CUDA producer allocation (#1262).
+    #[cfg(target_os = "linux")]
+    pub fn create_opaque_fd_export_buffer(
+        &self,
+        byte_size: u64,
+        device_local: bool,
+    ) -> Result<crate::core::rhi::StorageBuffer> {
+        let vulkan_device = &self.device.inner;
+        let buf = if device_local {
+            crate::vulkan::rhi::HostVulkanBuffer::new_opaque_fd_export_device_local(
+                vulkan_device,
+                byte_size,
+            )?
+        } else {
+            crate::vulkan::rhi::HostVulkanBuffer::new_opaque_fd_export(vulkan_device, byte_size)?
+        };
+        Ok(crate::core::rhi::StorageBuffer::from_host_vulkan_buffer(
+            Arc::new(buf),
+        ))
+    }
+
+    /// Export a fresh dup'd OPAQUE_FD from `buffer` plus its byte size
+    /// and the exporting device's `VkPhysicalDeviceIDProperties::deviceUUID`.
+    /// The fd ownership transfers to the caller; the 16-byte UUID is the
+    /// entire CUDA device-binding contract on multi-GPU rigs (a cdylib
+    /// CUDA adapter matches the CUDA device whose `cudaDeviceProp::uuid`
+    /// equals this value, never a silent fall-through to CUDA device 0).
+    /// Backs [`GpuContextFullAccess::export_storage_buffer_opaque_fd`]
+    /// (#1262).
+    #[cfg(target_os = "linux")]
+    pub fn export_storage_buffer_opaque_fd(
+        &self,
+        buffer: &crate::core::rhi::StorageBuffer,
+    ) -> Result<(std::os::unix::io::RawFd, u64, [u8; 16])> {
+        let fd = buffer.host_inner().export_opaque_fd_memory()?;
+        let size = buffer.byte_size();
+        let uuid = self.device.inner.physical_device_uuid();
+        Ok((fd, size, uuid))
+    }
+
+    /// Wrap an existing OPAQUE_FD `StorageBuffer` (flat `VkBuffer`) as a
+    /// `PixelBuffer` sharing the same `Arc<HostVulkanBuffer>`, so the flat
+    /// CUDA buffer can register through the existing
+    /// `SurfaceStore::register_pixel_buffer_with_timeline` path. Backs
+    /// [`GpuContextFullAccess::wrap_storage_buffer_as_pixel_buffer`]
+    /// (#1262).
+    #[cfg(target_os = "linux")]
+    pub fn wrap_storage_buffer_as_pixel_buffer(
+        &self,
+        storage_buffer: &crate::core::rhi::StorageBuffer,
+        width: u32,
+        height: u32,
+        bytes_per_pixel: u32,
+        format: crate::core::rhi::PixelFormat,
+    ) -> Result<crate::core::rhi::PixelBuffer> {
+        let inner = storage_buffer.host_inner_arc();
+        Ok(crate::core::rhi::PixelBuffer::from_host_vulkan_buffer(
+            inner,
+            width,
+            height,
+            bytes_per_pixel,
+            format,
+        ))
+    }
+
+    /// Per-frame CUDA producer copy: in one host-device submission,
+    /// optionally GPU-wait `consume_done` (`(timeline, wait_value)`),
+    /// `vkCmdCopyImageToBuffer` from `source_texture` (currently in
+    /// `source_layout`) into `dst`, then optionally signal `produce_done`
+    /// (`(timeline, signal_value)`) on completion. When both timelines
+    /// are `None` the submission blocks host-side via `submit_and_wait`.
+    /// Backs
+    /// [`GpuContextFullAccess::copy_texture_to_storage_buffer_and_signal`]
+    /// (#1262).
+    ///
+    /// The source is copied directly from `source_layout` (the camera
+    /// leaves ring textures in `GENERAL`, a legal copy-source layout), so
+    /// no extra layout transition is recorded — the timeline signal's
+    /// completion guarantee is what orders the buffer write ahead of the
+    /// consumer's `acquire_read`.
+    #[cfg(target_os = "linux")]
+    pub fn copy_texture_to_storage_buffer_and_signal(
+        &self,
+        source_texture: &crate::core::rhi::Texture,
+        source_layout: crate::core::rhi::VulkanLayout,
+        dst: &crate::core::rhi::StorageBuffer,
+        consume_done: Option<(&crate::vulkan::rhi::HostVulkanTimelineSemaphore, u64)>,
+        produce_done: Option<(&crate::vulkan::rhi::HostVulkanTimelineSemaphore, u64)>,
+    ) -> Result<()> {
+        let vulkan_device = &self.device.inner;
+        let mut recorder = crate::vulkan::rhi::RhiCommandRecorderInner::new(
+            vulkan_device,
+            "copy_texture_to_storage_buffer_and_signal",
+        )?;
+        recorder.begin()?;
+        let region = crate::vulkan::rhi::ImageCopyRegion::tightly_packed(
+            source_texture.width(),
+            source_texture.height(),
+        );
+        recorder.record_copy_image_to_buffer(source_texture, source_layout, dst, region)?;
+        match (consume_done, produce_done) {
+            (None, None) => recorder.submit_and_wait(),
+            (wait, signal) => recorder.submit_waiting_and_signaling_timeline(wait, signal),
+        }
+    }
+
     /// Transition `texture` into `VK_IMAGE_LAYOUT_GENERAL` via a
     /// one-shot command buffer + fence. Used as the prelude to binding
     /// a freshly-created storage image to a compute / RT kernel that
@@ -5105,6 +5216,228 @@ impl GpuContextFullAccess {
         }
     }
 
+    /// Allocate an OPAQUE_FD-exportable `VkBuffer` as a `StorageBuffer`
+    /// (`device_local` picks VRAM-resident vs HOST_VISIBLE). The
+    /// cdylib-safe OPAQUE_FD/CUDA producer allocation (#1262). Mode-routed:
+    /// host-mode via `host_inner()`, cdylib-mode via the
+    /// `create_opaque_fd_export_buffer` slot.
+    #[cfg(target_os = "linux")]
+    pub fn create_opaque_fd_export_buffer(
+        &self,
+        byte_size: u64,
+        device_local: bool,
+    ) -> Result<crate::core::rhi::StorageBuffer> {
+        match self.handle_kind {
+            HandleKind::Boxed => self
+                .host_inner()
+                .create_opaque_fd_export_buffer(byte_size, device_local),
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return Err(Error::GpuError(
+                        "create_opaque_fd_export_buffer: GpuContextFullAccess has null vtable".into(),
+                    ));
+                }
+                let mut out_buffer: std::mem::MaybeUninit<crate::core::rhi::StorageBuffer> =
+                    std::mem::MaybeUninit::uninit();
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                let status = unsafe {
+                    ((*self.vtable).create_opaque_fd_export_buffer)(
+                        self.handle,
+                        byte_size,
+                        u8::from(device_local),
+                        out_buffer.as_mut_ptr() as *mut std::ffi::c_void,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if status == 0 {
+                    // SAFETY: host signaled success and wrote the
+                    // StorageBuffer PluginAbiObject into the slot.
+                    Ok(unsafe { out_buffer.assume_init() })
+                } else {
+                    let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                        .into_owned();
+                    Err(Error::GpuError(msg))
+                }
+            }
+        }
+    }
+
+    /// Export a fresh dup'd OPAQUE_FD + byte size + exporting-device UUID
+    /// from a `StorageBuffer`. The fd transfers to the caller. Mode-routed:
+    /// host-mode via `host_inner()`, cdylib-mode via the
+    /// `export_storage_buffer_opaque_fd` slot (decoding the
+    /// [`OpaqueFdExportDescriptorRepr`](streamlib_plugin_abi::OpaqueFdExportDescriptorRepr)).
+    #[cfg(target_os = "linux")]
+    pub fn export_storage_buffer_opaque_fd(
+        &self,
+        buffer: &crate::core::rhi::StorageBuffer,
+    ) -> Result<(std::os::unix::io::RawFd, u64, [u8; 16])> {
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().export_storage_buffer_opaque_fd(buffer),
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return Err(Error::GpuError(
+                        "export_storage_buffer_opaque_fd: GpuContextFullAccess has null vtable"
+                            .into(),
+                    ));
+                }
+                let mut descriptor = streamlib_plugin_abi::OpaqueFdExportDescriptorRepr::default();
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                let status = unsafe {
+                    ((*self.vtable).export_storage_buffer_opaque_fd)(
+                        self.handle,
+                        buffer as *const _ as *const std::ffi::c_void,
+                        &mut descriptor,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if status == 0 {
+                    Ok((descriptor.fd, descriptor.size, descriptor.device_uuid))
+                } else {
+                    let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                        .into_owned();
+                    Err(Error::GpuError(msg))
+                }
+            }
+        }
+    }
+
+    /// Wrap an OPAQUE_FD `StorageBuffer` as a `PixelBuffer` sharing the
+    /// same allocation so it can register through the surface-store
+    /// `register_pixel_buffer_with_timeline` path (#1262). Mode-routed:
+    /// host-mode via `host_inner()`, cdylib-mode via the
+    /// `wrap_storage_buffer_as_pixel_buffer` slot.
+    #[cfg(target_os = "linux")]
+    pub fn wrap_storage_buffer_as_pixel_buffer(
+        &self,
+        storage_buffer: &crate::core::rhi::StorageBuffer,
+        width: u32,
+        height: u32,
+        bytes_per_pixel: u32,
+        format: crate::core::rhi::PixelFormat,
+    ) -> Result<crate::core::rhi::PixelBuffer> {
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().wrap_storage_buffer_as_pixel_buffer(
+                storage_buffer,
+                width,
+                height,
+                bytes_per_pixel,
+                format,
+            ),
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return Err(Error::GpuError(
+                        "wrap_storage_buffer_as_pixel_buffer: GpuContextFullAccess has null vtable"
+                            .into(),
+                    ));
+                }
+                let mut out_pixel_buffer: std::mem::MaybeUninit<crate::core::rhi::PixelBuffer> =
+                    std::mem::MaybeUninit::uninit();
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                let status = unsafe {
+                    ((*self.vtable).wrap_storage_buffer_as_pixel_buffer)(
+                        self.handle,
+                        storage_buffer as *const _ as *const std::ffi::c_void,
+                        width,
+                        height,
+                        bytes_per_pixel,
+                        format as u32,
+                        out_pixel_buffer.as_mut_ptr() as *mut std::ffi::c_void,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if status == 0 {
+                    // SAFETY: host signaled success and wrote the PixelBuffer
+                    // PluginAbiObject into the slot.
+                    Ok(unsafe { out_pixel_buffer.assume_init() })
+                } else {
+                    let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                        .into_owned();
+                    Err(Error::GpuError(msg))
+                }
+            }
+        }
+    }
+
+    /// Per-frame CUDA producer copy: image→buffer in one host-device
+    /// submission with optional `consume_done` wait + `produce_done`
+    /// signal (#1262). Mode-routed: host-mode via `host_inner()`,
+    /// cdylib-mode via the `copy_texture_to_storage_buffer_and_signal`
+    /// slot (marshalling the texture PluginAbiObject handle + timeline
+    /// inner-Arc pointers).
+    #[cfg(target_os = "linux")]
+    pub fn copy_texture_to_storage_buffer_and_signal(
+        &self,
+        source_texture: &crate::core::rhi::Texture,
+        source_layout: crate::core::rhi::VulkanLayout,
+        dst: &crate::core::rhi::StorageBuffer,
+        consume_done: Option<(&crate::vulkan::rhi::HostVulkanTimelineSemaphore, u64)>,
+        produce_done: Option<(&crate::vulkan::rhi::HostVulkanTimelineSemaphore, u64)>,
+    ) -> Result<()> {
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().copy_texture_to_storage_buffer_and_signal(
+                source_texture,
+                source_layout,
+                dst,
+                consume_done,
+                produce_done,
+            ),
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return Err(Error::GpuError(
+                        "copy_texture_to_storage_buffer_and_signal: GpuContextFullAccess has null vtable"
+                            .into(),
+                    ));
+                }
+                let (consume_handle, consume_value) = match consume_done {
+                    Some((sem, value)) => {
+                        (sem as *const _ as *const std::ffi::c_void, value)
+                    }
+                    None => (std::ptr::null(), 0),
+                };
+                let (produce_handle, produce_value) = match produce_done {
+                    Some((sem, value)) => {
+                        (sem as *const _ as *const std::ffi::c_void, value)
+                    }
+                    None => (std::ptr::null(), 0),
+                };
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                let status = unsafe {
+                    ((*self.vtable).copy_texture_to_storage_buffer_and_signal)(
+                        self.handle,
+                        source_texture.handle,
+                        source_layout.0,
+                        dst as *const _ as *const std::ffi::c_void,
+                        consume_handle,
+                        consume_value,
+                        produce_handle,
+                        produce_value,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if status == 0 {
+                    Ok(())
+                } else {
+                    let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                        .into_owned();
+                    Err(Error::GpuError(msg))
+                }
+            }
+        }
+    }
+
     /// Construct a timeline semaphore. Backs the camera processor's
     /// per-frame timeline that signals into downstream consumers
     /// (display, encoders). Mode-routed: host-mode dispatches through
@@ -5470,6 +5803,79 @@ mod tests {
         assert_eq!(resolved.height(), 480);
 
         println!("Texture cache: register + resolve OK");
+    }
+
+    /// #1262 OPAQUE_FD/CUDA producer surface — positive mint/export/wrap
+    /// path plus the zeroed-cached-fields regression.
+    ///
+    /// Mental-revert: if `create_opaque_fd_export_buffer` built the
+    /// `StorageBuffer` with a zeroed `byte_size_cached` (the silent
+    /// all-zero borrow hazard — `docs/learnings/cdylib-make-borrow-cached-fields.md`),
+    /// the `byte_size() == BYTES` assertion below fails immediately —
+    /// with no panic, no export error, just a wrong cached POD. GPU-gated:
+    /// skips when no device is present (CI is GPU-free).
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn opaque_fd_export_buffer_mint_export_wrap_and_non_zero_cache() {
+        let gpu = match GpuContext::init_for_platform() {
+            Ok(g) => g,
+            Err(_) => {
+                println!("Skipping - no GPU device available");
+                return;
+            }
+        };
+
+        const W: u32 = 32;
+        const H: u32 = 32;
+        const BPP: u32 = 4;
+        const BYTES: u64 = (W as u64) * (H as u64) * (BPP as u64);
+
+        // HOST_VISIBLE OPAQUE_FD flavor is broadly available; the
+        // DEVICE_LOCAL CUDA flavor rides the same code path with a
+        // different pool. Skip if the OPAQUE_FD pool is unavailable on
+        // this driver rather than failing the suite.
+        let storage = match gpu.create_opaque_fd_export_buffer(BYTES, false) {
+            Ok(s) => s,
+            Err(e) => {
+                println!("Skipping - OPAQUE_FD export pool unavailable: {e}");
+                return;
+            }
+        };
+
+        // Zeroed-cached-fields regression: the cached byte size must be
+        // the real allocation size, never 0.
+        assert_eq!(
+            storage.byte_size(),
+            BYTES,
+            "StorageBuffer.byte_size_cached must carry the real allocation size (zeroed-cache regression)"
+        );
+        assert!(
+            !storage.mapped_ptr().is_null(),
+            "HOST_VISIBLE OPAQUE_FD buffer must expose a persistent mapping"
+        );
+
+        // Export → fresh dup'd fd + size + device UUID.
+        let (fd, size, uuid) = gpu
+            .export_storage_buffer_opaque_fd(&storage)
+            .expect("export_storage_buffer_opaque_fd failed");
+        assert!(fd >= 0, "exported OPAQUE_FD must be non-negative, got {fd}");
+        assert_eq!(size, BYTES, "exported size must equal the allocation size");
+        assert!(
+            uuid.iter().any(|b| *b != 0),
+            "device UUID must not be all-zero — CUDA device binding depends on it, got {uuid:02x?}"
+        );
+        // The caller owns the dup'd fd; close it so the test leaks nothing.
+        unsafe { libc::close(fd) };
+
+        // Wrap → PixelBuffer sharing the same allocation, with the
+        // caller's pixel-shape metadata cached.
+        let pixel_buffer = gpu
+            .wrap_storage_buffer_as_pixel_buffer(&storage, W, H, BPP, crate::core::rhi::PixelFormat::Bgra32)
+            .expect("wrap_storage_buffer_as_pixel_buffer failed");
+        assert_eq!(pixel_buffer.width, W);
+        assert_eq!(pixel_buffer.height, H);
+
+        println!("OPAQUE_FD mint/export/wrap OK — byte_size={BYTES} uuid={uuid:02x?}");
     }
 
     #[test]

--- a/runtime/streamlib-engine/src/core/plugin/host_services/gpu_context/full/reserved_m32.rs
+++ b/runtime/streamlib-engine/src/core/plugin/host_services/gpu_context/full/reserved_m32.rs
@@ -533,7 +533,11 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_cr
     err_buf_cap: usize,
     err_len: *mut usize,
 ) -> i32 {
-    write_err_non_linux("create_opaque_fd_export_buffer", err_buf, err_buf_cap, err_len)
+    run_host_extern_c(
+        "host_gpu_full_create_opaque_fd_export_buffer",
+        || write_err_non_linux("create_opaque_fd_export_buffer", err_buf, err_buf_cap, err_len),
+        1,
+    )
 }
 
 #[cfg(target_os = "linux")]
@@ -609,15 +613,21 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_ex
     err_buf_cap: usize,
     err_len: *mut usize,
 ) -> i32 {
-    if !out_descriptor.is_null() {
-        // SAFETY: caller-provided out-pointer.
-        unsafe { (*out_descriptor).fd = -1 };
-    }
-    write_err_non_linux(
-        "export_storage_buffer_opaque_fd",
-        err_buf,
-        err_buf_cap,
-        err_len,
+    run_host_extern_c(
+        "host_gpu_full_export_storage_buffer_opaque_fd",
+        || -> i32 {
+            if !out_descriptor.is_null() {
+                // SAFETY: caller-provided out-pointer.
+                unsafe { (*out_descriptor).fd = -1 };
+            }
+            write_err_non_linux(
+                "export_storage_buffer_opaque_fd",
+                err_buf,
+                err_buf_cap,
+                err_len,
+            )
+        },
+        1,
     )
 }
 
@@ -663,6 +673,50 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_wr
             };
             // SAFETY: borrowed `*const StorageBuffer` for the call.
             let sb = unsafe { &*(storage_buffer as *const crate::core::rhi::StorageBuffer) };
+            // Reject degenerate / out-of-bounds pixel shapes BEFORE
+            // `PixelBuffer::from_host_vulkan_buffer` caches the dims. A
+            // `PixelBuffer` whose cached `width*height*bytes_per_pixel`
+            // claims more bytes than the backing OPAQUE_FD `VkBuffer`
+            // holds would let a downstream consumer read past the
+            // allocation (silent OOB read, no panic / validation
+            // complaint). Symmetric with `create_opaque_fd_export_buffer`'s
+            // `byte_size > 0` guard. `sb.byte_size()` is a pure cached-POD
+            // read (no ABI hop, no handle deref).
+            if width == 0 || height == 0 || bytes_per_pixel == 0 {
+                write_err(
+                    &format!(
+                        "wrap_storage_buffer_as_pixel_buffer: zero dimension \
+                         (width={width}, height={height}, bytes_per_pixel={bytes_per_pixel})"
+                    ),
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let required_bytes = (width as u64)
+                .checked_mul(height as u64)
+                .and_then(|wh| wh.checked_mul(bytes_per_pixel as u64));
+            match required_bytes {
+                Some(required) if required <= sb.byte_size() => {}
+                _ => {
+                    write_err(
+                        &format!(
+                            "wrap_storage_buffer_as_pixel_buffer: pixel shape \
+                             {width}x{height}x{bytes_per_pixel} requires {} bytes, \
+                             exceeds storage buffer byte_size {}",
+                            required_bytes
+                                .map(|r| r.to_string())
+                                .unwrap_or_else(|| "u64-overflow".to_string()),
+                            sb.byte_size()
+                        ),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    return 1;
+                }
+            }
             let result = with_full_scope_or_err(
                 scope_token,
                 "wrap_storage_buffer_as_pixel_buffer",
@@ -714,11 +768,17 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_wr
     err_buf_cap: usize,
     err_len: *mut usize,
 ) -> i32 {
-    write_err_non_linux(
-        "wrap_storage_buffer_as_pixel_buffer",
-        err_buf,
-        err_buf_cap,
-        err_len,
+    run_host_extern_c(
+        "host_gpu_full_wrap_storage_buffer_as_pixel_buffer",
+        || {
+            write_err_non_linux(
+                "wrap_storage_buffer_as_pixel_buffer",
+                err_buf,
+                err_buf_cap,
+                err_len,
+            )
+        },
+        1,
     )
 }
 
@@ -842,11 +902,17 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_co
     err_buf_cap: usize,
     err_len: *mut usize,
 ) -> i32 {
-    write_err_non_linux(
-        "copy_texture_to_storage_buffer_and_signal",
-        err_buf,
-        err_buf_cap,
-        err_len,
+    run_host_extern_c(
+        "host_gpu_full_copy_texture_to_storage_buffer_and_signal",
+        || {
+            write_err_non_linux(
+                "copy_texture_to_storage_buffer_and_signal",
+                err_buf,
+                err_buf_cap,
+                err_len,
+            )
+        },
+        1,
     )
 }
 
@@ -1303,9 +1369,14 @@ mod reserved_m32_wire_format_tests {
     fn wrap_storage_buffer_as_pixel_buffer_rejects_null_scope_token() {
         let (mut buf, mut len) = make_err_buf();
         let mut out = [0u8; 64];
-        // Aligned 32-byte backing so a `&StorageBuffer` can be formed
-        // (never read) ahead of the null-scope check.
-        let backing = [0u64; 4];
+        // Aligned 32-byte `StorageBuffer`-shaped backing whose cached
+        // `byte_size` (offset 16 → `[u64; 4]` index 2) is large enough
+        // to clear the dimension guard, so the null-scope check is what
+        // fires — not the zero-dim / oversized guards ahead of it.
+        // `byte_size()` is a pure POD read of this field (no handle
+        // deref).
+        let mut backing = [0u64; 4];
+        backing[2] = 64 * 64 * 4; // byte_size_cached
         let storage_ptr = backing.as_ptr() as *const c_void;
         let rc = unsafe {
             (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.wrap_storage_buffer_as_pixel_buffer)(
@@ -1325,6 +1396,78 @@ mod reserved_m32_wire_format_tests {
         assert!(
             err_buf_as_str(&buf, len)
                 .contains("wrap_storage_buffer_as_pixel_buffer: invalid escalate scope"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn wrap_storage_buffer_as_pixel_buffer_rejects_zero_dimension() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut out = [0u8; 64];
+        // Aligned `StorageBuffer`-shaped backing with a generous cached
+        // byte_size — the zero-dimension guard must fire before the
+        // oversized guard and before scope resolution.
+        let mut backing = [0u64; 4];
+        backing[2] = 1 << 20; // byte_size_cached
+        let storage_ptr = backing.as_ptr() as *const c_void;
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.wrap_storage_buffer_as_pixel_buffer)(
+                std::ptr::null(),
+                storage_ptr,
+                0, // zero width
+                64,
+                4,
+                0x42475241, // Bgra32 (valid — pushes past the format decode)
+                out.as_mut_ptr() as *mut c_void,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("wrap_storage_buffer_as_pixel_buffer: zero dimension"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn wrap_storage_buffer_as_pixel_buffer_rejects_oversized_shape() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut out = [0u8; 64];
+        // Aligned `StorageBuffer`-shaped backing whose cached byte_size
+        // (4096) is smaller than the requested pixel shape
+        // (64*64*4 = 16384) — the oversized guard must fire, blocking a
+        // `PixelBuffer` that would claim more bytes than the backing
+        // OPAQUE_FD buffer holds.
+        let mut backing = [0u64; 4];
+        backing[2] = 4096; // byte_size_cached < 64*64*4
+        let storage_ptr = backing.as_ptr() as *const c_void;
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.wrap_storage_buffer_as_pixel_buffer)(
+                std::ptr::null(),
+                storage_ptr,
+                64,
+                64,
+                4,
+                0x42475241, // Bgra32 (valid — pushes past the format decode)
+                out.as_mut_ptr() as *mut c_void,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len).contains(
+                "wrap_storage_buffer_as_pixel_buffer: pixel shape 64x64x4 requires 16384 bytes, \
+                 exceeds storage buffer byte_size 4096"
+            ),
             "got: {}",
             err_buf_as_str(&buf, len)
         );

--- a/runtime/streamlib-engine/src/core/plugin/host_services/gpu_context/full/reserved_m32.rs
+++ b/runtime/streamlib-engine/src/core/plugin/host_services/gpu_context/full/reserved_m32.rs
@@ -1,16 +1,26 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Reserved-but-unlanded `GpuContextFullAccessVTable` v11 host bodies
-//! (M32 one-shot slot reservation, #1253).
+//! `GpuContextFullAccessVTable` v11 host bodies (M32 one-shot slot
+//! reservation, #1253) — mixed landed + reserved.
 //!
-//! Each of the thirteen v11 slots ships a typed NotYetProvided-style
-//! stub here: a non-zero return ([`NOT_YET_PROVIDED_RC`]) + a
-//! descriptive `write_err` message, wrapped in the `run_host_extern_c`
-//! panic net — never `todo!()` / `unimplemented!()`, never an unguarded
-//! unwind across the ABI. The per-surface fill-in issues (#1258–#1262)
-//! replace these bodies against the frozen slots without touching the
-//! vtable struct again.
+//! The four OPAQUE_FD/CUDA slots (`create_opaque_fd_export_buffer`,
+//! `export_storage_buffer_opaque_fd`,
+//! `wrap_storage_buffer_as_pixel_buffer`,
+//! `copy_texture_to_storage_buffer_and_signal`) carry their real host
+//! bodies as of the #1262 fill-in: each validates its out-params +
+//! scope token, then dispatches to the resolved `Arc<GpuContext>` via
+//! [`with_full_scope_or_err`], all under the `run_host_extern_c` panic
+//! net. Linux-only; the non-Linux stubs return a typed
+//! "not available on this platform" error.
+//!
+//! The remaining reserved slots (present target #1258, hardware video
+//! #1259, exportable timeline #1260, texture readback #1261) still ship
+//! a typed NotYetProvided-style stub: a non-zero return
+//! ([`NOT_YET_PROVIDED_RC`]) + a descriptive `write_err` message, never
+//! `todo!()` / `unimplemented!()`, never an unguarded unwind across the
+//! ABI. Their per-surface fill-in issues replace those bodies against
+//! the frozen slots without touching the vtable struct again.
 //!
 //! The four drop-only slots (`drop_present_target`,
 //! `drop_encoder_session`, `drop_decoder_session`, `drop_texture_readback`)
@@ -28,6 +38,14 @@ use super::super::super::run_host_extern_c;
 use super::super::super::shared::wire::{NOT_YET_PROVIDED_RC, not_yet_provided, write_err};
 #[cfg(target_os = "linux")]
 use super::super::scope_token::with_full_scope_or_err;
+#[cfg(target_os = "linux")]
+use super::super::shared::pixel_format_from_raw;
+
+/// `VkExternalMemoryHandleTypeFlagBits::OPAQUE_FD`. Written into
+/// [`OpaqueFdExportDescriptorRepr::handle_type_raw`] so a cdylib CUDA
+/// adapter can pass the matching handle type to `cudaImportExternalMemory`.
+#[cfg(target_os = "linux")]
+const OPAQUE_FD_HANDLE_TYPE_RAW: u32 = 0x0000_0001;
 
 // ============================================================================
 // Present target (#1258)
@@ -444,8 +462,70 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_cr
 // OPAQUE_FD / CUDA buffer surface (#1262)
 // ============================================================================
 
+#[cfg(target_os = "linux")]
 pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_create_opaque_fd_export_buffer(
-    _gpu_handle: *const c_void,
+    scope_token: *const c_void,
+    byte_size: u64,
+    device_local: u8,
+    out_buffer: *mut c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_full_create_opaque_fd_export_buffer",
+        || -> i32 {
+            if out_buffer.is_null() {
+                write_err(
+                    "create_opaque_fd_export_buffer: null out_buffer pointer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            if byte_size == 0 {
+                write_err(
+                    "create_opaque_fd_export_buffer: byte_size must be > 0",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let result = with_full_scope_or_err(
+                scope_token,
+                "create_opaque_fd_export_buffer",
+                err_buf,
+                err_buf_cap,
+                err_len,
+                |gpu| gpu.create_opaque_fd_export_buffer(byte_size, device_local != 0),
+            );
+            match result {
+                Some(Ok(buf)) => {
+                    // SAFETY: host wrote the 32-byte `StorageBuffer`
+                    // PluginAbiObject into the caller's slot; its cached
+                    // `byte_size_cached` is populated by
+                    // `from_host_vulkan_buffer` (never a zeroed borrow).
+                    unsafe {
+                        std::ptr::write(out_buffer as *mut crate::core::rhi::StorageBuffer, buf);
+                    }
+                    0
+                }
+                Some(Err(e)) => {
+                    write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
+                    1
+                }
+                None => 1,
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_create_opaque_fd_export_buffer(
+    _scope_token: *const c_void,
     _byte_size: u64,
     _device_local: u8,
     _out_buffer: *mut c_void,
@@ -453,23 +533,13 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_cr
     err_buf_cap: usize,
     err_len: *mut usize,
 ) -> i32 {
-    run_host_extern_c(
-        "host_gpu_full_create_opaque_fd_export_buffer",
-        || {
-            not_yet_provided(
-                "create_opaque_fd_export_buffer",
-                err_buf,
-                err_buf_cap,
-                err_len,
-            )
-        },
-        NOT_YET_PROVIDED_RC,
-    )
+    write_err_non_linux("create_opaque_fd_export_buffer", err_buf, err_buf_cap, err_len)
 }
 
+#[cfg(target_os = "linux")]
 pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_export_storage_buffer_opaque_fd(
-    _gpu_handle: *const c_void,
-    _buffer: *const c_void,
+    scope_token: *const c_void,
+    buffer: *const c_void,
     out_descriptor: *mut OpaqueFdExportDescriptorRepr,
     err_buf: *mut u8,
     err_buf_cap: usize,
@@ -477,29 +547,163 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_ex
 ) -> i32 {
     run_host_extern_c(
         "host_gpu_full_export_storage_buffer_opaque_fd",
-        || {
-            // FD-failure convention: write `fd = -1` so a caller never
-            // reads a stale live fd from the descriptor on the error
-            // path (double-close guard).
+        || -> i32 {
+            // FD-failure convention: write `fd = -1` up-front so every
+            // error path leaves the sentinel and a caller never reads a
+            // stale live fd from the descriptor (double-close guard).
             if !out_descriptor.is_null() {
-                // SAFETY: caller-provided out-pointer; the reserved stub
-                // only writes the fd sentinel field.
+                // SAFETY: caller-provided out-pointer, writable for the
+                // descriptor.
                 unsafe { (*out_descriptor).fd = -1 };
             }
-            not_yet_provided(
+            if out_descriptor.is_null() || buffer.is_null() {
+                write_err(
+                    "export_storage_buffer_opaque_fd: null buffer / out_descriptor",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            // SAFETY: `buffer` is a borrowed `*const StorageBuffer` from
+            // the cdylib, valid for the call.
+            let sb = unsafe { &*(buffer as *const crate::core::rhi::StorageBuffer) };
+            let result = with_full_scope_or_err(
+                scope_token,
                 "export_storage_buffer_opaque_fd",
                 err_buf,
                 err_buf_cap,
                 err_len,
-            )
+                |gpu| gpu.export_storage_buffer_opaque_fd(sb),
+            );
+            match result {
+                Some(Ok((fd, size, uuid))) => {
+                    // SAFETY: out_descriptor checked non-null above.
+                    unsafe {
+                        let d = &mut *out_descriptor;
+                        d.fd = fd;
+                        d.handle_type_raw = OPAQUE_FD_HANDLE_TYPE_RAW;
+                        d.size = size;
+                        d.device_uuid = uuid;
+                    }
+                    0
+                }
+                // fd already written -1 on entry; leave it on both error paths.
+                Some(Err(e)) => {
+                    write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
+                    1
+                }
+                None => 1,
+            }
         },
-        NOT_YET_PROVIDED_RC,
+        1,
     )
 }
 
+#[cfg(not(target_os = "linux"))]
+pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_export_storage_buffer_opaque_fd(
+    _scope_token: *const c_void,
+    _buffer: *const c_void,
+    out_descriptor: *mut OpaqueFdExportDescriptorRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    if !out_descriptor.is_null() {
+        // SAFETY: caller-provided out-pointer.
+        unsafe { (*out_descriptor).fd = -1 };
+    }
+    write_err_non_linux(
+        "export_storage_buffer_opaque_fd",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    )
+}
+
+#[cfg(target_os = "linux")]
 #[allow(clippy::too_many_arguments)]
 pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_wrap_storage_buffer_as_pixel_buffer(
-    _gpu_handle: *const c_void,
+    scope_token: *const c_void,
+    storage_buffer: *const c_void,
+    width: u32,
+    height: u32,
+    bytes_per_pixel: u32,
+    format_raw: u32,
+    out_pixel_buffer: *mut c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_full_wrap_storage_buffer_as_pixel_buffer",
+        || -> i32 {
+            if out_pixel_buffer.is_null() || storage_buffer.is_null() {
+                write_err(
+                    "wrap_storage_buffer_as_pixel_buffer: null storage_buffer / out_pixel_buffer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let format = match pixel_format_from_raw(format_raw) {
+                Some(f) => f,
+                None => {
+                    write_err(
+                        &format!(
+                            "wrap_storage_buffer_as_pixel_buffer: invalid format_raw {format_raw}"
+                        ),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    return 1;
+                }
+            };
+            // SAFETY: borrowed `*const StorageBuffer` for the call.
+            let sb = unsafe { &*(storage_buffer as *const crate::core::rhi::StorageBuffer) };
+            let result = with_full_scope_or_err(
+                scope_token,
+                "wrap_storage_buffer_as_pixel_buffer",
+                err_buf,
+                err_buf_cap,
+                err_len,
+                |gpu| {
+                    gpu.wrap_storage_buffer_as_pixel_buffer(
+                        sb,
+                        width,
+                        height,
+                        bytes_per_pixel,
+                        format,
+                    )
+                },
+            );
+            match result {
+                Some(Ok(pb)) => {
+                    // SAFETY: host wrote the `PixelBuffer` PluginAbiObject
+                    // (cached width/height/format from the caller's inputs)
+                    // into the caller's slot.
+                    unsafe {
+                        std::ptr::write(out_pixel_buffer as *mut crate::core::rhi::PixelBuffer, pb);
+                    }
+                    0
+                }
+                Some(Err(e)) => {
+                    write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
+                    1
+                }
+                None => 1,
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::too_many_arguments)]
+pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_wrap_storage_buffer_as_pixel_buffer(
+    _scope_token: *const c_void,
     _storage_buffer: *const c_void,
     _width: u32,
     _height: u32,
@@ -510,23 +714,123 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_wr
     err_buf_cap: usize,
     err_len: *mut usize,
 ) -> i32 {
-    run_host_extern_c(
-        "host_gpu_full_wrap_storage_buffer_as_pixel_buffer",
-        || {
-            not_yet_provided(
-                "wrap_storage_buffer_as_pixel_buffer",
-                err_buf,
-                err_buf_cap,
-                err_len,
-            )
-        },
-        NOT_YET_PROVIDED_RC,
+    write_err_non_linux(
+        "wrap_storage_buffer_as_pixel_buffer",
+        err_buf,
+        err_buf_cap,
+        err_len,
     )
 }
 
+#[cfg(target_os = "linux")]
 #[allow(clippy::too_many_arguments)]
 pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_copy_texture_to_storage_buffer_and_signal(
-    _gpu_handle: *const c_void,
+    scope_token: *const c_void,
+    texture_handle: *const c_void,
+    source_layout_raw: i32,
+    storage_buffer: *const c_void,
+    consume_done_handle: *const c_void,
+    consume_done_wait_value: u64,
+    produce_done_handle: *const c_void,
+    produce_done_signal_value: u64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    use std::sync::Arc;
+    run_host_extern_c(
+        "host_gpu_full_copy_texture_to_storage_buffer_and_signal",
+        || -> i32 {
+            if texture_handle.is_null() || storage_buffer.is_null() {
+                write_err(
+                    "copy_texture_to_storage_buffer_and_signal: null texture_handle / storage_buffer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            // SAFETY: borrowed `*const StorageBuffer` for the call.
+            let dst = unsafe { &*(storage_buffer as *const crate::core::rhi::StorageBuffer) };
+            // Reconstruct a borrowed source `Texture` from the inner-Arc
+            // handle. `texture_handle` is the `Texture` PluginAbiObject's
+            // `handle` field — `Arc::into_raw(Arc<TextureInner>)` (same
+            // shape `host_vulkan_texture_arc` consumes). Bump the strong
+            // count, reconstruct the Arc, and re-wrap it as a `Texture`
+            // whose own `Drop` (via the limited-access `drop_texture` slot)
+            // balances the bump.
+            // SAFETY: handle is a live `Arc::into_raw(Arc<TextureInner>)`.
+            let texture = unsafe {
+                let ptr = texture_handle as *const crate::core::rhi::texture::TextureInner;
+                Arc::increment_strong_count(ptr);
+                let arc = Arc::from_raw(ptr);
+                let width = arc.width();
+                let height = arc.height();
+                let format = arc.format();
+                crate::core::rhi::Texture::from_arc_into_raw(arc, width, height, format)
+            };
+            let source_layout = crate::core::rhi::VulkanLayout(source_layout_raw);
+            // Timeline handles: null = none. A non-null handle is
+            // `Arc::into_raw(Arc<HostVulkanTimelineSemaphore>)` (the
+            // exportable-timeline PluginAbiObject's inner handle, minted by
+            // #1260); borrow without taking ownership.
+            let consume = if consume_done_handle.is_null() {
+                None
+            } else {
+                // SAFETY: borrowed timeline handle valid for the call.
+                Some((
+                    unsafe {
+                        &*(consume_done_handle
+                            as *const crate::vulkan::rhi::HostVulkanTimelineSemaphore)
+                    },
+                    consume_done_wait_value,
+                ))
+            };
+            let produce = if produce_done_handle.is_null() {
+                None
+            } else {
+                // SAFETY: borrowed timeline handle valid for the call.
+                Some((
+                    unsafe {
+                        &*(produce_done_handle
+                            as *const crate::vulkan::rhi::HostVulkanTimelineSemaphore)
+                    },
+                    produce_done_signal_value,
+                ))
+            };
+            let result = with_full_scope_or_err(
+                scope_token,
+                "copy_texture_to_storage_buffer_and_signal",
+                err_buf,
+                err_buf_cap,
+                err_len,
+                |gpu| {
+                    gpu.copy_texture_to_storage_buffer_and_signal(
+                        &texture,
+                        source_layout,
+                        dst,
+                        consume,
+                        produce,
+                    )
+                },
+            );
+            match result {
+                Some(Ok(())) => 0,
+                Some(Err(e)) => {
+                    write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
+                    1
+                }
+                None => 1,
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::too_many_arguments)]
+pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_copy_texture_to_storage_buffer_and_signal(
+    _scope_token: *const c_void,
     _texture_handle: *const c_void,
     _source_layout_raw: i32,
     _storage_buffer: *const c_void,
@@ -538,30 +842,44 @@ pub(in crate::core::plugin::host_services) unsafe extern "C" fn host_gpu_full_co
     err_buf_cap: usize,
     err_len: *mut usize,
 ) -> i32 {
-    run_host_extern_c(
-        "host_gpu_full_copy_texture_to_storage_buffer_and_signal",
-        || {
-            not_yet_provided(
-                "copy_texture_to_storage_buffer_and_signal",
-                err_buf,
-                err_buf_cap,
-                err_len,
-            )
-        },
-        NOT_YET_PROVIDED_RC,
+    write_err_non_linux(
+        "copy_texture_to_storage_buffer_and_signal",
+        err_buf,
+        err_buf_cap,
+        err_len,
     )
+}
+
+/// Shared "not available on this platform" writer for the non-Linux
+/// OPAQUE_FD/CUDA slot stubs (the surface is Linux-only RHI).
+#[cfg(not(target_os = "linux"))]
+fn write_err_non_linux(slot: &str, err_buf: *mut u8, err_buf_cap: usize, err_len: *mut usize) -> i32 {
+    super::super::super::shared::wire::write_err(
+        &format!("{slot}: not available on this platform"),
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
 }
 
 #[cfg(test)]
 mod reserved_m32_wire_format_tests {
-    //! Tier-1 wire-format tests for the reserved v11 FullAccess slots.
-    //! Each i32-returning slot must return [`NOT_YET_PROVIDED_RC`] with a
-    //! "not yet provided" message; each drop slot is a null-safe no-op.
+    //! Tier-1 wire-format tests for the v11 FullAccess slots.
     //!
-    //! Mental-revert: replace a stub body with `unimplemented!()` and the
-    //! matching test aborts the process instead of asserting the typed
-    //! refusal — the panic net + typed non-zero is exactly what these
-    //! lock in until the fill-in issues land the real bodies.
+    //! The still-reserved slots (present target, hardware video,
+    //! exportable timeline, texture readback) must return
+    //! [`NOT_YET_PROVIDED_RC`] with a "not yet provided" message; each
+    //! drop slot is a null-safe no-op. The landed OPAQUE_FD/CUDA slots
+    //! (#1262) instead assert their GPU-free guard paths (null-handle,
+    //! null-out-param, invalid-args, invalid-scope); their positive
+    //! mint/copy paths are GPU-gated integration tests.
+    //!
+    //! Mental-revert: replace a still-reserved stub body with
+    //! `unimplemented!()` and the matching test aborts the process
+    //! instead of asserting the typed refusal; drop a landed-slot guard
+    //! and the matching test trips on a UB deref or an unchecked scope
+    //! hit.
 
     use std::ffi::c_void;
 
@@ -777,13 +1095,72 @@ mod reserved_m32_wire_format_tests {
         );
     }
 
+    // ========================================================================
+    // OPAQUE_FD / CUDA buffer surface (#1262) — real host bodies.
+    //
+    // These slots run inside an escalate scope; the positive mint/copy
+    // paths need a live GPU and are GPU-gated (integration tests). The
+    // GPU-free wire tests below lock the null-handle / null-out-param /
+    // invalid-args / invalid-scope guards that fire before any device
+    // work. Mental-revert: dropping a guard turns the matching assertion
+    // into a UB deref (SIGSEGV) or an unchecked scope hit.
+    // ========================================================================
+
     #[test]
-    fn create_opaque_fd_export_buffer_reports_not_yet_provided() {
+    #[cfg(target_os = "linux")]
+    fn create_opaque_fd_export_buffer_rejects_null_out_param() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.create_opaque_fd_export_buffer)(
+                std::ptr::null(),
+                4096,
+                1,
+                std::ptr::null_mut(), // null out_buffer
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len).contains("create_opaque_fd_export_buffer: null out_buffer"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn create_opaque_fd_export_buffer_rejects_zero_byte_size() {
         let (mut buf, mut len) = make_err_buf();
         let mut out = [0u8; 32];
         let rc = unsafe {
             (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.create_opaque_fd_export_buffer)(
                 std::ptr::null(),
+                0, // invalid byte_size
+                1,
+                out.as_mut_ptr() as *mut c_void,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len).contains("byte_size must be > 0"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn create_opaque_fd_export_buffer_rejects_null_scope_token() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut out = [0u8; 32];
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.create_opaque_fd_export_buffer)(
+                std::ptr::null(), // null scope token
                 4096,
                 1,
                 out.as_mut_ptr() as *mut c_void,
@@ -792,17 +1169,57 @@ mod reserved_m32_wire_format_tests {
                 &mut len,
             )
         };
-        assert_eq!(rc, NOT_YET_PROVIDED_RC);
+        assert_eq!(rc, 1);
         assert!(
-            err_buf_as_str(&buf, len).contains("create_opaque_fd_export_buffer: not yet provided")
+            err_buf_as_str(&buf, len)
+                .contains("create_opaque_fd_export_buffer: invalid escalate scope"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
         );
     }
 
     #[test]
-    fn export_storage_buffer_opaque_fd_writes_minus_one_fd_on_refusal() {
+    #[cfg(target_os = "linux")]
+    fn export_storage_buffer_opaque_fd_writes_minus_one_fd_on_null_scope() {
         let (mut buf, mut len) = make_err_buf();
         let mut desc = streamlib_plugin_abi::OpaqueFdExportDescriptorRepr {
-            fd: 7, // start non-negative to prove the stub writes -1
+            fd: 7, // start non-negative to prove the body writes -1
+            handle_type_raw: 0,
+            size: 0,
+            device_uuid: [0u8; 16],
+        };
+        // Aligned 32-byte backing so the body can *form* (never read) a
+        // `&StorageBuffer` before the null-scope check fires — the scope
+        // closure that would deref its fields never runs on a null token.
+        let backing = [0u64; 4];
+        let buffer_ptr = backing.as_ptr() as *const c_void;
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.export_storage_buffer_opaque_fd)(
+                std::ptr::null(),
+                buffer_ptr,
+                &mut desc,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        // FD-failure convention: fd written -1 on any non-zero return.
+        assert_eq!(desc.fd, -1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("export_storage_buffer_opaque_fd: invalid escalate scope"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn export_storage_buffer_opaque_fd_writes_minus_one_fd_on_null_buffer() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut desc = streamlib_plugin_abi::OpaqueFdExportDescriptorRepr {
+            fd: 7,
             handle_type_raw: 0,
             size: 0,
             device_uuid: [0u8; 16],
@@ -810,26 +1227,26 @@ mod reserved_m32_wire_format_tests {
         let rc = unsafe {
             (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.export_storage_buffer_opaque_fd)(
                 std::ptr::null(),
-                std::ptr::null(),
+                std::ptr::null(), // null buffer
                 &mut desc,
                 buf.as_mut_ptr(),
                 buf.len(),
                 &mut len,
             )
         };
-        assert_eq!(rc, NOT_YET_PROVIDED_RC);
-        // FD-failure convention: fd written -1 on any non-zero return.
+        assert_eq!(rc, 1);
         assert_eq!(desc.fd, -1);
         assert!(
+            err_buf_as_str(&buf, len).contains("null buffer / out_descriptor"),
+            "got: {}",
             err_buf_as_str(&buf, len)
-                .contains("export_storage_buffer_opaque_fd: not yet provided")
         );
     }
 
     #[test]
-    fn wrap_storage_buffer_as_pixel_buffer_reports_not_yet_provided() {
+    #[cfg(target_os = "linux")]
+    fn wrap_storage_buffer_as_pixel_buffer_rejects_null_out_param() {
         let (mut buf, mut len) = make_err_buf();
-        let mut out = [0u8; 64];
         let rc = unsafe {
             (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.wrap_storage_buffer_as_pixel_buffer)(
                 std::ptr::null(),
@@ -837,29 +1254,92 @@ mod reserved_m32_wire_format_tests {
                 64,
                 64,
                 4,
-                0,
+                0x42475241, // Bgra32
+                std::ptr::null_mut(), // null out_pixel_buffer
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len).contains("null storage_buffer / out_pixel_buffer"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn wrap_storage_buffer_as_pixel_buffer_rejects_invalid_format() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut out = [0u8; 64];
+        let bogus_storage = 0x1usize as *const c_void;
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.wrap_storage_buffer_as_pixel_buffer)(
+                std::ptr::null(),
+                bogus_storage,
+                64,
+                64,
+                4,
+                0xDEAD_BEEF, // invalid format_raw
                 out.as_mut_ptr() as *mut c_void,
                 buf.as_mut_ptr(),
                 buf.len(),
                 &mut len,
             )
         };
-        assert_eq!(rc, NOT_YET_PROVIDED_RC);
+        assert_eq!(rc, 1);
         assert!(
             err_buf_as_str(&buf, len)
-                .contains("wrap_storage_buffer_as_pixel_buffer: not yet provided")
+                .contains("wrap_storage_buffer_as_pixel_buffer: invalid format_raw"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
         );
     }
 
     #[test]
-    fn copy_texture_to_storage_buffer_and_signal_reports_not_yet_provided() {
+    #[cfg(target_os = "linux")]
+    fn wrap_storage_buffer_as_pixel_buffer_rejects_null_scope_token() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut out = [0u8; 64];
+        // Aligned 32-byte backing so a `&StorageBuffer` can be formed
+        // (never read) ahead of the null-scope check.
+        let backing = [0u64; 4];
+        let storage_ptr = backing.as_ptr() as *const c_void;
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.wrap_storage_buffer_as_pixel_buffer)(
+                std::ptr::null(),
+                storage_ptr,
+                64,
+                64,
+                4,
+                0x42475241, // Bgra32 (valid — pushes past the format decode)
+                out.as_mut_ptr() as *mut c_void,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("wrap_storage_buffer_as_pixel_buffer: invalid escalate scope"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn copy_texture_to_storage_buffer_and_signal_rejects_null_handles() {
         let (mut buf, mut len) = make_err_buf();
         let rc = unsafe {
             (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.copy_texture_to_storage_buffer_and_signal)(
                 std::ptr::null(),
-                std::ptr::null(),
+                std::ptr::null(), // null texture_handle
                 0,
-                std::ptr::null(),
+                std::ptr::null(), // null storage_buffer
                 std::ptr::null(),
                 0,
                 std::ptr::null(),
@@ -869,10 +1349,11 @@ mod reserved_m32_wire_format_tests {
                 &mut len,
             )
         };
-        assert_eq!(rc, NOT_YET_PROVIDED_RC);
+        assert_eq!(rc, 1);
         assert!(
+            err_buf_as_str(&buf, len).contains("null texture_handle / storage_buffer"),
+            "got: {}",
             err_buf_as_str(&buf, len)
-                .contains("copy_texture_to_storage_buffer_and_signal: not yet provided")
         );
     }
 

--- a/runtime/streamlib-engine/src/core/rhi/storage_buffer.rs
+++ b/runtime/streamlib-engine/src/core/rhi/storage_buffer.rs
@@ -118,6 +118,35 @@ impl StorageBuffer {
         self.mapped_ptr_cached
     }
 
+    /// Engine-internal clone of the underlying `Arc<HostVulkanBuffer>`
+    /// (bumps the strong count by one). Used by host-side FullAccess
+    /// bodies that must hand the same allocation to another RHI wrapper
+    /// — e.g. `wrap_storage_buffer_as_pixel_buffer` re-wraps this
+    /// buffer's `Arc` as a [`super::PixelBuffer`]. Balances against the
+    /// returned `Arc`'s own `Drop`.
+    ///
+    /// **Panics if called from cdylib code** for the same reason
+    /// [`Self::host_inner`] does — the handle is only dereferenceable in
+    /// host-compiled code.
+    pub(crate) fn host_inner_arc(&self) -> Arc<crate::vulkan::rhi::HostVulkanBuffer> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "StorageBuffer::host_inner_arc() reached from cdylib code; this method \
+                 must run host-side. The panic is caught by run_host_extern_c at the \
+                 plugin ABI."
+            );
+        }
+        // SAFETY: `self.handle` is `Arc::into_raw(Arc<HostVulkanBuffer>)`
+        // (see `from_arc_into_raw`). Incrementing the strong count and
+        // reconstructing the `Arc` yields an owned clone whose `Drop`
+        // balances this increment; the original handle stays valid.
+        unsafe {
+            let ptr = self.handle as *const crate::vulkan::rhi::HostVulkanBuffer;
+            Arc::increment_strong_count(ptr);
+            Arc::from_raw(ptr)
+        }
+    }
+
     /// Engine-internal accessor for the raw
     /// `Arc::into_raw(Arc<HostVulkanBuffer>)` handle. Used by
     /// cdylib-mode dispatch paths

--- a/runtime/streamlib-engine/src/vulkan/rhi/vulkan_buffer.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/vulkan_buffer.rs
@@ -388,6 +388,14 @@ impl HostVulkanBuffer {
     pub fn buffer(&self) -> vk::Buffer {
         self.buffer
     }
+
+    /// The `HostVulkanDevice` this buffer was allocated from — its owning
+    /// device. Callers exporting an OPAQUE_FD bind the CUDA context to
+    /// this device's `physical_device_uuid()`, never the UUID of some
+    /// other (e.g. the current `GpuContext`'s) device.
+    pub(crate) fn vulkan_device(&self) -> &Arc<HostVulkanDevice> {
+        &self.vulkan_device
+    }
 }
 
 impl super::VulkanRhiBuffer for HostVulkanBuffer {

--- a/runtime/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
@@ -599,6 +599,52 @@ impl RhiCommandRecorderInner {
         self.submit_inner(Some((timeline.semaphore(), signal_value)))
     }
 
+    /// End recording and submit in one queue submission, optionally
+    /// GPU-waiting `wait` (`(timeline, wait_value)`) before the recorded
+    /// work runs and optionally signaling `signal`
+    /// (`(timeline, signal_value)`) on completion. `None` for either side
+    /// omits that half.
+    ///
+    /// This backs the OPAQUE_FD/CUDA per-frame producer copy
+    /// (`copy_texture_to_storage_buffer_and_signal`): the producer waits
+    /// on the consumer's `consume_done` timeline before overwriting the
+    /// shared buffer, then signals `produce_done` after the copy so the
+    /// consumer's `acquire_read` unblocks. Each signal/wait value MUST be
+    /// strictly greater than its timeline's current counter (Vulkan
+    /// disallows monotonic regressions).
+    ///
+    /// When both sides are `None` the caller gets a bare submission with
+    /// no host wait — use [`Self::submit_and_wait`] if a host-side drain
+    /// is needed instead.
+    #[tracing::instrument(level = "trace", skip(self, wait, signal), fields(label = %self.label))]
+    pub fn submit_waiting_and_signaling_timeline(
+        &mut self,
+        wait: Option<(&HostVulkanTimelineSemaphore, u64)>,
+        signal: Option<(&HostVulkanTimelineSemaphore, u64)>,
+    ) -> Result<()> {
+        let waits: Vec<vk::SemaphoreSubmitInfo> = wait
+            .into_iter()
+            .map(|(timeline, value)| {
+                vk::SemaphoreSubmitInfo::builder()
+                    .semaphore(timeline.semaphore())
+                    .value(value)
+                    .stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+                    .build()
+            })
+            .collect();
+        let signals: Vec<vk::SemaphoreSubmitInfo> = signal
+            .into_iter()
+            .map(|(timeline, value)| {
+                vk::SemaphoreSubmitInfo::builder()
+                    .semaphore(timeline.semaphore())
+                    .value(value)
+                    .stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+                    .build()
+            })
+            .collect();
+        self.submit_with_semaphores(&waits, &signals)
+    }
+
     /// End recording and submit without semaphore signaling. The
     /// recorder's internal completion fence is signaled so the next
     /// `begin()` blocks on completion.

--- a/runtime/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
@@ -673,6 +673,29 @@ impl RhiCommandRecorderInner {
         Ok(())
     }
 
+    /// Host-block until this recorder's most recent submission drains,
+    /// via its internal completion fence. Use after a
+    /// [`Self::submit_waiting_and_signaling_timeline`] whose signal side
+    /// is `None`: with no GPU-side signal to order a downstream consumer,
+    /// a host-side drain is the only completion guarantee the caller has.
+    /// No-op when nothing is in flight (the fence is already signaled).
+    #[tracing::instrument(level = "trace", skip(self), fields(label = %self.label))]
+    pub fn wait_for_completion(&mut self) -> Result<()> {
+        if self.submission_in_flight {
+            unsafe {
+                self.device
+                    .wait_for_fences(&[self.completion_fence], true, u64::MAX)
+                    .map_err(|e| {
+                        Error::GpuError(format!(
+                            "RhiCommandRecorder '{}': wait_for_fences in wait_for_completion: {e}",
+                            self.label
+                        ))
+                    })?;
+            }
+        }
+        Ok(())
+    }
+
     fn submit_inner(&mut self, timeline_signal: Option<(vk::Semaphore, u64)>) -> Result<()> {
         {
             let mut state = self.state.lock();

--- a/sdk/streamlib-plugin-sdk/src/context.rs
+++ b/sdk/streamlib-plugin-sdk/src/context.rs
@@ -1283,6 +1283,185 @@ impl GpuContextFullAccess {
             Err(Error::GpuError(msg))
         }
     }
+
+    /// Allocate an OPAQUE_FD-exportable `VkBuffer` as a
+    /// [`StorageBuffer`](crate::rhi::StorageBuffer) (`device_local = true`
+    /// → VRAM-resident CUDA-visible; `false` → HOST_VISIBLE). The
+    /// cdylib-safe OPAQUE_FD/CUDA producer allocation (#1262); dispatches
+    /// through the [`GpuContextFullAccessVTable`]'s
+    /// `create_opaque_fd_export_buffer` slot.
+    pub fn create_opaque_fd_export_buffer(
+        &self,
+        byte_size: u64,
+        device_local: bool,
+    ) -> Result<crate::rhi::StorageBuffer> {
+        if self.vtable.is_null() {
+            return Err(Error::GpuError(
+                "create_opaque_fd_export_buffer: GpuContextFullAccess has null vtable".into(),
+            ));
+        }
+        let mut out: std::mem::MaybeUninit<crate::rhi::StorageBuffer> =
+            std::mem::MaybeUninit::uninit();
+        let mut err_buf = [0u8; 512];
+        let mut err_len: usize = 0;
+        // SAFETY: vtable + handle (scope token) paired at construction;
+        // the host writes a valid `StorageBuffer` PluginAbiObject (with a
+        // populated `byte_size_cached`) into `out` on success.
+        let status = unsafe {
+            ((*self.vtable).create_opaque_fd_export_buffer)(
+                self.handle,
+                byte_size,
+                u8::from(device_local),
+                out.as_mut_ptr() as *mut c_void,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            // SAFETY: host signaled success and wrote a valid value.
+            Ok(unsafe { out.assume_init() })
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())]).into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    /// Export a fresh dup'd OPAQUE_FD plus byte size and exporting-device
+    /// UUID from `buffer`. The fd transfers to the caller (import it once
+    /// via `cudaImportExternalMemory`); the 16-byte UUID binds the CUDA
+    /// context to the matching physical device. Dispatches through the
+    /// `export_storage_buffer_opaque_fd` slot (#1262).
+    pub fn export_storage_buffer_opaque_fd(
+        &self,
+        buffer: &crate::rhi::StorageBuffer,
+    ) -> Result<(std::os::unix::io::RawFd, u64, [u8; 16])> {
+        if self.vtable.is_null() {
+            return Err(Error::GpuError(
+                "export_storage_buffer_opaque_fd: GpuContextFullAccess has null vtable".into(),
+            ));
+        }
+        let mut descriptor = crate::rhi::OpaqueFdExportDescriptorRepr::default();
+        let mut err_buf = [0u8; 512];
+        let mut err_len: usize = 0;
+        // SAFETY: vtable + handle paired at construction; `buffer` is a
+        // borrowed StorageBuffer valid for the call; the host writes the
+        // descriptor (or leaves `fd = -1` on refusal) into `descriptor`.
+        let status = unsafe {
+            ((*self.vtable).export_storage_buffer_opaque_fd)(
+                self.handle,
+                buffer as *const _ as *const c_void,
+                &mut descriptor,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok((descriptor.fd, descriptor.size, descriptor.device_uuid))
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())]).into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    /// Wrap an existing OPAQUE_FD [`StorageBuffer`](crate::rhi::StorageBuffer)
+    /// as a [`PixelBuffer`](crate::rhi::PixelBuffer) sharing the same
+    /// allocation, so the flat CUDA buffer can register through the
+    /// surface-store `register_pixel_buffer_with_timeline` path (#1262).
+    /// Dispatches through the `wrap_storage_buffer_as_pixel_buffer` slot.
+    pub fn wrap_storage_buffer_as_pixel_buffer(
+        &self,
+        storage_buffer: &crate::rhi::StorageBuffer,
+        width: u32,
+        height: u32,
+        bytes_per_pixel: u32,
+        format: PixelFormat,
+    ) -> Result<crate::rhi::PixelBuffer> {
+        if self.vtable.is_null() {
+            return Err(Error::GpuError(
+                "wrap_storage_buffer_as_pixel_buffer: GpuContextFullAccess has null vtable".into(),
+            ));
+        }
+        let mut out: std::mem::MaybeUninit<crate::rhi::PixelBuffer> =
+            std::mem::MaybeUninit::uninit();
+        let mut err_buf = [0u8; 512];
+        let mut err_len: usize = 0;
+        // SAFETY: vtable + handle paired at construction; `storage_buffer`
+        // borrowed for the call; the host writes a valid `PixelBuffer`
+        // PluginAbiObject (with cached width/height/format) into `out`.
+        let status = unsafe {
+            ((*self.vtable).wrap_storage_buffer_as_pixel_buffer)(
+                self.handle,
+                storage_buffer as *const _ as *const c_void,
+                width,
+                height,
+                bytes_per_pixel,
+                format as u32,
+                out.as_mut_ptr() as *mut c_void,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            // SAFETY: host signaled success and wrote a valid value.
+            Ok(unsafe { out.assume_init() })
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())]).into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    /// Per-frame CUDA producer copy: `vkCmdCopyImageToBuffer` from
+    /// `source_texture` (currently in `source_layout`) into `dst` in one
+    /// host-device submission (#1262). Dispatches through the
+    /// `copy_texture_to_storage_buffer_and_signal` slot.
+    ///
+    /// The cross-API timeline wait/signal (`consume_done` / `produce_done`)
+    /// rides null handles until #1260 lands the SDK exportable-timeline
+    /// PluginAbiObject; on the null path the host submission blocks until
+    /// the copy completes. When #1260 lands, this method gains the
+    /// `Option<(&HostTimelineSemaphore, u64)>` wait/signal parameters.
+    pub fn copy_texture_to_storage_buffer_and_signal(
+        &self,
+        source_texture: &crate::rhi::Texture,
+        source_layout: VulkanLayout,
+        dst: &crate::rhi::StorageBuffer,
+    ) -> Result<()> {
+        if self.vtable.is_null() {
+            return Err(Error::GpuError(
+                "copy_texture_to_storage_buffer_and_signal: GpuContextFullAccess has null vtable"
+                    .into(),
+            ));
+        }
+        let mut err_buf = [0u8; 512];
+        let mut err_len: usize = 0;
+        // SAFETY: vtable + handle paired at construction; the texture +
+        // storage buffer are borrowed for the call. Null timeline handles
+        // select the host-blocking (no cross-API sync) path.
+        let status = unsafe {
+            ((*self.vtable).copy_texture_to_storage_buffer_and_signal)(
+                self.handle,
+                source_texture.handle,
+                source_layout.0,
+                dst as *const _ as *const c_void,
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                0,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())]).into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
 }
 
 // =============================================================================

--- a/sdk/streamlib-plugin-sdk/src/rhi.rs
+++ b/sdk/streamlib-plugin-sdk/src/rhi.rs
@@ -66,6 +66,12 @@ pub use vulkan_graphics_kernel::VulkanGraphicsKernel;
 // Format / layout primitives — already engine-free in consumer-rhi.
 pub use streamlib_consumer_rhi::{PixelFormat, TextureFormat, TextureUsages, VulkanLayout};
 
+// OPAQUE_FD/CUDA export descriptor (#1262) — the `#[repr(C)]` POD is
+// authored once in `streamlib-plugin-abi`; re-exported here so cdylib
+// authors reach it as `sdk::rhi::OpaqueFdExportDescriptorRepr` without a
+// twin definition.
+pub use streamlib_plugin_abi::OpaqueFdExportDescriptorRepr;
+
 // Internal staging helper for `create_compute_kernel`.
 pub(crate) use compute_kernel_descriptor::stage_compute_kernel_descriptor;
 // Internal staging helper for `create_graphics_kernel`.


### PR DESCRIPTION
## What & why — OPAQUE_FD/CUDA producer mechanism (#1262, mechanism-only per owner decision (a))

Fills the reserved **v11** FullAccess slots for the engine-free **OPAQUE_FD/CUDA interop producer** — the mechanism a cdylib plugin uses to export a device-local GPU buffer as an OPAQUE_FD for zero-copy CUDA consumption. Four slots, all engine-free-callable across the plugin ABI:

- `create_opaque_fd_export_buffer` — cdylib-safe OPAQUE_FD-exportable device-local buffer.
- `export_storage_buffer_opaque_fd` — exports the buffer's fd + an `OpaqueFdExportDescriptorRepr` (32-byte `#[repr(C)]`: fd + handle_type + size + **device UUID**).
- `wrap_storage_buffer_as_pixel_buffer` — re-views a StorageBuffer as a PixelBuffer for the surface-share path.
- `copy_texture_to_storage_buffer_and_signal` — the host copy slot (texture → OPAQUE_FD buffer + timeline signal).

Device-flavor is **RATIFIED** (owner-approved signature block): **no Vulkan device** crosses the ABI, CUDA binds by the 16-byte device UUID, with a **typed mismatch error** (never a silent CUDA device 0). Pure fill-in of #1253's reserved slots — `STREAMLIB_ABI_VERSION`=5, `GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION`=11, no fingerprint fold. **ABI byte-untouched.**

## Re-scope (owner decision (a), 2026-07-16)
This ticket is **mechanism-only**. The **consumer half** — the `camera_to_cuda_copy` processor conversion **and** the `CudaSurfaceAdapter<D>` → device-UUID-binding refactor — moved to **#1226** (the processor constructs the adapter, so they're one edit; camera is the only shipped CUDA consumer). `camera_to_cuda_copy.rs` is untouched here.

## Hardening (the four findings, landed in this PR per owner direction)
1. **Panic net on every extern-C body** — the four non-Linux OPAQUE_FD stubs now wrap `run_host_extern_c` (matching the Linux bodies + the reserved siblings), so the net is unconditional across platforms.
2. **`wrap_storage_buffer_as_pixel_buffer` dimension validation** — rejects zero and oversized shapes (`width*height*bpp > byte_size`) with a typed error before caching the dims, closing an out-of-bounds-read hazard (previously validated only format). +2 GPU-free wire tests (`_rejects_zero_dimension`, `_rejects_oversized_shape`).
3. **Copy-slot completion guarantee on every timeline branch** — all four `(consume_done, produce_done)` combinations now carry a defined completion contract: `(None,None)` host-drains; `produce=Some` signals produce_done (the consumer's ordering guarantee); the previously-hazardous `(Some,None)` branch host-blocks via a new `RhiCommandRecorderInner::wait_for_completion` — a shared-buffer write never returns without either a GPU-side signal or a host drain.
4. **Exported device UUID from the buffer's owning device** — via a new `HostVulkanBuffer::vulkan_device()` accessor, so the CUDA device-binding UUID always names the buffer's actual device (not just the context's), sound even if a StorageBuffer ever originates from a different device.

## Tests / validation
- **check-boundaries: 0 violations**; `plugin-abi` **75**, `plugin-sdk` **54**, `streamlib-engine` **1588**. 19 GPU-free OPAQUE_FD wire tests (null/invalid-args/scope guards + the 2 new dimension tests), revert-verified; the `repr(C)` layout + republish gates pass.
- One **pre-existing, unrelated** flaky failed only under the parallel engine run — `core::logging::tests::rust_println_captured_via_fd_redirect` (a global-stdio fd-redirect race; passes in isolation). Not introduced here; it's the CI-flaky class tracked separately (#1368).

## verify-live tail (hardware-gated, human-run)
The copy slot's **positive path + the cross-boundary Arc-reconstruction refcount-balance lock** are GPU-gated (`/verify-live`); they compile + skip cleanly without a GPU. The full CUDA consumer E2E lands with **#1226**. The aarch64 cross-check of the non-Linux stubs is osxcross-blocked on this host (the `write_err` cfg was verified by source analysis) — a CI/verify-live item.

Closes #1262
