### PR TITLE
feat(engine): strict schema-validation opt-in at the connect wiring site

### DIFF
--- a/runtime/streamlib-engine/src/core/runtime/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/mod.rs
@@ -28,7 +28,7 @@ pub(crate) use module_loader::{
     lookup_schema_via_active_cdylib_sink, stage_processor_via_active_cdylib_sink,
     stage_schema_via_active_cdylib_sink,
 };
-pub use operations::{BoxFuture, RuntimeOperations};
+pub use operations::{BoxFuture, ConnectOptions, RuntimeOperations, SchemaValidationPosture};
 pub use runtime::Runner;
 pub use runtime_unique_id::RuntimeUniqueId;
 pub use status::RuntimeStatus;

--- a/runtime/streamlib-engine/src/core/runtime/operations.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations.rs
@@ -21,10 +21,6 @@ pub use crate::core::schema_agreement::SchemaValidationPosture;
 /// [`ConnectOptions::strict`] so the same mismatch instead hard-fails at the
 /// wiring site with [`Error::SchemaIdentMismatch`].
 ///
-/// Non-exhaustive so new per-wiring-site knobs can be added without breaking
-/// call sites — construct via [`ConnectOptions::default`],
-/// [`ConnectOptions::strict`], or [`ConnectOptions::with_validation`].
-///
 /// [`Error::SchemaIdentMismatch`]: crate::core::error::Error::SchemaIdentMismatch
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]

