### PR TITLE
docs(skills): add eight node-driving skills over the CLI control verbs

### DIFF
--- a/.claude/skills/author-and-submit-processor/SKILL.md
+++ b/.claude/skills/author-and-submit-processor/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: author-and-submit-processor
+description: Write a brand-new processor from source and submit it into a running StreamLib node as a fresh instance, optionally wiring its ports to existing processors in one transactional step, then confirm it landed and is producing. Use when adding a new stage to a live pipeline during development — a new filter, sink, or generator — without restarting the app. Wraps `streamlib submit` then `graph` + `tap` to confirm.
+---
+
+# author-and-submit-processor
+
+Adds a new processor to a running graph from source text. `submit` is transactional: it registers the source, instantiates the first discovered processor type as a fresh `@session/<name>` instance, and — if you pass `--connect` — wires it; a failed wiring rolls the entire submit back. Live submit is Python / TypeScript / Deno only; `rust` is rejected because it is a full cargo build, not a live graph mutation.
+
+## Steps
+
+### 1. Write the processor source to a file
+Author the processor in a real file (processors are real modules) — e.g. `/tmp/my_filter.py` (Python), `.ts` (TypeScript), or a Deno module. Note the PascalCase processor type name it defines.
+
+### 2. Inspect the live graph for wiring targets
+Run `inspect-live-graph` and note the processor ids and port names you will connect the new processor to. A connect spec is `local_port:role:peer_processor:peer_port`, where `role` is `output` (your `local_port` is an output feeding the peer's input) or `input` (your `local_port` is an input fed by the peer's output).
+
+### 3. Submit the processor
+```bash
+streamlib submit --node <runtime_id> \
+  --language python \
+  --source @/tmp/my_filter.py \
+  --requested-name my-filter \
+  --processor-type-name MyFilter \
+  --config '{"gain": 2}' \
+  --connect frames_in:input:camera:frames \
+  --connect frames_out:output:display:frames
+```
+- `--language` — `python` | `typescript` | `deno` (`rust` is rejected).
+- `--source` — `@<file>` or a plain path reads the file; `-` or omitting `--source` reads source from stdin.
+- `--requested-name` — the `@session/<name>` segment to mint under (derived from the type name if omitted).
+- `--processor-type-name` — the PascalCase type the source defines (derived from the requested name if omitted).
+- `--config` — JSON applied at instantiation (default `{}`).
+- `--connect` — repeatable; each is one `local_port:role:peer_processor:peer_port` wiring. Omit to submit unwired and wire later with `streamlib connect`.
+
+Address the node with `--url <control_url>` instead of `--node`, or omit both when exactly one node is live.
+
+### 4. Wire after the fact (only if you skipped `--connect`)
+```bash
+streamlib connect --node <runtime_id> \
+  --from-processor camera --from-port frames \
+  --to-processor <new_processor_id> --to-port frames_in
+```
+Get `<new_processor_id>` from the graph (step 5).
+
+### 5. Confirm it landed and is producing
+```bash
+streamlib graph --node <runtime_id>
+streamlib tap --node <runtime_id> <new_processor_id>/<output_port> --count 10
+```
+The graph should list the new processor with its links; the tap should show bags flowing on its output channel (see `tap-live-channel`). If `submit` exited non-zero, nothing was added — the transaction rolled back; read the error text, fix the source/wiring, and resubmit.
+
+## Notes
+- This authors a NEW processor. To swap an EXISTING processor's source, use `hot-swap-live-processor` (`replace`).
+- `submit` does not compile Rust and does not accept it — keep new processors in Python / TypeScript / Deno for the live path.
+- `STREAMLIB_MCP_TOKEN`, when set, authorizes the call as a bearer token.

