### PR TITLE
feat(cli): reachability-precursor extraction for #1411 manifest scan

### DIFF
--- a/docs/decisions/manifest-extraction-capability.md
+++ b/docs/decisions/manifest-extraction-capability.md
@@ -53,13 +53,20 @@ version at build time; that is a build-time projection, not a publish gate.
   identically after the move (its unit + integration tests are unchanged).
 - The scan is a lean text-in / manifest-out transform reusable by any build or
   submit path.
-- `extract_rust_processors` visits every `.rs` under `src/`, including platform
-  arms a given host does not compile (`linux/` vs `apple/`) and parked
-  directories (`_apple_impl_pending_/`). Two platform arms that both declare the
-  same processor both surface from one scan. Resolving the scan to the set
-  actually compiled for the build target — honoring `#[cfg]` and the parked-
-  directory convention — is required before extraction replaces the hand-
-  authored `processors:` as the authoritative truth-source, and before a drift
-  check between the two can be a hard `pkg build` error without false-positives
-  on cfg-gated packages. That module-reachability resolution builds on this scan
-  capability and its shared grammar.
+- `extract_rust_processors` is the RAW scan: it visits every `.rs` under `src/`,
+  including platform arms a given host does not compile (`linux/` vs `apple/`)
+  and parked directories (`_apple_impl_pending_/`), so two platform arms that
+  both declare the same processor both surface. `extract_reachable_rust_processors`
+  resolves that raw scan to the set the build **target** actually compiles: it
+  walks the module tree from the crate root (`lib.rs` / `main.rs`), follows each
+  `mod` the way `rustc` resolves module files (honoring `#[path]`), and evaluates
+  the `#[cfg(...)]` predicate on every `mod` and every `#[processor(...)]`-bearing
+  struct against a `ModuleReachabilityTarget` (the target's cfg atoms:
+  `target_os` / `target_arch` / `target_family` / features / family flags). The
+  parked-directory convention is not special-cased: a parked module is declared
+  `#[cfg(any())]`, an always-false predicate, so it is skipped by the same cfg
+  rule `rustc` applies — one rule, not a hard-coded directory name. This
+  reachability resolution is the precursor that makes extraction sound enough to
+  replace the hand-authored `processors:` as the authoritative truth-source, and
+  a drift check between the two a hard `pkg build` error without false positives
+  on cfg-gated packages.

--- a/schemas/streamlib.schema.json
+++ b/schemas/streamlib.schema.json
@@ -267,7 +267,7 @@
       "additionalProperties": false
     },
     "ProcessorSchema": {
-      "description": "A complete processor schema definition parsed from YAML.",
+      "description": "A complete processor schema definition — the manifest-shaped view of one processor, derived from its `#[processor(...)]` attribute (the source of truth) by the source-scan extractor.",
       "type": "object",
       "required": [
         "name",
@@ -320,7 +320,7 @@
           }
         },
         "name": {
-          "description": "Processor name in reverse domain notation (e.g., \"com.example.blur\").",
+          "description": "The `Type` segment of the processor's `@org/package/Type` identity — the PascalCase short name (e.g. \"Camera\"), NOT reverse-DNS.",
           "type": "string"
         },
         "outputs": {

--- a/sdk/streamlib-processor-extract/src/lib.rs
+++ b/sdk/streamlib-processor-extract/src/lib.rs
@@ -21,12 +21,14 @@
 //! scan produces.
 
 pub mod grammar;
+pub mod reachable;
 
 use std::path::{Path, PathBuf};
 
 use streamlib_processor_schema::ProcessorSchema;
 
 pub use grammar::{ParsedPort, ParsedProcessorAttr};
+pub use reachable::{ModuleReachabilityTarget, extract_reachable_rust_processors};
 
 /// One processor derived from a `#[processor(...)]` attribute in source.
 ///
@@ -87,6 +89,21 @@ pub enum ExtractError {
         path: PathBuf,
         struct_name: String,
         message: String,
+    },
+
+    /// A `mod <name>;` declaration reachable from the crate root resolved to no
+    /// file on disk (neither `<name>.rs` nor `<name>/mod.rs`, nor a `#[path]`
+    /// override). A compilable crate never hits this — the module-reachability
+    /// walk surfaces it rather than silently dropping a subtree that the build
+    /// target would have compiled.
+    #[error(
+        "`mod {module}` declared in {declared_in} resolves to no file \
+         (looked for {candidates})"
+    )]
+    UnresolvedModule {
+        module: String,
+        declared_in: PathBuf,
+        candidates: String,
     },
 }
 
