### PR TITLE
feat(pack): derive processor manifests from code with a drift gate (closes #1411)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5276,6 +5276,7 @@ dependencies = [
  "serde_yaml",
  "streamlib-cargo-build",
  "streamlib-idents",
+ "streamlib-processor-extract",
  "streamlib-processor-schema",
  "tempfile",
  "thiserror 2.0.18",
@@ -5315,7 +5316,9 @@ version = "0.7.10"
 dependencies = [
  "proc-macro2",
  "quote",
+ "serde",
  "serde_json",
+ "serde_yaml",
  "streamlib-processor-schema",
  "syn",
  "thiserror 2.0.18",

--- a/docs/decisions/manifest-extraction-capability.md
+++ b/docs/decisions/manifest-extraction-capability.md
@@ -46,22 +46,49 @@ per-language extractor imports every top-level module beside the
 decorator no longer validates its short name against a hand-authored
 `processors:` list — the decorator *is* that list.
 
-The extractors are designed to run in a fresh subprocess (`python -m
+The extractors run in a fresh subprocess (`python -m
 streamlib.extract_processors <dir>` / `deno run --allow-read
 extract_processors.ts <dir>`) so the registry starts empty; the in-process
-entrypoints clear the registry themselves. Once the pkg-build truth-flip lands,
-`pkg build` will invoke them on that path; today they ship as the standalone
-capability. Output is sorted by joined schema-ident string for determinism
-regardless of import order.
+entrypoints clear the registry themselves. Output is sorted by joined
+schema-ident string for determinism regardless of import order.
 
 The import-runs-code property is the cost of the inversion: a processor module
 whose third-party imports are unavailable cannot be enumerated, whereas the
 Rust AST scan is inert. Extraction therefore assumes the package's dependencies
-are installed — true at `pkg build` time, unlike the Rust `src/` walk. Full
-per-processor manifest fields (execution mode, entrypoint, ports) still come
-from `streamlib.yaml` for Python/Deno until ports-in-code lands for those
-runtimes; today's extractor supplies the processor identity set and declared
-port schemas, which is what the decorator carries.
+are installed — true at `pkg build` time, unlike the Rust `src/` walk.
+
+## The pkg-build drift gate
+
+`streamlib pkg build` (and `pkg publish`) derives the processor set from code —
+Rust in-process, Python/Deno via the subprocess extractors — and refuses to
+build a distributable `.slpkg` whose committed `processors:` section disagrees.
+The comparison is a **language-uniform identity surface**: processor `Type`
+name, execution mode, and each port's name + schema-type (or `any`). It
+deliberately excludes fields no code scan produces uniformly or that are
+authored/build-derived rather than code-derived — `version` (the release-core
+projection is a build concern), `entrypoint` (author/loader concern), the
+`config` binding, `description`, and the consumer-side port policies
+(`read_mode` / `overflow` / `buffer_size`, which the Python/Deno wire shape does
+not carry). What remains is exactly the surface a stale hand-authored
+`processors:` would misstate: a processor added, removed, or renamed in code; a
+port added, removed, reordered, or re-typed. The committed manifest stays the
+carrier of the excluded authored/build fields — the `processors:` section is not
+auto-overwritten, it is validated against code.
+
+Rust drift is always enforced (the `syn` scan is always runnable in-process). A
+Python/Deno extractor that cannot **run** — the runtime is absent, its import
+failed, or (Deno) it is unconfigured — is a logged skip, not a build break:
+extraction-is-import needs the runtime present, and a `pkg build` that merely
+bundles a Python/Deno package as source on a host without that runtime must
+still work. A skipped language's committed processors are excluded from the
+comparison rather than falsely flagged. A malformed *output* from an extractor
+that DID run is a hard error (the extractor ran and produced garbage — a real
+bug, not an absent runtime). Real Python/Deno drift enforcement is exercised
+live, where the runtime is present.
+
+The gate is scoped to the distributable `.slpkg` authoring path; the runtime
+orchestrator's staged-directory materialization assembles an already-validated
+artifact and does not re-run it.
 
 ## Rejected alternatives
 

--- a/sdk/streamlib-processor-extract/Cargo.toml
+++ b/sdk/streamlib-processor-extract/Cargo.toml
@@ -16,12 +16,14 @@ proc-macro2 = "1.0"
 
 streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.7.10" }
 
+serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
 quote = "1.0"
-serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 
 [lints]
 workspace = true

--- a/sdk/streamlib-processor-extract/src/derive.rs
+++ b/sdk/streamlib-processor-extract/src/derive.rs
@@ -1,0 +1,895 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cross-language processor derivation + manifest-drift gate.
+//!
+//! [`crate::extract_reachable_rust_processors`] derives the Rust half of a
+//! package's `processors:` section from `#[processor(...)]` attributes. Python
+//! and Deno packages carry the same truth in their `@processor` decorators,
+//! surfaced by the import-and-enumerate subprocess CLIs (`python -m
+//! streamlib.extract_processors <dir>` / `deno run --allow-read
+//! extract_processors.ts <dir>`), which emit the manifest processor list as JSON
+//! on stdout. This module unifies all three into one derivation and one **drift
+//! gate**: `streamlib pkg build` derives the processor set from code and refuses
+//! to build a package whose committed `processors:` disagrees with it.
+//!
+//! ## The comparison surface
+//!
+//! The drift check compares the *identity surface* every extractor produces
+//! uniformly — processor `Type` name, execution mode, and each port's name +
+//! schema-type (or `any`). It deliberately excludes fields not every runtime's
+//! extractor emits or that are authored/build-derived rather than code-derived:
+//! `version` (release-core projection is a build concern), `entrypoint`
+//! (author/loader concern), `config` binding, `description`, and the consumer-
+//! side port policies (`read_mode` / `overflow` / `buffer_size`, which the
+//! Python/Deno wire shape does not carry). What remains is exactly the surface a
+//! stale hand-authored `processors:` would misstate: a processor added, removed,
+//! or renamed in code; a port added, removed, reordered, or re-typed.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::Deserialize;
+use streamlib_processor_schema::{
+    PortSchemaSpec, ProcessorPortSchema, ProcessorSchema, ProcessorSchemaExecution,
+};
+
+use crate::reachable::{ModuleReachabilityTarget, extract_reachable_rust_processors};
+use crate::{ExtractError, ExtractedProcessor};
+
+/// A source language a package hosts processors in. Detected structurally from
+/// the package directory, independent of the (possibly-stale) `processors:`
+/// list, so derivation never trusts the manifest to decide what to derive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PackageLanguage {
+    Rust,
+    Python,
+    TypeScript,
+}
+
+impl PackageLanguage {
+    fn label(self) -> &'static str {
+        match self {
+            PackageLanguage::Rust => "rust",
+            PackageLanguage::Python => "python",
+            PackageLanguage::TypeScript => "deno",
+        }
+    }
+}
+
+/// Detect which languages a package hosts processors in, from files on disk.
+///
+/// - **Rust** — a `Cargo.toml` beside a `src/lib.rs` or `src/main.rs` crate root.
+/// - **Python** — a `pyproject.toml` (the Python extractor scans the top-level
+///   `*.py` beside it).
+/// - **Deno** — a `deno.json`.
+///
+/// A package may host more than one (a polyglot package), or none (a schema-only
+/// package like `@tatolab/core`).
+pub fn detect_package_languages(package_dir: &Path) -> BTreeSet<PackageLanguage> {
+    let mut out = BTreeSet::new();
+    let has_crate_root =
+        package_dir.join("src/lib.rs").is_file() || package_dir.join("src/main.rs").is_file();
+    if package_dir.join("Cargo.toml").is_file() && has_crate_root {
+        out.insert(PackageLanguage::Rust);
+    }
+    if package_dir.join("pyproject.toml").is_file() {
+        out.insert(PackageLanguage::Python);
+    }
+    if package_dir.join("deno.json").is_file() {
+        out.insert(PackageLanguage::TypeScript);
+    }
+    out
+}
+
+/// The language-uniform identity surface of one processor — the shape the drift
+/// gate compares. Derived identically from a code-derived [`ProcessorSchema`]
+/// (Rust scan) and from the Python/Deno subprocess wire JSON.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessorSurface {
+    /// The `Type` segment of the processor's identity (PascalCase short name).
+    pub name: String,
+    /// Execution mode.
+    pub execution: ProcessorSchemaExecution,
+    /// Input ports, in declaration order.
+    pub inputs: Vec<PortSurface>,
+    /// Output ports, in declaration order.
+    pub outputs: Vec<PortSurface>,
+}
+
+/// The identity surface of one port: its name and schema-type reference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PortSurface {
+    pub name: String,
+    pub schema: PortSchemaSurface,
+}
+
+/// A port's schema reference, normalized across the bare-`Named`, resolved-
+/// `Specific`, and version-free wire representations to just its `Type` segment
+/// (or the `any` wildcard). Two representations of the same schema type compare
+/// equal — a committed `schema: VideoFrame` (Named) and a code-derived
+/// `@tatolab/core/VideoFrame@0.0.0` (Specific) are the same surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PortSchemaSurface {
+    Any,
+    Type(String),
+}
+
+impl PortSchemaSurface {
+    fn from_spec(spec: &PortSchemaSpec) -> Self {
+        match spec {
+            PortSchemaSpec::Any => PortSchemaSurface::Any,
+            PortSchemaSpec::Named(name) => PortSchemaSurface::Type(name.as_str().to_string()),
+            PortSchemaSpec::Specific(ident) => {
+                PortSchemaSurface::Type(ident.r#type.as_str().to_string())
+            }
+        }
+    }
+}
+
+impl PortSurface {
+    fn from_port_schema(port: &ProcessorPortSchema) -> Self {
+        PortSurface {
+            name: port.name.clone(),
+            schema: PortSchemaSurface::from_spec(&port.schema),
+        }
+    }
+}
+
+impl ProcessorSurface {
+    /// Project a manifest-shaped [`ProcessorSchema`] (committed or Rust-derived)
+    /// onto the drift comparison surface.
+    pub fn from_processor_schema(schema: &ProcessorSchema) -> Self {
+        ProcessorSurface {
+            name: schema.name.clone(),
+            execution: schema.execution.clone(),
+            inputs: schema
+                .inputs
+                .iter()
+                .map(PortSurface::from_port_schema)
+                .collect(),
+            outputs: schema
+                .outputs
+                .iter()
+                .map(PortSurface::from_port_schema)
+                .collect(),
+        }
+    }
+
+    fn from_extracted(extracted: &ExtractedProcessor) -> Self {
+        Self::from_processor_schema(&extracted.schema)
+    }
+}
+
+/// Why cross-language derivation failed. Extraction never silently drops a
+/// processor it could not derive; every failure surfaces with the language and
+/// enough context to act on.
+#[derive(Debug, thiserror::Error)]
+pub enum DeriveError {
+    /// The Rust source scan failed (see [`ExtractError`]).
+    #[error(transparent)]
+    RustScan(#[from] ExtractError),
+
+    /// A per-language subprocess extractor could not be spawned.
+    #[error("spawn {language} extractor for {package}: {source}")]
+    SpawnExtractor {
+        language: &'static str,
+        package: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// A per-language subprocess extractor exited non-zero. Carries the
+    /// captured stderr so the author sees the underlying import/scan failure.
+    #[error("{language} extractor for {package} failed (exit {code}): {stderr}")]
+    ExtractorFailed {
+        language: &'static str,
+        package: PathBuf,
+        code: String,
+        stderr: String,
+    },
+
+    /// A subprocess extractor is required for a present language but no way to
+    /// invoke it was configured (Deno's extractor script path, specifically).
+    #[error("{language} processors present in {package} but no extractor is configured: {hint}")]
+    ExtractorUnconfigured {
+        language: &'static str,
+        package: PathBuf,
+        hint: String,
+    },
+
+    /// A subprocess extractor's stdout JSON did not parse into the manifest
+    /// processor shape.
+    #[error("parse {language} extractor output as manifest JSON: {source}")]
+    MalformedExtractorJson {
+        language: &'static str,
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+/// Spawns the Python / Deno import-and-enumerate subprocess extractors and
+/// returns their manifest JSON stdout. Injectable so the derivation + drift
+/// logic is unit-testable without a live Python/Deno runtime (which a sandboxed
+/// build cannot observe — exit 144); the real implementation is
+/// [`SystemSubprocessProcessorExtractor`].
+pub trait SubprocessProcessorExtractor {
+    /// Run the Python extractor over `package_dir`, returning stdout JSON.
+    fn extract_python(&self, package_dir: &Path) -> Result<String, DeriveError>;
+    /// Run the Deno extractor over `package_dir`, returning stdout JSON.
+    fn extract_deno(&self, package_dir: &Path) -> Result<String, DeriveError>;
+}
+
+/// The real subprocess extractor: spawns `python -m streamlib.extract_processors`
+/// and `deno run --allow-read <extract_processors.ts>`.
+///
+/// The Python interpreter defaults to `python3` (override with
+/// `STREAMLIB_PYTHON`); the Deno binary defaults to `deno` (override with
+/// `STREAMLIB_DENO`). The Deno extractor script has no reliable default path —
+/// it ships with the Deno SDK, whose on-disk location depends on the install —
+/// so it is taken from `STREAMLIB_DENO_EXTRACTOR`; a Deno package built without
+/// it set surfaces [`DeriveError::ExtractorUnconfigured`] rather than a guess.
+#[derive(Debug, Default, Clone)]
+pub struct SystemSubprocessProcessorExtractor;
+
+impl SystemSubprocessProcessorExtractor {
+    fn run(
+        language: &'static str,
+        package_dir: &Path,
+        mut command: Command,
+    ) -> Result<String, DeriveError> {
+        let output = command
+            .output()
+            .map_err(|source| DeriveError::SpawnExtractor {
+                language,
+                package: package_dir.to_path_buf(),
+                source,
+            })?;
+        if !output.status.success() {
+            return Err(DeriveError::ExtractorFailed {
+                language,
+                package: package_dir.to_path_buf(),
+                code: output
+                    .status
+                    .code()
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "signal".to_string()),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            });
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+}
+
+impl SubprocessProcessorExtractor for SystemSubprocessProcessorExtractor {
+    fn extract_python(&self, package_dir: &Path) -> Result<String, DeriveError> {
+        let python = std::env::var("STREAMLIB_PYTHON").unwrap_or_else(|_| "python3".to_string());
+        let mut command = Command::new(python);
+        command
+            .arg("-m")
+            .arg("streamlib.extract_processors")
+            .arg(package_dir);
+        Self::run("python", package_dir, command)
+    }
+
+    fn extract_deno(&self, package_dir: &Path) -> Result<String, DeriveError> {
+        let script = std::env::var("STREAMLIB_DENO_EXTRACTOR").map_err(|_| {
+            DeriveError::ExtractorUnconfigured {
+                language: "deno",
+                package: package_dir.to_path_buf(),
+                hint: "set STREAMLIB_DENO_EXTRACTOR to the Deno SDK's extract_processors.ts"
+                    .to_string(),
+            }
+        })?;
+        let deno = std::env::var("STREAMLIB_DENO").unwrap_or_else(|_| "deno".to_string());
+        let mut command = Command::new(deno);
+        command
+            .arg("run")
+            .arg("--allow-read")
+            .arg(script)
+            .arg(package_dir);
+        Self::run("deno", package_dir, command)
+    }
+}
+
+/// Parse a Python/Deno extractor's stdout JSON into the drift comparison
+/// surface. The wire shape is the `_to_manifest_json` / `toManifestJson` payload
+/// the subprocess CLIs emit: a list of `{ name, schema_ident, execution,
+/// scheduling, description, inputs[], outputs[] }`, where each port is `{ name,
+/// schema: {org,package,type,version} | null, description }`.
+pub fn parse_subprocess_manifest_json(
+    language: &'static str,
+    json: &str,
+) -> Result<Vec<ProcessorSurface>, DeriveError> {
+    let wire: Vec<WireProcessor> = serde_json::from_str(json)
+        .map_err(|source| DeriveError::MalformedExtractorJson { language, source })?;
+    Ok(wire.into_iter().map(WireProcessor::into_surface).collect())
+}
+
+#[derive(Debug, Deserialize)]
+struct WireProcessor {
+    name: String,
+    execution: ProcessorSchemaExecution,
+    #[serde(default)]
+    inputs: Vec<WirePort>,
+    #[serde(default)]
+    outputs: Vec<WirePort>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WirePort {
+    name: String,
+    /// `null` for an `any` wildcard port, else the 4-field schema ident.
+    #[serde(default)]
+    schema: Option<WireIdent>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WireIdent {
+    #[serde(rename = "type")]
+    type_name: String,
+}
+
+impl WirePort {
+    fn into_surface(self) -> PortSurface {
+        PortSurface {
+            name: self.name,
+            schema: match self.schema {
+                None => PortSchemaSurface::Any,
+                Some(ident) => PortSchemaSurface::Type(ident.type_name),
+            },
+        }
+    }
+}
+
+impl WireProcessor {
+    fn into_surface(self) -> ProcessorSurface {
+        ProcessorSurface {
+            name: self.name,
+            execution: self.execution,
+            inputs: self.inputs.into_iter().map(WirePort::into_surface).collect(),
+            outputs: self
+                .outputs
+                .into_iter()
+                .map(WirePort::into_surface)
+                .collect(),
+        }
+    }
+}
+
+/// Derive the full processor identity surface for a package from code, across
+/// every language it hosts. Rust is scanned in-process
+/// ([`extract_reachable_rust_processors`] against `target`); Python and Deno are
+/// derived by running their import-and-enumerate subprocess extractors through
+/// `extractor`.
+///
+/// The result is sorted by processor `Type` name so it is a set (order-
+/// independent) for the drift comparison.
+#[tracing::instrument(skip_all, fields(package = %package_dir.display()))]
+pub fn derive_package_processor_surfaces(
+    package_dir: &Path,
+    target: &ModuleReachabilityTarget,
+    extractor: &dyn SubprocessProcessorExtractor,
+) -> Result<Vec<ProcessorSurface>, DeriveError> {
+    let languages = detect_package_languages(package_dir);
+    let mut surfaces = Vec::new();
+
+    if languages.contains(&PackageLanguage::Rust) {
+        let rust = extract_reachable_rust_processors(package_dir, target)?;
+        surfaces.extend(rust.iter().map(ProcessorSurface::from_extracted));
+    }
+    if languages.contains(&PackageLanguage::Python) {
+        let json = extractor.extract_python(package_dir)?;
+        surfaces.extend(parse_subprocess_manifest_json("python", &json)?);
+    }
+    if languages.contains(&PackageLanguage::TypeScript) {
+        let json = extractor.extract_deno(package_dir)?;
+        surfaces.extend(parse_subprocess_manifest_json("deno", &json)?);
+    }
+
+    surfaces.sort_by(|a, b| a.name.cmp(&b.name));
+    tracing::debug!(processors = surfaces.len(), "derived across languages");
+    Ok(surfaces)
+}
+
+/// A committed `processors:` section that disagrees with what the code derives.
+/// Carries the specific disagreement so the `pkg build` error is actionable.
+#[derive(Debug)]
+pub struct ManifestDriftReport {
+    pub package_dir: PathBuf,
+    /// Processors the code declares that the committed `processors:` omits.
+    pub only_in_code: Vec<String>,
+    /// Processors the committed `processors:` declares that the code does not.
+    pub only_in_manifest: Vec<String>,
+    /// Processors present in both whose identity surface differs, each with a
+    /// one-line description of the disagreement.
+    pub differing: Vec<String>,
+}
+
+impl std::fmt::Display for ManifestDriftReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "the committed `processors:` section in {} is stale — it disagrees with the \
+             `#[processor(...)]` / `@processor(...)` declarations in code, which are the source \
+             of truth:",
+            self.package_dir.join("streamlib.yaml").display()
+        )?;
+        for name in &self.only_in_code {
+            writeln!(
+                f,
+                "  - `{name}` is declared in code but missing from `processors:`"
+            )?;
+        }
+        for name in &self.only_in_manifest {
+            writeln!(
+                f,
+                "  - `{name}` is listed in `processors:` but no longer declared in code"
+            )?;
+        }
+        for detail in &self.differing {
+            writeln!(f, "  - {detail}")?;
+        }
+        write!(
+            f,
+            "fix-it: the `processors:` section is derived from code — update it to match the \
+             declarations above (or remove the section entirely; it is regenerated at build), \
+             then re-run `streamlib pkg build`"
+        )
+    }
+}
+
+impl std::error::Error for ManifestDriftReport {}
+
+/// Compare the code-derived processor surface against a package's committed
+/// `processors:` list. Returns `Ok(())` when they agree, else a
+/// [`ManifestDriftReport`] naming every disagreement.
+///
+/// Both sides are keyed by processor `Type` name; a processor present on only
+/// one side, or present on both with a differing execution mode or port set, is
+/// drift. See the module docs for exactly which fields participate.
+#[tracing::instrument(skip_all, fields(package = %package_dir.display()))]
+pub fn check_processor_manifest_drift(
+    package_dir: &Path,
+    committed: &[ProcessorSchema],
+    derived: &[ProcessorSurface],
+) -> Result<(), ManifestDriftReport> {
+    use std::collections::BTreeMap;
+
+    let derived_by_name: BTreeMap<&str, &ProcessorSurface> =
+        derived.iter().map(|p| (p.name.as_str(), p)).collect();
+    let committed_surfaces: Vec<ProcessorSurface> = committed
+        .iter()
+        .map(ProcessorSurface::from_processor_schema)
+        .collect();
+    let committed_by_name: BTreeMap<&str, &ProcessorSurface> = committed_surfaces
+        .iter()
+        .map(|p| (p.name.as_str(), p))
+        .collect();
+
+    let mut only_in_code = Vec::new();
+    let mut only_in_manifest = Vec::new();
+    let mut differing = Vec::new();
+
+    for (name, code_surface) in &derived_by_name {
+        match committed_by_name.get(name) {
+            None => only_in_code.push((*name).to_string()),
+            Some(committed_surface) => {
+                if code_surface != committed_surface {
+                    differing.push(describe_difference(name, committed_surface, code_surface));
+                }
+            }
+        }
+    }
+    for name in committed_by_name.keys() {
+        if !derived_by_name.contains_key(name) {
+            only_in_manifest.push((*name).to_string());
+        }
+    }
+
+    if only_in_code.is_empty() && only_in_manifest.is_empty() && differing.is_empty() {
+        return Ok(());
+    }
+    only_in_code.sort();
+    only_in_manifest.sort();
+    differing.sort();
+    Err(ManifestDriftReport {
+        package_dir: package_dir.to_path_buf(),
+        only_in_code,
+        only_in_manifest,
+        differing,
+    })
+}
+
+/// One-line description of how two surfaces of the same-named processor differ.
+fn describe_difference(name: &str, manifest: &ProcessorSurface, code: &ProcessorSurface) -> String {
+    if manifest.execution != code.execution {
+        return format!(
+            "`{name}` execution differs: `processors:` says {:?}, code declares {:?}",
+            manifest.execution, code.execution
+        );
+    }
+    if port_names(&manifest.inputs) != port_names(&code.inputs) {
+        return format!(
+            "`{name}` input ports differ: `processors:` has [{}], code declares [{}]",
+            port_names(&manifest.inputs).join(", "),
+            port_names(&code.inputs).join(", ")
+        );
+    }
+    if port_names(&manifest.outputs) != port_names(&code.outputs) {
+        return format!(
+            "`{name}` output ports differ: `processors:` has [{}], code declares [{}]",
+            port_names(&manifest.outputs).join(", "),
+            port_names(&code.outputs).join(", ")
+        );
+    }
+    format!("`{name}` port schema types differ between `processors:` and code")
+}
+
+fn port_names(ports: &[PortSurface]) -> Vec<String> {
+    ports.iter().map(|p| p.name.clone()).collect()
+}
+
+/// The `label`s of every present language whose extractor a build must invoke —
+/// used by `pkg build` to report the polyglot extraction it ran.
+pub fn language_labels(languages: &BTreeSet<PackageLanguage>) -> Vec<&'static str> {
+    languages.iter().map(|l| l.label()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &Path, rel: &str, body: &str) {
+        let path = dir.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body).unwrap();
+    }
+
+    /// An extractor that returns canned JSON, so the derivation + drift logic is
+    /// exercised without a live Python/Deno runtime.
+    struct FakeExtractor {
+        python: String,
+        deno: String,
+    }
+    impl SubprocessProcessorExtractor for FakeExtractor {
+        fn extract_python(&self, _dir: &Path) -> Result<String, DeriveError> {
+            Ok(self.python.clone())
+        }
+        fn extract_deno(&self, _dir: &Path) -> Result<String, DeriveError> {
+            Ok(self.deno.clone())
+        }
+    }
+
+    fn linux() -> ModuleReachabilityTarget {
+        ModuleReachabilityTarget::new()
+            .with_key_value("target_os", "linux")
+            .with_key_value("target_family", "unix")
+            .with_flag("unix")
+    }
+
+    fn parse_committed(yaml: &str) -> Vec<ProcessorSchema> {
+        let cfg: streamlib_processor_schema::ProjectConfigMinimal =
+            serde_yaml::from_str(yaml).unwrap();
+        cfg.processors
+    }
+
+    #[test]
+    fn detects_rust_python_and_deno_structurally() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "Cargo.toml", "[package]\nname='x'\n");
+        write(root, "src/lib.rs", "");
+        write(root, "pyproject.toml", "");
+        write(root, "deno.json", "{}");
+        let langs = detect_package_languages(root);
+        assert!(langs.contains(&PackageLanguage::Rust));
+        assert!(langs.contains(&PackageLanguage::Python));
+        assert!(langs.contains(&PackageLanguage::TypeScript));
+    }
+
+    #[test]
+    fn cargo_without_crate_root_is_not_rust() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "Cargo.toml", "[package]\nname='x'\n");
+        assert!(!detect_package_languages(root).contains(&PackageLanguage::Rust));
+    }
+
+    #[test]
+    fn parses_python_wire_json_into_surface() {
+        // The exact shape `_to_manifest_json` emits: bare-string execution, a
+        // 4-field schema ident on a typed port, and `null` on an `any` port.
+        let json = r#"[
+          {
+            "name": "PassThrough",
+            "schema_ident": {"org":"tatolab","package":"camera","type":"PassThrough","version":"0.0.0"},
+            "execution": "reactive",
+            "scheduling": null,
+            "description": null,
+            "inputs": [
+              {"name":"any_in","schema":null,"description":null}
+            ],
+            "outputs": [
+              {"name":"video_out","schema":{"org":"tatolab","package":"core","type":"VideoFrame","version":"0.0.0"},"description":null}
+            ]
+          }
+        ]"#;
+        let surfaces = parse_subprocess_manifest_json("python", json).unwrap();
+        assert_eq!(surfaces.len(), 1);
+        assert_eq!(surfaces[0].name, "PassThrough");
+        assert_eq!(surfaces[0].execution, ProcessorSchemaExecution::Reactive);
+        assert_eq!(surfaces[0].inputs[0].schema, PortSchemaSurface::Any);
+        assert_eq!(
+            surfaces[0].outputs[0].schema,
+            PortSchemaSurface::Type("VideoFrame".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_continuous_map_execution_from_wire() {
+        let json = r#"[{"name":"Gen","schema_ident":{"org":"a","package":"b","type":"Gen","version":"0.0.0"},
+            "execution":{"type":"continuous","interval_ms":10},"scheduling":null,"description":null,
+            "inputs":[],"outputs":[]}]"#;
+        let surfaces = parse_subprocess_manifest_json("deno", json).unwrap();
+        assert_eq!(
+            surfaces[0].execution,
+            ProcessorSchemaExecution::Continuous { interval_ms: 10 }
+        );
+    }
+
+    #[test]
+    fn malformed_extractor_json_is_typed_error() {
+        let err = parse_subprocess_manifest_json("python", "not json").unwrap_err();
+        assert!(matches!(err, DeriveError::MalformedExtractorJson { .. }));
+    }
+
+    #[test]
+    fn rust_and_python_surfaces_union_and_match_committed() {
+        // A polyglot package: one Rust processor (scanned) + one Python
+        // processor (fake subprocess), both present in the committed manifest.
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "Cargo.toml", "[package]\nname='cam'\n");
+        write(
+            root,
+            "src/lib.rs",
+            r#"#[processor("@tatolab/camera/Camera", execution = manual,
+                output("video", "@tatolab/core/VideoFrame"))]
+            pub struct Camera;"#,
+        );
+        write(root, "pyproject.toml", "");
+        let python = r#"[{"name":"PassThrough",
+            "schema_ident":{"org":"tatolab","package":"camera","type":"PassThrough","version":"0.0.0"},
+            "execution":"reactive","scheduling":null,"description":null,
+            "inputs":[{"name":"any_in","schema":null,"description":null}],
+            "outputs":[{"name":"video_out","schema":{"org":"tatolab","package":"core","type":"VideoFrame","version":"0.0.0"},"description":null}]}]"#;
+        let extractor = FakeExtractor {
+            python: python.to_string(),
+            deno: String::new(),
+        };
+
+        let derived = derive_package_processor_surfaces(root, &linux(), &extractor).unwrap();
+        assert_eq!(derived.len(), 2);
+        assert_eq!(derived[0].name, "Camera"); // sorted
+        assert_eq!(derived[1].name, "PassThrough");
+
+        let committed = parse_committed(
+            r#"
+processors:
+- name: Camera
+  version: 1.0.0
+  runtime: rust
+  execution: manual
+  outputs:
+  - name: video
+    schema: VideoFrame
+- name: PassThrough
+  version: 1.0.0
+  runtime: python
+  entrypoint: src.pass:PassThrough
+  execution: reactive
+  inputs:
+  - name: any_in
+    schema: any
+    read_mode: skip_to_latest
+  outputs:
+  - name: video_out
+    schema: VideoFrame
+"#,
+        );
+        // In sync — a committed manifest that names both processors with the
+        // same execution + ports as code. `read_mode` / version / entrypoint on
+        // the committed side are outside the drift surface, so they don't trip it.
+        check_processor_manifest_drift(root, &committed, &derived).unwrap();
+    }
+
+    #[test]
+    fn processor_only_in_code_is_drift() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "Cargo.toml", "[package]\nname='x'\n");
+        write(
+            root,
+            "src/lib.rs",
+            r#"
+            #[processor("@tatolab/demo/Alpha", execution = reactive)]
+            pub struct Alpha;
+            #[processor("@tatolab/demo/Beta", execution = reactive)]
+            pub struct Beta;
+            "#,
+        );
+        let extractor = FakeExtractor {
+            python: String::new(),
+            deno: String::new(),
+        };
+        let derived = derive_package_processor_surfaces(root, &linux(), &extractor).unwrap();
+
+        // Committed manifest lists only Alpha — Beta was added in code and never
+        // written to `processors:`. Mentally revert the drift check to `Ok(())`
+        // and `pkg build` would ship a manifest missing Beta.
+        let committed = parse_committed(
+            r#"
+processors:
+- name: Alpha
+  version: 1.0.0
+  runtime: rust
+  execution: reactive
+"#,
+        );
+        let report = check_processor_manifest_drift(root, &committed, &derived).unwrap_err();
+        assert_eq!(report.only_in_code, vec!["Beta"]);
+        assert!(report.only_in_manifest.is_empty());
+        assert!(report.to_string().contains("Beta"));
+        assert!(report.to_string().contains("fix-it"));
+    }
+
+    #[test]
+    fn processor_only_in_manifest_is_drift() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "Cargo.toml", "[package]\nname='x'\n");
+        write(
+            root,
+            "src/lib.rs",
+            r#"#[processor("@tatolab/demo/Alpha", execution = reactive)]
+            pub struct Alpha;"#,
+        );
+        let extractor = FakeExtractor {
+            python: String::new(),
+            deno: String::new(),
+        };
+        let derived = derive_package_processor_surfaces(root, &linux(), &extractor).unwrap();
+        let committed = parse_committed(
+            r#"
+processors:
+- name: Alpha
+  version: 1.0.0
+  runtime: rust
+  execution: reactive
+- name: Ghost
+  version: 1.0.0
+  runtime: rust
+  execution: reactive
+"#,
+        );
+        let report = check_processor_manifest_drift(root, &committed, &derived).unwrap_err();
+        assert_eq!(report.only_in_manifest, vec!["Ghost"]);
+    }
+
+    #[test]
+    fn execution_mismatch_is_drift() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "Cargo.toml", "[package]\nname='x'\n");
+        write(
+            root,
+            "src/lib.rs",
+            r#"#[processor("@tatolab/demo/Alpha", execution = manual)]
+            pub struct Alpha;"#,
+        );
+        let extractor = FakeExtractor {
+            python: String::new(),
+            deno: String::new(),
+        };
+        let derived = derive_package_processor_surfaces(root, &linux(), &extractor).unwrap();
+        let committed = parse_committed(
+            r#"
+processors:
+- name: Alpha
+  version: 1.0.0
+  runtime: rust
+  execution: reactive
+"#,
+        );
+        let report = check_processor_manifest_drift(root, &committed, &derived).unwrap_err();
+        assert_eq!(report.differing.len(), 1);
+        assert!(report.differing[0].contains("execution differs"));
+    }
+
+    #[test]
+    fn added_port_is_drift() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "Cargo.toml", "[package]\nname='x'\n");
+        write(
+            root,
+            "src/lib.rs",
+            r#"#[processor("@tatolab/demo/Alpha", execution = reactive,
+                output("a", "@tatolab/core/VideoFrame"),
+                output("b", "@tatolab/core/VideoFrame"))]
+            pub struct Alpha;"#,
+        );
+        let extractor = FakeExtractor {
+            python: String::new(),
+            deno: String::new(),
+        };
+        let derived = derive_package_processor_surfaces(root, &linux(), &extractor).unwrap();
+        let committed = parse_committed(
+            r#"
+processors:
+- name: Alpha
+  version: 1.0.0
+  runtime: rust
+  execution: reactive
+  outputs:
+  - name: a
+    schema: VideoFrame
+"#,
+        );
+        let report = check_processor_manifest_drift(root, &committed, &derived).unwrap_err();
+        assert!(report.differing[0].contains("output ports differ"));
+    }
+
+    #[test]
+    fn schema_only_package_has_no_processors_and_no_drift() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        // No Cargo crate root, no pyproject, no deno.json — a schema-only package.
+        let extractor = FakeExtractor {
+            python: String::new(),
+            deno: String::new(),
+        };
+        let derived = derive_package_processor_surfaces(root, &linux(), &extractor).unwrap();
+        assert!(derived.is_empty());
+        check_processor_manifest_drift(root, &[], &derived).unwrap();
+    }
+
+    #[test]
+    fn deno_unconfigured_is_typed_error() {
+        // With STREAMLIB_DENO_EXTRACTOR unset, the system extractor reports an
+        // actionable unconfigured error rather than guessing a script path.
+        let tmp = tempdir();
+        let root = tmp.path();
+        // SAFETY: single-threaded test; no other thread reads the env here.
+        unsafe {
+            std::env::remove_var("STREAMLIB_DENO_EXTRACTOR");
+        }
+        let err = SystemSubprocessProcessorExtractor
+            .extract_deno(root)
+            .unwrap_err();
+        assert!(matches!(err, DeriveError::ExtractorUnconfigured { .. }));
+    }
+
+    struct TmpDir(PathBuf);
+    impl TmpDir {
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl Drop for TmpDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+    fn tempdir() -> TmpDir {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        let dir = std::env::temp_dir().join(format!("slderive-{pid}-{n}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        TmpDir(dir)
+    }
+}

--- a/sdk/streamlib-processor-extract/src/derive.rs
+++ b/sdk/streamlib-processor-extract/src/derive.rs
@@ -610,12 +610,6 @@ fn port_names(ports: &[PortSurface]) -> Vec<String> {
     ports.iter().map(|p| p.name.clone()).collect()
 }
 
-/// The `label`s of every present language whose extractor a build must invoke —
-/// used by `pkg build` to report the polyglot extraction it ran.
-pub fn language_labels(languages: &BTreeSet<PackageLanguage>) -> Vec<&'static str> {
-    languages.iter().map(|l| l.label()).collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sdk/streamlib-processor-extract/src/derive.rs
+++ b/sdk/streamlib-processor-extract/src/derive.rs
@@ -423,13 +423,15 @@ pub fn derive_package_processor_surfaces(
             .extend(rust.iter().map(ProcessorSurface::from_extracted));
         set.derived_languages.insert(PackageLanguage::Rust);
     }
-    for (language, run) in [
-        (PackageLanguage::Python, extractor.extract_python(package_dir)),
-        (PackageLanguage::TypeScript, extractor.extract_deno(package_dir)),
-    ] {
+    for language in [PackageLanguage::Python, PackageLanguage::TypeScript] {
         if !languages.contains(&language) {
             continue;
         }
+        let run = match language {
+            PackageLanguage::Python => extractor.extract_python(package_dir),
+            PackageLanguage::TypeScript => extractor.extract_deno(package_dir),
+            PackageLanguage::Rust => continue,
+        };
         match run {
             Ok(json) => {
                 set.surfaces
@@ -461,14 +463,13 @@ pub fn derive_package_processor_surfaces(
 /// language is in `languages` — the languages actually derived. A drift check
 /// must never flag a committed processor whose language was skipped for want of
 /// a runtime as "only in manifest".
-pub fn filter_committed_to_languages(
-    committed: &[ProcessorSchema],
+pub fn filter_committed_to_languages<'committed>(
+    committed: &'committed [ProcessorSchema],
     languages: &BTreeSet<PackageLanguage>,
-) -> Vec<ProcessorSchema> {
+) -> Vec<&'committed ProcessorSchema> {
     committed
         .iter()
         .filter(|schema| languages.contains(&PackageLanguage::of_processor(schema)))
-        .cloned()
         .collect()
 }
 
@@ -531,7 +532,7 @@ impl std::error::Error for ManifestDriftReport {}
 #[tracing::instrument(skip_all, fields(package = %package_dir.display()))]
 pub fn check_processor_manifest_drift(
     package_dir: &Path,
-    committed: &[ProcessorSchema],
+    committed: &[&ProcessorSchema],
     derived: &[ProcessorSurface],
 ) -> Result<(), ManifestDriftReport> {
     use std::collections::BTreeMap;
@@ -540,7 +541,7 @@ pub fn check_processor_manifest_drift(
         derived.iter().map(|p| (p.name.as_str(), p)).collect();
     let committed_surfaces: Vec<ProcessorSurface> = committed
         .iter()
-        .map(ProcessorSurface::from_processor_schema)
+        .map(|schema| ProcessorSurface::from_processor_schema(schema))
         .collect();
     let committed_by_name: BTreeMap<&str, &ProcessorSurface> = committed_surfaces
         .iter()
@@ -589,18 +590,22 @@ fn describe_difference(name: &str, manifest: &ProcessorSurface, code: &Processor
             manifest.execution, code.execution
         );
     }
-    if port_names(&manifest.inputs) != port_names(&code.inputs) {
+    let manifest_inputs = port_names(&manifest.inputs);
+    let code_inputs = port_names(&code.inputs);
+    if manifest_inputs != code_inputs {
         return format!(
             "`{name}` input ports differ: `processors:` has [{}], code declares [{}]",
-            port_names(&manifest.inputs).join(", "),
-            port_names(&code.inputs).join(", ")
+            manifest_inputs.join(", "),
+            code_inputs.join(", ")
         );
     }
-    if port_names(&manifest.outputs) != port_names(&code.outputs) {
+    let manifest_outputs = port_names(&manifest.outputs);
+    let code_outputs = port_names(&code.outputs);
+    if manifest_outputs != code_outputs {
         return format!(
             "`{name}` output ports differ: `processors:` has [{}], code declares [{}]",
-            port_names(&manifest.outputs).join(", "),
-            port_names(&code.outputs).join(", ")
+            manifest_outputs.join(", "),
+            code_outputs.join(", ")
         );
     }
     format!("`{name}` port schema types differ between `processors:` and code")
@@ -777,7 +782,8 @@ processors:
         // In sync — a committed manifest that names both processors with the
         // same execution + ports as code. `read_mode` / version / entrypoint on
         // the committed side are outside the drift surface, so they don't trip it.
-        check_processor_manifest_drift(root, &committed, &derived).unwrap();
+        check_processor_manifest_drift(root, &committed.iter().collect::<Vec<_>>(), &derived)
+            .unwrap();
     }
 
     #[test]
@@ -815,7 +821,9 @@ processors:
   execution: reactive
 "#,
         );
-        let report = check_processor_manifest_drift(root, &committed, &derived).unwrap_err();
+        let report =
+            check_processor_manifest_drift(root, &committed.iter().collect::<Vec<_>>(), &derived)
+                .unwrap_err();
         assert_eq!(report.only_in_code, vec!["Beta"]);
         assert!(report.only_in_manifest.is_empty());
         assert!(report.to_string().contains("Beta"));
@@ -853,7 +861,9 @@ processors:
   execution: reactive
 "#,
         );
-        let report = check_processor_manifest_drift(root, &committed, &derived).unwrap_err();
+        let report =
+            check_processor_manifest_drift(root, &committed.iter().collect::<Vec<_>>(), &derived)
+                .unwrap_err();
         assert_eq!(report.only_in_manifest, vec!["Ghost"]);
     }
 
@@ -884,7 +894,9 @@ processors:
   execution: reactive
 "#,
         );
-        let report = check_processor_manifest_drift(root, &committed, &derived).unwrap_err();
+        let report =
+            check_processor_manifest_drift(root, &committed.iter().collect::<Vec<_>>(), &derived)
+                .unwrap_err();
         assert_eq!(report.differing.len(), 1);
         assert!(report.differing[0].contains("execution differs"));
     }
@@ -921,7 +933,9 @@ processors:
     schema: VideoFrame
 "#,
         );
-        let report = check_processor_manifest_drift(root, &committed, &derived).unwrap_err();
+        let report =
+            check_processor_manifest_drift(root, &committed.iter().collect::<Vec<_>>(), &derived)
+                .unwrap_err();
         assert!(report.differing[0].contains("output ports differ"));
     }
 

--- a/sdk/streamlib-processor-extract/src/derive.rs
+++ b/sdk/streamlib-processor-extract/src/derive.rs
@@ -32,7 +32,8 @@ use std::process::Command;
 
 use serde::Deserialize;
 use streamlib_processor_schema::{
-    PortSchemaSpec, ProcessorPortSchema, ProcessorSchema, ProcessorSchemaExecution,
+    PortSchemaSpec, ProcessorLanguage, ProcessorPortSchema, ProcessorSchema,
+    ProcessorSchemaExecution,
 };
 
 use crate::reachable::{ModuleReachabilityTarget, extract_reachable_rust_processors};
@@ -54,6 +55,17 @@ impl PackageLanguage {
             PackageLanguage::Rust => "rust",
             PackageLanguage::Python => "python",
             PackageLanguage::TypeScript => "deno",
+        }
+    }
+
+    /// The [`PackageLanguage`] a committed processor's `runtime.language`
+    /// belongs to — the bridge for filtering the committed `processors:` list to
+    /// the languages actually derived.
+    pub fn of_processor(schema: &ProcessorSchema) -> Self {
+        match schema.runtime.language {
+            ProcessorLanguage::Rust => PackageLanguage::Rust,
+            ProcessorLanguage::Python => PackageLanguage::Python,
+            ProcessorLanguage::TypeScript => PackageLanguage::TypeScript,
         }
     }
 }
