### PR TITLE
refactor(examples): convert camera-rust-plugin + polyglot cdylibs to plugin-sdk (2 of 3, #1255)

### DIFF
--- a/examples/camera-rust-plugin/Cargo.toml
+++ b/examples/camera-rust-plugin/Cargo.toml
@@ -29,7 +29,11 @@ authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 license = "BUSL-1.1"
 
 [workspace.dependencies]
+# Engine facade — used ONLY by the runner (the host app), never the plugin.
 streamlib = { version = "0.6" }
+# Engine-free authoring SDK chain — used by the plugin cdylib.
+streamlib-plugin-sdk = { version = "0.6" }
+streamlib-macros = { version = "0.6" }
 streamlib-jtd-codegen = { version = "0.6" }
 streamlib-plugin-abi = { version = "0.6" }
 tracing = { version = "0.1.41", features = ["release_max_level_debug"] }

--- a/examples/camera-rust-plugin/plugin/Cargo.toml
+++ b/examples/camera-rust-plugin/plugin/Cargo.toml
@@ -19,7 +19,8 @@ crate-type = ["rlib", "cdylib"]
 streamlib-jtd-codegen = { workspace = true }
 
 [dependencies]
-streamlib = { workspace = true }
+streamlib-plugin-sdk = { workspace = true }
+streamlib-macros = { workspace = true }
 streamlib-plugin-abi = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }

--- a/examples/camera-rust-plugin/plugin/src/grayscale_kernel.rs
+++ b/examples/camera-rust-plugin/plugin/src/grayscale_kernel.rs
@@ -7,11 +7,14 @@
 //!
 //! The grayscale effect is example content: the BT.601 luma weights are
 //! baked into the fragment shader, so it doesn't belong in the engine.
-//! It rides the engine RHI's cdylib-safe
+//! It rides the engine-free `streamlib-plugin-sdk`'s cdylib-safe
 //! [`VulkanGraphicsKernel::offscreen_render`] + [`RhiCommandRecorder`]
-//! surfaces, so the crate stays inside the boundary-check rule — no
-//! `vulkanalia` dep, no allowlist exception. Every queue-mutex / fence /
-//! Drop / barrier bug the engine has fixed propagates here for free.
+//! surfaces — the kernel + recorder are built through
+//! [`GpuContextFullAccess::create_graphics_kernel`] /
+//! [`GpuContextFullAccess::create_command_recorder`], never a raw host
+//! device — so the cdylib links no engine facade and needs no allowlist
+//! exception. Every queue-mutex / fence / Drop / barrier bug the engine
+//! has fixed propagates here for free.
 //!
 //! ## Lifecycle
 //!
@@ -22,19 +25,17 @@
 //! textures are in `SHADER_READ_ONLY_OPTIMAL`, ready for the next
 //! consumer to sample without re-barriering.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
