### PR TITLE
feat(manifest): drop the vestigial per-processor version field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5335,7 +5335,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
  "streamlib-idents",
  "thiserror 2.0.18",
  "utoipa",

--- a/examples/camera-deno-subprocess/deno/streamlib.yaml
+++ b/examples/camera-deno-subprocess/deno/streamlib.yaml
@@ -21,7 +21,6 @@ schemas:
 
 processors:
   - name: GrayscaleProcessor
-    version: "1.0.0"
     description: "Grayscale processor — TypeScript/Deno"
     runtime: deno
     execution: reactive
@@ -34,7 +33,6 @@ processors:
         schema: VideoFrame
 
   - name: HalftoneProcessor
-    version: "1.0.0"
     description: "Halftone dot pattern via TypeGPU/WebGPU compute shader"
     runtime: deno
     execution: reactive

--- a/examples/camera-plugin-sdk-compute/plugin/streamlib.yaml
+++ b/examples/camera-plugin-sdk-compute/plugin/streamlib.yaml
@@ -21,7 +21,6 @@ schemas:
 
 processors:
   - name: GrayscaleCompute
-    version: 1.0.0
     description: "Grayscale video effect via an engine-free SPIR-V compute kernel"
     runtime: rust
     execution: reactive

--- a/examples/camera-python-display/effects/streamlib.yaml
+++ b/examples/camera-python-display/effects/streamlib.yaml
@@ -34,7 +34,6 @@ schemas:
 
 processors:
   - name: CrtFilmGrain
-    version: 1.0.0
     description: "CRT display + 80s film grain effect"
     execution: reactive
     runtime:
@@ -50,7 +49,6 @@ processors:
         description: "Processed video frames"
 
   - name: BlendingCompositor
-    version: 1.0.0
     description: "Multi-layer alpha blending compositor with PiP support"
     execution: manual
     scheduling:

--- a/examples/camera-python-display/python/streamlib.yaml
+++ b/examples/camera-python-display/python/streamlib.yaml
@@ -21,7 +21,6 @@ schemas:
 
 processors:
   - name: AvatarCharacter
-    version: "1.0.0"
     description: "MediaPipe pose detection + stylized 3D character as PiP overlay"
     runtime: python
     execution: reactive
@@ -34,7 +33,6 @@ processors:
         schema: VideoFrame
 
   - name: CyberpunkLowerThird
-    version: "1.0.0"
     description: "Cyberpunk animated lower third overlay — continuous RGBA generator"
     runtime: python
     execution:
@@ -46,7 +44,6 @@ processors:
         schema: VideoFrame
 
   - name: CyberpunkWatermark
-    version: "1.0.0"
     description: "Spray paint style watermark overlay — continuous RGBA generator"
     runtime: python
     execution:
@@ -58,7 +55,6 @@ processors:
         schema: VideoFrame
 
   - name: CyberpunkGlitch
-    version: "1.0.0"
     description: "Glitch post-processing — RGB separation, scanlines, slice displacement"
     runtime: python
     execution: reactive
@@ -71,7 +67,6 @@ processors:
         schema: VideoFrame
 
   - name: CyberpunkProcessor
-    version: "1.0.0"
     description: "Cyberpunk overlay with Skia GPU rendering — reference @processor adopter"
     runtime: python
     execution: reactive

--- a/examples/camera-python-subprocess/python/streamlib.yaml
+++ b/examples/camera-python-subprocess/python/streamlib.yaml
@@ -21,7 +21,6 @@ schemas:
 
 processors:
   - name: Grayscale
-    version: "1.0.0"
     description: "Grayscale processor — converts video frames to grayscale via Python subprocess"
     runtime: python
     execution: reactive

--- a/examples/camera-rust-plugin/plugin/streamlib.yaml
+++ b/examples/camera-rust-plugin/plugin/streamlib.yaml
@@ -21,7 +21,6 @@ schemas:
 
 processors:
   - name: GrayscaleRust
-    version: 1.0.0
     description: "Grayscale video effect (Rust dylib plugin)"
     runtime: rust
     execution: reactive

--- a/examples/cuda-fisheye-detection/python/streamlib.yaml
+++ b/examples/cuda-fisheye-detection/python/streamlib.yaml
@@ -20,7 +20,6 @@ schemas:
 
 processors:
   - name: CudaFisheyeUndistortion
-    version: "1.0.0"
     description: "Acquires the host-pre-registered OPAQUE_FD VkImage as a cudaTextureObject_t, runs a cupy.RawKernel undistortion + YOLOv8n detection, writes annotated PNG"
     runtime: python
     execution: reactive

--- a/examples/polyglot-continuous-processor/deno/streamlib.yaml
+++ b/examples/polyglot-continuous-processor/deno/streamlib.yaml
@@ -12,7 +12,6 @@ dependencies:
 
 processors:
   - name: PolyglotContinuousProcessor
-    version: "1.0.0"
     description: "Continuous processor: process() called by the runner at interval_ms cadence (now timerfd-paced); each call writes the tick count + a monotonic timestamp into the host cpu-readback surface. Reference example for the no-setTimeout pacing contract."
     runtime: deno
     execution:

--- a/examples/polyglot-continuous-processor/python/streamlib.yaml
+++ b/examples/polyglot-continuous-processor/python/streamlib.yaml
@@ -9,7 +9,6 @@ package:
 
 processors:
   - name: PolyglotContinuousProcessor
-    version: "1.0.0"
     description: "Continuous processor: process() called by the runner at interval_ms cadence (now timerfd-paced); each call writes the tick count + a monotonic timestamp into the host cpu-readback surface. Reference example for the no-time.sleep pacing contract."
     runtime: python
     execution:

--- a/examples/polyglot-cpu-readback-blur/deno/streamlib.yaml
+++ b/examples/polyglot-cpu-readback-blur/deno/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
 
 processors:
   - name: CpuReadbackBlurProcessor
-    version: "1.0.0"
     description: "Acquires a host-pre-registered cpu-readback surface, applies a separable Gaussian blur, releases"
     runtime: deno
     execution: reactive

--- a/examples/polyglot-cpu-readback-blur/python/streamlib.yaml
+++ b/examples/polyglot-cpu-readback-blur/python/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
 
 processors:
   - name: CpuReadbackBlur
-    version: "1.0.0"
     description: "Acquires a host-pre-registered cpu-readback surface, applies a Gaussian blur, releases"
     runtime: python
     execution: reactive

--- a/examples/polyglot-cuda-inference/deno/streamlib.yaml
+++ b/examples/polyglot-cuda-inference/deno/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
 
 processors:
   - name: CudaInferenceProcessor
-    version: "1.0.0"
     description: "Acquires a host-pre-registered cuda OPAQUE_FD surface, validates the DLPack capsule shape, logs VALIDATION_PASSED / VALIDATION_FAILED to stderr"
     runtime: deno
     execution: reactive

--- a/examples/polyglot-cuda-inference/python/streamlib.yaml
+++ b/examples/polyglot-cuda-inference/python/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
 
 processors:
   - name: CudaInference
-    version: "1.0.0"
     description: "Acquires a host-pre-registered cuda OPAQUE_FD surface, uploads a test image, runs YOLOv8n via torch.from_dlpack, writes annotated PNG"
     runtime: python
     execution: reactive

--- a/examples/polyglot-dma-buf-consumer/deno/streamlib.yaml
+++ b/examples/polyglot-dma-buf-consumer/deno/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
 
 processors:
   - name: DmaBufConsumer
-    version: "1.0.0"
     description: "Resolves an upstream surface_id to a DMA-BUF, locks/reads it, and forwards the frame downstream"
     runtime: deno
     execution: reactive

--- a/examples/polyglot-dma-buf-consumer/python/streamlib.yaml
+++ b/examples/polyglot-dma-buf-consumer/python/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
 
 processors:
   - name: DmaBufConsumer
-    version: "1.0.0"
     description: "Resolves an upstream surface_id to a DMA-BUF, locks/reads it, and forwards the frame downstream"
     runtime: python
     execution: reactive

--- a/examples/polyglot-manual-source/deno/streamlib.yaml
+++ b/examples/polyglot-manual-source/deno/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
 
 processors:
   - name: PolyglotManualSource
-    version: "1.0.0"
     description: "Manual source: spawns a worker Promise in start() that publishes Videoframes on the frame_out port at MonotonicTimer cadence. Reference example for the start()-must-return-promptly contract and #604's worker-task iceoryx2 publish path."
     runtime: deno
     execution: manual

--- a/examples/polyglot-manual-source/plugin/streamlib.yaml
+++ b/examples/polyglot-manual-source/plugin/streamlib.yaml
@@ -25,7 +25,6 @@ schemas:
 
 processors:
   - name: PolyglotManualSourceCountingSink
-    version: 1.0.0
     description: "Reactive sink that counts Videoframes and writes count + first/last timestamp to a stats file on teardown. Used to validate that polyglot manual sources can publish via iceoryx2 from a worker thread (#604)."
     runtime: rust
     execution: reactive

--- a/examples/polyglot-manual-source/python/streamlib.yaml
+++ b/examples/polyglot-manual-source/python/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
 
 processors:
   - name: PolyglotManualSource
-    version: "1.0.0"
     description: "Manual source: spawns a worker thread in start() that publishes Videoframes on the frame_out port at MonotonicTimer cadence. Reference example for the start()-must-return-promptly contract and #604's worker-thread iceoryx2 publish path."
     runtime: python
     execution: manual

