### PR TITLE
refactor(codecs): convert @tatolab/h264 + @tatolab/h265 to the engine-free plugin SDK

### DIFF
--- a/packages/h264/Cargo.toml
+++ b/packages/h264/Cargo.toml
@@ -17,17 +17,21 @@ crate-type = ["rlib", "cdylib"]
 streamlib-jtd-codegen = {version = "0.6.0"}
 
 [dependencies]
-# Engine substrate — runtime context, processor traits, generated config
-# types under `crate::_generated_::tatolab__h264::*`, EncodedVideoFrame /
-# VideoFrame wire types, host RHI bridge for queue handles + allocator.
-streamlib = {version = "0.6.0"}
+# Engine-free authoring SDK (never the `streamlib` facade) — capability-typed
+# runtime/GPU context views, the cdylib-safe `EncoderSession` / `DecoderSession`
+# PluginAbiObjects, generated wire types under `crate::_generated_::*`,
+# error/result types. Hardware encode/decode sessions are minted host-side
+# through `GpuContextFullAccess::create_encoder_session` /
+# `create_decoder_session`, never the raw host device.
+streamlib-plugin-sdk = {version = "0.6.0"}
 
-# Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
+# Procedural macros — `#[streamlib_plugin_sdk::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = {version = "0.6.0"}
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
-# runtime dlopens at load time.
+# runtime dlopens at load time; the `#[repr(C)]` video session descriptor /
+# packet / color-VUI reprs the codec fills for the session-mint slots.
 streamlib-plugin-abi = {version = "0.6.0"}
 
 # Serialization (config dataclasses ship as serde-derived).
@@ -35,13 +39,10 @@ streamlib-plugin-abi = {version = "0.6.0"}
 # so msgpack encoder/decoder I/O writes `bin` (1× wire) instead of array.
 serde = {version = "1.0", features = ["derive"]}
 
-# Logging.
+# `EncodedVideoFrame.data` serde_bytes support.
 serde_bytes = {version = "0.11"}
 
-# H.264 encode/decode primitives reach through the SDK's tier-2
-# `streamlib::sdk::engine::video::*` namespace — the codec layer lives
-# inside `streamlib-engine` (folded from the former `libs/vulkan-video`
-# crate). No Linux-specific Cargo dep needed beyond `streamlib`.
+# Logging.
 tracing = {version = "0.1.41", features = ["release_max_level_debug"]}
 
 [workspace]

