### PR TITLE
feat(engine): isolation policy tier — trust model + capability moat for loaded code

### DIFF
--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
@@ -10,7 +10,7 @@ use parking_lot::{Mutex, RwLock};
 
 use crate::core::compiler::scheduling::{SchedulingStrategy, scheduling_strategy_for_processor};
 use crate::core::context::{
-    GpuContext, GpuContextLimitedAccess, RuntimeContext, RuntimeContextFullAccess,
+    GpuContext, GpuContextLimitedAccess, IsolationTier, RuntimeContext, RuntimeContextFullAccess,
 };
 use crate::core::descriptors::ProcessorRuntime;
 use crate::core::error::{Error, Result};
@@ -157,6 +157,25 @@ fn spawn_dedicated_thread(
     };
 
     let processor_arc_clone = Arc::clone(&processor_arc);
+
+    // Derive the isolation trust tier by construction from module provenance:
+    // a @session module that was separately built + dlopened (cdylib-resident)
+    // is untrusted; host-compiled code and installed packages are trusted. The
+    // tier gates every FullAccess mint on this thread (setup / start / stop /
+    // teardown). Fail closed (untrusted) if the node vanished from the graph.
+    let isolation_tier = {
+        let graph = graph_arc.read();
+        let org = graph
+            .traversal()
+            .v(&processor_id)
+            .first()
+            .map(|n| n.processor_type().org.clone());
+        let cdylib_resident = processor_arc.lock().is_cdylib_resident();
+        match org {
+            Some(org) => IsolationTier::for_processor(&org, cdylib_resident),
+            None => IsolationTier::Untrusted,
+        }
+    };
 
     // Generous 8 MB stack — processors run arbitrary codec / plugin code
     // with deep call stacks. IPC payloads are slice-based (`[u8]`) in
