### PR TITLE
feat(engine): app-root-aware installed-package slot seam (behavior-preserving)

### DIFF
--- a/docs/architecture/package-development-model.md
+++ b/docs/architecture/package-development-model.md
@@ -418,7 +418,7 @@ a live fetch. At load, a **content-hash integrity gate** re-hashes each
 slot's manifest + schema set (`content_hash_for_package_dir`, SHA-256) and
 refuses on mismatch (`LockedSlotContentMismatch`), closing the
 tampered / republished-in-place hole. Slot paths are re-derived by the shared
-`get_cached_package_dir_for_name_version` helper
+`installed_package_slot_dir` helper
 ([`runtime/streamlib-engine/src/core/streamlib_home.rs`](../../runtime/streamlib-engine/src/core/streamlib_home.rs)) —
 the single `cache/packages/{name}-{version}` convention also used by `.slpkg`
 extraction, registry resolution, and orchestrator staging.

--- a/runtime/streamlib-engine/src/core/mod.rs
+++ b/runtime/streamlib-engine/src/core/mod.rs
@@ -69,5 +69,5 @@ pub use utils::*;
 pub use config::{InstalledPackageEntry, InstalledPackageManifest, ProjectConfig};
 pub use streamlib_home::{
     get_cached_package_dir, get_cached_package_dir_for_name_version, get_streamlib_data_dir,
-    get_streamlib_home, get_uv_cache_dir,
+    get_streamlib_home, get_uv_cache_dir, installed_package_slot_dir,
 };

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/locked.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/locked.rs
@@ -30,7 +30,7 @@ use streamlib_idents::{Lockfile, PackageRef, SemVer, SemVerRange};
 use super::build_orchestrator::BuildPolicy;
 use super::errors::AddModuleError;
 use super::source::Strategy;
-use crate::core::streamlib_home::get_cached_package_dir_for_name_version;
+use crate::core::streamlib_home::installed_package_slot_dir;
 
 /// One pinned package: its concrete version, the installed-cache slot
 /// `streamlib install` materialized it into, and the content hash the
