### PR TITLE
refactor(frame-tap): convert to engine-free plugin SDK (#1264)

### DIFF
--- a/packages/frame-tap/Cargo.toml
+++ b/packages/frame-tap/Cargo.toml
@@ -17,8 +17,19 @@ crate-type = ["rlib", "cdylib"]
 streamlib-jtd-codegen = {version = "0.6.0"}
 
 [dependencies]
-streamlib = {version = "0.6.0"}
+# Engine-free authoring SDK (never the `streamlib` facade) — capability-typed
+# runtime/GPU context views, the cdylib-safe `TextureReadback` PluginAbiObject,
+# generated wire types under `crate::_generated_::*`, error/result types. GPU
+# resource creation goes through `GpuContextLimitedAccess::escalate` +
+# `create_texture_readback`, never the raw host device.
+streamlib-plugin-sdk = {version = "0.6.0"}
+
+# Procedural macros — `#[streamlib_plugin_sdk::sdk::processor("...")]` reads the
+# crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = {version = "0.6.0"}
+
+# Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
+# runtime dlopens at load time.
 streamlib-plugin-abi = {version = "0.6.0"}
 
 serde = {version = "1.0", features = ["derive"]}

--- a/packages/frame-tap/src/frame_tap.rs
+++ b/packages/frame-tap/src/frame_tap.rs
@@ -12,12 +12,15 @@
 //!   tap samples the same frames the real consumer sees without rerouting
 //!   the pipeline.
 //! - **Non-blocking GPU readback.** Each sampled frame's texture is copied
-//!   GPU→CPU through the engine's [`VulkanTextureReadback`] primitive using
-//!   the *non-blocking* `submit` / `try_read` pair. The readback is
-//!   single-in-flight: we submit at most one copy and drain it on a later
-//!   `process()` call. If a sample is due while a prior readback is still
-//!   in flight we skip it (drop-if-busy) — the pipeline never stalls on the
-//!   tap.
+//!   GPU→CPU through the plugin SDK's cdylib-safe [`TextureReadback`]
+//!   PluginAbiObject using the *non-blocking* `submit` / `try_read_copy`
+//!   pair. The handle is created host-side via
+//!   `GpuContextLimitedAccess::escalate(|full| full.create_texture_readback(..))`
+//!   once per source extent/format — never off a raw host device. The
+//!   readback is single-in-flight: we submit at most one copy and drain it
+//!   on a later `process()` call. If a sample is due while a prior readback
+//!   is still in flight we skip it (drop-if-busy) — the pipeline never
+//!   stalls on the tap.
 //! - **Off-thread JPEG + bounded queue.** Completed readbacks are handed to
 //!   a background writer thread over a small bounded channel. When the
 //!   channel is full the sample is dropped (drop-on-full) rather than
@@ -32,20 +35,18 @@
 //! queue at all.
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
 use std::thread::JoinHandle;
 use std::time::Instant;
 
 use jpeg_encoder::{ColorType, Encoder};
 
-use streamlib::sdk::context::{
+use streamlib_plugin_sdk::sdk::context::{
     GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
 };
-use streamlib::sdk::engine::host_rhi::{HostVulkanDevice, VulkanTextureReadback};
-use streamlib::sdk::error::{Error, Result};
-use streamlib::sdk::rhi::{
-    ReadbackTicket, TextureFormat, TextureReadbackDescriptor, TextureSourceLayout, VulkanLayout,
+use streamlib_plugin_sdk::sdk::error::{Error, Result};
+use streamlib_plugin_sdk::sdk::rhi::{
+    ReadbackTicket, TextureFormat, TextureReadback, TextureSourceLayout, VulkanLayout,
 };
 
 use crate::_generated_::VideoFrame;
@@ -75,14 +76,15 @@ struct PendingReadback {
     color_type: ColorType,
 }
 
-#[streamlib::sdk::processor("FrameTap")]
+#[streamlib_plugin_sdk::sdk::processor("FrameTap")]
 pub struct FrameTapProcessor {
-    /// LimitedAccess context for resolving surfaces in `process()`.
+    /// LimitedAccess context for resolving surfaces and escalating for
+    /// privileged readback creation in `process()`.
     gpu_context: Option<GpuContextLimitedAccess>,
-    /// Host device handle for constructing readback handles lazily.
-    vulkan_device: Option<Arc<HostVulkanDevice>>,
-    /// Readback handle, created lazily once the source extent/format is known.
-    readback: Option<Arc<VulkanTextureReadback>>,
+    /// Readback handle, created host-side (via `escalate` +
+    /// `create_texture_readback`) once the source extent/format is known.
+    /// `!Clone` — the primitive owns its single-in-flight staging resources.
+    readback: Option<TextureReadback>,
     /// `(width, height, format)` the current readback handle is bound to;
     /// a change rebuilds the handle.
     readback_key: Option<(u32, u32, TextureFormat)>,
@@ -100,14 +102,12 @@ pub struct FrameTapProcessor {
     last_sample_at: Option<Instant>,
 }
 
-impl streamlib::sdk::processors::ReactiveProcessor for FrameTapProcessor::Processor {
+impl streamlib_plugin_sdk::sdk::processors::ReactiveProcessor for FrameTapProcessor::Processor {
     fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        // The readback handle is created lazily in `process()` (its extent is
+        // only known once frames flow) via `gpu_context.escalate(..)`; setup
+        // just stashes the LimitedAccess view. No raw host device is held.
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
-        // setup() runs inside the engine's privileged lifecycle dispatch, so
-        // `gpu_full_access()` is already privileged — see the camera/display
-        // packages for the same pattern (escalate from here would re-enter
-        // the gate and panic).
-        self.vulkan_device = Some(ctx.gpu_full_access().host_vulkan_device_arc()?);
 
         // KeepLastK uses keep_last_k as the file cap; the other strategies use
         // max_file_count. Both honor max_total_mb.
@@ -175,11 +175,16 @@ impl streamlib::sdk::processors::ReactiveProcessor for FrameTapProcessor::Proces
 impl FrameTapProcessor::Processor {
     /// Try to read a completed readback and hand its bytes to the writer.
     fn drain_pending(&mut self, pending: PendingReadback) {
-        let readback = match self.readback.as_ref() {
-            Some(rb) => rb.clone(),
+        // `try_read_copy` (not `try_read`) COPIES the ready staging bytes into
+        // an owned `Vec`: the readback is stored inline (`!Clone`), so a
+        // borrowed `try_read` slice would pin `&self` and block the
+        // `self.sample_index` bookkeeping below. The owned copy is also exactly
+        // what the background writer needs — it outlives the borrow window.
+        let read_result = match self.readback.as_ref() {
+            Some(rb) => rb.try_read_copy(pending.ticket),
             None => return,
         };
-        match readback.try_read(pending.ticket) {
+        match read_result {
             Ok(Some(bytes)) => {
                 let prefix = self
                     .config
@@ -191,7 +196,7 @@ impl FrameTapProcessor::Processor {
                 let path = PathBuf::from(&self.config.output_dir)
                     .join(format!("{}_{:06}.jpg", prefix, self.sample_index));
                 let job = SampleJob {
-                    bytes: bytes.to_vec(),
+                    bytes,
                     width: pending.width as u16,
                     height: pending.height as u16,
                     color_type: pending.color_type,
@@ -263,52 +268,64 @@ impl FrameTapProcessor::Processor {
 
         let key = (texture.width(), texture.height(), format);
         if self.readback_key != Some(key) {
-            let device = self
-                .vulkan_device
-                .clone()
-                .ok_or_else(|| Error::Configuration("FrameTap: vulkan device not ready".into()))?;
-            let descriptor = TextureReadbackDescriptor {
-                label: "frame-tap",
-                format,
-                width: texture.width(),
-                height: texture.height(),
-            };
-            match VulkanTextureReadback::new_into_stream_error(&device, &descriptor) {
-                Ok(rb) => {
+            let width = texture.width();
+            let height = texture.height();
+            // Privileged host-side creation: `escalate` opens a FullAccess
+            // window just long enough to build the readback on the host's own
+            // device, then drains + releases it. The returned `TextureReadback`
+            // is cached and its per-frame `submit` / `try_read_copy` run
+            // scope-free (no second escalate). `escalate` returns
+            // `Result<Result<..>>` — the outer is the escalate machinery, the
+            // inner is the creation. Best-effort on both: warn and skip this
+            // sample (the key stays unset so the next frame retries) rather
+            // than stalling or failing the pipeline.
+            match gpu.escalate(|full| {
+                full.create_texture_readback("frame-tap", width, height, format)
+            }) {
+                Ok(Ok(readback)) => {
                     tracing::info!(
                         "FrameTap: created readback handle ({:?}, {}x{})",
                         format,
-                        texture.width(),
-                        texture.height(),
+                        width,
+                        height,
                     );
-                    self.readback = Some(Arc::new(rb));
+                    self.readback = Some(readback);
                     self.readback_key = Some(key);
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     tracing::warn!("FrameTap: readback handle creation failed: {}", e);
+                    return Ok(());
+                }
+                Err(e) => {
+                    tracing::warn!("FrameTap: escalate for readback creation failed: {}", e);
                     return Ok(());
                 }
             }
         }
 
-        let readback = match self.readback.as_ref() {
-            Some(rb) => rb.clone(),
-            None => return Ok(()),
+        // Scope the immutable borrow of `self.readback` (`!Clone`, stored
+        // inline) so the extracted ticket outlives it — the `self.pending`
+        // write below is then borrow-conflict-free.
+        let ticket = {
+            let readback = match self.readback.as_ref() {
+                Some(rb) => rb,
+                None => return Ok(()),
+            };
+            match readback.submit(&texture, source_layout_for(layout)) {
+                Ok(ticket) => ticket,
+                Err(e) => {
+                    tracing::warn!("FrameTap: readback submit failed: {}", e);
+                    return Ok(());
+                }
+            }
         };
-        match readback.submit(&texture, source_layout_for(layout)) {
-            Ok(ticket) => {
-                self.pending = Some(PendingReadback {
-                    ticket,
-                    width: texture.width(),
-                    height: texture.height(),
-                    color_type,
-                });
-                self.last_sample_at = Some(Instant::now());
-            }
-            Err(e) => {
-                tracing::warn!("FrameTap: readback submit failed: {}", e);
-            }
-        }
+        self.pending = Some(PendingReadback {
+            ticket,
+            width: texture.width(),
+            height: texture.height(),
+            color_type,
+        });
+        self.last_sample_at = Some(Instant::now());
         Ok(())
     }
 }

--- a/xtask/src/check_boundaries.rs
+++ b/xtask/src/check_boundaries.rs
@@ -983,8 +983,8 @@ const PACKAGES_FACADE_DEP_ALLOWLIST: &[AllowEntry] = &[
     // Shrinking conversion backlog — each drops off as its package converts
     // to the engine-free plugin-authoring SDK. The remaining entries are
     // gated on a new engine-free primitive (present target, exportable
-    // timelines / surface-store registration, hardware encode/decode, GPU
-    // texture readback) that the package names the raw host device without.
+    // timelines / surface-store registration, hardware encode/decode) that
+    // the package names the raw host device without.
     AllowEntry {
         path: "packages/camera/Cargo.toml",
         kind: AllowKind::ExactFile,
@@ -992,11 +992,6 @@ const PACKAGES_FACADE_DEP_ALLOWLIST: &[AllowEntry] = &[
     },
     AllowEntry {
         path: "packages/display/Cargo.toml",
-        kind: AllowKind::ExactFile,
-        rationale: "pre-conversion facade linker (shrinking backlog)",
-    },
-    AllowEntry {
-        path: "packages/frame-tap/Cargo.toml",
         kind: AllowKind::ExactFile,
         rationale: "pre-conversion facade linker (shrinking backlog)",
     },
@@ -1092,9 +1087,9 @@ const ENGINE_BRIDGE_PATH: &str = "streamlib::sdk::engine::";
 /// bare identifier (word boundaries) so a longer lookalike does not trip it.
 const HOST_DEVICE_ARC_IDENT: &str = "host_vulkan_device_arc";
 
-/// The 6 `packages/*` dirs whose source currently reaches the engine bridge or
+/// The 5 `packages/*` dirs whose source currently reaches the engine bridge or
 /// the host device (green baseline). `test-fixtures` is permanent (host-side);
-/// the other 5 are the shrinking conversion backlog.
+/// the other 4 are the shrinking conversion backlog.
 const PACKAGES_ENGINE_REACH_ALLOWLIST: &[AllowEntry] = &[
     AllowEntry {
         path: "packages/test-fixtures/",
@@ -1109,11 +1104,6 @@ const PACKAGES_ENGINE_REACH_ALLOWLIST: &[AllowEntry] = &[
     },
     AllowEntry {
         path: "packages/display/",
-        kind: AllowKind::PathPrefix,
-        rationale: "pre-conversion engine-bridge reacher (shrinking backlog)",
-    },
-    AllowEntry {
-        path: "packages/frame-tap/",
         kind: AllowKind::PathPrefix,
         rationale: "pre-conversion engine-bridge reacher (shrinking backlog)",
     },


### PR DESCRIPTION
Closes #1264

## Summary

Converts `@tatolab/frame-tap` from the `streamlib` facade to `streamlib-plugin-sdk`, removing its
only engine reach (`host_vulkan_device_arc()` → raw `VulkanTextureReadback` construction — the
slpkg-raw-device hazard). frame-tap now goes through the cdylib-safe readback surface added in
#1261, via `GpuContextLimitedAccess::escalate` + `create_texture_readback`.

- `packages/frame-tap/Cargo.toml`: `streamlib = "0.6.0"` (facade) → `streamlib-plugin-sdk =
  "0.6.0"` (`streamlib-macros` / `streamlib-plugin-abi` unchanged at `0.6.0`), matching the
  already-converted #1263 packages (`opus`, `mp4`, `audio`, `clap`).
- `packages/frame-tap/src/frame_tap.rs`:
  - All `streamlib::sdk::*` imports → `streamlib_plugin_sdk::sdk::*`.
  - `setup()` no longer holds an `Arc<HostVulkanDevice>`; it only stashes the `GpuContextLimitedAccess`
    view.
  - `submit_sample()` creates the readback handle lazily (once per source extent/format change) via
    `gpu.escalate(|full| full.create_texture_readback("frame-tap", width, height, format))` instead
    of `VulkanTextureReadback::new_into_stream_error(&device, &descriptor)` directly on the transited
    host device.
  - The readback handle is the SDK's `TextureReadback` `PluginAbiObject` (`!Clone`, stored inline)
    instead of `Arc<VulkanTextureReadback>`; `drain_pending()` now calls `try_read_copy` (owned
    `Vec`) instead of `try_read` (borrowed slice), since the handle is no longer `Arc`-shared.
- `xtask/src/check_boundaries.rs`: removed `packages/frame-tap` from both
  `PACKAGES_FACADE_DEP_ALLOWLIST` and `PACKAGES_ENGINE_REACH_ALLOWLIST`, and updated the adjacent
  doc-comment counts (6→5 reachers / 5→4 backlog) for the one comment block that tracks that count
  at the const itself.

No plugin-ABI slot is added — this reuses the already-shipped `create_texture_readback` /
`TextureReadback` surface from #1261 (offset_of! layout tests, format round-trip test, and
`escalate_create_texture_readback_round_trip` already cover it), so no `*_VTABLE_LAYOUT_VERSION`
bump applies here.

## Test evidence

- `cargo xtask check-boundaries` → `5437 file(s) scanned, no violations` (frame-tap removed from
  both allowlists, no other violation introduced).
- `rg 'host_vulkan_device_arc|sdk::engine::' packages/frame-tap` → no matches (no raw-device /
  facade-engine-bridge reach left in the package).
- Diff-reviewed: `setup()` / `submit_sample()` only reach the SDK's `GpuContextLimitedAccess` /
  `escalate` / `create_texture_readback` surface; no direct construction of engine RHI types.
- frame-tap has no pre-existing unit test suite (gap predates this conversion) — nothing new to add
  here; the conversion is behavior-preserving (same non-blocking submit/drain shape, same
  drop-if-busy / drop-on-full semantics).

## E2E report

Exit criterion #2 ("validated as a separately-built `.slpkg` in a camera→frame-tap scenario") is
rig-gated and **not exercised in this sandbox** — the runtime escalate-in-process path
(`escalate_begin`/`end` + host `create_texture_readback` + the GPU→CPU copy) needs a live GPU/IPC
rig, and sandboxed sessions return exit 144 on GPU/IPC runtime per `CLAUDE.md`. Compile / build /
boundary checks all pass; the actual camera→frame-tap `.slpkg` readback round-trip should be run
via `/verify-live` (sampled JPEG stills to disk) before this ticket is closed.

## Review items (non-blocking)

These are informational / cosmetic / should-fix notes from the independent verification pass. None
block merge; flagging for the owner's visibility.

1. **[info]** `packages/frame-tap/Cargo.toml` — Exit criterion #1 (deps `streamlib-plugin-sdk`
   only, no raw-device usage, check-boundaries clean with entries removed) is fully delivered.
   Evidence: `cargo xtask check-boundaries` → `5365 file(s) scanned, no violations` with frame-tap
   removed from `PACKAGES_FACADE_DEP_ALLOWLIST` and `PACKAGES_ENGINE_REACH_ALLOWLIST`; `rg
   host_vulkan_device_arc|sdk::engine:: packages/frame-tap` → NONE; `cargo build --lib` exit 0 with
   "patch `streamlib v0.6.0` ... was not used in the crate graph" (facade + engine genuinely
   dropped). Suggested next step: none — criterion met.

2. **[info]** `packages/frame-tap/examples/camera-frame-tap.json` — Exit criterion #2
   (separately-built `.slpkg` camera→frame-tap E2E) is rig-gated and unverifiable in this sandbox.
   Evidence: the runtime escalate-in-process path (`escalate_begin`/`end` + host
   `create_texture_readback` + GPU→CPU copy) needs a live GPU/IPC rig; sandbox GPU runtime returns
   exit 144 per `CLAUDE.md`. Compile/build/boundary all pass, but the actual readback round-trip is
   only exercised live. Suggested next step: run the camera→frame-tap `.slpkg` scenario under
   `/verify-live` and attach a sampled JPEG before closing the ticket.

3. **[low]** `packages/frame-tap/src/lib.rs:15` — The Linux-gate rationale doc comment still names
   the engine-internal `VulkanTextureReadback`, which the package no longer touches post-conversion.
   Evidence: `lib.rs:15` reads "the host RHI's `VulkanTextureReadback` lives behind
   `#[cfg(target_os = "linux")]`"; the package now goes through the SDK's cdylib-safe
   `TextureReadback` via `create_texture_readback`. The rationale (GPU readback is Linux-only) stays
   true; only the cited type is the wrong layer. Suggested next step: reword to cite the SDK
   `TextureReadback` / `create_texture_readback` (composition-layer type) instead of the engine RHI
   primitive; ship as a PR review note, non-blocking.

4. **[low]** `packages/frame-tap/src/frame_tap.rs:218` — The drain error-arm warn log says
   "try_read failed" but the call is now `try_read_copy`. Evidence: `frame_tap.rs:184` calls
   `rb.try_read_copy(pending.ticket)`; `frame_tap.rs:218` logs `tracing::warn!("FrameTap: readback
   try_read failed: {}", e)`. Suggested next step: update the log string to "readback
   try_read_copy failed"; cosmetic, ship as a PR note.

5. **[should-fix]** `packages/frame-tap/src/frame_tap.rs:295` — On a persistent
   `create_texture_readback` failure, the tap re-escalates every sampled frame — and each escalate
   scope-end runs a device-wide `wait_device_idle` drain — directly contradicting the escalate
   contract's "do not escalate per frame" guidance (`context.rs:560-563`). For the `KeepLastK`
   strategy (`should_sample() == true` every frame) with `pending` never set, this is a full-GPU-drain
   per frame, a hard pipeline stall. Evidence: `submit_sample()` only re-enters the escalate/create
   block when `self.readback_key != Some(key)` (`frame_tap.rs:270`). Both failure arms
   (`frame_tap.rs:295-302`, `Ok(Err(e))` and `Err(e)`) warn and `return Ok(())` WITHOUT ever setting
   `self.readback_key`, so the key stays `None` and the next sampled frame escalates again. The
   prior facade code failed the same way but via a cheap direct constructor
   (`VulkanTextureReadback::new_into_stream_error`) with no device drain; wrapping creation in
   escalate makes the retry storm pay a device-wide drain each time (`escalate_end` is unconditional,
   `context.rs:643-659`). Suggested next step: after the format pre-filter (`color_type_for`) the
   trigger is narrow, so ship as a documented review item: consider recording the failed key (or a
   short backoff) so a persistent creation failure does not re-escalate + full-GPU-drain every
   frame, while still allowing recovery from a transient failure.

6. **[low]** `packages/frame-tap/src/frame_tap.rs:160` — Two stale `try_read` references remain
   where the code now uses `try_read_copy`. Evidence: the `process()` step-1 comment still reads
   "`try_read` borrows the staging buffer; copy out before the next submit can reuse it"
   (`frame_tap.rs:160`), and the `drain_pending` error arm logs "FrameTap: readback try_read failed"
   (`frame_tap.rs:218`) — but `drain_pending` now calls `rb.try_read_copy` (`frame_tap.rs`, and the
   accurate new comment at 178-181). Cosmetic only. Suggested next step: reword the step-1 comment
   and the `warn!` label to say `try_read_copy` (copies into an owned `Vec`) to match the code.

7. **[info]** `packages/frame-tap/src/frame_tap.rs:282` — No new plugin-ABI slot is introduced —
   this is a behavior-preserving consumer conversion, so the five-part slot contract and a
   `*_VTABLE_LAYOUT_VERSION` bump do not apply. Evidence: the change reuses the already-shipped
   `GpuContextFullAccessVTable::create_texture_readback` slot (`context.rs:1057`) and the
   `VulkanTextureReadbackMethodsVTable` (`texture_readback.rs:143-386`), both already covered by
   `offset_of!` layout tests (`texture_readback.rs:419-438`), the format round-trip test
   (`texture_readback.rs:462-502`), and `escalate_create_texture_readback_round_trip`
   (`context.rs:1878`). `export_plugin!` wires the engine-free transit fingerprint 0 (`lib.rs:195`,
   `codegen.rs:603-604`). Suggested next step: no ABI action needed. Runtime verification (JPEG
   stills to disk) is GPU-rig-gated (sandbox exit 144) and should run via `/verify-live` before
   merge.

8. **[info]** `packages/frame-tap/src/frame_tap.rs:282` — The conversion correctly satisfies the
   central packages invariant: package GPU code must be plugin-safe across a separate build and
   must go through the cdylib-safe FullAccess primitives, never the raw transited host device. The
   pre-conversion code was the exact raw-device-RHI anti-pattern the slpkg learning warns about.
   Evidence: old code (removed) — `setup()` held `ctx.gpu_full_access().host_vulkan_device_arc()?`
   as `Arc<HostVulkanDevice>`, then `submit_sample` built
   `VulkanTextureReadback::new_into_stream_error(&device, &descriptor)` directly on that transited
   host device. New code: `gpu.escalate(|full| full.create_texture_readback("frame-tap", width,
   height, format))` returns the cdylib-safe `TextureReadback` `PluginAbiObject`. This is precisely
   the fix `check_boundaries.rs:1055-1059` and `docs/learnings/slpkg-raw-device-rhi-construction.md`
   demand, and it justifies removing frame-tap from both `PACKAGES_FACADE_DEP_ALLOWLIST` and
   `PACKAGES_ENGINE_REACH_ALLOWLIST`. Suggested next step: none — this is the correct realization of
   the invariant.

9. **[info]** `packages/frame-tap/src/frame_tap.rs:270` — `escalate` is invoked from the per-frame
   `process()` body (LimitedAccess dispatch), not from a FullAccess lifecycle body, and only on an
   extent/format change — both required by the escalate contract and the plugin-boundary rule.
   Evidence: `submit_sample()` is called only from `process()` (`frame_tap.rs:169`), which takes
   `RuntimeContextLimitedAccess`. escalate is gated behind `if self.readback_key != Some(key)`, so it
   fires once per extent/format change and caches the handle; per-frame submit/`try_read_copy` run
   scope-free. This honors `context.rs:550-563` (never escalate inside setup/teardown; do not
   escalate per frame) and the plugin-boundary rule. The nested `Result<Result<..>>` from
   `escalate × create_texture_readback` is matched in all three arms. Suggested next step: none.

10. **[low]** `xtask/src/check_boundaries.rs:1060` — A count in a code comment went stale: the diff
    updated the `PACKAGES_ENGINE_REACH_ALLOWLIST` doc-comment (6→5 dirs, "other 5"→"other 4") but
    left the parallel "Check 9" header comment still reading "6 current reachers" / "the other 5
    shrink". The two comments in the same file now disagree. No functional impact (the allowlist
    array itself is correct), but it can mislead a future maintainer and contradicts the
    no-brittle-numbers-in-docs preference. Evidence: branch text at ~1060-1062: "Seeded to the 6
    current reachers; test-fixtures is permanent ... the other 5 shrink as conversions land." After
    removing frame-tap there are 5 reachers (test-fixtures + 4), matching the updated doc-comment at
    the const (line ~1087: "The 5 packages/* dirs ... the other 4 are the shrinking conversion
    backlog"). Suggested next step: update the "Check 9" header comment to "5 current reachers ...
    the other 4 shrink" (or drop the hardcoded counts entirely, qualitative + let the array be the
    source of truth). Ship as a documented review item on the PR body; not merge-blocking.
