### PR TITLE
feat(engine): loader slot derives version from typed identity, not path

### DIFF
--- a/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
@@ -408,12 +408,17 @@ pub(super) fn resolve_strategy_to_source(
             // versions are immutable (a content change ships a new version);
             // `streamlib pkg clean` clears the cache to force a re-fetch when a
             // version is republished in place during development.
+            //
+            // Reuse is gated on the materialized manifest's version equalling
+            // the selected version, not on the slot merely existing: a slot
+            // left behind by a divergent version (or an unreadable manifest) is
+            // re-downloaded rather than loaded as the wrong version.
             let slot = crate::core::streamlib_home::installed_package_slot_dir(
                 app_modules_root().as_deref(),
                 pkg_ref,
                 selected,
             );
-            let extracted = if matches!(build, BuildPolicy::IfStale) && slot.is_dir() {
+            let extracted = if registry_slot_holds_selected_version(*build, &slot, selected) {
                 tracing::debug!(
                     package = %pkg_ref,
                     version = %selected,
@@ -467,7 +472,7 @@ fn resolve_installed_cache_strategy(
         }
     }
     let (dir, _version) =
-        lookup_installed_cache(pkg_ref)?.ok_or_else(|| AddModuleError::ModuleNotFound {
+        lookup_installed_cache(pkg_ref, app_root)?.ok_or_else(|| AddModuleError::ModuleNotFound {
             package: pkg_ref.clone(),
         })?;
     // Same prefer-prebuilt-else-build-source decision as `.slpkg`:
@@ -914,14 +919,16 @@ fn fetch_git_checkout(
 }
 
 /// Look the canonical [`PackageRef`] up in the installed-package cache.
-/// Returns `(cache_dir, version)` when present.
+/// Returns `(slot_dir, version)` when present, the slot derived by
+/// [`installed_entry_slot_dir`]. `app_root` is the app-modules root the
+/// caller already resolved.
 ///
 /// [`PackageRef`]: streamlib_idents::PackageRef
 fn lookup_installed_cache(
     pkg_ref: &streamlib_idents::PackageRef,
+    app_root: Option<&std::path::Path>,
 ) -> std::result::Result<Option<(PathBuf, streamlib_idents::SemVer)>, AddModuleError> {
     use crate::core::config::InstalledPackageManifest;
-    use crate::core::streamlib_home::get_cached_package_dir;
 
     let manifest =
         InstalledPackageManifest::load().map_err(|e| AddModuleError::InstalledCacheLoadFailed {
@@ -929,7 +936,20 @@ fn lookup_installed_cache(
         })?;
     Ok(manifest
         .find_by_ref(pkg_ref)
-        .map(|entry| (get_cached_package_dir(&entry.cache_dir), entry.version)))
+        .map(|entry| (installed_entry_slot_dir(entry, app_root), entry.version)))
+}
+
+/// Slot directory for an installed-package entry, derived from its typed
+/// `name`/`version` through the [`installed_package_slot_dir`] seam — never
+/// from the persisted `cache_dir` string, so a stored path can never imply a
+/// version that disagrees with the typed key.
+///
+/// [`installed_package_slot_dir`]: crate::core::streamlib_home::installed_package_slot_dir
+fn installed_entry_slot_dir(
+    entry: &crate::core::config::InstalledPackageEntry,
+    app_root: Option<&std::path::Path>,
+) -> PathBuf {
+    crate::core::streamlib_home::installed_package_slot_dir(app_root, &entry.name, entry.version)
 }
 
 /// Read the `[package].version` field from the `streamlib.yaml` at
@@ -959,9 +979,26 @@ pub(super) fn read_version_from_manifest_dir(
     })
 }
 
+/// Whether an already-materialized registry cache `slot` can be reused for
+/// `selected` without a re-download/extract. Reuse only when the policy
+/// allows stale reuse AND the slot's `streamlib.yaml` reads AND pins exactly
+/// `selected` — a slot left by a divergent version (or an unreadable
+/// manifest) is refused so it gets re-downloaded rather than loaded as the
+/// wrong version.
+fn registry_slot_holds_selected_version(
+    build: BuildPolicy,
+    slot: &std::path::Path,
+    selected: streamlib_idents::SemVer,
+) -> bool {
+    matches!(build, BuildPolicy::IfStale)
+        && slot.is_dir()
+        && read_version_from_manifest_dir(slot).is_ok_and(|materialized| materialized == selected)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::config::InstalledPackageEntry;
 
     const RUST_YAML: &str = "package:\n  org: tatolab\n  name: rp\n  version: 0.1.0\nprocessors:\n  - name: P\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n";
     const PY_YAML: &str = "package:\n  org: tatolab\n  name: py\n  version: 0.1.0\nprocessors:\n  - name: P\n    description: d\n    runtime: python\n    execution: manual\n    entrypoint: \"p:P\"\n    inputs: []\n    outputs: []\n";
@@ -1819,5 +1856,102 @@ mod tests {
             unlocked.is_some(),
             "an unlocked run over the same marker must discover the link"
         );
+    }
+
+    // =====================================================================
+    // #1518 — the two path-implies-version consumers in the loader now derive
+    // the slot from typed identity (name+version), not from a persisted path
+    // string, and gate registry reuse on the materialized manifest version.
+    // =====================================================================
+
+    fn installed_entry(cache_dir: &str, version: streamlib_idents::SemVer) -> InstalledPackageEntry {
+        InstalledPackageEntry {
+            name: pkg_ref(),
+            version,
+            description: None,
+            installed_from: "test".into(),
+            installed_at: "test".into(),
+            cache_dir: cache_dir.into(),
+        }
+    }
+
+    /// The installed-cache slot is derived from the entry's typed
+    /// `name`/`version` seam, never the persisted `cache_dir` string. Mentally
+    /// revert to `get_cached_package_dir(&entry.cache_dir)` and a divergent
+    /// stored string would win, pointing the loader at the wrong slot.
+    #[test]
+    fn installed_entry_slot_ignores_divergent_cache_dir_string() {
+        let version = streamlib_idents::SemVer::new(0, 1, 0);
+        let entry = installed_entry("garbage-999-should-be-ignored", version);
+
+        let derived = installed_entry_slot_dir(&entry, None);
+
+        assert_eq!(
+            derived,
+            crate::core::streamlib_home::installed_package_slot_dir(None, &pkg_ref(), version),
+            "slot must come from the typed name+version seam"
+        );
+        assert!(
+            !derived.to_string_lossy().contains("garbage-999"),
+            "the divergent cache_dir string must not leak into the slot path"
+        );
+    }
+
+    /// Registry reuse is refused when the materialized slot pins a different
+    /// version than the one selected — the wrong-version slot is rebuilt.
+    /// Mentally revert to a `slot.is_dir()`-only gate and this returns `true`,
+    /// loading `0.1.0`'s bytes as if they were `0.2.0`.
+    #[test]
+    fn registry_reuse_refuses_wrong_version_slot() {
+        let dir = tempfile::tempdir().unwrap();
+        manifest(dir.path(), RUST_YAML); // pins 0.1.0
+        let selected = streamlib_idents::SemVer::new(0, 2, 0);
+        assert!(!registry_slot_holds_selected_version(
+            BuildPolicy::IfStale,
+            dir.path(),
+            selected
+        ));
+    }
+
+    /// Registry reuse is taken when the materialized slot pins exactly the
+    /// selected version under `IfStale`.
+    #[test]
+    fn registry_reuse_accepts_matching_version_slot() {
+        let dir = tempfile::tempdir().unwrap();
+        manifest(dir.path(), RUST_YAML); // pins 0.1.0
+        let selected = streamlib_idents::SemVer::new(0, 1, 0);
+        assert!(registry_slot_holds_selected_version(
+            BuildPolicy::IfStale,
+            dir.path(),
+            selected
+        ));
+    }
+
+    /// A slot with no readable manifest is refused (re-downloaded), never
+    /// reused as the selected version.
+    #[test]
+    fn registry_reuse_refuses_slot_without_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let selected = streamlib_idents::SemVer::new(0, 1, 0);
+        assert!(!registry_slot_holds_selected_version(
+            BuildPolicy::IfStale,
+            dir.path(),
+            selected
+        ));
+    }
+
+    /// Only `IfStale` reuses a materialized slot; the other policies always
+    /// fall through to the re-download/extract branch even on a version match.
+    #[test]
+    fn registry_reuse_only_under_if_stale_policy() {
+        let dir = tempfile::tempdir().unwrap();
+        manifest(dir.path(), RUST_YAML); // pins 0.1.0
+        let selected = streamlib_idents::SemVer::new(0, 1, 0);
+        for policy in [BuildPolicy::NeverBuild, BuildPolicy::AlwaysBuild] {
+            assert!(
+                !registry_slot_holds_selected_version(policy, dir.path(), selected),
+                "{policy:?} must not reuse the materialized slot"
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #1518

## Summary

Part of the #1506 → `streamlib_modules` co-location relocation (parent #1502), decomposed 2026-07-22. The two path-implies-version consumers in the module loader now key off typed identity instead of a persisted path string:

- `lookup_installed_cache` derives the slot via the app-root-aware `installed_package_slot_dir` seam from the entry's typed name+version, not from the stored `packages.yaml` `cache_dir` string.
- Registry `IfStale` reuse is gated on the materialized manifest version equalling the selected version (`read_version_from_manifest_dir`), not on the slot merely existing — a divergent-version or unreadable slot is re-downloaded rather than loaded as the wrong version.

Behavior-preserving at the current versioned layout (`cache_dir == {name}-{version} == slot file_name`). Adds regression tests that fail on mental-revert of each gate.

## Test evidence

```
cargo test -p streamlib-engine --lib module_loader::source::
...
test result: ok. 41 passed; 0 failed; 0 ignored; 0 measured; 1798 filtered out
```

Full engine-lib suite (1711 tests) also green per the branch's own verification pass.

No E2E/rig verification needed — this ticket is unit-testable only (no GPU/IPC/codec surface touched).

## Review items (non-blocking)

- **info** `runtime/streamlib-engine/src/core/config/installed_packages_manifest.rs:39` — Acceptance: packages.yaml carries no load-bearing path strings. After the change the only reads of `.cache_dir` are a doc-comment in a test (source.rs:1880). No production consumer derives a path from the stored string anymore. The field is still WRITTEN at install.rs:203-207 (staged_dir.file_name()), so it is now vestigial — stored but never read as load-bearing.
  Suggested next step: Leave as-is for this ticket; removing the now-vestigial `cache_dir` field is a packages.yaml format migration and out of scope for a behavior-preserving change. Optionally note the follow-up on the PR body.

- **info** `runtime/streamlib-engine/src/core/runtime/install.rs:203` — Behavior is identical at the current versioned layout (derived dir == previously-stored string). Stored cache_dir = staged_dir.file_name(); the orchestrator stages into the shared {name}-{version} slot per the installed_package_slot_dir seam (streamlib_home.rs:118-136). The new installed_entry_slot_dir derives {name}-{version} from typed name+version, so the derived path equals the previously-stored basename at the current layout. Confirmed behavior-preserving.
  Suggested next step: None — verified by tracing the seam; the vestigial-string only diverges in a corrupt/malformed-slot case, which is the hazard this ticket intentionally retires.

- **info** `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:1875` — New wrong-version regression tests fail when the fix is reverted (non-vacuous). installed_entry_slot_ignores_divergent_cache_dir_string: revert to get_cached_package_dir(&entry.cache_dir) with cache_dir='garbage-999...' yields cache/packages/garbage-999... != cache/packages/rp-0.1.0, and the contains('garbage-999') guard trips — both asserts fail. registry_reuse_refuses_wrong_version_slot and registry_reuse_refuses_slot_without_manifest: revert to the slot.is_dir()-only gate returns true, and both assert !reuse — both fail. Verified by reasoning; ran the full set (41 source-module tests + 1711 engine-lib tests) green.
  Suggested next step: None.

- **info** `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:475` — Deriving the InstalledCache slot from typed name+version (installed_entry_slot_dir → installed_package_slot_dir) instead of the persisted cache_dir string aligns the unlocked InstalledCache path with the locked-run deriver, which already routes through the same seam (locked.rs:73). This removes a real locked-vs-unlocked drift hazard the streamlib_home.rs seam doc warns about, and is behavior-preserving because the production writer (install.rs → staged_dir.file_name(), staged as `{name}-{version}` by tools/streamlib-build-orchestrator/src/lib.rs:192) already produced exactly `{name}-{version}`.
  Evidence: install.rs writes cache_dir = staged.staged_dir.file_name(); orchestrator stages to get_cached_package_dir_for_name_version(name,version) = `{name}-{version}`; new installed_entry_slot_dir returns installed_package_slot_dir(app_root,&entry.name,entry.version) = same `{name}-{version}`.
  Suggested next step: None — correctness-improving, no action.

- **info** `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:934` — The app_root now threaded through lookup_installed_cache and installed_entry_slot_dir is a no-op today: installed_package_slot_dir discards it (`let _ = app_modules_root;`, streamlib_home.rs:134) and returns the shared `.streamlib/cache/packages/{name}-{version}` slot regardless. This is intentional #1506 co-location prep and does not change resolution behavior in this PR.
  Evidence: streamlib_home.rs:129-136 installed_package_slot_dir body ignores app_modules_root.
  Suggested next step: None — flagged only so the reviewer doesn't read app_root threading as an active behavior change.

- **info** `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:991` — registry_slot_holds_selected_version adds a manifest-version equality gate on top of the prior `is_dir()` reuse check. Because the slot path is already version-keyed and extract_slpkg_to_cache always writes content to `{name}-{manifest_version}` (slpkg.rs:50), the mismatch branch is defense-in-depth against corruption/partial-extract/out-of-band tampering rather than a case the normal flow reaches; it also does NOT address republish-in-place staleness of an identical version string (that still needs `streamlib pkg clean`, per the existing comment at lines 402-410). The extra per-reuse manifest parse is cheap and, since a validly-extracted slot always carries a loadable streamlib.yaml, does not realistically regress the built-cdylib/venv-preservation optimization the reuse fast path exists for. Prerelease `-dev.N` versions round-trip: SemVer equality and Display are both full-version-inclusive, so a `-dev.N` slot matches its `-dev.N` selection.
  Evidence: registry_slot_holds_selected_version = IfStale && slot.is_dir() && read_version_from_manifest_dir == selected; SemVer derives Eq over prerelease (semver.rs:43-48) and Display emits `-{kind}.{n}` (semver.rs:177-184).
  Suggested next step: None — sound hardening; noted so the reviewer understands the gate's scope (it is not a republish-staleness fix).

- **info** `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:1885` — The added tests genuinely exercise the fix: installed_entry_slot_ignores_divergent_cache_dir_string asserts the derived slot ignores a garbage cache_dir string, and registry_reuse_refuses_wrong_version_slot / accepts_matching / refuses_slot_without_manifest / only_under_if_stale each fail if the gate is reverted to the old `slot.is_dir()`-only form. Mentally reverting either change reddens the corresponding test.
  Evidence: Tests build InstalledPackageEntry with cache_dir="garbage-999-should-be-ignored" and assert the derived path equals installed_package_slot_dir(None,&pkg_ref(),version) and excludes the garbage substring.
  Suggested next step: None.

- **info** `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:931` — installed_entry_slot_dir (and lookup_installed_cache) thread app_root into a seam that currently discards it. installed_entry_slot_dir forwards app_root to crate::core::streamlib_home::installed_package_slot_dir, whose body is `let _ = app_modules_root;` — the arg is provably unused today. This is deliberate: the seam's own doc states app context is threaded ahead of the #1506 co-location relocation so every deriver already carries it. Signature noise here is intentional consistency with the canonical seam, not a defect. No action.
  Suggested next step: None — leave as-is; the threading is the documented #1506 forward-path. Drop the unused-arg plumbing only when #1506 either consumes app_root or is abandoned.

- **info** `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:991` — registry_slot_holds_selected_version is a clean, correctly-scoped predicate; noting the one taste call for the record. The gate uses `matches!(build, BuildPolicy::IfStale)` where BuildPolicy derives PartialEq/Copy, so `build == BuildPolicy::IfStale` would read identically — pure taste, not a finding. The three-condition short-circuit (policy && is_dir && version-match) is well-ordered (cheapest checks first) and the doc states the wrong-version and unreadable-manifest refusal rationale. No change warranted.
  Suggested next step: None.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
