### PR TITLE
chore(flow): comment-hygiene rule + rust-craftsmanship review lens

### DIFF
--- a/.claude/agents/rust-craftsmanship-reviewer.md
+++ b/.claude/agents/rust-craftsmanship-reviewer.md
@@ -1,0 +1,32 @@
+---
+name: rust-craftsmanship-reviewer
+description: Senior-Rust-engineer code-quality reviewer, run as an always-on lens over any Rust diff before a PR opens. Grades production-grade clean code the mechanical gates and the correctness verifier don't judge — duplication (DRY), code smell, idiomatic Rust, ownership ergonomics, allocation waste, and API shape — and returns a structured verdict. Read-only; it finds and grades, it never edits.
+tools: Read, Bash, Grep, Glob
+model: opus
+---
+
+You are the **rust-craftsmanship-reviewer** — a staff-level Rust engineer reviewing a diff for the qualities that separate merely-compiling code from production-grade code. You are **read-only**: no Edit, no Write; your Bash runs `git`/`gh`/`grep`/`cargo` for inspection only, never to mutate the tree. You find and grade; you do not fix.
+
+You are not the correctness gate (the change-verifier owns "does it do what the ticket says"), the domain gate (the domain-expert lenses own invariant correctness), or the mechanical gate (CI/clippy own layout/lint/boundary). You are the layer they all skip: **is this clean, idiomatic, non-duplicative Rust a senior reviewer would approve?**
+
+**Default stance: hold the bar high, but separate real defects from taste.** A finding must be something a strong Rust reviewer would raise in review, with the concrete alternative named — not a stylistic preference. Show the smell at `file:line` and state the specific fix.
+
+## What you grade
+
+- **Duplication (DRY) — the primary lens.** Copy-pasted or near-identical logic across functions, match arms, or modules; repeated construction/validation/conversion that a helper, an iterator adaptor, a `From`/`TryFrom` impl, or a small macro should collapse. Distinguish *real* duplication (same logic that must change together — extract it) from *incidental* similarity (two things that happen to look alike but evolve independently — leave it). When you claim duplication, point at every site.
+- **Code smell.** Primitive obsession (stringly-typed state, bare `u32`/`bool` where a newtype or enum encodes intent and prevents bugs); functions doing several unrelated things; deep nesting that `?` / early-return / `let-else` would flatten; boolean-parameter traps (`f(true, false)`); a free function that should be a method (or vice versa); needless `mut`; shotgun surgery (one change forces edits in many places because a concept isn't reified).
+- **Idiomatic Rust.** Iterator chains vs manual index loops where the chain is clearer; `?` / `map_err` / combinators vs `match` on every `Result`; `Option`/`Result` combinators vs hand-rolled unwrapping; `impl Trait` / generics vs `Box<dyn>` where it matters; borrowing ergonomics — needless `.clone()` / `.to_owned()` / `.to_vec()`, `String` where `&str` suffices, `Vec<T>` where `&[T]` suffices, owning where borrowing would do. **`unwrap()` / `expect()` / `panic!` / array indexing that can panic in library code is a defect** (tests/examples exempt) — the codebase mandates `?` over `.unwrap()`.
+- **Allocation & waste (correctness-adjacent).** Collecting into a `Vec` only to iterate it once; re-allocating in a loop; recomputing an invariant per iteration; cloning to satisfy the borrow checker where a restructure removes the clone.
+- **API & type shape.** A raw integer / string / handle passed around where a newtype would make misuse unrepresentable; a wide `pub` surface that should be crate-private; missing `#[must_use]` on a builder/guard; an enum that should be `#[non_exhaustive]` across the ABI/crate boundary; a trait or struct spun up as a parallel abstraction where a core system already covers the concern (this overlaps engine-doctrine "search first, extend never parallel" — flag it).
+
+## How to work
+1. `git diff origin/main..<branch>` (the caller gives you the branch). Review **only the added/changed Rust** — do not grade pre-existing code you're not touching, except to note when the diff *adds a new copy* of logic that already exists elsewhere (that IS your duplication lens — grep for the twin).
+2. For each candidate, confirm it's real: read enough surrounding code to be sure it's duplication/smell and not a false positive. A senior reviewer who cries wolf gets ignored.
+3. Name the concrete fix: "extract `fn foo` — three call sites at A/B/C build the same X", "newtype `SurfaceId(u64)` — this `u64` is passed through 5 fns and confused with `frame_index`", "`?` here instead of the `match` at L40-48".
+
+## Output
+Return the verdict JSON (`verdict` APPROVE / REJECT / ESCALATE, `findings[]`, `lens`, `coverage_notes`). Set `lens` to `"rust-craftsmanship"`. Severity per the taxonomy the caller appends:
+- **blocker** → REJECT the branch: genuinely unacceptable production Rust — real copy-paste duplication of non-trivial logic, `unwrap`/`panic` in library code, a smell that will cause a bug.
+- **should-fix** → a clear cleanliness win the owner should see and would want (rides the PR body).
+- **low** → a nit. **info** → an observation.
+Put an overall one-line **craftsmanship grade** in `coverage_notes` (e.g. `grade: B — one real duplication (3 sites) + two needless clones; otherwise idiomatic`). If the diff touches no Rust, return APPROVE with `coverage_notes: "no Rust in diff"`.

--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -1,0 +1,16 @@
+# Comments
+
+Comments cost tokens and bloat diffs. Write one only when it carries information **not derivable from
+reading the code**. Default to none.
+
+- **Allowed:** an ABI / wire contract, a spec convention or driver quirk, a non-obvious external
+  constraint, or a *why* the code's shape cannot show. Public items get a **one-line** rustdoc (per
+  `engine-doctrine`) — no multi-paragraph essays, no `# Example` / `# Usage`, no ASCII or markdown
+  tables padding a doc comment.
+- **Banned:** narrating what the code does, restating a name in prose, per-line play-by-play, or
+  explaining / dictating a decision. Decisions live in the PR and commit rationale and in the code's
+  shape — never in a perpetual inline comment. No breadcrumbs (`moved-to` / `was` / `carved-from`).
+- **Clean as you go:** when you touch or review a method carrying narration or decision comments,
+  remove them in the same edit. Cutting comment noise is part of the change, not a separate task.
+
+Applies to Rust, Python, Deno, and everything else.

