### PR TITLE
feat(polyglot): manifest extraction inversion — decorator is the truth-source, not sibling streamlib.yaml

### DIFF
--- a/docs/decisions/manifest-extraction-capability.md
+++ b/docs/decisions/manifest-extraction-capability.md
@@ -46,11 +46,13 @@ per-language extractor imports every top-level module beside the
 decorator no longer validates its short name against a hand-authored
 `processors:` list — the decorator *is* that list.
 
-The extractors run in a fresh subprocess (`python -m
+The extractors are designed to run in a fresh subprocess (`python -m
 streamlib.extract_processors <dir>` / `deno run --allow-read
 extract_processors.ts <dir>`) so the registry starts empty; the in-process
-entrypoints clear the registry themselves. Output is sorted by joined
-schema-ident string for determinism regardless of import order.
+entrypoints clear the registry themselves. Once the pkg-build truth-flip lands,
+`pkg build` will invoke them on that path; today they ship as the standalone
+capability. Output is sorted by joined schema-ident string for determinism
+regardless of import order.
 
 The import-runs-code property is the cost of the inversion: a processor module
 whose third-party imports are unavailable cannot be enumerated, whereas the

--- a/docs/decisions/manifest-extraction-capability.md
+++ b/docs/decisions/manifest-extraction-capability.md
@@ -32,6 +32,35 @@ for an external one — the same way it already projects a bare `Named` ref
 through the `schemas:` map. A `-dev.N` package projects to its release-core
 version at build time; that is a build-time projection, not a publish gate.
 
+## Polyglot analogue: extraction is import
+
+The same "code is the truth-source" decision holds for the Python and Deno
+SDKs, but the mechanism inverts to fit each runtime. A `syn` AST scan reads
+Rust source without running it; Python and Deno have no comparable
+parse-without-run path for decorator semantics, so **extraction is import**:
+applying `@processor(...)` at import time registers the processor's structured
+identity into a process-global registry (`_processor_registry`), and the
+per-language extractor imports every top-level module beside the
+`streamlib.yaml` and enumerates what registered. Only the package identity
+(`package: { org, name, version }`) is still read from `streamlib.yaml`; the
+decorator no longer validates its short name against a hand-authored
+`processors:` list — the decorator *is* that list.
+
+The extractors run in a fresh subprocess (`python -m
+streamlib.extract_processors <dir>` / `deno run --allow-read
+extract_processors.ts <dir>`) so the registry starts empty; the in-process
+entrypoints clear the registry themselves. Output is sorted by joined
+schema-ident string for determinism regardless of import order.
+
+The import-runs-code property is the cost of the inversion: a processor module
+whose third-party imports are unavailable cannot be enumerated, whereas the
+Rust AST scan is inert. Extraction therefore assumes the package's dependencies
+are installed — true at `pkg build` time, unlike the Rust `src/` walk. Full
+per-processor manifest fields (execution mode, entrypoint, ports) still come
+from `streamlib.yaml` for Python/Deno until ports-in-code lands for those
+runtimes; today's extractor supplies the processor identity set and declared
+port schemas, which is what the decorator carries.
+
 ## Rejected alternatives
 
 - **Grammar in the proc-macro crate.** A `proc-macro = true` crate can only

--- a/sdk/streamlib-deno/_manifest.ts
+++ b/sdk/streamlib-deno/_manifest.ts
@@ -4,14 +4,17 @@
 /**
  * Decorator-side reader for `streamlib.yaml` package metadata.
  *
- * Reads only the shape needed by the `@processor` decorator:
+ * Reads only the top-level `package: { org, name, version, ... }` block — the
+ * package identity the `@processor` decorator needs to compose a structured
+ * `SchemaIdent`.
  *
- * - top-level `package: { org, name, version, ... }` block
- * - top-level `processors:` list, returning the `name` of each entry
+ * The `processors:` list is NOT read here: the decorator is the truth-source
+ * for which processors a package declares (extraction is import — see
+ * `extract_processors.ts`). Only the package identity lives in the manifest;
+ * the processor set is derived from `@processor` usage in code.
  *
- * The full manifest is parsed by the Rust runtime via `serde_yaml` when
- * the host loads it; this reader only needs enough fields to validate
- * the decorator's short name and compose a structured `SchemaIdent`.
+ * The full manifest is parsed by the Rust runtime via `serde_yaml` when the
+ * host loads it; this reader only needs the package identity fields.
  *
  * Uses the npm `yaml` parser (declared as a registry dependency) rather
  * than a `jsr:` import: the SDK is published to npm via `deno pack`, and
@@ -30,12 +33,6 @@ export interface ManifestPackage {
   readonly version: string;
 }
 
-/** Decorator-side view of a streamlib.yaml. */
-export interface ManifestSummary {
-  readonly package: ManifestPackage;
-  readonly processorNames: readonly string[];
-}
-
 /** Raised when a streamlib.yaml cannot be parsed for decorator use. */
 export class ManifestParseError extends Error {
   constructor(message: string) {
@@ -45,14 +42,13 @@ export class ManifestParseError extends Error {
 }
 
 /**
- * Parse the `package:` block + `processors[].name` list from a
- * streamlib.yaml at `path`.
+ * Parse the `package:` block from a streamlib.yaml at `path`.
  *
  * Throws `Deno.errors.NotFound` if the file does not exist, and
  * `ManifestParseError` if the manifest is missing `package:`, missing
  * any of `org`/`name`/`version`, or otherwise malformed.
  */
-export function readManifestSummary(path: string): ManifestSummary {
+export function readPackageBlock(path: string): ManifestPackage {
   let text: string;
   try {
     text = Deno.readTextFileSync(path);
@@ -109,25 +105,9 @@ export function readManifestSummary(path: string): ManifestSummary {
     );
   }
 
-  const processorNames: string[] = [];
-  const procsRaw = root["processors"];
-  if (Array.isArray(procsRaw)) {
-    for (const entry of procsRaw) {
-      if (entry !== null && typeof entry === "object" && !Array.isArray(entry)) {
-        const entryName = (entry as Record<string, unknown>)["name"];
-        if (typeof entryName === "string" && entryName.length > 0) {
-          processorNames.push(entryName);
-        }
-      }
-    }
-  }
-
   return {
-    package: {
-      org: org as string,
-      name: name as string,
-      version: version as string,
-    },
-    processorNames,
+    org: org as string,
+    name: name as string,
+    version: version as string,
   };
 }

--- a/sdk/streamlib-deno/_processor_registry.ts
+++ b/sdk/streamlib-deno/_processor_registry.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Module-level registry the `@processor` decorator appends to.
+ *
+ * The decorator is the manifest truth-source: applying `@processor(...)` at
+ * import time registers the processor's structured identity here, so a
+ * downstream extractor can enumerate a package's processors by *importing* its
+ * modules and reading this registry — never by trusting a hand-authored
+ * `processors:` list in `streamlib.yaml`. This is the Deno analogue of the
+ * Rust `syn` source-scan in `sdk/streamlib-processor-extract` and Python's
+ * `_processor_registry`; there the scan reads the AST without running it, here
+ * extraction *is* import.
+ *
+ * The registry is module-global and append-only during a normal import. An
+ * extractor that wants a package's processors in isolation calls
+ * {@linkcode clearRegisteredProcessors} before importing that package's
+ * modules.
+ *
+ * @module
+ */
+
+import type { SchemaIdent } from "./schema_ident.ts";
+import type { PortMetadata } from "./decorators.ts";
+
+/**
+ * One processor derived from a `@processor(...)` decorator at import time.
+ *
+ * Mirrors Rust's `streamlib_processor_extract::ExtractedProcessor` and
+ * Python's `RegisteredProcessor`.
+ */
+export interface RegisteredProcessor {
+  readonly shortName: string;
+  readonly schemaIdent: SchemaIdent;
+  readonly inputs: readonly PortMetadata[];
+  readonly outputs: readonly PortMetadata[];
+  readonly className: string;
+}
+
+const registeredProcessors: RegisteredProcessor[] = [];
+
+/** Append a decorator-derived processor to the module-global registry. */
+export function registerProcessor(entry: RegisteredProcessor): void {
+  registeredProcessors.push(entry);
+}
+
+/** Snapshot the processors registered so far, in registration order. */
+export function getRegisteredProcessors(): readonly RegisteredProcessor[] {
+  return registeredProcessors.slice();
+}
+
+/**
+ * Empty the registry.
+ *
+ * Used by the import-and-enumerate extractor to isolate one package's
+ * processors from anything already imported in the same process.
+ */
+export function clearRegisteredProcessors(): void {
+  registeredProcessors.length = 0;
+}

--- a/sdk/streamlib-deno/decorators.ts
+++ b/sdk/streamlib-deno/decorators.ts
@@ -6,11 +6,20 @@
  *
  * `@processor("PascalCase", import.meta.url)` mirrors Rust's
  * `#[streamlib::processor("Camera")]` proc-macro and Python's
- * `@processor("Camera")`: a positional PascalCase short name resolved
- * against the sibling `streamlib.yaml`'s `package: { org, name, version }`
- * block at decoration time. The result is a structured
- * {@linkcode SchemaIdent} attached to the class as
- * `streamlibSchemaIdent`.
+ * `@processor("Camera")`: a positional PascalCase short name. The decorator
+ * reads the package identity (`package: { org, name, version }`) from the
+ * sibling `streamlib.yaml`, composes a structured {@linkcode SchemaIdent}
+ * attached to the class as `streamlibSchemaIdent`, and registers the
+ * processor in the module-global registry (`_processor_registry.ts`).
+ *
+ * The decorator is the manifest truth-source for the `processors:` set: a
+ * package's processors are derived by *importing* its modules and enumerating
+ * what `@processor` registered — never by reading a hand-authored
+ * `processors:` list. This is the Deno analogue of the Rust `syn` source-scan
+ * in `sdk/streamlib-processor-extract` (there the scan reads the AST without
+ * running it; here extraction is import). Only the package identity comes from
+ * `streamlib.yaml`; the processor set comes from code. See
+ * `extract_processors.ts`.
  *
  * Deno has no `inspect.getfile` equivalent — TC39 stage-3 decorators
  * don't surface the source URL in the decorator context. The caller
@@ -47,10 +56,11 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
-  type ManifestSummary,
+  type ManifestPackage,
   ManifestParseError,
-  readManifestSummary,
+  readPackageBlock,
 } from "./_manifest.ts";
