### PR TITLE
feat(runtime): register-from-source + replace runtime ops (RuntimeOpsVTable v3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5012,6 +5012,7 @@ version = "0.7.21"
 dependencies = [
  "anyhow",
  "serde_json",
+ "serde_yaml",
  "serial_test",
  "streamlib-cargo-build",
  "streamlib-engine",
@@ -5019,6 +5020,8 @@ dependencies = [
  "streamlib-jtd-codegen",
  "streamlib-pack",
  "streamlib-plugin-abi",
+ "streamlib-processor-extract",
+ "streamlib-processor-schema",
  "tempfile",
  "thiserror 2.0.18",
  "toml_edit 0.22.27",

--- a/docs/architecture/plugin-abi.md
+++ b/docs/architecture/plugin-abi.md
@@ -134,8 +134,13 @@ the best of our current knowledge the in-tree set as of this doc is:
   reads.
 - **`RuntimeOpsVTable`** — submit-with-completion runtime mutation
   ops (`add_processor`, `remove_processor`, `connect`, `disconnect`,
-  `to_json`) plus `clone_handle` / `drop_handle` for the cdylib's
-  owning-Arc shim.
+  `to_json`, and the register-from-source pair
+  `register_processor_source` / `replace_processor`) plus
+  `clone_handle` / `drop_handle` for the cdylib's owning-Arc shim.
+  The register-from-source ops stage submitted source text into a
+  `@session/<name>@0.0.N` package through the module_loader's
+  transactional session-source seam; the success payload is the
+  minted registration `ModuleIdent`.
 
 ### GPU capability tiers
 

--- a/docs/architecture/plugin-abi.md
+++ b/docs/architecture/plugin-abi.md
@@ -139,8 +139,12 @@ the best of our current knowledge the in-tree set as of this doc is:
   `clone_handle` / `drop_handle` for the cdylib's owning-Arc shim.
   The register-from-source ops stage submitted source text into a
   `@session/<name>@0.0.N` package through the module_loader's
-  transactional session-source seam; the success payload is the
-  minted registration `ModuleIdent`.
+  transactional session-source seam; the success payload is a
+  registration receipt — the minted registration `ModuleIdent` plus
+  each installed processor's committed ports (name, schema id, input
+  delivery profile), built engine-side from the descriptors
+  post-commit. Growing the receipt is payload-only; the vtable layout
+  version pins fn-pointer offsets, not the msgpack body.
 
 ### GPU capability tiers
 

--- a/packages/api-server/src/handlers.rs
+++ b/packages/api-server/src/handlers.rs
@@ -497,8 +497,11 @@ mod router_auth_gate_tests {
         header::{AUTHORIZATION, CONTENT_TYPE},
         Request, StatusCode,
     };
+    use streamlib::sdk::descriptors::{ModuleIdent, SemVerRange};
     use streamlib::sdk::graph::{LinkUniqueId, ProcessorUniqueId};
-    use streamlib::sdk::runtime::BoxFuture;
+    use streamlib::sdk::runtime::{
+        BoxFuture, RegisterProcessorReceipt, ReplaceProcessorFromSource, SubmittedProcessorSource,
+    };
     use tower::ServiceExt;
 
     /// Stub runtime whose graph mutations all succeed, so the REAL
@@ -537,6 +540,18 @@ mod router_auth_gate_tests {
         fn to_json_async(&self) -> BoxFuture<'_, Result<serde_json::Value>> {
             Box::pin(async { Ok(serde_json::json!({})) })
         }
+        fn register_processor_source_async(
+            &self,
+            _request: SubmittedProcessorSource,
+        ) -> BoxFuture<'_, Result<RegisterProcessorReceipt>> {
+            Box::pin(async { Ok(stub_register_receipt()) })
+        }
+        fn replace_processor_async(
+            &self,
+            _request: ReplaceProcessorFromSource,
+        ) -> BoxFuture<'_, Result<RegisterProcessorReceipt>> {
+            Box::pin(async { Ok(stub_register_receipt()) })
+        }
         fn add_processor(&self, _spec: ProcessorSpec) -> Result<ProcessorUniqueId> {
             Ok(ProcessorUniqueId::new())
         }
@@ -552,6 +567,21 @@ mod router_auth_gate_tests {
         fn to_json(&self) -> Result<serde_json::Value> {
             Ok(serde_json::json!({}))
         }
+    }
+
+    /// A minimal always-succeeds register/replace receipt for [`AlwaysOkStubRuntime`]:
+    /// a dummy `@session/stub` registration ident with no installed processors.
+    /// The register-from-source path is not exercised by the auth-gate tests, so
+    /// the port surface is empty.
+    fn stub_register_receipt() -> RegisterProcessorReceipt {
+        RegisterProcessorReceipt::new(
+            ModuleIdent::new(
+                Org::new("session").expect("session org passes the org grammar"),
+                Package::new("stub").expect("stub package passes the package grammar"),
+                SemVerRange::Exact(SemVer::new(0, 0, 0)),
+            ),
+            vec![],
+        )
     }
 
     const TEST_TOKEN: &str = "test-bearer-secret";

--- a/runtime/streamlib-engine/Cargo.toml
+++ b/runtime/streamlib-engine/Cargo.toml
@@ -206,6 +206,7 @@ required-features = []
 
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0.7.21" }
+serde_json = { workspace = true }
 
 # Build dependencies for protobuf compilation (surface-share service gRPC)
 [target.'cfg(target_os = "macos")'.build-dependencies]

--- a/runtime/streamlib-engine/build.rs
+++ b/runtime/streamlib-engine/build.rs
@@ -12,6 +12,8 @@
 fn main() {
     streamlib_jtd_codegen::build_rs::run_for_rust_crate();
 
+    emit_deno_sdk_version();
+
     // Propagate the host target triple so `Runner::add_module` can
     // resolve plugin cdylibs by `lib/<triple>/...` at load time.
     let target = std::env::var("TARGET").expect("TARGET env var set by cargo for build.rs");
@@ -45,6 +47,32 @@ fn main() {
 
     #[cfg(target_os = "linux")]
     compile_shaders();
+}
+
+/// Bake the Deno SDK's OWN published version into `STREAMLIB_DENO_SDK_VERSION`
+/// by reading the `version` field of `sdk/streamlib-deno/deno.json`. The Deno
+/// SDK is on an independent version line from the Rust workspace
+/// (`CARGO_PKG_VERSION`), so a live session package's `deno.json` import map and
+/// the off-link `npm:@tatolab/streamlib-deno@<ver>/extract_processors.ts` spec
+/// must pin the actually-published SDK version, not the workspace version.
+/// `deno.json` is the single source of truth; the same read runs in the build
+/// orchestrator's build script.
+fn emit_deno_sdk_version() {
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR set by cargo for build.rs");
+    let deno_json = std::path::Path::new(&manifest_dir).join("../../sdk/streamlib-deno/deno.json");
+    println!("cargo:rerun-if-changed={}", deno_json.display());
+    let body = std::fs::read_to_string(&deno_json)
+        .unwrap_or_else(|e| panic!("reading {}: {e}", deno_json.display()));
+    let manifest: serde_json::Value = serde_json::from_str(&body)
+        .unwrap_or_else(|e| panic!("parsing {}: {e}", deno_json.display()));
+    let version = manifest["version"].as_str().unwrap_or_else(|| {
+        panic!(
+            "{} has no string `version` field to pin the Deno SDK",
+            deno_json.display()
+        )
+    });
+    println!("cargo:rustc-env=STREAMLIB_DENO_SDK_VERSION={version}");
 }
 
 #[cfg(target_os = "linux")]

--- a/runtime/streamlib-engine/src/core/context/runtime_ops_shim.rs
+++ b/runtime/streamlib-engine/src/core/context/runtime_ops_shim.rs
@@ -366,3 +366,21 @@ fn block_on_current_runtime<F: std::future::Future>(fut: F) -> F::Output {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    /// Unit-op decode contract: the unit-returning ops (`remove_processor` /
+    /// `disconnect`) route through `submit_msgpack::<_, ()>`, which msgpack-
+    /// DECODES the host's completion payload as `()`. The host emits `to_vec_
+    /// named(&())` (the msgpack nil `0xc0`); `from_slice::<()>` must decode it
+    /// back to `Ok(())`. Revert the unit ops to a no-decode path and this lock
+    /// still passes, but it pins the decode half so the DRY'd `submit_msgpack`
+    /// path can't silently start rejecting the nil the host sends.
+    #[test]
+    fn unit_op_completion_payload_round_trips_through_msgpack() {
+        let encoded = rmp_serde::to_vec_named(&()).expect("() encodes to msgpack nil");
+        let decoded: () = rmp_serde::from_slice(&encoded)
+            .expect("the host's nil completion payload must decode as ()");
+        assert_eq!(decoded, ());
+    }
+}

--- a/runtime/streamlib-engine/src/core/context/runtime_ops_shim.rs
+++ b/runtime/streamlib-engine/src/core/context/runtime_ops_shim.rs
@@ -27,10 +27,10 @@ use crate::core::error::{Error, Result};
 use crate::core::graph::{LinkUniqueId, ProcessorUniqueId};
 use crate::core::processors::ProcessorSpec;
 use crate::core::runtime::{
-    BoxFuture, ReplaceProcessorFromSource, RuntimeOperations, SubmittedProcessorSource,
+    BoxFuture, RegisterProcessorReceipt, ReplaceProcessorFromSource, RuntimeOperations,
+    SubmittedProcessorSource,
 };
 use crate::core::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib_idents::ModuleIdent;
 
 /// Cdylib-side handle to the host's graph-mutation operations.
 ///
@@ -295,7 +295,7 @@ impl RuntimeOperations for RuntimeOpsShim {
     fn register_processor_source_async(
         &self,
         request: SubmittedProcessorSource,
-    ) -> BoxFuture<'_, Result<ModuleIdent>> {
+    ) -> BoxFuture<'_, Result<RegisterProcessorReceipt>> {
         self.submit_msgpack(
             "register_processor_source_async",
             request,
@@ -308,7 +308,7 @@ impl RuntimeOperations for RuntimeOpsShim {
     fn replace_processor_async(
         &self,
         request: ReplaceProcessorFromSource,
-    ) -> BoxFuture<'_, Result<ModuleIdent>> {
+    ) -> BoxFuture<'_, Result<RegisterProcessorReceipt>> {
         self.submit_msgpack(
             "replace_processor_async",
             request,

--- a/runtime/streamlib-engine/src/core/context/runtime_ops_shim.rs
+++ b/runtime/streamlib-engine/src/core/context/runtime_ops_shim.rs
@@ -137,27 +137,48 @@ impl RuntimeOpsShim {
         }
     }
 
-    /// Same as [`submit`] but discards the response payload.
-    async fn submit_unit<F>(&self, request: F) -> Result<()>
+    /// Encode a single-payload request, submit it through `dispatch` (which
+    /// invokes the matching one-buffer `RuntimeOpsVTable` slot), and decode the
+    /// response as `Resp`. Owns the whole encode → early-error-future → submit
+    /// dance shared by every one-payload op; a msgpack encode failure returns an
+    /// immediately-ready error future without touching the vtable. `connect`
+    /// (two payloads) and `to_json` (none) call [`Self::submit`] directly.
+    fn submit_msgpack<Req, Resp>(
+        &self,
+        op_name: &'static str,
+        request: Req,
+        dispatch: fn(
+            *const RuntimeOpsVTable,
+            *const c_void,
+            *const u8,
+            usize,
+            RuntimeOpCompletionCallback,
+            *mut c_void,
+        ),
+    ) -> BoxFuture<'_, Result<Resp>>
     where
-        F: FnOnce(*const c_void, *const RuntimeOpsVTable, RuntimeOpCompletionCallback, *mut c_void)
-            + Send
-            + 'static,
+        Req: serde::Serialize,
+        Resp: serde::de::DeserializeOwned + Send + 'static,
     {
-        let (tx, rx) = tokio::sync::oneshot::channel::<(i32, Vec<u8>)>();
-        let sender_box: Box<tokio::sync::oneshot::Sender<(i32, Vec<u8>)>> = Box::new(tx);
-        let user_data = Box::into_raw(sender_box) as *mut c_void;
-        let completion: RuntimeOpCompletionCallback = runtime_ops_completion_trampoline;
-        request(self.handle, self.vtable, completion, user_data);
-        let (status, payload) = rx
-            .await
-            .map_err(|_| Error::Runtime("runtime-ops completion dropped".into()))?;
-        if status == 0 {
-            Ok(())
-        } else {
-            let msg = String::from_utf8_lossy(&payload).into_owned();
-            Err(Error::Runtime(msg))
-        }
+        let bytes = match rmp_serde::to_vec_named(&request) {
+            Ok(b) => b,
+            Err(e) => {
+                let err = Err(Error::Config(format!(
+                    "RuntimeOpsShim::{op_name}: request msgpack encode failed: {e}"
+                )));
+                return Box::pin(async move { err });
+            }
+        };
+        Box::pin(
+            self.submit(move |handle, vtable, completion, user_data| {
+                dispatch(vtable, handle, bytes.as_ptr(), bytes.len(), completion, user_data);
+                // `bytes` is moved into the closure and dropped at end-of-call;
+                // the host copies the buffer synchronously before its first
+                // await, per the vtable "valid for the duration of the call"
+                // contract.
+                drop(bytes);
+            }),
+        )
     }
 }
 
@@ -196,56 +217,22 @@ unsafe extern "C" fn runtime_ops_completion_trampoline(
 
 impl RuntimeOperations for RuntimeOpsShim {
     fn add_processor_async(&self, spec: ProcessorSpec) -> BoxFuture<'_, Result<ProcessorUniqueId>> {
-        let bytes = match rmp_serde::to_vec_named(&spec) {
-            Ok(b) => b,
-            Err(e) => {
-                let err = Err(Error::Config(format!(
-                    "RuntimeOpsShim::add_processor_async: spec msgpack encode failed: {e}"
-                )));
-                return Box::pin(async move { err });
-            }
-        };
-        Box::pin(
-            self.submit(move |handle, vtable, completion, user_data| unsafe {
-                ((*vtable).add_processor)(
-                    handle,
-                    bytes.as_ptr(),
-                    bytes.len(),
-                    completion,
-                    user_data,
-                );
-                // Hold bytes alive until the host has consumed them. The
-                // vtable contract is "valid for the duration of the call"
-                // — the spawned host task copies the bytes synchronously
-                // before its first await, so it's safe to drop bytes when
-                // this closure returns. `bytes` is moved into the closure,
-                // so it's dropped at end-of-call here.
-                drop(bytes);
-            }),
+        self.submit_msgpack(
+            "add_processor_async",
+            spec,
+            |vtable, handle, ptr, len, completion, user_data| unsafe {
+                ((*vtable).add_processor)(handle, ptr, len, completion, user_data)
+            },
         )
     }
 
     fn remove_processor_async(&self, processor_id: ProcessorUniqueId) -> BoxFuture<'_, Result<()>> {
-        let bytes = match rmp_serde::to_vec_named(&processor_id) {
-            Ok(b) => b,
-            Err(e) => {
-                let err = Err(Error::Config(format!(
-                    "RuntimeOpsShim::remove_processor_async: id msgpack encode failed: {e}"
-                )));
-                return Box::pin(async move { err });
-            }
-        };
-        Box::pin(
-            self.submit_unit(move |handle, vtable, completion, user_data| unsafe {
-                ((*vtable).remove_processor)(
-                    handle,
-                    bytes.as_ptr(),
-                    bytes.len(),
-                    completion,
-                    user_data,
-                );
-                drop(bytes);
-            }),
+        self.submit_msgpack(
+            "remove_processor_async",
+            processor_id,
+            |vtable, handle, ptr, len, completion, user_data| unsafe {
+                ((*vtable).remove_processor)(handle, ptr, len, completion, user_data)
+            },
         )
     }
 
@@ -290,20 +277,12 @@ impl RuntimeOperations for RuntimeOpsShim {
     }
 
     fn disconnect_async(&self, link_id: LinkUniqueId) -> BoxFuture<'_, Result<()>> {
-        let bytes = match rmp_serde::to_vec_named(&link_id) {
-            Ok(b) => b,
-            Err(e) => {
-                let err = Err(Error::Config(format!(
-                    "RuntimeOpsShim::disconnect_async: link_id msgpack encode failed: {e}"
-                )));
-                return Box::pin(async move { err });
-            }
-        };
-        Box::pin(
-            self.submit_unit(move |handle, vtable, completion, user_data| unsafe {
-                ((*vtable).disconnect)(handle, bytes.as_ptr(), bytes.len(), completion, user_data);
-                drop(bytes);
-            }),
+        self.submit_msgpack(
+            "disconnect_async",
+            link_id,
+            |vtable, handle, ptr, len, completion, user_data| unsafe {
+                ((*vtable).disconnect)(handle, ptr, len, completion, user_data)
+            },
         )
     }
 
@@ -317,26 +296,12 @@ impl RuntimeOperations for RuntimeOpsShim {
         &self,
         request: SubmittedProcessorSource,
     ) -> BoxFuture<'_, Result<ModuleIdent>> {
-        let bytes = match rmp_serde::to_vec_named(&request) {
-            Ok(b) => b,
-            Err(e) => {
-                let err = Err(Error::Config(format!(
-                    "RuntimeOpsShim::register_processor_source_async: request msgpack encode failed: {e}"
-                )));
-                return Box::pin(async move { err });
-            }
-        };
-        Box::pin(
-            self.submit(move |handle, vtable, completion, user_data| unsafe {
-                ((*vtable).register_processor_source)(
-                    handle,
-                    bytes.as_ptr(),
-                    bytes.len(),
-                    completion,
-                    user_data,
-                );
-                drop(bytes);
-            }),
+        self.submit_msgpack(
+            "register_processor_source_async",
+            request,
+            |vtable, handle, ptr, len, completion, user_data| unsafe {
+                ((*vtable).register_processor_source)(handle, ptr, len, completion, user_data)
+            },
         )
     }
 
@@ -344,26 +309,12 @@ impl RuntimeOperations for RuntimeOpsShim {
         &self,
         request: ReplaceProcessorFromSource,
     ) -> BoxFuture<'_, Result<ModuleIdent>> {
-        let bytes = match rmp_serde::to_vec_named(&request) {
-            Ok(b) => b,
-            Err(e) => {
-                let err = Err(Error::Config(format!(
-                    "RuntimeOpsShim::replace_processor_async: request msgpack encode failed: {e}"
-                )));
-                return Box::pin(async move { err });
-            }
-        };
-        Box::pin(
-            self.submit(move |handle, vtable, completion, user_data| unsafe {
-                ((*vtable).replace_processor)(
-                    handle,
-                    bytes.as_ptr(),
-                    bytes.len(),
-                    completion,
-                    user_data,
-                );
-                drop(bytes);
-            }),
+        self.submit_msgpack(
+            "replace_processor_async",
+            request,
+            |vtable, handle, ptr, len, completion, user_data| unsafe {
+                ((*vtable).replace_processor)(handle, ptr, len, completion, user_data)
+            },
         )
     }
 

--- a/runtime/streamlib-engine/src/core/context/runtime_ops_shim.rs
+++ b/runtime/streamlib-engine/src/core/context/runtime_ops_shim.rs
@@ -26,8 +26,11 @@ use streamlib_plugin_abi::{RuntimeOpCompletionCallback, RuntimeOpsVTable};
 use crate::core::error::{Error, Result};
 use crate::core::graph::{LinkUniqueId, ProcessorUniqueId};
 use crate::core::processors::ProcessorSpec;
-use crate::core::runtime::{BoxFuture, RuntimeOperations};
+use crate::core::runtime::{
+    BoxFuture, ReplaceProcessorFromSource, RuntimeOperations, SubmittedProcessorSource,
+};
 use crate::core::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib_idents::ModuleIdent;
 
 /// Cdylib-side handle to the host's graph-mutation operations.
 ///
@@ -308,6 +311,60 @@ impl RuntimeOperations for RuntimeOpsShim {
         Box::pin(self.submit(|handle, vtable, completion, user_data| unsafe {
             ((*vtable).to_json)(handle, completion, user_data);
         }))
+    }
+
+    fn register_processor_source_async(
+        &self,
+        request: SubmittedProcessorSource,
+    ) -> BoxFuture<'_, Result<ModuleIdent>> {
+        let bytes = match rmp_serde::to_vec_named(&request) {
+            Ok(b) => b,
+            Err(e) => {
+                let err = Err(Error::Config(format!(
+                    "RuntimeOpsShim::register_processor_source_async: request msgpack encode failed: {e}"
+                )));
+                return Box::pin(async move { err });
+            }
+        };
+        Box::pin(
+            self.submit(move |handle, vtable, completion, user_data| unsafe {
+                ((*vtable).register_processor_source)(
+                    handle,
+                    bytes.as_ptr(),
+                    bytes.len(),
+                    completion,
+                    user_data,
+                );
+                drop(bytes);
+            }),
+        )
+    }
+
+    fn replace_processor_async(
+        &self,
+        request: ReplaceProcessorFromSource,
+    ) -> BoxFuture<'_, Result<ModuleIdent>> {
+        let bytes = match rmp_serde::to_vec_named(&request) {
+            Ok(b) => b,
+            Err(e) => {
+                let err = Err(Error::Config(format!(
+                    "RuntimeOpsShim::replace_processor_async: request msgpack encode failed: {e}"
+                )));
+                return Box::pin(async move { err });
+            }
+        };
+        Box::pin(
+            self.submit(move |handle, vtable, completion, user_data| unsafe {
+                ((*vtable).replace_processor)(
+                    handle,
+                    bytes.as_ptr(),
+                    bytes.len(),
+                    completion,
+                    user_data,
+                );
+                drop(bytes);
+            }),
+        )
     }
 
     // -------------------------------------------------------------------------

--- a/runtime/streamlib-engine/src/core/plugin/host_services/runtime_ops.rs
+++ b/runtime/streamlib-engine/src/core/plugin/host_services/runtime_ops.rs
@@ -358,6 +358,94 @@ unsafe extern "C" fn host_rov_to_json(
     )
 }
 
+unsafe extern "C" fn host_rov_register_processor_source(
+    handle: *const c_void,
+    request_msgpack_ptr: *const u8,
+    request_msgpack_len: usize,
+    completion: streamlib_plugin_abi::RuntimeOpCompletionCallback,
+    user_data: *mut c_void,
+) {
+    run_host_extern_c(
+        "host_rov_register_processor_source",
+        || {
+            if handle.is_null() {
+                CompletionGuard::new(completion, user_data)
+                    .fire_err_msg(b"register_processor_source: null handle");
+                return;
+            }
+            let ops = unsafe { Arc::clone(&*(handle as *const Arc<dyn RuntimeOperations>)) };
+            let guard = CompletionGuard::new(completion, user_data);
+            let Some(rt) = host_tokio_handle() else {
+                guard.fire_err_msg(b"host tokio handle not installed");
+                return;
+            };
+            let request_bytes = if request_msgpack_len == 0 {
+                Vec::new()
+            } else {
+                unsafe { std::slice::from_raw_parts(request_msgpack_ptr, request_msgpack_len) }
+                    .to_vec()
+            };
+            rt.spawn(async move {
+                let result = match rmp_serde::from_slice::<
+                    crate::core::runtime::SubmittedProcessorSource,
+                >(&request_bytes)
+                {
+                    Ok(request) => ops.register_processor_source_async(request).await,
+                    Err(e) => Err(crate::core::Error::Config(format!(
+                        "register_processor_source: request msgpack decode failed: {e}"
+                    ))),
+                };
+                guard.fire_with_result(result);
+            });
+        },
+        (),
+    )
+}
+
+unsafe extern "C" fn host_rov_replace_processor(
+    handle: *const c_void,
+    request_msgpack_ptr: *const u8,
+    request_msgpack_len: usize,
+    completion: streamlib_plugin_abi::RuntimeOpCompletionCallback,
+    user_data: *mut c_void,
+) {
+    run_host_extern_c(
+        "host_rov_replace_processor",
+        || {
+            if handle.is_null() {
+                CompletionGuard::new(completion, user_data)
+                    .fire_err_msg(b"replace_processor: null handle");
+                return;
+            }
+            let ops = unsafe { Arc::clone(&*(handle as *const Arc<dyn RuntimeOperations>)) };
+            let guard = CompletionGuard::new(completion, user_data);
+            let Some(rt) = host_tokio_handle() else {
+                guard.fire_err_msg(b"host tokio handle not installed");
+                return;
+            };
+            let request_bytes = if request_msgpack_len == 0 {
+                Vec::new()
+            } else {
+                unsafe { std::slice::from_raw_parts(request_msgpack_ptr, request_msgpack_len) }
+                    .to_vec()
+            };
+            rt.spawn(async move {
+                let result = match rmp_serde::from_slice::<
+                    crate::core::runtime::ReplaceProcessorFromSource,
+                >(&request_bytes)
+                {
+                    Ok(request) => ops.replace_processor_async(request).await,
+                    Err(e) => Err(crate::core::Error::Config(format!(
+                        "replace_processor: request msgpack decode failed: {e}"
+                    ))),
+                };
+                guard.fire_with_result(result);
+            });
+        },
+        (),
+    )
+}
+
 /// Take a (borrowed) handle returned from
 /// `RuntimeContextVTable::runtime_ops_handle` (a `*const Arc<dyn
 /// RuntimeOperations>` pointing into `RuntimeContext`-owned storage)
@@ -412,6 +500,8 @@ pub static HOST_RUNTIME_OPS_VTABLE: RuntimeOpsVTable = RuntimeOpsVTable {
     to_json: host_rov_to_json,
     clone_handle: host_rov_clone_handle,
     drop_handle: host_rov_drop_handle,
+    register_processor_source: host_rov_register_processor_source,
+    replace_processor: host_rov_replace_processor,
 };
 
 /// Pointer to the [`RuntimeOpsVTable`] this DSO should dispatch
@@ -581,19 +671,51 @@ mod runtime_ops_vtable_null_handle_guards {
         assert_single_err_completion(&sink, "to_json: null handle");
         unsafe { reclaim_sink(user_data) };
     }
