### PR TITLE
ci(release): keep inter-crate version requirements in sync (sweep to 0.7.3 + auto-bump)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,6 +28,43 @@ jobs:
           manifest-file: .release-please-manifest.json
 
       # The `simple` release-type bumps [workspace.package].version in Cargo.toml
+      # but ships no cargo dependency-requirement updater. Every in-tree crate
+      # pins its workspace-versioned sibling crates with a frozen
+      # `version = "X.Y.Z"` requirement (e.g. streamlib-error, vulkan-jpeg). Those
+      # requirements never move on their own: caret-compatible within a 0.7.x line
+      # but silently EXCLUDING the next breaking bump (0.8.0), which would make the
+      # whole tree fail to resolve after the release. Rewrite them to the release
+      # version on the release-PR branch (found by the same `autorelease: pending`
+      # label the lock-sync and auto-merge steps use) so the squash-merge folds it
+      # into the release commit. Runs BEFORE the lock sync so `cargo update` below
+      # records the rewritten requirements. Independently-versioned `packages/*`
+      # domain crates are left alone by the script. No-ops when nothing is pending
+      # or the requirements are already in sync.
+      - name: Sync inter-crate version requirements to the release version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 100 \
+            --json headRefName,labels \
+            --jq 'map(select(.labels[].name == "autorelease: pending")) | .[0].headRefName // empty')
+          if [ -z "$BRANCH" ]; then
+            echo "no open release PR this run"
+            exit 0
+          fi
+          git fetch origin "$BRANCH"
+          git checkout "$BRANCH"
+          python3 scripts/sync-inter-crate-versions.py
+          if git diff --quiet; then
+            echo "inter-crate requirements already in sync"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: sync inter-crate version requirements to the release version"
+          git push origin "$BRANCH"
+
+      # The `simple` release-type bumps [workspace.package].version in Cargo.toml
       # (via extra-files) but has no Cargo.lock updater, so the workspace-member
       # entries in Cargo.lock keep the old version. CI runs cargo with --locked,
       # so a merged bump with a stale lock errors before any check runs. Sync the

--- a/adapters/streamlib-adapter-cpu-readback-helpers/Cargo.toml
+++ b/adapters/streamlib-adapter-cpu-readback-helpers/Cargo.toml
@@ -27,12 +27,12 @@ publish = false
 path = "src/lib.rs"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib = { path = "../../sdk/streamlib-sdk", version = "0.7.0" }
