### PR TITLE
feat(engine): BuildRequest carries the engine-computed staging destination

### DIFF
--- a/runtime/streamlib-engine/src/core/mod.rs
+++ b/runtime/streamlib-engine/src/core/mod.rs
@@ -68,6 +68,6 @@ pub use utils::*;
 // CLI tooling (`streamlib-cli`):
 pub use config::{InstalledPackageEntry, InstalledPackageManifest, ProjectConfig};
 pub use streamlib_home::{
-    get_cached_package_dir, get_cached_package_dir_for_name_version, get_streamlib_data_dir,
-    get_streamlib_home, get_uv_cache_dir, installed_package_slot_dir,
+    get_cached_package_dir, get_streamlib_data_dir, get_streamlib_home, get_uv_cache_dir,
+    installed_package_slot_dir,
 };

--- a/runtime/streamlib-engine/src/core/runtime/install.rs
+++ b/runtime/streamlib-engine/src/core/runtime/install.rs
@@ -175,21 +175,13 @@ pub fn install(
         .unwrap_or_else(|| root_dir.to_path_buf());
 
     for pkg in resolved.iter_all() {
-        let Some(pkg_ref) = package_ref_of(pkg) else {
+        let Some((pkg_ref, version)) = package_ref_of(pkg) else {
             // Root project with no `[package]` — nothing to materialize.
             continue;
         };
         // A package-flavor root IS materializable (installing a library),
         // but the resolver's `Root` source carries the root dir directly.
         tracing::info!(package = %pkg_ref, "install: materializing");
-        // `package_ref_of` returned `Some`, so the `[package]` block — and its
-        // version — is present.
-        let version = pkg
-            .manifest
-            .package
-            .as_ref()
-            .expect("package_ref_of is Some, so [package] is present")
-            .version;
         let request = BuildRequest {
             package: pkg_ref.clone(),
             source: BuildSource::PackageDir(pkg.root_dir.clone()),
@@ -262,9 +254,7 @@ pub fn install(
     let mut packages: Vec<(PackageRef, SemVer)> = resolved
         .packages
         .values()
-        .filter_map(|p| {
-            package_ref_of(p).map(|r| (r, p.manifest.package.as_ref().unwrap().version))
-        })
+        .filter_map(package_ref_of)
         .collect();
     packages.sort_by(|a, b| a.0.to_string().cmp(&b.0.to_string()));
 
@@ -279,13 +269,13 @@ pub fn install(
     })
 }
 
-/// The canonical [`PackageRef`] of a resolved package, or `None` for a
-/// project-flavor manifest (no `[package]` block).
-fn package_ref_of(pkg: &ResolvedPackage) -> Option<PackageRef> {
+/// The canonical [`PackageRef`] and version of a resolved package, or `None`
+/// for a project-flavor manifest (no `[package]` block).
+fn package_ref_of(pkg: &ResolvedPackage) -> Option<(PackageRef, SemVer)> {
     pkg.manifest
         .package
         .as_ref()
-        .map(|m| PackageRef::new(m.org.clone(), m.name.clone()))
+        .map(|m| (PackageRef::new(m.org.clone(), m.name.clone()), m.version))
 }
 
 /// Current UTC time as an RFC-3339 timestamp, dependency-free (the engine

--- a/runtime/streamlib-engine/src/core/runtime/install.rs
+++ b/runtime/streamlib-engine/src/core/runtime/install.rs
@@ -164,6 +164,16 @@ pub fn install(
     let mut staged_hashes: std::collections::BTreeMap<String, String> =
         std::collections::BTreeMap::new();
 
+    // The app root whose `streamlib_modules/` slot seam the install writes into:
+    // the lockfile's parent dir (default `<root_dir>/streamlib-app.lock`), or
+    // `root_dir` itself when no explicit lockfile path is configured.
+    let app_root: PathBuf = options
+        .lockfile_path
+        .as_deref()
+        .and_then(|p| p.parent())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| root_dir.to_path_buf());
+
     for pkg in resolved.iter_all() {
         let Some(pkg_ref) = package_ref_of(pkg) else {
             // Root project with no `[package]` — nothing to materialize.
@@ -172,12 +182,25 @@ pub fn install(
         // A package-flavor root IS materializable (installing a library),
         // but the resolver's `Root` source carries the root dir directly.
         tracing::info!(package = %pkg_ref, "install: materializing");
+        // `package_ref_of` returned `Some`, so the `[package]` block — and its
+        // version — is present.
+        let version = pkg
+            .manifest
+            .package
+            .as_ref()
+            .expect("package_ref_of is Some, so [package] is present")
+            .version;
         let request = BuildRequest {
             package: pkg_ref.clone(),
             source: BuildSource::PackageDir(pkg.root_dir.clone()),
             source_provenance: provenance_of(&pkg.source),
             policy,
             host_triple: host_target_triple().to_string(),
+            staging_destination_slot_dir: crate::core::installed_package_slot_dir(
+                Some(app_root.as_path()),
+                &pkg_ref,
+                version,
+            ),
         };
         let staged = orchestrator.materialize(&request, sink).map_err(|source| {
             InstallError::Materialize {

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/build_orchestrator.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/build_orchestrator.rs
@@ -120,6 +120,15 @@ pub struct BuildRequest {
     /// Host target triple the staged cdylib must target
     /// (e.g. `x86_64-unknown-linux-gnu`).
     pub host_triple: String,
+    /// The exact directory the orchestrator must stage this package into —
+    /// computed by the engine via the installed-package slot seam
+    /// ([`installed_package_slot_dir`]) at request-build time, so the
+    /// orchestrator holds NO slot-path convention of its own. This is the
+    /// write side of the write==read invariant: a locked run derives its
+    /// read slot from the same seam, so the two agree byte-for-byte.
+    ///
+    /// [`installed_package_slot_dir`]: crate::core::installed_package_slot_dir
+    pub staging_destination_slot_dir: PathBuf,
 }
 
 /// A successful [`BuildOrchestrator::materialize`] result. Constructed by

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
@@ -310,12 +310,12 @@ pub(super) fn resolve_strategy_to_source(
                 source = %pkg_dir.display(),
                 "streamlib link active — resolving module from linked checkout (overriding strategy)"
             );
-            return Ok(source_for_dir(
+            return source_for_dir(
                 pkg_ref,
                 pkg_dir,
                 BuildPolicy::IfStale,
                 PackageSourceProvenance::MutableUserCheckout,
-            ));
+            );
         }
     }
     match strategy {
@@ -332,27 +332,27 @@ pub(super) fn resolve_strategy_to_source(
             // A `.slpkg` may carry source and/or a prebuilt cdylib. Prefer
             // a prebuilt matching this host; otherwise build the bundled
             // source on the host (pip wheel-vs-sdist for Rust).
-            Ok(source_for_resolved_dir(pkg_ref, extracted))
+            source_for_resolved_dir(pkg_ref, extracted)
         }
         Strategy::Path { path, build } => {
             if !path.join("streamlib.yaml").exists() {
                 return Err(AddModuleError::ManifestDirectoryMissing { path: path.clone() });
             }
-            Ok(source_for_dir(
+            source_for_dir(
                 pkg_ref,
                 path.clone(),
                 *build,
                 PackageSourceProvenance::MutableUserCheckout,
-            ))
+            )
         }
         Strategy::Git { url, rev, build } => {
             let checkout = fetch_git_checkout(pkg_ref, url, rev)?;
-            Ok(source_for_dir(
+            source_for_dir(
                 pkg_ref,
                 checkout,
                 *build,
                 PackageSourceProvenance::ImmutableManagedExtract,
-            ))
+            )
         }
         Strategy::Url {
             url,
@@ -372,7 +372,7 @@ pub(super) fn resolve_strategy_to_source(
                     detail: e.to_string(),
                 }
             })?;
-            Ok(source_for_fetched_slpkg(pkg_ref, extracted, *build))
+            source_for_fetched_slpkg(pkg_ref, extracted, *build)
         }
         Strategy::Registry { version_req, build } => {
             // Same resolve shape as `Strategy::Url`, except the download URL
@@ -447,7 +447,7 @@ pub(super) fn resolve_strategy_to_source(
                     }
                 })?
             };
-            Ok(source_for_fetched_slpkg(pkg_ref, extracted, *build))
+            source_for_fetched_slpkg(pkg_ref, extracted, *build)
         }
     }
 }
@@ -468,7 +468,7 @@ fn resolve_installed_cache_strategy(
                 source = %modules_package_dir.display(),
                 "resolving module from the app's streamlib_modules folder"
             );
-            return Ok(source_for_resolved_dir(pkg_ref, modules_package_dir));
+            return source_for_resolved_dir(pkg_ref, modules_package_dir);
         }
     }
     let (dir, _version) =
