### PR TITLE
feat(cli): streamlib mcp — stdio MCP server spawnable by any MCP host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5058,6 +5058,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "streamlib",
+ "streamlib-api-server",
  "streamlib-cargo-build",
  "streamlib-idents",
  "streamlib-jtd-codegen",
@@ -5069,6 +5070,7 @@ dependencies = [
  "toml 0.8.23",
  "toml_edit 0.22.27",
  "tracing",
+ "ureq",
  "zip",
 ]
 

--- a/packages/api-server/src/lib.rs
+++ b/packages/api-server/src/lib.rs
@@ -14,8 +14,5 @@ mod processor;
 mod state;
 
 pub use _generated_::ApiServerConfig;
-pub use mcp::{
-    JsonRpcRequest, dispatch_jsonrpc, jsonrpc_parse_error, parse_jsonrpc_request,
-    serve_stdio_jsonrpc,
-};
+pub use mcp::serve_stdio_jsonrpc;
 pub use processor::ApiServerProcessor;

--- a/packages/api-server/src/lib.rs
+++ b/packages/api-server/src/lib.rs
@@ -14,4 +14,8 @@ mod processor;
 mod state;
 
 pub use _generated_::ApiServerConfig;
+pub use mcp::{
+    JsonRpcRequest, dispatch_jsonrpc, jsonrpc_parse_error, parse_jsonrpc_request,
+    serve_stdio_jsonrpc,
+};
 pub use processor::ApiServerProcessor;

--- a/packages/api-server/src/mcp.rs
+++ b/packages/api-server/src/mcp.rs
@@ -3,13 +3,17 @@
 
 //! Model Context Protocol (MCP) veneer over the api-server's control-plane ops.
 //!
-//! A single Streamable-HTTP endpoint (`POST /mcp`) speaks MCP's JSON-RPC 2.0
-//! wire directly on the existing axum stack — no separate proxy process, and
-//! the same [`crate::auth`] bearer middleware and [`crate::state::AppState`] the
-//! REST routes use. It exposes the runtime graph as MCP *tools* so an LLM agent
-//! can inspect and mutate the live graph the same way the REST client does; the
-//! tool handlers call the shared [`crate::ops`] layer, so the MCP surface and
-//! the REST surface can never drift.
+//! The MCP dispatch is transport-free: [`dispatch_jsonrpc`] answers one parsed
+//! JSON-RPC 2.0 message against an `Arc<dyn RuntimeOperations>` and knows
+//! nothing about how the bytes arrived. Two transports drive that one surface —
+//! the Streamable-HTTP endpoint (`POST /mcp`, [`mcp_endpoint`]) on the existing
+//! axum stack with its [`crate::auth`] bearer middleware, and the
+//! newline-delimited stdio server ([`serve_stdio_jsonrpc`]) an MCP host spawns
+//! over a pipe. Sharing the one dispatch means the two transports can never
+//! diverge. It exposes the runtime graph as MCP *tools* so an LLM agent can
+//! inspect and mutate the live graph the same way the REST client does; the tool
+//! handlers call the shared [`crate::ops`] layer, so the MCP surface and the REST
+//! surface can never drift.
 //!
 //! Two of the tools (`tap`, `logs`) front WebSocket *streams* in the REST API.
 //! MCP tools are request/response, so each bridges its stream to a **bounded
@@ -32,7 +36,7 @@ use serde_json::{Value, json};
 use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::pubsub::{Event, EventListener, PUBSUB, topics};
-use streamlib::sdk::runtime::SubmittedProcessorSource;
+use streamlib::sdk::runtime::{RuntimeOperations, SubmittedProcessorSource};
 
 use crate::ops::{ReplaceSourceError, SubmitSourceError, SubmittedSourceOutcome};
 use crate::state::{
@@ -86,9 +90,10 @@ const TAP_SAMPLE_WINDOW: Duration = Duration::from_millis(500);
 
 /// An inbound MCP message. A *request* carries an `id` and expects a paired
 /// response; a *notification* (e.g. `notifications/initialized`) omits `id` and
-/// is acknowledged with `202 Accepted` and no body.
+/// is dispatched for effect with no reply (HTTP acks it `202 Accepted`; stdio
+/// writes no response line).
 #[derive(Deserialize)]
-pub(crate) struct JsonRpcRequest {
+pub struct JsonRpcRequest {
     #[serde(default)]
     id: Option<Value>,
     method: String,
@@ -120,37 +125,109 @@ impl RpcError {
 }
 
 /// `POST /mcp` — the MCP Streamable-HTTP endpoint. Dispatches one JSON-RPC
-/// message and answers with a single `application/json` response (this server's
-/// tools are all request/response, so it never opens an SSE stream).
+/// message through the transport-free [`dispatch_jsonrpc`] and answers with a
+/// single `application/json` response (this server's tools are all
+/// request/response, so it never opens an SSE stream); a notification is acked
+/// `202 Accepted` with no body.
 #[tracing::instrument(skip_all, fields(mcp_method = %request.method))]
 pub(crate) async fn mcp_endpoint(
     State(state): State<AppState>,
     Json(request): Json<JsonRpcRequest>,
 ) -> Response {
-    let Some(id) = request.id.clone() else {
-        // A notification expects no response body under Streamable HTTP.
-        return StatusCode::ACCEPTED.into_response();
-    };
-
-    let params = request.params.clone().unwrap_or(Value::Null);
-    match dispatch(&state, &request.method, params).await {
-        Ok(result) => Json(json!({
-            "jsonrpc": "2.0",
-            "id": id,
-            "result": result,
-        }))
-        .into_response(),
-        Err(error) => Json(json!({
-            "jsonrpc": "2.0",
-            "id": id,
-            "error": { "code": error.code, "message": error.message },
-        }))
-        .into_response(),
+    match dispatch_jsonrpc(&state.runtime, request).await {
+        Some(response) => Json(response).into_response(),
+        None => StatusCode::ACCEPTED.into_response(),
     }
 }
 
+/// Dispatch one parsed MCP JSON-RPC 2.0 message against `runtime`, transport-free.
+///
+/// Returns the full JSON-RPC response envelope (`result` or `error`) for a
+/// request, or `None` for a notification (no `id`) — the caller decides how a
+/// no-reply is framed on its transport (HTTP: `202`; stdio: no output line).
+/// This is the single MCP surface both the HTTP endpoint and the stdio server
+/// call, so the two transports can never diverge.
+#[tracing::instrument(skip_all, fields(mcp_method = %request.method))]
+pub async fn dispatch_jsonrpc(
+    runtime: &Arc<dyn RuntimeOperations>,
+    request: JsonRpcRequest,
+) -> Option<Value> {
+    let id = request.id.clone()?;
+    let params = request.params.clone().unwrap_or(Value::Null);
+    let envelope = match dispatch(runtime, &request.method, params).await {
+        Ok(result) => json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": result,
+        }),
+        Err(error) => json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": { "code": error.code, "message": error.message },
+        }),
+    };
+    Some(envelope)
+}
+
+/// Parse one newline-delimited JSON-RPC 2.0 request line into a
+/// [`JsonRpcRequest`]. A malformed line is a JSON-RPC *parse error* — render it
+/// with [`jsonrpc_parse_error`] rather than dropping the input silently.
+pub fn parse_jsonrpc_request(line: &str) -> serde_json::Result<JsonRpcRequest> {
+    serde_json::from_str(line)
+}
+
+/// The JSON-RPC 2.0 envelope for a line that could not be parsed as a request
+/// (`-32700 Parse error`), with a null `id` since none could be recovered.
+pub fn jsonrpc_parse_error(message: &str) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": Value::Null,
+        "error": { "code": -32700, "message": format!("parse error: {message}") },
+    })
+}
+
+/// Serve MCP over a newline-delimited JSON-RPC 2.0 byte transport — the stdio
+/// framing an MCP host spawns a server with (`claude mcp add streamlib -- …`).
+///
+/// One JSON-RPC message per line is read from `reader`, dispatched through the
+/// shared [`dispatch_jsonrpc`] against `runtime`, and each response written as a
+/// single newline-terminated JSON line to `writer`; a notification produces no
+/// output line, and an unparseable line answers with a [`jsonrpc_parse_error`].
+/// Returns on reader EOF (the host closed the pipe), so the caller can tear its
+/// runtime down. Generic over the byte transport — this crate never touches the
+/// process's own stdio; the CLI passes `tokio::io::stdin`/`stdout`.
+pub async fn serve_stdio_jsonrpc<R, W>(
+    runtime: Arc<dyn RuntimeOperations>,
+    reader: R,
+    mut writer: W,
+) -> std::io::Result<()>
+where
+    R: tokio::io::AsyncBufRead + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+
+    let mut lines = reader.lines();
+    while let Some(line) = lines.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let response = match parse_jsonrpc_request(&line) {
+            Ok(request) => dispatch_jsonrpc(&runtime, request).await,
+            Err(error) => Some(jsonrpc_parse_error(&error.to_string())),
+        };
+        if let Some(response) = response {
+            let mut encoded = serde_json::to_vec(&response).unwrap_or_else(|_| b"null".to_vec());
+            encoded.push(b'\n');
+            writer.write_all(&encoded).await?;
+            writer.flush().await?;
+        }
+    }
+    Ok(())
+}
+
 async fn dispatch(
-    state: &AppState,
+    runtime: &Arc<dyn RuntimeOperations>,
     method: &str,
     params: Value,
 ) -> std::result::Result<Value, RpcError> {
@@ -158,7 +235,7 @@ async fn dispatch(
         "initialize" => Ok(initialize_result()),
         "ping" => Ok(json!({})),
         "tools/list" => Ok(json!({ "tools": tool_definitions() })),
-        "tools/call" => tools_call(state, params).await,
+        "tools/call" => tools_call(runtime, params).await,
         other => Err(RpcError::method_not_found(other)),
     }
 }
