### PR TITLE
fix(pack): ignore in-tree prebuilt cdylib on mutable/linked/AlwaysBuild staged builds

### DIFF
--- a/tools/streamlib-build-orchestrator/src/lib.rs
+++ b/tools/streamlib-build-orchestrator/src/lib.rs
@@ -173,6 +173,21 @@ fn rust_reuse_permitted(
     !has_rust || (!source_is_mutable && !link_active && cdylib_present)
 }
 
+/// Rebuild-time complement of [`rust_reuse_permitted`]: on the paths that reach
+/// an actual rebuild, whether assemble must ignore a `.so` a prior build
+/// promoted into the (co-located) source tree and let cargo's own fingerprint
+/// be the oracle. True for a mutable checkout, an active `streamlib link`, or an
+/// unconditional [`BuildPolicy::AlwaysBuild`]; false only for an immutable
+/// extract under [`BuildPolicy::IfStale`], which keeps the prebuilt preference
+/// so a venv-only re-provision stays compiler-free.
+fn ignore_in_tree_prebuilt_cdylib(
+    source_is_mutable: bool,
+    link_active: bool,
+    policy: BuildPolicy,
+) -> bool {
+    source_is_mutable || link_active || matches!(policy, BuildPolicy::AlwaysBuild)
+}
+
 impl PolyglotBuildOrchestrator {
     fn materialize_package_dir(
         &self,
@@ -350,9 +365,11 @@ impl PolyglotBuildOrchestrator {
         // artifact. Let cargo's own fingerprint be the oracle in those cases;
         // an immutable extract under `IfStale` keeps the prebuilt preference
         // so a venv-only re-provision stays compiler-free.
-        let ignore_in_tree_prebuilt_cdylib = source_is_mutable
-            || active_link.is_some()
-            || matches!(request.policy, BuildPolicy::AlwaysBuild);
+        let ignore_in_tree_prebuilt_cdylib = ignore_in_tree_prebuilt_cdylib(
+            source_is_mutable,
+            active_link.is_some(),
+            request.policy,
+        );
 
         let adapter = EngineSinkAdapter(sink);
         let outcome = assemble_artifact_with_cargo_config(
@@ -991,6 +1008,40 @@ mod tests {
         assert!(!rust_reuse_permitted(true, false, true, true));
         // Rust, immutable, no link, but no cdylib staged yet: must build.
         assert!(!rust_reuse_permitted(true, false, false, false));
+    }
+
+    // Mentally-revert check: dropping the `link_active` clause flips the
+    // active-link case below to `false`, silently reintroducing the #1550 bug
+    // (assemble honors a stale in-tree `.so` under an active `streamlib link`).
+    #[test]
+    fn ignore_in_tree_prebuilt_cdylib_holds_for_mutable_linked_or_always_build() {
+        // (source_is_mutable, link_active, policy)
+        // Mutable checkout: ignore the promoted `.so`, let cargo re-decide.
+        assert!(ignore_in_tree_prebuilt_cdylib(
+            true,
+            false,
+            BuildPolicy::IfStale
+        ));
+        // Active link: ignore (deps resolve to a mutable checkout) — the #1550
+        // case.
+        assert!(ignore_in_tree_prebuilt_cdylib(
+            false,
+            true,
+            BuildPolicy::IfStale
+        ));
+        // AlwaysBuild: ignore unconditionally.
+        assert!(ignore_in_tree_prebuilt_cdylib(
+            false,
+            false,
+            BuildPolicy::AlwaysBuild
+        ));
+        // Immutable extract under IfStale: keep the prebuilt preference so a
+        // venv-only re-provision stays compiler-free.
+        assert!(!ignore_in_tree_prebuilt_cdylib(
+            false,
+            false,
+            BuildPolicy::IfStale
+        ));
     }
 
     #[test]

--- a/tools/streamlib-build-orchestrator/src/lib.rs
+++ b/tools/streamlib-build-orchestrator/src/lib.rs
@@ -342,6 +342,18 @@ impl PolyglotBuildOrchestrator {
         // `[patch]` above covers for crate deps. `None` off a link ⇒ unchanged.
         let link_checkout = active_link.as_ref().map(|l| l.checkout.as_path());
 
+        // The staleness skip above already spared an immutable-extract slot
+        // with a matching cdylib; reaching here means we ARE rebuilding. A
+        // mutable checkout, an active link, or an unconditional `AlwaysBuild`
+        // must not have assemble honor a `.so` the prior build promoted into
+        // the (co-located) source tree — that would silently reuse a stale
+        // artifact. Let cargo's own fingerprint be the oracle in those cases;
+        // an immutable extract under `IfStale` keeps the prebuilt preference
+        // so a venv-only re-provision stays compiler-free.
+        let ignore_in_tree_prebuilt_cdylib = source_is_mutable
+            || active_link.is_some()
+            || matches!(request.policy, BuildPolicy::AlwaysBuild);
+
         let adapter = EngineSinkAdapter(sink);
         let outcome = assemble_artifact_with_cargo_config(
             pkg_dir,
@@ -353,6 +365,7 @@ impl PolyglotBuildOrchestrator {
                 // `path:` deps to absolute so the transitive walk still
                 // resolves each dep to its real source.
                 path_deps: PathDepPolicy::RewriteRelativeToAbsolute,
+                ignore_in_tree_prebuilt_cdylib,
             },
             &adapter,
             &cargo_config_files,

--- a/tools/streamlib-cli/src/commands/pkg.rs
+++ b/tools/streamlib-cli/src/commands/pkg.rs
@@ -406,6 +406,7 @@ fn assemble_source_slpkg(
             no_build: false,
             profile: CargoProfile::Release,
             path_deps: PathDepPolicy::RejectPathPatches,
+            ignore_in_tree_prebuilt_cdylib: false,
         },
         &(),
     )

--- a/tools/streamlib-cli/tests/add_remove.rs
+++ b/tools/streamlib-cli/tests/add_remove.rs
@@ -82,6 +82,7 @@ fn add_folder_and_slpkg_then_remove_via_app_modules() {
             no_build: false,
             profile: CargoProfile::Release,
             path_deps: PathDepPolicy::RejectPathPatches,
+            ignore_in_tree_prebuilt_cdylib: false,
         },
         &(),
     )
@@ -189,6 +190,7 @@ fn add_with_expect_sha256_mismatch_fails_with_no_partial_state() {
             no_build: false,
             profile: CargoProfile::Release,
             path_deps: PathDepPolicy::RejectPathPatches,
+            ignore_in_tree_prebuilt_cdylib: false,
         },
         &(),
     )

--- a/tools/streamlib-cli/tests/install_from_lock.rs
+++ b/tools/streamlib-cli/tests/install_from_lock.rs
@@ -60,6 +60,7 @@ fn install_reproduces_modules_in_a_clean_checkout_from_the_lock() {
             no_build: false,
             profile: CargoProfile::Release,
             path_deps: PathDepPolicy::RejectPathPatches,
+            ignore_in_tree_prebuilt_cdylib: false,
         },
         &(),
     )

--- a/tools/streamlib-pack/src/lib.rs
+++ b/tools/streamlib-pack/src/lib.rs
@@ -432,6 +432,15 @@ pub struct AssembleOptions {
     pub profile: CargoProfile,
     /// Manifest `path:` handling.
     pub path_deps: PathDepPolicy,
+    /// Ignore an in-tree prebuilt cdylib under `lib/<triple>/` and always
+    /// invoke cargo for the Rust half, letting cargo's own fingerprint be
+    /// the staleness oracle. Set for a `StagedDir` build whose source can
+    /// change out from under a promoted-in-place `.so` — a mutable user
+    /// checkout, an active `streamlib link`, or an unconditional
+    /// `AlwaysBuild` — where honoring the promoted `.so` would silently
+    /// reuse a stale artifact. An immutable managed extract under `IfStale`
+    /// leaves this `false` so a matching prebuilt still loads compiler-free.
+    pub ignore_in_tree_prebuilt_cdylib: bool,
 }
 
 /// Summary of what [`assemble_artifact`] produced.
@@ -606,7 +615,14 @@ pub fn assemble_artifact_with_cargo_config(
         let triple_dir = pkg_dir.join("lib").join(host_triple);
         let prebuilt = streamlib_cargo_build::collect_host_dylibs_in_lib(&triple_dir, dylib_ext)?;
 
-        if !prebuilt.is_empty() {
+        // Under a co-located source-dir slot the prior build's in-place
+        // promote lands the `.so` into the source tree, so an in-tree
+        // prebuilt is present even when the source was just edited. When the
+        // orchestrator flags the source as mutable / linked / AlwaysBuild it
+        // asks us to ignore that promoted `.so` and let cargo's own
+        // fingerprint decide staleness — otherwise a stale artifact is
+        // silently honored.
+        if !prebuilt.is_empty() && !opts.ignore_in_tree_prebuilt_cdylib {
             for path in prebuilt {
                 let filename = dylib_filename(&path)?;
                 files.push((format!("lib/{host_triple}/{filename}"), path));
@@ -1619,6 +1635,7 @@ mod tests {
             no_build,
             profile: CargoProfile::Release,
             path_deps: PathDepPolicy::RejectPathPatches,
+            ignore_in_tree_prebuilt_cdylib: false,
         }
     }
 
@@ -2005,6 +2022,7 @@ mod tests {
                 no_build: false,
                 profile: CargoProfile::Release,
                 path_deps: PathDepPolicy::RewriteRelativeToAbsolute,
+                ignore_in_tree_prebuilt_cdylib: false,
             },
             &(),
         )
@@ -2055,6 +2073,7 @@ mod tests {
                 no_build: false,
                 profile: CargoProfile::Release,
                 path_deps: PathDepPolicy::RewriteRelativeToAbsolute,
+                ignore_in_tree_prebuilt_cdylib: false,
             },
             &(),
         )
@@ -2109,6 +2128,100 @@ mod tests {
         assert!(
             !entries.iter().any(|e| e.starts_with("lib/")),
             "source-only .slpkg must not carry a prebuilt cdylib, got {entries:?}"
+        );
+    }
+
+    #[test]
+    fn staged_dir_ignore_prebuilt_flag_skips_stale_in_tree_cdylib() {
+        // #1550: under the co-located source-dir slot a prior build's
+        // in-place promote lands the cdylib into the source tree, so the next
+        // `StagedDir` materialize finds an in-tree prebuilt even when the
+        // source (mutable checkout / active link / `AlwaysBuild`) was just
+        // edited. With `ignore_in_tree_prebuilt_cdylib` OFF the assemble
+        // honors that stale `.so` and never rebuilds — the bug. With it ON the
+        // prebuilt-preference is skipped so cargo (the real staleness oracle)
+        // is what runs. `no_build` here stands in for "would have to compile":
+        // with the flag OFF the prebuilt is honored (Ok); with it ON the
+        // prebuilt is invisible, so `no_build` has nothing to honor and bails —
+        // deterministically proving the stale `.so` was skipped, no cargo.
+        fn write_stale_prebuilt_pkg(dir: &Path) -> PathBuf {
+            std::fs::write(
+                dir.join("streamlib.yaml"),
+                "package:\n  org: tatolab\n  name: rp\n  version: 0.1.0\nprocessors:\n  - name: P\n    description: d\n    runtime: rust\n    execution: manual\n    inputs: []\n    outputs: []\n",
+            )
+            .unwrap();
+            std::fs::write(
+                dir.join("Cargo.toml"),
+                "[package]\nname = \"rp\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+            )
+            .unwrap();
+            std::fs::create_dir_all(dir.join("src")).unwrap();
+            std::fs::write(
+                dir.join("src/lib.rs"),
+                b"#[processor(\"@tatolab/rp/P\", execution = manual)]\npub struct P;\n",
+            )
+            .unwrap();
+            let triple_dir = dir.join("lib").join(host_target_triple());
+            std::fs::create_dir_all(&triple_dir).unwrap();
+            let dylib = format!("librp.{}", host_dylib_extension());
+            std::fs::write(triple_dir.join(&dylib), b"stale-in-tree-cdylib").unwrap();
+            triple_dir.join(&dylib)
+        }
+
+        // Flag OFF: the stale in-tree `.so` is honored — no rebuild, and the
+        // stale bytes land in the staged slot. This is exactly the pre-fix
+        // behavior that leaves a co-located slot serving a stale artifact.
+        let src_reuse = tempdir().unwrap();
+        write_stale_prebuilt_pkg(src_reuse.path());
+        let staged_reuse = tempdir().unwrap();
+        let outcome = assemble_artifact(
+            src_reuse.path(),
+            &AssembleTarget::StagedDir(staged_reuse.path().to_path_buf()),
+            &AssembleOptions {
+                no_build: true,
+                profile: CargoProfile::Dev,
+                path_deps: PathDepPolicy::RewriteRelativeToAbsolute,
+                ignore_in_tree_prebuilt_cdylib: false,
+            },
+            &(),
+        )
+        .expect("flag off honors the in-tree prebuilt without rebuilding");
+        assert!(!outcome.rebuilt, "flag off reuses the prebuilt — no compile");
+        let staged_dylib = staged_reuse
+            .path()
+            .join("lib")
+            .join(host_target_triple())
+            .join(format!("librp.{}", host_dylib_extension()));
+        assert_eq!(
+            std::fs::read(&staged_dylib).unwrap(),
+            b"stale-in-tree-cdylib",
+            "flag off carries the stale in-tree cdylib verbatim"
+        );
+
+        // Flag ON: the prebuilt-preference is skipped. With `no_build` there is
+        // then no artifact to honor and cargo is forbidden, so assemble bails —
+        // which proves the stale `.so` was NOT reused. Mentally revert the
+        // `&& !opts.ignore_in_tree_prebuilt_cdylib` guard and this assemble
+        // succeeds by honoring the stale prebuilt, and this assertion fails.
+        let src_build = tempdir().unwrap();
+        write_stale_prebuilt_pkg(src_build.path());
+        let staged_build = tempdir().unwrap();
+        let err = assemble_artifact(
+            src_build.path(),
+            &AssembleTarget::StagedDir(staged_build.path().to_path_buf()),
+            &AssembleOptions {
+                no_build: true,
+                profile: CargoProfile::Dev,
+                path_deps: PathDepPolicy::RewriteRelativeToAbsolute,
+                ignore_in_tree_prebuilt_cdylib: true,
+            },
+            &(),
+        )
+        .expect_err("flag on must ignore the stale prebuilt, leaving no-build nothing to honor");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("no-build") && msg.contains("host-OS dylib"),
+            "flag on must bail in the no-dylib path, got: {err}"
         );
     }
 
@@ -2535,6 +2648,7 @@ mod tests {
                 no_build: false,
                 profile: CargoProfile::Dev,
                 path_deps: PathDepPolicy::RewriteRelativeToAbsolute,
+                ignore_in_tree_prebuilt_cdylib: false,
             },
             &(),
         )
@@ -2666,6 +2780,7 @@ mod tests {
                 no_build: false,
                 profile: CargoProfile::Dev,
                 path_deps: PathDepPolicy::RewriteRelativeToAbsolute,
+                ignore_in_tree_prebuilt_cdylib: false,
             },
             &(),
         )
@@ -2705,6 +2820,7 @@ mod tests {
                 no_build: false,
                 profile: CargoProfile::Dev,
                 path_deps: PathDepPolicy::RewriteRelativeToAbsolute,
+                ignore_in_tree_prebuilt_cdylib: false,
             },
             &(),
         )
