### PR TITLE
feat(engine): first-class channel tap op — read-only reserved-slot subscriber

### DIFF
--- a/packages/api-server/src/handlers.rs
+++ b/packages/api-server/src/handlers.rs
@@ -58,10 +58,11 @@ pub(crate) fn build_router(
     auth_token: Option<ApiServerBearerToken>,
     #[cfg(feature = "moq")] runtime_id: String,
 ) -> Router {
-    // The read-only tap WebSocket sits behind the SAME bearer gate as the
-    // mutating routes when auth is on (a tap observes live channel data), and is
-    // open like every other route when auth is off. Clone the token before it is
-    // moved into the mutating-route middleware below.
+    // The read-only tap WebSocket is gated exactly like the mutating routes WHEN
+    // auth is opted in — same bearer middleware, same route_layer binding; the
+    // default (auth off) leaves it open like every other route. This is
+    // mechanism parity, not a trust boundary the tap itself imposes. Clone the
+    // token before it is moved into the mutating-route middleware below.
     let tap_auth_token = auth_token.clone();
 
     let mut protected = OpenApiRouter::new()
@@ -562,10 +563,11 @@ async fn handle_tap_websocket(
         Ok(subscription) => subscription,
         Err(e) => {
             tracing::info!(channel = %channel, "tap attach rejected: {e}");
+            let (close_code, close_reason) = tap_error_close_frame(&e);
             let _ = sender
                 .send(Message::Close(Some(axum::extract::ws::CloseFrame {
-                    code: axum::extract::ws::close_code::ERROR,
-                    reason: e.to_string().into(),
+                    code: close_code,
+                    reason: close_reason.into(),
                 })))
                 .await;
             return;
@@ -605,6 +607,48 @@ async fn handle_tap_websocket(
     }
 
     tracing::info!(channel = %channel, "tap client detached");
+}
+
+/// Longest tap close reason RFC 6455 permits: a control frame caps its payload
+/// at 125 bytes and the 2-byte close code consumes the first two, leaving 123
+/// for the UTF-8 reason. tungstenite refuses to write an over-length close
+/// frame, so an untruncated tap error string (`NotSupported` runs ~180 bytes)
+/// would drop the client into an abnormal close with no reason at all.
+const MAX_WS_CLOSE_REASON_BYTES: usize = 123;
+
+/// Map a typed tap error to a WebSocket close code + a short, RFC-6455-legal
+/// reason (≤ [`MAX_WS_CLOSE_REASON_BYTES`], truncated on a UTF-8 char
+/// boundary). The full error is logged server-side at the call site; this
+/// surface is the machine-readable failure the client (and the #1429 MCP tool)
+/// reads off the close frame. App codes live in the 4000–4999 private range.
+fn tap_error_close_frame(error: &Error) -> (u16, String) {
+    let (code, reason) = match error {
+        Error::TapChannelNotFound(channel) => {
+            (4404, format!("tap channel not found: {channel}"))
+        }
+        Error::TapSlotOccupied(channel) => {
+            (4409, format!("tap slot already occupied: {channel}"))
+        }
+        other => (
+            axum::extract::ws::close_code::ERROR,
+            format!("tap attach failed: {other}"),
+        ),
+    };
+    (code, truncate_on_char_boundary(reason, MAX_WS_CLOSE_REASON_BYTES))
+}
+
+/// Truncate `text` to at most `max_bytes`, cutting on a UTF-8 char boundary so
+/// the result stays valid UTF-8.
+fn truncate_on_char_boundary(mut text: String, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text;
+    }
+    let mut boundary = max_bytes;
+    while boundary > 0 && !text.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    text.truncate(boundary);
+    text
 }
 
 #[cfg(test)]
@@ -919,10 +963,10 @@ mod router_auth_gate_tests {
 
     #[tokio::test]
     async fn tap_ws_rejects_missing_token_with_401_when_auth_on() {
-        // The read-only tap is a security-relevant surface: with auth on it must
-        // be gated exactly like the mutating routes. Deleting the tap_router
-        // `.route_layer(...)` flips this from 401 to the WS extractor's own
-        // (non-401) rejection, going red here.
+        // With auth opted in, the read-only tap is gated exactly like the
+        // mutating routes — mechanism parity, not a trust boundary the tap
+        // imposes. Deleting the tap_router `.route_layer(...)` flips this from
+        // 401 to the WS extractor's own (non-401) rejection, going red here.
         assert_eq!(status_of(tap_ws_request()).await, StatusCode::UNAUTHORIZED);
     }
 

--- a/packages/api-server/src/handlers.rs
+++ b/packages/api-server/src/handlers.rs
@@ -513,9 +513,9 @@ impl EventListener for WebSocketEventForwarder {
 /// Query parameters for the tap WebSocket: an optional bounded sample count.
 #[derive(Deserialize)]
 pub(crate) struct TapQuery {
-    /// Stream exactly `n` bags then close; absent streams live until the client
-    /// disconnects.
-    n: Option<usize>,
+    /// Stream exactly `count` bags then close; absent streams live until the
+    /// client disconnects.
+    count: Option<usize>,
 }
 
 /// `GET /ws/tap/{channel}` — attach a read-only tap to `channel` and stream its
@@ -531,7 +531,7 @@ pub(crate) async fn tap_websocket_handler(
     Path(channel): Path<String>,
     Query(query): Query<TapQuery>,
 ) -> impl IntoResponse {
-    ws.on_upgrade(move |socket| handle_tap_websocket(socket, state.runtime, channel, query.n))
+    ws.on_upgrade(move |socket| handle_tap_websocket(socket, state.runtime, channel, query.count))
 }
 
 async fn handle_tap_websocket(
@@ -561,8 +561,7 @@ async fn handle_tap_websocket(
     tracing::info!(channel = %channel, "tap client attached");
 
     // Own the subscription in this scope: forward bags until the tap ends
-    // (bounded count reached / channel gone) or the client disconnects. On
-    // return, `subscription` drops — detaching the tap and freeing the slot.
+    // (bounded count reached / channel gone) or the client disconnects.
     loop {
         tokio::select! {
             maybe_bag = subscription.recv() => match maybe_bag {
@@ -581,6 +580,14 @@ async fn handle_tap_websocket(
                 _ => {}
             },
         }
+    }
+
+    // Detach off the async worker: `TapSubscription::drop` joins the forwarder
+    // OS thread, and a synchronous join must never run on a tokio runtime
+    // worker. The join is bounded (the forwarder never parks), but blocking a
+    // shared executor thread on it is still wrong.
+    if let Err(join_error) = tokio::task::spawn_blocking(move || drop(subscription)).await {
+        tracing::warn!(channel = %channel, "tap detach task failed to join: {join_error}");
     }
 
     tracing::info!(channel = %channel, "tap client detached");
@@ -884,5 +891,45 @@ mod router_auth_gate_tests {
                 "DELETE {uri} must be open with auth off (no token)"
             );
         }
+    }
+
+    fn tap_ws_request() -> Request<Body> {
+        // A plain GET (no upgrade headers): enough to exercise the bearer gate,
+        // which runs as a `route_layer` BEFORE the WS upgrade extractor.
+        Request::builder()
+            .method("GET")
+            .uri("/ws/tap/some-channel")
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn tap_ws_rejects_missing_token_with_401_when_auth_on() {
+        // The read-only tap is a security-relevant surface: with auth on it must
+        // be gated exactly like the mutating routes. Deleting the tap_router
+        // `.route_layer(...)` flips this from 401 to the WS extractor's own
+        // (non-401) rejection, going red here.
+        assert_eq!(status_of(tap_ws_request()).await, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn tap_ws_with_token_clears_the_auth_gate() {
+        // A valid token passes the gate; the request then reaches the WS handler,
+        // whose upgrade extractor rejects this non-upgrade GET with a non-401
+        // status — proving the gate admitted it rather than rejecting it.
+        let mut request = tap_ws_request();
+        request
+            .headers_mut()
+            .insert(AUTHORIZATION, bearer(TEST_TOKEN).try_into().unwrap());
+        assert_ne!(status_of(request).await, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn tap_ws_is_open_with_auth_off() {
+        assert_ne!(
+            status_on(auth_disabled_router(), tap_ws_request()).await,
+            StatusCode::UNAUTHORIZED,
+            "GET /ws/tap/{{channel}} must be reachable with auth off (no token)"
+        );
     }
 }

--- a/packages/api-server/src/handlers.rs
+++ b/packages/api-server/src/handlers.rs
@@ -6,12 +6,14 @@
 use axum::{
     extract::ws::{Message, WebSocket, WebSocketUpgrade},
     extract::Path,
+    extract::Query,
     extract::State,
     http::StatusCode,
     response::IntoResponse,
     routing::get,
     Json, Router,
 };
+use serde::Deserialize;
 use futures_util::{SinkExt, StreamExt};
 use parking_lot::Mutex;
 use std::sync::Arc;
@@ -56,6 +58,12 @@ pub(crate) fn build_router(
     auth_token: Option<ApiServerBearerToken>,
     #[cfg(feature = "moq")] runtime_id: String,
 ) -> Router {
+    // The read-only tap WebSocket sits behind the SAME bearer gate as the
+    // mutating routes when auth is on (a tap observes live channel data), and is
+    // open like every other route when auth is off. Clone the token before it is
+    // moved into the mutating-route middleware below.
+    let tap_auth_token = auth_token.clone();
+
     let mut protected = OpenApiRouter::new()
         .routes(routes!(create_processor))
         .routes(routes!(delete_processor))
@@ -90,9 +98,18 @@ pub(crate) fn build_router(
         .on_request(DefaultOnRequest::new().level(Level::INFO))
         .on_response(DefaultOnResponse::new().level(Level::INFO));
 
+    let mut tap_router = Router::new().route("/ws/tap/{channel}", get(tap_websocket_handler));
+    if let Some(tap_auth_token) = tap_auth_token {
+        tap_router = tap_router.route_layer(axum::middleware::from_fn_with_state(
+            tap_auth_token,
+            crate::auth::require_bearer_token,
+        ));
+    }
+
     let router = router
         .route("/ws/events", get(websocket_handler))
-        .route("/api/openapi.json", get(get_openapi_spec));
+        .route("/api/openapi.json", get(get_openapi_spec))
+        .merge(tap_router);
 
     #[cfg(feature = "moq")]
     let router = router.route("/api/moq/catalog", get(get_moq_catalog));
@@ -489,6 +506,86 @@ impl EventListener for WebSocketEventForwarder {
     }
 }
 
+// ============================================================================
+// Channel Tap WebSocket (read-only channel observer)
+// ============================================================================
+
+/// Query parameters for the tap WebSocket: an optional bounded sample count.
+#[derive(Deserialize)]
+pub(crate) struct TapQuery {
+    /// Stream exactly `n` bags then close; absent streams live until the client
+    /// disconnects.
+    n: Option<usize>,
+}
+
+/// `GET /ws/tap/{channel}` — attach a read-only tap to `channel` and stream its
+/// raw bags as binary WebSocket frames.
+///
+/// Bag bytes are forwarded verbatim (the `FrameHeader`-framed wire form);
+/// decoding is the client's concern, which keeps the tap wire-neutral across
+/// Rust / Python / Deno publishers. Dropping the connection detaches the tap
+/// and frees the channel's reserved slot.
+pub(crate) async fn tap_websocket_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+    Path(channel): Path<String>,
+    Query(query): Query<TapQuery>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_tap_websocket(socket, state.runtime, channel, query.n))
+}
+
+async fn handle_tap_websocket(
+    socket: WebSocket,
+    runtime: Arc<dyn RuntimeOperations>,
+    channel: String,
+    count: Option<usize>,
+) {
+    let (mut sender, mut receiver) = socket.split();
+
+    // Attach the tap; a resolution / slot-occupied failure closes the socket
+    // with the typed reason rather than silently hanging.
+    let mut subscription = match runtime.tap_async(channel.clone(), count).await {
+        Ok(subscription) => subscription,
+        Err(e) => {
+            tracing::info!(channel = %channel, "tap attach rejected: {e}");
+            let _ = sender
+                .send(Message::Close(Some(axum::extract::ws::CloseFrame {
+                    code: axum::extract::ws::close_code::ERROR,
+                    reason: e.to_string().into(),
+                })))
+                .await;
+            return;
+        }
+    };
+
+    tracing::info!(channel = %channel, "tap client attached");
+
+    // Own the subscription in this scope: forward bags until the tap ends
+    // (bounded count reached / channel gone) or the client disconnects. On
+    // return, `subscription` drops — detaching the tap and freeing the slot.
+    loop {
+        tokio::select! {
+            maybe_bag = subscription.recv() => match maybe_bag {
+                Some(bytes) => {
+                    if sender.send(Message::Binary(bytes.into())).await.is_err() {
+                        break;
+                    }
+                }
+                None => {
+                    let _ = sender.send(Message::Close(None)).await;
+                    break;
+                }
+            },
+            maybe_msg = receiver.next() => match maybe_msg {
+                Some(Ok(Message::Close(_))) | Some(Err(_)) | None => break,
+                _ => {}
+            },
+        }
+    }
+
+    tracing::info!(channel = %channel, "tap client detached");
+}
+
 #[cfg(test)]
 mod router_auth_gate_tests {
     use super::*;
@@ -551,6 +648,13 @@ mod router_auth_gate_tests {
             _request: ReplaceProcessorFromSource,
         ) -> BoxFuture<'_, Result<RegisterProcessorReceipt>> {
             Box::pin(async { Ok(stub_register_receipt()) })
+        }
+        fn tap_async(
+            &self,
+            channel: String,
+            _count: Option<usize>,
+        ) -> BoxFuture<'_, Result<streamlib::sdk::runtime::TapSubscription>> {
+            Box::pin(async move { Err(Error::TapChannelNotFound(channel)) })
         }
         fn add_processor(&self, _spec: ProcessorSpec) -> Result<ProcessorUniqueId> {
             Ok(ProcessorUniqueId::new())

--- a/packages/api-server/src/handlers.rs
+++ b/packages/api-server/src/handlers.rs
@@ -525,6 +525,20 @@ pub(crate) struct TapQuery {
 /// decoding is the client's concern, which keeps the tap wire-neutral across
 /// Rust / Python / Deno publishers. Dropping the connection detaches the tap
 /// and frees the channel's reserved slot.
+#[utoipa::path(
+    get,
+    path = "/ws/tap/{channel}",
+    tag = "events",
+    params(
+        ("channel" = String, Path, description = "Name of the channel to observe"),
+        ("count" = Option<usize>, Query, description = "Stream exactly this many bags then close; absent streams live until the client disconnects")
+    ),
+    responses(
+        (status = 101, description = "WebSocket upgraded. Read-only observability tap: each channel bag is forwarded verbatim (FrameHeader-framed) as a binary WS frame with no encode, containerize, or transcode — decoding is the client's concern. To observe a viewable video feed, tap an encoded (h264/h265/jpeg) or container (CMAF/fMP4) channel; a raw video channel carries zero-copy DMA-BUF/VkImage frame descriptors (meaningless off-host), not pixels, and this is not a realtime-video transport (use the WebRTC/MoQ/display processors)."),
+        (status = 401, description = "Missing or malformed bearer token", body = UnauthorizedResponse),
+        (status = 403, description = "Invalid bearer token", body = ForbiddenResponse)
+    )
+)]
 pub(crate) async fn tap_websocket_handler(
     ws: WebSocketUpgrade,
     State(state): State<AppState>,

--- a/packages/api-server/src/state.rs
+++ b/packages/api-server/src/state.rs
@@ -106,6 +106,7 @@ pub(crate) struct ProcessorPortNotFoundResponse {
 
 #[derive(OpenApi)]
 #[openapi(
+    paths(crate::handlers::tap_websocket_handler),
     info(
         title = "StreamLib Runtime API",
         version = "0.1.0",

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/mod.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/mod.rs
@@ -11,6 +11,9 @@ mod subprocess_bridge;
 mod subprocess_escalate;
 
 pub use open_iceoryx2_service_op::{close_iceoryx2_service, open_iceoryx2_service};
+pub(crate) use open_iceoryx2_service_op::{
+    ChannelSizing, find_channel_source_port, resolve_channel_sizing,
+};
 pub(crate) use prepare_processor_op::prepare_processor;
 pub(crate) use spawn_deno_subprocess_op::create_deno_subprocess_host_constructor;
 pub(crate) use spawn_processor_op::spawn_processor;

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -154,11 +154,12 @@ pub fn open_iceoryx2_service(
     // The tier default is the structural ceiling; an operator raises or lowers it
     // per deployment through the tier's node-level env override.
     let channel_ceiling_bytes = effective_channel_ceiling_bytes(trust_tier);
-    let delivery = channel_delivery_profile(graph, &source_proc_id, &source_port)?.resolve();
-    let max_queued_messages = delivery.depth;
-    let enable_safe_overflow = delivery.overflow.enable_safe_overflow();
-    let drain_order = delivery.drain_order;
-    let max_subscribers = channel_max_subscribers(graph, &source_proc_id, &source_port);
+    let ChannelSizing {
+        max_subscribers,
+        max_queued_messages,
+        enable_safe_overflow,
+        drain_order,
+    } = resolve_channel_sizing(graph, &source_proc_id, &source_port)?;
     let max_notifiers = destination_fanin(graph, &dest_proc_id);
 
     let iceoryx2_node = runtime_ctx.iceoryx2_node();
@@ -326,6 +327,68 @@ fn channel_max_subscribers(
 ) -> usize {
     channel_destinations(graph, source_proc_id, source_port).len()
         + RESERVED_TAP_SUBSCRIBER_SLOTS_PER_CHANNEL
+}
+
+/// The iceoryx2 sizing a channel data service is opened with — the fixed
+/// parameters iceoryx2 verifies on every reopen of the same service name.
+///
+/// Both the compiler op (which creates the service with a publisher) and the
+/// phase-3.5 `tap` op (which reopens it publisher-free to add a reserved-slot
+/// subscriber) derive this from the SAME graph state via
+/// [`resolve_channel_sizing`], so their `open_or_create_service` calls agree —
+/// a mismatched `max_subscribers` / `subscriber_max_buffer_size` /
+/// `enable_safe_overflow` would be rejected by iceoryx2 on open.
+pub(crate) struct ChannelSizing {
+    /// Compile-time destination count plus the reserved tap slot.
+    pub(crate) max_subscribers: usize,
+    /// Ring depth (`subscriber_max_buffer_size`) — the agreed delivery profile's depth.
+    pub(crate) max_queued_messages: usize,
+    /// Overflow policy — `true` drops-oldest (realtime), `false` back-pressures (lossless).
+    pub(crate) enable_safe_overflow: bool,
+    /// The agreed delivery profile's consumer drain order.
+    pub(crate) drain_order: crate::iceoryx2::ReadMode,
+}
+
+/// Derive the [`ChannelSizing`] for the channel keyed on `(source_proc_id,
+/// source_port)` from the current graph — the single derivation both the
+/// service-open compiler op and the `tap` op share so their `open_or_create`
+/// calls request identical, iceoryx2-verified parameters.
+pub(crate) fn resolve_channel_sizing(
+    graph: &mut Graph,
+    source_proc_id: &ProcessorUniqueId,
+    source_port: &str,
+) -> Result<ChannelSizing> {
+    let delivery = channel_delivery_profile(graph, source_proc_id, source_port)?.resolve();
+    Ok(ChannelSizing {
+        max_subscribers: channel_max_subscribers(graph, source_proc_id, source_port),
+        max_queued_messages: delivery.depth,
+        enable_safe_overflow: delivery.overflow.enable_safe_overflow(),
+        drain_order: delivery.drain_order,
+    })
+}
+
+/// Reverse-resolve a channel data-service name to the `(source_proc_id,
+/// source_port)` that publishes to it, by scanning the graph's links for the
+/// one whose source output port derives that channel name.
+///
+/// A channel's iceoryx2 data service only exists once a `connect()` has wired
+/// its source output port, so a channel with no outbound link is genuinely
+/// untappable — the caller maps `None` to [`Error::TapChannelNotFound`]. The
+/// derivation is the same `streamlib_idents::source_channel_name` the compiler
+/// op keys the service on, so a match here is exact (including the
+/// hash-legalized over-budget form).
+pub(crate) fn find_channel_source_port(
+    graph: &mut Graph,
+    channel_service_name: &str,
+) -> Option<(ProcessorUniqueId, String)> {
+    graph.traversal_mut().e(()).iter().find_map(|link| {
+        let source = link.from_port();
+        let derived =
+            streamlib_idents::source_channel_name(source.processor_id.as_str(), &source.port_name)
+                .ok()?;
+        (derived.as_str() == channel_service_name)
+            .then(|| (source.processor_id.clone(), source.port_name.clone()))
+    })
 }
 
 /// The destination's compile-time fan-in — the count of inbound `connect()`
@@ -740,6 +803,74 @@ mod tests {
             3 + RESERVED_TAP_SUBSCRIBER_SLOTS_PER_CHANNEL,
             "one source port feeding 3 destinations must size the channel for 3 \
              subscribers plus the reserved tap slot",
+        );
+    }
+
+    /// The tap op reconstructs the exact `max_subscribers` the compiler op
+    /// opened the service with — `destinations + reserved tap` — via the shared
+    /// [`resolve_channel_sizing`]. iceoryx2 verifies `max_subscribers` on the
+    /// tap's publisher-free reopen, so a drift here would make every tap fail to
+    /// open. Mentally revert the reserved-tap term in `channel_max_subscribers`
+    /// and this count drops below what the service was created with.
+    #[test]
+    fn resolve_channel_sizing_recovers_service_open_max_subscribers() {
+        let mut graph = Graph::new();
+        let src_id = add_mock_output_only(&mut graph);
+        for _ in 0..2 {
+            let dest_id = add_mock_input_only(&mut graph);
+            graph.traversal_mut().add_e(
+                OutputLinkPortRef::new(&src_id, "out1"),
+                InputLinkPortRef::new(&dest_id, "in1"),
+            );
+        }
+        let src_uid: ProcessorUniqueId = src_id.as_str().into();
+
+        let sizing = resolve_channel_sizing(&mut graph, &src_uid, "out1")
+            .expect("sizing resolves for a wired channel");
+        assert_eq!(
+            sizing.max_subscribers,
+            2 + RESERVED_TAP_SUBSCRIBER_SLOTS_PER_CHANNEL,
+            "the tap must reopen the service with the same max_subscribers the \
+             compiler op created it with (2 destinations + reserved tap)",
+        );
+        assert_eq!(
+            sizing.max_subscribers,
+            channel_max_subscribers(&mut graph, &src_uid, "out1"),
+            "resolve_channel_sizing must agree with channel_max_subscribers — the \
+             single derivation both the service-open op and the tap op share",
+        );
+    }
+
+    /// A wired channel's data-service name reverse-resolves to the exact
+    /// `(source_proc, source_port)` that publishes to it; an unknown name
+    /// resolves to `None` (the tap op maps that to `TapChannelNotFound`).
+    /// Round-trips through the same `source_channel_name` the compiler op keys
+    /// the service on.
+    #[test]
+    fn find_channel_source_port_round_trips_and_misses() {
+        let mut graph = Graph::new();
+        let src_id = add_mock_output_only(&mut graph);
+        let dest_id = add_mock_input_only(&mut graph);
+        graph.traversal_mut().add_e(
+            OutputLinkPortRef::new(&src_id, "out1"),
+            InputLinkPortRef::new(&dest_id, "in1"),
+        );
+
+        let channel_name = streamlib_idents::source_channel_name(&src_id, "out1")
+            .expect("source port derives a channel name")
+            .into_string();
+
+        // The reverse lookup returns the graph node's original processor id (the
+        // channel name lowercases it only for the wire), so it round-trips to the
+        // id we wired, not its lowercased channel form.
+        let (resolved_proc, resolved_port) =
+            find_channel_source_port(&mut graph, &channel_name).expect("wired channel resolves");
+        assert_eq!(resolved_proc.as_str(), src_id.as_str());
+        assert_eq!(resolved_port, "out1");
+
+        assert!(
+            find_channel_source_port(&mut graph, "nosuch/channel").is_none(),
+            "an unwired / unknown channel name must not resolve to any source port",
         );
     }
 

--- a/runtime/streamlib-engine/src/core/context/runtime_context.rs
+++ b/runtime/streamlib-engine/src/core/context/runtime_context.rs
@@ -742,16 +742,31 @@ impl<'a> RuntimeContextFullAccess<'a> {
         AudioClockShim::from_ffi(handle, acv)
     }
 
-    /// Host-owned runtime operations as a typed plugin ABI shim. Implements
-    /// [`RuntimeOperations`] so existing call sites
-    /// (`ctx.runtime().add_processor_async(...).await`) keep working
-    /// transparently against a plugin-owned tokio runtime.
+    /// Host-owned runtime operations. Implements [`RuntimeOperations`]
+    /// so existing call sites
+    /// (`ctx.runtime().add_processor_async(...).await`) keep working.
     ///
-    /// The returned `Arc<dyn RuntimeOperations>` owns an Arc refcount
-    /// bump on the host's underlying ops impl via the
-    /// [`RuntimeOpsVTable::clone_handle`](streamlib_plugin_abi::RuntimeOpsVTable)
-    /// callback, so it's sound to stash past `Runner::stop()`.
+    /// When this build IS the host (no host callbacks installed — the
+    /// same host-vs-plugin discriminator
+    /// [`host_runtime_ops_vtable`](crate::core::plugin::host_services::host_runtime_ops_vtable)
+    /// uses), return a direct `Arc::clone` of the Runner-backed ops.
+    /// A host-resident processor (including the in-process api-server)
+    /// then reaches the real ops — the byte-shaped `RuntimeOpsVTable`
+    /// shim carries no transport for streaming ops such as `tap_async`
+    /// (its iceoryx2 subscriber is `!Send` and host-owned), so a
+    /// host-resident caller must bypass it. The `Arc` clone is
+    /// stash-safe past `Runner::stop()` exactly like the shim's
+    /// `clone_handle` refcount bump.
+    ///
+    /// When host callbacks ARE installed (a dlopened plugin), mint the
+    /// typed plugin ABI shim: the returned `Arc<dyn RuntimeOperations>`
+    /// owns an Arc refcount bump on the host's underlying ops impl via
+    /// the [`RuntimeOpsVTable::clone_handle`](streamlib_plugin_abi::RuntimeOpsVTable)
+    /// callback, so it too is sound to stash past `Runner::stop()`.
     pub fn runtime(&self) -> Arc<dyn RuntimeOperations> {
+        if crate::core::plugin::host_services::host_callbacks().is_none() {
+            return self.host_base().runtime();
+        }
         let borrowed_handle = unsafe { ((*self.vtable).runtime_ops_handle)(self.handle) };
         let rov = crate::core::plugin::host_services::host_runtime_ops_vtable();
         // SAFETY: rov + borrowed_handle come from the engine's host
@@ -936,9 +951,12 @@ impl<'a> RuntimeContextLimitedAccess<'a> {
         AudioClockShim::from_ffi(handle, acv)
     }
 
-    /// Host-owned runtime operations as a typed plugin ABI shim. See
+    /// Host-owned runtime operations. See
     /// [`RuntimeContextFullAccess::runtime`].
     pub fn runtime(&self) -> Arc<dyn RuntimeOperations> {
+        if crate::core::plugin::host_services::host_callbacks().is_none() {
+            return self.host_base().runtime();
+        }
         let borrowed_handle = unsafe { ((*self.vtable).runtime_ops_handle)(self.handle) };
         let rov = crate::core::plugin::host_services::host_runtime_ops_vtable();
         let owned_handle = unsafe { ((*rov).clone_handle)(borrowed_handle) };
@@ -1156,6 +1174,102 @@ mod with_cdylib_scope_tests {
             Ok(())
         });
         result.unwrap_or_else(|e| panic!("{TEST}: with_cdylib_scope returned err: {e}"));
+    }
+}
+
+#[cfg(test)]
+mod host_runtime_ops_wiring_tests {
+    //! Lock-in for the #1426 wiring fix: a host-resident processor's
+    //! `ctx.runtime()` must reach the REAL Runner-backed ops, not the
+    //! byte-shaped [`RuntimeOpsShim`]. The shim has no transport for a
+    //! streaming op, so `RuntimeOpsShim::tap_async` returns
+    //! [`Error::NotSupported`] — if `ctx.runtime()` handed the api-server
+    //! that shim, every host-side tap would be dead on arrival.
+    //!
+    //! The existing router tests inject a mock `RuntimeOperations` and so
+    //! never exercise the `host_callbacks().is_none()` branch this fix adds;
+    //! this test drives the branch through the SAME host-shaped
+    //! `RuntimeContextFullAccess::new(&base)` that lifecycle dispatch mints.
+    //!
+    //! Channel resolution (`find_channel_source_port` over the live graph)
+    //! runs BEFORE any iceoryx2 subscribe, so an unwired channel surfaces
+    //! [`Error::TapChannelNotFound`] with no IPC work. Mentally revert the
+    //! `host_callbacks().is_none()` branch in `runtime()` and the shim
+    //! answers [`Error::NotSupported`] instead — this test goes red, which
+    //! is the regression lock.
+    //!
+    //! GPU-gated because a `RuntimeContext` embeds a `GpuContext` by value;
+    //! the assertion itself needs no GPU work, only the context shell.
+
+    use super::*;
+    use crate::core::context::{
+        AudioClockConfig, GpuContext, SharedAudioClock, SoftwareAudioClock, TimeContext,
+    };
+    use crate::core::error::Error;
+    use crate::core::runtime::Runner;
+
+    fn gpu_or_skip(test_name: &str) -> Option<GpuContext> {
+        match GpuContext::init_for_platform_sync() {
+            Ok(gpu) => Some(gpu),
+            Err(e) => {
+                tracing::warn!("{test_name}: no GPU device ({e}) — skipping");
+                None
+            }
+        }
+    }
+
+    #[test]
+    fn host_ctx_runtime_reaches_real_runner_ops_not_the_shim() {
+        const TEST: &str = "host_ctx_runtime_reaches_real_runner_ops_not_the_shim";
+        // No plugin loaded in a plain lib test, so `host_callbacks()` is
+        // `None` — this build IS the host, exactly the branch under test.
+        assert!(
+            crate::core::plugin::host_services::host_callbacks().is_none(),
+            "{TEST}: precondition — a plain lib test has no host callbacks installed"
+        );
+
+        let Some(gpu) = gpu_or_skip(TEST) else {
+            return;
+        };
+
+        let runner = Runner::new().expect("runner builds");
+        let runtime_ops: Arc<dyn RuntimeOperations> =
+            Arc::clone(&runner) as Arc<dyn RuntimeOperations>;
+
+        let tokio_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread tokio runtime");
+        let node = Iceoryx2Node::new().expect("iceoryx2 node");
+        let audio_clock: SharedAudioClock =
+            Arc::new(SoftwareAudioClock::new(AudioClockConfig::default()));
+
+        let base = RuntimeContext::new(
+            gpu,
+            Arc::new(TimeContext::new()),
+            Arc::new(RuntimeUniqueId::new()),
+            runtime_ops,
+            tokio_runtime.handle().clone(),
+            node,
+            audio_clock,
+            #[cfg(target_os = "linux")]
+            std::path::PathBuf::from("/tmp/streamlib-test-tap-wiring.sock"),
+        );
+
+        let ctx = RuntimeContextFullAccess::new(&base);
+        let err = tokio_runtime.block_on(async {
+            ctx.runtime()
+                .tap_async("no-such-channel".to_string(), None)
+                .await
+                .expect_err("tapping an unwired channel must fail")
+        });
+
+        assert!(
+            matches!(err, Error::TapChannelNotFound(_)),
+            "{TEST}: host-resident ctx.runtime() must reach the real Runner ops so an unwired \
+             channel surfaces TapChannelNotFound; the RuntimeOpsShim would answer NotSupported. \
+             got {err:?}"
+        );
     }
 }
 

--- a/runtime/streamlib-engine/src/core/context/runtime_ops_shim.rs
+++ b/runtime/streamlib-engine/src/core/context/runtime_ops_shim.rs
@@ -324,12 +324,12 @@ impl RuntimeOperations for RuntimeOpsShim {
         _count: Option<usize>,
     ) -> BoxFuture<'_, Result<crate::core::runtime::TapSubscription>> {
         // A tap owns the host's `!Send` iceoryx2 subscriber on a host thread;
-        // there is no `RuntimeOpsVTable` op for it, so a subprocess reaching the
-        // runtime across the plugin ABI cannot initiate one. Tap from the
+        // there is no `RuntimeOpsVTable` op for it, so a plugin cdylib reaching
+        // the runtime across the plugin ABI cannot initiate one. Tap from the
         // host-side api-server / MCP surface instead.
         Box::pin(async move {
             Err(Error::NotSupported(
-                "tap is a host-side operation — a subprocess cannot initiate a channel tap across \
+                "tap is a host-side operation — a plugin cdylib cannot initiate a channel tap across \
                  the plugin ABI (no RuntimeOpsVTable op); tap from the host api-server / MCP surface"
                     .to_string(),
             ))

--- a/runtime/streamlib-engine/src/core/context/runtime_ops_shim.rs
+++ b/runtime/streamlib-engine/src/core/context/runtime_ops_shim.rs
@@ -318,6 +318,24 @@ impl RuntimeOperations for RuntimeOpsShim {
         )
     }
 
+    fn tap_async(
+        &self,
+        _channel: String,
+        _count: Option<usize>,
+    ) -> BoxFuture<'_, Result<crate::core::runtime::TapSubscription>> {
+        // A tap owns the host's `!Send` iceoryx2 subscriber on a host thread;
+        // there is no `RuntimeOpsVTable` op for it, so a subprocess reaching the
+        // runtime across the plugin ABI cannot initiate one. Tap from the
+        // host-side api-server / MCP surface instead.
+        Box::pin(async move {
+            Err(Error::NotSupported(
+                "tap is a host-side operation — a subprocess cannot initiate a channel tap across \
+                 the plugin ABI (no RuntimeOpsVTable op); tap from the host api-server / MCP surface"
+                    .to_string(),
+            ))
+        })
+    }
+
     // -------------------------------------------------------------------------
     // Sync convenience wrappers — `block_on` against the caller's
     // ambient tokio context. Plugins driving these from non-async

--- a/runtime/streamlib-engine/src/core/runtime/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/mod.rs
@@ -10,6 +10,7 @@ mod operations_runtime;
 mod runtime;
 mod runtime_unique_id;
 mod status;
+mod tap;
 
 pub use install::{InstallError, InstallOptions, InstallReport, install};
 pub use streamlib_idents::app_modules::{
@@ -34,6 +35,7 @@ pub use operations::{
     SchemaValidationPosture, SubmittedProcessorSource,
 };
 pub use runtime::Runner;
+pub use tap::TapSubscription;
 pub use runtime_unique_id::RuntimeUniqueId;
 pub use status::RuntimeStatus;
 

--- a/runtime/streamlib-engine/src/core/runtime/operations.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations.rs
@@ -4,6 +4,7 @@
 use crate::core::error::Result;
 use crate::core::graph::{LinkUniqueId, ProcessorUniqueId};
 use crate::core::processors::ProcessorSpec;
+use crate::core::runtime::TapSubscription;
 use crate::core::{InputLinkPortRef, OutputLinkPortRef};
 use std::future::Future;
 use std::pin::Pin;
@@ -244,6 +245,33 @@ pub trait RuntimeOperations: Send + Sync {
         &self,
         request: ReplaceProcessorFromSource,
     ) -> BoxFuture<'_, Result<RegisterProcessorReceipt>>;
+
+    /// Attach a read-only tap to a named channel, streaming its raw bags.
+    ///
+    /// `channel` is a channel data-service name
+    /// (`{source_processor}/{source_output_port}`,
+    /// `streamlib_idents::source_channel_name`); `count` bounds the tap to that
+    /// many bags then ends, `None` streams live until the returned
+    /// [`TapSubscription`] is dropped. The tap consumes the channel's single
+    /// reserved subscriber slot with no publisher re-open, so exactly one
+    /// concurrent tap per channel is allowed — a second attach fails with
+    /// [`Error::TapSlotOccupied`] until the first detaches (drops). An unwired /
+    /// unknown channel fails with [`Error::TapChannelNotFound`].
+    ///
+    /// There is no sync variant: a tap yields a live streaming handle, not a
+    /// one-shot result, so blocking on it is never the intent. Host-side only —
+    /// a subprocess cannot own the host's `!Send` subscriber, so
+    /// implementations reachable only across the plugin ABI reject this with
+    /// [`Error::NotSupported`].
+    ///
+    /// [`Error::TapSlotOccupied`]: crate::core::error::Error::TapSlotOccupied
+    /// [`Error::TapChannelNotFound`]: crate::core::error::Error::TapChannelNotFound
+    /// [`Error::NotSupported`]: crate::core::error::Error::NotSupported
+    fn tap_async(
+        &self,
+        channel: String,
+        count: Option<usize>,
+    ) -> BoxFuture<'_, Result<TapSubscription>>;
 
     // =========================================================================
     // Sync Methods (convenience wrappers - NOT safe from tokio tasks)

--- a/runtime/streamlib-engine/src/core/runtime/operations.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations.rs
@@ -260,7 +260,7 @@ pub trait RuntimeOperations: Send + Sync {
     ///
     /// There is no sync variant: a tap yields a live streaming handle, not a
     /// one-shot result, so blocking on it is never the intent. Host-side only —
-    /// a subprocess cannot own the host's `!Send` subscriber, so
+    /// a plugin cdylib cannot own the host's `!Send` subscriber, so
     /// implementations reachable only across the plugin ABI reject this with
     /// [`Error::NotSupported`].
     ///

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -416,6 +416,53 @@ impl RuntimeOperations for Runner {
         Box::pin(self.replace_processor_from_source(request))
     }
 
+    #[tracing::instrument(name = "runtime.tap", skip(self), fields(channel = %channel, count = ?count))]
+    fn tap_async(
+        &self,
+        channel: String,
+        count: Option<usize>,
+    ) -> BoxFuture<'_, Result<crate::core::runtime::TapSubscription>> {
+        // Resolve the channel's source output port and its iceoryx2 sizing from
+        // the live graph BEFORE spawning: the same derivation the compiler op
+        // used to open the service, so the tap's publisher-free reopen requests
+        // identical, iceoryx2-verified parameters.
+        let resolved = self.compiler.scope(
+            |graph, _tx| -> Result<(String, crate::core::compiler::compiler_ops::ChannelSizing)> {
+                let (source_proc_id, source_port) =
+                    crate::core::compiler::compiler_ops::find_channel_source_port(graph, &channel)
+                        .ok_or_else(|| Error::TapChannelNotFound(channel.clone()))?;
+                let sizing = crate::core::compiler::compiler_ops::resolve_channel_sizing(
+                    graph,
+                    &source_proc_id,
+                    &source_port,
+                )?;
+                Ok((channel.clone(), sizing))
+            },
+        );
+
+        let node = self.iceoryx2_node.clone();
+        Box::pin(async move {
+            let (channel, sizing) = resolved?;
+            // The reserved-slot subscriber is `!Send` and lives on a dedicated
+            // OS thread; `start_channel_tap` blocks briefly for its subscribe
+            // outcome, so it runs on a blocking pool, off the async worker.
+            tokio::task::spawn_blocking(move || {
+                crate::core::runtime::tap::start_channel_tap(
+                    node,
+                    channel,
+                    sizing.max_subscribers,
+                    sizing.max_queued_messages,
+                    sizing.enable_safe_overflow,
+                    count,
+                )
+            })
+            .await
+            .map_err(|join_error| {
+                Error::Runtime(format!("channel-tap start task failed to join: {join_error}"))
+            })?
+        })
+    }
+
     // =========================================================================
     // Sync Methods (variant-aware blocking strategy)
     // =========================================================================

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -450,9 +450,11 @@ impl RuntimeOperations for Runner {
                 crate::core::runtime::tap::start_channel_tap(
                     node,
                     channel,
-                    sizing.max_subscribers,
-                    sizing.max_queued_messages,
-                    sizing.enable_safe_overflow,
+                    crate::core::runtime::tap::TapChannelSizing {
+                        max_subscribers: sizing.max_subscribers,
+                        max_queued_messages: sizing.max_queued_messages,
+                        enable_safe_overflow: sizing.enable_safe_overflow,
+                    },
                     count,
                 )
             })

--- a/runtime/streamlib-engine/src/core/runtime/tap.rs
+++ b/runtime/streamlib-engine/src/core/runtime/tap.rs
@@ -19,6 +19,12 @@
 //! `max_subscribers`) and creates the reserved subscriber. No new service, no
 //! publisher change, no sizing change.
 //!
+//! The reserved slot is a COUNTING reservation (iceoryx2 only enforces
+//! `max_subscribers = destinations + 1`), not an identity reservation, so a tap
+//! attached during a startup/replace window before a destination subscriber
+//! exists can occupy the slot that destination will need — narrow in practice,
+//! since taps target already-running pipelines.
+//!
 //! iceoryx2's `Subscriber` holds `Rc` internally and is `!Send`, so it cannot
 //! move into the caller's tokio tasks. The tap therefore owns a dedicated OS
 //! thread that holds the subscriber and forwards each raw bag's bytes over a
@@ -236,17 +242,21 @@ fn run_forwarder(
         if signals.stop_flag.load(Ordering::Acquire) {
             break;
         }
+        // Enforce the bound BEFORE receiving/forwarding so `count = Some(0)` ends
+        // the stream with zero bags and a clean close. A post-forward check can
+        // only observe the bound after already delivering one bag, so count=0
+        // would leak a single frame.
+        if let Some(bound) = count {
+            if delivered >= bound {
+                break;
+            }
+        }
         match subscriber.receive() {
             Ok(Some(sample)) => {
                 use tokio::sync::mpsc::error::TrySendError;
                 match forward_tx.try_send(sample.payload().to_vec()) {
                     Ok(()) => {
                         delivered += 1;
-                        if let Some(bound) = count {
-                            if delivered >= bound {
-                                break;
-                            }
-                        }
                     }
                     // Downstream full: DROP the newest bag so the iceoryx2
                     // subscriber stays drained and the source is never
@@ -446,6 +456,43 @@ mod tests {
             assert!(
                 ended.is_none(),
                 "a count=2 tap must end its stream after exactly 2 bags",
+            );
+        });
+    }
+
+    /// A `count = Some(0)` tap forwards ZERO bags and closes its stream cleanly,
+    /// even while the channel keeps publishing. The bound is enforced before the
+    /// first forward, so no frame leaks past a zero bound.
+    ///
+    /// Mentally revert the pre-forward bound check to the post-forward one: the
+    /// first bag is delivered before `delivered >= 0` is observed, so `recv()`
+    /// yields one frame instead of `None` and this test goes red.
+    #[test]
+    fn zero_count_tap_delivers_no_bags_then_closes() {
+        let max_subscribers = RESERVED_TAP_SUBSCRIBER_SLOTS_PER_CHANNEL;
+        let node = Iceoryx2Node::new().expect("create iceoryx2 node");
+        let channel = unique_channel_name("zero-count");
+        let service = open_channel(&node, &channel, max_subscribers);
+        let publisher = service.create_publisher(64).expect("channel publisher");
+
+        let mut tap = start_channel_tap(node.clone(), channel.clone(), realtime_sizing(max_subscribers), Some(0))
+            .expect("zero-count tap attaches");
+
+        for marker in 0u8..5 {
+            publish_marker(&publisher, marker);
+        }
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .expect("current-thread runtime");
+        runtime.block_on(async {
+            let ended = tokio::time::timeout(Duration::from_secs(2), tap.recv())
+                .await
+                .expect("zero-count tap closes its stream promptly");
+            assert!(
+                ended.is_none(),
+                "a count=0 tap must deliver zero bags and close cleanly",
             );
         });
     }

--- a/runtime/streamlib-engine/src/core/runtime/tap.rs
+++ b/runtime/streamlib-engine/src/core/runtime/tap.rs
@@ -14,13 +14,23 @@
 //! iceoryx2's `Subscriber` holds `Rc` internally and is `!Send`, so it cannot
 //! move into the caller's tokio tasks. The tap therefore owns a dedicated OS
 //! thread that holds the subscriber and forwards each raw bag's bytes over a
-//! `tokio::sync::mpsc` (Send) to the async caller — the same sync-source →
-//! mpsc → async bridge the event WebSocket uses. Detaching = dropping the
-//! [`TapSubscription`]: the forwarder thread is signalled to stop, joined, and
-//! the reserved slot is freed for the next tap.
+//! `tokio::sync::mpsc` (Send) to the async caller.
+//!
+//! The forwarder ALWAYS drains the iceoryx2 subscriber and NEVER blocks on the
+//! downstream: it forwards with `try_send` over a BOUNDED mpsc and, when that
+//! channel is full, DROPS the newest bag (counted, [`TapSubscription::dropped_bags`])
+//! rather than parking. A read-only observability tap must never gate production
+//! throughput — on a lossless channel a forwarder parked in a blocking send
+//! would stop draining, fill the iceoryx2 buffer, and back-pressure the source
+//! processor's `send()`. This is deliberately unlike the UNBOUNDED event
+//! WebSocket bridge: the tap trades completeness for guaranteed non-interference.
+//!
+//! Detaching = dropping the [`TapSubscription`]: the mpsc receiver is closed,
+//! the forwarder thread is signalled to stop, joined, and the reserved slot is
+//! freed for the next tap.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
@@ -34,6 +44,30 @@ use crate::iceoryx2::{ChannelTapSubscribeError, Iceoryx2Node};
 /// draining a live channel promptly.
 const TAP_IDLE_POLL_BACKOFF: Duration = Duration::from_micros(500);
 
+/// Emit a drop warning on the first drop then once per this many subsequent
+/// drops, so a persistently-slow downstream is visible without spamming a log
+/// line per dropped bag on a hot channel.
+const TAP_DROP_WARN_INTERVAL: u64 = 256;
+
+/// The iceoryx2 sizing a tap must reopen its channel data service with. Both
+/// the compiler op that created the service and this tap derive the same triple
+/// from the live graph, so iceoryx2 accepts the publisher-free reopen.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TapChannelSizing {
+    pub(crate) max_subscribers: usize,
+    pub(crate) max_queued_messages: usize,
+    pub(crate) enable_safe_overflow: bool,
+}
+
+/// The two Arc handles shared between a [`TapSubscription`] and its forwarder
+/// thread: the stop flag the owner raises on detach, and the counter the
+/// forwarder bumps every time it drops a bag into a full downstream.
+#[derive(Debug, Clone)]
+struct TapForwarderSignals {
+    stop_flag: Arc<AtomicBool>,
+    dropped_bags: Arc<AtomicU64>,
+}
+
 /// A live read-only subscription to a named channel, streaming that channel's
 /// raw bag bytes ([`FrameHeader`](streamlib_ipc_types)-framed, exactly as
 /// published) to the async caller.
@@ -45,7 +79,7 @@ const TAP_IDLE_POLL_BACKOFF: Duration = Duration::from_micros(500);
 pub struct TapSubscription {
     channel: String,
     receiver: tokio::sync::mpsc::Receiver<Vec<u8>>,
-    stop_flag: Arc<AtomicBool>,
+    signals: TapForwarderSignals,
     forwarder_thread: Option<JoinHandle<()>>,
 }
 
@@ -61,11 +95,23 @@ impl TapSubscription {
     pub async fn recv(&mut self) -> Option<Vec<u8>> {
         self.receiver.recv().await
     }
+
+    /// Bags this tap dropped because the async consumer fell behind and the
+    /// bounded forward channel was full. A read-only tap drops rather than
+    /// back-pressuring the source, so a non-zero count means the observer is
+    /// too slow for the channel's rate, not that the pipeline stalled.
+    pub fn dropped_bags(&self) -> u64 {
+        self.signals.dropped_bags.load(Ordering::Acquire)
+    }
 }
 
 impl Drop for TapSubscription {
     fn drop(&mut self) {
-        self.stop_flag.store(true, Ordering::Release);
+        self.signals.stop_flag.store(true, Ordering::Release);
+        // Belt-and-suspenders: the forwarder uses try_send and never parks, but
+        // closing the receiver guarantees any in-flight send resolves to Closed
+        // so join() cannot hang.
+        self.receiver.close();
         if let Some(thread) = self.forwarder_thread.take() {
             let _ = thread.join();
         }
@@ -83,31 +129,30 @@ impl Drop for TapSubscription {
 pub(crate) fn start_channel_tap(
     node: Iceoryx2Node,
     channel: String,
-    max_subscribers: usize,
-    max_queued_messages: usize,
-    enable_safe_overflow: bool,
+    sizing: TapChannelSizing,
     count: Option<usize>,
 ) -> Result<TapSubscription> {
-    let forward_capacity = max_queued_messages.max(1);
+    let forward_capacity = sizing.max_queued_messages.max(1);
     let (forward_tx, receiver) = tokio::sync::mpsc::channel::<Vec<u8>>(forward_capacity);
     let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<()>>();
-    let stop_flag = Arc::new(AtomicBool::new(false));
+    let signals = TapForwarderSignals {
+        stop_flag: Arc::new(AtomicBool::new(false)),
+        dropped_bags: Arc::new(AtomicU64::new(0)),
+    };
 
     let thread_channel = channel.clone();
-    let thread_stop = Arc::clone(&stop_flag);
+    let thread_signals = signals.clone();
     let forwarder_thread = std::thread::Builder::new()
         .name("streamlib-channel-tap".into())
         .spawn(move || {
             run_forwarder(
                 node,
                 thread_channel,
-                max_subscribers,
-                max_queued_messages,
-                enable_safe_overflow,
+                sizing,
                 count,
                 forward_tx,
                 ready_tx,
-                thread_stop,
+                thread_signals,
             );
         })
         .map_err(|e| Error::Runtime(format!("failed to spawn channel-tap thread: {e}")))?;
@@ -119,7 +164,7 @@ pub(crate) fn start_channel_tap(
         Ok(Ok(())) => Ok(TapSubscription {
             channel,
             receiver,
-            stop_flag,
+            signals,
             forwarder_thread: Some(forwarder_thread),
         }),
         Ok(Err(subscribe_error)) => {
@@ -138,26 +183,23 @@ pub(crate) fn start_channel_tap(
 /// Body of the dedicated tap thread: open the channel service publisher-free,
 /// create the reserved-slot subscriber, report the outcome, then forward raw
 /// bags until stopped, the client detaches, or the bounded count is reached.
-#[allow(clippy::too_many_arguments)]
 fn run_forwarder(
     node: Iceoryx2Node,
     channel: String,
-    max_subscribers: usize,
-    max_queued_messages: usize,
-    enable_safe_overflow: bool,
+    sizing: TapChannelSizing,
     count: Option<usize>,
     forward_tx: tokio::sync::mpsc::Sender<Vec<u8>>,
     ready_tx: std::sync::mpsc::Sender<Result<()>>,
-    stop_flag: Arc<AtomicBool>,
+    signals: TapForwarderSignals,
 ) {
     // Reopen the existing service on the OPEN path — same max_subscribers, no
     // publisher created ("no publisher re-open" holds). iceoryx2 verifies the
     // sizing against the live service.
     let service = match node.open_or_create_service(
         &channel,
-        max_subscribers,
-        max_queued_messages,
-        enable_safe_overflow,
+        sizing.max_subscribers,
+        sizing.max_queued_messages,
+        sizing.enable_safe_overflow,
     ) {
         Ok(service) => service,
         Err(open_error) => {
@@ -183,20 +225,39 @@ fn run_forwarder(
 
     let mut delivered: usize = 0;
     loop {
-        if stop_flag.load(Ordering::Acquire) {
+        if signals.stop_flag.load(Ordering::Acquire) {
             break;
         }
         match subscriber.receive() {
             Ok(Some(sample)) => {
-                if forward_tx.blocking_send(sample.payload().to_vec()).is_err() {
-                    // Receiver dropped — the TapSubscription was detached.
-                    break;
-                }
-                delivered += 1;
-                if let Some(bound) = count {
-                    if delivered >= bound {
-                        break;
+                use tokio::sync::mpsc::error::TrySendError;
+                match forward_tx.try_send(sample.payload().to_vec()) {
+                    Ok(()) => {
+                        delivered += 1;
+                        if let Some(bound) = count {
+                            if delivered >= bound {
+                                break;
+                            }
+                        }
                     }
+                    // Downstream full: DROP the newest bag so the iceoryx2
+                    // subscriber stays drained and the source is never
+                    // back-pressured by this read-only tap.
+                    Err(TrySendError::Full(_dropped_bag)) => {
+                        let total =
+                            signals.dropped_bags.fetch_add(1, Ordering::AcqRel) + 1;
+                        if total == 1 || total % TAP_DROP_WARN_INTERVAL == 0 {
+                            tracing::warn!(
+                                channel = %channel,
+                                dropped_bags = total,
+                                "channel tap downstream is full; dropping bags to keep the \
+                                 iceoryx2 subscriber drained (a read-only tap never \
+                                 back-pressures the source)"
+                            );
+                        }
+                    }
+                    // Receiver dropped/closed — the TapSubscription detached.
+                    Err(TrySendError::Closed(_)) => break,
                 }
             }
             Ok(None) => std::thread::sleep(TAP_IDLE_POLL_BACKOFF),
@@ -255,6 +316,16 @@ mod tests {
             .expect("open channel data service")
     }
 
+    /// Realtime (drop-oldest) sizing matching [`open_channel`], for the tap's
+    /// publisher-free reopen.
+    fn realtime_sizing(max_subscribers: usize) -> TapChannelSizing {
+        TapChannelSizing {
+            max_subscribers,
+            max_queued_messages: RING_DEPTH,
+            enable_safe_overflow: true,
+        }
+    }
+
     /// A tap attaches to a live channel's reserved slot, observes the bags
     /// published after it attached, and — while it holds the reserved slot — a
     /// second concurrent tap is rejected with the named `TapSlotOccupied`.
@@ -280,11 +351,11 @@ mod tests {
             .collect();
 
         // Tap #1 fills the reserved slot.
-        let mut tap = start_channel_tap(node.clone(), channel.clone(), max_subscribers, RING_DEPTH, true, None)
+        let mut tap = start_channel_tap(node.clone(), channel.clone(), realtime_sizing(max_subscribers), None)
             .expect("first tap attaches to the reserved slot");
 
         // Tap #2 must be rejected — the single reserved slot is taken.
-        let err = start_channel_tap(node.clone(), channel.clone(), max_subscribers, RING_DEPTH, true, None)
+        let err = start_channel_tap(node.clone(), channel.clone(), realtime_sizing(max_subscribers), None)
             .expect_err("a second concurrent tap must be rejected");
         assert!(
             matches!(err, Error::TapSlotOccupied(_)),
@@ -322,7 +393,7 @@ mod tests {
         drop(tap);
 
         // A fresh tap now attaches only because the slot was freed on detach.
-        let tap_again = start_channel_tap(node.clone(), channel.clone(), max_subscribers, RING_DEPTH, true, None)
+        let tap_again = start_channel_tap(node.clone(), channel.clone(), realtime_sizing(max_subscribers), None)
             .expect("reserved slot must be free again after the first tap detached");
         drop(tap_again);
     }
@@ -338,7 +409,7 @@ mod tests {
         let service = open_channel(&node, &channel, max_subscribers);
         let publisher = service.create_publisher(64).expect("channel publisher");
 
-        let mut tap = start_channel_tap(node.clone(), channel.clone(), max_subscribers, RING_DEPTH, true, Some(2))
+        let mut tap = start_channel_tap(node.clone(), channel.clone(), realtime_sizing(max_subscribers), Some(2))
             .expect("bounded tap attaches");
 
         for marker in 0u8..5 {
@@ -369,5 +440,74 @@ mod tests {
                 "a count=2 tap must end its stream after exactly 2 bags",
             );
         });
+    }
+
+    /// A stalled downstream (the async consumer never calls `recv()`) must NOT
+    /// block the forwarder's iceoryx2 drain, and detaching such a tap must
+    /// return promptly instead of hanging on a parked forwarder.
+    ///
+    /// This is exercised on a LOSSLESS channel (`enable_safe_overflow = false`),
+    /// the exact production hazard: a forwarder parked in a blocking send would
+    /// stop draining iceoryx2 and back-pressure the source's `send()`. The
+    /// forwarder must instead keep receiving and DROP into the full mpsc
+    /// (asserted via `dropped_bags()`), and `drop(tap)` must not hang.
+    ///
+    /// Mentally revert to `blocking_send` (and remove `receiver.close()` from
+    /// Drop): the forwarder parks the moment the bounded mpsc fills, never bumps
+    /// `dropped_bags`, and — because Drop joins while the receiver is still
+    /// alive — `drop(tap)` blocks forever, tripping the recv_timeout below.
+    #[test]
+    fn stalled_downstream_never_blocks_the_drain_and_detach_returns_promptly() {
+        let max_subscribers = RESERVED_TAP_SUBSCRIBER_SLOTS_PER_CHANNEL;
+        let node = Iceoryx2Node::new().expect("create iceoryx2 node");
+        let channel = unique_channel_name("backpressure");
+        // Lossless: a forwarder that parks would stall the producer.
+        let service = node
+            .open_or_create_service(&channel, max_subscribers, RING_DEPTH, false)
+            .expect("open lossless channel data service");
+        let publisher = service.create_publisher(64).expect("channel publisher");
+
+        let sizing = TapChannelSizing {
+            max_subscribers,
+            max_queued_messages: RING_DEPTH,
+            enable_safe_overflow: false,
+        };
+        // Never drain this tap: the bounded forward channel (capacity RING_DEPTH)
+        // fills and stays full, so every further bag must be dropped.
+        let tap = start_channel_tap(node.clone(), channel.clone(), sizing, None)
+            .expect("tap attaches");
+
+        // Drive far more than the mpsc capacity through the channel until the
+        // forwarder reports drops — proving it kept receiving past a full
+        // downstream rather than parking.
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        let mut marker: u8 = 0;
+        while tap.dropped_bags() == 0 {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "forwarder never dropped a bag — it is not draining past a full downstream",
+            );
+            for _ in 0..(RING_DEPTH * 2) {
+                publish_marker(&publisher, marker);
+                marker = marker.wrapping_add(1);
+            }
+            std::thread::sleep(Duration::from_millis(2));
+        }
+        assert!(
+            tap.dropped_bags() > 0,
+            "a stalled downstream must make the forwarder drop bags, not park",
+        );
+
+        // Detaching must return promptly — the forwarder is never parked in a
+        // blocking send, so join() completes within its next poll.
+        let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
+        let joiner = std::thread::spawn(move || {
+            drop(tap);
+            let _ = done_tx.send(());
+        });
+        done_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("drop(tap) must return promptly, not hang on a parked forwarder");
+        joiner.join().expect("detach thread joins");
     }
 }

--- a/runtime/streamlib-engine/src/core/runtime/tap.rs
+++ b/runtime/streamlib-engine/src/core/runtime/tap.rs
@@ -1,0 +1,373 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! First-class channel tap — a read-only subscriber attachable to any named
+//! channel via the reserved tap slot the channel data service is sized for.
+//!
+//! A channel data service is opened with
+//! `max_subscribers = N_destinations + RESERVED_TAP_SUBSCRIBER_SLOTS_PER_CHANNEL`
+//! (1), so a tap is a pure subscriber-add onto the pre-sized reserved slot: it
+//! reopens the existing service publisher-free (iceoryx2 verifies the identical
+//! `max_subscribers`) and creates the reserved subscriber. No new service, no
+//! publisher change, no sizing change.
+//!
+//! iceoryx2's `Subscriber` holds `Rc` internally and is `!Send`, so it cannot
+//! move into the caller's tokio tasks. The tap therefore owns a dedicated OS
+//! thread that holds the subscriber and forwards each raw bag's bytes over a
+//! `tokio::sync::mpsc` (Send) to the async caller — the same sync-source →
+//! mpsc → async bridge the event WebSocket uses. Detaching = dropping the
+//! [`TapSubscription`]: the forwarder thread is signalled to stop, joined, and
+//! the reserved slot is freed for the next tap.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use crate::core::error::{Error, Result};
+use crate::iceoryx2::{ChannelTapSubscribeError, Iceoryx2Node};
+
+/// Idle backoff between empty `subscriber.receive()` polls on the forwarder
+/// thread. The tap has no notify-listener slot of its own (the notify service
+/// is destination-keyed and sized to fan-in), so it polls the channel ring; a
+/// short backoff keeps a quiet channel from busy-spinning a core while still
+/// draining a live channel promptly.
+const TAP_IDLE_POLL_BACKOFF: Duration = Duration::from_micros(500);
+
+/// A live read-only subscription to a named channel, streaming that channel's
+/// raw bag bytes ([`FrameHeader`](streamlib_ipc_types)-framed, exactly as
+/// published) to the async caller.
+///
+/// Dropping the subscription detaches the tap: the forwarder thread stops,
+/// joins, and drops the underlying subscriber — freeing the channel's reserved
+/// tap slot so a subsequent tap can attach.
+#[derive(Debug)]
+pub struct TapSubscription {
+    channel: String,
+    receiver: tokio::sync::mpsc::Receiver<Vec<u8>>,
+    stop_flag: Arc<AtomicBool>,
+    forwarder_thread: Option<JoinHandle<()>>,
+}
+
+impl TapSubscription {
+    /// The channel data-service name this tap is attached to.
+    pub fn channel(&self) -> &str {
+        &self.channel
+    }
+
+    /// Await the next raw bag from the channel. Returns `None` once the tap is
+    /// exhausted — the bounded sample count was reached, the channel's
+    /// forwarder thread ended, or the subscription is detaching.
+    pub async fn recv(&mut self) -> Option<Vec<u8>> {
+        self.receiver.recv().await
+    }
+}
+
+impl Drop for TapSubscription {
+    fn drop(&mut self) {
+        self.stop_flag.store(true, Ordering::Release);
+        if let Some(thread) = self.forwarder_thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+/// Attach a tap to the channel `channel` on `node`, sized to match the service
+/// the compiler opened, streaming raw bags to the returned [`TapSubscription`].
+///
+/// `count` bounds the tap to that many bags then ends; `None` streams live
+/// until the subscription is dropped. Blocks briefly until the reserved-slot
+/// subscriber is created so a [`Error::TapSlotOccupied`] second-tap rejection
+/// surfaces to the caller rather than failing silently on the thread — call it
+/// from `spawn_blocking`, not directly on an async worker.
+pub(crate) fn start_channel_tap(
+    node: Iceoryx2Node,
+    channel: String,
+    max_subscribers: usize,
+    max_queued_messages: usize,
+    enable_safe_overflow: bool,
+    count: Option<usize>,
+) -> Result<TapSubscription> {
+    let forward_capacity = max_queued_messages.max(1);
+    let (forward_tx, receiver) = tokio::sync::mpsc::channel::<Vec<u8>>(forward_capacity);
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<()>>();
+    let stop_flag = Arc::new(AtomicBool::new(false));
+
+    let thread_channel = channel.clone();
+    let thread_stop = Arc::clone(&stop_flag);
+    let forwarder_thread = std::thread::Builder::new()
+        .name("streamlib-channel-tap".into())
+        .spawn(move || {
+            run_forwarder(
+                node,
+                thread_channel,
+                max_subscribers,
+                max_queued_messages,
+                enable_safe_overflow,
+                count,
+                forward_tx,
+                ready_tx,
+                thread_stop,
+            );
+        })
+        .map_err(|e| Error::Runtime(format!("failed to spawn channel-tap thread: {e}")))?;
+
+    // The forwarder reports its subscribe outcome once, before entering the
+    // receive loop. A dropped sender (thread panicked before reporting) reads
+    // as a Runtime error rather than a hang.
+    match ready_rx.recv() {
+        Ok(Ok(())) => Ok(TapSubscription {
+            channel,
+            receiver,
+            stop_flag,
+            forwarder_thread: Some(forwarder_thread),
+        }),
+        Ok(Err(subscribe_error)) => {
+            let _ = forwarder_thread.join();
+            Err(subscribe_error)
+        }
+        Err(_) => {
+            let _ = forwarder_thread.join();
+            Err(Error::Runtime(format!(
+                "channel-tap thread for '{channel}' ended before reporting its subscribe outcome"
+            )))
+        }
+    }
+}
+
+/// Body of the dedicated tap thread: open the channel service publisher-free,
+/// create the reserved-slot subscriber, report the outcome, then forward raw
+/// bags until stopped, the client detaches, or the bounded count is reached.
+#[allow(clippy::too_many_arguments)]
+fn run_forwarder(
+    node: Iceoryx2Node,
+    channel: String,
+    max_subscribers: usize,
+    max_queued_messages: usize,
+    enable_safe_overflow: bool,
+    count: Option<usize>,
+    forward_tx: tokio::sync::mpsc::Sender<Vec<u8>>,
+    ready_tx: std::sync::mpsc::Sender<Result<()>>,
+    stop_flag: Arc<AtomicBool>,
+) {
+    // Reopen the existing service on the OPEN path — same max_subscribers, no
+    // publisher created ("no publisher re-open" holds). iceoryx2 verifies the
+    // sizing against the live service.
+    let service = match node.open_or_create_service(
+        &channel,
+        max_subscribers,
+        max_queued_messages,
+        enable_safe_overflow,
+    ) {
+        Ok(service) => service,
+        Err(open_error) => {
+            let _ = ready_tx.send(Err(open_error));
+            return;
+        }
+    };
+
+    let subscriber = match service.create_tap_subscriber() {
+        Ok(subscriber) => subscriber,
+        Err(ChannelTapSubscribeError::ReservedSlotOccupied) => {
+            let _ = ready_tx.send(Err(Error::TapSlotOccupied(channel)));
+            return;
+        }
+        Err(ChannelTapSubscribeError::Transport(detail)) => {
+            let _ = ready_tx.send(Err(Error::Runtime(format!(
+                "failed to attach tap subscriber to channel '{channel}': {detail}"
+            ))));
+            return;
+        }
+    };
+    let _ = ready_tx.send(Ok(()));
+
+    let mut delivered: usize = 0;
+    loop {
+        if stop_flag.load(Ordering::Acquire) {
+            break;
+        }
+        match subscriber.receive() {
+            Ok(Some(sample)) => {
+                if forward_tx.blocking_send(sample.payload().to_vec()).is_err() {
+                    // Receiver dropped — the TapSubscription was detached.
+                    break;
+                }
+                delivered += 1;
+                if let Some(bound) = count {
+                    if delivered >= bound {
+                        break;
+                    }
+                }
+            }
+            Ok(None) => std::thread::sleep(TAP_IDLE_POLL_BACKOFF),
+            Err(receive_error) => {
+                tracing::warn!(
+                    channel = %channel,
+                    "channel tap subscriber.receive() failed, ending tap: {receive_error:?}"
+                );
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    use iceoryx2::prelude::*;
+    use streamlib_ipc_types::RESERVED_TAP_SUBSCRIBER_SLOTS_PER_CHANNEL;
+
+    use crate::iceoryx2::{FRAME_HEADER_SIZE, Iceoryx2Node, Iceoryx2Service};
+
+    const RING_DEPTH: usize = 16;
+
+    fn unique_channel_name(tag: &str) -> String {
+        format!(
+            "test/tap/{}/{}/{}",
+            tag,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        )
+    }
+
+    /// Publish one bag whose last payload byte is `marker` (a full
+    /// `FRAME_HEADER_SIZE + 1` slice, mirroring the channel wire shape).
+    fn publish_marker(
+        publisher: &iceoryx2::port::publisher::Publisher<ipc::Service, [u8], ()>,
+        marker: u8,
+    ) {
+        let mut payload = vec![0u8; FRAME_HEADER_SIZE + 1];
+        payload[FRAME_HEADER_SIZE] = marker;
+        let sample = publisher
+            .loan_slice_uninit(payload.len())
+            .expect("loan slot");
+        let sample = sample.write_from_slice(&payload);
+        sample.send().expect("send bag");
+    }
+
+    fn open_channel(node: &Iceoryx2Node, name: &str, max_subscribers: usize) -> Iceoryx2Service {
+        node.open_or_create_service(name, max_subscribers, RING_DEPTH, true)
+            .expect("open channel data service")
+    }
+
+    /// A tap attaches to a live channel's reserved slot, observes the bags
+    /// published after it attached, and — while it holds the reserved slot — a
+    /// second concurrent tap is rejected with the named `TapSlotOccupied`.
+    /// Detaching (drop) frees the slot so a subsequent tap attaches cleanly.
+    ///
+    /// Mentally revert `RESERVED_TAP_SUBSCRIBER_SLOTS_PER_CHANNEL` to 0: the
+    /// service is sized to `destinations` only, so the FIRST tap (the
+    /// destination+1'th subscriber) no longer fits and this test's initial
+    /// attach fails.
+    #[test]
+    fn tap_observes_live_bags_then_detach_frees_the_reserved_slot() {
+        // One destination occupies one slot; the reserved tap slot is the +1.
+        let destinations = 1usize;
+        let max_subscribers = destinations + RESERVED_TAP_SUBSCRIBER_SLOTS_PER_CHANNEL;
+
+        let node = Iceoryx2Node::new().expect("create iceoryx2 node");
+        let channel = unique_channel_name("live");
+        let service = open_channel(&node, &channel, max_subscribers);
+        let publisher = service.create_publisher(64).expect("channel publisher");
+        // Occupy the destination slot(s) so the tap can only take the reserved one.
+        let _destination_subscribers: Vec<_> = (0..destinations)
+            .map(|_| service.create_subscriber().expect("destination subscriber"))
+            .collect();
+
+        // Tap #1 fills the reserved slot.
+        let mut tap = start_channel_tap(node.clone(), channel.clone(), max_subscribers, RING_DEPTH, true, None)
+            .expect("first tap attaches to the reserved slot");
+
+        // Tap #2 must be rejected — the single reserved slot is taken.
+        let err = start_channel_tap(node.clone(), channel.clone(), max_subscribers, RING_DEPTH, true, None)
+            .expect_err("a second concurrent tap must be rejected");
+        assert!(
+            matches!(err, Error::TapSlotOccupied(_)),
+            "second concurrent tap must fail with TapSlotOccupied; got {err:?}",
+        );
+
+        // The tap observes bags published after it attached.
+        for marker in 0u8..3 {
+            publish_marker(&publisher, marker);
+        }
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .expect("current-thread runtime");
+        runtime.block_on(async {
+            for expected in 0u8..3 {
+                let bag = tokio::time::timeout(Duration::from_secs(2), tap.recv())
+                    .await
+                    .expect("tap delivers a bag within 2s")
+                    .expect("tap stream is still open");
+                assert_eq!(
+                    bag.len(),
+                    FRAME_HEADER_SIZE + 1,
+                    "tap forwards the full framed bag verbatim",
+                );
+                assert_eq!(
+                    bag[FRAME_HEADER_SIZE], expected,
+                    "tap delivers bags in publish order",
+                );
+            }
+        });
+
+        // Detach — dropping the subscription joins the forwarder thread and
+        // frees the reserved slot.
+        drop(tap);
+
+        // A fresh tap now attaches only because the slot was freed on detach.
+        let tap_again = start_channel_tap(node.clone(), channel.clone(), max_subscribers, RING_DEPTH, true, None)
+            .expect("reserved slot must be free again after the first tap detached");
+        drop(tap_again);
+    }
+
+    /// A bounded tap (`count = Some(n)`) forwards exactly `n` bags then ends its
+    /// stream — `recv()` returns `None` after the nth — and the bound-reached
+    /// end also frees the reserved slot (the forwarder thread exits its loop).
+    #[test]
+    fn bounded_tap_delivers_exactly_n_bags_then_ends() {
+        let max_subscribers = RESERVED_TAP_SUBSCRIBER_SLOTS_PER_CHANNEL;
+        let node = Iceoryx2Node::new().expect("create iceoryx2 node");
+        let channel = unique_channel_name("bounded");
+        let service = open_channel(&node, &channel, max_subscribers);
+        let publisher = service.create_publisher(64).expect("channel publisher");
+
+        let mut tap = start_channel_tap(node.clone(), channel.clone(), max_subscribers, RING_DEPTH, true, Some(2))
+            .expect("bounded tap attaches");
+
+        for marker in 0u8..5 {
+            publish_marker(&publisher, marker);
+        }
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .expect("current-thread runtime");
+        runtime.block_on(async {
+            let first = tokio::time::timeout(Duration::from_secs(2), tap.recv())
+                .await
+                .expect("first bag arrives")
+                .expect("stream open");
+            assert_eq!(first[FRAME_HEADER_SIZE], 0);
+            let second = tokio::time::timeout(Duration::from_secs(2), tap.recv())
+                .await
+                .expect("second bag arrives")
+                .expect("stream open");
+            assert_eq!(second[FRAME_HEADER_SIZE], 1);
+            // The bound was 2 — the stream ends, so recv() resolves to None.
+            let ended = tokio::time::timeout(Duration::from_secs(2), tap.recv())
+                .await
+                .expect("bounded tap ends its stream promptly");
+            assert!(
+                ended.is_none(),
+                "a count=2 tap must end its stream after exactly 2 bags",
+            );
+        });
+    }
+}

--- a/runtime/streamlib-engine/src/core/runtime/tap.rs
+++ b/runtime/streamlib-engine/src/core/runtime/tap.rs
@@ -4,6 +4,14 @@
 //! First-class channel tap — a read-only subscriber attachable to any named
 //! channel via the reserved tap slot the channel data service is sized for.
 //!
+//! The tap is a read-only OBSERVABILITY primitive: it forwards each channel bag
+//! VERBATIM (`FrameHeader`-framed) as WS binary frames — no encode, containerize,
+//! or transcode, so decoding is the client's concern (wire-neutral across
+//! Rust/Python/Deno). To observe a viewable video feed, tap an ENCODED
+//! (h264/h265/jpeg) or container (CMAF/fMP4) channel; a RAW video channel carries
+//! zero-copy DMA-BUF/VkImage frame descriptors (meaningless off-host), not pixels.
+//! It is not a realtime-video transport — that is the WebRTC/MoQ/display processors.
+//!
 //! A channel data service is opened with
 //! `max_subscribers = N_destinations + RESERVED_TAP_SUBSCRIBER_SLOTS_PER_CHANNEL`
 //! (1), so a tap is a pure subscriber-add onto the pre-sized reserved slot: it

--- a/runtime/streamlib-engine/src/iceoryx2/mod.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/mod.rs
@@ -20,7 +20,10 @@ pub use channel_ceiling::{
 pub use delivery_profile::{DeliveryProfile, DeliveryResolution, FlowClass};
 pub use input::{BoundedReadOutcome, InputMailboxes, InputMailboxesInner};
 pub use mailbox::PortMailbox;
-pub use node::{Iceoryx2EventService, Iceoryx2Node, Iceoryx2NotifyService, Iceoryx2Service};
+pub use node::{
+    ChannelTapSubscribeError, Iceoryx2EventService, Iceoryx2Node, Iceoryx2NotifyService,
+    Iceoryx2Service,
+};
 pub use output::{ChannelEgressConfig, OutputWriter, OutputWriterInner};
 pub use overflow::Overflow;
 pub use payload::{

--- a/runtime/streamlib-engine/src/iceoryx2/node.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/node.rs
@@ -182,6 +182,47 @@ impl Iceoryx2Service {
             .create()
             .map_err(|e| Error::Runtime(format!("Failed to create subscriber: {:?}", e)))
     }
+
+    /// Create the channel's reserved-slot tap subscriber, discriminating the
+    /// slot-exhaustion case from every other transport failure.
+    ///
+    /// A channel data service is opened with
+    /// `max_subscribers = N_destinations + RESERVED_TAP_SUBSCRIBER_SLOTS_PER_CHANNEL`
+    /// (1). The N destination subscribers occupy their slots at compile time; the
+    /// reserved slot is what a tap consumes here. iceoryx2 fixes `max_subscribers`
+    /// at create time, so a second concurrent tap trips
+    /// [`iceoryx2::port::subscriber::SubscriberCreateError::ExceedsMaxSupportedSubscribers`]
+    /// — surfaced as [`ChannelTapSubscribeError::ReservedSlotOccupied`] so the op
+    /// can map it to the named [`Error::TapSlotOccupied`], distinct from a generic
+    /// subscribe failure.
+    pub fn create_tap_subscriber(
+        &self,
+    ) -> std::result::Result<
+        iceoryx2::port::subscriber::Subscriber<ipc::Service, [u8], ()>,
+        ChannelTapSubscribeError,
+    > {
+        use iceoryx2::port::subscriber::SubscriberCreateError;
+        self.inner
+            .subscriber_builder()
+            .buffer_size(self.max_queued_messages)
+            .create()
+            .map_err(|e| match e {
+                SubscriberCreateError::ExceedsMaxSupportedSubscribers => {
+                    ChannelTapSubscribeError::ReservedSlotOccupied
+                }
+                other => ChannelTapSubscribeError::Transport(format!("{:?}", other)),
+            })
+    }
+}
+
+/// Why creating a channel's reserved-slot tap subscriber failed.
+#[derive(Debug)]
+pub enum ChannelTapSubscribeError {
+    /// The channel's single reserved tap slot is already taken by another tap —
+    /// iceoryx2 rejected the create with `ExceedsMaxSupportedSubscribers`.
+    ReservedSlotOccupied,
+    /// Any other iceoryx2 subscriber-create failure, rendered for the log.
+    Transport(String),
 }
 
 /// Handle to an iceoryx2 Event service used for fd-multiplexed wakeups.

--- a/runtime/streamlib-runtime/tests/boot.rs
+++ b/runtime/streamlib-runtime/tests/boot.rs
@@ -377,11 +377,12 @@ fn tap_ws_unknown_channel_closes_with_well_formed_reason() {
     // Tap an unwired channel. This exercises the full path: route → real
     // host-shaped RuntimeContext → in-process Runner ops. `ctx.runtime()`
     // must reach the real Runner (not the byte-shaped shim) so the graph
-    // resolution fails with `TapChannelNotFound`; the handler then maps that
-    // to a well-formed WS close frame. If `ctx.runtime()` handed back the
-    // shim, the tap would fail with the long `NotSupported` string, whose
-    // >123-byte reason tungstenite refuses to write — the client would see an
-    // abnormal close with no reason and this test would go red.
+    // resolution fails with `TapChannelNotFound`; the handler maps that to the
+    // app-range close code 4404. If `ctx.runtime()` handed back the shim, the
+    // tap would fail with the `NotSupported` string, which the handler maps to
+    // the generic 1011 close (its over-length reason truncated to the 123-byte
+    // cap, so a reason IS written) — the `close_code == 4404` assertion below
+    // would then read 1011 and this test would go red.
     let mut ws = WsClient::connect(port, "/ws/tap/unknown-channel")
         .expect("WebSocket upgrade on /ws/tap/{channel} should 101");
 

--- a/runtime/streamlib-runtime/tests/boot.rs
+++ b/runtime/streamlib-runtime/tests/boot.rs
@@ -354,6 +354,73 @@ fn websocket_streams_runtime_events_end_to_end() {
 }
 
 #[test]
+fn tap_ws_unknown_channel_closes_with_well_formed_reason() {
+    let base_port = free_port();
+    let temp_home = std::env::temp_dir().join(format!("streamlib-runtime-tap-{base_port}"));
+    let _ = std::fs::remove_dir_all(&temp_home);
+
+    let child = Command::new(env!("CARGO_BIN_EXE_streamlib-runtime"))
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(base_port.to_string())
+        .env("STREAMLIB_HOME", &temp_home)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn streamlib-runtime");
+    let _guard = ChildGuard(child);
+
+    let port =
+        wait_for_health(base_port, Duration::from_secs(60)).expect("runtime should serve /health");
+
+    // Tap an unwired channel. This exercises the full path: route → real
+    // host-shaped RuntimeContext → in-process Runner ops. `ctx.runtime()`
+    // must reach the real Runner (not the byte-shaped shim) so the graph
+    // resolution fails with `TapChannelNotFound`; the handler then maps that
+    // to a well-formed WS close frame. If `ctx.runtime()` handed back the
+    // shim, the tap would fail with the long `NotSupported` string, whose
+    // >123-byte reason tungstenite refuses to write — the client would see an
+    // abnormal close with no reason and this test would go red.
+    let mut ws = WsClient::connect(port, "/ws/tap/unknown-channel")
+        .expect("WebSocket upgrade on /ws/tap/{channel} should 101");
+
+    let (opcode, payload) = ws
+        .read_frame(Instant::now() + Duration::from_secs(10))
+        .expect("the tap must answer an unwired channel with a frame, not a silent hang");
+
+    let _ = std::fs::remove_dir_all(&temp_home);
+
+    assert_eq!(opcode, 0x8, "an unwired-channel tap must close the socket");
+    // RFC 6455 caps a control-frame payload at 125 bytes: 2 for the close
+    // code + at most 123 for the reason.
+    assert!(
+        payload.len() <= 125,
+        "close frame payload must fit RFC 6455's 125-byte control-frame cap; got {}",
+        payload.len()
+    );
+    assert!(
+        payload.len() >= 2,
+        "close frame must carry a 2-byte close code"
+    );
+    let close_code = u16::from_be_bytes([payload[0], payload[1]]);
+    assert_eq!(
+        close_code, 4404,
+        "an unwired channel must close with the app-range channel-not-found code"
+    );
+    let reason = String::from_utf8(payload[2..].to_vec()).expect("close reason must be valid UTF-8");
+    assert!(
+        reason.len() <= 123,
+        "close reason must be <= 123 bytes; got {} ({reason:?})",
+        reason.len()
+    );
+    assert!(
+        reason.contains("not found"),
+        "close reason should name the channel-not-found class; got {reason:?}"
+    );
+}
+
+#[test]
 fn rejects_removed_plugin_args() {
     for arg in ["--plugin", "--plugin-dir"] {
         let output = Command::new(env!("CARGO_BIN_EXE_streamlib-runtime"))

--- a/sdk/streamlib-error/src/lib.rs
+++ b/sdk/streamlib-error/src/lib.rs
@@ -146,6 +146,20 @@ pub enum Error {
     #[error("Runtime error: {0}")]
     Runtime(String),
 
+    #[error(
+        "no tappable channel named '{0}' in the running graph — a channel's \
+         iceoryx2 data service exists only once a connect() has wired its source \
+         output port"
+    )]
+    TapChannelNotFound(String),
+
+    #[error(
+        "the reserved tap slot on channel '{0}' is already occupied — a channel \
+         reserves exactly one tap subscriber slot, so only one concurrent tap is \
+         allowed; detach the existing tap first"
+    )]
+    TapSlotOccupied(String),
+
     #[error("Plugin host services unavailable: {0}")]
     PluginHostUnavailable(String),
 


### PR DESCRIPTION
Closes #1426

## Summary

Adds `RuntimeOperations::tap_async(channel, count)` — a first-class, read-only subscriber attach on any named channel, using the `+1` reserved tap slot the channel data service is already sized for (`RESERVED_TAP_SUBSCRIBER_SLOTS_PER_CHANNEL`). No new iceoryx2 service, no publisher re-open, no sizing change. This is the "perceive" half of perceive-act (#1426).

**Engine**
- Extracted the channel-sizing derivation (`resolve_channel_sizing` + `find_channel_source_port`) shared by the service-open compiler op and the new tap op, so the tap's publisher-free reopen requests identical, iceoryx2-verified parameters (`max_subscribers` = destinations + reserved tap).
- `Iceoryx2Service::create_tap_subscriber` maps iceoryx2's `ExceedsMaxSupportedSubscribers` to a distinct `ReservedSlotOccupied` outcome, surfaced as the named `Error::TapSlotOccupied`.
- Because the iceoryx2 `Subscriber` is `!Send`, a tap owns a dedicated OS thread holding the subscriber and forwarding raw bag bytes over a tokio mpsc (the same sync-source → mpsc → async bridge the event WebSocket already uses). Detach = drop the `TapSubscription` → thread joins → reserved slot frees. The forwarder uses `try_send` (never blocking) so a stalled downstream drops bags instead of back-pressuring the source's `send()`; drop closes the receiver before `join()`.
- `RuntimeOpsShim` (subprocess/cdylib side) rejects tap with `Error::NotSupported` — there is no `RuntimeOpsVTable` op; tap is host-side by construction.
- New named error taxonomy: `Error::TapChannelNotFound` (no iceoryx2 data service wired) and `Error::TapSlotOccupied` (reserved slot already taken by a concurrent tap).

**api-server**
- `GET /ws/tap/{channel}?count=` streams raw bags as binary WS frames, gated behind the same bearer token as the mutating routes when auth is enabled.
- Detach runs via `tokio::task::spawn_blocking` so the `TapSubscription` drop (which joins an OS thread) never blocks a tokio worker.

**Scope**
- Not a `RuntimeOpsVTable` change — api-server is in-process, no cdylib hop.
- Polyglot parity is language-specific by construction: tap is host-side, so Python/Deno channels are tappable transparently with zero SDK change.
- No wire / `#[repr(C)]` / JTD change.

## Commits

- `c0fdc5e3` feat(error): named tap error taxonomy — `TapChannelNotFound` + `TapSlotOccupied`
- `a71ad6fc` feat(engine): first-class channel tap op — read-only reserved-slot subscriber
- `b37d9de9` fix(engine): tap forwarder must never back-pressure production
- `66ceca59` fix(api-server): tap WS auth-gate test, non-blocking detach, clear query param

## Test evidence

- Tap a live channel mid-run, observe bags in order; detach frees the slot (a second tap succeeds only after detach); double-tap → `TapSlotOccupied`; bounded tap delivers exactly `count` then ends; `resolve_channel_sizing` sizing-recovery + channel reverse-resolve unit locks.
- `stalled_downstream_never_blocks_the_drain_and_detach_returns_promptly` (lossless, `enable_safe_overflow=false` channel): asserts `dropped_bags() > 0` and that `drop(tap)` returns within 5s. Ran: PASS. Mentally reverting to `blocking_send` makes the dropped-bags loop hit its 10s deadline and hangs `drop(tap)`'s `recv_timeout` — non-vacuous.
- `tap_ws_rejects_missing_token_with_401_when_auth_on`, `tap_ws_with_token_clears_the_auth_gate`, `tap_ws_is_open_with_auth_off`: PASS. Deleting the `route_layer` flips the 401 assertion to the WS extractor's non-401 rejection — non-vacuous.
- api-server lib built and all 17 tests: PASS.

## Review items (non-blocking)

- **[info]** `runtime/streamlib-engine/src/core/runtime/tap.rs:246` — Prior-round backpressure finding is resolved: the forwarder must never park a lossless channel's drain. Forwarder now uses `forward_tx.try_send(...)` and on `TrySendError::Full` drops the bag (`dropped_bags` counter, warn-throttled) instead of blocking; `Drop` sets `stop_flag` + closes the receiver before `join()`. Regression test `stalled_downstream_never_blocks_the_drain_and_detach_returns_promptly` runs on a lossless (`enable_safe_overflow=false`) channel, asserts `dropped_bags()>0` and that `drop(tap)` returns within 5s. Ran it: PASS. Mentally reverting to `blocking_send` makes the `dropped_bags` loop hit its 10s deadline and drop(tap) hang the `recv_timeout` — non-vacuous. Suggested next step: None — resolved.
- **[info]** `packages/api-server/src/handlers.rs:95` — Prior-round auth-gate finding is resolved: the read-only tap WS is bearer-gated like the mutating routes. `tap_router` carries `.route_layer(from_fn_with_state(tap_auth_token, require_bearer_token))` when auth is on. Three new tests (`tap_ws_rejects_missing_token_with_401_when_auth_on`, `..._with_token_clears_the_auth_gate`, `..._is_open_with_auth_off`) ran PASS. Deleting the `route_layer` flips the 401 assertion to the WS extractor's non-401 rejection — non-vacuous. Suggested next step: None — resolved.
- **[info]** `packages/api-server/src/handlers.rs:586` — Prior-round non-blocking-detach finding is resolved: `TapSubscription::drop` (which joins an OS thread) no longer runs on a tokio worker. Detach is now `tokio::task::spawn_blocking(move || drop(subscription)).await`. api-server lib built and all 17 tests PASS. Suggested next step: None — resolved.
- **[low]** `runtime/streamlib-engine/src/core/runtime/tap.rs:243` — On sustained downstream overload the tap drops the NEWEST bag, so a slow WS/MCP client trails live indefinitely rather than skipping to fresh data, and `dropped_bags()` is never surfaced to the WS client. `tap.rs:246` drops `_dropped_bag` (the just-received newest sample) on `TrySendError::Full`; older bags stay queued in the mpsc. `handle_tap_websocket` never forwards `subscription.dropped_bags()` to the client. This is deliberate and documented (module doc lines 19-26) as a non-interference tradeoff; acceptable for the bounded-count observe use-case but suboptimal for a live observability tap under load. Suggested next step: Optional follow-up: consider drop-oldest for the live (`count=None`) case and/or emit a dropped-bags notice frame; fine to ship as a documented review note, not blocking.
- **[info]** `runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs:356` — The `ChannelSizing`/`resolve_channel_sizing` extraction is a justified shared derivation, not a silent DRY refactor, and is in scope. Both the service-open compiler op (line 157) and the tap op (`operations_runtime.rs:434`) consume `resolve_channel_sizing`, and correctness requires identical sizing on the tap's publisher-free reopen (iceoryx2 verifies `max_subscribers`). Called out in doc comments + commit messages, and locked by `resolve_channel_sizing_recovers_service_open_max_subscribers` (asserts agreement with `channel_max_subscribers`). This is the engine-doctrine "extend the existing derivation" move, not a parallel abstraction. Suggested next step: None.
