### PR TITLE
ci(schemas): install jtd-codegen; run client-package job on Linux

### DIFF
--- a/.github/workflows/schemas.yml
+++ b/.github/workflows/schemas.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   generate-and-publish:
     name: Generate & Publish Client Package
-    runs-on: macos-14  # macOS for Apple-specific code
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -19,7 +19,27 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: brew install opus pkg-config
+        # generate_schemas builds streamlib-engine, whose build.rs compiles GLSL
+        # with glslc and links Vulkan; the audio path links opus. Mirrors test.yml's
+        # Linux engine dep set (+ libopus-dev for the opus link brew previously gave).
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config \
+            protobuf-compiler \
+            libvulkan-dev \
+            glslc \
+            libopus-dev
+
+      - name: Install jtd-codegen
+        # The engine build.rs invokes the upstream jtd-codegen binary (v0.4.1) to
+        # generate JTD bindings; without it the build fails with "jtd-codegen not
+        # found". Same install as test.yml / check-pack-load.yml.
+        run: |
+          curl -sSL https://github.com/jsontypedef/json-typedef-codegen/releases/download/v0.4.1/x86_64-unknown-linux-gnu.zip -o /tmp/jtd-codegen.zip
+          unzip -q /tmp/jtd-codegen.zip -d /tmp/jtd-codegen
+          sudo install -m 0755 /tmp/jtd-codegen/jtd-codegen /usr/local/bin/jtd-codegen
+          jtd-codegen --version
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## The failure (recurring on every release)

`Schemas & Client` (called by release-please after each version bump) failed at its **Generate JSON schemas** step:
```
error: streamlib_jtd_codegen build.rs helper failed: Codegen failed
Caused by:
  0: jtd-codegen not found. Install v0.4.1 from …/json-typedef-codegen/releases/tag/v0.4.1
```
`generate_schemas` builds `streamlib-engine`, whose `build.rs` shells out to the upstream `jtd-codegen` binary — and this job **never installed it**. The two sibling codegen jobs (`test.yml`, `check-pack-load.yml`) install it and pass; this one was the outlier.

## Fix

- **Runner → `ubuntu-latest`.** This was the only macOS job; the `# macOS for Apple-specific code` comment was stale — `generate_schemas` has no Apple-only code, and the rest of the job (JSON→TS→Zod→OpenAPI, npm publish) is cross-platform. Running on Linux matches the other two codegen jobs and gives a native `jtd-codegen`.
- **Deps → apt**, mirroring `test.yml`'s engine set (`pkg-config`, `protobuf-compiler`, `libvulkan-dev`, `glslc`) plus `libopus-dev` (the opus link `brew install opus` previously provided).
- **Added the `jtd-codegen` v0.4.1 install** (`x86_64-unknown-linux-gnu`), identical to `test.yml` / `check-pack-load.yml`.

v0.4.1 ships no arm64-macOS asset, so Linux (native x86_64 binary) is the clean fix rather than an x86-via-Rosetta workaround on the arm64 macOS runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)