--- a/examples/polyglot-opengl-fragment-shader/deno/streamlib.yaml
+++ b/examples/polyglot-opengl-fragment-shader/deno/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
 
 processors:
   - name: OpenGlFragmentShaderProcessor
-    version: "1.0.0"
     description: "Acquires a host-pre-registered render-target DMA-BUF surface as a GL_TEXTURE_2D, renders a plasma-effect fragment shader, releases"
     runtime: deno
     execution: reactive

--- a/examples/polyglot-opengl-fragment-shader/python/streamlib.yaml
+++ b/examples/polyglot-opengl-fragment-shader/python/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
 
 processors:
   - name: OpenGlFragmentShader
-    version: "1.0.0"
     description: "Acquires a host-pre-registered render-target DMA-BUF surface as a GL_TEXTURE_2D, renders a Mandelbrot fragment shader, releases"
     runtime: python
     execution: reactive

--- a/examples/polyglot-skia-canvas/python/streamlib.yaml
+++ b/examples/polyglot-skia-canvas/python/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
 
 processors:
   - name: SkiaCanvas
-    version: "1.0.0"
     description: "Acquires a host-pre-registered render-target DMA-BUF surface as a skia.Surface, draws a known shape, releases"
     runtime: python
     execution: reactive

--- a/examples/polyglot-venv-isolation/pkg-a/python/streamlib.yaml
+++ b/examples/polyglot-venv-isolation/pkg-a/python/streamlib.yaml
@@ -7,7 +7,6 @@ package:
 
 processors:
   - name: NumpyVersionReporter
-    version: "1.0.0"
     description: "Continuous processor: imports numpy and writes numpy.__version__ to a host-visible output file. Package A's pyproject pins numpy==1.26.4, so a correctly-isolated per-package venv must yield exactly 1.26.4."
     runtime: python
     execution:

--- a/examples/polyglot-venv-isolation/pkg-b/python/streamlib.yaml
+++ b/examples/polyglot-venv-isolation/pkg-b/python/streamlib.yaml
@@ -7,7 +7,6 @@ package:
 
 processors:
   - name: NumpyVersionReporter
-    version: "1.0.0"
     description: "Continuous processor: imports numpy and writes numpy.__version__ to a host-visible output file. Package B's pyproject pins numpy==2.1.3, so a correctly-isolated per-package venv must yield exactly 2.1.3."
     runtime: python
     execution:

--- a/examples/polyglot-vulkan-compute/deno/streamlib.yaml
+++ b/examples/polyglot-vulkan-compute/deno/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
 
 processors:
   - name: VulkanComputeProcessor
-    version: "1.0.0"
     description: "Acquires a host-pre-registered render-target DMA-BUF surface as a VkImage, dispatches a Mandelbrot compute shader, releases"
     runtime: deno
     execution: reactive

--- a/examples/polyglot-vulkan-compute/python/streamlib.yaml
+++ b/examples/polyglot-vulkan-compute/python/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
 
 processors:
   - name: VulkanCompute
-    version: "1.0.0"
     description: "Acquires a host-pre-registered render-target DMA-BUF surface as a VkImage, dispatches a Mandelbrot compute shader, releases"
     runtime: python
     execution: reactive

--- a/examples/polyglot-vulkan-graphics/deno/streamlib.yaml
+++ b/examples/polyglot-vulkan-graphics/deno/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
 
 processors:
   - name: VulkanGraphicsProcessor
-    version: "1.0.0"
     description: "Acquires a host-pre-registered render-target DMA-BUF surface as a VkImage, draws a triangle via the host's VulkanGraphicsKernel, releases"
     runtime: deno
     execution: reactive

--- a/examples/polyglot-vulkan-graphics/python/streamlib.yaml
+++ b/examples/polyglot-vulkan-graphics/python/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
 
 processors:
   - name: VulkanGraphics
-    version: "1.0.0"
     description: "Acquires a host-pre-registered render-target DMA-BUF surface as a VkImage, draws a triangle via the host's VulkanGraphicsKernel, releases"
     runtime: python
     execution: reactive

--- a/examples/polyglot-vulkan-ray-tracing/deno/streamlib.yaml
+++ b/examples/polyglot-vulkan-ray-tracing/deno/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
 
 processors:
   - name: VulkanRayTracingProcessor
-    version: "1.0.0"
     description: "Builds a single-triangle BLAS + identity TLAS via escalate IPC, registers an RT kernel, and dispatches one trace into a host-pre-registered storage image"
     runtime: deno
     execution: reactive

--- a/examples/polyglot-vulkan-ray-tracing/python/streamlib.yaml
+++ b/examples/polyglot-vulkan-ray-tracing/python/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
 
 processors:
   - name: VulkanRayTracing
-    version: "1.0.0"
     description: "Builds a single-triangle BLAS + identity TLAS via escalate IPC, registers an RT kernel, and dispatches one trace into a host-pre-registered storage image"
     runtime: python
     execution: reactive

--- a/packages/api-server/streamlib.yaml
+++ b/packages/api-server/streamlib.yaml
@@ -19,7 +19,6 @@ schemas:
     file: schemas/api_server_config.yaml
 processors:
 - name: ApiServer
-  version: 1.0.0
   description: Runtime API server — HTTP + WebSocket control plane
   runtime: rust
   entrypoint: null

--- a/packages/audio/streamlib.yaml
+++ b/packages/audio/streamlib.yaml
@@ -26,7 +26,6 @@ schemas:
     file: schemas/chord_generator_config.yaml
 processors:
 - name: AudioCapture
-  version: 1.0.0
   description: Captures mono audio from microphones in device-native format (CoreAudio on macOS, ALSA on Linux)
   runtime:
     language: rust
@@ -51,7 +50,6 @@ processors:
     overflow: null
     buffer_size: null
 - name: AudioOutput
-  version: 1.0.0
   description: Plays audio through speakers/headphones (CoreAudio on macOS, ALSA on Linux)
   runtime:
     language: rust
@@ -76,7 +74,6 @@ processors:
     buffer_size: 32
   outputs: []
 - name: AudioMixer
-  version: 1.0.0
   description: Mixes two mono audio signals into a single stereo signal
   runtime: rust
   entrypoint: null
@@ -108,7 +105,6 @@ processors:
     overflow: null
     buffer_size: null
 - name: AudioChannelConverter
-  version: 1.0.0
   description: Converts mono audio to N-channel audio according to the configured mode
   runtime: rust
   entrypoint: null
@@ -134,7 +130,6 @@ processors:
     overflow: null
     buffer_size: null
 - name: AudioResampler
-  version: 1.0.0
   description: Resamples audio between sample rates
   runtime: rust
   entrypoint: null
@@ -160,7 +155,6 @@ processors:
     overflow: null
     buffer_size: null
 - name: BufferRechunker
-  version: 1.0.0
   description: Rechunks audio buffers to a fixed sample count
   runtime: rust
   entrypoint: null
@@ -186,7 +180,6 @@ processors:
     overflow: null
     buffer_size: null
 - name: ChordGenerator
-  version: 1.0.0
   description: Generates a C major chord (C4 + E4 + G4) driven by the runtime audio clock
   runtime: rust
   entrypoint: null

--- a/packages/camera/streamlib.yaml
+++ b/packages/camera/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
     package: '@tatolab/core'
 processors:
 - name: Camera
-  version: 1.0.0
   description: Captures video from cameras (V4L2 on Linux, AVFoundation on macOS/iOS)
   runtime: rust
   entrypoint: null
@@ -42,7 +41,6 @@ processors:
     overflow: null
     buffer_size: null
 - name: CameraToCudaCopy
-  version: 1.0.0
   description: 'Host-pipeline producer: camera VkImage -> cuda OPAQUE_FD VkBuffer with timeline signal for cross-API CUDA interop. Linux-only (CUDA is Linux-only on the in-tree adapter set).'
   runtime: rust
   entrypoint: null

--- a/packages/clap/streamlib.yaml
+++ b/packages/clap/streamlib.yaml
@@ -14,7 +14,6 @@ schemas:
     file: schemas/clap_effect_config.yaml
 processors:
 - name: ClapEffect
-  version: 1.0.0
   description: CLAP audio plugin processor with parameter control and automation
   runtime: rust
   entrypoint: null

--- a/packages/debug-utilities/streamlib.yaml
+++ b/packages/debug-utilities/streamlib.yaml
@@ -30,7 +30,6 @@ schemas:
     file: schemas/video_frame_counter_config.yaml
 processors:
 - name: SimplePassthrough
-  version: 1.0.0
   description: Passes video frames through unchanged (for testing)
   runtime: rust
   entrypoint: null
@@ -55,7 +54,6 @@ processors:
     overflow: null
     buffer_size: null
 - name: BgraFileSource
-  version: 1.0.0
   description: Streams raw BGRA frames from a file as Videoframes
   runtime: rust
   entrypoint: null
@@ -74,7 +72,6 @@ processors:
     overflow: null
     buffer_size: null
 - name: JpegBytesSource
-  version: 1.0.0
   description: Loads a JPEG file from disk at setup time and republishes it as EncodedJpegFrame on a paced background thread (for testing the JPEG decoder pipeline)
   runtime: rust
   entrypoint: null
@@ -93,7 +90,6 @@ processors:
     overflow: null
     buffer_size: null
 - name: VideoFrameCounter