@@ -477,7 +477,7 @@ fn resolve_installed_cache_strategy(
         })?;
     // Same prefer-prebuilt-else-build-source decision as `.slpkg`:
     // a cached package may carry source needing a host build.
-    Ok(source_for_resolved_dir(pkg_ref, dir))
+    source_for_resolved_dir(pkg_ref, dir)
 }
 
 /// Environment override for the directory that contains the app's
@@ -559,18 +559,36 @@ fn source_for_dir(
     dir: PathBuf,
     build: BuildPolicy,
     provenance: PackageSourceProvenance,
-) -> ResolvedSource {
+) -> std::result::Result<ResolvedSource, AddModuleError> {
     if build.requires_orchestrator() {
-        ResolvedSource::NeedsBuild(BuildRequest {
+        let staging_destination_slot_dir = staging_slot_for_dir(pkg_ref, &dir)?;
+        Ok(ResolvedSource::NeedsBuild(BuildRequest {
             package: pkg_ref.clone(),
             source: BuildSource::PackageDir(dir),
             source_provenance: provenance,
             policy: build,
             host_triple: host_target_triple().to_string(),
-        })
+            staging_destination_slot_dir,
+        }))
     } else {
-        ResolvedSource::Ready(dir)
+        Ok(ResolvedSource::Ready(dir))
     }
+}
+
+/// The installed-package slot the orchestrator must stage `dir` into, derived
+/// through the shared seam from the package's on-disk manifest version and the
+/// active app-modules root — the write side of the write==read invariant a
+/// locked run reads back through the same seam.
+fn staging_slot_for_dir(
+    pkg_ref: &streamlib_idents::PackageRef,
+    dir: &std::path::Path,
+) -> std::result::Result<PathBuf, AddModuleError> {
+    let version = read_version_from_manifest_dir(dir)?;
+    Ok(crate::core::streamlib_home::installed_package_slot_dir(
+        app_modules_root().as_deref(),
+        pkg_ref,
+        version,
+    ))
 }
 
 /// Decide how to load an already-resolved package directory (an extracted