--- a/.claude/skills/capture-node-evidence/SKILL.md
+++ b/.claude/skills/capture-node-evidence/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: capture-node-evidence
+description: Freeze a verifiable record of a running StreamLib node — a live graph snapshot, N tapped bags from one or more channels on disk, and a bounded log excerpt — into a directory for a PR, an issue, or a before/after comparison. Use when you need durable proof that a pipeline is running and producing, or to capture the "before" and "after" around a hot-swap. Wraps `streamlib graph`, `streamlib tap`, and `streamlib logs` with shell redirection.
+---
+
+# capture-node-evidence
+
+Turns a live node into on-disk artifacts nothing else touches. All three verbs print to stdout; none has an `--output` flag, so redirect stdout to files in a directory you control. Capture the same bundle twice (before and after a change) to produce a diffable comparison.
+
+## Steps
+
+### 1. Choose an evidence directory
+```bash
+EVIDENCE_DIR=/tmp/node-evidence-before
+mkdir -p "$EVIDENCE_DIR"
+```
+(Use a `-before` and a `-after` dir around a change.)
+
+### 2. Snapshot the live graph
+```bash
+streamlib graph --node <runtime_id> > "$EVIDENCE_DIR/graph.json"
+```
+Read the channel names you want to tap out of this snapshot (`{source_processor}/{source_output_port}` — see `inspect-live-graph`).
+
+### 3. Tap N bags per channel to disk
+`tap` has NO `--output` flag — redirect stdout. Repeat per channel:
+```bash
+streamlib tap --node <runtime_id> camera/frames --count 30 > "$EVIDENCE_DIR/frames-camera.json"
+streamlib tap --node <runtime_id> convert/frames --count 30 > "$EVIDENCE_DIR/frames-convert.json"
+```
+Each file holds the hex-preview-plus-byte-length sample for that channel (bytes-flowing proof, not decoded pixels).
+
+### 4. Capture a bounded log excerpt
+```bash
+streamlib logs --node <runtime_id> --count 200 > "$EVIDENCE_DIR/logs.txt"
+```
+`--count` bounds the sample of the runtime event stream (all topics) within a short window. In this control-plane mode `logs` is addressed by `--url` / `--node` and bounded by `--count` — there is no positional `runtime_id` here (that form is the offline on-disk log reader, a different mode).
+
+### 5. Confirm and hand off the bundle
+```bash
+ls -l "$EVIDENCE_DIR"
+```
+You now have `graph.json`, one `frames-<channel>.json` per tapped channel, and `logs.txt`. Attach them to the PR/issue (upload frame/graph artifacts with the `attach-artifact` skill), or diff a `-before` dir against a `-after` dir to show a change's effect.
+
+## Notes
+- Every verb targets the node with `--url` / `--node` (or neither, when one node is live); `STREAMLIB_MCP_TOKEN` authorizes when set.
+- All three are read-only — capturing evidence never mutates the graph.
+- Do not invent a `--output` flag on `tap` or `graph`; redirection is the mechanism.