-  version: 1.0.0
   description: Counts incoming VideoFrames into process-global atomics so integration tests can assert on frame count + first-frame dimensions after runtime.stop()
   runtime: rust
   entrypoint: null

--- a/packages/display/streamlib.yaml
+++ b/packages/display/streamlib.yaml
@@ -20,7 +20,6 @@ schemas:
     package: '@tatolab/core'
 processors:
 - name: Display
-  version: 1.0.0
   description: Displays video frames in a window with vsync
   runtime: rust
   entrypoint: null

--- a/packages/frame-tap/streamlib.yaml
+++ b/packages/frame-tap/streamlib.yaml
@@ -23,7 +23,6 @@ schemas:
 
 processors:
   - name: FrameTap
-    version: 1.0.0
     description: "Samples video frames to disk (JPEG) on a configurable strategy, off the hot path. A sink: attach it to any video output port (fan-out) to inspect that output without rerouting the pipeline."
     runtime: rust
     execution: reactive

--- a/packages/h264/streamlib.yaml
+++ b/packages/h264/streamlib.yaml
@@ -24,7 +24,6 @@ schemas:
     package: '@tatolab/core'
 processors:
 - name: H264Encoder
-  version: 1.0.0
   description: Encodes VideoFrame to EncodedVideoFrame (H.264) via Vulkan Video
   runtime: rust
   entrypoint: null
@@ -50,7 +49,6 @@ processors:
     overflow: null
     buffer_size: null
 - name: H264Decoder
-  version: 1.0.0
   description: Decodes EncodedVideoFrame (H.264) to VideoFrame via Vulkan Video
   runtime: rust
   entrypoint: null

--- a/packages/h265/streamlib.yaml
+++ b/packages/h265/streamlib.yaml
@@ -24,7 +24,6 @@ schemas:
     package: '@tatolab/core'
 processors:
 - name: H265Encoder
-  version: 1.0.0
   description: Encodes VideoFrame to EncodedVideoFrame (H.265) via Vulkan Video
   runtime: rust
   entrypoint: null
@@ -50,7 +49,6 @@ processors:
     overflow: null
     buffer_size: null
 - name: H265Decoder
-  version: 1.0.0
   description: Decodes EncodedVideoFrame (H.265) to VideoFrame via Vulkan Video
   runtime: rust
   entrypoint: null

--- a/packages/jpeg/streamlib.yaml
+++ b/packages/jpeg/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
     package: '@tatolab/core'
 processors:
 - name: JpegDecoder
-  version: 1.0.0
   description: Decodes EncodedJpegFrame to VideoFrame via the GPU SimpleJpegDecoder primitive
   runtime: rust
   entrypoint: null

--- a/packages/moq/streamlib.yaml
+++ b/packages/moq/streamlib.yaml
@@ -22,7 +22,6 @@ schemas:
     file: schemas/moq_subscribe_track_config.yaml
 processors:
 - name: MoqPublishTrack
-  version: 1.0.0
   description: Publishes raw bytes from a single graph input to a named MoQ track
   runtime: rust
   entrypoint: null
@@ -41,7 +40,6 @@ processors:
     buffer_size: null
   outputs: []
 - name: MoqSubscribeTrack
-  version: 1.0.0
   description: Subscribes to a named MoQ track and outputs raw bytes to the graph
   runtime: rust
   entrypoint: null

--- a/packages/mp4/streamlib.yaml
+++ b/packages/mp4/streamlib.yaml
@@ -20,7 +20,6 @@ schemas:
     package: '@tatolab/core'
 processors:
 - name: LinuxMp4Writer
-  version: 1.0.0
   description: Writes video frames to MP4 via ffmpeg encode + mux with silent audio track
   runtime: rust
   entrypoint: null

--- a/packages/opus/streamlib.yaml
+++ b/packages/opus/streamlib.yaml
@@ -18,7 +18,6 @@ schemas:
     file: schemas/opus_encoder_config.yaml
 processors:
 - name: OpusEncoder
-  version: 1.0.0
   description: Encodes AudioFrame to EncodedAudioFrame (Opus)
   runtime: rust
   entrypoint: null
@@ -44,7 +43,6 @@ processors:
     overflow: null
     buffer_size: null
 - name: OpusDecoder
-  version: 1.0.0
   description: Decodes EncodedAudioFrame (Opus) to AudioFrame
   runtime: rust
   entrypoint: null

--- a/packages/screen-capture/streamlib.yaml
+++ b/packages/screen-capture/streamlib.yaml
@@ -20,7 +20,6 @@ schemas:
     package: '@tatolab/core'
 processors:
 - name: ScreenCapture
-  version: 1.0.0
   description: Captures display, window, or application content using ScreenCaptureKit (macOS 12.3+)
   runtime:
     language: rust

--- a/packages/test-fixtures-abi-mismatch/streamlib.yaml
+++ b/packages/test-fixtures-abi-mismatch/streamlib.yaml
@@ -24,6 +24,5 @@ patch:
 
 processors:
   - name: AbiMismatchSentinel
-    version: 1.0.0
     description: "Sentinel processor whose only job is to make load_project enter the Rust-dylib code path; never gets registered because the abi_version check rejects the plugin first."
     execution: manual

--- a/packages/test-fixtures/streamlib.yaml
+++ b/packages/test-fixtures/streamlib.yaml
@@ -43,7 +43,6 @@ schemas:
 
 processors:
   - name: TestConfiguredProcessor
-    version: 1.0.0
     description: "Attribute-macro test fixture verifying config-emit against a streamlib.yaml package block"
     execution: continuous
     config:
@@ -51,7 +50,6 @@ processors:
       schema: TestConfiguredProcessorConfig
 
   - name: TcpBindTestProcessor
-    version: 1.0.0
     description: "dlopen-owns-tokio integration test fixture from #885 — binds a tokio::net::TcpListener on the plugin's own runtime"
     execution: manual
     config:
@@ -59,7 +57,6 @@ processors:
       schema: TcpBindTestProcessorConfig
 
   - name: GpuAcquireTestProcessor
-    version: 1.0.0
     description: "Phase C1 (#901) dlopen-cdylib GPU vtable integration test fixture — exercises clone_handle/acquire_pixel_buffer/plane_base_address_pixel_buffer/drop_pixel_buffer/drop_handle through the GpuContextLimitedAccessVTable"
     execution: manual
     config:
@@ -67,7 +64,6 @@ processors:
       schema: GpuAcquireTestProcessorConfig
 
   - name: EscalateSmokeTestProcessor
-    version: 1.0.0
     description: "Phase C3 (#903) dlopen-cdylib escalate smoke test fixture — runs gpu.escalate(|_full| Ok(())) end-to-end through the escalate_begin/escalate_end vtable + cdylib-side FullAccess construction via from_scope_token"
     execution: manual
     config:
@@ -75,7 +71,6 @@ processors:
       schema: EscalateSmokeTestProcessorConfig
 
   - name: ComputeKernelTestProcessor
-    version: 1.0.0
     description: "Phase E (#963) dlopen-cdylib compute-kernel CPU-reference integration test fixture — creates a kernel via FullAccess, allocates input + output storage buffers via LimitedAccess, dispatches output[i] = input[i] * 2 via the per-type binding-method vtable, and asserts CPU-reference match"
     execution: manual
     config:
@@ -83,7 +78,6 @@ processors:
       schema: ComputeKernelTestProcessorConfig
 
   - name: GraphicsKernelSmokeTestProcessor
-    version: 1.0.0
     description: "Phase E (#951) dlopen-cdylib graphics-kernel methods-vtable smoke test fixture — creates a graphics kernel via FullAccess, acquires a render-target Texture, runs a single offscreen_render() through the per-type binding-method vtable to assert the vtable round-trips don't panic. Smoke-only; pixel correctness not asserted."
     execution: manual
     config:
@@ -91,7 +85,6 @@ processors:
       schema: GraphicsKernelSmokeTestProcessorConfig
 
   - name: RayTracingKernelSmokeTestProcessor
-    version: 1.0.0
     description: "Phase E (#953) dlopen-cdylib ray-tracing-kernel methods-vtable smoke test fixture — builds a single-triangle BLAS + identity TLAS via FullAccess, creates an RT kernel, acquires a STORAGE_BINDING Texture, runs a single trace_rays() through the per-type binding-method vtable to assert the vtable round-trips (set_acceleration_structure / set_storage_image / set_push_constants / trace_rays) don't panic. Smoke-only; pixel correctness not asserted."
     execution: manual
     config:
@@ -99,7 +92,6 @@ processors:
       schema: RayTracingKernelSmokeTestProcessorConfig
 
   - name: LifecycleProbeProcessor
-    version: 1.0.0
     description: "Phase G (#961) dlopen-cdylib lifecycle-probe processor — appends marker lines for each ProcessorVTable lifecycle hook (setup / process / on_pause / on_resume / teardown) to a file so the integration test can confirm every hook dispatched through the cdylib boundary correctly."
     execution: continuous
     config:
@@ -107,7 +99,6 @@ processors:
       schema: LifecycleProbeProcessorConfig
 
   - name: PanickingManualLifecycleProcessor
-    version: 1.0.0
     description: "Phase H (#1005) dlopen-cdylib panic-injection Manual fixture. Panics in the configured lifecycle hook (setup / start / stop / teardown / on_pause / on_resume); the host's run_host_extern_c panic-safety net is expected to absorb the panic and keep the runtime alive."
     execution: manual
     config:
