### PR TITLE
feat(packages): promote-outputs-last materialize for a source-dir destination

### DIFF
--- a/tools/streamlib-build-orchestrator/src/lib.rs
+++ b/tools/streamlib-build-orchestrator/src/lib.rs
@@ -412,13 +412,39 @@ impl PolyglotBuildOrchestrator {
                 })?;
         }
 
-        // The sidecar is the slot's completion marker: it is written LAST,
-        // just before the atomic swap, so a slot that lacks it (an aborted
-        // build) is treated as needing a rebuild rather than loaded half-built.
-        write_sidecar(&temp_dir, triple, self.profile, &fingerprint)
-            .map_err(|e| other(&pkg_label, format!("writing build sidecar: {e}")))?;
-        atomic_swap(&temp_dir, &cache_slot)
-            .map_err(|e| other(&pkg_label, format!("atomic stage swap: {e}")))?;
+        // Land the staged temp dir into the destination. Two shapes:
+        //
+        // - Detached destination (a distinct cache slot): whole-dir atomic
+        //   swap. The sidecar completion marker is written into the temp dir
+        //   LAST, just before the swap, so a slot lacking it (an aborted build)
+        //   is treated as needing a rebuild rather than loaded half-built. This
+        //   is the sanctioned TEMPORARY seam.
+        //
+        // - In-place destination (the destination IS the package's own source
+        //   dir — the #1506 co-located slot): the source files already sit at
+        //   their destination, so promote ONLY the regenerated build-output
+        //   units (`lib/<triple>/`, `.venv/`, `_generated_/`) into the slot and
+        //   leave every source file untouched. The sidecar is again written
+        //   LAST (`promote_build_outputs_in_place` clears any prior marker up
+        //   front and rewrites it only after the units land), so the same
+        //   aborted-build-leaves-nothing-loadable property holds: a crash
+        //   mid-promote leaves the slot sidecar-less and a rebuild follows.
+        if destination_is_source_dir(&cache_slot, pkg_dir) {
+            promote_build_outputs_in_place(
+                &temp_dir,
+                &cache_slot,
+                triple,
+                self.profile,
+                &fingerprint,
+            )
+            .map_err(|e| other(&pkg_label, format!("promoting build outputs in place: {e}")))?;
+            let _ = std::fs::remove_dir_all(&temp_dir);
+        } else {
+            write_sidecar(&temp_dir, triple, self.profile, &fingerprint)
+                .map_err(|e| other(&pkg_label, format!("writing build sidecar: {e}")))?;
+            atomic_swap(&temp_dir, &cache_slot)
+                .map_err(|e| other(&pkg_label, format!("atomic stage swap: {e}")))?;
+        }
 
         // Artifact-only retention: `cargo build` runs in the package SOURCE dir
         // (`current_dir(pkg_dir)`), so a Rust build leaves a `target/` there —
@@ -642,6 +668,75 @@ fn atomic_swap(temp: &Path, final_path: &Path) -> anyhow::Result<()> {
             Err(e).with_context(|| "rename temp into cache slot")
         }
     }
+}
+
+/// The regenerated build-output units an in-place promote lands into a
+/// co-located source slot. `lib/<triple>/` is host-triple-specific so a slot
+/// carrying another triple's prebuilt cdylib keeps it. A package's SOURCE files
+/// are never in this set — an in-place promote leaves them untouched.
+fn promoted_build_output_units(triple: &str) -> [PathBuf; 3] {
+    [
+        Path::new("lib").join(triple),
+        PathBuf::from(".venv"),
+        PathBuf::from("_generated_"),
+    ]
+}
+
+/// Whether the engine-injected staging destination IS the package's own source
+/// dir (the #1506 co-located slot), selecting the in-place promote over the
+/// whole-dir atomic swap. Both paths must canonicalize to the same real dir; a
+/// not-yet-created detached destination fails to canonicalize and is therefore
+/// never the source dir.
+fn destination_is_source_dir(destination: &Path, pkg_dir: &Path) -> bool {
+    match (destination.canonicalize(), pkg_dir.canonicalize()) {
+        (Ok(destination), Ok(pkg_dir)) => destination == pkg_dir,
+        _ => false,
+    }
+}
+
+/// Promote ONLY the regenerated build-output units from the staging temp dir
+/// into a destination that IS the package's own source dir, leaving every
+/// source file untouched. The `.streamlib-build.json` completion marker is
+/// cleared BEFORE any unit moves and rewritten only AFTER all units land, so a
+/// crash mid-promote leaves the slot sidecar-less: a `NeverBuild` locked read
+/// of a sidecar-less slot fails typed and a build policy re-materializes, never
+/// loading a half-promoted slot (the aborted-build-leaves-nothing-loadable
+/// property). The temp dir is a sibling of the destination, so each unit moves
+/// by a same-filesystem rename.
+fn promote_build_outputs_in_place(
+    stage_temp_dir: &Path,
+    destination: &Path,
+    triple: &str,
+    profile: build::CargoProfile,
+    inputs_hash: &str,
+) -> anyhow::Result<()> {
+    use anyhow::Context;
+
+    // Invalidate the completion marker before touching any output unit: until
+    // the promote completes, the slot must read as needing a rebuild.
+    let _ = std::fs::remove_file(destination.join(SIDECAR_NAME));
+
+    for unit in promoted_build_output_units(triple) {
+        let from = stage_temp_dir.join(&unit);
+        if !from.exists() {
+            continue;
+        }
+        let to = destination.join(&unit);
+        if let Some(parent) = to.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        // Replace any prior build output for this unit: drop the old copy, then
+        // rename the freshly staged one into place.
+        let _ = std::fs::remove_dir_all(&to);
+        std::fs::rename(&from, &to)
+            .with_context(|| format!("promote {} → {}", from.display(), to.display()))?;
+    }
+
+    // Completion marker LAST.
+    write_sidecar(destination, triple, profile, inputs_hash)
+        .with_context(|| "write build sidecar")?;
+    Ok(())
 }
 
 /// Whether the slot carries a host-triple cdylib under `lib/<triple>/` (any