--- a/.claude/skills/discover-running-nodes/SKILL.md
+++ b/.claude/skills/discover-running-nodes/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: discover-running-nodes
+description: Enumerate the live StreamLib runtimes reachable over their control plane so you can pick a target before running any other control verb. Use when you need to know which running nodes exist — after `cargo run`-ing an example app in a worktree, when a control verb errors that zero or more-than-one node is live, or any time you must resolve a `runtime_id` / `control_url` to drive. Wraps `streamlib nodes` only.
+---
+
+# discover-running-nodes
+
+The entry point for every control-verb workflow: list the running nodes so a later verb can target one. A StreamLib node appears here only if its graph hosts an `@tatolab/api-server/ApiServer` processor — that processor is what binds a `POST /mcp` control endpoint and registers the node under `$XDG_RUNTIME_DIR/streamlib/nodes/<runtime_id>.json`. A runtime with no control endpoint is intentionally absent, not missing.
+
+## Steps
+
+### 1. List the nodes
+```bash
+streamlib nodes
+```
+This scans the registry, liveness-checks every entry (a `graph` control-plane round-trip plus, on unix, a host-pid check), prunes the entries that are definitively gone (unreachable AND no live pid), and prints an aligned table:
+
+```
+RUNTIME_ID  CONTROL_URL            PID    ALIVE?  HINT
+Rabc123     http://127.0.0.1:8080  12345  yes     streamlib (/path/to/app)
+```
+
+- `RUNTIME_ID` — pass to any control verb as `--node <runtime_id>`.
+- `CONTROL_URL` — pass to any control verb as `--url <control_url>` (its `POST /mcp` base).
+- `PID` — the host process; `teardown-running-node` signals this to stop the node.
+- `ALIVE?` — control-plane reachability (`yes` means a `graph` round-trip answered). An entry can show `no` transiently (pid still alive, control plane briefly slow) without being pruned.
+- `HINT` — a human breadcrumb (e.g. the app's cwd).
+
+### 2. Read the outcome
+- **One `yes` row** — that is your target; control verbs with neither `--url` nor `--node` default to this sole live node, so you can often skip pinning entirely.
+- **Several `yes` rows** — pick one and pin it with `--node <runtime_id>` (or `--url`) on every subsequent verb; a verb given neither flag with more than one live node errors and lists the candidates.
+- **`No running nodes found`** — start a node first (`cargo run` an example app whose graph hosts an `ApiServer` processor), then re-run.
+
+## Notes
+- No flags. `streamlib nodes` takes none.
+- When the control plane requires auth, export `STREAMLIB_MCP_TOKEN` before running — it rides the liveness probe (and every control verb) as an `authorization: Bearer` header.
+- To pin the chosen target and health-check it in one move, hand off to `drive-running-node`.

--- a/.claude/skills/drive-running-node/SKILL.md
+++ b/.claude/skills/drive-running-node/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: drive-running-node
+description: Resolve exactly one running StreamLib node and health-check it with a live `graph` round-trip, then pin its `--url` / `--node` so every following control verb targets the same node. Use at the start of a session against a running app — after `discover-running-nodes`, or whenever you are about to inspect, tap, submit, replace, connect, or capture and need a confirmed target locked in. Wraps `streamlib nodes` then `streamlib graph`.
+---
+
+# drive-running-node
+
+Turns "some node is running" into "this specific node answers, and here is how I address it." A `graph` call is the cheapest full control-plane round-trip, so it doubles as the health check: if `graph` returns the live topology, the node is drivable.
+
+## Steps
+
+### 1. Find the candidates
+```bash
+streamlib nodes
+```
+Read the `RUNTIME_ID` and `CONTROL_URL` of the row you want (see `discover-running-nodes` for the columns). Copy one identifier — either the `runtime_id` (for `--node`) or the `control_url` (for `--url`).
+
+### 2. Health-check + pin the target
+Pick ONE addressing form and reuse it verbatim on every later verb:
+
+By registry `runtime_id`:
+```bash
+streamlib graph --node <runtime_id>
+```
+By explicit control URL:
+```bash
+streamlib graph --url <control_url>
+```
+If exactly one node is live, both flags may be omitted and the resolver uses that sole node:
+```bash
+streamlib graph
+```
+
+A JSON graph dump (processors, links, states, metrics) means the node is healthy and the address is good. A non-zero exit means it is not drivable:
+- `no live StreamLib nodes found` — nothing is running; start a node.
+- `N live nodes found; disambiguate with --node ... or --url ...` — more than one is live and you passed neither flag; re-run with a specific `--node`/`--url`.
+- `no registered node with runtime_id <id>` — the `--node` value is wrong or the node exited; re-run `streamlib nodes`.
+- A transport/HTTP error — the endpoint is unreachable or auth failed (set `STREAMLIB_MCP_TOKEN`).
+
+### 3. Pin it for the rest of the session
+Record the chosen `--node <runtime_id>` (preferred — stable across a port change) or `--url <control_url>`, and pass the same flag to every subsequent verb (`inspect-live-graph`, `tap-live-channel`, `author-and-submit-processor`, `hot-swap-live-processor`, `capture-node-evidence`, `teardown-running-node`).
+
+## Notes
+- Prefer `--node <runtime_id>` over `--url` when several nodes may be live — it is unambiguous and survives the `ApiServer`'s port auto-increment.
+- `STREAMLIB_MCP_TOKEN`, when set, rides as the bearer token on the round-trip; export it once for the whole session.

--- a/.claude/skills/hot-swap-live-processor/SKILL.md
+++ b/.claude/skills/hot-swap-live-processor/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: hot-swap-live-processor
+description: Swap an existing processor's source registration in a running StreamLib node without restarting the app, rewire ports if the port shape changed, and confirm the new behavior on live data. Use when you have edited a processor's source and want the change reflected in a running pipeline during development. Wraps `streamlib replace` (type-level), with `submit` / `connect` / `remove` as needed, then `graph` + `tap` to confirm.
+---
+
+# hot-swap-live-processor
+
+Replaces the SOURCE REGISTRATION for a live `@session/<name>` module. This is type-level: `replace` swaps what the type resolves to, but already-running instances are NOT swapped in place — they keep running the prior source until removed and re-instantiated. So the flow depends on whether you need running instances to pick up the change immediately, and whether the port shape changed.
+
+## Steps
+
+### 1. Inspect the live graph first
+Run `inspect-live-graph`. Note the target `@session/<name>` module, the running instance's processor id, and its current input/output port names. Decide whether your edit changed the port shape (added/removed/renamed a port).
+
+### 2. Replace the source registration
+```bash
+streamlib replace --node <runtime_id> \
+  --target-session-module '@session/widget@*' \
+  --language python \
+  --source @/tmp/widget_v2.py \
+  --requested-name widget \
+  --processor-type-name Widget
+```
+- `--target-session-module` — the `@session/<name>@<range>` module to replace, e.g. `@session/widget@*`.
+- `--language` — `python` | `typescript` | `deno` (`rust` is rejected, same as `submit`).
+- `--source` — `@<file>` / plain path / `-` / stdin, same rules as `submit`.
+- `--requested-name`, `--processor-type-name` — the segment and PascalCase type of the replacement.
+
+`replace` is transactional: a failed replacement restores the prior registration. It updates the registration only — see step 4 to make a running instance actually run the new source.
+
+### 3. Rewire if the port shape changed
+If the edit added, removed, or renamed ports, fix the wiring against the new shape:
+```bash
+streamlib connect --node <runtime_id> \
+  --from-processor <upstream> --from-port <out> \
+  --to-processor <target_processor_id> --to-port <new_in>
+```
+Remove a link that no longer fits by removing and re-instantiating the affected instance (there is no standalone disconnect verb — `remove` drops the instance and its links).
+
+### 4. Re-instantiate to run the new source in a live instance
+Because `replace` does not swap running instances in place, a running instance keeps the old source. To run the new source now, remove the old instance and instantiate a fresh one from the updated registration:
+```bash
+streamlib remove --node <runtime_id> --processor-id <old_instance_id>
+streamlib submit --node <runtime_id> --language python \
+  --source @/tmp/widget_v2.py --requested-name widget --processor-type-name Widget \
+  --connect <local_port>:<role>:<peer>:<peer_port>
+```
+(Skip this step if you only needed the registration updated for future instantiations.)
+
+### 5. Confirm the new behavior
+```bash
+streamlib graph --node <runtime_id>
+streamlib tap --node <runtime_id> <target_processor_id>/<output_port> --count 10
+streamlib logs --node <runtime_id> --count 50
+```
+The graph reflects the new topology; the tap shows the changed output on the next bags; `logs` surfaces any errors from the swap (see `tap-live-channel` for reading a tap sample).
+
+## Notes
+- Type-level is the intended semantic — do not expect `replace` alone to mutate an already-running instance; step 4 is how a live instance takes the new source.
+- Every verb here targets the node with `--url` / `--node` (or neither, when one node is live); `STREAMLIB_MCP_TOKEN` authorizes when set.
+- To ADD a new processor rather than swap one, use `author-and-submit-processor`.

--- a/.claude/skills/inspect-live-graph/SKILL.md
+++ b/.claude/skills/inspect-live-graph/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: inspect-live-graph
+description: Dump a running StreamLib node's live processor graph — processors, ports, links, channel names, states, and metrics — as JSON, to use as ground truth before mutating or tapping it. Use when you need the current topology of a running app: to find a channel name for `tap-live-channel`, to learn the exact port names before a `connect`, to confirm a `submit`/`replace` landed, or to diff before/after a hot-swap. Wraps `streamlib graph`.
+---
+
+# inspect-live-graph
+
+The read-only ground-truth verb. Everything else keys off names that only the live graph knows — processor ids, port names, and channel data-service names (`{source_processor}/{source_output_port}`). Never guess these; dump the graph and read them.
+
+## Steps
+
+### 1. Export the live graph
+Target the node with the same flag you pinned in `drive-running-node`:
+```bash
+streamlib graph --node <runtime_id>
+# or
+streamlib graph --url <control_url>
+# or, when exactly one node is live:
+streamlib graph
+```
+The result is the `graph` MCP tool's JSON (pretty-printed): processors, links, states, metrics.
+
+### 2. Read what you need out of it
+- **Processor ids** — the `--processor-id` for `remove`, and the `from_processor` / `to_processor` for `connect`.
+- **Port names** — the `from_port` / `to_port` for `connect`, and the `local_port` in a `submit --connect` spec.
+- **Channel names** — form the tap target `{source_processor}/{source_output_port}` from the source processor and its output port; feed it to `tap-live-channel`.
+- **States / metrics** — confirm a processor is running and moving data (non-zero counters) rather than merely instantiated.
+
+### 3. Save it when it is evidence
+To freeze the topology for a PR or a before/after diff, redirect to a file (`graph` has no `--output` flag — use shell redirection):
+```bash
+streamlib graph --node <runtime_id> > /tmp/graph-before.json
+```
+For a full evidence bundle (graph + tapped frames + logs), use `capture-node-evidence`.
+
+## Notes
+- Pure read: `graph` never mutates the node.
+- A non-zero exit is a resolver or transport error, not an empty graph — an empty pipeline still returns valid JSON with empty arrays. See `drive-running-node` for resolver error messages.

--- a/.claude/skills/tap-live-channel/SKILL.md
+++ b/.claude/skills/tap-live-channel/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: tap-live-channel
+description: Attach a read-only tap to one named channel of a running StreamLib node and collect a bounded sample of raw bags to confirm data is actually flowing. Use to answer "are frames/samples really moving through this link?" — after inspecting the graph, to verify a `submit`/`connect` produced live output, or to spot-check behavior before and after a `hot-swap-live-processor`. Wraps `streamlib tap`.
+---
+
+# tap-live-channel
+
+Proof-of-life for a link. A channel is named `{source_processor}/{source_output_port}` — the source processor plus the output port it publishes on. Tapping collects a bounded sample of raw bags off that channel and prints a hex preview plus byte length per bag; it does NOT decode pixels or audio samples, so treat it as "bytes are flowing, and roughly this many per bag," not as a rendered frame.
+
+## Steps
+
+### 1. Get the channel name from the live graph
+Run `inspect-live-graph` and read the source processor and its output port, then join them:
+```
+{source_processor}/{source_output_port}   e.g.  camera/frames
+```
+
+### 2. Tap a bounded sample
+The channel is a positional argument; `--count` bounds how many bags to collect before returning:
+```bash
+streamlib tap --node <runtime_id> camera/frames --count 10
+# or
+streamlib tap --url <control_url> camera/frames --count 10
+# or, when exactly one node is live:
+streamlib tap camera/frames --count 10
+```
+Each collected bag prints as a hex preview and a byte length. Omitting `--count` uses the tool's own default sample bound.
+
+### 3. Interpret the sample
+- **Bags arrive, non-zero byte lengths** — data is flowing on that link; the source processor is producing.
+- **Byte lengths change frame-to-frame** — live, varying content (e.g. a moving camera image) rather than a stuck buffer.
+- **Zero bags / the call blocks then returns empty** — nothing is publishing on that channel; re-check the channel name against the graph, and confirm the source processor is running (states/metrics in `inspect-live-graph`).
+
+## Notes
+- `tap` has NO `--output` flag. To persist the sample as evidence, redirect stdout (`streamlib tap ... > frames.json`) — see `capture-node-evidence`.
+- Read-only: a tap never mutates the graph and never disturbs the real subscribers on the channel.
+- The channel positional and `--count` can appear in either order; the node is selected by `--url` / `--node` exactly like the other verbs.

--- a/.claude/skills/teardown-running-node/SKILL.md
+++ b/.claude/skills/teardown-running-node/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: teardown-running-node
+description: Stop a running StreamLib node cleanly by signaling its host process, then confirm its `runtime_id` is gone from the registry so the worktree's camera/GPU/port claim is released. Use when done driving a node — to free a `/dev/videoN` camera for another consumer, release the GPU, or clear a control port before starting a fresh run. Wraps `streamlib nodes` (to read the pid, then to confirm removal) plus an OS signal to the process — there is no `streamlib stop` verb.
+---
+
+# teardown-running-node
+
+Stops the node the same way you started it — by ending its process. There is deliberately no `streamlib stop` control verb (a control surface shouldn't self-destruct the deployment it operates), so teardown signals the host pid and then verifies the node deregistered. A node removes its own registry entry on clean teardown; `streamlib nodes` also prunes an entry once it is both unreachable and pid-dead.
+
+## Steps
+
+### 1. Read the target's pid
+```bash
+streamlib nodes
+```
+Find the row for your `RUNTIME_ID` and note its `PID` (the host process — typically the `cargo run` of the example app). Confirm `ALIVE?` is `yes` before signaling.
+
+### 2. Signal the process to stop cleanly
+Send `SIGTERM` (the default) so the runtime tears down gracefully and removes its own registry entry:
+```bash
+kill <pid>
+```
+If it is a `cargo run` you launched in this session's foreground, `Ctrl-C` is equivalent. Escalate to `kill -9 <pid>` only if the process refuses to exit after a graceful signal — a hard kill skips clean teardown, but `streamlib nodes` will still prune the stale entry on its next scan (unreachable AND pid-dead).
+
+### 3. Confirm the node is gone
+```bash
+streamlib nodes
+```
+The `runtime_id` should no longer appear (or the whole table reports `No running nodes found`). Its camera / GPU / control-port claim is now released for the next run or another worktree.
+
+## Notes
+- Get the pid from `streamlib nodes` — it is the authoritative source; do not guess.
+- One camera consumer per `/dev/videoN` — tearing the node down is what frees the device for another process in this or another worktree.
+- If the entry lingers after a hard kill, re-run `streamlib nodes` once; the scan prunes an entry that is unreachable and whose pid is gone.


### PR DESCRIPTION
**Stacked PR** — base is `feat/1561-nodes-registry-discovery` (a sibling deliverable branch), not `main`. Merge order: `feat/1561-cli-control-client-verbs` → `feat/1561-nodes-registry-discovery` → this PR → `main`.

Closes #1561 (final deliverable in the stack — driving skills built on top of the control-client verbs and node discovery from the earlier branches).

## Summary

Adds eight agent-recipe skills under `.claude/skills/` that make the CLI/control-client the dev control surface for driving already-running StreamLib nodes:

- `discover-running-nodes` — enumerate live nodes via the registry
- `drive-running-node` — connect/disconnect ports on a live node
- `inspect-live-graph` — dump the live processor graph
- `tap-live-channel` — tap a channel's live message stream
- `capture-node-evidence` — capture stdout/graph/tap output as evidence (no `--output` flag exists on graph/tap; shell-redirect instead)
- `hot-swap-live-processor` — replace a running processor's implementation in place
- `teardown-running-node` — cleanly stop a running node
- `author-and-submit-processor` — author a processor and submit it to a running node

Each skill is grounded verbatim against the base CLI's actual verbs/flags/messages (no invented flags, no fabricated output strings).

## Test evidence

Documentation-only change (8 `SKILL.md` files, 356 insertions, no code). Verified by cross-referencing every verb, flag, positional argument, and printed message against the CLI source (`main.rs`, `control.rs`, `nodes.rs`) — see the review items below for the specific line-level grounding checks performed.

## Review items (non-blocking)

- **info** — `.claude/skills/discover-running-nodes/SKILL.md:30` — Empty-registry outcome is quoted as `` `No running nodes found` ``.
  Evidence: `nodes.rs` `print_nodes` writes `No running nodes found in {}.` (registry dir appended). The skill's backticked `` `No running nodes found` `` (also in `teardown-running-node`) is an accurate prefix of the real output, not a fabricated string.
  Suggested next step: Optional — note it prints `... found in <dir>.` — no action required; the quoted prefix is correct.

- **info** — `.claude/skills/capture-node-evidence/SKILL.md:8` — All `--output` references are correct denials, not invented flags.
  Evidence: `git grep` of `--output` across the 8 skills returns only statements that graph/tap have NO `--output` flag plus shell-redirection guidance; confirmed against `main.rs` (Graph/Tap variants carry only `--url`/`--node`[`/channel`/`count`]).
  Suggested next step: None — this is the desired behavior the scope demanded.

- **info** — `.claude/skills/author-and-submit-processor/SKILL.md:1` — Every verb, flag, positional and semantic in all 8 skills is grounded verbatim against the base CLI.
  Evidence: Verified: `submit`/`replace` reject `rust` (value_parser `python|typescript|deno`, `main.rs:153/203`); connect spec `local_port:role:peer_processor:peer_port` role∈`output|input` (`control.rs` `parse_connect_spec:398-417`); resolver messages `no live StreamLib nodes found`, `N live nodes found; disambiguate with --node/--url`, `no registered node with runtime_id` (`control.rs:44-66`); logs control mode is `--url`/`--node`+`--count` no positional (`main.rs:29-51`, requires `logs_control_target`); tap channel positional+`--count` no `--output` (`main.rs:245-261`); nodes table `RUNTIME_ID/CONTROL_URL/PID/ALIVE?/HINT`, unix `kill(pid,0)` check, prune iff unreachable AND pid-dead (`nodes.rs:40-56,152-170`); no `streamlib stop`/`disconnect` verbs exist (`Commands` enum); replace type-level "running instances NOT swapped in place" matches `Replace` clap doc verbatim (`main.rs:181-187`).
  Suggested next step: None.

- **info** — `.claude/skills/discover-running-nodes/SKILL.md:2` — Frontmatter and scope match the agent-recipe house format.
  Evidence: All 8 files carry only `name` + `when-to-use` description; none has `user_invocable` (grep clean), matching `work-on-ticket`/`draft-design`/`milestone-loop` and unlike `verify-video`/`verify-live`. `git diff --name-only` shows exactly the 8 `SKILL.md` files, no scope creep, no code, no processor source embedded. Markdown files need no BUSL header.
  Suggested next step: None.