+import { registerProcessor } from "./_processor_registry.ts";
 import { SchemaIdent } from "./schema_ident.ts";
 
 // =============================================================================
@@ -107,16 +117,17 @@ type ClassConstructor = new (...args: any[]) => any;
  *
  * Mirrors Rust's `#[streamlib::processor("Camera")]` macro and Python's
  * `@processor("Camera")`. At decoration time, the decorator locates the
- * sibling `streamlib.yaml` (next to the file containing
- * `import.meta.url`), reads its `package: { org, name, version }` block,
- * validates that `shortName` appears in the manifest's `processors:`
- * list, and constructs a structured {@linkcode SchemaIdent} attached to
- * the class as `streamlibSchemaIdent`. Method-level port metadata
- * declared by {@linkcode input}/{@linkcode output} is collected onto
- * `streamlibPorts`.
+ * sibling `streamlib.yaml` (next to the file containing `import.meta.url`),
+ * reads its `package: { org, name, version }` block for the package identity,
+ * constructs a structured {@linkcode SchemaIdent} attached to the class as
+ * `streamlibSchemaIdent`, and registers the processor so the
+ * import-and-enumerate extractor can derive the package's `processors:` set
+ * from code. Method-level port metadata declared by
+ * {@linkcode input}/{@linkcode output} is collected onto `streamlibPorts`.
+ * `shortName` is NOT validated against a `processors:` list — the decorator IS
+ * that list.
  *
- * @param shortName PascalCase type name. Must match an entry in the
- *   sibling manifest's `processors:` list.
+ * @param shortName PascalCase type name — the processor's identity.
  * @param moduleUrl Pass `import.meta.url` from the file containing the
  *   decorated class. Required because Deno's TC39 decorator context
  *   does not expose the source URL.