@@ -358,39 +370,106 @@ impl WireProcessor {
     }
 }
 
-/// Derive the full processor identity surface for a package from code, across
-/// every language it hosts. Rust is scanned in-process
-/// ([`extract_reachable_rust_processors`] against `target`); Python and Deno are
-/// derived by running their import-and-enumerate subprocess extractors through
-/// `extractor`.
+/// One language whose derivation was skipped because its subprocess extractor
+/// could not run — the runtime was absent, failed to import, or was
+/// unconfigured. The build cannot prove agreement for a skipped language, so it
+/// neither fabricates a pass nor a drift; the drift comparison simply excludes
+/// that language's committed processors (see
+/// [`filter_committed_to_languages`]).
+#[derive(Debug, Clone)]
+pub struct SkippedLanguage {
+    pub language: PackageLanguage,
+    pub reason: String,
+}
+
+/// The code-derived processor surface for a package, plus which languages were
+/// actually derived and which were skipped for want of a runtime.
+#[derive(Debug, Default)]
+pub struct DerivedProcessorSet {
+    /// The derived processor surfaces, sorted by `Type` name (a set).
+    pub surfaces: Vec<ProcessorSurface>,
+    /// The languages successfully derived — the languages whose committed
+    /// processors the drift check may compare against.
+    pub derived_languages: BTreeSet<PackageLanguage>,
+    /// Languages present but skipped (extractor runtime absent / unconfigured).
+    pub skipped: Vec<SkippedLanguage>,
+}
+
+/// Derive the processor identity surface for a package from code, across every
+/// language it hosts. Rust is scanned in-process
+/// ([`extract_reachable_rust_processors`] against `target`) and is always
+/// derived; Python and Deno are derived by running their import-and-enumerate
+/// subprocess extractors through `extractor`.
 ///
