### PR TITLE
feat(cli): add/install compile packages on-the-box + fail-fast

### DIFF
--- a/runtime/streamlib-engine/src/core/runtime/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/mod.rs
@@ -16,7 +16,8 @@ pub use install::{InstallError, InstallOptions, InstallReport, install};
 pub use streamlib_idents::app_modules::{
     APP_MODULES_DIR_NAME, AddPackageOptions, AddPackageReport, AddPackageSource, AppModulesDir,
     AppModulesError, InstallFromLockfileReport, InstalledFromLockKind, InstalledFromLockPackage,
-    LinkPackageReport, RemovePackageReport, UnlinkPackageReport, parse_lockfile_package_key,
+    LinkPackageReport, RemovePackageReport, ReplacedSlotBackup, UnlinkPackageReport,
+    parse_lockfile_package_key,
 };
 pub use module_loader::{
     AcquireConfirmationHandler, AcquireOnReferencePolicy, AddModuleError, AddedModule,

--- a/sdk/streamlib-idents/src/app_modules.rs
+++ b/sdk/streamlib-idents/src/app_modules.rs
@@ -89,6 +89,15 @@ pub struct AddPackageOptions {
     /// and nothing is materialized. Ignored for folder sources (no archive
     /// bytes exist).
     pub expected_archive_sha256: Option<String>,
+    /// When `true` and the add replaces an already-present slot, the displaced
+    /// prior slot (contents + its lockfile entry) is retained as a restorable
+    /// [`ReplacedSlotBackup`] in the report rather than discarded, so a caller
+    /// running a post-add step (compile-on-add) can restore the prior working
+    /// version if that step fails. The caller MUST finalize the returned backup
+    /// with [`AppModulesDir::commit_replaced_slot_backup`] (discard) or
+    /// [`AppModulesDir::restore_replaced_slot`] (restore); an unfinalized backup
+    /// is swept as staging residue by the next add/install in another process.
+    pub retain_replaced_slot_backup: bool,
 }
 
 /// Outcome of a successful [`AppModulesDir::add_package`].
@@ -108,6 +117,27 @@ pub struct AddPackageReport {
     pub source: LockfileSource,
     /// `true` when an existing `streamlib_modules/@org/name/` was replaced.
     pub replaced_existing: bool,
+    /// The displaced prior slot, retained only when the add both replaced an
+    /// existing slot AND [`AddPackageOptions::retain_replaced_slot_backup`] was
+    /// set. `Some` means a prior working version is recoverable via
+    /// [`AppModulesDir::restore_replaced_slot`] and MUST be finalized (restore
+    /// or [`AppModulesDir::commit_replaced_slot_backup`]); `None` means either a
+    /// fresh add (no prior slot) or retention was not requested.
+    pub replaced_slot_backup: Option<ReplacedSlotBackup>,
+}
+
+/// A displaced prior `streamlib_modules/@org/name/` slot retained across a
+/// caller's post-add step (e.g. compile-on-add), so the prior working version
+/// can be restored if that step fails. Held in [`AddPackageReport`]; finalized
+/// via [`AppModulesDir::commit_replaced_slot_backup`] (the step succeeded —
+/// discard) or [`AppModulesDir::restore_replaced_slot`] (the step failed —
+/// put the prior version back).
+#[derive(Debug, Clone)]
+pub struct ReplacedSlotBackup {
+    /// The `.staging-replaced-*` sibling the prior slot contents were moved to.
+    backup_dir: PathBuf,
+    /// The lockfile entry that pointed at the prior slot, to rewrite on restore.
+    prior_lockfile_entry: LockfileEntry,
 }
 
 /// Outcome of a successful [`AppModulesDir::remove_package`].
@@ -530,15 +560,25 @@ impl AppModulesDir {
 
         // Promote: swap the staged root into `streamlib_modules/@org/name`,
         // keeping the displaced previous contents restorable until the new
-        // contents are in place.
+        // contents are in place. When retention is requested, the displaced
+        // prior slot survives the promote so a failed post-add step can restore
+        // it (compile-on-add), instead of being discarded on success.
         let package_dir = self.package_dir(&package);
-        let replaced_existing =
-            promote_staged_package_root(&staged_package_root, &package_dir, &modules_dir)?;
+        let promoted = promote_staged_package_root(
+            &staged_package_root,
+            &package_dir,
+            &modules_dir,
+            options.retain_replaced_slot_backup,
+        )?;
+        let replaced_existing = promoted.replaced;
         drop(staging); // best-effort cleanup of the (now-emptied) staging shell
 
-        // Lock: read-modify-write the modules lockfile, atomically.
+        // Lock: read-modify-write the modules lockfile, atomically. Capture the
+        // prior entry before overwriting it, so a retained backup can rewrite it
+        // on restore.
         let lockfile_path = self.lockfile_path();
         let mut lockfile = self.read_lockfile()?;
+        let prior_lockfile_entry = lockfile.packages.get(&package.to_string()).cloned();
         lockfile.packages.insert(
             package.to_string(),
             LockfileEntry {
@@ -553,6 +593,21 @@ impl AppModulesDir {
                 detail: e.to_string(),
             }
         })?;
+
+        let replaced_slot_backup = match (promoted.retained_backup, prior_lockfile_entry) {
+            (Some(backup_dir), Some(prior_lockfile_entry)) => Some(ReplacedSlotBackup {
+                backup_dir,
+                prior_lockfile_entry,
+            }),
+            (Some(backup_dir), None) => {
+                // Contents were displaced but there was no prior lockfile entry
+                // to restore (a healed orphan slot). Nothing to restore to, so
+                // discard the retained backup rather than leak it.
+                let _ = remove_dir_entry_all(&backup_dir);
+                None
+            }
+            (None, _) => None,
+        };
 
         tracing::info!(
             package = %package,
@@ -569,7 +624,69 @@ impl AppModulesDir {
             content_hash,
             source: lock_source,
             replaced_existing,
+            replaced_slot_backup,
         })
+    }
+
+    /// Discard a [`ReplacedSlotBackup`] retained by
+    /// [`add_package`](Self::add_package): the caller's post-add step succeeded,
+    /// so the prior version is no longer needed. Removes the backup directory.
+    #[tracing::instrument(skip(self, backup), fields(app_root = %self.app_root.display()))]
+    pub fn commit_replaced_slot_backup(
+        &self,
+        backup: &ReplacedSlotBackup,
+    ) -> Result<(), AppModulesError> {
+        remove_dir_entry_all(&backup.backup_dir).map_err(|e| AppModulesError::Io {
+            path: backup.backup_dir.clone(),
+            detail: format!("discarding retained replaced-slot backup: {e}"),
+        })
+    }
+
+    /// Restore a [`ReplacedSlotBackup`] retained by
+    /// [`add_package`](Self::add_package): the caller's post-add step failed, so
+    /// the just-placed (broken) slot is removed and the prior working version —
+    /// its contents AND its lockfile entry — is put back exactly as it was
+    /// before the add. Makes the failed add a no-op for the operator's
+    /// installed set.
+    #[tracing::instrument(skip(self, backup), fields(app_root = %self.app_root.display(), package = %package))]
+    pub fn restore_replaced_slot(
+        &self,
+        package: &PackageRef,
+        backup: &ReplacedSlotBackup,
+    ) -> Result<(), AppModulesError> {
+        let package_dir = self.package_dir(package);
+        // Drop the just-placed (broken) contents, then swing the retained prior
+        // slot back into place.
+        remove_dir_entry_all(&package_dir).map_err(|e| AppModulesError::Io {
+            path: package_dir.clone(),
+            detail: format!("removing the failed replacement slot before restore: {e}"),
+        })?;
+        std::fs::rename(&backup.backup_dir, &package_dir).map_err(|e| {
+            AppModulesError::StagePromoteFailed {
+                package_dir: package_dir.clone(),
+                detail: format!("restoring the prior slot from its backup: {e}"),
+            }
+        })?;
+
+        // Rewrite the prior lockfile entry over the one the failed add wrote.
+        let lockfile_path = self.lockfile_path();
+        let mut lockfile = self.read_lockfile()?;
+        lockfile
+            .packages
+            .insert(package.to_string(), backup.prior_lockfile_entry.clone());
+        write_modules_lockfile(&lockfile_path, &lockfile).map_err(|e| {
+            AppModulesError::LockfileWriteFailed {
+                lockfile_path,
+                detail: e.to_string(),
+            }
+        })?;
+
+        tracing::info!(
+            package = %package,
+            dir = %package_dir.display(),
+            "restore_replaced_slot: restored the prior version after a failed replace"
+        );
+        Ok(())
     }
 
     /// Remove one package: delete `streamlib_modules/@org/name/` (folder
@@ -708,7 +825,7 @@ impl AppModulesDir {
         let staging = StagingSymlink::create(&modules_dir, &canonical)?;
         let package_dir = self.package_dir(&package);
         let replaced_existing =
-            promote_staged_package_root(staging.path(), &package_dir, &modules_dir)?;
+            promote_staged_package_root(staging.path(), &package_dir, &modules_dir, false)?.replaced;
         drop(staging); // the symlink was renamed into place; nothing to clean
 
         let lock_source = LockfileSource::Link {
@@ -970,8 +1087,10 @@ impl AppModulesDir {
                     });
                 }
                 let staging = StagingSymlink::create(modules_dir, path)?;
-                let replaced = promote_staged_package_root(staging.path(), &package_dir, modules_dir)
-                    .map_err(|e| map_stage_error_to_install(package, e))?;
+                let replaced =
+                    promote_staged_package_root(staging.path(), &package_dir, modules_dir, false)
+                        .map_err(|e| map_stage_error_to_install(package, e))?
+                        .replaced;
                 drop(staging);
                 Ok((InstalledFromLockKind::Linked, replaced))
             }
