### PR TITLE
docs(architecture): zero-ceremony authoring guide + supersession sweep

### DIFF
--- a/docs/architecture/package-staging-layout.md
+++ b/docs/architecture/package-staging-layout.md
@@ -20,10 +20,17 @@ package is laid out, and all three runtimes use it. The payoff is that
 every relative path the author wrote resolves identically in dev and in
 the artifact:
 
-- A processor's sibling `streamlib.yaml` (the `@processor` decorator and
-  the Rust/Python proc-macros resolve the manifest as a sibling of the
-  source file).
-- A Deno processor's `./_generated_/<org>__<pkg>/<type>.ts` import.
+- > ~~A processor's sibling `streamlib.yaml` (the `@processor` decorator
+  > and the Rust/Python proc-macros resolve the manifest as a sibling of
+  > the source file).~~ — Superseded 2026-07-19: the decorator / proc-macro
+  > is the truth-source and reads **nothing** from disk at decoration time
+  > (see [`zero-ceremony-authoring.md`](zero-ceremony-authoring.md) and the
+  > `@processor` docstrings). Identity, execution, and ports are declared
+  > in code; a bare module with no `streamlib.yaml` is a working local
+  > processor. The mirror invariant still matters for *authored assets a
+  > package ships and reads at runtime* (below), not for manifest lookup.
+- A Deno processor's `./_generated_/<org>__<pkg>/<type>.ts` import (only
+  when the consumer opts into `streamlib generate` typed views).
 - Any asset a package ships and reads at runtime (`./shaders/x.wgsl`,
   `./models/y.bin`, embedded video/html/data) — at its authored path.
 
@@ -121,12 +128,19 @@ failure mode this rule prevents: a language whose assembler dropped the
 entrypoint into a subdir (`deno/<file>.ts`) while leaving
 `streamlib.yaml` at the root, and which bundled only the entrypoint
 rather than the full tree. The result was a staged layout the author
-never wrote — the sibling-manifest lookup failed, `_generated_` and
-`.npmrc` and assets never travelled, and the symptom (`@processor`
-reporting `streamlib.yaml not found`) pointed at the decorator rather
-than at the relocation that actually caused it. The fix was not to teach
-the decorator to climb directories; it was to stop relocating, so the
-authored layout and the staged layout agree by construction.
+never wrote — `_generated_` and `.npmrc` and assets never travelled, and
+the symptom pointed at the decorator rather than at the relocation that
+actually caused it. The fix was not to teach the decorator to climb
+directories; it was to stop relocating, so the authored layout and the
+staged layout agree by construction.
+
+> ~~The historical trigger for this rule was `@processor` reporting
+> `streamlib.yaml not found` after a relocation.~~ — Corrected 2026-07-19:
+> the decorator no longer reads a sibling `streamlib.yaml` at all
+> ([`zero-ceremony-authoring.md`](zero-ceremony-authoring.md)), so that
+> particular symptom can no longer occur. The rule still holds for the
+> asset / `_generated_` / `.npmrc` paths that *are* resolved relative to
+> the authored layout.
 
 If a new runtime or a new asset class tempts a relocation "for
 symmetry," stop — the symmetry that matters is dev-layout ==
@@ -141,8 +155,7 @@ staged-layout, and that is achieved by mirroring, not by moving.
   `provision_python_venv` (+ `ensure_streamlib_generated_in_venv`) in
   `src/python_venv.rs`; `provision_deno_typescript` (+
   `staged_package_has_deno`) in `src/deno_codegen.rs`.
-- **Consumers of the layout**: the `@processor` sibling-manifest lookup
-  in `sdk/streamlib-deno/decorators.ts`; the entrypoint resolution in
+- **Consumers of the layout**: the entrypoint resolution in
   `sdk/streamlib-deno/subprocess_runner.ts` (`resolveDenoModulePath`
   resolves against the package root); the Deno spawn op
   (`--config <pkg>/deno.json`) in

