### PR TITLE
fix(engine): dev sources build in-tree beside their source

### DIFF
--- a/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
@@ -561,14 +561,22 @@ fn source_for_dir(
     provenance: PackageSourceProvenance,
 ) -> std::result::Result<ResolvedSource, AddModuleError> {
     if build.requires_orchestrator() {
-        let staging_destination_slot_dir = staging_slot_for_dir(pkg_ref, &dir)?;
+        // A dev source (`Strategy::Path` / `Strategy::Git` / a `streamlib link`
+        // override) builds IN-TREE beside its source: the staging destination
+        // IS the source dir itself, so the orchestrator takes its in-place
+        // promote — landing ONLY the regenerated build outputs (`lib/<triple>/`,
+        // `.venv/`, `_generated_/`) into the source tree and leaving every
+        // source file untouched — rather than copying the whole tree into
+        // `.streamlib/cache/packages/`. The installed / registry / `.slpkg`
+        // arms keep their detached cache slot via `staging_slot_for_dir`; a
+        // locked run pins `NeverBuild` and so never reaches this branch.
         Ok(ResolvedSource::NeedsBuild(BuildRequest {
             package: pkg_ref.clone(),
-            source: BuildSource::PackageDir(dir),
+            source: BuildSource::PackageDir(dir.clone()),
             source_provenance: provenance,
             policy: build,
             host_triple: host_target_triple().to_string(),
-            staging_destination_slot_dir,
+            staging_destination_slot_dir: dir,
         }))
     } else {
         Ok(ResolvedSource::Ready(dir))
@@ -1987,6 +1995,109 @@ mod tests {
                 !registry_slot_holds_selected_version(policy, dir.path(), selected),
                 "{policy:?} must not reuse the materialized slot"
             );
+        }
+    }
+
+    // =====================================================================
+    // #1521 — a dev source (`Strategy::Path` / `Strategy::Git` / a link
+    // override) builds IN-TREE beside its source: the injected staging
+    // destination IS the source dir, so the orchestrator's in-place promote
+    // lands only the regenerated outputs and never copies the tree into
+    // `.streamlib/cache/packages/`. Installed / registry / `.slpkg` arms keep
+    // their detached cache slot; a locked run (NeverBuild) never gets here.
+    // =====================================================================
+
+    /// CRUX (bug-reproduce): a `Strategy::Path` source that needs the
+    /// orchestrator stages IN-TREE — `staging_destination_slot_dir` equals the
+    /// source dir itself, AND the build source equals it (the
+    /// `canonical(src) == canonical(dest)` case the in-place promote handles).
+    /// Mentally revert `source_for_dir` to `staging_slot_for_dir` and the
+    /// destination becomes a detached `.streamlib/cache/packages/` slot,
+    /// failing both equalities.
+    #[test]
+    fn path_strategy_stages_in_tree_beside_source() {
+        let dir = tempfile::tempdir().unwrap();
+        manifest(dir.path(), RUST_YAML);
+        std::fs::write(dir.path().join("Cargo.toml"), b"[package]\nname='rp'\n").unwrap();
+        let resolved = resolve_strategy_to_source(
+            &Strategy::Path {
+                path: dir.path().to_path_buf(),
+                build: BuildPolicy::IfStale,
+            },
+            &pkg_ref(),
+            None,
+        )
+        .expect("path source must resolve");
+        match resolved {
+            ResolvedSource::NeedsBuild(req) => {
+                assert_eq!(
+                    req.staging_destination_slot_dir.as_path(),
+                    dir.path(),
+                    "a dev Path source must stage in-tree beside its source"
+                );
+                match req.source {
+                    BuildSource::PackageDir(src) => assert_eq!(
+                        src.as_path(),
+                        dir.path(),
+                        "in-place staging requires source == destination"
+                    ),
+                    other => panic!("expected PackageDir source, got {other:?}"),
+                }
+            }
+            other => panic!("expected NeedsBuild, got {other:?}"),
+        }
+    }
+
+    /// A `NeverBuild` Path source (the locked-run posture) resolves to `Ready`
+    /// with NO build request — so a locked run never takes the in-place staging
+    /// path. Mentally revert the `requires_orchestrator` gate and this would
+    /// emit a build request against the source dir.
+    #[test]
+    fn path_strategy_never_build_is_ready_no_in_tree_stage() {
+        let dir = tempfile::tempdir().unwrap();
+        manifest(dir.path(), RUST_YAML);
+        std::fs::write(dir.path().join("Cargo.toml"), b"[package]\nname='rp'\n").unwrap();
+        let resolved = resolve_strategy_to_source(
+            &Strategy::Path {
+                path: dir.path().to_path_buf(),
+                build: BuildPolicy::NeverBuild,
+            },
+            &pkg_ref(),
+            None,
+        )
+        .expect("path source must resolve");
+        assert!(
+            matches!(resolved, ResolvedSource::Ready(_)),
+            "NeverBuild must load as-is, never emit an in-tree build request, got {resolved:?}"
+        );
+    }
+
+    /// A `streamlib link` override resolves the checkout package and — like a
+    /// `Strategy::Path` — stages IN-TREE beside the checkout source
+    /// (`staging_destination_slot_dir` == the checkout package dir), so the
+    /// link edit loop never copies into the package cache.
+    #[test]
+    fn active_link_stages_in_tree_beside_checkout_source() {
+        let checkout = fake_checkout_with_package("foo", "foo");
+        let consumer = tempfile::tempdir().unwrap();
+        let link = active_link_for(consumer.path(), checkout.path());
+
+        let resolved = resolve_strategy_to_source(
+            &Strategy::Registry {
+                version_req: SemVerRange::Any,
+                build: BuildPolicy::IfStale,
+            },
+            &pkg_ref_named("foo"),
+            Some(&link),
+        )
+        .expect("linked package must resolve from the checkout");
+        let expected = checkout.path().join("packages").join("foo");
+        match resolved {
+            ResolvedSource::NeedsBuild(req) => assert_eq!(
+                req.staging_destination_slot_dir, expected,
+                "a linked source must stage in-tree beside its checkout source"
+            ),
+            other => panic!("expected NeedsBuild(in-tree), got {other:?}"),
         }
     }
 }

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
@@ -561,15 +561,10 @@ fn source_for_dir(
     provenance: PackageSourceProvenance,
 ) -> std::result::Result<ResolvedSource, AddModuleError> {
     if build.requires_orchestrator() {
-        // A dev source (`Strategy::Path` / `Strategy::Git` / a `streamlib link`
-        // override) builds IN-TREE beside its source: the staging destination
-        // IS the source dir itself, so the orchestrator takes its in-place
-        // promote — landing ONLY the regenerated build outputs (`lib/<triple>/`,
-        // `.venv/`, `_generated_/`) into the source tree and leaving every
-        // source file untouched — rather than copying the whole tree into
-        // `.streamlib/cache/packages/`. The installed / registry / `.slpkg`
-        // arms keep their detached cache slot via `staging_slot_for_dir`; a
-        // locked run pins `NeverBuild` and so never reaches this branch.
+        // A dev source builds IN-TREE beside its source: the staging destination
+        // IS the source dir, so the orchestrator's in-place promote lands only
+        // the regenerated build outputs there instead of copying the whole tree
+        // into the package cache.
         Ok(ResolvedSource::NeedsBuild(BuildRequest {
             package: pkg_ref.clone(),
             source: BuildSource::PackageDir(dir.clone()),

--- a/tools/streamlib-build-orchestrator/src/lib.rs
+++ b/tools/streamlib-build-orchestrator/src/lib.rs
@@ -435,6 +435,7 @@ impl PolyglotBuildOrchestrator {
                 triple,
                 self.profile,
                 &fingerprint,
+                source_is_mutable,
             )
             .map_err(|e| other(&pkg_label, format!("promoting build outputs in place: {e}")))?;
             let _ = std::fs::remove_dir_all(&temp_dir);
@@ -695,15 +696,11 @@ fn destination_is_source_dir(destination: &Path, pkg_dir: &Path) -> bool {
     streamlib_pack::is_same_existing_file(destination, pkg_dir)
 }
 
-/// Ensure the package's own `.gitignore` (beside its source) excludes the
-/// in-tree build outputs an in-place promote lands: the host-triple cdylib dir,
-/// the provisioned Python venv, the regenerated Deno wire vocabulary, and the
-/// build completion marker. A dev source (`Strategy::Path` / `Strategy::Git` /
-/// a link checkout) is the user's own git tree, so these must not show as
-/// untracked. Idempotent: only entries not already present are appended, so
-/// repeated builds — and additional host triples, each with its own
-/// `lib/<triple>/` line — accumulate without duplication. `_generated_/` is NOT
-/// globally ignored for an external Path source, so it is listed here too.
+/// Append the in-tree build-output ignore lines (host-triple cdylib dir, venv,
+/// generated wire vocabulary, completion marker) to a mutable dev checkout's own
+/// `.gitignore` so they never show as untracked. Idempotent: only absent lines
+/// are appended, so repeated builds and additional host triples accumulate
+/// without duplication.
 fn ensure_build_outputs_gitignored(destination: &Path, triple: &str) -> anyhow::Result<()> {
     use anyhow::Context;
     use std::collections::HashSet;
@@ -740,7 +737,10 @@ fn ensure_build_outputs_gitignored(destination: &Path, triple: &str) -> anyhow::
 
 /// Promote ONLY the regenerated build-output units from the staging temp dir
 /// into a destination that IS the package's own source dir, leaving every
-/// source file untouched.
+/// source file untouched — except the beside-source `.gitignore`, which is the
+/// one intentional source-file write: for a mutable dev checkout
+/// (`source_is_mutable`) it is created/updated to keep the promoted outputs out
+/// of git. An immutable managed extract (a git-rev-pinned clone) skips even that.
 ///
 /// The publish is atomic at the completion-marker granularity. Each output unit
 /// lands via [`atomic_swap`] (rename the prior unit AWAY to a `.old-*` sibling,
@@ -760,20 +760,22 @@ fn promote_build_outputs_in_place(
     triple: &str,
     profile: build::CargoProfile,
     inputs_hash: &str,
+    source_is_mutable: bool,
 ) -> anyhow::Result<()> {
     use anyhow::Context;
 
-    // The destination IS the user's own git tree (a `Strategy::Path` source or a
-    // link checkout), so keep the regenerated build outputs out of git — without
-    // this they surface as untracked noise on every dev build. Best-effort: a
-    // `.gitignore` is hygiene, never a correctness gate, so a write failure is
-    // logged and the build proceeds rather than aborting.
-    if let Err(e) = ensure_build_outputs_gitignored(destination, triple) {
-        tracing::warn!(
-            dir = %destination.display(),
-            error = %e,
-            "could not gitignore in-tree build outputs; build outputs may show as untracked"
-        );
+    // Only a mutable dev checkout is the user's own git tree; a disposable
+    // rev-pinned managed clone the user never sees carries its own ignore rules,
+    // so writing into it is pointless churn. Best-effort: a `.gitignore` is
+    // hygiene, never a correctness gate, so a write failure is logged.
+    if source_is_mutable {
+        if let Err(e) = ensure_build_outputs_gitignored(destination, triple) {
+            tracing::warn!(
+                dir = %destination.display(),
+                error = %e,
+                "could not gitignore in-tree build outputs; build outputs may show as untracked"
+            );
+        }
     }
 
     // Invalidate the completion marker before touching any output unit: until
@@ -1169,6 +1171,7 @@ mod tests {
             triple,
             build::CargoProfile::Dev,
             "new-fingerprint",
+            true,
         )
         .unwrap();
 
@@ -1221,7 +1224,7 @@ mod tests {
         let temp = root.path().join(".tmp-pkg");
         std::fs::create_dir_all(&temp).unwrap();
 
-        promote_build_outputs_in_place(&temp, &dest, triple, build::CargoProfile::Dev, "fp")
+        promote_build_outputs_in_place(&temp, &dest, triple, build::CargoProfile::Dev, "fp", true)
             .unwrap();
 
         assert!(!dest.join("lib").exists(), "no lib/ unit to promote");
@@ -1261,6 +1264,7 @@ mod tests {
             triple,
             build::CargoProfile::Dev,
             "new",
+            true,
         )
         .expect_err("promote must fail when a unit cannot be swapped into place");
         let _ = err;
@@ -1318,6 +1322,7 @@ mod tests {
             triple,
             build::CargoProfile::Dev,
             "new",
+            true,
         )
         .expect_err("promote must fail when a later unit cannot be published");
         let _ = err;
@@ -1411,6 +1416,7 @@ mod tests {
             triple,
             build::CargoProfile::Dev,
             "fp",
+            true,
         )
         .unwrap();
 
@@ -1421,6 +1427,40 @@ mod tests {
             std::fs::read(dest.path().join("streamlib.yaml")).unwrap(),
             b"package: src",
             "source must be untouched"
+        );
+    }
+
+    /// An immutable managed extract (a disposable rev-pinned git clone,
+    /// `source_is_mutable == false`) gets its build outputs promoted in-tree but
+    /// NO `.gitignore` write — the clone is not the user's tree. Mentally-revert
+    /// the `source_is_mutable` guard and a stray `.gitignore` appears here.
+    #[test]
+    fn promote_build_outputs_in_place_skips_gitignore_for_immutable_extract() {
+        let temp = tempfile::tempdir().unwrap();
+        let dest = tempfile::tempdir().unwrap();
+        let triple = build::host_target_triple();
+        let lib = temp.path().join("lib").join(triple);
+        std::fs::create_dir_all(&lib).unwrap();
+        std::fs::write(lib.join("libpkg.so"), b"cdylib").unwrap();
+        std::fs::write(dest.path().join("streamlib.yaml"), b"package: src").unwrap();
+
+        promote_build_outputs_in_place(
+            temp.path(),
+            dest.path(),
+            triple,
+            build::CargoProfile::Dev,
+            "fp",
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            !dest.path().join(".gitignore").exists(),
+            "an immutable managed extract must not get a beside-source .gitignore"
+        );
+        assert!(
+            dest.path().join("lib").join(triple).join("libpkg.so").is_file(),
+            "the build output is still promoted in-tree for an immutable extract"
         );
     }
 
@@ -1591,6 +1631,50 @@ mod tests {
         assert!(
             restaged.contains("2048"),
             "edited schema must be re-staged into the cache, got: {restaged}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn in_place_materialize_reuses_despite_the_engine_written_gitignore() {
+        // A dev source builds IN-PLACE (staging destination IS the source dir),
+        // so the promote writes a beside-source `.gitignore`. That engine write
+        // must NOT perturb the reuse fingerprint: a second unchanged in-place
+        // materialize must reuse. Mentally-revert the `.gitignore` exclusion from
+        // the source fingerprint and the sidecar hash (recorded before the
+        // `.gitignore` existed) diverges from a recompute that now sees it, so
+        // the skip is missed and the source needlessly re-materializes.
+        let _home = HomeGuard::new();
+        let src = tempfile::tempdir().unwrap();
+        schemas_only_pkg(src.path());
+
+        // Destination IS the source dir → the in-place promote path.
+        let mut req = request(src.path(), BuildPolicy::IfStale);
+        req.staging_destination_slot_dir = src.path().to_path_buf();
+
+        let orch = PolyglotBuildOrchestrator::default();
+        let first = orch.materialize(&req, &NoopSink).unwrap();
+        assert_eq!(first.staged_dir, src.path());
+        assert!(
+            src.path().join(".gitignore").is_file(),
+            "in-place promote of a mutable source must write the beside-source .gitignore"
+        );
+
+        // The sidecar hash was recorded BEFORE the `.gitignore` write; a recompute
+        // now sees the `.gitignore` on disk. They must still agree — proving the
+        // engine-written ignore file is fingerprint-neutral.
+        let side = read_sidecar(src.path()).expect("first in-place build writes a sidecar");
+        let recomputed = compute_inputs_hash(src.path()).unwrap();
+        assert_eq!(
+            side.inputs_hash, recomputed,
+            "the engine-written .gitignore must not perturb the reuse fingerprint"
+        );
+
+        let second = orch.materialize(&req, &NoopSink).unwrap();
+        assert_eq!(second.staged_dir, src.path());
+        assert!(
+            !second.rebuilt,
+            "an unchanged second in-place materialize must reuse, not rebuild"
         );
     }
 

--- a/tools/streamlib-build-orchestrator/src/lib.rs
+++ b/tools/streamlib-build-orchestrator/src/lib.rs
@@ -695,6 +695,49 @@ fn destination_is_source_dir(destination: &Path, pkg_dir: &Path) -> bool {
     streamlib_pack::is_same_existing_file(destination, pkg_dir)
 }
 
+/// Ensure the package's own `.gitignore` (beside its source) excludes the
+/// in-tree build outputs an in-place promote lands: the host-triple cdylib dir,
+/// the provisioned Python venv, the regenerated Deno wire vocabulary, and the
+/// build completion marker. A dev source (`Strategy::Path` / `Strategy::Git` /
+/// a link checkout) is the user's own git tree, so these must not show as
+/// untracked. Idempotent: only entries not already present are appended, so
+/// repeated builds — and additional host triples, each with its own
+/// `lib/<triple>/` line — accumulate without duplication. `_generated_/` is NOT
+/// globally ignored for an external Path source, so it is listed here too.
+fn ensure_build_outputs_gitignored(destination: &Path, triple: &str) -> anyhow::Result<()> {
+    use anyhow::Context;
+    use std::collections::HashSet;
+
+    let required = [
+        format!("/lib/{triple}/"),
+        "/.venv/".to_string(),
+        "/_generated_/".to_string(),
+        format!("/{SIDECAR_NAME}"),
+    ];
+    let gitignore = destination.join(".gitignore");
+    let existing = std::fs::read_to_string(&gitignore).unwrap_or_default();
+    let present: HashSet<&str> = existing.lines().map(str::trim).collect();
+
+    let missing: Vec<&str> = required
+        .iter()
+        .map(String::as_str)
+        .filter(|line| !present.contains(*line))
+        .collect();
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let mut out = existing;
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    for line in missing {
+        out.push_str(line);
+        out.push('\n');
+    }
+    std::fs::write(&gitignore, out).with_context(|| format!("writing {}", gitignore.display()))
+}
+
 /// Promote ONLY the regenerated build-output units from the staging temp dir
 /// into a destination that IS the package's own source dir, leaving every
 /// source file untouched.
@@ -719,6 +762,19 @@ fn promote_build_outputs_in_place(
     inputs_hash: &str,
 ) -> anyhow::Result<()> {
     use anyhow::Context;
+
+    // The destination IS the user's own git tree (a `Strategy::Path` source or a
+    // link checkout), so keep the regenerated build outputs out of git — without
+    // this they surface as untracked noise on every dev build. Best-effort: a
+    // `.gitignore` is hygiene, never a correctness gate, so a write failure is
+    // logged and the build proceeds rather than aborting.
+    if let Err(e) = ensure_build_outputs_gitignored(destination, triple) {
+        tracing::warn!(
+            dir = %destination.display(),
+            error = %e,
+            "could not gitignore in-tree build outputs; build outputs may show as untracked"
+        );
+    }
 
     // Invalidate the completion marker before touching any output unit: until
     // the final marker flip, the slot must read as needing a rebuild.
@@ -1287,22 +1343,84 @@ mod tests {
         );
     }
 
+    /// A fresh in-tree destination gets a `.gitignore` covering every promoted
+    /// build-output unit plus the completion marker, so a dev source's build
+    /// outputs never show as untracked git noise. Mentally drop any required
+    /// line and the corresponding `contains` assertion fails.
     #[test]
-    #[serial]
-    fn production_injected_destination_is_never_the_source_dir() {
-        // Unreachability guard: the engine-injected staging destination for a
-        // normal build is a distinct cache slot, so the in-place promote branch
-        // ships dark (detached path taken) until the #1506 flip co-locates the
-        // slot onto the source. If a future change starts injecting the source
-        // dir as the destination, this flips and the in-place branch goes live.
-        let _home = HomeGuard::new();
-        let src = tempfile::tempdir().unwrap();
-        schemas_only_pkg(src.path());
-        let req = request(src.path(), BuildPolicy::IfStale);
+    fn ensure_build_outputs_gitignored_writes_all_units() {
+        let dest = tempfile::tempdir().unwrap();
+        let triple = "x86_64-unknown-linux-gnu";
+        ensure_build_outputs_gitignored(dest.path(), triple).unwrap();
+        let body = std::fs::read_to_string(dest.path().join(".gitignore")).unwrap();
+        assert!(body.contains(&format!("/lib/{triple}/")), "{body}");
+        assert!(body.contains("/.venv/"), "{body}");
+        assert!(body.contains("/_generated_/"), "{body}");
+        assert!(body.contains(&format!("/{SIDECAR_NAME}")), "{body}");
+    }
+
+    /// Idempotent + additive: a second call for the SAME triple adds nothing
+    /// (no duplicate lines), a call for a DIFFERENT triple appends only its own
+    /// `lib/<triple>/` line, and a pre-existing user entry is preserved.
+    #[test]
+    fn ensure_build_outputs_gitignored_is_idempotent_and_preserves_user_entries() {
+        let dest = tempfile::tempdir().unwrap();
+        std::fs::write(dest.path().join(".gitignore"), "node_modules/\n").unwrap();
+        let triple_a = "x86_64-unknown-linux-gnu";
+        let triple_b = "aarch64-apple-darwin";
+
+        ensure_build_outputs_gitignored(dest.path(), triple_a).unwrap();
+        ensure_build_outputs_gitignored(dest.path(), triple_a).unwrap();
+        let after_a = std::fs::read_to_string(dest.path().join(".gitignore")).unwrap();
+        assert_eq!(
+            after_a.matches(&format!("/lib/{triple_a}/")).count(),
+            1,
+            "a repeated same-triple call must not duplicate a line: {after_a}"
+        );
         assert!(
-            !destination_is_source_dir(&req.staging_destination_slot_dir, src.path()),
-            "today's injected destination must be detached from the source dir — \
-             the in-place promote branch is unreachable in production pre-flip"
+            after_a.contains("node_modules/"),
+            "a pre-existing user entry must be preserved: {after_a}"
+        );
+
+        ensure_build_outputs_gitignored(dest.path(), triple_b).unwrap();
+        let after_b = std::fs::read_to_string(dest.path().join(".gitignore")).unwrap();
+        assert!(after_b.contains(&format!("/lib/{triple_a}/")), "{after_b}");
+        assert!(after_b.contains(&format!("/lib/{triple_b}/")), "{after_b}");
+        assert_eq!(
+            after_b.matches("/.venv/").count(),
+            1,
+            "the venv entry must not be re-appended for a second triple: {after_b}"
+        );
+    }
+
+    /// The in-place promote writes the `.gitignore` alongside the promoted
+    /// units — proving the source-tree keeps its build outputs out of git.
+    #[test]
+    fn promote_build_outputs_in_place_gitignores_the_outputs() {
+        let temp = tempfile::tempdir().unwrap();
+        let dest = tempfile::tempdir().unwrap();
+        let triple = build::host_target_triple();
+        let lib = temp.path().join("lib").join(triple);
+        std::fs::create_dir_all(&lib).unwrap();
+        std::fs::write(lib.join("libpkg.so"), b"cdylib").unwrap();
+        std::fs::write(dest.path().join("streamlib.yaml"), b"package: src").unwrap();
+
+        promote_build_outputs_in_place(
+            temp.path(),
+            dest.path(),
+            triple,
+            build::CargoProfile::Dev,
+            "fp",
+        )
+        .unwrap();
+
+        let body = std::fs::read_to_string(dest.path().join(".gitignore")).unwrap();
+        assert!(body.contains(&format!("/lib/{triple}/")), "{body}");
+        assert!(body.contains(&format!("/{SIDECAR_NAME}")), "{body}");
+        assert_eq!(
+            std::fs::read(dest.path().join("streamlib.yaml")).unwrap(),
+            b"package: src",
+            "source must be untouched"
         );
     }
 

--- a/tools/streamlib-pack/src/lib.rs
+++ b/tools/streamlib-pack/src/lib.rs
@@ -964,6 +964,11 @@ fn cargo_path_dep_names(doc: &toml::Value) -> Vec<String> {
 /// `<pkg>/_generated_/`): a build artifact regenerated per-consumer at
 /// install time from the package's schemas, never shipped as source.
 ///
+/// `.gitignore` is excluded because the engine WRITES it beside an
+/// in-tree dev source (the in-place promote appends the build-output
+/// ignore lines); counting it as source would let that engine write
+/// perturb the reuse fingerprint and force a needless re-materialize.
+///
 /// `Cargo.lock` is stripped too: a streamlib package is a cdylib *library*,
 /// and a library's lockfile is neither published nor honored by a downstream
 /// build. Shipping it is actively harmful in the registry model — the lock
@@ -978,6 +983,7 @@ pub fn is_non_source_artifact(name: &std::ffi::OsStr) -> bool {
             "target"
             | "lib"
             | ".git"
+            | ".gitignore"
             | "node_modules"
             | "__pycache__"
             | "_generated_"


### PR DESCRIPTION
Closes #1521

## Summary

Last precursor before the #1522 flip. Routes `Strategy::Path` / `Strategy::Git` / link-resolved
dev sources to build **in-tree beside their source** instead of copying the whole tree into
`.streamlib/cache/packages/`, activating the atomic in-place promote landed in #1520
(destination == source).

- `source_for_dir` now injects the source dir itself as `staging_destination_slot_dir` for
  Path/Git/link-resolved sources; installed/registry/`.slpkg` flavors keep their detached cache
  slot via `staging_slot_for_dir`. A locked run pins `NeverBuild` and never reaches this branch.
- `ensure_build_outputs_gitignored` writes a beside-source `.gitignore` for `lib/<triple>/`,
  `.venv/`, `.streamlib-build.json` (`_generated_/` is not globally ignored for an external Path
  source, so it's listed here too) — idempotent + additive, best-effort (a write failure is
  logged, never a build gate). The write is scoped to mutable dev checkouts
  (`source_is_mutable`); an immutable `Strategy::Git` managed extract is a disposable rev-pinned
  clone the user never sees and already carries its own ignore rules, so it's exempted.
- `.gitignore` is folded into the shared `is_non_source_artifact` predicate so the fingerprint
  (`compute_inputs_hash`) is `.gitignore`-neutral — a second unchanged in-place load now skips
  `.gitignore`'s own presence when hashing, so an unchanged dev source invokes zero cargo/venv
  re-provision.
- Retires the `production_injected_destination_is_never_the_source_dir` guard: its pre-flip
  premise ("in-place promote unreachable") is exactly what this ticket flips.

## Test evidence

Local, unit-level (this is a value-handoff path — no locked/installed cross-process reader
re-derives dev-source paths, so live dev-loop proof is deferred to the #1522 flip's
`/verify-live`, per the ticket's own "Needs /verify-live: no" note):

```
$ cargo test -p streamlib-build-orchestrator -p streamlib-pack --lib
test result: ok. 63 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo test -p streamlib-engine --lib core::runtime::module_loader::source::
test result: ok. 71 passed; 0 failed; 0 ignored; 1772 filtered out
```

Covers: double in-place materialize (reuse / zero-cargo skip), immutable `Strategy::Git` extract
gets no `.gitignore`, crash-between-units atomicity (inherited from #1520), and the relocated
`production_injected_destination_is_never_the_source_dir` dark-guard test now living at the
engine layer.

## Review items (non-blocking)

- **info** `tools/streamlib-pack/src/lib.rs:986` — Fix 1 adds `.gitignore` to
  `is_non_source_artifact`, which is the shared predicate used by BOTH `compute_inputs_hash`
  (fingerprint) AND `collect_source_tree` (slpkg source packing) — so the change also excludes
  `.gitignore` from packed slpkg source, a side-effect beyond the stated fingerprint purpose.
  Evidence: `is_non_source_artifact` is called at orchestrator `lib.rs:580` (fingerprint) and pack
  `lib.rs:1009` (`collect_source_tree`). The `a9b7ae72` commit message only cites the fingerprint
  reuse rationale. Suggested next step: none required — excluding `.gitignore` from a distributed
  slpkg is correct and consistent, and fixing it at the shared "not-source" predicate is the right
  engine-layer placement. Optionally note the pack-copy side-effect in the PR body (noted here).
- **info** `tools/streamlib-build-orchestrator/src/lib.rs:737` — `ensure_build_outputs_gitignored`
  still writes `/_generated_/` into the beside-source `.gitignore` even though the ticket scope
  says `_generated_/` is already globally ignored. Evidence: the pre-fix-2 doc comment explained
  `_generated_/` is NOT globally ignored for an external Path source; fix 2 trimmed the comment but
  kept the `/_generated_/` line. Behavior is unchanged and correct for out-of-monorepo Path
  sources. Suggested next step: no action; intentional and behavior-preserving.

## Notes for the owner

- Blocked by / lands atop #1520 (merged) and #1534 (atomic in-place promote).
- Unblocks #1522, the flip itself — that PR is where `/verify-live` proves the live edit → rebuild
  dev loop end-to-end.
---
**DX / behavior notes (from review):**
- On the first build of a **mutable** dev package (Strategy::Path / active `link` — `MutableUserCheckout`), the engine writes/updates a beside-source `.gitignore` (`/lib/<triple>/`, `/.venv/`, `/_generated_/`, `/.streamlib-build.json`) to keep build output out of git noise. This is a deliberate, accepted trade — the engine touches one user-tracked file; the alternative is untracked build-output noise. Bounded per-triple line append (cross-machine).
- `Strategy::Git` immutable managed clones build in-tree but are **not** gitignored (disposable, user never sees them).
- `.gitignore` is excluded from the reuse fingerprint (so an unchanged reload does zero work) AND from packed slpkg source — both via the shared `is_non_source_artifact` predicate.