@@ -115,7 +106,6 @@ processors:
       schema: PanickingManualLifecycleProcessorConfig
 
   - name: PanickingContinuousLifecycleProcessor
-    version: 1.0.0
     description: "Phase H (#1005) dlopen-cdylib panic-injection Continuous fixture. Panics in the configured lifecycle hook (process); the host's run_host_extern_c panic-safety net is expected to absorb the panic and keep the runtime alive."
     execution: continuous
     config:
@@ -123,7 +113,6 @@ processors:
       schema: PanickingContinuousLifecycleProcessorConfig
 
   - name: ConcurrentEscalateTestProcessor
-    version: 1.0.0
     description: "Phase H (#1006 scenario 1) dlopen-cdylib concurrent-escalate fixture. Spawns thread_count threads from start(); each clones gpu_limited_access() and calls escalate concurrently. Output captures overlap count; expected overlaps=0 — proves the escalate gate serializes cdylib-path callers through escalate_via_vtable."
     execution: manual
     config:

--- a/packages/webrtc/streamlib.yaml
+++ b/packages/webrtc/streamlib.yaml
@@ -24,7 +24,6 @@ schemas:
     file: schemas/webrtc_whip_config.yaml
 processors:
 - name: WebrtcWhep
-  version: 1.0.0
   description: Receives encoded video and audio from a WHEP endpoint (WebRTC egress)
   runtime: rust
   entrypoint: null
@@ -49,7 +48,6 @@ processors:
     overflow: null
     buffer_size: null
 - name: WebrtcWhip
-  version: 1.0.0
   description: Streams pre-encoded video and audio to a WHIP endpoint (WebRTC ingress)
   runtime: rust
   entrypoint: null

--- a/runtime/streamlib-engine/src/core/config/project_config.rs
+++ b/runtime/streamlib-engine/src/core/config/project_config.rs
@@ -586,7 +586,6 @@ env:
 
 processors:
   - name: Grayscale
-    version: "1.0.0"
     description: Grayscale processor
     runtime: python
     execution: reactive
@@ -671,7 +670,6 @@ schemas:
     package: "@tatolab/core"
 processors:
   - name: Consumer
-    version: 1.0.0
     description: d
     runtime: rust
     execution: manual

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/lazy_discovery.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/lazy_discovery.rs
@@ -234,7 +234,7 @@ mod tests {
         );
         for proc in processors {
             yaml.push_str(&format!(
-                "  - name: {proc}\n    version: 1.0.0\n    description: d\n    runtime: rust\n    \
+                "  - name: {proc}\n    description: d\n    runtime: rust\n    \
                  execution: manual\n    inputs: []\n    outputs: []\n"
             ));
         }

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/processor_registration.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/processor_registration.rs
@@ -436,7 +436,7 @@ pub(super) fn register_manifest_processors(
             proc_schema_ident.clone(),
             proc_schema.description.as_deref().unwrap_or(""),
         )
