### PR TITLE
feat(plugin-sdk): surface shipped recorder/surface/GPU ABI slots as engine-free wrappers (#1226 PR 0)

### DIFF
--- a/sdk/streamlib-plugin-sdk/src/color.rs
+++ b/sdk/streamlib-plugin-sdk/src/color.rs
@@ -207,6 +207,51 @@ pub enum ColorSpaceKind {
     Yuv,
 }
 
+/// Resolve every missing axis to its per-kind default. The defaults
+/// mirror V4L2's `V4L2_MAP_*_DEFAULT` macros and libplacebo's
+/// `pl_color_space_infer`:
+///
+/// | axis | RGB default | YCbCr default |
+/// |---|---|---|
+/// | `primaries` | `Bt709` | `Bt709` |
+/// | `transfer` | `Srgb` | `Bt709` |
+/// | `matrix` | `Identity` | `Smpte170m` (BT.601, the UVC convention) |
+/// | `range` | `Full` | `Limited` |
+///
+/// RGB-encoded sources also override the matrix axis to `Identity`
+/// regardless of the on-wire value, since matrix is meaningless when
+/// data is already RGB.
+///
+/// Each axis takes an `Option<EngineId>` — `None` means the on-wire
+/// value was absent (H.273 "Unspecified").
+pub fn resolve_color_defaults(
+    primaries: Option<PrimariesId>,
+    transfer: Option<TransferId>,
+    matrix: Option<MatrixId>,
+    range: Option<RangeId>,
+    kind: ColorSpaceKind,
+) -> ResolvedColorInfo {
+    let primaries = primaries.unwrap_or(PrimariesId::Bt709);
+    let transfer = transfer.unwrap_or(match kind {
+        ColorSpaceKind::Rgb => TransferId::Srgb,
+        ColorSpaceKind::Yuv => TransferId::Bt709,
+    });
+    let matrix = match kind {
+        ColorSpaceKind::Rgb => MatrixId::Identity,
+        ColorSpaceKind::Yuv => matrix.unwrap_or(MatrixId::Smpte170m),
+    };
+    let range = range.unwrap_or(match kind {
+        ColorSpaceKind::Rgb => RangeId::Full,
+        ColorSpaceKind::Yuv => RangeId::Limited,
+    });
+    ResolvedColorInfo {
+        primaries,
+        transfer,
+        matrix,
+        range,
+    }
+}
+
 // =============================================================================
 // YCbCr → RGB matrix decomposition (matrix.rs twin)
 // =============================================================================
@@ -295,5 +340,69 @@ mod tests {
             [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
         );
         assert_eq!(d.offset, [0.0, 0.0, 0.0]);
+    }
+
+    /// All-None inputs for an RGB source resolve to
+    /// `Bt709 / Srgb / Identity / Full`.
+    #[test]
+    fn rgb_all_none_defaults_match_table() {
+        let r = resolve_color_defaults(None, None, None, None, ColorSpaceKind::Rgb);
+        assert_eq!(r.primaries, PrimariesId::Bt709);
+        assert_eq!(r.transfer, TransferId::Srgb);
+        assert_eq!(r.matrix, MatrixId::Identity);
+        assert_eq!(r.range, RangeId::Full);
+    }
+
+    /// All-None inputs for a YCbCr source resolve to the UVC
+    /// convention: `Bt709 / Bt709 / Smpte170m / Limited`.
+    #[test]
+    fn yuv_all_none_defaults_match_table() {
+        let r = resolve_color_defaults(None, None, None, None, ColorSpaceKind::Yuv);
+        assert_eq!(r.primaries, PrimariesId::Bt709);
+        assert_eq!(r.transfer, TransferId::Bt709);
+        assert_eq!(r.matrix, MatrixId::Smpte170m);
+        assert_eq!(r.range, RangeId::Limited);
+    }
+
+    /// Explicit values on every axis pass through unchanged for YUV.
+    #[test]
+    fn explicit_values_pass_through_yuv() {
+        let r = resolve_color_defaults(
+            Some(PrimariesId::Bt2020),
+            Some(TransferId::Pq),
+            Some(MatrixId::Bt2020Ncl),
+            Some(RangeId::Limited),
+            ColorSpaceKind::Yuv,
+        );
+        assert_eq!(r.primaries, PrimariesId::Bt2020);
+        assert_eq!(r.transfer, TransferId::Pq);
+        assert_eq!(r.matrix, MatrixId::Bt2020Ncl);
+        assert_eq!(r.range, RangeId::Limited);
+    }
+
+    /// RGB sources override the matrix axis to `Identity` even when
+    /// the input claims otherwise. Matrix coefficients are meaningless
+    /// for already-RGB data.
+    #[test]
+    fn rgb_overrides_matrix_to_identity() {
+        let r = resolve_color_defaults(
+            Some(PrimariesId::Bt709),
+            Some(TransferId::Srgb),
+            Some(MatrixId::Bt709),
+            Some(RangeId::Full),
+            ColorSpaceKind::Rgb,
+        );
+        assert_eq!(r.matrix, MatrixId::Identity);
+    }
+
+    /// Partial info: only matrix specified. Other axes pull defaults.
+    #[test]
+    fn partial_info_fills_only_missing_axes() {
+        let r =
+            resolve_color_defaults(None, None, Some(MatrixId::Bt709), None, ColorSpaceKind::Yuv);
+        assert_eq!(r.matrix, MatrixId::Bt709); // explicit
+        assert_eq!(r.primaries, PrimariesId::Bt709); // default
+        assert_eq!(r.transfer, TransferId::Bt709); // YUV default
+        assert_eq!(r.range, RangeId::Limited); // YUV default
     }
 }