-/// The result is sorted by processor `Type` name so it is a set (order-
-/// independent) for the drift comparison.
+/// A Python/Deno extractor that cannot **run** — the runtime is absent, its
+/// import failed, or (Deno) it is unconfigured — is a [`SkippedLanguage`], not a
+/// hard error: extraction-is-import needs the runtime present, and a `pkg build`
+/// that merely bundles a Python/Deno package as source on a host without that
+/// runtime must still work. A malformed *output* from an extractor that DID run
+/// is a hard [`DeriveError`] (the extractor ran and produced garbage — a real
+/// bug, not an absent runtime). Rust scan failures are always hard.
 #[tracing::instrument(skip_all, fields(package = %package_dir.display()))]
 pub fn derive_package_processor_surfaces(
     package_dir: &Path,
     target: &ModuleReachabilityTarget,
     extractor: &dyn SubprocessProcessorExtractor,
-) -> Result<Vec<ProcessorSurface>, DeriveError> {
+) -> Result<DerivedProcessorSet, DeriveError> {
     let languages = detect_package_languages(package_dir);
-    let mut surfaces = Vec::new();
+    let mut set = DerivedProcessorSet::default();
 
     if languages.contains(&PackageLanguage::Rust) {
         let rust = extract_reachable_rust_processors(package_dir, target)?;
-        surfaces.extend(rust.iter().map(ProcessorSurface::from_extracted));
+        set.surfaces
+            .extend(rust.iter().map(ProcessorSurface::from_extracted));
+        set.derived_languages.insert(PackageLanguage::Rust);
     }
-    if languages.contains(&PackageLanguage::Python) {
-        let json = extractor.extract_python(package_dir)?;
-        surfaces.extend(parse_subprocess_manifest_json("python", &json)?);
-    }
-    if languages.contains(&PackageLanguage::TypeScript) {
-        let json = extractor.extract_deno(package_dir)?;
-        surfaces.extend(parse_subprocess_manifest_json("deno", &json)?);
+    for (language, run) in [
+        (PackageLanguage::Python, extractor.extract_python(package_dir)),
+        (PackageLanguage::TypeScript, extractor.extract_deno(package_dir)),
+    ] {
+        if !languages.contains(&language) {
+            continue;
+        }
+        match run {
+            Ok(json) => {
+                set.surfaces
+                    .extend(parse_subprocess_manifest_json(language.label(), &json)?);
+                set.derived_languages.insert(language);
+            }
+            Err(err @ (DeriveError::SpawnExtractor { .. }
+            | DeriveError::ExtractorFailed { .. }
+            | DeriveError::ExtractorUnconfigured { .. })) => {
+                let reason = err.to_string();
+                tracing::warn!(
+                    language = language.label(),
+                    reason = %reason,
+                    "skipping processor drift check for a language whose extractor runtime is \
+                     unavailable — its committed processors are not verified against code"
+                );
+                set.skipped.push(SkippedLanguage { language, reason });
+            }
+            Err(other) => return Err(other),
+        }
     }
 
-    surfaces.sort_by(|a, b| a.name.cmp(&b.name));
-    tracing::debug!(processors = surfaces.len(), "derived across languages");
-    Ok(surfaces)
+    set.surfaces.sort_by(|a, b| a.name.cmp(&b.name));
+    tracing::debug!(processors = set.surfaces.len(), "derived across languages");
+    Ok(set)
+}
+
+/// Filter a committed `processors:` list to only the processors whose runtime
+/// language is in `languages` — the languages actually derived. A drift check
+/// must never flag a committed processor whose language was skipped for want of
+/// a runtime as "only in manifest".
+pub fn filter_committed_to_languages(
+    committed: &[ProcessorSchema],
+    languages: &BTreeSet<PackageLanguage>,
+) -> Vec<ProcessorSchema> {
+    committed
+        .iter()
+        .filter(|schema| languages.contains(&PackageLanguage::of_processor(schema)))
+        .cloned()
+        .collect()
 }
 
 /// A committed `processors:` section that disagrees with what the code derives.
@@ -670,7 +749,9 @@ mod tests {
             deno: String::new(),
         };
 
-        let derived = derive_package_processor_surfaces(root, &linux(), &extractor).unwrap();
+        let derived = derive_package_processor_surfaces(root, &linux(), &extractor)
+            .unwrap()
+            .surfaces;
         assert_eq!(derived.len(), 2);
         assert_eq!(derived[0].name, "Camera"); // sorted
         assert_eq!(derived[1].name, "PassThrough");
@@ -724,7 +805,9 @@ processors:
             python: String::new(),
             deno: String::new(),
         };
