### PR TITLE
feat(pack): opt-in cargo source-mirror — precursor for the separate-build validation gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5256,13 +5256,16 @@ name = "streamlib-pack"
 version = "0.6.0"
 dependencies = [
  "anyhow",
+ "flate2",
  "libc",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "streamlib-cargo-build",
  "streamlib-idents",
  "streamlib-processor-schema",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.8.23",

--- a/docs/architecture/package-development-model.md
+++ b/docs/architecture/package-development-model.md
@@ -272,8 +272,15 @@ workspace member ∧ linkable name (`streamlib*` / `vulkan-jpeg` /
 topological order. There is no "SDK-subset vs. all-libs" switch —
 `streamlib-plugin-sdk` / `vulkan-jpeg` are members by definition. It is the
 crate set `streamlib link` overrides (and the set a future SDK release would
-publish); the `.slpkg` emit no longer consults it (a `.slpkg` release
-publishes packages, not crates).
+publish). A routine `.slpkg` emit does not consult it (a `.slpkg` release
+publishes packages, not crates); a `--cargo-mirror` emit *does* — it records the
+closure in the release manifest's `crates` alongside the cargo source-replacement
+mirror it emits (see
+[`static-registry.md`](static-registry.md#the-opt-in-cargo-mirror)).
+
+> ~~The `.slpkg` emit no longer consults it.~~ — Superseded 2026-07-17 by the
+> separate-build validation gate's `--cargo-mirror` emit path, which consults
+> `compute_release_closure`. The claim held only for a routine (no-flag) emit.
 
 **Manifest-last atomicity.** A `ReleaseManifest`
 ([`sdk/streamlib-idents/src/release.rs`](../../sdk/streamlib-idents/src/release.rs))

--- a/docs/architecture/static-registry.md
+++ b/docs/architecture/static-registry.md
@@ -62,11 +62,48 @@ sees the previous *complete* release; the flip is the only mutation of the
 served path. This closes the mid-publish window where a consumer could resolve
 a higher partial version before its release manifest landed.
 
-The release manifest lists exactly the `.slpkg` packages the emit published;
-its `crates` set is empty (the emit no longer publishes an SDK crate chain).
-`compute_release_closure` — the single definition of "which library crates a
-release publishes" — survives as the crate set `streamlib link` patches, but is
-no longer consulted by the `.slpkg` emit.
+The release manifest lists the `.slpkg` packages the emit published. A routine
+emit leaves its `crates` set empty and does not consult `compute_release_closure`
+— the single definition of "which library crates a release publishes", which
+also survives as the crate set `streamlib link` patches. With `--cargo-mirror`
+the emit *does* consult `compute_release_closure`, recording that closure in
+`crates` as release metadata carried alongside the cargo source-replacement
+mirror it emits (see [The opt-in cargo mirror](#the-opt-in-cargo-mirror)).
+
+> ~~Its `crates` set is empty (the emit no longer publishes an SDK crate chain);
+> `compute_release_closure` … is no longer consulted by the `.slpkg` emit.~~ —
+> Superseded 2026-07-17 by the separate-build validation gate's `--cargo-mirror`
+> emit path, which consults `compute_release_closure` and populates `crates`
+> from it. The unconditional claim held only for a routine (no-flag) emit.
+
+## The opt-in cargo mirror
+
+`cargo xtask static-registry emit --cargo-mirror` additionally emits a cargo
+**source-replacement mirror** under `cargo-mirror/`: the full crates.io
+dependency closure of the engine/SDK crate chain, vendored as a cargo directory
+source, plus a generated `[source]` replacement config. A downstream package
+that declares the engine/SDK crates by bare version (`streamlib = "0.6.0"`) —
+with no `streamlib link` and no `[patch.crates-io]` — then resolves and compiles
+its whole closure entirely offline from the tree, the way the separate-build
+`.slpkg` validation gate builds a package by version.
+
+This is **not** a return of the removed `registry.tatolab.com` SDK-distribution
+registry (the cargo sparse index + `.crate` tarball emitters in the removal note
+above): only that SDK-distribution *emulation* — which served the SDK to
+arbitrary remote consumers by version — was removed. The cargo mirror is an
+emit-machine-**local**, gate-only affordance. A cargo directory source resolves
+by an **absolute** filesystem path baked into its `[source]` config, so it is
+local-only and cannot be HTTP-served. It is therefore deliberately **not** part
+of the relocatable `.slpkg` tree above: the absolute path in the emitted config
+is by design for a local build gate, not a relocatability regression.
+
+The mirror uses `[source.crates-io] replace-with = <mirror>` — the ratified
+`[source]`-**replacement** pattern. Replacement (not a `CARGO_REGISTRIES_*_INDEX`
+index override) preserves the canonical crates.io source id in a consumer's
+`Cargo.lock`, so a later `--locked` build stays reproducible. The mirror
+machinery lives in `tools/streamlib-pack/src/cargo_mirror.rs` (plus
+`crate_tarball.rs` for byte-stable packaging of the workspace's engine/SDK
+crates, which `cargo vendor` cannot carry).
 
 ## Catalog — queryable processor / port / schema metadata
 

--- a/tools/streamlib-pack/Cargo.toml
+++ b/tools/streamlib-pack/Cargo.toml
@@ -22,9 +22,11 @@ toml_edit = { workspace = true }
 tempfile = { workspace = true }
 zip = "2.2"
 # Byte-stable `.crate` normalization + directory-source injection for the cargo
-# source-replacement mirror (see `crate_tarball` + `cargo_mirror`). All three
-# versions are already resolved in the workspace lock (transitive), so adding
-# them here pulls no new crate.
+# source-replacement mirror (see `crate_tarball` + `cargo_mirror`). `sha2` has a
+# `[workspace.dependencies]` entry so it unifies via `workspace = true`; `flate2`
+# and `tar` have no workspace-table entry, so they are pinned locally here. All
+# three are already resolved in the workspace lock (transitive), so adding them
+# pulls no new crate.
 sha2 = { workspace = true }
 flate2 = "1"
 tar = "0.4"

--- a/tools/streamlib-pack/Cargo.toml
+++ b/tools/streamlib-pack/Cargo.toml
@@ -21,6 +21,13 @@ toml = { workspace = true }
 toml_edit = { workspace = true }
 tempfile = { workspace = true }
 zip = "2.2"
+# Byte-stable `.crate` normalization + directory-source injection for the cargo
+# source-replacement mirror (see `crate_tarball` + `cargo_mirror`). All three
+# versions are already resolved in the workspace lock (transitive), so adding
+# them here pulls no new crate.
+sha2 = { workspace = true }
+flate2 = "1"
+tar = "0.4"
 streamlib-cargo-build = { path = "../streamlib-cargo-build", version = "0.6.0" }
 streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.6.0" }
 streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.6.0" }

--- a/tools/streamlib-pack/src/cargo_mirror.rs
+++ b/tools/streamlib-pack/src/cargo_mirror.rs
@@ -1,0 +1,469 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cargo **source-replacement mirror** emission — the link-free, fully-offline
+//! build side of the static registry.
+//!
+//! A package a downstream consumer writes declares the engine/SDK crates by
+//! bare version (`streamlib = "0.6.0"`) with **no** `streamlib link` and **no**
+//! `[patch.crates-io]`. There is no crates registry and no publish step, so
+//! that bare version can only resolve if the whole crates.io dependency closure
+//! of the engine/SDK chain is present locally. This module emits exactly that:
+//! a cargo **directory source** carrying the FULL closure, plus the generated
+//! `[source]` replacement that redirects `crates-io` at it. A build against the
+//! emitted tree then resolves + compiles the package entirely offline — the way
+//! the separate-build `.slpkg` validation gate builds a package by version.
+//!
+//! ## Why a directory source (not a hand-rolled sparse local-registry)
+//!
+//! The transitive crates.io closure is hundreds of crates. `cargo vendor`
+//! produces the whole closure — unpacked sources plus per-crate
+//! `.cargo-checksum.json` — as a cargo directory source, and cargo itself
+//! computes every checksum and dependency edge; there are no sparse index lines
+//! to hand-render (one subtly-wrong `deps`/`features`/`registry` line among
+//! hundreds would break resolution). The only crates `cargo vendor` cannot
+//! carry are the engine/SDK crates themselves — they are workspace path members,
+//! not registry crates — so this module packages each ([`crate::crate_tarball`],
+//! byte-stable) and injects it into the same directory source as an extra entry.
+//!
+//! ## Source *replacement* keeps `--locked` clean
+//!
+//! The generated config uses `[source.crates-io] replace-with = <mirror>`, which
+//! **preserves** the canonical `registry+https://github.com/rust-lang/crates.io-index`
+//! source id in a consumer's `Cargo.lock`. A `CARGO_REGISTRIES_*_INDEX` env
+//! override would instead rewrite that source id and break `--locked`.
+//!
+//! ## Growing directory source, topological packaging
+//!
+//! An engine crate's packaged manifest declares its siblings by version
+//! (`streamlib-engine = "0.6.0"`), a crates.io dep once the path is stripped —
+//! so `cargo package` validates it against the (replaced) `crates-io` source.
+//! Crates are therefore packaged in the release closure's topological order
+//! (leaf-first) and each is injected into the directory source **before** its
+//! dependents are packaged, so every sibling resolves from the growing mirror.
+
+use std::collections::BTreeMap;
+use std::io::Read;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use flate2::read::GzDecoder;
+use sha2::{Digest, Sha256};
+
+use crate::ReleaseClosure;
+use crate::crate_tarball::finalize_crate_tarball;
+
+/// Subdir under the emitted registry tree holding the whole cargo mirror.
+pub const CARGO_MIRROR_SUBDIR: &str = "cargo-mirror";
+/// Subdir under [`CARGO_MIRROR_SUBDIR`] holding the vendored directory source
+/// (both the `cargo vendor` closure and the injected engine/SDK crates).
+pub const VENDOR_SUBDIR: &str = "vendor";
+/// The generated `[source]` replacement config a consumer points cargo at.
+pub const SOURCE_REPLACEMENT_CONFIG_FILE: &str = "config.toml";
+
+/// The `[source.<name>]` the mirror replacement is written under. A distinct,
+/// zero-context name so a consumer's own cargo config never collides with it.
+const MIRROR_SOURCE_NAME: &str = "streamlib-cargo-mirror";
+
+/// Render the `[source]` replacement stanza that redirects the canonical
+/// `crates-io` source at the vendored directory source rooted at `vendor_dir`.
+///
+/// A consumer writes this into its `.cargo/config.toml`; cargo then resolves
+/// every crates.io dep — including the engine/SDK crates injected into the
+/// directory source — from the local tree with no network. Source *replacement*
+/// (not an index override) preserves the canonical crates.io source id in the
+/// consumer's `Cargo.lock`, so a later `--locked` build stays reproducible.
+pub fn render_source_replacement_config(vendor_dir: &Path) -> String {
+    format!(
+        "[source.crates-io]\nreplace-with = \"{name}\"\n\n[source.{name}]\ndirectory = \"{dir}\"\n",
+        name = MIRROR_SOURCE_NAME,
+        dir = vendor_dir.display(),
+    )
+}
+
+/// A cargo directory-source `.cargo-checksum.json`: `files` (per-source-file
+/// sha256, which cargo verifies against the on-disk sources) + `package` (the
+/// `.crate` tarball sha256, recorded verbatim as the crate's `checksum` in a
+/// consumer's `Cargo.lock`).
+#[derive(serde::Serialize)]
+struct CargoDirectorySourceChecksum {
+    /// Sorted (`BTreeMap`) so re-serializing identical inputs yields identical
+    /// bytes — the byte-stability the whole mirror preserves.
+    files: BTreeMap<String, String>,
+    package: String,
+}
+
+/// Render a directory-source `.cargo-checksum.json` from a `relpath → sha256`
+/// file map and the `.crate` tarball's sha256. Keys are emitted sorted, so the
+/// output is a pure function of its inputs.
+pub fn render_cargo_checksum_json(
+    files: &BTreeMap<String, String>,
+    package_sha256: &str,
+) -> Result<String> {
+    serde_json::to_string(&CargoDirectorySourceChecksum {
+        files: files.clone(),
+        package: package_sha256.to_string(),
+    })
+    .context("serialize .cargo-checksum.json")
+}
+
+/// Unpack the byte-stable `.crate` at `crate_path` into
+/// `<vendor_dir>/<name>/` as a cargo **directory-source** entry: strip the
+/// `<name>-<version>/` tar prefix, write each file, and emit the
+/// `.cargo-checksum.json` (`files` = per-file sha256, `package` =
+/// `package_sha256`). A pre-existing entry is cleared first so a re-emit is
+/// clean.
+///
+/// The engine/SDK crates are workspace path members `cargo vendor` cannot carry,
+/// so this injects each into the same directory source the vendored crates.io
+/// closure lives in. cargo identifies the crate by the `Cargo.toml` inside the
+/// entry (not the directory name), and verifies each file against `files` on
+/// load — so the unpacked bytes and the recorded hashes must agree exactly,
+/// which they do because both come from the one normalized `.crate`.
+pub fn inject_crate_into_directory_source(
+    crate_path: &Path,
+    name: &str,
+    version: &str,
+    package_sha256: &str,
+    vendor_dir: &Path,
+) -> Result<()> {
+    let dest = vendor_dir.join(name);
+    if dest.exists() {
+        std::fs::remove_dir_all(&dest)
+            .with_context(|| format!("clear stale directory-source entry {}", dest.display()))?;
+    }
+    std::fs::create_dir_all(&dest)
+        .with_context(|| format!("create directory-source entry {}", dest.display()))?;
+
+    let bytes = std::fs::read(crate_path)
+        .with_context(|| format!("read crate tarball {}", crate_path.display()))?;
+    let mut decoded = Vec::new();
+    GzDecoder::new(&bytes[..])
+        .read_to_end(&mut decoded)
+        .with_context(|| format!("gzip-decode crate tarball {}", crate_path.display()))?;
+
+    let prefix = format!("{name}-{version}/");
+    let mut files: BTreeMap<String, String> = BTreeMap::new();
+    let mut archive = tar::Archive::new(&decoded[..]);
+    for entry in archive
+        .entries()
+        .with_context(|| format!("read crate tar entries {}", crate_path.display()))?
+    {
+        let mut entry = entry.context("read crate tar entry")?;
+        if !entry.header().entry_type().is_file() {
+            continue;
+        }
+        let entry_path = entry
+            .path()
+            .context("read crate tar entry path")?
+            .into_owned();
+        let raw = entry_path.to_string_lossy();
+        let rel = raw.strip_prefix(&prefix).unwrap_or(&raw).to_string();
+
+        let mut data = Vec::new();
+        entry
+            .read_to_end(&mut data)
+            .context("read crate tar entry data")?;
+
+        let out_path = dest.join(&rel);
+        if let Some(parent) = out_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        std::fs::write(&out_path, &data)
+            .with_context(|| format!("write {}", out_path.display()))?;
+
+        let mut hasher = Sha256::new();
+        hasher.update(&data);
+        files.insert(rel, format!("{:x}", hasher.finalize()));
+    }
+
+    let checksum = render_cargo_checksum_json(&files, package_sha256)?;
+    std::fs::write(dest.join(".cargo-checksum.json"), checksum)
+        .with_context(|| format!("write .cargo-checksum.json in {}", dest.display()))?;
+    Ok(())
+}
+
+/// The `--config` args that replace the canonical `crates-io` source with the
+/// directory source at `vendor_dir` for one `cargo package` invocation (no
+/// workspace `.cargo/config.toml` is touched).
+fn source_replacement_config_args(vendor_dir: &Path) -> Vec<String> {
+    vec![
+        format!("source.crates-io.replace-with=\"{MIRROR_SOURCE_NAME}\""),
+        format!(
+            "source.{MIRROR_SOURCE_NAME}.directory=\"{}\"",
+            vendor_dir.display()
+        ),
+    ]
+}
+
+/// Vendor the workspace's full crates.io closure into `vendor_dir` as a cargo
+/// directory source. Runs on the emit machine (network permitted); the emitted
+/// tree is what a consumer resolves offline.
+fn run_cargo_vendor(workspace_root: &Path, vendor_dir: &Path) -> Result<()> {
+    if let Some(parent) = vendor_dir.parent() {
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    let output = Command::new("cargo")
+        .arg("vendor")
+        .arg("--manifest-path")
+        .arg(workspace_root.join("Cargo.toml"))
+        .arg(vendor_dir)
+        .current_dir(workspace_root)
+        // The printed `[source]` stanza (stdout) is not consumed — this module
+        // renders its own config for the FINAL served path.
+        .stdout(std::process::Stdio::null())
+        .output()
+        .context("run `cargo vendor` for the cargo mirror closure")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "`cargo vendor` failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+/// `cargo package --no-verify --offline` one release-closure crate against the
+/// growing directory source (crates.io replaced by `vendor_dir`, so already
+/// injected siblings + the vendored closure resolve with no network). The
+/// `.crate` lands in `<workspace>/target/package/`.
+fn run_cargo_package(workspace_root: &Path, crate_name: &str, vendor_dir: &Path) -> Result<()> {
+    let mut cmd = Command::new("cargo");
+    cmd.args(["package", "--no-verify", "--offline", "--allow-dirty", "-p"])
+        .arg(crate_name);
+    for arg in source_replacement_config_args(vendor_dir) {
+        cmd.arg("--config").arg(arg);
+    }
+    let output = cmd
+        .current_dir(workspace_root)
+        .output()
+        .with_context(|| format!("run `cargo package -p {crate_name}`"))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "`cargo package -p {crate_name}` failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+/// Emit the cargo source-replacement mirror into `<staging>/cargo-mirror/`: the
+/// vendored crates.io closure + every engine/SDK release-closure crate, plus the
+/// generated `[source]` replacement config pointing at the FINAL served vendor
+/// dir (under `out`, where the staging tree flips to). Returns nothing; the
+/// caller lists the same closure in the release manifest's `crates`.
+///
+/// `closure` must be in topological (leaf-first) order so each crate's siblings
+/// are injected before it is packaged.
+pub fn emit_cargo_mirror(
+    workspace_root: &Path,
+    staging: &Path,
+    out: &Path,
+    closure: &ReleaseClosure,
+) -> Result<()> {
+    let mirror_dir = staging.join(CARGO_MIRROR_SUBDIR);
+    let vendor_dir = mirror_dir.join(VENDOR_SUBDIR);
+    std::fs::create_dir_all(&mirror_dir)
+        .with_context(|| format!("create cargo mirror dir {}", mirror_dir.display()))?;
+
+    tracing::info!(
+        vendor = %vendor_dir.display(),
+        "cargo mirror: vendoring the crates.io closure"
+    );
+    run_cargo_vendor(workspace_root, &vendor_dir)?;
+
+    for member in &closure.crates {
+        let crate_path = workspace_root
+            .join("target/package")
+            .join(format!("{}-{}.crate", member.name, member.version));
+        crate::crate_tarball::obtain_crate_tarball(
+            &crate_path,
+            &member.name,
+            &member.version,
+            || run_cargo_package(workspace_root, &member.name, &vendor_dir),
+        )?;
+        // Byte-stable normalize (strip git-HEAD vcs-info, fixed-header re-gzip)
+        // so `package` — the checksum a consumer's lock records — is a pure
+        // function of source, independent of the commit the emit ran at. First
+        // emit into a fresh staging tree ⇒ no prior `.crate` to guard against.
+        let package_sha256 =
+            finalize_crate_tarball(&crate_path, &member.name, &member.version, None)?;
+        inject_crate_into_directory_source(
+            &crate_path,
+            &member.name,
+            &member.version,
+            &package_sha256,
+            &vendor_dir,
+        )?;
+        tracing::info!(
+            crate_name = %member.name,
+            version = %member.version,
+            "cargo mirror: packaged + injected engine/SDK crate"
+        );
+    }
+
+    // The config's directory must name the FINAL served location (the staging
+    // tree flips into `out` atomically after this returns), so a consumer that
+    // reads the config post-flip resolves against a path that exists.
+    let served_vendor_dir = out.join(CARGO_MIRROR_SUBDIR).join(VENDOR_SUBDIR);
+    let config_path = mirror_dir.join(SOURCE_REPLACEMENT_CONFIG_FILE);
+    std::fs::write(
+        &config_path,
+        render_source_replacement_config(&served_vendor_dir),
+    )
+    .with_context(|| format!("write {}", config_path.display()))?;
+    tracing::info!(
+        crates = closure.crates.len(),
+        config = %config_path.display(),
+        "cargo mirror emit complete"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    /// The `[source]` stanza uses `replace-with` (not an index override) so the
+    /// canonical crates.io source id survives into a consumer's `Cargo.lock`,
+    /// and names the directory source with an absolute path.
+    #[test]
+    fn source_replacement_config_replaces_crates_io_with_directory() {
+        let cfg = render_source_replacement_config(Path::new("/srv/reg/cargo-mirror/vendor"));
+        assert!(cfg.contains("[source.crates-io]"), "{cfg}");
+        assert!(
+            cfg.contains("replace-with = \"streamlib-cargo-mirror\""),
+            "must replace, never override the index: {cfg}"
+        );
+        assert!(
+            cfg.contains("[source.streamlib-cargo-mirror]"),
+            "names the replacement source: {cfg}"
+        );
+        assert!(
+            cfg.contains("directory = \"/srv/reg/cargo-mirror/vendor\""),
+            "points at the vendored directory source: {cfg}"
+        );
+        assert!(
+            !cfg.to_ascii_uppercase().contains("CARGO_REGISTRIES"),
+            "an index env override would break --locked; must not appear: {cfg}"
+        );
+    }
+
+    /// `.cargo-checksum.json` carries sorted `files` + the `package` digest, and
+    /// is byte-stable for identical inputs (BTreeMap ordering).
+    #[test]
+    fn cargo_checksum_json_is_sorted_and_stable() {
+        let mut files = BTreeMap::new();
+        files.insert("src/lib.rs".to_string(), "bbbb".to_string());
+        files.insert("Cargo.toml".to_string(), "aaaa".to_string());
+        let a = render_cargo_checksum_json(&files, "deadbeef").unwrap();
+        let b = render_cargo_checksum_json(&files, "deadbeef").unwrap();
+        assert_eq!(a, b, "identical inputs must render byte-identically");
+        // Cargo.toml sorts before src/lib.rs.
+        let cargo_at = a.find("Cargo.toml").unwrap();
+        let lib_at = a.find("src/lib.rs").unwrap();
+        assert!(cargo_at < lib_at, "files keys must be sorted: {a}");
+        assert!(a.contains("\"package\":\"deadbeef\""), "{a}");
+    }
+
+    /// Build a minimal `.crate` (gzip-tar with the `<name>-<version>/` prefix)
+    /// mirroring `cargo package` layout.
+    fn write_fake_crate(path: &Path, name: &str, version: &str, entries: &[(&str, &[u8])]) {
+        use flate2::Compression;
+        use flate2::write::GzEncoder;
+        let mut builder = tar::Builder::new(Vec::new());
+        for (rel, data) in entries {
+            let full = format!("{name}-{version}/{rel}");
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            builder.append_data(&mut header, &full, *data).unwrap();
+        }
+        let raw = builder.into_inner().unwrap();
+        let file = std::fs::File::create(path).unwrap();
+        let mut enc = GzEncoder::new(file, Compression::default());
+        enc.write_all(&raw).unwrap();
+        enc.finish().unwrap();
+    }
+
+    /// Injecting a `.crate` produces a directory-source entry cargo accepts:
+    /// the `<name>-<version>/` prefix is stripped, every file lands unpacked,
+    /// and `.cargo-checksum.json` records the on-disk file hashes + `package`.
+    #[test]
+    fn inject_unpacks_and_writes_matching_checksums() {
+        let dir = tempfile::tempdir().unwrap();
+        let vendor = dir.path().join("vendor");
+        std::fs::create_dir_all(&vendor).unwrap();
+        let crate_path = dir.path().join("streamlib-idents-0.6.0.crate");
+        let manifest = b"[package]\nname = \"streamlib-idents\"\nversion = \"0.6.0\"\n";
+        let lib = b"pub fn ok() {}\n";
+        write_fake_crate(
+            &crate_path,
+            "streamlib-idents",
+            "0.6.0",
+            &[("Cargo.toml", manifest), ("src/lib.rs", lib)],
+        );
+
+        inject_crate_into_directory_source(
+            &crate_path,
+            "streamlib-idents",
+            "0.6.0",
+            "abc123",
+            &vendor,
+        )
+        .unwrap();
+
+        let entry = vendor.join("streamlib-idents");
+        // Prefix stripped: files live at the entry root, not under a versioned dir.
+        assert_eq!(std::fs::read(entry.join("Cargo.toml")).unwrap(), manifest);
+        assert_eq!(std::fs::read(entry.join("src/lib.rs")).unwrap(), lib);
+
+        // The recorded per-file hashes match the unpacked bytes exactly (what
+        // cargo verifies on load); `package` is passed through verbatim.
+        let checksum: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(entry.join(".cargo-checksum.json")).unwrap())
+                .unwrap();
+        assert_eq!(checksum["package"], "abc123");
+        let mut h = Sha256::new();
+        h.update(lib);
+        let want = format!("{:x}", h.finalize());
+        assert_eq!(checksum["files"]["src/lib.rs"], want);
+    }
+
+    /// Re-injecting over an existing entry replaces it wholesale (stale files
+    /// from a prior emit do not survive to corrupt the checksum map).
+    #[test]
+    fn inject_replaces_stale_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let vendor = dir.path().join("vendor");
+        let stale = vendor.join("streamlib-idents");
+        std::fs::create_dir_all(&stale).unwrap();
+        std::fs::write(stale.join("leftover.rs"), b"// stale\n").unwrap();
+
+        let crate_path = dir.path().join("c.crate");
+        write_fake_crate(
+            &crate_path,
+            "streamlib-idents",
+            "0.6.0",
+            &[
+                ("Cargo.toml", b"[package]\nname=\"streamlib-idents\"\n"),
+                ("src/lib.rs", b"// fresh\n"),
+            ],
+        );
+        inject_crate_into_directory_source(
+            &crate_path,
+            "streamlib-idents",
+            "0.6.0",
+            "sha",
+            &vendor,
+        )
+        .unwrap();
+        assert!(
+            !stale.join("leftover.rs").exists(),
+            "a stale file from a prior emit must not survive re-injection"
+        );
+    }
+}

--- a/tools/streamlib-pack/src/cargo_mirror.rs
+++ b/tools/streamlib-pack/src/cargo_mirror.rs
@@ -41,6 +41,15 @@
 //! Crates are therefore packaged in the release closure's topological order
 //! (leaf-first) and each is injected into the directory source **before** its
 //! dependents are packaged, so every sibling resolves from the growing mirror.
+//!
+//! ## Version immutability is discipline, not an in-emit guard
+//!
+//! The served tree stores each engine/SDK crate as **unpacked** directory-source
+//! entries, not a `.crate` tarball, so there is no prior tarball to diff a
+//! re-emit against. An engine crate's bytes staying immutable across re-emits at
+//! a fixed version therefore rests on version-bump discipline plus the atomic
+//! whole-tree staged swap (a re-emit replaces the whole tree at once), not on an
+//! in-emit content-immutability check.
 
 use std::collections::BTreeMap;
 use std::io::Read;
@@ -286,10 +295,8 @@ pub fn emit_cargo_mirror(
         )?;
         // Byte-stable normalize (strip git-HEAD vcs-info, fixed-header re-gzip)
         // so `package` — the checksum a consumer's lock records — is a pure
-        // function of source, independent of the commit the emit ran at. First
-        // emit into a fresh staging tree ⇒ no prior `.crate` to guard against.
-        let package_sha256 =
-            finalize_crate_tarball(&crate_path, &member.name, &member.version, None)?;
+        // function of source, independent of the commit the emit ran at.
+        let package_sha256 = finalize_crate_tarball(&crate_path, &member.name, &member.version)?;
         inject_crate_into_directory_source(
             &crate_path,
             &member.name,

--- a/tools/streamlib-pack/src/crate_tarball.rs
+++ b/tools/streamlib-pack/src/crate_tarball.rs
@@ -10,13 +10,13 @@
 //!   content-stale `target/package` leftover is never emitted.
 //! - [`normalize_crate_tarball`] rewrites a `.crate` into a form whose bytes are
 //!   a pure function of source content, and [`finalize_crate_tarball`] pairs
-//!   that with an immutability guard so re-emitting an unchanged release yields
-//!   identical checksums while a source change under a published version is
-//!   refused. `cargo package` is already byte-deterministic *except* for the
+//!   that with the normalized tarball's sha256 — the `package` checksum a
+//!   consumer's `Cargo.lock` records for the directory-source entry. `cargo
+//!   package` is already byte-deterministic *except* for the
 //!   `{name}-{version}/.cargo_vcs_info.json` entry, whose embedded git-HEAD
 //!   sha1 makes the checksum a function of the commit rather than the source;
-//!   normalization strips it (see
-//!   `docs/learnings/cargo-crate-vcs-info-nondeterminism.md`).
+//!   normalization strips it so the recorded checksum tracks source content,
+//!   not the commit the emit ran at.
 
 use std::io::{Read, Write};
 use std::path::Path;
@@ -46,40 +46,23 @@ pub enum CrateTarballIntegrityError {
     /// The required `{name}-{version}/Cargo.toml` entry is absent.
     #[error("crate tarball missing manifest entry `{expected}`")]
     MissingManifestEntry { expected: String },
-    /// The recorded sha256 did not match the tarball bytes.
-    #[error("crate tarball sha256 mismatch: expected {expected}, got {actual}")]
-    ChecksumMismatch { expected: String, actual: String },
 }
 
 /// Structurally verify a `cargo package` `.crate` at `path` for
 /// `(name, version)`: the gzip stream fully decodes (truncation trips the
-/// trailer check), every tar entry enumerates to EOF, the crate's
-/// `{name}-{version}/Cargo.toml` entry is present, and — when `expected_sha256`
-/// is given — the tarball bytes hash to it. The checksum arm is exercised by
-/// the tests and reserved for the byte-stable-emission follow-up; the emit's
-/// post-repackage integrity check calls with `None`.
+/// trailer check), every tar entry enumerates to EOF, and the crate's
+/// `{name}-{version}/Cargo.toml` entry is present. This is a structural check
+/// only — the byte-stable `package` checksum a consumer's lock records is
+/// produced downstream by [`finalize_crate_tarball`].
 pub fn verify_crate_tarball(
     path: &Path,
     name: &str,
     version: &str,
-    expected_sha256: Option<&str>,
 ) -> Result<(), CrateTarballIntegrityError> {
     let bytes = std::fs::read(path).map_err(|source| CrateTarballIntegrityError::Unreadable {
         path: path.display().to_string(),
         source,
     })?;
-
-    if let Some(expected) = expected_sha256 {
-        let mut hasher = Sha256::new();
-        hasher.update(&bytes);
-        let actual = format!("{:x}", hasher.finalize());
-        if !actual.eq_ignore_ascii_case(expected) {
-            return Err(CrateTarballIntegrityError::ChecksumMismatch {
-                expected: expected.to_string(),
-                actual,
-            });
-        }
-    }
 
     // Fully decode the gzip stream. A truncated tarball trips here: the
     // decoder reaches an unexpected EOF before the gzip trailer (CRC + ISIZE)
@@ -154,7 +137,7 @@ pub fn obtain_crate_tarball(
 
     repackage().with_context(|| format!("repackage crate {name} {version}"))?;
 
-    verify_crate_tarball(candidate, name, version, None).with_context(|| {
+    verify_crate_tarball(candidate, name, version).with_context(|| {
         format!(
             "freshly-packaged crate tarball at {} failed integrity verification",
             candidate.display()
@@ -237,48 +220,20 @@ pub fn normalize_crate_tarball(path: &Path, name: &str, version: &str) -> anyhow
     Ok(())
 }
 
-/// The sha256 of the crate's canonical (vcs-stripped, uncompressed) tar bytes —
-/// a compression-independent fingerprint of source content. Two crates built
-/// from identical source but a different git HEAD (or a different gzip level)
-/// share a fingerprint; a real source change is a different fingerprint.
-pub fn crate_content_fingerprint(path: &Path, name: &str, version: &str) -> anyhow::Result<String> {
-    let canonical = canonical_tar_bytes(path, name, version)?;
-    let mut hasher = Sha256::new();
-    hasher.update(&canonical);
-    Ok(format!("{:x}", hasher.finalize()))
-}
-
-/// Normalize the `.crate` at `path` into byte-stable form, refuse a source
-/// change under an already-published `(name, version)`, and return the
-/// normalized tarball's sha256 for the sparse-index line.
+/// Normalize the `.crate` at `path` into byte-stable form and return the
+/// normalized tarball's sha256 — the `package` checksum a consumer's
+/// `Cargo.lock` records for the directory-source entry.
 ///
-/// `previously_served` is the same crate's `.crate` in the prior complete
-/// served tree (still present during a staged emit). When it exists, its
-/// content fingerprint — normalized on the fly, so a legacy un-normalized
-/// served tree does not false-positive during the transition — must equal the
-/// new crate's; a mismatch means the source changed without a version bump and
-/// is refused. A benign commit bump (identical source, new git HEAD) passes and
-/// yields the same checksum, so it neither churns the index nor trips the guard.
-pub fn finalize_crate_tarball(
-    path: &Path,
-    name: &str,
-    version: &str,
-    previously_served: Option<&Path>,
-) -> anyhow::Result<String> {
+/// Normalization strips the git-HEAD vcs-info and fixes the gzip header, so the
+/// checksum is a pure function of source content: a benign commit bump
+/// (identical source, new git HEAD) yields the same checksum, so it neither
+/// churns the index nor depends on the commit the emit ran at. There is no
+/// prior-`.crate` immutability diff in the mirror path — the served tree stores
+/// unpacked directory-source entries, not `.crate` files, so version-bump
+/// discipline plus the atomic whole-tree swap, not an in-emit guard, keep an
+/// engine crate's bytes immutable across re-emits at a fixed version.
+pub fn finalize_crate_tarball(path: &Path, name: &str, version: &str) -> anyhow::Result<String> {
     normalize_crate_tarball(path, name, version)?;
-
-    if let Some(served) = previously_served {
-        let new_fingerprint = crate_content_fingerprint(path, name, version)?;
-        let served_fingerprint = crate_content_fingerprint(served, name, version)?;
-        if new_fingerprint != served_fingerprint {
-            anyhow::bail!(
-                "crate `{name}` `{version}` changed at the same version \
-                 (content fingerprint {new_fingerprint} != published \
-                 {served_fingerprint}) — bump the version; re-emitting different \
-                 source under a published version is refused"
-            );
-        }
-    }
 
     let bytes = std::fs::read(path)
         .with_context(|| format!("read normalized crate tarball {}", path.display()))?;
@@ -365,15 +320,6 @@ mod tests {
         dir.join(format!("{name}-{version}.crate"))
     }
 
-    /// gzip `raw` into a `.crate`-shaped file at `path` at an explicit
-    /// compression level (for the compression-independence fingerprint test).
-    fn gzip_to_file_at_level(path: &Path, raw: &[u8], level: Compression) {
-        let file = std::fs::File::create(path).unwrap();
-        let mut enc = GzEncoder::new(file, level);
-        enc.write_all(raw).unwrap();
-        enc.finish().unwrap();
-    }
-
     /// Write a `.crate` that mirrors what `cargo package` emits from a git
     /// checkout: a `.cargo_vcs_info.json` entry (carrying `vcs_sha1`) plus the
     /// manifest and a source file whose bytes are `lib_contents`.
@@ -428,7 +374,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
         write_valid_crate(&path, "streamlib-x", "0.5.0");
-        verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap();
+        verify_crate_tarball(&path, "streamlib-x", "0.5.0").unwrap();
     }
 
     /// KEY (exit criterion): a structurally-VALID but content-STALE cached
@@ -447,7 +393,7 @@ mod tests {
         // A pre-existing candidate that is structurally VALID (verifies clean)
         // but built from STALE source.
         write_valid_crate_with_lib(&path, "streamlib-x", "0.5.0", b"// STALE source\n");
-        verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).expect(
+        verify_crate_tarball(&path, "streamlib-x", "0.5.0").expect(
             "sanity: the stale cache is structurally valid, so the old fast-path WOULD reuse it",
         );
         let stale_bytes = std::fs::read(&path).unwrap();
@@ -475,7 +421,7 @@ mod tests {
             b"// FRESH source\n",
             "the emitted artifact must carry current source"
         );
-        verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap();
+        verify_crate_tarball(&path, "streamlib-x", "0.5.0").unwrap();
     }
 
     /// A corrupt pre-existing candidate is likewise dropped and repackaged into
@@ -498,7 +444,7 @@ mod tests {
             .unwrap()
             .set_len(20)
             .unwrap();
-        assert!(verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).is_err());
+        assert!(verify_crate_tarball(&path, "streamlib-x", "0.5.0").is_err());
 
         let repackaged = Cell::new(false);
         obtain_crate_tarball(&path, "streamlib-x", "0.5.0", || {
@@ -513,7 +459,7 @@ mod tests {
             "repackage MUST run for a corrupt cached tarball"
         );
         // Final artifact is valid.
-        verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap();
+        verify_crate_tarball(&path, "streamlib-x", "0.5.0").unwrap();
     }
 
     #[test]
@@ -521,7 +467,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
         std::fs::write(&path, b"").unwrap();
-        let err = verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap_err();
+        let err = verify_crate_tarball(&path, "streamlib-x", "0.5.0").unwrap_err();
         assert!(
             matches!(err, CrateTarballIntegrityError::GzipInvalid(_)),
             "got {err:?}"
@@ -535,43 +481,13 @@ mod tests {
         // A well-formed gzip-tar with a source file but NO Cargo.toml.
         let raw = build_tar_bytes(&[("streamlib-x-0.5.0/src/lib.rs", b"// lib\n")]);
         gzip_to_file(&path, &raw);
-        let err = verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap_err();
+        let err = verify_crate_tarball(&path, "streamlib-x", "0.5.0").unwrap_err();
         match err {
             CrateTarballIntegrityError::MissingManifestEntry { expected } => {
                 assert_eq!(expected, "streamlib-x-0.5.0/Cargo.toml");
             }
             other => panic!("expected MissingManifestEntry, got {other:?}"),
         }
-    }
-
-    #[test]
-    fn wrong_expected_sha256_mismatches() {
-        let dir = tempdir().unwrap();
-        let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
-        write_valid_crate(&path, "streamlib-x", "0.5.0");
-        let err = verify_crate_tarball(
-            &path,
-            "streamlib-x",
-            "0.5.0",
-            Some("0000000000000000000000000000000000000000000000000000000000000000"),
-        )
-        .unwrap_err();
-        assert!(
-            matches!(err, CrateTarballIntegrityError::ChecksumMismatch { .. }),
-            "got {err:?}"
-        );
-    }
-
-    #[test]
-    fn correct_expected_sha256_verifies() {
-        let dir = tempdir().unwrap();
-        let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
-        write_valid_crate(&path, "streamlib-x", "0.5.0");
-        let bytes = std::fs::read(&path).unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&bytes);
-        let sha = format!("{:x}", hasher.finalize());
-        verify_crate_tarball(&path, "streamlib-x", "0.5.0", Some(&sha)).unwrap();
     }
 
     #[test]
@@ -589,7 +505,7 @@ mod tests {
         .unwrap();
 
         assert!(repackaged.get());
-        verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap();
+        verify_crate_tarball(&path, "streamlib-x", "0.5.0").unwrap();
     }
 
     #[test]
@@ -636,7 +552,7 @@ mod tests {
         let keep = 1536 + 256;
         gzip_to_file(&path, &raw[..keep]);
 
-        let err = verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap_err();
+        let err = verify_crate_tarball(&path, "streamlib-x", "0.5.0").unwrap_err();
         assert!(
             matches!(err, CrateTarballIntegrityError::TarInvalid(_)),
             "got {err:?}"
@@ -659,7 +575,7 @@ mod tests {
             .unwrap()
             .set_len(full - 8)
             .unwrap();
-        let err = verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap_err();
+        let err = verify_crate_tarball(&path, "streamlib-x", "0.5.0").unwrap_err();
         assert!(
             matches!(err, CrateTarballIntegrityError::GzipInvalid(_)),
             "got {err:?}"
@@ -688,7 +604,7 @@ mod tests {
             "vcs-info entry must be stripped, got {names:?}"
         );
         // The normalized crate is still structurally valid (manifest present).
-        verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap();
+        verify_crate_tarball(&path, "streamlib-x", "0.5.0").unwrap();
 
         let after_first = std::fs::read(&path).unwrap();
         normalize_crate_tarball(&path, "streamlib-x", "0.5.0").unwrap();
@@ -727,127 +643,28 @@ mod tests {
         assert_eq!(sha256_of_file(&a), sha256_of_file(&b));
     }
 
-    /// NEGATIVE (exit-criterion 2): a changed source under the same version is
-    /// refused. Mentally revert the guard (drop the fingerprint compare) and
-    /// this returns Ok instead of Err.
+    /// `finalize_crate_tarball` normalizes the `.crate` in place and returns the
+    /// normalized tarball's sha256 (the `package` checksum a consumer's lock
+    /// records). The returned digest matches the on-disk normalized bytes, and a
+    /// benign commit bump (identical source, different git HEAD) yields the same
+    /// digest — the checksum tracks source, not the commit.
     #[test]
-    fn guard_refuses_changed_source_same_version() {
-        let dir = tempdir().unwrap();
-        let served = candidate_path(dir.path(), "streamlib-x", "0.5.0");
-        let fresh = dir.path().join("streamlib-x-0.5.0-fresh.crate");
-        write_crate_with_vcs(
-            &served,
-            "streamlib-x",
-            "0.5.0",
-            b"// source A\n",
-            "aaaaaaaa",
-        );
-        write_crate_with_vcs(
-            &fresh,
-            "streamlib-x",
-            "0.5.0",
-            b"// source B - CHANGED\n",
-            "bbbbbbbb",
-        );
-
-        let err = finalize_crate_tarball(&fresh, "streamlib-x", "0.5.0", Some(served.as_path()))
-            .unwrap_err();
-        let msg = format!("{err:#}");
-        assert!(
-            msg.contains("changed at the same version"),
-            "expected the immutability-guard message, got: {msg}"
-        );
-    }
-
-    /// A benign commit bump (identical source, different git HEAD) passes the
-    /// guard even when the served tree is a legacy *un-normalized* crate, and
-    /// the returned checksum is the stable normalized one.
-    #[test]
-    fn guard_allows_same_source_different_vcs() {
-        let dir = tempdir().unwrap();
-        let served = candidate_path(dir.path(), "streamlib-x", "0.5.0");
-        let served_copy = dir.path().join("streamlib-x-0.5.0-servedcopy.crate");
-        let fresh = dir.path().join("streamlib-x-0.5.0-fresh.crate");
-        // Served tree is legacy (un-normalized: still carries vcs-info).
-        write_crate_with_vcs(
-            &served,
-            "streamlib-x",
-            "0.5.0",
-            b"// stable source\n",
-            "aaaaaaaa",
-        );
-        std::fs::copy(&served, &served_copy).unwrap();
-        write_crate_with_vcs(
-            &fresh,
-            "streamlib-x",
-            "0.5.0",
-            b"// stable source\n",
-            "bbbbbbbb",
-        );
-
-        // The normalized checksum the served tree *should* carry.
-        normalize_crate_tarball(&served_copy, "streamlib-x", "0.5.0").unwrap();
-        let served_normalized_cksum = sha256_of_file(&served_copy);
-
-        let cksum = finalize_crate_tarball(&fresh, "streamlib-x", "0.5.0", Some(served.as_path()))
-            .expect("identical source under a legacy served tree must pass the guard");
-        assert_eq!(
-            cksum, served_normalized_cksum,
-            "a benign commit bump must yield the same normalized checksum (no index churn)"
-        );
-    }
-
-    /// A first emit into a fresh tree (no prior served crate) is always allowed
-    /// and still returns the normalized checksum.
-    #[test]
-    fn guard_absent_served_is_ok() {
+    fn finalize_normalizes_and_returns_stable_checksum() {
         let dir = tempdir().unwrap();
         let fresh = candidate_path(dir.path(), "streamlib-x", "0.5.0");
         write_crate_with_vcs(&fresh, "streamlib-x", "0.5.0", b"// lib\n", "aaaaaaaa");
 
-        let cksum = finalize_crate_tarball(&fresh, "streamlib-x", "0.5.0", None).unwrap();
+        let cksum = finalize_crate_tarball(&fresh, "streamlib-x", "0.5.0").unwrap();
         assert_eq!(cksum, sha256_of_file(&fresh));
-        verify_crate_tarball(&fresh, "streamlib-x", "0.5.0", None).unwrap();
-    }
+        verify_crate_tarball(&fresh, "streamlib-x", "0.5.0").unwrap();
 
-    /// The content fingerprint ignores both the git-HEAD sha1 and the gzip
-    /// compression level — it is a function of source content only.
-    #[test]
-    fn crate_content_fingerprint_ignores_vcs_and_compression() {
-        let dir = tempdir().unwrap();
-        // Same source, vcs "aaaa", default compression.
-        let a = candidate_path(dir.path(), "streamlib-x", "0.5.0");
-        write_crate_with_vcs(
-            &a,
-            "streamlib-x",
-            "0.5.0",
-            b"// identical source\n",
-            "aaaaaaaa",
-        );
-        // Same source, vcs "bbbb", a DIFFERENT compression level → different bytes.
-        let raw_b = build_tar_bytes(&[
-            (
-                "streamlib-x-0.5.0/.cargo_vcs_info.json",
-                b"{\n  \"git\": {\n    \"sha1\": \"bbbbbbbb\"\n  },\n  \"path_in_vcs\": \"\"\n}",
-            ),
-            (
-                "streamlib-x-0.5.0/Cargo.toml",
-                manifest_bytes("streamlib-x", "0.5.0").as_bytes(),
-            ),
-            ("streamlib-x-0.5.0/src/lib.rs", b"// identical source\n"),
-        ]);
-        let b = dir.path().join("streamlib-x-0.5.0-b.crate");
-        gzip_to_file_at_level(&b, &raw_b, Compression::best());
-
-        assert_ne!(
-            std::fs::read(&a).unwrap(),
-            std::fs::read(&b).unwrap(),
-            "sanity: differing vcs + compression level make the raw crates differ"
-        );
+        // A second crate: same source, different git HEAD → same finalized digest.
+        let bumped = dir.path().join("streamlib-x-0.5.0-bumped.crate");
+        write_crate_with_vcs(&bumped, "streamlib-x", "0.5.0", b"// lib\n", "bbbbbbbb");
+        let bumped_cksum = finalize_crate_tarball(&bumped, "streamlib-x", "0.5.0").unwrap();
         assert_eq!(
-            crate_content_fingerprint(&a, "streamlib-x", "0.5.0").unwrap(),
-            crate_content_fingerprint(&b, "streamlib-x", "0.5.0").unwrap(),
-            "the fingerprint must be independent of git HEAD and gzip level"
+            cksum, bumped_cksum,
+            "a benign commit bump must yield the same normalized checksum (no index churn)"
         );
     }
 }

--- a/tools/streamlib-pack/src/crate_tarball.rs
+++ b/tools/streamlib-pack/src/crate_tarball.rs
@@ -1,0 +1,853 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Integrity-verified emission + byte-stable normalization of `cargo package`
+//! crate tarballs.
+//!
+//! - [`verify_crate_tarball`] structurally validates a `.crate`;
+//!   [`obtain_crate_tarball`] always repackages via `cargo package` — the
+//!   source of truth for crate bytes — and verifies the fresh artifact, so a
+//!   content-stale `target/package` leftover is never emitted.
+//! - [`normalize_crate_tarball`] rewrites a `.crate` into a form whose bytes are
+//!   a pure function of source content, and [`finalize_crate_tarball`] pairs
+//!   that with an immutability guard so re-emitting an unchanged release yields
+//!   identical checksums while a source change under a published version is
+//!   refused. `cargo package` is already byte-deterministic *except* for the
+//!   `{name}-{version}/.cargo_vcs_info.json` entry, whose embedded git-HEAD
+//!   sha1 makes the checksum a function of the commit rather than the source;
+//!   normalization strips it (see
+//!   `docs/learnings/cargo-crate-vcs-info-nondeterminism.md`).
+
+use std::io::{Read, Write};
+use std::path::Path;
+
+use anyhow::Context;
+use flate2::read::GzDecoder;
+use flate2::{Compression, GzBuilder};
+use sha2::{Digest, Sha256};
+
+/// Why a `.crate` tarball failed integrity verification.
+#[derive(Debug, thiserror::Error)]
+pub enum CrateTarballIntegrityError {
+    /// The tarball bytes could not be read from disk.
+    #[error("read crate tarball {path}: {source}")]
+    Unreadable {
+        path: String,
+        source: std::io::Error,
+    },
+    /// The gzip container is invalid or truncated (decode failed before the
+    /// gzip trailer's CRC + length could be validated).
+    #[error("crate tarball gzip stream invalid or truncated: {0}")]
+    GzipInvalid(std::io::Error),
+    /// The tar archive is invalid or truncated (a short entry / missing block
+    /// surfaces here once the gzip layer decodes).
+    #[error("crate tarball tar archive invalid or truncated: {0}")]
+    TarInvalid(std::io::Error),
+    /// The required `{name}-{version}/Cargo.toml` entry is absent.
+    #[error("crate tarball missing manifest entry `{expected}`")]
+    MissingManifestEntry { expected: String },
+    /// The recorded sha256 did not match the tarball bytes.
+    #[error("crate tarball sha256 mismatch: expected {expected}, got {actual}")]
+    ChecksumMismatch { expected: String, actual: String },
+}
+
+/// Structurally verify a `cargo package` `.crate` at `path` for
+/// `(name, version)`: the gzip stream fully decodes (truncation trips the
+/// trailer check), every tar entry enumerates to EOF, the crate's
+/// `{name}-{version}/Cargo.toml` entry is present, and — when `expected_sha256`
+/// is given — the tarball bytes hash to it. The checksum arm is exercised by
+/// the tests and reserved for the byte-stable-emission follow-up; the emit's
+/// post-repackage integrity check calls with `None`.
+pub fn verify_crate_tarball(
+    path: &Path,
+    name: &str,
+    version: &str,
+    expected_sha256: Option<&str>,
+) -> Result<(), CrateTarballIntegrityError> {
+    let bytes = std::fs::read(path).map_err(|source| CrateTarballIntegrityError::Unreadable {
+        path: path.display().to_string(),
+        source,
+    })?;
+
+    if let Some(expected) = expected_sha256 {
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        let actual = format!("{:x}", hasher.finalize());
+        if !actual.eq_ignore_ascii_case(expected) {
+            return Err(CrateTarballIntegrityError::ChecksumMismatch {
+                expected: expected.to_string(),
+                actual,
+            });
+        }
+    }
+
+    // Fully decode the gzip stream. A truncated tarball trips here: the
+    // decoder reaches an unexpected EOF before the gzip trailer (CRC + ISIZE)
+    // can be validated. Reading to EOF — rather than stopping at the first
+    // manifest match — is what makes a truncation *after* the manifest entry
+    // still fail.
+    let mut decoded = Vec::new();
+    GzDecoder::new(&bytes[..])
+        .read_to_end(&mut decoded)
+        .map_err(CrateTarballIntegrityError::GzipInvalid)?;
+
+    // Walk every tar entry to EOF, requiring the crate's Cargo.toml. A tar
+    // truncated after the manifest header (but the gzip layer still complete)
+    // surfaces as a short read here.
+    let expected_entry = format!("{name}-{version}/Cargo.toml");
+    let mut archive = tar::Archive::new(&decoded[..]);
+    let mut found_manifest = false;
+    let entries = archive
+        .entries()
+        .map_err(CrateTarballIntegrityError::TarInvalid)?;
+    for entry in entries {
+        let entry = entry.map_err(CrateTarballIntegrityError::TarInvalid)?;
+        let entry_path = entry
+            .path()
+            .map_err(CrateTarballIntegrityError::TarInvalid)?;
+        if entry_path.to_string_lossy() == expected_entry {
+            found_manifest = true;
+        }
+    }
+    if !found_manifest {
+        return Err(CrateTarballIntegrityError::MissingManifestEntry {
+            expected: expected_entry,
+        });
+    }
+    Ok(())
+}
+
+/// Produce a fresh, structurally-verified `.crate` at `candidate` for
+/// `(name, version)` by always invoking `repackage` (`cargo package`).
+///
+/// `cargo package` is the single source of truth for crate bytes:
+/// `target/package/<crate>-<version>.crate` is cargo scratch, **not** a
+/// streamlib-managed content cache. Any pre-existing artifact is dropped up
+/// front and `repackage` always runs, so the emitted `.crate` always reflects
+/// current source at that version — a structurally-valid but content-stale
+/// leftover (e.g. an old-ABI tarball cached under a version whose source has
+/// since moved) can never be handed back verbatim. Dropping the leftover first
+/// also means a `repackage` that returns `Ok` without writing surfaces as a
+/// hard verification error rather than silently verifying stale bytes.
+///
+/// A freshly-packaged artifact that fails verification is a hard error (a
+/// `cargo package` / toolchain bug), surfaced loudly rather than emitted into
+/// the tree.
+pub fn obtain_crate_tarball(
+    candidate: &Path,
+    name: &str,
+    version: &str,
+    repackage: impl FnOnce() -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    // `target/package` is cargo scratch, never a trusted cache: drop any
+    // pre-existing artifact so `repackage` owns the bytes we verify and a
+    // no-write repackage can't be masked by a stale leftover.
+    match std::fs::remove_file(candidate) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("remove stale crate scratch tarball {}", candidate.display())
+            });
+        }
+    }
+
+    repackage().with_context(|| format!("repackage crate {name} {version}"))?;
+
+    verify_crate_tarball(candidate, name, version, None).with_context(|| {
+        format!(
+            "freshly-packaged crate tarball at {} failed integrity verification",
+            candidate.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+/// The vcs-info entry cargo embeds inside a `.crate` when packaging from a git
+/// checkout with commits: `{name}-{version}/.cargo_vcs_info.json`. Its
+/// `{"git":{"sha1":...}}` payload tracks git HEAD, not source, and is the sole
+/// per-commit non-determinism vector in an otherwise byte-deterministic
+/// `cargo package`.
+fn vcs_info_entry_name(name: &str, version: &str) -> String {
+    format!("{name}-{version}/.cargo_vcs_info.json")
+}
+
+/// Decode a `.crate` at `path`, drop the `.cargo_vcs_info.json` entry, and
+/// re-serialize the surviving entries — headers cloned verbatim from cargo's
+/// output, in cargo's original order — into canonical *uncompressed* tar bytes.
+/// The result is a pure function of the crate's source content: independent of
+/// git HEAD (vcs-info removed) and of gzip settings (uncompressed).
+fn canonical_tar_bytes(path: &Path, name: &str, version: &str) -> anyhow::Result<Vec<u8>> {
+    let bytes =
+        std::fs::read(path).with_context(|| format!("read crate tarball {}", path.display()))?;
+    let mut decoded = Vec::new();
+    GzDecoder::new(&bytes[..])
+        .read_to_end(&mut decoded)
+        .with_context(|| format!("gzip-decode crate tarball {}", path.display()))?;
+
+    let vcs_entry = vcs_info_entry_name(name, version);
+    let mut archive = tar::Archive::new(&decoded[..]);
+    let mut builder = tar::Builder::new(Vec::new());
+    let entries = archive
+        .entries()
+        .with_context(|| format!("read crate tar entries {}", path.display()))?;
+    for entry in entries {
+        let mut entry = entry.context("read crate tar entry")?;
+        let entry_path = entry
+            .path()
+            .context("read crate tar entry path")?
+            .into_owned();
+        if entry_path.to_string_lossy() == vcs_entry {
+            continue;
+        }
+        // Clone cargo's header verbatim (inherits its canonical mtime / mode /
+        // uid / gid / entry type / size), then re-emit via `append_data` so the
+        // long-name (GNU extension) handling is applied for the resolved path.
+        let mut header = entry.header().clone();
+        let mut data = Vec::new();
+        entry
+            .read_to_end(&mut data)
+            .context("read crate tar entry data")?;
+        builder
+            .append_data(&mut header, &entry_path, &data[..])
+            .context("re-append crate tar entry")?;
+    }
+    builder.into_inner().context("finalize canonical crate tar")
+}
+
+/// Rewrite the `.crate` at `path` into its byte-stable canonical form for
+/// `(name, version)`: strip `.cargo_vcs_info.json` and re-gzip with a fixed
+/// header (MTIME 0, no embedded filename). Idempotent — re-normalizing an
+/// already-normalized crate reproduces identical bytes, so re-emitting a crate
+/// at an unchanged version yields byte-identical output.
+pub fn normalize_crate_tarball(path: &Path, name: &str, version: &str) -> anyhow::Result<()> {
+    let canonical = canonical_tar_bytes(path, name, version)?;
+    let mut encoder = GzBuilder::new()
+        .mtime(0)
+        .write(Vec::new(), Compression::default());
+    encoder
+        .write_all(&canonical)
+        .context("gzip canonical crate tar")?;
+    let gzipped = encoder
+        .finish()
+        .context("finish gzip canonical crate tar")?;
+    std::fs::write(path, &gzipped)
+        .with_context(|| format!("write normalized crate tarball {}", path.display()))?;
+    Ok(())
+}
+
+/// The sha256 of the crate's canonical (vcs-stripped, uncompressed) tar bytes —
+/// a compression-independent fingerprint of source content. Two crates built
+/// from identical source but a different git HEAD (or a different gzip level)
+/// share a fingerprint; a real source change is a different fingerprint.
+pub fn crate_content_fingerprint(path: &Path, name: &str, version: &str) -> anyhow::Result<String> {
+    let canonical = canonical_tar_bytes(path, name, version)?;
+    let mut hasher = Sha256::new();
+    hasher.update(&canonical);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Normalize the `.crate` at `path` into byte-stable form, refuse a source
+/// change under an already-published `(name, version)`, and return the
+/// normalized tarball's sha256 for the sparse-index line.
+///
+/// `previously_served` is the same crate's `.crate` in the prior complete
+/// served tree (still present during a staged emit). When it exists, its
+/// content fingerprint — normalized on the fly, so a legacy un-normalized
+/// served tree does not false-positive during the transition — must equal the
+/// new crate's; a mismatch means the source changed without a version bump and
+/// is refused. A benign commit bump (identical source, new git HEAD) passes and
+/// yields the same checksum, so it neither churns the index nor trips the guard.
+pub fn finalize_crate_tarball(
+    path: &Path,
+    name: &str,
+    version: &str,
+    previously_served: Option<&Path>,
+) -> anyhow::Result<String> {
+    normalize_crate_tarball(path, name, version)?;
+
+    if let Some(served) = previously_served {
+        let new_fingerprint = crate_content_fingerprint(path, name, version)?;
+        let served_fingerprint = crate_content_fingerprint(served, name, version)?;
+        if new_fingerprint != served_fingerprint {
+            anyhow::bail!(
+                "crate `{name}` `{version}` changed at the same version \
+                 (content fingerprint {new_fingerprint} != published \
+                 {served_fingerprint}) — bump the version; re-emitting different \
+                 source under a published version is refused"
+            );
+        }
+    }
+
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("read normalized crate tarball {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+    use std::cell::Cell;
+    use std::io::Write;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    /// Serialize tar entries into raw (uncompressed) tar bytes.
+    fn build_tar_bytes(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+        for (name, data) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            builder.append_data(&mut header, name, *data).unwrap();
+        }
+        builder.into_inner().unwrap()
+    }
+
+    /// gzip `raw` into a `.crate`-shaped file at `path`.
+    fn gzip_to_file(path: &Path, raw: &[u8]) {
+        let file = std::fs::File::create(path).unwrap();
+        let mut enc = GzEncoder::new(file, Compression::default());
+        enc.write_all(raw).unwrap();
+        enc.finish().unwrap();
+    }
+
+    fn manifest_bytes(name: &str, version: &str) -> String {
+        format!("[package]\nname = \"{name}\"\nversion = \"{version}\"\n")
+    }
+
+    /// Write a valid `.crate` (Cargo.toml + a source file) at `path` whose
+    /// `src/lib.rs` carries `lib_contents` — the distinguishing marker used to
+    /// prove which source a `.crate` was built from.
+    fn write_valid_crate_with_lib(path: &Path, name: &str, version: &str, lib_contents: &[u8]) {
+        let manifest = manifest_bytes(name, version);
+        let manifest_entry = format!("{name}-{version}/Cargo.toml");
+        let lib_entry = format!("{name}-{version}/src/lib.rs");
+        let raw = build_tar_bytes(&[
+            (manifest_entry.as_str(), manifest.as_bytes()),
+            (lib_entry.as_str(), lib_contents),
+        ]);
+        gzip_to_file(path, &raw);
+    }
+
+    /// Write a valid `.crate` (Cargo.toml + a source file) at `path`.
+    fn write_valid_crate(path: &Path, name: &str, version: &str) {
+        write_valid_crate_with_lib(path, name, version, b"// lib\n");
+    }
+
+    /// Read back the `{name}-{version}/src/lib.rs` bytes from a `.crate` — the
+    /// source marker, for asserting which source a `.crate` was built from.
+    fn crate_lib_contents(path: &Path, name: &str, version: &str) -> Vec<u8> {
+        let want = format!("{name}-{version}/src/lib.rs");
+        let bytes = std::fs::read(path).unwrap();
+        let mut decoded = Vec::new();
+        GzDecoder::new(&bytes[..])
+            .read_to_end(&mut decoded)
+            .unwrap();
+        let mut archive = tar::Archive::new(&decoded[..]);
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            if entry.path().unwrap().to_string_lossy() == want {
+                let mut data = Vec::new();
+                entry.read_to_end(&mut data).unwrap();
+                return data;
+            }
+        }
+        panic!("crate {} missing lib entry {want}", path.display());
+    }
+
+    fn candidate_path(dir: &Path, name: &str, version: &str) -> PathBuf {
+        dir.join(format!("{name}-{version}.crate"))
+    }
+
+    /// gzip `raw` into a `.crate`-shaped file at `path` at an explicit
+    /// compression level (for the compression-independence fingerprint test).
+    fn gzip_to_file_at_level(path: &Path, raw: &[u8], level: Compression) {
+        let file = std::fs::File::create(path).unwrap();
+        let mut enc = GzEncoder::new(file, level);
+        enc.write_all(raw).unwrap();
+        enc.finish().unwrap();
+    }
+
+    /// Write a `.crate` that mirrors what `cargo package` emits from a git
+    /// checkout: a `.cargo_vcs_info.json` entry (carrying `vcs_sha1`) plus the
+    /// manifest and a source file whose bytes are `lib_contents`.
+    fn write_crate_with_vcs(
+        path: &Path,
+        name: &str,
+        version: &str,
+        lib_contents: &[u8],
+        vcs_sha1: &str,
+    ) {
+        let manifest = manifest_bytes(name, version);
+        let vcs_json = format!(
+            "{{\n  \"git\": {{\n    \"sha1\": \"{vcs_sha1}\"\n  }},\n  \"path_in_vcs\": \"\"\n}}"
+        );
+        let vcs_entry = format!("{name}-{version}/.cargo_vcs_info.json");
+        let manifest_entry = format!("{name}-{version}/Cargo.toml");
+        let lib_entry = format!("{name}-{version}/src/lib.rs");
+        // Match cargo's alphabetical entry order (.cargo_vcs_info.json sorts
+        // before Cargo.toml sorts before src/lib.rs).
+        let raw = build_tar_bytes(&[
+            (vcs_entry.as_str(), vcs_json.as_bytes()),
+            (manifest_entry.as_str(), manifest.as_bytes()),
+            (lib_entry.as_str(), lib_contents),
+        ]);
+        gzip_to_file(path, &raw);
+    }
+
+    /// The set of entry paths inside a `.crate` (for asserting vcs-info removal).
+    fn crate_entry_names(path: &Path) -> Vec<String> {
+        let bytes = std::fs::read(path).unwrap();
+        let mut decoded = Vec::new();
+        GzDecoder::new(&bytes[..])
+            .read_to_end(&mut decoded)
+            .unwrap();
+        let mut archive = tar::Archive::new(&decoded[..]);
+        archive
+            .entries()
+            .unwrap()
+            .map(|e| e.unwrap().path().unwrap().to_string_lossy().into_owned())
+            .collect()
+    }
+
+    fn sha256_of_file(path: &Path) -> String {
+        let bytes = std::fs::read(path).unwrap();
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        format!("{:x}", hasher.finalize())
+    }
+
+    #[test]
+    fn valid_tarball_verifies() {
+        let dir = tempdir().unwrap();
+        let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        write_valid_crate(&path, "streamlib-x", "0.5.0");
+        verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap();
+    }
+
+    /// KEY (exit criterion): a structurally-VALID but content-STALE cached
+    /// tarball is NOT trusted — `repackage` always runs and the final artifact
+    /// is the fresh source, never the stale cache. This is the exact defect
+    /// that turned `pack → load` red (an ABI-4 `.crate` cached under a version
+    /// whose source moved to ABI 5, re-emitted verbatim).
+    ///
+    /// Mental revert: restore the `if candidate.is_file() { verify → return }`
+    /// fast-path and the closure never runs — `repackaged` stays false and the
+    /// final bytes equal the stale cache — so both assertions fail.
+    #[test]
+    fn obtain_always_repackages_ignoring_valid_cached_tarball() {
+        let dir = tempdir().unwrap();
+        let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        // A pre-existing candidate that is structurally VALID (verifies clean)
+        // but built from STALE source.
+        write_valid_crate_with_lib(&path, "streamlib-x", "0.5.0", b"// STALE source\n");
+        verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).expect(
+            "sanity: the stale cache is structurally valid, so the old fast-path WOULD reuse it",
+        );
+        let stale_bytes = std::fs::read(&path).unwrap();
+
+        let repackaged = Cell::new(false);
+        obtain_crate_tarball(&path, "streamlib-x", "0.5.0", || {
+            repackaged.set(true);
+            // Fresh `cargo package` writes DIFFERENT bytes at the same version.
+            write_valid_crate_with_lib(&path, "streamlib-x", "0.5.0", b"// FRESH source\n");
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(
+            repackaged.get(),
+            "a structurally-valid cached tarball must NOT be trusted — repackage always runs"
+        );
+        let final_bytes = std::fs::read(&path).unwrap();
+        assert_ne!(
+            final_bytes, stale_bytes,
+            "the emitted artifact must be the fresh package, never the stale cache"
+        );
+        assert_eq!(
+            crate_lib_contents(&path, "streamlib-x", "0.5.0"),
+            b"// FRESH source\n",
+            "the emitted artifact must carry current source"
+        );
+        verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap();
+    }
+
+    /// A corrupt pre-existing candidate is likewise dropped and repackaged into
+    /// a valid fresh artifact (no error from the leftover).
+    #[test]
+    fn obtain_repackages_truncated_cached_tarball() {
+        let dir = tempdir().unwrap();
+        let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        write_valid_crate(&path, "streamlib-x", "0.5.0");
+
+        // Truncate to a small prefix — mid gzip stream, unmistakably corrupt.
+        let full = std::fs::metadata(&path).unwrap().len();
+        assert!(
+            full > 40,
+            "sanity: a real crate tarball is larger than the gzip header"
+        );
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_len(20)
+            .unwrap();
+        assert!(verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).is_err());
+
+        let repackaged = Cell::new(false);
+        obtain_crate_tarball(&path, "streamlib-x", "0.5.0", || {
+            repackaged.set(true);
+            write_valid_crate(&path, "streamlib-x", "0.5.0");
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(
+            repackaged.get(),
+            "repackage MUST run for a corrupt cached tarball"
+        );
+        // Final artifact is valid.
+        verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap();
+    }
+
+    #[test]
+    fn zero_byte_tarball_fails_verification() {
+        let dir = tempdir().unwrap();
+        let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        std::fs::write(&path, b"").unwrap();
+        let err = verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap_err();
+        assert!(
+            matches!(err, CrateTarballIntegrityError::GzipInvalid(_)),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn tarball_missing_manifest_entry_fails() {
+        let dir = tempdir().unwrap();
+        let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        // A well-formed gzip-tar with a source file but NO Cargo.toml.
+        let raw = build_tar_bytes(&[("streamlib-x-0.5.0/src/lib.rs", b"// lib\n")]);
+        gzip_to_file(&path, &raw);
+        let err = verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap_err();
+        match err {
+            CrateTarballIntegrityError::MissingManifestEntry { expected } => {
+                assert_eq!(expected, "streamlib-x-0.5.0/Cargo.toml");
+            }
+            other => panic!("expected MissingManifestEntry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wrong_expected_sha256_mismatches() {
+        let dir = tempdir().unwrap();
+        let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        write_valid_crate(&path, "streamlib-x", "0.5.0");
+        let err = verify_crate_tarball(
+            &path,
+            "streamlib-x",
+            "0.5.0",
+            Some("0000000000000000000000000000000000000000000000000000000000000000"),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, CrateTarballIntegrityError::ChecksumMismatch { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn correct_expected_sha256_verifies() {
+        let dir = tempdir().unwrap();
+        let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        write_valid_crate(&path, "streamlib-x", "0.5.0");
+        let bytes = std::fs::read(&path).unwrap();
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        let sha = format!("{:x}", hasher.finalize());
+        verify_crate_tarball(&path, "streamlib-x", "0.5.0", Some(&sha)).unwrap();
+    }
+
+    #[test]
+    fn absent_candidate_repackages_fresh() {
+        let dir = tempdir().unwrap();
+        let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        assert!(!path.exists());
+
+        let repackaged = Cell::new(false);
+        obtain_crate_tarball(&path, "streamlib-x", "0.5.0", || {
+            repackaged.set(true);
+            write_valid_crate(&path, "streamlib-x", "0.5.0");
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(repackaged.get());
+        verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap();
+    }
+
+    #[test]
+    fn repackage_producing_still_corrupt_is_hard_error() {
+        let dir = tempdir().unwrap();
+        let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        assert!(!path.exists());
+
+        let result = obtain_crate_tarball(&path, "streamlib-x", "0.5.0", || {
+            // "Repackage" writes garbage — the freshly-packaged verify must
+            // fail loud rather than emit a corrupt tarball.
+            std::fs::write(&path, b"not a gzip tarball").unwrap();
+            Ok(())
+        });
+        assert!(
+            result.is_err(),
+            "a still-corrupt repackage must be a hard error"
+        );
+    }
+
+    /// The verifier reads the tar layer to EOF: a tar truncated *after* the
+    /// manifest entry (with the gzip layer intact) still fails. Guards against
+    /// an implementation that returns early on the first manifest match.
+    #[test]
+    fn tar_truncation_after_manifest_entry_fails() {
+        let dir = tempdir().unwrap();
+        let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+
+        let manifest = manifest_bytes("streamlib-x", "0.5.0");
+        let big = vec![0x41u8; 8192];
+        let manifest_entry = "streamlib-x-0.5.0/Cargo.toml";
+        let big_entry = "streamlib-x-0.5.0/src/big.rs";
+        let raw = build_tar_bytes(&[
+            (manifest_entry, manifest.as_bytes()),
+            (big_entry, big.as_slice()),
+        ]);
+        // Layout (short paths fit the 512-byte name field, no long-name block):
+        //   [0..512)     manifest header
+        //   [512..1024)  manifest data block
+        //   [1024..1536) big-entry header
+        //   [1536..)     big-entry data (16 blocks)
+        // Cut mid big-entry data — the manifest is fully present, but the walk
+        // to EOF hits a short read after yielding the second entry.
+        let keep = 1536 + 256;
+        gzip_to_file(&path, &raw[..keep]);
+
+        let err = verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap_err();
+        assert!(
+            matches!(err, CrateTarballIntegrityError::TarInvalid(_)),
+            "got {err:?}"
+        );
+    }
+
+    /// A gzip stream whose trailer is truncated fails even though every entry's
+    /// data is present — the gzip `read_to_end` validates the CRC + length
+    /// footer, so reuse can't trust a stream that was cut at the very end.
+    #[test]
+    fn gzip_trailer_truncation_fails() {
+        let dir = tempdir().unwrap();
+        let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        write_valid_crate(&path, "streamlib-x", "0.5.0");
+        let full = std::fs::metadata(&path).unwrap().len();
+        // Drop the 8-byte gzip trailer (CRC32 + ISIZE).
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_len(full - 8)
+            .unwrap();
+        let err = verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap_err();
+        assert!(
+            matches!(err, CrateTarballIntegrityError::GzipInvalid(_)),
+            "got {err:?}"
+        );
+    }
+
+    /// Normalizing strips `.cargo_vcs_info.json`, leaves a still-valid `.crate`,
+    /// and is idempotent (a second normalize reproduces byte-identical output).
+    #[test]
+    fn normalize_strips_vcs_info_and_is_idempotent() {
+        let dir = tempdir().unwrap();
+        let path = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        write_crate_with_vcs(&path, "streamlib-x", "0.5.0", b"// lib A\n", "aaaaaaaa");
+        assert!(
+            crate_entry_names(&path)
+                .iter()
+                .any(|n| n.ends_with("/.cargo_vcs_info.json")),
+            "sanity: the pre-normalize crate carries a vcs-info entry"
+        );
+
+        normalize_crate_tarball(&path, "streamlib-x", "0.5.0").unwrap();
+
+        let names = crate_entry_names(&path);
+        assert!(
+            !names.iter().any(|n| n.ends_with("/.cargo_vcs_info.json")),
+            "vcs-info entry must be stripped, got {names:?}"
+        );
+        // The normalized crate is still structurally valid (manifest present).
+        verify_crate_tarball(&path, "streamlib-x", "0.5.0", None).unwrap();
+
+        let after_first = std::fs::read(&path).unwrap();
+        normalize_crate_tarball(&path, "streamlib-x", "0.5.0").unwrap();
+        let after_second = std::fs::read(&path).unwrap();
+        assert_eq!(
+            after_first, after_second,
+            "normalize must be idempotent — a second pass reproduces identical bytes"
+        );
+    }
+
+    /// KEY (exit-criterion 1): two crates with identical source but different
+    /// git HEAD sha1 normalize to byte-identical `.crate`s with equal checksums.
+    /// Mentally revert the vcs-strip and the two would differ at the vcs entry.
+    #[test]
+    fn two_vcs_variants_normalize_identical() {
+        let dir = tempdir().unwrap();
+        let a = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        let b = dir.path().join("streamlib-x-0.5.0-b.crate");
+        write_crate_with_vcs(&a, "streamlib-x", "0.5.0", b"// same source\n", "aaaaaaaa");
+        write_crate_with_vcs(&b, "streamlib-x", "0.5.0", b"// same source\n", "bbbbbbbb");
+        // Sanity: the two raw crates differ (the vcs sha1 is baked in).
+        assert_ne!(
+            std::fs::read(&a).unwrap(),
+            std::fs::read(&b).unwrap(),
+            "sanity: differing git HEAD makes the raw crates differ"
+        );
+
+        normalize_crate_tarball(&a, "streamlib-x", "0.5.0").unwrap();
+        normalize_crate_tarball(&b, "streamlib-x", "0.5.0").unwrap();
+
+        assert_eq!(
+            std::fs::read(&a).unwrap(),
+            std::fs::read(&b).unwrap(),
+            "identical source must normalize to byte-identical crates"
+        );
+        assert_eq!(sha256_of_file(&a), sha256_of_file(&b));
+    }
+
+    /// NEGATIVE (exit-criterion 2): a changed source under the same version is
+    /// refused. Mentally revert the guard (drop the fingerprint compare) and
+    /// this returns Ok instead of Err.
+    #[test]
+    fn guard_refuses_changed_source_same_version() {
+        let dir = tempdir().unwrap();
+        let served = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        let fresh = dir.path().join("streamlib-x-0.5.0-fresh.crate");
+        write_crate_with_vcs(
+            &served,
+            "streamlib-x",
+            "0.5.0",
+            b"// source A\n",
+            "aaaaaaaa",
+        );
+        write_crate_with_vcs(
+            &fresh,
+            "streamlib-x",
+            "0.5.0",
+            b"// source B - CHANGED\n",
+            "bbbbbbbb",
+        );
+
+        let err = finalize_crate_tarball(&fresh, "streamlib-x", "0.5.0", Some(served.as_path()))
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("changed at the same version"),
+            "expected the immutability-guard message, got: {msg}"
+        );
+    }
+
+    /// A benign commit bump (identical source, different git HEAD) passes the
+    /// guard even when the served tree is a legacy *un-normalized* crate, and
+    /// the returned checksum is the stable normalized one.
+    #[test]
+    fn guard_allows_same_source_different_vcs() {
+        let dir = tempdir().unwrap();
+        let served = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        let served_copy = dir.path().join("streamlib-x-0.5.0-servedcopy.crate");
+        let fresh = dir.path().join("streamlib-x-0.5.0-fresh.crate");
+        // Served tree is legacy (un-normalized: still carries vcs-info).
+        write_crate_with_vcs(
+            &served,
+            "streamlib-x",
+            "0.5.0",
+            b"// stable source\n",
+            "aaaaaaaa",
+        );
+        std::fs::copy(&served, &served_copy).unwrap();
+        write_crate_with_vcs(
+            &fresh,
+            "streamlib-x",
+            "0.5.0",
+            b"// stable source\n",
+            "bbbbbbbb",
+        );
+
+        // The normalized checksum the served tree *should* carry.
+        normalize_crate_tarball(&served_copy, "streamlib-x", "0.5.0").unwrap();
+        let served_normalized_cksum = sha256_of_file(&served_copy);
+
+        let cksum = finalize_crate_tarball(&fresh, "streamlib-x", "0.5.0", Some(served.as_path()))
+            .expect("identical source under a legacy served tree must pass the guard");
+        assert_eq!(
+            cksum, served_normalized_cksum,
+            "a benign commit bump must yield the same normalized checksum (no index churn)"
+        );
+    }
+
+    /// A first emit into a fresh tree (no prior served crate) is always allowed
+    /// and still returns the normalized checksum.
+    #[test]
+    fn guard_absent_served_is_ok() {
+        let dir = tempdir().unwrap();
+        let fresh = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        write_crate_with_vcs(&fresh, "streamlib-x", "0.5.0", b"// lib\n", "aaaaaaaa");
+
+        let cksum = finalize_crate_tarball(&fresh, "streamlib-x", "0.5.0", None).unwrap();
+        assert_eq!(cksum, sha256_of_file(&fresh));
+        verify_crate_tarball(&fresh, "streamlib-x", "0.5.0", None).unwrap();
+    }
+
+    /// The content fingerprint ignores both the git-HEAD sha1 and the gzip
+    /// compression level — it is a function of source content only.
+    #[test]
+    fn crate_content_fingerprint_ignores_vcs_and_compression() {
+        let dir = tempdir().unwrap();
+        // Same source, vcs "aaaa", default compression.
+        let a = candidate_path(dir.path(), "streamlib-x", "0.5.0");
+        write_crate_with_vcs(
+            &a,
+            "streamlib-x",
+            "0.5.0",
+            b"// identical source\n",
+            "aaaaaaaa",
+        );
+        // Same source, vcs "bbbb", a DIFFERENT compression level → different bytes.
+        let raw_b = build_tar_bytes(&[
+            (
+                "streamlib-x-0.5.0/.cargo_vcs_info.json",
+                b"{\n  \"git\": {\n    \"sha1\": \"bbbbbbbb\"\n  },\n  \"path_in_vcs\": \"\"\n}",
+            ),
+            (
+                "streamlib-x-0.5.0/Cargo.toml",
+                manifest_bytes("streamlib-x", "0.5.0").as_bytes(),
+            ),
+            ("streamlib-x-0.5.0/src/lib.rs", b"// identical source\n"),
+        ]);
+        let b = dir.path().join("streamlib-x-0.5.0-b.crate");
+        gzip_to_file_at_level(&b, &raw_b, Compression::best());
+
+        assert_ne!(
+            std::fs::read(&a).unwrap(),
+            std::fs::read(&b).unwrap(),
+            "sanity: differing vcs + compression level make the raw crates differ"
+        );
+        assert_eq!(
+            crate_content_fingerprint(&a, "streamlib-x", "0.5.0").unwrap(),
+            crate_content_fingerprint(&b, "streamlib-x", "0.5.0").unwrap(),
+            "the fingerprint must be independent of git HEAD and gzip level"
+        );
+    }
+}

--- a/tools/streamlib-pack/src/lib.rs
+++ b/tools/streamlib-pack/src/lib.rs
@@ -45,7 +45,9 @@ use streamlib_processor_schema::ProcessorLanguage;
 
 pub use streamlib_cargo_build::CargoProfile;
 
+pub mod cargo_mirror;
 pub mod catalog;
+pub mod crate_tarball;
 pub mod static_registry;
 
 // The `streamlib link` marker schema + discovery moved to `streamlib-idents`

--- a/tools/streamlib-pack/src/static_registry.rs
+++ b/tools/streamlib-pack/src/static_registry.rs
@@ -37,6 +37,12 @@ pub struct EmitOptions {
     pub out: PathBuf,
     /// `-dev.N` suffix for the emitted release version.
     pub dev: Option<u32>,
+    /// Also emit the cargo source-replacement mirror (the full crates.io
+    /// closure of the engine/SDK chain) under `cargo-mirror/`, and list the
+    /// engine/SDK release closure in the release manifest's `crates`. Off by
+    /// default: the mirror is a heavy vendored tree only the separate-build
+    /// validation gate needs, so a routine `.slpkg` emit stays lightweight.
+    pub cargo_mirror: bool,
 }
 
 /// Atomically publish a fully-built `staging` tree into the served `served`
@@ -344,11 +350,33 @@ fn emit_slpkg_and_manifest(
         tracing::info!(emitted, skipped, "static-registry .slpkg emit complete");
     }
 
+    // The engine/SDK crate chain: with `--cargo-mirror`, emit the cargo
+    // source-replacement mirror (the full crates.io closure of the chain, as a
+    // directory source under `cargo-mirror/`) so a link-free build resolves
+    // `streamlib = "0.6.0"` entirely offline from the tree, and list the closure
+    // in the release manifest's `crates` (what `crates_missing_from_release`
+    // checks a consumer's crate pins against). Without the flag the crate chain
+    // is absent and `crates` stays empty — a routine `.slpkg` emit does not pay
+    // for the heavy vendored tree. There is no publish step: the crates resolve
+    // from the emitted tree, not any registry.
+    let crate_members: Vec<ReleaseManifestMember> = if opts.cargo_mirror {
+        let closure = crate::compute_release_closure(&opts.workspace_root)
+            .context("computing the engine/SDK release closure for the cargo mirror")?;
+        crate::cargo_mirror::emit_cargo_mirror(&opts.workspace_root, staging, &opts.out, &closure)
+            .context("emitting the cargo source-replacement mirror")?;
+        closure
+            .crates
+            .iter()
+            .map(|c| ReleaseManifestMember::new(c.name.clone(), c.version.clone()))
+            .collect()
+    } else {
+        Vec::new()
+    };
+
     // The release manifest lists exactly the `.slpkg` packages this emit
-    // published. The SDK crate chain is NOT published by this emit — the custom
-    // cargo registry was removed; SDK / library crates ship from public
-    // registries as a separate, gated release step — so `crates` is empty.
-    let mut manifest = ReleaseManifest::new(target.to_string(), Vec::new());
+    // published plus (with `--cargo-mirror`) the engine/SDK crate closure the
+    // mirror carries.
+    let mut manifest = ReleaseManifest::new(target.to_string(), crate_members);
     manifest.packages = package_members;
 
     // Written LAST — the completion marker.

--- a/tools/streamlib-pack/src/static_registry.rs
+++ b/tools/streamlib-pack/src/static_registry.rs
@@ -353,12 +353,18 @@ fn emit_slpkg_and_manifest(
     // The engine/SDK crate chain: with `--cargo-mirror`, emit the cargo
     // source-replacement mirror (the full crates.io closure of the chain, as a
     // directory source under `cargo-mirror/`) so a link-free build resolves
-    // `streamlib = "0.6.0"` entirely offline from the tree, and list the closure
-    // in the release manifest's `crates` (what `crates_missing_from_release`
-    // checks a consumer's crate pins against). Without the flag the crate chain
-    // is absent and `crates` stays empty — a routine `.slpkg` emit does not pay
-    // for the heavy vendored tree. There is no publish step: the crates resolve
-    // from the emitted tree, not any registry.
+    // `streamlib = "0.6.0"` entirely offline from the tree, and record the
+    // closure in the release manifest's `crates` as release metadata carried
+    // alongside the mirror. That `crates` list is NOT what guards the mirror's
+    // completeness: `crates_missing_from_release` keys on `registry = tatolab`
+    // crate pins, which no manifest carries anymore (those pins were stripped
+    // when the custom cargo registry was removed), so it does not cover the
+    // bare-crates.io deps the mirror resolves — the pin seam is only
+    // half-reconnected. A partial mirror is prevented instead by the atomic
+    // whole-tree staged swap (a consumer observes the whole tree or none). Without
+    // the flag the crate chain is absent and `crates` stays empty — a routine
+    // `.slpkg` emit does not pay for the heavy vendored tree. There is no publish
+    // step: the crates resolve from the emitted tree, not any registry.
     let crate_members: Vec<ReleaseManifestMember> = if opts.cargo_mirror {
         let closure = crate::compute_release_closure(&opts.workspace_root)
             .context("computing the engine/SDK release closure for the cargo mirror")?;

--- a/tools/streamlib-pack/tests/cargo_mirror_offline_build.rs
+++ b/tools/streamlib-pack/tests/cargo_mirror_offline_build.rs
@@ -1,0 +1,200 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! End-to-end validation of the cargo source-replacement mirror: a package that
+//! declares the engine/SDK crates by bare version — with **no** `streamlib
+//! link` and **no** `[patch.crates-io]` — resolves and builds entirely offline
+//! from the emitted tree, the way the separate-build `.slpkg` validation gate
+//! builds a package by version.
+//!
+//! `#[ignore]` because it runs the full mirror emit: `cargo vendor` of the whole
+//! workspace closure (network permitted on the emit machine) plus a `cargo
+//! package` of every engine/SDK release-closure crate. Run explicitly:
+//!
+//! ```text
+//! cargo test -p streamlib-pack --test cargo_mirror_offline_build -- --ignored --nocapture
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use streamlib_pack::cargo_mirror::{
+    CARGO_MIRROR_SUBDIR, SOURCE_REPLACEMENT_CONFIG_FILE, VENDOR_SUBDIR, emit_cargo_mirror,
+};
+use streamlib_pack::compute_release_closure;
+
+/// The workspace root (two levels up from this crate's manifest dir).
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+/// Write a minimal standalone consumer crate at `dir` depending on `dep_line`
+/// (e.g. `streamlib = "0.6.0"`). The empty `[workspace]` keeps it out of any
+/// ambient workspace; `main.rs` references nothing so metadata/build test only
+/// resolution + the dep's own compile.
+fn write_consumer(dir: &Path, name: &str, dep_line: &str) {
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("Cargo.toml"),
+        format!(
+            "[package]\nname = \"{name}\"\nversion = \"0.0.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\n{dep_line}\n\n[workspace]\n"
+        ),
+    )
+    .unwrap();
+    std::fs::write(dir.join("src/main.rs"), "fn main() {}\n").unwrap();
+    // Guard: the consumer must carry NO link marker and NO patch — it resolves
+    // purely by version from the mirror, like a real downstream consumer.
+    let manifest = std::fs::read_to_string(dir.join("Cargo.toml")).unwrap();
+    assert!(
+        !manifest.contains("[patch"),
+        "consumer must not carry a [patch.*] block"
+    );
+    assert!(
+        !dir.join("streamlib.link.json").exists(),
+        "consumer must not be linked"
+    );
+}
+
+/// Install the generated `[source]` replacement config into the consumer's
+/// `.cargo/config.toml`.
+fn install_source_config(consumer: &Path, mirror_config: &Path) {
+    std::fs::create_dir_all(consumer.join(".cargo")).unwrap();
+    std::fs::copy(mirror_config, consumer.join(".cargo/config.toml")).unwrap();
+}
+
+fn run_cargo(consumer: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("cargo")
+        .args(args)
+        .current_dir(consumer)
+        // Isolate from any ambient CARGO_* the harness set.
+        .env_remove("CARGO_TARGET_DIR")
+        .output()
+        .expect("spawn cargo")
+}
+
+#[test]
+#[ignore = "runs a full cargo vendor + package of the engine/SDK chain; run with --ignored"]
+fn link_free_package_resolves_and_builds_offline_from_the_mirror() {
+    let ws = workspace_root();
+    let closure = compute_release_closure(&ws).expect("compute release closure");
+    assert!(
+        closure.crates.iter().any(|c| c.name == "streamlib"),
+        "the release closure must carry the `streamlib` SDK crate"
+    );
+
+    // Emit the mirror. staging == out so the generated config's `directory`
+    // (rooted at `out`) points at the real emitted vendor tree.
+    let tree = tempfile::tempdir().expect("mirror tree tempdir");
+    let tree_root = tree.path();
+    emit_cargo_mirror(&ws, tree_root, tree_root, &closure).expect("emit cargo mirror");
+
+    let mirror_config = tree_root
+        .join(CARGO_MIRROR_SUBDIR)
+        .join(SOURCE_REPLACEMENT_CONFIG_FILE);
+    let vendor_dir = tree_root.join(CARGO_MIRROR_SUBDIR).join(VENDOR_SUBDIR);
+    assert!(mirror_config.is_file(), "generated [source] config missing");
+    assert!(
+        vendor_dir
+            .join("streamlib")
+            .join(".cargo-checksum.json")
+            .is_file(),
+        "the `streamlib` SDK crate must be injected as a directory-source entry"
+    );
+
+    // ---- NEGATIVE CONTROL: `--offline` alone is insufficient ----
+    // `streamlib-idents` is not published on any real crates.io, so an offline
+    // resolve WITHOUT the [source] replacement cannot find it and MUST fail.
+    // (The `streamlib` name itself is squatted on crates.io by an unrelated
+    // crate, so it would resolve to the WRONG crate — see the squatter-shadow
+    // assertion below — which is why the control uses an unambiguous name.)
+    let neg = tempfile::tempdir().unwrap();
+    write_consumer(neg.path(), "neg-consumer", "streamlib-idents = \"0.6.0\"");
+    let neg_out = run_cargo(neg.path(), &["generate-lockfile", "--offline"]);
+    assert!(
+        !neg_out.status.success(),
+        "negative control MUST fail: offline resolve of `streamlib-idents = 0.6.0` without the \
+         [source] replacement cannot find the engine crate.\nstderr:\n{}",
+        String::from_utf8_lossy(&neg_out.stderr)
+    );
+
+    // ---- RESOLVE the full engine/SDK chain offline via the mirror ----
+    let resolver = tempfile::tempdir().unwrap();
+    write_consumer(resolver.path(), "resolve-consumer", "streamlib = \"0.6.0\"");
+    install_source_config(resolver.path(), &mirror_config);
+
+    let lockgen = run_cargo(resolver.path(), &["generate-lockfile", "--offline"]);
+    assert!(
+        lockgen.status.success(),
+        "generate-lockfile --offline against the mirror must succeed.\nstderr:\n{}",
+        String::from_utf8_lossy(&lockgen.stderr)
+    );
+
+    let lock = std::fs::read_to_string(resolver.path().join("Cargo.lock")).unwrap();
+    let streamlib_block = lock
+        .split("[[package]]")
+        .find(|b| b.contains("name = \"streamlib\"\n"))
+        .expect("consumer lock must list the streamlib crate");
+    // The mirror shadows the crates.io squatter: `streamlib = ^0.6.0` resolves
+    // to the ENGINE crate at 0.6.0 (the only version in the mirror), not the
+    // unrelated crates.io `streamlib` (0.6.4 at time of writing). Proven two
+    // ways: the resolved version is exactly ours, and the engine's private
+    // `streamlib-engine` dep is pulled in (the squatter has no such dep).
+    assert!(
+        streamlib_block.contains("version = \"0.6.0\"\n"),
+        "mirror must resolve `streamlib` to the ENGINE 0.6.0, not the crates.io squatter:\n{streamlib_block}"
+    );
+    assert!(
+        lock.contains("name = \"streamlib-engine\"\n"),
+        "the resolved `streamlib` must be the engine SDK crate (pulls streamlib-engine), \
+         proving the mirror shadowed the crates.io squatter"
+    );
+    // The lock records the CANONICAL crates.io source id (source *replacement*
+    // preserves it) so `--locked` stays clean.
+    assert!(
+        streamlib_block.contains("registry+https://github.com/rust-lang/crates.io-index"),
+        "the streamlib lock entry must preserve the canonical crates.io source id:\n{streamlib_block}"
+    );
+
+    let metadata = run_cargo(
+        resolver.path(),
+        &["metadata", "--locked", "--offline", "--format-version", "1"],
+    );
+    assert!(
+        metadata.status.success(),
+        "`cargo metadata --locked --offline` must resolve the whole engine/SDK chain from the \
+         mirror.\nstderr:\n{}",
+        String::from_utf8_lossy(&metadata.stderr)
+    );
+
+    // ---- COMPILE a real engine crate offline from the mirror ----
+    // Building the full `streamlib` SDK pulls the entire engine (Vulkan / system
+    // libs) — out of scope for a resolution test — so compile a pure-Rust leaf
+    // engine crate to prove genuine offline compilation of engine sources +
+    // their vendored transitive deps.
+    let builder = tempfile::tempdir().unwrap();
+    write_consumer(
+        builder.path(),
+        "build-consumer",
+        "streamlib-idents = \"0.6.0\"",
+    );
+    install_source_config(builder.path(), &mirror_config);
+    let build_lockgen = run_cargo(builder.path(), &["generate-lockfile", "--offline"]);
+    assert!(
+        build_lockgen.status.success(),
+        "lockgen: {}",
+        String::from_utf8_lossy(&build_lockgen.stderr)
+    );
+    let build = run_cargo(builder.path(), &["build", "--locked", "--offline"]);
+    assert!(
+        build.status.success(),
+        "`cargo build --locked --offline` of `streamlib-idents = 0.6.0` must compile from the \
+         mirror.\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+}

--- a/tools/streamlib-pack/tests/cargo_mirror_offline_build.rs
+++ b/tools/streamlib-pack/tests/cargo_mirror_offline_build.rs
@@ -198,3 +198,116 @@ fn link_free_package_resolves_and_builds_offline_from_the_mirror() {
         String::from_utf8_lossy(&build.stderr)
     );
 }
+
+/// The `--cargo-mirror` glue through the WHOLE-TREE emit (`emit_static_registry`,
+/// not `emit_cargo_mirror` directly): the static-registry path must compute the
+/// release closure, emit the mirror, AND record that closure in the release
+/// manifest's `crates`. The sibling test above bypasses this glue by calling
+/// `emit_cargo_mirror` directly, so nothing else exercises the closure →
+/// `ReleaseManifest.crates` wiring end-to-end.
+///
+/// `#[ignore]` for the same reason as the sibling test — it runs the full emit
+/// (every distributable `packages/*` `.slpkg` plus `cargo vendor` + `cargo
+/// package` of the whole engine/SDK chain). Run explicitly:
+///
+/// ```text
+/// cargo test -p streamlib-pack --test cargo_mirror_offline_build \
+///   emit_static_registry_with_cargo_mirror -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore = "runs the full static-registry emit + cargo mirror of the engine/SDK chain; run with --ignored"]
+fn emit_static_registry_with_cargo_mirror_records_closure_and_resolves_offline() {
+    use streamlib_idents::{RegistryClient, RegistryConfig};
+    use streamlib_pack::static_registry::{EmitOptions, emit_static_registry};
+
+    let ws = workspace_root();
+    let closure = compute_release_closure(&ws).expect("compute release closure");
+    assert!(
+        closure.crates.iter().any(|c| c.name == "streamlib"),
+        "the release closure must carry the `streamlib` SDK crate"
+    );
+
+    // Emit the WHOLE tree (slpkg store + catalog + release manifest) WITH the
+    // cargo mirror, through the real `emit_static_registry` glue. `out` is
+    // created by the emit's staged build + atomic flip.
+    let out_root = tempfile::tempdir().expect("emit out tempdir");
+    let out = out_root.path().join("registry");
+    emit_static_registry(&EmitOptions {
+        workspace_root: ws.clone(),
+        out: out.clone(),
+        dev: None,
+        cargo_mirror: true,
+    })
+    .expect("`static-registry emit --cargo-mirror` must succeed");
+
+    // (a) The release manifest's `crates` lists EXACTLY the release closure the
+    // mirror carries — the glue the direct `emit_cargo_mirror` test never runs.
+    let cfg = RegistryConfig {
+        base_url: format!("file://{}", out.display()),
+    };
+    let client = RegistryClient::new(&cfg);
+    let versions = client
+        .list_release_versions("tatolab")
+        .expect("list release versions");
+    assert_eq!(versions.len(), 1, "exactly one release emitted: {versions:?}");
+    let manifest = client
+        .fetch_release_manifest("tatolab", &versions[0].to_string())
+        .expect("fetch release manifest")
+        .expect("the release manifest must be present (completion marker)");
+
+    let mut manifest_crates: Vec<(String, String)> = manifest
+        .crates
+        .iter()
+        .map(|m| (m.name.clone(), m.version.clone()))
+        .collect();
+    let mut closure_crates: Vec<(String, String)> = closure
+        .crates
+        .iter()
+        .map(|c| (c.name.clone(), c.version.clone()))
+        .collect();
+    manifest_crates.sort();
+    closure_crates.sort();
+    assert_eq!(
+        manifest_crates, closure_crates,
+        "the release manifest's `crates` must list exactly the release closure"
+    );
+
+    // (b) The emitted tree resolves `streamlib = 0.6.0` entirely offline. The
+    // generated [source] config's `directory` names the FINAL served vendor dir
+    // (rooted at `out`), so it is valid after the atomic flip.
+    let mirror_config = out
+        .join(CARGO_MIRROR_SUBDIR)
+        .join(SOURCE_REPLACEMENT_CONFIG_FILE);
+    assert!(
+        out.join(CARGO_MIRROR_SUBDIR)
+            .join(VENDOR_SUBDIR)
+            .join("streamlib")
+            .join(".cargo-checksum.json")
+            .is_file(),
+        "the whole-tree emit must inject the `streamlib` SDK crate into the mirror"
+    );
+
+    let resolver = tempfile::tempdir().unwrap();
+    write_consumer(resolver.path(), "resolve-consumer", "streamlib = \"0.6.0\"");
+    install_source_config(resolver.path(), &mirror_config);
+    let lockgen = run_cargo(resolver.path(), &["generate-lockfile", "--offline"]);
+    assert!(
+        lockgen.status.success(),
+        "generate-lockfile --offline against the emitted tree must succeed.\nstderr:\n{}",
+        String::from_utf8_lossy(&lockgen.stderr)
+    );
+    let lock = std::fs::read_to_string(resolver.path().join("Cargo.lock")).unwrap();
+    let streamlib_block = lock
+        .split("[[package]]")
+        .find(|b| b.contains("name = \"streamlib\"\n"))
+        .expect("consumer lock must list the streamlib crate");
+    assert!(
+        streamlib_block.contains("version = \"0.6.0\"\n"),
+        "the mirror must resolve `streamlib` to the ENGINE 0.6.0, not the crates.io squatter:\n{streamlib_block}"
+    );
+    assert!(
+        lock.contains("name = \"streamlib-engine\"\n"),
+        "the resolved `streamlib` must be the engine SDK crate (pulls streamlib-engine), \
+         proving the mirror shadowed the crates.io squatter"
+    );
+}

--- a/tools/streamlib-pack/tests/emit_static_registry_catalog.rs
+++ b/tools/streamlib-pack/tests/emit_static_registry_catalog.rs
@@ -107,6 +107,7 @@ fn real_emit_writes_catalog_inside_the_flipped_tree() {
         workspace_root: workspace,
         out: out.clone(),
         dev: None,
+        cargo_mirror: false,
     })
     .expect("real emit path (slpkg + catalog + manifest) succeeds");
 

--- a/tools/streamlib-pack/tests/static_registry_slpkg.rs
+++ b/tools/streamlib-pack/tests/static_registry_slpkg.rs
@@ -215,6 +215,7 @@ fn emitted_tree_truncation_is_rejected_by_consumer_checks() {
         workspace_root: ws.clone(),
         out: out.clone(),
         dev: None,
+        cargo_mirror: false,
     })
     .expect("slpkg emit against the fake workspace must succeed");
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -228,6 +228,13 @@ enum StaticRegistryAction {
         /// publish scripts' bump/restore convention).
         #[arg(long)]
         dev: Option<u32>,
+        /// Also emit the cargo source-replacement mirror under `cargo-mirror/`
+        /// (the full crates.io closure of the engine/SDK chain) so a link-free
+        /// build resolves `streamlib = "<version>"` entirely offline from the
+        /// tree — what the separate-build `.slpkg` validation gate needs. Off
+        /// by default: a routine `.slpkg` emit skips the heavy vendored tree.
+        #[arg(long)]
+        cargo_mirror: bool,
     },
 }
 
@@ -292,12 +299,17 @@ fn main() -> Result<()> {
                 .with_context(|| format!("stripping path patches from {}", dir.display()))?;
             tracing::info!(dir = %dir.display(), "stripped path-flavor patch entries from streamlib.yaml");
         }
-        Commands::StaticRegistry(StaticRegistryAction::Emit { out, dev }) => {
+        Commands::StaticRegistry(StaticRegistryAction::Emit {
+            out,
+            dev,
+            cargo_mirror,
+        }) => {
             use streamlib_pack::static_registry::{EmitOptions, emit_static_registry};
             emit_static_registry(&EmitOptions {
                 workspace_root: workspace_root()?,
                 out,
                 dev,
+                cargo_mirror,
             })?
         }
     }


### PR DESCRIPTION
## What & why

The separate-build `.slpkg` validation gate (**Part of #1257**) must build a package the way a real downstream consumer would: resolving the engine crates **by bare version** (`streamlib = "0.6.0"`), **link-free** — no `streamlib link`, no `[patch.crates-io]`. A `streamlib link` build resolves the engine to the *same workspace source* via `[patch.crates-io]`, so its layout is matched to the host by construction and it **masks** the exact distribution hazards the gate exists to catch (raw-device double-free, ABI-skew refusal — see `docs/learnings/slpkg-raw-device-rhi-construction.md`). Nothing today resolves `streamlib = "0.6.0"` for a link-free build, so this adds the missing precursor.

**What:** `cargo xtask static-registry emit --cargo-mirror` additionally emits a cargo **source-replacement mirror** (`cargo vendor` of the full crates.io closure + the workspace engine/SDK crates injected byte-stable) plus a generated `[source.crates-io] replace-with` config. A package then resolves + compiles its whole closure **offline** from the tree. Opt-in (off by default) so a routine `.slpkg` emit doesn't pay for the ~690MB vendor.

**Not a return of the removed registry (#1322):** #1322 removed the SDK-distribution registry *emulation* (the never-deployed `registry.tatolab.com` sparse index + `registry use/serve` CLI). This is an emit-machine-**local**, gate-only affordance — a cargo directory source resolves by an absolute local path and can't be HTTP-served, so it's deliberately outside the relocatable tree. the ratified precedent for the `[source]`-replacement pattern is #1278; `crate_tarball.rs` returns verbatim as the #1250 byte-stability helper (structural `.crate` verification + vcs-info-strip normalization), not registry emulation.

**Alternatives rejected:** link/`[patch]` (layout-matched → masks the hazards; excluded by the gate's "no path/link overrides"); a second-checkout `[patch]` (still a path override, misses `.crate` packaging bugs); publishing to real crates.io (owner-gated release act, and the name is squatted — below).

## Validation (real output)

- Link-free offline resolve + **compile**: `streamlib = "0.6.0"` locks 521 packages; `cargo build --locked --offline` compiles the engine chain from the mirror.
- Byte-stable: injected `.crate` `package` checksum identical across independent re-emits; `--locked`-clean (canonical crates.io source id preserved).
- Non-vacuous negative control: `--offline` with no replacement fails (`location searched: crates.io index`).
- `tools/streamlib-pack/tests/cargo_mirror_offline_build.rs` (`--ignored`) encodes all of it; a new integration test covers the `--cargo-mirror` closure glue; the full gate battery is green (18/0).

## ⚠️ Squat finding (future decision — not forced here)

The `streamlib` crate name is **squatted on crates.io** (`streamlib = 0.6.4`, unrelated). Bare `^0.6.0` admits it, so an *online* resolve without the replacement would lock the squatter — but `streamlib-engine` / `-idents` / `-consumer-rhi` don't exist on crates.io, so an **offline** resolve fails hard and the replacement shadows the squatter (the test asserts `streamlib-engine` in the lock). The gate is offline-by-construction → no silent-wrong-crate risk. Whether to eventually **rename/reserve** the engine crate name is a strategic call tied to the future public-publish step — flagged, yours to make later.

## Scope

Precursor only — the gate ticket stays open. Its exit criteria (the one-command gate — emit→resolve→run→verdict — its use by a conversion, and the stale-ABI negative case) are untouched by the mirror alone. The release-completeness pin seam (`crates_missing_from_release`) is only half-reconnected (it keys on `registry=tatolab` pins that #1322 stripped) — noted as gate-work.

Part of #1257 · direction adjudicated + owner-greenlit (full-offline vendor).