@@ -585,9 +603,13 @@ fn source_for_dir(
 /// extracted `.slpkg` or installed-cache entry carries source but no venv,
 /// and `materialize` is the only place the venv is provisioned. Loading it
 /// as-is would leave its subprocess spawn with no interpreter.
-fn source_for_resolved_dir(pkg_ref: &streamlib_idents::PackageRef, dir: PathBuf) -> ResolvedSource {
+fn source_for_resolved_dir(
+    pkg_ref: &streamlib_idents::PackageRef,
+    dir: PathBuf,
+) -> std::result::Result<ResolvedSource, AddModuleError> {
     if needs_host_build(&dir) || needs_polyglot_provisioning(&dir) {
-        ResolvedSource::NeedsBuild(BuildRequest {
+        let staging_destination_slot_dir = staging_slot_for_dir(pkg_ref, &dir)?;
+        Ok(ResolvedSource::NeedsBuild(BuildRequest {
             package: pkg_ref.clone(),
             source: BuildSource::PackageDir(dir),
             source_provenance: PackageSourceProvenance::ImmutableManagedExtract,
@@ -598,9 +620,10 @@ fn source_for_resolved_dir(pkg_ref: &streamlib_idents::PackageRef, dir: PathBuf)
             // an already-provisioned cache slot, so there is no rebuild loop.
             policy: BuildPolicy::IfStale,
             host_triple: host_target_triple().to_string(),
-        })
+            staging_destination_slot_dir,
+        }))
     } else {
-        ResolvedSource::Ready(dir)
+        Ok(ResolvedSource::Ready(dir))
     }
 }
 
@@ -624,9 +647,9 @@ fn source_for_fetched_slpkg(
     pkg_ref: &streamlib_idents::PackageRef,
     dir: PathBuf,
     build: BuildPolicy,
-) -> ResolvedSource {
+) -> std::result::Result<ResolvedSource, AddModuleError> {
     match build {
-        BuildPolicy::NeverBuild => ResolvedSource::Ready(dir),
+        BuildPolicy::NeverBuild => Ok(ResolvedSource::Ready(dir)),
         BuildPolicy::IfStale => source_for_resolved_dir(pkg_ref, dir),
         BuildPolicy::AlwaysBuild => {
             // `has_buildable_rust_source` covers the "rebuild the Rust cdylib"
@@ -637,15 +660,17 @@ fn source_for_fetched_slpkg(
             // AlwaysBuild paths — `streamlib add` and `Strategy::Registry`
             // resolve with AlwaysBuild through here.
             if has_buildable_rust_source(&dir) || needs_polyglot_provisioning(&dir) {
-                ResolvedSource::NeedsBuild(BuildRequest {
+                let staging_destination_slot_dir = staging_slot_for_dir(pkg_ref, &dir)?;
+                Ok(ResolvedSource::NeedsBuild(BuildRequest {
                     package: pkg_ref.clone(),
                     source: BuildSource::PackageDir(dir),
                     source_provenance: PackageSourceProvenance::ImmutableManagedExtract,
                     policy: BuildPolicy::AlwaysBuild,
                     host_triple: host_target_triple().to_string(),
-                })
+                    staging_destination_slot_dir,
+                }))
             } else {
-                ResolvedSource::Ready(dir)
+                Ok(ResolvedSource::Ready(dir))
             }
         }
     }
@@ -1074,7 +1099,8 @@ mod tests {
             &pkg_ref(),
             dir.path().to_path_buf(),
             BuildPolicy::NeverBuild,
-        );
+        )
+        .unwrap();
         assert!(matches!(resolved, ResolvedSource::Ready(_)));
     }
 
@@ -1085,7 +1111,8 @@ mod tests {
         manifest(dir.path(), RUST_YAML);
         std::fs::write(dir.path().join("Cargo.toml"), b"[package]\nname='rp'\n").unwrap();
         let resolved =
-            source_for_fetched_slpkg(&pkg_ref(), dir.path().to_path_buf(), BuildPolicy::IfStale);
+            source_for_fetched_slpkg(&pkg_ref(), dir.path().to_path_buf(), BuildPolicy::IfStale)
+                .unwrap();
         assert!(matches!(resolved, ResolvedSource::NeedsBuild(_)));
     }
 
@@ -1099,7 +1126,8 @@ mod tests {
         std::fs::create_dir_all(&triple_dir).unwrap();
         std::fs::write(triple_dir.join("librp.so"), b"prebuilt").unwrap();
         let resolved =
-            source_for_fetched_slpkg(&pkg_ref(), dir.path().to_path_buf(), BuildPolicy::IfStale);
+            source_for_fetched_slpkg(&pkg_ref(), dir.path().to_path_buf(), BuildPolicy::IfStale)
+                .unwrap();
         assert!(matches!(resolved, ResolvedSource::Ready(_)));
     }
 
@@ -1119,7 +1147,8 @@ mod tests {
             &pkg_ref(),
             dir.path().to_path_buf(),
             BuildPolicy::AlwaysBuild,
-        );
+        )
+        .unwrap();
         match resolved {
             ResolvedSource::NeedsBuild(req) => assert_eq!(req.policy, BuildPolicy::AlwaysBuild),
             other => panic!("expected NeedsBuild(AlwaysBuild), got {other:?}"),
@@ -1136,7 +1165,8 @@ mod tests {
             &pkg_ref(),
             dir.path().to_path_buf(),
             BuildPolicy::AlwaysBuild,
-        );
+        )
+        .unwrap();
         assert!(matches!(resolved, ResolvedSource::Ready(_)));
     }
 
