### PR TITLE
feat(sdk): App entrypoint sugar over Runner (#1412)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4779,6 +4779,8 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 name = "streamlib"
 version = "0.7.8"
 dependencies = [
+ "serde",
+ "serde_json",
  "streamlib-build-orchestrator",
  "streamlib-engine",
 ]

--- a/sdk/streamlib-sdk/Cargo.toml
+++ b/sdk/streamlib-sdk/Cargo.toml
@@ -36,3 +36,10 @@ hardware-tests = ["streamlib-engine/hardware-tests"]
 [dependencies]
 streamlib-engine = { path = "../../runtime/streamlib-engine", version = "0.7.8" }
 streamlib-build-orchestrator = { path = "../../tools/streamlib-build-orchestrator", version = "0.7.8", optional = true }
+# `App` sugar takes `impl Serialize` configs and encodes them to the JSON the
+# runtime carries.
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/sdk/streamlib-sdk/src/lib.rs
+++ b/sdk/streamlib-sdk/src/lib.rs
@@ -132,6 +132,17 @@ pub mod sdk {
     pub use streamlib_engine::core::sync;
     pub use streamlib_engine::core::texture;
 
+    // ---- App authoring sugar ----
+
+    /// [`App`] — thin authoring sugar over [`runtime::Runner`]. Construct, add
+    /// processors, connect ports, run; every method forwards to an existing
+    /// `Runner` op.
+    #[cfg(feature = "auto-build")]
+    pub mod app;
+
+    #[cfg(feature = "auto-build")]
+    pub use app::{App, AppPortEndpoint};
+
     // ---- Processors namespace ----
     //
     // Combines engine's `core::processors::*` with the platform-

--- a/sdk/streamlib-sdk/src/sdk/app.rs
+++ b/sdk/streamlib-sdk/src/sdk/app.rs
@@ -1,0 +1,126 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! [`App`] — thin authoring sugar over [`Runner`](crate::sdk::runtime::Runner).
+//!
+//! Every method is a direct delegation to an existing `Runner` op; `App`
+//! adds no runtime state of its own and owns no graph capability the runtime
+//! doesn't. [`App::runner`] is the escape hatch back to the full `Runner`
+//! surface for anything the sugar doesn't cover.
+
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use crate::sdk::RunnerAutoBuild;
+use crate::sdk::error::{Error, Result};
+use crate::sdk::graph::{InputLinkPortRef, LinkUniqueId, OutputLinkPortRef, ProcessorUniqueId};
+use crate::sdk::processors::{Config, GeneratedProcessor, ProcessorSpec, ProcessorTypeReference};
+use crate::sdk::runtime::Runner;
+
+/// A `(processor, port)` endpoint for [`App::connect`]. The processor is
+/// referenced by the [`ProcessorUniqueId`] an `add`/`add_local` call returned;
+/// the port is the source-declared port name.
+pub type AppPortEndpoint<'a> = (&'a ProcessorUniqueId, &'a str);
+
+/// Thin authoring sugar over [`Runner`]: construct,
+/// add processors, connect ports, run.
+///
+/// `App` is not a parallel runtime — it holds one `Runner` and forwards to it.
+/// Errors surface as the underlying engine [`Error`] variants unchanged. For
+/// any capability the sugar omits, drop to [`App::runner`].
+pub struct App {
+    runner: Arc<Runner>,
+}
+
+impl App {
+    /// Build an `App` over a `Runner` with the default polyglot build
+    /// orchestrator wired (the [`RunnerAutoBuild::with_auto_build`] path), so a
+    /// version-free [`add`](Self::add) reference to a not-yet-built package
+    /// materializes from source on demand.
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            runner: Runner::with_auto_build()?,
+        })
+    }
+
+    /// Add a processor by type reference, configured from `config`. `config` is
+    /// any [`Serialize`] value (a generated config `Bag`, a plain struct, or a
+    /// [`serde_json::Value`]); it is encoded to JSON and handed to the runtime
+    /// unchanged.
+    pub fn add(
+        &self,
+        processor_ref: impl Into<ProcessorTypeReference>,
+        config: impl Serialize,
+    ) -> Result<ProcessorUniqueId> {
+        let config = to_config_value(config)?;
+        self.runner
+            .add_processor(ProcessorSpec::new(processor_ref, config))
+    }
+
+    /// Register a `#[processor]`-annotated host type `P` live (no package on
+    /// disk — the [`Runner::add_local_blocking`](crate::sdk::runtime::Runner)
+    /// path) and immediately instantiate it, returning the connectable
+    /// [`ProcessorUniqueId`]. `config` is validated against `P::Config` at
+    /// registration and used as the instance config.
+    pub fn add_local<P>(&self, config: impl Serialize) -> Result<ProcessorUniqueId>
+    where
+        P: GeneratedProcessor + 'static,
+        P::Config: Config,
+    {
+        let config = to_config_value(config)?;
+        let loaded = self.runner.add_local_blocking::<P>(config.clone())?;
+        // The minted module is `@session/<name>@0.0.N`; its one processor's
+        // short type name comes from the type's own descriptor. Resolve it as
+        // an installed `(org, package, type)` triple — the session processor is
+        // already registered, so this hits the fast path with no disk load.
+        let descriptor = P::descriptor().ok_or_else(|| {
+            Error::Configuration(format!(
+                "add_local::<{}>() registered a session module but the type exposes no descriptor",
+                std::any::type_name::<P>()
+            ))
+        })?;
+        let reference = ProcessorTypeReference::ResolveToInstalled {
+            org: loaded.ident.org,
+            package: loaded.ident.name,
+            r#type: descriptor.name.r#type,
+        };
+        self.runner
+            .add_processor(ProcessorSpec::new(reference, config))
+    }
+
+    /// Connect an output endpoint to an input endpoint — `((&from, "out"),
+    /// (&to, "in"))`. A nonexistent port surfaces the runtime's
+    /// [`Error::ProcessorPortNotFound`] unchanged.
+    pub fn connect(
+        &self,
+        from: AppPortEndpoint<'_>,
+        to: AppPortEndpoint<'_>,
+    ) -> Result<LinkUniqueId> {
+        self.runner.connect(
+            OutputLinkPortRef::new(from.0, from.1),
+            InputLinkPortRef::new(to.0, to.1),
+        )
+    }
+
+    /// Start the graph, then block until a shutdown signal
+    /// ([`Runner::start`](crate::sdk::runtime::Runner) +
+    /// [`wait_for_signal`](crate::sdk::runtime::Runner)).
+    pub fn run(&self) -> Result<()> {
+        self.runner.start()?;
+        self.runner.wait_for_signal()
+    }
+
+    /// The underlying [`Runner`] — the escape
+    /// hatch for anything the sugar doesn't wrap.
+    pub fn runner(&self) -> &Arc<Runner> {
+        &self.runner
+    }
+}
+
+/// Encode a caller config value to the JSON the runtime carries, mapping a
+/// serialization failure to [`Error::Configuration`].
+fn to_config_value(config: impl Serialize) -> Result<serde_json::Value> {
+    serde_json::to_value(config)
+        .map_err(|e| Error::Configuration(format!("processor config is not serializable: {e}")))
+}