--- a/sdk/streamlib-plugin-sdk/src/context.rs
+++ b/sdk/streamlib-plugin-sdk/src/context.rs
@@ -34,6 +34,8 @@ use crate::audio_clock_shim::AudioClockShim;
 use streamlib_consumer_rhi::{PixelFormat, TextureFormat, TextureUsages, VulkanLayout};
 #[cfg(target_os = "linux")]
 use streamlib_error::{Error, Result};
+#[cfg(target_os = "linux")]
+use streamlib_plugin_abi::GpuCapabilitiesRepr;
 
 // =============================================================================
 // GpuContextLimitedAccess — cdylib arm
@@ -763,6 +765,40 @@ impl Drop for GpuContextFullAccess {
             // No-op — escalate_end is the authority.
             HandleKind::ScopeToken => {}
         }
+    }
+}
+
+/// Host GPU capability snapshot — the Rust-side projection of the plugin
+/// ABI's `GpuCapabilitiesRepr`, read once at processor setup for
+/// device-vendor branching and external-memory / cross-device-DMA-BUF
+/// probe checks. Returned by
+/// [`GpuContextFullAccess::gpu_capabilities`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GpuCapabilities {
+    /// GPU device / vendor name (`VkPhysicalDeviceProperties::deviceName`).
+    pub device_name: String,
+    /// Whether the GPU exposes `VK_KHR_external_memory_fd` +
+    /// `VK_EXT_external_memory_dma_buf` (DMA-BUF FD import available).
+    pub supports_external_memory: bool,
+    /// Whether cross-device DMA-BUF probe is supported (NVIDIA Linux
+    /// reports `false` per the engine-layer capability guard).
+    pub supports_cross_device_dma_buf_probe: bool,
+    /// Whether the GPU exposes `VK_KHR_ray_tracing_pipeline`.
+    pub supports_ray_tracing_pipeline: bool,
+}
+
+/// Project a `GpuCapabilitiesRepr` (fixed-size UTF-8 device-name buffer +
+/// valid-length + `u8` capability bools) into the Rust-side
+/// [`GpuCapabilities`].
+#[cfg(target_os = "linux")]
+fn gpu_capabilities_from_repr(repr: &GpuCapabilitiesRepr) -> GpuCapabilities {
+    let name_len = (repr.device_name_len as usize).min(repr.device_name.len());
+    let device_name = String::from_utf8_lossy(&repr.device_name[..name_len]).into_owned();
+    GpuCapabilities {
+        device_name,
+        supports_external_memory: repr.supports_external_memory != 0,
+        supports_cross_device_dma_buf_probe: repr.supports_cross_device_dma_buf_probe != 0,
+        supports_ray_tracing_pipeline: repr.supports_ray_tracing_pipeline != 0,
     }
 }
 
