### PR TITLE
fix(engine): reclaim iceoryx2 ports per-link on disconnect (#1549)

### DIFF
--- a/runtime/streamlib-engine/benches/output_writer_ffi_hop.rs
+++ b/runtime/streamlib-engine/benches/output_writer_ffi_hop.rs
@@ -135,7 +135,7 @@ fn build_inner_with_connection(tag: &str) -> BenchFixture {
             ceiling_bytes: TRUSTED_CHANNEL_PAYLOAD_CEILING_BYTES,
         },
     );
-    inner.add_channel_notifier("out", notifier);
+    inner.add_channel_notifier("out", "L-bench-ffi-hop", notifier);
 
     BenchFixture {
         inner,
@@ -275,7 +275,7 @@ fn build_inner_with_fanout(tag: &str, subscriber_count: usize) -> FanoutFixture 
             .unwrap();
         let notifier = notify.notifier_builder().create().unwrap();
         let listener = notify.listener_builder().create().unwrap();
-        inner.add_channel_notifier("out", notifier);
+        inner.add_channel_notifier("out", &format!("L-bench-fanout-{i}"), notifier);
         listeners.push(listener);
     }
 

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -252,18 +252,14 @@ pub fn open_iceoryx2_service(
 /// Reclaim one `connect()` link's iceoryx2 ports on `disconnect`.
 ///
 /// Stamping [`LinkState::Disconnected`] is not enough: the source-side notifier
-/// and dest-side subscriber (plus the destination listener and any orphaned
-/// port mailbox / channel publisher) must be dropped so their iceoryx2 services
-/// are released. Otherwise a reconnect of a persistent endpoint re-appends past
-/// the notify service's create-time `max_notifiers` cap
+/// and dest-side subscriber (plus listener, orphaned mailbox, channel publisher)
+/// must be dropped to release their iceoryx2 services, else a reconnect re-appends
+/// past the notify service's create-time `max_notifiers` cap
 /// (`ExceedsMaxSupportedNotifiers`) and the stale, shallower-sized data service
-/// collides with a deeper-ring reopen (`DoesNotSupportRequestedMinBufferSize`)
-/// — the two #1549 errors, one cause.
+/// collides with a deeper-ring reopen (`DoesNotSupportRequestedMinBufferSize`).
 ///
-/// Rust→Rust reclaim is complete here (both ports are host-owned). A subprocess
-/// endpoint opens its own ports from the wiring envelope and has no host-reachable
-/// drop path, so its live reclaim needs a Python/Deno cdylib drop entry point
-/// (tracked follow-up); this op does not touch a running subprocess's ports.
+/// Rust→Rust reclaim is complete here; a subprocess endpoint owns its own ports
+/// and needs a cdylib drop entry point (follow-up) — this op leaves them untouched.
 #[tracing::instrument(name = "compiler.close_iceoryx2_service", skip(graph), fields(link_id = %link_id))]
 pub fn close_iceoryx2_service(graph: &mut Graph, link_id: &LinkUniqueId) -> Result<()> {
     tracing::info!("Closing iceoryx2 service: {}", link_id);

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -268,11 +268,17 @@ pub fn open_iceoryx2_service(
 pub fn close_iceoryx2_service(graph: &mut Graph, link_id: &LinkUniqueId) -> Result<()> {
     tracing::info!("Closing iceoryx2 service: {}", link_id);
 
-    let Some((from_port, to_port)) = graph
+    let Some((source_proc_id, source_port, dest_proc_id)) = graph
         .traversal_mut()
         .e(link_id)
         .first()
-        .map(|link| (link.from_port().clone(), link.to_port().clone()))
+        .map(|link| {
+            (
+                link.from_port().processor_id.clone(),
+                link.from_port().port_name.clone(),
+                link.to_port().processor_id.clone(),
+            )
+        })
     else {
         tracing::warn!(
             "close_iceoryx2_service: link '{}' not in graph; nothing to reclaim",
@@ -280,9 +286,6 @@ pub fn close_iceoryx2_service(graph: &mut Graph, link_id: &LinkUniqueId) -> Resu
         );
         return Ok(());
     };
-    let source_proc_id = from_port.processor_id.clone();
-    let source_port = from_port.port_name.clone();
-    let dest_proc_id = to_port.processor_id.clone();
 
     let source_is_subprocess = is_subprocess_processor(graph, &source_proc_id);
     let dest_is_subprocess = is_subprocess_processor(graph, &dest_proc_id);
@@ -290,33 +293,47 @@ pub fn close_iceoryx2_service(graph: &mut Graph, link_id: &LinkUniqueId) -> Resu
     // Source side: drop this link's destination notifier (and the channel
     // publisher when this was the source port's last outbound link).
     if !source_is_subprocess {
-        if let Ok(source_processor) = get_single_processor(graph, &source_proc_id) {
-            let source_guard = source_processor.lock();
-            if let Some(output_inner) = source_guard.iceoryx2_output_writer_inner() {
-                let channel_released =
-                    output_inner.remove_channel_link(&source_port, link_id.as_str());
-                tracing::debug!(
-                    source = %source_proc_id,
-                    port = %source_port,
-                    channel_released,
-                    "Reclaimed source-side egress for disconnected link"
-                );
+        match get_single_processor(graph, &source_proc_id) {
+            Ok(source_processor) => {
+                let source_guard = source_processor.lock();
+                if let Some(output_inner) = source_guard.iceoryx2_output_writer_inner() {
+                    let channel_released =
+                        output_inner.remove_channel_link(&source_port, link_id.as_str());
+                    tracing::debug!(
+                        source = %source_proc_id,
+                        port = %source_port,
+                        channel_released,
+                        "Reclaimed source-side egress for disconnected link"
+                    );
+                }
             }
+            Err(error) => tracing::warn!(
+                proc_id = %source_proc_id,
+                error = %error,
+                "close_iceoryx2_service: processor missing; port not reclaimed"
+            ),
         }
     }
 
     // Destination side: drop this link's channel subscriber (and the port
     // mailbox / shared listener when their last inbound link went away).
     if !dest_is_subprocess {
-        if let Ok(dest_processor) = get_single_processor(graph, &dest_proc_id) {
-            let dest_guard = dest_processor.lock();
-            if let Some(input_inner) = dest_guard.iceoryx2_input_mailboxes_inner() {
-                input_inner.remove_channel_link(link_id.as_str());
-                tracing::debug!(
-                    dest = %dest_proc_id,
-                    "Reclaimed destination-side ports for disconnected link"
-                );
+        match get_single_processor(graph, &dest_proc_id) {
+            Ok(dest_processor) => {
+                let dest_guard = dest_processor.lock();
+                if let Some(input_inner) = dest_guard.iceoryx2_input_mailboxes_inner() {
+                    input_inner.remove_channel_link(link_id.as_str());
+                    tracing::debug!(
+                        dest = %dest_proc_id,
+                        "Reclaimed destination-side ports for disconnected link"
+                    );
+                }
             }
+            Err(error) => tracing::warn!(
+                proc_id = %dest_proc_id,
+                error = %error,
+                "close_iceoryx2_service: processor missing; port not reclaimed"
+            ),
         }
     }
 

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -193,6 +193,7 @@ pub fn open_iceoryx2_service(
         wire_rust_source(
             &source_processor,
             &source_port,
+            link_id,
             &output_schema,
             &service,
             &notify_service,
@@ -224,6 +225,7 @@ pub fn open_iceoryx2_service(
         wire_rust_dest(
             &dest_processor,
             &dest_port,
+            link_id,
             &dest_schema,
             drain_order,
             max_queued_messages,
@@ -247,10 +249,77 @@ pub fn open_iceoryx2_service(
     Ok(())
 }
 
-/// Close an iceoryx2 service by link ID.
+/// Reclaim one `connect()` link's iceoryx2 ports on `disconnect`.
+///
+/// Stamping [`LinkState::Disconnected`] is not enough: the source-side notifier
+/// and dest-side subscriber (plus the destination listener and any orphaned
+/// port mailbox / channel publisher) must be dropped so their iceoryx2 services
+/// are released. Otherwise a reconnect of a persistent endpoint re-appends past
+/// the notify service's create-time `max_notifiers` cap
+/// (`ExceedsMaxSupportedNotifiers`) and the stale, shallower-sized data service
+/// collides with a deeper-ring reopen (`DoesNotSupportRequestedMinBufferSize`)
+/// — the two #1549 errors, one cause.
+///
+/// Rust→Rust reclaim is complete here (both ports are host-owned). A subprocess
+/// endpoint opens its own ports from the wiring envelope and has no host-reachable
+/// drop path, so its live reclaim needs a Python/Deno cdylib drop entry point
+/// (tracked follow-up); this op does not touch a running subprocess's ports.
 #[tracing::instrument(name = "compiler.close_iceoryx2_service", skip(graph), fields(link_id = %link_id))]
 pub fn close_iceoryx2_service(graph: &mut Graph, link_id: &LinkUniqueId) -> Result<()> {
     tracing::info!("Closing iceoryx2 service: {}", link_id);
+
+    let Some((from_port, to_port)) = graph
+        .traversal_mut()
+        .e(link_id)
+        .first()
+        .map(|link| (link.from_port().clone(), link.to_port().clone()))
+    else {
+        tracing::warn!(
+            "close_iceoryx2_service: link '{}' not in graph; nothing to reclaim",
+            link_id
+        );
+        return Ok(());
+    };
+    let source_proc_id = from_port.processor_id.clone();
+    let source_port = from_port.port_name.clone();
+    let dest_proc_id = to_port.processor_id.clone();
+
+    let source_is_subprocess = is_subprocess_processor(graph, &source_proc_id);
+    let dest_is_subprocess = is_subprocess_processor(graph, &dest_proc_id);
+
+    // Source side: drop this link's destination notifier (and the channel
+    // publisher when this was the source port's last outbound link).
+    if !source_is_subprocess {
+        if let Ok(source_processor) = get_single_processor(graph, &source_proc_id) {
+            let source_guard = source_processor.lock();
+            if let Some(output_inner) = source_guard.iceoryx2_output_writer_inner() {
+                let channel_released =
+                    output_inner.remove_channel_link(&source_port, link_id.as_str());
+                tracing::debug!(
+                    source = %source_proc_id,
+                    port = %source_port,
+                    channel_released,
+                    "Reclaimed source-side egress for disconnected link"
+                );
+            }
+        }
+    }
+
+    // Destination side: drop this link's channel subscriber (and the port
+    // mailbox / shared listener when their last inbound link went away).
+    if !dest_is_subprocess {
+        if let Ok(dest_processor) = get_single_processor(graph, &dest_proc_id) {
+            let dest_guard = dest_processor.lock();
+            if let Some(input_inner) = dest_guard.iceoryx2_input_mailboxes_inner() {
+                input_inner.remove_channel_link(link_id.as_str());
+                tracing::debug!(
+                    dest = %dest_proc_id,
+                    "Reclaimed destination-side ports for disconnected link"
+                );
+            }
+        }
+    }
+
     if let Some(link) = graph.traversal_mut().e(link_id).first_mut() {
         link.insert(LinkStateComponent(LinkState::Disconnected));
     }
@@ -557,6 +626,7 @@ fn get_single_processor(
 fn wire_rust_source(
     source_processor: &Arc<Mutex<ProcessorInstance>>,
     source_port: &str,
+    link_id: &LinkUniqueId,
     output_schema: &PortSchemaSpec,
     service: &Iceoryx2Service,
     notify_service: &Iceoryx2NotifyService,
@@ -582,7 +652,7 @@ fn wire_rust_source(
     }
 
     let notifier = notify_service.create_notifier()?;
-    output_inner.add_channel_notifier(source_port, notifier);
+    output_inner.add_channel_notifier(source_port, link_id.as_str(), notifier);
     Ok(())
 }
 
@@ -591,6 +661,7 @@ fn wire_rust_source(
 fn wire_rust_dest(
     dest_processor: &Arc<Mutex<ProcessorInstance>>,
     dest_port: &str,
+    link_id: &LinkUniqueId,
     dest_schema: &PortSchemaSpec,
     drain_order: crate::iceoryx2::ReadMode,
     depth: usize,
@@ -608,7 +679,7 @@ fn wire_rust_dest(
     input_inner.set_port_expected_schema_ident(dest_port, schema_ident_wire_for_spec(dest_schema));
 
     let subscriber = service.create_subscriber()?;
-    input_inner.add_channel_subscriber(dest_port, subscriber);
+    input_inner.add_channel_subscriber(dest_port, link_id.as_str(), subscriber);
     tracing::debug!(
         "Bound channel subscriber to destination input port '{}'",
         dest_port

--- a/runtime/streamlib-engine/src/iceoryx2/input.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/input.rs
@@ -54,6 +54,12 @@ use crate::core::schema_agreement::{SchemaAgreement, classify_wire_schema_agreem
 /// destinations subscribing the same channel would each map to a different local
 /// port).
 struct PortBoundSubscriber {
+    /// The inbound `connect()` link this subscriber serves. Tags the subscriber
+    /// so a per-link `disconnect` reclaims exactly it (see
+    /// [`InputMailboxesInner::remove_channel_link`]) — a destination fanning in
+    /// N links holds N subscribers on one local port, and only the disconnected
+    /// one must go.
+    link_id: String,
     local_port: String,
     subscriber: Subscriber<ipc::Service, [u8], ()>,
 }
@@ -78,14 +84,39 @@ impl SendableChannelSubscribers {
         Self(UnsafeCell::new(Vec::new()))
     }
 
-    fn push(&self, local_port: String, subscriber: Subscriber<ipc::Service, [u8], ()>) {
+    fn push(
+        &self,
+        link_id: String,
+        local_port: String,
+        subscriber: Subscriber<ipc::Service, [u8], ()>,
+    ) {
         // SAFETY: Only called from the processor's execution thread during wiring.
         unsafe {
             (*self.0.get()).push(PortBoundSubscriber {
+                link_id,
                 local_port,
                 subscriber,
             });
         }
+    }
+
+    /// Remove the subscriber serving `link_id`, returning the local input port it
+    /// was bound to (so the caller can decide whether that port's mailbox is now
+    /// orphaned). `None` if no subscriber matches — a no-op.
+    fn remove_by_link(&self, link_id: &str) -> Option<String> {
+        // SAFETY: same single-thread-during-wiring discipline as `push`; a
+        // per-link `disconnect` runs in the same wiring phase as a `connect`.
+        unsafe {
+            let subscribers = &mut *self.0.get();
+            let position = subscribers.iter().position(|b| b.link_id == link_id)?;
+            Some(subscribers.remove(position).local_port)
+        }
+    }
+
+    /// Whether any remaining subscriber is still bound to `local_port`.
+    fn port_still_bound(&self, local_port: &str) -> bool {
+        // SAFETY: Only called from the processor's execution thread.
+        unsafe { (*self.0.get()).iter().any(|b| b.local_port == local_port) }
     }
 
     fn iter(&self) -> &[PortBoundSubscriber] {
@@ -123,6 +154,16 @@ impl SendableListener {
     fn get(&self) -> Option<&Listener<ipc::Service>> {
         // SAFETY: Only called from the processor's execution thread
         unsafe { (*self.0.get()).as_ref() }
+    }
+
+    /// Drop the listener, releasing the destination-keyed notify service's
+    /// listener slot. Called when a destination's last inbound link disconnects
+    /// so a reconnect recreates the notify service fresh.
+    fn clear(&self) {
+        // SAFETY: same single-thread-during-wiring discipline as `set`.
+        unsafe {
+            *self.0.get() = None;
+        }
     }
 }
 
@@ -277,9 +318,38 @@ impl InputMailboxesInner {
     pub fn add_channel_subscriber(
         &self,
         local_port: &str,
+        link_id: &str,
         subscriber: Subscriber<ipc::Service, [u8], ()>,
     ) {
-        self.subscribers.push(local_port.to_string(), subscriber);
+        self.subscribers
+            .push(link_id.to_string(), local_port.to_string(), subscriber);
+    }
+
+    /// Reclaim the destination-side ports for one disconnected `connect()` link.
+    ///
+    /// Drops the `link_id`-tagged channel subscriber. When the local input port
+    /// it fed has no remaining subscribers, that port's mailbox is removed; when
+    /// the destination has no remaining subscribers at all, the shared listener
+    /// is dropped — releasing the destination-keyed notify service so a later
+    /// reconnect recreates fresh-sized, refcounted ports instead of colliding
+    /// with the stale service (`DoesNotSupportRequestedMinBufferSize`). Without
+    /// this reclaim, disconnect left the subscriber and listener live — the
+    /// #1549 leak on the destination half.
+    ///
+    /// A no-op if no subscriber matches `link_id`.
+    ///
+    /// Note: This should only be called from the processor's execution thread,
+    /// in the same wiring phase a `connect` runs in.
+    pub fn remove_channel_link(&self, link_id: &str) {
+        let Some(local_port) = self.subscribers.remove_by_link(link_id) else {
+            return;
+        };
+        if !self.subscribers.port_still_bound(&local_port) {
+            self.ports.lock().remove(&local_port);
+        }
+        if self.subscribers.is_empty() {
+            self.listener.clear();
+        }
     }
 
     /// Check if a listener has already been configured.
@@ -977,8 +1047,8 @@ mod tests {
 
         let mailboxes = InputMailboxesInner::new();
         mailboxes.add_port("in", 64, ReadMode::ReadNextInOrder);
-        mailboxes.add_channel_subscriber("in", sub_a);
-        mailboxes.add_channel_subscriber("in", sub_b);
+        mailboxes.add_channel_subscriber("in", "L-fanin-a", sub_a);
+        mailboxes.add_channel_subscriber("in", "L-fanin-b", sub_b);
 
         let mut payloads: Vec<Vec<u8>> = Vec::new();
         while let Some((data, _ts)) = mailboxes.read_raw("in").unwrap() {
@@ -989,6 +1059,78 @@ mod tests {
             payloads,
             vec![b"frame-from-a".to_vec(), b"frame-from-b".to_vec()],
             "both inbound channels must fan into the one local input port's mailbox",
+        );
+    }
+
+    /// Per-link destination reclaim (#1549): a destination fanning two inbound
+    /// links into ONE local port holds two tagged subscribers plus one shared
+    /// listener. Disconnecting one link drops only its subscriber (the port
+    /// mailbox and listener survive so the other link keeps delivering);
+    /// disconnecting the last link removes the port mailbox AND drops the shared
+    /// listener — releasing the notify service so a reconnect recreates it fresh.
+    ///
+    /// Fail-without-fix: revert `remove_channel_link` to a no-op (the pre-#1549
+    /// `close_iceoryx2_service` behaviour) and the final disconnect leaves the
+    /// port and listener live, so `has_port` / `has_listener` stay true and the
+    /// release assertions fail.
+    #[test]
+    fn remove_channel_link_reclaims_per_link_then_drops_port_and_listener() {
+        let node = NodeBuilder::new().create::<ipc::Service>().unwrap();
+
+        let open_subscriber = |tag: &str| {
+            node.service_builder(&ServiceName::new(&unique_suffix(tag)).unwrap())
+                .publish_subscribe::<[u8]>()
+                .max_publishers(2)
+                .open_or_create()
+                .unwrap()
+                .subscriber_builder()
+                .create()
+                .unwrap()
+        };
+        let listener = node
+            .service_builder(&ServiceName::new(&unique_suffix("reclaim/notify")).unwrap())
+            .event()
+            .max_notifiers(2)
+            .max_listeners(1)
+            .open_or_create()
+            .unwrap()
+            .listener_builder()
+            .create()
+            .unwrap();
+
+        let inner = InputMailboxesInner::new();
+        inner.add_port("in", 64, ReadMode::ReadNextInOrder);
+        inner.add_channel_subscriber("in", "L-link-a", open_subscriber("reclaim/a"));
+        inner.add_channel_subscriber("in", "L-link-b", open_subscriber("reclaim/b"));
+        inner.set_listener(listener);
+        assert!(inner.has_port("in"));
+        assert!(inner.has_listener());
+
+        // Disconnect one of two links into the shared port: port + listener stay.
+        inner.remove_channel_link("L-link-a");
+        assert!(
+            inner.has_port("in"),
+            "the local port must stay while link-b still feeds it",
+        );
+        assert!(
+            inner.has_listener(),
+            "the shared listener must stay while any inbound link remains",
+        );
+
+        // Unknown link id is a no-op.
+        inner.remove_channel_link("L-does-not-exist");
+        assert!(inner.has_port("in"));
+
+        // Disconnect the last link: port mailbox removed, listener released.
+        inner.remove_channel_link("L-link-b");
+        assert!(
+            !inner.has_port("in"),
+            "the port mailbox must be reclaimed once its last subscriber is gone",
+        );
+        assert!(
+            !inner.has_listener(),
+            "the destination's listener (and its notify service) must be released \
+             after the last inbound link disconnects so a reconnect recreates it",
         );
     }
 

--- a/runtime/streamlib-engine/src/iceoryx2/input.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/input.rs
@@ -329,19 +329,14 @@ impl InputMailboxesInner {
 
     /// Reclaim the destination-side ports for one disconnected `connect()` link.
     ///
-    /// Drops the `link_id`-tagged channel subscriber. When the local input port
-    /// it fed has no remaining subscribers, that port's mailbox is removed; when
-    /// the destination has no remaining subscribers at all, the shared listener
-    /// is dropped — releasing the destination-keyed notify service so a later
-    /// reconnect recreates fresh-sized, refcounted ports instead of colliding
-    /// with the stale service (`DoesNotSupportRequestedMinBufferSize`). Without
-    /// this reclaim, disconnect left the subscriber and listener live — the
-    /// #1549 leak on the destination half.
+    /// Drops the `link_id`-tagged subscriber; when its local input port has no
+    /// remaining subscribers the mailbox is removed, and when the destination has
+    /// none at all the shared listener is dropped — releasing the destination-keyed
+    /// notify service so a reconnect recreates fresh-sized, refcounted ports rather
+    /// than colliding with the stale service (`DoesNotSupportRequestedMinBufferSize`).
     ///
-    /// A no-op if no subscriber matches `link_id`.
-    ///
-    /// Note: This should only be called from the processor's execution thread,
-    /// in the same wiring phase a `connect` runs in.
+    /// Must be called from the processor's execution thread, in the same wiring
+    /// phase a `connect` runs in.
     pub fn remove_channel_link(&self, link_id: &str) {
         let Some(local_port) = self.subscribers.remove_by_link(link_id) else {
             return;

--- a/runtime/streamlib-engine/src/iceoryx2/input.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/input.rs
@@ -104,8 +104,8 @@ impl SendableChannelSubscribers {
     /// was bound to (so the caller can decide whether that port's mailbox is now
     /// orphaned). `None` if no subscriber matches — a no-op.
     fn remove_by_link(&self, link_id: &str) -> Option<String> {
-        // SAFETY: same single-thread-during-wiring discipline as `push`; a
-        // per-link `disconnect` runs in the same wiring phase as a `connect`.
+        // SAFETY: sound because every caller (exec thread and compiler thread)
+        // holds the owning ProcessorInstance mutex; never call without that lock.
         unsafe {
             let subscribers = &mut *self.0.get();
             let position = subscribers.iter().position(|b| b.link_id == link_id)?;
@@ -115,7 +115,8 @@ impl SendableChannelSubscribers {
 
     /// Whether any remaining subscriber is still bound to `local_port`.
     fn port_still_bound(&self, local_port: &str) -> bool {
-        // SAFETY: Only called from the processor's execution thread.
+        // SAFETY: sound because every caller (exec thread and compiler thread)
+        // holds the owning ProcessorInstance mutex; never call without that lock.
         unsafe { (*self.0.get()).iter().any(|b| b.local_port == local_port) }
     }
 
@@ -160,7 +161,8 @@ impl SendableListener {
     /// listener slot. Called when a destination's last inbound link disconnects
     /// so a reconnect recreates the notify service fresh.
     fn clear(&self) {
-        // SAFETY: same single-thread-during-wiring discipline as `set`.
+        // SAFETY: sound because every caller (exec thread and compiler thread)
+        // holds the owning ProcessorInstance mutex; never call without that lock.
         unsafe {
             *self.0.get() = None;
         }

--- a/runtime/streamlib-engine/src/iceoryx2/node.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/node.rs
@@ -939,4 +939,121 @@ mod tests {
         assert_eq!(received.payload()[0], 0xAB);
         assert_eq!(received.payload()[oversized - 1], 0xCD);
     }
+
+    /// End-to-end #1549 reconnect cycle: connect → disconnect → reconnect a
+    /// persistent source+destination pair the way the compiler op wires it, and
+    /// prove the per-link reclaim releases both iceoryx2 services so the reconnect
+    /// recreates them fresh — reproducing (and defeating) BOTH reported errors:
+    ///
+    /// - `ExceedsMaxSupportedNotifiers`: the notify service is created with
+    ///   `max_notifiers = fan-in (1)`. Without reclaim, the first connect's
+    ///   notifier stays live on [`OutputWriterInner`], so the reconnect's
+    ///   `create_notifier` is the SECOND on a max-1 service and fails.
+    /// - `DoesNotSupportRequestedMinBufferSize`: the reconnect opens the data
+    ///   service at a DEEPER ring depth. Without reclaim, the stale shallow
+    ///   service is still held by the leaked publisher/subscriber, so the deeper
+    ///   reopen is rejected.
+    ///
+    /// Fail-without-fix: revert `OutputWriterInner::remove_channel_link` /
+    /// `InputMailboxesInner::remove_channel_link` to no-ops (the pre-#1549
+    /// `close_iceoryx2_service` behaviour) and the reconnect's `create_notifier`
+    /// trips `ExceedsMaxSupportedNotifiers` and the deeper `open_or_create_service`
+    /// trips `DoesNotSupportRequestedMinBufferSize` — the two `.expect`s panic.
+    #[test]
+    fn disconnect_reconnect_cycle_reclaims_notifier_and_data_service() {
+        use crate::iceoryx2::{
+            ChannelEgressConfig, ChannelTrustTier, InputMailboxesInner, OutputWriterInner, ReadMode,
+            TRUSTED_CHANNEL_PAYLOAD_CEILING_BYTES,
+        };
+        use streamlib_ipc_types::{RESERVED_TAP_SUBSCRIBER_SLOTS_PER_CHANNEL, SchemaIdentWire};
+
+        let node = Iceoryx2Node::new().expect("create iceoryx2 node");
+        let data_name = unique_service_name("cycle/data");
+        let notify_name = unique_service_name("cycle/notify");
+        let link_id = "L-cycle-1";
+        // fan-in = 1 (one inbound link), fan-out = 1 (+ reserved tap slot).
+        let max_notifiers = 1usize;
+        let max_subscribers = 1 + RESERVED_TAP_SUBSCRIBER_SLOTS_PER_CHANNEL;
+        let schema =
+            SchemaIdentWire::from_segments("tatolab", "core", "VideoFrame", 1, 0, 0).unwrap();
+
+        let out_inner = Arc::new(OutputWriterInner::new());
+        let in_inner = Arc::new(InputMailboxesInner::new());
+
+        // One `connect()` wiring pass at ring depth `depth`, exactly as the
+        // compiler op stitches a Rust→Rust link.
+        let connect = |depth: usize| {
+            let data = node
+                .open_or_create_service(&data_name, max_subscribers, depth, true)
+                .expect("open channel data service");
+            let notify = node
+                .open_or_create_notify_service(&notify_name, max_notifiers)
+                .expect("open notify service");
+
+            if !out_inner.has_channel_publisher("out") {
+                let publisher = data.create_publisher(64).expect("source publisher");
+                out_inner.set_channel_publisher(
+                    "out",
+                    schema,
+                    publisher,
+                    ChannelEgressConfig {
+                        service_name: data_name.clone(),
+                        trust_tier: ChannelTrustTier::Trusted,
+                        expected_payload_bytes: 64,
+                        ceiling_bytes: TRUSTED_CHANNEL_PAYLOAD_CEILING_BYTES,
+                    },
+                );
+            }
+            out_inner.add_channel_notifier(
+                "out",
+                link_id,
+                notify.create_notifier().expect(
+                    "create_notifier must fit the notify service's max_notifiers cap — a \
+                     leaked notifier from the previous connect would trip \
+                     ExceedsMaxSupportedNotifiers here",
+                ),
+            );
+
+            if !in_inner.has_port("in") {
+                in_inner.add_port("in", depth, ReadMode::ReadNextInOrder);
+            }
+            in_inner.add_channel_subscriber(
+                "in",
+                link_id,
+                data.create_subscriber().expect("dest subscriber"),
+            );
+            if !in_inner.has_listener() {
+                in_inner.set_listener(notify.create_listener().expect("dest listener"));
+            }
+        };
+
+        // Simulate `close_iceoryx2_service`'s per-link reclaim on both halves.
+        let disconnect = || {
+            out_inner.remove_channel_link("out", link_id);
+            in_inner.remove_channel_link(link_id);
+        };
+
+        // First connect at a shallow depth.
+        connect(4);
+        assert!(out_inner.has_channel_publisher("out"));
+        assert!(in_inner.has_listener());
+
+        // Disconnect: the reclaim must drop the publisher, notifier, subscriber
+        // and listener so iceoryx2 releases both services.
+        disconnect();
+        assert!(
+            !out_inner.has_channel_publisher("out"),
+            "the channel publisher must be released on disconnect",
+        );
+        assert!(
+            !in_inner.has_listener(),
+            "the destination listener must be released on disconnect",
+        );
+
+        // Reconnect at a DEEPER ring depth. Both `.expect`s inside `connect`
+        // (create_notifier + open_or_create_service) are the #1549 trip-wires.
+        connect(64);
+        assert!(out_inner.has_channel_publisher("out"));
+        assert!(in_inner.has_listener());
+    }
 }

--- a/runtime/streamlib-engine/src/iceoryx2/output.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/output.rs
@@ -218,20 +218,13 @@ impl OutputWriterInner {
 
     /// Reclaim the source-side egress for one disconnected `connect()` link.
     ///
-    /// Drops the `link_id`-tagged destination notifier from `output_port`'s
-    /// channel egress. When that was the last outbound link from the port, the
-    /// whole [`ChannelEgress`] is removed — dropping the publisher and releasing
-    /// the underlying iceoryx2 data service so a later reconnect recreates a
-    /// fresh-sized, refcounted service rather than colliding with the stale one
-    /// (`DoesNotSupportRequestedMinBufferSize`) or exceeding the notify service's
-    /// create-time `max_notifiers` cap (`ExceedsMaxSupportedNotifiers`). Without
-    /// this reclaim, disconnect left the notifier and publisher live, so a
-    /// reconnect re-appended past the cap — the #1549 leak.
+    /// When the dropped `link_id` notifier was the port's last outbound link, the
+    /// whole [`ChannelEgress`] (publisher + data service) is released so a reconnect
+    /// recreates a fresh-sized, refcounted service rather than colliding with the
+    /// stale one (`DoesNotSupportRequestedMinBufferSize`) or exceeding the notify
+    /// service's create-time `max_notifiers` cap (`ExceedsMaxSupportedNotifiers`).
     ///
-    /// Returns `true` when the channel publisher was fully removed (the last link
-    /// went away), `false` when other outbound links keep it alive. A no-op that
-    /// returns `false` if `output_port` has no channel or no notifier for
-    /// `link_id`.
+    /// Returns `true` when that last link went away and the publisher was removed.
     pub fn remove_channel_link(&self, output_port: &str, link_id: &str) -> bool {
         let mut channels = self.channels.lock();
         let Some(egress) = channels.get_mut(output_port) else {

--- a/runtime/streamlib-engine/src/iceoryx2/output.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/output.rs
@@ -72,7 +72,12 @@ fn trust_tier_label(trust_tier: ChannelTrustTier) -> ChannelTrustTierLabel {
 struct ChannelEgress {
     schema_ident: SchemaIdentWire,
     publisher: Publisher<ipc::Service, [u8], ()>,
-    notifiers: Vec<Notifier<ipc::Service>>,
+    /// One `(link_id, notifier)` per outbound `connect()` link from this source
+    /// port. The link id tags each notifier so a per-link `disconnect` reclaims
+    /// exactly its own notifier (see
+    /// [`OutputWriterInner::remove_channel_link`]) rather than the whole
+    /// fan-out — a source feeding N destinations must keep the other N-1 alive.
+    notifiers: Vec<(String, Notifier<ipc::Service>)>,
     /// iceoryx2 service name for this channel (`{source}/{output_port}`) —
     /// carried only for the growth / ceiling tracing fields.
     channel_service_name: String,
@@ -191,14 +196,53 @@ impl OutputWriterInner {
             .unwrap_or(0)
     }
 
-    /// Append a destination notifier to an output port's channel.
+    /// Append a destination notifier to an output port's channel, tagged with
+    /// the `link_id` of the `connect()` link it serves.
     ///
     /// One notifier per `connect()` link out of this port — each wakes a distinct
-    /// destination's listener fd. No-op (the notifier is dropped) if the channel
-    /// publisher has not been installed yet, which the wiring op never does.
-    pub fn add_channel_notifier(&self, output_port: &str, notifier: Notifier<ipc::Service>) {
+    /// destination's listener fd. The `link_id` tag lets a later per-link
+    /// `disconnect` reclaim exactly this notifier via
+    /// [`Self::remove_channel_link`]. No-op (the notifier is dropped) if the
+    /// channel publisher has not been installed yet, which the wiring op never
+    /// does.
+    pub fn add_channel_notifier(
+        &self,
+        output_port: &str,
+        link_id: &str,
+        notifier: Notifier<ipc::Service>,
+    ) {
         if let Some(egress) = self.channels.lock().get_mut(output_port) {
-            egress.notifiers.push(notifier);
+            egress.notifiers.push((link_id.to_string(), notifier));
+        }
+    }
+
+    /// Reclaim the source-side egress for one disconnected `connect()` link.
+    ///
+    /// Drops the `link_id`-tagged destination notifier from `output_port`'s
+    /// channel egress. When that was the last outbound link from the port, the
+    /// whole [`ChannelEgress`] is removed — dropping the publisher and releasing
+    /// the underlying iceoryx2 data service so a later reconnect recreates a
+    /// fresh-sized, refcounted service rather than colliding with the stale one
+    /// (`DoesNotSupportRequestedMinBufferSize`) or exceeding the notify service's
+    /// create-time `max_notifiers` cap (`ExceedsMaxSupportedNotifiers`). Without
+    /// this reclaim, disconnect left the notifier and publisher live, so a
+    /// reconnect re-appended past the cap — the #1549 leak.
+    ///
+    /// Returns `true` when the channel publisher was fully removed (the last link
+    /// went away), `false` when other outbound links keep it alive. A no-op that
+    /// returns `false` if `output_port` has no channel or no notifier for
+    /// `link_id`.
+    pub fn remove_channel_link(&self, output_port: &str, link_id: &str) -> bool {
+        let mut channels = self.channels.lock();
+        let Some(egress) = channels.get_mut(output_port) else {
+            return false;
+        };
+        egress.notifiers.retain(|(id, _)| id != link_id);
+        if egress.notifiers.is_empty() {
+            channels.remove(output_port);
+            true
+        } else {
+            false
         }
     }
 
@@ -262,7 +306,7 @@ impl OutputWriterInner {
         // (e.g. a listener not yet created) — log and continue rather than
         // failing the publish; the data is already in shared memory and the
         // next send() will wake the listener anyway.
-        for notifier in &egress.notifiers {
+        for (_link_id, notifier) in &egress.notifiers {
             if let Err(e) = notifier.notify() {
                 tracing::trace!(
                     "OutputWriter: notify() failed for port '{}': {:?}",
@@ -573,7 +617,7 @@ mod tests {
                 ceiling_bytes: crate::iceoryx2::TRUSTED_CHANNEL_PAYLOAD_CEILING_BYTES,
             },
         );
-        inner.add_channel_notifier("out", notifier);
+        inner.add_channel_notifier("out", "L-test-notify", notifier);
 
         // Pre-flight: the listener has no events queued.
         let mut count: usize = 0;
@@ -663,7 +707,11 @@ mod tests {
                 .max_listeners(1)
                 .open_or_create()
                 .unwrap();
-            inner.add_channel_notifier("out", notify.notifier_builder().create().unwrap());
+            inner.add_channel_notifier(
+                "out",
+                &format!("L-test-fanout-{i}"),
+                notify.notifier_builder().create().unwrap(),
+            );
             listeners.push(notify.listener_builder().create().unwrap());
         }
 
@@ -688,6 +736,89 @@ mod tests {
                 "subscriber {i} received the wrong payload",
             );
         }
+    }
+
+    /// Per-link source reclaim (#1549): a source port feeding two destination
+    /// links holds two tagged notifiers on ONE channel egress. Disconnecting one
+    /// link drops only its notifier (the channel — and its publisher — survive so
+    /// the other destination keeps receiving); disconnecting the last link removes
+    /// the whole channel egress, releasing the publisher so a reconnect recreates
+    /// a fresh-sized service.
+    ///
+    /// Fail-without-fix: revert `remove_channel_link` to a no-op (the pre-#1549
+    /// `close_iceoryx2_service` behaviour) and the first removal leaves both
+    /// notifiers, so `has_channel_publisher` stays true after the final
+    /// disconnect and the "channel fully removed" assertion fails.
+    #[test]
+    fn remove_channel_link_reclaims_per_link_then_drops_channel() {
+        let node = NodeBuilder::new().create::<ipc::Service>().unwrap();
+        let pubsub = node
+            .service_builder(&ServiceName::new(&unique_suffix("reclaim/pubsub")).unwrap())
+            .publish_subscribe::<[u8]>()
+            .max_publishers(2)
+            .max_subscribers(4)
+            .open_or_create()
+            .unwrap();
+        let publisher = pubsub
+            .publisher_builder()
+            .initial_max_slice_len(4096)
+            .create()
+            .unwrap();
+
+        let inner = Arc::new(OutputWriterInner::new());
+        let schema =
+            SchemaIdentWire::from_segments("tatolab", "core", "VideoFrame", 1, 0, 0).unwrap();
+        inner.set_channel_publisher(
+            "out",
+            schema,
+            publisher,
+            ChannelEgressConfig {
+                service_name: "test/reclaim/out".to_string(),
+                trust_tier: ChannelTrustTier::Trusted,
+                expected_payload_bytes: 4096,
+                ceiling_bytes: crate::iceoryx2::TRUSTED_CHANNEL_PAYLOAD_CEILING_BYTES,
+            },
+        );
+
+        let notify = |tag: &str| {
+            node.service_builder(&ServiceName::new(&unique_suffix(tag)).unwrap())
+                .event()
+                .max_notifiers(2)
+                .max_listeners(1)
+                .open_or_create()
+                .unwrap()
+                .notifier_builder()
+                .create()
+                .unwrap()
+        };
+        inner.add_channel_notifier("out", "L-link-a", notify("reclaim/notify/a"));
+        inner.add_channel_notifier("out", "L-link-b", notify("reclaim/notify/b"));
+        assert!(inner.has_channel_publisher("out"));
+
+        // Disconnect one of two links: the channel (and publisher) survive.
+        assert!(
+            !inner.remove_channel_link("out", "L-link-a"),
+            "removing one of two links must NOT drop the shared channel publisher",
+        );
+        assert!(
+            inner.has_channel_publisher("out"),
+            "the channel must stay wired while link-b is still connected",
+        );
+
+        // A stale/unknown link id is a no-op that keeps the channel.
+        assert!(!inner.remove_channel_link("out", "L-does-not-exist"));
+        assert!(inner.has_channel_publisher("out"));
+
+        // Disconnect the last link: the whole channel egress is reclaimed.
+        assert!(
+            inner.remove_channel_link("out", "L-link-b"),
+            "removing the last outbound link must drop the channel publisher",
+        );
+        assert!(
+            !inner.has_channel_publisher("out"),
+            "the publisher (and its data service) must be released after the final \
+             disconnect so a reconnect recreates a fresh-sized service",
+        );
     }
 
     /// Empty (unwired) writers should fail cleanly rather than crash.

--- a/sdk/streamlib-sdk/src/hello_streamlib_example_e2e.rs
+++ b/sdk/streamlib-sdk/src/hello_streamlib_example_e2e.rs
@@ -139,14 +139,14 @@ fn fixture_frame_traverses_the_inline_forward_processor() {
             ceiling_bytes: TRUSTED_CHANNEL_PAYLOAD_CEILING_BYTES,
         },
     );
-    output_writer_inner.add_channel_notifier("video_out", notifier);
+    output_writer_inner.add_channel_notifier("video_out", "L-video-forward", notifier);
 
     // Sink: an input mailbox subscribed to the same channel, bound to its local
     // `video_in` port. `read_raw` drains the subscriber and hands back the
     // forwarded payload.
     let sink_inputs = Arc::new(InputMailboxesInner::new());
     sink_inputs.add_port("video_in", 8, ReadMode::ReadNextInOrder);
-    sink_inputs.add_channel_subscriber("video_in", subscriber);
+    sink_inputs.add_channel_subscriber("video_in", "L-video-forward", subscriber);
 
     // Build the example processor and wire in the real host-side inners.
     let mut processor = HelloForward::Processor::from_config(EmptyConfig)


### PR DESCRIPTION
## Ticket

Closes #1549

## Summary

`GraphChangeListener` logged `Commit failed: ExceedsMaxSupportedNotifiers` /
`Commit failed: ... DoesNotSupportRequestedMinBufferSize` on every graph mutation
during live reconfigure. The listener itself only calls `compiler.commit()` — the
real defect is one layer down: `close_iceoryx2_service` stamped
`LinkState::Disconnected` on a link but never reclaimed the source-side notifier,
dest-side subscriber, port mailbox, listener, or channel publisher. On
disconnect→reconnect of a persistent endpoint the source re-appended a notifier
past the notify service's create-time `max_notifiers` cap
(`ExceedsMaxSupportedNotifiers`), and the stale shallow data service collided with
a deeper-ring reopen (`DoesNotSupportRequestedMinBufferSize`) — both surfaced
through the listener's error-logging prefix, not caused by it.

Three commits, engine-layer fix:

1. **`fix(engine): reclaim iceoryx2 ports per-link on disconnect (#1549)`** — add
   per-link reclaim to the host-owned inners: `OutputWriterInner::remove_channel_link`
   tags notifiers by link id and drops the whole `ChannelEgress` (publisher) when
   the last outbound link goes away; `InputMailboxesInner::remove_channel_link` tags
   subscribers by link id, drops the port mailbox when its last subscriber goes,
   and drops the shared listener when the destination's last inbound link goes.
   `close_iceoryx2_service` now calls both so a reconnect recreates fresh-sized,
   refcounted services.
2. **`fix(engine): sweep remaining add_channel_notifier/subscriber call sites (#1549)`**
   — canonical-pattern sweep of the remaining call sites onto the new per-link API.
3. **`fix(engine): surface un-reclaimable endpoints; correct reclaim SAFETY
   invariant (#1549)`** — `close_iceoryx2_service` warns instead of silently
   dropping the `Err` arm when a non-subprocess source/dest processor is missing,
   so a port that is never reclaimed leaves a trace; reworded the
   `SendableSubscriber`/`SendableListener` `SAFETY` comments (soundness is external
   mutual exclusion via the owning `ProcessorInstance` mutex, held by both exec and
   compiler threads — not single-thread-during-wiring); dropped an unused
   `to_port.port_name` clone on the reclaim path.

## Test evidence

Ran in-worktree (`cargo test -p streamlib-engine --lib`, no GPU/rig required):

```
running 36 tests (iceoryx2::*)
test iceoryx2::node::tests::disconnect_reconnect_cycle_reclaims_notifier_and_data_service ... ok
...
test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 1810 filtered out

running 7 tests (core::compiler::compiler_ops::open_iceoryx2_service_op::*)
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1839 filtered out
```

The locking regression test is `disconnect_reconnect_cycle_reclaims_notifier_and_data_service`
(`runtime/streamlib-engine/src/iceoryx2/node.rs`): it connects a persistent
source→dest pair at ring depth 4 (mirroring the compiler op's wiring), disconnects,
then reconnects at ring depth 64 (a deeper reopen). Reverting
`OutputWriterInner::remove_channel_link` / `InputMailboxesInner::remove_channel_link`
to no-ops (the pre-#1549 behavior) makes the reconnect's `create_notifier` trip
`ExceedsMaxSupportedNotifiers` and the deeper `open_or_create_service` trip
`DoesNotSupportRequestedMinBufferSize` — reproducing both reported errors and
proving the fix defeats them. Plus new unit tests:
`remove_channel_link_reclaims_per_link_then_drops_port_and_listener` (input.rs) and
`remove_channel_link_reclaims_per_link_then_drops_channel` (output.rs).

Per `docs/project_ci_strategy_no_gpu`, no GPU/rig E2E is required for this
change — it's IPC-layer reclaim, fully covered by the `cargo test --lib` evidence
above.

## Review items (non-blocking)

- **[info]** `runtime/streamlib-engine/src/core/runtime/graph_change_listener.rs:60`
  — Ticket points the fix at `graph_change_listener.rs`; the branch instead
  changes the iceoryx2 inners + compiler close/open service path.
  Evidence: `GraphChangeListener::on_event` only calls `compiler.commit()`
  (line 60-64) and opens no iceoryx2 service/notifier itself. The ticket's log
  line `[GraphChangeListener] Commit failed: ExceedsMaxSupportedNotifiers /
  DoesNotSupportRequestedMinBufferSize` is the compiler's reconnect error
  surfaced under that prefix. Root cause is `close_iceoryx2_service` only
  stamping `LinkState::Disconnected` without reclaiming per-link ports, so a
  persistent-endpoint reconnect re-appends a notifier past `max_notifiers` and
  reopens the data service at a deeper ring depth colliding with the stale one.
  The branch's re-diagnosis is correct and doctrine-aligned (fix at engine
  layer, not bandaid the listener).
  Suggested next step: None — the ticket "Fix direction" was a hypothesis; the
  engine-layer re-diagnosis is the correct target. Note it on the PR body.

- **[info]** `runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs:268`
  — Reclaim is complete only for host-owned Rust->Rust links; subprocess
  (Python/Deno) endpoint reclaim is deferred.
  Evidence: `close_iceoryx2_service` skips reclaim when
  `source_is_subprocess`/`dest_is_subprocess` (guards at the
  `if !source_is_subprocess`/`if !dest_is_subprocess` arms). The doc comment
  states subprocess live reclaim needs a Python/Deno cdylib drop entry point
  (tracked follow-up). The ticket's repro used Rust processors
  (SimplePassthrough / continuous-forwarder), so the reported scenario is fully
  covered; the subprocess gap is disclosed, not silent.
  Suggested next step: Confirm a follow-up issue exists for subprocess-endpoint
  reclaim so the "tracked follow-up" claim in the doc is not dangling.

- **[low]** `runtime/streamlib-engine/src/iceoryx2/output.rs:235` — The new
  rustdoc blocks on `remove_channel_link` (output.rs:235, input.rs:345) and
  `close_iceoryx2_service` (open_iceoryx2_service_op.rs:268) are multi-paragraph
  essays that restate the #1549 narrative.
  Evidence: `.claude/rules/comments.md`: "Don't write multi-paragraph rustdoc
  essays" and "Don't explain or justify a decision — that belongs in the
  PR/commit". The load-bearing content is the iceoryx2 quirk (create-time
  `max_notifiers` cap; data-service refcount/min-buffer-size collision), which
  is worth one or two lines; the surrounding #1549 justification duplicates the
  commit message.
  Suggested next step: Trim each doc block to the one-line summary plus the
  iceoryx2 quirk note; move the #1549 narrative to the PR/commit.
