### PR TITLE
ci: make Cache Cargo step non-fatal across all workflows

### DIFF
--- a/.github/workflows/check-abi-republish.yml
+++ b/.github/workflows/check-abi-republish.yml
@@ -42,6 +42,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/check-boundaries.yml
+++ b/.github/workflows/check-boundaries.yml
@@ -45,6 +45,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/check-cdylib-reach.yml
+++ b/.github/workflows/check-cdylib-reach.yml
@@ -32,6 +32,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/check-consumer-rhi-repr.yml
+++ b/.github/workflows/check-consumer-rhi-repr.yml
@@ -45,6 +45,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/check-manifest-schema.yml
+++ b/.github/workflows/check-manifest-schema.yml
@@ -36,6 +36,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/check-no-inventory-submit.yml
+++ b/.github/workflows/check-no-inventory-submit.yml
@@ -37,6 +37,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/check-no-reverse-dns.yml
+++ b/.github/workflows/check-no-reverse-dns.yml
@@ -33,6 +33,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/check-no-streamlib-metadata.yml
+++ b/.github/workflows/check-no-streamlib-metadata.yml
@@ -31,6 +31,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/check-pack-load.yml
+++ b/.github/workflows/check-pack-load.yml
@@ -75,6 +75,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/check-package-version-drift.yml
+++ b/.github/workflows/check-package-version-drift.yml
@@ -32,6 +32,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/check-schema-versions.yml
+++ b/.github/workflows/check-schema-versions.yml
@@ -32,6 +32,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/lint-logging.yml
+++ b/.github/workflows/lint-logging.yml
@@ -35,6 +35,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/schemas.yml
+++ b/.github/workflows/schemas.yml
@@ -32,6 +32,8 @@ jobs:
           scope: '@tatolab'
 
       - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
         uses: actions/cache@v4
         with:
           path: |


### PR DESCRIPTION
## What & why

The `pack → load smoke` job — and any workflow sharing the `Cache Cargo` step — intermittently fails when `actions/cache@v4` hangs mid-run: the job dies at the cache step (status `in_progress`) **before any test step executes**, so the failed-job log is empty and the actual checks never ran. It red-flags otherwise-green PRs and forces a manual `gh run rerun --failed` every time — pure churn. It hit #1372, #1373, and #1375 this week (#1375, the escalate linchpin, was held up by it).

A cache is a build accelerator, not a correctness gate — a cache-service failure should degrade to a cold build, never fail the job.

## Change

Add `continue-on-error: true` to the `Cache Cargo` step in all **14** workflows that use `actions/cache@v4`. On a cache-service flake the step is marked non-fatal and the job proceeds to run the real checks (slower, cold build). A genuine `cargo test` / xtask failure still fails the job — the test/check steps are untouched.

Swept across all 14 for uniformity (identical step in each). The two workflows with no `Cache Cargo` step (`license-check.yml`, `release-please.yml`) are untouched. All patched files validated as still-parsing YAML; `continue-on-error` sits as a step-level key alongside `uses:`.

This is the permanent fix for the recurring first-run-X flake — no more per-PR re-triggers.

Closes #1378

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DEfgEGQczmiDxYcWzAv6D