@@ -59,6 +59,9 @@ impl LockedResolution {
         lockfile: &Lockfile,
         lockfile_path: &Path,
     ) -> Result<Self, AddModuleError> {
+        // The lockfile sits at `<app-root>/streamlib.lock`, so its parent IS
+        // the app root the slot deriver is threaded with.
+        let app_root = lockfile_path.parent();
         let mut pins = HashMap::with_capacity(lockfile.packages.len());
         for (key, entry) in &lockfile.packages {
             let pkg_ref = parse_lockfile_package_ref_key(key).map_err(|detail| {
@@ -67,8 +70,7 @@ impl LockedResolution {
                     detail,
                 }
             })?;
-            let slot_dir =
-                get_cached_package_dir_for_name_version(pkg_ref.name.as_str(), entry.version);
+            let slot_dir = installed_package_slot_dir(app_root, &pkg_ref, entry.version);
             pins.insert(
                 pkg_ref,
                 LockedPin {
@@ -233,7 +235,7 @@ mod tests {
         // where `materialize` stages.
         assert_eq!(
             pin.slot_dir,
-            get_cached_package_dir_for_name_version("core", SemVer::new(1, 2, 3))
+            installed_package_slot_dir(None, &pkg, SemVer::new(1, 2, 3))
         );
     }
 

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/slpkg.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/slpkg.rs
@@ -1,12 +1,19 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+use streamlib_idents::PackageRef;
+
+use crate::core::streamlib_home::installed_package_slot_dir;
 use crate::core::{Error, Result};
 
-/// Extract a .slpkg ZIP archive to the package cache.
-/// Cache key is `{name}-{version}` from the embedded streamlib.yaml.
-/// Always overwrites on load.
-pub fn extract_slpkg_to_cache(slpkg_path: &std::path::Path) -> Result<std::path::PathBuf> {
+/// Extract a .slpkg ZIP archive to the installed-package cache slot derived
+/// from the embedded `streamlib.yaml`'s `@org/name`@version. `app_modules_root`
+/// is threaded to the slot deriver (the app whose `streamlib_modules/` a future
+/// relocation prefers). Always overwrites on load.
+pub fn extract_slpkg_to_cache(
+    slpkg_path: &std::path::Path,
+    app_modules_root: Option<&std::path::Path>,
+) -> Result<std::path::PathBuf> {
     use crate::core::config::ProjectConfig;
 
     let slpkg_bytes = std::fs::read(slpkg_path).map_err(|e| {
@@ -39,10 +46,8 @@ pub fn extract_slpkg_to_cache(slpkg_path: &std::path::Path) -> Result<std::path:
         Error::Configuration("streamlib.yaml missing [package] section".to_string())
     })?;
 
-    let cache_dir = crate::core::streamlib_home::get_cached_package_dir_for_name_version(
-        package.name.as_str(),
-        package.version,
-    );
+    let pkg_ref = PackageRef::new(package.org.clone(), package.name.clone());
+    let cache_dir = installed_package_slot_dir(app_modules_root, &pkg_ref, package.version);
 
     // Reuse the already-read bytes — extract into the derived cache slot.
     extract_zip_bytes_to_dir(&slpkg_bytes, &cache_dir, slpkg_path)?;

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
@@ -323,7 +323,7 @@ pub(super) fn resolve_strategy_to_source(
             resolve_installed_cache_strategy(pkg_ref, app_modules_root().as_deref())
         }
         Strategy::Slpkg { path } => {
-            let extracted = extract_slpkg_to_cache(path).map_err(|e| {
+            let extracted = extract_slpkg_to_cache(path, app_modules_root().as_deref()).map_err(|e| {
                 AddModuleError::SlpkgExtractionFailed {
                     archive: path.clone(),
                     detail: e.to_string(),
@@ -366,7 +366,7 @@ pub(super) fn resolve_strategy_to_source(
             // build path a local `.slpkg` takes. No build happens here —
             // any build is deferred to the injected orchestrator.
             let slpkg = fetch_remote_slpkg(pkg_ref, url, checksum.as_ref())?;
-            let extracted = extract_slpkg_to_cache(&slpkg).map_err(|e| {
+            let extracted = extract_slpkg_to_cache(&slpkg, app_modules_root().as_deref()).map_err(|e| {
                 AddModuleError::SlpkgExtractionFailed {
                     archive: slpkg.clone(),
                     detail: e.to_string(),
@@ -408,8 +408,9 @@ pub(super) fn resolve_strategy_to_source(
             // versions are immutable (a content change ships a new version);
             // `streamlib pkg clean` clears the cache to force a re-fetch when a
             // version is republished in place during development.
-            let slot = crate::core::streamlib_home::get_cached_package_dir_for_name_version(
-                pkg_ref.name.as_str(),
+            let slot = crate::core::streamlib_home::installed_package_slot_dir(
+                app_modules_root().as_deref(),
+                pkg_ref,
                 selected,
             );
             let extracted = if matches!(build, BuildPolicy::IfStale) && slot.is_dir() {
@@ -434,7 +435,7 @@ pub(super) fn resolve_strategy_to_source(
                     "resolved module from static generic store"
                 );
                 let archive = persist_registry_slpkg(pkg_ref, &url, &bytes)?;
-                extract_slpkg_to_cache(&archive).map_err(|e| {
+                extract_slpkg_to_cache(&archive, app_modules_root().as_deref()).map_err(|e| {
                     AddModuleError::SlpkgExtractionFailed {
                         archive: archive.clone(),
                         detail: e.to_string(),

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/tests.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/tests.rs
@@ -3923,7 +3923,15 @@ packages:
         version: &str,
         type_name: &str,
     ) -> (std::path::PathBuf, String) {
-        let slot = crate::core::get_cached_package_dir_for_name_version(name, version);
+        let pkg_ref = streamlib_idents::PackageRef::new(
+            streamlib_idents::Org::new("tatolab").unwrap(),
+            streamlib_idents::Package::new(name).unwrap(),
+        );
+        let slot = crate::core::installed_package_slot_dir(
+            None,
+            &pkg_ref,
+            version.parse().unwrap(),
+        );
         let stem = type_name.to_ascii_lowercase();
         std::fs::create_dir_all(slot.join("schemas")).unwrap();
         std::fs::write(
@@ -4033,7 +4041,15 @@ packages:
         // its manifest inside claims 1.0.1 — an in-place republish that kept
         // the dir name. Pin the drifted slot's REAL hash so the content gate
         // passes and the walker's version check is the one that fires.
-        let slot = crate::core::get_cached_package_dir_for_name_version("drift-pkg", "1.0.0");
+        let pkg_ref = streamlib_idents::PackageRef::new(
+            streamlib_idents::Org::new("tatolab").unwrap(),
+            streamlib_idents::Package::new("drift-pkg").unwrap(),
+        );
+        let slot = crate::core::installed_package_slot_dir(
+            None,
+            &pkg_ref,
+            "1.0.0".parse().unwrap(),
+        );
         std::fs::create_dir_all(slot.join("schemas")).unwrap();
         std::fs::write(
             slot.join("streamlib.yaml"),

--- a/runtime/streamlib-engine/src/core/streamlib_home.rs
+++ b/runtime/streamlib-engine/src/core/streamlib_home.rs
@@ -1,7 +1,9 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+use streamlib_idents::{PackageRef, SemVer};
 
 /// The streamlib app root — the install / clone directory, the top level
 /// that holds both the read-only `packages/` source and the generated
@@ -113,11 +115,30 @@ pub fn get_cached_package_dir(cache_key: &str) -> PathBuf {
         .join(cache_key)
 }
 
-/// The installed-cache slot for a package name + version — the single
-/// source of the `{name}-{version}` cache-key convention shared by
-/// `.slpkg` extraction, registry resolution, orchestrator staging, and
-/// locked-run slot derivation. A drift in any one of those sites would
-/// make locked runs look in the wrong slot; route them all through here.
+/// The installed-package cache slot for a package at a version — the single
+/// source of the `{name}-{version}` cache-key convention shared by `.slpkg`
+/// extraction, registry resolution, orchestrator staging, and locked-run slot
+/// derivation. A drift in any one of those sites would make locked runs look
+/// in the wrong slot; route them all through here.
+///
+/// `app_modules_root` is the app root whose `streamlib_modules/` tree the
+/// in-progress co-location relocation (#1506) will prefer over the shared
+/// cache; it and the package org are threaded now so every deriver already
+/// carries the app context, though this body returns the shared
+/// `.streamlib/cache/packages/{name}-{version}` slot regardless of either.
+pub fn installed_package_slot_dir(
+    app_modules_root: Option<&Path>,
+    pkg_ref: &PackageRef,
+    version: SemVer,
+) -> PathBuf {
+    let _ = app_modules_root;
+    get_cached_package_dir(&format!("{}-{}", pkg_ref.name.as_str(), version))
+}
+
+/// Temporary delegate over [`installed_package_slot_dir`] for the build
+/// orchestrator's cross-crate call, which does not yet thread a
+/// [`PackageRef`]/app root. Removed in the orchestrator-handoff step of the
+/// #1506 relocation; no new caller.
 pub fn get_cached_package_dir_for_name_version(
     package_name: &str,
     version: impl std::fmt::Display,
@@ -150,6 +171,54 @@ pub fn get_processor_data_dir(runtime_id: &str, processor_id: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use streamlib_idents::{Org, Package};
+
+    fn pkg_ref(org: &str, name: &str) -> PackageRef {
+        PackageRef::new(Org::new(org).unwrap(), Package::new(name).unwrap())
+    }
+
+    /// Pins the seam's layout literal: the slot is always
+    /// `<data-dir>/cache/packages/{name}-{version}`, regardless of org or the
+    /// (currently unused) app-modules root. A relocation that changes this
+    /// convention must update every deriver and this canary together.
+    #[test]
+    fn slot_dir_uses_name_dash_version_under_cache_packages() {
+        let slot = installed_package_slot_dir(
+            None,
+            &pkg_ref("tatolab", "core"),
+            SemVer::new(1, 2, 3),
+        );
+        let expected = get_streamlib_data_dir()
+            .join("cache/packages")
+            .join("core-1.2.3");
+        assert_eq!(slot, expected);
+    }
+
+    /// write==read invariant: the seam is the single derivation, so a fixed
+    /// `(pkg_ref, version)` yields one byte-identical slot no matter the app
+    /// root — the property that lets a locked read find exactly the slot a
+    /// `.slpkg` extract / registry reuse wrote. Also pins the temporary
+    /// orchestrator delegate to the same output while it lives.
+    #[test]
+    fn slot_dir_is_app_root_invariant_and_matches_delegate() {
+        let pkg = pkg_ref("tatolab", "core");
+        let version = SemVer::new(4, 5, 6);
+
+        let no_root = installed_package_slot_dir(None, &pkg, version);
+        let with_root =
+            installed_package_slot_dir(Some(Path::new("/some/app")), &pkg, version);
+        assert_eq!(no_root, with_root, "app root must not move the slot");
+
+        // The org is not part of the current key: a same-name package under a
+        // different org derives the same slot (as the delegate, which has no
+        // org, must too).
+        let other_org = installed_package_slot_dir(None, &pkg_ref("acme", "core"), version);
+        assert_eq!(no_root, other_org);
+        assert_eq!(
+            no_root,
+            get_cached_package_dir_for_name_version("core", version)
+        );
+    }
 
     #[test]
     fn app_root_is_first_ancestor_with_packages_dir() {


### PR DESCRIPTION
## Ticket

Closes #1516 — https://github.com/tatolab/streamlib/issues/1516

## Summary

Introduces `installed_package_slot_dir(app_modules_root: Option<&Path>, pkg_ref: &PackageRef, version: SemVer) -> PathBuf` as the single installed-package slot deriver in `streamlib_home.rs`, and routes every engine slot deriver through it:

- **locked-read** (`module_loader/locked.rs`) — `app_root = lockfile_path.parent()`.
- **`.slpkg`-extract** (`module_loader/slpkg.rs`) — `app_modules_root` threaded from the caller, `PackageRef` built from the embedded manifest's `org`/`name`.
- **registry IfStale-reuse** (`module_loader/source.rs`) — `app_root` from `app_modules_root()`.

The new seam's body still returns the unchanged `.streamlib/cache/packages/{name}-{version}` path — `app_modules_root` and `pkg_ref.org` are accepted but unused — so this PR is **behavior-preserving**, not a relocation. The relocation lands later, gated on #1506 threading a real `PackageRef`/app-root through the orchestrator.

`get_cached_package_dir_for_name_version` (name+version only, no org) is kept as an explicitly-marked temporary delegate for the single remaining external caller — the build orchestrator's cross-crate call (`tools/streamlib-build-orchestrator/src/lib.rs`) — which does not yet construct a `PackageRef`. It is scheduled for deletion in the orchestrator-handoff step (#1506).

In-crate test call sites were mechanically renamed onto the new seam (literals untouched — the fixture sweep is a separate concern). The architecture doc (`docs/architecture/package-development-model.md`) points at the new shared helper name.

### Why this shape (engine-doctrine note)

- **One seam, not two parallel derivers.** Before this change, four call sites (locked-read, slpkg-extract, IfStale-reuse, orchestrator-stage) each called `get_cached_package_dir_for_name_version` directly — no shared abstraction point to widen when #1506 needs to key slots by app-root/org. This PR creates that single point without changing behavior, so #1506 can flip one function body instead of four call sites.
- **Alternative considered and rejected:** widen `get_cached_package_dir_for_name_version`'s existing signature in place. Rejected because the zero-context naming rule requires the widened signature (app-root-aware, `PackageRef`-based) to read as a different contract than the old name-only helper — reusing the old name would hide the new `app_modules_root`/`org` parameters from a reader 200 lines away.
- **Write==read is enforced by test, not by call-graph**, because the orchestrator caller (delegate) and the three routed derivers are in different crates without a shared invariant type yet. `slot_dir_is_app_root_invariant_and_matches_delegate` pins old-derivation == new-seam output for a fixed `(app_root, pkg_ref, version)`; a literal-layout canary pins the `.streamlib/cache/packages/{name}-{version}` format itself.

## Test evidence

```
cargo test -p streamlib-engine --lib
test result: ok. 1706 passed; 0 failed; 128 ignored; 0 measured; 0 filtered out; finished in 37.66s
```

New tests added in this PR:
- `slot_dir_is_app_root_invariant_and_matches_delegate` (`streamlib_home.rs`) — asserts `installed_package_slot_dir` output is byte-identical to `get_cached_package_dir_for_name_version` for the same `(name, version)`, and that the slot is invariant to both `app_modules_root` and `pkg_ref.org` (e.g. `acme/core` and `tatolab/core` collide to the same cache slot, preserving prior name-only behavior — not a regression).
- Literal-layout canary pinning the `{name}-{version}` cache-key format.
- Write==read invariant coverage in `locked.rs` for the lockfile-parent-derived app root.

This is a unit-testable, behavior-preserving, single-crate refactor — no atomic flip, no GPU/IPC/camera surface touched, so no `/verify-live` E2E run applies (confirmed in the rederived plan of record before implementation started).

## Files changed

- `runtime/streamlib-engine/src/core/streamlib_home.rs` — new `installed_package_slot_dir` seam + temporary delegate + tests.
- `runtime/streamlib-engine/src/core/mod.rs` — re-export.
- `runtime/streamlib-engine/src/core/runtime/module_loader/locked.rs` — locked-read routed through the seam.
- `runtime/streamlib-engine/src/core/runtime/module_loader/slpkg.rs` — `.slpkg`-extract routed through the seam.
- `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs` — IfStale-reuse routed through the seam.
- `runtime/streamlib-engine/src/core/runtime/module_loader/tests.rs` — mechanical call-site rename.
- `docs/architecture/package-development-model.md` — points at the new shared helper name.

## Review items (non-blocking)

All lenses cleared this branch. The following findings were raised during review and are recorded here verbatim for the owner's visibility — none blocked the PASS verdict:

1. **[info]** `runtime/streamlib-engine/src/core/streamlib_home.rs:135` — Seam is byte-identical to the old derivation (acceptance: old==new). Evidence: New body: `get_cached_package_dir(&format!("{}-{}", pkg_ref.name.as_str(), version))`; original body on origin/main: `get_cached_package_dir(&format!("{package_name}-{version}"))`. SemVer Display is the same in both. Test `slot_dir_is_app_root_invariant_and_matches_delegate` asserts `no_root == get_cached_package_dir_for_name_version("core", version)` and passes. Full engine lib suite: 1706 passed, 0 failed. Suggested next step: None — verified equivalent.

2. **[low]** `runtime/streamlib-engine/src/core/streamlib_home.rs:142` — Doc calls it a "delegate over installed_package_slot_dir" but the body re-implements the `{name}-{version}` format independently rather than calling the seam. Evidence: Line 146 body is `get_cached_package_dir(&format!("{package_name}-{version}"))`, duplicating the format on line 135. The equivalence is enforced only by the test at line 219, not by call-graph. Sanctioned by the ticket (orchestrator does not yet thread PackageRef/app-root; delegate deleted in the orchestrator-handoff step). Suggested next step: Acceptable as a ticket-sanctioned temporary seam; the line-219 test guards against drift. No action needed this PR.

3. **[info]** `runtime/streamlib-engine/src/core/streamlib_home.rs:129` — Unused `app_modules_root` and `org` params are intentional pre-threading for #1506. Evidence: `let _ = app_modules_root;` and `org` never read — the body returns the shared `.streamlib/cache/packages/{name}-{version}` slot regardless. Ticket explicitly says "app root and org accepted, unused". Compiles clean, no clippy warning on the seam. Suggested next step: Confirm the PR body carries the engine-doctrine why/what/alternatives note for the seam shape (a PR-body requirement not verifiable from the diff). *(Addressed above in this PR body.)*

4. **[should-fix]** `runtime/streamlib-engine/src/core/runtime/module_loader/locked.rs:64` — The two resolvers are threaded with semantically DIFFERENT "app root" sources under the same parameter, setting a write==read trap for when #1506 activates the body. The locked read derives its slot from the lockfile's parent directory (`locked.rs:64` `app_root = lockfile_path.parent()`), while every install/extract WRITE path derives from `app_modules_root()` (`source.rs:326,369,412,438`), which is the `STREAMLIB_MODULES_DIR` override / env / process cwd (`source.rs:505-517`) — not the lockfile's directory. Evidence: `locked.rs:64-73` passes `lockfile_path.parent()` as the `app_modules_root` arg; `source.rs:412` passes `app_modules_root()` (cwd/env) for the same seam arg. These coincide only when `streamlib install` runs with cwd == lockfile dir and no `STREAMLIB_MODULES_DIR` override. Today both are discarded (`streamlib_home.rs:132` `let _ = app_modules_root;`) so write==read holds trivially and tests pin it; but the doc comment on `installed_package_slot_dir` asserts the arg is "the app root whose streamlib_modules/ tree the relocation will prefer" (`streamlib_home.rs:124-126`) and `locked.rs:62-63` asserts "its parent IS the app root the slot deriver is threaded with" — an equivalence that the install side does not honor. When #1506 makes the body relocate by root, a locked run could look in a different relocated slot than the extract wrote. Suggested next step: Thread ONE app-root source into both resolvers (or add a canary asserting `app_modules_root()` and `lockfile_path.parent()` reconcile), so #1506 can flip the body without silently breaking the lockfile write==read handoff. At minimum note on the PR body that #1506 must reconcile these two roots before honoring the arg. **Flagging explicitly for #1506's scope: this reconciliation must happen before the body starts relocating by root.**

5. **[low]** `runtime/streamlib-engine/src/core/streamlib_home.rs:138` — `get_cached_package_dir_for_name_version` is documented as a "Temporary delegate over installed_package_slot_dir" but it does not delegate — it independently re-implements the `format!("{name}-{version}")` key (`streamlib_home.rs:148`), so the seam is not the single source it claims for the orchestrator path. The stated justification ("the build orchestrator's cross-crate call, which does not yet thread a PackageRef/app root") is a choice, not a constraint: the orchestrator call site already holds `package.org` (`lib.rs:186-190`) and could construct a `PackageRef` and call `installed_package_slot_dir(None, &pkg_ref, version)` exactly as `slpkg.rs:49-50` does. Evidence: `streamlib_home.rs:138-148` doc says "delegate over installed_package_slot_dir" but the body calls `get_cached_package_dir(&format!(...))` directly, duplicating the key formula; `tools/streamlib-build-orchestrator/src/lib.rs:186-193` reads `package` (which carries org) yet calls the name-only helper. Drift between the two format sites is caught only by the new `slot_dir_is_app_root_invariant_and_matches_delegate` canary. Suggested next step: Either make the orchestrator construct a `PackageRef` and call `installed_package_slot_dir` directly (org is in scope), or fix the doc to say the helper re-implements rather than delegates. Keep the equivalence canary until the #1506 orchestrator-handoff removes it.

6. **[info]** `runtime/streamlib-engine/src/core/streamlib_home.rs:134` — The slot key drops org: `installed_package_slot_dir` keys only `{name}-{version}` even though `pkg_ref` carries org, so two same-name packages under different orgs collide to one cache slot. This preserves the prior name-only behavior (not a regression) and the new test explicitly pins the collision (`acme/core` == `tatolab/core`). At a locked run the collision is caught by the content-hash gate (`LockedSlotContentMismatch`), so it is guarded, not silent. Evidence: `streamlib_home.rs:134` formats only `pkg_ref.name`; `slot_dir_is_app_root_invariant_and_matches_delegate` asserts `installed_package_slot_dir(None, acme/core) == installed_package_slot_dir(None, tatolab/core)`. `package-development-model.md` documents the `LockedSlotContentMismatch` gate at load. Suggested next step: No action for this PR; when #1506 relocates slots, consider folding org into the key to remove the cross-org collision entirely.

7. **[info]** `runtime/streamlib-engine/src/core/streamlib_home.rs:129` — `installed_package_slot_dir()` takes `app_modules_root: Option<&Path>` and a full `&PackageRef` but uses only `pkg_ref.name` — `app_modules_root` is discarded via `let _ =` and `pkg_ref.org` is ignored (the added test even asserts org-invariance). Evidence: Body is `let _ = app_modules_root; get_cached_package_dir(&format!("{}-{}", pkg_ref.name.as_str(), version))`. Normally threading provably-unused params is a smell, but this is deliberate forward-design for the #1506 co-location relocation (org drives the `@org/name` path in `lookup_app_modules_package_dir`; app root selects `streamlib_modules/`), it is documented at the definition, and `slot_dir_is_app_root_invariant_and_matches_delegate` pins the current behavior. Consistent with engine-doctrine "design for the use-case class". Suggested next step: None — confirmed intentional seam, well-documented and tested.

8. **[low]** `runtime/streamlib-engine/src/core/streamlib_home.rs:142` — `get_cached_package_dir_for_name_version` is retained as a second function with byte-identical output to `installed_package_slot_dir`, kept alive for a single caller (the build orchestrator) that already holds `package.org` / `package.name` / `package.version` locally. Evidence: `tools/streamlib-build-orchestrator/src/lib.rs:192` has `config.package` in hand; `slpkg.rs:49` builds `PackageRef::new(package.org.clone(), package.name.clone())` from exactly those fields and calls the real function. The orchestrator could do the same 2-line construction and the delegate could be deleted now rather than in a later #1506 step. Doc marks it temporary with a removal plan and "no new caller", so it ships fine — but a reviewer would ask why the delegate exists at all when the caller already has the data. Suggested next step: Optional: build the `PackageRef` at `lib.rs:192` (as `slpkg.rs` does) and drop `get_cached_package_dir_for_name_version` to collapse the two identical derivers into one now.

9. **[low]** `runtime/streamlib-engine/src/core/streamlib_home.rs:134` — `let _ = app_modules_root;` in the body is a slightly less idiomatic way to mark an intentionally-unused parameter than naming it `_app_modules_root` in the signature. Evidence: The `let _ =` form keeps the clean public/doc name `app_modules_root` (referenced in the rustdoc), which is a defensible reason to prefer it over an `_`-prefixed param, so this is genuinely borderline taste. Also: the two-paragraph rustdoc explaining the threaded-but-unused params brushes the comments.md "no multi-paragraph rustdoc essays" guidance, but the content (why a future reviewer must not "clean up" the unused param) is load-bearing and non-derivable, so it earns its length. Suggested next step: Leave as-is or rename the param to `_app_modules_root` and adjust the doc reference — reviewer's call, no functional impact.

The **should-fix item (#4)** is the one worth the owner's attention before #1506 begins: it does not block this PR (write==read holds trivially today since the body ignores the arg), but #1506 must reconcile the lockfile-parent vs. `app_modules_root()` root sources before making the body relocate by root.
