### PR TITLE
fix(engine): restore grant-gated RuntimeContextFullAccess::new in tap-wiring test

### DIFF
--- a/runtime/streamlib-engine/src/core/context/runtime_context.rs
+++ b/runtime/streamlib-engine/src/core/context/runtime_context.rs
@@ -1201,7 +1201,7 @@ mod host_runtime_ops_wiring_tests {
     //! The existing router tests inject a mock `RuntimeOperations` and so
     //! never exercise the `host_callbacks().is_none()` branch this fix adds;
     //! this test drives the branch through the SAME host-shaped
-    //! `RuntimeContextFullAccess::new(&base)` that lifecycle dispatch mints.
+    //! `RuntimeContextFullAccess::new(&base, grant)` that lifecycle dispatch mints.
     //!
     //! Channel resolution (`find_channel_source_port` over the live graph)
     //! runs BEFORE any iceoryx2 subscribe, so an unwired channel surfaces
@@ -1268,7 +1268,13 @@ mod host_runtime_ops_wiring_tests {
             std::path::PathBuf::from("/tmp/streamlib-test-tap-wiring.sock"),
         );
 
-        let ctx = RuntimeContextFullAccess::new(&base);
+        // The FullAccess ctor is grant-gated (the isolation capability moat);
+        // a test standing in for lifecycle dispatch mints a grant from the
+        // trusted tier, exactly as `thread_runner` does at teardown.
+        let grant = crate::core::context::isolation::IsolationTier::TrustedInstalled
+            .grant_full_access()
+            .expect("TrustedInstalled mints a FullAccessGrant");
+        let ctx = RuntimeContextFullAccess::new(&base, grant);
         let err = tokio_runtime.block_on(async {
             ctx.runtime()
                 .tap_async("no-such-channel".to_string(), None)


### PR DESCRIPTION
## What

Restores the grant-gated `RuntimeContextFullAccess::new(&base, grant)` call in the `#1426`
tap-wiring regression test (`runtime_context.rs:1277`).

## Why

A **semantic merge collision**: `#1493` added the tap-wiring test calling `RuntimeContextFullAccess::new(&base)` (1 arg); `#1494` made that constructor grant-gated (`base` + `FullAccessGrant`). The two merged ~25 min apart, each green against its own base, so neither PR's CI saw the break. The test module is a plain `#[cfg(test)]` (runtime-GPU-skipped, **not** compile-cfg-gated), so it compiles unconditionally — `cargo test -p streamlib-engine --lib` is red on `main` with `error[E0061]`.

Note: the repo's `test.yml` lib gate compiles `-p streamlib -p streamlib-plugin-abi -p streamlib-plugin-sdk -p streamlib-processor-extract` (not `-p streamlib-engine`), so CI stayed green while the engine crate's own `--lib` tests could not compile locally.

## Fix

Mint the grant from the trusted isolation tier, exactly as the three `thread_runner.rs`
lifecycle-dispatch sites do. Reverting reintroduces the `E0061`.

Surfaced during the #1506 rework; landed standalone since it's an independent red-gate fix.
