### PR TITLE
feat(engine): flip installed-package slot to co-located streamlib_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,12 +77,14 @@ examples/camera-python-display/assets/*
 .envrc
 .cargo/config.toml
 
-# Co-located package build output (compile-on-install): the compiled cdylib
-# and build-provenance sidecar live beside a package's source, inside its
-# `streamlib_modules/@org/name/` slot — regenerable artifacts, never committed.
+# Co-located package slots (compile-on-install): `streamlib add` / `install`
+# materialize package sources and their build output (compiled cdylib, venv,
+# build-provenance sidecar) into `streamlib_modules/@org/name/`. In THIS repo
+# that tree is only ever regenerable app/test scratch — a real consumer app
+# owns its own tree in its own repo — so ignore it wholesale here.
 # (`.venv/`, `target/`, `_generated_/` are already ignored above/below.)
 .streamlib-build.json
-streamlib_modules/**/lib/
+streamlib_modules/
 
 plan.md
 

--- a/docs/architecture/package-development-model.md
+++ b/docs/architecture/package-development-model.md
@@ -420,8 +420,9 @@ refuses on mismatch (`LockedSlotContentMismatch`), closing the
 tampered / republished-in-place hole. Slot paths are re-derived by the shared
 `installed_package_slot_dir` helper
 ([`runtime/streamlib-engine/src/core/streamlib_home.rs`](../../runtime/streamlib-engine/src/core/streamlib_home.rs)) —
-the single `cache/packages/{name}-{version}` convention also used by `.slpkg`
-extraction, registry resolution, and orchestrator staging.
+the single co-located, version-free `<app-root>/streamlib_modules/@org/name`
+convention also used by `.slpkg` extraction, registry resolution, and
+orchestrator staging.
 
 **Three lockfiles, three lifecycles.** All serialize the same `Lockfile` wire
 shape ([`sdk/streamlib-idents/src/lockfile.rs`](../../sdk/streamlib-idents/src/lockfile.rs))

--- a/docs/architecture/runtime-module-materialization.md
+++ b/docs/architecture/runtime-module-materialization.md
@@ -56,7 +56,7 @@ deployment chooses to wire (or not).
         │              pyproject + uv.lock) — NO wheel               │
         │     deno   → entrypoint under deno/                        │
         │     always → streamlib.yaml + schemas/                     │
-        │  → <STREAMLIB_HOME>/.streamlib/cache/packages/<name>-<ver>/│
+        │  → <app-root>/streamlib_modules/@org/name/                │
         │    (build-to-temp + atomic rename + .streamlib-build       │
         │     sidecar: abi_version, triple, profile, inputs_hash)    │
         │    — byte-identical to extracting a .slpkg / GitHub install│
@@ -67,13 +67,25 @@ There is ONE materialization path, shared with `streamlib pkg build` and
 with installing from a `.slpkg` / GitHub repo. The orchestrator assembles
 the *complete* artifact (Rust cdylib, full Python source, Deno bundle,
 schemas) via [`streamlib-pack`] and stages it as an extracted directory
-into the package cache — the same `cache/packages/<name>-<version>/`
+into the installed slot — the same `<app-root>/streamlib_modules/@org/name`
 location an extracted `.slpkg` lands in. Because dev, release, and
 install-from-anywhere produce the identical artifact shape, a package
 that loads in dev cannot silently break when distributed. The shared
 assembly lib is the programmatic equivalent of the manual pack/build/
 install steps, which is also what a future build *daemon* calls through
 the same `BuildOrchestrator` seam.
