### PR TITLE
ci: install libasound2-dev so install-packages can build @tatolab/audio

### DIFF
--- a/.github/workflows/install-packages.yml
+++ b/.github/workflows/install-packages.yml
@@ -51,12 +51,14 @@ jobs:
         # streamlib-engine, whose build.rs compiles GLSL compute shaders with
         # glslc and generates JTD bindings; the Linux engine dep set links
         # Vulkan. No GPU/codec backends — this gate stops at the artifact.
+        # `libasound2-dev`: @tatolab/audio build-links alsa-sys (ALSA headers).
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             pkg-config \
             protobuf-compiler \
             libvulkan-dev \
+            libasound2-dev \
             glslc
 
       - name: Install jtd-codegen


### PR DESCRIPTION
The `install-packages` gate (from #1509) fails compiling `@tatolab/audio` — `alsa-sys` build.rs cannot find ALSA on the runner. `audio` build-links `alsa-sys`, so the runner needs the ALSA dev headers, exactly as it already installs `libvulkan-dev` for the engine.

14/15 distributable packages compiled; only `audio` hit the missing system lib. This is pre-existing (surfaced on any package-touching PR, e.g. #340) and blocks all such PRs.

Fix: add `libasound2-dev` to the workflow's system-deps step. This PR touches the workflow, so the gate re-runs against the fixed version and self-verifies.

Follow-up (not this PR): whether `@tatolab/audio` should lazy-link ALSA (dlopen at runtime) per the adapter-no-hard-deps rule, so a consumer can `streamlib add @tatolab/audio` without ALSA headers. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)