### PR TITLE
feat(cli): control-client verbs over the running-node MCP seam

### DIFF
--- a/tools/streamlib-cli/src/commands/control.rs
+++ b/tools/streamlib-cli/src/commands/control.rs
@@ -21,7 +21,7 @@
 use std::io::{Read, Write};
 
 use anyhow::{Context, Result, bail};
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 
 /// POST one JSON-RPC request body to `{url}/mcp` and return the response body.
 /// A 2xx yields the body (empty for a `202` notification); a non-2xx or
@@ -77,28 +77,20 @@ pub fn submit(args: SubmitArgs) -> Result<()> {
         .map(|spec| parse_connect_spec(spec))
         .collect::<Result<Vec<_>>>()?;
 
-    let mut arguments = json!({
-        "language": args.language,
-        "source": source,
-        "config": config,
-    });
-    let map = arguments
-        .as_object_mut()
-        .expect("json! object literal is always an object");
-    if let Some(requested_name) = args.requested_name {
-        map.insert("requested_name".into(), Value::String(requested_name));
-    }
-    if let Some(processor_type_name) = args.processor_type_name {
-        map.insert(
-            "processor_type_name".into(),
-            Value::String(processor_type_name),
-        );
-    }
+    let mut arguments = Map::new();
+    arguments.insert("language".into(), Value::String(args.language));
+    arguments.insert("source".into(), Value::String(source));
+    arguments.insert("config".into(), config);
+    insert_optional_naming(
+        &mut arguments,
+        args.requested_name,
+        args.processor_type_name,
+    );
     if !connect.is_empty() {
-        map.insert("connect".into(), Value::Array(connect));
+        arguments.insert("connect".into(), Value::Array(connect));
     }
 
-    call_tool_to_stdout(&args.url, "submit_processor", arguments)
+    call_tool_to_stdout(&args.url, "submit_processor", Value::Object(arguments))
 }
 
 /// Arguments for the `replace` verb, mirroring the `replace_processor`
