### PR TITLE
feat(packages): api-server POST /api/processor/source + replace endpoints

### DIFF
--- a/packages/api-server/src/handlers.rs
+++ b/packages/api-server/src/handlers.rs
@@ -1,21 +1,23 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! HTTP + WebSocket handlers backing the routes declared in [`crate::routes`].
+//! HTTP + WebSocket handlers, wired into the router by [`build_router`].
 
 use axum::{
-    extract::ws::{Message, WebSocket, WebSocketUpgrade},
+    Json, Router,
     extract::Path,
     extract::State,
+    extract::ws::{Message, WebSocket, WebSocketUpgrade},
     http::StatusCode,
     response::IntoResponse,
     routing::get,
-    Json, Router,
 };
 use futures_util::{SinkExt, StreamExt};
 use parking_lot::Mutex;
 use std::sync::Arc;
-use streamlib::sdk::descriptors::{Org, Package, SchemaIdent, SemVer, TypeName};
+use streamlib::sdk::descriptors::{
+    ModuleIdent, Org, Package, SchemaIdent, SemVer, SemVerRange, TypeName,
+};
 use streamlib::sdk::error::{Error, Result};
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::json_schema::{
@@ -24,8 +26,11 @@ use streamlib::sdk::json_schema::{
 };
 use streamlib::sdk::processors::PROCESSOR_REGISTRY;
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib::sdk::pubsub::{topics, Event, EventListener, PUBSUB};
-use streamlib::sdk::runtime::RuntimeOperations;
+use streamlib::sdk::pubsub::{Event, EventListener, PUBSUB, topics};
+use streamlib::sdk::runtime::{
+    RegisterProcessorReceipt, ReplaceProcessorFromSource, RuntimeOperations,
+    SubmittedProcessorSource,
+};
 use tower_http::trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer};
 use tracing::Level;
 use utoipa::OpenApi;
@@ -34,8 +39,15 @@ use utoipa_axum::{router::OpenApiRouter, routes};
 use crate::auth::{ApiServerBearerToken, ForbiddenResponse, UnauthorizedResponse};
 use crate::state::{
     ApiDoc, AppState, CreateConnectionRequest, CreateProcessorRequest, ErrorResponse, IdResponse,
-    ProcessorNotFoundResponse, ProcessorPortNotFoundResponse, UnknownProcessorTypeResponse,
+    ProcessorNotFoundResponse, ProcessorPortNotFoundResponse, RegisterProcessorSourceResponse,
+    RegisteredPortResponse, RegisteredProcessorPortsResponse, ReplaceProcessorSourceRequest,
+    SourceProcessorPortRole, SubmittedProcessorSourceRequest, UnknownProcessorTypeResponse,
 };
+
+/// The relative WebSocket URL carrying this runtime's live event stream — the
+/// route registered in [`build_router`]. Returned in the source-submit
+/// response so a client learns where to observe the new instance's live state.
+const RUNTIME_EVENTS_URL: &str = "/ws/events";
 
 // ============================================================================
 // Router Construction
