### PR TITLE
feat(idents): channel-name grammar + connect() generator + fix PortKey silent truncation (#1416)

### DIFF
--- a/runtime/streamlib-engine/src/core/embedded_schemas/integration_tests.rs
+++ b/runtime/streamlib-engine/src/core/embedded_schemas/integration_tests.rs
@@ -285,6 +285,7 @@ fn test_frame_header_plus_256kb_roundtrip_through_slice_service() {
     let schema_ident = SchemaIdentWire::from_segments("test", "wire", "LargeFrame", 1, 0, 0)
         .expect("LargeFrame segments fit SchemaIdentWire bounds");
     FrameHeader::new("dest_port", schema_ident, 42, data_size as u32)
+        .expect("dest_port fits PortKey bounds")
         .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
     frame[FRAME_HEADER_SIZE..].copy_from_slice(&data);
 

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -159,13 +159,16 @@ async fn connect_impl(
     // The one channel name this link publishes to / subscribes from — the
     // deterministic `connect()` sugar (#1416). Intra-node it currently maps
     // onto the per-destination iceoryx2 service; the name is what phase [L]
-    // cross-node routing keys on. Always a valid `ChannelName` by construction.
+    // cross-node routing keys on. An out-of-grammar endpoint (e.g. an
+    // underscore-bearing port name) surfaces as a typed link error rather than
+    // an invalid wire name.
     let channel = streamlib_idents::connect_channel_name(
         from_processor.as_str(),
         &from_port,
         to_processor.as_str(),
         &to_port,
-    );
+    )
+    .map_err(|source| Error::InvalidLink(source.to_string()))?;
 
     PUBSUB.publish(
         topics::RUNTIME_GLOBAL,
@@ -454,7 +457,8 @@ mod channel_wire_bound_tests {
         // must construct a PortKey without the fallible constructor rejecting it.
         let long = "verylongprocessorname".repeat(4);
         let channel =
-            streamlib_idents::connect_channel_name(&long, "outputport", "sinkproc", "inputport");
+            streamlib_idents::connect_channel_name(&long, "outputport", "sinkproc", "inputport")
+                .expect("a grammar-legal set of endpoints must produce a channel name");
         streamlib_ipc_types::PortKey::new(channel.as_str())
             .expect("a grammar-legal channel name must always fit the PortKey wire");
     }

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -159,9 +159,9 @@ async fn connect_impl(
     // The one channel name this link publishes to / subscribes from — the
     // deterministic `connect()` sugar (#1416). Intra-node it currently maps
     // onto the per-destination iceoryx2 service; the name is what phase [L]
-    // cross-node routing keys on. An out-of-grammar endpoint (e.g. an
-    // underscore-bearing port name) surfaces as a typed link error rather than
-    // an invalid wire name.
+    // cross-node routing keys on. An out-of-grammar endpoint (e.g. a port name
+    // carrying `/` or uppercase) surfaces as a typed link error rather than an
+    // invalid wire name; underscore is legal and rides through.
     let channel = streamlib_idents::connect_channel_name(
         from_processor.as_str(),
         &from_port,

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -156,6 +156,17 @@ async fn connect_impl(
     let to_processor = to.processor_id.clone();
     let to_port = to.port_name.clone();
 
+    // The one channel name this link publishes to / subscribes from — the
+    // deterministic `connect()` sugar (#1416). Intra-node it currently maps
+    // onto the per-destination iceoryx2 service; the name is what phase [L]
+    // cross-node routing keys on. Always a valid `ChannelName` by construction.
+    let channel = streamlib_idents::connect_channel_name(
+        from_processor.as_str(),
+        &from_port,
+        to_processor.as_str(),
+        &to_port,
+    );
+
     PUBSUB.publish(
         topics::RUNTIME_GLOBAL,
         &Event::RuntimeGlobal(RuntimeEvent::RuntimeWillConnect {
@@ -210,6 +221,12 @@ async fn connect_impl(
             .map(|link| link.id.clone())
             .ok_or_else(|| Error::GraphError("failed to create link after validation".into()))
     })?;
+
+    tracing::debug!(
+        link_id = %link_id,
+        channel = channel.as_str(),
+        "connect assigned channel"
+    );
 
     PUBSUB.publish(
         topics::RUNTIME_GLOBAL,
@@ -412,5 +429,33 @@ impl RuntimeOperations for Runner {
 
     fn to_json(&self) -> Result<serde_json::Value> {
         Runner::to_json(self)
+    }
+}
+
+#[cfg(test)]
+mod channel_wire_bound_tests {
+    // The channel-name grammar (streamlib_idents) and the fixed PortKey wire
+    // capacity (streamlib_ipc_types) live in separate crates that cannot depend
+    // on each other, so the max-length bound is duplicated. This engine layer
+    // depends on both and is the one place that reconciles them: a channel name
+    // that passes the grammar must always fit the wire.
+    #[test]
+    fn channel_name_bound_matches_port_key_wire_capacity() {
+        assert_eq!(
+            streamlib_idents::MAX_CHANNEL_NAME_BYTES,
+            streamlib_ipc_types::PortKey::MAX_NAME_BYTES,
+            "channel-name grammar bound drifted from the PortKey wire capacity"
+        );
+    }
+
+    #[test]
+    fn generated_connect_channel_name_fits_the_wire() {
+        // A generated name — including the hash-suffixed over-budget path —
+        // must construct a PortKey without the fallible constructor rejecting it.
+        let long = "verylongprocessorname".repeat(4);
+        let channel =
+            streamlib_idents::connect_channel_name(&long, "outputport", "sinkproc", "inputport");
+        streamlib_ipc_types::PortKey::new(channel.as_str())
+            .expect("a grammar-legal channel name must always fit the PortKey wire");
     }
 }

--- a/runtime/streamlib-engine/src/iceoryx2/input.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/input.rs
@@ -732,7 +732,7 @@ mod tests {
         .expect("schema ident");
         let make_frame = |port: &str| -> Vec<u8> {
             let mut buf = vec![0u8; FRAME_HEADER_SIZE + 4];
-            let header = FrameHeader::new(port, schema_ident, 0, 4);
+            let header = FrameHeader::new(port, schema_ident, 0, 4).expect("port fits PortKey");
             header.write_to_slice(&mut buf);
             buf[FRAME_HEADER_SIZE..].copy_from_slice(&[1, 2, 3, 4]);
             buf

--- a/runtime/streamlib-engine/src/iceoryx2/output.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/output.rs
@@ -132,6 +132,12 @@ impl OutputWriterInner {
                 timestamp_ns,
                 data.len() as u32,
             )
+            .map_err(|e| {
+                Error::Link(format!(
+                    "output port '{}' → dest '{}': {}",
+                    port, conn.dest_port, e
+                ))
+            })?
             .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
             frame[FRAME_HEADER_SIZE..].copy_from_slice(data);
 

--- a/runtime/streamlib-ipc-types/src/lib.rs
+++ b/runtime/streamlib-ipc-types/src/lib.rs
@@ -79,6 +79,36 @@ pub const MAX_SUBSCRIBERS_PER_DESTINATION: usize = 1;
 /// Size of the frame header in the `[u8]` slice wire format.
 pub const FRAME_HEADER_SIZE: usize = MAX_PORT_KEY_SIZE + SCHEMA_IDENT_WIRE_SIZE + 8 + 4; // 204 bytes
 
+/// Error constructing a [`PortKey`] from a name that overflows the fixed
+/// wire capacity.
+///
+/// This is the engine-layer replacement for the pre-#1416 silent truncation:
+/// a port / channel name longer than [`MAX_PORT_KEY_SIZE`] `- 1` bytes used to
+/// be quietly clipped, routing frames to a different (truncated) port than the
+/// one the author named. Over-length is now a hard, named error the caller
+/// must handle rather than a data-corruption surface. Names crossing this
+/// boundary have already passed the charset + length grammar in
+/// `streamlib_idents::validate_channel_name`; this guard is the wire-level
+/// backstop that makes truncation unrepresentable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PortKeyError {
+    /// The UTF-8 name is `len` bytes, past the fixed `max`-byte capacity.
+    TooLong { len: usize, max: usize },
+}
+
+impl std::fmt::Display for PortKeyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TooLong { len, max } => write!(
+                f,
+                "port key name is {len} bytes, exceeding the fixed wire capacity of {max} bytes"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PortKeyError {}
+
 /// Fixed-size port name for zero-copy IPC.
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug, ZeroCopySend)]
 #[repr(C)]
@@ -88,15 +118,28 @@ pub struct PortKey {
 }
 
 impl PortKey {
-    pub fn new(name: &str) -> Self {
+    /// Maximum UTF-8 byte length a port / channel name may occupy on the wire
+    /// (the fixed `name` field is [`MAX_PORT_KEY_SIZE`] `- 1` bytes).
+    pub const MAX_NAME_BYTES: usize = MAX_PORT_KEY_SIZE - 1;
+
+    /// Construct a [`PortKey`], rejecting an over-length name.
+    ///
+    /// A name past [`PortKey::MAX_NAME_BYTES`] is a [`PortKeyError::TooLong`]
+    /// rather than a silent truncation — see [`PortKeyError`].
+    pub fn new(name: &str) -> Result<Self, PortKeyError> {
         let bytes = name.as_bytes();
-        let len = bytes.len().min(MAX_PORT_KEY_SIZE - 1) as u8;
+        if bytes.len() > Self::MAX_NAME_BYTES {
+            return Err(PortKeyError::TooLong {
+                len: bytes.len(),
+                max: Self::MAX_NAME_BYTES,
+            });
+        }
         let mut key = Self {
-            len,
+            len: bytes.len() as u8,
             name: [0u8; MAX_PORT_KEY_SIZE - 1],
         };
-        key.name[..len as usize].copy_from_slice(&bytes[..len as usize]);
-        key
+        key.name[..bytes.len()].copy_from_slice(bytes);
+        Ok(key)
     }
 
     pub fn as_str(&self) -> &str {
@@ -322,17 +365,25 @@ pub struct FramePayload {
 
 impl FramePayload {
     /// Create a new payload with the given port, structured schema ident, and data.
-    pub fn new(port: &str, schema_ident: SchemaIdentWire, timestamp_ns: i64, data: &[u8]) -> Self {
+    ///
+    /// Fails with [`PortKeyError`] if `port` overflows the fixed wire capacity —
+    /// see [`PortKey::new`].
+    pub fn new(
+        port: &str,
+        schema_ident: SchemaIdentWire,
+        timestamp_ns: i64,
+        data: &[u8],
+    ) -> Result<Self, PortKeyError> {
         let len = data.len().min(MAX_PAYLOAD_SIZE) as u32;
         let mut payload = Self {
-            port_key: PortKey::new(port),
+            port_key: PortKey::new(port)?,
             schema_ident,
             timestamp_ns,
             len,
             data: [0u8; MAX_PAYLOAD_SIZE],
         };
         payload.data[..len as usize].copy_from_slice(&data[..len as usize]);
-        payload
+        Ok(payload)
     }
 
     /// Get the actual data slice (excluding padding).
@@ -391,18 +442,21 @@ pub struct FrameHeader {
 
 impl FrameHeader {
     /// Create a new frame header from a structured schema identifier.
+    ///
+    /// Fails with [`PortKeyError`] if `port` overflows the fixed wire capacity —
+    /// see [`PortKey::new`].
     pub fn new(
         port: &str,
         schema_ident: SchemaIdentWire,
         timestamp_ns: i64,
         data_len: u32,
-    ) -> Self {
-        Self {
-            port_key: PortKey::new(port),
+    ) -> Result<Self, PortKeyError> {
+        Ok(Self {
+            port_key: PortKey::new(port)?,
             schema_ident,
             timestamp_ns,
             len: data_len,
-        }
+        })
     }
 
     /// Write the header to the first [`FRAME_HEADER_SIZE`] bytes of `buf`.
@@ -656,7 +710,7 @@ mod tests {
     fn frame_header_round_trip_via_slice() {
         let ident = SchemaIdentWire::from_segments("tatolab", "core", "EncodedVideoFrame", 1, 2, 3)
             .unwrap();
-        let header = FrameHeader::new("dest_port", ident, 42, 1024);
+        let header = FrameHeader::new("dest_port", ident, 42, 1024).unwrap();
         let mut buf = [0u8; FRAME_HEADER_SIZE];
         header.write_to_slice(&mut buf);
         let back = FrameHeader::read_from_slice(&buf);
@@ -719,6 +773,43 @@ mod tests {
         assert_eq!(u32::from_le_bytes(buf[116..120].try_into().unwrap()), 1);
         assert_eq!(u32::from_le_bytes(buf[120..124].try_into().unwrap()), 2);
         assert_eq!(u32::from_le_bytes(buf[124..128].try_into().unwrap()), 3);
+    }
+
+    #[test]
+    fn port_key_accepts_max_length_name() {
+        // Exact-fit boundary: a name of MAX_NAME_BYTES must construct.
+        let name = "a".repeat(PortKey::MAX_NAME_BYTES);
+        let key = PortKey::new(&name).expect("max-length name must construct");
+        assert_eq!(key.as_str(), name);
+    }
+
+    #[test]
+    fn port_key_rejects_over_length_name_instead_of_truncating() {
+        // Mental-revert guard for the pre-#1416 silent truncation: a name one
+        // byte past the wire capacity must be a named error, NOT a clipped key
+        // that routes frames to the wrong port. Revert `PortKey::new` to the
+        // `.min(MAX_PORT_KEY_SIZE - 1)` truncation and this fails — the
+        // construction would succeed and `as_str()` would return the clipped
+        // 63-byte prefix.
+        let over = "b".repeat(PortKey::MAX_NAME_BYTES + 1);
+        assert_eq!(over.len(), 64);
+        assert_eq!(
+            PortKey::new(&over),
+            Err(PortKeyError::TooLong { len: 64, max: 63 })
+        );
+    }
+
+    #[test]
+    fn frame_header_rejects_over_length_port() {
+        // The truncation defect surfaced through FrameHeader::new on the write
+        // path — over-length must propagate as the typed error, not silently
+        // build a header with a clipped port key.
+        let ident = sample_ident();
+        let over = "c".repeat(PortKey::MAX_NAME_BYTES + 1);
+        assert!(matches!(
+            FrameHeader::new(&over, ident, 0, 0),
+            Err(PortKeyError::TooLong { .. })
+        ));
     }
 
     #[test]

--- a/sdk/streamlib-deno-native/src/lib.rs
+++ b/sdk/streamlib-deno-native/src/lib.rs
@@ -830,13 +830,25 @@ pub unsafe extern "C" fn sldn_output_write(
 
     let total_len = FRAME_HEADER_SIZE + data_slice.len();
     let mut frame = vec![0u8; total_len];
-    FrameHeader::new(
+    let header = match FrameHeader::new(
         &state.dest_port,
         state.schema_ident,
         timestamp_ns,
         data_slice.len() as u32,
-    )
-    .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
+    ) {
+        Ok(h) => h,
+        Err(e) => {
+            tracing::error!(
+                "[sldn:{}] Invalid dest port '{}' for output port '{}': {}",
+                ctx.processor_id,
+                state.dest_port,
+                port_name,
+                e
+            );
+            return -1;
+        }
+    };
+    header.write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
     frame[FRAME_HEADER_SIZE..].copy_from_slice(data_slice);
 
     let sample = match state.publisher.loan_slice_uninit(total_len) {

--- a/sdk/streamlib-idents/src/channel.rs
+++ b/sdk/streamlib-idents/src/channel.rs
@@ -1,0 +1,275 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Channel names — the pub/sub rendezvous identifier a port publishes to /
+//! subscribes from.
+//!
+//! A channel name is the same string in two roles: an iceoryx2 service name
+//! intra-node and (phase [L]) a Zenoh key-expression cross-node. Its charset
+//! reuses the canonical org/package ident grammar (`[a-z][a-z0-9-]*`) — the
+//! one charset that is simultaneously iceoryx2-service-legal and
+//! Zenoh-keyexpr-legal — so the authoring model does not change when routing
+//! moves cross-node. This module is the single source of truth for that
+//! grammar; the SDK and the engine both validate through it rather than
+//! forking a parallel copy.
+//!
+//! The wire carries a channel name through a fixed-width `PortKey`
+//! ([`MAX_CHANNEL_NAME_BYTES`] bytes), so an over-length explicit name is a
+//! hard error and a generated name is hash-suffixed to stay in bound (never
+//! prefix-truncated, which would collide).
+
+use crate::error::{IdentError, IdentResult};
+use crate::ident::is_lower_alnum_or_hyphen;
+use std::fmt;
+
+/// Maximum channel-name length in UTF-8 bytes.
+///
+/// Pinned to the fixed `PortKey` wire capacity
+/// (`streamlib_ipc_types::PortKey::MAX_NAME_BYTES`). The engine holds a
+/// cross-crate assertion that the two constants agree — this crate has no
+/// `streamlib-ipc-types` dependency (that crate pulls in iceoryx2), so the
+/// bound is duplicated here as a plain constant and reconciled at the engine
+/// layer that depends on both.
+pub const MAX_CHANNEL_NAME_BYTES: usize = 63;
+
+/// Number of lowercase-hex characters in the deterministic disambiguating
+/// suffix appended when a generated channel name would overflow
+/// [`MAX_CHANNEL_NAME_BYTES`]. 12 hex chars = 48 bits of the name hash.
+const CHANNEL_NAME_HASH_SUFFIX_HEX_LEN: usize = 12;
+
+/// A validated channel name.
+///
+/// Constructed via [`ChannelName::new`] (validating an explicit user-supplied
+/// name) or [`connect_channel_name`] (deterministically generating the name
+/// `connect()` assigns to both ends of a link). Both paths guarantee the
+/// charset grammar and the [`MAX_CHANNEL_NAME_BYTES`] bound hold.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ChannelName(String);
+
+impl ChannelName {
+    /// Validate and wrap an explicit, user-supplied channel name.
+    ///
+    /// An over-length name is [`IdentError::ChannelNameTooLong`] — never
+    /// truncated. Charset violations surface as the matching named variant.
+    pub fn new(s: impl Into<String>) -> IdentResult<Self> {
+        let s = s.into();
+        validate_channel_name(&s)?;
+        Ok(Self(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for ChannelName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Validate a channel name against the canonical grammar
+/// (`[a-z][a-z0-9-]*`, at most [`MAX_CHANNEL_NAME_BYTES`] UTF-8 bytes).
+pub fn validate_channel_name(s: &str) -> IdentResult<()> {
+    if s.is_empty() {
+        return Err(IdentError::EmptyChannelName);
+    }
+    if s.len() > MAX_CHANNEL_NAME_BYTES {
+        return Err(IdentError::ChannelNameTooLong {
+            name: s.to_string(),
+            len: s.len(),
+            max: MAX_CHANNEL_NAME_BYTES,
+        });
+    }
+    let mut chars = s.chars();
+    let first = chars.next().expect("non-empty");
+    if !first.is_ascii_lowercase() {
+        return Err(IdentError::ChannelNameMustStartWithLowercase(s.to_string()));
+    }
+    for c in chars {
+        if !is_lower_alnum_or_hyphen(c) {
+            return Err(IdentError::InvalidChannelNameCharacter(s.to_string(), c));
+        }
+    }
+    Ok(())
+}
+
+/// Deterministically derive the channel name `connect()` assigns to both ends
+/// of a link: `{src_processor}-{src_output}--{dst_processor}-{dst_input}`.
+///
+/// The `--` double-hyphen separates the source `proc-port` pair from the
+/// destination pair; single hyphens join a processor to its port. All four
+/// inputs are already lowercase idents, so the joined form is grammar-legal by
+/// construction. If it overflows [`MAX_CHANNEL_NAME_BYTES`], the human-readable
+/// prefix is shortened and a stable hash of the *full* joined form is appended
+/// (`{prefix}-{hash}`) — a pure function of the inputs that stays unique rather
+/// than a prefix truncation that would collide two long links onto one channel.
+///
+/// The result is always a valid [`ChannelName`]; construction cannot fail.
+pub fn connect_channel_name(
+    src_processor: &str,
+    src_output: &str,
+    dst_processor: &str,
+    dst_input: &str,
+) -> ChannelName {
+    let joined = format!("{src_processor}-{src_output}--{dst_processor}-{dst_input}");
+    if joined.len() <= MAX_CHANNEL_NAME_BYTES {
+        return ChannelName(joined);
+    }
+
+    let hash = fnv1a_64(joined.as_bytes());
+    let suffix = format!("{hash:016x}");
+    let suffix = &suffix[suffix.len() - CHANNEL_NAME_HASH_SUFFIX_HEX_LEN..];
+
+    // Reserve room for the `-` joiner and the hex suffix, then keep as much of
+    // the human-readable prefix as fits on a UTF-8 char boundary.
+    let prefix_budget = MAX_CHANNEL_NAME_BYTES - 1 - CHANNEL_NAME_HASH_SUFFIX_HEX_LEN;
+    let mut cut = prefix_budget.min(joined.len());
+    while !joined.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    let prefix = &joined[..cut];
+    ChannelName(format!("{prefix}-{suffix}"))
+}
+
+/// FNV-1a 64-bit — a fixed, platform-stable hash so a regenerated channel name
+/// is byte-identical across builds and runtimes (`std`'s `DefaultHasher` is
+/// explicitly not stable across versions).
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    const OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+    const PRIME: u64 = 0x00000100000001b3;
+    let mut hash = OFFSET_BASIS;
+    for &b in bytes {
+        hash ^= b as u64;
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_canonical_names() {
+        for name in ["a", "camera-out", "cam-frame--sink-in", "a1-b2-c3"] {
+            validate_channel_name(name).unwrap_or_else(|e| panic!("{name}: {e}"));
+            assert_eq!(ChannelName::new(name).unwrap().as_str(), name);
+        }
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(matches!(
+            validate_channel_name(""),
+            Err(IdentError::EmptyChannelName)
+        ));
+    }
+
+    #[test]
+    fn rejects_uppercase_and_leading_non_alpha() {
+        assert!(matches!(
+            validate_channel_name("Camera"),
+            Err(IdentError::ChannelNameMustStartWithLowercase(_))
+        ));
+        assert!(matches!(
+            validate_channel_name("1cam"),
+            Err(IdentError::ChannelNameMustStartWithLowercase(_))
+        ));
+        assert!(matches!(
+            validate_channel_name("-cam"),
+            Err(IdentError::ChannelNameMustStartWithLowercase(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_illegal_charset() {
+        // Underscore, dot, slash — none are iceoryx2/keyexpr-safe.
+        for (name, bad) in [("cam_out", '_'), ("cam.out", '.'), ("cam/out", '/')] {
+            assert_eq!(
+                validate_channel_name(name),
+                Err(IdentError::InvalidChannelNameCharacter(name.to_string(), bad))
+            );
+        }
+    }
+
+    #[test]
+    fn double_hyphen_separator_is_grammar_legal() {
+        // The connect() separator `--` must pass — the charset allows runs of
+        // hyphens, which is what keeps the generated name a single valid ident.
+        validate_channel_name("src-out--dst-in").unwrap();
+    }
+
+    #[test]
+    fn explicit_over_length_name_is_a_hard_error_not_truncated() {
+        // Mental-revert guard for the whole grammar decision: an explicit
+        // user-supplied name past the wire bound must error, never truncate.
+        let long = "a".repeat(MAX_CHANNEL_NAME_BYTES + 1);
+        assert_eq!(long.len(), 64);
+        assert_eq!(
+            ChannelName::new(&long),
+            Err(IdentError::ChannelNameTooLong {
+                name: long.clone(),
+                len: 64,
+                max: MAX_CHANNEL_NAME_BYTES,
+            })
+        );
+    }
+
+    #[test]
+    fn exact_bound_name_is_accepted() {
+        let exact = "a".repeat(MAX_CHANNEL_NAME_BYTES);
+        assert_eq!(exact.len(), MAX_CHANNEL_NAME_BYTES);
+        assert!(ChannelName::new(&exact).is_ok());
+    }
+
+    #[test]
+    fn connect_name_is_deterministic() {
+        let a = connect_channel_name("cam", "frame", "sink", "in");
+        let b = connect_channel_name("cam", "frame", "sink", "in");
+        assert_eq!(a, b);
+        assert_eq!(a.as_str(), "cam-frame--sink-in");
+    }
+
+    #[test]
+    fn connect_name_is_a_valid_channel_name() {
+        let name = connect_channel_name("camera", "output", "encoder", "input");
+        validate_channel_name(name.as_str()).unwrap();
+    }
+
+    #[test]
+    fn connect_name_distinct_endpoints_are_unique() {
+        // Distinct links must land on distinct channels — the whole point of a
+        // per-link generated name.
+        let a = connect_channel_name("cam", "frame", "sink", "in");
+        let b = connect_channel_name("cam", "frame", "sink", "aux");
+        let c = connect_channel_name("cam", "alt", "sink", "in");
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(b, c);
+    }
+
+    #[test]
+    fn connect_name_over_bound_is_hash_suffixed_not_truncated() {
+        // Two links whose long human prefixes share the first 50 bytes must NOT
+        // collapse onto one channel — the hash suffix keeps them distinct while
+        // both stay inside the wire bound.
+        let long = "verylongprocessorname".repeat(3); // 63 bytes, > budget
+        let a = connect_channel_name(&long, "outputport", "downstreamsink", "inputport");
+        let b = connect_channel_name(&long, "outputport", "downstreamsink", "otherport");
+        assert!(a.as_str().len() <= MAX_CHANNEL_NAME_BYTES);
+        assert!(b.as_str().len() <= MAX_CHANNEL_NAME_BYTES);
+        validate_channel_name(a.as_str()).unwrap();
+        validate_channel_name(b.as_str()).unwrap();
+        assert_ne!(a, b, "hash suffix must disambiguate prefix-colliding links");
+        // Deterministic even on the hashed path.
+        assert_eq!(
+            a,
+            connect_channel_name(&long, "outputport", "downstreamsink", "inputport")
+        );
+    }
+}

--- a/sdk/streamlib-idents/src/channel.rs
+++ b/sdk/streamlib-idents/src/channel.rs
@@ -19,7 +19,7 @@
 //! prefix-truncated, which would collide).
 
 use crate::error::{IdentError, IdentResult};
-use crate::ident::is_lower_alnum_or_hyphen;
+use crate::ident::validate_lower_hyphen_grammar;
 use std::fmt;
 
 /// Maximum channel-name length in UTF-8 bytes.
@@ -57,10 +57,12 @@ impl ChannelName {
         Ok(Self(s))
     }
 
+    /// Borrow the validated channel name as a string slice.
     pub fn as_str(&self) -> &str {
         &self.0
     }
 
+    /// Consume the wrapper and return the owned validated channel name.
     pub fn into_string(self) -> String {
         self.0
     }
@@ -72,12 +74,23 @@ impl fmt::Display for ChannelName {
     }
 }
 
+/// Validate the channel charset grammar (`[a-z][a-z0-9-]*`) without the
+/// [`MAX_CHANNEL_NAME_BYTES`] length bound — the charset half shared by
+/// [`validate_channel_name`] and [`connect_channel_name`]'s pre-hash input
+/// guard (the joined form is length-legalized by hashing, so only its charset
+/// is checked up front).
+fn validate_channel_charset(s: &str) -> IdentResult<()> {
+    validate_lower_hyphen_grammar(
+        s,
+        || IdentError::EmptyChannelName,
+        |s| IdentError::ChannelNameMustStartWithLowercase(s.to_string()),
+        |s, c| IdentError::InvalidChannelNameCharacter(s.to_string(), c),
+    )
+}
+
 /// Validate a channel name against the canonical grammar
 /// (`[a-z][a-z0-9-]*`, at most [`MAX_CHANNEL_NAME_BYTES`] UTF-8 bytes).
 pub fn validate_channel_name(s: &str) -> IdentResult<()> {
-    if s.is_empty() {
-        return Err(IdentError::EmptyChannelName);
-    }
     if s.len() > MAX_CHANNEL_NAME_BYTES {
         return Err(IdentError::ChannelNameTooLong {
             name: s.to_string(),
@@ -85,40 +98,38 @@ pub fn validate_channel_name(s: &str) -> IdentResult<()> {
             max: MAX_CHANNEL_NAME_BYTES,
         });
     }
-    let mut chars = s.chars();
-    let first = chars.next().expect("non-empty");
-    if !first.is_ascii_lowercase() {
-        return Err(IdentError::ChannelNameMustStartWithLowercase(s.to_string()));
-    }
-    for c in chars {
-        if !is_lower_alnum_or_hyphen(c) {
-            return Err(IdentError::InvalidChannelNameCharacter(s.to_string(), c));
-        }
-    }
-    Ok(())
+    validate_channel_charset(s)
 }
 
 /// Deterministically derive the channel name `connect()` assigns to both ends
 /// of a link: `{src_processor}-{src_output}--{dst_processor}-{dst_input}`.
 ///
 /// The `--` double-hyphen separates the source `proc-port` pair from the
-/// destination pair; single hyphens join a processor to its port. All four
-/// inputs are already lowercase idents, so the joined form is grammar-legal by
-/// construction. If it overflows [`MAX_CHANNEL_NAME_BYTES`], the human-readable
-/// prefix is shortened and a stable hash of the *full* joined form is appended
+/// destination pair; single hyphens join a processor to its port. If the joined
+/// form overflows [`MAX_CHANNEL_NAME_BYTES`], the human-readable prefix is
+/// shortened and a stable hash of the *full* joined form is appended
 /// (`{prefix}-{hash}`) — a pure function of the inputs that stays unique rather
 /// than a prefix truncation that would collide two long links onto one channel.
 ///
-/// The result is always a valid [`ChannelName`]; construction cannot fail.
+/// The four inputs are not grammar-guaranteed: a port name may carry characters
+/// outside the channel charset (e.g. `video_in`), and a processor id need not be
+/// lowercase. Such an input would otherwise produce a silently-invalid wire
+/// name, so it surfaces here as the matching [`IdentError`] charset variant —
+/// the joined form (which carries every input character) is grammar-checked
+/// before the length-legalizing hash step.
 pub fn connect_channel_name(
     src_processor: &str,
     src_output: &str,
     dst_processor: &str,
     dst_input: &str,
-) -> ChannelName {
+) -> IdentResult<ChannelName> {
     let joined = format!("{src_processor}-{src_output}--{dst_processor}-{dst_input}");
+    validate_channel_charset(&joined)?;
+
     if joined.len() <= MAX_CHANNEL_NAME_BYTES {
-        return ChannelName(joined);
+        let name = ChannelName(joined);
+        debug_assert!(validate_channel_name(name.as_str()).is_ok());
+        return Ok(name);
     }
 
     let hash = fnv1a_64(joined.as_bytes());
@@ -133,7 +144,9 @@ pub fn connect_channel_name(
         cut -= 1;
     }
     let prefix = &joined[..cut];
-    ChannelName(format!("{prefix}-{suffix}"))
+    let name = ChannelName(format!("{prefix}-{suffix}"));
+    debug_assert!(validate_channel_name(name.as_str()).is_ok());
+    Ok(name)
 }
 
 /// FNV-1a 64-bit — a fixed, platform-stable hash so a regenerated channel name
@@ -229,15 +242,15 @@ mod tests {
 
     #[test]
     fn connect_name_is_deterministic() {
-        let a = connect_channel_name("cam", "frame", "sink", "in");
-        let b = connect_channel_name("cam", "frame", "sink", "in");
+        let a = connect_channel_name("cam", "frame", "sink", "in").unwrap();
+        let b = connect_channel_name("cam", "frame", "sink", "in").unwrap();
         assert_eq!(a, b);
         assert_eq!(a.as_str(), "cam-frame--sink-in");
     }
 
     #[test]
     fn connect_name_is_a_valid_channel_name() {
-        let name = connect_channel_name("camera", "output", "encoder", "input");
+        let name = connect_channel_name("camera", "output", "encoder", "input").unwrap();
         validate_channel_name(name.as_str()).unwrap();
     }
 
@@ -245,9 +258,9 @@ mod tests {
     fn connect_name_distinct_endpoints_are_unique() {
         // Distinct links must land on distinct channels — the whole point of a
         // per-link generated name.
-        let a = connect_channel_name("cam", "frame", "sink", "in");
-        let b = connect_channel_name("cam", "frame", "sink", "aux");
-        let c = connect_channel_name("cam", "alt", "sink", "in");
+        let a = connect_channel_name("cam", "frame", "sink", "in").unwrap();
+        let b = connect_channel_name("cam", "frame", "sink", "aux").unwrap();
+        let c = connect_channel_name("cam", "alt", "sink", "in").unwrap();
         assert_ne!(a, b);
         assert_ne!(a, c);
         assert_ne!(b, c);
@@ -259,8 +272,8 @@ mod tests {
         // collapse onto one channel — the hash suffix keeps them distinct while
         // both stay inside the wire bound.
         let long = "verylongprocessorname".repeat(3); // 63 bytes, > budget
-        let a = connect_channel_name(&long, "outputport", "downstreamsink", "inputport");
-        let b = connect_channel_name(&long, "outputport", "downstreamsink", "otherport");
+        let a = connect_channel_name(&long, "outputport", "downstreamsink", "inputport").unwrap();
+        let b = connect_channel_name(&long, "outputport", "downstreamsink", "otherport").unwrap();
         assert!(a.as_str().len() <= MAX_CHANNEL_NAME_BYTES);
         assert!(b.as_str().len() <= MAX_CHANNEL_NAME_BYTES);
         validate_channel_name(a.as_str()).unwrap();
@@ -269,7 +282,29 @@ mod tests {
         // Deterministic even on the hashed path.
         assert_eq!(
             a,
-            connect_channel_name(&long, "outputport", "downstreamsink", "inputport")
+            connect_channel_name(&long, "outputport", "downstreamsink", "inputport").unwrap()
         );
+    }
+
+    #[test]
+    fn connect_name_rejects_out_of_grammar_input() {
+        // A port name carrying an out-of-grammar char (underscore is legal for a
+        // port ident but not for the iceoryx2/keyexpr channel charset) must
+        // surface as a typed connect-time error, never a silently-invalid wire
+        // name. Mental-revert guard: without the input charset check the
+        // underscore would ride through into the emitted ChannelName.
+        assert_eq!(
+            connect_channel_name("cam", "video_in", "sink", "in"),
+            Err(IdentError::InvalidChannelNameCharacter(
+                "cam-video_in--sink-in".to_string(),
+                '_'
+            ))
+        );
+        // An uppercase (non-lowercase-leading) source processor id is likewise
+        // rejected rather than emitting a name iceoryx2 would refuse.
+        assert!(matches!(
+            connect_channel_name("Cam", "frame", "sink", "in"),
+            Err(IdentError::ChannelNameMustStartWithLowercase(_))
+        ));
     }
 }

--- a/sdk/streamlib-idents/src/channel.rs
+++ b/sdk/streamlib-idents/src/channel.rs
@@ -6,10 +6,12 @@
 //!
 //! A channel name is the same string in two roles: an iceoryx2 service name
 //! intra-node and (phase [L]) a Zenoh key-expression cross-node. Its charset
-//! reuses the canonical org/package ident grammar (`[a-z][a-z0-9-]*`) — the
-//! one charset that is simultaneously iceoryx2-service-legal and
-//! Zenoh-keyexpr-legal — so the authoring model does not change when routing
-//! moves cross-node. This module is the single source of truth for that
+//! is the lowercase-leading ident grammar plus `_` (`[a-z][a-z0-9_-]*`) — the
+//! org/package charset widened by underscore so port names like `video_in`
+//! (which `connect()` folds into the channel name) cross intact. Underscore is
+//! transport-legal: iceoryx2 `ServiceName` imposes no charset restriction
+//! beyond non-empty / length / no `iox2://` prefix, and a Zenoh keyexpr segment
+//! forbids only `/ * $ ? #`. This module is the single source of truth for that
 //! grammar; the SDK and the engine both validate through it rather than
 //! forking a parallel copy.
 //!
@@ -19,7 +21,7 @@
 //! prefix-truncated, which would collide).
 
 use crate::error::{IdentError, IdentResult};
-use crate::ident::validate_lower_hyphen_grammar;
+use crate::ident::{is_lower_alnum_hyphen_or_underscore, validate_lower_hyphen_grammar};
 use std::fmt;
 
 /// Maximum channel-name length in UTF-8 bytes.
@@ -74,14 +76,16 @@ impl fmt::Display for ChannelName {
     }
 }
 
-/// Validate the channel charset grammar (`[a-z][a-z0-9-]*`) without the
+/// Validate the channel charset grammar (`[a-z][a-z0-9_-]*`) without the
 /// [`MAX_CHANNEL_NAME_BYTES`] length bound — the charset half shared by
 /// [`validate_channel_name`] and [`connect_channel_name`]'s pre-hash input
 /// guard (the joined form is length-legalized by hashing, so only its charset
-/// is checked up front).
+/// is checked up front). Underscore is admitted here (but not for org/package)
+/// so a port name like `video_in` is a legal channel-name character.
 fn validate_channel_charset(s: &str) -> IdentResult<()> {
     validate_lower_hyphen_grammar(
         s,
+        is_lower_alnum_hyphen_or_underscore,
         || IdentError::EmptyChannelName,
         |s| IdentError::ChannelNameMustStartWithLowercase(s.to_string()),
         |s, c| IdentError::InvalidChannelNameCharacter(s.to_string(), c),
@@ -89,7 +93,7 @@ fn validate_channel_charset(s: &str) -> IdentResult<()> {
 }
 
 /// Validate a channel name against the canonical grammar
-/// (`[a-z][a-z0-9-]*`, at most [`MAX_CHANNEL_NAME_BYTES`] UTF-8 bytes).
+/// (`[a-z][a-z0-9_-]*`, at most [`MAX_CHANNEL_NAME_BYTES`] UTF-8 bytes).
 pub fn validate_channel_name(s: &str) -> IdentResult<()> {
     if s.len() > MAX_CHANNEL_NAME_BYTES {
         return Err(IdentError::ChannelNameTooLong {
@@ -111,12 +115,13 @@ pub fn validate_channel_name(s: &str) -> IdentResult<()> {
 /// (`{prefix}-{hash}`) — a pure function of the inputs that stays unique rather
 /// than a prefix truncation that would collide two long links onto one channel.
 ///
-/// The four inputs are not grammar-guaranteed: a port name may carry characters
-/// outside the channel charset (e.g. `video_in`), and a processor id need not be
-/// lowercase. Such an input would otherwise produce a silently-invalid wire
-/// name, so it surfaces here as the matching [`IdentError`] charset variant —
-/// the joined form (which carries every input character) is grammar-checked
-/// before the length-legalizing hash step.
+/// The four inputs are not grammar-guaranteed: a port name may carry a genuinely
+/// illegal character (uppercase, `/`, `.`, whitespace), or a processor id need
+/// not be lowercase. Such an input would otherwise produce a silently-invalid
+/// wire name, so it surfaces here as the matching [`IdentError`] charset variant
+/// — the joined form (which carries every input character) is grammar-checked
+/// before the length-legalizing hash step. Underscore is a legal channel
+/// character, so a port like `video_in` rides through with no error.
 pub fn connect_channel_name(
     src_processor: &str,
     src_output: &str,
@@ -201,12 +206,26 @@ mod tests {
 
     #[test]
     fn rejects_illegal_charset() {
-        // Underscore, dot, slash — none are iceoryx2/keyexpr-safe.
-        for (name, bad) in [("cam_out", '_'), ("cam.out", '.'), ("cam/out", '/')] {
+        // Dot, slash, space — none are iceoryx2/keyexpr-safe. Underscore is NOT
+        // in this list: it is transport-legal and admitted into the channel
+        // charset (see `underscore_is_legal_for_channels`).
+        for (name, bad) in [("cam.out", '.'), ("cam/out", '/'), ("cam out", ' ')] {
             assert_eq!(
                 validate_channel_name(name),
                 Err(IdentError::InvalidChannelNameCharacter(name.to_string(), bad))
             );
+        }
+    }
+
+    #[test]
+    fn underscore_is_legal_for_channels() {
+        // Underscore is transport-legal (iceoryx2 ServiceName has no charset
+        // restriction; a Zenoh keyexpr segment forbids only `/ * $ ? #`), so a
+        // shipped underscore port name is a valid channel name. Mental-revert
+        // guard: narrow the channel charset back to `[a-z0-9-]` and this fails.
+        for name in ["video_in", "video_out", "encoded_jpeg_in", "cam_frame--sink_in"] {
+            validate_channel_name(name).unwrap_or_else(|e| panic!("{name}: {e}"));
+            assert_eq!(ChannelName::new(name).unwrap().as_str(), name);
         }
     }
 
@@ -287,17 +306,29 @@ mod tests {
     }
 
     #[test]
+    fn connect_name_accepts_underscore_ports() {
+        // Shipped port names carry underscores (`video_in`, `video_out`, …).
+        // `connect()` folds them into the channel name, so an underscore port
+        // must yield a VALID ChannelName with NO error — a silent fallback here
+        // would break every shipped underscore port. Mental-revert guard:
+        // narrow the channel charset back to `[a-z0-9-]` and this errors.
+        let name = connect_channel_name("cam", "video_out", "sink", "video_in").unwrap();
+        assert_eq!(name.as_str(), "cam-video_out--sink-video_in");
+        validate_channel_name(name.as_str()).unwrap();
+    }
+
+    #[test]
     fn connect_name_rejects_out_of_grammar_input() {
-        // A port name carrying an out-of-grammar char (underscore is legal for a
-        // port ident but not for the iceoryx2/keyexpr channel charset) must
-        // surface as a typed connect-time error, never a silently-invalid wire
-        // name. Mental-revert guard: without the input charset check the
-        // underscore would ride through into the emitted ChannelName.
+        // A port name carrying a genuinely-illegal char (`/` is not
+        // iceoryx2/keyexpr-safe) must surface as a typed connect-time error,
+        // never a silently-invalid wire name. Mental-revert guard: without the
+        // input charset check the slash would ride through into the emitted
+        // ChannelName.
         assert_eq!(
-            connect_channel_name("cam", "video_in", "sink", "in"),
+            connect_channel_name("cam", "video/in", "sink", "in"),
             Err(IdentError::InvalidChannelNameCharacter(
-                "cam-video_in--sink-in".to_string(),
-                '_'
+                "cam-video/in--sink-in".to_string(),
+                '/'
             ))
         );
         // An uppercase (non-lowercase-leading) source processor id is likewise

--- a/sdk/streamlib-idents/src/error.rs
+++ b/sdk/streamlib-idents/src/error.rs
@@ -41,6 +41,24 @@ pub enum IdentError {
     #[error("type `{0}` must start with A-Z (PascalCase)")]
     TypeMustStartWithUppercase(String),
 
+    #[error("channel name is empty")]
+    EmptyChannelName,
+
+    #[error(
+        "channel `{0}` contains invalid character `{1}` (allowed: a-z, 0-9, hyphen, must start with a-z)"
+    )]
+    InvalidChannelNameCharacter(String, char),
+
+    #[error("channel `{0}` must start with a-z")]
+    ChannelNameMustStartWithLowercase(String),
+
+    #[error("channel `{name}` is {len} bytes, exceeding the {max}-byte wire capacity")]
+    ChannelNameTooLong {
+        name: String,
+        len: usize,
+        max: usize,
+    },
+
     #[error("invalid semver `{0}`: {1}")]
     InvalidSemVer(String, String),
 

--- a/sdk/streamlib-idents/src/ident.rs
+++ b/sdk/streamlib-idents/src/ident.rs
@@ -495,40 +495,51 @@ pub(crate) fn parse_module_ident_wire(raw: &str) -> IdentResult<ModuleIdent> {
     Ok(ModuleIdent { org, name, version })
 }
 
-/// Validate an org segment per the grammar: `[a-z][a-z0-9-]*`.
-pub fn validate_org(s: &str) -> IdentResult<()> {
+/// Validate a segment against the shared lowercase-hyphen grammar
+/// (`[a-z][a-z0-9-]*`): non-empty, first char `[a-z]`, remaining chars
+/// `[a-z0-9-]`. The three `on_*` selectors map each failure to the caller's
+/// segment-specific [`IdentError`] variant so org / package / channel names
+/// keep distinct messages while sharing one grammar loop.
+pub(crate) fn validate_lower_hyphen_grammar(
+    s: &str,
+    on_empty: fn() -> IdentError,
+    on_first_not_lowercase: fn(&str) -> IdentError,
+    on_invalid_char: fn(&str, char) -> IdentError,
+) -> IdentResult<()> {
     if s.is_empty() {
-        return Err(IdentError::EmptyOrg);
+        return Err(on_empty());
     }
     let mut chars = s.chars();
     let first = chars.next().expect("non-empty");
     if !first.is_ascii_lowercase() {
-        return Err(IdentError::OrgMustStartWithLowercase(s.to_string()));
+        return Err(on_first_not_lowercase(s));
     }
     for c in chars {
         if !is_lower_alnum_or_hyphen(c) {
-            return Err(IdentError::InvalidOrgCharacter(s.to_string(), c));
+            return Err(on_invalid_char(s, c));
         }
     }
     Ok(())
 }
 
+/// Validate an org segment per the grammar: `[a-z][a-z0-9-]*`.
+pub fn validate_org(s: &str) -> IdentResult<()> {
+    validate_lower_hyphen_grammar(
+        s,
+        || IdentError::EmptyOrg,
+        |s| IdentError::OrgMustStartWithLowercase(s.to_string()),
+        |s, c| IdentError::InvalidOrgCharacter(s.to_string(), c),
+    )
+}
+
 /// Validate a package segment per the grammar: `[a-z][a-z0-9-]*`.
 pub fn validate_package(s: &str) -> IdentResult<()> {
-    if s.is_empty() {
-        return Err(IdentError::EmptyPackage);
-    }
-    let mut chars = s.chars();
-    let first = chars.next().expect("non-empty");
-    if !first.is_ascii_lowercase() {
-        return Err(IdentError::PackageMustStartWithLowercase(s.to_string()));
-    }
-    for c in chars {
-        if !is_lower_alnum_or_hyphen(c) {
-            return Err(IdentError::InvalidPackageCharacter(s.to_string(), c));
-        }
-    }
-    Ok(())
+    validate_lower_hyphen_grammar(
+        s,
+        || IdentError::EmptyPackage,
+        |s| IdentError::PackageMustStartWithLowercase(s.to_string()),
+        |s, c| IdentError::InvalidPackageCharacter(s.to_string(), c),
+    )
 }
 
 /// Validate a type segment per the grammar: `[A-Z][A-Za-z0-9]*` (PascalCase).

--- a/sdk/streamlib-idents/src/ident.rs
+++ b/sdk/streamlib-idents/src/ident.rs
@@ -549,7 +549,7 @@ pub fn validate_type(s: &str) -> IdentResult<()> {
     Ok(())
 }
 
-fn is_lower_alnum_or_hyphen(c: char) -> bool {
+pub(crate) fn is_lower_alnum_or_hyphen(c: char) -> bool {
     matches!(c, 'a'..='z' | '0'..='9' | '-')
 }
 

--- a/sdk/streamlib-idents/src/ident.rs
+++ b/sdk/streamlib-idents/src/ident.rs
@@ -495,13 +495,16 @@ pub(crate) fn parse_module_ident_wire(raw: &str) -> IdentResult<ModuleIdent> {
     Ok(ModuleIdent { org, name, version })
 }
 
-/// Validate a segment against the shared lowercase-hyphen grammar
-/// (`[a-z][a-z0-9-]*`): non-empty, first char `[a-z]`, remaining chars
-/// `[a-z0-9-]`. The three `on_*` selectors map each failure to the caller's
-/// segment-specific [`IdentError`] variant so org / package / channel names
-/// keep distinct messages while sharing one grammar loop.
+/// Validate a segment against the shared lowercase-leading grammar: non-empty,
+/// first char `[a-z]`, remaining chars accepted by `char_allowed`. The charset
+/// predicate is supplied by the caller so org / package keep the
+/// no-underscore charset (`[a-z][a-z0-9-]*`) while channel / port names admit
+/// `_` (`[a-z][a-z0-9_-]*`). The three `on_*` selectors map each failure to the
+/// caller's segment-specific [`IdentError`] variant so the segments keep
+/// distinct messages while sharing one grammar loop.
 pub(crate) fn validate_lower_hyphen_grammar(
     s: &str,
+    char_allowed: fn(char) -> bool,
     on_empty: fn() -> IdentError,
     on_first_not_lowercase: fn(&str) -> IdentError,
     on_invalid_char: fn(&str, char) -> IdentError,
@@ -515,7 +518,7 @@ pub(crate) fn validate_lower_hyphen_grammar(
         return Err(on_first_not_lowercase(s));
     }
     for c in chars {
-        if !is_lower_alnum_or_hyphen(c) {
+        if !char_allowed(c) {
             return Err(on_invalid_char(s, c));
         }
     }
@@ -526,6 +529,7 @@ pub(crate) fn validate_lower_hyphen_grammar(
 pub fn validate_org(s: &str) -> IdentResult<()> {
     validate_lower_hyphen_grammar(
         s,
+        is_lower_alnum_or_hyphen,
         || IdentError::EmptyOrg,
         |s| IdentError::OrgMustStartWithLowercase(s.to_string()),
         |s, c| IdentError::InvalidOrgCharacter(s.to_string(), c),
@@ -536,6 +540,7 @@ pub fn validate_org(s: &str) -> IdentResult<()> {
 pub fn validate_package(s: &str) -> IdentResult<()> {
     validate_lower_hyphen_grammar(
         s,
+        is_lower_alnum_or_hyphen,
         || IdentError::EmptyPackage,
         |s| IdentError::PackageMustStartWithLowercase(s.to_string()),
         |s, c| IdentError::InvalidPackageCharacter(s.to_string(), c),
@@ -562,6 +567,15 @@ pub fn validate_type(s: &str) -> IdentResult<()> {
 
 pub(crate) fn is_lower_alnum_or_hyphen(c: char) -> bool {
     matches!(c, 'a'..='z' | '0'..='9' | '-')
+}
+
+/// Channel / port charset predicate: the org/package charset plus `_`
+/// (`[a-z0-9_-]`). Underscore is transport-legal — iceoryx2 `ServiceName`
+/// imposes no charset restriction beyond non-empty / length / no `iox2://`
+/// prefix, and a Zenoh keyexpr segment forbids only `/ * $ ? #` — so port
+/// names like `video_in` cross the wire intact.
+pub(crate) fn is_lower_alnum_hyphen_or_underscore(c: char) -> bool {
+    matches!(c, 'a'..='z' | '0'..='9' | '-' | '_')
 }
 
 fn ident_string_schema(description: &str, pattern: &str) -> Schema {

--- a/sdk/streamlib-idents/src/lib.rs
+++ b/sdk/streamlib-idents/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod app_modules;
 pub mod archive;
 mod catalog;
+mod channel;
 mod error;
 mod git;
 mod ident;
@@ -29,6 +30,9 @@ pub use catalog::{
     parse_catalog_index_ndjson, render_catalog_index_ndjson, schema_jtd_file_name,
 };
 
+pub use channel::{
+    ChannelName, MAX_CHANNEL_NAME_BYTES, connect_channel_name, validate_channel_name,
+};
 pub use error::{IdentError, IdentResult, ResolverError, ResolverResult};
 pub use git::fetch_git;
 pub use ident::{

--- a/sdk/streamlib-python-native/src/lib.rs
+++ b/sdk/streamlib-python-native/src/lib.rs
@@ -848,13 +848,25 @@ pub unsafe extern "C" fn slpn_output_write(
 
     let total_len = FRAME_HEADER_SIZE + data_slice.len();
     let mut frame = vec![0u8; total_len];
-    FrameHeader::new(
+    let header = match FrameHeader::new(
         &state.dest_port,
         state.schema_ident,
         timestamp_ns,
         data_slice.len() as u32,
-    )
-    .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
+    ) {
+        Ok(h) => h,
+        Err(e) => {
+            tracing::error!(
+                "[slpn:{}] Invalid dest port '{}' for output port '{}': {}",
+                ctx.processor_id,
+                state.dest_port,
+                port_name,
+                e
+            );
+            return -1;
+        }
+    };
+    header.write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
     frame[FRAME_HEADER_SIZE..].copy_from_slice(data_slice);
 
     let sample = match state.publisher.loan_slice_uninit(total_len) {

--- a/sdk/streamlib-python/python/streamlib/frame_payload.py
+++ b/sdk/streamlib-python/python/streamlib/frame_payload.py
@@ -36,9 +36,17 @@ class PortKey(ctypes.Structure):
 
     @staticmethod
     def from_str(s: str) -> "PortKey":
+        # Mirrors Rust `PortKey::new` (#1416): an over-length name is a hard
+        # error, never a silent truncation that would route frames to a
+        # different (clipped) port than the one the author named.
         key = PortKey()
         data = s.encode("utf-8")
-        key.len = min(len(data), MAX_PORT_KEY_SIZE - 1)
+        if len(data) > MAX_PORT_KEY_SIZE - 1:
+            raise ValueError(
+                f"port key name is {len(data)} bytes, exceeding the fixed wire "
+                f"capacity of {MAX_PORT_KEY_SIZE - 1} bytes"
+            )
+        key.len = len(data)
         ctypes.memmove(key.name, data, key.len)
         return key
 

--- a/sdk/streamlib-python/python/streamlib/tests/test_port_key.py
+++ b/sdk/streamlib-python/python/streamlib/tests/test_port_key.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Regression tests for `PortKey.from_str` over-length handling (#1416).
+
+The Rust `PortKey::new` and this Python ctypes mirror both refuse a port /
+channel name longer than the fixed wire capacity instead of silently
+truncating it. A clipped name used to route frames to a different (shorter)
+port than the one the author named — a silent cross-wiring defect.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from streamlib.frame_payload import MAX_PORT_KEY_SIZE, PortKey
+
+MAX_NAME_BYTES = MAX_PORT_KEY_SIZE - 1
+
+
+def test_port_key_accepts_max_length_name():
+    name = "a" * MAX_NAME_BYTES
+    key = PortKey.from_str(name)
+    assert key.as_str() == name
+
+
+def test_port_key_rejects_over_length_name_instead_of_truncating():
+    # Mental-revert guard: restore the old `min(len(data), 63)` truncation and
+    # this fails — `from_str` would succeed and `as_str()` would return the
+    # clipped 63-byte prefix rather than raising.
+    over = "b" * (MAX_NAME_BYTES + 1)
+    assert len(over.encode("utf-8")) == 64
+    with pytest.raises(ValueError, match="exceeding the fixed wire capacity"):
+        PortKey.from_str(over)


### PR DESCRIPTION
Closes #1416 (on the ratified scope — see #1416 for the design brief + scope reconciliation).

## The load-bearing win: fix the wire-key silent-truncation bug
`PortKey::new` (and `FrameHeader::new` / `FramePayload::new`) silently **truncated** any port/channel name past 63 bytes (`.min(MAX_PORT_KEY_SIZE - 1)`), routing frames to a *different clipped port* than the author named. This PR makes the constructors **fallible** (`Err(TooLong{len,max})`), deletes the truncation, and sweeps every caller across Rust, the Python-native + Deno-native wire builders, and the pure-Python ctypes mirror (raises `ValueError`). Bug-reproduce-first: reverting to the `.min()` clip fails `port_key_rejects_over_length_name_instead_of_truncating`. ABI byte layout is unchanged (only return types became fallible) — layout regression tests stay green.

## Channel-naming grammar + generator (per the ratified design)
- `ChannelName` newtype with one canonical validator (shared `validate_lower_hyphen_grammar` in `ident.rs`, parameterized by charset — org/package stay `[a-z][a-z0-9-]*`, channel/port admit `_` → `[a-z][a-z0-9_-]*`). `_` was confirmed legal in both transports (iceoryx2 0.8.1 `ServiceName` imposes no charset restriction; Zenoh keyexprs forbid only `/ * $ ? #`), per the owner's ratified "admit `_`" decision.
- Deterministic `connect()` channel-name generator: human-readable `{src}-{out}--{dst}-{in}`, `--` separator, hash-suffixed (never truncated) when over the 63-byte wire bound.
- `connect_channel_name` is fallible and enforces the grammar (rejects genuinely-illegal input — uppercase, `/`, whitespace — as a connect-time `Error::InvalidLink`), with a `debug_assert` on the invariant.

## Scope (ratified) — deferred to phase-2 #36 / K#1419
The channel-**service** consumption is out of scope for #1416: the generated name is not yet stored on the graph edge / consumed by the engine to assign one iceoryx2 service. Deferred to K#1419 (channel-centric services): port-model wiring, explicit publish/subscribe-by-name authoring, and graph-compile collision reject for explicit names. `TopicKey::new` (same truncation defect on the 128-byte event wire) is a tracked followup.

## Gates
Local battery: **30 passed, 0 failed** (idents/ipc-types/engine cross-crate + Python pytest, xtask lint suite, license, boundaries). Two verify fix rounds applied (validator-invariant enforcement + grammar DRY; then the `_`-admission correction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
