### PR TITLE
feat(engine): Runner::add_local — register a #[processor] host type live

### DIFF
--- a/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
+++ b/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
@@ -1276,6 +1276,38 @@ impl ProcessorInstanceFactory {
         self.descriptors.read().get(processor_type).cloned()
     }
 
+    /// Warn when `ident`'s short type name collides with an already-registered
+    /// processor under a different `(org, package)` — the session-local vs
+    /// installed name-shadow case. Both stay addressable by full ident (the
+    /// registry keys on the structured `SchemaIdent`, never the short name), so
+    /// this only surfaces the ambiguity a bare short-name reference would hit;
+    /// it never removes or overwrites either registration. Returns the shadowed
+    /// idents (for tests / diagnostics).
+    pub fn warn_on_short_name_shadow(&self, ident: &SchemaIdent) -> Vec<SchemaIdent> {
+        let shadowed: Vec<SchemaIdent> = self
+            .descriptors
+            .read()
+            .keys()
+            .filter(|other| {
+                other.r#type == ident.r#type
+                    && (other.org != ident.org || other.package != ident.package)
+            })
+            .cloned()
+            .collect();
+        for other in &shadowed {
+            tracing::warn!(
+                registering = %ident,
+                shadows = %other,
+                "processor short type name '{}' is now registered under two \
+                 distinct packages; both remain addressable by their full \
+                 `@org/package/Type@version` ident, but a bare short-name \
+                 reference is ambiguous",
+                ident.r#type,
+            );
+        }
+        shadowed
+    }
+
     /// List all registered processor types with their full descriptors.
     pub fn list_registered(&self) -> Vec<ProcessorDescriptor> {
         self.descriptors.read().values().cloned().collect()

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/errors.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/errors.rs
@@ -438,6 +438,59 @@ pub enum AddModuleError {
         package: streamlib_idents::PackageRef,
         processor_type: crate::core::descriptors::SchemaIdent,
     },
+
+    /// [`Runner::add_local`] was handed a type whose
+    /// [`GeneratedProcessor::descriptor`] returned `None` — it carries no
+    /// registerable descriptor, so there is nothing to register under
+    /// `@session/…`. Annotate the type with `#[processor(...)]`.
+    ///
+    /// [`Runner::add_local`]: super::super::Runner::add_local
+    /// [`GeneratedProcessor::descriptor`]: crate::core::processors::GeneratedProcessor::descriptor
+    #[error(
+        "add_local::<{type_name}>() failed: the type carries no processor \
+         descriptor. Annotate it with `#[processor(...)]` so it has a \
+         registerable identity."
+    )]
+    SessionProcessorHasNoDescriptor { type_name: String },
+
+    /// [`Runner::add_local`] derived a session package name that fails the
+    /// ident grammar (`[a-z][a-z0-9-]*`). `detail` carries the underlying
+    /// [`streamlib_idents::IdentError`].
+    ///
+    /// [`Runner::add_local`]: super::super::Runner::add_local
+    #[error(
+        "add_local::<{type_name}>() failed: cannot mint a `@session/<name>` \
+         ident from the type name: {detail}"
+    )]
+    SessionProcessorNameInvalid { type_name: String, detail: String },
+
+    /// [`Runner::add_local`] was handed a config that does not deserialize
+    /// into the processor type's `Config` — refused before registering, so a
+    /// session type never registers with a config its own schema rejects.
+    ///
+    /// [`Runner::add_local`]: super::super::Runner::add_local
+    #[error(
+        "add_local::<{type_name}>() failed: the supplied config is not valid \
+         for the processor's Config type: {detail}"
+    )]
+    SessionProcessorConfigInvalid { type_name: String, detail: String },
+
+    /// [`Runner::add_local`] found a live `@session/<name>` registration
+    /// already in the ledger — the same session-local name is registered and
+    /// was not removed. Never silently overwritten. Remove it first
+    /// ([`Runner::remove_module`]), or register the new type under a distinct
+    /// name.
+    ///
+    /// [`Runner::add_local`]: super::super::Runner::add_local
+    /// [`Runner::remove_module`]: super::super::Runner::remove_module
+    #[error(
+        "add_local failed: a session-local processor is already registered as \
+         '{module}'. Remove it (remove_module) before re-registering the same \
+         name, or use a distinct type name."
+    )]
+    DuplicateSessionProcessorName {
+        module: streamlib_idents::ModuleIdent,
+    },
 }
 
 impl From<AddModuleError> for Error {

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -39,11 +39,15 @@
 //!   process-lifetime plugin-image retention.
 //! - [`ledger`] — process-global record of committed loads consumed by
 //!   [`Runner::remove_module`].
+//! - [`session`] — [`Runner::add_local`]: register a `#[processor]` host
+//!   type live under `@session/<name>@0.0.N` through the same staging seam,
+//!   with no package on disk.
 //! - [`slpkg`] — `.slpkg` archive extraction.
 //!
 //! [`Runner::remove_module`]: super::Runner::remove_module
 //! [`Runner::add_module`]: super::Runner::add_module
 //! [`Runner::add_module_with`]: super::Runner::add_module_with
+//! [`Runner::add_local`]: super::Runner::add_local
 //! [`Runner::await_modules`]: super::Runner::await_modules
 
 use std::collections::HashSet;
@@ -65,12 +69,16 @@ mod locked;
 mod processor_registration;
 mod recursive_walker;
 mod schema_registration;
+mod session;
 mod slpkg;
 mod source;
 mod staging;
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod session_tests;
 
 pub use added_module::{AddedModule, LoadedModule, ModuleLoadEvent};
 pub use build_orchestrator::{

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/session.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/session.rs
@@ -1,0 +1,290 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! [`Runner::add_local`] — register a `#[processor]`-annotated host type
+//! live at runtime, with no package on disk.
+//!
+//! In-app authoring is register-on-live-runtime: an already-compiled host
+//! type is minted a fresh `@session/<name>@0.0.N` identity (distinct from
+//! its compile-time `@app/local/<Type>` identity) and registered onto the
+//! one [`PROCESSOR_REGISTRY`] through the same
+//! [`ModuleLoadRegistrationStaging`] → commit → [`ledger`] seam a disk-backed
+//! module load uses — so [`Runner::remove_module`] unregisters it
+//! symmetrically. No manifest, no dylib, no build.
+//!
+//! [`PROCESSOR_REGISTRY`]: crate::core::processors::PROCESSOR_REGISTRY
+//! [`ModuleLoadRegistrationStaging`]: super::staging::ModuleLoadRegistrationStaging
+//! [`ledger`]: super::ledger
+//! [`Runner::remove_module`]: super::super::Runner::remove_module
+
+use std::time::Instant;
+
+use tokio::sync::broadcast;
+
+use streamlib_plugin_abi::ProcessorVTable;
+
+use super::super::Runner;
+use super::super::runtime::TokioRuntimeVariant;
+use super::added_module::MODULE_EVENT_CHANNEL_CAPACITY;
+use super::errors::AddModuleError;
+use super::{AddedModule, LoadedModule, ModuleLoadEvent};
+use crate::core::descriptors::{ProcessorDescriptor, SchemaIdent};
+use crate::core::processors::{Config, GeneratedProcessor};
+
+/// The prepared (or refused-before-spawn) outcome of an [`Runner::add_local`]
+/// call. The module ident is derived even on the failure paths so the
+/// returned [`AddedModule`] handle always names a `@session/…` module.
+struct PreparedSessionRegistration {
+    module: streamlib_idents::ModuleIdent,
+    version: streamlib_idents::SemVer,
+    /// The re-homed descriptor + monomorphized host vtable, or the typed
+    /// refusal to surface through the load future.
+    outcome: std::result::Result<(ProcessorDescriptor, &'static ProcessorVTable), AddModuleError>,
+}
+
+impl Runner {
+    /// Register a `#[processor]`-annotated host type live at runtime, minting
+    /// it a fresh `@session/<name>@0.0.N` identity on the one
+    /// [`PROCESSOR_REGISTRY`]. In-app authoring with no package on disk: no
+    /// manifest, no dylib, no build. Returns an [`AddedModule`] (a `Future`
+    /// whose work is already running); a session registration resolves almost
+    /// immediately.
+    ///
+    /// `config` is validated against the type's `Config` before registering —
+    /// a config that does not deserialize into `P::Config` is refused with
+    /// [`AddModuleError::SessionProcessorConfigInvalid`], so a session type
+    /// never registers with a config its own schema rejects.
+    /// [`serde_json::Value::Null`] means "use the type's default config" and
+    /// always validates.
+    ///
+    /// A short-type-name collision with an already-registered (installed or
+    /// session) processor **warns** and keeps both addressable by full ident;
+    /// it never overwrites. A live same-`@session/<name>` registration is
+    /// refused with [`AddModuleError::DuplicateSessionProcessorName`] — remove
+    /// it first ([`Runner::remove_module`]).
+    ///
+    /// [`PROCESSOR_REGISTRY`]: crate::core::processors::PROCESSOR_REGISTRY
+    /// [`Runner::remove_module`]: Self::remove_module
+    #[must_use = "the returned AddedModule cancels on drop — await it or pass it to await_modules"]
+    #[tracing::instrument(skip_all, fields(processor = std::any::type_name::<P>()))]
+    pub fn add_local<P>(&self, config: serde_json::Value) -> AddedModule
+    where
+        P: GeneratedProcessor + 'static,
+        P::Config: Config,
+    {
+        let prepared = prepare_session_registration::<P>(config);
+        self.spawn_session_registration(prepared)
+    }
+
+    /// Synchronous convenience for [`Self::add_local`]: drive the session
+    /// registration to completion and return the [`LoadedModule`] (whose
+    /// `ident` is the minted `@session/<name>@0.0.N`). For simple `fn main`
+    /// examples and tests. Returns [`AddModuleError::BlockingCallFromAsyncContext`]
+    /// (never panics) when called from inside a tokio runtime — use the async
+    /// surface there.
+    pub fn add_local_blocking<P>(
+        &self,
+        config: serde_json::Value,
+    ) -> std::result::Result<LoadedModule, AddModuleError>
+    where
+        P: GeneratedProcessor + 'static,
+        P::Config: Config,
+    {
+        if matches!(
+            self.tokio_runtime_variant,
+            TokioRuntimeVariant::ExternalTokioHandle(_)
+        ) {
+            let prepared = prepare_session_registration::<P>(config);
+            return Err(AddModuleError::BlockingCallFromAsyncContext {
+                module: prepared.module,
+            });
+        }
+        let added = self.add_local::<P>(config);
+        match &self.tokio_runtime_variant {
+            TokioRuntimeVariant::OwnedTokioRuntime(rt) => rt.block_on(added),
+            // Guarded above — the external arm returned already.
+            TokioRuntimeVariant::ExternalTokioHandle(_) => unreachable!(),
+        }
+    }
+
+    /// Spawn the prepared session registration onto the runtime's tokio
+    /// handle and wrap it as an [`AddedModule`], mirroring
+    /// [`Runner::add_module_with`]'s eager-load shape.
+    fn spawn_session_registration(&self, prepared: PreparedSessionRegistration) -> AddedModule {
+        let module = prepared.module.clone();
+        let version = prepared.version;
+        let outcome = prepared.outcome;
+
+        let (tx, initial_rx) = broadcast::channel(MODULE_EVENT_CHANNEL_CAPACITY);
+        let events = tx.clone();
+        let module_for_task = module.clone();
+
+        let join = self
+            .tokio_runtime_variant
+            .handle()
+            .spawn_blocking(move || {
+                run_session_registration(module_for_task, version, outcome, &events)
+            });
+
+        AddedModule::new(module, join, tx, initial_rx)
+    }
+}
+
+/// Derive the `@session/<name>@0.0.N` identity for `P`, validate `config`
+/// against `P::Config`, and monomorphize its host vtable — capturing any
+/// refusal to surface through the load future. Fallible steps that can't
+/// bind a real module ident fall back to `@session/local@0.0.N` so the
+/// returned handle still names a session module.
+fn prepare_session_registration<P>(config: serde_json::Value) -> PreparedSessionRegistration
+where
+    P: GeneratedProcessor + 'static,
+    P::Config: Config,
+{
+    let type_name = std::any::type_name::<P>().to_string();
+
+    let Some(descriptor) = <P as GeneratedProcessor>::descriptor() else {
+        let fallback = fallback_session_module();
+        return PreparedSessionRegistration {
+            module: fallback.module,
+            version: fallback.version,
+            outcome: Err(AddModuleError::SessionProcessorHasNoDescriptor { type_name }),
+        };
+    };
+
+    let processor_type_name = descriptor.name.r#type.clone();
+    let session_name = kebab_case(processor_type_name.as_str());
+
+    let minted = match streamlib_idents::mint_session_module_ident(&session_name) {
+        Ok(minted) => minted,
+        Err(e) => {
+            let fallback = fallback_session_module();
+            return PreparedSessionRegistration {
+                module: fallback.module,
+                version: fallback.version,
+                outcome: Err(AddModuleError::SessionProcessorNameInvalid {
+                    type_name,
+                    detail: e.to_string(),
+                }),
+            };
+        }
+    };
+
+    if !config.is_null() {
+        if let Err(e) = serde_json::from_value::<P::Config>(config) {
+            return PreparedSessionRegistration {
+                module: minted.module,
+                version: minted.version,
+                outcome: Err(AddModuleError::SessionProcessorConfigInvalid {
+                    type_name,
+                    detail: e.to_string(),
+                }),
+            };
+        }
+    }
+
+    let mut descriptor = descriptor;
+    descriptor.name = SchemaIdent::new(
+        minted.module.org.clone(),
+        minted.package.clone(),
+        processor_type_name,
+        minted.version,
+    );
+    let vtable = crate::core::plugin::processor_vtable::vtable_for::<P>();
+
+    PreparedSessionRegistration {
+        module: minted.module,
+        version: minted.version,
+        outcome: Ok((descriptor, vtable)),
+    }
+}
+
+/// Run a prepared session registration on the spawned task: on the `Ok`
+/// arm, stage + commit the one processor through the shared staging seam;
+/// emit the terminal load event either way.
+fn run_session_registration(
+    module: streamlib_idents::ModuleIdent,
+    version: streamlib_idents::SemVer,
+    outcome: std::result::Result<(ProcessorDescriptor, &'static ProcessorVTable), AddModuleError>,
+    events: &broadcast::Sender<ModuleLoadEvent>,
+) -> std::result::Result<LoadedModule, AddModuleError> {
+    let start = Instant::now();
+    let _ = events.send(ModuleLoadEvent::Started {
+        ident: module.clone(),
+    });
+
+    let result = outcome.and_then(|(descriptor, vtable)| {
+        let staging = super::staging::ModuleLoadRegistrationStaging::new();
+        super::staging::commit_session_processor_registration(
+            &staging, &module, version, descriptor, vtable,
+        )
+        .map(|_ident| ())
+    });
+
+    match result {
+        Ok(()) => {
+            let _ = events.send(ModuleLoadEvent::Completed {
+                ident: module.clone(),
+                took: start.elapsed(),
+            });
+            Ok(LoadedModule { ident: module })
+        }
+        Err(e) => {
+            let _ = events.send(ModuleLoadEvent::Failed {
+                ident: module.clone(),
+                error: e.to_string(),
+            });
+            Err(e)
+        }
+    }
+}
+
+/// A `@session/local@0.0.N` fallback identity for the pre-registration
+/// failure paths (no descriptor / un-mintable name) so the returned
+/// [`AddedModule`] handle still names a session module.
+fn fallback_session_module() -> streamlib_idents::MintedSessionIdent {
+    streamlib_idents::mint_session_module_ident("local")
+        .expect("`local` is a valid session package name")
+}
+
+/// Kebab-case a PascalCase processor type name into a `@session/<name>`
+/// package segment: `TestMockProcessor` → `test-mock-processor`. A `-` is
+/// inserted before each interior uppercase run boundary; underscores map to
+/// `-`; the result is lowercased and de-duplicated / trimmed of `-`.
+fn kebab_case(type_name: &str) -> String {
+    let mut out = String::with_capacity(type_name.len() + 4);
+    let mut prev_was_lower_or_digit = false;
+    for ch in type_name.chars() {
+        if ch == '_' || ch == '-' {
+            if !out.ends_with('-') {
+                out.push('-');
+            }
+            prev_was_lower_or_digit = false;
+            continue;
+        }
+        if ch.is_ascii_uppercase() {
+            if prev_was_lower_or_digit && !out.ends_with('-') {
+                out.push('-');
+            }
+            out.push(ch.to_ascii_lowercase());
+            prev_was_lower_or_digit = false;
+        } else {
+            out.push(ch);
+            prev_was_lower_or_digit = ch.is_ascii_lowercase() || ch.is_ascii_digit();
+        }
+    }
+    out.trim_matches('-').to_string()
+}
+
+#[cfg(test)]
+mod kebab_tests {
+    use super::kebab_case;
+
+    #[test]
+    fn kebabs_pascal_case_type_names() {
+        assert_eq!(kebab_case("TestMockProcessor"), "test-mock-processor");
+        assert_eq!(kebab_case("Camera"), "camera");
+        assert_eq!(kebab_case("Widget"), "widget");
+        assert_eq!(kebab_case("HttpV2Sink"), "http-v2-sink");
+        assert_eq!(kebab_case("Already_snake"), "already-snake");
+    }
+}

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/session_tests.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/session_tests.rs
@@ -1,0 +1,358 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Tests for [`Runner::add_local`] — live registration of a `#[processor]`
+//! host type under `@session/<name>@0.0.N`, with no package on disk.
+//!
+//! Each test uses a distinct fixture type so their `@session/<name>` ledger
+//! keys never collide across the process-global registry / ledger; the tests
+//! are `#[serial]` for the same reason.
+
+use serial_test::serial;
+
+use super::super::Runner;
+use crate::core::descriptors::{Org, Package, ProcessorDescriptor, SchemaIdent, SemVer, TypeName};
+use crate::core::processors::PROCESSOR_REGISTRY;
+
+// =============================================================================
+// Fixtures — `#[processor]` host types authored in-crate (no package on disk).
+// Distinct names ⇒ distinct `@session/<name>` keys ⇒ no cross-test collision.
+// =============================================================================
+
+#[crate::processor("@app/local/SessionLocalAlpha", execution = manual)]
+struct SessionLocalAlpha;
+impl crate::core::ManualProcessor for SessionLocalAlpha::Processor {
+    fn setup(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+    fn teardown(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+    fn start(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+}
+
+#[crate::processor("@app/local/SessionLocalBeta", execution = manual)]
+struct SessionLocalBeta;
+impl crate::core::ManualProcessor for SessionLocalBeta::Processor {
+    fn setup(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+    fn teardown(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+    fn start(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+}
+
+#[crate::processor("@app/local/SessionLocalGamma", execution = manual)]
+struct SessionLocalGamma;
+impl crate::core::ManualProcessor for SessionLocalGamma::Processor {
+    fn setup(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+    fn teardown(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+    fn start(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+}
+
+/// A shadow fixture: its short type name `Widget` deliberately matches an
+/// installed `@tatolab/things/Widget` registered in the shadow test.
+#[crate::processor("@app/local/Widget", execution = manual)]
+struct SessionShadowWidget;
+impl crate::core::ManualProcessor for SessionShadowWidget::Processor {
+    fn setup(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+    fn teardown(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+    fn start(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+}
+
+/// A typed config for the config-validation fixture — a required `gain` field
+/// so a malformed config JSON is genuinely rejected.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Default)]
+pub struct SessionGainConfig {
+    gain: f32,
+}
+
+#[crate::processor(
+    "@app/local/SessionConfigured",
+    execution = manual,
+    config = SessionGainConfig,
+)]
+struct SessionConfigured;
+impl crate::core::ManualProcessor for SessionConfigured::Processor {
+    fn setup(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        let _ = self.config.gain;
+        Ok(())
+    }
+    fn teardown(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+    fn start(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+}
+
+fn session_ident_for(
+    module: &streamlib_idents::ModuleIdent,
+    type_name: &str,
+) -> Option<SchemaIdent> {
+    PROCESSOR_REGISTRY.resolve_installed_processor_type(
+        &module.org,
+        &module.name,
+        &TypeName::new(type_name).expect("valid type name"),
+    )
+}
+
+// =============================================================================
+
+/// The core acceptance path: `add_local` registers a host type with NO
+/// package, manifest, dylib, or build on disk — the whole flow is the type,
+/// a minted `@session/<name>@0.0.N` ident, and the registry. The registered
+/// session processor is fully instantiable (descriptor + port info + a
+/// non-cdylib host vtable all present).
+#[test]
+#[serial]
+fn add_local_registers_a_session_processor_with_no_package_on_disk() {
+    let runtime = Runner::new().unwrap();
+    let loaded = runtime
+        .add_local_blocking::<SessionLocalAlpha::Processor>(serde_json::Value::Null)
+        .expect("session registration must succeed");
+
+    // Minted under the reserved session org, at a concrete 0.0.N version.
+    assert_eq!(loaded.ident.org.as_str(), "session");
+    assert_eq!(loaded.ident.name.as_str(), "session-local-alpha");
+
+    let ident = session_ident_for(&loaded.ident, "SessionLocalAlpha")
+        .expect("the session processor ident must resolve after registration");
+    assert_eq!(ident.org.as_str(), "session");
+    assert!(PROCESSOR_REGISTRY.is_registered(&ident));
+    assert!(
+        PROCESSOR_REGISTRY.port_info(&ident).is_some(),
+        "a registered session processor exposes port info (is instantiable)"
+    );
+    assert!(PROCESSOR_REGISTRY.descriptor(&ident).is_some());
+
+    runtime
+        .remove_module(loaded.ident)
+        .expect("remove_module unregisters the session processor symmetrically");
+    assert!(
+        session_ident_for(
+            &streamlib_idents::ModuleIdent::new(
+                Org::new("session").unwrap(),
+                Package::new("session-local-alpha").unwrap(),
+                streamlib_idents::SemVerRange::Any,
+            ),
+            "SessionLocalAlpha",
+        )
+        .is_none(),
+        "after remove_module the session processor is gone"
+    );
+}
+
+/// A second live `add_local` of the same `@session/<name>` (not removed) is a
+/// loud typed refusal — never a silent overwrite. Mentally revert the
+/// ledger-collision check in `commit_session_processor_registration` and the
+/// second call silently succeeds (the vtable registry dedups by ident key),
+/// failing this assertion.
+#[test]
+#[serial]
+fn add_local_refuses_a_duplicate_live_session_name() {
+    let runtime = Runner::new().unwrap();
+    let _first = runtime
+        .add_local_blocking::<SessionLocalBeta::Processor>(serde_json::Value::Null)
+        .expect("first registration succeeds");
+
+    let err = runtime
+        .add_local_blocking::<SessionLocalBeta::Processor>(serde_json::Value::Null)
+        .expect_err("a duplicate live session name must be refused");
+    assert!(
+        matches!(err, super::errors::AddModuleError::DuplicateSessionProcessorName { .. }),
+        "expected DuplicateSessionProcessorName, got {err:?}"
+    );
+
+    // Cleanup so the fixture's @session name is free for other runs.
+    let ident = session_ident_for(
+        &streamlib_idents::ModuleIdent::new(
+            Org::new("session").unwrap(),
+            Package::new("session-local-beta").unwrap(),
+            streamlib_idents::SemVerRange::Any,
+        ),
+        "SessionLocalBeta",
+    )
+    .expect("registered");
+    let module = streamlib_idents::ModuleIdent::new(
+        ident.org.clone(),
+        ident.package.clone(),
+        streamlib_idents::SemVerRange::Any,
+    );
+    runtime.remove_module(module).expect("cleanup remove");
+}
+
+/// After `remove_module`, the same type re-registers cleanly at a FRESH
+/// version — the monotonic session counter never reuses a stale ident. This
+/// is the add/remove/add cycle the counter exists for.
+#[test]
+#[serial]
+fn add_local_re_registers_after_removal_at_a_fresh_version() {
+    let runtime = Runner::new().unwrap();
+    let first = runtime
+        .add_local_blocking::<SessionLocalGamma::Processor>(serde_json::Value::Null)
+        .expect("first registration");
+    let first_version = first.ident.version.clone();
+
+    runtime
+        .remove_module(first.ident)
+        .expect("remove clears the ledger entry");
+
+    let second = runtime
+        .add_local_blocking::<SessionLocalGamma::Processor>(serde_json::Value::Null)
+        .expect("re-registration after removal succeeds");
+    assert_ne!(
+        second.ident.version, first_version,
+        "the re-registered version must be fresh, not the stale prior version"
+    );
+
+    runtime.remove_module(second.ident).expect("cleanup remove");
+}
+
+/// A session processor whose short type name shadows an already-registered
+/// installed processor keeps BOTH addressable by full ident — never
+/// overwrites. The registry keys on the structured `SchemaIdent`, so
+/// `@tatolab/things/Widget` and `@session/widget/Widget` coexist.
+#[test]
+#[serial]
+fn add_local_shadow_keeps_both_installed_and_session_addressable() {
+    let runtime = Runner::new().unwrap();
+
+    let installed = SchemaIdent::new(
+        Org::new("tatolab").unwrap(),
+        Package::new("things").unwrap(),
+        TypeName::new("Widget").unwrap(),
+        SemVer::new(1, 0, 0),
+    );
+    PROCESSOR_REGISTRY
+        .register_descriptor_only(ProcessorDescriptor::new(installed.clone(), "installed widget"))
+        .expect("installed Widget registers");
+
+    let loaded = runtime
+        .add_local_blocking::<SessionShadowWidget::Processor>(serde_json::Value::Null)
+        .expect("session Widget registers despite the short-name shadow");
+
+    let session_widget = session_ident_for(&loaded.ident, "Widget").expect("session Widget resolves");
+    assert_ne!(session_widget, installed);
+    assert!(
+        PROCESSOR_REGISTRY.descriptor(&installed).is_some(),
+        "the installed Widget stays addressable"
+    );
+    assert!(
+        PROCESSOR_REGISTRY.is_registered(&session_widget),
+        "the session Widget is addressable"
+    );
+
+    // The shadow helper reports the cross-package collision (used to warn).
+    let shadowed = PROCESSOR_REGISTRY.warn_on_short_name_shadow(&session_widget);
+    assert!(
+        shadowed.contains(&installed),
+        "the installed Widget is reported as shadowed by the session Widget"
+    );
+
+    runtime.remove_module(loaded.ident).expect("cleanup remove");
+}
+
+/// A malformed config is refused BEFORE registering — a session type never
+/// registers with a config its own `Config` type rejects.
+#[test]
+#[serial]
+fn add_local_rejects_a_config_that_does_not_match_the_type() {
+    let runtime = Runner::new().unwrap();
+    let err = runtime
+        .add_local_blocking::<SessionConfigured::Processor>(serde_json::json!({ "gain": "not-a-number" }))
+        .expect_err("a config that doesn't fit P::Config must be refused");
+    assert!(
+        matches!(err, super::errors::AddModuleError::SessionProcessorConfigInvalid { .. }),
+        "expected SessionProcessorConfigInvalid, got {err:?}"
+    );
+
+    // The type never registered — nothing to clean up.
+    assert!(
+        session_ident_for(
+            &streamlib_idents::ModuleIdent::new(
+                Org::new("session").unwrap(),
+                Package::new("session-configured").unwrap(),
+                streamlib_idents::SemVerRange::Any,
+            ),
+            "SessionConfigured",
+        )
+        .is_none(),
+        "a refused registration leaves zero registry residue"
+    );
+}
+
+/// A well-formed config validates and registers; the type is then live.
+#[test]
+#[serial]
+fn add_local_accepts_a_well_formed_config() {
+    let runtime = Runner::new().unwrap();
+    let loaded = runtime
+        .add_local_blocking::<SessionConfigured::Processor>(serde_json::json!({ "gain": 1.5 }))
+        .expect("a valid config registers");
+    let ident = session_ident_for(&loaded.ident, "SessionConfigured").expect("registered");
+    assert!(PROCESSOR_REGISTRY.is_registered(&ident));
+    runtime.remove_module(loaded.ident).expect("cleanup remove");
+}

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/staging.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/staging.rs
@@ -508,3 +508,97 @@ pub(super) fn commit_module_load_registrations(
         signal.publish_committed();
     }
 }
+
+/// Register a single already-compiled session-local processor (the
+/// `add_local` path) through the SAME staging → commit → ledger seam a
+/// disk-backed module load uses, minus the manifest walk a runtime-authored
+/// host type has no need of. Stages the one processor, then — under
+/// [`MODULE_REGISTRY_COMMIT_LOCK`] — registers its host-address-space vtable
+/// (`cdylib_resident: false`, identical to [`crate::core::processors::ProcessorInstanceFactory::register`])
+/// and writes a ledger record keyed by `@session/<name>`, so
+/// [`super::super::Runner::remove_module`] unregisters it symmetrically.
+///
+/// Fail-loud on a live name collision: a `@session/<name>` already in the
+/// ledger is an unremoved live registration of the same name, refused with
+/// [`AddModuleError::DuplicateSessionProcessorName`] rather than silently
+/// deduped by the vtable registry's ident key. The short-type-name shadow of
+/// an installed processor is a warning (both stay addressable), never a
+/// refusal — that check runs before the ident-key registration.
+pub(super) fn commit_session_processor_registration(
+    staging: &ModuleLoadRegistrationStaging,
+    module: &streamlib_idents::ModuleIdent,
+    version: streamlib_idents::SemVer,
+    descriptor: ProcessorDescriptor,
+    vtable: &'static ProcessorVTable,
+) -> std::result::Result<SchemaIdent, super::errors::AddModuleError> {
+    use super::ledger;
+
+    let package_ref = module.package_ref();
+    let processor_ident = descriptor.name.clone();
+
+    let _commit_guard = MODULE_REGISTRY_COMMIT_LOCK.lock();
+
+    // Live-name collision: an unremoved `@session/<name>` registration.
+    if ledger::with_loaded_module_registration_record(&package_ref, |_| ()).is_some() {
+        return Err(super::errors::AddModuleError::DuplicateSessionProcessorName {
+            module: module.clone(),
+        });
+    }
+
+    // Short-type-name shadow of an installed processor: warn, keep both.
+    crate::core::processors::PROCESSOR_REGISTRY.warn_on_short_name_shadow(&processor_ident);
+
+    staging.stage_processor(
+        descriptor,
+        StagedProcessorRegistrationKind::VTable {
+            vtable,
+            cdylib_resident: false,
+        },
+        package_ref.clone(),
+    );
+
+    let staged: Vec<StagedProcessorRegistration> = staging.processors.lock().drain(..).collect();
+    let mut committed_idents: Vec<SchemaIdent> = Vec::new();
+    for staged_processor in staged {
+        let ident = staged_processor.descriptor.name.clone();
+        match staged_processor.kind {
+            StagedProcessorRegistrationKind::VTable {
+                vtable,
+                cdylib_resident,
+            } => {
+                match crate::core::processors::PROCESSOR_REGISTRY.register_via_vtable(
+                    staged_processor.descriptor,
+                    vtable,
+                    cdylib_resident,
+                ) {
+                    Ok(()) => committed_idents.push(ident),
+                    Err(e) => tracing::error!(
+                        processor = %ident,
+                        "add_local commit failed to apply the staged session \
+                         processor registration (bug-grade): {e}",
+                    ),
+                }
+            }
+            StagedProcessorRegistrationKind::Dynamic { .. } => {
+                tracing::error!(
+                    processor = %ident,
+                    "add_local staged a Dynamic-kind processor (bug-grade — \
+                     session registration stages only host vtables)",
+                );
+            }
+        }
+    }
+
+    ledger::insert_loaded_module_registration_record(
+        package_ref,
+        ledger::LoadedModuleRegistrationRecord {
+            version,
+            schema_ids: Vec::new(),
+            processor_idents: committed_idents,
+            dylib_paths: Vec::new(),
+            required_by: Vec::new(),
+        },
+    );
+
+    Ok(processor_ident)
+}

--- a/sdk/streamlib-idents/src/ident.rs
+++ b/sdk/streamlib-idents/src/ident.rs
@@ -28,6 +28,18 @@ use crate::semver::{SemVer, SemVerRange};
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Org(String);
 
+/// Org segment reserved for in-app / session-local processors.
+///
+/// A processor registered live at runtime (e.g. via the in-app authoring
+/// path) lives under `@session/…` so it never collides with an installed
+/// `@org/…` package on the registry key. This org is **constructible** —
+/// [`validate_org`] accepts it, so runtime `@session/…` idents can be built —
+/// but it is **not publishable**: `streamlib pkg build` / `pkg publish` reject
+/// a package that declares it (see [`Org::is_reserved_for_session`]). The two
+/// facts are deliberately separate seams: grammar admits it; the publish
+/// boundary refuses it.
+pub const SESSION_ORG: &str = "session";
+
 impl Org {
     pub fn new(s: impl Into<String>) -> IdentResult<Self> {
         let s = s.into();
@@ -37,6 +49,15 @@ impl Org {
 
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    /// Whether this org is the [`SESSION_ORG`] reserved for in-app /
+    /// session-local processors — constructible for runtime idents, but
+    /// rejected at the publish boundary. Callers on the `pkg build` /
+    /// `pkg publish` path use this to refuse a distribution artifact that
+    /// would squat the reserved namespace.
+    pub fn is_reserved_for_session(&self) -> bool {
+        self.0 == SESSION_ORG
     }
 }
 
@@ -725,6 +746,25 @@ version: 0.4.33-dev.2
             validate_type("Video-Frame"),
             Err(IdentError::InvalidTypeCharacter(_, '-'))
         ));
+    }
+
+    #[test]
+    fn session_org_stays_constructible_via_grammar() {
+        // The reserved `session` org MUST keep passing `validate_org` /
+        // `Org::new` — runtime `@session/…` idents are built from it. The
+        // publish rejection lives at the `pkg build` boundary, never in the
+        // grammar. Revert the "keep accepting" contract (reject `session` in
+        // `validate_org`) and this fails, catching the wrong-seam mistake.
+        assert!(validate_org(SESSION_ORG).is_ok());
+        let org = Org::new(SESSION_ORG).expect("session org must be constructible");
+        assert_eq!(org.as_str(), "session");
+    }
+
+    #[test]
+    fn is_reserved_for_session_flags_only_session_org() {
+        assert!(Org::new(SESSION_ORG).unwrap().is_reserved_for_session());
+        assert!(!Org::new("tatolab").unwrap().is_reserved_for_session());
+        assert!(!Org::new("sessions").unwrap().is_reserved_for_session());
     }
 
     #[test]

--- a/sdk/streamlib-idents/src/lib.rs
+++ b/sdk/streamlib-idents/src/lib.rs
@@ -31,8 +31,8 @@ pub use catalog::{
 pub use error::{IdentError, IdentResult, ResolverError, ResolverResult};
 pub use git::fetch_git;
 pub use ident::{
-    ModuleIdent, Org, Package, PackageRef, SchemaIdent, TypeName, validate_org, validate_package,
-    validate_type,
+    ModuleIdent, Org, Package, PackageRef, SESSION_ORG, SchemaIdent, TypeName, validate_org,
+    validate_package, validate_type,
 };
 pub use lockfile::{
     APP_LOCKFILE_NAME, CODEGEN_LOCKFILE_NAME, Lockfile, LockfileEntry, LockfileSource,

--- a/sdk/streamlib-idents/src/lib.rs
+++ b/sdk/streamlib-idents/src/lib.rs
@@ -21,6 +21,7 @@ mod registry;
 mod release;
 mod resolver;
 mod semver;
+mod session;
 
 pub use catalog::{
     CATALOG_INDEX_PATH, CatalogClient, CatalogConfig, CatalogIndexLine, CatalogPort,
@@ -55,3 +56,4 @@ pub use resolver::{
     content_hash_for_package_dir, resolve, resolve_bare_schema_name, resolve_with,
 };
 pub use semver::{Prerelease, PrereleaseKind, SemVer, SemVerRange};
+pub use session::{MintedSessionIdent, mint_session_module_ident, next_session_module_version};

--- a/sdk/streamlib-idents/src/session.rs
+++ b/sdk/streamlib-idents/src/session.rs
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Minting fresh `@session/<name>@0.0.N` identities for in-app /
+//! session-local processors registered live at runtime.
+//!
+//! A processor registered live (the in-app authoring path, `add_local`)
+//! lives under the [`crate::SESSION_ORG`] org so it never collides with an
+//! installed `@org/…` package on the registry key. Each registration is
+//! stamped a fresh `0.0.N` version from a process-global monotonic counter,
+//! so re-registering the same name after a removal yields a distinct
+//! version rather than reusing a stale ident.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use crate::SESSION_ORG;
+use crate::error::IdentResult;
+use crate::ident::{ModuleIdent, Org, Package};
+use crate::semver::{SemVer, SemVerRange};
+
+/// Process-global monotonic counter that stamps the `patch` of each minted
+/// `@session/<name>@0.0.N` version. Starts at 0 and only ever advances, so
+/// two mints in one process never share a version — even for the same name
+/// across an add/remove/add cycle.
+static NEXT_SESSION_VERSION_PATCH: AtomicU32 = AtomicU32::new(0);
+
+/// The concrete next `0.0.N` release version from the session counter. The
+/// major/minor stay `0.0` by convention (session identities are ephemeral
+/// and never published); `N` is the monotonic patch.
+pub fn next_session_module_version() -> SemVer {
+    let n = NEXT_SESSION_VERSION_PATCH.fetch_add(1, Ordering::Relaxed);
+    SemVer::new(0, 0, n)
+}
+
+/// A freshly-minted session identity: the `@session/<name>@0.0.N` module
+/// ident, its concrete `0.0.N` version, and the validated `@session/<name>`
+/// package. Returned by [`mint_session_module_ident`].
+#[derive(Debug, Clone)]
+pub struct MintedSessionIdent {
+    /// `@session/<name>@=0.0.N` — the imperative module ident carried by an
+    /// `AddedModule` load handle.
+    pub module: ModuleIdent,
+    /// The concrete `0.0.N` version stamped from the monotonic counter.
+    pub version: SemVer,
+    /// The validated `<name>` package segment.
+    pub package: Package,
+}
+
+/// Mint a fresh `@session/<name>@0.0.N` module identity from a package-name
+/// segment (typically a kebab-cased processor type name).
+///
+/// The `name` must satisfy the package grammar (`[a-z][a-z0-9-]*`) — a
+/// malformed name is a loud typed error, never a silently-mangled ident.
+/// The version is stamped from the process-global monotonic counter, so two
+/// calls (even with the same `name`) never share a version.
+pub fn mint_session_module_ident(name: &str) -> IdentResult<MintedSessionIdent> {
+    let org = Org::new(SESSION_ORG).expect("SESSION_ORG passes the org grammar by construction");
+    let package = Package::new(name)?;
+    let version = next_session_module_version();
+    let module = ModuleIdent::new(org, package.clone(), SemVerRange::Exact(version));
+    Ok(MintedSessionIdent {
+        module,
+        version,
+        package,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mint_stamps_a_monotonically_increasing_version() {
+        // Two mints of the SAME name must produce DISTINCT versions — this is
+        // what lets an add/remove/add cycle re-register a name without reusing
+        // a stale ident. Revert the `fetch_add` to a constant and the two
+        // versions collide, failing this assertion.
+        let first = mint_session_module_ident("my-processor").expect("valid name mints");
+        let second = mint_session_module_ident("my-processor").expect("valid name mints");
+        assert_eq!(first.package.as_str(), "my-processor");
+        assert_eq!(first.module.org.as_str(), SESSION_ORG);
+        assert!(
+            second.version.patch > first.version.patch,
+            "the session version counter must be monotonic: {} !> {}",
+            second.version.patch,
+            first.version.patch
+        );
+    }
+
+    #[test]
+    fn mint_rejects_a_malformed_name() {
+        // A leading uppercase / underscore fails the package grammar — the mint
+        // surfaces the typed error rather than building an invalid ident.
+        assert!(mint_session_module_ident("_bad").is_err());
+        assert!(mint_session_module_ident("Bad").is_err());
+        assert!(mint_session_module_ident("").is_err());
+    }
+
+    #[test]
+    fn minted_module_ident_renders_under_the_session_org() {
+        let minted = mint_session_module_ident("camera").expect("valid name mints");
+        let rendered = minted.module.to_string();
+        assert!(
+            rendered.starts_with("@session/camera@="),
+            "expected @session/camera@=0.0.N, got {rendered}"
+        );
+    }
+}

--- a/tools/streamlib-pack/src/lib.rs
+++ b/tools/streamlib-pack/src/lib.rs
@@ -513,6 +513,20 @@ pub fn assemble_artifact_with_cargo_config(
         // by an active `streamlib link`. `StagedDir` stays exempt so
         // orchestrator load-time builds keep working while linked.
         link_marker::ensure_no_active_link_for_pack(pkg_dir)?;
+        // The `@session/…` org is reserved for in-app / session-local
+        // processors registered live at runtime; it is deliberately NOT
+        // publishable. Refuse to build a distribution `.slpkg` that squats it
+        // so a session-local name can never masquerade as an installable
+        // package on the registry. `StagedDir` stays exempt (dev-resolution).
+        if package.org.is_reserved_for_session() {
+            anyhow::bail!(
+                "streamlib.yaml at {} declares the reserved `@{}/…` org, which is \
+                 reserved for in-app / session-local processors and cannot be built \
+                 into a distributable package. Publish under your own org instead.",
+                pkg_dir.display(),
+                streamlib_idents::SESSION_ORG,
+            );
+        }
     }
 
     // (archive_path, source_path) pairs for every file EXCEPT the
@@ -1649,6 +1663,56 @@ mod tests {
             &(),
         )
         .expect("StagedDir assembly must stay exempt while linked");
+    }
+
+    #[test]
+    fn slpkg_assembly_rejects_reserved_session_org_but_staged_dir_is_exempt() {
+        // The reserved-org publish guard: `@session/…` is reserved for in-app /
+        // session-local processors registered live at runtime and is NOT
+        // publishable, so a distributable `.slpkg` that declares it is refused.
+        // StagedDir (orchestrator dev-resolution build) stays exempt. Mentally
+        // revert the `is_reserved_for_session()` bail and the Slpkg arm below
+        // assembles instead of erroring, letting a session name squat the
+        // registry.
+        let dir = tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("schemas")).unwrap();
+        std::fs::write(
+            dir.path().join("streamlib.yaml"),
+            "package:\n  org: session\n  name: my-processor\n  version: 0.0.1\nschemas:\n  T:\n    file: schemas/t.yaml\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("schemas/t.yaml"),
+            "metadata:\n  type: T\n  max_payload_bytes: 16\n",
+        )
+        .unwrap();
+
+        let err = assemble_artifact(
+            dir.path(),
+            &AssembleTarget::Slpkg(dir.path().join("o.slpkg")),
+            &slpkg_opts(false),
+            &(),
+        )
+        .expect_err("a package under the reserved @session org must be refused for build/publish");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("session"),
+            "the refusal must name the reserved session org, got: {msg}"
+        );
+
+        // StagedDir target → exempt, assembles fine (dev-resolution path).
+        let staged = tempdir().unwrap();
+        assemble_artifact(
+            dir.path(),
+            &AssembleTarget::StagedDir(staged.path().to_path_buf()),
+            &AssembleOptions {
+                no_build: false,
+                profile: CargoProfile::Release,
+                path_deps: PathDepPolicy::RewriteRelativeToAbsolute,
+            },
+            &(),
+        )
+        .expect("StagedDir assembly must stay exempt from the session-org publish guard");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1410

## Summary

Adds `Runner::add_local::<P>(config: serde_json::Value) -> AddedModule`, a live-registration op that registers a `#[processor]`-annotated host type directly onto the existing `PROCESSOR_REGISTRY` — no package on disk, no dylib. Packaging stays for *sharing* a processor; it is never a prerequisite to *having* one.

- Reuses the module_loader's transactional staging/ledger/rollback seam via a new session module-source variant (`session.rs`, `staging.rs`) — no parallel local registry.
- Mints runtime identities under a reserved `@session/<kebab-name>@0.0.N` org (`streamlib-idents`), with a monotonically increasing version per re-registration.
- `@session` is refused at `pkg build` / registry publish (`tools/streamlib-pack`) — session names can never masquerade as an installable package.
- Local-vs-installed same-name collision **warns** and keeps both addressable (never silently overwrites).
- Named error variants for duplicate `@session` name and malformed name (`module_loader/errors.rs`).
- Config is validated against `P::Config` (JSON round-trip, same currency as `ProcessorSpec.config`) before registration.

Landed in 3 commits:
- `bbeab4ac` feat(idents): reserve `@session` org — non-publishable, refused at pkg build
- `d4d29480` feat(idents): mint `@session/<name>@0.0.N` runtime identities
- `f51d795e` feat(engine): `Runner::add_local` — register a `#[processor]` host type live

## Test evidence

All commands run in-worktree against `f51d795e` on this branch:

```
cargo test -p streamlib-engine --lib module_loader::session
  test core::runtime::module_loader::session::kebab_tests::kebabs_pascal_case_type_names ... ok
  test core::runtime::module_loader::session_tests::add_local_accepts_a_well_formed_config ... ok
  test core::runtime::module_loader::session_tests::add_local_refuses_a_duplicate_live_session_name ... ok
  test core::runtime::module_loader::session_tests::add_local_re_registers_after_removal_at_a_fresh_version ... ok
  test core::runtime::module_loader::session_tests::add_local_rejects_a_config_that_does_not_match_the_type ... ok
  test core::runtime::module_loader::session_tests::add_local_registers_a_session_processor_with_no_package_on_disk ... ok
  test core::runtime::module_loader::session_tests::add_local_shadow_keeps_both_installed_and_session_addressable ... ok
  test result: ok. 7 passed; 0 failed

cargo test -p streamlib-idents session
  test ident::tests::session_org_stays_constructible_via_grammar ... ok
  test ident::tests::is_reserved_for_session_flags_only_session_org ... ok
  test session::tests::mint_rejects_a_malformed_name ... ok
  test session::tests::mint_stamps_a_monotonically_increasing_version ... ok
  test session::tests::minted_module_ident_renders_under_the_session_org ... ok
  test result: ok. 5 passed; 0 failed

cargo test -p streamlib-pack --lib slpkg_assembly_rejects_reserved_session_org
  test tests::slpkg_assembly_rejects_reserved_session_org_but_staged_dir_is_exempt ... ok
  test result: ok. 1 passed; 0 failed

cargo test -p streamlib-pack   (full crate, sanity)
  3 + 1 + 4 unit/integration tests across catalog/registry/slpkg suites ... all ok
```

No GPU/IPC runtime surface touched (registry + registration bookkeeping only) — no live-rig E2E needed for this change.

## Acceptance criteria (from #1410)

- [x] `add_local::<T>()` registers on the existing `PROCESSOR_REGISTRY` and returns `AddedModule` (same shape `add` returns)
- [x] Runtime-dynamic op reusing module_loader's staging/ledger/rollback seam (session module-source variant) — verified against a constructed runtime; see review item below on the running-runtime leg
- [x] `@session` org reserved in `streamlib-idents` + refused at `pkg build`
- [x] Local-vs-installed same-name collision warns, both addressable
- [x] Named error variants (duplicate `@session` name, malformed name)
- [x] Tests: register+instantiate with no package on disk; collision warns + both resolvable; `@session/` rejected at `pkg build`

### Signature deviation from the 2026-07-18 acceptance-criteria correction

The correction says `add_local::<T>(bag)` taking a config `Bag` (default `Bag::empty()`). The implementation is `add_local::<P>(config: serde_json::Value)`. `Bag` lives in the engine-free `sdk/streamlib-plugin-sdk`, which the engine cannot depend on without inverting layering, and the `Config` trait mandates a JSON round-trip — `serde_json::Value` is the same currency `ProcessorSpec.config` already uses. The Bag ergonomic surface is scoped to #1412's App sugar (`sdk/streamlib-sdk`), which converts Bag→json before calling this primitive. Flagged as a review item below for the owner to confirm the layering call.

## Review items (non-blocking)

These surfaced during verification and don't block merge; listed here so they're visible in-context for the owner.

1. **should-fix** — `runtime/streamlib-engine/src/core/runtime/module_loader/session.rs:70`: The 2026-07-18 acceptance-criteria correction says the signature is `add_local::<T>(bag)` taking a config `Bag` (default `Bag::empty()`); the implementation is `add_local<P>(config: serde_json::Value)`.
   - Evidence: session.rs:70 `pub fn add_local<P>(&self, config: serde_json::Value) -> AddedModule`. Bag lives in the engine-free `sdk/streamlib-plugin-sdk` (bag.rs:44), which the engine cannot depend on without inverting layering; and the `Config` trait (core/processors/traits/config.rs) mandates JSON round-trip, so `serde_json::Value` — the same currency as `ProcessorSpec.config` — is the consistent engine-layer choice. The Bag ergonomic surface belongs to #1412's App sugar (`sdk/streamlib-sdk`), which can convert Bag→json.
   - Suggested next step: Document the deviation on the PR body (engine primitive takes serde_json::Value; Bag surface deferred to #1412 App sugar which bridges Bag→json). No code change needed if the owner accepts the layering rationale.

2. **should-fix** — `runtime/streamlib-engine/src/core/runtime/module_loader/session_tests.rs:170`: Acceptance criterion 2 requires the op be valid against a constructed AND a running runtime; tests only exercise a freshly-constructed `Runner::new()` (never started).
   - Evidence: Every test builds `Runner::new().unwrap()` and calls `add_local_blocking` without starting the runtime. No test drives `add_local` (async) or exercises registration after the runtime is running. The mechanism (spawn_blocking + PROCESSOR_REGISTRY/ledger under MODULE_REGISTRY_COMMIT_LOCK) is runtime-state-independent, so this is a coverage gap, not a demonstrated defect.
   - Suggested next step: Add a test that registers via add_local after the runtime is started, or file a rig-gated follow-up if starting a full runtime requires GPU/IPC unavailable in the sandbox (exit 144). Note the gap on the PR.

3. **info** — `runtime/streamlib-engine/src/core/runtime/module_loader/session.rs:175`: `config` is validated against `P::Config` then discarded — the registration stores only the descriptor + vtable, never the config.
   - Evidence: prepare_session_registration does `serde_json::from_value::<P::Config>(config)` purely for validation; the config value is dropped and the registered `ProcessorDescriptor` carries no config. A processor instance's real config is supplied later at add_processor time. Early validation can drift from the config actually used to instantiate.
   - Suggested next step: Confirm with #1412 App-sugar design that the add_local config param is intentionally validate-only (not instance-binding); the returned AddedModule is a module handle, not an instance handle.

4. **low** — `runtime/streamlib-engine/src/core/runtime/module_loader/staging.rs:540`: The `Err(e)` arm of `register_via_vtable` in commit_session_processor_registration logs a bug-grade error but then still inserts a ledger record and returns `Ok(processor_ident)`, reporting false success.
   - Evidence: register_via_vtable (processor_instance_factory.rs:882) currently returns `Ok(())` on every path (dedups duplicates by returning Ok), so the Err arm is effectively dead defensive code. If register_via_vtable ever gains a real Err path, the current shape would swallow it and return a spurious success.
   - Suggested next step: If register_via_vtable stays infallible, this is harmless; otherwise propagate the error instead of logging-and-inserting an empty ledger record.

5. **low** — `runtime/streamlib-engine/src/core/runtime/module_loader/session.rs:257`: `add_local_blocking`'s `unreachable!()` for the guarded `ExternalTokioHandle` arm omits the message string its sibling uses, a small consistency gap.
   - Evidence: Line 257 is `TokioRuntimeVariant::ExternalTokioHandle(_) => unreachable!(),` with a `// Guarded above` comment. The canonical siblings in the same module write `unreachable!("guarded above")` (mod.rs:435) — the guard-then-rematch-with-unreachable shape is the established convention here, so the code is structurally correct; only the panic message is missing.
   - Suggested next step: Match the sibling: `unreachable!("guarded above")` so a would-be panic (a real bug) names why it was thought impossible. Do NOT restructure into a single match — the two-step guard-then-match is the file's canonical pattern (mod.rs:422/435, 463/469) and consistency wins.

6. **low** — `runtime/streamlib-engine/src/core/runtime/module_loader/session.rs:404`: `kebab_case` reimplements PascalCase word-boundary splitting that already exists as `to_snake_case` and `pascal_to_snake`.
   - Evidence: `to_snake_case` (sdk/streamlib-processor-schema/src/processor_schema.rs:689, pub) and `pascal_to_snake` (sdk/streamlib-jtd-codegen/src/lib.rs:1687) already walk the same upper/lower/digit boundaries; for every case in `kebab_tests` the output equals `to_snake_case(name).replace('_', "-")`. This is a 4th hand-rolled case-splitter. It stays a *low* because it has a single call site (below engine-doctrine's ">1 call site" bar for mandatory extraction) and no *kebab* converter exists today — the extra dedup/trim logic is genuinely new.
   - Suggested next step: Optional: derive from the canonical splitter (`to_snake_case(type_name).replace('_', "-")` plus the existing trim/dedup), or leave as-is and note in the PR body that a shared case-conversion util is the eventual home. No change required to merge.

7. **info** — `runtime/streamlib-engine/src/core/runtime/module_loader/session.rs:396`: `expect()` appears in library code in `fallback_session_module` and (in the idents crate) `mint_session_module_ident`/`Org::new(SESSION_ORG)`.
   - Evidence: session.rs:396-397 `mint_session_module_ident("local").expect("`local` is a valid session package name")` and sdk/streamlib-idents/src/session.rs:699 `Org::new(SESSION_ORG).expect("SESSION_ORG passes the org grammar by construction")`. Both are infallible-by-construction (a hardcoded grammar-valid constant) with descriptive messages, which is the accepted idiom for a true invariant rather than a `?`-able error — not a defect, noted only because the repo mandates `?` over unwrap/expect broadly.
   - Suggested next step: No action. These are correct uses of `expect` on compile-constant invariants; leaving them is preferable to inventing an impossible error variant.

8. **info** — `runtime/streamlib-engine/src/core/runtime/module_loader/staging.rs:499`: The staged-processor drain/register loop in `commit_session_processor_registration` parallels the existing loop in `commit_module_load_registrations`.
   - Evidence: staging.rs:499-529 drains `staging.processors` and dispatches on `StagedProcessorRegistrationKind` exactly like staging.rs:418-452. The two intentionally diverge (session collects a flat `Vec<SchemaIdent>` and treats the `Dynamic` arm as bug-grade; the module-load path groups by owner and registers `Dynamic` normally), so this is incidental similarity of two loops that will evolve independently, not extract-worthy duplication.
   - Suggested next step: Leave as-is; the semantic divergence (Dynamic-is-a-bug vs Dynamic-is-valid, flat vs by-owner) makes a shared helper a net loss. Nothing to change.

9. **info** — `runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs:16`: `warn_on_short_name_shadow` returns `Vec<SchemaIdent>` whose only consumer is tests — the sole production caller ignores it.
   - Evidence: The prod call at staging.rs:488 is `PROCESSOR_REGISTRY.warn_on_short_name_shadow(&processor_ident);` with the return value discarded; the doc (line 15) states the Vec is "for tests / diagnostics." Returning data purely to give tests a hook is a mild smell, but it doubles as a legitimate diagnostic surface and costs one allocation only on the (rare) collision path.
   - Suggested next step: Acceptable as diagnostics. If tightening later, the collision set could be asserted via a `tracing`-capture test instead, but no change is needed to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)