--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -1,16 +1,23 @@
 # Comments
 
-Comments cost tokens and bloat diffs. Write one only when it carries information **not derivable from
-reading the code**. Default to none.
+Write a comment only when it carries information you can't get by reading the code. Default to none.
 
-- **Allowed:** an ABI / wire contract, a spec convention or driver quirk, a non-obvious external
-  constraint, or a *why* the code's shape cannot show. Public items get a **one-line** rustdoc (per
-  `engine-doctrine`) — no multi-paragraph essays, no `# Example` / `# Usage`, no ASCII or markdown
-  tables padding a doc comment.
-- **Banned:** narrating what the code does, restating a name in prose, per-line play-by-play, or
-  explaining / dictating a decision. Decisions live in the PR and commit rationale and in the code's
-  shape — never in a perpetual inline comment. No breadcrumbs (`moved-to` / `was` / `carved-from`).
-- **Clean as you go:** when you touch or review a method carrying narration or decision comments,
-  remove them in the same edit. Cutting comment noise is part of the change, not a separate task.
+## Don't
+- Don't restate what the code does.
+- Don't narrate a change (`changed X to Y`, `now uses…`, `previously…`).
+- Don't explain or justify a decision — that belongs in the PR/commit, not an inline comment.
+- Don't leave per-line play-by-play.
+- Don't leave breadcrumbs: `moved-to`, `was`, `carved-from`.
+- Don't write multi-paragraph rustdoc essays.
+- Don't put `# Example` or `# Usage` sections in a doc comment.
+- Don't put ASCII or markdown tables in a doc comment.
+
+## Do
+- Give each public item a one-line doc.
+- Comment an ABI or wire contract.
+- Comment a spec convention or a driver quirk.
+- Comment a non-obvious external constraint.
+- Comment a *why* the code's shape can't show.
+- Delete narration or decision comments from any method you touch, in the same edit.
 
 Applies to Rust, Python, Deno, and everything else.

--- a/.claude/workflows/verify-change.js
+++ b/.claude/workflows/verify-change.js
@@ -9,7 +9,7 @@ export const meta = {
     'Adjudicate a branch before opening a PR: the change-verifier (Stage A) plus parallel path-routed domain lenses and, when the branch claims E2E evidence, the evidence-verifier (Stage B). Any blocker → FIX; an unresolved owner question → DISCUSS; else PASS opens a PR ready for review (never a draft).',
   phases: [
     { title: 'Verify', detail: 'Stage A: the always-on change-verifier reviews the diff against the ticket and returns its verdict JSON.' },
-    { title: 'Lenses', detail: 'Stage B: parallel read-only domain lenses over the diff, plus evidence-verifier if E2E evidence is claimed.' },
+    { title: 'Lenses', detail: 'Stage B: parallel read-only domain lenses over the diff, the always-on rust-craftsmanship lens when the diff touches Rust, plus evidence-verifier if E2E evidence is claimed.' },
     { title: 'Adjudicate', detail: 'Merge findings → FIX / DISCUSS / PASS; PASS opens a PR ready for review via gh (never a draft, never a merge).' },
   ],
 };
@@ -122,8 +122,9 @@ const guard =
       `Confirm all three: (1) issue #${issue} is OPEN (\`gh issue view ${issue} --json state\`); (2) the branch ` +
       `\`${branch}\` exists (\`git rev-parse --verify ${branch}\` or \`git ls-remote --exit-code --heads origin ${branch}\`); ` +
       `(3) \`git diff origin/main..${branch} --stat\` is NON-EMPTY. Return { ok: true } only if all three hold; ` +
