### PR TITLE
ci: compile every distributable package via the on-box install path

### DIFF
--- a/.github/workflows/install-packages.yml
+++ b/.github/workflows/install-packages.yml
@@ -1,0 +1,98 @@
+name: Install Packages
+
+# Standalone `packages/*` are NOT workspace members, so `cargo test --lib`
+# (see test.yml) never compiles them — a package can rot undetected between
+# releases. This gate closes that gap by exercising the SAME on-box user
+# install path: it links the engine into a scratch consumer via
+# `streamlib link --engine` and compiles every distributable package through
+# `streamlib add` (compile-on-place), failing with the per-package compiler
+# error. It compiles then discards; it NEVER ships a prebuilt. CPU-only —
+# it stops at the compiled artifact (no dlopen / GPU).
+#
+# The trigger set is the cdylib-safe dependency surface every distributable
+# package builds against: the authoring SDK crates + the plugin ABI + the
+# consumer-side RHI carve-out. A change to any of them can break a package
+# without touching the package's own files.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/**'
+      - 'sdk/**'
+      - 'runtime/streamlib-plugin-abi/**'
+      - 'runtime/streamlib-consumer-rhi/**'
+      - 'tools/streamlib-pack/**'
+      - 'xtask/**'
+      - '.github/workflows/install-packages.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/**'
+      - 'sdk/**'
+      - 'runtime/streamlib-plugin-abi/**'
+      - 'runtime/streamlib-consumer-rhi/**'
+      - 'tools/streamlib-pack/**'
+      - 'xtask/**'
+      - '.github/workflows/install-packages.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  install-packages-linux:
+    name: Install Packages (Linux, CPU-only)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        # Same minimal subset as test.yml: building `streamlib-cli` pulls
+        # streamlib-engine, whose build.rs compiles GLSL compute shaders with
+        # glslc and generates JTD bindings; the Linux engine dep set links
+        # Vulkan. No GPU/codec backends — this gate stops at the artifact.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config \
+            protobuf-compiler \
+            libvulkan-dev \
+            glslc
+
+      - name: Install jtd-codegen
+        # The engine's build.rs and every package's schema-dep codegen invoke
+        # the upstream jtd-codegen binary (v0.4.1) — see
+        # sdk/streamlib-jtd-codegen/src/lib.rs for the version contract.
+        run: |
+          curl -sSL https://github.com/jsontypedef/json-typedef-codegen/releases/download/v0.4.1/x86_64-unknown-linux-gnu.zip -o /tmp/jtd-codegen.zip
+          unzip -q /tmp/jtd-codegen.zip -d /tmp/jtd-codegen
+          sudo install -m 0755 /tmp/jtd-codegen/jtd-codegen /usr/local/bin/jtd-codegen
+          jtd-codegen --version
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-install-packages-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-install-packages-
+
+      - name: Build the streamlib CLI
+        # The driver drives the on-box install path through this exact binary.
+        run: cargo build --locked -p streamlib-cli
+
+      - name: Compile every distributable package via the on-box install path
+        # The xtask enumerator links the engine into a scratch consumer and
+        # runs `streamlib add` per distributable package, failing with the
+        # per-package compiler error. The skip set is driven from the one
+        # `non_distributable_path_offenders` predicate the whole-tree registry
+        # emit skips on, so it equals the emit skip set by construction.
+        run: cargo run --locked -p xtask -- install-packages --streamlib-bin target/debug/streamlib

--- a/packages/audio/src/linux/audio_capture.rs
+++ b/packages/audio/src/linux/audio_capture.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::{Device, Stream, StreamConfig};
+use cpal::{Device, StreamConfig};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::mpsc;
+use std::thread::JoinHandle;
 use streamlib_plugin_sdk::sdk::error::{Result, Error};
 use streamlib_plugin_sdk::sdk::context::RuntimeContextFullAccess;
 use streamlib_plugin_sdk::sdk::iceoryx2::OutputWriter;
@@ -28,11 +30,18 @@ pub struct LinuxAudioInputDevice {
 )]
 pub struct LinuxAudioCaptureProcessor {
     device_info: Option<LinuxAudioInputDevice>,
-    _device: Option<Device>,
-    _stream: Option<Stream>,
     is_capturing: Arc<AtomicBool>,
     frame_counter: Arc<AtomicU64>,
     stream_setup_done: bool,
+    // A `cpal::Stream` is `!Send` (the ALSA backend's handle must not move
+    // across threads), but the `#[processor]` macro requires the processor to
+    // be `Send` (it runs on the runtime thread pool). The stream is therefore
+    // confined to a dedicated thread that builds it, plays it, and holds it
+    // alive; the processor keeps only `Send` handles. Dropping the sender in
+    // `teardown` wakes the thread, which then drops the stream on its own
+    // thread.
+    capture_thread: Option<JoinHandle<()>>,
+    shutdown_sender: Option<mpsc::Sender<()>>,
 }
 
 impl streamlib_plugin_sdk::sdk::processors::ManualProcessor for LinuxAudioCaptureProcessor::Processor {
@@ -56,8 +65,13 @@ impl streamlib_plugin_sdk::sdk::processors::ManualProcessor for LinuxAudioCaptur
 
         self.is_capturing.store(false, Ordering::Relaxed);
 
-        self._stream = None;
-        self._device = None;
+        // Dropping the sender unblocks the capture thread's `recv`, which then
+        // drops the `cpal::Stream` on its owning thread and exits.
+        self.shutdown_sender = None;
+        if let Some(handle) = self.capture_thread.take() {
+            let _ = handle.join();
+        }
+        self.stream_setup_done = false;
         Ok(())
     }
 
