### PR TITLE
feat(sdk): unify read_mode/overflow/buffer_size/max_queued_messages into one delivery profile

### DIFF
--- a/docs/architecture/static-registry.md
+++ b/docs/architecture/static-registry.md
@@ -159,12 +159,9 @@ version (a missing dep is `ExternalDepMissing`, a cycle is
 
 ### Deliberate omissions
 
-`CatalogPort` carries `name`, `description`, `schema`, `read_mode` only. Two
-classes of manifest field are intentionally dropped:
+`CatalogPort` carries `name`, `description`, `schema`, `delivery_profile` only.
+One class of manifest field is intentionally dropped:
 
-- `overflow` / `buffer_size` — present on the authored manifest port, but
-  they are per-edge *buffering knobs*, not wiring topology, so they don't
-  belong in a palette the editor wires graphs from.
 - `required` — has no authored-manifest source at all; it exists only on the
   runtime port descriptors, not on the `streamlib.yaml` port.
 

--- a/docs/decisions/manifest-extraction-capability.md
+++ b/docs/decisions/manifest-extraction-capability.md
@@ -67,9 +67,9 @@ name, execution mode, and each port's name + schema-type (or `any`). It
 deliberately excludes fields no code scan produces uniformly or that are
 authored/build-derived rather than code-derived — `version` (the release-core
 projection is a build concern), `entrypoint` (author/loader concern), the
-`config` binding, `description`, and the consumer-side port policies
-(`read_mode` / `overflow` / `buffer_size`, which the Python/Deno wire shape does
-not carry). What remains is exactly the surface a stale hand-authored
+`config` binding, `description`, and the consumer-side `delivery_profile`
+(which the Python/Deno wire shape does not carry uniformly). What remains is
+exactly the surface a stale hand-authored
 `processors:` would misstate: a processor added, removed, or renamed in code; a
 port added, removed, reordered, or re-typed. The committed manifest stays the
 carrier of the excluded authored/build fields — the `processors:` section is not

--- a/docs/learnings/startup-crash-iceoryx2-wire-vs-gpu-setup-race.md
+++ b/docs/learnings/startup-crash-iceoryx2-wire-vs-gpu-setup-race.md
@@ -72,7 +72,8 @@ doesn't fire.
 ## Reference
 
 - iceoryx2 sizing fix: `core/compiler/compiler_ops/open_iceoryx2_service_op.rs`
-  (`max_queued_messages_for_dest`) + `iceoryx2/node.rs` (`max_subscribers`).
+  (the channel's agreed delivery-profile ring depth) + `iceoryx2/node.rs`
+  (`max_subscribers`).
 - The latent GPU race's mechanism (main-vs-fan-out glcore contention) and the
   funnel candidate fix live in the tracked issue for it, not here — this file
   is the *diagnostic* learning, not the fix proposal.

--- a/packages/audio/src/apple/audio_output.rs
+++ b/packages/audio/src/apple/audio_output.rs
@@ -55,7 +55,7 @@ pub struct AppleAudioDevice {
     execution = manual,
     scheduling = realtime,
     config = crate::_generated_::AudioOutputConfig,
-    input("audio", "@tatolab/core/AudioFrame", read_mode = "read_next_in_order", buffer_size = 32, description = "Stereo audio frame to play through speakers"),
+    input("audio", "@tatolab/core/AudioFrame", description = "Stereo audio frame to play through speakers"),
 )]
 pub struct AppleAudioOutputProcessor {
     device_id: Option<usize>,

--- a/packages/audio/src/audio_channel_converter.rs
+++ b/packages/audio/src/audio_channel_converter.rs
@@ -12,7 +12,7 @@ use streamlib_plugin_sdk::sdk::context::{RuntimeContextFullAccess, RuntimeContex
     execution = reactive,
     scheduling = realtime,
     config = crate::_generated_::AudioChannelConverterConfig,
-    input("audio_in", "@tatolab/core/AudioFrame", read_mode = "read_next_in_order", buffer_size = 32, description = "Mono audio frame"),
+    input("audio_in", "@tatolab/core/AudioFrame", description = "Mono audio frame"),
     output("audio_out", "@tatolab/core/AudioFrame", description = "Multi-channel audio frame"),
 )]
 pub struct AudioChannelConverterProcessor {

--- a/packages/audio/src/audio_mixer.rs
+++ b/packages/audio/src/audio_mixer.rs
@@ -12,8 +12,8 @@ use streamlib_plugin_sdk::sdk::context::{RuntimeContextFullAccess, RuntimeContex
     execution = reactive,
     scheduling = realtime,
     config = crate::_generated_::AudioMixerConfig,
-    input("left", "@tatolab/core/AudioFrame", read_mode = "read_next_in_order", buffer_size = 32, description = "Left channel mono audio frame"),
-    input("right", "@tatolab/core/AudioFrame", read_mode = "read_next_in_order", buffer_size = 32, description = "Right channel mono audio frame"),
+    input("left", "@tatolab/core/AudioFrame", description = "Left channel mono audio frame"),
+    input("right", "@tatolab/core/AudioFrame", description = "Right channel mono audio frame"),
     output("audio", "@tatolab/core/AudioFrame", description = "Mixed stereo audio frame"),
 )]
 pub struct AudioMixerProcessor {

--- a/packages/audio/src/audio_resampler.rs
+++ b/packages/audio/src/audio_resampler.rs
@@ -21,7 +21,7 @@ fn quality_to_resampling_quality(quality: &Quality) -> ResamplingQuality {
     execution = reactive,
     scheduling = realtime,
     config = crate::_generated_::AudioResamplerConfig,
-    input("audio_in", "@tatolab/core/AudioFrame", read_mode = "read_next_in_order", buffer_size = 32, description = "Audio frame to resample"),
+    input("audio_in", "@tatolab/core/AudioFrame", description = "Audio frame to resample"),
     output("audio_out", "@tatolab/core/AudioFrame", description = "Resampled audio frame"),
 )]
 pub struct AudioResamplerProcessor {

--- a/packages/audio/src/buffer_rechunker.rs
+++ b/packages/audio/src/buffer_rechunker.rs
@@ -11,7 +11,7 @@ use streamlib_plugin_sdk::sdk::context::{RuntimeContextFullAccess, RuntimeContex
     execution = reactive,
     scheduling = realtime,
     config = crate::_generated_::BufferRechunkerConfig,
-    input("audio_in", "@tatolab/core/AudioFrame", read_mode = "read_next_in_order", buffer_size = 32, description = "Variable-size audio frame"),
+    input("audio_in", "@tatolab/core/AudioFrame", description = "Variable-size audio frame"),
     output("audio_out", "@tatolab/core/AudioFrame", description = "Fixed-size audio frame"),
 )]
 pub struct BufferRechunkerProcessor {

--- a/packages/audio/src/linux/audio_output.rs
+++ b/packages/audio/src/linux/audio_output.rs
@@ -55,7 +55,7 @@ pub struct LinuxAudioDevice {
     execution = manual,
     scheduling = realtime,
     config = crate::_generated_::AudioOutputConfig,
-    input("audio", "@tatolab/core/AudioFrame", read_mode = "read_next_in_order", buffer_size = 32, description = "Stereo audio frame to play through speakers"),
+    input("audio", "@tatolab/core/AudioFrame", description = "Stereo audio frame to play through speakers"),
 )]
 pub struct LinuxAudioOutputProcessor {
     device_id: Option<usize>,

--- a/packages/audio/streamlib.yaml
+++ b/packages/audio/streamlib.yaml
@@ -46,9 +46,7 @@ processors:
   - name: audio
     schema: AudioFrame
     description: Captured mono audio frames in device-native sample rate
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null
 - name: AudioOutput
   description: Plays audio through speakers/headphones (CoreAudio on macOS, ALSA on Linux)
   runtime:
@@ -69,9 +67,7 @@ processors:
   - name: audio
     schema: AudioFrame
     description: Stereo audio frame to play through speakers
-    read_mode: read_next_in_order
-    overflow: null
-    buffer_size: 32
+    delivery_profile: null
   outputs: []
 - name: AudioMixer
   description: Mixes two mono audio signals into a single stereo signal
@@ -88,22 +84,16 @@ processors:
   - name: left
     schema: AudioFrame
     description: Left channel mono audio frame
-    read_mode: read_next_in_order
-    overflow: null
-    buffer_size: 32
+    delivery_profile: null
   - name: right
     schema: AudioFrame
     description: Right channel mono audio frame
-    read_mode: read_next_in_order
-    overflow: null
-    buffer_size: 32
+    delivery_profile: null
   outputs:
   - name: audio
     schema: AudioFrame
     description: Mixed stereo audio frame
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null
 - name: AudioChannelConverter
   description: Converts mono audio to N-channel audio according to the configured mode
   runtime: rust
@@ -119,16 +109,12 @@ processors:
   - name: audio_in
     schema: AudioFrame
     description: Mono audio frame
-    read_mode: read_next_in_order
-    overflow: null
-    buffer_size: 32
+    delivery_profile: null
   outputs:
   - name: audio_out
     schema: AudioFrame
     description: Multi-channel audio frame
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null
 - name: AudioResampler
   description: Resamples audio between sample rates
   runtime: rust
@@ -144,16 +130,12 @@ processors:
   - name: audio_in
     schema: AudioFrame
     description: Audio frame to resample
-    read_mode: read_next_in_order
-    overflow: null
-    buffer_size: 32
+    delivery_profile: null
   outputs:
   - name: audio_out
     schema: AudioFrame
     description: Resampled audio frame
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null
 - name: BufferRechunker
   description: Rechunks audio buffers to a fixed sample count
   runtime: rust
@@ -169,16 +151,12 @@ processors:
   - name: audio_in
     schema: AudioFrame
     description: Variable-size audio frame
-    read_mode: read_next_in_order
-    overflow: null
-    buffer_size: 32
+    delivery_profile: null
   outputs:
   - name: audio_out
     schema: AudioFrame
     description: Fixed-size audio frame
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null
 - name: ChordGenerator
   description: Generates a C major chord (C4 + E4 + G4) driven by the runtime audio clock
   runtime: rust
@@ -195,6 +173,4 @@ processors:
   - name: chord
     schema: AudioFrame
     description: Stereo chord audio frame
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null

--- a/packages/camera/streamlib.yaml
+++ b/packages/camera/streamlib.yaml
@@ -37,9 +37,7 @@ processors:
   - name: video
     schema: VideoFrame
     description: Live video frames from the camera
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null
 - name: CameraToCudaCopy
   description: 'Host-pipeline producer: camera VkImage -> cuda OPAQUE_FD VkBuffer with timeline signal for cross-API CUDA interop. Linux-only (CUDA is Linux-only on the in-tree adapter set).'
   runtime: rust
@@ -55,13 +53,9 @@ processors:
   - name: video_in
     schema: VideoFrame
     description: Camera ring texture (RGBA8 DMA-BUF) frame metadata
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null
   outputs:
   - name: video_out
     schema: VideoFrame
     description: Camera frame forwarded verbatim; cuda surface side-effect happens during process()
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null

--- a/packages/clap/src/clap_effect.rs
+++ b/packages/clap/src/clap_effect.rs
@@ -72,7 +72,7 @@ impl SendableClapHostPtr {
     description = "CLAP audio plugin processor with parameter control and automation",
     execution = manual,
     config = crate::_generated_::ClapEffectConfig,
-    input("audio_in", "@tatolab/core/AudioFrame", read_mode = "read_next_in_order", buffer_size = 32, description = "Stereo audio frame to process through CLAP plugin (2 channels)"),
+    input("audio_in", "@tatolab/core/AudioFrame", description = "Stereo audio frame to process through CLAP plugin (2 channels)"),
     output("audio_out", "@tatolab/core/AudioFrame", description = "Processed stereo audio frame from CLAP plugin (2 channels)"),
 )]
 pub struct ClapEffectProcessor {

--- a/packages/clap/streamlib.yaml
+++ b/packages/clap/streamlib.yaml
@@ -27,13 +27,9 @@ processors:
   - name: audio_in
     schema: AudioFrame
     description: Stereo audio frame to process through CLAP plugin (2 channels)
-    read_mode: read_next_in_order
-    overflow: null
-    buffer_size: 32
+    delivery_profile: null
   outputs:
   - name: audio_out
     schema: AudioFrame
     description: Processed stereo audio frame from CLAP plugin (2 channels)
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null

--- a/packages/core/schemas/audio_frame.yaml
+++ b/packages/core/schemas/audio_frame.yaml
@@ -6,8 +6,7 @@
 metadata:
   type: AudioFrame
   description: "Audio frame with interleaved samples (1-8 channels)"
-  read_mode: read_next_in_order
-  max_queued_messages: 32
+  flow_class: sample_stream
 
 properties:
   samples:

--- a/packages/core/schemas/encoded_audio_frame.yaml
+++ b/packages/core/schemas/encoded_audio_frame.yaml
@@ -6,8 +6,7 @@
 metadata:
   type: EncodedAudioFrame
   description: "Encoded audio frame with Opus/AAC bitstream data"
-  read_mode: skip_to_latest
-  max_queued_messages: 8
+  flow_class: state_stream
 
 properties:
   data:

--- a/packages/core/schemas/encoded_video_frame.yaml
+++ b/packages/core/schemas/encoded_video_frame.yaml
@@ -23,13 +23,12 @@ imports:
 metadata:
   type: EncodedVideoFrame
   description: "Encoded video frame with H.264/H.265 NAL unit data"
-  read_mode: read_next_in_order
-  max_queued_messages: 16
+  flow_class: sample_stream
   # Slot-priming HINT, never a cap: the publisher opens under PowerOfTwo growth
   # and grows the segment on the first oversized loan (a 4K IDR ≈ 8–12 MiB), so
   # a keyframe past this hint delivers instead of crashing. 4 MiB covers the
   # common 1080p CQP IDR (≈ 2–3 MiB) without a first-frame regrow while keeping
-  # the primed commitment (max_queued_messages * hint) an order of magnitude
+  # the primed commitment (ring depth * hint) an order of magnitude
   # below the old fixed 16 MiB slot.
   expected_payload_bytes: 4194304
 

--- a/packages/core/schemas/video_frame.yaml
+++ b/packages/core/schemas/video_frame.yaml
@@ -23,8 +23,7 @@ imports:
 metadata:
   type: VideoFrame
   description: "Video frame for IPC - references GPU surface by ID"
-  read_mode: skip_to_latest
-  max_queued_messages: 4
+  flow_class: state_stream
 
 properties:
   surface_id:

--- a/packages/debug-utilities/src/simple_passthrough.rs
+++ b/packages/debug-utilities/src/simple_passthrough.rs
@@ -11,7 +11,7 @@ use streamlib_plugin_sdk::sdk::processors::ManualProcessor;
     description = "Passes video frames through unchanged (for testing)",
     execution = manual,
     config = crate::_generated_::SimplePassthroughConfig,
-    input("input", "@tatolab/core/VideoFrame", read_mode = "skip_to_latest", buffer_size = 4, description = "Video frame input"),
+    input("input", "@tatolab/core/VideoFrame", description = "Video frame input"),
     output("output", "@tatolab/core/VideoFrame", description = "Video frame output (unchanged)"),
 )]
 pub struct SimplePassthroughProcessor;

--- a/packages/debug-utilities/src/video_frame_counter.rs
+++ b/packages/debug-utilities/src/video_frame_counter.rs
@@ -52,7 +52,7 @@ pub fn reset() {
     description = "Counts incoming VideoFrames into process-global atomics so integration tests can assert on frame count + first-frame dimensions after runtime.stop()",
     execution = reactive,
     config = crate::_generated_::VideoFrameCounterConfig,
-    input("input", "@tatolab/core/VideoFrame", read_mode = "read_next_in_order", buffer_size = 16, description = "VideoFrame stream to observe"),
+    input("input", "@tatolab/core/VideoFrame", delivery_profile = "every_sample", description = "VideoFrame stream to observe"),
 )]
 pub struct VideoFrameCounterProcessor;
 

--- a/packages/debug-utilities/streamlib.yaml
+++ b/packages/debug-utilities/streamlib.yaml
@@ -43,16 +43,12 @@ processors:
   - name: input
     schema: VideoFrame
     description: Video frame input
-    read_mode: skip_to_latest
-    overflow: null
-    buffer_size: 4
+    delivery_profile: null
   outputs:
   - name: output
     schema: VideoFrame
     description: Video frame output (unchanged)
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null
 - name: BgraFileSource
   description: Streams raw BGRA frames from a file as Videoframes
   runtime: rust
@@ -68,9 +64,7 @@ processors:
   - name: video
     schema: VideoFrame
     description: Video frames read from the BGRA file
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null
 - name: JpegBytesSource
   description: Loads a JPEG file from disk at setup time and republishes it as EncodedJpegFrame on a paced background thread (for testing the JPEG decoder pipeline)
   runtime: rust
@@ -86,9 +80,7 @@ processors:
   - name: encoded_jpeg
     schema: EncodedJpegFrame
     description: JPEG-encoded bytes wrapped in an EncodedJpegFrame
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null
 - name: VideoFrameCounter
   description: Counts incoming VideoFrames into process-global atomics so integration tests can assert on frame count + first-frame dimensions after runtime.stop()
   runtime: rust
@@ -103,7 +95,5 @@ processors:
   - name: input
     schema: VideoFrame
     description: VideoFrame stream to observe
-    read_mode: read_next_in_order
-    overflow: null
-    buffer_size: 16
+    delivery_profile: every_sample
   outputs: []

--- a/packages/display/src/apple/display.rs
+++ b/packages/display/src/apple/display.rs
@@ -31,7 +31,7 @@ static NEXT_WINDOW_ID: AtomicU64 = AtomicU64::new(1);
     execution = manual,
     scheduling = high,
     config = crate::_generated_::DisplayConfig,