@@ -117,24 +109,19 @@ pub struct ReplaceArgs {
 /// in place.
 pub fn replace(args: ReplaceArgs) -> Result<()> {
     let source = read_source(args.source.as_deref())?;
-    let mut arguments = json!({
-        "target_session_module": args.target_session_module,
-        "language": args.language,
-        "source": source,
-    });
-    let map = arguments
-        .as_object_mut()
-        .expect("json! object literal is always an object");
-    if let Some(requested_name) = args.requested_name {
-        map.insert("requested_name".into(), Value::String(requested_name));
-    }
-    if let Some(processor_type_name) = args.processor_type_name {
-        map.insert(
-            "processor_type_name".into(),
-            Value::String(processor_type_name),
-        );
-    }
-    call_tool_to_stdout(&args.url, "replace_processor", arguments)
+    let mut arguments = Map::new();
+    arguments.insert(
+        "target_session_module".into(),
+        Value::String(args.target_session_module),
+    );
+    arguments.insert("language".into(), Value::String(args.language));
+    arguments.insert("source".into(), Value::String(source));
+    insert_optional_naming(
+        &mut arguments,
+        args.requested_name,
+        args.processor_type_name,
+    );
+    call_tool_to_stdout(&args.url, "replace_processor", Value::Object(arguments))
 }
 
 /// Remove a processor instance from the graph by id (`remove_processor`).
@@ -169,26 +156,42 @@ pub fn connect(
 
 /// Attach a read-only tap to `channel` and collect a bounded sample (`tap`).
 pub fn tap(url: &str, channel: &str, count: Option<usize>) -> Result<()> {
-    let mut arguments = json!({ "channel": channel });
-    if let Some(count) = count {
-        arguments
-            .as_object_mut()
-            .expect("json! object literal is always an object")
-            .insert("count".into(), json!(count));
-    }
-    call_tool_to_stdout(url, "tap", arguments)
+    let mut arguments = Map::new();
+    arguments.insert("channel".into(), Value::String(channel.to_string()));
+    insert_optional_count(&mut arguments, count);
+    call_tool_to_stdout(url, "tap", Value::Object(arguments))
 }
 
 /// Collect a bounded sample of the runtime event stream (`logs`).
 pub fn logs(url: &str, count: Option<usize>) -> Result<()> {
-    let mut arguments = json!({});
-    if let Some(count) = count {
-        arguments
-            .as_object_mut()
-            .expect("json! object literal is always an object")
-            .insert("count".into(), json!(count));
+    let mut arguments = Map::new();
+    insert_optional_count(&mut arguments, count);
+    call_tool_to_stdout(url, "logs", Value::Object(arguments))
+}
+
+/// Insert the optional `requested_name` / `processor_type_name` pair the
+/// `submit_processor` and `replace_processor` `inputSchema`s share.
+fn insert_optional_naming(
+    arguments: &mut Map<String, Value>,
+    requested_name: Option<String>,
+    processor_type_name: Option<String>,
+) {
+    if let Some(requested_name) = requested_name {
+        arguments.insert("requested_name".into(), Value::String(requested_name));
     }
-    call_tool_to_stdout(url, "logs", arguments)
+    if let Some(processor_type_name) = processor_type_name {
+        arguments.insert(
+            "processor_type_name".into(),
+            Value::String(processor_type_name),
+        );
+    }
+}
+
+/// Insert the optional `count` cap the `tap` and `logs` `inputSchema`s share.
+fn insert_optional_count(arguments: &mut Map<String, Value>, count: Option<usize>) {
+    if let Some(count) = count {
+        arguments.insert("count".into(), json!(count));
+    }
 }
 
 /// Drive one `tools/call` against `{url}/mcp` and print the result to stdout,

--- a/tools/streamlib-cli/src/commands/control.rs
+++ b/tools/streamlib-cli/src/commands/control.rs
@@ -1,0 +1,576 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib graph | submit | replace | remove | connect | tap | logs` — thin
+//! JSON-RPC control clients over a running node's `POST {url}/mcp`.
+//!
+//! Each verb marshals its args into a `tools/call` for one of the 7 api-server
+//! MCP tools ([`streamlib_api_server`]'s `tool_definitions`) and POSTs it over
+//! the same `ureq` seam the `mcp --attach` bridge uses ([`post_mcp_request`],
+//! shared with [`super::mcp`]). There is no local runtime and no fourth
+//! dispatch: the tool set is exactly those 7, and the arg shapes mirror each
+//! tool's `inputSchema` 1:1.
+//!
+//! The optional `STREAMLIB_MCP_TOKEN` rides as an `authorization: Bearer`
+//! header, matching the `--attach` bridge. Result handling covers four
+//! channels: a non-2xx HTTP status, a top-level JSON-RPC `error` (returned
+//! inside an HTTP 200), a tool-level `result.isError`, and success — the first
+//! three exit non-zero with the error text, the last prints the tool result's
+//! already-pretty text content.
+
+use std::io::{Read, Write};
+
+use anyhow::{Context, Result, bail};
+use serde_json::{Value, json};
+
+/// POST one JSON-RPC request body to `{url}/mcp` and return the response body.
+/// A 2xx yields the body (empty for a `202` notification); a non-2xx or
+/// transport error is surfaced as an `Err`. `bearer_token`, when set, rides as
+/// an `authorization: Bearer` header. This is the single request/response seam
+/// the `mcp --attach` bridge and every control verb share.
+pub fn post_mcp_request(
+    url: &str,
+    bearer_token: Option<&str>,
+    request_body: &str,
+) -> Result<String> {
+    let endpoint = format!("{}/mcp", url.trim_end_matches('/'));
+    let mut request = ureq::post(&endpoint).set("content-type", "application/json");
+    if let Some(bearer_token) = bearer_token {
+        request = request.set("authorization", &format!("Bearer {bearer_token}"));
+    }
+    match request.send_string(request_body) {
+        Ok(response) => Ok(response.into_string()?),
+        Err(ureq::Error::Status(code, response)) => {
+            let body = response.into_string().unwrap_or_default();
+            bail!("POST {endpoint} failed: HTTP {code}: {body}");
+        }
+        Err(error) => bail!("POST {endpoint} transport error: {error}"),
+    }
+}
+
+/// Export the live runtime graph as JSON (`graph` tool).
+pub fn graph(url: &str) -> Result<()> {
+    call_tool_to_stdout(url, "graph", json!({}))
+}
+
+/// Arguments for the `submit` verb, mirroring the `submit_processor`
+/// `inputSchema`. `source` is a `--source` value (`@file`, a plain path, `-`,
+/// or absent → stdin); `config` is a JSON string (absent → `{}`); each
+/// `connect` entry is a `local_port:role:peer_processor:peer_port` spec.
+pub struct SubmitArgs {
+    pub url: String,
+    pub language: String,
+    pub source: Option<String>,
+    pub requested_name: Option<String>,
+    pub processor_type_name: Option<String>,
+    pub config: Option<String>,
+    pub connect: Vec<String>,
+}
+
+/// Register a processor from source and optionally wire it (`submit_processor`).
+pub fn submit(args: SubmitArgs) -> Result<()> {
+    let source = read_source(args.source.as_deref())?;
+    let config = parse_config(args.config.as_deref())?;
+    let connect = args
+        .connect
+        .iter()
+        .map(|spec| parse_connect_spec(spec))
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut arguments = json!({
+        "language": args.language,
+        "source": source,
+        "config": config,
+    });
+    let map = arguments
+        .as_object_mut()
+        .expect("json! object literal is always an object");
+    if let Some(requested_name) = args.requested_name {
+        map.insert("requested_name".into(), Value::String(requested_name));
+    }
+    if let Some(processor_type_name) = args.processor_type_name {
+        map.insert(
+            "processor_type_name".into(),
+            Value::String(processor_type_name),
+        );
+    }
+    if !connect.is_empty() {
+        map.insert("connect".into(), Value::Array(connect));
+    }
+
+    call_tool_to_stdout(&args.url, "submit_processor", arguments)
+}
+
+/// Arguments for the `replace` verb, mirroring the `replace_processor`
+/// `inputSchema`.
+pub struct ReplaceArgs {
+    pub url: String,
+    pub target_session_module: String,
+    pub language: String,
+    pub source: Option<String>,
+    pub requested_name: Option<String>,
+    pub processor_type_name: Option<String>,
+}
+
+/// Swap a live `@session/<name>` source registration for a replacement
+/// (`replace_processor`). Type-level: already-running instances are not swapped
+/// in place.
+pub fn replace(args: ReplaceArgs) -> Result<()> {
+    let source = read_source(args.source.as_deref())?;
+    let mut arguments = json!({
+        "target_session_module": args.target_session_module,
+        "language": args.language,
+        "source": source,
+    });
+    let map = arguments
+        .as_object_mut()
+        .expect("json! object literal is always an object");
+    if let Some(requested_name) = args.requested_name {
+        map.insert("requested_name".into(), Value::String(requested_name));
+    }
+    if let Some(processor_type_name) = args.processor_type_name {
+        map.insert(
+            "processor_type_name".into(),
+            Value::String(processor_type_name),
+        );
+    }
+    call_tool_to_stdout(&args.url, "replace_processor", arguments)
+}
+
+/// Remove a processor instance from the graph by id (`remove_processor`).
+pub fn remove(url: &str, processor_id: &str) -> Result<()> {
+    call_tool_to_stdout(
+        url,
+        "remove_processor",
+        json!({ "processor_id": processor_id }),
+    )
+}
+
+/// Connect an output port to an input port between two existing processors
+/// (`connect`).
+pub fn connect(
+    url: &str,
+    from_processor: &str,
+    from_port: &str,
+    to_processor: &str,
+    to_port: &str,
+) -> Result<()> {
+    call_tool_to_stdout(
+        url,
+        "connect",
+        json!({
+            "from_processor": from_processor,
+            "from_port": from_port,
+            "to_processor": to_processor,
+            "to_port": to_port,
+        }),
+    )
+}
+
+/// Attach a read-only tap to `channel` and collect a bounded sample (`tap`).
+pub fn tap(url: &str, channel: &str, count: Option<usize>) -> Result<()> {
+    let mut arguments = json!({ "channel": channel });
+    if let Some(count) = count {
+        arguments
+            .as_object_mut()
+            .expect("json! object literal is always an object")
+            .insert("count".into(), json!(count));
+    }
+    call_tool_to_stdout(url, "tap", arguments)
+}
+
+/// Collect a bounded sample of the runtime event stream (`logs`).
+pub fn logs(url: &str, count: Option<usize>) -> Result<()> {
+    let mut arguments = json!({});
+    if let Some(count) = count {
+        arguments
+            .as_object_mut()
+            .expect("json! object literal is always an object")
+            .insert("count".into(), json!(count));
+    }
+    call_tool_to_stdout(url, "logs", arguments)
+}
+
+/// Drive one `tools/call` against `{url}/mcp` and print the result to stdout,
+/// forwarding `STREAMLIB_MCP_TOKEN` as the bearer token when set.
+fn call_tool_to_stdout(url: &str, tool_name: &str, arguments: Value) -> Result<()> {
+    let bearer_token = std::env::var("STREAMLIB_MCP_TOKEN").ok();
+    let stdout = std::io::stdout();
+    call_tool(
+        url,
+        bearer_token.as_deref(),
+        tool_name,
+        arguments,
+        &mut stdout.lock(),
+    )
+}
+
+/// Marshal `arguments` into a `tools/call` for `tool_name`, POST it, and write
+/// the tool result's text content to `writer`. Generic over the writer so a
+/// test captures the output while the CLI wires process stdout. Covers the four
+/// result channels described in the module docs.
+fn call_tool(
+    url: &str,
+    bearer_token: Option<&str>,
+    tool_name: &str,
+    arguments: Value,
+    writer: &mut impl Write,
+) -> Result<()> {
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": { "name": tool_name, "arguments": arguments },
+    });
+    let body = post_mcp_request(url, bearer_token, &request.to_string())?;
+    let response: Value = serde_json::from_str(&body)
+        .with_context(|| format!("control plane returned a non-JSON response: {body}"))?;
+
+    if let Some(error) = response.get("error") {
+        let message = error
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown JSON-RPC error");
+        bail!("{tool_name} failed: {message}");
+    }
+
+    let result = response
+        .get("result")
+        .with_context(|| format!("control plane response missing `result`: {body}"))?;
+    let text = result
+        .get("content")
+        .and_then(|content| content.get(0))
+        .and_then(|first| first.get("text"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+
+    if result
+        .get("isError")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        bail!("{tool_name} failed: {text}");
+    }
+
+    writeln!(writer, "{text}")?;
+    Ok(())
+}
+
+/// Resolve a `--source` value to processor source text: `@<path>` or a plain
+/// `<path>` reads the file; `-` or an absent value reads stdin.
+fn read_source(source_arg: Option<&str>) -> Result<String> {
+    let path = match source_arg {
+        None => return read_stdin(),
+        Some(value) => value.strip_prefix('@').unwrap_or(value),
+    };
+    if path == "-" {
+        return read_stdin();
+    }
+    std::fs::read_to_string(path).with_context(|| format!("reading --source file `{path}`"))
+}
+
+/// Read all of stdin as UTF-8 source text.
+fn read_stdin() -> Result<String> {
+    let mut buffer = String::new();
+    std::io::stdin()
+        .read_to_string(&mut buffer)
+        .context("reading --source from stdin")?;
+    Ok(buffer)
+}
+
+/// Parse a `--config` value as JSON; an absent value defaults to `{}`.
+fn parse_config(config_arg: Option<&str>) -> Result<Value> {
+    match config_arg {
+        None => Ok(json!({})),
+        Some(text) => serde_json::from_str(text)
+            .with_context(|| format!("--config is not valid JSON: {text}")),
+    }
+}
+
+/// Parse one `--connect` spec (`local_port:role:peer_processor:peer_port`) into
+/// the `connect[]` item shape the `submit_processor` `inputSchema` requires.
+fn parse_connect_spec(spec: &str) -> Result<Value> {
+    let fields: Vec<&str> = spec.split(':').collect();
+    if fields.len() != 4 {
+        bail!(
+            "--connect must be `local_port:role:peer_processor:peer_port`; got `{spec}` \
+             ({} field(s))",
+            fields.len()
+        );
+    }
+    let role = fields[1];
+    if role != "output" && role != "input" {
+        bail!("--connect role must be `output` or `input`; got `{role}` in `{spec}`");
+    }
+    Ok(json!({
+        "local_port": fields[0],
+        "role": role,
+        "peer_processor": fields[2],
+        "peer_port": fields[3],
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    //! Hermetic tests for the control verbs: a local TCP server stands in for a
+    //! running node's `POST /mcp` (the same in-process mock pattern the
+    //! `mcp --attach` bridge tests use), so `tools/call` marshaling, the four
+    //! result channels, and arg parsing are exercised without a live runtime.
+
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::{Arc, Mutex};
+    use std::thread::JoinHandle;
+
+    use super::*;
+
+    struct RecordedRequest {
+        authorization: Option<String>,
+        body: String,
+    }
+
+    struct MockReply {
+        status_line: &'static str,
+        body: String,
+    }
+
+    type RecordedRequests = Arc<Mutex<Vec<RecordedRequest>>>;
+
+    /// Spin a local HTTP server answering `replies.len()` requests in order,
+    /// recording each request's `authorization` header and body.
+    fn spawn_mock_mcp_server(
+        replies: Vec<MockReply>,
+    ) -> (String, RecordedRequests, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock mcp server");
+        let url = format!("http://{}", listener.local_addr().expect("local addr"));
+        let recorded: RecordedRequests = Arc::new(Mutex::new(Vec::new()));
+        let recorded_for_thread = recorded.clone();
+        let handle = std::thread::spawn(move || {
+            for reply in replies {
+                let (mut stream, _) = listener.accept().expect("accept");
+                let request = read_http_request(&stream);
+                recorded_for_thread.lock().unwrap().push(request);
+                let response = format!(
+                    "HTTP/1.1 {}\r\nContent-Length: {}\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{}",
+                    reply.status_line,
+                    reply.body.len(),
+                    reply.body,
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write response");
+                stream.flush().ok();
+            }
+        });
+        (url, recorded, handle)
+    }
+
+    fn read_http_request(stream: &TcpStream) -> RecordedRequest {
+        let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+        let mut request_line = String::new();
+        reader.read_line(&mut request_line).expect("request line");
+
+        let mut authorization = None;
+        let mut content_length = 0usize;
+        loop {
+            let mut header = String::new();
+            reader.read_line(&mut header).expect("header line");
+            let header = header.trim_end();
+            if header.is_empty() {
+                break;
+            }
+            let (name, value) = header.split_once(':').unwrap_or((header, ""));
+            match name.trim().to_ascii_lowercase().as_str() {
+                "authorization" => authorization = Some(value.trim().to_string()),
+                "content-length" => content_length = value.trim().parse().unwrap_or(0),
+                _ => {}
+            }
+        }
+
+        let mut body = vec![0u8; content_length];
+        reader.read_exact(&mut body).expect("read body");
+        RecordedRequest {
+            authorization,
+            body: String::from_utf8(body).expect("utf8 body"),
+        }
+    }
+
+    /// A successful tool result carrying `value` as its pretty-JSON text block.
+    fn tool_ok_reply(id: u64, value: Value) -> MockReply {
+        let text = serde_json::to_string_pretty(&value).unwrap();
+        MockReply {
+            status_line: "200 OK",
+            body: json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": { "content": [{ "type": "text", "text": text }], "isError": false },
+            })
+            .to_string(),
+        }
+    }
+
+    #[test]
+    fn graph_marshals_a_tools_call_and_prints_the_text_content() {
+        let (url, recorded, server) =
+            spawn_mock_mcp_server(vec![tool_ok_reply(1, json!({ "processors": [] }))]);
+
+        let mut output = Vec::new();
+        call_tool(&url, None, "graph", json!({}), &mut output).expect("graph call");
+        server.join().unwrap();
+
+        let printed = String::from_utf8(output).unwrap();
+        assert!(
+            printed.contains("\"processors\""),
+            "the tool result text content must be printed; got: {printed}"
+        );
+
+        let recorded = recorded.lock().unwrap();
+        let request: Value = serde_json::from_str(&recorded[0].body).unwrap();
+        assert_eq!(request["method"], "tools/call");
+        assert_eq!(request["params"]["name"], "graph");
+    }
+
+    #[test]
+    fn a_top_level_jsonrpc_error_exits_non_zero_with_the_message() {
+        let (url, _recorded, server) = spawn_mock_mcp_server(vec![MockReply {
+            status_line: "200 OK",
+            body: json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": { "code": -32601, "message": "method not found" },
+            })
+            .to_string(),
+        }]);
+
+        let mut output = Vec::new();
+        let error =
+            call_tool(&url, None, "graph", json!({}), &mut output).expect_err("must be an error");
+        server.join().unwrap();
+
+        assert!(
+            error.to_string().contains("method not found"),
+            "the JSON-RPC error.message must surface; got: {error}"
+        );
+        assert!(output.is_empty(), "no output line on an error");
+    }
+
+    #[test]
+    fn a_tool_level_is_error_exits_non_zero_with_the_content_text() {
+        let (url, _recorded, server) = spawn_mock_mcp_server(vec![MockReply {
+            status_line: "200 OK",
+            body: json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "content": [{ "type": "text", "text": "connect failed: no such port" }],
+                    "isError": true,
+                },
+            })
+            .to_string(),
+        }]);
+
+        let mut output = Vec::new();
+        let error = call_tool(&url, None, "connect", json!({}), &mut output)
+            .expect_err("isError must surface as an error");
+        server.join().unwrap();
+
+        assert!(
+            error.to_string().contains("no such port"),
+            "the isError content text must surface; got: {error}"
+        );
+    }
+
+    #[test]
+    fn a_non_2xx_exits_non_zero_with_the_body() {
+        let (url, _recorded, server) = spawn_mock_mcp_server(vec![MockReply {
+            status_line: "401 Unauthorized",
+            body: "missing bearer".to_string(),
+        }]);
+
+        let mut output = Vec::new();
+        let error = call_tool(&url, None, "graph", json!({}), &mut output)
+            .expect_err("a non-2xx must surface as an error");
+        server.join().unwrap();
+
+        assert!(error.to_string().contains("401"), "got: {error}");
+        assert!(error.to_string().contains("missing bearer"), "got: {error}");
+    }
+
+    #[test]
+    fn submit_arguments_carry_config_and_connect_wirings() {
+        let (url, recorded, server) =
+            spawn_mock_mcp_server(vec![tool_ok_reply(1, json!({ "processors": [] }))]);
+
+        let arguments = json!({
+            "language": "python",
+            "source": "class Widget: pass\n",
+            "config": { "gain": 2 },
+            "connect": [parse_connect_spec("out:output:sink:in").unwrap()],
+        });
+        let mut output = Vec::new();
+        call_tool(&url, None, "submit_processor", arguments, &mut output).expect("submit call");
+        server.join().unwrap();
+
+        let recorded = recorded.lock().unwrap();
+        let request: Value = serde_json::from_str(&recorded[0].body).unwrap();
+        let args = &request["params"]["arguments"];
+        assert_eq!(args["language"], "python");
+        assert_eq!(args["config"]["gain"], 2);
+        assert_eq!(args["connect"][0]["local_port"], "out");
+        assert_eq!(args["connect"][0]["role"], "output");
+        assert_eq!(args["connect"][0]["peer_processor"], "sink");
+        assert_eq!(args["connect"][0]["peer_port"], "in");
+    }
+
+    #[test]
+    fn the_bearer_token_rides_as_an_authorization_header() {
+        let (url, recorded, server) = spawn_mock_mcp_server(vec![tool_ok_reply(1, json!({}))]);
+
+        let mut output = Vec::new();
+        call_tool(&url, Some("secret-token"), "graph", json!({}), &mut output).expect("graph call");
+        server.join().unwrap();
+
+        assert_eq!(
+            recorded.lock().unwrap()[0].authorization.as_deref(),
+            Some("Bearer secret-token")
+        );
+    }
+
+    #[test]
+    fn parse_connect_spec_rejects_a_bad_arity_and_role() {
+        assert!(
+            parse_connect_spec("a:output:b").is_err(),
+            "3 fields must fail"
+        );
+        assert!(
+            parse_connect_spec("a:sideways:b:c").is_err(),
+            "an unknown role must fail"
+        );
+        let ok = parse_connect_spec("a:input:b:c").expect("valid spec");
+        assert_eq!(ok["role"], "input");
+    }
+
+    #[test]
+    fn parse_config_defaults_to_empty_object() {
+        assert_eq!(parse_config(None).unwrap(), json!({}));
+        assert_eq!(parse_config(Some(r#"{"x":1}"#)).unwrap(), json!({ "x": 1 }));
+        assert!(parse_config(Some("not json")).is_err());
+    }
+
+    #[test]
+    fn read_source_reads_an_at_file_and_a_plain_path() {
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        write!(file, "source text\n").unwrap();
+        let path = file.path().to_str().unwrap();
+
+        assert_eq!(
+            read_source(Some(&format!("@{path}"))).unwrap(),
+            "source text\n"
+        );
+        assert_eq!(read_source(Some(path)).unwrap(), "source text\n");
+        assert!(
+            read_source(Some("@/no/such/file/here")).is_err(),
+            "a missing file must error"
+        );
+    }
+}

--- a/tools/streamlib-cli/src/commands/mcp.rs
+++ b/tools/streamlib-cli/src/commands/mcp.rs
@@ -87,32 +87,17 @@ fn bridge_stdio_to_remote(
     reader: impl std::io::BufRead,
     mut writer: impl std::io::Write,
 ) -> Result<()> {
-    let endpoint = format!("{}/mcp", url.trim_end_matches('/'));
-
     for line in reader.lines() {
         let line = line?;
         if line.trim().is_empty() {
             continue;
         }
-        let mut request = ureq::post(&endpoint).set("content-type", "application/json");
-        if let Some(bearer_token) = bearer_token {
-            request = request.set("authorization", &format!("Bearer {bearer_token}"));
-        }
-        match request.send_string(&line) {
-            // 2xx: a request answers `200` with the JSON-RPC envelope; a
-            // notification answers `202` with an empty body → no response line.
-            Ok(response) => {
-                let body = response.into_string()?;
-                if !body.trim().is_empty() {
-                    writeln!(writer, "{body}")?;
-                    writer.flush()?;
-                }
-            }
-            Err(ureq::Error::Status(code, response)) => {
-                let body = response.into_string().unwrap_or_default();
-                anyhow::bail!("attach POST {endpoint} failed: HTTP {code}: {body}");
-            }
-            Err(error) => anyhow::bail!("attach POST {endpoint} transport error: {error}"),
+        // 2xx: a request answers `200` with the JSON-RPC envelope; a
+        // notification answers `202` with an empty body → no response line.
+        let body = super::control::post_mcp_request(url, bearer_token, &line)?;
+        if !body.trim().is_empty() {
+            writeln!(writer, "{body}")?;
+            writer.flush()?;
         }
     }
     Ok(())

--- a/tools/streamlib-cli/src/commands/mod.rs
+++ b/tools/streamlib-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod add;
 pub mod build_on_place;
+pub mod control;
 pub mod generate;
 pub mod install;
 pub mod link;

--- a/tools/streamlib-cli/src/main.rs
+++ b/tools/streamlib-cli/src/main.rs
@@ -34,7 +34,7 @@ enum Commands {
         /// Control-plane URL: collect a bounded sample of the running node's
         /// live event stream (all topics) via its `POST /mcp` instead of
         /// reading an on-disk JSONL log file.
-        #[arg(long, value_name = "URL", conflicts_with_all = ["list", "follow", "processor", "pipeline", "rhi", "level", "source", "intercepted_only", "since"])]
+        #[arg(long, value_name = "URL", conflicts_with_all = ["runtime_id", "list", "follow", "processor", "pipeline", "rhi", "level", "source", "intercepted_only", "since"])]
         url: Option<String>,
 
         /// (control-plane mode) Max events to collect before returning.
@@ -295,7 +295,7 @@ enum Commands {
     Remove {
         /// Canonical `@org/name` reference to remove (local mode). Omit with
         /// `--url`.
-        #[arg(required_unless_present = "url")]
+        #[arg(required_unless_present = "url", conflicts_with = "url")]
         name: Option<String>,
 
         /// App root to anchor streamlib_modules/ + streamlib.lock at
@@ -572,16 +572,14 @@ async fn async_main(cli: Cli) -> Result<()> {
             from_port,
             to_processor,
             to_port,
-        }) => commands::control::connect(
-            &url,
-            &from_processor,
-            &from_port,
-            &to_processor,
-            &to_port,
-        )?,
-        Some(Commands::Tap { url, channel, count }) => {
-            commands::control::tap(&url, &channel, count)?
+        }) => {
+            commands::control::connect(&url, &from_processor, &from_port, &to_processor, &to_port)?
         }
+        Some(Commands::Tap {
+            url,
+            channel,
+            count,
+        }) => commands::control::tap(&url, &channel, count)?,
         Some(Commands::Setup { action }) => match action {
             SetupCommands::Shell { shell } => commands::setup::shell(shell.as_deref())?,
         },
@@ -612,7 +610,9 @@ async fn async_main(cli: Cli) -> Result<()> {
                 commands::control::remove(&url, &processor_id)?
             }
             None => {
-                let name = name.expect("clap requires `name` unless `--url` is set");
+                let name = name.ok_or_else(|| {
+                    anyhow::anyhow!("`remove` requires either `<name>` (local mode) or `--url` (control-plane mode)")
+                })?;
                 commands::add::remove(&name, dir.as_deref())?
             }
         },

--- a/tools/streamlib-cli/src/main.rs
+++ b/tools/streamlib-cli/src/main.rs
@@ -23,11 +23,23 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Stream a runtime's on-disk JSONL log file in pretty format.
+    /// Stream a runtime's on-disk JSONL log file in pretty format, or — with
+    /// `--url` — collect a bounded sample of a running node's live event stream
+    /// via its control plane.
     Logs {
-        /// Runtime ID to read logs for. Omit when using `--list`.
-        #[arg(value_name = "RUNTIME_ID", required_unless_present = "list")]
+        /// Runtime ID to read logs for. Omit when using `--list` or `--url`.
+        #[arg(value_name = "RUNTIME_ID", required_unless_present_any = ["list", "url"])]
         runtime_id: Option<String>,
+
+        /// Control-plane URL: collect a bounded sample of the running node's
+        /// live event stream (all topics) via its `POST /mcp` instead of
+        /// reading an on-disk JSONL log file.
+        #[arg(long, value_name = "URL", conflicts_with_all = ["list", "follow", "processor", "pipeline", "rhi", "level", "source", "intercepted_only", "since"])]
+        url: Option<String>,
+
+        /// (control-plane mode) Max events to collect before returning.
+        #[arg(long, value_name = "COUNT", requires = "url")]
+        count: Option<usize>,
 
         /// Enumerate available runtime log files instead of streaming one.
         #[arg(long, conflicts_with_all = ["runtime_id", "follow"])]
@@ -83,6 +95,124 @@ enum Commands {
         /// hosting an in-process runtime.
         #[arg(long, value_name = "URL")]
         attach: Option<String>,
+    },
+
+    /// Export a running node's live graph (processors, links, states, metrics)
+    /// as JSON via its control plane.
+    Graph {
+        /// Control-plane base URL of the target node (its `POST /mcp` host).
+        #[arg(long, value_name = "URL")]
+        url: String,
+    },
+
+    /// Author a processor from source and submit it into a running node's graph.
+    ///
+    /// Transactional: registers the source, instantiates the first discovered
+    /// processor, and optionally wires it to existing graph ports; a failed
+    /// wiring rolls the whole submit back.
+    Submit {
+        /// Control-plane base URL of the target node (its `POST /mcp` host).
+        #[arg(long, value_name = "URL")]
+        url: String,
+
+        /// Source language. `rust` is rejected for live submit — it's a full
+        /// cargo build, not a live graph mutation.
+        #[arg(long, value_parser = ["python", "typescript", "deno"])]
+        language: String,
+
+        /// Processor module source: `@<file>` or a plain path reads the file;
+        /// `-` or an omitted flag reads stdin.
+        #[arg(long, value_name = "SOURCE")]
+        source: Option<String>,
+
+        /// The `@session/<name>` segment to mint under (derived from the
+        /// processor type name if omitted).
+        #[arg(long, value_name = "NAME")]
+        requested_name: Option<String>,
+
+        /// The PascalCase processor type the source defines (derived from the
+        /// requested name if omitted).
+        #[arg(long, value_name = "TYPE")]
+        processor_type_name: Option<String>,
+
+        /// Config JSON applied when the processor is instantiated (default `{}`).
+        #[arg(long, value_name = "JSON")]
+        config: Option<String>,
+
+        /// Wire the new processor after instantiation. Repeatable:
+        /// `local_port:role:peer_processor:peer_port` (role ∈ `output`|`input`).
+        #[arg(long, value_name = "SPEC")]
+        connect: Vec<String>,
+    },
+
+    /// Swap a running node's `@session/<name>` source registration for a
+    /// replacement.
+    ///
+    /// Type-level: this swaps the SOURCE REGISTRATION only — already-running
+    /// instances are NOT swapped in place; they keep running the prior source
+    /// until removed and re-instantiated. Transactional: a failed replacement
+    /// restores the prior registration.
+    Replace {
+        /// Control-plane base URL of the target node (its `POST /mcp` host).
+        #[arg(long, value_name = "URL")]
+        url: String,
+
+        /// The `@session/<name>@<range>` module to replace, e.g.
+        /// `@session/widget@*`.
+        #[arg(long, value_name = "MODULE")]
+        target_session_module: String,
+
+        /// Replacement source language. `rust` is rejected for live submit.
+        #[arg(long, value_parser = ["python", "typescript", "deno"])]
+        language: String,
+
+        /// Replacement source: `@<file>` or a plain path reads the file; `-` or
+        /// an omitted flag reads stdin.
+        #[arg(long, value_name = "SOURCE")]
+        source: Option<String>,
+
+        /// The `@session/<name>` segment to mint under.
+        #[arg(long, value_name = "NAME")]
+        requested_name: Option<String>,
+
+        /// The PascalCase processor type the replacement source defines.
+        #[arg(long, value_name = "TYPE")]
+        processor_type_name: Option<String>,
+    },
+
+    /// Connect an output port to an input port between two running processors.
+    Connect {
+        /// Control-plane base URL of the target node (its `POST /mcp` host).
+        #[arg(long, value_name = "URL")]
+        url: String,
+
+        #[arg(long, value_name = "PROCESSOR")]
+        from_processor: String,
+
+        #[arg(long, value_name = "PORT")]
+        from_port: String,
+
+        #[arg(long, value_name = "PROCESSOR")]
+        to_processor: String,
+
+        #[arg(long, value_name = "PORT")]
+        to_port: String,
+    },
+
+    /// Attach a read-only tap to a running node's channel and collect a bounded
+    /// sample of raw bags (a hex preview plus byte length per bag).
+    Tap {
+        /// Control-plane base URL of the target node (its `POST /mcp` host).
+        #[arg(long, value_name = "URL")]
+        url: String,
+
+        /// Channel data-service name, e.g. `{source_processor}/{source_output_port}`.
+        #[arg(value_name = "CHANNEL")]
+        channel: String,
+
+        /// Number of bags to collect before returning.
+        #[arg(long, value_name = "COUNT")]
+        count: Option<usize>,
     },
 
     /// Setup commands
@@ -155,18 +285,32 @@ enum Commands {
         no_build: bool,
     },
 
-    /// Remove a package from this app's streamlib_modules/ folder.
+    /// Remove a package from this app's streamlib_modules/ folder, or — with
+    /// `--url` — remove a processor instance from a running node's graph via
+    /// its control plane.
     ///
-    /// Deletes `streamlib_modules/@org/name/` and drops the package's entry
-    /// from the app's `streamlib.lock`.
+    /// Local mode deletes `streamlib_modules/@org/name/` and drops the
+    /// package's entry from the app's `streamlib.lock`. Control-plane mode
+    /// (`--url` + `--processor-id`) removes a live processor instance by id.
     Remove {
-        /// Canonical `@org/name` reference to remove.
-        name: String,
+        /// Canonical `@org/name` reference to remove (local mode). Omit with
+        /// `--url`.
+        #[arg(required_unless_present = "url")]
+        name: Option<String>,
 
         /// App root to anchor streamlib_modules/ + streamlib.lock at
         /// (default: current working directory, no walk-up).
         #[arg(long)]
         dir: Option<PathBuf>,
+
+        /// Control-plane URL: remove a processor instance from the running node
+        /// at this URL (its `POST /mcp` host) instead of a package.
+        #[arg(long, value_name = "URL")]
+        url: Option<String>,
+
+        /// Processor instance id to remove (control-plane mode; requires `--url`).
+        #[arg(long, value_name = "ID", requires = "url")]
+        processor_id: Option<String>,
     },
 
     /// Manage installed packages
@@ -359,6 +503,8 @@ async fn async_main(cli: Cli) -> Result<()> {
     match cli.command {
         Some(Commands::Logs {
             runtime_id,
+            url,
+            count,
             list,
             follow,
             processor,
@@ -369,6 +515,9 @@ async fn async_main(cli: Cli) -> Result<()> {
             intercepted_only,
             since,
         }) => {
+            if let Some(url) = url {
+                return commands::control::logs(&url, count);
+            }
             commands::logs::run(commands::logs::LogsArgs {
                 runtime_id: runtime_id.as_deref(),
                 list,
@@ -384,6 +533,55 @@ async fn async_main(cli: Cli) -> Result<()> {
             .await?
         }
         Some(Commands::Mcp { attach }) => commands::mcp::run(attach).await?,
+        Some(Commands::Graph { url }) => commands::control::graph(&url)?,
+        Some(Commands::Submit {
+            url,
+            language,
+            source,
+            requested_name,
+            processor_type_name,
+            config,
+            connect,
+        }) => commands::control::submit(commands::control::SubmitArgs {
+            url,
+            language,
+            source,
+            requested_name,
+            processor_type_name,
+            config,
+            connect,
+        })?,
+        Some(Commands::Replace {
+            url,
+            target_session_module,
+            language,
+            source,
+            requested_name,
+            processor_type_name,
+        }) => commands::control::replace(commands::control::ReplaceArgs {
+            url,
+            target_session_module,
+            language,
+            source,
+            requested_name,
+            processor_type_name,
+        })?,
+        Some(Commands::Connect {
+            url,
+            from_processor,
+            from_port,
+            to_processor,
+            to_port,
+        }) => commands::control::connect(
+            &url,
+            &from_processor,
+            &from_port,
+            &to_processor,
+            &to_port,
+        )?,
+        Some(Commands::Tap { url, channel, count }) => {
+            commands::control::tap(&url, &channel, count)?
+        }
         Some(Commands::Setup { action }) => match action {
             SetupCommands::Shell { shell } => commands::setup::shell(shell.as_deref())?,
         },
@@ -401,7 +599,23 @@ async fn async_main(cli: Cli) -> Result<()> {
             expect_sha256,
             no_build,
         }) => commands::add::add(&spec, dir.as_deref(), expect_sha256.as_deref(), no_build)?,
-        Some(Commands::Remove { name, dir }) => commands::add::remove(&name, dir.as_deref())?,
+        Some(Commands::Remove {
+            name,
+            dir,
+            url,
+            processor_id,
+        }) => match url {
+            Some(url) => {
+                let processor_id = processor_id.ok_or_else(|| {
+                    anyhow::anyhow!("`remove --url <url>` requires `--processor-id <id>`")
+                })?;
+                commands::control::remove(&url, &processor_id)?
+            }
+            None => {
+                let name = name.expect("clap requires `name` unless `--url` is set");
+                commands::add::remove(&name, dir.as_deref())?
+            }
+        },
         Some(Commands::Pkg { action }) => match action {
             PkgCommands::Build { output } => commands::pkg::build(output.as_deref())?,
             PkgCommands::Publish => commands::pkg::publish()?,


### PR DESCRIPTION
Closes #1561

## Summary

Adds `streamlib graph | submit | replace | remove | connect | tap | logs` as thin control-client verbs over a running node's `POST {url}/mcp` — the same running-node MCP seam the `mcp --attach` bridge already uses.

- Each verb marshals its args (mirrored 1:1 from the 7 api-server MCP tools' `inputSchema`) into a `tools/call` JSON-RPC request.
- Extracted the shared `post_mcp_request` seam out of `mcp.rs`'s `bridge_stdio_to_remote` so the bridge and every control verb POST through one function (`content-type: application/json`, optional Bearer from `STREAMLIB_MCP_TOKEN`).
- Result handling covers four channels: non-2xx HTTP, top-level JSON-RPC error, tool-level `isError`, and success (prints the already-pretty `content[0].text`).
- `submit` reads `--source` from `@file` / a path / stdin, parses `--config` as JSON (default `{}`), and takes repeatable `--connect local_port:role:peer_processor:peer_port`.
- `replace --help` states the type-level semantic.
- `remove` and `logs` collide with existing local subcommands: presence of `--url` routes them to the control plane (option A), leaving local behavior intact. `--url` is required on the five non-colliding verbs.

## Test evidence

- 9/9 hermetic tests in `tools/streamlib-cli/src/commands/control.rs` pass and are non-vacuous.
- Cross-checked all 7 verbs against `tool_definitions()` schemas (`graph`/`submit_processor`/`replace_processor`/`remove_processor`/`connect`/`tap`/`logs`) — property names, required sets, and the `connect[]` item shape match exactly.
- `--rust` rejected at parse via `value_parser=[python,typescript,deno]`.

## Review items (non-blocking)

The following findings came out of independent verification of the branch. None are blocking — the branch is otherwise a PASS — but flagging them here so they're visible in-context for the owner.

1. **[should-fix]** `tools/streamlib-cli/src/main.rs:572` — The branch's own newly-added `Connect` and `Tap` match arms are rustfmt-clean.
   Evidence: `cargo fmt -p streamlib-cli -- --check` flags main.rs:572: rustfmt reformats the branch-added `Some(Commands::Connect {..}) => commands::control::connect(&url, &from_processor, ...)` into a block form and destructures the `Some(Commands::Tap { url, channel, count })` arm multi-line. These arms are added by this branch (present in the diff). control.rs itself is fmt-clean. (main.rs:489 `logging_config_for` and mcp.rs:154 are pre-existing drift, not in this diff.)
   Suggested next step: Run `cargo fmt -p streamlib-cli` and commit only the two newly-added arms; leave the pre-existing add.rs/build_on_place.rs drift untouched per no-auto-fix.

2. **[should-fix]** `tools/streamlib-cli/src/main.rs:300` — The remove/logs local-vs-control-plane collision is fully coherent.
   Evidence: Precedence (`--url` present => control mode) and required-arg enforcement are correct: `remove --url X` errors requiring `--processor-id`, and `logs`/`remove` route to `control::*` when `--url` is set. But `remove`'s `name` has `required_unless_present="url"` with no `conflicts_with="url"`, and `logs`'s `--url` `conflicts_with_all` lists many flags but NOT `runtime_id`. So `remove @org/foo --url X --processor-id p` and `logs some-id --url X` are both accepted and the stray local-mode positional is silently ignored (verified: `remove @org/foo --url http://127.0.0.1:9 --processor-id p` proceeds straight to the control POST, dropping `@org/foo`).
   Suggested next step: Add `conflicts_with="url"` to remove's `name` and `runtime_id` in the logs `--url` conflicts set so a mixed-mode invocation is a hard clap error rather than a silent drop.

3. **[info]** `tools/streamlib-cli/src/commands/control.rs:1` — 1:1 marshaling, error-channel exit codes, source/config parsing, and DRY extraction are all delivered as specified.
   Evidence: Cross-checked all 7 verbs against `tool_definitions()` schemas (graph/submit_processor/replace_processor/remove_processor/connect/tap/logs) — property names, required sets, and the `connect[]` item shape match exactly; `--rust` rejected at parse via `value_parser=[python,typescript,deno]`. `tool_ok` in mcp.rs uses `to_string_pretty` so `content[].text` is already-pretty and is printed verbatim. 9/9 hermetic tests pass and are non-vacuous. `post_mcp_request` extraction is ticket-mandated reuse (shared with mcp.rs bridge), not a silent DRY refactor.
   Suggested next step: None — record as evidence on the PR body.

4. **[should-fix]** `tools/streamlib-cli/src/commands/control.rs:84` — The "build a `json!` object, then conditionally insert optional fields via `as_object_mut().expect(...)`" pattern is duplicated across four functions. `submit` (L84-99) and `replace` (L124-136) insert the SAME two optional fields — `requested_name` and `processor_type_name` — with byte-identical `if let Some(x) { map.insert("requested_name".into(), Value::String(x)); }` blocks; `tap` (L173-178) and `logs` (L185-190) each repeat the same conditional `count` insert verbatim. This is real duplication (the four sites must change together if a field's marshaling changes), plus four copies of the `.as_object_mut().expect("json! object literal is always an object")` boilerplate.
   Evidence: control.rs:88-96 (submit) and control.rs:128-135 (replace) are identical `requested_name`/`processor_type_name` inserts; control.rs:175-177 (tap) and control.rs:187-189 (logs) are identical `count` inserts. Four `.expect("json! object literal is always an object")` at L87/L127/L176/L188.
   Suggested next step: Build each arguments object from a `serde_json::Map::new()` and insert directly (or add `fn insert_optional_string(map, key, Option<String>)` and `fn insert_optional_count(map, Option<usize>)` helpers). Constructing the `Map` directly eliminates all four `as_object_mut().expect(...)` sites and collapses the requested_name/processor_type_name duplication between submit and replace to one call each.

5. **[info]** `tools/streamlib-cli/src/commands/mcp.rs:97` — The shared HTTP request/response seam `post_mcp_request` lives in the newer `control` module, and `mcp.rs` reaches upward into `super::control::post_mcp_request`. The extraction itself is correct and non-duplicative (the old inline `ureq::post` block in the bridge is fully removed), but the dependency direction — the pre-existing `mcp` bridge depending on the new `control` module for its core transport — is slightly inverted. Not a defect; the module doc already flags the shared seam explicitly.
   Evidence: mcp.rs:97 calls `super::control::post_mcp_request(...)`; `post_mcp_request` is defined at control.rs:29.
   Suggested next step: Optional: if a third consumer appears, hoist `post_mcp_request` to a neutral `commands/mcp_transport.rs` (or keep as-is — the current placement is defensible for a two-consumer seam).

6. **[low]** `tools/streamlib-cli/src/main.rs:614` — `name.expect("clap requires \`name\` unless \`--url\` is set")` encodes a clap `required_unless_present` invariant as a panic. It is provably unreachable given the arg attribute, but a `let Some(name) = name else { ... }` or matching on the pair would keep the CLI panic-free even if the clap attribute is later edited without updating this arm.
   Evidence: main.rs Remove arm: `let name = name.expect("clap requires \`name\` unless \`--url\` is set");` inside the `None => {}` branch; guarded by `#[arg(required_unless_present = "url")]` at the field.
   Suggested next step: Optional: replace the `expect` with `ok_or_else(|| anyhow!("..."))?` (mirroring the `processor_id.ok_or_else(...)` handling three lines above in the same arm) so both missing-arg branches surface as errors rather than one panicking and one erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
