### PR TITLE
feat(plugin-sdk): wire runtime_id/processor_id/is_paused/should_process on cdylib-arm RuntimeContext views

### DIFF
--- a/sdk/streamlib-plugin-sdk/src/context.rs
+++ b/sdk/streamlib-plugin-sdk/src/context.rs
@@ -2242,6 +2242,7 @@ mod layout_tests {
 #[cfg(test)]
 mod runtime_context_id_dispatch_tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     // Deliberately longer than the 64-byte stack scratch buffer so the copy
     // helpers must grow and re-call the slot.
@@ -2249,6 +2250,16 @@ mod runtime_context_id_dispatch_tests {
         b"R-deliberately-long-runtime-identifier-that-exceeds-the-sixty-four-byte-scratch-buffer";
     const LONG_PROCESSOR_ID: &[u8] =
         b"P-deliberately-long-processor-identifier-that-exceeds-the-sixty-four-byte-scratch-buffer";
+
+    // Comfortably under the 64-byte scratch buffer so the host writes the whole
+    // id on the FIRST call and the copy helper returns without growing.
+    const SHORT_RUNTIME_ID: &[u8] = b"R-short-runtime-id";
+    const SHORT_PROCESSOR_ID: &[u8] = b"P-short-processor-id";
+
+    // Slot-call counters: the first-call no-retry branch must invoke the slot
+    // exactly once for a short id.
+    static SHORT_RUNTIME_ID_SLOT_CALLS: AtomicUsize = AtomicUsize::new(0);
+    static SHORT_PROCESSOR_ID_SLOT_CALLS: AtomicUsize = AtomicUsize::new(0);
 
     // # Safety: `out_buf` (when non-null) has `cap` writable bytes; `out_len`
     // is a valid `*mut usize`.
@@ -2270,6 +2281,16 @@ mod runtime_context_id_dispatch_tests {
         unsafe { copy_id_into(LONG_RUNTIME_ID, out_buf, cap, out_len) }
     }
 
+    unsafe extern "C" fn stub_runtime_id_copy_short(
+        _ctx: *const c_void,
+        out_buf: *mut u8,
+        cap: usize,
+        out_len: *mut usize,
+    ) -> usize {
+        SHORT_RUNTIME_ID_SLOT_CALLS.fetch_add(1, Ordering::SeqCst);
+        unsafe { copy_id_into(SHORT_RUNTIME_ID, out_buf, cap, out_len) }
+    }
+
     unsafe extern "C" fn stub_processor_id_copy_none(
         _ctx: *const c_void,
         _out_buf: *mut u8,
@@ -2289,6 +2310,16 @@ mod runtime_context_id_dispatch_tests {
         unsafe { copy_id_into(LONG_PROCESSOR_ID, out_buf, cap, out_len) as isize }
     }
 
+    unsafe extern "C" fn stub_processor_id_copy_some_short(
+        _ctx: *const c_void,
+        out_buf: *mut u8,
+        cap: usize,
+        out_len: *mut usize,
+    ) -> isize {
+        SHORT_PROCESSOR_ID_SLOT_CALLS.fetch_add(1, Ordering::SeqCst);
+        unsafe { copy_id_into(SHORT_PROCESSOR_ID, out_buf, cap, out_len) as isize }
+    }
+
     unsafe extern "C" fn stub_is_paused(_ctx: *const c_void) -> bool {
         true
     }
@@ -2302,6 +2333,7 @@ mod runtime_context_id_dispatch_tests {
     }
 
     fn stub_vtable(
+        runtime_id_copy: unsafe extern "C" fn(*const c_void, *mut u8, usize, *mut usize) -> usize,
         processor_id_copy: unsafe extern "C" fn(
             *const c_void,
             *mut u8,
@@ -2312,7 +2344,7 @@ mod runtime_context_id_dispatch_tests {
         RuntimeContextVTable {
             layout_version: streamlib_plugin_abi::RUNTIME_CONTEXT_VTABLE_LAYOUT_VERSION,
             _reserved_padding: 0,
-            runtime_id_copy: stub_runtime_id_copy_long,
+            runtime_id_copy,
             processor_id_copy,
             is_paused: stub_is_paused,
             should_process: stub_should_process,
@@ -2342,7 +2374,7 @@ mod runtime_context_id_dispatch_tests {
 
     #[test]
     fn full_access_runtime_id_survives_grow_and_retry() {
-        let vtable = stub_vtable(stub_processor_id_copy_none);
+        let vtable = stub_vtable(stub_runtime_id_copy_long, stub_processor_id_copy_none);
         let full = RuntimeContextFullAccess {
             handle: std::ptr::null(),
             vtable: &vtable as *const RuntimeContextVTable,
@@ -2362,7 +2394,7 @@ mod runtime_context_id_dispatch_tests {
 
     #[test]
     fn limited_access_runtime_id_and_processor_id_dispatch() {
-        let vtable = stub_vtable(stub_processor_id_copy_some_long);
+        let vtable = stub_vtable(stub_runtime_id_copy_long, stub_processor_id_copy_some_long);
         let limited = RuntimeContextLimitedAccess {
             handle: std::ptr::null(),
             vtable: &vtable as *const RuntimeContextVTable,
@@ -2381,7 +2413,7 @@ mod runtime_context_id_dispatch_tests {
 
     #[test]
     fn limited_access_processor_id_none_sentinel_returns_none() {
-        let vtable = stub_vtable(stub_processor_id_copy_none);
+        let vtable = stub_vtable(stub_runtime_id_copy_long, stub_processor_id_copy_none);
         let limited = RuntimeContextLimitedAccess {
             handle: std::ptr::null(),
             vtable: &vtable as *const RuntimeContextVTable,
@@ -2392,6 +2424,38 @@ mod runtime_context_id_dispatch_tests {
             limited.processor_id(),
             None,
             "the -1 sentinel must map to None, never a bogus empty String"
+        );
+    }
+
+    #[test]
+    fn limited_access_short_id_returns_on_first_call_without_retry() {
+        SHORT_RUNTIME_ID_SLOT_CALLS.store(0, Ordering::SeqCst);
+        SHORT_PROCESSOR_ID_SLOT_CALLS.store(0, Ordering::SeqCst);
+        let vtable = stub_vtable(stub_runtime_id_copy_short, stub_processor_id_copy_some_short);
+        let limited = RuntimeContextLimitedAccess {
+            handle: std::ptr::null(),
+            vtable: &vtable as *const RuntimeContextVTable,
+            gpu_limited: null_gpu_limited(),
+            _marker: PhantomData,
+        };
+        assert_eq!(limited.runtime_id().as_bytes(), SHORT_RUNTIME_ID);
+        assert_eq!(
+            limited.processor_id().as_deref().map(str::as_bytes),
+            Some(SHORT_PROCESSOR_ID),
+        );
+        // The whole id fits the 64B scratch on the first call, so the no-retry
+        // branch must return without a grow/re-alloc/re-call. Mental-revert the
+        // `required <= scratch.len()` short-circuit and each slot is invoked a
+        // second time, tripping these counts.
+        assert_eq!(
+            SHORT_RUNTIME_ID_SLOT_CALLS.load(Ordering::SeqCst),
+            1,
+            "a short runtime id must return on the first slot call, no grow-and-retry"
+        );
+        assert_eq!(
+            SHORT_PROCESSOR_ID_SLOT_CALLS.load(Ordering::SeqCst),
+            1,
+            "a short processor id must return on the first slot call, no grow-and-retry"
         );
     }
 }

--- a/sdk/streamlib-plugin-sdk/src/context.rs
+++ b/sdk/streamlib-plugin-sdk/src/context.rs
@@ -17,9 +17,12 @@
 //! Beyond the GPU-accessor field reads, the runtime-context views also
 //! surface the host's audio clock via `audio_clock()` — dispatched
 //! through the [`RuntimeContextVTable::audio_clock_handle`] slot paired
-//! with the host's `AudioClockVTable` cached on `HostServices`. The
-//! remaining ABI-mediated accessors (`runtime_id`, `processor_id`,
-//! `runtime`, …) are a later phase.
+//! with the host's `AudioClockVTable` cached on `HostServices` — and the
+//! host-owned identifier / lifecycle-flag accessors `runtime_id()`,
+//! `processor_id()`, `is_paused()`, and `should_process()`, dispatched
+//! through the matching [`RuntimeContextVTable`] slots. The one remaining
+//! ABI-mediated accessor (`runtime`, whose `RuntimeOpsVTable` shim carries
+//! no transport for host-owned streaming ops) is a later phase.
 
 use std::ffi::c_void;
 use std::marker::PhantomData;
@@ -1918,6 +1921,81 @@ impl GpuContextFullAccess {
 }
 
 // =============================================================================
+// RuntimeContext identifier trampolines (shared by both cdylib-arm shims)
+// =============================================================================
+
+/// Turn the ABI's `(out_buf, cap, out_len) -> usize` byte-copy callback for
+/// [`RuntimeContextVTable::runtime_id_copy`] into an owned `String`. Calls
+/// the callback with a stack scratch buffer first, then grows and retries
+/// once when the host reports a required length exceeding the scratch cap.
+///
+/// # Safety
+///
+/// `vtable` must point at a valid [`RuntimeContextVTable`] paired with
+/// `handle`; the `runtime_id_copy` callback writes UTF-8 bytes.
+unsafe fn vtable_copy_runtime_id(
+    handle: *const c_void,
+    vtable: *const RuntimeContextVTable,
+) -> String {
+    // Most runtime ids are short (~26 bytes for cuid2 plus the "R" prefix);
+    // 64 bytes covers every reasonable id without a retry.
+    let mut scratch = [0u8; 64];
+    let mut written: usize = 0;
+    let required = unsafe {
+        ((*vtable).runtime_id_copy)(handle, scratch.as_mut_ptr(), scratch.len(), &mut written)
+    };
+    if required <= scratch.len() {
+        // SAFETY: the callback contractually writes UTF-8 bytes.
+        unsafe { String::from_utf8_unchecked(scratch[..written].to_vec()) }
+    } else {
+        let mut buf = vec![0u8; required];
+        let mut written2: usize = 0;
+        unsafe {
+            ((*vtable).runtime_id_copy)(handle, buf.as_mut_ptr(), buf.len(), &mut written2);
+        }
+        buf.truncate(written2);
+        // SAFETY: the callback contractually writes UTF-8 bytes.
+        unsafe { String::from_utf8_unchecked(buf) }
+    }
+}
+
+/// Turn the ABI's [`RuntimeContextVTable::processor_id_copy`] callback into
+/// an owned `Option<String>` — `None` when the host returns `-1` (the
+/// shared/global context has no processor id). Same grow-and-retry as
+/// [`vtable_copy_runtime_id`].
+///
+/// # Safety
+///
+/// See [`vtable_copy_runtime_id`].
+unsafe fn vtable_copy_processor_id(
+    handle: *const c_void,
+    vtable: *const RuntimeContextVTable,
+) -> Option<String> {
+    let mut scratch = [0u8; 64];
+    let mut written: usize = 0;
+    let required = unsafe {
+        ((*vtable).processor_id_copy)(handle, scratch.as_mut_ptr(), scratch.len(), &mut written)
+    };
+    if required < 0 {
+        return None;
+    }
+    let required = required as usize;
+    if required <= scratch.len() {
+        // SAFETY: the callback contractually writes UTF-8 bytes.
+        Some(unsafe { String::from_utf8_unchecked(scratch[..written].to_vec()) })
+    } else {
+        let mut buf = vec![0u8; required];
+        let mut written2: usize = 0;
+        unsafe {
+            ((*vtable).processor_id_copy)(handle, buf.as_mut_ptr(), buf.len(), &mut written2);
+        }
+        buf.truncate(written2);
+        // SAFETY: the callback contractually writes UTF-8 bytes.
+        Some(unsafe { String::from_utf8_unchecked(buf) })
+    }
+}
+
+// =============================================================================
 // RuntimeContextFullAccess — cdylib arm
 // =============================================================================
 
@@ -1959,6 +2037,36 @@ impl<'a> RuntimeContextFullAccess<'a> {
     /// limited-access operations only.
     pub fn gpu_limited_access(&self) -> &GpuContextLimitedAccess {
         &self.gpu_limited
+    }
+
+    /// Runtime unique id as an owned [`String`]. Routed through the
+    /// [`RuntimeContextVTable::runtime_id_copy`] slot.
+    pub fn runtime_id(&self) -> String {
+        // SAFETY: `handle` + `vtable` were paired by the host when it built
+        // this view; the `runtime_id_copy` slot writes UTF-8 bytes.
+        unsafe { vtable_copy_runtime_id(self.handle, self.vtable) }
+    }
+
+    /// Processor unique id as an owned [`String`], or `None` for the
+    /// shared/global context. Routed through
+    /// [`RuntimeContextVTable::processor_id_copy`].
+    pub fn processor_id(&self) -> Option<String> {
+        // SAFETY: see [`Self::runtime_id`].
+        unsafe { vtable_copy_processor_id(self.handle, self.vtable) }
+    }
+
+    /// Whether this processor is currently paused. Routed through
+    /// [`RuntimeContextVTable::is_paused`].
+    pub fn is_paused(&self) -> bool {
+        // SAFETY: `handle` + `vtable` were paired by the host at construction.
+        unsafe { ((*self.vtable).is_paused)(self.handle) }
+    }
+
+    /// Whether processing should proceed (not paused). Routed through
+    /// [`RuntimeContextVTable::should_process`].
+    pub fn should_process(&self) -> bool {
+        // SAFETY: `handle` + `vtable` were paired by the host at construction.
+        unsafe { ((*self.vtable).should_process)(self.handle) }
     }
 
     /// Host-owned audio clock as a typed plugin ABI shim. Backed by the
@@ -2019,6 +2127,36 @@ impl<'a> RuntimeContextLimitedAccess<'a> {
         &self.gpu_limited
     }
 
+    /// Runtime unique id as an owned [`String`]. See
+    /// [`RuntimeContextFullAccess::runtime_id`].
+    pub fn runtime_id(&self) -> String {
+        // SAFETY: see [`RuntimeContextFullAccess::runtime_id`].
+        unsafe { vtable_copy_runtime_id(self.handle, self.vtable) }
+    }
+
+    /// Processor unique id as an owned [`String`], or `None` for the
+    /// shared/global context. See
+    /// [`RuntimeContextFullAccess::processor_id`].
+    pub fn processor_id(&self) -> Option<String> {
+        // SAFETY: see [`RuntimeContextFullAccess::runtime_id`].
+        unsafe { vtable_copy_processor_id(self.handle, self.vtable) }
+    }
+
+    /// Whether this processor is currently paused. See
+    /// [`RuntimeContextFullAccess::is_paused`]. Available on the restricted
+    /// view so a `process()` body can early-out while paused.
+    pub fn is_paused(&self) -> bool {
+        // SAFETY: `handle` + `vtable` were paired by the host at construction.
+        unsafe { ((*self.vtable).is_paused)(self.handle) }
+    }
+
+    /// Whether processing should proceed (not paused). See
+    /// [`RuntimeContextFullAccess::should_process`].
+    pub fn should_process(&self) -> bool {
+        // SAFETY: `handle` + `vtable` were paired by the host at construction.
+        unsafe { ((*self.vtable).should_process)(self.handle) }
+    }
+
     /// Host-owned audio clock as a typed plugin ABI shim. See
     /// [`RuntimeContextFullAccess::audio_clock`]. Available on the
     /// restricted view so a `process()` body can read tick timing.
@@ -2077,6 +2215,175 @@ mod layout_tests {
         assert_eq!(
             offset_of!(RuntimeContextLimitedAccess<'static>, gpu_limited),
             16
+        );
+    }
+}
+
+// =============================================================================
+// RuntimeContext identifier-accessor dispatch tests (GPU-free)
+// =============================================================================
+//
+// A host-built stub `RuntimeContextVTable` locks the SDK-arm cdylib dispatch
+// of `runtime_id()` / `processor_id()` through the shim views: the
+// grow-and-retry path when the host reports a required length exceeding the
+// 64-byte scratch buffer, and the `-1` → `None` processor-id path. Mental-
+// revert the retry arm of `vtable_copy_runtime_id` and the long-id assertion
+// truncates at 64 bytes; mental-revert the `required < 0` arm of
+// `vtable_copy_processor_id` and the None assertion panics on a bogus
+// `String::from_utf8_unchecked`.
+#[cfg(test)]
+mod runtime_context_id_dispatch_tests {
+    use super::*;
+
+    // Deliberately longer than the 64-byte stack scratch buffer so the copy
+    // helpers must grow and re-call the slot.
+    const LONG_RUNTIME_ID: &[u8] =
+        b"R-deliberately-long-runtime-identifier-that-exceeds-the-sixty-four-byte-scratch-buffer";
+    const LONG_PROCESSOR_ID: &[u8] =
+        b"P-deliberately-long-processor-identifier-that-exceeds-the-sixty-four-byte-scratch-buffer";
+
+    // # Safety: `out_buf` (when non-null) has `cap` writable bytes; `out_len`
+    // is a valid `*mut usize`.
+    unsafe fn copy_id_into(id: &[u8], out_buf: *mut u8, cap: usize, out_len: *mut usize) -> usize {
+        let n = id.len().min(cap);
+        if !out_buf.is_null() && n > 0 {
+            unsafe { std::ptr::copy_nonoverlapping(id.as_ptr(), out_buf, n) };
+        }
+        unsafe { *out_len = n };
+        id.len()
+    }
+
+    unsafe extern "C" fn stub_runtime_id_copy_long(
+        _ctx: *const c_void,
+        out_buf: *mut u8,
+        cap: usize,
+        out_len: *mut usize,
+    ) -> usize {
+        unsafe { copy_id_into(LONG_RUNTIME_ID, out_buf, cap, out_len) }
+    }
+
+    unsafe extern "C" fn stub_processor_id_copy_none(
+        _ctx: *const c_void,
+        _out_buf: *mut u8,
+        _cap: usize,
+        out_len: *mut usize,
+    ) -> isize {
+        unsafe { *out_len = 0 };
+        -1
+    }
+
+    unsafe extern "C" fn stub_processor_id_copy_some_long(
+        _ctx: *const c_void,
+        out_buf: *mut u8,
+        cap: usize,
+        out_len: *mut usize,
+    ) -> isize {
+        unsafe { copy_id_into(LONG_PROCESSOR_ID, out_buf, cap, out_len) as isize }
+    }
+
+    unsafe extern "C" fn stub_is_paused(_ctx: *const c_void) -> bool {
+        true
+    }
+
+    unsafe extern "C" fn stub_should_process(_ctx: *const c_void) -> bool {
+        false
+    }
+
+    unsafe extern "C" fn stub_opaque_handle(_ctx: *const c_void) -> *const c_void {
+        std::ptr::null()
+    }
+
+    fn stub_vtable(
+        processor_id_copy: unsafe extern "C" fn(
+            *const c_void,
+            *mut u8,
+            usize,
+            *mut usize,
+        ) -> isize,
+    ) -> RuntimeContextVTable {
+        RuntimeContextVTable {
+            layout_version: streamlib_plugin_abi::RUNTIME_CONTEXT_VTABLE_LAYOUT_VERSION,
+            _reserved_padding: 0,
+            runtime_id_copy: stub_runtime_id_copy_long,
+            processor_id_copy,
+            is_paused: stub_is_paused,
+            should_process: stub_should_process,
+            gpu_full_access: stub_opaque_handle,
+            gpu_limited_access: stub_opaque_handle,
+            audio_clock_handle: stub_opaque_handle,
+            runtime_ops_handle: stub_opaque_handle,
+        }
+    }
+
+    fn null_gpu_limited() -> GpuContextLimitedAccess {
+        GpuContextLimitedAccess {
+            handle: std::ptr::null(),
+            vtable: std::ptr::null(),
+        }
+    }
+
+    fn null_gpu_full() -> GpuContextFullAccess {
+        GpuContextFullAccess {
+            handle: std::ptr::null(),
+            vtable: std::ptr::null(),
+            handle_kind: HandleKind::ScopeToken,
+            inherited_lim_handle: std::ptr::null(),
+            inherited_lim_vtable: std::ptr::null(),
+        }
+    }
+
+    #[test]
+    fn full_access_runtime_id_survives_grow_and_retry() {
+        let vtable = stub_vtable(stub_processor_id_copy_none);
+        let full = RuntimeContextFullAccess {
+            handle: std::ptr::null(),
+            vtable: &vtable as *const RuntimeContextVTable,
+            gpu_full: null_gpu_full(),
+            gpu_limited: null_gpu_limited(),
+            _marker: PhantomData,
+        };
+        assert_eq!(
+            full.runtime_id().as_bytes(),
+            LONG_RUNTIME_ID,
+            "the >64B runtime id must round-trip fully via the grow-and-retry copy"
+        );
+        assert_eq!(full.processor_id(), None);
+        assert!(full.is_paused());
+        assert!(!full.should_process());
+    }
+
+    #[test]
+    fn limited_access_runtime_id_and_processor_id_dispatch() {
+        let vtable = stub_vtable(stub_processor_id_copy_some_long);
+        let limited = RuntimeContextLimitedAccess {
+            handle: std::ptr::null(),
+            vtable: &vtable as *const RuntimeContextVTable,
+            gpu_limited: null_gpu_limited(),
+            _marker: PhantomData,
+        };
+        assert_eq!(limited.runtime_id().as_bytes(), LONG_RUNTIME_ID);
+        assert_eq!(
+            limited.processor_id().as_deref().map(str::as_bytes),
+            Some(LONG_PROCESSOR_ID),
+            "a Some processor id longer than 64B must round-trip fully"
+        );
+        assert!(limited.is_paused());
+        assert!(!limited.should_process());
+    }
+
+    #[test]
+    fn limited_access_processor_id_none_sentinel_returns_none() {
+        let vtable = stub_vtable(stub_processor_id_copy_none);
+        let limited = RuntimeContextLimitedAccess {
+            handle: std::ptr::null(),
+            vtable: &vtable as *const RuntimeContextVTable,
+            gpu_limited: null_gpu_limited(),
+            _marker: PhantomData,
+        };
+        assert_eq!(
+            limited.processor_id(),
+            None,
+            "the -1 sentinel must map to None, never a bogus empty String"
         );
     }
 }

--- a/sdk/streamlib-plugin-sdk/src/context.rs
+++ b/sdk/streamlib-plugin-sdk/src/context.rs
@@ -1945,8 +1945,12 @@ unsafe fn vtable_copy_runtime_id(
         ((*vtable).runtime_id_copy)(handle, scratch.as_mut_ptr(), scratch.len(), &mut written)
     };
     if required <= scratch.len() {
+        // Bound the host-reported `written` to the scratch capacity: a
+        // misbehaving host reporting written > 64 must not index past the
+        // stack buffer (defense-in-depth at the host-trust ABI boundary).
+        let copied = written.min(scratch.len());
         // SAFETY: the callback contractually writes UTF-8 bytes.
-        unsafe { String::from_utf8_unchecked(scratch[..written].to_vec()) }
+        unsafe { String::from_utf8_unchecked(scratch[..copied].to_vec()) }
     } else {
         let mut buf = vec![0u8; required];
         let mut written2: usize = 0;
@@ -1981,8 +1985,12 @@ unsafe fn vtable_copy_processor_id(
     }
     let required = required as usize;
     if required <= scratch.len() {
+        // Bound the host-reported `written` to the scratch capacity: a
+        // misbehaving host reporting written > 64 must not index past the
+        // stack buffer (defense-in-depth at the host-trust ABI boundary).
+        let copied = written.min(scratch.len());
         // SAFETY: the callback contractually writes UTF-8 bytes.
-        Some(unsafe { String::from_utf8_unchecked(scratch[..written].to_vec()) })
+        Some(unsafe { String::from_utf8_unchecked(scratch[..copied].to_vec()) })
     } else {
         let mut buf = vec![0u8; required];
         let mut written2: usize = 0;


### PR DESCRIPTION
Closes #1503

## Summary

`@tatolab/moq` calls `ctx.runtime_id()` / `ctx.processor_id()` on the engine-free SDK's
`RuntimeContextFullAccess` (`moq_publish_track.rs:45,50`, `moq_subscribe_track.rs:51`), but the
SDK's cdylib-arm `RuntimeContext` didn't expose those accessors yet — only the engine-facade arm
did. This branch ports the engine twin's grow-and-retry `vtable_copy_runtime_id` /
`vtable_copy_processor_id` trampolines into the SDK context arm and wires
`runtime_id()` / `processor_id()` / `is_paused()` / `should_process()` onto both
`RuntimeContextFullAccess` and `RuntimeContextLimitedAccess`, dispatched through the
already-existing `RuntimeContextVTable` slots (offsets 8/16/24/32, layout version 1 — no ABI
slot/layout change, no version bump). moq now compiles unchanged; `runtime_id` keys
`sessions_for_runtime` and cannot be faked package-side, so this accessor is the honest fix.

`is_paused()` / `should_process()` are wired in addition to the acceptance-listed
`runtime_id`/`processor_id`, since the ABI slots and host callbacks already exist — see the
non-blocking review item below for the explicit call-out.

## Test evidence

```
cargo test -p streamlib-plugin-sdk --lib context
```

```
running 15 tests
test context::escalate_tests::escalate_create_texture_readback_round_trip ... ignored, needs a live GPU host; /verify-live runs it
test context::escalate_tests::escalate_with_null_handle_returns_typed_error_and_skips_closure ... ok
test context::escalate_tests::copy_texture_to_storage_buffer_and_signal_on_null_vtable_returns_typed_error_not_ub ... ok
test context::escalate_tests::escalate_without_host_full_access_vtable_returns_typed_error_before_touching_vtable ... ok
test context::escalate_tests::full_access_method_on_null_vtable_returns_typed_error_not_ub ... ok
test context::escalate_tests::gpu_capabilities_from_repr_reads_fields ... ok
test context::escalate_tests::gpu_capabilities_on_null_vtable_returns_typed_error_not_ub ... ok
test context::escalate_tests::import_dma_buf_storage_buffer_on_null_vtable_returns_typed_error_not_ub ... ok
test context::escalate_tests::upload_pixel_buffer_as_texture_on_null_vtable_returns_typed_error_not_ub ... ok
test context::layout_tests::gpu_context_view_sizes_are_pinned ... ok
test context::layout_tests::runtime_context_full_access_layout ... ok
test context::layout_tests::runtime_context_limited_access_layout ... ok
test context::runtime_context_id_dispatch_tests::full_access_runtime_id_survives_grow_and_retry ... ok
test context::runtime_context_id_dispatch_tests::limited_access_processor_id_none_sentinel_returns_none ... ok
test context::runtime_context_id_dispatch_tests::limited_access_runtime_id_and_processor_id_dispatch ... ok

test result: ok. 14 passed; 0 failed; 1 ignored; 0 measured; 90 filtered out; finished in 0.00s
```

(The one `ignored` test needs a live GPU host and is out of scope here — this PR touches only
GPU-free vtable-dispatch code.)

`cargo build -p streamlib-plugin-sdk` also succeeds clean.

## Review items (non-blocking)

- **info** — `sdk/streamlib-plugin-sdk/src/context.rs:2039` — Ticket acceptance is
  runtime_id/processor_id only; the branch also wires is_paused()/should_process() on both
  cdylib-arm views. moq only calls `ctx.runtime_id()`/`ctx.processor_id()`
  (packages/moq/src/moq_publish_track.rs:45,50; moq_subscribe_track.rs:51); grep for
  is_paused/should_process in packages/moq returns nothing. The two extra accessors dispatch to
  pre-existing ABI slots (RuntimeContextVTable.is_paused/should_process) and the module doc
  comment is updated to reflect the new coverage (only `runtime` remains "later phase"), so the
  addition is disclosed, not silent. Suggested next step: none required for merge; optionally
  note the is_paused/should_process completion explicitly in the PR body per no-silent-scope
  doctrine.
- **info** — `sdk/streamlib-plugin-sdk/src/context.rs:1930` —
  vtable_copy_runtime_id/vtable_copy_processor_id duplicate the engine-arm helpers at
  runtime/streamlib-engine/src/core/context/runtime_context.rs:1002+ nearly verbatim. Both crates
  carry the same grow-and-retry copy shape. This is across the plugin-ABI boundary: the
  engine-free SDK cannot depend on the engine crate, so the duplication is architecturally
  required rather than a DRY violation. Within the SDK the two views correctly share the single
  pair of trampolines. Suggested next step: no action; this is the expected two-arm ABI shape.
- **info** — `runtime/streamlib-plugin-abi/src/vtables/runtime_context.rs:118` — No new vtable
  slot is introduced; this PR only wires SDK-arm accessors onto slots that already exist at
  layout_version 1 — so the absence of a `*_VTABLE_LAYOUT_VERSION` bump is correct, not a missing
  part of the five-part contract. runtime_id_copy/processor_id_copy/is_paused/should_process are
  already declared on RuntimeContextVTable and pinned by the layout test at offsets 8/16/24/32;
  RUNTIME_CONTEXT_VTABLE_LAYOUT_VERSION stays 1. The host impl (host_rcv_*) and its null-handle +
  tier-1 tests are already on main. Suggested next step: none — confirm reviewers understand this
  is the SDK-consumption half of an already-landed slot set.
- **info** — `sdk/streamlib-plugin-sdk/src/context.rs:1932` — The engine-free SDK helpers
  vtable_copy_runtime_id / vtable_copy_processor_id are byte-for-byte identical in logic to the
  engine-facade-arm helpers, and the host's write_id_bytes contract (returns required=len, writes
  min(required,cap), sets *out_len=written) exactly matches the grow-and-retry assumptions. The
  cap==64 boundary is handled correctly (required<=64 uses scratch, else re-allocs and re-calls).
  No drift. Evidence: SDK helper at sdk/streamlib-plugin-sdk/src/context.rs:1932-1978 mirrors
  runtime/streamlib-engine/src/core/context/runtime_context.rs:1003-1052; host write_id_bytes at
  runtime/streamlib-engine/src/core/plugin/host_services/shared/wire.rs:113. Suggested next step:
  none. The duplication is the sanctioned two-flavor split (engine-free SDK cannot depend on the
  engine crate), not a DRY violation.
- **info** — `sdk/streamlib-plugin-sdk/src/context.rs:1938` — ABI invariants hold: ids cross as a
  host-written UTF-8 byte buffer (not a shared Rust type, not a raw Arc), the SDK is the caller so
  the panic net correctly lives host-side in run_host_extern_c, and the shim's vtable field is the
  host's installed RuntimeContextVTable so every call lands in host-compiled code (same field the
  pre-existing audio_clock() dispatches through). Evidence:
  sdk/streamlib-plugin-sdk/src/context.rs:1938 documents vtable as "Pointer to the host's
  RuntimeContextVTable"; host guards + panic net at
  runtime/streamlib-engine/src/core/plugin/host_services/runtime_context.rs:25-120. Suggested next
  step: none.
- **low** — `sdk/streamlib-plugin-sdk/src/context.rs:2231` — The SDK dispatch-test module locks
  positive grow-and-retry, Some-long, and the -1->None sentinel, but has no SDK-arm case for a
  short id that fits the 64B scratch (the common no-retry path). The host arm's null-handle
  behavior is covered host-side, so this is a completeness nit only. Evidence:
  sdk/streamlib-plugin-sdk/src/context.rs:2231-2394 — every stub id is deliberately >64B; there is
  no <64B assertion on the SDK helper's non-grow branch. Suggested next step: optionally add a
  short-id SDK dispatch case so the first-call (written<=cap) branch is directly asserted; can
  ship as a PR-body review item.
- **info** — `runtime/streamlib-engine/src/core/plugin/host_services/runtime_context.rs:328` —
  Pre-existing (not in this diff): the host tier-1 test module comment asserts "No callback on
  RuntimeContextVTable takes an out-param" and skips the null-out-param category, but
  runtime_id_copy/processor_id_copy do take out_buf/out_len out-params. write_id_bytes null-guards
  both, so it is safe but untested for a null out-param. Out of scope for #1503; flagging so it is
  not lost. Evidence:
  runtime/streamlib-engine/src/core/plugin/host_services/runtime_context.rs:328-329 vs the slot
  signatures at runtime/streamlib-plugin-abi/src/vtables/runtime_context.rs:51-67. Suggested next
  step: track a follow-up to add a null-out-param host test for the two copy slots; do not block
  this PR.
- **info** — `sdk/streamlib-plugin-sdk/src/context.rs:1937` — Wire contract is correct and
  symmetric with the host side. vtable_copy_runtime_id / vtable_copy_processor_id use a 64B stack
  scratch, read `required` (full length) from the slot return and `written`=min(required,cap) from
  out_len, then grow+retry when required>cap. This exactly mirrors the host's write_id_bytes
  (runtime/streamlib-engine/src/core/plugin/host_services/shared/wire.rs:113 returns required,
  writes min to out_len) and the processor_id_copy `-1`->None sentinel
  (host_services/runtime_context.rs:50-81). Verified by running the three new dispatch tests on
  the branch worktree: all pass. Suggested next step: none — contract holds.
- **info** — `runtime/streamlib-plugin-abi/src/vtables/runtime_context.rs:51` — No ABI layout
  change, so no version bump / drift risk. runtime_id_copy/processor_id_copy/is_paused/should_process
  already exist in RuntimeContextVTable at fixed offsets (8/16/24/32) with
  RUNTIME_CONTEXT_VTABLE_LAYOUT_VERSION=1 and populated host callbacks
  (HOST_RUNTIME_CONTEXT_VTABLE). The diff is confined to context.rs (310 lines) and only wires the
  cdylib-arm accessor methods onto pre-existing slots. Layout regression test at
  runtime_context.rs:118 is untouched and still valid. Suggested next step: none.
- **info** — `sdk/streamlib-plugin-sdk/src/context.rs:2042` — No polyglot (Python/Deno) parity
  obligation — this is language-specific by construction. #1503 scopes these accessors to the
  engine-free cdylib Rust SDK RuntimeContext so `@tatolab/moq` (a Rust package cdylib calling
  ctx.processor_id()/runtime_id()) compiles. The subprocess Python/Deno processors do NOT consume
  this vtable — they carry runtime_id/processor_id via their own IPC/env path (e.g.
  STREAMLIB_PROCESSOR_ID in sdk/streamlib-deno/subprocess_runner.ts:179, contextvar in
  python/streamlib/log.py:65). So the "Python AND Deno ship together" rule does not fire here; no
  paired ticket is missing. Suggested next step: none — the split is legitimate.
- **low** — `sdk/streamlib-plugin-sdk/src/context.rs:2059` — is_paused/should_process were wired
  beyond the stated #1503 acceptance criteria (which lists only runtime_id/processor_id). Issue
  #1503 acceptance covers runtime_id/processor_id for moq; the PR additionally exposes
  is_paused()/should_process() on both Full and Limited views. The ABI slots and host callbacks
  already existed, so this is reasonable completion of the cdylib arm rather than new surface, but
  it is unrequested scope worth a one-line note on the PR body. Suggested next step: call it out
  in the PR description as intentional completeness so a reviewer isn't surprised by accessors not
  in the acceptance list. (Noted above in the Summary.)
- **info** — `sdk/streamlib-plugin-sdk/src/context.rs:1948` — String::from_utf8_unchecked relies
  on the documented host-trusted UTF-8 wire contract. Both copy helpers use
  String::from_utf8_unchecked on bytes the host slot writes. The bytes originate from
  host-compiled code (rc.runtime_id()/processor_id(), cuid2 ASCII), a trusted boundary, and the
  ABI doc-comments the UTF-8 contract. Acceptable at a host-trusted seam; a checked/lossy decode
  would only matter if a future host produced non-UTF-8 ids, which the contract forbids. Suggested
  next step: none; leave as-is (host is the trusted producer).
- **should-fix** — `sdk/streamlib-plugin-sdk/src/context.rs:1936` — `vtable_copy_runtime_id`
  (L1936) and `vtable_copy_processor_id` (L1970) duplicate the whole grow-and-retry byte-copy →
  owned UTF-8 String protocol: identical 64-byte scratch, identical first-call/`required <=
  scratch.len()` fast path, identical `vec![0u8; required]` grow + recall + `truncate` +
  `from_utf8_unchecked` slow path. The only real difference in the processor variant is the
  `required < 0 → None` sentinel and the `Some(..)` wrap. Evidence: L1942-1959 vs L1974-1994 are
  line-for-line the same except the isize sentinel check and Option wrapping. A change to scratch
  size, a bug fix in the retry, or a switch away from `from_utf8_unchecked` must be made in both
  places. Suggested next step: extract one `unsafe fn vtable_copy_utf8(handle, call: impl FnMut(*mut
  u8, usize, *mut usize) -> usize) -> String` holding the scratch/grow/truncate/decode logic;
  `vtable_copy_runtime_id` calls it directly; `vtable_copy_processor_id` does its `required < 0 →
  None` check first, then delegates the non-negative case and wraps in `Some`.
- **should-fix** — `sdk/streamlib-plugin-sdk/src/context.rs:1949` — `scratch[..written]` (L1949,
  and again at L1985) slices a fixed 64-byte stack array by `written`, an out-param the host
  callback fills. On the fast path (`required <= scratch.len()`) there is no bound on `written`: a
  contract-violating/skewed host that sets `written > 64` while returning a small `required`
  triggers an out-of-bounds slice panic in library code — the exact "array indexing that can panic
  in library code" the bar prohibits. Evidence: L1947 gates on `required`, not `written`; L1949
  then indexes `scratch[..written]`. The retry path is safe (`buf.truncate(written2)` cannot
  panic), so only the fast path is exposed. This is the untrusted-plugin-ABI boundary that
  layout-version checks otherwise guard. Suggested next step: bound the length:
  `scratch[..written.min(scratch.len())]` (or `scratch.get(..written).unwrap_or(&scratch[..])`) in
  both `vtable_copy_runtime_id` and `vtable_copy_processor_id`. Converts a host-driven panic into
  correct truncation at negligible cost.
- **low** — `sdk/streamlib-plugin-sdk/src/context.rs:1949` — `String::from_utf8_unchecked` on
  host-provided bytes (L1949/L1958/L1985/L1994) trusts the host for UTF-8 validity — a soundness
  (UB) risk on a misbehaving host, and inconsistent with the sibling ABI helper
  `grow_and_retry_read`, which uses `String::from_utf8_lossy` for host-provided bytes. Evidence:
  runtime/streamlib-plugin-abi/src/vtables/input_mailboxes.rs:181 uses `from_utf8_lossy`; here the
  id path uses `from_utf8_unchecked`. Note: `from_utf8_unchecked` is also the prevailing pattern
  elsewhere in this SDK (layout_skew_diagnostic.rs, rhi/texture_ring.rs), so this is a consistency
  observation, not a clear defect. These accessors are not per-frame hot, so a checked/lossy decode
  would cost effectively nothing. Suggested next step: consider `from_utf8_lossy(..).into_owned()`
  to match `grow_and_retry_read` and remove a UB vector, or leave as-is if the
  ABI-contract-trusts-host convention is deliberate — owner's call on which pattern is canonical
  for id reads.
- **info** — `sdk/streamlib-plugin-sdk/src/context.rs:2042` — The four new accessors
  (`runtime_id`/`processor_id`/`is_paused`/`should_process`) are declared with byte-identical
  bodies on both `RuntimeContextFullAccess` (L2042+) and `RuntimeContextLimitedAccess` (L2130+);
  `is_paused`/`should_process` are inline `unsafe { ((*self.vtable).is_paused)(self.handle) }`
  copied verbatim across the two views. Evidence: L2059-2071 vs L2147-2159. This mirrors the file's
  existing shape (audio_clock and the gpu accessors are already duplicated across the two
  capability views), so it is consistent, not a regression. A trait or shared free fns (as already
  done for the id copies) could unify, but that would reshape the public view surface. Suggested
  next step: no action required; noting for symmetry. If you extract the id-copy helper (finding
  1), consider matching free fns for the two bool slots so all four accessors delegate uniformly.

The two **should-fix** items (unbounded `scratch[..written]` slice on the fast path; duplicated
grow-and-retry protocol between the runtime_id/processor_id helpers) are real and worth a
follow-up pass, but neither is a live bug today — the host is a trusted producer that always
returns `written <= required <= cap` on the fast path, and the duplication is between two
functions in one file. Flagging here rather than blocking, per the lens's own framing.
