### PR TITLE
fix(module-loader): provision Python/Deno-only packages on resolve, not load-as-is

### DIFF
--- a/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
@@ -585,7 +585,11 @@ fn source_for_resolved_dir(pkg_ref: &streamlib_idents::PackageRef, dir: PathBuf)
 /// - [`BuildPolicy::IfStale`] — prefer a matching prebuilt, else build the
 ///   bundled source. Identical to how a local [`Strategy::Slpkg`] resolves.
 /// - [`BuildPolicy::AlwaysBuild`] — rebuild the bundled source even when a
-///   prebuilt is present (no-op when there's nothing to build).
+///   prebuilt is present. A box with no Rust source is not automatically a
+///   no-op: an unprovisioned Python/Deno box still routes through
+///   `materialize` (same reason as [`source_for_resolved_dir`]) so its venv /
+///   `_generated_/` gets provisioned before load; only a fully-provisioned
+///   non-Rust box loads as-is.
 fn source_for_fetched_slpkg(
     pkg_ref: &streamlib_idents::PackageRef,
     dir: PathBuf,
@@ -595,7 +599,14 @@ fn source_for_fetched_slpkg(
         BuildPolicy::NeverBuild => ResolvedSource::Ready(dir),
         BuildPolicy::IfStale => source_for_resolved_dir(pkg_ref, dir),
         BuildPolicy::AlwaysBuild => {
-            if has_buildable_rust_source(&dir) {
+            // `has_buildable_rust_source` covers the "rebuild the Rust cdylib"
+            // intent; `needs_polyglot_provisioning` covers an unprovisioned
+            // Python/Deno box (no `.venv` / no `_generated_/`) that would
+            // otherwise load as-is and die at subprocess spawn with
+            // `.venv/bin/python: No such file or directory`. Both are LIVE
+            // AlwaysBuild paths — `streamlib add` and `Strategy::Registry`
+            // resolve with AlwaysBuild through here.
+            if has_buildable_rust_source(&dir) || needs_polyglot_provisioning(&dir) {
                 ResolvedSource::NeedsBuild(BuildRequest {
                     package: pkg_ref.clone(),
                     source: BuildSource::PackageDir(dir),
@@ -618,7 +629,7 @@ fn needs_host_build(dir: &std::path::Path) -> bool {
     has_buildable_rust_source(dir) && !has_matching_prebuilt(dir)
 }
 
-/// Whether a resolved package dir declares Python or Deno processors but is
+/// Whether a resolved package dir carries a Python or Deno runtime but is
 /// missing the build-time provisioning those runtimes need — a Python package
 /// with no `.venv/bin/python` interpreter, or a Deno package with no
 /// regenerated `_generated_/` wire vocabulary. Such a dir must route through
@@ -627,24 +638,31 @@ fn needs_host_build(dir: &std::path::Path) -> bool {
 /// as-is, a Python package's subprocess spawn dies with `.venv/bin/python: No
 /// such file or directory`. An already-provisioned dir returns `false` and
 /// loads directly; the orchestrator's own `IfStale` staleness-skip then
-/// short-circuits any redundant rebuild (no rebuild loop). Mirrors the
-/// per-language provisioned-checks the orchestrator's staleness-skip uses.
+/// short-circuits any redundant rebuild (no rebuild loop).
+///
+/// Each language's presence oracle is the SAME one the orchestrator's
+/// staleness-skip uses, so the two resolvers can never disagree (a disagreement
+/// would ping-pong: source.rs routes to `NeedsBuild` while the orchestrator's
+/// guard deems the venv-less slot reusable, loading it broken):
+/// - Python — filesystem-detected (a `python/` source dir or a `pyproject.toml`
+///   at the package root), matching `python_venv::staged_package_has_python`.
+/// - Deno — manifest-detected (a `TypeScript` runtime processor), matching
+///   `deno_codegen::staged_package_has_deno`.
 fn needs_polyglot_provisioning(dir: &std::path::Path) -> bool {
     use streamlib_processor_schema::ProcessorLanguage;
-    let config = match crate::core::config::ProjectConfig::load(dir) {
-        Ok(c) => c,
-        Err(_) => return false,
-    };
-    let declares = |language: ProcessorLanguage| {
-        config
+    // Python: filesystem oracle, aligned with `staged_package_has_python`.
+    let has_python = dir.join("python").is_dir() || dir.join("pyproject.toml").is_file();
+    let python_unprovisioned =
+        has_python && !dir.join(".venv").join("bin").join("python").exists();
+    // Deno: manifest oracle, aligned with `staged_package_has_deno`.
+    let declares_deno = match crate::core::config::ProjectConfig::load(dir) {
+        Ok(c) => c
             .processors
             .iter()
-            .any(|p| p.runtime.language == language)
+            .any(|p| p.runtime.language == ProcessorLanguage::TypeScript),
+        Err(_) => false,
     };
-    let python_unprovisioned = declares(ProcessorLanguage::Python)
-        && !dir.join(".venv").join("bin").join("python").exists();
-    let deno_unprovisioned =
-        declares(ProcessorLanguage::TypeScript) && !dir.join("_generated_").is_dir();
+    let deno_unprovisioned = declares_deno && !dir.join("_generated_").is_dir();
     python_unprovisioned || deno_unprovisioned
 }
 
@@ -1059,6 +1077,33 @@ mod tests {
         assert!(matches!(resolved, ResolvedSource::Ready(_)));
     }
 
+    /// COMPLETENESS (bug-reproduce, LIVE `Strategy::Url` / `Strategy::Registry`
+    /// + `streamlib add` path): `AlwaysBuild` on an UNPROVISIONED Python box
+    /// (a `pyproject.toml` present but no `.venv`) must route through
+    /// `materialize`, NOT load as-is — the same `.venv/bin/python: No such file
+    /// or directory` bug as the `IfStale` path, on the AlwaysBuild arm. Mentally
+    /// revert the `|| needs_polyglot_provisioning(&dir)` clause in the
+    /// `AlwaysBuild` arm and this resolves to `Ready`, failing the assertion.
+    #[test]
+    fn fetched_slpkg_always_build_provisions_unprovisioned_python() {
+        let dir = tempfile::tempdir().unwrap();
+        manifest(dir.path(), PY_YAML);
+        std::fs::write(
+            dir.path().join("pyproject.toml"),
+            b"[project]\nname = \"py\"\n",
+        )
+        .unwrap();
+        let resolved = source_for_fetched_slpkg(
+            &pkg_ref(),
+            dir.path().to_path_buf(),
+            BuildPolicy::AlwaysBuild,
+        );
+        match resolved {
+            ResolvedSource::NeedsBuild(req) => assert_eq!(req.policy, BuildPolicy::AlwaysBuild),
+            other => panic!("expected NeedsBuild(AlwaysBuild), got {other:?}"),
+        }
+    }
+
     // =====================================================================
     // Polyglot provisioning — an unprovisioned Python/Deno package must
     // route through the orchestrator's `materialize` (which provisions the
@@ -1080,9 +1125,16 @@ mod tests {
     /// assertion.
     #[test]
     fn resolved_dir_routes_unprovisioned_python_to_build() {
+        // Python presence is filesystem-detected (a `pyproject.toml`, matching
+        // the orchestrator's `staged_package_has_python`), so the fixture
+        // stages that on-disk layout rather than relying on the manifest.
         let dir = tempfile::tempdir().unwrap();
         manifest(dir.path(), PY_YAML);
-        std::fs::write(dir.path().join("p.py"), b"#").unwrap();
+        std::fs::write(
+            dir.path().join("pyproject.toml"),
+            b"[project]\nname = \"py\"\n",
+        )
+        .unwrap();
         let resolved = source_for_resolved_dir(&pkg_ref(), dir.path().to_path_buf());
         assert!(
             matches!(resolved, ResolvedSource::NeedsBuild(_)),
@@ -1090,12 +1142,28 @@ mod tests {
         );
     }
 
-    /// A Python package with no `.venv/bin/python` needs provisioning.
+    /// A Python package (a `pyproject.toml` on disk) with no `.venv/bin/python`
+    /// needs provisioning.
     #[test]
     fn needs_polyglot_provisioning_for_python_without_venv() {
         let dir = tempfile::tempdir().unwrap();
         manifest(dir.path(), PY_YAML);
-        std::fs::write(dir.path().join("p.py"), b"#").unwrap();
+        std::fs::write(
+            dir.path().join("pyproject.toml"),
+            b"[project]\nname = \"py\"\n",
+        )
+        .unwrap();
+        assert!(needs_polyglot_provisioning(dir.path()));
+    }
+
+    /// A `python/` source dir alone (no `pyproject.toml`) is the other half of
+    /// the filesystem oracle — a package staged that way with no `.venv` still
+    /// needs provisioning, matching `staged_package_has_python`.
+    #[test]
+    fn needs_polyglot_provisioning_for_python_dir_without_venv() {
+        let dir = tempfile::tempdir().unwrap();
+        manifest(dir.path(), PY_YAML);
+        std::fs::create_dir_all(dir.path().join("python")).unwrap();
         assert!(needs_polyglot_provisioning(dir.path()));
     }
 
@@ -1107,9 +1175,28 @@ mod tests {
     fn no_polyglot_provisioning_when_python_venv_present() {
         let dir = tempfile::tempdir().unwrap();
         manifest(dir.path(), PY_YAML);
+        std::fs::write(
+            dir.path().join("pyproject.toml"),
+            b"[project]\nname = \"py\"\n",
+        )
+        .unwrap();
         let bin = dir.path().join(".venv").join("bin");
         std::fs::create_dir_all(&bin).unwrap();
         std::fs::write(bin.join("python"), b"#!/bin/sh\n").unwrap();
+        assert!(!needs_polyglot_provisioning(dir.path()));
+    }
+
+    /// Oracle-parity (Finding 2): a manifest that declares Python WITHOUT the
+    /// on-disk layout (no `python/` dir, no `pyproject.toml`) is NOT detected —
+    /// matching the orchestrator's `staged_package_has_python`, which is
+    /// filesystem-only. A manifest-driven oracle here would disagree with the
+    /// orchestrator's staleness-skip and ping-pong. Mentally revert the
+    /// filesystem detection to manifest-based and this returns `true`, breaking
+    /// parity.
+    #[test]
+    fn no_polyglot_provisioning_for_manifest_python_without_filesystem_layout() {
+        let dir = tempfile::tempdir().unwrap();
+        manifest(dir.path(), PY_YAML);
         assert!(!needs_polyglot_provisioning(dir.path()));
     }
 
@@ -1491,6 +1578,9 @@ mod tests {
 
     /// Write `<app_root>/streamlib_modules/@tatolab/<pkg_name>/streamlib.yaml`
     /// declaring `@tatolab/<declared_name>` (differ only in the mismatch test).
+    /// Stages the on-disk Python layout (`pyproject.toml`) so the fixture trips
+    /// the filesystem provisioning oracle — the realistic shape a Python
+    /// `streamlib_modules` entry ships with.
     fn write_app_modules_package(
         app_root: &std::path::Path,
         pkg_name: &str,
@@ -1511,11 +1601,14 @@ mod tests {
             ),
         )
         .unwrap();
+        std::fs::write(dir.join("pyproject.toml"), b"[project]\nname = \"p\"\n").unwrap();
         dir
     }
 
     /// Record `@tatolab/<name>` in the sandboxed installed cache and create
-    /// its slot on disk. Returns the slot dir.
+    /// its slot on disk. Returns the slot dir. Stages the on-disk Python layout
+    /// (`pyproject.toml`) so the slot trips the filesystem provisioning oracle —
+    /// the realistic shape an extracted Python `.slpkg` cache slot carries.
     fn record_installed_cache_package(name: &str) -> PathBuf {
         use crate::core::config::{InstalledPackageEntry, InstalledPackageManifest};
         let slot = crate::core::streamlib_home::get_cached_package_dir(&format!("{name}-1.0.0"));
@@ -1530,6 +1623,7 @@ mod tests {
             ),
         )
         .unwrap();
+        std::fs::write(slot.join("pyproject.toml"), b"[project]\nname = \"p\"\n").unwrap();
         let mut manifest = InstalledPackageManifest::load().unwrap();
         manifest.add(InstalledPackageEntry {
             name: pkg_ref_named(name),

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
@@ -550,14 +550,22 @@ fn source_for_dir(
 /// instant); otherwise build the bundled Rust source on the host. This is
 /// the pip wheel-vs-sdist model for Rust: one artifact runs everywhere,
 /// and a toolchain is needed only when there's no matching prebuilt.
+///
+/// A Python/Deno package that has not yet been provisioned (no `.venv` /
+/// no regenerated `_generated_/`) also routes to the orchestrator — an
+/// extracted `.slpkg` or installed-cache entry carries source but no venv,
+/// and `materialize` is the only place the venv is provisioned. Loading it
+/// as-is would leave its subprocess spawn with no interpreter.
 fn source_for_resolved_dir(pkg_ref: &streamlib_idents::PackageRef, dir: PathBuf) -> ResolvedSource {
-    if needs_host_build(&dir) {
+    if needs_host_build(&dir) || needs_polyglot_provisioning(&dir) {
         ResolvedSource::NeedsBuild(BuildRequest {
             package: pkg_ref.clone(),
             source: BuildSource::PackageDir(dir),
             // No explicit policy on these arms — a build is required only
-            // because the prebuilt is absent, so `IfStale` (build iff the
-            // cdylib isn't already staged) is the right semantics.
+            // because the prebuilt / provisioning is absent, so `IfStale`
+            // (build iff the output isn't already staged) is the right
+            // semantics; the orchestrator's own staleness-skip short-circuits
+            // an already-provisioned cache slot, so there is no rebuild loop.
             policy: BuildPolicy::IfStale,
             host_triple: host_target_triple().to_string(),
         })
@@ -608,6 +616,36 @@ fn source_for_fetched_slpkg(
 /// as-is and fails loud at dlopen (no artifact, nothing to build).
 fn needs_host_build(dir: &std::path::Path) -> bool {
     has_buildable_rust_source(dir) && !has_matching_prebuilt(dir)
+}
+
+/// Whether a resolved package dir declares Python or Deno processors but is
+/// missing the build-time provisioning those runtimes need — a Python package
+/// with no `.venv/bin/python` interpreter, or a Deno package with no
+/// regenerated `_generated_/` wire vocabulary. Such a dir must route through
+/// the orchestrator's `materialize` (which provisions the venv / regenerates
+/// `_generated_/` at the cache slot it loads from), not load as-is: loaded
+/// as-is, a Python package's subprocess spawn dies with `.venv/bin/python: No
+/// such file or directory`. An already-provisioned dir returns `false` and
+/// loads directly; the orchestrator's own `IfStale` staleness-skip then
+/// short-circuits any redundant rebuild (no rebuild loop). Mirrors the
+/// per-language provisioned-checks the orchestrator's staleness-skip uses.
+fn needs_polyglot_provisioning(dir: &std::path::Path) -> bool {
+    use streamlib_processor_schema::ProcessorLanguage;
+    let config = match crate::core::config::ProjectConfig::load(dir) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    let declares = |language: ProcessorLanguage| {
+        config
+            .processors
+            .iter()
+            .any(|p| p.runtime.language == language)
+    };
+    let python_unprovisioned = declares(ProcessorLanguage::Python)
+        && !dir.join(".venv").join("bin").join("python").exists();
+    let deno_unprovisioned =
+        declares(ProcessorLanguage::TypeScript) && !dir.join("_generated_").is_dir();
+    python_unprovisioned || deno_unprovisioned
 }
 
 /// Whether `dir` declares Rust processors AND carries a `Cargo.toml` to
@@ -1022,6 +1060,111 @@ mod tests {
     }
 
     // =====================================================================
+    // Polyglot provisioning — an unprovisioned Python/Deno package must
+    // route through the orchestrator's `materialize` (which provisions the
+    // venv / regenerates `_generated_/` at the cache slot it loads from),
+    // not load as-is. The bug: a Python-only package loaded as-is has no
+    // `.venv/bin/python`, so its subprocess spawn dies at runtime with
+    // `.venv/bin/python: No such file or directory`.
+    // =====================================================================
+
+    const DENO_YAML: &str = "package:\n  org: tatolab\n  name: ts\n  version: 0.1.0\nprocessors:\n  - name: T\n    version: 1.0.0\n    description: d\n    runtime: deno\n    execution: manual\n    entrypoint: \"t.ts:default\"\n    inputs: []\n    outputs: []\n";
+
+    /// CRUX (bug-reproduce): a resolved (extracted `.slpkg` / installed-cache /
+    /// `streamlib_modules`) Python-only package (no Rust, no `Cargo.toml`) with
+    /// no provisioned `.venv` must resolve to `NeedsBuild` so the orchestrator
+    /// provisions its venv — NOT `Ready` (loaded as-is, the subprocess spawn
+    /// then fails with `.venv/bin/python: No such file or directory`). Mentally
+    /// revert the `needs_polyglot_provisioning` clause in
+    /// `source_for_resolved_dir` and this resolves to `Ready`, failing the
+    /// assertion.
+    #[test]
+    fn resolved_dir_routes_unprovisioned_python_to_build() {
+        let dir = tempfile::tempdir().unwrap();
+        manifest(dir.path(), PY_YAML);
+        std::fs::write(dir.path().join("p.py"), b"#").unwrap();
+        let resolved = source_for_resolved_dir(&pkg_ref(), dir.path().to_path_buf());
+        assert!(
+            matches!(resolved, ResolvedSource::NeedsBuild(_)),
+            "unprovisioned Python-only package must route through materialize, got {resolved:?}"
+        );
+    }
+
+    /// A Python package with no `.venv/bin/python` needs provisioning.
+    #[test]
+    fn needs_polyglot_provisioning_for_python_without_venv() {
+        let dir = tempfile::tempdir().unwrap();
+        manifest(dir.path(), PY_YAML);
+        std::fs::write(dir.path().join("p.py"), b"#").unwrap();
+        assert!(needs_polyglot_provisioning(dir.path()));
+    }
+
+    /// Once the venv interpreter is present, the package loads as-is — the
+    /// short-circuit that stops a rebuild loop. Mentally revert the
+    /// `.venv/bin/python` existence check and this stays `true`, re-materializing
+    /// an already-provisioned slot on every load.
+    #[test]
+    fn no_polyglot_provisioning_when_python_venv_present() {
+        let dir = tempfile::tempdir().unwrap();
+        manifest(dir.path(), PY_YAML);
+        let bin = dir.path().join(".venv").join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::write(bin.join("python"), b"#!/bin/sh\n").unwrap();
+        assert!(!needs_polyglot_provisioning(dir.path()));
+    }
+
+    /// A Deno package with no regenerated `_generated_/` needs provisioning.
+    #[test]
+    fn needs_polyglot_provisioning_for_deno_without_generated() {
+        let dir = tempfile::tempdir().unwrap();
+        manifest(dir.path(), DENO_YAML);
+        assert!(needs_polyglot_provisioning(dir.path()));
+    }
+
+    /// A Deno package whose `_generated_/` is already present loads as-is.
+    #[test]
+    fn no_polyglot_provisioning_when_deno_generated_present() {
+        let dir = tempfile::tempdir().unwrap();
+        manifest(dir.path(), DENO_YAML);
+        std::fs::create_dir_all(dir.path().join("_generated_")).unwrap();
+        assert!(!needs_polyglot_provisioning(dir.path()));
+    }
+
+    /// A Deno-only package also routes through `source_for_resolved_dir` when
+    /// its `_generated_/` is missing — the codegen-provisioning analog of the
+    /// Python-venv bug.
+    #[test]
+    fn resolved_dir_routes_unprovisioned_deno_to_build() {
+        let dir = tempfile::tempdir().unwrap();
+        manifest(dir.path(), DENO_YAML);
+        let resolved = source_for_resolved_dir(&pkg_ref(), dir.path().to_path_buf());
+        assert!(
+            matches!(resolved, ResolvedSource::NeedsBuild(_)),
+            "unprovisioned Deno-only package must route through materialize, got {resolved:?}"
+        );
+    }
+
+    /// Rust-path non-regression: a Rust package (whose build decision is
+    /// `needs_host_build`, not the polyglot path) must NOT be treated as
+    /// needing polyglot provisioning — no venv/`_generated_` is ever expected
+    /// for it. A schemas-only package likewise needs no provisioning.
+    #[test]
+    fn no_polyglot_provisioning_for_rust_or_schemas_only() {
+        let rust = tempfile::tempdir().unwrap();
+        manifest(rust.path(), RUST_YAML);
+        std::fs::write(rust.path().join("Cargo.toml"), b"[package]\nname='rp'\n").unwrap();
+        assert!(!needs_polyglot_provisioning(rust.path()));
+
+        let schemas_only = tempfile::tempdir().unwrap();
+        std::fs::write(
+            schemas_only.path().join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: s\n  version: 0.1.0\n",
+        )
+        .unwrap();
+        assert!(!needs_polyglot_provisioning(schemas_only.path()));
+    }
+
+    // =====================================================================
     // fetch_remote_slpkg — fetch, integrity check, cache reuse
     // =====================================================================
 
@@ -1400,11 +1543,29 @@ mod tests {
         slot
     }
 
+    /// The resolved package dir regardless of whether it loads directly
+    /// (`Ready`) or routes through the orchestrator (`NeedsBuild`) — used by
+    /// the precedence tests below, which assert *which* dir won independent of
+    /// the build/provision decision. A Python-only fixture (the realistic
+    /// installed-cache / `streamlib_modules` shape) routes to `NeedsBuild`
+    /// because it needs its venv provisioned.
+    fn resolved_dir(resolved: &ResolvedSource) -> PathBuf {
+        match resolved {
+            ResolvedSource::Ready(dir) => dir.clone(),
+            ResolvedSource::NeedsBuild(req) => match &req.source {
+                BuildSource::PackageDir(dir) => dir.clone(),
+                other => panic!("expected PackageDir source, got {other:?}"),
+            },
+        }
+    }
+
     /// CRUX (D7 bridge): with BOTH an app-modules entry and an installed-cache
     /// record present, `Strategy::InstalledCache` resolves the app-modules
     /// dir. Mentally revert the modules probe in
     /// `resolve_installed_cache_strategy` and this resolves the cache slot
-    /// instead, failing the assertion.
+    /// instead, failing the assertion. (The Python-only fixtures route to
+    /// `NeedsBuild` — see [`resolved_dir`] — so the assertion is on the winning
+    /// dir, not the `Ready`/`NeedsBuild` variant.)
     #[test]
     #[serial_test::serial]
     fn installed_cache_strategy_prefers_app_modules_dir() {
@@ -1417,13 +1578,11 @@ mod tests {
         let resolved =
             resolve_installed_cache_strategy(&pkg_ref_named("foo"), Some(app_root.path()))
                 .expect("must resolve");
-        match resolved {
-            ResolvedSource::Ready(dir) => assert_eq!(
-                dir, modules_dir,
-                "app modules must win over the installed cache"
-            ),
-            other => panic!("expected Ready(app modules dir), got {other:?}"),
-        }
+        assert_eq!(
+            resolved_dir(&resolved),
+            modules_dir,
+            "app modules must win over the installed cache"
+        );
     }
 
     /// A package absent from `streamlib_modules/` falls through to the
@@ -1439,10 +1598,7 @@ mod tests {
         let resolved =
             resolve_installed_cache_strategy(&pkg_ref_named("foo"), Some(app_root.path()))
                 .expect("must resolve from the installed cache");
-        match resolved {
-            ResolvedSource::Ready(dir) => assert_eq!(dir, slot),
-            other => panic!("expected Ready(cache slot), got {other:?}"),
-        }
+        assert_eq!(resolved_dir(&resolved), slot);
     }
 
     /// A `streamlib_modules/@org/name` dir whose manifest declares a DIFFERENT
@@ -1460,10 +1616,30 @@ mod tests {
         let resolved =
             resolve_installed_cache_strategy(&pkg_ref_named("foo"), Some(app_root.path()))
                 .expect("must fall through to the installed cache");
-        match resolved {
-            ResolvedSource::Ready(dir) => assert_eq!(dir, slot),
-            other => panic!("expected Ready(cache slot), got {other:?}"),
-        }
+        assert_eq!(resolved_dir(&resolved), slot);
+    }
+
+    /// CRUX (bug path): a Python-only package resolved from the app's
+    /// `streamlib_modules/` folder with no provisioned venv must resolve to
+    /// `NeedsBuild` (source = the app-modules dir) so `materialize` provisions
+    /// the venv at the cache slot it loads from — the exact
+    /// `resolve_installed_cache_strategy` path that shipped the module as-is and
+    /// left the subprocess spawn with `.venv/bin/python: No such file or
+    /// directory`. Mentally revert the `needs_polyglot_provisioning` clause in
+    /// `source_for_resolved_dir` and this resolves to `Ready`, failing
+    /// `assert_builds_from`.
+    #[test]
+    #[serial_test::serial]
+    fn installed_cache_strategy_routes_unprovisioned_python_app_module_to_build() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = sandbox_home(home.path());
+        let app_root = tempfile::tempdir().unwrap();
+        let modules_dir = write_app_modules_package(app_root.path(), "foo", "foo");
+
+        let resolved =
+            resolve_installed_cache_strategy(&pkg_ref_named("foo"), Some(app_root.path()))
+                .expect("must resolve");
+        assert_builds_from(resolved, &modules_dir);
     }
 
     /// Neither app modules nor installed cache ⇒ typed ModuleNotFound.


### PR DESCRIPTION
Closes #1397

## Summary

A Python-only (or Deno-only) package resolved from `streamlib_modules/` or the installed cache was loaded **as-is**, bypassing `PolyglotBuildOrchestrator::materialize` — the only place the `.venv` (Python) and `_generated_` (Deno codegen) get provisioned. `source_for_resolved_dir` gated the build decision solely on `needs_host_build`, which is Rust-only; a non-Rust package short-circuited to `ResolvedSource::Ready(dir)` and never reached `materialize`. At runtime, the package's Python subprocess processors then failed to spawn:

```
Setup failed: Failed to spawn Python native subprocess … No such file or directory.
Python: '…/streamlib_modules/@org/name/.venv/bin/python'
```

### Fix

Adds `needs_polyglot_provisioning` in `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs`: a resolved dir that declares Python with no `.venv/bin/python`, or declares Deno with no `_generated_/`, now routes to `NeedsBuild` (`IfStale`), so `materialize` provisions the venv / regenerates `_generated_` at the cache slot the module actually loads from. The orchestrator's own `IfStale` staleness-skip short-circuits an already-provisioned slot, so there's no rebuild loop. The Rust prebuilt-vs-build path (`needs_host_build`) is untouched.

This is a single-file change confined to the non-locked resolve path (`source_for_resolved_dir`); the locked-run enforcer (`locked.rs`) still forces `Strategy::Path { build: NeverBuild }` and never reaches this code (see review item below — verified as a positive, not a gap).

## Test evidence

Ran the full `module_loader` test module on this branch in a scratch worktree (`cargo test -p streamlib-engine --lib module_loader`):

```
test result: ok. 115 passed; 0 failed; 0 ignored; 0 measured; 1646 filtered out; finished in 3.08s
```

Bug-reproduce-first coverage specifically exercised:

```
test core::runtime::module_loader::source::tests::needs_polyglot_provisioning_for_deno_without_generated ... ok
test core::runtime::module_loader::source::tests::no_polyglot_provisioning_when_deno_generated_present ... ok
test core::runtime::module_loader::source::tests::resolved_dir_routes_unprovisioned_deno_to_build ... ok
test core::runtime::module_loader::source::tests::resolved_dir_routes_unprovisioned_python_to_build ... ok
test core::runtime::module_loader::source::tests::no_polyglot_provisioning_for_rust_or_schemas_only ... ok
```

`resolved_dir_routes_unprovisioned_python_to_build` asserts `NeedsBuild` for an unprovisioned Python-only dir and fails pre-fix (got `Ready`) against unmodified `source_for_resolved_dir`, per the commit message. `cargo clippy -p streamlib-engine --lib` shows no new warnings introduced by this change (pre-existing `result_large_err` noise only).

No GPU/rig E2E run was needed for this fix — it is a pure module-resolution/build-routing change with no Vulkan/V4L2/display surface; the original bug was discovered via a rig render check (`camera-python-display`, per the ticket), and the fix is exercised by the unit tests above rather than a fresh live run.

## Review items (non-blocking)

- **should-fix** — `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:599`: The fix routes unprovisioned Python/Deno-only packages through `materialize`, but only on the `source_for_resolved_dir` path. The `AlwaysBuild` arm of `source_for_fetched_slpkg` still has the identical load-as-is-for-non-Rust shape the ticket calls a bug. Evidence: `source_for_fetched_slpkg`'s `BuildPolicy::AlwaysBuild => { if has_buildable_rust_source(&dir) {..} else { ResolvedSource::Ready(dir) } }` (lines ~591-599) returns `Ready` for a Python/Deno-only package with no venv. It is a live load path: `Strategy::Url` and `Strategy::Registry` (source.rs:358, :427) feed `source_for_fetched_slpkg(pkg_ref, extracted, *build)` directly into the loader, and `streamlib add` / `Strategy::Registry` use `AlwaysBuild` (`tools/streamlib-pack/src/lib.rs:571`). So a Python-only package loaded via `Url`/`Registry` with `AlwaysBuild` loads unprovisioned and its subprocess spawn dies with the same `.venv/bin/python: No such file or directory` the ticket describes. The `IfStale` arm is fixed (delegates to `source_for_resolved_dir`); only the `AlwaysBuild` non-Rust arm is missed. Suggested next step: document that the `AlwaysBuild` non-Rust arm of `source_for_fetched_slpkg` is a known same-shape gap; ideally route non-Rust-unprovisioned dirs through `materialize` there too (or state why `AlwaysBuild`-on-`Url`/`Registry`-Python is unreachable at runtime load, given the install → `InstalledCache` → `source_for_resolved_dir` flow re-provisions).

- **info** — `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:630`: The definition of "polyglot-provisioned" now lives in two layers: engine `needs_polyglot_provisioning` (checks the resolved dir) and orchestrator `cache_slot_is_reusable` (checks the cache slot). Evidence: `needs_polyglot_provisioning` checks `dir/.venv/bin/python` and `dir/_generated_`; `tools/streamlib-build-orchestrator/src/lib.rs:141` `cache_slot_is_reusable` + `python_venv::staged_package_has_python` / `deno_codegen::staged_package_has_deno` check the same shapes on `cache_slot`. The two operate on different dirs at different layers, and the engine cannot depend on the orchestrator (dependency direction), so unification is not straightforward. The doc comment explicitly calls out the mirroring, and the checks are trivial fs probes. Drift risk only; no action required, noted for awareness that a future change to what "provisioned" means must be applied in both places.

- **info** — `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:554`: `ProjectConfig::load` runs twice per resolved dir at resolve time. Evidence: `needs_host_build(&dir) || needs_polyglot_provisioning(&dir)` — both call `crate::core::config::ProjectConfig::load(&dir)` internally. Module resolution is a one-shot per package at pipeline setup, not a hot path, so this is negligible. None; recorded only.

- **info** — `runtime/streamlib-engine/src/core/runtime/module_loader/locked.rs:174`: The change does NOT touch the locked-run / two-resolver split — the most load-bearing charter invariant. A locked run forces every edge to `Strategy::Path { build: NeverBuild }`, which dispatches to `source_for_dir` (respects `NeverBuild` → `Ready`) and never reaches `source_for_resolved_dir` / `needs_polyglot_provisioning`. So the new `NeedsBuild` routing is confined to non-locked resolution (`InstalledCache`/lazy-discovery, local Slpkg, and `Url`/`Registry` via `IfStale`). The offline, build-free locked path is preserved. Evidence: `locked.rs:174-176` builds `Strategy::Path { build: BuildPolicy::NeverBuild }`; `resolve_strategy_to_source` (source.rs:330-335) sends `Strategy::Path` through `source_for_dir`, not `source_for_resolved_dir`. The new clause lives only in `source_for_resolved_dir` (source.rs:554). Positive confirmation — no action needed. The fix correctly targets the dev/install resolve path and leaves the locked enforcer alone.

- **low** — `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:627`: The doc comment claims `needs_polyglot_provisioning` "Mirrors the per-language provisioned-checks the orchestrator's staleness-skip uses." That is exact for Deno (both read the manifest: source.rs `declares(TypeScript)` vs orchestrator `staged_package_has_deno` → `has_typescript_runtime_processors`) but NOT for Python: source.rs detects Python from the manifest (`processors[].runtime.language == Python`) while the orchestrator's reuse guard `staged_package_has_python` detects it from the filesystem (a `python/` dir or `pyproject.toml`). For a well-formed packed package these always agree (assemble stages Python source into `python/`), so it is benign today — but the two "is this Python" oracles are not the same predicate, and a manifest that declares Python without a `python/` layout would route to `NeedsBuild` forever while the orchestrator refuses to provision and its skip deems the slot reusable, loading with no venv (the exact bug). Evidence: source.rs `needs_polyglot_provisioning`: `declares(ProcessorLanguage::Python) && !dir.join(".venv/bin/python").exists()` (manifest-driven). `python_venv.rs:162-164` `staged_package_has_python`: `temp_dir.join("python").is_dir() || temp_dir.join("pyproject.toml").is_file()` (filesystem-driven). `deno_codegen.rs:115-120` `staged_package_has_deno` is manifest-driven, matching source.rs's Deno branch. Suggested next step: either soften the doc comment to say the Python detection is manifest-driven (the orchestrator's Python reuse guard is filesystem-driven) rather than claiming full parity, or align the two Python detectors on one oracle. Ship as a documented review note; not blocking.

- **info** — `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:554`: A mixed Rust+Python package that ships a matching prebuilt cdylib now routes to `NeedsBuild` (`needs_host_build` is false because the prebuilt exists, but `needs_polyglot_provisioning` is true because there is no venv). The orchestrator's `has_rust` path skips the staleness short-circuit (it is `!has_rust`-only) and always re-runs cargo (`assemble_artifact`, `no_build: false`), discarding the shipped prebuilt and requiring a Rust toolchain at load time — the compiler-free wheel promise is lost for that shape. This is NOT a regression: the same package was already broken before this change (`Ready` → no venv → Python subprocess spawn dies), so there was no working prebuilt-only path to lose; and a load-time source build is the sanctioned model (`FullAccess` primitives keep it plugin-safe per the slpkg learning). Flagging only because it touches the wheel-vs-sdist model directly and mixed-language packages aren't demonstrated in-tree. Evidence: orchestrator staleness skip gated on `!has_rust` (lib.rs:226); `has_rust` path falls straight through to assemble (lib.rs:258-320). `cache_slot_is_reusable` (lib.rs:144-151) is only consulted on the `!has_rust` branch. Pack excludes `.venv`/`_generated_` from every artifact (`streamlib-pack/src/lib.rs:865-867`), so a freshly-added package never carries a venv. Suggested next step: no action required for this fix. If mixed Rust+Python packages become a shipped shape, consider a "provision venv without rebuilding the cdylib" orchestrator path so a shipped prebuilt survives. Owner-independent engineering note.

- **low** — `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:553`: `source_for_resolved_dir` now parses `streamlib.yaml` up to twice per resolve: once inside `needs_host_build` → `has_buildable_rust_source`, and again inside `needs_polyglot_provisioning` (both call `ProjectConfig::load(dir)`). Resolve is not a hot path (once per package load), so the cost is negligible, but it is a small redundancy where one manifest read could feed both language checks. Evidence: `has_buildable_rust_source` (source.rs:617-628) and `needs_polyglot_provisioning` both open with `ProjectConfig::load(dir)`; `source_for_resolved_dir`'s OR (source.rs:554) evaluates `needs_host_build` first, then `needs_polyglot_provisioning` when the first is false. Suggested next step: optional — hoist a single `ProjectConfig::load` into `source_for_resolved_dir` and pass the config (or its per-language flags) to both predicates. Cosmetic; do not block.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