@@ -43,14 +55,16 @@ use crate::state::{
 
 /// Build the full router with shared state and trace layer attached.
 ///
-/// The four mutating routes (`POST /api/processor`, `DELETE
-/// /api/processors/{id}`, `POST /api/connections`, `DELETE
-/// /api/connections/{id}`) sit behind the bearer-token auth middleware only
-/// when `auth_token` is `Some` (auth opted in); with `None` — the
-/// zero-ceremony default — they are open like every other route. The GET
-/// routes, health check, WebSocket event stream, and OpenAPI spec are always
-/// open. `route_layer` binds the auth layer to exactly the routes already on
-/// the protected sub-router, so a later `merge` leaves the open routes ungated.
+/// The mutating routes (`POST /api/processor`, `POST /api/processor/source`,
+/// `POST /api/processor/source/replace`, `DELETE /api/processors/{id}`, `POST
+/// /api/connections`, `DELETE /api/connections/{id}`) sit behind the
+/// bearer-token auth middleware only when `auth_token` is `Some` (auth opted
+/// in); with `None` — the zero-ceremony default — they are open like every
+/// other route. The two source-submit routes are RCE-capable (they execute
+/// submitted source), so they join this gated group. The GET routes, health
+/// check, WebSocket event stream, and OpenAPI spec are always open.
+/// `route_layer` binds the auth layer to exactly the routes already on the
+/// protected sub-router, so a later `merge` leaves the open routes ungated.
 pub(crate) fn build_router(
     runtime: Arc<dyn RuntimeOperations>,
     auth_token: Option<ApiServerBearerToken>,
@@ -58,6 +72,8 @@ pub(crate) fn build_router(
 ) -> Router {
     let mut protected = OpenApiRouter::new()
         .routes(routes!(create_processor))
+        .routes(routes!(create_processor_source))
+        .routes(routes!(replace_processor_source))
         .routes(routes!(delete_processor))
         .routes(routes!(create_connection))
         .routes(routes!(delete_connection));
@@ -186,11 +202,7 @@ pub(crate) async fn create_processor(
     let spec = ProcessorSpec::new(ident, body.config);
 
     match state.runtime.add_processor_async(spec).await {
-        Ok(id) => (
-            StatusCode::OK,
-            Json(IdResponse { id: id.to_string() }),
-        )
-            .into_response(),
+        Ok(id) => (StatusCode::OK, Json(IdResponse { id: id.to_string() })).into_response(),
         Err(Error::UnknownProcessorType { ident: _ }) => (
             StatusCode::UNPROCESSABLE_ENTITY,
             Json(UnknownProcessorTypeResponse {
@@ -206,6 +218,285 @@ pub(crate) async fn create_processor(
             }),
         )
             .into_response(),
+    }
+}
+
+/// Project a register/replace receipt's committed ports onto the wire
+/// response shape (`schema` rendered as `"any"` or `@org/package/Type@version`).
+fn project_receipt_ports(
+    receipt: &RegisterProcessorReceipt,
+) -> Vec<RegisteredProcessorPortsResponse> {
+    let project = |ports: &[streamlib::sdk::runtime::RegisteredPortReceipt]| {
+        ports
+            .iter()
+            .map(|port| RegisteredPortResponse {
+                name: port.name.clone(),
+                schema: port.schema.to_string(),
+                delivery_profile: port.delivery_profile.clone(),
+            })
+            .collect()
+    };
+    receipt
+        .processors
+        .iter()
+        .map(|processor| RegisteredProcessorPortsResponse {
+            name: processor.name.clone(),
+            inputs: project(&processor.inputs),
+            outputs: project(&processor.outputs),
+        })
+        .collect()
+}
+
+/// The concrete [`SemVer`] a session-module range pins. Session registrations
+/// mint an `Exact` range, so the other range shapes fall back to their lower
+/// bound and only a wildcard `Any` (never minted for a session) yields `None`.
+fn pinned_version(range: &SemVerRange) -> Option<SemVer> {
+    match range {
+        SemVerRange::Exact(version)
+        | SemVerRange::AtLeast(version)
+        | SemVerRange::Caret(version)
+        | SemVerRange::Tilde(version) => Some(version.clone()),
+        SemVerRange::Any => None,
+    }
+}
+
+/// Build the instantiable [`SchemaIdent`] for a discovered processor `type_name`
+/// under the receipt's minted `@org/name@0.0.N` registration module.
+fn session_processor_ident(module: &ModuleIdent, type_name: &str) -> Option<SchemaIdent> {
+    let r#type = TypeName::new(type_name.to_string()).ok()?;
+    let version = pinned_version(&module.version)?;
+    Some(SchemaIdent::new(
+        module.org.clone(),
+        module.name.clone(),
+        r#type,
+        version,
+    ))
+}
+
+/// Map a register/replace-from-source [`Error`] onto an HTTP response. The
+/// source-submit refusals (unsupported language, missing name, un-mintable
+/// name, build failure, replace-target mismatch) surface as
+/// [`Error::Configuration`] — the JSON request was well-formed but the
+/// submitted source could not be registered — so they map to 422; a runtime
+/// failure (including a catastrophic replace where restoring the prior
+/// registration also failed) maps to 500.
+fn source_submit_error_response(error: Error) -> axum::response::Response {
+    let status = match error {
+        Error::Configuration(_) => StatusCode::UNPROCESSABLE_ENTITY,
+        Error::Runtime(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        _ => StatusCode::BAD_REQUEST,
+    };
+    (
+        status,
+        Json(ErrorResponse {
+            error: error.to_string(),
+        }),
+    )
+        .into_response()
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/processor/source",
+    tag = "processors",
+    request_body = SubmittedProcessorSourceRequest,
+    responses(
+        (status = 200, description = "Source registered, first discovered processor instantiated, and optional connections wired; body carries the minted registration ident, discovered ports, instance id, and connection ids", body = RegisterProcessorSourceResponse),
+        (status = 400, description = "A referenced peer processor/port for a `connect` wiring is malformed", body = ErrorResponse),
+        (status = 401, description = "Missing or malformed bearer token", body = UnauthorizedResponse),
+        (status = 403, description = "Invalid bearer token", body = ForbiddenResponse),
+        (status = 404, description = "A `connect` wiring references a peer processor not in the graph", body = ProcessorNotFoundResponse),
+        (status = 422, description = "The submitted source could not be registered or instantiated (unsupported language, missing name, build failure, or unknown processor type)", body = ErrorResponse),
+        (status = 500, description = "Runtime failure while registering the source", body = ErrorResponse)
+    )
+)]
+pub(crate) async fn create_processor_source(
+    State(state): State<AppState>,
+    Json(body): Json<SubmittedProcessorSourceRequest>,
+) -> axum::response::Response {
+    let submitted = SubmittedProcessorSource {
+        source_text: body.source,
+        language: body.language.into(),
+        requested_name: body.requested_name,
+        processor_type_name: body.processor_type_name,
+    };
+
+    let receipt = match state
+        .runtime
+        .register_processor_source_async(submitted)
+        .await
+    {
+        Ok(receipt) => receipt,
+        Err(error) => return source_submit_error_response(error),
+    };
+
+    let processors = project_receipt_ports(&receipt);
+    let module = receipt.module.to_string();
+
+    // Composite "app is code" server-side wiring: instantiate the first
+    // discovered processor, then apply the optional connect wirings.
+    let Some(first) = receipt.processors.first() else {
+        return (
+            StatusCode::OK,
+            Json(RegisterProcessorSourceResponse {
+                module,
+                processors,
+                processor_id: None,
+                state: "registered",
+                connections: Vec::new(),
+                events_url: RUNTIME_EVENTS_URL,
+            }),
+        )
+            .into_response();
+    };
+
+    let Some(ident) = session_processor_ident(&receipt.module, &first.name) else {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(ErrorResponse {
+                error: format!(
+                    "registered module `{module}` yielded an uninstantiable processor identity for type `{}`",
+                    first.name
+                ),
+            }),
+        )
+            .into_response();
+    };
+
+    let config = body.config.unwrap_or_else(|| serde_json::json!({}));
+    let processor_id = match state
+        .runtime
+        .add_processor_async(ProcessorSpec::new(ident, config))
+        .await
+    {
+        Ok(id) => id,
+        Err(Error::UnknownProcessorType { ident: _ }) => {
+            return (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(ErrorResponse {
+                    error: format!(
+                        "registered module `{module}` did not expose processor type `{}` to the runtime",
+                        first.name
+                    ),
+                }),
+            )
+                .into_response();
+        }
+        Err(error) => return source_submit_error_response(error),
+    };
+
+    let mut connections = Vec::with_capacity(body.connect.len());
+    for wiring in body.connect {
+        let (from, to) = match wiring.role {
+            SourceProcessorPortRole::Output => (
+                OutputLinkPortRef::new(processor_id.clone(), wiring.local_port),
+                InputLinkPortRef::new(wiring.peer_processor, wiring.peer_port),
+            ),
+            SourceProcessorPortRole::Input => (
+                OutputLinkPortRef::new(wiring.peer_processor, wiring.peer_port),
+                InputLinkPortRef::new(processor_id.clone(), wiring.local_port),
+            ),
+        };
+        match state.runtime.connect_async(from, to).await {
+            Ok(link_id) => connections.push(link_id.to_string()),
+            Err(Error::ProcessorNotFound(peer)) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(ProcessorNotFoundResponse {
+                        error: "ProcessorNotFound",
+                        processor_id: peer,
+                    }),
+                )
+                    .into_response();
+            }
+            Err(error) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse {
+                        error: error.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        }
+    }
+
+    (
+        StatusCode::OK,
+        Json(RegisterProcessorSourceResponse {
+            module,
+            processors,
+            processor_id: Some(processor_id.to_string()),
+            state: "added",
+            connections,
+            events_url: RUNTIME_EVENTS_URL,
+        }),
+    )
+        .into_response()
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/processor/source/replace",
+    tag = "processors",
+    request_body = ReplaceProcessorSourceRequest,
+    responses(
+        (status = 200, description = "Prior `@session/<name>` registration replaced; body carries the new registration ident and discovered ports (type-level replacement — running graph instances are not swapped)", body = RegisterProcessorSourceResponse),
+        (status = 400, description = "`target_session_module` is not a valid `@org/name@<range>` module ident", body = ErrorResponse),
+        (status = 401, description = "Missing or malformed bearer token", body = UnauthorizedResponse),
+        (status = 403, description = "Invalid bearer token", body = ForbiddenResponse),
+        (status = 422, description = "The replacement source could not be registered, or its name does not resolve to the target's `@session/<name>`", body = ErrorResponse),
+        (status = 500, description = "Runtime failure while replacing (including a replacement that failed and could not restore the prior registration)", body = ErrorResponse)
+    )
+)]
+pub(crate) async fn replace_processor_source(
+    State(state): State<AppState>,
+    Json(body): Json<ReplaceProcessorSourceRequest>,
+) -> axum::response::Response {
+    use serde::{Deserialize, de::IntoDeserializer};
+    let target_session_module: ModuleIdent = match ModuleIdent::deserialize(
+        body.target_session_module.as_str().into_deserializer(),
+    ) {
+        Ok(module) => module,
+        Err(error) => {
+            let error: serde::de::value::Error = error;
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "target_session_module `{}` is not a valid `@org/name@<range>` module ident: {error}",
+                        body.target_session_module
+                    ),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    let request = ReplaceProcessorFromSource {
+        target_session_module,
+        replacement: SubmittedProcessorSource {
+            source_text: body.source,
+            language: body.language.into(),
+            requested_name: body.requested_name,
+            processor_type_name: body.processor_type_name,
+        },
+    };
+
+    match state.runtime.replace_processor_async(request).await {
+        Ok(receipt) => (
+            StatusCode::OK,
+            Json(RegisterProcessorSourceResponse {
+                module: receipt.module.to_string(),
+                processors: project_receipt_ports(&receipt),
+                processor_id: None,
+                state: "registered",
+                connections: Vec::new(),
+                events_url: RUNTIME_EVENTS_URL,
+            }),
+        )
+            .into_response(),
+        Err(error) => source_submit_error_response(error),
     }
 }
 
@@ -258,11 +549,7 @@ pub(crate) async fn create_connection(
     let to = InputLinkPortRef::new(body.to_processor, body.to_port);
 
     match state.runtime.connect_async(from, to).await {
-        Ok(id) => (
-            StatusCode::OK,
-            Json(IdResponse { id: id.to_string() }),
-        )
-            .into_response(),
+        Ok(id) => (StatusCode::OK, Json(IdResponse { id: id.to_string() })).into_response(),
         Err(Error::ProcessorNotFound(processor_id)) => (
             StatusCode::NOT_FOUND,
             Json(ProcessorNotFoundResponse {
@@ -494,13 +781,15 @@ mod router_auth_gate_tests {
     use super::*;
     use axum::body::Body;
     use axum::http::{
-        header::{AUTHORIZATION, CONTENT_TYPE},
         Request, StatusCode,
+        header::{AUTHORIZATION, CONTENT_TYPE},
     };
     use streamlib::sdk::descriptors::{ModuleIdent, SemVerRange};
     use streamlib::sdk::graph::{LinkUniqueId, ProcessorUniqueId};
+    use streamlib::sdk::processors::PortSchemaSpec;
     use streamlib::sdk::runtime::{
-        BoxFuture, RegisterProcessorReceipt, ReplaceProcessorFromSource, SubmittedProcessorSource,
+        BoxFuture, RegisterProcessorReceipt, RegisteredPortReceipt, RegisteredProcessorReceipt,
+        ReplaceProcessorFromSource, SubmittedProcessorSource,
     };
     use tower::ServiceExt;
 
@@ -569,10 +858,12 @@ mod router_auth_gate_tests {
         }
     }
 
-    /// A minimal always-succeeds register/replace receipt for [`AlwaysOkStubRuntime`]:
-    /// a dummy `@session/stub` registration ident with no installed processors.
-    /// The register-from-source path is not exercised by the auth-gate tests, so
-    /// the port surface is empty.
+    /// An always-succeeds register/replace receipt for [`AlwaysOkStubRuntime`]:
+    /// a `@session/stub@0.0.0` registration installing one `Widget` processor
+    /// with a `video` input (`any`) and a `frame` output (a specific
+    /// `@tatolab/core/VideoFrame@1.0.0`). Non-empty so the source-submit
+    /// composite reaches its instantiate step and the port projection is
+    /// exercised; the auth-gate tests ignore the body.
     fn stub_register_receipt() -> RegisterProcessorReceipt {
         RegisterProcessorReceipt::new(
             ModuleIdent::new(
@@ -580,7 +871,24 @@ mod router_auth_gate_tests {
                 Package::new("stub").expect("stub package passes the package grammar"),
                 SemVerRange::Exact(SemVer::new(0, 0, 0)),
             ),
-            vec![],
+            vec![RegisteredProcessorReceipt {
+                name: "Widget".to_string(),
+                inputs: vec![RegisteredPortReceipt {
+                    name: "video".to_string(),
+                    schema: PortSchemaSpec::Any,
+                    delivery_profile: Some("latest".to_string()),
+                }],
+                outputs: vec![RegisteredPortReceipt {
+                    name: "frame".to_string(),
+                    schema: PortSchemaSpec::Specific(SchemaIdent::new(
+                        Org::new("tatolab").expect("tatolab org passes the grammar"),
+                        Package::new("core").expect("core package passes the grammar"),
+                        TypeName::new("VideoFrame").expect("VideoFrame type name is valid"),
+                        SemVer::new(1, 0, 0),
+                    )),
+                    delivery_profile: None,
+                }],
+            }],
         )
     }
 
@@ -643,8 +951,39 @@ mod router_auth_gate_tests {
         )
     }
 
+    fn create_processor_source_body() -> Body {
+        Body::from(
+            serde_json::json!({
+                "language": "python",
+                "source": "class Widget:\n    pass\n",
+                "requested_name": "widget"
+            })
+            .to_string(),
+        )
+    }
+
+    fn replace_processor_source_body() -> Body {
+        Body::from(
+            serde_json::json!({
+                "target_session_module": "@session/widget@*",
+                "language": "python",
+                "source": "class Widget:\n    pass\n",
+                "requested_name": "widget"
+            })
+            .to_string(),
+        )
+    }
+
     fn bearer(token: &str) -> String {
         format!("Bearer {token}")
+    }
+
+    async fn json_body_on(router: Router, request: Request<Body>) -> serde_json::Value {
+        let response = router.oneshot(request).await.unwrap();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
     }
 
     #[tokio::test]
@@ -655,6 +994,18 @@ mod router_auth_gate_tests {
                 .uri("/api/processor")
                 .header(CONTENT_TYPE, "application/json")
                 .body(create_processor_body())
+                .unwrap(),
+            Request::builder()
+                .method("POST")
+                .uri("/api/processor/source")
+                .header(CONTENT_TYPE, "application/json")
+                .body(create_processor_source_body())
+                .unwrap(),
+            Request::builder()
+                .method("POST")
+                .uri("/api/processor/source/replace")
+                .header(CONTENT_TYPE, "application/json")
+                .body(replace_processor_source_body())
                 .unwrap(),
             Request::builder()
                 .method("POST")
@@ -688,6 +1039,122 @@ mod router_auth_gate_tests {
             .body(create_processor_body())
             .unwrap();
         assert_eq!(status_of(request).await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn create_processor_source_returns_discovered_ports_and_instance() {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/processor/source")
+            .header(AUTHORIZATION, bearer(TEST_TOKEN))
+            .header(CONTENT_TYPE, "application/json")
+            .body(create_processor_source_body())
+            .unwrap();
+        let body = json_body_on(auth_enabled_router(), request).await;
+
+        assert_eq!(body["module"], "@session/stub@=0.0.0");
+        assert_eq!(body["state"], "added");
+        assert!(
+            body["processor_id"].is_string(),
+            "the composite must instantiate the first discovered processor and return its id"
+        );
+        assert_eq!(body["events_url"], "/ws/events");
+
+        let processors = body["processors"].as_array().expect("processors array");
+        assert_eq!(processors.len(), 1);
+        assert_eq!(processors[0]["name"], "Widget");
+        assert_eq!(processors[0]["inputs"][0]["name"], "video");
+        assert_eq!(processors[0]["inputs"][0]["schema"], "any");
+        assert_eq!(processors[0]["inputs"][0]["delivery_profile"], "latest");
+        assert_eq!(processors[0]["outputs"][0]["name"], "frame");
+        assert_eq!(
+            processors[0]["outputs"][0]["schema"],
+            "@tatolab/core/VideoFrame@1.0.0"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_processor_source_wires_optional_connections() {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/processor/source")
+            .header(AUTHORIZATION, bearer(TEST_TOKEN))
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                serde_json::json!({
+                    "language": "python",
+                    "source": "class Widget:\n    pass\n",
+                    "requested_name": "widget",
+                    "connect": [{
+                        "local_port": "frame",
+                        "role": "output",
+                        "peer_processor": "display-1",
+                        "peer_port": "video"
+                    }]
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        let body = json_body_on(auth_enabled_router(), request).await;
+
+        let connections = body["connections"].as_array().expect("connections array");
+        assert_eq!(
+            connections.len(),
+            1,
+            "the single requested wiring must produce one link id"
+        );
+        assert!(connections[0].is_string());
+    }
+
+    #[tokio::test]
+    async fn replace_processor_source_with_token_is_200() {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/processor/source/replace")
+            .header(AUTHORIZATION, bearer(TEST_TOKEN))
+            .header(CONTENT_TYPE, "application/json")
+            .body(replace_processor_source_body())
+            .unwrap();
+        assert_eq!(status_of(request).await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn replace_processor_source_rejects_malformed_target_module_with_400() {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/processor/source/replace")
+            .header(AUTHORIZATION, bearer(TEST_TOKEN))
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                serde_json::json!({
+                    "target_session_module": "not-a-module-ident",
+                    "language": "python",
+                    "source": "class Widget:\n    pass\n",
+                    "requested_name": "widget"
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        assert_eq!(status_of(request).await, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn source_routes_are_documented_in_the_openapi_spec() {
+        let request = Request::builder()
+            .method("GET")
+            .uri("/api/openapi.json")
+            .body(Body::empty())
+            .unwrap();
+        let spec = json_body_on(auth_enabled_router(), request).await;
+        let paths = &spec["paths"];
+        assert!(
+            paths["/api/processor/source"]["post"].is_object(),
+            "POST /api/processor/source must appear in the OpenAPI spec"
+        );
+        assert!(
+            paths["/api/processor/source/replace"]["post"].is_object(),
+            "POST /api/processor/source/replace must appear in the OpenAPI spec"
+        );
     }
 
     #[tokio::test]

--- a/packages/api-server/src/handlers.rs
+++ b/packages/api-server/src/handlers.rs
@@ -40,8 +40,9 @@ use crate::auth::{ApiServerBearerToken, ForbiddenResponse, UnauthorizedResponse}
 use crate::state::{
     ApiDoc, AppState, CreateConnectionRequest, CreateProcessorRequest, ErrorResponse, IdResponse,
     ProcessorNotFoundResponse, ProcessorPortNotFoundResponse, RegisterProcessorSourceResponse,
-    RegisteredPortResponse, RegisteredProcessorPortsResponse, ReplaceProcessorSourceRequest,
-    SourceProcessorPortRole, SubmittedProcessorSourceRequest, UnknownProcessorTypeResponse,
+    RegisteredPortResponse, RegisteredProcessorPortsResponse, RegistrationOutcome,
+    ReplaceProcessorSourceRequest, SourceProcessorPortRole, SubmittedProcessorSourceRequest,
+    UnknownProcessorTypeResponse,
 };
 
 /// The relative WebSocket URL carrying this runtime's live event stream — the
@@ -255,7 +256,7 @@ fn pinned_version(range: &SemVerRange) -> Option<SemVer> {
         SemVerRange::Exact(version)
         | SemVerRange::AtLeast(version)
         | SemVerRange::Caret(version)
-        | SemVerRange::Tilde(version) => Some(version.clone()),
+        | SemVerRange::Tilde(version) => Some(*version),
         SemVerRange::Any => None,
     }
 }
@@ -295,6 +296,48 @@ fn source_submit_error_response(error: Error) -> axum::response::Response {
         .into_response()
 }
 
+/// Map a `connect`/link [`Error`] onto an HTTP response, shared by
+/// [`create_connection`] and the source-submit composite wiring loop so both
+/// endpoints answer connect failures identically: a missing peer processor →
+/// 404 ([`ProcessorNotFoundResponse`]), a missing port on an existing processor
+/// → 422 ([`ProcessorPortNotFoundResponse`]), anything else → 400.
+fn connect_error_response(error: Error) -> axum::response::Response {
+    match error {
+        Error::ProcessorNotFound(processor_id) => (
+            StatusCode::NOT_FOUND,
+            Json(ProcessorNotFoundResponse {
+                error: "ProcessorNotFound",
+                processor_id,
+            }),
+        )
+            .into_response(),
+        Error::ProcessorPortNotFound {
+            processor_id,
+            port_name,
+            direction,
+        } => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(ProcessorPortNotFoundResponse {
+                error: "ProcessorPortNotFound",
+                processor_id,
+                port_name,
+                direction: match direction {
+                    streamlib::sdk::error::PortDirection::Input => "input",
+                    streamlib::sdk::error::PortDirection::Output => "output",
+                },
+            }),
+        )
+            .into_response(),
+        other => (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: other.to_string(),
+            }),
+        )
+            .into_response(),
+    }
+}
+
 #[utoipa::path(
     post,
     path = "/api/processor/source",
@@ -302,11 +345,11 @@ fn source_submit_error_response(error: Error) -> axum::response::Response {
     request_body = SubmittedProcessorSourceRequest,
     responses(
         (status = 200, description = "Source registered, first discovered processor instantiated, and optional connections wired; body carries the minted registration ident, discovered ports, instance id, and connection ids", body = RegisterProcessorSourceResponse),
-        (status = 400, description = "A referenced peer processor/port for a `connect` wiring is malformed", body = ErrorResponse),
+        (status = 400, description = "A `connect` wiring failed for a generic graph reason (neither a missing peer processor nor a missing peer port). On any wiring failure the whole submit is rolled back — the instantiated processor and any links created earlier in the call are removed", body = ErrorResponse),
         (status = 401, description = "Missing or malformed bearer token", body = UnauthorizedResponse),
         (status = 403, description = "Invalid bearer token", body = ForbiddenResponse),
-        (status = 404, description = "A `connect` wiring references a peer processor not in the graph", body = ProcessorNotFoundResponse),
-        (status = 422, description = "The submitted source could not be registered or instantiated (unsupported language, missing name, build failure, or unknown processor type)", body = ErrorResponse),
+        (status = 404, description = "A `connect` wiring references a peer processor not in the graph (same shape as POST /api/connections)", body = ProcessorNotFoundResponse),
+        (status = 422, description = "The submitted source could not be registered or instantiated (unsupported language, missing name, build failure, unknown processor type); OR a `connect` wiring references a port that doesn't exist on an existing peer processor — the latter carries a ProcessorPortNotFoundResponse body, same shape as POST /api/connections", body = ErrorResponse),
         (status = 500, description = "Runtime failure while registering the source", body = ErrorResponse)
     )
 )]
@@ -342,7 +385,7 @@ pub(crate) async fn create_processor_source(
                 module,
                 processors,
                 processor_id: None,
-                state: "registered",
+                state: RegistrationOutcome::Registered,
                 connections: Vec::new(),
                 events_url: RUNTIME_EVENTS_URL,
             }),
@@ -385,7 +428,7 @@ pub(crate) async fn create_processor_source(
         Err(error) => return source_submit_error_response(error),
     };
 
-    let mut connections = Vec::with_capacity(body.connect.len());
+    let mut created_links = Vec::with_capacity(body.connect.len());
     for wiring in body.connect {
         let (from, to) = match wiring.role {
             SourceProcessorPortRole::Output => (
@@ -398,28 +441,28 @@ pub(crate) async fn create_processor_source(
             ),
         };
         match state.runtime.connect_async(from, to).await {
-            Ok(link_id) => connections.push(link_id.to_string()),
-            Err(Error::ProcessorNotFound(peer)) => {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(ProcessorNotFoundResponse {
-                        error: "ProcessorNotFound",
-                        processor_id: peer,
-                    }),
-                )
-                    .into_response();
-            }
+            Ok(link_id) => created_links.push(link_id),
             Err(error) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorResponse {
-                        error: error.to_string(),
-                    }),
-                )
-                    .into_response();
+                // Transactional wiring: a failed connect rolls the whole submit
+                // back — disconnect the links created earlier in this call, then
+                // remove the just-instantiated processor — so the endpoint is
+                // all-or-nothing and leaves no orphan node the caller can't reach.
+                for created_link_id in &created_links {
+                    let _ = state
+                        .runtime
+                        .disconnect_async(created_link_id.clone())
+                        .await;
+                }
+                let _ = state
+                    .runtime
+                    .remove_processor_async(processor_id.clone())
+                    .await;
+                return connect_error_response(error);
             }
         }
     }
+
+    let connections = created_links.iter().map(|id| id.to_string()).collect();
 
     (
         StatusCode::OK,
@@ -427,7 +470,7 @@ pub(crate) async fn create_processor_source(
             module,
             processors,
             processor_id: Some(processor_id.to_string()),
-            state: "added",
+            state: RegistrationOutcome::Added,
             connections,
             events_url: RUNTIME_EVENTS_URL,
         }),
@@ -490,7 +533,7 @@ pub(crate) async fn replace_processor_source(
                 module: receipt.module.to_string(),
                 processors: project_receipt_ports(&receipt),
                 processor_id: None,
-                state: "registered",
+                state: RegistrationOutcome::Registered,
                 connections: Vec::new(),
                 events_url: RUNTIME_EVENTS_URL,
             }),
@@ -550,38 +593,7 @@ pub(crate) async fn create_connection(
 
     match state.runtime.connect_async(from, to).await {
         Ok(id) => (StatusCode::OK, Json(IdResponse { id: id.to_string() })).into_response(),
-        Err(Error::ProcessorNotFound(processor_id)) => (
-            StatusCode::NOT_FOUND,
-            Json(ProcessorNotFoundResponse {
-                error: "ProcessorNotFound",
-                processor_id,
-            }),
-        )
-            .into_response(),
-        Err(Error::ProcessorPortNotFound {
-            processor_id,
-            port_name,
-            direction,
-        }) => (
-            StatusCode::UNPROCESSABLE_ENTITY,
-            Json(ProcessorPortNotFoundResponse {
-                error: "ProcessorPortNotFound",
-                processor_id,
-                port_name,
-                direction: match direction {
-                    streamlib::sdk::error::PortDirection::Input => "input",
-                    streamlib::sdk::error::PortDirection::Output => "output",
-                },
-            }),
-        )
-            .into_response(),
-        Err(e) => (
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: e.to_string(),
-            }),
-        )
-            .into_response(),
+        Err(error) => connect_error_response(error),
     }
 }
 
@@ -858,6 +870,85 @@ mod router_auth_gate_tests {
         }
     }
 
+    /// Stub runtime that instantiates one fixed processor, admits the first
+    /// `connect` and fails the second with [`Error::ProcessorNotFound`], and
+    /// records every `remove_processor` / `disconnect` it receives — so a
+    /// source-submit rollback can be observed: the just-instantiated processor
+    /// leaves no orphan, and links created earlier in the same call are undone.
+    struct RollbackObservingStubRuntime {
+        instance_id: ProcessorUniqueId,
+        first_link_id: LinkUniqueId,
+        connect_calls: std::sync::atomic::AtomicUsize,
+        removed_processors: Arc<Mutex<Vec<ProcessorUniqueId>>>,
+        disconnected_links: Arc<Mutex<Vec<LinkUniqueId>>>,
+    }
+
+    impl RuntimeOperations for RollbackObservingStubRuntime {
+        fn add_processor_async(
+            &self,
+            _spec: ProcessorSpec,
+        ) -> BoxFuture<'_, Result<ProcessorUniqueId>> {
+            let id = self.instance_id.clone();
+            Box::pin(async move { Ok(id) })
+        }
+        fn remove_processor_async(
+            &self,
+            processor_id: ProcessorUniqueId,
+        ) -> BoxFuture<'_, Result<()>> {
+            self.removed_processors.lock().push(processor_id);
+            Box::pin(async { Ok(()) })
+        }
+        fn connect_async(
+            &self,
+            _from: OutputLinkPortRef,
+            _to: InputLinkPortRef,
+        ) -> BoxFuture<'_, Result<LinkUniqueId>> {
+            let call = self
+                .connect_calls
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            if call == 0 {
+                let id = self.first_link_id.clone();
+                Box::pin(async move { Ok(id) })
+            } else {
+                Box::pin(async { Err(Error::ProcessorNotFound("missing-peer".to_string())) })
+            }
+        }
+        fn disconnect_async(&self, link_id: LinkUniqueId) -> BoxFuture<'_, Result<()>> {
+            self.disconnected_links.lock().push(link_id);
+            Box::pin(async { Ok(()) })
+        }
+        fn to_json_async(&self) -> BoxFuture<'_, Result<serde_json::Value>> {
+            Box::pin(async { Ok(serde_json::json!({})) })
+        }
+        fn register_processor_source_async(
+            &self,
+            _request: SubmittedProcessorSource,
+        ) -> BoxFuture<'_, Result<RegisterProcessorReceipt>> {
+            Box::pin(async { Ok(stub_register_receipt()) })
+        }
+        fn replace_processor_async(
+            &self,
+            _request: ReplaceProcessorFromSource,
+        ) -> BoxFuture<'_, Result<RegisterProcessorReceipt>> {
+            Box::pin(async { Ok(stub_register_receipt()) })
+        }
+        fn add_processor(&self, _spec: ProcessorSpec) -> Result<ProcessorUniqueId> {
+            Ok(self.instance_id.clone())
+        }
+        fn remove_processor(&self, _processor_id: &ProcessorUniqueId) -> Result<()> {
+            Ok(())
+        }
+        fn connect(&self, _from: OutputLinkPortRef, _to: InputLinkPortRef) -> Result<LinkUniqueId> {
+            Ok(self.first_link_id.clone())
+        }
+        fn disconnect(&self, _link_id: &LinkUniqueId) -> Result<()> {
+            Ok(())
+        }
+        fn to_json(&self) -> Result<serde_json::Value> {
+            Ok(serde_json::json!({}))
+        }
+    }
+
     /// An always-succeeds register/replace receipt for [`AlwaysOkStubRuntime`]:
     /// a `@session/stub@0.0.0` registration installing one `Widget` processor
     /// with a `video` input (`any`) and a `frame` output (a specific