-        let derived = derive_package_processor_surfaces(root, &linux(), &extractor).unwrap();
+        let derived = derive_package_processor_surfaces(root, &linux(), &extractor)
+            .unwrap()
+            .surfaces;
 
         // Committed manifest lists only Alpha — Beta was added in code and never
         // written to `processors:`. Mentally revert the drift check to `Ok(())`
@@ -760,7 +843,9 @@ processors:
             python: String::new(),
             deno: String::new(),
         };
-        let derived = derive_package_processor_surfaces(root, &linux(), &extractor).unwrap();
+        let derived = derive_package_processor_surfaces(root, &linux(), &extractor)
+            .unwrap()
+            .surfaces;
         let committed = parse_committed(
             r#"
 processors:
@@ -793,7 +878,9 @@ processors:
             python: String::new(),
             deno: String::new(),
         };
-        let derived = derive_package_processor_surfaces(root, &linux(), &extractor).unwrap();
+        let derived = derive_package_processor_surfaces(root, &linux(), &extractor)
+            .unwrap()
+            .surfaces;
         let committed = parse_committed(
             r#"
 processors:
@@ -825,7 +912,9 @@ processors:
             python: String::new(),
             deno: String::new(),
         };
-        let derived = derive_package_processor_surfaces(root, &linux(), &extractor).unwrap();
+        let derived = derive_package_processor_surfaces(root, &linux(), &extractor)
+            .unwrap()
+            .surfaces;
         let committed = parse_committed(
             r#"
 processors:
@@ -842,6 +931,54 @@ processors:
         assert!(report.differing[0].contains("output ports differ"));
     }
 