+
+    #[test]
+    fn register_processor_source_fires_error_completion_on_null_handle() {
+        let (user_data, sink) = install_sink_user_data();
+        unsafe {
+            (HOST_RUNTIME_OPS_VTABLE.register_processor_source)(
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+                record_completion,
+                user_data,
+            );
+        }
+        assert_single_err_completion(&sink, "register_processor_source: null handle");
+        unsafe { reclaim_sink(user_data) };
+    }
+
+    #[test]
+    fn replace_processor_fires_error_completion_on_null_handle() {
+        let (user_data, sink) = install_sink_user_data();
+        unsafe {
+            (HOST_RUNTIME_OPS_VTABLE.replace_processor)(
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+                record_completion,
+                user_data,
+            );
+        }
+        assert_single_err_completion(&sink, "replace_processor: null handle");
+        unsafe { reclaim_sink(user_data) };
+    }
 }
 
 #[cfg(test)]
 mod runtime_ops_vtable_tier1_wire_format_tests {
     //! Tier-1 wire-format tests for [`HOST_RUNTIME_OPS_VTABLE`].
     //!
-    //! Per-callback null-handle coverage for the 5
-    //! submit-with-completion ops (`add_processor`,
-    //! `remove_processor`, `connect`, `disconnect`, `to_json`)
-    //! lives in [`runtime_ops_vtable_null_handle_guards`] above.
-    //! This module adds:
+    //! Per-callback null-handle coverage for the submit-with-completion
+    //! ops (`add_processor`, `remove_processor`, `connect`,
+    //! `disconnect`, `to_json`, and the v3 `register_processor_source`
+    //! / `replace_processor`) lives in
+    //! [`runtime_ops_vtable_null_handle_guards`] above. This module adds:
     //!
-    //! - `layout_version_matches_constant` — locks the v2 layout
+    //! - `layout_version_matches_constant` — locks the v3 layout
     //!   version against the cdylib-visible constant.
     //! - `clone_handle` / `drop_handle` null-handle coverage — the
     //!   v2 Arc-lifecycle pair already had explicit guards

--- a/runtime/streamlib-engine/src/core/plugin/host_services/runtime_ops.rs
+++ b/runtime/streamlib-engine/src/core/plugin/host_services/runtime_ops.rs
@@ -133,6 +133,76 @@ impl Drop for CompletionGuard {
 unsafe impl Send for CompletionGuard {}
 unsafe impl Sync for CompletionGuard {}
 
+/// Shared host-side body for every single-msgpack-payload runtime op
+/// (`add_processor`, `remove_processor`, `disconnect`,
+/// `register_processor_source`, `replace_processor`): null-handle guard →
+/// clone the ops handle → resolve the host tokio handle → copy the request
+/// bytes → spawn a task that decodes `Req`, runs `run`, and fires the
+/// completion with the serialized `Resp`. `connect` (two payloads) and
+/// `to_json` (none) stay bespoke — this helper deliberately covers only the
+/// one-payload shape.
+///
+/// `op_name` is the operation's short name (e.g. `"add_processor"`) — it names
+/// the null-handle / decode-error messages the cdylib observes and the
+/// `run_host_extern_c` panic label.
+///
+/// # Safety
+/// `handle` must be null or a valid `*const Arc<dyn RuntimeOperations>`, and
+/// `ptr`/`len` must describe a readable byte range (or `len == 0`) — the same
+/// contract every `RuntimeOpsVTable` submit callback carries.
+fn host_rov_submit_single_msgpack<Req, Resp, Fut>(
+    op_name: &'static str,
+    handle: *const c_void,
+    ptr: *const u8,
+    len: usize,
+    completion: streamlib_plugin_abi::RuntimeOpCompletionCallback,
+    user_data: *mut c_void,
+    run: impl FnOnce(Arc<dyn RuntimeOperations>, Req) -> Fut + Send + 'static,
+) where
+    Req: serde::de::DeserializeOwned + Send + 'static,
+    Resp: serde::Serialize + Send + 'static,
+    Fut: std::future::Future<Output = crate::core::Result<Resp>> + Send + 'static,
+{
+    run_host_extern_c(
+        op_name,
+        || {
+            if handle.is_null() {
+                CompletionGuard::new(completion, user_data)
+                    .fire_err_msg(format!("{op_name}: null handle").as_bytes());
+                return;
+            }
+            // SAFETY: non-null handle is a `*const Arc<dyn RuntimeOperations>`
+            // per the vtable contract (see fn-level Safety).
+            let ops = unsafe { Arc::clone(&*(handle as *const Arc<dyn RuntimeOperations>)) };
+            let guard = CompletionGuard::new(completion, user_data);
+            let Some(rt) = host_tokio_handle() else {
+                guard.fire_err_msg(b"host tokio handle not installed");
+                return;
+            };
+            let bytes = if len == 0 {
+                Vec::new()
+            } else {
+                // SAFETY: ptr/len describe a readable range per the contract.
+                unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec()
+            };
+            rt.spawn(async move {
+                let result = match rmp_serde::from_slice::<Req>(&bytes) {
+                    Ok(req) => run(ops, req).await,
+                    Err(e) => Err(crate::core::Error::Config(format!(
+                        "{op_name}: request msgpack decode failed: {e}"
+                    ))),
+                };
+                guard.fire_with_result(result);
+            });
+        },
+        // Sync-body panic: CompletionGuard's Drop fires the abort completion if
+        // `guard` was constructed before the panic; otherwise the cdylib's
+        // `rx.await` hangs. The cdylib's RAII-on-Drop trampoline reclaims its
+        // boxed Sender either way.
+        (),
+    )
+}
+
 unsafe extern "C" fn host_rov_add_processor(
     handle: *const c_void,
     spec_msgpack_ptr: *const u8,
@@ -140,43 +210,14 @@ unsafe extern "C" fn host_rov_add_processor(
     completion: streamlib_plugin_abi::RuntimeOpCompletionCallback,
     user_data: *mut c_void,
 ) {
-    run_host_extern_c(
-        "host_rov_add_processor",
-        || {
-            if handle.is_null() {
-                CompletionGuard::new(completion, user_data)
-                    .fire_err_msg(b"add_processor: null handle");
-                return;
-            }
-            let ops = unsafe { Arc::clone(&*(handle as *const Arc<dyn RuntimeOperations>)) };
-            let guard = CompletionGuard::new(completion, user_data);
-            let Some(rt) = host_tokio_handle() else {
-                guard.fire_err_msg(b"host tokio handle not installed");
-                return;
-            };
-            let spec_bytes = if spec_msgpack_len == 0 {
-                Vec::new()
-            } else {
-                unsafe { std::slice::from_raw_parts(spec_msgpack_ptr, spec_msgpack_len) }.to_vec()
-            };
-            rt.spawn(async move {
-                let result = match rmp_serde::from_slice::<crate::core::processors::ProcessorSpec>(
-                    &spec_bytes,
-                ) {
-                    Ok(spec) => ops.add_processor_async(spec).await,
-                    Err(e) => Err(crate::core::Error::Config(format!(
-                        "add_processor: spec msgpack decode failed: {e}"
-                    ))),
-                };
-                guard.fire_with_result(result);
-            });
-        },
-        // Sync-body panic: CompletionGuard's Drop fires the abort
-        // completion if `guard` was constructed before the panic;
-        // otherwise the cdylib's `rx.await` hangs. The cdylib's
-        // RAII-on-Drop trampoline reclaims its boxed Sender either
-        // way.
-        (),
+    host_rov_submit_single_msgpack::<crate::core::processors::ProcessorSpec, _, _>(
+        "add_processor",
+        handle,
+        spec_msgpack_ptr,
+        spec_msgpack_len,
+        completion,
+        user_data,
+        |ops, spec| async move { ops.add_processor_async(spec).await },
     )
 }
 
@@ -187,41 +228,14 @@ unsafe extern "C" fn host_rov_remove_processor(
     completion: streamlib_plugin_abi::RuntimeOpCompletionCallback,
     user_data: *mut c_void,
 ) {
-    run_host_extern_c(
-        "host_rov_remove_processor",
-        || {
-            if handle.is_null() {
-                CompletionGuard::new(completion, user_data)
-                    .fire_err_msg(b"remove_processor: null handle");
-                return;
-            }
-            let ops = unsafe { Arc::clone(&*(handle as *const Arc<dyn RuntimeOperations>)) };
-            let guard = CompletionGuard::new(completion, user_data);
-            let Some(rt) = host_tokio_handle() else {
-                guard.fire_err_msg(b"host tokio handle not installed");
-                return;
-            };
-            let id_bytes = if processor_id_msgpack_len == 0 {
-                Vec::new()
-            } else {
-                unsafe {
-                    std::slice::from_raw_parts(processor_id_msgpack_ptr, processor_id_msgpack_len)
-                }
-                .to_vec()
-            };
-            rt.spawn(async move {
-                let result =
-                    match rmp_serde::from_slice::<crate::core::graph::ProcessorUniqueId>(&id_bytes)
-                    {
-                        Ok(pid) => ops.remove_processor_async(pid).await,
-                        Err(e) => Err(crate::core::Error::Config(format!(
-                            "remove_processor: processor_id msgpack decode failed: {e}"
-                        ))),
-                    };
-                guard.fire_with_result(result);
-            });
-        },
-        (),
+    host_rov_submit_single_msgpack::<crate::core::graph::ProcessorUniqueId, _, _>(
+        "remove_processor",
+        handle,
+        processor_id_msgpack_ptr,
+        processor_id_msgpack_len,
+        completion,
+        user_data,
+        |ops, pid| async move { ops.remove_processor_async(pid).await },
     )
 }
 
@@ -296,38 +310,14 @@ unsafe extern "C" fn host_rov_disconnect(
     completion: streamlib_plugin_abi::RuntimeOpCompletionCallback,
     user_data: *mut c_void,
 ) {
-    run_host_extern_c(
-        "host_rov_disconnect",
-        || {
-            if handle.is_null() {
-                CompletionGuard::new(completion, user_data)
-                    .fire_err_msg(b"disconnect: null handle");
-                return;
-            }
-            let ops = unsafe { Arc::clone(&*(handle as *const Arc<dyn RuntimeOperations>)) };
-            let guard = CompletionGuard::new(completion, user_data);
-            let Some(rt) = host_tokio_handle() else {
-                guard.fire_err_msg(b"host tokio handle not installed");
-                return;
-            };
-            let bytes = if link_id_msgpack_len == 0 {
-                Vec::new()
-            } else {
-                unsafe { std::slice::from_raw_parts(link_id_msgpack_ptr, link_id_msgpack_len) }
-                    .to_vec()
-            };
-            rt.spawn(async move {
-                let result = match rmp_serde::from_slice::<crate::core::graph::LinkUniqueId>(&bytes)
-                {
-                    Ok(link_id) => ops.disconnect_async(link_id).await,
-                    Err(e) => Err(crate::core::Error::Config(format!(
-                        "disconnect: link_id msgpack decode failed: {e}"
-                    ))),
-                };
-                guard.fire_with_result(result);
-            });
-        },
-        (),
+    host_rov_submit_single_msgpack::<crate::core::graph::LinkUniqueId, (), _>(
+        "disconnect",
+        handle,
+        link_id_msgpack_ptr,
+        link_id_msgpack_len,
+        completion,
+        user_data,
+        |ops, link_id| async move { ops.disconnect_async(link_id).await },
     )
 }
 
@@ -365,40 +355,14 @@ unsafe extern "C" fn host_rov_register_processor_source(
     completion: streamlib_plugin_abi::RuntimeOpCompletionCallback,
     user_data: *mut c_void,
 ) {
-    run_host_extern_c(
-        "host_rov_register_processor_source",
-        || {
-            if handle.is_null() {
-                CompletionGuard::new(completion, user_data)
-                    .fire_err_msg(b"register_processor_source: null handle");
-                return;
-            }
-            let ops = unsafe { Arc::clone(&*(handle as *const Arc<dyn RuntimeOperations>)) };
-            let guard = CompletionGuard::new(completion, user_data);
-            let Some(rt) = host_tokio_handle() else {
-                guard.fire_err_msg(b"host tokio handle not installed");
-                return;
-            };
-            let request_bytes = if request_msgpack_len == 0 {
-                Vec::new()
-            } else {
-                unsafe { std::slice::from_raw_parts(request_msgpack_ptr, request_msgpack_len) }
-                    .to_vec()
-            };
-            rt.spawn(async move {
-                let result = match rmp_serde::from_slice::<
-                    crate::core::runtime::SubmittedProcessorSource,
-                >(&request_bytes)
-                {
-                    Ok(request) => ops.register_processor_source_async(request).await,
-                    Err(e) => Err(crate::core::Error::Config(format!(
-                        "register_processor_source: request msgpack decode failed: {e}"
-                    ))),
-                };
-                guard.fire_with_result(result);
-            });
-        },
-        (),
+    host_rov_submit_single_msgpack::<crate::core::runtime::SubmittedProcessorSource, _, _>(
+        "register_processor_source",
+        handle,
+        request_msgpack_ptr,
+        request_msgpack_len,
+        completion,
+        user_data,
+        |ops, request| async move { ops.register_processor_source_async(request).await },
     )
 }
 
@@ -409,40 +373,14 @@ unsafe extern "C" fn host_rov_replace_processor(
     completion: streamlib_plugin_abi::RuntimeOpCompletionCallback,
     user_data: *mut c_void,
 ) {
-    run_host_extern_c(
-        "host_rov_replace_processor",
-        || {
-            if handle.is_null() {
-                CompletionGuard::new(completion, user_data)
-                    .fire_err_msg(b"replace_processor: null handle");
-                return;
-            }
-            let ops = unsafe { Arc::clone(&*(handle as *const Arc<dyn RuntimeOperations>)) };
-            let guard = CompletionGuard::new(completion, user_data);
-            let Some(rt) = host_tokio_handle() else {
-                guard.fire_err_msg(b"host tokio handle not installed");
-                return;
-            };
-            let request_bytes = if request_msgpack_len == 0 {
-                Vec::new()
-            } else {
-                unsafe { std::slice::from_raw_parts(request_msgpack_ptr, request_msgpack_len) }
-                    .to_vec()
-            };
-            rt.spawn(async move {
-                let result = match rmp_serde::from_slice::<
-                    crate::core::runtime::ReplaceProcessorFromSource,
-                >(&request_bytes)
-                {
-                    Ok(request) => ops.replace_processor_async(request).await,
-                    Err(e) => Err(crate::core::Error::Config(format!(
-                        "replace_processor: request msgpack decode failed: {e}"
-                    ))),
-                };
-                guard.fire_with_result(result);
-            });
-        },
-        (),
+    host_rov_submit_single_msgpack::<crate::core::runtime::ReplaceProcessorFromSource, _, _>(
+        "replace_processor",
+        handle,
+        request_msgpack_ptr,
+        request_msgpack_len,
+        completion,
+        user_data,
+        |ops, request| async move { ops.replace_processor_async(request).await },
     )
 }
 

--- a/runtime/streamlib-engine/src/core/runtime/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/mod.rs
@@ -28,7 +28,10 @@ pub(crate) use module_loader::{
     lookup_schema_via_active_cdylib_sink, stage_processor_via_active_cdylib_sink,
     stage_schema_via_active_cdylib_sink,
 };
-pub use operations::{BoxFuture, ConnectOptions, RuntimeOperations, SchemaValidationPosture};
+pub use operations::{
+    BoxFuture, ConnectOptions, ReplaceProcessorFromSource, RuntimeOperations,
+    SchemaValidationPosture, SubmittedProcessorSource,
+};
 pub use runtime::Runner;
 pub use runtime_unique_id::RuntimeUniqueId;
 pub use status::RuntimeStatus;

--- a/runtime/streamlib-engine/src/core/runtime/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/mod.rs
@@ -29,7 +29,8 @@ pub(crate) use module_loader::{
     stage_schema_via_active_cdylib_sink,
 };
 pub use operations::{
-    BoxFuture, ConnectOptions, ReplaceProcessorFromSource, RuntimeOperations,
+    BoxFuture, ConnectOptions, RegisterProcessorReceipt, RegisteredPortReceipt,
+    RegisteredProcessorReceipt, ReplaceProcessorFromSource, RuntimeOperations,
     SchemaValidationPosture, SubmittedProcessorSource,
 };
 pub use runtime::Runner;

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/errors.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/errors.rs
@@ -491,6 +491,43 @@ pub enum AddModuleError {
     DuplicateSessionProcessorName {
         module: streamlib_idents::ModuleIdent,
     },
+
+    /// [`Runner::register_processor_from_source`] was handed a `language` that
+    /// live source submit does not support. Only the subprocess languages
+    /// (Python / TypeScript) run from source with no host compile; Rust from
+    /// source is a full cargo build (the `streamlib pkg build` flow), never a
+    /// live graph mutation.
+    ///
+    /// [`Runner::register_processor_from_source`]: super::super::Runner::register_processor_from_source
+    #[error(
+        "register_processor_from_source: language '{language}' is not supported \
+         for live source submit — only Python and TypeScript run from source. \
+         Build a Rust processor with `streamlib pkg build` and load the package."
+    )]
+    SourceLanguageUnsupportedForLiveSubmit { language: String },
+
+    /// [`Runner::register_processor_from_source`] was handed a submission with
+    /// neither a `requested_name` nor a `processor_type_name` — there is no
+    /// identity to mint a `@session/<name>` under.
+    ///
+    /// [`Runner::register_processor_from_source`]: super::super::Runner::register_processor_from_source
+    #[error(
+        "register_processor_from_source: the submission carries neither a \
+         requested name nor a processor type name — supply one so a \
+         `@session/<name>` identity can be minted."
+    )]
+    SubmittedSourceMissingName,
+
+    /// [`Runner::register_processor_from_source`] failed to stage the submitted
+    /// source to disk (directory creation, source write, or manifest write).
+    /// `detail` names the failing step.
+    ///
+    /// [`Runner::register_processor_from_source`]: super::super::Runner::register_processor_from_source
+    #[error("register_processor_from_source: failed to stage '{module}' to disk: {detail}")]
+    SubmittedSourceStagingFailed {
+        module: streamlib_idents::ModuleIdent,
+        detail: String,
+    },
 }
 
 impl From<AddModuleError> for Error {

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/errors.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/errors.rs
@@ -528,6 +528,76 @@ pub enum AddModuleError {
         module: streamlib_idents::ModuleIdent,
         detail: String,
     },
+
+    /// [`Runner::replace_processor_from_source`] was given a replacement whose
+    /// minted `@session/<name>` segment does not match the target's — a replace
+    /// only ever re-registers the SAME session name at a fresh `0.0.N`. Refused
+    /// before any mutation (no removal, no staging), so the target is untouched.
+    ///
+    /// [`Runner::replace_processor_from_source`]: super::super::Runner::replace_processor_from_source
+    #[error(
+        "replace_processor_from_source: the replacement resolves to session name \
+         '{replacement_name}' but the target is '{target}' — a replace re-registers \
+         the same `@session/<name>`. Submit the replacement under the target's name, \
+         or use remove_module + register_processor_from_source for a rename."
+    )]
+    ReplaceTargetNameMismatch {
+        target: streamlib_idents::ModuleIdent,
+        replacement_name: String,
+    },
+
+    /// [`Runner::replace_processor_from_source`] refused because the target's
+    /// loaded version is not source-backed on disk — no staged
+    /// `session-source/<name>/<loaded-version>/` dir exists to restore from if
+    /// the replacement fails. This is the case for an `add_local` host-vtable
+    /// registration (registered from a compiled type, never staged as source),
+    /// which is outside the live-source-iteration use case. Refused before any
+    /// mutation, so the target is untouched.
+    ///
+    /// [`Runner::replace_processor_from_source`]: super::super::Runner::replace_processor_from_source
+    #[error(
+        "replace_processor_from_source: target '{target}' is not source-backed \
+         (no staged source at {}), so it cannot be transactionally restored if the \
+         replacement fails — this is an `add_local` host-vtable registration. Use \
+         remove_module + register_processor_from_source to swap it explicitly.",
+        expected_dir.display()
+    )]
+    ReplaceTargetNotSourceBacked {
+        target: streamlib_idents::ModuleIdent,
+        expected_dir: std::path::PathBuf,
+    },
+
+    /// [`Runner::replace_processor_from_source`] removed the target and then the
+    /// replacement's registration failed — but the target's prior registration
+    /// was restored from its on-disk staged source, so the runtime is back to
+    /// its pre-replace state. `cause` carries the replacement's failure.
+    ///
+    /// [`Runner::replace_processor_from_source`]: super::super::Runner::replace_processor_from_source
+    #[error(
+        "replace_processor_from_source: the replacement for '{target}' failed to \
+         register ({cause}); the prior registration was restored — the runtime is \
+         unchanged. Fix the replacement source and retry."
+    )]
+    ReplacementRegistrationFailedPriorRegistrationRestored {
+        target: streamlib_idents::ModuleIdent,
+        cause: String,
+    },
+
+    /// [`Runner::replace_processor_from_source`] removed the target, the
+    /// replacement's registration failed, AND the compensating restore of the
+    /// prior registration ALSO failed — the runtime is now missing the target.
+    /// Reachable only if the previously-built target no longer rebuilds from its
+    /// still-present staged source (a degraded, unexpected state).
+    ///
+    /// [`Runner::replace_processor_from_source`]: super::super::Runner::replace_processor_from_source
+    #[error(
+        "replace_processor_from_source: the replacement for '{target}' failed AND \
+         restoring the prior registration also failed — the target is no longer \
+         registered. Re-register it with register_processor_from_source."
+    )]
+    ReplacementRegistrationFailedRestoreAlsoFailed {
+        target: streamlib_idents::ModuleIdent,
+    },
 }
 
 impl From<AddModuleError> for Error {

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/from_source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/from_source.rs
@@ -25,7 +25,7 @@
 //! [`Strategy::Path`]: super::Strategy::Path
 //! [`ledger`]: super::ledger
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use streamlib_processor_schema::ProcessorLanguage;
 
@@ -33,9 +33,29 @@ use super::super::Runner;
 use super::super::operations::{ReplaceProcessorFromSource, SubmittedProcessorSource};
 use super::build_orchestrator::BuildPolicy;
 use super::errors::AddModuleError;
+use super::ledger;
 use super::session::kebab_case;
 use super::source::Strategy;
 use crate::core::error::{Error, Result};
+
+/// The per-language staging profile for a live source submit: the manifest
+/// runtime key, the staged source file's relative path (given the module
+/// stem), the subprocess entrypoint (given stem + type name), and the
+/// subprocess dependency-resolution artifacts staged beside the source so the
+/// build orchestrator's venv / Deno provisioning has a project to work from.
+/// A single `match request.language` yields one of these; Rust returns the
+/// unsupported-language refusal instead.
+struct LiveSubmitLanguage {
+    runtime_key: &'static str,
+    source_rel: fn(module_stem: &str) -> String,
+    entrypoint: fn(module_stem: &str, type_name: &str) -> String,
+    /// `(relative_path, contents)` for the dependency-resolution artifacts a
+    /// build of this language needs — a `pyproject.toml` declaring the
+    /// `streamlib` SDK dep (Python), a `deno.json` import map (TypeScript).
+    /// Without these the orchestrator's provision tail has no project to
+    /// resolve the SDK from and hard-fails.
+    dep_artifacts: fn(package_name: &str, version: streamlib_idents::SemVer) -> Vec<(String, String)>,
+}
 
 /// A submitted-source package staged to disk, ready to load through
 /// [`Strategy::Path`].
@@ -65,8 +85,24 @@ impl Runner {
         request: SubmittedProcessorSource,
     ) -> Result<streamlib_idents::ModuleIdent> {
         let staged = stage_submitted_source(&request)?;
-        let module = staged.module.clone();
-        let dir = staged.dir.clone();
+        self.load_staged_session_source(staged).await
+    }
+
+    /// Load an already-staged session source through the transactional
+    /// [`Runner::add_module_with`] / [`Strategy::Path`] seam. The staging half
+    /// of [`Self::register_processor_from_source`], split out as the shared
+    /// seam the transactional [`Self::replace_processor_from_source`] pre-stages
+    /// through. On load failure the staged scratch dir (and its now-empty parent)
+    /// is reclaimed — the module_loader already discarded its registration
+    /// staging, so this only cleans the filesystem.
+    ///
+    /// [`Runner::add_module_with`]: Self::add_module_with
+    /// [`Strategy::Path`]: super::Strategy::Path
+    async fn load_staged_session_source(
+        &self,
+        staged: StagedSessionSource,
+    ) -> Result<streamlib_idents::ModuleIdent> {
+        let StagedSessionSource { module, dir } = staged;
         let added = self.add_module_with(
             module.clone(),
             Strategy::Path {
@@ -77,59 +113,159 @@ impl Runner {
         match added.await {
             Ok(_loaded) => Ok(module),
             Err(load_error) => {
-                // Best-effort staging cleanup: the load failed, so the staged
-                // dir is dead. The module_loader already discarded its
-                // registration staging (zero registry residue); this only
-                // reclaims the scratch directory.
-                if let Err(cleanup) = std::fs::remove_dir_all(&dir) {
-                    tracing::debug!(
-                        dir = %dir.display(),
-                        "failed to remove staged session-source dir after a failed submit: {cleanup}",
-                    );
-                }
+                remove_staged_dir_and_prune_parent(&dir);
                 Err(Error::from(load_error))
             }
         }
     }
 
-    /// Remove a prior `@session/<name>` registration, then re-register the
-    /// replacement source at a monotonically-bumped `0.0.N`. The removal must
-    /// succeed (the target must be a live, in-use-free session registration)
-    /// before the replacement registers, so a replace never leaves two live
-    /// registrations of the same name. Returns the minted registration
-    /// [`ModuleIdent`](streamlib_idents::ModuleIdent) for the new definition.
+    /// Transactionally replace a live `@session/<name>` source registration:
+    /// pre-validate, pre-stage the replacement, remove the target, load the
+    /// replacement — and on any failure of the replacement, restore the target's
+    /// exact prior registration from its on-disk staged source so a failed
+    /// replacement never destroys the working processor. Returns the minted
+    /// registration [`ModuleIdent`](streamlib_idents::ModuleIdent) for the new
+    /// definition.
+    ///
+    /// Removal-before-registration ordering is invariant-forced (the
+    /// coexistence gates reject two live registrations of the same session
+    /// name), so atomicity comes from compensation, not from reordering: the
+    /// old staged dir is the restore artifact and is deleted only AFTER the new
+    /// registration commits.
     #[tracing::instrument(skip(self, request), fields(target = %request.target_session_module))]
     pub async fn replace_processor_from_source(
         &self,
         request: ReplaceProcessorFromSource,
     ) -> Result<streamlib_idents::ModuleIdent> {
-        self.remove_module(request.target_session_module.clone())
-            .map_err(Error::from)?;
-        self.register_processor_from_source(request.replacement).await
+        let target = request.target_session_module.clone();
+
+        // (1) PRE-VALIDATE — no mutation.
+        //
+        // (1a) The replacement must resolve to the target's `@session/<name>`;
+        // a replace re-registers the same name, never renames.
+        let (_replacement_type, replacement_name) =
+            derive_session_type_and_name(&request.replacement)?;
+        if !target.org.is_reserved_for_session() || replacement_name != target.name.as_str() {
+            return Err(AddModuleError::ReplaceTargetNameMismatch {
+                target,
+                replacement_name,
+            }
+            .into());
+        }
+
+        // (1b) Restorability preflight. The target's LOADED (concrete) version
+        // must be source-backed on disk — otherwise there is nothing to restore
+        // from if the replacement fails. A target with no live registration (or
+        // whose loaded version doesn't satisfy the requested range) falls through
+        // to `remove_module`, which surfaces the typed not-loaded error before
+        // any registration runs.
+        let loaded_version =
+            ledger::with_loaded_module_registration_record(&target.package_ref(), |r| r.version)
+                .filter(|v| target.version.matches(*v));
+        let Some(loaded_version) = loaded_version else {
+            self.remove_module(target.clone()).map_err(Error::from)?;
+            return self.register_processor_from_source(request.replacement).await;
+        };
+        let old_dir = session_source_staging_root()
+            .join(target.name.as_str())
+            .join(loaded_version.to_string());
+        if !old_dir.is_dir() {
+            return Err(AddModuleError::ReplaceTargetNotSourceBacked {
+                target,
+                expected_dir: old_dir,
+            }
+            .into());
+        }
+
+        // (2) PRE-STAGE the replacement (filesystem-only) BEFORE removal — a
+        // language / mint / I/O refusal here leaves the target untouched.
+        let staged = match stage_submitted_source(&request.replacement) {
+            Ok(staged) => staged,
+            Err(stage_error) => return Err(Error::from(stage_error)),
+        };
+        let new_dir = staged.dir.clone();
+
+        // (3) Remove the target. A refusal (still required / in use) leaves the
+        // target untouched; drop the pre-staged replacement scratch.
+        if let Err(remove_error) = self.remove_module(target.clone()) {
+            remove_staged_dir_and_prune_parent(&new_dir);
+            return Err(Error::from(remove_error));
+        }
+
+        // (4) Load the pre-staged replacement. `load_staged_session_source`
+        // reclaims the replacement's scratch dir on its own failure.
+        match self.load_staged_session_source(staged).await {
+            Ok(new_module) => {
+                // (6) HOUSEKEEPING: the old staged dir was the restore artifact;
+                // delete it only now that the new registration has committed.
+                remove_staged_dir_and_prune_parent(&old_dir);
+                Ok(new_module)
+            }
+            Err(cause) => {
+                // (5) COMPENSATE: restore the target's EXACT prior ModuleIdent
+                // from its still-present staged source. `Strategy::Path` +
+                // `IfStale` hits the warm orchestrator sidecar slot and bypasses
+                // re-minting, so the old `0.0.M` identity is restored verbatim.
+                let restore = self.add_module_with(
+                    streamlib_idents::ModuleIdent::new(
+                        target.org.clone(),
+                        target.name.clone(),
+                        streamlib_idents::SemVerRange::Exact(loaded_version),
+                    ),
+                    Strategy::Path {
+                        path: old_dir,
+                        build: BuildPolicy::IfStale,
+                    },
+                );
+                match restore.await {
+                    Ok(_restored) => {
+                        Err(AddModuleError::ReplacementRegistrationFailedPriorRegistrationRestored {
+                            target,
+                            cause: cause.to_string(),
+                        }
+                        .into())
+                    }
+                    Err(restore_error) => {
+                        tracing::error!(
+                            target = %target,
+                            replacement_cause = %cause,
+                            restore_error = %restore_error,
+                            "replace_processor_from_source: replacement failed and \
+                             restoring the prior registration also failed",
+                        );
+                        Err(AddModuleError::ReplacementRegistrationFailedRestoreAlsoFailed {
+                            target,
+                        }
+                        .into())
+                    }
+                }
+            }
+        }
     }
 }
 
-/// Stage a submitted source into a `@session/<name>@0.0.N` package directory:
-/// mint the identity, write a generated `streamlib.yaml` plus the source file
-/// in the subprocess runtime's expected layout. Returns the staged dir + minted
-/// module ident, or a typed refusal (unsupported language / missing name /
-/// un-mintable name / I/O).
-fn stage_submitted_source(
-    request: &SubmittedProcessorSource,
-) -> std::result::Result<StagedSessionSource, AddModuleError> {
-    let runtime_key = match request.language {
-        ProcessorLanguage::Python => "python",
-        ProcessorLanguage::TypeScript => "deno",
-        ProcessorLanguage::Rust => {
-            return Err(AddModuleError::SourceLanguageUnsupportedForLiveSubmit {
-                language: "rust".to_string(),
-            });
-        }
-    };
+/// Best-effort reclamation of a staged session-source version dir plus its
+/// now-empty `@session/<name>/` parent. `remove_dir` on the parent removes it
+/// only when empty, so a sibling version dir keeps the parent intact.
+fn remove_staged_dir_and_prune_parent(dir: &Path) {
+    if let Err(cleanup) = std::fs::remove_dir_all(dir) {
+        tracing::debug!(
+            dir = %dir.display(),
+            "failed to remove staged session-source dir: {cleanup}",
+        );
+    }
+    if let Some(parent) = dir.parent() {
+        let _ = std::fs::remove_dir(parent);
+    }
+}
 
-    // Type name (PascalCase) → subprocess entrypoint class + registered short
-    // name. Falls back to a PascalCase projection of the requested package
-    // name; one of the two must be present.
+/// Derive the `(PascalCase type name, kebab `@session/<name>` segment)` a
+/// submission mints under. The type name falls back to a PascalCase projection
+/// of the requested package name; the name segment falls back to a kebab
+/// projection of the type name. One of the two must be present.
+fn derive_session_type_and_name(
+    request: &SubmittedProcessorSource,
+) -> std::result::Result<(String, String), AddModuleError> {
     let type_name = request
         .processor_type_name
         .clone()
@@ -142,6 +278,49 @@ fn stage_submitted_source(
         .clone()
         .unwrap_or_else(|| kebab_case(&type_name));
     let name_segment = kebab_case(&name_segment);
+    Ok((type_name, name_segment))
+}
+
+/// Resolve the per-language staging profile, or the unsupported-language
+/// refusal for Rust (a full cargo build, never a live graph mutation).
+fn live_submit_language(
+    language: &ProcessorLanguage,
+) -> std::result::Result<LiveSubmitLanguage, AddModuleError> {
+    match language {
+        ProcessorLanguage::Python => Ok(LiveSubmitLanguage {
+            runtime_key: "python",
+            source_rel: |stem| format!("python/{stem}.py"),
+            entrypoint: |stem, type_name| format!("{stem}:{type_name}"),
+            dep_artifacts: |name, _version| {
+                vec![("pyproject.toml".to_string(), session_pyproject_toml(name))]
+            },
+        }),
+        ProcessorLanguage::TypeScript => Ok(LiveSubmitLanguage {
+            runtime_key: "deno",
+            source_rel: |stem| format!("deno/{stem}.ts"),
+            entrypoint: |stem, type_name| format!("{stem}.ts:{type_name}"),
+            dep_artifacts: |_name, _version| {
+                vec![("deno.json".to_string(), session_deno_json())]
+            },
+        }),
+        ProcessorLanguage::Rust => Err(AddModuleError::SourceLanguageUnsupportedForLiveSubmit {
+            language: "rust".to_string(),
+        }),
+    }
+}
+
+/// Stage a submitted source into a `@session/<name>@0.0.N` package directory:
+/// mint the identity, write a generated `streamlib.yaml`, the source file in
+/// the subprocess runtime's expected layout, and the language's
+/// dependency-resolution artifacts (`pyproject.toml` / `deno.json`) so the
+/// build orchestrator's venv / Deno provision tail has a project to resolve the
+/// SDK from. Returns the staged dir + minted module ident, or a typed refusal
+/// (unsupported language / missing name / un-mintable name / I/O).
+fn stage_submitted_source(
+    request: &SubmittedProcessorSource,
+) -> std::result::Result<StagedSessionSource, AddModuleError> {
+    let lang = live_submit_language(&request.language)?;
+    let (type_name, name_segment) = derive_session_type_and_name(request)?;
 
     let minted = streamlib_idents::mint_session_module_ident(&name_segment).map_err(|e| {
         AddModuleError::SessionProcessorNameInvalid {
@@ -163,17 +342,8 @@ fn stage_submitted_source(
     std::fs::create_dir_all(&dir)
         .map_err(|e| stage_err(format!("creating staging dir {}: {e}", dir.display())))?;
 
-    let (source_rel, entrypoint) = match request.language {
-        ProcessorLanguage::Python => (
-            format!("python/{module_stem}.py"),
-            format!("{module_stem}:{type_name}"),
-        ),
-        ProcessorLanguage::TypeScript => (
-            format!("deno/{module_stem}.ts"),
-            format!("{module_stem}.ts:{type_name}"),
-        ),
-        ProcessorLanguage::Rust => unreachable!("rust rejected above"),
-    };
+    let source_rel = (lang.source_rel)(&module_stem);
+    let entrypoint = (lang.entrypoint)(&module_stem, &type_name);
 
     let source_path = dir.join(&source_rel);
     if let Some(parent) = source_path.parent() {
@@ -183,11 +353,21 @@ fn stage_submitted_source(
     std::fs::write(&source_path, request.source_text.as_bytes())
         .map_err(|e| stage_err(format!("writing source {}: {e}", source_path.display())))?;
 
+    for (rel, contents) in (lang.dep_artifacts)(minted.package.as_str(), minted.version) {
+        let artifact_path = dir.join(&rel);
+        std::fs::write(&artifact_path, contents.as_bytes()).map_err(|e| {
+            stage_err(format!(
+                "writing dependency artifact {}: {e}",
+                artifact_path.display()
+            ))
+        })?;
+    }
+
     let manifest = generate_session_manifest(
         minted.package.as_str(),
         minted.version,
         &type_name,
-        runtime_key,
+        lang.runtime_key,
         &entrypoint,
     );
     let manifest_path = dir.join(streamlib_idents::Manifest::FILE_NAME);
@@ -198,6 +378,38 @@ fn stage_submitted_source(
         module: minted.module,
         dir,
     })
+}
+
+/// A minimal `pyproject.toml` for a live-submitted Python session package: it
+/// declares the `streamlib` SDK dependency so the orchestrator's venv tail
+/// resolves it (from the linked checkout under an active `streamlib link`, or
+/// from the registry by version otherwise) — without it the venv is empty and
+/// the `import streamlib` probe hard-fails.
+fn session_pyproject_toml(name: &str) -> String {
+    format!(
+        "[project]\n\
+         name = \"{name}\"\n\
+         version = \"0.0.0\"\n\
+         dependencies = [\"streamlib\"]\n\
+         \n\
+         [build-system]\n\
+         requires = [\"hatchling\"]\n\
+         build-backend = \"hatchling.build\"\n"
+    )
+}
+
+/// A minimal `deno.json` import map for a live-submitted TypeScript session
+/// package: maps the `streamlib` specifier the source imports at the SDK so the
+/// Deno subprocess resolves it (redirected at the linked checkout under an
+/// active `streamlib link`).
+fn session_deno_json() -> String {
+    "{\n  \
+       \"imports\": {\n    \
+         \"streamlib\": \"npm:@tatolab/streamlib-deno\",\n    \
+         \"streamlib/\": \"npm:/@tatolab/streamlib-deno/\"\n  \
+       }\n\
+     }\n"
+        .to_string()
 }
 
 /// The root under which live-submitted session sources are staged:
@@ -327,7 +539,53 @@ mod tests {
             "source must be staged at the entrypoint module path"
         );
 
+        // The Python dependency-resolution artifact must be staged beside the
+        // source — without it the orchestrator's venv tail makes an empty venv
+        // and the `import streamlib` probe hard-fails. Mentally-revert the
+        // `dep_artifacts` staging and this pyproject.toml is absent.
+        let pyproject = staged.dir.join("pyproject.toml");
+        assert!(
+            pyproject.is_file(),
+            "a live-submitted Python session package must stage a pyproject.toml"
+        );
+        let pyproject_body = std::fs::read_to_string(&pyproject).unwrap();
+        assert!(
+            pyproject_body.contains("streamlib"),
+            "the staged pyproject must declare the streamlib SDK dep so the venv \
+             tail can resolve it, got: {pyproject_body}"
+        );
+
         // Reclaim the scratch dir this hermetic test wrote.
+        let _ = std::fs::remove_dir_all(&staged.dir);
+    }
+
+    #[test]
+    fn stages_typescript_source_with_a_deno_json_import_map() {
+        // The TypeScript live-submit path must stage the source under `deno/`
+        // plus a `deno.json` import map so the Deno subprocess resolves the
+        // `streamlib` SDK specifier. Mentally-revert the `dep_artifacts`
+        // staging and the deno.json is absent.
+        let request = SubmittedProcessorSource {
+            source_text: "export class Widget {}\n".to_string(),
+            language: ProcessorLanguage::TypeScript,
+            requested_name: Some("ts-widget".to_string()),
+            processor_type_name: Some("Widget".to_string()),
+        };
+        let staged = stage_submitted_source(&request).expect("typescript stages");
+        assert!(
+            staged.dir.join("deno").join("ts_widget.ts").is_file(),
+            "source must be staged at the entrypoint module path"
+        );
+        let deno_json = staged.dir.join("deno.json");
+        assert!(
+            deno_json.is_file(),
+            "a live-submitted TypeScript session package must stage a deno.json"
+        );
+        let deno_body = std::fs::read_to_string(&deno_json).unwrap();
+        assert!(
+            deno_body.contains("streamlib"),
+            "the staged deno.json must map the streamlib specifier, got: {deno_body}"
+        );
         let _ = std::fs::remove_dir_all(&staged.dir);
     }
 
@@ -346,5 +604,428 @@ mod tests {
         );
         let _ = std::fs::remove_dir_all(&first.dir);
         let _ = std::fs::remove_dir_all(&second.dir);
+    }
+
+    // =========================================================================
+    // Public-method orchestration locks. These drive `register_processor_from_
+    // source` / `replace_processor_from_source` end-to-end against a fake
+    // in-process build orchestrator (no Python/GPU/venv): subprocess processors
+    // register their ports straight from the staged manifest, so the whole load
+    // is hermetic. Each uses a distinct `@session/<name>` so the process-global
+    // registry / ledger never collide across tests, and `#[serial]` guards the
+    // process-global STREAMLIB_HOME + registry.
+    // =========================================================================
+
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use serial_test::serial;
+
+    use super::super::build_orchestrator::{
+        BuildError, BuildEvent, BuildEventSink, BuildOrchestrator, BuildRequest, BuildSource,
+        StagedArtifact,
+    };
+    use crate::core::descriptors::{SchemaIdent, TypeName};
+    use crate::core::processors::PROCESSOR_REGISTRY;
+
+    /// An `add_local` fixture: a host-vtable session processor registered from a
+    /// compiled type with NO staged source on disk — the not-source-backed case
+    /// the transactional replace refuses.
+    #[crate::processor("@app/local/FromSourceReplaceTarget", execution = manual)]
+    struct FromSourceReplaceTarget;
+    impl crate::core::ManualProcessor for FromSourceReplaceTarget::Processor {
+        fn setup(
+            &mut self,
+            _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+        ) -> crate::core::error::Result<()> {
+            Ok(())
+        }
+        fn teardown(
+            &mut self,
+            _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+        ) -> crate::core::error::Result<()> {
+            Ok(())
+        }
+        fn start(
+            &mut self,
+            _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+        ) -> crate::core::error::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Resolve the registered structured processor ident for a session module's
+    /// short type name.
+    fn session_ident_for(
+        module: &streamlib_idents::ModuleIdent,
+        type_name: &str,
+    ) -> Option<SchemaIdent> {
+        PROCESSOR_REGISTRY.resolve_installed_processor_type(
+            &module.org,
+            &module.name,
+            &TypeName::new(type_name).expect("valid type name"),
+        )
+    }
+
+    /// Point STREAMLIB_HOME at a fresh tempdir so session-source staging lands
+    /// in an isolated tree, and STREAMLIB_PYTHON_NATIVE_LIB at a dummy existing
+    /// file so the Python host resolves at registration (the constructor only
+    /// stores the path — it is dlopen'd at instantiate, which these
+    /// registration-only tests never reach). Restores prior values on drop;
+    /// serial tests only.
+    struct HomeGuard {
+        _tmp: tempfile::TempDir,
+        prev_home: Option<String>,
+        prev_native: Option<String>,
+    }
+    impl HomeGuard {
+        fn new() -> Self {
+            let tmp = tempfile::tempdir().unwrap();
+            let native = tmp.path().join("libstreamlib_python_native.so");
+            std::fs::write(&native, b"dummy").unwrap();
+            let prev_home = std::env::var("STREAMLIB_HOME").ok();
+            let prev_native = std::env::var("STREAMLIB_PYTHON_NATIVE_LIB").ok();
+            // SAFETY: serial tests — no other thread races the process env.
+            unsafe {
+                std::env::set_var("STREAMLIB_HOME", tmp.path());
+                std::env::set_var("STREAMLIB_PYTHON_NATIVE_LIB", &native);
+            }
+            Self {
+                _tmp: tmp,
+                prev_home,
+                prev_native,
+            }
+        }
+    }
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: see `HomeGuard::new` — serial tests, no env race.
+            unsafe {
+                match &self.prev_home {
+                    Some(v) => std::env::set_var("STREAMLIB_HOME", v),
+                    None => std::env::remove_var("STREAMLIB_HOME"),
+                }
+                match &self.prev_native {
+                    Some(v) => std::env::set_var("STREAMLIB_PYTHON_NATIVE_LIB", v),
+                    None => std::env::remove_var("STREAMLIB_PYTHON_NATIVE_LIB"),
+                }
+            }
+        }
+    }
+
+    /// Block on a `Runner` async op using the runner's own owned tokio runtime.
+    fn drive<T>(runtime: &Runner, fut: impl std::future::Future<Output = T>) -> T {
+        runtime.tokio_runtime_variant.handle().block_on(fut)
+    }
+
+    /// No-op build event sink.
+    struct NoopSink;
+    impl BuildEventSink for NoopSink {
+        fn emit(&self, _event: BuildEvent) {}
+    }
+
+    /// "Materializes" a `PackageDir` by loading it in place — no toolchain. The
+    /// subprocess registration path reads ports from the staged manifest, so
+    /// this is enough to register a session source with real ports.
+    struct LoadAsIsOrchestrator;
+    impl BuildOrchestrator for LoadAsIsOrchestrator {
+        fn materialize(
+            &self,
+            request: &BuildRequest,
+            _sink: &dyn BuildEventSink,
+        ) -> std::result::Result<StagedArtifact, BuildError> {
+            match &request.source {
+                BuildSource::PackageDir(dir) => Ok(StagedArtifact {
+                    staged_dir: dir.clone(),
+                    rebuilt: false,
+                }),
+                other => Err(BuildError::UnsupportedSource(format!("{other:?}"))),
+            }
+        }
+    }
+
+    /// [`LoadAsIsOrchestrator`] that fails the FIRST materialize after it is
+    /// armed, then succeeds — the fault injection for the transactional-replace
+    /// lock: it fails the replacement load but lets the compensating restore of
+    /// the prior registration through.
+    struct FailNextMaterializeOrchestrator {
+        armed: AtomicBool,
+    }
+    impl BuildOrchestrator for FailNextMaterializeOrchestrator {
+        fn materialize(
+            &self,
+            request: &BuildRequest,
+            _sink: &dyn BuildEventSink,
+        ) -> std::result::Result<StagedArtifact, BuildError> {
+            match &request.source {
+                BuildSource::PackageDir(dir) => {
+                    if self.armed.swap(false, Ordering::SeqCst) {
+                        return Err(BuildError::BuildFailed {
+                            tool: "test".to_string(),
+                            package: request.package.to_string(),
+                            detail: "forced replacement materialize failure".to_string(),
+                        });
+                    }
+                    Ok(StagedArtifact {
+                        staged_dir: dir.clone(),
+                        rebuilt: false,
+                    })
+                }
+                other => Err(BuildError::UnsupportedSource(format!("{other:?}"))),
+            }
+        }
+    }
+
+    /// [`LoadAsIsOrchestrator`] that rewrites the staged manifest's empty
+    /// `inputs: []` / `outputs: []` placeholders into real ports before the
+    /// load reads them — the fake stand-in for the (out-of-engine) subprocess
+    /// port-extraction pass, proving the registration path mints CONNECTABLE
+    /// ports from whatever the staged manifest declares.
+    struct PortSplicingOrchestrator;
+    impl BuildOrchestrator for PortSplicingOrchestrator {
+        fn materialize(
+            &self,
+            request: &BuildRequest,
+            _sink: &dyn BuildEventSink,
+        ) -> std::result::Result<StagedArtifact, BuildError> {
+            let BuildSource::PackageDir(dir) = &request.source else {
+                return Err(BuildError::UnsupportedSource(format!("{:?}", request.source)));
+            };
+            let manifest_path = dir.join(streamlib_idents::Manifest::FILE_NAME);
+            let body = std::fs::read_to_string(&manifest_path).map_err(|e| BuildError::Other {
+                package: request.package.to_string(),
+                detail: format!("read staged manifest: {e}"),
+            })?;
+            let spliced = body
+                .replace(
+                    "inputs: []",
+                    "inputs:\n      - name: in0\n        schema: any",
+                )
+                .replace(
+                    "outputs: []",
+                    "outputs:\n      - name: out0\n        schema: any",
+                );
+            std::fs::write(&manifest_path, spliced).map_err(|e| BuildError::Other {
+                package: request.package.to_string(),
+                detail: format!("write spliced manifest: {e}"),
+            })?;
+            Ok(StagedArtifact {
+                staged_dir: dir.clone(),
+                rebuilt: false,
+            })
+        }
+    }
+
+    fn python_named(name: &str) -> SubmittedProcessorSource {
+        SubmittedProcessorSource {
+            source_text: "class Widget:\n    def process(self, ctx):\n        pass\n".to_string(),
+            language: ProcessorLanguage::Python,
+            requested_name: Some(name.to_string()),
+            processor_type_name: Some("Widget".to_string()),
+        }
+    }
+
+    fn session_package_in_ledger(name: &str) -> bool {
+        let pkg = streamlib_idents::PackageRef::new(
+            streamlib_idents::Org::new(streamlib_idents::SESSION_ORG).unwrap(),
+            streamlib_idents::Package::new(name).unwrap(),
+        );
+        ledger::loaded_module_registration_ledger_packages().contains(&pkg)
+    }
+
+    #[test]
+    #[serial]
+    fn register_from_source_without_orchestrator_is_a_typed_error_with_no_residue() {
+        // (7a) A build-requiring load with NO orchestrator wired fails typed,
+        // the staged scratch dir (and its empty parent) is reclaimed, and the
+        // ledger carries zero residue. Mentally-revert the on-failure cleanup in
+        // `load_staged_session_source` and the staged parent survives.
+        let _home = HomeGuard::new();
+        let runtime = Runner::new().unwrap();
+        let name = "fromsrc-no-orch";
+
+        let err = drive(&runtime, runtime.register_processor_from_source(python_named(name)))
+            .expect_err("no orchestrator must fail the build-requiring load");
+        // Wrapped through `Error::from(AddModuleError)`.
+        assert!(
+            err.to_string().contains("BuildOrchestrator")
+                || err.to_string().contains("no BuildOrchestrator"),
+            "expected a no-orchestrator error, got: {err}"
+        );
+        assert!(
+            !session_source_staging_root().join(name).exists(),
+            "the staged @session/<name> dir must be reclaimed after a failed load"
+        );
+        assert!(
+            !session_package_in_ledger(name),
+            "a failed load must leave zero ledger residue"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn replace_of_an_unregistered_target_surfaces_the_remove_error() {
+        // (7b) Replacing a target that was never loaded surfaces the typed
+        // not-loaded removal error before any registration runs.
+        let _home = HomeGuard::new();
+        let runtime = Runner::new().unwrap();
+        runtime.set_build_orchestrator(LoadAsIsOrchestrator);
+
+        let target = streamlib_idents::ModuleIdent::any(
+            streamlib_idents::Org::new(streamlib_idents::SESSION_ORG).unwrap(),
+            streamlib_idents::Package::new("fromsrc-never-loaded").unwrap(),
+        );
+        let request = ReplaceProcessorFromSource {
+            target_session_module: target,
+            replacement: python_named("fromsrc-never-loaded"),
+        };
+        let err = drive(&runtime, runtime.replace_processor_from_source(request))
+            .expect_err("replacing an unloaded target must error");
+        assert!(
+            err.to_string().contains("remove_module"),
+            "expected the remove_module not-loaded error, got: {err}"
+        );
+        assert!(
+            !session_package_in_ledger("fromsrc-never-loaded"),
+            "no registration must have occurred"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn replace_failure_restores_the_exact_prior_registration() {
+        // (7c) TRANSACTIONAL LOCK: a replacement whose load fails must leave the
+        // OLD exact registration intact (restored from disk) and surface the
+        // typed "prior registration restored" error. Mentally-revert the
+        // compensation branch and the old registration is gone.
+        let _home = HomeGuard::new();
+        let runtime = Runner::new().unwrap();
+        runtime.set_build_orchestrator(FailNextMaterializeOrchestrator {
+            armed: AtomicBool::new(false),
+        });
+        let name = "fromsrc-transactional";
+
+        // Register the original (orchestrator not yet armed → succeeds).
+        let original = drive(
+            &runtime,
+            runtime.register_processor_from_source(python_named(name)),
+        )
+        .expect("original registration succeeds");
+        let original_ident = session_ident_for(&original, "Widget").expect("original resolves");
+        assert!(PROCESSOR_REGISTRY.is_registered(&original_ident));
+
+        // Arm the fault so the replacement's load fails; the compensating
+        // restore (a second materialize) then succeeds.
+        runtime.set_build_orchestrator(FailNextMaterializeOrchestrator {
+            armed: AtomicBool::new(true),
+        });
+        let request = ReplaceProcessorFromSource {
+            target_session_module: original.clone(),
+            replacement: python_named(name),
+        };
+        let err = drive(&runtime, runtime.replace_processor_from_source(request))
+            .expect_err("a failing replacement must error");
+        assert!(
+            matches!(
+                err,
+                Error::Configuration(ref m)
+                    if m.contains("prior registration was restored")
+            ),
+            "expected the restored-prior error, got: {err}"
+        );
+
+        // The OLD exact ident is still registered — the working processor
+        // survived the failed replacement.
+        assert!(
+            PROCESSOR_REGISTRY.is_registered(&original_ident),
+            "the prior registration must be restored intact"
+        );
+        assert!(
+            session_package_in_ledger(name),
+            "the target's ledger record must survive the failed replace"
+        );
+
+        // Cleanup.
+        runtime
+            .remove_module(original)
+            .expect("cleanup remove of the restored target");
+    }
+
+    #[test]
+    #[serial]
+    fn register_from_source_mints_connectable_ports_from_the_manifest() {
+        // (7d) PORTS LOCK: when the staged manifest declares ports, the
+        // registered descriptor carries them (connectable). The regression twin
+        // below asserts the placeholder (portless) manifest yields empty ports —
+        // proving the ports come from the manifest the orchestrator produced,
+        // not from anything hardcoded.
+        let _home = HomeGuard::new();
+
+        // With ports spliced into the staged manifest → connectable ports.
+        let runtime = Runner::new().unwrap();
+        runtime.set_build_orchestrator(PortSplicingOrchestrator);
+        let ported = drive(
+            &runtime,
+            runtime.register_processor_from_source(python_named("fromsrc-ported")),
+        )
+        .expect("registration with ports succeeds");
+        let ported_ident = session_ident_for(&ported, "Widget").expect("ported resolves");
+        let (inputs, outputs) = PROCESSOR_REGISTRY
+            .port_info(&ported_ident)
+            .expect("a registered session processor exposes port info");
+        assert_eq!(inputs.len(), 1, "spliced input port must be registered");
+        assert_eq!(outputs.len(), 1, "spliced output port must be registered");
+        runtime.remove_module(ported).expect("cleanup ported");
+
+        // Regression twin: the placeholder manifest (no splice) → portless.
+        let plain_runtime = Runner::new().unwrap();
+        plain_runtime.set_build_orchestrator(LoadAsIsOrchestrator);
+        let plain = drive(
+            &plain_runtime,
+            plain_runtime.register_processor_from_source(python_named("fromsrc-portless")),
+        )
+        .expect("registration without ports succeeds");
+        let plain_ident = session_ident_for(&plain, "Widget").expect("plain resolves");
+        let (plain_in, plain_out) = PROCESSOR_REGISTRY
+            .port_info(&plain_ident)
+            .expect("port info present");
+        assert!(
+            plain_in.is_empty() && plain_out.is_empty(),
+            "the placeholder manifest must yield a portless descriptor — got \
+             {plain_in:?} / {plain_out:?}"
+        );
+        plain_runtime.remove_module(plain).expect("cleanup portless");
+    }
+
+    #[test]
+    #[serial]
+    fn replace_of_an_add_local_target_is_refused_and_leaves_it_intact() {
+        // (7e) An `add_local` host-vtable registration is not source-backed on
+        // disk, so a transactional replace refuses it (ReplaceTargetNotSource-
+        // Backed) and leaves the target intact — the operator must use the
+        // explicit remove + register escape hatch.
+        let _home = HomeGuard::new();
+        let runtime = Runner::new().unwrap();
+        let loaded = runtime
+            .add_local_blocking::<FromSourceReplaceTarget::Processor>(serde_json::Value::Null)
+            .expect("add_local registers a host-vtable session processor");
+
+        let request = ReplaceProcessorFromSource {
+            target_session_module: loaded.ident.clone(),
+            replacement: python_named(loaded.ident.name.as_str()),
+        };
+        let err = drive(&runtime, runtime.replace_processor_from_source(request))
+            .expect_err("replacing a non-source-backed add_local target must be refused");
+        assert!(
+            matches!(
+                err,
+                Error::Configuration(ref m) if m.contains("not source-backed")
+            ),
+            "expected ReplaceTargetNotSourceBacked, got: {err}"
+        );
+        // The add_local target is untouched.
+        let ident = session_ident_for(&loaded.ident, "FromSourceReplaceTarget")
+            .expect("the add_local target must remain registered");
+        assert!(PROCESSOR_REGISTRY.is_registered(&ident));
+        runtime.remove_module(loaded.ident).expect("cleanup remove");
     }
 }

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/from_source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/from_source.rs
@@ -352,7 +352,7 @@ fn stage_submitted_source(
     let lang = live_submit_language(&request.language)?;
     let (type_name, name_segment) = derive_session_type_and_name(request)?;
 
-    let minted = streamlib_idents::mint_session_module_ident(&name_segment).map_err(|e| {
+    let minted = mint_session_module_ident_above_on_disk(&name_segment).map_err(|e| {
         AddModuleError::SessionProcessorNameInvalid {
             type_name: type_name.clone(),
             detail: e.to_string(),
@@ -431,14 +431,16 @@ fn session_pyproject_toml(name: &str) -> String {
 /// A minimal `deno.json` import map for a live-submitted TypeScript session
 /// package: maps the `streamlib` specifier the source imports at the
 /// npm-published SDK so the Deno subprocess resolves it. The `streamlib-deno`
-/// version is pinned to this build's workspace version (`CARGO_PKG_VERSION` —
-/// the version the static-registry emit publishes every SDK at) so a session
-/// package can never resolve a version-skewed SDK across the msgpack / handshake
-/// ABI. This is a static, pinned npm import map with no `streamlib link`
-/// redirect: unlike Python's editable venv install, a Deno session package
-/// always resolves the published SDK by version.
+/// version is pinned to the Deno SDK's OWN published version
+/// (`STREAMLIB_DENO_SDK_VERSION`, read from `sdk/streamlib-deno/deno.json` at
+/// build time) — NOT the Rust workspace version — because the Deno SDK is on an
+/// independent version line, so a session package resolves the actually-published
+/// SDK and never a version-skewed one across the msgpack / handshake ABI. This
+/// is a static, pinned npm import map with no `streamlib link` redirect: unlike
+/// Python's editable venv install, a Deno session package always resolves the
+/// published SDK by version.
 fn session_deno_json() -> String {
-    let version = env!("CARGO_PKG_VERSION");
+    let version = env!("STREAMLIB_DENO_SDK_VERSION");
     format!(
         "{{\n  \
            \"imports\": {{\n    \
@@ -455,34 +457,63 @@ fn session_source_staging_root() -> PathBuf {
     crate::core::streamlib_home::get_streamlib_data_dir().join("session-source")
 }
 
-/// Reclaim the whole session-source staging tree exactly once per process, at
-/// runtime start. The `@session/<name>@0.0.N` version counter
+/// Mint a `@session/<name>@0.0.N` identity whose version sits strictly ABOVE the
+/// highest version already staged on disk under
+/// `<session-source>/<name>/`. The session version counter
 /// ([`streamlib_idents::next_session_module_version`]) is process-global and
-/// restarts at `0` each process, so without this a fresh process would re-mint
-/// `0.0.0` onto a `session-source/<name>/0.0.0/` dir surviving from a prior run
-/// and reuse its stale staged source / venv. Clearing the tree on start makes
-/// every mint in the new process land in a clean staging root; the reclaim is
-/// gated to the FIRST runtime of the process (matching the counter's lifetime),
-/// so a second in-process runtime never clobbers a live registration's on-disk
-/// staged source (the replace/restore transaction's restore artifact).
-pub(crate) fn reclaim_session_source_staging_root_once() {
-    static RECLAIMED: std::sync::Once = std::sync::Once::new();
-    RECLAIMED.call_once(|| reclaim_session_source_staging_tree(&session_source_staging_root()));
+/// restarts at `0` each process, so a fresh process would otherwise re-mint a low
+/// `0.0.N` onto a `session-source/<name>/0.0.N/` dir surviving from a prior run
+/// and reuse its stale staged source / venv. Reconciling against the on-disk
+/// maximum at mint time keeps every mint cross-run collision-free WITHOUT a
+/// destructive start-up wipe of the shared per-user staging tree — a wipe would
+/// clobber a concurrent runtime process's in-flight replace/restore artifacts.
+///
+/// The disk reconcile lives here (the module_loader owns
+/// [`session_source_staging_root`]), never in the `streamlib-idents` leaf crate:
+/// the pure ident grammar stays unaware of the filesystem. The counter still
+/// provides in-process uniqueness; on-disk reconciliation adds cross-process
+/// uniqueness. Sequential staging (mint → `create_dir_all` → write, all within
+/// [`stage_submitted_source`]) means each mint sees the prior mint's version dir
+/// on disk, so same-process re-mints of one name stay monotonic.
+fn mint_session_module_ident_above_on_disk(
+    name_segment: &str,
+) -> std::result::Result<streamlib_idents::MintedSessionIdent, streamlib_idents::IdentError> {
+    let minted = streamlib_idents::mint_session_module_ident(name_segment)?;
+    match highest_on_disk_session_version(name_segment) {
+        Some(on_disk_ceiling) if minted.version <= on_disk_ceiling => {
+            let version = streamlib_idents::SemVer::new(0, 0, on_disk_ceiling.patch + 1);
+            let module = streamlib_idents::ModuleIdent::new(
+                minted.module.org,
+                minted.package.clone(),
+                streamlib_idents::SemVerRange::Exact(version),
+            );
+            Ok(streamlib_idents::MintedSessionIdent {
+                module,
+                version,
+                package: minted.package,
+            })
+        }
+        _ => Ok(minted),
+    }
 }
 
-/// Best-effort removal of the session-source staging tree at `root`. A missing
-/// tree is the common (clean) case and is not an error; any other failure is
-/// logged and swallowed so a stale-permission staging dir never blocks runtime
-/// start. Pure over `root` so the reclaim is unit-testable without the data dir.
-fn reclaim_session_source_staging_tree(root: &Path) {
-    match std::fs::remove_dir_all(root) {
-        Ok(()) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => tracing::debug!(
-            root = %root.display(),
-            "failed to reclaim session-source staging tree at runtime start: {e}",
-        ),
-    }
+/// The highest `0.0.N` version already staged on disk under
+/// `<session-source>/<name>/`, or `None` when the name has no staged version
+/// dirs. A non-directory entry or a name that doesn't parse as a [`SemVer`] is
+/// skipped. Pure over the on-disk tree so [`mint_session_module_ident_above_on_disk`]
+/// places a fresh mint above any surviving staged dir.
+fn highest_on_disk_session_version(name_segment: &str) -> Option<streamlib_idents::SemVer> {
+    std::fs::read_dir(session_source_staging_root().join(name_segment))
+        .ok()?
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .filter_map(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .and_then(|name| name.parse::<streamlib_idents::SemVer>().ok())
+        })
+        .max()
 }
 
 /// Generate the `streamlib.yaml` for a single-processor `@session/<name>`
@@ -633,12 +664,36 @@ mod tests {
         );
         let deno_body = std::fs::read_to_string(&deno_json).unwrap();
         assert!(
-            deno_body
-                .contains(&format!("npm:@tatolab/streamlib-deno@{}", env!("CARGO_PKG_VERSION"))),
-            "the staged deno.json must pin the streamlib-deno SDK to this build's version so a \
-             session package can't resolve a version-skewed SDK, got: {deno_body}"
+            deno_body.contains(&format!(
+                "npm:@tatolab/streamlib-deno@{}",
+                env!("STREAMLIB_DENO_SDK_VERSION")
+            )),
+            "the staged deno.json must pin the streamlib-deno SDK to the Deno SDK's own \
+             published version so a session package can't resolve a version-skewed SDK, \
+             got: {deno_body}"
         );
         let _ = std::fs::remove_dir_all(&staged.dir);
+    }
+
+    #[test]
+    fn deno_session_pin_matches_the_deno_sdk_manifest_version() {
+        // The baked `STREAMLIB_DENO_SDK_VERSION` must equal the `version` field
+        // of `sdk/streamlib-deno/deno.json` (the authoritative Deno SDK version,
+        // on an independent line from the Rust workspace `CARGO_PKG_VERSION`).
+        // This catches a future skew — e.g. reverting the build-script read back
+        // to `CARGO_PKG_VERSION` — via `cargo test`, so an off-link Deno
+        // register-from-source can never pin an unpublished version.
+        let deno_json = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../sdk/streamlib-deno/deno.json");
+        let body = std::fs::read_to_string(&deno_json)
+            .unwrap_or_else(|e| panic!("reading {}: {e}", deno_json.display()));
+        let manifest: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let manifest_version = manifest["version"].as_str().expect("deno.json has a version");
+        assert_eq!(
+            env!("STREAMLIB_DENO_SDK_VERSION"),
+            manifest_version,
+            "the baked Deno SDK pin must track sdk/streamlib-deno/deno.json"
+        );
     }
 
     #[test]
@@ -1184,28 +1239,44 @@ mod tests {
     }
 
     #[test]
-    fn reclaim_clears_a_stale_on_disk_session_version_dir() {
-        // Restart-collision lock: the `@session/<name>@0.0.N` counter restarts
-        // at 0 each process, so a stale `session-source/<name>/0.0.0/` dir from a
-        // prior run must be reclaimed on runtime start — otherwise a fresh
-        // process re-mints `0.0.0` onto it and reuses its stale source/venv.
-        // Mentally-revert the reclaim and the planted stale dir survives, so a
-        // first-mint-after-restart would collide with it.
-        let root_holder = tempfile::tempdir().unwrap();
-        let root = root_holder.path().join("session-source");
-        let stale_version_dir = root.join("widget").join("0.0.0");
-        std::fs::create_dir_all(&stale_version_dir).unwrap();
-        std::fs::write(stale_version_dir.join("widget.py"), "stale\n").unwrap();
+    #[serial]
+    fn mint_reconciles_above_a_surviving_on_disk_session_version() {
+        // Restart-collision lock WITHOUT a destructive wipe: the
+        // `@session/<name>@0.0.N` counter restarts at 0 each process, so a fresh
+        // process must mint ABOVE any `session-source/<name>/0.0.N/` dir
+        // surviving from a prior run — rather than wiping the shared per-user
+        // tree (which would clobber a concurrent process's in-flight
+        // replace/restore artifacts). A high stale version is planted; a fresh
+        // stage must land above it AND leave the stale dir intact. Mentally-revert
+        // the reconcile and the mint lands at the low counter value (below the
+        // planted version), failing the ordering assertion.
+        let _home = HomeGuard::new();
+        let name = "fromsrc-reconcile";
+        let stale_version = streamlib_idents::SemVer::new(0, 0, 424_242);
+        let stale_dir = session_source_staging_root()
+            .join(name)
+            .join(stale_version.to_string());
+        std::fs::create_dir_all(&stale_dir).unwrap();
+        std::fs::write(stale_dir.join("fromsrc_reconcile.py"), "stale\n").unwrap();
 
-        reclaim_session_source_staging_tree(&root);
-
+        let staged =
+            stage_submitted_source(&python_named(name)).expect("stages above the stale version");
+        let minted_version = match &staged.module.version {
+            streamlib_idents::SemVerRange::Exact(v) => *v,
+            other => panic!("a minted session module carries an exact version, got {other:?}"),
+        };
         assert!(
-            !root.exists(),
-            "the reclaim must clear the whole session-source staging tree so no stale \
-             version dir survives a restart"
+            minted_version > stale_version,
+            "a fresh mint must sit above the surviving on-disk version: \
+             {minted_version} !> {stale_version}"
         );
 
-        // A second reclaim over the now-absent tree is a no-op, not an error.
-        reclaim_session_source_staging_tree(&root);
+        // The concurrent-process staged dir must NOT be wiped.
+        assert!(
+            stale_dir.is_dir(),
+            "the mint-reconcile must not destroy a surviving staged dir"
+        );
+
+        let _ = std::fs::remove_dir_all(session_source_staging_root().join(name));
     }
 }

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/from_source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/from_source.rs
@@ -429,23 +429,60 @@ fn session_pyproject_toml(name: &str) -> String {
 }
 
 /// A minimal `deno.json` import map for a live-submitted TypeScript session
-/// package: maps the `streamlib` specifier the source imports at the SDK so the
-/// Deno subprocess resolves it (redirected at the linked checkout under an
-/// active `streamlib link`).
+/// package: maps the `streamlib` specifier the source imports at the
+/// npm-published SDK so the Deno subprocess resolves it. The `streamlib-deno`
+/// version is pinned to this build's workspace version (`CARGO_PKG_VERSION` —
+/// the version the static-registry emit publishes every SDK at) so a session
+/// package can never resolve a version-skewed SDK across the msgpack / handshake
+/// ABI. This is a static, pinned npm import map with no `streamlib link`
+/// redirect: unlike Python's editable venv install, a Deno session package
+/// always resolves the published SDK by version.
 fn session_deno_json() -> String {
-    "{\n  \
-       \"imports\": {\n    \
-         \"streamlib\": \"npm:@tatolab/streamlib-deno\",\n    \
-         \"streamlib/\": \"npm:/@tatolab/streamlib-deno/\"\n  \
-       }\n\
-     }\n"
-        .to_string()
+    let version = env!("CARGO_PKG_VERSION");
+    format!(
+        "{{\n  \
+           \"imports\": {{\n    \
+             \"streamlib\": \"npm:@tatolab/streamlib-deno@{version}\",\n    \
+             \"streamlib/\": \"npm:/@tatolab/streamlib-deno@{version}/\"\n  \
+           }}\n\
+         }}\n"
+    )
 }
 
 /// The root under which live-submitted session sources are staged:
 /// `<STREAMLIB_DATA_DIR>/session-source/`.
 fn session_source_staging_root() -> PathBuf {
     crate::core::streamlib_home::get_streamlib_data_dir().join("session-source")
+}
+
+/// Reclaim the whole session-source staging tree exactly once per process, at
+/// runtime start. The `@session/<name>@0.0.N` version counter
+/// ([`streamlib_idents::next_session_module_version`]) is process-global and
+/// restarts at `0` each process, so without this a fresh process would re-mint
+/// `0.0.0` onto a `session-source/<name>/0.0.0/` dir surviving from a prior run
+/// and reuse its stale staged source / venv. Clearing the tree on start makes
+/// every mint in the new process land in a clean staging root; the reclaim is
+/// gated to the FIRST runtime of the process (matching the counter's lifetime),
+/// so a second in-process runtime never clobbers a live registration's on-disk
+/// staged source (the replace/restore transaction's restore artifact).
+pub(crate) fn reclaim_session_source_staging_root_once() {
+    static RECLAIMED: std::sync::Once = std::sync::Once::new();
+    RECLAIMED.call_once(|| reclaim_session_source_staging_tree(&session_source_staging_root()));
+}
+
+/// Best-effort removal of the session-source staging tree at `root`. A missing
+/// tree is the common (clean) case and is not an error; any other failure is
+/// logged and swallowed so a stale-permission staging dir never blocks runtime
+/// start. Pure over `root` so the reclaim is unit-testable without the data dir.
+fn reclaim_session_source_staging_tree(root: &Path) {
+    match std::fs::remove_dir_all(root) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => tracing::debug!(
+            root = %root.display(),
+            "failed to reclaim session-source staging tree at runtime start: {e}",
+        ),
+    }
 }
 
 /// Generate the `streamlib.yaml` for a single-processor `@session/<name>`
@@ -596,8 +633,10 @@ mod tests {
         );
         let deno_body = std::fs::read_to_string(&deno_json).unwrap();
         assert!(
-            deno_body.contains("streamlib"),
-            "the staged deno.json must map the streamlib specifier, got: {deno_body}"
+            deno_body
+                .contains(&format!("npm:@tatolab/streamlib-deno@{}", env!("CARGO_PKG_VERSION"))),
+            "the staged deno.json must pin the streamlib-deno SDK to this build's version so a \
+             session package can't resolve a version-skewed SDK, got: {deno_body}"
         );
         let _ = std::fs::remove_dir_all(&staged.dir);
     }
@@ -1142,5 +1181,31 @@ mod tests {
         runtime
             .remove_module(replaced.module)
             .expect("cleanup remove of the replacement");
+    }
+
+    #[test]
+    fn reclaim_clears_a_stale_on_disk_session_version_dir() {
+        // Restart-collision lock: the `@session/<name>@0.0.N` counter restarts
+        // at 0 each process, so a stale `session-source/<name>/0.0.0/` dir from a
+        // prior run must be reclaimed on runtime start — otherwise a fresh
+        // process re-mints `0.0.0` onto it and reuses its stale source/venv.
+        // Mentally-revert the reclaim and the planted stale dir survives, so a
+        // first-mint-after-restart would collide with it.
+        let root_holder = tempfile::tempdir().unwrap();
+        let root = root_holder.path().join("session-source");
+        let stale_version_dir = root.join("widget").join("0.0.0");
+        std::fs::create_dir_all(&stale_version_dir).unwrap();
+        std::fs::write(stale_version_dir.join("widget.py"), "stale\n").unwrap();
+
+        reclaim_session_source_staging_tree(&root);
+
+        assert!(
+            !root.exists(),
+            "the reclaim must clear the whole session-source staging tree so no stale \
+             version dir survives a restart"
+        );
+
+        // A second reclaim over the now-absent tree is a no-op, not an error.
+        reclaim_session_source_staging_tree(&root);
     }
 }

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/from_source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/from_source.rs
@@ -294,7 +294,12 @@ fn derive_session_type_and_name(
     let type_name = request
         .processor_type_name
         .clone()
-        .or_else(|| request.requested_name.as_deref().map(pascal_case))
+        .or_else(|| {
+            request
+                .requested_name
+                .as_deref()
+                .map(streamlib_processor_schema::to_pascal_case)
+        })
         .filter(|t| !t.is_empty())
         .ok_or(AddModuleError::SubmittedSourceMissingName)?;
 
@@ -469,28 +474,6 @@ fn generate_session_manifest(
     )
 }
 
-/// Project a package-name segment (`my-processor`) or a loose identifier into a
-/// PascalCase type name (`MyProcessor`) — the inverse of
-/// [`kebab_case`](super::session::kebab_case). Interior `-` / `_` boundaries
-/// start a new capitalized run.
-fn pascal_case(name: &str) -> String {
-    let mut out = String::with_capacity(name.len());
-    let mut capitalize_next = true;
-    for ch in name.chars() {
-        if ch == '-' || ch == '_' || ch == ' ' {
-            capitalize_next = true;
-            continue;
-        }
-        if capitalize_next {
-            out.extend(ch.to_uppercase());
-            capitalize_next = false;
-        } else {
-            out.push(ch);
-        }
-    }
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -505,10 +488,15 @@ mod tests {
     }
 
     #[test]
-    fn pascal_case_projects_kebab_and_snake() {
-        assert_eq!(pascal_case("my-processor"), "MyProcessor");
-        assert_eq!(pascal_case("already_snake"), "AlreadySnake");
-        assert_eq!(pascal_case("camera"), "Camera");
+    fn requested_name_projects_to_a_pascal_type_via_shared_helper() {
+        // The requested-name → PascalCase type projection this module falls back
+        // to when no explicit `processor_type_name` is given. It reuses the
+        // shared `to_pascal_case`; these are the minted-`@session/<name>` inputs
+        // it must handle.
+        use streamlib_processor_schema::to_pascal_case;
+        assert_eq!(to_pascal_case("my-processor"), "MyProcessor");
+        assert_eq!(to_pascal_case("already_snake"), "AlreadySnake");
+        assert_eq!(to_pascal_case("camera"), "Camera");
     }
 
     #[test]
@@ -1075,5 +1063,84 @@ mod tests {
             .expect("the add_local target must remain registered");
         assert!(PROCESSOR_REGISTRY.is_registered(&ident));
         runtime.remove_module(loaded.ident).expect("cleanup remove");
+    }
+
+    #[test]
+    #[serial]
+    fn replace_bumps_the_version_and_swaps_the_registration() {
+        // (7f) HAPPY-PATH replace: a source-backed `@session/<name>`
+        // registration replaced by the same name mints a HIGHER version,
+        // unregisters the OLD ident, registers the NEW one, and (step-6
+        // housekeeping) removes the old staged dir now that the replacement
+        // committed. Mentally-revert the version mint, the removal, or the
+        // step-6 cleanup and one of these assertions fails.
+        let _home = HomeGuard::new();
+        let runtime = Runner::new().unwrap();
+        runtime.set_build_orchestrator(LoadAsIsOrchestrator);
+        let name = "fromsrc-happy-replace";
+
+        let original = drive(
+            &runtime,
+            runtime.register_processor_from_source(python_named(name)),
+        )
+        .expect("original registration succeeds");
+        let original_ident =
+            session_ident_for(&original.module, "Widget").expect("original resolves");
+        assert!(PROCESSOR_REGISTRY.is_registered(&original_ident));
+
+        // Register left the source staged on disk — the restore artifact a
+        // replace compensates from, and the dir step-6 housekeeping reclaims.
+        let original_version = match &original.module.version {
+            streamlib_idents::SemVerRange::Exact(v) => *v,
+            other => panic!("a minted session module carries an exact version, got {other:?}"),
+        };
+        let old_staged_dir = session_source_staging_root()
+            .join(name)
+            .join(original_version.to_string());
+        assert!(
+            old_staged_dir.is_dir(),
+            "a successful register must leave the source staged on disk"
+        );
+
+        let request = ReplaceProcessorFromSource {
+            target_session_module: original.module.clone(),
+            replacement: python_named(name),
+        };
+        let replaced = drive(&runtime, runtime.replace_processor_from_source(request))
+            .expect("the happy-path replace succeeds");
+
+        // The replacement minted a HIGHER version under the SAME name.
+        let replaced_version = match &replaced.module.version {
+            streamlib_idents::SemVerRange::Exact(v) => *v,
+            other => panic!("a minted session module carries an exact version, got {other:?}"),
+        };
+        assert_eq!(replaced.module.name, original.module.name);
+        assert!(
+            replaced_version > original_version,
+            "replace must bump the version: {replaced_version} !> {original_version}"
+        );
+
+        // The OLD ident is gone; the NEW one is registered.
+        assert!(
+            !PROCESSOR_REGISTRY.is_registered(&original_ident),
+            "the replaced (old) ident must be unregistered"
+        );
+        let replaced_ident =
+            session_ident_for(&replaced.module, "Widget").expect("the replacement resolves");
+        assert!(
+            PROCESSOR_REGISTRY.is_registered(&replaced_ident),
+            "the replacement ident must be registered"
+        );
+
+        // Step-6 housekeeping removed the old staged dir (the restore artifact),
+        // now that the new registration has committed.
+        assert!(
+            !old_staged_dir.exists(),
+            "step-6 housekeeping must remove the old staged dir after the replacement commits"
+        );
+
+        runtime
+            .remove_module(replaced.module)
+            .expect("cleanup remove of the replacement");
     }
 }

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/from_source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/from_source.rs
@@ -1,0 +1,350 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! [`Runner::register_processor_from_source`] — register a processor
+//! definition submitted as source text into a live runtime.
+//!
+//! Live source submit is the disk-backed sibling of [`super::session`]'s
+//! `add_local` (which registers an already-compiled host type). The submitted
+//! source is staged into a `@session/<name>@0.0.N` package directory, then
+//! driven through the SAME transactional [`Runner::add_module_with`] /
+//! [`Strategy::Path`] staging → build → commit → [`ledger`] seam a disk-backed
+//! module load uses — so the build orchestrator provisions the subprocess
+//! runtime (Python venv / Deno `_generated_/`), derives the manifest from the
+//! staged source, and a failed submit drops the staging with zero registry
+//! residue. [`Runner::remove_module`] unregisters it symmetrically.
+//!
+//! Live submit covers the subprocess languages (Python / TypeScript): they run
+//! from source with no host compile. Rust-from-source at runtime is a full
+//! cargo build — the `streamlib pkg build` flow, not a live graph mutation —
+//! and is refused here with a typed error.
+//!
+//! [`Runner::register_processor_from_source`]: super::super::Runner::register_processor_from_source
+//! [`Runner::add_module_with`]: super::super::Runner::add_module_with
+//! [`Runner::remove_module`]: super::super::Runner::remove_module
+//! [`Strategy::Path`]: super::Strategy::Path
+//! [`ledger`]: super::ledger
+
+use std::path::PathBuf;
+
+use streamlib_processor_schema::ProcessorLanguage;
+
+use super::super::Runner;
+use super::super::operations::{ReplaceProcessorFromSource, SubmittedProcessorSource};
+use super::build_orchestrator::BuildPolicy;
+use super::errors::AddModuleError;
+use super::session::kebab_case;
+use super::source::Strategy;
+use crate::core::error::{Error, Result};
+
+/// A submitted-source package staged to disk, ready to load through
+/// [`Strategy::Path`].
+#[derive(Debug)]
+struct StagedSessionSource {
+    module: streamlib_idents::ModuleIdent,
+    dir: PathBuf,
+}
+
+impl Runner {
+    /// Register a processor definition submitted as source text into the live
+    /// runtime, minting it a `@session/<name>@0.0.N` identity. The source is
+    /// staged to disk and loaded through the transactional
+    /// [`Runner::add_module_with`] / [`Strategy::Path`] seam; a failed submit
+    /// leaves zero registry residue. Returns the minted registration
+    /// [`ModuleIdent`](streamlib_idents::ModuleIdent) — a registration ident,
+    /// NOT an `add_processor` instance id.
+    ///
+    /// [`Runner::add_module_with`]: Self::add_module_with
+    /// [`Strategy::Path`]: super::Strategy::Path
+    #[tracing::instrument(
+        skip(self, request),
+        fields(language = ?request.language, name = ?request.requested_name),
+    )]
+    pub async fn register_processor_from_source(
+        &self,
+        request: SubmittedProcessorSource,
+    ) -> Result<streamlib_idents::ModuleIdent> {
+        let staged = stage_submitted_source(&request)?;
+        let module = staged.module.clone();
+        let dir = staged.dir.clone();
+        let added = self.add_module_with(
+            module.clone(),
+            Strategy::Path {
+                path: dir.clone(),
+                build: BuildPolicy::IfStale,
+            },
+        );
+        match added.await {
+            Ok(_loaded) => Ok(module),
+            Err(load_error) => {
+                // Best-effort staging cleanup: the load failed, so the staged
+                // dir is dead. The module_loader already discarded its
+                // registration staging (zero registry residue); this only
+                // reclaims the scratch directory.
+                if let Err(cleanup) = std::fs::remove_dir_all(&dir) {
+                    tracing::debug!(
+                        dir = %dir.display(),
+                        "failed to remove staged session-source dir after a failed submit: {cleanup}",
+                    );
+                }
+                Err(Error::from(load_error))
+            }
+        }
+    }
+
+    /// Remove a prior `@session/<name>` registration, then re-register the
+    /// replacement source at a monotonically-bumped `0.0.N`. The removal must
+    /// succeed (the target must be a live, in-use-free session registration)
+    /// before the replacement registers, so a replace never leaves two live
+    /// registrations of the same name. Returns the minted registration
+    /// [`ModuleIdent`](streamlib_idents::ModuleIdent) for the new definition.
+    #[tracing::instrument(skip(self, request), fields(target = %request.target_session_module))]
+    pub async fn replace_processor_from_source(
+        &self,
+        request: ReplaceProcessorFromSource,
+    ) -> Result<streamlib_idents::ModuleIdent> {
+        self.remove_module(request.target_session_module.clone())
+            .map_err(Error::from)?;
+        self.register_processor_from_source(request.replacement).await
+    }
+}
+
+/// Stage a submitted source into a `@session/<name>@0.0.N` package directory:
+/// mint the identity, write a generated `streamlib.yaml` plus the source file
+/// in the subprocess runtime's expected layout. Returns the staged dir + minted
+/// module ident, or a typed refusal (unsupported language / missing name /
+/// un-mintable name / I/O).
+fn stage_submitted_source(
+    request: &SubmittedProcessorSource,
+) -> std::result::Result<StagedSessionSource, AddModuleError> {
+    let runtime_key = match request.language {
+        ProcessorLanguage::Python => "python",
+        ProcessorLanguage::TypeScript => "deno",
+        ProcessorLanguage::Rust => {
+            return Err(AddModuleError::SourceLanguageUnsupportedForLiveSubmit {
+                language: "rust".to_string(),
+            });
+        }
+    };
+
+    // Type name (PascalCase) → subprocess entrypoint class + registered short
+    // name. Falls back to a PascalCase projection of the requested package
+    // name; one of the two must be present.
+    let type_name = request
+        .processor_type_name
+        .clone()
+        .or_else(|| request.requested_name.as_deref().map(pascal_case))
+        .filter(|t| !t.is_empty())
+        .ok_or(AddModuleError::SubmittedSourceMissingName)?;
+
+    let name_segment = request
+        .requested_name
+        .clone()
+        .unwrap_or_else(|| kebab_case(&type_name));
+    let name_segment = kebab_case(&name_segment);
+
+    let minted = streamlib_idents::mint_session_module_ident(&name_segment).map_err(|e| {
+        AddModuleError::SessionProcessorNameInvalid {
+            type_name: type_name.clone(),
+            detail: e.to_string(),
+        }
+    })?;
+
+    let module_stem = name_segment.replace('-', "_");
+    let dir = session_source_staging_root()
+        .join(minted.package.as_str())
+        .join(minted.version.to_string());
+
+    let stage_err = |detail: String| AddModuleError::SubmittedSourceStagingFailed {
+        module: minted.module.clone(),
+        detail,
+    };
+
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| stage_err(format!("creating staging dir {}: {e}", dir.display())))?;
+
+    let (source_rel, entrypoint) = match request.language {
+        ProcessorLanguage::Python => (
+            format!("python/{module_stem}.py"),
+            format!("{module_stem}:{type_name}"),
+        ),
+        ProcessorLanguage::TypeScript => (
+            format!("deno/{module_stem}.ts"),
+            format!("{module_stem}.ts:{type_name}"),
+        ),
+        ProcessorLanguage::Rust => unreachable!("rust rejected above"),
+    };
+
+    let source_path = dir.join(&source_rel);
+    if let Some(parent) = source_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| stage_err(format!("creating source dir {}: {e}", parent.display())))?;
+    }
+    std::fs::write(&source_path, request.source_text.as_bytes())
+        .map_err(|e| stage_err(format!("writing source {}: {e}", source_path.display())))?;
+
+    let manifest = generate_session_manifest(
+        minted.package.as_str(),
+        minted.version,
+        &type_name,
+        runtime_key,
+        &entrypoint,
+    );
+    let manifest_path = dir.join(streamlib_idents::Manifest::FILE_NAME);
+    std::fs::write(&manifest_path, manifest.as_bytes())
+        .map_err(|e| stage_err(format!("writing manifest {}: {e}", manifest_path.display())))?;
+
+    Ok(StagedSessionSource {
+        module: minted.module,
+        dir,
+    })
+}
+
+/// The root under which live-submitted session sources are staged:
+/// `<STREAMLIB_DATA_DIR>/session-source/`.
+fn session_source_staging_root() -> PathBuf {
+    crate::core::streamlib_home::get_streamlib_data_dir().join("session-source")
+}
+
+/// Generate the `streamlib.yaml` for a single-processor `@session/<name>`
+/// package staged from live-submitted source.
+fn generate_session_manifest(
+    name: &str,
+    version: streamlib_idents::SemVer,
+    type_name: &str,
+    runtime_key: &str,
+    entrypoint: &str,
+) -> String {
+    format!(
+        "package:\n  \
+           org: {org}\n  \
+           name: {name}\n  \
+           version: \"{version}\"\n\
+         processors:\n  \
+           - name: {type_name}\n    \
+             description: live-submitted session processor\n    \
+             runtime: {runtime_key}\n    \
+             execution: manual\n    \
+             entrypoint: \"{entrypoint}\"\n    \
+             inputs: []\n    \
+             outputs: []\n",
+        org = streamlib_idents::SESSION_ORG,
+    )
+}
+
+/// Project a package-name segment (`my-processor`) or a loose identifier into a
+/// PascalCase type name (`MyProcessor`) — the inverse of
+/// [`kebab_case`](super::session::kebab_case). Interior `-` / `_` boundaries
+/// start a new capitalized run.
+fn pascal_case(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut capitalize_next = true;
+    for ch in name.chars() {
+        if ch == '-' || ch == '_' || ch == ' ' {
+            capitalize_next = true;
+            continue;
+        }
+        if capitalize_next {
+            out.extend(ch.to_uppercase());
+            capitalize_next = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn python_request(name: Option<&str>) -> SubmittedProcessorSource {
+        SubmittedProcessorSource {
+            source_text: "class Widget:\n    def process(self, ctx):\n        pass\n".to_string(),
+            language: ProcessorLanguage::Python,
+            requested_name: name.map(str::to_string),
+            processor_type_name: Some("Widget".to_string()),
+        }
+    }
+
+    #[test]
+    fn pascal_case_projects_kebab_and_snake() {
+        assert_eq!(pascal_case("my-processor"), "MyProcessor");
+        assert_eq!(pascal_case("already_snake"), "AlreadySnake");
+        assert_eq!(pascal_case("camera"), "Camera");
+    }
+
+    #[test]
+    fn rust_source_is_refused_for_live_submit() {
+        // Rust-from-source is a full cargo build (the `streamlib pkg build`
+        // flow), never a live graph mutation. Revert the Rust arm and this
+        // would attempt to stage a cargo project the live path can't build.
+        let request = SubmittedProcessorSource {
+            source_text: "struct S;".to_string(),
+            language: ProcessorLanguage::Rust,
+            requested_name: Some("widget".to_string()),
+            processor_type_name: Some("Widget".to_string()),
+        };
+        let err = stage_submitted_source(&request).expect_err("rust must be refused");
+        assert!(matches!(
+            err,
+            AddModuleError::SourceLanguageUnsupportedForLiveSubmit { .. }
+        ));
+    }
+
+    #[test]
+    fn missing_name_is_refused_before_staging() {
+        // Neither a package name nor a type name: nothing to mint an identity
+        // from. Refused before any filesystem side effect.
+        let request = SubmittedProcessorSource {
+            source_text: "class Widget: pass".to_string(),
+            language: ProcessorLanguage::Python,
+            requested_name: None,
+            processor_type_name: None,
+        };
+        let err = stage_submitted_source(&request).expect_err("missing name must be refused");
+        assert!(matches!(err, AddModuleError::SubmittedSourceMissingName));
+    }
+
+    #[test]
+    fn stages_python_source_into_a_loadable_session_package() {
+        // The staged dir must carry a parseable `streamlib.yaml` declaring the
+        // `@session/<name>` package plus the source file at the entrypoint's
+        // module path — the exact on-disk shape `Strategy::Path` loads.
+        let request = python_request(Some("widget"));
+        let staged = stage_submitted_source(&request).expect("python stages");
+        assert_eq!(staged.module.org.as_str(), streamlib_idents::SESSION_ORG);
+
+        let manifest_path = staged.dir.join(streamlib_idents::Manifest::FILE_NAME);
+        assert!(manifest_path.is_file(), "manifest must be staged");
+        let manifest = streamlib_idents::Manifest::load(&staged.dir).expect("manifest parses");
+        let package = manifest.package.expect("package block present");
+        assert_eq!(package.org.as_str(), streamlib_idents::SESSION_ORG);
+        assert_eq!(package.name.as_str(), "widget");
+
+        assert!(
+            staged.dir.join("python").join("widget.py").is_file(),
+            "source must be staged at the entrypoint module path"
+        );
+
+        // Reclaim the scratch dir this hermetic test wrote.
+        let _ = std::fs::remove_dir_all(&staged.dir);
+    }
+
+    #[test]
+    fn each_stage_mints_a_distinct_monotonic_version() {
+        // Two submits of the same name mint distinct `0.0.N` versions — the
+        // property `replace` relies on so a bumped re-registration never
+        // collides with the prior one.
+        let first = stage_submitted_source(&python_request(Some("widget"))).expect("first stages");
+        let second =
+            stage_submitted_source(&python_request(Some("widget"))).expect("second stages");
+        assert_ne!(
+            second.module.to_string(),
+            first.module.to_string(),
+            "each mint must advance the session version counter"
+        );
+        let _ = std::fs::remove_dir_all(&first.dir);
+        let _ = std::fs::remove_dir_all(&second.dir);
+    }
+}

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/from_source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/from_source.rs
@@ -30,7 +30,10 @@ use std::path::{Path, PathBuf};
 use streamlib_processor_schema::ProcessorLanguage;
 
 use super::super::Runner;
-use super::super::operations::{ReplaceProcessorFromSource, SubmittedProcessorSource};
+use super::super::operations::{
+    RegisterProcessorReceipt, RegisteredProcessorReceipt, ReplaceProcessorFromSource,
+    SubmittedProcessorSource,
+};
 use super::build_orchestrator::BuildPolicy;
 use super::errors::AddModuleError;
 use super::ledger;
@@ -83,7 +86,7 @@ impl Runner {
     pub async fn register_processor_from_source(
         &self,
         request: SubmittedProcessorSource,
-    ) -> Result<streamlib_idents::ModuleIdent> {
+    ) -> Result<RegisterProcessorReceipt> {
         let staged = stage_submitted_source(&request)?;
         self.load_staged_session_source(staged).await
     }
@@ -101,7 +104,7 @@ impl Runner {
     async fn load_staged_session_source(
         &self,
         staged: StagedSessionSource,
-    ) -> Result<streamlib_idents::ModuleIdent> {
+    ) -> Result<RegisterProcessorReceipt> {
         let StagedSessionSource { module, dir } = staged;
         let added = self.add_module_with(
             module.clone(),
@@ -111,7 +114,7 @@ impl Runner {
             },
         );
         match added.await {
-            Ok(_loaded) => Ok(module),
+            Ok(_loaded) => Ok(build_registration_receipt(&module)),
             Err(load_error) => {
                 remove_staged_dir_and_prune_parent(&dir);
                 Err(Error::from(load_error))
@@ -136,7 +139,7 @@ impl Runner {
     pub async fn replace_processor_from_source(
         &self,
         request: ReplaceProcessorFromSource,
-    ) -> Result<streamlib_idents::ModuleIdent> {
+    ) -> Result<RegisterProcessorReceipt> {
         let target = request.target_session_module.clone();
 
         // (1) PRE-VALIDATE — no mutation.
@@ -195,11 +198,11 @@ impl Runner {
         // (4) Load the pre-staged replacement. `load_staged_session_source`
         // reclaims the replacement's scratch dir on its own failure.
         match self.load_staged_session_source(staged).await {
-            Ok(new_module) => {
+            Ok(receipt) => {
                 // (6) HOUSEKEEPING: the old staged dir was the restore artifact;
                 // delete it only now that the new registration has committed.
                 remove_staged_dir_and_prune_parent(&old_dir);
-                Ok(new_module)
+                Ok(receipt)
             }
             Err(cause) => {
                 // (5) COMPENSATE: restore the target's EXACT prior ModuleIdent
@@ -242,6 +245,28 @@ impl Runner {
             }
         }
     }
+}
+
+/// Build the register/replace success receipt from the committed processor
+/// descriptors for `module`, post-commit. Enumerates the registry for the
+/// processors installed under the minted `(org, package)` at the loaded
+/// version and projects each committed [`ProcessorDescriptor`] onto its port
+/// surface, so the caller learns the connectable ports (names, schema ids,
+/// input delivery profiles) without a second graph round-trip.
+///
+/// [`ProcessorDescriptor`]: crate::core::descriptors::ProcessorDescriptor
+fn build_registration_receipt(module: &streamlib_idents::ModuleIdent) -> RegisterProcessorReceipt {
+    let processors = crate::core::processors::PROCESSOR_REGISTRY
+        .list_registered()
+        .into_iter()
+        .filter(|descriptor| {
+            descriptor.name.org == module.org
+                && descriptor.name.package == module.name
+                && module.version.matches(descriptor.name.version)
+        })
+        .map(|descriptor| RegisteredProcessorReceipt::from_descriptor(&descriptor))
+        .collect();
+    RegisterProcessorReceipt::new(module.clone(), processors)
 }
 
 /// Best-effort reclamation of a staged session-source version dir plus its
@@ -910,7 +935,8 @@ mod tests {
             runtime.register_processor_from_source(python_named(name)),
         )
         .expect("original registration succeeds");
-        let original_ident = session_ident_for(&original, "Widget").expect("original resolves");
+        let original_ident =
+            session_ident_for(&original.module, "Widget").expect("original resolves");
         assert!(PROCESSOR_REGISTRY.is_registered(&original_ident));
 
         // Arm the fault so the replacement's load fails; the compensating
@@ -919,7 +945,7 @@ mod tests {
             armed: AtomicBool::new(true),
         });
         let request = ReplaceProcessorFromSource {
-            target_session_module: original.clone(),
+            target_session_module: original.module.clone(),
             replacement: python_named(name),
         };
         let err = drive(&runtime, runtime.replace_processor_from_source(request))
@@ -946,7 +972,7 @@ mod tests {
 
         // Cleanup.
         runtime
-            .remove_module(original)
+            .remove_module(original.module)
             .expect("cleanup remove of the restored target");
     }
 
@@ -968,13 +994,29 @@ mod tests {
             runtime.register_processor_from_source(python_named("fromsrc-ported")),
         )
         .expect("registration with ports succeeds");
-        let ported_ident = session_ident_for(&ported, "Widget").expect("ported resolves");
+        let ported_ident = session_ident_for(&ported.module, "Widget").expect("ported resolves");
         let (inputs, outputs) = PROCESSOR_REGISTRY
             .port_info(&ported_ident)
             .expect("a registered session processor exposes port info");
         assert_eq!(inputs.len(), 1, "spliced input port must be registered");
         assert_eq!(outputs.len(), 1, "spliced output port must be registered");
-        runtime.remove_module(ported).expect("cleanup ported");
+        // The v3 receipt reports the SAME committed ports, built engine-side
+        // from the descriptors post-commit — no second graph round-trip needed.
+        assert_eq!(ported.processors.len(), 1, "receipt names the installed processor");
+        assert_eq!(ported.processors[0].name, "Widget");
+        assert_eq!(
+            ported.processors[0].inputs.len(),
+            1,
+            "receipt carries the committed input port"
+        );
+        assert_eq!(ported.processors[0].inputs[0].name, "in0");
+        assert_eq!(
+            ported.processors[0].outputs.len(),
+            1,
+            "receipt carries the committed output port"
+        );
+        assert_eq!(ported.processors[0].outputs[0].name, "out0");
+        runtime.remove_module(ported.module).expect("cleanup ported");
 
         // Regression twin: the placeholder manifest (no splice) → portless.
         let plain_runtime = Runner::new().unwrap();
@@ -984,7 +1026,7 @@ mod tests {
             plain_runtime.register_processor_from_source(python_named("fromsrc-portless")),
         )
         .expect("registration without ports succeeds");
-        let plain_ident = session_ident_for(&plain, "Widget").expect("plain resolves");
+        let plain_ident = session_ident_for(&plain.module, "Widget").expect("plain resolves");
         let (plain_in, plain_out) = PROCESSOR_REGISTRY
             .port_info(&plain_ident)
             .expect("port info present");
@@ -993,7 +1035,13 @@ mod tests {
             "the placeholder manifest must yield a portless descriptor — got \
              {plain_in:?} / {plain_out:?}"
         );
-        plain_runtime.remove_module(plain).expect("cleanup portless");
+        // The receipt mirrors the portless descriptor: named, but no ports.
+        assert_eq!(plain.processors.len(), 1);
+        assert!(
+            plain.processors[0].inputs.is_empty() && plain.processors[0].outputs.is_empty(),
+            "the portless receipt must carry no ports"
+        );
+        plain_runtime.remove_module(plain.module).expect("cleanup portless");
     }
 
     #[test]

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -92,7 +92,6 @@ pub use build_orchestrator::{
     BuildSource, BuildStream, StagedArtifact,
 };
 pub use errors::{AddModuleError, RemoveModuleError};
-pub(crate) use from_source::reclaim_session_source_staging_root_once;
 pub(crate) use locked::LockedResolution;
 pub use processor_registration::host_target_triple;
 pub(crate) use recursive_walker::ResolutionMemo;

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -92,6 +92,7 @@ pub use build_orchestrator::{
     BuildSource, BuildStream, StagedArtifact,
 };
 pub use errors::{AddModuleError, RemoveModuleError};
+pub(crate) use from_source::reclaim_session_source_staging_root_once;
 pub(crate) use locked::LockedResolution;
 pub use processor_registration::host_target_triple;
 pub(crate) use recursive_walker::ResolutionMemo;

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -42,6 +42,9 @@
 //! - [`session`] — [`Runner::add_local`]: register a `#[processor]` host
 //!   type live under `@session/<name>@0.0.N` through the same staging seam,
 //!   with no package on disk.
+//! - [`from_source`] — [`Runner::register_processor_from_source`]: stage
+//!   live-submitted source text into a `@session/<name>@0.0.N` package and
+//!   load it through the [`Strategy::Path`] build/commit seam.
 //! - [`slpkg`] — `.slpkg` archive extraction.
 //!
 //! [`Runner::remove_module`]: super::Runner::remove_module
@@ -64,6 +67,7 @@ mod acquire;
 mod added_module;
 mod build_orchestrator;
 mod errors;
+mod from_source;
 mod lazy_discovery;
 mod ledger;
 mod locked;

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/session.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/session.rs
@@ -250,7 +250,7 @@ fn fallback_session_module() -> streamlib_idents::MintedSessionIdent {
 /// package segment: `TestMockProcessor` → `test-mock-processor`. A `-` is
 /// inserted before each interior uppercase run boundary; underscores map to
 /// `-`; the result is lowercased and de-duplicated / trimmed of `-`.
-fn kebab_case(type_name: &str) -> String {
+pub(super) fn kebab_case(type_name: &str) -> String {
     let mut out = String::with_capacity(type_name.len() + 4);
     let mut prev_was_lower_or_digit = false;
     for ch in type_name.chars() {

--- a/runtime/streamlib-engine/src/core/runtime/operations.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations.rs
@@ -95,20 +95,12 @@ pub struct ReplaceProcessorFromSource {
     pub replacement: SubmittedProcessorSource,
 }
 
-/// The success payload of `register_processor_source` / `replace_processor`.
+/// The success payload of `register_processor_source` / `replace_processor`:
+/// the minted registration [`ModuleIdent`] plus each installed processor's
+/// committed port surface.
 ///
-/// A thin receipt: the minted registration [`ModuleIdent`] plus, for every
-/// processor the registration installed, its committed port surface. Built
-/// engine-side from the committed [`ProcessorDescriptor`]s AFTER the load
-/// commits, so a live-submit caller (filed #1424) learns the connectable ports
-/// — names, schema ids, input delivery profiles — without a second graph
-/// round-trip.
-///
-/// This is a payload-only growth over the former bare `ModuleIdent` return: the
-/// `RuntimeOpsVTable` v3 layout (fn-pointer offsets) is unchanged; only the
-/// msgpack body carried on the success completion grew. It is the msgpack wire
-/// payload the register/replace slots return, so it is serde-stable across the
-/// plugin ABI.
+/// The msgpack wire payload the register/replace slots return; serde-stable
+/// across the plugin ABI.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RegisterProcessorReceipt {
     /// The minted `@session/<name>@0.0.N` registration ident (NOT an

--- a/runtime/streamlib-engine/src/core/runtime/operations.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations.rs
@@ -8,7 +8,9 @@ use crate::core::{InputLinkPortRef, OutputLinkPortRef};
 use std::future::Future;
 use std::pin::Pin;
 use streamlib_idents::ModuleIdent;
-use streamlib_processor_schema::ProcessorLanguage;
+use streamlib_processor_schema::{PortSchemaSpec, ProcessorLanguage};
+
+use crate::core::descriptors::{PortDescriptor, ProcessorDescriptor};
 
 /// Boxed future type for async trait methods (required for dyn compatibility).
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
@@ -93,6 +95,94 @@ pub struct ReplaceProcessorFromSource {
     pub replacement: SubmittedProcessorSource,
 }
 
+/// The success payload of `register_processor_source` / `replace_processor`.
+///
+/// A thin receipt: the minted registration [`ModuleIdent`] plus, for every
+/// processor the registration installed, its committed port surface. Built
+/// engine-side from the committed [`ProcessorDescriptor`]s AFTER the load
+/// commits, so a live-submit caller (filed #1424) learns the connectable ports
+/// — names, schema ids, input delivery profiles — without a second graph
+/// round-trip.
+///
+/// This is a payload-only growth over the former bare `ModuleIdent` return: the
+/// `RuntimeOpsVTable` v3 layout (fn-pointer offsets) is unchanged; only the
+/// msgpack body carried on the success completion grew. It is the msgpack wire
+/// payload the register/replace slots return, so it is serde-stable across the
+/// plugin ABI.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RegisterProcessorReceipt {
+    /// The minted `@session/<name>@0.0.N` registration ident (NOT an
+    /// `add_processor` instance id).
+    pub module: ModuleIdent,
+    /// The processors the registration installed, with their committed ports.
+    pub processors: Vec<RegisteredProcessorReceipt>,
+}
+
+impl RegisterProcessorReceipt {
+    /// A receipt carrying only the minted ident — the ports vector empty. The
+    /// caller fills `processors` from the committed descriptors post-commit.
+    pub fn new(module: ModuleIdent, processors: Vec<RegisteredProcessorReceipt>) -> Self {
+        Self { module, processors }
+    }
+}
+
+/// One processor's committed port surface within a [`RegisterProcessorReceipt`].
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RegisteredProcessorReceipt {
+    /// The processor's PascalCase short `Type` name.
+    pub name: String,
+    /// Input ports, in declaration order.
+    pub inputs: Vec<RegisteredPortReceipt>,
+    /// Output ports, in declaration order.
+    pub outputs: Vec<RegisteredPortReceipt>,
+}
+
+impl RegisteredProcessorReceipt {
+    /// Project a committed [`ProcessorDescriptor`] onto its receipt surface.
+    pub fn from_descriptor(descriptor: &ProcessorDescriptor) -> Self {
+        Self {
+            name: descriptor.name.r#type.as_str().to_string(),
+            inputs: descriptor
+                .inputs
+                .iter()
+                .map(RegisteredPortReceipt::from_port)
+                .collect(),
+            outputs: descriptor
+                .outputs
+                .iter()
+                .map(RegisteredPortReceipt::from_port)
+                .collect(),
+        }
+    }
+}
+
+/// One committed port within a [`RegisteredProcessorReceipt`].
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RegisteredPortReceipt {
+    /// The port name.
+    pub name: String,
+    /// The port's schema id — `Any` or a fully-qualified `SchemaIdent`.
+    /// Serialized through the plugin-ABI-safe wire codec so `Specific`
+    /// round-trips across the msgpack boundary (the default `PortSchemaSpec`
+    /// serde is YAML-shaped and lossy on `Specific`).
+    #[serde(with = "crate::core::descriptors::port_schema_spec_wire")]
+    pub schema: PortSchemaSpec,
+    /// Input-port delivery-profile override (`"latest"` / `"every_sample"` /
+    /// `"lossless"`); always `None` on output ports.
+    #[serde(default)]
+    pub delivery_profile: Option<String>,
+}
+
+impl RegisteredPortReceipt {
+    fn from_port(port: &PortDescriptor) -> Self {
+        Self {
+            name: port.name.clone(),
+            schema: port.schema.clone(),
+            delivery_profile: port.delivery_profile.clone(),
+        }
+    }
+}
+
 /// Unified interface for runtime graph operations.
 ///
 /// Implemented by `Runner` (direct) and `RuntimeProxy` (channel-based).
@@ -147,20 +237,21 @@ pub trait RuntimeOperations: Send + Sync {
 
     /// Register a processor definition from source text into the live
     /// runtime, minting it a `@session/<name>@0.0.N` identity through the
-    /// module_loader's transactional session-source seam. Returns the minted
-    /// registration [`ModuleIdent`] (NOT an `add_processor` instance id).
+    /// module_loader's transactional session-source seam. Returns a
+    /// [`RegisterProcessorReceipt`] — the minted registration ident plus the
+    /// committed port surface of each installed processor.
     fn register_processor_source_async(
         &self,
         request: SubmittedProcessorSource,
-    ) -> BoxFuture<'_, Result<ModuleIdent>>;
+    ) -> BoxFuture<'_, Result<RegisterProcessorReceipt>>;
 
     /// Remove a prior `@session/<name>` registration, then re-register the
-    /// replacement source at a monotonically-bumped `0.0.N`. Returns the
-    /// minted registration [`ModuleIdent`] for the new definition.
+    /// replacement source at a monotonically-bumped `0.0.N`. Returns a
+    /// [`RegisterProcessorReceipt`] for the new definition.
     fn replace_processor_async(
         &self,
         request: ReplaceProcessorFromSource,
-    ) -> BoxFuture<'_, Result<ModuleIdent>>;
+    ) -> BoxFuture<'_, Result<RegisterProcessorReceipt>>;
 
     // =========================================================================
     // Sync Methods (convenience wrappers - NOT safe from tokio tasks)
@@ -252,6 +343,58 @@ mod source_submit_wire_tests {
             target.to_string()
         );
         assert_eq!(decoded.replacement.language, ProcessorLanguage::TypeScript);
+    }
+
+    #[test]
+    fn register_receipt_round_trips_through_msgpack() {
+        // The v3 SUCCESS payload: minted ident + per-processor committed ports.
+        // Crosses the plugin ABI, so a field rename / reorder or a schema-spec
+        // wire-codec regression must fail here. Covers both an `Any` port and a
+        // `Specific(SchemaIdent)` port (the case the default YAML-shaped
+        // PortSchemaSpec serde would lose) plus an input delivery profile.
+        use streamlib_idents::{Org, Package, SchemaIdent, SemVer, TypeName};
+
+        let module = streamlib_idents::mint_session_module_ident("widget")
+            .expect("valid name mints")
+            .module;
+        let specific = PortSchemaSpec::Specific(SchemaIdent::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("core").unwrap(),
+            TypeName::new("VideoFrame").unwrap(),
+            SemVer::new(1, 2, 3),
+        ));
+        let receipt = RegisterProcessorReceipt::new(
+            module.clone(),
+            vec![RegisteredProcessorReceipt {
+                name: "Widget".to_string(),
+                inputs: vec![RegisteredPortReceipt {
+                    name: "in0".to_string(),
+                    schema: PortSchemaSpec::Any,
+                    delivery_profile: Some("latest".to_string()),
+                }],
+                outputs: vec![RegisteredPortReceipt {
+                    name: "out0".to_string(),
+                    schema: specific.clone(),
+                    delivery_profile: None,
+                }],
+            }],
+        );
+
+        let bytes = rmp_serde::to_vec_named(&receipt).expect("encode");
+        let decoded: RegisterProcessorReceipt = rmp_serde::from_slice(&bytes).expect("decode");
+        assert_eq!(decoded.module.to_string(), module.to_string());
+        assert_eq!(decoded.processors.len(), 1);
+        assert_eq!(decoded.processors[0].name, "Widget");
+        assert_eq!(decoded.processors[0].inputs[0].name, "in0");
+        assert_eq!(
+            decoded.processors[0].inputs[0].delivery_profile.as_deref(),
+            Some("latest")
+        );
+        assert_eq!(decoded.processors[0].outputs[0].name, "out0");
+        assert_eq!(
+            decoded.processors[0].outputs[0].schema, specific,
+            "the Specific schema id must round-trip through the wire codec"
+        );
     }
 
     #[test]

--- a/runtime/streamlib-engine/src/core/runtime/operations.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations.rs
@@ -7,6 +7,8 @@ use crate::core::processors::ProcessorSpec;
 use crate::core::{InputLinkPortRef, OutputLinkPortRef};
 use std::future::Future;
 use std::pin::Pin;
+use streamlib_idents::ModuleIdent;
+use streamlib_processor_schema::ProcessorLanguage;
 
 /// Boxed future type for async trait methods (required for dyn compatibility).
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
@@ -54,6 +56,41 @@ impl ConnectOptions {
         self.validation = validation;
         self
     }
+}
+
+/// A processor definition submitted as source text for live registration
+/// into a running runtime (`register_processor_source` / `replace_processor`).
+///
+/// The host stages the source through the module_loader's transactional
+/// session-source seam and mints a `@session/<name>@0.0.N` identity. This is
+/// the msgpack wire payload the `RuntimeOpsVTable` v3 slots carry, so it is
+/// serde-stable across the plugin ABI.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SubmittedProcessorSource {
+    /// The processor source text (a Python module / a TypeScript module).
+    pub source_text: String,
+    /// The runtime language the source is authored in.
+    pub language: ProcessorLanguage,
+    /// The `@session/<name>` package-name segment to mint the registration
+    /// under. `None` derives a default segment from `processor_type_name`.
+    pub requested_name: Option<String>,
+    /// The PascalCase processor type name the source defines — the subprocess
+    /// entrypoint class symbol and the registered short type name. `None`
+    /// derives it from `requested_name`.
+    pub processor_type_name: Option<String>,
+}
+
+/// A `replace_processor` request: remove a prior `@session/<name>`
+/// registration, then re-register `replacement` at a monotonically-bumped
+/// `0.0.N`. The msgpack wire payload the `RuntimeOpsVTable::replace_processor`
+/// slot carries.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ReplaceProcessorFromSource {
+    /// The `@session/<name>` module whose prior registration is removed
+    /// before the replacement registers.
+    pub target_session_module: ModuleIdent,
+    /// The replacement definition, registered at a fresh `0.0.N`.
+    pub replacement: SubmittedProcessorSource,
 }
 
 /// Unified interface for runtime graph operations.
@@ -108,6 +145,23 @@ pub trait RuntimeOperations: Send + Sync {
     /// Export graph state as JSON asynchronously.
     fn to_json_async(&self) -> BoxFuture<'_, Result<serde_json::Value>>;
 
+    /// Register a processor definition from source text into the live
+    /// runtime, minting it a `@session/<name>@0.0.N` identity through the
+    /// module_loader's transactional session-source seam. Returns the minted
+    /// registration [`ModuleIdent`] (NOT an `add_processor` instance id).
+    fn register_processor_source_async(
+        &self,
+        request: SubmittedProcessorSource,
+    ) -> BoxFuture<'_, Result<ModuleIdent>>;
+
+    /// Remove a prior `@session/<name>` registration, then re-register the
+    /// replacement source at a monotonically-bumped `0.0.N`. Returns the
+    /// minted registration [`ModuleIdent`] for the new definition.
+    fn replace_processor_async(
+        &self,
+        request: ReplaceProcessorFromSource,
+    ) -> BoxFuture<'_, Result<ModuleIdent>>;
+
     // =========================================================================
     // Sync Methods (convenience wrappers - NOT safe from tokio tasks)
     // =========================================================================
@@ -150,4 +204,63 @@ pub trait RuntimeOperations: Send + Sync {
 
     /// Export graph state as JSON including topology, processor states, metrics, and buffer levels.
     fn to_json(&self) -> Result<serde_json::Value>;
+}
+
+#[cfg(test)]
+mod source_submit_wire_tests {
+    //! Tier-1 wire-format locks for the `RuntimeOpsVTable` v3 register-
+    //! from-source payloads. These msgpack shapes cross the plugin ABI
+    //! (`register_processor_source` / `replace_processor` slots), so a
+    //! field rename / reorder must fail here, not silently at a plugin.
+
+    use super::*;
+
+    #[test]
+    fn submitted_source_round_trips_through_msgpack() {
+        let request = SubmittedProcessorSource {
+            source_text: "class Widget:\n    pass\n".to_string(),
+            language: ProcessorLanguage::Python,
+            requested_name: Some("widget".to_string()),
+            processor_type_name: Some("Widget".to_string()),
+        };
+        let bytes = rmp_serde::to_vec_named(&request).expect("encode");
+        let decoded: SubmittedProcessorSource = rmp_serde::from_slice(&bytes).expect("decode");
+        assert_eq!(decoded.source_text, request.source_text);
+        assert_eq!(decoded.language, request.language);
+        assert_eq!(decoded.requested_name, request.requested_name);
+        assert_eq!(decoded.processor_type_name, request.processor_type_name);
+    }
+
+    #[test]
+    fn replace_request_round_trips_through_msgpack() {
+        let target = streamlib_idents::mint_session_module_ident("widget")
+            .expect("valid name mints")
+            .module;
+        let request = ReplaceProcessorFromSource {
+            target_session_module: target.clone(),
+            replacement: SubmittedProcessorSource {
+                source_text: "class Widget:\n    pass\n".to_string(),
+                language: ProcessorLanguage::TypeScript,
+                requested_name: None,
+                processor_type_name: Some("Widget".to_string()),
+            },
+        };
+        let bytes = rmp_serde::to_vec_named(&request).expect("encode");
+        let decoded: ReplaceProcessorFromSource = rmp_serde::from_slice(&bytes).expect("decode");
+        assert_eq!(
+            decoded.target_session_module.to_string(),
+            target.to_string()
+        );
+        assert_eq!(decoded.replacement.language, ProcessorLanguage::TypeScript);
+    }
+
+    #[test]
+    fn malformed_request_bytes_fail_to_decode() {
+        // Invalid-args wire lock: a truncated / non-conforming buffer must
+        // surface a decode error (the host callback converts this to an error
+        // completion), never a partially-populated request.
+        let garbage = [0xffu8, 0x00, 0x13, 0x37];
+        let decoded = rmp_serde::from_slice::<SubmittedProcessorSource>(&garbage);
+        assert!(decoded.is_err(), "malformed bytes must not decode");
+    }
 }

--- a/runtime/streamlib-engine/src/core/runtime/operations.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations.rs
@@ -119,8 +119,8 @@ pub struct RegisterProcessorReceipt {
 }
 
 impl RegisterProcessorReceipt {
-    /// A receipt carrying only the minted ident — the ports vector empty. The
-    /// caller fills `processors` from the committed descriptors post-commit.
+    /// A receipt of the minted registration ident plus each installed
+    /// processor's committed ports.
     pub fn new(module: ModuleIdent, processors: Vec<RegisteredProcessorReceipt>) -> Self {
         Self { module, processors }
     }

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -5,10 +5,9 @@ use std::sync::Arc;
 
 use super::Runner;
 use super::operations::{
-    BoxFuture, ConnectOptions, ReplaceProcessorFromSource, RuntimeOperations,
-    SubmittedProcessorSource,
+    BoxFuture, ConnectOptions, RegisterProcessorReceipt, ReplaceProcessorFromSource,
+    RuntimeOperations, SubmittedProcessorSource,
 };
-use streamlib_idents::ModuleIdent;
 use super::runtime::TokioRuntimeVariant;
 use crate::core::compiler::{Compiler, PendingOperation};
 use crate::core::graph::{
@@ -406,14 +405,14 @@ impl RuntimeOperations for Runner {
     fn register_processor_source_async(
         &self,
         request: SubmittedProcessorSource,
-    ) -> BoxFuture<'_, Result<ModuleIdent>> {
+    ) -> BoxFuture<'_, Result<RegisterProcessorReceipt>> {
         Box::pin(self.register_processor_from_source(request))
     }
 
     fn replace_processor_async(
         &self,
         request: ReplaceProcessorFromSource,
-    ) -> BoxFuture<'_, Result<ModuleIdent>> {
+    ) -> BoxFuture<'_, Result<RegisterProcessorReceipt>> {
         Box::pin(self.replace_processor_from_source(request))
     }
 

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -4,7 +4,11 @@
 use std::sync::Arc;
 
 use super::Runner;
-use super::operations::{BoxFuture, ConnectOptions, RuntimeOperations};
+use super::operations::{
+    BoxFuture, ConnectOptions, ReplaceProcessorFromSource, RuntimeOperations,
+    SubmittedProcessorSource,
+};
+use streamlib_idents::ModuleIdent;
 use super::runtime::TokioRuntimeVariant;
 use crate::core::compiler::{Compiler, PendingOperation};
 use crate::core::graph::{
@@ -397,6 +401,20 @@ impl RuntimeOperations for Runner {
 
     fn to_json_async(&self) -> BoxFuture<'_, Result<serde_json::Value>> {
         Box::pin(async move { Runner::to_json(self) })
+    }
+
+    fn register_processor_source_async(
+        &self,
+        request: SubmittedProcessorSource,
+    ) -> BoxFuture<'_, Result<ModuleIdent>> {
+        Box::pin(self.register_processor_from_source(request))
+    }
+
+    fn replace_processor_async(
+        &self,
+        request: ReplaceProcessorFromSource,
+    ) -> BoxFuture<'_, Result<ModuleIdent>> {
+        Box::pin(self.replace_processor_from_source(request))
     }
 
     // =========================================================================

--- a/runtime/streamlib-engine/src/core/runtime/runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/runtime.rs
@@ -227,6 +227,12 @@ impl Runner {
         tracing::debug!("STREAMLIB_HOME: {}", streamlib_home.display());
         crate::core::runtime_hooks::run_init_hooks(&streamlib_home)?;
 
+        // Reclaim the session-source staging tree once per process. The
+        // `@session/<name>@0.0.N` version counter restarts at 0 each process, so
+        // a stale `session-source/<name>/0.0.0/` dir from a prior run would
+        // otherwise be re-minted onto and its stale source/venv reused.
+        crate::core::runtime::module_loader::reclaim_session_source_staging_root_once();
+
         // The engine substrate is empty by construction — there are no
         // compile-time-linked processors. Callers populate the
         // `PROCESSOR_REGISTRY` after `Runner::new()` returns via

--- a/runtime/streamlib-engine/src/core/runtime/runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/runtime.rs
@@ -227,12 +227,6 @@ impl Runner {
         tracing::debug!("STREAMLIB_HOME: {}", streamlib_home.display());
         crate::core::runtime_hooks::run_init_hooks(&streamlib_home)?;
 
-        // Reclaim the session-source staging tree once per process. The
-        // `@session/<name>@0.0.N` version counter restarts at 0 each process, so
-        // a stale `session-source/<name>/0.0.0/` dir from a prior run would
-        // otherwise be re-minted onto and its stale source/venv reused.
-        crate::core::runtime::module_loader::reclaim_session_source_staging_root_once();
-
         // The engine substrate is empty by construction — there are no
         // compile-time-linked processors. Callers populate the
         // `PROCESSOR_REGISTRY` after `Runner::new()` returns via

--- a/runtime/streamlib-plugin-abi/src/lib.rs
+++ b/runtime/streamlib-plugin-abi/src/lib.rs
@@ -1059,9 +1059,11 @@ mod layout_tests {
         assert_eq!(PROCESSOR_VTABLE_LAYOUT_VERSION, 2);
         assert_eq!(RUNTIME_CONTEXT_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(AUDIO_CLOCK_VTABLE_LAYOUT_VERSION, 1);
-        // v2: added owning-Arc handle lifetime callbacks
+        // v3: added register-from-source slots
+        // (`register_processor_source` / `replace_processor`); v2
+        // added the owning-Arc handle lifetime callbacks
         // (`clone_handle` / `drop_handle`).
-        assert_eq!(RUNTIME_OPS_VTABLE_LAYOUT_VERSION, 2);
+        assert_eq!(RUNTIME_OPS_VTABLE_LAYOUT_VERSION, 3);
         // v15: #1270 removed the v12–v14 video-source-timeline slots.
         assert_eq!(GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION, 15);
         // SurfaceStore stays at v1 for the entire M32 milestone — #1260

--- a/runtime/streamlib-plugin-abi/src/vtables/runtime_ops.rs
+++ b/runtime/streamlib-plugin-abi/src/vtables/runtime_ops.rs
@@ -22,11 +22,16 @@ use core::ffi::c_void;
 ///   submit a processor definition from source text into a live
 ///   runtime. The host stages the source through the module_loader's
 ///   transactional session-source seam into a minted
-///   `@session/<name>@0.0.N` identity; the success payload is the
-///   msgpack-encoded minted `ModuleIdent` (a registration ident, NOT
-///   an `add_processor` instance `ProcessorUniqueId`). `replace`
-///   carries a target `@session/<name>` module to remove-then-
-///   re-register at a monotonically-bumped `0.0.N`.
+///   `@session/<name>@0.0.N` identity; the success payload is a
+///   msgpack-encoded registration receipt (the minted `ModuleIdent` —
+///   a registration ident, NOT an `add_processor` instance
+///   `ProcessorUniqueId` — plus each installed processor's committed
+///   ports). `replace` carries a target `@session/<name>` module to
+///   remove-then-re-register at a monotonically-bumped `0.0.N`.
+///
+///   The layout version pins the fn-pointer offsets, not the msgpack
+///   body: growing the success payload from a bare `ModuleIdent` to
+///   the receipt is a payload-only change and does NOT re-bump v3.
 pub const RUNTIME_OPS_VTABLE_LAYOUT_VERSION: u32 = 3;
 
 /// Completion callback signature for async runtime ops.
@@ -141,8 +146,10 @@ pub struct RuntimeOpsVTable {
     /// text + language + optional processor name). The host stages the
     /// source through the module_loader's session-source seam and mints
     /// a `@session/<name>@0.0.N` identity. On success the result payload
-    /// is the msgpack-encoded minted `ModuleIdent` (a registration
-    /// ident, NOT an `add_processor` instance `ProcessorUniqueId`).
+    /// is a msgpack-encoded registration receipt: the minted `ModuleIdent`
+    /// (a registration ident, NOT an `add_processor` instance
+    /// `ProcessorUniqueId`) plus each installed processor's committed
+    /// ports (name, schema id, input delivery profile).
     pub register_processor_source: unsafe extern "C" fn(
         handle: *const c_void,
         request_msgpack_ptr: *const u8,
@@ -156,8 +163,9 @@ pub struct RuntimeOpsVTable {
     /// module to remove, plus the replacement source text + language +
     /// optional name). The host removes the prior session registration,
     /// then re-registers the replacement at a monotonically-bumped
-    /// `0.0.N`. On success the result payload is the msgpack-encoded
-    /// minted `ModuleIdent` for the new registration.
+    /// `0.0.N`. On success the result payload is the same msgpack-encoded
+    /// registration receipt `register_processor_source` returns, carrying
+    /// the new registration's minted `ModuleIdent` and committed ports.
     pub replace_processor: unsafe extern "C" fn(
         handle: *const c_void,
         request_msgpack_ptr: *const u8,

--- a/runtime/streamlib-plugin-abi/src/vtables/runtime_ops.rs
+++ b/runtime/streamlib-plugin-abi/src/vtables/runtime_ops.rs
@@ -18,7 +18,16 @@ use core::ffi::c_void;
 ///   handle and releases it via `drop_handle` in its Drop impl,
 ///   keeping the host's `Arc<dyn RuntimeOperations>` alive for the
 ///   shim's lifetime independently of `RuntimeContext`'s lifetime.
-pub const RUNTIME_OPS_VTABLE_LAYOUT_VERSION: u32 = 2;
+/// - v3: added `register_processor_source` / `replace_processor` —
+///   submit a processor definition from source text into a live
+///   runtime. The host stages the source through the module_loader's
+///   transactional session-source seam into a minted
+///   `@session/<name>@0.0.N` identity; the success payload is the
+///   msgpack-encoded minted `ModuleIdent` (a registration ident, NOT
+///   an `add_processor` instance `ProcessorUniqueId`). `replace`
+///   carries a target `@session/<name>` module to remove-then-
+///   re-register at a monotonically-bumped `0.0.N`.
+pub const RUNTIME_OPS_VTABLE_LAYOUT_VERSION: u32 = 3;
 
 /// Completion callback signature for async runtime ops.
 ///
@@ -125,6 +134,37 @@ pub struct RuntimeOpsVTable {
     /// Calling on the same owned handle twice is undefined behaviour
     /// (it would double-free the Arc refcount).
     pub drop_handle: unsafe extern "C" fn(owned_handle: *const c_void),
+
+    // v3 additions: register-from-source + replace.
+    /// Submit a `register_processor_source` operation. `request_msgpack`
+    /// carries a msgpack-encoded register-from-source request (source
+    /// text + language + optional processor name). The host stages the
+    /// source through the module_loader's session-source seam and mints
+    /// a `@session/<name>@0.0.N` identity. On success the result payload
+    /// is the msgpack-encoded minted `ModuleIdent` (a registration
+    /// ident, NOT an `add_processor` instance `ProcessorUniqueId`).
+    pub register_processor_source: unsafe extern "C" fn(
+        handle: *const c_void,
+        request_msgpack_ptr: *const u8,
+        request_msgpack_len: usize,
+        completion: RuntimeOpCompletionCallback,
+        user_data: *mut c_void,
+    ),
+
+    /// Submit a `replace_processor` operation. `request_msgpack` carries
+    /// a msgpack-encoded replace request (a target `@session/<name>`
+    /// module to remove, plus the replacement source text + language +
+    /// optional name). The host removes the prior session registration,
+    /// then re-registers the replacement at a monotonically-bumped
+    /// `0.0.N`. On success the result payload is the msgpack-encoded
+    /// minted `ModuleIdent` for the new registration.
+    pub replace_processor: unsafe extern "C" fn(
+        handle: *const c_void,
+        request_msgpack_ptr: *const u8,
+        request_msgpack_len: usize,
+        completion: RuntimeOpCompletionCallback,
+        user_data: *mut c_void,
+    ),
 }
 
 unsafe impl Send for RuntimeOpsVTable {}
@@ -137,8 +177,9 @@ mod tests {
 
     #[test]
     fn runtime_ops_vtable_layout() {
-        // 4 + 4 + 7 fn pointers (v2: 5 submit ops + clone_handle + drop_handle) = 64 bytes
-        assert_eq!(size_of::<RuntimeOpsVTable>(), 64);
+        // 4 + 4 + 9 fn pointers (v3: 5 submit ops + clone_handle +
+        // drop_handle + register_processor_source + replace_processor) = 80 bytes
+        assert_eq!(size_of::<RuntimeOpsVTable>(), 80);
         assert_eq!(align_of::<RuntimeOpsVTable>(), 8);
         assert_eq!(offset_of!(RuntimeOpsVTable, layout_version), 0);
         assert_eq!(offset_of!(RuntimeOpsVTable, _reserved_padding), 4);
@@ -149,5 +190,7 @@ mod tests {
         assert_eq!(offset_of!(RuntimeOpsVTable, to_json), 40);
         assert_eq!(offset_of!(RuntimeOpsVTable, clone_handle), 48);
         assert_eq!(offset_of!(RuntimeOpsVTable, drop_handle), 56);
+        assert_eq!(offset_of!(RuntimeOpsVTable, register_processor_source), 64);
+        assert_eq!(offset_of!(RuntimeOpsVTable, replace_processor), 72);
     }
 }

--- a/sdk/streamlib-deno/deno.json
+++ b/sdk/streamlib-deno/deno.json
@@ -4,6 +4,7 @@
   "exports": {
     ".": "./mod.ts",
     "./subprocess_runner.ts": "./subprocess_runner.ts",
+    "./extract_processors.ts": "./extract_processors.ts",
     "./escalate.ts": "./escalate.ts",
     "./types.ts": "./types.ts",
     "./adapters/vulkan.ts": "./adapters/vulkan.ts",

--- a/sdk/streamlib-idents/src/session.rs
+++ b/sdk/streamlib-idents/src/session.rs
@@ -22,6 +22,14 @@ use crate::semver::{SemVer, SemVerRange};
 /// `@session/<name>@0.0.N` version. Starts at 0 and only ever advances, so
 /// two mints in one process never share a version — even for the same name
 /// across an add/remove/add cycle.
+///
+/// The counter is process-scoped and restarts at 0 each process. So that a
+/// restart cannot re-mint `0.0.0` onto a `session-source/<name>/0.0.0/` staging
+/// dir surviving from a prior run, the engine reclaims the whole session-source
+/// staging tree once at runtime start (before any mint) — see
+/// `module_loader::reclaim_session_source_staging_root_once`. Cross-run
+/// uniqueness therefore comes from starting each process on a clean staging
+/// tree, not from persisting the counter.
 static NEXT_SESSION_VERSION_PATCH: AtomicU32 = AtomicU32::new(0);
 
 /// The concrete next `0.0.N` release version from the session counter. The

--- a/sdk/streamlib-idents/src/session.rs
+++ b/sdk/streamlib-idents/src/session.rs
@@ -23,13 +23,12 @@ use crate::semver::{SemVer, SemVerRange};
 /// two mints in one process never share a version — even for the same name
 /// across an add/remove/add cycle.
 ///
-/// The counter is process-scoped and restarts at 0 each process. So that a
-/// restart cannot re-mint `0.0.0` onto a `session-source/<name>/0.0.0/` staging
-/// dir surviving from a prior run, the engine reclaims the whole session-source
-/// staging tree once at runtime start (before any mint) — see
-/// `module_loader::reclaim_session_source_staging_root_once`. Cross-run
-/// uniqueness therefore comes from starting each process on a clean staging
-/// tree, not from persisting the counter.
+/// The counter is process-scoped and restarts at 0 each process. Cross-run
+/// uniqueness (so a restart cannot re-mint `0.0.0` onto a
+/// `session-source/<name>/0.0.0/` staging dir surviving from a prior run) is the
+/// module_loader's concern, not this leaf crate's: at mint time it reconciles
+/// the minted version ABOVE the highest version already staged on disk for the
+/// name, so no destructive start-up wipe of the shared staging tree is needed.
 static NEXT_SESSION_VERSION_PATCH: AtomicU32 = AtomicU32::new(0);
 
 /// The concrete next `0.0.N` release version from the session counter. The

--- a/sdk/streamlib-processor-extract/src/derive.rs
+++ b/sdk/streamlib-processor-extract/src/derive.rs
@@ -32,8 +32,8 @@ use std::process::Command;
 
 use serde::Deserialize;
 use streamlib_processor_schema::{
-    PortSchemaSpec, ProcessorLanguage, ProcessorPortSchema, ProcessorSchema,
-    ProcessorSchemaExecution,
+    PortSchemaSpec, ProcessorLanguage, ProcessorPortSchema, ProcessorScheduling, ProcessorSchema,
+    ProcessorSchemaExecution, SchemaIdent,
 };
 
 use crate::reachable::{ModuleReachabilityTarget, extract_reachable_rust_processors};
@@ -365,6 +365,122 @@ impl WireProcessor {
                 .outputs
                 .into_iter()
                 .map(WirePort::into_surface)
+                .collect(),
+        }
+    }
+}
+
+/// A full-fidelity manifest projection of one extractor-emitted processor.
+///
+/// Where [`ProcessorSurface`] keeps only the lossy drift-comparison identity
+/// (type name, execution, port names + bare schema type), this retains
+/// everything the manifest `processors:` entry carries — the full schema
+/// identity (org/package/type/version), execution + scheduling, description,
+/// and each port's schema id, description, and delivery-profile override. It is
+/// the shape the build orchestrator splices into a staged `@session/<name>`
+/// manifest so a live-submitted processor mints connectable ports from its real
+/// declared surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtractedManifestProcessor {
+    /// The processor's full `@org/package/Type@version` identity.
+    pub schema_ident: SchemaIdent,
+    /// Execution mode.
+    pub execution: ProcessorSchemaExecution,
+    /// Declarative scheduling intent the source declared, if any.
+    pub scheduling: Option<ProcessorScheduling>,
+    /// Human-readable description the source declared, if any.
+    pub description: Option<String>,
+    /// Input ports, in declaration order.
+    pub inputs: Vec<ExtractedManifestPort>,
+    /// Output ports, in declaration order.
+    pub outputs: Vec<ExtractedManifestPort>,
+}
+
+/// One port from a full-fidelity extractor projection: its name, schema
+/// identity (`None` for an `any` wildcard), description, and — inputs only —
+/// the delivery-profile override.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtractedManifestPort {
+    pub name: String,
+    pub schema: Option<SchemaIdent>,
+    pub description: Option<String>,
+    pub delivery_profile: Option<String>,
+}
+
+/// Parse a Python/Deno extractor's stdout JSON into the full-fidelity manifest
+/// projection.
+///
+/// The sibling of [`parse_subprocess_manifest_json`]: same wire input, but it
+/// retains org/package/version, per-port schema id + description +
+/// delivery_profile, and execution/scheduling rather than collapsing to the
+/// drift-comparison surface. The build orchestrator consumes this to splice
+/// real ports into a staged `@session/<name>` manifest.
+pub fn parse_subprocess_manifest_json_full(
+    language: &'static str,
+    json: &str,
+) -> Result<Vec<ExtractedManifestProcessor>, DeriveError> {
+    let wire: Vec<WireProcessorFull> = serde_json::from_str(json)
+        .map_err(|source| DeriveError::MalformedExtractorJson { language, source })?;
+    Ok(wire
+        .into_iter()
+        .map(WireProcessorFull::into_manifest)
+        .collect())
+}
+
+#[derive(Debug, Deserialize)]
+struct WireProcessorFull {
+    schema_ident: SchemaIdent,
+    execution: ProcessorSchemaExecution,
+    #[serde(default)]
+    scheduling: Option<ProcessorScheduling>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    inputs: Vec<WirePortFull>,
+    #[serde(default)]
+    outputs: Vec<WirePortFull>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WirePortFull {
+    name: String,
+    /// `null` for an `any` wildcard port, else the 4-field schema ident.
+    #[serde(default)]
+    schema: Option<SchemaIdent>,
+    #[serde(default)]
+    description: Option<String>,
+    /// Present on input ports only; `null`/absent on outputs.
+    #[serde(default)]
+    delivery_profile: Option<String>,
+}
+
+impl WirePortFull {
+    fn into_manifest(self) -> ExtractedManifestPort {
+        ExtractedManifestPort {
+            name: self.name,
+            schema: self.schema,
+            description: self.description,
+            delivery_profile: self.delivery_profile,
+        }
+    }
+}
+
+impl WireProcessorFull {
+    fn into_manifest(self) -> ExtractedManifestProcessor {
+        ExtractedManifestProcessor {
+            schema_ident: self.schema_ident,
+            execution: self.execution,
+            scheduling: self.scheduling,
+            description: self.description,
+            inputs: self
+                .inputs
+                .into_iter()
+                .map(WirePortFull::into_manifest)
+                .collect(),
+            outputs: self
+                .outputs
+                .into_iter()
+                .map(WirePortFull::into_manifest)
                 .collect(),
         }
     }
@@ -753,6 +869,69 @@ mod tests {
     #[test]
     fn malformed_extractor_json_is_typed_error() {
         let err = parse_subprocess_manifest_json("python", "not json").unwrap_err();
+        assert!(matches!(err, DeriveError::MalformedExtractorJson { .. }));
+    }
+
+    #[test]
+    fn full_parse_retains_ident_delivery_profile_and_scheduling() {
+        // The full-fidelity parse keeps everything the lossy drift surface drops:
+        // the full 4-field schema ident (org/package/version, not just the type),
+        // per-input `delivery_profile` + `description`, and top-level
+        // `scheduling`. This is exactly what the orchestrator splice needs to
+        // rewrite a staged @session manifest's ports.
+        let json = r#"[
+          {
+            "name": "PassThrough",
+            "schema_ident": {"org":"session","package":"widget","type":"PassThrough","version":"0.0.3"},
+            "execution": "reactive",
+            "scheduling": {"priority":"high"},
+            "description": "a live-submitted pass-through",
+            "inputs": [
+              {"name":"any_in","schema":null,"description":"wildcard input","delivery_profile":"latest"}
+            ],
+            "outputs": [
+              {"name":"video_out","schema":{"org":"tatolab","package":"core","type":"VideoFrame","version":"0.0.0"},"description":null}
+            ]
+          }
+        ]"#;
+        let procs = parse_subprocess_manifest_json_full("python", json).unwrap();
+        assert_eq!(procs.len(), 1);
+        let p = &procs[0];
+        assert_eq!(p.schema_ident.org.as_str(), "session");
+        assert_eq!(p.schema_ident.package.as_str(), "widget");
+        assert_eq!(p.schema_ident.r#type.as_str(), "PassThrough");
+        assert_eq!(p.schema_ident.version.to_string(), "0.0.3");
+        assert_eq!(p.execution, ProcessorSchemaExecution::Reactive);
+        assert_eq!(
+            p.scheduling.map(|s| s.priority),
+            Some(streamlib_processor_schema::ThreadPriority::High)
+        );
+        assert_eq!(p.description.as_deref(), Some("a live-submitted pass-through"));
+        assert_eq!(p.inputs.len(), 1);
+        assert!(p.inputs[0].schema.is_none(), "null schema is an any wildcard");
+        assert_eq!(p.inputs[0].delivery_profile.as_deref(), Some("latest"));
+        assert_eq!(p.inputs[0].description.as_deref(), Some("wildcard input"));
+        assert_eq!(p.outputs.len(), 1);
+        assert_eq!(
+            p.outputs[0].schema.as_ref().map(|s| s.r#type.as_str()),
+            Some("VideoFrame")
+        );
+    }
+
+    #[test]
+    fn full_parse_handles_continuous_execution_and_malformed_json() {
+        let json = r#"[{"name":"Gen",
+            "schema_ident":{"org":"session","package":"gen","type":"Gen","version":"0.0.1"},
+            "execution":{"type":"continuous","interval_ms":10},"scheduling":null,"description":null,
+            "inputs":[],"outputs":[]}]"#;
+        let procs = parse_subprocess_manifest_json_full("deno", json).unwrap();
+        assert_eq!(
+            procs[0].execution,
+            ProcessorSchemaExecution::Continuous { interval_ms: 10 }
+        );
+        assert!(procs[0].scheduling.is_none());
+
+        let err = parse_subprocess_manifest_json_full("python", "not json").unwrap_err();
         assert!(matches!(err, DeriveError::MalformedExtractorJson { .. }));
     }
 

--- a/sdk/streamlib-processor-extract/src/lib.rs
+++ b/sdk/streamlib-processor-extract/src/lib.rs
@@ -29,10 +29,11 @@ use std::path::{Path, PathBuf};
 use streamlib_processor_schema::ProcessorSchema;
 
 pub use derive::{
-    DeriveError, DerivedProcessorSet, ManifestDriftReport, PackageLanguage, PortSchemaSurface,
-    PortSurface, ProcessorSurface, SkippedLanguage, SubprocessProcessorExtractor,
-    SystemSubprocessProcessorExtractor, check_processor_manifest_drift,
-    derive_package_processor_surfaces, detect_package_languages, filter_committed_to_languages,
+    DeriveError, DerivedProcessorSet, ExtractedManifestPort, ExtractedManifestProcessor,
+    ManifestDriftReport, PackageLanguage, PortSchemaSurface, PortSurface, ProcessorSurface,
+    SkippedLanguage, SubprocessProcessorExtractor, SystemSubprocessProcessorExtractor,
+    check_processor_manifest_drift, derive_package_processor_surfaces, detect_package_languages,
+    filter_committed_to_languages, parse_subprocess_manifest_json_full,
 };
 pub use grammar::{ParsedPort, ParsedProcessorAttr};
 pub use reachable::{ModuleReachabilityTarget, extract_reachable_rust_processors};

--- a/tools/streamlib-build-orchestrator/Cargo.toml
+++ b/tools/streamlib-build-orchestrator/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 toml_edit = { workspace = true }
 ureq = { workspace = true }
 streamlib-engine = { path = "../../runtime/streamlib-engine", version = "0.7.21" }
@@ -23,6 +24,11 @@ streamlib-pack = { path = "../streamlib-pack", version = "0.7.21" }
 streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.7.21" }
 streamlib-plugin-abi = { path = "../../runtime/streamlib-plugin-abi", version = "0.7.21" }
 streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0.7.21" }
+# Extraction stays OUTSIDE the engine: the build orchestrator (a tool) owns the
+# subprocess port-extraction seam and derives a session package's real ports
+# from its submitted source. The engine gains no such dep.
+streamlib-processor-extract = { path = "../../sdk/streamlib-processor-extract", version = "0.7.21" }
+streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.7.21" }
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/tools/streamlib-build-orchestrator/Cargo.toml
+++ b/tools/streamlib-build-orchestrator/Cargo.toml
@@ -30,6 +30,9 @@ streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0
 streamlib-processor-extract = { path = "../../sdk/streamlib-processor-extract", version = "0.7.21" }
 streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.7.21" }
 
+[build-dependencies]
+serde_json = { workspace = true }
+
 [dev-dependencies]
 tempfile = "3.14"
 serial_test = "3.2"

--- a/tools/streamlib-build-orchestrator/build.rs
+++ b/tools/streamlib-build-orchestrator/build.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+#![allow(clippy::disallowed_macros)] // build.rs uses println! for `cargo:` directives
+
+//! Build script: bakes the Deno SDK's OWN published version into
+//! `STREAMLIB_DENO_SDK_VERSION` by reading `version` from
+//! `sdk/streamlib-deno/deno.json`. The off-link Deno extractor spec
+//! (`npm:@tatolab/streamlib-deno@<ver>/extract_processors.ts`) must pin the
+//! actually-published SDK — the Deno SDK is on an independent version line from
+//! the Rust workspace `CARGO_PKG_VERSION`. `deno.json` is the single source of
+//! truth; the same read runs in the engine's build script.
+
+fn main() {
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR set by cargo for build.rs");
+    let deno_json = std::path::Path::new(&manifest_dir).join("../../sdk/streamlib-deno/deno.json");
+    println!("cargo:rerun-if-changed={}", deno_json.display());
+    let body = std::fs::read_to_string(&deno_json)
+        .unwrap_or_else(|e| panic!("reading {}: {e}", deno_json.display()));
+    let manifest: serde_json::Value = serde_json::from_str(&body)
+        .unwrap_or_else(|e| panic!("parsing {}: {e}", deno_json.display()));
+    let version = manifest["version"].as_str().unwrap_or_else(|| {
+        panic!(
+            "{} has no string `version` field to pin the Deno SDK",
+            deno_json.display()
+        )
+    });
+    println!("cargo:rustc-env=STREAMLIB_DENO_SDK_VERSION={version}");
+}

--- a/tools/streamlib-build-orchestrator/src/lib.rs
+++ b/tools/streamlib-build-orchestrator/src/lib.rs
@@ -40,6 +40,7 @@ mod deno_codegen;
 mod native_host;
 mod python_venv;
 mod release_check;
+mod session_ports;
 
 #[cfg(test)]
 mod test_support;
@@ -350,6 +351,24 @@ impl PolyglotBuildOrchestrator {
             e
         })?;
 
+        // ---- session-source port extraction ----
+        // A live-submitted `@session/<name>` package stages a placeholder
+        // `inputs: []` / `outputs: []` manifest (the submit site cannot know the
+        // ports without running the source). Now that the subprocess runtime is
+        // provisioned, derive the REAL ports from the staged source by running
+        // the language's import-and-enumerate extractor and splice them into the
+        // staged manifest before the atomic rename carries it into the cache.
+        // Gated on the reserved session org so a normal package (whose committed
+        // `processors:` is the source of truth, drift-checked at `pkg build`) is
+        // never rewritten here.
+        if package.org.is_reserved_for_session() {
+            session_ports::splice_session_manifest_ports(&temp_dir, active_link.as_ref(), &pkg_label)
+                .map_err(|e| {
+                    let _ = std::fs::remove_dir_all(&temp_dir);
+                    e
+                })?;
+        }
+
         write_sidecar(&temp_dir, triple, self.profile, &fingerprint)
             .map_err(|e| other(&pkg_label, format!("writing build sidecar: {e}")))?;
         atomic_swap(&temp_dir, &cache_slot)
@@ -543,6 +562,10 @@ struct ActiveBuildLink {
     consumer_cargo_config: Option<PathBuf>,
     /// The linked checkout's Python SDK path (uv editable source target).
     python_sdk_path: PathBuf,
+    /// The linked checkout's Deno SDK entrypoint (`.../streamlib-deno/mod.ts`).
+    /// The session port-extraction tail resolves the Deno `extract_processors.ts`
+    /// as its sibling under a link.
+    deno_sdk_entrypoint_path: PathBuf,
 }
 
 /// Discover the active `streamlib link` for the current build from the process
@@ -582,6 +605,7 @@ fn discover_active_build_link_from(
         checkout: manifest.checkout,
         consumer_cargo_config,
         python_sdk_path: manifest.python_sdk_path,
+        deno_sdk_entrypoint_path: manifest.deno_sdk_entrypoint_path,
     }))
 }
 

--- a/tools/streamlib-build-orchestrator/src/session_ports.rs
+++ b/tools/streamlib-build-orchestrator/src/session_ports.rs
@@ -22,7 +22,7 @@
 //! never register silent empty (unconnectable) ports. Off-link Deno extraction
 //! mirrors off-link Python: with no `STREAMLIB_DENO_EXTRACTOR` override and no
 //! active `streamlib link`, the extractor is the npm-published SDK's
-//! `extract_processors.ts` (pinned to this build's version), run over the staged
+//! `extract_processors.ts` (pinned to the Deno SDK's own published version), run over the staged
 //! `deno.json` — the direct analogue of running `.venv/bin/python -m
 //! streamlib.extract_processors` off-link. A resolution that genuinely fails
 //! (the `deno run npm:` fetch itself) surfaces as a hard [`BuildError`] rather
@@ -385,8 +385,9 @@ fn build_failed(package: &str, detail: String) -> BuildError {
 /// in priority order: an explicit `STREAMLIB_DENO_EXTRACTOR` override or the
 /// linked checkout's `extract_processors.ts` (both a local `.ts` script on disk)
 /// win; off-link with neither, the extractor is the npm-published SDK's
-/// `extract_processors.ts` pinned to this build's version — the exact mirror of
-/// how off-link Python runs `.venv/bin/python -m streamlib.extract_processors`.
+/// `extract_processors.ts` pinned to the Deno SDK's own published version — the
+/// exact mirror of how off-link Python runs `.venv/bin/python -m
+/// streamlib.extract_processors`.
 #[derive(Debug, PartialEq, Eq)]
 enum DenoExtractorSource {
     /// A local `extract_processors.ts` on disk (the `STREAMLIB_DENO_EXTRACTOR`
@@ -446,7 +447,7 @@ impl SessionSourceExtractor {
         let deno_extractor_source = resolve_deno_extractor_source(
             std::env::var_os("STREAMLIB_DENO_EXTRACTOR").map(PathBuf::from),
             link,
-            env!("CARGO_PKG_VERSION"),
+            env!("STREAMLIB_DENO_SDK_VERSION"),
         );
 
         Self {
@@ -710,8 +711,8 @@ mod tests {
         // Resolution-priority lock for off-link Deno extraction: an explicit
         // `STREAMLIB_DENO_EXTRACTOR` override wins, then the linked checkout's
         // `extract_processors.ts` sibling, and off-link with neither the
-        // extractor is the npm-published SDK pinned to this build's version — the
-        // mirror of off-link Python's `.venv/bin/python -m
+        // extractor is the npm-published SDK pinned to the Deno SDK's own
+        // published version — the mirror of off-link Python's `.venv/bin/python -m
         // streamlib.extract_processors`. Mentally-revert the npm tier and the
         // `neither` case has no extractor (the old hard-refusal / portless gap).
         let override_script = PathBuf::from("/opt/custom/extract_processors.ts");
@@ -794,7 +795,7 @@ mod tests {
             venv_python: python3,
             deno_binary: "deno".to_string(),
             deno_extractor_source: DenoExtractorSource::PublishedNpm {
-                sdk_version: env!("CARGO_PKG_VERSION").to_string(),
+                sdk_version: env!("STREAMLIB_DENO_SDK_VERSION").to_string(),
             },
             deno_config: dir.path().join("deno.json"),
         };

--- a/tools/streamlib-build-orchestrator/src/session_ports.rs
+++ b/tools/streamlib-build-orchestrator/src/session_ports.rs
@@ -1,0 +1,647 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Session-source port extraction tail for the build orchestrator.
+//!
+//! A live-submitted `@session/<name>` package is staged with a placeholder
+//! `inputs: []` / `outputs: []` manifest — the submit site can't know the
+//! processor's ports without running its source. This tail closes that gap:
+//! once the subprocess runtime is provisioned (Python venv / Deno
+//! `_generated_`), it runs the language's import-and-enumerate extractor over
+//! the staged source, then splices the real ports, execution mode, scheduling,
+//! and description into the staged `streamlib.yaml` before the atomic rename
+//! carries it into the package cache. The engine's registration path then mints
+//! CONNECTABLE ports straight from that populated manifest.
+//!
+//! Extraction lives OUTSIDE the engine on purpose: it depends on
+//! [`streamlib_processor_extract`] (which pulls the `#[processor]` grammar +
+//! `syn`), a build-tool concern. The engine consumes only the populated
+//! manifest; it never imports the extractor.
+//!
+//! A spawn / non-zero-exit / malformed-output failure is a HARD
+//! [`BuildError`] — a session package must never register silent empty ports.
+//! The single bounded fallback is [`DeriveError::ExtractorUnconfigured`] (the
+//! Deno extractor script couldn't be located off a link and with no env
+//! override): that language is skipped with a warning rather than failing the
+//! whole materialize.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use streamlib_engine::core::runtime::BuildError;
+use streamlib_processor_extract::{
+    DeriveError, ExtractedManifestPort, ExtractedManifestProcessor, SubprocessProcessorExtractor,
+    parse_subprocess_manifest_json_full,
+};
+use streamlib_processor_schema::{PortSchemaSpec, ProcessorPortSchema};
+
+use crate::ActiveBuildLink;
+
+/// Derive the real ports for a staged `@session/<name>` package and splice them
+/// into its manifest. Constructs the real [`SessionSourceExtractor`] from the
+/// staged venv + the active link, then runs the language-agnostic splice.
+pub(crate) fn splice_session_manifest_ports(
+    staged_dir: &Path,
+    link: Option<&ActiveBuildLink>,
+    package_label: &str,
+) -> Result<(), BuildError> {
+    let extractor = SessionSourceExtractor::for_staged(staged_dir, link);
+    rewrite_staged_manifest_ports(staged_dir, package_label, &extractor)
+}
+
+/// The language-agnostic splice: detect which subprocess languages the staged
+/// package carries, run each present language's extractor through `extractor`,
+/// and rewrite the staged manifest's processors with the derived ports. The
+/// `extractor` seam is injectable so the splice is unit-testable without a live
+/// Python/Deno runtime.
+fn rewrite_staged_manifest_ports(
+    staged_dir: &Path,
+    package_label: &str,
+    extractor: &dyn SubprocessProcessorExtractor,
+) -> Result<(), BuildError> {
+    let mut extracted: Vec<ExtractedManifestProcessor> = Vec::new();
+
+    // Python source is staged under `python/` (beside the pyproject); the
+    // extractor scans the top-level `*.py` there.
+    let python_dir = staged_dir.join("python");
+    if python_dir.is_dir()
+        && let Some(procs) = run_language_extractor("python", &python_dir, package_label, || {
+            extractor.extract_python(&python_dir)
+        })?
+    {
+        extracted.extend(procs);
+    }
+
+    // Deno source is staged under `deno/`; the extractor scans the top-level
+    // `*.ts` there.
+    let deno_dir = staged_dir.join("deno");
+    if deno_dir.is_dir()
+        && let Some(procs) = run_language_extractor("deno", &deno_dir, package_label, || {
+            extractor.extract_deno(&deno_dir)
+        })?
+    {
+        extracted.extend(procs);
+    }
+
+    if extracted.is_empty() {
+        tracing::debug!(
+            package = %package_label,
+            "no session processors extracted — leaving the staged manifest's port placeholders"
+        );
+        return Ok(());
+    }
+
+    let manifest_path = staged_dir.join(streamlib_idents::Manifest::FILE_NAME);
+    let body = std::fs::read_to_string(&manifest_path).map_err(|e| {
+        build_failed(
+            package_label,
+            format!("read staged session manifest {}: {e}", manifest_path.display()),
+        )
+    })?;
+    let mut manifest: serde_yaml::Value = serde_yaml::from_str(&body).map_err(|e| {
+        build_failed(package_label, format!("parse staged session manifest: {e}"))
+    })?;
+
+    let spliced = apply_extracted_to_manifest(&mut manifest, &extracted, package_label)?;
+    tracing::info!(
+        package = %package_label,
+        spliced,
+        extracted = extracted.len(),
+        "spliced live-extracted ports into staged session manifest"
+    );
+
+    let rewritten = serde_yaml::to_string(&manifest).map_err(|e| {
+        build_failed(package_label, format!("re-serialize staged session manifest: {e}"))
+    })?;
+    std::fs::write(&manifest_path, rewritten).map_err(|e| {
+        build_failed(
+            package_label,
+            format!("write spliced session manifest {}: {e}", manifest_path.display()),
+        )
+    })?;
+    Ok(())
+}
+
+/// Run one language's extractor, mapping the [`DeriveError`] taxonomy onto the
+/// hard-vs-bounded contract: a spawn / non-zero-exit / malformed-output failure
+/// is a hard [`BuildError`]; [`DeriveError::ExtractorUnconfigured`] is the sole
+/// bounded fallback (that language is skipped, `Ok(None)`).
+fn run_language_extractor(
+    language: &'static str,
+    language_dir: &Path,
+    package_label: &str,
+    run: impl FnOnce() -> Result<String, DeriveError>,
+) -> Result<Option<Vec<ExtractedManifestProcessor>>, BuildError> {
+    match run() {
+        Ok(json) => {
+            let procs = parse_subprocess_manifest_json_full(language, &json)
+                .map_err(|e| map_extract_err(language, package_label, e))?;
+            if procs.is_empty() {
+                tracing::warn!(
+                    package = %package_label,
+                    language,
+                    dir = %language_dir.display(),
+                    "session extractor ran but registered no processors — the submitted \
+                     source declares none for this language; staged ports left empty"
+                );
+            }
+            Ok(Some(procs))
+        }
+        Err(DeriveError::ExtractorUnconfigured { hint, .. }) => {
+            tracing::warn!(
+                package = %package_label,
+                language,
+                hint,
+                "session port extraction skipped: no extractor configured for this language"
+            );
+            Ok(None)
+        }
+        Err(other) => Err(map_extract_err(language, package_label, other)),
+    }
+}
+
+/// Splice each extracted processor's execution / scheduling / description /
+/// ports onto the staged manifest processor of the same `Type` name. Returns
+/// the number of processors spliced.
+fn apply_extracted_to_manifest(
+    manifest: &mut serde_yaml::Value,
+    extracted: &[ExtractedManifestProcessor],
+    package_label: &str,
+) -> Result<usize, BuildError> {
+    let processors = manifest
+        .as_mapping_mut()
+        .and_then(|m| m.get_mut(serde_yaml::Value::String("processors".to_string())))
+        .and_then(|p| p.as_sequence_mut())
+        .ok_or_else(|| {
+            build_failed(
+                package_label,
+                "staged session manifest has no `processors:` sequence to splice into".to_string(),
+            )
+        })?;
+
+    let mut spliced = 0usize;
+    for entry in processors.iter_mut() {
+        let Some(map) = entry.as_mapping_mut() else {
+            continue;
+        };
+        let name = map
+            .get(serde_yaml::Value::String("name".to_string()))
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let Some(name) = name else { continue };
+
+        // Match the staged processor to the extractor's projection by `Type`
+        // short name — a session package stages exactly one processor per
+        // submitted source, keyed by the minted type name.
+        let Some(proc) = extracted
+            .iter()
+            .find(|p| p.schema_ident.r#type.as_str() == name)
+        else {
+            continue;
+        };
+
+        let execution = serde_yaml::to_value(&proc.execution)
+            .map_err(|e| build_failed(package_label, format!("encode execution: {e}")))?;
+        map.insert(serde_yaml::Value::String("execution".to_string()), execution);
+
+        if let Some(scheduling) = &proc.scheduling {
+            let scheduling = serde_yaml::to_value(scheduling)
+                .map_err(|e| build_failed(package_label, format!("encode scheduling: {e}")))?;
+            map.insert(
+                serde_yaml::Value::String("scheduling".to_string()),
+                scheduling,
+            );
+        }
+        if let Some(description) = &proc.description {
+            map.insert(
+                serde_yaml::Value::String("description".to_string()),
+                serde_yaml::Value::String(description.clone()),
+            );
+        }
+
+        map.insert(
+            serde_yaml::Value::String("inputs".to_string()),
+            ports_to_yaml(&proc.inputs, true, package_label)?,
+        );
+        map.insert(
+            serde_yaml::Value::String("outputs".to_string()),
+            ports_to_yaml(&proc.outputs, false, package_label)?,
+        );
+        spliced += 1;
+    }
+    Ok(spliced)
+}
+
+/// Project a port list onto its manifest YAML sequence. `is_input` gates the
+/// `delivery_profile` override (output ports never carry one).
+fn ports_to_yaml(
+    ports: &[ExtractedManifestPort],
+    is_input: bool,
+    package_label: &str,
+) -> Result<serde_yaml::Value, BuildError> {
+    let mut seq = Vec::with_capacity(ports.len());
+    for port in ports {
+        // The manifest use-site references a schema by bare `Type` name (or the
+        // `any` wildcard); the full ident's org/package/version live in the
+        // package's `schemas:`/dependency resolution, not the port line.
+        let schema = match &port.schema {
+            Some(ident) => PortSchemaSpec::Named(ident.r#type.clone()),
+            None => PortSchemaSpec::Any,
+        };
+        let manifest_port = ProcessorPortSchema {
+            name: port.name.clone(),
+            schema,
+            description: port.description.clone(),
+            delivery_profile: if is_input {
+                port.delivery_profile.clone()
+            } else {
+                None
+            },
+        };
+        seq.push(
+            serde_yaml::to_value(&manifest_port)
+                .map_err(|e| build_failed(package_label, format!("encode port: {e}")))?,
+        );
+    }
+    Ok(serde_yaml::Value::Sequence(seq))
+}
+
+fn map_extract_err(language: &str, package_label: &str, err: DeriveError) -> BuildError {
+    build_failed(
+        package_label,
+        format!("session {language} port extraction failed: {err}"),
+    )
+}
+
+fn build_failed(package: &str, detail: String) -> BuildError {
+    BuildError::BuildFailed {
+        tool: "session-ports".to_string(),
+        package: package.to_string(),
+        detail,
+    }
+}
+
+/// The build orchestrator's real [`SubprocessProcessorExtractor`]: spawns the
+/// staged package's provisioned venv Python (`.venv/bin/python -m
+/// streamlib.extract_processors <dir>`) and, for Deno, the SDK's
+/// `extract_processors.ts` resolved off the active link (or the
+/// `STREAMLIB_DENO_EXTRACTOR` override), running it against the staged
+/// `deno.json` import map so the source's `streamlib` specifier resolves.
+struct SessionSourceExtractor {
+    venv_python: PathBuf,
+    deno_binary: String,
+    deno_extractor_script: Option<PathBuf>,
+    deno_config: PathBuf,
+}
+
+impl SessionSourceExtractor {
+    fn for_staged(staged_dir: &Path, link: Option<&ActiveBuildLink>) -> Self {
+        #[cfg(unix)]
+        let venv_python = staged_dir.join(".venv").join("bin").join("python");
+        #[cfg(windows)]
+        let venv_python = staged_dir.join(".venv").join("Scripts").join("python.exe");
+
+        // Resolve the Deno extractor script: an explicit override wins, else the
+        // linked checkout's Deno SDK entrypoint sibling. With neither, Deno
+        // extraction is unconfigured (the bounded fallback).
+        let deno_extractor_script = std::env::var_os("STREAMLIB_DENO_EXTRACTOR")
+            .map(PathBuf::from)
+            .or_else(|| {
+                link.and_then(|l| {
+                    l.deno_sdk_entrypoint_path
+                        .parent()
+                        .map(|dir| dir.join("extract_processors.ts"))
+                })
+            });
+
+        Self {
+            venv_python,
+            deno_binary: std::env::var("STREAMLIB_DENO").unwrap_or_else(|_| "deno".to_string()),
+            deno_extractor_script,
+            deno_config: staged_dir.join("deno.json"),
+        }
+    }
+}
+
+/// Run a spawned extractor command, mapping spawn / non-zero-exit into the
+/// [`DeriveError`] taxonomy the shared splice consumes.
+fn run_extractor_command(
+    language: &'static str,
+    package_dir: &Path,
+    mut command: Command,
+) -> Result<String, DeriveError> {
+    let output = command
+        .output()
+        .map_err(|source| DeriveError::SpawnExtractor {
+            language,
+            package: package_dir.to_path_buf(),
+            source,
+        })?;
+    if !output.status.success() {
+        return Err(DeriveError::ExtractorFailed {
+            language,
+            package: package_dir.to_path_buf(),
+            code: output
+                .status
+                .code()
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "signal".to_string()),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+impl SubprocessProcessorExtractor for SessionSourceExtractor {
+    fn extract_python(&self, package_dir: &Path) -> Result<String, DeriveError> {
+        let mut command = Command::new(&self.venv_python);
+        command
+            .arg("-m")
+            .arg("streamlib.extract_processors")
+            .arg(package_dir);
+        run_extractor_command("python", package_dir, command)
+    }
+
+    fn extract_deno(&self, package_dir: &Path) -> Result<String, DeriveError> {
+        let Some(script) = &self.deno_extractor_script else {
+            return Err(DeriveError::ExtractorUnconfigured {
+                language: "deno",
+                package: package_dir.to_path_buf(),
+                hint: "set STREAMLIB_DENO_EXTRACTOR to the Deno SDK's extract_processors.ts, \
+                       or run under an active `streamlib link`"
+                    .to_string(),
+            });
+        };
+        let mut command = Command::new(&self.deno_binary);
+        command
+            .arg("run")
+            .arg("--allow-all")
+            .arg("--config")
+            .arg(&self.deno_config)
+            .arg(script)
+            .arg(package_dir);
+        run_extractor_command("deno", package_dir, command)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A canned-JSON extractor so the splice is exercised without a live
+    /// Python/Deno runtime (the FakeExtractor pattern).
+    struct FakeExtractor {
+        python: Result<String, DeriveError>,
+        deno: Result<String, DeriveError>,
+    }
+    impl FakeExtractor {
+        fn python_only(json: &str) -> Self {
+            Self {
+                python: Ok(json.to_string()),
+                deno: Ok("[]".to_string()),
+            }
+        }
+    }
+    impl SubprocessProcessorExtractor for FakeExtractor {
+        fn extract_python(&self, _dir: &Path) -> Result<String, DeriveError> {
+            self.python
+                .as_ref()
+                .map(|s| s.clone())
+                .map_err(clone_derive_err)
+        }
+        fn extract_deno(&self, _dir: &Path) -> Result<String, DeriveError> {
+            self.deno.as_ref().map(|s| s.clone()).map_err(clone_derive_err)
+        }
+    }
+
+    fn clone_derive_err(err: &DeriveError) -> DeriveError {
+        // DeriveError isn't Clone; reconstruct the variants the tests use.
+        match err {
+            DeriveError::ExtractorFailed {
+                language,
+                package,
+                code,
+                stderr,
+            } => DeriveError::ExtractorFailed {
+                language,
+                package: package.clone(),
+                code: code.clone(),
+                stderr: stderr.clone(),
+            },
+            DeriveError::ExtractorUnconfigured {
+                language,
+                package,
+                hint,
+            } => DeriveError::ExtractorUnconfigured {
+                language,
+                package: package.clone(),
+                hint: hint.clone(),
+            },
+            _ => DeriveError::MalformedExtractorJson {
+                language: "python",
+                source: serde_json::from_str::<serde_json::Value>("x").unwrap_err(),
+            },
+        }
+    }
+
+    /// Stage a placeholder `@session/<name>` package: a Python source subdir and
+    /// the portless manifest `stage_submitted_source` writes.
+    fn stage_placeholder_python(dir: &Path, type_name: &str) {
+        std::fs::create_dir_all(dir.join("python")).unwrap();
+        std::fs::write(dir.join("python").join("widget.py"), "class Widget: pass\n").unwrap();
+        std::fs::write(
+            dir.join("streamlib.yaml"),
+            format!(
+                "package:\n  org: session\n  name: widget\n  version: \"0.0.1\"\n\
+                 processors:\n  - name: {type_name}\n    description: live-submitted session processor\n    \
+                 runtime: python\n    execution: manual\n    entrypoint: \"widget:{type_name}\"\n    \
+                 inputs: []\n    outputs: []\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    fn full_json(type_name: &str) -> String {
+        format!(
+            r#"[{{
+              "name": "{type_name}",
+              "schema_ident": {{"org":"session","package":"widget","type":"{type_name}","version":"0.0.1"}},
+              "execution": "reactive",
+              "scheduling": {{"priority":"high"}},
+              "description": "extracted description",
+              "inputs": [
+                {{"name":"in0","schema":null,"description":"an input","delivery_profile":"latest"}}
+              ],
+              "outputs": [
+                {{"name":"out0","schema":{{"org":"tatolab","package":"core","type":"VideoFrame","version":"0.0.0"}},"description":null}}
+              ]
+            }}]"#
+        )
+    }
+
+    #[test]
+    fn splice_rewrites_placeholder_manifest_with_real_ports() {
+        // The injectable-splice lock: with canned full-fidelity extractor JSON,
+        // the staged `inputs: []` / `outputs: []` placeholders become real ports,
+        // and execution / scheduling / description are rewritten from the
+        // extracted surface. Mentally-revert the splice and the manifest keeps
+        // its empty placeholders → a portless (unconnectable) session processor.
+        let dir = tempfile::tempdir().unwrap();
+        stage_placeholder_python(dir.path(), "Widget");
+        let extractor = FakeExtractor::python_only(&full_json("Widget"));
+
+        rewrite_staged_manifest_ports(dir.path(), "session/widget", &extractor)
+            .expect("splice must succeed");
+
+        let cfg: streamlib_processor_schema::ProjectConfigMinimal = serde_yaml::from_str(
+            &std::fs::read_to_string(dir.path().join("streamlib.yaml")).unwrap(),
+        )
+        .expect("spliced manifest must re-parse");
+        assert_eq!(cfg.processors.len(), 1);
+        let proc = &cfg.processors[0];
+        assert_eq!(proc.name, "Widget");
+        assert_eq!(
+            proc.execution,
+            streamlib_processor_schema::ProcessorSchemaExecution::Reactive
+        );
+        assert_eq!(
+            proc.scheduling.map(|s| s.priority),
+            Some(streamlib_processor_schema::ThreadPriority::High)
+        );
+        assert_eq!(proc.description.as_deref(), Some("extracted description"));
+        assert_eq!(proc.inputs.len(), 1, "the placeholder input must be spliced");
+        assert_eq!(proc.inputs[0].name, "in0");
+        assert_eq!(proc.inputs[0].delivery_profile.as_deref(), Some("latest"));
+        assert_eq!(proc.outputs.len(), 1, "the placeholder output must be spliced");
+        assert_eq!(proc.outputs[0].name, "out0");
+        assert_eq!(proc.outputs[0].schema.to_string(), "VideoFrame");
+    }
+
+    #[test]
+    fn extractor_failure_is_a_hard_build_error_not_empty_ports() {
+        // Contract lock: a spawn / non-zero-exit failure must fail the whole
+        // materialize, never leave the placeholder ports silently empty.
+        let dir = tempfile::tempdir().unwrap();
+        stage_placeholder_python(dir.path(), "Widget");
+        let extractor = FakeExtractor {
+            python: Err(DeriveError::ExtractorFailed {
+                language: "python",
+                package: dir.path().join("python"),
+                code: "1".to_string(),
+                stderr: "No module named 'streamlib'".to_string(),
+            }),
+            deno: Ok("[]".to_string()),
+        };
+        let err = rewrite_staged_manifest_ports(dir.path(), "session/widget", &extractor)
+            .expect_err("a failed extractor must hard-fail the splice");
+        assert!(matches!(err, BuildError::BuildFailed { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn deno_unconfigured_is_a_bounded_skip() {
+        // A staged Deno session package whose extractor script can't be located
+        // (no link, no env override) is skipped with a warning, not failed —
+        // the single bounded fallback. The placeholder ports remain.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("deno")).unwrap();
+        std::fs::write(dir.path().join("deno").join("widget.ts"), "export class Widget {}\n")
+            .unwrap();
+        std::fs::write(
+            dir.path().join("streamlib.yaml"),
+            "package:\n  org: session\n  name: widget\n  version: \"0.0.1\"\n\
+             processors:\n  - name: Widget\n    description: d\n    runtime: deno\n    \
+             execution: manual\n    entrypoint: \"widget.ts:Widget\"\n    inputs: []\n    outputs: []\n",
+        )
+        .unwrap();
+        let extractor = FakeExtractor {
+            python: Ok("[]".to_string()),
+            deno: Err(DeriveError::ExtractorUnconfigured {
+                language: "deno",
+                package: dir.path().join("deno"),
+                hint: "no script".to_string(),
+            }),
+        };
+        rewrite_staged_manifest_ports(dir.path(), "session/widget", &extractor)
+            .expect("unconfigured deno must be a bounded skip, not a hard error");
+
+        let body = std::fs::read_to_string(dir.path().join("streamlib.yaml")).unwrap();
+        assert!(
+            body.contains("inputs: []") && body.contains("outputs: []"),
+            "placeholder ports must remain untouched when extraction is skipped: {body}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn real_extractor_spawns_python3_and_parses_manifest_json() {
+        // Real-extractor subprocess lock: the actual
+        // `SessionSourceExtractor::extract_python` path — spawn python3, run
+        // `-m streamlib.extract_processors <dir>`, capture stdout — is exercised
+        // end-to-end. Subprocess spawn is sandbox-OK (exit 144 is GPU/IPC only).
+        // Gated on `python3` being present, like `streamlib-pack`'s subprocess
+        // tests. A hermetic fake `streamlib.extract_processors` module (planted
+        // on PYTHONPATH) stands in for the SDK's, so the test doesn't require a
+        // provisioned venv; it still drives the real method and asserts the
+        // spawn → stdout → full-fidelity-parse pipeline is wired.
+        let Some(python3) = which_python3() else {
+            eprintln!("skipping: `python3` not on PATH");
+            return;
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let pkg = dir.path().join("python");
+        std::fs::create_dir_all(&pkg).unwrap();
+
+        let sitedir = dir.path().join("site");
+        let streamlib_pkg = sitedir.join("streamlib");
+        std::fs::create_dir_all(&streamlib_pkg).unwrap();
+        std::fs::write(streamlib_pkg.join("__init__.py"), "").unwrap();
+        std::fs::write(
+            streamlib_pkg.join("extract_processors.py"),
+            "import json\n\
+             print(json.dumps([{\n\
+             \"name\": \"Widget\",\n\
+             \"schema_ident\": {\"org\": \"session\", \"package\": \"widget\", \"type\": \"Widget\", \"version\": \"0.0.1\"},\n\
+             \"execution\": \"reactive\", \"scheduling\": None, \"description\": None,\n\
+             \"inputs\": [], \"outputs\": []}]))\n",
+        )
+        .unwrap();
+
+        let extractor = SessionSourceExtractor {
+            venv_python: python3,
+            deno_binary: "deno".to_string(),
+            deno_extractor_script: None,
+            deno_config: dir.path().join("deno.json"),
+        };
+
+        // The extractor spawns the interpreter inheriting the process env, so
+        // point PYTHONPATH at the fake site dir for the duration of the call.
+        // SAFETY: `#[serial]` serializes the process-global env mutation, and no
+        // concurrent test spawns a Python interpreter that would observe it.
+        let prev = std::env::var_os("PYTHONPATH");
+        unsafe { std::env::set_var("PYTHONPATH", &sitedir) };
+        let result = extractor.extract_python(&pkg);
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("PYTHONPATH", v),
+                None => std::env::remove_var("PYTHONPATH"),
+            }
+        }
+
+        let json = result.expect("real python extractor must run against the fixture");
+        let procs = parse_subprocess_manifest_json_full("python", &json)
+            .expect("fixture output must parse as full-fidelity manifest JSON");
+        assert_eq!(procs.len(), 1);
+        assert_eq!(procs[0].schema_ident.r#type.as_str(), "Widget");
+    }
+
+    fn which_python3() -> Option<PathBuf> {
+        let path = std::env::var_os("PATH")?;
+        for dir in std::env::split_paths(&path) {
+            let candidate = dir.join("python3");
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+}

--- a/tools/streamlib-build-orchestrator/src/session_ports.rs
+++ b/tools/streamlib-build-orchestrator/src/session_ports.rs
@@ -18,12 +18,13 @@
 //! `syn`), a build-tool concern. The engine consumes only the populated
 //! manifest; it never imports the extractor.
 //!
-//! A spawn / non-zero-exit / malformed-output failure is a HARD
-//! [`BuildError`] — a session package must never register silent empty ports.
-//! The single bounded fallback is [`DeriveError::ExtractorUnconfigured`] (the
-//! Deno extractor script couldn't be located off a link and with no env
-//! override): that language is skipped with a warning rather than failing the
-//! whole materialize.
+//! EVERY extractor failure is a HARD [`BuildError`] — a session package must
+//! never register silent empty (unconnectable) ports. That includes
+//! [`DeriveError::ExtractorUnconfigured`] (the Deno extractor script couldn't
+//! be located off a link and with no env override): an off-link Deno live
+//! submit fails LOUDLY with a `run under streamlib link / set
+//! STREAMLIB_DENO_EXTRACTOR` hint, mirroring how Rust-from-source is refused,
+//! rather than shipping a portless processor.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -64,23 +65,25 @@ fn rewrite_staged_manifest_ports(
     // Python source is staged under `python/` (beside the pyproject); the
     // extractor scans the top-level `*.py` there.
     let python_dir = staged_dir.join("python");
-    if python_dir.is_dir()
-        && let Some(procs) = run_language_extractor("python", &python_dir, package_label, || {
-            extractor.extract_python(&python_dir)
-        })?
-    {
-        extracted.extend(procs);
+    if python_dir.is_dir() {
+        extracted.extend(run_language_extractor(
+            "python",
+            &python_dir,
+            package_label,
+            || extractor.extract_python(&python_dir),
+        )?);
     }
 
     // Deno source is staged under `deno/`; the extractor scans the top-level
     // `*.ts` there.
     let deno_dir = staged_dir.join("deno");
-    if deno_dir.is_dir()
-        && let Some(procs) = run_language_extractor("deno", &deno_dir, package_label, || {
-            extractor.extract_deno(&deno_dir)
-        })?
-    {
-        extracted.extend(procs);
+    if deno_dir.is_dir() {
+        extracted.extend(run_language_extractor(
+            "deno",
+            &deno_dir,
+            package_label,
+            || extractor.extract_deno(&deno_dir),
+        )?);
     }
 
     if extracted.is_empty() {
@@ -122,114 +125,210 @@ fn rewrite_staged_manifest_ports(
     Ok(())
 }
 
-/// Run one language's extractor, mapping the [`DeriveError`] taxonomy onto the
-/// hard-vs-bounded contract: a spawn / non-zero-exit / malformed-output failure
-/// is a hard [`BuildError`]; [`DeriveError::ExtractorUnconfigured`] is the sole
-/// bounded fallback (that language is skipped, `Ok(None)`).
+/// Run one language's extractor for a live-submitted SESSION package. Every
+/// [`DeriveError`] — spawn / non-zero-exit / malformed-output AND
+/// [`DeriveError::ExtractorUnconfigured`] — is a HARD [`BuildError`]: a session
+/// submit must never register a silent portless (unconnectable) processor. An
+/// off-link Deno submit with no resolvable extractor therefore fails LOUDLY
+/// (the [`DeriveError::ExtractorUnconfigured`] Display carries the `run under
+/// streamlib link / set STREAMLIB_DENO_EXTRACTOR` hint), mirroring how
+/// Rust-from-source is explicitly refused, rather than shipping empty ports.
 fn run_language_extractor(
     language: &'static str,
     language_dir: &Path,
     package_label: &str,
     run: impl FnOnce() -> Result<String, DeriveError>,
-) -> Result<Option<Vec<ExtractedManifestProcessor>>, BuildError> {
-    match run() {
-        Ok(json) => {
-            let procs = parse_subprocess_manifest_json_full(language, &json)
-                .map_err(|e| map_extract_err(language, package_label, e))?;
-            if procs.is_empty() {
-                tracing::warn!(
-                    package = %package_label,
-                    language,
-                    dir = %language_dir.display(),
-                    "session extractor ran but registered no processors — the submitted \
-                     source declares none for this language; staged ports left empty"
-                );
-            }
-            Ok(Some(procs))
-        }
-        Err(DeriveError::ExtractorUnconfigured { hint, .. }) => {
-            tracing::warn!(
-                package = %package_label,
-                language,
-                hint,
-                "session port extraction skipped: no extractor configured for this language"
-            );
-            Ok(None)
-        }
-        Err(other) => Err(map_extract_err(language, package_label, other)),
+) -> Result<Vec<ExtractedManifestProcessor>, BuildError> {
+    let json = run().map_err(|e| map_extract_err(language, package_label, e))?;
+    let procs = parse_subprocess_manifest_json_full(language, &json)
+        .map_err(|e| map_extract_err(language, package_label, e))?;
+    if procs.is_empty() {
+        tracing::warn!(
+            package = %package_label,
+            language,
+            dir = %language_dir.display(),
+            "session extractor ran but registered no processors — the submitted \
+             source declares none for this language; staged ports left empty"
+        );
     }
+    Ok(procs)
 }
 
 /// Splice each extracted processor's execution / scheduling / description /
-/// ports onto the staged manifest processor of the same `Type` name. Returns
-/// the number of processors spliced.
+/// ports onto the staged manifest processor of the same `Type` name, and
+/// synthesize the `schemas:` / `dependencies:` maps that let the engine rebind
+/// each port's bare `Named` schema ref to its fully-qualified `Specific` ident.
+/// Returns the number of processors spliced.
 fn apply_extracted_to_manifest(
     manifest: &mut serde_yaml::Value,
     extracted: &[ExtractedManifestProcessor],
     package_label: &str,
 ) -> Result<usize, BuildError> {
-    let processors = manifest
-        .as_mapping_mut()
-        .and_then(|m| m.get_mut(serde_yaml::Value::String("processors".to_string())))
-        .and_then(|p| p.as_sequence_mut())
-        .ok_or_else(|| {
-            build_failed(
-                package_label,
-                "staged session manifest has no `processors:` sequence to splice into".to_string(),
-            )
-        })?;
+    // Bare `Type` → owning `@org/package`, and `@org/package` → its concrete
+    // version, harvested from the extracted ports whose schema retains a full
+    // ident. The staged port lines carry only the bare `Type`; without these
+    // maps the engine's `resolve_bare_schema_refs` has nothing to rebind the
+    // bare ref against and the port is left a dangling (unconnectable) `Named`.
+    let mut schema_owner_by_type: std::collections::BTreeMap<String, String> =
+        std::collections::BTreeMap::new();
+    let mut version_by_owner: std::collections::BTreeMap<String, String> =
+        std::collections::BTreeMap::new();
 
     let mut spliced = 0usize;
-    for entry in processors.iter_mut() {
-        let Some(map) = entry.as_mapping_mut() else {
-            continue;
-        };
-        let name = map
-            .get(serde_yaml::Value::String("name".to_string()))
-            .and_then(|v| v.as_str())
-            .map(str::to_string);
-        let Some(name) = name else { continue };
+    {
+        let processors = manifest
+            .as_mapping_mut()
+            .and_then(|m| m.get_mut(serde_yaml::Value::String("processors".to_string())))
+            .and_then(|p| p.as_sequence_mut())
+            .ok_or_else(|| {
+                build_failed(
+                    package_label,
+                    "staged session manifest has no `processors:` sequence to splice into"
+                        .to_string(),
+                )
+            })?;
 
-        // Match the staged processor to the extractor's projection by `Type`
-        // short name — a session package stages exactly one processor per
-        // submitted source, keyed by the minted type name.
-        let Some(proc) = extracted
-            .iter()
-            .find(|p| p.schema_ident.r#type.as_str() == name)
-        else {
-            continue;
-        };
+        for entry in processors.iter_mut() {
+            let Some(map) = entry.as_mapping_mut() else {
+                continue;
+            };
+            let name = map
+                .get(serde_yaml::Value::String("name".to_string()))
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            let Some(name) = name else { continue };
 
-        let execution = serde_yaml::to_value(&proc.execution)
-            .map_err(|e| build_failed(package_label, format!("encode execution: {e}")))?;
-        map.insert(serde_yaml::Value::String("execution".to_string()), execution);
+            // Match the staged processor to the extractor's projection by `Type`
+            // short name — a session package stages exactly one processor per
+            // submitted source, keyed by the minted type name.
+            let Some(proc) = extracted
+                .iter()
+                .find(|p| p.schema_ident.r#type.as_str() == name)
+            else {
+                continue;
+            };
 
-        if let Some(scheduling) = &proc.scheduling {
-            let scheduling = serde_yaml::to_value(scheduling)
-                .map_err(|e| build_failed(package_label, format!("encode scheduling: {e}")))?;
+            let execution = serde_yaml::to_value(&proc.execution)
+                .map_err(|e| build_failed(package_label, format!("encode execution: {e}")))?;
+            map.insert(serde_yaml::Value::String("execution".to_string()), execution);
+
+            if let Some(scheduling) = &proc.scheduling {
+                let scheduling = serde_yaml::to_value(scheduling)
+                    .map_err(|e| build_failed(package_label, format!("encode scheduling: {e}")))?;
+                map.insert(
+                    serde_yaml::Value::String("scheduling".to_string()),
+                    scheduling,
+                );
+            }
+            if let Some(description) = &proc.description {
+                map.insert(
+                    serde_yaml::Value::String("description".to_string()),
+                    serde_yaml::Value::String(description.clone()),
+                );
+            }
+
             map.insert(
-                serde_yaml::Value::String("scheduling".to_string()),
-                scheduling,
+                serde_yaml::Value::String("inputs".to_string()),
+                ports_to_yaml(&proc.inputs, true, package_label)?,
             );
-        }
-        if let Some(description) = &proc.description {
             map.insert(
-                serde_yaml::Value::String("description".to_string()),
-                serde_yaml::Value::String(description.clone()),
+                serde_yaml::Value::String("outputs".to_string()),
+                ports_to_yaml(&proc.outputs, false, package_label)?,
             );
-        }
 
-        map.insert(
-            serde_yaml::Value::String("inputs".to_string()),
-            ports_to_yaml(&proc.inputs, true, package_label)?,
-        );
-        map.insert(
-            serde_yaml::Value::String("outputs".to_string()),
-            ports_to_yaml(&proc.outputs, false, package_label)?,
-        );
-        spliced += 1;
+            for port in proc.inputs.iter().chain(proc.outputs.iter()) {
+                if let Some(ident) = &port.schema {
+                    collect_schema_binding(&mut schema_owner_by_type, &mut version_by_owner, ident);
+                }
+            }
+            spliced += 1;
+        }
     }
+
+    splice_schema_bindings(manifest, &schema_owner_by_type, &version_by_owner, package_label)?;
     Ok(spliced)
+}
+
+/// Record the `schemas:`/`dependencies:` binding a single extracted port's
+/// schema ident implies: the bare `Type` maps to its owning `@org/package`,
+/// which pins to the ident's concrete version. A `@session/<name>`-owned type
+/// is skipped — it names no external dependency to import from.
+fn collect_schema_binding(
+    schema_owner_by_type: &mut std::collections::BTreeMap<String, String>,
+    version_by_owner: &mut std::collections::BTreeMap<String, String>,
+    ident: &streamlib_processor_schema::SchemaIdent,
+) {
+    if ident.org.as_str() == streamlib_idents::SESSION_ORG {
+        return;
+    }
+    let owner =
+        streamlib_idents::PackageRef::new(ident.org.clone(), ident.package.clone()).to_string();
+    schema_owner_by_type.insert(ident.r#type.as_str().to_string(), owner.clone());
+    version_by_owner.insert(owner, ident.version.to_string());
+}
+
+/// Merge the synthesized `schemas:` (bare `Type` → `{ package: @org/pkg }`
+/// External imports) and `dependencies:` (`@org/pkg` → `{ version }`) maps into
+/// the staged manifest, so the engine's bare-name schema resolution rebinds
+/// each port's `Named` ref to a `Specific` ident. Existing entries are
+/// preserved; the synthesized bindings never clobber a hand-authored key.
+fn splice_schema_bindings(
+    manifest: &mut serde_yaml::Value,
+    schema_owner_by_type: &std::collections::BTreeMap<String, String>,
+    version_by_owner: &std::collections::BTreeMap<String, String>,
+    package_label: &str,
+) -> Result<(), BuildError> {
+    if schema_owner_by_type.is_empty() {
+        return Ok(());
+    }
+    let root = manifest.as_mapping_mut().ok_or_else(|| {
+        build_failed(
+            package_label,
+            "staged session manifest is not a mapping".to_string(),
+        )
+    })?;
+
+    let schemas = mapping_entry(root, "schemas");
+    for (type_name, owner) in schema_owner_by_type {
+        let mut entry = serde_yaml::Mapping::new();
+        entry.insert(
+            serde_yaml::Value::String("package".to_string()),
+            serde_yaml::Value::String(owner.clone()),
+        );
+        schemas
+            .entry(serde_yaml::Value::String(type_name.clone()))
+            .or_insert(serde_yaml::Value::Mapping(entry));
+    }
+
+    let dependencies = mapping_entry(root, "dependencies");
+    for (owner, version) in version_by_owner {
+        let mut entry = serde_yaml::Mapping::new();
+        entry.insert(
+            serde_yaml::Value::String("version".to_string()),
+            serde_yaml::Value::String(version.clone()),
+        );
+        dependencies
+            .entry(serde_yaml::Value::String(owner.clone()))
+            .or_insert(serde_yaml::Value::Mapping(entry));
+    }
+    Ok(())
+}
+
+/// Borrow (creating if absent) a nested `serde_yaml` mapping under `key` in the
+/// manifest root.
+fn mapping_entry<'a>(
+    root: &'a mut serde_yaml::Mapping,
+    key: &str,
+) -> &'a mut serde_yaml::Mapping {
+    let key = serde_yaml::Value::String(key.to_string());
+    let slot = root
+        .entry(key)
+        .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+    if !slot.is_mapping() {
+        *slot = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
+    }
+    slot.as_mapping_mut()
+        .expect("slot was just ensured to be a mapping")
 }
 
 /// Project a port list onto its manifest YAML sequence. `is_input` gates the
@@ -538,10 +637,13 @@ mod tests {
     }
 
     #[test]
-    fn deno_unconfigured_is_a_bounded_skip() {
-        // A staged Deno session package whose extractor script can't be located
-        // (no link, no env override) is skipped with a warning, not failed —
-        // the single bounded fallback. The placeholder ports remain.
+    fn deno_unconfigured_is_a_hard_build_error_not_portless() {
+        // Contract lock: a staged Deno session package whose extractor script
+        // can't be located (no link, no env override) is a HARD build error, not
+        // a silent portless registration — an off-link Deno live submit fails
+        // LOUDLY rather than shipping an unconnectable processor. Mentally-revert
+        // the ExtractorUnconfigured→hard-error change and this yields an Ok with
+        // empty placeholder ports.
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join("deno")).unwrap();
         std::fs::write(dir.path().join("deno").join("widget.ts"), "export class Widget {}\n")
@@ -558,17 +660,12 @@ mod tests {
             deno: Err(DeriveError::ExtractorUnconfigured {
                 language: "deno",
                 package: dir.path().join("deno"),
-                hint: "no script".to_string(),
+                hint: "set STREAMLIB_DENO_EXTRACTOR or run under `streamlib link`".to_string(),
             }),
         };
-        rewrite_staged_manifest_ports(dir.path(), "session/widget", &extractor)
-            .expect("unconfigured deno must be a bounded skip, not a hard error");
-
-        let body = std::fs::read_to_string(dir.path().join("streamlib.yaml")).unwrap();
-        assert!(
-            body.contains("inputs: []") && body.contains("outputs: []"),
-            "placeholder ports must remain untouched when extraction is skipped: {body}"
-        );
+        let err = rewrite_staged_manifest_ports(dir.path(), "session/widget", &extractor)
+            .expect_err("an unconfigured deno extractor must hard-fail the session submit");
+        assert!(matches!(err, BuildError::BuildFailed { .. }), "got {err:?}");
     }
 
     #[test]
@@ -643,5 +740,118 @@ mod tests {
             }
         }
         None
+    }
+
+    /// A full-fidelity extractor JSON whose OUTPUT port carries a full
+    /// `@tatolab/core/VideoFrame@1.0.0` schema ident — the shape the splice
+    /// harvests into the synthesized `schemas:` / `dependencies:` maps.
+    fn json_with_core_output_port() -> String {
+        r#"[{
+          "name": "Widget",
+          "schema_ident": {"org":"session","package":"widget","type":"Widget","version":"0.0.1"},
+          "execution": "reactive",
+          "scheduling": null,
+          "description": null,
+          "inputs": [],
+          "outputs": [
+            {"name":"out0","schema":{"org":"tatolab","package":"core","type":"VideoFrame","version":"1.0.0"},"description":null}
+          ]
+        }]"#
+        .to_string()
+    }
+
+    /// Write `<checkout>/packages/core` declaring `VideoFrame` as a Local schema
+    /// — the owning package the synthesized `@tatolab/core` dep resolves to
+    /// under a link.
+    fn write_checkout_core(checkout: &Path) {
+        let core = checkout.join("packages").join("core");
+        std::fs::create_dir_all(core.join("schemas")).unwrap();
+        std::fs::write(
+            core.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: core\n  version: 1.0.0\nschemas:\n  VideoFrame:\n    file: schemas/video_frame.yaml\n",
+        )
+        .unwrap();
+        std::fs::write(
+            core.join("schemas/video_frame.yaml"),
+            "metadata:\n  type: VideoFrame\nproperties: {}\n",
+        )
+        .unwrap();
+    }
+
+    /// Clear the resolution env so the load resolves the synthesized dep from
+    /// the checkout only (zero registry). Restores prior values on drop.
+    struct CleanResolutionEnv {
+        prev_registry: Option<String>,
+        prev_link: Option<String>,
+    }
+    impl CleanResolutionEnv {
+        fn new() -> Self {
+            let prev_registry = std::env::var("STREAMLIB_REGISTRY_URL").ok();
+            let prev_link = std::env::var("STREAMLIB_LINK_CHECKOUT").ok();
+            // SAFETY: `#[serial]` serializes the process-global env mutation.
+            unsafe {
+                std::env::remove_var("STREAMLIB_REGISTRY_URL");
+                std::env::remove_var("STREAMLIB_LINK_CHECKOUT");
+            }
+            Self {
+                prev_registry,
+                prev_link,
+            }
+        }
+    }
+    impl Drop for CleanResolutionEnv {
+        fn drop(&mut self) {
+            unsafe {
+                match self.prev_registry.take() {
+                    Some(v) => std::env::set_var("STREAMLIB_REGISTRY_URL", v),
+                    None => std::env::remove_var("STREAMLIB_REGISTRY_URL"),
+                }
+                match self.prev_link.take() {
+                    Some(v) => std::env::set_var("STREAMLIB_LINK_CHECKOUT", v),
+                    None => std::env::remove_var("STREAMLIB_LINK_CHECKOUT"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn extracted_schema_port_rebinds_to_a_specific_ident() {
+        // Schema-rebind lock: an extracted port carrying a full schema ident
+        // must yield a synthesized `schemas:` + `dependencies:` pair so the
+        // engine's bare-name resolution rebinds the staged bare `Named` port to
+        // a `Specific` FQ ident. Mentally-revert `splice_schema_bindings` and the
+        // port stays a dangling bare `Named` — the engine load then fails to
+        // resolve it (unconnectable, can't size an iceoryx2 slot).
+        use streamlib_engine::core::ProjectConfig;
+        use streamlib_processor_schema::PortSchemaSpec;
+
+        let _env = CleanResolutionEnv::new();
+        let staged = tempfile::tempdir().unwrap();
+        stage_placeholder_python(staged.path(), "Widget");
+        let extractor = FakeExtractor::python_only(&json_with_core_output_port());
+        rewrite_staged_manifest_ports(staged.path(), "session/widget", &extractor)
+            .expect("splice must succeed");
+
+        // The synthesized maps are present in the rewritten manifest.
+        let body = std::fs::read_to_string(staged.path().join("streamlib.yaml")).unwrap();
+        assert!(
+            body.contains("VideoFrame") && body.contains("@tatolab/core"),
+            "the spliced manifest must synthesize a schemas/dependencies binding: {body}"
+        );
+
+        // The engine resolver rebinds the bare `Named` port to `Specific`,
+        // resolving `@tatolab/core` from the checkout with zero registry.
+        let checkout = tempfile::tempdir().unwrap();
+        write_checkout_core(checkout.path());
+        let config = ProjectConfig::load_with_link(staged.path(), Some(checkout.path()))
+            .expect("the spliced manifest must load and rebind its bare schema ref");
+        let port = &config.processors[0].outputs[0];
+        match &port.schema {
+            PortSchemaSpec::Specific(ident) => {
+                assert_eq!(ident.to_string(), "@tatolab/core/VideoFrame@1.0.0");
+            }
+            other => panic!("extracted port must rebind to a Specific ident, got {other:?}"),
+        }
     }
 }

--- a/tools/streamlib-build-orchestrator/src/session_ports.rs
+++ b/tools/streamlib-build-orchestrator/src/session_ports.rs
@@ -19,12 +19,14 @@
 //! manifest; it never imports the extractor.
 //!
 //! EVERY extractor failure is a HARD [`BuildError`] — a session package must
-//! never register silent empty (unconnectable) ports. That includes
-//! [`DeriveError::ExtractorUnconfigured`] (the Deno extractor script couldn't
-//! be located off a link and with no env override): an off-link Deno live
-//! submit fails LOUDLY with a `run under streamlib link / set
-//! STREAMLIB_DENO_EXTRACTOR` hint, mirroring how Rust-from-source is refused,
-//! rather than shipping a portless processor.
+//! never register silent empty (unconnectable) ports. Off-link Deno extraction
+//! mirrors off-link Python: with no `STREAMLIB_DENO_EXTRACTOR` override and no
+//! active `streamlib link`, the extractor is the npm-published SDK's
+//! `extract_processors.ts` (pinned to this build's version), run over the staged
+//! `deno.json` — the direct analogue of running `.venv/bin/python -m
+//! streamlib.extract_processors` off-link. A resolution that genuinely fails
+//! (the `deno run npm:` fetch itself) surfaces as a hard [`BuildError`] rather
+//! than a portless registration, just as Rust-from-source is refused.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -126,13 +128,12 @@ fn rewrite_staged_manifest_ports(
 }
 
 /// Run one language's extractor for a live-submitted SESSION package. Every
-/// [`DeriveError`] — spawn / non-zero-exit / malformed-output AND
-/// [`DeriveError::ExtractorUnconfigured`] — is a HARD [`BuildError`]: a session
-/// submit must never register a silent portless (unconnectable) processor. An
-/// off-link Deno submit with no resolvable extractor therefore fails LOUDLY
-/// (the [`DeriveError::ExtractorUnconfigured`] Display carries the `run under
-/// streamlib link / set STREAMLIB_DENO_EXTRACTOR` hint), mirroring how
-/// Rust-from-source is explicitly refused, rather than shipping empty ports.
+/// [`DeriveError`] — spawn / non-zero-exit / malformed-output — is a HARD
+/// [`BuildError`]: a session submit must never register a silent portless
+/// (unconnectable) processor. Off-link Deno resolves to the npm-published
+/// extractor, so a genuine resolution failure surfaces as a non-zero `deno run`
+/// exit ([`DeriveError::ExtractorFailed`]), still a hard [`BuildError`], rather
+/// than shipping empty ports — the same refusal Rust-from-source gets.
 fn run_language_extractor(
     language: &'static str,
     language_dir: &Path,
@@ -380,16 +381,58 @@ fn build_failed(package: &str, detail: String) -> BuildError {
     }
 }
 
+/// How the Deno processor extractor for a staged session package is resolved,
+/// in priority order: an explicit `STREAMLIB_DENO_EXTRACTOR` override or the
+/// linked checkout's `extract_processors.ts` (both a local `.ts` script on disk)
+/// win; off-link with neither, the extractor is the npm-published SDK's
+/// `extract_processors.ts` pinned to this build's version — the exact mirror of
+/// how off-link Python runs `.venv/bin/python -m streamlib.extract_processors`.
+#[derive(Debug, PartialEq, Eq)]
+enum DenoExtractorSource {
+    /// A local `extract_processors.ts` on disk (the `STREAMLIB_DENO_EXTRACTOR`
+    /// override, or the active link's checkout).
+    LocalScript(PathBuf),
+    /// The npm-published `@tatolab/streamlib-deno@<sdk_version>/extract_processors.ts`,
+    /// resolved (off-link) through the staged `deno.json` import map.
+    PublishedNpm { sdk_version: String },
+}
+
+/// Resolve the Deno extractor source for a staged session package: the
+/// `STREAMLIB_DENO_EXTRACTOR` override wins, then the linked checkout's
+/// `extract_processors.ts` sibling, and off-link with neither the npm-published
+/// SDK pinned to `sdk_version`. Pure over its inputs so the resolution priority
+/// is unit-testable without mutating the process env.
+fn resolve_deno_extractor_source(
+    env_override: Option<PathBuf>,
+    link: Option<&ActiveBuildLink>,
+    sdk_version: &str,
+) -> DenoExtractorSource {
+    if let Some(script) = env_override {
+        return DenoExtractorSource::LocalScript(script);
+    }
+    if let Some(linked_script) = link.and_then(|l| {
+        l.deno_sdk_entrypoint_path
+            .parent()
+            .map(|dir| dir.join("extract_processors.ts"))
+    }) {
+        return DenoExtractorSource::LocalScript(linked_script);
+    }
+    DenoExtractorSource::PublishedNpm {
+        sdk_version: sdk_version.to_string(),
+    }
+}
+
 /// The build orchestrator's real [`SubprocessProcessorExtractor`]: spawns the
 /// staged package's provisioned venv Python (`.venv/bin/python -m
 /// streamlib.extract_processors <dir>`) and, for Deno, the SDK's
-/// `extract_processors.ts` resolved off the active link (or the
-/// `STREAMLIB_DENO_EXTRACTOR` override), running it against the staged
-/// `deno.json` import map so the source's `streamlib` specifier resolves.
+/// `extract_processors.ts` — resolved from the `STREAMLIB_DENO_EXTRACTOR`
+/// override, the active link's checkout, or (off-link) the npm-published SDK by
+/// pinned version — run against the staged `deno.json` import map so the
+/// source's `streamlib` specifier resolves.
 struct SessionSourceExtractor {
     venv_python: PathBuf,
     deno_binary: String,
-    deno_extractor_script: Option<PathBuf>,
+    deno_extractor_source: DenoExtractorSource,
     deno_config: PathBuf,
 }
 
@@ -400,23 +443,16 @@ impl SessionSourceExtractor {
         #[cfg(windows)]
         let venv_python = staged_dir.join(".venv").join("Scripts").join("python.exe");
 
-        // Resolve the Deno extractor script: an explicit override wins, else the
-        // linked checkout's Deno SDK entrypoint sibling. With neither, Deno
-        // extraction is unconfigured (the bounded fallback).
-        let deno_extractor_script = std::env::var_os("STREAMLIB_DENO_EXTRACTOR")
-            .map(PathBuf::from)
-            .or_else(|| {
-                link.and_then(|l| {
-                    l.deno_sdk_entrypoint_path
-                        .parent()
-                        .map(|dir| dir.join("extract_processors.ts"))
-                })
-            });
+        let deno_extractor_source = resolve_deno_extractor_source(
+            std::env::var_os("STREAMLIB_DENO_EXTRACTOR").map(PathBuf::from),
+            link,
+            env!("CARGO_PKG_VERSION"),
+        );
 
         Self {
             venv_python,
             deno_binary: std::env::var("STREAMLIB_DENO").unwrap_or_else(|_| "deno".to_string()),
-            deno_extractor_script,
+            deno_extractor_source,
             deno_config: staged_dir.join("deno.json"),
         }
     }
@@ -462,23 +498,23 @@ impl SubprocessProcessorExtractor for SessionSourceExtractor {
     }
 
     fn extract_deno(&self, package_dir: &Path) -> Result<String, DeriveError> {
-        let Some(script) = &self.deno_extractor_script else {
-            return Err(DeriveError::ExtractorUnconfigured {
-                language: "deno",
-                package: package_dir.to_path_buf(),
-                hint: "set STREAMLIB_DENO_EXTRACTOR to the Deno SDK's extract_processors.ts, \
-                       or run under an active `streamlib link`"
-                    .to_string(),
-            });
-        };
         let mut command = Command::new(&self.deno_binary);
         command
             .arg("run")
             .arg("--allow-all")
             .arg("--config")
-            .arg(&self.deno_config)
-            .arg(script)
-            .arg(package_dir);
+            .arg(&self.deno_config);
+        match &self.deno_extractor_source {
+            DenoExtractorSource::LocalScript(script) => {
+                command.arg(script);
+            }
+            DenoExtractorSource::PublishedNpm { sdk_version } => {
+                command.arg(format!(
+                    "npm:@tatolab/streamlib-deno@{sdk_version}/extract_processors.ts"
+                ));
+            }
+        }
+        command.arg(package_dir);
         run_extractor_command("deno", package_dir, command)
     }
 }
@@ -505,11 +541,11 @@ mod tests {
         fn extract_python(&self, _dir: &Path) -> Result<String, DeriveError> {
             self.python
                 .as_ref()
-                .map(|s| s.clone())
+                .map(String::clone)
                 .map_err(clone_derive_err)
         }
         fn extract_deno(&self, _dir: &Path) -> Result<String, DeriveError> {
-            self.deno.as_ref().map(|s| s.clone()).map_err(clone_derive_err)
+            self.deno.as_ref().map(String::clone).map_err(clone_derive_err)
         }
     }
 
@@ -637,13 +673,14 @@ mod tests {
     }
 
     #[test]
-    fn deno_unconfigured_is_a_hard_build_error_not_portless() {
-        // Contract lock: a staged Deno session package whose extractor script
-        // can't be located (no link, no env override) is a HARD build error, not
-        // a silent portless registration — an off-link Deno live submit fails
-        // LOUDLY rather than shipping an unconnectable processor. Mentally-revert
-        // the ExtractorUnconfigured→hard-error change and this yields an Ok with
-        // empty placeholder ports.
+    fn deno_extractor_error_hard_fails_the_splice() {
+        // Contract lock: a Deno extractor `DeriveError` (here an unconfigured
+        // extractor) hard-fails the whole splice when a `deno/` dir is staged —
+        // a session submit never registers silent portless (unconnectable) ports.
+        // Mentally-revert the DeriveError→hard-`BuildError` mapping and this
+        // yields an Ok with empty placeholder ports. (Off-link resolution itself
+        // now falls through to the npm-published extractor — see
+        // `deno_extractor_source_prefers_override_then_link_then_npm`.)
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join("deno")).unwrap();
         std::fs::write(dir.path().join("deno").join("widget.ts"), "export class Widget {}\n")
@@ -666,6 +703,56 @@ mod tests {
         let err = rewrite_staged_manifest_ports(dir.path(), "session/widget", &extractor)
             .expect_err("an unconfigured deno extractor must hard-fail the session submit");
         assert!(matches!(err, BuildError::BuildFailed { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn deno_extractor_source_prefers_override_then_link_then_npm() {
+        // Resolution-priority lock for off-link Deno extraction: an explicit
+        // `STREAMLIB_DENO_EXTRACTOR` override wins, then the linked checkout's
+        // `extract_processors.ts` sibling, and off-link with neither the
+        // extractor is the npm-published SDK pinned to this build's version — the
+        // mirror of off-link Python's `.venv/bin/python -m
+        // streamlib.extract_processors`. Mentally-revert the npm tier and the
+        // `neither` case has no extractor (the old hard-refusal / portless gap).
+        let override_script = PathBuf::from("/opt/custom/extract_processors.ts");
+        assert_eq!(
+            resolve_deno_extractor_source(Some(override_script.clone()), None, "9.9.9"),
+            DenoExtractorSource::LocalScript(override_script),
+            "an explicit STREAMLIB_DENO_EXTRACTOR override must win",
+        );
+
+        let link = ActiveBuildLink {
+            checkout: PathBuf::from("/co"),
+            consumer_cargo_config: None,
+            python_sdk_path: PathBuf::from("/co/sdk/streamlib-python"),
+            deno_sdk_entrypoint_path: PathBuf::from("/co/sdk/streamlib-deno/mod.ts"),
+        };
+        assert_eq!(
+            resolve_deno_extractor_source(None, Some(&link), "9.9.9"),
+            DenoExtractorSource::LocalScript(PathBuf::from(
+                "/co/sdk/streamlib-deno/extract_processors.ts"
+            )),
+            "an active link must resolve the checkout's extract_processors.ts sibling",
+        );
+
+        assert_eq!(
+            resolve_deno_extractor_source(None, None, "9.9.9"),
+            DenoExtractorSource::PublishedNpm {
+                sdk_version: "9.9.9".to_string()
+            },
+            "off-link with no override must resolve the npm-published SDK by pinned version",
+        );
+
+        // The override outranks a present link.
+        assert_eq!(
+            resolve_deno_extractor_source(
+                Some(PathBuf::from("/env/extract_processors.ts")),
+                Some(&link),
+                "9.9.9"
+            ),
+            DenoExtractorSource::LocalScript(PathBuf::from("/env/extract_processors.ts")),
+            "the env override must outrank a present link",
+        );
     }
 
     #[test]
@@ -706,7 +793,9 @@ mod tests {
         let extractor = SessionSourceExtractor {
             venv_python: python3,
             deno_binary: "deno".to_string(),
-            deno_extractor_script: None,
+            deno_extractor_source: DenoExtractorSource::PublishedNpm {
+                sdk_version: env!("CARGO_PKG_VERSION").to_string(),
+            },
             deno_config: dir.path().join("deno.json"),
         };
 


### PR DESCRIPTION
Closes #1423

## Summary

Adds RuntimeOpsVTable v3: two new runtime ops — `register_processor_source` and
`replace_processor` — that let a live caller submit Python/TypeScript processor
source and have the engine stage it into a `@session/<name>@0.0.N` package,
build it through the existing `add_module_with(Strategy::Path)` seam, and
commit it into the registry, without a `streamlib pkg build` round-trip.

- **v3 vtable + wire ops** (`5a946d3e`, `5803a30e`): two new fn-pointer slots at
  the reserved seam after `drop_handle` (offsets 64/72),
  `RUNTIME_OPS_VTABLE_LAYOUT_VERSION` 2→3. Host callbacks decode msgpack,
  run under `run_host_extern_c` + `CompletionGuard`, drive new
  `RuntimeOperations::register_processor_source_async` /
  `replace_processor_async` on `Runner` (host-direct) and `RuntimeOpsShim`
  (cdylib dispatch). New `AddModuleError` variants for the live-submit paths.
  Rust-from-source is explicitly refused (a full cargo build is the `streamlib
  pkg build` flow, not a live graph mutation).
- **Vtable layout pin fix** (`4bb576cb`): the v3 bump had left a second layout
  lock (`host_services_layout_versions_pinned`) asserting the old value 2.
- **Transactional replace + staging precursor** (`ab6b261e`): stage a
  `pyproject.toml` / `deno.json` beside submitted source so the build
  orchestrator's venv/Deno provision tail has a project to resolve the SDK
  from. `replace_processor_from_source` is now transactional via
  compensation — pre-validate, pre-stage the replacement, remove the target,
  load the replacement, and on failure restore the target's exact prior
  `ModuleIdent` from its still-present staged source; the old staged dir is
  deleted only after the new registration commits.
- **DRY refactor** (`912a87bb`): collapsed the five single-payload runtime-op
  host bodies into `host_rov_submit_single_msgpack`, and the shim bodies into
  `submit_msgpack`. Real duplication, called out, behavior-preserving.
- **Real ports producer** (`5fc67f06`): a live Python/Deno submit no longer
  registers portless. `streamlib-processor-extract` gains a full-fidelity
  `parse_subprocess_manifest_json_full` projection; the build orchestrator
  runs the language's extractor over the staged source after
  venv/Deno-provisioning and before the atomic rename, splicing real
  ports/execution/scheduling/description into the staged manifest for both
  Python and Deno. A spawn/exit/malformed failure is a hard `BuildError`
  (never silent empty ports).
- **Register/replace receipt** (`3637c1a8`): the v3 SUCCESS payload grows from
  a bare `ModuleIdent` to a `RegisterProcessorReceipt` carrying the minted
  ident plus each installed processor's committed ports (name, schema id,
  input delivery profile), built from the committed `ProcessorDescriptor`s
  post-commit — so a live-submit caller learns connectable ports without a
  second graph round-trip. Payload-only; no vtable/layout change.
- **Follow-up round** (`9970a3fd` and preceding fix commits): resolves the
  should-fix items from the first review pass — bare-name schema resolution
  for concrete (non-`any`) session ports now works end-to-end, off-link Deno
  hard-fails instead of silently registering portless, a successful
  replace-bump is now driven by a real test, session versioning reconciles
  against a surviving on-disk version on restart, and the parallel
  `pascal_case` helper was deleted in favor of the shared
  `streamlib_processor_schema::to_pascal_case`. See "Review items" below for
  the verification detail on each.

## Test evidence

Local `cargo test --lib` on the touched crates, all green:

```
streamlib-plugin-abi:          37 passed; 0 failed
streamlib-engine:             1685+ passed; 0 failed; 128 ignored (GPU/live-only, per project CI strategy)
streamlib-build-orchestrator:   77 passed; 0 failed
streamlib-processor-extract:    62 passed; 0 failed
streamlib-api-server:           14 passed; 0 failed
```

Coverage highlights: vtable layout regression (v3, 80 bytes) + both layout
locks pinned; null-handle guards for both new slots; positive + invalid-args
msgpack round-trips; hermetic staging/mint/rollback tests for
register-from-source; transactional-replace tests (no-orchestrator residue,
unregistered-target remove error, transactional restore lock, ports lock,
add_local refusal); injectable-splice ports tests (real ports spliced,
hard-fail on extractor failure); msgpack receipt round-trip covering Any +
Specific ports and a delivery profile; a real happy-path replace-bump test
(`replace_bumps_the_version_and_swaps_the_registration`); a real engine
resolver test driving a concrete `@tatolab/core/VideoFrame@1.0.0` port through
`ProjectConfig::load_with_link`
(`extracted_schema_port_rebinds_to_a_specific_ident`); a stale-on-disk-session
mint-reconcile test (`mint_reconciles_above_a_surviving_on_disk_session_version`).

All lenses cleared this branch in `verify-change`.

The live venv → extract → connect end-to-end is deferred to `/verify-live` per
project CI strategy (sandboxed sessions can't observe the GPU/IPC runtime; no
live-rig run was performed for this PR).

## Review items (non-blocking)

These survived independent verification lenses. None block merge; the owner
should triage before or shortly after merging.

1. **[info]** `tools/streamlib-build-orchestrator/src/session_ports.rs:909` —
   Item 4 (concrete non-`any` port schema fails load-time bare-name
   resolution) is resolved.
   Evidence: `apply_extracted_to_manifest`/`splice_schema_bindings` now
   synthesizes `schemas:` (bare Type -> @org/pkg) + `dependencies:` (@org/pkg
   -> version) maps from the extracted ports' full idents. Test
   `extracted_schema_port_rebinds_to_a_specific_ident` (line 909) stages a
   Widget with a full `@tatolab/core/VideoFrame@1.0.0` output, runs the
   splice, then drives the REAL engine resolver
   `ProjectConfig::load_with_link` over a zero-registry checkout and asserts
   the port rebinds bare Named -> Specific `@tatolab/core/VideoFrame@1.0.0`.
   Mentally reverting `splice_schema_bindings` drops the maps and
   `load_with_link`'s `.expect` fails — non-vacuous. Passed. Covers the exact
   resolver seam that failed (not full runtime register end-to-end, but the
   load-time resolution that was broken).
   Suggested next step: None — resolved at the seam that failed.

2. **[info]** `tools/streamlib-build-orchestrator/src/session_ports.rs:137` —
   Items 2/3 (off-link Deno silently registers portless via
   `ExtractorUnconfigured` -> `Ok(None)`) are resolved.
   Evidence: `run_language_extractor` now maps EVERY `DeriveError` to a hard
   `BuildError` via `map_extract_err`; the `Ok(None)` bounded-skip is gone.
   `resolve_deno_extractor_source` resolves the off-link extractor to
   `npm:@tatolab/streamlib-deno@<sdk_version>/extract_processors.ts` (version
   from `build.rs` `STREAMLIB_DENO_SDK_VERSION`), mirroring off-link Python.
   Tests `deno_extractor_error_hard_fails_the_splice` and
   `extractor_failure_is_a_hard_build_error_not_empty_ports` pass.
   Suggested next step: None — live venv->extract->connect deferred to
   `/verify-live` per project CI strategy (sandbox exit 144).

3. **[info]** `runtime/streamlib-engine/src/core/runtime/module_loader/from_source.rs:1164` —
   Item 1 (no successful replace-bump test) and Item 13 (session version
   resets on restart) are resolved.
   Evidence: `replace_bumps_the_version_and_swaps_the_registration` (1164)
   drives a real happy-path replace: asserts bumped version > original, old
   ident unregistered, new registered, and step-6 staged-dir housekeeping ran.
   `mint_reconciles_above_a_surviving_on_disk_session_version` (1243) plants a
   stale `0.0.424242` dir and asserts a fresh mint lands above it without
   wiping — locking `mint_session_module_ident_above_on_disk`. Both
   non-vacuous and passing.
   Suggested next step: None.

4. **[info]** `runtime/streamlib-engine/src/core/runtime/module_loader/from_source.rs:301` —
   Item 5 (parallel `pascal_case` helper) resolved.
   Evidence: Private `pascal_case` deleted; call site at `from_source.rs:301`
   now uses `streamlib_processor_schema::to_pascal_case`, and the test
   `requested_name_projects_to_a_pascal_type_via_shared_helper` (562) asserts
   against it. No `fn pascal_case` remains in the file.
   Suggested next step: None.

5. **[info]** `runtime/streamlib-engine/src/core/context/runtime_ops_shim.rs:380` —
   Item 6 (unit-op decode contract had no CI-runnable lock) resolved as
   agreed, but the added test does not fail on reverting the production
   change.
   Evidence: `unit_op_completion_payload_round_trips_through_msgpack` (380)
   locks `from_slice::<()>(to_vec_named(&()))==Ok(())`. Its own doc admits:
   reverting the unit ops to a no-decode path still passes this test. The
   full shim->host round-trip only runs against a live loaded plugin (not
   lib-testable in sandbox). The applied remediation matches the prior
   verify's suggested next step exactly; the DRY refactor is
   behavior-preserving. Acceptable coverage boundary for a should-fix, not a
   blocker.
   Suggested next step: Accept as the CI-testable half; live round-trip stays
   a `/verify-live` concern.

6. **[low]** `runtime/streamlib-engine/src/core/runtime/operations.rs:103` —
   A tracker ref (`filed #1424`) sits in a versioned source rustdoc.
   Evidence: `operations.rs:103` rustdoc reads "...so a live-submit caller
   (filed #1424) learns the connectable ports". Versioned files should
   describe shipped state without issue/PR numbers (arch-docs-merged-only
   spirit; refs go stale). Introduced in this delta.
   Suggested next step: Drop `(filed #1424)` from the rustdoc; it adds
   nothing the code doesn't show.

7. **[low]** `runtime/streamlib-engine/src/core/runtime/operations.rs:98` —
   `RegisterProcessorReceipt` carries a 3-paragraph rustdoc essay against the
   one-line-doc comments rule.
   Evidence: `operations.rs:98-111` is a multi-paragraph rustdoc (receipt
   shape + payload-only-growth rationale + serde-stability note).
   `.claude/rules/comments.md`: give each public item a one-line doc; don't
   write multi-paragraph rustdoc essays; decision rationale belongs in the
   PR, not the comment. The ABI/wire-contract sentence (serde-stable across
   the plugin ABI) legitimately stays; the payload-growth narration does not.
   Suggested next step: Trim to a one-line doc plus the single wire-contract
   line; move the growth rationale to the PR body.

8. **[info]** `packages/api-server/src/handlers.rs:517` —
   The `RuntimeOperations` trait grew two methods; all implementors updated,
   no compile regression.
   Evidence: Three impls exist (`RuntimeOpsShim`, `Runner`, test-only
   `AlwaysOkStubRuntime`) — all touched in the diff. api-server's stub was
   the rebase-surfaced E0046; fixed in commit `9970a3fd`.
   `cargo test --lib -p streamlib-api-server` = 14 passed / 0 failed. Full
   5-crate battery exit 0.
   Suggested next step: None.---

## ✅ Review-items resolution (2026-07-21) — supersedes the "Review items" list above

All 14 items from the pre-fix verify list are addressed; the branch was independently re-verified **PASS** and rebased onto `origin/main` (0.7.21).

- **#1** replace-bump — happy-path test `replace_bumps_the_version_and_swaps_the_registration` (asserts version bump, old ident gone, new registered, staged-dir housekeeping).
- **#2 / #3** off-link Deno — `ExtractorUnconfigured` is now a hard `BuildError` (no silent portless), and the off-link extractor resolves via `npm:@tatolab/streamlib-deno@<sdk_version>/extract_processors.ts`, pinned to the **Deno SDK's own** version (baked from `sdk/streamlib-deno/deno.json` via `build.rs`, with a skew-guard test), mirroring off-link Python. Live `deno run npm:` extraction → `/verify-live` (rig-gated).
- **#4** concrete (non-`any`) ports — the splice synthesizes `schemas:`/`dependencies:` maps; `extracted_schema_port_rebinds_to_a_specific_ident` drives the real engine resolver and asserts bare `Named` → `Specific`.
- **#5** `pascal_case` → shared `to_pascal_case`. **#7 / #10** receipt rustdoc reworded/trimmed. **#11** `.cloned()`. **#12** covered by #4's resolver test. **#14** vtable-tail convention (sound, no action).
- **#13** session version counter — replaced the process-global reset with a **mint-time on-disk reconcile** (`mint_session_module_ident_above_on_disk`), so a restart mints above any surviving staging dir without a destructive tree wipe (avoids clobbering a concurrent process's replace-restore artifacts).
- **#6** unit-op decode — the CI-testable half is locked; the full shim→host round-trip is a `/verify-live` concern (noted honestly, not overclaimed).
- **#8 [report-only]** `clippy::result_large_err` — the tree-wide core `Error`-enum pattern; **intentionally not auto-fixed** per engine doctrine (report, don't touch an unrelated workspace-wide lint).

Also fixed during integration: rebased onto 0.7.21 (release-please #1490 after #1488 merged); and the `RuntimeOperations` trait grew two methods, so its test-stub implementor in `api-server` (`AlwaysOkStubRuntime`, arrived via #1488) was updated — `cargo build/test -p streamlib-api-server` green.

_Note: `pascal_case`→`to_pascal_case` is a benign behavioral delta (space/Unicode vs `.`/ascii) unreachable for the kebab `@session/<name>` grammar. The unit-op decode test documents the nil-decode contract but does not lock the production submit path (that's a `/verify-live` concern)._