@@ -1104,6 +1195,93 @@ mod router_auth_gate_tests {
             "the single requested wiring must produce one link id"
         );
         assert!(connections[0].is_string());
+    }
+
+    #[tokio::test]
+    async fn create_processor_source_rolls_back_on_connect_failure() {
+        let removed_processors = Arc::new(Mutex::new(Vec::new()));
+        let disconnected_links = Arc::new(Mutex::new(Vec::new()));
+        let instance_id: ProcessorUniqueId = "orphan-instance".to_string().into();
+        let first_link_id: LinkUniqueId = "link-a".to_string().into();
+        let runtime = Arc::new(RollbackObservingStubRuntime {
+            instance_id: instance_id.clone(),
+            first_link_id: first_link_id.clone(),
+            connect_calls: std::sync::atomic::AtomicUsize::new(0),
+            removed_processors: removed_processors.clone(),
+            disconnected_links: disconnected_links.clone(),
+        });
+        let router = build_router(
+            runtime,
+            None,
+            #[cfg(feature = "moq")]
+            "test-runtime-id".to_string(),
+        );
+        // The first wiring connects; the second targets a missing peer and
+        // fails — the whole submit must roll back.
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/processor/source")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                serde_json::json!({
+                    "language": "python",
+                    "source": "class Widget:\n    pass\n",
+                    "requested_name": "widget",
+                    "connect": [
+                        {
+                            "local_port": "frame",
+                            "role": "output",
+                            "peer_processor": "peer-a",
+                            "peer_port": "video"
+                        },
+                        {
+                            "local_port": "frame",
+                            "role": "output",
+                            "peer_processor": "missing-peer",
+                            "peer_port": "video"
+                        }
+                    ]
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let status = router.oneshot(request).await.unwrap().status();
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "a connect to a missing peer must surface as 404"
+        );
+        assert_eq!(
+            *removed_processors.lock(),
+            vec![instance_id],
+            "rollback must remove the just-instantiated processor so no orphan is left in the graph"
+        );
+        assert_eq!(
+            *disconnected_links.lock(),
+            vec![first_link_id],
+            "rollback must disconnect links created earlier in the same submit"
+        );
+    }
+
+    #[tokio::test]
+    async fn processor_language_schema_advertises_deno_alias() {
+        let request = Request::builder()
+            .method("GET")
+            .uri("/api/openapi.json")
+            .body(Body::empty())
+            .unwrap();
+        let spec = json_body_on(auth_enabled_router(), request).await;
+        let enum_values = spec["components"]["schemas"]["ProcessorLanguageDto"]["enum"]
+            .as_array()
+            .expect("ProcessorLanguageDto must be a documented enum schema");
+        let langs: Vec<&str> = enum_values.iter().filter_map(|v| v.as_str()).collect();
+        for expected in ["rust", "python", "typescript", "deno"] {
+            assert!(
+                langs.contains(&expected),
+                "OpenAPI ProcessorLanguageDto enum must advertise `{expected}`, got {langs:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/packages/api-server/src/state.rs
+++ b/packages/api-server/src/state.rs
@@ -104,7 +104,7 @@ pub(crate) struct ProcessorPortNotFoundResponse {
 /// but not `utoipa::ToSchema`. Kept identical to the SDK enum's wire form
 /// (lowercase; `deno` is accepted as an alias for `typescript`) and mapped
 /// into it on the way in.
-#[derive(Deserialize, utoipa::ToSchema)]
+#[derive(Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum ProcessorLanguageDto {
     /// Rust — rejected for live source submit (a full cargo build, not a
@@ -114,6 +114,24 @@ pub(crate) enum ProcessorLanguageDto {
     #[serde(alias = "deno")]
     TypeScript,
 }
+
+// A derived `ToSchema` would drop the `deno` alias — utoipa reads serde
+// `rename`/`rename_all` but not `alias` — leaving a spec-driven client unaware
+// `deno` is accepted. Hand-implement the schema with the same 4-value enum the
+// SDK's `ProcessorLanguage` JsonSchema advertises.
+impl utoipa::PartialSchema for ProcessorLanguageDto {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        utoipa::openapi::ObjectBuilder::new()
+            .schema_type(utoipa::openapi::schema::Type::String)
+            .description(Some(
+                "Processor runtime language. `deno` is accepted as an alias for `typescript`.",
+            ))
+            .enum_values(Some(["rust", "python", "typescript", "deno"]))
+            .into()
+    }
+}
+
+impl utoipa::ToSchema for ProcessorLanguageDto {}
 
 impl From<ProcessorLanguageDto> for ProcessorLanguage {
     fn from(dto: ProcessorLanguageDto) -> Self {
@@ -227,6 +245,18 @@ pub(crate) struct RegisteredProcessorPortsResponse {
     pub outputs: Vec<RegisteredPortResponse>,
 }
 
+/// Composite outcome of a source submit: `Added` when an instance was created
+/// into the running graph, `Registered` when only the definition was registered
+/// (no instantiable processor discovered).
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum RegistrationOutcome {
+    /// An instance was instantiated into the running graph.
+    Added,
+    /// Only the definition was registered; no instantiable processor discovered.
+    Registered,
+}
+
 /// Response to `POST /api/processor/source` and
 /// `POST /api/processor/source/replace`: the minted registration ident plus
 /// each installed processor's discovered ports, and — for a source submit —
@@ -242,11 +272,11 @@ pub(crate) struct RegisterProcessorSourceResponse {
     /// instantiated the first discovered processor into the graph.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub processor_id: Option<String>,
-    /// Composite outcome: `"added"` when an instance was created into the
-    /// running graph, `"registered"` when only the definition was registered
-    /// (no instantiable processor discovered). Live per-instance state is
-    /// observed via `GET /api/graph` and the `events_url` event stream.
-    pub state: &'static str,
+    /// Composite outcome: `added` when an instance was created into the running
+    /// graph, `registered` when only the definition was registered (no
+    /// instantiable processor discovered). Live per-instance state is observed
+    /// via `GET /api/graph` and the `events_url` event stream.
+    pub state: RegistrationOutcome,
     /// Link ids created by the optional `connect` wirings, in request order.
     pub connections: Vec<String>,
     /// The WebSocket URL carrying this runtime's live event stream.

--- a/packages/api-server/src/state.rs
+++ b/packages/api-server/src/state.rs
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use streamlib::sdk::json_schema::SchemaIdentOutput;
-use streamlib::sdk::runtime::RuntimeOperations;
+use streamlib::sdk::runtime::{ProcessorLanguage, RuntimeOperations};
 use utoipa::OpenApi;
 
 /// Shared HTTP handler state.
@@ -98,6 +98,159 @@ pub(crate) struct ProcessorPortNotFoundResponse {
     pub port_name: String,
     /// `"input"` or `"output"`.
     pub direction: &'static str,
+}
+
+/// OpenAPI-documentable mirror of [`ProcessorLanguage`], which derives serde
+/// but not `utoipa::ToSchema`. Kept identical to the SDK enum's wire form
+/// (lowercase; `deno` is accepted as an alias for `typescript`) and mapped
+/// into it on the way in.
+#[derive(Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum ProcessorLanguageDto {
+    /// Rust — rejected for live source submit (a full cargo build, not a
+    /// live graph mutation); present for wire-form parity with the SDK enum.
+    Rust,
+    Python,
+    #[serde(alias = "deno")]
+    TypeScript,
+}
+
+impl From<ProcessorLanguageDto> for ProcessorLanguage {
+    fn from(dto: ProcessorLanguageDto) -> Self {
+        match dto {
+            ProcessorLanguageDto::Rust => ProcessorLanguage::Rust,
+            ProcessorLanguageDto::Python => ProcessorLanguage::Python,
+            ProcessorLanguageDto::TypeScript => ProcessorLanguage::TypeScript,
+        }
+    }
+}
+
+/// Which end of a link the newly-instantiated processor's port sits on, for
+/// an optional `connect` wiring in a [`SubmittedProcessorSourceRequest`].
+#[derive(Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum SourceProcessorPortRole {
+    /// `local_port` is the OUTPUT (upstream) end; it feeds the peer's input.
+    Output,
+    /// `local_port` is the INPUT (downstream) end; it is fed by the peer's output.
+    Input,
+}
+
+/// One optional post-instantiation wiring in a
+/// [`SubmittedProcessorSourceRequest`]: connect a port on the
+/// newly-instantiated processor to a port on a processor already in the graph.
+#[derive(Deserialize, utoipa::ToSchema)]
+pub(crate) struct SourceProcessorConnection {
+    /// Port name on the newly-instantiated processor.
+    pub local_port: String,
+    /// Whether `local_port` is the output or the input end of the link.
+    pub role: SourceProcessorPortRole,
+    /// The already-present peer processor's id (as returned by
+    /// `POST /api/processor` or a prior source submit).
+    pub peer_processor: String,
+    /// The peer processor's port name.
+    pub peer_port: String,
+}
+
+/// Body of `POST /api/processor/source`: submit processor source text for
+/// live registration, then instantiate it and (optionally) wire it in.
+#[derive(Deserialize, utoipa::ToSchema)]
+pub(crate) struct SubmittedProcessorSourceRequest {
+    /// The runtime language the source is authored in.
+    pub language: ProcessorLanguageDto,
+    /// The processor source text (a Python module / a TypeScript module).
+    pub source: String,
+    /// The `@session/<name>` package-name segment to mint the registration
+    /// under. Omit to derive it from `processor_type_name`. One of
+    /// `requested_name` / `processor_type_name` must be present.
+    #[serde(default)]
+    pub requested_name: Option<String>,
+    /// The PascalCase processor type name the source defines. Omit to derive
+    /// it from `requested_name`.
+    #[serde(default)]
+    pub processor_type_name: Option<String>,
+    /// Config applied when the registered processor is instantiated into the
+    /// graph. Defaults to an empty object.
+    #[serde(default)]
+    pub config: Option<serde_json::Value>,
+    /// Optional wirings applied after instantiation, each connecting a port on
+    /// the new processor to a port on an existing graph processor.
+    #[serde(default)]
+    pub connect: Vec<SourceProcessorConnection>,
+}
+
+/// Body of `POST /api/processor/source/replace`: swap a live
+/// `@session/<name>` source registration for a replacement, transactionally
+/// (a failed replacement restores the prior registration).
+#[derive(Deserialize, utoipa::ToSchema)]
+pub(crate) struct ReplaceProcessorSourceRequest {
+    /// The `@session/<name>@<range>` module whose prior registration is
+    /// removed before the replacement registers (wire form, e.g.
+    /// `@session/widget@*`).
+    pub target_session_module: String,
+    /// The replacement source text.
+    pub source: String,
+    /// The replacement's runtime language.
+    pub language: ProcessorLanguageDto,
+    /// The replacement's `@session/<name>` package-name segment. Must resolve
+    /// to the same `<name>` as `target_session_module` — a replace
+    /// re-registers the same name, never renames.
+    #[serde(default)]
+    pub requested_name: Option<String>,
+    /// The replacement's PascalCase processor type name.
+    #[serde(default)]
+    pub processor_type_name: Option<String>,
+}
+
+/// One committed port in a [`RegisteredProcessorPortsResponse`].
+#[derive(Serialize, utoipa::ToSchema)]
+pub(crate) struct RegisteredPortResponse {
+    /// The port name.
+    pub name: String,
+    /// The port's schema id — `"any"` or a fully-qualified
+    /// `@org/package/Type@version`.
+    pub schema: String,
+    /// Input-port delivery-profile override; always absent on output ports.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delivery_profile: Option<String>,
+}
+
+/// One installed processor's committed port surface in a
+/// [`RegisterProcessorSourceResponse`].
+#[derive(Serialize, utoipa::ToSchema)]
+pub(crate) struct RegisteredProcessorPortsResponse {
+    /// The processor's PascalCase short `Type` name.
+    pub name: String,
+    /// Input ports, in declaration order.
+    pub inputs: Vec<RegisteredPortResponse>,
+    /// Output ports, in declaration order.
+    pub outputs: Vec<RegisteredPortResponse>,
+}
+
+/// Response to `POST /api/processor/source` and
+/// `POST /api/processor/source/replace`: the minted registration ident plus
+/// each installed processor's discovered ports, and — for a source submit —
+/// the instantiated instance id and any created connection ids.
+#[derive(Serialize, utoipa::ToSchema)]
+pub(crate) struct RegisterProcessorSourceResponse {
+    /// The minted `@session/<name>@0.0.N` registration module ident (NOT an
+    /// `add_processor` instance id).
+    pub module: String,
+    /// The processors the registration installed, with their committed ports.
+    pub processors: Vec<RegisteredProcessorPortsResponse>,
+    /// The `add_processor` instance id, present when the composite
+    /// instantiated the first discovered processor into the graph.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub processor_id: Option<String>,
+    /// Composite outcome: `"added"` when an instance was created into the
+    /// running graph, `"registered"` when only the definition was registered
+    /// (no instantiable processor discovered). Live per-instance state is
+    /// observed via `GET /api/graph` and the `events_url` event stream.
+    pub state: &'static str,
+    /// Link ids created by the optional `connect` wirings, in request order.
+    pub connections: Vec<String>,
+    /// The WebSocket URL carrying this runtime's live event stream.
+    pub events_url: &'static str,
 }
 
 // ============================================================================

--- a/runtime/streamlib-engine/src/core/runtime/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/mod.rs
@@ -29,7 +29,7 @@ pub(crate) use module_loader::{
     stage_schema_via_active_cdylib_sink,
 };
 pub use operations::{
-    BoxFuture, ConnectOptions, RegisterProcessorReceipt, RegisteredPortReceipt,
+    BoxFuture, ConnectOptions, ProcessorLanguage, RegisterProcessorReceipt, RegisteredPortReceipt,
     RegisteredProcessorReceipt, ReplaceProcessorFromSource, RuntimeOperations,
     SchemaValidationPosture, SubmittedProcessorSource,
 };

--- a/runtime/streamlib-engine/src/core/runtime/operations.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations.rs
@@ -8,7 +8,8 @@ use crate::core::{InputLinkPortRef, OutputLinkPortRef};
 use std::future::Future;
 use std::pin::Pin;
 use streamlib_idents::ModuleIdent;
-use streamlib_processor_schema::{PortSchemaSpec, ProcessorLanguage};
+use streamlib_processor_schema::PortSchemaSpec;
+pub use streamlib_processor_schema::ProcessorLanguage;
 
 use crate::core::descriptors::{PortDescriptor, ProcessorDescriptor};
 


### PR DESCRIPTION
Closes #1424

## Summary

Adds two write endpoints to `streamlib-api-server`'s processor-graph HTTP surface:

- `POST /api/processor/source` — register a processor from source (subprocess-registered
  language runtimes), returning discovered ports/module/state/`processor_id`/`events_url`, and
  optionally applying a `connect: [...]` list of wirings to other processors in the same request.
- `POST /api/processor/{id}/replace` (`replace_processor_source_*`) — swap a running processor's
  source in place, rejecting a malformed `target_module` with 400.

`ProcessorLanguage` is re-exported at the SDK runtime surface
(`runtime/streamlib-engine/src/core/runtime/operations.rs` + `mod.rs`) so the HTTP handler can map
its DTO (`ProcessorLanguageDto` in `packages/api-server/src/state.rs`) without a parallel enum
definition — `ProcessorLanguage` derives `serde` but not `utoipa::ToSchema`, hence the DTO/`From`
mirror.

## Test evidence

```
cargo test -p streamlib-api-server
```
```
running 19 tests
test auth::tests::generated_tokens_are_distinct ... ok
test auth::tests::token_is_generated_persisted_0600_and_reused ... ok
test auth::tests::wrong_token_is_403 ... ok
test auth::tests::missing_token_is_401 ... ok
test auth::tests::valid_token_passes_through ... ok
test auth::tests::malformed_authorization_header_is_401 ... ok
test handlers::router_auth_gate_tests::delete_connection_with_token_is_204 ... ok
test handlers::router_auth_gate_tests::delete_processor_with_token_is_204 ... ok
test handlers::router_auth_gate_tests::create_processor_source_wires_optional_connections ... ok
test handlers::router_auth_gate_tests::create_connection_with_token_is_200 ... ok
test handlers::router_auth_gate_tests::create_processor_source_returns_discovered_ports_and_instance ... ok
test handlers::router_auth_gate_tests::create_processor_with_token_is_200 ... ok
test handlers::router_auth_gate_tests::replace_processor_source_with_token_is_200 ... ok
test handlers::router_auth_gate_tests::source_routes_are_documented_in_the_openapi_spec ... ok
test handlers::router_auth_gate_tests::replace_processor_source_rejects_malformed_target_module_with_400 ... ok
test handlers::router_auth_gate_tests::auth_off_lets_delete_routes_through_without_a_token ... ok
test handlers::router_auth_gate_tests::auth_off_lets_create_routes_through_without_a_token ... ok
test handlers::router_auth_gate_tests::open_routes_need_no_authorization_header ... ok
test handlers::router_auth_gate_tests::mutating_routes_reject_missing_token_with_401 ... ok

test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Coverage is at the handler/projection layer against `AlwaysOkStubRuntime` (per the no-GPU CI
policy — real subprocess registration and `ProcessorLanguage::Rust` rejection are engine-side,
covered by #1423).

## Verification

Ran through `verify-change` (Stage A change-verifier + path-routed domain lenses). All lenses
cleared the branch; the findings below survived as non-blocking review items for the owner.

## Review items (non-blocking)

- **should-fix** — `packages/api-server/src/handlers.rs:405`: POST /api/processor/source
  instantiates the processor, then applies `connect` wirings; a wiring failure returns 404/400 and
  leaves the just-added processor (and any earlier successful links) orphaned in the graph, and the
  error body does not carry the created `processor_id`.
  In `create_processor_source`, `add_processor_async` runs first and returns `processor_id`; the
  `for wiring in body.connect` loop then early-returns `ProcessorNotFoundResponse` /
  `ErrorResponse` on the first failing connect. No rollback of the instantiated processor or prior
  links, and the discarded `processor_id` is not surfaced — for the "agent-operable runtime"
  milestone the caller must `GET /api/graph` to discover and clean up the orphan.
  Suggested next step: either roll back the instantiated processor + prior links on a connect
  failure, or include the created processor_id/connection ids in the error response so the agent
  can reconcile. Document the chosen semantics on the PR body.

- **low** — `packages/api-server/src/handlers.rs:258`: new helper `pinned_version` clones a `Copy`
  type, tripping `clippy::clone_on_copy`.
  `cargo clippy -p streamlib-api-server --all-features`: `warning: using clone on type SemVer which
  implements the Copy trait --> packages/api-server/src/handlers.rs:258:47 |
  Some(version.clone())`. Introduced by this branch. No CI clippy gate denies it (`test.yml` runs
  no clippy and does not even include `streamlib-api-server`), so it does not block, but it is a
  needless clone in new code.
  Suggested next step: replace `version.clone()` with `*version` in `pinned_version`.

- **info** — `packages/api-server/src/handlers.rs:896`: tests exercise the HTTP handler wiring
  against `AlwaysOkStubRuntime`, not a real S1 source registration — the "submit source → running"
  half of the acceptance criterion is verified only at the handler/projection layer.
  `AlwaysOkStubRuntime::register_processor_source_async` returns a fixed
  `stub_register_receipt`; `create_processor_source_returns_discovered_ports_and_instance` asserts
  the projected ports/module/state/processor_id/events_url. Mentally reverting
  `project_receipt_ports` or the composite instantiate does fail these (non-vacuous), but real
  subprocess registration + `ProcessorLanguage::Rust` rejection are engine-side (#1423) and not
  exercised here. Appropriate for a package-level lib test under the no-GPU CI policy.
  Suggested next step: none — noted so the reader knows the real registration path is covered at
  the engine layer, not here.

- **info** — `runtime/streamlib-engine/src/core/runtime/operations.rs:11`: runtime change is
  limited to re-exporting `ProcessorLanguage` at the SDK runtime surface so the handler can map its
  DTO — minimal and in-scope, no parallel abstraction.
  `operations.rs` changes `use ...ProcessorLanguage` to `pub use
  streamlib_processor_schema::ProcessorLanguage;` and `mod.rs` adds it to the pub re-export list;
  `ProcessorLanguageDto` in `state.rs` mirrors it with a `From` impl only because
  `ProcessorLanguage` derives serde but not `utoipa::ToSchema`. No new load-bearing engine shape.
  Suggested next step: none.

- **low** — `packages/api-server/src/state.rs:676`: `ProcessorLanguageDto` exists for OpenAPI
  documentability, but its derived `utoipa::ToSchema` will not surface the `deno` alias — the
  generated enum lists only rust/python/typescript, dropping the `deno` value the code accepts and
  the doc comment (state.rs:674) advertises.
  utoipa's `ToSchema` derive honors serde `rename_all`/`rename` but not `#[serde(alias =
  "deno")]` (line 683). The SDK's hand-written `JsonSchema` for `ProcessorLanguage` deliberately
  added "deno" to `enum_values`
  (`sdk/streamlib-processor-schema/src/processor_schema.rs:197`) precisely to keep the spec honest;
  the DTO's derived schema regresses that, so a spec-driven client never learns `deno` is valid.
  Suggested next step: either hand-implement `ToSchema` for `ProcessorLanguageDto` with an explicit
  4-value enum (rust/python/typescript/deno) mirroring the SDK's `JsonSchema`, or drop the `deno`
  alias from the HTTP DTO and require `typescript` on the wire. Confirm against the generated
  `/api/openapi.json` enum values.

- **info** — `packages/api-server/src/handlers.rs:279`: the `create_processor_source` composite is
  non-atomic: on a `connect` wiring failure after `add_processor` already succeeded, the
  instantiated processor (and any earlier links) stay in the graph, but the error response carries
  neither `processor_id` nor `module`, so the caller has no handle to clean up the orphan.
  `add_processor_async` at handlers.rs:258 commits the instance; the loop at :280 returns 404/400
  on the first failing wiring (:293-311) with only an `ErrorResponse`/`ProcessorNotFoundResponse`
  — the successfully-created `processor_id` and the minted session module are dropped from the
  reply.
  Suggested next step: adjacent to my lens (graph ops). Consider returning a 207-style partial body
  that still includes `processor_id` + `module` + the connections created so far, or documenting
  the non-transactional behavior on the endpoint. Owner/graph-ops call, not a distribution
  invariant.

- **should-fix** — `packages/api-server/src/handlers.rs:400`: the source-submit connect-wiring
  loop and `create_connection` both map `connect_async` errors, and the two mappings have DRIFTED:
  the source-submit loop (handlers.rs:400-420) has only `ProcessorNotFound`->404 + a catch-all
  ->400, while `create_connection` (handlers.rs:551-585) additionally maps
  `Error::ProcessorPortNotFound` -> 422 with a structured `ProcessorPortNotFoundResponse`. Same
  underlying call, two hand-maintained error tables that have already fallen out of sync.
  Source loop: `Err(Error::ProcessorNotFound(peer)) => 404 ProcessorNotFoundResponse` then
  `Err(error) => 400 ErrorResponse` (handlers.rs:402-420). `create_connection`: same 404 arm PLUS
  `Err(Error::ProcessorPortNotFound{..}) => 422 ProcessorPortNotFoundResponse` (handlers.rs:561-577)
  before the 400 fallback. Consequence: a `connect` wiring with a valid peer processor but a bad
  port name yields an undocumented generic 400 via the source endpoint but a structured 422 via
  `POST /api/connections` — and the source route's `#[utoipa::path]` responses (handlers.rs:307-308)
  never document 422.
  Suggested next step: extract `fn connect_error_response(error: Error) -> axum::response::Response`
  covering the `ProcessorNotFound`(404)/`ProcessorPortNotFound`(422)/fallback(400) arms once, call
  it from both `create_connection` and the source-submit wiring loop, and add the 422 response to
  the source route's utoipa::path so the two endpoints answer identical connect failures
  identically.

- **low** — `packages/api-server/src/state.rs:253`:
  `RegisterProcessorSourceResponse.state` is a bare `&'static str` carrying a closed two-value
  domain ("added" / "registered"), set as string literals at three sites (handlers.rs:345, 430,
  493). Primitive-obsession on a write-only DTO: a typo in any literal is undetectable and utoipa
  documents the field as a free-form string rather than an enum with two known variants.
  `pub state: &'static str` with literals `state: "registered"` (handlers.rs:345,493) and
  `state: "added"` (handlers.rs:430).
  Suggested next step: replace with a `#[derive(Serialize, utoipa::ToSchema)]
  #[serde(rename_all="lowercase")] enum RegistrationOutcome { Added, Registered }` so the two
  variants are type-checked at each set-site and appear as an enum in the OpenAPI schema.
