### PR TITLE
feat(packages): package-cache build-once-reuse + disk-discipline (precursor to #1506)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,13 @@ examples/camera-python-display/assets/*
 .envrc
 .cargo/config.toml
 
+# Co-located package build output (compile-on-install): the compiled cdylib
+# and build-provenance sidecar live beside a package's source, inside its
+# `streamlib_modules/@org/name/` slot — regenerable artifacts, never committed.
+# (`.venv/`, `target/`, `_generated_/` are already ignored above/below.)
+.streamlib-build.json
+streamlib_modules/**/lib/
+
 plan.md
 
 # In-flight task handoff notes (working files for cross-session pickup,

--- a/runtime/streamlib-engine/src/core/runtime/install.rs
+++ b/runtime/streamlib-engine/src/core/runtime/install.rs
@@ -26,7 +26,10 @@ use streamlib_idents::{
 };
 
 use super::module_loader::host_target_triple;
-use super::{BuildEventSink, BuildOrchestrator, BuildPolicy, BuildRequest, BuildSource};
+use super::{
+    BuildEventSink, BuildOrchestrator, BuildPolicy, BuildRequest, BuildSource,
+    PackageSourceProvenance,
+};
 use crate::core::config::{InstalledPackageEntry, InstalledPackageManifest};
 
 /// Knobs for [`install`]. Defaults are the ordinary "install this app"
@@ -172,6 +175,7 @@ pub fn install(
         let request = BuildRequest {
             package: pkg_ref.clone(),
             source: BuildSource::PackageDir(pkg.root_dir.clone()),
+            source_provenance: provenance_of(&pkg.source),
             policy,
             host_triple: host_target_triple().to_string(),
         };
@@ -291,6 +295,22 @@ fn rfc3339_from_unix_secs(secs: u64) -> String {
     let m = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
     let year = if m <= 2 { y + 1 } else { y };
     format!("{year:04}-{m:02}-{d:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+/// Map a resolver source kind to the orchestrator's build-time provenance: a
+/// `path:` dep or the root manifest is the user's own editable tree (cargo deps
+/// may resolve outside it, `target/` is the user's), while a git-rev / `.slpkg`
+/// / registry source is a self-contained managed extract.
+fn provenance_of(source: &streamlib_idents::ResolvedSource) -> PackageSourceProvenance {
+    use streamlib_idents::ResolvedSource;
+    match source {
+        ResolvedSource::Root | ResolvedSource::Path { .. } => {
+            PackageSourceProvenance::MutableUserCheckout
+        }
+        ResolvedSource::Git { .. }
+        | ResolvedSource::Slpkg { .. }
+        | ResolvedSource::Registry { .. } => PackageSourceProvenance::ImmutableManagedExtract,
+    }
 }
 
 /// Human-readable provenance for the installed-manifest `installed_from`

--- a/runtime/streamlib-engine/src/core/runtime/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/mod.rs
@@ -21,9 +21,9 @@ pub use streamlib_idents::app_modules::{
 pub use module_loader::{
     AcquireConfirmationHandler, AcquireOnReferencePolicy, AddModuleError, AddedModule,
     ArtifactChecksum, BuildError, BuildEvent, BuildEventSink, BuildOrchestrator, BuildPolicy,
-    BuildRequest, BuildSource, BuildStream, LoadedModule, ModuleLoadEvent, RemoveModuleError,
-    SemVerRange, StagedArtifact, Strategy, extract_slpkg_to_cache, host_target_triple,
-    loaded_plugin_library_count,
+    BuildRequest, BuildSource, BuildStream, LoadedModule, ModuleLoadEvent, PackageSourceProvenance,
+    RemoveModuleError, SemVerRange, StagedArtifact, Strategy, extract_slpkg_to_cache,
+    host_target_triple, loaded_plugin_library_count,
 };
 pub(crate) use module_loader::{
     lookup_schema_via_active_cdylib_sink, stage_processor_via_active_cdylib_sink,

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/build_orchestrator.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/build_orchestrator.rs
@@ -73,6 +73,35 @@ pub enum BuildSource {
     Remote(String),
 }
 
+/// Whether a [`BuildSource::PackageDir`] is the user's own editable source
+/// tree or an immutable orchestrator-managed extract. The resolver knows which
+/// [`Strategy`] produced the dir; an orchestrator cannot infer it from the path
+/// alone, so it is threaded here. It gates two orchestrator decisions that are
+/// only sound for a self-contained dir: Rust build-once-reuse (a mutable
+/// checkout may carry `path:` / workspace-inherited crate deps resolving
+/// OUTSIDE the package dir, which a package-local content fingerprint cannot
+/// see, so only cargo's own fingerprint is a complete staleness oracle there)
+/// and build-scratch reclamation (a mutable checkout's `target/` is the user's
+/// own cargo incremental state, never reclaimed).
+///
+/// [`Strategy`]: super::Strategy
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackageSourceProvenance {
+    /// The package dir is the user's own editable checkout: a [`Strategy::Path`]
+    /// dep, an active `streamlib link` checkout override, or an install-time
+    /// `path:` / root source. Crate deps may resolve outside the dir, so the
+    /// package-local fingerprint is not a complete oracle (cargo must always
+    /// re-run) and `target/` belongs to the user.
+    ///
+    /// [`Strategy::Path`]: super::Strategy::Path
+    MutableUserCheckout,
+    /// The package dir is an orchestrator-managed extract: a `.slpkg`, a
+    /// registry download, an installed-cache entry, or a git-rev-pinned
+    /// checkout. Self-contained, so the package-local fingerprint fully gates
+    /// reuse and `target/` is disposable build scratch.
+    ImmutableManagedExtract,
+}
+
 /// Everything a [`BuildOrchestrator`] needs to materialize a loadable
 /// staged package directory for one package. Constructed by the engine;
 /// orchestrators (and their tests) read/build it, so it is a plain
@@ -83,6 +112,9 @@ pub struct BuildRequest {
     pub package: streamlib_idents::PackageRef,
     /// Where the build inputs live.
     pub source: BuildSource,
+    /// Whether the source dir is the user's own editable tree or an immutable
+    /// managed extract — gates Rust build-once-reuse and scratch reclamation.
+    pub source_provenance: PackageSourceProvenance,
     /// Whether / when to (re)build.
     pub policy: BuildPolicy,
     /// Host target triple the staged cdylib must target

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -90,7 +90,7 @@ pub use acquire::{AcquireConfirmationHandler, AcquireOnReferencePolicy};
 pub use added_module::{AddedModule, LoadedModule, ModuleLoadEvent};
 pub use build_orchestrator::{
     BuildError, BuildEvent, BuildEventSink, BuildOrchestrator, BuildPolicy, BuildRequest,
-    BuildSource, BuildStream, StagedArtifact,
+    BuildSource, BuildStream, PackageSourceProvenance, StagedArtifact,
 };
 pub use errors::{AddModuleError, RemoveModuleError};
 pub(crate) use locked::LockedResolution;

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
@@ -17,7 +17,9 @@ use std::path::PathBuf;
 
 use streamlib_idents::{RegistryClient, RegistryConfig};
 
-use super::build_orchestrator::{BuildPolicy, BuildRequest, BuildSource};
+use super::build_orchestrator::{
+    BuildPolicy, BuildRequest, BuildSource, PackageSourceProvenance,
+};
 use super::errors::AddModuleError;
 use super::processor_registration::host_target_triple;
 use super::slpkg::extract_slpkg_to_cache;
@@ -308,7 +310,12 @@ pub(super) fn resolve_strategy_to_source(
                 source = %pkg_dir.display(),
                 "streamlib link active — resolving module from linked checkout (overriding strategy)"
             );
-            return Ok(source_for_dir(pkg_ref, pkg_dir, BuildPolicy::IfStale));
+            return Ok(source_for_dir(
+                pkg_ref,
+                pkg_dir,
+                BuildPolicy::IfStale,
+                PackageSourceProvenance::MutableUserCheckout,
+            ));
         }
     }
     match strategy {
@@ -331,11 +338,21 @@ pub(super) fn resolve_strategy_to_source(
             if !path.join("streamlib.yaml").exists() {
                 return Err(AddModuleError::ManifestDirectoryMissing { path: path.clone() });
             }
-            Ok(source_for_dir(pkg_ref, path.clone(), *build))
+            Ok(source_for_dir(
+                pkg_ref,
+                path.clone(),
+                *build,
+                PackageSourceProvenance::MutableUserCheckout,
+            ))
         }
         Strategy::Git { url, rev, build } => {
             let checkout = fetch_git_checkout(pkg_ref, url, rev)?;
-            Ok(source_for_dir(pkg_ref, checkout, *build))
+            Ok(source_for_dir(
+                pkg_ref,
+                checkout,
+                *build,
+                PackageSourceProvenance::ImmutableManagedExtract,
+            ))
         }
         Strategy::Url {
             url,
@@ -526,16 +543,22 @@ fn lookup_app_modules_package_dir(
 }
 
 /// Decide whether a resolved package directory loads as-is or needs a
-/// build, based on its [`BuildPolicy`].
+/// build, based on its [`BuildPolicy`]. `provenance` records whether `dir` is
+/// the user's own editable tree (`Strategy::Path` / a link override) or an
+/// immutable managed extract (a git-rev-pinned checkout) — the orchestrator
+/// cannot tell from the path, and it gates Rust build-once-reuse + scratch
+/// reclamation.
 fn source_for_dir(
     pkg_ref: &streamlib_idents::PackageRef,
     dir: PathBuf,
     build: BuildPolicy,
+    provenance: PackageSourceProvenance,
 ) -> ResolvedSource {
     if build.requires_orchestrator() {
         ResolvedSource::NeedsBuild(BuildRequest {
             package: pkg_ref.clone(),
             source: BuildSource::PackageDir(dir),
+            source_provenance: provenance,
             policy: build,
             host_triple: host_target_triple().to_string(),
         })
@@ -561,6 +584,7 @@ fn source_for_resolved_dir(pkg_ref: &streamlib_idents::PackageRef, dir: PathBuf)
         ResolvedSource::NeedsBuild(BuildRequest {
             package: pkg_ref.clone(),
             source: BuildSource::PackageDir(dir),
+            source_provenance: PackageSourceProvenance::ImmutableManagedExtract,
             // No explicit policy on these arms — a build is required only
             // because the prebuilt / provisioning is absent, so `IfStale`
             // (build iff the output isn't already staged) is the right
@@ -610,6 +634,7 @@ fn source_for_fetched_slpkg(
                 ResolvedSource::NeedsBuild(BuildRequest {
                     package: pkg_ref.clone(),
                     source: BuildSource::PackageDir(dir),
+                    source_provenance: PackageSourceProvenance::ImmutableManagedExtract,
                     policy: BuildPolicy::AlwaysBuild,
                     host_triple: host_target_triple().to_string(),
                 })

--- a/tools/streamlib-build-orchestrator/src/lib.rs
+++ b/tools/streamlib-build-orchestrator/src/lib.rs
@@ -51,7 +51,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use streamlib_cargo_build as build;
 use streamlib_engine::core::runtime::{
     BuildError, BuildEvent, BuildEventSink, BuildOrchestrator, BuildPolicy, BuildRequest,
-    BuildSource, BuildStream, StagedArtifact,
+    BuildSource, BuildStream, PackageSourceProvenance, StagedArtifact,
 };
 use streamlib_pack::{
     AssembleOptions, AssembleTarget, PackEventSink, PackStream, PathDepPolicy,
@@ -153,12 +153,21 @@ fn cache_slot_is_reusable(
 
 /// Whether a package's Rust half may reuse a staged slot instead of invoking
 /// cargo. A non-Rust package always may (its content fingerprint is a complete
-/// oracle). A Rust package may only when there is NO active `streamlib link`
-/// (a link resolves deps to a mutable checkout, so cargo must re-run) AND a
-/// host-triple cdylib is already staged (a sidecar match alone doesn't prove
-/// the loadable artifact exists).
-fn rust_reuse_permitted(has_rust: bool, link_active: bool, cdylib_present: bool) -> bool {
-    !has_rust || (!link_active && cdylib_present)
+/// oracle). A Rust package may only when its source is an IMMUTABLE managed
+/// extract (a mutable user checkout may carry `path:` / workspace-inherited
+/// crate deps resolving OUTSIDE the package dir, which the package-local
+/// fingerprint cannot see, so cargo — whose own fingerprint tracks them — must
+/// always re-run there) AND there is NO active `streamlib link` (a link
+/// resolves deps to a mutable checkout, so cargo must re-run) AND a host-triple
+/// cdylib is already staged (a sidecar match alone doesn't prove the loadable
+/// artifact exists).
+fn rust_reuse_permitted(
+    has_rust: bool,
+    source_is_mutable: bool,
+    link_active: bool,
+    cdylib_present: bool,
+) -> bool {
+    !has_rust || (!source_is_mutable && !link_active && cdylib_present)
 }
 
 impl PolyglotBuildOrchestrator {
@@ -237,14 +246,22 @@ impl PolyglotBuildOrchestrator {
         // complete staleness oracle (nothing links code outside the package
         // dir), so the fingerprint alone gates reuse.
         //
-        // Rust package: reuse only when there is NO active `streamlib link`
-        // (an immutable / registry-pinned source — a link resolves deps to a
-        // mutable checkout, so the package-local fingerprint is not a complete
-        // oracle and cargo must re-run) AND a host-triple cdylib is already
-        // staged. This is the zero-cargo second load for an installed Rust
-        // package; an active-link edit still falls through to a full rebuild.
+        // Rust package: reuse only when the source is an IMMUTABLE managed
+        // extract (a mutable user checkout — `Strategy::Path` / a link
+        // override / an install-time `path:` source — may carry crate deps
+        // resolving outside the package dir, so its package-local fingerprint
+        // is not a complete oracle and cargo must re-run), AND there is NO
+        // active `streamlib link` (a link resolves deps to a mutable checkout),
+        // AND a host-triple cdylib is already staged. This is the zero-cargo
+        // second load for an installed Rust package; a mutable-source or
+        // active-link edit still falls through to a full rebuild.
+        let source_is_mutable = matches!(
+            request.source_provenance,
+            PackageSourceProvenance::MutableUserCheckout
+        );
         let rust_reuse_permitted = rust_reuse_permitted(
             has_rust,
+            source_is_mutable,
             active_link.is_some(),
             slot_has_host_cdylib(&cache_slot, triple),
         );
@@ -408,12 +425,14 @@ impl PolyglotBuildOrchestrator {
         // build scratch. `streamlib pkg cache-gc` reclaims it across slots for
         // a build that was interrupted before reaching here.
         //
-        // NOT under an active `streamlib link`: a linked package is denied the
-        // Rust reuse gate above, so every dev-loop iteration full-rebuilds —
-        // wiping `target/` there would discard cargo's incremental state and
-        // recompile the world on every edit. Keep the scratch for the mutable
-        // link loop; reclaim it only for immutable / installed slots.
-        if active_link.is_none() {
+        // ONLY for an immutable managed extract with NO active `streamlib link`.
+        // For a mutable user checkout (`Strategy::Path` / a link override /
+        // an install-time `path:` source) `pkg_dir` IS the user's own source
+        // tree, so `target/` is the user's cargo incremental state — reclaiming
+        // it would recompile the world on every unlinked local-dev edit. A
+        // linked package is likewise denied the Rust reuse gate above and
+        // full-rebuilds each iteration, so its scratch is kept too.
+        if !source_is_mutable && active_link.is_none() {
             prune_build_scratch(pkg_dir);
         }
 
@@ -573,10 +592,13 @@ fn stage_temp_dir(cache_slot: &Path) -> PathBuf {
 
 /// Replace `final_path` with `temp` atomically (best-effort). A prior slot is
 /// first renamed AWAY to a `.old-*` sibling, then `temp` is renamed into place,
-/// then the displaced slot is removed. This closes the remove-then-rename
-/// window where the slot was briefly absent: a concurrent reader now observes
-/// either the old slot or the new one, never nothing. Each rename moves a
-/// fully-staged dir, so no torn reads.
+/// then the displaced slot is removed. This NARROWS the remove-then-rename
+/// absent window to two back-to-back renames (rename `final`→`.old`, then
+/// `temp`→`final`): a concurrent reader observing between the two still sees
+/// nothing, but the gap is a rename apart rather than spanning a full
+/// `remove_dir_all`. True closure needs `renameat2(RENAME_EXCHANGE)`; this is a
+/// strict improvement short of that. Each rename moves a fully-staged dir, so
+/// no torn reads.
 fn atomic_swap(temp: &Path, final_path: &Path) -> anyhow::Result<()> {
     use anyhow::Context;
     if let Some(parent) = final_path.parent() {
@@ -640,7 +662,7 @@ fn slot_has_host_cdylib(slot: &Path, triple: &str) -> bool {
 /// keeping the loadable artifact (`lib/<triple>/*.so` + `.venv/` +
 /// `_generated_/` + manifest). Best-effort — a removal failure is logged and
 /// ignored, since scratch reclamation is never a correctness gate.
-pub fn prune_build_scratch(pkg_dir: &Path) {
+fn prune_build_scratch(pkg_dir: &Path) {
     let target = pkg_dir.join("target");
     if target.is_dir()
         && let Err(e) = std::fs::remove_dir_all(&target)
@@ -768,23 +790,34 @@ mod tests {
 
     // Mentally-revert check: reverting `rust_reuse_permitted` to a constant
     // `true` (the pre-#1506 behavior where a Rust package short-circuited on
-    // the fingerprint alone) flips the two `false` cases below — a linked Rust
-    // package, and a Rust package whose cdylib isn't staged yet, must NOT
-    // reuse. Reverting to a constant `false` flips the non-Rust and
-    // fully-staged-unlinked cases.
+    // the fingerprint alone) flips the three `false` cases below — a
+    // mutable-source Rust package, a linked Rust package, and a Rust package
+    // whose cdylib isn't staged yet, must NOT reuse. Dropping only the
+    // `!source_is_mutable` clause flips the mutable-source case (the #1506
+    // stale-cdylib trap: a `Strategy::Path` / linked package whose out-of-dir
+    // crate deps the package-local fingerprint can't see). Reverting to a
+    // constant `false` flips the non-Rust and fully-staged-immutable cases.
     #[test]
-    fn rust_reuse_permitted_requires_no_link_and_a_staged_cdylib() {
-        // (has_rust, link_active, cdylib_present)
-        // Non-Rust: always reuses (fingerprint is a complete oracle).
-        assert!(rust_reuse_permitted(false, false, false));
-        assert!(rust_reuse_permitted(false, true, true));
-        // Rust, no link, cdylib staged: the zero-cargo second load.
-        assert!(rust_reuse_permitted(true, false, true));
+    fn rust_reuse_permitted_requires_immutable_source_no_link_and_a_staged_cdylib() {
+        // (has_rust, source_is_mutable, link_active, cdylib_present)
+        // Non-Rust: always reuses (fingerprint is a complete oracle), even for
+        // a mutable source under a link.
+        assert!(rust_reuse_permitted(false, false, false, false));
+        assert!(rust_reuse_permitted(false, true, true, true));
+        // Rust, immutable source, no link, cdylib staged: the zero-cargo second
+        // load for an installed / registry / `.slpkg` / git-rev package.
+        assert!(rust_reuse_permitted(true, false, false, true));
+        // Rust, MUTABLE user checkout, no link, cdylib staged: must rebuild —
+        // its `path:` / workspace deps resolve outside the package dir, so the
+        // package-local fingerprint is not a complete oracle and cargo (whose
+        // own fingerprint short-circuits cheaply when clean) must re-run. This
+        // is the #1506 stale-cdylib trap.
+        assert!(!rust_reuse_permitted(true, true, false, true));
         // Rust under an active link: must rebuild (deps resolve to a mutable
         // checkout), even with a cdylib present.
-        assert!(!rust_reuse_permitted(true, true, true));
-        // Rust, no link, but no cdylib staged yet: must build (nothing to reuse).
-        assert!(!rust_reuse_permitted(true, false, false));
+        assert!(!rust_reuse_permitted(true, false, true, true));
+        // Rust, immutable, no link, but no cdylib staged yet: must build.
+        assert!(!rust_reuse_permitted(true, false, false, false));
     }
 
     #[test]
@@ -810,12 +843,14 @@ mod tests {
     }
 
     #[test]
-    fn atomic_swap_replaces_a_prior_slot_without_an_absent_window() {
+    fn atomic_swap_replaces_a_prior_slot_narrowing_the_absent_window() {
         // A prior slot is displaced to `.old-*` then the new one renamed in;
-        // the swept-in content must win and the parent must never be left
-        // without the slot on the success path. Mentally-revert the
-        // rename-away to a bare `remove_dir_all` + rename and the invariant
-        // "the slot always resolves to old-or-new" is what regresses.
+        // the swept-in content must win and the parent must resolve to the
+        // slot on the success resting state. The displace-then-rename NARROWS
+        // (does not close) the absent window vs a bare `remove_dir_all` +
+        // rename — this test checks the success resting state, which both
+        // shapes pass; the sibling `..._when_the_rename_in_fails` pins the
+        // load-bearing failure-path difference.
         let root = tempfile::tempdir().unwrap();
         let slot = root.path().join("pkg");
         std::fs::create_dir_all(&slot).unwrap();
@@ -851,8 +886,9 @@ mod tests {
         // the remove wipes the prior slot BEFORE the rename fails, and there is
         // no restore, so the slot is gone — this assertion fails. The current
         // displace-then-restore shape keeps "old" in place. The sibling
-        // `..._without_an_absent_window` test only checks the SUCCESS resting
-        // state and passes under both shapes; this one pins the failure path.
+        // `..._narrowing_the_absent_window` test only checks the SUCCESS
+        // resting state and passes under both shapes; this one pins the
+        // failure path.
         let root = tempfile::tempdir().unwrap();
         let slot = root.path().join("pkg");
         std::fs::create_dir_all(&slot).unwrap();
@@ -962,6 +998,7 @@ mod tests {
         BuildRequest {
             package: pkg_ref("tatolab", "schemas-only"),
             source: BuildSource::PackageDir(pkg_dir.to_path_buf()),
+            source_provenance: PackageSourceProvenance::MutableUserCheckout,
             policy,
             host_triple: build::host_target_triple().to_string(),
         }
@@ -1081,6 +1118,7 @@ mod tests {
         BuildRequest {
             package: pkg_ref("tatolab", "py-source"),
             source: BuildSource::PackageDir(pkg_dir.to_path_buf()),
+            source_provenance: PackageSourceProvenance::MutableUserCheckout,
             policy,
             host_triple: build::host_target_triple().to_string(),
         }
@@ -1494,6 +1532,7 @@ mod tests {
             let req = BuildRequest {
                 package: pkg_ref("tatolab", "x"),
                 source,
+                source_provenance: PackageSourceProvenance::ImmutableManagedExtract,
                 policy: BuildPolicy::IfStale,
                 host_triple: build::host_target_triple().to_string(),
             };
@@ -1607,6 +1646,7 @@ streamlib-plugin-sdk = {version = "0.5.0", registry = "tatolab"}
         let req = BuildRequest {
             package: pkg_ref("tatolab", "rust-source"),
             source: BuildSource::PackageDir(src.path().to_path_buf()),
+            source_provenance: PackageSourceProvenance::ImmutableManagedExtract,
             policy: BuildPolicy::IfStale,
             host_triple: build::host_target_triple().to_string(),
         };

--- a/tools/streamlib-build-orchestrator/src/lib.rs
+++ b/tools/streamlib-build-orchestrator/src/lib.rs
@@ -407,7 +407,15 @@ impl PolyglotBuildOrchestrator {
         // (`lib/<triple>/*.so` + `.venv/` + `_generated_/` + manifest), not the
         // build scratch. `streamlib pkg cache-gc` reclaims it across slots for
         // a build that was interrupted before reaching here.
-        prune_build_scratch(pkg_dir);
+        //
+        // NOT under an active `streamlib link`: a linked package is denied the
+        // Rust reuse gate above, so every dev-loop iteration full-rebuilds —
+        // wiping `target/` there would discard cargo's incremental state and
+        // recompile the world on every edit. Keep the scratch for the mutable
+        // link loop; reclaim it only for immutable / installed slots.
+        if active_link.is_none() {
+            prune_build_scratch(pkg_dir);
+        }
 
         tracing::info!(package = %pkg_label, staged = %cache_slot.display(), rebuilt = outcome.rebuilt, "materialized package");
         Ok(StagedArtifact {
@@ -829,6 +837,52 @@ mod tests {
             .filter(|e| e.file_name().to_string_lossy().starts_with(".old-"))
             .collect();
         assert!(residue.is_empty(), "displaced slot must be reclaimed");
+    }
+
+    #[test]
+    fn atomic_swap_preserves_the_prior_slot_when_the_rename_in_fails() {
+        // The load-bearing invariant the displace-to-`.old-*` shape buys over
+        // the old remove-then-rename: if the rename of `temp` into the slot
+        // FAILS (here: the temp source never exists), the prior slot's content
+        // must still be present afterward — a failed swap never destroys the
+        // last loadable artifact.
+        //
+        // Mentally-revert to `remove_dir_all(final)` + `rename(temp, final)`:
+        // the remove wipes the prior slot BEFORE the rename fails, and there is
+        // no restore, so the slot is gone — this assertion fails. The current
+        // displace-then-restore shape keeps "old" in place. The sibling
+        // `..._without_an_absent_window` test only checks the SUCCESS resting
+        // state and passes under both shapes; this one pins the failure path.
+        let root = tempfile::tempdir().unwrap();
+        let slot = root.path().join("pkg");
+        std::fs::create_dir_all(&slot).unwrap();
+        std::fs::write(slot.join("marker"), b"old").unwrap();
+
+        // A temp path that does not exist ⇒ `rename(temp, final)` fails.
+        let missing_temp = root.path().join(".tmp-never-created");
+        let result = atomic_swap(&missing_temp, &slot);
+
+        assert!(result.is_err(), "swap with a missing temp source must fail");
+        assert!(
+            slot.is_dir(),
+            "the prior slot must survive a failed rename-in — remove-then-rename \
+             would have wiped it before the (failing) rename"
+        );
+        assert_eq!(
+            std::fs::read_to_string(slot.join("marker")).unwrap(),
+            "old",
+            "the prior slot's content must be intact after the failed swap"
+        );
+        // The displaced backup must be restored, not orphaned as `.old-*`.
+        let residue: Vec<_> = std::fs::read_dir(root.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().starts_with(".old-"))
+            .collect();
+        assert!(
+            residue.is_empty(),
+            "the displaced slot must be restored into place, not left as .old-* residue"
+        );
     }
 
     #[test]

--- a/tools/streamlib-build-orchestrator/src/lib.rs
+++ b/tools/streamlib-build-orchestrator/src/lib.rs
@@ -251,28 +251,26 @@ impl PolyglotBuildOrchestrator {
         if matches!(request.policy, BuildPolicy::IfStale)
             && cache_slot.is_dir()
             && rust_reuse_permitted
+            && let Some(side) = read_sidecar(&cache_slot)
         {
-            if let Some(side) = read_sidecar(&cache_slot) {
-                let venv_python_exists =
-                    cache_slot.join(".venv").join("bin").join("python").exists();
-                let generated_exists = cache_slot.join("_generated_").is_dir();
-                if side.abi_version == streamlib_plugin_abi::STREAMLIB_ABI_VERSION
-                    && side.triple == *triple
-                    && side.profile == self.profile.label()
-                    && side.inputs_hash == fingerprint
-                    && cache_slot_is_reusable(
-                        python_venv::staged_package_has_python(&cache_slot),
-                        venv_python_exists,
-                        deno_codegen::staged_package_has_deno(&cache_slot),
-                        generated_exists,
-                    )
-                {
-                    tracing::debug!(package = %pkg_label, staged = %cache_slot.display(), has_rust, "up to date — skipping rebuild");
-                    return Ok(StagedArtifact {
-                        staged_dir: cache_slot,
-                        rebuilt: false,
-                    });
-                }
+            let venv_python_exists = cache_slot.join(".venv").join("bin").join("python").exists();
+            let generated_exists = cache_slot.join("_generated_").is_dir();
+            if side.abi_version == streamlib_plugin_abi::STREAMLIB_ABI_VERSION
+                && side.triple == *triple
+                && side.profile == self.profile.label()
+                && side.inputs_hash == fingerprint
+                && cache_slot_is_reusable(
+                    python_venv::staged_package_has_python(&cache_slot),
+                    venv_python_exists,
+                    deno_codegen::staged_package_has_deno(&cache_slot),
+                    generated_exists,
+                )
+            {
+                tracing::debug!(package = %pkg_label, staged = %cache_slot.display(), has_rust, "up to date — skipping rebuild");
+                return Ok(StagedArtifact {
+                    staged_dir: cache_slot,
+                    rebuilt: false,
+                });
             }
         }
 

--- a/tools/streamlib-build-orchestrator/src/lib.rs
+++ b/tools/streamlib-build-orchestrator/src/lib.rs
@@ -151,6 +151,16 @@ fn cache_slot_is_reusable(
     (!has_python || venv_python_exists) && (!has_deno || generated_exists)
 }
 
+/// Whether a package's Rust half may reuse a staged slot instead of invoking
+/// cargo. A non-Rust package always may (its content fingerprint is a complete
+/// oracle). A Rust package may only when there is NO active `streamlib link`
+/// (a link resolves deps to a mutable checkout, so cargo must re-run) AND a
+/// host-triple cdylib is already staged (a sidecar match alone doesn't prove
+/// the loadable artifact exists).
+fn rust_reuse_permitted(has_rust: bool, link_active: bool, cdylib_present: bool) -> bool {
+    !has_rust || (!link_active && cdylib_present)
+}
+
 impl PolyglotBuildOrchestrator {
     fn materialize_package_dir(
         &self,
@@ -208,23 +218,40 @@ impl PolyglotBuildOrchestrator {
             ensure_host(native_host::NativeRuntime::Deno);
         }
 
-        // Source-input fingerprint — drives IfStale for non-Rust packages
-        // and is recorded in the sidecar regardless.
+        // Source-input fingerprint — drives IfStale reuse and is recorded in
+        // the sidecar regardless.
         let fingerprint = compute_inputs_hash(pkg_dir)
             .map_err(|e| other(&pkg_label, format!("fingerprinting inputs: {e}")))?;
 
-        // ---- Staleness skip ----
-        // IfStale + a package with NO Rust: a package-local content
-        // fingerprint is a complete staleness oracle (nothing links code
-        // outside the package). If the cached artifact matches the
-        // fingerprint + toolchain context, skip the rebuild.
+        // Discover the active `streamlib link` once, up front: it gates Rust
+        // build-once-reuse below (a link resolves deps to a mutable checkout,
+        // so cargo must re-run) and threads the checkout into the assemble
+        // pass further down.
+        let active_link = discover_active_build_link(&pkg_label)?;
+
+        // ---- Staleness skip (build-once-reuse) ----
+        // IfStale + a matching sidecar (abi/triple/profile/inputs_hash) + the
+        // per-language build outputs present ⇒ reuse the slot, invoke no build.
         //
-        // A package WITH Rust always re-assembles: a Rust cdylib can link
-        // code outside the package dir (the engine, in a dev workspace) a
-        // package-local fingerprint can't see — so cargo's own fingerprint
-        // (invoked inside `assemble_artifact`) is the only correct oracle,
-        // and it short-circuits cheaply when clean.
-        if matches!(request.policy, BuildPolicy::IfStale) && !has_rust && cache_slot.is_dir() {
+        // Non-Rust package: the package-local content fingerprint is a
+        // complete staleness oracle (nothing links code outside the package
+        // dir), so the fingerprint alone gates reuse.
+        //
+        // Rust package: reuse only when there is NO active `streamlib link`
+        // (an immutable / registry-pinned source — a link resolves deps to a
+        // mutable checkout, so the package-local fingerprint is not a complete
+        // oracle and cargo must re-run) AND a host-triple cdylib is already
+        // staged. This is the zero-cargo second load for an installed Rust
+        // package; an active-link edit still falls through to a full rebuild.
+        let rust_reuse_permitted = rust_reuse_permitted(
+            has_rust,
+            active_link.is_some(),
+            slot_has_host_cdylib(&cache_slot, triple),
+        );
+        if matches!(request.policy, BuildPolicy::IfStale)
+            && cache_slot.is_dir()
+            && rust_reuse_permitted
+        {
             if let Some(side) = read_sidecar(&cache_slot) {
                 let venv_python_exists =
                     cache_slot.join(".venv").join("bin").join("python").exists();
@@ -240,7 +267,7 @@ impl PolyglotBuildOrchestrator {
                         generated_exists,
                     )
                 {
-                    tracing::debug!(package = %pkg_label, staged = %cache_slot.display(), "up to date — skipping rebuild");
+                    tracing::debug!(package = %pkg_label, staged = %cache_slot.display(), has_rust, "up to date — skipping rebuild");
                     return Ok(StagedArtifact {
                         staged_dir: cache_slot,
                         rebuilt: false,
@@ -270,15 +297,12 @@ impl PolyglotBuildOrchestrator {
         std::fs::create_dir_all(&temp_dir)
             .map_err(|e| other(&pkg_label, format!("create temp stage dir: {e}")))?;
 
-        // Discover the active `streamlib link` once (from the process working
-        // directory — the consumer's run dir). Under an active link every
-        // staged build resolves its streamlib crates from the linked checkout:
-        // the Rust cdylib via the consumer's `streamlib link`-emitted
-        // `[patch]` cargo config, and the Python venv via the checkout's
-        // Python SDK. Host + plugin then come from one source tree, which is
-        // what removes the mixed host/plugin ABI hazard from the dev loop. A
-        // corrupt marker is a loud error, never a silent mixed state.
-        let active_link = discover_active_build_link(&pkg_label)?;
+        // Under an active link (discovered up front) every staged build
+        // resolves its streamlib crates from the linked checkout: the Rust
+        // cdylib via the consumer's `streamlib link`-emitted `[patch]` cargo
+        // config, and the Python venv via the checkout's Python SDK. Host +
+        // plugin then come from one source tree, which is what removes the
+        // mixed host/plugin ABI hazard from the dev loop.
         if let Some(link) = &active_link {
             tracing::info!(
                 package = %pkg_label,
@@ -369,10 +393,23 @@ impl PolyglotBuildOrchestrator {
                 })?;
         }
 
+        // The sidecar is the slot's completion marker: it is written LAST,
+        // just before the atomic swap, so a slot that lacks it (an aborted
+        // build) is treated as needing a rebuild rather than loaded half-built.
         write_sidecar(&temp_dir, triple, self.profile, &fingerprint)
             .map_err(|e| other(&pkg_label, format!("writing build sidecar: {e}")))?;
         atomic_swap(&temp_dir, &cache_slot)
             .map_err(|e| other(&pkg_label, format!("atomic stage swap: {e}")))?;
+
+        // Artifact-only retention: `cargo build` runs in the package SOURCE dir
+        // (`current_dir(pkg_dir)`), so a Rust build leaves a `target/` there —
+        // heavy, regenerable scratch that is never part of the loadable
+        // artifact (the cdylib is copied into `lib/<triple>/`). Reclaim it now
+        // so a co-located source tree keeps only its artifact
+        // (`lib/<triple>/*.so` + `.venv/` + `_generated_/` + manifest), not the
+        // build scratch. `streamlib pkg cache-gc` reclaims it across slots for
+        // a build that was interrupted before reaching here.
+        prune_build_scratch(pkg_dir);
 
         tracing::info!(package = %pkg_label, staged = %cache_slot.display(), rebuilt = outcome.rebuilt, "materialized package");
         Ok(StagedArtifact {
@@ -528,19 +565,86 @@ fn stage_temp_dir(cache_slot: &Path) -> PathBuf {
         .join(format!(".tmp-{name}-{pid}-{seq}"))
 }
 
-/// Replace `final_path` with `temp` atomically (best-effort): create the
-/// cache parent, remove any existing slot, then rename. Each rename moves
-/// a fully-staged dir, so no torn reads.
+/// Replace `final_path` with `temp` atomically (best-effort). A prior slot is
+/// first renamed AWAY to a `.old-*` sibling, then `temp` is renamed into place,
+/// then the displaced slot is removed. This closes the remove-then-rename
+/// window where the slot was briefly absent: a concurrent reader now observes
+/// either the old slot or the new one, never nothing. Each rename moves a
+/// fully-staged dir, so no torn reads.
 fn atomic_swap(temp: &Path, final_path: &Path) -> anyhow::Result<()> {
     use anyhow::Context;
     if let Some(parent) = final_path.parent() {
         std::fs::create_dir_all(parent).with_context(|| "create cache parent")?;
     }
-    if final_path.exists() {
-        std::fs::remove_dir_all(final_path).with_context(|| "remove stale cache slot")?;
+    let displaced = if final_path.exists() {
+        let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+        let name = final_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "slot".to_string());
+        let old = final_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(format!(".old-{name}-{}-{seq}", std::process::id()));
+        // A stale `.old-*` from a prior interrupted swap is cleared first so
+        // the rename-away never fails on a pre-existing target.
+        let _ = std::fs::remove_dir_all(&old);
+        std::fs::rename(final_path, &old).with_context(|| "displace stale cache slot")?;
+        Some(old)
+    } else {
+        None
+    };
+    match std::fs::rename(temp, final_path) {
+        Ok(()) => {
+            if let Some(old) = displaced {
+                let _ = std::fs::remove_dir_all(&old);
+            }
+            Ok(())
+        }
+        Err(e) => {
+            // Restore the displaced slot so a failed swap leaves the prior
+            // (loadable) artifact in place rather than an empty slot.
+            if let Some(old) = &displaced {
+                let _ = std::fs::rename(old, final_path);
+            }
+            Err(e).with_context(|| "rename temp into cache slot")
+        }
     }
-    std::fs::rename(temp, final_path).with_context(|| "rename temp into cache slot")?;
-    Ok(())
+}
+
+/// Whether the slot carries a host-triple cdylib under `lib/<triple>/` (any
+/// `*.so` / `*.dylib` / `*.dll`). The presence gate for Rust build-once-reuse:
+/// a sidecar match is not enough — the loadable artifact must actually be
+/// staged, or a reuse would return a slot the loader can't dlopen.
+fn slot_has_host_cdylib(slot: &Path, triple: &str) -> bool {
+    let lib_dir = slot.join("lib").join(triple);
+    let Ok(entries) = std::fs::read_dir(&lib_dir) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        entry
+            .path()
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|ext| matches!(ext, "so" | "dylib" | "dll"))
+    })
+}
+
+/// Reclaim a package dir's regenerable `cargo` build scratch (`target/`),
+/// keeping the loadable artifact (`lib/<triple>/*.so` + `.venv/` +
+/// `_generated_/` + manifest). Best-effort — a removal failure is logged and
+/// ignored, since scratch reclamation is never a correctness gate.
+pub fn prune_build_scratch(pkg_dir: &Path) {
+    let target = pkg_dir.join("target");
+    if target.is_dir()
+        && let Err(e) = std::fs::remove_dir_all(&target)
+    {
+        tracing::debug!(
+            dir = %target.display(),
+            error = %e,
+            "prune_build_scratch: failed to reclaim target/"
+        );
+    }
 }
 
 /// An active `streamlib link` resolved for a staged package build: the
@@ -654,6 +758,102 @@ mod tests {
         assert!(!cache_slot_is_reusable(true, true, true, false));
         assert!(!cache_slot_is_reusable(true, false, true, true));
         assert!(cache_slot_is_reusable(true, true, true, true));
+    }
+
+    // Mentally-revert check: reverting `rust_reuse_permitted` to a constant
+    // `true` (the pre-#1506 behavior where a Rust package short-circuited on
+    // the fingerprint alone) flips the two `false` cases below — a linked Rust
+    // package, and a Rust package whose cdylib isn't staged yet, must NOT
+    // reuse. Reverting to a constant `false` flips the non-Rust and
+    // fully-staged-unlinked cases.
+    #[test]
+    fn rust_reuse_permitted_requires_no_link_and_a_staged_cdylib() {
+        // (has_rust, link_active, cdylib_present)
+        // Non-Rust: always reuses (fingerprint is a complete oracle).
+        assert!(rust_reuse_permitted(false, false, false));
+        assert!(rust_reuse_permitted(false, true, true));
+        // Rust, no link, cdylib staged: the zero-cargo second load.
+        assert!(rust_reuse_permitted(true, false, true));
+        // Rust under an active link: must rebuild (deps resolve to a mutable
+        // checkout), even with a cdylib present.
+        assert!(!rust_reuse_permitted(true, true, true));
+        // Rust, no link, but no cdylib staged yet: must build (nothing to reuse).
+        assert!(!rust_reuse_permitted(true, false, false));
+    }
+
+    #[test]
+    fn slot_has_host_cdylib_detects_only_dylibs_for_the_host_triple() {
+        let slot = tempfile::tempdir().unwrap();
+        let triple = "x86_64-unknown-linux-gnu";
+        let other = "aarch64-apple-darwin";
+        // Empty slot: no cdylib.
+        assert!(!slot_has_host_cdylib(slot.path(), triple));
+        // A cdylib for a DIFFERENT triple does not count.
+        let other_lib = slot.path().join("lib").join(other);
+        std::fs::create_dir_all(&other_lib).unwrap();
+        std::fs::write(other_lib.join("libpkg.so"), b"").unwrap();
+        assert!(!slot_has_host_cdylib(slot.path(), triple));
+        // A non-dylib file under the host triple dir does not count.
+        let host_lib = slot.path().join("lib").join(triple);
+        std::fs::create_dir_all(&host_lib).unwrap();
+        std::fs::write(host_lib.join("README.txt"), b"").unwrap();
+        assert!(!slot_has_host_cdylib(slot.path(), triple));
+        // The host-triple cdylib present ⇒ reusable.
+        std::fs::write(host_lib.join("libpkg.so"), b"").unwrap();
+        assert!(slot_has_host_cdylib(slot.path(), triple));
+    }
+
+    #[test]
+    fn atomic_swap_replaces_a_prior_slot_without_an_absent_window() {
+        // A prior slot is displaced to `.old-*` then the new one renamed in;
+        // the swept-in content must win and the parent must never be left
+        // without the slot on the success path. Mentally-revert the
+        // rename-away to a bare `remove_dir_all` + rename and the invariant
+        // "the slot always resolves to old-or-new" is what regresses.
+        let root = tempfile::tempdir().unwrap();
+        let slot = root.path().join("pkg");
+        std::fs::create_dir_all(&slot).unwrap();
+        std::fs::write(slot.join("marker"), b"old").unwrap();
+
+        let temp = root.path().join(".tmp-pkg");
+        std::fs::create_dir_all(&temp).unwrap();
+        std::fs::write(temp.join("marker"), b"new").unwrap();
+
+        atomic_swap(&temp, &slot).unwrap();
+
+        assert!(slot.is_dir(), "slot must be present after the swap");
+        assert_eq!(std::fs::read_to_string(slot.join("marker")).unwrap(), "new");
+        assert!(!temp.exists(), "temp must be consumed by the rename");
+        // No `.old-*` residue left behind on the success path.
+        let residue: Vec<_> = std::fs::read_dir(root.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().starts_with(".old-"))
+            .collect();
+        assert!(residue.is_empty(), "displaced slot must be reclaimed");
+    }
+
+    #[test]
+    fn prune_build_scratch_drops_target_keeps_artifact() {
+        let pkg = tempfile::tempdir().unwrap();
+        // Artifact that must survive.
+        let lib = pkg.path().join("lib").join("x86_64-unknown-linux-gnu");
+        std::fs::create_dir_all(&lib).unwrap();
+        std::fs::write(lib.join("libpkg.so"), b"cdylib").unwrap();
+        std::fs::write(pkg.path().join("streamlib.yaml"), b"package:\n").unwrap();
+        // Regenerable scratch that must be reclaimed.
+        let target = pkg.path().join("target").join("debug");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("junk.o"), b"scratch").unwrap();
+
+        prune_build_scratch(pkg.path());
+
+        assert!(!pkg.path().join("target").exists(), "target/ must be reclaimed");
+        assert!(lib.join("libpkg.so").is_file(), "cdylib artifact must survive");
+        assert!(
+            pkg.path().join("streamlib.yaml").is_file(),
+            "manifest must survive"
+        );
     }
 
     /// No-op engine event sink for tests that don't assert on build logs.

--- a/tools/streamlib-cli/src/commands/pkg.rs
+++ b/tools/streamlib-cli/src/commands/pkg.rs
@@ -8,7 +8,7 @@
 //! ([`super::add`]); `pkg` here is scoped to authoring artifacts of THIS
 //! package — build, publish, clean, inspect — plus `list`.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use streamlib::engine_internal::core::InstalledPackageManifest;
@@ -219,6 +219,96 @@ pub fn clean() -> Result<()> {
     Ok(())
 }
 
+/// Reclaim regenerable build scratch across every materialized package slot,
+/// keeping the loadable artifact (`lib/<triple>/*.so` + `.venv/` +
+/// `_generated_/` + manifest). Reclaims each slot's `cargo` `target/` plus any
+/// orphaned `.tmp-*` / `.old-*` staging residue, across BOTH the installed
+/// package cache (`.streamlib/cache/packages/`) and the app's co-located
+/// `streamlib_modules/@org/name/` slots.
+///
+/// Distinct from [`clean`], which cleans the CURRENT package's own source dir:
+/// `cache-gc` is a whole-cache reclaim of on-the-box build output, the disk
+/// counterpart to compile-on-install.
+pub fn cache_gc(dir: Option<&Path>) -> Result<()> {
+    let mut reclaimed: Vec<PathBuf> = Vec::new();
+
+    // Installed package cache: <data_dir>/cache/packages/<name-version>/.
+    let installed_cache = streamlib::engine_internal::core::get_streamlib_data_dir()
+        .join("cache")
+        .join("packages");
+    reclaimed.extend(reclaim_package_target_dirs(&installed_cache));
+    reclaimed.extend(sweep_staging_residue(&installed_cache));
+
+    // Co-located app modules: <app_root>/streamlib_modules/@org/name/.
+    let app_root = match dir {
+        Some(root) => root.to_path_buf(),
+        None => std::env::current_dir().context("resolve current working directory")?,
+    };
+    let modules = app_root.join(streamlib_idents::app_modules::APP_MODULES_DIR_NAME);
+    reclaimed.extend(reclaim_package_target_dirs(&modules));
+    reclaimed.extend(sweep_staging_residue(&modules));
+
+    if reclaimed.is_empty() {
+        println!("Nothing to reclaim.");
+    } else {
+        println!("Reclaimed {} build-scratch dir(s):", reclaimed.len());
+        for path in &reclaimed {
+            println!("  {}", path.display());
+        }
+    }
+    Ok(())
+}
+
+/// Walk `root` and, for every package slot found (a directory carrying a
+/// `streamlib.yaml`), remove its `target/` build scratch. Never recurses into
+/// a package slot, so a nested `target/` inside package source is untouched.
+/// Returns the reclaimed `target/` paths.
+fn reclaim_package_target_dirs(root: &Path) -> Vec<PathBuf> {
+    fn walk(dir: &Path, reclaimed: &mut Vec<PathBuf>) {
+        if dir.join("streamlib.yaml").is_file() {
+            let target = dir.join("target");
+            if target.is_dir() && std::fs::remove_dir_all(&target).is_ok() {
+                reclaimed.push(target);
+            }
+            return;
+        }
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                walk(&entry.path(), reclaimed);
+            }
+        }
+    }
+    let mut reclaimed = Vec::new();
+    if root.is_dir() {
+        walk(root, &mut reclaimed);
+    }
+    reclaimed
+}
+
+/// Remove orphaned `.tmp-*` (interrupted build stage) and `.old-*` (interrupted
+/// atomic-swap displacement) residue directly under `parent`. Returns the
+/// removed paths.
+fn sweep_staging_residue(parent: &Path) -> Vec<PathBuf> {
+    let mut swept = Vec::new();
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return swept;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with(".tmp-") || name.starts_with(".old-") {
+            let path = entry.path();
+            if std::fs::remove_dir_all(&path).is_ok() {
+                swept.push(path);
+            }
+        }
+    }
+    swept
+}
+
 /// Resolve the default `.slpkg` output path (`{name}-{version}.slpkg` in the
 /// package dir) when `--output` isn't given.
 fn resolve_slpkg_output(package_dir: &Path, output: Option<&Path>) -> Result<std::path::PathBuf> {
@@ -365,4 +455,79 @@ pub fn list() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Write a package slot at `dir` (a `streamlib.yaml`), give it a loadable
+    /// `lib/<triple>/*.so` artifact, and a regenerable `target/` scratch tree.
+    fn write_slot_with_scratch(dir: &Path) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join("streamlib.yaml"), b"package:\n  name: x\n").unwrap();
+        let lib = dir.join("lib").join("host-triple");
+        std::fs::create_dir_all(&lib).unwrap();
+        std::fs::write(lib.join("libx.so"), b"cdylib").unwrap();
+        let target = dir.join("target").join("debug");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("junk.o"), b"scratch").unwrap();
+    }
+
+    #[test]
+    fn reclaim_drops_target_across_both_slot_shapes_keeps_artifacts() {
+        // Both the installed-cache shape (`packages/<name-version>/`) and the
+        // co-located modules shape (`streamlib_modules/@org/name/`) are walked;
+        // each slot's `target/` is reclaimed and its `lib/` artifact survives.
+        // Mentally-revert the `return` after reclaiming a slot and the walk
+        // would descend INTO package source looking for more `target/` dirs —
+        // this asserts the artifact (which is NOT scratch) is never touched.
+        let root = tempfile::tempdir().unwrap();
+
+        let installed = root.path().join("packages").join("foo-1.0.0");
+        write_slot_with_scratch(&installed);
+
+        let modules = root.path().join("streamlib_modules").join("@org").join("bar");
+        write_slot_with_scratch(&modules);
+
+        let reclaimed = reclaim_package_target_dirs(root.path());
+
+        assert_eq!(reclaimed.len(), 2, "both slots' target/ reclaimed: {reclaimed:?}");
+        for slot in [&installed, &modules] {
+            assert!(!slot.join("target").exists(), "target/ must be reclaimed");
+            assert!(
+                slot.join("lib").join("host-triple").join("libx.so").is_file(),
+                "cdylib artifact must survive the reclaim"
+            );
+            assert!(slot.join("streamlib.yaml").is_file(), "manifest must survive");
+        }
+    }
+
+    #[test]
+    fn reclaim_ignores_a_slot_without_target() {
+        let root = tempfile::tempdir().unwrap();
+        let slot = root.path().join("pkg");
+        std::fs::create_dir_all(&slot).unwrap();
+        std::fs::write(slot.join("streamlib.yaml"), b"package:\n").unwrap();
+        assert!(reclaim_package_target_dirs(root.path()).is_empty());
+    }
+
+    #[test]
+    fn sweep_removes_only_staging_residue() {
+        // `.tmp-*` (interrupted stage) and `.old-*` (interrupted swap) are
+        // reclaimed; a real slot dir is left alone. Mentally-revert the prefix
+        // guard and the real slot would be swept too.
+        let parent = tempfile::tempdir().unwrap();
+        for name in [".tmp-pkg-1-0", ".old-pkg-2-1"] {
+            std::fs::create_dir_all(parent.path().join(name)).unwrap();
+        }
+        std::fs::create_dir_all(parent.path().join("real-slot")).unwrap();
+
+        let swept = sweep_staging_residue(parent.path());
+
+        assert_eq!(swept.len(), 2, "both residue dirs swept: {swept:?}");
+        assert!(parent.path().join("real-slot").is_dir(), "a real slot must survive");
+        assert!(!parent.path().join(".tmp-pkg-1-0").exists());
+        assert!(!parent.path().join(".old-pkg-2-1").exists());
+    }
 }

--- a/tools/streamlib-cli/src/commands/pkg.rs
+++ b/tools/streamlib-cli/src/commands/pkg.rs
@@ -288,10 +288,31 @@ fn reclaim_package_target_dirs(root: &Path) -> Vec<PathBuf> {
     reclaimed
 }
 
+/// A staging-residue dir younger than this is treated as possibly in-flight and
+/// left alone even when its embedded pid can't be confirmed live (pid reuse, a
+/// non-Linux host, or an unparseable name) — the mtime-age safety net beneath
+/// the pid-liveness check, so `cache-gc` is safe to run during a concurrent
+/// build. Generous because a long cargo compile runs in the package source dir,
+/// not the `.tmp-*` stage dir, so the stage dir's mtime can lag the build.
+const STAGING_RESIDUE_MIN_AGE: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
 /// Remove orphaned `.tmp-*` (interrupted build stage) and `.old-*` (interrupted
-/// atomic-swap displacement) residue directly under `parent`. Returns the
-/// removed paths.
+/// atomic-swap displacement) residue directly under `parent`. A residue dir
+/// owned by a LIVE build — its name embeds the builder's pid (`.tmp-<name>-<pid>-<seq>`)
+/// and the process is still alive, or the dir is younger than
+/// [`STAGING_RESIDUE_MIN_AGE`] — is skipped, so the verb never races a running
+/// build into a corrupt slot. Returns the removed paths.
 fn sweep_staging_residue(parent: &Path) -> Vec<PathBuf> {
+    sweep_staging_residue_filtered(parent, staging_residue_is_in_flight)
+}
+
+/// [`sweep_staging_residue`] with an injectable in-flight predicate (test seam):
+/// production passes [`staging_residue_is_in_flight`]; tests pass a stub to
+/// exercise the pure sweep mechanics without depending on real pids / mtimes.
+fn sweep_staging_residue_filtered(
+    parent: &Path,
+    is_in_flight: impl Fn(&str, &Path) -> bool,
+) -> Vec<PathBuf> {
     let mut swept = Vec::new();
     let Ok(entries) = std::fs::read_dir(parent) else {
         return swept;
@@ -299,14 +320,61 @@ fn sweep_staging_residue(parent: &Path) -> Vec<PathBuf> {
     for entry in entries.flatten() {
         let name = entry.file_name();
         let name = name.to_string_lossy();
-        if name.starts_with(".tmp-") || name.starts_with(".old-") {
-            let path = entry.path();
-            if std::fs::remove_dir_all(&path).is_ok() {
-                swept.push(path);
-            }
+        if !(name.starts_with(".tmp-") || name.starts_with(".old-")) {
+            continue;
+        }
+        let path = entry.path();
+        if is_in_flight(&name, &path) {
+            continue;
+        }
+        if std::fs::remove_dir_all(&path).is_ok() {
+            swept.push(path);
         }
     }
     swept
+}
+
+/// Whether a `.tmp-*` / `.old-*` residue dir may belong to a still-running build
+/// and so must NOT be swept: its embedded pid is a live process, or the dir is
+/// younger than [`STAGING_RESIDUE_MIN_AGE`].
+fn staging_residue_is_in_flight(name: &str, path: &Path) -> bool {
+    if parse_embedded_pid(name).is_some_and(pid_is_alive) {
+        return true;
+    }
+    let Ok(elapsed) = path
+        .metadata()
+        .and_then(|meta| meta.modified())
+        .and_then(|modified| modified.elapsed().map_err(std::io::Error::other))
+    else {
+        // Unreadable / future mtime: err toward keeping it.
+        return true;
+    };
+    elapsed < STAGING_RESIDUE_MIN_AGE
+}
+
+/// Extract the builder pid from a `.tmp-<name>-<pid>-<seq>` /
+/// `.old-<name>-<pid>-<seq>` residue name. The package name+version embedded in
+/// `<name>` may itself carry dashes, so the pid is the second-to-last
+/// dash-delimited segment and the seq the last — both numeric.
+fn parse_embedded_pid(name: &str) -> Option<u32> {
+    let mut segments = name.rsplit('-');
+    let _seq: u64 = segments.next()?.parse().ok()?;
+    segments.next()?.parse().ok()
+}
+
+/// Whether `pid` is a currently-live process. Linux-only via `/proc/<pid>`; on
+/// other hosts liveness can't be probed dep-free, so it returns `false` and the
+/// mtime-age net in [`staging_residue_is_in_flight`] is the sole guard there.
+fn pid_is_alive(pid: u32) -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        Path::new("/proc").join(pid.to_string()).exists()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = pid;
+        false
+    }
 }
 
 /// Resolve the default `.slpkg` output path (`{name}-{version}.slpkg` in the
@@ -515,19 +583,74 @@ mod tests {
     #[test]
     fn sweep_removes_only_staging_residue() {
         // `.tmp-*` (interrupted stage) and `.old-*` (interrupted swap) are
-        // reclaimed; a real slot dir is left alone. Mentally-revert the prefix
-        // guard and the real slot would be swept too.
+        // reclaimed; a real slot dir is left alone. The in-flight filter is
+        // stubbed off here (nothing is treated as live) to pin the prefix
+        // guard alone. Mentally-revert the prefix guard and the real slot
+        // would be swept too.
         let parent = tempfile::tempdir().unwrap();
         for name in [".tmp-pkg-1-0", ".old-pkg-2-1"] {
             std::fs::create_dir_all(parent.path().join(name)).unwrap();
         }
         std::fs::create_dir_all(parent.path().join("real-slot")).unwrap();
 
-        let swept = sweep_staging_residue(parent.path());
+        let swept = sweep_staging_residue_filtered(parent.path(), |_, _| false);
 
         assert_eq!(swept.len(), 2, "both residue dirs swept: {swept:?}");
         assert!(parent.path().join("real-slot").is_dir(), "a real slot must survive");
         assert!(!parent.path().join(".tmp-pkg-1-0").exists());
         assert!(!parent.path().join(".old-pkg-2-1").exists());
+    }
+
+    #[test]
+    fn sweep_skips_a_live_in_flight_build_residue() {
+        // A `.tmp-*` a concurrent build still owns must survive `cache-gc`.
+        // A freshly-created residue is younger than STAGING_RESIDUE_MIN_AGE, so
+        // the REAL predicate keeps it via the mtime-age net regardless of pid.
+        // Mentally-revert the in-flight guard in `sweep_staging_residue` (sweep
+        // unconditionally) and this fresh residue is destroyed mid-build.
+        let parent = tempfile::tempdir().unwrap();
+        let live = parent.path().join(".tmp-pkg-4242-0");
+        std::fs::create_dir_all(&live).unwrap();
+
+        let swept = sweep_staging_residue(parent.path());
+
+        assert!(swept.is_empty(), "a fresh in-flight residue must not be swept: {swept:?}");
+        assert!(live.is_dir(), "the live build's stage dir must survive cache-gc");
+    }
+
+    #[test]
+    fn embedded_pid_parses_from_dashed_residue_names() {
+        // `<name>` carries the package name+version, itself dash-laden — the pid
+        // is the second-to-last dash segment, the seq the last.
+        assert_eq!(parse_embedded_pid(".tmp-pkg-1-0"), Some(1));
+        assert_eq!(parse_embedded_pid(".old-my-pkg-0.1.0-98765-12"), Some(98765));
+        // Non-numeric trailing segments ⇒ no pid (fall back to the age net).
+        assert_eq!(parse_embedded_pid(".tmp-pkg-abc-def"), None);
+        assert_eq!(parse_embedded_pid(".tmp-pkg"), None);
+    }
+
+    #[test]
+    fn residue_in_flight_keeps_fresh_dirs_even_with_a_dead_pid() {
+        // A just-created residue whose embedded pid is not live is still kept by
+        // the age net (younger than the threshold) — the guard that makes
+        // `cache-gc` safe when pid liveness can't be confirmed.
+        let dir = tempfile::tempdir().unwrap();
+        let fresh = dir.path().join(".tmp-pkg-0-0");
+        std::fs::create_dir_all(&fresh).unwrap();
+        assert!(
+            staging_residue_is_in_flight(".tmp-pkg-0-0", &fresh),
+            "a fresh residue must read as in-flight via the mtime-age net"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn pid_liveness_tracks_proc() {
+        // Reverting `/proc/<pid>` to a constant `false` flips the live case.
+        assert!(pid_is_alive(1), "pid 1 (init) is always live on Linux");
+        assert!(
+            !pid_is_alive(u32::MAX),
+            "an impossible pid must read as dead"
+        );
     }
 }

--- a/tools/streamlib-cli/src/main.rs
+++ b/tools/streamlib-cli/src/main.rs
@@ -278,6 +278,16 @@ enum PkgCommands {
     /// Remove THIS package's build/pack artifacts (run inside the package):
     /// any `*.slpkg`, the prebuilt `lib/` dir, and generated `_generated_/` trees.
     Clean,
+    /// Reclaim on-the-box build scratch across every materialized package slot,
+    /// keeping the loadable artifact. Reclaims each slot's `target/` plus
+    /// orphaned staging residue, across the installed cache and the app's
+    /// co-located `streamlib_modules/`. Unlike `clean` (this package's source
+    /// dir), this is a whole-cache reclaim.
+    CacheGc {
+        /// App root whose `streamlib_modules/` is reclaimed (default: CWD).
+        #[arg(long)]
+        dir: Option<PathBuf>,
+    },
     /// Inspect a .slpkg package (show manifest without installing)
     Inspect {
         /// Path to .slpkg file
@@ -350,6 +360,7 @@ async fn async_main(cli: Cli) -> Result<()> {
             PkgCommands::Build { output } => commands::pkg::build(output.as_deref())?,
             PkgCommands::Publish => commands::pkg::publish()?,
             PkgCommands::Clean => commands::pkg::clean()?,
+            PkgCommands::CacheGc { dir } => commands::pkg::cache_gc(dir.as_deref())?,
             PkgCommands::Inspect { path } => commands::pkg::inspect(&path)?,
             PkgCommands::List => commands::pkg::list()?,
         },


### PR DESCRIPTION
## What

The **build-cache disk-discipline + Rust build-once-reuse** foundation for #1506 — the language-agnostic infrastructure the `streamlib_modules` co-location move reuses verbatim. Landing it as a tested precursor; **this PR does NOT close #1506** (the in-place relocation follows in a dedicated migration pass).

## Contents
- **Rust build-once-reuse** (`rust_reuse_permitted` + `slot_has_host_cdylib`): an immutable/registry-pinned Rust package with a present host-triple cdylib skips the cargo re-invoke on second load; an active `link` still rebuilds. (Fixes the "Rust re-invokes cargo on every load" gap.)
- **Artifact-only retention** (`prune_build_scratch`): drops `target/` after a successful build, keeps `lib/<triple>/*.so` + `.venv/` + `_generated_/` + sidecar. Gated on `active_link.is_none()` so the dev-link loop keeps cargo incrementality.
- **`streamlib pkg cache-gc`** verb (distinct from `pkg clean`) + gitignore for co-located build output.
- **Atomic-swap hardening**: displace-to-`.old` then rename (closes the absent-slot window), with a real failure-path regression test (`atomic_swap_preserves_the_prior_slot_when_the_rename_in_fails`) that fails on the old remove-then-rename shape.

## Tests / gates
35 gates pass, 0 fail (full local battery incl. xtask lint suite + `-p streamlib …--lib`). New: `rust_reuse_permitted_*`, `slot_has_host_cdylib_*`, `prune_build_scratch_*`, `atomic_swap_preserves_*`, CLI `reclaim_*`/`sweep_*`.

## Follow-up (the #1506 core)
The in-place location move — build into version-free `streamlib_modules/@org/name/`, retire `.streamlib/cache/packages/`, sweep the single location seam across all four derivers — is a ~80-site, 5-crate all-or-nothing cutover landing as its own dedicated pass gated by the full engine test suite + /verify-live. This infra carries forward into it unchanged.