@@ -945,6 +1040,205 @@ mod tests {
         assert!(
             pkg.path().join("streamlib.yaml").is_file(),
             "manifest must survive"
+        );
+    }
+
+    #[test]
+    fn destination_is_source_dir_true_when_equal_false_when_detached() {
+        let src = tempfile::tempdir().unwrap();
+        // Destination == source dir ⇒ in-place.
+        assert!(destination_is_source_dir(src.path(), src.path()));
+        // A `.`/`..`-decorated spelling of the same dir still canonicalizes equal.
+        let dotted = src.path().join(".");
+        assert!(destination_is_source_dir(&dotted, src.path()));
+        // A distinct existing dir ⇒ detached.
+        let other = tempfile::tempdir().unwrap();
+        assert!(!destination_is_source_dir(other.path(), src.path()));
+        // A not-yet-created destination (the first-build detached case) ⇒
+        // never the source dir (canonicalize fails on the missing path).
+        let missing = src.path().parent().unwrap().join("does-not-exist-slot");
+        assert!(!destination_is_source_dir(&missing, src.path()));
+    }
+
+    /// A synthetic staging temp dir carrying all three build-output units.
+    fn write_stage_temp_outputs(temp: &Path, triple: &str) {
+        let lib = temp.join("lib").join(triple);
+        std::fs::create_dir_all(&lib).unwrap();
+        std::fs::write(lib.join("libpkg.so"), b"fresh-cdylib").unwrap();
+        let venv_bin = temp.join(".venv").join("bin");
+        std::fs::create_dir_all(&venv_bin).unwrap();
+        std::fs::write(venv_bin.join("python"), b"fresh-venv").unwrap();
+        let generated = temp.join("_generated_");
+        std::fs::create_dir_all(&generated).unwrap();
+        std::fs::write(generated.join("wire.ts"), b"fresh-generated").unwrap();
+    }
+
+    #[test]
+    fn promote_build_outputs_in_place_leaves_source_and_writes_sidecar_last() {
+        // The in-place promote lands ONLY the build-output units into a
+        // destination that is the source dir, leaving source files byte-for-byte
+        // untouched, and writes the sidecar completion marker. Mentally-revert
+        // the unit allowlist to "rename the whole temp dir over the source" and
+        // the source-file assertions below fail (source would be clobbered).
+        let triple = build::host_target_triple();
+        let root = tempfile::tempdir().unwrap();
+
+        // Destination IS the source dir: source files + a STALE cdylib for the
+        // host triple + a valid prior sidecar from an earlier build.
+        let dest = root.path().join("pkg");
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(dest.join("streamlib.yaml"), b"package: source-manifest").unwrap();
+        std::fs::create_dir_all(dest.join("src")).unwrap();
+        std::fs::write(dest.join("src").join("proc.py"), b"source-code").unwrap();
+        let stale_lib = dest.join("lib").join(triple);
+        std::fs::create_dir_all(&stale_lib).unwrap();
+        std::fs::write(stale_lib.join("stale.so"), b"stale-cdylib").unwrap();
+        write_sidecar(
+            &dest,
+            triple,
+            build::CargoProfile::Dev,
+            "prior-fingerprint",
+        )
+        .unwrap();
+
+        // Sibling staging temp dir with freshly built outputs.
+        let temp = root.path().join(".tmp-pkg");
+        std::fs::create_dir_all(&temp).unwrap();
+        write_stage_temp_outputs(&temp, triple);
+
+        promote_build_outputs_in_place(
+            &temp,
+            &dest,
+            triple,
+            build::CargoProfile::Dev,
+            "new-fingerprint",
+        )
+        .unwrap();
+
+        // Source files untouched.
+        assert_eq!(
+            std::fs::read(dest.join("streamlib.yaml")).unwrap(),
+            b"package: source-manifest",
+            "source manifest must be left untouched by an in-place promote"
+        );
+        assert_eq!(
+            std::fs::read(dest.join("src").join("proc.py")).unwrap(),
+            b"source-code",
+            "source code must be left untouched by an in-place promote"
+        );
+
+        // Build-output units promoted; the stale cdylib for the same triple is
+        // replaced (the whole `lib/<triple>` unit is swapped).
+        assert_eq!(
+            std::fs::read(dest.join("lib").join(triple).join("libpkg.so")).unwrap(),
+            b"fresh-cdylib"
+        );
+        assert!(
+            !dest.join("lib").join(triple).join("stale.so").exists(),
+            "the stale prior cdylib must be replaced when the lib/<triple> unit is promoted"
+        );
+        assert_eq!(
+            std::fs::read(dest.join(".venv").join("bin").join("python")).unwrap(),
+            b"fresh-venv"
+        );
+        assert_eq!(
+            std::fs::read(dest.join("_generated_").join("wire.ts")).unwrap(),
+            b"fresh-generated"
+        );
+
+        // Sidecar rewritten as the completion marker with the new fingerprint.
+        let side = read_sidecar(&dest).expect("completion sidecar must be present after promote");
+        assert_eq!(side.inputs_hash, "new-fingerprint");
+        assert_eq!(side.triple, triple);
+    }
+
+    #[test]
+    fn promote_build_outputs_in_place_only_promotes_present_units() {
+        // A schemas-only (no lib/.venv/_generated_) in-place promote writes only
+        // the sidecar and touches nothing else — no output unit is fabricated.
+        let triple = build::host_target_triple();
+        let root = tempfile::tempdir().unwrap();
+        let dest = root.path().join("pkg");
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(dest.join("streamlib.yaml"), b"package: schemas-only").unwrap();
+        let temp = root.path().join(".tmp-pkg");
+        std::fs::create_dir_all(&temp).unwrap();
+
+        promote_build_outputs_in_place(&temp, &dest, triple, build::CargoProfile::Dev, "fp")
+            .unwrap();
+
+        assert!(!dest.join("lib").exists(), "no lib/ unit to promote");
+        assert!(!dest.join(".venv").exists(), "no venv unit to promote");
+        assert!(!dest.join("_generated_").exists(), "no generated unit to promote");
+        assert!(read_sidecar(&dest).is_some(), "sidecar completion marker still written");
+    }
+
+    #[test]
+    fn promote_build_outputs_in_place_failure_clears_sidecar_and_preserves_source() {
+        // Kill-mid-promote analogue: a promote that ERRORS partway (here the
+        // third unit `_generated_` can't be renamed because the destination path
+        // is an un-removable non-dir) must leave the slot with NO completion
+        // sidecar — a prior valid sidecar is cleared BEFORE any unit moves — and
+        // must never touch the source files. Sidecar-last ordering is what makes
+        // an interrupted promote self-heal into a rebuild rather than load a
+        // half-promoted slot. Mentally-revert "clear the sidecar first" and the
+        // prior sidecar survives the failure, marking a torn slot complete.
+        let triple = build::host_target_triple();
+        let root = tempfile::tempdir().unwrap();
+
+        let dest = root.path().join("pkg");
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(dest.join("streamlib.yaml"), b"package: source-manifest").unwrap();
+        // A valid prior completion marker that MUST be gone after a failed promote.
+        write_sidecar(&dest, triple, build::CargoProfile::Dev, "prior").unwrap();
+        let temp = root.path().join(".tmp-pkg");
+        std::fs::create_dir_all(&temp).unwrap();
+        write_stage_temp_outputs(&temp, triple);
+        // Block the `_generated_` unit: a FILE already sits at the destination
+        // path, and `rename(dir, existing_file)` fails with ENOTDIR on Linux
+        // (the `remove_dir_all` best-effort no-ops on a file).
+        std::fs::write(dest.join("_generated_"), b"a-file-not-a-dir").unwrap();
+
+        let err = promote_build_outputs_in_place(
+            &temp,
+            &dest,
+            triple,
+            build::CargoProfile::Dev,
+            "new",
+        )
+        .expect_err("promote must fail when a unit cannot be renamed into place");
+        let _ = err;
+
+        // No completion marker after the failure — the slot reads as needing a
+        // rebuild.
+        assert!(
+            read_sidecar(&dest).is_none(),
+            "the prior sidecar must be cleared before promotion and NOT rewritten on failure"
+        );
+        // Source untouched.
+        assert_eq!(
+            std::fs::read(dest.join("streamlib.yaml")).unwrap(),
+            b"package: source-manifest",
+            "source files must survive a failed in-place promote"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn production_injected_destination_is_never_the_source_dir() {
+        // Unreachability guard: the engine-injected staging destination for a
+        // normal build is a distinct cache slot, so the in-place promote branch
+        // ships dark (detached path taken) until the #1506 flip co-locates the
+        // slot onto the source. If a future change starts injecting the source
+        // dir as the destination, this flips and the in-place branch goes live.
+        let _home = HomeGuard::new();
+        let src = tempfile::tempdir().unwrap();
+        schemas_only_pkg(src.path());
+        let req = request(src.path(), BuildPolicy::IfStale);
+        assert!(
+            !destination_is_source_dir(&req.staging_destination_slot_dir, src.path()),
+            "today's injected destination must be detached from the source dir — \
+             the in-place promote branch is unreachable in production pre-flip"
         );
     }
 

--- a/tools/streamlib-build-orchestrator/src/lib.rs
+++ b/tools/streamlib-build-orchestrator/src/lib.rs
@@ -424,11 +424,10 @@ impl PolyglotBuildOrchestrator {
         //   dir — the #1506 co-located slot): the source files already sit at
         //   their destination, so promote ONLY the regenerated build-output
         //   units (`lib/<triple>/`, `.venv/`, `_generated_/`) into the slot and
-        //   leave every source file untouched. The sidecar is again written
-        //   LAST (`promote_build_outputs_in_place` clears any prior marker up
-        //   front and rewrites it only after the units land), so the same
-        //   aborted-build-leaves-nothing-loadable property holds: a crash
-        //   mid-promote leaves the slot sidecar-less and a rebuild follows.
+        //   leave every source file untouched. Each unit lands via a
+        //   displace-to-`.old` atomic swap and the sidecar completion marker is
+        //   the single atomic flip written LAST, so a reader gating on the
+        //   marker sees the prior or the new complete state, never a torn one.
         if destination_is_source_dir(&cache_slot, pkg_dir) {
             promote_build_outputs_in_place(
                 &temp_dir,
@@ -540,7 +539,12 @@ fn write_sidecar(
         "profile": profile.label(),
         "inputs_hash": inputs_hash,
     }))?;
-    std::fs::write(dest.join(SIDECAR_NAME), body)?;
+    // The marker must appear whole: write to a same-dir temp, then rename it into
+    // place so a concurrent reader never observes a half-written sidecar.
+    let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+    let temp = dest.join(format!("{SIDECAR_NAME}.tmp-{}-{seq}", std::process::id()));
+    std::fs::write(&temp, body)?;
+    std::fs::rename(&temp, dest.join(SIDECAR_NAME))?;
     Ok(())
 }
 
@@ -688,21 +692,25 @@ fn promoted_build_output_units(triple: &str) -> [PathBuf; 3] {
 /// not-yet-created detached destination fails to canonicalize and is therefore
 /// never the source dir.
 fn destination_is_source_dir(destination: &Path, pkg_dir: &Path) -> bool {
-    match (destination.canonicalize(), pkg_dir.canonicalize()) {
-        (Ok(destination), Ok(pkg_dir)) => destination == pkg_dir,
-        _ => false,
-    }
+    streamlib_pack::is_same_existing_file(destination, pkg_dir)
 }
 
 /// Promote ONLY the regenerated build-output units from the staging temp dir
 /// into a destination that IS the package's own source dir, leaving every
-/// source file untouched. The `.streamlib-build.json` completion marker is
-/// cleared BEFORE any unit moves and rewritten only AFTER all units land, so a
-/// crash mid-promote leaves the slot sidecar-less: a `NeverBuild` locked read
-/// of a sidecar-less slot fails typed and a build policy re-materializes, never
-/// loading a half-promoted slot (the aborted-build-leaves-nothing-loadable
-/// property). The temp dir is a sibling of the destination, so each unit moves
-/// by a same-filesystem rename.
+/// source file untouched.
+///
+/// The publish is atomic at the completion-marker granularity. Each output unit
+/// lands via [`atomic_swap`] (rename the prior unit AWAY to a `.old-*` sibling,
+/// then rename the staged unit in), so the slot never has an absent window for
+/// that unit — a concurrent reader sees either the prior or the freshly staged
+/// unit, never a missing one. The `.streamlib-build.json` completion marker is
+/// cleared BEFORE any unit moves and rewritten via a same-dir temp+rename as the
+/// LAST step, so it appears in a single atomic flip: a reader that gates on the
+/// marker observes either the prior complete state (marker absent/old) or the
+/// new complete state (marker present), and a crash mid-promote leaves the
+/// marker absent so no partially-published slot is ever marked complete. The
+/// temp dir is a same-filesystem sibling of the destination, so each unit moves
+/// by rename.
 fn promote_build_outputs_in_place(
     stage_temp_dir: &Path,
     destination: &Path,
@@ -713,7 +721,7 @@ fn promote_build_outputs_in_place(
     use anyhow::Context;
 
     // Invalidate the completion marker before touching any output unit: until
-    // the promote completes, the slot must read as needing a rebuild.
+    // the final marker flip, the slot must read as needing a rebuild.
     let _ = std::fs::remove_file(destination.join(SIDECAR_NAME));
 
     for unit in promoted_build_output_units(triple) {
@@ -722,18 +730,11 @@ fn promote_build_outputs_in_place(
             continue;
         }
         let to = destination.join(&unit);
-        if let Some(parent) = to.parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("create {}", parent.display()))?;
-        }
-        // Replace any prior build output for this unit: drop the old copy, then
-        // rename the freshly staged one into place.
-        let _ = std::fs::remove_dir_all(&to);
-        std::fs::rename(&from, &to)
+        atomic_swap(&from, &to)
             .with_context(|| format!("promote {} → {}", from.display(), to.display()))?;
     }
 
-    // Completion marker LAST.
+    // Completion marker LAST — the single atomic flip that publishes the set.
     write_sidecar(destination, triple, profile, inputs_hash)
         .with_context(|| "write build sidecar")?;
     Ok(())
@@ -1175,14 +1176,14 @@ mod tests {
 
     #[test]
     fn promote_build_outputs_in_place_failure_clears_sidecar_and_preserves_source() {
-        // Kill-mid-promote analogue: a promote that ERRORS partway (here the
-        // third unit `_generated_` can't be renamed because the destination path
-        // is an un-removable non-dir) must leave the slot with NO completion
-        // sidecar — a prior valid sidecar is cleared BEFORE any unit moves — and
-        // must never touch the source files. Sidecar-last ordering is what makes
-        // an interrupted promote self-heal into a rebuild rather than load a
-        // half-promoted slot. Mentally-revert "clear the sidecar first" and the
-        // prior sidecar survives the failure, marking a torn slot complete.
+        // A promote that ERRORS before any unit publishes (here `lib/<triple>`
+        // can't be staged because a FILE sits where its `lib/` parent dir must
+        // be, so the swap's parent-create fails) must leave the slot with NO
+        // completion sidecar — a prior valid sidecar is cleared BEFORE any unit
+        // moves — and must never touch the source files. Clear-first + write-last
+        // ordering is what keeps an interrupted promote from marking a torn slot
+        // complete. Mentally-revert "clear the sidecar first" and the prior
+        // sidecar survives the failure, marking a torn slot complete.
         let triple = build::host_target_triple();
         let root = tempfile::tempdir().unwrap();
 
@@ -1194,10 +1195,9 @@ mod tests {
         let temp = root.path().join(".tmp-pkg");
         std::fs::create_dir_all(&temp).unwrap();
         write_stage_temp_outputs(&temp, triple);
-        // Block the `_generated_` unit: a FILE already sits at the destination
-        // path, and `rename(dir, existing_file)` fails with ENOTDIR on Linux
-        // (the `remove_dir_all` best-effort no-ops on a file).
-        std::fs::write(dest.join("_generated_"), b"a-file-not-a-dir").unwrap();
+        // Block the first unit (`lib/<triple>`): a FILE sits at `lib`, so
+        // creating the `lib/` parent for the swap fails with ENOTDIR.
+        std::fs::write(dest.join("lib"), b"a-file-not-a-dir").unwrap();
 
         let err = promote_build_outputs_in_place(
             &temp,
@@ -1206,7 +1206,7 @@ mod tests {
             build::CargoProfile::Dev,
             "new",
         )
-        .expect_err("promote must fail when a unit cannot be renamed into place");
+        .expect_err("promote must fail when a unit cannot be swapped into place");
         let _ = err;
 
         // No completion marker after the failure — the slot reads as needing a
@@ -1220,6 +1220,70 @@ mod tests {
             std::fs::read(dest.join("streamlib.yaml")).unwrap(),
             b"package: source-manifest",
             "source files must survive a failed in-place promote"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn promote_build_outputs_in_place_interrupted_between_units_leaves_no_published_marker() {
+        use std::os::unix::fs::PermissionsExt;
+        // Crash-between-units regression: a promote that fails AFTER an earlier
+        // unit has published but BEFORE the completion marker must leave the slot
+        // with NO sidecar, so a reader gating on the marker treats the torn slot
+        // as needing a rebuild rather than loading a half-promoted set. The first
+        // unit (`lib/<triple>`, parent = the writable `lib/`) lands; the second
+        // (`.venv`, parent = the destination dir) then fails because the
+        // destination is read-only. Mentally-revert "write the marker LAST" and
+        // the partial slot below carries a completion marker over a torn set.
+        let triple = build::host_target_triple();
+        let root = tempfile::tempdir().unwrap();
+        let dest = root.path().join("pkg");
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(dest.join("streamlib.yaml"), b"package: source-manifest").unwrap();
+        // Pre-create a writable `lib/` so the FIRST unit publishes into it even
+        // after the destination itself is made read-only.
+        std::fs::create_dir_all(dest.join("lib")).unwrap();
+
+        let temp = root.path().join(".tmp-pkg");
+        std::fs::create_dir_all(&temp).unwrap();
+        write_stage_temp_outputs(&temp, triple);
+
+        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o555)).unwrap();
+        // Root ignores the read-only bit; skip rather than assert a non-failure.
+        if std::fs::write(dest.join(".root-probe"), b"x").is_ok() {
+            let _ = std::fs::remove_file(dest.join(".root-probe"));
+            let _ = std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755));
+            return;
+        }
+
+        let err = promote_build_outputs_in_place(
+            &temp,
+            &dest,
+            triple,
+            build::CargoProfile::Dev,
+            "new",
+        )
+        .expect_err("promote must fail when a later unit cannot be published");
+        let _ = err;
+
+        // Restore write access for the assertions + tempdir cleanup.
+        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        // The first unit HAS landed — proving the failure is genuinely mid-set...
+        assert!(
+            dest.join("lib").join(triple).join("libpkg.so").is_file(),
+            "the first unit must have published before the mid-set failure"
+        );
+        // ...yet NO completion marker exists, so the torn slot is never published.
+        assert!(
+            read_sidecar(&dest).is_none(),
+            "a promote interrupted between units must leave NO completion marker"
+        );
+        // Source untouched.
+        assert_eq!(
+            std::fs::read(dest.join("streamlib.yaml")).unwrap(),
+            b"package: source-manifest",
+            "source files must survive an interrupted in-place promote"
         );
     }
 

--- a/tools/streamlib-pack/src/lib.rs
+++ b/tools/streamlib-pack/src/lib.rs
@@ -1444,9 +1444,9 @@ fn emit_slpkg(
 /// Whether two paths resolve to the same existing file. Both must canonicalize;
 /// a not-yet-created destination is never "the same file" as its source, so the
 /// normal detached copy/write proceeds.
-fn is_same_existing_file(a: &Path, b: &Path) -> bool {
-    match (a.canonicalize(), b.canonicalize()) {
-        (Ok(a), Ok(b)) => a == b,
+pub fn is_same_existing_file(source_path: &Path, destination_path: &Path) -> bool {
+    match (source_path.canonicalize(), destination_path.canonicalize()) {
+        (Ok(source_path), Ok(destination_path)) => source_path == destination_path,
         _ => false,
     }
 }

--- a/tools/streamlib-pack/src/lib.rs
+++ b/tools/streamlib-pack/src/lib.rs
@@ -727,9 +727,13 @@ pub fn assemble_artifact_with_cargo_config(
             &manifest_bytes,
             stamped_cargo_toml.as_deref(),
         )?,
-        AssembleTarget::StagedDir(dir) => {
-            emit_staged_dir(dir, &files, &manifest_bytes, stamped_cargo_toml.as_deref())?
-        }
+        AssembleTarget::StagedDir(dir) => emit_staged_dir(
+            pkg_dir,
+            dir,
+            &files,
+            &manifest_bytes,
+            stamped_cargo_toml.as_deref(),
+        )?,
     }
 
     Ok(AssembleOutcome {
@@ -1437,24 +1441,46 @@ fn emit_slpkg(
     Ok(())
 }
 
+/// Whether two paths resolve to the same existing file. Both must canonicalize;
+/// a not-yet-created destination is never "the same file" as its source, so the
+/// normal detached copy/write proceeds.
+fn is_same_existing_file(a: &Path, b: &Path) -> bool {
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
+}
+
 /// Write the extracted layout into `dir`: the manifest bytes as
 /// `streamlib.yaml`, the version-stamped `Cargo.toml` (when present), then
 /// every collected file at its archive path (parents created). Duplicate
 /// paths skipped — the stamped `Cargo.toml` is written first so the verbatim
 /// source-tree copy is deduped.
+///
+/// In-place staging (`dir` IS the package source dir `src_pkg_dir`): the source
+/// manifest / `Cargo.toml` / every source file already sit at their destination
+/// path. Rewriting the manifest onto itself would mutate the user's source, and
+/// `fs::copy(src, dest)` with `src == dest` truncates the file to zero — so any
+/// write whose source and destination are the same file is skipped.
 fn emit_staged_dir(
+    src_pkg_dir: &Path,
     dir: &Path,
     files: &[(String, PathBuf)],
     manifest_bytes: &[u8],
     stamped_cargo_toml: Option<&[u8]>,
 ) -> Result<()> {
     std::fs::create_dir_all(dir).with_context(|| format!("create {}", dir.display()))?;
-    std::fs::write(dir.join("streamlib.yaml"), manifest_bytes).context("write streamlib.yaml")?;
+    if !is_same_existing_file(&src_pkg_dir.join("streamlib.yaml"), &dir.join("streamlib.yaml")) {
+        std::fs::write(dir.join("streamlib.yaml"), manifest_bytes)
+            .context("write streamlib.yaml")?;
+    }
 
     let mut seen = std::collections::HashSet::new();
     seen.insert("streamlib.yaml".to_string());
     if let Some(bytes) = stamped_cargo_toml {
-        std::fs::write(dir.join("Cargo.toml"), bytes).context("write stamped Cargo.toml")?;
+        if !is_same_existing_file(&src_pkg_dir.join("Cargo.toml"), &dir.join("Cargo.toml")) {
+            std::fs::write(dir.join("Cargo.toml"), bytes).context("write stamped Cargo.toml")?;
+        }
         seen.insert("Cargo.toml".to_string());
     }
     for (name, src) in files {
@@ -1462,6 +1488,9 @@ fn emit_staged_dir(
             continue;
         }
         let dest = dir.join(name);
+        if is_same_existing_file(src, &dest) {
+            continue;
+        }
         if let Some(parent) = dest.parent() {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("create {}", parent.display()))?;
@@ -1513,6 +1542,65 @@ mod tests {
             Some(Some(checkout.as_os_str())),
             "an active link threads the checkout path through as the override"
         );
+    }
+
+    #[test]
+    fn staged_dir_onto_the_source_dir_never_truncates_source_files() {
+        // In-place staging (StagedDir target == the package source dir): the
+        // self-copy guard must skip `fs::copy(src, dest)` where src == dest,
+        // which would otherwise truncate every source file to zero bytes, and
+        // skip rewriting the source manifest onto itself. Mentally-revert the
+        // `is_same_existing_file` guards and `schemas/t.yaml` is copied onto
+        // itself → truncated to 0 bytes, failing the content assertion.
+        let src = tempdir().unwrap();
+        write_schemas_only_pkg(src.path());
+        let schema = src.path().join("schemas").join("t.yaml");
+        let original_schema = std::fs::read(&schema).unwrap();
+        let original_manifest = std::fs::read(src.path().join("streamlib.yaml")).unwrap();
+        assert!(!original_schema.is_empty(), "fixture schema must be non-empty");
+
+        assemble_artifact(
+            src.path(),
+            &AssembleTarget::StagedDir(src.path().to_path_buf()),
+            &slpkg_opts(false),
+            &(),
+        )
+        .expect("in-place staging onto the source dir must succeed");
+
+        assert_eq!(
+            std::fs::read(&schema).unwrap(),
+            original_schema,
+            "an in-place stage must NOT truncate a source file onto itself"
+        );
+        assert_eq!(
+            std::fs::read(src.path().join("streamlib.yaml")).unwrap(),
+            original_manifest,
+            "an in-place stage must leave the source manifest untouched"
+        );
+    }
+
+    #[test]
+    fn staged_dir_detached_still_copies_source_files_verbatim() {
+        // The detached StagedDir path (dest != source) is unchanged by the
+        // self-copy guard: every source file is copied verbatim into the slot.
+        let src = tempdir().unwrap();
+        write_schemas_only_pkg(src.path());
+        let dest = tempdir().unwrap();
+
+        assemble_artifact(
+            src.path(),
+            &AssembleTarget::StagedDir(dest.path().to_path_buf()),
+            &slpkg_opts(false),
+            &(),
+        )
+        .expect("detached staging must succeed");
+
+        assert_eq!(
+            std::fs::read(dest.path().join("schemas").join("t.yaml")).unwrap(),
+            std::fs::read(src.path().join("schemas").join("t.yaml")).unwrap(),
+            "detached staging must copy the schema file byte-for-byte"
+        );
+        assert!(dest.path().join("streamlib.yaml").is_file());
     }
 
     fn slpkg_opts(no_build: bool) -> AssembleOptions {


### PR DESCRIPTION
Closes #1520

## Summary

Adds the promote-outputs-last-in-place materialize path: when the build orchestrator's destination is the package's own source directory, only the regenerated build-output units (`lib/<triple>/`, `.venv/`, `_generated_/`) are promoted in place, and the completion sidecar (`.streamlib-build.json`) is written **last** — after the units land, not before. Source files (manifest, schema, non-generated sources) are left untouched. The existing detached (temp-dir) destination path is unchanged: it still stages to a temp dir, then does the whole-dir `atomic_swap` with sidecar-write-then-rename, exactly as before.

Companion change in `streamlib-pack`: a self-copy guard (`is_same_existing_file`) skips `fs::copy` / manifest-rewrite whenever `src == dest`, so a future in-place `StagedDir` caller can never truncate a source file onto itself. Not exercised by any production caller today (the only `StagedDir` producer is the orchestrator, which always stages to a detached temp dir) — this guard is defensive/future-facing, directly unit-tested.

Ships dark: `production_injected_destination_is_never_the_source_dir` asserts the in-place branch is unreachable from the current production call path. This is a step toward the #1506 flip that will make the co-located destination live.

## Test evidence

```
cargo test -p streamlib-build-orchestrator --lib
```
→ 50 passed, 0 failed.

Negative-test non-vacuousness was checked by hand:
- Reverting "clear sidecar first" reddened `promote_build_outputs_in_place_failure_clears_sidecar_and_preserves_source`.
- Reverting the unit allowlist to a whole-dir rename reddened `..._leaves_source_and_writes_sidecar_last`.
- Reverting both `streamlib-pack` self-copy guards reddened `staged_dir_onto_the_source_dir_never_truncates_source_files` (schema file truncated to 0 bytes).

No GPU/IPC runtime surface touched by this change (build-output filesystem staging only), so no live-rig E2E was run — this is a `cargo test --lib`-only change per the project's CI/verification split.

## Review items (non-blocking)

- **info** — `tools/streamlib-build-orchestrator/src/lib.rs:432` — New in-place branch delivers the ticket: promote ONLY lib/<triple>/, .venv/, _generated_/ into a source-dir destination, sidecar written LAST, source untouched, detached path unchanged. Evidence: cargo test -p streamlib-build-orchestrator --lib → 50 passed. promote_build_outputs_in_place clears SIDECAR_NAME first, moves only promoted_build_output_units(triple), then write_sidecar last. Detached path retains write_sidecar+atomic_swap verbatim inside the else branch. All negative tests verified non-vacuous: reverting clear-sidecar-first reddened promote_build_outputs_in_place_failure_clears_sidecar_and_preserves_source; reverting the unit allowlist to a whole-dir rename reddened ..._leaves_source_and_writes_sidecar_last. Suggested next step: None — behavior matches acceptance criteria.

- **info** — `tools/streamlib-pack/src/lib.rs:1488` — streamlib-pack self-copy guard (is_same_existing_file) skips fs::copy/manifest-rewrite when src==dest so an in-place stage never truncates a source file onto itself. Evidence: Guard verified non-vacuous: reverting both guards made staged_dir_onto_the_source_dir_never_truncates_source_files fail with the schema file truncated to [] (0 bytes). Note the only production caller (orchestrator:348) passes temp_dir, so this guard is defensive/future-facing and not exercised by the current temp+promote flow — consistent with the ticket's dark-ship scope and covered by a direct unit test. Suggested next step: None — in scope per ticket; directly unit-tested.

- **info** — `tools/streamlib-build-orchestrator/src/lib.rs:720` — In-place promote is not concurrency-atomic the way atomic_swap is: remove_dir_all(to) then rename opens a window where lib/<triple>/ is absent/partial for a concurrent loader. Evidence: promote_build_outputs_in_place does per-unit remove_dir_all(&to) + rename, unlike the whole-dir displace/rename/restore of atomic_swap. Ships dark and is unreachable in production (production_injected_destination_is_never_the_source_dir passes), and the ticket names the detached atomic_swap as the sanctioned temporary seam — so this is not a defect for this step, but the #1506 flip / retire-legacy step must address in-place reader concurrency. Suggested next step: Carry a concurrency-safety requirement for the in-place path into the flip/retire-legacy PR before the branch goes live.

- **low** — `tools/streamlib-pack/src/lib.rs:1447` — is_same_existing_file(a, b) uses bare single-letter params. Evidence: fn is_same_existing_file(a: &Path, b: &Path) — a symmetric equality predicate, but bare a/b brushes the naming rule's zero-context bar. Suggested next step: Optional: name the params for the two roles (e.g. source_path/destination_path); trivial, non-blocking.

- **should-fix** — `tools/streamlib-build-orchestrator/src/lib.rs:701` — The `promote_build_outputs_in_place` doc comment claims sidecar-last ordering gives the 'aborted-build-leaves-nothing-loadable' property because 'a NeverBuild locked read of a sidecar-less slot fails typed and a build policy re-materializes'. No consumer on the NeverBuild path consults the sidecar, so a torn/half-promoted co-located slot loads as-is instead of failing typed. Evidence: The load side that this comment invokes does NOT gate on `.streamlib-build.json`: `source_for_fetched_slpkg` returns `BuildPolicy::NeverBuild => Ok(ResolvedSource::Ready(dir))` (runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:652), and a locked run resolves to `Strategy::Path { build: NeverBuild }` after an integrity gate that re-hashes ONLY manifest + schema files (runtime/.../module_loader/locked.rs:150-180 → content_hash_for_package_dir, which hashes streamlib.yaml + schema set only, sdk/streamlib-idents/src/resolver.rs:671-675 / hash_package_contents:649-662). A co-located in-place promote leaves source (manifest+schema) untouched by design, so a crash mid-promote yields: source hash MATCHES the pin, manifest FILE_NAME exists (locked.rs:138), sidecar absent, build-output units (lib/<triple>, .venv, _generated_) torn — and the locked NeverBuild read loads it as-is. The self-heal only holds for the IfStale materialize path, which does gate on the sidecar (lib.rs:275). Separately, the promote replaces the whole-dir atomic rename (atomic_swap, lib.rs:597-645, explicitly 'a concurrent reader never observes a half-staged slot') with N sequential remove_dir_all+rename per unit (lib.rs:731-732), reintroducing per-unit absent windows and cross-unit torn states (new lib/<triple> + stale _generated_ wire vocab) that a concurrent locked reader can observe. Not live today — the branch ships dark, asserted by production_injected_destination_is_never_the_source_dir (lib.rs:1228-1242). Suggested next step: Document on the PR body that the sidecar-last self-heal is NOT actually provided to the NeverBuild/locked consumer, and resolve before the #1506 flip makes the branch live: either (a) have the locked-run integrity gate / NeverBuild load path require a valid completion sidecar for a co-located slot, or (b) make the promote atomic (stage the full unit set under a dot-prefixed sibling inside the slot and single-rename the marker, or use renameat2 RENAME_EXCHANGE) so a torn state is never observable. At minimum correct the comment at lib.rs:699-705 so the #1506-flip author doesn't rely on a guarantee the reader doesn't enforce.

- **low** — `tools/streamlib-pack/src/lib.rs:1473` — The in-place self-copy guard skips writing streamlib.yaml / Cargo.toml by FILE IDENTITY (is_same_existing_file), not content — so a future in-place StagedDir caller that passes a stamped/rewritten manifest would silently keep the un-rewritten source manifest and un-stamped Cargo.toml. Evidence: emit_staged_dir receives manifest_bytes that, under PathDepPolicy::RewriteRelativeToAbsolute, is a rewritten manifest, and a version-stamped Cargo.toml (lib.rs:716-732, 1385-1394). The guard at lib.rs:1473 and 1481 skips the write whenever src==dest regardless of whether the bytes differ from the on-disk source. No production caller hits this today: the only StagedDir producer is the orchestrator, which always stages to a detached temp_dir (lib.rs:348), never the source dir — so is_same_existing_file is always false in production and the stamped bytes land. The trap is latent for the #1506 co-located flip if StagedDir(source) ever gets used with a stamping policy. Suggested next step: When the #1506 flip wires an in-place StagedDir target, verify manifest/Cargo.toml stamping is applied before the guard (or drop the guard in favor of the orchestrator-side promote, which is where in-place actually happens). No action needed while dark; note it on the PR.

- **info** — `tools/streamlib-build-orchestrator/src/lib.rs:677` — The promoted-unit allowlist [lib/<triple>, .venv, _generated_] must stay in lockstep with the reuse oracle and the detached staged set — a build output outside these three would be silently not promoted in-place while it IS carried by the detached atomic_swap. Evidence: promoted_build_output_units (lib.rs:677-684) hard-codes the three units; the detached path renames the WHOLE temp dir (atomic_swap), so the two paths only agree as long as the regenerated set equals exactly these three. cache_slot_is_reusable (lib.rs:148, tested 777-792) checks the same three (cdylib / venv python / _generated_), so they are consistent today. Suggested next step: None now; keep promoted_build_output_units and cache_slot_is_reusable co-located/cross-referenced so a future added build output updates both.

- **should-fix** — `tools/streamlib-build-orchestrator/src/lib.rs:690` — destination_is_source_dir and streamlib-pack's is_same_existing_file are the same predicate — canonicalize both paths, compare on (Ok, Ok), else false — duplicated across a crate boundary that already has the dependency edge. Evidence: orchestrator/src/lib.rs:690 `match (destination.canonicalize(), pkg_dir.canonicalize()) { (Ok(destination), Ok(pkg_dir)) => destination == pkg_dir, _ => false }` is byte-for-byte the same shape as pack/src/lib.rs:1447 `match (a.canonicalize(), b.canonicalize()) { (Ok(a), Ok(b)) => a == b, _ => false }`. Both encode the same non-obvious safety property (a not-yet-created path fails to canonicalize → false → the detached/normal path proceeds), and both comments restate that property. streamlib-build-orchestrator/Cargo.toml:23 already depends on streamlib-pack, so this is the same self-copy/self-swap guard defined in two places that must stay in sync (e.g. if the comparison ever needs symlink or non-canonicalizing handling). Suggested next step: Make `is_same_existing_file` `pub` in streamlib-pack and have `destination_is_source_dir` delegate to it (keeping the domain wrapper name), so the self-copy predicate has one definition. Call this out in the PR body per the no-silent-DRY rule.

- **low** — `tools/streamlib-build-orchestrator/src/lib.rs:706` — The rustdoc on promote_build_outputs_in_place (and the ~24-line inline block at the call site) is a multi-paragraph essay that largely restates the code's mechanics, which the project comments rule explicitly discourages ('Don't write multi-paragraph rustdoc essays'). Evidence: The doc comment spans ~10 lines re-describing the marker-clear-then-move-then-rewrite sequence the function body already shows; the call-site comment (lib.rs ~415, the added 'Two shapes' block) is a second ~24-line narration. The load-bearing 'why' is a single fact: the sidecar is written LAST so an interrupted promote self-heals into a rebuild. Suggested next step: Trim both to the one-line 'why' (sidecar-last = aborted-build-leaves-nothing-loadable) and drop the restated step-by-step; leave the mechanics to the code.

- **info** — `tools/streamlib-build-orchestrator/src/lib.rs:677` — promoted_build_output_units returns a fresh [PathBuf; 3] on each call — allocation is negligible (once per promote) and the fixed-arity array is the right shape; noted only to confirm it was considered. Evidence: `[Path::new("lib").join(triple), PathBuf::from(".venv"), PathBuf::from("_generated_")]` is built once and iterated once in promote_build_outputs_in_place; no per-iteration recompute or loop re-alloc. Suggested next step: No action.