@@ -1309,13 +1428,26 @@ fn locate_staged_package_root(
     })
 }
 
+/// Outcome of [`promote_staged_package_root`].
+struct PromotedSlot {
+    /// Whether previous contents occupied the slot and were displaced.
+    replaced: bool,
+    /// The `.staging-replaced-*` backup of the displaced prior slot, present
+    /// only when `retain_replaced_backup` was requested AND a prior slot was
+    /// displaced. The caller owns finalizing it (discard or restore).
+    retained_backup: Option<PathBuf>,
+}
+
 /// Swap `staged_package_root` into `package_dir`, displacing any previous
-/// contents restorably. Returns whether previous contents were replaced.
+/// contents restorably. When `retain_replaced_backup` is set and a prior slot
+/// was displaced, its backup is kept (not deleted on success) and returned so
+/// the caller can restore it after a failed post-promote step.
 fn promote_staged_package_root(
     staged_package_root: &Path,
     package_dir: &Path,
     modules_dir: &Path,
-) -> Result<bool, AppModulesError> {
+    retain_replaced_backup: bool,
+) -> Result<PromotedSlot, AppModulesError> {
     let promote_err = |detail: String| AppModulesError::StagePromoteFailed {
         package_dir: package_dir.to_path_buf(),
         detail,
@@ -1348,16 +1480,25 @@ fn promote_staged_package_root(
     };
 
     match std::fs::rename(staged_package_root, package_dir) {
-        Ok(()) => {
-            if let Some(backup) = displaced {
+        Ok(()) => match displaced {
+            Some(backup) if retain_replaced_backup => Ok(PromotedSlot {
+                replaced: true,
+                retained_backup: Some(backup),
+            }),
+            Some(backup) => {
                 // The displaced previous slot may be a symlink (a prior link
                 // being replaced); unlink it rather than recursing into it.
                 let _ = remove_dir_entry_all(&backup);
-                Ok(true)
-            } else {
-                Ok(false)
+                Ok(PromotedSlot {
+                    replaced: true,
+                    retained_backup: None,
+                })
             }
-        }
+            None => Ok(PromotedSlot {
+                replaced: false,
+                retained_backup: None,
+            }),
+        },
         Err(e) => {
             if let Some(backup) = &displaced {
                 let _ = std::fs::rename(backup, package_dir);
@@ -1490,6 +1631,7 @@ fn reproduce_materialized_from_lock(
     let staging = StagingDir::create(modules_dir)?;
     let options = AddPackageOptions {
         expected_archive_sha256,
+        ..Default::default()
     };
     let (_lock_source, source_label) = stage_source_contents(&source, &options, staging.path())
         .map_err(|e| map_stage_error_to_install(package, e))?;
@@ -1513,8 +1655,9 @@ fn reproduce_materialized_from_lock(
         });
     }
 
-    let replaced = promote_staged_package_root(&staged_root, package_dir, modules_dir)
-        .map_err(|e| map_stage_error_to_install(package, e))?;
+    let replaced = promote_staged_package_root(&staged_root, package_dir, modules_dir, false)
+        .map_err(|e| map_stage_error_to_install(package, e))?
+        .replaced;
     drop(staging);
     Ok((InstalledFromLockKind::Materialized, replaced))
 }
@@ -2105,6 +2248,7 @@ mod tests {
             &source,
             &AddPackageOptions {
                 expected_archive_sha256: Some(sha256_hex(&bytes)),
+                ..Default::default()
             },
         )
         .expect("matching sha must pass");
@@ -2112,6 +2256,7 @@ mod tests {
             &source,
             &AddPackageOptions {
                 expected_archive_sha256: Some(format!("sha256:{}", sha256_hex(&bytes))),
+                ..Default::default()
             },
         )
         .expect("prefixed matching sha must pass");
@@ -2124,6 +2269,7 @@ mod tests {
                 &source,
                 &AddPackageOptions {
                     expected_archive_sha256: Some("00".repeat(32)),
+                    ..Default::default()
                 },
             )
             .expect_err("mismatched sha must fail loud");

--- a/tools/streamlib-cli/src/commands/add.rs
+++ b/tools/streamlib-cli/src/commands/add.rs
@@ -40,10 +40,10 @@ use super::build_on_place::{
 /// package-authoring dir, otherwise materializes a byte source into the app's
 /// `streamlib_modules/` and compiles it on-the-box.
 ///
-/// `no_build` is the toolchain-free opt-out: it maps to
-/// [`BuildPolicy::NeverBuild`] (placement only, the old behavior). Otherwise the
-/// just-placed slot is compiled in place with [`BuildPolicy::IfStale`] and a
-/// compile failure rolls the placement back.
+/// `no_build` skips the on-the-box compile (placement/reproduce only). Otherwise
+/// the just-placed slot is compiled in place with [`BuildPolicy::IfStale`] and a
+/// compile failure rolls the placement back — restoring the prior version when
+/// the add replaced one.
 pub fn add(
     spec: &str,
     dir: Option<&Path>,
@@ -88,14 +88,16 @@ pub fn add(
 
     let options = AddPackageOptions {
         expected_archive_sha256: expect_sha256.map(|s| s.to_string()),
+        // When we're about to compile, retain a displaced prior slot so a
+        // compile failure can restore the previously-working version rather
+        // than leaving the operator with nothing.
+        retain_replaced_slot_backup: !no_build,
     };
     let report = app
         .add_package(&source, &options)
         .map_err(|e| anyhow::anyhow!("add failed: {e}"))?;
 
     if !no_build {
-        println!();
-        println!("Compiling {} v{}…", report.package, report.version);
         build_added_slot_or_rollback(
             &app,
             &report,

--- a/tools/streamlib-cli/src/commands/add.rs
+++ b/tools/streamlib-cli/src/commands/add.rs
@@ -26,15 +26,30 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use streamlib::sdk::runtime::{
-    AddPackageOptions, AddPackageReport, AddPackageSource, AppModulesDir, LinkPackageReport,
+    AddPackageOptions, AddPackageReport, AddPackageSource, AppModulesDir, BuildPolicy,
+    LinkPackageReport,
 };
 use streamlib_idents::{DependencySpec, Manifest, PackageRef, RegistryDependency, SemVerRange};
 use streamlib_processor_schema::StreamlibYaml;
 
+use super::build_on_place::{
+    ConsoleBuildEventSink, build_added_slot_or_rollback, default_orchestrator,
+};
+
 /// `streamlib add <spec>` — records a dependency range when run in a
 /// package-authoring dir, otherwise materializes a byte source into the app's
-/// `streamlib_modules/`.
-pub fn add(spec: &str, dir: Option<&Path>, expect_sha256: Option<&str>) -> Result<()> {
+/// `streamlib_modules/` and compiles it on-the-box.
+///
+/// `no_build` is the toolchain-free opt-out: it maps to
+/// [`BuildPolicy::NeverBuild`] (placement only, the old behavior). Otherwise the
+/// just-placed slot is compiled in place with [`BuildPolicy::IfStale`] and a
+/// compile failure rolls the placement back.
+pub fn add(
+    spec: &str,
+    dir: Option<&Path>,
+    expect_sha256: Option<&str>,
+    no_build: bool,
+) -> Result<()> {
     let anchor = anchor_dir(dir)?;
     if let Some(manifest) = load_anchor_manifest(&anchor)? {
         if manifest.is_package_flavor() {
@@ -77,6 +92,18 @@ pub fn add(spec: &str, dir: Option<&Path>, expect_sha256: Option<&str>) -> Resul
     let report = app
         .add_package(&source, &options)
         .map_err(|e| anyhow::anyhow!("add failed: {e}"))?;
+
+    if !no_build {
+        println!();
+        println!("Compiling {} v{}…", report.package, report.version);
+        build_added_slot_or_rollback(
+            &app,
+            &report,
+            &default_orchestrator(),
+            &ConsoleBuildEventSink,
+            BuildPolicy::IfStale,
+        )?;
+    }
 
     print_add_report(&report);
     Ok(())
@@ -485,7 +512,7 @@ mod tests {
         )
         .unwrap();
 
-        let err = add("./anything", Some(dir.path()), None)
+        let err = add("./anything", Some(dir.path()), None, false)
             .expect_err("add must reject an app-dir manifest that declares dependencies");
         match err.downcast_ref::<streamlib::sdk::error::Error>() {
             Some(streamlib::sdk::error::Error::AppManifestDeclaresDependencies {

--- a/tools/streamlib-cli/src/commands/build_on_place.rs
+++ b/tools/streamlib-cli/src/commands/build_on_place.rs
@@ -1,0 +1,363 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Compile a just-placed `streamlib_modules/@org/name/` slot on-the-box.
+//!
+//! `add` / `install` place a package's bytes into its co-located
+//! `streamlib_modules/@org/name/` slot (the pure [`AppModulesDir`] twin never
+//! builds), then hand the slot here to compile it IN PLACE through the injected
+//! [`BuildOrchestrator`]: the build source IS the destination slot, so the
+//! orchestrator promotes only the regenerated build-output units
+//! (`lib/<triple>/`, `.venv/`, `_generated_/`) beside the untouched sources.
+//!
+//! Provenance is [`PackageSourceProvenance::ImmutableManagedExtract`]: an
+//! added / reproduced copy is a self-contained managed extract, not the user's
+//! editable checkout, so cargo's build-once-reuse (zero-cargo second load) and
+//! build-scratch reclamation both apply. A dev `streamlib link` slot is
+//! deliberately NOT routed here — a linked checkout is a mutable user tree that
+//! stays lazy/edit-rebuild at run time.
+//!
+//! Failure posture differs by command:
+//! - `add` rolls the placement back (folder + lock entry) so a non-compiling
+//!   package leaves no residue.
+//! - `install` reproduces rather than acquires, so it does NOT roll back;
+//!   it aggregates every broken package and fails listing them all.
+//!
+//! [`AppModulesDir`]: streamlib::sdk::runtime::AppModulesDir
+
+use std::path::Path;
+
+use anyhow::Result;
+use streamlib::sdk::PolyglotBuildOrchestrator;
+use streamlib::sdk::runtime::{
+    AddPackageReport, AppModulesDir, BuildEvent, BuildEventSink, BuildOrchestrator, BuildPolicy,
+    BuildRequest, BuildSource, BuildStream, InstallFromLockfileReport, InstalledFromLockKind,
+    PackageSourceProvenance, StagedArtifact, host_target_triple,
+};
+use streamlib_idents::PackageRef;
+
+/// The default in-process polyglot build orchestrator the CLI wires for
+/// compile-on-place.
+pub fn default_orchestrator() -> PolyglotBuildOrchestrator {
+    PolyglotBuildOrchestrator::default()
+}
+
+/// Compile one placed slot in place. `source` and `staging_destination_slot_dir`
+/// are both `package_dir`, which the orchestrator detects as an in-place
+/// destination (promote build outputs beside the untouched sources).
+pub fn build_placed_slot(
+    orchestrator: &dyn BuildOrchestrator,
+    sink: &dyn BuildEventSink,
+    package: &PackageRef,
+    package_dir: &Path,
+    policy: BuildPolicy,
+) -> Result<StagedArtifact> {
+    let request = BuildRequest {
+        package: package.clone(),
+        source: BuildSource::PackageDir(package_dir.to_path_buf()),
+        source_provenance: PackageSourceProvenance::ImmutableManagedExtract,
+        policy,
+        host_triple: host_target_triple().to_string(),
+        staging_destination_slot_dir: package_dir.to_path_buf(),
+    };
+    orchestrator
+        .materialize(&request, sink)
+        .map_err(|e| anyhow::anyhow!("{e}"))
+}
+
+/// `add`-side compile: build the just-placed slot, rolling the placement
+/// (folder + lock entry) back on failure so a non-compiling `add` leaves no
+/// `streamlib_modules/` slot and no lock entry.
+pub fn build_added_slot_or_rollback(
+    app: &AppModulesDir,
+    report: &AddPackageReport,
+    orchestrator: &dyn BuildOrchestrator,
+    sink: &dyn BuildEventSink,
+    policy: BuildPolicy,
+) -> Result<()> {
+    match build_placed_slot(orchestrator, sink, &report.package, &report.package_dir, policy) {
+        Ok(_) => Ok(()),
+        Err(build_err) => {
+            if let Err(rollback_err) = app.remove_package(&report.package) {
+                tracing::warn!(
+                    package = %report.package,
+                    error = %rollback_err,
+                    "add: rolling back placement after a build failure also failed"
+                );
+            }
+            anyhow::bail!(
+                "building '{}' failed; rolled back its streamlib_modules/ slot and \
+                 streamlib.lock entry:\n{build_err}",
+                report.package
+            )
+        }
+    }
+}
+
+/// `install`-side compile: build every materialized (non-linked) reproduced
+/// slot, AGGREGATING failures so one broken package doesn't mask the rest.
+/// Install reproduces rather than acquires, so it does NOT roll back — a
+/// partially built set stays on disk and every broken package is listed.
+/// Linked entries stay lazy/edit-rebuild and are skipped.
+pub fn build_installed_slots(
+    report: &InstallFromLockfileReport,
+    orchestrator: &dyn BuildOrchestrator,
+    sink: &dyn BuildEventSink,
+    policy: BuildPolicy,
+) -> Result<()> {
+    let mut failures: Vec<(PackageRef, anyhow::Error)> = Vec::new();
+    for pkg in &report.packages {
+        if pkg.kind == InstalledFromLockKind::Linked {
+            continue;
+        }
+        println!();
+        println!("Building {} v{}…", pkg.package, pkg.version);
+        if let Err(e) =
+            build_placed_slot(orchestrator, sink, &pkg.package, &pkg.package_dir, policy)
+        {
+            eprintln!("  build failed for {}: {e}", pkg.package);
+            failures.push((pkg.package.clone(), e));
+        }
+    }
+    if failures.is_empty() {
+        return Ok(());
+    }
+    let mut message = String::from("install failed to build the following package(s):");
+    for (package, error) in &failures {
+        message.push_str(&format!("\n  - {package}: {error}"));
+    }
+    anyhow::bail!(message)
+}
+
+/// Console sink: surface build-tool output to the operator's terminal so a
+/// compile failure shows the compiler error rather than a debug-level swallow.
+pub struct ConsoleBuildEventSink;
+
+impl BuildEventSink for ConsoleBuildEventSink {
+    fn emit(&self, event: BuildEvent) {
+        match event {
+            BuildEvent::Started { language } => println!("  compiling {language}…"),
+            BuildEvent::Line { stream, line } => match stream {
+                BuildStream::Stdout => println!("    {line}"),
+                BuildStream::Stderr => eprintln!("    {line}"),
+            },
+            BuildEvent::Finished { language } => println!("  compiled {language}"),
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    use streamlib::sdk::runtime::{AddPackageSource, BuildError};
+    use streamlib_idents::{Org, Package};
+
+    use super::*;
+
+    /// A recording stub orchestrator: captures every request it is handed and
+    /// fails the packages named in `fail_packages`, so the CLI wiring
+    /// (request shape, rollback, aggregation, linked-skip) is testable without
+    /// a toolchain.
+    #[derive(Default)]
+    struct StubOrchestrator {
+        fail_packages: HashSet<String>,
+        seen: Mutex<Vec<BuildRequest>>,
+    }
+
+    impl BuildOrchestrator for StubOrchestrator {
+        fn materialize(
+            &self,
+            request: &BuildRequest,
+            _sink: &dyn BuildEventSink,
+        ) -> std::result::Result<StagedArtifact, BuildError> {
+            self.seen.lock().unwrap().push(request.clone());
+            if self.fail_packages.contains(&request.package.to_string()) {
+                return Err(BuildError::BuildFailed {
+                    tool: "cargo".to_string(),
+                    package: request.package.to_string(),
+                    detail: "synthetic compile failure".to_string(),
+                });
+            }
+            Ok(StagedArtifact {
+                staged_dir: request.staging_destination_slot_dir.clone(),
+                rebuilt: true,
+            })
+        }
+    }
+
+    /// Write a minimal schema-only package folder (a valid `package:` manifest,
+    /// no processors, so `add_package` places it with no toolchain needed).
+    fn write_schema_only_package(dir: &Path, org: &str, name: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join("streamlib.yaml"),
+            format!("package:\n  org: {org}\n  name: {name}\n  version: 0.1.0\n"),
+        )
+        .unwrap();
+    }
+
+    fn ref_of(org: &str, name: &str) -> PackageRef {
+        PackageRef::new(Org::new(org).unwrap(), Package::new(name).unwrap())
+    }
+
+    #[test]
+    fn build_placed_slot_requests_in_place_immutable_ifstale() {
+        let stub = StubOrchestrator::default();
+        let sink = ConsoleBuildEventSink;
+        let package = ref_of("tatolab", "widget");
+        let slot = PathBuf::from("/tmp/streamlib_modules/@tatolab/widget");
+
+        build_placed_slot(&stub, &sink, &package, &slot, BuildPolicy::IfStale).unwrap();
+
+        let seen = stub.seen.lock().unwrap();
+        assert_eq!(seen.len(), 1);
+        let req = &seen[0];
+        // In-place: the build source IS the destination slot.
+        assert!(matches!(&req.source, BuildSource::PackageDir(dir) if dir == &slot));
+        assert_eq!(req.staging_destination_slot_dir, slot);
+        // The two zero-cargo-reuse preconditions the CLI must supply.
+        assert_eq!(
+            req.source_provenance,
+            PackageSourceProvenance::ImmutableManagedExtract
+        );
+        assert_eq!(req.policy, BuildPolicy::IfStale);
+        assert_eq!(req.host_triple, host_target_triple());
+    }
+
+    #[test]
+    fn add_rollback_removes_slot_and_lock_entry_on_build_failure() {
+        let app_root = tempfile::tempdir().unwrap();
+        let src = tempfile::tempdir().unwrap();
+        write_schema_only_package(src.path(), "tatolab", "widget");
+
+        let app = AppModulesDir::at(app_root.path());
+        let report = app
+            .add_package(
+                &AddPackageSource::Folder {
+                    path: src.path().to_path_buf(),
+                },
+                &Default::default(),
+            )
+            .unwrap();
+        // Placement happened.
+        assert!(report.package_dir.exists());
+        assert!(app.read_lockfile().unwrap().packages.contains_key("@tatolab/widget"));
+
+        let stub = StubOrchestrator {
+            fail_packages: HashSet::from(["@tatolab/widget".to_string()]),
+            ..Default::default()
+        };
+        let err = build_added_slot_or_rollback(
+            &app,
+            &report,
+            &stub,
+            &ConsoleBuildEventSink,
+            BuildPolicy::IfStale,
+        )
+        .expect_err("a failed build must fail the add");
+        assert!(err.to_string().contains("rolled back"), "{err}");
+
+        // Rolled back: no slot, no lock entry.
+        assert!(!report.package_dir.exists(), "slot must be gone after rollback");
+        assert!(
+            !app.read_lockfile()
+                .unwrap()
+                .packages
+                .contains_key("@tatolab/widget"),
+            "lock entry must be gone after rollback"
+        );
+    }
+
+    #[test]
+    fn add_keeps_slot_and_lock_entry_on_build_success() {
+        let app_root = tempfile::tempdir().unwrap();
+        let src = tempfile::tempdir().unwrap();
+        write_schema_only_package(src.path(), "tatolab", "widget");
+
+        let app = AppModulesDir::at(app_root.path());
+        let report = app
+            .add_package(
+                &AddPackageSource::Folder {
+                    path: src.path().to_path_buf(),
+                },
+                &Default::default(),
+            )
+            .unwrap();
+
+        build_added_slot_or_rollback(
+            &app,
+            &report,
+            &StubOrchestrator::default(),
+            &ConsoleBuildEventSink,
+            BuildPolicy::IfStale,
+        )
+        .unwrap();
+
+        assert!(report.package_dir.exists());
+        assert!(app.read_lockfile().unwrap().packages.contains_key("@tatolab/widget"));
+    }
+
+    #[test]
+    fn install_aggregates_failures_skips_linked_and_does_not_roll_back() {
+        let app_root = tempfile::tempdir().unwrap();
+        let good_src = tempfile::tempdir().unwrap();
+        let bad_src = tempfile::tempdir().unwrap();
+        let linked_src = tempfile::tempdir().unwrap();
+        write_schema_only_package(good_src.path(), "tatolab", "good");
+        write_schema_only_package(bad_src.path(), "tatolab", "bad");
+        write_schema_only_package(linked_src.path(), "tatolab", "linked");
+
+        let app = AppModulesDir::at(app_root.path());
+        app.add_package(
+            &AddPackageSource::Folder {
+                path: good_src.path().to_path_buf(),
+            },
+            &Default::default(),
+        )
+        .unwrap();
+        app.add_package(
+            &AddPackageSource::Folder {
+                path: bad_src.path().to_path_buf(),
+            },
+            &Default::default(),
+        )
+        .unwrap();
+        app.link_package(linked_src.path()).unwrap();
+
+        let report = app.install_from_lockfile().unwrap();
+
+        let stub = StubOrchestrator {
+            fail_packages: HashSet::from(["@tatolab/bad".to_string()]),
+            ..Default::default()
+        };
+        let err =
+            build_installed_slots(&report, &stub, &ConsoleBuildEventSink, BuildPolicy::IfStale)
+                .expect_err("a broken package must fail install");
+        let message = err.to_string();
+        assert!(message.contains("@tatolab/bad"), "must name the broken package: {message}");
+        assert!(!message.contains("@tatolab/good"), "must not name the good package: {message}");
+
+        // The linked entry stays lazy — never handed to the orchestrator.
+        let built: Vec<String> = stub
+            .seen
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|r| r.package.to_string())
+            .collect();
+        assert!(built.contains(&"@tatolab/good".to_string()));
+        assert!(built.contains(&"@tatolab/bad".to_string()));
+        assert!(
+            !built.contains(&"@tatolab/linked".to_string()),
+            "a linked slot must not be compiled at install time: {built:?}"
+        );
+
+        // Install does NOT roll back: both materialized slots remain on disk.
+        assert!(app.package_dir(&ref_of("tatolab", "good")).exists());
+        assert!(app.package_dir(&ref_of("tatolab", "bad")).exists());
+    }
+}

--- a/tools/streamlib-cli/src/commands/build_on_place.rs
+++ b/tools/streamlib-cli/src/commands/build_on_place.rs
@@ -62,12 +62,23 @@ pub fn build_placed_slot(
     };
     orchestrator
         .materialize(&request, sink)
-        .map_err(|e| anyhow::anyhow!("{e}"))
+        .map_err(anyhow::Error::new)
 }
 
-/// `add`-side compile: build the just-placed slot, rolling the placement
-/// (folder + lock entry) back on failure so a non-compiling `add` leaves no
-/// `streamlib_modules/` slot and no lock entry.
+/// The single per-slot compile banner both `add` and `install` print, so the
+/// verb and shape live in one place.
+fn print_compile_banner(package: &PackageRef, version: &streamlib_idents::SemVer) {
+    println!();
+    println!("Compiling {package} v{version}…");
+}
+
+/// `add`-side compile: build the just-placed slot, undoing the placement on a
+/// build failure. A fresh add (no prior slot) rolls back to empty — no
+/// `streamlib_modules/` slot and no lock entry. An add that REPLACED an
+/// existing slot restores that prior working version (contents + lock entry)
+/// from the backup [`add_package`](streamlib::sdk::runtime::AppModulesDir::add_package)
+/// retained, so a failed re-add leaves the operator's installed set untouched
+/// rather than deleting the version that worked.
 pub fn build_added_slot_or_rollback(
     app: &AppModulesDir,
     report: &AddPackageReport,
@@ -75,22 +86,59 @@ pub fn build_added_slot_or_rollback(
     sink: &dyn BuildEventSink,
     policy: BuildPolicy,
 ) -> Result<()> {
+    print_compile_banner(&report.package, &report.version);
     match build_placed_slot(orchestrator, sink, &report.package, &report.package_dir, policy) {
-        Ok(_) => Ok(()),
-        Err(build_err) => {
-            if let Err(rollback_err) = app.remove_package(&report.package) {
+        Ok(_) => {
+            // The compile succeeded — a retained prior slot (from a replace) is
+            // no longer needed. A discard failure is hygiene, never fatal.
+            if let Some(backup) = &report.replaced_slot_backup
+                && let Err(discard_err) = app.commit_replaced_slot_backup(backup)
+            {
                 tracing::warn!(
                     package = %report.package,
-                    error = %rollback_err,
-                    "add: rolling back placement after a build failure also failed"
+                    error = %discard_err,
+                    "add: discarding the retained prior-version backup after a successful build failed"
                 );
             }
-            anyhow::bail!(
-                "building '{}' failed; rolled back its streamlib_modules/ slot and \
-                 streamlib.lock entry:\n{build_err}",
-                report.package
-            )
+            Ok(())
         }
+        Err(build_err) => match &report.replaced_slot_backup {
+            // The add replaced a prior version: put it back, exactly.
+            Some(backup) => {
+                if let Err(restore_err) = app.restore_replaced_slot(&report.package, backup) {
+                    tracing::warn!(
+                        package = %report.package,
+                        error = %restore_err,
+                        "add: restoring the prior version after a build failure also failed"
+                    );
+                    anyhow::bail!(
+                        "building '{}' failed, AND restoring the previously-installed version also \
+                         failed ({restore_err}) — the slot may be in a broken state:\n{build_err}",
+                        report.package
+                    )
+                }
+                anyhow::bail!(
+                    "building '{}' failed; restored the previously-installed version and left \
+                     streamlib.lock unchanged:\n{build_err}",
+                    report.package
+                )
+            }
+            // Fresh add (nothing was replaced): roll back to empty.
+            None => {
+                if let Err(rollback_err) = app.remove_package(&report.package) {
+                    tracing::warn!(
+                        package = %report.package,
+                        error = %rollback_err,
+                        "add: rolling back placement after a build failure also failed"
+                    );
+                }
+                anyhow::bail!(
+                    "building '{}' failed; rolled back its streamlib_modules/ slot and \
+                     streamlib.lock entry:\n{build_err}",
+                    report.package
+                )
+            }
+        },
     }
 }
 
@@ -105,13 +153,14 @@ pub fn build_installed_slots(
     sink: &dyn BuildEventSink,
     policy: BuildPolicy,
 ) -> Result<()> {
+    use std::fmt::Write;
+
     let mut failures: Vec<(PackageRef, anyhow::Error)> = Vec::new();
     for pkg in &report.packages {
         if pkg.kind == InstalledFromLockKind::Linked {
             continue;
         }
-        println!();
-        println!("Building {} v{}…", pkg.package, pkg.version);
+        print_compile_banner(&pkg.package, &pkg.version);
         if let Err(e) =
             build_placed_slot(orchestrator, sink, &pkg.package, &pkg.package_dir, policy)
         {
@@ -124,7 +173,7 @@ pub fn build_installed_slots(
     }
     let mut message = String::from("install failed to build the following package(s):");
     for (package, error) in &failures {
-        message.push_str(&format!("\n  - {package}: {error}"));
+        write!(message, "\n  - {package}: {error}").ok();
     }
     anyhow::bail!(message)
 }
@@ -153,7 +202,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Mutex;
 
-    use streamlib::sdk::runtime::{AddPackageSource, BuildError};
+    use streamlib::sdk::runtime::{AddPackageOptions, AddPackageSource, BuildError};
     use streamlib_idents::{Org, Package};
 
     use super::*;
@@ -192,12 +241,28 @@ mod tests {
     /// Write a minimal schema-only package folder (a valid `package:` manifest,
     /// no processors, so `add_package` places it with no toolchain needed).
     fn write_schema_only_package(dir: &Path, org: &str, name: &str) {
+        write_schema_only_package_versioned(dir, org, name, "0.1.0", None);
+    }
+
+    /// Like [`write_schema_only_package`] but with an explicit version and an
+    /// optional marker file, so two adds of the same identity are
+    /// content-distinguishable (which version currently occupies the slot).
+    fn write_schema_only_package_versioned(
+        dir: &Path,
+        org: &str,
+        name: &str,
+        version: &str,
+        marker_file: Option<&str>,
+    ) {
         std::fs::create_dir_all(dir).unwrap();
         std::fs::write(
             dir.join("streamlib.yaml"),
-            format!("package:\n  org: {org}\n  name: {name}\n  version: 0.1.0\n"),
+            format!("package:\n  org: {org}\n  name: {name}\n  version: {version}\n"),
         )
         .unwrap();
+        if let Some(marker) = marker_file {
+            std::fs::write(dir.join(marker), version).unwrap();
+        }
     }
 
     fn ref_of(org: &str, name: &str) -> PackageRef {
@@ -270,6 +335,72 @@ mod tests {
                 .contains_key("@tatolab/widget"),
             "lock entry must be gone after rollback"
         );
+    }
+
+    #[test]
+    fn add_replaced_slot_restores_prior_version_on_build_failure() {
+        // A working v1 is installed; re-adding a v2 that fails to compile must
+        // restore v1 (its contents AND its lock entry), not leave the slot
+        // empty. Mentally reverting the restore (the old remove-to-empty
+        // rollback) deletes the working version — this asserts against that.
+        let app_root = tempfile::tempdir().unwrap();
+        let src_v1 = tempfile::tempdir().unwrap();
+        let src_v2 = tempfile::tempdir().unwrap();
+        write_schema_only_package_versioned(src_v1.path(), "tatolab", "widget", "0.1.0", Some("VERSION_V1"));
+        write_schema_only_package_versioned(src_v2.path(), "tatolab", "widget", "0.2.0", Some("VERSION_V2"));
+
+        let app = AppModulesDir::at(app_root.path());
+
+        // Install v1 (a working version — add_package never builds).
+        app.add_package(
+            &AddPackageSource::Folder {
+                path: src_v1.path().to_path_buf(),
+            },
+            &Default::default(),
+        )
+        .unwrap();
+
+        // Re-add v2 with the retain option the compile-on-add path uses.
+        let report_v2 = app
+            .add_package(
+                &AddPackageSource::Folder {
+                    path: src_v2.path().to_path_buf(),
+                },
+                &AddPackageOptions {
+                    retain_replaced_slot_backup: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(report_v2.replaced_existing, "v2 must replace the v1 slot");
+        assert!(
+            report_v2.replaced_slot_backup.is_some(),
+            "a replace with retention must carry a restorable backup"
+        );
+
+        // v2 fails to compile.
+        let stub = StubOrchestrator {
+            fail_packages: HashSet::from(["@tatolab/widget".to_string()]),
+            ..Default::default()
+        };
+        let err = build_added_slot_or_rollback(
+            &app,
+            &report_v2,
+            &stub,
+            &ConsoleBuildEventSink,
+            BuildPolicy::IfStale,
+        )
+        .expect_err("a failed re-add build must fail");
+        assert!(err.to_string().contains("restored the previously-installed version"), "{err}");
+
+        // v1 is restored: slot present, v1 contents (not v2), lock pins 0.1.0.
+        let slot = app.package_dir(&ref_of("tatolab", "widget"));
+        assert!(slot.exists(), "the prior version's slot must be restored");
+        assert!(slot.join("VERSION_V1").exists(), "restored slot must hold v1 contents");
+        assert!(!slot.join("VERSION_V2").exists(), "the failed v2 contents must be gone");
+        let lock = app.read_lockfile().unwrap();
+        let entry = lock.packages.get("@tatolab/widget").expect("lock entry must survive");
+        assert_eq!(entry.version.to_string(), "0.1.0", "lock must pin the restored v1");
     }
 
     #[test]

--- a/tools/streamlib-cli/src/commands/install.rs
+++ b/tools/streamlib-cli/src/commands/install.rs
@@ -13,21 +13,42 @@
 //! resolution decisions. Each byte-source entry (folder / archive / URL) is
 //! re-materialized and re-verified against its recorded content hash; a linked
 //! entry's symlink is re-created (a gone checkout target is a typed error — a
-//! dev link isn't reproducible on another machine). Never builds.
+//! dev link isn't reproducible on another machine).
+//!
+//! After reproduction, every materialized (non-linked) slot is compiled
+//! on-the-box with [`BuildPolicy::IfStale`]: install reproduces rather than
+//! acquires, so it does NOT roll back — it aggregates every non-compiling
+//! package and fails listing them all. `--no-build` maps to
+//! [`BuildPolicy::NeverBuild`] (reproduce only). Linked entries stay
+//! lazy/edit-rebuild and are never compiled here.
 
 use std::path::Path;
 
 use anyhow::Result;
-use streamlib::sdk::runtime::{AppModulesDir, InstallFromLockfileReport, InstalledFromLockKind};
+use streamlib::sdk::runtime::{
+    AppModulesDir, BuildPolicy, InstallFromLockfileReport, InstalledFromLockKind,
+};
 
-/// Reproduce the app's `streamlib_modules/` from its `streamlib.lock`.
-pub fn install(dir: Option<&Path>) -> Result<()> {
+use super::build_on_place::{ConsoleBuildEventSink, build_installed_slots, default_orchestrator};
+
+/// Reproduce the app's `streamlib_modules/` from its `streamlib.lock`, then
+/// compile every materialized slot (unless `no_build`).
+pub fn install(dir: Option<&Path>, no_build: bool) -> Result<()> {
     let app = app_modules_dir(dir)?;
     println!("Installing from {}…", app.lockfile_path().display());
     let report = app
         .install_from_lockfile()
         .map_err(|e| anyhow::anyhow!("install failed: {e}"))?;
     print_install_report(&report);
+
+    if !no_build {
+        build_installed_slots(
+            &report,
+            &default_orchestrator(),
+            &ConsoleBuildEventSink,
+            BuildPolicy::IfStale,
+        )?;
+    }
     Ok(())
 }
 

--- a/tools/streamlib-cli/src/commands/install.rs
+++ b/tools/streamlib-cli/src/commands/install.rs
@@ -18,9 +18,9 @@
 //! After reproduction, every materialized (non-linked) slot is compiled
 //! on-the-box with [`BuildPolicy::IfStale`]: install reproduces rather than
 //! acquires, so it does NOT roll back — it aggregates every non-compiling
-//! package and fails listing them all. `--no-build` maps to
-//! [`BuildPolicy::NeverBuild`] (reproduce only). Linked entries stay
-//! lazy/edit-rebuild and are never compiled here.
+//! package and fails listing them all. `--no-build` skips the on-the-box
+//! compile (reproduce only). Linked entries stay lazy/edit-rebuild and are
+//! never compiled here.
 
 use std::path::Path;
 

--- a/tools/streamlib-cli/src/commands/mod.rs
+++ b/tools/streamlib-cli/src/commands/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 pub mod add;
+pub mod build_on_place;
 pub mod generate;
 pub mod install;
 pub mod link;

--- a/tools/streamlib-cli/src/main.rs
+++ b/tools/streamlib-cli/src/main.rs
@@ -94,6 +94,11 @@ enum Commands {
         /// (default: current working directory, no walk-up).
         #[arg(long)]
         dir: Option<PathBuf>,
+
+        /// Reproduce only — skip the on-the-box compile of each materialized
+        /// slot (for toolchain-free machines).
+        #[arg(long)]
+        no_build: bool,
     },
 
     /// Record a dependency (in a package dir) or adopt a package (in an app).
@@ -124,6 +129,11 @@ enum Commands {
         /// prefix). A mismatch fails the add with nothing materialized.
         #[arg(long)]
         expect_sha256: Option<String>,
+
+        /// Place only — skip the on-the-box compile of the added slot (for
+        /// toolchain-free machines).
+        #[arg(long)]
+        no_build: bool,
     },
 
     /// Remove a package from this app's streamlib_modules/ folder.
@@ -353,12 +363,15 @@ async fn async_main(cli: Cli) -> Result<()> {
                 commands::schema::validate_processor(&path)?
             }
         },
-        Some(Commands::Install { dir }) => commands::install::install(dir.as_deref())?,
+        Some(Commands::Install { dir, no_build }) => {
+            commands::install::install(dir.as_deref(), no_build)?
+        }
         Some(Commands::Add {
             spec,
             dir,
             expect_sha256,
-        }) => commands::add::add(&spec, dir.as_deref(), expect_sha256.as_deref())?,
+            no_build,
+        }) => commands::add::add(&spec, dir.as_deref(), expect_sha256.as_deref(), no_build)?,
         Some(Commands::Remove { name, dir }) => commands::add::remove(&name, dir.as_deref())?,
         Some(Commands::Pkg { action }) => match action {
             PkgCommands::Build { output } => commands::pkg::build(output.as_deref())?,


### PR DESCRIPTION
## Ticket

Closes #1507

## Summary

Realizes the #1502 compile-on-install gap: `streamlib add` and `streamlib install` now compile every materialized/placed `streamlib_modules/@org/name` slot on the box (`BuildPolicy::IfStale`) instead of leaving packages placed-but-uncompiled, and both fail fast with the compiler's own diagnostics when a package doesn't build.

- `tools/streamlib-cli/src/commands/build_on_place.rs` (new): `build_placed_slot` / `build_added_slot_or_rollback` / `build_installed_slots` — wraps the engine `BuildOrchestrator` trait (reused, not a parallel build system) to build a package in place, using `ImmutableManagedExtract` provenance since source == destination for this in-place path.
- `tools/streamlib-cli/src/commands/add.rs`: after placement, builds the newly added slot; on build failure, rolls back the add. A **replace** (re-adding an already-installed package) now backs up the prior slot before overwriting and restores it atomically on build failure instead of deleting it — see the fix commit below.
- `tools/streamlib-cli/src/commands/install.rs`: after reproduce-from-lock, builds every installed slot; `--no-build` skips the on-the-box compile entirely (placement/reproduce only).
- `tools/streamlib-cli/src/commands/mod.rs`, `main.rs`: wiring for the new module and CLI flag plumbing.
- Compile diagnostics flow through a new `ConsoleBuildEventSink` (stdout/stderr) — the CLI is the legitimate terminal consumer the injectable `BuildEventSink` trait exists for.
- Follow-up fix commit (`07e94bde`): `add_package` now captures the prior lockfile entry before overwrite and, when `retain_replaced_slot_backup` is set, returns a `ReplacedSlotBackup` pointing at a `.staging-replaced-<pid>-<nanos>` dir. `build_added_slot_or_rollback` restores it on build failure (removes the broken slot, renames the backup back, rewrites the prior lock entry) and discards it via `commit_replaced_slot_backup` on success — closing the silent-data-loss gap a prior verify pass flagged.

## Test evidence

- `cargo test -p streamlib-cli` — green on this branch except for two pre-existing, unrelated failures (see Review items below).
- New regression test `add_replaced_slot_restores_prior_version_on_build_failure` (`build_on_place.rs:340`) installs a working v1, re-adds a v2 with `retain_replaced_slot_backup=true`, fails the compile via `StubOrchestrator` (a real `BuildError::BuildFailed`), then asserts `slot.join("VERSION_V1").exists()`, `!VERSION_V2`, and the lock pins back to `0.1.0`. Mentally reverting `restore_replaced_slot` to the old `remove_package` path empties the slot and fails these assertions — the test is non-vacuous.

## Review items (non-blocking)

- **info** — `sdk/streamlib-idents/src/app_modules.rs:588`: The prior verify finding — a failed compile-on-add that REPLACED an installed package deleted the working version (silent data loss) — is resolved atomically. `add_package` now captures `prior_lockfile_entry` before overwrite and, when `retain_replaced_slot_backup` is set, returns a `ReplacedSlotBackup` pointing at the `.staging-replaced-<pid>-<nanos>` dir. `build_added_slot_or_rollback` (`build_on_place.rs:79`) restores it on build failure via `restore_replaced_slot` (removes broken slot, renames backup back, rewrites the prior lock entry) and discards via `commit_replaced_slot_backup` on success. `sweep_orphan_staging_entries` spares current-process pids, so the retained backup survives the same-process compile step. Both worktree test runs green. Suggested next step: none — mechanism is correct and complete.
- **info** — `tools/streamlib-cli/src/commands/build_on_place.rs:340`: The added regression test locks the fix (non-vacuous). `add_replaced_slot_restores_prior_version_on_build_failure` installs a working v1, re-adds a v2 with `retain_replaced_slot_backup=true`, fails the compile via `StubOrchestrator` (which returns a real `BuildError::BuildFailed`), then asserts `slot.join("VERSION_V1").exists()`, `!VERSION_V2`, and lock pins `0.1.0`. Mentally reverting `restore_replaced_slot` back to the old `remove_package` path empties the slot -> `slot.exists()`/`VERSION_V1` assertions fail. Ran: `cargo test -p streamlib-cli` -> this test passes. Suggested next step: none.
- **info** — `tools/streamlib-cli/src/commands/add.rs:94`: Secondary reword findings applied correctly: `--no-build` docs no longer claim a `BuildPolicy::NeverBuild` mapping, and retain is gated to build runs. No `NeverBuild` references remain in `commands/`; add/install now `if !no_build { build... }` (skip, not a policy map) and docs match. `retain_replaced_slot_backup: !no_build` is correct — nothing to fail when not building. `BuildError` source chain preserved via `anyhow::Error::new` (`build_on_place.rs:64`); install aggregate built with `write!`. New file `build_on_place.rs` carries the BUSL header. Suggested next step: none.
- **info** — `tools/streamlib-cli/src/commands/add.rs:516`: Two streamlib-cli tests are red — but this is a pre-existing repo-wide failure, NOT a delta regression, and out of scope for #1507. `commands::add::tests::record_dependency_range_is_format_preserving` and `_writes_caret_and_preserves_fields` panic on `processors[0]: unknown field `version`` (processor schema drift, tests added in #1473). Confirmed failing identically on a fresh `origin/main` worktree. `streamlib-cli` has no lib target, so per the repo's `cargo test --lib`-only CI these bin tests likely do not gate CI; regardless they are unrelated to this branch. Suggested next step: file a separate ticket to refresh the `record_dependency_range` fixtures against the current processor schema; do not fold into #1507.
