### PR TITLE
chore(flow): resilientAgent catches structured-agent throw instead of dying

### DIFF
--- a/.claude/workflows/draft-design.js
+++ b/.claude/workflows/draft-design.js
@@ -64,15 +64,29 @@ const briefSchema = {
 // K3: degrade-not-crash — see implement-ticket.js. On a null/failed structured
 // result, retry ONCE schema-free and parse; then continue degraded, not dead.
 async function resilientAgent(prompt, opts) {
-  const first = await agent(prompt, opts);
-  if (first) return first;
   const options = opts || {};
   const { schema, ...schemaFree } = options;
+  let first;
+  try {
+    first = await agent(prompt, opts);
+  } catch (structuredThrow) {
+    // agent({schema}) throws when it exhausts the StructuredOutput retry cap;
+    // degrade to the schema-free retry below instead of killing the whole run.
+    log(`resilientAgent: structured attempt threw (${options.label || 'unlabeled'}); falling back to schema-free retry`);
+    first = null;
+  }
+  if (first) return first;
   const shape = schema ? JSON.stringify(schema) : '{}';
-  const retry = await agent(
-    `${prompt}\n\nReturn ONLY a single JSON object matching this shape — no prose, no code fence: ${shape}`,
-    schemaFree,
-  );
+  let retry;
+  try {
+    retry = await agent(
+      `${prompt}\n\nReturn ONLY a single JSON object matching this shape — no prose, no code fence: ${shape}`,
+      schemaFree,
+    );
+  } catch (retryThrow) {
+    log(`resilientAgent: schema-free retry also threw (${options.label || 'unlabeled'}); continuing degraded`);
+    return { degraded: true };
+  }
   if (retry && typeof retry === 'object') return retry;
   if (typeof retry === 'string') {
     try {

--- a/.claude/workflows/fix-ticket.js
+++ b/.claude/workflows/fix-ticket.js
@@ -60,15 +60,29 @@ function leadOpts(extra) {
 // K3: degrade-not-crash — see implement-ticket.js. On a null/failed structured
 // result, retry ONCE schema-free and parse; then continue degraded, not dead.
 async function resilientAgent(prompt, opts) {
-  const first = await agent(prompt, opts);
-  if (first) return first;
   const options = opts || {};
   const { schema, ...schemaFree } = options;
+  let first;
+  try {
+    first = await agent(prompt, opts);
+  } catch (structuredThrow) {
+    // agent({schema}) throws when it exhausts the StructuredOutput retry cap;
+    // degrade to the schema-free retry below instead of killing the whole run.
+    log(`resilientAgent: structured attempt threw (${options.label || 'unlabeled'}); falling back to schema-free retry`);
+    first = null;
+  }
+  if (first) return first;
   const shape = schema ? JSON.stringify(schema) : '{}';
-  const retry = await agent(
-    `${prompt}\n\nReturn ONLY a single JSON object matching this shape — no prose, no code fence: ${shape}`,
-    schemaFree,
-  );
+  let retry;
+  try {
+    retry = await agent(
+      `${prompt}\n\nReturn ONLY a single JSON object matching this shape — no prose, no code fence: ${shape}`,
+      schemaFree,
+    );
+  } catch (retryThrow) {
+    log(`resilientAgent: schema-free retry also threw (${options.label || 'unlabeled'}); continuing degraded`);
+    return { degraded: true };
+  }
   if (retry && typeof retry === 'object') return retry;
   if (typeof retry === 'string') {
     try {

--- a/.claude/workflows/implement-ticket.js
+++ b/.claude/workflows/implement-ticket.js
@@ -104,15 +104,29 @@ const implementSchema = {
 // give up — returning { degraded: true } + a log line so the phase continues
 // degraded instead of the run dying.
 async function resilientAgent(prompt, opts) {
-  const first = await agent(prompt, opts);
-  if (first) return first;
   const options = opts || {};
   const { schema, ...schemaFree } = options;
+  let first;
+  try {
+    first = await agent(prompt, opts);
+  } catch (structuredThrow) {
+    // agent({schema}) throws when it exhausts the StructuredOutput retry cap;
+    // degrade to the schema-free retry below instead of killing the whole run.
+    log(`resilientAgent: structured attempt threw (${options.label || 'unlabeled'}); falling back to schema-free retry`);
+    first = null;
+  }
+  if (first) return first;
   const shape = schema ? JSON.stringify(schema) : '{}';
-  const retry = await agent(
-    `${prompt}\n\nReturn ONLY a single JSON object matching this shape — no prose, no code fence: ${shape}`,
-    schemaFree,
-  );
+  let retry;
+  try {
+    retry = await agent(
+      `${prompt}\n\nReturn ONLY a single JSON object matching this shape — no prose, no code fence: ${shape}`,
+      schemaFree,
+    );
+  } catch (retryThrow) {
+    log(`resilientAgent: schema-free retry also threw (${options.label || 'unlabeled'}); continuing degraded`);
+    return { degraded: true };
+  }
   if (retry && typeof retry === 'object') return retry;
   if (typeof retry === 'string') {
     try {

--- a/.claude/workflows/run-research.js
+++ b/.claude/workflows/run-research.js
@@ -33,15 +33,29 @@ function expertsForZones(zoneList) {
 // K3: degrade-not-crash — see implement-ticket.js. On a null/failed structured
 // result, retry ONCE schema-free and parse; then continue degraded, not dead.
 async function resilientAgent(prompt, opts) {
-  const first = await agent(prompt, opts);
-  if (first) return first;
   const options = opts || {};
   const { schema, ...schemaFree } = options;
+  let first;
+  try {
+    first = await agent(prompt, opts);
+  } catch (structuredThrow) {
+    // agent({schema}) throws when it exhausts the StructuredOutput retry cap;
+    // degrade to the schema-free retry below instead of killing the whole run.
+    log(`resilientAgent: structured attempt threw (${options.label || 'unlabeled'}); falling back to schema-free retry`);
+    first = null;
+  }
+  if (first) return first;
   const shape = schema ? JSON.stringify(schema) : '{}';
-  const retry = await agent(
-    `${prompt}\n\nReturn ONLY a single JSON object matching this shape — no prose, no code fence: ${shape}`,
-    schemaFree,
-  );
+  let retry;
+  try {
+    retry = await agent(
+      `${prompt}\n\nReturn ONLY a single JSON object matching this shape — no prose, no code fence: ${shape}`,
+      schemaFree,
+    );
+  } catch (retryThrow) {
+    log(`resilientAgent: schema-free retry also threw (${options.label || 'unlabeled'}); continuing degraded`);
+    return { degraded: true };
+  }
   if (retry && typeof retry === 'object') return retry;
   if (typeof retry === 'string') {
     try {

--- a/.claude/workflows/verify-change.js
+++ b/.claude/workflows/verify-change.js
@@ -77,15 +77,29 @@ const severityTaxonomy =
 // K3: degrade-not-crash — see implement-ticket.js. On a null/failed structured
 // result, retry ONCE schema-free and parse; then continue degraded, not dead.
 async function resilientAgent(prompt, opts) {
-  const first = await agent(prompt, opts);
-  if (first) return first;
   const options = opts || {};
   const { schema, ...schemaFree } = options;
+  let first;
+  try {
+    first = await agent(prompt, opts);
+  } catch (structuredThrow) {
+    // agent({schema}) throws when it exhausts the StructuredOutput retry cap;
+    // degrade to the schema-free retry below instead of killing the whole run.
+    log(`resilientAgent: structured attempt threw (${options.label || 'unlabeled'}); falling back to schema-free retry`);
+    first = null;
+  }
+  if (first) return first;
   const shape = schema ? JSON.stringify(schema) : '{}';
-  const retry = await agent(
-    `${prompt}\n\nReturn ONLY a single JSON object matching this shape — no prose, no code fence: ${shape}`,
-    schemaFree,
-  );
+  let retry;
+  try {
+    retry = await agent(
+      `${prompt}\n\nReturn ONLY a single JSON object matching this shape — no prose, no code fence: ${shape}`,
+      schemaFree,
+    );
+  } catch (retryThrow) {
+    log(`resilientAgent: schema-free retry also threw (${options.label || 'unlabeled'}); continuing degraded`);
+    return { degraded: true };
+  }
   if (retry && typeof retry === 'object') return retry;
   if (typeof retry === 'string') {
     try {


### PR DESCRIPTION
## What

`resilientAgent` (the "degrade, don't crash" helper in all five loop workflows) wrapped its schema-free retry path in careful fallbacks — but its **first** call, `const first = await agent(prompt, opts)`, was uncaught. `agent({schema})` *throws* when it exhausts the StructuredOutput retry cap, so that throw propagated straight out and killed the whole workflow run, defeating the helper's entire purpose.

This is the recurring bug that forced full relaunches of #1409's and #1414's rederive phases (2+ observed occurrences).

## Fix

Wrap both `agent()` calls in try/catch:
- a throw on the **structured** attempt → falls through to the schema-free retry (with a `log` line), exactly as a `null` return already did;
- a throw on the **retry** itself → degrades to `{ degraded: true }` so the phase continues degraded rather than dying.

Applied identically to all five workflows carrying the helper (`implement-ticket`, `fix-ticket`, `verify-change`, `draft-design`, `run-research`) — canonical-pattern sweep, no consumer left on the old shape.

## Why chore

Operating-model change under `.claude/` → its own PR with rationale per `.claude/rules/flow.md`; touches no library code and no ABI, so no version bump.

## Verification

`node --check` passes on all five scripts. In-flight runs are unaffected (they load their script at launch); the fix takes effect on the next workflow launched from a fast-forwarded `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)