@@ -195,7 +212,7 @@ fn walk_item(
 /// The `#[processor(...)]` attribute on an item, if present. Matches both the
 /// bare `#[processor(...)]` and the path-qualified `#[streamlib::processor(...)]`
 /// forms by their final path segment.
-fn processor_attr(attrs: &[syn::Attribute]) -> Option<&syn::Attribute> {
+pub(crate) fn processor_attr(attrs: &[syn::Attribute]) -> Option<&syn::Attribute> {
     attrs.iter().find(|attr| {
         attr.path()
             .segments
@@ -206,7 +223,7 @@ fn processor_attr(attrs: &[syn::Attribute]) -> Option<&syn::Attribute> {
 
 /// Parse a single `#[processor(...)]` attribute through the shared grammar and
 /// build the manifest-shaped [`ExtractedProcessor`].
-fn parse_processor_attr(
+pub(crate) fn parse_processor_attr(
     attr: &syn::Attribute,
     struct_ident: &syn::Ident,
     rel_path: &Path,

--- a/sdk/streamlib-processor-extract/src/reachable.rs
+++ b/sdk/streamlib-processor-extract/src/reachable.rs
@@ -1,0 +1,744 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Module-reachability resolution for the processor source-scan.
+//!
+//! [`crate::extract_rust_processors`] visits every `.rs` under `src/`, including
+//! platform arms a given host does not compile (`linux/` vs `apple/`) and parked
+//! directories (`_apple_impl_pending_/`). That raw scan over-collects: two
+//! platform arms declaring the same processor both surface, and a parked module
+//! surfaces a `#[processor(...)]` that never compiles on any target. Before
+//! extraction can replace the hand-authored `processors:` as the authoritative
+//! truth-source — and before a drift check between the two can be a hard
+//! `pkg build` error without false positives on cfg-gated packages — the scan
+//! must resolve to the set of modules the build **target** actually compiles.
+//!
+//! [`extract_reachable_rust_processors`] does that: it walks the module tree
+//! from the crate root (`src/lib.rs` / `src/main.rs`), follows each `mod` the
+//! way `rustc` does (honoring `#[path = "..."]`), evaluates the `#[cfg(...)]`
+//! predicate on every `mod` and every `#[processor(...)]`-bearing struct against
+//! a [`ModuleReachabilityTarget`], and collects only the processors that survive.
+//!
+//! The parked-directory convention needs no special case: a parked module is
+//! declared `#[cfg(any())]` (an always-false predicate), so cfg evaluation skips
+//! it exactly as `rustc` does — one rule, not a hard-coded directory name.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use syn::punctuated::Punctuated;
+use syn::{Meta, Token};
+
+use crate::{ExtractError, ExtractedProcessor, parse_processor_attr, processor_attr};
+
+/// The `#[cfg(...)]` evaluation environment a module-reachability walk resolves
+/// against — the set of cfg atoms the build **target** defines.
+///
+/// A `#[cfg(target_os = "linux")]` module is reachable iff `("target_os",
+/// "linux")` is in [`ModuleReachabilityTarget::key_values`]; a `#[cfg(unix)]`
+/// module iff `"unix"` is in [`ModuleReachabilityTarget::flags`]. An atom the
+/// target does not define evaluates to `false` — the same way `rustc` treats an
+/// unset cfg — so a cross-target platform arm and a `#[cfg(any())]` parked
+/// module are both excluded.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ModuleReachabilityTarget {
+    /// Key/value cfg atoms the target defines, e.g. `("target_os", "linux")`,
+    /// `("target_arch", "x86_64")`, `("feature", "cuda")`.
+    pub key_values: BTreeSet<(String, String)>,
+    /// Bare flag cfg atoms the target defines, e.g. `"unix"`, `"windows"`.
+    pub flags: BTreeSet<String>,
+}
+
+impl ModuleReachabilityTarget {
+    /// An empty target defining no cfg atoms — every `#[cfg(...)]`-gated module
+    /// is excluded, only unconditional modules are reachable.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The cfg atoms for the **host** the extractor is running on, derived from
+    /// [`std::env::consts`]: `target_os`, `target_arch`, `target_family`, and
+    /// the `unix` / `windows` family flag. This is the target `streamlib
+    /// pkg build` extracts for — the package is built for the invoking host's
+    /// triple, so the reachable processor set is the set that host compiles.
+    ///
+    /// Cargo features are NOT inferred here (the extractor cannot know which
+    /// features a downstream build enables); add each enabled feature with
+    /// [`ModuleReachabilityTarget::with_feature`].
+    pub fn for_host() -> Self {
+        let os = std::env::consts::OS; // "linux" / "macos" / "windows"
+        let arch = std::env::consts::ARCH; // "x86_64" / "aarch64" / …
+        let family = std::env::consts::FAMILY; // "unix" / "windows"
+        Self::new()
+            .with_key_value("target_os", os)
+            .with_key_value("target_arch", arch)
+            .with_key_value("target_family", family)
+            .with_flag(family)
+    }
+
+    /// Add a key/value cfg atom (e.g. `("target_os", "linux")`).
+    pub fn with_key_value(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.key_values.insert((key.into(), value.into()));
+        self
+    }
+
+    /// Add a bare flag cfg atom (e.g. `unix`).
+    pub fn with_flag(mut self, flag: impl Into<String>) -> Self {
+        self.flags.insert(flag.into());
+        self
+    }
+
+    /// Add an enabled cargo feature (`#[cfg(feature = "<name>")]`).
+    pub fn with_feature(self, name: impl Into<String>) -> Self {
+        self.with_key_value("feature", name)
+    }
+
+    /// Whether `("key", "value")` is defined by this target.
+    fn has_key_value(&self, key: &str, value: &str) -> bool {
+        self.key_values
+            .contains(&(key.to_string(), value.to_string()))
+    }
+
+    /// Whether the bare flag `name` is defined by this target.
+    fn has_flag(&self, name: &str) -> bool {
+        self.flags.contains(name)
+    }
+}
+
+/// Derive the `processors:` manifest section from the modules a Rust crate
+/// compiles **for `target`** — the reachability-resolved counterpart to
+/// [`crate::extract_rust_processors`].
+///
+/// Starts at the crate root (`src/lib.rs`, else `src/main.rs`, else both when a
+/// crate carries a lib and a bin), follows every reachable `mod` the way
+/// `rustc` resolves module files, and evaluates `#[cfg(...)]` on each `mod` and
+/// each `#[processor(...)]`-bearing struct against `target`. A `#[processor]`
+/// under a cfg-excluded module — a cross-platform arm, a disabled feature, or a
+/// `#[cfg(any())]` parked directory — is never collected. The result is
+/// deterministic (source order within a file, module-declaration order across
+/// files) and de-duplicated by resolved source file.
+#[tracing::instrument(skip_all, fields(crate_root = %crate_root.display()))]
+pub fn extract_reachable_rust_processors(
+    crate_root: &Path,
+    target: &ModuleReachabilityTarget,
+) -> Result<Vec<ExtractedProcessor>, ExtractError> {
+    let src_dir = crate_root.join("src");
+    if !src_dir.is_dir() {
+        return Err(ExtractError::NoSrcDir {
+            root: crate_root.to_path_buf(),
+        });
+    }
+
+    let mut walker = ReachableModuleWalker {
+        crate_root,
+        target,
+        visited: BTreeSet::new(),
+        out: Vec::new(),
+    };
+
+    // A crate root is `lib.rs` and/or `main.rs`; both are module roots whose
+    // child modules resolve relative to `src/`. Scan whichever exist so a bare
+    // `@app/local` bin (`main.rs`) and a plugin cdylib (`lib.rs`) both work.
+    let mut scanned_any = false;
+    for root_name in ["lib.rs", "main.rs"] {
+        let root_file = src_dir.join(root_name);
+        if root_file.is_file() {
+            scanned_any = true;
+            walker.walk_file(&root_file, &src_dir)?;
+        }
+    }
+    if !scanned_any {
+        return Err(ExtractError::NoSrcDir {
+            root: crate_root.to_path_buf(),
+        });
+    }
+
+    tracing::debug!(processors = walker.out.len(), "extracted (reachable)");
+    Ok(walker.out)
+}
+
+/// Carries the walk state so the recursive descent doesn't thread five
+/// parameters through every call.
+struct ReachableModuleWalker<'walk> {
+    crate_root: &'walk Path,
+    target: &'walk ModuleReachabilityTarget,
+    visited: BTreeSet<PathBuf>,
+    out: Vec<ExtractedProcessor>,
+}
+
+impl ReachableModuleWalker<'_> {
+    /// Parse `file` and process its items. `mod_dir` is the directory that this
+    /// file's `mod <name>;` children resolve against: `src/` for the crate root
+    /// and for a `src/foo/mod.rs`, or `src/foo/` for a `src/foo.rs` (which
+    /// introduces the `foo` directory component).
+    fn walk_file(&mut self, file: &Path, mod_dir: &Path) -> Result<(), ExtractError> {
+        // A module file is reachable via exactly one `mod` path in valid Rust,
+        // but guard against re-processing (and any pathological `#[path]` alias).
+        let canonical = file.to_path_buf();
+        if !self.visited.insert(canonical) {
+            return Ok(());
+        }
+
+        let body = std::fs::read_to_string(file).map_err(|e| ExtractError::Io {
+            path: file.to_path_buf(),
+            source: e,
+        })?;
+        let parsed = syn::parse_file(&body).map_err(|e| ExtractError::Syntax {
+            path: file.to_path_buf(),
+            source: e,
+        })?;
+
+        let rel = file
+            .strip_prefix(self.crate_root)
+            .unwrap_or(file)
+            .to_path_buf();
+        for item in &parsed.items {
+            self.walk_item(item, file, mod_dir, &rel)?;
+        }
+        Ok(())
+    }
+
+    /// Process one item: collect a reachable `#[processor(...)]` struct, or
+    /// descend into a cfg-reachable module (inline or external).
+    fn walk_item(
+        &mut self,
+        item: &syn::Item,
+        declaring_file: &Path,
+        mod_dir: &Path,
+        rel_path: &Path,
+    ) -> Result<(), ExtractError> {
+        match item {
+            syn::Item::Struct(item_struct) => {
+                // A struct behind a false `#[cfg(...)]` is not compiled, so its
+                // `#[processor]` (if any) is not a real processor for this target.
+                if !self.cfg_reachable(&item_struct.attrs) {
+                    return Ok(());
+                }
+                if let Some(attr) = processor_attr(&item_struct.attrs) {
+                    let extracted = parse_processor_attr(attr, &item_struct.ident, rel_path)?;
+                    self.out.push(extracted);
+                }
+            }
+            syn::Item::Mod(item_mod) => {
+                if !self.cfg_reachable(&item_mod.attrs) {
+                    return Ok(());
+                }
+                match &item_mod.content {
+                    // Inline `mod foo { ... }` introduces a `foo` directory
+                    // component for its children's file resolution.
+                    Some((_, items)) => {
+                        let inner_dir = mod_dir.join(item_mod.ident.to_string());
+                        for inner in items {
+                            self.walk_item(inner, declaring_file, &inner_dir, rel_path)?;
+                        }
+                    }
+                    // External `mod foo;` resolves to a sibling file.
+                    None => {
+                        let child = self.resolve_module_file(item_mod, declaring_file, mod_dir)?;
+                        // `#[path]` on the child controls its own directory the
+                        // same rustc way: a `foo.rs` introduces `foo/`, a
+                        // `foo/mod.rs` keeps its own dir as the child module dir.
+                        let child_mod_dir = child_module_dir(&child, &item_mod.ident.to_string());
+                        self.walk_file(&child, &child_mod_dir)?;
+                    }
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// Resolve an external `mod <name>;` to its source file, honoring a
+    /// `#[path = "..."]` override (relative to `mod_dir`) and otherwise the
+    /// standard `<mod_dir>/<name>.rs` then `<mod_dir>/<name>/mod.rs` search.
+    fn resolve_module_file(
+        &self,
+        item_mod: &syn::ItemMod,
+        declaring_file: &Path,
+        mod_dir: &Path,
+    ) -> Result<PathBuf, ExtractError> {
+        let name = item_mod.ident.to_string();
+
+        if let Some(path_attr) = path_override(&item_mod.attrs) {
+            let candidate = mod_dir.join(&path_attr);
+            if candidate.is_file() {
+                return Ok(candidate);
+            }
+            return Err(ExtractError::UnresolvedModule {
+                module: name,
+                declared_in: declaring_file.to_path_buf(),
+                candidates: candidate.display().to_string(),
+            });
+        }
+
+        let flat = mod_dir.join(format!("{name}.rs"));
+        if flat.is_file() {
+            return Ok(flat);
+        }
+        let nested = mod_dir.join(&name).join("mod.rs");
+        if nested.is_file() {
+            return Ok(nested);
+        }
+        Err(ExtractError::UnresolvedModule {
+            module: name,
+            declared_in: declaring_file.to_path_buf(),
+            candidates: format!("{} or {}", flat.display(), nested.display()),
+        })
+    }
+
+    /// Whether every `#[cfg(...)]` attribute on an item passes for the target.
+    /// An item with no `#[cfg]` is always reachable; multiple `#[cfg]`s are
+    /// ANDed (rustc applies each independently).
+    fn cfg_reachable(&self, attrs: &[syn::Attribute]) -> bool {
+        attrs
+            .iter()
+            .filter(|attr| attr.path().is_ident("cfg"))
+            .all(|attr| self.eval_cfg_attr(attr))
+    }
+
+    /// Evaluate a single `#[cfg(<predicate>)]`. A malformed predicate the parser
+    /// can't read is treated as unreachable (conservative: never over-collect a
+    /// processor from a cfg we could not prove true).
+    fn eval_cfg_attr(&self, attr: &syn::Attribute) -> bool {
+        match attr.parse_args::<Meta>() {
+            Ok(meta) => self.eval_cfg_meta(&meta),
+            Err(_) => false,
+        }
+    }
+
+    /// Evaluate a cfg predicate meta: `all(..)` / `any(..)` / `not(..)`
+    /// combinators, `key = "value"` atoms, and bare flag atoms.
+    fn eval_cfg_meta(&self, meta: &Meta) -> bool {
+        match meta {
+            Meta::Path(path) => path
+                .get_ident()
+                .is_some_and(|ident| self.target.has_flag(&ident.to_string())),
+            Meta::NameValue(name_value) => {
+                let Some(key) = name_value.path.get_ident().map(|i| i.to_string()) else {
+                    return false;
+                };
+                match literal_str(&name_value.value) {
+                    Some(value) => self.target.has_key_value(&key, &value),
+                    None => false,
+                }
+            }
+            Meta::List(list) => {
+                let combinator = match list.path.get_ident() {
+                    Some(ident) => ident.to_string(),
+                    None => return false,
+                };
+                let Ok(inner) =
+                    list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+                else {
+                    return false;
+                };
+                match combinator.as_str() {
+                    // `all()` is vacuously true; `any()` is vacuously false —
+                    // which is exactly why `#[cfg(any())]` parks a module.
+                    "all" => inner.iter().all(|m| self.eval_cfg_meta(m)),
+                    "any" => inner.iter().any(|m| self.eval_cfg_meta(m)),
+                    "not" => inner.len() == 1 && !self.eval_cfg_meta(&inner[0]),
+                    _ => false,
+                }
+            }
+        }
+    }
+}
+
+/// The `#[path = "..."]` override on a `mod`, if present.
+fn path_override(attrs: &[syn::Attribute]) -> Option<String> {
+    attrs.iter().find_map(|attr| {
+        if !attr.path().is_ident("path") {
+            return None;
+        }
+        match &attr.meta {
+            Meta::NameValue(name_value) => literal_str(&name_value.value),
+            _ => None,
+        }
+    })
+}
+
+/// The string value of an expression literal (`"linux"`), if it is one.
+fn literal_str(expr: &syn::Expr) -> Option<String> {
+    if let syn::Expr::Lit(expr_lit) = expr
+        && let syn::Lit::Str(lit_str) = &expr_lit.lit
+    {
+        return Some(lit_str.value());
+    }
+    None
+}
+
+/// The directory a child module file's own `mod <name>;` children resolve
+/// against. A `.../foo/mod.rs` keeps `.../foo`; a `.../foo.rs` introduces the
+/// `.../foo` directory component (matching rustc).
+fn child_module_dir(child_file: &Path, mod_name: &str) -> PathBuf {
+    let parent = child_file.parent().unwrap_or_else(|| Path::new(""));
+    match child_file.file_name().and_then(|n| n.to_str()) {
+        Some("mod.rs") => parent.to_path_buf(),
+        _ => parent.join(mod_name),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &Path, rel: &str, body: &str) {
+        let path = dir.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body).unwrap();
+    }
+
+    fn linux() -> ModuleReachabilityTarget {
+        ModuleReachabilityTarget::new()
+            .with_key_value("target_os", "linux")
+            .with_key_value("target_family", "unix")
+            .with_flag("unix")
+    }
+
+    fn macos() -> ModuleReachabilityTarget {
+        ModuleReachabilityTarget::new()
+            .with_key_value("target_os", "macos")
+            .with_key_value("target_family", "unix")
+            .with_flag("unix")
+    }
+
+    fn names(mut procs: Vec<ExtractedProcessor>) -> Vec<String> {
+        procs.sort_by(|a, b| a.schema.name.cmp(&b.schema.name));
+        procs.into_iter().map(|p| p.schema.name).collect()
+    }
+
+    /// The parked-directory convention (`#[cfg(any())] mod _apple_impl_pending_;`)
+    /// falls out of cfg evaluation for free: `any()` is vacuously false, so the
+    /// parked subtree is never walked and its `#[processor]` never collected.
+    /// Mentally revert `eval_cfg_meta`'s `any` arm to `true` and this fails.
+    #[test]
+    fn parked_cfg_any_module_is_excluded() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "src/lib.rs",
+            r#"
+            #[cfg(target_os = "linux")]
+            pub mod linux_impl;
+
+            #[cfg(any())]
+            mod _apple_impl_pending_;
+            "#,
+        );
+        write(
+            root,
+            "src/linux_impl.rs",
+            r#"
+            #[processor("@tatolab/demo/Camera", execution = manual, output("v", "@tatolab/core/VideoFrame"))]
+            pub struct Camera;
+            "#,
+        );
+        write(
+            root,
+            "src/_apple_impl_pending_/mod.rs",
+            r#"
+            #[processor("@tatolab/demo/AppleCamera", execution = manual, output("v", "@tatolab/core/VideoFrame"))]
+            pub struct AppleCamera;
+            "#,
+        );
+
+        let procs = extract_reachable_rust_processors(root, &linux()).unwrap();
+        assert_eq!(names(procs), vec!["Camera"]);
+    }
+
+    /// Two platform arms declaring the same processor: only the arm the target
+    /// compiles surfaces (the raw scan would surface both).
+    #[test]
+    fn cross_platform_arms_resolve_to_the_target_arm() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "src/lib.rs",
+            r#"
+            #[cfg(target_os = "linux")]
+            pub mod linux;
+            #[cfg(target_os = "macos")]
+            pub mod apple;
+            "#,
+        );
+        write(
+            root,
+            "src/linux.rs",
+            r#"#[processor("@tatolab/demo/LinuxCam", execution = manual, output("v", "@tatolab/core/VideoFrame"))]
+            pub struct LinuxCam;"#,
+        );
+        write(
+            root,
+            "src/apple.rs",
+            r#"#[processor("@tatolab/demo/AppleCam", execution = manual, output("v", "@tatolab/core/VideoFrame"))]
+            pub struct AppleCam;"#,
+        );
+
+        assert_eq!(
+            names(extract_reachable_rust_processors(root, &linux()).unwrap()),
+            vec!["LinuxCam"]
+        );
+        assert_eq!(
+            names(extract_reachable_rust_processors(root, &macos()).unwrap()),
+            vec!["AppleCam"]
+        );
+    }
+
+    /// A `#[processor]` directly on a cfg-gated struct (no module boundary) is
+    /// gated too.
+    #[test]
+    fn cfg_on_the_struct_itself_is_honored() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "src/lib.rs",
+            r#"
+            #[cfg(target_os = "linux")]
+            #[processor("@tatolab/demo/OnlyLinux", execution = reactive)]
+            pub struct OnlyLinux;
+
+            #[cfg(target_os = "windows")]
+            #[processor("@tatolab/demo/OnlyWindows", execution = reactive)]
+            pub struct OnlyWindows;
+            "#,
+        );
+        assert_eq!(
+            names(extract_reachable_rust_processors(root, &linux()).unwrap()),
+            vec!["OnlyLinux"]
+        );
+    }
+
+    /// A module never `mod`-declared from the crate root is unreachable — a
+    /// stray `.rs` under `src/` (scratch file, unwired arm) is not compiled and
+    /// must not contribute a processor. The raw whole-tree scan would collect it.
+    #[test]
+    fn undeclared_file_under_src_is_unreachable() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "src/lib.rs", "pub mod wired;\n");
+        write(
+            root,
+            "src/wired.rs",
+            r#"#[processor("@tatolab/demo/Wired", execution = reactive)]
+            pub struct Wired;"#,
+        );
+        write(
+            root,
+            "src/scratch.rs",
+            r#"#[processor("@tatolab/demo/Scratch", execution = reactive)]
+            pub struct Scratch;"#,
+        );
+        assert_eq!(
+            names(extract_reachable_rust_processors(root, &linux()).unwrap()),
+            vec!["Wired"]
+        );
+    }
+
+    /// `not(...)`, `all(...)`, and `any(...)` combinators evaluate against the
+    /// target.
+    #[test]
+    fn cfg_combinators_evaluate() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "src/lib.rs",
+            r#"
+            #[cfg(all(unix, target_arch = "x86_64"))]
+            #[processor("@tatolab/demo/UnixX86", execution = reactive)]
+            pub struct UnixX86;
+
+            #[cfg(not(target_os = "windows"))]
+            #[processor("@tatolab/demo/NotWindows", execution = reactive)]
+            pub struct NotWindows;
+
+            #[cfg(any(target_os = "windows", target_os = "redox"))]
+            #[processor("@tatolab/demo/Exotic", execution = reactive)]
+            pub struct Exotic;
+            "#,
+        );
+        let target = linux().with_key_value("target_arch", "x86_64");
+        assert_eq!(
+            names(extract_reachable_rust_processors(root, &target).unwrap()),
+            vec!["NotWindows", "UnixX86"]
+        );
+    }
+
+    /// A `#[cfg(feature = "...")]` module is reachable only when the feature is
+    /// declared on the target.
+    #[test]
+    fn feature_gated_module_needs_the_feature() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "src/lib.rs",
+            r#"
+            #[cfg(feature = "cuda")]
+            pub mod cuda;
+            "#,
+        );
+        write(
+            root,
+            "src/cuda.rs",
+            r#"#[processor("@tatolab/demo/Cuda", execution = reactive)]
+            pub struct Cuda;"#,
+        );
+
+        assert!(extract_reachable_rust_processors(root, &linux()).unwrap().is_empty());
+        let with_cuda = linux().with_feature("cuda");
+        assert_eq!(
+            names(extract_reachable_rust_processors(root, &with_cuda).unwrap()),
+            vec!["Cuda"]
+        );
+    }
+
+    /// Nested module-file resolution: `mod.rs` keeps its dir, a `foo.rs`
+    /// introduces the `foo/` directory for its own children, and `#[path]`
+    /// overrides the search.
+    #[test]
+    fn nested_and_path_override_module_resolution() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "src/lib.rs",
+            "pub mod devices;\n#[path = \"custom_location.rs\"]\npub mod aliased;\n",
+        );
+        // devices/mod.rs → devices/webcam.rs (mod.rs keeps its own dir).
+        write(root, "src/devices/mod.rs", "pub mod webcam;\n");
+        write(
+            root,
+            "src/devices/webcam.rs",
+            r#"#[processor("@tatolab/demo/Webcam", execution = reactive)]
+            pub struct Webcam;"#,
+        );
+        write(
+            root,
+            "src/custom_location.rs",
+            r#"#[processor("@tatolab/demo/Aliased", execution = reactive)]
+            pub struct Aliased;"#,
+        );
+        assert_eq!(
+            names(extract_reachable_rust_processors(root, &linux()).unwrap()),
+            vec!["Aliased", "Webcam"]
+        );
+    }
+
+    /// A `foo.rs` (not `mod.rs`) introduces a `foo/` directory component for its
+    /// own `mod bar;` children.
+    #[test]
+    fn non_mod_rs_file_introduces_directory_component() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "src/lib.rs", "pub mod outer;\n");
+        write(root, "src/outer.rs", "pub mod inner;\n");
+        write(
+            root,
+            "src/outer/inner.rs",
+            r#"#[processor("@tatolab/demo/Deep", execution = reactive)]
+            pub struct Deep;"#,
+        );
+        assert_eq!(
+            names(extract_reachable_rust_processors(root, &linux()).unwrap()),
+            vec!["Deep"]
+        );
+    }
+
+    /// A reachable `mod x;` with no backing file is a typed error (a compilable
+    /// crate never hits it, but the walk surfaces it rather than dropping a
+    /// subtree the target would compile).
+    #[test]
+    fn missing_reachable_module_file_is_typed_error() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "src/lib.rs", "pub mod ghost;\n");
+        let err = extract_reachable_rust_processors(root, &linux()).unwrap_err();
+        match err {
+            ExtractError::UnresolvedModule { module, .. } => assert_eq!(module, "ghost"),
+            other => panic!("expected UnresolvedModule, got {other:?}"),
+        }
+    }
+
+    /// A bare `@app/local` bin (`main.rs`, no `lib.rs`) is a valid crate root.
+    #[test]
+    fn main_rs_is_a_crate_root() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "src/main.rs",
+            r#"
+            #[processor(execution = reactive)]
+            struct MyLocalThing;
+            fn main() {}
+            "#,
+        );
+        assert_eq!(
+            names(extract_reachable_rust_processors(root, &linux()).unwrap()),
+            vec!["MyLocalThing"]
+        );
+    }
+
+    /// An unconditional module is reachable regardless of target.
+    #[test]
+    fn unconditional_module_always_reachable() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "src/lib.rs", "pub mod always;\n");
+        write(
+            root,
+            "src/always.rs",
+            r#"#[processor("@tatolab/demo/Always", execution = reactive)]
+            pub struct Always;"#,
+        );
+        assert_eq!(
+            names(extract_reachable_rust_processors(root, &macos()).unwrap()),
+            vec!["Always"]
+        );
+    }
+
+    /// `for_host()` defines the running host's os/arch/family so the crate's own
+    /// host arm is reachable.
+    #[test]
+    fn for_host_defines_host_atoms() {
+        let host = ModuleReachabilityTarget::for_host();
+        assert!(host.has_key_value("target_os", std::env::consts::OS));
+        assert!(host.has_key_value("target_arch", std::env::consts::ARCH));
+        assert!(host.has_flag(std::env::consts::FAMILY));
+    }
+
+    /// Missing `src/` is the same typed error the raw scan gives.
+    #[test]
+    fn missing_src_dir_is_typed_error() {
+        let tmp = tempdir();
+        let err = extract_reachable_rust_processors(tmp.path(), &linux()).unwrap_err();
+        assert!(matches!(err, ExtractError::NoSrcDir { .. }));
+    }
+
+    /// Minimal tempdir (no `tempfile` dep in this lean crate).
+    struct TmpDir(PathBuf);
+    impl TmpDir {
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl Drop for TmpDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+    fn tempdir() -> TmpDir {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        let dir = std::env::temp_dir().join(format!("slreach-{pid}-{n}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        TmpDir(dir)
+    }
+}

--- a/sdk/streamlib-processor-extract/tests/real_package_reachability.rs
+++ b/sdk/streamlib-processor-extract/tests/real_package_reachability.rs
@@ -1,0 +1,73 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Reachability resolution over a REAL in-tree package.
+//!
+//! `@tatolab/camera` is the canonical over-collection case: its Linux arm
+//! (`src/linux/camera.rs`) and its parked Apple arm
+//! (`src/_apple_impl_pending_/camera.rs`) BOTH declare a `@tatolab/camera/Camera`
+//! processor. The parked arm is gated `#[cfg(any())]` in `src/lib.rs`, so it
+//! never compiles on any target. This locks that:
+//!
+//! - the raw whole-tree scan over-collects (two `Camera`s), and
+//! - the reachability-resolved scan for a Linux target yields exactly the set
+//!   the package's committed `processors:` manifest lists — no parked duplicate.
+
+use std::path::PathBuf;
+
+use streamlib_processor_extract::{
+    ModuleReachabilityTarget, extract_reachable_rust_processors, extract_rust_processors,
+};
+
+fn camera_package_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("packages")
+        .join("camera")
+}
+
+fn linux_target() -> ModuleReachabilityTarget {
+    ModuleReachabilityTarget::new()
+        .with_key_value("target_os", "linux")
+        .with_key_value("target_arch", "x86_64")
+        .with_key_value("target_family", "unix")
+        .with_flag("unix")
+}
+
+fn sorted_names(procs: Vec<streamlib_processor_extract::ExtractedProcessor>) -> Vec<String> {
+    let mut names: Vec<String> = procs.into_iter().map(|p| p.schema.name).collect();
+    names.sort();
+    names
+}
+
+#[test]
+fn raw_scan_over_collects_the_parked_apple_arm() {
+    let dir = camera_package_dir();
+    if !dir.join("src").is_dir() {
+        // The in-tree package moved; skip rather than fail a layout-coupled test.
+        return;
+    }
+    let names = sorted_names(extract_rust_processors(&dir).unwrap());
+    // Both the Linux and the parked Apple arm declare `Camera` → duplicate.
+    let camera_count = names.iter().filter(|n| n.as_str() == "Camera").count();
+    assert!(
+        camera_count >= 2,
+        "raw scan should over-collect the parked Apple `Camera`; got {names:?}"
+    );
+}
+
+#[test]
+fn reachable_scan_matches_the_committed_manifest() {
+    let dir = camera_package_dir();
+    if !dir.join("src").is_dir() {
+        return;
+    }
+    let names = sorted_names(extract_reachable_rust_processors(&dir, &linux_target()).unwrap());
+    assert_eq!(
+        names,
+        vec!["Camera".to_string(), "CameraToCudaCopy".to_string()],
+        "reachable Linux scan must equal the package's `processors:` set, \
+         with the parked Apple `Camera` excluded"
+    );
+}

--- a/sdk/streamlib-processor-schema/src/processor_schema.rs
+++ b/sdk/streamlib-processor-schema/src/processor_schema.rs
@@ -587,11 +587,14 @@ pub struct ProcessorScheduling {
     pub priority: ThreadPriority,
 }
 
-/// A complete processor schema definition parsed from YAML.
+/// A complete processor schema definition — the manifest-shaped view of one
+/// processor, derived from its `#[processor(...)]` attribute (the source of
+/// truth) by the source-scan extractor.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ProcessorSchema {
-    /// Processor name in reverse domain notation (e.g., "com.example.blur").
+    /// The `Type` segment of the processor's `@org/package/Type` identity — the
+    /// PascalCase short name (e.g. "Camera"), NOT reverse-DNS.
     pub name: String,
 
     /// Processor version (e.g., "1.0.0").


### PR DESCRIPTION
Ticket: https://github.com/tatolab/streamlib/issues/1411

## Summary
- Adds `extract_reachable_rust_processors` + `ModuleReachabilityTarget` to `streamlib-processor-extract`: a cfg-aware module walker that resolves `#[processor]` usage down to the set of modules actually reachable for a given compile target (host OS/arch/family, plus explicit `#[cfg]` key-values / flags / features), retaining the existing whole-crate scan as the over-collection reference for a future drift check.
- Reconciles the `ProcessorSchema.name` doc in `sdk/streamlib-processor-schema/src/processor_schema.rs` with the Type-segment identity the grammar already emits (reverse-DNS wording was stale).
- Regenerates `schemas/streamlib.schema.json` for the doc change and updates `docs/decisions/manifest-extraction-capability.md`.

This is the **reachability precursor slice** of #1411 — it ships the extraction *capability* only. It does not close #1411: `pkg build` wiring (`tools/streamlib-cli/src/commands/pkg.rs`), the hard drift-check error, Python/Deno extraction, and dev-version projection are not part of this PR and land in follow-ups.

## Test evidence
```
cargo test -p streamlib-processor-extract -p streamlib-processor-schema
...
test result: ok. 46 passed; 0 failed; 0 ignored (streamlib-processor-extract unit tests)
running 2 tests (tests/real_package_reachability.rs)
test raw_scan_over_collects_the_parked_apple_arm ... ok
test reachable_scan_matches_the_committed_manifest ... ok
test result: ok. 2 passed; 0 failed
test result: ok. 30 passed; 0 failed (streamlib-processor-schema unit tests)
```
No GPU/runtime surface touched — CPU-only AST/schema work, covered by `cargo test --lib` per CI policy.

## Review items (non-blocking)

These surfaced during independent verification. None block merge; listed for owner visibility.

1. **[info]** `sdk/streamlib-processor-extract/src/reachable.rs:110` — This slice delivers the ticket's `pkg build invokes extraction` and `drift check` criteria.
   Evidence: The 6-file diff (`git diff 5cac1ae..FETCH_HEAD`) touches no `tools/streamlib-cli/src/commands/pkg.rs`; grep for `extract_reachable`/`ModuleReachabilityTarget` in pkg.rs returns nothing. This PR ships only the reachability *capability* (`extract_reachable_rust_processors` + `ModuleReachabilityTarget`), not its consumption. That matches the ticket framing of reachability as the precursor, but the pkg-build wiring, hard drift error, Python/Deno extraction, and dev-version projection criteria are NOT in this slice.
   Suggested next step: State in the PR body that this is the reachability-precursor slice of #1411 and does not close it; the wiring/drift/polyglot criteria land in follow-up PRs. (Done above.)

2. **[should-fix]** `sdk/streamlib-processor-extract/src/reachable.rs:63` — `for_host()` gives the correct cfg environment for the target pkg build compiles.
   Evidence: `for_host()` sets target_os/arch/family + family flag but deliberately infers no cargo features (documented). A processor gated behind a *default-enabled* `#[cfg(feature="...")]` would therefore be excluded from the extracted set. Once this feeds the drift check, that yields a false-positive drift against a committed manifest that includes the default-feature processor.
   Suggested next step: When wiring into pkg build (follow-up), thread the resolved/enabled feature set through `with_feature`; note the requirement on the capability so the consumer doesn't miss it.

3. **[low]** `sdk/streamlib-processor-extract/src/reachable.rs:352` — Module-file resolution follows `rustc` `#[path]` handling.
   Evidence: `child_module_dir` derives a path-override module's child directory from the *mod name* (`parent.join(mod_name)`), not the path file's stem. For `#[path="custom_location.rs"] mod aliased;` with its own `mod deep;`, rustc resolves `deep` under `custom_location/` but this code looks under `aliased/`. Edge case; tests cover only a path-override leaf module, not a nested one.
   Suggested next step: Optionally derive the child dir from the resolved file's stem for the non-mod.rs `#[path]` case, or note the limitation; low impact given rarity.

4. **[should-fix]** `sdk/streamlib-processor-schema/src/processor_schema.rs:590` — Reconciles the §11 #8 dual identity/version model.
   Evidence: The change corrects only the `name` doc (reverse-DNS -> Type segment) to match what the grammar already emits (integration test asserts `["Camera","CameraToCudaCopy"]` = Type segments). The parallel per-processor `version` field flagged in the same landmine note is untouched. Honest per its commit scope, but the landmine's version half is not addressed here.
   Suggested next step: State in the PR body that only the `name` half of the dual-identity reconciliation lands here and where the `version` reconciliation is handled. (Noted: the `version` half is not addressed in this PR and is tracked separately against the §11 #8 landmine on #1411.)

5. **[should-fix]** `sdk/streamlib-processor-extract/src/reachable.rs:174` — The file-read/parse/relativize prologue is duplicated between `ReachableModuleWalker::walk_file` and `lib.rs::extract_from_file`.
   Evidence: `walk_file` (reachable.rs L174-206) and `extract_from_file` (lib.rs ~L165-186) both do the identical sequence: `std::fs::read_to_string` mapped to `ExtractError::Io`, `syn::parse_file` mapped to `ExtractError::Syntax`, then `file.strip_prefix(crate_root).unwrap_or(file).to_path_buf()` for `rel`. These are the same ~12 lines and would have to change together if the Io/Syntax variants or the rel-path convention ever change.
   Suggested next step: Extract a crate-private helper e.g. `fn parse_crate_file(path: &Path, crate_root: &Path) -> Result<(syn::File, PathBuf), ExtractError>` returning the parsed file plus the relativized path, and call it from both walkers. Call out the extraction in the PR body (no silent DRY refactors).

6. **[should-fix]** `sdk/streamlib-processor-extract/src/reachable.rs:424` — The TmpDir/tempdir/write test scaffolding is duplicated verbatim between the reachable.rs test module and the lib.rs test module.
   Evidence: reachable.rs tests define `fn write`, `struct TmpDir`, `impl Drop for TmpDir`, and `fn tempdir()`; lib.rs tests (L260, L457-476) define the identical items differing only in the temp-dir prefix string ("slreach-" vs "slextract-"). Same logic, two copies that must be kept in sync.
   Suggested next step: Hoist the shared test scaffolding into one `#[cfg(test)]` support module (e.g. `src/test_support.rs`) that both test modules import, parameterizing the prefix if it matters.

7. **[low]** `sdk/streamlib-processor-extract/src/reachable.rs:97` — `has_key_value` allocates two Strings on every cfg-atom lookup just to probe a BTreeSet.
   Evidence: `self.key_values.contains(&(key.to_string(), value.to_string()))` allocates two owned Strings per call solely to build the lookup tuple; the set is tiny (a handful of atoms) so a linear scan is both alloc-free and no slower.
   Suggested next step: Replace with `self.key_values.iter().any(|(k, v)| k == key && v == value)` (and similarly leave `has_flag` as-is since `&str` probes a `BTreeSet<String>` without alloc).

8. **[low]** `sdk/streamlib-processor-extract/src/reachable.rs:177` — The `canonical` local is named for a canonicalization that never happens, weakening the re-visit guard it documents.
   Evidence: `let canonical = file.to_path_buf();` then `self.visited.insert(canonical)` — the comment above says it guards against a "pathological `#[path]` alias", but two different path spellings resolving to the same file (exactly what an alias produces) would not dedupe because the path is never canonicalized.
   Suggested next step: Either canonicalize (`std::fs::canonicalize`, falling back to the raw path on error) so the visited-set actually catches aliases, or rename the local to `key`/`visited_path` and drop the alias claim from the comment.

9. **[low]** `sdk/streamlib-processor-extract/src/reachable.rs:80` — The pure builder methods lack `#[must_use]`.
   Evidence: `new()`, `for_host()`, `with_key_value()`, `with_flag()`, and `with_feature()` all take/return `Self` and have no side effects; dropping their return value is always a bug, but nothing flags it.
   Suggested next step: Add `#[must_use]` to the `ModuleReachabilityTarget` builder methods (and the type itself is a reasonable `#[must_use]` candidate too).

10. **[info]** `sdk/streamlib-processor-extract/src/reachable.rs:109` — `extract_reachable_rust_processors` stands alongside `extract_rust_processors` as a second whole-crate extractor — a near-parallel entrypoint, but a justified one.
    Evidence: The module doc (L1-24) and the integration test (`real_package_reachability.rs`) explain the raw scan is intentionally retained as the over-collection reference for the drift check, while the reachable scan is the resolved truth-source; both are exercised. This is the documented "why/what/alternatives" the engine doctrine asks for, so it is not a defect — noting only that once the drift check lands, whether the raw scan should be retired is a follow-up worth tracking.
    Suggested next step: No action now; when the reachable scan becomes authoritative, revisit whether `extract_rust_processors` should be collapsed into it or narrowed to a test-only helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
