### PR TITLE
chore: M38 follow-up cleanups (stale fixtures, dead cache/wheels mkdir, unhonored audio unsafe_send)

### DIFF
--- a/packages/audio/streamlib.yaml
+++ b/packages/audio/streamlib.yaml
@@ -30,7 +30,6 @@ processors:
   runtime:
     language: rust
     options:
-      unsafe_send: true
       python_version: null
     env: {}
   entrypoint: null
@@ -52,7 +51,6 @@ processors:
   runtime:
     language: rust
     options:
-      unsafe_send: true
       python_version: null
     env: {}
   entrypoint: null

--- a/runtime/streamlib-engine/src/core/streamlib_home.rs
+++ b/runtime/streamlib-engine/src/core/streamlib_home.rs
@@ -98,7 +98,6 @@ fn fallback_home() -> PathBuf {
 pub fn ensure_streamlib_home() -> std::io::Result<PathBuf> {
     let data = get_streamlib_data_dir();
 
-    std::fs::create_dir_all(data.join("cache/wheels"))?;
     std::fs::create_dir_all(data.join("cache/uv"))?;
     std::fs::create_dir_all(data.join("runtimes"))?;
 

--- a/tools/streamlib-cli/src/commands/add.rs
+++ b/tools/streamlib-cli/src/commands/add.rs
@@ -538,7 +538,7 @@ mod tests {
             &manifest_path,
             "# yaml-language-server: $schema=./schemas/streamlib.schema.json\n\
              package:\n  org: tatolab\n  name: widget\n  version: 0.1.0\n\
-             processors:\n- name: Widget\n  version: 1.0.0\n  runtime: rust\n  execution: reactive\n",
+             processors:\n- name: Widget\n  runtime: rust\n  execution: reactive\n",
         )
         .unwrap();
 
@@ -583,7 +583,6 @@ schemas:
     file: schemas/widget_config.yaml
 processors:
 - name: Widget
-  version: 1.0.0
   runtime: rust
   execution: reactive
 ";


### PR DESCRIPTION
M38 follow-up cleanups (#4 + #5 from the milestone wrap). Three independent, low-risk cleanups:

### 1. `test(cli)` — fix the red `record_dependency_range_*` fixtures
Both `record_dependency_range_writes_caret_and_preserves_fields` and `record_dependency_range_is_format_preserving` were failing locally with `processors[0]: unknown field \`version\`` — the test fixtures put a `version:` on a *processor*, which the schema rejects (processors have no version; the package carries it, from #1409/#1473 drift). Dropped the field; both now pass. (Local-only — CI doesn't run `-p streamlib-cli`.)

### 2. `chore(engine)` — remove the dead `.streamlib/cache/wheels` mkdir
`ensure_streamlib_home` created `<data>/cache/wheels`, but nothing creates or reads that path — the uv cache is `cache/uv` (`get_uv_cache_dir`), and per-package wheels live in the package tree. Dead since the wheel handling moved in-package.

### 3. `chore(packages)` — remove the unhonored `unsafe_send: true` from the audio manifest
Post-#1437 (ports-in-code) the `#[processor]` **code** attribute is the source of truth, and the audio code declares no `unsafe_send`; #1509 made `AudioCapture`/`AudioOutput` genuinely `Send` via thread-confinement, so the yaml flag was stale + misleading. **The `install-packages` CI gate compiles `audio`**, so a green run here verifies the processors are still `Send` without the override.

### Verification
- `cargo test -p streamlib-cli record_dependency_range` → 2 passed (was 2 failed).
- `cargo run -p xtask -- check-manifest-schema` → 57 manifests valid (audio without `unsafe_send`).
- streamlib-engine compiles (the CLI test builds it as a dep).
- CI `install-packages` gate is the backstop for the audio Send-ness (#3).
