### PR TITLE
feat(engine): read the wire schema-ident tag — connect-time + runtime schema-mismatch checks

### DIFF
--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -14,7 +14,7 @@ use crate::core::ProcessorUniqueId;
 use crate::core::context::RuntimeContext;
 use crate::core::embedded_schemas::{
     max_payload_bytes_for_port_spec, max_queued_messages_for_port_spec, overflow_for_input_port,
-    port_schema_spec,
+    resolve_node_port_schema,
 };
 use crate::core::error::{Error, Result};
 use crate::core::graph::{
@@ -321,25 +321,15 @@ fn resolve_output_schema(
 }
 
 /// Resolve the [`PortSchemaSpec`] on one port of a graph node, in either
-/// direction. Looks the node's processor type up in the graph, then delegates
-/// to the shared registry primitive [`port_schema_spec`]. Returns
-/// [`PortSchemaSpec::Any`] when the node is absent (no processor type to read).
+/// direction. Delegates to the shared graph→port-schema primitive
+/// [`resolve_node_port_schema`].
 fn resolve_port_schema(
-    graph: &mut Graph,
+    graph: &Graph,
     proc_id: &ProcessorUniqueId,
     port: &str,
     direction: crate::core::PortDirection,
 ) -> PortSchemaSpec {
-    let proc_type = graph
-        .traversal_mut()
-        .v(proc_id)
-        .first()
-        .map(|node| node.processor_type().clone());
-
-    match proc_type {
-        Some(ident) => port_schema_spec(&ident, port, direction),
-        None => PortSchemaSpec::Any,
-    }
+    resolve_node_port_schema(graph, proc_id, port, direction)
 }
 
 /// Deepest `max_queued_messages` across all of a destination's inbound links.

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -14,6 +14,7 @@ use crate::core::ProcessorUniqueId;
 use crate::core::context::RuntimeContext;
 use crate::core::embedded_schemas::{
     max_payload_bytes_for_port_spec, max_queued_messages_for_port_spec, overflow_for_input_port,
+    port_schema_spec,
 };
 use crate::core::error::{Error, Result};
 use crate::core::graph::{
@@ -38,7 +39,10 @@ fn schema_ident_json(spec: &PortSchemaSpec) -> serde_json::Value {
 /// tag. `Any` ports yield the default zero-segment wire bytes (unset routing
 /// tag — preserves the existing wildcard semantics). `Specific(...)` ports
 /// build the wire bytes directly from the validated structured fields.
-fn schema_ident_wire_for_producer(spec: &PortSchemaSpec) -> SchemaIdentWire {
+///
+/// Used both to stamp a producer's output tag onto every frame and to record
+/// a consumer port's expected tag for the per-frame read-side check.
+fn schema_ident_wire_for_spec(spec: &PortSchemaSpec) -> SchemaIdentWire {
     match spec {
         PortSchemaSpec::Any => SchemaIdentWire::default(),
         PortSchemaSpec::Specific(ident) => SchemaIdentWire::from_segments(
@@ -308,22 +312,34 @@ fn resolve_output_schema(
     source_proc_id: &ProcessorUniqueId,
     source_port: &str,
 ) -> PortSchemaSpec {
-    let source_proc_type = graph
+    resolve_port_schema(
+        graph,
+        source_proc_id,
+        source_port,
+        crate::core::PortDirection::Output,
+    )
+}
+
+/// Resolve the [`PortSchemaSpec`] on one port of a graph node, in either
+/// direction. Looks the node's processor type up in the graph, then delegates
+/// to the shared registry primitive [`port_schema_spec`]. Returns
+/// [`PortSchemaSpec::Any`] when the node is absent (no processor type to read).
+fn resolve_port_schema(
+    graph: &mut Graph,
+    proc_id: &ProcessorUniqueId,
+    port: &str,
+    direction: crate::core::PortDirection,
+) -> PortSchemaSpec {
+    let proc_type = graph
         .traversal_mut()
-        .v(source_proc_id)
+        .v(proc_id)
         .first()
         .map(|node| node.processor_type().clone());
 
-    source_proc_type
-        .as_ref()
-        .and_then(|ident| PROCESSOR_REGISTRY.port_info(ident))
-        .and_then(|(_, outputs)| {
-            outputs
-                .iter()
-                .find(|p| p.name == source_port)
-                .map(|p| p.data_type.clone())
-        })
-        .unwrap_or_default()
+    match proc_type {
+        Some(ident) => port_schema_spec(&ident, port, direction),
+        None => PortSchemaSpec::Any,
+    }
 }
 
 /// Deepest `max_queued_messages` across all of a destination's inbound links.
@@ -429,6 +445,12 @@ fn open_iceoryx2_pubsub(
     // Look up schema for the output port before creating the publisher so we can size
     // the shared memory slot correctly via max_payload_bytes_for_port_spec.
     let output_schema = resolve_output_schema(graph, source_proc_id, source_port);
+    let dest_schema = resolve_port_schema(
+        graph,
+        dest_proc_id,
+        dest_port,
+        crate::core::PortDirection::Input,
+    );
 
     tracing::debug!(
         "Output port '{}' has schema '{}'",
@@ -466,7 +488,7 @@ fn open_iceoryx2_pubsub(
         if let Some(output_inner) = source_guard.iceoryx2_output_writer_inner() {
             output_inner.add_connection(
                 source_port,
-                schema_ident_wire_for_producer(&output_schema),
+                schema_ident_wire_for_spec(&output_schema),
                 dest_port,
                 publisher,
                 notifier,
@@ -501,6 +523,12 @@ fn open_iceoryx2_pubsub(
             // The cdylib's read_raw then allocates exactly this
             // size — no truncation, no retry, no silent drop.
             input_inner.set_port_max_payload_bytes(dest_port, max_payload);
+
+            // Record the consumer port's expected schema tag so the host-side
+            // read path can compare it against each inbound frame's stamped
+            // tag (#1430 — the tag was stamped-but-unread before this).
+            input_inner
+                .set_port_expected_schema_ident(dest_port, schema_ident_wire_for_spec(&dest_schema));
 
             // Only set subscriber+listener if this is the first connection to this destination
             // All subsequent connections reuse the same pair (max_listeners=1 enforces this).
@@ -688,6 +716,12 @@ fn open_iceoryx2_subprocess_to_rust(
 
     // Look up schema for the output port from the registry
     let output_schema = resolve_output_schema(graph, source_proc_id, source_port);
+    let dest_schema = resolve_port_schema(
+        graph,
+        dest_proc_id,
+        dest_port,
+        crate::core::PortDirection::Input,
+    );
     let max_payload = max_payload_bytes_for_port_spec(&output_schema)?;
     let max_queued_messages = max_queued_messages_for_dest(graph, dest_proc_id)?;
     let enable_safe_overflow = resolve_enable_safe_overflow(graph, dest_proc_id, dest_port)?;
@@ -767,6 +801,11 @@ fn open_iceoryx2_subprocess_to_rust(
             // bound the publisher uses. See the same call in the
             // local-source branch above for full rationale.
             input_inner.set_port_max_payload_bytes(dest_port, max_payload);
+
+            // Record the consumer port's expected schema tag for the
+            // host-side per-frame read-side check (#1430).
+            input_inner
+                .set_port_expected_schema_ident(dest_port, schema_ident_wire_for_spec(&dest_schema));
 
             if !input_inner.has_subscriber() {
                 let subscriber = service.create_subscriber()?;
@@ -853,7 +892,7 @@ fn open_iceoryx2_rust_to_subprocess(
         if let Some(output_inner) = source_guard.iceoryx2_output_writer_inner() {
             output_inner.add_connection(
                 source_port,
-                schema_ident_wire_for_producer(&output_schema),
+                schema_ident_wire_for_spec(&output_schema),
                 dest_port,
                 publisher,
                 notifier,

--- a/runtime/streamlib-engine/src/core/embedded_schemas/mod.rs
+++ b/runtime/streamlib-engine/src/core/embedded_schemas/mod.rs
@@ -218,9 +218,9 @@ pub fn overflow_for_input_port(
 /// when the processor type isn't registered or the named port doesn't exist —
 /// the same "unconstrained" default the port-spec metadata resolvers assume.
 ///
-/// This is the single registry-lookup primitive behind both the connect-time
-/// agreement check (`operations_runtime`) and the wire-time output-schema
-/// resolution (`open_iceoryx2_service_op`).
+/// The registry-lookup primitive keyed by a resolved processor `SchemaIdent`.
+/// The graph-level wrapper [`resolve_node_port_schema`] reads a node's
+/// processor type out of the graph and delegates here.
 ///
 /// [`PROCESSOR_REGISTRY`]: crate::core::processors::PROCESSOR_REGISTRY
 /// [`PortSchemaSpec`]: streamlib_processor_schema::PortSchemaSpec
@@ -245,6 +245,37 @@ pub fn port_schema_spec(
         .find(|p| p.name == port_name)
         .map(|p| p.data_type.clone())
         .unwrap_or_default()
+}
+
+/// Resolve the [`PortSchemaSpec`] on one port of a graph node, in either
+/// direction.
+///
+/// Reads the node's processor type out of `graph`, then delegates to the
+/// registry primitive [`port_schema_spec`]. Returns [`PortSchemaSpec::Any`]
+/// (the tolerant wildcard) when the node is absent — no processor type to read.
+///
+/// This is the single graph→port-schema primitive behind both the connect-time
+/// agreement check (`operations_runtime`) and the wire-time output/destination
+/// schema resolution (`open_iceoryx2_service_op`).
+///
+/// [`PortSchemaSpec`]: streamlib_processor_schema::PortSchemaSpec
+/// [`PortSchemaSpec::Any`]: streamlib_processor_schema::PortSchemaSpec::Any
+pub fn resolve_node_port_schema(
+    graph: &crate::core::graph::Graph,
+    proc_id: &crate::core::graph::ProcessorUniqueId,
+    port_name: &str,
+    direction: crate::core::PortDirection,
+) -> streamlib_processor_schema::PortSchemaSpec {
+    let proc_type = graph
+        .traversal()
+        .v(proc_id)
+        .first()
+        .map(|node| node.processor_type().clone());
+
+    match proc_type {
+        Some(ident) => port_schema_spec(&ident, port_name, direction),
+        None => streamlib_processor_schema::PortSchemaSpec::Any,
+    }
 }
 
 /// Shared lookup helper for both port-spec metadata resolvers.

--- a/runtime/streamlib-engine/src/core/embedded_schemas/mod.rs
+++ b/runtime/streamlib-engine/src/core/embedded_schemas/mod.rs
@@ -209,6 +209,44 @@ pub fn overflow_for_input_port(
     })
 }
 
+/// Resolve the [`PortSchemaSpec`] declared on one port of a registered
+/// processor type.
+///
+/// Reads [`PROCESSOR_REGISTRY`]'s `port_info` for `processor_type`, selects the
+/// input or output port list per `direction`, and returns the named port's
+/// `data_type`. Falls back to [`PortSchemaSpec::Any`] (the tolerant wildcard)
+/// when the processor type isn't registered or the named port doesn't exist —
+/// the same "unconstrained" default the port-spec metadata resolvers assume.
+///
+/// This is the single registry-lookup primitive behind both the connect-time
+/// agreement check (`operations_runtime`) and the wire-time output-schema
+/// resolution (`open_iceoryx2_service_op`).
+///
+/// [`PROCESSOR_REGISTRY`]: crate::core::processors::PROCESSOR_REGISTRY
+/// [`PortSchemaSpec`]: streamlib_processor_schema::PortSchemaSpec
+pub fn port_schema_spec(
+    processor_type: &streamlib_idents::SchemaIdent,
+    port_name: &str,
+    direction: crate::core::PortDirection,
+) -> streamlib_processor_schema::PortSchemaSpec {
+    use crate::core::PortDirection;
+
+    let Some((inputs, outputs)) =
+        crate::core::processors::PROCESSOR_REGISTRY.port_info(processor_type)
+    else {
+        return streamlib_processor_schema::PortSchemaSpec::Any;
+    };
+    let ports = match direction {
+        PortDirection::Input => inputs,
+        PortDirection::Output => outputs,
+    };
+    ports
+        .iter()
+        .find(|p| p.name == port_name)
+        .map(|p| p.data_type.clone())
+        .unwrap_or_default()
+}
+
 /// Shared lookup helper for both port-spec metadata resolvers.
 ///
 /// `Any` → `Ok(None)` (caller substitutes default).

--- a/runtime/streamlib-engine/src/core/mod.rs
+++ b/runtime/streamlib-engine/src/core/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod logging;
 pub(crate) mod observability;
 pub mod plugin;
 pub(crate) mod runtime_hooks;
+pub(crate) mod schema_agreement;
 pub(crate) mod signals;
 pub(crate) mod streamlib_home;
 #[cfg(test)]

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -11,7 +11,7 @@ use crate::core::graph::{
     GraphEdgeWithComponents, GraphNodeWithComponents, LinkUniqueId, PendingDeletionComponent,
     ProcessorUniqueId, StateComponent,
 };
-use crate::core::embedded_schemas::port_schema_spec;
+use crate::core::embedded_schemas::resolve_node_port_schema;
 use crate::core::processors::{ProcessorSpec, ProcessorState};
 use crate::core::pubsub::{Event, PUBSUB, RuntimeEvent, topics};
 use crate::core::schema_agreement::{
@@ -223,33 +223,29 @@ async fn connect_impl(
         // back rather than committing a mismatched edge. Endpoints are already
         // validated to exist above.
         {
-            let producer_type = graph
-                .traversal()
-                .v(&from.processor_id)
-                .first()
-                .map(|node| node.processor_type().clone());
-            let consumer_type = graph
-                .traversal()
-                .v(&to.processor_id)
-                .first()
-                .map(|node| node.processor_type().clone());
-            if let (Some(producer_type), Some(consumer_type)) = (producer_type, consumer_type) {
-                let producer_schema =
-                    port_schema_spec(&producer_type, &from.port_name, PortDirection::Output);
-                let consumer_schema =
-                    port_schema_spec(&consumer_type, &to.port_name, PortDirection::Input);
-                enforce_connect_schema_agreement(
-                    &producer_schema,
-                    &consumer_schema,
-                    validation,
-                    ConnectSchemaContext {
-                        from_processor: from.processor_id.as_str(),
-                        from_port: &from.port_name,
-                        to_processor: to.processor_id.as_str(),
-                        to_port: &to.port_name,
-                    },
-                )?;
-            }
+            let producer_schema = resolve_node_port_schema(
+                graph,
+                &from.processor_id,
+                &from.port_name,
+                PortDirection::Output,
+            );
+            let consumer_schema = resolve_node_port_schema(
+                graph,
+                &to.processor_id,
+                &to.port_name,
+                PortDirection::Input,
+            );
+            enforce_connect_schema_agreement(
+                &producer_schema,
+                &consumer_schema,
+                validation,
+                ConnectSchemaContext {
+                    from_processor: from.processor_id.as_str(),
+                    from_port: &from.port_name,
+                    to_processor: to.processor_id.as_str(),
+                    to_port: &to.port_name,
+                },
+            )?;
         }
 
         // The one channel this link's source output port publishes to — keyed

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -11,8 +11,12 @@ use crate::core::graph::{
     GraphEdgeWithComponents, GraphNodeWithComponents, LinkUniqueId, PendingDeletionComponent,
     ProcessorUniqueId, StateComponent,
 };
+use crate::core::embedded_schemas::port_schema_spec;
 use crate::core::processors::{ProcessorSpec, ProcessorState};
 use crate::core::pubsub::{Event, PUBSUB, RuntimeEvent, topics};
+use crate::core::schema_agreement::{
+    ConnectSchemaContext, SchemaValidationPosture, enforce_connect_schema_agreement,
+};
 use crate::core::{Error, InputLinkPortRef, OutputLinkPortRef, PortDirection, Result};
 use streamlib_idents::ChannelName;
 
@@ -147,10 +151,17 @@ async fn remove_processor_impl(
 }
 
 /// Core implementation for connect - takes owned Arcs for 'static lifetime.
+///
+/// `validation` selects the schema-agreement posture for this wiring site.
+/// The public `connect` / `connect_async` entrypoints pass
+/// [`SchemaValidationPosture::Loose`] (warn-but-wire); a safety-critical
+/// wiring site passes [`SchemaValidationPosture::Strict`] to hard-fail on a
+/// producer/consumer schema mismatch.
 async fn connect_impl(
     compiler: Arc<Compiler>,
     from: OutputLinkPortRef,
     to: InputLinkPortRef,
+    validation: SchemaValidationPosture,
 ) -> Result<LinkUniqueId> {
     let from_processor = from.processor_id.clone();
     let from_port = from.port_name.clone();
@@ -201,6 +212,43 @@ async fn connect_impl(
                     port_name: to.port_name.clone(),
                     direction: PortDirection::Input,
                 });
+            }
+        }
+
+        // Schema-agreement check at the wiring site: resolve the producer's
+        // output schema and the consumer's input schema from the registry and
+        // compare. A wildcard (`any`) on either side never mismatches; two
+        // concrete-but-unequal schemas warn (loose) or hard-fail (strict).
+        // Runs before `add_e` so a strict rejection rolls the pending link
+        // back rather than committing a mismatched edge. Endpoints are already
+        // validated to exist above.
+        {
+            let producer_type = graph
+                .traversal()
+                .v(&from.processor_id)
+                .first()
+                .map(|node| node.processor_type().clone());
+            let consumer_type = graph
+                .traversal()
+                .v(&to.processor_id)
+                .first()
+                .map(|node| node.processor_type().clone());
+            if let (Some(producer_type), Some(consumer_type)) = (producer_type, consumer_type) {
+                let producer_schema =
+                    port_schema_spec(&producer_type, &from.port_name, PortDirection::Output);
+                let consumer_schema =
+                    port_schema_spec(&consumer_type, &to.port_name, PortDirection::Input);
+                enforce_connect_schema_agreement(
+                    &producer_schema,
+                    &consumer_schema,
+                    validation,
+                    ConnectSchemaContext {
+                        from_processor: from.processor_id.as_str(),
+                        from_port: &from.port_name,
+                        to_processor: to.processor_id.as_str(),
+                        to_port: &to.port_name,
+                    },
+                )?;
             }
         }
 
@@ -336,7 +384,12 @@ impl RuntimeOperations for Runner {
         to: InputLinkPortRef,
     ) -> BoxFuture<'_, Result<LinkUniqueId>> {
         let compiler = Arc::clone(&self.compiler);
-        Box::pin(connect_impl(compiler, from, to))
+        Box::pin(connect_impl(
+            compiler,
+            from,
+            to,
+            SchemaValidationPosture::Loose,
+        ))
     }
 
     fn disconnect_async(&self, link_id: LinkUniqueId) -> BoxFuture<'_, Result<()>> {
@@ -402,7 +455,8 @@ impl RuntimeOperations for Runner {
                 let compiler = Arc::clone(&self.compiler);
                 let (tx, rx) = std::sync::mpsc::channel();
                 handle.spawn(async move {
-                    let result = connect_impl(compiler, from, to).await;
+                    let result =
+                        connect_impl(compiler, from, to, SchemaValidationPosture::Loose).await;
                     let _ = tx.send(result);
                 });
                 rx.recv()

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -525,3 +525,192 @@ mod channel_wire_bound_tests {
             .expect("a grammar-legal channel name must always fit the PortKey wire");
     }
 }
+
+#[cfg(test)]
+mod connect_schema_agreement_tests {
+    //! End-to-end connect-path revert lock for the connect-time schema
+    //! agreement check (#1430). Drives [`connect_impl`] against two registered
+    //! processor types whose concrete output / input schemas disagree, and
+    //! asserts the posture-dependent outcome: [`Loose`] warns but still wires
+    //! the link; [`Strict`] rejects it with a typed [`Error::SchemaIdentMismatch`].
+    //!
+    //! Mentally reverting the connect-time `enforce_connect_schema_agreement`
+    //! call in [`connect_impl`] collapses both halves — the Loose warn stops
+    //! firing and Strict stops rejecting — failing this module. The unit tests
+    //! on `enforce_connect_schema_agreement` alone do NOT catch that regression:
+    //! they never exercise the wiring site.
+    //!
+    //! [`Loose`]: SchemaValidationPosture::Loose
+    //! [`Strict`]: SchemaValidationPosture::Strict
+
+    use std::sync::{Arc, Mutex, Once};
+
+    use serde_json::Value;
+    use tracing::field::{Field, Visit};
+    use tracing_subscriber::Layer;
+    use tracing_subscriber::layer::{Context, SubscriberExt};
+
+    use super::connect_impl;
+    use crate::core::Error;
+    use crate::core::compiler::Compiler;
+    use crate::core::descriptors::{PortDescriptor, ProcessorDescriptor};
+    use crate::core::graph::{InputLinkPortRef, OutputLinkPortRef, ProcessorUniqueId};
+    use crate::core::processors::{PROCESSOR_REGISTRY, ProcessorSpec};
+    use crate::core::schema_agreement::SchemaValidationPosture;
+    use streamlib_idents::{Org, Package, SchemaIdent, SemVer, TypeName};
+    use streamlib_processor_schema::PortSchemaSpec;
+
+    const PRODUCER_TYPE: &str = "SchemaMismatchProducer";
+    const CONSUMER_TYPE: &str = "SchemaMismatchConsumer";
+
+    fn ident(package: &str, ty: &str) -> SchemaIdent {
+        SchemaIdent::new(
+            Org::new("test").unwrap(),
+            Package::new(package).unwrap(),
+            TypeName::new(ty).unwrap(),
+            SemVer::new(1, 0, 0),
+        )
+    }
+
+    fn schema(ty: &str) -> PortSchemaSpec {
+        PortSchemaSpec::Specific(ident("core", ty))
+    }
+
+    /// Register a producer type (`out` → VideoFrame) and a consumer type
+    /// (`in` → AudioFrame) so any wired producer→consumer link is a concrete
+    /// schema mismatch. Idempotent across tests in the process.
+    fn ensure_mismatch_types_registered() {
+        static REGISTER: Once = Once::new();
+        REGISTER.call_once(|| {
+            let mut producer =
+                ProcessorDescriptor::new(ident("connectcheck", PRODUCER_TYPE), "mismatch producer");
+            producer
+                .outputs
+                .push(PortDescriptor::iceoryx2("out", "output", schema("VideoFrame")));
+            PROCESSOR_REGISTRY
+                .register_descriptor_only(producer)
+                .expect("register mismatch producer descriptor");
+
+            let mut consumer =
+                ProcessorDescriptor::new(ident("connectcheck", CONSUMER_TYPE), "mismatch consumer");
+            consumer
+                .inputs
+                .push(PortDescriptor::iceoryx2("in", "input", schema("AudioFrame")));
+            PROCESSOR_REGISTRY
+                .register_descriptor_only(consumer)
+                .expect("register mismatch consumer descriptor");
+        });
+    }
+
+    /// Fresh compiler holding one producer node and one consumer node, plus the
+    /// wiring refs for their mismatched ports.
+    fn compiler_with_mismatched_pair() -> (Arc<Compiler>, OutputLinkPortRef, InputLinkPortRef) {
+        ensure_mismatch_types_registered();
+        let compiler = Arc::new(Compiler::new());
+        let (from_id, to_id): (ProcessorUniqueId, ProcessorUniqueId) =
+            compiler.scope(|graph, _tx| {
+                let from = graph
+                    .traversal_mut()
+                    .add_v(ProcessorSpec::new(
+                        ident("connectcheck", PRODUCER_TYPE),
+                        Value::Null,
+                    ))
+                    .first()
+                    .expect("producer node must be created")
+                    .id
+                    .clone();
+                let to = graph
+                    .traversal_mut()
+                    .add_v(ProcessorSpec::new(
+                        ident("connectcheck", CONSUMER_TYPE),
+                        Value::Null,
+                    ))
+                    .first()
+                    .expect("consumer node must be created")
+                    .id
+                    .clone();
+                (from, to)
+            });
+        (
+            compiler,
+            OutputLinkPortRef::new(from_id, "out"),
+            InputLinkPortRef::new(to_id, "in"),
+        )
+    }
+
+    fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("current-thread runtime")
+            .block_on(fut)
+    }
+
+    /// Collects the message of every `WARN`-level tracing event so a test can
+    /// assert the connect-time schema warn actually fired.
+    #[derive(Clone, Default)]
+    struct CapturedWarnings(Arc<Mutex<Vec<String>>>);
+
+    struct WarnMessageVisitor<'a>(&'a mut String);
+    impl Visit for WarnMessageVisitor<'_> {
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            if field.name() == "message" {
+                use std::fmt::Write;
+                let _ = write!(self.0, "{value:?}");
+            }
+        }
+    }
+
+    impl<S: tracing::Subscriber> Layer<S> for CapturedWarnings {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+            if *event.metadata().level() == tracing::Level::WARN {
+                let mut message = String::new();
+                event.record(&mut WarnMessageVisitor(&mut message));
+                self.0.lock().unwrap().push(message);
+            }
+        }
+    }
+
+    #[test]
+    fn loose_connect_warns_but_wires_a_mismatched_link() {
+        let (compiler, from, to) = compiler_with_mismatched_pair();
+        let warnings = CapturedWarnings::default();
+        let subscriber = tracing_subscriber::registry().with(warnings.clone());
+
+        let result = tracing::subscriber::with_default(subscriber, || {
+            block_on(connect_impl(
+                compiler,
+                from,
+                to,
+                SchemaValidationPosture::Loose,
+            ))
+        });
+
+        result.expect("loose posture must wire the mismatched link, not fail");
+
+        let captured = warnings.0.lock().unwrap();
+        assert!(
+            captured
+                .iter()
+                .any(|m| m.contains("does not match consumer input")),
+            "loose connect over a concrete producer/consumer schema mismatch must \
+             emit the connect-time warn; captured WARN messages: {captured:?}"
+        );
+    }
+
+    #[test]
+    fn strict_connect_rejects_a_mismatched_link() {
+        let (compiler, from, to) = compiler_with_mismatched_pair();
+        let err = block_on(connect_impl(
+            compiler,
+            from,
+            to,
+            SchemaValidationPosture::Strict,
+        ))
+        .expect_err("strict posture must reject the mismatched link");
+        assert!(
+            matches!(err, Error::SchemaIdentMismatch { .. }),
+            "strict connect over a concrete schema mismatch must surface \
+             Error::SchemaIdentMismatch; got {err:?}"
+        );
+    }
+}

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -153,10 +153,19 @@ async fn remove_processor_impl(
 /// Core implementation for connect - takes owned Arcs for 'static lifetime.
 ///
 /// `validation` selects the schema-agreement posture for this wiring site.
-/// The public `connect` / `connect_async` entrypoints pass
-/// [`SchemaValidationPosture::Loose`] (warn-but-wire); a safety-critical
-/// wiring site passes [`SchemaValidationPosture::Strict`] to hard-fail on a
-/// producer/consumer schema mismatch.
+/// Every public caller (`connect` / `connect_async`) currently passes
+/// [`SchemaValidationPosture::Loose`] (warn-but-wire). The
+/// [`Strict`][SchemaValidationPosture::Strict] mechanism — hard-failing a
+/// concrete producer/consumer schema mismatch with
+/// [`Error::SchemaIdentMismatch`] — is complete and revert-locked by tests, but
+/// has no public caller yet: the strict opt-in lands with the #1419 per-channel
+/// wiring surface. Until then Strict is intentionally dormant (owner decision
+/// (a), 2026-07-20) and reachable only through this `_impl` entry.
+#[tracing::instrument(
+    name = "runtime.connect",
+    skip(compiler),
+    fields(from = %from, to = %to, validation = ?validation),
+)]
 async fn connect_impl(
     compiler: Arc<Compiler>,
     from: OutputLinkPortRef,

--- a/runtime/streamlib-engine/src/core/schema_agreement.rs
+++ b/runtime/streamlib-engine/src/core/schema_agreement.rs
@@ -1,0 +1,311 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Producer/consumer schema-agreement checks for a wired link.
+//!
+//! Every frame already carries a 128-byte [`SchemaIdentWire`] tag stamped from
+//! the producer's output [`PortSchemaSpec`]; this module is the single place
+//! that reads the two ends and decides whether they agree. Two surfaces feed
+//! it:
+//!
+//! - Connect-time: two [`PortSchemaSpec`]s (producer output vs consumer input),
+//!   resolved from the registry before the link is wired.
+//! - Runtime: two [`SchemaIdentWire`]s (the tag stamped on an inbound frame vs
+//!   the consumer port's expected tag), compared per read.
+//!
+//! Agreement is intentionally permissive: an `Any` / unset tag on *either* side
+//! is the tolerant wildcard and never mismatches. Only two concrete-but-unequal
+//! schemas are a mismatch. The default posture is [loose-but-observed][Loose] —
+//! a mismatch is a `tracing::warn`, not a hard error — matching the #1345 design
+//! (a graph that ran yesterday must not stop running because a port was
+//! re-typed). A safety-critical wiring site opts into [`Strict`][Strict] to turn
+//! that warn into a typed [`Error::SchemaIdentMismatch`] at the wiring site.
+//!
+//! [`SchemaIdentWire`]: crate::iceoryx2::SchemaIdentWire
+//! [`PortSchemaSpec`]: streamlib_processor_schema::PortSchemaSpec
+//! [Loose]: SchemaValidationPosture::Loose
+//! [Strict]: SchemaValidationPosture::Strict
+//! [`Error::SchemaIdentMismatch`]: crate::core::error::Error::SchemaIdentMismatch
+
+use streamlib_processor_schema::PortSchemaSpec;
+
+use crate::core::error::{Error, Result};
+use crate::iceoryx2::SchemaIdentWire;
+
+/// How aggressively a wiring site enforces producer/consumer schema agreement.
+///
+/// The engine-wide default is [`Loose`](Self::Loose): a mismatch is observed
+/// (warned) but the link is still wired, so a re-typed port never silently
+/// stops a running graph. A safety-critical channel selects
+/// [`Strict`](Self::Strict) to hard-fail the wiring instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SchemaValidationPosture {
+    /// Warn on a concrete mismatch, then wire the link anyway.
+    #[default]
+    Loose,
+    /// Reject the wiring with [`Error::SchemaIdentMismatch`] on a concrete
+    /// mismatch.
+    ///
+    /// [`Error::SchemaIdentMismatch`]: crate::core::error::Error::SchemaIdentMismatch
+    Strict,
+}
+
+/// Whether a producer schema and a consumer schema agree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemaAgreement {
+    /// The two ends agree — identical concrete schemas, or a wildcard
+    /// (`Any` / unset) on at least one side.
+    Compatible,
+    /// Both ends declare a concrete schema and the two differ.
+    Mismatch,
+}
+
+/// Classify two resolved port specs at a connect-time wiring site.
+///
+/// A wildcard ([`PortSchemaSpec::Any`]) — or an unresolved
+/// [`PortSchemaSpec::Named`], which the registry never yields for a wired link
+/// but is handled here defensively — on either side is
+/// [`Compatible`](SchemaAgreement::Compatible): the check can only assert a
+/// mismatch when *both* ends are concrete [`PortSchemaSpec::Specific`].
+pub fn classify_port_schema_agreement(
+    producer: &PortSchemaSpec,
+    consumer: &PortSchemaSpec,
+) -> SchemaAgreement {
+    match (producer.specific(), consumer.specific()) {
+        (Some(producer_ident), Some(consumer_ident)) => {
+            if producer_ident == consumer_ident {
+                SchemaAgreement::Compatible
+            } else {
+                SchemaAgreement::Mismatch
+            }
+        }
+        // A wildcard / unresolved end can carry any payload — no assertion.
+        _ => SchemaAgreement::Compatible,
+    }
+}
+
+/// Classify a stamped inbound-frame tag against a consumer port's expected tag.
+///
+/// An [unset][SchemaIdentWire::is_unset] tag on either side is the wildcard and
+/// never mismatches; two set-but-unequal tags are a mismatch.
+pub fn classify_wire_schema_agreement(
+    stamped: &SchemaIdentWire,
+    expected: &SchemaIdentWire,
+) -> SchemaAgreement {
+    if stamped.is_unset() || expected.is_unset() {
+        SchemaAgreement::Compatible
+    } else if stamped == expected {
+        SchemaAgreement::Compatible
+    } else {
+        SchemaAgreement::Mismatch
+    }
+}
+
+/// Diagnostic context for a connect-time agreement check — the endpoints being
+/// wired, so a warn / error names the exact link.
+pub struct ConnectSchemaContext<'a> {
+    pub from_processor: &'a str,
+    pub from_port: &'a str,
+    pub to_processor: &'a str,
+    pub to_port: &'a str,
+}
+
+/// Enforce producer/consumer schema agreement at a connect-time wiring site.
+///
+/// Returns `Ok(())` when the two ends are [`Compatible`](SchemaAgreement::Compatible).
+/// On a [`Mismatch`](SchemaAgreement::Mismatch) the [posture][SchemaValidationPosture]
+/// decides: [`Loose`](SchemaValidationPosture::Loose) logs a `tracing::warn` and
+/// returns `Ok(())`; [`Strict`](SchemaValidationPosture::Strict) returns
+/// [`Error::SchemaIdentMismatch`] so the caller rolls the link back.
+pub fn enforce_connect_schema_agreement(
+    producer: &PortSchemaSpec,
+    consumer: &PortSchemaSpec,
+    posture: SchemaValidationPosture,
+    ctx: ConnectSchemaContext<'_>,
+) -> Result<()> {
+    if classify_port_schema_agreement(producer, consumer) == SchemaAgreement::Compatible {
+        return Ok(());
+    }
+
+    match posture {
+        SchemaValidationPosture::Loose => {
+            tracing::warn!(
+                from_processor = ctx.from_processor,
+                from_port = ctx.from_port,
+                to_processor = ctx.to_processor,
+                to_port = ctx.to_port,
+                producer_schema = %producer,
+                consumer_schema = %consumer,
+                "connect: producer output schema does not match consumer input \
+                 schema — wiring the link anyway (loose validation). Relax a port \
+                 to `any` to silence this, or opt the channel into strict \
+                 validation to hard-fail instead."
+            );
+            Ok(())
+        }
+        SchemaValidationPosture::Strict => Err(Error::SchemaIdentMismatch {
+            from_processor: ctx.from_processor.to_string(),
+            from_port: ctx.from_port.to_string(),
+            to_processor: ctx.to_processor.to_string(),
+            to_port: ctx.to_port.to_string(),
+            producer_schema: producer.to_string(),
+            consumer_schema: consumer.to_string(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use streamlib_idents::{Org, Package, SchemaIdent, SemVer, TypeName};
+
+    fn spec(org: &str, package: &str, ty: &str, major: u32) -> PortSchemaSpec {
+        PortSchemaSpec::Specific(SchemaIdent::new(
+            Org::new(org).unwrap(),
+            Package::new(package).unwrap(),
+            TypeName::new(ty).unwrap(),
+            SemVer::new(major, 0, 0),
+        ))
+    }
+
+    fn ctx() -> ConnectSchemaContext<'static> {
+        ConnectSchemaContext {
+            from_processor: "producer1",
+            from_port: "out",
+            to_processor: "consumer1",
+            to_port: "in",
+        }
+    }
+
+    #[test]
+    fn wildcard_on_either_side_is_compatible() {
+        let a = spec("tatolab", "core", "VideoFrame", 1);
+        assert_eq!(
+            classify_port_schema_agreement(&PortSchemaSpec::Any, &a),
+            SchemaAgreement::Compatible,
+            "an `any` producer accepts any consumer",
+        );
+        assert_eq!(
+            classify_port_schema_agreement(&a, &PortSchemaSpec::Any),
+            SchemaAgreement::Compatible,
+            "an `any` consumer accepts any producer",
+        );
+        assert_eq!(
+            classify_port_schema_agreement(&PortSchemaSpec::Any, &PortSchemaSpec::Any),
+            SchemaAgreement::Compatible,
+        );
+    }
+
+    #[test]
+    fn identical_concrete_specs_are_compatible() {
+        let a = spec("tatolab", "core", "VideoFrame", 1);
+        assert_eq!(
+            classify_port_schema_agreement(&a, &a.clone()),
+            SchemaAgreement::Compatible,
+        );
+    }
+
+    /// Revert lock: two distinct concrete specs MUST classify as a mismatch.
+    /// Mentally revert the comparison to always-`Compatible` and this fails —
+    /// which is exactly the "no consumer reads the tag" gap #1430 closes.
+    #[test]
+    fn distinct_concrete_specs_mismatch() {
+        let producer = spec("tatolab", "core", "VideoFrame", 1);
+        let consumer = spec("tatolab", "core", "AudioFrame", 1);
+        assert_eq!(
+            classify_port_schema_agreement(&producer, &consumer),
+            SchemaAgreement::Mismatch,
+        );
+        // Same type, different major version is still a concrete mismatch.
+        let consumer_v2 = spec("tatolab", "core", "VideoFrame", 2);
+        assert_eq!(
+            classify_port_schema_agreement(&producer, &consumer_v2),
+            SchemaAgreement::Mismatch,
+        );
+    }
+
+    #[test]
+    fn loose_mismatch_warns_but_does_not_fail() {
+        let producer = spec("tatolab", "core", "VideoFrame", 1);
+        let consumer = spec("tatolab", "core", "AudioFrame", 1);
+        enforce_connect_schema_agreement(
+            &producer,
+            &consumer,
+            SchemaValidationPosture::Loose,
+            ctx(),
+        )
+        .expect("loose posture must warn, not fail, on a mismatch");
+    }
+
+    /// Revert lock for strict opt-in: a concrete mismatch under `Strict` MUST
+    /// hard-fail with the typed [`Error::SchemaIdentMismatch`] naming both
+    /// schemas and the link endpoints.
+    #[test]
+    fn strict_mismatch_hard_fails_with_typed_error() {
+        let producer = spec("tatolab", "core", "VideoFrame", 1);
+        let consumer = spec("tatolab", "core", "AudioFrame", 1);
+        let err = enforce_connect_schema_agreement(
+            &producer,
+            &consumer,
+            SchemaValidationPosture::Strict,
+            ctx(),
+        )
+        .expect_err("strict posture must hard-fail on a mismatch");
+
+        assert!(
+            matches!(err, Error::SchemaIdentMismatch { .. }),
+            "strict mismatch must surface Error::SchemaIdentMismatch; got {err:?}",
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("VideoFrame"), "message names producer: {msg}");
+        assert!(msg.contains("AudioFrame"), "message names consumer: {msg}");
+        assert!(msg.contains("producer1"), "message names endpoints: {msg}");
+    }
+
+    #[test]
+    fn strict_is_silent_when_schemas_agree() {
+        let a = spec("tatolab", "core", "VideoFrame", 1);
+        enforce_connect_schema_agreement(&a, &a.clone(), SchemaValidationPosture::Strict, ctx())
+            .expect("matching schemas must pass even under strict validation");
+        enforce_connect_schema_agreement(
+            &PortSchemaSpec::Any,
+            &a,
+            SchemaValidationPosture::Strict,
+            ctx(),
+        )
+        .expect("a wildcard end must pass even under strict validation");
+    }
+
+    #[test]
+    fn wire_agreement_treats_unset_as_wildcard() {
+        let set = SchemaIdentWire::from_segments("tatolab", "core", "VideoFrame", 1, 0, 0).unwrap();
+        let unset = SchemaIdentWire::default();
+        assert_eq!(
+            classify_wire_schema_agreement(&unset, &set),
+            SchemaAgreement::Compatible,
+        );
+        assert_eq!(
+            classify_wire_schema_agreement(&set, &unset),
+            SchemaAgreement::Compatible,
+        );
+        assert_eq!(
+            classify_wire_schema_agreement(&set, &set),
+            SchemaAgreement::Compatible,
+        );
+    }
+
+    /// Revert lock for the runtime read path: two distinct stamped/expected
+    /// tags MUST classify as a mismatch. Reverting the per-frame tag read to
+    /// "ignore the tag" collapses this to `Compatible` and fails here.
+    #[test]
+    fn wire_agreement_flags_distinct_set_tags() {
+        let stamped =
+            SchemaIdentWire::from_segments("tatolab", "core", "VideoFrame", 1, 0, 0).unwrap();
+        let expected =
+            SchemaIdentWire::from_segments("tatolab", "core", "AudioFrame", 1, 0, 0).unwrap();
+        assert_eq!(
+            classify_wire_schema_agreement(&stamped, &expected),
+            SchemaAgreement::Mismatch,
+        );
+    }
+}

--- a/runtime/streamlib-engine/src/iceoryx2/input.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/input.rs
@@ -30,6 +30,7 @@ use std::cell::UnsafeCell;
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use iceoryx2::port::listener::Listener;
 use iceoryx2::port::subscriber::Subscriber;
@@ -39,8 +40,9 @@ use streamlib_plugin_abi::InputMailboxesVTable;
 
 use super::mailbox::PortMailbox;
 use super::read_mode::ReadMode;
-use super::{FRAME_HEADER_SIZE, FrameHeader};
+use super::{FRAME_HEADER_SIZE, FrameHeader, SchemaIdentWire};
 use crate::core::error::{Error, Result};
+use crate::core::schema_agreement::{SchemaAgreement, classify_wire_schema_agreement};
 
 /// Thread-local subscriber wrapper.
 ///
@@ -127,6 +129,20 @@ struct PortConfig {
     /// [`InputMailboxesInner::set_port_max_payload_bytes`] from the
     /// compiler op).
     max_payload_bytes: usize,
+    /// Schema-ident tag this consumer port expects every inbound frame to
+    /// carry — the wire form of the port's declared input schema, set by the
+    /// compiler op at wire time via
+    /// [`InputMailboxesInner::set_port_expected_schema_ident`]. Default
+    /// [`SchemaIdentWire::default`] (unset) means "no expectation" (an `any`
+    /// port), which never triggers a mismatch. `read_raw` compares each
+    /// frame's stamped tag against this and warns on a concrete mismatch.
+    expected_schema_ident: SchemaIdentWire,
+    /// Latched once `read_raw` observes an inbound tag that disagrees with
+    /// [`Self::expected_schema_ident`]. Doubles as the warn-once guard (the
+    /// realtime read path must not re-log every frame) and the test / graph
+    /// observation surface via
+    /// [`InputMailboxesInner::schema_mismatch_observed`].
+    schema_mismatch_observed: AtomicBool,
 }
 
 /// Host-side inner state for input mailboxes. Owns the per-port
@@ -180,6 +196,8 @@ impl InputMailboxesInner {
                 mailbox: PortMailbox::new(buffer_size),
                 read_mode,
                 max_payload_bytes: crate::iceoryx2::MAX_PAYLOAD_SIZE,
+                expected_schema_ident: SchemaIdentWire::default(),
+                schema_mismatch_observed: AtomicBool::new(false),
             },
         );
     }
@@ -205,6 +223,33 @@ impl InputMailboxesInner {
     /// surfaces this as `0`, the caller's wiring-error sentinel).
     pub fn max_payload_for_port(&self, port: &str) -> Option<usize> {
         self.ports.lock().get(port).map(|cfg| cfg.max_payload_bytes)
+    }
+
+    /// Record the schema-ident tag this port expects inbound frames to carry.
+    /// Called by the compiler op at wire time from the consumer's declared
+    /// input schema; [`read_raw`] compares each frame's stamped tag against it
+    /// and warns on a concrete mismatch. No-op for unknown ports.
+    ///
+    /// [`read_raw`]: Self::read_raw
+    pub fn set_port_expected_schema_ident(&self, port: &str, expected: SchemaIdentWire) {
+        if let Some(cfg) = self.ports.lock().get_mut(port) {
+            cfg.expected_schema_ident = expected;
+            cfg.schema_mismatch_observed.store(false, Ordering::Relaxed);
+        }
+    }
+
+    /// Whether [`read_raw`] has observed at least one inbound frame whose
+    /// stamped schema tag disagreed with the port's expected tag. Latches on
+    /// the first mismatch (the read path warns once, not per frame). `false`
+    /// for unknown ports.
+    ///
+    /// [`read_raw`]: Self::read_raw
+    pub fn schema_mismatch_observed(&self, port: &str) -> bool {
+        self.ports
+            .lock()
+            .get(port)
+            .map(|cfg| cfg.schema_mismatch_observed.load(Ordering::Relaxed))
+            .unwrap_or(false)
     }
 
     /// Check if a subscriber has already been configured.
@@ -324,6 +369,22 @@ impl InputMailboxesInner {
         match raw {
             Some(r) => {
                 let header = FrameHeader::read_from_slice(&r);
+                if classify_wire_schema_agreement(header.schema(), &port_config.expected_schema_ident)
+                    == SchemaAgreement::Mismatch
+                    && !port_config
+                        .schema_mismatch_observed
+                        .swap(true, Ordering::Relaxed)
+                {
+                    tracing::warn!(
+                        port = port,
+                        stamped_schema = %header.schema().render_joined(),
+                        expected_schema = %port_config.expected_schema_ident.render_joined(),
+                        "read_raw: inbound frame carries a schema tag that does not \
+                         match this port's expected input schema (loose validation; \
+                         warned once per port). A producer was re-typed, or the \
+                         wrong producer is wired to this port."
+                    );
+                }
                 let data = r[FRAME_HEADER_SIZE..FRAME_HEADER_SIZE + header.len as usize].to_vec();
                 Ok(Some((data, header.timestamp_ns)))
             }
@@ -782,6 +843,70 @@ mod tests {
             !mailboxes.any_port_has_data(),
             "both ports drained — must report no data",
         );
+    }
+
+    fn frame_with_schema(port: &str, schema: SchemaIdentWire) -> Vec<u8> {
+        let mut buf = vec![0u8; FRAME_HEADER_SIZE + 4];
+        let header = FrameHeader::new(port, schema, 0, 4).expect("port fits PortKey");
+        header.write_to_slice(&mut buf);
+        buf[FRAME_HEADER_SIZE..].copy_from_slice(&[9, 8, 7, 6]);
+        buf
+    }
+
+    /// Runtime read-side schema check (#1430): a frame whose stamped schema
+    /// tag disagrees with the port's expected input schema is observed as a
+    /// mismatch, but the read still succeeds (loose-but-observed posture).
+    ///
+    /// Revert lock: mentally revert `read_raw`'s tag comparison (stop reading
+    /// `header.schema()`) and `schema_mismatch_observed` stays `false` — this
+    /// asserts `true`, so the test fails, catching a regression back to the
+    /// pre-#1430 "stamped-but-unread" state.
+    #[test]
+    fn read_raw_observes_schema_tag_mismatch_but_still_delivers() {
+        let mailboxes = InputMailboxesInner::new();
+        mailboxes.add_port("in", 64, ReadMode::ReadNextInOrder);
+
+        let expected =
+            SchemaIdentWire::from_segments("tatolab", "core", "VideoFrame", 1, 0, 0).unwrap();
+        mailboxes.set_port_expected_schema_ident("in", expected);
+
+        let stamped_wrong =
+            SchemaIdentWire::from_segments("tatolab", "core", "AudioFrame", 1, 0, 0).unwrap();
+        assert!(mailboxes.route(frame_with_schema("in", stamped_wrong)));
+
+        let read = mailboxes
+            .read_raw("in")
+            .expect("read_raw must succeed under loose validation")
+            .expect("a frame is queued");
+        assert_eq!(read.0, vec![9, 8, 7, 6], "payload delivered despite mismatch");
+        assert!(
+            mailboxes.schema_mismatch_observed("in"),
+            "the disagreeing tag must be observed as a mismatch",
+        );
+    }
+
+    /// A frame whose stamped tag matches the port's expected schema is NOT
+    /// flagged; the wildcard cases (unset expected, or unset stamp) are
+    /// likewise silent.
+    #[test]
+    fn read_raw_is_silent_on_matching_or_wildcard_schema() {
+        let matching = SchemaIdentWire::from_segments("tatolab", "core", "VideoFrame", 1, 0, 0)
+            .unwrap();
+
+        // Exact match → no mismatch.
+        let mb_match = InputMailboxesInner::new();
+        mb_match.add_port("in", 64, ReadMode::ReadNextInOrder);
+        mb_match.set_port_expected_schema_ident("in", matching);
+        assert!(mb_match.route(frame_with_schema("in", matching)));
+        mb_match.read_raw("in").unwrap().unwrap();
+        assert!(!mb_match.schema_mismatch_observed("in"));
+
+        // Unset expected (an `any` port) accepts any stamped tag.
+        let mb_any = InputMailboxesInner::new();
+        mb_any.add_port("in", 64, ReadMode::ReadNextInOrder);
+        assert!(mb_any.route(frame_with_schema("in", matching)));
+        mb_any.read_raw("in").unwrap().unwrap();
+        assert!(!mb_any.schema_mismatch_observed("in"));
     }
 
     /// Empty (unwired) PluginAbiObject should return Ok(None) from read_raw

--- a/runtime/streamlib-ipc-types/src/lib.rs
+++ b/runtime/streamlib-ipc-types/src/lib.rs
@@ -284,6 +284,21 @@ impl SchemaIdentWire {
         Ok(wire)
     }
 
+    /// Whether this is the zero-segment "unset" wire tag a producer stamps
+    /// for a [`PortSchemaSpec::Any`] output — no org / package / type and a
+    /// `0.0.0` version. Schema-agreement checks treat an unset tag on either
+    /// side as the tolerant wildcard: it never triggers a mismatch.
+    ///
+    /// [`PortSchemaSpec::Any`]: https://docs.rs/streamlib-processor-schema
+    pub fn is_unset(&self) -> bool {
+        self.org_len == 0
+            && self.package_len == 0
+            && self.type_len == 0
+            && self.version_major == 0
+            && self.version_minor == 0
+            && self.version_patch == 0
+    }
+
     pub fn org_str(&self) -> &str {
         std::str::from_utf8(&self.org[..self.org_len as usize]).unwrap_or("")
     }

--- a/sdk/streamlib-error/src/lib.rs
+++ b/sdk/streamlib-error/src/lib.rs
@@ -106,6 +106,22 @@ pub enum Error {
         direction: PortDirection,
     },
 
+    #[error(
+        "Schema-ident mismatch on link {from_processor}:{from_port} -> \
+         {to_processor}:{to_port}: producer emits `{producer_schema}` but consumer \
+         port `{to_port}` expects `{consumer_schema}`. Strict schema validation was \
+         requested for this wiring site — align the two schemas, or relax a port to \
+         `any` to accept the mismatch."
+    )]
+    SchemaIdentMismatch {
+        from_processor: String,
+        from_port: String,
+        to_processor: String,
+        to_port: String,
+        producer_schema: String,
+        consumer_schema: String,
+    },
+
     #[error("Buffer operation failed: {0}")]
     BufferError(String),
 


### PR DESCRIPTION
Refs #1430 (partial — does **not** close it; see scope below).

## What
Wires up the stamped-but-unread 128-byte `SchemaIdentWire` tag so a producer/consumer schema mismatch is finally observed:
- The consumer path reads the tag on each frame (`iceoryx2/input.rs::read_raw`) and, on a concrete mismatch, warns once (`schema_mismatch_observed`).
- `connect()` compares the producer's stamped schema ident against the consumer port's expected schema and emits a `tracing::warn` on mismatch — **loose-but-observed** (warn, not hard-fail), per design #1345 §02/§11.
- The `SchemaValidationPosture::Strict` hard-fail mechanism (typed `Error::SchemaIdentMismatch`) is implemented and revert-locked, but **intentionally dormant**: every public caller passes `Loose`. Its opt-in surface belongs to the per-channel config that #1419 builds.

## Scope (owner decision (a), 2026-07-20)
Acceptance criteria 1, 2, 4, 5 are delivered. **Criterion 3 (a safety-critical channel opts into strict validation) intentionally remains** — the public strict opt-in lands with #1419's per-channel surface, so criterion 3 is split out as **blocked_by #1419**. This PR ships the production-reachable core win now rather than parking it under the #1419 rewrite.

## Fixes applied on top of the initial implementation (verify should-fixes)
- **Revert-lock criterion 2:** a connect-path integration test drives `connect_impl` end-to-end with mismatched schemas — `loose_connect_warns_but_wires_a_mismatched_link` (asserts the warn fires and the link still wires) and `strict_connect_rejects_a_mismatched_link` (asserts `Err(SchemaIdentMismatch)`). Neutering the `enforce_connect_schema_agreement` call fails both.
- `#[tracing::instrument]` on `connect_impl` (criterion 4); `read_raw` left uninstrumented (per-frame realtime path).
- **DRY (called out, no silent extraction):** `resolve_node_port_schema(graph, proc_id, port, direction) -> PortSchemaSpec` extracted beside `port_schema_spec` in `embedded_schemas`; `connect_impl` (×2) and `open_iceoryx2_service_op::resolve_port_schema` both delegate to it.
- Corrected the `connect_impl` rustdoc that previously claimed a strict wiring site exists.

## Tests / gates
Engine lib suite green; the two new connect-path tests + the existing `read_raw` revert-locks pass. Local gate battery: **20 passed, 0 failed** (3 skipped: rig hardware-tier + PR-title + release automation — not local-runnable).

## Merge-order note
#1419 (channel-centric service naming) is in flight and rewrites this same connect path + `iceoryx2/input.rs`. This small partial should merge first; #1419 rebases onto it and preserves the schema-agreement check (coordination note on #1419).

🤖 Generated with [Claude Code](https://claude.com/claude-code)