### PR TITLE
feat(engine): installed slot is load-only — typed InstalledPackageNotBuilt, never a cold-build

### DIFF
--- a/docs/architecture/runtime-module-materialization.md
+++ b/docs/architecture/runtime-module-materialization.md
@@ -123,7 +123,7 @@ comes from:
 
 | Variant | Source | Builds? |
 |---|---|---|
-| `InstalledCache` | `<app-root>/streamlib_modules/@org/name` (co-located, version-free) | only if Rust source + no matching prebuilt |
+| `InstalledCache` | `<app-root>/streamlib_modules/@org/name` (co-located, version-free) | never — load-only (unbuilt slot ⇒ typed `InstalledPackageNotBuilt`) |
 | `Path { path, build }` | a directory with `streamlib.yaml` | per `build` |
 | `Slpkg { path }` | a `.slpkg` archive (engine extracts) | only if Rust source + no matching prebuilt |
 | `Git { url, rev, build }` | a git checkout (engine fetches) | per `build` |
@@ -136,11 +136,13 @@ loaded.
 
 ### A `.slpkg` carries source and/or a prebuilt — host prefers prebuilt, else builds
 
-A `.slpkg` (and an `InstalledCache` entry) is a box that can hold **source
-and/or a prebuilt cdylib**, like a pip package shipping both a wheel and an
-sdist. `assemble_artifact` bundles, for a Rust package, *both* the crate
-source (`Cargo.toml` + `src/` …) and the prebuilt cdylib for the packing
-host's triple. On load, the resolver (`source_for_resolved_dir`) decides:
+A `.slpkg` is a box that can hold **source and/or a prebuilt cdylib**, like
+a pip package shipping both a wheel and an sdist. `assemble_artifact`
+bundles, for a Rust package, *both* the crate source (`Cargo.toml` + `src/`
+…) and the prebuilt cdylib for the packing host's triple. On load, the
+`.slpkg` / `Url` / `Registry` resolver (`source_for_resolved_dir`) decides
+(the co-located `InstalledCache` slot is load-only — it never runs this
+build fallback; an unbuilt slot is a typed `InstalledPackageNotBuilt`):
 
 ```
 manifest has Rust processors?
@@ -222,7 +224,10 @@ If a build-requiring policy (`IfStale` or `AlwaysBuild`) is reached with
 package shape. Future agents get a clear signal instead of a
 silently-loaded, possibly-stale artifact. A no-build deployment uses
 `NeverBuild` / `InstalledCache` / `.slpkg`; a building one wires an
-orchestrator (`Runner::with_auto_build()`).
+orchestrator (`Runner::with_auto_build()`). The co-located `InstalledCache`
+slot never reaches this arm at all — it is load-only, so an unbuilt slot
+fails as `InstalledPackageNotBuilt` (fix-it: `streamlib install`) regardless
+of whether an orchestrator is wired, never `BuildRequiredButNoOrchestrator`.
 
 ## The eager async surface
 

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/errors.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/errors.rs
@@ -23,6 +23,25 @@ pub enum AddModuleError {
         package: streamlib_idents::PackageRef,
     },
 
+    /// An installed `streamlib_modules/@org/name` slot was found but is not
+    /// built for this host: it carries buildable Rust source with no matching
+    /// prebuilt cdylib, or a Python/Deno runtime with no provisioning (no
+    /// `.venv`, no regenerated `_generated_/`). The installed-slot loader is
+    /// load-only — it never cold-builds on the app's critical path (that is
+    /// `streamlib install`'s job) — so an unbuilt slot is this typed fix-it
+    /// rather than a silent runtime compile or a
+    /// [`Self::BuildRequiredButNoOrchestrator`]. `.slpkg` / `Url` / `Registry`
+    /// resolves still build the bundled source; only the installed slot is gated.
+    #[error(
+        "Installed package '{package}' (version {version}) is present but not \
+         built for this host. Run `streamlib install` to build it, then run \
+         again — the runtime never cold-builds an installed package on load."
+    )]
+    InstalledPackageNotBuilt {
+        package: streamlib_idents::PackageRef,
+        version: streamlib_idents::SemVer,
+    },
+
     /// Workspace stage dir or installed-cache entry was found but the
     /// `streamlib.yaml` failed to parse / lacked a `package:` block.
     #[error(

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
@@ -458,7 +458,8 @@ pub(super) fn resolve_strategy_to_source(
 /// production, an explicit dir in tests; `None` (unresolvable cwd) or a missing
 /// slot is a typed [`AddModuleError::ModuleNotFound`]. Post-#1506 the installed
 /// slot IS this folder, so there is no separate installed-package cache to fall
-/// back to.
+/// back to. Load-only: a present-but-unbuilt slot is a typed
+/// [`AddModuleError::InstalledPackageNotBuilt`], never a runtime cold-build.
 fn resolve_installed_cache_strategy(
     pkg_ref: &streamlib_idents::PackageRef,
     app_root: Option<&std::path::Path>,
@@ -473,9 +474,24 @@ fn resolve_installed_cache_strategy(
         source = %modules_package_dir.display(),
         "resolving module from the app's streamlib_modules folder"
     );
-    // Same prefer-prebuilt-else-build-source decision as `.slpkg`:
-    // the slot may carry source needing a host build.
-    source_for_resolved_dir(pkg_ref, modules_package_dir)
+    // Load-only, UNLIKE `.slpkg` / `Url` / `Registry` (which build the bundled
+    // source on the host via `source_for_resolved_dir`). An installed slot must
+    // already carry its host-matched prebuilt (Rust) and its provisioning
+    // (Python `.venv` / Deno `_generated_/`) — building it here would be a silent
+    // runtime cold-build on the app's critical path. The build is `streamlib
+    // install`'s job (#1502/#1507); an unbuilt slot is a typed fix-it, so this
+    // strategy NEVER emits `NeedsBuild` and a no-orchestrator run yields
+    // `InstalledPackageNotBuilt`, not `BuildRequiredButNoOrchestrator`. The two
+    // oracles are the SAME ones `source_for_resolved_dir` uses, so "unbuilt" here
+    // means exactly "would have been NeedsBuild there".
+    if needs_host_build(&modules_package_dir) || needs_polyglot_provisioning(&modules_package_dir) {
+        let version = read_version_from_manifest_dir(&modules_package_dir)?;
+        return Err(AddModuleError::InstalledPackageNotBuilt {
+            package: pkg_ref.clone(),
+            version,
+        });
+    }
+    Ok(ResolvedSource::Ready(modules_package_dir))
 }
 
 pub(crate) use crate::core::streamlib_home::{app_modules_root, set_app_modules_root_override};