-streamlib-engine = { path = "../../runtime/streamlib-engine", version = "0.7.0" }
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.7.0" }
-streamlib-adapter-cpu-readback = { path = "../streamlib-adapter-cpu-readback", version = "0.7.0" }
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.0" }
-streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.0" }
+streamlib = { path = "../../sdk/streamlib-sdk", version = "0.7.6" }
+streamlib-engine = { path = "../../runtime/streamlib-engine", version = "0.7.6" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.7.6" }
+streamlib-adapter-cpu-readback = { path = "../streamlib-adapter-cpu-readback", version = "0.7.6" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.6" }
+streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.6" }
 vulkanalia.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/adapters/streamlib-adapter-cpu-readback/Cargo.toml
+++ b/adapters/streamlib-adapter-cpu-readback/Cargo.toml
@@ -15,14 +15,14 @@ name = "streamlib_adapter_cpu_readback"
 path = "src/lib.rs"
 
 [dependencies]
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.7.0" }
-streamlib-adapter-cpu-readback-abi = { path = "../streamlib-adapter-cpu-readback-abi", version = "0.7.0" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.7.6" }
+streamlib-adapter-cpu-readback-abi = { path = "../streamlib-adapter-cpu-readback-abi", version = "0.7.6" }
 thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.0" }
-streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.0" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.6" }
+streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.6" }
 vulkanalia.workspace = true
 libc.workspace = true
 serde = { workspace = true }

--- a/adapters/streamlib-adapter-cuda-helpers/Cargo.toml
+++ b/adapters/streamlib-adapter-cuda-helpers/Cargo.toml
@@ -42,11 +42,11 @@ default = []
 cuda = ["dep:cudarc"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib = { path = "../../sdk/streamlib-sdk", version = "0.7.0" }
-streamlib-engine = { path = "../../runtime/streamlib-engine", version = "0.7.0" }
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.7.0" }
-streamlib-adapter-cuda = { path = "../streamlib-adapter-cuda", version = "0.7.0" }
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.0" }
+streamlib = { path = "../../sdk/streamlib-sdk", version = "0.7.6" }
+streamlib-engine = { path = "../../runtime/streamlib-engine", version = "0.7.6" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.7.6" }
+streamlib-adapter-cuda = { path = "../streamlib-adapter-cuda", version = "0.7.6" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.6" }
 vulkanalia.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/adapters/streamlib-adapter-cuda/Cargo.toml
+++ b/adapters/streamlib-adapter-cuda/Cargo.toml
@@ -29,14 +29,14 @@ default = []
 cuda = []
 
 [dependencies]
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.7.0" }
-streamlib-adapter-cuda-abi = { path = "../streamlib-adapter-cuda-abi", version = "0.7.0" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.7.6" }
+streamlib-adapter-cuda-abi = { path = "../streamlib-adapter-cuda-abi", version = "0.7.6" }
 thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.0" }
-streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.0" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.6" }
+streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.6" }
 vulkanalia.workspace = true
 libc.workspace = true
 # DLPack ABI mirrors only — `default-features = false` pulls in only

--- a/adapters/streamlib-adapter-opengl/Cargo.toml
+++ b/adapters/streamlib-adapter-opengl/Cargo.toml
@@ -15,15 +15,15 @@ name = "streamlib_adapter_opengl"
 path = "src/lib.rs"
 
 [dependencies]
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.7.0" }
-streamlib-adapter-opengl-abi = { path = "../streamlib-adapter-opengl-abi", version = "0.7.0" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.7.6" }
+streamlib-adapter-opengl-abi = { path = "../streamlib-adapter-opengl-abi", version = "0.7.6" }
 parking_lot = "0.12"
 thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.0" }
-streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.0" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.6" }
+streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.6" }
 khronos-egl = { version = "6.0", features = ["dynamic"] }
 gl = "0.14"
 libc.workspace = true

--- a/adapters/streamlib-adapter-skia/Cargo.toml
+++ b/adapters/streamlib-adapter-skia/Cargo.toml
@@ -15,15 +15,15 @@ name = "streamlib_adapter_skia"
 path = "src/lib.rs"
 
 [dependencies]
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.7.0" }
-streamlib-adapter-skia-abi = { path = "../streamlib-adapter-skia-abi", version = "0.7.0" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.7.6" }
+streamlib-adapter-skia-abi = { path = "../streamlib-adapter-skia-abi", version = "0.7.6" }
 thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan", version = "0.7.0" }
-streamlib-adapter-opengl = { path = "../streamlib-adapter-opengl", version = "0.7.0" }
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.0" }
+streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan", version = "0.7.6" }
+streamlib-adapter-opengl = { path = "../streamlib-adapter-opengl", version = "0.7.6" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.6" }
 vulkanalia.workspace = true
 skia-safe = { workspace = true }
 # vkGetInstanceProcAddr lives on vulkanalia's private StaticCommands;
@@ -37,7 +37,7 @@ libloading = "0.8"
 # live under regular `[dependencies]` rather than `[dev-dependencies]`
 # because Cargo's `[[bin]]` targets don't see dev-deps. Same shape as
 # `streamlib-adapter-opengl/Cargo.toml`.
-streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.0" }
+streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.6" }
 serde = { workspace = true }
 serde_json.workspace = true
 libc.workspace = true

--- a/adapters/streamlib-adapter-vulkan-helpers/Cargo.toml
+++ b/adapters/streamlib-adapter-vulkan-helpers/Cargo.toml
@@ -27,12 +27,12 @@ publish = false
 path = "src/lib.rs"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib = { path = "../../sdk/streamlib-sdk", version = "0.7.0" }
-streamlib-engine = { path = "../../runtime/streamlib-engine", version = "0.7.0" }
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.7.0" }
-streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan", version = "0.7.0" }
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.0" }
-streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.0" }
+streamlib = { path = "../../sdk/streamlib-sdk", version = "0.7.6" }
+streamlib-engine = { path = "../../runtime/streamlib-engine", version = "0.7.6" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.7.6" }
+streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan", version = "0.7.6" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.6" }
+streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.6" }
 vulkanalia.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/adapters/streamlib-adapter-vulkan/Cargo.toml
+++ b/adapters/streamlib-adapter-vulkan/Cargo.toml
@@ -15,14 +15,14 @@ name = "streamlib_adapter_vulkan"
 path = "src/lib.rs"
 
 [dependencies]
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.7.0" }
-streamlib-adapter-vulkan-abi = { path = "../streamlib-adapter-vulkan-abi", version = "0.7.0" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.7.6" }
+streamlib-adapter-vulkan-abi = { path = "../streamlib-adapter-vulkan-abi", version = "0.7.6" }
 thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.0" }
-streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.0" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.6" }
+streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.6" }
 vulkanalia.workspace = true
 libc.workspace = true
 serde = { workspace = true }

--- a/examples/audio-mixer-demo/Cargo.toml
+++ b/examples/audio-mixer-demo/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2024"
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 serde_json = "1"
 
 # Standalone example (headed to its own repo). The empty `[workspace]` table

--- a/examples/camera-audio-recorder/Cargo.toml
+++ b/examples/camera-audio-recorder/Cargo.toml
@@ -23,6 +23,6 @@ publish = false
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 
 [workspace]

--- a/examples/camera-deno-subprocess/Cargo.toml
+++ b/examples/camera-deno-subprocess/Cargo.toml
@@ -23,7 +23,7 @@ backend-vulkan = ["streamlib/backend-vulkan"]
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 serde_json = "1.0"
 
 [workspace]

--- a/examples/camera-display/Cargo.toml
+++ b/examples/camera-display/Cargo.toml
@@ -22,7 +22,7 @@ backend-vulkan = ["streamlib/backend-vulkan"]
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 tokio = { version = "1.48.0", features = ["full"] }
 anyhow = "1.0.100"
 serde_json = "1.0"

--- a/examples/camera-plugin-sdk-compute/Cargo.toml
+++ b/examples/camera-plugin-sdk-compute/Cargo.toml
@@ -30,12 +30,12 @@ license = "BUSL-1.1"
 
 [workspace.dependencies]
 # Engine facade — used ONLY by the runner (the host app), never the plugin.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 # Engine-free authoring SDK chain — used by the plugin cdylib.
-streamlib-plugin-sdk = { version = "0.7" }
-streamlib-macros = { version = "0.7" }
-streamlib-plugin-abi = { version = "0.7" }
-streamlib-jtd-codegen = { version = "0.7" }
+streamlib-plugin-sdk = { version = "0.7.6" }
+streamlib-macros = { version = "0.7.6" }
+streamlib-plugin-abi = { version = "0.7.6" }
+streamlib-jtd-codegen = { version = "0.7.6" }
 tracing = { version = "0.1.41", features = ["release_max_level_debug"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/examples/camera-python-display/Cargo.toml
+++ b/examples/camera-python-display/Cargo.toml
@@ -40,14 +40,14 @@ license = "BUSL-1.1"
 [workspace.dependencies]
 # Engine facade — used ONLY by the runner (the host app), never the `effects`
 # plugin cdylib.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 # Engine-free authoring SDK chain — used by the `effects` plugin cdylib.
-streamlib-plugin-sdk = { version = "0.7" }
-streamlib-macros = { version = "0.7" }
-streamlib-jtd-codegen = { version = "0.7" }
-streamlib-plugin-abi = { version = "0.7" }
-streamlib-adapter-abi = { version = "0.7" }
-streamlib-consumer-rhi = { version = "0.7" }
+streamlib-plugin-sdk = { version = "0.7.6" }
+streamlib-macros = { version = "0.7.6" }
+streamlib-jtd-codegen = { version = "0.7.6" }
+streamlib-plugin-abi = { version = "0.7.6" }
+streamlib-adapter-abi = { version = "0.7.6" }
+streamlib-consumer-rhi = { version = "0.7.6" }
 tracing = { version = "0.1.41", features = ["release_max_level_debug"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/examples/camera-python-subprocess/Cargo.toml
+++ b/examples/camera-python-subprocess/Cargo.toml
@@ -19,7 +19,7 @@ publish = false
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 serde_json = "1.0"
 
 [workspace]

--- a/examples/camera-rust-plugin/Cargo.toml
+++ b/examples/camera-rust-plugin/Cargo.toml
@@ -30,12 +30,12 @@ license = "BUSL-1.1"
 
 [workspace.dependencies]
 # Engine facade — used ONLY by the runner (the host app), never the plugin.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 # Engine-free authoring SDK chain — used by the plugin cdylib.
-streamlib-plugin-sdk = { version = "0.7" }
-streamlib-macros = { version = "0.7" }
-streamlib-jtd-codegen = { version = "0.7" }
-streamlib-plugin-abi = { version = "0.7" }
+streamlib-plugin-sdk = { version = "0.7.6" }
+streamlib-macros = { version = "0.7.6" }
+streamlib-jtd-codegen = { version = "0.7.6" }
+streamlib-plugin-abi = { version = "0.7.6" }
 tracing = { version = "0.1.41", features = ["release_max_level_debug"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/examples/cuda-fisheye-detection/Cargo.toml
+++ b/examples/cuda-fisheye-detection/Cargo.toml
@@ -11,9 +11,9 @@ publish = false
 # crates.io yet, so `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point them at the in-repo SDK for local development.
 [dependencies]
-streamlib = { version = "0.7" }
-streamlib-adapter-abi = { version = "0.7" }
-streamlib-adapter-cuda = { version = "0.7" }
+streamlib = { version = "0.7.6" }
+streamlib-adapter-abi = { version = "0.7.6" }
+streamlib-adapter-cuda = { version = "0.7.6" }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 serde_json = "1.0"
 

--- a/examples/jpeg-psnr/Cargo.toml
+++ b/examples/jpeg-psnr/Cargo.toml
@@ -18,7 +18,7 @@ publish = false
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 serde_json = "1"
 anyhow = "1.0.100"
 

--- a/examples/microphone-reverb-speaker/Cargo.toml
+++ b/examples/microphone-reverb-speaker/Cargo.toml
@@ -23,6 +23,6 @@ publish = false
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 
 [workspace]

--- a/examples/moq-roundtrip/Cargo.toml
+++ b/examples/moq-roundtrip/Cargo.toml
@@ -18,7 +18,7 @@ publish = false
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 serde_json = "1"
 tokio = { version = "1.48.0", features = ["full"] }
 tracing = "0.1.41"

--- a/examples/polyglot-continuous-processor/Cargo.toml
+++ b/examples/polyglot-continuous-processor/Cargo.toml
@@ -18,7 +18,7 @@ publish = false
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 serde_json = "1.0"
 
 [workspace]

--- a/examples/polyglot-cpu-readback-blur/Cargo.toml
+++ b/examples/polyglot-cpu-readback-blur/Cargo.toml
@@ -11,9 +11,9 @@ publish = false
 # crates.io yet, so `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point them at the in-repo SDK for local development.
 [dependencies]
-streamlib = { version = "0.7" }
-streamlib-adapter-abi = { version = "0.7" }
-streamlib-adapter-cpu-readback = { version = "0.7" }
+streamlib = { version = "0.7.6" }
+streamlib-adapter-abi = { version = "0.7.6" }
+streamlib-adapter-cpu-readback = { version = "0.7.6" }
 serde_json = "1.0"
 png = "0.17"
 

--- a/examples/polyglot-cuda-inference/Cargo.toml
+++ b/examples/polyglot-cuda-inference/Cargo.toml
@@ -11,9 +11,9 @@ publish = false
 # crates.io yet, so `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point them at the in-repo SDK for local development.
 [dependencies]
-streamlib = { version = "0.7" }
-streamlib-adapter-abi = { version = "0.7" }
-streamlib-adapter-cuda = { version = "0.7" }
+streamlib = { version = "0.7.6" }
+streamlib-adapter-abi = { version = "0.7.6" }
+streamlib-adapter-cuda = { version = "0.7.6" }
 serde_json = "1.0"
 
 [workspace]

--- a/examples/polyglot-dma-buf-consumer/Cargo.toml
+++ b/examples/polyglot-dma-buf-consumer/Cargo.toml
@@ -19,7 +19,7 @@ publish = false
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 serde_json = "1.0"
 
 [workspace]

--- a/examples/polyglot-manual-source/Cargo.toml
+++ b/examples/polyglot-manual-source/Cargo.toml
@@ -32,12 +32,12 @@ license = "BUSL-1.1"
 
 [workspace.dependencies]
 # Engine facade — used ONLY by the runner (the host app), never the plugin.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 # Engine-free authoring SDK chain — used by the plugin cdylib.
-streamlib-plugin-sdk = { version = "0.7" }
-streamlib-macros = { version = "0.7" }
-streamlib-jtd-codegen = { version = "0.7" }
-streamlib-plugin-abi = { version = "0.7" }
+streamlib-plugin-sdk = { version = "0.7.6" }
+streamlib-macros = { version = "0.7.6" }
+streamlib-jtd-codegen = { version = "0.7.6" }
+streamlib-plugin-abi = { version = "0.7.6" }
 tracing = { version = "0.1.41", features = ["release_max_level_debug"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/examples/polyglot-opengl-fragment-shader/Cargo.toml
+++ b/examples/polyglot-opengl-fragment-shader/Cargo.toml
@@ -11,12 +11,12 @@ publish = false
 # crates.io yet, so `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point them at the in-repo SDK for local development.
 [dependencies]
-streamlib = { version = "0.7" }
-streamlib-adapter-abi = { version = "0.7" }
+streamlib = { version = "0.7.6" }
+streamlib-adapter-abi = { version = "0.7.6" }
 serde_json = "1.0"
 png = "0.17"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-adapter-opengl = { version = "0.7" }
+streamlib-adapter-opengl = { version = "0.7.6" }
 
 [workspace]

--- a/examples/polyglot-skia-canvas/Cargo.toml
+++ b/examples/polyglot-skia-canvas/Cargo.toml
@@ -11,12 +11,12 @@ publish = false
 # crates.io yet, so `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point them at the in-repo SDK for local development.
 [dependencies]
-streamlib = { version = "0.7" }
-streamlib-adapter-abi = { version = "0.7" }
+streamlib = { version = "0.7.6" }
+streamlib-adapter-abi = { version = "0.7.6" }
 serde_json = "1.0"
 png = "0.17"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-adapter-vulkan = { version = "0.7" }
+streamlib-adapter-vulkan = { version = "0.7.6" }
 
 [workspace]

--- a/examples/polyglot-venv-isolation/Cargo.toml
+++ b/examples/polyglot-venv-isolation/Cargo.toml
@@ -18,7 +18,7 @@ publish = false
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 serde_json = "1.0"
 
 [workspace]

--- a/examples/polyglot-vulkan-compute/Cargo.toml
+++ b/examples/polyglot-vulkan-compute/Cargo.toml
@@ -12,14 +12,14 @@ build = "build.rs"
 # crates.io yet, so `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point them at the in-repo SDK for local development.
 [dependencies]
-streamlib = { version = "0.7" }
-streamlib-adapter-abi = { version = "0.7" }
+streamlib = { version = "0.7.6" }
+streamlib-adapter-abi = { version = "0.7.6" }
 serde_json = "1.0"
 png = "0.17"
 parking_lot = "0.12"
 sha2 = { version = "0.10", features = ["std"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-adapter-vulkan = { version = "0.7" }
+streamlib-adapter-vulkan = { version = "0.7.6" }
 
 [workspace]

--- a/examples/polyglot-vulkan-graphics/Cargo.toml
+++ b/examples/polyglot-vulkan-graphics/Cargo.toml
@@ -12,13 +12,13 @@ build = "build.rs"
 # crates.io yet, so `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point them at the in-repo SDK for local development.
 [dependencies]
-streamlib = { version = "0.7" }
-streamlib-adapter-abi = { version = "0.7" }
+streamlib = { version = "0.7.6" }
+streamlib-adapter-abi = { version = "0.7.6" }
 serde_json = "1.0"
 png = "0.17"
 parking_lot = "0.12"
 sha2 = { version = "0.10", features = ["std"] }
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-adapter-vulkan = { version = "0.7" }
+streamlib-adapter-vulkan = { version = "0.7.6" }
 
 [workspace]

--- a/examples/polyglot-vulkan-ray-tracing/Cargo.toml
+++ b/examples/polyglot-vulkan-ray-tracing/Cargo.toml
@@ -12,13 +12,13 @@ build = "build.rs"
 # crates.io yet, so `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point them at the in-repo SDK for local development.
 [dependencies]
-streamlib = { version = "0.7" }
-streamlib-adapter-abi = { version = "0.7" }
+streamlib = { version = "0.7.6" }
+streamlib-adapter-abi = { version = "0.7.6" }
 serde_json = "1.0"
 png = "0.17"
 parking_lot = "0.12"
 sha2 = { version = "0.10", features = ["std"] }
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-adapter-vulkan = { version = "0.7" }
+streamlib-adapter-vulkan = { version = "0.7.6" }
 
 [workspace]

--- a/examples/raytracing-showcase/Cargo.toml
+++ b/examples/raytracing-showcase/Cargo.toml
@@ -17,7 +17,7 @@ publish = false
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 anyhow = "1.0.100"
 
 [workspace]

--- a/examples/runtime-graph-json-demo/Cargo.toml
+++ b/examples/runtime-graph-json-demo/Cargo.toml
@@ -18,7 +18,7 @@ publish = false
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 serde_json = "1.0"
 
 [workspace]

--- a/examples/screen-recorder/Cargo.toml
+++ b/examples/screen-recorder/Cargo.toml
@@ -23,6 +23,6 @@ publish = false
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 
 [workspace]

--- a/examples/tokio-integration/Cargo.toml
+++ b/examples/tokio-integration/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 tokio = { version = "1", features = ["full"] }
 
 [workspace]

--- a/examples/vulkan-video-psnr/Cargo.toml
+++ b/examples/vulkan-video-psnr/Cargo.toml
@@ -18,7 +18,7 @@ publish = false
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 serde_json = "1"
 anyhow = "1.0.100"
 

--- a/examples/vulkan-video-roundtrip-cdylib-camera/Cargo.toml
+++ b/examples/vulkan-video-roundtrip-cdylib-camera/Cargo.toml
@@ -22,7 +22,7 @@ publish = false
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 serde_json = "1"
 
 [workspace]

--- a/examples/vulkan-video-roundtrip/Cargo.toml
+++ b/examples/vulkan-video-roundtrip/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 [dependencies]
 # SDK by version; not published to crates.io yet, so `./setup.sh` runs
 # `streamlib link --engine <checkout>` to point it at the in-repo SDK.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 serde_json = "1"
 anyhow = "1.0.100"
 

--- a/examples/webrtc-cloudflare-stream/Cargo.toml
+++ b/examples/webrtc-cloudflare-stream/Cargo.toml
@@ -20,14 +20,14 @@ publish = false
 [build-dependencies]
 # The SDK codegen crate is resolved by version (same link-by-checkout dev loop
 # as the `streamlib` dep below).
-streamlib-jtd-codegen = { version = "0.7" }
+streamlib-jtd-codegen = { version = "0.7.6" }
 
 [dependencies]
 # The SDK is resolved by version. It is not published to crates.io yet, so for
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 tokio = { version = "1.48.0", features = ["full"] }
 anyhow = "1.0.100"
 libc = "0.2"

--- a/examples/whep-player/Cargo.toml
+++ b/examples/whep-player/Cargo.toml
@@ -23,6 +23,6 @@ publish = false
 # local development `./setup.sh` runs `streamlib link --engine <checkout>` to
 # point this dep at the in-repo SDK. Once the SDK publishes, the bare version
 # resolves with no link step.
-streamlib = { version = "0.7" }
+streamlib = { version = "0.7.6" }
 
 [workspace]

--- a/packages/api-server/Cargo.toml
+++ b/packages/api-server/Cargo.toml
@@ -31,12 +31,12 @@ moq = ["dep:streamlib-moq"]
 # Host-side member: the zone crates resolve by path (this package is never
 # published, so there is no registry closure to satisfy by version).
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0.7.0" }
+streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0.7.6" }
 
 [dependencies]
-streamlib = { path = "../../sdk/streamlib-sdk", version = "0.7.0" }
-streamlib-macros = { path = "../../sdk/streamlib-macros", version = "0.7.0" }
-streamlib-moq = { path = "../../runtime/streamlib-moq", version = "0.7.0", optional = true }
+streamlib = { path = "../../sdk/streamlib-sdk", version = "0.7.6" }
+streamlib-macros = { path = "../../sdk/streamlib-macros", version = "0.7.6" }
+streamlib-moq = { path = "../../runtime/streamlib-moq", version = "0.7.6", optional = true }
 
 tower-http = { version = "0.6", features = ["trace"] }
 futures-util = "0.3"

--- a/packages/audio/Cargo.toml
+++ b/packages/audio/Cargo.toml
@@ -14,21 +14,21 @@ name = "streamlib_audio"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = {version = "0.7.0"}
+streamlib-jtd-codegen = {version = "0.7.6"}
 
 [dependencies]
 # Engine-free authoring SDK (never the `streamlib` facade) — runtime context, processor traits, generated config
 # types under `crate::_generated_::tatolab__audio::*`, AudioFrame
 # wire type, audio utilities (resample, channel/format conversion).
-streamlib-plugin-sdk = {version = "0.7.0"}
+streamlib-plugin-sdk = {version = "0.7.6"}
 
 # Procedural macros — `#[streamlib_plugin_sdk::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = {version = "0.7.0"}
+streamlib-macros = {version = "0.7.6"}
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = {version = "0.7.0"}
+streamlib-plugin-abi = {version = "0.7.6"}
 
 # Cross-platform deps used by every audio processor.
 parking_lot = "0.12"

--- a/packages/camera/Cargo.toml
+++ b/packages/camera/Cargo.toml
@@ -14,7 +14,7 @@ name = "streamlib_camera"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = {version = "0.7.0"}
+streamlib-jtd-codegen = {version = "0.7.6"}
 
 [dependencies]
 # Engine-free authoring SDK (never the `streamlib` facade) — capability-typed
@@ -24,15 +24,15 @@ streamlib-jtd-codegen = {version = "0.7.0"}
 # `VulkanLayout` / `PixelFormat` / `TextureFormat` primitives, generated config
 # types under `crate::_generated_::*`, and the `VideoFrame` wire type. Every GPU
 # resource comes through `GpuContextFullAccess`, never the raw host device.
-streamlib-plugin-sdk = {version = "0.7.0"}
+streamlib-plugin-sdk = {version = "0.7.6"}
 
 # Procedural macros — `#[streamlib_plugin_sdk::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = {version = "0.7.0"}
+streamlib-macros = {version = "0.7.6"}
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = {version = "0.7.0"}
+streamlib-plugin-abi = {version = "0.7.6"}
 
 tracing = {version = "0.1.41", features = ["release_max_level_debug"]}
 

--- a/packages/clap/Cargo.toml
+++ b/packages/clap/Cargo.toml
@@ -14,12 +14,12 @@ name = "streamlib_clap"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = {version = "0.7.0"}
+streamlib-jtd-codegen = {version = "0.7.6"}
 
 [dependencies]
 # Engine-free authoring SDK (never the `streamlib` facade) — runtime context, processor traits, generated wire
 # types under `crate::_generated_::*` (AudioFrame).
-streamlib-plugin-sdk = {version = "0.7.0"}
+streamlib-plugin-sdk = {version = "0.7.6"}
 
 # Audio domain package — owns `ProcessorAudioConverter` + `AudioResampler`
 # (carved out of the engine in #734). Consumers that need channel /
@@ -28,11 +28,11 @@ streamlib-audio = {version = "0.7.0"}
 
 # Procedural macros — `#[streamlib_plugin_sdk::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = {version = "0.7.0"}
+streamlib-macros = {version = "0.7.6"}
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = {version = "0.7.0"}
+streamlib-plugin-abi = {version = "0.7.6"}
 
 # Serialization (config dataclasses ship as serde-derived).
 

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -13,7 +13,7 @@ name = "streamlib_core_schema_tests"
 path = "src/lib.rs"
 
 [build-dependencies]
-streamlib-jtd-codegen = { version = "0.7.0" }
+streamlib-jtd-codegen = { version = "0.7.6" }
 
 [dependencies]
 serde.workspace = true

--- a/packages/debug-utilities/Cargo.toml
+++ b/packages/debug-utilities/Cargo.toml
@@ -14,21 +14,21 @@ name = "streamlib_debug_utilities"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = {version = "0.7.0"}
+streamlib-jtd-codegen = {version = "0.7.6"}
 
 [dependencies]
 # Engine-free authoring SDK (never the `streamlib` facade) — runtime context, processor traits, generated config
 # types under `crate::_generated_::tatolab__debug_utilities::*`, the
 # VideoFrame wire type, RHI primitives.
-streamlib-plugin-sdk = {version = "0.7.0"}
+streamlib-plugin-sdk = {version = "0.7.6"}
 
 # Procedural macros — `#[streamlib_plugin_sdk::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = {version = "0.7.0"}
+streamlib-macros = {version = "0.7.6"}
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = {version = "0.7.0"}
+streamlib-plugin-abi = {version = "0.7.6"}
 
 # Serialization (config dataclasses ship as serde-derived).
 # Generated `EncodedJpegFrame.data` rides msgpack `bin` (1× wire) instead of array.

--- a/packages/display/Cargo.toml
+++ b/packages/display/Cargo.toml
@@ -14,7 +14,7 @@ name = "streamlib_display"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = {version = "0.7.0"}
+streamlib-jtd-codegen = {version = "0.7.6"}
 
 [dependencies]
 # Engine-free authoring SDK (never the `streamlib` facade) — capability-typed
@@ -25,15 +25,15 @@ streamlib-jtd-codegen = {version = "0.7.0"}
 # resource creation goes through `GpuContextLimitedAccess::escalate` +
 # `create_present_target` / `create_graphics_kernel` / `create_texture_readback`,
 # never the raw host device.
-streamlib-plugin-sdk = {version = "0.7.0"}
+streamlib-plugin-sdk = {version = "0.7.6"}
 
 # Procedural macros — `#[streamlib_plugin_sdk::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = {version = "0.7.0"}
+streamlib-macros = {version = "0.7.6"}
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = {version = "0.7.0"}
+streamlib-plugin-abi = {version = "0.7.6"}
 
 tracing = {version = "0.1.41", features = ["release_max_level_debug"]}
 serde = {version = "1.0", features = ["derive"]}

--- a/packages/frame-tap/Cargo.toml
+++ b/packages/frame-tap/Cargo.toml
@@ -14,7 +14,7 @@ name = "streamlib_frame_tap"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = {version = "0.7.0"}
+streamlib-jtd-codegen = {version = "0.7.6"}
 
 [dependencies]
 # Engine-free authoring SDK (never the `streamlib` facade) — capability-typed
@@ -22,15 +22,15 @@ streamlib-jtd-codegen = {version = "0.7.0"}
 # generated wire types under `crate::_generated_::*`, error/result types. GPU
 # resource creation goes through `GpuContextLimitedAccess::escalate` +
 # `create_texture_readback`, never the raw host device.
-streamlib-plugin-sdk = {version = "0.7.0"}
+streamlib-plugin-sdk = {version = "0.7.6"}
 
 # Procedural macros — `#[streamlib_plugin_sdk::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = {version = "0.7.0"}
+streamlib-macros = {version = "0.7.6"}
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = {version = "0.7.0"}
+streamlib-plugin-abi = {version = "0.7.6"}
 
 serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0", features = ["preserve_order"]}

--- a/packages/h264/Cargo.toml
+++ b/packages/h264/Cargo.toml
@@ -14,7 +14,7 @@ name = "streamlib_h264"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = {version = "0.7.0"}
+streamlib-jtd-codegen = {version = "0.7.6"}
 
 [dependencies]
 # Engine-free authoring SDK (never the `streamlib` facade) — capability-typed
@@ -23,16 +23,16 @@ streamlib-jtd-codegen = {version = "0.7.0"}
 # error/result types. Hardware encode/decode sessions are minted host-side
 # through `GpuContextFullAccess::create_encoder_session` /
 # `create_decoder_session`, never the raw host device.
-streamlib-plugin-sdk = {version = "0.7.0"}
+streamlib-plugin-sdk = {version = "0.7.6"}
 
 # Procedural macros — `#[streamlib_plugin_sdk::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = {version = "0.7.0"}
+streamlib-macros = {version = "0.7.6"}
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time; the `#[repr(C)]` video session descriptor /
 # packet / color-VUI reprs the codec fills for the session-mint slots.
-streamlib-plugin-abi = {version = "0.7.0"}
+streamlib-plugin-abi = {version = "0.7.6"}
 
 # Serialization (config dataclasses ship as serde-derived).
 # Generated `EncodedVideoFrame.data` carries `#[serde(with = "serde_bytes")]`

--- a/packages/h265/Cargo.toml
+++ b/packages/h265/Cargo.toml
@@ -14,7 +14,7 @@ name = "streamlib_h265"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = {version = "0.7.0"}
+streamlib-jtd-codegen = {version = "0.7.6"}
 
 [dependencies]
 # Engine-free authoring SDK (never the `streamlib` facade) — capability-typed
@@ -23,16 +23,16 @@ streamlib-jtd-codegen = {version = "0.7.0"}
 # error/result types. Hardware encode/decode sessions are minted host-side
 # through `GpuContextFullAccess::create_encoder_session` /
 # `create_decoder_session`, never the raw host device.
-streamlib-plugin-sdk = {version = "0.7.0"}
+streamlib-plugin-sdk = {version = "0.7.6"}
 
 # Procedural macros — `#[streamlib_plugin_sdk::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = {version = "0.7.0"}
+streamlib-macros = {version = "0.7.6"}
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time; the `#[repr(C)]` video session descriptor /
 # packet / color-VUI reprs the codec fills for the session-mint slots.
-streamlib-plugin-abi = {version = "0.7.0"}
+streamlib-plugin-abi = {version = "0.7.6"}
 
 # Serialization (config dataclasses ship as serde-derived).
 # Generated `EncodedVideoFrame.data` carries `#[serde(with = "serde_bytes")]`

--- a/packages/jpeg/Cargo.toml
+++ b/packages/jpeg/Cargo.toml
@@ -14,7 +14,7 @@ name = "streamlib_jpeg"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = {version = "0.7.0"}
+streamlib-jtd-codegen = {version = "0.7.6"}
 
 [dependencies]
 # Engine-free authoring SDK — runtime context views, processor traits,
@@ -22,15 +22,15 @@ streamlib-jtd-codegen = {version = "0.7.0"}
 # VideoFrame wire type, RHI texture / color primitives. Depending on the
 # plugin SDK by its real name (never the `streamlib` engine facade) keeps
 # this plugin cdylib from statically linking a second copy of the engine.
-streamlib-plugin-sdk = {version = "0.7.0"}
+streamlib-plugin-sdk = {version = "0.7.6"}
 
 # Procedural macros — `#[streamlib_plugin_sdk::sdk::processor("...")]`
 # reads the crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = {version = "0.7.0"}
+streamlib-macros = {version = "0.7.6"}
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = {version = "0.7.0"}
+streamlib-plugin-abi = {version = "0.7.6"}
 
 # Serialization (config dataclasses ship as serde-derived).
 # Generated `EncodedJpegFrame.data` carries `#[serde(with = "serde_bytes")]`
@@ -46,6 +46,6 @@ tracing = {version = "0.1.41", features = ["release_max_level_debug"]}
 # GPU JPEG decode primitive — fused Vulkan compute kernel behind
 # SimpleJpegDecoder. Owns its own texture ring. Engine-free;
 # the nvJPEG fast path was parked in the engine during the SDK extraction.
-vulkan-jpeg = {version = "0.6.0"}
+vulkan-jpeg = {version = "0.7.6"}
 
 [workspace]

--- a/packages/moq/Cargo.toml
+++ b/packages/moq/Cargo.toml
@@ -14,14 +14,14 @@ name = "streamlib_moq_processors"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = {version = "0.7.0"}
+streamlib-jtd-codegen = {version = "0.7.6"}
 
 [dependencies]
 # Transport library half of @tatolab/moq (publish/subscribe sessions + catalog).
-streamlib-moq = {version = "0.7.0"}
-streamlib-plugin-sdk = {version = "0.7.0"}
-streamlib-macros = {version = "0.7.0"}
-streamlib-plugin-abi = {version = "0.7.0"}
+streamlib-moq = {version = "0.7.6"}
+streamlib-plugin-sdk = {version = "0.7.6"}
+streamlib-macros = {version = "0.7.6"}
+streamlib-plugin-abi = {version = "0.7.6"}
 
 # Generated `EncodedVideoFrame.data` rides msgpack `bin` instead of array.
 serde = {version = "1.0", features = ["derive"]}

--- a/packages/mp4/Cargo.toml
+++ b/packages/mp4/Cargo.toml
@@ -14,15 +14,15 @@ name = "streamlib_mp4"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = {version = "0.7.0"}
+streamlib-jtd-codegen = {version = "0.7.6"}
 
 [dependencies]
 # Engine-free authoring SDK (never the `streamlib` facade) — runtime context
 # views, processor traits, generated wire types. Depending on the plugin SDK
 # by its real name keeps this cdylib from statically linking a second engine.
-streamlib-plugin-sdk = {version = "0.7.0"}
-streamlib-macros = {version = "0.7.0"}
-streamlib-plugin-abi = {version = "0.7.0"}
+streamlib-plugin-sdk = {version = "0.7.6"}
+streamlib-macros = {version = "0.7.6"}
+streamlib-plugin-abi = {version = "0.7.6"}
 
 serde = {version = "1.0", features = ["derive"]}
 tracing = {version = "0.1.41", features = ["release_max_level_debug"]}

--- a/packages/opus/Cargo.toml
+++ b/packages/opus/Cargo.toml
@@ -14,21 +14,21 @@ name = "streamlib_opus"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = {version = "0.7.0"}
+streamlib-jtd-codegen = {version = "0.7.6"}
 
 [dependencies]
 # Engine-free authoring SDK (never the `streamlib` facade) — runtime context, processor traits, generated wire
 # types under `crate::_generated_::*` (AudioFrame,
 # EncodedAudioFrame from `@tatolab/core`), error/result types.
-streamlib-plugin-sdk = {version = "0.7.0"}
+streamlib-plugin-sdk = {version = "0.7.6"}
 
 # Procedural macros — `#[streamlib_plugin_sdk::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = {version = "0.7.0"}
+streamlib-macros = {version = "0.7.6"}
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = {version = "0.7.0"}
+streamlib-plugin-abi = {version = "0.7.6"}
 
 # Serialization (config dataclasses ship as serde-derived).
 # Generated `EncodedAudioFrame.data` rides msgpack `bin` (1× wire) instead of array.

--- a/packages/screen-capture/Cargo.toml
+++ b/packages/screen-capture/Cargo.toml
@@ -14,22 +14,22 @@ name = "streamlib_screen_capture"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = {version = "0.7.0"}
+streamlib-jtd-codegen = {version = "0.7.6"}
 
 [dependencies]
 # Engine-free authoring SDK (never the `streamlib` facade) — runtime context
 # views, processor traits, generated wire types under `crate::_generated_::*`
 # (VideoFrame), RHI primitives. Depending on the plugin SDK by its real name
 # keeps this cdylib from statically linking a second engine.
-streamlib-plugin-sdk = {version = "0.7.0"}
+streamlib-plugin-sdk = {version = "0.7.6"}
 
 # Procedural macros — `#[streamlib_plugin_sdk::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = {version = "0.7.0"}
+streamlib-macros = {version = "0.7.6"}
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = {version = "0.7.0"}
+streamlib-plugin-abi = {version = "0.7.6"}
 
 # Serialization (config dataclasses ship as serde-derived).
 

--- a/packages/test-fixtures-abi-mismatch/Cargo.toml
+++ b/packages/test-fixtures-abi-mismatch/Cargo.toml
@@ -34,7 +34,7 @@ tamper-too-high = []
 tamper-abi-layout-fingerprint = []
 
 [dependencies]
-streamlib-plugin-abi = { path = "../../runtime/streamlib-plugin-abi", version = "0.7.0" }
+streamlib-plugin-abi = { path = "../../runtime/streamlib-plugin-abi", version = "0.7.6" }
 
 [lints]
 workspace = true

--- a/packages/test-fixtures/Cargo.toml
+++ b/packages/test-fixtures/Cargo.toml
@@ -17,20 +17,20 @@ name = "streamlib_test_fixtures"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0.7.0" }
+streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0.7.6" }
 
 [dependencies]
 # Engine substrate — runtime context, processor traits, generated config
 # types under `crate::_generated_::tatolab__test_fixtures::*`.
-streamlib = { path = "../../sdk/streamlib-sdk", version = "0.7.0" }
+streamlib = { path = "../../sdk/streamlib-sdk", version = "0.7.6" }
 
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = { path = "../../sdk/streamlib-macros", version = "0.7.0" }
+streamlib-macros = { path = "../../sdk/streamlib-macros", version = "0.7.6" }
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
 # runtime dlopens at load time.
-streamlib-plugin-abi = { path = "../../runtime/streamlib-plugin-abi", version = "0.7.0" }
+streamlib-plugin-abi = { path = "../../runtime/streamlib-plugin-abi", version = "0.7.6" }
 
 # Serialization (config dataclass ships as serde-derived).
 serde.workspace = true

--- a/packages/webrtc/Cargo.toml
+++ b/packages/webrtc/Cargo.toml
@@ -14,15 +14,15 @@ name = "streamlib_webrtc"
 crate-type = ["rlib", "cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = {version = "0.7.0"}
+streamlib-jtd-codegen = {version = "0.7.6"}
 
 [dependencies]
 # Engine-free authoring SDK (never the `streamlib` facade) — runtime context
 # views, processor traits, generated wire types. Depending on the plugin SDK
 # by its real name keeps this cdylib from statically linking a second engine.
-streamlib-plugin-sdk = {version = "0.7.0"}
-streamlib-macros = {version = "0.7.0"}
-streamlib-plugin-abi = {version = "0.7.0"}
+streamlib-plugin-sdk = {version = "0.7.6"}
+streamlib-macros = {version = "0.7.6"}
+streamlib-plugin-abi = {version = "0.7.6"}
 
 # Generated `EncodedVideoFrame.data` / `EncodedAudioFrame.data` ride msgpack
 # `bin` (1× wire) instead of array.

--- a/runtime/streamlib-consumer-rhi/Cargo.toml
+++ b/runtime/streamlib-consumer-rhi/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.7.0" }
+streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.7.6" }
 vulkanalia.workspace = true
 libc.workspace = true
 

--- a/runtime/streamlib-engine/Cargo.toml
+++ b/runtime/streamlib-engine/Cargo.toml
@@ -38,33 +38,33 @@ clear_bitstream_buffers_on_create = []
 
 [dependencies]
 # Processor schema types (shared with macros for code generation)
-streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.7.0", features = ["utoipa"] }
+streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.7.6", features = ["utoipa"] }
 
 # Canonical Error / Result / PortDirection, shared with the plugin-SDK so
 # plugin cdylibs author against them without linking the engine. The engine
 # re-exports them at `core::error`.
-streamlib-error = { path = "../../sdk/streamlib-error", version = "0.7.0" }
+streamlib-error = { path = "../../sdk/streamlib-error", version = "0.7.6" }
 
 # Schema identity + manifest types (one source of truth for the
 # structured `dependencies:` shape consumed at runtime).
-streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.7.0" }
+streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.7.6" }
 # Runtime-layer codegen: the engine regenerates the source-only Python SDK's
 # wire vocabulary (`streamlib/_generated_`) into each processor venv after
 # install. Same codegen the build script uses; needed at runtime here too.
-streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0.7.0" }
+streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0.7.6" }
 
 # Procedural macros
-streamlib-macros = { path = "../../sdk/streamlib-macros", version = "0.7.0" }
+streamlib-macros = { path = "../../sdk/streamlib-macros", version = "0.7.6" }
 
 # Plugin ABI wire-protocol header. Dep direction reversed in #877:
 # streamlib-plugin-abi no longer depends on streamlib (the SDK), so the
 # cyclic dep this dep used to dodge (engine → plugin-abi → sdk → engine)
 # is gone. The engine's dlopen loader uses `PluginDeclaration` and
 # `STREAMLIB_ABI_VERSION` from this crate directly.
-streamlib-plugin-abi = { path = "../streamlib-plugin-abi", version = "0.7.0" }
+streamlib-plugin-abi = { path = "../streamlib-plugin-abi", version = "0.7.6" }
 
 # Shared iceoryx2 payload types (for cross-process IPC)
-streamlib-ipc-types = { path = "../streamlib-ipc-types", version = "0.7.0" }
+streamlib-ipc-types = { path = "../streamlib-ipc-types", version = "0.7.6" }
 
 # Consumer-side carve-out — owns the format primitives
 # (TextureFormat / TextureUsages / PixelFormat), the trait machinery
@@ -72,7 +72,7 @@ streamlib-ipc-types = { path = "../streamlib-ipc-types", version = "0.7.0" }
 # Consumer* RHI types (Linux), and a slim ConsumerRhiError. streamlib
 # re-exports the primitives so existing in-tree call sites (e.g.
 # `crate::core::rhi::TextureFormat`) keep working unchanged.
-streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.7.0" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.7.6" }
 
 # Core dependencies (always included)
 thiserror.workspace = true
@@ -154,17 +154,17 @@ raw-window-handle = "0.6"  # Raw window handle types for Vulkan surface creation
 # privileged syscall on the requesting thread's behalf.
 zbus = "5"
 # Wire-format helpers for the per-runtime surface-sharing socket
-streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.7.0" }
+streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.7.6" }
 # Surface adapter ABI types referenced by the host-side CpuReadbackBridge
 # trait (linux-only; the cpu-readback adapter is linux-only).
-streamlib-adapter-abi = { path = "../../adapters/streamlib-adapter-abi", version = "0.7.0" }
+streamlib-adapter-abi = { path = "../../adapters/streamlib-adapter-abi", version = "0.7.6" }
 # Consumer-side carve-out — defines the trait machinery
 # (VulkanRhiDevice, DevicePrivilege, *Like, ConsumerMarker), the
 # Consumer* RHI types, and the format/error primitives shared with the
 # host side. streamlib re-exports for in-tree consumers; subprocess
 # cdylibs depend on it directly so the FullAccess capability boundary
 # is enforced by the type system.
-streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.7.0" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.7.6" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"
@@ -205,7 +205,7 @@ path = "tests/bin/surface_share_crash_helper.rs"
 required-features = []
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0.7.0" }
+streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0.7.6" }
 
 # Build dependencies for protobuf compilation (surface-share service gRPC)
 [target.'cfg(target_os = "macos")'.build-dependencies]

--- a/runtime/streamlib-moq/Cargo.toml
+++ b/runtime/streamlib-moq/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/lib.rs"
 # links this transport lib, so pulling the facade here would statically bundle
 # a second copy of streamlib-engine into the host process (the direct-dep grep
 # in check-boundaries does not see this transitive path).
-streamlib-error = { path = "../../sdk/streamlib-error", version = "0.7.0" }
-streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.7.0" }
+streamlib-error = { path = "../../sdk/streamlib-error", version = "0.7.6" }
+streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.7.6" }
 
 # MoQ-over-QUIC transport stack.
 moq-transport = "0.14.1"

--- a/runtime/streamlib-runtime/Cargo.toml
+++ b/runtime/streamlib-runtime/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 # Engine + SDK. Every processor EXCEPT the always-present control plane is
 # loaded at runtime through the all-dynamic module loader, not linked here.
-streamlib = { path = "../../sdk/streamlib-sdk", version = "0.7.0" }
+streamlib = { path = "../../sdk/streamlib-sdk", version = "0.7.6" }
 
 # The API server is the control plane — a host, not a loadable plugin — so
 # it is statically linked and registered in-process on `PROCESSOR_REGISTRY`

--- a/scripts/sync-inter-crate-versions.py
+++ b/scripts/sync-inter-crate-versions.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
 """Sync inter-crate dependency version requirements to the workspace version.
 
 The `simple` release-please release-type bumps `[workspace.package].version` in

--- a/scripts/sync-inter-crate-versions.py
+++ b/scripts/sync-inter-crate-versions.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Sync inter-crate dependency version requirements to the workspace version.
+
+The `simple` release-please release-type bumps `[workspace.package].version` in
+the root Cargo.toml but ships no cargo dependency-requirement updater. Every
+in-tree crate that depends on a sibling workspace-versioned crate pins it with a
+frozen `version = "X.Y.Z"` requirement (alongside a dev-loop `path`). Those
+requirements never move on their own: they stay caret-compatible within a
+0.7.x line but silently EXCLUDE the next breaking bump (e.g. 0.8.0), which would
+make the whole tree fail to resolve after a release.
+
+This script rewrites, in place, every dependency requirement that targets a
+workspace-versioned sibling crate (any crate whose own `[package]` uses
+`version.workspace = true` — the engine/SDK/adapter crates plus vulkan-jpeg) to
+the current `[workspace.package].version`. Independently-versioned domain
+packages under `packages/*` (which set an explicit `version = "1.0.x"`) are NOT
+workspace-versioned, so deps on them (e.g. streamlib-api-server, streamlib-audio)
+are left untouched — their requirements are managed with the package, not the
+workspace.
+
+The rewrite is idempotent: a no-op when everything is already in sync (exit 0,
+nothing written). Run from CI on the release-PR branch so the squash-merge folds
+it into the release commit, and as a one-time sweep by hand.
+
+Usage: sync-inter-crate-versions.py [REPO_ROOT]   (defaults to CWD)
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# `NAME = { ... }` inline-table dep, or `NAME = "req"` bare dep, at line start.
+DEP_LINE = re.compile(r'^(?P<name>[A-Za-z0-9_-]+)\s*=\s*(?P<rhs>.+)$')
+# `version = "req"` inside an inline table.
+INLINE_VERSION = re.compile(r'(version\s*=\s*")(?P<req>[^"]*)(")')
+# Whole-value bare string requirement: `= "0.7.0"`.
+BARE_VERSION = re.compile(r'^"(?P<req>[^"]*)"\s*$')
+
+
+def read_package_name_and_workspace_version(manifest_text: str) -> tuple[str | None, bool]:
+    """Return (package name, uses_version_workspace) for a manifest's own crate."""
+    in_package = False
+    name: str | None = None
+    version_is_workspace = False
+    for raw in manifest_text.splitlines():
+        line = raw.strip()
+        if line.startswith("["):
+            in_package = line == "[package]"
+            continue
+        if not in_package:
+            continue
+        if name is None:
+            m = re.match(r'name\s*=\s*"([^"]+)"', line)
+            if m:
+                name = m.group(1)
+        if re.match(r'version\s*\.\s*workspace\s*=\s*true', line) or re.match(
+            r'version\s*=\s*\{\s*workspace\s*=\s*true', line
+        ):
+            version_is_workspace = True
+    return name, version_is_workspace
+
+
+def read_workspace_version(root_manifest_text: str) -> str:
+    """Read `[workspace.package].version` from the root manifest."""
+    in_ws_package = False
+    for raw in root_manifest_text.splitlines():
+        line = raw.strip()
+        if line.startswith("["):
+            in_ws_package = line == "[workspace.package]"
+            continue
+        if in_ws_package:
+            m = re.match(r'version\s*=\s*"([^"]+)"', line)
+            if m:
+                return m.group(1)
+    raise SystemExit("error: [workspace.package].version not found in root Cargo.toml")
+
+
+def rewrite_manifest(text: str, ws_crates: set[str], ws_version: str) -> tuple[str, list[tuple[str, str]]]:
+    """Rewrite dep requirements on workspace-versioned crates. Returns (text, changes)."""
+    changes: list[tuple[str, str]] = []
+    out_lines: list[str] = []
+    for raw in text.splitlines():
+        m = DEP_LINE.match(raw)
+        if not m or m.group("name") not in ws_crates:
+            out_lines.append(raw)
+            continue
+        name = m.group("name")
+        rhs = m.group("rhs")
+        bare = BARE_VERSION.match(rhs)
+        if bare:
+            if bare.group("req") != ws_version:
+                changes.append((f"{name} (bare)", f'{bare.group("req")} -> {ws_version}'))
+                raw = raw[: m.start("rhs")] + f'"{ws_version}"'
+            out_lines.append(raw)
+            continue
+        vm = INLINE_VERSION.search(rhs)
+        if vm and vm.group("req") != ws_version:
+            changes.append((name, f'{vm.group("req")} -> {ws_version}'))
+            new_rhs = rhs[: vm.start()] + vm.group(1) + ws_version + vm.group(3) + rhs[vm.end():]
+            raw = raw[: m.start("rhs")] + new_rhs
+        out_lines.append(raw)
+    trailing_newline = "\n" if text.endswith("\n") else ""
+    return "\n".join(out_lines) + trailing_newline, changes
+
+
+def main() -> int:
+    root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path.cwd()
+    root_manifest = root / "Cargo.toml"
+    ws_version = read_workspace_version(root_manifest.read_text())
+
+    manifests = [
+        p
+        for p in root.rglob("Cargo.toml")
+        if "vendor" not in p.parts and "target" not in p.parts
+    ]
+
+    ws_crates: set[str] = set()
+    for manifest in manifests:
+        name, is_ws = read_package_name_and_workspace_version(manifest.read_text())
+        if name and is_ws:
+            ws_crates.add(name)
+
+    total_changes = 0
+    for manifest in sorted(manifests):
+        text = manifest.read_text()
+        new_text, changes = rewrite_manifest(text, ws_crates, ws_version)
+        if changes:
+            manifest.write_text(new_text)
+            rel = manifest.relative_to(root)
+            for dep, delta in changes:
+                print(f"{rel}: {dep}: {delta}")
+            total_changes += len(changes)
+
+    if total_changes == 0:
+        print(f"inter-crate versions already in sync at {ws_version}")
+    else:
+        print(f"synced {total_changes} inter-crate requirement(s) to {ws_version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/streamlib-deno-native/Cargo.toml
+++ b/sdk/streamlib-deno-native/Cargo.toml
@@ -14,7 +14,7 @@ description = "FFI cdylib for Deno subprocess processors to access iceoryx2 dire
 crate-type = ["cdylib"]
 
 [dependencies]
-streamlib-ipc-types = { path = "../../runtime/streamlib-ipc-types", version = "0.7.0" }
+streamlib-ipc-types = { path = "../../runtime/streamlib-ipc-types", version = "0.7.6" }
 iceoryx2 = "0.8.1"
 libc.workspace = true
 rmp-serde = "1.3"
@@ -31,32 +31,32 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.0" }
+streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.6" }
 # Subprocess-side OpenGl runtime (#530). Reuses the host adapter crate's
 # EglRuntime + OpenGlSurfaceAdapter so subprocess code never re-derives EGL
 # bring-up or DMA-BUF → GL_TEXTURE_2D import.
-streamlib-adapter-abi = { path = "../../adapters/streamlib-adapter-abi", version = "0.7.0" }
-streamlib-adapter-opengl = { path = "../../adapters/streamlib-adapter-opengl", version = "0.7.0" }
+streamlib-adapter-abi = { path = "../../adapters/streamlib-adapter-abi", version = "0.7.6" }
+streamlib-adapter-opengl = { path = "../../adapters/streamlib-adapter-opengl", version = "0.7.6" }
 # Subprocess-side Vulkan runtime (#531). Same shape as streamlib-python-native
 # — wraps the host `VulkanSurfaceAdapter` against a subprocess-local
 # `ConsumerVulkanDevice` so subprocess code never re-implements
 # layout-transition / timeline-wait / queue-mutex semantics.
-streamlib-adapter-vulkan = { path = "../../adapters/streamlib-adapter-vulkan", version = "0.7.0" }
+streamlib-adapter-vulkan = { path = "../../adapters/streamlib-adapter-vulkan", version = "0.7.6" }
 # Consumer-side RHI carve-out — see streamlib-python-native/Cargo.toml
 # for the type-system-boundary rationale.
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.0" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.6" }
 # Subprocess-side cpu-readback runtime (#562). Same shape as the python
 # native — adapter generic over device flavor, instantiated here
 # against ConsumerVulkanDevice. Per-acquire `vkCmdCopyImageToBuffer`
 # runs host-side, triggered via the `run_cpu_readback_copy` escalate
 # IPC; the consumer waits on the imported timeline through the carve-out.
-streamlib-adapter-cpu-readback = { path = "../../adapters/streamlib-adapter-cpu-readback", version = "0.7.0" }
+streamlib-adapter-cpu-readback = { path = "../../adapters/streamlib-adapter-cpu-readback", version = "0.7.6" }
 # Subprocess-side CUDA runtime (#590). Mirrors the Python sibling
 # (#589) — generic-over-device adapter, instantiated here against
 # `ConsumerVulkanDevice`, OPAQUE_FD VkBuffer + timeline imported into
 # CUDA via `cudaImportExternalMemory` / `cudaImportExternalSemaphore`,
 # DLPack capsule emitted across the FFI boundary.
-streamlib-adapter-cuda = { path = "../../adapters/streamlib-adapter-cuda", version = "0.7.0" }
+streamlib-adapter-cuda = { path = "../../adapters/streamlib-adapter-cuda", version = "0.7.6" }
 # CUDA bindings — see streamlib-python-native/Cargo.toml for the
 # `fallback-dynamic-loading` rationale. Same workspace pin so the two
 # cdylibs stay lockstep on CUDA ABI.

--- a/sdk/streamlib-error/Cargo.toml
+++ b/sdk/streamlib-error/Cargo.toml
@@ -17,10 +17,10 @@ path = "src/lib.rs"
 [dependencies]
 thiserror.workspace = true
 anyhow.workspace = true
-streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.7.0" }
+streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.7.6" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.0" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.6" }
 
 [lints]
 workspace = true

--- a/sdk/streamlib-jtd-codegen/Cargo.toml
+++ b/sdk/streamlib-jtd-codegen/Cargo.toml
@@ -22,7 +22,7 @@ serde_yaml = { workspace = true }
 
 # Resolver + manifest types (the codegen pipeline ingests resolved package
 # sets produced by the streamlib-yaml resolver — Decision 7 of milestone 10).
-streamlib-idents = { path = "../streamlib-idents", version = "0.7.0" }
+streamlib-idents = { path = "../streamlib-idents", version = "0.7.6" }
 
 # Logging — library crates emit through tracing per docs/logging.md;
 # binary callers (xtask, streamlib-cli) initialize a subscriber.

--- a/sdk/streamlib-macros/Cargo.toml
+++ b/sdk/streamlib-macros/Cargo.toml
@@ -23,14 +23,14 @@ serde = { workspace = true }
 serde_yaml = { workspace = true }
 
 # Execution types (shared with streamlib for code generation)
-streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.7.0" }
+streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.7.6" }
 # The `#[processor(...)]` attribute grammar — shared with the source-scan
 # extractor so both parse the attribute through one parser (#1411).
-streamlib-processor-extract = { path = "../streamlib-processor-extract", version = "0.7.0" }
+streamlib-processor-extract = { path = "../streamlib-processor-extract", version = "0.7.6" }
 # Manifest resolver — used to walk the enclosing manifest's `schemas:` map
 # and resolve bare-name `PortSchemaSpec::Named` references to fully-
 # qualified `SchemaIdent`s at proc-macro expansion time (#767).
-streamlib-idents = { path = "../streamlib-idents", version = "0.7.0" }
+streamlib-idents = { path = "../streamlib-idents", version = "0.7.6" }
 
 
 [dev-dependencies]

--- a/sdk/streamlib-plugin-sdk/Cargo.toml
+++ b/sdk/streamlib-plugin-sdk/Cargo.toml
@@ -16,20 +16,20 @@ path = "src/lib.rs"
 
 [dependencies]
 # Canonical Error / Result / PortDirection (engine-free).
-streamlib-error = { path = "../streamlib-error", version = "0.7.0" }
+streamlib-error = { path = "../streamlib-error", version = "0.7.6" }
 # Schema identity, descriptor types, execution config — engine-free shared
 # data the macro emits against and the views/traits return.
-streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.7.0" }
+streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.7.6" }
 # Plugin ABI vtables + HostServices + export_plugin! (zero-dep, engine-free).
-streamlib-plugin-abi = { path = "../../runtime/streamlib-plugin-abi", version = "0.7.0" }
+streamlib-plugin-abi = { path = "../../runtime/streamlib-plugin-abi", version = "0.7.6" }
 # Procedural macros (#[processor], schema_ident!, module_ident!, ...). Re-exported
 # under sdk::* so plugins author against this crate by its real name.
-streamlib-macros = { path = "../streamlib-macros", version = "0.7.0" }
+streamlib-macros = { path = "../streamlib-macros", version = "0.7.6" }
 # Engine-free panic-safety helper (run_host_extern_c) shared by the engine
 # and the five surface adapters; the SDK's processor_vtable thunks route
 # every extern "C" boundary crossing through it. Deps: bitflags / parking_lot
 # / thiserror / tracing / libc — no engine.
-streamlib-adapter-abi = { path = "../../adapters/streamlib-adapter-abi", version = "0.7.0" }
+streamlib-adapter-abi = { path = "../../adapters/streamlib-adapter-abi", version = "0.7.6" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -50,7 +50,7 @@ iceoryx2-log = "0.8.1"
 # Consumer-side RHI carve-out: TextureFormat / TextureUsages / PixelFormat /
 # VulkanLayout the views surface. Engine-free (the python/deno cdylibs already
 # depend on it instead of the engine).
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.0" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.6" }
 
 [features]
 # Marker feature gating the `escalate` happy-path round-trip test, which needs

--- a/sdk/streamlib-processor-extract/Cargo.toml
+++ b/sdk/streamlib-processor-extract/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 proc-macro2 = "1.0"
 
-streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.7.0" }
+streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.7.6" }
 
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/sdk/streamlib-processor-schema/Cargo.toml
+++ b/sdk/streamlib-processor-schema/Cargo.toml
@@ -15,7 +15,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }  # used by schemars for enum_values literals
 serde_yaml = { workspace = true }
 sha2 = { workspace = true }
-streamlib-idents = { path = "../streamlib-idents", version = "0.7.0" }
+streamlib-idents = { path = "../streamlib-idents", version = "0.7.6" }
 thiserror = { workspace = true }
 schemars = "0.8"  # JSON Schema generation for streamlib.yaml editor support
 # Host-only OpenAPI schema derive for the wire-output DTOs, behind the

--- a/sdk/streamlib-python-native/Cargo.toml
+++ b/sdk/streamlib-python-native/Cargo.toml
@@ -15,7 +15,7 @@ name = "streamlib_python_native"
 crate-type = ["cdylib"]
 
 [dependencies]
-streamlib-ipc-types = { path = "../../runtime/streamlib-ipc-types", version = "0.7.0" }
+streamlib-ipc-types = { path = "../../runtime/streamlib-ipc-types", version = "0.7.6" }
 iceoryx2 = "0.8.1"
 libc.workspace = true
 rmp-serde = "1.3"
@@ -32,12 +32,12 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.0" }
+streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.7.6" }
 # Subprocess-side OpenGl runtime (#530). Reuses the host adapter crate's
 # EglRuntime + OpenGlSurfaceAdapter so subprocess code never re-derives EGL
 # bring-up or DMA-BUF → GL_TEXTURE_2D import.
-streamlib-adapter-abi = { path = "../../adapters/streamlib-adapter-abi", version = "0.7.0" }
-streamlib-adapter-opengl = { path = "../../adapters/streamlib-adapter-opengl", version = "0.7.0" }
+streamlib-adapter-abi = { path = "../../adapters/streamlib-adapter-abi", version = "0.7.6" }
+streamlib-adapter-opengl = { path = "../../adapters/streamlib-adapter-opengl", version = "0.7.6" }
 # Subprocess-side Vulkan runtime (#531). Reuses the host adapter crate's
 # `VulkanSurfaceAdapter` against a subprocess-local `ConsumerVulkanDevice`
 # from the consumer RHI carve-out: same timeline-wait, same layout-transition,
@@ -45,13 +45,13 @@ streamlib-adapter-opengl = { path = "../../adapters/streamlib-adapter-opengl", v
 # not apply because this VkDevice is created before any other in-process
 # Vulkan device has active GPU work — see
 # `docs/learnings/nvidia-dual-vulkan-device-crash.md`.
-streamlib-adapter-vulkan = { path = "../../adapters/streamlib-adapter-vulkan", version = "0.7.0" }
+streamlib-adapter-vulkan = { path = "../../adapters/streamlib-adapter-vulkan", version = "0.7.6" }
 # Consumer-side RHI carve-out — `ConsumerVulkanDevice`,
 # `ConsumerVulkanTexture`, the `VulkanRhiDevice` trait, etc. The cdylib
 # does NOT depend on `streamlib` (full crate); the FullAccess capability
 # boundary is type-system enforced by what `streamlib-consumer-rhi`
 # exposes vs. what it doesn't.
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.0" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.7.6" }
 # Subprocess-side cpu-readback runtime (#562). Same shape as
 # adapter-vulkan / adapter-opengl: the adapter is generic over device
 # flavor, and this cdylib instantiates it against the consumer-side
@@ -59,7 +59,7 @@ streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", versio
 # Per-acquire `vkCmdCopyImageToBuffer` runs host-side and is triggered
 # via a thin `run_cpu_readback_copy` escalate IPC; the consumer waits
 # on the imported timeline through the carve-out.
-streamlib-adapter-cpu-readback = { path = "../../adapters/streamlib-adapter-cpu-readback", version = "0.7.0" }
+streamlib-adapter-cpu-readback = { path = "../../adapters/streamlib-adapter-cpu-readback", version = "0.7.6" }
 # Subprocess-side CUDA runtime (#589). Same single-pattern shape as the
 # other adapters: generic over `D: VulkanRhiDevice`, instantiated here
 # against `ConsumerVulkanDevice`. The cdylib re-imports the OPAQUE_FD
@@ -67,7 +67,7 @@ streamlib-adapter-cpu-readback = { path = "../../adapters/streamlib-adapter-cpu-
 # `cudaImportExternalSemaphore` and hands DLPack capsules back to
 # Python. No per-acquire IPC; the host's pipeline writes into the
 # OPAQUE_FD `VkBuffer` and signals the shared timeline ambiently.
-streamlib-adapter-cuda = { path = "../../adapters/streamlib-adapter-cuda", version = "0.7.0" }
+streamlib-adapter-cuda = { path = "../../adapters/streamlib-adapter-cuda", version = "0.7.6" }
 # CUDA bindings. Linux-only (the cuda module is `#[cfg(target_os =
 # "linux")]`), `fallback-dynamic-loading` means libcuda.so is dlopen'd
 # at runtime so a build host without a CUDA toolkit can still link the

--- a/sdk/streamlib-sdk/Cargo.toml
+++ b/sdk/streamlib-sdk/Cargo.toml
@@ -34,5 +34,5 @@ strip_debug_logging = ["streamlib-engine/strip_debug_logging"]
 hardware-tests = ["streamlib-engine/hardware-tests"]
 
 [dependencies]
-streamlib-engine = { path = "../../runtime/streamlib-engine", version = "0.7.0" }
-streamlib-build-orchestrator = { path = "../../tools/streamlib-build-orchestrator", version = "0.7.0", optional = true }
+streamlib-engine = { path = "../../runtime/streamlib-engine", version = "0.7.6" }
+streamlib-build-orchestrator = { path = "../../tools/streamlib-build-orchestrator", version = "0.7.6", optional = true }

--- a/sdk/vulkan-jpeg/Cargo.toml
+++ b/sdk/vulkan-jpeg/Cargo.toml
@@ -19,7 +19,7 @@ bytemuck = { version = "1.16", features = ["derive"] }
 # types, and the GpuContext{Full,Limited}Access views) under
 # `streamlib_plugin_sdk::sdk::*`. Depending on the SDK by its real name keeps
 # this crate engine-free, so it is safe to compile into a `.slpkg` cdylib.
-streamlib-plugin-sdk = { path = "../streamlib-plugin-sdk", version = "0.7.0" }
+streamlib-plugin-sdk = { path = "../streamlib-plugin-sdk", version = "0.7.6" }
 
 [dev-dependencies]
 jpeg-encoder = "0.6"

--- a/tools/streamlib-build-orchestrator/Cargo.toml
+++ b/tools/streamlib-build-orchestrator/Cargo.toml
@@ -17,12 +17,12 @@ thiserror = { workspace = true }
 serde_json = { workspace = true }
 toml_edit = { workspace = true }
 ureq = { workspace = true }
-streamlib-engine = { path = "../../runtime/streamlib-engine", version = "0.7.0" }
-streamlib-cargo-build = { path = "../streamlib-cargo-build", version = "0.7.0" }
-streamlib-pack = { path = "../streamlib-pack", version = "0.7.0" }
-streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.7.0" }
-streamlib-plugin-abi = { path = "../../runtime/streamlib-plugin-abi", version = "0.7.0" }
-streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0.7.0" }
+streamlib-engine = { path = "../../runtime/streamlib-engine", version = "0.7.6" }
+streamlib-cargo-build = { path = "../streamlib-cargo-build", version = "0.7.6" }
+streamlib-pack = { path = "../streamlib-pack", version = "0.7.6" }
+streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.7.6" }
+streamlib-plugin-abi = { path = "../../runtime/streamlib-plugin-abi", version = "0.7.6" }
+streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0.7.6" }
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/tools/streamlib-cargo-build/Cargo.toml
+++ b/tools/streamlib-cargo-build/Cargo.toml
@@ -17,8 +17,8 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
-streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.7.0" }
-streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.7.0" }
+streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.7.6" }
+streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.7.6" }
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/tools/streamlib-cli/Cargo.toml
+++ b/tools/streamlib-cli/Cargo.toml
@@ -16,23 +16,23 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library (bundles all Rust processors)
-streamlib = { path = "../../sdk/streamlib-sdk", version = "0.7.0" }
+streamlib = { path = "../../sdk/streamlib-sdk", version = "0.7.6" }
 
 # Schema types (processor YAML parsing)
-streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.7.0" }
+streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.7.6" }
 
 # Manifest + workspace + dependency-spec types for `streamlib pack` /
 # `streamlib add` / `streamlib remove` — typed PackageRef, Manifest schema, etc.
-streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.7.0" }
+streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.7.6" }
 
 # Cargo-build orchestration helpers — `streamlib pack`'s auto-build branch
 # routes through this crate so the same logic is reused by
 # `streamlib-build-orchestrator` without dragging in the full CLI surface.
-streamlib-cargo-build = { path = "../streamlib-cargo-build", version = "0.7.0" }
-streamlib-pack = { path = "../streamlib-pack", version = "0.7.0" }
+streamlib-cargo-build = { path = "../streamlib-cargo-build", version = "0.7.6" }
+streamlib-pack = { path = "../streamlib-pack", version = "0.7.6" }
 
 # JTD-codegen pipeline (drives `streamlib generate`)
-streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0.7.0" }
+streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0.7.6" }
 
 # CLI framework
 clap = { version = "4.5", features = ["derive"] }

--- a/tools/streamlib-cross-rustc-fixture/Cargo.toml
+++ b/tools/streamlib-cross-rustc-fixture/Cargo.toml
@@ -33,7 +33,7 @@ name = "streamlib_cross_rustc_fixture"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0.7.0" }
+streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0.7.6" }
 
 [dependencies]
 # Engine substrate — runtime context, processor traits,
@@ -41,14 +41,14 @@ streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0
 # the fixture
 # rebuilds the SDK against THIS workspace's resolver pass, not the
 # host workspace's. Same source, different transitive resolution.
-streamlib = { path = "../../sdk/streamlib-sdk", version = "0.7.0" }
+streamlib = { path = "../../sdk/streamlib-sdk", version = "0.7.6" }
 
 # Procedural macros — `#[streamlib::sdk::processor("...")]`.
-streamlib-macros = { path = "../../sdk/streamlib-macros", version = "0.7.0" }
+streamlib-macros = { path = "../../sdk/streamlib-macros", version = "0.7.6" }
 
 # Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol
 # the runtime dlopens at load time.
-streamlib-plugin-abi = { path = "../../runtime/streamlib-plugin-abi", version = "0.7.0" }
+streamlib-plugin-abi = { path = "../../runtime/streamlib-plugin-abi", version = "0.7.6" }
 
 # Serialization for the config dataclass + diagnostic tracing. Pinned
 # to specific OLDER patches than what the host workspace resolves

--- a/tools/streamlib-pack/Cargo.toml
+++ b/tools/streamlib-pack/Cargo.toml
@@ -21,9 +21,9 @@ toml = { workspace = true }
 toml_edit = { workspace = true }
 tempfile = { workspace = true }
 zip = "2.2"
-streamlib-cargo-build = { path = "../streamlib-cargo-build", version = "0.7.0" }
-streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.7.0" }
-streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.7.0" }
+streamlib-cargo-build = { path = "../streamlib-cargo-build", version = "0.7.6" }
+streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.7.6" }
+streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.7.6" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Gapless atomic directory swap (renameat2 RENAME_EXCHANGE) for the static


### PR DESCRIPTION
Owner-directed (both options from the version-number discussion): a one-time sweep of stale inter-crate version requirements **and** a release-automation step so they stay in sync going forward.

## The problem
Each crate pins its sibling `streamlib-*` crates with a version requirement that was frozen at `0.7.0` (`streamlib-error = { path = "...", version = "0.7.0" }`). Within `0.7.x` these caret requirements are harmless (they accept `0.7.3`), but our release-type is `simple`, which has **no cargo dep-requirement updater** — so they never advance and would *exclude* the next breaking bump (`0.8.0`). One was already genuinely broken: `packages/jpeg`'s `vulkan-jpeg = "0.6.0"` excludes the `0.7.x` it now needs.

## What this does
1. **One-time sweep** — rewrites every inter-crate requirement targeting a **workspace-versioned** sibling crate to the current `0.7.3`: **76 Cargo.toml files, 242 requirement rewrites** (`0.7.0`→`0.7.3` ×174, short-form `0.7`→`0.7.3` ×67, and the jpeg `0.6.0`→`0.7.3` fix). Only version strings changed (`path`/`optional`/`features` preserved). Independently-versioned `packages/*` domain crates (`1.0.x`) are deliberately left alone.
2. **jpeg fix** — `vulkan-jpeg` `0.6.0` → `0.7.3` (it's a workspace crate at `0.7.3`); verified jpeg now resolves under `streamlib link` (`unpatched=0`).
3. **Auto-bump on release** — `scripts/sync-inter-crate-versions.py` (idempotent, self-discovers the workspace-versioned crate set from `version.workspace = true`, TOML-safe line rewrites) + a step in `.github/workflows/release-please.yml` that runs it on the release-PR branch (after `open`, before the `cargo update` lockfile-sync from #1435), so future releases keep these requirements current. No-ops when nothing is pending / already in sync.

## Verification
- `cargo update --workspace --offline` → 0 packages moved, `Cargo.lock` unchanged (path deps already resolved to `0.7.3`).
- `cargo metadata --locked` ✓ · `cargo check --workspace` ✓ (warnings only).
- `streamlib link --engine` on `packages/jpeg` and `packages/h264` → both `unpatched=0`.
- sync script idempotent; `release-please.yml` YAML valid.

## Out of scope — surfaced separately (needs an owner architecture call)
`packages/clap`'s `streamlib-audio` dependency is **not** a version-staleness — clap uses `ProcessorAudioConverter` from `streamlib-audio` as a real Rust type, but `streamlib-audio` is a non-workspace `packages/*` crate that `streamlib link` doesn't patch (the release closure covers only workspace-member `streamlib*` crates + `vulkan-jpeg`), so clap can't resolve it at *any* version. Left untouched here; the fix is an architecture decision (see the follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
