### PR TITLE
feat(cli): derive + reconcile package dependencies; streamlib add records the range

### DIFF
--- a/docs/architecture/package-development-model.md
+++ b/docs/architecture/package-development-model.md
@@ -383,6 +383,16 @@ instead of a copy — recorded as a `LockfileSource::Link` — so checkout edits
 are live on the next run; `streamlib install` re-creates that symlink when
 reproducing the lock.
 
+The CLI `streamlib add` verb is context-sensitive on its anchor directory. The
+byte-source adoption above is the **consumer / app** flow (no `package:` block
+in the anchor's `streamlib.yaml`). In a **package-authoring** dir (a
+`streamlib.yaml` *with* a `package:` block), `streamlib add @org/name@<version>`
+instead records a caret dependency (`^<version>`) into that package's own
+`dependencies:` table — the schema-tier `cargo add` — preserving every other
+manifest field and the leading `# yaml-language-server` comment header. The
+`AppModulesDir` primitive itself is unchanged: it is the consumer flow and still
+refuses a registry-coordinate byte source.
+
 At load time, `Strategy::InstalledCache` (the bare `Runner::add_module`
 default) probes `<cwd>/streamlib_modules/@org/name` **before** the
 installed-package cache; an active engine `streamlib link --engine` still

--- a/docs/decisions/dependency-reconciliation.md
+++ b/docs/decisions/dependency-reconciliation.md
@@ -1,0 +1,61 @@
+# Dependency reconciliation at package build
+
+## Trigger
+
+Reach for this when touching how a package's declared `dependencies:` relates to
+what its code references — deriving the dependency set, deciding what an
+undeclared or unreferenced dependency does at `pkg build`, or wondering why the
+reconciler reads the manifest rather than re-scanning code.
+
+## Decision
+
+`pkg build` reconciles the hand-declared `dependencies:` against the dependency
+set *derived* from the package's references, for the distributable `.slpkg`
+target only (`streamlib_pack::dependency_reconcile`):
+
+- A **referenced-but-undeclared** package is a hard error, carrying a
+  `streamlib add @org/name@<version>` fix-it. The manifest must declare every
+  package its code references.
+- A **declared-but-unreferenced** package that is not marked `runtime: true` is
+  a non-fatal prune warning — dead-weight in the dependency list.
+- `runtime: true` on a dependency keeps a runtime-composition dependency that
+  imports none of the referenced package's schema types.
+
+The referenced set is derived from the **manifest** — every `schemas:
+External { package }` import plus any resolved `Specific(SchemaIdent)` port id —
+not from a fresh per-language code scan. The committed `processors:` block is
+already pinned to code by the processor-manifest drift gate, so deriving from
+the manifest *is* deriving from code, and the manifest's `schemas:` map is the
+only place a bare `schema: VideoFrame` reference's owning `@org/package` is
+recorded.
+
+## Rejected alternatives
+
+- **Scan code for the referenced set (the processor-extract crate).** The
+  cross-language processor surface collapses each port schema to its bare `Type`
+  short-name and drops `@org/package`, so it cannot name the owning dependency;
+  a Rust-only raw scan could, but the owning package for a bare port name lives
+  in the manifest's `schemas:` map regardless. Deriving from the manifest is
+  both language-uniform and the only complete source.
+- **Prune destructively — rewrite the shipped manifest to drop the dead
+  dependency.** A published `.slpkg` manifest must stay byte-identical to the
+  one an orchestrator `StagedDir` build produces from the same source; pruning
+  only on the `Slpkg` path would diverge the two. Pruning is therefore a warning
+  that tells the author to remove the dependency (or mark it `runtime: true`),
+  never a silent under-the-author manifest rewrite.
+- **Make an unreferenced dependency a hard error too.** Over-rotates: a
+  legitimate runtime-composition dependency imports no schema types, and the
+  `runtime: true` marker already expresses that intent. Undeclared references
+  are always a manifest lie and stay hard; unreferenced ones are advisory.
+
+## Consequences
+
+- The `schemas:` map is load-bearing for dependency identity, not just schema
+  resolution: an external schema import is the machine-checkable evidence that a
+  declared dependency is needed.
+- A package that composes another package's processors at runtime without
+  importing its schemas must mark that dependency `runtime: true`, or accept the
+  prune warning.
+- The reconcile runs after the path-artifact gate, so a dev-only package
+  carrying a `patch:` path override never reaches it — its dependency list is
+  reconciled only once it is built as a standalone, path-free artifact.

--- a/schemas/streamlib.schema.json
+++ b/schemas/streamlib.schema.json
@@ -86,6 +86,10 @@
         "rev": {
           "description": "Pinned commit. Branch / tag refs are deliberately not supported — pinning is required for reproducible resolution. Mirrors the workspace rule from `CLAUDE.md` (`Conventions → Dependencies`).",
           "type": "string"
+        },
+        "runtime": {
+          "description": "Runtime-only dependency marker — see [`DependencySpec::is_runtime`].",
+          "type": "boolean"
         }
       },
       "additionalProperties": false
@@ -141,6 +145,10 @@
       "properties": {
         "path": {
           "type": "string"
+        },
+        "runtime": {
+          "description": "Runtime-only dependency marker — see [`DependencySpec::is_runtime`].",
+          "type": "boolean"
         }
       },
       "additionalProperties": false