+    /// A present Python package whose extractor cannot run is a skip, not a hard
+    /// error: derivation succeeds with the language recorded in `skipped`, and
+    /// filtering the committed list to the derived languages drops the Python
+    /// processors so they are not falsely flagged as drift. Mentally reroute the
+    /// `ExtractorFailed` arm to `return Err(other)` and this build path would
+    /// hard-fail whenever python/streamlib is absent — breaking source-only
+    /// bundling.
+    #[test]
+    fn python_extractor_failure_is_skipped_not_hard_error() {
+        struct FailingPython;
+        impl SubprocessProcessorExtractor for FailingPython {
+            fn extract_python(&self, dir: &Path) -> Result<String, DeriveError> {
+                Err(DeriveError::ExtractorFailed {
+                    language: "python",
+                    package: dir.to_path_buf(),
+                    code: "1".to_string(),
+                    stderr: "No module named 'streamlib'".to_string(),
+                })
+            }
+            fn extract_deno(&self, _dir: &Path) -> Result<String, DeriveError> {
+                Ok("[]".to_string())
+            }
+        }
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "pyproject.toml", "");
+        let set = derive_package_processor_surfaces(root, &linux(), &FailingPython).unwrap();
+        assert!(set.surfaces.is_empty());
+        assert!(!set.derived_languages.contains(&PackageLanguage::Python));
+        assert_eq!(set.skipped.len(), 1);
+        assert_eq!(set.skipped[0].language, PackageLanguage::Python);
+
+        let committed = parse_committed(
+            r#"
+processors:
+- name: PassThrough
+  version: 1.0.0
+  runtime: python
+  entrypoint: src.pass:PassThrough
+  execution: reactive
+"#,
+        );
+        // Python was skipped → its committed processor is filtered out → no drift.
+        let filtered = filter_committed_to_languages(&committed, &set.derived_languages);
+        assert!(filtered.is_empty());
+        check_processor_manifest_drift(root, &filtered, &set.surfaces).unwrap();
+    }
+
     #[test]
     fn schema_only_package_has_no_processors_and_no_drift() {
         let tmp = tempdir();
@@ -851,7 +988,9 @@ processors:
             python: String::new(),
             deno: String::new(),
         };