-        .with_version(&proc_schema.version)
+        .with_version(proc_schema_ident.version.to_string())
         .with_runtime(runtime.clone());
 
         if let Some(entrypoint) = &proc_schema.entrypoint {

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
@@ -937,8 +937,8 @@ pub(super) fn read_version_from_manifest_dir(
 mod tests {
     use super::*;
 
-    const RUST_YAML: &str = "package:\n  org: tatolab\n  name: rp\n  version: 0.1.0\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n";
-    const PY_YAML: &str = "package:\n  org: tatolab\n  name: py\n  version: 0.1.0\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: python\n    execution: manual\n    entrypoint: \"p:P\"\n    inputs: []\n    outputs: []\n";
+    const RUST_YAML: &str = "package:\n  org: tatolab\n  name: rp\n  version: 0.1.0\nprocessors:\n  - name: P\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n";
+    const PY_YAML: &str = "package:\n  org: tatolab\n  name: py\n  version: 0.1.0\nprocessors:\n  - name: P\n    description: d\n    runtime: python\n    execution: manual\n    entrypoint: \"p:P\"\n    inputs: []\n    outputs: []\n";
 
     fn manifest(dir: &std::path::Path, body: &str) {
         std::fs::write(dir.join("streamlib.yaml"), body).unwrap();
@@ -1113,7 +1113,7 @@ mod tests {
     // `.venv/bin/python: No such file or directory`.
     // =====================================================================
 
-    const DENO_YAML: &str = "package:\n  org: tatolab\n  name: ts\n  version: 0.1.0\nprocessors:\n  - name: T\n    version: 1.0.0\n    description: d\n    runtime: deno\n    execution: manual\n    entrypoint: \"t.ts:default\"\n    inputs: []\n    outputs: []\n";
+    const DENO_YAML: &str = "package:\n  org: tatolab\n  name: ts\n  version: 0.1.0\nprocessors:\n  - name: T\n    description: d\n    runtime: deno\n    execution: manual\n    entrypoint: \"t.ts:default\"\n    inputs: []\n    outputs: []\n";
 
     /// CRUX (bug-reproduce): a resolved (extracted `.slpkg` / installed-cache /
     /// `streamlib_modules`) Python-only package (no Rust, no `Cargo.toml`) with
@@ -1402,7 +1402,7 @@ mod tests {
             pkg.join("streamlib.yaml"),
             format!(
                 "package:\n  org: tatolab\n  name: {pkg_name}\n  version: 0.1.0\nprocessors:\n  \
-                 - name: P\n    version: 1.0.0\n    description: d\n    runtime: python\n    \
+                 - name: P\n    description: d\n    runtime: python\n    \
                  execution: manual\n    entrypoint: \"p:P\"\n    inputs: []\n    outputs: []\n"
             ),
         )
@@ -1595,7 +1595,7 @@ mod tests {
             dir.join("streamlib.yaml"),
             format!(
                 "package:\n  org: tatolab\n  name: {declared_name}\n  version: 0.9.0\n\
-                 processors:\n  - name: P\n    version: 1.0.0\n    description: d\n    \
+                 processors:\n  - name: P\n    description: d\n    \
                  runtime: python\n    execution: manual\n    entrypoint: \"p:P\"\n    \
                  inputs: []\n    outputs: []\n"
             ),
@@ -1617,7 +1617,7 @@ mod tests {
             slot.join("streamlib.yaml"),
             format!(
                 "package:\n  org: tatolab\n  name: {name}\n  version: 1.0.0\n\
-                 processors:\n  - name: P\n    version: 1.0.0\n    description: d\n    \
+                 processors:\n  - name: P\n    description: d\n    \
                  runtime: python\n    execution: manual\n    entrypoint: \"p:P\"\n    \
                  inputs: []\n    outputs: []\n"
             ),

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/tests.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/tests.rs
@@ -836,7 +836,6 @@ package:
   version: "0.1.0"
 processors:
   - name: TestProcessor
-    version: 1.0.0
     description: "Test"
     runtime: rust
     execution: manual
@@ -906,7 +905,6 @@ package:
   version: "0.1.0"
 processors:
   - name: TestProcessor
-    version: 1.0.0
     description: "Test"
     runtime: rust
     execution: manual
@@ -1429,7 +1427,6 @@ package:
   version: "0.1.0"
 processors:
   - name: PyProc
-    version: 1.0.0
     description: "source-only python processor"
     runtime: python
     execution: manual
@@ -2851,7 +2848,6 @@ processors:
              schemas:\n  TxnProcConfigSchema:\n    file: schemas/txn_proc_config.yaml\n\
              processors:\n\
              \x20 - name: TxnAlphaProcessor\n\
-             \x20   version: 1.0.0\n\
              \x20   runtime: typescript\n\
              \x20   entrypoint: main.ts\n\
              \x20   execution: manual\n\
@@ -2859,7 +2855,6 @@ processors:
              \x20     name: config\n\
              \x20     schema: TxnProcConfigSchema\n\
              \x20 - name: TxnBetaProcessor\n\
-             \x20   version: 1.0.0\n\
              \x20   runtime: typescript\n\
              \x20   entrypoint: main.ts\n\
              \x20   execution: manual\n\
@@ -2933,12 +2928,10 @@ processors:
             "package:\n  org: tatolab\n  name: txn-dupname\n  version: \"1.0.0\"\n\
              processors:\n\
              \x20 - name: TxnDupProcessor\n\
-             \x20   version: 1.0.0\n\
              \x20   runtime: typescript\n\
              \x20   entrypoint: main.ts\n\
              \x20   execution: manual\n\
              \x20 - name: TxnDupProcessor\n\
-             \x20   version: 1.0.0\n\
              \x20   runtime: typescript\n\
              \x20   entrypoint: main.ts\n\
              \x20   execution: manual\n",
@@ -3015,7 +3008,6 @@ processors:
             "package:\n  org: tatolab\n  name: txn-global\n  version: \"1.0.0\"\n\
              processors:\n\
              \x20 - name: TxnGlobalProcessor\n\
-             \x20   version: 1.0.0\n\
              \x20   runtime: typescript\n\
              \x20   entrypoint: main.ts\n\
              \x20   execution: manual\n",
@@ -3187,7 +3179,6 @@ processors:
              \x20 \"@tatolab/conc-root-e\":\n    path: ../e\n\
              processors:\n\
              \x20 - name: ConcRootFailingProcessor\n\
-             \x20   version: 1.0.0\n\
              \x20   runtime: typescript\n\
              \x20   entrypoint: main.ts\n\
              \x20   execution: manual\n\
@@ -3406,7 +3397,6 @@ processors:
              schemas:\n  RmInUseConfigSchema:\n    file: schemas/rm_inuse_config.yaml\n\
              processors:\n\
              \x20 - name: RmInUseProcessor\n\
-             \x20   version: 1.0.0\n\
              \x20   runtime: typescript\n\
              \x20   entrypoint: main.ts\n\
              \x20   execution: manual\n\

--- a/runtime/streamlib-engine/streamlib.yaml
+++ b/runtime/streamlib-engine/streamlib.yaml
@@ -38,7 +38,6 @@ processors:
   # === Test mock processors ===
 
   - name: TestMockProcessor
-    version: 1.0.0
     description: "Mock processor for testing graph operations"
     execution: manual
     inputs:
@@ -57,7 +56,6 @@ processors:
         description: Test output port 2
 
   - name: TestMockInputOnlyProcessor
-    version: 1.0.0
     description: "Mock processor with only input ports for testing"
     execution: manual
     inputs:
@@ -69,7 +67,6 @@ processors:
         description: Test input port 2
 
   - name: TestMockOutputOnlyProcessor
-    version: 1.0.0
     description: "Mock processor with only output ports for testing"
     execution: manual
     outputs:
@@ -83,7 +80,6 @@ processors:
   # === Test attribute macro processors ===
 
   - name: TestProcessor
-    version: 1.0.0
     description: "Test processor for attribute macro tests"
     execution: manual
     inputs:

--- a/runtime/streamlib-engine/tests/pack_then_load_smoke.rs
+++ b/runtime/streamlib-engine/tests/pack_then_load_smoke.rs
@@ -264,7 +264,6 @@ package:
   version: 0.1.0
 processors:
   - name: ForeignTripleStub
-    version: 1.0.0
     description: "stub"
     execution: manual
     runtime:

--- a/schemas/streamlib.schema.json
+++ b/schemas/streamlib.schema.json
@@ -278,8 +278,7 @@
       "description": "A complete processor schema definition — the manifest-shaped view of one processor, derived from its `#[processor(...)]` attribute (the source of truth) by the source-scan extractor.",
       "type": "object",
       "required": [
-        "name",
-        "version"
+        "name"
       ],
       "properties": {
         "config": {
@@ -367,10 +366,6 @@
           "items": {
             "$ref": "#/definitions/ProcessorStateField"
           }
-        },
-        "version": {
-          "description": "Processor version (e.g., \"1.0.0\").",
-          "type": "string"
         }
       },
       "additionalProperties": false

--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -288,7 +288,10 @@ fn generate_processor_impl_from_schema(
 
     let processor_name = &schema.name;
     let description = schema.description.as_deref().unwrap_or("Processor");
-    let version = &schema.version;
+    // The descriptor version mirrors the processor's own identity version — the
+    // version-free `0.0.0` sentinel in the attribute grammar (#1409); the load
+    // path re-registers the descriptor under the package version.
+    let version = schema_ident.version.to_string();
     let schema_ident_literal = schema_ident_tokens(schema_ident);
 
     // Derive execution mode from schema
@@ -361,7 +364,7 @@ fn generate_processor_impl_from_schema(
     let from_config_body =
         generate_from_config_from_schema(schema, config_field_name, custom_fields);
     let descriptor_impl =
-        generate_descriptor_from_schema(schema, description, version, config_schema_id);
+        generate_descriptor_from_schema(schema, description, &version, config_schema_id);
     let iceoryx2_accessors = generate_iceoryx2_accessors_from_schema(schema);
 
     let update_config = config_field_name.as_ref().map(|name| {
@@ -818,7 +821,6 @@ mod processor_struct_emit_tests {
     fn minimal_schema() -> ProcessorSchema {
         ProcessorSchema {
             name: "MinimalProbe".to_string(),
-            version: "0.1.0".to_string(),
             description: None,
             runtime: Default::default(),
             entrypoint: None,

--- a/sdk/streamlib-processor-extract/src/derive.rs
+++ b/sdk/streamlib-processor-extract/src/derive.rs
@@ -19,12 +19,12 @@
 //! uniformly — processor `Type` name, execution mode, and each port's name +
 //! schema-type (or `any`). It deliberately excludes fields not every runtime's
 //! extractor emits or that are authored/build-derived rather than code-derived:
-//! `version` (release-core projection is a build concern), `entrypoint`
-//! (author/loader concern), `config` binding, `description`, and the consumer-
-//! side port policies (`read_mode` / `overflow` / `buffer_size`, which the
-//! Python/Deno wire shape does not carry). What remains is exactly the surface a
-//! stale hand-authored `processors:` would misstate: a processor added, removed,
-//! or renamed in code; a port added, removed, reordered, or re-typed.
+//! `entrypoint` (author/loader concern), `config` binding, `description`, and
+//! the consumer-side port policies (`read_mode` / `overflow` / `buffer_size`,
+//! which the Python/Deno wire shape does not carry). What remains is exactly
+//! the surface a stale hand-authored `processors:` would misstate: a
+//! processor added, removed, or renamed in code; a port added, removed,
+//! reordered, or re-typed.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -792,14 +792,12 @@ mod tests {
             r#"
 processors:
 - name: Camera
-  version: 1.0.0
   runtime: rust
   execution: manual
   outputs:
   - name: video
     schema: VideoFrame
 - name: PassThrough
-  version: 1.0.0
   runtime: python
   entrypoint: src.pass:PassThrough
   execution: reactive
@@ -813,8 +811,8 @@ processors:
 "#,
         );
         // In sync — a committed manifest that names both processors with the
-        // same execution + ports as code. `read_mode` / version / entrypoint on
-        // the committed side are outside the drift surface, so they don't trip it.
+        // same execution + ports as code. `read_mode` / entrypoint on the
+        // committed side are outside the drift surface, so they don't trip it.
         check_processor_manifest_drift(root, &committed.iter().collect::<Vec<_>>(), &derived)
             .unwrap();
     }
@@ -849,7 +847,6 @@ processors:
             r#"
 processors:
 - name: Alpha
-  version: 1.0.0
   runtime: rust
   execution: reactive
 "#,
@@ -885,11 +882,9 @@ processors:
             r#"
 processors:
 - name: Alpha
-  version: 1.0.0
   runtime: rust
   execution: reactive
 - name: Ghost
-  version: 1.0.0
   runtime: rust
   execution: reactive
 "#,
@@ -922,7 +917,6 @@ processors:
             r#"
 processors:
 - name: Alpha
-  version: 1.0.0
   runtime: rust
   execution: reactive
 "#,
@@ -958,7 +952,6 @@ processors:
             r#"
 processors:
 - name: Alpha
-  version: 1.0.0
   runtime: rust
   execution: reactive
   outputs:
@@ -1008,7 +1001,6 @@ processors:
             r#"
 processors:
 - name: PassThrough
-  version: 1.0.0
   runtime: python
   entrypoint: src.pass:PassThrough
   execution: reactive

--- a/sdk/streamlib-processor-extract/src/grammar.rs
+++ b/sdk/streamlib-processor-extract/src/grammar.rs
@@ -106,7 +106,6 @@ impl ParsedProcessorAttr {
 
         ProcessorSchema {
             name: self.ident.r#type.as_str().to_string(),
-            version: self.ident.version.to_string(),
             description: self.description.clone(),
             runtime: RuntimeConfig {
                 language: Default::default(),

--- a/sdk/streamlib-processor-extract/src/lib.rs
+++ b/sdk/streamlib-processor-extract/src/lib.rs
@@ -403,8 +403,6 @@ mod tests {
         assert_eq!(procs.len(), 1);
         assert_eq!(procs[0].schema.name, "MyLocalThing");
         assert_eq!(procs[0].struct_name, "MyLocalThing");
-        // App-local synthesized identity carries the version-free 0.0.0 sentinel.
-        assert_eq!(procs[0].schema.version, "0.0.0");
     }
 
     #[test]

--- a/sdk/streamlib-processor-schema/Cargo.toml
+++ b/sdk/streamlib-processor-schema/Cargo.toml
@@ -14,7 +14,6 @@ repository.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }  # used by schemars for enum_values literals
 serde_yaml = { workspace = true }
-sha2 = { workspace = true }
 streamlib-idents = { path = "../streamlib-idents", version = "0.7.15" }
 thiserror = { workspace = true }
 schemars = "0.8"  # JSON Schema generation for streamlib.yaml editor support

--- a/sdk/streamlib-processor-schema/src/lib.rs
+++ b/sdk/streamlib-processor-schema/src/lib.rs
@@ -24,7 +24,7 @@ pub use error::{SchemaError, SchemaResult};
 pub use processor_schema::{
     PortSchemaSpec, ProcessorConfigSchema, ProcessorLanguage, ProcessorPortSchema,
     ProcessorScheduling, ProcessorSchema, ProcessorSchemaExecution, ProcessorStateField,
-    RuntimeConfig, RuntimeOptions, compute_schema_id, to_pascal_case, to_snake_case,
+    RuntimeConfig, RuntimeOptions, to_pascal_case, to_snake_case,
 };
 pub use processor_schema_parser::{parse_processor_yaml, parse_processor_yaml_file};
 pub use schema_ident_output::{SchemaIdentOutput, SemanticVersionOutput};

--- a/sdk/streamlib-processor-schema/src/processor_schema.rs
+++ b/sdk/streamlib-processor-schema/src/processor_schema.rs
@@ -5,7 +5,6 @@ use schemars::JsonSchema;
 use schemars::r#gen::SchemaGenerator;
 use schemars::schema::{InstanceType, Schema, SchemaObject, SubschemaValidation};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use std::borrow::Cow;
 use streamlib_idents::{SchemaIdent, TypeName};
 
@@ -597,9 +596,6 @@ pub struct ProcessorSchema {
     /// PascalCase short name (e.g. "Camera"), NOT reverse-DNS.
     pub name: String,
 
-    /// Processor version (e.g., "1.0.0").
-    pub version: String,
-
     /// Human-readable description.
     #[serde(default)]
     pub description: Option<String>,
@@ -639,16 +635,6 @@ pub struct ProcessorSchema {
 }
 
 impl ProcessorSchema {
-    /// Returns the full processor name with version (e.g., "com.example.blur@1.0.0").
-    pub fn full_name(&self) -> String {
-        format!("{}@{}", self.name, self.version)
-    }
-
-    /// Computes the processor ID (hash of full name).
-    pub fn processor_id(&self) -> u64 {
-        compute_schema_id(&self.full_name())
-    }
-
     /// Returns the Rust struct name derived from the processor name.
     pub fn rust_struct_name(&self) -> String {
         let last_segment = self.name.split('.').next_back().unwrap_or(&self.name);
@@ -659,14 +645,6 @@ impl ProcessorSchema {
     pub fn rust_module_name(&self) -> String {
         self.name.replace('.', "_").to_lowercase()
     }
-}
-
-/// Compute schema ID from full name (first 8 bytes of SHA-256).
-pub fn compute_schema_id(full_name: &str) -> u64 {
-    let mut hasher = Sha256::new();
-    hasher.update(full_name.as_bytes());
-    let result = hasher.finalize();
-    u64::from_be_bytes(result[0..8].try_into().unwrap())
 }
 
 /// Convert a string to PascalCase.

--- a/sdk/streamlib-processor-schema/src/processor_schema_parser.rs
+++ b/sdk/streamlib-processor-schema/src/processor_schema_parser.rs
@@ -51,30 +51,6 @@ fn validate_processor_schema(schema: &ProcessorSchema) -> SchemaResult<()> {
         });
     }
 
-    // Validate version format (semver-like)
-    if schema.version.is_empty() {
-        return Err(SchemaError::MissingField {
-            field: "version".to_string(),
-        });
-    }
-
-    let version_parts: Vec<&str> = schema.version.split('.').collect();
-    if version_parts.len() < 2 || version_parts.len() > 3 {
-        return Err(SchemaError::InvalidName {
-            name: schema.version.clone(),
-            reason: "version must be in format X.Y or X.Y.Z".to_string(),
-        });
-    }
-
-    for part in &version_parts {
-        if part.parse::<u32>().is_err() {
-            return Err(SchemaError::InvalidName {
-                name: schema.version.clone(),
-                reason: "version parts must be numeric".to_string(),
-            });
-        }
-    }
-
     // Config schema reference: shape (non-empty bare PascalCase TypeName)
     // is locked by `TypeName`'s typed deserializer in
     // `streamlib_idents::TypeName`. Resolution against the enclosing
@@ -120,12 +96,10 @@ mod tests {
     fn test_parse_processor_schema_minimal() {
         let yaml = r#"
 name: Passthrough
-version: 1.0.0
 "#;
 
         let schema = parse_processor_yaml(yaml).unwrap();
         assert_eq!(schema.name, "Passthrough");
-        assert_eq!(schema.version, "1.0.0");
         assert!(schema.description.is_none());
         assert!(schema.entrypoint.is_none());
         assert!(schema.config.is_none());
@@ -137,7 +111,6 @@ version: 1.0.0
     fn test_parse_processor_schema_full() {
         let yaml = r#"
 name: Blur
-version: 1.0.0
 description: "Gaussian blur filter"
 
 runtime: rust
@@ -160,7 +133,6 @@ outputs:
 
         let schema = parse_processor_yaml(yaml).unwrap();
         assert_eq!(schema.name, "Blur");
-        assert_eq!(schema.version, "1.0.0");
         assert_eq!(schema.description, Some("Gaussian blur filter".to_string()));
         assert_eq!(
             schema.runtime.language,
@@ -187,7 +159,6 @@ outputs:
     fn test_parse_processor_schema_python_runtime() {
         let yaml = r#"
 name: ObjectDetector
-version: 1.0.0
 runtime: python
 entrypoint: detector:ObjectDetector
 
@@ -213,7 +184,6 @@ outputs:
         // `(org, package)` come from the enclosing `streamlib.yaml`.
         let yaml = r#"
 name: Camera
-version: 1.0.0
 "#;
 
         let schema = parse_processor_yaml(yaml).unwrap();
@@ -227,7 +197,6 @@ version: 1.0.0
         // PascalCase short name.
         let yaml = r#"
 name: com.example.legacy_processor
-version: 1.0.0
 "#;
 
         let result = parse_processor_yaml(yaml);
@@ -243,7 +212,6 @@ version: 1.0.0
     fn test_processor_schema_rejects_snake_case_name() {
         let yaml = r#"
 name: blur_filter
-version: 1.0.0
 "#;
 
         let result = parse_processor_yaml(yaml);
@@ -254,18 +222,6 @@ version: 1.0.0
     fn test_processor_schema_rejects_empty_name() {
         let yaml = r#"
 name: ""
-version: 1.0.0
-"#;
-
-        let result = parse_processor_yaml(yaml);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_processor_schema_invalid_version() {
-        let yaml = r#"
-name: Test
-version: invalid
 "#;
 
         let result = parse_processor_yaml(yaml);
@@ -280,7 +236,6 @@ version: invalid
         // `schemas:` map.
         let yaml = r#"
 name: Test
-version: 1.0.0
 
 inputs:
   - name: video
@@ -300,7 +255,6 @@ inputs:
     fn test_processor_schema_rejects_structured_port_form() {
         let yaml = r#"
 name: Test
-version: 1.0.0
 inputs:
   - name: video
     schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
@@ -320,7 +274,6 @@ inputs:
         // payloads (e.g. MoQ tracks).
         let yaml = r#"
 name: Test
-version: 1.0.0
 
 inputs:
   - name: data
@@ -335,7 +288,6 @@ inputs:
     fn test_processor_schema_config_local_type() {
         let yaml = r#"
 name: Test
-version: 1.0.0
 
 config:
   name: config
@@ -349,21 +301,9 @@ config:
     }
 
     #[test]
-    fn test_processor_schema_full_name() {
-        let yaml = r#"
-name: Blur
-version: 1.0.0
-"#;
-
-        let schema = parse_processor_yaml(yaml).unwrap();
-        assert_eq!(schema.full_name(), "Blur@1.0.0");
-    }
-
-    #[test]
     fn test_processor_schema_rust_struct_name_is_identity_for_pascal_case() {
         let yaml = r#"
 name: BlurFilter
-version: 1.0.0
 "#;
 
         let schema = parse_processor_yaml(yaml).unwrap();
@@ -374,7 +314,6 @@ version: 1.0.0
     fn test_input_port_read_mode_and_buffer_size() {
         let yaml = r#"
 name: Decoder
-version: 1.0.0
 
 inputs:
   - name: encoded_video_in
@@ -396,7 +335,6 @@ inputs:
     fn test_input_port_defaults_without_read_mode_and_buffer_size() {
         let yaml = r#"
 name: Passthrough
-version: 1.0.0
 
 inputs:
   - name: video
@@ -413,7 +351,6 @@ inputs:
     fn scheduling_block_round_trips_priority() {
         let yaml = r#"
 name: Audio
-version: 1.0.0
 
 scheduling:
   priority: realtime
@@ -427,7 +364,6 @@ scheduling:
     fn scheduling_block_absent_yields_none() {
         let yaml = r#"
 name: Passthrough
-version: 1.0.0
 "#;
         let schema = parse_processor_yaml(yaml).unwrap();
         assert!(schema.scheduling.is_none());
@@ -437,7 +373,6 @@ version: 1.0.0
     fn scheduling_block_rejects_invalid_priority() {
         let yaml = r#"
 name: Bogus
-version: 1.0.0
 
 scheduling:
   priority: NotAValidVariant
@@ -456,7 +391,6 @@ scheduling:
     fn scheduling_block_rejects_unknown_field() {
         let yaml = r#"
 name: Bogus
-version: 1.0.0
 
 scheduling:
   priority: high
@@ -473,7 +407,6 @@ scheduling:
     fn thread_priority_accepts_legacy_pascal_case_aliases() {
         let yaml = r#"
 name: Audio
-version: 1.0.0
 
 scheduling:
   priority: RealTime
@@ -487,7 +420,6 @@ scheduling:
     fn test_input_port_buffer_size_zero_rejected() {
         let yaml = r#"
 name: Test
-version: 1.0.0
 
 inputs:
   - name: video

--- a/tools/streamlib-build-orchestrator/src/deno_codegen.rs
+++ b/tools/streamlib-build-orchestrator/src/deno_codegen.rs
@@ -137,7 +137,7 @@ mod tests {
         let deno = tempdir().unwrap();
         std::fs::write(
             deno.path().join("streamlib.yaml"),
-            "package:\n  org: tatolab\n  name: ts\n  version: 0.1.0\nprocessors:\n  - name: T\n    version: 1.0.0\n    description: d\n    runtime: deno\n    execution: manual\n    entrypoint: \"t.ts:default\"\n    inputs: []\n    outputs: []\n",
+            "package:\n  org: tatolab\n  name: ts\n  version: 0.1.0\nprocessors:\n  - name: T\n    description: d\n    runtime: deno\n    execution: manual\n    entrypoint: \"t.ts:default\"\n    inputs: []\n    outputs: []\n",
         )
         .unwrap();
         assert!(staged_package_has_deno(deno.path()));
@@ -183,7 +183,7 @@ mod tests {
         let dir = tempdir().unwrap();
         std::fs::write(
             dir.path().join("streamlib.yaml"),
-            "package:\n  org: tatolab\n  name: ts\n  version: 0.1.0\nschemas:\n  Foo:\n    file: schemas/foo.yaml\nprocessors:\n  - name: T\n    version: 1.0.0\n    description: d\n    runtime: deno\n    execution: manual\n    entrypoint: \"t.ts:default\"\n    inputs: []\n    outputs: []\n",
+            "package:\n  org: tatolab\n  name: ts\n  version: 0.1.0\nschemas:\n  Foo:\n    file: schemas/foo.yaml\nprocessors:\n  - name: T\n    description: d\n    runtime: deno\n    execution: manual\n    entrypoint: \"t.ts:default\"\n    inputs: []\n    outputs: []\n",
         )
         .unwrap();
         std::fs::create_dir(dir.path().join("schemas")).unwrap();

--- a/tools/streamlib-build-orchestrator/src/lib.rs
+++ b/tools/streamlib-build-orchestrator/src/lib.rs
@@ -1282,7 +1282,6 @@ mod tests {
   version: 0.1.0
 processors:
   - name: RustProc
-    version: 1.0.0
     description: "rust processor fixture (never built - pre-check fires first)"
     runtime: rust
     execution: manual

--- a/tools/streamlib-build-orchestrator/src/test_support.rs
+++ b/tools/streamlib-build-orchestrator/src/test_support.rs
@@ -73,7 +73,6 @@ pub(crate) fn write_python_source_package(pkg_dir: &Path, sdk: &Path) {
   version: 0.1.0
 processors:
   - name: PyProc
-    version: 1.0.0
     description: "offline python processor fixture"
     runtime: python
     execution: manual

--- a/tools/streamlib-cli/src/commands/pkg.rs
+++ b/tools/streamlib-cli/src/commands/pkg.rs
@@ -302,7 +302,7 @@ pub fn inspect(path: &std::path::Path) -> Result<()> {
         println!();
         println!("Processors ({}):", config.processors.len());
         for proc in &config.processors {
-            println!("  {} v{}", proc.name, proc.version);
+            println!("  {}", proc.name);
             if let Some(desc) = &proc.description {
                 println!("    {}", desc);
             }

--- a/tools/streamlib-cli/src/commands/schema.rs
+++ b/tools/streamlib-cli/src/commands/schema.rs
@@ -15,7 +15,6 @@ pub fn validate_processor(path: &Path) -> Result<()> {
         Ok(schema) => {
             println!();
             println!("  Name:        {}", schema.name);
-            println!("  Version:     {}", schema.version);
             if let Some(desc) = &schema.description {
                 println!("  Description: {}", desc);
             }

--- a/tools/streamlib-cli/tests/pkg_publish_catalog.rs
+++ b/tools/streamlib-cli/tests/pkg_publish_catalog.rs
@@ -137,7 +137,6 @@ schemas:
     package: '@tatolab/core'
 processors:
 - name: Bar
-  version: 1.0.0
   runtime: rust
   execution: reactive
   outputs:

--- a/tools/streamlib-cross-rustc-fixture/streamlib.yaml
+++ b/tools/streamlib-cross-rustc-fixture/streamlib.yaml
@@ -23,7 +23,6 @@ schemas:
 
 processors:
   - name: PluginAbiObjectRoundTripProcessor
-    version: 1.0.0
     description: "Cdylib processor that creates + clones + drops every #917 PluginAbiObject return type and writes a sentinel result file. Locks the cross-rustc-version plugin ABI contract end-to-end."
     execution: manual
     config:

--- a/tools/streamlib-pack/src/catalog.rs
+++ b/tools/streamlib-pack/src/catalog.rs
@@ -561,7 +561,6 @@ schemas:
     package: '@tatolab/core'
 processors:
 - name: Camera
-  version: 1.0.0
   description: Captures video
   runtime: rust
   execution: manual
@@ -574,7 +573,6 @@ processors:
     schema: VideoFrame
     description: Live frames
 - name: PassThrough
-  version: 1.0.0
   runtime: python
   entrypoint: src.pass:PassThrough
   execution: reactive
@@ -711,7 +709,6 @@ schemas:
     package: '@tatolab/b'
 processors:
 - name: A
-  version: 1.0.0
   runtime: rust
   execution: reactive
   outputs:
@@ -810,7 +807,6 @@ schemas:
     file: schemas/widget_config.yaml
 processors:
 - name: Widget
-  version: 1.0.0
   runtime: rust
   execution: reactive
   config:
@@ -859,7 +855,6 @@ schemas:
     file: schemas/known.yaml
 processors:
 - name: Widget
-  version: 1.0.0
   runtime: rust
   execution: reactive
   outputs:

--- a/tools/streamlib-pack/src/lib.rs
+++ b/tools/streamlib-pack/src/lib.rs
@@ -1740,7 +1740,7 @@ mod tests {
         let dir = tempdir().unwrap();
         write_rust_processor_pkg(
             dir.path(),
-            "processors:\n- name: Camera\n  version: 1.0.0\n  runtime: rust\n  execution: manual\n  outputs:\n  - name: video\n    schema: VideoFrame\n",
+            "processors:\n- name: Camera\n  runtime: rust\n  execution: manual\n  outputs:\n  - name: video\n    schema: VideoFrame\n",
         );
         let out = dir.path().join("o.slpkg");
         let outcome = assemble_artifact(
@@ -1764,7 +1764,7 @@ mod tests {
         // Manifest lists a different processor name than code declares.
         write_rust_processor_pkg(
             dir.path(),
-            "processors:\n- name: Stale\n  version: 1.0.0\n  runtime: rust\n  execution: manual\n",
+            "processors:\n- name: Stale\n  runtime: rust\n  execution: manual\n",
         );
         let out = dir.path().join("o.slpkg");
         let err = assemble_artifact(
@@ -1972,7 +1972,7 @@ mod tests {
         let dir = tempdir().unwrap();
         std::fs::write(
             dir.path().join("streamlib.yaml"),
-            "package:\n  org: tatolab\n  name: rp\n  version: 0.1.0\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n",
+            "package:\n  org: tatolab\n  name: rp\n  version: 0.1.0\nprocessors:\n  - name: P\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n",
         )
         .unwrap();
         std::fs::write(dir.path().join("Cargo.toml"), b"[package]\nname='rp'\n").unwrap();
@@ -2022,7 +2022,7 @@ mod tests {
         let dir = tempdir().unwrap();
         std::fs::write(
             dir.path().join("streamlib.yaml"),
-            "package:\n  org: tatolab\n  name: rp\n  version: 0.1.0\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n",
+            "package:\n  org: tatolab\n  name: rp\n  version: 0.1.0\nprocessors:\n  - name: P\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n",
         )
         .unwrap();
         std::fs::write(
@@ -2083,7 +2083,7 @@ mod tests {
         let dir = tempdir().unwrap();
         std::fs::write(
             dir.path().join("streamlib.yaml"),
-            "package:\n  org: tatolab\n  name: py\n  version: 0.1.0\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: python\n    execution: manual\n    entrypoint: \"p:P\"\n    inputs: []\n    outputs: []\n",
+            "package:\n  org: tatolab\n  name: py\n  version: 0.1.0\nprocessors:\n  - name: P\n    description: d\n    runtime: python\n    execution: manual\n    entrypoint: \"p:P\"\n    inputs: []\n    outputs: []\n",
         )
         .unwrap();
         std::fs::write(
@@ -2170,7 +2170,7 @@ mod tests {
         let dir = tempdir().unwrap();
         std::fs::write(
             dir.path().join("streamlib.yaml"),
-            "package:\n  org: tatolab\n  name: py\n  version: 0.1.0\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: python\n    execution: manual\n    entrypoint: \"p:P\"\n    inputs: []\n    outputs: []\n",
+            "package:\n  org: tatolab\n  name: py\n  version: 0.1.0\nprocessors:\n  - name: P\n    description: d\n    runtime: python\n    execution: manual\n    entrypoint: \"p:P\"\n    inputs: []\n    outputs: []\n",
         )
         .unwrap();
         std::fs::write(
@@ -2235,7 +2235,7 @@ mod tests {
         let dir = tempdir().unwrap();
         std::fs::write(
             dir.path().join("streamlib.yaml"),
-            "package:\n  org: tatolab\n  name: py\n  version: 0.1.0\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: python\n    execution: manual\n    entrypoint: \"cuda_fisheye.processor:P\"\n    inputs: []\n    outputs: []\n",
+            "package:\n  org: tatolab\n  name: py\n  version: 0.1.0\nprocessors:\n  - name: P\n    description: d\n    runtime: python\n    execution: manual\n    entrypoint: \"cuda_fisheye.processor:P\"\n    inputs: []\n    outputs: []\n",
         )
         .unwrap();
         std::fs::write(
@@ -2279,7 +2279,7 @@ mod tests {
         let dir = tempdir().unwrap();
         std::fs::write(
             dir.path().join("streamlib.yaml"),
-            "package:\n  org: tatolab\n  name: py\n  version: 0.1.0\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: python\n    execution: manual\n    entrypoint: \"p:P\"\n    inputs: []\n    outputs: []\n",
+            "package:\n  org: tatolab\n  name: py\n  version: 0.1.0\nprocessors:\n  - name: P\n    description: d\n    runtime: python\n    execution: manual\n    entrypoint: \"p:P\"\n    inputs: []\n    outputs: []\n",
         )
         .unwrap();
         std::fs::write(
@@ -2327,7 +2327,7 @@ mod tests {
         let dir = tempdir().unwrap();
         std::fs::write(
             dir.path().join("streamlib.yaml"),
-            "package:\n  org: tatolab\n  name: py\n  version: 0.1.0\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: python\n    execution: manual\n    entrypoint: \"p:P\"\n    inputs: []\n    outputs: []\n",
+            "package:\n  org: tatolab\n  name: py\n  version: 0.1.0\nprocessors:\n  - name: P\n    description: d\n    runtime: python\n    execution: manual\n    entrypoint: \"p:P\"\n    inputs: []\n    outputs: []\n",
         )
         .unwrap();
         std::fs::write(dir.path().join("p.py"), b"# stub").unwrap();
@@ -2361,7 +2361,7 @@ mod tests {
         let dir = tempdir().unwrap();
         std::fs::write(
             dir.path().join("streamlib.yaml"),
-            "package:\n  org: tatolab\n  name: ts\n  version: 0.1.0\nprocessors:\n  - name: T\n    version: 1.0.0\n    description: d\n    runtime: deno\n    execution: manual\n    entrypoint: \"t.ts:default\"\n    inputs: []\n    outputs: []\n",
+            "package:\n  org: tatolab\n  name: ts\n  version: 0.1.0\nprocessors:\n  - name: T\n    description: d\n    runtime: deno\n    execution: manual\n    entrypoint: \"t.ts:default\"\n    inputs: []\n    outputs: []\n",
         )
         .unwrap();
         std::fs::write(dir.path().join("t.ts"), b"export default class {}").unwrap();
@@ -2423,7 +2423,7 @@ mod tests {
         let dir = tempdir().unwrap();
         std::fs::write(
             dir.path().join("streamlib.yaml"),
-            "package:\n  org: tatolab\n  name: ts\n  version: 0.1.0\nprocessors:\n  - name: T\n    version: 1.0.0\n    description: d\n    runtime: deno\n    execution: manual\n    entrypoint: \"t.ts:default\"\n    inputs: []\n    outputs: []\n",
+            "package:\n  org: tatolab\n  name: ts\n  version: 0.1.0\nprocessors:\n  - name: T\n    description: d\n    runtime: deno\n    execution: manual\n    entrypoint: \"t.ts:default\"\n    inputs: []\n    outputs: []\n",
         )
         .unwrap();
         std::fs::write(dir.path().join("t.ts"), b"export default class {}").unwrap();
@@ -2721,7 +2721,7 @@ mod tests {
         let dir = tempdir().unwrap();
         std::fs::write(
             dir.path().join("streamlib.yaml"),
-            "package:\n  org: tatolab\n  name: rp\n  version: 1.1.3-dev.4\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n",
+            "package:\n  org: tatolab\n  name: rp\n  version: 1.1.3-dev.4\nprocessors:\n  - name: P\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n",
         )
         .unwrap();
         std::fs::write(
@@ -2771,7 +2771,7 @@ mod tests {
         let dir = tempdir().unwrap();
         std::fs::write(
             dir.path().join("streamlib.yaml"),
-            "package:\n  org: tatolab\n  name: rp\n  version: 1.1.3-dev.4\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n",
+            "package:\n  org: tatolab\n  name: rp\n  version: 1.1.3-dev.4\nprocessors:\n  - name: P\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n",
         )
         .unwrap();
         std::fs::write(
@@ -2842,7 +2842,7 @@ mod tests {
         let dir = tempdir().unwrap();
         std::fs::write(
             dir.path().join("streamlib.yaml"),
-            "package:\n  org: tatolab\n  name: rp\n  version: 1.0.0\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n",
+            "package:\n  org: tatolab\n  name: rp\n  version: 1.0.0\nprocessors:\n  - name: P\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n",
         )
         .unwrap();
         std::fs::write(dir.path().join("Cargo.toml"), ":::: not toml ::::\n").unwrap();
@@ -2885,7 +2885,7 @@ mod tests {
         let dir = tempdir().unwrap();
         std::fs::write(
             dir.path().join("streamlib.yaml"),
-            "package:\n  org: tatolab\n  name: rp\n  version: 1.0.0\nprocessors:\n  - name: P\n    version: 1.0.0\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n",
+            "package:\n  org: tatolab\n  name: rp\n  version: 1.0.0\nprocessors:\n  - name: P\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n",
         )
         .unwrap();
         std::fs::write(

--- a/tools/streamlib-pack/tests/catalog_pkg_publish.rs
+++ b/tools/streamlib-pack/tests/catalog_pkg_publish.rs
@@ -89,7 +89,6 @@ schemas:
     package: '@tatolab/core'
 processors:
 - name: Camera
-  version: 1.0.0
   description: Captures video
   runtime: rust
   execution: manual
@@ -101,7 +100,6 @@ processors:
     schema: VideoFrame
     description: Live frames
 - name: Sink
-  version: 1.0.0
   runtime: python
   entrypoint: src.sink:Sink
   execution: reactive
@@ -128,7 +126,6 @@ schemas:
     package: '@tatolab/core'
 processors:
 - name: Camera
-  version: 1.0.0
   description: Captures video
   runtime: rust
   execution: manual
@@ -322,7 +319,6 @@ schemas:
     file: schemas/widget_config.yaml
 processors:
 - name: Widget
-  version: 1.0.0
   runtime: rust
   execution: reactive
   config:

--- a/tools/streamlib-pack/tests/catalog_publish_query.rs
+++ b/tools/streamlib-pack/tests/catalog_publish_query.rs
@@ -69,7 +69,6 @@ schemas:
     package: '@tatolab/core'
 processors:
 - name: Camera
-  version: 1.0.0
   description: Captures video
   runtime: rust
   execution: manual
@@ -81,7 +80,6 @@ processors:
     schema: VideoFrame
     description: Live frames
 - name: Sink
-  version: 1.0.0
   runtime: python
   entrypoint: src.sink:Sink
   execution: reactive
@@ -245,7 +243,6 @@ schemas:
     file: schemas/widget_config.yaml
 processors:
 - name: Widget
-  version: 1.0.0
   runtime: rust
   execution: reactive
   config:

--- a/tools/streamlib-pack/tests/emit_static_registry_catalog.rs
+++ b/tools/streamlib-pack/tests/emit_static_registry_catalog.rs
@@ -84,7 +84,6 @@ schemas:
     package: '@tatolab/fixcore'
 processors:
 - name: FixSource
-  version: 1.0.0
   runtime: python
   entrypoint: src.fix:FixSource
   execution: reactive


### PR DESCRIPTION
## Why

Post-#1409 (version-free processor identity) and #1460 (version-blind load-gate cross-check), the per-**processor** `version:` field in a `streamlib.yaml` `processors:` entry is vestigial:

- the module-load path and the #1411 drift gate are version-blind — only the **package** version identifies a processor;
- `ProcessorSchema::full_name()` / `processor_id()` / `compute_schema_id` existed only to format that per-processor version, and had no non-test callers;
- the Rust macro path already stamped the version-free `0.0.0` sentinel into it, so the value was meaningless on that side.

## What changed

Removed as a canonical-pattern sweep across Rust + manifests + examples + fixtures + generated schema:

- **`sdk/streamlib-processor-schema`**: drop `version` from `ProcessorSchema`; delete `full_name()`, `processor_id()`, `compute_schema_id` (and its export + the now-unused `sha2` dependency); drop the parser's version-format validation.
- **`schemas/streamlib.schema.json`**: regenerated with `cargo xtask emit-manifest-schema` — `version` leaves the `ProcessorSchema` `required` set and `properties` (only that block changes).
- **`ProcessorDescriptor.version`** (the introspection field, kept) is now sourced from the processor's identity version instead of the removed field: the version-free sentinel in the macro codegen (`sdk/streamlib-macros`), and the package version in the module-loader registration path (`processor_registration.rs`).
- **Manifests + fixtures**: stripped the `version:` line from every committed `streamlib.yaml` processor entry (packages, examples, test-fixtures, the engine's own manifest) and every in-tree Rust manifest fixture — required because `ProcessorSchema` is `#[serde(deny_unknown_fields)]`, so a lingering `version:` now fails to parse. Package `version:` and dependency `version:` are untouched.

Load-bearing check: the Python/Deno extractor wire format deserializes into a separate `WireProcessor` type (no `deny_unknown_fields`), so it is unaffected by this change.

## Gates

- `cargo build --workspace --all-targets` — clean
- `cargo test --lib` — engine 1642, processor-extract 59, processor-schema 28, pack 61, build-orchestrator 33, idents 231, macros 7 — all green
- `cargo run -p xtask -- check-manifest-schema` — 57 manifests validated against the regenerated schema
- `cargo test -p xtask manifest_schema` — 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)