### PR TITLE
feat(sdk): engine-free request_runtime_shutdown via reserved plugin-ABI control topic

### DIFF
--- a/packages/audio/tests/sdk_pubsub_resolves.rs
+++ b/packages/audio/tests/sdk_pubsub_resolves.rs
@@ -5,10 +5,16 @@
 //!
 //! This crate is a domain package (`streamlib-audio`) that depends on
 //! `streamlib` (the SDK facade) and NOT on `streamlib-engine`. If
-//! `streamlib::sdk::pubsub::*` stops resolving here, packages can no
-//! longer publish runtime events (e.g. `RuntimeEvent::RuntimeShutdown`
-//! from a display package on window-close) without reaching past the
-//! SDK boundary.
+//! `streamlib::sdk::pubsub::*` stops resolving here, facade packages can
+//! no longer publish or subscribe to runtime events without reaching
+//! past the SDK boundary.
+//!
+//! Requesting runtime shutdown is no longer a consumer of this facade
+//! path: engine-free packages on `streamlib-plugin-sdk` call
+//! `sdk::runtime_control::request_runtime_shutdown`, which routes a
+//! reason string through the reserved plugin-ABI control topic and lets
+//! the host own the `Event` encoding. This test still locks the facade
+//! pubsub surface that facade packages like this one depend on.
 
 use parking_lot::Mutex;
 use std::sync::Arc;

--- a/runtime/streamlib-engine/src/core/plugin/host_services/mod.rs
+++ b/runtime/streamlib-engine/src/core/plugin/host_services/mod.rs
@@ -690,6 +690,14 @@ unsafe extern "C" fn host_tracing_emit(
     )
 }
 
