### PR TITLE
refactor(examples): convert camera-python-display/effects to the engine-free plugin SDK

### DIFF
--- a/examples/camera-python-display/Cargo.toml
+++ b/examples/camera-python-display/Cargo.toml
@@ -38,7 +38,12 @@ authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 license = "BUSL-1.1"
 
 [workspace.dependencies]
+# Engine facade — used ONLY by the runner (the host app), never the `effects`
+# plugin cdylib.
 streamlib = { version = "0.6" }
+# Engine-free authoring SDK chain — used by the `effects` plugin cdylib.
+streamlib-plugin-sdk = { version = "0.6" }
+streamlib-macros = { version = "0.6" }
 streamlib-jtd-codegen = { version = "0.6" }
 streamlib-plugin-abi = { version = "0.6" }
 streamlib-adapter-abi = { version = "0.6" }

--- a/examples/camera-python-display/effects/Cargo.toml
+++ b/examples/camera-python-display/effects/Cargo.toml
@@ -4,6 +4,11 @@
 # Member of the standalone `camera-python-display` workspace — inherits its
 # `[workspace.package]` fields and resolves every dependency by version
 # via `[workspace.dependencies]`. No path deps.
+#
+# Engine-free plugin: this cdylib links ONLY `streamlib-plugin-sdk` (never the
+# `streamlib` engine facade), matching `camera-plugin-sdk-compute/plugin`. Its
+# GPU work rides the cdylib-safe FullAccess / Limited primitives, so the image
+# stays sound as a separately-built `.slpkg`.
 [package]
 name = "camera-python-display-effects"
 version.workspace = true
@@ -19,12 +24,10 @@ crate-type = ["rlib", "cdylib"]
 streamlib-jtd-codegen = { workspace = true }
 
 [dependencies]
-streamlib = { workspace = true }
+# Engine-free authoring SDK — the whole point of this example. NO `streamlib`
+# facade dependency: the plugin cdylib must not statically link the engine.
+streamlib-plugin-sdk = { workspace = true }
+streamlib-macros = { workspace = true }
 streamlib-plugin-abi = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
-
-[target.'cfg(target_os = "linux")'.dependencies]
-streamlib-adapter-abi = { workspace = true }
-streamlib-consumer-rhi = { workspace = true }

--- a/examples/camera-python-display/effects/build.rs
+++ b/examples/camera-python-display/effects/build.rs
@@ -6,13 +6,14 @@
 //! Codegen + Vulkan shader compilation for the camera-python-display
 //! effects package.
 //!
-//! The two graphics-kernel wrappers in this crate
-//! (`blending_compositor.rs`, `crt_film_grain.rs`) are sandboxed
-//! scenario content for the camera-python-display demo. Each wrapper
-//! drives its dispatch through the engine RHI's cdylib-safe
-//! `VulkanGraphicsKernel::offscreen_render` + `RhiCommandRecorder`
-//! surfaces, so this crate stays inside the boundary-check rule —
-//! no `vulkanalia` dep, no allowlist exception.
+//! The two graphics-kernel wrappers (`blending_compositor.rs`,
+//! `crt_film_grain.rs`) and the sandboxed tone-mapper (`tone_mapper.rs`)
+//! are sandboxed scenario content for the camera-python-display demo.
+//! Each rides the engine-free plugin SDK's cdylib-safe FullAccess /
+//! Limited primitives (`create_graphics_kernel` / `create_compute_kernel`
+//! / `create_command_recorder` / `offscreen_render`), so this crate links
+//! ONLY `streamlib-plugin-sdk` — no `streamlib` facade, no `vulkanalia`
+//! dep, no boundary allowlist exception.
 //!
 //! `lib.rs` embeds the resulting SPIR-V via
 //! `include_bytes!(concat!(env!("OUT_DIR"), …))`.
