### PR TITLE
chore(release): sync Cargo.lock to workspace version 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4777,7 +4777,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "streamlib"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "streamlib-build-orchestrator",
  "streamlib-engine",
@@ -4785,7 +4785,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-adapter-abi"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -4796,7 +4796,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-adapter-cpu-readback"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "libc",
  "serde",
@@ -4816,11 +4816,11 @@ dependencies = [
 
 [[package]]
 name = "streamlib-adapter-cpu-readback-abi"
-version = "0.7.0"
+version = "0.7.1"
 
 [[package]]
 name = "streamlib-adapter-cpu-readback-helpers"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "libc",
  "serde",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-adapter-cuda"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "dlpark",
  "libc",
@@ -4858,11 +4858,11 @@ dependencies = [
 
 [[package]]
 name = "streamlib-adapter-cuda-abi"
-version = "0.7.0"
+version = "0.7.1"
 
 [[package]]
 name = "streamlib-adapter-cuda-helpers"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cudarc",
  "libc",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-adapter-opengl"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "gl",
  "khronos-egl",
@@ -4905,11 +4905,11 @@ dependencies = [
 
 [[package]]
 name = "streamlib-adapter-opengl-abi"
-version = "0.7.0"
+version = "0.7.1"
 
 [[package]]
 name = "streamlib-adapter-skia"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "libc",
  "libloading 0.8.9",
@@ -4933,11 +4933,11 @@ dependencies = [
 
 [[package]]
 name = "streamlib-adapter-skia-abi"
-version = "0.7.0"
+version = "0.7.1"
 
 [[package]]
 name = "streamlib-adapter-vulkan"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "libc",
  "serde",
@@ -4957,11 +4957,11 @@ dependencies = [
 
 [[package]]
 name = "streamlib-adapter-vulkan-abi"
-version = "0.7.0"
+version = "0.7.1"
 
 [[package]]
 name = "streamlib-adapter-vulkan-helpers"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "libc",
  "serde",
@@ -5001,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-build-orchestrator"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-cargo-build"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -5036,7 +5036,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-consumer-rhi"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "libc",
  "streamlib-surface-client",
@@ -5075,7 +5075,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-deno-native"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cudarc",
  "iceoryx2",
@@ -5097,7 +5097,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-engine"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-error"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "streamlib-consumer-rhi",
@@ -5187,7 +5187,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-idents"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "flate2",
  "schemars 0.8.22",
@@ -5206,14 +5206,14 @@ dependencies = [
 
 [[package]]
 name = "streamlib-ipc-types"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "iceoryx2",
 ]
 
 [[package]]
 name = "streamlib-jtd-codegen"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -5228,7 +5228,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-macros"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "crossbeam-channel",
  "proc-macro-crate",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-moq"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bytes",
  "moq-transport",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-pack"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "libc",
@@ -5284,11 +5284,11 @@ dependencies = [
 
 [[package]]
 name = "streamlib-plugin-abi"
-version = "0.7.0"
+version = "0.7.1"
 
 [[package]]
 name = "streamlib-plugin-sdk"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "criterion",
  "iceoryx2-log",
@@ -5308,7 +5308,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-processor-schema"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "rmp-serde",
  "schemars 0.8.22",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-python-native"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cudarc",
  "iceoryx2",
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-runtime"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-surface-client"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "libc",
  "serde_json",
@@ -5367,7 +5367,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-test-fixtures"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde",
  "streamlib",
@@ -5379,7 +5379,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-test-fixtures-abi-mismatch"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "streamlib-plugin-abi",
 ]
@@ -6079,7 +6079,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vulkan-jpeg"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bytemuck",
  "jpeg-encoder",


### PR DESCRIPTION
## What
Regenerate the root `Cargo.lock` so its 37 workspace-crate entries read `0.7.1`, matching `[workspace.package].version` in `Cargo.toml`. Version-only diff (`cargo update --workspace`), zero dependency changes.

## Why
The `0.7.1` release (#1432, release-please) bumped `Cargo.toml` to `0.7.1` but did **not** regenerate `Cargo.lock`, which still pinned every workspace crate at `0.7.0`. CI runs cargo with `--locked`, so the mismatch made cargo error before any check ran:

```
error: cannot update the lock file ... because --locked was passed
```

That turned **all** compiling CI jobs red on every open PR (only the two non-cargo checks — `check-headers`, `conventional-title` — passed). This is a broken baseline on `main`, not a code regression, and it does not self-heal.

Verified locally: `cargo metadata --locked` now succeeds (the exact condition CI failed on).

## Why `chore`, not `fix`
A `fix` title would make release-please cut `0.7.2`, which — until the durable fix below lands — would recreate the same stale-lock breakage at `0.7.2`. `chore` doesn't bump the version; main just gets the corrected `0.7.1` lock.

## Follow-up (separate, tracked)
The root cause is that release-please isn't regenerating `Cargo.lock` on version bumps. A durable config fix (so this doesn't recur on the next release) is being researched and will land as its own operating-model PR. This PR is only the one-time unblock.

After this merges, open M34 branches (e.g. #1433) rebase onto `main` to inherit the corrected lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)