--- a/runtime/streamlib-engine/src/core/runtime/operations.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations.rs
@@ -11,6 +11,55 @@ use std::pin::Pin;
 /// Boxed future type for async trait methods (required for dyn compatibility).
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
+pub use crate::core::schema_agreement::SchemaValidationPosture;
+
+/// Per-wiring-site options for a connect call.
+///
+/// The default is the engine-wide loose-but-observed schema validation
+/// ([`SchemaValidationPosture::Loose`]): a concrete producer/consumer schema
+/// mismatch warns but the link is still wired. A safety-critical channel selects
+/// [`ConnectOptions::strict`] so the same mismatch instead hard-fails at the
+/// wiring site with [`Error::SchemaIdentMismatch`].
+///
+/// Non-exhaustive so new per-wiring-site knobs can be added without breaking
+/// call sites — construct via [`ConnectOptions::default`],
+/// [`ConnectOptions::strict`], or [`ConnectOptions::with_validation`].
+///
+/// [`Error::SchemaIdentMismatch`]: crate::core::error::Error::SchemaIdentMismatch
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct ConnectOptions {
+    /// Schema-agreement posture applied when the link is wired.
+    pub validation: SchemaValidationPosture,
+}
+
+impl ConnectOptions {
+    /// Loose-but-observed validation — the engine-wide default; a concrete
+    /// schema mismatch warns, then wires the link anyway.
+    pub fn loose() -> Self {
+        Self {
+            validation: SchemaValidationPosture::Loose,
+        }
+    }
+
+    /// Strict validation — a concrete producer/consumer schema mismatch is
+    /// rejected at the wiring site with [`Error::SchemaIdentMismatch`].
+    ///
+    /// [`Error::SchemaIdentMismatch`]: crate::core::error::Error::SchemaIdentMismatch
+    pub fn strict() -> Self {
+        Self {
+            validation: SchemaValidationPosture::Strict,
+        }
+    }
+
+    /// Set the schema-validation posture explicitly.
+    #[must_use]
+    pub fn with_validation(mut self, validation: SchemaValidationPosture) -> Self {
+        self.validation = validation;
+        self
+    }
+}
+
 /// Unified interface for runtime graph operations.
 ///
 /// Implemented by `Runner` (direct) and `RuntimeProxy` (channel-based).

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use super::Runner;
-use super::operations::{BoxFuture, RuntimeOperations};
+use super::operations::{BoxFuture, ConnectOptions, RuntimeOperations};
 use super::runtime::TokioRuntimeVariant;
 use crate::core::compiler::{Compiler, PendingOperation};
 use crate::core::graph::{
@@ -153,14 +153,13 @@ async fn remove_processor_impl(
 /// Core implementation for connect - takes owned Arcs for 'static lifetime.
 ///
 /// `validation` selects the schema-agreement posture for this wiring site.
-/// Every public caller (`connect` / `connect_async`) currently passes
-/// [`SchemaValidationPosture::Loose`] (warn-but-wire). The
-/// [`Strict`][SchemaValidationPosture::Strict] mechanism — hard-failing a
-/// concrete producer/consumer schema mismatch with
-/// [`Error::SchemaIdentMismatch`] — is complete and revert-locked by tests, but
-/// has no public caller yet: the strict opt-in lands with the #1419 per-channel
-/// wiring surface. Until then Strict is intentionally dormant (owner decision
-/// (a), 2026-07-20) and reachable only through this `_impl` entry.
+/// [`connect`](Runner::connect) / [`connect_async`](RuntimeOperations::connect_async)
+/// pass [`SchemaValidationPosture::Loose`] (warn-but-wire); the
+/// [`connect_with`](Runner::connect_with) opt-in passes the caller's
+/// [`ConnectOptions`] posture, so a safety-critical channel selects
+/// [`Strict`][SchemaValidationPosture::Strict] to hard-fail a concrete
+/// producer/consumer schema mismatch with [`Error::SchemaIdentMismatch`]
+/// instead of only warning.
 #[tracing::instrument(
     name = "runtime.connect",
     skip(compiler),
@@ -498,6 +497,61 @@ impl RuntimeOperations for Runner {
     }
 }
 
+impl Runner {
+    /// Connect two ports under explicit [`ConnectOptions`] — the strict
+    /// schema-validation opt-in for a safety-critical wiring site.
+    ///
+    /// [`connect`](RuntimeOperations::connect) is the loose-but-observed default
+    /// (a concrete producer/consumer schema mismatch warns, then wires the link
+    /// anyway); this threads the caller's posture into the same wiring path, so
+    /// under [`ConnectOptions::strict`] the mismatch instead hard-fails with
+    /// [`Error::SchemaIdentMismatch`] and the link is not wired.
+    pub fn connect_with(
+        &self,
+        from: impl Into<OutputLinkPortRef>,
+        to: impl Into<InputLinkPortRef>,
+        options: ConnectOptions,
+    ) -> Result<LinkUniqueId> {
+        let from = from.into();
+        let to = to.into();
+        match &self.tokio_runtime_variant {
+            TokioRuntimeVariant::OwnedTokioRuntime(rt) => rt.block_on(connect_impl(
+                Arc::clone(&self.compiler),
+                from,
+                to,
+                options.validation,
+            )),
+            TokioRuntimeVariant::ExternalTokioHandle(handle) => {
+                let compiler = Arc::clone(&self.compiler);
+                let (tx, rx) = std::sync::mpsc::channel();
+                handle.spawn(async move {
+                    let result = connect_impl(compiler, from, to, options.validation).await;
+                    let _ = tx.send(result);
+                });
+                rx.recv()
+                    .map_err(|_| Error::Runtime("Task channel closed".into()))?
+            }
+        }
+    }
+
+    /// Async form of [`connect_with`](Self::connect_with) — safe from any
+    /// context, including a tokio task.
+    pub fn connect_with_async(
+        &self,
+        from: impl Into<OutputLinkPortRef>,
+        to: impl Into<InputLinkPortRef>,
+        options: ConnectOptions,
+    ) -> BoxFuture<'_, Result<LinkUniqueId>> {
+        let compiler = Arc::clone(&self.compiler);
+        Box::pin(connect_impl(
+            compiler,
+            from.into(),
+            to.into(),
+            options.validation,
+        ))
+    }
+}
+
 #[cfg(test)]
 mod channel_wire_bound_tests {
     // The channel-name grammar (streamlib_idents) and the fixed PortKey wire
@@ -550,7 +604,10 @@ mod connect_schema_agreement_tests {
     use tracing_subscriber::Layer;
     use tracing_subscriber::layer::{Context, SubscriberExt};
 
+    use serial_test::serial;
+
     use super::connect_impl;
+    use super::{ConnectOptions, Runner};
     use crate::core::Error;
     use crate::core::compiler::Compiler;
     use crate::core::descriptors::{PortDescriptor, ProcessorDescriptor};
@@ -712,5 +769,55 @@ mod connect_schema_agreement_tests {
             "strict connect over a concrete schema mismatch must surface \
              Error::SchemaIdentMismatch; got {err:?}"
         );
+    }
+
+    /// Criterion-3 revert lock for the *public* strict opt-in: driving the
+    /// `Runner::connect_with` authoring surface with [`ConnectOptions::strict`]
+    /// over a concrete producer/consumer schema mismatch hard-fails with the
+    /// typed [`Error::SchemaIdentMismatch`] and does not wire the link, while
+    /// [`ConnectOptions::default`] (loose) over the same pair still wires it.
+    ///
+    /// Mentally reverting `connect_with` to drop `options.validation` — routing
+    /// through the loose `connect` — makes the strict half return `Ok` and fails
+    /// here. The `connect_impl`-level tests above never exercise the public
+    /// surface, so they don't catch that regression.
+    #[test]
+    #[serial]
+    fn connect_with_strict_rejects_a_mismatched_link_via_the_public_surface() {
+        ensure_mismatch_types_registered();
+        let runtime = Runner::new().expect("runner builds");
+
+        let producer = runtime
+            .add_processor(ProcessorSpec::new(
+                ident("connectcheck", PRODUCER_TYPE),
+                Value::Null,
+            ))
+            .expect("producer node adds");
+        let consumer = runtime
+            .add_processor(ProcessorSpec::new(
+                ident("connectcheck", CONSUMER_TYPE),
+                Value::Null,
+            ))
+            .expect("consumer node adds");
+
+        let err = runtime
+            .connect_with(
+                OutputLinkPortRef::new(producer.clone(), "out"),
+                InputLinkPortRef::new(consumer.clone(), "in"),
+                ConnectOptions::strict(),
+            )
+            .expect_err("strict connect_with must reject the mismatched link");
+        assert!(
+            matches!(err, Error::SchemaIdentMismatch { .. }),
+            "public strict opt-in must surface Error::SchemaIdentMismatch; got {err:?}"
+        );
+
+        runtime
+            .connect_with(
+                OutputLinkPortRef::new(producer, "out"),
+                InputLinkPortRef::new(consumer, "in"),
+                ConnectOptions::default(),
+            )
+            .expect("loose connect_with over the same pair must still wire the link");
     }
 }

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -387,13 +387,7 @@ impl RuntimeOperations for Runner {
         from: OutputLinkPortRef,
         to: InputLinkPortRef,
     ) -> BoxFuture<'_, Result<LinkUniqueId>> {