@@ -28,6 +29,9 @@ fn compile_shaders() {
     use std::path::{Path, PathBuf};
     use std::process::Command;
 
+    // `(source, out_name, glslc_stage)`. The tone-mapper compute shader
+    // `#include`s `color_convert_common.glsl` (also copied example-local),
+    // resolved via the `-I shaders` include dir below.
     let shaders: &[(&str, &str, &str)] = &[
         (
             "shaders/blending_compositor.vert",
@@ -49,7 +53,17 @@ fn compile_shaders() {
             "crt_film_grain.frag.spv",
             "fragment",
         ),
+        ("shaders/tone_curve.comp", "tone_curve.comp.spv", "compute"),
     ];
+
+    // Include dir for `#include "color_convert_common.glsl"` in the
+    // tone-mapper compute shader. Harmless for the graphics stages (they
+    // include nothing). Rerun the build when the shared header changes.
+    let shader_include_dir = "shaders";
+    println!(
+        "cargo:rerun-if-changed={}/color_convert_common.glsl",
+        shader_include_dir
+    );
 
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
 
@@ -63,6 +77,8 @@ fn compile_shaders() {
         let status = Command::new(&glslc)
             .arg(format!("-fshader-stage={stage}"))
             .arg("-O")
+            .arg("-I")
+            .arg(shader_include_dir)
             .arg(src_path)
             .arg("-o")
             .arg(&dst_path)

--- a/examples/camera-python-display/effects/shaders/color_convert_common.glsl
+++ b/examples/camera-python-display/effects/shaders/color_convert_common.glsl
@@ -1,0 +1,105 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Shared math for color conversion compute shaders. Example-local copy of the
+// engine's `runtime/streamlib-engine/src/vulkan/rhi/shaders/color_convert_common.glsl`
+// — the sandboxed tone-mapper (`tone_curve.comp`) rides the engine-free plugin
+// SDK, so its shader math lives in the example rather than reaching engine
+// internals. The 32-byte push-constant layout lock in `tone_mapper.rs` guards
+// drift on the Rust side; the `TransferId` enum values are shared with
+// `streamlib_plugin_sdk::sdk::color::TransferId`.
+
+// Keep in sync with `streamlib_plugin_sdk::sdk::color::TransferId`.
+const uint TRANSFER_LINEAR = 0u;
+const uint TRANSFER_SRGB = 1u;
+const uint TRANSFER_BT709 = 2u;
+const uint TRANSFER_PQ = 3u;
+const uint TRANSFER_HLG = 4u;
+
+// Keep in sync with `ColorConverterPushConstants::FLAG_APPLY_TRANSFER`.
+const uint FLAG_APPLY_TRANSFER = 1u;
+
+float transfer_to_linear(uint id, float x) {
+    if (id == TRANSFER_SRGB) {
+        return x <= 0.04045 ? x / 12.92 : pow((x + 0.055) / 1.055, 2.4);
+    }
+    if (id == TRANSFER_BT709) {
+        return x < 0.081 ? x / 4.5 : pow((x + 0.099) / 1.099, 1.0 / 0.45);
+    }
+    if (id == TRANSFER_PQ) {
+        const float m1 = 2610.0 / 16384.0;
+        const float m2 = (2523.0 / 4096.0) * 128.0;
+        const float c1 = 3424.0 / 4096.0;
+        const float c2 = (2413.0 / 4096.0) * 32.0;
+        const float c3 = (2392.0 / 4096.0) * 32.0;
+        float xp = pow(max(x, 0.0), 1.0 / m2);
+        float num = max(xp - c1, 0.0);
+        float den = c2 - c3 * xp;
+        return pow(num / den, 1.0 / m1);
+    }
+    if (id == TRANSFER_HLG) {
+        const float a = 0.17883277;
+        const float b = 0.28466892;
+        const float c = 0.55991073;
+        return x <= 0.5 ? (x * x) / 3.0 : (exp((x - c) / a) + b) / 12.0;
+    }
+    // TRANSFER_LINEAR (and any unrecognized id) → identity.
+    return x;
+}
+
+float transfer_from_linear(uint id, float x) {
+    if (id == TRANSFER_SRGB) {
+        return x <= 0.0031308 ? 12.92 * x : 1.055 * pow(x, 1.0 / 2.4) - 0.055;
+    }
+    if (id == TRANSFER_BT709) {
+        return x < 0.018 ? 4.5 * x : 1.099 * pow(x, 0.45) - 0.099;
+    }
+    if (id == TRANSFER_PQ) {
+        const float m1 = 2610.0 / 16384.0;
+        const float m2 = (2523.0 / 4096.0) * 128.0;
+        const float c1 = 3424.0 / 4096.0;
+        const float c2 = (2413.0 / 4096.0) * 32.0;
+        const float c3 = (2392.0 / 4096.0) * 32.0;
+        float xp = pow(max(x, 0.0), m1);
+        float num = c1 + c2 * xp;
+        float den = 1.0 + c3 * xp;
+        return pow(num / den, m2);
+    }
+    if (id == TRANSFER_HLG) {
+        const float a = 0.17883277;
+        const float b = 0.28466892;
+        const float c = 0.55991073;
+        return x <= 1.0 / 12.0 ? sqrt(3.0 * max(x, 0.0))
+                               : a * log(12.0 * x - b) + c;
+    }
+    return x;
+}
+
+// Closed-form `ycbcr_byte → rgba_normalized` pipeline:
+//   1. Subtract `range_offset` from raw byte-domain YCbCr.
+//   2. Multiply by the (row-major) 3×3 matrix; the matrix bakes in
+//      range expansion (Y scale = 255/219 for limited-range, 1 for
+//      full-range; chroma scale = 255/224 for limited).
+//   3. Divide by 255 + clamp to `[0, 1]`.
+//   4. If `FLAG_APPLY_TRANSFER` is set, run the transfer-in EOTF then
+//      transfer-out OETF closed-form on each channel.
+vec3 convert_color(
+    vec3 ycbcr_byte,
+    vec3 row0,
+    vec3 row1,
+    vec3 row2,
+    vec3 range_offset,
+    uint transfer_in,
+    uint transfer_out,
+    uint flags
+) {
+    vec3 c = ycbcr_byte - range_offset;
+    vec3 rgb_byte = vec3(dot(row0, c), dot(row1, c), dot(row2, c));
+    vec3 rgb = clamp(rgb_byte / 255.0, 0.0, 1.0);
+    if ((flags & FLAG_APPLY_TRANSFER) != 0u) {
+        rgb.r = transfer_from_linear(transfer_out, transfer_to_linear(transfer_in, rgb.r));
+        rgb.g = transfer_from_linear(transfer_out, transfer_to_linear(transfer_in, rgb.g));
+        rgb.b = transfer_from_linear(transfer_out, transfer_to_linear(transfer_in, rgb.b));
+    }
+    return rgb;
+}

--- a/examples/camera-python-display/effects/shaders/tone_curve.comp
+++ b/examples/camera-python-display/effects/shaders/tone_curve.comp
@@ -1,0 +1,253 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Image-source → image-dest tone-curve compute shader. Example-local copy of
+// the engine's `runtime/streamlib-engine/src/vulkan/rhi/shaders/tone_curve.comp`
+// — the sandboxed tone-mapper (`tone_mapper.rs`) rides the engine-free plugin
+// SDK, so its shader lives in the example. The 32-byte push-constant block is
+// locked byte-for-byte against `tone_mapper::ToneMapperPushConstants` by a
+// layout regression test on the Rust side.
+//
+// Bindings:
+//   0 — `readonly image2D rgba_input` (RGBA8 / RGBA16F storage image,
+//       interpreted in input_transfer encoding).
+//   1 — `writeonly image2D rgba_output` (RGBA8 / RGBA16F storage image,
+//       written in output_transfer encoding).
+//
+// Per-channel pipeline:
+//   1. EOTF: input_transfer → linear (per-channel, normalized to peak_in_nits).
+//   2. tonemap_curve: optional tone-curve in linear or PQ space.
+//   3. OETF: linear → output_transfer (per-channel, normalized to peak_out_nits).
+
+#version 450
+#extension GL_GOOGLE_include_directive : require
+
+#include "color_convert_common.glsl"
+
+layout(local_size_x = 16, local_size_y = 16) in;
+
+// Storage images — format-agnostic at the SPIR-V level (the
+// `set_storage_image` binding picks the texture's view format at
+// runtime). The shader operates on `vec4` color, so this works for
+// RGBA8_UNORM, RGBA16_UNORM, and RGBA16_SFLOAT alike.
+layout(rgba8, set = 0, binding = 0) readonly uniform image2D rgba_input;
+layout(rgba8, set = 0, binding = 1) writeonly uniform image2D rgba_output;
+
+layout(push_constant, std430) uniform PushConstants {
+    uint width;
+    uint height;
+    uint input_transfer;
+    uint output_transfer;
+    uint tonemap_curve;
+    float peak_in_nits;
+    float peak_out_nits;
+    uint flags;
+} pc;
+
+// Keep in sync with `tone_mapper::ToneCurveId`.
+const uint TONE_CURVE_NONE      = 0u;  // identity (transfer conversion only)
+const uint TONE_CURVE_BT2390    = 1u;  // forward HDR→SDR, ITU-R BT.2390 EETF
+const uint TONE_CURVE_BT2446A   = 2u;  // inverse SDR→HDR, ITU-R BT.2446-1 method A2
+
+// PQ space conversion (PQ encodes 1.0 = 10000 nits per spec).
+// These mirror `transfer_to_linear` / `transfer_from_linear` for PQ in
+// `color_convert_common.glsl`; duplicated here as the named helpers
+// `pq_encode` / `pq_decode` so the BT.2390 algorithm reads as
+// "encode, normalize, spline, denormalize, decode" — matches the
+// spec's pseudocode in Annex 2 of BT.2390-9.
+
+float pq_encode(float linear_abs) {
+    // linear_abs in [0, 1] where 1.0 = 10000 nits.
+    const float m1 = 2610.0 / 16384.0;
+    const float m2 = (2523.0 / 4096.0) * 128.0;
+    const float c1 = 3424.0 / 4096.0;
+    const float c2 = (2413.0 / 4096.0) * 32.0;
+    const float c3 = (2392.0 / 4096.0) * 32.0;
+    float xp = pow(max(linear_abs, 0.0), m1);
+    float num = c1 + c2 * xp;
+    float den = 1.0 + c3 * xp;
+    return pow(num / den, m2);
+}
+
+float pq_decode(float pq) {
+    return transfer_to_linear(TRANSFER_PQ, pq);
+}
+
+// BT.2390 EETF — per-channel HDR→SDR tone curve in PQ space.
+//
+// Reference: ITU-R Report BT.2390-9, Annex 2 §5 (Hermite spline EETF).
+//
+// Inputs:
+//   linear_norm: per-channel linear value normalized to peak_in_nits
+//                (1.0 = peak_in_nits).
+//   peak_in_nits:  source reference peak luminance.
+//   peak_out_nits: target reference peak luminance.
+// Output:
+//   per-channel linear value normalized to peak_out_nits
+//   (1.0 = peak_out_nits).
+//
+// The spline operates in PQ space normalized so that 1.0 = source peak.
+// The knee point KS = 1.5 * maxLum - 0.5; below KS pass-through, above
+// KS the cubic Hermite spline interpolates from (KS, KS) to (1, maxLum).
+float bt2390_eetf(float linear_norm, float peak_in_nits, float peak_out_nits) {
+    // Convert source-normalized linear → absolute linear (1.0 = 10000 nits).
+    float linear_abs = linear_norm * peak_in_nits / 10000.0;
+    // Source peak in PQ units (where 1.0 = 10000 nits).
+    float pq_src = pq_encode(peak_in_nits / 10000.0);
+    // Destination peak in PQ units.
+    float pq_dst = pq_encode(peak_out_nits / 10000.0);
+    // Input value in PQ units, then normalized to source-peak space.
+    float pq_in = pq_encode(linear_abs);
+    float E1 = pq_in / pq_src;
+    // Maximum allowed luminance in source-normalized PQ space.
+    float maxLum = pq_dst / pq_src;
+    // Knee start.
+    float ks = 1.5 * maxLum - 0.5;
+
+    float E2;
+    if (E1 < ks) {
+        // Below knee: linear pass-through preserves shadows + midtones.
+        E2 = E1;
+    } else {
+        // Hermite spline P(B) where B in [0, 1] from KS to 1.
+        float t = (E1 - ks) / max(1.0 - ks, 1e-6);
+        float t2 = t * t;
+        float t3 = t2 * t;
+        E2 = (2.0 * t3 - 3.0 * t2 + 1.0) * ks
+           + (t3 - 2.0 * t2 + t) * (1.0 - ks)
+           + (-2.0 * t3 + 3.0 * t2) * maxLum;
+    }
+
+    // Denormalize back to absolute PQ.
+    float pq_out = E2 * pq_src;
+    // Decode PQ → linear absolute (1.0 = 10000 nits).
+    float lin_out_abs = pq_decode(pq_out);
+    // Renormalize to destination peak.
+    return lin_out_abs * 10000.0 / peak_out_nits;
+}
+
+// BT.2446-1 method A2 — per-channel SDR→HDR inverse tone curve.
+//
+// Reference: ITU-R Report BT.2446-1, §5 method A2 (closed-form
+// inverse tone-mapping for SDR→HDR up-conversion).
+//
+// Inputs:
+//   linear_norm: per-channel linear value normalized to peak_in_nits.
+//   peak_in_nits:  source SDR reference peak (typically 100 nits).
+//   peak_out_nits: target HDR reference peak (e.g., 1000 or 4000 nits).
+// Output:
+//   per-channel linear value normalized to peak_out_nits.
+//
+// Below the knee (≈ midtone), shadows are preserved roughly linearly
+// to keep SDR midtones at SDR-equivalent display nits. Above the knee
+// the curve smoothly expands into HDR headroom so that 1.0 SDR maps
+// to 1.0 HDR (peak preserved).
+float bt2446a_inverse(float linear_norm, float peak_in_nits, float peak_out_nits) {
+    // Trivial case: no expansion needed.
+    if (peak_out_nits <= peak_in_nits) {
+        // Map 1.0 input → peak_in/peak_out output (so SDR stays at
+        // SDR-equivalent absolute nits in the smaller target range).
+        return linear_norm * peak_in_nits / peak_out_nits;
+    }
+    float ratio = peak_out_nits / peak_in_nits;
+    // Knee at SDR=0.5 (≈ midtone). Below: linear preserving shadows.
+    // Above: cubic Hermite ease into peak.
+    const float knee = 0.5;
+    if (linear_norm <= knee) {
+        // Map [0, knee] in source → [0, knee/ratio] in dest, linear.
+        // This keeps SDR shadows at the same absolute nits as before
+        // (knee_source_nits = knee * peak_in; output normalized to
+        // peak_out gives knee/ratio * peak_out = knee * peak_in nits).
+        return linear_norm / ratio;
+    }
+    // Above knee: cubic ease from (knee, knee/ratio) to (1.0, 1.0).
+    // Both endpoint slopes match the linear segment + tangent at peak,
+    // giving C1 continuity at both endpoints.
+    float t = (linear_norm - knee) / (1.0 - knee);
+    float t2 = t * t;
+    float t3 = t2 * t;
+    // Hermite basis functions (h00, h10, h01, h11):
+    //   p(t) = h00*p0 + h10*m0 + h01*p1 + h11*m1
+    float h00 =  2.0 * t3 - 3.0 * t2 + 1.0;
+    float h10 =        t3 - 2.0 * t2 + t;
+    float h01 = -2.0 * t3 + 3.0 * t2;
+    float h11 =        t3 -       t2;
+    float p0 = knee / ratio;
+    float p1 = 1.0;
+    // Tangents in destination units. Source-side derivative below knee
+    // is 1/ratio (linear segment); preserve it at the start. End
+    // tangent is 0 to soften approach to peak (no overshoot).
+    float m0 = 1.0 / ratio;
+    float m1 = 0.0;
+    return h00 * p0 + h10 * m0 + h01 * p1 + h11 * m1;
+}
+
+// Per-transfer reference luminance — the nit value that linear=1.0
+// represents after the EOTF (and that linear=1.0 means in the OETF
+// input). PQ encodes up to 10000 nits, HLG to its reference peak,
+// SDR transfers to ~100 nits diffuse white.
+float transfer_reference_nits(uint transfer_id) {
+    if (transfer_id == TRANSFER_PQ)  return 10000.0;
+    if (transfer_id == TRANSFER_HLG) return 1000.0;
+    return 100.0;
+}
+
+float apply_tone_curve(float linear_post_eotf, uint curve, uint input_transfer,
+                       uint output_transfer, float peak_in, float peak_out) {
+    // `linear_post_eotf` is in transfer-reference-normalized space
+    // (1.0 = `transfer_reference_nits(input_transfer)`). The tone-
+    // curve algorithms expect "linear normalized to peak_in_nits" on
+    // input and produce "linear normalized to peak_out_nits" on
+    // output — so we renormalize at the boundary so the math matches
+    // its spec (BT.2390 Annex 2; BT.2446-1 §5).
+    float ref_in  = transfer_reference_nits(input_transfer);
+    float ref_out = transfer_reference_nits(output_transfer);
+    float lin_in_norm = linear_post_eotf * ref_in / peak_in;
+
+    float lin_out_norm;
+    if (curve == TONE_CURVE_BT2390) {
+        lin_out_norm = bt2390_eetf(lin_in_norm, peak_in, peak_out);
+    } else if (curve == TONE_CURVE_BT2446A) {
+        lin_out_norm = bt2446a_inverse(lin_in_norm, peak_in, peak_out);
+    } else if (peak_in == peak_out) {
+        lin_out_norm = lin_in_norm;
+    } else {
+        lin_out_norm = lin_in_norm * peak_in / peak_out;
+    }
+
+    // Renormalize back to the OETF's reference space.
+    return lin_out_norm * peak_out / ref_out;
+}
+
+void main() {
+    uvec2 pos = gl_GlobalInvocationID.xy;
+    if (pos.x >= pc.width || pos.y >= pc.height) return;
+
+    vec4 src = imageLoad(rgba_input, ivec2(pos));
+
+    // EOTF input → linear (per-channel, normalized to peak_in_nits).
+    vec3 lin_in = vec3(
+        transfer_to_linear(pc.input_transfer, src.r),
+        transfer_to_linear(pc.input_transfer, src.g),
+        transfer_to_linear(pc.input_transfer, src.b)
+    );
+
+    // Tone curve (per-channel).
+    vec3 lin_out = vec3(
+        apply_tone_curve(lin_in.r, pc.tonemap_curve, pc.input_transfer,
+                         pc.output_transfer, pc.peak_in_nits, pc.peak_out_nits),
+        apply_tone_curve(lin_in.g, pc.tonemap_curve, pc.input_transfer,
+                         pc.output_transfer, pc.peak_in_nits, pc.peak_out_nits),
+        apply_tone_curve(lin_in.b, pc.tonemap_curve, pc.input_transfer,
+                         pc.output_transfer, pc.peak_in_nits, pc.peak_out_nits)
+    );
+
+    // OETF linear → output (per-channel, normalized to peak_out_nits).
+    vec3 enc_out = vec3(
+        transfer_from_linear(pc.output_transfer, clamp(lin_out.r, 0.0, 1.0)),
+        transfer_from_linear(pc.output_transfer, clamp(lin_out.g, 0.0, 1.0)),
+        transfer_from_linear(pc.output_transfer, clamp(lin_out.b, 0.0, 1.0))
+    );
+
+    imageStore(rgba_output, ivec2(pos), vec4(enc_out, src.a));
+}

--- a/examples/camera-python-display/effects/src/blending_compositor.rs
+++ b/examples/camera-python-display/effects/src/blending_compositor.rs
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //! Blending Compositor — multi-layer alpha-over composite with PiP slide-in
-//! on the canonical graphics-kernel + texture-cache RHI.
+//! on the engine-free plugin SDK's graphics-kernel + texture-cache surfaces.
 //!
-//! Runs as a [`ManualProcessor`] with a render thread paced against the
-//! display's refresh rate (60 Hz fallback). Each tick reads the latest
-//! frame from each input port (older queued frames are dropped by the
-//! port's `SkipToLatest` read mode), resolves the input frames'
-//! [`Texture`]s via `GpuContext::resolve_texture_registration_by_surface_id`
+//! Runs as a [`ManualProcessor`] with a render thread paced against a
+//! fixed 60 Hz cadence (the render thread has no window handle, so there
+//! is no live refresh query). Each tick reads the latest frame from each
+//! input port (older queued frames are dropped by the port's
+//! `SkipToLatest` read mode), resolves the input frames' [`Texture`]s via
+//! `GpuContextLimitedAccess::resolve_texture_registration_by_surface_id`
 //! (Path 1 — same-process texture cache), picks the next slot in a
 //! ring of pre-allocated render-target output `Texture`s,
 //! dispatches the compositor's graphics kernel into it, and emits the
@@ -16,14 +17,17 @@
 //!
 //! Layer order (bottom → top): video → lower_third → watermark → PiP.
 //!
-//! Linux-only. The macOS Metal path was retired when the compositor
-//! moved onto the graphics-kernel + texture-cache RHI; supporting it
-//! would have required parallel adapter machinery that does not exist
-//! outside the engine today.
+//! Linux-only. Everything goes through the engine-free
+//! `streamlib-plugin-sdk`: the compositor kernel, tone-mapper, output
+//! ring, and per-slot timelines are built on `GpuContextFullAccess` at
+//! setup (privileged), and the render thread resolves + dispatches on
+//! `GpuContextLimitedAccess` (the hot path never escalates). No raw
+//! `HostVulkanDevice`, so the cdylib stays sound as a separately-built
+//! `.slpkg`.
 //!
 //! The kernel wrapper itself ([`SandboxedBlendingCompositor`]) lives
-//! in `blending_compositor_kernel.rs` — see that file's module-level
-//! doc for why it lives in the example and not the engine.
+//! in `blending_compositor_kernel.rs`; the sandboxed tone-mapper
+//! ([`SandboxedToneMapper`]) in `tone_mapper.rs`.
 
 #![cfg(target_os = "linux")]
 
@@ -33,30 +37,28 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
-use streamlib::sdk::engine::host_rhi::{HostVulkanTexture, HostVulkanTimelineSemaphore};
-use streamlib::sdk::engine::{HostSurfaceStoreExt, HostTextureExt};
 
-use streamlib::sdk::color::TransferId;
-use streamlib::sdk::display_info;
-use streamlib::sdk::rhi::{
-    RhiToneMapper, Texture, TextureDescriptor, TextureFormat, TextureUsages, ToneCurveId,
-    ToneMapperPushConstants, VulkanLayout,
+use streamlib_plugin_sdk::sdk::color::TransferId;
+use streamlib_plugin_sdk::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess};
+use streamlib_plugin_sdk::sdk::error::{Error, Result};
+use streamlib_plugin_sdk::sdk::iceoryx2::{InputMailboxes, OutputWriter};
+use streamlib_plugin_sdk::sdk::rhi::{
+    HostTimelineSemaphore, PooledTextureHandle, Texture, TextureFormat, TexturePoolDescriptor,
+    TextureRegistration, TextureUsages, VulkanLayout,
 };
-use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess};
-use streamlib::sdk::error::{Result, Error};
-use streamlib::sdk::iceoryx2::{InputMailboxes, OutputWriter};
+
 use crate::_generated_::tatolab__core::color_info::{Matrix, Primaries, Range, Transfer};
 use crate::_generated_::{ColorInfo, VideoFrame};
 
-// Sandboxed kernel wrapper — see `blending_compositor_kernel.rs` for
-// the rationale (sandboxed scenario content rides the engine RHI's
-// cdylib-safe surfaces).
+// Sandboxed kernel + tone-mapper wrappers — see their module-level docs
+// for why they live in the example and not the engine.
 use crate::blending_compositor_kernel::{
     BlendingCompositorInputs, BlendingLayer, BlendingOutput, SandboxedBlendingCompositor,
 };
+use crate::tone_mapper::{SandboxedToneMapper, ToneCurveId, ToneMapperPushConstants};
 
 /// Iteration cap applied when [`BlendingCompositorConfig::target_fps`]
-/// or the display refresh query produces a non-positive value.
+/// produces a non-positive value.
 const FALLBACK_TARGET_FPS: f64 = 60.0;
 
 /// Render-loop iteration count slack: at 60 Hz nominal we tolerate up
@@ -90,13 +92,14 @@ pub struct BlendingCompositorConfig {
     /// Delay after first camera frame before PiP slides in, seconds.
     pub pip_slide_delay: f32,
     /// Override the render loop's target frame rate. When unset, the
-    /// loop polls [`display_info::get_refresh_rate`]; primarily useful
-    /// for tests that need a deterministic cadence without a window.
+    /// loop paces against the 60 Hz fallback (the render thread has no
+    /// window handle, so there is no live refresh query); primarily
+    /// useful for tests that need a deterministic cadence.
     #[serde(default)]
     pub target_fps: Option<f64>,
     /// Working-space `ColorInfo` for the per-acquire compositing model:
     /// each input frame whose declared `ColorInfo` differs from this is
-    /// converted via [`RhiToneMapper`] into a per-port intermediate
+    /// converted via [`SandboxedToneMapper`] into a per-port intermediate
     /// before the composite kernel reads it; the output frame stamps
     /// this same `ColorInfo`.
     ///
@@ -118,8 +121,8 @@ pub struct BlendingCompositorConfig {
     pub default_tone_curve: Option<ToneCurveSelector>,
 }
 
-/// Serializable proxy for [`ToneCurveId`] so the engine-internal enum
-/// can be set from config YAML / JSON without leaking the engine type.
+/// Serializable proxy for [`ToneCurveId`] so the tone-curve enum can be
+/// set from config YAML / JSON.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ToneCurveSelector {
     /// Identity — pure transfer rescale, no tone curve.
@@ -156,54 +159,53 @@ impl Default for BlendingCompositorConfig {
 }
 
 /// Output ring slot — pre-allocated render-target texture + the UUID
-/// it is registered under in `GpuContext::texture_cache`.
+/// it is registered under in the same-process texture cache.
 struct OutputSlot {
     surface_id: String,
     texture: Texture,
-    // Per-slot single-writer-per-edge timeline pair held on the host
+    // Per-slot single-writer-per-edge timeline pair held on the plugin
     // side so cross-process consumers reaching the slot via
     // `surface_store.lookup` see live timeline FDs (the registration
-    // duplicated them via SCM_RIGHTS but the host-side Arcs must
+    // duplicated them via SCM_RIGHTS but the producer-side handles must
     // outlive the surface). See
     // `docs/architecture/adapter-timeline-single-writer.md`.
-    _produce_done: Arc<HostVulkanTimelineSemaphore>,
-    _consume_done: Arc<HostVulkanTimelineSemaphore>,
+    _produce_done: HostTimelineSemaphore,
+    _consume_done: HostTimelineSemaphore,
 }
 
 /// GPU backend bundle owned by the processor and moved into the
-/// render thread on `start()`. The output texture ring is allocated
-/// during `setup()` (FullAccess required for
-/// `acquire_render_target_dma_buf_image`) and consumed read-only by
-/// the render thread (LimitedAccess is sufficient for resolving
-/// registrations).
+/// render thread on `start()`. Everything is built during `setup()`
+/// from the privileged `GpuContextFullAccess` and consumed by the
+/// render thread through cdylib-safe method dispatch + the Limited
+/// `acquire_texture` pool (for intermediates).
 struct GpuBackend {
     compositor: Arc<SandboxedBlendingCompositor>,
     output_ring: Vec<OutputSlot>,
-    /// Per-input tone-mapper. Constructed in `setup()` (kernel is
-    /// allocated lazily on first dispatch). Engaged by
+    /// Per-input tone-mapper. Constructed in `setup()`. Engaged by
     /// `normalize_layer` when an input frame's `ColorInfo` differs
     /// from the working space.
-    tone_mapper: Arc<RhiToneMapper>,
-    /// Per-port intermediate textures, lazily allocated on first
-    /// frame and reallocated when input dimensions change. Keyed by
+    tone_mapper: Arc<SandboxedToneMapper>,
+    /// Per-port intermediate textures, lazily acquired on first
+    /// frame and re-acquired when input dimensions change. Keyed by
     /// port name ("video_in", "lower_third_in", etc.). Only the
     /// render thread mutates this; the mutex exists so the map can
     /// also be inspected from other threads if a debug surface is
     /// added later.
     intermediates: StdMutex<HashMap<String, Intermediate>>,
-    /// Host Vulkan device, threaded through for lazy intermediate
-    /// allocation. The render thread holds the only consumer-side
-    /// `Arc`; teardown releases it when the thread exits.
-    vulkan_device: Arc<streamlib::sdk::engine::host_rhi::HostVulkanDevice>,
 }
 
 /// Per-input intermediate texture used by the per-acquire tone-mapping
 /// stage. The compositor reads this when the input's `ColorInfo`
-/// differs from the working space; allocated lazily on first
-/// conversion at the input's dimensions and reallocated on dimension
-/// change.
+/// differs from the working space; acquired lazily on first conversion
+/// at the input's dimensions and re-acquired on dimension change.
 struct Intermediate {
-    texture: Texture,
+    /// Pooled scratch texture acquired via
+    /// [`GpuContextLimitedAccess::acquire_texture`]. Held so the pool
+    /// slot stays checked out for the intermediate's lifetime; the
+    /// texture is bound via [`PooledTextureHandle::texture`]. Dropped
+    /// (returned to the pool) when the port's dimensions change and a
+    /// new one is acquired.
+    pool_handle: PooledTextureHandle,
     width: u32,
     height: u32,
     /// Last-known Vulkan layout the texture is in. Tracked by the
@@ -212,7 +214,7 @@ struct Intermediate {
     current_layout: VulkanLayout,
 }
 
-#[streamlib::sdk::processor("BlendingCompositor")]
+#[streamlib_plugin_sdk::sdk::processor("BlendingCompositor")]
 pub struct BlendingCompositorProcessor {
     config: BlendingCompositorConfig,
 
@@ -229,7 +231,7 @@ pub struct BlendingCompositorProcessor {
     backend: Option<GpuBackend>,
 }
 
-impl streamlib::sdk::processors::ManualProcessor for BlendingCompositorProcessor::Processor {
+impl streamlib_plugin_sdk::sdk::processors::ManualProcessor for BlendingCompositorProcessor::Processor {
     fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.setup_inner(ctx)
     }
@@ -288,9 +290,7 @@ impl streamlib::sdk::processors::ManualProcessor for BlendingCompositorProcessor
                     frame_count.load(Ordering::Relaxed)
                 );
             })
-            .map_err(|e| {
-                Error::Configuration(format!("spawn render thread: {e}"))
-            })?;
+            .map_err(|e| Error::Configuration(format!("spawn render thread: {e}")))?;
         self.render_thread = Some(handle);
         Ok(())
     }
@@ -311,53 +311,40 @@ impl BlendingCompositorProcessor::Processor {
                 return fps;
             }
         }
-        // Render thread runs without a window handle; the underlying
-        // helper falls back to the primary monitor's refresh on Linux,
-        // returning a positive `f64` directly.
-        let rate = display_info::get_refresh_rate(None);
-        if rate > 0.0 {
-            rate
-        } else {
-            FALLBACK_TARGET_FPS
-        }
+        // The render thread runs without a window handle; there is no
+        // live refresh-rate query on this path, so use the standard
+        // 60 Hz fallback (the display's default cadence).
+        FALLBACK_TARGET_FPS
     }
 
     fn setup_inner(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        tracing::info!("BlendingCompositor: setup (Vulkan)");
+        tracing::info!("BlendingCompositor: setup (engine-free Vulkan)");
         let gpu_context = ctx.gpu_limited_access().clone();
         self.gpu_context = Some(gpu_context.clone());
 
         // setup() runs inside the engine's privileged lifecycle dispatch
         // (`ProcessorInstance::setup`), so `ctx.gpu_full_access()` is
-        // already privileged in both cdylib and in-process modes: cdylib
-        // bodies see a ScopeToken-shaped FullAccess routed through the
-        // FullAccess vtable, in-process bodies see the Boxed FullAccess
-        // dispatched directly. Calling `gpu_limited_access().escalate(...)`
-        // here would re-enter the same gate and trip the gate's same-
-        // thread re-entry panic.
-        //
-        // `host_vulkan_device_arc()` is the cdylib-safe FullAccess
-        // accessor; the `Arc<HostVulkanDevice>` it returns is held by
-        // the sandboxed graphics-kernel wrapper for steady-state
-        // dispatch.
+        // already privileged — building the kernel + ring + tone-mapper +
+        // timelines here (not via `gpu_limited_access().escalate(...)`)
+        // avoids re-entering the escalate gate on the same thread.
         let width = self.config.width;
         let height = self.config.height;
         let full = ctx.gpu_full_access();
-        let vulkan_device = full.host_vulkan_device_arc()?;
-        let compositor = Arc::new(SandboxedBlendingCompositor::new(&vulkan_device)?);
+        let compositor = Arc::new(SandboxedBlendingCompositor::new(full)?);
+
+        // Per-input tone-mapper. Built once here; engaged by
+        // `normalize_layer` when an input's `ColorInfo` differs from the
+        // working space.
+        let tone_mapper = Arc::new(SandboxedToneMapper::new(full)?);
 
         // Pre-allocate the output texture ring — render-target-capable
         // tiled DMA-BUF VkImages. Dual-registration happens below via
         // the LimitedAccess `register_texture_with_layout` /
         // `surface_store` primitives.
-        let mut ring_descriptors: Vec<(String, Texture)> =
-            Vec::with_capacity(OUTPUT_RING_DEPTH);
+        let mut ring_descriptors: Vec<(String, Texture)> = Vec::with_capacity(OUTPUT_RING_DEPTH);
         for slot_idx in 0..OUTPUT_RING_DEPTH {
-            let texture = full.acquire_render_target_dma_buf_image(
-                width,
-                height,
-                TextureFormat::Bgra8Unorm,
-            )?;
+            let texture =
+                full.acquire_render_target_dma_buf_image(width, height, TextureFormat::Bgra8Unorm)?;
             // Engine UUIDv4-shaped fixed string per slot — keeps the
             // `surface_id` stable across runs (helpful for log
             // correlation) and the slot index visible in the last
@@ -365,22 +352,27 @@ impl BlendingCompositorProcessor::Processor {
             // Hex-only by construction so any future consumer that
             // parses surface_id as a real UUID still resolves it
             // (`b1e0d` ≈ "blend").
-            let surface_id =
-                format!("00000000-0000-0000-0000-00000b1e0d{slot_idx:02x}");
+            let surface_id = format!("00000000-0000-0000-0000-00000b1e0d{slot_idx:02x}");
             ring_descriptors.push((surface_id, texture));
         }
 
-        // Per-input tone-mapper. Cheap to construct (kernel built
-        // lazily on first dispatch); each consumer owns its own
-        // instance per the "no engine-side cache" pattern.
-        let tone_mapper = Arc::new(RhiToneMapper::new(&vulkan_device));
+        // Cross-process surface-share handle for Path 2 consumers (the
+        // `cyberpunk_glitch` Python subprocess reaching the ring via
+        // `OpenGLContext.acquire_read`). Fetch once — the FullAccess
+        // mirror inherits the Limited `surface_store` slot.
+        let surface_store = full.surface_store();
+        if surface_store.is_none() {
+            return Err(Error::Configuration(
+                "BlendingCompositor: GpuContext has no surface_store — cross-process output \
+                 (Glitch consumer) unavailable"
+                    .to_string(),
+            ));
+        }
 
-        // Dual-register each slot outside `escalate`:
+        // Dual-register each slot:
         // - `GpuContext::texture_cache` (Path 1 — in-process consumers
         //   like `LinuxDisplayProcessor` and `CrtFilmGrain`).
-        // - `surface_store` (Path 2 — cross-process consumers like the
-        //   `cyberpunk_glitch` Python subprocess reaching the ring via
-        //   `OpenGLContext.acquire_read`).
+        // - `surface_store` (Path 2 — cross-process consumers).
         //
         // The two registrations describe the same texture and declare
         // matching layouts (anti-pattern #2 in `texture-registration.md`
@@ -390,55 +382,40 @@ impl BlendingCompositorProcessor::Processor {
         // `SHADER_READ_ONLY_OPTIMAL` because Glitch reads after the
         // first render lands.
         let mut output_ring: Vec<OutputSlot> = Vec::with_capacity(OUTPUT_RING_DEPTH);
-        for (slot_idx, (surface_id, texture)) in ring_descriptors.into_iter().enumerate()
-        {
+        for (slot_idx, (surface_id, texture)) in ring_descriptors.into_iter().enumerate() {
             // Per-slot single-writer-per-edge exportable timelines —
-            // `produce_done` signaled by the host-side compositor,
+            // `produce_done` signaled by the plugin-side compositor,
             // `consume_done` signaled by cross-process consumers (Glitch
             // Python subprocess). See
             // `docs/architecture/adapter-timeline-single-writer.md`.
-            let produce_done = Arc::new(
-                HostVulkanTimelineSemaphore::new_exportable(vulkan_device.device(), 0)
-                    .map_err(|e| {
-                        Error::Configuration(format!(
-                            "BlendingCompositor: HostVulkanTimelineSemaphore::new_exportable \
-                             (produce_done) slot {slot_idx}: {e}"
-                        ))
-                    })?,
-            );
-            let consume_done = Arc::new(
-                HostVulkanTimelineSemaphore::new_exportable(vulkan_device.device(), 0)
-                    .map_err(|e| {
-                        Error::Configuration(format!(
-                            "BlendingCompositor: HostVulkanTimelineSemaphore::new_exportable \
-                             (consume_done) slot {slot_idx}: {e}"
-                        ))
-                    })?,
-            );
+            let produce_done = full.create_exportable_timeline_semaphore(0).map_err(|e| {
+                Error::Configuration(format!(
+                    "BlendingCompositor: create_exportable_timeline_semaphore (produce_done) \
+                     slot {slot_idx}: {e}"
+                ))
+            })?;
+            let consume_done = full.create_exportable_timeline_semaphore(0).map_err(|e| {
+                Error::Configuration(format!(
+                    "BlendingCompositor: create_exportable_timeline_semaphore (consume_done) \
+                     slot {slot_idx}: {e}"
+                ))
+            })?;
             gpu_context.register_texture_with_layout(
                 &surface_id,
                 texture.clone(),
                 VulkanLayout::UNDEFINED,
             );
-            let surface_store = gpu_context.surface_store().ok_or_else(|| {
-                Error::Configuration(
-                    "BlendingCompositor: GpuContext has no surface_store \
-                     — cross-process output (Glitch consumer) unavailable"
-                        .to_string(),
-                )
-            })?;
             surface_store
                 .register_texture(
                     &surface_id,
                     &texture,
-                    Some(produce_done.as_ref()),
-                    Some(consume_done.as_ref()),
+                    Some(&produce_done),
+                    Some(&consume_done),
                     VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
                 )
                 .map_err(|e| {
                     Error::Configuration(format!(
-                        "BlendingCompositor: surface_store.register_texture \
-                         slot {slot_idx}: {e}"
+                        "BlendingCompositor: surface_store.register_texture slot {slot_idx}: {e}"
                     ))
                 })?;
             output_ring.push(OutputSlot {
@@ -457,7 +434,6 @@ impl BlendingCompositorProcessor::Processor {
             output_ring,
             tone_mapper,
             intermediates: StdMutex::new(HashMap::new()),
-            vulkan_device,
         });
         Ok(())
     }
@@ -633,7 +609,7 @@ fn compose_one_frame(
                 state.default_tone_curve,
                 &backend.tone_mapper,
                 &backend.intermediates,
-                &backend.vulkan_device,
+                gpu_ctx,
             )?;
         }
     }
@@ -683,8 +659,8 @@ fn compose_one_frame(
     let pip = state.last_pip.as_ref();
 
     // Dispatch — the compositor records input barriers (when needed) +
-    // offscreen render + output post-barrier through the engine RHI,
-    // submits each, and waits before returning.
+    // offscreen render + output post-barrier through the plugin SDK's
+    // RHI, submits each, and waits before returning.
     backend.compositor.dispatch(BlendingCompositorInputs {
         video: video.map(|l| l.as_layer()),
         lower_third: lower_third.map(|l| l.as_layer()),
@@ -751,13 +727,11 @@ fn default_working_space() -> ColorInfo {
     }
 }
 
-/// Map BC's local schema `Transfer` enum to the engine's `TransferId`
-/// push-constant id. Local because the engine's
-/// [`streamlib::sdk::color::transfer_id_from_schema`] takes the
-/// engine-crate's flavor of the schema enum (a distinct Rust type
-/// from BC's `_generated_/` codegen output, even though both are
-/// generated from the same JTD source). Match arms mirror the
-/// engine helper's coverage.
+/// Map BC's local schema `Transfer` enum to the plugin SDK's
+/// [`TransferId`] push-constant id. Local because the SDK's
+/// `TransferId` is a distinct Rust type from BC's `_generated_/`
+/// codegen output, even though both are generated from the same JTD
+/// source.
 fn transfer_id_from_schema(t: &Transfer) -> TransferId {
     match t {
         Transfer::Srgb => TransferId::Srgb,
@@ -800,7 +774,7 @@ fn color_info_matches_working_space(input: Option<&ColorInfo>, working: &ColorIn
 /// used by `normalize_layer` to detect mismatches against the
 /// working space and engage the tone-mapper.
 struct ResolvedLayer {
-    registration: streamlib::sdk::context::TextureRegistration,
+    registration: TextureRegistration,
     texture: Texture,
     /// `ColorInfo` declared on the source `VideoFrame`. `None` means
     /// the producer didn't tag the frame; defaults to the working
@@ -886,21 +860,22 @@ fn refresh_layer(
 /// Per-input tone-map normalization: if `layer.source_color_info`
 /// (after defaults resolution) differs from the working space, run
 /// the tone-mapper from the upstream texture into a per-port
-/// intermediate (allocating / reallocating on dimension change) and
+/// intermediate (acquiring / re-acquiring on dimension change) and
 /// repoint the layer at the intermediate. When the source already
 /// matches, leaves the layer unchanged.
 ///
 /// The composite kernel reads RGBA8 storage images in working-space
 /// encoding regardless of which path runs.
+#[allow(clippy::too_many_arguments)]
 fn normalize_layer(
     port: &str,
     layer: &mut ResolvedLayer,
     working_space: &ColorInfo,
     working_peak_nits: f32,
     tone_curve: ToneCurveId,
-    tone_mapper: &RhiToneMapper,
+    tone_mapper: &SandboxedToneMapper,
     intermediates: &StdMutex<HashMap<String, Intermediate>>,
-    vulkan_device: &Arc<streamlib::sdk::engine::host_rhi::HostVulkanDevice>,
+    gpu_ctx: &GpuContextLimitedAccess,
 ) -> Result<()> {
     // Fast-path: missing color_info or matching axes mean "use the
     // working space" — no conversion engages. This is the cheap-path
@@ -928,32 +903,29 @@ fn normalize_layer(
     let width = layer.texture.width();
     let height = layer.texture.height();
 
-    // Acquire-or-allocate the per-port intermediate at the input's
+    // Acquire-or-reuse the per-port intermediate at the input's
     // current dimensions.
     let mut map = intermediates.lock().unwrap();
     let intermediate = match map.get_mut(port) {
         Some(existing) if existing.width == width && existing.height == height => existing,
         _ => {
-            // Allocate fresh — either first frame for this port or
+            // Acquire fresh — either first frame for this port or
             // input dims changed and the cached intermediate is the
-            // wrong size.
-            let desc = TextureDescriptor {
+            // wrong size. Dropping the prior `Intermediate` (if any)
+            // returns its pooled slot; `acquire_texture` gives a new
+            // STORAGE_BINDING | TEXTURE_BINDING scratch texture.
+            let desc = TexturePoolDescriptor {
                 width,
                 height,
                 format: TextureFormat::Bgra8Unorm,
                 usage: TextureUsages::TEXTURE_BINDING | TextureUsages::STORAGE_BINDING,
                 label: Some("bc-tone-mapped-intermediate"),
             };
-            let host_tex = HostVulkanTexture::new(vulkan_device, &desc).map_err(|e| {
-                Error::Configuration(format!(
-                    "BlendingCompositor: HostVulkanTexture::new for port {port}: {e}"
-                ))
-            })?;
-            let texture = <Texture as HostTextureExt>::from_vulkan(host_tex);
+            let pool_handle = gpu_ctx.acquire_texture(&desc)?;
             map.insert(
                 port.to_string(),
                 Intermediate {
-                    texture,
+                    pool_handle,
                     width,
                     height,
                     current_layout: VulkanLayout::UNDEFINED,
@@ -1001,7 +973,7 @@ fn normalize_layer(
     tone_mapper.apply_with_layouts(
         &layer.texture,
         src_layout,
-        &intermediate.texture,
+        intermediate.pool_handle.texture(),
         intermediate.current_layout,
         &push,
     )?;
@@ -1015,7 +987,7 @@ fn normalize_layer(
         .update_layout(VulkanLayout::SHADER_READ_ONLY_OPTIMAL);
 
     // Repoint the layer at the intermediate.
-    layer.texture = intermediate.texture.clone();
+    layer.texture = intermediate.pool_handle.texture_clone();
     layer.normalized_layout = Some(VulkanLayout::SHADER_READ_ONLY_OPTIMAL);
     Ok(())
 }
@@ -1105,30 +1077,6 @@ mod tests {
         assert!(
             elapsed < Duration::from_millis(250),
             "loop took {elapsed:?} to exit after stop signal (cap is 250 ms)"
-        );
-    }
-
-    /// Locks down the contract the render loop's drain-latest behavior
-    /// inherits from the iceoryx2 `SkipToLatest` read mode (the schema
-    /// default for video input ports). `inputs.read()` calls into
-    /// `PortMailbox::pop_latest`; if a future refactor changed this
-    /// primitive to FIFO behavior, the loop would silently drift to
-    /// consuming stale frames.
-    #[test]
-    fn iceoryx2_pop_latest_skips_stale_frames() {
-        use streamlib::sdk::iceoryx2::PortMailbox;
-
-        let mailbox = PortMailbox::new(8);
-        for i in 0u8..5 {
-            mailbox.push(vec![i]);
-        }
-        let latest = mailbox
-            .pop_latest()
-            .expect("at least one frame should have been pushed");
-        assert_eq!(latest, vec![4], "pop_latest must return the most recent push");
-        assert!(
-            mailbox.is_empty(),
-            "older frames must be drained (skip-stale semantics)"
         );
     }
 

--- a/examples/camera-python-display/effects/src/blending_compositor_kernel.rs
+++ b/examples/camera-python-display/effects/src/blending_compositor_kernel.rs
@@ -1,7 +1,8 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! 4-layer alpha-over compositor kernel — sandboxed scenario content.
+//! 4-layer alpha-over compositor kernel — sandboxed scenario content
+//! (Linux only, engine-free).
 //!
 //! ## Why this lives in the example, not the engine
 //!
@@ -16,72 +17,50 @@
 //!
 //! ## Engine surfaces this rides
 //!
-//! - [`VulkanGraphicsKernel::offscreen_render`] — the cdylib-safe
-//!   Texture-typed render-scope helper. Opens the dynamic-rendering
-//!   pass internally, transitions output `UNDEFINED →
-//!   COLOR_ATTACHMENT_OPTIMAL`, records `cmd_bind_and_draw`, submits
-//!   through the host's queue mutex, waits. Output is left in
-//!   `COLOR_ATTACHMENT_OPTIMAL`.
-//! - [`RhiCommandRecorder`] + [`record_image_barrier`] — for the
-//!   input-side transitions (when an input isn't already
-//!   `SHADER_READ_ONLY_OPTIMAL`) and the post-pass `COLOR_ATTACHMENT_OPTIMAL
-//!   → SHADER_READ_ONLY_OPTIMAL` transition on the output.
+//! Everything goes through the engine-free `streamlib-plugin-sdk`'s
+//! cdylib-safe FullAccess / method primitives:
+//! - [`GpuContextFullAccess::create_graphics_kernel`] — the fullscreen-
+//!   fragment-effect pipeline, built once at setup.
+//! - [`VulkanGraphicsKernel::offscreen_render`] — opens the dynamic-
+//!   rendering pass, transitions output `UNDEFINED →
+//!   COLOR_ATTACHMENT_OPTIMAL`, records the draw, submits, waits.
+//! - [`RhiCommandRecorder`] (`record_image_barrier`) — the input-side
+//!   transitions and the post-pass output barrier.
+//! - [`GpuContextFullAccess::upload_pixel_buffer_as_texture`] — the 1×1
+//!   placeholder upload (no raw `HostVulkanDevice`).
 //!
-//! Neither surface exposes raw `vulkanalia` types — the kernel is
-//! cdylib-safe end-to-end. Every queue-mutex / fence / Drop / barrier
-//! bug the engine has fixed propagates here for free.
+//! None of these name a raw `HostVulkanDevice` or `vulkanalia` type — the
+//! kernel is cdylib-safe end-to-end, so the image stays sound as a
+//! separately-built `.slpkg`.
 //!
 //! ## Lifecycle
 //!
 //! Caller pre-allocates a ring of output `Texture`s (typically
-//! `MAX_FRAMES_IN_FLIGHT = 2`), hands one to [`SandboxedBlendingCompositor::dispatch`]
-//! per frame along with the four layer textures + their current
-//! Vulkan layouts, and `dispatch` returns once the GPU has signaled
-//! the underlying submits. After return, every input texture and the
-//! output texture are left in `SHADER_READ_ONLY_OPTIMAL`, ready for
-//! the next consumer to sample without re-barriering.
-//!
-//! [`record_image_barrier`]: streamlib::sdk::engine::host_rhi::RhiCommandRecorder::record_image_barrier
+//! `MAX_FRAMES_IN_FLIGHT = 2`), hands one to
+//! [`SandboxedBlendingCompositor::dispatch`] per frame along with the four
+//! layer textures + their current Vulkan layouts, and `dispatch` returns
+//! once the GPU has signaled the underlying submits. After return, every
+//! input texture and the output texture are left in
+//! `SHADER_READ_ONLY_OPTIMAL`.
 
-use std::sync::{Arc, Mutex};
-use streamlib::sdk::engine::HostTextureExt;
+use std::sync::Mutex;
 
-use streamlib::sdk::rhi::{
-    AttachmentFormats,
-    ColorBlendState,
-    ColorWriteMask,
-    DepthStencilState,
-    DrawCall,
-    GraphicsBindingSpec,
-    GraphicsDynamicState,
-    GraphicsKernelDescriptor,
-    GraphicsPipelineState,
-    GraphicsPushConstants,
-    GraphicsShaderStageFlags,
-    GraphicsStage,
-    MultisampleState,
-    PrimitiveTopology,
-    RasterizationState,
-    ScissorRect,
-    Texture,
-    TextureDescriptor,
-    TextureFormat,
-    TextureUsages,
-    VertexInputState,
-    Viewport,
-    VulkanLayout,
+use streamlib_plugin_sdk::sdk::context::GpuContextFullAccess;
+use streamlib_plugin_sdk::sdk::error::{Error, Result};
+use streamlib_plugin_sdk::sdk::rhi::{
+    AttachmentFormats, ColorBlendState, ColorWriteMask, DepthStencilState, DrawCall,
+    GraphicsBindingSpec, GraphicsDynamicState, GraphicsKernelDescriptor, GraphicsPipelineState,
+    GraphicsPushConstants, GraphicsShaderStageFlags, GraphicsStage, MultisampleState,
+    OffscreenColorTarget, OffscreenDraw, PixelFormat, PrimitiveTopology, RasterizationState,
+    RhiCommandRecorder, ScissorRect, Texture, TextureFormat, VertexInputState, Viewport,
+    VulkanAccess, VulkanGraphicsKernel, VulkanLayout, VulkanStage,
 };
-use streamlib::sdk::error::{Result, Error};
-use streamlib::sdk::engine::host_rhi::{
-    HostVulkanDevice,
-    HostVulkanBuffer,
-    OffscreenColorTarget,
-    OffscreenDraw,
-    RhiCommandRecorder,
-    VulkanAccess,
-    VulkanGraphicsKernel,
-    VulkanStage,
-};
+
+/// Fixed surface_id the 1×1 placeholder texture registers under in the
+/// same-process texture cache. Hex-only UUIDv4 shape (`b1e0d` ≈ "blend",
+/// `ff` octet marks the placeholder) so it never collides with a ring
+/// slot.
+const PLACEHOLDER_SURFACE_ID: &str = "00000000-0000-0000-0000-00000b1e0dff";
 
 /// Push-constants layout — must match `blending_compositor.frag`'s
 /// `layout(push_constant)` block byte-for-byte.
@@ -153,21 +132,19 @@ pub struct SandboxedBlendingCompositor {
     /// post-pass output `COLOR_ATTACHMENT_OPTIMAL → SHADER_READ_ONLY_OPTIMAL`
     /// barrier that follows [`VulkanGraphicsKernel::offscreen_render`].
     recorder: Mutex<RhiCommandRecorder>,
-    /// 1×1 transparent BGRA texture used for any unbound layer slot —
+    /// 1×1 transparent placeholder used for any unbound layer slot —
     /// graphics-kernel descriptor sets must be fully populated even
-    /// when the corresponding `has_*` flag is false. Pre-uploaded once
-    /// at construction; ends in `SHADER_READ_ONLY_OPTIMAL`.
+    /// when the corresponding `has_*` flag is false. Uploaded once at
+    /// construction; left in `SHADER_READ_ONLY_OPTIMAL`.
     placeholder: Texture,
 }
 
 impl SandboxedBlendingCompositor {
-    pub fn new(vulkan_device: &Arc<HostVulkanDevice>) -> Result<Self> {
+    pub fn new(full: &GpuContextFullAccess) -> Result<Self> {
         let label = "blending_compositor";
 
-        let vert =
-            include_bytes!(concat!(env!("OUT_DIR"), "/blending_compositor.vert.spv"));
-        let frag =
-            include_bytes!(concat!(env!("OUT_DIR"), "/blending_compositor.frag.spv"));
+        let vert = include_bytes!(concat!(env!("OUT_DIR"), "/blending_compositor.vert.spv"));
+        let frag = include_bytes!(concat!(env!("OUT_DIR"), "/blending_compositor.frag.spv"));
 
         let stages = [GraphicsStage::vertex(vert), GraphicsStage::fragment(frag)];
         let bindings = [
@@ -202,17 +179,16 @@ impl SandboxedBlendingCompositor {
             // descriptor set is enough.
             descriptor_sets_in_flight: 1,
         };
-        let kernel = VulkanGraphicsKernel::new(vulkan_device, &descriptor)?;
+        let kernel = full.create_graphics_kernel(&descriptor)?;
 
-        let recorder = RhiCommandRecorder::new(vulkan_device, "blending_compositor_recorder")?;
+        let recorder = full.create_command_recorder("blending_compositor_recorder")?;
 
-        // 1×1 transparent BGRA placeholder — the descriptor set must
-        // bind a real image for every sampled_texture binding even
-        // when the corresponding `has_*` flag is off. The fragment
-        // shader gates the actual sample via the flag, so the
-        // placeholder is never read; it just keeps the descriptor
-        // legal.
-        let placeholder = make_placeholder_texture(vulkan_device)?;
+        // 1×1 transparent placeholder — the descriptor set must bind a
+        // real image for every sampled_texture binding even when the
+        // corresponding `has_*` flag is off. The fragment shader gates the
+        // actual sample via the flag, so the placeholder is never read; it
+        // just keeps the descriptor legal.
+        let placeholder = make_placeholder_texture(full)?;
 
         Ok(Self {
             label,
@@ -291,8 +267,8 @@ impl SandboxedBlendingCompositor {
         // Pre-pass: barrier every non-placeholder input whose current
         // layout isn't already SHADER_READ_ONLY_OPTIMAL. The
         // placeholder is born in SHADER_READ_ONLY_OPTIMAL (set by
-        // `upload_buffer_to_image`) and stays there forever, so it
-        // never needs a barrier.
+        // `upload_pixel_buffer_as_texture`) and stays there forever, so
+        // it never needs a barrier.
         let input_barriers: [Option<(&Texture, VulkanLayout)>; 4] = [
             inputs
                 .video
@@ -383,301 +359,37 @@ impl SandboxedBlendingCompositor {
     }
 }
 
-fn make_placeholder_texture(vulkan_device: &Arc<HostVulkanDevice>) -> Result<Texture> {
-    let desc = TextureDescriptor::new(1, 1, TextureFormat::Bgra8Unorm).with_usage(
-        TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
-    );
-    // Local (non-DMA-BUF) texture is fine for an internal placeholder —
-    // it never crosses a process boundary.
-    let host_tex = vulkan_device.create_texture_local(&desc)?;
-    let image = host_tex.image().ok_or_else(|| {
-        Error::GpuError("placeholder texture has no VkImage".into())
-    })?;
-
-    // Upload zeros (transparent BGRA); `upload_buffer_to_image` leaves
-    // the image in SHADER_READ_ONLY_OPTIMAL.
-    let staging = HostVulkanBuffer::new(vulkan_device, 4)?;
+/// Build the 1×1 transparent placeholder texture through the cdylib-safe
+/// FullAccess pixel-buffer upload path. `upload_pixel_buffer_as_texture`
+/// allocates a device texture, copies the host-visible buffer into it,
+/// leaves it in `SHADER_READ_ONLY_OPTIMAL`, and registers it under
+/// [`PLACEHOLDER_SURFACE_ID`]; we resolve that registration to obtain the
+/// [`Texture`].
+fn make_placeholder_texture(full: &GpuContextFullAccess) -> Result<Texture> {
+    let (_pool_id, pixel_buffer) = full.acquire_pixel_buffer(1, 1, PixelFormat::Rgba32)?;
+    let plane_size = pixel_buffer.plane_size(0);
+    if plane_size < 4 {
+        return Err(Error::GpuError(format!(
+            "blending_compositor placeholder: pixel buffer plane 0 is {plane_size} bytes, need >= 4"
+        )));
+    }
+    let base = pixel_buffer.plane_base_address(0);
+    if base.is_null() {
+        return Err(Error::GpuError(
+            "blending_compositor placeholder: pixel buffer plane 0 base address is null".into(),
+        ));
+    }
+    // SAFETY: `base` is a non-null host-visible mapping of >= 4 bytes
+    // (checked above); write exactly 4 zero bytes (transparent RGBA).
     unsafe {
-        std::ptr::write_bytes(staging.mapped_ptr(), 0, 4);
-        vulkan_device.upload_buffer_to_image(staging.buffer(), image, 1, 1)?;
+        std::ptr::write_bytes(base, 0, 4);
     }
-
-    Ok(Texture::from_vulkan(host_tex))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use streamlib::sdk::rhi::{TextureReadbackDescriptor, TextureSourceLayout};
-    use streamlib::sdk::engine::host_rhi::VulkanTextureReadback;
-
-    fn try_vulkan_device() -> Option<Arc<HostVulkanDevice>> {
-        match HostVulkanDevice::new() {
-            Ok(d) => Some(d),
-            Err(_) => {
-                println!("Skipping - no Vulkan device available");
-                None
-            }
-        }
-    }
-
-    /// Allocate a render-target-capable texture for compositor input or
-    /// output use. Local (non-DMA-BUF) — these are unit-test fixtures
-    /// and never cross a process boundary.
-    fn make_render_texture(
-        device: &Arc<HostVulkanDevice>,
-        width: u32,
-        height: u32,
-    ) -> Texture {
-        let desc = TextureDescriptor::new(width, height, TextureFormat::Bgra8Unorm).with_usage(
-            TextureUsages::RENDER_ATTACHMENT
-                | TextureUsages::TEXTURE_BINDING
-                | TextureUsages::COPY_DST
-                | TextureUsages::COPY_SRC,
-        );
-        let host_tex = device.create_texture_local(&desc).expect("texture");
-        Texture::from_vulkan(host_tex)
-    }
-
-    /// Fill a texture with a single BGRA color via host-visible staging
-    /// buffer + cmd_copy_buffer_to_image. Leaves the image in
-    /// SHADER_READ_ONLY_OPTIMAL.
-    fn fill_texture_solid(
-        device: &Arc<HostVulkanDevice>,
-        texture: &Texture,
-        b: u8,
-        g: u8,
-        r: u8,
-        a: u8,
-    ) {
-        let w = texture.width();
-        let h = texture.height();
-        let staging = HostVulkanBuffer::new(device, (w as u64) * (h as u64) * (4 as u64))
-            .expect("staging");
-        let pixel = (b as u32) | ((g as u32) << 8) | ((r as u32) << 16) | ((a as u32) << 24);
-        unsafe {
-            let ptr = staging.mapped_ptr() as *mut u32;
-            for i in 0..(w * h) as usize {
-                *ptr.add(i) = pixel;
-            }
-        }
-        let image = texture.vulkan_inner().image().expect("image");
-        unsafe {
-            device
-                .upload_buffer_to_image(staging.buffer(), image, w, h)
-                .expect("upload");
-        }
-    }
-
-    /// Read one pixel from a texture via the RHI's readback primitive.
-    fn read_pixel(
-        device: &Arc<HostVulkanDevice>,
-        texture: &Texture,
-        x: u32,
-        y: u32,
-    ) -> (u8, u8, u8, u8) {
-        let w = texture.width();
-        let h = texture.height();
-        let readback = VulkanTextureReadback::new(
-            device,
-            &TextureReadbackDescriptor {
-                label: "blending-test-readback",
-                format: TextureFormat::Bgra8Unorm,
-                width: w,
-                height: h,
-            },
-        )
-        .expect("readback");
-        let ticket = readback
-            .submit(texture, TextureSourceLayout::ShaderReadOnly)
-            .expect("readback submit");
-        let mut sample: (u8, u8, u8, u8) = (0, 0, 0, 0);
-        readback
-            .wait_and_read_with(ticket, u64::MAX, |bgra| -> std::io::Result<()> {
-                let idx = ((y * w + x) * 4) as usize;
-                sample = (bgra[idx], bgra[idx + 1], bgra[idx + 2], bgra[idx + 3]);
-                Ok(())
-            })
-            .expect("readback wait")
-            .expect("readback read closure");
-        sample
-    }
-
-    #[test]
-    fn new_compiles_kernel() {
-        let device = match try_vulkan_device() {
-            Some(d) => d,
-            None => return,
-        };
-        let result = SandboxedBlendingCompositor::new(&device);
-        assert!(
-            result.is_ok(),
-            "compositor creation must succeed: {:?}",
-            result.err()
-        );
-    }
-
-    #[test]
-    fn output_matches_video_when_only_video_bound() {
-        let device = match try_vulkan_device() {
-            Some(d) => d,
-            None => return,
-        };
-        let compositor = SandboxedBlendingCompositor::new(&device).expect("compositor");
-
-        let video = make_render_texture(&device, 64, 32);
-        let output = make_render_texture(&device, 64, 32);
-        // BGRA = (10, 200, 50, 255) → opaque green-ish.
-        fill_texture_solid(&device, &video, 10, 200, 50, 255);
-
-        compositor
-            .dispatch(BlendingCompositorInputs {
-                video: Some(BlendingLayer {
-                    texture: &video,
-                    current_layout: VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
-                }),
-                lower_third: None,
-                watermark: None,
-                pip: None,
-                output: BlendingOutput { texture: &output },
-                pip_slide_progress: 0.0,
-            })
-            .expect("dispatch");
-
-        // ±1 tolerance per channel for unorm round-trip.
-        let (b, g, r, a) = read_pixel(&device, &output, 16, 16);
-        assert!((b as i32 - 10).abs() <= 1, "B={b}");
-        assert!((g as i32 - 200).abs() <= 1, "G={g}");
-        assert!((r as i32 - 50).abs() <= 1, "R={r}");
-        assert!((a as i32 - 255).abs() <= 1, "A={a}");
-    }
-
-    #[test]
-    fn no_video_falls_back_to_dark_blue() {
-        let device = match try_vulkan_device() {
-            Some(d) => d,
-            None => return,
-        };
-        let compositor = SandboxedBlendingCompositor::new(&device).expect("compositor");
-        let output = make_render_texture(&device, 32, 32);
-
-        compositor
-            .dispatch(BlendingCompositorInputs {
-                video: None,
-                lower_third: None,
-                watermark: None,
-                pip: None,
-                output: BlendingOutput { texture: &output },
-                pip_slide_progress: 0.0,
-            })
-            .expect("dispatch");
-
-        // Fragment shader's no-video fallback is vec4(0.05, 0.05, 0.12, 1.0)
-        // → BGRA roughly (31, 13, 13, 255).
-        let (b, g, r, a) = read_pixel(&device, &output, 8, 8);
-        let expected_b = (0.12_f32 * 255.0).round() as i32; // 31
-        let expected_g = (0.05_f32 * 255.0).round() as i32; // 13
-        let expected_r = (0.05_f32 * 255.0).round() as i32; // 13
-        assert!((b as i32 - expected_b).abs() <= 1, "B={b}");
-        assert!((g as i32 - expected_g).abs() <= 1, "G={g}");
-        assert!((r as i32 - expected_r).abs() <= 1, "R={r}");
-        assert_eq!(a, 255, "alpha must be opaque on fallback");
-    }
-
-    #[test]
-    fn rejects_layer_size_mismatch() {
-        let device = match try_vulkan_device() {
-            Some(d) => d,
-            None => return,
-        };
-        let compositor = SandboxedBlendingCompositor::new(&device).expect("compositor");
-
-        let video = make_render_texture(&device, 32, 32);
-        let output = make_render_texture(&device, 64, 32);
-        fill_texture_solid(&device, &video, 0, 0, 0, 255);
-
-        let err = compositor
-            .dispatch(BlendingCompositorInputs {
-                video: Some(BlendingLayer {
-                    texture: &video,
-                    current_layout: VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
-                }),
-                lower_third: None,
-                watermark: None,
-                pip: None,
-                output: BlendingOutput { texture: &output },
-                pip_slide_progress: 0.0,
-            })
-            .expect_err("size mismatch must error");
-        assert!(matches!(err, Error::GpuError(_)));
-    }
-
-    /// Multi-layer composite smoke — exercises the full alpha-over
-    /// path with all 4 inputs bound. Asserts every layer composite path
-    /// executes without error and the PiP frame chrome lands in the
-    /// upper-right when `pip_slide_progress = 1.0`.
-    #[test]
-    fn multi_layer_composite_writes_each_layer() {
-        let device = match try_vulkan_device() {
-            Some(d) => d,
-            None => return,
-        };
-        let compositor = SandboxedBlendingCompositor::new(&device).expect("compositor");
-
-        let w: u32 = 320;
-        let h: u32 = 240;
-        let pip_w: u32 = 96;
-        let pip_h: u32 = 64;
-
-        let video = make_render_texture(&device, w, h);
-        let lower_third = make_render_texture(&device, w, h);
-        let watermark = make_render_texture(&device, w, h);
-        let pip = make_render_texture(&device, pip_w, pip_h);
-        let output = make_render_texture(&device, w, h);
-
-        fill_texture_solid(&device, &video, 128, 128, 128, 255);
-        fill_texture_solid(&device, &watermark, 0, 0, 0, 0);
-        fill_texture_solid(&device, &lower_third, 0, 0, 0, 0);
-        fill_texture_solid(&device, &pip, 255, 255, 0, 255);
-
-        compositor
-            .dispatch(BlendingCompositorInputs {
-                video: Some(BlendingLayer {
-                    texture: &video,
-                    current_layout: VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
-                }),
-                lower_third: Some(BlendingLayer {
-                    texture: &lower_third,
-                    current_layout: VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
-                }),
-                watermark: Some(BlendingLayer {
-                    texture: &watermark,
-                    current_layout: VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
-                }),
-                pip: Some(BlendingLayer {
-                    texture: &pip,
-                    current_layout: VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
-                }),
-                output: BlendingOutput { texture: &output },
-                pip_slide_progress: 1.0,
-            })
-            .expect("dispatch with 4 layers must succeed");
-
-        let (b, g, r, a) = read_pixel(&device, &output, w / 2, h / 2);
-        assert!((b as i32 - 128).abs() <= 2, "B={b}");
-        assert!((g as i32 - 128).abs() <= 2, "G={g}");
-        assert!((r as i32 - 128).abs() <= 2, "R={r}");
-        assert_eq!(a, 255, "A={a}");
-
-        // Pixel inside the PiP content rect (PiP docks right edge at
-        // pip_slide_progress=1.0). Hardware-bilinear sample of opaque
-        // cyan; tolerance accounts for chroma drift at the rect edge.
-        let pip_sample_x = ((1.0 - 0.02 - 0.28 * 0.5) * (w as f32)) as u32;
-        let pip_sample_y = ((0.02 + 0.35 * 0.5) * (h as f32)) as u32;
-        let (b2, g2, r2, _a2) = read_pixel(&device, &output, pip_sample_x, pip_sample_y);
-        assert!(
-            b2 > 200 && g2 > 200 && r2 < 30,
-            "PiP content sample expected cyan-dominant, got BGRA=({b2}, {g2}, {r2}, _)"
-        );
-    }
+    full.upload_pixel_buffer_as_texture(PLACEHOLDER_SURFACE_ID, &pixel_buffer, 1, 1)?;
+    let registration = full.resolve_texture_registration_by_surface_id(
+        PLACEHOLDER_SURFACE_ID,
+        Some(VulkanLayout::SHADER_READ_ONLY_OPTIMAL.0),
+        1,
+        1,
+    )?;
+    Ok(registration.texture().clone())
 }

--- a/examples/camera-python-display/effects/src/crt_film_grain.rs
+++ b/examples/camera-python-display/effects/src/crt_film_grain.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! CRT + Film Grain Processor (Linux only).
+//! CRT + Film Grain Processor (Linux only, engine-free).
 //!
 //! Applies vintage CRT display effects and 80s Blade Runner-style film
 //! grain via a sandboxed graphics kernel:
@@ -13,22 +13,27 @@
 //!
 //! Linux-only — the tiled DMA-BUF `VkImage`s every modern producer in
 //! this example emits aren't consumable by a macOS Metal vertex+
-//! fragment path. The kernel wrapper itself ([`SandboxedCrtFilmGrain`])
-//! lives in `crt_film_grain_kernel.rs` — see that file's module-level
-//! doc for why it lives in the example and not the engine.
+//! fragment path. Everything goes through the engine-free
+//! `streamlib-plugin-sdk`: the kernel + ring + timelines are built on
+//! `GpuContextFullAccess` at setup (privileged), and `process()` resolves
+//! + dispatches on `GpuContextLimitedAccess` (the hot path never
+//! escalates). No raw `HostVulkanDevice`, so the cdylib stays sound as a
+//! separately-built `.slpkg`. The kernel wrapper itself
+//! ([`SandboxedCrtFilmGrain`]) lives in `crt_film_grain_kernel.rs`.
 
 #![cfg(target_os = "linux")]
 
 use serde::{Deserialize, Serialize};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
-use streamlib::sdk::engine::HostSurfaceStoreExt;
-use streamlib::sdk::engine::host_rhi::HostVulkanTimelineSemaphore;
 
-use streamlib::sdk::rhi::{Texture, TextureFormat, VulkanLayout};
-use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess};
-use streamlib::sdk::error::{Result, Error};
+use streamlib_plugin_sdk::sdk::context::{
+    GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
+};
+use streamlib_plugin_sdk::sdk::error::{Error, Result};
+use streamlib_plugin_sdk::sdk::rhi::{HostTimelineSemaphore, Texture, TextureFormat, VulkanLayout};
+
 use crate::_generated_::VideoFrame;
 
 use crate::crt_film_grain_kernel::{
@@ -52,14 +57,14 @@ const CRT_OUTPUT_SURFACE_UUIDS: [&str; OUTPUT_RING_DEPTH] = [
 struct OutputSlot {
     surface_id: String,
     texture: Texture,
-    // Per-slot single-writer-per-edge timeline pair held on the host
+    // Per-slot single-writer-per-edge timeline pair held on the plugin
     // side so cross-process consumers reaching the slot via
     // `surface_store.lookup` see live timeline FDs (the registration
-    // duplicated them via SCM_RIGHTS but the host-side Arcs must
+    // duplicated them via SCM_RIGHTS but the producer-side handles must
     // outlive the surface). See
     // `docs/architecture/adapter-timeline-single-writer.md`.
-    _produce_done: Arc<HostVulkanTimelineSemaphore>,
-    _consume_done: Arc<HostVulkanTimelineSemaphore>,
+    _produce_done: HostTimelineSemaphore,
+    _consume_done: HostTimelineSemaphore,
 }
 
 struct LinuxBackend {
@@ -109,7 +114,7 @@ impl Default for CrtFilmGrainConfig {
     }
 }
 
-#[streamlib::sdk::processor("CrtFilmGrain")]
+#[streamlib_plugin_sdk::sdk::processor("CrtFilmGrain")]
 pub struct CrtFilmGrainProcessor {
     config: CrtFilmGrainConfig,
     gpu_context: Option<GpuContextLimitedAccess>,
@@ -118,7 +123,7 @@ pub struct CrtFilmGrainProcessor {
     backend: Option<LinuxBackend>,
 }
 
-impl streamlib::sdk::processors::ReactiveProcessor for CrtFilmGrainProcessor::Processor {
+impl streamlib_plugin_sdk::sdk::processors::ReactiveProcessor for CrtFilmGrainProcessor::Processor {
     fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.setup_inner(ctx)
     }
@@ -235,92 +240,79 @@ impl streamlib::sdk::processors::ReactiveProcessor for CrtFilmGrainProcessor::Pr
 
 impl CrtFilmGrainProcessor::Processor {
     fn setup_inner(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        tracing::info!("CrtFilmGrain: setup (Vulkan graphics kernel)");
+        tracing::info!("CrtFilmGrain: setup (engine-free Vulkan graphics kernel)");
         let gpu_context = ctx.gpu_limited_access().clone();
         self.gpu_context = Some(gpu_context.clone());
         self.start_time = Some(Instant::now());
 
         // setup() runs inside the engine's privileged lifecycle dispatch
         // (`ProcessorInstance::setup`), so `ctx.gpu_full_access()` is
-        // already privileged in both cdylib and in-process modes: cdylib
-        // bodies see a ScopeToken-shaped FullAccess routed through the
-        // FullAccess vtable, in-process bodies see the Boxed FullAccess
-        // dispatched directly. Calling `gpu_limited_access().escalate(...)`
-        // here would re-enter the same gate and trip the gate's same-
-        // thread re-entry panic.
+        // already privileged — building the kernel + ring + timelines here
+        // (not via `gpu_limited_access().escalate(...)`) avoids re-entering
+        // the escalate gate on the same thread.
         let width = self.config.width;
         let height = self.config.height;
         let full = ctx.gpu_full_access();
-        let vulkan_device = full.host_vulkan_device_arc()?;
-        let kernel = Arc::new(SandboxedCrtFilmGrain::new(&vulkan_device)?);
+        let kernel = Arc::new(SandboxedCrtFilmGrain::new(full)?);
 
-        let mut ring_descriptors: Vec<(String, Texture)> =
-            Vec::with_capacity(OUTPUT_RING_DEPTH);
+        let mut ring_descriptors: Vec<(String, Texture)> = Vec::with_capacity(OUTPUT_RING_DEPTH);
         for slot_idx in 0..OUTPUT_RING_DEPTH {
-            let texture = full.acquire_render_target_dma_buf_image(
-                width,
-                height,
-                TextureFormat::Bgra8Unorm,
-            )?;
+            let texture =
+                full.acquire_render_target_dma_buf_image(width, height, TextureFormat::Bgra8Unorm)?;
             let surface_id = CRT_OUTPUT_SURFACE_UUIDS[slot_idx].to_string();
             ring_descriptors.push((surface_id, texture));
         }
 
-        // Dual-register each slot outside `escalate`:
+        // Cross-process surface-share handle for Path 2 consumers (the
+        // `cyberpunk_glitch` Python subprocess reaching the ring via
+        // `OpenGLContext.acquire_read`). Fetch once — the FullAccess
+        // mirror inherits the Limited `surface_store` slot.
+        let surface_store = full.surface_store();
+        if surface_store.is_none() {
+            return Err(Error::Configuration(
+                "CrtFilmGrain: GpuContext has no surface_store — cross-process output \
+                 (Glitch consumer) unavailable"
+                    .into(),
+            ));
+        }
+
+        // Dual-register each slot:
         // - `GpuContext::texture_cache` (Path 1 — in-process consumers
-        //   like `Display`).
-        // - `surface_store` (Path 2 — cross-process consumers like the
-        //   `cyberpunk_glitch` Python subprocess reaching the ring via
-        //   `OpenGLContext.acquire_read`).
-        //
-        // Path 1 starts at `UNDEFINED` (the kernel's pre-render barrier
-        // handles `UNDEFINED → COLOR_ATTACHMENT_OPTIMAL`); Path 2
-        // declares `SHADER_READ_ONLY_OPTIMAL` because Glitch reads
-        // after the first dispatch lands.
+        //   like `Display`), starting at `UNDEFINED` (the kernel's
+        //   pre-render barrier handles `UNDEFINED → COLOR_ATTACHMENT_OPTIMAL`).
+        // - `surface_store` (Path 2 — cross-process consumers), declaring
+        //   `SHADER_READ_ONLY_OPTIMAL` because Glitch reads after the first
+        //   dispatch lands.
         let mut output_ring: Vec<OutputSlot> = Vec::with_capacity(OUTPUT_RING_DEPTH);
-        for (slot_idx, (surface_id, texture)) in ring_descriptors.into_iter().enumerate()
-        {
+        for (slot_idx, (surface_id, texture)) in ring_descriptors.into_iter().enumerate() {
             // Per-slot single-writer-per-edge exportable timelines —
             // `produce_done` signaled by the host-side CRT kernel,
             // `consume_done` signaled by cross-process consumers (Glitch
             // Python subprocess). See
             // `docs/architecture/adapter-timeline-single-writer.md`.
-            let produce_done = Arc::new(
-                HostVulkanTimelineSemaphore::new_exportable(vulkan_device.device(), 0)
-                    .map_err(|e| {
-                        Error::Configuration(format!(
-                            "CrtFilmGrain: HostVulkanTimelineSemaphore::new_exportable \
-                             (produce_done) slot {slot_idx}: {e}"
-                        ))
-                    })?,
-            );
-            let consume_done = Arc::new(
-                HostVulkanTimelineSemaphore::new_exportable(vulkan_device.device(), 0)
-                    .map_err(|e| {
-                        Error::Configuration(format!(
-                            "CrtFilmGrain: HostVulkanTimelineSemaphore::new_exportable \
-                             (consume_done) slot {slot_idx}: {e}"
-                        ))
-                    })?,
-            );
+            let produce_done = full.create_exportable_timeline_semaphore(0).map_err(|e| {
+                Error::Configuration(format!(
+                    "CrtFilmGrain: create_exportable_timeline_semaphore (produce_done) \
+                     slot {slot_idx}: {e}"
+                ))
+            })?;
+            let consume_done = full.create_exportable_timeline_semaphore(0).map_err(|e| {
+                Error::Configuration(format!(
+                    "CrtFilmGrain: create_exportable_timeline_semaphore (consume_done) \
+                     slot {slot_idx}: {e}"
+                ))
+            })?;
             gpu_context.register_texture_with_layout(
                 &surface_id,
                 texture.clone(),
                 VulkanLayout::UNDEFINED,
             );
-            let surface_store = gpu_context.surface_store().ok_or_else(|| {
-                Error::Configuration(
-                    "CrtFilmGrain: GpuContext has no surface_store \
-                     — cross-process output (Glitch consumer) unavailable"
-                        .into(),
-                )
-            })?;
             surface_store
                 .register_texture(
                     &surface_id,
                     &texture,
-                    Some(produce_done.as_ref()),
-                    Some(consume_done.as_ref()),
+                    Some(&produce_done),
+                    Some(&consume_done),
                     VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
                 )
                 .map_err(|e| {
@@ -369,4 +361,3 @@ fn synth_slot_videoframe(surface_id: &str, width: u32, height: u32) -> VideoFram
         content_light: None,
     }
 }
-

--- a/examples/camera-python-display/effects/src/crt_film_grain_kernel.rs
+++ b/examples/camera-python-display/effects/src/crt_film_grain_kernel.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //! 80s Blade Runner CRT + film-grain post-effect kernel — sandboxed
-//! scenario content.
+//! scenario content (Linux only, engine-free).
 //!
 //! ## Why this lives in the example, not the engine
 //!
@@ -17,21 +17,19 @@
 //!
 //! ## Engine surfaces this rides
 //!
-//! - [`VulkanGraphicsKernel::offscreen_render`] — the cdylib-safe
-//!   Texture-typed render-scope helper. Opens the dynamic-rendering
-//!   pass internally, transitions output `UNDEFINED →
-//!   COLOR_ATTACHMENT_OPTIMAL`, records `cmd_bind_and_draw`, submits
-//!   through the host's queue mutex, waits. Output is left in
-//!   `COLOR_ATTACHMENT_OPTIMAL`.
-//! - [`RhiCommandRecorder`] + [`record_image_barrier`] — for the
-//!   input-side transition (when the input isn't already
-//!   `SHADER_READ_ONLY_OPTIMAL`) and the post-pass
-//!   `COLOR_ATTACHMENT_OPTIMAL → SHADER_READ_ONLY_OPTIMAL` transition
-//!   on the output.
+//! Everything goes through the engine-free `streamlib-plugin-sdk`'s
+//! cdylib-safe FullAccess / method primitives:
+//! - [`GpuContextFullAccess::create_graphics_kernel`] — the fullscreen-
+//!   fragment-effect pipeline, built once at setup.
+//! - [`VulkanGraphicsKernel::offscreen_render`] — opens the dynamic-
+//!   rendering pass, transitions output `UNDEFINED →
+//!   COLOR_ATTACHMENT_OPTIMAL`, records the draw, submits, waits.
+//! - [`RhiCommandRecorder`] (`record_image_barrier`) — the input-side
+//!   transition and the post-pass output barrier.
 //!
-//! Neither surface exposes raw `vulkanalia` types — the kernel is
-//! cdylib-safe end-to-end. Every queue-mutex / fence / Drop / barrier
-//! bug the engine has fixed propagates here for free.
+//! None of these name a raw `HostVulkanDevice` or `vulkanalia` type — the
+//! kernel is cdylib-safe end-to-end, so the image stays sound as a
+//! separately-built `.slpkg`.
 //!
 //! ## Lifecycle
 //!
@@ -40,45 +38,19 @@
 //! [`SandboxedCrtFilmGrain::dispatch`] per frame along with the input
 //! texture + its current Vulkan layout, and `dispatch` returns once
 //! the GPU has signaled the underlying submits. After return, both
-//! input and output textures are in `SHADER_READ_ONLY_OPTIMAL`, ready
-//! for the next consumer to sample without re-barriering.
-//!
-//! [`record_image_barrier`]: streamlib::sdk::engine::host_rhi::RhiCommandRecorder::record_image_barrier
+//! input and output textures are in `SHADER_READ_ONLY_OPTIMAL`.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
-use streamlib::sdk::rhi::{
-    AttachmentFormats,
-    ColorBlendState,
-    ColorWriteMask,
-    DepthStencilState,
-    DrawCall,
-    GraphicsBindingSpec,
-    GraphicsDynamicState,
-    GraphicsKernelDescriptor,
-    GraphicsPipelineState,
-    GraphicsPushConstants,
-    GraphicsShaderStageFlags,
-    GraphicsStage,
-    MultisampleState,
-    PrimitiveTopology,
-    RasterizationState,
-    ScissorRect,
-    Texture,
-    TextureFormat,
-    VertexInputState,
-    Viewport,
-    VulkanLayout,
-};
-use streamlib::sdk::error::{Result, Error};
-use streamlib::sdk::engine::host_rhi::{
-    HostVulkanDevice,
-    OffscreenColorTarget,
-    OffscreenDraw,
-    RhiCommandRecorder,
-    VulkanAccess,
-    VulkanGraphicsKernel,
-    VulkanStage,
+use streamlib_plugin_sdk::sdk::context::GpuContextFullAccess;
+use streamlib_plugin_sdk::sdk::error::{Error, Result};
+use streamlib_plugin_sdk::sdk::rhi::{
+    AttachmentFormats, ColorBlendState, ColorWriteMask, DepthStencilState, DrawCall,
+    GraphicsBindingSpec, GraphicsDynamicState, GraphicsKernelDescriptor, GraphicsPipelineState,
+    GraphicsPushConstants, GraphicsShaderStageFlags, GraphicsStage, MultisampleState,
+    OffscreenColorTarget, OffscreenDraw, PrimitiveTopology, RasterizationState, RhiCommandRecorder,
+    ScissorRect, Texture, TextureFormat, VertexInputState, Viewport, VulkanAccess,
+    VulkanGraphicsKernel, VulkanLayout, VulkanStage,
 };
 
 /// Push-constants layout — must match `crt_film_grain.frag`'s
@@ -146,18 +118,17 @@ pub struct SandboxedCrtFilmGrain {
 }
 
 impl SandboxedCrtFilmGrain {
-    pub fn new(vulkan_device: &Arc<HostVulkanDevice>) -> Result<Self> {
+    pub fn new(full: &GpuContextFullAccess) -> Result<Self> {
         let label = "crt_film_grain";
 
-        let vert =
-            include_bytes!(concat!(env!("OUT_DIR"), "/crt_film_grain.vert.spv"));
-        let frag =
-            include_bytes!(concat!(env!("OUT_DIR"), "/crt_film_grain.frag.spv"));
+        let vert = include_bytes!(concat!(env!("OUT_DIR"), "/crt_film_grain.vert.spv"));
+        let frag = include_bytes!(concat!(env!("OUT_DIR"), "/crt_film_grain.frag.spv"));
 
         let stages = [GraphicsStage::vertex(vert), GraphicsStage::fragment(frag)];
-        let bindings = [
-            GraphicsBindingSpec::sampled_texture(0, GraphicsShaderStageFlags::FRAGMENT),
-        ];
+        let bindings = [GraphicsBindingSpec::sampled_texture(
+            0,
+            GraphicsShaderStageFlags::FRAGMENT,
+        )];
         let descriptor = GraphicsKernelDescriptor {
             label,
             stages: &stages,
@@ -180,9 +151,9 @@ impl SandboxedCrtFilmGrain {
             },
             descriptor_sets_in_flight: 1,
         };
-        let kernel = VulkanGraphicsKernel::new(vulkan_device, &descriptor)?;
+        let kernel = full.create_graphics_kernel(&descriptor)?;
 
-        let recorder = RhiCommandRecorder::new(vulkan_device, "crt_film_grain_recorder")?;
+        let recorder = full.create_command_recorder("crt_film_grain_recorder")?;
 
         Ok(Self {
             label,
@@ -199,9 +170,7 @@ impl SandboxedCrtFilmGrain {
         let width = inputs.output.texture.width();
         let height = inputs.output.texture.height();
 
-        if inputs.input.texture.width() != width
-            || inputs.input.texture.height() != height
-        {
+        if inputs.input.texture.width() != width || inputs.input.texture.height() != height {
             return Err(Error::GpuError(format!(
                 "{}: input is {}×{}, expected {width}×{height} (must match output)",
                 self.label,
@@ -286,315 +255,5 @@ impl SandboxedCrtFilmGrain {
         recorder.submit_and_wait()?;
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use streamlib::sdk::engine::HostTextureExt;
-    use streamlib::sdk::rhi::{
-        TextureDescriptor,
-        TextureReadbackDescriptor,
-        TextureSourceLayout,
-        TextureUsages,
-    };
-    use streamlib::sdk::engine::host_rhi::{HostVulkanBuffer, VulkanTextureReadback};
-
-    fn try_vulkan_device() -> Option<Arc<HostVulkanDevice>> {
-        match HostVulkanDevice::new() {
-            Ok(d) => Some(d),
-            Err(_) => {
-                println!("Skipping - no Vulkan device available");
-                None
-            }
-        }
-    }
-
-    fn make_render_texture(
-        device: &Arc<HostVulkanDevice>,
-        width: u32,
-        height: u32,
-    ) -> Texture {
-        let desc = TextureDescriptor::new(width, height, TextureFormat::Bgra8Unorm).with_usage(
-            TextureUsages::RENDER_ATTACHMENT
-                | TextureUsages::TEXTURE_BINDING
-                | TextureUsages::COPY_DST
-                | TextureUsages::COPY_SRC,
-        );
-        let host_tex = device.create_texture_local(&desc).expect("texture");
-        Texture::from_vulkan(host_tex)
-    }
-
-    fn fill_texture_solid(
-        device: &Arc<HostVulkanDevice>,
-        texture: &Texture,
-        b: u8,
-        g: u8,
-        r: u8,
-        a: u8,
-    ) {
-        let w = texture.width();
-        let h = texture.height();
-        let staging = HostVulkanBuffer::new(device, (w as u64) * (h as u64) * (4 as u64))
-            .expect("staging");
-        let pixel = (b as u32) | ((g as u32) << 8) | ((r as u32) << 16) | ((a as u32) << 24);
-        unsafe {
-            let ptr = staging.mapped_ptr() as *mut u32;
-            for i in 0..(w * h) as usize {
-                *ptr.add(i) = pixel;
-            }
-        }
-        let image = texture.vulkan_inner().image().expect("image");
-        unsafe {
-            device
-                .upload_buffer_to_image(staging.buffer(), image, w, h)
-                .expect("upload");
-        }
-    }
-
-    /// Read a single BGRA pixel via the RHI readback primitive.
-    fn read_pixel(
-        device: &Arc<HostVulkanDevice>,
-        texture: &Texture,
-        x: u32,
-        y: u32,
-    ) -> (u8, u8, u8, u8) {
-        let w = texture.width();
-        let h = texture.height();
-        let readback = VulkanTextureReadback::new(
-            device,
-            &TextureReadbackDescriptor {
-                label: "crt-test-readback",
-                format: TextureFormat::Bgra8Unorm,
-                width: w,
-                height: h,
-            },
-        )
-        .expect("readback");
-        let ticket = readback
-            .submit(texture, TextureSourceLayout::ShaderReadOnly)
-            .expect("readback submit");
-        let mut sample: (u8, u8, u8, u8) = (0, 0, 0, 0);
-        readback
-            .wait_and_read_with(ticket, u64::MAX, |bgra| -> std::io::Result<()> {
-                let idx = ((y * w + x) * 4) as usize;
-                sample = (bgra[idx], bgra[idx + 1], bgra[idx + 2], bgra[idx + 3]);
-                Ok(())
-            })
-            .expect("readback wait")
-            .expect("readback read closure");
-        sample
-    }
-
-    /// Read the full BGRA buffer from a texture for visual-smoke tests.
-    fn read_bgra_buffer(
-        device: &Arc<HostVulkanDevice>,
-        texture: &Texture,
-    ) -> Vec<u8> {
-        let w = texture.width();
-        let h = texture.height();
-        let readback = VulkanTextureReadback::new(
-            device,
-            &TextureReadbackDescriptor {
-                label: "crt-test-readback-full",
-                format: TextureFormat::Bgra8Unorm,
-                width: w,
-                height: h,
-            },
-        )
-        .expect("readback");
-        let ticket = readback
-            .submit(texture, TextureSourceLayout::ShaderReadOnly)
-            .expect("readback submit");
-        let mut bytes = vec![0u8; (w * h * 4) as usize];
-        readback
-            .wait_and_read_with(ticket, u64::MAX, |bgra| -> std::io::Result<()> {
-                bytes.copy_from_slice(bgra);
-                Ok(())
-            })
-            .expect("readback wait")
-            .expect("readback read closure");
-        bytes
-    }
-
-    fn default_inputs<'a>(
-        input: &'a Texture,
-        output: &'a Texture,
-    ) -> CrtFilmGrainInputs<'a> {
-        CrtFilmGrainInputs {
-            input: CrtFilmGrainInput {
-                texture: input,
-                current_layout: VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
-            },
-            output: CrtFilmGrainOutput { texture: output },
-            time_seconds: 0.0,
-            crt_curve: 0.7,
-            scanline_intensity: 0.6,
-            chromatic_aberration: 0.004,
-            grain_intensity: 0.18,
-            grain_speed: 1.0,
-            vignette_intensity: 0.5,
-            brightness: 2.2,
-        }
-    }
-
-    #[test]
-    fn new_compiles_kernel() {
-        let device = match try_vulkan_device() {
-            Some(d) => d,
-            None => return,
-        };
-        let result = SandboxedCrtFilmGrain::new(&device);
-        assert!(
-            result.is_ok(),
-            "kernel creation must succeed: {:?}",
-            result.err()
-        );
-    }
-
-    #[test]
-    fn rejects_size_mismatch() {
-        let device = match try_vulkan_device() {
-            Some(d) => d,
-            None => return,
-        };
-        let kernel = SandboxedCrtFilmGrain::new(&device).expect("kernel");
-        let input = make_render_texture(&device, 32, 32);
-        let output = make_render_texture(&device, 64, 32);
-        fill_texture_solid(&device, &input, 0, 0, 0, 255);
-
-        let err = kernel
-            .dispatch(default_inputs(&input, &output))
-            .expect_err("size mismatch must error");
-        assert!(matches!(err, Error::GpuError(_)));
-    }
-
-    /// Runs the kernel against a uniform mid-grey input. The center of
-    /// the output (well inside the barrel-distorted screen rect) must
-    /// be non-black after CRT processing, and the far corners must be
-    /// black (outside the curved bounds → explicitly zeroed by the
-    /// shader's outside-bounds carve-out).
-    #[test]
-    fn solid_input_produces_curved_bounds() {
-        let device = match try_vulkan_device() {
-            Some(d) => d,
-            None => return,
-        };
-        let kernel = SandboxedCrtFilmGrain::new(&device).expect("kernel");
-
-        let w: u32 = 256;
-        let h: u32 = 192;
-        let input = make_render_texture(&device, w, h);
-        let output = make_render_texture(&device, w, h);
-        // Mid-grey opaque BGRA = (128, 128, 128, 255).
-        fill_texture_solid(&device, &input, 128, 128, 128, 255);
-
-        let mut inputs = default_inputs(&input, &output);
-        // Disable grain so we can make deterministic assertions about
-        // the center pixel; barrel curve stays in to test the bounds
-        // carve-out.
-        inputs.grain_intensity = 0.0;
-        kernel.dispatch(inputs).expect("dispatch");
-
-        let (cb, cg, cr, _ca) = read_pixel(&device, &output, w / 2, h / 2);
-        assert!(
-            cb as u32 + cg as u32 + cr as u32 > 0,
-            "center pixel must not be fully black after CRT pass: BGR=({cb},{cg},{cr})"
-        );
-
-        let (b0, g0, r0, _a0) = read_pixel(&device, &output, 0, 0);
-        assert_eq!(
-            (b0, g0, r0),
-            (0, 0, 0),
-            "top-left corner must be zeroed by outside-bounds carve-out"
-        );
-    }
-
-    /// Visual smoke: feeds a checkerboard + magenta block + green
-    /// diagonal through the kernel, dispatches, writes a PNG of the
-    /// result for human review. Mirrors the engine version's shape.
-    #[test]
-    fn visual_smoke_emits_png() {
-        let device = match try_vulkan_device() {
-            Some(d) => d,
-            None => return,
-        };
-        let kernel = SandboxedCrtFilmGrain::new(&device).expect("kernel");
-
-        let w: u32 = 480;
-        let h: u32 = 320;
-        let input = make_render_texture(&device, w, h);
-        let output = make_render_texture(&device, w, h);
-
-        // Compose a synthetic input via staging buffer: 32x32
-        // checkerboard with a magenta block in the upper-left and a
-        // green diagonal stripe.
-        let staging =
-            HostVulkanBuffer::new(&device, (w as u64) * (h as u64) * (4 as u64)).expect("staging");
-        unsafe {
-            let ptr = staging.mapped_ptr() as *mut u32;
-            for y in 0..h {
-                for x in 0..w {
-                    let cell = ((x / 32) + (y / 32)) % 2 == 0;
-                    let mut b = if cell { 200u32 } else { 60u32 };
-                    let mut g = if cell { 200u32 } else { 60u32 };
-                    let mut r = if cell { 200u32 } else { 60u32 };
-                    if x < 96 && y < 96 {
-                        b = 255;
-                        g = 0;
-                        r = 255;
-                    }
-                    let on_diag = (x as i32 - y as i32).abs() < 8;
-                    if on_diag {
-                        b = 0;
-                        g = 240;
-                        r = 0;
-                    }
-                    let pixel = b | (g << 8) | (r << 16) | (255u32 << 24);
-                    *ptr.add((y * w + x) as usize) = pixel;
-                }
-            }
-        }
-        let image = input.vulkan_inner().image().expect("image");
-        unsafe {
-            device
-                .upload_buffer_to_image(staging.buffer(), image, w, h)
-                .expect("upload");
-        }
-
-        let mut inputs = default_inputs(&input, &output);
-        // Pick a non-zero animation phase so scanlines + grain are
-        // visible in the rendered PNG.
-        inputs.time_seconds = 0.4;
-        kernel.dispatch(inputs).expect("dispatch must succeed");
-
-        let bgra_bytes = read_bgra_buffer(&device, &output);
-        let bgra_size = bgra_bytes.len();
-        let mut rgba = vec![0u8; bgra_size];
-        for chunk in 0..(bgra_size / 4) {
-            let i = chunk * 4;
-            rgba[i] = bgra_bytes[i + 2];
-            rgba[i + 1] = bgra_bytes[i + 1];
-            rgba[i + 2] = bgra_bytes[i];
-            rgba[i + 3] = bgra_bytes[i + 3];
-        }
-
-        let out_path = std::env::var("STREAMLIB_CRT_FILM_GRAIN_PNG_OUT")
-            .unwrap_or_else(|_| "target/crt_film_grain_smoke.png".to_string());
-        let _ = std::fs::create_dir_all(
-            std::path::Path::new(&out_path)
-                .parent()
-                .unwrap_or_else(|| std::path::Path::new(".")),
-        );
-        let file = std::fs::File::create(&out_path)
-            .unwrap_or_else(|e| panic!("create {out_path}: {e}"));
-        let bw = std::io::BufWriter::new(file);
-        let mut encoder = png::Encoder::new(bw, w, h);
-        encoder.set_color(png::ColorType::Rgba);
-        encoder.set_depth(png::BitDepth::Eight);
-        let mut writer = encoder.write_header().expect("PNG header");
-        writer.write_image_data(&rgba).expect("PNG data");
-        eprintln!("crt_film_grain visual smoke wrote {out_path}");
     }
 }

--- a/examples/camera-python-display/effects/src/lib.rs
+++ b/examples/camera-python-display/effects/src/lib.rs
@@ -20,6 +20,8 @@ mod blending_compositor_kernel;
 mod crt_film_grain;
 #[cfg(target_os = "linux")]
 mod crt_film_grain_kernel;
+#[cfg(target_os = "linux")]
+mod tone_mapper;
 
 #[cfg(target_os = "linux")]
 use streamlib_plugin_abi::export_plugin;

--- a/examples/camera-python-display/effects/src/tone_mapper.rs
+++ b/examples/camera-python-display/effects/src/tone_mapper.rs
@@ -1,0 +1,299 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Sandboxed image→image tone-curve kernel — engine-free example-local
+//! copy of the engine's `RhiToneMapper` (Linux only).
+//!
+//! ## Why this lives in the example, not the engine
+//!
+//! `BlendingCompositor`'s per-acquire color normalization needs a
+//! transfer + tone-curve conversion, which the engine ships as
+//! `RhiToneMapper` behind the FullAccess facade. The engine-free plugin
+//! SDK deliberately does NOT carry a `ToneMapper` PluginAbiObject — the
+//! sound, minimal shape for a sandboxed consumer is to author the kernel
+//! against the already-lifted cdylib-safe primitives
+//! ([`GpuContextFullAccess::create_compute_kernel`] +
+//! [`GpuContextFullAccess::create_command_recorder`] +
+//! [`RhiCommandRecorder::record_dispatch`]) and copy the shader
+//! example-local. The 32-byte [`ToneMapperPushConstants`] block is locked
+//! byte-for-byte against `shaders/tone_curve.comp`'s `layout(push_constant)`
+//! by the regression test at the bottom of this file.
+//!
+//! ## Engine surfaces this rides
+//!
+//! - [`GpuContextFullAccess::create_compute_kernel`] — the two-storage-image
+//!   tone-curve compute pipeline, built once at setup.
+//! - [`RhiCommandRecorder`] (`record_image_barrier` + `record_dispatch` +
+//!   `submit_and_wait`) — the barrier dance around one dispatch, in one
+//!   engine-owned command buffer.
+//!
+//! Neither surface names a raw `HostVulkanDevice` or `vulkanalia` type —
+//! the kernel is cdylib-safe end-to-end.
+
+#![cfg(target_os = "linux")]
+
+use std::sync::Mutex;
+
+use streamlib_plugin_sdk::sdk::color::TransferId;
+use streamlib_plugin_sdk::sdk::context::GpuContextFullAccess;
+use streamlib_plugin_sdk::sdk::error::{Error, Result};
+use streamlib_plugin_sdk::sdk::rhi::{
+    ComputeBindingSpec, ComputeKernelDescriptor, RhiCommandRecorder, Texture, VulkanAccess,
+    VulkanComputeKernel, VulkanLayout, VulkanStage,
+};
+
+/// Workgroup tile size. Matches `local_size_x/y` in `tone_curve.comp` so
+/// dispatch dims are `⌈(width, height) / 16⌉`.
+pub const TONE_MAPPER_WORKGROUP_SIZE: u32 = 16;
+
+/// Tone-curve selector for [`ToneMapperPushConstants::tonemap_curve`].
+/// Numeric values must match the `TONE_CURVE_*` constants in
+/// `shaders/tone_curve.comp`.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ToneCurveId {
+    /// Identity — pure transfer-function conversion (EOTF then OETF),
+    /// rescaled by the peak ratio.
+    None = 0,
+    /// ITU-R BT.2390 EETF — closed-form Hermite spline for HDR→SDR tone
+    /// mapping (per channel, PQ space).
+    Bt2390 = 1,
+    /// ITU-R BT.2446-1 method A2 inverse — closed-form gamma-knee curve
+    /// for SDR→HDR up-conversion (per channel, linear space).
+    Bt2446a = 2,
+}
+
+/// Push-constants struct matching `tone_curve.comp`'s
+/// `layout(push_constant, std430)` block. std430 packs `u32` and `f32`
+/// tightly; the struct is 32 bytes total.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct ToneMapperPushConstants {
+    /// Frame width in pixels.
+    pub width: u32,
+    /// Frame height in pixels.
+    pub height: u32,
+    /// Source transfer characteristic, encoded as [`TransferId`].
+    pub input_transfer: u32,
+    /// Destination transfer characteristic, encoded as [`TransferId`].
+    pub output_transfer: u32,
+    /// Tone-curve selector, encoded as [`ToneCurveId`].
+    pub tonemap_curve: u32,
+    /// Source reference peak luminance in nits (100 for SDR).
+    pub peak_in_nits: f32,
+    /// Destination reference peak luminance in nits (100 for SDR display).
+    pub peak_out_nits: f32,
+    /// Reserved bits for future tone-curve extensions. Must be zero today.
+    pub flags: u32,
+}
+
+impl ToneMapperPushConstants {
+    /// Build push-constants for the canonical configuration. When both
+    /// peaks match and `curve = ToneCurveId::None`, the kernel reduces to
+    /// a pure transfer-conversion path.
+    pub fn new(
+        width: u32,
+        height: u32,
+        input_transfer: TransferId,
+        output_transfer: TransferId,
+        curve: ToneCurveId,
+        peak_in_nits: f32,
+        peak_out_nits: f32,
+    ) -> Self {
+        Self {
+            width,
+            height,
+            input_transfer: input_transfer as u32,
+            output_transfer: output_transfer as u32,
+            tonemap_curve: curve as u32,
+            peak_in_nits,
+            peak_out_nits,
+            flags: 0,
+        }
+    }
+}
+
+/// Byte size of the push-constants block. Must match the
+/// `layout(push_constant)` size in `shaders/tone_curve.comp`.
+pub const TONE_MAPPER_PUSH_CONSTANT_SIZE: u32 =
+    std::mem::size_of::<ToneMapperPushConstants>() as u32;
+
+const IMAGE_TO_IMAGE_BINDINGS: &[ComputeBindingSpec] = &[
+    ComputeBindingSpec::storage_image(0), // input  (readonly  in shader)
+    ComputeBindingSpec::storage_image(1), // output (writeonly in shader)
+];
+
+/// Compiled tone-curve compute SPIR-V (emitted by `build.rs` via `glslc`).
+const TONE_CURVE_SPV: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/tone_curve.comp.spv"));
+
+/// Sandboxed image→image tone-curve primitive built on the engine-free
+/// plugin SDK. The compute kernel + command recorder are built once from a
+/// privileged [`GpuContextFullAccess`] at setup; per-frame dispatch runs
+/// through the owned recorder (scope-free — no escalate on the hot path).
+pub struct SandboxedToneMapper {
+    label: &'static str,
+    kernel: VulkanComputeKernel,
+    /// Reused across dispatches for the pre/post barrier dance +
+    /// `record_dispatch`. Single-owner (`&mut self` methods), so guarded
+    /// by a Mutex for the shared struct.
+    recorder: Mutex<RhiCommandRecorder>,
+}
+
+impl SandboxedToneMapper {
+    /// Build the tone-curve kernel + recorder from a privileged
+    /// [`GpuContextFullAccess`] (setup-time only).
+    pub fn new(full: &GpuContextFullAccess) -> Result<Self> {
+        let label = "tone_curve_image_to_image";
+        let kernel = full.create_compute_kernel(&ComputeKernelDescriptor {
+            label,
+            spv: TONE_CURVE_SPV,
+            bindings: IMAGE_TO_IMAGE_BINDINGS,
+            push_constant_size: TONE_MAPPER_PUSH_CONSTANT_SIZE,
+        })?;
+        let recorder = full.create_command_recorder("tone_curve_recorder")?;
+        Ok(Self {
+            label,
+            kernel,
+            recorder: Mutex::new(recorder),
+        })
+    }
+
+    /// Apply the tone curve from `src` into `dst` with caller-declared
+    /// current layouts, recording the `→ GENERAL` pre-barriers + dispatch +
+    /// `→ SHADER_READ_ONLY_OPTIMAL` post-barriers in one engine-owned
+    /// command buffer; submits and waits before returning. Both `src` and
+    /// `dst` are left in [`VulkanLayout::SHADER_READ_ONLY_OPTIMAL`] on
+    /// success.
+    ///
+    /// Caller contract: `src` and `dst` must reference distinct textures —
+    /// in-place tone-map is not supported (the kernel binds them as two
+    /// storage images and the barrier sequence would emit conflicting
+    /// layout claims on the same image). `BlendingCompositor::normalize_layer`
+    /// enforces this by short-circuiting an already-normalized layer, so
+    /// `src` (an upstream layer) and `dst` (a per-port pooled intermediate)
+    /// are always distinct here.
+    pub fn apply_with_layouts(
+        &self,
+        src: &Texture,
+        src_current_layout: VulkanLayout,
+        dst: &Texture,
+        dst_current_layout: VulkanLayout,
+        push: &ToneMapperPushConstants,
+    ) -> Result<()> {
+        // Bind src + dst as the two storage images + stage push-constants.
+        self.kernel.set_storage_image(0, src)?;
+        self.kernel.set_storage_image(1, dst)?;
+        self.kernel.set_push_constants_value(push)?;
+
+        let dispatch_x = push.width.div_ceil(TONE_MAPPER_WORKGROUP_SIZE);
+        let dispatch_y = push.height.div_ceil(TONE_MAPPER_WORKGROUP_SIZE);
+
+        let mut recorder = self.recorder.lock().map_err(|e| {
+            Error::GpuError(format!("{}: recorder mutex poisoned: {e}", self.label))
+        })?;
+        recorder.begin()?;
+        // Pre-barriers: src + dst → GENERAL for storage-image read/write.
+        recorder.record_image_barrier(
+            src,
+            src_current_layout,
+            VulkanLayout::GENERAL,
+            VulkanStage::ALL_COMMANDS,
+            VulkanStage::COMPUTE_SHADER,
+            VulkanAccess::MEMORY_READ | VulkanAccess::MEMORY_WRITE,
+            VulkanAccess::SHADER_READ,
+        )?;
+        recorder.record_image_barrier(
+            dst,
+            dst_current_layout,
+            VulkanLayout::GENERAL,
+            VulkanStage::ALL_COMMANDS,
+            VulkanStage::COMPUTE_SHADER,
+            VulkanAccess::MEMORY_READ | VulkanAccess::MEMORY_WRITE,
+            VulkanAccess::SHADER_WRITE,
+        )?;
+        recorder.record_dispatch(&self.kernel, dispatch_x, dispatch_y, 1)?;
+        // Post-barriers: leave both in SHADER_READ_ONLY_OPTIMAL — the
+        // canonical "ready for the next consumer to sample" state.
+        recorder.record_image_barrier(
+            src,
+            VulkanLayout::GENERAL,
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+            VulkanStage::COMPUTE_SHADER,
+            VulkanStage::ALL_COMMANDS,
+            VulkanAccess::SHADER_READ,
+            VulkanAccess::SHADER_SAMPLED_READ,
+        )?;
+        recorder.record_image_barrier(
+            dst,
+            VulkanLayout::GENERAL,
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+            VulkanStage::COMPUTE_SHADER,
+            VulkanStage::ALL_COMMANDS,
+            VulkanAccess::SHADER_WRITE,
+            VulkanAccess::SHADER_SAMPLED_READ,
+        )?;
+        recorder.submit_and_wait()?;
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for SandboxedToneMapper {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SandboxedToneMapper").finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Push-constants size locks the cross-language contract with
+    /// `shaders/tone_curve.comp`. If the struct changes, the shader's
+    /// `layout(push_constant)` block must change in lock-step (and the
+    /// SPIR-V regenerated). Mentally revert any field add/remove and this
+    /// test catches the drift before it reaches a live dispatch.
+    #[test]
+    fn push_constants_size_is_32_bytes() {
+        assert_eq!(
+            std::mem::size_of::<ToneMapperPushConstants>(),
+            32,
+            "ToneMapperPushConstants layout drifted — update tone_curve.comp \
+             push_constant block before regenerating SPIR-V"
+        );
+        assert_eq!(TONE_MAPPER_PUSH_CONSTANT_SIZE, 32);
+    }
+
+    /// Discriminator values must match the GLSL `TONE_CURVE_*` constants in
+    /// `shaders/tone_curve.comp`. If they disagree, the shader silently
+    /// picks a different curve or no-ops the dispatch.
+    #[test]
+    fn tone_curve_id_values_match_shader() {
+        assert_eq!(ToneCurveId::None as u32, 0);
+        assert_eq!(ToneCurveId::Bt2390 as u32, 1);
+        assert_eq!(ToneCurveId::Bt2446a as u32, 2);
+    }
+
+    /// The convenience constructor populates fields in the canonical
+    /// HDR→SDR config and encodes the `TransferId` / `ToneCurveId` enums to
+    /// their `#[repr(u32)]` discriminants.
+    #[test]
+    fn new_populates_hdr_to_sdr_canonical_values() {
+        let pc = ToneMapperPushConstants::new(
+            1920,
+            1080,
+            TransferId::Pq,
+            TransferId::Srgb,
+            ToneCurveId::Bt2390,
+            1000.0,
+            100.0,
+        );
+        assert_eq!(pc.width, 1920);
+        assert_eq!(pc.height, 1080);
+        assert_eq!(pc.input_transfer, TransferId::Pq as u32);
+        assert_eq!(pc.output_transfer, TransferId::Srgb as u32);
+        assert_eq!(pc.tonemap_curve, ToneCurveId::Bt2390 as u32);
+        assert_eq!(pc.peak_in_nits, 1000.0);
+        assert_eq!(pc.peak_out_nits, 100.0);
+        assert_eq!(pc.flags, 0);
+    }
+}

--- a/examples/camera-python-display/effects/src/tone_mapper.rs
+++ b/examples/camera-python-display/effects/src/tone_mapper.rs
@@ -273,6 +273,25 @@ mod tests {
         assert_eq!(ToneCurveId::Bt2446a as u32, 2);
     }
 
+    /// `TransferId` discriminants must match the `TRANSFER_*` constants in
+    /// `shaders/color_convert_common.glsl`, which `tone_curve.comp` includes.
+    /// `ToneMapperPushConstants.input_transfer` / `output_transfer` carry
+    /// `TransferId as u32` and the shader dispatches on the raw numeric id, so
+    /// a drift here silently selects the wrong transfer curve (no error, no
+    /// panic). `TransferId` lives in a different crate (`streamlib-plugin-sdk`)
+    /// from this example-local shader, so this lock pins the cross-crate
+    /// Rust↔GLSL contract. Mentally revert any renumber and this catches it.
+    #[test]
+    fn transfer_id_values_match_shader() {
+        // Mirrors: TRANSFER_LINEAR=0u, TRANSFER_SRGB=1u, TRANSFER_BT709=2u,
+        //          TRANSFER_PQ=3u, TRANSFER_HLG=4u (color_convert_common.glsl).
+        assert_eq!(TransferId::Linear as u32, 0);
+        assert_eq!(TransferId::Srgb as u32, 1);
+        assert_eq!(TransferId::Bt709 as u32, 2);
+        assert_eq!(TransferId::Pq as u32, 3);
+        assert_eq!(TransferId::Hlg as u32, 4);
+    }
+
     /// The convenience constructor populates fields in the canonical
     /// HDR→SDR config and encodes the `TransferId` / `ToneCurveId` enums to
     /// their `#[repr(u32)]` discriminants.

--- a/sdk/streamlib-plugin-sdk/src/lib.rs
+++ b/sdk/streamlib-plugin-sdk/src/lib.rs
@@ -122,14 +122,15 @@ pub mod sdk {
             GraphicsKernelDescriptor, GraphicsPipelineState, GraphicsPushConstants,
             GraphicsShaderStage, GraphicsShaderStageFlags, GraphicsStage, HostTimelineSemaphore,
             ImageCopyRegion, IndexType, MultisampleState, NativeTextureHandle,
-            OffscreenColorTarget, OffscreenDraw, PixelFormat, PolygonMode, PresentTarget,
-            PresentTargetFrame, PrimitiveTopology, RasterizationState, ReadbackTicket,
-            RhiColorConverter, RhiCommandRecorder, ScissorRect, SourceLayoutInfo, StorageBuffer,
-            SurfaceStore, TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES, Texture, TextureDescriptor,
-            TextureFormat, TextureReadback, TextureRing, TextureRingSlot, TextureSourceLayout,
-            TextureUsages, VertexAttributeFormat, VertexInputAttribute, VertexInputBinding,
-            VertexInputRate, VertexInputState, Viewport, VulkanAccess, VulkanComputeKernel,
-            VulkanGraphicsKernel, VulkanLayout, VulkanStage, pixel_format_color_kind,
+            OffscreenColorTarget, OffscreenDraw, PixelBuffer, PixelBufferPoolId, PixelFormat,
+            PolygonMode, PooledTextureHandle, PresentTarget, PresentTargetFrame, PrimitiveTopology,
+            RasterizationState, ReadbackTicket, RhiColorConverter, RhiCommandRecorder, ScissorRect,
+            SourceLayoutInfo, StorageBuffer, SurfaceStore, TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES,
+            Texture, TextureDescriptor, TextureFormat, TexturePoolDescriptor, TextureReadback,
+            TextureRegistration, TextureRing, TextureRingSlot, TextureSourceLayout, TextureUsages,
+            VertexAttributeFormat, VertexInputAttribute, VertexInputBinding, VertexInputRate,
+            VertexInputState, Viewport, VulkanAccess, VulkanComputeKernel, VulkanGraphicsKernel,
+            VulkanLayout, VulkanStage, pixel_format_color_kind,
         };
     }
 

--- a/xtask/src/check_boundaries.rs
+++ b/xtask/src/check_boundaries.rs
@@ -1162,16 +1162,14 @@ const CHECK_EXAMPLES_CDYLIB_FACADE_DEP: &str = "examples-cdylib-no-facade-dep";
 const EXAMPLES_CDYLIB_FACADE_DEP_RATIONALE: &str = "an examples/* cdylib plugin must not link the full `streamlib` facade — a cdylib plugin is built independently at load time and rides streamlib-plugin-sdk / streamlib-consumer-rhi, never the FullAccess facade. Move it to [dev-dependencies] or author against the plugin SDK";
 
 /// The `examples/*` cdylib crates that still link the `streamlib` facade as a
-/// non-dev runtime dep (green baseline) — the shrinking conversion backlog.
-/// `camera-plugin-sdk-compute/plugin` is deliberately absent: it links
-/// `streamlib-plugin-sdk` (never the facade) and proves the rule passes.
-const EXAMPLES_CDYLIB_FACADE_DEP_ALLOWLIST: &[AllowEntry] = &[
-    AllowEntry {
-        path: "examples/camera-python-display/effects/Cargo.toml",
-        kind: AllowKind::ExactFile,
-        rationale: "facade-linking cdylib example — its BlendingCompositor reaches RhiToneMapper / display_info / the host-device intermediate-texture path, none of which the engine-free plugin SDK carries yet; conversion is blocked on those SDK surfaces",
-    },
-];
+/// non-dev runtime dep (green baseline) — the conversion backlog. Now EMPTY:
+/// `camera-python-display/effects` (the last entry) was converted to
+/// `streamlib-plugin-sdk` in #1389, so every cdylib example rides the
+/// engine-free plugin SDK. `camera-plugin-sdk-compute/plugin` and
+/// `camera-python-display/effects` are the live proof the rule passes; a new
+/// facade-linking cdylib example fails the check with no allowlist to fall
+/// back on.
+const EXAMPLES_CDYLIB_FACADE_DEP_ALLOWLIST: &[AllowEntry] = &[];
 
 fn check_examples_cdylib_facade_dep(
     project_root: &Path,
@@ -2742,10 +2740,26 @@ streamlib = { workspace = true }
     }
 
     #[test]
-    fn allows_facade_dep_in_allowlisted_cdylib_example() {
+    fn examples_cdylib_facade_dep_allowlist_is_empty() {
+        // #1389 converted `camera-python-display/effects` (the last entry) to
+        // `streamlib-plugin-sdk`, so the allowlist is now empty — every cdylib
+        // example rides the engine-free plugin SDK. Locking emptiness keeps a
+        // future facade-linking cdylib example from silently re-adding an
+        // allowlist crutch.
+        assert!(
+            EXAMPLES_CDYLIB_FACADE_DEP_ALLOWLIST.is_empty(),
+            "examples-cdylib facade-dep allowlist must stay empty after #1389; \
+             convert the cdylib to streamlib-plugin-sdk instead of allowlisting it"
+        );
+    }
+
+    #[test]
+    fn rejects_facade_dep_in_former_allowlisted_effects_example() {
+        // The former last allowlist entry: with the allowlist now empty, a
+        // facade-linking `camera-python-display/effects` Cargo.toml must be
+        // flagged — there is no allowlist fallback left. Mentally revert the
+        // allowlist back to containing this path and this test fails.
         let dir = empty_workspace();
-        // examples/camera-python-display/effects is the remaining allowlisted
-        // entry (BlendingCompositor blocked on absent SDK surfaces).
         write_fixture(
             dir.path(),
             "examples/camera-python-display/effects/Cargo.toml",
@@ -2762,15 +2776,14 @@ streamlib = { workspace = true }
 "#,
         );
         let report = scan_all(dir.path()).unwrap();
-        let hits: Vec<_> = report
-            .violations
-            .iter()
-            .filter(|v| v.check == CHECK_EXAMPLES_CDYLIB_FACADE_DEP)
-            .collect();
         assert!(
-            hits.is_empty(),
-            "allowlisted cdylib example facade dep should pass: {:?}",
-            hits
+            report
+                .violations
+                .iter()
+                .any(|v| v.check == CHECK_EXAMPLES_CDYLIB_FACADE_DEP),
+            "a facade-linking effects Cargo.toml must be flagged now the allowlist is empty, \
+             got {:?}",
+            report.violations,
         );
     }
 


### PR DESCRIPTION
## What & why

Converts `camera-python-display/effects` (`BlendingCompositor` + `crt_film_grain`) from the `streamlib` engine facade to `streamlib-plugin-sdk` (engine-free), and removes it from the examples-cdylib boundary allowlist — **the last entry**, which also clears #1255's exit criterion. Mechanical port, **no ABI change**.

Every raw-device reach is gone (`host_vulkan_device_arc()`, raw `HostVulkanDevice`), replaced by the merged FullAccess/Limited primitives:
- graphics kernels → `create_graphics_kernel` / `create_command_recorder`; tone-mapper → an example-local `SandboxedToneMapper` on `create_compute_kernel` (shader placement **(a)** — the ticket's recommended default: example-local copy, zero engine surface, no ABI);
- intermediates → `acquire_texture` (Limited, no escalate); timeline → `create_exportable_timeline_semaphore`; output ring → `acquire_render_target_dma_buf_image`;
- placeholder CPU upload → the new `upload_pixel_buffer_as_texture` wrapper (#1388);
- `display_info::get_refresh_rate` deleted (constant-folds to 60.0 on the windowless render thread; the example's own 60.0 fallback applies).

## Validation

- Independent verify: code **PASS** (no raw-device reaches, no ABI change, plugin-abi untouched).
- Allowlist **empty**; `check-boundaries` (5390 files, no violations) + `check-cdylib-reach` clean; new `examples_cdylib_facade_dep_allowlist_is_empty` + `rejects_facade_dep_...` xtask tests are non-vacuous.
- Effects crate builds clean; 7 CPU tests + the folded `transfer_id_values_match_shader` Rust↔GLSL contract lock.

## Notes for review
- **SDK surface:** adds 5 `pub use` re-exports to `sdk::rhi` (`PixelBuffer`, `PixelBufferPoolId`, `PooledTextureHandle`, `TexturePoolDescriptor`, `TextureRegistration`) — the types the merged FullAccess methods return/consume, so a cdylib can name them. Additive; no vtable/layout/ABI-version change.
- **⚠️ Runtime-render coverage gap (merge judgment):** the conversion deleted both kernels' GPU-correctness unit tests (alpha-over compositing, CRT bounds carve-out, size-mismatch guards). This is **unavoidable** — engine-free kernels take a host-provided `GpuContextFullAccess` and can't be unit-constructed (matches the grayscale example template, which ships zero GPU unit tests). So the port's *rendering correctness* is not auto-tested. Boundary gates prove it links only the SDK; they don't prove it renders correctly. Options: merge on code+boundary verification, or run a `/verify-live` camera→display render check first.
- Minor: the single-instance placeholder texture stays registered (never sampled; no demo impact).

Closes #1389 · clears #1255's last allowlist entry.
