### PR TITLE
ci(release): sync Cargo.lock in the release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,6 +17,8 @@ jobs:
       tag_name: ${{ steps.tag.outputs.tag_name || steps.open.outputs.tag_name }}
       version: ${{ steps.tag.outputs.major || steps.open.outputs.major }}.${{ steps.tag.outputs.minor || steps.open.outputs.minor }}.${{ steps.tag.outputs.patch || steps.open.outputs.patch }}
     steps:
+      - uses: actions/checkout@v4
+
       # Pass 1 — open / refresh the standing release PR (version bump + changelog)
       # for the feat/fix commits landed since the last release.
       - uses: googleapis/release-please-action@v4
@@ -24,6 +26,39 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # The `simple` release-type bumps [workspace.package].version in Cargo.toml
+      # (via extra-files) but has no Cargo.lock updater, so the workspace-member
+      # entries in Cargo.lock keep the old version. CI runs cargo with --locked,
+      # so a merged bump with a stale lock errors before any check runs. Sync the
+      # lock on the release-PR branch (found by the same `autorelease: pending`
+      # label the auto-merge step below uses) so the squash-merge folds it into
+      # the release commit. `cargo update --workspace` rewrites only the member
+      # versions and leaves external deps pinned (resolution only, no build);
+      # no-ops when nothing is pending or the lock is already in sync.
+      - name: Sync Cargo.lock to the release version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 100 \
+            --json headRefName,labels \
+            --jq 'map(select(.labels[].name == "autorelease: pending")) | .[0].headRefName // empty')
+          if [ -z "$BRANCH" ]; then
+            echo "no open release PR this run"
+            exit 0
+          fi
+          git fetch origin "$BRANCH"
+          git checkout "$BRANCH"
+          cargo update --workspace
+          if git diff --quiet -- Cargo.lock; then
+            echo "Cargo.lock already in sync"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Cargo.lock
+          git commit -m "chore: sync Cargo.lock to the release version"
+          git push origin "$BRANCH"
 
       # A version cut is pure bookkeeping — version + changelog, no code — so it
       # needs no human gate; auto-merge the release PR the moment it exists. The


### PR DESCRIPTION
## Problem
release-please uses `release-type: "simple"` — the only type that handles this **virtual workspace**'s shared `[workspace.package].version` (inherited by all 37 members via `version.workspace = true`). `simple` bumps `Cargo.toml` (via `extra-files`) but has **no `Cargo.lock` updater**, so after a release the lock's workspace-member entries stay at the old version. CI runs cargo with `--locked`, so the next PR errors before any check runs:

```
error: cannot update the lock file ... because --locked was passed
```

This is what turned all CI red after `0.7.1` (#1432).

## Why not the obvious alternatives (checked against release-please source)
- **`release-type: "rust"`** — its `CargoToml` updater *rejects* a virtual-workspace root and *skips* members using `version.workspace = true` (all 37 here). It's incompatible with this layout, which is why #1405 chose `simple`.
- **`extra-files` → `Cargo.lock`** — no jsonpath isolates the 37 member entries among hundreds of external-dep versions; the annotation-based `generic` updater doesn't survive cargo rewriting the lock.

## Fix
Add a step to the release workflow that, **after** the release PR is opened and **before** it auto-merges, checks out the release branch, runs `cargo update --workspace` (rewrites only the member versions; external deps stay pinned; resolution only, no build), and commits the synced lock. The existing squash-merge then folds a matching `Cargo.lock` into the release commit. The step:
- finds the release branch by the same `autorelease: pending` label the auto-merge step already uses;
- no-ops cleanly when there's no pending release or the lock is already in sync;
- self-heals across reruns (a later `open` refresh drops the commit; this step re-adds it).

`contents: write` is already granted, so the default `GITHUB_TOKEN` authorizes the push — no new secret.

## Scope / caveats
- Takes effect from the **next** release (`0.7.2+`). It does **not** retroactively fix `main` — the already-merged `0.7.1` lock is fixed one-time by #1434.
- Standalone operating-model change per the flow rules (its own PR, `ci:` title — no version bump).
- **CI on this PR is red until #1434 merges** (same stale-lock baseline); it'll go green on rebase after #1434 lands. The change itself is a workflow-only edit and doesn't run until a future release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)