@@ -286,7 +363,10 @@ fn tool_definitions() -> Vec<Value> {
 // tools/call dispatch
 // ============================================================================
 
-async fn tools_call(state: &AppState, params: Value) -> std::result::Result<Value, RpcError> {
+async fn tools_call(
+    runtime: &Arc<dyn RuntimeOperations>,
+    params: Value,
+) -> std::result::Result<Value, RpcError> {
     #[derive(Deserialize)]
     struct ToolCallParams {
         name: String,
@@ -302,26 +382,26 @@ async fn tools_call(state: &AppState, params: Value) -> std::result::Result<Valu
     };
 
     let result = match name.as_str() {
-        "graph" => call_graph(state).await,
-        "submit_processor" => call_submit_processor(state, arguments).await,
-        "replace_processor" => call_replace_processor(state, arguments).await,
-        "remove_processor" => call_remove_processor(state, arguments).await,
-        "connect" => call_connect(state, arguments).await,
-        "tap" => call_tap(state, arguments).await,
-        "logs" => call_logs(state, arguments).await,
+        "graph" => call_graph(runtime).await,
+        "submit_processor" => call_submit_processor(runtime, arguments).await,
+        "replace_processor" => call_replace_processor(runtime, arguments).await,
+        "remove_processor" => call_remove_processor(runtime, arguments).await,
+        "connect" => call_connect(runtime, arguments).await,
+        "tap" => call_tap(runtime, arguments).await,
+        "logs" => call_logs(runtime, arguments).await,
         other => tool_error(format!("unknown tool: {other}")),
     };
     Ok(result)
 }
 
-async fn call_graph(state: &AppState) -> Value {
-    match state.runtime.to_json_async().await {
+async fn call_graph(runtime: &Arc<dyn RuntimeOperations>) -> Value {
+    match runtime.to_json_async().await {
         Ok(graph) => tool_ok(graph),
         Err(e) => tool_error(format!("graph export failed: {e}")),
     }
 }
 
-async fn call_submit_processor(state: &AppState, arguments: Value) -> Value {
+async fn call_submit_processor(runtime: &Arc<dyn RuntimeOperations>, arguments: Value) -> Value {
     let request: SubmittedProcessorSourceRequest = match serde_json::from_value(arguments) {
         Ok(request) => request,
         Err(e) => return tool_error(format!("submit_processor arguments: {e}")),
@@ -333,15 +413,13 @@ async fn call_submit_processor(state: &AppState, arguments: Value) -> Value {
         processor_type_name: request.processor_type_name,
     };
     let config = request.config.unwrap_or_else(|| json!({}));
-    match crate::ops::submit_processor_source(&state.runtime, submitted, config, request.connect)
-        .await
-    {
+    match crate::ops::submit_processor_source(runtime, submitted, config, request.connect).await {
         Ok(outcome) => tool_ok(submitted_source_json(outcome)),
         Err(error) => tool_error(submit_source_error_message(error)),
     }
 }
 
-async fn call_replace_processor(state: &AppState, arguments: Value) -> Value {
+async fn call_replace_processor(runtime: &Arc<dyn RuntimeOperations>, arguments: Value) -> Value {
     let request: ReplaceProcessorSourceRequest = match serde_json::from_value(arguments) {
         Ok(request) => request,
         Err(e) => return tool_error(format!("replace_processor arguments: {e}")),
@@ -352,12 +430,8 @@ async fn call_replace_processor(state: &AppState, arguments: Value) -> Value {
         requested_name: request.requested_name,
         processor_type_name: request.processor_type_name,
     };
-    match crate::ops::replace_processor_source(
-        &state.runtime,
-        &request.target_session_module,
-        replacement,
-    )
-    .await
+    match crate::ops::replace_processor_source(runtime, &request.target_session_module, replacement)
+        .await
     {
         Ok(outcome) => tool_ok(submitted_source_json(outcome)),
         Err(ReplaceSourceError::MalformedTargetModule(message)) => tool_error(message),
@@ -365,7 +439,7 @@ async fn call_replace_processor(state: &AppState, arguments: Value) -> Value {
     }
 }
 
-async fn call_remove_processor(state: &AppState, arguments: Value) -> Value {
+async fn call_remove_processor(runtime: &Arc<dyn RuntimeOperations>, arguments: Value) -> Value {
     #[derive(Deserialize)]
     struct RemoveArgs {
         processor_id: String,
@@ -374,8 +448,7 @@ async fn call_remove_processor(state: &AppState, arguments: Value) -> Value {
         Ok(args) => args,
         Err(e) => return tool_error(format!("remove_processor arguments: {e}")),
     };
-    match state
-        .runtime
+    match runtime
         .remove_processor_async(processor_id.clone().into())
         .await
     {
@@ -384,20 +457,20 @@ async fn call_remove_processor(state: &AppState, arguments: Value) -> Value {
     }
 }
 
-async fn call_connect(state: &AppState, arguments: Value) -> Value {
+async fn call_connect(runtime: &Arc<dyn RuntimeOperations>, arguments: Value) -> Value {
     let request: CreateConnectionRequest = match serde_json::from_value(arguments) {
         Ok(request) => request,
         Err(e) => return tool_error(format!("connect arguments: {e}")),
     };
     let from = OutputLinkPortRef::new(request.from_processor, request.from_port);
     let to = InputLinkPortRef::new(request.to_processor, request.to_port);
-    match state.runtime.connect_async(from, to).await {
+    match runtime.connect_async(from, to).await {
         Ok(link_id) => tool_ok(json!({ "link_id": link_id.to_string() })),
         Err(e) => tool_error(format!("connect failed: {e}")),
     }
 }
 
-async fn call_tap(state: &AppState, arguments: Value) -> Value {
+async fn call_tap(runtime: &Arc<dyn RuntimeOperations>, arguments: Value) -> Value {
     #[derive(Deserialize)]
     struct TapArgs {
         channel: String,
@@ -410,7 +483,7 @@ async fn call_tap(state: &AppState, arguments: Value) -> Value {
     };
     let sample = bounded_sample_count(count, DEFAULT_TAP_SAMPLE_COUNT);
 
-    let mut subscription = match state.runtime.tap_async(channel.clone(), Some(sample)).await {
+    let mut subscription = match runtime.tap_async(channel.clone(), Some(sample)).await {
         Ok(subscription) => subscription,
         Err(e) => return tool_error(format!("tap attach failed: {e}")),
     };
@@ -443,8 +516,8 @@ async fn call_tap(state: &AppState, arguments: Value) -> Value {
     }))
 }
 
-async fn call_logs(state: &AppState, arguments: Value) -> Value {
-    let _ = state;
+async fn call_logs(runtime: &Arc<dyn RuntimeOperations>, arguments: Value) -> Value {
+    let _ = runtime;
     #[derive(Deserialize)]
     struct LogsArgs {
         #[serde(default)]
@@ -1215,5 +1288,161 @@ mod tests {
             "recorded target module = {}",
             recorded[0]
         );
+    }
+
+    /// Drive [`serve_stdio_jsonrpc`] over an in-memory pipe — the same
+    /// transport-free surface the `streamlib mcp` CLI hosts over the process's
+    /// stdio — feeding newline-delimited request lines and collecting the
+    /// response lines. Reuses [`RecordingStubRuntime`], so it is hermetic (no
+    /// live engine / rig) and runs in CI. Returns the responses in arrival
+    /// order plus the stub's recorded-source handle for a submit assertion.
+    async fn drive_stdio(request_lines: &[Value]) -> (Vec<Value>, Arc<Mutex<Option<String>>>) {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+        let runtime = Arc::new(RecordingStubRuntime::new());
+        let recorded_source = runtime.last_submitted_source.clone();
+        let runtime: Arc<dyn RuntimeOperations> = runtime;
+
+        // One duplex carries request lines client→server, the other carries
+        // response lines server→client; each duplex is a one-way byte pipe.
+        let (mut client_writer, server_reader) = tokio::io::duplex(64 * 1024);
+        let (server_writer, client_reader) = tokio::io::duplex(64 * 1024);
+
+        let server = tokio::spawn(async move {
+            serve_stdio_jsonrpc(runtime, BufReader::new(server_reader), server_writer)
+                .await
+                .expect("stdio server loop");
+        });
+
+        let mut request_bytes = Vec::new();
+        for line in request_lines {
+            request_bytes.extend_from_slice(line.to_string().as_bytes());
+            request_bytes.push(b'\n');
+        }
+        client_writer
+            .write_all(&request_bytes)
+            .await
+            .expect("write request lines");
+        // Drop the request writer so the server loop sees EOF and finishes.
+        drop(client_writer);
+
+        let mut responses = Vec::new();
+        let mut lines = BufReader::new(client_reader).lines();
+        while let Some(line) = lines.next_line().await.expect("read response line") {
+            if line.trim().is_empty() {
+                continue;
+            }
+            responses.push(serde_json::from_str::<Value>(&line).expect("response line is JSON"));
+        }
+        server.await.expect("stdio server task");
+        (responses, recorded_source)
+    }
+
+    #[tokio::test]
+    async fn stdio_server_handshakes_lists_all_tools_and_submits_over_a_pipe() {
+        let (responses, recorded_source) = drive_stdio(&[
+            json!({
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": { "protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": { "name": "test", "version": "0" } }
+            }),
+            // A notification carries no id and must produce no response line.
+            json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }),
+            json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list" }),
+            json!({
+                "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+                "params": {
+                    "name": "submit_processor",
+                    "arguments": {
+                        "language": "python",
+                        "source": "class Widget:\n    pass\n",
+                        "requested_name": "widget"
+                    }
+                }
+            }),
+        ])
+        .await;
+
+        assert_eq!(
+            responses.len(),
+            3,
+            "three requests carry ids; the notification yields no line — got {responses:?}"
+        );
+
+        let initialize = &responses[0];
+        assert_eq!(initialize["id"], 1);
+        assert_eq!(initialize["result"]["protocolVersion"], "2025-06-18");
+        assert_eq!(
+            initialize["result"]["serverInfo"]["name"],
+            "streamlib-api-server"
+        );
+
+        let tools_list = &responses[1];
+        assert_eq!(tools_list["id"], 2);
+        let names: Vec<&str> = tools_list["result"]["tools"]
+            .as_array()
+            .expect("tools array")
+            .iter()
+            .filter_map(|tool| tool["name"].as_str())
+            .collect();
+        for expected in [
+            "graph",
+            "submit_processor",
+            "replace_processor",
+            "remove_processor",
+            "connect",
+            "tap",
+            "logs",
+        ] {
+            assert!(
+                names.contains(&expected),
+                "stdio tools/list must advertise `{expected}`, got {names:?}"
+            );
+        }
+
+        let submit = &responses[2];
+        assert_eq!(submit["id"], 3);
+        assert_eq!(submit["result"]["isError"], false, "submit={submit}");
+        let text = submit["result"]["content"][0]["text"]
+            .as_str()
+            .expect("submit result text content block");
+        let outcome: Value = serde_json::from_str(text).expect("submit text is JSON");
+        assert_eq!(outcome["module"], "@session/widget@=0.0.0");
+        assert_eq!(outcome["processor_id"], "mcp-instance");
+        assert_eq!(
+            recorded_source.lock().as_deref(),
+            Some("class Widget:\n    pass\n"),
+            "the submitted source must have reached the stub through the stdio dispatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn stdio_server_answers_a_malformed_line_with_a_parse_error() {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+        let runtime: Arc<dyn RuntimeOperations> = Arc::new(RecordingStubRuntime::new());
+        let (mut client_writer, server_reader) = tokio::io::duplex(4096);
+        let (server_writer, client_reader) = tokio::io::duplex(4096);
+        let server = tokio::spawn(async move {
+            serve_stdio_jsonrpc(runtime, BufReader::new(server_reader), server_writer)
+                .await
+                .expect("stdio server loop");
+        });
+
+        client_writer
+            .write_all(b"this is not json\n")
+            .await
+            .expect("write malformed line");
+        drop(client_writer);
+
+        let mut lines = BufReader::new(client_reader).lines();
+        let response = lines
+            .next_line()
+            .await
+            .expect("read line")
+            .expect("a malformed line must still get a parse-error response line");
+        let response: Value = serde_json::from_str(&response).expect("response is JSON");
+        assert_eq!(response["error"]["code"], -32700);
+        assert!(response["id"].is_null());
+        server.await.expect("stdio server task");
     }
 }

--- a/packages/api-server/src/mcp.rs
+++ b/packages/api-server/src/mcp.rs
@@ -93,7 +93,7 @@ const TAP_SAMPLE_WINDOW: Duration = Duration::from_millis(500);
 /// is dispatched for effect with no reply (HTTP acks it `202 Accepted`; stdio
 /// writes no response line).
 #[derive(Deserialize)]
-pub struct JsonRpcRequest {
+pub(crate) struct JsonRpcRequest {
     #[serde(default)]
     id: Option<Value>,
     method: String,
@@ -134,7 +134,7 @@ pub(crate) async fn mcp_endpoint(
     State(state): State<AppState>,
     Json(request): Json<JsonRpcRequest>,
 ) -> Response {
-    match dispatch_jsonrpc(&state.runtime, request).await {
+    match dispatch_jsonrpc(&state.runtime, &request).await {
         Some(response) => Json(response).into_response(),
         None => StatusCode::ACCEPTED.into_response(),
     }
@@ -148,9 +148,9 @@ pub(crate) async fn mcp_endpoint(
 /// This is the single MCP surface both the HTTP endpoint and the stdio server
 /// call, so the two transports can never diverge.
 #[tracing::instrument(skip_all, fields(mcp_method = %request.method))]
-pub async fn dispatch_jsonrpc(
+pub(crate) async fn dispatch_jsonrpc(
     runtime: &Arc<dyn RuntimeOperations>,
-    request: JsonRpcRequest,
+    request: &JsonRpcRequest,
 ) -> Option<Value> {
     let id = request.id.clone()?;
     let params = request.params.clone().unwrap_or(Value::Null);
@@ -172,13 +172,13 @@ pub async fn dispatch_jsonrpc(
 /// Parse one newline-delimited JSON-RPC 2.0 request line into a
 /// [`JsonRpcRequest`]. A malformed line is a JSON-RPC *parse error* — render it
 /// with [`jsonrpc_parse_error`] rather than dropping the input silently.
-pub fn parse_jsonrpc_request(line: &str) -> serde_json::Result<JsonRpcRequest> {
+pub(crate) fn parse_jsonrpc_request(line: &str) -> serde_json::Result<JsonRpcRequest> {
     serde_json::from_str(line)
 }
 
 /// The JSON-RPC 2.0 envelope for a line that could not be parsed as a request
 /// (`-32700 Parse error`), with a null `id` since none could be recovered.
-pub fn jsonrpc_parse_error(message: &str) -> Value {
+pub(crate) fn jsonrpc_parse_error(message: &str) -> Value {
     json!({
         "jsonrpc": "2.0",
         "id": Value::Null,
@@ -213,11 +213,14 @@ where
             continue;
         }
         let response = match parse_jsonrpc_request(&line) {
-            Ok(request) => dispatch_jsonrpc(&runtime, request).await,
+            Ok(request) => dispatch_jsonrpc(&runtime, &request).await,
             Err(error) => Some(jsonrpc_parse_error(&error.to_string())),
         };
         if let Some(response) = response {
-            let mut encoded = serde_json::to_vec(&response).unwrap_or_else(|_| b"null".to_vec());
+            // `response` is an already-constructed `serde_json::Value`, whose
+            // serialization is infallible.
+            let mut encoded =
+                serde_json::to_vec(&response).expect("a serde_json::Value always serializes");
             encoded.push(b'\n');
             writer.write_all(&encoded).await?;
             writer.flush().await?;

--- a/runtime/streamlib-engine/benches/logging.rs
+++ b/runtime/streamlib-engine/benches/logging.rs
@@ -34,8 +34,8 @@ use tracing::subscriber::{DefaultGuard, NoSubscriber};
 
 use streamlib_engine::core::runtime::RuntimeUniqueId;
 use streamlib_engine::logging::{
-    LogLevel, LoggingTunables, RuntimeLogEvent, StreamlibLoggingConfig, StreamlibLoggingGuard,
-    init_for_tests,
+    LogLevel, LoggingTunables, PrettyMirrorStream, RuntimeLogEvent, StreamlibLoggingConfig,
+    StreamlibLoggingGuard, init_for_tests,
 };
 
 fn install_pathway(tmp: &TempDir, runtime_id: &str) -> StreamlibLoggingGuard {
@@ -49,6 +49,7 @@ fn install_pathway(tmp: &TempDir, runtime_id: &str) -> StreamlibLoggingGuard {
         service_name: "bench".into(),
         runtime_id: Some(runtime_id),
         stdout: false,
+        pretty_mirror_stream: PrettyMirrorStream::Stdout,
         jsonl: true,
         intercept_stdio: false,
         tunables: LoggingTunables {
@@ -191,6 +192,7 @@ fn bench_burst_drops_surface(c: &mut Criterion) {
                     service_name: "bench".into(),
                     runtime_id: Some(Arc::clone(&runtime_id)),
                     stdout: false,
+                    pretty_mirror_stream: PrettyMirrorStream::Stdout,
                     jsonl: true,
                     intercept_stdio: false,
                     tunables: LoggingTunables {

--- a/runtime/streamlib-engine/src/core/logging/config.rs
+++ b/runtime/streamlib-engine/src/core/logging/config.rs
@@ -26,6 +26,19 @@ const DEFAULT_BATCH_BYTES: usize = 64 * 1024;
 const DEFAULT_BATCH_MS: u64 = 100;
 const DEFAULT_CHANNEL_CAPACITY: usize = 65_536;
 
+/// Which process stream the pretty mirror is written to. Defaults to
+/// [`Stdout`](PrettyMirrorStream::Stdout) for human-facing invocations;
+/// [`Stderr`](PrettyMirrorStream::Stderr) keeps fd 1 a pure protocol channel
+/// for a subcommand that speaks a byte protocol on stdout (the `streamlib mcp`
+/// stdio transport requires stdout carry only MCP JSON-RPC frames).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrettyMirrorStream {
+    /// Mirror to fd 1 (`std::io::stdout`).
+    Stdout,
+    /// Mirror to fd 2 (`std::io::stderr`), leaving stdout uncontaminated.
+    Stderr,
+}
+
 /// Configuration passed to [`init`](super::init).
 #[derive(Debug, Clone)]
 pub struct StreamlibLoggingConfig {
@@ -37,9 +50,13 @@ pub struct StreamlibLoggingConfig {
     /// lived CLI invocations that only want env-filtered tracing).
     pub runtime_id: Option<Arc<RuntimeUniqueId>>,
 
-    /// Enable the line-buffered pretty stdout mirror. Overridden to
+    /// Enable the line-buffered pretty mirror. Overridden to
     /// `false` when `STREAMLIB_QUIET=1` is set.
     pub stdout: bool,
+
+    /// Which process stream the pretty mirror writes to. `Stdout` for a
+    /// human-facing CLI; `Stderr` when stdout is a protocol channel.
+    pub pretty_mirror_stream: PrettyMirrorStream,
 
     /// Enable the batched JSONL file writer. Requires `runtime_id` to be
     /// set; silently disabled when `runtime_id == None`.
@@ -105,9 +122,22 @@ impl StreamlibLoggingConfig {
             service_name: service_name.into(),
             runtime_id: None,
             stdout: true,
+            pretty_mirror_stream: PrettyMirrorStream::Stdout,
             jsonl: false,
             intercept_stdio: false,
             tunables: LoggingTunables::default(),
+        }
+    }
+
+    /// Config for a CLI subcommand that speaks a byte protocol on stdout (the
+    /// `streamlib mcp` stdio transport): identical to [`for_cli`](Self::for_cli)
+    /// but the pretty mirror is routed to stderr so fd 1 carries only protocol
+    /// frames. Interception stays off — it would redirect fd 1 out from under
+    /// the protocol writer.
+    pub fn for_stdio_protocol(service_name: impl Into<String>) -> Self {
+        Self {
+            pretty_mirror_stream: PrettyMirrorStream::Stderr,
+            ..Self::for_cli(service_name)
         }
     }
 
@@ -120,6 +150,7 @@ impl StreamlibLoggingConfig {
             service_name: service_name.into(),
             runtime_id: Some(runtime_id),
             stdout: true,
+            pretty_mirror_stream: PrettyMirrorStream::Stdout,
             jsonl: true,
             intercept_stdio: true,
             tunables: LoggingTunables::default(),

--- a/runtime/streamlib-engine/src/core/logging/init.rs
+++ b/runtime/streamlib-engine/src/core/logging/init.rs
@@ -16,7 +16,7 @@ use tracing::Dispatch;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::{EnvFilter, Registry};
 
-use crate::core::logging::config::{ResolvedTunables, StreamlibLoggingConfig};
+use crate::core::logging::config::{PrettyMirrorStream, ResolvedTunables, StreamlibLoggingConfig};
 use crate::core::logging::event::Source;
 use crate::core::logging::layer::JsonlSinkLayer;
 use crate::core::logging::paths::runtime_log_path;
@@ -247,10 +247,17 @@ fn build_components(config: StreamlibLoggingConfig) -> Result<(Dispatch, Streaml
 
     let stdout_sink: Option<Box<dyn std::io::Write + Send>> = if !stdout_enabled {
         None
-    } else if let Some(file) = real_stdout_file.take() {
-        Some(Box::new(file))
     } else {
-        Some(Box::new(std::io::stdout()))
+        match config.pretty_mirror_stream {
+            // fd 2 keeps fd 1 a pure protocol channel (the `streamlib mcp`
+            // stdio transport). The dup'd real-stdout handle from the
+            // interceptor is never claimed here, so it drops and closes cleanly.
+            PrettyMirrorStream::Stderr => Some(Box::new(std::io::stderr())),
+            PrettyMirrorStream::Stdout => match real_stdout_file.take() {
+                Some(file) => Some(Box::new(file)),
+                None => Some(Box::new(std::io::stdout())),
+            },
+        }
     };
 
     let worker = spawn_worker(WorkerConfig {

--- a/runtime/streamlib-engine/src/core/logging/mod.rs
+++ b/runtime/streamlib-engine/src/core/logging/mod.rs
@@ -7,7 +7,7 @@
 //! See `docs/logging-schema.md` for the JSONL schema (the durable
 //! interface contract) and `CLAUDE.md` for the engine-model framing.
 
-pub use config::{LoggingTunables, StreamlibLoggingConfig};
+pub use config::{LoggingTunables, PrettyMirrorStream, StreamlibLoggingConfig};
 pub use event::{LogLevel, RuntimeLogEvent, SCHEMA_VERSION, Source};
 pub use init::{StreamlibLoggingGuard, init, init_for_tests};
 pub use paths::{log_dir, runtime_log_path};

--- a/runtime/streamlib-engine/src/core/logging/tests.rs
+++ b/runtime/streamlib-engine/src/core/logging/tests.rs
@@ -13,7 +13,7 @@ use serial_test::serial;
 use tempfile::TempDir;
 
 use crate::core::logging::{
-    LoggingTunables, StreamlibLoggingConfig,
+    LoggingTunables, PrettyMirrorStream, StreamlibLoggingConfig,
     event::{LogLevel, RuntimeLogEvent, SCHEMA_VERSION, Source},
     init::init_for_tests,
     paths::{log_dir, runtime_log_path},
@@ -154,6 +154,7 @@ fn time_triggered_flush_writes_without_size_trigger() {
         service_name: "test".into(),
         runtime_id: Some(Arc::clone(&runtime_id)),
         stdout: false,
+        pretty_mirror_stream: PrettyMirrorStream::Stdout,
         jsonl: true,
         intercept_stdio: false,
         tunables: LoggingTunables {
@@ -261,6 +262,7 @@ fn panic_hook_best_effort_flush() {
         service_name: "test".into(),
         runtime_id: Some(Arc::clone(&runtime_id)),
         stdout: false,
+        pretty_mirror_stream: PrettyMirrorStream::Stdout,
         jsonl: true,
         intercept_stdio: false,
         tunables: LoggingTunables {
@@ -306,6 +308,7 @@ fn hot_path_is_not_blocked_on_io() {
         service_name: "test".into(),
         runtime_id: Some(Arc::clone(&runtime_id)),
         stdout: false,
+        pretty_mirror_stream: PrettyMirrorStream::Stdout,
         jsonl: true,
         intercept_stdio: false,
         tunables: LoggingTunables {
@@ -363,6 +366,7 @@ fn rust_println_captured_via_fd_redirect() {
         service_name: "test".into(),
         runtime_id: Some(Arc::clone(&runtime_id)),
         stdout: false,
+        pretty_mirror_stream: PrettyMirrorStream::Stdout,
         jsonl: true,
         intercept_stdio: true,
         tunables: LoggingTunables::default(),
@@ -411,6 +415,7 @@ fn rust_c_printf_via_libc_captured() {
         service_name: "test".into(),
         runtime_id: Some(Arc::clone(&runtime_id)),
         stdout: false,
+        pretty_mirror_stream: PrettyMirrorStream::Stdout,
         jsonl: true,
         intercept_stdio: true,
         tunables: LoggingTunables::default(),
@@ -461,6 +466,7 @@ fn intercept_stdio_off_in_tests() {
         service_name: "test".into(),
         runtime_id: Some(Arc::clone(&runtime_id)),
         stdout: false,
+        pretty_mirror_stream: PrettyMirrorStream::Stdout,
         jsonl: true,
         intercept_stdio: false,
         tunables: LoggingTunables::default(),
@@ -507,6 +513,7 @@ fn intercepted_fd2_uses_channel_fd2() {
         service_name: "test".into(),
         runtime_id: Some(Arc::clone(&runtime_id)),
         stdout: false,
+        pretty_mirror_stream: PrettyMirrorStream::Stdout,
         jsonl: true,
         intercept_stdio: true,
         tunables: LoggingTunables::default(),
@@ -559,6 +566,7 @@ fn no_redirect_loop_when_mirror_enabled() {
         service_name: "test".into(),
         runtime_id: Some(Arc::clone(&runtime_id)),
         stdout: true,
+        pretty_mirror_stream: PrettyMirrorStream::Stdout,
         jsonl: true,
         intercept_stdio: true,
         tunables: LoggingTunables::default(),
@@ -609,6 +617,7 @@ fn reader_thread_shuts_down_on_runtime_drop() {
         service_name: "test".into(),
         runtime_id: Some(Arc::clone(&runtime_id)),
         stdout: false,
+        pretty_mirror_stream: PrettyMirrorStream::Stdout,
         jsonl: true,
         intercept_stdio: true,
         tunables: LoggingTunables::default(),
@@ -845,6 +854,7 @@ fn burst_surfaces_dropped_counter_record() {
         service_name: "test".into(),
         runtime_id: Some(Arc::clone(&runtime_id)),
         stdout: false,
+        pretty_mirror_stream: PrettyMirrorStream::Stdout,
         jsonl: true,
         intercept_stdio: false,
         tunables: LoggingTunables {

--- a/runtime/streamlib-engine/tests/bin/log_emit_1000.rs
+++ b/runtime/streamlib-engine/tests/bin/log_emit_1000.rs
@@ -18,7 +18,9 @@
 use std::sync::Arc;
 
 use streamlib_engine::core::runtime::RuntimeUniqueId;
-use streamlib_engine::logging::{LoggingTunables, StreamlibLoggingConfig, init_for_tests};
+use streamlib_engine::logging::{
+    LoggingTunables, PrettyMirrorStream, StreamlibLoggingConfig, init_for_tests,
+};
 
 fn raw_write_stdout(bytes: &[u8]) {
     unsafe {
@@ -57,6 +59,7 @@ fn main() {
         service_name: "log_emit_1000".into(),
         runtime_id: Some(runtime_id),
         stdout: false,
+        pretty_mirror_stream: PrettyMirrorStream::Stdout,
         jsonl: true,
         intercept_stdio: false,
         tunables: LoggingTunables {

--- a/tools/streamlib-cli/Cargo.toml
+++ b/tools/streamlib-cli/Cargo.toml
@@ -31,6 +31,12 @@ streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.7.41" }
 streamlib-cargo-build = { path = "../streamlib-cargo-build", version = "0.7.41" }
 streamlib-pack = { path = "../streamlib-pack", version = "0.7.41" }
 
+# Host-side control plane: the CLI's `mcp` subcommand hosts the api-server's
+# transport-free MCP dispatch (`serve_stdio_jsonrpc`) over stdio, reusing the
+# one dispatch surface `POST /mcp` uses. Path-only (api-server is `publish =
+# false`, never in the registry closure).
+streamlib-api-server = { path = "../../packages/api-server" }
+
 # JTD-codegen pipeline (drives `streamlib generate`)
 streamlib-jtd-codegen = { path = "../../sdk/streamlib-jtd-codegen", version = "0.7.41" }
 
@@ -59,6 +65,11 @@ thiserror.workspace = true
 
 # Load .env files for development environment
 dotenvy = "0.15"
+
+# Blocking HTTP client for `streamlib mcp --attach <url>`: forwards each stdio
+# JSON-RPC line to a running runtime's `POST /mcp`. Blocking by design — the
+# attach loop runs on `spawn_blocking`, off the tokio runtime.
+ureq.workspace = true
 
 # Logging
 tracing.workspace = true

--- a/tools/streamlib-cli/src/commands/mcp.rs
+++ b/tools/streamlib-cli/src/commands/mcp.rs
@@ -1,0 +1,107 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib mcp` — speak the Model Context Protocol over stdio so any MCP host
+//! (`claude mcp add streamlib -- streamlib mcp`) can spawn StreamLib's
+//! agent-operable tools with zero port/daemon juggling.
+//!
+//! Two modes, both hosting the api-server's one transport-free MCP dispatch
+//! ([`streamlib_api_server::serve_stdio_jsonrpc`]) — never a parallel MCP impl:
+//!
+//! - **Default (in-process):** build a fresh live [`Runner`] and serve its MCP
+//!   over the process's stdio; the host gets an operable runtime with no setup.
+//!   Torn down when the host closes stdin (EOF).
+//! - **`--attach <url>`:** forward each stdio JSON-RPC line to a running
+//!   runtime's `POST /mcp`, to operate an existing live pipeline; no local
+//!   Runner is built.
+//!
+//! Auth is a no-op on the in-process path by construction (a local child
+//! process, no bearer header); only `--attach` may forward a token
+//! (`STREAMLIB_MCP_TOKEN`) to the remote endpoint.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use streamlib::sdk::RunnerAutoBuild;
+use streamlib::sdk::runtime::{Runner, RuntimeOperations};
+
+/// Run the `mcp` subcommand. `attach` selects the bridge-to-remote mode; its
+/// absence is the in-process default.
+pub async fn run(attach: Option<String>) -> Result<()> {
+    match attach {
+        Some(url) => attach_to_remote(url).await,
+        None => serve_in_process().await,
+    }
+}
+
+/// Build a live in-process runtime and serve MCP over stdio against it. The
+/// runtime is started before the loop and stopped on stdin EOF (the host
+/// closing the pipe). Needs the runtime rig (GPU/iceoryx2) — an MCP host spawns
+/// this in the user's environment, so it has the rig.
+async fn serve_in_process() -> Result<()> {
+    let runner = Runner::with_auto_build()?;
+    runner.start()?;
+
+    let runtime: Arc<dyn RuntimeOperations> = runner.clone();
+    let served = streamlib_api_server::serve_stdio_jsonrpc(
+        runtime,
+        tokio::io::BufReader::new(tokio::io::stdin()),
+        tokio::io::stdout(),
+    )
+    .await;
+
+    // Tear the runtime down regardless of how the loop ended, then surface any
+    // transport error.
+    if let Err(stop_error) = runner.stop() {
+        tracing::warn!("runtime stop after MCP stdio EOF failed: {stop_error}");
+    }
+    served?;
+    Ok(())
+}
+
+/// Bridge stdio ↔ a running runtime's `POST /mcp`: each inbound JSON-RPC line is
+/// POSTed to the remote endpoint and the response body (if any) written back as
+/// a line. Runs the whole blocking bridge on a blocking thread so the tokio
+/// runtime is never parked on `ureq` I/O.
+async fn attach_to_remote(url: String) -> Result<()> {
+    tokio::task::spawn_blocking(move || attach_to_remote_blocking(&url)).await?
+}
+
+fn attach_to_remote_blocking(url: &str) -> Result<()> {
+    use std::io::{BufRead, Write};
+
+    let endpoint = format!("{}/mcp", url.trim_end_matches('/'));
+    let bearer_token = std::env::var("STREAMLIB_MCP_TOKEN").ok();
+
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+
+    for line in stdin.lock().lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let mut request = ureq::post(&endpoint).set("content-type", "application/json");
+        if let Some(bearer_token) = &bearer_token {
+            request = request.set("authorization", &format!("Bearer {bearer_token}"));
+        }
+        match request.send_string(&line) {
+            // 2xx: a request answers `200` with the JSON-RPC envelope; a
+            // notification answers `202` with an empty body → no response line.
+            Ok(response) => {
+                let body = response.into_string()?;
+                if !body.trim().is_empty() {
+                    writeln!(stdout, "{body}")?;
+                    stdout.flush()?;
+                }
+            }
+            Err(ureq::Error::Status(code, response)) => {
+                let body = response.into_string().unwrap_or_default();
+                anyhow::bail!("attach POST {endpoint} failed: HTTP {code}: {body}");
+            }
+            Err(error) => anyhow::bail!("attach POST {endpoint} transport error: {error}"),
+        }
+    }
+    Ok(())
+}

--- a/tools/streamlib-cli/src/commands/mcp.rs
+++ b/tools/streamlib-cli/src/commands/mcp.rs
@@ -68,22 +68,34 @@ async fn attach_to_remote(url: String) -> Result<()> {
 }
 
 fn attach_to_remote_blocking(url: &str) -> Result<()> {
-    use std::io::{BufRead, Write};
-
-    let endpoint = format!("{}/mcp", url.trim_end_matches('/'));
     let bearer_token = std::env::var("STREAMLIB_MCP_TOKEN").ok();
-
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();
-    let mut stdout = stdout.lock();
+    bridge_stdio_to_remote(url, bearer_token.as_deref(), stdin.lock(), stdout.lock())
+}
 
-    for line in stdin.lock().lines() {
+/// Forward each newline-delimited JSON-RPC line from `reader` to `{url}/mcp`,
+/// writing each non-empty response body back to `writer` as a line. A 2xx with
+/// an empty body (a notification's `202`) yields no output line; a non-2xx
+/// surfaces an error. `bearer_token`, when set, rides as an `authorization:
+/// Bearer` header. Generic over the byte transport so the CLI wires the process
+/// stdio while a test drives an in-memory pipe — mirroring
+/// [`streamlib_api_server::serve_stdio_jsonrpc`].
+fn bridge_stdio_to_remote(
+    url: &str,
+    bearer_token: Option<&str>,
+    reader: impl std::io::BufRead,
+    mut writer: impl std::io::Write,
+) -> Result<()> {
+    let endpoint = format!("{}/mcp", url.trim_end_matches('/'));
+
+    for line in reader.lines() {
         let line = line?;
         if line.trim().is_empty() {
             continue;
         }
         let mut request = ureq::post(&endpoint).set("content-type", "application/json");
-        if let Some(bearer_token) = &bearer_token {
+        if let Some(bearer_token) = bearer_token {
             request = request.set("authorization", &format!("Bearer {bearer_token}"));
         }
         match request.send_string(&line) {
@@ -92,8 +104,8 @@ fn attach_to_remote_blocking(url: &str) -> Result<()> {
             Ok(response) => {
                 let body = response.into_string()?;
                 if !body.trim().is_empty() {
-                    writeln!(stdout, "{body}")?;
-                    stdout.flush()?;
+                    writeln!(writer, "{body}")?;
+                    writer.flush()?;
                 }
             }
             Err(ureq::Error::Status(code, response)) => {
@@ -104,4 +116,171 @@ fn attach_to_remote_blocking(url: &str) -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    //! Hermetic tests for the `--attach` stdio→HTTP bridge: a local TCP server
+    //! stands in for a running runtime's `POST /mcp`, so the forward loop,
+    //! notification handling, bearer forwarding, and error surfacing are
+    //! exercised without a live runtime. The bridge reads an in-memory pipe
+    //! (not the process stdio) via the [`bridge_stdio_to_remote`] seam.
+
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::{Arc, Mutex};
+    use std::thread::JoinHandle;
+
+    use super::*;
+
+    /// One request as the mock server observed it.
+    struct RecordedRequest {
+        authorization: Option<String>,
+        body: String,
+    }
+
+    /// A canned HTTP reply for one request.
+    struct MockReply {
+        status_line: &'static str,
+        body: &'static str,
+    }
+
+    type RecordedRequests = Arc<Mutex<Vec<RecordedRequest>>>;
+
+    /// Spin a local HTTP server that answers `replies.len()` requests in order,
+    /// recording each request's `authorization` header and body. Binds on port
+    /// 0 and returns the resolved base URL, the recording handle, and the
+    /// server thread's join handle.
+    fn spawn_mock_mcp_server(
+        replies: Vec<MockReply>,
+    ) -> (String, RecordedRequests, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock mcp server");
+        let url = format!("http://{}", listener.local_addr().expect("local addr"));
+        let recorded: RecordedRequests = Arc::new(Mutex::new(Vec::new()));
+        let recorded_for_thread = recorded.clone();
+        let handle = std::thread::spawn(move || {
+            for reply in replies {
+                let (mut stream, _) = listener.accept().expect("accept");
+                let request = read_http_request(&stream);
+                recorded_for_thread.lock().unwrap().push(request);
+                let response = format!(
+                    "HTTP/1.1 {}\r\nContent-Length: {}\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{}",
+                    reply.status_line,
+                    reply.body.len(),
+                    reply.body,
+                );
+                stream.write_all(response.as_bytes()).expect("write response");
+                stream.flush().ok();
+            }
+        });
+        (url, recorded, handle)
+    }
+
+    /// Parse one HTTP/1.1 request off `stream`: capture the `authorization`
+    /// header, then read exactly `content-length` body bytes.
+    fn read_http_request(stream: &TcpStream) -> RecordedRequest {
+        let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+        let mut request_line = String::new();
+        reader.read_line(&mut request_line).expect("request line");
+
+        let mut authorization = None;
+        let mut content_length = 0usize;
+        loop {
+            let mut header = String::new();
+            reader.read_line(&mut header).expect("header line");
+            let header = header.trim_end();
+            if header.is_empty() {
+                break;
+            }
+            let (name, value) = header.split_once(':').unwrap_or((header, ""));
+            match name.trim().to_ascii_lowercase().as_str() {
+                "authorization" => authorization = Some(value.trim().to_string()),
+                "content-length" => content_length = value.trim().parse().unwrap_or(0),
+                _ => {}
+            }
+        }
+
+        let mut body = vec![0u8; content_length];
+        reader.read_exact(&mut body).expect("read body");
+        RecordedRequest {
+            authorization,
+            body: String::from_utf8(body).expect("utf8 body"),
+        }
+    }
+
+    #[test]
+    fn attach_bridge_round_trips_a_request_line() {
+        let reply_body = r#"{"jsonrpc":"2.0","id":1,"result":{}}"#;
+        let (url, recorded, server) = spawn_mock_mcp_server(vec![MockReply {
+            status_line: "200 OK",
+            body: reply_body,
+        }]);
+
+        let input: &[u8] = b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}\n";
+        let mut output = Vec::new();
+        bridge_stdio_to_remote(&url, None, input, &mut output).expect("bridge");
+        server.join().unwrap();
+
+        assert_eq!(String::from_utf8(output).unwrap().trim(), reply_body);
+        let recorded = recorded.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert!(recorded[0].body.contains("\"method\":\"ping\""));
+        assert_eq!(recorded[0].authorization, None);
+    }
+
+    #[test]
+    fn attach_bridge_writes_no_line_for_a_notification_202() {
+        let (url, _recorded, server) = spawn_mock_mcp_server(vec![MockReply {
+            status_line: "202 Accepted",
+            body: "",
+        }]);
+
+        let input: &[u8] = b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n";
+        let mut output = Vec::new();
+        bridge_stdio_to_remote(&url, None, input, &mut output).expect("bridge");
+        server.join().unwrap();
+
+        assert!(
+            output.is_empty(),
+            "a 202 empty body must yield no response line"
+        );
+    }
+
+    #[test]
+    fn attach_bridge_forwards_the_bearer_token() {
+        let (url, recorded, server) = spawn_mock_mcp_server(vec![MockReply {
+            status_line: "200 OK",
+            body: "{}",
+        }]);
+
+        let input: &[u8] = b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}\n";
+        let mut output = Vec::new();
+        bridge_stdio_to_remote(&url, Some("secret-token"), input, &mut output).expect("bridge");
+        server.join().unwrap();
+
+        assert_eq!(
+            recorded.lock().unwrap()[0].authorization.as_deref(),
+            Some("Bearer secret-token"),
+            "STREAMLIB_MCP_TOKEN must ride as an authorization: Bearer header"
+        );
+    }
+
+    #[test]
+    fn attach_bridge_surfaces_a_non_2xx_as_an_error() {
+        let (url, _recorded, server) = spawn_mock_mcp_server(vec![MockReply {
+            status_line: "500 Internal Server Error",
+            body: "boom",
+        }]);
+
+        let input: &[u8] = b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}\n";
+        let mut output = Vec::new();
+        let result = bridge_stdio_to_remote(&url, None, input, &mut output);
+        server.join().unwrap();
+
+        let error = result.expect_err("a non-2xx must surface as an error");
+        assert!(
+            error.to_string().contains("500"),
+            "error must report the HTTP status; got: {error}"
+        );
+    }
 }

--- a/tools/streamlib-cli/src/commands/mod.rs
+++ b/tools/streamlib-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod generate;
 pub mod install;
 pub mod link;
 pub mod logs;
+pub mod mcp;
 pub mod pkg;
 pub mod schema;
 pub mod setup;

--- a/tools/streamlib-cli/src/main.rs
+++ b/tools/streamlib-cli/src/main.rs
@@ -66,6 +66,25 @@ enum Commands {
         since: Option<String>,
     },
 
+    /// Speak the Model Context Protocol over stdio so any MCP host can spawn
+    /// StreamLib's agent-operable tools (`claude mcp add streamlib -- streamlib
+    /// mcp`).
+    ///
+    /// Default (no `--attach`): host a fresh in-process runtime and serve its
+    /// MCP over stdio — zero-config; the host gets an operable runtime, torn
+    /// down when it closes stdin. `--attach <url>` instead bridges stdio to a
+    /// running runtime's `POST {url}/mcp` to operate an existing live pipeline.
+    /// Exposes the same 7 tools as `POST /mcp`: graph / submit_processor /
+    /// replace_processor / remove_processor / connect / tap / logs. Auth is off
+    /// by construction on the in-process path; `--attach` forwards a token from
+    /// `STREAMLIB_MCP_TOKEN` when set.
+    Mcp {
+        /// Bridge stdio to this running runtime's `POST {url}/mcp` instead of
+        /// hosting an in-process runtime.
+        #[arg(long, value_name = "URL")]
+        attach: Option<String>,
+    },
+
     /// Setup commands
     Setup {
         #[command(subcommand)]
@@ -355,6 +374,7 @@ async fn async_main(cli: Cli) -> Result<()> {
             })
             .await?
         }
+        Some(Commands::Mcp { attach }) => commands::mcp::run(attach).await?,
         Some(Commands::Setup { action }) => match action {
             SetupCommands::Shell { shell } => commands::setup::shell(shell.as_deref())?,
         },

--- a/tools/streamlib-cli/src/main.rs
+++ b/tools/streamlib-cli/src/main.rs
@@ -341,11 +341,20 @@ fn main() -> Result<()> {
         .block_on(async_main(cli))
 }
 
+/// The short-lived-CLI logging config for `command`. Every subcommand mirrors
+/// pretty logs to stdout except `mcp`, which speaks a byte protocol on stdout
+/// and so routes its mirror to stderr to keep fd 1 carrying only MCP JSON-RPC
+/// frames.
+fn logging_config_for(command: &Option<Commands>) -> streamlib::sdk::logging::StreamlibLoggingConfig {
+    if matches!(command, Some(Commands::Mcp { .. })) {
+        streamlib::sdk::logging::StreamlibLoggingConfig::for_stdio_protocol("streamlib-cli")
+    } else {
+        streamlib::sdk::logging::StreamlibLoggingConfig::for_cli("streamlib-cli")
+    }
+}
+
 async fn async_main(cli: Cli) -> Result<()> {
-    // Short-lived CLI invocation: stdout-only tracing, no JSONL file.
-    let _logging_guard = streamlib::sdk::logging::init(
-        streamlib::sdk::logging::StreamlibLoggingConfig::for_cli("streamlib-cli"),
-    )?;
+    let _logging_guard = streamlib::sdk::logging::init(logging_config_for(&cli.command))?;
 
     match cli.command {
         Some(Commands::Logs {
@@ -473,4 +482,33 @@ async fn async_main(cli: Cli) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use streamlib::sdk::logging::PrettyMirrorStream;
+
+    /// The `mcp` subcommand's stdio transport requires fd 1 carry only MCP
+    /// JSON-RPC frames — its pretty log mirror MUST route to stderr. Reverting
+    /// the mcp branch of [`logging_config_for`] (mirror back to stdout) goes red
+    /// here, catching a regression that would re-pollute the protocol stream.
+    #[test]
+    fn mcp_subcommand_mirrors_logs_to_stderr_not_stdout() {
+        let mcp = logging_config_for(&Some(Commands::Mcp { attach: None }));
+        assert_eq!(
+            mcp.pretty_mirror_stream,
+            PrettyMirrorStream::Stderr,
+            "mcp stdout is a protocol channel — the pretty mirror must go to stderr"
+        );
+    }
+
+    /// Every path other than `mcp` keeps the human-facing stdout mirror.
+    #[test]
+    fn non_mcp_invocation_mirrors_logs_to_stdout() {
+        assert_eq!(
+            logging_config_for(&None).pretty_mirror_stream,
+            PrettyMirrorStream::Stdout
+        );
+    }
 }


### PR DESCRIPTION
## What
`streamlib mcp` — a stdio MCP server so any MCP host (`claude mcp add streamlib -- streamlib mcp`) gets StreamLib's agent-operable tools natively: `graph` / `submit_processor` / `replace_processor` / `remove_processor` / `connect` / `tap` / `logs`.

Reuses #1429's MCP dispatch — extracted a transport-free `dispatch_jsonrpc` + `serve_stdio_jsonrpc` that **both** the HTTP `/mcp` endpoint and the new stdio server call (the HTTP path was repointed onto it; 38 pre-existing HTTP tests unchanged). Default mode hosts an in-process runtime; `--attach <url>` bridges to a running one. Auth token-optional / off by default.

## Verify-live (real hardware)
Built the CLI and drove `streamlib mcp` over a pipe with a real handshake:
```
stdin:  initialize → notifications/initialized → tools/list
stdout: 2 lines, BOTH pure JSON — initialize result + all 7 tools     (exit 0)
stderr: 66 runtime log lines (GPU/iceoryx2/setup)
```
stdout carries **only** MCP frames; **all logging is on stderr** — the MCP stdio contract. A real host parses it cleanly.

## Review history
verify-change caught a feature-breaking **blocker** the hermetic (in-memory duplex) tests structurally couldn't: logs + JSON-RPC were both on stdout. Fixed with a `for_stdio_protocol` logging mode that routes the pretty mirror to stderr (regression test locks it). Fix round also added 4 hermetic `--attach` bridge tests, made `dispatch_jsonrpc` borrow the request, and narrowed the crate's public surface.

## Follow-ups (non-blocking, noted)
- CLI now pulls api-server's dep closure (axum/utoipa); a lighter shared MCP-dispatch crate is a later carve-out if binary size matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