--- a/sdk/streamlib-sdk/tests/app_sugar_test.rs
+++ b/sdk/streamlib-sdk/tests/app_sugar_test.rs
@@ -1,0 +1,279 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `App` is thin sugar over `Runner`: a graph built through `App` must be
+//! byte-for-byte the graph built by the equivalent `Runner` calls (once the
+//! nondeterministic per-node ids are normalized away), every method must be a
+//! faithful pass-through that surfaces the runtime's own errors unchanged, and
+//! the `add_local` hello-world path must materialize a real node with no
+//! package, no `streamlib.yaml`, and no generated modules on disk.
+//!
+//! `App` mints default `P{cuid2}` processor ids, so `App::connect` exercises
+//! the exact #1416 channel-name path the engine fix repaired: a valid link
+//! between two real `add`-ed processors returns `Ok(LinkUniqueId)`, and a
+//! connect to a nonexistent port surfaces the typed `ProcessorPortNotFound`
+//! rather than a masking `InvalidLink`.
+
+use std::collections::HashMap;
+
+use streamlib::sdk::App;
+use streamlib::sdk::context::RuntimeContextFullAccess;
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::processors::{Config, GeneratedProcessor, ManualProcessor, ProcessorSpec, ProcessorTypeReference};
+use streamlib::sdk::runtime::Runner;
+
+// =============================================================================
+// Fixtures — in-crate `#[processor]` host types. No package, no streamlib.yaml,
+// no build: the macro synthesizes identity and the runtime registers them live.
+// Distinct type names per test ⇒ distinct `@session/<name>` keys ⇒ the
+// process-global registry never collides across the (parallel) test binary.
+// =============================================================================
+
+macro_rules! manual_fixture {
+    ($struct_name:ident, $ident:literal) => {
+        #[streamlib::sdk::processor($ident, execution = manual)]
+        struct $struct_name;
+        impl ManualProcessor for $struct_name::Processor {
+            fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+                Ok(())
+            }
+            fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+                Ok(())
+            }
+            fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+                Ok(())
+            }
+        }
+    };
+}
+
+manual_fixture!(EquivAlpha, "@tatolab/app-sugar-test/EquivAlpha");
+manual_fixture!(EquivBeta, "@tatolab/app-sugar-test/EquivBeta");
+manual_fixture!(PassthroughNode, "@tatolab/app-sugar-test/PassthroughNode");
+manual_fixture!(MaterializeNode, "@tatolab/app-sugar-test/MaterializeNode");
+manual_fixture!(IgnoredConnectNode, "@tatolab/app-sugar-test/IgnoredConnectNode");
+
+/// Register a `#[processor]` host type live under `@session/<name>` and derive
+/// the version-free reference that resolves it — the same reference shape
+/// `App::add_local` builds internally, but without instantiating, so both an
+/// `App` graph and a `Runner` graph can reference the one registered type.
+fn register_session_reference<P>(registrar: &Runner) -> ProcessorTypeReference
+where
+    P: GeneratedProcessor + 'static,
+    P::Config: Config,
+{
+    let loaded = registrar
+        .add_local_blocking::<P>(serde_json::Value::Null)
+        .expect("session registration must succeed");
+    let descriptor = P::descriptor().expect("fixture exposes a descriptor");
+    ProcessorTypeReference::ResolveToInstalled {
+        org: loaded.ident.org,
+        package: loaded.ident.name,
+        r#type: descriptor.name.r#type,
+    }
+}
+
+/// Replace each captured concrete id with its positional token so two graphs
+/// built by identical operations differ only where the runtime minted a random
+/// cuid2. Ids are 24-char cuid2 strings — they never alias JSON structure.
+fn normalize_ids(graph_json: &serde_json::Value, ids_in_build_order: &[String]) -> String {
+    let mut text = serde_json::to_string_pretty(graph_json).expect("graph serializes");
+    for (index, concrete_id) in ids_in_build_order.iter().enumerate() {
+        text = text.replace(concrete_id, &format!("<ID{index}>"));
+    }
+    text
+}
+
+/// A graph built via `App::add` and the equivalent graph built via
+/// `Runner::add_processor` produce the identical snapshot once the minted ids
+/// are normalized — the proof that `App::add` adds no graph shape of its own.
+#[test]
+fn app_add_matches_runner_add_processor_snapshot() {
+    let registrar = Runner::new().expect("registrar runtime");
+    let alpha_ref = register_session_reference::<EquivAlpha::Processor>(&registrar);
+    let beta_ref = register_session_reference::<EquivBeta::Processor>(&registrar);
+
+    let config = serde_json::json!({});
+
+    // App-built graph.
+    let app = App::new().expect("App::new");
+    let app_alpha = app.add(alpha_ref.clone(), config.clone()).expect("app add alpha");
+    let app_beta = app.add(beta_ref.clone(), config.clone()).expect("app add beta");
+    let app_snapshot = normalize_ids(
+        &app.runner().to_json().expect("app graph json"),
+        &[app_alpha.to_string(), app_beta.to_string()],
+    );
+
+    // Runner-built graph — the same operations, spelled out against `Runner`.
+    let runner = Runner::new().expect("runner runtime");
+    let runner_alpha = runner
+        .add_processor(ProcessorSpec::new(alpha_ref, config.clone()))
+        .expect("runner add alpha");
+    let runner_beta = runner
+        .add_processor(ProcessorSpec::new(beta_ref, config))
+        .expect("runner add beta");
+    let runner_snapshot = normalize_ids(
+        &runner.to_json().expect("runner graph json"),
+        &[runner_alpha.to_string(), runner_beta.to_string()],
+    );
+
+    assert_eq!(
+        app_snapshot, runner_snapshot,
+        "App-built and Runner-built graphs must snapshot identically"
+    );
+}
+
+/// `App::connect` is a faithful pass-through of `Runner::connect`: on the same
+/// runner, with the same endpoints, the two calls return the identical error.
+/// This holds regardless of what the runtime decides (it neither swallows nor
+/// rewraps the error), so it stays valid across the engine connect() fix.
+#[test]
+fn app_connect_is_a_faithful_passthrough_of_runner_connect() {
+    use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+
+    let app = App::new().expect("App::new");
+    let node = app
+        .add_local::<PassthroughNode::Processor>(serde_json::json!({}))
+        .expect("add_local returns a connectable id");
+
+    let via_app = app.connect((&node, "no_such_out"), (&node, "no_such_in"));
+    let via_runner = app.runner().connect(
+        OutputLinkPortRef::new(&node, "no_such_out"),
+        InputLinkPortRef::new(&node, "no_such_in"),
+    );
+
+    assert_eq!(
+        format!("{:?}", via_app),
+        format!("{:?}", via_runner),
+        "App::connect must return exactly what Runner::connect returns"
+    );
+}
+
+/// Register a descriptor-only processor type with one real input and one real
+/// output port — enough to satisfy `connect`'s port-existence check without
+/// instantiating. Unique short names per call keep the process-global registry
+/// collision-free across the parallel test binary.
+fn register_ported_type(short: &str, input: &str, output: &str) -> ProcessorTypeReference {
+    use streamlib::sdk::descriptors::{
+        Org, Package, PortDescriptor, PortSchemaSpec, ProcessorDescriptor, SchemaIdent, SemVer,
+        TypeName,
+    };
+    use streamlib::sdk::processors::PROCESSOR_REGISTRY;
+
+    let id = SchemaIdent::new(
+        Org::new("tatolab").unwrap(),
+        Package::new("app-sugar-test").unwrap(),
+        TypeName::new(short).unwrap(),
+        SemVer::new(1, 0, 0),
+    );
+    let descriptor = ProcessorDescriptor::new(id.clone(), "app-sugar connect test")
+        .with_input(PortDescriptor::new(input, "", PortSchemaSpec::Any, false))
+        .with_output(PortDescriptor::new(output, "", PortSchemaSpec::Any, false));
+    let _ = PROCESSOR_REGISTRY.register_descriptor_only(descriptor);
+    id.into()
+}
+
+/// End-to-end through the `App` surface: `App::add` mints default `P{cuid2}`
+/// ids, and `App::connect` between two real added processors on valid ports
+/// returns `Ok(LinkUniqueId)` — the exact #1416 regression path (channel-name
+/// derivation lowercases the uppercase-leading id) exercised through the sugar.
+#[test]
+fn app_connect_between_real_processors_on_valid_ports_returns_ok() {
+    let source_ref = register_ported_type("AppConnectOkSource", "_unused_in", "video");
+    let sink_ref = register_ported_type("AppConnectOkSink", "video_in", "_unused_out");
+
+    let app = App::new().expect("App::new");
+    let source = app.add(source_ref, serde_json::json!({})).expect("app add source");
+    let sink = app.add(sink_ref, serde_json::json!({})).expect("app add sink");
+
+    // The ids `App` handed back are the default uppercase-leading form — the
+    // shape that pre-fix produced `InvalidLink` for every real connect.
+    assert!(source.to_string().starts_with('P'));
+    assert!(sink.to_string().starts_with('P'));
+
+    let link = app
+        .connect((&source, "video"), (&sink, "video_in"))
+        .expect("App::connect on valid ports must return Ok, not InvalidLink");
+    assert!(
+        !link.to_string().is_empty(),
+        "a real connect must return a non-empty LinkUniqueId"
+    );
+}
+
+/// The hello-world path: `add_local` registers an in-crate `#[processor]` type
+/// with no package / `streamlib.yaml` / generated modules on disk, and returns
+/// a [`ProcessorUniqueId`] that is a real, addressable node in the graph.
+#[test]
+fn add_local_hello_world_materializes_a_real_node() {
+    let app = App::new().expect("App::new");
+
+    let node = app
+        .add_local::<MaterializeNode::Processor>(serde_json::json!({}))
+        .expect("add_local materializes a node");
+
+    let graph_json = app.runner().to_json().expect("graph json");
+    let node_ids: Vec<&str> = graph_json["nodes"]
+        .as_array()
+        .expect("nodes array")
+        .iter()
+        .filter_map(|n| n["id"].as_str())
+        .collect();
+
+    assert!(
+        node_ids.contains(&node.to_string().as_str()),
+        "the add_local id {node} must name a real node in the graph, found {node_ids:?}"
+    );
+}
+
+/// A config value that cannot serialize to JSON (a map with non-string keys)
+/// surfaces as [`Error::Configuration`] rather than panicking — the
+/// `to_config_value` error path.
+#[test]
+fn add_rejects_a_non_serializable_config() {
+    use streamlib::sdk::descriptors::{Org, Package, TypeName};
+
+    // The config is encoded before the reference is ever resolved, so any
+    // reference works — the serialization error must fire first.
+    let reference = ProcessorTypeReference::ResolveToInstalled {
+        org: Org::new("tatolab").unwrap(),
+        package: Package::new("app-sugar-test").unwrap(),
+        r#type: TypeName::new("Whatever").unwrap(),
+    };
+
+    let app = App::new().expect("App::new");
+    // A compound (tuple) map key cannot become a JSON object key — `to_value`
+    // errors rather than coercing (unlike an integer key, which stringifies).
+    let mut unserializable: HashMap<(i32, i32), i32> = HashMap::new();
+    unserializable.insert((1, 2), 3);
+
+    match app.add(reference, unserializable) {
+        Err(Error::Configuration(_)) => {}
+        other => panic!("expected Error::Configuration, got {other:?}"),
+    }
+}
+
+/// Connecting a nonexistent port on a real (default `P{cuid2}`-id) processor
+/// surfaces the runtime's typed [`Error::ProcessorPortNotFound`] through
+/// `App::connect` unchanged — never a masking `InvalidLink` from the
+/// channel-name grammar.
+#[test]
+fn connect_to_nonexistent_port_surfaces_processor_port_not_found() {
+    use streamlib::sdk::error::PortDirection;
+
+    let app = App::new().expect("App::new");
+    let node = app
+        .add_local::<IgnoredConnectNode::Processor>(serde_json::json!({}))
+        .expect("add_local returns a connectable id");
+
+    let error = app
+        .connect((&node, "no_such_out"), (&node, "no_such_in"))
+        .expect_err("connecting a nonexistent port must fail");
+
+    match error {
+        Error::ProcessorPortNotFound { port_name, direction, .. } => {
+            assert_eq!(port_name, "no_such_out");
+            assert_eq!(direction, PortDirection::Output);
+        }
+        other => panic!("expected ProcessorPortNotFound, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Closes #1412.

`App::new / add / add_local / connect / run()` — a thin authoring layer over `Runner`, so a three-node app is ~25 lines instead of ~80. Sugar only: `Runner` stays fully reachable; `App` adds no graph shape (a snapshot test locks `App::add` == `Runner::add_processor`).

## Surface
- `App::add("@org/pkg:Type", cfg)` / `App::add_local::<T>(cfg)` — config is `impl Serialize` (not `Bag` directly: the SDK facade can't depend on `streamlib-plugin-sdk` where `Bag` lives; `Bag` impls `Serialize`, so it's accepted, and this is strictly more permissive). Encoded to the engine's `serde_json::Value` config currency.
- `App::connect((&a, "out"), (&b, "in"))` — faithful passthrough to `Runner::connect`.
- `App::run()` — folds `start()? ; wait_for_signal()`, the pair every example hand-writes.
- Gated behind the `auto-build` feature (`App::new` uses `Runner::with_auto_build`), so a frozen `--no-default-features` (.slpkg-only) build excludes it.

## Connect works end-to-end (validated against #1451)
`App` mints default `P{cuid2}` processor ids — the exact input that tripped the #1416 `connect()` regression. With that fixed on main (#1451), this PR:
- un-`#[ignore]`s `connect_to_nonexistent_port_surfaces_processor_port_not_found` (now green — typed `ProcessorPortNotFound`, not `InvalidLink`), and
- adds `app_connect_between_real_processors_on_valid_ports_returns_ok`, which adds two processors via `App::add` (minting `P…` ids) and asserts a valid `App::connect` returns `Ok(LinkUniqueId)`.

## Out of scope
Python + Deno `App` entrypoints (issue #1412 "phase 3") — a follow-up.

## Gates
App tests 6 passed / **0 ignored** · CI unit-test gate pass · `RUSTDOCFLAGS=-D warnings cargo doc` clean · clippy clean. (Note: `clippy::result_large_err` on App's `Result` methods is the engine-wide `Error`-size concern, out of scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