@@ -1032,6 +1048,118 @@ mod tests {
             streamlib_idents::Org::new("tatolab").unwrap(),
             streamlib_idents::Package::new("rp").unwrap(),
         )
+    }
+
+    fn py_pkg_ref() -> streamlib_idents::PackageRef {
+        streamlib_idents::PackageRef::new(
+            streamlib_idents::Org::new("tatolab").unwrap(),
+            streamlib_idents::Package::new("py").unwrap(),
+        )
+    }
+
+    // =====================================================================
+    // resolve_installed_cache_strategy — the installed slot is LOAD-ONLY:
+    // it prefers the on-box-built artifact and NEVER cold-builds. An unbuilt
+    // slot is the typed `InstalledPackageNotBuilt` fix-it, never `NeedsBuild`
+    // (unlike `.slpkg` / `Url` / `Registry`, which build the bundled source).
+    // =====================================================================
+
+    /// Stage a `<app_root>/streamlib_modules/@tatolab/<name>` slot carrying
+    /// `manifest_body`, returning the slot dir so a test can drop a
+    /// `Cargo.toml` / prebuilt / `pyproject.toml` into it.
+    fn stage_installed_slot(
+        app_root: &std::path::Path,
+        name: &str,
+        manifest_body: &str,
+    ) -> PathBuf {
+        let slot = app_root
+            .join(streamlib_idents::app_modules::APP_MODULES_DIR_NAME)
+            .join("@tatolab")
+            .join(name);
+        std::fs::create_dir_all(&slot).unwrap();
+        manifest(&slot, manifest_body);
+        slot
+    }
+
+    /// CRUX (bug-reproduce): an installed slot with buildable Rust source but
+    /// NO matching prebuilt resolves to the typed `InstalledPackageNotBuilt`
+    /// fix-it (carrying the slot's version), NOT `NeedsBuild`. Mentally revert
+    /// the load-only guard (fall back to `source_for_resolved_dir`) and this
+    /// resolves to `NeedsBuild`, failing the match — a silent runtime cold-build.
+    #[test]
+    fn installed_cache_unbuilt_rust_slot_is_typed_not_built_error() {
+        let app_root = tempfile::tempdir().unwrap();
+        let slot = stage_installed_slot(app_root.path(), "rp", RUST_YAML);
+        std::fs::write(slot.join("Cargo.toml"), b"[package]\nname='rp'\n").unwrap();
+        let err = resolve_installed_cache_strategy(&pkg_ref(), Some(app_root.path()))
+            .expect_err("unbuilt installed slot must fail loud");
+        match err {
+            AddModuleError::InstalledPackageNotBuilt { package, version } => {
+                assert_eq!(package, pkg_ref());
+                assert_eq!(version, streamlib_idents::SemVer::new(0, 1, 0));
+            }
+            other => panic!("expected InstalledPackageNotBuilt, got {other:?}"),
+        }
+    }
+
+    /// An installed slot carrying a host-matched prebuilt loads as-is
+    /// (`Ready`) — zero build. The prefer-prebuilt half of the load-only gate.
+    #[test]
+    fn installed_cache_prebuilt_slot_is_ready() {
+        let app_root = tempfile::tempdir().unwrap();
+        let slot = stage_installed_slot(app_root.path(), "rp", RUST_YAML);
+        std::fs::write(slot.join("Cargo.toml"), b"[package]\nname='rp'\n").unwrap();
+        let triple_dir = slot.join("lib").join(host_target_triple());
+        std::fs::create_dir_all(&triple_dir).unwrap();
+        std::fs::write(triple_dir.join("librp.so"), b"prebuilt").unwrap();
+        let resolved =
+            resolve_installed_cache_strategy(&pkg_ref(), Some(app_root.path())).unwrap();
+        assert!(matches!(resolved, ResolvedSource::Ready(_)));
+    }
+
+    /// A schemas-only installed slot (no Rust, no Python/Deno runtime) needs
+    /// no build and loads as-is — the load-only gate must not over-fire on a
+    /// package that was never buildable.
+    #[test]
+    fn installed_cache_schemas_only_slot_is_ready() {
+        let app_root = tempfile::tempdir().unwrap();
+        stage_installed_slot(
+            app_root.path(),
+            "rp",
+            "package:\n  org: tatolab\n  name: rp\n  version: 0.1.0\n",
+        );
+        let resolved =
+            resolve_installed_cache_strategy(&pkg_ref(), Some(app_root.path())).unwrap();
+        assert!(matches!(resolved, ResolvedSource::Ready(_)));
+    }
+
+    /// An unprovisioned Python installed slot (`pyproject.toml` present, no
+    /// `.venv`) is ALSO the typed fix-it — the polyglot-provisioning half of
+    /// the same load-only gate.
+    #[test]
+    fn installed_cache_unprovisioned_python_slot_is_typed_not_built_error() {
+        let app_root = tempfile::tempdir().unwrap();
+        let slot = stage_installed_slot(app_root.path(), "py", PY_YAML);
+        std::fs::write(slot.join("pyproject.toml"), b"[project]\nname = \"py\"\n").unwrap();
+        let err = resolve_installed_cache_strategy(&py_pkg_ref(), Some(app_root.path()))
+            .expect_err("unprovisioned python installed slot must fail loud");
+        assert!(
+            matches!(err, AddModuleError::InstalledPackageNotBuilt { .. }),
+            "expected InstalledPackageNotBuilt, got {err:?}",
+        );
+    }
+
+    /// A missing slot is `ModuleNotFound`, not `InstalledPackageNotBuilt` —
+    /// the not-built gate only applies to a slot that actually exists.
+    #[test]
+    fn installed_cache_missing_slot_is_module_not_found() {
+        let app_root = tempfile::tempdir().unwrap();
+        let err = resolve_installed_cache_strategy(&pkg_ref(), Some(app_root.path()))
+            .expect_err("missing installed slot must fail loud");
+        assert!(
+            matches!(err, AddModuleError::ModuleNotFound { .. }),
+            "expected ModuleNotFound, got {err:?}",
+        );
     }
 
     /// A Rust box carrying source but no matching prebuilt: `NeverBuild`
