### PR TITLE
feat(idents): version never blocks a load — remove hard VersionRangeConflict stop

### DIFF
--- a/docs/architecture/package-development-model.md
+++ b/docs/architecture/package-development-model.md
@@ -220,9 +220,15 @@ under one lock: the first resolver to reach a package inserts an
 `InFlightPlaceholder`; a second load that observes the placeholder skips and
 waits on a `PackageResolutionCompletionSignal` at the *end* of the walk
 (600s timeout) rather than blocking inside the gate — so the design is
-deadlock-free (no thread blocks holding the packages lock). A concrete
-version mismatch raises `SingleVersionConflict { package, existing_version,
-existing_required_by, conflicting_version, conflicting_required_by }`.
+deadlock-free (no thread blocks holding the packages lock). A live
+re-encounter that resolves the same package to a *different* concrete
+version warns and dedupes to the first-resolved winner (single-version
+model — a version mismatch never blocks a load; an incompatibility
+surfaces at runtime), never a hard conflict. Range enforcement is hard
+only at a *locked* run: an installed slot whose on-disk version drifts
+from its lockfile `Exact` pin raises `VersionRangeUnsatisfied` (a
+reproducibility/integrity failure), keeping the range→concrete resolver
+(install) and the concrete-enforcement resolver (locked run) separate.
 `InFlightPlaceholderGuard` is RAII: flipped-to-committed by the load's
 whole-load commit on success (registration is transactional — see
 [`runtime-module-materialization.md`](runtime-module-materialization.md)),

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/errors.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/errors.rs
@@ -69,13 +69,20 @@ pub enum AddModuleError {
         actual: String,
     },
 
-    /// On-disk version doesn't satisfy the ident's [`SemVerRange`].
+    /// Locked-run integrity failure: an installed slot's on-disk version
+    /// doesn't satisfy the lockfile's `Exact` pin — the slot drifted from the
+    /// pinned version after install (an in-place republish that kept the dir).
+    /// Hard by the locked-run reproducibility contract. A *live* (install- or
+    /// dev-derived) walk never raises this: a declared range that no installed
+    /// version satisfies warns and loads the installed version (single-version
+    /// model — a version mismatch never blocks a live load).
     ///
     /// [`SemVerRange`]: streamlib_idents::SemVerRange
     #[error(
-        "Module '{module}' resolved to version {found} at {} which doesn't \
-         satisfy the requested range. Install a matching version or relax \
-         the range.",
+        "Locked run: module '{module}' resolved to version {found} at {} which \
+         doesn't satisfy the lockfile pin — the installed slot drifted from the \
+         pinned version. Re-run `streamlib install` to re-materialize and \
+         re-pin, then run again.",
         source_path.display()
     )]
     VersionRangeUnsatisfied {
@@ -301,33 +308,6 @@ pub enum AddModuleError {
     )]
     DependencyCycleDetected {
         cycle: Vec<streamlib_idents::PackageRef>,
-    },
-
-    /// Two requirers resolved the same `@org/name` package to different
-    /// concrete versions within the runtime's lifetime — a diamond
-    /// version conflict. The engine enforces a single version per package
-    /// across the whole module graph (and across successive `add_module`
-    /// calls), so this is a hard error rather than a silent
-    /// double-registration. Resolve it by pinning a single version via a
-    /// `patch:` entry in the requiring `streamlib.yaml` that redirects the
-    /// package to one `path:` / `git:` source, or by aligning the two
-    /// requirers on a single declared version.
-    #[error(
-        "Single-version conflict for package '{package}': version \
-         {existing_version} (required by {existing_required_by}) conflicts \
-         with version {conflicting_version} (required by \
-         {conflicting_required_by}). streamlib enforces one version per \
-         package across the module graph — pin a single version via a \
-         `patch:` entry in the requiring streamlib.yaml (redirecting \
-         '{package}' to one path/git source), or align the two requirers \
-         on the same version."
-    )]
-    SingleVersionConflict {
-        package: streamlib_idents::PackageRef,
-        existing_version: streamlib_idents::SemVer,
-        existing_required_by: String,
-        conflicting_version: streamlib_idents::SemVer,
-        conflicting_required_by: String,
     },
 
     /// This load skipped registering `package` because a concurrent

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
@@ -475,6 +475,15 @@ pub(super) struct ModuleLoadWalkContext<'load> {
         Vec<(streamlib_idents::PackageRef, streamlib_idents::PackageRef)>,
 }
 
+impl ModuleLoadWalkContext<'_> {
+    /// The package that required the node currently being resolved — the
+    /// penultimate element of the recursion path (the last is the current
+    /// node). `None` for a top-level `add_module` (path length < 2).
+    fn requirer(&self) -> Option<&streamlib_idents::PackageRef> {
+        (self.path.len() >= 2).then(|| &self.path[self.path.len() - 2])
+    }
+}
+
 /// Recursive worker: resolves the [`Strategy`] to a source, materializes
 /// via the injected [`BuildOrchestrator`] when a build is required,
 /// validates the manifest's identity + version range, stages the
@@ -599,8 +608,9 @@ fn add_module_recursive_body(
                 source_path: manifest_dir.clone(),
             });
         }