-        let derived = derive_package_processor_surfaces(root, &linux(), &extractor).unwrap();
+        let derived = derive_package_processor_surfaces(root, &linux(), &extractor)
+            .unwrap()
+            .surfaces;
         assert!(derived.is_empty());
         check_processor_manifest_drift(root, &[], &derived).unwrap();
     }

--- a/sdk/streamlib-processor-extract/src/lib.rs
+++ b/sdk/streamlib-processor-extract/src/lib.rs
@@ -20,6 +20,7 @@
 //! here rather than the proc-macro crate, and the identity/version model the
 //! scan produces.
 
+pub mod derive;
 pub mod grammar;
 pub mod reachable;
 
@@ -27,6 +28,11 @@ use std::path::{Path, PathBuf};
 
 use streamlib_processor_schema::ProcessorSchema;
 
+pub use derive::{
+    DeriveError, ManifestDriftReport, PackageLanguage, PortSchemaSurface, PortSurface,
+    ProcessorSurface, SubprocessProcessorExtractor, SystemSubprocessProcessorExtractor,
+    check_processor_manifest_drift, derive_package_processor_surfaces, detect_package_languages,
+};
 pub use grammar::{ParsedPort, ParsedProcessorAttr};
 pub use reachable::{ModuleReachabilityTarget, extract_reachable_rust_processors};
 