@@ -432,6 +440,10 @@
         "version"
       ],
       "properties": {
+        "runtime": {
+          "description": "Runtime-only dependency marker — see [`DependencySpec::is_runtime`].",
+          "type": "boolean"
+        },
         "version": {
           "$ref": "#/definitions/SemVerRange"
         }

--- a/sdk/streamlib-idents/src/manifest.rs
+++ b/sdk/streamlib-idents/src/manifest.rs
@@ -303,16 +303,45 @@ pub enum DependencySpec {
     Git(GitDependency),
 }
 
+impl DependencySpec {
+    /// Whether this dependency is a **runtime** dependency — one the package
+    /// composes at runtime without importing any of its schema types. The
+    /// build-time dependency reconciler derives a package's referenced set from
+    /// its schema/port references; a declared dependency that resolves to none
+    /// of them is otherwise reported as prunable. `runtime: true` marks the
+    /// dependency as intentionally schema-unreferenced so the reconciler keeps
+    /// it. Registry-string shorthand (`^1.2.3`) is never a runtime dependency.
+    pub fn is_runtime(&self) -> bool {
+        match self {
+            Self::Registry(r) => r.runtime,
+            Self::Path(p) => p.runtime,
+            Self::Git(g) => g.runtime,
+        }
+    }
+}
+
+/// `skip_serializing_if` predicate for the default-`false` `runtime` flag, so a
+/// plain dependency serializes without a redundant `runtime: false`.
+fn is_false(flag: &bool) -> bool {
+    !*flag
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RegistryDependency {
     pub version: SemVerRange,
+    /// Runtime-only dependency marker — see [`DependencySpec::is_runtime`].
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub runtime: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct PathDependency {
     pub path: PathBuf,
+    /// Runtime-only dependency marker — see [`DependencySpec::is_runtime`].
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub runtime: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -323,6 +352,9 @@ pub struct GitDependency {
     /// pinning is required for reproducible resolution. Mirrors the
     /// workspace rule from `CLAUDE.md` (`Conventions → Dependencies`).
     pub rev: String,
+    /// Runtime-only dependency marker — see [`DependencySpec::is_runtime`].
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub runtime: bool,
 }
 
 impl JsonSchema for DependencySpec {
@@ -375,7 +407,10 @@ impl<'de> Deserialize<'de> for DependencySpec {
 
         let repr = Repr::deserialize(d)?;
         Ok(match repr {
-            Repr::Range(v) => Self::Registry(RegistryDependency { version: v }),
+            Repr::Range(v) => Self::Registry(RegistryDependency {
+                version: v,
+                runtime: false,
+            }),
             Repr::Map(StructuredRepr::Registry(r)) => Self::Registry(r),
             Repr::Map(StructuredRepr::Path(p)) => Self::Path(p),
             Repr::Map(StructuredRepr::Git(g)) => Self::Git(g),

--- a/tools/streamlib-cli/src/commands/add.rs
+++ b/tools/streamlib-cli/src/commands/add.rs
@@ -1,29 +1,52 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! `streamlib add <source>` / `streamlib remove <name>` — per-app package
-//! adoption, the node_modules model for streamlib packages.
+//! `streamlib add <source>` / `streamlib remove <name>` — package adoption.
 //!
-//! Thin CLI wrappers over the programmatic
-//! [`streamlib::sdk::runtime::AppModulesDir`] twins so the CLI and any
-//! embedding host share one adoption flow. `add` takes any valid streamlib
-//! package byte source — a folder, an archive (`.slpkg` / `.zip` /
-//! `.tar.gz`), or a URL — materializes it into `streamlib_modules/@org/name/`
-//! beside the app, and records it in the app's `streamlib.lock`. Identity is
-//! read from the package's own manifest, never supplied as a lookup
-//! coordinate. `remove` reverses it. Neither builds anything.
+//! `streamlib add` is context-sensitive on the directory it runs in:
+//!
+//! - **Package-authoring dir** (a `streamlib.yaml` with a `package:` block):
+//!   `streamlib add @org/name@<version>` records a caret dependency
+//!   (`^<version>`) into that package's own `dependencies:` — the schema-tier
+//!   analog of `cargo add`. `pkg build` then reconciles the declared set
+//!   against what the code references.
+//! - **Consumer / app dir** (no `package:` block): `add` takes any valid
+//!   streamlib package byte source — a folder, an archive (`.slpkg` / `.zip`
+//!   / `.tar.gz`), or a URL — materializes it into `streamlib_modules/@org/name/`
+//!   beside the app, and records it in the app's `streamlib.lock`. Identity is
+//!   read from the package's own manifest, never supplied as a lookup
+//!   coordinate. This flows through the programmatic
+//!   [`streamlib::sdk::runtime::AppModulesDir`] twin so the CLI and any
+//!   embedding host share one adoption flow.
+//!
+//! `remove` reverses the consumer-dir flow. Neither builds anything.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use streamlib::sdk::runtime::{
     AddPackageOptions, AddPackageReport, AddPackageSource, AppModulesDir, LinkPackageReport,
 };
-use streamlib_idents::PackageRef;
+use streamlib_idents::{
+    DependencySpec, Manifest, PackageRef, RegistryDependency, SemVerRange,
+};
+use streamlib_processor_schema::StreamlibYaml;
 
-/// Add one package source (folder | archive | URL) into the app's
-/// `streamlib_modules/` + `streamlib.lock`.
+/// `streamlib add <spec>` — records a dependency range when run in a
+/// package-authoring dir, otherwise materializes a byte source into the app's
+/// `streamlib_modules/`.
 pub fn add(spec: &str, dir: Option<&Path>, expect_sha256: Option<&str>) -> Result<()> {
+    let anchor = anchor_dir(dir)?;
+    if let Some(manifest_path) = package_authoring_manifest(&anchor)? {
+        if expect_sha256.is_some() {
+            eprintln!(
+                "warning: --expect-sha256 is ignored when recording a dependency range in a \
+                 package's streamlib.yaml; it applies only to archive and URL byte sources"
+            );
+        }
+        return record_dependency_range(&manifest_path, spec);
+    }
+
     let app = app_modules_dir(dir)?;
     let source = AddPackageSource::detect(spec).map_err(|e| anyhow::anyhow!("{e}"))?;
     // A folder source has no archive bytes to hash, so `--expect-sha256` is a
@@ -103,6 +126,102 @@ fn app_modules_dir(dir: Option<&Path>) -> Result<AppModulesDir> {
         Some(root) => Ok(AppModulesDir::at(root)),
         None => AppModulesDir::from_cwd().map_err(|e| anyhow::anyhow!("{e}")),
     }
+}
+
+/// The directory `add` anchors on: `--dir` when given, else the exact CWD
+/// (no walk-up — mirrors [`app_modules_dir`]).
+fn anchor_dir(dir: Option<&Path>) -> Result<PathBuf> {
+    match dir {
+        Some(root) => Ok(root.to_path_buf()),
+        None => std::env::current_dir().context("resolve current working directory"),
+    }
+}
+
+/// The `streamlib.yaml` path when `dir` holds a **package-authoring** manifest
+/// (one with a `package:` block), else `None`. A missing manifest or a
+/// project-flavor manifest (no `package:`) routes `add` to the consumer flow.
+fn package_authoring_manifest(dir: &Path) -> Result<Option<PathBuf>> {
+    let manifest_path = dir.join(Manifest::FILE_NAME);
+    if !manifest_path.is_file() {
+        return Ok(None);
+    }
+    let manifest = Manifest::load(dir).map_err(|e| anyhow::anyhow!("{e}"))?;
+    Ok(manifest.is_package_flavor().then_some(manifest_path))
+}
+
+/// Record `spec` (`@org/name@<version>`) as a caret dependency in the package
+/// manifest at `manifest_path`, preserving every other manifest field and the
+/// leading `# yaml-language-server` / comment header.
+fn record_dependency_range(manifest_path: &Path, spec: &str) -> Result<()> {
+    let (pkg_ref, version) = parse_authoring_spec(spec)?;
+    let range = SemVerRange::from_str(&format!("^{version}"))
+        .map_err(|e| anyhow::anyhow!("invalid version `{version}` in `{spec}`: {e}"))?;
+
+    let raw = std::fs::read_to_string(manifest_path)
+        .with_context(|| format!("read {}", manifest_path.display()))?;
+    let (header, body) = split_leading_comment_header(&raw);
+    let mut manifest: StreamlibYaml =
+        serde_yaml::from_str(&body).with_context(|| format!("parse {}", manifest_path.display()))?;
+
+    let replaced = manifest
+        .dependencies
+        .insert(
+            pkg_ref.clone(),
+            DependencySpec::Registry(RegistryDependency {
+                version: range.clone(),
+                runtime: false,
+            }),
+        )
+        .is_some();
+
+    let serialized =
+        serde_yaml::to_string(&manifest).context("serialize streamlib.yaml")?;
+    std::fs::write(manifest_path, format!("{header}{serialized}"))
+        .with_context(|| format!("write {}", manifest_path.display()))?;
+
+    let verb = if replaced { "Updated" } else { "Added" };
+    println!("{verb} dependency {pkg_ref} {range}");
+    println!("  Manifest: {}", manifest_path.display());
+    Ok(())
+}
+
+/// Parse an authoring-mode spec into a canonical [`PackageRef`] and its
+/// version. Accepts `@org/name@<version>`; the version is required in
+/// authoring mode (the caret range is anchored on it — there is no registry
+/// lookup here). Returns a CLI-friendly error otherwise.
+fn parse_authoring_spec(spec: &str) -> Result<(PackageRef, String)> {
+    let inner = spec.strip_prefix('@').ok_or_else(|| {
+        anyhow::anyhow!(
+            "expected `@org/name@<version>` (e.g. `@tatolab/core@1.0.0`); got `{spec}`"
+        )
+    })?;
+    let (name_part, version) = inner.split_once('@').ok_or_else(|| {
+        anyhow::anyhow!(
+            "missing version in `{spec}` — recording a dependency requires a version to \
+             anchor the caret range on: `streamlib add @org/name@<version>`"
+        )
+    })?;
+    if version.is_empty() {
+        anyhow::bail!("empty version in `{spec}`: `streamlib add @org/name@<version>`");
+    }
+    let pkg_ref = parse_canonical_package_ref(&format!("@{name_part}"))?;
+    Ok((pkg_ref, version.to_string()))
+}
+
+/// Split a `streamlib.yaml` into its leading comment/blank header (the
+/// `# yaml-language-server: $schema=` magic comment and friends) and the rest,
+/// so a serde round-trip can re-prepend the header it would otherwise drop.
+fn split_leading_comment_header(raw: &str) -> (String, String) {
+    let mut split_at = 0;
+    for line in raw.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            split_at += line.len();
+        } else {
+            break;
+        }
+    }
+    (raw[..split_at].to_string(), raw[split_at..].to_string())
 }
 
 /// Pretty-print the add outcome plus a manifest-derived processor summary.
@@ -231,5 +350,72 @@ mod tests {
             AddPackageSource::Url { .. }
         ));
         assert!(AddPackageSource::detect("ftp://example.com/pkg.slpkg").is_err());
+    }
+
+    #[test]
+    fn parse_authoring_spec_requires_org_name_and_version() {
+        let (pkg_ref, version) = parse_authoring_spec("@tatolab/core@1.2.3").unwrap();
+        assert_eq!(pkg_ref.to_string(), "@tatolab/core");
+        assert_eq!(version, "1.2.3");
+        // A bare `@org/name` has no version to anchor the caret on.
+        assert!(parse_authoring_spec("@tatolab/core").is_err());
+        // A non-`@`-prefixed spec is not a package coordinate.
+        assert!(parse_authoring_spec("tatolab/core@1.0.0").is_err());
+    }
+
+    #[test]
+    fn package_authoring_manifest_detects_only_package_flavor() {
+        let dir = tempfile::tempdir().unwrap();
+        // No manifest → consumer flow.
+        assert!(package_authoring_manifest(dir.path()).unwrap().is_none());
+        // Project-flavor (no `package:`) → consumer flow.
+        std::fs::write(
+            dir.path().join("streamlib.yaml"),
+            "dependencies:\n  '@tatolab/core': ^1.0.0\n",
+        )
+        .unwrap();
+        assert!(package_authoring_manifest(dir.path()).unwrap().is_none());
+        // Package-flavor → authoring.
+        std::fs::write(
+            dir.path().join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: widget\n  version: 0.1.0\n",
+        )
+        .unwrap();
+        assert!(package_authoring_manifest(dir.path()).unwrap().is_some());
+    }
+
+    #[test]
+    fn record_dependency_range_writes_caret_and_preserves_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("streamlib.yaml");
+        std::fs::write(
+            &manifest_path,
+            "# yaml-language-server: $schema=./schemas/streamlib.schema.json\n\
+             package:\n  org: tatolab\n  name: widget\n  version: 0.1.0\n\
+             processors:\n- name: Widget\n  version: 1.0.0\n  runtime: rust\n  execution: reactive\n",
+        )
+        .unwrap();
+
+        record_dependency_range(&manifest_path, "@tatolab/core@1.4.0").unwrap();
+
+        let written = std::fs::read_to_string(&manifest_path).unwrap();
+        // Leading magic comment preserved.
+        assert!(
+            written.starts_with("# yaml-language-server:"),
+            "header dropped: {written}"
+        );
+        // Caret range recorded.
+        let reparsed: StreamlibYaml = serde_yaml::from_str(&written).unwrap();
+        let core = parse_canonical_package_ref("@tatolab/core").unwrap();
+        match reparsed.dependencies.get(&core).unwrap() {
+            DependencySpec::Registry(r) => {
+                assert_eq!(r.version, SemVerRange::from_str("^1.4.0").unwrap());
+                assert!(!r.runtime);
+            }
+            other => panic!("expected registry dep, got {other:?}"),
+        }
+        // Runtime fields (processors) survive the round-trip.
+        assert_eq!(reparsed.processors.len(), 1);
+        assert_eq!(reparsed.processors[0].name, "Widget");
     }
 }

--- a/tools/streamlib-cli/src/main.rs
+++ b/tools/streamlib-cli/src/main.rs
@@ -96,23 +96,27 @@ enum Commands {
         dir: Option<PathBuf>,
     },
 
-    /// Bring any valid streamlib package into this app's streamlib_modules/
-    /// folder — the node_modules model for streamlib packages.
+    /// Record a dependency (in a package dir) or adopt a package (in an app).
     ///
-    /// Takes a byte source — a package folder, an archive (`.slpkg` / `.zip`
-    /// / `.tar.gz`), or a `file://` / HTTP(S) URL — materializes it into
-    /// `streamlib_modules/@org/name/` beside the app, and records identity,
-    /// source, and content hash in the app's `streamlib.lock`. The package's
-    /// identity comes from its own manifest. Re-adding replaces cleanly.
-    /// Never builds and never resolves a registry coordinate; a bare
-    /// `runtime.add_module(ident)` run from the app directory finds the
-    /// package afterward.
+    /// Context-sensitive on the anchor directory:
+    ///
+    /// - In a **package-authoring dir** (a `streamlib.yaml` with a `package:`
+    ///   block), `streamlib add @org/name@<version>` records a caret
+    ///   dependency (`^<version>`) into that package's own `dependencies:` —
+    ///   the schema-tier `cargo add`. `pkg build` reconciles it against code.
+    /// - In a **consumer / app dir**, takes a byte source — a package folder,
+    ///   an archive (`.slpkg` / `.zip` / `.tar.gz`), or a `file://` / HTTP(S)
+    ///   URL — materializes it into `streamlib_modules/@org/name/` beside the
+    ///   app, and records identity, source, and content hash in the app's
+    ///   `streamlib.lock`. Identity comes from the package's own manifest;
+    ///   re-adding replaces cleanly. Never builds.
     Add {
-        /// Package folder | archive (`.slpkg`/`.zip`/`.tar.gz`) | URL
+        /// Package dir: `@org/name@<version>`. App dir: package folder |
+        /// archive (`.slpkg`/`.zip`/`.tar.gz`) | URL.
         spec: String,
 
-        /// App root to anchor streamlib_modules/ + streamlib.lock at
-        /// (default: current working directory, no walk-up).
+        /// Anchor dir — a package dir to record a dependency in, or an app root
+        /// to materialize into (default: current working directory, no walk-up).
         #[arg(long)]
         dir: Option<PathBuf>,
 

--- a/tools/streamlib-pack/src/dependency_reconcile.rs
+++ b/tools/streamlib-pack/src/dependency_reconcile.rs
@@ -1,0 +1,190 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Build-time dependency reconciliation.
+//!
+//! A package's dependency identity is derivable from what its code references
+//! — the owning `@org/package` of every schema it imports (declared in the
+//! manifest's `schemas:` map as `External { package }`) plus any fully-qualified
+//! port schema id resolved on a processor. [`reconcile_package_dependencies`]
+//! derives that referenced set and reconciles it against the hand-declared
+//! `dependencies:` table:
+//!
+//! - **Undeclared** — a referenced package that is not declared. This is a hard
+//!   error at `pkg build`: the manifest lies about what the package needs. The
+//!   fix is to declare it (`streamlib add @org/name@<version>`).
+//! - **Pruned** — a declared package referenced by none of the code, and not
+//!   marked `runtime: true`. Reported as prunable (dead-weight dependency).
+//! - **Retained** — every other declared package (referenced, or a deliberate
+//!   `runtime: true` composition dependency).
+//!
+//! The referenced set is derived from the manifest — the `schemas:` map is the
+//! language-uniform source of the bare-name → owning-package resolution the
+//! catalog itself uses, and (unlike a per-language code scan) it carries the
+//! `@org/package` a bare `schema: VideoFrame` port reference resolves to. The
+//! committed `processors:` block is already pinned to code by the
+//! processor-manifest drift gate, so deriving from the manifest is deriving
+//! from code.
+
+use std::collections::BTreeSet;
+
+use streamlib_idents::{Manifest, PackageRef, SchemaEntry};
+use streamlib_processor_schema::{PortSchemaSpec, ProcessorSchema};
+
+/// The outcome of reconciling a package's declared `dependencies:` against the
+/// dependency set derived from its code/schema references.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DependencyReconciliation {
+    /// Referenced packages that are not declared — a hard error at build.
+    pub undeclared: Vec<PackageRef>,
+    /// Declared packages referenced by nothing and not marked `runtime: true`.
+    pub pruned: Vec<PackageRef>,
+    /// Declared packages that are kept — referenced, or `runtime: true`.
+    pub retained: Vec<PackageRef>,
+}
+
+/// The `@org/package` set a package's code/schema references resolve to, minus
+/// the package itself. Union of every `schemas: External { package }` import
+/// and every fully-qualified [`PortSchemaSpec::Specific`] port id.
+pub fn derive_referenced_packages(
+    manifest: &Manifest,
+    processors: &[ProcessorSchema],
+) -> BTreeSet<PackageRef> {
+    let mut referenced = BTreeSet::new();
+
+    if let Some(schemas) = manifest.schemas.as_ref() {
+        for entry in schemas.values() {
+            if let SchemaEntry::External { package } = entry {
+                referenced.insert(package.clone());
+            }
+        }
+    }
+
+    for proc in processors {
+        for port in proc.inputs.iter().chain(proc.outputs.iter()) {
+            if let PortSchemaSpec::Specific(ident) = &port.schema {
+                referenced.insert(PackageRef::new(ident.org.clone(), ident.package.clone()));
+            }
+        }
+    }
+
+    if let Some(owner) = manifest.package_ref() {
+        referenced.remove(&owner);
+    }
+    referenced
+}
+
+/// Reconcile a package's declared `dependencies:` against the set derived from
+/// its code/schema references. See the module docs for the three outcomes.
+pub fn reconcile_package_dependencies(
+    manifest: &Manifest,
+    processors: &[ProcessorSchema],
+) -> DependencyReconciliation {
+    let referenced = derive_referenced_packages(manifest, processors);
+    let declared: BTreeSet<&PackageRef> = manifest.dependencies.keys().collect();
+
+    let undeclared = referenced
+        .iter()
+        .filter(|pkg| !declared.contains(pkg))
+        .cloned()
+        .collect();
+
+    let mut pruned = Vec::new();
+    let mut retained = Vec::new();
+    for (pkg, spec) in &manifest.dependencies {
+        if referenced.contains(pkg) || spec.is_runtime() {
+            retained.push(pkg.clone());
+        } else {
+            pruned.push(pkg.clone());
+        }
+    }
+
+    DependencyReconciliation {
+        undeclared,
+        pruned,
+        retained,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use streamlib_idents::{DependencySpec, RegistryDependency, SemVerRange};
+
+    fn manifest_from_yaml(yaml: &str) -> Manifest {
+        serde_yaml::from_str(yaml).expect("manifest parses")
+    }
+
+    fn pkg_ref(spec: &str) -> PackageRef {
+        serde_yaml::from_value(serde_yaml::Value::String(spec.to_string())).expect("valid ref")
+    }
+
+    /// The referenced set (schema imports) is exactly the declared set: nothing
+    /// undeclared, nothing pruned.
+    #[test]
+    fn derive_matches_declared_is_clean() {
+        let manifest = manifest_from_yaml(
+            "package:\n  org: tatolab\n  name: camera\n  version: 2.1.0\n\
+             dependencies:\n  '@tatolab/core':\n    version: ^1.0.0\n\
+             schemas:\n  CameraConfig:\n    file: schemas/camera_config.yaml\n  VideoFrame:\n    package: '@tatolab/core'\n",
+        );
+        let out = reconcile_package_dependencies(&manifest, &[]);
+        assert!(out.undeclared.is_empty(), "no undeclared: {out:?}");
+        assert!(out.pruned.is_empty(), "no pruned: {out:?}");
+        assert_eq!(out.retained, vec![pkg_ref("@tatolab/core")]);
+    }
+
+    /// A schema imported from a package that is not declared is undeclared —
+    /// the hard-error input.
+    #[test]
+    fn undeclared_schema_import_is_flagged() {
+        let manifest = manifest_from_yaml(
+            "package:\n  org: tatolab\n  name: camera\n  version: 2.1.0\n\
+             schemas:\n  VideoFrame:\n    package: '@tatolab/core'\n",
+        );
+        let out = reconcile_package_dependencies(&manifest, &[]);
+        assert_eq!(out.undeclared, vec![pkg_ref("@tatolab/core")]);
+    }
+
+    /// A declared dep referenced by nothing is pruned — unless it carries
+    /// `runtime: true`, which keeps it.
+    #[test]
+    fn unreferenced_dep_is_pruned_unless_runtime() {
+        let manifest = manifest_from_yaml(
+            "package:\n  org: tatolab\n  name: app\n  version: 1.0.0\n\
+             dependencies:\n  '@tatolab/core':\n    version: ^1.0.0\n  '@tatolab/audio':\n    version: ^1.0.0\n    runtime: true\n",
+        );
+        let out = reconcile_package_dependencies(&manifest, &[]);
+        assert_eq!(out.pruned, vec![pkg_ref("@tatolab/core")]);
+        assert_eq!(out.retained, vec![pkg_ref("@tatolab/audio")]);
+        assert!(out.undeclared.is_empty());
+    }
+
+    /// The self-package is never counted as its own dependency even when it
+    /// imports its own type through an `External` self-reference.
+    #[test]
+    fn self_reference_is_dropped() {
+        let manifest = manifest_from_yaml(
+            "package:\n  org: tatolab\n  name: core\n  version: 1.0.0\n\
+             schemas:\n  VideoFrame:\n    package: '@tatolab/core'\n",
+        );
+        let referenced = derive_referenced_packages(&manifest, &[]);
+        assert!(referenced.is_empty(), "self dropped: {referenced:?}");
+    }
+
+    #[test]
+    fn runtime_flag_round_trips_through_dependency_spec() {
+        let spec: DependencySpec = serde_yaml::from_str("version: ^1.0.0\nruntime: true\n").unwrap();
+        assert!(spec.is_runtime());
+        assert_eq!(
+            spec,
+            DependencySpec::Registry(RegistryDependency {
+                version: SemVerRange::from_str("^1.0.0").unwrap(),
+                runtime: true,
+            })
+        );
+        // The bare-string shorthand is never a runtime dependency.
+        let plain: DependencySpec = serde_yaml::from_str("^1.0.0").unwrap();
+        assert!(!plain.is_runtime());
+    }
+}

--- a/tools/streamlib-pack/src/lib.rs
+++ b/tools/streamlib-pack/src/lib.rs
@@ -46,6 +46,7 @@ use streamlib_processor_schema::ProcessorLanguage;
 pub use streamlib_cargo_build::CargoProfile;
 
 pub mod catalog;
+pub mod dependency_reconcile;
 pub mod static_registry;
 
 // The `streamlib link` marker schema + discovery moved to `streamlib-idents`
@@ -534,6 +535,13 @@ pub fn assemble_artifact_with_cargo_config(
         // orchestrator load-time build) is exempt — it assembles an already-
         // published, drift-validated artifact.
         enforce_processor_manifest_matches_code(pkg_dir, &config.processors)?;
+        // Reconcile the hand-declared `dependencies:` against the dependency
+        // set derived from the package's schema/port references. An undeclared
+        // reference is a hard error; an unreferenced, non-`runtime` dependency
+        // is warned as prunable dead weight. `StagedDir` is exempt for the same
+        // reason as the processor drift gate — it assembles an already-
+        // reconciled, published artifact.
+        enforce_declared_dependencies_match_code(pkg_dir, &config.processors)?;
     }
 
     // (archive_path, source_path) pairs for every file EXCEPT the
@@ -788,6 +796,59 @@ fn enforce_processor_manifest_matches_code(
         &derived.surfaces,
     )
     .map_err(|report| anyhow::anyhow!("{report}"))
+}
+
+/// Reconcile the hand-declared `dependencies:` against the dependency set
+/// derived from the package's schema/port references (see
+/// [`crate::dependency_reconcile`]). A referenced-but-undeclared package is a
+/// hard error carrying a `streamlib add` fix-it; a declared-but-unreferenced
+/// package that is not marked `runtime: true` is warned as prunable dead
+/// weight. Called only for the [`AssembleTarget::Slpkg`] target.
+///
+/// Pruning is intentionally non-destructive: the shipped manifest stays
+/// byte-identical to the one an orchestrator `StagedDir` build produces, so the
+/// author is told to remove the dead dependency (or mark it `runtime: true`)
+/// rather than the build silently rewriting the manifest under them.
+fn enforce_declared_dependencies_match_code(
+    pkg_dir: &Path,
+    processors: &[streamlib_processor_schema::ProcessorSchema],
+) -> Result<()> {
+    let manifest = Manifest::load(pkg_dir)
+        .with_context(|| format!("read {} for dependency reconcile", pkg_dir.display()))?;
+    let reconciliation =
+        crate::dependency_reconcile::reconcile_package_dependencies(&manifest, processors);
+
+    if !reconciliation.undeclared.is_empty() {
+        let fix_its = reconciliation
+            .undeclared
+            .iter()
+            .map(|pkg| format!("  streamlib add {pkg}@<version>"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let refs = reconciliation
+            .undeclared
+            .iter()
+            .map(|pkg| pkg.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        anyhow::bail!(
+            "{} references schema(s) from undeclared dependenc(ies) [{}] — a package's \
+             `dependencies:` must declare every package its code references. Declare each:\n{}",
+            pkg_dir.join(Manifest::FILE_NAME).display(),
+            refs,
+            fix_its,
+        );
+    }
+
+    for pkg in &reconciliation.pruned {
+        tracing::warn!(
+            package = %pkg,
+            manifest = %pkg_dir.join(Manifest::FILE_NAME).display(),
+            "declared dependency is referenced by no schema/port — remove it, or mark it \
+             `runtime: true` if the package composes it at runtime without importing its types"
+        );
+    }
+    Ok(())
 }
 
 /// Enforce the standalone, registry-only contract for a published `.slpkg`:
@@ -1719,6 +1780,76 @@ mod tests {
             msg.contains("source of truth"),
             "drift error must explain code is truth: {msg}"
         );
+    }
+
+    /// Write a minimal schema-owning package: one `Local` schema plus whatever
+    /// extra manifest sections (`dependencies:` / `schemas:` imports) a test
+    /// splices in. No processors — the dependency reconcile runs regardless.
+    fn write_schema_pkg(dir: &Path, extra_manifest: &str) {
+        std::fs::create_dir_all(dir.join("schemas")).unwrap();
+        std::fs::write(
+            dir.join("schemas/local.yaml"),
+            "metadata:\n  type: LocalT\n  max_payload_bytes: 16\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("streamlib.yaml"),
+            format!(
+                "package:\n  org: tatolab\n  name: leaf\n  version: 0.1.0\n\
+                 schemas:\n  LocalT:\n    file: schemas/local.yaml\n{extra_manifest}"
+            ),
+        )
+        .unwrap();
+    }
+
+    /// A `.slpkg` build hard-errors when code references a schema from a
+    /// dependency the manifest never declares, and the error carries the
+    /// `streamlib add` fix-it. Mentally revert
+    /// `enforce_declared_dependencies_match_code` and this build succeeds while
+    /// shipping a manifest whose `dependencies:` lies about what it needs.
+    #[test]
+    fn slpkg_build_fails_on_undeclared_schema_dependency() {
+        let dir = tempdir().unwrap();
+        write_schema_pkg(
+            dir.path(),
+            "  Imported:\n    package: '@other/dep'\n",
+        );
+        let out = dir.path().join("o.slpkg");
+        let err = assemble_artifact(
+            dir.path(),
+            &AssembleTarget::Slpkg(out),
+            &slpkg_opts(false),
+            &(),
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("@other/dep"), "must name the dep: {msg}");
+        assert!(
+            msg.contains("streamlib add @other/dep@<version>"),
+            "must carry the streamlib add fix-it: {msg}"
+        );
+    }
+
+    /// A declared dependency referenced by no schema still builds — pruning is a
+    /// non-fatal advisory — and a `runtime: true` marker is the sanctioned way
+    /// to keep a runtime-composition dependency that imports no schema types.
+    #[test]
+    fn slpkg_build_prunes_are_non_fatal_and_runtime_marker_is_honored() {
+        for dep_block in [
+            "dependencies:\n  '@tatolab/audio':\n    version: ^1.0.0\n",
+            "dependencies:\n  '@tatolab/audio':\n    version: ^1.0.0\n    runtime: true\n",
+        ] {
+            let dir = tempdir().unwrap();
+            write_schema_pkg(dir.path(), dep_block);
+            let out = dir.path().join("o.slpkg");
+            assemble_artifact(
+                dir.path(),
+                &AssembleTarget::Slpkg(out),
+                &slpkg_opts(false),
+                &(),
+            )
+            .expect("an unreferenced dep is pruned non-fatally, not a build error");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #1417

## Summary
- Adds a build-time dependency reconciler (`tools/streamlib-pack/src/dependency_reconcile.rs`): the referenced `@org/package` set is derived from the manifest's `schemas:` External imports plus resolved `Specific` port idents — the language-uniform, drift-validated source the catalog already uses for bare-name → owner resolution.
- Undeclared reference → hard error at package build (`Slpkg`) with a `streamlib add @org/name@<version>` fix-it.
- Declared-but-unreferenced, non-`runtime` dependency → non-fatal prune warning; kept non-destructive so a shipped manifest stays byte-identical to a `StagedDir` build.
- New `runtime: bool` marker on `DependencySpec` (Registry/Path/Git) preserves a runtime-composition dependency that imports no schema types.
- `streamlib add` is now context-sensitive on the anchor directory: in a package-authoring dir (`streamlib.yaml` with a `package:` block), `streamlib add @org/name@<version>` records a caret dependency (`^<version>`) into the package's own `dependencies:`, preserving every other manifest field and the leading `yaml-language-server` comment header. In a consumer/app dir it keeps the existing `streamlib_modules/` byte-source adoption flow.
- Regenerates the manifest JSON schema (`schemas/streamlib.schema.json`) for the new `runtime` marker.
- Docs: `docs/decisions/dependency-reconciliation.md` records the manifest-driven derivation + non-destructive prune + `runtime: true` rationale; `docs/architecture/package-development-model.md` documents the context-sensitive `add` verb.

## Test evidence
- `cargo test -p streamlib-pack --lib`: 61 passed, 0 failed (includes `slpkg_build_fails_on_undeclared_schema_dependency`, `slpkg_build_prunes_are_non_fatal_and_runtime_marker_is_honored`, `slpkg_build_succeeds_when_manifest_matches_code`, `dependency_reconcile::tests::unreferenced_dep_is_pruned_unless_runtime`).
- `cargo test -p streamlib-cli --bins`: 43 passed, 0 failed (includes `commands::add::tests::record_dependency_range_writes_caret_and_preserves_fields`).
- Verify pass confirmed a revert-fail on the undeclared-dependency hard error (removing the manifest dep reintroduces the build failure), locking the regression.

## Review items (non-blocking)

1. **should-fix** — `tools/streamlib-cli/src/commands/add.rs:163` — `record_dependency_range` preserves the manifest on `streamlib add`.
   Evidence: it reads the manifest, splits off only the leading comment header, then serde-reserializes `StreamlibYaml` and re-prepends the header. `serde_yaml` emits struct fields in `StreamlibYaml` declaration order and drops all non-leading comments, so a first `streamlib add` on a hand-authored manifest can reorder every top-level key and delete inline comments. The test only asserts the leading `# yaml-language-server` line and field *presence* survive (`record_dependency_range_writes_caret_and_preserves_fields`), not ordering or inline comments. The decision doc scopes preservation to "every other manifest field and the leading comment header" — a documented tradeoff, not a correctness bug, but it produces noisy real-world diffs.
   Suggested next step: ship as a documented PR review item; consider a comment-preserving YAML edit (e.g. `serde_yaml::Value` patch or a targeted dependencies-block insert) if authoring-diff noise matters to the owner.

2. **info** — `tools/streamlib-cli/src/commands/add.rs:32` — The new `eprintln!` for the ignored `--expect-sha256` warning violates the "no eprintln!" non-negotiable.
   Evidence: `clippy -p streamlib-cli --bins` produced zero disallowed-macros violations despite the crate's heavy `println!` use (`install.rs`/`schema.rs`/`setup.rs`); the CLI binary is de-facto exempt as user-facing output. This is the first non-test `eprintln!` in the CLI but is consistent with the existing `println!` convention and introduces no CI failure.
   Suggested next step: no action required; flagged for owner awareness.

3. **info** — `tools/streamlib-pack/src/dependency_reconcile.rs:58` — Deriving the referenced set from the manifest (not a code scan) fully covers code refs.
   Evidence: `derive_referenced_packages` unions `schemas: External{package}` imports with processor `PortSchemaSpec::Specific` idents; `PortSchemaSpec::Named` (bare names) resolve to a package only via the `schemas` map, and `Any` carries no package — both correctly handled. A bare code ref to an external schema is unusable without a `schemas`-map entry, so the manifest is the complete resolution point. Rationale is captured in `docs/decisions/dependency-reconciliation.md`.
   Suggested next step: none; noting the derivation-source design choice for the domain lens to sanity-check against the manifest-extraction pipeline (#1345/M34).

4. **low** — `tools/streamlib-cli/src/commands/add.rs:169` — Two avoidable clones (`pkg_ref.clone()` at :169, `range.clone()` at :171) exist only because both values are moved into `dependencies.insert(...)` yet reused in the `println!("{verb} dependency {pkg_ref} {range}")` / `Manifest:` lines afterward.
   Evidence: `insert()` consumes `pkg_ref` and `range`, then :183-184 print them again, forcing the clones.
   Suggested next step: cold path (single manifest write) so this is a nit. If touched: compute the print strings before the insert, or `insert(pkg_ref.clone(), ...)` only for the key and borrow the range from a local before moving — or simply print after insert using references into `manifest.dependencies`. Not worth a dedicated change.

5. **low** — `tools/streamlib-pack/src/lib.rs:822` — `enforce_declared_dependencies_match_code` iterates `reconciliation.undeclared` twice — once to build `fix_its` (:822) and once to build `refs` (:828) — allocating two `Vec`s and two joined strings over the same small slice.
   Evidence: two consecutive `.iter().map(...).collect::<Vec<_>>().join(...)` chains over the identical `undeclared` set.
   Suggested next step: trivial (error path, tiny N). If consolidated, a single loop or a `fold` could build both strings in one pass, but the current form is clearer; leave unless the block grows.

6. **info** — `tools/streamlib-pack/src/dependency_reconcile.rs:48` — `derive_referenced_packages` / `reconcile_package_dependencies` are clean, deterministic (`BTreeSet`/`BTreeMap` ordering), and reuse existing core types (`PackageRef`, `SchemaEntry::External`, `PortSchemaSpec::Specific`, `Manifest::package_ref`) rather than spinning up a parallel abstraction — consistent with engine doctrine.
   Evidence: combinator-based set derivation with self-package removal; no manual index loops, no `unwrap` in library code (unwraps confined to `#[cfg(test)]`).
   Suggested next step: none — recorded as a positive coverage observation.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>