+/// Reserved topic-namespace prefix for host-interpreted `control:` topics
+/// (e.g. [`streamlib_plugin_abi::PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST`]).
+/// A topic under this prefix is mapped to a host action in
+/// [`host_pubsub_publish`] and is never decoded as an `Event` or delivered
+/// to subscribers; a prefixed topic that matches no handler is warn-dropped,
+/// never re-published.
+const RESERVED_CONTROL_TOPIC_PREFIX: &str = "control:";
+
 unsafe extern "C" fn host_pubsub_publish(
     _host: HostHandle,
     topic_ptr: *const u8,
@@ -713,6 +721,27 @@ unsafe extern "C" fn host_pubsub_publish(
             if topic == streamlib_plugin_abi::PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST {
                 let reason: String = rmp_serde::from_slice(event_bytes).unwrap_or_default();
                 crate::core::runtime::request_runtime_shutdown_from_plugin_abi_boundary(&reason);
+                return;
+            }
+
+            // The `control:` namespace is reserved for host-interpreted
+            // control topics (matched above), never delivered to `Event` /
+            // `Custom` subscribers. A `control:`-prefixed topic that matched
+            // no handler is a host/plugin version skew or a plugin misusing
+            // the reserved namespace: warn-and-drop rather than routing it
+            // into the general `Event` decode / re-publish path below, which
+            // would silently hijack or swallow the reserved topic. Enforcing
+            // the reservation here makes it host-defended, not prose.
+            if topic.starts_with(RESERVED_CONTROL_TOPIC_PREFIX) {
+                tracing::warn!(
+                    target: "streamlib::plugin",
+                    topic,
+                    "host_pubsub_publish: reserved `control:` topic with no \
+                     registered handler — dropping (not re-published as an \
+                     Event). A plugin published a reserved control topic this \
+                     host does not handle (host/plugin version skew or \
+                     reserved-namespace misuse)."
+                );
                 return;
             }
 
@@ -1235,6 +1264,110 @@ mod runtime_shutdown_control_topic_tests {
             Some(Event::RuntimeGlobal(RuntimeEvent::RuntimeShutdown)),
             "the control topic must map to a RuntimeShutdown event on RUNTIME_GLOBAL",
         );
+
+        drop(listener);
+    }
+
+    /// A `control:`-prefixed topic with NO registered host handler must be
+    /// warn-dropped by `host_pubsub_publish`, never routed into the general
+    /// `Event` decode / re-publish path — otherwise an `Event::Custom`
+    /// landing on a reserved `control:` topic would be silently
+    /// re-published to (hijacking) that reserved topic. Mental-revert:
+    /// removing the reserved-namespace guard sends the (valid) `Custom`
+    /// bytes into `PUBSUB.publish(control_topic, ..)`, the warmed-up
+    /// subscriber below receives them, and the final assertion fails.
+    #[test]
+    fn host_pubsub_publish_drops_unhandled_reserved_control_topic() {
+        // Same global-bus rationale as the mapping test above: the drop /
+        // re-publish decision lands on the process-global PUBSUB. A unique
+        // topic namespaces this test's delivery from every other.
+        let runtime_id = format!("test-unhandled-control-{}", uuid::Uuid::new_v4());
+        let node = Iceoryx2Node::new().expect("Failed to create iceoryx2 node");
+        PUBSUB.init(&runtime_id, node);
+
+        // A reserved `control:`-prefixed topic that maps to NO host handler.
+        let unhandled_control_topic = format!("control:unhandled-{}", uuid::Uuid::new_v4());
+
+        let (tx, rx) = mpsc::channel();
+        let listener: Arc<Mutex<dyn EventListener>> =
+            Arc::new(Mutex::new(RuntimeGlobalChannelListener { sender: tx }));
+        PUBSUB.subscribe(&unhandled_control_topic, listener.clone());
+
+        // The bytes the drop path must NOT deliver: a fully valid `Event`
+        // msgpack — a `Custom` event whose topic is the reserved one,
+        // encoded exactly as a cdylib encodes events (`to_vec_named`). It
+        // MUST decode cleanly so a reverted guard would re-publish it,
+        // keeping this a reservation test, not an accidental decode test.
+        let hijack_event = Event::custom(
+            unhandled_control_topic.clone(),
+            serde_json::Value::String("must-not-be-delivered".to_string()),
+        );
+        let hijack_bytes = rmp_serde::to_vec_named(&hijack_event).expect("encode Custom event");
+        assert!(
+            rmp_serde::from_slice::<Event>(&hijack_bytes).is_ok(),
+            "the drop-path payload must decode as an Event so the mental-revert would deliver it",
+        );
+
+        // Warm-up: prove the subscriber is live on this exact topic by
+        // delivering a DISTINCT probe event directly through the bus (the
+        // same transport a reverted `host_pubsub_publish` would use). Until
+        // this arrives there is no subscriber and a negative assertion would
+        // be vacuous.
+        let probe_event = Event::custom(
+            unhandled_control_topic.clone(),
+            serde_json::Value::String("transport-liveness-probe".to_string()),
+        );
+        let warmup_deadline = Instant::now() + Duration::from_secs(5);
+        let mut warmed_up = false;
+        while Instant::now() < warmup_deadline {
+            PUBSUB.publish(&unhandled_control_topic, &probe_event);
+            match rx.recv_timeout(Duration::from_millis(50)) {
+                Ok(_) => {
+                    warmed_up = true;
+                    break;
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+        assert!(
+            warmed_up,
+            "subscriber never became live on the reserved control topic — negative assertion would be vacuous",
+        );
+
+        // Drain any buffered warm-up duplicates so only post-drop delivery
+        // is observed below.
+        while rx.try_recv().is_ok() {}
+
+        // The path under test: publish the hijack event on the reserved
+        // control topic THROUGH `host_pubsub_publish`. The guard must drop it.
+        // SAFETY: `host` is unused by `host_pubsub_publish`; the topic and
+        // payload slices outlive the call.
+        unsafe {
+            host_pubsub_publish(
+                std::ptr::null(),
+                unhandled_control_topic.as_ptr(),
+                unhandled_control_topic.len(),
+                hijack_bytes.as_ptr(),
+                hijack_bytes.len(),
+            );
+        }
+
+        // Assert the hijack event never reaches the subscriber. Warm-up
+        // established ~<=50ms delivery latency, so a silent window well
+        // beyond that is a strong drop signal. Late warm-up duplicates
+        // (distinct payload) are ignored; only the hijack payload fails.
+        let quiet_deadline = Instant::now() + Duration::from_secs(1);
+        while Instant::now() < quiet_deadline {
+            match rx.recv_timeout(Duration::from_millis(50)) {
+                Ok(event) => assert_ne!(
+                    event, hijack_event,
+                    "a reserved `control:` topic with no handler was re-published to subscribers instead of being warn-dropped",
+                ),
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
 
         drop(listener);
     }

--- a/runtime/streamlib-engine/src/core/plugin/host_services/mod.rs
+++ b/runtime/streamlib-engine/src/core/plugin/host_services/mod.rs
@@ -705,6 +705,17 @@ unsafe extern "C" fn host_pubsub_publish(
             };
             let event_bytes =
                 unsafe { std::slice::from_raw_parts(event_msgpack_ptr, event_msgpack_len) };
+
+            // Reserved `control:` topics carry a per-topic payload defined
+            // next to their constant, NOT an `Event` msgpack, and map onto
+            // an internal host action rather than re-publishing the bytes.
+            // Match them before the general `Event` decode below.
+            if topic == streamlib_plugin_abi::PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST {
+                let reason: String = rmp_serde::from_slice(event_bytes).unwrap_or_default();
+                crate::core::runtime::request_runtime_shutdown_from_plugin_abi_boundary(&reason);
+                return;
+            }
+
             let event: Event = match rmp_serde::from_slice(event_bytes) {
                 Ok(e) => e,
                 Err(e) => {
@@ -1130,3 +1141,101 @@ pub mod runtime_facing {
 // `tests/` under the `streamlib/hardware-tests` feature. The dlopen
 // integration test that exercises the full cdylib → vtable → host chain
 // arrives with C3.
+
+// =============================================================================
+// Reserved-control-topic mapping tests (iceoryx2 transport, no GPU required)
+// =============================================================================
+
+#[cfg(test)]
+mod runtime_shutdown_control_topic_tests {
+    use super::host_pubsub_publish;
+    use crate::core::pubsub::{Event, EventListener, PUBSUB, RuntimeEvent, topics};
+    use crate::iceoryx2::Iceoryx2Node;
+    use parking_lot::Mutex;
+    use std::sync::Arc;
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
+
+    /// Forwards received events through an mpsc channel for assertion.
+    struct RuntimeGlobalChannelListener {
+        sender: mpsc::Sender<Event>,
+    }
+
+    impl EventListener for RuntimeGlobalChannelListener {
+        fn on_event(&mut self, event: &Event) -> crate::core::error::Result<()> {
+            let _ = self.sender.send(event.clone());
+            Ok(())
+        }
+    }
+
+    /// `host_pubsub_publish` matches the reserved
+    /// `control:runtime-shutdown-request` topic BEFORE the general
+    /// `Event` decode: the msgpack reason string is mapped onto
+    /// `Event::RuntimeGlobal(RuntimeEvent::RuntimeShutdown)` and
+    /// published on `RUNTIME_GLOBAL`, where any shutdown listener sees
+    /// it. Reverting that topic-match sends the reason bytes into the
+    /// `Event` decode instead — a bare msgpack string is not a valid
+    /// `Event` map, so it warn-and-drops and the subscriber below never
+    /// receives the shutdown. That is what makes this test genuinely
+    /// exercise the mapping rather than the transport.
+    #[test]
+    fn host_pubsub_publish_maps_control_topic_to_runtime_shutdown() {
+        // The host-side publish lands on the process-global PUBSUB, so
+        // this test drives the global bus (the pubsub integration tests
+        // use ad-hoc local buses; the control mapping is wired to the
+        // global one the runtime installs). `init` is a `OnceLock`
+        // set — first writer wins — and the unique runtime_id namespaces
+        // this test's iceoryx2 services so it cannot cross-talk with
+        // other tests' local buses.
+        let runtime_id = format!("test-shutdown-control-{}", uuid::Uuid::new_v4());
+        let node = Iceoryx2Node::new().expect("Failed to create iceoryx2 node");
+        PUBSUB.init(&runtime_id, node);
+
+        let (tx, rx) = mpsc::channel();
+        let listener: Arc<Mutex<dyn EventListener>> =
+            Arc::new(Mutex::new(RuntimeGlobalChannelListener { sender: tx }));
+        PUBSUB.subscribe(topics::RUNTIME_GLOBAL, listener.clone());
+
+        // The control-topic payload is a msgpack UTF-8 reason string,
+        // NOT an `Event` msgpack.
+        let reason = "unit-test shutdown request";
+        let reason_bytes = rmp_serde::to_vec(reason).expect("encode shutdown reason");
+        let topic = streamlib_plugin_abi::PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST;
+
+        // Retry-publish to cover the subscriber-thread startup race
+        // (PubSub gives no readiness signal), mirroring the pubsub
+        // integration tests' `publish_until_received`. Repeated requests
+        // are idempotent by design.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut received = None;
+        while Instant::now() < deadline {
+            // SAFETY: `host` is unused by `host_pubsub_publish`; the topic
+            // and payload slices outlive the call.
+            unsafe {
+                host_pubsub_publish(
+                    std::ptr::null(),
+                    topic.as_ptr(),
+                    topic.len(),
+                    reason_bytes.as_ptr(),
+                    reason_bytes.len(),
+                );
+            }
+            match rx.recv_timeout(Duration::from_millis(50)) {
+                Ok(event) => {
+                    received = Some(event);
+                    break;
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+
+        assert_eq!(
+            received,
+            Some(Event::RuntimeGlobal(RuntimeEvent::RuntimeShutdown)),
+            "the control topic must map to a RuntimeShutdown event on RUNTIME_GLOBAL",
+        );
+
+        drop(listener);
+    }
+}

--- a/runtime/streamlib-engine/src/core/runtime/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/mod.rs
@@ -31,3 +31,24 @@ pub use operations::{BoxFuture, RuntimeOperations};
 pub use runtime::Runner;
 pub use runtime_unique_id::RuntimeUniqueId;
 pub use status::RuntimeStatus;
+
+use crate::core::pubsub::{Event, PUBSUB, RuntimeEvent};
+
+/// Map a cross-plugin-ABI shutdown request onto the engine's internal
+/// runtime-shutdown event. This is the single mapping point every
+/// engine-free boundary funnels through — today the plugin-ABI
+/// `pubsub_publish` control topic
+/// ([`streamlib_plugin_abi::PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST`]),
+/// tomorrow a subprocess escalate op or an api-server endpoint — so the
+/// engine owns the `Event` encoding in exactly one place rather than
+/// letting each boundary freeze it into its own wire form. The request
+/// is idempotent (the shutdown listeners are flag-setting) and
+/// fire-and-forget, matching every other `RuntimeShutdown` publisher
+/// including the engine's own signal handler. `reason` is logged at
+/// `info` so operators can attribute who stopped the runtime.
+#[tracing::instrument]
+pub fn request_runtime_shutdown_from_plugin_abi_boundary(reason: &str) {
+    tracing::info!(reason, "runtime shutdown requested across the plugin ABI");
+    let shutdown_event = Event::RuntimeGlobal(RuntimeEvent::RuntimeShutdown);
+    PUBSUB.publish(&shutdown_event.topic(), &shutdown_event);
+}

--- a/runtime/streamlib-plugin-abi/src/lib.rs
+++ b/runtime/streamlib-plugin-abi/src/lib.rs
@@ -416,6 +416,24 @@ pub const PLUGIN_ABI_LAYOUT_FINGERPRINT: u64 = {
 };
 
 // =============================================================================
+// Reserved PUBSUB control topics
+// =============================================================================
+
+/// Reserved control topic for [`HostServices::pubsub_publish`]: an
+/// engine-free plugin asks the host runtime to shut down (equivalent
+/// to SIGINT/SIGTERM). The payload is a msgpack-encoded UTF-8 string —
+/// a human-readable reason for shutdown-attribution in host logs
+/// (empty string = unspecified). The host never re-publishes on this
+/// topic; it maps the request onto its internal runtime-shutdown
+/// event. Requests are idempotent and fire-and-forget.
+///
+/// The string value is wire contract shared by every host and every
+/// plugin — a silent rename is a break, so it is locked by a
+/// constant-value test in this crate.
+pub const PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST: &str =
+    "control:runtime-shutdown-request";
+
+// =============================================================================
 // HostServices — the callback table
 // =============================================================================
 
@@ -497,6 +515,13 @@ pub struct HostServices {
     /// the same way `PubSub::publish` encodes today (msgpack-named
     /// via `rmp_serde::to_vec_named`), so host-side
     /// deserialization is identical regardless of caller plugin.
+    ///
+    /// Reserved `control:` topics are the exception: their payload is
+    /// the per-topic wire shape defined next to their constant, NOT an
+    /// `Event` msgpack. The host matches those topics before the
+    /// `Event` decode and maps each onto an internal action rather than
+    /// re-publishing the bytes. See
+    /// [`PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST`].
     ///
     /// Subscribe is intentionally absent: cdylib code does not
     /// currently subscribe; if a future plugin shape needs it, add a
@@ -1209,5 +1234,24 @@ mod layout_tests {
         assert_send_sync::<VulkanTextureReadbackMethodsVTable>();
         assert_send_sync::<HostServices>();
         assert_send_sync::<ProcessorVTable>();
+    }
+}
+
+#[cfg(test)]
+mod control_topic_tests {
+    use super::*;
+
+    /// The reserved control-topic string is wire contract shared by
+    /// every host and every already-built plugin: the host matches on
+    /// this exact literal in `host_pubsub_publish`, and the SDK's
+    /// `request_runtime_shutdown` publishes to it. A silent rename
+    /// would make the host warn-and-drop the request and the runtime
+    /// would hang, so the value is locked here.
+    #[test]
+    fn runtime_shutdown_request_control_topic_value_is_locked() {
+        assert_eq!(
+            PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST,
+            "control:runtime-shutdown-request"
+        );
     }
 }

--- a/sdk/streamlib-error/src/lib.rs
+++ b/sdk/streamlib-error/src/lib.rs
@@ -114,6 +114,9 @@ pub enum Error {
     #[error("Runtime error: {0}")]
     Runtime(String),
 
+    #[error("Plugin host services unavailable: {0}")]
+    PluginHostUnavailable(String),
+
     #[error("Invalid escalate scope: {0}")]
     InvalidEscalateScope(String),
 

--- a/sdk/streamlib-plugin-sdk/src/lib.rs
+++ b/sdk/streamlib-plugin-sdk/src/lib.rs
@@ -34,6 +34,7 @@ mod plugin;
 mod processors;
 #[cfg(target_os = "linux")]
 mod rhi;
+mod runtime_control;
 
 /// Public plugin-authoring surface. Packages author against
 /// `streamlib_plugin_sdk::sdk::*`; the `#[processor]` macro and
@@ -167,6 +168,15 @@ pub mod sdk {
         pub use crate::iceoryx2::{
             InputMailboxes, InputMailboxesInner, OutputWriter, OutputWriterInner, ReadMode,
         };
+    }
+
+    // ---- Runtime-control requests (engine-free) ----
+    /// `request_runtime_shutdown` — ask the host runtime to stop
+    /// without any engine type crossing into the plugin. Backed by the
+    /// reserved plugin-ABI control topic and the cached `pubsub_publish`
+    /// callback.
+    pub mod runtime_control {
+        pub use crate::runtime_control::request_runtime_shutdown;
     }
 
     // ---- Plugin registration glue (cdylib arm) ----

--- a/sdk/streamlib-plugin-sdk/src/runtime_control.rs
+++ b/sdk/streamlib-plugin-sdk/src/runtime_control.rs
@@ -1,0 +1,75 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Engine-free runtime-control requests a plugin can make of its host.
+//!
+//! A plugin authored against this SDK links no engine, so it holds no
+//! engine `Event` / `RuntimeEvent` type and cannot publish a shutdown
+//! event directly. Instead it publishes a msgpack reason string to the
+//! reserved plugin-ABI control topic
+//! ([`streamlib_plugin_abi::PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST`])
+//! through the cached `pubsub_publish` callback; the host — the only
+//! party that owns `Event` — maps the request onto its internal
+//! runtime-shutdown event. Only the plugin-ABI topic constant and a
+//! reason string cross the boundary, never an engine type.
+
+use streamlib_error::{Error, Result};
+use streamlib_plugin_abi::PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST;
+
+/// Ask the host runtime to shut down (equivalent to Ctrl+C / SIGTERM).
+///
+/// `reason` is a human-readable attribution the host logs (empty string
+/// = unspecified). Idempotent and fire-and-forget: the host maps this
+/// onto its internal runtime-shutdown event, repeated calls are
+/// harmless, and a call during teardown is a no-op on the host side.
+///
+/// Returns [`Error::PluginHostUnavailable`] when called from a cdylib
+/// whose host services were never installed — i.e. code not loaded by a
+/// streamlib host — which is the only real failure class.
+#[tracing::instrument]
+pub fn request_runtime_shutdown(reason: &str) -> Result<()> {
+    let Some(callbacks) = crate::plugin::host_callbacks() else {
+        return Err(Error::PluginHostUnavailable(
+            "request_runtime_shutdown called in a cdylib whose host services \
+             were never installed (not loaded by a streamlib host)"
+                .into(),
+        ));
+    };
+
+    let reason_msgpack = rmp_serde::to_vec(reason)
+        .map_err(|e| Error::Runtime(format!("failed to encode shutdown reason: {e}")))?;
+
+    // SAFETY: `callbacks.pubsub_publish` and `callbacks.host` were
+    // populated by `install_host_services` from a host-provided
+    // `HostServices` and stay valid for the plugin's process lifetime.
+    // The topic and payload slices outlive the synchronous call.
+    unsafe {
+        (callbacks.pubsub_publish)(
+            callbacks.host,
+            PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST.as_ptr(),
+            PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST.len(),
+            reason_msgpack.as_ptr(),
+            reason_msgpack.len(),
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// With no host services installed (the SDK lib test binary never
+    /// calls `install_host_services`), the request has no transport to
+    /// reach and must surface the named `PluginHostUnavailable` error
+    /// rather than silently succeeding.
+    #[test]
+    fn request_runtime_shutdown_without_host_returns_plugin_host_unavailable() {
+        let result = request_runtime_shutdown("no host installed");
+        assert!(
+            matches!(result, Err(Error::PluginHostUnavailable(_))),
+            "expected PluginHostUnavailable, got {result:?}",
+        );
+    }
+}

--- a/sdk/streamlib-plugin-sdk/src/runtime_control.rs
+++ b/sdk/streamlib-plugin-sdk/src/runtime_control.rs
@@ -13,6 +13,7 @@
 //! runtime-shutdown event. Only the plugin-ABI topic constant and a
 //! reason string cross the boundary, never an engine type.
 
+use crate::plugin::HostCallbacks;
 use streamlib_error::{Error, Result};
 use streamlib_plugin_abi::PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST;
 
@@ -36,6 +37,19 @@ pub fn request_runtime_shutdown(reason: &str) -> Result<()> {
         ));
     };
 
+    publish_runtime_shutdown_request(callbacks, reason)
+}
+
+/// Encode `reason` and publish a runtime-shutdown request on the reserved
+/// plugin-ABI control topic through the host's `pubsub_publish` callback.
+///
+/// Split out of [`request_runtime_shutdown`] so the load-bearing wire
+/// selection — the reserved topic constant and the `rmp_serde::to_vec`
+/// reason encoding the host decodes with `rmp_serde::from_slice` — is
+/// driven by a hermetic test against a capturing `pubsub_publish`, without
+/// installing the process-global host-services table (which is a set-once
+/// `OnceLock` shared with the no-host negative test in this module).
+fn publish_runtime_shutdown_request(callbacks: &HostCallbacks, reason: &str) -> Result<()> {
     let reason_msgpack = rmp_serde::to_vec(reason)
         .map_err(|e| Error::Runtime(format!("failed to encode shutdown reason: {e}")))?;
 
@@ -59,6 +73,9 @@ pub fn request_runtime_shutdown(reason: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::cell::RefCell;
+    use core::ffi::c_void;
+    use streamlib_plugin_abi::{HostHandle, HostInterest, HostLogLevel, ProcessorVTable};
 
     /// With no host services installed (the SDK lib test binary never
     /// calls `install_host_services`), the request has no transport to
@@ -70,6 +87,164 @@ mod tests {
         assert!(
             matches!(result, Err(Error::PluginHostUnavailable(_))),
             "expected PluginHostUnavailable, got {result:?}",
+        );
+    }
+
+    /// One captured `pubsub_publish` call: the exact topic + payload byte
+    /// slices `request_runtime_shutdown` handed the host callback.
+    struct CapturedRuntimeShutdownPublish {
+        topic: Vec<u8>,
+        payload: Vec<u8>,
+    }
+
+    // Capturing `pubsub_publish`: `host` is a `*const RefCell<Vec<...>>`
+    // the test owns; copy the topic + payload bytes out and record them.
+    unsafe extern "C" fn capturing_pubsub_publish(
+        host: HostHandle,
+        topic_ptr: *const u8,
+        topic_len: usize,
+        payload_ptr: *const u8,
+        payload_len: usize,
+    ) {
+        let sink = unsafe { &*(host as *const RefCell<Vec<CapturedRuntimeShutdownPublish>>) };
+        let topic = unsafe { core::slice::from_raw_parts(topic_ptr, topic_len) }.to_vec();
+        let payload = unsafe { core::slice::from_raw_parts(payload_ptr, payload_len) }.to_vec();
+        sink.borrow_mut()
+            .push(CapturedRuntimeShutdownPublish { topic, payload });
+    }
+
+    // The shutdown request reads only `host` + `pubsub_publish`; these
+    // stubs fill the remaining `#[repr(C)]` fn-pointer fields so a full
+    // `HostCallbacks` can be built without a live host. Mirrors the
+    // `host_services_with_capture` pattern in
+    // `plugin/layout_skew_diagnostic.rs`.
+    unsafe extern "C" fn unused_tracing_register_callsite(
+        _: HostHandle,
+        _: *const u8,
+        _: usize,
+        _: HostLogLevel,
+    ) -> HostInterest {
+        HostInterest::Never
+    }
+    unsafe extern "C" fn unused_tracing_enabled(
+        _: HostHandle,
+        _: *const u8,
+        _: usize,
+        _: HostLogLevel,
+    ) -> bool {
+        false
+    }
+    unsafe extern "C" fn unused_tracing_emit(
+        _: HostHandle,
+        _: *const u8,
+        _: usize,
+        _: HostLogLevel,
+        _: *const u8,
+        _: usize,
+        _: *const u8,
+        _: usize,
+    ) {
+    }
+    unsafe extern "C" fn unused_schema_register(
+        _: HostHandle,
+        _: *const u8,
+        _: usize,
+        _: *const u8,
+        _: usize,
+    ) {
+    }
+    unsafe extern "C" fn unused_schema_lookup(
+        _: HostHandle,
+        _: *const u8,
+        _: usize,
+        _: extern "C" fn(*mut c_void, *const u8, usize),
+        _: *mut c_void,
+    ) {
+    }
+    unsafe extern "C" fn unused_iceoryx_log_emit(
+        _: HostHandle,
+        _: HostLogLevel,
+        _: *const u8,
+        _: usize,
+        _: *const u8,
+        _: usize,
+    ) {
+    }
+    unsafe extern "C" fn unused_processor_register(
+        _: HostHandle,
+        _: *const u8,
+        _: usize,
+        _: *const ProcessorVTable,
+    ) -> i32 {
+        0
+    }
+
+    // A `HostCallbacks` whose `pubsub_publish` records into `sink` and
+    // whose `host` points at it; every other slot is an unused stub or a
+    // null vtable pointer.
+    fn host_callbacks_with_capture(
+        sink: &RefCell<Vec<CapturedRuntimeShutdownPublish>>,
+    ) -> HostCallbacks {
+        HostCallbacks {
+            host: sink as *const RefCell<Vec<CapturedRuntimeShutdownPublish>> as HostHandle,
+            tracing_register_callsite: unused_tracing_register_callsite,
+            tracing_enabled: unused_tracing_enabled,
+            tracing_emit: unused_tracing_emit,
+            pubsub_publish: capturing_pubsub_publish,
+            schema_register: unused_schema_register,
+            schema_lookup: unused_schema_lookup,
+            iceoryx_log_emit: unused_iceoryx_log_emit,
+            processor_register: unused_processor_register,
+            runtime_context_vtable: core::ptr::null(),
+            audio_clock_vtable: core::ptr::null(),
+            runtime_ops_vtable: core::ptr::null(),
+            gpu_context_limited_access_vtable: core::ptr::null(),
+            surface_store_vtable: core::ptr::null(),
+            gpu_context_full_access_vtable: core::ptr::null(),
+            texture_ring_methods_vtable: core::ptr::null(),
+            vulkan_compute_kernel_methods_vtable: core::ptr::null(),
+            vulkan_graphics_kernel_methods_vtable: core::ptr::null(),
+            vulkan_ray_tracing_kernel_methods_vtable: core::ptr::null(),
+            vulkan_acceleration_structure_methods_vtable: core::ptr::null(),
+            rhi_color_converter_methods_vtable: core::ptr::null(),
+            rhi_command_recorder_methods_vtable: core::ptr::null(),
+            output_writer_vtable: core::ptr::null(),
+            input_mailboxes_vtable: core::ptr::null(),
+            present_target_methods_vtable: core::ptr::null(),
+            video_encoder_session_methods_vtable: core::ptr::null(),
+            video_decoder_session_methods_vtable: core::ptr::null(),
+            host_timeline_semaphore_methods_vtable: core::ptr::null(),
+            vulkan_texture_readback_methods_vtable: core::ptr::null(),
+        }
+    }
+
+    /// The SDK's wire selection is load-bearing: the host decodes the
+    /// reason with `rmp_serde::from_slice(..).unwrap_or_default()` and
+    /// STILL shuts down, so a drifted SDK encoding silently loses reason
+    /// attribution with no failure. This pins the exact `(topic, payload)`
+    /// the SDK hands the host `pubsub_publish` callback. Mental-revert:
+    /// swapping the topic constant, or `to_vec` → `to_vec_named` / raw
+    /// bytes / omitted encode, fails one of the asserts below.
+    #[test]
+    fn request_runtime_shutdown_publishes_reserved_control_topic_with_msgpack_reason() {
+        let sink: RefCell<Vec<CapturedRuntimeShutdownPublish>> = RefCell::new(Vec::new());
+        let callbacks = host_callbacks_with_capture(&sink);
+
+        let result = publish_runtime_shutdown_request(&callbacks, "x");
+        assert!(result.is_ok(), "publish helper must succeed, got {result:?}");
+
+        let captured = sink.borrow();
+        assert_eq!(captured.len(), 1, "exactly one pubsub_publish call");
+        let call = &captured[0];
+        assert_eq!(
+            call.topic,
+            PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST.as_bytes(),
+            "topic must be EXACTLY the reserved runtime-shutdown control topic",
+        );
+        assert_eq!(
+            call.payload,
+            rmp_serde::to_vec("x").expect("encode reason"),
+            "payload must be the msgpack reason the host decodes with rmp_serde::from_slice",
         );
     }
 }


### PR DESCRIPTION
Closes #1385

## Summary

Adds the engine-free `sdk::runtime_control::request_runtime_shutdown(reason)` primitive so an
engine-free cdylib plugin (e.g. `@tatolab/display` on window-close / `--frames N`, precursor for
#1266) can ask the host runtime to stop — without any engine `Event` / `RuntimeEvent` / `PUBSUB`
type crossing the plugin ABI.

Design (Fable-designed, owner-approved — Option A: reserved control topic, host-owned mapping):

- **`streamlib-plugin-abi`**: new `PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST` constant
  (`"control:runtime-shutdown-request"`). Payload on this topic is a msgpack UTF-8 reason string,
  not `Event`. `pubsub_publish` doc comment amended to document the reserved-topic contract.
  Constant-value lock test added. **No `#[repr(C)]` field, no vtable slot, no layout-version bump**
  — the shutdown request reuses the existing `pubsub_publish` transport slot.
- **Engine host** (`host_pubsub_publish`, `core/plugin/host_services/mod.rs`): matches the
  control topic before the general `Event` decode and calls a new host-internal
  `request_runtime_shutdown_from_plugin_abi_boundary(reason)`, which publishes
  `Event::RuntimeGlobal(RuntimeEvent::RuntimeShutdown)` — the single reusable mapping point for
  future ABI-boundary shutdown requests (e.g. a subprocess escalate op).
- **SDK**: new `sdk::runtime_control` module — `request_runtime_shutdown(reason: &str) -> Result<()>`,
  fire-and-forget, idempotent, `#[tracing::instrument]`. Not a `RuntimeContext` method (display's
  render thread outlives the ctx borrow).
- **streamlib-error**: new named variant `Error::PluginHostUnavailable(String)`.

Rejected alternatives (see issue): SDK-owned static bytes of the engine `Event` enum (freezes
engine-internal serde as a de-facto ABI, silent-hang on drift); a new `HostServices` slot or
`RuntimeOps` v3 slot (forces a layout-version bump that would refuse every already-built
`.slpkg`; wrong growth axis — shutdown is a bus event, not a graph-mutation op).

## Exit criteria

- [x] `request_runtime_shutdown(reason)` drives runtime shutdown end-to-end through the existing
      `pubsub_publish` slot; no engine type crosses the ABI; **no layout-version bump** —
      `git diff origin/main -- runtime/streamlib-plugin-abi/` is only the new const, the doc-comment
      amend, and its lock test.
- [x] Named error variant + `tracing`; the host mapping helper is documented as the single reusable
      ABI-boundary shutdown mapping.

## Test evidence

Ran in a worktree of this branch (`f52d2392`):

```
$ cargo test -p streamlib-plugin-abi control_topic
test control_topic_tests::runtime_shutdown_request_control_topic_value_is_locked ... ok

$ cargo test -p streamlib-plugin-sdk request_runtime_shutdown
test runtime_control::tests::request_runtime_shutdown_without_host_returns_plugin_host_unavailable ... ok

$ cargo test -p streamlib-engine --lib host_pubsub_publish_maps_control_topic
test core::plugin::host_services::runtime_shutdown_control_topic_tests::host_pubsub_publish_maps_control_topic_to_runtime_shutdown ... ok
```

All three pass. Mental revert of the topic-match in `host_pubsub_publish`: the general path would
publish on the raw `control:` topic string instead of the `RUNTIME_GLOBAL` subscriber's channel
(and a bare msgpack string also fails `Event` decode), so the engine integration test fails on
revert — it exercises the actual bug, not a tautology.

Diffstat:

```
 packages/audio/tests/sdk_pubsub_resolves.rs        |  14 ++-
 .../src/core/plugin/host_services/mod.rs           | 109 +++++++++++++++++++++
 runtime/streamlib-engine/src/core/runtime/mod.rs   |  21 ++++
 runtime/streamlib-plugin-abi/src/lib.rs            |  44 +++++++++
 sdk/streamlib-error/src/lib.rs                     |   3 +
 sdk/streamlib-plugin-sdk/src/lib.rs                |  10 ++
 sdk/streamlib-plugin-sdk/src/runtime_control.rs    |  75 ++++++++++++++
 7 files changed, 272 insertions(+), 4 deletions(-)
```

No GPU/IPC-runtime E2E was required for this change (in-process pubsub wiring only, verified via
the real `iceoryx2` bus in the engine integration test above) — no separate E2E report.

## Review items (non-blocking)

All lenses (change-verifier + path-routed domain reviews) passed this branch. The items below are
recorded verbatim from that pass for the owner's visibility; none block merge.

1. **[info]** `runtime/streamlib-plugin-abi/src/lib.rs:416` — NO layout-version bump; plugin-abi
   diff is only the new const + doc-comment amend + lock test (exit criterion 1).
   `PLUGIN_ABI_LAYOUT_FINGERPRINT` (lib.rs:244) folds only `*_LAYOUT_VERSION` constants and struct
   size/align — adding `PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST` touches none of them.
   `git diff origin/main -- runtime/streamlib-plugin-abi/` shows only the const, the
   `HostServices::pubsub_publish` doc amend, and control_topic_tests. No version constant changed.
   *Next step: none — criterion met.*

2. **[info]** `runtime/streamlib-engine/src/core/plugin/host_services/mod.rs:1188` — all three
   claimed tests exist, pass, and are non-vacuous. Ran in a worktree of the branch: plugin-abi lock
   test PASS; SDK no-host `PluginHostUnavailable` PASS; engine
   `host_pubsub_publish_maps_control_topic_to_runtime_shutdown` PASS (real iceoryx2). Mental revert
   of the topic-match: the general path publishes on the raw `control:` topic string not
   `RUNTIME_GLOBAL`, so the `RUNTIME_GLOBAL` subscriber gets nothing (and a bare msgpack string
   also fails `Event` decode) — the test fails on revert. *Next step: none.*

3. **[low]** `runtime/streamlib-engine/src/core/plugin/host_services/mod.rs:1192` — the engine
   integration test's namespace isolation relies on being the first `PUBSUB.init` in the test
   binary. `PUBSUB.init` is a first-writer-wins `OnceLock` (bus.rs:71). `runtime.rs:255` and
   `loop_control.rs:117` also call it; if a `Runner`-based lib test init'd `PUBSUB` first, this
   test's unique `runtime_id` is silently ignored and its subscriber shares the global
   `RUNTIME_GLOBAL` service, so a foreign `RuntimeStarted`/`GraphDidChange` could be picked up first
   and break the exact-match assert. In practice mitigated: `Runner` construction is GPU-gated and
   does not run under `cargo test --lib` CI; test passed here. The comment acknowledges the
   `OnceLock` behavior. *Next step: optional PR note; no change required for merge.*

4. **[info]** `runtime/streamlib-engine/src/core/plugin/host_services/mod.rs:714` — malformed
   reason payload on the control topic still triggers shutdown.
   `let reason: String = rmp_serde::from_slice(event_bytes).unwrap_or_default();` — a
   non-decodable payload yields `reason=""` and still calls
   `request_runtime_shutdown_from_plugin_abi_boundary`. Consistent with the documented
   fire-and-forget, topic-is-the-signal design (empty string = unspecified); only the SDK's
   `request_runtime_shutdown` publishes on this topic. *Next step: none — intended behavior.*

5. **[info]** Correct design call: the shutdown request rides the existing `pubsub_publish` slot
   via a reserved topic string, so NO vtable slot is added and NO layout version / fingerprint is
   bumped. This is the right five-part-contract-vs-reuse judgment.
   `runtime/streamlib-plugin-abi/src/lib.rs:433` adds only
   `pub const PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST` + docs + a test module — no
   `#[repr(C)]` struct field and no vtable slot changed, so `PLUGIN_ABI_LAYOUT_FINGERPRINT` and
   `HOST_SERVICES_LAYOUT_VERSION` correctly stay put. Bumping either would have falsely rejected
   compatible already-built `.slpkg` plugins at the load handshake. *Next step: none — noting the
   correct restraint so a later reviewer doesn't "fix" a missing bump that shouldn't exist.*

6. **[should-fix]** `sdk/streamlib-plugin-sdk/src/runtime_control.rs:30` — the new cross-ABI wire
   contract has no SDK-side positive wire-format test. The SDK's topic selection and reason
   encoding are verified only by inspection; a regression there would silently lose reason
   attribution while shutdown still fires, so no test would catch it.
   `request_runtime_shutdown` encodes the reason with `rmp_serde::to_vec(reason)` (line 39) and
   calls `(callbacks.pubsub_publish)(host, TOPIC.as_ptr(), TOPIC.len(), payload…)` (line 47). The
   only SDK test (line 68) is the no-host negative path. The host side decodes with
   `rmp_serde::from_slice(event_bytes).unwrap_or_default()`
   (`host_services/mod.rs:714`), so if the SDK ever changed its encoding (e.g. `to_vec_named`, raw
   bytes, or forgot to encode), the host would fall back to an empty reason and still shut down —
   the load-bearing behavior masks the regression. The host mapping test
   (`host_services/mod.rs:1182`) exercises `host_pubsub_publish` directly with its own `to_vec`
   bytes; it never drives the SDK's actual call, so the SDK's (topic, payload) selection is
   untested. *Next step: add an SDK positive test that installs a capturing `HostServices` (reuse
   the `host_services_with_capture` pattern in `plugin/layout_skew_diagnostic.rs`), calls
   `request_runtime_shutdown("x")`, and asserts the captured callback received exactly
   `PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST` as the topic slice and
   `rmp_serde::to_vec("x")` as the payload. Ship as a documented review item on the PR body if not
   blocking.*

7. **[info]** Cross-build soundness of the reserved topic rests entirely on the value-lock test,
   not the build fingerprint — a correct but worth-recording boundary of the fingerprint's
   protection. The topic string is not folded into `PLUGIN_ABI_LAYOUT_FINGERPRINT` (correct — it is
   not a `#[repr(C)]` layout element; the fingerprint folds versions + first-order raw-`Arc` transit
   layout). The value-lock test at `runtime/streamlib-plugin-abi/src/lib.rs:1251` is the sole
   guard. Implication: if the constant value were ever edited (with the lock test updated to
   match), a new host + an already-built older plugin would diverge — the host would fail the
   `topic ==` match at `host_services/mod.rs:713`, route the bytes into the `Event` decode,
   warn-and-drop them, and that plugin's shutdown requests would hang, while the fingerprint
   handshake would NOT refuse the load. The doc comment at lib.rs already states "a silent rename
   is a break"; this just records that the fingerprint is not the backstop here. *Next step: none
   — the value-lock test is the intended and sufficient mitigation. Do not fold the string into the
   fingerprint (that would over-couple).*

8. **[info]** No canonical-pattern-sweep violation: the display/camera packages that publish
   `RuntimeEvent::RuntimeShutdown` directly are facade (engine-linked) packages and legitimately
   hold `Event`; the new `request_runtime_shutdown` is an addition for engine-free plugins, not a
   replacement of the facade publish path. `packages/display/Cargo.toml` still depends on the
   `streamlib` facade and remains in `PACKAGES_FACADE_DEP_ALLOWLIST`
   (`xtask/src/check_boundaries.rs:994`); its direct publish at
   `packages/display/src/linux/display.rs:282` is valid. The audio facade test doc
   (`packages/audio/tests/sdk_pubsub_resolves.rs`) was correctly updated to reflect that
   shutdown-request is no longer a facade-only concern while still locking the facade pubsub
   surface. frame-tap was correctly removed from both the facade-dep and engine-reach allowlists
   (`check_boundaries.rs`) matching its engine-free conversion, and its GPU readback goes through
   `GpuContextLimitedAccess::escalate` + `create_texture_readback` inside `process()`
   (`packages/frame-tap/src/frame_tap.rs:319`), never naming the host device — the escalate is in a
   `LimitedAccess` `process()` path, not a `FullAccess` lifecycle body. *Next step: none.*

9. **[should-fix]** `runtime/streamlib-engine/src/core/plugin/host_services/mod.rs:713` — the
   newly-reserved `control:` topic family is enforced only by exact-string equality against the
   caller-supplied topic, with no guard on the `Event` publish path. An `Event::Custom { topic, .. }`
   (whose `topic()` returns the caller's arbitrary string, `events.rs:67`) equal to a reserved
   control string is intercepted before the `Event` decode and hijacked into an internal host
   action — it is never delivered to `Custom` subscribers. Today only the exact literal
   `control:runtime-shutdown-request` collides (accidental collision is near-nil), but the code
   comments repeatedly describe `control:` as a growing reserved namespace ("Reserved `control:`
   topics", plural), so as the family grows any Custom/Event publisher landing on a reserved topic
   is silently swallowed. The reservation is asserted in prose but not defended at the wire.
   `host_services/mod.rs:713` `if topic == streamlib_plugin_abi::PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST`
   matches before the general decode at line 719; `pubsub/events.rs:67` lets a `Custom` event carry
   an arbitrary topic; no `starts_with("control:")` rejection exists on the publish path.
   *Next step: ship as a documented PR review item: either reject/validate `control:`-prefixed
   topics on the general `Event` publish path (host + SDK), or document the reservation
   prominently so packages avoid it. An engine wire-format namespace reservation should be
   type/validation-enforced, not comment-enforced.*

10. **[low]** The reason decode uses `unwrap_or_default()`, so a malformed (non-string)
    control-topic payload still triggers a full runtime shutdown with an empty reason and no
    diagnostic. Triggering shutdown on that topic is the intent, but a wire-shape mismatch between
    a plugin's encoder and the host's `String` decoder is invisible — no warn for attribution,
    unlike the sibling `Event` path which warn-and-drops on decode failure (line 711).
    `host_services/mod.rs:714`
    `let reason: String = rmp_serde::from_slice(event_bytes).unwrap_or_default();`
    *Next step: on decode error, `tracing::warn!` the mismatch (still proceed to shutdown with empty
    reason) so an encoder/decoder wire drift is observable.*

11. **[info]** Polyglot parity check: this is a Rust cdylib plugin-SDK-only capability. Subprocess
    Python and Deno SDKs have NO request-runtime-shutdown — the escalate schema exposes only
    acquire/release/log ops (`escalate_request.yaml`), and the "shutdown" references in the
    Python/Deno runners are their own log/teardown, not a host-runtime-stop request. This is
    symmetric (both subprocess runtimes equally lack it), so it is NOT the "Python first, Deno
    deferred" failure mode, and the transport is genuinely different (in-process `pubsub_publish`
    callback vs the subprocess escalate pipe). The mapping helper is explicitly designed as the
    single funnel point for a future subprocess escalate op ("tomorrow a subprocess escalate op",
    `runtime/mod.rs`). `packages/escalate/schemas/escalate_request.yaml` discriminator `op` maps
    only `acquire_pixel_buffer`/`acquire_texture`/`acquire_image` (+release/log); `runtime/mod.rs`
    helper doc names the future subprocess escalate op as the next funnel. *Next step: if a
    subprocess processor should be able to stop the host runtime, file paired Python+Deno
    escalate-op tickets (schema edit -> regen -> rebuild all three -> paired tests) that funnel
    through this same `request_runtime_shutdown_from_plugin_abi_boundary` helper. Nothing to change
    in this PR.*

12. **[info]** ABI-safety is correct: no `HostServices` field was added — the reserved topic reuses
    the existing `pubsub_publish` transport slot. `PLUGIN_ABI_LAYOUT_FINGERPRINT` is unchanged and
    `STREAMLIB_ABI_VERSION` needs no bump, so every already-built `.slpkg` keeps loading. The topic
    string is a wire contract locked by a constant-value test, and the mapping helper mirrors the
    signal handler's publisher shape (`Event::RuntimeGlobal(RuntimeEvent::RuntimeShutdown)` via
    `PUBSUB.publish`, `signals.rs:154`) with an idempotent flag-setting listener
    (`runtime.rs:918`). The SDK's `to_vec(&str)` and the host's `from_slice::<String>` are
    byte-compatible. `plugin-abi/src/lib.rs:433` adds only a `pub const` + lock test (no struct
    field); `runtime_control.rs:39` `to_vec` vs host `from_slice::<String>`; `runtime.rs:918`
    flag-setting `ShutdownListener`. *Next step: no action — confirming the no-ABI-break design is
    sound.*

13. **[low]** The iceoryx2-backed integration test drives the process-global `PUBSUB` `OnceLock`
    and acknowledges "first writer wins" — so if a co-running test in the same binary calls
    `PUBSUB.init` first, this test's unique `runtime_id` never takes effect and it shares the global
    bus (and `RUNTIME_GLOBAL` subscription) with that test. The author documents the tradeoff and
    the retry-publish + exact-event assertion tolerates it, but a co-running `RUNTIME_GLOBAL` test
    could receive this test's spurious `RuntimeShutdown`.
    `host_services/mod.rs` `runtime_shutdown_control_topic_tests`:
    `PUBSUB.init(&runtime_id, node)` on the process-global singleton with an in-comment "first
    writer wins" caveat. *Next step: acceptable as documented; if flakiness appears, gate this test
    behind a serial marker or assert against a per-runtime-id local bus. No change required to
    merge.*