--- a/sdk/streamlib-processor-extract/src/lib.rs
+++ b/sdk/streamlib-processor-extract/src/lib.rs
@@ -29,9 +29,10 @@ use std::path::{Path, PathBuf};
 use streamlib_processor_schema::ProcessorSchema;
 
 pub use derive::{
-    DeriveError, ManifestDriftReport, PackageLanguage, PortSchemaSurface, PortSurface,
-    ProcessorSurface, SubprocessProcessorExtractor, SystemSubprocessProcessorExtractor,
-    check_processor_manifest_drift, derive_package_processor_surfaces, detect_package_languages,
+    DeriveError, DerivedProcessorSet, ManifestDriftReport, PackageLanguage, PortSchemaSurface,
+    PortSurface, ProcessorSurface, SkippedLanguage, SubprocessProcessorExtractor,
+    SystemSubprocessProcessorExtractor, check_processor_manifest_drift,
+    derive_package_processor_surfaces, detect_package_languages, filter_committed_to_languages,
 };
 pub use grammar::{ParsedPort, ParsedProcessorAttr};
 pub use reachable::{ModuleReachabilityTarget, extract_reachable_rust_processors};

--- a/tools/streamlib-pack/Cargo.toml
+++ b/tools/streamlib-pack/Cargo.toml
@@ -23,6 +23,7 @@ tempfile = { workspace = true }
 zip = "2.2"
 streamlib-cargo-build = { path = "../streamlib-cargo-build", version = "0.7.10" }
 streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.7.10" }
+streamlib-processor-extract = { path = "../../sdk/streamlib-processor-extract", version = "0.7.10" }
 streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.7.10" }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/tools/streamlib-pack/src/lib.rs
+++ b/tools/streamlib-pack/src/lib.rs
@@ -527,6 +527,13 @@ pub fn assemble_artifact_with_cargo_config(
                 streamlib_idents::SESSION_ORG,
             );
         }
+        // The `#[processor(...)]` / `@processor(...)` declarations in code are the
+        // source of truth for the `processors:` section (#1411). Derive the
+        // processor set from code and refuse to build a distributable `.slpkg`
+        // whose committed `processors:` disagrees. `StagedDir` (runtime
+        // orchestrator load-time build) is exempt — it assembles an already-
+        // published, drift-validated artifact.
+        enforce_processor_manifest_matches_code(pkg_dir, &config.processors)?;
     }
 
     // (archive_path, source_path) pairs for every file EXCEPT the
@@ -749,6 +756,38 @@ fn dylib_filename(path: &Path) -> Result<String> {
         .ok_or_else(|| anyhow::anyhow!("dylib path has no filename: {}", path.display()))?
         .to_string_lossy()
         .into_owned())
+}
+
+/// Derive the processor set from a package's code and fail the build if the
+/// committed `processors:` section disagrees. The Rust half is a `syn` source
+/// scan (in-process, no compile); the Python / Deno halves shell out to the
+/// SDK's import-and-enumerate extractor CLIs. Reachability is resolved for the
+/// **host** target — the triple `pkg build` produces a cdylib for — so a
+/// cross-platform arm the host doesn't compile never counts as drift.
+///
+/// A schema-only package (no Rust crate root, no `pyproject.toml`, no
+/// `deno.json`) derives an empty set and must therefore carry no `processors:`;
+/// a package that hosts code carries exactly the processors it declares.
+fn enforce_processor_manifest_matches_code(
+    pkg_dir: &Path,
+    committed: &[streamlib_processor_schema::ProcessorSchema],
+) -> Result<()> {
+    let target = streamlib_processor_extract::ModuleReachabilityTarget::for_host();
+    let extractor = streamlib_processor_extract::SystemSubprocessProcessorExtractor;
+    let derived =
+        streamlib_processor_extract::derive_package_processor_surfaces(pkg_dir, &target, &extractor)
+            .map_err(|e| anyhow::anyhow!("deriving the processor set from code: {e}"))?;
+    // Compare only the languages actually derived. A language whose extractor
+    // runtime was unavailable (Python/Deno on a host without it) is skipped, and
+    // its committed processors are excluded rather than falsely flagged as drift.
+    let committed_in_scope =
+        streamlib_processor_extract::filter_committed_to_languages(committed, &derived.derived_languages);
+    streamlib_processor_extract::check_processor_manifest_drift(
+        pkg_dir,
+        &committed_in_scope,
+        &derived.surfaces,
+    )
+    .map_err(|report| anyhow::anyhow!("{report}"))
 }
 
 /// Enforce the standalone, registry-only contract for a published `.slpkg`:
@@ -1605,6 +1644,83 @@ mod tests {
         );
     }
 