@@ -2896,6 +3012,7 @@ mod tests {
                 no_build: true,
                 profile: CargoProfile::Dev,
                 path_deps: PathDepPolicy::RewriteRelativeToAbsolute,
+                ignore_in_tree_prebuilt_cdylib: false,
             },
             &(),
         )
@@ -2963,6 +3080,7 @@ mod tests {
                 no_build: true,
                 profile: CargoProfile::Dev,
                 path_deps: PathDepPolicy::RewriteRelativeToAbsolute,
+                ignore_in_tree_prebuilt_cdylib: false,
             },
             &(),
         )
@@ -3010,6 +3128,7 @@ mod tests {
                 no_build: true,
                 profile: CargoProfile::Dev,
                 path_deps: PathDepPolicy::RewriteRelativeToAbsolute,
+                ignore_in_tree_prebuilt_cdylib: false,
             },
             &(),
         )

--- a/tools/streamlib-pack/src/static_registry.rs
+++ b/tools/streamlib-pack/src/static_registry.rs
@@ -470,6 +470,7 @@ fn assemble_slpkg_bytes(pkg_dir: &Path) -> Result<(PackageRef, String, Vec<u8>)>
             no_build: false,
             profile: crate::CargoProfile::Release,
             path_deps: crate::PathDepPolicy::RejectPathPatches,