-        let requirer_for_warning = (walk_context.path.len() >= 2)
-            .then(|| walk_context.path[walk_context.path.len() - 2].to_string())
+        let requirer_for_warning = walk_context
+            .requirer()
+            .map(ToString::to_string)
             .unwrap_or_else(|| "top-level add_module".to_string());
         tracing::warn!(
             module = %module,
@@ -628,7 +638,10 @@ fn add_module_recursive_body(
     // loads dedupe the same `@org/name` to one first-resolved winner here
     // instead of double-registering. A later encounter resolving a
     // DIFFERENT concrete version warns and reuses the winner (single-version
-    // model; an incompatibility surfaces at runtime), never blocks the load.
+    // model; an incompatibility surfaces at compile-on-install for source
+    // packages — a consumer codegen'd against the winner's older schema idents
+    // fails the ident lookup / type-check — or at runtime for prebuilt slots),
+    // never blocks the load.
     //
     // First encounter inserts an in-flight placeholder under the same
     // lock as the check (no check-then-commit window for a concurrent
@@ -637,8 +650,7 @@ fn add_module_recursive_body(
     // skip is recorded in `skipped_in_flight` and the owner's outcome is
     // verified at the end of this walk — nobody ever blocks mid-walk, so
     // concurrent walks cannot deadlock.
-    let requirer_package = (walk_context.path.len() >= 2)
-        .then(|| walk_context.path[walk_context.path.len() - 2].clone());
+    let requirer_package = walk_context.requirer().cloned();
     let requirer = RequirerRecord {
         requirer: requirer_package.clone(),
     };

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
@@ -27,7 +27,7 @@ pub(super) const SKIPPED_IN_FLIGHT_WAIT_TIMEOUT: Duration = Duration::from_secs(
 
 /// A single requirer edge into a resolved package: the parent
 /// [`PackageRef`] that declared the dependency (or `None` for a
-/// top-level `add_module` call) plus the version range it declared.
+/// top-level `add_module` call).
 ///
 /// [`PackageRef`]: streamlib_idents::PackageRef
 #[derive(Debug, Clone)]
@@ -35,11 +35,6 @@ pub(crate) struct RequirerRecord {
     /// The parent package that pulled this dependency in, or `None` when
     /// the package was the root of a top-level `add_module` call.
     pub requirer: Option<streamlib_idents::PackageRef>,
-    /// The [`SemVerRange`] the requirer declared for this package (`Any`
-    /// for path / git deps, which carry no range).
-    ///
-    /// [`SemVerRange`]: streamlib_idents::SemVerRange
-    pub declared_range: streamlib_idents::SemVerRange,
 }
 
 /// The single-version resolution record for one `@org/name` package.
@@ -142,25 +137,29 @@ pub(crate) struct SkippedInFlightDependency {
 pub(super) enum SingleVersionGateOutcome {
     /// First encounter — placeholder inserted; register + recurse.
     ProceedAsFirstResolution,
-    /// Already committed at the same version — requirer recorded; skip.
-    SkipAlreadyCommittedSameVersion,
+    /// Already committed — requirer recorded; skip. A re-encounter at a
+    /// different version deduped to the first-resolved winner lands here too.
+    SkipAlreadyCommittedWinner,
     /// In flight on THIS load (a same-load diamond re-encounter) —
     /// requirer recorded; skip with no wait entry. Waiting on the owner
     /// would be waiting on ourselves: this load's placeholders only flip
     /// at its own whole-load commit, which runs after the wait phase.
     SkipOwnedByThisLoad,
-    /// In flight on a concurrent load at the same version — requirer
-    /// recorded; skip locally and verify the owner's outcome at the end
-    /// of this walk via the carried signal.
-    SkipInFlightSameVersion(Arc<PackageResolutionCompletionSignal>),
+    /// In flight on a concurrent load — requirer recorded; skip locally and
+    /// verify the owner's outcome at the end of this walk via the carried
+    /// signal. A concurrent re-encounter at a different version deduped to
+    /// the winner lands here too.
+    SkipInFlightWinner(Arc<PackageResolutionCompletionSignal>),
 }
 
 /// Runtime-lifetime memo of every package resolved by the live module
 /// walker, keyed by `@org/name`. Persists across every `add_module` call
 /// on a [`Runner`] so two independently-rooted diamond branches, two
-/// successive `add_module` calls, or two concurrent loads that resolve
-/// the same package to different concrete versions conflict instead of
-/// silently double-registering.
+/// successive `add_module` calls, or two concurrent loads dedupe the same
+/// `@org/name` to a single first-resolved winner instead of
+/// double-registering. A later encounter at a different concrete version
+/// warns and reuses the winner (single-version model; an incompatibility
+/// surfaces at runtime).
 ///
 /// [`Runner`]: crate::core::runtime::Runner
 pub(crate) struct ResolutionMemo {
@@ -209,23 +208,19 @@ impl ResolutionMemo {
                 PackageResolutionState::Committed { record } => record,
             };
             if record.version != on_disk_version {
-                return Err(AddModuleError::SingleVersionConflict {
-                    package: pkg_ref.clone(),
-                    existing_version: record.version,
-                    existing_required_by: format!(
-                        "{} [resolved from {}]",
-                        describe_requirers(&record.required_by),
-                        record.source_path.display(),
-                    ),
-                    conflicting_version: on_disk_version,
-                    conflicting_required_by: format!(
-                        "{} [resolved from {}]",
-                        describe_requirer(&requirer),
-                        manifest_dir.display(),
-                    ),
-                });
-            }
-            if record.source_path != manifest_dir {
+                tracing::warn!(
+                    package = %pkg_ref,
+                    resolved_version = %record.version,
+                    resolved_from = %record.source_path.display(),
+                    conflicting_version = %on_disk_version,
+                    conflicting_from = %manifest_dir.display(),
+                    "single-version gate: package already resolved to a \
+                     different version from an earlier source — keeping the \
+                     first-resolved winner and ignoring the later encounter \
+                     (single-version model; if the two are incompatible it \
+                     will surface at runtime)",
+                );
+            } else if record.source_path != manifest_dir {
                 tracing::warn!(
                     package = %pkg_ref,
                     version = %on_disk_version,
@@ -244,10 +239,10 @@ impl ResolutionMemo {
                 tracing::debug!(
                     package = %pkg_ref,
                     version = %on_disk_version,
-                    "single-version gate: already resolved at this version — \
-                     skipping re-registration and re-recursion",
+                    "single-version gate: already resolved — skipping \
+                     re-registration and re-recursion",
                 );
-                Ok(SingleVersionGateOutcome::SkipAlreadyCommittedSameVersion)
+                Ok(SingleVersionGateOutcome::SkipAlreadyCommittedWinner)
             }
             PackageResolutionState::InFlightPlaceholder {
                 completion_signal,
@@ -258,9 +253,8 @@ impl ResolutionMemo {
                     tracing::debug!(
                         package = %pkg_ref,
                         version = %on_disk_version,
-                        "single-version gate: same version in flight on THIS \
-                         load (diamond re-encounter) — skipping with no wait \
-                         entry",
+                        "single-version gate: already in flight on THIS load \
+                         (diamond re-encounter) — skipping with no wait entry",
                     );
                     return Ok(SingleVersionGateOutcome::SkipOwnedByThisLoad);
                 }
@@ -268,11 +262,10 @@ impl ResolutionMemo {
                     package = %pkg_ref,
                     version = %on_disk_version,
                     owner_load_id = *owner_load_id,
-                    "single-version gate: same version in flight on a \
-                     concurrent load — skipping locally; outcome verified at \
-                     end of walk",
+                    "single-version gate: already in flight on a concurrent \
+                     load — skipping locally; outcome verified at end of walk",
                 );
-                Ok(SingleVersionGateOutcome::SkipInFlightSameVersion(
+                Ok(SingleVersionGateOutcome::SkipInFlightWinner(
                     Arc::clone(completion_signal),
                 ))
             }
@@ -444,27 +437,6 @@ impl Drop for InFlightPlaceholderGuard<'_> {
     }
 }
 
-/// Render one requirer edge for a
-/// [`AddModuleError::SingleVersionConflict`] message.
-fn describe_requirer(requirer: &RequirerRecord) -> String {
-    match &requirer.requirer {
-        Some(pkg) => format!("{pkg} (declared `{}`)", requirer.declared_range),
-        None => format!(
-            "top-level add_module (declared `{}`)",
-            requirer.declared_range
-        ),
-    }
-}
-
-/// Render the accumulated requirers of an already-resolved package.
-fn describe_requirers(requirers: &[RequirerRecord]) -> String {
-    requirers
-        .iter()
-        .map(describe_requirer)
-        .collect::<Vec<_>>()
-        .join(", ")
-}
-
 /// Everything one top-level module load threads through its recursive
 /// dependency walk: the immutable per-load inputs (node, orchestrator,
 /// memo, staging buffer, lockfile / link context) plus the mutable
@@ -612,11 +584,35 @@ fn add_module_recursive_body(
         });
     }
     if !module.version.matches(on_disk_version) {
-        return Err(AddModuleError::VersionRangeUnsatisfied {
-            module: module.clone(),
-            found: on_disk_version,
-            source_path: manifest_dir.clone(),
-        });
+        // A locked run resolves each dep to its lockfile `Exact` pin, so a
+        // mismatch here is a slot whose on-disk version drifted from the pin
+        // (an in-place republish after install) — a reproducibility/integrity
+        // failure, hard by the locked-run contract. Only the live (install- or
+        // dev-derived) walk is lenient: a declared range that no installed
+        // version satisfies warns and loads the installed version, matching the
+        // install-time resolver's single-version model — a version mismatch
+        // never blocks a live load.
+        if walk_context.locked.is_some() {
+            return Err(AddModuleError::VersionRangeUnsatisfied {
+                module: module.clone(),
+                found: on_disk_version,
+                source_path: manifest_dir.clone(),
+            });
+        }
+        let requirer_for_warning = (walk_context.path.len() >= 2)
+            .then(|| walk_context.path[walk_context.path.len() - 2].to_string())
+            .unwrap_or_else(|| "top-level add_module".to_string());
+        tracing::warn!(
+            module = %module,
+            requested_range = %module.version,
+            installed_version = %on_disk_version,
+            requirer = %requirer_for_warning,
+            source_path = %manifest_dir.display(),
+            "loading the installed version although the requirer declared a \
+             range no installed version satisfies — no matching version \
+             installed; loading it anyway (single-version model: a version \
+             mismatch never blocks a load)",
+        );
     }
 
     tracing::info!(
@@ -629,23 +625,22 @@ fn add_module_recursive_body(
     // Single-version-per-package gate. The memo persists across the whole
     // runtime lifetime (not per walk), so two independently-rooted diamond
     // branches, two successive `add_module` calls, or two concurrent
-    // loads that resolve the same package to different concrete versions
-    // conflict here instead of silently double-registering. Compares
-    // concrete resolved `SemVer`s, never ranges: path / git deps enter
-    // with range `Any`, so a range-only check would never fire.
+    // loads dedupe the same `@org/name` to one first-resolved winner here
+    // instead of double-registering. A later encounter resolving a
+    // DIFFERENT concrete version warns and reuses the winner (single-version
+    // model; an incompatibility surfaces at runtime), never blocks the load.
     //
     // First encounter inserts an in-flight placeholder under the same
     // lock as the check (no check-then-commit window for a concurrent
-    // load to slip through). A same-version re-encounter skips
-    // re-registration + re-recursion; when the same version is in flight
-    // on a CONCURRENT load, the skip is recorded in `skipped_in_flight`
-    // and the owner's outcome is verified at the end of this walk —
-    // nobody ever blocks mid-walk, so concurrent walks cannot deadlock.
+    // load to slip through). A re-encounter skips re-registration +
+    // re-recursion; when the winner is in flight on a CONCURRENT load, the
+    // skip is recorded in `skipped_in_flight` and the owner's outcome is
+    // verified at the end of this walk — nobody ever blocks mid-walk, so
+    // concurrent walks cannot deadlock.
     let requirer_package = (walk_context.path.len() >= 2)
         .then(|| walk_context.path[walk_context.path.len() - 2].clone());
     let requirer = RequirerRecord {
         requirer: requirer_package.clone(),
-        declared_range: module.version.clone(),
     };
     match walk_context.resolution_memo.gate(
         walk_context.load_id,
@@ -654,7 +649,7 @@ fn add_module_recursive_body(
         &manifest_dir,
         requirer,
     )? {
-        SingleVersionGateOutcome::SkipAlreadyCommittedSameVersion => {
+        SingleVersionGateOutcome::SkipAlreadyCommittedWinner => {
             // The package belongs to an EARLIER committed load; record the
             // requirer edge so this load's commit appends it onto the
             // dependency's ledger record.
@@ -666,7 +661,7 @@ fn add_module_recursive_body(
             return Ok(());
         }
         SingleVersionGateOutcome::SkipOwnedByThisLoad => return Ok(()),
-        SingleVersionGateOutcome::SkipInFlightSameVersion(completion_signal) => {
+        SingleVersionGateOutcome::SkipInFlightWinner(completion_signal) => {
             walk_context
                 .skipped_in_flight
                 .push(SkippedInFlightDependency {

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/tests.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/tests.rs
@@ -1210,25 +1210,33 @@ mod add_module_tests {
         );
     }
 
+    /// #1505 live-walk leniency: a top-level `add_module` requesting a range
+    /// (`^3.0.0`) that the only installed version (`1.0.0`) does not satisfy
+    /// WARNS and loads the installed version rather than hard-failing — the
+    /// single-version model, where a version mismatch never blocks a load.
+    /// Mentally-revertible: restoring the `VersionRangeUnsatisfied` gate makes
+    /// this `add_module` return `Err` and the `expect` below panics.
     #[test]
     #[serial]
-    fn add_module_rejects_version_range_mismatch() {
+    fn add_module_range_mismatch_warns_and_loads_installed() {
+        const TYPE_NAME: &str = "AddModuleRangeSchema";
         let home = tempfile::tempdir().unwrap();
         let _guard = HomeGuard::install(home.path());
-        install_cached_package("tatolab", "add-module-range", "1.0.0", None);
+        install_cached_package("tatolab", "add-module-range", "1.0.0", Some(TYPE_NAME));
 
         let runtime = Runner::new().expect("Runner::new");
-        let err = runtime
+        let canonical = format!("@tatolab/add-module-range/{TYPE_NAME}");
+        runtime
             .add_module_blocking(ModuleIdent::new(
                 Org::new("tatolab").unwrap(),
                 Package::new("add-module-range").unwrap(),
-                SemVerRange::Caret(SemVer::new(2, 0, 0)),
+                SemVerRange::Caret(SemVer::new(3, 0, 0)),
             ))
-            .expect_err("range mismatch must error");
+            .expect("a range no installed version satisfies must warn and load the installed version");
 
         assert!(
-            matches!(err, AddModuleError::VersionRangeUnsatisfied { found, .. } if found == SemVer::new(1, 0, 0)),
-            "expected VersionRangeUnsatisfied(1.0.0), got: {err:?}",
+            crate::core::embedded_schemas::get_embedded_schema_definition(&canonical).is_some(),
+            "the installed 1.0.0 slot must load despite the unsatisfied ^3.0.0 range",
         );
     }
 
@@ -1749,9 +1757,15 @@ processors:
         }
     }
 
+    /// #1505 live-walk leniency through a transitive dep: vmm-a declares
+    /// `@tatolab/vmm-b: ^2.0.0` but the resolved vmm-b is `1.0.0`. The walk
+    /// WARNS and loads vmm-b@1.0.0 rather than propagating a hard error — a
+    /// version mismatch never blocks a live load. Mentally-revertible:
+    /// restoring the `VersionRangeUnsatisfied` gate makes the walk return
+    /// `Err` and the `expect` below panics.
     #[test]
     #[serial]
-    fn dep_walker_surfaces_version_mismatch_from_dep() {
+    fn dep_walker_range_mismatch_from_dep_warns_and_loads() {
         let home = tempfile::tempdir().unwrap();
         let pkg_root = tempfile::tempdir().unwrap();
         let a = pkg_root.path().join("a");
@@ -1773,7 +1787,7 @@ processors:
         let _guard = HomeGuard::install(home.path());
         let runtime = Runner::new().expect("Runner::new");
         runtime.set_build_orchestrator(LoadAsIsOrchestrator);
-        let err = runtime
+        runtime
             .add_module_with_blocking(
                 ModuleIdent::any(Org::new("tatolab").unwrap(), Package::new("vmm-a").unwrap()),
                 Strategy::Path {
@@ -1781,26 +1795,32 @@ processors:
                     build: BuildPolicy::NeverBuild,
                 },
             )
-            .expect_err("version mismatch from dep must propagate");
-        assert!(
-            matches!(err, AddModuleError::VersionRangeUnsatisfied { ref module, found, .. }
-                if module.name.as_str() == "vmm-b" && found == SemVer::new(1, 0, 0)),
-            "expected VersionRangeUnsatisfied for vmm-b@1.0.0, got: {err:?}",
+            .expect("a dep range no resolved version satisfies must warn and load");
+        let vmm_b = streamlib_idents::PackageRef::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("vmm-b").unwrap(),
         );
+        let record = runtime
+            .resolution_memo
+            .committed_record(&vmm_b)
+            .expect("vmm-b must be committed despite the unsatisfied ^2.0.0 range");
+        assert_eq!(record.version, SemVer::new(1, 0, 0));
     }
 
     // =========================================================================
     // Single-version-per-package gate (#1216)
     // =========================================================================
 
-    /// A diamond where the two branches resolve the shared dependency to
-    /// *different* concrete versions (B→D@1.0.0, C→D@1.1.0) must surface a
-    /// typed [`AddModuleError::SingleVersionConflict`] naming both versions
-    /// and both requirers — not a silent double-registration. Path deps
-    /// enter with range `Any`, so the gate must compare concrete `SemVer`s.
+    /// #1505 single-version dedupe: a diamond whose two branches resolve the
+    /// shared dependency to *different* concrete versions (B→D@1.0.0,
+    /// C→D@1.1.0) WARNS and dedupes to the first-resolved winner (D@1.0.0)
+    /// rather than hard-failing. B is walked before C (BTreeMap key order), so
+    /// D@1.0.0 lands in the memo first and D@1.1.0 is the deduped encounter.
+    /// Mentally-revertible: restoring the `SingleVersionConflict` gate makes
+    /// this load return `Err` and the `expect` below panics.
     #[test]
     #[serial]
-    fn diamond_conflicting_versions_error_single_version_conflict() {
+    fn diamond_conflicting_versions_dedupes_to_first_winner() {
         let home = tempfile::tempdir().unwrap();
         let pkg_root = tempfile::tempdir().unwrap();
         let a = pkg_root.path().join("a");
@@ -1844,7 +1864,7 @@ processors:
         let _guard = HomeGuard::install(home.path());
         let runtime = Runner::new().expect("Runner::new");
         runtime.set_build_orchestrator(LoadAsIsOrchestrator);
-        let err = runtime
+        runtime
             .add_module_with_blocking(
                 ModuleIdent::any(
                     Org::new("tatolab").unwrap(),
@@ -1855,31 +1875,25 @@ processors:
                     build: BuildPolicy::NeverBuild,
                 },
             )
-            .expect_err("diamond version conflict must error");
-        match err {
-            AddModuleError::SingleVersionConflict {
-                package,
-                existing_version,
-                existing_required_by,
-                conflicting_version,
-                conflicting_required_by,
-            } => {
-                assert_eq!(package.name.as_str(), "diamond-d");
-                // B is walked before C (BTreeMap key order), so D@1.0.0 lands
-                // in the memo first and D@1.1.0 is the conflicting encounter.
-                assert_eq!(existing_version, SemVer::new(1, 0, 0));
-                assert_eq!(conflicting_version, SemVer::new(1, 1, 0));
-                assert!(
-                    existing_required_by.contains("diamond-b"),
-                    "existing requirer should name diamond-b, got: {existing_required_by}",
-                );
-                assert!(
-                    conflicting_required_by.contains("diamond-c"),
-                    "conflicting requirer should name diamond-c, got: {conflicting_required_by}",
-                );
-            }
-            other => panic!("expected SingleVersionConflict, got: {other:?}"),
-        }
+            .expect("a diamond version divergence must dedupe to the winner, not error");
+        let diamond_d = streamlib_idents::PackageRef::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("diamond-d").unwrap(),
+        );
+        let record = runtime
+            .resolution_memo
+            .committed_record(&diamond_d)
+            .expect("diamond-d must be committed as a single resolution");
+        assert_eq!(
+            record.version,
+            SemVer::new(1, 0, 0),
+            "the first-walked branch (diamond-b → D@1.0.0) must win the dedupe",
+        );
+        assert_eq!(
+            record.required_by.len(),
+            2,
+            "both diamond-b and diamond-c must be recorded as requirers of the single D resolution",
+        );
     }
 
     /// A diamond where both branches agree on the shared dependency's
@@ -2006,10 +2020,14 @@ processors:
 
     /// The memo persists across successive `add_module` calls on the same
     /// runtime: adding X@1.0.0, then adding Y (which depends on X@2.0.0),
-    /// conflicts even though the two loads are independent top-level calls.
+    /// dedupes to the first-resolved winner (X@1.0.0) across the two
+    /// independent top-level calls — the second load WARNS and reuses the
+    /// committed X rather than hard-failing. Mentally-revertible: restoring
+    /// the `SingleVersionConflict` gate makes the second `add_module` return
+    /// `Err` and the `expect` below panics.
     #[test]
     #[serial]
-    fn cross_call_conflicting_versions_error() {
+    fn cross_call_conflicting_versions_dedupe_to_first_winner() {
         let home = tempfile::tempdir().unwrap();
         let pkg_root = tempfile::tempdir().unwrap();
         let xa = pkg_root.path().join("xa");
@@ -2052,7 +2070,7 @@ processors:
             )
             .expect("first add_module (x@1.0.0) must succeed");
 
-        let err = runtime
+        runtime
             .add_module_with_blocking(
                 ModuleIdent::any(
                     Org::new("tatolab").unwrap(),
@@ -2063,26 +2081,20 @@ processors:
                     build: BuildPolicy::NeverBuild,
                 },
             )
-            .expect_err("second add_module pulling x@2.0.0 must conflict");
-        match err {
-            AddModuleError::SingleVersionConflict {
-                package,
-                existing_version,
-                existing_required_by,
-                conflicting_version,
-                ..
-            } => {
-                assert_eq!(package.name.as_str(), "crosscall-x");
-                assert_eq!(existing_version, SemVer::new(1, 0, 0));
-                assert_eq!(conflicting_version, SemVer::new(2, 0, 0));
-                assert!(
-                    existing_required_by.contains("top-level add_module"),
-                    "existing requirer must name the top-level add_module call, \
-                     got: {existing_required_by}",
-                );
-            }
-            other => panic!("expected SingleVersionConflict, got: {other:?}"),
-        }
+            .expect("second add_module pulling x@2.0.0 must dedupe to the winner, not conflict");
+        let crosscall_x = streamlib_idents::PackageRef::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("crosscall-x").unwrap(),
+        );
+        let record = runtime
+            .resolution_memo
+            .committed_record(&crosscall_x)
+            .expect("crosscall-x must remain committed as a single resolution");
+        assert_eq!(
+            record.version,
+            SemVer::new(1, 0, 0),
+            "the first top-level add (x@1.0.0) must win across the two calls",
+        );
     }
 
     /// Re-adding the same package at the same version is a cheap idempotent
@@ -2337,15 +2349,18 @@ processors:
         );
     }
 
-    /// Two CONCURRENT top-level loads pulling DIFFERENT versions of the
-    /// same package (TA→D@1.0.0, TB→D@1.1.0) produce exactly one
-    /// SingleVersionConflict — never a silent last-commit-wins
-    /// double-registration. The rendezvous barrier guarantees both walks
-    /// hit the gate window together; whichever loses the insert race
-    /// conflicts against the winner's placeholder or committed record.
+    /// #1505 single-version dedupe under concurrency: two CONCURRENT
+    /// top-level loads pulling DIFFERENT versions of the same package
+    /// (TA→D@1.0.0, TB→D@1.1.0) both SUCCEED and dedupe to one committed D —
+    /// whichever wins the insert race commits, the other WARNS and reuses the
+    /// winner (never a hard conflict, never a double-registration). The
+    /// rendezvous barrier guarantees both walks hit the gate window together.
+    /// Mentally-revertible: restoring the `SingleVersionConflict` gate makes
+    /// exactly one load return `Err`, dropping `ok_count` below 2 and failing
+    /// the assertion.
     #[test]
     #[serial]
-    fn concurrent_loads_conflicting_shared_dep_exactly_one_conflict() {
+    fn concurrent_loads_conflicting_shared_dep_dedupe_to_one_winner() {
         let home = tempfile::tempdir().unwrap();
         let pkg_root = tempfile::tempdir().unwrap();
         let ta = pkg_root.path().join("ta");
@@ -2414,31 +2429,25 @@ processors:
         let (result_ta, result_tb) = handle.block_on(async { tokio::join!(added_ta, added_tb) });
 
         let results = [result_ta.map(|_| ()), result_tb.map(|_| ())];
-        let conflict_count = results
-            .iter()
-            .filter(|r| {
-                matches!(
-                    r,
-                    Err(AddModuleError::SingleVersionConflict { package, .. })
-                        if package.name.as_str() == "conc-conflict-d"
-                )
-            })
-            .count();
         let ok_count = results.iter().filter(|r| r.is_ok()).count();
         assert_eq!(
-            (ok_count, conflict_count),
-            (1, 1),
-            "exactly one load must succeed and one must conflict on D, got: {results:?}",
+            ok_count, 2,
+            "both concurrent loads must succeed and dedupe to one D, got: {results:?}",
         );
-        // The winner's resolution of D is committed; the loser's own
-        // top-level placeholder was cleared by its drop-guard.
+        // D is committed as a single resolution at whichever version won the
+        // insert race; the loser deduped to it.
         let d_ref = streamlib_idents::PackageRef::new(
             Org::new("tatolab").unwrap(),
             Package::new("conc-conflict-d").unwrap(),
         );
+        let record = runtime
+            .resolution_memo
+            .committed_record(&d_ref)
+            .expect("the winning load's D resolution must be committed");
         assert!(
-            runtime.resolution_memo.committed_record(&d_ref).is_some(),
-            "the winning load's D resolution must be committed",
+            record.version == SemVer::new(1, 0, 0) || record.version == SemVer::new(1, 1, 0),
+            "D must commit at one of the two raced versions, got: {}",
+            record.version,
         );
     }
 

--- a/runtime/streamlib-engine/src/core/runtime/runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/runtime.rs
@@ -143,17 +143,18 @@ pub struct Runner {
     /// [`Runner::add_module`] call; persists across calls so a diamond
     /// version divergence — or two successive / concurrent `add_module`s
     /// resolving different concrete versions of the same package —
-    /// surfaces as [`AddModuleError::SingleVersionConflict`] instead of a
-    /// silent double-registration. Lives for the runtime's lifetime;
-    /// [`Runner::remove_module`] clears a removed package's entry so a
-    /// later `add_module` re-resolves it from scratch.
+    /// dedupes to the first-resolved winner (single-version model: a later
+    /// encounter at a different version warns and reuses the winner rather
+    /// than double-registering; if the two are incompatible it surfaces at
+    /// runtime). Lives for the runtime's lifetime; [`Runner::remove_module`]
+    /// clears a removed package's entry so a later `add_module` re-resolves
+    /// it from scratch.
     /// The memo is Runner-scoped while the schema / processor registries
     /// it protects are process-global statics — a second [`Runner`] in
     /// the same process carries its own memo and does not see this one's
     /// resolutions (pre-existing registry topology, unchanged here).
     ///
     /// [`Runner::add_module`]: Self::add_module
-    /// [`AddModuleError::SingleVersionConflict`]: crate::core::runtime::module_loader::AddModuleError::SingleVersionConflict
     pub(crate) resolution_memo: Arc<crate::core::runtime::module_loader::ResolutionMemo>,
 }
 

--- a/runtime/streamlib-engine/src/core/runtime/runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/runtime.rs
@@ -146,7 +146,8 @@ pub struct Runner {
     /// dedupes to the first-resolved winner (single-version model: a later
     /// encounter at a different version warns and reuses the winner rather
     /// than double-registering; if the two are incompatible it surfaces at
-    /// runtime). Lives for the runtime's lifetime; [`Runner::remove_module`]
+    /// compile-on-install for source packages, or at runtime for prebuilt
+    /// slots). Lives for the runtime's lifetime; [`Runner::remove_module`]
     /// clears a removed package's entry so a later `add_module` re-resolves
     /// it from scratch.
     /// The memo is Runner-scoped while the schema / processor registries

--- a/sdk/streamlib-idents/src/error.rs
+++ b/sdk/streamlib-idents/src/error.rs
@@ -116,17 +116,6 @@ pub enum ResolverError {
         range: String,
     },
 
-    #[error(
-        "dependency `{name}` resolution conflict: range `{range_a}` (from `{from_a}`) and `{range_b}` (from `{from_b}`) have no overlap"
-    )]
-    VersionRangeConflict {
-        name: String,
-        range_a: String,
-        from_a: PathBuf,
-        range_b: String,
-        from_b: PathBuf,
-    },
-
     #[error("circular dependency detected: {chain}")]
     CircularDependency { chain: String },
 

--- a/sdk/streamlib-idents/src/resolver.rs
+++ b/sdk/streamlib-idents/src/resolver.rs
@@ -1409,8 +1409,6 @@ patch:
     /// both arms of the source scoping.
     #[test]
     fn registry_source_out_of_range_still_errors() {
-        use std::str::FromStr;
-
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join("core");
         write_streamlib_yaml(
@@ -1451,8 +1449,6 @@ patch:
     /// panic instead of returning.
     #[test]
     fn reconcile_against_no_package_block_does_not_panic() {
-        use std::str::FromStr;
-
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join("nopkg");
         write_streamlib_yaml(

--- a/sdk/streamlib-idents/src/resolver.rs
+++ b/sdk/streamlib-idents/src/resolver.rs
@@ -96,8 +96,8 @@ pub enum ResolvedSource {
     /// Resolved from a `.slpkg` archive (path to the archive is stored).
     Slpkg { archive: PathBuf },
     /// Resolved from the static registry's generic store: the URL the concrete
-    /// `.slpkg` was fetched from. Constructed by [`resolve_registry_dependency`]
-    /// and recorded in the lockfile via [`ResolvedSource::to_lockfile_source`].
+    /// `.slpkg` was fetched from. Constructed by `resolve_registry_dependency`
+    /// and recorded in the lockfile via `ResolvedSource::to_lockfile_source`.
     Registry { url: String },
 }
 
@@ -850,7 +850,21 @@ fn check_resolved_satisfies_spec(
             declared: "<no package block>".into(),
             requested: dep_id.to_string(),
         })?;
-    if !reg.version.matches(v) {
+    if reg.version.matches(v) {
+        return Ok(());
+    }
+    // The resolved concrete is out of the declared range. Only a genuine
+    // registry resolution is hard here: `select_version` already guarantees an
+    // in-range pick from the store, so a mismatch on a `Registry` source is a
+    // registry mis-selection and stays an error as defense-in-depth. A
+    // link/patch override (resolve_one's short-circuit to a linked checkout, or
+    // a dev `patch:` redirect) legitimately produces a Path/Git/Slpkg concrete
+    // whose version diverges from the declared range — its "link resolution
+    // overrides the declared spec" contract. Per #1505 a version mismatch never
+    // blocks a load, so that case warns and keeps the override (mirroring
+    // `warn_when_existing_unsatisfies_spec`). The locked-run drift check stays
+    // hard elsewhere as an integrity guarantee.
+    if matches!(resolved.source, ResolvedSource::Registry { .. }) {
         return Err(ResolverError::VersionRangeUnsatisfied {
             name: dep_id.to_string(),
             from: consumer_dir.join(Manifest::FILE_NAME),
@@ -858,6 +872,16 @@ fn check_resolved_satisfies_spec(
             range: reg.version.to_string(),
         });
     }
+    tracing::warn!(
+        dependency = %dep_id,
+        resolved_version = %v,
+        declared_range = %reg.version,
+        resolved_from = %resolved.root_dir.join(Manifest::FILE_NAME).display(),
+        requirer_from = %consumer_dir.join(Manifest::FILE_NAME).display(),
+        "resolved version does not satisfy the declared range, but a link/patch \
+         override is in effect; keeping the overridden version (a version \
+         mismatch never blocks a load)"
+    );
     Ok(())
 }
 
@@ -1331,6 +1355,89 @@ dependencies:
                 .to_string(),
             "1.2.0",
             "the shared dep must keep the first-resolved installed winner"
+        );
+    }
+
+    /// #1505 first-resolution gate leniency: a dep is DECLARED by a Registry
+    /// range but a dev `patch:` redirects it to a local checkout whose version
+    /// is out of that range (the same shape a `streamlib link` produces). The
+    /// resolve MUST NOT error — a version mismatch never blocks a load; the
+    /// override wins and only warns. Regression lock: re-broadening
+    /// `check_resolved_satisfies_spec` to error for a non-`Registry` source
+    /// makes `resolve_with` return `Err` here and the `unwrap()` panics.
+    #[test]
+    fn patch_override_out_of_range_warns_not_conflict() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("project");
+        let core = tmp.path().join("core");
+
+        write_streamlib_yaml(
+            &core,
+            "package:\n  org: tatolab\n  name: core\n  version: 2.0.0\n",
+        );
+        write_streamlib_yaml(
+            &root,
+            r#"
+dependencies:
+  "@tatolab/core": "^1.0.0"
+patch:
+  "@tatolab/core":
+    path: ../core
+"#,
+        );
+
+        let opts = ResolverOptions {
+            cache_dir: Some(tmp.path().join("cache")),
+            registry: None,
+            link_checkout: None,
+        };
+        let res = resolve_with(&root, &opts).unwrap();
+        let core_pkg = res.packages.get("@tatolab/core").unwrap();
+        assert!(matches!(core_pkg.source, ResolvedSource::Path { .. }));
+        assert_eq!(
+            core_pkg.manifest.package.as_ref().unwrap().version.to_string(),
+            "2.0.0",
+            "the patch-overridden out-of-range version must win, not error"
+        );
+    }
+
+    /// The registry-scoping half of the same gate: a GENUINE `Registry`-source
+    /// concrete that somehow falls out of the declared range is still a hard
+    /// `VersionRangeUnsatisfied` (defense-in-depth against a store
+    /// mis-selection), where `select_version` normally guarantees an in-range
+    /// pick. Pairs with `patch_override_out_of_range_warns_not_conflict` to pin
+    /// both arms of the source scoping.
+    #[test]
+    fn registry_source_out_of_range_still_errors() {
+        use std::str::FromStr;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("core");
+        write_streamlib_yaml(
+            &dir,
+            "package:\n  org: tatolab\n  name: core\n  version: 2.0.0\n",
+        );
+        let manifest = Manifest::load(&dir).unwrap();
+
+        let resolved = ResolvedPackage {
+            manifest,
+            root_dir: dir.clone(),
+            schema_files: Vec::new(),
+            source: ResolvedSource::Registry {
+                url: "file:///mirror/core-2.0.0.slpkg".into(),
+            },
+            content_hash: "sha256:0".into(),
+        };
+        let spec = DependencySpec::Registry(RegistryDependency {
+            version: crate::semver::SemVerRange::from_str("^1.0.0").unwrap(),
+            runtime: false,
+        });
+
+        let err = check_resolved_satisfies_spec(&resolved, &spec, &dir, "@tatolab/core")
+            .unwrap_err();
+        assert!(
+            matches!(err, ResolverError::VersionRangeUnsatisfied { .. }),
+            "a registry-source out-of-range concrete must stay hard, got {err:?}"
         );
     }
 

--- a/sdk/streamlib-idents/src/resolver.rs
+++ b/sdk/streamlib-idents/src/resolver.rs
@@ -95,8 +95,9 @@ pub enum ResolvedSource {
     Git { url: String, rev: String },
     /// Resolved from a `.slpkg` archive (path to the archive is stored).
     Slpkg { archive: PathBuf },
-    /// Resolved from a registry. Reserved — v1 does not implement a
-    /// registry, so this variant is constructable only by future code paths.
+    /// Resolved from the static registry's generic store: the URL the concrete
+    /// `.slpkg` was fetched from. Constructed by [`resolve_registry_dependency`]
+    /// and recorded in the lockfile via [`ResolvedSource::to_lockfile_source`].
     Registry { url: String },
 }
 
@@ -341,7 +342,7 @@ pub fn resolve_with(
             let dep_id = dep_ref.to_string();
 
             if let Some(existing) = packages.get(&dep_id) {
-                check_existing_satisfies_spec(existing, &spec, &consumer_dir, &dep_id)?;
+                warn_when_existing_unsatisfies_spec(existing, &spec, &consumer_dir, &dep_id);
                 continue;
             }
 
@@ -860,30 +861,41 @@ fn check_resolved_satisfies_spec(
     Ok(())
 }
 
-fn check_existing_satisfies_spec(
+/// Reconcile a second requirer's range against the already-resolved concrete
+/// version of a shared dependency. Per the compile-on-install model, a range
+/// mismatch resolves to what is already installed rather than failing the walk:
+/// the winning concrete version stays, and the unsatisfied range is surfaced as
+/// a warning naming both the winner's manifest and the requirer that couldn't be
+/// honored. Only range enforcement at a *locked run* (module_loader's
+/// `SemVerRange::Exact` check) is hard — this install/codegen unification stage
+/// is deliberately lenient.
+fn warn_when_existing_unsatisfies_spec(
     existing: &ResolvedPackage,
     spec: &DependencySpec,
     consumer_dir: &Path,
     dep_id: &str,
-) -> ResolverResult<()> {
-    if let DependencySpec::Registry(reg) = spec {
-        let v = existing
-            .manifest
-            .package
-            .as_ref()
-            .map(|p| p.version)
-            .expect("existing dep is package-flavor");
-        if !reg.version.matches(v) {
-            return Err(ResolverError::VersionRangeConflict {
-                name: dep_id.to_string(),
-                range_a: format!("(already-resolved {})", v),
-                from_a: existing.root_dir.join(Manifest::FILE_NAME),
-                range_b: reg.version.to_string(),
-                from_b: consumer_dir.join(Manifest::FILE_NAME),
-            });
-        }
+) {
+    let DependencySpec::Registry(reg) = spec else {
+        return;
+    };
+    let installed = existing
+        .manifest
+        .package
+        .as_ref()
+        .map(|p| p.version)
+        .expect("existing dep is package-flavor");
+    if !reg.version.matches(installed) {
+        tracing::warn!(
+            dependency = %dep_id,
+            installed = %installed,
+            unsatisfied_range = %reg.version,
+            winner_from = %existing.root_dir.join(Manifest::FILE_NAME).display(),
+            requirer_from = %consumer_dir.join(Manifest::FILE_NAME).display(),
+            "dependency range not satisfied by the already-resolved version; \
+             keeping the installed version (compile-on-install: a mismatch \
+             resolves to what is installed)"
+        );
     }
-    Ok(())
 }
 
 fn default_cache_dir() -> ResolverResult<PathBuf> {
@@ -1246,6 +1258,83 @@ dependencies:
         assert!(res.packages.contains_key("@tatolab/core"));
         assert!(res.packages.contains_key("@tatolab/a"));
         assert!(res.packages.contains_key("@tatolab/b"));
+    }
+
+    /// #1505 winner-selection: two requirers of the same registry dependency
+    /// declare disjoint semver ranges. The first-walked requirer (`@tatolab/a`,
+    /// `^1.0.0`) resolves the shared dep to the installed `1.2.0`; the second
+    /// (`@tatolab/b`, `^3.0.0`) can't be satisfied by that concrete version.
+    /// Per the compile-on-install model the resolve MUST NOT error — it keeps
+    /// the already-resolved winner and only warns. This is the regression lock:
+    /// restoring the old `VersionRangeConflict` hard error makes `resolve_with`
+    /// return `Err` here and the `unwrap()` panics.
+    #[test]
+    fn disjoint_ranges_resolve_to_installed_winner_not_conflict() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mirror = tmp.path().join("mirror");
+        let cache = tmp.path().join("cache");
+
+        // Only 1.2.0 is published; `@tatolab/a`'s `^1.0.0` selects it, and
+        // `@tatolab/b`'s `^3.0.0` is disjoint from it.
+        write_escalate_slpkg(&mirror, "1.2.0");
+
+        let root = tmp.path().join("project");
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+
+        write_streamlib_yaml(
+            &a,
+            r#"
+package:
+  org: tatolab
+  name: a
+  version: 1.0.0
+dependencies:
+  "@tatolab/escalate": "^1.0.0"
+"#,
+        );
+        write_streamlib_yaml(
+            &b,
+            r#"
+package:
+  org: tatolab
+  name: b
+  version: 1.0.0
+dependencies:
+  "@tatolab/escalate": "^3.0.0"
+"#,
+        );
+        write_streamlib_yaml(
+            &root,
+            r#"
+dependencies:
+  "@tatolab/a":
+    path: ../a
+  "@tatolab/b":
+    path: ../b
+"#,
+        );
+
+        let opts = ResolverOptions {
+            cache_dir: Some(cache),
+            registry: Some(crate::RegistryConfig {
+                base_url: format!("file://{}", mirror.display()),
+            }),
+            link_checkout: None,
+        };
+        let res = resolve_with(&root, &opts).unwrap();
+        let escalate = res.packages.get("@tatolab/escalate").unwrap();
+        assert_eq!(
+            escalate
+                .manifest
+                .package
+                .as_ref()
+                .unwrap()
+                .version
+                .to_string(),
+            "1.2.0",
+            "the shared dep must keep the first-resolved installed winner"
+        );
     }
 
     #[test]

--- a/sdk/streamlib-idents/src/resolver.rs
+++ b/sdk/streamlib-idents/src/resolver.rs
@@ -878,12 +878,9 @@ fn warn_when_existing_unsatisfies_spec(
     let DependencySpec::Registry(reg) = spec else {
         return;
     };
-    let installed = existing
-        .manifest
-        .package
-        .as_ref()
-        .map(|p| p.version)
-        .expect("existing dep is package-flavor");
+    let Some(installed) = existing.manifest.package.as_ref().map(|p| p.version) else {
+        return;
+    };
     if !reg.version.matches(installed) {
         tracing::warn!(
             dependency = %dep_id,
@@ -1335,6 +1332,51 @@ dependencies:
             "1.2.0",
             "the shared dep must keep the first-resolved installed winner"
         );
+    }
+
+    /// A dep first resolved via a path/git spec carries a manifest whose
+    /// `package` block can legitimately be `None` (that flavor skips the
+    /// package-id check). Re-referencing it through a Registry range must
+    /// reconcile leniently — the whole point of #1505 is that a version
+    /// mismatch never halts a load, so a missing package block on the installed
+    /// winner must be an early return, not a panic. Regression lock: restoring
+    /// the old `.expect("existing dep is package-flavor")` makes this call
+    /// panic instead of returning.
+    #[test]
+    fn reconcile_against_no_package_block_does_not_panic() {
+        use std::str::FromStr;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("nopkg");
+        write_streamlib_yaml(
+            &dir,
+            r#"
+dependencies:
+  "@tatolab/core":
+    path: ../core
+"#,
+        );
+        let manifest = Manifest::load(&dir).unwrap();
+        assert!(
+            manifest.package.is_none(),
+            "fixture must have no package block to exercise the lenient path"
+        );
+
+        let existing = ResolvedPackage {
+            manifest,
+            root_dir: dir.clone(),
+            schema_files: Vec::new(),
+            source: ResolvedSource::Path {
+                relative: PathBuf::from("../core"),
+            },
+            content_hash: "sha256:0".into(),
+        };
+        let spec = DependencySpec::Registry(RegistryDependency {
+            version: crate::semver::SemVerRange::from_str("^3.0.0").unwrap(),
+            runtime: false,
+        });
+
+        warn_when_existing_unsatisfies_spec(&existing, &spec, &dir, "@tatolab/core");
     }
 
     #[test]


### PR DESCRIPTION
## Ticket

Closes #1505 — feat(idents): version never blocks a load — remove the hard `VersionRangeConflict` stop.

Parent: #1502.

## Summary

Implements the #1502 principle end-to-end: a version-range mismatch resolves to a winning/installed
version and never halts a load. Scope grew from the resolver-only literal ticket text to a full
Scope B (owner-decided, see #1505 comment thread) after grounding showed the resolver fix alone left
two module-loader gates that still hard-failed the same class of mismatch on a live load:

- `sdk/streamlib-idents/src/resolver.rs` — shared-dep range mismatch resolves to the installed
  winner instead of hard-erroring; `check_resolved_satisfies_spec`'s first-resolution range gate is
  scoped to genuine `ResolvedSource::Registry` resolutions only (defense-in-depth against store
  mis-selection — `select_version` already guarantees in-range) so a link/patch override no longer
  hard-fails a dev-loop load.
- `runtime/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs` — the live walk's
  `VersionRangeUnsatisfied` and (now-removed) `SingleVersionConflict` gates warn-and-load instead of
  hard-failing, except when `walk_context.locked.is_some()` (a lockfile Exact-pin drift is a
  reproducibility integrity failure, kept hard on purpose).
- Dead `AddModuleError` variants removed; canonical-pattern doc sweep
  (`docs/architecture/package-development-model.md`).

## Test evidence

- `cargo test -p streamlib-idents --lib` — 237 passed, 0 failed.
- `cargo test -p streamlib-engine --lib core::runtime::module_loader` — 156 passed, 0 failed.
- New regression tests lock the leniency in both directions: cross-requirer range mismatch resolves
  to the installed winner (resolver), live-walk range/single-version mismatches warn-and-load
  (recursive_walker), link/patch first-resolution mismatch warns-and-loads (resolver), while a
  locked-run (lockfile) version drift still hard-fails (integrity, unchanged).

No GPU/IPC runtime surface touched — resolver + module-loader logic only, no `/verify-live` run
needed.

## Review items (non-blocking)

- **should-fix** — `sdk/streamlib-idents/src/resolver.rs:1412`: The fix-delta commit `f4089086` (a
  review-finding fix) keeps the build warning-free (its own message downgrades doc links for exactly
  this reason). The two new tests it added each open with `use std::str::FromStr;` (resolver.rs:1412
  and :1454), but call `crate::semver::SemVerRange::from_str(...)`, which is an INHERENT method
  (semver.rs:269 `pub fn from_str`). clippy emits `unused import: std::str::FromStr` at both lines.
  `git show origin/main:...resolver.rs | grep -c 'use std::str::FromStr'` = 0 vs 2 on the branch —
  net-new warnings introduced by this delta. Suggested next step: delete both
  `use std::str::FromStr;` lines; the inherent `SemVerRange::from_str` needs no trait in scope.
  Re-run `cargo clippy -p streamlib-idents --all-targets` to confirm the two warnings are gone.
- **info** — `runtime/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs:593`: No
  code path fails a load on a version gate (ticket intent). `AddModuleError::VersionRangeUnsatisfied`
  is RETAINED as a hard error, but deliberately re-scoped: in the live walk it only fires when
  `walk_context.locked.is_some()` (lockfile Exact-pin drift = reproducibility failure), and in the
  resolver's first-resolution gate only for a genuine `ResolvedSource::Registry` concrete
  (defense-in-depth against store mis-selection; `select_version` already guarantees in-range). The
  ticket's named target `VersionRangeConflict` is fully removed from the error enum and every load
  path. The retained hard error is a distinct integrity concern, thoroughly documented at
  `errors.rs:69` and `resolver.rs:850`. Recording so a reader does not mistake it for the removed
  gate. Suggested next step: note the locked-run/registry-source scoping on the PR body so the owner
  sees that "version never blocks a load" applies to live/install-derived walks, not to
  lockfile-pin-drift integrity checks.
