### PR TITLE
chore(flow): fix-ticket Apply phase returns a structured report

### DIFF
--- a/.claude/workflows/fix-ticket.js
+++ b/.claude/workflows/fix-ticket.js
@@ -130,8 +130,14 @@ const applyPrompt =
       `resulting \`commits\`, and \`git diff origin/main --stat\` in \`diff_stat\`.\n\n` +
       `Findings to apply (JSON): ${JSON.stringify(findings)}`;
 
+// The schema is load-bearing: without it the Apply agent's return is raw text,
+// `applied.worktree_path` is undefined, and the Test phase gates against an empty
+// path (the hard guard then skips the whole battery). Force the structured report.
 const applied =
-  (await resilientAgent(applyPrompt, leadOpts({ phase: 'Apply', label: `fix:${lead || 'generic'}:${mode}` }))) || {};
+  (await resilientAgent(
+    applyPrompt,
+    leadOpts({ phase: 'Apply', label: `fix:${lead || 'generic'}:${mode}`, schema: fixReportSchema }),
+  )) || {};
 log(`fix applied: mode=${mode} branch=${applied.branch || branch} commits=${(applied.commits || []).length} unresolved=${(applied.unresolved || []).length}`);
 
 phase('Test');


### PR DESCRIPTION
## Bug
Every `fix-ticket.js` run skipped its entire gate battery. The Apply-phase agent (both `fix` and `rebase` modes) was invoked with **no `schema`**, so `resilientAgent` returned the agent's raw **text**. The next line reads `applied.worktree_path` on that string → `undefined` → the Test phase gates against an empty path and the hard guard aborts before any gate runs.

Observed 4× across both modes this session:
- **fix** mode (#1407, #1408 fix rounds): branch also went **unpushed** — each round needed a manual `local-ci-runner` + push workaround.
- **rebase** mode (#1433, #1435): the rebase + force-push still happened (so GitHub CI covered the branch), but the in-worktree gate report was lost.

`implement-ticket.js` doesn't have this bug because its implement agent passes `schema: implementSchema`.

## Fix
Attach the already-defined `fixReportSchema` (which lists `worktree_path` as `required`) to the Apply-phase agent, so it returns the structured `{worktree_path, branch, commits, diff_stat, applied, unresolved, rebased, force_pushed}` report. The Test phase then receives a real worktree path and runs the battery. One-line root-cause fix + a short comment marking the schema load-bearing.

`node --check` passes.

## Why `chore(flow)`
Operating-model change under `.claude/` — must not bump the engine/SDK version (matches #1405/#1404/#1402). Per the flow rules it ships as its own PR with rationale, not folded into feature work.

## Verification note
The defect is in agent-orchestration plumbing, not unit-testable in isolation; correctness is by inspection (the schema forces structured output, mirroring implement-ticket.js) and will be confirmed by the next real `fix-ticket` fix-round returning a populated `worktree_path` + a run gate table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)