### PR TITLE
ci: wire the three orphaned xtask checks into CI

### DIFF
--- a/.github/workflows/check-device-wait-idle.yml
+++ b/.github/workflows/check-device-wait-idle.yml
@@ -1,0 +1,46 @@
+name: Check Device Wait Idle
+
+# CI gate for RHI device-idle discipline.
+# `cargo xtask check-device-wait-idle` walks the engine sources and fails
+# if any raw `device_wait_idle` call bypasses `HostVulkanDevice::wait_idle`
+# — every full-device stall must route through the single RHI entrypoint.
+#
+# Grep-shaped on purpose: sub-second on a clean runner, no workspace build.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  xtask-check-device-wait-idle:
+    name: xtask check-device-wait-idle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-xtask-${{ hashFiles('xtask/Cargo.toml', 'xtask/Cargo.lock', 'Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-xtask-
+
+      - name: cargo xtask check-device-wait-idle
+        run: cargo run --locked -q -p xtask -- check-device-wait-idle
+
+      - name: cargo test -p xtask check_device_wait_idle (fixture tests)
+        run: cargo test --locked -p xtask check_device_wait_idle

--- a/.github/workflows/check-no-escalate-in-lifecycle.yml
+++ b/.github/workflows/check-no-escalate-in-lifecycle.yml
@@ -1,0 +1,47 @@
+name: Check No Escalate In Lifecycle
+
+# CI gate for the sandbox lifecycle contract.
+# `cargo xtask check-no-escalate-in-lifecycle` walks the engine sources
+# and fails if any `.escalate(...)` call appears inside a FullAccess
+# lifecycle body (setup / teardown / start / stop and their `_inner`
+# helpers), where escalate ops are not permitted.
+#
+# Grep-shaped on purpose: sub-second on a clean runner, no workspace build.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  xtask-check-no-escalate-in-lifecycle:
+    name: xtask check-no-escalate-in-lifecycle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-xtask-${{ hashFiles('xtask/Cargo.toml', 'xtask/Cargo.lock', 'Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-xtask-
+
+      - name: cargo xtask check-no-escalate-in-lifecycle
+        run: cargo run --locked -q -p xtask -- check-no-escalate-in-lifecycle
+
+      - name: cargo test -p xtask check_no_escalate_in_lifecycle (fixture tests)
+        run: cargo test --locked -p xtask check_no_escalate_in_lifecycle

--- a/.github/workflows/check-processor-spec-new.yml
+++ b/.github/workflows/check-processor-spec-new.yml
@@ -1,0 +1,47 @@
+name: Check ProcessorSpec Construction
+
+# CI gate for structured processor identity.
+# `cargo xtask check-processor-spec-new` walks `examples/` and fails if
+# any site constructs a `ProcessorSpec` from a bare string or hand-rolls
+# a `SchemaIdent` literal instead of the typed constructors. See
+# `docs/architecture/schema-identity-and-packaging.md`.
+#
+# Grep-shaped on purpose: sub-second on a clean runner, no workspace build.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  xtask-check-processor-spec-new:
+    name: xtask check-processor-spec-new
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-xtask-${{ hashFiles('xtask/Cargo.toml', 'xtask/Cargo.lock', 'Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-xtask-
+
+      - name: cargo xtask check-processor-spec-new
+        run: cargo run --locked -q -p xtask -- check-processor-spec-new
+
+      - name: cargo test -p xtask check_processor_spec_new (fixture tests)
+        run: cargo test --locked -p xtask check_processor_spec_new


### PR DESCRIPTION
## What

Three `xtask` gates ship with fixture tests but were never referenced in any `.github/workflows/*.yml`, so they only ran when someone invoked them by hand:

- `check-processor-spec-new` — no bare-string `ProcessorSpec::new` / hand-rolled `SchemaIdent` literals in `examples/`
- `check-no-escalate-in-lifecycle` — no `.escalate(...)` inside a FullAccess lifecycle body
- `check-device-wait-idle` — no raw `device_wait_idle` bypassing `HostVulkanDevice::wait_idle`

## How

One workflow file per check, mirroring the existing grep-shaped xtask gates (`check-no-reverse-dns.yml` and friends): install Rust, restore the shared `cargo-xtask` cache, run the check, then run its fixture tests. Same triggers (`pull_request` / `push` to `main`), same job shape.

## Verification

Locally on this branch:
- `cargo run -p xtask -- check-processor-spec-new` → pass
- `cargo run -p xtask -- check-no-escalate-in-lifecycle` → pass
- `cargo run -p xtask -- check-device-wait-idle` → pass
- `cargo test -p xtask` → 219 passed (includes all three checks' fixture suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)