--- a/docs/architecture/schema-identity-and-packaging.md
+++ b/docs/architecture/schema-identity-and-packaging.md
@@ -443,13 +443,14 @@ use tatolab_core::VIDEO_FRAME_IDENT;
 graph.add_edge(VIDEO_FRAME_IDENT, …);   // No org/package on the wire
 ```
 
-The package-internal short-name pattern
-(`#[streamlib::processor("Camera")]` — positional PascalCase short
-name resolved against the enclosing `streamlib.yaml`'s `package:`
-block, exposed via `Processor::schema_ident()`) is the canonical
-shorthand mechanism for **owning** a processor's identity inside its
-own crate. Three macros sit alongside it for **referencing**
-processors at a call site (typically the spawning binary that doesn't
+> ~~The package-internal short-name pattern (`#[streamlib::processor("Camera")]` — positional
+> PascalCase short name resolved against the enclosing `streamlib.yaml`'s `package:` block) is the
+> canonical shorthand for **owning** a processor's identity.~~ — Superseded 2026-07-19: a
+> `#[processor("@org/package/Type")]` declares a **version-free identity in code** (or synthesizes
+> `@app/local/<Type>`), reading nothing from a manifest. See
+> [`zero-ceremony-authoring.md`](zero-ceremony-authoring.md).
+
+Three macros **reference** a processor at a call site (typically the spawning binary that doesn't
 own the processor's Rust module):
 
 - **`streamlib::sdk::processor_type_ref!("org", "package", "Type")`**
@@ -527,17 +528,12 @@ to the authoring path:
   `streamlib_idents::Org` / `Package` / `TypeName` / `SemVer`
   enforce). No `parse` / `from_str` API; the joined `__str__` form
   is render-only and never round-trips through a parser.
-- **`streamlib._manifest`** — hand-rolled minimal YAML reader
-  that extracts the `package: { org, name, version }` block plus
-  the processor-name list. Avoids adding PyYAML as the SDK's first
-  runtime dep. Full manifest deserialization stays Rust-side.
-- **`@streamlib.processor("PascalCase")`** — mirrors Rust's
-  `#[streamlib::processor("Camera")]` proc-macro: positional
-  PascalCase short name resolved at decoration time against the
-  enclosing package's `streamlib.yaml`. The decorator validates
-  that the short name appears in the manifest's `processors:`
-  list and attaches `__streamlib_schema_ident__: SchemaIdent` to
-  the class.
+- > ~~**`streamlib._manifest`** — hand-rolled YAML reader for the `package:` block + processor-name
+  > list; **`@streamlib.processor("PascalCase")`** — positional short name resolved at decoration
+  > time against the enclosing `streamlib.yaml`, validated against the manifest's `processors:` list.~~
+  > — Superseded 2026-07-19: `_manifest` was removed and `@processor("@org/package/Type")` declares a
+  > version-free identity from the decorator arguments, reading nothing from disk. See
+  > [`zero-ceremony-authoring.md`](zero-ceremony-authoring.md).
 - **`@streamlib.input(schema=...)` / `@streamlib.output(schema=...)`**
   — accept a `SchemaIdent` instance or a class that carries
   `__streamlib_schema_ident__`. Bare-string and joined-string
@@ -619,13 +615,12 @@ const today.
   - `sdk/streamlib-python/python/streamlib/schema_ident.py` —
     Python `SchemaIdent` dataclass with regex-validating
     constructors and render-only joined `__str__`.
-  - `sdk/streamlib-python/python/streamlib/_manifest.py` —
-    hand-rolled minimal YAML reader for `package:` block +
-    `processors[].name` list.
+  - ~~`sdk/streamlib-python/python/streamlib/_manifest.py`~~ — removed 2026-07-19 (the decorators no
+    longer read a manifest).
   - `sdk/streamlib-python/python/streamlib/decorators.py` —
-    `@processor("PascalCase")` / `@input` / `@output`
-    decorators; manifest-driven structured ident attached at
-    decoration time.
+    `@processor("@org/package/Type")` / `@input` / `@output`
+    decorators; version-free identity from the decorator arguments,
+    read from code, not a manifest.
 - **Tests**:
   - `sdk/streamlib-idents/src/{ident,semver,manifest,lockfile,resolver}.rs::tests`
     — unit tests covering grammar conformance, semver-range matching,
@@ -649,13 +644,10 @@ const today.
   - `xtask/src/check_no_streamlib_metadata.rs::tests` —
     legacy-metadata lint fixtures.
   - `sdk/streamlib-python/python/streamlib/tests/test_processor_decorator.py`
-    — `SchemaIdent` validation, `@processor` manifest-driven
-    decoration paths, `@input` / `@output` schema rejection of
+    — `SchemaIdent` validation, `@processor` version-free identity
+    decoration, `@input` / `@output` schema rejection of
     bare-string and joined-string forms.
-  - `sdk/streamlib-python/python/streamlib/tests/test_manifest_reader.py`
-    — minimal YAML reader edge cases (quoted scalars, comments,
-    nested processor bodies, missing fields, name-first ordering
-    constraint).
+  - ~~`test_manifest_reader.py`~~ — removed 2026-07-19 with the `_manifest` reader.
 - **Sibling architecture docs**:
   - [`compute-kernel.md`](compute-kernel.md), [`graphics-kernel.md`](graphics-kernel.md),
     [`ray-tracing-kernel.md`](ray-tracing-kernel.md) — the kernel-shape

--- a/docs/architecture/schema-identity-and-packaging.md
+++ b/docs/architecture/schema-identity-and-packaging.md
@@ -543,22 +543,36 @@ to the authoring path:
   `__streamlib_schema_ident__`. Bare-string and joined-string
   forms are rejected at decoration time, mirroring the no-parse
   invariant on the Rust side.
-- **Schemas enter Python only through codegen.** Authors import
-  generated dataclasses from `streamlib._generated_.<package>`
-  (or their own package's `_generated_/`); the codegen Python
-  post-processor injects
-  `__streamlib_schema_ident__: ClassVar[SchemaIdent] =
-  SchemaIdent(org=…, package=…, type_=…, version=…)` as a class
-  attribute on every new-shape (`metadata.type` + package
-  context) generated dataclass, so `@input(schema=GeneratedClass)`
-  resolves to a structured `SchemaIdent` directly. There is no
-  language-side authoring affordance for declaring schemas —
-  JTD-in-YAML is the canonical schema source, and deriving JTD
-  from Python field declarations would leak Python-native
-  expressivity (custom classes, numpy types, pydantic types)
-  that doesn't translate cross-language. The same constraint
-  applies to Rust and Deno: schemas are always YAML-authored,
-  generated code is what authors import.
+- > ~~**Schemas enter Python only through codegen.** Authors import
+  > generated dataclasses from `streamlib._generated_.<package>`
+  > (or their own package's `_generated_/`) … There is no
+  > language-side authoring affordance for declaring schemas —
+  > JTD-in-YAML is the canonical schema source … schemas are always
+  > YAML-authored, generated code is what authors import.~~ —
+  > Superseded 2026-07-19 by the two-door descriptor model (see
+  > [`zero-ceremony-authoring.md`](zero-ceremony-authoring.md)).
+  > Codegen is no longer the *only* door schemas enter a language, and
+  > importing generated types is no longer required to move data:
+  >
+  > 1. **Self-describing wire** — a processor sends / receives msgpack
+  >    named maps (`Bag`) with **zero type**; the wire carries its own
+  >    field names, so no schema and no generated type is needed to
+  >    interoperate.
+  > 2. **An optional by-ID JTD descriptor** — for validation, the visual
+  >    builder, and opt-in typed views, referenced by identity and
+  >    **consumed as data, with no codegen**.
+  > 3. **`streamlib generate` typed views are opt-in sugar** — importing
+  >    a generated dataclass for static field access is a convenience,
+  >    never a requirement.
+  >
+  > JTD-in-YAML survives as the authored source **only** for a shared
+  > vocabulary type (one small contract-only file). What still holds:
+  > when codegen *is* run, the Python post-processor injects
+  > `__streamlib_schema_ident__: ClassVar[SchemaIdent]` on every
+  > generated dataclass so `@input(schema=GeneratedClass)` resolves to a
+  > structured `SchemaIdent` directly; and deriving JTD from Python /
+  > Deno field declarations is still rejected (it would leak
+  > language-native expressivity that doesn't translate cross-language).
 
 The reason for the focused subset rather than full parity:
 structured-everywhere eliminates the need for non-Rust callers to

--- a/docs/architecture/schema-identity-and-packaging.md
+++ b/docs/architecture/schema-identity-and-packaging.md
@@ -543,36 +543,15 @@ to the authoring path:
   `__streamlib_schema_ident__`. Bare-string and joined-string
   forms are rejected at decoration time, mirroring the no-parse
   invariant on the Rust side.
-- > ~~**Schemas enter Python only through codegen.** Authors import
-  > generated dataclasses from `streamlib._generated_.<package>`
-  > (or their own package's `_generated_/`) … There is no
-  > language-side authoring affordance for declaring schemas —
-  > JTD-in-YAML is the canonical schema source … schemas are always
-  > YAML-authored, generated code is what authors import.~~ —
-  > Superseded 2026-07-19 by the two-door descriptor model (see
-  > [`zero-ceremony-authoring.md`](zero-ceremony-authoring.md)).
-  > Codegen is no longer the *only* door schemas enter a language, and
-  > importing generated types is no longer required to move data:
-  >
-  > 1. **Self-describing wire** — a processor sends / receives msgpack
-  >    named maps (`Bag`) with **zero type**; the wire carries its own
-  >    field names, so no schema and no generated type is needed to
-  >    interoperate.
-  > 2. **An optional by-ID JTD descriptor** — for validation, the visual
-  >    builder, and opt-in typed views, referenced by identity and
-  >    **consumed as data, with no codegen**.
-  > 3. **`streamlib generate` typed views are opt-in sugar** — importing
-  >    a generated dataclass for static field access is a convenience,
-  >    never a requirement.
-  >
-  > JTD-in-YAML survives as the authored source **only** for a shared
-  > vocabulary type (one small contract-only file). What still holds:
-  > when codegen *is* run, the Python post-processor injects
-  > `__streamlib_schema_ident__: ClassVar[SchemaIdent]` on every
-  > generated dataclass so `@input(schema=GeneratedClass)` resolves to a
-  > structured `SchemaIdent` directly; and deriving JTD from Python /
-  > Deno field declarations is still rejected (it would leak
-  > language-native expressivity that doesn't translate cross-language).
+- ~~**Schemas enter Python only through codegen.** Authors import generated
+  dataclasses; there is no language-side affordance for declaring a schema —
+  JTD-in-YAML is the canonical source and generated code is what authors import.~~
+  — Superseded 2026-07-19 by the two-door descriptor model
+  ([`zero-ceremony-authoring.md`](zero-ceremony-authoring.md)): the self-describing
+  `Bag` wire carries its own field names, so no schema and no generated type is
+  needed to interoperate; a by-ID JTD descriptor is consumed as data, never via
+  required codegen. `@input(schema=GeneratedClass)` is now an optional typed view,
+  not the only door schemas enter a language.
 
 The reason for the focused subset rather than full parity:
 structured-everywhere eliminates the need for non-Rust callers to

--- a/docs/architecture/zero-ceremony-authoring.md
+++ b/docs/architecture/zero-ceremony-authoring.md
@@ -1,0 +1,159 @@
+# Zero-ceremony authoring
+
+> Current known state of the authoring surface. Subject to staleness or
+> drift — verify against the code before relying on any claim. Not
+> authoritative, not enforcement.
+
+## What this document describes
+
+How a processor is authored today: identity and ports declared **in
+code**, configuration carried as a dynamic [`Bag`], a graph wired
+directly through `App` sugar, and packaging reserved for the moment a
+processor is *shared*. The through-line is that nothing on the authoring
+path requires a manifest, a config schema, a build step, or codegen. A
+bare source module is a working local processor; ceremony is opt-in and
+scoped to the consumer that actually shares wire vocabulary.
+
+## The processor is the code
+
+A processor's identity, execution mode, scheduling, and ports are
+declared on the type itself. No sibling `streamlib.yaml` is read to
+learn what a processor is or what it declares — the decorator (Python /
+Deno) and the `#[processor]` proc-macro (Rust) are the truth-source.
+
+- **Rust** — `#[streamlib::sdk::processor("@org/package/Type", execution
+  = manual)]` on a struct. The macro synthesizes identity and the
+  runtime registers the type; a `#[processor]` type in a plain crate,
+  with no package and no build, is a complete processor.
+- **Python** — `@processor("@org/package/Type", execution="manual")` on
+  a class. Identity, execution, and scheduling come from the decorator
+  arguments; nothing is read from disk at decoration time.
+- **Deno** — `@processor("@org/package/Type", { execution: "manual" })`
+  on a class, same contract.
+
+The identity string is **version-free** (`@org/package/Type`, no
+`@version`): a schema reference is an identity the runtime binds
+version-blind, and the concrete version is derived at package-build
+time, never hand-authored. Omitting the identity entirely synthesizes
+`@app/local/<TypeName>` — a bare module with no manifest defines a
+working local processor.
+
+The package's processor set is derived by **importing the modules and
+enumerating what registered**, never by reading a hand-authored
+`processors:` list out of a manifest. In Rust the equivalent is a `syn`
+source-scan that reads the AST without running it; in Python and Deno
+extraction *is* import.
+
+## Config is a `Bag`
+
+A processor's configuration does not require a schema. [`Bag`] is a
+dynamic, self-describing msgpack named-map payload: a processor declares
+`type Config = Bag` (Rust) — or accepts a plain dict / object
+(Python / Deno) — and reads the fields it needs at runtime with named,
+typed accessors. A missing key and a wrong-typed key are distinct named
+errors, never a panic and never an untyped failure.
+
+`Bag` is the schema-free counterpart to the typed `read::<T>` /
+`write::<T>` paths. It encodes byte-for-byte as the same msgpack named
+map a generated config struct would, so a `Bag`-typed config crosses the
+plugin ABI exactly like a codegen struct, and a processor can migrate
+between the two without a wire change. There is no mandatory config
+schema on the authoring path.
+
+## Wiring: `App` sugar
+
+`App` is thin authoring sugar over the runtime `Runner` — it holds one
+`Runner`, adds no runtime state of its own, and forwards every call. For
+anything the sugar omits, `App::runner` is the escape hatch back to the
+full surface.
+
+- **`App::add(processor_ref, config)`** — add a processor by version-free
+  type reference, configured from any serializable value (a generated
+  config struct, a plain struct, or a `Bag`). A reference to a
+  not-yet-built package materializes from source on demand.
+- **`App::add_local::<P>(config)`** — register a `#[processor]` host type
+  `P` live, with **no package on disk**, and instantiate it in one call.
+  This is the zero-ceremony hello-world path: a `#[processor]` type in
+  the same crate becomes a connectable node with no manifest, no build,
+  and no staging.
+- **`App::connect((&from, "out"), (&to, "in"))`** — connect an output
+  endpoint to an input endpoint by the `ProcessorUniqueId` an
+  `add`/`add_local` call returned and the source-declared port name. A
+  nonexistent port surfaces the runtime's typed
+  `ProcessorPortNotFound` unchanged.
+- **`App::run()`** — start the graph and block until a shutdown signal.
+
+## Packaging is only for sharing
+
+Nothing above needs a package. A `streamlib.yaml` manifest, a staged
+package cache slot, and a published `.slpkg` exist to **share** a
+processor across projects or machines — they are distribution mechanics,
+not an authoring requirement. A processor you only run locally never
+acquires a manifest. When you do package for sharing, the staged artifact
+is a faithful mirror of the authored source tree (see
+[`package-staging-layout.md`]); packaging adds distribution metadata, it
+does not change how the processor is authored.
+
+## The two-door descriptor model
+
+Schema authoring collapses to two doors, and the second is optional:
+
+1. **Self-describing wire** — send / receive with **zero type**. A
+   processor emits and consumes msgpack named maps (`Bag`) directly; the
+   wire carries its own field names, so no schema, no generated type, and
+   no codegen is needed to move data between processors.
+2. **An optional by-ID JTD descriptor** — for validation, the visual
+   builder, and opt-in typed views. It is referenced by identity and
+   **consumed as data, with no codegen**. A processor that wants
+   validation or a builder entry points at a descriptor by ID; the
+   descriptor is loaded and interpreted, never compiled in.
+3. **`streamlib generate` typed views are opt-in sugar only** — running
+   codegen to import a generated struct/dataclass/interface is a
+   convenience for authors who want static field access, never a
+   requirement for correctness or for moving data.
+
+Ceremony-death is scoped to the **consumer**: the `schemas:` closure
+map, `build.rs`, the `_generated_` tree, and `streamlib-codegen.lock` all
+belong to the opt-in typed-view path and disappear from a processor that
+stays on the self-describing wire. A **shared vocabulary type** — a wire
+contract two independently-built processors must agree on — still carries
+one small authored contract-only JTD file: the by-ID descriptor above.
+That single authored contract is the floor; there is no ceremony below it.
+
+## Standing guidance: the separate-build GPU hazard at the share boundary
+
+A **shared** processor is built separately from the host that loads it (a
+prebuilt cdylib per packing host). GPU code inside such a separately-built
+processor must route through the cdylib-safe `FullAccess` primitives —
+`ctx.gpu_full_access().…` — never a hand-rolled RHI call against a device
+handle transited across the plugin ABI. The raw-device transit slots that
+once made this a live hazard have been removed, so this is **standing
+guidance**, not an open landmine: the safe primitives are the only door,
+and there is no raw-Arc device to hand-roll against. Refcount and device
+lifetime accounting run in host-compiled code via the clone/drop slots;
+the plugin never touches the host's device directly. See
+[`cdylib-reachability.md`] and [`plugin-abi.md`].
+
+## Reference
+
+- **`App` sugar** — `App::add` / `add_local` / `connect` / `run` in
+  `sdk/streamlib-sdk/src/sdk/app.rs`, exercised in
+  `sdk/streamlib-sdk/tests/app_sugar_test.rs`.
+- **`Bag`** — `sdk/streamlib-plugin-sdk/src/bag.rs`.
+- **`#[processor]` extraction** — `sdk/streamlib-macros`,
+  `sdk/streamlib-processor-extract`; the Python decorator in
+  `sdk/streamlib-python/python/streamlib/decorators.py`; the Deno
+  decorator in `sdk/streamlib-deno/decorators.ts`.
+- **Related**:
+  - [`schema-identity-and-packaging.md`] — schema identity grammar and
+    the codegen path the opt-in typed views ride.
+  - [`package-staging-layout.md`] — how a shared package is laid out.
+  - [`plugin-abi.md`] / [`cdylib-reachability.md`] — the plugin ABI and
+    the cdylib-safe `FullAccess` primitives the share-boundary guidance
+    rests on.
+
+[`Bag`]: ../../sdk/streamlib-plugin-sdk/src/bag.rs
+[`package-staging-layout.md`]: package-staging-layout.md
+[`schema-identity-and-packaging.md`]: schema-identity-and-packaging.md
+[`plugin-abi.md`]: plugin-abi.md
+[`cdylib-reachability.md`]: cdylib-reachability.md

--- a/sdk/streamlib-deno/decorators.ts
+++ b/sdk/streamlib-deno/decorators.ts
@@ -30,12 +30,19 @@
  * `sdk/streamlib-processor-extract` (there the scan reads the AST without
  * running it; here extraction is import). See `extract_processors.ts`.
  *
- * Schema references in port declarations (`@input(...)` / `@output(...)`)
- * are cross-package by definition. The only accepted forms are a
- * {@linkcode SchemaIdent} instance or a class carrying
- * `streamlibSchemaIdent` as a static field. String forms (bare type
- * name or joined `@org/pkg/Type@v`) are rejected — schemas have no
- * shorthand. See `docs/architecture/schema-identity-and-packaging.md`.
+ * Schema references in port declarations follow the two-door descriptor
+ * model (`docs/architecture/zero-ceremony-authoring.md`). A port needs
+ * **no** schema to move data: the wire is self-describing (msgpack named
+ * maps / `Bag`), so send and receive work with zero type. When a port
+ * *does* declare a schema — for validation, the visual builder, or
+ * opt-in typed views — the reference is cross-package by definition, and
+ * the only accepted forms are a {@linkcode SchemaIdent} instance or a
+ * class carrying `streamlibSchemaIdent` as a static field (produced by
+ * the opt-in `streamlib generate`). String forms (bare type name or
+ * joined `@org/pkg/Type@v`) are rejected — schemas have no shorthand.
+ * `streamlib generate` typed views are sugar consumed as data;
+ * JTD-in-YAML remains the authored source for a shared vocabulary type.
+ * See `docs/architecture/schema-identity-and-packaging.md`.
  *
  * Timestamps
  * ----------

--- a/sdk/streamlib-python/python/streamlib/decorators.py
+++ b/sdk/streamlib-python/python/streamlib/decorators.py
@@ -28,17 +28,21 @@ the Python analogue of the Rust `syn` source-scan in
 it; here extraction is import). See
 [`streamlib.extract_processors`][].
 
-Schema references in port declarations (`@input(schema=...)` /
-`@output(schema=...)`) are cross-package by definition. The only accepted
-forms are a [`SchemaIdent`][streamlib.schema_ident.SchemaIdent] instance
-or a codegen-emitted class carrying `__streamlib_schema_ident__` as a
-class attribute (produced by `streamlib generate` from the package's
-JTD/YAML schemas). There is no Python-side authoring decorator for
-declaring new schemas — JTD-in-YAML is the canonical schema source, and
-deriving JTD from Python field declarations would leak Python-native
-expressivity that doesn't translate cross-language. See the architecture
-preamble in issue #704 and
-`docs/architecture/schema-identity-and-packaging.md`.
+Schema references in port declarations follow the two-door descriptor
+model (`docs/architecture/zero-ceremony-authoring.md`). A port needs
+**no** schema to move data: the wire is self-describing (msgpack named
+maps / `Bag`), so send and receive work with zero type. When a port
+*does* declare a schema — for validation, the visual builder, or opt-in
+typed views — the reference is cross-package by definition, and the only
+accepted forms are a [`SchemaIdent`][streamlib.schema_ident.SchemaIdent]
+instance or a codegen-emitted class carrying `__streamlib_schema_ident__`
+as a class attribute (produced by the opt-in `streamlib generate` from
+the package's JTD/YAML schemas). There is still no Python-side decorator
+for *authoring* a new schema: `streamlib generate` typed views are sugar
+consumed as data, JTD-in-YAML remains the authored source for a shared
+vocabulary type, and deriving JTD from Python field declarations would
+leak Python-native expressivity that doesn't translate cross-language.
+See `docs/architecture/schema-identity-and-packaging.md`.
 
 Timestamps
 ----------


### PR DESCRIPTION
Closes #1415

## Summary

Adds the zero-ceremony authoring guide and completes the supersession sweep for the two-door descriptor model.

- `docs/architecture/zero-ceremony-authoring.md` (new): describes the two-door model for schema authoring — door #1 (byte-shaped inline payloads, no descriptor needed) and door #2 (optional by-ID JTD descriptor for validation, the visual builder, and opt-in typed views), consumed as data with no codegen.
- `docs/architecture/schema-identity-and-packaging.md`: dated strikethrough over the superseded "schemas enter Python only through codegen" claim, replaced by the two-door model. Retains the still-true "no language-side authoring of new schemas" doctrine — a shared vocabulary type still carries one small authored contract-only JTD file.
- `docs/architecture/package-staging-layout.md`: supersession sweep to keep staging-layout references consistent with the two-door model.
- `sdk/streamlib-deno/decorators.ts`, `sdk/streamlib-python/python/streamlib/decorators.py`: docstring updates only (no logic changes) to reflect current state — no Python/Deno-side decorator for authoring a brand-new schema; JTD-in-YAML remains the authored source for a shared vocabulary type.

## Test evidence

Docs-only change; no production code logic changed (decorator edits are docstring-only).

- `python3 -c "import ast; ast.parse(open('sdk/streamlib-python/python/streamlib/decorators.py').read())"` → parse OK.
- All documented `App`/`Bag`/`add_local` symbols referenced in the guide resolve in the tree (`sdk/streamlib-sdk/src/sdk/app.rs`).
- CI markdown/logging/license gates apply mechanically to this diff.

## Review items (non-blocking)

- **info** — `docs/architecture/zero-ceremony-authoring.md:118`: The two-door descriptor model's door #2 (by-ID JTD descriptor for validation and the visual builder) is written in present tense as current architecture, but the M34 milestone marks the descriptor/validation strand as phase 2 (#1430, unshipped) and the "visual builder" has no shipped consumer.
  Evidence: Guide: "An optional by-ID JTD descriptor — for validation, the visual builder, and opt-in typed views ... consumed as data, with no codegen." Milestone body: "the descriptor/validation strand is phase 2 (filed as #1430)." Mitigated by the doc's own disclaimer header ("Not authoritative, subject to staleness — verify against the code") and by the ticket's post-audit design update, which explicitly directs the guide to state the two-door model verbatim.
  Suggested next step: No change required — inclusion is owner-mandated in the ticket and the disclaimer header scopes authoritativeness. Note in the PR body that door-2's validation/visual-builder consumers are forward-looking so the owner can confirm the framing.

- **info** — `docs/architecture/schema-identity-and-packaging.md:540`: The ticket's acceptance bullet asked for a dated strikethrough over the "no Python-side schema authoring" doctrine; the implementer struck only the narrower "schemas enter Python only through codegen" claim and retained the "no language-side authoring of new schemas" doctrine.
  Evidence: Struck: "~~Schemas enter Python only through codegen ... there is no language-side affordance~~ — Superseded ... by the two-door descriptor model". Retained in decorators.py/.ts docstrings: "there is still no Python-side decorator for authoring a new schema ... JTD-in-YAML remains the authored source for a shared vocabulary type." This is consistent with the ticket's own later design update ("a shared vocabulary type still carries one small authored contract-only JTD file"), so the doctrine is still true and correctly kept rather than struck.
  Suggested next step: None — the retention is the correct reading of the newer design update; the decorator docstrings were rewritten to current state (not strikethrough) which is right for code comments, avoiding breadcrumb comments.

- **info** — `sdk/streamlib-sdk/src/sdk/app.rs:66`: Docs PR documents already-shipped API; no production code logic changed in this branch (decorator edits are docstring-only), so no gate/negative-test applies.
  Evidence: git diff of decorators.py/.ts shows only doc-comment lines changed; python3 ast.parse of the branch decorators.py returns "parse OK"; all documented App/Bag/add_local symbols resolve in the tree.
  Suggested next step: No test to run — docs-only change; CI markdown/logging/license gates apply mechanically.

- **should-fix** — `sdk/streamlib-processor-extract/src/derive.rs:611`: `describe_difference`'s schema-type fallback branch is vaguer than the module's own actionability contract — it names neither the port nor the two differing schema types.
  Evidence: Lines 586-612: the execution branch, input-ports branch, and output-ports branch each name the specific disagreement (`processors: says X, code declares Y`). But a port that keeps its name and only changes schema type (e.g. VideoFrame -> AudioFrame) falls through to the generic `format!("`{name}` port schema types differ between `processors:` and code")`, naming neither which port nor the before/after types. The type ManifestDriftReport's own doc says it "Carries the specific disagreement so the `pkg build` error is actionable," and the module header lists "a port ... re-typed" as exactly a case the gate is meant to catch actionably.
  Suggested next step: In the final branch, walk the zipped inputs+outputs, find the first port whose PortSchemaSurface differs, and format `<port>` schema differs: `processors:` says <a>, code declares <b> — mirroring the execution/port-name branches. PortSchemaSurface already derives Eq and has a Type(String)/Any shape that renders cleanly.

- **info** — `sdk/streamlib-processor-extract/src/derive.rs:614`: `port_names` allocates a fresh `Vec<String>` (cloning every port name) purely to compare and then join — four allocations per differing processor.
  Evidence: `describe_difference` builds manifest_inputs/code_inputs/manifest_outputs/code_outputs via port_names (line 614: `ports.iter().map(|p| p.name.clone()).collect()`) and compares the Vecs before joining. This is the drift error path only (runs when a build is already failing), so it is genuinely cold — noting for completeness, not as a defect. Comparison could be `a.iter().map(|p| &p.name).ne(b.iter().map(|p| &p.name))` to avoid the compare-side allocations, but the join still needs owned strings, so the win is marginal.
  Suggested next step: Leave as-is; cold path. Only worth touching if the line-611 message fix reworks this function anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
