### PR TITLE
test(engine): run the tone-mapper GPU tests; drop empty vk_video_decoder stubs

### DIFF
--- a/runtime/streamlib-engine/src/vulkan/rhi/vulkan_tone_mapper.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/vulkan_tone_mapper.rs
@@ -476,7 +476,10 @@ mod tests {
     /// `bt2390_eetf`) and this test fails — the GPU output diverges
     /// from the CPU reference everywhere above the knee.
     #[test]
-    #[ignore = "hardware integration — requires a working Vulkan device + queue"]
+    #[cfg_attr(
+        not(feature = "hardware-tests"),
+        ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md"
+    )]
     fn bt2390_pq_to_srgb_matches_cpu_reference() {
         let Some(device) = try_vulkan_device() else {
             return;
@@ -603,7 +606,10 @@ mod tests {
     /// the new precondition check at the top of
     /// `VulkanToneMapper::apply_with_layouts` and this test fails.
     #[test]
-    #[ignore = "hardware integration — requires a working Vulkan device + queue"]
+    #[cfg_attr(
+        not(feature = "hardware-tests"),
+        ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md"
+    )]
     fn apply_with_layouts_rejects_same_image_for_src_and_dst() {
         let Some(device) = try_vulkan_device() else {
             return;

--- a/runtime/streamlib-engine/src/vulkan/video/vk_video_decoder/vk_video_decoder.rs
+++ b/runtime/streamlib-engine/src/vulkan/video/vk_video_decoder/vk_video_decoder.rs
@@ -1582,13 +1582,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "requires GPU — VkVideoDecoder::new() needs a real VideoContext"]
-    fn test_create_decoder() {
-        // VkVideoDecoder::new() requires Arc<VideoContext> with a live Vulkan
-        // device. This test is kept as a placeholder for GPU integration tests.
-    }
-
-    #[test]
     fn test_get_video_codec_string() {
         assert_eq!(
             VkVideoDecoder::get_video_codec_string(vk::VideoCodecOperationFlagsKHR::NONE),
@@ -1642,30 +1635,6 @@ mod tests {
     }
 
     // test_set_export_preferences removed — set_export_preferences method was removed.
-
-    #[test]
-    #[ignore = "requires GPU — VkVideoDecoder::new() needs a real VideoContext"]
-    fn test_start_video_sequence() {
-        // Requires Arc<VideoContext> with a live Vulkan device.
-    }
-
-    #[test]
-    #[ignore = "requires GPU — VkVideoDecoder::new() needs a real VideoContext"]
-    fn test_get_current_frame_data() {
-        // Requires Arc<VideoContext> with a live Vulkan device.
-    }
-
-    #[test]
-    #[ignore = "requires GPU — VkVideoDecoder::new() needs a real VideoContext"]
-    fn test_get_bitstream_buffer_updates_max() {
-        // Requires Arc<VideoContext> with a live Vulkan device.
-    }
-
-    #[test]
-    #[ignore = "requires GPU — VkVideoDecoder::new() needs a real VideoContext"]
-    fn test_deinitialize_is_safe() {
-        // Requires Arc<VideoContext> with a live Vulkan device.
-    }
 
     #[test]
     fn test_nv_vk_decode_frame_data_resize() {


### PR DESCRIPTION
## What & why

Two `VulkanToneMapper` GPU-parity tests carried a **plain `#[ignore]`**, which ignores them unconditionally — so they never ran even under `--features hardware-tests`. On a GPU box that's dead coverage. This flips them to the canonical `#[cfg_attr(not(feature = "hardware-tests"), ignore = "…")]` gate (the shape already used in `vulkan_buffer.rs`, `vulkan_color_converter.rs`, `vulkan_video_session.rs`), so the tier-2 hardware suite exercises them.

**Verified on the RTX 3090** — `cargo test -p streamlib-engine --features hardware-tests --lib -- --test-threads=1 vulkan_tone_mapper`:

```
running 5 tests
test ...tone_mapper::tests::apply_with_layouts_rejects_same_image_for_src_and_dst ... ok
test ...tone_mapper::tests::bt2390_pq_to_srgb_matches_cpu_reference ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 1747 filtered out
```

`0 ignored` — before this change those two showed as ignored right here. `bt2390…` asserts per-pixel PQ→sRGB parity vs a CPU reference (±2 ULP); `apply_with_layouts_rejects_same_image…` asserts the `src == dst` precondition rejection.

## Also: delete 5 empty decoder placeholder stubs

`vk_video_decoder.rs` had five `#[ignore]`'d "tests" whose bodies are comment-only: `test_create_decoder`, `test_start_video_sequence`, `test_get_current_frame_data`, `test_get_bitstream_buffer_updates_max`, `test_deinitialize_is_safe`. They test nothing. Wiring them to the hardware-tests feature would only manufacture a **vacuous pass** — worse than ignored, since the tier-2 count would then read as real coverage. Deleted. Actual decoder GPU coverage lives in the `vulkan_video_session` hardware tests and the h264/h265 decode round-trips through the vtable (`h264_decode_half_round_trip_through_vtable`, exercised in the tier-2 suite).

Those `vk_video_decoder` lifecycle methods have no *direct* unit coverage — flagging that here rather than leaving empty stubs that misrepresent it. Happy to file a "write real decoder-lifecycle GPU tests" ticket if you want one.

## Scope / safety

- **Test-only**, no library changes. Without `hardware-tests` the two tone-mapper tests remain `#[ignore]`'d exactly as before → `cargo test --lib` (the no-GPU CI) is unchanged.
- Left alone (correctly on-demand, not hardware correctness tests): the `texture_ring` perf bench and the `tone.rs` diagnostic printer.

Found while auditing the tier-2 "9 ignored" count during the GPU-E2E work.
