### PR TITLE
chore(hooks): gate PR-merge on an owner-controlled authorization toggle

### DIFF
--- a/.claude/hooks/branch-shield.sh
+++ b/.claude/hooks/branch-shield.sh
@@ -44,9 +44,19 @@ deny() {
 
 match() { printf '%s' "$norm" | grep -Eq "$1"; }
 
-# gh pr merge — merging is the owner's call.
+# gh pr merge — gated on an owner-controlled authorization toggle, default OFF.
+# The guardrail stays safe-by-default: the agent may merge only when the owner has
+# opted in via the gitignored authorization file (single source of truth at the
+# project root, read regardless of worktree). Owner toggles it from any terminal:
+#   echo on  > .claude/merge-authorization.local   # grant merge to the agent
+#   echo off > .claude/merge-authorization.local   # revoke (or: rm the file)
+# First line must trim to exactly "on" (case-insensitive) to authorize.
 if match 'gh[[:space:]]+pr[[:space:]]+merge'; then
-  deny "merging PRs is the owner's call (gh pr merge)"
+  auth_file="${CLAUDE_PROJECT_DIR:-.}/.claude/merge-authorization.local"
+  auth="$(head -n1 "$auth_file" 2>/dev/null | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+  if [ "$auth" != "on" ]; then
+    deny "merge authorization is OFF — owner enables with: echo on > .claude/merge-authorization.local (off/rm to revoke) (gh pr merge)"
+  fi
 fi
 
 # git push targeting origin main (force or not): 'origin main', 'origin +main',

--- a/.gitignore
+++ b/.gitignore
@@ -98,5 +98,10 @@ _generated_/
 # covered by *.local.md above; listed explicitly so it's greppable.
 docs/rig-profile.local.md
 
+# Owner-controlled merge-authorization toggle read by .claude/hooks/branch-shield.sh.
+# Absent (default) = the agent may NOT `gh pr merge`; first line "on" grants it.
+# Per-machine, never committed — a committed grant would give every clone merge rights.
+.claude/merge-authorization.local
+
 # Per-developer amos focus state (machine-local, set by /amos:focus).
 .amosrc.toml


### PR DESCRIPTION
## Why

`branch-shield.sh` hard-refused the agent's PR-merge action **unconditionally** — so even when you wanted the agent to merge (e.g. the full-autonomous authorization), it structurally couldn't. You asked to control merge on/off via authorization; this replaces the hard block with a toggle you own.

## How it works

Default **OFF** — the guardrail stays safe-by-default. You flip it from any terminal:

```
echo on  > .claude/merge-authorization.local   # grant the agent merge rights
echo off > .claude/merge-authorization.local   # revoke
rm         .claude/merge-authorization.local    # revoke (absent = off)
```

- The hook reads `$CLAUDE_PROJECT_DIR/.claude/merge-authorization.local`; its first line must trim to `on` (case-insensitive) to authorize. Anything else (absent, empty, `off`) refuses.
- The file is **gitignored and absent by default** — a committed grant would give every clone merge rights, so it's per-machine only.
- Single source of truth at the project root (read the same regardless of worktree).
- **Every other branch-shield refusal is unchanged**: push to `origin main`, commit on `main`/`master`, `reset --hard origin/`, `branch -D main`.

## Verified

Ran the hook against all states before committing:

| input | toggle | result |
|---|---|---|
| PR-merge command | absent (default) | ✅ refused |
| PR-merge command | `on` | ✅ allowed |
| PR-merge command | `off` | ✅ refused |
| PR-merge command | `  ON  ` | ✅ allowed (trim + case) |
| `git push origin main` | any | ✅ still refused |
| `gh pr view …` | any | ✅ still allowed |

## Note: you merge this one manually

Chicken-and-egg — the agent can't merge this PR (the current hard block is still on `main` until this lands). Merge it via the GitHub UI or your own terminal; then `echo on > .claude/merge-authorization.local` and the agent can clear the #1494 / #1493 / #1496 backlog on your say-so.

## Follow-up spotted (not fixed here — out of scope)

`branch-shield`'s quoted-message stripping is **line-based**, so a multi-line commit message (or a `gh pr create` body) containing the PR-merge token still false-triggers the guard — it bit both this commit and the PR-create call here. Single-line quoted payloads are handled; multi-line ones aren't. Worth a separate hardening PR to the shared strip/normalize logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