-use streamlib::sdk::engine::host_rhi::{
-    HostVulkanDevice, OffscreenColorTarget, OffscreenDraw, RhiCommandRecorder, VulkanAccess,
-    VulkanGraphicsKernel, VulkanStage,
-};
-use streamlib::sdk::error::{Error, Result};
-use streamlib::sdk::rhi::{
+use streamlib_plugin_sdk::sdk::context::GpuContextFullAccess;
+use streamlib_plugin_sdk::sdk::error::{Error, Result};
+use streamlib_plugin_sdk::sdk::rhi::{
     AttachmentFormats, ColorBlendState, ColorWriteMask, DepthStencilState, DrawCall,
     GraphicsBindingSpec, GraphicsDynamicState, GraphicsKernelDescriptor, GraphicsPipelineState,
     GraphicsPushConstants, GraphicsShaderStageFlags, GraphicsStage, MultisampleState,
-    PrimitiveTopology, RasterizationState, ScissorRect, Texture, TextureFormat, VertexInputState,
-    Viewport, VulkanLayout,
+    OffscreenColorTarget, OffscreenDraw, PrimitiveTopology, RasterizationState, RhiCommandRecorder,
+    ScissorRect, Texture, TextureFormat, VertexInputState, Viewport, VulkanAccess,
+    VulkanGraphicsKernel, VulkanLayout, VulkanStage,
 };
 
 /// Single input layer (the pre-effect texture) + its current Vulkan
@@ -72,7 +73,7 @@ pub struct SandboxedGrayscale {
 }
 
 impl SandboxedGrayscale {
-    pub fn new(vulkan_device: &Arc<HostVulkanDevice>) -> Result<Self> {
+    pub fn new(full: &GpuContextFullAccess) -> Result<Self> {
         let label = "grayscale";
 
         let vert = include_bytes!(concat!(env!("OUT_DIR"), "/grayscale.vert.spv"));
@@ -102,9 +103,9 @@ impl SandboxedGrayscale {
             },
             descriptor_sets_in_flight: 1,
         };
-        let kernel = VulkanGraphicsKernel::new(vulkan_device, &descriptor)?;
+        let kernel = full.create_graphics_kernel(&descriptor)?;
 
-        let recorder = RhiCommandRecorder::new(vulkan_device, "grayscale_recorder")?;
+        let recorder = full.create_command_recorder("grayscale_recorder")?;
 
         Ok(Self {
             label,

--- a/examples/camera-rust-plugin/plugin/src/grayscale_linux.rs
+++ b/examples/camera-rust-plugin/plugin/src/grayscale_linux.rs
@@ -14,11 +14,11 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use streamlib::sdk::context::{
+use streamlib_plugin_sdk::sdk::context::{
     GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
 };
-use streamlib::sdk::error::{Error, Result};
-use streamlib::sdk::rhi::{TextureUsages, VulkanLayout};
+use streamlib_plugin_sdk::sdk::error::{Error, Result};
+use streamlib_plugin_sdk::sdk::rhi::{TextureFormat, TextureRing, TextureUsages, VulkanLayout};
 
 use crate::_generated_::VideoFrame;
 use crate::grayscale_kernel::{
@@ -32,17 +32,17 @@ const OUTPUT_RING_DEPTH: usize = 2;
 
 struct LinuxBackend {
     kernel: Arc<SandboxedGrayscale>,
-    output_ring: streamlib::sdk::context::TextureRing,
+    output_ring: TextureRing,
 }
 
-#[streamlib::sdk::processor("GrayscaleRust")]
+#[streamlib_plugin_sdk::sdk::processor("GrayscaleRust")]
 pub struct GrayscaleProcessor {
     gpu_context: Option<GpuContextLimitedAccess>,
     frame_count: AtomicU64,
     backend: Option<LinuxBackend>,
 }
 
-impl streamlib::sdk::processors::ReactiveProcessor for GrayscaleProcessor::Processor {
+impl streamlib_plugin_sdk::sdk::processors::ReactiveProcessor for GrayscaleProcessor::Processor {
     fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.setup_inner(ctx)
     }
@@ -141,8 +141,7 @@ impl GrayscaleProcessor::Processor {
         // `gpu_limited_access().escalate(...)` here would re-enter the
         // escalate gate on the same thread and trip its re-entry panic.
         let full = ctx.gpu_full_access();
-        let vulkan_device = full.host_vulkan_device_arc()?;
-        let kernel = Arc::new(SandboxedGrayscale::new(&vulkan_device)?);
+        let kernel = Arc::new(SandboxedGrayscale::new(full)?);
 
         // Camera in this example emits 1920×1080. The grayscale kernel
         // validates input/output dimensions match per dispatch, so a
@@ -153,7 +152,7 @@ impl GrayscaleProcessor::Processor {
         let output_ring = full.create_texture_ring(
             width,
             height,
-            streamlib::sdk::rhi::TextureFormat::Bgra8Unorm,
+            TextureFormat::Bgra8Unorm,
             TextureUsages::RENDER_ATTACHMENT
                 | TextureUsages::TEXTURE_BINDING
                 | TextureUsages::COPY_SRC,

--- a/examples/camera-rust-plugin/plugin/src/lib.rs
+++ b/examples/camera-rust-plugin/plugin/src/lib.rs
@@ -11,8 +11,17 @@
 //! The Linux implementation ([`grayscale_linux`]) samples the input
 //! camera texture through a sandboxed graphics kernel and writes a
 //! BT.601-luma grayscale frame into a ring of output render-target
-//! textures. The macOS implementation ([`grayscale_apple`]) reads pixels
-//! directly from `CVPixelBuffer` memory via CoreVideo.
+//! textures.
+//!
+//! The macOS/iOS grayscale arm (`grayscale_apple.rs`) reads pixels from
+//! `CVPixelBuffer` on the CPU. It is not compiled here: it needs the
+//! `GpuContextLimitedAccess` CPU-surface accessors (`check_out_surface` /
+//! `acquire_pixel_buffer`) that the engine-free `streamlib-plugin-sdk`
+//! carries on Linux but not yet on macOS. The source stays in-tree; the
+//! rewrite onto the SDK's macOS surface is a separate follow-up (Apple
+//! paths are parked until the Linux path is stable). Compiling it here
+//! would require the `streamlib` facade, reintroducing the double-engine
+//! hazard this cdylib avoids by linking only the SDK.
 
 #[allow(non_snake_case, unused_imports, dead_code, clippy::all)]
 mod _generated_ {
@@ -24,14 +33,8 @@ mod grayscale_kernel;
 #[cfg(target_os = "linux")]
 mod grayscale_linux;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-mod grayscale_apple;
-
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))]
+#[cfg(target_os = "linux")]
 use streamlib_plugin_abi::export_plugin;
 
 #[cfg(target_os = "linux")]
 export_plugin!(grayscale_linux::GrayscaleProcessor::Processor);
-
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-export_plugin!(grayscale_apple::GrayscaleProcessor::Processor);

--- a/examples/polyglot-manual-source/Cargo.toml
+++ b/examples/polyglot-manual-source/Cargo.toml
@@ -31,7 +31,11 @@ authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 license = "BUSL-1.1"
 
 [workspace.dependencies]
+# Engine facade — used ONLY by the runner (the host app), never the plugin.
 streamlib = { version = "0.6" }
+# Engine-free authoring SDK chain — used by the plugin cdylib.
+streamlib-plugin-sdk = { version = "0.6" }
+streamlib-macros = { version = "0.6" }
 streamlib-jtd-codegen = { version = "0.6" }
 streamlib-plugin-abi = { version = "0.6" }
 tracing = { version = "0.1.41", features = ["release_max_level_debug"] }

--- a/examples/polyglot-manual-source/plugin/Cargo.toml
+++ b/examples/polyglot-manual-source/plugin/Cargo.toml
@@ -19,7 +19,8 @@ crate-type = ["rlib", "cdylib"]
 streamlib-jtd-codegen = { workspace = true }
 
 [dependencies]
-streamlib = { workspace = true }
+streamlib-plugin-sdk = { workspace = true }
+streamlib-macros = { workspace = true }
 streamlib-plugin-abi = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/examples/polyglot-manual-source/plugin/src/lib.rs
+++ b/examples/polyglot-manual-source/plugin/src/lib.rs
@@ -25,13 +25,13 @@ mod _generated_ {
 
 use std::path::PathBuf;
 use crate::_generated_::VideoFrame;
-use streamlib::sdk::error::{Result, Error};
-use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
+use streamlib_plugin_sdk::sdk::error::{Result, Error};
+use streamlib_plugin_sdk::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
 use streamlib_plugin_abi::export_plugin;
 
 const OUTPUT_ENV_VAR: &str = "STREAMLIB_POLYGLOT_MANUAL_SOURCE_SINK_OUTPUT";
 
-#[streamlib::sdk::processor("PolyglotManualSourceCountingSink")]
+#[streamlib_plugin_sdk::sdk::processor("PolyglotManualSourceCountingSink")]
 pub struct PolyglotManualSourceCountingSink {
     output_file: Option<PathBuf>,
     frame_counter: u64,
@@ -39,7 +39,7 @@ pub struct PolyglotManualSourceCountingSink {
     last_ns: u64,
 }
 
-impl streamlib::sdk::processors::ReactiveProcessor for PolyglotManualSourceCountingSink::Processor {
+impl streamlib_plugin_sdk::sdk::processors::ReactiveProcessor for PolyglotManualSourceCountingSink::Processor {
     fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let output = std::env::var(OUTPUT_ENV_VAR)
             .ok()

--- a/xtask/src/check_boundaries.rs
+++ b/xtask/src/check_boundaries.rs
@@ -1183,33 +1183,23 @@ fn check_packages_engine_reach(
 // calling the runtime's add-module API). Cdylib detection reuses
 // `check_cdylib_reach::cargo_toml_has_cdylib` — one crate-type detector.
 //
-// Seeded to the 3 current offenders; `camera-plugin-sdk-compute/plugin` is left
-// un-allowlisted as live proof the rule passes for a correctly-authored cdylib
-// example (it links `streamlib-plugin-sdk`, never the facade).
+// `camera-plugin-sdk-compute/plugin` is left un-allowlisted as live proof the
+// rule passes for a correctly-authored cdylib example (it links
+// `streamlib-plugin-sdk`, never the facade).
 
 const CHECK_EXAMPLES_CDYLIB_FACADE_DEP: &str = "examples-cdylib-no-facade-dep";
 
 const EXAMPLES_CDYLIB_FACADE_DEP_RATIONALE: &str = "an examples/* cdylib plugin must not link the full `streamlib` facade — a cdylib plugin is built independently at load time and rides streamlib-plugin-sdk / streamlib-consumer-rhi, never the FullAccess facade. Move it to [dev-dependencies] or author against the plugin SDK";
 
-/// The 3 `examples/*` cdylib crates that currently link the `streamlib` facade
-/// as a non-dev runtime dep (green baseline). Each is the shrinking conversion
-/// backlog. `camera-plugin-sdk-compute/plugin` is deliberately absent — it
-/// links `streamlib-plugin-sdk` (never the facade) and proves the rule passes.
+/// The `examples/*` cdylib crates that still link the `streamlib` facade as a
+/// non-dev runtime dep (green baseline) — the shrinking conversion backlog.
+/// `camera-plugin-sdk-compute/plugin` is deliberately absent: it links
+/// `streamlib-plugin-sdk` (never the facade) and proves the rule passes.
 const EXAMPLES_CDYLIB_FACADE_DEP_ALLOWLIST: &[AllowEntry] = &[
-    AllowEntry {
-        path: "examples/camera-rust-plugin/plugin/Cargo.toml",
-        kind: AllowKind::ExactFile,
-        rationale: "pre-conversion facade-linking cdylib example (shrinking backlog)",
-    },
     AllowEntry {
         path: "examples/camera-python-display/effects/Cargo.toml",
         kind: AllowKind::ExactFile,
-        rationale: "pre-conversion facade-linking cdylib example (shrinking backlog)",
-    },
-    AllowEntry {
-        path: "examples/polyglot-manual-source/plugin/Cargo.toml",
-        kind: AllowKind::ExactFile,
-        rationale: "pre-conversion facade-linking cdylib example (shrinking backlog)",
+        rationale: "facade-linking cdylib example — its BlendingCompositor reaches RhiToneMapper / display_info / the host-device intermediate-texture path, none of which the engine-free plugin SDK carries yet; conversion is blocked on those SDK surfaces",
     },
 ];
 
@@ -2784,12 +2774,13 @@ streamlib = { workspace = true }
     #[test]
     fn allows_facade_dep_in_allowlisted_cdylib_example() {
         let dir = empty_workspace();
-        // examples/camera-rust-plugin/plugin is on the seeded baseline.
+        // examples/camera-python-display/effects is the remaining allowlisted
+        // entry (BlendingCompositor blocked on absent SDK surfaces).
         write_fixture(
             dir.path(),
-            "examples/camera-rust-plugin/plugin/Cargo.toml",
+            "examples/camera-python-display/effects/Cargo.toml",
             r#"[package]
-name = "camera-rust-plugin"
+name = "camera-python-display-effects"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
## What & why (2 of 3 — #1255)

Converts two of the three facade-linking example cdylibs off the `streamlib` facade to `streamlib-plugin-sdk`, removing their `EXAMPLES_CDYLIB_FACADE_DEP_ALLOWLIST` entries:

- **`camera-rust-plugin/plugin`** — the grayscale graphics kernel now builds via `GpuContextFullAccess::create_graphics_kernel` / `create_command_recorder` instead of the raw-device `VulkanGraphicsKernel::new` / `RhiCommandRecorder::new`. This eliminates the separately-built-`.slpkg` double-free hazard (`docs/learnings/slpkg-raw-device-rhi-construction.md`) — the charter-mandated cdylib-safe path.
- **`polyglot-manual-source/plugin`** — pure iceoryx2 sink; straight `streamlib::sdk::*` → `streamlib_plugin_sdk::sdk::*` flip.

Independent verify (`verify-change`) APPROVE'd the code: SDK symbols all genuinely re-exported, deps consistent with the canonical `camera-plugin-sdk-compute/plugin` template, boundary gate green (5475 files, no violations; the non-vacuous `rejects_facade_dep_in_new_cdylib_example` negative test passes with both entries removed).

## Partial — converts 2 of 3; #1255 stays open (do NOT auto-resolve it)

Only 2 of 3 convert. The 3rd — **`camera-python-display/effects`** (an HDR compositor) — needs a small SDK surface that doesn't exist yet, so it's split to **#1389** (blocked_by the **#1388** `upload_pixel_buffer_as_texture` SDK wrapper). `#1255` stays open (`blocked_by #1389`) until the examples tree is fully facade-free. Owner-decided (defer + track; the "4 blocking surfaces" were Fable-scoped down to ~2-3 small PRs, no ABI change).

## Honest status on validation

- ✅ Code verified + boundary gate green.
- ⚠️ **E2E not yet run.** The two scenarios (camera-rust-plugin, polyglot-manual-source) need a real camera(vivid)→sink run, which is being stood up as autonomous GPU/vivid E2E (operating-model work in progress) — until then this is code-verified only. Do not treat the runtime path as E2E-confirmed on merge.
- **macOS parked:** `camera-rust-plugin`'s macOS grayscale arm is disabled (its `mod`/export removed; `grayscale_apple.rs` retained but uncompiled) — it needs the SDK's macOS CPU-surface accessors, parked under the Apple-pre-Linux-stable doctrine. Tracked as a follow-up.

Refs #1255 · splits #1389 (+ #1388)