@@ -324,7 +343,24 @@ fn spawn_dedicated_thread(
                 .with_pause_gate(pause_gate_inner.clone());
             {
                 let tokio_handle = runtime_ctx_clone.tokio_handle();
-                let full_ctx = RuntimeContextFullAccess::new(&processor_context);
+                // The trust-axis moat: an untrusted tier yields no
+                // `FullAccessGrant`, so an in-process FullAccess context is
+                // unrepresentable here. Refuse to run privileged setup()
+                // in-process — the untrusted processor's privileged lifecycle
+                // belongs behind the subprocess sandbox (isolation enforcement).
+                let Some(full_access_grant) = isolation_tier.grant_full_access() else {
+                    tracing::warn!(
+                        "[{}] Untrusted isolation tier ({}): in-process FullAccess denied by \
+                         construction — refusing privileged setup() (belongs behind the \
+                         subprocess sandbox)",
+                        proc_id_clone,
+                        isolation_tier.as_str(),
+                    );
+                    *state_arc.lock() = ProcessorState::Error;
+                    return;
+                };
+                let full_ctx =
+                    RuntimeContextFullAccess::new(&processor_context, full_access_grant);
                 let mut guard = processor_arc_clone.lock();
 
                 tracing::info!(
@@ -368,6 +404,7 @@ fn spawn_dedicated_thread(
                 pause_gate_inner,
                 exec_config,
                 processor_context,
+                isolation_tier,
             );
         })
         .map_err(|e| Error::Runtime(format!("Failed to spawn thread: {}", e)))?;

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
@@ -9,7 +9,6 @@ use std::os::fd::OwnedFd;
 use parking_lot::{Mutex, RwLock};
 
 use crate::core::compiler::scheduling::{SchedulingStrategy, scheduling_strategy_for_processor};
-use streamlib_idents::Org;
 
 use crate::core::context::{
     FullAccessGrant, GpuContext, GpuContextLimitedAccess, IsolationTier, RuntimeContext,
@@ -149,14 +148,17 @@ fn spawn_dedicated_thread(
     let runtime_ctx_clone = Arc::clone(runtime_ctx);
     let proc_id_clone = processor_id.clone();
 
-    // Create processor instance now (with lock) since factory needs node reference
-    let processor_arc = {
+    // Create processor instance now (with lock) since factory needs node
+    // reference; read the org off the same guaranteed-present node so the
+    // isolation tier is always derived from provenance, never from node absence.
+    let (processor_arc, org) = {
         let graph = graph_arc.read();
         let node = graph.traversal().v(&processor_id).first().ok_or_else(|| {
             Error::ProcessorNotFound(format!("Processor '{}' not found", processor_id))
         })?;
+        let org = node.processor_type().org.clone();
         let processor = factory.create(node)?;
-        Arc::new(Mutex::new(processor))
+        (Arc::new(Mutex::new(processor)), org)
     };
 
     let processor_arc_clone = Arc::clone(&processor_arc);
@@ -165,21 +167,11 @@ fn spawn_dedicated_thread(
     // trusted by default (same as installed), and a @session cdylib is eligible
     // for Untrusted only when the operator opts in (STREAMLIB_SESSION_ISOLATION_TIER
     // / set_session_isolation_tier). The tier gates every FullAccess mint on this
-    // thread (setup / start / stop / teardown).
-    //
-    // cdylib-residency (off the instance) and org (off the graph node) are two
-    // independent reads — taken unnested so no graph(read)→processor(mutex) lock
-    // order is introduced.
+    // thread (setup / start / stop / teardown). cdylib-residency is read off the
+    // instance after the graph lock is released, so no graph(read)→processor(mutex)
+    // lock order is introduced.
     let cdylib_resident = processor_arc.lock().is_cdylib_resident();
-    let org = {
-        let graph = graph_arc.read();
-        graph
-            .traversal()
-            .v(&processor_id)
-            .first()
-            .map(|n| n.processor_type().org.clone())
-    };
-    let isolation_tier = isolation_tier_for_spawn(org.as_ref(), cdylib_resident);
+    let isolation_tier = IsolationTier::for_processor(&org, cdylib_resident);
 
     // Generous 8 MB stack — processors run arbitrary codec / plugin code
     // with deep call stacks. IPC payloads are slice-based (`[u8]`) in
@@ -359,8 +351,7 @@ fn spawn_dedicated_thread(
                 ) else {
                     return;
                 };
-                let full_ctx =
-                    RuntimeContextFullAccess::new(&processor_context, full_access_grant);
+                let full_ctx = RuntimeContextFullAccess::new(&processor_context, full_access_grant);
                 let mut guard = processor_arc_clone.lock();
 
                 tracing::info!(
@@ -423,17 +414,6 @@ fn spawn_dedicated_thread(
     }
 
     Ok(())
-}
-
-/// Derive the isolation trust tier for a spawned processor from its module
-/// provenance. A missing graph node (`org == None`) fails closed to
-/// [`IsolationTier::Untrusted`] — a processor whose node vanished must never be
-/// granted an in-process FullAccess context.
-fn isolation_tier_for_spawn(org: Option<&Org>, cdylib_resident: bool) -> IsolationTier {
-    match org {
-        Some(org) => IsolationTier::for_processor(org, cdylib_resident),
-        None => IsolationTier::Untrusted,
-    }
 }
 
 /// The trust-axis moat at the FullAccess minting seam: yield a
@@ -527,36 +507,6 @@ mod tests {
     use std::sync::mpsc;
     use std::thread;
     use std::time::Duration;
-
-    /// Fail-closed: a processor whose graph node vanished (`org == None`)
-    /// derives [`IsolationTier::Untrusted`], never a trusted tier — a missing
-    /// node must never be granted in-process FullAccess. Mentally revert
-    /// [`isolation_tier_for_spawn`]'s `None` arm to `TrustedInstalled` and this
-    /// flips.
-    #[test]
-    fn spawn_tier_fails_closed_to_untrusted_when_node_missing() {
-        assert_eq!(isolation_tier_for_spawn(None, true), IsolationTier::Untrusted);
-        assert_eq!(
-            isolation_tier_for_spawn(None, false),
-            IsolationTier::Untrusted
-        );
-    }
-
-    /// An installed (non-session) package is trusted however it was loaded —
-    /// its spawn-side derivation is independent of the session override, so
-    /// this assertion is race-free against the global tier override.
-    #[test]
-    fn spawn_tier_trusts_installed_provenance() {
-        let installed = Org::new("tatolab").expect("valid org");
-        assert_eq!(
-            isolation_tier_for_spawn(Some(&installed), true),
-            IsolationTier::TrustedInstalled
-        );
-        assert_eq!(
-            isolation_tier_for_spawn(Some(&installed), false),
-            IsolationTier::TrustedInstalled
-        );
-    }
 
     /// The trust-axis moat wiring at the spawn setup seam: an untrusted tier
     /// yields no [`FullAccessGrant`], and the gate marks the processor

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
@@ -9,8 +9,11 @@ use std::os::fd::OwnedFd;
 use parking_lot::{Mutex, RwLock};
 
 use crate::core::compiler::scheduling::{SchedulingStrategy, scheduling_strategy_for_processor};
+use streamlib_idents::Org;
+
 use crate::core::context::{
-    GpuContext, GpuContextLimitedAccess, IsolationTier, RuntimeContext, RuntimeContextFullAccess,
+    FullAccessGrant, GpuContext, GpuContextLimitedAccess, IsolationTier, RuntimeContext,
+    RuntimeContextFullAccess,
 };
 use crate::core::descriptors::ProcessorRuntime;
 use crate::core::error::{Error, Result};
@@ -162,20 +165,21 @@ fn spawn_dedicated_thread(
     // a @session module that was separately built + dlopened (cdylib-resident)
     // is untrusted; host-compiled code and installed packages are trusted. The
     // tier gates every FullAccess mint on this thread (setup / start / stop /
-    // teardown). Fail closed (untrusted) if the node vanished from the graph.
-    let isolation_tier = {
+    // teardown).
+    //
+    // cdylib-residency (off the instance) and org (off the graph node) are two
+    // independent reads — taken unnested so no graph(read)→processor(mutex) lock
+    // order is introduced.
+    let cdylib_resident = processor_arc.lock().is_cdylib_resident();
+    let org = {
         let graph = graph_arc.read();
-        let org = graph
+        graph
             .traversal()
             .v(&processor_id)
             .first()
-            .map(|n| n.processor_type().org.clone());
-        let cdylib_resident = processor_arc.lock().is_cdylib_resident();
-        match org {
-            Some(org) => IsolationTier::for_processor(&org, cdylib_resident),
-            None => IsolationTier::Untrusted,
-        }
+            .map(|n| n.processor_type().org.clone())
     };
+    let isolation_tier = isolation_tier_for_spawn(org.as_ref(), cdylib_resident);
 
     // Generous 8 MB stack — processors run arbitrary codec / plugin code
     // with deep call stacks. IPC payloads are slice-based (`[u8]`) in
@@ -345,18 +349,14 @@ fn spawn_dedicated_thread(
                 let tokio_handle = runtime_ctx_clone.tokio_handle();
                 // The trust-axis moat: an untrusted tier yields no
                 // `FullAccessGrant`, so an in-process FullAccess context is
-                // unrepresentable here. Refuse to run privileged setup()
-                // in-process — the untrusted processor's privileged lifecycle
-                // belongs behind the subprocess sandbox (isolation enforcement).
-                let Some(full_access_grant) = isolation_tier.grant_full_access() else {
-                    tracing::warn!(
-                        "[{}] Untrusted isolation tier ({}): in-process FullAccess denied by \
-                         construction — refusing privileged setup() (belongs behind the \
-                         subprocess sandbox)",
-                        proc_id_clone,
-                        isolation_tier.as_str(),
-                    );
-                    *state_arc.lock() = ProcessorState::Error;
+                // unrepresentable here — refuse privileged setup() in-process
+                // (the untrusted processor's privileged lifecycle belongs behind
+                // the subprocess sandbox) and leave the processor `Error`.
+                let Some(full_access_grant) = full_access_grant_or_mark_untrusted_error(
+                    isolation_tier,
+                    &state_arc,
+                    &proc_id_clone,
+                ) else {
                     return;
                 };
                 let full_ctx =
@@ -425,6 +425,43 @@ fn spawn_dedicated_thread(
     Ok(())
 }
 
+/// Derive the isolation trust tier for a spawned processor from its module
+/// provenance. A missing graph node (`org == None`) fails closed to
+/// [`IsolationTier::Untrusted`] — a processor whose node vanished must never be
+/// granted an in-process FullAccess context.
+fn isolation_tier_for_spawn(org: Option<&Org>, cdylib_resident: bool) -> IsolationTier {
+    match org {
+        Some(org) => IsolationTier::for_processor(org, cdylib_resident),
+        None => IsolationTier::Untrusted,
+    }
+}
+
+/// The trust-axis moat at the FullAccess minting seam: yield a
+/// [`FullAccessGrant`] iff the tier permits an in-process FullAccess context.
+/// On refusal (untrusted), mark the processor [`ProcessorState::Error`] — its
+/// privileged lifecycle belongs behind the subprocess sandbox (isolation
+/// enforcement) — and yield `None` so the caller skips setup and the loop.
+fn full_access_grant_or_mark_untrusted_error(
+    isolation_tier: IsolationTier,
+    state_arc: &Arc<Mutex<ProcessorState>>,
+    processor_id: &ProcessorUniqueId,
+) -> Option<FullAccessGrant> {
+    match isolation_tier.grant_full_access() {
+        Some(grant) => Some(grant),
+        None => {
+            tracing::warn!(
+                "[{}] Untrusted isolation tier ({}): in-process FullAccess denied by \
+                 construction — refusing privileged setup() (belongs behind the \
+                 subprocess sandbox)",
+                processor_id,
+                isolation_tier.as_str(),
+            );
+            *state_arc.lock() = ProcessorState::Error;
+            None
+        }
+    }
+}
+
 /// Run a processor's `__generated_setup` body.
 ///
 /// Gate management for Rust-runtime processors moved one layer
@@ -490,6 +527,83 @@ mod tests {
     use std::sync::mpsc;
     use std::thread;
     use std::time::Duration;
+
+    /// Fail-closed: a processor whose graph node vanished (`org == None`)
+    /// derives [`IsolationTier::Untrusted`], never a trusted tier — a missing
+    /// node must never be granted in-process FullAccess. Mentally revert
+    /// [`isolation_tier_for_spawn`]'s `None` arm to `TrustedInstalled` and this
+    /// flips.
+    #[test]
+    fn spawn_tier_fails_closed_to_untrusted_when_node_missing() {
+        assert_eq!(isolation_tier_for_spawn(None, true), IsolationTier::Untrusted);
+        assert_eq!(
+            isolation_tier_for_spawn(None, false),
+            IsolationTier::Untrusted
+        );
+    }
+
+    /// An installed (non-session) package is trusted however it was loaded —
+    /// its spawn-side derivation is independent of the session override, so
+    /// this assertion is race-free against the global tier override.
+    #[test]
+    fn spawn_tier_trusts_installed_provenance() {
+        let installed = Org::new("tatolab").expect("valid org");
+        assert_eq!(
+            isolation_tier_for_spawn(Some(&installed), true),
+            IsolationTier::TrustedInstalled
+        );
+        assert_eq!(
+            isolation_tier_for_spawn(Some(&installed), false),
+            IsolationTier::TrustedInstalled
+        );
+    }
+
+    /// The trust-axis moat wiring at the spawn setup seam: an untrusted tier
+    /// yields no [`FullAccessGrant`], and the gate marks the processor
+    /// [`ProcessorState::Error`] (so setup + the process loop are skipped).
+    /// Mentally revert the gate to yield `Some(..)` unconditionally — the
+    /// grant-absence and the `Error` state both flip.
+    #[test]
+    fn untrusted_tier_gate_refuses_and_marks_error() {
+        let state = Arc::new(Mutex::new(ProcessorState::Idle));
+        let proc_id = ProcessorUniqueId::from("test.untrusted");
+        let grant = full_access_grant_or_mark_untrusted_error(
+            IsolationTier::Untrusted,
+            &state,
+            &proc_id,
+        );
+        assert!(
+            grant.is_none(),
+            "untrusted tier must not yield a FullAccess grant"
+        );
+        assert_eq!(
+            *state.lock(),
+            ProcessorState::Error,
+            "the refused untrusted setup must mark the processor Error"
+        );
+    }
+
+    /// The trusted arm of the same seam: a trusted tier yields a grant and
+    /// never touches processor state (setup proceeds normally).
+    #[test]
+    fn trusted_tier_gate_yields_grant_and_leaves_state() {
+        let state = Arc::new(Mutex::new(ProcessorState::Idle));
+        let proc_id = ProcessorUniqueId::from("test.trusted");
+        let grant = full_access_grant_or_mark_untrusted_error(
+            IsolationTier::TrustedInstalled,
+            &state,
+            &proc_id,
+        );
+        assert!(
+            grant.is_some(),
+            "trusted tier must yield a FullAccess grant"
+        );
+        assert_eq!(
+            *state.lock(),
+            ProcessorState::Idle,
+            "the trusted path must not touch processor state"
+        );
+    }
 
     fn gpu_or_skip(test_name: &str) -> Option<GpuContext> {
         match GpuContext::init_for_platform_sync() {

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
@@ -161,11 +161,11 @@ fn spawn_dedicated_thread(
 
     let processor_arc_clone = Arc::clone(&processor_arc);
 
-    // Derive the isolation trust tier by construction from module provenance:
-    // a @session module that was separately built + dlopened (cdylib-resident)
-    // is untrusted; host-compiled code and installed packages are trusted. The
-    // tier gates every FullAccess mint on this thread (setup / start / stop /
-    // teardown).
+    // Resolve the isolation trust tier through the opt-in session isolation tier:
+    // trusted by default (same as installed), and a @session cdylib is eligible
+    // for Untrusted only when the operator opts in (STREAMLIB_SESSION_ISOLATION_TIER
+    // / set_session_isolation_tier). The tier gates every FullAccess mint on this
+    // thread (setup / start / stop / teardown).
     //
     // cdylib-residency (off the instance) and org (off the graph node) are two
     // independent reads — taken unnested so no graph(read)→processor(mutex) lock

--- a/runtime/streamlib-engine/src/core/context/isolation.rs
+++ b/runtime/streamlib-engine/src/core/context/isolation.rs
@@ -1,0 +1,291 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Isolation trust tier — the by-construction capability moat deciding whether
+//! a processor's privileged lifecycle may mint an in-process
+//! [`RuntimeContextFullAccess`](super::RuntimeContextFullAccess).
+//!
+//! This is an **orthogonal trust axis** that composes with the phase-axis
+//! capability typestate (`RuntimeContextFullAccess` for `setup`/`start`/`stop`/
+//! `teardown`, `RuntimeContextLimitedAccess` for the hot path). The phase axis
+//! answers *which* lifecycle method is running; the trust axis answers *whether
+//! the code running it is trusted enough to hold FullAccess in-process at all*.
+//!
+//! The tier is **derived by construction from module provenance** — never
+//! hand-set on the untrusted path:
+//! - a `@session/…` (in-app authored / agent-submitted) module that was
+//!   separately built and dlopened (cdylib-resident) is [`IsolationTier::Untrusted`];
+//! - an installed, content-hash-locked package, and any host-binary-compiled
+//!   processor (`register::<P>()` / `add_local::<P>()`, which is the host's own
+//!   code under a `@session` namespace key), is [`IsolationTier::TrustedInstalled`].
+//!
+//! The moat is the [`FullAccessGrant`] token: minting a
+//! [`RuntimeContextFullAccess`](super::RuntimeContextFullAccess) requires one,
+//! and a grant is producible **only** from [`IsolationTier::TrustedInstalled`]
+//! (see [`IsolationTier::grant_full_access`]). The untrusted lifecycle dispatch
+//! has no grant to pass, so an in-process FullAccess context is unrepresentable
+//! for it — a compile-time guarantee, not a runtime check.
+//!
+//! Actual runtime *enforcement* of the untrusted tier — own-subprocess sandbox,
+//! cgroup-v2 limits, narrow Deno permissions — is a separate concern
+//! (isolation *enforcement*); this module owns only the policy model, the
+//! process-wide config default, and the capability moat at the minting seam.
+
+use std::sync::RwLock;
+
+use streamlib_idents::Org;
+
+/// Environment variable selecting the tier assigned to `@session/…`
+/// cdylib-resident (submitted-source) modules — `untrusted` (default) or
+/// `trusted`. A programmatic override ([`set_session_isolation_tier`]) takes
+/// precedence.
+pub(crate) const SESSION_ISOLATION_TIER_ENV: &str = "STREAMLIB_SESSION_ISOLATION_TIER";
+
+/// Declarative trust tier a loaded processor runs under, derived by
+/// construction from module provenance.
+///
+/// Composes with — does not replace — the phase-axis capability typestate. A
+/// [`TrustedInstalled`](Self::TrustedInstalled) processor still only sees
+/// FullAccess in its privileged lifecycle methods; an
+/// [`Untrusted`](Self::Untrusted) processor never sees an in-process FullAccess
+/// at all.
+///
+/// The capability moat is sealed by construction: `grant_full_access` (the only
+/// producer of the token `RuntimeContextFullAccess::new` requires) is
+/// crate-internal, so no external caller — trusted tier or not — can mint a
+/// FullAccess grant:
+///
+/// ```compile_fail
+/// use streamlib::sdk::context::IsolationTier;
+/// let _ = IsolationTier::TrustedInstalled.grant_full_access();
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IsolationTier {
+    /// Session / agent-submitted, separately-built (cdylib-resident) code.
+    /// Never mints an in-process FullAccess context — its privileged lifecycle
+    /// is expected to run behind the subprocess sandbox (isolation enforcement).
+    Untrusted,
+    /// Installed, content-hash-locked package, or host-binary-compiled code.
+    /// May mint an in-process FullAccess context via [`Self::grant_full_access`].
+    TrustedInstalled,
+}
+
+impl IsolationTier {
+    /// Derive the tier from a processor's module provenance.
+    ///
+    /// A `@session/…` module that was separately built and dlopened
+    /// (`cdylib_resident == true`) is untrusted by default — the process-wide
+    /// session override ([`set_session_isolation_tier`]) can opt it into
+    /// [`TrustedInstalled`](Self::TrustedInstalled) for the in-app dev flow.
+    /// Everything else — installed packages (any non-session org) and
+    /// host-binary-compiled processors (`register::<P>()` / `add_local::<P>()`,
+    /// which are not cdylib-resident even under a `@session` key) — is
+    /// [`TrustedInstalled`](Self::TrustedInstalled).
+    pub fn for_processor(org: &Org, cdylib_resident: bool) -> Self {
+        if cdylib_resident && org.is_reserved_for_session() {
+            session_isolation_tier()
+        } else {
+            Self::TrustedInstalled
+        }
+    }
+
+    /// Produce a [`FullAccessGrant`] iff this tier is
+    /// [`TrustedInstalled`](Self::TrustedInstalled). The
+    /// [`Untrusted`](Self::Untrusted) tier returns `None`, so the untrusted
+    /// dispatch path has no token to mint a
+    /// [`RuntimeContextFullAccess`](super::RuntimeContextFullAccess).
+    pub(crate) fn grant_full_access(self) -> Option<FullAccessGrant> {
+        match self {
+            Self::TrustedInstalled => Some(FullAccessGrant(())),
+            Self::Untrusted => None,
+        }
+    }
+
+    /// Whether this tier permits minting an in-process FullAccess context.
+    pub fn permits_in_process_full_access(self) -> bool {
+        matches!(self, Self::TrustedInstalled)
+    }
+
+    /// Stable lowercase label for logs / config round-tripping.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Untrusted => "untrusted",
+            Self::TrustedInstalled => "trusted",
+        }
+    }
+
+    /// Parse the `untrusted` / `trusted` spelling (case-insensitive). An
+    /// unrecognized value is `None` so the caller falls back to the default
+    /// rather than silently widening trust.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "untrusted" | "session" | "off" => Some(Self::Untrusted),
+            "trusted" | "installed" | "on" => Some(Self::TrustedInstalled),
+            _ => None,
+        }
+    }
+}
+
+/// Zero-sized capability token proving an [`IsolationTier::TrustedInstalled`]
+/// authorized minting a
+/// [`RuntimeContextFullAccess`](super::RuntimeContextFullAccess).
+///
+/// Constructible **only** inside this module, and only via
+/// [`IsolationTier::grant_full_access`] — the untrusted dispatch path can never
+/// obtain one, so an in-process FullAccess context is unrepresentable for it by
+/// construction. The field is private so no other module (in-crate or out) can
+/// fabricate a grant.
+pub(crate) struct FullAccessGrant(());
+
+/// Process-wide override for the tier assigned to `@session/…` cdylib-resident
+/// modules. `None` falls back to [`SESSION_ISOLATION_TIER_ENV`], then the
+/// [`IsolationTier::Untrusted`] default.
+static SESSION_TIER_OVERRIDE: RwLock<Option<IsolationTier>> = RwLock::new(None);
+
+/// Set (or clear, with `None`) the process-wide session isolation tier
+/// override. `None` restores the env / [`IsolationTier::Untrusted`] default.
+pub(crate) fn set_session_isolation_tier(tier: Option<IsolationTier>) {
+    *SESSION_TIER_OVERRIDE
+        .write()
+        .expect("session isolation tier override lock poisoned") = tier;
+}
+
+/// The effective tier for a `@session/…` cdylib-resident module: the runtime
+/// override, else the [`SESSION_ISOLATION_TIER_ENV`] env var, else
+/// [`IsolationTier::Untrusted`]. An unrecognized env value warns once per read
+/// and falls back to `Untrusted` (fail-closed — never silently trusts).
+pub(crate) fn session_isolation_tier() -> IsolationTier {
+    if let Some(tier) = *SESSION_TIER_OVERRIDE
+        .read()
+        .expect("session isolation tier override lock poisoned")
+    {
+        return tier;
+    }
+    match std::env::var(SESSION_ISOLATION_TIER_ENV) {
+        Ok(raw) if !raw.trim().is_empty() => match IsolationTier::parse(&raw) {
+            Some(tier) => tier,
+            None => {
+                tracing::warn!(
+                    value = %raw,
+                    env = SESSION_ISOLATION_TIER_ENV,
+                    "unrecognized session isolation tier — expected untrusted/trusted; \
+                     defaulting to untrusted"
+                );
+                IsolationTier::Untrusted
+            }
+        },
+        _ => IsolationTier::Untrusted,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use streamlib_idents::{Org, SESSION_ORG};
+
+    fn session_org() -> Org {
+        Org::new(SESSION_ORG).expect("session org is constructible")
+    }
+
+    /// The moat: an untrusted tier can never produce a [`FullAccessGrant`];
+    /// only the trusted tier can. Revert `grant_full_access` to return
+    /// `Some(..)` unconditionally and the untrusted assertion below fails.
+    #[test]
+    fn only_the_trusted_tier_grants_full_access() {
+        assert!(
+            IsolationTier::TrustedInstalled.grant_full_access().is_some(),
+            "the trusted tier must mint a FullAccess grant"
+        );
+        assert!(
+            IsolationTier::Untrusted.grant_full_access().is_none(),
+            "the untrusted tier must never mint a FullAccess grant"
+        );
+        assert!(!IsolationTier::Untrusted.permits_in_process_full_access());
+        assert!(IsolationTier::TrustedInstalled.permits_in_process_full_access());
+    }
+
+    /// A `@session/…` cdylib-resident module defaults to untrusted; a
+    /// host-binary-compiled `@session` processor (not cdylib-resident) and any
+    /// installed (non-session) module are trusted. Revert the
+    /// `cdylib_resident && is_reserved_for_session` guard and the first
+    /// assertion flips.
+    #[test]
+    fn tier_is_derived_from_provenance() {
+        use std::sync::Mutex;
+        static SERIALIZE: Mutex<()> = Mutex::new(());
+        let _guard = SERIALIZE.lock().unwrap();
+        set_session_isolation_tier(None);
+
+        let session = session_org();
+        let installed = Org::new("tatolab").expect("valid org");
+
+        // @session + separately-built (cdylib) → untrusted by default.
+        assert_eq!(
+            IsolationTier::for_processor(&session, true),
+            IsolationTier::Untrusted
+        );
+        // @session but host-compiled (not cdylib-resident) → trusted: it's the
+        // host binary's own code under a @session namespace key.
+        assert_eq!(
+            IsolationTier::for_processor(&session, false),
+            IsolationTier::TrustedInstalled
+        );
+        // Installed (non-session) package, however loaded → trusted.
+        assert_eq!(
+            IsolationTier::for_processor(&installed, true),
+            IsolationTier::TrustedInstalled
+        );
+        assert_eq!(
+            IsolationTier::for_processor(&installed, false),
+            IsolationTier::TrustedInstalled
+        );
+    }
+
+    /// The process-wide override opts a `@session` cdylib module into the
+    /// trusted tier (the in-app dev flow), and clearing it restores the
+    /// untrusted default.
+    #[test]
+    fn session_override_opts_into_trusted_and_clears() {
+        use std::sync::Mutex;
+        static SERIALIZE: Mutex<()> = Mutex::new(());
+        let _guard = SERIALIZE.lock().unwrap();
+
+        let session = session_org();
+
+        set_session_isolation_tier(None);
+        assert_eq!(
+            IsolationTier::for_processor(&session, true),
+            IsolationTier::Untrusted,
+            "default @session cdylib tier is untrusted"
+        );
+
+        set_session_isolation_tier(Some(IsolationTier::TrustedInstalled));
+        assert_eq!(
+            IsolationTier::for_processor(&session, true),
+            IsolationTier::TrustedInstalled,
+            "the override must opt @session into trusted"
+        );
+
+        set_session_isolation_tier(None);
+        assert_eq!(
+            IsolationTier::for_processor(&session, true),
+            IsolationTier::Untrusted,
+            "clearing the override restores the untrusted default"
+        );
+    }
+
+    #[test]
+    fn parse_accepts_the_two_spellings_and_labels_round_trip() {
+        assert_eq!(
+            IsolationTier::parse("untrusted"),
+            Some(IsolationTier::Untrusted)
+        );
+        assert_eq!(
+            IsolationTier::parse("TRUSTED"),
+            Some(IsolationTier::TrustedInstalled)
+        );
+        assert_eq!(IsolationTier::parse("garbage"), None);
+        assert_eq!(IsolationTier::Untrusted.as_str(), "untrusted");
+        assert_eq!(IsolationTier::TrustedInstalled.as_str(), "trusted");
+    }
+}

--- a/runtime/streamlib-engine/src/core/context/isolation.rs
+++ b/runtime/streamlib-engine/src/core/context/isolation.rs
@@ -102,8 +102,12 @@ impl IsolationTier {
     }
 
     /// Whether this tier permits minting an in-process FullAccess context.
+    ///
+    /// Delegates to [`Self::grant_full_access`] so the moat predicate and the
+    /// grant producer are a single source of truth — a future third tier can't
+    /// desync them.
     pub fn permits_in_process_full_access(self) -> bool {
-        matches!(self, Self::TrustedInstalled)
+        self.grant_full_access().is_some()
     }
 
     /// Stable lowercase label for logs / config round-tripping.
@@ -114,13 +118,14 @@ impl IsolationTier {
         }
     }
 
-    /// Parse the `untrusted` / `trusted` spelling (case-insensitive). An
-    /// unrecognized value is `None` so the caller falls back to the default
-    /// rather than silently widening trust.
+    /// Parse the `untrusted` / `trusted` spelling (case-insensitive) — the two
+    /// canonical labels [`Self::as_str`] round-trips. An unrecognized value is
+    /// `None` so the caller falls back to the default rather than silently
+    /// widening trust.
     pub fn parse(value: &str) -> Option<Self> {
         match value.trim().to_ascii_lowercase().as_str() {
-            "untrusted" | "session" | "off" => Some(Self::Untrusted),
-            "trusted" | "installed" | "on" => Some(Self::TrustedInstalled),
+            "untrusted" => Some(Self::Untrusted),
+            "trusted" => Some(Self::TrustedInstalled),
             _ => None,
         }
     }

--- a/runtime/streamlib-engine/src/core/context/isolation.rs
+++ b/runtime/streamlib-engine/src/core/context/isolation.rs
@@ -11,13 +11,18 @@
 //! answers *which* lifecycle method is running; the trust axis answers *whether
 //! the code running it is trusted enough to hold FullAccess in-process at all*.
 //!
-//! The tier is **derived by construction from module provenance** — never
-//! hand-set on the untrusted path:
-//! - a `@session/…` (in-app authored / agent-submitted) module that was
-//!   separately built and dlopened (cdylib-resident) is [`IsolationTier::Untrusted`];
-//! - an installed, content-hash-locked package, and any host-binary-compiled
-//!   processor (`register::<P>()` / `add_local::<P>()`, which is the host's own
-//!   code under a `@session` namespace key), is [`IsolationTier::TrustedInstalled`].
+//! Isolation is an **opt-in feature**: by default every loaded processor —
+//! including `@session/…` (in-app authored / agent-submitted) separately-built
+//! (cdylib-resident) code — runs [`IsolationTier::TrustedInstalled`], with the
+//! same in-process FullAccess permissions as an installed package (no behavior
+//! change vs before the trust axis existed). An operator opts into sandboxing
+//! submitted code by setting the session tier to `untrusted` (via
+//! [`SESSION_ISOLATION_TIER_ENV`] or [`set_session_isolation_tier`]); only then
+//! is a `@session/…` cdylib-resident module classified
+//! [`IsolationTier::Untrusted`]. Installed, content-hash-locked packages and any
+//! host-binary-compiled processor (`register::<P>()` / `add_local::<P>()`, the
+//! host's own code under a `@session` namespace key) are always
+//! [`IsolationTier::TrustedInstalled`] and are unaffected by the knob.
 //!
 //! The moat is the [`FullAccessGrant`] token: minting a
 //! [`RuntimeContextFullAccess`](super::RuntimeContextFullAccess) requires one,
@@ -36,9 +41,10 @@ use std::sync::RwLock;
 use streamlib_idents::Org;
 
 /// Environment variable selecting the tier assigned to `@session/…`
-/// cdylib-resident (submitted-source) modules — `untrusted` (default) or
-/// `trusted`. A programmatic override ([`set_session_isolation_tier`]) takes
-/// precedence.
+/// cdylib-resident (submitted-source) modules — `trusted` (default) or
+/// `untrusted`. Setting it to `untrusted` is the operator's opt-in to sandbox
+/// submitted code; unset leaves submitted code trusted like installed code. A
+/// programmatic override ([`set_session_isolation_tier`]) takes precedence.
 pub(crate) const SESSION_ISOLATION_TIER_ENV: &str = "STREAMLIB_SESSION_ISOLATION_TIER";
 
 /// Declarative trust tier a loaded processor runs under, derived by
@@ -73,14 +79,16 @@ pub enum IsolationTier {
 impl IsolationTier {
     /// Derive the tier from a processor's module provenance.
     ///
-    /// A `@session/…` module that was separately built and dlopened
-    /// (`cdylib_resident == true`) is untrusted by default — the process-wide
-    /// session override ([`set_session_isolation_tier`]) can opt it into
-    /// [`TrustedInstalled`](Self::TrustedInstalled) for the in-app dev flow.
-    /// Everything else — installed packages (any non-session org) and
-    /// host-binary-compiled processors (`register::<P>()` / `add_local::<P>()`,
-    /// which are not cdylib-resident even under a `@session` key) — is
-    /// [`TrustedInstalled`](Self::TrustedInstalled).
+    /// [`TrustedInstalled`](Self::TrustedInstalled) by default for everything —
+    /// isolation is opt-in. A `@session/…` module that was separately built and
+    /// dlopened (`cdylib_resident == true`) resolves through the process-wide
+    /// session tier ([`session_isolation_tier`]), which is
+    /// [`TrustedInstalled`](Self::TrustedInstalled) unless the operator opts into
+    /// `untrusted` via [`SESSION_ISOLATION_TIER_ENV`] /
+    /// [`set_session_isolation_tier`]. Everything else — installed packages (any
+    /// non-session org) and host-binary-compiled processors (`register::<P>()` /
+    /// `add_local::<P>()`, which are not cdylib-resident even under a `@session`
+    /// key) — is always [`TrustedInstalled`](Self::TrustedInstalled).
     pub fn for_processor(org: &Org, cdylib_resident: bool) -> Self {
         if cdylib_resident && org.is_reserved_for_session() {
             session_isolation_tier()
@@ -144,11 +152,12 @@ pub(crate) struct FullAccessGrant(());
 
 /// Process-wide override for the tier assigned to `@session/…` cdylib-resident
 /// modules. `None` falls back to [`SESSION_ISOLATION_TIER_ENV`], then the
-/// [`IsolationTier::Untrusted`] default.
+/// [`IsolationTier::TrustedInstalled`] default (isolation is opt-in).
 static SESSION_TIER_OVERRIDE: RwLock<Option<IsolationTier>> = RwLock::new(None);
 
 /// Set (or clear, with `None`) the process-wide session isolation tier
-/// override. `None` restores the env / [`IsolationTier::Untrusted`] default.
+/// override. `None` restores the env / [`IsolationTier::TrustedInstalled`]
+/// default.
 pub(crate) fn set_session_isolation_tier(tier: Option<IsolationTier>) {
     *SESSION_TIER_OVERRIDE
         .write()
@@ -157,8 +166,10 @@ pub(crate) fn set_session_isolation_tier(tier: Option<IsolationTier>) {
 
 /// The effective tier for a `@session/…` cdylib-resident module: the runtime
 /// override, else the [`SESSION_ISOLATION_TIER_ENV`] env var, else
-/// [`IsolationTier::Untrusted`]. An unrecognized env value warns once per read
-/// and falls back to `Untrusted` (fail-closed — never silently trusts).
+/// [`IsolationTier::TrustedInstalled`] — isolation is opt-in, so submitted code
+/// runs trusted (like installed code) unless the operator opts into `untrusted`.
+/// An unrecognized env value warns once per read and falls back to the trusted
+/// default (a garbage value is not an opt-in to sandboxing).
 pub(crate) fn session_isolation_tier() -> IsolationTier {
     if let Some(tier) = *SESSION_TIER_OVERRIDE
         .read()
@@ -174,12 +185,12 @@ pub(crate) fn session_isolation_tier() -> IsolationTier {
                     value = %raw,
                     env = SESSION_ISOLATION_TIER_ENV,
                     "unrecognized session isolation tier — expected untrusted/trusted; \
-                     defaulting to untrusted"
+                     defaulting to trusted"
                 );
-                IsolationTier::Untrusted
+                IsolationTier::TrustedInstalled
             }
         },
-        _ => IsolationTier::Untrusted,
+        _ => IsolationTier::TrustedInstalled,
     }
 }
 
@@ -209,11 +220,11 @@ mod tests {
         assert!(IsolationTier::TrustedInstalled.permits_in_process_full_access());
     }
 
-    /// A `@session/…` cdylib-resident module defaults to untrusted; a
-    /// host-binary-compiled `@session` processor (not cdylib-resident) and any
-    /// installed (non-session) module are trusted. Revert the
-    /// `cdylib_resident && is_reserved_for_session` guard and the first
-    /// assertion flips.
+    /// Isolation is opt-in: with no override every provenance — `@session`
+    /// cdylib-resident submitted code included — derives
+    /// [`IsolationTier::TrustedInstalled`], the same permissions as an installed
+    /// package. Revert the `session_isolation_tier` default back to `Untrusted`
+    /// and the first assertion flips.
     #[test]
     fn tier_is_derived_from_provenance() {
         use std::sync::Mutex;
@@ -224,10 +235,10 @@ mod tests {
         let session = session_org();
         let installed = Org::new("tatolab").expect("valid org");
 
-        // @session + separately-built (cdylib) → untrusted by default.
+        // @session + separately-built (cdylib) → trusted by default (opt-in).
         assert_eq!(
             IsolationTier::for_processor(&session, true),
-            IsolationTier::Untrusted
+            IsolationTier::TrustedInstalled
         );
         // @session but host-compiled (not cdylib-resident) → trusted: it's the
         // host binary's own code under a @session namespace key.
@@ -246,11 +257,11 @@ mod tests {
         );
     }
 
-    /// The process-wide override opts a `@session` cdylib module into the
-    /// trusted tier (the in-app dev flow), and clearing it restores the
-    /// untrusted default.
+    /// The operator opt-in: setting the process-wide session tier to `untrusted`
+    /// sandboxes `@session` cdylib submitted code, and clearing it restores the
+    /// trusted (opt-out) default.
     #[test]
-    fn session_override_opts_into_trusted_and_clears() {
+    fn session_override_opts_into_untrusted_and_clears() {
         use std::sync::Mutex;
         static SERIALIZE: Mutex<()> = Mutex::new(());
         let _guard = SERIALIZE.lock().unwrap();
@@ -260,23 +271,45 @@ mod tests {
         set_session_isolation_tier(None);
         assert_eq!(
             IsolationTier::for_processor(&session, true),
-            IsolationTier::Untrusted,
-            "default @session cdylib tier is untrusted"
+            IsolationTier::TrustedInstalled,
+            "default @session cdylib tier is trusted (isolation is opt-in)"
         );
 
-        set_session_isolation_tier(Some(IsolationTier::TrustedInstalled));
+        set_session_isolation_tier(Some(IsolationTier::Untrusted));
         assert_eq!(
             IsolationTier::for_processor(&session, true),
-            IsolationTier::TrustedInstalled,
-            "the override must opt @session into trusted"
+            IsolationTier::Untrusted,
+            "the override must opt @session into untrusted (sandboxed)"
         );
 
         set_session_isolation_tier(None);
         assert_eq!(
             IsolationTier::for_processor(&session, true),
-            IsolationTier::Untrusted,
-            "clearing the override restores the untrusted default"
+            IsolationTier::TrustedInstalled,
+            "clearing the override restores the trusted default"
         );
+    }
+
+    /// Opt-in default in full: an `@session` cdylib-resident module with no
+    /// override mints a [`FullAccessGrant`] — it runs in-process with the same
+    /// FullAccess as installed code, so the interim fail-closed dead-end is gone
+    /// by default. Revert the `session_isolation_tier` default to `Untrusted`
+    /// and the grant vanishes.
+    #[test]
+    fn default_session_cdylib_mints_full_access_grant() {
+        use std::sync::Mutex;
+        static SERIALIZE: Mutex<()> = Mutex::new(());
+        let _guard = SERIALIZE.lock().unwrap();
+        set_session_isolation_tier(None);
+
+        let session = session_org();
+        let tier = IsolationTier::for_processor(&session, true);
+        assert_eq!(tier, IsolationTier::TrustedInstalled);
+        assert!(
+            tier.grant_full_access().is_some(),
+            "default @session cdylib must mint a FullAccess grant (runs in-process like installed)"
+        );
+        assert!(tier.permits_in_process_full_access());
     }
 
     #[test]

--- a/runtime/streamlib-engine/src/core/context/isolation.rs
+++ b/runtime/streamlib-engine/src/core/context/isolation.rs
@@ -36,7 +36,7 @@
 //! (isolation *enforcement*); this module owns only the policy model, the
 //! process-wide config default, and the capability moat at the minting seam.
 
-use std::sync::RwLock;
+use parking_lot::RwLock;
 
 use streamlib_idents::Org;
 
@@ -159,9 +159,7 @@ static SESSION_TIER_OVERRIDE: RwLock<Option<IsolationTier>> = RwLock::new(None);
 /// override. `None` restores the env / [`IsolationTier::TrustedInstalled`]
 /// default.
 pub(crate) fn set_session_isolation_tier(tier: Option<IsolationTier>) {
-    *SESSION_TIER_OVERRIDE
-        .write()
-        .expect("session isolation tier override lock poisoned") = tier;
+    *SESSION_TIER_OVERRIDE.write() = tier;
 }
 
 /// The effective tier for a `@session/…` cdylib-resident module: the runtime
@@ -171,10 +169,7 @@ pub(crate) fn set_session_isolation_tier(tier: Option<IsolationTier>) {
 /// An unrecognized env value warns once per read and falls back to the trusted
 /// default (a garbage value is not an opt-in to sandboxing).
 pub(crate) fn session_isolation_tier() -> IsolationTier {
-    if let Some(tier) = *SESSION_TIER_OVERRIDE
-        .read()
-        .expect("session isolation tier override lock poisoned")
-    {
+    if let Some(tier) = *SESSION_TIER_OVERRIDE.read() {
         return tier;
     }
     match std::env::var(SESSION_ISOLATION_TIER_ENV) {
@@ -203,6 +198,36 @@ mod tests {
         Org::new(SESSION_ORG).expect("session org is constructible")
     }
 
+    /// Serialized (via `#[serial_test::serial]`) reset of the process-wide
+    /// session-tier state shared by the three tests below. On construction and
+    /// on drop it clears the override AND [`SESSION_ISOLATION_TIER_ENV`], so a
+    /// panicking test can't leak `Untrusted` into the next, and a developer
+    /// machine that exports the env var can't perturb the trusted-by-default
+    /// assertions (which fall through to the env when the override is `None`).
+    struct SessionIsolationTierTestStateGuard;
+
+    impl SessionIsolationTierTestStateGuard {
+        fn new() -> Self {
+            Self::reset_session_tier_state();
+            Self
+        }
+
+        fn reset_session_tier_state() {
+            set_session_isolation_tier(None);
+            // SAFETY: the three callers are serialized by
+            // `#[serial_test::serial]`, and this env var is read only by
+            // `session_isolation_tier`, which no other test touches — no
+            // concurrent env access races this write.
+            unsafe { std::env::remove_var(SESSION_ISOLATION_TIER_ENV) };
+        }
+    }
+
+    impl Drop for SessionIsolationTierTestStateGuard {
+        fn drop(&mut self) {
+            Self::reset_session_tier_state();
+        }
+    }
+
     /// The moat: an untrusted tier can never produce a [`FullAccessGrant`];
     /// only the trusted tier can. Revert `grant_full_access` to return
     /// `Some(..)` unconditionally and the untrusted assertion below fails.
@@ -226,11 +251,9 @@ mod tests {
     /// package. Revert the `session_isolation_tier` default back to `Untrusted`
     /// and the first assertion flips.
     #[test]
+    #[serial_test::serial]
     fn tier_is_derived_from_provenance() {
-        use std::sync::Mutex;
-        static SERIALIZE: Mutex<()> = Mutex::new(());
-        let _guard = SERIALIZE.lock().unwrap();
-        set_session_isolation_tier(None);
+        let _guard = SessionIsolationTierTestStateGuard::new();
 
         let session = session_org();
         let installed = Org::new("tatolab").expect("valid org");
@@ -261,14 +284,12 @@ mod tests {
     /// sandboxes `@session` cdylib submitted code, and clearing it restores the
     /// trusted (opt-out) default.
     #[test]
+    #[serial_test::serial]
     fn session_override_opts_into_untrusted_and_clears() {
-        use std::sync::Mutex;
-        static SERIALIZE: Mutex<()> = Mutex::new(());
-        let _guard = SERIALIZE.lock().unwrap();
+        let _guard = SessionIsolationTierTestStateGuard::new();
 
         let session = session_org();
 
-        set_session_isolation_tier(None);
         assert_eq!(
             IsolationTier::for_processor(&session, true),
             IsolationTier::TrustedInstalled,
@@ -296,11 +317,9 @@ mod tests {
     /// by default. Revert the `session_isolation_tier` default to `Untrusted`
     /// and the grant vanishes.
     #[test]
+    #[serial_test::serial]
     fn default_session_cdylib_mints_full_access_grant() {
-        use std::sync::Mutex;
-        static SERIALIZE: Mutex<()> = Mutex::new(());
-        let _guard = SERIALIZE.lock().unwrap();
-        set_session_isolation_tier(None);
+        let _guard = SessionIsolationTierTestStateGuard::new();
 
         let session = session_org();
         let tier = IsolationTier::for_processor(&session, true);

--- a/runtime/streamlib-engine/src/core/context/mod.rs
+++ b/runtime/streamlib-engine/src/core/context/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod escalate_scope_registry;
 mod gpu_context;
 #[cfg(target_os = "linux")]
 mod graphics_kernel_bridge;
+pub(crate) mod isolation;
 #[cfg(target_os = "linux")]
 mod ray_tracing_kernel_bridge;
 mod runtime_context;
@@ -51,6 +52,7 @@ pub use ray_tracing_kernel_bridge::{
     RayTracingKernelRegisterDecl, RayTracingKernelRunDispatch, RayTracingShaderGroupWire,
     RayTracingShaderStageWire, RayTracingStageDecl, TlasInstanceDeclWire, TlasRegisterDecl,
 };
+pub use isolation::IsolationTier;
 pub use runtime_context::{RuntimeContext, RuntimeContextFullAccess, RuntimeContextLimitedAccess};
 pub use runtime_ops_shim::RuntimeOpsShim;
 pub use surface_store::SurfaceStore;

--- a/runtime/streamlib-engine/src/core/context/mod.rs
+++ b/runtime/streamlib-engine/src/core/context/mod.rs
@@ -53,6 +53,7 @@ pub use ray_tracing_kernel_bridge::{
     RayTracingShaderStageWire, RayTracingStageDecl, TlasInstanceDeclWire, TlasRegisterDecl,
 };
 pub use isolation::IsolationTier;
+pub(crate) use isolation::FullAccessGrant;
 pub use runtime_context::{RuntimeContext, RuntimeContextFullAccess, RuntimeContextLimitedAccess};
 pub use runtime_ops_shim::RuntimeOpsShim;
 pub use surface_store::SurfaceStore;

--- a/runtime/streamlib-engine/src/core/context/runtime_context.rs
+++ b/runtime/streamlib-engine/src/core/context/runtime_context.rs
@@ -679,9 +679,10 @@ impl<'a> RuntimeContextFullAccess<'a> {
     /// Requires a [`FullAccessGrant`](super::isolation::FullAccessGrant) — the
     /// by-construction capability moat. A grant is producible only from an
     /// [`IsolationTier::TrustedInstalled`](super::isolation::IsolationTier),
-    /// so an untrusted (`@session` submitted-source) processor's lifecycle
-    /// dispatch has no token to pass and cannot mint an in-process FullAccess
-    /// context. The token is consumed (not stored): it proves authorization at
+    /// so an untrusted processor's lifecycle dispatch (a `@session`
+    /// submitted-source module once the operator opts into sandboxing) has no
+    /// token to pass and cannot mint an in-process FullAccess context. The token
+    /// is consumed (not stored): it proves authorization at
     /// the minting seam and carries no runtime state.
     pub(crate) fn new(
         base: &'a RuntimeContext,

--- a/runtime/streamlib-engine/src/core/context/runtime_context.rs
+++ b/runtime/streamlib-engine/src/core/context/runtime_context.rs
@@ -675,7 +675,18 @@ impl<'a> RuntimeContextFullAccess<'a> {
     /// Construct a full-access view over `base`. Crate-internal: only the
     /// runtime's lifecycle dispatch (attribute macro + `spawn_processor_op`)
     /// is permitted to create these.
-    pub(crate) fn new(base: &'a RuntimeContext) -> Self {
+    ///
+    /// Requires a [`FullAccessGrant`](super::isolation::FullAccessGrant) — the
+    /// by-construction capability moat. A grant is producible only from an
+    /// [`IsolationTier::TrustedInstalled`](super::isolation::IsolationTier),
+    /// so an untrusted (`@session` submitted-source) processor's lifecycle
+    /// dispatch has no token to pass and cannot mint an in-process FullAccess
+    /// context. The token is consumed (not stored): it proves authorization at
+    /// the minting seam and carries no runtime state.
+    pub(crate) fn new(
+        base: &'a RuntimeContext,
+        _grant: super::isolation::FullAccessGrant,
+    ) -> Self {
         Self {
             handle: base as *const RuntimeContext as *const c_void,
             vtable: crate::core::plugin::host_services::host_runtime_context_vtable(),

--- a/runtime/streamlib-engine/src/core/execution/thread_runner.rs
+++ b/runtime/streamlib-engine/src/core/execution/thread_runner.rs
@@ -14,7 +14,7 @@ use std::os::fd::OwnedFd;
 use parking_lot::Mutex;
 
 use crate::core::RuntimeContext;
-use crate::core::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
+use crate::core::context::{IsolationTier, RuntimeContextFullAccess, RuntimeContextLimitedAccess};
 use crate::core::execution::{ExecutionConfig, ProcessExecution};
 use crate::core::graph::ProcessorUniqueId;
 use crate::core::processors::{ProcessorInstance, ProcessorState};
@@ -27,7 +27,7 @@ const PAUSE_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_mill
 const NO_WAITER_FALLBACK_SLEEP: std::time::Duration = std::time::Duration::from_millis(100);
 
 /// Run the processor thread main loop based on execution mode.
-#[tracing::instrument(name = "processor.lifecycle", skip(processor, shutdown_rx, shutdown_eventfd, state, pause_gate, exec_config, runtime_ctx), fields(processor_id = %id))]
+#[tracing::instrument(name = "processor.lifecycle", skip(processor, shutdown_rx, shutdown_eventfd, state, pause_gate, exec_config, runtime_ctx), fields(processor_id = %id, isolation_tier = isolation_tier.as_str()))]
 pub fn run_processor_loop(
     id: ProcessorUniqueId,
     processor: Arc<Mutex<ProcessorInstance>>,
@@ -37,6 +37,7 @@ pub fn run_processor_loop(
     pause_gate: Arc<AtomicBool>,
     exec_config: ExecutionConfig,
     runtime_ctx: RuntimeContext,
+    isolation_tier: IsolationTier,
 ) {
     tracing::info!(
         "[{}] Thread started ({})",
@@ -67,21 +68,41 @@ pub fn run_processor_loop(
             );
         }
         ProcessExecution::Manual => {
-            run_manual_mode(&id, &processor, &shutdown_rx, &pause_gate, &runtime_ctx);
+            run_manual_mode(
+                &id,
+                &processor,
+                &shutdown_rx,
+                &pause_gate,
+                &runtime_ctx,
+                isolation_tier,
+            );
         }
     }
 
-    // Teardown — privileged ctx.
-    tracing::info!("[{}] Invoking teardown()...", id);
-    {
-        let full_ctx = RuntimeContextFullAccess::new(&runtime_ctx);
-        let mut guard = processor.lock();
-        // block_on is now internal to ProcessorInstance::teardown's
-        // dispatch (LegacyDyn variant) or the cdylib's vtable
-        // wrapper (VTable variant).
-        match guard.teardown(&full_ctx) {
-            Ok(()) => tracing::info!("[{}] teardown() completed successfully", id),
-            Err(e) => tracing::warn!("[{}] teardown() failed: {}", id, e),
+    // Teardown — privileged ctx. Gated by the isolation trust axis: an
+    // untrusted tier yields no `FullAccessGrant`, so no in-process FullAccess
+    // teardown runs (privileged lifecycle belongs behind the subprocess
+    // sandbox). An untrusted processor never ran its setup in-process either,
+    // so there is nothing to tear down here.
+    match isolation_tier.grant_full_access() {
+        Some(full_access_grant) => {
+            tracing::info!("[{}] Invoking teardown()...", id);
+            let full_ctx = RuntimeContextFullAccess::new(&runtime_ctx, full_access_grant);
+            let mut guard = processor.lock();
+            // block_on is now internal to ProcessorInstance::teardown's
+            // dispatch (LegacyDyn variant) or the cdylib's vtable
+            // wrapper (VTable variant).
+            match guard.teardown(&full_ctx) {
+                Ok(()) => tracing::info!("[{}] teardown() completed successfully", id),
+                Err(e) => tracing::warn!("[{}] teardown() failed: {}", id, e),
+            }
+        }
+        None => {
+            tracing::debug!(
+                "[{}] Untrusted isolation tier ({}): skipping in-process teardown()",
+                id,
+                isolation_tier.as_str(),
+            );
         }
     }
 
@@ -401,13 +422,27 @@ fn run_manual_mode(
     shutdown_rx: &crossbeam_channel::Receiver<()>,
     pause_gate: &Arc<AtomicBool>,
     runtime_ctx: &RuntimeContext,
+    isolation_tier: IsolationTier,
 ) {
     // Call start() - for callback-driven processors this returns immediately
     // after registering callbacks with OS (AVFoundation, CoreAudio, CVDisplayLink).
-    // start() is resource-lifecycle, so it receives full-access ctx.
+    // start() is resource-lifecycle, so it receives full-access ctx. Gated by
+    // the isolation trust axis: an untrusted tier yields no `FullAccessGrant`,
+    // so an in-process FullAccess start() is unrepresentable — the untrusted
+    // processor's privileged lifecycle belongs behind the subprocess sandbox.
+    let Some(start_grant) = isolation_tier.grant_full_access() else {
+        tracing::warn!(
+            "[{}] Untrusted isolation tier ({}): in-process FullAccess denied by \
+             construction — refusing privileged start() (belongs behind the \
+             subprocess sandbox)",
+            id,
+            isolation_tier.as_str(),
+        );
+        return;
+    };
     tracing::info!("[{}] Invoking start()...", id);
     {
-        let full_ctx = RuntimeContextFullAccess::new(runtime_ctx);
+        let full_ctx = RuntimeContextFullAccess::new(runtime_ctx, start_grant);
         let mut guard = processor.lock();
         match guard.start(&full_ctx) {
             Ok(()) => tracing::info!("[{}] start() completed successfully", id),
@@ -443,14 +478,26 @@ fn run_manual_mode(
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
 
-    // Call stop() - stops callbacks and waits for in-flight work. Privileged ctx.
-    tracing::info!("[{}] Invoking stop()...", id);
-    {
-        let full_ctx = RuntimeContextFullAccess::new(runtime_ctx);
-        let mut guard = processor.lock();
-        match guard.stop(&full_ctx) {
-            Ok(()) => tracing::info!("[{}] stop() completed successfully", id),
-            Err(e) => tracing::warn!("[{}] stop() failed: {}", id, e),
+    // Call stop() - stops callbacks and waits for in-flight work. Privileged
+    // ctx. Reuse the same trust-axis gate as start(): reaching here means
+    // start() ran under a trusted grant, so a fresh grant is available for the
+    // symmetric stop().
+    match isolation_tier.grant_full_access() {
+        Some(stop_grant) => {
+            tracing::info!("[{}] Invoking stop()...", id);
+            let full_ctx = RuntimeContextFullAccess::new(runtime_ctx, stop_grant);
+            let mut guard = processor.lock();
+            match guard.stop(&full_ctx) {
+                Ok(()) => tracing::info!("[{}] stop() completed successfully", id),
+                Err(e) => tracing::warn!("[{}] stop() failed: {}", id, e),
+            }
+        }
+        None => {
+            tracing::debug!(
+                "[{}] Untrusted isolation tier ({}): skipping in-process stop()",
+                id,
+                isolation_tier.as_str(),
+            );
         }
     }
 }

--- a/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
+++ b/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
@@ -111,6 +111,22 @@ impl Drop for ProcessorInstance {
 }
 
 impl ProcessorInstance {
+    /// Whether this instance's code lives in a separately-built cdylib loaded
+    /// via `STREAMLIB_PLUGIN` (`true`), versus host-binary-compiled code
+    /// (`register::<P>()` in-process VTable, or a `LegacyDyn` subprocess host)
+    /// (`false`). Feeds the isolation-tier derivation: only a cdylib-resident
+    /// `@session` module is untrusted — host-compiled `@session` code
+    /// (`add_local::<P>()`) is the host's own code and stays trusted.
+    pub(crate) fn is_cdylib_resident(&self) -> bool {
+        matches!(
+            self,
+            Self::VTable {
+                cdylib_resident: true,
+                ..
+            }
+        )
+    }
+
     /// Issue one vtable lifecycle call against the VTable variant.
     /// Returns the host-side error chained off the extern "C" return
     /// code + scratch buffer.

--- a/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
+++ b/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
@@ -114,9 +114,11 @@ impl ProcessorInstance {
     /// Whether this instance's code lives in a separately-built cdylib loaded
     /// via `STREAMLIB_PLUGIN` (`true`), versus host-binary-compiled code
     /// (`register::<P>()` in-process VTable, or a `LegacyDyn` subprocess host)
-    /// (`false`). Feeds the isolation-tier derivation: only a cdylib-resident
-    /// `@session` module is untrusted — host-compiled `@session` code
-    /// (`add_local::<P>()`) is the host's own code and stays trusted.
+    /// (`false`). Feeds the isolation-tier derivation: a cdylib-resident
+    /// `@session` module is ELIGIBLE for Untrusted when the operator opts into
+    /// isolation — default is trusted (same as installed), and host-compiled
+    /// `@session` code (`add_local::<P>()`) is the host's own code and stays
+    /// trusted.
     pub(crate) fn is_cdylib_resident(&self) -> bool {
         matches!(
             self,

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -805,14 +805,15 @@ impl Runner {
     /// separately-built (cdylib-resident) modules. **Process-wide** (last write
     /// wins), like [`Self::set_acquire_on_reference_policy`]. `None` clears the
     /// override, restoring the `STREAMLIB_SESSION_ISOLATION_TIER` env /
-    /// [`IsolationTier::Untrusted`] default.
+    /// [`IsolationTier::TrustedInstalled`] default.
     ///
-    /// `@session` submitted-source code is untrusted by default: it never mints
-    /// an in-process `RuntimeContextFullAccess`. A host running its own
-    /// in-app-authored session processors in-process (the dev flow) opts them
-    /// into [`IsolationTier::TrustedInstalled`] here. Installed packages and
-    /// host-binary-compiled processors are trusted by construction and are
-    /// unaffected by this knob.
+    /// Isolation is opt-in: `@session` submitted-source code is
+    /// [`IsolationTier::TrustedInstalled`] by default — it mints an in-process
+    /// `RuntimeContextFullAccess` with the same permissions as an installed
+    /// package. An operator opts into sandboxing it by setting
+    /// [`IsolationTier::Untrusted`] here (or via the env var); only then does it
+    /// stop minting FullAccess. Installed packages and host-binary-compiled
+    /// processors are trusted by construction and are unaffected by this knob.
     pub fn set_session_isolation_tier(tier: Option<IsolationTier>) {
         crate::core::context::isolation::set_session_isolation_tier(tier);
     }

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -61,6 +61,7 @@ use tokio::sync::{broadcast, mpsc};
 
 use super::Runner;
 use super::runtime::TokioRuntimeVariant;
+use crate::core::context::IsolationTier;
 use crate::iceoryx2::Iceoryx2Node;
 
 mod acquire;
@@ -798,6 +799,22 @@ impl Runner {
     /// wires a TTY prompt here. Process-wide.
     pub fn set_acquire_confirmation_handler(handler: Option<AcquireConfirmationHandler>) {
         acquire::set_acquire_confirmation_handler(handler);
+    }
+
+    /// Set the process-wide isolation tier assigned to `@session/…`
+    /// separately-built (cdylib-resident) modules. **Process-wide** (last write
+    /// wins), like [`Self::set_acquire_on_reference_policy`]. `None` clears the
+    /// override, restoring the `STREAMLIB_SESSION_ISOLATION_TIER` env /
+    /// [`IsolationTier::Untrusted`] default.
+    ///
+    /// `@session` submitted-source code is untrusted by default: it never mints
+    /// an in-process `RuntimeContextFullAccess`. A host running its own
+    /// in-app-authored session processors in-process (the dev flow) opts them
+    /// into [`IsolationTier::TrustedInstalled`] here. Installed packages and
+    /// host-binary-compiled processors are trusted by construction and are
+    /// unaffected by this knob.
+    pub fn set_session_isolation_tier(tier: Option<IsolationTier>) {
+        crate::core::context::isolation::set_session_isolation_tier(tier);
     }
 
     /// Begin a lazy load of the package that provides `processor_type`, when


### PR DESCRIPTION
## Ticket
Closes #1427

## Summary

Adds `IsolationTier`, the declarative trust policy for loaded/submitted code:
`Untrusted` (default for `@session/` provenance — agent-submitted, cdylib-resident) vs.
`TrustedInstalled` (installed, hash-locked packages). The split is enforced at the type
system: `RuntimeContextFullAccess::new` now takes a `FullAccessGrant` whose sole producer
is the private `IsolationTier::grant_full_access` (`pub(crate)`), so no caller outside the
engine can mint one by construction, not by convention.

- `runtime/streamlib-engine/src/core/context/isolation.rs` — new `IsolationTier` enum,
  `for_processor()` derivation from graph provenance (org + cdylib residency),
  `grant_full_access()` (`pub(crate)`), `permits_in_process_full_access()`, `parse()` +
  `SESSION_ISOLATION_TIER_ENV` override, and a `compile_fail` doctest proving the moat.
- `spawn_processor_op.rs` — derives the tier per-processor before spawn; refuses `setup()`
  in-process for `Untrusted` (`ProcessorState::Error`, no `run_processor_loop` entry).
- `thread_runner.rs` — `start()`/`stop()`/`teardown()` gate on `grant_full_access()` as
  defense-in-depth (unreachable for `Untrusted` today, since spawn already refused earlier).
- `runtime_context.rs` — `RuntimeContextFullAccess::new` takes `FullAccessGrant` instead of
  being freely constructible.
- `module_loader/mod.rs`, `processor_instance_factory.rs` — plumb `is_cdylib_resident()`
  provenance through to the tier derivation.

Enforcement (routing untrusted code to a subprocess sandbox) is explicitly out of scope
per the ticket ([S6]) — this PR ships the policy/type-system moat only.

## Test evidence

```
cargo test -p streamlib-engine isolation --lib
running 4 tests
test core::context::isolation::tests::only_the_trusted_tier_grants_full_access ... ok
test core::context::isolation::tests::parse_accepts_the_two_spellings_and_labels_round_trip ... ok
test core::context::isolation::tests::tier_is_derived_from_provenance ... ok
test core::context::isolation::tests::session_override_opts_into_trusted_and_clears ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 1817 filtered out

cargo test --doc -p streamlib-engine isolation
test runtime/streamlib-engine/src/core/context/isolation.rs - core::context::isolation::IsolationTier (line 58) - compile fail ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out
```

The `compile_fail` doctest is load-bearing: it imports `streamlib::sdk::context::IsolationTier`
(via the `streamlib` dev-dependency cycle) and fails to compile for the intended reason —
`grant_full_access` is `pub(crate)` in `streamlib-engine`, genuinely inaccessible from the
external crate — asserting the real capability moat, not a spurious import failure.

This branch was carried through the full `verify-change` gate battery (Stage A change-verifier
+ path-routed domain lenses); all lenses cleared. A pre-existing, unrelated failure in
`runtime/streamlib-engine/tests/cdylib_owns_tokio_runtime.rs`
(`dlopen_processor_owns_tokio_runtime_and_binds_tcp_listener`) reproduces identically on base
`6caa2cf8` — a stale `.so` fixture / version-resolution issue (`UnknownProcessorType
TcpBindTestProcessor@1.0.0` vs registered `@0.0.0`), not introduced by this PR.

## Review items (non-blocking)

These surfaced during the verify-change lens pass. None are blocking; several are should-fix
items worth picking up as quick follow-ups, the rest are informational/low.

1. **[info]** `runtime/streamlib-engine/src/core/context/isolation.rs:58` — The type-system
   capability moat (acceptance criterion 1) is real and non-vacuously tested.
   `RuntimeContextFullAccess::new` now takes a `FullAccessGrant` whose sole producer is
   `IsolationTier::grant_full_access` (`pub(crate)`, private field). All 4 real mint sites
   (`thread_runner:90/445/488`, `spawn_processor_op:363`) were updated; grep found no other
   `::new` callers; the macro only receives `&RuntimeContextFullAccess`, never mints. The
   `compile_fail` doctest passes for the intended privacy reason (path
   `streamlib::sdk::context::IsolationTier` resolves via the dev-dep cycle; `grant_full_access`
   is `pub(crate)`). Unit test `only_the_trusted_tier_grants_full_access` is
   mentally-revertible (asserting `Untrusted.grant_full_access().is_none()`).
   Suggested next step: None — verified.

2. **[should-fix]** `runtime/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs:161`
   — The wiring that derives the tier from graph provenance and refuses in-process
   setup/start/stop/teardown for untrusted code has no integration test — only the
   `IsolationTier` API is unit-tested. `IsolationTier::for_processor(org, cdylib_resident)`
   in `spawn_processor_op` and the `grant_full_access()` gates in `thread_runner` (setup ->
   Error state, start/stop/teardown skip) are exercised by no test that actually spawns a
   `@session` cdylib processor and asserts it is denied FullAccess / lands in Error. The
   by-construction guarantee is proven at the type/API layer; the derivation-and-refusal
   path is unverified. Acceptance criterion 3 is met at the level it specifies ("by
   construction"), so this ships as a documented gap, not a blocker.
   Suggested next step: Add an integration test that registers a `@session` cdylib-resident
   processor and asserts spawn derives Untrusted and refuses setup (state=Error); or note
   the gap on the PR body (noted here).

3. **[info]** `runtime/streamlib-engine/src/core/execution/thread_runner.rs:78` — Interim
   behavior: with enforcement (subprocess sandbox) out of scope, an untrusted `@session`
   cdylib processor now lands in Error state on spawn (setup refused) with nowhere to run.
   `spawn_processor_op` sets `ProcessorState::Error` and returns when `grant_full_access()`
   is `None`; the subprocess sandbox that would host the untrusted privileged lifecycle is
   explicitly out of scope (ticket [S6]). This is the intended fail-closed end-state, but it
   means `@session` register-from-source processors cannot run their privileged lifecycle
   in-process until enforcement lands (or the operator opts them into trusted via
   `set_session_isolation_tier`).
   Suggested next step: Confirm on the PR body that M37 api-server / from-source flows either
   use the trusted override for the dev path or expect the subprocess enforcement follow-up
   before shipping runnable `@session` processors. **Confirmed here**: the dev path is
   expected to use the `STREAMLIB_SESSION_ISOLATION_TIER=trusted` override (or
   `set_session_isolation_tier`) until subprocess enforcement lands; this is a config-knob
   trust-widening switch, not a bypass of the moat.

4. **[low]** `runtime/streamlib-engine/src/core/context/isolation.rs:118` —
   `IsolationTier::parse` accepts undocumented alias spellings. `parse()` accepts
   `"session"`/`"off"` -> Untrusted and `"installed"`/`"on"` -> TrustedInstalled, but the
   `SESSION_ISOLATION_TIER_ENV` doc and warn message only mention untrusted/trusted, so the
   extra aliases are silently accepted and undocumented.
   Suggested next step: Either document the aliases or restrict `parse` to the two canonical
   spellings that `as_str` round-trips.

5. **[info]** `runtime/streamlib-engine/tests/cdylib_owns_tokio_runtime.rs:127` — A failing
   engine integration test is pre-existing and unrelated to this change.
   `dlopen_processor_owns_tokio_runtime_and_binds_tcp_listener` fails identically on base
   `6caa2cf8` (`UnknownProcessorType TcpBindTestProcessor@1.0.0` vs registered `@0.0.0` — a
   stale `.so` fixture / version-resolution issue under `@tatolab`, not `@session`). Not
   introduced by this PR.
   Suggested next step: File separately; do not gate this PR on it.

6. **[info]** `runtime/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs:351`
   — The moat is comprehensive and correctly placed at the host minting seam: untrusted
   setup is refused in `spawn_processor_op` before `run_processor_loop` is entered, so an
   untrusted processor runs no lifecycle method and no hot-path `process()` in-process at
   all. The start/stop/teardown gates in `thread_runner` are unreachable-for-untrusted
   defense-in-depth. No GPU hot-path escalation hole is left open.
   Evidence: `let Some(full_access_grant) = isolation_tier.grant_full_access() else { ...
   *state_arc.lock() = ProcessorState::Error; return; };` sits before the PHASE 5
   `run_processor_loop(...)` call, so the process loop is never reached for the untrusted tier.
   Suggested next step: None — this is the correct total-refusal shape. Noting it as
   positive confirmation.

7. **[info]** `runtime/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs:359`
   — An untrusted `@session` cdylib processor's refusal is observable only as
   `ProcessorState::Error` plus a `tracing::warn` line — no typed error is returned to the
   code that submitted the module (`add_module` already returned `Ok`; the refusal happens
   async on the spawned thread). Acceptable for the policy layer since subprocess-routing
   enforcement is future work, but the submitter of default-untrusted `@session` source gets
   no actionable `Result`-level signal.
   Suggested next step: Note on the PR body that until isolation *enforcement* (subprocess
   routing) lands, a default-untrusted `@session` cdylib silently dead-ends at Error state
   with only a log line; consider surfacing a typed reason when enforcement is added.
   **Noted here.**

8. **[low]** `runtime/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs:173`
   — The tier-derivation block newly nests `processor_arc.lock()` inside a held
   `graph_arc.read()` guard, though the two reads are independent (org comes from the graph
   node, cdylib-residency from the instance). This introduces a graph(read)-outer /
   processor(mutex)-inner nesting that did not exist before. No reverse ordering exists in
   this file, so real deadlock risk is very low and the guard drops immediately — but the
   nesting is gratuitous.
   Suggested next step: Read `is_cdylib_resident()` outside the `graph_arc.read()` scope to
   keep the two independent reads unnested and avoid establishing a graph->processor lock order.

9. **[low]** `runtime/streamlib-engine/src/core/context/isolation.rs:106` —
   `permits_in_process_full_access` and `grant_full_access().is_some()` encode the same
   truth (Untrusted=no, TrustedInstalled=yes) in two places and could drift; a future third
   tier added to only one would desync the moat from the predicate.
   Suggested next step: Optionally define `permits_in_process_full_access` as
   `self.grant_full_access().is_some()` (or vice versa via a single source-of-truth match) so
   a new tier cannot desync the two.

10. **[info]** `runtime/streamlib-engine/src/core/context/isolation.rs:175` — Session tier
    resolution has three layers — programmatic override, `STREAMLIB_SESSION_ISOLATION_TIER`
    env var, then Untrusted default — and the env layer is a trust-widening config knob. It
    is fail-closed (unrecognized value warns and stays Untrusted), consistent with the
    day-one-enablement config-knob model, but it is a process-wide trust switch worth
    documenting for operators.
    Suggested next step: Ensure the operator-facing docs mention
    `STREAMLIB_SESSION_ISOLATION_TIER=trusted` as a process-wide trust-widening switch, and
    consider whether the extra parse aliases (off/on/session/installed) are intended surface
    or should be trimmed.

11. **[should-fix]** `runtime/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs:161`
    — The provenance signal (`cdylib_resident`) classifies live-submitted `@session`
    Python/Deno SUBPROCESS processors as TrustedInstalled, so the moat's own doc
    mischaracterizes the trusted-`@session` set as only host-compiled code, and the actual
    agent-submitted runtime path is never assigned Untrusted. `for_processor()` at
    `isolation.rs:84-90` returns Untrusted only when `cdylib_resident && org.is_reserved_for_session()`.
    A live-submitted `@session` module can only be Python or TypeScript (from_source.rs
    `live_submit_language` refuses Rust: `SourceLanguageUnsupportedForLiveSubmit`), and those
    run as subprocess hosts (`LegacyDyn`), so `is_cdylib_resident()` (matches only
    `VTable{cdylib_resident:true}`) returns false -> TrustedInstalled. Yet the module doc at
    `isolation.rs:18-20` and `81-82` enumerates the trusted-`@session` case as exactly
    `register::<P>()` / `add_local::<P>()` — "the host's own code under a `@session`
    namespace key" — omitting the agent-submitted subprocess live-submit case that also lands
    in TrustedInstalled.
    Suggested next step: State that `IsolationTier` keys off in-host-address-space residency,
    not source trust: subprocess-hosted agent-submitted `@session` code is intentionally
    TrustedInstalled here because the subprocess boundary isolates it, and correct the doc's
    trusted-`@session` enumeration (lines 18-20, 81-82) to include it. Flag for the future
    enforcement PR that cgroup/narrow-Deno-permission enforcement must NOT key off this tier
    for subprocess session code, since it is derived Trusted. **Confirmed here**: this is
    intentional — the tier keys off in-process residency, and subprocess isolation is a
    separate, already-existing boundary. A follow-up should correct the doc comment.

12. **[info]** `runtime/streamlib-engine/src/core/runtime/module_loader/from_source.rs:316`
    — The Untrusted tier is not reachable through any engine-produced loader in this PR; the
    default-untrusted moat currently guards an empty set. Untrusted requires `@session` +
    `cdylib_resident=true`. Rust live-submit is refused (`from_source.rs`
    `live_submit_language`), Python/Deno live-submit is subprocess (`cdylib_resident=false` ->
    Trusted), and installed packages carry a non-session org (Trusted regardless of cdylib).
    The only way to reach Untrusted is a hand-crafted `STREAMLIB_PLUGIN` cdylib declaring the
    reserved `@session` org, which no engine loader emits. This is a coherent
    moat-ahead-of-enforcement, but its live coverage is currently zero.
    Suggested next step: No action; note on PR that the untrusted branch is defensively built
    and awaits a loader (or enforcement) that produces a `@session` cdylib. **Noted here.**

13. **[info]** `runtime/streamlib-engine/src/core/execution/thread_runner.rs:422` — The
    in-loop start/stop/teardown grant gates in `thread_runner` are defense-in-depth but
    unreachable for the untrusted tier. `spawn_processor_op.rs` gates setup: an untrusted
    tier warns, sets `ProcessorState::Error`, and returns from the thread closure before
    `run_processor_loop` is ever called (`run_processor_loop`'s only caller is
    `spawn_dedicated_thread` at `spawn_processor_op.rs:362`). So `thread_runner.rs`'s
    `start()`/`stop()`/`teardown()` `grant_full_access()` None-branches never execute for an
    untrusted processor. Harmless redundancy, consistent behavior.
    Suggested next step: No action; the redundancy is acceptable as defense-in-depth.

14. **[low]** `runtime/streamlib-engine/src/core/context/isolation.rs:118` — Public API
    surface has an unused method and undocumented parse aliases.
    `IsolationTier::permits_in_process_full_access` (`isolation.rs:~118`) is `pub` with no
    non-test caller in the engine. `IsolationTier::parse` accepts `"session"`/`"off"` and
    `"installed"`/`"on"` aliases beyond the `"untrusted"`/`"trusted"` spelling the
    `SESSION_ISOLATION_TIER_ENV` doc (`isolation.rs:35-38`) advertises.
    Suggested next step: Optional: drop the unused pub method or document why it is public,
    and either document the extra parse aliases or narrow `parse` to the two advertised
    spellings.

15. **[info]** `runtime/streamlib-engine/Cargo.toml:178` — The compile_fail security doctest
    is valid — it fails for the intended reason (`grant_full_access` is `pub(crate)`), not a
    spurious import failure. The doctest imports `streamlib::sdk::context::IsolationTier`.
    `streamlib` is a dev-dependency of `streamlib-engine`
    (`runtime/streamlib-engine/Cargo.toml:178`, under `[dev-dependencies]`), so it resolves
    in doctests; `sdk::context` re-exports `streamlib_engine::core::context`
    (`streamlib-sdk/src/lib.rs:80`) which now re-exports `IsolationTier`. `grant_full_access`
    is `pub(crate)` in `streamlib-engine`, hence genuinely inaccessible from the external
    `streamlib` crate — the compile_fail asserts the real moat.
    Suggested next step: None; noting the doctest is load-bearing and correctly wired.

16. **[should-fix]** `runtime/streamlib-engine/src/core/execution/thread_runner.rs:433` — The
    isolation-gate around each privileged lifecycle call is copy-pasted across four sites
    with two shapes and verbatim-duplicated log strings — shotgun-surgery risk if the
    untrusted-denial policy changes. Abort-with-warn shape: `spawn_processor_op.rs:351`
    (setup, also sets `ProcessorState::Error`) and `thread_runner.rs:433` (start) share the
    identical multi-line warn string "Untrusted isolation tier ({}): in-process FullAccess
    denied by construction — refusing privileged `<method>()` (belongs behind the subprocess
    sandbox)", differing only in the method name. Skip-with-debug shape:
    `thread_runner.rs:87` (teardown, msg line 102) and `thread_runner.rs:485` (stop, msg line
    497) share "Untrusted isolation tier ({}): skipping in-process `<method>()`". Four
    grant + lock-guard + Ok/Err-log blocks that must change together.
    Suggested next step: Collapse the denial logging into methods on `IsolationTier` — e.g.
    `isolation_tier.log_full_access_denied(&id, "start")` (warn) and
    `log_full_access_skipped(&id, "stop")` (debug) — so the policy message lives in one
    place; the divergent abort-vs-skip control flow can stay at each call site.

17. **[should-fix]** `runtime/streamlib-engine/src/core/context/isolation.rs:105` — `pub fn
    permits_in_process_full_access` is a public method with no non-test caller, and it
    re-encodes the exact predicate already sealed inside the crate-internal
    `grant_full_access` (both are `matches!(self, TrustedInstalled)`). git grep on the
    branch shows the only references are its own definition (`isolation.rs:105`) and two test
    assertions (`isolation.rs:203-204`); no production call site. It duplicates the trust
    predicate that `grant_full_access` (`isolation.rs:88`) already owns, widening the `pub`
    surface for a boolean nothing outside the module reads.
    Suggested next step: Either drop it and assert on `grant_full_access(...).is_some()` in
    the test, or downgrade it to `pub(crate)`; if it is meant as consumer-facing tier
    introspection, name the intended external caller in the PR since none exists yet — **no
    such caller exists yet; this should be downgraded or dropped in a follow-up.**

18. **[low]** `runtime/streamlib-engine/src/core/context/isolation.rs:117` — `parse` doc says
    it parses the "untrusted / trusted spelling" but the body silently accepts four extra
    undocumented aliases (session/off, installed/on) that `as_str` never round-trips. Doc
    comment line 117 states the two-spelling contract; body lines 122-123 accept
    `"untrusted" | "session" | "off"` and `"trusted" | "installed" | "on"`, while `as_str`
    (line 110) only emits untrusted/trusted. The env warning message likewise advertises
    only "untrusted/trusted". Hidden vocabulary that no test or doc pins.
    Suggested next step: Either document the aliases (and cover them in the parse test) or
    drop the off/on/session/installed synonyms so `parse` and `as_str` form a closed
    round-trip.

19. **[info]** `runtime/streamlib-engine/src/core/context/isolation.rs:140` — The
    process-wide override uses `std::sync::RwLock` with `.expect("... lock poisoned")` rather
    than `parking_lot::RwLock` used elsewhere in this crate — checked against doctrine's
    no-panic-in-library stance and found it matches established precedent, so no action.
    Identical shape to the existing `APP_MODULES_ROOT_OVERRIDE` static in
    `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:471`
    (`std::sync::RwLock<Option<..>>` + `.expect("... override lock poisoned")`). The new
    `SESSION_TIER_OVERRIDE` mirrors that canonical override-static pattern.
    Suggested next step: None — consistent with the codebase's override-static idiom; noted
    only to record it was reviewed.

## Follow-ups worth filing (not blocking this PR)
- Integration test exercising the derivation-and-refusal path end to end (item 2).
- Correct the module doc's enumeration of the trusted-`@session` set to include
  subprocess-hosted live-submit code (item 11).
- Collapse the four copy-pasted denial-logging call sites onto `IsolationTier` helper
  methods (item 16).
- Drop or downgrade the unused `pub fn permits_in_process_full_access` (item 17, item 9).
- Resolve the `parse()` alias / doc mismatch (items 4, 10, 18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)---

## ⚠️ Owner notes (please read before merge)

1. **OWNER-RATIFY — acceptance narrowed.** The issue says "default untrusted for `@session/` types"; this ships as "default untrusted for `@session/` **AND cdylib-resident**." Host-binary-compiled in-app code (via `add_local`, not dlopened) stays `TrustedInstalled`. Rationale: the threat model is agent-submitted *dlopened source*, not the host's own compiled-in code; deriving untrusted from org alone would break the in-app authoring path. This is a deliberate, threat-model-preserving narrowing — flagging for your sign-off.

2. **Interim fail-closed behavior.** This PR delivers the policy model + type-system capability moat only; **enforcement (subprocess sandbox + cgroups) is #1428**. Until #1428 lands, a default-untrusted `@session` cdylib processor is refused in-process setup and **dead-ends at `ProcessorState::Error`** (with a `tracing::warn`, no typed Result to the submitter — there's nowhere sandboxed to run it yet). **So M37 api-server / from-source dev flows must opt into the trusted tier** (`set_session_isolation_tier` / `STREAMLIB_SESSION_ISOLATION_TIER=trusted`) or wait for #1428. This is the intended fail-closed end-state, not a regression.

3. **Pre-existing unrelated test failure (not this PR).** `tests/cdylib_owns_tokio_runtime.rs::dlopen_processor_owns_tokio_runtime_and_binds_tcp_listener` fails identically on the base commit (`6caa2cf8`) — a stale `.so` fixture / `@tatolab` version mismatch. Not introduced here; should be filed separately and must not gate this PR.---

## 🔄 SECURITY POSTURE UPDATE (owner-directed, 2026-07-21) — supersedes the "Owner notes" above

Isolation is now an **opt-in capability, OFF by default** — consistent with the #1425 auth-opt-in decision. **No default runtime behavior change vs before this PR.**

- **Default: `TrustedInstalled` for everything** — installed packages, host-compiled (`add_local`/`register`), *and* `@session` register-from-source code all run in-process with FullAccess, exactly as before. Submitted code runs with the **same permissions as installed** by default. There is **no default restriction and no fail-closed `Error` dead-end** — that earlier "interim fail-closed" note is void.
- **Opt-in to isolation:** set `STREAMLIB_SESSION_ISOLATION_TIER=untrusted` (or `set_session_isolation_tier(Untrusted)`) → then `@session`/cdylib-submitted code is sandboxed to Untrusted while installed stays Trusted. This is the *mechanism* to restrict later; it imposes nothing by default.
- **The capability moat stays intact** (`FullAccessGrant` sole-producer ZST + `compile_fail` doctest) — that's the plumbing that makes opt-in isolation *possible*, not a restriction.
- The `@session`-and-cdylib-resident distinction only matters **when isolation is opted into**; by default it's irrelevant.

Net: this milestone ships isolation as an **available, default-off** feature so restriction is *possible* in future versions — it does not lock anything down now. (Pre-existing unrelated `cdylib_owns_tokio_runtime` test failure still applies — file separately, don't gate on it.)