--- a/packages/h264/src/linux/color_vui_translate.rs
+++ b/packages/h264/src/linux/color_vui_translate.rs
@@ -1,46 +1,128 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Translation between the engine-side `ColorInfo` domain enums (from
-//! `@tatolab/core`'s JTD codegen) and
-//! `streamlib::sdk::engine::video::H273ColorVui`, the codec-native byte
-//! representation the codec layer in `streamlib-engine/src/vulkan/video/`
-//! uses on the bitstream side.
+//! Translation between the engine-free `ColorInfo` domain enums (from
+//! `@tatolab/core`'s JTD codegen) and the codec-native H.273 byte
+//! representation the hardware encode/decode surface exchanges over the
+//! plugin ABI:
 //!
-//! The codec layer does not depend on `@tatolab/core` schemas; this seam
-//! is what keeps that boundary clean. Both H.264 and H.265 packages carry
-//! an identical translator because each has its own codegen module
-//! (`crate::_generated_::*`); the duplication is ~70 lines per codec.
+//! - **Encode:** `ColorInfo` → [`H273ColorVuiRepr`] (the `color_vui` field
+//!   of the encoder-session descriptor). Each axis flattens to a `value` +
+//!   `present` byte pair; an all-absent repr reads host-side as "no VUI".
+//! - **Decode:** the SDK's [`DecodedColorVui`] (parsed SPS VUI, each axis
+//!   `Option`) → `ColorInfo` for surfacing on `VideoFrame.color_info`.
+//!
+//! The raw H.273 enumerant byte values (ITU-T H.273 / ISO/IEC 23091-2 — the
+//! representation that appears verbatim in the H.264 / H.265 bitstream) are
+//! defined locally: the engine-free codec package no longer links the
+//! engine's `color_vui` module, and these standardized enumerants are frozen
+//! forever. Both H.264 and H.265 packages carry an identical translator
+//! because each has its own codegen module (`crate::_generated_::*`).
 
 use crate::_generated_::tatolab__core::color_info::{
     ColorInfo, Matrix, Primaries, Range, Transfer,
 };
-use streamlib::sdk::engine::video::{color_vui, H273ColorVui};
+use streamlib_plugin_abi::H273ColorVuiRepr;
+use streamlib_plugin_sdk::sdk::rhi::DecodedColorVui;
 
-/// Translate `ColorInfo` → `H273ColorVui` for the encoder's SPS chain.
-///
-/// Returns `None` when every axis is `None` — the caller treats that as
-/// "no codec-side color VUI requested" and leaves `SimpleEncoderConfig::
-/// color_vui = None`, which skips the colour_description block in the
-/// SPS entirely (timing is still emitted because the H.264 SPS always
-/// chains a VUI for it).
-pub fn color_info_to_h273(info: &ColorInfo) -> Option<H273ColorVui> {
-    let v = H273ColorVui {
-        primaries: info.primaries.as_ref().map(primaries_to_byte),
-        transfer: info.transfer.as_ref().map(transfer_to_byte),
-        matrix: info.matrix.as_ref().map(matrix_to_byte),
-        full_range: info.range.as_ref().map(|r| matches!(r, Range::Full)),
-    };
-    if !v.is_video_signal_type_block_needed() {
-        return None;
-    }
-    Some(v)
+// ---------------------------------------------------------------------------
+// H.273 enumerant constants (ITU-T H.273 / ISO/IEC 23091-2)
+// ---------------------------------------------------------------------------
+//
+// The subset streamlib's `ColorInfo` schema declares — full H.273 tables are
+// larger. Values are frozen by the spec.
+
+/// ColourPrimaries values — H.273 §8.1.
+mod primaries {
+    pub const BT709: u8 = 1;
+    pub const BT470_M: u8 = 4;
+    pub const BT470_BG: u8 = 5;
+    pub const SMPTE170M: u8 = 6;
+    pub const SMPTE240M: u8 = 7;
+    pub const FILM: u8 = 8;
+    pub const BT2020: u8 = 9;
+    pub const SMPTE428: u8 = 10;
+    pub const SMPTE431: u8 = 11;
+    pub const SMPTE432: u8 = 12;
+    pub const EBU3213: u8 = 22;
 }
 
-/// Translate `H273ColorVui` → `ColorInfo` for surfacing decoded VUI
-/// metadata on `VideoFrame.color_info`. Per-axis `None` (Unspecified on
-/// the wire) stays `None` in the result.
-pub fn h273_to_color_info(vui: &H273ColorVui) -> ColorInfo {
+/// TransferCharacteristics values — H.273 §8.2.
+mod transfer {
+    pub const BT709: u8 = 1;
+    pub const GAMMA22: u8 = 4;
+    pub const GAMMA28: u8 = 5;
+    pub const SMPTE170M: u8 = 6;
+    pub const SMPTE240M: u8 = 7;
+    pub const LINEAR: u8 = 8;
+    pub const LOG100: u8 = 9;
+    pub const LOG100_SQRT10: u8 = 10;
+    pub const XVYCC: u8 = 11;
+    pub const BT1361: u8 = 12;
+    pub const SRGB: u8 = 13;
+    pub const BT2020_TEN_BIT: u8 = 14;
+    pub const BT2020_TWELVE_BIT: u8 = 15;
+    pub const SMPTE2084: u8 = 16;
+    pub const SMPTE428: u8 = 17;
+    pub const ARIB_STD_B67: u8 = 18;
+}
+
+/// MatrixCoefficients values — H.273 §8.3.
+mod matrix {
+    pub const IDENTITY: u8 = 0;
+    pub const BT709: u8 = 1;
+    pub const FCC: u8 = 4;
+    pub const BT470_BG: u8 = 5;
+    pub const SMPTE170M: u8 = 6;
+    pub const SMPTE240M: u8 = 7;
+    pub const YCGCO: u8 = 8;
+    pub const BT2020_NCL: u8 = 9;
+    pub const BT2020_CL: u8 = 10;
+    pub const SMPTE2085: u8 = 11;
+    pub const CHROMA_NCL: u8 = 12;
+    pub const CHROMA_CL: u8 = 13;
+    pub const ICTCP: u8 = 14;
+}
+
+/// Flatten an `Option<u8>` H.273 axis into the repr's `(value, present)`
+/// byte pair. Absent → `(0, 0)`; the host reads `present == 0` as "axis
+/// Unspecified".
+fn axis(value: Option<u8>) -> (u8, u8) {
+    match value {
+        Some(v) => (v, 1),
+        None => (0, 0),
+    }
+}
+
+/// Translate `ColorInfo` → [`H273ColorVuiRepr`] for the encoder-session
+/// descriptor's SPS VUI chain.
+///
+/// An all-absent repr (every `*_present` byte 0) is what the host reads as
+/// "no colour_description block" — the encoder emits no VUI rather than an
+/// empty one, so no separate `Option` wrapper is needed.
+pub fn color_info_to_h273_repr(info: &ColorInfo) -> H273ColorVuiRepr {
+    let (primaries, primaries_present) = axis(info.primaries.as_ref().map(primaries_to_byte));
+    let (transfer, transfer_present) = axis(info.transfer.as_ref().map(transfer_to_byte));
+    let (matrix, matrix_present) = axis(info.matrix.as_ref().map(matrix_to_byte));
+    let (full_range, full_range_present) =
+        axis(info.range.as_ref().map(|r| u8::from(matches!(r, Range::Full))));
+    H273ColorVuiRepr {
+        primaries,
+        primaries_present,
+        transfer,
+        transfer_present,
+        matrix,
+        matrix_present,
+        full_range,
+        full_range_present,
+    }
+}
+
+/// Translate the SDK's parsed [`DecodedColorVui`] → `ColorInfo` for surfacing
+/// decoded VUI metadata on `VideoFrame.color_info`. Per-axis `None`
+/// (Unspecified on the wire) stays `None`; an H.273 enumerant streamlib
+/// doesn't model decodes to `None` rather than fabricating a variant.
+pub fn decoded_vui_to_color_info(vui: &DecodedColorVui) -> ColorInfo {
     ColorInfo {
         primaries: vui.primaries.and_then(primaries_from_byte),
         transfer: vui.transfer.and_then(transfer_from_byte),
@@ -51,113 +133,113 @@ pub fn h273_to_color_info(vui: &H273ColorVui) -> ColorInfo {
 
 fn primaries_to_byte(p: &Primaries) -> u8 {
     match p {
-        Primaries::Bt709 => color_vui::primaries::BT709,
-        Primaries::Bt470M => color_vui::primaries::BT470_M,
-        Primaries::Bt470Bg => color_vui::primaries::BT470_BG,
-        Primaries::Smpte170m => color_vui::primaries::SMPTE170M,
-        Primaries::Smpte240m => color_vui::primaries::SMPTE240M,
-        Primaries::Film => color_vui::primaries::FILM,
-        Primaries::Bt2020 => color_vui::primaries::BT2020,
-        Primaries::Smpte428 => color_vui::primaries::SMPTE428,
-        Primaries::Smpte431 => color_vui::primaries::SMPTE431,
-        Primaries::Smpte432 => color_vui::primaries::SMPTE432,
-        Primaries::Ebu3213 => color_vui::primaries::EBU3213,
+        Primaries::Bt709 => primaries::BT709,
+        Primaries::Bt470M => primaries::BT470_M,
+        Primaries::Bt470Bg => primaries::BT470_BG,
+        Primaries::Smpte170m => primaries::SMPTE170M,
+        Primaries::Smpte240m => primaries::SMPTE240M,
+        Primaries::Film => primaries::FILM,
+        Primaries::Bt2020 => primaries::BT2020,
+        Primaries::Smpte428 => primaries::SMPTE428,
+        Primaries::Smpte431 => primaries::SMPTE431,
+        Primaries::Smpte432 => primaries::SMPTE432,
+        Primaries::Ebu3213 => primaries::EBU3213,
     }
 }
 
 fn primaries_from_byte(b: u8) -> Option<Primaries> {
     Some(match b {
-        x if x == color_vui::primaries::BT709 => Primaries::Bt709,
-        x if x == color_vui::primaries::BT470_M => Primaries::Bt470M,
-        x if x == color_vui::primaries::BT470_BG => Primaries::Bt470Bg,
-        x if x == color_vui::primaries::SMPTE170M => Primaries::Smpte170m,
-        x if x == color_vui::primaries::SMPTE240M => Primaries::Smpte240m,
-        x if x == color_vui::primaries::FILM => Primaries::Film,
-        x if x == color_vui::primaries::BT2020 => Primaries::Bt2020,
-        x if x == color_vui::primaries::SMPTE428 => Primaries::Smpte428,
-        x if x == color_vui::primaries::SMPTE431 => Primaries::Smpte431,
-        x if x == color_vui::primaries::SMPTE432 => Primaries::Smpte432,
-        x if x == color_vui::primaries::EBU3213 => Primaries::Ebu3213,
+        x if x == primaries::BT709 => Primaries::Bt709,
+        x if x == primaries::BT470_M => Primaries::Bt470M,
+        x if x == primaries::BT470_BG => Primaries::Bt470Bg,
+        x if x == primaries::SMPTE170M => Primaries::Smpte170m,
+        x if x == primaries::SMPTE240M => Primaries::Smpte240m,
+        x if x == primaries::FILM => Primaries::Film,
+        x if x == primaries::BT2020 => Primaries::Bt2020,
+        x if x == primaries::SMPTE428 => Primaries::Smpte428,
+        x if x == primaries::SMPTE431 => Primaries::Smpte431,
+        x if x == primaries::SMPTE432 => Primaries::Smpte432,
+        x if x == primaries::EBU3213 => Primaries::Ebu3213,
         _ => return None,
     })
 }
 
 fn transfer_to_byte(t: &Transfer) -> u8 {
     match t {
-        Transfer::Bt709 => color_vui::transfer::BT709,
-        Transfer::Gamma22 => color_vui::transfer::GAMMA22,
-        Transfer::Gamma28 => color_vui::transfer::GAMMA28,
-        Transfer::Smpte170m => color_vui::transfer::SMPTE170M,
-        Transfer::Smpte240m => color_vui::transfer::SMPTE240M,
-        Transfer::Linear => color_vui::transfer::LINEAR,
-        Transfer::Log100 => color_vui::transfer::LOG100,
-        Transfer::Log100Sqrt10 => color_vui::transfer::LOG100_SQRT10,
-        Transfer::Xvycc => color_vui::transfer::XVYCC,
-        Transfer::Bt1361 => color_vui::transfer::BT1361,
-        Transfer::Srgb => color_vui::transfer::SRGB,
-        Transfer::Bt2020TenBit => color_vui::transfer::BT2020_TEN_BIT,
-        Transfer::Bt2020TwelveBit => color_vui::transfer::BT2020_TWELVE_BIT,
-        Transfer::Smpte2084 => color_vui::transfer::SMPTE2084,
-        Transfer::Smpte428 => color_vui::transfer::SMPTE428,
-        Transfer::AribStdB67 => color_vui::transfer::ARIB_STD_B67,
+        Transfer::Bt709 => transfer::BT709,
+        Transfer::Gamma22 => transfer::GAMMA22,
+        Transfer::Gamma28 => transfer::GAMMA28,
+        Transfer::Smpte170m => transfer::SMPTE170M,
+        Transfer::Smpte240m => transfer::SMPTE240M,
+        Transfer::Linear => transfer::LINEAR,
+        Transfer::Log100 => transfer::LOG100,
+        Transfer::Log100Sqrt10 => transfer::LOG100_SQRT10,
+        Transfer::Xvycc => transfer::XVYCC,
+        Transfer::Bt1361 => transfer::BT1361,
+        Transfer::Srgb => transfer::SRGB,
+        Transfer::Bt2020TenBit => transfer::BT2020_TEN_BIT,
+        Transfer::Bt2020TwelveBit => transfer::BT2020_TWELVE_BIT,
+        Transfer::Smpte2084 => transfer::SMPTE2084,
+        Transfer::Smpte428 => transfer::SMPTE428,
+        Transfer::AribStdB67 => transfer::ARIB_STD_B67,
     }
 }
 
 fn transfer_from_byte(b: u8) -> Option<Transfer> {
     Some(match b {
-        x if x == color_vui::transfer::BT709 => Transfer::Bt709,
-        x if x == color_vui::transfer::GAMMA22 => Transfer::Gamma22,
-        x if x == color_vui::transfer::GAMMA28 => Transfer::Gamma28,
-        x if x == color_vui::transfer::SMPTE170M => Transfer::Smpte170m,
-        x if x == color_vui::transfer::SMPTE240M => Transfer::Smpte240m,
-        x if x == color_vui::transfer::LINEAR => Transfer::Linear,
-        x if x == color_vui::transfer::LOG100 => Transfer::Log100,
-        x if x == color_vui::transfer::LOG100_SQRT10 => Transfer::Log100Sqrt10,
-        x if x == color_vui::transfer::XVYCC => Transfer::Xvycc,
-        x if x == color_vui::transfer::BT1361 => Transfer::Bt1361,
-        x if x == color_vui::transfer::SRGB => Transfer::Srgb,
-        x if x == color_vui::transfer::BT2020_TEN_BIT => Transfer::Bt2020TenBit,
-        x if x == color_vui::transfer::BT2020_TWELVE_BIT => Transfer::Bt2020TwelveBit,
-        x if x == color_vui::transfer::SMPTE2084 => Transfer::Smpte2084,
-        x if x == color_vui::transfer::SMPTE428 => Transfer::Smpte428,
-        x if x == color_vui::transfer::ARIB_STD_B67 => Transfer::AribStdB67,
+        x if x == transfer::BT709 => Transfer::Bt709,
+        x if x == transfer::GAMMA22 => Transfer::Gamma22,
+        x if x == transfer::GAMMA28 => Transfer::Gamma28,
+        x if x == transfer::SMPTE170M => Transfer::Smpte170m,
+        x if x == transfer::SMPTE240M => Transfer::Smpte240m,
+        x if x == transfer::LINEAR => Transfer::Linear,
+        x if x == transfer::LOG100 => Transfer::Log100,
+        x if x == transfer::LOG100_SQRT10 => Transfer::Log100Sqrt10,
+        x if x == transfer::XVYCC => Transfer::Xvycc,
+        x if x == transfer::BT1361 => Transfer::Bt1361,
+        x if x == transfer::SRGB => Transfer::Srgb,
+        x if x == transfer::BT2020_TEN_BIT => Transfer::Bt2020TenBit,
+        x if x == transfer::BT2020_TWELVE_BIT => Transfer::Bt2020TwelveBit,
+        x if x == transfer::SMPTE2084 => Transfer::Smpte2084,
+        x if x == transfer::SMPTE428 => Transfer::Smpte428,
+        x if x == transfer::ARIB_STD_B67 => Transfer::AribStdB67,
         _ => return None,
     })
 }
 
 fn matrix_to_byte(m: &Matrix) -> u8 {
     match m {
-        Matrix::Identity => color_vui::matrix::IDENTITY,
-        Matrix::Bt709 => color_vui::matrix::BT709,
-        Matrix::Fcc => color_vui::matrix::FCC,
-        Matrix::Bt470Bg => color_vui::matrix::BT470_BG,
-        Matrix::Smpte170m => color_vui::matrix::SMPTE170M,
-        Matrix::Smpte240m => color_vui::matrix::SMPTE240M,
-        Matrix::Ycgco => color_vui::matrix::YCGCO,
-        Matrix::Bt2020Ncl => color_vui::matrix::BT2020_NCL,
-        Matrix::Bt2020Cl => color_vui::matrix::BT2020_CL,
-        Matrix::Smpte2085 => color_vui::matrix::SMPTE2085,
-        Matrix::ChromaNcl => color_vui::matrix::CHROMA_NCL,
-        Matrix::ChromaCl => color_vui::matrix::CHROMA_CL,
-        Matrix::Ictcp => color_vui::matrix::ICTCP,
+        Matrix::Identity => matrix::IDENTITY,
+        Matrix::Bt709 => matrix::BT709,
+        Matrix::Fcc => matrix::FCC,
+        Matrix::Bt470Bg => matrix::BT470_BG,
+        Matrix::Smpte170m => matrix::SMPTE170M,
+        Matrix::Smpte240m => matrix::SMPTE240M,
+        Matrix::Ycgco => matrix::YCGCO,
+        Matrix::Bt2020Ncl => matrix::BT2020_NCL,
+        Matrix::Bt2020Cl => matrix::BT2020_CL,
+        Matrix::Smpte2085 => matrix::SMPTE2085,
+        Matrix::ChromaNcl => matrix::CHROMA_NCL,
+        Matrix::ChromaCl => matrix::CHROMA_CL,
+        Matrix::Ictcp => matrix::ICTCP,
     }
 }
 
 fn matrix_from_byte(b: u8) -> Option<Matrix> {
     Some(match b {
-        x if x == color_vui::matrix::IDENTITY => Matrix::Identity,
-        x if x == color_vui::matrix::BT709 => Matrix::Bt709,
-        x if x == color_vui::matrix::FCC => Matrix::Fcc,
-        x if x == color_vui::matrix::BT470_BG => Matrix::Bt470Bg,
-        x if x == color_vui::matrix::SMPTE170M => Matrix::Smpte170m,
-        x if x == color_vui::matrix::SMPTE240M => Matrix::Smpte240m,
-        x if x == color_vui::matrix::YCGCO => Matrix::Ycgco,
-        x if x == color_vui::matrix::BT2020_NCL => Matrix::Bt2020Ncl,
-        x if x == color_vui::matrix::BT2020_CL => Matrix::Bt2020Cl,
-        x if x == color_vui::matrix::SMPTE2085 => Matrix::Smpte2085,
-        x if x == color_vui::matrix::CHROMA_NCL => Matrix::ChromaNcl,
-        x if x == color_vui::matrix::CHROMA_CL => Matrix::ChromaCl,
-        x if x == color_vui::matrix::ICTCP => Matrix::Ictcp,
+        x if x == matrix::IDENTITY => Matrix::Identity,
+        x if x == matrix::BT709 => Matrix::Bt709,
+        x if x == matrix::FCC => Matrix::Fcc,
+        x if x == matrix::BT470_BG => Matrix::Bt470Bg,
+        x if x == matrix::SMPTE170M => Matrix::Smpte170m,
+        x if x == matrix::SMPTE240M => Matrix::Smpte240m,
+        x if x == matrix::YCGCO => Matrix::Ycgco,
+        x if x == matrix::BT2020_NCL => Matrix::Bt2020Ncl,
+        x if x == matrix::BT2020_CL => Matrix::Bt2020Cl,
+        x if x == matrix::SMPTE2085 => Matrix::Smpte2085,
+        x if x == matrix::CHROMA_NCL => Matrix::ChromaNcl,
+        x if x == matrix::CHROMA_CL => Matrix::ChromaCl,
+        x if x == matrix::ICTCP => Matrix::Ictcp,
         _ => return None,
     })
 }
@@ -165,6 +247,22 @@ fn matrix_from_byte(b: u8) -> Option<Matrix> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build a `DecodedColorVui` the way the decoder session would from a
+    /// repr — used to exercise the decode-side translation without a GPU.
+    fn decoded(
+        primaries: Option<u8>,
+        transfer: Option<u8>,
+        matrix: Option<u8>,
+        full_range: Option<bool>,
+    ) -> DecodedColorVui {
+        DecodedColorVui {
+            primaries,
+            transfer,
+            matrix,
+            full_range,
+        }
+    }
 
     #[test]
     fn full_color_info_round_trip() {
@@ -174,30 +272,34 @@ mod tests {
             matrix: Some(Matrix::Smpte170m),
             range: Some(Range::Full),
         };
-        let vui = color_info_to_h273(&info).expect("non-empty input yields Some");
-        assert_eq!(vui.primaries, Some(1));
-        assert_eq!(vui.transfer, Some(13));
-        assert_eq!(vui.matrix, Some(6));
-        assert_eq!(vui.full_range, Some(true));
-        let back = h273_to_color_info(&vui);
+        let repr = color_info_to_h273_repr(&info);
+        assert_eq!((repr.primaries, repr.primaries_present), (1, 1));
+        assert_eq!((repr.transfer, repr.transfer_present), (13, 1));
+        assert_eq!((repr.matrix, repr.matrix_present), (6, 1));
+        assert_eq!((repr.full_range, repr.full_range_present), (1, 1));
+        // Repr axes → DecodedColorVui (the shape the session emits) → back.
+        let back = decoded_vui_to_color_info(&decoded(Some(1), Some(13), Some(6), Some(true)));
         assert_eq!(back, info);
     }
 
     #[test]
-    fn all_none_yields_no_vui() {
-        let info = ColorInfo::default();
-        assert!(color_info_to_h273(&info).is_none());
+    fn all_none_yields_absent_repr() {
+        let repr = color_info_to_h273_repr(&ColorInfo::default());
+        assert_eq!(repr.primaries_present, 0);
+        assert_eq!(repr.transfer_present, 0);
+        assert_eq!(repr.matrix_present, 0);
+        assert_eq!(repr.full_range_present, 0);
     }
 
     #[test]
-    fn range_alone_still_yields_vui() {
+    fn range_alone_still_present_in_repr() {
         let info = ColorInfo {
             range: Some(Range::Limited),
             ..Default::default()
         };
-        let vui = color_info_to_h273(&info).expect("range alone is enough");
-        assert_eq!(vui.full_range, Some(false));
-        assert!(vui.primaries.is_none());
+        let repr = color_info_to_h273_repr(&info);
+        assert_eq!((repr.full_range, repr.full_range_present), (0, 1));
+        assert_eq!(repr.primaries_present, 0);
     }
 
     #[test]
@@ -209,25 +311,20 @@ mod tests {
             matrix: Some(Matrix::Bt2020Ncl),
             range: Some(Range::Full),
         };
-        let vui = color_info_to_h273(&info).unwrap();
-        assert_eq!(vui.primaries, Some(9));
-        assert_eq!(vui.transfer, Some(16));
-        assert_eq!(vui.matrix, Some(9));
-        assert_eq!(vui.full_range, Some(true));
-        assert_eq!(h273_to_color_info(&vui), info);
+        let repr = color_info_to_h273_repr(&info);
+        assert_eq!((repr.primaries, repr.primaries_present), (9, 1));
+        assert_eq!((repr.transfer, repr.transfer_present), (16, 1));
+        assert_eq!((repr.matrix, repr.matrix_present), (9, 1));
+        assert_eq!((repr.full_range, repr.full_range_present), (1, 1));
+        let back = decoded_vui_to_color_info(&decoded(Some(9), Some(16), Some(9), Some(true)));
+        assert_eq!(back, info);
     }
 
     #[test]
     fn unknown_byte_decodes_to_none() {
-        // A decoder seeing H.273 enumerants streamlib doesn't model (e.g.
-        // 99) should drop them silently rather than fabricate variants.
-        let vui = H273ColorVui {
-            primaries: Some(99),
-            transfer: Some(13),
-            matrix: Some(99),
-            full_range: Some(false),
-        };
-        let info = h273_to_color_info(&vui);
+        // A decoder seeing H.273 enumerants streamlib doesn't model (e.g. 99)
+        // drops them silently rather than fabricating variants.
+        let info = decoded_vui_to_color_info(&decoded(Some(99), Some(13), Some(99), Some(false)));
         assert!(info.primaries.is_none());
         assert_eq!(info.transfer, Some(Transfer::Srgb));
         assert!(info.matrix.is_none());

--- a/packages/h264/src/linux/decoder.rs
+++ b/packages/h264/src/linux/decoder.rs
@@ -3,75 +3,73 @@
 
 // H.264 Decoder Processor
 //
-// Thin wrapper around streamlib::sdk::engine::video::SimpleDecoder using the shared RHI
-// HostVulkanDevice. Decoded NV12 frames are written to pixel buffers for output.
+// Thin wrapper around the engine-free plugin SDK's hardware
+// `DecoderSession` PluginAbiObject. The session is minted host-side in
+// `setup()` via `GpuContextFullAccess::create_decoder_session` (a FullAccess
+// lifecycle body already holds the gate — no escalate); coded dimensions
+// auto-detect from the first SPS. Per bitstream chunk, `feed` decodes +
+// stages `0..N` RGBA frames, pulled via `drain_frame`.
+//
+// Each decoded RGBA frame is staged into a pooled host-visible pixel buffer;
+// the pool id doubles as the output `VideoFrame.surface_id`. Downstream
+// consumers resolve that surface_id, at which point the host uploads the
+// buffer to a GPU texture (SHADER_READ_ONLY_OPTIMAL) — the same CPU→GPU
+// hand-off the camera uses. No engine-only `TextureRing` /
+// `copy_pixel_buffer_to_slot` reach from the cdylib.
 
 
 use crate::_generated_::{EncodedVideoFrame, VideoFrame};
-use crate::linux::color_vui_translate::h273_to_color_info;
-use streamlib::sdk::context::{
-    GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess, TextureRing,
+use crate::linux::color_vui_translate::decoded_vui_to_color_info;
+use streamlib_plugin_sdk::sdk::context::{
+    GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
 };
-use streamlib::sdk::error::{Error, Result};
-use streamlib::sdk::rhi::{PixelFormat, TextureFormat, TextureUsages};
+use streamlib_plugin_sdk::sdk::error::{Error, Result};
+use streamlib_plugin_sdk::sdk::rhi::{DecoderSession, PixelFormat};
 
-use streamlib::sdk::engine::video::{Codec, SimpleDecoder, SimpleDecoderConfig};
-
-/// Pre-allocated output texture ring depth. Matches `MAX_FRAMES_IN_FLIGHT`
-/// — one slot for the GPU's in-flight upload, one for the next decoded
-/// frame the processor is staging. See `docs/learnings/vulkan-frames-in-flight.md`.
-const RING_DEPTH: usize = 2;
+use streamlib_plugin_abi::{VideoCodecRepr, VideoDecoderSessionDescriptorRepr};
 
 // ============================================================================
 // PROCESSOR
 // ============================================================================
 
-#[streamlib::sdk::processor("H264Decoder")]
+#[streamlib_plugin_sdk::sdk::processor("H264Decoder")]
 pub struct H264DecoderProcessor {
-    /// Vulkan Video hardware decoder (shares RHI device).
-    decoder: Option<SimpleDecoder>,
+    /// Vulkan Video hardware decoder session (minted in `setup`). `!Clone` —
+    /// owns exclusive Vulkan Video session / DPB / command resources.
+    session: Option<DecoderSession>,
 
-    /// GPU context for creating pixel buffers for decoded frames.
+    /// GPU context for staging decoded frames into pooled pixel buffers.
     gpu_context: Option<GpuContextLimitedAccess>,
-
-    /// Pre-allocated output texture ring. Built lazily on the first
-    /// decoded frame (dimensions come from the SPS), rebuilt only on
-    /// mid-stream resolution change.
-    texture_ring: Option<TextureRing>,
 
     /// Frames decoded counter.
     frames_decoded: u64,
 }
 
-impl streamlib::sdk::processors::ReactiveProcessor for H264DecoderProcessor::Processor {
+impl streamlib_plugin_sdk::sdk::processors::ReactiveProcessor for H264DecoderProcessor::Processor {
     fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
 
-        // Decoder dimensions come from H.264 SPS — leaving `max_width` /
-        // `max_height` at zero tells `SimpleDecoder` to size the DPB and
-        // video session from the first parsed SPS rather than pre-allocating
-        // for a hard-coded resolution cap.
-        let decoder_config = SimpleDecoderConfig {
-            codec: Codec::H264,
-            rgba_output: true,
-            max_width: 0,
-            max_height: 0,
+        // Decoder dimensions come from the H.264 SPS — leaving `max_width` /
+        // `max_height` at zero tells the host to size the DPB and video
+        // session from the first parsed SPS rather than pre-allocating for a
+        // hard-coded resolution cap. `rgba_output = 1`: drained frames are
+        // GPU NV12→RGBA converted host-side.
+        let descriptor = VideoDecoderSessionDescriptorRepr {
+            codec: VideoCodecRepr::H264 as u32,
+            rgba_output: 1,
             ..Default::default()
         };
 
-        let decoder = SimpleDecoder::from_full_access(ctx.gpu_full_access(), decoder_config)
-            .map_err(|e| Error::Runtime(format!("Failed to create H.264 decoder: {e}")))?;
+        // FullAccess lifecycle body: call the create slot directly — the
+        // dispatcher already holds the gate, so no `escalate` here.
+        let session = ctx
+            .gpu_full_access()
+            .create_decoder_session(&descriptor)
+            .map_err(|e| Error::Runtime(format!("Failed to create H.264 decoder session: {e}")))?;
 
-        // Session creation, DPB allocation, and the NV12→RGBA converter are
-        // built lazily inside `SimpleDecoder::feed()` once the first SPS
-        // arrives — at that point the actual coded extent is known and
-        // sized to match. The processor-setup mutex inside `escalate` and
-        // the RHI queue submitter coordinate device-side ordering, so the
-        // historical pre-swapchain pre-init is no longer required.
+        tracing::info!("[H264Decoder] Session minted (Vulkan Video hardware)");
 
-        tracing::info!("[H264Decoder] Initialized (shared RHI device, Vulkan Video hardware)");
-
-        self.decoder = Some(decoder);
+        self.session = Some(session);
         Ok(())
     }
 
@@ -80,8 +78,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264DecoderProcessor::Pro
             frames_decoded = self.frames_decoded,
             "[H264Decoder] Shutting down"
         );
-        self.decoder.take();
-        self.texture_ring.take();
+        self.session.take();
         self.gpu_context.take();
         Ok(())
     }
@@ -95,90 +92,85 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264DecoderProcessor::Pro
         let gpu_ctx = self
             .gpu_context
             .as_ref()
-            .ok_or_else(|| Error::Runtime("GPU context not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("GPU context not initialized".into()))?
+            .clone();
 
-        let decoder = self
-            .decoder
+        let session = self
+            .session
             .as_mut()
-            .ok_or_else(|| Error::Runtime("H.264 decoder not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("H.264 decoder session not initialized".into()))?;
 
-        let decoded_frames = decoder.feed(&encoded.data).map_err(|e| {
-            Error::Runtime(format!("H.264 decode failed: {e}"))
-        })?;
+        let frame_count = session
+            .feed(&encoded.data)
+            .map_err(|e| Error::Runtime(format!("H.264 decode failed: {e}")))?;
 
-        for decoded in decoded_frames {
+        // Color info: prefer the parsed bitstream VUI (self-describing,
+        // survives muxer round-trips that re-encode `EncodedVideoFrame.
+        // color_info`) over the producer's attestation. Falls back to the
+        // passthrough when the bitstream didn't carry a VUI. The VUI is
+        // best-effort metadata — a query error (e.g. a null methods vtable)
+        // must not drop otherwise-valid decoded frames, so warn + fall back.
+        let parsed_vui = match session.current_color_vui() {
+            Ok(vui) => vui,
+            Err(e) => {
+                tracing::warn!(error = %e, "[H264Decoder] color VUI query failed; using passthrough");
+                None
+            }
+        };
+        let color_info_source = if parsed_vui.is_some() {
+            "bitstream"
+        } else {
+            "encoded_passthrough"
+        };
+        let color_info = parsed_vui
+            .map(|vui| decoded_vui_to_color_info(&vui))
+            .or_else(|| encoded.color_info.clone());
+
+        for index in 0..frame_count {
+            let decoded = session
+                .drain_frame(index)
+                .map_err(|e| Error::Runtime(format!("H.264 drain frame failed: {e}")))?;
             let width = decoded.width;
             let height = decoded.height;
 
-            // Decoded frames come back as RGBA (GPU NV12→RGBA via Nv12ToRgbConverter).
+            // Decoded frames come back as RGBA (host GPU NV12→RGBA convert).
             let rgba_size = (width * height * 4) as usize;
             let src = &decoded.data[..rgba_size.min(decoded.data.len())];
 
-            // Acquire (or build, on first frame / resolution change) the
-            // output texture ring. SPS-driven dimensions are stable within
-            // a session, so the escalate path runs at most once per stream
-            // and steady-state decode stays Limited-only.
-            let need_rebuild = match self.texture_ring.as_ref() {
-                Some(ring) => ring.width() != width || ring.height() != height,
-                None => true,
-            };
-            if need_rebuild {
-                self.texture_ring = Some(gpu_ctx.escalate(|full| {
-                    full.create_texture_ring(
-                        width,
-                        height,
-                        TextureFormat::Rgba8Unorm,
-                        TextureUsages::COPY_DST
-                            | TextureUsages::TEXTURE_BINDING
-                            | TextureUsages::STORAGE_BINDING,
-                        RING_DEPTH,
-                    )
-                })?);
-            }
-            let ring = self.texture_ring.as_ref().unwrap();
-            let slot = ring.acquire_next();
-
-            // Stage RGBA into a host-visible pixel buffer, then copy into
-            // the ring slot's pre-allocated DEVICE_LOCAL texture via the
-            // ring's amortized upload primitive — no per-frame escalation
-            // AND no per-frame vkCreateCommandPool / vkAllocateCommandBuffers
-            // / vkCreateFence (the slot's command pool + cb + fence are
-            // pre-allocated by `create_texture_ring`, reset+reused per call).
-            let (_pool_id, pixel_buffer) =
+            // Stage RGBA into a pooled host-visible pixel buffer. The pool id
+            // is the output surface_id: downstream `resolve_texture_by_surface_id`
+            // triggers the host to upload this buffer into a GPU texture. The
+            // `pixel_buffer` handle stays live through the `outputs.write`
+            // below so the pool can't rotate this slot out mid-flight (the
+            // pool skips buffers whose Arc is still held).
+            let (pool_id, pixel_buffer) =
                 gpu_ctx.acquire_pixel_buffer(width, height, PixelFormat::Rgba32)?;
             let dst_ptr = pixel_buffer.plane_base_address(0);
-            unsafe {
-                std::ptr::copy_nonoverlapping(src.as_ptr(), dst_ptr, src.len());
+            if dst_ptr.is_null() {
+                return Err(Error::Runtime(
+                    "H.264 decoder: pixel buffer plane base address is null".into(),
+                ));
             }
-            ring.copy_pixel_buffer_to_slot(&slot, &pixel_buffer, width, height)?;
-            let surface_id = slot.surface_id().to_string();
-
-            let timestamp_ns = encoded.timestamp_ns.clone();
-
-            // Color info: prefer the parsed bitstream VUI (self-describing,
-            // survives muxer round-trips that re-encode `EncodedVideoFrame.
-            // color_info`) over the producer's attestation. Falls back to the
-            // passthrough when the bitstream didn't carry a VUI.
-            let parsed_vui = decoder.current_color_vui();
-            let color_info_source = if parsed_vui.is_some() {
-                "bitstream"
-            } else {
-                "encoded_passthrough"
-            };
-            let color_info = parsed_vui
-                .map(|vui| h273_to_color_info(&vui))
-                .or_else(|| encoded.color_info.clone());
+            let copy_len = src.len().min(pixel_buffer.plane_size(0) as usize);
+            // SAFETY: `dst_ptr` is the mapped host-visible base of a pixel
+            // buffer sized (width, height, Rgba32) = `width*height*4` bytes;
+            // `copy_len` is clamped to both the RGBA source and the plane
+            // size, and the regions do not overlap.
+            unsafe {
+                std::ptr::copy_nonoverlapping(src.as_ptr(), dst_ptr, copy_len);
+            }
+            let surface_id = pool_id.to_string();
 
             let video_frame = VideoFrame {
                 surface_id,
                 width,
                 height,
-                timestamp_ns,
+                timestamp_ns: encoded.timestamp_ns.clone(),
                 fps: encoded.fps,
                 // Per-frame override is opt-in; per-surface
                 // `current_image_layout` from surface-share is the default.
                 texture_layout: None,
-                color_info,
+                color_info: color_info.clone(),
                 mastering_display: encoded.mastering_display.clone(),
                 content_light: encoded.content_light.clone(),
             };
@@ -193,6 +185,8 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264DecoderProcessor::Pro
                     "[H264Decoder] First frame decoded — surfaced color_info"
                 );
             }
+            // `pixel_buffer` drops here (after the write) — matches the
+            // camera's in-flight hold.
         }
 
         if self.frames_decoded % 300 == 0 && self.frames_decoded > 0 {

--- a/packages/h264/src/linux/encoder.rs
+++ b/packages/h264/src/linux/encoder.rs
@@ -3,53 +3,56 @@
 
 // H.264 Encoder Processor
 //
-// Thin wrapper around streamlib::sdk::engine::video::SimpleEncoder using the shared RHI
-// HostVulkanDevice. The encoder shares streamlib's Vulkan device, VMA allocator,
-// and queues — no separate device creation, no NVIDIA dual-device crash.
+// Thin wrapper around the engine-free plugin SDK's hardware
+// `EncoderSession` PluginAbiObject. The session is minted host-side via
+// `GpuContextLimitedAccess::escalate(|full| full.create_encoder_session(..))`
+// on the first VideoFrame, so its dimensions track the upstream frame size.
+// Config width/height become guardrails (mismatch logs a warning, frame
+// wins) mirroring how `frame.fps` flows through `mp4_writer`. The escalate
+// window ends after the one-shot mint; per-frame `submit_texture` / `drain_packet`
+// ride the session's own scope-free methods — never re-escalate per frame.
 //
-// The encoder is constructed lazily on the first VideoFrame so its session
-// dimensions track the upstream frame size. Config width/height become
-// guardrails (mismatch logs a warning, frame wins) mirroring how `frame.fps`
-// flows through `mp4_writer`. Privileged resource construction runs inside
-// `GpuContextLimitedAccess::escalate(|full| …)` so the processor-setup mutex
-// and `device_wait_idle` order it against the rest of the GPU work.
-//
-// The camera's GPU-resident textures are on the same device, so encode_image()
-// accepts them directly (zero-copy).
+// The camera's GPU-resident texture is resolved by `surface_id` and handed
+// to `submit_texture`, which resolves the encode-src image view host-side —
+// no `host_vulkan_texture_arc` / raw-view bridge in the cdylib.
 
 
 use crate::_generated_::{EncodedVideoFrame, VideoFrame};
-use crate::linux::color_vui_translate::color_info_to_h273;
-use streamlib::sdk::context::{
+use crate::linux::color_vui_translate::color_info_to_h273_repr;
+use streamlib_plugin_sdk::sdk::context::{
     GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
 };
-use streamlib::sdk::engine::HostTextureExt;
-use streamlib::sdk::error::{Error, Result};
+use streamlib_plugin_sdk::sdk::error::{Error, Result};
+use streamlib_plugin_sdk::sdk::rhi::{EncoderSession, VulkanLayout};
 
-use streamlib::sdk::engine::video::{Codec, Preset, SimpleEncoder, SimpleEncoderConfig};
+use streamlib_plugin_abi::{
+    VideoCodecRepr, VideoEncoderPresetRepr, VideoEncoderSessionDescriptorRepr,
+};
 
 // ============================================================================
 // PROCESSOR
 // ============================================================================
 
-#[streamlib::sdk::processor("H264Encoder")]
+#[streamlib_plugin_sdk::sdk::processor("H264Encoder")]
 pub struct H264EncoderProcessor {
-    /// Vulkan Video hardware encoder (built lazily from the first frame).
-    encoder: Option<SimpleEncoder>,
+    /// Vulkan Video hardware encoder session (minted lazily from the first
+    /// frame). `!Clone` — owns exclusive Vulkan Video session / DPB /
+    /// command resources.
+    session: Option<EncoderSession>,
 
     /// GPU context for resolving VideoFrame textures and escalating to
-    /// full access for the one-shot lazy encoder construction.
+    /// full access for the one-shot lazy encoder-session mint.
     gpu_context: Option<GpuContextLimitedAccess>,
 
     /// Frames encoded counter.
     frames_encoded: u64,
 }
 
-impl streamlib::sdk::processors::ReactiveProcessor for H264EncoderProcessor::Processor {
+impl streamlib_plugin_sdk::sdk::processors::ReactiveProcessor for H264EncoderProcessor::Processor {
     fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
         tracing::info!(
-            "[H264Encoder] Setup complete (encoder construction deferred to first frame)"
+            "[H264Encoder] Setup complete (encoder-session mint deferred to first frame)"
         );
         Ok(())
     }
@@ -59,7 +62,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264EncoderProcessor::Pro
             frames_encoded = self.frames_encoded,
             "[H264Encoder] Shutting down"
         );
-        self.encoder.take();
+        self.session.take();
         self.gpu_context.take();
         Ok(())
     }
@@ -73,50 +76,46 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264EncoderProcessor::Pro
         let gpu_ctx = self
             .gpu_context
             .as_ref()
-            .ok_or_else(|| Error::Runtime("GPU context not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("GPU context not initialized".into()))?
+            .clone();
 
-        if self.encoder.is_none() {
-            let encoder = build_encoder_lazily(gpu_ctx, &self.config, &frame)?;
-            self.encoder = Some(encoder);
+        if self.session.is_none() {
+            let session = build_encoder_session_lazily(&gpu_ctx, &self.config, &frame)?;
+            self.session = Some(session);
         }
 
-        let encoder = self
-            .encoder
-            .as_mut()
-            .ok_or_else(|| Error::Runtime("H.264 encoder not initialized".into()))?;
-
+        // Resolve the incoming frame's GPU texture; `submit_texture` resolves
+        // the encode-src view host-side and requires the source in
+        // SHADER_READ_ONLY_OPTIMAL (the layout resolved textures are left in).
         let texture = gpu_ctx.resolve_texture_by_surface_id(
             &frame.surface_id,
             frame.texture_layout,
             frame.width,
             frame.height,
         )?;
-        // Cdylib-safe: `Texture::vulkan_inner()` reaches `host_inner()` which
-        // panics under `host_callbacks().is_some()`. Route through the
-        // `host_vulkan_texture_arc` FullAccess slot so cdylib callers don't
-        // trip the panic guard.
-        let host_texture = texture.host_vulkan_texture_arc().map_err(|e| {
-            Error::GpuError(format!("Failed to acquire host texture for encode: {e}"))
-        })?;
-        let image_view = host_texture.image_view().map_err(|e| {
-            Error::GpuError(format!("Failed to get image view: {e}"))
-        })?;
 
         let timestamp_ns: Option<i64> = frame.timestamp_ns.parse().ok();
         let frame_fps = frame.fps;
         // Pass color metadata through input → encoded so the muxer /
-        // downstream consumer can populate VUI / colr without re-
-        // deriving from the bitstream. VUI write-back from encoder
-        // config lands in a follow-up.
+        // downstream consumer can populate VUI / colr without re-deriving
+        // from the bitstream.
         let frame_color_info = frame.color_info.clone();
         let frame_mastering_display = frame.mastering_display.clone();
         let frame_content_light = frame.content_light.clone();
 
-        let packets = encoder.encode_image(image_view, timestamp_ns).map_err(|e| {
-            Error::Runtime(format!("H.264 encode failed: {e}"))
-        })?;
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| Error::Runtime("H.264 encoder session not initialized".into()))?;
 
-        for packet in packets {
+        let packet_count = session
+            .submit_texture(&texture, VulkanLayout::SHADER_READ_ONLY_OPTIMAL, timestamp_ns)
+            .map_err(|e| Error::Runtime(format!("H.264 encode failed: {e}")))?;
+
+        for index in 0..packet_count {
+            let packet = session
+                .drain_packet(index)
+                .map_err(|e| Error::Runtime(format!("H.264 drain packet failed: {e}")))?;
             let encoded = EncodedVideoFrame {
                 data: packet.data,
                 fps: frame_fps,
@@ -174,11 +173,13 @@ fn select_encoder_dims(
     (frame_width, frame_height, fps)
 }
 
-fn build_encoder_lazily(
+/// Build the frozen encoder-session descriptor from config + first frame,
+/// then mint the host `EncoderSession` inside a one-shot escalate window.
+fn build_encoder_session_lazily(
     gpu_ctx: &GpuContextLimitedAccess,
     config: &crate::_generated_::H264EncoderConfig,
     frame: &VideoFrame,
-) -> Result<SimpleEncoder> {
+) -> Result<EncoderSession> {
     let (width, height, fps) = select_encoder_dims(
         config.width,
         config.height,
@@ -190,58 +191,87 @@ fn build_encoder_lazily(
 
     // First-frame color info drives the session-level SPS VUI. Mid-stream
     // ColorInfo changes are not honored — switching colorimetry requires a
-    // new SPS, which the encoder doesn't re-emit per frame.
+    // new SPS, which the encoder doesn't re-emit per frame. An all-absent
+    // repr (every `*_present` byte 0) reads host-side as "no VUI".
     let color_vui = frame
         .color_info
         .as_ref()
-        .and_then(color_info_to_h273);
+        .map(color_info_to_h273_repr)
+        .unwrap_or_default();
 
-    let encoder_config = SimpleEncoderConfig {
+    let (has_bitrate, bitrate_bps) = match config.bitrate_bps {
+        Some(bps) => (1, bps),
+        None => (0, 0),
+    };
+    let (has_effort_level, effort_level) = match config.effort_level {
+        Some(level) => (1, level),
+        None => (0, 0),
+    };
+    let idr_interval_secs = config.keyframe_interval_seconds.unwrap_or(2.0) as u32;
+
+    let descriptor = VideoEncoderSessionDescriptorRepr {
         width,
         height,
         fps,
-        codec: Codec::H264,
-        preset: Preset::Medium,
-        streaming: true,
-        idr_interval_secs: config.keyframe_interval_seconds.unwrap_or(2.0) as u32,
-        bitrate_bps: config.bitrate_bps,
-        prepend_header_to_idr: Some(true),
-        effort_level: config.effort_level,
+        codec: VideoCodecRepr::H264 as u32,
+        preset: VideoEncoderPresetRepr::Medium as u32,
+        bitrate_bps,
+        has_bitrate,
+        idr_interval_secs,
+        effort_level,
+        has_effort_level,
+        // `streaming = true`: header prepended to each IDR for mid-stream join.
+        streaming: 1,
+        prepend_header_present: 1,
+        prepend_header: 1,
+        // Texture input: keep the eager `prepare_gpu_encode_resources` the
+        // host folds in when this byte is 0.
+        disable_gpu_input_prealloc: 0,
         color_vui,
         ..Default::default()
     };
 
-    let encoder = gpu_ctx.escalate(|full| {
-        let mut encoder = SimpleEncoder::from_full_access(full, encoder_config)
-            .map_err(|e| Error::Runtime(format!("Failed to create H.264 encoder: {e}")))?;
+    // Mint the session in a one-shot escalate window — the scope-end drains
+    // the device, so this runs at most once per session (first frame). Per-
+    // frame `submit_texture` / `drain_packet` ride the session's own
+    // scope-free methods. `escalate` returns `Result<Result<..>>`: the outer
+    // is the escalate machinery, the inner is the mint.
+    let session = match gpu_ctx.escalate(|full| full.create_encoder_session(&descriptor)) {
+        Ok(Ok(session)) => session,
+        Ok(Err(e)) => {
+            return Err(Error::Runtime(format!(
+                "Failed to create H.264 encoder session: {e}"
+            )));
+        }
+        Err(e) => {
+            return Err(Error::Runtime(format!(
+                "escalate for H.264 encoder-session mint failed: {e}"
+            )));
+        }
+    };
 
-        encoder
-            .prepare_gpu_encode_resources()
-            .map_err(|e| Error::Runtime(format!("Failed to pre-allocate H.264 encode resources: {e}")))?;
-
-        Ok(encoder)
-    })?;
-
+    let (aligned_width, aligned_height) = session.aligned_extent();
     tracing::info!(
-        "[H264Encoder] Initialized lazily ({}x{}, {}fps, shared RHI device, Vulkan Video hardware)",
+        aligned_width,
+        aligned_height,
+        "[H264Encoder] Session minted lazily ({}x{}, {}fps, Vulkan Video hardware)",
         width,
         height,
         fps
     );
-    tracing::info!(
-        color_vui = ?color_vui,
-        "[H264Encoder] SPS VUI color metadata chained from first-frame color_info"
-    );
     // Debug: emit the cached SPS+PPS bytes as hex once at construction so
-    // E2E flows can `ffprobe` the SPS VUI without saving a full MP4. This
-    // is a one-shot trace; encoded packets at frame rate are not logged.
-    tracing::debug!(
-        header_hex = %hex_encode(encoder.header()),
-        header_len = encoder.header().len(),
-        "[H264Encoder] Cached SPS+PPS header"
-    );
+    // E2E flows can `ffprobe` the SPS VUI without saving a full MP4. This is
+    // a one-shot trace; encoded packets at frame rate are not logged.
+    match session.header() {
+        Ok(header) => tracing::debug!(
+            header_hex = %hex_encode(&header),
+            header_len = header.len(),
+            "[H264Encoder] Cached SPS+PPS header"
+        ),
+        Err(e) => tracing::debug!(error = %e, "[H264Encoder] Header fetch failed (non-fatal)"),
+    }
 
-    Ok(encoder)
+    Ok(session)
 }
 
 /// Lowercase hex encoder for the one-shot SPS+PPS debug log. Returns an

--- a/packages/h265/Cargo.toml
+++ b/packages/h265/Cargo.toml
@@ -17,17 +17,21 @@ crate-type = ["rlib", "cdylib"]
 streamlib-jtd-codegen = {version = "0.6.0"}
 
 [dependencies]
-# Engine substrate — runtime context, processor traits, generated config
-# types under `crate::_generated_::tatolab__h265::*`, EncodedVideoFrame /
-# VideoFrame wire types, host RHI bridge for queue handles + allocator.
-streamlib = {version = "0.6.0"}
+# Engine-free authoring SDK (never the `streamlib` facade) — capability-typed
+# runtime/GPU context views, the cdylib-safe `EncoderSession` / `DecoderSession`
+# PluginAbiObjects, generated wire types under `crate::_generated_::*`,
+# error/result types. Hardware encode/decode sessions are minted host-side
+# through `GpuContextFullAccess::create_encoder_session` /
+# `create_decoder_session`, never the raw host device.
+streamlib-plugin-sdk = {version = "0.6.0"}
 
-# Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
+# Procedural macros — `#[streamlib_plugin_sdk::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = {version = "0.6.0"}
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
-# runtime dlopens at load time.
+# runtime dlopens at load time; the `#[repr(C)]` video session descriptor /
+# packet / color-VUI reprs the codec fills for the session-mint slots.
 streamlib-plugin-abi = {version = "0.6.0"}
 
 # Serialization (config dataclasses ship as serde-derived).
@@ -35,13 +39,10 @@ streamlib-plugin-abi = {version = "0.6.0"}
 # so msgpack encoder/decoder I/O writes `bin` (1× wire) instead of array.
 serde = {version = "1.0", features = ["derive"]}
 
-# Logging.
+# `EncodedVideoFrame.data` serde_bytes support.
 serde_bytes = {version = "0.11"}
 
-# H.265 encode/decode primitives reach through the SDK's tier-2
-# `streamlib::sdk::engine::video::*` namespace — the codec layer lives
-# inside `streamlib-engine` (folded from the former `libs/vulkan-video`
-# crate). No Linux-specific Cargo dep needed beyond `streamlib`.
+# Logging.
 tracing = {version = "0.1.41", features = ["release_max_level_debug"]}
 
 [workspace]

--- a/packages/h265/src/linux/color_vui_translate.rs
+++ b/packages/h265/src/linux/color_vui_translate.rs
@@ -1,46 +1,128 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Translation between the engine-side `ColorInfo` domain enums (from
-//! `@tatolab/core`'s JTD codegen) and
-//! `streamlib::sdk::engine::video::H273ColorVui`, the codec-native byte
-//! representation the codec layer in `streamlib-engine/src/vulkan/video/`
-//! uses on the bitstream side.
+//! Translation between the engine-free `ColorInfo` domain enums (from
+//! `@tatolab/core`'s JTD codegen) and the codec-native H.273 byte
+//! representation the hardware encode/decode surface exchanges over the
+//! plugin ABI:
 //!
-//! The codec layer does not depend on `@tatolab/core` schemas; this seam
-//! is what keeps that boundary clean. Both H.264 and H.265 packages carry
-//! an identical translator because each has its own codegen module
-//! (`crate::_generated_::*`); the duplication is ~70 lines per codec.
+//! - **Encode:** `ColorInfo` → [`H273ColorVuiRepr`] (the `color_vui` field
+//!   of the encoder-session descriptor). Each axis flattens to a `value` +
+//!   `present` byte pair; an all-absent repr reads host-side as "no VUI".
+//! - **Decode:** the SDK's [`DecodedColorVui`] (parsed SPS VUI, each axis
+//!   `Option`) → `ColorInfo` for surfacing on `VideoFrame.color_info`.
+//!
+//! The raw H.273 enumerant byte values (ITU-T H.273 / ISO/IEC 23091-2 — the
+//! representation that appears verbatim in the H.264 / H.265 bitstream) are
+//! defined locally: the engine-free codec package no longer links the
+//! engine's `color_vui` module, and these standardized enumerants are frozen
+//! forever. Both H.264 and H.265 packages carry an identical translator
+//! because each has its own codegen module (`crate::_generated_::*`).
 
 use crate::_generated_::tatolab__core::color_info::{
     ColorInfo, Matrix, Primaries, Range, Transfer,
 };
-use streamlib::sdk::engine::video::{color_vui, H273ColorVui};
+use streamlib_plugin_abi::H273ColorVuiRepr;
+use streamlib_plugin_sdk::sdk::rhi::DecodedColorVui;
 
-/// Translate `ColorInfo` → `H273ColorVui` for the encoder's SPS chain.
-///
-/// Returns `None` when every axis is `None` — the caller treats that as
-/// "no codec-side color VUI requested" and leaves `SimpleEncoderConfig::
-/// color_vui = None`, which skips the colour_description block in the
-/// SPS entirely (timing is still emitted because the H.264 SPS always
-/// chains a VUI for it).
-pub fn color_info_to_h273(info: &ColorInfo) -> Option<H273ColorVui> {
-    let v = H273ColorVui {
-        primaries: info.primaries.as_ref().map(primaries_to_byte),
-        transfer: info.transfer.as_ref().map(transfer_to_byte),
-        matrix: info.matrix.as_ref().map(matrix_to_byte),
-        full_range: info.range.as_ref().map(|r| matches!(r, Range::Full)),
-    };
-    if !v.is_video_signal_type_block_needed() {
-        return None;
-    }
-    Some(v)
+// ---------------------------------------------------------------------------
+// H.273 enumerant constants (ITU-T H.273 / ISO/IEC 23091-2)
+// ---------------------------------------------------------------------------
+//
+// The subset streamlib's `ColorInfo` schema declares — full H.273 tables are
+// larger. Values are frozen by the spec.
+
+/// ColourPrimaries values — H.273 §8.1.
+mod primaries {
+    pub const BT709: u8 = 1;
+    pub const BT470_M: u8 = 4;
+    pub const BT470_BG: u8 = 5;
+    pub const SMPTE170M: u8 = 6;
+    pub const SMPTE240M: u8 = 7;
+    pub const FILM: u8 = 8;
+    pub const BT2020: u8 = 9;
+    pub const SMPTE428: u8 = 10;
+    pub const SMPTE431: u8 = 11;
+    pub const SMPTE432: u8 = 12;
+    pub const EBU3213: u8 = 22;
 }
 
-/// Translate `H273ColorVui` → `ColorInfo` for surfacing decoded VUI
-/// metadata on `VideoFrame.color_info`. Per-axis `None` (Unspecified on
-/// the wire) stays `None` in the result.
-pub fn h273_to_color_info(vui: &H273ColorVui) -> ColorInfo {
+/// TransferCharacteristics values — H.273 §8.2.
+mod transfer {
+    pub const BT709: u8 = 1;
+    pub const GAMMA22: u8 = 4;
+    pub const GAMMA28: u8 = 5;
+    pub const SMPTE170M: u8 = 6;
+    pub const SMPTE240M: u8 = 7;
+    pub const LINEAR: u8 = 8;
+    pub const LOG100: u8 = 9;
+    pub const LOG100_SQRT10: u8 = 10;
+    pub const XVYCC: u8 = 11;
+    pub const BT1361: u8 = 12;
+    pub const SRGB: u8 = 13;
+    pub const BT2020_TEN_BIT: u8 = 14;
+    pub const BT2020_TWELVE_BIT: u8 = 15;
+    pub const SMPTE2084: u8 = 16;
+    pub const SMPTE428: u8 = 17;
+    pub const ARIB_STD_B67: u8 = 18;
+}
+
+/// MatrixCoefficients values — H.273 §8.3.
+mod matrix {
+    pub const IDENTITY: u8 = 0;
+    pub const BT709: u8 = 1;
+    pub const FCC: u8 = 4;
+    pub const BT470_BG: u8 = 5;
+    pub const SMPTE170M: u8 = 6;
+    pub const SMPTE240M: u8 = 7;
+    pub const YCGCO: u8 = 8;
+    pub const BT2020_NCL: u8 = 9;
+    pub const BT2020_CL: u8 = 10;
+    pub const SMPTE2085: u8 = 11;
+    pub const CHROMA_NCL: u8 = 12;
+    pub const CHROMA_CL: u8 = 13;
+    pub const ICTCP: u8 = 14;
+}
+
+/// Flatten an `Option<u8>` H.273 axis into the repr's `(value, present)`
+/// byte pair. Absent → `(0, 0)`; the host reads `present == 0` as "axis
+/// Unspecified".
+fn axis(value: Option<u8>) -> (u8, u8) {
+    match value {
+        Some(v) => (v, 1),
+        None => (0, 0),
+    }
+}
+
+/// Translate `ColorInfo` → [`H273ColorVuiRepr`] for the encoder-session
+/// descriptor's SPS VUI chain.
+///
+/// An all-absent repr (every `*_present` byte 0) is what the host reads as
+/// "no colour_description block" — the encoder emits no VUI rather than an
+/// empty one, so no separate `Option` wrapper is needed.
+pub fn color_info_to_h273_repr(info: &ColorInfo) -> H273ColorVuiRepr {
+    let (primaries, primaries_present) = axis(info.primaries.as_ref().map(primaries_to_byte));
+    let (transfer, transfer_present) = axis(info.transfer.as_ref().map(transfer_to_byte));
+    let (matrix, matrix_present) = axis(info.matrix.as_ref().map(matrix_to_byte));
+    let (full_range, full_range_present) =
+        axis(info.range.as_ref().map(|r| u8::from(matches!(r, Range::Full))));
+    H273ColorVuiRepr {
+        primaries,
+        primaries_present,
+        transfer,
+        transfer_present,
+        matrix,
+        matrix_present,
+        full_range,
+        full_range_present,
+    }
+}
+
+/// Translate the SDK's parsed [`DecodedColorVui`] → `ColorInfo` for surfacing
+/// decoded VUI metadata on `VideoFrame.color_info`. Per-axis `None`
+/// (Unspecified on the wire) stays `None`; an H.273 enumerant streamlib
+/// doesn't model decodes to `None` rather than fabricating a variant.
+pub fn decoded_vui_to_color_info(vui: &DecodedColorVui) -> ColorInfo {
     ColorInfo {
         primaries: vui.primaries.and_then(primaries_from_byte),
         transfer: vui.transfer.and_then(transfer_from_byte),
@@ -51,113 +133,113 @@ pub fn h273_to_color_info(vui: &H273ColorVui) -> ColorInfo {
 
 fn primaries_to_byte(p: &Primaries) -> u8 {
     match p {
-        Primaries::Bt709 => color_vui::primaries::BT709,
-        Primaries::Bt470M => color_vui::primaries::BT470_M,
-        Primaries::Bt470Bg => color_vui::primaries::BT470_BG,
-        Primaries::Smpte170m => color_vui::primaries::SMPTE170M,
-        Primaries::Smpte240m => color_vui::primaries::SMPTE240M,
-        Primaries::Film => color_vui::primaries::FILM,
-        Primaries::Bt2020 => color_vui::primaries::BT2020,
-        Primaries::Smpte428 => color_vui::primaries::SMPTE428,
-        Primaries::Smpte431 => color_vui::primaries::SMPTE431,
-        Primaries::Smpte432 => color_vui::primaries::SMPTE432,
-        Primaries::Ebu3213 => color_vui::primaries::EBU3213,
+        Primaries::Bt709 => primaries::BT709,
+        Primaries::Bt470M => primaries::BT470_M,
+        Primaries::Bt470Bg => primaries::BT470_BG,
+        Primaries::Smpte170m => primaries::SMPTE170M,
+        Primaries::Smpte240m => primaries::SMPTE240M,
+        Primaries::Film => primaries::FILM,
+        Primaries::Bt2020 => primaries::BT2020,
+        Primaries::Smpte428 => primaries::SMPTE428,
+        Primaries::Smpte431 => primaries::SMPTE431,
+        Primaries::Smpte432 => primaries::SMPTE432,
+        Primaries::Ebu3213 => primaries::EBU3213,
     }
 }
 
 fn primaries_from_byte(b: u8) -> Option<Primaries> {
     Some(match b {
-        x if x == color_vui::primaries::BT709 => Primaries::Bt709,
-        x if x == color_vui::primaries::BT470_M => Primaries::Bt470M,
-        x if x == color_vui::primaries::BT470_BG => Primaries::Bt470Bg,
-        x if x == color_vui::primaries::SMPTE170M => Primaries::Smpte170m,
-        x if x == color_vui::primaries::SMPTE240M => Primaries::Smpte240m,
-        x if x == color_vui::primaries::FILM => Primaries::Film,
-        x if x == color_vui::primaries::BT2020 => Primaries::Bt2020,
-        x if x == color_vui::primaries::SMPTE428 => Primaries::Smpte428,
-        x if x == color_vui::primaries::SMPTE431 => Primaries::Smpte431,
-        x if x == color_vui::primaries::SMPTE432 => Primaries::Smpte432,
-        x if x == color_vui::primaries::EBU3213 => Primaries::Ebu3213,
+        x if x == primaries::BT709 => Primaries::Bt709,
+        x if x == primaries::BT470_M => Primaries::Bt470M,
+        x if x == primaries::BT470_BG => Primaries::Bt470Bg,
+        x if x == primaries::SMPTE170M => Primaries::Smpte170m,
+        x if x == primaries::SMPTE240M => Primaries::Smpte240m,
+        x if x == primaries::FILM => Primaries::Film,
+        x if x == primaries::BT2020 => Primaries::Bt2020,
+        x if x == primaries::SMPTE428 => Primaries::Smpte428,
+        x if x == primaries::SMPTE431 => Primaries::Smpte431,
+        x if x == primaries::SMPTE432 => Primaries::Smpte432,
+        x if x == primaries::EBU3213 => Primaries::Ebu3213,
         _ => return None,
     })
 }
 
 fn transfer_to_byte(t: &Transfer) -> u8 {
     match t {
-        Transfer::Bt709 => color_vui::transfer::BT709,
-        Transfer::Gamma22 => color_vui::transfer::GAMMA22,
-        Transfer::Gamma28 => color_vui::transfer::GAMMA28,
-        Transfer::Smpte170m => color_vui::transfer::SMPTE170M,
-        Transfer::Smpte240m => color_vui::transfer::SMPTE240M,
-        Transfer::Linear => color_vui::transfer::LINEAR,
-        Transfer::Log100 => color_vui::transfer::LOG100,
-        Transfer::Log100Sqrt10 => color_vui::transfer::LOG100_SQRT10,
-        Transfer::Xvycc => color_vui::transfer::XVYCC,
-        Transfer::Bt1361 => color_vui::transfer::BT1361,
-        Transfer::Srgb => color_vui::transfer::SRGB,
-        Transfer::Bt2020TenBit => color_vui::transfer::BT2020_TEN_BIT,
-        Transfer::Bt2020TwelveBit => color_vui::transfer::BT2020_TWELVE_BIT,
-        Transfer::Smpte2084 => color_vui::transfer::SMPTE2084,
-        Transfer::Smpte428 => color_vui::transfer::SMPTE428,
-        Transfer::AribStdB67 => color_vui::transfer::ARIB_STD_B67,
+        Transfer::Bt709 => transfer::BT709,
+        Transfer::Gamma22 => transfer::GAMMA22,
+        Transfer::Gamma28 => transfer::GAMMA28,
+        Transfer::Smpte170m => transfer::SMPTE170M,
+        Transfer::Smpte240m => transfer::SMPTE240M,
+        Transfer::Linear => transfer::LINEAR,
+        Transfer::Log100 => transfer::LOG100,
+        Transfer::Log100Sqrt10 => transfer::LOG100_SQRT10,
+        Transfer::Xvycc => transfer::XVYCC,
+        Transfer::Bt1361 => transfer::BT1361,
+        Transfer::Srgb => transfer::SRGB,
+        Transfer::Bt2020TenBit => transfer::BT2020_TEN_BIT,
+        Transfer::Bt2020TwelveBit => transfer::BT2020_TWELVE_BIT,
+        Transfer::Smpte2084 => transfer::SMPTE2084,
+        Transfer::Smpte428 => transfer::SMPTE428,
+        Transfer::AribStdB67 => transfer::ARIB_STD_B67,
     }
 }
 
 fn transfer_from_byte(b: u8) -> Option<Transfer> {
     Some(match b {
-        x if x == color_vui::transfer::BT709 => Transfer::Bt709,
-        x if x == color_vui::transfer::GAMMA22 => Transfer::Gamma22,
-        x if x == color_vui::transfer::GAMMA28 => Transfer::Gamma28,
-        x if x == color_vui::transfer::SMPTE170M => Transfer::Smpte170m,
-        x if x == color_vui::transfer::SMPTE240M => Transfer::Smpte240m,
-        x if x == color_vui::transfer::LINEAR => Transfer::Linear,
-        x if x == color_vui::transfer::LOG100 => Transfer::Log100,
-        x if x == color_vui::transfer::LOG100_SQRT10 => Transfer::Log100Sqrt10,
-        x if x == color_vui::transfer::XVYCC => Transfer::Xvycc,
-        x if x == color_vui::transfer::BT1361 => Transfer::Bt1361,
-        x if x == color_vui::transfer::SRGB => Transfer::Srgb,
-        x if x == color_vui::transfer::BT2020_TEN_BIT => Transfer::Bt2020TenBit,
-        x if x == color_vui::transfer::BT2020_TWELVE_BIT => Transfer::Bt2020TwelveBit,
-        x if x == color_vui::transfer::SMPTE2084 => Transfer::Smpte2084,
-        x if x == color_vui::transfer::SMPTE428 => Transfer::Smpte428,
-        x if x == color_vui::transfer::ARIB_STD_B67 => Transfer::AribStdB67,
+        x if x == transfer::BT709 => Transfer::Bt709,
+        x if x == transfer::GAMMA22 => Transfer::Gamma22,
+        x if x == transfer::GAMMA28 => Transfer::Gamma28,
+        x if x == transfer::SMPTE170M => Transfer::Smpte170m,
+        x if x == transfer::SMPTE240M => Transfer::Smpte240m,
+        x if x == transfer::LINEAR => Transfer::Linear,
+        x if x == transfer::LOG100 => Transfer::Log100,
+        x if x == transfer::LOG100_SQRT10 => Transfer::Log100Sqrt10,
+        x if x == transfer::XVYCC => Transfer::Xvycc,
+        x if x == transfer::BT1361 => Transfer::Bt1361,
+        x if x == transfer::SRGB => Transfer::Srgb,
+        x if x == transfer::BT2020_TEN_BIT => Transfer::Bt2020TenBit,
+        x if x == transfer::BT2020_TWELVE_BIT => Transfer::Bt2020TwelveBit,
+        x if x == transfer::SMPTE2084 => Transfer::Smpte2084,
+        x if x == transfer::SMPTE428 => Transfer::Smpte428,
+        x if x == transfer::ARIB_STD_B67 => Transfer::AribStdB67,
         _ => return None,
     })
 }
 
 fn matrix_to_byte(m: &Matrix) -> u8 {
     match m {
-        Matrix::Identity => color_vui::matrix::IDENTITY,
-        Matrix::Bt709 => color_vui::matrix::BT709,
-        Matrix::Fcc => color_vui::matrix::FCC,
-        Matrix::Bt470Bg => color_vui::matrix::BT470_BG,
-        Matrix::Smpte170m => color_vui::matrix::SMPTE170M,
-        Matrix::Smpte240m => color_vui::matrix::SMPTE240M,
-        Matrix::Ycgco => color_vui::matrix::YCGCO,
-        Matrix::Bt2020Ncl => color_vui::matrix::BT2020_NCL,
-        Matrix::Bt2020Cl => color_vui::matrix::BT2020_CL,
-        Matrix::Smpte2085 => color_vui::matrix::SMPTE2085,
-        Matrix::ChromaNcl => color_vui::matrix::CHROMA_NCL,
-        Matrix::ChromaCl => color_vui::matrix::CHROMA_CL,
-        Matrix::Ictcp => color_vui::matrix::ICTCP,
+        Matrix::Identity => matrix::IDENTITY,
+        Matrix::Bt709 => matrix::BT709,
+        Matrix::Fcc => matrix::FCC,
+        Matrix::Bt470Bg => matrix::BT470_BG,
+        Matrix::Smpte170m => matrix::SMPTE170M,
+        Matrix::Smpte240m => matrix::SMPTE240M,
+        Matrix::Ycgco => matrix::YCGCO,
+        Matrix::Bt2020Ncl => matrix::BT2020_NCL,
+        Matrix::Bt2020Cl => matrix::BT2020_CL,
+        Matrix::Smpte2085 => matrix::SMPTE2085,
+        Matrix::ChromaNcl => matrix::CHROMA_NCL,
+        Matrix::ChromaCl => matrix::CHROMA_CL,
+        Matrix::Ictcp => matrix::ICTCP,
     }
 }
 
 fn matrix_from_byte(b: u8) -> Option<Matrix> {
     Some(match b {
-        x if x == color_vui::matrix::IDENTITY => Matrix::Identity,
-        x if x == color_vui::matrix::BT709 => Matrix::Bt709,
-        x if x == color_vui::matrix::FCC => Matrix::Fcc,
-        x if x == color_vui::matrix::BT470_BG => Matrix::Bt470Bg,
-        x if x == color_vui::matrix::SMPTE170M => Matrix::Smpte170m,
-        x if x == color_vui::matrix::SMPTE240M => Matrix::Smpte240m,
-        x if x == color_vui::matrix::YCGCO => Matrix::Ycgco,
-        x if x == color_vui::matrix::BT2020_NCL => Matrix::Bt2020Ncl,
-        x if x == color_vui::matrix::BT2020_CL => Matrix::Bt2020Cl,
-        x if x == color_vui::matrix::SMPTE2085 => Matrix::Smpte2085,
-        x if x == color_vui::matrix::CHROMA_NCL => Matrix::ChromaNcl,
-        x if x == color_vui::matrix::CHROMA_CL => Matrix::ChromaCl,
-        x if x == color_vui::matrix::ICTCP => Matrix::Ictcp,
+        x if x == matrix::IDENTITY => Matrix::Identity,
+        x if x == matrix::BT709 => Matrix::Bt709,
+        x if x == matrix::FCC => Matrix::Fcc,
+        x if x == matrix::BT470_BG => Matrix::Bt470Bg,
+        x if x == matrix::SMPTE170M => Matrix::Smpte170m,
+        x if x == matrix::SMPTE240M => Matrix::Smpte240m,
+        x if x == matrix::YCGCO => Matrix::Ycgco,
+        x if x == matrix::BT2020_NCL => Matrix::Bt2020Ncl,
+        x if x == matrix::BT2020_CL => Matrix::Bt2020Cl,
+        x if x == matrix::SMPTE2085 => Matrix::Smpte2085,
+        x if x == matrix::CHROMA_NCL => Matrix::ChromaNcl,
+        x if x == matrix::CHROMA_CL => Matrix::ChromaCl,
+        x if x == matrix::ICTCP => Matrix::Ictcp,
         _ => return None,
     })
 }
@@ -165,6 +247,22 @@ fn matrix_from_byte(b: u8) -> Option<Matrix> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build a `DecodedColorVui` the way the decoder session would from a
+    /// repr — used to exercise the decode-side translation without a GPU.
+    fn decoded(
+        primaries: Option<u8>,
+        transfer: Option<u8>,
+        matrix: Option<u8>,
+        full_range: Option<bool>,
+    ) -> DecodedColorVui {
+        DecodedColorVui {
+            primaries,
+            transfer,
+            matrix,
+            full_range,
+        }
+    }
 
     #[test]
     fn full_color_info_round_trip() {
@@ -174,30 +272,34 @@ mod tests {
             matrix: Some(Matrix::Smpte170m),
             range: Some(Range::Full),
         };
-        let vui = color_info_to_h273(&info).expect("non-empty input yields Some");
-        assert_eq!(vui.primaries, Some(1));
-        assert_eq!(vui.transfer, Some(13));
-        assert_eq!(vui.matrix, Some(6));
-        assert_eq!(vui.full_range, Some(true));
-        let back = h273_to_color_info(&vui);
+        let repr = color_info_to_h273_repr(&info);
+        assert_eq!((repr.primaries, repr.primaries_present), (1, 1));
+        assert_eq!((repr.transfer, repr.transfer_present), (13, 1));
+        assert_eq!((repr.matrix, repr.matrix_present), (6, 1));
+        assert_eq!((repr.full_range, repr.full_range_present), (1, 1));
+        // Repr axes → DecodedColorVui (the shape the session emits) → back.
+        let back = decoded_vui_to_color_info(&decoded(Some(1), Some(13), Some(6), Some(true)));
         assert_eq!(back, info);
     }
 
     #[test]
-    fn all_none_yields_no_vui() {
-        let info = ColorInfo::default();
-        assert!(color_info_to_h273(&info).is_none());
+    fn all_none_yields_absent_repr() {
+        let repr = color_info_to_h273_repr(&ColorInfo::default());
+        assert_eq!(repr.primaries_present, 0);
+        assert_eq!(repr.transfer_present, 0);
+        assert_eq!(repr.matrix_present, 0);
+        assert_eq!(repr.full_range_present, 0);
     }
 
     #[test]
-    fn range_alone_still_yields_vui() {
+    fn range_alone_still_present_in_repr() {
         let info = ColorInfo {
             range: Some(Range::Limited),
             ..Default::default()
         };
-        let vui = color_info_to_h273(&info).expect("range alone is enough");
-        assert_eq!(vui.full_range, Some(false));
-        assert!(vui.primaries.is_none());
+        let repr = color_info_to_h273_repr(&info);
+        assert_eq!((repr.full_range, repr.full_range_present), (0, 1));
+        assert_eq!(repr.primaries_present, 0);
     }
 
     #[test]
@@ -209,25 +311,20 @@ mod tests {
             matrix: Some(Matrix::Bt2020Ncl),
             range: Some(Range::Full),
         };
-        let vui = color_info_to_h273(&info).unwrap();
-        assert_eq!(vui.primaries, Some(9));
-        assert_eq!(vui.transfer, Some(16));
-        assert_eq!(vui.matrix, Some(9));
-        assert_eq!(vui.full_range, Some(true));
-        assert_eq!(h273_to_color_info(&vui), info);
+        let repr = color_info_to_h273_repr(&info);
+        assert_eq!((repr.primaries, repr.primaries_present), (9, 1));
+        assert_eq!((repr.transfer, repr.transfer_present), (16, 1));
+        assert_eq!((repr.matrix, repr.matrix_present), (9, 1));
+        assert_eq!((repr.full_range, repr.full_range_present), (1, 1));
+        let back = decoded_vui_to_color_info(&decoded(Some(9), Some(16), Some(9), Some(true)));
+        assert_eq!(back, info);
     }
 
     #[test]
     fn unknown_byte_decodes_to_none() {
-        // A decoder seeing H.273 enumerants streamlib doesn't model (e.g.
-        // 99) should drop them silently rather than fabricate variants.
-        let vui = H273ColorVui {
-            primaries: Some(99),
-            transfer: Some(13),
-            matrix: Some(99),
-            full_range: Some(false),
-        };
-        let info = h273_to_color_info(&vui);
+        // A decoder seeing H.273 enumerants streamlib doesn't model (e.g. 99)
+        // drops them silently rather than fabricating variants.
+        let info = decoded_vui_to_color_info(&decoded(Some(99), Some(13), Some(99), Some(false)));
         assert!(info.primaries.is_none());
         assert_eq!(info.transfer, Some(Transfer::Srgb));
         assert!(info.matrix.is_none());

--- a/packages/h265/src/linux/decoder.rs
+++ b/packages/h265/src/linux/decoder.rs
@@ -3,75 +3,73 @@
 
 // H.265 Decoder Processor
 //
-// Thin wrapper around streamlib::sdk::engine::video::SimpleDecoder using the shared RHI
-// HostVulkanDevice. Decoded NV12 frames are written to pixel buffers for output.
+// Thin wrapper around the engine-free plugin SDK's hardware
+// `DecoderSession` PluginAbiObject. The session is minted host-side in
+// `setup()` via `GpuContextFullAccess::create_decoder_session` (a FullAccess
+// lifecycle body already holds the gate — no escalate); coded dimensions
+// auto-detect from the first SPS. Per bitstream chunk, `feed` decodes +
+// stages `0..N` RGBA frames, pulled via `drain_frame`.
+//
+// Each decoded RGBA frame is staged into a pooled host-visible pixel buffer;
+// the pool id doubles as the output `VideoFrame.surface_id`. Downstream
+// consumers resolve that surface_id, at which point the host uploads the
+// buffer to a GPU texture (SHADER_READ_ONLY_OPTIMAL) — the same CPU→GPU
+// hand-off the camera uses. No engine-only `TextureRing` /
+// `copy_pixel_buffer_to_slot` reach from the cdylib.
 
 
 use crate::_generated_::{EncodedVideoFrame, VideoFrame};
-use crate::linux::color_vui_translate::h273_to_color_info;
-use streamlib::sdk::context::{
-    GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess, TextureRing,
+use crate::linux::color_vui_translate::decoded_vui_to_color_info;
+use streamlib_plugin_sdk::sdk::context::{
+    GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
 };
-use streamlib::sdk::error::{Error, Result};
-use streamlib::sdk::rhi::{PixelFormat, TextureFormat, TextureUsages};
+use streamlib_plugin_sdk::sdk::error::{Error, Result};
+use streamlib_plugin_sdk::sdk::rhi::{DecoderSession, PixelFormat};
 
-use streamlib::sdk::engine::video::{Codec, SimpleDecoder, SimpleDecoderConfig};
-
-/// Pre-allocated output texture ring depth. Matches `MAX_FRAMES_IN_FLIGHT`
-/// — one slot for the GPU's in-flight upload, one for the next decoded
-/// frame the processor is staging. See `docs/learnings/vulkan-frames-in-flight.md`.
-const RING_DEPTH: usize = 2;
+use streamlib_plugin_abi::{VideoCodecRepr, VideoDecoderSessionDescriptorRepr};
 
 // ============================================================================
 // PROCESSOR
 // ============================================================================
 
-#[streamlib::sdk::processor("H265Decoder")]
+#[streamlib_plugin_sdk::sdk::processor("H265Decoder")]
 pub struct H265DecoderProcessor {
-    /// Vulkan Video hardware decoder (shares RHI device).
-    decoder: Option<SimpleDecoder>,
+    /// Vulkan Video hardware decoder session (minted in `setup`). `!Clone` —
+    /// owns exclusive Vulkan Video session / DPB / command resources.
+    session: Option<DecoderSession>,
 
-    /// GPU context for creating pixel buffers for decoded frames.
+    /// GPU context for staging decoded frames into pooled pixel buffers.
     gpu_context: Option<GpuContextLimitedAccess>,
-
-    /// Pre-allocated output texture ring. Built lazily on the first
-    /// decoded frame (dimensions come from the SPS), rebuilt only on
-    /// mid-stream resolution change.
-    texture_ring: Option<TextureRing>,
 
     /// Frames decoded counter.
     frames_decoded: u64,
 }
 
-impl streamlib::sdk::processors::ReactiveProcessor for H265DecoderProcessor::Processor {
+impl streamlib_plugin_sdk::sdk::processors::ReactiveProcessor for H265DecoderProcessor::Processor {
     fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
 
-        // Decoder dimensions come from H.265 SPS — leaving `max_width` /
-        // `max_height` at zero tells `SimpleDecoder` to size the DPB and
-        // video session from the first parsed SPS rather than pre-allocating
-        // for a hard-coded resolution cap.
-        let decoder_config = SimpleDecoderConfig {
-            codec: Codec::H265,
-            rgba_output: true,
-            max_width: 0,
-            max_height: 0,
+        // Decoder dimensions come from the H.265 SPS — leaving `max_width` /
+        // `max_height` at zero tells the host to size the DPB and video
+        // session from the first parsed SPS rather than pre-allocating for a
+        // hard-coded resolution cap. `rgba_output = 1`: drained frames are
+        // GPU NV12→RGBA converted host-side.
+        let descriptor = VideoDecoderSessionDescriptorRepr {
+            codec: VideoCodecRepr::H265 as u32,
+            rgba_output: 1,
             ..Default::default()
         };
 
-        let decoder = SimpleDecoder::from_full_access(ctx.gpu_full_access(), decoder_config)
-            .map_err(|e| Error::Runtime(format!("Failed to create H.265 decoder: {e}")))?;
+        // FullAccess lifecycle body: call the create slot directly — the
+        // dispatcher already holds the gate, so no `escalate` here.
+        let session = ctx
+            .gpu_full_access()
+            .create_decoder_session(&descriptor)
+            .map_err(|e| Error::Runtime(format!("Failed to create H.265 decoder session: {e}")))?;
 
-        // Session creation, DPB allocation, and the NV12→RGBA converter are
-        // built lazily inside `SimpleDecoder::feed()` once the first SPS
-        // arrives — at that point the actual coded extent is known and
-        // sized to match. The processor-setup mutex inside `escalate` and
-        // the RHI queue submitter coordinate device-side ordering, so the
-        // historical pre-swapchain pre-init is no longer required.
+        tracing::info!("[H265Decoder] Session minted (Vulkan Video hardware)");
 
-        tracing::info!("[H265Decoder] Initialized (shared RHI device, Vulkan Video hardware)");
-
-        self.decoder = Some(decoder);
+        self.session = Some(session);
         Ok(())
     }
 
@@ -80,8 +78,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265DecoderProcessor::Pro
             frames_decoded = self.frames_decoded,
             "[H265Decoder] Shutting down"
         );
-        self.decoder.take();
-        self.texture_ring.take();
+        self.session.take();
         self.gpu_context.take();
         Ok(())
     }
@@ -95,90 +92,85 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265DecoderProcessor::Pro
         let gpu_ctx = self
             .gpu_context
             .as_ref()
-            .ok_or_else(|| Error::Runtime("GPU context not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("GPU context not initialized".into()))?
+            .clone();
 
-        let decoder = self
-            .decoder
+        let session = self
+            .session
             .as_mut()
-            .ok_or_else(|| Error::Runtime("H.265 decoder not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("H.265 decoder session not initialized".into()))?;
 
-        let decoded_frames = decoder.feed(&encoded.data).map_err(|e| {
-            Error::Runtime(format!("H.265 decode failed: {e}"))
-        })?;
+        let frame_count = session
+            .feed(&encoded.data)
+            .map_err(|e| Error::Runtime(format!("H.265 decode failed: {e}")))?;
 
-        for decoded in decoded_frames {
+        // Color info: prefer the parsed bitstream VUI (self-describing,
+        // survives muxer round-trips that re-encode `EncodedVideoFrame.
+        // color_info`) over the producer's attestation. Falls back to the
+        // passthrough when the bitstream didn't carry a VUI. The VUI is
+        // best-effort metadata — a query error (e.g. a null methods vtable)
+        // must not drop otherwise-valid decoded frames, so warn + fall back.
+        let parsed_vui = match session.current_color_vui() {
+            Ok(vui) => vui,
+            Err(e) => {
+                tracing::warn!(error = %e, "[H265Decoder] color VUI query failed; using passthrough");
+                None
+            }
+        };
+        let color_info_source = if parsed_vui.is_some() {
+            "bitstream"
+        } else {
+            "encoded_passthrough"
+        };
+        let color_info = parsed_vui
+            .map(|vui| decoded_vui_to_color_info(&vui))
+            .or_else(|| encoded.color_info.clone());
+
+        for index in 0..frame_count {
+            let decoded = session
+                .drain_frame(index)
+                .map_err(|e| Error::Runtime(format!("H.265 drain frame failed: {e}")))?;
             let width = decoded.width;
             let height = decoded.height;
 
-            // Decoded frames come back as RGBA (GPU NV12→RGBA via Nv12ToRgbConverter).
+            // Decoded frames come back as RGBA (host GPU NV12→RGBA convert).
             let rgba_size = (width * height * 4) as usize;
             let src = &decoded.data[..rgba_size.min(decoded.data.len())];
 
-            // Acquire (or build, on first frame / resolution change) the
-            // output texture ring. SPS-driven dimensions are stable within
-            // a session, so the escalate path runs at most once per stream
-            // and steady-state decode stays Limited-only.
-            let need_rebuild = match self.texture_ring.as_ref() {
-                Some(ring) => ring.width() != width || ring.height() != height,
-                None => true,
-            };
-            if need_rebuild {
-                self.texture_ring = Some(gpu_ctx.escalate(|full| {
-                    full.create_texture_ring(
-                        width,
-                        height,
-                        TextureFormat::Rgba8Unorm,
-                        TextureUsages::COPY_DST
-                            | TextureUsages::TEXTURE_BINDING
-                            | TextureUsages::STORAGE_BINDING,
-                        RING_DEPTH,
-                    )
-                })?);
-            }
-            let ring = self.texture_ring.as_ref().unwrap();
-            let slot = ring.acquire_next();
-
-            // Stage RGBA into a host-visible pixel buffer, then copy into
-            // the ring slot's pre-allocated DEVICE_LOCAL texture via the
-            // ring's amortized upload primitive — no per-frame escalation
-            // AND no per-frame vkCreateCommandPool / vkAllocateCommandBuffers
-            // / vkCreateFence (the slot's command pool + cb + fence are
-            // pre-allocated by `create_texture_ring`, reset+reused per call).
-            let (_pool_id, pixel_buffer) =
+            // Stage RGBA into a pooled host-visible pixel buffer. The pool id
+            // is the output surface_id: downstream `resolve_texture_by_surface_id`
+            // triggers the host to upload this buffer into a GPU texture. The
+            // `pixel_buffer` handle stays live through the `outputs.write`
+            // below so the pool can't rotate this slot out mid-flight (the
+            // pool skips buffers whose Arc is still held).
+            let (pool_id, pixel_buffer) =
                 gpu_ctx.acquire_pixel_buffer(width, height, PixelFormat::Rgba32)?;
             let dst_ptr = pixel_buffer.plane_base_address(0);
-            unsafe {
-                std::ptr::copy_nonoverlapping(src.as_ptr(), dst_ptr, src.len());
+            if dst_ptr.is_null() {
+                return Err(Error::Runtime(
+                    "H.265 decoder: pixel buffer plane base address is null".into(),
+                ));
             }
-            ring.copy_pixel_buffer_to_slot(&slot, &pixel_buffer, width, height)?;
-            let surface_id = slot.surface_id().to_string();
-
-            let timestamp_ns = encoded.timestamp_ns.clone();
-
-            // Color info: prefer the parsed bitstream VUI (self-describing,
-            // survives muxer round-trips that re-encode `EncodedVideoFrame.
-            // color_info`) over the producer's attestation. Falls back to the
-            // passthrough when the bitstream didn't carry a VUI.
-            let parsed_vui = decoder.current_color_vui();
-            let color_info_source = if parsed_vui.is_some() {
-                "bitstream"
-            } else {
-                "encoded_passthrough"
-            };
-            let color_info = parsed_vui
-                .map(|vui| h273_to_color_info(&vui))
-                .or_else(|| encoded.color_info.clone());
+            let copy_len = src.len().min(pixel_buffer.plane_size(0) as usize);
+            // SAFETY: `dst_ptr` is the mapped host-visible base of a pixel
+            // buffer sized (width, height, Rgba32) = `width*height*4` bytes;
+            // `copy_len` is clamped to both the RGBA source and the plane
+            // size, and the regions do not overlap.
+            unsafe {
+                std::ptr::copy_nonoverlapping(src.as_ptr(), dst_ptr, copy_len);
+            }
+            let surface_id = pool_id.to_string();
 
             let video_frame = VideoFrame {
                 surface_id,
                 width,
                 height,
-                timestamp_ns,
+                timestamp_ns: encoded.timestamp_ns.clone(),
                 fps: encoded.fps,
                 // Per-frame override is opt-in; per-surface
                 // `current_image_layout` from surface-share is the default.
                 texture_layout: None,
-                color_info,
+                color_info: color_info.clone(),
                 mastering_display: encoded.mastering_display.clone(),
                 content_light: encoded.content_light.clone(),
             };
@@ -193,6 +185,8 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265DecoderProcessor::Pro
                     "[H265Decoder] First frame decoded — surfaced color_info"
                 );
             }
+            // `pixel_buffer` drops here (after the write) — matches the
+            // camera's in-flight hold.
         }
 
         if self.frames_decoded % 300 == 0 && self.frames_decoded > 0 {

--- a/packages/h265/src/linux/encoder.rs
+++ b/packages/h265/src/linux/encoder.rs
@@ -3,53 +3,56 @@
 
 // H.265 Encoder Processor
 //
-// Thin wrapper around streamlib::sdk::engine::video::SimpleEncoder using the shared RHI
-// HostVulkanDevice. The encoder shares streamlib's Vulkan device, VMA allocator,
-// and queues — no separate device creation, no NVIDIA dual-device crash.
+// Thin wrapper around the engine-free plugin SDK's hardware
+// `EncoderSession` PluginAbiObject. The session is minted host-side via
+// `GpuContextLimitedAccess::escalate(|full| full.create_encoder_session(..))`
+// on the first VideoFrame, so its dimensions track the upstream frame size.
+// Config width/height become guardrails (mismatch logs a warning, frame
+// wins) mirroring how `frame.fps` flows through `mp4_writer`. The escalate
+// window ends after the one-shot mint; per-frame `submit_texture` / `drain_packet`
+// ride the session's own scope-free methods — never re-escalate per frame.
 //
-// The encoder is constructed lazily on the first VideoFrame so its session
-// dimensions track the upstream frame size. Config width/height become
-// guardrails (mismatch logs a warning, frame wins) mirroring how `frame.fps`
-// flows through `mp4_writer`. Privileged resource construction runs inside
-// `GpuContextLimitedAccess::escalate(|full| …)` so the processor-setup mutex
-// and `device_wait_idle` order it against the rest of the GPU work.
-//
-// The camera's GPU-resident textures are on the same device, so encode_image()
-// accepts them directly (zero-copy).
+// The camera's GPU-resident texture is resolved by `surface_id` and handed
+// to `submit_texture`, which resolves the encode-src image view host-side —
+// no `host_vulkan_texture_arc` / raw-view bridge in the cdylib.
 
 
 use crate::_generated_::{EncodedVideoFrame, VideoFrame};
-use crate::linux::color_vui_translate::color_info_to_h273;
-use streamlib::sdk::context::{
+use crate::linux::color_vui_translate::color_info_to_h273_repr;
+use streamlib_plugin_sdk::sdk::context::{
     GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
 };
-use streamlib::sdk::engine::HostTextureExt;
-use streamlib::sdk::error::{Error, Result};
+use streamlib_plugin_sdk::sdk::error::{Error, Result};
+use streamlib_plugin_sdk::sdk::rhi::{EncoderSession, VulkanLayout};
 
-use streamlib::sdk::engine::video::{Codec, Preset, SimpleEncoder, SimpleEncoderConfig};
+use streamlib_plugin_abi::{
+    VideoCodecRepr, VideoEncoderPresetRepr, VideoEncoderSessionDescriptorRepr,
+};
 
 // ============================================================================
 // PROCESSOR
 // ============================================================================
 
-#[streamlib::sdk::processor("H265Encoder")]
+#[streamlib_plugin_sdk::sdk::processor("H265Encoder")]
 pub struct H265EncoderProcessor {
-    /// Vulkan Video hardware encoder (built lazily from the first frame).
-    encoder: Option<SimpleEncoder>,
+    /// Vulkan Video hardware encoder session (minted lazily from the first
+    /// frame). `!Clone` — owns exclusive Vulkan Video session / DPB /
+    /// command resources.
+    session: Option<EncoderSession>,
 
     /// GPU context for resolving VideoFrame textures and escalating to
-    /// full access for the one-shot lazy encoder construction.
+    /// full access for the one-shot lazy encoder-session mint.
     gpu_context: Option<GpuContextLimitedAccess>,
 
     /// Frames encoded counter.
     frames_encoded: u64,
 }
 
-impl streamlib::sdk::processors::ReactiveProcessor for H265EncoderProcessor::Processor {
+impl streamlib_plugin_sdk::sdk::processors::ReactiveProcessor for H265EncoderProcessor::Processor {
     fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
         tracing::info!(
-            "[H265Encoder] Setup complete (encoder construction deferred to first frame)"
+            "[H265Encoder] Setup complete (encoder-session mint deferred to first frame)"
         );
         Ok(())
     }
@@ -59,7 +62,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265EncoderProcessor::Pro
             frames_encoded = self.frames_encoded,
             "[H265Encoder] Shutting down"
         );
-        self.encoder.take();
+        self.session.take();
         self.gpu_context.take();
         Ok(())
     }
@@ -73,50 +76,46 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265EncoderProcessor::Pro
         let gpu_ctx = self
             .gpu_context
             .as_ref()
-            .ok_or_else(|| Error::Runtime("GPU context not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("GPU context not initialized".into()))?
+            .clone();
 
-        if self.encoder.is_none() {
-            let encoder = build_encoder_lazily(gpu_ctx, &self.config, &frame)?;
-            self.encoder = Some(encoder);
+        if self.session.is_none() {
+            let session = build_encoder_session_lazily(&gpu_ctx, &self.config, &frame)?;
+            self.session = Some(session);
         }
 
-        let encoder = self
-            .encoder
-            .as_mut()
-            .ok_or_else(|| Error::Runtime("H.265 encoder not initialized".into()))?;
-
+        // Resolve the incoming frame's GPU texture; `submit_texture` resolves
+        // the encode-src view host-side and requires the source in
+        // SHADER_READ_ONLY_OPTIMAL (the layout resolved textures are left in).
         let texture = gpu_ctx.resolve_texture_by_surface_id(
             &frame.surface_id,
             frame.texture_layout,
             frame.width,
             frame.height,
         )?;
-        // Cdylib-safe: `Texture::vulkan_inner()` reaches `host_inner()` which
-        // panics under `host_callbacks().is_some()`. Route through the
-        // `host_vulkan_texture_arc` FullAccess slot so cdylib callers don't
-        // trip the panic guard.
-        let host_texture = texture.host_vulkan_texture_arc().map_err(|e| {
-            Error::GpuError(format!("Failed to acquire host texture for encode: {e}"))
-        })?;
-        let image_view = host_texture.image_view().map_err(|e| {
-            Error::GpuError(format!("Failed to get image view: {e}"))
-        })?;
 
         let timestamp_ns: Option<i64> = frame.timestamp_ns.parse().ok();
         let frame_fps = frame.fps;
         // Pass color metadata through input → encoded so the muxer /
-        // downstream consumer can populate VUI / colr without re-
-        // deriving from the bitstream. VUI write-back from encoder
-        // config lands in a follow-up.
+        // downstream consumer can populate VUI / colr without re-deriving
+        // from the bitstream.
         let frame_color_info = frame.color_info.clone();
         let frame_mastering_display = frame.mastering_display.clone();
         let frame_content_light = frame.content_light.clone();
 
-        let packets = encoder.encode_image(image_view, timestamp_ns).map_err(|e| {
-            Error::Runtime(format!("H.265 encode failed: {e}"))
-        })?;
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| Error::Runtime("H.265 encoder session not initialized".into()))?;
 
-        for packet in packets {
+        let packet_count = session
+            .submit_texture(&texture, VulkanLayout::SHADER_READ_ONLY_OPTIMAL, timestamp_ns)
+            .map_err(|e| Error::Runtime(format!("H.265 encode failed: {e}")))?;
+
+        for index in 0..packet_count {
+            let packet = session
+                .drain_packet(index)
+                .map_err(|e| Error::Runtime(format!("H.265 drain packet failed: {e}")))?;
             let encoded = EncodedVideoFrame {
                 data: packet.data,
                 fps: frame_fps,
@@ -174,11 +173,13 @@ fn select_encoder_dims(
     (frame_width, frame_height, fps)
 }
 
-fn build_encoder_lazily(
+/// Build the frozen encoder-session descriptor from config + first frame,
+/// then mint the host `EncoderSession` inside a one-shot escalate window.
+fn build_encoder_session_lazily(
     gpu_ctx: &GpuContextLimitedAccess,
     config: &crate::_generated_::H265EncoderConfig,
     frame: &VideoFrame,
-) -> Result<SimpleEncoder> {
+) -> Result<EncoderSession> {
     let (width, height, fps) = select_encoder_dims(
         config.width,
         config.height,
@@ -190,58 +191,87 @@ fn build_encoder_lazily(
 
     // First-frame color info drives the session-level SPS VUI. Mid-stream
     // ColorInfo changes are not honored — switching colorimetry requires a
-    // new SPS, which the encoder doesn't re-emit per frame.
+    // new SPS, which the encoder doesn't re-emit per frame. An all-absent
+    // repr (every `*_present` byte 0) reads host-side as "no VUI".
     let color_vui = frame
         .color_info
         .as_ref()
-        .and_then(color_info_to_h273);
+        .map(color_info_to_h273_repr)
+        .unwrap_or_default();
 
-    let encoder_config = SimpleEncoderConfig {
+    let (has_bitrate, bitrate_bps) = match config.bitrate_bps {
+        Some(bps) => (1, bps),
+        None => (0, 0),
+    };
+    let (has_effort_level, effort_level) = match config.effort_level {
+        Some(level) => (1, level),
+        None => (0, 0),
+    };
+    let idr_interval_secs = config.keyframe_interval_seconds.unwrap_or(2.0) as u32;
+
+    let descriptor = VideoEncoderSessionDescriptorRepr {
         width,
         height,
         fps,
-        codec: Codec::H265,
-        preset: Preset::Medium,
-        streaming: true,
-        idr_interval_secs: config.keyframe_interval_seconds.unwrap_or(2.0) as u32,
-        bitrate_bps: config.bitrate_bps,
-        prepend_header_to_idr: Some(true),
-        effort_level: config.effort_level,
+        codec: VideoCodecRepr::H265 as u32,
+        preset: VideoEncoderPresetRepr::Medium as u32,
+        bitrate_bps,
+        has_bitrate,
+        idr_interval_secs,
+        effort_level,
+        has_effort_level,
+        // `streaming = true`: header prepended to each IDR for mid-stream join.
+        streaming: 1,
+        prepend_header_present: 1,
+        prepend_header: 1,
+        // Texture input: keep the eager `prepare_gpu_encode_resources` the
+        // host folds in when this byte is 0.
+        disable_gpu_input_prealloc: 0,
         color_vui,
         ..Default::default()
     };
 
-    let encoder = gpu_ctx.escalate(|full| {
-        let mut encoder = SimpleEncoder::from_full_access(full, encoder_config)
-            .map_err(|e| Error::Runtime(format!("Failed to create H.265 encoder: {e}")))?;
+    // Mint the session in a one-shot escalate window — the scope-end drains
+    // the device, so this runs at most once per session (first frame). Per-
+    // frame `submit_texture` / `drain_packet` ride the session's own
+    // scope-free methods. `escalate` returns `Result<Result<..>>`: the outer
+    // is the escalate machinery, the inner is the mint.
+    let session = match gpu_ctx.escalate(|full| full.create_encoder_session(&descriptor)) {
+        Ok(Ok(session)) => session,
+        Ok(Err(e)) => {
+            return Err(Error::Runtime(format!(
+                "Failed to create H.265 encoder session: {e}"
+            )));
+        }
+        Err(e) => {
+            return Err(Error::Runtime(format!(
+                "escalate for H.265 encoder-session mint failed: {e}"
+            )));
+        }
+    };
 
-        encoder
-            .prepare_gpu_encode_resources()
-            .map_err(|e| Error::Runtime(format!("Failed to pre-allocate H.265 encode resources: {e}")))?;
-
-        Ok(encoder)
-    })?;
-
+    let (aligned_width, aligned_height) = session.aligned_extent();
     tracing::info!(
-        "[H265Encoder] Initialized lazily ({}x{}, {}fps, shared RHI device, Vulkan Video hardware)",
+        aligned_width,
+        aligned_height,
+        "[H265Encoder] Session minted lazily ({}x{}, {}fps, Vulkan Video hardware)",
         width,
         height,
         fps
     );
-    tracing::info!(
-        color_vui = ?color_vui,
-        "[H265Encoder] SPS VUI color metadata chained from first-frame color_info"
-    );
-    // Debug: emit the cached VPS+SPS+PPS bytes as hex once at construction
-    // so E2E flows can `ffprobe` the parameter sets without saving a full
-    // MP4. One-shot trace; encoded packets at frame rate are not logged.
-    tracing::debug!(
-        header_hex = %hex_encode(encoder.header()),
-        header_len = encoder.header().len(),
-        "[H265Encoder] Cached VPS+SPS+PPS header"
-    );
+    // Debug: emit the cached VPS+SPS+PPS bytes as hex once at construction so
+    // E2E flows can `ffprobe` the parameter sets without saving a full MP4.
+    // One-shot trace; encoded packets at frame rate are not logged.
+    match session.header() {
+        Ok(header) => tracing::debug!(
+            header_hex = %hex_encode(&header),
+            header_len = header.len(),
+            "[H265Encoder] Cached VPS+SPS+PPS header"
+        ),
+        Err(e) => tracing::debug!(error = %e, "[H265Encoder] Header fetch failed (non-fatal)"),
+    }
 
-    Ok(encoder)
+    Ok(session)
 }
 
 /// Lowercase hex encoder for the one-shot VPS+SPS+PPS debug log. Returns an

--- a/xtask/src/check_boundaries.rs
+++ b/xtask/src/check_boundaries.rs
@@ -990,16 +990,6 @@ const PACKAGES_FACADE_DEP_ALLOWLIST: &[AllowEntry] = &[
         kind: AllowKind::ExactFile,
         rationale: "pre-conversion facade linker (shrinking backlog)",
     },
-    AllowEntry {
-        path: "packages/h264/Cargo.toml",
-        kind: AllowKind::ExactFile,
-        rationale: "pre-conversion facade linker (shrinking backlog)",
-    },
-    AllowEntry {
-        path: "packages/h265/Cargo.toml",
-        kind: AllowKind::ExactFile,
-        rationale: "pre-conversion facade linker (shrinking backlog)",
-    },
 ];
 
 fn check_packages_facade_runtime_dep(
@@ -1095,16 +1085,6 @@ const PACKAGES_ENGINE_REACH_ALLOWLIST: &[AllowEntry] = &[
     // Shrinking conversion backlog.
     AllowEntry {
         path: "packages/camera/",
-        kind: AllowKind::PathPrefix,
-        rationale: "pre-conversion engine-bridge reacher (shrinking backlog)",
-    },
-    AllowEntry {
-        path: "packages/h264/",
-        kind: AllowKind::PathPrefix,
-        rationale: "pre-conversion engine-bridge reacher (shrinking backlog)",
-    },
-    AllowEntry {
-        path: "packages/h265/",
         kind: AllowKind::PathPrefix,
         rationale: "pre-conversion engine-bridge reacher (shrinking backlog)",
     },
@@ -2667,10 +2647,10 @@ streamlib = { version = "0.6.0" }
     #[test]
     fn allows_engine_reach_in_allowlisted_package() {
         let dir = empty_workspace();
-        // packages/h264 is on the seeded baseline — both reach forms pass.
+        // packages/camera is on the seeded baseline — both reach forms pass.
         write_fixture(
             dir.path(),
-            "packages/h264/src/linux/encoder.rs",
+            "packages/camera/src/linux/camera.rs",
             "use streamlib::sdk::engine::host_rhi::VulkanDevice;\nfn f() { let d = full.host_vulkan_device_arc().unwrap(); }\n",
         );
         let report = scan_all(dir.path()).unwrap();

--- a/xtask/src/check_cdylib_reach.rs
+++ b/xtask/src/check_cdylib_reach.rs
@@ -174,9 +174,7 @@ pub fn run(workspace_root: &Path) -> Result<()> {
                1. For raw `VkImage` / `VkImageView` access from a `Texture`, \
                   use `HostTextureExt::host_vulkan_texture_arc()` (the v10 \
                   FullAccess vtable slot — already in use by \
-                  `packages/camera/src/camera_to_cuda_copy.rs`, \
-                  `packages/h264/src/linux/encoder.rs`, \
-                  `packages/h265/src/linux/encoder.rs`).\n    \
+                  `packages/camera/src/camera_to_cuda_copy.rs`).\n    \
                2. If the call genuinely belongs in a host-only path (a \
                   `#[test]` or `#[cfg(test)]` helper), move it under \
                   `#[cfg(test)]` / `mod tests` so the lint skips it."


### PR DESCRIPTION
Closes #1265

## Summary

Converts both `@tatolab/h264` and `@tatolab/h265` codec packages from the `streamlib` facade
dependency to `streamlib-plugin-sdk`, closing the slpkg raw-device hazard documented in
`docs/learnings/slpkg-raw-device-rhi-construction.md`.

- Encoder: drops `host_vulkan_texture_arc().image_view()` and `SimpleEncoder::from_full_access`;
  now mints a hardware session via `gpu_ctx.escalate(|full| full.create_encoder_session(&descriptor))`
  from `process()` and drives per-frame work through `session.submit_texture(&texture,
  VulkanLayout::SHADER_READ_ONLY_OPTIMAL, ts)` — the host resolves the encode-src view.
- Decoder: drops `SimpleDecoder::from_full_access`; now mints via
  `ctx.gpu_full_access().create_decoder_session(&descriptor)` directly inside `setup()` (no
  `.escalate()`, matching the "never escalate inside a FullAccess lifecycle body" rule). Output
  moves from a pre-uploaded `TextureRing` slot to a pooled host-visible pixel buffer
  (`acquire_pixel_buffer`) whose pool_id is emitted as `surface_id`; the host resolves/uploads it
  on the consumer side (Path 3 of `resolve_texture_registration_by_surface_id`).
- `#[repr(C)]` descriptors (`VideoEncoderSessionDescriptorRepr`, `VideoDecoderSessionDescriptorRepr`,
  `H273ColorVuiRepr`, `VideoCodecRepr`, `VideoEncoderPresetRepr`) are filled per the layout-tested
  structs in `runtime/streamlib-plugin-abi/src/repr/video.rs` — this PR only consumes slots landed
  in #1259, no ABI vtable change.
- H.273 colorimetry enumerant constants are now package-local (verified byte-identical to the
  engine's authoritative values in `runtime/streamlib-engine/src/vulkan/video/encode/color_vui.rs`,
  minus the sentinel the reprs model differently via a `*_present` flag).
- `Cargo.toml` for both packages now depends on `streamlib-plugin-sdk` / `streamlib-macros` /
  `streamlib-plugin-abi` (version-only, resolved via `streamlib link --engine`), no more facade dep.
- `xtask/src/check_boundaries.rs` / `check_cdylib_reach.rs`: h264/h265 removed from
  `PACKAGES_FACADE_DEP_ALLOWLIST` and `PACKAGES_ENGINE_REACH_ALLOWLIST`; the now-orphaned
  engine-reach test fixture re-pointed to `packages/camera` (still allowlisted).

## Test evidence

- `check-boundaries`: 5385 file(s) scanned, no violations (h264/h265 allowlist entries removed;
  both packages pass with the stricter gate).
- Both packages compile and pass their unit tests against the real linked SDK
  (`streamlib link --engine`), not a stub.
- `git grep` on the branch confirms zero residual `sdk::engine::` / `host_vulkan_*_arc` /
  `SimpleEncoder`/`SimpleDecoder`/`TextureRing` references in `packages/h264|h265/src` (only
  comments documenting their intentional absence, and the parked `_apple_impl_pending_` dir).

## E2E / runtime validation

All four exit/validation checkboxes on #1265 are unchecked — the runtime criteria
(vulkan-video-roundtrip for both codecs as separately-built `.slpkg`s + PSNR fixture rig) are
GPU-runtime and cannot execute in this sandbox (exit 144). See `/verify-live` for the owner-run
command block. Code-level criteria are verified (see above).

## Review items (non-blocking)

- **[info]** `packages/h264/src/linux/encoder.rs:76` — Ticket runtime exit criteria (E2E
  vulkan-video-roundtrip both codecs as separately-built `.slpkg`s + PSNR rig) are the real
  validation but are unchecked. All four exit/validation checkboxes on #1265 are unmarked; these
  are GPU-runtime and cannot run in this sandbox (exit 144). Code-level criteria (dep=
  streamlib-plugin-sdk only, no `sdk::engine::video` / raw-texture bridging, check-boundaries
  clean) are verified: `check-boundaries: 5385 file(s) scanned, no violations`; both packages
  compile and pass unit tests against the real linked SDK. Suggested next step: gate merge on
  human `/verify-live`: vulkan-video-roundtrip + `e2e_fixture_psnr.sh` for h264 AND h265 with the
  packages as separately-built `.slpkg`s, PNG read-tool check. Not a code blocker.

- **[low]** `packages/h264/src/linux/decoder.rs:191` — Comment "the same CPU→GPU hand-off the
  camera uses" conflates two distinct mechanisms. The camera
  (`packages/camera/src/linux/camera.rs:1046`) explicitly calls
  `register_texture_with_layout(pool_id, ring_texture, SHADER_READ_ONLY_OPTIMAL)` so resolve finds
  a pre-existing GPU texture; the decoder registers nothing and relies on `acquire_pixel_buffer`
  auto-registering the buffer (`gpu_context.rs:200 store.register_buffer`) plus upload-on-resolve.
  The mechanism is real and supported, but the parity claim is imprecise. Suggested next step:
  reword the comment to describe the pixel-buffer-auto-register + upload-on-resolve path rather
  than asserting parity with the camera's explicit ring-texture registration.

- **[low]** `packages/h264/src/linux/color_vui_translate.rs:24` — H.273 enumerant byte constants
  are now duplicated per-package (h264 + h265) after being severed from the engine's `color_vui`
  module. No H.273 enumerant constants exist in `streamlib-plugin-sdk` or `streamlib-plugin-abi`
  (grep returned nothing); each package defines `mod primaries/transfer/matrix` locally. Both
  packages already dep `streamlib-plugin-abi` where `H273ColorVuiRepr` lives. The duplication is
  explicitly called out in the module doc (not a silent-DRY violation) and the mapping fns must
  stay per-package (they reference crate `_generated_` codegen), so only the ~40-line
  frozen-constant block is duplicable. Suggested next step: optional — hoist the codec-agnostic
  H.273 enumerant constants next to `H273ColorVuiRepr` in `streamlib-plugin-abi` so both codec
  packages consume one copy; defensible as-is given the separately-built model.

- **[info]** `packages/h264/src/linux/decoder.rs:106` — Decoder now queries color VUI once per
  `feed()` batch instead of once per decoded frame (behavioral shift from the pre-conversion code).
  Old code called `decoder.current_color_vui()` inside `for decoded in decoded_frames`; new code
  calls `session.current_color_vui()` once before `for index in 0..frame_count` and clones
  `color_info` per frame. Benign for single-access-unit feeds; differs only if one feed spans a
  mid-batch SPS/colorimetry change. Suggested next step: no action required; note for the
  gpu-vulkan/domain lens in case mid-stream colorimetry changes within one feed() are in scope.

- **[info]** `packages/h264/src/linux/encoder.rs:90` — This is a genuine ABI-soundness
  improvement: both codecs stop reaching the raw-view bridge and the raw full-access device, and
  now drive host-minted `PluginAbiObject`s opaquely. `encoder.rs` deletes
  `texture.host_vulkan_texture_arc().image_view()` (the exact `host_inner()` panic-guard reach the
  cdylib-reachability doc warns against) and `SimpleEncoder::from_full_access`, replacing them
  with `session.submit_texture(&texture, VulkanLayout::SHADER_READ_ONLY_OPTIMAL, ts)` where the
  host resolves the encode-src view. `decoder.rs` drops `SimpleDecoder::from_full_access` for
  `ctx.gpu_full_access().create_decoder_session(&descriptor)`. The codec never constructs an Arc,
  never names a host device/kernel/buffer ctor. Suggested next step: none — merge-positive.

- **[info]** `packages/h264/src/linux/encoder.rs:224` — escalate discipline is correct on both
  sides: encoder mints one-shot inside escalate from `process()`; decoder mints in `setup()` via a
  direct FullAccess call with no escalate. `encoder` `build_encoder_session_lazily` uses
  `gpu_ctx.escalate(|full| full.create_encoder_session(&descriptor))` and matches the
  `Result<Result<..>>` shape exhaustively (Ok(Ok)/Ok(Err)/Err). `decoder` `setup()` (a FullAccess
  lifecycle body) calls `ctx.gpu_full_access().create_decoder_session(&descriptor)` directly —
  matching the plugin-boundary rule "never `.escalate()` inside a FullAccess lifecycle body".
  Suggested next step: none.

- **[info]** `runtime/streamlib-plugin-abi/src/repr/video.rs:85` — the `#[repr(C)]`
  descriptors/reprs are filled correctly and the codecs add no vtable slot, so no
  `*_VTABLE_LAYOUT_VERSION` bump is owed. The codec fills `VideoEncoderSessionDescriptorRepr` /
  `VideoDecoderSessionDescriptorRepr` / `H273ColorVuiRepr` / `VideoCodecRepr` /
  `VideoEncoderPresetRepr` with field names, u32 discriminants, and the (value,present) flattening
  that exactly match the layout-tested structs in
  `runtime/streamlib-plugin-abi/src/repr/video.rs` (offset_of!/discriminant tests). h265 uses
  `VideoCodecRepr::H265`, h264 uses `H264` (verified in both encoder and decoder); the two codecs
  are byte-for-byte identical modulo codec/name/config/log strings. This PR only CONSUMES slots
  landed in #1259 — the five-part slot-addition contract does not apply. Suggested next step:
  none.

- **[info]** `xtask/src/check_boundaries.rs:1026` — boundary-gate hygiene is complete: the
  de-allowlisting is matched by an actually-complete conversion, so the now-strict guards stay
  green. `check_boundaries.rs` removes h264/h265 from `PACKAGES_FACADE_DEP_ALLOWLIST` and
  `PACKAGES_ENGINE_REACH_ALLOWLIST`; `check_cdylib_reach.rs` drops the two encoder paths from its
  fix-hint. Scanned the branch h264/h265 trees: the only residual references to
  `host_vulkan_texture_arc` / `streamlib::` are inside `//` comments and the parked
  `_apple_impl_pending_` dir. Both scanners skip comments (engine-reach via
  `trimmed.starts_with("//")`; cdylib-reach + facade-dep via syn AST / exact TOML dep-key `==
  "streamlib"`), so no gate turns red. `Cargo.toml` facade dep `streamlib` is fully replaced by
  `streamlib-plugin-sdk`. Suggested next step: none.

- **[low]** `packages/h264/src/linux/decoder.rs:14` — decoder doc-comment mis-describes the
  surface hand-off as "the same CPU->GPU hand-off the camera uses" — it is a different resolve
  path, though the outcome is equivalent. `decoder.rs` writes `pool_id.to_string()` as
  `surface_id` and registers NO texture, relying on the host resolve to upload. The camera
  (`packages/camera/src/linux/camera.rs:1046`) pre-registers a GPU ring texture under the pool_id
  and fills it with a compute kernel — it resolves via Path 1 (texture_cache) / Path 2
  (surface-share). The decoder instead resolves via Path 3, the pixel-buffer fallback
  (`gpu_context.rs:846-863` `surface_store.lookup_buffer` -> `refresh_pixel_buffer_texture`), which
  only works because `PixelBufferPoolManager::acquire` auto-registers the buffer into the
  `surface_store` (`gpu_context.rs:199-200`). Same end result (host uploads to a
  SHADER_READ_ONLY_OPTIMAL texture), different mechanism. Suggested next step: optional — reword
  the doc-comment to name the pixel-buffer fallback (Path 3) rather than implying the camera's
  pre-registered-texture path. Code is correct; comment only.

- **[info]** `packages/h264/src/linux/decoder.rs:130` — the decoded-frame pixel-buffer lifecycle
  (drop-after-enqueue, refcount-gated pool recycling, surface_store registration) is a
  runtime-behavioral surface the sandbox cannot exercise — worth an explicit E2E rig pass.
  `decoder.rs` drops `pixel_buffer` at the end of each loop iteration right after `outputs.write`
  (which only enqueues into the msgpack/iceoryx2 mailbox); resolvability past that point depends
  on the surface_store retaining the buffer under its unique pool_id until a downstream consumer
  resolves it. When a single `feed` stages `frame_count>1` (reorder/batch), multiple distinct
  pool_ids are minted and each buffer dropped after enqueue. This mirrors the established
  cross-process pixel-buffer pattern (not new machinery), but it is the "clean pipeline, no error"
  class where a pool-depth/lifecycle mismatch would surface only as black or stale downstream
  frames. Suggested next step: run a live decode->display and decode->mux E2E on the rig (sandbox
  exits 144 on GPU) to confirm frames arrive intact; no code change indicated unless that surfaces
  stale/black output.

- **[info]** `packages/h264/src/linux/decoder.rs:107` — two intentional behavioral refinements
  worth noting for the PR body, neither a defect. (1) decoder now queries `current_color_vui()`
  once per feed (was once per drained frame) — equivalent-or-better since the VUI is
  SPS/session-level, and a query error now warns+falls back instead of dropping valid frames. (2)
  encoder always tells `submit_texture` the input layout is SHADER_READ_ONLY_OPTIMAL regardless of
  `frame.texture_layout`; consistent with the resolve contract (all in-tree producers + Path 3
  leave textures in that layout) and matches prior behavior, but is an implicit assumption for any
  future non-SHADER_READ producer. Suggested next step: note in PR body; no change required.

- **[info]** `packages/h264/src/linux/encoder.rs:112` — the conversion correctly closes the slpkg
  raw-device trap (`docs/learnings/slpkg-raw-device-rhi-construction.md`): the encoder/decoder no
  longer construct `SimpleEncoder`/`SimpleDecoder` via `from_full_access`, no longer reach
  `host_vulkan_texture_arc` / `vulkan_inner`, and no longer build a `TextureRing` on the raw
  device. Hardware sessions are now minted host-side via
  `GpuContextFullAccess::create_encoder_session` / `create_decoder_session`
  (`gpu_context.rs:1974/2008`) and per-frame work rides the cdylib-safe
  `EncoderSession`/`DecoderSession` `PluginAbiObject` methods. `git grep` on the branch shows zero
  residual `sdk::engine::` / `host_vulkan_device_arc` / `host_vulkan_texture_arc` / `SimpleEncoder`
  / `SimpleDecoder` / `TextureRing` references in `packages/h264|h265/src` (only comments
  documenting their intentional absence). Encoder mints via `gpu_ctx.escalate(|full|
  full.create_encoder_session(&descriptor))` inside a reactive body; decoder mints via
  `ctx.gpu_full_access().create_decoder_session(&descriptor)` directly inside `setup()` — correct
  escalate discipline per `.claude/rules/plugin-boundary.md` (never escalate inside a FullAccess
  lifecycle body). Suggested next step: none — this is the prescribed fix. GPU-runtime
  verification is rig-gated (`/verify-live`): confirm a separately-built `.slpkg` encode+decode
  round-trip on NVIDIA before closing #1265.

- **[info]** `packages/h264/src/linux/decoder.rs:162` — decoder output handoff shifts from a
  pre-uploaded DEVICE_LOCAL `TextureRing` slot (old Path-1 registered texture) to a pooled
  host-visible pixel buffer whose pool_id is emitted as `surface_id`. Verified sound:
  `acquire_pixel_buffer` (`gpu_context.rs:642`) passes `surface_store` to the pool manager so the
  buffer's DMA-BUF fd is registered, and `resolve_texture_registration_by_surface_id`
  (`gpu_context.rs:841`) Path 3 uploads it via `refresh_pixel_buffer_texture`, leaving it in
  SHADER_READ_ONLY_OPTIMAL. This mirrors the camera's proven cross-process-CPU path.
  `packages/camera/src/linux/camera.rs:1232-1237` uses the identical `pool_id.to_string()`
  surface_id pattern (though camera additionally registers a Path-1 GPU texture as a
  same-process zero-copy optimization the decoder omits). Behavioral note: the GPU upload now
  happens at consumer resolve time (re-uploaded per resolve via the buffer_texture_cache
  get-or-refresh) rather than once at decode time — roughly cost-equivalent for a
  single-consumer topology. Suggested next step: none required. Reviewers should note the
  upload-timing shift; a multi-consumer fan-out would re-upload per consumer, unlike the old
  single pre-upload.

- **[info]** `packages/h264/src/linux/color_vui_translate.rs:37` — H.273 enumerant constants were
  moved package-local (engine's `color_vui` module is no longer linked). Verified byte-identical
  to the engine's authoritative values, so no silent colorimetry drift. Diff of every `pub const
  NAME: u8 = N` between `runtime/streamlib-engine/src/vulkan/video/encode/color_vui.rs` and
  `packages/h264/src/linux/color_vui_translate.rs` shows the only delta is the engine's
  UNSPECIFIED/H273_UNSPECIFIED = 2 sentinels, which the package intentionally omits (it models
  axis-absence via the `H273ColorVuiRepr` `*_present` byte instead). h264 and h265
  `color_vui_translate.rs` are byte-identical to each other (sanctioned per-package codegen
  duplication). The layout-regression tests for the reprs the packages fill live in
  `runtime/streamlib-plugin-abi/src/repr/video.rs:187-343` (pre-existing on main). Suggested next
  step: none.

- **[info]** `xtask/src/check_boundaries.rs:998` — boundary gates were tightened correctly:
  h264/h265 removed from both `PACKAGES_FACADE_DEP_ALLOWLIST` and
  `PACKAGES_ENGINE_REACH_ALLOWLIST` (they no longer link the streamlib facade nor reach the engine
  bridge), and the now-orphaned `allows_engine_reach_in_allowlisted_package` test fixture was
  re-pointed from `packages/h264` to `packages/camera` (still allowlisted). No stale h264/h265
  references remain anywhere in xtask. Remaining ENGINE_REACH allowlist = test-fixtures
  (permanent) + camera + display (shrinking backlog); FACADE_DEP = api-server + test-fixtures
  (permanent) + camera + display. `Cargo.toml` deps are version-only (`{version = "0.6.0"}` for
  streamlib-plugin-sdk / streamlib-macros / streamlib-plugin-abi) with no `path=` or `[patch]`
  entries and an empty `[workspace]` table — correct version-resolves-via-link model, no
  path/patch cross-crate dep introduced. Suggested next step: none.

- **[info]** `packages/h264/src/linux/encoder.rs:112` — the conversion is the correct fix for the
  slpkg raw-device hazard: h264/h265 GPU work now routes exclusively through the `#[repr(C)]`
  session `PluginAbiObject`s (`create_encoder_session`/`create_decoder_session`), removing every
  `host_vulkan_device_arc` / `host_vulkan_texture_arc` / `SimpleEncoder`/`Decoder::from_full_access`
  reach. This makes both codecs safe to ship as separately-built `.slpkg` packages. `encoder.rs:112`
  `submit_texture(&texture,...)` replaces the old `host_vulkan_texture_arc().image_view()` bridge;
  `encoder.rs:239` mints via `escalate(|full| full.create_encoder_session(&descriptor))`;
  `decoder.rs:67` `create_decoder_session(&descriptor)`. `git grep` confirms zero residual
  `streamlib::sdk::engine::` / `host_vulkan_*_arc` / `SimpleEncoder`/`SimpleDecoder` in
  `packages/h264|h265/src`. Reprs are `#[repr(C)]` with offset_of layout tests in
  `runtime/streamlib-plugin-abi/src/repr/video.rs:187-343`. Matches
  `docs/learnings/slpkg-raw-device-rhi-construction.md`. Suggested next step: none — this is the
  sanctioned pattern. Note it as the headline in the PR body.

- **[info]** `xtask/src/check_boundaries.rs:1078` — boundary allowlist tightening is correct and
  now enforces the clean state. h264/h265 removed from both `PACKAGES_FACADE_DEP_ALLOWLIST` and
  `PACKAGES_ENGINE_REACH_ALLOWLIST`, and the cdylib-reach lint dropped the h264/h265
  `host_vulkan_texture_arc` references. The converted source contains no engine-bridge or
  vulkanalia reach, so check-boundaries will pass with the entries removed.
  `xtask/src/check_boundaries.rs`: allowlist entries for `packages/h264` and `packages/h265`
  deleted; comment updated 5->3 / 4->2. Test fixture reseeded to `packages/camera`. `git grep` on
  the branch shows converted source clean of the banned identifiers. Suggested next step: none.

- **[info]** `packages/h264/src/linux/decoder.rs:147` — decoder output-surface contract changed
  from a codec-owned `TextureRing` (registered texture, resolve Path 1) to the host pixel-buffer
  pool + resolve-time Path-3 re-upload (`refresh_pixel_buffer_texture`, which leaves the texture
  in SHADER_READ_ONLY_OPTIMAL). This is functionally sound: on Linux `surface_store` is
  unconditionally initialized at runtime start (fail-fast), `acquire_pixel_buffer` registers the
  buffer under the pool_id, and pool depth (4, expandable to 64) is >= the old RING_DEPTH of 2, so
  burst behavior is no worse than before. It is NOT a hand-rolled parallel abstraction — the
  pixel-buffer pool and host texture cache are first-class engine primitives — so no RHI invariant
  is violated. Cannot be exercised in-sandbox (GPU exit 144). `decoder.rs:147`
  `acquire_pixel_buffer` + pool_id-as-surface_id; resolution via `gpu_context.rs:846-864` Path 3
  (`surface_store.lookup_buffer` -> `refresh_pixel_buffer_texture`); `runtime.rs:496-517` always
  sets surface_store on Linux; `POOL_PRE_ALLOCATE_COUNT=4` / `POOL_MAX_BUFFER_COUNT=64` at
  `gpu_context.rs:19-22`. Suggested next step: gate merge/verification on a
  camera->encode->mux->decode->display E2E live-verify (per
  `docs/learnings/camera-display-e2e-validation.md`); confirms decoded frames resolve non-black
  end-to-end.

- **[low]** `packages/h264/src/linux/encoder.rs:112` — encoder hardcodes
  `VulkanLayout::SHADER_READ_ONLY_OPTIMAL` as the `submit_texture` input layout. The host validates
  this and rejects any other layout with a typed error, so a future encoder whose upstream
  produces a different resolved layout (e.g. a non-camera/decoder source leaving GENERAL) would
  hard-error rather than silently mis-encode. This is stricter and safer than the pre-conversion
  silent `image_view` assumption; the host already documents that arbitrary-layout transition on
  the encode path is a follow-up. `encoder.rs:112` passes SHADER_READ_ONLY_OPTIMAL
  unconditionally; host guard at
  `runtime/streamlib-engine/src/core/plugin/host_services/video_encoder_session.rs:358` rejects
  any other `input_layout` with a typed error. Suggested next step: no action for this PR. If a
  non-SHADER_READ_ONLY producer is ever wired ahead of the encoder, file the arbitrary-layout-
  transition follow-up the host comment references.

- **[info]** `packages/h264/src/linux/decoder.rs:160` — decoder RGBA stage now clamps copy length
  to the pixel-buffer plane size and adds a null base-pointer guard — this fixes a latent
  out-of-bounds write in the old unclamped flat copy (which used `src.len()` directly against the
  mapped buffer). `decoder.rs:149` `dst_ptr.is_null()` guard; `decoder.rs:160`
  `copy_nonoverlapping` bounded by `copy_len = src.len().min(plane_size(0))`. Old code copied
  `src.len()` bytes with no plane-size clamp. Suggested next step: none — defensive improvement.