-      `otherwise { ok: false, reason: "<which check failed>" }.`,
-    { phase: 'Guard', label: 'branch-guard', model: 'sonnet', schema: { type: 'object', properties: { ok: { type: 'boolean' }, reason: { type: 'string' } }, required: ['ok'] } },
+      `otherwise { ok: false, reason: "<which check failed>" }. Also set touches_rust: true if ` +
+      `\`git diff origin/main..${branch} --name-only\` lists any path ending in \`.rs\`, else false.`,
+    { phase: 'Guard', label: 'branch-guard', model: 'sonnet', schema: { type: 'object', properties: { ok: { type: 'boolean' }, reason: { type: 'string' }, touches_rust: { type: 'boolean' } }, required: ['ok'] } },
   )) || {};
 if (guard.ok !== true) {
   const reason = guard.reason || 'branch-guard produced no result';
@@ -159,6 +160,19 @@ const lensThunks = experts.map((expert) => () =>
     { agentType: expert, phase: 'Lenses', label: `lens:${expert}`, schema: verdictSchema },
   ),
 );
+// The always-on Rust clean-code lens — duplication/smell/idiom/ownership/API shape
+// the mechanical gates and the correctness verifier don't judge. Gated on touches_rust.
+if (guard.touches_rust) {
+  lensThunks.push(() =>
+    resilientAgent(
+      `Read-only senior-Rust craftsmanship review of the added/changed Rust in the diff on issue #${issue}'s branch \`${branch}\`. ` +
+        `Grade duplication (DRY), code smell, idiomatic Rust, ownership/allocation ergonomics, and API/type shape — the clean-code ` +
+        `qualities the mechanical gates and the correctness verifier do not judge. Do NOT edit. Cite file:line and name the concrete ` +
+        `fix. Emit the verdict JSON (lens "rust-craftsmanship"); put an overall craftsmanship grade in coverage_notes. ${severityTaxonomy}`,
+      { agentType: 'rust-craftsmanship-reviewer', phase: 'Lenses', label: 'lens:rust-craftsmanship', schema: verdictSchema },
+    ),
+  );
+}
 if (claimsE2e) {
   lensThunks.push(() =>
     resilientAgent(

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ StreamLib is a BUSL-1.1-licensed real-time media engine (Vulkan RHI, V4L2, vulka
 iceoryx2 IPC, dlopen'd .slpkg plugin packages, Python/Deno SDKs). It is built like a game engine:
 ONE core system per concern — extend the existing system, never build a parallel one. Search first.
 
-Rules load from `.claude/rules/` (licensing, naming, engine doctrine always; RHI, plugin-ABI,
+Rules load from `.claude/rules/` (licensing, naming, engine doctrine, comments always; RHI, plugin-ABI,
 polyglot, docs-policy, flow rules load when you read matching files). Empirical driver knowledge
 lives in `docs/learnings/`; design rationale in `docs/decisions/`. Everything else is re-derived
 from code at need — do not create summary docs of what code already shows.


### PR DESCRIPTION
## Operating-model: comment hygiene + Rust craftsmanship review

Two quality-enforcement changes, owner-directed, shipped together as one operating-model PR per `.claude/rules/flow.md`.

### 1. Comment-hygiene rule
Adds always-loaded `.claude/rules/comments.md`: write a comment only when it carries information **not derivable from reading the code** — never to narrate or dictate decisions — and remove such comments from methods as they're touched. Registered in the CLAUDE.md rule-load line. Curbs AI-comment bloat and token waste.

### 2. Rust-craftsmanship review lens
Adds a `rust-craftsmanship-reviewer` agent (opus, read-only) and wires it into `verify-change.js` as an **always-on lens whenever a diff touches Rust**. It grades — like a senior Rust engineer — duplication (DRY), code smell, idiomatic Rust, ownership/allocation ergonomics, and API/type shape: the clean-code layer the mechanical gates (CI/clippy) and the correctness verifier don't judge. Findings ride the existing severity taxonomy — `blocker` forces FIX, `should-fix` rides the PR body — so real duplication and smell get caught before merge instead of accreting.

Per flow.md's new-agent requirement:
- **Non-derivable knowledge:** senior-Rust craftsmanship judgment — real vs incidental duplication, idiomatic patterns, ownership ergonomics, when a newtype/trait is warranted vs a parallel abstraction.
- **Why existing agents don't cover it:** change-verifier judges correctness / scope / test quality; the domain experts judge invariant correctness; neither grades clean-code craft.
- **Model tier:** opus (reasoning / judgment).

Gated on `touches_rust` (the branch-guard now reports it), so pure non-Rust changes don't pay for the lens.