@@ -1741,16 +1777,22 @@ impl GpuContextFullAccess {
     /// host-device submission (#1262). Dispatches through the
     /// `copy_texture_to_storage_buffer_and_signal` slot.
     ///
-    /// The cross-API timeline wait/signal (`consume_done` / `produce_done`)
-    /// rides null handles until #1260 lands the SDK exportable-timeline
-    /// PluginAbiObject; on the null path the host submission blocks until
-    /// the copy completes. When #1260 lands, this method gains the
-    /// `Option<(&HostTimelineSemaphore, u64)>` wait/signal parameters.
+    /// In the same submission the host GPU-waits on `consume_done` at its
+    /// value before the copy and signals `produce_done` at its value on
+    /// completion (single-writer-per-edge). Pass `None` for either edge to
+    /// skip that wait / signal. A cross-process consumer MUST be handed a
+    /// `produce_done` timeline here — the GPU-queue completion this method
+    /// schedules is what advances it; a fully-`None` call blocks host-side
+    /// until the copy completes with no cross-API sync, so a subprocess
+    /// consumer waiting on a never-signalled `produce_done` would block
+    /// forever.
     pub fn copy_texture_to_storage_buffer_and_signal(
         &self,
         source_texture: &crate::rhi::Texture,
         source_layout: VulkanLayout,
         dst: &crate::rhi::StorageBuffer,
+        consume_done: Option<(&crate::rhi::HostTimelineSemaphore, u64)>,
+        produce_done: Option<(&crate::rhi::HostTimelineSemaphore, u64)>,
     ) -> Result<()> {
         if self.vtable.is_null() {
             return Err(Error::GpuError(
@@ -1758,21 +1800,31 @@ impl GpuContextFullAccess {
                     .into(),
             ));
         }
+        let (consume_handle, consume_value) = match consume_done {
+            Some((timeline, value)) => (timeline.cdylib_handle(), value),
+            None => (std::ptr::null(), 0),
+        };
+        let (produce_handle, produce_value) = match produce_done {
+            Some((timeline, value)) => (timeline.cdylib_handle(), value),
+            None => (std::ptr::null(), 0),
+        };
         let mut err_buf = [0u8; 512];
         let mut err_len: usize = 0;
         // SAFETY: vtable + handle paired at construction; the texture +
-        // storage buffer are borrowed for the call. Null timeline handles
-        // select the host-blocking (no cross-API sync) path.
+        // storage buffer are borrowed for the call; each timeline handle is
+        // the host-minted `Arc::into_raw(Arc<HostVulkanTimelineSemaphore>)`
+        // inner pointer the host derefs as a borrow (null selects "no wait /
+        // no signal" on that edge).
         let status = unsafe {
             ((*self.vtable).copy_texture_to_storage_buffer_and_signal)(
                 self.handle,
                 source_texture.handle,
                 source_layout.0,
                 dst as *const _ as *const c_void,
-                std::ptr::null(),
-                0,
-                std::ptr::null(),
-                0,
+                consume_handle,
+                consume_value,
+                produce_handle,
+                produce_value,
                 err_buf.as_mut_ptr(),
                 err_buf.len(),
                 &mut err_len as *mut usize,
@@ -1780,6 +1832,86 @@ impl GpuContextFullAccess {
         };
         if status == 0 {
             Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())]).into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    /// Read the host GPU capability snapshot (v5 `gpu_capabilities` slot):
+    /// device name plus external-memory / cross-device-DMA-BUF-probe /
+    /// ray-tracing capability bools, read once at setup for device-vendor
+    /// branching. Dispatches through the [`GpuContextFullAccessVTable`]'s
+    /// `gpu_capabilities` slot.
+    pub fn gpu_capabilities(&self) -> Result<GpuCapabilities> {
+        if self.vtable.is_null() {
+            return Err(Error::GpuError(
+                "gpu_capabilities: GpuContextFullAccess has null vtable".into(),
+            ));
+        }
+        let mut caps: std::mem::MaybeUninit<GpuCapabilitiesRepr> = std::mem::MaybeUninit::uninit();
+        let mut err_buf = [0u8; 512];
+        let mut err_len: usize = 0;
+        // SAFETY: vtable + handle paired at construction; the host fully
+        // populates `caps` (fixed-size device_name buffer + len + capability
+        // bools) on success.
+        let status = unsafe {
+            ((*self.vtable).gpu_capabilities)(
+                self.handle,
+                caps.as_mut_ptr(),
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status != 0 {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())]).into_owned();
+            return Err(Error::GpuError(msg));
+        }
+        // SAFETY: host signaled success and wrote a valid GpuCapabilitiesRepr.
+        let caps = unsafe { caps.assume_init() };
+        Ok(gpu_capabilities_from_repr(&caps))
+    }
+
+    /// Import a V4L2 (or otherwise externally-allocated) DMA-BUF FD as a
+    /// [`StorageBuffer`](crate::rhi::StorageBuffer) (SSBO-shaped) over the
+    /// v7 slot. Dispatches through the [`GpuContextFullAccessVTable`]'s
+    /// `import_dma_buf_storage_buffer` slot.
+    ///
+    /// **The host consumes `fd` on success** (`vkImportMemoryFdInfoKHR`
+    /// takes ownership). On failure the caller retains ownership and must
+    /// close it.
+    pub fn import_dma_buf_storage_buffer(
+        &self,
+        fd: i32,
+        byte_size: u64,
+    ) -> Result<crate::rhi::StorageBuffer> {
+        if self.vtable.is_null() {
+            return Err(Error::GpuError(
+                "import_dma_buf_storage_buffer: GpuContextFullAccess has null vtable".into(),
+            ));
+        }
+        let mut out: std::mem::MaybeUninit<crate::rhi::StorageBuffer> =
+            std::mem::MaybeUninit::uninit();
+        let mut err_buf = [0u8; 512];
+        let mut err_len: usize = 0;
+        // SAFETY: vtable + handle paired at construction; the host writes a
+        // valid `StorageBuffer` PluginAbiObject (with populated
+        // `byte_size_cached`) into `out` and consumes `fd` on success.
+        let status = unsafe {
+            ((*self.vtable).import_dma_buf_storage_buffer)(
+                self.handle,
+                fd,
+                byte_size,
+                out.as_mut_ptr() as *mut c_void,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            // SAFETY: host signaled success and wrote a valid value.
+            Ok(unsafe { out.assume_init() })
         } else {
             let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())]).into_owned();
             Err(Error::GpuError(msg))
@@ -2105,5 +2237,98 @@ mod escalate_tests {
             vtable: std::ptr::null(),
         };
         let _ = round_trip(&limited);
+    }
+
+    fn null_full_access() -> GpuContextFullAccess {
+        GpuContextFullAccess {
+            handle: std::ptr::null(),
+            vtable: std::ptr::null(),
+            handle_kind: HandleKind::ScopeToken,
+            inherited_lim_handle: std::ptr::null(),
+            inherited_lim_vtable: std::ptr::null(),
+        }
+    }
+
+    #[test]
+    fn gpu_capabilities_on_null_vtable_returns_typed_error_not_ub() {
+        // Mental-revert the `self.vtable.is_null()` guard in
+        // `gpu_capabilities` and this UB-derefs the null vtable to reach its
+        // `gpu_capabilities` slot.
+        let full = null_full_access();
+        let result = full.gpu_capabilities();
+        assert!(
+            matches!(result, Err(Error::GpuError(_))),
+            "null-vtable gpu_capabilities must return a typed GpuError, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn import_dma_buf_storage_buffer_on_null_vtable_returns_typed_error_not_ub() {
+        // Mental-revert the `self.vtable.is_null()` guard in
+        // `import_dma_buf_storage_buffer` and this UB-derefs the null vtable.
+        // The caller retains the fd on this guard path (the host never sees
+        // it), so passing `-1` is safe.
+        let full = null_full_access();
+        let result = full.import_dma_buf_storage_buffer(-1, 4096);
+        assert!(
+            matches!(result, Err(Error::GpuError(_))),
+            "null-vtable import_dma_buf_storage_buffer must return a typed GpuError, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn copy_texture_to_storage_buffer_and_signal_on_null_vtable_returns_typed_error_not_ub() {
+        // The GAP-B-fixed method still guards the null vtable before touching
+        // the copy slot or dereferencing any timeline handle. Mental-revert
+        // the `self.vtable.is_null()` guard and this UB-derefs the null vtable.
+        let full = null_full_access();
+        let texture = crate::rhi::Texture {
+            handle: std::ptr::null(),
+            vtable: std::ptr::null(),
+            width_cached: 0,
+            height_cached: 0,
+            format_raw: 0,
+            _padding: 0,
+        };
+        let storage_buffer = crate::rhi::StorageBuffer {
+            handle: std::ptr::null(),
+            vtable: std::ptr::null(),
+            byte_size_cached: 0,
+            mapped_ptr_cached: std::ptr::null_mut(),
+        };
+        let result = full.copy_texture_to_storage_buffer_and_signal(
+            &texture,
+            VulkanLayout(0),
+            &storage_buffer,
+            None,
+            None,
+        );
+        assert!(
+            matches!(result, Err(Error::GpuError(_))),
+            "null-vtable copy_texture_to_storage_buffer_and_signal must return a typed GpuError, \
+             got {result:?}"
+        );
+    }
+
+    #[test]
+    fn gpu_capabilities_from_repr_reads_fields() {
+        // Construct a repr with a known device name + capability bools and
+        // assert the u8→bool and UTF-8-slice→String projection.
+        let mut device_name = [0u8; 256];
+        let name = b"Test GPU 9000";
+        device_name[..name.len()].copy_from_slice(name);
+        let repr = GpuCapabilitiesRepr {
+            device_name,
+            device_name_len: name.len() as u32,
+            supports_external_memory: 1,
+            supports_cross_device_dma_buf_probe: 0,
+            supports_ray_tracing_pipeline: 1,
+            _reserved_padding: 0,
+        };
+        let caps = gpu_capabilities_from_repr(&repr);
+        assert_eq!(caps.device_name, "Test GPU 9000");
+        assert!(caps.supports_external_memory);
+        assert!(!caps.supports_cross_device_dma_buf_probe);
+        assert!(caps.supports_ray_tracing_pipeline);
     }
 }

--- a/sdk/streamlib-plugin-sdk/src/lib.rs
+++ b/sdk/streamlib-plugin-sdk/src/lib.rs
@@ -88,8 +88,8 @@ pub mod sdk {
     pub mod context {
         pub use crate::audio_clock_shim::{AudioClockShim, AudioTickContext};
         pub use crate::context::{
-            GpuContextFullAccess, GpuContextLimitedAccess, RuntimeContextFullAccess,
-            RuntimeContextLimitedAccess,
+            GpuCapabilities, GpuContextFullAccess, GpuContextLimitedAccess,
+            RuntimeContextFullAccess, RuntimeContextLimitedAccess,
         };
     }
 
@@ -143,8 +143,8 @@ pub mod sdk {
         pub use crate::color::{
             ColorSpaceKind, MatrixId, PrimariesId, RangeId, ResolvedColorInfo, TransferId,
             YuvToRgbDecomposition, bt709_to_linear, from_linear, hlg_to_linear, linear_to_bt709,
-            linear_to_hlg, linear_to_pq, linear_to_srgb, pq_to_linear, srgb_to_linear, to_linear,
-            yuv_to_rgb_matrix,
+            linear_to_hlg, linear_to_pq, linear_to_srgb, pq_to_linear, resolve_color_defaults,
+            srgb_to_linear, to_linear, yuv_to_rgb_matrix,
         };
     }
 

--- a/sdk/streamlib-plugin-sdk/src/rhi/command_recorder.rs
+++ b/sdk/streamlib-plugin-sdk/src/rhi/command_recorder.rs
@@ -14,23 +14,29 @@
 //! mutable state (`begin()` → `record_*(&mut self)` → `submit_*(&mut
 //! self)`) that doesn't survive duplication.
 //!
-//! The host `RhiCommandRecorderInner` backing + the methods that name
-//! host-only types (`record_buffer_barrier` / `record_copy_*` over
-//! `VulkanBufferLike` / `PixelBuffer`, `record_draw*` over
-//! `VulkanGraphicsKernel`, `submit_signaling_timeline` over
-//! `HostVulkanTimelineSemaphore`, the raw-`vk::*` swapchain / dynamic-
-//! rendering methods) stay in the engine — they can't cross the
-//! engine-free boundary.
+//! The host `RhiCommandRecorderInner` backing stays in the engine; the
+//! cdylib holds only the opaque `handle` and dispatches every method
+//! through the vtables.
+//!
+//! ~~The `record_buffer_barrier` / `record_copy_*` (over `VulkanBufferLike`
+//! / `PixelBuffer`) and `submit_signaling_timeline` (over
+//! `HostVulkanTimelineSemaphore`) methods stay in the engine — they can't
+//! cross the engine-free boundary.~~ (2026-07-17, #1226: they cross now —
+//! #1260 / #1262 shipped the engine-free `StorageBuffer` / `PixelBuffer` /
+//! `HostTimelineSemaphore` twins these slots marshal through, so every
+//! `RhiCommandRecorderMethodsVTable` slot is wrapped here.)
 
 use std::ffi::c_void;
 
 use streamlib_consumer_rhi::VulkanLayout;
 use streamlib_error::{Error, Result};
-use streamlib_plugin_abi::{GpuContextFullAccessVTable, RhiCommandRecorderMethodsVTable};
+use streamlib_plugin_abi::{
+    GpuContextFullAccessVTable, ImageCopyRegionRepr, RhiCommandRecorderMethodsVTable,
+};
 
 use crate::rhi::{
-    DrawCall, DrawIndexedCall, Texture, VulkanAccess, VulkanComputeKernel, VulkanGraphicsKernel,
-    VulkanStage,
+    DrawCall, DrawIndexedCall, HostTimelineSemaphore, PixelBuffer, StorageBuffer, Texture,
+    VulkanAccess, VulkanComputeKernel, VulkanGraphicsKernel, VulkanStage,
 };
 
 /// Image-to-buffer / buffer-to-image copy region.
@@ -60,6 +66,21 @@ impl ImageCopyRegion {
             buffer_image_height: height,
             mip_level: 0,
             array_layer: 0,
+        }
+    }
+
+    /// Project into the plugin-ABI `#[repr(C)]` wire struct the copy slots
+    /// read once at call time.
+    fn to_repr(self) -> ImageCopyRegionRepr {
+        ImageCopyRegionRepr {
+            width: self.width,
+            height: self.height,
+            buffer_offset: self.buffer_offset,
+            buffer_row_length: self.buffer_row_length,
+            buffer_image_height: self.buffer_image_height,
+            mip_level: self.mip_level,
+            array_layer: self.array_layer,
+            _reserved_padding: 0,
         }
     }
 }
@@ -224,6 +245,176 @@ impl RhiCommandRecorder {
         let status = unsafe {
             ((*self.methods_vtable).submit_and_wait)(
                 self.handle,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        status_to_result(status, &err_buf, err_len)
+    }
+
+    // -------------------------------------------------------------------------
+    // Buffer copy / barrier / timeline-submit wrappers (recorder-v1/v2 slots).
+    // The camera producer path drives these per frame:
+    // `record_copy_image_to_*` moves the compute output into an SSBO or a
+    // pooled pixel buffer, `record_*_barrier` transitions that destination
+    // for the reader, and `submit_signaling_timeline` ends the recording
+    // signalling a `produce_done` timeline. Sibling-slot-per-buffer-flavor:
+    // one typed wrapper per StorageBuffer / PixelBuffer destination, matching
+    // the ABI's `record_buffer_barrier` / `record_pixel_buffer_barrier` pair.
+    // -------------------------------------------------------------------------
+
+    /// Record `vkCmdCopyImageToBuffer` from `src` (currently in `src_layout`)
+    /// into a [`StorageBuffer`] destination. Dispatches the
+    /// `record_copy_image_to_buffer` slot.
+    pub fn record_copy_image_to_buffer(
+        &mut self,
+        src: &Texture,
+        src_layout: VulkanLayout,
+        dst: &StorageBuffer,
+        region: ImageCopyRegion,
+    ) -> Result<()> {
+        let vt = self.require_methods_vtable("record_copy_image_to_buffer")?;
+        let region_repr = region.to_repr();
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        // SAFETY: methods_vtable non-null per the guard; `src.handle` /
+        // `dst.handle` are the borrowed inner-`Arc` pointers the host
+        // reconstructs; `region_repr` lives across the call.
+        let status = unsafe {
+            ((*vt).record_copy_image_to_buffer)(
+                self.handle,
+                src.handle,
+                src_layout.0,
+                dst.handle,
+                &region_repr,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        status_to_result(status, &err_buf, err_len)
+    }
+
+    /// PixelBuffer-flavored sibling of [`Self::record_copy_image_to_buffer`]:
+    /// record `vkCmdCopyImageToBuffer` from `src` into a [`PixelBuffer`]
+    /// destination. Dispatches the `record_copy_image_to_pixel_buffer` slot.
+    pub fn record_copy_image_to_pixel_buffer(
+        &mut self,
+        src: &Texture,
+        src_layout: VulkanLayout,
+        dst: &PixelBuffer,
+        region: ImageCopyRegion,
+    ) -> Result<()> {
+        let vt = self.require_methods_vtable("record_copy_image_to_pixel_buffer")?;
+        let region_repr = region.to_repr();
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        // SAFETY: methods_vtable non-null per the guard; `src.handle` /
+        // `dst.handle` are the borrowed inner-`Arc` pointers the host
+        // reconstructs; `region_repr` lives across the call.
+        let status = unsafe {
+            ((*vt).record_copy_image_to_pixel_buffer)(
+                self.handle,
+                src.handle,
+                src_layout.0,
+                dst.handle,
+                &region_repr,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        status_to_result(status, &err_buf, err_len)
+    }
+
+    /// Record a whole-buffer memory barrier on a [`StorageBuffer`],
+    /// transitioning it across the given stage/access masks. Dispatches the
+    /// `record_buffer_barrier` slot.
+    pub fn record_buffer_barrier(
+        &mut self,
+        buffer: &StorageBuffer,
+        from_stage: VulkanStage,
+        to_stage: VulkanStage,
+        from_access: VulkanAccess,
+        to_access: VulkanAccess,
+    ) -> Result<()> {
+        let vt = self.require_methods_vtable("record_buffer_barrier")?;
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        // SAFETY: methods_vtable non-null per the guard; `buffer.handle` is
+        // the borrowed inner-`Arc` pointer the host reconstructs via
+        // `make_storage_buffer_borrow`.
+        let status = unsafe {
+            ((*vt).record_buffer_barrier)(
+                self.handle,
+                buffer.handle,
+                from_stage.0 as i64,
+                to_stage.0 as i64,
+                from_access.0 as i64,
+                to_access.0 as i64,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        status_to_result(status, &err_buf, err_len)
+    }
+
+    /// PixelBuffer-flavored sibling of [`Self::record_buffer_barrier`]:
+    /// record a whole-buffer memory barrier on a [`PixelBuffer`] (the
+    /// camera's per-frame `TRANSFER_WRITE` → `HOST_READ` transition on the
+    /// pooled IPC buffer). Dispatches the `record_pixel_buffer_barrier` slot.
+    pub fn record_pixel_buffer_barrier(
+        &mut self,
+        buffer: &PixelBuffer,
+        from_stage: VulkanStage,
+        to_stage: VulkanStage,
+        from_access: VulkanAccess,
+        to_access: VulkanAccess,
+    ) -> Result<()> {
+        let vt = self.require_methods_vtable("record_pixel_buffer_barrier")?;
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        // SAFETY: methods_vtable non-null per the guard; `buffer.handle` is
+        // the borrowed inner-`Arc` pointer the host reconstructs via
+        // `make_pixel_buffer_borrow`.
+        let status = unsafe {
+            ((*vt).record_pixel_buffer_barrier)(
+                self.handle,
+                buffer.handle,
+                from_stage.0 as i64,
+                to_stage.0 as i64,
+                from_access.0 as i64,
+                to_access.0 as i64,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        status_to_result(status, &err_buf, err_len)
+    }
+
+    /// End recording and submit, signalling `timeline` to `signal_value` on
+    /// GPU completion. Dispatches the `submit_signaling_timeline` slot.
+    pub fn submit_signaling_timeline(
+        &mut self,
+        timeline: &HostTimelineSemaphore,
+        signal_value: u64,
+    ) -> Result<()> {
+        let vt = self.require_methods_vtable("submit_signaling_timeline")?;
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        // SAFETY: methods_vtable non-null per the guard;
+        // `timeline.cdylib_handle()` is the borrowed
+        // `Arc::into_raw(Arc<HostVulkanTimelineSemaphore>)` inner pointer the
+        // host derefs as a `&HostVulkanTimelineSemaphore` borrow without
+        // bumping the refcount.
+        let status = unsafe {
+            ((*vt).submit_signaling_timeline)(
+                self.handle,
+                timeline.cdylib_handle(),
+                signal_value,
                 err_buf.as_mut_ptr(),
                 err_buf.len(),
                 &mut err_len as *mut usize,
@@ -498,5 +689,119 @@ mod layout_tests {
     fn rhi_command_recorder_is_send_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<RhiCommandRecorder>();
+    }
+}
+
+#[cfg(test)]
+mod dispatch_guard_tests {
+    use super::*;
+
+    fn null_recorder() -> RhiCommandRecorder {
+        RhiCommandRecorder {
+            handle: std::ptr::null(),
+            vtable: std::ptr::null(),
+            methods_vtable: std::ptr::null(),
+        }
+    }
+
+    fn null_texture() -> Texture {
+        Texture {
+            handle: std::ptr::null(),
+            vtable: std::ptr::null(),
+            width_cached: 0,
+            height_cached: 0,
+            format_raw: 0,
+            _padding: 0,
+        }
+    }
+
+    fn null_storage_buffer() -> StorageBuffer {
+        StorageBuffer {
+            handle: std::ptr::null(),
+            vtable: std::ptr::null(),
+            byte_size_cached: 0,
+            mapped_ptr_cached: std::ptr::null_mut(),
+        }
+    }
+
+    fn null_pixel_buffer() -> PixelBuffer {
+        PixelBuffer {
+            handle: std::ptr::null(),
+            vtable: std::ptr::null(),
+            width: 0,
+            height: 0,
+            format_raw: 0,
+            plane_count_cached: 0,
+        }
+    }
+
+    fn null_timeline() -> HostTimelineSemaphore {
+        HostTimelineSemaphore {
+            handle: std::ptr::null(),
+            methods: std::ptr::null(),
+        }
+    }
+
+    /// Every buffer copy / barrier / timeline-submit wrapper must refuse a
+    /// null methods vtable with a typed `Err`, never dereference it.
+    ///
+    /// Mental-revert: drop each wrapper's `require_methods_vtable` guard and
+    /// the `((*vt).slot)(...)` call UB-derefs a null
+    /// `*const RhiCommandRecorderMethodsVTable` (SIGSEGV in the runner).
+    #[test]
+    fn buffer_copy_barrier_timeline_wrappers_are_typed_errors_on_null_vtable() {
+        let mut recorder = null_recorder();
+        let texture = null_texture();
+        let storage_buffer = null_storage_buffer();
+        let pixel_buffer = null_pixel_buffer();
+        let timeline = null_timeline();
+        let region = ImageCopyRegion::tightly_packed(4, 4);
+
+        assert!(
+            recorder
+                .record_copy_image_to_buffer(&texture, VulkanLayout(0), &storage_buffer, region)
+                .is_err(),
+            "record_copy_image_to_buffer on a null-vtable recorder must return a typed Err, not UB"
+        );
+        assert!(
+            recorder
+                .record_copy_image_to_pixel_buffer(
+                    &texture,
+                    VulkanLayout(0),
+                    &pixel_buffer,
+                    region
+                )
+                .is_err(),
+            "record_copy_image_to_pixel_buffer on a null-vtable recorder must return a typed Err, \
+             not UB"
+        );
+        assert!(
+            recorder
+                .record_buffer_barrier(
+                    &storage_buffer,
+                    VulkanStage(0),
+                    VulkanStage(0),
+                    VulkanAccess(0),
+                    VulkanAccess(0)
+                )
+                .is_err(),
+            "record_buffer_barrier on a null-vtable recorder must return a typed Err, not UB"
+        );
+        assert!(
+            recorder
+                .record_pixel_buffer_barrier(
+                    &pixel_buffer,
+                    VulkanStage(0),
+                    VulkanStage(0),
+                    VulkanAccess(0),
+                    VulkanAccess(0)
+                )
+                .is_err(),
+            "record_pixel_buffer_barrier on a null-vtable recorder must return a typed Err, not UB"
+        );
+        assert!(
+            recorder.submit_signaling_timeline(&timeline, 1).is_err(),
+            "submit_signaling_timeline on a null-vtable recorder must return a typed Err, not UB"
+        );
     }
 }

--- a/sdk/streamlib-plugin-sdk/src/rhi/surface_store.rs
+++ b/sdk/streamlib-plugin-sdk/src/rhi/surface_store.rs
@@ -27,7 +27,7 @@ use streamlib_consumer_rhi::VulkanLayout;
 use streamlib_error::{Error, Result};
 use streamlib_plugin_abi::SurfaceStoreVTable;
 
-use crate::rhi::{HostTimelineSemaphore, Texture};
+use crate::rhi::{HostTimelineSemaphore, PixelBuffer, Texture};
 
 /// Cross-process surface-sharing handle (producer arm).
 ///
@@ -161,6 +161,75 @@ impl SurfaceStore {
         status_to_unit("register_texture", status, &err_buf, err_len)
     }
 
+    /// PixelBuffer sibling of [`Self::register_texture`]: register a pixel
+    /// buffer for cross-process sharing under `surface_id`, with optional
+    /// `produce_done` / `consume_done` timeline sidecars
+    /// (single-writer-per-edge; see
+    /// `docs/architecture/adapter-timeline-single-writer.md`). Dispatches
+    /// through the vtable's `register_pixel_buffer_with_timeline` slot
+    /// (Linux-only host-side).
+    ///
+    /// The cdylib passes a pointer to its own [`PixelBuffer`] PluginAbiObject
+    /// (the host reinterprets the layout-identical bytes) and the inner
+    /// handles of the exportable timelines; the host derefs the timeline
+    /// handles as `Arc<HostVulkanTimelineSemaphore>` borrows.
+    ///
+    /// Unlike [`Self::register_texture`], this slot takes no `VkImageLayout`
+    /// — a flat pixel-buffer allocation carries no image-layout state.
+    ///
+    /// Lifetime contract matches [`Self::register_texture`]: registration
+    /// only BORROWS the `produce_done` / `consume_done` timelines — the host
+    /// exports each one's `OPAQUE_FD` during this call and retains no clone
+    /// of the [`HostTimelineSemaphore`]. The caller MUST keep both timeline
+    /// values alive (and keep signalling `produce_done` by GPU-queue
+    /// completion) for the whole registration / session lifetime. Dropping a
+    /// timeline after registration decrements the host `VkSemaphore` refcount
+    /// to zero, so the producer can never signal `produce_done` again and a
+    /// subprocess consumer blocks forever waiting on it.
+    pub fn register_pixel_buffer_with_timeline(
+        &self,
+        surface_id: &str,
+        pixel_buffer: &PixelBuffer,
+        produce_done: Option<&HostTimelineSemaphore>,
+        consume_done: Option<&HostTimelineSemaphore>,
+    ) -> Result<()> {
+        if self.is_none() {
+            return Err(Error::GpuError(
+                "SurfaceStore::register_pixel_buffer_with_timeline: null handle".into(),
+            ));
+        }
+        let produce_done_ptr = produce_done
+            .map(|t| t.cdylib_handle())
+            .unwrap_or(std::ptr::null());
+        let consume_done_ptr = consume_done
+            .map(|t| t.cdylib_handle())
+            .unwrap_or(std::ptr::null());
+        let mut err_buf = [0u8; 512];
+        let mut err_len: usize = 0;
+        // SAFETY: handle + vtable paired at construction; `pixel_buffer` is a
+        // live `&PixelBuffer` whose `#[repr(C)]` layout matches the engine's,
+        // and the timeline handles are the host-minted inner Arc pointers.
+        let status = unsafe {
+            ((*self.vtable).register_pixel_buffer_with_timeline)(
+                self.handle,
+                surface_id.as_ptr(),
+                surface_id.len(),
+                pixel_buffer as *const PixelBuffer as *const c_void,
+                produce_done_ptr,
+                consume_done_ptr,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        status_to_unit(
+            "register_pixel_buffer_with_timeline",
+            status,
+            &err_buf,
+            err_len,
+        )
+    }
+
     /// Update the published `VkImageLayout` for an already-registered
     /// texture. Producer-side per-frame op after a layout transition.
     /// Dispatches through the vtable's `update_image_layout` slot.
@@ -287,6 +356,27 @@ mod layout_tests {
                 .register_texture("s", &null_texture, None, None, VulkanLayout(0))
                 .is_err(),
             "register_texture on a null store must return a typed Err, not UB"
+        );
+        // Same guard for the PixelBuffer sibling: build a null-handle
+        // PixelBuffer to pass — the is_none() guard fires before the pixel
+        // buffer pointer or the vtable is ever read.
+        //
+        // Mental-revert: drop register_pixel_buffer_with_timeline's is_none()
+        // guard and this call UB-derefs the null `*const SurfaceStoreVTable`
+        // (SIGSEGV).
+        let null_pixel_buffer = PixelBuffer {
+            handle: std::ptr::null(),
+            vtable: std::ptr::null(),
+            width: 0,
+            height: 0,
+            format_raw: 0,
+            plane_count_cached: 0,
+        };
+        assert!(
+            store
+                .register_pixel_buffer_with_timeline("s", &null_pixel_buffer, None, None)
+                .is_err(),
+            "register_pixel_buffer_with_timeline on a null store must return a typed Err, not UB"
         );
         drop(store);
     }


### PR DESCRIPTION
## PR 0 of 2 for #1226 — engine-free SDK precursor

Part of #1226 (convert `@tatolab/camera` to the engine-free plugin SDK). This is **PR 0**: expose already-shipped, host-tested ABI vtable slots through `streamlib-plugin-sdk` wrappers, so the camera port (PR 1) can drop the `streamlib` facade. **No ABI vtable change, no layout bump** — SDK wrappers only. The camera conversion itself is PR 1.

### Why a precursor
`process()` holds `GpuContextLimitedAccess`, the one-shot copy method is FullAccess-only, and per-frame `escalate` is prohibited (every escalate scope-end runs `wait_device_idle`). The sanctioned per-frame path is a setup-minted `RhiCommandRecorder` driven scope-free — the vtable v1 was designed for exactly this, but the SDK wrapper never exposed the methods (its module doc still claimed they "stay in the engine", stale since #1260/#1262).

### What's added (all over existing slots)
- **`RhiCommandRecorder`**: `record_copy_image_to_buffer`, `record_copy_image_to_pixel_buffer`, `record_buffer_barrier`, `record_pixel_buffer_barrier`, `submit_signaling_timeline`. Module doc's stale "stay in the engine" claim gets a dated strikethrough.
- **`SurfaceStore::register_pixel_buffer_with_timeline`** — the PixelBuffer sibling of `register_texture` (the ABI slot carries no layout param, unlike `register_texture`).
- **`GpuContextFullAccess::gpu_capabilities()`** (v5) + **`import_dma_buf_storage_buffer(fd, byte_size)`** (v7).
- **`resolve_color_defaults`** ported into SDK `color` (pure fn, no engine deps).
- **Bug fix (GAP B):** `copy_texture_to_storage_buffer_and_signal` was hardwiring `std::ptr::null()` for both timelines → `produce_done` never signaled → any cross-process consumer blocked forever. Now plumbs the produce/consume timelines through (the ABI slot + host body already carried the params). No external callers to migrate.

### Tests
Null-vtable typed-error guard per new wrapper (non-vacuous — reverting a guard SIGSEGVs the test), a `GpuCapabilitiesRepr` field-projection read, and the ported resolver cases. `cargo test -p streamlib-plugin-sdk --lib`: 84 passed.

### Verification (independent change-verifier)
- **No ABI/layout drift:** 5 files, all under `sdk/streamlib-plugin-sdk/src/`, zero under `runtime/`; `cargo test -p streamlib-plugin-abi --lib` 76/0, every vtable/repr layout test unchanged.
- **GAP B param order** cross-checked against the ABI slot *and* the host body (consume=wait first, produce=signal).
- `cargo xtask check-boundaries`: clean (5390 files).

### Notes
- One non-blocking style item: `resolve_color_defaults` rustdoc includes a 4-row defaults table (documentation of behavior, not a `# Example`/ASCII-diagram section).
- Live cross-process GPU dispatch is `/verify-live` territory (the sandbox can't observe the GPU); param/handle/order were verified by ABI + host source cross-reference.

Part of #1226 · PR 1 (camera conversion) to follow.