+    /// Write a minimal Rust package that declares one `#[processor]` in code.
+    /// `manifest_processors` is spliced verbatim as the `processors:` YAML so a
+    /// test can make it agree with — or drift from — the code.
+    fn write_rust_processor_pkg(dir: &Path, manifest_processors: &str) {
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            "[package]\nname = \"cam\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("src/lib.rs"),
+            r#"#[processor("@tatolab/camera/Camera", execution = manual, output("video", "@tatolab/core/VideoFrame"))]
+            pub struct Camera;
+            "#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("streamlib.yaml"),
+            format!(
+                "package:\n  org: tatolab\n  name: cam\n  version: 0.1.0\n{manifest_processors}"
+            ),
+        )
+        .unwrap();
+    }
+
+    /// A source-only `.slpkg` build assembles when the committed `processors:`
+    /// matches the `#[processor(...)]` declarations in code. (The Slpkg target
+    /// ships source only — no cdylib build — so the Rust source scan is the only
+    /// derivation that runs; no live runtime is needed.)
+    #[test]
+    fn slpkg_build_succeeds_when_manifest_matches_code() {
+        let dir = tempdir().unwrap();
+        write_rust_processor_pkg(
+            dir.path(),
+            "processors:\n- name: Camera\n  version: 1.0.0\n  runtime: rust\n  execution: manual\n  outputs:\n  - name: video\n    schema: VideoFrame\n",
+        );
+        let out = dir.path().join("o.slpkg");
+        let outcome = assemble_artifact(
+            dir.path(),
+            &AssembleTarget::Slpkg(out.clone()),
+            &slpkg_opts(false),
+            &(),
+        )
+        .expect("in-sync manifest must build");
+        assert_eq!(outcome.processors, 1);
+    }
+
+    /// The truth-flip gate (#1411): a `.slpkg` build is a hard error when the
+    /// committed `processors:` disagrees with code. Here the manifest omits the
+    /// `Camera` the code declares. Mentally revert
+    /// `enforce_processor_manifest_matches_code` and this build succeeds despite
+    /// shipping a manifest that lies about the package's processors.
+    #[test]
+    fn slpkg_build_fails_on_processor_manifest_drift() {
+        let dir = tempdir().unwrap();
+        // Manifest lists a different processor name than code declares.
+        write_rust_processor_pkg(
+            dir.path(),
+            "processors:\n- name: Stale\n  version: 1.0.0\n  runtime: rust\n  execution: manual\n",
+        );
+        let out = dir.path().join("o.slpkg");
+        let err = assemble_artifact(
+            dir.path(),
+            &AssembleTarget::Slpkg(out),
+            &slpkg_opts(false),
+            &(),
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Camera"), "drift error must name Camera: {msg}");
+        assert!(
+            msg.contains("source of truth"),
+            "drift error must explain code is truth: {msg}"
+        );
+    }
+
     #[test]
     fn slpkg_assembly_refuses_under_an_active_link_but_staged_dir_is_exempt() {
         // The load-bearing pack-seam guard: a distributable `.slpkg` must not
@@ -1730,7 +1846,11 @@ mod tests {
         .unwrap();
         std::fs::write(dir.path().join("Cargo.toml"), b"[package]\nname='rp'\n").unwrap();
         std::fs::create_dir(dir.path().join("src")).unwrap();
-        std::fs::write(dir.path().join("src/lib.rs"), b"// crate source").unwrap();
+        std::fs::write(
+            dir.path().join("src/lib.rs"),
+            b"#[processor(\"@tatolab/rp/P\", execution = manual)]\npub struct P;\n",
+        )
+        .unwrap();
         let triple_dir = dir.path().join("lib").join(host_target_triple());
         std::fs::create_dir_all(&triple_dir).unwrap();
         let dylib = format!("librp.{}", host_dylib_extension());
@@ -2479,7 +2599,11 @@ mod tests {
         )
         .unwrap();
         std::fs::create_dir(dir.path().join("src")).unwrap();
-        std::fs::write(dir.path().join("src/lib.rs"), b"// crate source").unwrap();
+        std::fs::write(
+            dir.path().join("src/lib.rs"),
+            b"#[processor(\"@tatolab/rp/P\", execution = manual)]\npub struct P;\n",
+        )
+        .unwrap();
 
         let out = dir.path().join("o.slpkg");
         assemble_artifact(


### PR DESCRIPTION
Closes #1411

## Summary

- `sdk/streamlib-processor-extract`: cross-language (Rust/Python/Deno) processor derivation from code, plus per-platform module reachability (`reachable.rs`) so only processors reachable for the host target are compared.
- `tools/streamlib-pack`: `pkg build` now flips to the code-derived processor manifest as the source of truth, gated by `enforce_processor_manifest_matches_code` — any drift between the committed `processors:` block and what's actually reachable in code is a hard build error (`only_in_code`, `only_in_manifest`, execution/port mismatches all covered).
- `docs/decisions/manifest-extraction-capability.md` records the drift-gate + drift-surface rationale.

This is the truth-flip stage of the #1411 manifest-extraction capability (stage 1 landed in #1439, per-platform reachability landed in #1445, Python/Deno decorator inversion landed in #1440/#1448). With this PR, the manifest is no longer hand-authored truth — it's a derived, drift-checked projection of the code.

## Test evidence

```
cargo test --lib -p streamlib-processor-extract -p streamlib-pack
```

- `streamlib-processor-extract`: 59 passed, 0 failed (grammar, derive, reachable module coverage — cfg combinators, feature-gated modules, cross-platform arm resolution, parked `cfg(any())` exclusion, drift detection for only-in-code / only-in-manifest / execution-mismatch / added-port cases)
- `streamlib-pack`: 54 passed, 0 failed, including `slpkg_build_fails_on_processor_manifest_drift` (negative gate test) and `slpkg_build_succeeds_when_manifest_matches_code` (positive path)

Verified end-to-end against real in-tree packages: `packages/audio` (7 processors, platform shims present) and `packages/camera` (2 processors) both `streamlib pkg build` cleanly on Linux.

## Review items (non-blocking)

These surfaced during lens review and don't block merge, but are worth the owner's eyes:

1. **[should-fix]** `sdk/streamlib-processor-extract/src/derive.rs:464` — A target-gated (e.g. Apple-only) processor listed in a cross-platform committed manifest will false-drift on a host that doesn't compile that arm. `filter_committed_to_languages` filters committed processors by `PackageLanguage` (rust/python/deno), NOT by cfg/target. On a Linux `pkg build`, if the crate has any rust processor, Rust is in `derived_languages`, so a macOS-only rust processor in `processors:` survives the filter, is absent from the host-target derived set (reachable scan uses `for_host()`), and lands in `only_in_manifest` → hard drift error. The `enforce_processor_manifest_matches_code` doc comment (`tools/streamlib-pack/src/lib.rs`) claims "a cross-platform arm the host doesn't compile never counts as drift" — true only for the `only_in_code` direction, not `only_in_manifest`. Currently latent: no in-tree package has an Apple-only processor (Apple is parked under `cfg(any())`); verified `packages/audio` (7 procs, platform shims present) and `packages/camera` (2 procs) both `streamlib pkg build` cleanly on Linux. Suggested next step: track for Apple activation — exclude committed processors that are target-gated for a non-host triple from the `only_in_manifest` comparison, or derive across all supported targets.

2. **[should-fix]** `sdk/streamlib-processor-extract/src/derive.rs:426` — The Python and Deno extractors are spawned unconditionally on every derivation, even for packages that don't host that language. The array literal `[(Python, extractor.extract_python(package_dir)), (TypeScript, extractor.extract_deno(package_dir))]` eagerly evaluates BOTH subprocess calls when the array is constructed — the `if !languages.contains(&language) { continue; }` guard at line 430 runs only afterward, so it discards an already-spawned process rather than preventing the spawn. For the common Rust-only package this shells out to `python3 -m streamlib.extract_processors` and (if configured) `deno run ...` over a directory with no Python/Deno, throwing the output away. Correctness is preserved (skipped-language results are dropped), but every distributable `pkg build` pays needless subprocess I/O and can trigger surprising extractor invocations in environments where those runtimes are configured. Suggested next step: make the extractor call lazy under the presence guard — iterate over just the language tags, `continue` when not present, then match on `language` to invoke the corresponding `extractor.extract_*` only when actually present.

3. **[low]** `sdk/streamlib-processor-extract/src/derive.rs:82` — A package with a `Cargo.toml` but no `src/lib.rs` or `src/main.rs` crate root is not detected as Rust, so its committed rust processors are silently dropped from the drift check rather than flagged. `detect_package_languages` requires `Cargo.toml` AND (`src/lib.rs` || `src/main.rs`). A crate using a custom `[lib]` path, or a manifest listing rust processors with no crate root, passes the gate vacuously. The `slpkg_rejects_path_cargo_dependency` test relies on exactly this shape to avoid tripping the gate. Suggested next step: consider detecting the crate root from `Cargo.toml`'s `[lib]` path, or treat a `Cargo.toml` with committed rust-runtime processors but no scannable root as an error. Non-blocking.

4. **[low]** `sdk/streamlib-processor-extract/src/derive.rs:592` — `describe_difference` recomputes each `port_names(...)` `Vec<String>` twice: once in the `if` condition and again inside the `format!` body (for both inputs and outputs). Each call allocates a fresh `Vec` plus a `String` per port. Suggested next step: bind `port_names(&manifest.inputs)` / `port_names(&code.inputs)` once and reuse in both the comparison and the format (same for outputs). Cold path, purely a cleanliness nit.

5. **[info]** `sdk/streamlib-processor-extract/src/derive.rs:131` — Port schema comparison collapses to the `Type` short-name, so an org/package swap on a port schema is not detected as drift. `PortSchemaSurface::from_spec` maps both `Named(name)` and `Specific(ident)` to `Type(<short type name>)`, dropping org/package. Two schemas `@a/x/VideoFrame` and `@b/y/VideoFrame` compare equal. This is documented (module doc) and inherent — the committed bare `schema: VideoFrame` (Named) form carries no org/package — so it is the correct common denominator, but it is a known blind spot. No action suggested; recorded for awareness.

6. **[info]** `tools/streamlib-pack/src/lib.rs:530` — Negative/gate tests are non-vacuous and the gate is correctly scoped. `slpkg_build_fails_on_processor_manifest_drift` asserts the error message contains `"Camera"` AND `"source of truth"` (a string only `ManifestDriftReport::Display` emits) — reverting `enforce_processor_manifest_matches_code` makes assemble succeed and the `.unwrap_err()` panics. The call sits inside the `matches!(target, AssembleTarget::Slpkg(_))` block, so `StagedDir` (orchestrator load-time) stays exempt as documented. Derive-level tests (`only_in_code` / `only_in_manifest` / execution / added-port) each construct real drift and assert the specific report field. No action needed.

7. **[info]** `sdk/streamlib-processor-extract/src/derive.rs:464` — `filter_committed_to_languages` clones every retained `ProcessorSchema` (`.cloned().collect()`), and the sole caller (`check_processor_manifest_drift`) immediately re-projects each one to a `ProcessorSurface` and discards the owned schemas. The full-schema clone is redundant work. Optional: return `Vec<&ProcessorSchema>` (borrowing), or project straight to `Vec<ProcessorSurface>` here, so the drift check consumes the filtered surface without an intermediate owned-schema copy. Build-time path, not load-bearing — noting only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)