### PR TITLE
feat(cli): manifest extraction capability — syn source-scan + shared grammar (#1411 stage 1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,4 +64,4 @@ jobs:
       # streamlib-engine's lib tests (host-body tier-1 + engine twin) are a tracked
       # follow-up, pending a fix to a parallel-run test flake.
       - name: Run unit tests
-        run: cargo test --locked -p streamlib -p streamlib-plugin-abi -p streamlib-plugin-sdk --lib
+        run: cargo test --locked -p streamlib -p streamlib-plugin-abi -p streamlib-plugin-sdk -p streamlib-processor-extract --lib

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5313,6 +5313,7 @@ version = "0.7.2"
 dependencies = [
  "proc-macro2",
  "quote",
+ "serde_json",
  "streamlib-processor-schema",
  "syn",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5238,6 +5238,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "streamlib-idents",
+ "streamlib-processor-extract",
  "streamlib-processor-schema",
  "syn",
 ]
@@ -5303,6 +5304,18 @@ dependencies = [
  "streamlib-macros",
  "streamlib-plugin-abi",
  "streamlib-processor-schema",
+ "tracing",
+]
+
+[[package]]
+name = "streamlib-processor-extract"
+version = "0.7.2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "streamlib-processor-schema",
+ "syn",
+ "thiserror 2.0.18",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "sdk/streamlib-jtd-codegen", # JTD-codegen pipeline: schema YAML → typed Rust/Python/TypeScript bindings
     "sdk/streamlib-idents",    # Structured schema identifiers, semver, manifest/lockfile types (#399)
     "sdk/streamlib-macros",    # Procedural macros for reducing boilerplate
+    "sdk/streamlib-processor-extract", # Shared `#[processor(...)]` grammar + syn source-scan that derives the `processors:` manifest from code (#1411)
     "runtime/streamlib-plugin-abi", # ABI-stable FFI types for dynamic plugins
     "adapters/streamlib-adapter-abi", # ABI-stable surface adapter contract (in-tree + 3rd-party adapters)
     "runtime/streamlib-consumer-rhi", # Consumer-side carve-out of the Vulkan RHI — DMA-BUF FD import + bind + map. cdylibs depend on this NOT the full streamlib so the FullAccess capability boundary is type-system enforced (Linux)

--- a/docs/decisions/manifest-extraction-capability.md
+++ b/docs/decisions/manifest-extraction-capability.md
@@ -1,0 +1,65 @@
+# Manifest extraction as a shared source-scan capability
+
+## Trigger
+
+Reach for this when touching how a package's `processors:` manifest section
+relates to its `#[processor(...)]` attributes — deriving the manifest from
+code, deciding where the attribute grammar lives, or reconciling the version-
+free attribute grammar with the release-core versions the catalog carries.
+
+## Decision
+
+The `#[processor(...)]` attribute is the single source of truth for a
+processor's identity, execution mode, and ports. The `processors:` manifest
+section is therefore *derived* from the attribute usage in code, by a
+source-scan that reads a crate's `src/` **without compiling it into the host**
+and produces the manifest-shaped processor list.
+
+The attribute is parsed by exactly one parser,
+`streamlib_processor_extract::grammar`. Both readers of code-as-truth call it:
+the proc-macro (`streamlib-macros`) at expansion, and the source-scan extractor
+over the tokens a `syn`-parsed attribute carries. The grammar and the extractor
+live together in the small non-proc-macro crate `streamlib-processor-extract`,
+which both `streamlib-macros` and the build seam (`streamlib-pack`) depend on.
+
+The scan produces a `ProcessorSchema` whose `name` is the identity's `Type`
+segment, whose `version` is the `0.0.0` version-free sentinel, and whose ports
+carry resolve-free `PortSchemaSpec::Specific(@org/package/Type@0.0.0)` idents.
+Version resolution is the consumer's projection: the publish-time catalog
+projects each version-free ref to a release-core `SchemaIdent` — the owner
+package's version for a locally-owned schema, the owning dependency's version
+for an external one — the same way it already projects a bare `Named` ref
+through the `schemas:` map. A `-dev.N` package projects to its release-core
+version at build time; that is a build-time projection, not a publish gate.
+
+## Rejected alternatives
+
+- **Grammar in the proc-macro crate.** A `proc-macro = true` crate can only
+  export procedural macros, never a library function another crate links — so
+  the source-scan could not reuse it, and would need a second parser that
+  drifts against the first.
+- **A second parser in the extractor.** A parallel grammar is the parallel
+  abstraction the engine doctrine forbids; the two would diverge silently.
+- **Extraction inside the engine runtime crate.** A `syn`-AST scan over an
+  uncompiled crate needs none of the engine runtime (RHI, IPC, executor) and
+  must not pull it into the build seam.
+- **Extraction only inside `streamlib-pack`.** Pack is the natural consumer,
+  but the grammar must also be shared with the proc-macro, and a future
+  live-submit path needs the extractor without the whole pack crate.
+
+## Consequences
+
+- One grammar serves both the macro and the scan; the macro expands
+  identically after the move (its unit + integration tests are unchanged).
+- The scan is a lean text-in / manifest-out transform reusable by any build or
+  submit path.
+- `extract_rust_processors` visits every `.rs` under `src/`, including platform
+  arms a given host does not compile (`linux/` vs `apple/`) and parked
+  directories (`_apple_impl_pending_/`). Two platform arms that both declare the
+  same processor both surface from one scan. Resolving the scan to the set
+  actually compiled for the build target — honoring `#[cfg]` and the parked-
+  directory convention — is required before extraction replaces the hand-
+  authored `processors:` as the authoritative truth-source, and before a drift
+  check between the two can be a hard `pkg build` error without false-positives
+  on cfg-gated packages. That module-reachability resolution builds on this scan
+  capability and its shared grammar.

--- a/sdk/streamlib-macros/Cargo.toml
+++ b/sdk/streamlib-macros/Cargo.toml
@@ -24,6 +24,9 @@ serde_yaml = { workspace = true }
 
 # Execution types (shared with streamlib for code generation)
 streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.7.0" }
+# The `#[processor(...)]` attribute grammar — shared with the source-scan
+# extractor so both parse the attribute through one parser (#1411).
+streamlib-processor-extract = { path = "../streamlib-processor-extract", version = "0.7.0" }
 # Manifest resolver — used to walk the enclosing manifest's `schemas:` map
 # and resolve bare-name `PortSchemaSpec::Named` references to fully-
 # qualified `SchemaIdent`s at proc-macro expansion time (#767).

--- a/sdk/streamlib-macros/src/lib.rs
+++ b/sdk/streamlib-macros/src/lib.rs
@@ -6,7 +6,7 @@
 //! - `#[streamlib::processor("@org/package/Type", execution = …, …)]`
 //!   — processor definition. The attribute is the single source of truth:
 //!   identity, execution mode, and input/output ports are declared in code,
-//!   read from no file at expansion. See [`attribute_grammar`] for the full
+//!   read from no file at expansion. See [`streamlib_processor_extract::grammar`] for the full
 //!   grammar. An identity string omitted from the attribute synthesizes an
 //!   `@app/local/<StructName>` identity so a bare crate with no
 //!   `streamlib.yaml` compiles.
@@ -23,9 +23,13 @@
 //!   reason to refuse newer-but-compatible registered versions; the
 //!   `_any_version` form is the right default for everything else.
 
-mod attribute_grammar;
 mod codegen;
 mod config_descriptor;
+
+// The `#[processor(...)]` grammar lives in `streamlib-processor-extract` so the
+// source-scan extractor and this macro parse it through one shared parser (a
+// `proc-macro = true` crate cannot export the grammar as a library). #1411.
+use streamlib_processor_extract::grammar as attribute_grammar;
 
 use proc_macro::TokenStream;
 use quote::quote;
@@ -47,7 +51,7 @@ use syn::{
 /// Main processor attribute macro.
 ///
 /// The attribute is the single source of truth for a processor's identity,
-/// execution mode, and ports — see [`attribute_grammar`] for the grammar. It
+/// execution mode, and ports — see [`streamlib_processor_extract::grammar`] for the grammar. It
 /// reads no file at expansion. An omitted identity string synthesizes an
 /// `@app/local/<StructName>` identity so a bare crate compiles with no
 /// `streamlib.yaml`.
@@ -69,7 +73,7 @@ use syn::{
 pub fn processor(attr: TokenStream, item: TokenStream) -> TokenStream {
     let item_struct = parse_macro_input!(item as ItemStruct);
 
-    let parsed = match attribute_grammar::parse(attr, &item_struct.ident) {
+    let parsed = match attribute_grammar::parse2(attr.into(), &item_struct.ident) {
         Ok(parsed) => parsed,
         Err(err) => return err.to_compile_error().into(),
     };

--- a/sdk/streamlib-macros/src/lib.rs
+++ b/sdk/streamlib-macros/src/lib.rs
@@ -33,10 +33,7 @@ use streamlib_processor_extract::grammar as attribute_grammar;
 
 use proc_macro::TokenStream;
 use quote::quote;
-use streamlib_processor_schema::{
-    Org, Package, ProcessorPortSchema, ProcessorSchema, ProcessorScheduling, RuntimeConfig,
-    RuntimeOptions, SemVer, TypeName,
-};
+use streamlib_processor_schema::{Org, Package, SemVer, TypeName};
 
 // Range parsing for `module_ident!*` macros. The streamlib_idents crate
 // owns the SemVerRange grammar; the macro just forwards the input through
@@ -78,7 +75,7 @@ pub fn processor(attr: TokenStream, item: TokenStream) -> TokenStream {
         Err(err) => return err.to_compile_error().into(),
     };
 
-    let schema = processor_schema_from_parsed(&parsed);
+    let schema = parsed.to_processor_schema();
     let schema_ident = parsed.ident.clone();
     let config_field_name = parsed
         .config_type
@@ -96,45 +93,6 @@ pub fn processor(attr: TokenStream, item: TokenStream) -> TokenStream {
     );
 
     TokenStream::from(generated)
-}
-
-/// Build a [`ProcessorSchema`] from a parsed attribute so the existing codegen
-/// (identity / execution / scheduling / ports emission) is reused unchanged.
-/// Config binding is threaded separately (the Rust config type comes from the
-/// attribute, not a resolved manifest schema), so `config` is always `None`
-/// here.
-fn processor_schema_from_parsed(parsed: &attribute_grammar::ParsedProcessorAttr) -> ProcessorSchema {
-    let to_port = |p: &attribute_grammar::ParsedPort| ProcessorPortSchema {
-        name: p.name.clone(),
-        schema: p.schema.clone(),
-        description: p.description.clone(),
-        read_mode: p.read_mode.clone(),
-        overflow: p.overflow.clone(),
-        buffer_size: p.buffer_size,
-    };
-
-    ProcessorSchema {
-        name: parsed.ident.r#type.as_str().to_string(),
-        version: parsed.ident.version.to_string(),
-        description: parsed.description.clone(),
-        runtime: RuntimeConfig {
-            language: Default::default(),
-            options: RuntimeOptions {
-                unsafe_send: parsed.unsafe_send,
-                python_version: None,
-            },
-            env: Default::default(),
-        },
-        entrypoint: None,
-        execution: parsed.execution.clone(),
-        scheduling: parsed
-            .scheduling
-            .map(|priority| ProcessorScheduling { priority }),
-        config: None,
-        state: Vec::new(),
-        inputs: parsed.inputs.iter().map(to_port).collect(),
-        outputs: parsed.outputs.iter().map(to_port).collect(),
-    }
 }
 
 /// Resolve the path to the `sdk` module the emitted code authors against.

--- a/sdk/streamlib-processor-extract/Cargo.toml
+++ b/sdk/streamlib-processor-extract/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "streamlib-processor-extract"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license-file.workspace = true
+repository.workspace = true
+
+[dependencies]
+# The `#[processor(...)]` attribute grammar lives here (not in the proc-macro
+# crate) so BOTH the macro AND the source-scan extractor parse it through the
+# exact same parser — one grammar, never two. A `proc-macro = true` crate can
+# only export proc-macros, so the grammar cannot be shared from there.
+syn = { version = "2.0", features = ["full", "extra-traits"] }
+proc-macro2 = "1.0"
+
+streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.7.0" }
+
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+quote = "1.0"
+
+[lints]
+workspace = true

--- a/sdk/streamlib-processor-extract/Cargo.toml
+++ b/sdk/streamlib-processor-extract/Cargo.toml
@@ -21,6 +21,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 quote = "1.0"
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/sdk/streamlib-processor-extract/src/grammar.rs
+++ b/sdk/streamlib-processor-extract/src/grammar.rs
@@ -30,7 +30,8 @@
 //! scope here and handled at the runtime layer.
 
 use streamlib_processor_schema::{
-    Org, Package, PortSchemaSpec, ProcessorSchemaExecution, SchemaIdent, SemVer, ThreadPriority,
+    Org, Package, PortSchemaSpec, ProcessorPortSchema, ProcessorSchema, ProcessorSchemaExecution,
+    ProcessorScheduling, RuntimeConfig, RuntimeOptions, SchemaIdent, SemVer, ThreadPriority,
     TypeName,
 };
 use syn::ext::IdentExt;
@@ -80,13 +81,62 @@ pub struct ParsedProcessorAttr {
     pub outputs: Vec<ParsedPort>,
 }
 
+impl ParsedProcessorAttr {
+    /// Project the parsed attribute into the manifest-shaped [`ProcessorSchema`].
+    ///
+    /// This is the single projection both readers of the attribute share: the
+    /// proc-macro emits its descriptor from this, and the source-scan extractor
+    /// builds each manifest entry from it — so an added `ParsedProcessorAttr` or
+    /// `ProcessorSchema` field can never silently diverge the two. `name` is the
+    /// identity's `Type` segment, ports carry the resolve-free `Specific` idents
+    /// the attribute declared, and the runtime language defaults to Rust (the
+    /// only language a source scan of a Rust crate can produce). `config` stays
+    /// `None`: the attribute binds a config *type*, not a resolved manifest
+    /// schema; the consuming layer projects the config-schema id to a
+    /// release-core catalog entry.
+    pub fn to_processor_schema(&self) -> ProcessorSchema {
+        let to_port = |p: &ParsedPort| ProcessorPortSchema {
+            name: p.name.clone(),
+            schema: p.schema.clone(),
+            description: p.description.clone(),
+            read_mode: p.read_mode.clone(),
+            overflow: p.overflow.clone(),
+            buffer_size: p.buffer_size,
+        };
+
+        ProcessorSchema {
+            name: self.ident.r#type.as_str().to_string(),
+            version: self.ident.version.to_string(),
+            description: self.description.clone(),
+            runtime: RuntimeConfig {
+                language: Default::default(),
+                options: RuntimeOptions {
+                    unsafe_send: self.unsafe_send,
+                    python_version: None,
+                },
+                env: Default::default(),
+            },
+            entrypoint: None,
+            execution: self.execution.clone(),
+            scheduling: self
+                .scheduling
+                .map(|priority| ProcessorScheduling { priority }),
+            config: None,
+            state: Vec::new(),
+            inputs: self.inputs.iter().map(to_port).collect(),
+            outputs: self.outputs.iter().map(to_port).collect(),
+        }
+    }
+}
+
 /// Parse the `#[processor(...)]` attribute tokens into a [`ParsedProcessorAttr`].
 ///
 /// This is the single, shared grammar entrypoint: the proc-macro calls it with
 /// the attribute tokens it receives at expansion (converting its
 /// `proc_macro::TokenStream` via `.into()`), and the source-scan
-/// [`crate::extract`] calls it with the tokens a `syn`-parsed `#[processor(...)]`
-/// attribute carries. There is deliberately no second parser — code is the
+/// [`crate::extract_rust_processors`] calls it with the tokens a `syn`-parsed
+/// `#[processor(...)]` attribute carries. There is deliberately no second
+/// parser — code is the
 /// source of truth, so both readers of that truth share one grammar.
 ///
 /// `struct_ident` provides the `Type` segment for the synthesized `@app/local`

--- a/sdk/streamlib-processor-extract/src/grammar.rs
+++ b/sdk/streamlib-processor-extract/src/grammar.rs
@@ -29,7 +29,6 @@
 //! validation (does the referenced schema exist / stay compatible) is out of
 //! scope here and handled at the runtime layer.
 
-use proc_macro::TokenStream;
 use streamlib_processor_schema::{
     Org, Package, PortSchemaSpec, ProcessorSchemaExecution, SchemaIdent, SemVer, ThreadPriority,
     TypeName,
@@ -81,14 +80,17 @@ pub struct ParsedProcessorAttr {
     pub outputs: Vec<ParsedPort>,
 }
 
-/// Parse the attribute tokens. `struct_ident` provides the `Type` segment for
-/// the synthesized `@app/local` identity when no identity string is declared.
-pub fn parse(attr: TokenStream, struct_ident: &Ident) -> syn::Result<ParsedProcessorAttr> {
-    parse2(attr.into(), struct_ident)
-}
-
-/// [`proc_macro2`]-based entrypoint so the grammar is unit-testable without a
-/// proc-macro expansion context.
+/// Parse the `#[processor(...)]` attribute tokens into a [`ParsedProcessorAttr`].
+///
+/// This is the single, shared grammar entrypoint: the proc-macro calls it with
+/// the attribute tokens it receives at expansion (converting its
+/// `proc_macro::TokenStream` via `.into()`), and the source-scan
+/// [`crate::extract`] calls it with the tokens a `syn`-parsed `#[processor(...)]`
+/// attribute carries. There is deliberately no second parser — code is the
+/// source of truth, so both readers of that truth share one grammar.
+///
+/// `struct_ident` provides the `Type` segment for the synthesized `@app/local`
+/// identity when no identity string is declared.
 pub fn parse2(
     attr: proc_macro2::TokenStream,
     struct_ident: &Ident,

--- a/sdk/streamlib-processor-extract/src/lib.rs
+++ b/sdk/streamlib-processor-extract/src/lib.rs
@@ -24,9 +24,7 @@ pub mod grammar;
 
 use std::path::{Path, PathBuf};
 
-use streamlib_processor_schema::{
-    ProcessorPortSchema, ProcessorSchema, ProcessorScheduling, RuntimeConfig, RuntimeOptions,
-};
+use streamlib_processor_schema::ProcessorSchema;
 
 pub use grammar::{ParsedPort, ParsedProcessorAttr};
 
@@ -229,56 +227,12 @@ fn parse_processor_attr(
     })?;
 
     Ok(ExtractedProcessor {
-        schema: processor_schema_from_parsed(&parsed),
+        schema: parsed.to_processor_schema(),
         config_schema_id: parsed.config_schema_id.clone(),
         config_field_name: parsed.config_field_name.clone(),
         struct_name: struct_ident.to_string(),
         source_file: rel_path.to_path_buf(),
     })
-}
-
-/// Build the manifest-shaped [`ProcessorSchema`] from a parsed attribute.
-///
-/// Mirrors the proc-macro's own `ProcessorSchema` construction so the extracted
-/// manifest matches the descriptor the macro emits: `name` is the identity's
-/// `Type` segment, ports carry the resolve-free `Specific` idents the attribute
-/// declared, and the runtime language defaults to Rust (the only language a
-/// source scan of a Rust crate can produce). `config` stays `None` here — the
-/// attribute binds a config *type*, not a resolved manifest schema; the
-/// consuming layer projects [`ExtractedProcessor::config_schema_id`] to a
-/// release-core catalog entry.
-fn processor_schema_from_parsed(parsed: &ParsedProcessorAttr) -> ProcessorSchema {
-    let to_port = |p: &ParsedPort| ProcessorPortSchema {
-        name: p.name.clone(),
-        schema: p.schema.clone(),
-        description: p.description.clone(),
-        read_mode: p.read_mode.clone(),
-        overflow: p.overflow.clone(),
-        buffer_size: p.buffer_size,
-    };
-
-    ProcessorSchema {
-        name: parsed.ident.r#type.as_str().to_string(),
-        version: parsed.ident.version.to_string(),
-        description: parsed.description.clone(),
-        runtime: RuntimeConfig {
-            language: Default::default(),
-            options: RuntimeOptions {
-                unsafe_send: parsed.unsafe_send,
-                python_version: None,
-            },
-            env: Default::default(),
-        },
-        entrypoint: None,
-        execution: parsed.execution.clone(),
-        scheduling: parsed
-            .scheduling
-            .map(|priority| ProcessorScheduling { priority }),
-        config: None,
-        state: Vec::new(),
-        inputs: parsed.inputs.iter().map(to_port).collect(),
-        outputs: parsed.outputs.iter().map(to_port).collect(),
-    }
 }
 
 #[cfg(test)]
@@ -361,6 +315,48 @@ mod tests {
         assert_eq!(
             inner.schema.execution,
             ProcessorSchemaExecution::Continuous { interval_ms: 10 }
+        );
+    }
+
+    #[test]
+    fn scan_schema_equals_the_macro_descriptor_projection() {
+        // The 'one grammar, no drift' invariant, made structural: the schema the
+        // source scan puts in the manifest and the descriptor the proc-macro
+        // emits are BOTH `ParsedProcessorAttr::to_processor_schema()`. This locks
+        // that the scanner routes through the shared projection rather than a
+        // reintroduced parallel copy — a whole-struct serde comparison catches
+        // any field the two would otherwise disagree on. Mentally reroute the
+        // scanner to a hand-rolled builder and this fails.
+        let attr = r#""@tatolab/demo/Blur",
+            execution = reactive,
+            scheduling = high,
+            unsafe_send,
+            description = "Blurs frames",
+            input("frames_in", "@tatolab/core/VideoFrame", read_mode = "skip_to_latest", buffer_size = 4),
+            output("frames_out", "@tatolab/core/VideoFrame")"#;
+
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "src/lib.rs",
+            &format!("#[processor({attr})]\npub struct Blur;\n"),
+        );
+        let procs = extract_rust_processors(root).unwrap();
+        assert_eq!(procs.len(), 1);
+        let scanned = &procs[0].schema;
+
+        // The proc-macro's own descriptor path: parse the same attribute tokens
+        // through the shared grammar and project them the same way the macro does.
+        let tokens: proc_macro2::TokenStream = attr.parse().unwrap();
+        let struct_ident = syn::Ident::new("Blur", proc_macro2::Span::call_site());
+        let macro_descriptor = grammar::parse2(tokens, &struct_ident)
+            .unwrap()
+            .to_processor_schema();
+
+        assert_eq!(
+            serde_json::to_value(scanned).unwrap(),
+            serde_json::to_value(&macro_descriptor).unwrap(),
         );
     }
 

--- a/sdk/streamlib-processor-extract/src/lib.rs
+++ b/sdk/streamlib-processor-extract/src/lib.rs
@@ -303,7 +303,7 @@ mod tests {
             "src/lib.rs",
             r#"
             pub mod camera;
-            #[streamlib::processor(
+            #[streamlib::sdk::processor(
                 "@tatolab/demo/Blur",
                 execution = reactive,
                 input("frames_in", "@tatolab/core/VideoFrame", read_mode = "skip_to_latest", buffer_size = 4),

--- a/sdk/streamlib-processor-extract/src/lib.rs
+++ b/sdk/streamlib-processor-extract/src/lib.rs
@@ -16,8 +16,9 @@
 //! carrying `#[processor(...)]` / `#[streamlib::processor(...)]`, and the
 //! attribute tokens are parsed through the SAME [`grammar`] the proc-macro uses
 //! — never a second, drift-prone parser. See
-//! `docs/architecture/manifest-extraction.md` for the capability-placement and
-//! identity/version reconciliation decisions.
+//! `docs/decisions/manifest-extraction-capability.md` for why the grammar lives
+//! here rather than the proc-macro crate, and the identity/version model the
+//! scan produces.
 
 pub mod grammar;
 
@@ -162,7 +163,7 @@ fn extract_from_file(
 
     let rel = path.strip_prefix(crate_root).unwrap_or(path).to_path_buf();
     for item in &file.items {
-        walk_item(item, path, &rel, out)?;
+        walk_item(item, &rel, out)?;
     }
     Ok(())
 }
@@ -171,21 +172,20 @@ fn extract_from_file(
 /// `#[processor(...)]`-bearing structs.
 fn walk_item(
     item: &syn::Item,
-    abs_path: &Path,
     rel_path: &Path,
     out: &mut Vec<ExtractedProcessor>,
 ) -> Result<(), ExtractError> {
     match item {
         syn::Item::Struct(item_struct) => {
             if let Some(attr) = processor_attr(&item_struct.attrs) {
-                let extracted = parse_processor_attr(attr, &item_struct.ident, abs_path, rel_path)?;
+                let extracted = parse_processor_attr(attr, &item_struct.ident, rel_path)?;
                 out.push(extracted);
             }
         }
         syn::Item::Mod(item_mod) => {
             if let Some((_, items)) = &item_mod.content {
                 for inner in items {
-                    walk_item(inner, abs_path, rel_path, out)?;
+                    walk_item(inner, rel_path, out)?;
                 }
             }
         }
@@ -211,7 +211,6 @@ fn processor_attr(attrs: &[syn::Attribute]) -> Option<&syn::Attribute> {
 fn parse_processor_attr(
     attr: &syn::Attribute,
     struct_ident: &syn::Ident,
-    abs_path: &Path,
     rel_path: &Path,
 ) -> Result<ExtractedProcessor, ExtractError> {
     // A `#[processor]` with no argument list (`Meta::Path`) synthesizes an
@@ -228,7 +227,6 @@ fn parse_processor_attr(
         struct_name: struct_ident.to_string(),
         message: e.to_string(),
     })?;
-    let _ = abs_path;
 
     Ok(ExtractedProcessor {
         schema: processor_schema_from_parsed(&parsed),

--- a/sdk/streamlib-processor-extract/src/lib.rs
+++ b/sdk/streamlib-processor-extract/src/lib.rs
@@ -1,0 +1,466 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Manifest extraction as a runtime/loader capability.
+//!
+//! Ports-in-code (#1437) made the `#[processor(...)]` attribute the single
+//! source of truth for a processor's identity, execution mode, and ports.
+//! This crate is the inverse of the old flow: instead of the macro reading a
+//! hand-authored `processors:` list, a `syn`-based source scan *derives* that
+//! list from the `#[processor(...)]` usage in a crate's `src/`, so
+//! `streamlib pkg build` (and any future live-submit path) obtains the
+//! processor manifest from code rather than trusting a committed enumeration.
+//!
+//! The scan runs over a crate's source **without compiling it into the host**:
+//! `syn::parse_file` builds each module's AST, the walk finds every struct
+//! carrying `#[processor(...)]` / `#[streamlib::processor(...)]`, and the
+//! attribute tokens are parsed through the SAME [`grammar`] the proc-macro uses
+//! — never a second, drift-prone parser. See
+//! `docs/architecture/manifest-extraction.md` for the capability-placement and
+//! identity/version reconciliation decisions.
+
+pub mod grammar;
+
+use std::path::{Path, PathBuf};
+
+use streamlib_processor_schema::{
+    ProcessorPortSchema, ProcessorSchema, ProcessorScheduling, RuntimeConfig, RuntimeOptions,
+};
+
+pub use grammar::{ParsedPort, ParsedProcessorAttr};
+
+/// One processor derived from a `#[processor(...)]` attribute in source.
+///
+/// Carries the manifest-shaped [`ProcessorSchema`] the catalog / `.slpkg`
+/// assembly consumes, plus the source location it was found at (for diagnostics)
+/// and the config binding the attribute declared. The config binding is surfaced
+/// separately rather than folded into `schema.config` because reconciling the
+/// attribute's version-free config-schema id with the catalog's release-core
+/// projection is the consuming layer's job, not the scanner's.
+#[derive(Debug, Clone)]
+pub struct ExtractedProcessor {
+    /// The manifest-shaped processor schema derived from the attribute.
+    pub schema: ProcessorSchema,
+    /// The version-free config-schema identity the attribute declared (or
+    /// synthesized from the config type), if the processor binds a config.
+    pub config_schema_id: Option<String>,
+    /// The struct field the runtime binds the typed config into.
+    pub config_field_name: String,
+    /// The Rust struct the attribute was written on (the `Type` segment source).
+    pub struct_name: String,
+    /// The source file, relative to the scanned crate root, the attribute was
+    /// found in.
+    pub source_file: PathBuf,
+}
+
+/// Why source-scan extraction failed. Every variant carries the offending path
+/// and enough context to act on; extraction never panics and never silently
+/// drops a `#[processor(...)]` it could not parse.
+#[derive(Debug, thiserror::Error)]
+pub enum ExtractError {
+    /// The crate root has no `src/` directory to scan.
+    #[error("no `src/` directory under crate root {root} — nothing to scan for processors")]
+    NoSrcDir { root: PathBuf },
+
+    /// A source file could not be read off disk.
+    #[error("read {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// A `.rs` file did not parse as Rust. The scan requires a parseable AST;
+    /// a syntactically-broken file is surfaced, never skipped (skipping could
+    /// hide a `#[processor]` the author expects to ship).
+    #[error("parse {path} as Rust: {source}")]
+    Syntax {
+        path: PathBuf,
+        #[source]
+        source: syn::Error,
+    },
+
+    /// A `#[processor(...)]` attribute failed the shared grammar. The message is
+    /// the grammar's own spanned diagnostic, re-anchored to the file it came
+    /// from so a build-time scan points at the offending source.
+    #[error("`#[processor(...)]` on `{struct_name}` in {path}: {message}")]
+    Grammar {
+        path: PathBuf,
+        struct_name: String,
+        message: String,
+    },
+}
+
+/// Derive the `processors:` manifest section from a Rust crate's source.
+///
+/// Scans every `.rs` file under `<crate_root>/src` for structs carrying a
+/// `#[processor(...)]` attribute and parses each through the shared [`grammar`].
+/// The returned list is deterministic: files are walked in sorted path order and
+/// attributes in source order within a file. An empty result is valid — a crate
+/// may legitimately declare no processors (a schema-only package).
+#[tracing::instrument(skip_all, fields(crate_root = %crate_root.display()))]
+pub fn extract_rust_processors(crate_root: &Path) -> Result<Vec<ExtractedProcessor>, ExtractError> {
+    let src_dir = crate_root.join("src");
+    if !src_dir.is_dir() {
+        return Err(ExtractError::NoSrcDir {
+            root: crate_root.to_path_buf(),
+        });
+    }
+
+    let mut rs_files = Vec::new();
+    collect_rs_files(&src_dir, &mut rs_files)?;
+    rs_files.sort();
+
+    let mut out = Vec::new();
+    for path in &rs_files {
+        extract_from_file(path, crate_root, &mut out)?;
+    }
+    tracing::debug!(processors = out.len(), files = rs_files.len(), "extracted");
+    Ok(out)
+}
+
+/// Recursively gather every `*.rs` file under `dir`.
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), ExtractError> {
+    let entries = std::fs::read_dir(dir).map_err(|e| ExtractError::Io {
+        path: dir.to_path_buf(),
+        source: e,
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|e| ExtractError::Io {
+            path: dir.to_path_buf(),
+            source: e,
+        })?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|e| ExtractError::Io {
+            path: path.clone(),
+            source: e,
+        })?;
+        if file_type.is_dir() {
+            collect_rs_files(&path, out)?;
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// Parse one `.rs` file and push every `#[processor(...)]`-bearing struct into
+/// `out`, in source order.
+fn extract_from_file(
+    path: &Path,
+    crate_root: &Path,
+    out: &mut Vec<ExtractedProcessor>,
+) -> Result<(), ExtractError> {
+    let body = std::fs::read_to_string(path).map_err(|e| ExtractError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    let file = syn::parse_file(&body).map_err(|e| ExtractError::Syntax {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+
+    let rel = path.strip_prefix(crate_root).unwrap_or(path).to_path_buf();
+    for item in &file.items {
+        walk_item(item, path, &rel, out)?;
+    }
+    Ok(())
+}
+
+/// Walk one item, descending into inline `mod { ... }` blocks, collecting
+/// `#[processor(...)]`-bearing structs.
+fn walk_item(
+    item: &syn::Item,
+    abs_path: &Path,
+    rel_path: &Path,
+    out: &mut Vec<ExtractedProcessor>,
+) -> Result<(), ExtractError> {
+    match item {
+        syn::Item::Struct(item_struct) => {
+            if let Some(attr) = processor_attr(&item_struct.attrs) {
+                let extracted = parse_processor_attr(attr, &item_struct.ident, abs_path, rel_path)?;
+                out.push(extracted);
+            }
+        }
+        syn::Item::Mod(item_mod) => {
+            if let Some((_, items)) = &item_mod.content {
+                for inner in items {
+                    walk_item(inner, abs_path, rel_path, out)?;
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// The `#[processor(...)]` attribute on an item, if present. Matches both the
+/// bare `#[processor(...)]` and the path-qualified `#[streamlib::processor(...)]`
+/// forms by their final path segment.
+fn processor_attr(attrs: &[syn::Attribute]) -> Option<&syn::Attribute> {
+    attrs.iter().find(|attr| {
+        attr.path()
+            .segments
+            .last()
+            .is_some_and(|seg| seg.ident == "processor")
+    })
+}
+
+/// Parse a single `#[processor(...)]` attribute through the shared grammar and
+/// build the manifest-shaped [`ExtractedProcessor`].
+fn parse_processor_attr(
+    attr: &syn::Attribute,
+    struct_ident: &syn::Ident,
+    abs_path: &Path,
+    rel_path: &Path,
+) -> Result<ExtractedProcessor, ExtractError> {
+    // A `#[processor]` with no argument list (`Meta::Path`) synthesizes an
+    // app-local identity from the struct name — parse an empty token stream so
+    // the same grammar path handles it. A `#[processor(...)]` (`Meta::List`)
+    // carries the args verbatim.
+    let tokens = match &attr.meta {
+        syn::Meta::List(list) => list.tokens.clone(),
+        _ => proc_macro2::TokenStream::new(),
+    };
+
+    let parsed = grammar::parse2(tokens, struct_ident).map_err(|e| ExtractError::Grammar {
+        path: rel_path.to_path_buf(),
+        struct_name: struct_ident.to_string(),
+        message: e.to_string(),
+    })?;
+    let _ = abs_path;
+
+    Ok(ExtractedProcessor {
+        schema: processor_schema_from_parsed(&parsed),
+        config_schema_id: parsed.config_schema_id.clone(),
+        config_field_name: parsed.config_field_name.clone(),
+        struct_name: struct_ident.to_string(),
+        source_file: rel_path.to_path_buf(),
+    })
+}
+
+/// Build the manifest-shaped [`ProcessorSchema`] from a parsed attribute.
+///
+/// Mirrors the proc-macro's own `ProcessorSchema` construction so the extracted
+/// manifest matches the descriptor the macro emits: `name` is the identity's
+/// `Type` segment, ports carry the resolve-free `Specific` idents the attribute
+/// declared, and the runtime language defaults to Rust (the only language a
+/// source scan of a Rust crate can produce). `config` stays `None` here — the
+/// attribute binds a config *type*, not a resolved manifest schema; the
+/// consuming layer projects [`ExtractedProcessor::config_schema_id`] to a
+/// release-core catalog entry.
+fn processor_schema_from_parsed(parsed: &ParsedProcessorAttr) -> ProcessorSchema {
+    let to_port = |p: &ParsedPort| ProcessorPortSchema {
+        name: p.name.clone(),
+        schema: p.schema.clone(),
+        description: p.description.clone(),
+        read_mode: p.read_mode.clone(),
+        overflow: p.overflow.clone(),
+        buffer_size: p.buffer_size,
+    };
+
+    ProcessorSchema {
+        name: parsed.ident.r#type.as_str().to_string(),
+        version: parsed.ident.version.to_string(),
+        description: parsed.description.clone(),
+        runtime: RuntimeConfig {
+            language: Default::default(),
+            options: RuntimeOptions {
+                unsafe_send: parsed.unsafe_send,
+                python_version: None,
+            },
+            env: Default::default(),
+        },
+        entrypoint: None,
+        execution: parsed.execution.clone(),
+        scheduling: parsed
+            .scheduling
+            .map(|priority| ProcessorScheduling { priority }),
+        config: None,
+        state: Vec::new(),
+        inputs: parsed.inputs.iter().map(to_port).collect(),
+        outputs: parsed.outputs.iter().map(to_port).collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use streamlib_processor_schema::{PortSchemaSpec, ProcessorSchemaExecution};
+
+    fn write(dir: &Path, rel: &str, body: &str) {
+        let path = dir.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn golden_extraction_over_a_fixture_crate() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        // Two processors across two files + a nested module, plus a plain
+        // struct with no attribute (must be ignored).
+        write(
+            root,
+            "src/lib.rs",
+            r#"
+            pub mod camera;
+            #[streamlib::processor(
+                "@tatolab/demo/Blur",
+                execution = reactive,
+                input("frames_in", "@tatolab/core/VideoFrame", read_mode = "skip_to_latest", buffer_size = 4),
+                output("frames_out", "@tatolab/core/VideoFrame"),
+            )]
+            pub struct Blur;
+
+            pub struct NotAProcessor;
+            "#,
+        );
+        write(
+            root,
+            "src/camera.rs",
+            r#"
+            #[processor(
+                "@tatolab/demo/Camera",
+                execution = manual,
+                scheduling = high,
+                output("video", "@tatolab/core/VideoFrame"),
+            )]
+            pub struct Camera;
+
+            mod inner {
+                #[processor("@tatolab/demo/Inner", execution = continuous(interval_ms = 10))]
+                pub struct Inner;
+            }
+            "#,
+        );
+
+        let mut procs = extract_rust_processors(root).unwrap();
+        procs.sort_by(|a, b| a.schema.name.cmp(&b.schema.name));
+        let names: Vec<&str> = procs.iter().map(|p| p.schema.name.as_str()).collect();
+        assert_eq!(names, vec!["Blur", "Camera", "Inner"]);
+
+        let blur = procs.iter().find(|p| p.schema.name == "Blur").unwrap();
+        assert_eq!(blur.schema.execution, ProcessorSchemaExecution::Reactive);
+        assert_eq!(blur.schema.inputs.len(), 1);
+        assert_eq!(blur.schema.inputs[0].name, "frames_in");
+        assert_eq!(blur.schema.inputs[0].read_mode.as_deref(), Some("skip_to_latest"));
+        assert!(matches!(
+            blur.schema.inputs[0].schema,
+            PortSchemaSpec::Specific(_)
+        ));
+        assert_eq!(blur.schema.outputs[0].name, "frames_out");
+        assert_eq!(blur.source_file, PathBuf::from("src/lib.rs"));
+
+        let camera = procs.iter().find(|p| p.schema.name == "Camera").unwrap();
+        assert_eq!(camera.schema.execution, ProcessorSchemaExecution::Manual);
+        assert_eq!(
+            camera.schema.scheduling.as_ref().map(|s| s.priority),
+            Some(streamlib_processor_schema::ThreadPriority::High)
+        );
+
+        let inner = procs.iter().find(|p| p.schema.name == "Inner").unwrap();
+        assert_eq!(
+            inner.schema.execution,
+            ProcessorSchemaExecution::Continuous { interval_ms: 10 }
+        );
+    }
+
+    #[test]
+    fn bare_app_local_crate_extracts_cleanly() {
+        // A bare crate with an identity-free `#[processor(...)]` synthesizes an
+        // @app/local/<StructName> identity — extraction must handle it without a
+        // streamlib.yaml anywhere in sight.
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "src/main.rs",
+            r#"
+            #[processor(execution = reactive)]
+            struct MyLocalThing;
+            "#,
+        );
+        let procs = extract_rust_processors(root).unwrap();
+        assert_eq!(procs.len(), 1);
+        assert_eq!(procs[0].schema.name, "MyLocalThing");
+        assert_eq!(procs[0].struct_name, "MyLocalThing");
+        // App-local synthesized identity carries the version-free 0.0.0 sentinel.
+        assert_eq!(procs[0].schema.version, "0.0.0");
+    }
+
+    #[test]
+    fn schema_only_crate_yields_no_processors() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "src/lib.rs", "pub struct JustAType { pub x: u32 }\n");
+        let procs = extract_rust_processors(root).unwrap();
+        assert!(procs.is_empty());
+    }
+
+    #[test]
+    fn malformed_attribute_surfaces_a_grammar_error_with_the_file() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "src/lib.rs",
+            r#"
+            #[processor("@tatolab/demo/Broken")]
+            pub struct Broken;
+            "#,
+        );
+        let err = extract_rust_processors(root).unwrap_err();
+        match err {
+            ExtractError::Grammar {
+                struct_name,
+                path,
+                message,
+            } => {
+                assert_eq!(struct_name, "Broken");
+                assert_eq!(path, PathBuf::from("src/lib.rs"));
+                assert!(message.contains("missing required `execution`"), "got: {message}");
+            }
+            other => panic!("expected Grammar error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unparseable_rust_is_a_syntax_error_not_a_skip() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "src/lib.rs", "fn broken( {\n");
+        let err = extract_rust_processors(root).unwrap_err();
+        assert!(matches!(err, ExtractError::Syntax { .. }));
+    }
+
+    #[test]
+    fn missing_src_dir_is_a_typed_error() {
+        let tmp = tempdir();
+        let err = extract_rust_processors(tmp.path()).unwrap_err();
+        assert!(matches!(err, ExtractError::NoSrcDir { .. }));
+    }
+
+    /// Minimal tempdir without pulling the `tempfile` crate into this lean
+    /// dependency set: a unique dir under the OS temp root, removed on drop.
+    struct TmpDir(PathBuf);
+    impl TmpDir {
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl Drop for TmpDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+    fn tempdir() -> TmpDir {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        let dir = std::env::temp_dir().join(format!("slextract-{pid}-{n}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        TmpDir(dir)
+    }
+}


### PR DESCRIPTION
Advances #1411 (stage 1 — does **not** close it; owner-agreed staged delivery, see #1411 comment).

## What this lands (stage 1: the extraction capability)
- New engine-free crate `sdk/streamlib-processor-extract`: a **syn source-scan extractor** (`extract_rust_processors`) that derives a processor's `ProcessorSchema` from its `#[processor(...)]` attribute across a crate's `src/` — the foundation `pkg build` will invoke, per §11 #1 (a build-time AST scan, **not** a proc-macro tweak).
- **Grammar consolidation (engine-doctrine):** the `#[processor]` grammar moved out of the proc-macro crate into the shared `streamlib-processor-extract`, so the macro and the extractor parse via **one grammar** — no parallel copy.
- The `ParsedProcessorAttr → ProcessorSchema` **projection is also shared** (`ParsedProcessorAttr::to_processor_schema()`), with a `scan_schema_equals_the_macro_descriptor_projection` test making "extracted manifest == macro-emitted descriptor" a **structural** invariant, not a hand-maintained twin.
- Decision record `docs/decisions/manifest-extraction-capability.md` (placement + version model + the reachability gate below).
- CI: added `-p streamlib-processor-extract` to the unit-test gate (33 tests, incl. the golden extraction + scan-equals-macro tests).

## What is deferred to stage 2 (keeps #1411 open)
- **Flip `pkg build` to consume extracted processors** as truth-source + a hard **drift-detection error** with fix-it (criteria #2/#5). Gated on a real prerequisite: **per-platform module reachability** — a naive full-tree `src/` scan over-extracts `#[cfg]`-gated/parked arms (e.g. camera declares `Camera` in both `src/linux` and `src/_apple_impl_pending_`, which would false-positive a drift check). Documented in the decision record.
- **Python/Deno manifest-extraction inversion** (decorator becomes the manifest truth-source, not sibling-yaml) → a separate filed follow-up.

## Verify
verify-change → DISCUSS on completeness only; owner ratified the staged scope. Fix round applied the should-fix findings (projection dedup + test, rustdoc link, CI gate). Local gate battery: **30 passed, 0 failed**.

Note (not this PR's blame): `streamlib-macros` carries now-unused `serde`/`serde_yaml` deps left by #1437's YAML-path removal — flagged for a #1437-line cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