@@ -1160,7 +1190,8 @@ mod tests {
             &pkg_ref(),
             dir.path().to_path_buf(),
             BuildPolicy::AlwaysBuild,
-        );
+        )
+        .unwrap();
         match resolved {
             ResolvedSource::NeedsBuild(req) => assert_eq!(req.policy, BuildPolicy::AlwaysBuild),
             other => panic!("expected NeedsBuild(AlwaysBuild), got {other:?}"),
@@ -1198,7 +1229,7 @@ mod tests {
             b"[project]\nname = \"py\"\n",
         )
         .unwrap();
-        let resolved = source_for_resolved_dir(&pkg_ref(), dir.path().to_path_buf());
+        let resolved = source_for_resolved_dir(&pkg_ref(), dir.path().to_path_buf()).unwrap();
         assert!(
             matches!(resolved, ResolvedSource::NeedsBuild(_)),
             "unprovisioned Python-only package must route through materialize, got {resolved:?}"
@@ -1287,7 +1318,7 @@ mod tests {
     fn resolved_dir_routes_unprovisioned_deno_to_build() {
         let dir = tempfile::tempdir().unwrap();
         manifest(dir.path(), DENO_YAML);
-        let resolved = source_for_resolved_dir(&pkg_ref(), dir.path().to_path_buf());
+        let resolved = source_for_resolved_dir(&pkg_ref(), dir.path().to_path_buf()).unwrap();
         assert!(
             matches!(resolved, ResolvedSource::NeedsBuild(_)),
             "unprovisioned Deno-only package must route through materialize, got {resolved:?}"

--- a/runtime/streamlib-engine/src/core/streamlib_home.rs
+++ b/runtime/streamlib-engine/src/core/streamlib_home.rs
@@ -135,17 +135,6 @@ pub fn installed_package_slot_dir(
     get_cached_package_dir(&format!("{}-{}", pkg_ref.name.as_str(), version))
 }
 
-/// Temporary delegate over [`installed_package_slot_dir`] for the build
-/// orchestrator's cross-crate call, which does not yet thread a
-/// [`PackageRef`]/app root. Removed in the orchestrator-handoff step of the
-/// #1506 relocation; no new caller.
-pub fn get_cached_package_dir_for_name_version(
-    package_name: &str,
-    version: impl std::fmt::Display,
-) -> PathBuf {
-    get_cached_package_dir(&format!("{package_name}-{version}"))
-}
-
 /// Get the path to a runtime's directory.
 pub fn get_runtime_dir(runtime_id: &str) -> PathBuf {
     get_streamlib_data_dir().join("runtimes").join(runtime_id)
@@ -197,10 +186,9 @@ mod tests {
     /// write==read invariant: the seam is the single derivation, so a fixed
     /// `(pkg_ref, version)` yields one byte-identical slot no matter the app
     /// root — the property that lets a locked read find exactly the slot a
-    /// `.slpkg` extract / registry reuse wrote. Also pins the temporary
-    /// orchestrator delegate to the same output while it lives.
+    /// `.slpkg` extract / registry reuse wrote.
     #[test]
-    fn slot_dir_is_app_root_invariant_and_matches_delegate() {
+    fn slot_dir_is_app_root_and_org_invariant() {
         let pkg = pkg_ref("tatolab", "core");
         let version = SemVer::new(4, 5, 6);
 
@@ -210,14 +198,9 @@ mod tests {
         assert_eq!(no_root, with_root, "app root must not move the slot");
 
         // The org is not part of the current key: a same-name package under a
-        // different org derives the same slot (as the delegate, which has no
-        // org, must too).
+        // different org derives the same slot.
         let other_org = installed_package_slot_dir(None, &pkg_ref("acme", "core"), version);
         assert_eq!(no_root, other_org);
-        assert_eq!(
-            no_root,
-            get_cached_package_dir_for_name_version("core", version)
-        );
     }
 
     #[test]

--- a/tools/streamlib-build-orchestrator/src/lib.rs
+++ b/tools/streamlib-build-orchestrator/src/lib.rs
@@ -15,8 +15,10 @@
 //! (via [`streamlib_pack::assemble_artifact`] — the same routine
 //! `streamlib pack` uses: Rust cdylib via cargo + crate source, Python as
 //! full source, Deno bundle, schemas) and stage it as an extracted
-//! directory into the package cache
-//! (`<STREAMLIB_HOME>/.streamlib/cache/packages/<name>-<version>/`).
+//! directory at the destination the engine hands over on the
+//! [`BuildRequest`] (`staging_destination_slot_dir`). The orchestrator holds
+//! no slot-path convention of its own — the engine owns the installed-package
+//! slot seam and injects the exact write location.
 //! A runtime-built staged dir is byte-identical to what extracting the
 //! corresponding `.slpkg` would produce — dev, release, and
 //! install-from-anywhere share the shape, so a package that loads in dev
@@ -32,6 +34,7 @@
 //! fingerprint cannot — the original stale-artifact trap).
 //!
 //! [`BuildOrchestrator`]: streamlib_engine::core::runtime::BuildOrchestrator
+//! [`BuildRequest`]: streamlib_engine::core::runtime::BuildRequest
 //! [`Strategy::Path`]: streamlib_engine::core::runtime::Strategy::Path
 //! [`Strategy::Git`]: streamlib_engine::core::runtime::Strategy::Git
 //! [`BuildPolicy`]: streamlib_engine::core::runtime::BuildPolicy
@@ -189,10 +192,11 @@ impl PolyglotBuildOrchestrator {
                 "streamlib.yaml missing [package] section".into(),
             )
         })?;
-        let cache_slot = streamlib_engine::core::get_cached_package_dir_for_name_version(
-            package.name.as_str(),
-            package.version,
-        );
+        // The engine computed the staging destination via the installed-package
+        // slot seam and handed it over on the request; the orchestrator holds no
+        // slot-path convention of its own. `read_minimal_project_config` above is
+        // still needed (has_rust, [package], the reserved-session org check).
+        let cache_slot = request.staging_destination_slot_dir.clone();
 
         let has_rust = build::has_rust_runtime_processors(&config);
 
@@ -1001,6 +1005,9 @@ mod tests {
             source_provenance: PackageSourceProvenance::MutableUserCheckout,
             policy,
             host_triple: build::host_target_triple().to_string(),
+            staging_destination_slot_dir: streamlib_engine::core::get_cached_package_dir(
+                "schemas-only-0.1.0",
+            ),
         }
     }
 
@@ -1008,10 +1015,9 @@ mod tests {
     #[serial]
     fn schemas_only_stages_into_package_cache() {
         // A schemas-only package (no compiler involved) assembles into the
-        // package cache at cache/packages/<name>-<version>/ — the same
-        // location an extracted .slpkg / GitHub install lands in — with
-        // its streamlib.yaml + schemas/ present. rebuilt=false because no
-        // build tool ran.
+        // engine-injected staging destination — the same slot an extracted
+        // .slpkg / GitHub install lands in — with its streamlib.yaml +
+        // schemas/ present. rebuilt=false because no build tool ran.
         let _home = HomeGuard::new();
         let src = tempfile::tempdir().unwrap();
         schemas_only_pkg(src.path());
@@ -1036,6 +1042,36 @@ mod tests {
             staged.staged_dir.join(SIDECAR_NAME).is_file(),
             "sidecar must be written for the IfStale skip-check"
         );
+    }
+
+    /// write==read handoff: the orchestrator stages into EXACTLY the
+    /// `staging_destination_slot_dir` the engine injected on the request — it
+    /// re-derives no slot of its own. The injected destination deliberately
+    /// carries a name that a `{package.name}-{package.version}` self-derivation
+    /// would NOT produce, so restoring the deleted self-derivation would land
+    /// the staged dir at `schemas-only-0.1.0` and fail this assertion.
+    #[test]
+    #[serial]
+    fn stages_into_injected_destination_not_a_self_derived_slot() {
+        let _home = HomeGuard::new();
+        let src = tempfile::tempdir().unwrap();
+        schemas_only_pkg(src.path());
+
+        let injected =
+            streamlib_engine::core::get_cached_package_dir("schemas-only-injected-slot");
+        let mut req = request(src.path(), BuildPolicy::IfStale);
+        req.staging_destination_slot_dir = injected.clone();
+
+        let orch = PolyglotBuildOrchestrator::default();
+        let staged = orch
+            .materialize(&req, &NoopSink)
+            .expect("schemas-only must materialize");
+
+        assert_eq!(
+            staged.staged_dir, injected,
+            "orchestrator must stage into the engine-injected destination, not a re-derived slot"
+        );
+        assert!(staged.staged_dir.join("streamlib.yaml").is_file());
     }
 
     #[test]
@@ -1121,6 +1157,9 @@ mod tests {
             source_provenance: PackageSourceProvenance::MutableUserCheckout,
             policy,
             host_triple: build::host_target_triple().to_string(),
+            staging_destination_slot_dir: streamlib_engine::core::get_cached_package_dir(
+                "py-source-0.1.0",
+            ),
         }
     }
 
@@ -1535,6 +1574,9 @@ mod tests {
                 source_provenance: PackageSourceProvenance::ImmutableManagedExtract,
                 policy: BuildPolicy::IfStale,
                 host_triple: build::host_target_triple().to_string(),
+                staging_destination_slot_dir: streamlib_engine::core::get_cached_package_dir(
+                    "x-0.1.0",
+                ),
             };
             let err = orch.materialize(&req, &NoopSink).expect_err("must reject");
             assert!(matches!(err, BuildError::UnsupportedSource(_)));
@@ -1649,6 +1691,9 @@ streamlib-plugin-sdk = {version = "0.5.0", registry = "tatolab"}
             source_provenance: PackageSourceProvenance::ImmutableManagedExtract,
             policy: BuildPolicy::IfStale,
             host_triple: build::host_target_triple().to_string(),
+            staging_destination_slot_dir: streamlib_engine::core::get_cached_package_dir(
+                "rust-source-0.1.0",
+            ),
         };
         let err = with_scratch_registry(registry.path(), || {
             orch.materialize(&req, &NoopSink)


### PR DESCRIPTION
## Ticket

Closes #1517

## Summary

Part of the #1506 → `streamlib_modules` co-location relocation (strangler-seam decomposition, blocked by #1516/#1515, both merged). This step makes the staging write destination a pure value handoff instead of a self-derivation:

- `BuildRequest` (`build_orchestrator.rs`) gains `staging_destination_slot_dir: PathBuf`, computed by the engine at request-build time via the `#1516` seam (`installed_package_slot_dir`).
- `tools/streamlib-build-orchestrator/src/lib.rs`: deleted the orchestrator's self-derivation and the temporary engine-side delegate fn from seam-route. Staleness-skip, `stage_temp_dir`, `atomic_swap`, and sidecar reuse all now target the injected destination — the orchestrator crate has zero slot-path-convention knowledge left.
- `runtime/streamlib-engine/src/core/runtime/install.rs`: `cache_dir` is now recorded from the seam-derived staged dir (same value as before — the PR states the equivalence: `cache_dir` is always the derived `file_name`).
- `source.rs`: the `source_for_*` helpers were made fallible and now thread the seam-derived staging destination into every `BuildRequest` literal instead of letting the orchestrator re-derive it.
- Orchestrator tests (`schemas_only_stages_into_package_cache`, fingerprint tests) now assert location via the injected destination, not re-derived literals, plus a new negative regression-lock test (`stages_into_injected_destination_not_a_self_derived_slot`) that injects a destination a self-derived slot would never produce.

Behavior-preserving / additive — byte-identical output on every path; no `/verify-live` needed (unit-testable per the ticket).

## Test evidence

Run fresh in the branch's worktree (`.claude/worktrees/wf_da9e7aff-bfc-2`, `ee3a0003`):

```
cargo test -p streamlib-engine --lib
test result: ok. 1706 passed; 0 failed; 128 ignored; 0 measured; 0 filtered out; finished in 37.97s

cargo test -p streamlib-build-orchestrator --lib
test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.15s
```

No `/verify-live` run — this change is unit-testable only, per the ticket's own acceptance criteria (no rig-dependent path touched).

## Review items (non-blocking)

- **info** — `runtime/streamlib-engine/src/core/runtime/install.rs:167`: `install()` computes `app_root` from `lockfile_path.parent()` and threads it into `installed_package_slot_dir`. Evidence: `installed_package_slot_dir` does `let _ = app_modules_root;` (`streamlib_home.rs:134`) so the threaded `app_root` is currently inert; `source.rs`'s `staging_slot_for_dir` threads a *different* app-root notion (env-based `app_modules_root()`). Both inert today, byte-identical output, so behavior is preserved. Suggested next step: no action for this PR; note the two app-root notions must be reconciled when #1506 activates the seam arg, or the write==read invariant could split across install vs module-load paths.
- **low** — `runtime/streamlib-engine/src/core/runtime/install.rs:199`: version is pulled via `.expect("package_ref_of is Some, so [package] is present")`. Evidence: `package_ref_of` (`install.rs:284`) returns `Some` iff `pkg.manifest.package` is `Some`, and `pkg` is not mutated between the `let Some(pkg_ref) = package_ref_of(pkg) else continue` and this expect — provably unreachable and documented. Engine doctrine discourages panic-on-internal-bug, but this is a proven-unreachable re-borrow. Suggested next step: optional — destructure the `[package]` meta once (as the block at `:196` already does) to remove the panic entirely; not blocking.
- **info** — `tools/streamlib-build-orchestrator/src/lib.rs:1048`: new negative test locks the handoff by mentally-revert. Evidence: `stages_into_injected_destination_not_a_self_derived_slot` injects `schemas-only-injected-slot`, which a restored `{name}-{version}` self-derivation (`schemas-only-0.1.0`) would not yield; ran it green (45/45 orchestrator tests). Reverting the production handoff would land `staged_dir` at the self-derived name and fail the `assert_eq`. Suggested next step: none — genuine regression lock.
- **should-fix** — `runtime/streamlib-engine/src/core/runtime/install.rs:187`: new `.expect("package_ref_of is Some, so [package] is present")` is a panic-on-internal-bug in engine library code, and it is a third copy of a fragile pattern: call `package_ref_of(pkg)` (which reads `pkg.manifest.package`), then separately re-reach into `pkg.manifest.package.as_ref().unwrap()/expect()` to pull the version the helper threw away. Evidence: `install.rs:184-190` does `pkg.manifest.package.as_ref().expect(...).version` immediately after the `let Some(pkg_ref) = package_ref_of(pkg) else { continue }` at `L168`. The pre-existing twin at `install.rs:243` does the identical `package_ref_of(p).map(|r| (r, p.manifest.package.as_ref().unwrap().version))`. `package_ref_of` (`L261-266`) returns `Option<PackageRef>`, discarding the version, forcing every caller that needs the version to re-open the same `Option` with unwrap/expect. Engine doctrine mandates `?` over `.unwrap()` and "no panic-on-internal-bug" in library code. Suggested next step: change `package_ref_of` to yield the version alongside the ref — return `Option<(PackageRef, SemVer)>` (or `Option<&Package>`). That collapses the new `L187` `.expect()` and the pre-existing `L243` `.unwrap()` into one panic-free destructure each, removes the double manifest-block traversal, and fixes the smell at the shared helper rather than at each call site.
- **info** — `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:583`: test
- **info** — `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:554`: three `BuildRequest { package, source, source_provenance, policy, host_triple, staging_destination_slot_dir }` literals now sit in `source_for_dir`, `source_for_resolved_dir`, and `source_for_fetched_slpkg`, differing only in `source_provenance`/`policy`. Evidence: `source.rs:557-566, 602-618, 656-666` each repeat the same 6-field struct-literal with the same `BuildSource::PackageDir(dir)` / `host_target_triple().to_string()` / `staging_slot_for_dir(...)` boilerplate. This duplication predates the PR (the PR only adds the one new field to each), so it is not introduced here, but the shape now has 3 near-identical copies plus the in-`install.rs` copy. Suggested next step: optional, out of scope for this PR — a `BuildRequest::for_package_dir(pkg_ref, dir, provenance, policy, staging_slot)` constructor would collapse all four literals. Not blocking — flag only if these get edited together again.
