### PR TITLE
chore(flow): rig-brake asks for approval instead of hard-denying

### DIFF
--- a/.claude/hooks/rig-brake.sh
+++ b/.claude/hooks/rig-brake.sh
@@ -1,63 +1,61 @@
 #!/usr/bin/env bash
-# rig-brake (PreToolUse / Bash): refuse rig-consuming commands a sandboxed session
-# cannot observe (they die at exit 144). Read-only device probes stay allowed.
+# rig-brake (PreToolUse / Bash): a rig-consuming command (camera/display/GPU) that
+# runs in an unattended/sandboxed firing dies at exit 144 — but when the owner is
+# present it's a deliberate eval that SHOULD run. So rig-brake never has the final
+# say: it ESCALATES a suspected rig command to the human for approval (permission
+# "ask"), never hard-denies. The human always decides; benign probes/builds fall
+# through silently, so it only asks when a command actually looks like it drives
+# the rig.
 #
-# Every deny pattern is evaluated over the FULL command string, so a benign lead
-# clause (e.g. a v4l2-ctl query verb) can never blanket-allow a rig command
-# chained after it. The v4l2-ctl query verbs are exempt only from the v4l2
-# streaming deny — they are not in that pattern, so they simply don't match it.
-# Exit 2 + stderr = deny; exit 0 = allow.
+# Contract: exit 0 + JSON `permissionDecision:"ask"` escalates to the human. Plain
+# exit 0 (no output) defers to the normal permission flow. It never exits 2 — that
+# would be a hard deny, the final say we deliberately don't take.
 
 input="$(cat)"
 cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // ""')"
 cwd="$(printf '%s' "$input" | jq -r '.cwd // ""')"
 
-deny_rig() {
-  cat >&2 <<'MSG'
-rig-brake: refused — sandboxed sessions cannot observe GPU/IPC runtime (exit 144).
-Park the issue for /verify-live and post the command block for the owner's terminal.
-MSG
-  exit 2
+REASON='Looks like a rig-consuming command (camera/display/GPU). If you are here and this is a real eval, approve it — it runs with the sandbox bypass. If this is an unattended/sandboxed firing, decline and park it for /verify-live (it would otherwise die at exit 144). rig-brake only asks; you decide.'
+
+ask_rig() {
+  jq -n --arg r "$REASON" '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask", permissionDecisionReason: $r}}'
+  exit 0
 }
 
 has() { printf '%s' "$cmd" | grep -Eq -- "$1"; }
 cwd_has() { printf '%s' "$cwd" | grep -Eq -- "$1"; }
 
-# 1. ffmpeg with a v4l2 output or reading a camera device node.
+# 1. ffmpeg reading a camera device or writing a v4l2 output.
 if has '\bffmpeg\b' && has '\-f[[:space:]]+v4l2|/dev/video[0-9]+'; then
-  deny_rig
+  ask_rig
 fi
 
-# 2. cargo run for example crates that open camera/display at runtime:
-#    (a) the -p / --package matcher, (b) run from inside an examples/ dir
-#    (payload cwd), or (c) the command references an examples/ path.
+# 2. cargo run for example crates that open camera/display at runtime.
 if has 'cargo[[:space:]]+run'; then
   if has '(-p|--package)[[:space:]]+(camera-display|vulkan-video-roundtrip)' \
      || cwd_has '(^|/)examples(/|$)' \
      || has '(^|[^[:alnum:]_.-])examples/'; then
-    deny_rig
+    ask_rig
   fi
 fi
 
 # 3. e2e_ fixture scripts under tests/fixtures/.
 if has 'tests/fixtures/e2e_[[:alnum:]_./-]*\.sh'; then
-  deny_rig
+  ask_rig
 fi
 
-# 4. Reading/streaming a camera device node via a media tool — cat, dd, ffplay,
-#    mpv, gst-launch*. A word-boundary match on the tool name plus a real
-#    /dev/video[0-9] path. A bare textual mention (grep/echo/log path) does not
-#    match: the tool name isn't one of these, or there's no /dev/video path.
-if has '\b(cat|dd|ffplay|mpv|gst-launch(-[0-9.]+)?)\b' && has '/dev/video[0-9]+'; then
-  deny_rig
+# 4. A media PLAYER/streamer pointed at a real camera device node. cat/dd are
+#    dropped from this rule: a benign `cat file` that merely mentions a device
+#    path in the same command must not trigger an ask (the old false-positive).
+if has '\b(ffplay|mpv|gst-launch(-[0-9.]+)?)\b' && has '/dev/video[0-9]+'; then
+  ask_rig
 fi
 
-# 5. v4l2-ctl streaming verbs. Query verbs (--list-devices, --get-fmt-video,
-#    --list-formats*, --all, --info, -D, --get-*) are exempt — they aren't in
-#    this pattern, so a query-only v4l2-ctl command falls through to exit 0.
+# 5. v4l2-ctl streaming verbs. Query verbs (--list-*, --get-*, --all, --info, -D)
+#    aren't in this pattern, so a query-only v4l2-ctl command falls through.
 if has '\bv4l2-ctl\b' \
    && has '--stream-(mmap|user|to|out|dmabuf|from|dqmax)|--stream[[:space:]=]'; then
-  deny_rig
+  ask_rig
 fi
 
 exit 0


### PR DESCRIPTION
## rig-brake: ask, never deny (operating-model)

Owner-directed. rig-brake was built on "sandboxed sessions can't observe the rig," so it **hard-denied** (exit 2) rig commands. But rig evals — running a pipeline on the real rig and proving it with images — are first-class, and the hook was blocking them (it false-positived on a benign `cat` that merely mentioned a device path).

**Change:** every deny path becomes a PreToolUse `permissionDecision: "ask"` — it **escalates to the human, who approves**, and never has the final say. It only asks when a command genuinely looks like it drives the rig; benign probes, builds, and directly-run binaries fall through silently.

- `exit 2` (deny) → `{ hookSpecificOutput: { permissionDecision: "ask", ... } }` (exit 0).
- Dropped `cat`/`dd` from the media-tool+device rule (the false-positive source); kept `ffplay`/`mpv`/`gst-launch`.
- Unchanged: query verbs and built-binary runs (the eval path) pass silently; `cargo run` from examples, ffmpeg+v4l2, e2e scripts, and `v4l2-ctl --stream` now **ask** instead of deny.

Verified against the exact cases (the old false-positive → silent; a query verb → silent; `cargo run`/ffplay/`--stream` → ask). Operating-model change, its own PR per `.claude/rules/flow.md`.