### PR TITLE
feat(runtime): load-gate installed-set-only resolution; apps carry no dependencies

### DIFF
--- a/docs/architecture/runtime-module-materialization.md
+++ b/docs/architecture/runtime-module-materialization.md
@@ -296,13 +296,40 @@ Because the lazy load rides transactional registration, a failure leaves
 keeps running. `add_processor` returns a typed, recoverable error rather
 than crashing:
 
-- **No package provides the type** → `Error::UnknownProcessorType` (the
-  pre-existing miss behavior; the failed node stays in the graph in
-  `Error` state for observability).
+- **No package provides the type** → `Error::UnknownProcessorType`, whose
+  message names the exact `streamlib add @org/name` fix-it (the install
+  recovery for the installed-set-only gate). A `@session/` type is exempt —
+  session processors register live via `Runner::add_local` and are never
+  installable, so no install fix-it is offered. The failed node stays in the
+  graph in `Error` state for observability.
 - **Two folders declare the same type** → `Error::AmbiguousProcessorTypeProviders`
   (a malformed install; discovery refuses to guess).
 - **A discovered package fails to load** → `Error::LazyModuleLoadFailed`
   naming the type, the package, and the underlying reason.
+
+### Installed-set-only, and acquire-on-reference
+
+An app is code, not a manifest: it resolves processor refs against its
+**installed set** (`streamlib_modules/` + `streamlib.lock`), never a manifest
+dependency list. An app-dir `streamlib.yaml` that is project-flavor (no
+`package:` block) yet declares `dependencies:` is a phantom-dependency list the
+runtime never resolves — both `streamlib add` and the load gate reject it with
+`Error::AppManifestDeclaresDependencies`, naming the fix-it (remove the block;
+install each package with `streamlib add <source>`).
+
+On a miss against the installed set, a fleet may opt into
+**acquire-on-reference** — off by default (`AcquireOnReferencePolicy::Off`),
+set via `Runner::set_acquire_on_reference_policy` or the
+`STREAMLIB_ACQUIRE_ON_REFERENCE` env var (`off` / `on` / `prompt`). When on, the
+runtime resolves the reference's range → concrete against the static registry,
+materializes that version's `.slpkg` into `streamlib_modules/`, records it in
+`streamlib.lock` (the install-shaped resolver — the byte-source add flow), then
+loads it from the now-populated installed cache. `prompt` gates each
+acquisition behind a host-installed confirmation handler and fails closed when
+none is installed; a normal (`off`) run stays installed-set-only and never
+reaches the network. This is never the locked-run resolver — the two-resolver
+split (range→concrete WRITES the lock at install; a locked run loads the pinned
+set offline) holds.
 
 ### The modules-dir
 