@@ -156,18 +167,7 @@ export function processor(shortName: string, moduleUrl: string) {
     _context: ClassDecoratorContext,
   ): T => {
     const manifestPath = locateSiblingManifest(moduleUrl, shortName);
-    const summary = loadManifestSummary(manifestPath, shortName);
-
-    if (!summary.processorNames.includes(shortName)) {
-      const available = summary.processorNames.length > 0
-        ? summary.processorNames.join("\n    ")
-        : "(none declared)";
-      throw new Error(
-        `@processor(${JSON.stringify(shortName)}): short name not declared ` +
-          `in ${manifestPath}'s \`processors:\` list. Available processors:\n    ` +
-          `${available}`,
-      );
-    }
+    const pkg = loadPackageBlock(manifestPath, shortName);
 
     // Schema idents are release-only by invariant: a package may carry a
     // `-dev.N` / `-rc.N` prerelease version, but its schema idents project
@@ -175,10 +175,10 @@ export function processor(shortName: string, moduleUrl: string) {
     // 3-part `SchemaIdent` validator would otherwise reject a legitimately
     // dev-versioned package's processors.
     const ident = new SchemaIdent(
-      summary.package.org,
-      summary.package.name,
+      pkg.org,
+      pkg.name,
       shortName,
-      releaseCore(summary.package.version),
+      releaseCore(pkg.version),
     );
 
     // Attach as static fields. Mirrors Python's
@@ -211,6 +211,14 @@ export function processor(shortName: string, moduleUrl: string) {
       writable: false,
       enumerable: true,
       configurable: false,
+    });
+
+    registerProcessor({
+      shortName,
+      schemaIdent: ident,
+      inputs: Object.freeze(inputs.slice()),
+      outputs: Object.freeze(outputs.slice()),
+      className: target.name,
     });
 
     return target;
@@ -325,19 +333,18 @@ function locateSiblingManifest(
   return join(dirname(filePath), "streamlib.yaml");
 }
 
-function loadManifestSummary(
+function loadPackageBlock(
   manifestPath: string,
   shortName: string,
-): ManifestSummary {
+): ManifestPackage {
   try {
-    return readManifestSummary(manifestPath);
+    return readPackageBlock(manifestPath);
   } catch (e) {
     if (e instanceof Deno.errors.NotFound) {
       throw new Error(
         `streamlib.yaml not found at ${manifestPath}. ` +
           `@processor(${JSON.stringify(shortName)}) requires a sibling ` +
-          `streamlib.yaml with a \`package: { org, name, version }\` block ` +
-          `and a matching \`processors:\` entry.`,
+          `streamlib.yaml with a \`package: { org, name, version }\` block.`,
       );
     }
     if (e instanceof ManifestParseError) {

--- a/sdk/streamlib-deno/decorators_test.ts
+++ b/sdk/streamlib-deno/decorators_test.ts
@@ -288,7 +288,10 @@ Deno.test("@processor errors with expected path when manifest missing", async ()
   }
 });
 
-Deno.test("@processor short-name not in manifest lists available", async () => {
+Deno.test("@processor short name need not appear in manifest processors list", async () => {
+  // The decorator is the truth-source: a short name is minted straight from
+  // the package identity regardless of any `processors:` list the manifest
+  // happens to carry. (The list is no longer read at all.)
   const fixture = await makeFixture(
     [
       "package:",
@@ -297,26 +300,19 @@ Deno.test("@processor short-name not in manifest lists available", async () => {
       "  version: 0.1.0",
       "",
       "processors:",
-      "  - name: Camera",
-      "  - name: Display",
+      "  - name: SomethingElse",
       "",
     ].join("\n"),
     moduleHeader() +
-      `@processor("MissingProcessor", import.meta.url)\n` +
-      `export default class MissingProcessor {}\n`,
+      `@processor("NotInTheYamlList", import.meta.url)\n` +
+      `export default class NotInTheYamlList {}\n`,
   );
   try {
-    let caught: unknown = null;
-    try {
-      await import(`file://${fixture.modulePath}`);
-    } catch (e) {
-      caught = e;
-    }
-    assert(caught instanceof Error);
-    const msg = (caught as Error).message;
-    assert(msg.includes("Available processors"), msg);
-    assert(msg.includes("Camera"), msg);
-    assert(msg.includes("Display"), msg);
+    const mod = await import(`file://${fixture.modulePath}`);
+    const cls = mod.default as unknown as StreamlibClassMetadata;
+    const ident = cls.streamlibSchemaIdent;
+    assertEquals(ident.type, "NotInTheYamlList");
+    assertEquals(String(ident), "@tatolab/example/NotInTheYamlList@0.1.0");
   } finally {
     await Deno.remove(fixture.dir, { recursive: true });
   }

--- a/sdk/streamlib-deno/extract_processors.ts
+++ b/sdk/streamlib-deno/extract_processors.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
+// streamlib:lint-logging:allow-file — pkg-build subprocess CLI; emits the manifest JSON on stdout and usage/errors on stderr with no log pipeline installed
 
 /**
  * Import-and-enumerate processor extractor for a Deno package directory.

--- a/sdk/streamlib-deno/extract_processors.ts
+++ b/sdk/streamlib-deno/extract_processors.ts
@@ -13,13 +13,14 @@
  * decorators, which register into `_processor_registry.ts`; the registered set
  * is then emitted.
  *
- * `streamlib pkg build` invokes this in a fresh subprocess
- * (`deno run --allow-read <this> <package_dir>`), reads the JSON on stdout, and
- * writes the manifest `processors:` section — the same shape the Rust extractor
- * feeds the catalog. Running in a fresh process guarantees an empty registry to
- * start; the in-process {@linkcode extractProcessorsFromDir} entrypoint clears
- * the registry itself so it is safe to call repeatedly (over distinct dirs —
- * Deno caches dynamic imports by URL).
+ * Once the pkg-build truth-flip lands, `streamlib pkg build` will invoke this in
+ * a fresh subprocess (`deno run --allow-read <this> <package_dir>`), read the
+ * JSON on stdout, and write the manifest `processors:` section — the same shape
+ * the Rust extractor feeds the catalog. Running in a fresh process guarantees an
+ * empty registry to start; the in-process {@linkcode extractProcessorsFromDir}
+ * entrypoint clears the registry and forces a fresh module evaluation per call,
+ * so repeated calls (including over the same dir) stay isolated despite Deno
+ * caching dynamic imports by URL.
  *
  * Discovery matches the Rust scan's `collect_rs_files` + sort: every top-level
  * `*.ts` beside the `streamlib.yaml`, imported in sorted filename order (test
@@ -45,12 +46,15 @@ export class ProcessorExtractionError extends Error {
   }
 }
 
+let extractionGeneration = 0;
+
 /**
  * Import every top-level module under `packageDir` and enumerate processors.
  *
  * Returns the processors registered by `@processor` during import, sorted by
- * joined schema-ident string. The registry is cleared first, so repeated calls
- * over distinct directories in one process are isolated.
+ * joined schema-ident string. The registry is cleared first and every module is
+ * re-evaluated under a per-call generation token, so repeated calls in one
+ * process — including repeated calls over the same directory — are isolated.
  *
  * Throws {@linkcode ProcessorExtractionError} if `packageDir` is not a
  * directory.
@@ -83,9 +87,16 @@ export async function extractProcessorsFromDir(
   tsFiles.sort();
 
   clearRegisteredProcessors();
+  // Deno caches dynamic imports by URL, so a second call over the same dir
+  // would re-import nothing and re-run no `@processor` decorators. Append a
+  // per-call generation token to the module URL so each extraction forces a
+  // fresh evaluation of the top-level module and re-registers its processors.
+  // Sibling relative imports (the SDK, the shared registry) drop the query and
+  // resolve to their canonical URLs, so the registry stays a single instance.
+  const generation = ++extractionGeneration;
   for (const name of tsFiles) {
     const href = toFileUrl(join(packageDir, name)).href;
-    await import(href);
+    await import(`${href}?streamlib_extract=${generation}`);
   }
 
   const procs = getRegisteredProcessors().slice();

--- a/sdk/streamlib-deno/extract_processors.ts
+++ b/sdk/streamlib-deno/extract_processors.ts
@@ -100,7 +100,9 @@ export async function extractProcessorsFromDir(
   }
 
   const procs = getRegisteredProcessors().slice();
-  procs.sort((a, b) => String(a.schemaIdent).localeCompare(String(b.schemaIdent)));
+  procs.sort((a, b) =>
+    String(a.schemaIdent).localeCompare(String(b.schemaIdent))
+  );
   return procs;
 }
 

--- a/sdk/streamlib-deno/extract_processors.ts
+++ b/sdk/streamlib-deno/extract_processors.ts
@@ -1,0 +1,135 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Import-and-enumerate processor extractor for a Deno package directory.
+ *
+ * The Deno analogue of Rust's `streamlib_processor_extract` and Python's
+ * `streamlib.extract_processors`: derive a package's `processors:` manifest
+ * section from code rather than a hand-authored list. Where the Rust
+ * capability parses source without running it, here extraction *is* import —
+ * every top-level module is dynamic-imported, which runs the `@processor`
+ * decorators, which register into `_processor_registry.ts`; the registered set
+ * is then emitted.
+ *
+ * `streamlib pkg build` invokes this in a fresh subprocess
+ * (`deno run --allow-read <this> <package_dir>`), reads the JSON on stdout, and
+ * writes the manifest `processors:` section — the same shape the Rust extractor
+ * feeds the catalog. Running in a fresh process guarantees an empty registry to
+ * start; the in-process {@linkcode extractProcessorsFromDir} entrypoint clears
+ * the registry itself so it is safe to call repeatedly (over distinct dirs —
+ * Deno caches dynamic imports by URL).
+ *
+ * Discovery matches the Rust scan's `collect_rs_files` + sort: every top-level
+ * `*.ts` beside the `streamlib.yaml`, imported in sorted filename order (test
+ * files are skipped). The emitted list is sorted by joined schema-ident string
+ * so output is deterministic regardless of import order.
+ *
+ * @module
+ */
+
+import { join, toFileUrl } from "@std/path";
+
+import {
+  clearRegisteredProcessors,
+  getRegisteredProcessors,
+  type RegisteredProcessor,
+} from "./_processor_registry.ts";
+
+/** Raised when a package directory cannot be scanned for processors. */
+export class ProcessorExtractionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProcessorExtractionError";
+  }
+}
+
+/**
+ * Import every top-level module under `packageDir` and enumerate processors.
+ *
+ * Returns the processors registered by `@processor` during import, sorted by
+ * joined schema-ident string. The registry is cleared first, so repeated calls
+ * over distinct directories in one process are isolated.
+ *
+ * Throws {@linkcode ProcessorExtractionError} if `packageDir` is not a
+ * directory.
+ */
+export async function extractProcessorsFromDir(
+  packageDir: string,
+): Promise<readonly RegisteredProcessor[]> {
+  let stat: Deno.FileInfo;
+  try {
+    stat = Deno.statSync(packageDir);
+  } catch {
+    throw new ProcessorExtractionError(
+      `not a directory: ${packageDir} — nothing to scan for processors`,
+    );
+  }
+  if (!stat.isDirectory) {
+    throw new ProcessorExtractionError(
+      `not a directory: ${packageDir} — nothing to scan for processors`,
+    );
+  }
+
+  const tsFiles: string[] = [];
+  for (const entry of Deno.readDirSync(packageDir)) {
+    if (!entry.isFile) continue;
+    const name = entry.name;
+    if (!name.endsWith(".ts")) continue;
+    if (name.endsWith("_test.ts") || name.endsWith(".d.ts")) continue;
+    tsFiles.push(name);
+  }
+  tsFiles.sort();
+
+  clearRegisteredProcessors();
+  for (const name of tsFiles) {
+    const href = toFileUrl(join(packageDir, name)).href;
+    await import(href);
+  }
+
+  const procs = getRegisteredProcessors().slice();
+  procs.sort((a, b) => String(a.schemaIdent).localeCompare(String(b.schemaIdent)));
+  return procs;
+}
+
+/** Render extracted processors as the JSON `pkg build` consumes on stdout. */
+export function toManifestJson(procs: readonly RegisteredProcessor[]): string {
+  const payload = procs.map((entry) => ({
+    name: entry.shortName,
+    schema_ident: entry.schemaIdent.toWireObject(),
+    inputs: entry.inputs.map((port) => ({
+      name: port.name,
+      schema: port.schema === null ? null : port.schema.toWireObject(),
+      description: port.description,
+    })),
+    outputs: entry.outputs.map((port) => ({
+      name: port.name,
+      schema: port.schema === null ? null : port.schema.toWireObject(),
+      description: port.description,
+    })),
+  }));
+  return JSON.stringify(payload, null, 2);
+}
+
+/** CLI entrypoint: `deno run --allow-read extract_processors.ts <package_dir>`. */
+export async function main(args: string[]): Promise<number> {
+  if (args.length !== 1) {
+    console.error(
+      "usage: deno run --allow-read extract_processors.ts <package_dir>",
+    );
+    return 2;
+  }
+  let procs: readonly RegisteredProcessor[];
+  try {
+    procs = await extractProcessorsFromDir(args[0]);
+  } catch (e) {
+    console.error(e instanceof Error ? e.message : String(e));
+    return 1;
+  }
+  console.log(toManifestJson(procs));
+  return 0;
+}
+
+if (import.meta.main) {
+  Deno.exit(await main(Deno.args));
+}

--- a/sdk/streamlib-deno/extract_processors_test.ts
+++ b/sdk/streamlib-deno/extract_processors_test.ts
@@ -1,0 +1,138 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Golden-extraction tests for the import-and-enumerate processor extractor.
+ *
+ * Mirrors the Python `test_processor_extraction.py` and Rust
+ * `golden_extraction_over_a_fixture_crate` shape: a fixture package with
+ * several processors across several modules (plus a non-processor module that
+ * must be ignored), extracted by importing and enumerating the registry rather
+ * than reading the manifest's `processors:` list.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path";
+
+import {
+  extractProcessorsFromDir,
+  toManifestJson,
+} from "./extract_processors.ts";
+import { SchemaIdent } from "./schema_ident.ts";
+
+function moduleHeader(): string {
+  const decoratorsUrl = new URL("./decorators.ts", import.meta.url).href;
+  const schemaIdentUrl = new URL("./schema_ident.ts", import.meta.url).href;
+  return (
+    `import { input, output, processor } from "${decoratorsUrl}";\n` +
+    `import { SchemaIdent } from "${schemaIdentUrl}";\n`
+  );
+}
+
+async function makeFixturePackage(): Promise<string> {
+  const dir = await Deno.makeTempDir({ prefix: "streamlib-extract-" });
+  await Deno.writeTextFile(
+    join(dir, "streamlib.yaml"),
+    [
+      "package:",
+      "  org: tatolab",
+      "  name: demo-pack",
+      "  version: 0.2.0",
+      "",
+    ].join("\n"),
+  );
+  await Deno.writeTextFile(
+    join(dir, "blur.ts"),
+    moduleHeader() +
+      `const VIDEO = new SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0");\n` +
+      `@processor("Blur", import.meta.url)\n` +
+      `export default class Blur {\n` +
+      `  @input({ name: "frames_in", schema: VIDEO })\n` +
+      `  handleIn() {}\n` +
+      `  @output({ name: "frames_out", schema: VIDEO })\n` +
+      `  handleOut() {}\n` +
+      `}\n`,
+  );
+  await Deno.writeTextFile(
+    join(dir, "camera.ts"),
+    moduleHeader() +
+      `@processor("Camera", import.meta.url)\n` +
+      `export default class Camera {}\n`,
+  );
+  await Deno.writeTextFile(
+    join(dir, "not_a_processor.ts"),
+    `export class JustAHelper {}\n`,
+  );
+  return dir;
+}
+
+Deno.test("golden extraction over a fixture package", async () => {
+  const dir = await makeFixturePackage();
+  try {
+    const procs = await extractProcessorsFromDir(dir);
+    const names = procs.map((p) => p.shortName);
+    // Deterministic: sorted by joined schema-ident string.
+    assertEquals(names, ["Blur", "Camera"]);
+
+    const blur = procs.find((p) => p.shortName === "Blur")!;
+    assert(blur.schemaIdent instanceof SchemaIdent);
+    assertEquals(String(blur.schemaIdent), "@tatolab/demo-pack/Blur@0.2.0");
+    assertEquals(blur.inputs.map((port) => port.name), ["frames_in"]);
+    assertEquals(blur.outputs.map((port) => port.name), ["frames_out"]);
+    assertEquals(blur.inputs[0].schema!.type, "VideoFrame");
+
+    const camera = procs.find((p) => p.shortName === "Camera")!;
+    assertEquals(String(camera.schemaIdent), "@tatolab/demo-pack/Camera@0.2.0");
+    assertEquals(camera.inputs.length, 0);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("extractor emits manifest JSON pkg build consumes", async () => {
+  const dir = await makeFixturePackage();
+  try {
+    const procs = await extractProcessorsFromDir(dir);
+    const payload = JSON.parse(toManifestJson(procs)) as Array<{
+      name: string;
+      schema_ident: Record<string, string>;
+      inputs: Array<{ name: string; schema: Record<string, string> | null }>;
+    }>;
+    assertEquals(payload.map((e) => e.name), ["Blur", "Camera"]);
+    const blur = payload.find((e) => e.name === "Blur")!;
+    assertEquals(blur.schema_ident, {
+      org: "tatolab",
+      package: "demo-pack",
+      type: "Blur",
+      version: "0.2.0",
+    });
+    assertEquals(blur.inputs[0].name, "frames_in");
+    assertEquals(blur.inputs[0].schema!.type, "VideoFrame");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("schema-only package yields no processors", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "streamlib-extract-" });
+  try {
+    await Deno.writeTextFile(
+      join(dir, "streamlib.yaml"),
+      [
+        "package:",
+        "  org: tatolab",
+        "  name: schema-only",
+        "  version: 1.0.0",
+        "",
+      ].join("\n"),
+    );
+    await Deno.writeTextFile(
+      join(dir, "types.ts"),
+      `export class JustAType {}\n`,
+    );
+    const procs = await extractProcessorsFromDir(dir);
+    assertEquals(procs.length, 0);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/sdk/streamlib-deno/extract_processors_test.ts
+++ b/sdk/streamlib-deno/extract_processors_test.ts
@@ -120,7 +120,9 @@ Deno.test("repeated calls over the same dir are isolated", async () => {
   const dir = await makeFixturePackage();
   try {
     const first = (await extractProcessorsFromDir(dir)).map((p) => p.shortName);
-    const second = (await extractProcessorsFromDir(dir)).map((p) => p.shortName);
+    const second = (await extractProcessorsFromDir(dir)).map((p) =>
+      p.shortName
+    );
     assertEquals(first, ["Blur", "Camera"]);
     assertEquals(second, first);
   } finally {

--- a/sdk/streamlib-deno/extract_processors_test.ts
+++ b/sdk/streamlib-deno/extract_processors_test.ts
@@ -113,6 +113,21 @@ Deno.test("extractor emits manifest JSON pkg build consumes", async () => {
   }
 });
 
+Deno.test("repeated calls over the same dir are isolated", async () => {
+  // Deno caches dynamic imports by URL: without forced re-evaluation the
+  // second extraction over the same dir would re-run no decorators and return
+  // []. The extractor must re-register per call and yield the same set.
+  const dir = await makeFixturePackage();
+  try {
+    const first = (await extractProcessorsFromDir(dir)).map((p) => p.shortName);
+    const second = (await extractProcessorsFromDir(dir)).map((p) => p.shortName);
+    assertEquals(first, ["Blur", "Camera"]);
+    assertEquals(second, first);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
 Deno.test("schema-only package yields no processors", async () => {
   const dir = await Deno.makeTempDir({ prefix: "streamlib-extract-" });
   try {

--- a/sdk/streamlib-python/python/streamlib/_manifest.py
+++ b/sdk/streamlib-python/python/streamlib/_manifest.py
@@ -3,28 +3,31 @@
 
 """Minimal hand-rolled YAML reader for `streamlib.yaml` package metadata.
 
-Reads only the shape needed by the `@processor` decorator:
+Reads only the top-level `package: { org, name, version, ... }` block — the
+package identity the `@processor` decorator needs to compose a structured
+[`SchemaIdent`][streamlib.schema_ident.SchemaIdent].
 
-- top-level `package: { org, name, version, ... }` block
-- top-level `processors:` list, returning the `name` of each entry
+The `processors:` list is NOT read here: the decorator is the truth-source
+for which processors a package declares (extraction is import — see
+[`streamlib.extract_processors`][]). Only the package identity lives in the
+manifest; the processor set is derived from `@processor` usage in code.
 
 A full YAML parser would require PyYAML, which would be the SDK's first
-runtime dep. The streamlib.yaml shape is constrained enough that a focused
-line-oriented reader suffices: 2-space indented mappings, sequence items
-prefixed by `-`, comments, blank lines, optional single/double quotes
-around scalars. Anything more complex (anchors, multi-line strings, flow
-style outside `{ a: b }`) is out of scope for this reader.
+runtime dep. The `package:` block shape is constrained enough that a focused
+line-oriented reader suffices: 2-space indented mappings, comments, blank
+lines, optional single/double quotes around scalars. Anything more complex
+(anchors, multi-line strings, flow style outside `{ a: b }`) is out of scope
+for this reader.
 
 The full manifest is parsed by the Rust runtime via `serde_yaml` when the
-host loads it; this reader only needs enough fields to validate the
-decorator's short name and compose a structured `SchemaIdent`.
+host loads it; this reader only needs the package identity fields.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 
 @dataclass(frozen=True)
@@ -36,36 +39,23 @@ class ManifestPackage:
     version: str
 
 
-@dataclass(frozen=True)
-class ManifestSummary:
-    """Decorator-side view of a streamlib.yaml.
-
-    Carries the package metadata and the set of processor names declared
-    in the manifest — enough for the decorator to validate that its
-    short-name argument matches an entry the manifest declares.
-    """
-
-    package: ManifestPackage
-    processor_names: List[str]
-
-
 class ManifestParseError(ValueError):
     """Raised when a streamlib.yaml cannot be parsed for decorator use."""
 
 
-def read_manifest_summary(path: Path) -> ManifestSummary:
-    """Parse the package block + processors[].name list from a streamlib.yaml.
+def read_package_block(path: Path) -> ManifestPackage:
+    """Parse the `package:` block from a streamlib.yaml.
 
     Raises:
         FileNotFoundError: if `path` does not exist.
-        ManifestParseError: if the manifest is missing `package:`, missing
+        ManifestParseError: if the manifest is missing `package:`, or missing
             any of `org`/`name`/`version`, or malformed.
     """
     if not path.exists():
         raise FileNotFoundError(str(path))
 
     text = path.read_text(encoding="utf-8")
-    org, name, version, processor_names = _scan(text, path)
+    org, name, version = _scan_package(text)
 
     missing = [field for field, val in (("org", org), ("name", name), ("version", version)) if val is None]
     if missing:
@@ -75,21 +65,15 @@ def read_manifest_summary(path: Path) -> ManifestSummary:
             f"to construct a structured SchemaIdent."
         )
 
-    return ManifestSummary(
-        package=ManifestPackage(org=org, name=name, version=version),
-        processor_names=processor_names,
-    )
+    return ManifestPackage(org=org, name=name, version=version)
 
 
-def _scan(
-    text: str, path: Path
-) -> Tuple[Optional[str], Optional[str], Optional[str], List[str]]:
+def _scan_package(text: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:
     org: Optional[str] = None
     name: Optional[str] = None
     version: Optional[str] = None
-    processor_names: List[str] = []
 
-    section: Optional[str] = None  # "package" | "processors" | None
+    in_package = False
 
     for raw in text.splitlines():
         line = _strip_comment(raw).rstrip()
@@ -100,15 +84,10 @@ def _scan(
         content = line.lstrip()
 
         if indent == 0:
-            if content.rstrip(":") == "package" and content.endswith(":"):
-                section = "package"
-            elif content.rstrip(":") == "processors" and content.endswith(":"):
-                section = "processors"
-            else:
-                section = None
+            in_package = content.rstrip(":") == "package" and content.endswith(":")
             continue
 
-        if section == "package" and indent == 2 and ":" in content:
+        if in_package and indent == 2 and ":" in content:
             key, _, val = content.partition(":")
             key = key.strip()
             val = _strip_quotes(val.strip())
@@ -119,23 +98,7 @@ def _scan(
             elif key == "version":
                 version = val
 
-        elif section == "processors" and indent == 2 and content.startswith("- "):
-            # Sequence item start. We assume `name:` is the first key per the
-            # repo convention; if a future manifest reorders, extend this.
-            rest = content[2:].lstrip()
-            if rest.startswith("name:"):
-                _, _, val = rest.partition(":")
-                val = _strip_quotes(val.strip())
-                if val:
-                    processor_names.append(val)
-            else:
-                raise ManifestParseError(
-                    f"streamlib.yaml at {path} has a processor entry whose first "
-                    f"key is not `name:` — the decorator's manifest reader only "
-                    f"supports `name`-first ordering. Got: {content!r}"
-                )
-
-    return org, name, version, processor_names
+    return org, name, version
 
 
 def _strip_quotes(s: str) -> str:

--- a/sdk/streamlib-python/python/streamlib/_processor_registry.py
+++ b/sdk/streamlib-python/python/streamlib/_processor_registry.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Module-level registry the `@processor` decorator appends to.
+
+The decorator is the manifest truth-source: applying `@processor(...)` at
+import time registers the processor's structured identity here, so a
+downstream extractor can enumerate a package's processors by *importing* its
+modules and reading this registry — never by trusting a hand-authored
+`processors:` list in `streamlib.yaml`. This is the Python analogue of the
+Rust `syn` source-scan in `sdk/streamlib-processor-extract`; there the scan
+reads the AST without running it, here extraction *is* import.
+
+The registry is process-global and append-only during a normal import. An
+extractor that wants a package's processors in isolation calls
+[`clear_registered_processors`][] before importing that package's modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+from .schema_ident import SchemaIdent
+
+
+@dataclass(frozen=True)
+class RegisteredProcessor:
+    """One processor derived from a `@processor(...)` decorator at import time.
+
+    Mirrors Rust's `streamlib_processor_extract::ExtractedProcessor`: the
+    structured identity the manifest/`.slpkg` assembly consumes, plus the
+    port metadata declared by `@input` / `@output` and the class it was
+    written on (for diagnostics).
+    """
+
+    short_name: str
+    schema_ident: SchemaIdent
+    inputs: Tuple[dict, ...] = field(default=())
+    outputs: Tuple[dict, ...] = field(default=())
+    class_qualname: str = ""
+
+
+_REGISTERED_PROCESSORS: List[RegisteredProcessor] = []
+
+
+def register_processor(entry: RegisteredProcessor) -> None:
+    """Append a decorator-derived processor to the process-global registry."""
+    _REGISTERED_PROCESSORS.append(entry)
+
+
+def registered_processors() -> Tuple[RegisteredProcessor, ...]:
+    """Snapshot the processors registered so far, in registration order."""
+    return tuple(_REGISTERED_PROCESSORS)
+
+
+def clear_registered_processors() -> None:
+    """Empty the registry.
+
+    Used by the import-and-enumerate extractor to isolate one package's
+    processors from anything already imported in the same process.
+    """
+    _REGISTERED_PROCESSORS.clear()

--- a/sdk/streamlib-python/python/streamlib/decorators.py
+++ b/sdk/streamlib-python/python/streamlib/decorators.py
@@ -4,11 +4,21 @@
 """Decorators for defining StreamLib processors in Python.
 
 `@processor("PascalCase")` mirrors Rust's `#[streamlib::processor("Camera")]`
-proc-macro: a positional PascalCase short name that the decorator resolves
-against the sibling `streamlib.yaml`'s `package: { org, name, version }`
-block at decoration time. The result is a structured
-[`SchemaIdent`][streamlib.schema_ident.SchemaIdent] attached to the class
-as `__streamlib_schema_ident__`.
+proc-macro: a positional PascalCase short name. The decorator reads the
+package identity (`package: { org, name, version }`) from the sibling
+`streamlib.yaml`, composes a structured
+[`SchemaIdent`][streamlib.schema_ident.SchemaIdent] attached to the class as
+`__streamlib_schema_ident__`, and registers the processor in the
+process-global [`_processor_registry`][streamlib._processor_registry].
+
+The decorator is the manifest truth-source for the `processors:` set: a
+package's processors are derived by *importing* its modules and enumerating
+what `@processor` registered — never by reading a hand-authored `processors:`
+list. This is the Python analogue of the Rust `syn` source-scan in
+`sdk/streamlib-processor-extract` (there the scan reads the AST without
+running it; here extraction is import). Only the package identity comes from
+`streamlib.yaml`; the processor set comes from code. See
+[`streamlib.extract_processors`][].
 
 Schema references in port declarations (`@input(schema=...)` /
 `@output(schema=...)`) are cross-package by definition. The only accepted
@@ -47,7 +57,8 @@ import re
 from pathlib import Path
 from typing import Optional, Pattern, Type, Union
 
-from ._manifest import ManifestParseError, read_manifest_summary
+from ._manifest import ManifestParseError, read_package_block
+from ._processor_registry import RegisteredProcessor, register_processor
 from .schema_ident import SchemaIdent
 
 
@@ -62,20 +73,21 @@ def processor(short_name: str):
     Mirrors Rust's `#[streamlib::processor("Camera")]` macro. At decoration
     time, the decorator locates the sibling `streamlib.yaml` (next to the
     file containing the decorated class), reads its
-    `package: { org, name, version }` block, validates that `short_name`
-    appears in the manifest's `processors:` list, and constructs a
-    structured `SchemaIdent` attached to the class as
-    `__streamlib_schema_ident__`.
+    `package: { org, name, version }` block for the package identity,
+    constructs a structured `SchemaIdent` attached to the class as
+    `__streamlib_schema_ident__`, and registers the processor in the
+    process-global registry so the import-and-enumerate extractor can derive
+    the package's `processors:` set from code. The `short_name` is NOT
+    validated against a `processors:` list in the manifest — the decorator IS
+    that list.
 
     Args:
-        short_name: PascalCase type name. Must match an entry in the
-            sibling manifest's `processors:` list.
+        short_name: PascalCase type name — the processor's identity.
 
     Raises:
         FileNotFoundError: if no sibling `streamlib.yaml` is found.
         ManifestParseError: if the manifest is malformed or missing
             required `package:` fields.
-        ValueError: if `short_name` is not declared in the manifest.
 
     Example:
         ```python
@@ -102,24 +114,15 @@ def processor(short_name: str):
     def decorator(cls):
         manifest_path = _locate_sibling_manifest(cls)
         try:
-            summary = read_manifest_summary(manifest_path)
+            package = read_package_block(manifest_path)
         except ManifestParseError:
             raise
         except FileNotFoundError as exc:
             raise FileNotFoundError(
                 f"streamlib.yaml not found at {manifest_path}. "
                 f"@processor({short_name!r}) requires a sibling streamlib.yaml "
-                f"with a `package: {{ org, name, version }}` block and a matching "
-                f"`processors:` entry."
+                f"with a `package: {{ org, name, version }}` block."
             ) from exc
-
-        if short_name not in summary.processor_names:
-            available = "\n    ".join(summary.processor_names) or "(none declared)"
-            raise ValueError(
-                f"@processor({short_name!r}): short name not declared in "
-                f"{manifest_path}'s `processors:` list. Available processors:\n    "
-                f"{available}"
-            )
 
         # Schema idents are release-only by invariant: a package may carry a
         # `-dev.N` / `-rc.N` prerelease version, but its schema idents project
@@ -127,10 +130,10 @@ def processor(short_name: str):
         # 3-part `SchemaIdent` validator would otherwise reject a legitimately
         # dev-versioned package's processors.
         ident = SchemaIdent(
-            org=summary.package.org,
-            package=summary.package.name,
+            org=package.org,
+            package=package.name,
             type_=short_name,
-            version=_release_core(summary.package.version),
+            version=_release_core(package.version),
         )
         cls.__streamlib_schema_ident__ = ident
 
@@ -147,6 +150,16 @@ def processor(short_name: str):
                 if hasattr(attr, "_streamlib_output_port"):
                     outputs.append(attr._streamlib_output_port)
         cls.__streamlib_ports__ = {"inputs": inputs, "outputs": outputs}
+
+        register_processor(
+            RegisteredProcessor(
+                short_name=short_name,
+                schema_ident=ident,
+                inputs=tuple(inputs),
+                outputs=tuple(outputs),
+                class_qualname=getattr(cls, "__qualname__", cls.__name__),
+            )
+        )
 
         return cls
 

--- a/sdk/streamlib-python/python/streamlib/extract_processors.py
+++ b/sdk/streamlib-python/python/streamlib/extract_processors.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
+# streamlib:lint-logging:allow-file — pkg-build subprocess CLI; emits the manifest JSON on stdout and usage/errors on stderr with no log pipeline installed
 
 """Import-and-enumerate processor extractor for a Python package directory.
 

--- a/sdk/streamlib-python/python/streamlib/extract_processors.py
+++ b/sdk/streamlib-python/python/streamlib/extract_processors.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Import-and-enumerate processor extractor for a Python package directory.
+
+The Python analogue of Rust's `streamlib_processor_extract`: derive a
+package's `processors:` manifest section from code rather than a hand-authored
+list. Where the Rust capability parses source without running it, here
+extraction *is* import — every top-level module is imported, which runs the
+`@processor` decorators, which register into
+[`_processor_registry`][streamlib._processor_registry]; the registered set is
+then emitted.
+
+`streamlib pkg build` invokes this in a fresh subprocess
+(`python -m streamlib.extract_processors <package_dir>`), reads the JSON on
+stdout, and writes the manifest `processors:` section — the same shape the
+Rust extractor feeds the catalog. Running in a fresh process guarantees an
+empty registry to start; the in-process [`extract_processors_from_dir`][]
+entrypoint clears the registry itself so it is safe to call repeatedly.
+
+Discovery matches the Rust scan's `collect_rs_files` + sort: every top-level
+`*.py` beside the `streamlib.yaml`, imported in sorted filename order. Modules
+are deduplicated through `sys.modules`, so a processor imported transitively
+by an earlier module registers exactly once. The emitted list is sorted by
+joined schema-ident string so output is deterministic regardless of import
+order.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import List
+
+from ._processor_registry import (
+    RegisteredProcessor,
+    clear_registered_processors,
+    registered_processors,
+)
+
+
+class ProcessorExtractionError(RuntimeError):
+    """Raised when a package directory cannot be scanned for processors."""
+
+
+def extract_processors_from_dir(package_dir: Path) -> List[RegisteredProcessor]:
+    """Import every top-level module under `package_dir` and enumerate processors.
+
+    Returns the processors registered by `@processor` during import, sorted by
+    joined schema-ident string. The registry is cleared first, so repeated
+    calls in one process are isolated. `sys.modules` and `sys.path` are
+    restored on exit.
+
+    Raises:
+        ProcessorExtractionError: if `package_dir` is not a directory.
+    """
+    package_dir = package_dir.resolve()
+    if not package_dir.is_dir():
+        raise ProcessorExtractionError(
+            f"not a directory: {package_dir} — nothing to scan for processors"
+        )
+
+    py_files = sorted(
+        p
+        for p in package_dir.glob("*.py")
+        if p.is_file() and p.name != "__init__.py"
+    )
+    module_names = [p.stem for p in py_files]
+
+    clear_registered_processors()
+
+    # Force a fresh import of every target module: stash any pre-existing
+    # `sys.modules` entry so a transitive import inside the loop can't collide
+    # with (or be shadowed by) a stale module of the same name, then restore
+    # on exit. Deduplication is left to the import machinery — a module
+    # imported transitively by an earlier file is cached and not re-run.
+    stashed = {name: sys.modules.pop(name, None) for name in module_names}
+    sys.path.insert(0, str(package_dir))
+    try:
+        for name in module_names:
+            importlib.import_module(name)
+        procs = list(registered_processors())
+    finally:
+        sys.path.remove(str(package_dir))
+        for name in module_names:
+            sys.modules.pop(name, None)
+        for name, prev in stashed.items():
+            if prev is not None:
+                sys.modules[name] = prev
+
+    procs.sort(key=lambda entry: str(entry.schema_ident))
+    return procs
+
+
+def _to_manifest_json(procs: List[RegisteredProcessor]) -> str:
+    """Render extracted processors as the JSON `pkg build` consumes on stdout."""
+    payload = [
+        {
+            "name": entry.short_name,
+            "schema_ident": entry.schema_ident.to_wire_dict(),
+            "inputs": [
+                {
+                    "name": port["name"],
+                    "schema": (
+                        port["schema"].to_wire_dict()
+                        if port["schema"] is not None
+                        else None
+                    ),
+                    "description": port["description"],
+                }
+                for port in entry.inputs
+            ],
+            "outputs": [
+                {
+                    "name": port["name"],
+                    "schema": (
+                        port["schema"].to_wire_dict()
+                        if port["schema"] is not None
+                        else None
+                    ),
+                    "description": port["description"],
+                }
+                for port in entry.outputs
+            ],
+        }
+        for entry in procs
+    ]
+    return json.dumps(payload, indent=2)
+
+
+def main(argv: List[str]) -> int:
+    """CLI entrypoint: `python -m streamlib.extract_processors <package_dir>`."""
+    if len(argv) != 1:
+        sys.stderr.write(
+            "usage: python -m streamlib.extract_processors <package_dir>\n"
+        )
+        return 2
+    try:
+        procs = extract_processors_from_dir(Path(argv[0]))
+    except ProcessorExtractionError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 1
+    sys.stdout.write(_to_manifest_json(procs))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/sdk/streamlib-python/python/streamlib/extract_processors.py
+++ b/sdk/streamlib-python/python/streamlib/extract_processors.py
@@ -12,12 +12,13 @@ extraction *is* import — every top-level module is imported, which runs the
 [`_processor_registry`][streamlib._processor_registry]; the registered set is
 then emitted.
 
-`streamlib pkg build` invokes this in a fresh subprocess
-(`python -m streamlib.extract_processors <package_dir>`), reads the JSON on
-stdout, and writes the manifest `processors:` section — the same shape the
-Rust extractor feeds the catalog. Running in a fresh process guarantees an
-empty registry to start; the in-process [`extract_processors_from_dir`][]
-entrypoint clears the registry itself so it is safe to call repeatedly.
+Once the pkg-build truth-flip lands, `streamlib pkg build` will invoke this
+in a fresh subprocess (`python -m streamlib.extract_processors
+<package_dir>`), read the JSON on stdout, and write the manifest
+`processors:` section — the same shape the Rust extractor feeds the catalog.
+Running in a fresh process guarantees an empty registry to start; the
+in-process [`extract_processors_from_dir`][] entrypoint clears the registry
+itself so it is safe to call repeatedly.
 
 Discovery matches the Rust scan's `collect_rs_files` + sort: every top-level
 `*.py` beside the `streamlib.yaml`, imported in sorted filename order. Modules

--- a/sdk/streamlib-python/python/streamlib/tests/test_manifest_reader.py
+++ b/sdk/streamlib-python/python/streamlib/tests/test_manifest_reader.py
@@ -1,7 +1,12 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 
-"""Tests for the hand-rolled streamlib.yaml minimal manifest reader."""
+"""Tests for the hand-rolled streamlib.yaml package-block reader.
+
+The reader is package-identity-only: the `processors:` set is derived from
+`@processor` decorators (see `test_processor_extraction.py`), never read from
+the manifest.
+"""
 
 from __future__ import annotations
 
@@ -10,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-from streamlib._manifest import ManifestParseError, read_manifest_summary
+from streamlib._manifest import ManifestParseError, read_package_block
 
 
 def _write(tmp_path: Path, body: str) -> Path:
@@ -19,8 +24,8 @@ def _write(tmp_path: Path, body: str) -> Path:
     return p
 
 
-class TestManifestReader:
-    def test_parses_package_block_and_processors_list(self, tmp_path: Path) -> None:
+class TestPackageBlockReader:
+    def test_parses_package_block(self, tmp_path: Path) -> None:
         path = _write(
             tmp_path,
             """
@@ -34,15 +39,12 @@ class TestManifestReader:
               - name: AvatarCharacter
                 runtime: python
                 execution: reactive
-              - name: CyberpunkLowerThird
-                runtime: python
             """,
         )
-        summary = read_manifest_summary(path)
-        assert summary.package.org == "tatolab"
-        assert summary.package.name == "cyberpunk-processor"
-        assert summary.package.version == "0.1.0"
-        assert summary.processor_names == ["AvatarCharacter", "CyberpunkLowerThird"]
+        package = read_package_block(path)
+        assert package.org == "tatolab"
+        assert package.name == "cyberpunk-processor"
+        assert package.version == "0.1.0"
 
     def test_strips_double_quotes_around_version(self, tmp_path: Path) -> None:
         path = _write(
@@ -52,13 +54,10 @@ class TestManifestReader:
               org: tatolab
               name: example
               version: "1.2.3"
-
-            processors:
-              - name: Foo
             """,
         )
-        summary = read_manifest_summary(path)
-        assert summary.package.version == "1.2.3"
+        package = read_package_block(path)
+        assert package.version == "1.2.3"
 
     def test_strips_single_quotes(self, tmp_path: Path) -> None:
         path = _write(
@@ -68,13 +67,11 @@ class TestManifestReader:
               org: 'tatolab'
               name: 'example'
               version: '1.2.3'
-
-            processors: []
             """,
         )
-        summary = read_manifest_summary(path)
-        assert summary.package.org == "tatolab"
-        assert summary.processor_names == []
+        package = read_package_block(path)
+        assert package.org == "tatolab"
+        assert package.name == "example"
 
     def test_ignores_trailing_comments(self, tmp_path: Path) -> None:
         path = _write(
@@ -90,12 +87,13 @@ class TestManifestReader:
               - name: Foo
             """,
         )
-        summary = read_manifest_summary(path)
-        assert summary.package.org == "tatolab"
-        assert summary.processor_names == ["Foo"]
+        package = read_package_block(path)
+        assert package.org == "tatolab"
+        assert package.name == "example"
 
-    def test_skips_nested_processor_body(self, tmp_path: Path) -> None:
-        # Inner ports/inputs/outputs must NOT show up as processor entries.
+    def test_ignores_processors_section(self, tmp_path: Path) -> None:
+        # The reader must not choke on a `processors:` block; it is simply not
+        # read (the decorator is the truth-source).
         path = _write(
             tmp_path,
             """
@@ -109,14 +107,11 @@ class TestManifestReader:
                 inputs:
                   - name: video_in
                     schema: any
-                outputs:
-                  - name: video_out
-                    schema: any
               - name: Bar
             """,
         )
-        summary = read_manifest_summary(path)
-        assert summary.processor_names == ["Foo", "Bar"]
+        package = read_package_block(path)
+        assert package.name == "example"
 
     def test_missing_package_block_errors(self, tmp_path: Path) -> None:
         path = _write(
@@ -127,7 +122,7 @@ class TestManifestReader:
             """,
         )
         with pytest.raises(ManifestParseError, match="missing required"):
-            read_manifest_summary(path)
+            read_package_block(path)
 
     def test_missing_org_field_errors(self, tmp_path: Path) -> None:
         path = _write(
@@ -136,32 +131,11 @@ class TestManifestReader:
             package:
               name: example
               version: 0.1.0
-
-            processors:
-              - name: Foo
             """,
         )
         with pytest.raises(ManifestParseError, match=r"org"):
-            read_manifest_summary(path)
+            read_package_block(path)
 
     def test_no_file_raises_filenotfound(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError):
-            read_manifest_summary(tmp_path / "does-not-exist.yaml")
-
-    def test_processor_entry_with_non_name_first_key_errors(self, tmp_path: Path) -> None:
-        # Defends the "name-first ordering" assumption with a clear failure.
-        path = _write(
-            tmp_path,
-            """
-            package:
-              org: tatolab
-              name: example
-              version: 0.1.0
-
-            processors:
-              - runtime: python
-                name: Foo
-            """,
-        )
-        with pytest.raises(ManifestParseError, match="name`-first"):
-            read_manifest_summary(path)
+            read_package_block(tmp_path / "does-not-exist.yaml")

--- a/sdk/streamlib-python/python/streamlib/tests/test_processor_decorator.py
+++ b/sdk/streamlib-python/python/streamlib/tests/test_processor_decorator.py
@@ -209,7 +209,12 @@ class TestProcessorDecorator:
                 """,
             )
 
-    def test_short_name_not_in_manifest_lists_available(self, tmp_path: Path) -> None:
+    def test_short_name_need_not_appear_in_manifest_processors_list(
+        self, tmp_path: Path
+    ) -> None:
+        # The decorator is the truth-source: a short name is minted straight
+        # from the package identity regardless of any `processors:` list the
+        # manifest happens to carry. (The list is no longer read at all.)
         _write_manifest(
             tmp_path,
             """
@@ -219,22 +224,23 @@ class TestProcessorDecorator:
               version: 0.1.0
 
             processors:
-              - name: Camera
-              - name: Display
+              - name: SomethingElse
             """,
         )
-        with pytest.raises(ValueError, match=r"Available processors"):
-            _import_class_from_dir(
-                tmp_path,
-                "missing_short_name_module",
-                """
-                from streamlib import processor
+        module = _import_class_from_dir(
+            tmp_path,
+            "unlisted_short_name_module",
+            """
+            from streamlib import processor
 
-                @processor("MissingProcessor")
-                class MissingProcessor:
-                    pass
-                """,
-            )
+            @processor("NotInTheYamlList")
+            class NotInTheYamlList:
+                pass
+            """,
+        )
+        ident = module.NotInTheYamlList.__streamlib_schema_ident__
+        assert ident.type_ == "NotInTheYamlList"
+        assert str(ident) == "@tatolab/example/NotInTheYamlList@0.1.0"
 
     def test_manifest_missing_org_errors(self, tmp_path: Path) -> None:
         _write_manifest(

--- a/sdk/streamlib-python/python/streamlib/tests/test_processor_extraction.py
+++ b/sdk/streamlib-python/python/streamlib/tests/test_processor_extraction.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Golden-extraction tests for the import-and-enumerate processor extractor.
+
+Mirrors the Rust `golden_extraction_over_a_fixture_crate` shape in
+`sdk/streamlib-processor-extract/src/lib.rs`: a fixture package with several
+processors across several modules (plus a non-processor module that must be
+ignored), extracted by importing and enumerating the registry rather than
+reading the manifest's `processors:` list.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from streamlib.extract_processors import extract_processors_from_dir
+
+
+def _write(dir_path: Path, rel: str, body: str) -> None:
+    (dir_path / rel).write_text(textwrap.dedent(body).lstrip("\n"))
+
+
+def _fixture_package(root: Path) -> None:
+    _write(
+        root,
+        "streamlib.yaml",
+        """
+        package:
+          org: tatolab
+          name: demo-pack
+          version: 0.2.0
+        """,
+    )
+    # Two processors in two modules; a nested port declaration on one; and a
+    # module that declares no processor (must be ignored).
+    _write(
+        root,
+        "blur.py",
+        """
+        from streamlib import processor, input, output, SchemaIdent
+
+        VIDEO = SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0")
+
+        @processor("Blur")
+        class Blur:
+            @input(name="frames_in", schema=VIDEO)
+            def handle_in(self): ...
+            @output(name="frames_out", schema=VIDEO)
+            def handle_out(self): ...
+        """,
+    )
+    _write(
+        root,
+        "camera.py",
+        """
+        from streamlib import processor
+
+        @processor("Camera")
+        class Camera:
+            pass
+        """,
+    )
+    _write(
+        root,
+        "not_a_processor.py",
+        """
+        class JustAHelper:
+            pass
+        """,
+    )
+
+
+class TestProcessorExtraction:
+    def test_golden_extraction_over_a_fixture_package(self, tmp_path: Path) -> None:
+        _fixture_package(tmp_path)
+
+        procs = extract_processors_from_dir(tmp_path)
+        names = [p.short_name for p in procs]
+        # Deterministic: sorted by joined schema-ident string.
+        assert names == ["Blur", "Camera"]
+
+        blur = next(p for p in procs if p.short_name == "Blur")
+        assert str(blur.schema_ident) == "@tatolab/demo-pack/Blur@0.2.0"
+        assert [port["name"] for port in blur.inputs] == ["frames_in"]
+        assert [port["name"] for port in blur.outputs] == ["frames_out"]
+        assert blur.inputs[0]["schema"].type_ == "VideoFrame"
+
+        camera = next(p for p in procs if p.short_name == "Camera")
+        assert str(camera.schema_ident) == "@tatolab/demo-pack/Camera@0.2.0"
+        assert camera.inputs == ()
+
+    def test_repeated_calls_are_isolated(self, tmp_path: Path) -> None:
+        # The registry is cleared per call — extracting twice must not
+        # accumulate duplicates.
+        _fixture_package(tmp_path)
+        first = extract_processors_from_dir(tmp_path)
+        second = extract_processors_from_dir(tmp_path)
+        assert [p.short_name for p in first] == [p.short_name for p in second]
+
+    def test_schema_only_package_yields_no_processors(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "streamlib.yaml",
+            """
+            package:
+              org: tatolab
+              name: schema-only
+              version: 1.0.0
+            """,
+        )
+        _write(tmp_path, "types.py", "class JustAType:\n    pass\n")
+        assert extract_processors_from_dir(tmp_path) == []
+
+    def test_cli_emits_manifest_json(self, tmp_path: Path) -> None:
+        # The path `pkg build` drives: a fresh subprocess printing JSON.
+        _fixture_package(tmp_path)
+        result = subprocess.run(
+            [sys.executable, "-m", "streamlib.extract_processors", str(tmp_path)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        payload = json.loads(result.stdout)
+        names = [entry["name"] for entry in payload]
+        assert names == ["Blur", "Camera"]
+        blur = next(e for e in payload if e["name"] == "Blur")
+        assert blur["schema_ident"] == {
+            "org": "tatolab",
+            "package": "demo-pack",
+            "type": "Blur",
+            "version": "0.2.0",
+        }
+        assert blur["inputs"][0]["name"] == "frames_in"
+        assert blur["inputs"][0]["schema"]["type"] == "VideoFrame"


### PR DESCRIPTION
Closes #1440

## Summary

Inverts manifest extraction for the Python and Deno SDKs to mirror the Rust model landed in #1411: the `@processor` decorator becomes the manifest truth-source at import time (registering into a process-global / module-global registry), and a new import-and-enumerate extractor derives the `processors:` set from code instead of reading a hand-authored `processors:` list off a sibling `streamlib.yaml`.

- **Python** (`sdk/streamlib-python/python/streamlib/`):
  - `_manifest.py` slimmed to a package-block-only reader (`read_package_block`); the sibling-`streamlib.yaml` processor-name lookup is deleted from `decorators.py`.
  - `_processor_registry.py`: new process-global registry `@processor` appends to.
  - `extract_processors.py`: `python -m streamlib.extract_processors <dir>` CLI + `extract_processors_from_dir()` entrypoint.
- **Deno** (`sdk/streamlib-deno/`):
  - `_manifest.ts` slimmed the same way (`readPackageBlock`); the sibling-yaml lookup dropped from `decorators.ts`.
  - `_processor_registry.ts`: the module-global registry analogue.
  - `extract_processors.ts`: `deno run --allow-read extract_processors.ts <dir>` CLI + `extractProcessorsFromDir()` entrypoint.
- `docs/decisions/manifest-extraction-capability.md`: extended with the Python/Deno import-and-enumerate analogue, the import-runs-code cost vs. the Rust inert AST scan, and the note that full per-processor manifest fields still come from `streamlib.yaml` pending ports-in-code (#1413) for Python/Deno.
- Follow-up fix: exempted the two extractor CLI entrypoints from the lint-logging gate (same subprocess-bootstrap class as `subprocess_runner.py`/`.ts`, which already carry the pragma).

## Test evidence

Ran directly against this branch in-worktree:

- **Python** (`python3 -m pytest streamlib/tests/`): 135 passed, 7 skipped, 5 failed. All 5 failures are pre-existing/unrelated to this change:
  - 2 require codegen-emitted schema classes (`streamlib._generated_`) not produced without a prior `streamlib link` / codegen run.
  - 3 (`test_subprocess_runner_cleanup.py`) require `STREAMLIB_PROTOCOL_VERSION` set by a real engine subprocess launch — confirmed failing identically on `main` (not introduced by this branch).
  - All new extraction/manifest tests (golden extraction, slimmed reader, decorator registration) pass.
- **Deno** (`deno test --allow-read --allow-write --allow-env extract_processors_test.ts decorators_test.ts`): 30 passed, 0 failed.

No GPU/IPC/live-rig surface touched by this change — no E2E rig run required.

## Review items (non-blocking)

- **should-fix** — `sdk/streamlib-python/python/streamlib/extract_processors.py:0` — Acceptance criterion 3: `pkg build` invokes the per-language extractor to produce the manifest `processors:` section (parity with the Rust path). Evidence: grep across `tools/` and `runtime/` for `extract_processors` / `extractProcessors` returns nothing — no Rust build code invokes either CLI. The extractor libraries + CLIs are delivered but unreferenced by the build pipeline. This is consistent with the ticket's Out-of-scope (the `pkg build` truth-flip is #1411 stage 2) and with Rust parity (`streamlib_processor_extract` is likewise not wired into `pkg.rs` — it is only used by `streamlib-macros`), so it is not a correctness defect, but the criterion-3 checkbox is not literally met and the CLIs are dead until stage 2. Suggested next step: call out on the PR body that pkg-build wiring is deferred to the stage-2 truth-flip, and confirm a tracked follow-up exists that wires all three languages' extractors into `pkg build` (Rust included) — otherwise these CLIs ship as unreachable code.
- **should-fix** — `sdk/streamlib-deno/extract_processors.ts:47` — `extractProcessorsFromDir` is safe to call repeatedly (the in-process entrypoint clears the registry itself). Evidence: the Deno entrypoint clears the registry then `await import(href)`, but Deno caches dynamic imports by URL, so a second call over the SAME dir re-imports nothing, re-runs no `@processor` decorators, and returns `[]`. Python's analogue pops `sys.modules` entries in its `finally` block so re-import re-runs — and Python ships `test_repeated_calls_are_isolated` proving it. Deno has no equivalent test (it would fail). The divergence is disclosed in the module doc but the two "analogue" implementations behave differently, and the Deno in-process path silently returns empty on a repeat, a latent footgun. Suggested next step: either evict the imported module URLs from the Deno module cache to match Python's per-call isolation, or tighten the doc/API to make the same-dir-repeat-returns-empty behavior impossible to hit silently; add a repeated-call test if isolation is intended.
- **low** — `sdk/streamlib-python/python/streamlib/extract_processors.py:19` — Docstring: `streamlib pkg build` invokes this in a fresh subprocess. Evidence: present-tense description of an integration that is not yet wired (no build code invokes the CLI). Same present-tense framing in the decision doc's polyglot section. Describes aspirational wiring as shipped state. Suggested next step: reword to conditional/future ("will be invoked by `pkg build` once the truth-flip lands") or land the wiring, to keep docs describing shipped state.
- **info** — `sdk/streamlib-python/python/streamlib/tests/test_processor_decorator.py:349` — Two Python tests fail under pytest. Evidence: `TestGeneratedSchemaIdents::test_video_frame_carries_structured_schema_ident` and `::test_input_port_resolves_codegen_emitted_class` fail with `ModuleNotFoundError: streamlib._generated_` — they require codegen-emitted schema classes (`streamlib link` / codegen run first), not produced by this diff. Pre-existing, unrelated to the extraction change; all 35 other tests including every new extraction/manifest test pass. Suggested next step: none for this PR; confirm these are green in the codegen-provisioned CI environment.
- **info** — `sdk/streamlib-python/python/streamlib/decorators.py:114` — Acceptance criterion 5: canonical-pattern sweep migrates any in-repo package on the old sibling-yaml lookup. Evidence: the old lookup (short-name validated against `processors:` list) lived entirely inside the decorator, not copied per package; changing the decorator migrates all consumers automatically. Existing packages/examples keep their hand-authored `processors:` blocks, which remain load-bearing (still parsed by the Rust host/serde_yaml and by `pkg build`) until the stage-2 truth-flip — so no per-package edit is possible or needed now. Criterion 5 is satisfied vacuously. Suggested next step: none; note in the PR that the sweep is a no-op by construction and the hand-authored `processors:` lists get retired at stage 2.