-    input("video", "@tatolab/core/VideoFrame", read_mode = "skip_to_latest", buffer_size = 4, description = "Video frames to display in the window"),
+    input("video", "@tatolab/core/VideoFrame", description = "Video frames to display in the window"),
 )]
 pub struct AppleDisplayProcessor {
     /// Window address stored as usize (NSWindow is !Send, but we leak it anyway)

--- a/packages/display/src/linux/display.rs
+++ b/packages/display/src/linux/display.rs
@@ -62,7 +62,7 @@ const DISPLAY_BLIT_FRAG_SPV: &[u8] =
     execution = manual,
     scheduling = high,
     config = crate::_generated_::DisplayConfig,
-    input("video", "@tatolab/core/VideoFrame", read_mode = "skip_to_latest", buffer_size = 4, description = "Video frames to display in the window"),
+    input("video", "@tatolab/core/VideoFrame", description = "Video frames to display in the window"),
 )]
 pub struct LinuxDisplayProcessor {
     gpu_context: Option<GpuContextLimitedAccess>,

--- a/packages/display/streamlib.yaml
+++ b/packages/display/streamlib.yaml
@@ -34,7 +34,5 @@ processors:
   - name: video
     schema: VideoFrame
     description: Video frames to display in the window
-    read_mode: skip_to_latest
-    overflow: null
-    buffer_size: 4
+    delivery_profile: null
   outputs: []

--- a/packages/h264/src/linux/decoder.rs
+++ b/packages/h264/src/linux/decoder.rs
@@ -38,7 +38,7 @@ use streamlib_plugin_abi::{VideoCodecRepr, VideoDecoderSessionDescriptorRepr};
     execution = reactive,
     scheduling = high,
     config = crate::_generated_::H264DecoderConfig,
-    input("encoded_video_in", "@tatolab/core/EncodedVideoFrame", read_mode = "read_next_in_order", buffer_size = 16, description = "H.264 encoded video frames to decode"),
+    input("encoded_video_in", "@tatolab/core/EncodedVideoFrame", description = "H.264 encoded video frames to decode"),
     output("video_out", "@tatolab/core/VideoFrame", description = "Decoded video frames"),
 )]
 pub struct H264DecoderProcessor {

--- a/packages/h264/src/linux/encoder.rs
+++ b/packages/h264/src/linux/encoder.rs
@@ -39,7 +39,7 @@ use streamlib_plugin_abi::{
     execution = reactive,
     scheduling = high,
     config = crate::_generated_::H264EncoderConfig,
-    input("video_in", "@tatolab/core/VideoFrame", read_mode = "read_next_in_order", buffer_size = 8, description = "Raw video frames to encode"),
+    input("video_in", "@tatolab/core/VideoFrame", delivery_profile = "every_sample", description = "Raw video frames to encode"),
     output("encoded_video_out", "@tatolab/core/EncodedVideoFrame", description = "H.264 encoded video frames"),
 )]
 pub struct H264EncoderProcessor {

--- a/packages/h264/streamlib.yaml
+++ b/packages/h264/streamlib.yaml
@@ -38,16 +38,12 @@ processors:
   - name: video_in
     schema: VideoFrame
     description: Raw video frames to encode
-    read_mode: read_next_in_order
-    overflow: null
-    buffer_size: 8
+    delivery_profile: every_sample
   outputs:
   - name: encoded_video_out
     schema: EncodedVideoFrame
     description: H.264 encoded video frames
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null
 - name: H264Decoder
   description: Decodes EncodedVideoFrame (H.264) to VideoFrame via Vulkan Video
   runtime: rust
@@ -63,13 +59,9 @@ processors:
   - name: encoded_video_in
     schema: EncodedVideoFrame
     description: H.264 encoded video frames to decode
-    read_mode: read_next_in_order
-    overflow: null
-    buffer_size: 16
+    delivery_profile: null
   outputs:
   - name: video_out
     schema: VideoFrame
     description: Decoded video frames
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null

--- a/packages/h265/src/linux/decoder.rs
+++ b/packages/h265/src/linux/decoder.rs
@@ -38,7 +38,7 @@ use streamlib_plugin_abi::{VideoCodecRepr, VideoDecoderSessionDescriptorRepr};
     execution = reactive,
     scheduling = high,
     config = crate::_generated_::H265DecoderConfig,
-    input("encoded_video_in", "@tatolab/core/EncodedVideoFrame", read_mode = "read_next_in_order", buffer_size = 16, description = "H.265 encoded video frames to decode"),
+    input("encoded_video_in", "@tatolab/core/EncodedVideoFrame", description = "H.265 encoded video frames to decode"),
     output("video_out", "@tatolab/core/VideoFrame", description = "Decoded video frames"),
 )]
 pub struct H265DecoderProcessor {

--- a/packages/h265/src/linux/encoder.rs
+++ b/packages/h265/src/linux/encoder.rs
@@ -39,7 +39,7 @@ use streamlib_plugin_abi::{
     execution = reactive,
     scheduling = high,
     config = crate::_generated_::H265EncoderConfig,
-    input("video_in", "@tatolab/core/VideoFrame", read_mode = "read_next_in_order", buffer_size = 8, description = "Raw video frames to encode"),
+    input("video_in", "@tatolab/core/VideoFrame", delivery_profile = "every_sample", description = "Raw video frames to encode"),
     output("encoded_video_out", "@tatolab/core/EncodedVideoFrame", description = "H.265 encoded video frames"),
 )]
 pub struct H265EncoderProcessor {

--- a/packages/h265/streamlib.yaml
+++ b/packages/h265/streamlib.yaml
@@ -38,16 +38,12 @@ processors:
   - name: video_in
     schema: VideoFrame
     description: Raw video frames to encode
-    read_mode: read_next_in_order
-    overflow: null
-    buffer_size: 8
+    delivery_profile: every_sample
   outputs:
   - name: encoded_video_out
     schema: EncodedVideoFrame
     description: H.265 encoded video frames
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null
 - name: H265Decoder
   description: Decodes EncodedVideoFrame (H.265) to VideoFrame via Vulkan Video
   runtime: rust
@@ -63,13 +59,9 @@ processors:
   - name: encoded_video_in
     schema: EncodedVideoFrame
     description: H.265 encoded video frames to decode
-    read_mode: read_next_in_order
-    overflow: null
-    buffer_size: 16
+    delivery_profile: null
   outputs:
   - name: video_out
     schema: VideoFrame
     description: Decoded video frames
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null

--- a/packages/jpeg/schemas/encoded_jpeg_frame.yaml
+++ b/packages/jpeg/schemas/encoded_jpeg_frame.yaml
@@ -13,8 +13,7 @@
 metadata:
   type: EncodedJpegFrame
   description: "JPEG-encoded image bytes (one self-contained frame per message)"
-  read_mode: read_next_in_order
-  max_queued_messages: 16
+  flow_class: sample_stream
   # Slot-priming HINT, never a cap: the publisher grows its PowerOfTwo segment
   # on the first oversized loan, so a high-quality 4K JPEG (Q=100 ≈ 4–8 MiB)
   # delivers via one growth event rather than crashing. 1 MiB covers the common

--- a/packages/jpeg/src/linux/decoder.rs
+++ b/packages/jpeg/src/linux/decoder.rs
@@ -35,7 +35,7 @@ const DEFAULT_MAX_HEIGHT: u32 = 2160;
     execution = reactive,
     scheduling = high,
     config = crate::_generated_::JpegDecoderConfig,
-    input("encoded_jpeg_in", "@tatolab/jpeg/EncodedJpegFrame", read_mode = "read_next_in_order", buffer_size = 16, description = "JPEG-encoded frames to decode"),
+    input("encoded_jpeg_in", "@tatolab/jpeg/EncodedJpegFrame", description = "JPEG-encoded frames to decode"),
     output("video_out", "@tatolab/core/VideoFrame", description = "Decoded video frames"),
 )]
 pub struct JpegDecoderProcessor {

--- a/packages/jpeg/streamlib.yaml
+++ b/packages/jpeg/streamlib.yaml
@@ -36,13 +36,9 @@ processors:
   - name: encoded_jpeg_in
     schema: EncodedJpegFrame
     description: JPEG-encoded frames to decode
-    read_mode: read_next_in_order
-    overflow: null
-    buffer_size: 16
+    delivery_profile: null
   outputs:
   - name: video_out
     schema: VideoFrame
     description: Decoded video frames
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null

--- a/packages/moq/streamlib.yaml
+++ b/packages/moq/streamlib.yaml
@@ -35,9 +35,7 @@ processors:
   - name: data_in
     schema: any
     description: Input data to publish to MoQ track (any serialized type)
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null
   outputs: []
 - name: MoqSubscribeTrack
   description: Subscribes to a named MoQ track and outputs raw bytes to the graph
@@ -54,6 +52,4 @@ processors:
   - name: data_out
     schema: any
     description: Received data from MoQ track subscription (any serialized type)
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null

--- a/packages/mp4/src/_apple_impl_pending_/mp4_writer.rs
+++ b/packages/mp4/src/_apple_impl_pending_/mp4_writer.rs
@@ -30,7 +30,7 @@ extern "C" {
     "@tatolab/mp4/Mp4Writer",
     execution = reactive,
     config = crate::_generated_::LinuxMp4WriterConfig,
-    input("video_in", "@tatolab/core/VideoFrame", read_mode = "read_next_in_order", overflow = "block", buffer_size = 32),
+    input("video_in", "@tatolab/core/VideoFrame", delivery_profile = "lossless")
 )]
 pub struct AppleMp4WriterProcessor {
     // RuntimeContext for main thread dispatch

--- a/packages/mp4/src/linux/mp4_writer.rs
+++ b/packages/mp4/src/linux/mp4_writer.rs
@@ -14,7 +14,7 @@ use std::process::{Child, Command, Stdio};
     description = "Writes video frames to MP4 via ffmpeg encode + mux with silent audio track",
     execution = reactive,
     config = crate::_generated_::LinuxMp4WriterConfig,
-    input("video_in", "@tatolab/core/VideoFrame", read_mode = "read_next_in_order", overflow = "block", buffer_size = 32, description = "Decoded video frames (raw pixels) to encode and write"),
+    input("video_in", "@tatolab/core/VideoFrame", delivery_profile = "lossless", description = "Decoded video frames (raw pixels) to encode and write"),
 )]
 pub struct LinuxMp4WriterProcessor {
     gpu_context: Option<GpuContextLimitedAccess>,

--- a/packages/mp4/streamlib.yaml
+++ b/packages/mp4/streamlib.yaml
@@ -33,7 +33,5 @@ processors:
   - name: video_in
     schema: VideoFrame
     description: Decoded video frames (raw pixels) to encode and write
-    read_mode: read_next_in_order
-    overflow: block
-    buffer_size: 32
+    delivery_profile: lossless
   outputs: []

--- a/packages/opus/src/opus_decoder.rs
+++ b/packages/opus/src/opus_decoder.rs
@@ -186,7 +186,7 @@ impl OpusDecoder {
     execution = reactive,
     scheduling = realtime,
     config = crate::_generated_::OpusDecoderConfig,
-    input("encoded_audio_in", "@tatolab/core/EncodedAudioFrame", read_mode = "skip_to_latest", buffer_size = 8, description = "Opus encoded audio frames to decode"),
+    input("encoded_audio_in", "@tatolab/core/EncodedAudioFrame", description = "Opus encoded audio frames to decode"),
     output("audio_out", "@tatolab/core/AudioFrame", description = "Decoded audio frames"),
 )]
 pub struct OpusDecoderProcessor {

--- a/packages/opus/src/opus_encoder.rs
+++ b/packages/opus/src/opus_encoder.rs
@@ -203,7 +203,7 @@ impl AudioEncoderOpus for OpusEncoder {
     execution = reactive,
     scheduling = realtime,
     config = crate::_generated_::OpusEncoderConfig,
-    input("audio_in", "@tatolab/core/AudioFrame", read_mode = "read_next_in_order", buffer_size = 32, description = "Raw audio frames to encode"),
+    input("audio_in", "@tatolab/core/AudioFrame", description = "Raw audio frames to encode"),
     output("encoded_audio_out", "@tatolab/core/EncodedAudioFrame", description = "Opus encoded audio frames"),
 )]
 pub struct OpusEncoderProcessor {

--- a/packages/opus/streamlib.yaml
+++ b/packages/opus/streamlib.yaml
@@ -32,16 +32,12 @@ processors:
   - name: audio_in
     schema: AudioFrame
     description: Raw audio frames to encode
-    read_mode: read_next_in_order
-    overflow: null
-    buffer_size: 32
+    delivery_profile: null
   outputs:
   - name: encoded_audio_out
     schema: EncodedAudioFrame
     description: Opus encoded audio frames
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null
 - name: OpusDecoder
   description: Decodes EncodedAudioFrame (Opus) to AudioFrame
   runtime: rust
@@ -57,13 +53,9 @@ processors:
   - name: encoded_audio_in
     schema: EncodedAudioFrame
     description: Opus encoded audio frames to decode
-    read_mode: skip_to_latest
-    overflow: null
-    buffer_size: 8
+    delivery_profile: null
   outputs:
   - name: audio_out
     schema: AudioFrame
     description: Decoded audio frames
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null

--- a/packages/screen-capture/streamlib.yaml
+++ b/packages/screen-capture/streamlib.yaml
@@ -39,6 +39,4 @@ processors:
   - name: video
     schema: VideoFrame
     description: Captured video frames from screen content
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null

--- a/packages/webrtc/src/webrtc_whip.rs
+++ b/packages/webrtc/src/webrtc_whip.rs
@@ -36,8 +36,8 @@ enum WhipClientMessage {
     description = "Streams pre-encoded video and audio to a WHIP endpoint (WebRTC ingress)",
     execution = reactive,
     config = crate::_generated_::WebrtcWhipConfig,
-    input("encoded_video_in", "@tatolab/core/EncodedVideoFrame", read_mode = "read_next_in_order", buffer_size = 16, description = "H.264 encoded video frames to stream"),
-    input("encoded_audio_in", "@tatolab/core/EncodedAudioFrame", read_mode = "skip_to_latest", buffer_size = 8, description = "Opus encoded audio frames to stream"),
+    input("encoded_video_in", "@tatolab/core/EncodedVideoFrame", description = "H.264 encoded video frames to stream"),
+    input("encoded_audio_in", "@tatolab/core/EncodedAudioFrame", description = "Opus encoded audio frames to stream"),
 )]
 pub struct WebRtcWhipProcessor {
     // Session state

--- a/packages/webrtc/streamlib.yaml
+++ b/packages/webrtc/streamlib.yaml
@@ -38,15 +38,11 @@ processors:
   - name: encoded_video_out
     schema: EncodedVideoFrame
     description: H.264 encoded video frames from WHEP stream
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null
   - name: encoded_audio_out
     schema: EncodedAudioFrame
     description: Opus encoded audio frames from WHEP stream
-    read_mode: null
-    overflow: null
-    buffer_size: null
+    delivery_profile: null
 - name: WebrtcWhip
   description: Streams pre-encoded video and audio to a WHIP endpoint (WebRTC ingress)
   runtime: rust
@@ -61,13 +57,9 @@ processors:
   - name: encoded_video_in
     schema: EncodedVideoFrame
     description: H.264 encoded video frames to stream
-    read_mode: read_next_in_order
-    overflow: null
-    buffer_size: 16
+    delivery_profile: null
   - name: encoded_audio_in
     schema: EncodedAudioFrame
     description: Opus encoded audio frames to stream
-    read_mode: skip_to_latest
-    overflow: null
-    buffer_size: 8
+    delivery_profile: null
   outputs: []

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -20,8 +20,7 @@ use crate::core::PortSchemaSpec;
 use crate::core::ProcessorUniqueId;
 use crate::core::context::RuntimeContext;
 use crate::core::embedded_schemas::{
-    expected_payload_bytes_for_port_spec, max_queued_messages_for_port_spec, overflow_for_input_port,
-    port_schema_spec,
+    delivery_profile_for_input_port, expected_payload_bytes_for_port_spec, port_schema_spec,
 };
 use crate::core::error::{Error, Result};
 use crate::core::graph::{
@@ -131,10 +130,10 @@ pub fn open_iceoryx2_service(
     );
 
     // Resolve schemas + channel sizing. The channel carries one publisher (the
-    // source), so its ring depth and slot size derive from the source output
-    // schema; its subscriber count is the compile-time destination fan-out plus
-    // the reserved tap slot; its overflow policy is the destinations' agreed
-    // policy.
+    // source), so its slot size derives from the source output schema; its
+    // subscriber count is the compile-time destination fan-out plus the reserved
+    // tap slot. Ring depth, overflow policy, and consumer drain order all derive
+    // from the single delivery profile the channel's destinations agree on.
     let output_schema = resolve_output_schema(graph, &source_proc_id, &source_port);
     let dest_schema = resolve_port_schema(
         graph,
@@ -155,10 +154,11 @@ pub fn open_iceoryx2_service(
     // The tier default is the structural ceiling; an operator raises or lowers it
     // per deployment through the tier's node-level env override.
     let channel_ceiling_bytes = effective_channel_ceiling_bytes(trust_tier);
-    let max_queued_messages = max_queued_messages_for_port_spec(&output_schema)?;
+    let delivery = channel_delivery_profile(graph, &source_proc_id, &source_port)?.resolve();
+    let max_queued_messages = delivery.depth;
+    let enable_safe_overflow = delivery.overflow.enable_safe_overflow();
+    let drain_order = delivery.drain_order;
     let max_subscribers = channel_max_subscribers(graph, &source_proc_id, &source_port);
-    let enable_safe_overflow =
-        channel_enable_safe_overflow(graph, &source_proc_id, &source_port)?;
     let max_notifiers = destination_fanin(graph, &dest_proc_id);
 
     let iceoryx2_node = runtime_ctx.iceoryx2_node();
@@ -213,6 +213,7 @@ pub fn open_iceoryx2_service(
             &dest_port,
             &channel_service_name,
             &notify_service_name,
+            drain_order,
             max_queued_messages,
             max_subscribers,
             max_notifiers,
@@ -223,6 +224,8 @@ pub fn open_iceoryx2_service(
             &dest_processor,
             &dest_port,
             &dest_schema,
+            drain_order,
+            max_queued_messages,
             &service,
             &notify_service,
         )?;
@@ -331,46 +334,50 @@ fn destination_fanin(graph: &mut Graph, dest_proc_id: &ProcessorUniqueId) -> usi
     graph.traversal_mut().v(dest_proc_id).in_e().iter().count()
 }
 
-/// The channel's `enable_safe_overflow`, agreed across every destination the
+/// The channel's [`DeliveryProfile`], agreed across every destination the
 /// channel feeds.
 ///
-/// `enable_safe_overflow` is a service-level property shared by all subscribers,
-/// so a channel whose destinations declare conflicting overflow policies
-/// (`drop_oldest` vs `block`) is genuinely ambiguous — that is a named
-/// [`Error::Configuration`] rather than a silent pick. A channel with a single
-/// destination (the common case) uses that destination's policy.
-fn channel_enable_safe_overflow(
+/// A channel's single publisher shares one ring config
+/// (depth + `enable_safe_overflow`) across all subscribers, so its
+/// destinations must resolve to one delivery profile. A channel whose
+/// destinations disagree (`latest` vs `lossless`, say) is genuinely ambiguous —
+/// a named [`Error::Configuration`] rather than a silent pick. A channel with a
+/// single destination (the common case) uses that destination's profile.
+///
+/// [`DeliveryProfile`]: crate::iceoryx2::DeliveryProfile
+fn channel_delivery_profile(
     graph: &mut Graph,
     source_proc_id: &ProcessorUniqueId,
     source_port: &str,
-) -> Result<bool> {
+) -> Result<crate::iceoryx2::DeliveryProfile> {
     // Collected up front so the traversal borrow is released before re-traversing
     // per edge to read each destination's processor type.
     let destinations = channel_destinations(graph, source_proc_id, source_port);
 
-    let mut agreed: Option<bool> = None;
+    let mut agreed: Option<crate::iceoryx2::DeliveryProfile> = None;
     for (dest_proc_id, dest_port) in &destinations {
         let dest_type = graph
             .traversal_mut()
             .v(dest_proc_id)
             .first()
             .map(|node| node.processor_type().clone());
-        let overflow = match dest_type.as_ref() {
-            Some(ident) => overflow_for_input_port(ident, dest_port)?,
-            None => crate::iceoryx2::Overflow::default(),
+        let profile = match dest_type.as_ref() {
+            Some(ident) => delivery_profile_for_input_port(ident, dest_port)?,
+            None => crate::iceoryx2::DeliveryProfile::Latest,
         };
-        let enable = overflow.enable_safe_overflow();
         match agreed {
-            None => agreed = Some(enable),
-            Some(prev) if prev != enable => {
+            None => agreed = Some(profile),
+            Some(prev) if prev != profile => {
                 return Err(Error::Configuration(format!(
-                    "channel '{}:{}' feeds destinations with conflicting overflow \
-                     policies — one wants drop_oldest (enable_safe_overflow) and \
-                     another wants block. A channel's single publisher shares one \
-                     overflow policy across all subscribers; give the destinations \
-                     the same input-port overflow, or fan them out through distinct \
-                     source ports.",
-                    source_proc_id, source_port,
+                    "channel '{}:{}' feeds destinations with conflicting delivery \
+                     profiles — '{}' vs '{}'. A channel's single publisher shares \
+                     one ring config across all subscribers; give the destinations \
+                     the same input-port delivery profile, or fan them out through \
+                     distinct source ports.",
+                    source_proc_id,
+                    source_port,
+                    prev.as_manifest_str(),
+                    profile.as_manifest_str(),
                 )));
             }
             Some(_) => {}
@@ -379,7 +386,7 @@ fn channel_enable_safe_overflow(
 
     // Every wired link has at least the current destination, so `agreed` is Some;
     // the realtime default is the correct fallback if the outbound set were empty.
-    Ok(agreed.unwrap_or_else(|| crate::iceoryx2::Overflow::default().enable_safe_overflow()))
+    Ok(agreed.unwrap_or(crate::iceoryx2::DeliveryProfile::Latest))
 }
 
 /// Check if a processor is a subprocess (Python-native, TypeScript, etc.).
@@ -522,6 +529,8 @@ fn wire_rust_dest(
     dest_processor: &Arc<Mutex<ProcessorInstance>>,
     dest_port: &str,
     dest_schema: &PortSchemaSpec,
+    drain_order: crate::iceoryx2::ReadMode,
+    depth: usize,
     service: &Iceoryx2Service,
     notify_service: &Iceoryx2NotifyService,
 ) -> Result<()> {
@@ -531,7 +540,7 @@ fn wire_rust_dest(
     };
 
     if !input_inner.has_port(dest_port) {
-        input_inner.add_port(dest_port, 1, Default::default());
+        input_inner.add_port(dest_port, depth, drain_order);
     }
     input_inner.set_port_expected_schema_ident(dest_port, schema_ident_wire_for_spec(dest_schema));
 
@@ -606,6 +615,7 @@ fn wire_subprocess_dest(
     dest_port: &str,
     channel_service_name: &str,
     notify_service_name: &str,
+    drain_order: crate::iceoryx2::ReadMode,
     max_queued_messages: usize,
     max_subscribers: usize,
     notify_max_notifiers: usize,
@@ -613,11 +623,13 @@ fn wire_subprocess_dest(
     // The dest reader no longer carries a payload-size hint: the subprocess read
     // buffer starts at the default and grows to the frame it actually receives
     // (PowerOfTwo segment growth on the publisher side, grow-and-retry on read).
+    // The drain order is the delivery profile's, resolved host-side; the
+    // subprocess maps the string back to its `*_input_set_read_mode` integer.
     let entry = serde_json::json!({
         "name": dest_port,
         "channel_service_name": channel_service_name,
         "notify_service_name": notify_service_name,
-        "read_mode": "skip_to_latest",
+        "read_mode": drain_order.as_manifest_str(),
         "max_queued_messages": max_queued_messages,
         "max_subscribers": max_subscribers,
         "notify_max_notifiers": notify_max_notifiers,
@@ -749,31 +761,31 @@ mod tests {
         assert_eq!(destination_fanin(&mut graph, &dest_uid), 3);
     }
 
-    /// A source output port feeding two destinations whose input ports declare
-    /// CONFLICTING overflow policies (`block` vs `drop_oldest`) is genuinely
-    /// ambiguous: a channel's single publisher shares one `enable_safe_overflow`
-    /// across every subscriber. `channel_enable_safe_overflow` surfaces this as a
-    /// named [`Error::Configuration`], not a silent first-connection-wins pick.
+    /// A source output port feeding two destinations whose input ports resolve
+    /// to CONFLICTING delivery profiles (`lossless` vs `latest`) is genuinely
+    /// ambiguous: a channel's single publisher shares one ring config across
+    /// every subscriber. `channel_delivery_profile` surfaces this as a named
+    /// [`Error::Configuration`], not a silent first-connection-wins pick.
     ///
     /// Revert lock: drop the conflict branch (return the first destination's
-    /// policy) and this returns `Ok(_)` — the `expect_err` fails.
+    /// profile) and this returns `Ok(_)` — the `expect_err` fails.
     #[test]
-    fn conflicting_destination_overflow_is_a_configuration_error() {
+    fn conflicting_destination_profile_is_a_configuration_error() {
         use crate::core::descriptors::{PortDescriptor, ProcessorDescriptor};
         use streamlib_idents::{Org, Package, SemVer, TypeName};
         use streamlib_processor_schema::PortSchemaSpec;
 
-        let register_sink = |pkg: &str, overflow: &str| -> SchemaIdent {
+        let register_sink = |pkg: &str, profile: &str| -> SchemaIdent {
             let ident = SchemaIdent::new(
                 Org::new("tatolab").unwrap(),
                 Package::new(pkg).unwrap(),
-                TypeName::new("OverflowSink").unwrap(),
+                TypeName::new("ProfileSink").unwrap(),
                 SemVer::new(1, 0, 0),
             );
-            let mut desc = ProcessorDescriptor::new(ident.clone(), "conflicting-overflow sink");
+            let mut desc = ProcessorDescriptor::new(ident.clone(), "conflicting-profile sink");
             desc.inputs.push(
                 PortDescriptor::iceoryx2("in1", "input", PortSchemaSpec::Any)
-                    .with_overflow(overflow),
+                    .with_delivery_profile(profile),
             );
             // Idempotent: a duplicate ident (re-run in the same process) errors;
             // the first registration is the one that stands.
@@ -781,41 +793,41 @@ mod tests {
             ident
         };
 
-        let block_ident = register_sink("test-conflicting-overflow-block", "block");
-        let drop_ident = register_sink("test-conflicting-overflow-drop", "drop_oldest");
+        let lossless_ident = register_sink("test-conflicting-profile-lossless", "lossless");
+        let latest_ident = register_sink("test-conflicting-profile-latest", "latest");
 
         let mut graph = Graph::new();
         let src_id = add_mock_output_only(&mut graph);
-        let block_dest = graph
+        let lossless_dest = graph
             .traversal_mut()
-            .add_v(ProcessorSpec::new(block_ident, serde_json::Value::Null))
+            .add_v(ProcessorSpec::new(lossless_ident, serde_json::Value::Null))
             .first()
-            .expect("block sink node")
+            .expect("lossless sink node")
             .id
             .to_string();
-        let drop_dest = graph
+        let latest_dest = graph
             .traversal_mut()
-            .add_v(ProcessorSpec::new(drop_ident, serde_json::Value::Null))
+            .add_v(ProcessorSpec::new(latest_ident, serde_json::Value::Null))
             .first()
-            .expect("drop sink node")
+            .expect("latest sink node")
             .id
             .to_string();
 
         graph.traversal_mut().add_e(
             OutputLinkPortRef::new(&src_id, "out1"),
-            InputLinkPortRef::new(&block_dest, "in1"),
+            InputLinkPortRef::new(&lossless_dest, "in1"),
         );
         graph.traversal_mut().add_e(
             OutputLinkPortRef::new(&src_id, "out1"),
-            InputLinkPortRef::new(&drop_dest, "in1"),
+            InputLinkPortRef::new(&latest_dest, "in1"),
         );
 
         let src_uid: ProcessorUniqueId = src_id.as_str().into();
-        let err = channel_enable_safe_overflow(&mut graph, &src_uid, "out1")
-            .expect_err("conflicting overflow policies must be a configuration error");
+        let err = channel_delivery_profile(&mut graph, &src_uid, "out1")
+            .expect_err("conflicting delivery profiles must be a configuration error");
         assert!(
             matches!(err, Error::Configuration(_)),
-            "conflicting destination overflow must surface as Error::Configuration; got {err:?}",
+            "conflicting destination profile must surface as Error::Configuration; got {err:?}",
         );
     }
 

--- a/runtime/streamlib-engine/src/core/embedded_schemas/mod.rs
+++ b/runtime/streamlib-engine/src/core/embedded_schemas/mod.rs
@@ -144,72 +144,103 @@ pub fn expected_payload_bytes_for_port_spec(
         .map(|opt| opt.unwrap_or(DEFAULT_EXPECTED_PAYLOAD_BYTES))
 }
 
-/// Resolve the iceoryx2 ring depth (slot count) for a port's wire schema
-/// from `metadata.max_queued_messages`.
+/// Resolve the effective [`DeliveryProfile`] for a destination input port.
 ///
-/// Returns [`DEFAULT_MAX_QUEUED_MESSAGES`] for `Any` (legitimate wildcard)
-/// and for registered schemas that don't declare the field. Returns
-/// [`Error::Configuration`] when the spec refers to a schema absent from
-/// the runtime registry — the actionable shape catches the "forgot
-/// `runtime.add_module(...)`" footgun at wire time rather than as a
-/// silently undersized ring dropping messages under burst load.
+/// This is the single delivery-resolution primitive. Precedence:
 ///
-/// [`DEFAULT_MAX_QUEUED_MESSAGES`]: crate::iceoryx2::DEFAULT_MAX_QUEUED_MESSAGES
-/// [`Error::Configuration`]: crate::core::error::Error::Configuration
-pub fn max_queued_messages_for_port_spec(
-    schema_spec: &streamlib_processor_schema::PortSchemaSpec,
-) -> crate::core::error::Result<usize> {
-    use crate::iceoryx2::DEFAULT_MAX_QUEUED_MESSAGES;
-    resolve_metadata_u64_for_port_spec(schema_spec, "max_queued_messages")
-        .map(|opt| opt.unwrap_or(DEFAULT_MAX_QUEUED_MESSAGES))
-}
-
-/// Resolve the producer-side overflow policy for a destination input port.
+/// 1. A port-site `delivery_profile` override (the one delivery knob on the
+///    authoring surface) wins outright.
+/// 2. Otherwise the default derived from the wire type's `metadata.flow_class`
+///    ([`flow_class_for_port_spec`]): `sample_stream` → `every_sample`,
+///    `state_stream` → `latest`.
+/// 3. Otherwise (an `any` wildcard port, or a registered schema that declares
+///    no `flow_class`) [`DeliveryProfile::Latest`] — the newest-wins realtime
+///    default.
 ///
-/// Looks up the destination processor in [`PROCESSOR_REGISTRY`] and reads
-/// the named input port's declared `overflow` field. Falls back to
-/// [`Overflow::default()`] (`DropOldest` — the engine-wide realtime
-/// invariant) when:
-///
-/// - The destination processor type isn't registered (e.g. an in-tree
-///   compiler-op site that fires before registration completes — should
-///   never happen for a Wired link but the conservative fallback is
-///   correct).
-/// - The named port doesn't exist on the destination (shape-mismatched
-///   wiring; the compiler's other validators surface this distinctly).
-/// - The port exists but no `overflow:` is declared (the common case).
-///
-/// Returns [`Error::Configuration`] when the declared string is non-empty
-/// but unrecognized — typo at the manifest level is a wire-time error,
+/// Falls back to [`DeliveryProfile::Latest`] when the destination processor
+/// type isn't registered or the named port doesn't exist (defensive; a Wired
+/// link always resolves both). Returns [`Error::Configuration`] when an
+/// override or `flow_class` string is present but unrecognized, or when the
+/// port's wire schema is absent from the runtime registry — a wire-time error,
 /// not a silent default substitution.
 ///
-/// [`PROCESSOR_REGISTRY`]: crate::core::processors::PROCESSOR_REGISTRY
-/// [`Overflow::default()`]: crate::iceoryx2::Overflow::default
+/// [`DeliveryProfile`]: crate::iceoryx2::DeliveryProfile
+/// [`DeliveryProfile::Latest`]: crate::iceoryx2::DeliveryProfile::Latest
 /// [`Error::Configuration`]: crate::core::error::Error::Configuration
-pub fn overflow_for_input_port(
+pub fn delivery_profile_for_input_port(
     processor_type: &streamlib_idents::SchemaIdent,
     port_name: &str,
-) -> crate::core::error::Result<crate::iceoryx2::Overflow> {
-    use crate::iceoryx2::Overflow;
+) -> crate::core::error::Result<crate::iceoryx2::DeliveryProfile> {
+    use crate::iceoryx2::DeliveryProfile;
 
     let Some((inputs, _outputs)) =
         crate::core::processors::PROCESSOR_REGISTRY.port_info(processor_type)
     else {
-        return Ok(Overflow::default());
+        return Ok(DeliveryProfile::Latest);
     };
     let Some(port) = inputs.iter().find(|p| p.name == port_name) else {
-        return Ok(Overflow::default());
+        return Ok(DeliveryProfile::Latest);
     };
-    let Some(declared) = port.overflow.as_deref() else {
-        return Ok(Overflow::default());
-    };
-    Overflow::from_manifest_str(declared).map_err(|err| {
+
+    if let Some(declared) = port.delivery_profile.as_deref() {
+        return DeliveryProfile::from_manifest_str(declared).map_err(|err| {
+            crate::core::error::Error::Configuration(format!(
+                "input port '{}' on '{}' declared {}",
+                port_name, processor_type, err
+            ))
+        });
+    }
+
+    Ok(flow_class_for_port_spec(&port.data_type)?
+        .map(|fc| fc.default_profile())
+        .unwrap_or(DeliveryProfile::Latest))
+}
+
+/// Resolve the [`FlowClass`] declared in a port's wire schema
+/// `metadata.flow_class`.
+///
+/// `Any` → `Ok(None)` (wildcard, no type-level default). A registered schema
+/// that declares no `flow_class` → `Ok(None)` (caller substitutes the realtime
+/// default). A registry miss → [`Error::Configuration`] naming the missing
+/// canonical id and pointing at `runtime.add_module(...)`. A present-but-
+/// unrecognized `flow_class` string → [`Error::Configuration`].
+///
+/// [`FlowClass`]: crate::iceoryx2::FlowClass
+/// [`Error::Configuration`]: crate::core::error::Error::Configuration
+pub fn flow_class_for_port_spec(
+    schema_spec: &streamlib_processor_schema::PortSchemaSpec,
+) -> crate::core::error::Result<Option<crate::iceoryx2::FlowClass>> {
+    use crate::iceoryx2::FlowClass;
+
+    if matches!(schema_spec, streamlib_processor_schema::PortSchemaSpec::Any) {
+        return Ok(None);
+    }
+    let canonical = schema_spec.to_string();
+    let yaml = get_embedded_schema_definition(&canonical).ok_or_else(|| {
         crate::core::error::Error::Configuration(format!(
-            "input port '{}' on '{}' declared {} — manifest must use one of \
-             'drop_oldest' or 'block'.",
-            port_name, processor_type, err
+            "schema '{canonical}' referenced by a port spec but not in the \
+             runtime schema registry — did you forget to call \
+             `runtime.add_module(...)` for the package providing it? \
+             (Use `list_embedded_schema_names()` to inspect what's currently \
+             registered.)"
         ))
-    })
+    })?;
+    let value: serde_yaml::Value = match serde_yaml::from_str(&yaml) {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+    let declared = value
+        .get("metadata")
+        .and_then(|m| m.get("flow_class"))
+        .and_then(|v| v.as_str());
+    match declared {
+        Some(s) => FlowClass::from_manifest_str(s).map(Some).map_err(|err| {
+            crate::core::error::Error::Configuration(format!(
+                "schema '{canonical}' declared {err}"
+            ))
+        }),
+        None => Ok(None),
+    }
 }
 
 /// Resolve the [`PortSchemaSpec`] declared on one port of a registered
@@ -392,11 +423,11 @@ pub(crate) mod test_support {
         INIT.call_once(|| {
             register_schema(
                 SMALL_FRAME_ID,
-                "metadata:\n  type: SmallFrame\n  expected_payload_bytes: 131072\n  max_queued_messages: 32\n",
+                "metadata:\n  type: SmallFrame\n  expected_payload_bytes: 131072\n  flow_class: state_stream\n",
             );
             register_schema(
                 LARGE_FRAME_ID,
-                "metadata:\n  type: LargeFrame\n  expected_payload_bytes: 16777216\n  max_queued_messages: 16\n",
+                "metadata:\n  type: LargeFrame\n  expected_payload_bytes: 16777216\n  flow_class: sample_stream\n",
             );
         });
     }
@@ -565,223 +596,203 @@ mod tests {
         );
     }
 
-    /// Symmetric registry-miss test for `max_queued_messages_for_port_spec`
-    /// — the more insidious half of the helper pair (an undersized ring
-    /// silently drops messages under burst load with no error visible to
-    /// the application).
+    /// `flow_class` resolves the type-level default: `state_stream` → the
+    /// resolver returns `StateStream`, whose default profile is `Latest`.
     #[test]
-    fn max_queued_messages_errors_on_registry_miss_with_add_module_hint() {
+    fn flow_class_resolves_state_stream() {
+        use crate::iceoryx2::FlowClass;
+        test_support::register_test_wire_vocabulary();
+        assert_eq!(
+            flow_class_for_port_spec(&test_wire_spec("SmallFrame")).unwrap(),
+            Some(FlowClass::StateStream),
+            "SmallFrame declares flow_class: state_stream"
+        );
+        assert_eq!(
+            flow_class_for_port_spec(&test_wire_spec("LargeFrame")).unwrap(),
+            Some(FlowClass::SampleStream),
+            "LargeFrame declares flow_class: sample_stream"
+        );
+    }
+
+    /// `Any` and a registered schema with no `flow_class` both resolve to
+    /// `None` — the caller substitutes the realtime default.
+    #[test]
+    fn flow_class_none_for_any_and_field_absent() {
+        assert_eq!(
+            flow_class_for_port_spec(&PortSchemaSpec::Any).unwrap(),
+            None
+        );
+        let canonical = "@tatolab/test-flowclass-absent/NoClass";
+        register_schema(
+            canonical,
+            "metadata:\n  type: NoClass\n  expected_payload_bytes: 4096\n",
+        );
         let spec = PortSchemaSpec::Specific(SchemaIdent::new(
             Org::new("tatolab").unwrap(),
-            Package::new("does-not-exist-mqm").unwrap(),
+            Package::new("test-flowclass-absent").unwrap(),
+            TypeName::new("NoClass").unwrap(),
+            SemVer::new(1, 0, 0),
+        ));
+        assert_eq!(flow_class_for_port_spec(&spec).unwrap(), None);
+    }
+
+    /// A `flow_class` referencing a schema absent from the registry surfaces
+    /// a typed configuration error naming the missing id and pointing at
+    /// `runtime.add_module(...)`.
+    #[test]
+    fn flow_class_errors_on_registry_miss_with_add_module_hint() {
+        let spec = PortSchemaSpec::Specific(SchemaIdent::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("does-not-exist-flowclass").unwrap(),
             TypeName::new("Nothing").unwrap(),
             SemVer::new(1, 0, 0),
         ));
-        let err = max_queued_messages_for_port_spec(&spec)
-            .expect_err("registry miss must surface as Err");
+        let err =
+            flow_class_for_port_spec(&spec).expect_err("registry miss must surface as Err");
         let msg = err.to_string();
         assert!(
-            msg.contains("@tatolab/does-not-exist-mqm/Nothing"),
+            msg.contains("@tatolab/does-not-exist-flowclass/Nothing"),
             "error must name the missing canonical id; got: {msg}"
         );
         assert!(
             msg.contains("add_module"),
-            "error must point at `runtime.add_module(...)` as the fix; got: {msg}"
+            "error must point at `runtime.add_module(...)`; got: {msg}"
         );
-        assert!(
-            matches!(err, crate::core::error::Error::Configuration(_)),
-            "registry miss must be Error::Configuration; got: {err:?}"
-        );
-    }
-
-    #[test]
-    fn max_queued_messages_any_returns_default() {
-        use crate::iceoryx2::DEFAULT_MAX_QUEUED_MESSAGES;
-        assert_eq!(
-            max_queued_messages_for_port_spec(&PortSchemaSpec::Any).unwrap(),
-            DEFAULT_MAX_QUEUED_MESSAGES
-        );
-    }
-
-    /// A schema declaring `metadata.max_queued_messages` is honored by the
-    /// resolver. Reverting the resolver's `metadata.max_queued_messages`
-    /// branch to return the default will fail this test.
-    #[test]
-    fn max_queued_messages_resolves_declared_value() {
-        let canonical = "@tatolab/test-mqm-resolves/HighRateStream";
-        register_schema(
-            canonical,
-            "metadata:\n  type: HighRateStream\n  max_queued_messages: 128\n",
-        );
-        let spec = PortSchemaSpec::Specific(SchemaIdent::new(
-            Org::new("tatolab").unwrap(),
-            Package::new("test-mqm-resolves").unwrap(),
-            TypeName::new("HighRateStream").unwrap(),
-            SemVer::new(1, 0, 0),
-        ));
-        assert_eq!(max_queued_messages_for_port_spec(&spec).unwrap(), 128);
-    }
-
-    /// A registered schema without `metadata.max_queued_messages` falls
-    /// back to the default — proves the resolver doesn't accidentally
-    /// read some adjacent field, and proves the registry-miss-vs-field-
-    /// absent split: a schema that IS registered but doesn't declare the
-    /// field is a legitimate "use default" case (no error), whereas a
-    /// registry miss is a configuration error.
-    #[test]
-    fn max_queued_messages_falls_back_when_field_absent() {
-        use crate::iceoryx2::DEFAULT_MAX_QUEUED_MESSAGES;
-        let canonical = "@tatolab/test-mqm-fallback/NoMqm";
-        register_schema(
-            canonical,
-            "metadata:\n  type: NoMqm\n  expected_payload_bytes: 4096\n",
-        );
-        let spec = PortSchemaSpec::Specific(SchemaIdent::new(
-            Org::new("tatolab").unwrap(),
-            Package::new("test-mqm-fallback").unwrap(),
-            TypeName::new("NoMqm").unwrap(),
-            SemVer::new(1, 0, 0),
-        ));
-        assert_eq!(
-            max_queued_messages_for_port_spec(&spec).unwrap(),
-            DEFAULT_MAX_QUEUED_MESSAGES
-        );
+        assert!(matches!(err, crate::core::error::Error::Configuration(_)));
     }
 
     /// Locks the default-fallback path: a processor type that isn't
-    /// registered yields `Overflow::DropOldest` (the engine-wide
-    /// realtime invariant). Mentally reverting the fallback to
-    /// `Block` here would silently re-introduce producer-blocking
-    /// for unregistered (defensively-handled) cases — fail loudly
-    /// rather than ship that quietly.
+    /// registered yields [`DeliveryProfile::Latest`] (the newest-wins
+    /// realtime default). Mentally reverting the fallback to a blocking
+    /// profile would silently re-introduce producer-blocking for
+    /// unregistered (defensively-handled) cases.
     #[test]
-    fn overflow_for_input_port_defaults_when_processor_unregistered() {
-        use crate::iceoryx2::Overflow;
+    fn delivery_profile_defaults_latest_when_processor_unregistered() {
+        use crate::iceoryx2::DeliveryProfile;
         let unknown = SchemaIdent::new(
             Org::new("tatolab").unwrap(),
-            Package::new("does-not-exist-overflow").unwrap(),
+            Package::new("does-not-exist-profile").unwrap(),
             TypeName::new("Nothing").unwrap(),
             SemVer::new(1, 0, 0),
         );
         assert_eq!(
-            overflow_for_input_port(&unknown, "video_in").unwrap(),
-            Overflow::DropOldest
+            delivery_profile_for_input_port(&unknown, "video_in").unwrap(),
+            DeliveryProfile::Latest
         );
     }
 
-    /// Manifest-declared `overflow: "block"` on an input port is
-    /// honored by the registry-side resolver. Built directly against
-    /// the registry helpers used by `register_descriptor_only` — the
-    /// subprocess registration path — so the assertion covers both
-    /// host and subprocess wirings.
+    /// A port-site `delivery_profile` override wins over the flow-class
+    /// default — `lossless` on a video input (whose flow_class default is
+    /// `latest`) resolves to `Lossless`.
     #[test]
-    fn overflow_for_input_port_resolves_block_declaration() {
+    fn delivery_profile_override_wins_over_flow_class() {
         use crate::core::descriptors::{PortDescriptor, ProcessorDescriptor};
         use crate::core::processors::PROCESSOR_REGISTRY;
-        use crate::iceoryx2::Overflow;
+        use crate::iceoryx2::DeliveryProfile;
 
         let processor_type = SchemaIdent::new(
             Org::new("tatolab").unwrap(),
-            Package::new("test-overflow-block").unwrap(),
+            Package::new("test-profile-override").unwrap(),
             TypeName::new("BlockSink").unwrap(),
             SemVer::new(1, 0, 0),
         );
+        register_schema(
+            "@tatolab/test-profile-override/StateFrame",
+            "metadata:\n  type: StateFrame\n  flow_class: state_stream\n",
+        );
         let video_schema = PortSchemaSpec::Specific(SchemaIdent::new(
             Org::new("tatolab").unwrap(),
-            Package::new("core").unwrap(),
-            TypeName::new("VideoFrame").unwrap(),
+            Package::new("test-profile-override").unwrap(),
+            TypeName::new("StateFrame").unwrap(),
             SemVer::new(1, 0, 0),
         ));
         let mut desc = ProcessorDescriptor::new(processor_type.clone(), "block-sink");
         desc.inputs.push(
-            PortDescriptor::iceoryx2("video_in", "input", video_schema).with_overflow("block"),
+            PortDescriptor::iceoryx2("video_in", "input", video_schema)
+                .with_delivery_profile("lossless"),
         );
         PROCESSOR_REGISTRY
             .register_descriptor_only(desc)
             .expect("descriptor registration");
 
         assert_eq!(
-            overflow_for_input_port(&processor_type, "video_in").unwrap(),
-            Overflow::Block
+            delivery_profile_for_input_port(&processor_type, "video_in").unwrap(),
+            DeliveryProfile::Lossless,
+            "explicit lossless override must beat the state_stream default"
         );
     }
 
-    /// A registered input port without an explicit `overflow:`
-    /// declaration falls back to the engine-wide default. Symmetric to
-    /// the registry-miss test above — distinguishes "field absent" from
-    /// "processor absent" so a future refactor can't conflate them.
+    /// With no override, the flow-class default drives the profile:
+    /// `sample_stream` → `EverySample`.
     #[test]
-    fn overflow_for_input_port_defaults_when_field_absent() {
+    fn delivery_profile_defaults_from_flow_class() {
         use crate::core::descriptors::{PortDescriptor, ProcessorDescriptor};
         use crate::core::processors::PROCESSOR_REGISTRY;
-        use crate::iceoryx2::Overflow;
+        use crate::iceoryx2::DeliveryProfile;
 
         let processor_type = SchemaIdent::new(
             Org::new("tatolab").unwrap(),
-            Package::new("test-overflow-default").unwrap(),
-            TypeName::new("DefaultSink").unwrap(),
+            Package::new("test-profile-default").unwrap(),
+            TypeName::new("SampleSink").unwrap(),
             SemVer::new(1, 0, 0),
         );
-        let video_schema = PortSchemaSpec::Specific(SchemaIdent::new(
+        register_schema(
+            "@tatolab/test-profile-default/SampleFrame",
+            "metadata:\n  type: SampleFrame\n  flow_class: sample_stream\n",
+        );
+        let schema = PortSchemaSpec::Specific(SchemaIdent::new(
             Org::new("tatolab").unwrap(),
-            Package::new("core").unwrap(),
-            TypeName::new("VideoFrame").unwrap(),
+            Package::new("test-profile-default").unwrap(),
+            TypeName::new("SampleFrame").unwrap(),
             SemVer::new(1, 0, 0),
         ));
-        let mut desc = ProcessorDescriptor::new(processor_type.clone(), "default-sink");
+        let mut desc = ProcessorDescriptor::new(processor_type.clone(), "sample-sink");
         desc.inputs
-            .push(PortDescriptor::iceoryx2("video_in", "input", video_schema));
+            .push(PortDescriptor::iceoryx2("audio_in", "input", schema));
         PROCESSOR_REGISTRY
             .register_descriptor_only(desc)
             .expect("descriptor registration");
 
         assert_eq!(
-            overflow_for_input_port(&processor_type, "video_in").unwrap(),
-            Overflow::DropOldest
+            delivery_profile_for_input_port(&processor_type, "audio_in").unwrap(),
+            DeliveryProfile::EverySample
         );
     }
 
-    /// A typo at the manifest level surfaces as a typed configuration
-    /// error rather than a silent default fallback — wire-time rejection
-    /// of bad declarations is the actionable shape.
+    /// A typo in a port-site `delivery_profile` override surfaces as a typed
+    /// configuration error rather than a silent default fallback.
     #[test]
-    fn overflow_for_input_port_rejects_unknown_string() {
+    fn delivery_profile_rejects_unknown_override() {
         use crate::core::descriptors::{PortDescriptor, ProcessorDescriptor};
         use crate::core::processors::PROCESSOR_REGISTRY;
 
         let processor_type = SchemaIdent::new(
             Org::new("tatolab").unwrap(),
-            Package::new("test-overflow-typo").unwrap(),
+            Package::new("test-profile-typo").unwrap(),
             TypeName::new("TypoSink").unwrap(),
             SemVer::new(1, 0, 0),
         );
-        let video_schema = PortSchemaSpec::Specific(SchemaIdent::new(
-            Org::new("tatolab").unwrap(),
-            Package::new("core").unwrap(),
-            TypeName::new("VideoFrame").unwrap(),
-            SemVer::new(1, 0, 0),
-        ));
         let mut desc = ProcessorDescriptor::new(processor_type.clone(), "typo-sink");
         desc.inputs.push(
-            PortDescriptor::iceoryx2("video_in", "input", video_schema)
-                .with_overflow("drop-oldest"), // hyphen instead of underscore
+            PortDescriptor::iceoryx2("video_in", "input", PortSchemaSpec::Any)
+                .with_delivery_profile("skip_to_latest"), // retired knob, not a profile
         );
         PROCESSOR_REGISTRY
             .register_descriptor_only(desc)
             .expect("descriptor registration");
 
-        let err = overflow_for_input_port(&processor_type, "video_in")
-            .expect_err("unknown overflow string must error");
+        let err = delivery_profile_for_input_port(&processor_type, "video_in")
+            .expect_err("unknown delivery_profile must error");
         let msg = err.to_string();
+        assert!(msg.contains("latest"), "error must list valid values: {msg}");
         assert!(
-            msg.contains("drop_oldest"),
+            msg.contains("every_sample"),
             "error must list valid values: {msg}"
         );
-        assert!(msg.contains("block"), "error must list valid values: {msg}");
-        assert!(
-            matches!(err, crate::core::error::Error::Configuration(_)),
-            "must be Configuration error: {err:?}"
-        );
+        assert!(matches!(
+            err,
+            crate::core::error::Error::Configuration(_)
+        ));
     }
 
     #[test]

--- a/runtime/streamlib-engine/src/core/embedded_schemas/mod.rs
+++ b/runtime/streamlib-engine/src/core/embedded_schemas/mod.rs
@@ -201,9 +201,9 @@ pub fn delivery_profile_for_input_port(
 ///
 /// `Any` → `Ok(None)` (wildcard, no type-level default). A registered schema
 /// that declares no `flow_class` → `Ok(None)` (caller substitutes the realtime
-/// default). A registry miss → [`Error::Configuration`] naming the missing
-/// canonical id and pointing at `runtime.add_module(...)`. A present-but-
-/// unrecognized `flow_class` string → [`Error::Configuration`].
+/// default). A registry miss or malformed schema YAML → [`Error::Configuration`]
+/// naming the schema (registry misses also point at `runtime.add_module(...)`).
+/// A present-but-unrecognized `flow_class` string → [`Error::Configuration`].
 ///
 /// [`FlowClass`]: crate::iceoryx2::FlowClass
 /// [`Error::Configuration`]: crate::core::error::Error::Configuration
@@ -212,31 +212,14 @@ pub fn flow_class_for_port_spec(
 ) -> crate::core::error::Result<Option<crate::iceoryx2::FlowClass>> {
     use crate::iceoryx2::FlowClass;
 
-    if matches!(schema_spec, streamlib_processor_schema::PortSchemaSpec::Any) {
+    let Some(value) = metadata_value_for_port_spec(schema_spec, "flow_class")? else {
         return Ok(None);
-    }
-    let canonical = schema_spec.to_string();
-    let yaml = get_embedded_schema_definition(&canonical).ok_or_else(|| {
-        crate::core::error::Error::Configuration(format!(
-            "schema '{canonical}' referenced by a port spec but not in the \
-             runtime schema registry — did you forget to call \
-             `runtime.add_module(...)` for the package providing it? \
-             (Use `list_embedded_schema_names()` to inspect what's currently \
-             registered.)"
-        ))
-    })?;
-    let value: serde_yaml::Value = match serde_yaml::from_str(&yaml) {
-        Ok(v) => v,
-        Err(_) => return Ok(None),
     };
-    let declared = value
-        .get("metadata")
-        .and_then(|m| m.get("flow_class"))
-        .and_then(|v| v.as_str());
-    match declared {
+    match value.as_str() {
         Some(s) => FlowClass::from_manifest_str(s).map(Some).map_err(|err| {
             crate::core::error::Error::Configuration(format!(
-                "schema '{canonical}' declared {err}"
+                "schema '{}' declared {err}",
+                schema_spec
             ))
         }),
         None => Ok(None),
@@ -312,20 +295,25 @@ pub fn resolve_node_port_schema(
     }
 }
 
-/// Shared lookup helper for both port-spec metadata resolvers.
+/// Shared registry-lookup preamble for every port-spec metadata resolver.
+///
+/// Owns the three concerns each leaf resolver would otherwise copy: the `Any`
+/// wildcard guard, the registry-miss error, and the schema-YAML parse. Returns
+/// the `metadata.<field>` node cloned out of the parsed schema so callers can
+/// project only their leaf (`.as_u64()`, `.as_str()`).
 ///
 /// `Any` → `Ok(None)` (caller substitutes default).
-/// `Specific` / `Named` with registry hit → `Ok(Some(value))` if the
-/// declared `metadata.<field>` parses as a `u64`, else `Ok(None)`
-/// (caller substitutes default — registered schema chose not to
-/// constrain).
-/// `Specific` / `Named` with registry miss → `Err(Configuration(...))`
-/// naming the missing canonical id and pointing the developer at
-/// `runtime.add_module(...)`.
-fn resolve_metadata_u64_for_port_spec(
+/// Registry hit, field present → `Ok(Some(value))`.
+/// Registry hit, field absent → `Ok(None)` (caller substitutes default —
+/// registered schema chose not to constrain).
+/// Registry miss → `Err(Configuration(...))` naming the missing canonical id
+/// and pointing the developer at `runtime.add_module(...)`.
+/// Malformed schema YAML → `Err(Configuration(...))` naming the schema — a
+/// wire-time error, not a silent default substitution.
+fn metadata_value_for_port_spec(
     schema_spec: &streamlib_processor_schema::PortSchemaSpec,
     field: &str,
-) -> crate::core::error::Result<Option<usize>> {
+) -> crate::core::error::Result<Option<serde_yaml::Value>> {
     if matches!(schema_spec, streamlib_processor_schema::PortSchemaSpec::Any) {
         return Ok(None);
     }
@@ -339,16 +327,26 @@ fn resolve_metadata_u64_for_port_spec(
              registered.)"
         ))
     })?;
-    let value: serde_yaml::Value = match serde_yaml::from_str(&yaml) {
-        Ok(v) => v,
-        Err(_) => return Ok(None),
-    };
-    let declared = value
-        .get("metadata")
-        .and_then(|m| m.get(field))
-        .and_then(|v| v.as_u64())
-        .map(|n| n as usize);
-    Ok(declared)
+    let value: serde_yaml::Value = serde_yaml::from_str(&yaml).map_err(|err| {
+        crate::core::error::Error::Configuration(format!(
+            "schema '{canonical}' has malformed metadata YAML in the runtime \
+             schema registry: {err}"
+        ))
+    })?;
+    Ok(value.get("metadata").and_then(|m| m.get(field)).cloned())
+}
+
+/// `u64` leaf projection over [`metadata_value_for_port_spec`]. A present-but-
+/// non-`u64` value resolves to `Ok(None)` (caller substitutes default —
+/// registered schema chose not to constrain).
+fn resolve_metadata_u64_for_port_spec(
+    schema_spec: &streamlib_processor_schema::PortSchemaSpec,
+    field: &str,
+) -> crate::core::error::Result<Option<usize>> {
+    Ok(metadata_value_for_port_spec(schema_spec, field)?
+        .as_ref()
+        .and_then(serde_yaml::Value::as_u64)
+        .map(|n| n as usize))
 }
 
 /// List every registered schema's canonical identifier (unversioned).
@@ -657,6 +655,30 @@ mod tests {
         assert!(
             msg.contains("add_module"),
             "error must point at `runtime.add_module(...)`; got: {msg}"
+        );
+        assert!(matches!(err, crate::core::error::Error::Configuration(_)));
+    }
+
+    /// A registered schema whose body is malformed YAML surfaces a typed
+    /// configuration error naming the schema — a wire-time error, never a
+    /// silent fall-through to the realtime default. Mentally reverting the
+    /// shared helper's parse to `Err(_) => Ok(None)` makes this fail.
+    #[test]
+    fn flow_class_errors_on_malformed_schema_yaml() {
+        let canonical = "@tatolab/test-flowclass-malformed/Broken";
+        register_schema(canonical, "metadata: {unterminated flow mapping\n");
+        let spec = PortSchemaSpec::Specific(SchemaIdent::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("test-flowclass-malformed").unwrap(),
+            TypeName::new("Broken").unwrap(),
+            SemVer::new(1, 0, 0),
+        ));
+        let err =
+            flow_class_for_port_spec(&spec).expect_err("malformed schema YAML must surface as Err");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("@tatolab/test-flowclass-malformed/Broken"),
+            "error must name the schema with malformed YAML; got: {msg}"
         );
         assert!(matches!(err, crate::core::error::Error::Configuration(_)));
     }

--- a/runtime/streamlib-engine/src/core/graph/nodes/port_info.rs
+++ b/runtime/streamlib-engine/src/core/graph/nodes/port_info.rs
@@ -13,12 +13,13 @@ pub struct PortInfo {
     pub data_type: PortSchemaSpec,
     #[serde(default)]
     pub port_kind: PortKind,
-    /// Producer-side overflow policy declared by this input port —
-    /// `Some("drop_oldest")` or `Some("block")`, or `None` for output
-    /// ports / inputs that defer to the engine-wide default. Mirrors
-    /// the field on [`crate::core::descriptors::PortDescriptor`] so
-    /// the compiler op can resolve a destination's overflow at wire
-    /// time without locking the processor instance.
+    /// Delivery-profile override declared by this input port —
+    /// `Some("latest" | "every_sample" | "lossless")`, or `None` for
+    /// output ports / inputs that defer to the wire type's `flow_class`
+    /// default. Mirrors the field on
+    /// [`crate::core::descriptors::PortDescriptor`] so the compiler op
+    /// can resolve a destination's delivery profile at wire time without
+    /// locking the processor instance.
     #[serde(default)]
-    pub overflow: Option<String>,
+    pub delivery_profile: Option<String>,
 }

--- a/runtime/streamlib-engine/src/core/json_schema.rs
+++ b/runtime/streamlib-engine/src/core/json_schema.rs
@@ -461,7 +461,7 @@ mod schema_ident_output_tests {
                 SemVer::new(1, 0, 0),
             )),
             port_kind: crate::core::graph::PortKind::Data,
-            overflow: None,
+            delivery_profile: None,
         };
         let out = PortInfoOutput::from(&port);
         let s = out.data_type.as_ref().expect("Specific must resolve");
@@ -487,7 +487,7 @@ mod schema_ident_output_tests {
             name: "data".to_string(),
             data_type: PortSchemaSpec::Any,
             port_kind: crate::core::graph::PortKind::Data,
-            overflow: None,
+            delivery_profile: None,
         };
         let out = PortInfoOutput::from(&port);
         assert!(out.data_type.is_none());

--- a/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
+++ b/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
@@ -908,7 +908,7 @@ impl ProcessorInstanceFactory {
                 name: p.name.clone(),
                 data_type: p.schema.clone(),
                 port_kind: Default::default(),
-                overflow: p.overflow.clone(),
+                delivery_profile: p.delivery_profile.clone(),
             })
             .collect();
 
@@ -919,7 +919,7 @@ impl ProcessorInstanceFactory {
                 name: p.name.clone(),
                 data_type: p.schema.clone(),
                 port_kind: Default::default(),
-                overflow: p.overflow.clone(),
+                delivery_profile: p.delivery_profile.clone(),
             })
             .collect();
 
@@ -992,7 +992,7 @@ impl ProcessorInstanceFactory {
                 name: p.name.clone(),
                 data_type: p.schema.clone(),
                 port_kind: Default::default(),
-                overflow: p.overflow.clone(),
+                delivery_profile: p.delivery_profile.clone(),
             })
             .collect();
 
@@ -1003,7 +1003,7 @@ impl ProcessorInstanceFactory {
                 name: p.name.clone(),
                 data_type: p.schema.clone(),
                 port_kind: Default::default(),
-                overflow: p.overflow.clone(),
+                delivery_profile: p.delivery_profile.clone(),
             })
             .collect();
 
@@ -1064,7 +1064,7 @@ impl ProcessorInstanceFactory {
                 name: p.name.clone(),
                 data_type: p.schema.clone(),
                 port_kind: Default::default(),
-                overflow: p.overflow.clone(),
+                delivery_profile: p.delivery_profile.clone(),
             })
             .collect();
 
@@ -1075,7 +1075,7 @@ impl ProcessorInstanceFactory {
                 name: p.name.clone(),
                 data_type: p.schema.clone(),
                 port_kind: Default::default(),
-                overflow: p.overflow.clone(),
+                delivery_profile: p.delivery_profile.clone(),
             })
             .collect();
 

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/processor_registration.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/processor_registration.rs
@@ -410,12 +410,16 @@ pub(super) fn register_manifest_processors(
             .inputs
             .iter()
             .map(|p| {
-                PortDescriptor::new(
+                let descriptor = PortDescriptor::new(
                     &p.name,
                     p.description.as_deref().unwrap_or(""),
                     p.schema.clone(),
                     true,
-                )
+                );
+                match &p.delivery_profile {
+                    Some(profile) => descriptor.with_delivery_profile(profile),
+                    None => descriptor,
+                }
             })
             .collect();
 

--- a/runtime/streamlib-engine/src/iceoryx2/delivery_profile.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/delivery_profile.rs
@@ -12,15 +12,12 @@
 //! default derives from the wire type's [`FlowClass`], carried in the schema
 //! `metadata` block — so authors mostly never touch it.
 
-use serde::{Deserialize, Serialize};
-
 use super::overflow::Overflow;
 use super::read_mode::ReadMode;
 
 /// The one per-port delivery knob. Each profile bundles a fixed
 /// (drain order, overflow policy, ring depth) triple; see [`DeliveryProfile::resolve`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeliveryProfile {
     /// Newest-wins: drain to the latest sample, evict oldest under pressure,
     /// shallow ring. State snapshots — video frames, control state — where a
@@ -105,8 +102,7 @@ impl DeliveryProfile {
 /// The per-wire-type data class carried in a schema's `metadata.flow_class`.
 /// It sets the *default* [`DeliveryProfile`] for any port carrying that type,
 /// which a port-site profile override still wins over.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlowClass {
     /// Ordered samples where every one matters — audio, encoded frames.
     /// Defaults to [`DeliveryProfile::EverySample`].

--- a/runtime/streamlib-engine/src/iceoryx2/delivery_profile.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/delivery_profile.rs
@@ -1,0 +1,240 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The single per-port delivery knob on the authoring surface.
+//!
+//! A [`DeliveryProfile`] is the one word an author writes at a port declaration
+//! site (`#[processor]` attribute / `@processor` decorator). It resolves to the
+//! three transport settings the engine used to expose as four separate knobs
+//! (`read_mode`, `overflow`, `buffer_size`, `max_queued_messages`): the
+//! consumer-side drain order ([`ReadMode`]), the producer-side overflow policy
+//! ([`Overflow`]), and the ring depth. When a port declares no profile, the
+//! default derives from the wire type's [`FlowClass`], carried in the schema
+//! `metadata` block — so authors mostly never touch it.
+
+use serde::{Deserialize, Serialize};
+
+use super::overflow::Overflow;
+use super::read_mode::ReadMode;
+
+/// The one per-port delivery knob. Each profile bundles a fixed
+/// (drain order, overflow policy, ring depth) triple; see [`DeliveryProfile::resolve`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeliveryProfile {
+    /// Newest-wins: drain to the latest sample, evict oldest under pressure,
+    /// shallow ring. State snapshots — video frames, control state — where a
+    /// stale sample has no value once a fresher one exists.
+    Latest,
+    /// FIFO with a bounded backlog: read next in order, evict + count the
+    /// oldest under sustained overrun, deeper ring. Sample streams — audio,
+    /// encoded frames — where order matters but the producer must never block.
+    EverySample,
+    /// Lossless FIFO: read next in order, the producer blocks rather than
+    /// drop, deeper ring. File writers, muxers, loggers where every sample
+    /// must be delivered. Explicit-only — no [`FlowClass`] resolves here.
+    Lossless,
+}
+
+/// The resolved transport triple a [`DeliveryProfile`] expands to at wire time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeliveryResolution {
+    /// Consumer-side drain order applied by the destination's mailbox.
+    pub drain_order: ReadMode,
+    /// Producer-side overflow policy sizing the channel's `enable_safe_overflow`.
+    pub overflow: Overflow,
+    /// Ring depth — both the iceoryx2 subscriber buffer and the host mailbox
+    /// capacity.
+    pub depth: usize,
+}
+
+impl DeliveryProfile {
+    /// Ring depth for [`DeliveryProfile::Latest`].
+    pub const LATEST_DEPTH: usize = 4;
+    /// Ring depth for [`DeliveryProfile::EverySample`] and [`DeliveryProfile::Lossless`].
+    pub const STREAM_DEPTH: usize = 16;
+
+    /// Expand this profile into its fixed (drain order, overflow, depth) triple.
+    pub fn resolve(self) -> DeliveryResolution {
+        match self {
+            DeliveryProfile::Latest => DeliveryResolution {
+                drain_order: ReadMode::SkipToLatest,
+                overflow: Overflow::DropOldest,
+                depth: Self::LATEST_DEPTH,
+            },
+            DeliveryProfile::EverySample => DeliveryResolution {
+                drain_order: ReadMode::ReadNextInOrder,
+                overflow: Overflow::DropOldest,
+                depth: Self::STREAM_DEPTH,
+            },
+            DeliveryProfile::Lossless => DeliveryResolution {
+                drain_order: ReadMode::ReadNextInOrder,
+                overflow: Overflow::Block,
+                depth: Self::STREAM_DEPTH,
+            },
+        }
+    }
+
+    /// Parse an author-declared profile string.
+    ///
+    /// Recognized values: `"latest"`, `"every_sample"`, `"lossless"`. Unknown
+    /// values surface as a structured configuration error so a typo at the
+    /// declaration site is rejected at wire time, not silently defaulted.
+    pub fn from_manifest_str(value: &str) -> Result<Self, String> {
+        match value {
+            "latest" => Ok(Self::Latest),
+            "every_sample" => Ok(Self::EverySample),
+            "lossless" => Ok(Self::Lossless),
+            other => Err(format!(
+                "unknown delivery_profile value '{other}', expected 'latest', \
+                 'every_sample', or 'lossless'"
+            )),
+        }
+    }
+
+    /// The canonical manifest string for this profile.
+    pub fn as_manifest_str(self) -> &'static str {
+        match self {
+            DeliveryProfile::Latest => "latest",
+            DeliveryProfile::EverySample => "every_sample",
+            DeliveryProfile::Lossless => "lossless",
+        }
+    }
+}
+
+/// The per-wire-type data class carried in a schema's `metadata.flow_class`.
+/// It sets the *default* [`DeliveryProfile`] for any port carrying that type,
+/// which a port-site profile override still wins over.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FlowClass {
+    /// Ordered samples where every one matters — audio, encoded frames.
+    /// Defaults to [`DeliveryProfile::EverySample`].
+    SampleStream,
+    /// Latest-state snapshots where a stale sample has no value once a fresher
+    /// one exists — video frames, control state. Defaults to
+    /// [`DeliveryProfile::Latest`].
+    StateStream,
+}
+
+impl FlowClass {
+    /// Parse a schema-declared `metadata.flow_class` string.
+    ///
+    /// Recognized values: `"sample_stream"` and `"state_stream"`. `lossless`
+    /// is deliberately absent — a lossless profile is an explicit port-site
+    /// choice, never a type-level default (a wire type doesn't know whether a
+    /// given consumer can afford to backpressure its producer).
+    pub fn from_manifest_str(value: &str) -> Result<Self, String> {
+        match value {
+            "sample_stream" => Ok(Self::SampleStream),
+            "state_stream" => Ok(Self::StateStream),
+            other => Err(format!(
+                "unknown flow_class value '{other}', expected 'sample_stream' or 'state_stream'"
+            )),
+        }
+    }
+
+    /// The default [`DeliveryProfile`] a port carrying this flow class resolves
+    /// to when it declares no explicit profile override.
+    pub fn default_profile(self) -> DeliveryProfile {
+        match self {
+            FlowClass::SampleStream => DeliveryProfile::EverySample,
+            FlowClass::StateStream => DeliveryProfile::Latest,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn latest_resolves_to_skip_drop_shallow() {
+        let r = DeliveryProfile::Latest.resolve();
+        assert_eq!(r.drain_order, ReadMode::SkipToLatest);
+        assert_eq!(r.overflow, Overflow::DropOldest);
+        assert_eq!(r.depth, 4);
+        assert!(r.overflow.enable_safe_overflow());
+    }
+
+    #[test]
+    fn every_sample_resolves_to_fifo_drop_deep() {
+        let r = DeliveryProfile::EverySample.resolve();
+        assert_eq!(r.drain_order, ReadMode::ReadNextInOrder);
+        assert_eq!(r.overflow, Overflow::DropOldest);
+        assert_eq!(r.depth, 16);
+        assert!(r.overflow.enable_safe_overflow());
+    }
+
+    #[test]
+    fn lossless_resolves_to_fifo_block_deep() {
+        let r = DeliveryProfile::Lossless.resolve();
+        assert_eq!(r.drain_order, ReadMode::ReadNextInOrder);
+        assert_eq!(r.overflow, Overflow::Block);
+        assert_eq!(r.depth, 16);
+        assert!(
+            !r.overflow.enable_safe_overflow(),
+            "lossless must NOT enable safe overflow — the producer backpressures"
+        );
+    }
+
+    #[test]
+    fn profile_parses_known_and_rejects_unknown() {
+        assert_eq!(
+            DeliveryProfile::from_manifest_str("latest").unwrap(),
+            DeliveryProfile::Latest
+        );
+        assert_eq!(
+            DeliveryProfile::from_manifest_str("every_sample").unwrap(),
+            DeliveryProfile::EverySample
+        );
+        assert_eq!(
+            DeliveryProfile::from_manifest_str("lossless").unwrap(),
+            DeliveryProfile::Lossless
+        );
+        let err = DeliveryProfile::from_manifest_str("Latest").unwrap_err();
+        assert!(err.contains("every_sample"));
+    }
+
+    #[test]
+    fn manifest_str_roundtrips() {
+        for p in [
+            DeliveryProfile::Latest,
+            DeliveryProfile::EverySample,
+            DeliveryProfile::Lossless,
+        ] {
+            assert_eq!(
+                DeliveryProfile::from_manifest_str(p.as_manifest_str()).unwrap(),
+                p
+            );
+        }
+    }
+
+    #[test]
+    fn flow_class_defaults_match_landmines() {
+        // Landmine #1: video_frame (skip_to_latest) is state_stream → latest.
+        assert_eq!(
+            FlowClass::StateStream.default_profile(),
+            DeliveryProfile::Latest
+        );
+        // sample_stream (audio, encoded frames) → every_sample.
+        assert_eq!(
+            FlowClass::SampleStream.default_profile(),
+            DeliveryProfile::EverySample
+        );
+    }
+
+    #[test]
+    fn flow_class_parses_known_and_rejects_lossless() {
+        assert_eq!(
+            FlowClass::from_manifest_str("sample_stream").unwrap(),
+            FlowClass::SampleStream
+        );
+        assert_eq!(
+            FlowClass::from_manifest_str("state_stream").unwrap(),
+            FlowClass::StateStream
+        );
+        // Landmine #3: lossless never resolves from a flow class.
+        assert!(FlowClass::from_manifest_str("lossless").is_err());
+    }
+}

--- a/runtime/streamlib-engine/src/iceoryx2/mod.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/mod.rs
@@ -4,6 +4,7 @@
 //! iceoryx2-based IPC communication layer for cross-process processor communication.
 
 mod channel_ceiling;
+mod delivery_profile;
 mod input;
 mod mailbox;
 mod node;
@@ -16,6 +17,7 @@ pub use channel_ceiling::{
     ENV_MAX_PAYLOAD_BYTES_PER_CHANNEL_TRUSTED, ENV_MAX_PAYLOAD_BYTES_PER_CHANNEL_UNTRUSTED_SESSION,
     effective_channel_ceiling_bytes,
 };
+pub use delivery_profile::{DeliveryProfile, DeliveryResolution, FlowClass};
 pub use input::{BoundedReadOutcome, InputMailboxes, InputMailboxesInner};
 pub use mailbox::PortMailbox;
 pub use node::{Iceoryx2EventService, Iceoryx2Node, Iceoryx2NotifyService, Iceoryx2Service};

--- a/runtime/streamlib-engine/src/iceoryx2/node.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/node.rs
@@ -99,18 +99,16 @@ impl Iceoryx2Node {
     /// — iceoryx2 verifies it on `open`.
     ///
     /// `max_queued_messages` caps how many `[u8]` samples any subscriber on this
-    /// service can buffer — resolved from the channel's wire schema's
-    /// `metadata.max_queued_messages` via
-    /// [`crate::core::embedded_schemas::max_queued_messages_for_port_spec`],
-    /// defaulting to [`crate::iceoryx2::DEFAULT_MAX_QUEUED_MESSAGES`].
+    /// service can buffer — the ring depth of the channel's agreed
+    /// [`DeliveryProfile`](crate::iceoryx2::DeliveryProfile), resolved via
+    /// [`crate::core::embedded_schemas::delivery_profile_for_input_port`].
     ///
-    /// `enable_safe_overflow` derives from the channel's destination overflow
-    /// policy (see [`crate::core::embedded_schemas::overflow_for_input_port`]).
+    /// `enable_safe_overflow` derives from that same profile's overflow policy.
     /// When `true` (the realtime default — `Overflow::DropOldest`), the subscriber
     /// buffer auto-evicts the oldest sample on overflow and the publisher's
-    /// `send()` never blocks. When `false` (`Overflow::Block`), the producer blocks
-    /// until the consumer drains a slot — reserve for muxers / file writers that
-    /// need every sample in order.
+    /// `send()` never blocks. When `false` (`Overflow::Block`, the `lossless`
+    /// profile), the producer blocks until the consumer drains a slot — reserve
+    /// for muxers / file writers that need every sample in order.
     pub fn open_or_create_service(
         &self,
         service_name: &str,

--- a/runtime/streamlib-engine/src/iceoryx2/overflow.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/overflow.rs
@@ -3,20 +3,20 @@
 
 //! Producer-side overflow policy for an iceoryx2 service.
 //!
-//! Declared on the destination's input port; the engine derives the
-//! iceoryx2 service-level `enable_safe_overflow` setting at wire time.
-//! See `docs/learnings/iceoryx2-overflow-vs-readmode.md` (companion
-//! to [`ReadMode`](crate::iceoryx2::ReadMode)).
+//! No longer an authoring knob — it is the producer-side half a
+//! [`DeliveryProfile`](crate::iceoryx2::DeliveryProfile) resolves to. The
+//! engine derives the iceoryx2 service-level `enable_safe_overflow` setting
+//! from it at wire time.
 
 use serde::{Deserialize, Serialize};
 
 /// How an iceoryx2 service behaves when the subscriber's shared-memory
 /// buffer is full and the producer tries to publish another sample.
 ///
-/// Pairs with [`ReadMode`](crate::iceoryx2::ReadMode) which controls the
-/// consumer-side drain order. The two are orthogonal: `read_mode`
-/// decides how the consumer pops samples; `overflow` decides whether
-/// the producer ever blocks.
+/// Pairs with [`ReadMode`](crate::iceoryx2::ReadMode), the consumer-side drain
+/// order; a [`DeliveryProfile`](crate::iceoryx2::DeliveryProfile) resolves to
+/// both. The two are orthogonal: the drain order decides how the consumer pops
+/// samples; overflow decides whether the producer ever blocks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Overflow {
@@ -34,22 +34,6 @@ pub enum Overflow {
 }
 
 impl Overflow {
-    /// Parse a manifest-declared overflow string.
-    ///
-    /// Recognized values: `"drop_oldest"` and `"block"`. Unknown values
-    /// surface as a structured configuration error so a typo at the
-    /// manifest level (`drop-oldest`, `Block`) is rejected at wire
-    /// time, not silently treated as default.
-    pub fn from_manifest_str(value: &str) -> Result<Self, String> {
-        match value {
-            "drop_oldest" => Ok(Self::DropOldest),
-            "block" => Ok(Self::Block),
-            other => Err(format!(
-                "unknown overflow value '{other}', expected 'drop_oldest' or 'block'"
-            )),
-        }
-    }
-
     /// Returns true when the iceoryx2 service-level
     /// `enable_safe_overflow` flag should be set.
     pub fn enable_safe_overflow(self) -> bool {
@@ -64,25 +48,6 @@ mod tests {
     #[test]
     fn default_is_drop_oldest() {
         assert_eq!(Overflow::default(), Overflow::DropOldest);
-    }
-
-    #[test]
-    fn parses_known_strings() {
-        assert_eq!(
-            Overflow::from_manifest_str("drop_oldest").unwrap(),
-            Overflow::DropOldest
-        );
-        assert_eq!(
-            Overflow::from_manifest_str("block").unwrap(),
-            Overflow::Block
-        );
-    }
-
-    #[test]
-    fn rejects_unknown_strings() {
-        let err = Overflow::from_manifest_str("drop-oldest").unwrap_err();
-        assert!(err.contains("drop_oldest"));
-        assert!(err.contains("block"));
     }
 
     #[test]

--- a/runtime/streamlib-engine/src/iceoryx2/read_mode.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/read_mode.rs
@@ -6,6 +6,9 @@
 use serde::{Deserialize, Serialize};
 
 /// How frames should be read from an input port's buffer.
+///
+/// No longer an authoring knob — it is the consumer-side drain order a
+/// [`DeliveryProfile`](crate::iceoryx2::DeliveryProfile) resolves to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReadMode {
@@ -14,4 +17,15 @@ pub enum ReadMode {
     SkipToLatest,
     /// Read next frame in FIFO order (required for audio).
     ReadNextInOrder,
+}
+
+impl ReadMode {
+    /// The canonical manifest/envelope string — the wire form the subprocess
+    /// SDKs map back to their `*_input_set_read_mode` integer.
+    pub fn as_manifest_str(self) -> &'static str {
+        match self {
+            ReadMode::SkipToLatest => "skip_to_latest",
+            ReadMode::ReadNextInOrder => "read_next_in_order",
+        }
+    }
 }

--- a/schemas/streamlib.schema.json
+++ b/schemas/streamlib.schema.json
@@ -209,15 +209,13 @@
         "schema"
       ],
       "properties": {
-        "buffer_size": {
-          "description": "Ring buffer capacity for this input port.",
+        "delivery_profile": {
+          "description": "Delivery-profile override for this input port — `\"latest\"`, `\"every_sample\"`, or `\"lossless\"`. The one delivery knob on the authoring surface: it resolves to the consumer-side drain order, the producer-side overflow policy, and the ring depth. `None` defers to the default derived from the wire type's `flow_class`. Always `None` on output ports.",
           "default": null,
           "type": [
-            "integer",
+            "string",
             "null"
-          ],
-          "format": "uint",
-          "minimum": 0.0
+          ]
         },
         "description": {
           "description": "Human-readable description.",
@@ -230,22 +228,6 @@
         "name": {
           "description": "Port name (e.g., \"video_in\").",
           "type": "string"
-        },
-        "overflow": {
-          "description": "Producer-side overflow policy for the service feeding this input port. `\"drop_oldest\"` (the engine-wide realtime default) lets the publisher's `send()` never block — the iceoryx2 subscriber buffer evicts the oldest sample to make room. `\"block\"` keeps the producer waiting until the consumer drains a slot; reserve for sinks that need every sample in order (file writers, muxers, loggers).",
-          "default": null,
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "read_mode": {
-          "description": "Read mode for this input port (e.g., \"skip_to_latest\", \"read_next_in_order\").",
-          "default": null,
-          "type": [
-            "string",
-            "null"
-          ]
         },
         "schema": {
           "description": "Schema spec — either `any` or a bare PascalCase TypeName resolved against the enclosing manifest's `schemas:` map.",

--- a/sdk/streamlib-deno/decorators.ts
+++ b/sdk/streamlib-deno/decorators.ts
@@ -118,6 +118,8 @@ export interface PortMetadata {
   readonly name: string;
   readonly schema: SchemaIdent | null;
   readonly description: string;
+  /** Delivery-profile override for an input port, or `null` to default. */
+  readonly deliveryProfile: string | null;
 }
 
 /**
@@ -139,6 +141,12 @@ export interface PortOptions {
   schema?: SchemaCarrier | null;
   /** Human-readable description for introspection. */
   description?: string;
+  /**
+   * The one delivery knob for an input port — `"latest"`, `"every_sample"`,
+   * or `"lossless"`. Omit to default from the wire type's `flow_class`.
+   * Ignored on an output port.
+   */
+  deliveryProfile?: string;
 }
 
 // The version-free sentinel every code-declared identity carries. The concrete
@@ -320,6 +328,7 @@ export function input(opts: PortOptions = {}) {
       name: portName,
       schema: resolveSchemaIdent(opts.schema ?? null),
       description: opts.description ?? "",
+      deliveryProfile: opts.deliveryProfile ?? null,
     } as PortMetadata;
   };
 }
@@ -344,6 +353,7 @@ export function output(opts: PortOptions = {}) {
       name: portName,
       schema: resolveSchemaIdent(opts.schema ?? null),
       description: opts.description ?? "",
+      deliveryProfile: null,
     } as PortMetadata;
   };
 }

--- a/sdk/streamlib-deno/decorators_test.ts
+++ b/sdk/streamlib-deno/decorators_test.ts
@@ -428,6 +428,26 @@ Deno.test("@input port name override", () => {
   assertEquals(meta.name, "video_in");
 });
 
+Deno.test("@input delivery_profile override is captured", () => {
+  class P {
+    @input({ deliveryProfile: "lossless" })
+    sink() {}
+  }
+  // deno-lint-ignore no-explicit-any
+  const meta = (P.prototype as any).sink.streamlibInputPort as PortMetadata;
+  assertEquals(meta.deliveryProfile, "lossless");
+});
+
+Deno.test("@input delivery_profile defaults to null", () => {
+  class P {
+    @input()
+    control() {}
+  }
+  // deno-lint-ignore no-explicit-any
+  const meta = (P.prototype as any).control.streamlibInputPort as PortMetadata;
+  assertEquals(meta.deliveryProfile, null);
+});
+
 Deno.test("@processor collects @input + @output ports declared in code", () => {
   const VIDEO = new SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0");
 

--- a/sdk/streamlib-deno/extract_processors.ts
+++ b/sdk/streamlib-deno/extract_processors.ts
@@ -118,6 +118,7 @@ export function toManifestJson(procs: readonly RegisteredProcessor[]): string {
       name: port.name,
       schema: port.schema === null ? null : port.schema.toWireObject(),
       description: port.description,
+      delivery_profile: port.deliveryProfile,
     })),
     outputs: entry.outputs.map((port) => ({
       name: port.name,

--- a/sdk/streamlib-idents/src/catalog.rs
+++ b/sdk/streamlib-idents/src/catalog.rs
@@ -122,9 +122,9 @@ pub struct CatalogPort {
     pub description: Option<String>,
     /// Resolved schema flowing through this port.
     pub schema: CatalogSchemaRef,
-    /// Declared read mode for an input port (e.g. `skip_to_latest`).
+    /// Declared delivery-profile override for an input port (e.g. `lossless`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub read_mode: Option<String>,
+    pub delivery_profile: Option<String>,
 }
 
 /// The config binding of a catalog processor.

--- a/sdk/streamlib-idents/src/catalog.rs
+++ b/sdk/streamlib-idents/src/catalog.rs
@@ -365,7 +365,7 @@ mod tests {
                 name: "video".into(),
                 description: Some("Live frames".into()),
                 schema: CatalogSchemaRef::Schema(ident("core", "VideoFrame", SemVer::new(1, 0, 0))),
-                read_mode: None,
+                delivery_profile: None,
             }],
         }
     }
@@ -434,7 +434,7 @@ mod tests {
                         name: "video_in".into(),
                         description: None,
                         schema: CatalogSchemaRef::Any,
-                        read_mode: Some("skip_to_latest".into()),
+                        delivery_profile: Some("latest".into()),
                     }],
                     outputs: vec![],
                 },

--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -526,11 +526,11 @@ fn generate_from_config_from_schema(
     // emits empty PluginAbiObjects; the host's
     // `ProcessorInstance::install_iceoryx2_resources` patches in
     // real handles via `ProcessorVTable::set_iceoryx2_resources`
-    // immediately after `from_config` returns. Per-port read_mode
-    // / buffer_size live in the macro-emitted
-    // `__post_install_iceoryx2_resources` body run from
-    // `set_iceoryx2_resources` so the schema-driven settings still
-    // reach the host-side `InputMailboxesInner::add_port` call.
+    // immediately after `from_config` returns. Per-port delivery
+    // resolution (drain order + ring depth) is owned entirely by the
+    // host wire path, which reads the wire type's `flow_class` and any
+    // port-site `delivery_profile` override at wire time — the macro
+    // registers no ports here.
     let ipc_input_init = if !schema.inputs.is_empty() {
         quote! { inputs: __streamlib_sdk::iceoryx2::InputMailboxes::empty(), }
     } else {
@@ -592,7 +592,7 @@ fn generate_descriptor_from_schema(
             let port_name = &p.name;
             let port_schema_tokens = port_schema_spec_tokens(&p.schema);
             let port_desc = p.description.as_deref().unwrap_or("");
-            let overflow_tokens = match p.overflow.as_deref() {
+            let delivery_profile_tokens = match p.delivery_profile.as_deref() {
                 Some(value) => quote! { ::std::option::Option::Some(#value.to_string()) },
                 None => quote! { ::std::option::Option::None },
             };
@@ -603,7 +603,7 @@ fn generate_descriptor_from_schema(
                     schema: #port_schema_tokens,
                     required: true,
                     is_iceoryx2: true,
-                    overflow: #overflow_tokens,
+                    delivery_profile: #delivery_profile_tokens,
                 })
             }
         })
@@ -624,7 +624,7 @@ fn generate_descriptor_from_schema(
                     schema: #port_schema_tokens,
                     required: true,
                     is_iceoryx2: true,
-                    overflow: ::std::option::Option::None,
+                    delivery_profile: ::std::option::Option::None,
                 })
             }
         })
@@ -706,42 +706,10 @@ fn generate_iceoryx2_accessors_from_schema(schema: &ProcessorSchema) -> TokenStr
     // Issue #894: emit `set_iceoryx2_resources` to receive host-
     // allocated PluginAbiObjects + the `iceoryx2_output_writer_inner` /
     // `iceoryx2_input_mailboxes_inner` accessors so the host's
-    // wiring path can mutate the inner Arc directly.
-    let add_port_calls: Vec<TokenStream> = if has_iceoryx2_inputs {
-        schema
-            .inputs
-            .iter()
-            .map(|port| {
-                let name = &port.name;
-                let buffer_size = port.buffer_size.unwrap_or(1);
-                let read_mode_tokens = match port.read_mode.as_deref() {
-                    Some("read_next_in_order") => {
-                        quote! { __streamlib_sdk::iceoryx2::ReadMode::ReadNextInOrder }
-                    }
-                    Some("skip_to_latest") | None => {
-                        quote! { __streamlib_sdk::iceoryx2::ReadMode::SkipToLatest }
-                    }
-                    Some(unknown) => {
-                        let msg = format!(
-                            "unknown read_mode '{}' on input port '{}', expected 'skip_to_latest' or 'read_next_in_order'",
-                            unknown, name
-                        );
-                        return quote! { compile_error!(#msg); };
-                    }
-                };
-                quote! {
-                    if let ::std::option::Option::Some(ref input_inner) = input_inner_opt {
-                        if !input_inner.has_port(#name) {
-                            input_inner.add_port(#name, #buffer_size, #read_mode_tokens);
-                        }
-                    }
-                }
-            })
-            .collect()
-    } else {
-        Vec::new()
-    };
-
+    // wiring path can mutate the inner Arc directly. The host owns
+    // per-port registration (`InputMailboxesInner::add_port`) at wire
+    // time, where it resolves the delivery profile from the wire type's
+    // `flow_class` + any port-site override — the macro registers none.
     let assign_outputs = if has_iceoryx2_outputs {
         quote! {
             if let ::std::option::Option::Some(ow) = output_writer {
@@ -754,13 +722,9 @@ fn generate_iceoryx2_accessors_from_schema(schema: &ProcessorSchema) -> TokenStr
 
     let assign_inputs = if has_iceoryx2_inputs {
         quote! {
-            let input_inner_opt = input_mailboxes
-                .as_ref()
-                .and_then(|im| im.inner_arc());
             if let ::std::option::Option::Some(im) = input_mailboxes {
                 self.inputs = im;
             }
-            #(#add_port_calls)*
         }
     } else {
         quote! {

--- a/sdk/streamlib-processor-extract/src/derive.rs
+++ b/sdk/streamlib-processor-extract/src/derive.rs
@@ -20,8 +20,8 @@
 //! schema-type (or `any`). It deliberately excludes fields not every runtime's
 //! extractor emits or that are authored/build-derived rather than code-derived:
 //! `entrypoint` (author/loader concern), `config` binding, `description`, and
-//! the consumer-side port policies (`read_mode` / `overflow` / `buffer_size`,
-//! which the Python/Deno wire shape does not carry). What remains is exactly
+//! the consumer-side `delivery_profile` (which the Python/Deno wire shape does
+//! not carry uniformly). What remains is exactly
 //! the surface a stale hand-authored `processors:` would misstate: a
 //! processor added, removed, or renamed in code; a port added, removed,
 //! reordered, or re-typed.
@@ -804,14 +804,14 @@ processors:
   inputs:
   - name: any_in
     schema: any
-    read_mode: skip_to_latest
+    delivery_profile: latest
   outputs:
   - name: video_out
     schema: VideoFrame
 "#,
         );
         // In sync — a committed manifest that names both processors with the
-        // same execution + ports as code. `read_mode` / entrypoint on the
+        // same execution + ports as code. `delivery_profile` / entrypoint on the
         // committed side are outside the drift surface, so they don't trip it.
         check_processor_manifest_drift(root, &committed.iter().collect::<Vec<_>>(), &derived)
             .unwrap();

--- a/sdk/streamlib-processor-extract/src/grammar.rs
+++ b/sdk/streamlib-processor-extract/src/grammar.rs
@@ -14,8 +14,7 @@
 //!     scheduling = high,                // realtime | high | normal (default: normal)
 //!     unsafe_send,                      // flag — emit `unsafe impl Send`
 //!     config = crate::CameraConfig,     // Rust type path for the typed Config alias
-//!     input("video_in", "@tatolab/core/VideoFrame",
-//!           read_mode = "skip_to_latest", buffer_size = 4, overflow = "drop_oldest"),
+//!     input("video_in", "@tatolab/core/VideoFrame", delivery_profile = "latest"),
 //!     output("video", "@tatolab/core/VideoFrame"),
 //! )]
 //! ```
@@ -38,9 +37,8 @@ use syn::ext::IdentExt;
 use syn::parse::{ParseStream, Parser};
 use syn::{Ident, LitInt, LitStr, Path, Token, parenthesized};
 
-/// Which side of a link a port sits on. Producer-side policy keys
-/// (`read_mode` / `overflow` / `buffer_size`) are consumer-side settings and
-/// are only valid on an `input(...)`; the grammar rejects them on an
+/// Which side of a link a port sits on. `delivery_profile` is a consumer-side
+/// setting only valid on an `input(...)`; the grammar rejects it on an
 /// `output(...)`.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum PortDirection {
@@ -62,9 +60,7 @@ pub struct ParsedPort {
     pub name: String,
     pub schema: PortSchemaSpec,
     pub description: Option<String>,
-    pub read_mode: Option<String>,
-    pub overflow: Option<String>,
-    pub buffer_size: Option<usize>,
+    pub delivery_profile: Option<String>,
 }
 
 /// The fully-parsed `#[processor(...)]` attribute.
@@ -99,9 +95,7 @@ impl ParsedProcessorAttr {
             name: p.name.clone(),
             schema: p.schema.clone(),
             description: p.description.clone(),
-            read_mode: p.read_mode.clone(),
-            overflow: p.overflow.clone(),
-            buffer_size: p.buffer_size,
+            delivery_profile: p.delivery_profile.clone(),
         };
 
         ProcessorSchema {
@@ -374,14 +368,13 @@ fn parse_execution(input: ParseStream<'_>) -> syn::Result<ProcessorSchemaExecuti
 
 /// Parse an `input(...)` / `output(...)` port body.
 ///
-/// `<name-string>, <schema>, [read_mode = "...", overflow = "...", buffer_size = N,
-/// description = "..."]` — where `<schema>` is either the bare identifier `any`
-/// or a version-free `"@org/package/Type"` string.
+/// `<name-string>, <schema>, [delivery_profile = "...", description = "..."]` —
+/// where `<schema>` is either the bare identifier `any` or a version-free
+/// `"@org/package/Type"` string.
 ///
-/// The producer-side policy keys (`read_mode` / `overflow` / `buffer_size`) are
-/// consumer-side settings the destination input port declares; they are
-/// rejected with a spanned error on an `output(...)` rather than silently
-/// dropped.
+/// `delivery_profile` is a consumer-side setting the destination input port
+/// declares; it is rejected with a spanned error on an `output(...)` rather
+/// than silently dropped.
 fn parse_port(input: ParseStream<'_>, direction: PortDirection) -> syn::Result<ParsedPort> {
     let content;
     parenthesized!(content in input);
@@ -396,9 +389,7 @@ fn parse_port(input: ParseStream<'_>, direction: PortDirection) -> syn::Result<P
     let schema = parse_port_schema(&content)?;
 
     let mut description = None;
-    let mut read_mode = None;
-    let mut overflow = None;
-    let mut buffer_size = None;
+    let mut delivery_profile = None;
 
     while !content.is_empty() {
         content.parse::<Token![,]>()?;
@@ -413,27 +404,17 @@ fn parse_port(input: ParseStream<'_>, direction: PortDirection) -> syn::Result<P
                 let lit: LitStr = content.parse()?;
                 description = Some(lit.value());
             }
-            "read_mode" => {
+            "delivery_profile" => {
                 let lit: LitStr = content.parse()?;
-                reject_producer_key_on_output(direction, "read_mode", &name, key_span)?;
-                read_mode = Some(lit.value());
-            }
-            "overflow" => {
-                let lit: LitStr = content.parse()?;
-                reject_producer_key_on_output(direction, "overflow", &name, key_span)?;
-                overflow = Some(lit.value());
-            }
-            "buffer_size" => {
-                let lit: LitInt = content.parse()?;
-                reject_producer_key_on_output(direction, "buffer_size", &name, key_span)?;
-                buffer_size = Some(lit.base10_parse()?);
+                reject_delivery_profile_on_output(direction, &name, key_span)?;
+                delivery_profile = Some(lit.value());
             }
             other => {
                 return Err(syn::Error::new(
                     key.span(),
                     format!(
-                        "unknown port key `{other}` — expected `read_mode`, `overflow`, \
-                         `buffer_size`, or `description`"
+                        "unknown port key `{other}` — expected `delivery_profile` or \
+                         `description`"
                     ),
                 ));
             }
@@ -444,17 +425,15 @@ fn parse_port(input: ParseStream<'_>, direction: PortDirection) -> syn::Result<P
         name,
         schema,
         description,
-        read_mode,
-        overflow,
-        buffer_size,
+        delivery_profile,
     })
 }
 
-/// Reject a producer-side policy key on an `output(...)` with a spanned error.
+/// Reject `delivery_profile` on an `output(...)` with a spanned error — the
+/// profile is a consumer-side setting the destination input port declares.
 /// A no-op on an `input(...)`.
-fn reject_producer_key_on_output(
+fn reject_delivery_profile_on_output(
     direction: PortDirection,
-    key: &str,
     port_name: &str,
     span: proc_macro2::Span,
 ) -> syn::Result<()> {
@@ -462,10 +441,9 @@ fn reject_producer_key_on_output(
         return Err(syn::Error::new(
             span,
             format!(
-                "`{key}` is a consumer-side policy key and is not valid on \
-                 `{}(\"{port_name}\", ...)` — `read_mode`, `overflow`, and \
-                 `buffer_size` are declared by the destination input port, not \
-                 the producing output port",
+                "`delivery_profile` is a consumer-side setting and is not valid on \
+                 `{}(\"{port_name}\", ...)` — it is declared by the destination \
+                 input port, not the producing output port",
                 direction.keyword()
             ),
         ));
@@ -564,7 +542,7 @@ mod tests {
             "@tatolab/camera/Camera",
             execution = manual,
             scheduling = high,
-            input("video_in", "@tatolab/core/VideoFrame", read_mode = "skip_to_latest", buffer_size = 4),
+            input("video_in", "@tatolab/core/VideoFrame", delivery_profile = "latest"),
             output("video", "@tatolab/core/VideoFrame"),
         });
         assert_eq!(parsed.ident.org.as_str(), "tatolab");
@@ -576,16 +554,15 @@ mod tests {
         assert_eq!(parsed.scheduling, Some(ThreadPriority::High));
         assert_eq!(parsed.inputs.len(), 1);
         assert_eq!(parsed.inputs[0].name, "video_in");
-        assert_eq!(parsed.inputs[0].read_mode.as_deref(), Some("skip_to_latest"));
-        assert_eq!(parsed.inputs[0].buffer_size, Some(4));
+        assert_eq!(parsed.inputs[0].delivery_profile.as_deref(), Some("latest"));
         assert!(matches!(
             parsed.inputs[0].schema,
             PortSchemaSpec::Specific(_)
         ));
         assert_eq!(parsed.outputs.len(), 1);
         assert_eq!(parsed.outputs[0].name, "video");
-        // Output ports never carry a producer-side policy.
-        assert_eq!(parsed.outputs[0].read_mode, None);
+        // Output ports never carry a delivery profile.
+        assert_eq!(parsed.outputs[0].delivery_profile, None);
     }
 
     #[test]
@@ -747,40 +724,36 @@ mod tests {
     }
 
     #[test]
-    fn output_producer_side_policy_keys_are_rejected() {
-        // Regression: producer-side policy keys on an `output(...)` were
-        // silently parsed-then-nulled. They must now be a spanned error.
-        // Mentally revert `reject_producer_key_on_output` and each of these
-        // parses cleanly (bug) instead of erroring.
-        for key in ["overflow", "read_mode", "buffer_size"] {
-            let value = if key == "buffer_size" { "4" } else { "\"drop_oldest\"" };
-            let tokens: proc_macro2::TokenStream = format!(
-                "\"@tatolab/camera/Camera\", execution = manual, \
-                 output(\"video\", \"@tatolab/core/VideoFrame\", {key} = {value})"
-            )
-            .parse()
-            .expect("token stream parses");
-            let msg = parse_err(tokens);
-            assert!(
-                msg.contains(&format!("`{key}` is a consumer-side policy key")),
-                "key `{key}` got: {msg}"
-            );
-        }
+    fn output_delivery_profile_is_rejected() {
+        // Regression: `delivery_profile` is a consumer-side setting on an
+        // `output(...)`. It must be a spanned error, not silently nulled.
+        // Mentally revert `reject_delivery_profile_on_output` and this parses
+        // cleanly (bug) instead of erroring.
+        let tokens: proc_macro2::TokenStream =
+            "\"@tatolab/camera/Camera\", execution = manual, \
+             output(\"video\", \"@tatolab/core/VideoFrame\", delivery_profile = \"latest\")"
+                .parse()
+                .expect("token stream parses");
+        let msg = parse_err(tokens);
+        assert!(
+            msg.contains("`delivery_profile` is a consumer-side setting"),
+            "got: {msg}"
+        );
     }
 
     #[test]
-    fn input_producer_side_policy_keys_are_accepted() {
-        // The mirror of the rejection test: the same keys stay valid on an
-        // `input(...)` and reach the parsed port.
+    fn input_delivery_profile_is_accepted() {
+        // The mirror of the rejection test: `delivery_profile` stays valid on
+        // an `input(...)` and reaches the parsed port.
         let parsed = parse_ok(quote! {
             "@tatolab/camera/Camera",
             execution = manual,
-            input("video_in", "@tatolab/core/VideoFrame",
-                  read_mode = "skip_to_latest", overflow = "drop_oldest", buffer_size = 4),
+            input("video_in", "@tatolab/core/VideoFrame", delivery_profile = "lossless"),
         });
-        assert_eq!(parsed.inputs[0].read_mode.as_deref(), Some("skip_to_latest"));
-        assert_eq!(parsed.inputs[0].overflow.as_deref(), Some("drop_oldest"));
-        assert_eq!(parsed.inputs[0].buffer_size, Some(4));
+        assert_eq!(
+            parsed.inputs[0].delivery_profile.as_deref(),
+            Some("lossless")
+        );
     }
 
     #[test]

--- a/sdk/streamlib-processor-extract/src/lib.rs
+++ b/sdk/streamlib-processor-extract/src/lib.rs
@@ -284,7 +284,7 @@ mod tests {
             #[streamlib::sdk::processor(
                 "@tatolab/demo/Blur",
                 execution = reactive,
-                input("frames_in", "@tatolab/core/VideoFrame", read_mode = "skip_to_latest", buffer_size = 4),
+                input("frames_in", "@tatolab/core/VideoFrame", delivery_profile = "latest"),
                 output("frames_out", "@tatolab/core/VideoFrame"),
             )]
             pub struct Blur;
@@ -320,7 +320,7 @@ mod tests {
         assert_eq!(blur.schema.execution, ProcessorSchemaExecution::Reactive);
         assert_eq!(blur.schema.inputs.len(), 1);
         assert_eq!(blur.schema.inputs[0].name, "frames_in");
-        assert_eq!(blur.schema.inputs[0].read_mode.as_deref(), Some("skip_to_latest"));
+        assert_eq!(blur.schema.inputs[0].delivery_profile.as_deref(), Some("latest"));
         assert!(matches!(
             blur.schema.inputs[0].schema,
             PortSchemaSpec::Specific(_)
@@ -356,7 +356,7 @@ mod tests {
             scheduling = high,
             unsafe_send,
             description = "Blurs frames",
-            input("frames_in", "@tatolab/core/VideoFrame", read_mode = "skip_to_latest", buffer_size = 4),
+            input("frames_in", "@tatolab/core/VideoFrame", delivery_profile = "latest"),
             output("frames_out", "@tatolab/core/VideoFrame")"#;
 
         let tmp = tempdir();

--- a/sdk/streamlib-processor-schema/src/descriptors.rs
+++ b/sdk/streamlib-processor-schema/src/descriptors.rs
@@ -139,13 +139,12 @@ pub struct PortDescriptor {
     /// Whether this port uses iceoryx2 IPC.
     #[serde(default)]
     pub is_iceoryx2: bool,
-    /// Producer-side overflow policy declared by an *input* port (the
-    /// destination of an iceoryx2 service). `None` defers to the
-    /// engine-wide default `drop_oldest` at wire time. Always `None`
-    /// on output ports — the producer side reads the destination port's
-    /// declaration.
+    /// Delivery-profile override declared by an *input* port (the
+    /// destination of an iceoryx2 service) — `"latest"`, `"every_sample"`,
+    /// or `"lossless"`. `None` defers to the default derived from the wire
+    /// type's `flow_class` at wire time. Always `None` on output ports.
     #[serde(default)]
-    pub overflow: Option<String>,
+    pub delivery_profile: Option<String>,
 }
 
 impl PortDescriptor {
@@ -161,7 +160,7 @@ impl PortDescriptor {
             schema,
             required,
             is_iceoryx2: false,
-            overflow: None,
+            delivery_profile: None,
         }
     }
 
@@ -177,15 +176,14 @@ impl PortDescriptor {
             schema,
             required: true,
             is_iceoryx2: true,
-            overflow: None,
+            delivery_profile: None,
         }
     }
 
-    /// Builder-style override for the producer-side overflow policy.
-    /// Meaningful only on input ports; engine-side derivation ignores
-    /// this on output ports.
-    pub fn with_overflow(mut self, overflow: impl Into<String>) -> Self {
-        self.overflow = Some(overflow.into());
+    /// Builder-style override for the delivery profile. Meaningful only on
+    /// input ports; engine-side derivation ignores this on output ports.
+    pub fn with_delivery_profile(mut self, delivery_profile: impl Into<String>) -> Self {
+        self.delivery_profile = Some(delivery_profile.into());
         self
     }
 }

--- a/sdk/streamlib-processor-schema/src/processor_schema.rs
+++ b/sdk/streamlib-processor-schema/src/processor_schema.rs
@@ -527,21 +527,14 @@ pub struct ProcessorPortSchema {
     /// Human-readable description.
     #[serde(default)]
     pub description: Option<String>,
-    /// Read mode for this input port (e.g., "skip_to_latest", "read_next_in_order").
+    /// Delivery-profile override for this input port — `"latest"`,
+    /// `"every_sample"`, or `"lossless"`. The one delivery knob on the
+    /// authoring surface: it resolves to the consumer-side drain order,
+    /// the producer-side overflow policy, and the ring depth. `None`
+    /// defers to the default derived from the wire type's `flow_class`.
+    /// Always `None` on output ports.
     #[serde(default)]
-    pub read_mode: Option<String>,
-    /// Producer-side overflow policy for the service feeding this input
-    /// port. `"drop_oldest"` (the engine-wide realtime default) lets
-    /// the publisher's `send()` never block — the iceoryx2 subscriber
-    /// buffer evicts the oldest sample to make room. `"block"` keeps
-    /// the producer waiting until the consumer drains a slot; reserve
-    /// for sinks that need every sample in order (file writers,
-    /// muxers, loggers).
-    #[serde(default)]
-    pub overflow: Option<String>,
-    /// Ring buffer capacity for this input port.
-    #[serde(default)]
-    pub buffer_size: Option<usize>,
+    pub delivery_profile: Option<String>,
 }
 
 /// Config definition within a processor schema.

--- a/sdk/streamlib-processor-schema/src/processor_schema_parser.rs
+++ b/sdk/streamlib-processor-schema/src/processor_schema_parser.rs
@@ -67,12 +67,6 @@ fn validate_processor_schema(schema: &ProcessorSchema) -> SchemaResult<()> {
                 reason: "input port name cannot be empty".to_string(),
             });
         }
-        if input.buffer_size == Some(0) {
-            return Err(SchemaError::InvalidName {
-                name: schema.name.clone(),
-                reason: format!("input '{}' buffer_size cannot be 0", input.name),
-            });
-        }
     }
 
     // Validate output port schema references — port name presence only.
@@ -311,28 +305,26 @@ name: BlurFilter
     }
 
     #[test]
-    fn test_input_port_read_mode_and_buffer_size() {
+    fn test_input_port_delivery_profile() {
         let yaml = r#"
-name: Decoder
+name: Writer
 
 inputs:
-  - name: encoded_video_in
-    schema: EncodedVideoFrame
-    read_mode: read_next_in_order
-    buffer_size: 16
+  - name: video_in
+    schema: VideoFrame
+    delivery_profile: lossless
 "#;
 
         let schema = parse_processor_yaml(yaml).unwrap();
         assert_eq!(schema.inputs.len(), 1);
         assert_eq!(
-            schema.inputs[0].read_mode,
-            Some("read_next_in_order".to_string())
+            schema.inputs[0].delivery_profile,
+            Some("lossless".to_string())
         );
-        assert_eq!(schema.inputs[0].buffer_size, Some(16));
     }
 
     #[test]
-    fn test_input_port_defaults_without_read_mode_and_buffer_size() {
+    fn test_input_port_defaults_without_delivery_profile() {
         let yaml = r#"
 name: Passthrough
 
@@ -343,8 +335,7 @@ inputs:
 
         let schema = parse_processor_yaml(yaml).unwrap();
         assert_eq!(schema.inputs.len(), 1);
-        assert_eq!(schema.inputs[0].read_mode, None);
-        assert_eq!(schema.inputs[0].buffer_size, None);
+        assert_eq!(schema.inputs[0].delivery_profile, None);
     }
 
     #[test]
@@ -416,20 +407,20 @@ scheduling:
         assert_eq!(scheduling.priority, crate::ThreadPriority::RealTime);
     }
 
+    /// A retired per-port knob (`read_mode` / `overflow` / `buffer_size`) is
+    /// now an unknown field — `deny_unknown_fields` rejects it so a stale
+    /// manifest fails loudly rather than silently ignoring the knob.
     #[test]
-    fn test_input_port_buffer_size_zero_rejected() {
+    fn test_input_port_retired_knob_rejected() {
         let yaml = r#"
 name: Test
 
 inputs:
   - name: video
     schema: Frame
-    buffer_size: 0
+    read_mode: skip_to_latest
 "#;
 
-        let result = parse_processor_yaml(yaml);
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("buffer_size cannot be 0"));
+        assert!(parse_processor_yaml(yaml).is_err());
     }
 }

--- a/sdk/streamlib-python/python/streamlib/decorators.py
+++ b/sdk/streamlib-python/python/streamlib/decorators.py
@@ -286,6 +286,7 @@ def input(
     *,
     schema: Union[SchemaIdent, Type, None] = None,
     description: str = "",
+    delivery_profile: Optional[str] = None,
 ):
     """Mark a method as defining an input port.
 
@@ -297,6 +298,8 @@ def input(
             package's JTD/YAML schemas). String forms (bare type name or
             joined `@org/pkg/Type@v`) are rejected with a clear error.
         description: Human-readable description for introspection.
+        delivery_profile: The one delivery knob — `"latest"`, `"every_sample"`,
+            or `"lossless"`. Omit to default from the wire type's `flow_class`.
 
     Example:
         ```python
@@ -313,6 +316,7 @@ def input(
             "name": port_name,
             "schema": _resolve_schema_ident(schema),
             "description": description,
+            "delivery_profile": delivery_profile,
         }
         return method
 

--- a/sdk/streamlib-python/python/streamlib/extract_processors.py
+++ b/sdk/streamlib-python/python/streamlib/extract_processors.py
@@ -114,6 +114,7 @@ def _to_manifest_json(procs: List[RegisteredProcessor]) -> str:
                         else None
                     ),
                     "description": port["description"],
+                    "delivery_profile": port.get("delivery_profile"),
                 }
                 for port in entry.inputs
             ],

--- a/sdk/streamlib-python/python/streamlib/tests/test_processor_decorator.py
+++ b/sdk/streamlib-python/python/streamlib/tests/test_processor_decorator.py
@@ -269,6 +269,20 @@ class TestPortSchemaResolution:
 
         assert control._streamlib_input_port["schema"] is None
 
+    def test_delivery_profile_override_captured(self) -> None:
+        @input(schema=None, delivery_profile="lossless")
+        def sink(self):
+            pass
+
+        assert sink._streamlib_input_port["delivery_profile"] == "lossless"
+
+    def test_delivery_profile_defaults_to_none(self) -> None:
+        @input(schema=None)
+        def control(self):
+            pass
+
+        assert control._streamlib_input_port["delivery_profile"] is None
+
     def test_processor_collects_ports_declared_in_code(self) -> None:
         VIDEO = SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0")
 

--- a/tools/streamlib-pack/src/catalog.rs
+++ b/tools/streamlib-pack/src/catalog.rs
@@ -302,7 +302,7 @@ fn build_port(
         name: port.name.clone(),
         description: port.description.clone(),
         schema,
-        read_mode: port.read_mode.clone(),
+        delivery_profile: port.delivery_profile.clone(),
     })
 }
 
@@ -579,7 +579,7 @@ processors:
   inputs:
   - name: any_in
     schema: any
-    read_mode: skip_to_latest
+    delivery_profile: latest
   outputs:
   - name: video_out
     schema: VideoFrame
@@ -630,8 +630,8 @@ processors:
         // `any` port stays a wildcard.
         assert_eq!(passthrough.inputs[0].schema, CatalogSchemaRef::Any);
         assert_eq!(
-            passthrough.inputs[0].read_mode.as_deref(),
-            Some("skip_to_latest")
+            passthrough.inputs[0].delivery_profile.as_deref(),
+            Some("latest")
         );
     }
 

--- a/tools/streamlib-pack/tests/catalog_pkg_publish.rs
+++ b/tools/streamlib-pack/tests/catalog_pkg_publish.rs
@@ -106,7 +106,7 @@ processors:
   inputs:
   - name: video_in
     schema: VideoFrame
-    read_mode: skip_to_latest
+    delivery_profile: latest
 "#;
 
 /// Camera manifest re-authored with ONLY the `Camera` processor (Sink removed) —
@@ -221,7 +221,7 @@ fn pkg_publish_emits_fetchable_catalog_and_republish_does_not_duplicate() {
     let sink = &cam.processors[1];
     assert_eq!(sink.runtime, CatalogRuntime::Python);
     assert_eq!(sink.entrypoint.as_deref(), Some("src.sink:Sink"));
-    assert_eq!(sink.inputs[0].read_mode.as_deref(), Some("skip_to_latest"));
+    assert_eq!(sink.inputs[0].delivery_profile.as_deref(), Some("latest"));
 
     // 3. The aggregate carries one line per processor; core (schema-only)
     //    contributes none.

--- a/tools/streamlib-pack/tests/catalog_publish_query.rs
+++ b/tools/streamlib-pack/tests/catalog_publish_query.rs
@@ -86,7 +86,7 @@ processors:
   inputs:
   - name: video_in
     schema: VideoFrame
-    read_mode: skip_to_latest
+    delivery_profile: latest
 "#,
     );
     write(
@@ -164,8 +164,8 @@ fn reconstruct_wiring_graph_from_catalog_without_touching_slpkg() {
     );
     assert_eq!(out_schema.to_string(), "@tatolab/core/VideoFrame@1.4.0");
     assert_eq!(
-        sink_line.processor.inputs[0].read_mode.as_deref(),
-        Some("skip_to_latest")
+        sink_line.processor.inputs[0].delivery_profile.as_deref(),
+        Some("latest")
     );
     assert_eq!(camera_line.processor.runtime, CatalogRuntime::Rust);
     assert_eq!(sink_line.processor.runtime, CatalogRuntime::Python);


### PR DESCRIPTION
Closes #1420

## Summary

Unifies the four smeared delivery knobs (`read_mode`, overflow policy, buffer sizing,
`max_queued_messages`) into a single per-port `DeliveryProfile`: `latest`
(SkipToLatest + DropOldest, depth 4), `every_sample` (ReadNextInOrder + DropOldest,
counted+warned drops, depth 16), `lossless` (ReadNextInOrder + Block, depth 16).

- New `DeliveryProfile` core system (`runtime/streamlib-engine/src/iceoryx2/delivery_profile.rs`) —
  the one place profile → `(read_mode, overflow, depth)` resolution lives.
- Defaults derived from a per-vocabulary-type `flow_class` carried in the schema `metadata` block
  (`sample_stream` → `every_sample`, `state_stream` → `latest`; `lossless` is explicit-only),
  replacing `read_mode`/`max_queued_messages` there.
- One-word code override at the port declaration site — Rust `#[processor]` attribute + Python/Deno
  decorators (parity tests added for both).
- The four legacy knobs and every dead/hardcoded `read_mode` path deleted across Rust engine,
  plugin-sdk, Python-native, Deno (canonical-pattern sweep in this PR); every schema YAML's
  `metadata` swept to `flow_class`.
- `schemas/streamlib.schema.json` regenerated for the new manifest `delivery_profile` port field;
  manifest→descriptor path threads it through (`30e56840`, `3b81e8ae`).
- No plugin-ABI version bump — the wire representation is `Option<String>` end to end, not a new
  `#[repr(C)]` field.

71 files changed, +793/-692.

## Test evidence

Ran in a clean worktree at the branch head (`3b81e8ae`):

- CI's own unit-test gate (`.github/workflows/test.yml`):
  `cargo test --locked -p streamlib -p streamlib-plugin-abi -p streamlib-plugin-sdk -p streamlib-processor-extract --lib`
  → **all green**: `streamlib` 2/2, `streamlib-plugin-abi` 77/77, `streamlib-plugin-sdk` 101/101 (1 ignored),
  `streamlib-processor-extract` 60/60 (includes the new `grammar::tests::input_delivery_profile_is_accepted` /
  `output_delivery_profile_is_rejected` cases).
- `cargo test -p streamlib-engine --lib delivery_profile::` → **7/7 passed** (per-profile resolution table,
  `flow_class` default-vs-landmine mapping, manifest string round-trip, unknown-profile/lossless-as-flow-class
  rejection).
- `cargo test -p streamlib-engine --lib embedded_schemas::` → **31/31 passed** (`delivery_profile_defaults_from_flow_class`,
  `delivery_profile_override_wins_over_flow_class`, `delivery_profile_defaults_latest_when_processor_unregistered`,
  `delivery_profile_rejects_unknown_override`, plus the pre-existing registry/payload-bytes suite unaffected by the sweep).
- `cargo run -p xtask -- check-manifest-schema` → **57/57 `streamlib.yaml` files validated** against the regenerated
  `schemas/streamlib.schema.json`.

## E2E / live-verify report

Rig-touching (touches the iceoryx2 transport read/overflow/depth path), so a live rig run was done on this
milestone's merged transport stack (#1419/#1421/#1430) immediately ahead of this ticket's implementation to
confirm the underlying channel-native transport delivers frames end-to-end before layering the profile sweep
on top: built `camera-display` at `0.7.19`, ran `vivid(/dev/video0) → tatolab/camera → iceoryx2 transport →
tatolab/display`, screenshotted the live display window — vivid SMPTE color bars rendered correctly, OSD
timecode advancing, 1920x1080 NV12, transport log clean (no schema-mismatch, no ceiling-refusal/growth error,
no panic), graceful shutdown. Evidence: https://gh-artifact.tatolab.com/share/20260720-194407/m36-channel-transport-vivid-smpte.jpg

A dedicated live run of *this* branch's per-profile behavior under a throttled consumer (does `latest` skip,
does `every_sample` bound+drop-oldest, does `lossless` backpressure) was not additionally captured — see
should-fix item 2 below; the resolution logic itself is unit-tested end to end.

## Review items (non-blocking)

- **[should-fix]** `packages/opus/src/opus_decoder.rs:189` (same pattern at `webrtc_whip.rs:40`) — the sweep
  silently changes encoded-audio delivery semantics: `encoded_audio_in` previously declared
  `read_mode="skip_to_latest"` (drop stale packets, keep newest) and now falls back to the `EncodedAudioFrame`
  flow_class default `every_sample` (`ReadNextInOrder`, in-order). This diverges from how the same PR faithfully
  preserved `read_next_in_order`-on-`VideoFrame` by adding an explicit `delivery_profile="every_sample"` override
  (h264/h265 encoder `video_in`, `video_frame_counter`) — the `skip_to_latest` divergences were dropped instead of
  mapped to `delivery_profile="latest"`. Evidence: `git diff e94ef4c0..branch` — `opus_decoder` & `webrtc_whip`
  `encoded_audio_in` lose `read_mode = "skip_to_latest", buffer_size = 8` and gain no override; `EncodedAudioFrame`
  schema now `flow_class: sample_stream` → `every_sample`. No test asserts the resulting delivery for either
  encoded-audio port. Suggested next step: decide intent — if the old skip-to-latest was a deliberate live-stream
  latency bound, restore it with `delivery_profile="latest"` on both `encoded_audio_in` ports; if the
  `every_sample` canonicalization is intended, state that explicitly (encoded audio now drains in-order rather
  than skipping to latest).
- **[should-fix]** `runtime/streamlib-engine/src/iceoryx2/delivery_profile.rs:146` — the acceptance criterion
  "Tests: per-profile semantics under a slow consumer (latest skips; every_sample bounds+drops-oldest; lossless
  backpressures)" is not covered; only the resolution table, `flow_class` default resolution, override-wins, and
  the conflict error are unit-tested — nothing exercises actual iceoryx2 delivery behavior under a slow consumer.
  Runtime IPC can't run in the sandbox (exit 144), so this is genuinely rig-gated. Suggested next step: a
  live-verify pass (or an ignored integration test) exercising latest-skips / every_sample-drops-oldest /
  lossless-backpressures against a throttled reader on the rig; the resolution logic itself is well covered so
  this is a documented deferral, not a blocker.
- **[info]** `sdk/streamlib-macros/src/codegen.rs:706` — the `#[processor]` macro no longer registers Rust
  in-process input ports (dropped the `__post_install add_port` calls with `buffer_size`/`read_mode`); the host
  wire path (`wire_rust_dest`) now owns all port registration via `add_port(dest_port, depth, drain_order)` using
  the resolved delivery profile. This correctly removes the dead/hardcoded `read_mode` path the ticket called out.
  Only verifiable at runtime — folds into the live-verify note above; confirm during live verification that
  in-process Rust processors still receive frames on all wired inputs.
- **[should-fix]** `runtime/streamlib-engine/src/core/embedded_schemas/mod.rs:210` — the newly-added
  `flow_class_for_port_spec` copy-pastes the entire registry-lookup preamble of the pre-existing
  `resolve_metadata_u64_for_port_spec` (`mod.rs:325`): the `Any`→`Ok(None)` guard, `schema_spec.to_string()`,
  the `get_embedded_schema_definition(...).ok_or_else(...)` miss handling, and the `serde_yaml::from_str` parse.
  The multi-line "referenced by a port spec but not in the runtime schema registry — did you forget to call
  `runtime.add_module(...)`" error string is duplicated verbatim (`mod.rs:221` and `mod.rs:335`). Same-logic-must-
  change-together duplication: reword the add_module hint and you must edit two sites. Suggested next step:
  extract a `metadata_value_for_port_spec(schema_spec, field) -> Result<Option<&serde_yaml::Value>>` helper that
  owns the `Any`-guard + registry-miss error + yaml parse, with both resolvers projecting only their leaf; call
  this out as replacing real duplication (per the no-silent-DRY-refactor rule).
- **[low]** `runtime/streamlib-engine/src/iceoryx2/delivery_profile.rs:22` — `DeliveryProfile` (and `FlowClass`,
  ~line 96) derive `Serialize, Deserialize` with `#[serde(rename_all = "snake_case")]`, but neither is ever
  serialized/deserialized via serde: the value crosses every wire boundary as `Option<String>`
  (`PortInfo`/`PortDescriptor`/`ProcessorPortSchema`) and is parsed exclusively through the hand-rolled
  `from_manifest_str`. The serde mapping is a silent second source of truth for the same strings that
  `as_manifest_str`/`from_manifest_str` already own. Suggested next step: drop the unused derives, or route
  `from_manifest_str` through serde if round-tripping is actually intended.
- **[low]** `runtime/streamlib-engine/src/core/embedded_schemas/mod.rs:228` — `flow_class_for_port_spec` swallows
  a YAML parse failure with `Err(_) => return Ok(None)`, silently falling back to the `Latest` default. This
  contradicts the same function's own rustdoc ("a wire-time error, not a silent default substitution") and its
  loud registry-miss handling three lines above. Embedded schemas are pre-validated so it rarely fires, but a
  malformed `metadata` block would resolve a channel to the wrong delivery profile with no diagnostic. Suggested
  next step: map the parse error to `Error::Configuration` naming the schema, consistent with the registry-miss
  branch — do it in the extracted helper from the should-fix above.
