### PR TITLE
chore(ops): auto-remove a worktree when its PR merges

### DIFF
--- a/.claude/hooks/worktree-gc.sh
+++ b/.claude/hooks/worktree-gc.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# worktree-gc (PostToolUse / Bash): after a `gh pr merge`, remove the merged PR's
+# worktree so its multi-GB build target doesn't leak. Delegates to
+# .claude/scripts/gc-merged-worktrees.sh (which only removes merged-PR worktrees,
+# so this is safe to fire after any command — it no-ops unless a merge just landed).
+# PostToolUse hooks cannot block; this only ever cleans up.
+input="$(cat)"
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)"
+
+printf '%s' "$cmd" | grep -Eq 'gh[[:space:]]+pr[[:space:]]+merge' || exit 0
+
+dir="${CLAUDE_PROJECT_DIR:-.}"
+"$dir/.claude/scripts/gc-merged-worktrees.sh" || true
+exit 0

--- a/.claude/scripts/gc-merged-worktrees.sh
+++ b/.claude/scripts/gc-merged-worktrees.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# gc-merged-worktrees — remove any worktree under .claude/worktrees/ whose branch
+# has a MERGED pull request, reclaiming the orphaned build target (each is a full
+# multi-GB build tree). Keyed on a merged PR, not on git ancestry, because the repo
+# squash-merges (the branch's commits never become ancestors of main). A worktree
+# with no PR, or an open PR, is left untouched — so in-flight / unpushed work is safe.
+#
+# Runs from the PostToolUse hook after `gh pr merge`, and is safe to run standalone
+# or from a periodic sweep (it only removes merged-PR worktrees; it is idempotent).
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+WT_DIR="$ROOT/.claude/worktrees"
+[ -d "$WT_DIR" ] || exit 0
+command -v gh >/dev/null 2>&1 || exit 0
+
+git -C "$ROOT" worktree prune 2>/dev/null || true
+
+# path<TAB>branch for every registered worktree living under .claude/worktrees/.
+git -C "$ROOT" worktree list --porcelain 2>/dev/null | awk -v pfx="$WT_DIR/" '
+  /^worktree /{ wt=substr($0, 10) }
+  /^branch /{ if (index(wt, pfx)==1) print wt "\t" substr($0, 8) }
+' | while IFS=$'\t' read -r wt ref; do
+  branch="${ref#refs/heads/}"
+  [ -n "$branch" ] || continue
+  merged="$(gh pr list --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" \
+            --head "$branch" --state merged --json number --jq 'length' 2>/dev/null || echo 0)"
+  if [ "${merged:-0}" -gt 0 ]; then
+    if git -C "$ROOT" worktree remove --force "$wt" 2>/dev/null; then
+      echo "gc-merged-worktrees: removed $wt (branch '$branch' — PR merged)" >&2
+    fi
+  fi
+done
+
+git -C "$ROOT" worktree prune 2>/dev/null || true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,6 +40,15 @@
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/rs-sentinels.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-gc.sh"
+          }
+        ]
       }
     ]
   }

--- a/.claude/skills/milestone-loop/SKILL.md
+++ b/.claude/skills/milestone-loop/SKILL.md
@@ -35,6 +35,11 @@ GitHub is the source of truth; the state file only caches the loop's picture.
 
 Reconcile via `gh`:
 - **Prune ghosts** — drop state entries for PRs that merged or issues that closed since last turn.
+- **GC merged worktrees** — run `.claude/scripts/gc-merged-worktrees.sh`. It removes any worktree
+  under `.claude/worktrees/` whose branch has a merged PR (whoever merged it — a mobile merge leaves
+  no local event), reclaiming its multi-GB build target. Safe/idempotent: only touches merged-PR
+  worktrees, never an in-flight or unpushed one. (Also fires immediately after the loop's own
+  `gh pr merge` via the `worktree-gc` PostToolUse hook.)
 - **Validate IDs** — every ticket ref in the state file still resolves to an open issue in the focused milestone.
 - **Consume owner answers.** The owner login is `owner_login` in the state frontmatter (operator-set — never derived from `gh repo view`, which returns the org). The loop's own `gh` identity shares that login, so `author.login` equality **cannot** distinguish an owner answer from the loop's own comment. Detection runs off a **comment-id ledger** instead: every time the loop posts a comment on a ticket (a claim, a parked question, any update — step 6), it records that comment's id (returned by `gh api`) in the ticket's state entry. A parked question is cleared by any comment on that ticket that postdates the question **and whose id the loop did NOT record as its own** — never by a comment the loop posted itself.
 - **Conflicting PRs.** A loop-owned open PR that is CONFLICTING vs `main` → launch `.claude/workflows/fix-ticket.js` with `mode: 'rebase'` (a zone-matched lead rebases in-worktree, re-runs the gates, force-pushes). Rebases do **not** occupy `max_parallel` code slots — they add no new surface — so a mergeable PR never queues behind busy code slots, and the main context never hand-rebases.


### PR DESCRIPTION
## Why

Every workflow/agent run creates a git worktree under `.claude/worktrees/` and builds a full ~20G Vulkan target in it. Nothing removed them after their PR landed, so **36 orphan worktrees (~800G) filled the box's disk to 100%** (`constraints.md` already says "never leave orphan worktrees behind" — it just wasn't enforced).

## What

`.claude/scripts/gc-merged-worktrees.sh` — removes any worktree under `.claude/worktrees/` whose branch has a **merged PR**, reclaiming its build target.

- **Keyed on a merged PR (`gh pr list --head <branch> --state merged`), not git ancestry** — the repo squash-merges, so a merged branch's commits never become ancestors of `main`; the merged-PR check is the unambiguous signal.
- **Safe / idempotent:** it only removes merged-PR worktrees. A worktree with no PR, or an open PR, or unpushed work, is left untouched.

Wired two ways so it catches every merge:
- **`worktree-gc` PostToolUse hook** (`.claude/hooks/worktree-gc.sh`) — fires the sweep immediately after the loop's own PR-merge command.
- **milestone-loop reconciler** — runs the sweep each pass, so a PR you merge from **GitHub mobile** (no local event to hook) gets its worktree reclaimed on the next pass.

## Verified live

Ran it against the current tree: **swept 34 merged-PR worktrees, kept the 2 in-flight ones** (`feat/340-dynamic-reconfigure-example-harness` — open; `feat/1410-session-org-publish-guard` — unmerged). Dry-run first confirmed the selection before any deletion.

## Files
- `.claude/scripts/gc-merged-worktrees.sh` (new)
- `.claude/hooks/worktree-gc.sh` (new, PostToolUse)
- `.claude/settings.json` — register the PostToolUse hook
- `.claude/skills/milestone-loop/SKILL.md` — add the reconciler GC step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