+            ignore_in_tree_prebuilt_cdylib: false,
         },
         &(),
     )?;


### PR DESCRIPTION
Closes #1550

## Summary

Under the co-located source-dir slot (#1534, #1536), a prior `StagedDir` build's
in-place cdylib promote lands the `.so` into the source tree. The next
`materialize` found that in-tree prebuilt at `lib/<triple>/` and honored it,
skipping cargo even though the mutable/linked source had changed — so an
active dev-linked package (`streamlib link <checkout>`) with an edited source
silently served a **stale cdylib** ("declared but not registered by the
dylib"). It also silently downgraded `BuildPolicy::AlwaysBuild` to
reuse-the-prebuilt.

Adds `AssembleOptions.ignore_in_tree_prebuilt_cdylib`. The orchestrator sets it
when:
- the source is a mutable user checkout, or
- an active `streamlib link` is present, or
- the policy is `AlwaysBuild`

In all three cases `assemble` skips the prebuilt-preference and runs cargo,
whose own fingerprint is the real staleness oracle. An immutable managed
extract under `IfStale` keeps the prebuilt preference, so a venv-only
re-provision stays cargo-free.

## Test evidence

Run in the branch worktree (`tools/streamlib-build-orchestrator`,
`tools/streamlib-pack`, `tools/streamlib-cli`):

```
cargo test -p streamlib-pack --lib
  test result: ok. 64 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
  (includes new staged_dir_ignore_prebuilt_flag_skips_stale_in_tree_cdylib)

cargo test -p streamlib-build-orchestrator --lib
  test result: ok. 55 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo test -p streamlib-cli --lib
  (no lib tests — bin crate)
```

`tools/streamlib-cli/tests/add_remove.rs` /
`tools/streamlib-cli/tests/install_from_lock.rs` integration tests were also
run and confirmed pre-existing/unrelated (see Review items below) — same
failure reproduces on `fc0ad3ba` (branch base, before this diff), whose only
change to those files is an added `ignore_in_tree_prebuilt_cdylib: false`
struct field that cannot affect YAML parsing.

No live rig/E2E run was required for this change — it is a pure
build-orchestrator/pack staleness-fix with no GPU/camera/display/codec
surface.

## Review items (non-blocking)

These surfaced during independent verification. None block merge; the owner
may triage/schedule as follow-ups.

1. **[should-fix]** `tools/streamlib-build-orchestrator/src/lib.rs:353` — The
   orchestrator wiring that sets `ignore_in_tree_prebuilt_cdylib` for the
   ticket's exact scenario (active dev link) is the load-bearing line, yet has
   no test — removing `active_link.is_some()` from the OR would silently
   reintroduce the reported bug with all tests still green.
   Evidence: `ignore_in_tree_prebuilt_cdylib = source_is_mutable ||
   active_link.is_some() || matches!(request.policy, BuildPolicy::AlwaysBuild)`
   (lib.rs ~353) is inline; grep for `ignore_in_tree_prebuilt_cdylib` in
   orchestrator tests returns nothing. The only new test lives at the pack
   layer and is handed the flag explicitly, so it never exercises the
   mutable/link/AlwaysBuild→true derivation. Contrast the adjacent
   `rust_reuse_permitted`, which was extracted precisely so its boolean is
   unit-tested (`rust_reuse_permitted_requires_immutable_source_no_link_and_a_staged_cdylib`).
   Suggested next step: Extract the flag computation into a small pure fn
   (mirroring `rust_reuse_permitted`) and add a table test asserting
   active_link→true, mutable→true, AlwaysBuild→true, immutable+IfStale→false;
   note the e2e link-rebuild repro as a rig follow-up on the PR body.

2. **[should-fix]** `tools/streamlib-build-orchestrator/src/lib.rs:352` — The
   new `ignore_in_tree_prebuilt_cdylib` predicate is derived inline as
   `source_is_mutable || active_link.is_some() || matches!(request.policy,
   BuildPolicy::AlwaysBuild)` and has no unit test — its sibling policy
   `rust_reuse_permitted` (same file, line 167) was deliberately extracted into
   a named free function with a truth-table unit test
   (`rust_reuse_permitted_requires_immutable_source_no_link_and_a_staged_cdylib`,
   line 961). The (mutable / linked / AlwaysBuild) -> flag mapping is only
   exercised indirectly by the pack-layer test, which sets the flag literally
   true/false and never covers the derivation.
   Evidence: `let ignore_in_tree_prebuilt_cdylib = source_is_mutable ||
   active_link.is_some() || matches!(request.policy,
   BuildPolicy::AlwaysBuild);` — grep for a test referencing
   `ignore_in_tree_prebuilt_cdylib`/`AlwaysBuild` in the orchestrator crate
   returns nothing.
   Suggested next step: Extract `fn ignore_in_tree_prebuilt_cdylib(source_is_mutable:
   bool, link_active: bool, policy: BuildPolicy) -> bool` next to
   `rust_reuse_permitted` and add the matching 3-input truth-table test,
   mirroring the established pattern. Cheap; closes the untested-derivation
   gap and matches the crate's own convention.

3. **[info]** `tools/streamlib-cli/tests/add_remove.rs:57` —
   `add_remove` / `install_from_lock` integration tests fail, but not because
   of this change.
   Evidence: `add_folder_and_slpkg_then_remove_via_app_modules` and two
   siblings fail with `materialize failed ... reading streamlib.yaml: Failed
   to parse .../streamlib.yaml`; the identical failure reproduces on the base
   tree (HEAD 01c587de, prior to branch base fc0ad3ba) where the diff's only
   change to these files is an added `ignore_in_tree_prebuilt_cdylib: false`
   struct field that cannot affect YAML parsing.
   Suggested next step: Treat as a separate pre-existing test-harness/fixture
   defect; do not gate this PR on it, but flag it for a dedicated fix.

4. **[info]** `tools/streamlib-pack/src/lib.rs:435` — The pack-layer
   regression test is non-vacuous and locks the changed guard.
   Evidence: `staged_dir_ignore_prebuilt_flag_skips_stale_in_tree_cdylib`
   asserts flag-OFF honors the stale in-tree `.so` verbatim (rebuilt=false,
   staged bytes == 'stale-in-tree-cdylib') and flag-ON hits the no_build bail
   path; mentally reverting `&& !opts.ignore_in_tree_prebuilt_cdylib` makes the
   flag-ON branch honor the prebuilt (Ok), so the `.expect_err` panics — test
   fails. It uses `no_build: true` as a proxy for "would compile" rather than
   running real cargo, which is an honest, stated trade-off.
   Suggested next step: None; acceptable.

5. **[info]** `tools/streamlib-build-orchestrator/src/lib.rs:353` — The fix
   also closes a latent `AlwaysBuild` correctness gap beyond the stale-promote
   bug the title names: a prebuilt-carrying slpkg under `AlwaysBuild`
   previously had assemble honor the in-tree prebuilt and skip cargo,
   contradicting the documented `AlwaysBuild` contract at source.rs:619.
   Adding `AlwaysBuild` to the flag now forces the source rebuild.
   Evidence: `streamlib-build-orchestrator/src/lib.rs:353` adds the
   `AlwaysBuild` disjunct, gated at `streamlib-pack/src/lib.rs:618`; the
   commit body acknowledges it downgraded `AlwaysBuild` to
   reuse-the-prebuilt.
   Suggested next step: Keep the `AlwaysBuild` note in the PR body so the
   behavior change reads as intentional rather than incidental scope creep.

6. **[info]** `tools/streamlib-build-orchestrator/src/lib.rs:167` — For a
   mutable user checkout with unchanged source, the post-fix path always
   invokes cargo (which no-ops via incremental) instead of honoring the
   co-located promoted `.so` compiler-free. Minor extra cargo-invocation cost,
   but it is the already-established contract for mutable sources and the
   only sound choice since a mutable checkout's package-local fingerprint is
   not a complete staleness oracle. Not a defect.
   Evidence: `rust_reuse_permitted` at
   `streamlib-build-orchestrator/src/lib.rs:167-174` already returns `false`
   for a mutable source, so assemble is always reached; the flag makes it
   cargo-gated rather than prebuilt-gated. Contract stated at lib.rs:260-261.
   Suggested next step: No action; recording the perf trade so it is not
   mistaken for a regression.

7. **[info]** `tools/streamlib-pack/src/lib.rs:2134` — The regression test
   genuinely exercises the bug. `no_build: true` stands in for
   "would-have-to-compile": flag-off honors the stale in-tree cdylib so stale
   bytes reach the staged slot; flag-on makes the prebuilt invisible so
   `no_build` has nothing to honor and bails. Reverting the guard makes the
   flag-on assemble succeed and the `.expect_err` fail, so the test locks the
   fix.
   Evidence: `streamlib-pack/src/lib.rs:2134-2226`
   (`staged_dir_ignore_prebuilt_flag_skips_stale_in_tree_cdylib`); production
   orchestrator uses `no_build: false` at lib.rs:350 so it actually rebuilds.
   Suggested next step: None.

8. **[info]** `tools/streamlib-build-orchestrator/src/lib.rs:353` — The new
   predicate's `source_is_mutable || active_link.is_some()` fragment
   conceptually mirrors the `!source_is_mutable && !link_active` clause
   inside `rust_reuse_permitted` (line 173). These encode related-but-distinct
   policies (whole-slot reuse vs ignoring an in-tree promoted `.so` during a
   rebuild), so this is coupling to watch, not true DRY duplication that must
   change together — leaving it separate is defensible. Flagging only so the
   shared inputs are visible: if "source can change under us" grows a new
   input, both sites need it.
   Evidence: `rust_reuse_permitted` (l.173): `!has_rust || (!source_is_mutable
   && !link_active && cdylib_present)`; new predicate (l.352-354) reuses the
   same two boolean inputs with opposite polarity.
   Suggested next step: No change required. If the extraction in the
   should-fix is done, a one-line doc on the helper noting it is the
   rebuild-time complement of `rust_reuse_permitted` makes the coupling
   explicit.

9. **[low]** `tools/streamlib-pack/src/lib.rs:2141` — The test closure
   `write_stale_prebuilt_pkg` re-writes the Cargo.toml + `#[processor(...)]`
   src/lib.rs + streamlib.yaml scaffold that the module already has in
   `write_rust_processor_pkg` (line 1810), and the "create `lib/<triple>/` and
   write a stale dylib" snippet is now inline in ~5 test sites (lines 2084,
   2883, 2950, 2997, and this new one). Test code, so exempt from the strict
   library rules and independence often justifies a little copy — but the
   prebuilt-dylib scaffold is a candidate for one shared helper.
   Evidence: `write_stale_prebuilt_pkg` duplicates the manifest/source
   scaffold of `write_rust_processor_pkg` (differs only in pkg name `rp` vs
   `cam` and processor set) plus the `lib/<triple>/librp.<ext>` write repeated
   at four other test sites.
   Suggested next step: Optionally factor a `fn
   write_host_prebuilt_dylib(dir, bytes) -> PathBuf` shared by the five sites
   and reuse `write_rust_processor_pkg` for the source/manifest half. Nit —
   safe to leave.

10. **[low]** `tools/streamlib-pack/src/lib.rs:435` — The same "in-place
   promote lands the `.so` in the source tree, so ignore it and let cargo's
   fingerprint decide" rationale is written three times: the field rustdoc
   (l.435-441), the orchestrator derivation comment (orchestrator lib.rs
   l.345-353), and the assemble guard comment (l.616-622). The field doc is
   the API contract and the orchestrator/guard comments serve different
   crates, so it is defensible, but it is the same "why" restated three
   times.
   Evidence: Field doc, orchestrator comment above the predicate, and the
   guard comment above `if !prebuilt.is_empty() &&
   !opts.ignore_in_tree_prebuilt_cdylib` all narrate the co-located
   promote-then-stale mechanism.
   Suggested next step: Consider trimming the guard-site comment to a
   one-liner that points at the field doc as the authoritative "why", keeping
   the API-contract explanation in one place per the comments rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
