### PR TITLE
fix(runtime): connect() with default processor ids no longer returns InvalidLink (#1416 regression)

### DIFF
--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -14,6 +14,7 @@ use crate::core::graph::{
 use crate::core::processors::{ProcessorSpec, ProcessorState};
 use crate::core::pubsub::{Event, PUBSUB, RuntimeEvent, topics};
 use crate::core::{Error, InputLinkPortRef, OutputLinkPortRef, PortDirection, Result};
+use streamlib_idents::ChannelName;
 
 // =============================================================================
 // Core Implementation Functions ('static async fns for spawn compatibility)
@@ -156,35 +157,22 @@ async fn connect_impl(
     let to_processor = to.processor_id.clone();
     let to_port = to.port_name.clone();
 
-    // The one channel name this link publishes to / subscribes from — the
-    // deterministic `connect()` sugar (#1416). Intra-node it currently maps
-    // onto the per-destination iceoryx2 service; the name is what phase [L]
-    // cross-node routing keys on. An out-of-grammar endpoint (e.g. a port name
-    // carrying `/` or uppercase) surfaces as a typed link error rather than an
-    // invalid wire name; underscore is legal and rides through.
-    let channel = streamlib_idents::connect_channel_name(
-        from_processor.as_str(),
-        &from_port,
-        to_processor.as_str(),
-        &to_port,
-    )
-    .map_err(|source| Error::InvalidLink(source.to_string()))?;
-
     PUBSUB.publish(
         topics::RUNTIME_GLOBAL,
         &Event::RuntimeGlobal(RuntimeEvent::RuntimeWillConnect {
-            from_processor,
+            from_processor: from_processor.clone(),
             from_port: from_port.clone(),
-            to_processor,
+            to_processor: to_processor.clone(),
             to_port: to_port.clone(),
         }),
     );
 
-    let link_id = compiler.scope(|graph, tx| -> Result<LinkUniqueId> {
-        // Validate endpoints + ports up-front so failures surface as typed
-        // errors instead of the generic `add_e`-returns-empty-traversal path.
-        // The `add_e` call still does its own checks defensively, but this
-        // pre-validation is what gets the typed error to the caller.
+    let (link_id, channel) = compiler.scope(|graph, tx| -> Result<(LinkUniqueId, ChannelName)> {
+        // Validate endpoints + ports FIRST — before the channel-name
+        // derivation — so a missing processor/port reads as the typed
+        // ProcessorNotFound / ProcessorPortNotFound and never gets masked by an
+        // InvalidLink from the wire-name grammar. The `add_e` call still checks
+        // defensively; this pre-validation is what gets the typed error out.
         // Validate source processor + output port.
         {
             let from_node = graph
@@ -216,13 +204,31 @@ async fn connect_impl(
             }
         }
 
-        graph
+        // The one channel name this link publishes to / subscribes from — the
+        // deterministic `connect()` sugar (#1416). Intra-node it currently maps
+        // onto the per-destination iceoryx2 service; the name is what phase [L]
+        // cross-node routing keys on. Endpoints are validated above, so a
+        // grammar failure here is a genuinely-illegal PORT name (author error),
+        // surfaced as InvalidLink. Processor ids are lowercased inside
+        // `connect_channel_name`; underscore is legal and rides through.
+        // Deriving inside the transaction means an illegal port name rolls the
+        // pending link back rather than committing a half-built edge.
+        let channel = streamlib_idents::connect_channel_name(
+            from.processor_id.as_str(),
+            &from.port_name,
+            to.processor_id.as_str(),
+            &to.port_name,
+        )
+        .map_err(|source| Error::InvalidLink(source.to_string()))?;
+
+        let link_id = graph
             .traversal_mut()
             .add_e(from, to)
             .inspect(|link| tx.log(PendingOperation::AddLink(link.id.clone())))
             .first()
             .map(|link| link.id.clone())
-            .ok_or_else(|| Error::GraphError("failed to create link after validation".into()))
+            .ok_or_else(|| Error::GraphError("failed to create link after validation".into()))?;
+        Ok((link_id, channel))
     })?;
 
     tracing::debug!(

--- a/runtime/streamlib-engine/tests/connect_typed_errors_test.rs
+++ b/runtime/streamlib-engine/tests/connect_typed_errors_test.rs
@@ -17,9 +17,13 @@
 //!   empty, so any port name fails the input/output lookup).
 
 use serial_test::serial;
+use streamlib::sdk::descriptors::{
+    Org, Package, PortDescriptor, PortSchemaSpec, ProcessorDescriptor, SchemaIdent, SemVer,
+    TypeName,
+};
 use streamlib::sdk::error::Error;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::processors::{PROCESSOR_REGISTRY, ProcessorSpec};
 use streamlib::sdk::runtime::Runner;
 use streamlib_engine::core::PortDirection;
 
@@ -30,6 +34,24 @@ fn unknown_ident() -> streamlib::sdk::descriptors::SchemaIdent {
         "DefinitelyNotARegisteredProcessor",
         "9.9.9"
     )
+}
+
+/// Register a descriptor-only processor type with one real input and one real
+/// output port — enough to satisfy `connect`'s port-existence check. Idempotent
+/// under `serial_test` (a re-register returns an already-registered error we
+/// discard).
+fn register_test_type(short: &str, input: &str, output: &str) -> SchemaIdent {
+    let id = SchemaIdent::new(
+        Org::new("tatolab").unwrap(),
+        Package::new("connect-typed-errors-test").unwrap(),
+        TypeName::new(short).unwrap(),
+        SemVer::new(1, 0, 0),
+    );
+    let descriptor = ProcessorDescriptor::new(id.clone(), "connect typed-errors test")
+        .with_input(PortDescriptor::new(input, "", PortSchemaSpec::Any, false))
+        .with_output(PortDescriptor::new(output, "", PortSchemaSpec::Any, false));
+    let _ = PROCESSOR_REGISTRY.register_descriptor_only(descriptor);
+    id
 }
 
 #[test]
@@ -133,5 +155,79 @@ fn connect_with_unknown_target_processor_id_returns_processor_not_found() {
             assert_eq!(id, "nonexistent-source");
         }
         other => panic!("expected ProcessorNotFound for source, got {:?}", other),
+    }
+}
+
+#[test]
+#[serial]
+fn connect_default_id_processors_with_valid_ports_returns_ok() {
+    // Regression for #1416: a real `connect()` uses default `ProcessorUniqueId`s
+    // (`P{cuid2}` — uppercase-leading `P`). The channel-name derivation lowercases
+    // the processor-id components, so a valid output->input link returns
+    // `Ok(LinkUniqueId)` instead of `Error::InvalidLink("channel `P…`")`. Mentally
+    // revert the `to_ascii_lowercase` normalization in `connect_channel_name` and
+    // this fails with InvalidLink for every default-id link.
+    let cam = register_test_type("CameraSource", "_unused_in", "video");
+    let sink = register_test_type("DisplaySink", "video_in", "_unused_out");
+
+    let runtime = Runner::new().unwrap();
+    let cam_id = runtime
+        .add_processor(ProcessorSpec::new(cam, serde_json::json!({})))
+        .unwrap();
+    let sink_id = runtime
+        .add_processor(ProcessorSpec::new(sink, serde_json::json!({})))
+        .unwrap();
+
+    // The generated ids are the default uppercase-leading form.
+    assert!(cam_id.as_str().starts_with('P'));
+    assert!(sink_id.as_str().starts_with('P'));
+
+    let link = runtime
+        .connect(
+            OutputLinkPortRef::new(&cam_id, "video"),
+            InputLinkPortRef::new(&sink_id, "video_in"),
+        )
+        .expect("default-id connect with valid ports must return Ok, not InvalidLink");
+    // A non-empty LinkUniqueId came back.
+    assert!(!link.to_string().is_empty());
+}
+
+#[test]
+#[serial]
+fn connect_valid_processors_nonexistent_port_returns_port_not_found_not_invalid_link() {
+    // Port-validation now runs BEFORE the channel-name derivation, so a connect
+    // to a port that doesn't exist on a real (default-id) processor surfaces as
+    // the typed `ProcessorPortNotFound`, never a masking `InvalidLink`. The port
+    // name here is also grammar-illegal (`/` is not iceoryx2/keyexpr-safe), which
+    // is exactly what pre-reorder produced an InvalidLink for — real ports are
+    // always grammar-legal, so a grammar-illegal port is always a nonexistent
+    // one, and the port-existence error is the actionable one. Mentally revert
+    // the reorder in `connect_impl` (derive the channel name first) and this
+    // reads as InvalidLink instead.
+    let cam = register_test_type("CameraSource", "_unused_in", "video");
+    let sink = register_test_type("DisplaySink", "video_in", "_unused_out");
+
+    let runtime = Runner::new().unwrap();
+    let cam_id = runtime
+        .add_processor(ProcessorSpec::new(cam, serde_json::json!({})))
+        .unwrap();
+    let sink_id = runtime
+        .add_processor(ProcessorSpec::new(sink, serde_json::json!({})))
+        .unwrap();
+
+    match runtime.connect(
+        OutputLinkPortRef::new(&cam_id, "video"),
+        InputLinkPortRef::new(&sink_id, "no/such/input"),
+    ) {
+        Err(Error::ProcessorPortNotFound {
+            processor_id,
+            port_name,
+            direction,
+        }) => {
+            assert_eq!(processor_id, sink_id.to_string());
+            assert_eq!(port_name, "no/such/input");
+            assert_eq!(direction, PortDirection::Input);
+        }
+        other => panic!("expected ProcessorPortNotFound, got {:?}", other),
     }
 }

--- a/sdk/streamlib-idents/src/channel.rs
+++ b/sdk/streamlib-idents/src/channel.rs
@@ -115,19 +115,26 @@ pub fn validate_channel_name(s: &str) -> IdentResult<()> {
 /// (`{prefix}-{hash}`) — a pure function of the inputs that stays unique rather
 /// than a prefix truncation that would collide two long links onto one channel.
 ///
-/// The four inputs are not grammar-guaranteed: a port name may carry a genuinely
-/// illegal character (uppercase, `/`, `.`, whitespace), or a processor id need
-/// not be lowercase. Such an input would otherwise produce a silently-invalid
-/// wire name, so it surfaces here as the matching [`IdentError`] charset variant
-/// — the joined form (which carries every input character) is grammar-checked
-/// before the length-legalizing hash step. Underscore is a legal channel
-/// character, so a port like `video_in` rides through with no error.
+/// The processor ids are engine-generated (`ProcessorUniqueId` is `P{cuid2}` —
+/// an uppercase-leading `P` over a lowercase base-36 body), so their raw form is
+/// never lowercase-leading-legal. They are normalized to lowercase before
+/// joining: the cuid2 body already keeps the id unique, and lowercasing the
+/// leading `P` is what makes a valid `connect()` with default ids produce a
+/// grammar-legal wire name instead of erroring. A port name, by contrast, is
+/// author-supplied and is NOT normalized: a genuinely illegal character
+/// (uppercase, `/`, `.`, whitespace) surfaces here as the matching
+/// [`IdentError`] charset variant rather than a silently-invalid wire name — the
+/// joined form is grammar-checked before the length-legalizing hash step.
+/// Underscore is a legal channel character, so a port like `video_in` rides
+/// through with no error.
 pub fn connect_channel_name(
     src_processor: &str,
     src_output: &str,
     dst_processor: &str,
     dst_input: &str,
 ) -> IdentResult<ChannelName> {
+    let src_processor = src_processor.to_ascii_lowercase();
+    let dst_processor = dst_processor.to_ascii_lowercase();
     let joined = format!("{src_processor}-{src_output}--{dst_processor}-{dst_input}");
     validate_channel_charset(&joined)?;
 
@@ -318,12 +325,12 @@ mod tests {
     }
 
     #[test]
-    fn connect_name_rejects_out_of_grammar_input() {
-        // A port name carrying a genuinely-illegal char (`/` is not
+    fn connect_name_rejects_out_of_grammar_port_name() {
+        // A PORT name carrying a genuinely-illegal char (`/` is not
         // iceoryx2/keyexpr-safe) must surface as a typed connect-time error,
-        // never a silently-invalid wire name. Mental-revert guard: without the
-        // input charset check the slash would ride through into the emitted
-        // ChannelName.
+        // never a silently-invalid wire name. Port names are author-supplied and
+        // NOT normalized. Mental-revert guard: without the input charset check
+        // the slash would ride through into the emitted ChannelName.
         assert_eq!(
             connect_channel_name("cam", "video/in", "sink", "in"),
             Err(IdentError::InvalidChannelNameCharacter(
@@ -331,11 +338,33 @@ mod tests {
                 '/'
             ))
         );
-        // An uppercase (non-lowercase-leading) source processor id is likewise
-        // rejected rather than emitting a name iceoryx2 would refuse.
-        assert!(matches!(
-            connect_channel_name("Cam", "frame", "sink", "in"),
-            Err(IdentError::ChannelNameMustStartWithLowercase(_))
-        ));
+        // An uppercase char in a port name is also an author error — the port
+        // name is not normalized, only the processor ids are. It lands
+        // mid-string (the processor id leads), so it reads as an invalid
+        // character rather than a bad leading char.
+        assert_eq!(
+            connect_channel_name("cam", "Frame", "sink", "in"),
+            Err(IdentError::InvalidChannelNameCharacter(
+                "cam-Frame--sink-in".to_string(),
+                'F'
+            ))
+        );
+    }
+
+    #[test]
+    fn connect_name_lowercases_uppercase_leading_processor_id() {
+        // Real `ProcessorUniqueId`s are `P{cuid2}` — uppercase-leading `P` over
+        // a lowercase base-36 body. The derivation lowercases the processor-id
+        // components so a valid connect with default ids yields a grammar-legal
+        // channel name instead of erroring. Mental-revert guard: drop the
+        // `to_ascii_lowercase` normalization and this errors with
+        // ChannelNameMustStartWithLowercase.
+        let name = connect_channel_name("Pabc123def", "video", "Pxyz789ghi", "video_in").unwrap();
+        assert_eq!(name.as_str(), "pabc123def-video--pxyz789ghi-video_in");
+        validate_channel_name(name.as_str()).unwrap();
+
+        // Distinct P-ids stay distinct after lowercasing (cuid2 bodies differ).
+        let other = connect_channel_name("Pabc123def", "video", "Pxyz789jkl", "video_in").unwrap();
+        assert_ne!(name, other);
     }
 }


### PR DESCRIPTION
Fixes a **live regression in `main` (0.7.7)** introduced by #1416: `connect()` returned `Error::InvalidLink` for **every** link between default-id processors, so no real pipeline could wire up.

## Root cause
`ProcessorUniqueId` is `format!("P{}", cuid2::create_id())` — uppercase-leading `P`. #1416's channel grammar (`[a-z][a-z0-9_-]*`) requires a **lowercase**-leading char, and `connect_impl` derived the deterministic channel name via `connect_channel_name(...)` and returned `InvalidLink` on grammar failure **before** validating processors/ports. So every default-id link failed with `InvalidLink("channel `P…`")`, also masking the typed `ProcessorPortNotFound`/`ProcessorNotFound` errors. #1416's tests used explicit lowercase identity strings, not the runtime `P{cuid2}` ids, so they didn't catch it.

**Why CI missed it:** the failing tests (`connect_typed_errors_test`, and `graph_snapshot_round_trip_test` which does a default-id `connect().unwrap()`) are *integration* tests. CI's gate is `cargo test --lib` only — integration tests don't run. (Flagging as a CI-gap follow-up below.)

## Fix (engine layer — no consumer bandaid)
1. `connect_channel_name` normalizes the processor-id components with `to_ascii_lowercase()` before joining (the cuid2 body keeps them unique; only the leading `P` needs lowering). Port names stay grammar-validated (a genuinely-illegal port name is an author error).
2. `connect_impl` now validates processors + ports **first**, then derives the channel name inside the same transaction (an illegal port rolls back the pending link instead of committing a half-built edge).
3. bug-reproduce-first: added `connect_default_id_processors_with_valid_ports_returns_ok` and `connect_valid_processors_nonexistent_port_returns_port_not_found_not_invalid_link`. Mental-revert proof: stashing the two source fixes fails 4/5 `connect_typed_errors_test` cases with `InvalidLink(...must start with a-z)`; restoring passes all.

The #1416 `PortKey` truncation fix and the fallible grammar are untouched.

## Gates
`streamlib-idents` 228 passed · `connect_typed_errors_test` 5 · `graph_snapshot_round_trip_test` 4 · engine `--lib` passed · clippy clean on both touched crates.

## Follow-ups (not in this PR)
- **K#1419:** whether `ProcessorUniqueId`'s prefix should be natively lowercase (or the grammar widened) once the channel name becomes the load-bearing iceoryx2 service name — today it's observational (routing keys on `streamlib/{dest_proc_id}`), so lowercasing in the derivation is the low-risk fix. Edge to decide there: normalization folds two ids differing only in case to one channel (a non-issue for engine-generated `P{cuid2}`).
- **CI gap:** the connect integration tests aren't in the `--lib` gate that would have caught this — worth adding key integration suites to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