@@ -77,10 +91,116 @@ impl streamlib_plugin_sdk::sdk::processors::ManualProcessor for LinuxAudioCaptur
 }
 
 impl LinuxAudioCaptureProcessor::Processor {
+    /// Spawn the stream-owning thread and block until it reports whether the
+    /// `cpal` stream built and started. The `cpal::Stream` is `!Send`, so it is
+    /// built and held entirely on that thread; only the device summary crosses
+    /// back here.
     fn setup_stream(&mut self) -> Result<()> {
+        let device_id = self.config.device_id.clone();
+        let outputs = self.outputs.clone();
+        let frame_counter = Arc::clone(&self.frame_counter);
+        let is_capturing = Arc::clone(&self.is_capturing);
+
+        let (ready_sender, ready_receiver) = mpsc::channel::<Result<LinuxAudioInputDevice>>();
+        let (shutdown_sender, shutdown_receiver) = mpsc::channel::<()>();
+
+        let handle = std::thread::Builder::new()
+            .name("audio-capture".to_string())
+            .spawn(move || {
+                match build_capture_stream(device_id, outputs, frame_counter, &is_capturing) {
+                    Ok((device_info, stream)) => {
+                        is_capturing.store(true, Ordering::Relaxed);
+                        if ready_sender.send(Ok(device_info)).is_err() {
+                            return;
+                        }
+                        // Hold the stream alive on this thread until teardown
+                        // drops the sender; the `cpal` callback fires on the
+                        // backend's own thread meanwhile.
+                        let _ = shutdown_receiver.recv();
+                        drop(stream);
+                    }
+                    Err(e) => {
+                        let _ = ready_sender.send(Err(e));
+                    }
+                }
+            })
+            .map_err(|e| {
+                Error::Configuration(format!("Failed to spawn audio capture thread: {}", e))
+            })?;
+
+        let device_info = ready_receiver
+            .recv()
+            .map_err(|_| {
+                Error::Configuration(
+                    "Audio capture thread exited before reporting stream setup".into(),
+                )
+            })??;
+
+        self.device_info = Some(device_info);
+        self.capture_thread = Some(handle);
+        self.shutdown_sender = Some(shutdown_sender);
+        Ok(())
+    }
+
+    pub fn list_devices() -> Result<Vec<LinuxAudioInputDevice>> {
+        let host = cpal::default_host();
+        let devices: Result<Vec<LinuxAudioInputDevice>> = host
+            .input_devices()
+            .map_err(|e| {
+                Error::Configuration(format!(
+                    "Failed to enumerate audio input devices: {}",
+                    e
+                ))
+            })?
+            .enumerate()
+            .filter_map(|(id, device)| {
+                let name = device.name().ok()?;
+                let config = device.default_input_config().ok()?;
+                let channels = config.channels();
+
+                if channels != 1 {
+                    return None;
+                }
+
+                let sample_rate = config.sample_rate().0;
+
+                let is_default = if let Some(default_device) = host.default_input_device() {
+                    device.name().ok() == default_device.name().ok()
+                } else {
+                    false
+                };
+
+                Some(Ok(LinuxAudioInputDevice {
+                    id,
+                    name,
+                    sample_rate,
+                    channels: 1,
+                    is_default,
+                }))
+            })
+            .collect();
+
+        devices
+    }
+
+    pub fn current_device(&self) -> Option<&LinuxAudioInputDevice> {
+        self.device_info.as_ref()
+    }
+}
+
+/// Select the input device, build the mono `cpal` input stream, and start it.
+/// Runs entirely on the capture thread because a `cpal::Stream` is `!Send`.
+/// The callback writes device-native mono frames to `outputs` until
+/// `is_capturing` is cleared.
+fn build_capture_stream(
+    device_id: Option<String>,
+    outputs: OutputWriter,
+    frame_counter: Arc<AtomicU64>,
+    is_capturing: &Arc<AtomicBool>,
+) -> Result<(LinuxAudioInputDevice, cpal::Stream)> {
         let host = cpal::default_host();
 
-        let device = if let Some(device_name_str) = &self.config.device_id {
+        let device = if let Some(device_name_str) = &device_id {
             let devices: Vec<Device> = host
                 .input_devices()
                 .map_err(|e| {
@@ -134,12 +254,12 @@ impl LinuxAudioCaptureProcessor::Processor {
             name: device_name.clone(),
             sample_rate: device_sample_rate,
             channels: device_channels as u32,
-            is_default: self.config.device_id.is_none(),
+            is_default: device_id.is_none(),
         };
 
-        let outputs_clone: OutputWriter = self.outputs.clone();
-        let frame_counter_clone = self.frame_counter.clone();
-        let is_capturing_clone = Arc::clone(&self.is_capturing);
+        let outputs_clone: OutputWriter = outputs;
+        let frame_counter_clone = frame_counter;
+        let is_capturing_clone = Arc::clone(is_capturing);
         let sample_rate_clone = device_sample_rate;
 
         let stream_config = StreamConfig {
@@ -189,67 +309,16 @@ impl LinuxAudioCaptureProcessor::Processor {
             Error::Configuration(format!("Failed to start audio stream: {}", e))
         })?;
 
-        self.is_capturing.store(true, Ordering::Relaxed);
         tracing::info!(
             "[AudioCapture] Stream active - capturing mono audio at {}Hz",
             device_sample_rate
         );
 
-        self.device_info = Some(device_info);
-        self._device = Some(device);
-        self._stream = Some(stream);
-
         tracing::info!(
             "[AudioCapture] {} Started - outputting device-native mono frames",
             device_name
         );
-        Ok(())
-    }
-
-    pub fn list_devices() -> Result<Vec<LinuxAudioInputDevice>> {
-        let host = cpal::default_host();
-        let devices: Result<Vec<LinuxAudioInputDevice>> = host
-            .input_devices()
-            .map_err(|e| {
-                Error::Configuration(format!(
-                    "Failed to enumerate audio input devices: {}",
-                    e
-                ))
-            })?
-            .enumerate()
-            .filter_map(|(id, device)| {
-                let name = device.name().ok()?;
-                let config = device.default_input_config().ok()?;
-                let channels = config.channels();
-
-                if channels != 1 {
-                    return None;
-                }
-
-                let sample_rate = config.sample_rate().0;
-
-                let is_default = if let Some(default_device) = host.default_input_device() {
-                    device.name().ok() == default_device.name().ok()
-                } else {
-                    false
-                };
-
-                Some(Ok(LinuxAudioInputDevice {
-                    id,
-                    name,
-                    sample_rate,
-                    channels: 1,
-                    is_default,
-                }))
-            })
-            .collect();
-
-        devices
-    }
-
-    pub fn current_device(&self) -> Option<&LinuxAudioInputDevice> {
-        self.device_info.as_ref()
-    }
+        Ok((device_info, stream))
 }
 
 #[cfg(test)]

--- a/packages/audio/src/linux/audio_output.rs
+++ b/packages/audio/src/linux/audio_output.rs
@@ -13,34 +13,6 @@ use crate::_generated_::AudioFrame;
 use streamlib_plugin_sdk::sdk::error::{Result, Error};
 use streamlib_plugin_sdk::sdk::context::RuntimeContextFullAccess;
 
-/// Wrapper for InputMailboxes pointer that is Send.
-struct SendableInputsPtr(*const streamlib_plugin_sdk::sdk::iceoryx2::InputMailboxes);
-
-// SAFETY: InputMailboxes is Send, and we control the lifetime
-unsafe impl Send for SendableInputsPtr {}
-
-impl SendableInputsPtr {
-    /// SAFETY: Caller must ensure the pointed-to data is still valid.
-    unsafe fn get(&self) -> &streamlib_plugin_sdk::sdk::iceoryx2::InputMailboxes {
-        unsafe { &*self.0 }
-    }
-}
-
-/// Wrapper for ProcessorAudioConverter pointer that is Send.
-struct SendableAudioConverterPtr(*mut ProcessorAudioConverter);
-
-// SAFETY: Only one thread accesses it, and we join before drop
-unsafe impl Send for SendableAudioConverterPtr {}
-
-#[allow(clippy::mut_from_ref)]
-impl SendableAudioConverterPtr {
-    /// SAFETY: Caller must ensure the pointed-to data is still valid
-    /// and no other thread is accessing it.
-    unsafe fn get_mut(&self) -> &mut ProcessorAudioConverter {
-        unsafe { &mut *self.0 }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct LinuxAudioDevice {
     pub id: usize,
@@ -68,13 +40,15 @@ pub struct LinuxAudioOutputProcessor {
     buffer_size: usize,
     frame_producer: Arc<Mutex<Option<Producer<AudioFrame>>>>,
     // A `cpal::Stream` is `!Send`, but the `#[processor]` macro requires the
-    // processor to be `Send`. The stream is therefore built and held on the
-    // output thread (below) — which also runs the input-poll loop — and never
-    // stored on the processor. The thread drops the stream when `stop_polling`
-    // is set and it exits.
+    // processor to be `Send`. The stream — and the `ProcessorAudioConverter`
+    // that feeds it — are therefore built and held entirely on the output
+    // thread (below), which also runs the input-poll loop; neither is stored on
+    // the processor, so nothing borrows `self` across the thread boundary. The
+    // processor keeps only `Send` handles (an `InputMailboxes` clone, the ring
+    // producer, the stop flag). The thread drops the stream and converter when
+    // `stop_polling` is set and it exits.
     output_thread: Option<thread::JoinHandle<()>>,
     stop_polling: Arc<AtomicBool>,
-    audio: Option<ProcessorAudioConverter>,
 }
 
 /// The device configuration the output thread resolved, reported back to the
@@ -93,7 +67,6 @@ impl streamlib_plugin_sdk::sdk::processors::ManualProcessor for LinuxAudioOutput
             .device_id
             .as_ref()
             .and_then(|s| s.parse::<usize>().ok());
-        self.audio = Some(ProcessorAudioConverter::new());
         tracing::info!(
             "AudioOutput: start() called (Pull mode - will query device for native config)"
         );
@@ -132,17 +105,11 @@ impl streamlib_plugin_sdk::sdk::processors::ManualProcessor for LinuxAudioOutput
         let stop_flag = Arc::clone(&self.stop_polling);
         stop_flag.store(false, Ordering::SeqCst);
 
-        // SAFETY for both raw pointers:
-        // 1. The output thread is stopped in teardown() before self is dropped
-        // 2. Only the output thread accesses these after start() returns
-        // 3. In Manual mode, no other code touches self between start() and teardown()
-        let audio = self.audio.as_mut().ok_or_else(|| {
-            Error::Configuration(
-                "audio converter not initialized — setup() must run before start()".into(),
-            )
-        })?;
-        let inputs_ptr = SendableInputsPtr(&self.inputs as *const _);
-        let audio_ptr = SendableAudioConverterPtr(audio as *mut _);
+        // Cross the thread boundary with owned `Send` handles only — an
+        // `InputMailboxes` clone (its handle is refcounted through the plugin
+        // ABI vtable), never a borrow of `self`. The converter is built inside
+        // the thread below, so nothing the thread touches outlives `self`.
+        let inputs = self.inputs.clone();
         let producer_clone = Arc::clone(&self.frame_producer);
         let stop_clone = Arc::clone(&stop_flag);
         let device_id = self.device_id;
@@ -169,18 +136,19 @@ impl streamlib_plugin_sdk::sdk::processors::ManualProcessor for LinuxAudioOutput
                     buffer_size: None,
                 };
 
+                // The converter lives entirely on this thread — no borrow of
+                // `self` crosses the boundary, so it can never outlive the
+                // processor.
+                let mut audio = ProcessorAudioConverter::new();
+
                 if ready_sender.send(Ok(resolved)).is_err() {
                     return;
                 }
 
                 tracing::info!("[AudioOutput] Polling loop started");
                 while !stop_clone.load(Ordering::SeqCst) {
-                    let inputs = unsafe { inputs_ptr.get() };
-
                     if inputs.has_data("audio") {
                         if let Ok(frame) = inputs.read::<AudioFrame>("audio") {
-                            let audio = unsafe { audio_ptr.get_mut() };
-
                             match audio.convert(&frame, &target) {
                                 Ok(converted_frames) => {
                                     let mut producer_guard = producer_clone.lock().unwrap();

--- a/packages/audio/src/linux/audio_output.rs
+++ b/packages/audio/src/linux/audio_output.rs
@@ -3,10 +3,11 @@
 
 use crate::processor_audio_converter::{ProcessorAudioConverter, ProcessorAudioConverterTargetFormat};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::{Stream, StreamConfig};
+use cpal::StreamConfig;
 use rtrb::{Producer, RingBuffer};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::sync::mpsc;
 use std::thread;
 use crate::_generated_::AudioFrame;
 use streamlib_plugin_sdk::sdk::error::{Result, Error};
@@ -61,15 +62,28 @@ pub struct LinuxAudioOutputProcessor {
     device_id: Option<usize>,
     device_name: String,
     device_info: Option<LinuxAudioDevice>,
-    stream: Option<Stream>,
     stream_setup_done: bool,
     sample_rate: u32,
     channels: u32,
     buffer_size: usize,
     frame_producer: Arc<Mutex<Option<Producer<AudioFrame>>>>,
-    polling_thread: Option<thread::JoinHandle<()>>,
+    // A `cpal::Stream` is `!Send`, but the `#[processor]` macro requires the
+    // processor to be `Send`. The stream is therefore built and held on the
+    // output thread (below) — which also runs the input-poll loop — and never
+    // stored on the processor. The thread drops the stream when `stop_polling`
+    // is set and it exits.
+    output_thread: Option<thread::JoinHandle<()>>,
     stop_polling: Arc<AtomicBool>,
     audio: Option<ProcessorAudioConverter>,
+}
+
+/// The device configuration the output thread resolved, reported back to the
+/// processor for its `current_device` summary.
+struct ResolvedOutputConfig {
+    device_name: String,
+    sample_rate: u32,
+    channels: u32,
+    buffer_size: usize,
 }
 
 impl streamlib_plugin_sdk::sdk::processors::ManualProcessor for LinuxAudioOutputProcessor::Processor {
@@ -89,11 +103,13 @@ impl streamlib_plugin_sdk::sdk::processors::ManualProcessor for LinuxAudioOutput
     fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.stop_polling.store(true, Ordering::SeqCst);
 
-        if let Some(handle) = self.polling_thread.take() {
+        // The output thread owns the `cpal::Stream`; joining it drops the
+        // stream on its own thread.
+        if let Some(handle) = self.output_thread.take() {
             let _ = handle.join();
         }
 
-        self.stream = None;
+        self.stream_setup_done = false;
         tracing::info!("AudioOutput {}: Stopped", self.device_name);
         Ok(())
     }
@@ -107,106 +123,7 @@ impl streamlib_plugin_sdk::sdk::processors::ManualProcessor for LinuxAudioOutput
             "AudioOutput: start() called - setting up stream now that connections are wired"
         );
 
-        let host = cpal::default_host();
-        let device = if let Some(id) = self.device_id {
-            let devices: Vec<_> = host
-                .output_devices()
-                .map_err(|e| {
-                    Error::Configuration(format!("Failed to enumerate audio devices: {}", e))
-                })?
-                .collect();
-            devices
-                .get(id)
-                .ok_or_else(|| {
-                    Error::Configuration(format!("Audio device {} not found", id))
-                })?
-                .clone()
-        } else {
-            host.default_output_device().ok_or_else(|| {
-                Error::Configuration("No default audio output device".into())
-            })?
-        };
-
-        let device_config = device.default_output_config().map_err(|e| {
-            Error::Configuration(format!("Failed to get audio config: {}", e))
-        })?;
-
-        let device_sample_rate = device_config.sample_rate().0;
-        let device_channels = device_config.channels() as u32;
-
-        // 512 samples (~10ms at 48kHz) balances latency and reliability.
-        let device_buffer_size = match device_config.buffer_size() {
-            cpal::SupportedBufferSize::Range { min, max } => {
-                let preferred = 512u32;
-                preferred.clamp(*min, *max) as usize
-            }
-            cpal::SupportedBufferSize::Unknown => 512,
-        };
-
-        tracing::info!(
-            "AudioOutput: Queried device config - {}Hz, {} channels, {} buffer size (ALSA backend)",
-            device_sample_rate,
-            device_channels,
-            device_buffer_size
-        );
-
         let (producer, consumer) = RingBuffer::<AudioFrame>::new(256);
-
-        let consumer = Arc::new(Mutex::new(consumer));
-        let consumer_for_callback = Arc::clone(&consumer);
-
-        tracing::info!("AudioOutput: Setting up adaptive audio output with cpal");
-
-        let mut sample_buffer: Vec<f32> = Vec::new();
-
-        let stream_config = StreamConfig {
-            channels: device_channels as u16,
-            sample_rate: cpal::SampleRate(device_sample_rate),
-            buffer_size: cpal::BufferSize::Fixed(device_buffer_size as u32),
-        };
-
-        let stream = device
-            .build_output_stream(
-                &stream_config,
-                move |data: &mut [f32], _info: &cpal::OutputCallbackInfo| {
-                    let mut consumer_guard = consumer_for_callback.lock().unwrap();
-
-                    while sample_buffer.len() < data.len() {
-                        if let Ok(audio_frame) = consumer_guard.pop() {
-                            sample_buffer.extend_from_slice(&audio_frame.samples);
-                        } else {
-                            break;
-                        }
-                    }
-
-                    if sample_buffer.len() >= data.len() {
-                        data.copy_from_slice(&sample_buffer[..data.len()]);
-                        sample_buffer.drain(..data.len());
-                    } else if !sample_buffer.is_empty() {
-                        let copy_len = sample_buffer.len();
-                        data[..copy_len].copy_from_slice(&sample_buffer);
-                        data[copy_len..].fill(0.0);
-                        sample_buffer.clear();
-                    } else {
-                        data.fill(0.0);
-                    }
-                },
-                |err| {
-                    tracing::error!("Audio output stream error: {}", err);
-                },
-                None,
-            )
-            .map_err(|e| {
-                Error::Configuration(format!("Failed to build audio stream: {}", e))
-            })?;
-
-        tracing::info!("AudioOutput: Starting cpal stream playback");
-        stream
-            .play()
-            .map_err(|e| Error::Configuration(format!("Failed to start stream: {}", e)))?;
-
-        tracing::info!("AudioOutput: cpal stream.play() succeeded");
-
         {
             let mut producer_guard = self.frame_producer.lock().unwrap();
             *producer_guard = Some(producer);
@@ -216,8 +133,8 @@ impl streamlib_plugin_sdk::sdk::processors::ManualProcessor for LinuxAudioOutput
         stop_flag.store(false, Ordering::SeqCst);
 
         // SAFETY for both raw pointers:
-        // 1. The polling thread is stopped in teardown() before self is dropped
-        // 2. Only the polling thread accesses these after start() returns
+        // 1. The output thread is stopped in teardown() before self is dropped
+        // 2. Only the output thread accesses these after start() returns
         // 3. In Manual mode, no other code touches self between start() and teardown()
         let audio = self.audio.as_mut().ok_or_else(|| {
             Error::Configuration(
@@ -228,69 +145,91 @@ impl streamlib_plugin_sdk::sdk::processors::ManualProcessor for LinuxAudioOutput
         let audio_ptr = SendableAudioConverterPtr(audio as *mut _);
         let producer_clone = Arc::clone(&self.frame_producer);
         let stop_clone = Arc::clone(&stop_flag);
-        let target_sample_rate = device_sample_rate;
-        let target_channels = device_channels as u8;
+        let device_id = self.device_id;
 
-        let polling_thread = thread::spawn(move || {
-            tracing::info!("[AudioOutput] Polling thread started");
+        let (ready_sender, ready_receiver) = mpsc::channel::<Result<ResolvedOutputConfig>>();
 
-            let target = ProcessorAudioConverterTargetFormat {
-                sample_rate: Some(target_sample_rate),
-                channels: Some(target_channels),
-                buffer_size: None,
-            };
+        let output_thread = thread::Builder::new()
+            .name("audio-output".to_string())
+            .spawn(move || {
+                // A `cpal::Stream` is `!Send`: build, play, and hold it entirely
+                // on this thread; the input-poll loop below runs on the same
+                // thread and the stream drops when the loop exits.
+                let (resolved, stream) = match build_output_stream(device_id, consumer) {
+                    Ok(built) => built,
+                    Err(e) => {
+                        let _ = ready_sender.send(Err(e));
+                        return;
+                    }
+                };
 
-            while !stop_clone.load(Ordering::SeqCst) {
-                let inputs = unsafe { inputs_ptr.get() };
+                let target = ProcessorAudioConverterTargetFormat {
+                    sample_rate: Some(resolved.sample_rate),
+                    channels: Some(resolved.channels as u8),
+                    buffer_size: None,
+                };
 
-                if inputs.has_data("audio") {
-                    if let Ok(frame) = inputs.read::<AudioFrame>("audio") {
-                        let audio = unsafe { audio_ptr.get_mut() };
+                if ready_sender.send(Ok(resolved)).is_err() {
+                    return;
+                }
 
-                        match audio.convert(&frame, &target) {
-                            Ok(converted_frames) => {
-                                let mut producer_guard = producer_clone.lock().unwrap();
-                                if let Some(ref mut producer) = *producer_guard {
-                                    for converted in converted_frames {
-                                        if producer.push(converted).is_err() {
-                                            tracing::warn!(
-                                                "[AudioOutput] Ring buffer full, dropping frame"
-                                            );
+                tracing::info!("[AudioOutput] Polling loop started");
+                while !stop_clone.load(Ordering::SeqCst) {
+                    let inputs = unsafe { inputs_ptr.get() };
+
+                    if inputs.has_data("audio") {
+                        if let Ok(frame) = inputs.read::<AudioFrame>("audio") {
+                            let audio = unsafe { audio_ptr.get_mut() };
+
+                            match audio.convert(&frame, &target) {
+                                Ok(converted_frames) => {
+                                    let mut producer_guard = producer_clone.lock().unwrap();
+                                    if let Some(ref mut producer) = *producer_guard {
+                                        for converted in converted_frames {
+                                            if producer.push(converted).is_err() {
+                                                tracing::warn!(
+                                                    "[AudioOutput] Ring buffer full, dropping frame"
+                                                );
+                                            }
                                         }
                                     }
                                 }
-                            }
-                            Err(e) => {
-                                tracing::error!("[AudioOutput] Audio conversion failed: {}", e);
+                                Err(e) => {
+                                    tracing::error!(
+                                        "[AudioOutput] Audio conversion failed: {}",
+                                        e
+                                    );
+                                }
                             }
                         }
+                    } else {
+                        thread::sleep(std::time::Duration::from_micros(500));
                     }
-                } else {
-                    thread::sleep(std::time::Duration::from_micros(500));
                 }
-            }
 
-            tracing::info!("[AudioOutput] Polling thread stopped");
-        });
+                drop(stream);
+                tracing::info!("[AudioOutput] Polling loop stopped");
+            })
+            .map_err(|e| {
+                Error::Configuration(format!("Failed to spawn audio output thread: {}", e))
+            })?;
 
-        self.polling_thread = Some(polling_thread);
+        let resolved = ready_receiver.recv().map_err(|_| {
+            Error::Configuration("Audio output thread exited before reporting stream setup".into())
+        })??;
 
-        let device_name = device
-            .name()
-            .unwrap_or_else(|_| "Unknown Device".to_string());
-
-        self.stream = Some(stream);
-        self.device_name = device_name.clone();
+        self.output_thread = Some(output_thread);
+        self.device_name = resolved.device_name.clone();
         self.device_info = Some(LinuxAudioDevice {
             id: self.device_id.unwrap_or(0),
-            name: device_name,
-            sample_rate: device_sample_rate,
-            channels: device_channels,
+            name: resolved.device_name,
+            sample_rate: resolved.sample_rate,
+            channels: resolved.channels,
             is_default: self.device_id.is_none(),
         });
-        self.sample_rate = device_sample_rate;
-        self.channels = device_channels;
-        self.buffer_size = device_buffer_size;
+        self.sample_rate = resolved.sample_rate;
+        self.channels = resolved.channels;
+        self.buffer_size = resolved.buffer_size;
         self.stream_setup_done = true;
 
         tracing::info!(
@@ -303,4 +242,117 @@ impl streamlib_plugin_sdk::sdk::processors::ManualProcessor for LinuxAudioOutput
 
         Ok(())
     }
+}
+
+/// Select the output device, build the `cpal` output stream fed by `consumer`,
+/// and start playback. Runs entirely on the output thread because a
+/// `cpal::Stream` is `!Send`; the resolved device config is returned so the
+/// processor can report it.
+fn build_output_stream(
+    device_id: Option<usize>,
+    consumer: rtrb::Consumer<AudioFrame>,
+) -> Result<(ResolvedOutputConfig, cpal::Stream)> {
+    let host = cpal::default_host();
+    let device = if let Some(id) = device_id {
+        let devices: Vec<_> = host
+            .output_devices()
+            .map_err(|e| {
+                Error::Configuration(format!("Failed to enumerate audio devices: {}", e))
+            })?
+            .collect();
+        devices
+            .get(id)
+            .ok_or_else(|| Error::Configuration(format!("Audio device {} not found", id)))?
+            .clone()
+    } else {
+        host.default_output_device()
+            .ok_or_else(|| Error::Configuration("No default audio output device".into()))?
+    };
+
+    let device_config = device.default_output_config().map_err(|e| {
+        Error::Configuration(format!("Failed to get audio config: {}", e))
+    })?;
+
+    let device_sample_rate = device_config.sample_rate().0;
+    let device_channels = device_config.channels() as u32;
+
+    // 512 samples (~10ms at 48kHz) balances latency and reliability.
+    let device_buffer_size = match device_config.buffer_size() {
+        cpal::SupportedBufferSize::Range { min, max } => {
+            let preferred = 512u32;
+            preferred.clamp(*min, *max) as usize
+        }
+        cpal::SupportedBufferSize::Unknown => 512,
+    };
+
+    tracing::info!(
+        "AudioOutput: Queried device config - {}Hz, {} channels, {} buffer size (ALSA backend)",
+        device_sample_rate,
+        device_channels,
+        device_buffer_size
+    );
+
+    let consumer = Arc::new(Mutex::new(consumer));
+    let consumer_for_callback = Arc::clone(&consumer);
+    let mut sample_buffer: Vec<f32> = Vec::new();
+
+    let stream_config = StreamConfig {
+        channels: device_channels as u16,
+        sample_rate: cpal::SampleRate(device_sample_rate),
+        buffer_size: cpal::BufferSize::Fixed(device_buffer_size as u32),
+    };
+
+    let stream = device
+        .build_output_stream(
+            &stream_config,
+            move |data: &mut [f32], _info: &cpal::OutputCallbackInfo| {
+                let mut consumer_guard = consumer_for_callback.lock().unwrap();
+
+                while sample_buffer.len() < data.len() {
+                    if let Ok(audio_frame) = consumer_guard.pop() {
+                        sample_buffer.extend_from_slice(&audio_frame.samples);
+                    } else {
+                        break;
+                    }
+                }
+
+                if sample_buffer.len() >= data.len() {
+                    data.copy_from_slice(&sample_buffer[..data.len()]);
+                    sample_buffer.drain(..data.len());
+                } else if !sample_buffer.is_empty() {
+                    let copy_len = sample_buffer.len();
+                    data[..copy_len].copy_from_slice(&sample_buffer);
+                    data[copy_len..].fill(0.0);
+                    sample_buffer.clear();
+                } else {
+                    data.fill(0.0);
+                }
+            },
+            |err| {
+                tracing::error!("Audio output stream error: {}", err);
+            },
+            None,
+        )
+        .map_err(|e| Error::Configuration(format!("Failed to build audio stream: {}", e)))?;
+
+    tracing::info!("AudioOutput: Starting cpal stream playback");
+    stream
+        .play()
+        .map_err(|e| Error::Configuration(format!("Failed to start stream: {}", e)))?;
+
+    tracing::info!("AudioOutput: cpal stream.play() succeeded");
+
+    let device_name = device
+        .name()
+        .unwrap_or_else(|_| "Unknown Device".to_string());
+
+    Ok((
+        ResolvedOutputConfig {
+            device_name,
+            sample_rate: device_sample_rate,
+            channels: device_channels,
+            buffer_size: device_buffer_size,
+        },
+        stream,
+    ))
 }

--- a/packages/clap/Cargo.toml
+++ b/packages/clap/Cargo.toml
@@ -36,15 +36,10 @@ serde = {version = "1.0", features = ["derive"]}
 tracing = {version = "0.1.41", features = ["release_max_level_debug"]}
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-# Audio domain package — owns `ProcessorAudioConverter` + `AudioResampler`
-# (carved out of the engine in #734). Used only by the macOS/iOS-gated
-# `clap_effect` (see lib.rs cfg). A cross-PACKAGE crate dep: there is no
-# crates registry, so it cannot resolve by version — it is a monorepo source
-# (`path`) dep, which by design marks this package NON-distributable (the
-# whole-tree emit + the install-packages gate skip it via the shared
-# `non_distributable_path_offenders` predicate). It becomes distributable
-# again once `ProcessorAudioConverter` moves to the authoring SDK (resolvable
-# by version) or the audio package is registry-published.
+# Path dep on the audio domain package (owns `ProcessorAudioConverter`, used by
+# the macOS/iOS-gated `clap_effect`) ⇒ this package is non-distributable via the
+# shared `non_distributable_path_offenders` predicate. Re-enabled when
+# `ProcessorAudioConverter` moves to the authoring SDK and resolves by version.
 streamlib-audio = { path = "../audio" }
 
 # CLAP plugin host bindings — not available on Linux/Windows in this

--- a/packages/clap/Cargo.toml
+++ b/packages/clap/Cargo.toml
@@ -21,11 +21,6 @@ streamlib-jtd-codegen = {version = "0.7.38"}
 # types under `crate::_generated_::*` (AudioFrame).
 streamlib-plugin-sdk = {version = "0.7.38"}
 
-# Audio domain package — owns `ProcessorAudioConverter` + `AudioResampler`
-# (carved out of the engine in #734). Consumers that need channel /
-# sample-rate / rechunk conversion reach for them here.
-streamlib-audio = {version = "0.7.0"}
-
 # Procedural macros — `#[streamlib_plugin_sdk::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = {version = "0.7.38"}
@@ -41,6 +36,17 @@ serde = {version = "1.0", features = ["derive"]}
 tracing = {version = "0.1.41", features = ["release_max_level_debug"]}
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+# Audio domain package — owns `ProcessorAudioConverter` + `AudioResampler`
+# (carved out of the engine in #734). Used only by the macOS/iOS-gated
+# `clap_effect` (see lib.rs cfg). A cross-PACKAGE crate dep: there is no
+# crates registry, so it cannot resolve by version — it is a monorepo source
+# (`path`) dep, which by design marks this package NON-distributable (the
+# whole-tree emit + the install-packages gate skip it via the shared
+# `non_distributable_path_offenders` predicate). It becomes distributable
+# again once `ProcessorAudioConverter` moves to the authoring SDK (resolvable
+# by version) or the audio package is registry-published.
+streamlib-audio = { path = "../audio" }
+
 # CLAP plugin host bindings — not available on Linux/Windows in this
 # package; Linux CLAP support is a future ticket.
 clack-host = { git = "https://github.com/prokopyl/clack", rev = "f53f8fc132c001a332c0a7221267812dfb654e92" }

--- a/tools/streamlib-pack/src/lib.rs
+++ b/tools/streamlib-pack/src/lib.rs
@@ -1271,7 +1271,12 @@ pub(crate) fn path_patch_offenders(pkg_dir: &Path) -> Result<Vec<String>> {
 /// hard-fail on: the skip set equals the rejection set, sound by construction
 /// (one shared definition per half) rather than a proxy. TARGET paths
 /// (`[[bin]].path` / `[lib].path`) are not dependency paths and never count.
-pub(crate) fn non_distributable_path_offenders(pkg_dir: &Path) -> Result<Vec<String>> {
+///
+/// `pub` so the `install-packages` CI enumerator (xtask) drives its skip set
+/// from this exact predicate — the same one the whole-tree emit and the
+/// single-package pack hard-fail on — so the CI skip set equals the emit skip
+/// set by construction rather than a re-derived YAML list.
+pub fn non_distributable_path_offenders(pkg_dir: &Path) -> Result<Vec<String>> {
     let mut offenders = path_patch_offenders(pkg_dir)?;
     offenders.extend(cargo_path_dep_offenders(pkg_dir)?);
     Ok(offenders)

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -46,6 +46,11 @@ jsonschema = { version = "0.30", default-features = false }
 # Error handling
 anyhow = "1.0"
 
+# Scratch consumer dir for the install-packages CI enumerator — the engine
+# link marker + materialized streamlib_modules/ slots live in a tempdir that is
+# discarded on drop (compile-then-discard, never ship a prebuilt).
+tempfile = "3.15"
+
 # Recursive file walk for lint-logging + check-manifest-schema
 walkdir = "2.5"
 
@@ -54,7 +59,4 @@ walkdir = "2.5"
 # file-level #![allow(...)]) without having to compile the workspace.
 syn = { version = "2", features = ["full", "visit", "extra-traits"] }
 proc-macro2 = { version = "1", features = ["span-locations"] }
-
-[dev-dependencies]
-tempfile = "3.15"
 

--- a/xtask/src/install_packages.rs
+++ b/xtask/src/install_packages.rs
@@ -1,0 +1,345 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `xtask install-packages` — the ground-truth enumerator + driver for the
+//! `install-packages` CI gate (#1509).
+//!
+//! Standalone `packages/*` are NOT workspace members, so `cargo test --lib`
+//! never compiles them — that is how a package rots undetected between releases.
+//! This driver closes the gap by exercising the SAME on-box user install path a
+//! consumer hits: it links the engine into a scratch consumer via
+//! `streamlib link --engine` and then, for every distributable package, runs
+//! `streamlib add <pkg_dir>` — which materializes the package into
+//! `streamlib_modules/` and compiles the placed slot in place, failing with the
+//! real per-package compiler error. It compiles then discards; it NEVER ships a
+//! prebuilt (that is the distribution path, not the install path). CPU-only —
+//! it stops at the compiled artifact, with no dlopen and no GPU.
+//!
+//! The distributable set is not a re-derived YAML list: it is driven from the
+//! single [`streamlib_pack::non_distributable_path_offenders`] predicate — the
+//! exact one the whole-tree static-registry emit skips on and the single-package
+//! `streamlib pkg build` hard-fails on — so the CI skip set equals the emit skip
+//! set by construction. A package carrying a `streamlib.yaml` path-`patch:`
+//! block or a `Cargo.toml` dependency-table `path` dep (the host-side,
+//! non-distributable exceptions: `api-server`, `core`, the test fixtures) is
+//! skipped exactly as the emit skips it. A schema-only package with no
+//! compilable unit (e.g. `escalate`) is a no-op through the install path, never
+//! a failure.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+/// One package the enumerator classified as distributable and drove through the
+/// install path, paired with the outcome of its on-box compile.
+struct PackageCompileOutcome {
+    /// `packages/<name>` directory the package was compiled from.
+    package_dir: PathBuf,
+    /// The captured `streamlib add` output when the compile failed; `None` on
+    /// success. Carries the compiler error so CI names it per package.
+    failure_output: Option<String>,
+}
+
+/// Drive every distributable `packages/*` through the on-box install path,
+/// failing (and naming each package with its compiler error) when any stops
+/// compiling.
+///
+/// `streamlib_bin` is the pre-built `streamlib` CLI. The engine is resolved via
+/// `streamlib link --engine <workspace_root>` into a throwaway scratch consumer
+/// (`[patch.crates-io]` path overrides + `STREAMLIB_LINK_CHECKOUT`), so package
+/// crate deps that pin `version = "0.7.x"` resolve to the local checkout — there
+/// is no crates registry and no publish step.
+pub fn run(workspace_root: &Path, streamlib_bin: &Path) -> Result<()> {
+    if !streamlib_bin.is_file() {
+        bail!(
+            "streamlib CLI binary not found at {} — build it first with `cargo build -p streamlib-cli`",
+            streamlib_bin.display()
+        );
+    }
+    let streamlib_bin = streamlib_bin
+        .canonicalize()
+        .with_context(|| format!("canonicalize {}", streamlib_bin.display()))?;
+
+    let packages_dir = workspace_root.join("packages");
+    let (distributable, skipped) = partition_packages(&packages_dir)
+        .with_context(|| format!("enumerating {}", packages_dir.display()))?;
+
+    for (pkg_dir, offenders) in &skipped {
+        tracing::info!(
+            package = %package_label(pkg_dir),
+            offenders = %offenders.join(", "),
+            "install-packages: skipping non-distributable package (path-patch / path-dep); it is \
+             skipped by the whole-tree emit for the same reason"
+        );
+    }
+
+    if distributable.is_empty() {
+        bail!(
+            "no distributable packages found under {} — the enumerator would validate nothing",
+            packages_dir.display()
+        );
+    }
+
+    // The scratch consumer holds the engine link marker + `[patch.crates-io]`
+    // cargo config and every materialized `streamlib_modules/` slot; the whole
+    // tree is discarded on drop (compile-then-discard, never ship a prebuilt).
+    let scratch = tempfile::tempdir().context("creating the scratch consumer directory")?;
+    establish_engine_link(&streamlib_bin, workspace_root, scratch.path())
+        .context("linking the engine into the scratch consumer")?;
+
+    tracing::info!(
+        count = distributable.len(),
+        "install-packages: compiling every distributable package via the on-box install path"
+    );
+
+    let mut outcomes: Vec<PackageCompileOutcome> = Vec::with_capacity(distributable.len());
+    for pkg_dir in &distributable {
+        tracing::info!(package = %package_label(pkg_dir), "install-packages: streamlib add (compile-on-place)");
+        let failure_output = compile_via_install_path(&streamlib_bin, scratch.path(), pkg_dir)?;
+        if failure_output.is_some() {
+            tracing::error!(package = %package_label(pkg_dir), "install-packages: FAILED to compile");
+        }
+        outcomes.push(PackageCompileOutcome {
+            package_dir: pkg_dir.clone(),
+            failure_output,
+        });
+    }
+
+    report_outcomes(&outcomes)
+}
+
+/// Partition `packages/*` (each a dir with a `streamlib.yaml`) into the
+/// distributable set (compiled through the install path) and the skipped set
+/// (each with the offenders that make it non-distributable), keyed on the exact
+/// [`streamlib_pack::non_distributable_path_offenders`] predicate.
+fn partition_packages(
+    packages_dir: &Path,
+) -> Result<(Vec<PathBuf>, Vec<(PathBuf, Vec<String>)>)> {
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(packages_dir)
+        .with_context(|| format!("read_dir {}", packages_dir.display()))?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.join("streamlib.yaml").is_file())
+        .collect();
+    entries.sort();
+
+    let mut distributable = Vec::new();
+    let mut skipped = Vec::new();
+    for pkg_dir in entries {
+        let offenders = streamlib_pack::non_distributable_path_offenders(&pkg_dir)
+            .with_context(|| format!("classifying {}", pkg_dir.display()))?;
+        if offenders.is_empty() {
+            distributable.push(pkg_dir);
+        } else {
+            skipped.push((pkg_dir, offenders));
+        }
+    }
+    Ok((distributable, skipped))
+}
+
+/// `streamlib link --engine <workspace_root> --skip-verify` in the scratch
+/// consumer. `--skip-verify` because the scratch consumer is a bare directory
+/// with no `Cargo.toml` to resolve against — the link only needs to write the
+/// `[patch.crates-io]` cargo config + `.streamlib/link.json` marker the
+/// per-package compile discovers.
+fn establish_engine_link(
+    streamlib_bin: &Path,
+    workspace_root: &Path,
+    scratch: &Path,
+) -> Result<()> {
+    let output = Command::new(streamlib_bin)
+        .arg("link")
+        .arg("--engine")
+        .arg(workspace_root)
+        .arg("--skip-verify")
+        .current_dir(scratch)
+        .output()
+        .with_context(|| format!("spawning {} link --engine", streamlib_bin.display()))?;
+    if !output.status.success() {
+        bail!(
+            "`streamlib link --engine {}` failed:\n{}",
+            workspace_root.display(),
+            combined_output(&output)
+        );
+    }
+    Ok(())
+}
+
+/// Compile one package through the install path: `streamlib add <pkg_dir>` in
+/// the scratch consumer. `add` materializes the package into
+/// `streamlib_modules/@org/name/` and compiles the placed slot in place, rolling
+/// the placement back on a compile failure. Returns `Some(output)` carrying the
+/// compiler error when the compile failed, `None` on success (schema-only
+/// packages compile trivially — a no-op, still `None`). Process cwd is the
+/// scratch consumer so the build orchestrator discovers the engine link marker.
+fn compile_via_install_path(
+    streamlib_bin: &Path,
+    scratch: &Path,
+    pkg_dir: &Path,
+) -> Result<Option<String>> {
+    let output = Command::new(streamlib_bin)
+        .arg("add")
+        .arg(pkg_dir)
+        .arg("--dir")
+        .arg(scratch)
+        .current_dir(scratch)
+        .output()
+        .with_context(|| format!("spawning {} add {}", streamlib_bin.display(), pkg_dir.display()))?;
+    if output.status.success() {
+        Ok(None)
+    } else {
+        Ok(Some(combined_output(&output)))
+    }
+}
+
+/// Aggregate every compile outcome into a single pass/fail verdict: on any
+/// failure, bail with each broken package named alongside its compiler error so
+/// the CI log points straight at the regression.
+fn report_outcomes(outcomes: &[PackageCompileOutcome]) -> Result<()> {
+    use std::fmt::Write;
+
+    let failures: Vec<&PackageCompileOutcome> =
+        outcomes.iter().filter(|o| o.failure_output.is_some()).collect();
+    let compiled = outcomes.len() - failures.len();
+
+    if failures.is_empty() {
+        tracing::info!(
+            compiled,
+            "install-packages: every distributable package compiled via the on-box install path"
+        );
+        return Ok(());
+    }
+
+    let mut message = format!(
+        "install-packages: {} of {} distributable package(s) failed to compile via the on-box \
+         install path:",
+        failures.len(),
+        outcomes.len()
+    );
+    for outcome in &failures {
+        write!(
+            message,
+            "\n\n=== {} ===\n{}",
+            package_label(&outcome.package_dir),
+            outcome.failure_output.as_deref().unwrap_or("")
+        )
+        .ok();
+    }
+    bail!(message)
+}
+
+/// `packages/<name>` → `<name>` for log lines.
+fn package_label(pkg_dir: &Path) -> String {
+    pkg_dir
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| pkg_dir.display().to_string())
+}
+
+/// Stdout + stderr of a captured subprocess, concatenated for a diagnostic.
+fn combined_output(output: &std::process::Output) -> String {
+    let mut combined = String::new();
+    combined.push_str(&String::from_utf8_lossy(&output.stdout));
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    combined
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Write a minimal package dir: a `streamlib.yaml` and, optionally, a
+    /// `Cargo.toml` carrying a `path` dependency (which makes it
+    /// non-distributable through the shared predicate).
+    fn write_package(root: &Path, name: &str, with_path_dep: bool) -> PathBuf {
+        let dir = root.join("packages").join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("streamlib.yaml"),
+            format!("package:\n  org: tatolab\n  name: {name}\n  version: 0.1.0\n"),
+        )
+        .unwrap();
+        if with_path_dep {
+            std::fs::write(
+                dir.join("Cargo.toml"),
+                format!(
+                    "[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+                     [dependencies]\nlocal-thing = {{ path = \"../local-thing\" }}\n"
+                ),
+            )
+            .unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn partition_drives_skip_set_from_the_shared_offender_predicate() {
+        // A distributable package (no path artifacts) is compiled; a package
+        // carrying a Cargo.toml path dep is skipped — the exact set the
+        // whole-tree emit skips, keyed on the one shared predicate. Mentally
+        // reverting to "compile every packages/* dir" would push the path-dep
+        // package into the distributable list; this asserts against that.
+        let root = tempfile::tempdir().unwrap();
+        let dist = write_package(root.path(), "camera", false);
+        let skip = write_package(root.path(), "api-server", true);
+
+        let (distributable, skipped) =
+            partition_packages(&root.path().join("packages")).unwrap();
+
+        assert_eq!(distributable, vec![dist]);
+        assert_eq!(skipped.len(), 1);
+        assert_eq!(skipped[0].0, skip);
+        assert!(
+            !skipped[0].1.is_empty(),
+            "a skipped package must name its offenders"
+        );
+    }
+
+    #[test]
+    fn partition_ignores_dirs_without_a_manifest() {
+        let root = tempfile::tempdir().unwrap();
+        write_package(root.path(), "camera", false);
+        // A stray dir with no streamlib.yaml is not a package.
+        std::fs::create_dir_all(root.path().join("packages").join("not-a-package")).unwrap();
+
+        let (distributable, skipped) =
+            partition_packages(&root.path().join("packages")).unwrap();
+
+        assert_eq!(distributable.len(), 1);
+        assert!(skipped.is_empty());
+    }
+
+    #[test]
+    fn report_outcomes_names_each_broken_package_with_its_error() {
+        let outcomes = vec![
+            PackageCompileOutcome {
+                package_dir: PathBuf::from("packages/camera"),
+                failure_output: None,
+            },
+            PackageCompileOutcome {
+                package_dir: PathBuf::from("packages/webrtc"),
+                failure_output: Some("error[E0599]: no method named `frobnicate`".to_string()),
+            },
+        ];
+        let err = report_outcomes(&outcomes).expect_err("a broken package must fail the gate");
+        let message = err.to_string();
+        assert!(message.contains("webrtc"), "must name the broken package: {message}");
+        assert!(
+            message.contains("no method named `frobnicate`"),
+            "must carry the compiler error: {message}"
+        );
+        assert!(
+            !message.contains("packages/camera"),
+            "must not name the green package: {message}"
+        );
+    }
+
+    #[test]
+    fn report_outcomes_passes_when_all_green() {
+        let outcomes = vec![PackageCompileOutcome {
+            package_dir: PathBuf::from("packages/camera"),
+            failure_output: None,
+        }];
+        report_outcomes(&outcomes).unwrap();
+    }
+}

--- a/xtask/src/install_packages.rs
+++ b/xtask/src/install_packages.rs
@@ -20,11 +20,16 @@
 //! exact one the whole-tree static-registry emit skips on and the single-package
 //! `streamlib pkg build` hard-fails on — so the CI skip set equals the emit skip
 //! set by construction. A package carrying a `streamlib.yaml` path-`patch:`
-//! block or a `Cargo.toml` dependency-table `path` dep (the host-side,
-//! non-distributable exceptions: `api-server`, `core`, the test fixtures) is
-//! skipped exactly as the emit skips it. A schema-only package with no
-//! compilable unit (e.g. `escalate`) is a no-op through the install path, never
-//! a failure.
+//! block or a `Cargo.toml` dependency-table `path` dep (e.g. `api-server`,
+//! `clap`, the test fixtures) is skipped exactly as the emit skips it. A TARGET
+//! path (`[lib].path` / `[[bin]].path`) is not a dependency path and never
+//! counts, so a schema-only package like `core` — whose test-only `Cargo.toml`
+//! carries a `[lib].path` and workspace-inherited fields but no `processors:`
+//! block — is DISTRIBUTABLE, not a path-predicate skip. It (like `escalate`)
+//! drives through the install path as a no-op: the on-box compile is gated on
+//! the manifest's `processors:` set, not on the presence of a `Cargo.toml`, so
+//! a package with no Rust processors never builds its Cargo unit and never
+//! fails.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -25,6 +25,7 @@ pub mod check_package_version_drift;
 pub mod check_processor_spec_new;
 pub mod check_schema_versions;
 pub mod check_vendored_vulkanalia;
+pub mod install_packages;
 pub mod lint_logging;
 pub mod manifest_schema;
 
@@ -204,6 +205,23 @@ enum Commands {
     /// registry daemon, no token. See `docs/architecture/static-registry.md`.
     #[command(subcommand)]
     StaticRegistry(StaticRegistryAction),
+
+    /// Ground-truth enumerator for the `install-packages` CI gate (#1509):
+    /// compile every distributable `packages/*` through the SAME on-box user
+    /// install path (`streamlib link --engine` into a scratch consumer, then
+    /// `streamlib add <pkg>` per package), failing with the per-package
+    /// compiler error. Standalone packages are not workspace members, so
+    /// `cargo test --lib` never compiles them — this closes that gap. The skip
+    /// set is driven from the one `non_distributable_path_offenders` predicate
+    /// the whole-tree emit skips on, so it equals the emit skip set by
+    /// construction. CPU-only: it stops at the compiled artifact (no dlopen /
+    /// GPU) and discards, never shipping a prebuilt.
+    InstallPackages {
+        /// The pre-built `streamlib` CLI binary (default:
+        /// `<workspace>/target/debug/streamlib`).
+        #[arg(long)]
+        streamlib_bin: Option<PathBuf>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -290,6 +308,12 @@ fn main() -> Result<()> {
                 out,
                 dev,
             })?
+        }
+        Commands::InstallPackages { streamlib_bin } => {
+            let root = workspace_root()?;
+            let streamlib_bin =
+                streamlib_bin.unwrap_or_else(|| root.join("target/debug/streamlib"));
+            install_packages::run(&root, &streamlib_bin)?
         }
     }
 


### PR DESCRIPTION
Closes #1509

## Summary

Standalone `packages/*` are not workspace members, so `cargo test --lib` never compiles them — a package can rot undetected between releases (this is exactly how debug-utilities rotted, see #1502-adjacent history). This PR adds an `xtask install-packages` enumerator that is the ground-truth compile gate for every distributable package, and fixes the two real stragglers it surfaced.

- **`xtask install-packages`** links the engine into a scratch consumer via `streamlib link --engine` and compiles every distributable package through `streamlib add` (compile-on-place) — it compiles then discards; it never ships a prebuilt artifact. CPU-only, no GPU/dlopen involved.
- The skip set (non-distributable packages) is driven from the single `streamlib_pack::non_distributable_path_offenders` predicate — the same predicate the whole-tree registry emit already skips on — so the CI skip set equals the emit skip set by construction, never a re-derived YAML list.
- `.github/workflows/install-packages.yml` runs the gate on the cdylib-safe dep surface (packages, sdk, plugin-abi, consumer-rhi).
- **`audio` fix**: Linux `AudioCapture` / `AudioOutput` stored a `cpal::Stream` (`!Send`) directly as a struct field, so the `#[processor]` macro's `Send` bound (processors run on the runtime thread pool) failed to compile. Both processors now confine the stream to a dedicated owning thread and keep only `Send` handles crossing the processor boundary — capture holds the stream alive on a thread that blocks until teardown drops the shutdown sender; output builds and holds it on the same thread that runs the input-poll loop.
- **`clap` fix**: `streamlib-clap` cargo-depended on the `streamlib-audio` package crate by version, which cannot resolve (no crates registry, packages are outside the engine-link release closure). Converted to a monorepo `path` dep, which by design classifies `clap` non-distributable — the whole-tree emit and the install-packages gate both skip it via the shared predicate. Becomes distributable again once `ProcessorAudioConverter` moves to the authoring SDK or `streamlib-audio` is registry-published.

## Test evidence

- Live-verified the gate is non-vacuous: linked the branch engine into a scratch consumer and ran the gate's exact path against **main's** pre-fix audio package (`_stream: Option<Stream>`) — `streamlib add` exited 1 with `error[E0277] ... Option<cpal::Stream> ... required by a bound in GeneratedProcessor: Send + 'static` (6 errors), and rolled back the `streamlib_modules` slot cleanly.
- Full gate on this branch: all 15 distributable packages compiled, `GATE EXIT: 0`.

## Review items (non-blocking)

An independent verification pass reviewed this branch. Findings below, verbatim, for visibility — none are blocking:

1. **[info]** `xtask/src/install_packages.rs:51` — The install-packages gate is non-vacuous: `streamlib add` exits non-zero on a genuine compile failure and the enumerator surfaces it. Evidence: linked the branch engine into a scratch consumer and ran the gate's exact path against main's pre-fix audio (`packages/audio`, which stores `_stream: Option<Stream>`): `streamlib add` exited 1 with `error[E0277] ... Option<cpal::Stream> ... required by a bound in GeneratedProcessor: Send + 'static` (6 errors), and rolled back the `streamlib_modules` slot. The branch's fixed audio compiled green. Full gate on the branch: all 15 distributable packages compiled, GATE EXIT: 0. Suggested next step: None — gate mechanism and both acceptance criteria verified live.

2. **[low]** `packages/audio/streamlib.yaml:33` — `AudioCapture` and `AudioOutput` still declare `unsafe_send: true` in `streamlib.yaml`, but the code's `#[processor(...)]` attribute carries no `unsafe_send` (post-#1437 ports-in-code, the attribute is the source of truth), so the field is stale and unhonored — which is exactly why the old code failed the Send bound. Evidence: grep shows `unsafe_send: true` at `packages/audio/streamlib.yaml:33` and `:55`; the branch attribute at `packages/audio/src/linux/audio_output.rs:53` has no `unsafe_send`. The fix removes the `!Send` field entirely (sound), making the stale yaml flag both unnecessary and misleading. yaml is not touched by this PR (pre-existing drift). Suggested next step: Drop the stale `unsafe_send: true` from the audio yaml in a follow-up (or regenerate the manifest) so it reflects the now-sound processors; out of scope for #1509.

3. **[info]** `xtask/src/install_packages.rs:205` — The gate aggregates all package failures and reports them at the end (`report_outcomes`) rather than the ticket's literal "fail-fast inline". Evidence: `run()` collects every `PackageCompileOutcome` then `report_outcomes()` bails once with all failures named. This diverges from "fail-fast" wording but directly serves the ticket's stated primary purpose ("this compile pass IS the ground-truth enumerator") — fail-fast would hide later stragglers. Defensible, arguably superior. Suggested next step: None — aggregate reporting better serves the enumeration goal; no change needed.

4. **[info]** `packages/clap/Cargo.toml:39` — clap is marked non-distributable by moving `streamlib-audio` to a macos/ios-gated path dep, so the gate skips it rather than "fixing" the named HIGH-suspicion straggler. Evidence: Gate log: `skipping non-distributable package ... package=clap offenders=streamlib-audio`. All clap src is macos/ios cfg-gated (`packages/clap/src/lib.rs`), so `streamlib-audio` is only needed there; `cargo_path_dep_names` scans `[target.<cfg>.*]` tables so the path dep is caught cross-platform. The Cargo.toml comment documents the path back to distributable (publish streamlib-audio or move `ProcessorAudioConverter` to the SDK). Correct classification given no registry publish is in scope. Suggested next step: None — correct and documented; making clap distributable is a separate ticket.

5. **[should-fix]** `xtask/src/install_packages.rs:24` — The driver doc claims `core` is a non-distributable exception skipped via the path predicate, but `packages/core` has NO path offenders — it is classified DISTRIBUTABLE and driven through `streamlib add`, and its test-only Cargo.toml uses `version.workspace = true` which cannot resolve outside the workspace. Evidence: The module doc (line 24) lists "the host-side, non-distributable exceptions: api-server, core, the test fixtures". But `packages/core/Cargo.toml` (`streamlib-core-schema-tests`, `publish=false`) has only a `[lib].path` TARGET path (never counts) and version-only deps — `non_distributable_path_offenders` returns empty, so `partition_packages` puts core in the DISTRIBUTABLE set. Unlike `escalate` (schemas + streamlib.yaml only, cleanly no-ops), core additionally ships a Cargo.toml with `version.workspace = true` / `edition.workspace = true`. If build-on-place materializes and cargo-builds that crate standalone (no `[workspace.package]` parent), it errors `field version was not set`. The gate would then FAIL on `@tatolab/core`, not skip it. Suggested next step: Run `cargo run -p xtask -- install-packages` locally (or in CI) and confirm `streamlib add packages/core` no-ops cleanly. If it fails, either add core to an explicit skip set or ensure the schema-only add ignores the test-only Cargo.toml. Either way, correct the doc: core is not skipped by the path predicate.

6. **[should-fix]** `packages/audio/src/linux/audio_output.rs:33` — `AudioOutput` makes itself Send by sending raw pointers into `self` (`&self.inputs`, `self.audio`) into the worker thread via `unsafe impl Send`, with soundness resting on join-before-drop — but the join only lives in `teardown()`, there is NO Drop guard, so a drop-without-teardown (panic / runtime teardown skip) leaves the thread dereferencing freed memory. The sibling `AudioCapture`'s `!Send cpal::Stream` problem is solved cleanly in `audio_capture.rs` by thread-confinement with only owned Send handles crossing — no raw self-pointers. Evidence: `SendableInputsPtr`/`SendableAudioConverterPtr` (lines 18-41) wrap `*const/*mut` into self-owned fields; `start()` (line 143-145) captures `&self.inputs as *const _` and `audio as *mut _` into the spawned thread; the SAFETY note assumes self never moves between `start()` and `teardown()` and that teardown always runs. `teardown()` joins (line 108-109) but there is no `impl Drop`. `audio_capture.rs` (lines 36-43) instead confines the stream and keeps only `Arc<Atomic*>`/`JoinHandle`/`mpsc::Sender` — the canonical safe shape. Suggested next step: Route to the plugin-ABI/engine memory-safety lens. Preferred fix: mirror `audio_capture.rs`'s thread-confinement (move the converter + an owned input handle into the thread) so no raw pointer into `self` crosses the boundary; failing that, add a Drop that joins. This is plugin-cdylib soundness, adjacent to the distribution lens — flagged here, the engine lens should make the call.

7. **[info]** `packages/clap/Cargo.toml:48` — clap converts `streamlib-audio = {version = "0.7.0"}` (unresolvable — there is no crates registry for domain packages, and link only patches engine/SDK crates) to `streamlib-audio = { path = "../audio" }`, correctly marking the whole package non-distributable. This is the sanctioned use of the path-dep-as-non-distributable marker, well-documented with an exit condition. Side effect: clap is now FULLY skipped by the gate, so even its Linux-buildable surface (the dep is macOS/iOS-gated and absent on Linux) loses compile coverage. Evidence: The dep sits under `[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]` (line 38); the comment states it marks the package non-distributable via the shared predicate. `cargo_path_dep_names` scans target tables regardless of host, so on Linux the whole clap package is skipped even though clap-on-Linux would compile without streamlib-audio. Package-level distributability is all-or-nothing by design, so this is consistent, not a defect — just a coverage note. Suggested next step: No action required. When `ProcessorAudioConverter` moves to the authoring SDK per the comment, clap becomes distributable and regains coverage. Consider noting the temporary clap coverage loss on the PR body.

8. **[info]** `.github/workflows/install-packages.yml:1` — The gate validates COMPILATION only, through the link loop — it does NOT exercise the separately-built source-only `.slpkg` path, so it does not surface the cross-build binary-divergence / plugin-safety hazard (GPU package hand-rolling RHI on a transited host device) that the slpkg learning warns about. Correctly scoped and documented (CPU-only, no dlopen, no GPU), but it should not be read as closing the plugin-safety-across-separate-build gap. Evidence: Workflow header and `install_packages.rs` module doc both state the gate stops at the compiled artifact via `streamlib link --engine` + `streamlib add`. Link builds every package against the local checkout via `[patch.crates-io]`, which is the dev loop, not the distribution loop — the same masking noted in prior link-run-vs-distribution-evidence findings. Suggested next step: None for this PR. Track the link-free registry-build validation separately (already noted as blocked). This gate is a compile gate, not a plugin-safety gate.

9. **[should-fix]** `xtask/src/install_packages.rs:296` — `package_label()` and the `packages/*` directory enumeration duplicate logic that already exists in `xtask::check_package_version_drift` — a new file re-implements package enumeration + labeling the engine already has one copy of. Evidence: `package_label()` (install_packages.rs:296-301) is a byte-for-byte copy of the label fragment at `check_package_version_drift.rs:110-113` (`.file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_else(|| pkg_dir.display().to_string())`). Separately, `partition_packages` (install_packages.rs:~150) and `scan` (check_package_version_drift.rs:88-93) both build the same `read_dir → filter_map(e.ok().map(path)) → filter(has streamlib.yaml/is_dir) → sort` enumeration of `packages/*`. Engine doctrine: "search first, extend never parallel." Suggested next step: Extract a small shared xtask helper, e.g. `xtask::packages::{enumerate_package_dirs(root) -> Result<Vec<PathBuf>>, package_label(&Path) -> String}`, and call it from both `install_packages.rs` and `check_package_version_drift.rs` (canonical-pattern sweep of both consumers in this PR).

10. **[low]** `xtask/src/install_packages.rs:108` — Needless per-package clone: `pkg_dir.clone()` into `PackageCompileOutcome` while iterating `&distributable`, but `distributable` is never used after the loop. Evidence: `run()` iterates `for pkg_dir in &distributable` then does `package_dir: pkg_dir.clone()`. `distributable`'s last use is `Vec::with_capacity(distributable.len())` just above; nothing reads it afterward. Suggested next step: Iterate `for pkg_dir in distributable` (into_iter), take the label before moving, and store `package_dir: pkg_dir` with no clone.

11. **[info]** `xtask/src/install_packages.rs:200` — `compile_via_install_path` returns `Result<Option<String>>` where `Ok(None)` means the compile SUCCEEDED and `Ok(Some)` means it FAILED — an inverted-Option shape where the success case is the empty variant. Evidence: The two failure levels (spawn error = outer `Err`; compile failure = inner `Some(String)`) are collapsed into `Result<Option<String>>`; `failure_output: Option<String>` propagates the same None-means-success convention into the struct. It is documented, but a reader must recall that `None` is the good path. Suggested next step: Optional: a dedicated `enum PackageCompile { Compiled, Failed(String) }` (or naming the field `compile_failure_output`) makes the success/failure polarity self-evident. Not required — documented convention is acceptable for internal tooling.

12. **[low]** `xtask/src/install_packages.rs:1` — Several rustdoc blocks are essay-length rationale, which the repo's comments rule ("Don't write multi-paragraph rustdoc essays"; "Don't explain or justify a decision — that belongs in the PR/commit") discourages. Evidence: The module doc (install_packages.rs:4-27) and `run()`'s doc (~55-67) are multi-paragraph justifications; the added pub-doc on streamlib-pack `non_distributable_path_offenders` (lib.rs:1274-1279) explains a design decision. Some of the "why" is genuinely load-bearing (e.g. the `--skip-verify` rationale at `establish_engine_link` is a valid novel "why"); the length/justification form is the issue. Suggested next step: Trim each public item to a one-line doc, keep only the non-derivable "why" one-liners (e.g. skip-verify reason), and move the design rationale to the PR body. Not blocking.