@@ -1674,12 +1802,19 @@ mod tests {
         slot
     }
 
+    /// Stage a `.venv/bin/python` under `dir` so a Python fixture slot reads as
+    /// provisioned (built). The load-only installed-slot resolver then returns
+    /// `Ready` for it instead of the `InstalledPackageNotBuilt` fix-it.
+    fn provision_python_venv(dir: &std::path::Path) {
+        let venv_bin = dir.join(".venv").join("bin");
+        std::fs::create_dir_all(&venv_bin).unwrap();
+        std::fs::write(venv_bin.join("python"), b"#!/bin/sh\n").unwrap();
+    }
+
     /// The resolved package dir regardless of whether it loads directly
     /// (`Ready`) or routes through the orchestrator (`NeedsBuild`) — used by
     /// the precedence tests below, which assert *which* dir won independent of
-    /// the build/provision decision. A Python-only fixture (the realistic
-    /// installed-cache / `streamlib_modules` shape) routes to `NeedsBuild`
-    /// because it needs its venv provisioned.
+    /// the build/provision decision.
     fn resolved_dir(resolved: &ResolvedSource) -> PathBuf {
         match resolved {
             ResolvedSource::Ready(dir) => dir.clone(),
@@ -1690,12 +1825,12 @@ mod tests {
         }
     }
 
-    /// A co-located package materialized at its `streamlib_modules/` slot
-    /// resolves to that dir under the app root. Post-#1506 the installed slot
-    /// IS the `<app-root>/streamlib_modules/@org/name` folder the resolver reads
-    /// directly. (The Python-only fixture routes to `NeedsBuild` — see
-    /// [`resolved_dir`] — so the assertion is on the resolved dir, not the
-    /// variant.)
+    /// A co-located package materialized (and provisioned) at its
+    /// `streamlib_modules/` slot resolves to that dir under the app root.
+    /// Post-#1506 the installed slot IS the `<app-root>/streamlib_modules/@org/name`
+    /// folder the resolver reads directly. The slot is provisioned (its venv
+    /// staged) so the load-only resolver returns it `Ready` rather than the
+    /// not-built fix-it.
     #[test]
     #[serial_test::serial]
     fn installed_cache_strategy_resolves_colocated_app_modules_dir() {
@@ -1703,7 +1838,8 @@ mod tests {
         let _guard = sandbox_home(home.path());
         let app_root = tempfile::tempdir().unwrap();
         let modules_dir = write_app_modules_package(app_root.path(), "foo", "foo");
-        record_installed_cache_package(app_root.path(), "foo");
+        let slot = record_installed_cache_package(app_root.path(), "foo");
+        provision_python_venv(&slot);
 
         let resolved =
             resolve_installed_cache_strategy(&pkg_ref_named("foo"), Some(app_root.path()))
@@ -1711,7 +1847,7 @@ mod tests {
         assert_eq!(resolved_dir(&resolved), modules_dir);
     }
 
-    /// A package materialized at its co-located slot resolves to that exact
+    /// A provisioned package at its co-located slot resolves to that exact
     /// slot — the write==read tie between the fixture's on-disk slot and the dir
     /// the resolver derives from the app-modules root through the shared seam.
     #[test]
@@ -1721,6 +1857,7 @@ mod tests {
         let _guard = sandbox_home(home.path());
         let app_root = tempfile::tempdir().unwrap();
         let slot = record_installed_cache_package(app_root.path(), "foo");
+        provision_python_venv(&slot);
 
         let resolved =
             resolve_installed_cache_strategy(&pkg_ref_named("foo"), Some(app_root.path()))
@@ -1749,27 +1886,30 @@ mod tests {
         );
     }
 
-    /// CRUX (bug path): a Python-only package resolved from the app's
-    /// `streamlib_modules/` folder with no provisioned venv must resolve to
-    /// `NeedsBuild` (source = the app-modules dir) so `materialize` provisions
-    /// the venv at the cache slot it loads from — the exact
-    /// `resolve_installed_cache_strategy` path that shipped the module as-is and
-    /// left the subprocess spawn with `.venv/bin/python: No such file or
-    /// directory`. Mentally revert the `needs_polyglot_provisioning` clause in
-    /// `source_for_resolved_dir` and this resolves to `Ready`, failing
-    /// `assert_builds_from`.
+    /// CRUX (#1508): a Python-only package resolved from the app's
+    /// `streamlib_modules/` folder with no provisioned venv is LOAD-ONLY — it
+    /// resolves to the typed `InstalledPackageNotBuilt` fix-it, NOT `NeedsBuild`.
+    /// The installed-slot loader never cold-builds on the app's critical path
+    /// (that is `streamlib install`'s job, #1502/#1507); unlike a `.slpkg` /
+    /// `Url` / `Registry` resolve, it does not fall through to
+    /// `source_for_resolved_dir`. Mentally revert the load-only guard in
+    /// `resolve_installed_cache_strategy` and this resolves to `NeedsBuild` (a
+    /// silent runtime cold-build), failing the match.
     #[test]
     #[serial_test::serial]
-    fn installed_cache_strategy_routes_unprovisioned_python_app_module_to_build() {
+    fn installed_cache_strategy_unprovisioned_python_app_module_is_not_built_error() {
         let home = tempfile::tempdir().unwrap();
         let _guard = sandbox_home(home.path());
         let app_root = tempfile::tempdir().unwrap();
-        let modules_dir = write_app_modules_package(app_root.path(), "foo", "foo");
+        write_app_modules_package(app_root.path(), "foo", "foo");
 
-        let resolved =
-            resolve_installed_cache_strategy(&pkg_ref_named("foo"), Some(app_root.path()))
-                .expect("must resolve");
-        assert_builds_from(resolved, &modules_dir);
+        let err = resolve_installed_cache_strategy(&pkg_ref_named("foo"), Some(app_root.path()))
+            .expect_err("an unprovisioned python installed slot must fail loud, not build");
+        assert!(
+            matches!(err, AddModuleError::InstalledPackageNotBuilt { ref package, version }
+                if package.name.as_str() == "foo" && version == streamlib_idents::SemVer::new(0, 9, 0)),
+            "expected InstalledPackageNotBuilt(foo 0.9.0), got {err:?}",
+        );
     }
 
     /// No streamlib_modules slot for the package ⇒ typed ModuleNotFound.

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
@@ -47,9 +47,12 @@ pub enum Strategy {
     /// populated by `streamlib add` / `install`). Post-#1506 the installed slot
     /// IS this folder: a package's presence is its `@org/name` dir plus its own
     /// manifest, resolved directly with no separate installed-package record.
-    /// Never builds a package that carries a matching prebuilt. The default for
-    /// bare top-level [`Runner::add_module`] loads (transitive registry-flavored
-    /// deps map to [`Strategy::Registry`] instead).
+    /// Load-only: it never builds. An unbuilt slot (no matching prebuilt, or no
+    /// polyglot provisioning) is a typed
+    /// [`AddModuleError::InstalledPackageNotBuilt`] carrying a `streamlib install`
+    /// fix-it, never a runtime cold-build. The default for bare top-level
+    /// [`Runner::add_module`] loads (transitive registry-flavored deps map to
+    /// [`Strategy::Registry`] instead).
     /// Precedence: active `streamlib link` > the co-located slot.
     ///
     /// [`Runner::add_module`]: super::super::Runner::add_module
@@ -481,10 +484,10 @@ fn resolve_installed_cache_strategy(
     // runtime cold-build on the app's critical path. The build is `streamlib
     // install`'s job (#1502/#1507); an unbuilt slot is a typed fix-it, so this
     // strategy NEVER emits `NeedsBuild` and a no-orchestrator run yields
-    // `InstalledPackageNotBuilt`, not `BuildRequiredButNoOrchestrator`. The two
-    // oracles are the SAME ones `source_for_resolved_dir` uses, so "unbuilt" here
-    // means exactly "would have been NeedsBuild there".
-    if needs_host_build(&modules_package_dir) || needs_polyglot_provisioning(&modules_package_dir) {
+    // `InstalledPackageNotBuilt`, not `BuildRequiredButNoOrchestrator`. Shares
+    // `needs_build_or_provisioning` with `source_for_resolved_dir`, so "unbuilt"
+    // here means exactly "would have been NeedsBuild there".
+    if needs_build_or_provisioning(&modules_package_dir) {
         let version = read_version_from_manifest_dir(&modules_package_dir)?;
         return Err(AddModuleError::InstalledPackageNotBuilt {
             package: pkg_ref.clone(),
@@ -583,7 +586,7 @@ fn source_for_resolved_dir(
     pkg_ref: &streamlib_idents::PackageRef,
     dir: PathBuf,
 ) -> std::result::Result<ResolvedSource, AddModuleError> {
-    if needs_host_build(&dir) || needs_polyglot_provisioning(&dir) {
+    if needs_build_or_provisioning(&dir) {
         let staging_destination_slot_dir = staging_slot_for_dir(pkg_ref);
         Ok(ResolvedSource::NeedsBuild(BuildRequest {
             package: pkg_ref.clone(),
@@ -696,6 +699,15 @@ fn needs_polyglot_provisioning(dir: &std::path::Path) -> bool {
     };
     let deno_unprovisioned = declares_deno && !dir.join("_generated_").is_dir();
     python_unprovisioned || deno_unprovisioned
+}
+
+/// Whether a resolved package dir must be built or provisioned before it can
+/// load. The single oracle the installed-slot loader
+/// ([`resolve_installed_cache_strategy`]) and the build resolver
+/// ([`source_for_resolved_dir`]) share so their "unbuilt" verdict is one
+/// definition, not two copies that must be kept identical by hand.
+fn needs_build_or_provisioning(dir: &std::path::Path) -> bool {
+    needs_host_build(dir) || needs_polyglot_provisioning(dir)
 }
 
 /// Whether `dir` declares Rust processors AND carries a `Cargo.toml` to

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/tests.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/tests.rs
@@ -1310,6 +1310,61 @@ mod add_module_tests {
         );
     }
 
+    /// A Rust `streamlib.yaml` (one Rust-runtime processor) for `name`, staged
+    /// into an installed slot as source needing a host build.
+    fn rust_source_manifest(name: &str) -> String {
+        format!(
+            "package:\n  org: tatolab\n  name: {name}\n  version: \"0.1.0\"\n\
+             processors:\n  - name: RustProc\n    description: \"source-only rust processor\"\n\
+             \x20   runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n"
+        )
+    }
+
+    /// ACCEPTANCE (#1508): referencing an installed-but-unbuilt package yields
+    /// the typed `InstalledPackageNotBuilt` fix-it AND the wired orchestrator is
+    /// NEVER asked to materialize it — zero cold-build on the app's critical
+    /// path (so no `Building`/`BuildLog` event can fire, since those come only
+    /// from the orchestrator's build). An installed Rust slot with source but no
+    /// prebuilt is the unbuilt case. Mentally revert the load-only gate in
+    /// `resolve_installed_cache_strategy` and the orchestrator materializes the
+    /// slot (count > 0) and the load succeeds — failing both assertions.
+    #[test]
+    #[serial]
+    fn installed_cache_unbuilt_slot_errors_without_building() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = HomeGuard::install(home.path());
+        // Unbuilt Rust slot: a Rust-runtime manifest + Cargo.toml, no prebuilt.
+        let slot = installed_package_slot_for_test("tatolab", "unbuilt-rust");
+        std::fs::create_dir_all(&slot).unwrap();
+        std::fs::write(slot.join("streamlib.yaml"), rust_source_manifest("unbuilt-rust")).unwrap();
+        std::fs::write(slot.join("Cargo.toml"), b"[package]\nname='unbuilt-rust'\n").unwrap();
+
+        let counts = Arc::new(parking_lot::Mutex::new(
+            std::collections::HashMap::<std::path::PathBuf, usize>::new(),
+        ));
+        let runtime = Runner::new().expect("Runner::new");
+        runtime.set_build_orchestrator(MaterializeCountingOrchestrator {
+            counts: Arc::clone(&counts),
+        });
+
+        let err = runtime
+            .add_module_blocking(ModuleIdent::any(
+                Org::new("tatolab").unwrap(),
+                Package::new("unbuilt-rust").unwrap(),
+            ))
+            .expect_err("an installed-but-unbuilt slot must fail loud");
+        assert!(
+            matches!(err, AddModuleError::InstalledPackageNotBuilt { ref package, version }
+                if package.name.as_str() == "unbuilt-rust" && version == SemVer::new(0, 1, 0)),
+            "expected InstalledPackageNotBuilt(unbuilt-rust 0.1.0), got: {err:?}",
+        );
+        assert_eq!(
+            count_materializations_for_dir_named(&counts, "unbuilt-rust"),
+            0,
+            "the loader must NEVER cold-build an installed slot — no orchestrator call may fire",
+        );
+    }
+
     #[test]
     #[serial]
     fn path_strategy_loads_arbitrary_dir() {


### PR DESCRIPTION
Closes #1508

## Summary

`Strategy::InstalledCache` now resolves **load-only**: a co-located `streamlib_modules/@org/name` slot must already carry its host-matched prebuilt (Rust) and provisioning (Python `.venv` / Deno `_generated_`). `resolve_installed_cache_strategy` reuses the existing `needs_host_build` / `needs_polyglot_provisioning` oracles and returns the typed `AddModuleError::InstalledPackageNotBuilt { package, version }` fix-it instead of emitting `NeedsBuild`.

Because the installed slot never emits `NeedsBuild` anymore:
- A no-orchestrator run yields the typed `InstalledPackageNotBuilt` error, not `BuildRequiredButNoOrchestrator`.
- A `with_auto_build` run no longer silently cold-builds on the app's critical path — no `Building`/`BuildLog` events fire for an installed slot.

`source_for_resolved_dir` (used by `Slpkg` / `Url` / `Registry` strategies) is unchanged — those strategies still build bundled source on the host. Session live-submit (`Strategy::Path` `IfStale`) and locked runs (`NeverBuild`) were already prebuilt-loading and are untouched; acquire-on-reference and lazy discovery inherit the fix through `Strategy::InstalledCache`.

As part of the same change, the compile-on-add rollback machinery in `sdk/streamlib-idents/src/app_modules.rs` (`AddPackageOptions.retain_replaced_slot_backup`, `AddPackageReport.replaced_slot_backup`, `ReplacedSlotBackup`, `commit_replaced_slot_backup`, `restore_replaced_slot`, `PromotedSlot`) is removed since it existed to support cold-building on add, which this PR eliminates; `promote_staged_package_root` reverts to returning a plain `bool`. `tools/streamlib-cli/src/commands/build_on_place.rs` is deleted and `streamlib install` no longer builds installed slots.

## Test evidence

- Full engine lib suite: **1713 passed, 0 failed**.
- Regression-locks verified non-vacuous: reverting the new guard block back to the old `source_for_resolved_dir(pkg_ref, modules_package_dir)` call causes exactly 4 tests to fail:
  - `installed_cache_unbuilt_rust_slot_is_typed_not_built_error`
  - `installed_cache_unprovisioned_python_slot_is_typed_not_built_error`
  - `installed_cache_strategy_unprovisioned_python_app_module_is_not_built_error`
  - `installed_cache_unbuilt_slot_errors_without_building`
  while `installed_cache_prebuilt_slot_is_ready` / `_schemas_only_` / `_missing_slot_` correctly stay green. Restoring the fix brings the suite back to 1713 passed, 0 failed.

## Review items (non-blocking)

- **[info]** `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:476` — The load-only guard is correct and the negative tests actually fail when the fix is reverted (non-vacuous). Evidence: Replaced the new guard block with the old `source_for_resolved_dir(pkg_ref, modules_package_dir)` call and re-ran: exactly 4 tests failed (`installed_cache_unbuilt_rust_slot_is_typed_not_built_error`, `installed_cache_unprovisioned_python_slot_is_typed_not_built_error`, `installed_cache_strategy_unprovisioned_python_app_module_is_not_built_error`, `installed_cache_unbuilt_slot_errors_without_building`) while `installed_cache_prebuilt_slot_is_ready` / `_schemas_only_` / `_missing_slot_` correctly stayed green. Restored: full engine lib suite 1713 passed, 0 failed. Suggested next step: None — tests lock the behavior.

- **[info]** `runtime/streamlib-engine/src/core/runtime/module_loader/tests.rs:1330` — Acceptance (b) — the `@session/` live-submit counter-test — has no dedicated new assertion on this branch; it is covered structurally rather than by a new test. Evidence: Session live-submit routes through `Strategy::Path` (`from_source.rs` docs + grep confirms `InstalledCache` is only used by acquire-on-reference/lazy-discovery/blocking `add_module`, not session). The demote only edits `resolve_installed_cache_strategy`, so the session build path is untouched by construction and existing path/build tests (`python_source_package_without_orchestrator_fails_loud`, `if_stale_without_orchestrator_fails_loud`) still pass. Suggested next step: Optional — note in the PR body that the session counter-path is covered structurally (different strategy) rather than by a new dedicated test.

- **[info]** `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:37` — The `Strategy` doc comment ("InstalledCache: cache only, no build, fail loud if absent") now matches the implementation; previously it was aspirational since the arm actually built via `source_for_resolved_dir`. Evidence: `source.rs:36-40` doc already described load-only semantics; this PR brings the `InstalledCache` arm in line with that documented contract. Suggested next step: None.

- **[low]** `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:50` — The `Strategy::InstalledCache` variant rustdoc still reads "Never builds a package that carries a matching prebuilt," which under-describes the new load-only behavior — the sweep updated the arch doc and the errors.rs doc but missed the variant's own doc. Evidence: Line 50 says "Never builds a package that carries a matching prebuilt." Post-change, `InstalledCache` never builds AT ALL: a slot without a matching prebuilt now errors as `InstalledPackageNotBuilt` rather than building. The statement is still literally true (a prebuilt-carrying package is never built) but omits the load-only-error-when-unbuilt half that is the whole point of this PR. The enum-level doc at line 37 ("cache only, no build, fail loud if absent") is now the more accurate description. Suggested next step: Amend the `source.rs:46-53` variant rustdoc to state the slot is load-only: it never builds, and an unbuilt slot (no matching prebuilt / no polyglot provisioning) is a typed `InstalledPackageNotBuilt` fix-it. Ships as a PR review item; no code change needed.

- **[info]** `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:478` — The load-only gate is correctly derived and its equivalence claim to `source_for_resolved_dir` is sound; behavior change is an intentional tightening, not a stranding. Evidence: The new guard uses `needs_host_build(dir) || needs_polyglot_provisioning(dir)` — byte-identical to `source_for_resolved_dir`'s predicate at `source.rs:570`. For a no-orchestrator locked run this converts the old `BuildRequiredButNoOrchestrator` into a more actionable `InstalledPackageNotBuilt`; for a `with_auto_build` run it replaces a silent runtime cold-build with a loud fix-it — exactly the #1508 intent and the owner's #1502 compile-on-install direction (no owner-question warranted, the direction is already decided in the #1502/#1507/#1508 chain). Suggested next step: None — ship.

- **[should-fix]** `runtime/streamlib-engine/src/core/runtime/module_loader/errors.rs:36` — The `InstalledPackageNotBuilt` error text instructs "Run `streamlib install` to build it, then run again", but this same PR rewrites `tools/streamlib-cli/src/commands/install.rs` so install no longer builds — the module docstring now reads "Never builds." (`install.rs:16`) and the `build_installed_slots` call is deleted (`build_on_place.rs` removed entirely). The user-facing remediation points at a command this PR made a no-op for that purpose; for a source-only installed slot with no prebuilt, `streamlib install` reproduces the same unbuilt slot and the runtime re-emits the same error — an inescapable loop with no build path left in the CLI. Evidence: `errors.rs:36-38` message string vs `install.rs:16` ("Never builds.") and `install.rs:24` (`pub fn install(dir)` with the `build_installed_slots` block deleted); `git grep` confirms no remaining installed-slot build path in the CLI (`pkg.rs` `no_build` is the unrelated `.slpkg`-assembly flag). Suggested next step: Reconcile the two files in this PR: either reword the fix-it so it does not claim `streamlib install` builds (point at the actual build path, e.g. the #1502 compile-on-install flow), or restore install's build. Flag to the change-verifier/owner whether removing install's build is in-scope for #1508 given #1502 compile-on-install has not landed.

- **[should-fix]** `runtime/streamlib-engine/src/core/runtime/module_loader/source.rs:487` — The "does this dir need a build/provision before it can load" predicate `needs_host_build(dir) || needs_polyglot_provisioning(dir)` is now duplicated verbatim across `resolve_installed_cache_strategy` (`source.rs:487`) and `source_for_resolved_dir` (`source.rs:586`). The inline comment explicitly states the two must stay identical ("The two oracles are the SAME ones `source_for_resolved_dir` uses, so 'unbuilt' here means exactly 'would have been NeedsBuild there'") — a lockstep invariant currently maintained by copy, not by structure. If a third oracle (e.g. a `needs_C` clause) is later added to one site, the other silently drifts and the installed-slot loader disagrees with the build resolver. Evidence: `source.rs:487` `if needs_host_build(&modules_package_dir) || needs_polyglot_provisioning(&modules_package_dir)` and `source.rs:586` `if needs_host_build(&dir) || needs_polyglot_provisioning(&dir)` — same boolean over the same two helpers, with a paragraph of comments asserting they can never disagree. Suggested next step: Extract `fn needs_build_or_provisioning(dir: &std::path::Path) -> bool { needs_host_build(dir) || needs_polyglot_provisioning(dir) }` and call it from both sites, making the "these must match" contract structural instead of comment-enforced.

- **[info]** `sdk/streamlib-idents/src/app_modules.rs:1311` — The removal of the compile-on-add rollback machinery (`AddPackageOptions.retain_replaced_slot_backup`, `AddPackageReport.replaced_slot_backup`, `ReplacedSlotBackup`, `commit_replaced_slot_backup`, `restore_replaced_slot`, and the `PromotedSlot` struct collapsing back to a plain `bool`) is clean and complete — all four `promote_staged_package_root` call sites were updated, `..Default::default()` spreads dropped where the struct is now single-field, and `git grep` shows no dangling references to any removed symbol. Good simplification, no craftsmanship concern. Evidence: `promote_staged_package_root` return type reverted `Result<PromotedSlot,_>` → `Result<bool,_>`; no remaining refs to `ReplacedSlotBackup`/`retain_replaced_slot_backup`/`restore_replaced_slot` across the branch. Suggested next step: None — noted as a positive.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