-        let compiler = Arc::clone(&self.compiler);
-        Box::pin(connect_impl(
-            compiler,
-            from,
-            to,
-            SchemaValidationPosture::Loose,
-        ))
+        self.connect_with_async(from, to, ConnectOptions::loose())
     }
 
     fn disconnect_async(&self, link_id: LinkUniqueId) -> BoxFuture<'_, Result<()>> {
@@ -453,20 +447,7 @@ impl RuntimeOperations for Runner {
     }
 
     fn connect(&self, from: OutputLinkPortRef, to: InputLinkPortRef) -> Result<LinkUniqueId> {
-        match &self.tokio_runtime_variant {
-            TokioRuntimeVariant::OwnedTokioRuntime(rt) => rt.block_on(self.connect_async(from, to)),
-            TokioRuntimeVariant::ExternalTokioHandle(handle) => {
-                let compiler = Arc::clone(&self.compiler);
-                let (tx, rx) = std::sync::mpsc::channel();
-                handle.spawn(async move {
-                    let result =
-                        connect_impl(compiler, from, to, SchemaValidationPosture::Loose).await;
-                    let _ = tx.send(result);
-                });
-                rx.recv()
-                    .map_err(|_| Error::Runtime("Task channel closed".into()))?
-            }
-        }
+        self.connect_with(from, to, ConnectOptions::loose())
     }
 
     fn disconnect(&self, link_id: &LinkUniqueId) -> Result<()> {

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -489,12 +489,10 @@ impl Runner {
     /// [`Error::SchemaIdentMismatch`] and the link is not wired.
     pub fn connect_with(
         &self,
-        from: impl Into<OutputLinkPortRef>,
-        to: impl Into<InputLinkPortRef>,
+        from: OutputLinkPortRef,
+        to: InputLinkPortRef,
         options: ConnectOptions,
     ) -> Result<LinkUniqueId> {
-        let from = from.into();
-        let to = to.into();
         match &self.tokio_runtime_variant {
             TokioRuntimeVariant::OwnedTokioRuntime(rt) => rt.block_on(connect_impl(
                 Arc::clone(&self.compiler),
@@ -519,17 +517,12 @@ impl Runner {
     /// context, including a tokio task.
     pub fn connect_with_async(
         &self,
-        from: impl Into<OutputLinkPortRef>,
-        to: impl Into<InputLinkPortRef>,
+        from: OutputLinkPortRef,
+        to: InputLinkPortRef,
         options: ConnectOptions,
     ) -> BoxFuture<'_, Result<LinkUniqueId>> {
         let compiler = Arc::clone(&self.compiler);
-        Box::pin(connect_impl(
-            compiler,
-            from.into(),
-            to.into(),
-            options.validation,
-        ))
+        Box::pin(connect_impl(compiler, from, to, options.validation))
     }
 }
 

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -801,4 +801,54 @@ mod connect_schema_agreement_tests {
             )
             .expect("loose connect_with over the same pair must still wire the link");
     }
+
+    /// Async counterpart to
+    /// [`connect_with_strict_rejects_a_mismatched_link_via_the_public_surface`]:
+    /// awaiting `Runner::connect_with_async` from inside a tokio task under
+    /// [`ConnectOptions::strict`] hard-fails a concrete producer/consumer schema
+    /// mismatch with the typed [`Error::SchemaIdentMismatch`] and does not wire
+    /// the link, while [`ConnectOptions::default`] (loose) over the same pair
+    /// still wires it.
+    ///
+    /// Mentally reverting `connect_with_async` to thread a hardcoded `Loose`
+    /// posture instead of `options.validation` makes the strict half return `Ok`
+    /// and fails here — the sync `connect_with` test never drives the async
+    /// opt-in path, so it doesn't catch that regression.
+    #[test]
+    #[serial]
+    fn connect_with_async_strict_rejects_a_mismatched_link_via_the_public_surface() {
+        ensure_mismatch_types_registered();
+        let runtime = Runner::new().expect("runner builds");
+
+        let producer = runtime
+            .add_processor(ProcessorSpec::new(
+                ident("connectcheck", PRODUCER_TYPE),
+                Value::Null,
+            ))
+            .expect("producer node adds");
+        let consumer = runtime
+            .add_processor(ProcessorSpec::new(
+                ident("connectcheck", CONSUMER_TYPE),
+                Value::Null,
+            ))
+            .expect("consumer node adds");
+
+        let err = block_on(runtime.connect_with_async(
+            OutputLinkPortRef::new(producer.clone(), "out"),
+            InputLinkPortRef::new(consumer.clone(), "in"),
+            ConnectOptions::strict(),
+        ))
+        .expect_err("strict connect_with_async must reject the mismatched link");
+        assert!(
+            matches!(err, Error::SchemaIdentMismatch { .. }),
+            "public async strict opt-in must surface Error::SchemaIdentMismatch; got {err:?}"
+        );
+
+        block_on(runtime.connect_with_async(
+            OutputLinkPortRef::new(producer, "out"),
+            InputLinkPortRef::new(consumer, "in"),
+            ConnectOptions::default(),
+        ))
+        .expect("loose connect_with_async over the same pair must still wire the link");
+    }
 }

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -749,7 +749,7 @@ mod connect_schema_agreement_tests {
     /// `Runner::connect_with` authoring surface with [`ConnectOptions::strict`]
     /// over a concrete producer/consumer schema mismatch hard-fails with the
     /// typed [`Error::SchemaIdentMismatch`] and does not wire the link, while
-    /// [`ConnectOptions::default`] (loose) over the same pair still wires it.
+    /// [`ConnectOptions::loose`] over the same pair still wires it.
     ///
     /// Mentally reverting `connect_with` to drop `options.validation` — routing
     /// through the loose `connect` — makes the strict half return `Ok` and fails
@@ -790,7 +790,7 @@ mod connect_schema_agreement_tests {
             .connect_with(
                 OutputLinkPortRef::new(producer, "out"),
                 InputLinkPortRef::new(consumer, "in"),
-                ConnectOptions::default(),
+                ConnectOptions::loose(),
             )
             .expect("loose connect_with over the same pair must still wire the link");
     }
@@ -800,7 +800,7 @@ mod connect_schema_agreement_tests {
     /// awaiting `Runner::connect_with_async` from inside a tokio task under
     /// [`ConnectOptions::strict`] hard-fails a concrete producer/consumer schema
     /// mismatch with the typed [`Error::SchemaIdentMismatch`] and does not wire
-    /// the link, while [`ConnectOptions::default`] (loose) over the same pair
+    /// the link, while [`ConnectOptions::loose`] over the same pair
     /// still wires it.
     ///
     /// Mentally reverting `connect_with_async` to thread a hardcoded `Loose`
@@ -840,7 +840,7 @@ mod connect_schema_agreement_tests {
         block_on(runtime.connect_with_async(
             OutputLinkPortRef::new(producer, "out"),
             InputLinkPortRef::new(consumer, "in"),
-            ConnectOptions::default(),
+            ConnectOptions::loose(),
         ))
         .expect("loose connect_with_async over the same pair must still wire the link");
     }

--- a/runtime/streamlib-engine/src/lib.rs
+++ b/runtime/streamlib-engine/src/lib.rs
@@ -63,6 +63,7 @@ pub use streamlib_macros::{
 };
 
 pub use core::{
+    ConnectOptions,
     ConnectionDefinition,
     // Processor traits (mode-specific)
     ContinuousProcessor,
@@ -85,6 +86,7 @@ pub use core::{
     RuntimeContext,
     RuntimeContextFullAccess,
     RuntimeContextLimitedAccess,
+    SchemaValidationPosture,
     Texture,
     TextureDescriptor,
     TextureFormat,

--- a/sdk/streamlib-sdk/src/sdk/app.rs
+++ b/sdk/streamlib-sdk/src/sdk/app.rs
@@ -16,7 +16,7 @@ use crate::sdk::RunnerAutoBuild;
 use crate::sdk::error::{Error, Result};
 use crate::sdk::graph::{InputLinkPortRef, LinkUniqueId, OutputLinkPortRef, ProcessorUniqueId};
 use crate::sdk::processors::{Config, GeneratedProcessor, ProcessorSpec, ProcessorTypeReference};
-use crate::sdk::runtime::Runner;
+use crate::sdk::runtime::{ConnectOptions, Runner};
 
 /// A `(processor, port)` endpoint for [`App::connect`]. The processor is
 /// referenced by the [`ProcessorUniqueId`] an `add`/`add_local` call returned;
@@ -100,6 +100,24 @@ impl App {
         self.runner.connect(
             OutputLinkPortRef::new(from.0, from.1),
             InputLinkPortRef::new(to.0, to.1),
+        )
+    }
+
+    /// Connect two endpoints under explicit [`ConnectOptions`] — the strict
+    /// schema-validation opt-in for a safety-critical channel. Under
+    /// [`ConnectOptions::strict`] a concrete producer/consumer schema mismatch
+    /// surfaces the runtime's [`Error::SchemaIdentMismatch`] at the wiring site
+    /// instead of only warning.
+    pub fn connect_with(
+        &self,
+        from: AppPortEndpoint<'_>,
+        to: AppPortEndpoint<'_>,
+        options: ConnectOptions,
+    ) -> Result<LinkUniqueId> {
+        self.runner.connect_with(
+            OutputLinkPortRef::new(from.0, from.1),
+            InputLinkPortRef::new(to.0, to.1),
+            options,
         )
     }
 

--- a/sdk/streamlib-sdk/tests/app_sugar_test.rs
+++ b/sdk/streamlib-sdk/tests/app_sugar_test.rs
@@ -190,7 +190,7 @@ fn app_connect_with_forwards_strict_posture_to_runner() {
     app.connect_with(
         (&producer, "out"),
         (&consumer, "in"),
-        ConnectOptions::default(),
+        ConnectOptions::loose(),
     )
     .expect("loose App::connect_with over the same pair must still wire the link");
 }

--- a/sdk/streamlib-sdk/tests/app_sugar_test.rs
+++ b/sdk/streamlib-sdk/tests/app_sugar_test.rs
@@ -149,6 +149,96 @@ fn app_connect_is_a_faithful_passthrough_of_runner_connect() {
     );
 }
 
+/// `App::connect_with` faithfully forwards its [`ConnectOptions`] posture to
+/// `Runner::connect_with`: over a concrete producer/consumer schema mismatch,
+/// `ConnectOptions::strict()` rejects at the App surface with the runtime's
+/// `Error::SchemaIdentMismatch`, while the loose default over the same pair
+/// still wires the link. Hardcoding the posture in `App::connect_with`
+/// (strict-always or loose-always, or dropping the `options` argument) breaks
+/// one half and fails here — guarding the App layer against drift from the
+/// runner surface.
+#[test]
+fn app_connect_with_forwards_strict_posture_to_runner() {
+    use streamlib::sdk::runtime::ConnectOptions;
+
+    let (producer_ref, consumer_ref) = register_schema_mismatched_pair(
+        "AppConnectWithStrictProducer",
+        "AppConnectWithStrictConsumer",
+    );
+
+    let app = App::new().expect("App::new");
+    let producer = app
+        .add(producer_ref, serde_json::json!({}))
+        .expect("app add producer");
+    let consumer = app
+        .add(consumer_ref, serde_json::json!({}))
+        .expect("app add consumer");
+
+    let err = app
+        .connect_with(
+            (&producer, "out"),
+            (&consumer, "in"),
+            ConnectOptions::strict(),
+        )
+        .expect_err("strict App::connect_with must reject the mismatched link");
+    assert!(
+        matches!(err, Error::SchemaIdentMismatch { .. }),
+        "App::connect_with must forward the strict posture and surface \
+         Error::SchemaIdentMismatch; got {err:?}"
+    );
+
+    app.connect_with(
+        (&producer, "out"),
+        (&consumer, "in"),
+        ConnectOptions::default(),
+    )
+    .expect("loose App::connect_with over the same pair must still wire the link");
+}
+
+/// Register a producer type (`out` → a `VideoFrame` schema) and a consumer type
+/// (`in` → an `AudioFrame` schema) so any wired producer→consumer link is a
+/// concrete schema mismatch. Unique short names per call keep the
+/// process-global registry collision-free across the parallel test binary.
+fn register_schema_mismatched_pair(
+    producer_short: &str,
+    consumer_short: &str,
+) -> (ProcessorTypeReference, ProcessorTypeReference) {
+    use streamlib::sdk::descriptors::{
+        Org, Package, PortDescriptor, PortSchemaSpec, ProcessorDescriptor, SchemaIdent, SemVer,
+        TypeName,
+    };
+    use streamlib::sdk::processors::PROCESSOR_REGISTRY;
+
+    let schema = |ty: &str| {
+        PortSchemaSpec::Specific(SchemaIdent::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("app-sugar-test").unwrap(),
+            TypeName::new(ty).unwrap(),
+            SemVer::new(1, 0, 0),
+        ))
+    };
+    let type_id = |short: &str| {
+        SchemaIdent::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("app-sugar-test").unwrap(),
+            TypeName::new(short).unwrap(),
+            SemVer::new(1, 0, 0),
+        )
+    };
+
+    let producer_id = type_id(producer_short);
+    let producer = ProcessorDescriptor::new(producer_id.clone(), "app-sugar strict producer")
+        .with_output(PortDescriptor::new("out", "", schema("VideoFrame"), false));
+    let _ = PROCESSOR_REGISTRY.register_descriptor_only(producer);
+
+    let consumer_id = type_id(consumer_short);
+    let consumer = ProcessorDescriptor::new(consumer_id.clone(), "app-sugar strict consumer")
+        .with_input(PortDescriptor::new("in", "", schema("AudioFrame"), false));
+    let _ = PROCESSOR_REGISTRY.register_descriptor_only(consumer);
+
+    (producer_id.into(), consumer_id.into())
+}
+
 /// Register a descriptor-only processor type with one real input and one real
 /// output port — enough to satisfy `connect`'s port-existence check without
 /// instantiating. Unique short names per call keep the process-global registry


### PR DESCRIPTION
## Ticket

Closes #1430

## Summary

Exposes a per-wiring-site opt-in that selects the (previously dormant) `Strict`
schema-validation posture at `connect()` time, satisfying acceptance criterion 3 of
#1430 (a safety-critical channel may opt into strict validation / hard-fail at the
wiring site).

- `ConnectOptions` (`non_exhaustive`; `loose()` / `strict()` / `with_validation()`)
  added to the connect surface, re-exported alongside `SchemaValidationPosture`.
- `Runner::connect_with` / `connect_with_async` route the caller's posture through
  the same `connect_impl` path `connect()` / `connect_async()` already use, so a
  strict-opted channel hard-fails a concrete producer/consumer schema mismatch with
  `Error::SchemaIdentMismatch` instead of only warning.
- `App::connect_with` sugar mirrors the `Runner` surface.
- `connect()` / `connect_async()` are refactored to delegate onto
  `connect_with[_async]` with `ConnectOptions::loose()`, removing a fourth copy of
  the `TokioRuntimeVariant` (`OwnedTokioRuntime` / `ExternalTokioHandle`) dispatch
  that had been hand-rolled separately in `connect()`.

## Test evidence

- `cargo test -p streamlib-engine` — `connect`-named lib tests (10) plus the
  pre-existing loose/strict `connect_impl` tests pass.
- `cargo test -p streamlib-sdk --test app_sugar_test` — 7 tests pass, including the
  new `App::connect_with` strict-posture passthrough test.
- New revert-lock tests added on this branch:
  - `test(runtime): revert-lock connect_with_async strict opt-in` — awaiting
    `Runner::connect_with_async` under `ConnectOptions::strict` rejects a concrete
    producer/consumer schema mismatch with `Error::SchemaIdentMismatch` and does not
    wire the link, while the loose default still wires it. Fails if the async
    opt-in path is reverted to a hardcoded `Loose` posture.
  - `test(sdk): App::connect_with strict-posture passthrough` — `App::connect_with`
    forwards `ConnectOptions::strict()` to `Runner::connect_with`, so a concrete
    schema mismatch rejects at the App surface, while the loose default over the
    same pair still wires the link.

All lenses cleared this branch (verify-change: PASS).

## Review items (non-blocking)

- **[info]** `runtime/streamlib-engine/src/core/runtime/operations_runtime.rs:387` — Commit 48e54797 collapses connect/connect_async onto the new connect_with[_async] — a DRY refactor of the core connect path. Evidence: connect() now delegates to self.connect_with(from,to,ConnectOptions::loose()) and connect_async() to connect_with_async(...loose()); the block_on/spawn variant logic moved verbatim into connect_with. Behavior-preserving: 10 `connect`-named engine lib tests + 7 app_sugar tests pass, and the pre-existing loose/strict connect_impl tests still pass. Suggested next step: None — refactor is in-scope for introducing the opt-in surface and is isolated in its own commit; no action needed.
- **[info]** `sdk/streamlib-sdk/src/sdk/app.rs:106` — Strict opt-in is exposed only on the Rust surface (Runner + App); no Python/Deno authoring parity. Evidence: connect_with is additive — connect() still exists and behaves identically (loose), so this is not a canonical-pattern replacement requiring a same-PR polyglot sweep. Ticket #1430 acceptance criteria name only the connect() wiring site; polyglot parity is not listed and design defers the broader per-channel surface to #1419. Suggested next step: Optionally track polyglot strict opt-in as a follow-up when #1419's per-channel wiring surface lands; not required by this ticket.
- **[low]** `runtime/streamlib-engine/src/core/runtime/operations.rs:24` — ConnectOptions is a borderline-generic name under the zero-context naming rule. Evidence: Rules ban bare generic words (Writer/State/ctx). `ConnectOptions` encodes operation (connect) + role (options) and is a non_exhaustive carrier for future per-wiring knobs; its sole field `validation: SchemaValidationPosture` is explicit. Reads clearly at call sites (ConnectOptions::strict()). Suggested next step: Acceptable as-is; if the owner wants maximal explicitness, ConnectWiringOptions would read marginally clearer, but this is not load-bearing.
- **[info]** `runtime/streamlib-engine/src/core/runtime/operations_runtime.rs:447` — The connect/connect_async refactor is a real duplication removal, not a silent DRY refactor to nitpick. Evidence: `connect` previously hand-rolled the `match &self.tokio_runtime_variant { OwnedTokioRuntime => rt.block_on(..), ExternalTokioHandle => spawn + mpsc recv }` dispatch with a hardcoded `SchemaValidationPosture::Loose`; that block is now deleted and `connect` delegates to `connect_with(.., ConnectOptions::loose())`, with the single copy of the dispatch living in `connect_with`. Net one-fewer copy; the `runtime.connect` tracing span on `connect_impl` still fires on both paths. Suggested next step: No action — positive observation; the extraction replaces genuine duplication and is the point of the PR.
- **[low]** `runtime/streamlib-engine/src/core/runtime/operations_runtime.rs:483` — `impl Into<OutputLinkPortRef>` / `impl Into<InputLinkPortRef>` on connect_with/connect_with_async is speculative generality — no non-identity `From` impls exist, so it only ever accepts the concrete type. Evidence: grep for `impl From<..> for OutputLinkPortRef`/`InputLinkPortRef` returns nothing, so `impl Into` resolves only to the blanket identity conversion. The generic param buys no ergonomics today and makes the inherent `connect_with` signature diverge from the trait `connect(from: OutputLinkPortRef, to: InputLinkPortRef)`. The one in-tree caller (App::connect_with) already passes concrete `OutputLinkPortRef::new(..)`. Suggested next step: Take concrete `OutputLinkPortRef`/`InputLinkPortRef` to match the `RuntimeOperations::connect` trait signature; reintroduce `impl Into` only when a real `From` conversion is added.
- **[low]** `runtime/streamlib-engine/src/core/runtime/operations.rs:29` — `ConnectOptions::loose()` is a redundant spelling of `ConnectOptions::default()`. Evidence: `SchemaValidationPosture::Loose` is `#[default]` and `ConnectOptions` derives `Default`, so `loose()` produces exactly `default()`. The codebase now uses both spellings interchangeably (`connect` calls `ConnectOptions::loose()`, the tests call `ConnectOptions::default()`), which is two names for one value. Suggested next step: Keep `loose()` only if the intent-revealing call-site name is deliberate; otherwise drop it and use `default()`, or document that `loose()` is the preferred readable spelling so callers converge on one.