+
+The installed-package slot is the co-located, version-free
+`<app-root>/streamlib_modules/@org/name` dir — the same tree the module
+loader's app-modules probe reads, and the same slot an extracted `.slpkg`
+/ GitHub install lands in.
+
+> ~~The slot was `<STREAMLIB_HOME>/.streamlib/cache/packages/<name>-<version>/`.~~
+> — Superseded 2026-07-22: installed packages now materialize into the
+> co-located version-free `<app-root>/streamlib_modules/@org/name` slot
+> (a package occupies one `@org/name` dir; the pinned version is enforced
+> against the slot's manifest, not encoded in the path). The legacy
+> `.streamlib/cache/packages/` directory is not yet retired.
 
 **Python ships as source, not a wheel.** A Python processor runs from
 its source dir (`PYTHONPATH = <staged package dir>`), never from a
@@ -114,7 +126,7 @@ comes from:
 
 | Variant | Source | Builds? |
 |---|---|---|
-| `InstalledCache` | `<STREAMLIB_HOME>/.streamlib/cache/packages/…` | only if Rust source + no matching prebuilt |
+| `InstalledCache` | `<app-root>/streamlib_modules/@org/name` (co-located, version-free) | only if Rust source + no matching prebuilt |
 | `Path { path, build }` | a directory with `streamlib.yaml` | per `build` |
 | `Slpkg { path }` | a `.slpkg` archive (engine extracts) | only if Rust source + no matching prebuilt |
 | `Git { url, rev, build }` | a git checkout (engine fetches) | per `build` |
@@ -471,8 +483,8 @@ is a future refinement of the orchestrator.
 ## Profile parity
 
 The orchestrator builds packages with the **host binary's** compiled
-profile (`cfg!(debug_assertions)` → dev, else release). The package cache
-slot (`cache/packages/<name>-<version>/`) is shared with `.slpkg`
+profile (`cfg!(debug_assertions)` → dev, else release). The installed
+slot (`<app-root>/streamlib_modules/@org/name`) is shared with `.slpkg`
 installs, so it is *not* keyed by profile; the `.streamlib-build.json`
 sidecar records the profile, and a profile mismatch is treated as stale
 (re-assemble). This is a consistency / perf-sanity choice, not an ABI
@@ -520,13 +532,13 @@ Engine ↔ plugin stay in lock-step on two complementary layers:
   the committed-load ledger `remove_module` consumes, `mod.rs` = the
   `Runner` API incl. `remove_module`).
 - Default orchestrator: `tools/streamlib-build-orchestrator/` (calls
-  `streamlib-pack` and stages into `cache/packages/<name>-<version>/`).
+  `streamlib-pack` and stages into `<app-root>/streamlib_modules/@org/name`).
 - Shared assembly: `tools/streamlib-pack/` (`assemble_artifact` —
   emits a `.slpkg` for `streamlib pkg build` or an extracted `StagedDir` for
   the orchestrator).
 - Python venv provisioning (the tail of `materialize`: `uv venv` →
   `uv pip install` → `streamlib/_generated_` codegen → `compileall`,
-  produced into the staged `{name}-{version}/.venv` under the
+  produced into the staged `@org/name/.venv` under the
   orchestrator's single fingerprint):
   `tools/streamlib-build-orchestrator/src/python_venv.rs`.
 - SDK wiring: `sdk/streamlib-sdk/` (`auto-build` feature).

--- a/runtime/streamlib-engine/src/core/runtime/install.rs
+++ b/runtime/streamlib-engine/src/core/runtime/install.rs
@@ -175,7 +175,7 @@ pub fn install(
         .unwrap_or_else(|| root_dir.to_path_buf());
 
     for pkg in resolved.iter_all() {
-        let Some((pkg_ref, version)) = package_ref_of(pkg) else {
+        let Some((pkg_ref, _version)) = package_ref_of(pkg) else {
             // Root project with no `[package]` — nothing to materialize.
             continue;
         };
@@ -191,7 +191,6 @@ pub fn install(
             staging_destination_slot_dir: crate::core::installed_package_slot_dir(
                 Some(app_root.as_path()),
                 &pkg_ref,
-                version,
             ),
         };
         let staged = orchestrator.materialize(&request, sink).map_err(|source| {

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/locked.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/locked.rs
@@ -71,7 +71,7 @@ impl LockedResolution {
                     detail,
                 }
             })?;
-            let slot_dir = installed_package_slot_dir(app_root, &pkg_ref, entry.version);
+            let slot_dir = installed_package_slot_dir(app_root, &pkg_ref);
             pins.insert(
                 pkg_ref,
                 LockedPin {
@@ -238,7 +238,7 @@ mod tests {
         // install write and this locked read share (write==read).
         assert_eq!(
             pin.slot_dir,
-            installed_package_slot_dir(lockfile_path.parent(), &pkg, SemVer::new(1, 2, 3))
+            installed_package_slot_dir(lockfile_path.parent(), &pkg)
         );
     }
 

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/locked.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/locked.rs
@@ -53,8 +53,9 @@ pub(crate) struct LockedResolution {
 
 impl LockedResolution {
     /// Build the pin set from a parsed [`Lockfile`]. Each entry's `@org/name`
-    /// key is parsed to a typed [`PackageRef`]; the cache slot is derived by
-    /// the shared `{name}-{version}` convention (where `materialize` stages).
+    /// key is parsed to a typed [`PackageRef`]; the slot is the co-located
+    /// `<app-root>/streamlib_modules/@org/name` dir the seam derives from the
+    /// lockfile's parent (where `materialize` stages).
     pub(crate) fn from_lockfile(
         lockfile: &Lockfile,
         lockfile_path: &Path,
@@ -225,17 +226,19 @@ mod tests {
 
     #[test]
     fn from_lockfile_maps_slot_version_and_hash() {
+        let lockfile_path = Path::new("/app/streamlib.lock");
         let lf = lockfile_with(&[("@tatolab/core", SemVer::new(1, 2, 3), "sha256:aa")]);
-        let locked = LockedResolution::from_lockfile(&lf, Path::new("x.lock")).unwrap();
+        let locked = LockedResolution::from_lockfile(&lf, lockfile_path).unwrap();
         let pkg = PackageRef::new(Org::new("tatolab").unwrap(), Package::new("core").unwrap());
         let pin = locked.pins.get(&pkg).unwrap();
         assert_eq!(pin.version, SemVer::new(1, 2, 3));
         assert_eq!(pin.expected_content_hash, "sha256:aa");
-        // Slot is derived via the shared name-version convention, matching
-        // where `materialize` stages.
+        // The slot is the co-located `<app-root>/streamlib_modules/@org/name`
+        // dir the seam derives from the lockfile's parent — the app root the
+        // install write and this locked read share (write==read).
         assert_eq!(
             pin.slot_dir,
-            installed_package_slot_dir(None, &pkg, SemVer::new(1, 2, 3))
+            installed_package_slot_dir(lockfile_path.parent(), &pkg, SemVer::new(1, 2, 3))
         );
     }
 

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/slpkg.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/slpkg.rs
@@ -47,7 +47,7 @@ pub fn extract_slpkg_to_cache(
     })?;
 
     let pkg_ref = PackageRef::new(package.org.clone(), package.name.clone());
-    let cache_dir = installed_package_slot_dir(app_modules_root, &pkg_ref, package.version);
+    let cache_dir = installed_package_slot_dir(app_modules_root, &pkg_ref);
 
     // Reuse the already-read bytes — extract into the derived cache slot.
     extract_zip_bytes_to_dir(&slpkg_bytes, &cache_dir, slpkg_path)?;

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
@@ -417,7 +417,6 @@ pub(super) fn resolve_strategy_to_source(
             let slot = crate::core::streamlib_home::installed_package_slot_dir(
                 app_modules_root().as_deref(),
                 pkg_ref,
-                selected,
             );
             let extracted = if registry_slot_holds_selected_version(*build, &slot, selected) {
                 tracing::debug!(
@@ -541,19 +540,16 @@ fn source_for_dir(
 }
 
 /// The installed-package slot the orchestrator must stage `dir` into, derived
-/// through the shared seam from the package's on-disk manifest version and the
-/// active app-modules root — the write side of the write==read invariant a
-/// locked run reads back through the same seam.
+/// through the shared seam from the package ref and the active app-modules root
+/// — the write side of the write==read invariant a locked run reads back
+/// through the same seam.
 fn staging_slot_for_dir(
     pkg_ref: &streamlib_idents::PackageRef,
-    dir: &std::path::Path,
-) -> std::result::Result<PathBuf, AddModuleError> {
-    let version = read_version_from_manifest_dir(dir)?;
-    Ok(crate::core::streamlib_home::installed_package_slot_dir(
+) -> PathBuf {
+    crate::core::streamlib_home::installed_package_slot_dir(
         app_modules_root().as_deref(),
         pkg_ref,
-        version,
-    ))
+    )
 }
 
 /// Decide how to load an already-resolved package directory (an extracted
@@ -573,7 +569,7 @@ fn source_for_resolved_dir(
     dir: PathBuf,
 ) -> std::result::Result<ResolvedSource, AddModuleError> {
     if needs_host_build(&dir) || needs_polyglot_provisioning(&dir) {
-        let staging_destination_slot_dir = staging_slot_for_dir(pkg_ref, &dir)?;
+        let staging_destination_slot_dir = staging_slot_for_dir(pkg_ref);
         Ok(ResolvedSource::NeedsBuild(BuildRequest {
             package: pkg_ref.clone(),
             source: BuildSource::PackageDir(dir),
@@ -625,7 +621,7 @@ fn source_for_fetched_slpkg(
             // AlwaysBuild paths — `streamlib add` and `Strategy::Registry`
             // resolve with AlwaysBuild through here.
             if has_buildable_rust_source(&dir) || needs_polyglot_provisioning(&dir) {
-                let staging_destination_slot_dir = staging_slot_for_dir(pkg_ref, &dir)?;
+                let staging_destination_slot_dir = staging_slot_for_dir(pkg_ref);
                 Ok(ResolvedSource::NeedsBuild(BuildRequest {
                     package: pkg_ref.clone(),
                     source: BuildSource::PackageDir(dir),
@@ -930,16 +926,16 @@ fn lookup_installed_cache(
 }
 
 /// Slot directory for an installed-package entry, derived from its typed
-/// `name`/`version` through the [`installed_package_slot_dir`] seam — never
-/// from the persisted `cache_dir` string, so a stored path can never imply a
-/// version that disagrees with the typed key.
+/// `name` through the [`installed_package_slot_dir`] seam — never from the
+/// persisted `cache_dir` string, so a stored path can never imply a slot that
+/// disagrees with the typed key.
 ///
 /// [`installed_package_slot_dir`]: crate::core::streamlib_home::installed_package_slot_dir
 fn installed_entry_slot_dir(
     entry: &crate::core::config::InstalledPackageEntry,
     app_root: Option<&std::path::Path>,
 ) -> PathBuf {
-    crate::core::streamlib_home::installed_package_slot_dir(app_root, &entry.name, entry.version)
+    crate::core::streamlib_home::installed_package_slot_dir(app_root, &entry.name)
 }
 
 /// Read the `[package].version` field from the `streamlib.yaml` at
@@ -1676,7 +1672,6 @@ mod tests {
         let slot = crate::core::streamlib_home::installed_package_slot_dir(
             Some(app_root),
             &pkg_ref_named(name),
-            streamlib_idents::SemVer::new(1, 0, 0),
         );
         std::fs::create_dir_all(&slot).unwrap();
         std::fs::write(
@@ -1894,8 +1889,8 @@ mod tests {
 
         assert_eq!(
             derived,
-            crate::core::streamlib_home::installed_package_slot_dir(None, &pkg_ref(), version),
-            "slot must come from the typed name+version seam"
+            crate::core::streamlib_home::installed_package_slot_dir(None, &pkg_ref()),
+            "slot must come from the typed name seam"
         );
         assert!(
             !derived.to_string_lossy().contains("garbage-999"),

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
@@ -43,13 +43,14 @@ pub use streamlib_idents::SemVerRange;
 /// [`Runner::add_module`]: super::super::Runner::add_module
 #[derive(Debug, Clone)]
 pub enum Strategy {
-    /// The per-app modules folder (`<cwd>/streamlib_modules/@org/name`,
-    /// populated by `streamlib add`) first, then the installed-package cache
-    /// (`<STREAMLIB_HOME>/.streamlib/cache/packages/...`). Never builds a
-    /// package that carries a matching prebuilt. The default for bare
-    /// top-level [`Runner::add_module`] loads (transitive registry-flavored
-    /// deps map to [`Strategy::Registry`] instead).
-    /// Precedence: active `streamlib link` > app modules > installed cache.
+    /// The app's co-located package tree (`<app-root>/streamlib_modules/@org/name`,
+    /// populated by `streamlib add` / `install`). Post-#1506 the installed slot
+    /// IS this tree, so the physically-present folder and an installed-manifest
+    /// record resolve the same dir. Never builds a package that carries a
+    /// matching prebuilt. The default for bare top-level [`Runner::add_module`]
+    /// loads (transitive registry-flavored deps map to [`Strategy::Registry`]
+    /// instead).
+    /// Precedence: active `streamlib link` > the co-located slot.
     ///
     /// [`Runner::add_module`]: super::super::Runner::add_module
     InstalledCache,
@@ -480,46 +481,7 @@ fn resolve_installed_cache_strategy(
     source_for_resolved_dir(pkg_ref, dir)
 }
 
-/// Environment override for the directory that contains the app's
-/// `streamlib_modules/` folder — the GST_PLUGIN_PATH-style default a
-/// daemon/host sets. A runtime override ([`set_app_modules_root_override`])
-/// takes precedence.
-pub(crate) const APP_MODULES_DIR_ENV: &str = "STREAMLIB_MODULES_DIR";
-
-/// Process-wide override for the app-modules root, set via
-/// [`Runner::set_app_modules_dir`]. `None` falls back to the env var, then the
-/// process working directory.
-///
-/// [`Runner::set_app_modules_dir`]: super::super::Runner::set_app_modules_dir
-static APP_MODULES_ROOT_OVERRIDE: std::sync::RwLock<Option<PathBuf>> =
-    std::sync::RwLock::new(None);
-
-/// Tell the module loader which directory contains the app's
-/// `streamlib_modules/` folder for lazy discovery and [`Strategy::InstalledCache`]
-/// resolution. `None` clears the override (back to env / cwd).
-pub(crate) fn set_app_modules_root_override(root: Option<PathBuf>) {
-    *APP_MODULES_ROOT_OVERRIDE
-        .write()
-        .expect("app-modules root override lock poisoned") = root;
-}
-
-/// The app-modules root: the runtime-set override, else the
-/// `STREAMLIB_MODULES_DIR` env var, else the exact process working directory
-/// (no walk-up). `None` only when the cwd is unresolvable and neither override
-/// nor env is set — resolution then proceeds with the installed cache alone.
-pub(crate) fn app_modules_root() -> Option<PathBuf> {
-    if let Some(root) = APP_MODULES_ROOT_OVERRIDE
-        .read()
-        .expect("app-modules root override lock poisoned")
-        .clone()
-    {
-        return Some(root);
-    }
-    if let Some(env) = std::env::var_os(APP_MODULES_DIR_ENV).filter(|env| !env.is_empty()) {
-        return Some(PathBuf::from(env));
-    }
-    std::env::current_dir().ok()
-}
+pub(crate) use crate::core::streamlib_home::{app_modules_root, set_app_modules_root_override};
 
 /// `<app_root>/streamlib_modules/@org/name` when it exists and its manifest
 /// declares `pkg_ref`; `None` otherwise (a present-but-mismatched entry warns
@@ -1702,14 +1664,17 @@ mod tests {
         dir
     }
 
-    /// Record `@tatolab/<name>` in the sandboxed installed cache and create
-    /// its slot on disk. Returns the slot dir. Stages the on-disk Python layout
+    /// Record `@tatolab/<name>` in the installed-package manifest and create
+    /// its co-located slot on disk under `app_root`. Returns the slot dir.
+    /// Post-#1506 the installed slot IS `<app_root>/streamlib_modules/@org/name`
+    /// — the same tree the app-modules probe reads — so the fixture must anchor
+    /// at the app root the resolver is handed. Stages the on-disk Python layout
     /// (`pyproject.toml`) so the slot trips the filesystem provisioning oracle —
     /// the realistic shape an extracted Python `.slpkg` cache slot carries.
-    fn record_installed_cache_package(name: &str) -> PathBuf {
+    fn record_installed_cache_package(app_root: &std::path::Path, name: &str) -> PathBuf {
         use crate::core::config::{InstalledPackageEntry, InstalledPackageManifest};
         let slot = crate::core::streamlib_home::installed_package_slot_dir(
-            None,
+            Some(app_root),
             &pkg_ref_named(name),
             streamlib_idents::SemVer::new(1, 0, 0),
         );
@@ -1754,64 +1719,67 @@ mod tests {
         }
     }
 
-    /// CRUX (D7 bridge): with BOTH an app-modules entry and an installed-cache
-    /// record present, `Strategy::InstalledCache` resolves the app-modules
-    /// dir. Mentally revert the modules probe in
-    /// `resolve_installed_cache_strategy` and this resolves the cache slot
-    /// instead, failing the assertion. (The Python-only fixtures route to
-    /// `NeedsBuild` — see [`resolved_dir`] — so the assertion is on the winning
-    /// dir, not the `Ready`/`NeedsBuild` variant.)
+    /// A co-located package present as both a physical `streamlib_modules/`
+    /// slot and an installed-manifest record resolves to its co-located dir
+    /// under the app root. Post-#1506 the installed-cache slot and the
+    /// app-modules dir are the SAME `<app-root>/streamlib_modules/@org/name`
+    /// tree, so both the physical slot and the recorded entry point here.
+    /// (The Python-only fixture routes to `NeedsBuild` — see [`resolved_dir`] —
+    /// so the assertion is on the resolved dir, not the variant.)
     #[test]
     #[serial_test::serial]
-    fn installed_cache_strategy_prefers_app_modules_dir() {
+    fn installed_cache_strategy_resolves_colocated_app_modules_dir() {
         let home = tempfile::tempdir().unwrap();
         let _guard = sandbox_home(home.path());
-        record_installed_cache_package("foo");
         let app_root = tempfile::tempdir().unwrap();
         let modules_dir = write_app_modules_package(app_root.path(), "foo", "foo");
+        record_installed_cache_package(app_root.path(), "foo");
 
         let resolved =
             resolve_installed_cache_strategy(&pkg_ref_named("foo"), Some(app_root.path()))
                 .expect("must resolve");
-        assert_eq!(
-            resolved_dir(&resolved),
-            modules_dir,
-            "app modules must win over the installed cache"
-        );
+        assert_eq!(resolved_dir(&resolved), modules_dir);
     }
 
-    /// A package absent from `streamlib_modules/` falls through to the
-    /// installed cache unchanged.
+    /// A package recorded in the installed manifest and materialized at its
+    /// co-located slot resolves to that exact slot — the write==read tie between
+    /// the fixture's on-disk slot and the dir the resolver derives from the
+    /// recorded entry through the shared seam.
     #[test]
     #[serial_test::serial]
-    fn installed_cache_strategy_falls_through_when_app_modules_absent() {
+    fn installed_cache_strategy_resolves_recorded_colocated_slot() {
         let home = tempfile::tempdir().unwrap();
         let _guard = sandbox_home(home.path());
-        let slot = record_installed_cache_package("foo");
-        let app_root = tempfile::tempdir().unwrap(); // no streamlib_modules
+        let app_root = tempfile::tempdir().unwrap();
+        let slot = record_installed_cache_package(app_root.path(), "foo");
 
         let resolved =
             resolve_installed_cache_strategy(&pkg_ref_named("foo"), Some(app_root.path()))
-                .expect("must resolve from the installed cache");
+                .expect("must resolve the recorded co-located slot");
         assert_eq!(resolved_dir(&resolved), slot);
     }
 
-    /// A `streamlib_modules/@org/name` dir whose manifest declares a DIFFERENT
-    /// package is skipped (warn + fall through), not loaded.
+    /// A co-located `streamlib_modules/@org/name` dir whose manifest declares a
+    /// DIFFERENT package is not resolved as the requested one; with no matching
+    /// installed-manifest entry, resolution is a typed `ModuleNotFound`.
+    /// Mentally revert the `manifest_declares_package` guard and the wrong
+    /// package's dir would resolve as `foo`.
     #[test]
     #[serial_test::serial]
-    fn installed_cache_strategy_skips_mismatched_app_modules_entry() {
+    fn installed_cache_strategy_rejects_mismatched_colocated_manifest() {
         let home = tempfile::tempdir().unwrap();
         let _guard = sandbox_home(home.path());
-        let slot = record_installed_cache_package("foo");
         let app_root = tempfile::tempdir().unwrap();
-        // Dir named foo, but the manifest declares @tatolab/bar.
+        // Dir named foo, but the manifest declares @tatolab/bar; nothing records
+        // foo in the installed manifest.
         write_app_modules_package(app_root.path(), "foo", "bar");
 
-        let resolved =
-            resolve_installed_cache_strategy(&pkg_ref_named("foo"), Some(app_root.path()))
-                .expect("must fall through to the installed cache");
-        assert_eq!(resolved_dir(&resolved), slot);
+        let err = resolve_installed_cache_strategy(&pkg_ref_named("foo"), Some(app_root.path()))
+            .expect_err("a mismatched co-located manifest must not resolve as foo");
+        assert!(
+            matches!(err, AddModuleError::ModuleNotFound { .. }),
+            "expected ModuleNotFound, got {err:?}"
+        );
     }
 
     /// CRUX (bug path): a Python-only package resolved from the app's
@@ -1997,9 +1965,10 @@ mod tests {
     // #1521 — a dev source (`Strategy::Path` / `Strategy::Git` / a link
     // override) builds IN-TREE beside its source: the injected staging
     // destination IS the source dir, so the orchestrator's in-place promote
-    // lands only the regenerated outputs and never copies the tree into
-    // `.streamlib/cache/packages/`. Installed / registry / `.slpkg` arms keep
-    // their detached cache slot; a locked run (NeverBuild) never gets here.
+    // lands only the regenerated outputs and never copies the tree into a
+    // co-located `streamlib_modules/@org/name` slot. Installed / registry /
+    // `.slpkg` arms keep their co-located slot; a locked run (NeverBuild)
+    // never gets here.
     // =====================================================================
 
     /// CRUX (bug-reproduce): a `Strategy::Path` source that needs the
@@ -2007,7 +1976,7 @@ mod tests {
     /// source dir itself, AND the build source equals it (the
     /// `canonical(src) == canonical(dest)` case the in-place promote handles).
     /// Mentally revert `source_for_dir` to `staging_slot_for_dir` and the
-    /// destination becomes a detached `.streamlib/cache/packages/` slot,
+    /// destination becomes a detached `streamlib_modules/@org/name` slot,
     /// failing both equalities.
     #[test]
     fn path_strategy_stages_in_tree_beside_source() {

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/tests.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/tests.rs
@@ -561,6 +561,25 @@ impl Drop for StreamlibHomeRestore {
     }
 }
 
+/// Pins the process-global app-modules root override to a test app root for the
+/// scope, clearing it on drop. Post-#1506 the installed slot lives under
+/// `<app-root>/streamlib_modules/`, so a locked-run test that hand-stages via
+/// the `None` seam and reads a lockfile from the same dir must anchor both at
+/// one app root — otherwise the seam falls through to the process cwd and the
+/// staged slot and the locked read diverge.
+struct AppModulesRootOverrideGuard;
+impl AppModulesRootOverrideGuard {
+    fn install(app_root: &std::path::Path) -> Self {
+        crate::core::streamlib_home::set_app_modules_root_override(Some(app_root.to_path_buf()));
+        Self
+    }
+}
+impl Drop for AppModulesRootOverrideGuard {
+    fn drop(&mut self) {
+        crate::core::streamlib_home::set_app_modules_root_override(None);
+    }
+}
+
 /// Clears a set of env vars on construction and restores them on drop, so a
 /// test can assert behavior under "no ambient registry config" deterministically
 /// regardless of the developer/CI shell. `#[serial]` makes the env exclusive.
@@ -1068,9 +1087,13 @@ mod add_module_tests {
     use super::*;
     use streamlib_idents::{ModuleIdent, Org, Package, SemVer, SemVerRange};
 
-    /// RAII guard that restores `STREAMLIB_HOME` to its pre-test value on
-    /// drop. Every cache-backed test isolates the installed-package cache
-    /// to a tempdir to keep the host's real cache out of the test surface.
+    /// RAII guard that pins both `STREAMLIB_HOME` and the app-modules root to
+    /// the same tempdir for the test scope, restoring the prior state on drop.
+    /// The installed-package slot lives under `<app-root>/streamlib_modules/`
+    /// (co-location, #1506), so isolating the cache off the host requires
+    /// pinning the app-modules root too — otherwise the seam falls through to
+    /// the process cwd. Both are process-global, so cache-backed tests using
+    /// this guard are `#[serial]`.
     struct HomeGuard {
         home_prev: Option<std::ffi::OsString>,
     }
@@ -1081,12 +1104,14 @@ mod add_module_tests {
             unsafe {
                 std::env::set_var("STREAMLIB_HOME", home_root);
             }
+            crate::core::streamlib_home::set_app_modules_root_override(Some(home_root.to_path_buf()));
             Self { home_prev }
         }
     }
 
     impl Drop for HomeGuard {
         fn drop(&mut self) {
+            crate::core::streamlib_home::set_app_modules_root_override(None);
             unsafe {
                 match self.home_prev.take() {
                     Some(v) => std::env::set_var("STREAMLIB_HOME", v),
@@ -1151,12 +1176,12 @@ mod add_module_tests {
     }
 
     /// Layout-pin canary: the ONE test in this crate that hard-codes the
-    /// `.streamlib/cache/packages/{name}-{version}` installed-cache slot
-    /// literal. Every other fixture derives its slot through the
+    /// co-located installed-slot literal — `<app-root>/streamlib_modules/@org/name`,
+    /// version-free (#1506). Every other fixture derives its slot through the
     /// [`installed_package_slot_dir`] seam (see `installed_package_slot_for_test`)
-    /// so they track this pin for free — a write==read oracle. The #1506
-    /// co-location relocation that moves the slot under `streamlib_modules/`
-    /// must update THIS assertion and the seam body together; nothing else.
+    /// so they track this pin for free — a write==read oracle. A relocation
+    /// that moves the slot again must update THIS assertion and the seam body
+    /// together; nothing else.
     ///
     /// [`installed_package_slot_dir`]: crate::core::installed_package_slot_dir
     #[test]
@@ -1168,11 +1193,13 @@ mod add_module_tests {
             Org::new("tatolab").unwrap(),
             Package::new("canary-pkg").unwrap(),
         );
+        // `None` resolves the app root via the same chain the module loader
+        // uses; the guard pins it to `home`, so the slot lands under it.
         let slot = crate::core::installed_package_slot_dir(None, &pkg_ref, SemVer::new(1, 0, 0));
         assert_eq!(
             slot,
             home.path()
-                .join(".streamlib/cache/packages/canary-pkg-1.0.0"),
+                .join("streamlib_modules/@tatolab/canary-pkg"),
             "installed-cache slot layout drifted from the pinned literal",
         );
     }
@@ -3568,10 +3595,10 @@ processors:
 
     use std::io::Write as _;
 
-    /// Orchestrator that stages a `PackageDir` into the installed-package
-    /// cache slot `cache/packages/<name>-<version>/` — where a locked run
-    /// looks — by copying the resolved source tree. No toolchain: enough to
-    /// prove the resolve→materialize→lock→locked-run handoff with
+    /// Orchestrator that stages a `PackageDir` into the co-located slot the
+    /// install seam injects (`<app-root>/streamlib_modules/@org/name/`) — where
+    /// a locked run looks — by copying the resolved source tree. No toolchain:
+    /// enough to prove the resolve→materialize→lock→locked-run handoff with
     /// schemas-only packages. The real `PolyglotBuildOrchestrator` stages
     /// into the identical slot (plus builds cdylibs / venvs / native hosts).
     struct StageIntoCacheOrchestrator;
@@ -3585,20 +3612,10 @@ processors:
                 BuildSource::PackageDir(d) => d.clone(),
                 other => return Err(BuildError::UnsupportedSource(format!("{other:?}"))),
             };
-            let cfg =
-                crate::core::config::ProjectConfig::load(&src).map_err(|e| BuildError::Other {
-                    package: request.package.to_string(),
-                    detail: e.to_string(),
-                })?;
-            let pkg = cfg.package.as_ref().ok_or_else(|| BuildError::Other {
-                package: request.package.to_string(),
-                detail: "no [package] block".into(),
-            })?;
-            let slot = crate::core::installed_package_slot_dir(
-                None,
-                &streamlib_idents::PackageRef::new(pkg.org.clone(), pkg.name.clone()),
-                pkg.version,
-            );
+            // Honor the co-located slot the install seam injected (#1517) rather
+            // than self-deriving — write==read only holds when the orchestrator
+            // stages into the exact dir the locked read later resolves.
+            let slot = request.staging_destination_slot_dir.clone();
             let _ = std::fs::remove_dir_all(&slot);
             copy_dir_recursive(&src, &slot).map_err(|e| BuildError::Other {
                 package: request.package.to_string(),
@@ -3863,6 +3880,10 @@ processors:
         let _restore = StreamlibHomeRestore(prev_home);
         let _clear = EnvVarsCleared::new(&["STREAMLIB_REGISTRY_URL"]);
 
+        // Stage and read against one app root: the lockfile lives under
+        // `sandbox`, so the co-located slot must too.
+        let _modules_root = AppModulesRootOverrideGuard::install(sandbox.path());
+
         // Hand-stage a package whose manifest declares a dep on `miss-dep`,
         // and a lockfile that pins ONLY the package (stale relative to the
         // manifest graph).
@@ -4032,6 +4053,10 @@ packages:
         let _restore = StreamlibHomeRestore(prev_home);
         let _clear = EnvVarsCleared::new(&["STREAMLIB_REGISTRY_URL"]);
 
+        // Stage and read against one app root: the lockfile lives under
+        // `sandbox`, so the co-located slot must too.
+        let _modules_root = AppModulesRootOverrideGuard::install(sandbox.path());
+
         let (slot, hash) = stage_schemas_only_slot("tamper-pkg", "0.1.0", "TamperPkgSchema");
         let lock = write_single_pin_lockfile(sandbox.path(), "tamper-pkg", "0.1.0", &hash);
 
@@ -4074,16 +4099,20 @@ packages:
         let _restore = StreamlibHomeRestore(prev_home);
         let _clear = EnvVarsCleared::new(&["STREAMLIB_REGISTRY_URL"]);
 
-        // The slot lives at the LOCKED version's key (drift-pkg-1.0.0), but
-        // its manifest inside claims 1.0.1 — an in-place republish that kept
-        // the dir name. Pin the drifted slot's REAL hash so the content gate
-        // passes and the walker's version check is the one that fires.
+        // Stage and read against one app root: the lockfile lives under
+        // `sandbox`, so the co-located slot must too.
+        let _modules_root = AppModulesRootOverrideGuard::install(sandbox.path());
+
+        // The slot lives at the co-located `@org/name` dir, but its manifest
+        // inside claims 1.0.1 while the lock pins 1.0.0 — an in-place republish
+        // that kept the dir. Pin the drifted slot's REAL hash so the content
+        // gate passes and the walker's version check is the one that fires.
         let pkg_ref = streamlib_idents::PackageRef::new(
             streamlib_idents::Org::new("tatolab").unwrap(),
             streamlib_idents::Package::new("drift-pkg").unwrap(),
         );
         let slot = crate::core::installed_package_slot_dir(
-            None,
+            Some(sandbox.path()),
             &pkg_ref,
             "1.0.0".parse().unwrap(),
         );

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/tests.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/tests.rs
@@ -11,20 +11,20 @@ use super::processor_registration::{host_target_triple, list_available_triples};
 use super::*;
 use serial_test::serial;
 
-/// Resolve the installed-package cache slot for `@org/name`@`version` through
-/// the production [`installed_package_slot_dir`] seam, so a fixture writes to
-/// (and an assertion reads) the exact slot a locked run derives — never a
-/// hand-rolled `{name}-{version}` string that could silently drift from the
-/// seam. The single place that pins the literal on-disk layout is the
-/// `installed_cache_slot_layout_canary` test.
+/// Resolve the installed-package cache slot for `@org/name` through the
+/// production [`installed_package_slot_dir`] seam, so a fixture writes to (and
+/// an assertion reads) the exact slot a locked run derives — never a
+/// hand-rolled `{name}` string that could silently drift from the seam. The
+/// slot is version-free; the single place that pins the literal on-disk layout
+/// is the `installed_cache_slot_layout_canary` test.
 ///
 /// [`installed_package_slot_dir`]: crate::core::installed_package_slot_dir
-fn installed_package_slot_for_test(org: &str, name: &str, version: &str) -> std::path::PathBuf {
+fn installed_package_slot_for_test(org: &str, name: &str) -> std::path::PathBuf {
     let pkg_ref = streamlib_idents::PackageRef::new(
         streamlib_idents::Org::new(org).unwrap(),
         streamlib_idents::Package::new(name).unwrap(),
     );
-    crate::core::installed_package_slot_dir(None, &pkg_ref, version.parse().unwrap())
+    crate::core::installed_package_slot_dir(None, &pkg_ref)
 }
 
 /// Minimal [`BuildOrchestrator`] for tests: "materializes" a
@@ -756,7 +756,7 @@ fn path_package_registry_dep_routes_to_registry_not_installed_cache() {
 
     // An installed-cache entry for @tatolab/b that WOULD satisfy `^0.1.0` —
     // resolved through the seam so it lands at the real layout.
-    let dep_cache_dir = installed_package_slot_for_test("tatolab", "b", "0.1.0");
+    let dep_cache_dir = installed_package_slot_for_test("tatolab", "b");
     std::fs::create_dir_all(&dep_cache_dir).unwrap();
     std::fs::write(
         dep_cache_dir.join("streamlib.yaml"),
@@ -1152,7 +1152,7 @@ mod add_module_tests {
     /// Install a schemas-only package into the sandboxed installed-package
     /// cache so bare `add_module` (which resolves cache-only) can find it.
     fn install_cached_package(org: &str, name: &str, version: &str, schema: Option<&str>) {
-        let dep_cache_dir = installed_package_slot_for_test(org, name, version);
+        let dep_cache_dir = installed_package_slot_for_test(org, name);
         std::fs::create_dir_all(&dep_cache_dir).unwrap();
         write_schemas_only_manifest(&dep_cache_dir, org, name, version, schema);
 
@@ -1195,7 +1195,7 @@ mod add_module_tests {
         );
         // `None` resolves the app root via the same chain the module loader
         // uses; the guard pins it to `home`, so the slot lands under it.
-        let slot = crate::core::installed_package_slot_dir(None, &pkg_ref, SemVer::new(1, 0, 0));
+        let slot = crate::core::installed_package_slot_dir(None, &pkg_ref);
         assert_eq!(
             slot,
             home.path()
@@ -1263,8 +1263,7 @@ mod add_module_tests {
         // Cache entry keyed @tatolab/add-module-identity but the on-disk
         // manifest declares a different identity (clobbered cache). Resolve
         // through the seam so the fixture tracks the real layout.
-        let dep_cache_dir =
-            installed_package_slot_for_test("tatolab", "add-module-identity", "1.0.0");
+        let dep_cache_dir = installed_package_slot_for_test("tatolab", "add-module-identity");
         std::fs::create_dir_all(&dep_cache_dir).unwrap();
         write_schemas_only_manifest(&dep_cache_dir, "vendor", "other", "1.0.0", None);
         let mut installed = crate::core::config::InstalledPackageManifest::default();
@@ -3887,7 +3886,7 @@ processors:
         // Hand-stage a package whose manifest declares a dep on `miss-dep`,
         // and a lockfile that pins ONLY the package (stale relative to the
         // manifest graph).
-        let slot = installed_package_slot_for_test("tatolab", "miss-pkg", "0.1.0");
+        let slot = installed_package_slot_for_test("tatolab", "miss-pkg");
         std::fs::create_dir_all(slot.join("schemas")).unwrap();
         std::fs::write(
             slot.join("streamlib.yaml"),
@@ -3985,11 +3984,7 @@ packages:
             streamlib_idents::Org::new("tatolab").unwrap(),
             streamlib_idents::Package::new(name).unwrap(),
         );
-        let slot = crate::core::installed_package_slot_dir(
-            None,
-            &pkg_ref,
-            version.parse().unwrap(),
-        );
+        let slot = crate::core::installed_package_slot_dir(None, &pkg_ref);
         let stem = type_name.to_ascii_lowercase();
         std::fs::create_dir_all(slot.join("schemas")).unwrap();
         std::fs::write(
@@ -4111,11 +4106,7 @@ packages:
             streamlib_idents::Org::new("tatolab").unwrap(),
             streamlib_idents::Package::new("drift-pkg").unwrap(),
         );
-        let slot = crate::core::installed_package_slot_dir(
-            Some(sandbox.path()),
-            &pkg_ref,
-            "1.0.0".parse().unwrap(),
-        );
+        let slot = crate::core::installed_package_slot_dir(Some(sandbox.path()), &pkg_ref);
         std::fs::create_dir_all(slot.join("schemas")).unwrap();
         std::fs::write(
             slot.join("streamlib.yaml"),

--- a/runtime/streamlib-engine/src/core/streamlib_home.rs
+++ b/runtime/streamlib-engine/src/core/streamlib_home.rs
@@ -4,7 +4,7 @@
 use std::path::{Path, PathBuf};
 
 use streamlib_idents::app_modules::AppModulesDir;
-use streamlib_idents::{PackageRef, SemVer};
+use streamlib_idents::PackageRef;
 
 /// The streamlib app root — the install / clone directory, the top level
 /// that holds both the read-only `packages/` source and the generated
@@ -169,15 +169,13 @@ pub(crate) fn app_modules_root() -> Option<PathBuf> {
 /// so write and read agree byte-for-byte). `None` resolves the app root via
 /// [`app_modules_root`] (override > `STREAMLIB_MODULES_DIR` > cwd), the same
 /// chain the module loader resolves against — so a `None` deriver lands in the
-/// identical slot a resolved caller does. The slot is version-free by design
-/// (#1506): a package occupies one `@org/name` dir; the pinned version is
-/// enforced against the slot's manifest at the walker, not encoded in the path.
+/// identical slot a resolved caller does. The slot is version-free: a package
+/// occupies one `@org/name` dir; the pinned version is enforced against the
+/// slot's manifest at the walker, not encoded in the path.
 pub fn installed_package_slot_dir(
     explicit_app_modules_root: Option<&Path>,
     pkg_ref: &PackageRef,
-    version: SemVer,
 ) -> PathBuf {
-    let _ = version;
     let app_root = explicit_app_modules_root
         .map(Path::to_path_buf)
         .or_else(app_modules_root)
@@ -223,47 +221,29 @@ mod tests {
     #[test]
     fn slot_dir_is_org_scoped_and_version_free_under_streamlib_modules() {
         let app_root = Path::new("/some/app");
-        let slot = installed_package_slot_dir(
-            Some(app_root),
-            &pkg_ref("tatolab", "core"),
-            SemVer::new(1, 2, 3),
-        );
+        let slot = installed_package_slot_dir(Some(app_root), &pkg_ref("tatolab", "core"));
         let expected = app_root
             .join("streamlib_modules")
             .join("@tatolab")
             .join("core");
         assert_eq!(slot, expected);
-        assert!(
-            !slot.to_string_lossy().contains("1.2.3"),
-            "the version must not appear in the slot path"
-        );
     }
 
     /// write==read distinctness: the app root and the org each move the slot,
     /// so an install writing under one `(app-root, @org)` and a locked read
-    /// under another never collide — while a fixed `(app-root, @org/name)`
-    /// yields one byte-identical slot across versions (version is not in path).
+    /// under another never collide.
     #[test]
     fn slot_dir_moves_with_app_root_and_org() {
         let pkg = pkg_ref("tatolab", "core");
-        let version = SemVer::new(4, 5, 6);
 
-        let app_a = installed_package_slot_dir(Some(Path::new("/app/a")), &pkg, version);
-        let app_b = installed_package_slot_dir(Some(Path::new("/app/b")), &pkg, version);
+        let app_a = installed_package_slot_dir(Some(Path::new("/app/a")), &pkg);
+        let app_b = installed_package_slot_dir(Some(Path::new("/app/b")), &pkg);
         assert_ne!(app_a, app_b, "the app root must move the slot");
 
         // A same-name package under a different org gets a distinct slot.
-        let other_org = installed_package_slot_dir(
-            Some(Path::new("/app/a")),
-            &pkg_ref("acme", "core"),
-            version,
-        );
+        let other_org =
+            installed_package_slot_dir(Some(Path::new("/app/a")), &pkg_ref("acme", "core"));
         assert_ne!(app_a, other_org, "the org must move the slot");
-
-        // The version is not part of the path: two versions share the slot.
-        let bumped =
-            installed_package_slot_dir(Some(Path::new("/app/a")), &pkg, SemVer::new(9, 9, 9));
-        assert_eq!(app_a, bumped, "the version must not move the slot");
     }
 
     #[test]

--- a/runtime/streamlib-engine/src/core/streamlib_home.rs
+++ b/runtime/streamlib-engine/src/core/streamlib_home.rs
@@ -3,6 +3,7 @@
 
 use std::path::{Path, PathBuf};
 
+use streamlib_idents::app_modules::AppModulesDir;
 use streamlib_idents::{PackageRef, SemVer};
 
 /// The streamlib app root — the install / clone directory, the top level
@@ -25,11 +26,12 @@ use streamlib_idents::{PackageRef, SemVer};
 /// ```text
 /// <streamlib-home>/                     ← app root (install / clone)
 /// ├── packages/                         # read-only source (NOT under .streamlib)
+/// ├── streamlib_modules/@org/name/      # installed / built package slots,
+/// │                                     #   co-located under the APP root
+/// │                                     #   (installed_package_slot_dir); each
+/// │                                     #   Python slot carries its own `.venv/`
 /// └── .streamlib/                       # generated working tree — get_streamlib_data_dir()
 ///     ├── cache/
-///     │   ├── packages/                 # built / extracted package artifacts
-///     │   │                             #   (each Python package carries its own
-///     │   │                             #   `.venv/`, provisioned by the orchestrator)
 ///     │   └── uv/                        # uv PyPI cache      (Python packages only)
 ///     ├── logs/<runtime_id>-<ts>.jsonl  # per-runtime JSONL logs
 ///     ├── resolver-cache/               # git / URL checkouts (Strategy::Git / Url)
@@ -37,7 +39,7 @@ use streamlib_idents::{PackageRef, SemVer};
 /// ```
 ///
 /// Each subdir is created on demand by its consumer — an all-Rust,
-/// `Strategy::Path` graph populates `cache/packages/` and `logs/`.
+/// `Strategy::Path` graph populates `streamlib_modules/` and `logs/`.
 pub fn get_streamlib_home() -> PathBuf {
     if let Ok(home) = std::env::var("STREAMLIB_HOME") {
         return PathBuf::from(home);
@@ -115,24 +117,72 @@ pub fn get_cached_package_dir(cache_key: &str) -> PathBuf {
         .join(cache_key)
 }
 
-/// The installed-package cache slot for a package at a version — the single
-/// source of the `{name}-{version}` cache-key convention shared by `.slpkg`
-/// extraction, registry resolution, orchestrator staging, and locked-run slot
-/// derivation. A drift in any one of those sites would make locked runs look
-/// in the wrong slot; route them all through here.
+/// Environment override for the directory that contains the app's
+/// `streamlib_modules/` folder — the GST_PLUGIN_PATH-style default a
+/// daemon/host sets. A runtime override ([`set_app_modules_root_override`])
+/// takes precedence.
+pub(crate) const APP_MODULES_DIR_ENV: &str = "STREAMLIB_MODULES_DIR";
+
+/// Process-wide override for the app-modules root, set via
+/// [`Runner::set_app_modules_dir`]. `None` falls back to the env var, then the
+/// process working directory.
 ///
-/// `app_modules_root` is the app root whose `streamlib_modules/` tree the
-/// in-progress co-location relocation (#1506) will prefer over the shared
-/// cache; it and the package org are threaded now so every deriver already
-/// carries the app context, though this body returns the shared
-/// `.streamlib/cache/packages/{name}-{version}` slot regardless of either.
+/// [`Runner::set_app_modules_dir`]: crate::core::runtime::Runner::set_app_modules_dir
+static APP_MODULES_ROOT_OVERRIDE: std::sync::RwLock<Option<PathBuf>> =
+    std::sync::RwLock::new(None);
+
+/// Tell the module loader which directory contains the app's
+/// `streamlib_modules/` folder for lazy discovery, installed-slot derivation,
+/// and locked-run resolution. `None` clears the override (back to env / cwd).
+pub(crate) fn set_app_modules_root_override(root: Option<PathBuf>) {
+    *APP_MODULES_ROOT_OVERRIDE
+        .write()
+        .expect("app-modules root override lock poisoned") = root;
+}
+
+/// The app-modules root: the runtime-set override, else the
+/// `STREAMLIB_MODULES_DIR` env var, else the exact process working directory
+/// (no walk-up). `None` only when the cwd is unresolvable and neither override
+/// nor env is set — resolution then proceeds with the installed cache alone.
+pub(crate) fn app_modules_root() -> Option<PathBuf> {
+    if let Some(root) = APP_MODULES_ROOT_OVERRIDE
+        .read()
+        .expect("app-modules root override lock poisoned")
+        .clone()
+    {
+        return Some(root);
+    }
+    if let Some(env) = std::env::var_os(APP_MODULES_DIR_ENV).filter(|env| !env.is_empty()) {
+        return Some(PathBuf::from(env));
+    }
+    std::env::current_dir().ok()
+}
+
+/// The installed-package slot for a package — the single source of the
+/// co-located `<app-root>/streamlib_modules/@org/name` convention shared by
+/// `.slpkg` extraction, registry resolution, orchestrator staging, install,
+/// and locked-run slot derivation. A drift in any one of those sites would
+/// make locked runs look in the wrong slot; route them all through here.
+///
+/// `explicit_app_modules_root` pins the app root whose `streamlib_modules/`
+/// tree owns the slot (the install/locked path threads the lockfile's parent
+/// so write and read agree byte-for-byte). `None` resolves the app root via
+/// [`app_modules_root`] (override > `STREAMLIB_MODULES_DIR` > cwd), the same
+/// chain the module loader resolves against — so a `None` deriver lands in the
+/// identical slot a resolved caller does. The slot is version-free by design
+/// (#1506): a package occupies one `@org/name` dir; the pinned version is
+/// enforced against the slot's manifest at the walker, not encoded in the path.
 pub fn installed_package_slot_dir(
-    app_modules_root: Option<&Path>,
+    explicit_app_modules_root: Option<&Path>,
     pkg_ref: &PackageRef,
     version: SemVer,
 ) -> PathBuf {
-    let _ = app_modules_root;
-    get_cached_package_dir(&format!("{}-{}", pkg_ref.name.as_str(), version))
+    let _ = version;
+    let app_root = explicit_app_modules_root
+        .map(Path::to_path_buf)
+        .or_else(app_modules_root)
+        .unwrap_or_else(|| PathBuf::from("."));
+    AppModulesDir::at(app_root).package_dir(pkg_ref)
 }
 
 /// Get the path to a runtime's directory.
@@ -166,41 +216,54 @@ mod tests {
         PackageRef::new(Org::new(org).unwrap(), Package::new(name).unwrap())
     }
 
-    /// Pins the seam's layout literal: the slot is always
-    /// `<data-dir>/cache/packages/{name}-{version}`, regardless of org or the
-    /// (currently unused) app-modules root. A relocation that changes this
-    /// convention must update every deriver and this canary together.
+    /// Pins the seam's layout: an explicit app root scopes the slot to
+    /// `<app-root>/streamlib_modules/@org/name`, version-free. A relocation
+    /// that changes this convention must update every deriver and this canary
+    /// together.
     #[test]
-    fn slot_dir_uses_name_dash_version_under_cache_packages() {
+    fn slot_dir_is_org_scoped_and_version_free_under_streamlib_modules() {
+        let app_root = Path::new("/some/app");
         let slot = installed_package_slot_dir(
-            None,
+            Some(app_root),
             &pkg_ref("tatolab", "core"),
             SemVer::new(1, 2, 3),
         );
-        let expected = get_streamlib_data_dir()
-            .join("cache/packages")
-            .join("core-1.2.3");
+        let expected = app_root
+            .join("streamlib_modules")
+            .join("@tatolab")
+            .join("core");
         assert_eq!(slot, expected);
+        assert!(
+            !slot.to_string_lossy().contains("1.2.3"),
+            "the version must not appear in the slot path"
+        );
     }
 
-    /// write==read invariant: the seam is the single derivation, so a fixed
-    /// `(pkg_ref, version)` yields one byte-identical slot no matter the app
-    /// root — the property that lets a locked read find exactly the slot a
-    /// `.slpkg` extract / registry reuse wrote.
+    /// write==read distinctness: the app root and the org each move the slot,
+    /// so an install writing under one `(app-root, @org)` and a locked read
+    /// under another never collide — while a fixed `(app-root, @org/name)`
+    /// yields one byte-identical slot across versions (version is not in path).
     #[test]
-    fn slot_dir_is_app_root_and_org_invariant() {
+    fn slot_dir_moves_with_app_root_and_org() {
         let pkg = pkg_ref("tatolab", "core");
         let version = SemVer::new(4, 5, 6);
 
-        let no_root = installed_package_slot_dir(None, &pkg, version);
-        let with_root =
-            installed_package_slot_dir(Some(Path::new("/some/app")), &pkg, version);
-        assert_eq!(no_root, with_root, "app root must not move the slot");
+        let app_a = installed_package_slot_dir(Some(Path::new("/app/a")), &pkg, version);
+        let app_b = installed_package_slot_dir(Some(Path::new("/app/b")), &pkg, version);
+        assert_ne!(app_a, app_b, "the app root must move the slot");
 
-        // The org is not part of the current key: a same-name package under a
-        // different org derives the same slot.
-        let other_org = installed_package_slot_dir(None, &pkg_ref("acme", "core"), version);
-        assert_eq!(no_root, other_org);
+        // A same-name package under a different org gets a distinct slot.
+        let other_org = installed_package_slot_dir(
+            Some(Path::new("/app/a")),
+            &pkg_ref("acme", "core"),
+            version,
+        );
+        assert_ne!(app_a, other_org, "the org must move the slot");
+
+        // The version is not part of the path: two versions share the slot.
+        let bumped =
+            installed_package_slot_dir(Some(Path::new("/app/a")), &pkg, SemVer::new(9, 9, 9));
+        assert_eq!(app_a, bumped, "the version must not move the slot");
     }
 
     #[test]

--- a/runtime/streamlib-engine/tests/pack_then_load_smoke.rs
+++ b/runtime/streamlib-engine/tests/pack_then_load_smoke.rs
@@ -39,16 +39,16 @@
 //!   against.
 //!
 //! Cache scope: the `SlpkgArchive` strategy extracts every slpkg into
-//! the process-global installed-package cache slot the
-//! `installed_package_slot_dir` seam derives. This test therefore writes to the *real* jpeg / core
-//! cache entries (at their current package versions) on the host
-//! running the test. The
-//! extract is idempotent (`extract_slpkg_to_cache` clears the dir
-//! before re-extracting) and the package names match the real
-//! workspace packages, so a fresh extract reproduces the same
-//! contents — accepted as low-risk. CI runners are fresh per job; on
-//! developer machines the entries are rebuilt every time the test
-//! runs against the current workspace tree.
+//! the co-located `<app-root>/streamlib_modules/@org/name` slot the
+//! `installed_package_slot_dir` seam derives (app root =
+//! `STREAMLIB_MODULES_DIR` / runtime override / process cwd, version-free).
+//! This test therefore writes to the jpeg / core slots under whichever app
+//! root is active on the host running the test. The extract is idempotent
+//! (`extract_slpkg_to_cache` clears the dir before re-extracting) and the
+//! package names match the real workspace packages, so a fresh extract
+//! reproduces the same contents — accepted as low-risk. CI runners are
+//! fresh per job; on developer machines the slots are rebuilt every time
+//! the test runs against the current workspace tree.
 //!
 //! Companion to `load_project_dylib_smoke.rs`, which exercises the
 //! same dlopen path but feeds `add_module_with(ManifestDirectory)`

--- a/sdk/streamlib-idents/src/resolver.rs
+++ b/sdk/streamlib-idents/src/resolver.rs
@@ -1001,6 +1001,60 @@ mod tests {
         assert!(matches!(res.root.source, ResolvedSource::Root));
     }
 
+    /// Load-bearing invariant of the #1506 co-location flip: build outputs
+    /// materialized BESIDE a package's source in its `streamlib_modules/@org/name`
+    /// slot (`lib/<triple>/*.so`, `.venv/`, `.streamlib-build.json`, cargo
+    /// `target/`) do NOT change `content_hash_for_package_dir`. The hash covers
+    /// only the manifest + owned schema files, so a locked run re-hashing a
+    /// compiled-in-place slot still matches the lockfile pin instead of tripping
+    /// a spurious `LockedSlotContentMismatch`. Mutating a hashed schema DOES move
+    /// the hash — proving it isn't trivially constant.
+    #[test]
+    fn content_hash_ignores_colocated_build_outputs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let slot = tmp.path().join("streamlib_modules").join("@tatolab").join("core");
+        write_streamlib_yaml(
+            &slot,
+            "package:\n  org: tatolab\n  name: core\n  version: 1.0.0\n",
+        );
+        std::fs::create_dir_all(slot.join("schemas")).unwrap();
+        write_yaml(
+            &slot.join("schemas"),
+            "VideoFrame.yaml",
+            "metadata:\n  name: VideoFrame\nproperties:\n  width:\n    type: uint32\n",
+        );
+
+        let before = content_hash_for_package_dir(&slot).unwrap();
+
+        // Materialize the compile-on-install build outputs beside the source.
+        let lib_triple = slot.join("lib").join("x86_64-unknown-linux-gnu");
+        std::fs::create_dir_all(&lib_triple).unwrap();
+        std::fs::write(lib_triple.join("libcore.so"), b"\x7fELF-not-really").unwrap();
+        std::fs::create_dir_all(slot.join(".venv").join("bin")).unwrap();
+        std::fs::write(slot.join(".venv").join("bin").join("python"), b"#!venv").unwrap();
+        std::fs::write(slot.join(".streamlib-build.json"), b"{\"built\":true}").unwrap();
+        std::fs::create_dir_all(slot.join("target").join("debug")).unwrap();
+        std::fs::write(slot.join("target").join("debug").join("junk"), b"scratch").unwrap();
+
+        let after = content_hash_for_package_dir(&slot).unwrap();
+        assert_eq!(
+            before, after,
+            "co-located build outputs must not move the content hash"
+        );
+
+        // A change to a HASHED input (the schema) does move the hash.
+        write_yaml(
+            &slot.join("schemas"),
+            "VideoFrame.yaml",
+            "metadata:\n  name: VideoFrame\nproperties:\n  width:\n    type: uint64\n",
+        );
+        let mutated = content_hash_for_package_dir(&slot).unwrap();
+        assert_ne!(
+            before, mutated,
+            "a mutated schema must move the content hash"
+        );
+    }
+
     #[test]
     fn resolve_path_dependency() {
         let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Closes #1522.

## Summary

Re-points the `installed_package_slot_dir` seam (part of the #1506 strangler) from the
shared `<STREAMLIB_HOME>/.streamlib/cache/packages/{name}-{version}/` slot to the app's
co-located `<app-root>/streamlib_modules/@org/name` slot, version-free (npm-`node_modules`
shaped). Every reader (`locked.rs`, the installed-cache lookup, `IfStale` reuse) and every
writer (install via the injected destination, `.slpkg` extraction) moves onto the same
resolved directory by construction, so write==read stays atomic through the flip.

- Relocated the app-modules-root resolution chain (override > `STREAMLIB_MODULES_DIR` >
  cwd) up into the core `streamlib_home` layer next to `get_streamlib_home`, so the
  core-layer seam can resolve a `None` app root without a layering inversion into the
  private `module_loader::source` module. `source.rs` re-exports it, so every existing
  `source::app_modules_root()` / `set_app_modules_root_override()` call site is unchanged.
- The seam body now delegates to `AppModulesDir::at(root).package_dir(pkg_ref)`; the
  `version` parameter stays in the signature but no longer contributes to the path (the
  pinned version is enforced against the slot manifest at the walker, not the path).
- Swept the seam's own unit tests, the layout canary, the two-tier resolver tests
  (installed-cache and app-modules collapse onto one co-located tree), and the
  locked-run integrity tests onto one canonical app root; the test orchestrator now
  honors the injected staging destination instead of self-deriving a slot.
- Refreshed the stale `.streamlib/cache/packages` doc literals in the touched files to
  the co-located layout; gitignored the regenerable `streamlib_modules/` scratch tree in
  this repo (it's app/test scratch here, not committed package source).
- A companion commit (`test(idents): pin content-hash stability across co-located build
  outputs`) pins content-hash stability now that build outputs sit beside their source.

## Test evidence

Run in-branch (worktree at `feat/1522-flip-installed-slot-to-streamlib-modules`,
commit `93833332`):

- `cargo test -p streamlib-engine --lib module_loader` — 151 passed; 0 failed; 0 ignored
- `cargo test -p streamlib-engine --lib` (full engine lib suite) — 1715 passed; 0 failed;
  128 ignored
- `cargo test -p streamlib-engine --test pack_then_load_smoke` — 3 passed; 0 failed;
  1 ignored

No GPU/rig-dependent surface is touched by this change (module-loader / filesystem-slot
resolution only), so no `/verify-live` pass is needed.

## Review items (non-blocking)

The independent verify pass surfaced the following; none are blocking, listed here
verbatim for the owner's judgment call on scope:

1. **[should-fix]** `runtime/streamlib-engine/src/core/streamlib_home.rs:184` — The seam
   still takes `version: SemVer` but the body drops it (`let _ = version;`) — the slot is
   version-free, so the parameter is now inert while ~8 production call sites
   (`install.rs:191`, `source.rs:942`, `slpkg.rs:50`, `locked.rs:74`, etc.) still thread
   it. Evidence: body is `let _ = version;` then
   `AppModulesDir::at(app_root).package_dir(pkg_ref)` — `pkg_ref` only. A caller reading
   the signature reasonably believes version scopes the slot; it does not. The rustdoc
   does state "version-free by design ... enforced at the walker," which softens but does
   not remove the misleading surface. Suggested next step: either drop the `version`
   param and sweep the callers (clean pre-1.0 rename), or keep it and note here why the
   inert arg is retained; owner's call on the sweep size.

2. **[low]** `.gitignore:87` — The ignore broadened from `streamlib_modules/**/lib/`
   (just build output) to `streamlib_modules/` (the whole co-located tree) in this repo.
   Evidence: diff replaces `streamlib_modules/**/lib/` with `streamlib_modules/`. Safe
   today — `git ls-files | grep streamlib_modules/` returns 0 tracked files — but it
   would silently hide any future in-repo co-located package source. Justified by the
   header comment ("in THIS repo that tree is only regenerable app/test scratch").
   Suggested next step: accept as-is; re-scope to
   `streamlib_modules/**/{lib,target,.venv}/` only if a real in-repo co-located source is
   ever committed.

3. **[info]** `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:484` —
   Ticket scope says "Change ONLY the seam body in streamlib_home.rs," but the
   app-modules root chain (`APP_MODULES_DIR_ENV` const, `APP_MODULES_ROOT_OVERRIDE`
   static, `app_modules_root()`, `set_app_modules_root_override()`) was moved from
   `source.rs` into `streamlib_home.rs` and re-exported. Evidence: `source.rs` now:
   `pub(crate) use crate::core::streamlib_home::{app_modules_root,
   set_app_modules_root_override};` — the definitions relocated to `streamlib_home.rs`.
   This is a structural move (no logic change), necessary so the now-lower-layer seam can
   call the fallback chain; `source.rs` consumers keep working via the re-export. Broader
   than the literal ticket wording but a required consequence of moving the seam.
   Suggested next step: none needed; noting the relocation here so it isn't read as
   unrelated churn.

4. **[info]** `runtime/streamlib-engine/src/core/runtime/module_loader/tests.rs:3612` —
   Ticket acceptance "zero other test edits needed (test-sweep made tests the oracle)" is
   contradicted by the diff. Evidence: the flip required rewriting `source.rs` resolver
   tests (app-modules-vs-cache preference collapsed into one tree — e.g.
   `installed_cache_strategy_prefers_app_modules_dir` ->
   `_resolves_colocated_app_modules_dir`), changing the `StageIntoCacheOrchestrator` to
   honor `request.staging_destination_slot_dir` instead of self-deriving, updating
   `locked.rs`'s `from_lockfile` test, and adding `AppModulesRootOverrideGuard`. All edits
   are correct and necessary consequences of the flip, but the prediction of zero test
   edits was wrong. Suggested next step: noting here that test edits were required and
   why (the app-modules and installed-cache trees are now the same dir, so preference
   tests had to be re-expressed).

5. **[should-fix]** Authoritative module-materialization arch docs still describe the
   `InstalledCache` slot at the pre-flip location
   `<STREAMLIB_HOME>/.streamlib/cache/packages/<name>-<version>/`, contradicting the
   shipped co-located `<app-root>/streamlib_modules/@org/name` (version-free) slot this
   branch makes canonical. Evidence:
   `docs/architecture/runtime-module-materialization.md:117` strategy table row
   `| InstalledCache | <STREAMLIB_HOME>/.streamlib/cache/packages/… |`, plus lines
   59/70/475/523 in the same doc and
   `docs/architecture/package-development-model.md:423` ("the single
   `cache/packages/{name}-{version}` convention"). None of these files are in the diff.
   The engine-doctrine canonical-pattern sweep requires updating every doc in the same
   PR that makes a new pattern canonical; merging leaves main's module-materialization
   doc — and `package-development-model.md`, which the package-registry symptom index
   routes readers to — factually wrong about where installed packages live. Suggested
   next step: update the `InstalledCache` slot description in
   `runtime-module-materialization.md` (table row + lines 59/70/475/523) and
   `package-development-model.md:423` to the co-located version-free
   `<app-root>/streamlib_modules/@org/name` slot in this PR, or note the doc sweep
   explicitly as a follow-up here.

6. **[low]** `runtime/streamlib-engine/src/core/streamlib_home.rs:577` — The `version`
   parameter of the `installed_package_slot_dir` seam is now dead (`let _ = version;`),
   yet the signature still requires it and `staging_slot_for_dir` performs a
   `read_version_from_manifest_dir(dir)` solely to feed the ignored argument. Evidence:
   `streamlib_home.rs` `installed_package_slot_dir` body: `let _ = version;` then
   `AppModulesDir::at(app_root).package_dir(pkg_ref)` — version never contributes to the
   path (slot is version-free by design). `source.rs` `staging_slot_for_dir` reads the
   manifest version only to pass it into that ignored param. Pre-1.0 no-cruft/clean-rename
   doctrine argues for dropping the dead parameter and the now-pointless version read.
   Suggested next step: consider removing the `version` parameter from the seam and the
   vestigial version read in `staging_slot_for_dir`, or leave a one-line note if it is
   retained deliberately for the walker's separate version enforcement.

7. **[low]** `tools/streamlib-cli/src/commands/pkg.rs:235` — The CLI `cache_gc` still
   scans the now-orphaned `.streamlib/cache/packages/` and its doc comment claims
   installed packages live there — vestigial post-flip (harmless: it also scans the new
   co-located tree). Evidence: `// Installed package cache:
   <data_dir>/cache/packages/<name-version>/.` and the
   `get_streamlib_data_dir()`/`cache/packages` reclaim arm; this file is not in the diff.
   Nothing writes installed slots there anymore, so the arm reclaims nothing, but the
   comment now misstates the model. Suggested next step: drop the dead
   `cache/packages` reclaim arm and fix the comment when the doc sweep lands; no
   functional break, so it can trail.

8. **[info]** With no runtime override / `STREAMLIB_MODULES_DIR` set, the
   `pack_then_load` smoke test now materializes real jpeg/core package slots into the
   process cwd's `streamlib_modules/` (i.e. the working tree) instead of the
   machine-global `STREAMLIB_HOME` cache. Evidence: `pack_then_load_smoke.rs` module note
   (branch): app root = `STREAMLIB_MODULES_DIR` / override / process cwd, version-free.
   The new wholesale `.gitignore` `streamlib_modules/` keeps these out of VCS and the
   extract is idempotent, so this is a benign test-hygiene shift the note acknowledges.
   Suggested next step: none required; optionally pin `STREAMLIB_MODULES_DIR` to a
   tempdir in the smoke test to avoid writing package slots into the crate working dir.

9. **[info]** The version-free co-located slot means one version per `@org/name` per app
   tree: a second add/extract of a different version of the same package silently
   clobbers the first slot (extract clears the dir). This is the intended
   npm-`node_modules` model and matches lockfile single-version unification, but it is a
   behavioral change from the old `{name}-{version}` cache that let versions coexist.
   Evidence: `streamlib_home.rs` `installed_package_slot_dir` drops version from the path;
   `slpkg.rs:50` extracts into that version-free slot and the extractor clears before
   re-extracting. Sound under locked/unified flows; a non-locked multi-add of divergent
   versions is the only case that observes the clobber. Suggested next step: none —
   consistent with the single-version-per-tree design; noted for awareness.

10. **[should-fix]** `runtime/streamlib-engine/src/core/streamlib_home.rs:180` —
    `version: SemVer` is now a dead parameter (`let _ = version;`) — the slot is
    version-free by design (#1506, enforced at the walker not the path). Evidence: L177
    signature keeps `version: SemVer`; L180 discards it with `let _ = version;`. All
    non-test callers still compute+pass it: `install.rs:191`, `slpkg.rs:50`,
    `source.rs:590/980`, `locked.rs:73`. This is the second migration where the seam
    carries a dead param behind `let _ =` (previously `app_modules_root` was dead).
    Suggested next step: if the version-free layout is final, drop `version` from the
    signature and sweep the ~5 callers in the same PR; doctrine (pre-1.0, rename cleanly,
    no cruft) favors removal over a signature-stability hedge.

11. **[should-fix]** `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:494`
    — `lookup_app_modules_package_dir` hand-rolls the same
    `<app-root>/streamlib_modules/@org/name` path that the diff's
    `installed_package_slot_dir` now derives via the `AppModulesDir::at().package_dir()`
    newtype seam — the read side and write side of the PR's write==read invariant use
    two different derivations. Evidence: `source.rs:494-496` builds
    `app_root.join(APP_MODULES_DIR_NAME).join(format!("@{}", pkg_ref.org)).join(pkg_ref.name.as_str())`,
    byte-identical to `AppModulesDir::package_dir` (`app_modules.rs:464-468`) which
    `streamlib_home.rs:185` now uses. The PR asserts these must resolve the same dir.
    Suggested next step: route `lookup_app_modules_package_dir` (read side) through
    `AppModulesDir::at(root).package_dir(pkg_ref)` so write==read holds by construction
    rather than by two copies staying in sync. Pre-existing code, but the diff makes them
    converge.

12. **[info]** `runtime/streamlib-engine/src/core/streamlib_home.rs:184` — When no
    explicit root, override, env var, or cwd resolves, the slot falls back to a relative
    `./streamlib_modules/@org/name`. Evidence: L182-184: `.map(Path::to_path_buf).or_else(app_modules_root).unwrap_or_else(|| PathBuf::from("."))`.
    Old code returned `None` and skipped in this case; new code always yields a
    (possibly relative) path. Suggested next step: behavior nuance for the correctness
    verifier to confirm intended; not a craftsmanship defect.

### E2E Test Report — #1506 co-location flip (#1522)

**Scenario**: package-lifecycle co-location E2E (not camera→display). The flip repoints the installed-package slot from `.streamlib/cache/packages/<name>-<version>/` to the co-located version-free `<app-root>/streamlib_modules/@org/name`. The load path is CPU/dlopen (no GPU rig needed); the GPU pipeline is unchanged by the flip and stays covered by the existing E2E fixtures on main.

**Build profile**: debug (flip branch `feat/1522-flip-installed-slot-to-streamlib-modules`, HEAD `e08f5697`)

#### 1. Co-located materialization (pack → compile → load)
`pack_then_load_smoke` (3 passed): packages materialized into **`streamlib_modules/@tatolab/core`** and **`streamlib_modules/@tatolab/foreign-triple-fixture`** — version-free `@org/name`, each with its `streamlib.yaml` + `schemas/`. Legacy `.streamlib/cache/packages/` received **zero** installed slots.

#### 2. Real Rust cdylib dlopen roundtrip from the co-located slot
`load_project_dylib_version_free_ref` (1 passed). Runtime log:
```
lazily discovered the package ... package="@tatolab/test-fixtures" source=".../streamlib_modules/@tatolab/test-fixtures"
resolving module from the app's streamlib_modules folder
Loading Rust dylib plugin: .../streamlib_modules/@tatolab/test-fixtures/lib/x86_64-unknown-linux-gnu/libstreamlib_test_fixtures.so
Rust dylib plugin loaded and registrations staged
[register] new processor type registered '@tatolab/test-fixtures/ComputeKernelTestProcessor@0.0.0'   (+10 more — 11 total)
Loading dependency '@tatolab/core@^1.0.0' ... materialized package ... rebuilt=false
```
A real `.so` loaded from the co-located `streamlib_modules/@org/name/lib/<triple>/`, 11 processors registered, dependency resolved + reused (`rebuilt=false`). The one ERROR line is the test's intentional negative case (a not-installed processor correctly refused).

#### 3. write==read across processes
The 14-test locked-run integrity set (drift / tamper / miss / offline) passes: stage and read both anchor under one app root — a package installed in one process resolves the identical co-located slot in a fresh locked-run process. `content_hash_ignores_colocated_build_outputs` confirms co-located build output doesn't perturb the integrity hash.

#### Outcome
- **Pass** — the co-location cutover works end-to-end: packages materialize into `streamlib_modules/@org/name` (version-free), a real cdylib loads + registers from there, the legacy cache is bypassed, and write==read holds across processes.
- Caveats/follow-ups: full `.streamlib/cache/packages/` retirement + resolver-tier collapse + test-home tempdir hygiene tracked in #1523 (retire-legacy).