--- a/runtime/streamlib-engine/src/core/runtime/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/mod.rs
@@ -18,10 +18,11 @@ pub use streamlib_idents::app_modules::{
     LinkPackageReport, RemovePackageReport, UnlinkPackageReport,
 };
 pub use module_loader::{
-    AddModuleError, AddedModule, ArtifactChecksum, BuildError, BuildEvent, BuildEventSink,
-    BuildOrchestrator, BuildPolicy, BuildRequest, BuildSource, BuildStream, LoadedModule,
-    ModuleLoadEvent, RemoveModuleError, SemVerRange, StagedArtifact, Strategy,
-    extract_slpkg_to_cache, host_target_triple, loaded_plugin_library_count,
+    AcquireConfirmationHandler, AcquireOnReferencePolicy, AddModuleError, AddedModule,
+    ArtifactChecksum, BuildError, BuildEvent, BuildEventSink, BuildOrchestrator, BuildPolicy,
+    BuildRequest, BuildSource, BuildStream, LoadedModule, ModuleLoadEvent, RemoveModuleError,
+    SemVerRange, StagedArtifact, Strategy, extract_slpkg_to_cache, host_target_triple,
+    loaded_plugin_library_count,
 };
 pub(crate) use module_loader::{
     lookup_schema_via_active_cdylib_sink, stage_processor_via_active_cdylib_sink,

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/acquire.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/acquire.rs
@@ -64,8 +64,9 @@ impl AcquireOnReferencePolicy {
 
 /// A host-installed acquisition confirmation gate for
 /// [`AcquireOnReferencePolicy::Prompt`]: given the package + resolution range
-/// about to be acquired, return `true` to proceed. The CLI wires a TTY prompt
-/// here; the engine performs no interactive I/O itself (engine purity).
+/// about to be acquired, return `true` to proceed. A host (such as the CLI) can
+/// install a confirmation handler here; with none installed, `Prompt` fails
+/// closed. The engine performs no interactive I/O itself (engine purity).
 pub type AcquireConfirmationHandler = Arc<dyn Fn(&PackageRef, &SemVerRange) -> bool + Send + Sync>;
 
 /// Process-wide policy override. `None` falls back to [`ACQUIRE_ON_REFERENCE_ENV`],

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/acquire.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/acquire.rs
@@ -1,0 +1,229 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Policy-gated **acquire-on-reference**: on a load miss against the installed
+//! set, optionally fetch the providing package from the static registry,
+//! verify it, and record it in `streamlib.lock` — completing the load without
+//! an explicit `streamlib add`.
+//!
+//! This is the fleet affordance behind the installed-set-only load gate. It is
+//! **off by default**: a normal run resolves refs strictly against
+//! `streamlib_modules/` + `streamlib.lock` and never reaches the network. The
+//! knob has three settings:
+//!
+//! - [`AcquireOnReferencePolicy::Off`] (default) — never acquire; a miss is a
+//!   fix-it error naming `streamlib add`.
+//! - [`AcquireOnReferencePolicy::On`] — acquire on every miss.
+//! - [`AcquireOnReferencePolicy::Prompt`] — acquire only after a host-installed
+//!   [confirmation handler](set_acquire_confirmation_handler) approves; with no
+//!   handler installed it **fails closed** (does not acquire) so an unattended
+//!   run never silently fetches.
+//!
+//! Acquire itself is install-shaped (range → concrete, WRITES the lock) via
+//! [`AppModulesDir::acquire_from_registry`]; it is never the locked-run
+//! resolver — the two-resolver split stays intact.
+//!
+//! [`AppModulesDir::acquire_from_registry`]: streamlib_idents::app_modules::AppModulesDir::acquire_from_registry
+
+use std::sync::{Arc, RwLock};
+
+use streamlib_idents::{PackageRef, SemVerRange};
+
+/// Environment variable carrying the acquire-on-reference policy —
+/// `off` (default) / `on` / `prompt`. A programmatic override
+/// ([`set_acquire_on_reference_policy`]) takes precedence.
+pub(crate) const ACQUIRE_ON_REFERENCE_ENV: &str = "STREAMLIB_ACQUIRE_ON_REFERENCE";
+
+/// Whether — and how — the runtime may acquire a package from the registry on
+/// a load miss. Off by default: the load gate is installed-set-only unless a
+/// fleet explicitly opts in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AcquireOnReferencePolicy {
+    /// Never acquire. A miss surfaces the `streamlib add` fix-it.
+    #[default]
+    Off,
+    /// Acquire on every miss.
+    On,
+    /// Acquire only when a host-installed confirmation handler approves.
+    Prompt,
+}
+
+impl AcquireOnReferencePolicy {
+    /// Parse the `off` / `on` / `prompt` spelling (case-insensitive). An
+    /// unrecognized value is `None` so the caller can fall back to the default
+    /// rather than silently enabling acquisition.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "off" | "false" | "0" => Some(Self::Off),
+            "on" | "true" | "1" => Some(Self::On),
+            "prompt" | "ask" => Some(Self::Prompt),
+            _ => None,
+        }
+    }
+}
+
+/// A host-installed acquisition confirmation gate for
+/// [`AcquireOnReferencePolicy::Prompt`]: given the package + resolution range
+/// about to be acquired, return `true` to proceed. The CLI wires a TTY prompt
+/// here; the engine performs no interactive I/O itself (engine purity).
+pub type AcquireConfirmationHandler =
+    Arc<dyn Fn(&PackageRef, &SemVerRange) -> bool + Send + Sync>;
+
+/// Process-wide policy override. `None` falls back to [`ACQUIRE_ON_REFERENCE_ENV`],
+/// then the [`AcquireOnReferencePolicy::Off`] default.
+static POLICY_OVERRIDE: RwLock<Option<AcquireOnReferencePolicy>> = RwLock::new(None);
+
+/// Process-wide confirmation handler for the `Prompt` policy.
+static CONFIRMATION_HANDLER: RwLock<Option<AcquireConfirmationHandler>> = RwLock::new(None);
+
+/// Set the process-wide acquire-on-reference policy override. `None` clears it
+/// (back to env / default).
+pub(crate) fn set_acquire_on_reference_policy(policy: Option<AcquireOnReferencePolicy>) {
+    *POLICY_OVERRIDE
+        .write()
+        .expect("acquire policy override lock poisoned") = policy;
+}
+
+/// Install (or clear, with `None`) the confirmation handler consulted under the
+/// `Prompt` policy.
+pub(crate) fn set_acquire_confirmation_handler(handler: Option<AcquireConfirmationHandler>) {
+    *CONFIRMATION_HANDLER
+        .write()
+        .expect("acquire confirmation handler lock poisoned") = handler;
+}
+
+/// The effective acquire-on-reference policy: the runtime override, else the
+/// [`ACQUIRE_ON_REFERENCE_ENV`] env var, else [`AcquireOnReferencePolicy::Off`].
+/// An unrecognized env value warns once per read and falls back to `Off`.
+pub(crate) fn acquire_on_reference_policy() -> AcquireOnReferencePolicy {
+    if let Some(policy) = *POLICY_OVERRIDE
+        .read()
+        .expect("acquire policy override lock poisoned")
+    {
+        return policy;
+    }
+    match std::env::var(ACQUIRE_ON_REFERENCE_ENV) {
+        Ok(raw) if !raw.trim().is_empty() => match AcquireOnReferencePolicy::parse(&raw) {
+            Some(policy) => policy,
+            None => {
+                tracing::warn!(
+                    value = %raw,
+                    env = ACQUIRE_ON_REFERENCE_ENV,
+                    "unrecognized acquire-on-reference policy — expected off/on/prompt; \
+                     defaulting to off"
+                );
+                AcquireOnReferencePolicy::Off
+            }
+        },
+        _ => AcquireOnReferencePolicy::Off,
+    }
+}
+
+/// Decide whether acquisition is permitted for `pkg_ref` at `range` under the
+/// current policy. `Off` → never; `On` → always; `Prompt` → the confirmation
+/// handler's verdict (or `false` — fail closed — when none is installed).
+pub(crate) fn acquisition_permitted(pkg_ref: &PackageRef, range: &SemVerRange) -> bool {
+    match acquire_on_reference_policy() {
+        AcquireOnReferencePolicy::Off => false,
+        AcquireOnReferencePolicy::On => true,
+        AcquireOnReferencePolicy::Prompt => {
+            let handler = CONFIRMATION_HANDLER
+                .read()
+                .expect("acquire confirmation handler lock poisoned")
+                .clone();
+            match handler {
+                Some(confirm) => confirm(pkg_ref, range),
+                None => {
+                    tracing::warn!(
+                        package = %pkg_ref,
+                        "acquire-on-reference is set to `prompt` but no confirmation handler \
+                         is installed — declining to acquire (set the policy to `on`, or \
+                         install a confirmation handler)"
+                    );
+                    false
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use streamlib_idents::{Org, Package};
+
+    fn pkg_ref(org: &str, name: &str) -> PackageRef {
+        PackageRef::new(Org::new(org).unwrap(), Package::new(name).unwrap())
+    }
+
+    #[test]
+    fn parse_accepts_the_three_spellings() {
+        assert_eq!(
+            AcquireOnReferencePolicy::parse("off"),
+            Some(AcquireOnReferencePolicy::Off)
+        );
+        assert_eq!(
+            AcquireOnReferencePolicy::parse("ON"),
+            Some(AcquireOnReferencePolicy::On)
+        );
+        assert_eq!(
+            AcquireOnReferencePolicy::parse(" Prompt "),
+            Some(AcquireOnReferencePolicy::Prompt)
+        );
+        assert_eq!(AcquireOnReferencePolicy::parse("garbage"), None);
+    }
+
+    #[test]
+    fn default_policy_is_off() {
+        assert_eq!(
+            AcquireOnReferencePolicy::default(),
+            AcquireOnReferencePolicy::Off
+        );
+    }
+
+    /// The override drives the permission decision without touching env, and
+    /// `Prompt` fails closed with no handler installed. Serialized against the
+    /// process-wide statics via a mutex so the parallel test runner can't
+    /// interleave two policy writers.
+    #[test]
+    fn permission_honors_override_and_prompt_fails_closed() {
+        use std::sync::Mutex;
+        static SERIALIZE: Mutex<()> = Mutex::new(());
+        let _guard = SERIALIZE.lock().unwrap();
+
+        let pr = pkg_ref("tatolab", "camera");
+        let range = SemVerRange::Any;
+
+        set_acquire_on_reference_policy(Some(AcquireOnReferencePolicy::Off));
+        assert!(!acquisition_permitted(&pr, &range), "off never acquires");
+
+        set_acquire_on_reference_policy(Some(AcquireOnReferencePolicy::On));
+        assert!(acquisition_permitted(&pr, &range), "on always acquires");
+
+        // Prompt with no handler fails closed.
+        set_acquire_confirmation_handler(None);
+        set_acquire_on_reference_policy(Some(AcquireOnReferencePolicy::Prompt));
+        assert!(
+            !acquisition_permitted(&pr, &range),
+            "prompt without a handler must fail closed"
+        );
+
+        // Prompt with an approving handler acquires.
+        set_acquire_confirmation_handler(Some(Arc::new(|_pkg, _range| true)));
+        assert!(
+            acquisition_permitted(&pr, &range),
+            "prompt with an approving handler acquires"
+        );
+
+        // A declining handler blocks.
+        set_acquire_confirmation_handler(Some(Arc::new(|_pkg, _range| false)));
+        assert!(
+            !acquisition_permitted(&pr, &range),
+            "prompt with a declining handler blocks"
+        );
+
+        // Reset the process-wide statics for other tests.
+        set_acquire_confirmation_handler(None);
+        set_acquire_on_reference_policy(None);
+    }
+}

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/acquire.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/acquire.rs
@@ -66,8 +66,7 @@ impl AcquireOnReferencePolicy {
 /// [`AcquireOnReferencePolicy::Prompt`]: given the package + resolution range
 /// about to be acquired, return `true` to proceed. The CLI wires a TTY prompt
 /// here; the engine performs no interactive I/O itself (engine purity).
-pub type AcquireConfirmationHandler =
-    Arc<dyn Fn(&PackageRef, &SemVerRange) -> bool + Send + Sync>;
+pub type AcquireConfirmationHandler = Arc<dyn Fn(&PackageRef, &SemVerRange) -> bool + Send + Sync>;
 
 /// Process-wide policy override. `None` falls back to [`ACQUIRE_ON_REFERENCE_ENV`],
 /// then the [`AcquireOnReferencePolicy::Off`] default.

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/acquire.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/acquire.rs
@@ -1,29 +1,11 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Policy-gated **acquire-on-reference**: on a load miss against the installed
-//! set, optionally fetch the providing package from the static registry,
-//! verify it, and record it in `streamlib.lock` — completing the load without
-//! an explicit `streamlib add`.
-//!
-//! This is the fleet affordance behind the installed-set-only load gate. It is
-//! **off by default**: a normal run resolves refs strictly against
-//! `streamlib_modules/` + `streamlib.lock` and never reaches the network. The
-//! knob has three settings:
-//!
-//! - [`AcquireOnReferencePolicy::Off`] (default) — never acquire; a miss is a
-//!   fix-it error naming `streamlib add`.
-//! - [`AcquireOnReferencePolicy::On`] — acquire on every miss.
-//! - [`AcquireOnReferencePolicy::Prompt`] — acquire only after a host-installed
-//!   [confirmation handler](set_acquire_confirmation_handler) approves; with no
-//!   handler installed it **fails closed** (does not acquire) so an unattended
-//!   run never silently fetches.
-//!
-//! Acquire itself is install-shaped (range → concrete, WRITES the lock) via
-//! [`AppModulesDir::acquire_from_registry`]; it is never the locked-run
-//! resolver — the two-resolver split stays intact.
-//!
-//! [`AppModulesDir::acquire_from_registry`]: streamlib_idents::app_modules::AppModulesDir::acquire_from_registry
+//! Policy-gated **acquire-on-reference**: on an installed-set load miss,
+//! optionally fetch the providing package from the static registry and record
+//! it in `streamlib.lock` — completing the load without an explicit
+//! `streamlib add`. Off by default (a normal run never reaches the network);
+//! the [`AcquireOnReferencePolicy`] knob opts a fleet in.
 
 use std::sync::{Arc, RwLock};
 

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -869,7 +869,7 @@ impl Runner {
 
         // Session types register live via `add_local`; they are never installed
         // and so never acquired.
-        if processor_type.org().as_str() == "session" {
+        if processor_type.org().as_str() == streamlib_idents::SESSION_ORG {
             return Ok(None);
         }
         let pkg_ref = streamlib_idents::PackageRef::new(
@@ -899,10 +899,9 @@ impl Runner {
         };
         let report = AppModulesDir::at(&app_root)
             .acquire_from_registry(&pkg_ref, &range, &config)
-            .map_err(|e| {
-                crate::core::error::Error::Configuration(format!(
-                    "acquire-on-reference for {pkg_ref} failed: {e}"
-                ))
+            .map_err(|e| crate::core::error::Error::AcquireOnReferenceFailed {
+                package: pkg_ref.clone(),
+                detail: e.to_string(),
             })?;
         tracing::info!(
             package = %pkg_ref,

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -846,21 +846,12 @@ impl Runner {
         }
     }
 
-    /// Begin a **policy-gated acquire-on-reference** load: on a miss against the
-    /// installed set, fetch the providing package from the static registry,
-    /// record it in `streamlib.lock`, then load it from the (now-populated)
-    /// installed cache. Returns `Ok(None)` — no acquisition — when the policy is
-    /// `Off` (the default), a `Prompt` handler declines, the referenced package
-    /// is a `@session/` type, no app-modules root or registry URL is configured;
-    /// `Ok(Some(added))` with the in-flight cache load once acquired; a typed
-    /// `Err` when acquisition was permitted but the registry resolve / download
-    /// failed.
-    ///
-    /// This is the install-shaped resolver (range → concrete, WRITES the lock)
-    /// via [`AppModulesDir::acquire_from_registry`], never the locked-run
-    /// resolver — the two-resolver split holds.
-    ///
-    /// [`AppModulesDir::acquire_from_registry`]: streamlib_idents::app_modules::AppModulesDir::acquire_from_registry
+    /// Begin a **policy-gated acquire-on-reference** load: on an installed-set
+    /// miss, fetch the providing package from the registry, record it in
+    /// `streamlib.lock`, and load it from the now-populated cache. `Ok(None)`
+    /// signals a declined acquisition (policy `Off`, a `Prompt` handler
+    /// declines, a `@session/` type, or no app-modules root / registry URL
+    /// configured) — distinct from a typed `Err` on a permitted-but-failed fetch.
     fn begin_acquire_on_reference(
         &self,
         processor_type: &crate::core::processors::ProcessorTypeReference,
@@ -869,7 +860,7 @@ impl Runner {
 
         // Session types register live via `add_local`; they are never installed
         // and so never acquired.
-        if processor_type.org().as_str() == streamlib_idents::SESSION_ORG {
+        if processor_type.org().is_reserved_for_session() {
             return Ok(None);
         }
         let pkg_ref = streamlib_idents::PackageRef::new(

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -252,8 +252,7 @@ fn run_module_load(
     // ident) fails loud here with a typed error, so the whole load rolls
     // back with zero residue instead of committing a partial set. This is
     // what makes the commit itself infallible-by-construction.
-    let result =
-        result.and_then(|()| staging.validate_no_dynamic_processor_collisions());
+    let result = result.and_then(|()| staging.validate_no_dynamic_processor_collisions());
     match result {
         Ok(()) => {
             // Whole-load commit: apply staged registrations, write the

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -60,6 +60,7 @@ use super::Runner;
 use super::runtime::TokioRuntimeVariant;
 use crate::iceoryx2::Iceoryx2Node;
 
+mod acquire;
 mod added_module;
 mod build_orchestrator;
 mod errors;
@@ -80,6 +81,7 @@ mod tests;
 #[cfg(test)]
 mod session_tests;
 
+pub use acquire::{AcquireConfirmationHandler, AcquireOnReferencePolicy};
 pub use added_module::{AddedModule, LoadedModule, ModuleLoadEvent};
 pub use build_orchestrator::{
     BuildError, BuildEvent, BuildEventSink, BuildOrchestrator, BuildPolicy, BuildRequest,
@@ -710,6 +712,33 @@ impl Runner {
     }
 }
 
+/// Installed-set-only gate at the runtime load boundary: an app dir's
+/// `streamlib.yaml` must not declare `dependencies:`. A project-flavor (app)
+/// manifest carrying deps is a phantom-dependency list the runtime never
+/// resolves — return the typed fix-it. A missing or unparseable manifest, or a
+/// package-flavor manifest (whose deps are legitimate), passes.
+fn check_app_manifest_declares_no_dependencies(
+    app_root: &std::path::Path,
+) -> std::result::Result<(), crate::core::error::Error> {
+    let manifest_path = app_root.join(streamlib_idents::Manifest::FILE_NAME);
+    if !manifest_path.is_file() {
+        return Ok(());
+    }
+    // An unreadable / unparseable manifest is not this gate's concern — the
+    // resolver surfaces its own parse error elsewhere; here we only reject a
+    // well-formed app manifest that declares phantom deps.
+    let Ok(manifest) = streamlib_idents::Manifest::load(app_root) else {
+        return Ok(());
+    };
+    if let Some(count) = manifest.app_dependency_violation_count() {
+        return Err(crate::core::error::Error::AppManifestDeclaresDependencies {
+            manifest_path: manifest_path.display().to_string(),
+            declared_count: count,
+        });
+    }
+    Ok(())
+}
+
 /// Build the recoverable [`Error::LazyModuleLoadFailed`] for a discovered
 /// package that failed to load, naming the type and its providing package.
 fn lazy_module_load_failed(
@@ -748,6 +777,26 @@ impl Runner {
         source::set_app_modules_root_override(None);
     }
 
+    /// Set the process-wide [`AcquireOnReferencePolicy`] — whether, on a load
+    /// miss against the installed set, the runtime may fetch the providing
+    /// package from the static registry and record it in `streamlib.lock`.
+    /// **Process-wide** (last write wins), like [`Self::set_app_modules_dir`].
+    /// `None` clears the override, restoring the [`acquire::ACQUIRE_ON_REFERENCE_ENV`]
+    /// env / [`AcquireOnReferencePolicy::Off`] default. Off by default: a normal
+    /// run resolves refs installed-set-only and never reaches the network.
+    pub fn set_acquire_on_reference_policy(policy: Option<AcquireOnReferencePolicy>) {
+        acquire::set_acquire_on_reference_policy(policy);
+    }
+
+    /// Install (or clear, with `None`) the confirmation handler consulted under
+    /// [`AcquireOnReferencePolicy::Prompt`]: it is called with the package +
+    /// resolution range about to be acquired and returns `true` to proceed.
+    /// The engine performs no interactive I/O itself — a host (e.g. the CLI)
+    /// wires a TTY prompt here. Process-wide.
+    pub fn set_acquire_confirmation_handler(handler: Option<AcquireConfirmationHandler>) {
+        acquire::set_acquire_confirmation_handler(handler);
+    }
+
     /// Begin a lazy load of the package that provides `processor_type`, when
     /// the type isn't registered yet. Returns the in-flight [`AddedModule`] to
     /// drive to completion, or `None` when nothing needs loading (the type is
@@ -780,6 +829,11 @@ impl Runner {
         let Some(app_modules_root) = source::app_modules_root() else {
             return Ok(None);
         };
+        // Installed-set-only gate: an app is code, not a manifest. If the app
+        // dir carries a project-flavor `streamlib.yaml` that declares
+        // `dependencies:`, those are phantom deps the runtime never resolves —
+        // fail loud with the fix-it rather than silently ignoring them.
+        check_app_manifest_declares_no_dependencies(&app_modules_root)?;
         // Discovery ignores the reference-site version and matches on
         // `(org, package, type)`; it takes a concrete `SchemaIdent` only for
         // its diagnostics, so a version-free reference projects to
@@ -791,6 +845,79 @@ impl Runner {
             )),
             None => Ok(None),
         }
+    }
+
+    /// Begin a **policy-gated acquire-on-reference** load: on a miss against the
+    /// installed set, fetch the providing package from the static registry,
+    /// record it in `streamlib.lock`, then load it from the (now-populated)
+    /// installed cache. Returns `Ok(None)` — no acquisition — when the policy is
+    /// `Off` (the default), a `Prompt` handler declines, the referenced package
+    /// is a `@session/` type, no app-modules root or registry URL is configured;
+    /// `Ok(Some(added))` with the in-flight cache load once acquired; a typed
+    /// `Err` when acquisition was permitted but the registry resolve / download
+    /// failed.
+    ///
+    /// This is the install-shaped resolver (range → concrete, WRITES the lock)
+    /// via [`AppModulesDir::acquire_from_registry`], never the locked-run
+    /// resolver — the two-resolver split holds.
+    ///
+    /// [`AppModulesDir::acquire_from_registry`]: streamlib_idents::app_modules::AppModulesDir::acquire_from_registry
+    fn begin_acquire_on_reference(
+        &self,
+        processor_type: &crate::core::processors::ProcessorTypeReference,
+    ) -> std::result::Result<Option<AddedModule>, crate::core::error::Error> {
+        use streamlib_idents::app_modules::AppModulesDir;
+
+        // Session types register live via `add_local`; they are never installed
+        // and so never acquired.
+        if processor_type.org().as_str() == "session" {
+            return Ok(None);
+        }
+        let pkg_ref = streamlib_idents::PackageRef::new(
+            processor_type.org().clone(),
+            processor_type.package().clone(),
+        );
+        // The range comes from the reference itself, not any app manifest: a
+        // version-pinned ref acquires that exact version; a version-free ref
+        // takes the highest release the registry holds.
+        let range = match processor_type.as_version_pinned() {
+            Some(ident) => streamlib_idents::SemVerRange::Exact(ident.version),
+            None => streamlib_idents::SemVerRange::Any,
+        };
+        if !acquire::acquisition_permitted(&pkg_ref, &range) {
+            return Ok(None);
+        }
+        let Some(app_root) = source::app_modules_root() else {
+            return Ok(None);
+        };
+        let Some(config) = streamlib_idents::RegistryConfig::from_env() else {
+            tracing::warn!(
+                package = %pkg_ref,
+                "acquire-on-reference is enabled but no registry URL is configured \
+                 (STREAMLIB_REGISTRY_URL) — cannot acquire"
+            );
+            return Ok(None);
+        };
+        let report = AppModulesDir::at(&app_root)
+            .acquire_from_registry(&pkg_ref, &range, &config)
+            .map_err(|e| {
+                crate::core::error::Error::Configuration(format!(
+                    "acquire-on-reference for {pkg_ref} failed: {e}"
+                ))
+            })?;
+        tracing::info!(
+            package = %pkg_ref,
+            version = %report.version,
+            "acquire-on-reference: acquired package; loading from the installed cache"
+        );
+        let module_ident = streamlib_idents::ModuleIdent::new(
+            pkg_ref.org.clone(),
+            pkg_ref.name.clone(),
+            streamlib_idents::SemVerRange::Any,
+        );
+        Ok(Some(
+            self.add_module_with(module_ident, Strategy::InstalledCache),
+        ))
     }
 
     /// Lazily discover + load the plugin providing `processor_type` on first
@@ -810,7 +937,16 @@ impl Runner {
                 Ok(_) => None,
                 Err(e) => Some(lazy_module_load_failed(processor_type, e)),
             },
-            Ok(None) => None,
+            // Miss against the installed set — try policy-gated
+            // acquire-on-reference (off by default → `Ok(None)` here).
+            Ok(None) => match self.begin_acquire_on_reference(processor_type) {
+                Ok(Some(added)) => match added.await {
+                    Ok(_) => None,
+                    Err(e) => Some(lazy_module_load_failed(processor_type, e)),
+                },
+                Ok(None) => None,
+                Err(e) => Some(e),
+            },
             Err(e) => Some(e),
         }
     }
@@ -824,7 +960,12 @@ impl Runner {
     ) -> Option<crate::core::error::Error> {
         let added = match self.begin_lazy_provider_load(processor_type) {
             Ok(Some(added)) => added,
-            Ok(None) => return None,
+            // Miss — try policy-gated acquire-on-reference (off by default).
+            Ok(None) => match self.begin_acquire_on_reference(processor_type) {
+                Ok(Some(added)) => added,
+                Ok(None) => return None,
+                Err(e) => return Some(e),
+            },
             Err(e) => return Some(e),
         };
         match self.drive_added_module_to_completion_blocking(added) {
@@ -857,6 +998,48 @@ impl Runner {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod app_manifest_gate_tests {
+    use super::*;
+
+    /// The installed-set-only gate rejects a project-flavor (app) manifest that
+    /// declares `dependencies:`, names the manifest path + count, and passes a
+    /// package-flavor manifest, an app with no deps, and a dir with no manifest.
+    #[test]
+    fn rejects_app_manifest_dependencies_only() {
+        let dir = tempfile::tempdir().unwrap();
+        // No manifest → pass.
+        check_app_manifest_declares_no_dependencies(dir.path()).unwrap();
+
+        // Project-flavor (app) manifest with deps → typed rejection.
+        std::fs::write(
+            dir.path().join("streamlib.yaml"),
+            "dependencies:\n  '@tatolab/core': ^1.0.0\n  '@tatolab/camera': ^2.0.0\n",
+        )
+        .unwrap();
+        match check_app_manifest_declares_no_dependencies(dir.path()) {
+            Err(crate::core::error::Error::AppManifestDeclaresDependencies {
+                declared_count,
+                ..
+            }) => assert_eq!(declared_count, 2),
+            other => panic!("expected AppManifestDeclaresDependencies, got {other:?}"),
+        }
+
+        // Package-flavor manifest with deps → legitimate, passes.
+        std::fs::write(
+            dir.path().join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: widget\n  version: 0.1.0\n\
+             dependencies:\n  '@tatolab/core': ^1.0.0\n",
+        )
+        .unwrap();
+        check_app_manifest_declares_no_dependencies(dir.path()).unwrap();
+
+        // Project-flavor with no deps → passes.
+        std::fs::write(dir.path().join("streamlib.yaml"), "dependencies: {}\n").unwrap();
+        check_app_manifest_declares_no_dependencies(dir.path()).unwrap();
     }
 }
 

--- a/sdk/streamlib-error/src/lib.rs
+++ b/sdk/streamlib-error/src/lib.rs
@@ -207,7 +207,7 @@ pub enum Error {
 /// `Runner::add_local` and are never installable, so no `streamlib add` fix-it
 /// is offered for them.
 fn unknown_processor_type_message(ident: &SchemaIdent) -> String {
-    if ident.org.as_str() == "session" {
+    if ident.org.is_reserved_for_session() {
         format!("Unknown processor type: {ident} (not registered)")
     } else {
         format!(

--- a/sdk/streamlib-error/src/lib.rs
+++ b/sdk/streamlib-error/src/lib.rs
@@ -83,6 +83,9 @@ pub enum Error {
         detail: String,
     },
 
+    #[error("acquire-on-reference for package {package} failed: {detail}")]
+    AcquireOnReferenceFailed { package: PackageRef, detail: String },
+
     #[error(
         "This app's streamlib.yaml at {manifest_path} declares `dependencies:` \
          ({declared_count} package(s)), but an app is code, not a manifest — it \

--- a/sdk/streamlib-error/src/lib.rs
+++ b/sdk/streamlib-error/src/lib.rs
@@ -60,7 +60,7 @@ pub enum Error {
     #[error("Processor not found: {0}")]
     ProcessorNotFound(String),
 
-    #[error("Unknown processor type: {ident} (not registered)")]
+    #[error("{}", unknown_processor_type_message(.ident))]
     UnknownProcessorType { ident: SchemaIdent },
 
     #[error(
@@ -81,6 +81,19 @@ pub enum Error {
         processor_type: SchemaIdent,
         package: PackageRef,
         detail: String,
+    },
+
+    #[error(
+        "This app's streamlib.yaml at {manifest_path} declares `dependencies:` \
+         ({declared_count} package(s)), but an app is code, not a manifest — it \
+         resolves processor refs against its installed set (streamlib_modules/ + \
+         streamlib.lock), never a manifest dependency list. Remove the \
+         `dependencies:` block; install each package with `streamlib add <source>` \
+         (a folder, a .slpkg archive, or a URL)."
+    )]
+    AppManifestDeclaresDependencies {
+        manifest_path: String,
+        declared_count: usize,
     },
 
     #[error("Processor '{processor_id}' has no {direction} port named '{port_name}'")]
@@ -185,6 +198,26 @@ pub enum Error {
     Other(#[from] anyhow::Error),
 }
 
+/// Render the [`Error::UnknownProcessorType`] message. A genuinely-absent
+/// package-owned type carries a fix-it naming `streamlib add @org/name` — the
+/// installed-set-only load gate resolves refs against `streamlib_modules/` +
+/// `streamlib.lock`, so the recovery is to install the providing package. A
+/// `@session/` type is exempt: session processors register live via
+/// `Runner::add_local` and are never installable, so no `streamlib add` fix-it
+/// is offered for them.
+fn unknown_processor_type_message(ident: &SchemaIdent) -> String {
+    if ident.org.as_str() == "session" {
+        format!("Unknown processor type: {ident} (not registered)")
+    } else {
+        format!(
+            "Unknown processor type: {ident} (not registered). No installed package \
+             provides it — run `streamlib add @{}/{}` to install the providing package \
+             into this app's streamlib_modules/, then re-run.",
+            ident.org, ident.package
+        )
+    }
+}
+
 /// StreamLib result alias.
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -214,5 +247,61 @@ impl From<streamlib_consumer_rhi::ConsumerRhiError> for Error {
             streamlib_consumer_rhi::ConsumerRhiError::Gpu(s) => Error::GpuError(s),
             streamlib_consumer_rhi::ConsumerRhiError::Configuration(s) => Error::Configuration(s),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use streamlib_processor_schema::{Org, Package, SchemaIdent, SemVer, TypeName};
+
+    fn ident(org: &str, package: &str, ty: &str) -> SchemaIdent {
+        SchemaIdent::new(
+            Org::new(org).unwrap(),
+            Package::new(package).unwrap(),
+            TypeName::new(ty).unwrap(),
+            SemVer::new(1, 0, 0),
+        )
+    }
+
+    #[test]
+    fn unknown_processor_type_names_streamlib_add_fix_it() {
+        // A genuinely-absent package-owned type must name the exact
+        // `streamlib add @org/name` recovery. Mentally revert the fix-it branch
+        // and the message drops the actionable command.
+        let msg = Error::UnknownProcessorType {
+            ident: ident("tatolab", "camera", "Camera"),
+        }
+        .to_string();
+        assert!(
+            msg.contains("streamlib add @tatolab/camera"),
+            "fix-it missing: {msg}"
+        );
+    }
+
+    #[test]
+    fn unknown_processor_type_exempts_session_types() {
+        // A `@session/` type registers live via `add_local` and is never
+        // installable, so it must NOT be told to `streamlib add`.
+        let msg = Error::UnknownProcessorType {
+            ident: ident("session", "test-mock", "TestMock"),
+        }
+        .to_string();
+        assert!(
+            !msg.contains("streamlib add"),
+            "session type must not carry an install fix-it: {msg}"
+        );
+        assert!(msg.contains("not registered"), "message: {msg}");
+    }
+
+    #[test]
+    fn app_manifest_declares_dependencies_names_the_installed_set() {
+        let msg = Error::AppManifestDeclaresDependencies {
+            manifest_path: "/app/streamlib.yaml".to_string(),
+            declared_count: 2,
+        }
+        .to_string();
+        assert!(msg.contains("streamlib_modules/"), "message: {msg}");
+        assert!(msg.contains("streamlib add"), "message: {msg}");
     }
 }

--- a/sdk/streamlib-error/src/lib.rs
+++ b/sdk/streamlib-error/src/lib.rs
@@ -168,9 +168,7 @@ pub enum Error {
     #[error("Bag key '{key}' is not present")]
     BagKeyMissing { key: String },
 
-    #[error(
-        "Bag key '{key}' could not be read as `{expected_type}`: {detail}"
-    )]
+    #[error("Bag key '{key}' could not be read as `{expected_type}`: {detail}")]
     BagTypeMismatch {
         key: String,
         expected_type: String,

--- a/sdk/streamlib-idents/src/app_modules.rs
+++ b/sdk/streamlib-idents/src/app_modules.rs
@@ -3330,4 +3330,75 @@ mod tests {
             other => panic!("expected InstallUnsupportedSource, got {other:?}"),
         }
     }
+
+    /// Acquire-on-reference's install-shaped half: a `range → concrete`
+    /// resolution against a `file://` registry that materializes the highest
+    /// matching version into `streamlib_modules/` and WRITES the lock — the
+    /// exact byte-source add flow. Mentally revert `acquire_from_registry` to a
+    /// no-op and both the materialized slot and the lock entry vanish.
+    #[test]
+    fn acquire_from_registry_resolves_range_materializes_and_locks() {
+        let tree = tempfile::tempdir().unwrap();
+        let config = RegistryConfig::for_local_tree(tree.path()).unwrap();
+        let client = RegistryClient::new(&config);
+        let pr = pkg_ref("tatolab", "foo");
+        client
+            .upload_slpkg(&pr, SemVer::new(1, 0, 0), &slpkg_bytes("tatolab", "foo", "1.0.0"))
+            .unwrap();
+        client
+            .upload_slpkg(&pr, SemVer::new(1, 2, 0), &slpkg_bytes("tatolab", "foo", "1.2.0"))
+            .unwrap();
+
+        let app_root = tempfile::tempdir().unwrap();
+        let app = AppModulesDir::at(app_root.path());
+        // A caret range resolves to the highest matching concrete version.
+        let report = app
+            .acquire_from_registry(&pr, &SemVerRange::Caret(SemVer::new(1, 0, 0)), &config)
+            .unwrap();
+        assert_eq!(report.version, SemVer::new(1, 2, 0));
+        assert!(
+            app.package_dir(&pr).join("streamlib.yaml").is_file(),
+            "the acquired package must be materialized into streamlib_modules/"
+        );
+
+        // The lock records the acquired package at the resolved version via the
+        // registry download URL — indistinguishable from a hand `streamlib add`.
+        let lock = app.read_lockfile().unwrap();
+        let entry = lock
+            .packages
+            .get("@tatolab/foo")
+            .expect("acquired package must be locked");
+        assert_eq!(entry.version, SemVer::new(1, 2, 0));
+        assert!(
+            matches!(entry.source, LockfileSource::Url { .. }),
+            "acquired via a registry download URL, got {:?}",
+            entry.source
+        );
+    }
+
+    /// A range no published version satisfies is a typed acquire failure — not
+    /// a silent no-op that would leave the load stuck.
+    #[test]
+    fn acquire_from_registry_errors_when_no_version_matches() {
+        let tree = tempfile::tempdir().unwrap();
+        let config = RegistryConfig::for_local_tree(tree.path()).unwrap();
+        let client = RegistryClient::new(&config);
+        let pr = pkg_ref("tatolab", "foo");
+        client
+            .upload_slpkg(&pr, SemVer::new(1, 0, 0), &slpkg_bytes("tatolab", "foo", "1.0.0"))
+            .unwrap();
+
+        let app_root = tempfile::tempdir().unwrap();
+        let app = AppModulesDir::at(app_root.path());
+        let err = app
+            .acquire_from_registry(&pr, &SemVerRange::Caret(SemVer::new(2, 0, 0)), &config)
+            .expect_err("no 2.x version is published");
+        assert!(
+            matches!(err, AppModulesError::AcquireRegistryFailed { .. }),
+            "expected AcquireRegistryFailed, got {err:?}"
+        );
+        // Nothing materialized, nothing locked.
+        assert!(!app.package_dir(&pr).exists());
+        assert!(!app.lockfile_path().exists());
+    }
 }

--- a/sdk/streamlib-idents/src/app_modules.rs
+++ b/sdk/streamlib-idents/src/app_modules.rs
@@ -10,8 +10,9 @@ use crate::lockfile::{
     write_modules_lockfile,
 };
 use crate::manifest::Manifest;
+use crate::registry::{RegistryClient, RegistryConfig, select_version};
 use crate::resolver::content_hash_for_package_dir;
-use crate::semver::SemVer;
+use crate::semver::{SemVer, SemVerRange};
 
 /// Conventional per-app modules folder name, created beside the app's
 /// [`MODULES_LOCKFILE_NAME`]. Packages land at `streamlib_modules/@org/name/`.
@@ -413,6 +414,11 @@ pub enum AppModulesError {
     /// promote / symlink). Names the package plus the underlying detail.
     #[error("reproducing '{package}' failed: {detail}")]
     InstallReproduceFailed { package: PackageRef, detail: String },
+
+    /// Resolving a `range → concrete version` against the registry (listing
+    /// versions or selecting one) failed while acquiring a package on reference.
+    #[error("acquiring '{package}' from the registry failed: {detail}")]
+    AcquireRegistryFailed { package: PackageRef, detail: String },
 }
 
 /// A per-app `streamlib_modules/` folder plus its `streamlib.lock`, anchored
@@ -902,6 +908,54 @@ impl AppModulesDir {
             modules_dir,
             packages,
         })
+    }
+
+    /// Acquire `pkg_ref` from the static registry `config` on reference:
+    /// resolve the declared `range` to the highest concrete version the
+    /// registry holds, then materialize that version's `.slpkg` into
+    /// `streamlib_modules/@org/name/` and record it in `streamlib.lock` — the
+    /// exact byte-source [`add_package`](Self::add_package) flow (fetch →
+    /// hash → atomic promote → lock), so an acquired package is
+    /// indistinguishable from one added by hand.
+    ///
+    /// This is the **install-shaped** half of the two-resolver split: a
+    /// `range → concrete` resolution that WRITES the lock. It reuses the same
+    /// [`RegistryClient`] + content-hash + [`write_modules_lockfile`] machinery
+    /// `streamlib add`/`install` use; it is never the locked-run resolver
+    /// (which loads a pinned set offline and makes no resolution decisions).
+    ///
+    /// [`write_modules_lockfile`]: crate::lockfile::write_modules_lockfile
+    #[tracing::instrument(skip(self, config), fields(app_root = %self.app_root.display(), package = %pkg_ref, %range))]
+    pub fn acquire_from_registry(
+        &self,
+        pkg_ref: &PackageRef,
+        range: &SemVerRange,
+        config: &RegistryConfig,
+    ) -> Result<AddPackageReport, AppModulesError> {
+        let acquire_err = |detail: String| AppModulesError::AcquireRegistryFailed {
+            package: pkg_ref.clone(),
+            detail,
+        };
+        let client = RegistryClient::new(config);
+        let available = client
+            .list_versions(pkg_ref)
+            .map_err(|e| acquire_err(format!("listing versions: {e}")))?;
+        let version = select_version(pkg_ref, range, &available)
+            .map_err(|e| acquire_err(e.to_string()))?;
+        let url = client.download_url(pkg_ref, version);
+        tracing::info!(
+            package = %pkg_ref,
+            %version,
+            %url,
+            "acquire_from_registry: resolved range to a concrete version; materializing"
+        );
+        // Route through the byte-source materialize + lock flow. A `file://` or
+        // `http(s)://` download URL is fetched, hashed, extracted, atomically
+        // promoted, and recorded in streamlib.lock — one adoption path.
+        self.add_package(
+            &AddPackageSource::Url { url },
+            &AddPackageOptions::default(),
+        )
     }
 
     /// Reproduce one lockfile entry into its `streamlib_modules/@org/name` slot.

--- a/sdk/streamlib-idents/src/app_modules.rs
+++ b/sdk/streamlib-idents/src/app_modules.rs
@@ -910,21 +910,12 @@ impl AppModulesDir {
         })
     }
 
-    /// Acquire `pkg_ref` from the static registry `config` on reference:
-    /// resolve the declared `range` to the highest concrete version the
-    /// registry holds, then materialize that version's `.slpkg` into
-    /// `streamlib_modules/@org/name/` and record it in `streamlib.lock` — the
-    /// exact byte-source [`add_package`](Self::add_package) flow (fetch →
-    /// hash → atomic promote → lock), so an acquired package is
-    /// indistinguishable from one added by hand.
-    ///
-    /// This is the **install-shaped** half of the two-resolver split: a
-    /// `range → concrete` resolution that WRITES the lock. It reuses the same
-    /// [`RegistryClient`] + content-hash + [`write_modules_lockfile`] machinery
-    /// `streamlib add`/`install` use; it is never the locked-run resolver
-    /// (which loads a pinned set offline and makes no resolution decisions).
-    ///
-    /// [`write_modules_lockfile`]: crate::lockfile::write_modules_lockfile
+    /// Acquire `pkg_ref` from the static registry on reference: resolve `range`
+    /// to the highest concrete version the registry holds, then materialize its
+    /// `.slpkg` via the [`add_package`](Self::add_package) byte-source flow and
+    /// record it in `streamlib.lock`. The install-shaped half of the
+    /// two-resolver split (`range → concrete`, WRITES the lock) — never the
+    /// locked-run resolver.
     #[tracing::instrument(skip(self, config), fields(app_root = %self.app_root.display(), package = %pkg_ref, %range))]
     pub fn acquire_from_registry(
         &self,

--- a/sdk/streamlib-idents/src/manifest.rs
+++ b/sdk/streamlib-idents/src/manifest.rs
@@ -101,6 +101,22 @@ impl Manifest {
         self.package.is_some()
     }
 
+    /// The number of declared dependencies when this manifest is an **app**
+    /// manifest (project flavor — no `package:` block) that nonetheless carries
+    /// a non-empty `dependencies:` block, else `None`.
+    ///
+    /// An app is code, not a manifest: it resolves processor refs against its
+    /// installed set (`streamlib_modules/` + `streamlib.lock`), so a
+    /// `dependencies:` list on an app manifest is a phantom-dependency
+    /// declaration that never resolves — both `streamlib add` and the runtime
+    /// load gate reject it. A **package**-flavor manifest's `dependencies:` are
+    /// legitimate (the recursive walker resolves a loaded package's transitive
+    /// deps), so this returns `None` for it.
+    pub fn app_dependency_violation_count(&self) -> Option<usize> {
+        (!self.is_package_flavor() && !self.dependencies.is_empty())
+            .then_some(self.dependencies.len())
+    }
+
     /// Canonical [`PackageRef`] for this manifest, when it's a package
     /// flavor. Consumers that need the joined `"@org/name"` string form
     /// (e.g. for lockfile keys, log messages) call `.to_string()` on the
@@ -723,6 +739,29 @@ dependencies:
         .unwrap();
         let m = Manifest::load(tmp.path()).unwrap();
         assert_eq!(m.package_id().as_deref(), Some("@tatolab/core"));
+    }
+
+    #[test]
+    fn app_dependency_violation_flags_project_flavor_with_deps() {
+        // Project flavor (no `package:`) + non-empty `dependencies:` is the
+        // phantom-dependency app manifest — flagged with the declared count.
+        let app: Manifest = serde_yaml::from_str(
+            "dependencies:\n  '@tatolab/core': ^1.0.0\n  '@tatolab/camera': ^2.0.0\n",
+        )
+        .unwrap();
+        assert_eq!(app.app_dependency_violation_count(), Some(2));
+
+        // Project flavor with no deps is fine.
+        let empty_app: Manifest = serde_yaml::from_str("dependencies: {}\n").unwrap();
+        assert_eq!(empty_app.app_dependency_violation_count(), None);
+
+        // A package-flavor manifest's deps are legitimate — never flagged.
+        let package: Manifest = serde_yaml::from_str(
+            "package:\n  org: tatolab\n  name: widget\n  version: 0.1.0\n\
+             dependencies:\n  '@tatolab/core': ^1.0.0\n",
+        )
+        .unwrap();
+        assert_eq!(package.app_dependency_violation_count(), None);
     }
 
     #[test]

--- a/sdk/streamlib-idents/src/registry.rs
+++ b/sdk/streamlib-idents/src/registry.rs
@@ -366,8 +366,11 @@ impl<'a> RegistryClient<'a> {
     }
 
     /// Canonical `.slpkg` download URL (recorded in the lockfile):
-    /// `<base>/slpkg/<name>/<version>/<name>.slpkg`.
-    fn download_url(&self, pkg_ref: &PackageRef, version: SemVer) -> String {
+    /// `<base>/slpkg/<name>/<version>/<name>.slpkg`. Public so acquire-shaped
+    /// callers (e.g. [`crate::app_modules::AppModulesDir::acquire_from_registry`])
+    /// can resolve a concrete version's URL and hand it to the byte-source
+    /// materialize + lock flow.
+    pub fn download_url(&self, pkg_ref: &PackageRef, version: SemVer) -> String {
         let name = pkg_ref.name.as_str();
         format!(
             "{}/{}/{}/{}/{}.slpkg",

--- a/sdk/streamlib-idents/src/registry.rs
+++ b/sdk/streamlib-idents/src/registry.rs
@@ -366,11 +366,8 @@ impl<'a> RegistryClient<'a> {
     }
 
     /// Canonical `.slpkg` download URL (recorded in the lockfile):
-    /// `<base>/slpkg/<name>/<version>/<name>.slpkg`. Public so acquire-shaped
-    /// callers (e.g. [`crate::app_modules::AppModulesDir::acquire_from_registry`])
-    /// can resolve a concrete version's URL and hand it to the byte-source
-    /// materialize + lock flow.
-    pub fn download_url(&self, pkg_ref: &PackageRef, version: SemVer) -> String {
+    /// `<base>/slpkg/<name>/<version>/<name>.slpkg`.
+    pub(crate) fn download_url(&self, pkg_ref: &PackageRef, version: SemVer) -> String {
         let name = pkg_ref.name.as_str();
         format!(
             "{}/{}/{}/{}/{}.slpkg",

--- a/tools/streamlib-cli/src/commands/add.rs
+++ b/tools/streamlib-cli/src/commands/add.rs
@@ -27,9 +27,7 @@ use anyhow::{Context, Result};
 use streamlib::sdk::runtime::{
     AddPackageOptions, AddPackageReport, AddPackageSource, AppModulesDir, LinkPackageReport,
 };
-use streamlib_idents::{
-    DependencySpec, Manifest, PackageRef, RegistryDependency, SemVerRange,
-};
+use streamlib_idents::{DependencySpec, Manifest, PackageRef, RegistryDependency, SemVerRange};
 use streamlib_processor_schema::StreamlibYaml;
 
 /// `streamlib add <spec>` — records a dependency range when run in a
@@ -181,8 +179,8 @@ fn record_dependency_range(manifest_path: &Path, spec: &str) -> Result<()> {
     let raw = std::fs::read_to_string(manifest_path)
         .with_context(|| format!("read {}", manifest_path.display()))?;
     let (header, body) = split_leading_comment_header(&raw);
-    let mut manifest: StreamlibYaml =
-        serde_yaml::from_str(&body).with_context(|| format!("parse {}", manifest_path.display()))?;
+    let mut manifest: StreamlibYaml = serde_yaml::from_str(&body)
+        .with_context(|| format!("parse {}", manifest_path.display()))?;
 
     let replaced = manifest
         .dependencies
@@ -195,8 +193,7 @@ fn record_dependency_range(manifest_path: &Path, spec: &str) -> Result<()> {
         )
         .is_some();
 
-    let serialized =
-        serde_yaml::to_string(&manifest).context("serialize streamlib.yaml")?;
+    let serialized = serde_yaml::to_string(&manifest).context("serialize streamlib.yaml")?;
     std::fs::write(manifest_path, format!("{header}{serialized}"))
         .with_context(|| format!("write {}", manifest_path.display()))?;
 
@@ -212,9 +209,7 @@ fn record_dependency_range(manifest_path: &Path, spec: &str) -> Result<()> {
 /// lookup here). Returns a CLI-friendly error otherwise.
 fn parse_authoring_spec(spec: &str) -> Result<(PackageRef, String)> {
     let inner = spec.strip_prefix('@').ok_or_else(|| {
-        anyhow::anyhow!(
-            "expected `@org/name@<version>` (e.g. `@tatolab/core@1.0.0`); got `{spec}`"
-        )
+        anyhow::anyhow!("expected `@org/name@<version>` (e.g. `@tatolab/core@1.0.0`); got `{spec}`")
     })?;
     let (name_part, version) = inner.split_once('@').ok_or_else(|| {
         anyhow::anyhow!(

--- a/tools/streamlib-cli/src/commands/add.rs
+++ b/tools/streamlib-cli/src/commands/add.rs
@@ -399,6 +399,34 @@ mod tests {
     }
 
     #[test]
+    fn add_rejects_app_dir_manifest_declaring_dependencies() {
+        let dir = tempfile::tempdir().unwrap();
+        // Project-flavor (no `package:`) manifest carrying a phantom
+        // `dependencies:` block — an app resolves refs against its installed
+        // set, so `add` must reject before touching streamlib_modules/.
+        std::fs::write(
+            dir.path().join("streamlib.yaml"),
+            "dependencies:\n  '@tatolab/core': ^1.0.0\n",
+        )
+        .unwrap();
+
+        let err = add("./anything", Some(dir.path()), None)
+            .expect_err("add must reject an app-dir manifest that declares dependencies");
+        match err.downcast_ref::<streamlib::sdk::error::Error>() {
+            Some(streamlib::sdk::error::Error::AppManifestDeclaresDependencies {
+                declared_count,
+                ..
+            }) => assert_eq!(*declared_count, 1),
+            other => panic!("expected AppManifestDeclaresDependencies, got {other:?}"),
+        }
+        // The rejection is before any adoption side-effect.
+        assert!(
+            !dir.path().join("streamlib_modules").exists(),
+            "add must not create streamlib_modules/ when it rejects the manifest"
+        );
+    }
+
+    #[test]
     fn record_dependency_range_writes_caret_and_preserves_fields() {
         let dir = tempfile::tempdir().unwrap();
         let manifest_path = dir.path().join("streamlib.yaml");

--- a/tools/streamlib-cli/src/commands/add.rs
+++ b/tools/streamlib-cli/src/commands/add.rs
@@ -49,7 +49,12 @@ pub fn add(spec: &str, dir: Option<&Path>, expect_sha256: Option<&str>) -> Resul
         // phantom-dependency list — an app resolves refs against its installed
         // set, not a manifest. Reject before touching streamlib_modules/.
         if let Some(count) = manifest.app_dependency_violation_count() {
-            anyhow::bail!(app_dependencies_rejection(&anchor, count));
+            anyhow::bail!(
+                streamlib::sdk::error::Error::AppManifestDeclaresDependencies {
+                    manifest_path: anchor.join(Manifest::FILE_NAME).display().to_string(),
+                    declared_count: count,
+                }
+            );
         }
     }
 
@@ -152,20 +157,6 @@ fn load_anchor_manifest(dir: &Path) -> Result<Option<Manifest>> {
     Manifest::load(dir)
         .map(Some)
         .map_err(|e| anyhow::anyhow!("{e}"))
-}
-
-/// The rejection shown when `streamlib add` runs in an app dir whose
-/// `streamlib.yaml` declares `dependencies:` — an app resolves refs against its
-/// installed set, never a manifest dependency list.
-fn app_dependencies_rejection(dir: &Path, count: usize) -> String {
-    format!(
-        "this app's {} declares `dependencies:` ({count} package(s)), but an app is code, \
-         not a manifest — it resolves processor refs against its installed set \
-         (streamlib_modules/ + streamlib.lock), never a manifest dependency list.\n  \
-         Fix: remove the `dependencies:` block, then install each package with \
-         `streamlib add <source>` (a folder, a .slpkg archive, or a URL).",
-        dir.join(Manifest::FILE_NAME).display()
-    )
 }
 
 /// Record `spec` (`@org/name@<version>`) as a caret dependency in the package
@@ -405,14 +396,6 @@ mod tests {
         let pkg = load_anchor_manifest(dir.path()).unwrap().unwrap();
         assert!(pkg.is_package_flavor());
         assert_eq!(pkg.app_dependency_violation_count(), None);
-    }
-
-    #[test]
-    fn app_dependencies_rejection_names_the_installed_set_fix_it() {
-        let dir = tempfile::tempdir().unwrap();
-        let msg = app_dependencies_rejection(dir.path(), 2);
-        assert!(msg.contains("streamlib_modules/"), "message: {msg}");
-        assert!(msg.contains("streamlib add <source>"), "message: {msg}");
     }
 
     #[test]

--- a/tools/streamlib-cli/src/commands/add.rs
+++ b/tools/streamlib-cli/src/commands/add.rs
@@ -37,14 +37,22 @@ use streamlib_processor_schema::StreamlibYaml;
 /// `streamlib_modules/`.
 pub fn add(spec: &str, dir: Option<&Path>, expect_sha256: Option<&str>) -> Result<()> {
     let anchor = anchor_dir(dir)?;
-    if let Some(manifest_path) = package_authoring_manifest(&anchor)? {
-        if expect_sha256.is_some() {
-            eprintln!(
-                "warning: --expect-sha256 is ignored when recording a dependency range in a \
-                 package's streamlib.yaml; it applies only to archive and URL byte sources"
-            );
+    if let Some(manifest) = load_anchor_manifest(&anchor)? {
+        if manifest.is_package_flavor() {
+            if expect_sha256.is_some() {
+                eprintln!(
+                    "warning: --expect-sha256 is ignored when recording a dependency range in a \
+                     package's streamlib.yaml; it applies only to archive and URL byte sources"
+                );
+            }
+            return record_dependency_range(&anchor.join(Manifest::FILE_NAME), spec);
         }
-        return record_dependency_range(&manifest_path, spec);
+        // A project-flavor (app) manifest that declares `dependencies:` is a
+        // phantom-dependency list — an app resolves refs against its installed
+        // set, not a manifest. Reject before touching streamlib_modules/.
+        if let Some(count) = manifest.app_dependency_violation_count() {
+            anyhow::bail!(app_dependencies_rejection(&anchor, count));
+        }
     }
 
     let app = app_modules_dir(dir)?;
@@ -137,16 +145,29 @@ fn anchor_dir(dir: Option<&Path>) -> Result<PathBuf> {
     }
 }
 
-/// The `streamlib.yaml` path when `dir` holds a **package-authoring** manifest
-/// (one with a `package:` block), else `None`. A missing manifest or a
-/// project-flavor manifest (no `package:`) routes `add` to the consumer flow.
-fn package_authoring_manifest(dir: &Path) -> Result<Option<PathBuf>> {
-    let manifest_path = dir.join(Manifest::FILE_NAME);
-    if !manifest_path.is_file() {
+/// Load the `streamlib.yaml` at `dir`, or `None` when the dir carries no
+/// manifest (the common consumer-app case — an app is code, not a manifest).
+fn load_anchor_manifest(dir: &Path) -> Result<Option<Manifest>> {
+    if !dir.join(Manifest::FILE_NAME).is_file() {
         return Ok(None);
     }
-    let manifest = Manifest::load(dir).map_err(|e| anyhow::anyhow!("{e}"))?;
-    Ok(manifest.is_package_flavor().then_some(manifest_path))
+    Manifest::load(dir)
+        .map(Some)
+        .map_err(|e| anyhow::anyhow!("{e}"))
+}
+
+/// The rejection shown when `streamlib add` runs in an app dir whose
+/// `streamlib.yaml` declares `dependencies:` — an app resolves refs against its
+/// installed set, never a manifest dependency list.
+fn app_dependencies_rejection(dir: &Path, count: usize) -> String {
+    format!(
+        "this app's {} declares `dependencies:` ({count} package(s)), but an app is code, \
+         not a manifest — it resolves processor refs against its installed set \
+         (streamlib_modules/ + streamlib.lock), never a manifest dependency list.\n  \
+         Fix: remove the `dependencies:` block, then install each package with \
+         `streamlib add <source>` (a folder, a .slpkg archive, or a URL).",
+        dir.join(Manifest::FILE_NAME).display()
+    )
 }
 
 /// Record `spec` (`@org/name@<version>`) as a caret dependency in the package
@@ -364,24 +385,39 @@ mod tests {
     }
 
     #[test]
-    fn package_authoring_manifest_detects_only_package_flavor() {
+    fn load_anchor_manifest_reads_flavor_and_deps() {
         let dir = tempfile::tempdir().unwrap();
-        // No manifest → consumer flow.
-        assert!(package_authoring_manifest(dir.path()).unwrap().is_none());
-        // Project-flavor (no `package:`) → consumer flow.
+        // No manifest → None (consumer flow).
+        assert!(load_anchor_manifest(dir.path()).unwrap().is_none());
+
+        // Project-flavor (no `package:`) with deps → flagged as an app-deps
+        // violation, so `add` rejects rather than routing to consumer flow.
         std::fs::write(
             dir.path().join("streamlib.yaml"),
             "dependencies:\n  '@tatolab/core': ^1.0.0\n",
         )
         .unwrap();
-        assert!(package_authoring_manifest(dir.path()).unwrap().is_none());
-        // Package-flavor → authoring.
+        let app = load_anchor_manifest(dir.path()).unwrap().unwrap();
+        assert!(!app.is_package_flavor());
+        assert_eq!(app.app_dependency_violation_count(), Some(1));
+
+        // Package-flavor → authoring dir (deps are legitimate there).
         std::fs::write(
             dir.path().join("streamlib.yaml"),
             "package:\n  org: tatolab\n  name: widget\n  version: 0.1.0\n",
         )
         .unwrap();
-        assert!(package_authoring_manifest(dir.path()).unwrap().is_some());
+        let pkg = load_anchor_manifest(dir.path()).unwrap().unwrap();
+        assert!(pkg.is_package_flavor());
+        assert_eq!(pkg.app_dependency_violation_count(), None);
+    }
+
+    #[test]
+    fn app_dependencies_rejection_names_the_installed_set_fix_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let msg = app_dependencies_rejection(dir.path(), 2);
+        assert!(msg.contains("streamlib_modules/"), "message: {msg}");
+        assert!(msg.contains("streamlib add <source>"), "message: {msg}");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1418.

## Summary

Apps are code, not manifests — this closes the last M34 gap by making the runtime's load gate
resolve app processor refs **only** against the installed set (`streamlib_modules/` +
`streamlib.lock`), with a policy-gated acquire-on-reference fallback for fleets:

- `streamlib add` in a project-flavor (app) directory now rejects a `streamlib.yaml` that carries
  a `dependencies:` block, with an installed-set fix-it, before touching `streamlib_modules/`.
- The runtime load gate (`begin_lazy_provider_load`) rejects the same phantom-deps app manifest
  with a new typed `Error::AppManifestDeclaresDependencies`. A ref absent from the installed set
  fails with a fix-it (`streamlib add @org/name`); `@session/` types stay exempt (they register
  live via `add_local`, never installable).
- New acquire-on-reference policy knob (`STREAMLIB_ACQUIRE_ON_REFERENCE` /
  `Runner::set_acquire_on_reference_policy`, **off by default**): on a load miss, `on` fetches the
  providing package from the registry via `AppModulesDir::acquire_from_registry`, verifies the
  hash, records it in `streamlib.lock`, then loads it from the installed cache. `prompt` fails
  closed today (no host wires a confirmation handler yet — see review items below).
- Architecture doc (`docs/architecture/runtime-module-materialization.md`) updated to reflect the
  shipped behavior.

## Commits

- `6fe708ad` feat(runtime): installed-set-only load-gate surfaces + acquire primitive
- `8e2fb872` feat(runtime): reject app-manifest deps + policy-gated acquire-on-reference
- `f9b9ec1c` docs(architecture): installed-set-only load gate + acquire-on-reference
- `e66138b7` style: rustfmt the touched engine/error/cli files
- `e9844aa7` fix(runtime): typed AcquireOnReferenceFailed + SESSION_ORG const + conditional prompt doc
- `8a48762f` refactor(cli): single-source app-manifest-deps rejection via typed engine error

## Test evidence

Local gate battery, all green:

- `streamlib-error`: 3/3
- `streamlib-idents`: 231/231
- `streamlib-cli`: 44/44
- `streamlib-engine` `module_loader`: 128/128
- Revert-fail confirmed (undeclared-dep hard error reproduces before the fix, passes after)

Verified by an independent lens pass (all lenses cleared) prior to this PR being opened.

## Review items (non-blocking)

The verifier surfaced the following findings. None are blocking — they're recorded here verbatim
for the owner's visibility and to decide on follow-up:

1. **[should-fix]** `runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs:935` — The
   composed runtime acquire-on-reference path (miss -> `begin_acquire_on_reference` ->
   `add_module_with(Strategy::InstalledCache)`) is wired but has no test.
   Evidence: `begin_acquire_on_reference` and its call sites in `resolve_lazy_provider_load`
   (line 938) and the blocking variant (line 961) are new production wiring. The only added tests
   cover the pieces in isolation: `acquire::tests::permission_honors_override_and_prompt_fails_closed`
   (permission gate) and `app_modules::tests::acquire_from_registry_*` (the install-shaped
   resolver). Mentally reverting the wiring that threads `begin_acquire_on_reference` into the
   lazy-load result — or reverting the final `add_module_with(InstalledCache)` reload after
   acquire — fails no test. The claim that an acquired package loads from the now-populated
   installed cache (that `AppModulesDir::at(app_root)` writes to the same root
   `Strategy::InstalledCache` reads from) is unverified. I cannot exercise the full runtime here
   (GPU/IPC sandboxed).
   Suggested next step: Add a runtime-level test: policy=On, a `file://` registry holding the
   package, a miss on first reference drives acquire + reload and the type ends up registered;
   and policy=Off leaves it a `UnknownProcessorType` miss.

2. **[should-fix]** `tools/streamlib-cli/src/commands/add.rs:48` — Acceptance criterion 1
   (app-dir `streamlib add` rejects any `dependencies:` key with a message) — the CLI rejection
   branch is not directly exercised.
   Evidence: `add()` bails with `Error::AppManifestDeclaresDependencies` when
   `load_anchor_manifest` reports a non-package flavor with deps, but the only added CLI test
   (`load_anchor_manifest_reads_flavor_and_deps`) tests the helper + `app_dependency_violation_count`,
   not `add()` itself. Reverting the bail branch in `add()` would not fail any test. The
   equivalent engine-side gate (`check_app_manifest_declares_no_dependencies`) IS tested
   non-vacuously, and the message is tested in `streamlib-error`, so the logic is covered — but
   not the CLI entrypoint the criterion names.
   Suggested next step: Add an `add_remove.rs` integration test invoking the CLI `add` on an app
   dir whose `streamlib.yaml` is project-flavor with a `dependencies:` block, asserting a non-zero
   exit and the fix-it message, and that `streamlib_modules/` is untouched.

3. **[low]** `sdk/streamlib-error/src/lib.rs:209` — `unknown_processor_type_message` hardcodes the
   literal `"session"` instead of the `SESSION_ORG` constant / an `Org::is_session()` predicate.
   Evidence: `begin_acquire_on_reference` (mod.rs) uses `streamlib_idents::SESSION_ORG` for the
   same exemption, but the error crate uses `ident.org.as_str() == "session"`. The value is
   defined once as `pub const SESSION_ORG: &str = "session"` in idents; the error crate depends
   on `streamlib_processor_schema`, so reachability may differ — but this is a duplicated magic
   string for a load-bearing exemption.
   Suggested next step: Route the check through a shared const / `Org::is_session()` predicate
   reachable from the error crate, or note why the literal is unavoidable.

4. **[info]** `sdk/streamlib-idents/src/app_modules.rs:947` — Acceptance criterion 3's "verify
   hash" is satisfied only in the record-the-computed-hash sense — there is no verification
   against a registry-published checksum.
   Evidence: `acquire_from_registry` routes through `add_package` with `AddPackageOptions::default()`,
   so `verify_and_hash_archive_bytes` computes and records the sha but skips the expected-sha
   branch. The static registry index (`render_index_ndjson`) publishes only `{name, vers}` with no
   checksum, so there is no trusted hash to verify against — this matches the existing registry-dep
   download path (`download_slpkg` records without verifying), so it is not a regression.
   Suggested next step: If per-artifact integrity is desired, publish checksums in the registry
   index and thread `expected_archive_sha256` through acquire; otherwise note in the PR that
   "verify hash" means record-and-lock, consistent with the rest of the registry flow.

5. **[should-fix]** `runtime/streamlib-engine/src/core/runtime/module_loader/acquire.rs:4` —
   Several new rustdoc blocks are multi-paragraph essays, which the comments rule discourages.
   Evidence: `acquire.rs` module doc, `begin_acquire_on_reference` (mod.rs ~line 846), and
   `acquire_from_registry` (app_modules.rs ~line 913) carry multi-paragraph rustdoc.
   `comments.md`: "Don't write multi-paragraph rustdoc essays." They are informative and free of
   `# Example` sections, so this is a style nit, not a doc-policy violation.
   Suggested next step: Trim to a one-line doc plus, where load-bearing, a single why-clause; move
   rationale to the PR body.

6. **[should-fix]** `sdk/streamlib-error/src/lib.rs:210` — Magic string `"session"` duplicates the
   `SESSION_ORG` constant's value across a crate boundary and drifts from the named predicate
   already on the type.
   Evidence: `unknown_processor_type_message` does `if ident.org.as_str() == "session"`.
   `ident.org` is `streamlib_idents::Org` (re-exported through `streamlib_processor_schema`),
   which already exposes `fn is_reserved_for_session(&self) -> bool` backed by
   `pub const SESSION_ORG = "session"` in `ident.rs`. The bare literal will silently diverge if
   `SESSION_ORG` ever changes, and it spells the same concept differently from the twin check in
   `module_loader/mod.rs:872` (which uses `streamlib_idents::SESSION_ORG`).
   Suggested next step: Replace `ident.org.as_str() == "session"` with
   `ident.org.is_reserved_for_session()` — no new dependency needed (the method rides the
   re-exported `Org`).

7. **[should-fix]** `sdk/streamlib-idents/src/registry.rs:373` — `download_url` widened from
   private to fully `pub` but has no cross-crate caller — over-broad public API surface.
   Evidence: The diff changes `fn download_url` to `pub fn download_url`, justified in the doc as
   needed by `AppModulesDir::acquire_from_registry`. But grep shows the only callers are
   `app_modules.rs:945` and `registry.rs:180/209` — all inside the `streamlib-idents` crate. The
   engine calls `acquire_from_registry`, never `download_url` directly. `pub(crate)` covers every
   real caller.
   Suggested next step: Change `pub fn download_url` to `pub(crate) fn download_url` to keep the
   crate's public surface minimal.

8. **[low]** `runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs:872` — Session check
   spells the reserved-org predicate as a constant comparison where a named boolean method exists.
   Evidence: `if processor_type.org().as_str() == streamlib_idents::SESSION_ORG` — `org()` returns
   `&Org`, which has `is_reserved_for_session()`. Using the constant is already better than the
   `streamlib-error` literal, but the method reads more clearly and would make both diff sites
   spell the concept identically.
   Suggested next step: Optional: `if processor_type.org().is_reserved_for_session()` for a single
   canonical spelling across both new session checks.

9. **[info]** `runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs:940` — Near-identical
   acquire-on-reference fallback arms in the async and blocking lazy-load drivers.
   Evidence: Both `mod.rs:940` (async, `added.await`) and `mod.rs:962` (blocking,
   `drive_added_module_to_completion_blocking`) open with
   `Ok(None) => match self.begin_acquire_on_reference(processor_type) { Ok(Some(added)) => ...,
   Ok(None) => ..., Err(e) => Some(e) }`. The bodies genuinely differ (await vs blocking drive, and
   the control-flow shape), so this is incidental similarity that evolves independently — not
   worth extracting.
   Suggested next step: No action; noted only so a future edit to acquire semantics remembers to
   touch both drivers.
