### PR TITLE
fix(dx): purge misleading central-registry wording from runtime/sdk/tools strings

### DIFF
--- a/runtime/streamlib-engine/src/core/runtime/module_loader/errors.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/errors.rs
@@ -147,16 +147,19 @@ pub enum AddModuleError {
     },
 
     /// A [`Strategy::Registry`] resolution found no usable registry
-    /// endpoint: neither `STREAMLIB_REGISTRY_URL` nor its `STREAMLIB_REGISTRY_URL`
-    /// fallback is set. Point one at the static registry base URL (e.g.
-    /// `file:///path/to/registry-tree`) so the generic registry is reachable.
-    /// Fail-loud — never silently fall back to a local source for a
-    /// dependency the caller asked to resolve from the registry.
+    /// endpoint: `STREAMLIB_REGISTRY_URL` is not set. Point one at the static
+    /// registry base URL (e.g. `file:///path/to/registry-tree`) so the static
+    /// registry tree is reachable. Fail-loud — never silently fall back to a
+    /// local source for a dependency the caller asked to resolve by version.
     ///
     /// [`Strategy::Registry`]: super::Strategy::Registry
     #[error(
-        "Registry not configured for '{package}': set {env} (e.g. \
-         file:///path/to/registry-tree) to resolve from the static generic store"
+        "No source for '{package}': it is not in the app's streamlib_modules/ \
+         slot, no `streamlib link` is active, and no static registry tree is \
+         configured. Run `streamlib link` to resolve from a local checkout, \
+         `streamlib add {package}@<version>` to install a published version, \
+         or set {env} to a static registry tree (e.g. \
+         file:///path/to/registry-tree)."
     )]
     RegistryNotConfigured {
         package: streamlib_idents::PackageRef,

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -905,8 +905,9 @@ impl Runner {
         let Some(config) = streamlib_idents::RegistryConfig::from_env() else {
             tracing::warn!(
                 package = %pkg_ref,
-                "acquire-on-reference is enabled but no registry URL is configured \
-                 (STREAMLIB_REGISTRY_URL) — cannot acquire"
+                "acquire-on-reference is enabled but nothing can resolve '{pkg_ref}': no \
+                 `streamlib link` is active and STREAMLIB_REGISTRY_URL is unset — run \
+                 `streamlib add {pkg_ref}` or set a static registry tree to acquire"
             );
             return Ok(None);
         };

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/recursive_walker.rs
@@ -821,11 +821,11 @@ fn derive_dep_strategy_and_ident(
                      not another registry range.",
                 )));
             }
-            // A registry-version dependency resolves from the configured the static registry
-            // generic registry by version: pull the `.slpkg` and build it from
+            // A registry-version dependency resolves from the configured static registry
+            // tree by version: pull the `.slpkg` and build it from
             // source on the host (IfStale prefers a matching prebuilt). The
             // registry endpoint comes from the environment
-            // (STREAMLIB_REGISTRY_URL / STREAMLIB_REGISTRY_URL).
+            // (STREAMLIB_REGISTRY_URL).
             Strategy::Registry {
                 version_req: r.version.clone(),
                 build: BuildPolicy::IfStale,

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/source.rs
@@ -98,7 +98,7 @@ pub enum Strategy {
         checksum: Option<ArtifactChecksum>,
     },
 
-    /// Resolve from the configured the static registry **generic** registry by semver
+    /// Resolve from the configured static registry tree (generic .slpkg store) by semver
     /// requirement — the cross-repo consumer path. Lists the package's
     /// published versions from its anonymous, cargo-sparse-shaped version
     /// index (`/api/packages/{org}/generic/{name}/index/index.json`),
@@ -440,7 +440,7 @@ pub(super) fn resolve_strategy_to_source(
                     package = %pkg_ref,
                     version = %selected,
                     %url,
-                    "resolved module from static generic store"
+                    "fetched module .slpkg from the static registry tree"
                 );
                 let archive = persist_registry_slpkg(pkg_ref, &url, &bytes)?;
                 extract_slpkg_to_cache(&archive, app_modules_root().as_deref()).map_err(|e| {

--- a/runtime/streamlib-engine/src/core/runtime/runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/runtime.rs
@@ -1151,7 +1151,7 @@ impl Runner {
 
         for module in to_load {
             tracing::info!(
-                "Snapshot: resolving module '{}' from registry",
+                "Snapshot: resolving module '{}' by version (linked checkout if a streamlib link is active, else the static registry tree)",
                 module.package_ref()
             );
             self.add_module_with(

--- a/sdk/streamlib-idents/src/error.rs
+++ b/sdk/streamlib-idents/src/error.rs
@@ -136,9 +136,10 @@ pub enum ResolverError {
     SlpkgExtractFailed { path: PathBuf, message: String },
 
     #[error(
-        "registry dependency `{name}` cannot be resolved: no registry is configured. \
-         Set `{env}` to the registry tree-root URL (`file://<root>` or `http(s)://…`), \
-         or add a `patch:` override."
+        "dependency `{name}` requested by version but nothing resolves it: no `streamlib link` \
+         is active and no registry is configured. Run `streamlib link` for a local checkout, \
+         add a dev `patch:` override, or set `{env}` to a static registry tree-root URL \
+         (`file://<root>` or `http(s)://…`)."
     )]
     RegistryNotConfigured { name: String, env: String },
 

--- a/sdk/streamlib-idents/src/resolver.rs
+++ b/sdk/streamlib-idents/src/resolver.rs
@@ -155,11 +155,12 @@ pub struct ResolverOptions {
 
 impl ResolverOptions {
     /// Options with the registry config read from the environment
-    /// (`STREAMLIB_REGISTRY_URL`, defaulting to the first-party registry) and
-    /// the default cache dir. This is the codegen-boundary constructor — build
-    /// scripts and `streamlib generate` use it so a registry-cached crate
-    /// resolves its schema deps from the configured registry. Unit tests
-    /// construct [`ResolverOptions`] directly to stay hermetic.
+    /// (`STREAMLIB_REGISTRY_URL`; unset means no registry — `from_env` does NOT
+    /// default to a first-party URL) and the default cache dir. This is the
+    /// codegen-boundary constructor — build scripts and `streamlib generate`
+    /// use it so a registry-cached crate resolves its schema deps from the
+    /// configured registry. Unit tests construct [`ResolverOptions`] directly
+    /// to stay hermetic.
     pub fn from_env() -> Self {
         Self {
             cache_dir: None,

--- a/tools/streamlib-build-orchestrator/src/deno_codegen.rs
+++ b/tools/streamlib-build-orchestrator/src/deno_codegen.rs
@@ -14,7 +14,7 @@
 //! `ensure_streamlib_generated_in_venv`: both run in-process JTD codegen so a
 //! staged polyglot package is runnable without a separate `deno task setup`.
 //! Schema deps (e.g. `@tatolab/core`) resolve from the static registry via the
-//! codegen resolver's env-aware config (`STREAMLIB_REGISTRY_URL` / `STREAMLIB_REGISTRY_URL`)
+//! codegen resolver's env-aware config (`STREAMLIB_REGISTRY_URL`)
 //! — the same path the Rust build-script codegen uses.
 //!
 //! Generating into the orchestrator's build-to-temp directory means the
@@ -99,8 +99,9 @@ pub fn provision_deno_typescript(
         build_failed(
             package_label,
             format!(
-                "failed to generate Deno wire vocabulary (schema deps resolve from the \
-                 registry — is STREAMLIB_REGISTRY_URL / STREAMLIB_REGISTRY_URL set?): {e}"
+                "failed to generate Deno wire vocabulary (schema deps resolve from a linked \
+                 checkout or the static registry tree — is a `streamlib link` active, or is \
+                 STREAMLIB_REGISTRY_URL set?): {e}"
             ),
         )
     })

--- a/tools/streamlib-build-orchestrator/src/native_host.rs
+++ b/tools/streamlib-build-orchestrator/src/native_host.rs
@@ -129,7 +129,7 @@ pub(crate) fn ensure_native_host(
         crate_name = runtime.crate_name(),
         %version,
         profile = profile.label(),
-        "building subprocess native host from registry source (first use / version change)"
+        "building subprocess native host from the static registry tree's cargo subtree (first use / version change)"
     );
 
     // 1. Fetch the `.crate` source from the static registry tree's cargo

--- a/tools/streamlib-cli/src/commands/pkg.rs
+++ b/tools/streamlib-cli/src/commands/pkg.rs
@@ -43,7 +43,7 @@ pub fn build(output: Option<&Path>) -> Result<()> {
 }
 
 /// Publish THIS package (the current working directory) into the static
-/// registry tree's `.slpkg` generic store. Always repacks a fresh source-only
+/// registry tree's `.slpkg` store. Always repacks a fresh source-only
 /// `.slpkg` to a temp file (never trusts a pre-existing artifact), writes it by
 /// version, refreshes the package's version index, and emits the same catalog
 /// artifacts a whole-tree `static-registry emit` would — the per-package

--- a/tools/streamlib-cli/src/main.rs
+++ b/tools/streamlib-cli/src/main.rs
@@ -442,7 +442,7 @@ enum PkgCommands {
     /// Publish THIS package to the registry (run inside the package).
     ///
     /// Always repacks a fresh source-only `.slpkg` (never trusts an existing
-    /// artifact) and writes it into the static generic store. The registry
+    /// artifact) and writes it into the static registry tree. The registry
     /// tree root comes from `STREAMLIB_REGISTRY_URL` and must be a `file://`
     /// tree — publishing writes files (a static HTTP mount is read-only);
     /// reads are tokenless. Publishing many packages is a script over this


### PR DESCRIPTION
## What

Purges misleading central/hosted-registry wording from runtime, SDK, and tools user-facing strings and doc-comments. Closes the code portions of #1570 (§1 misleading strings, §3 code audit) and #1569 (Part 1 code doc-comments).

## The real model (model of record)

The static file tree is the ONLY registry. Packages are consumed by-version:

- `streamlib link` overrides registry resolution and resolves from the linked local checkout (short-circuit above the strategy match).
- `streamlib add <pkg>@<ver>` installs a published version into the app's `streamlib_modules/` slot.
- `STREAMLIB_REGISTRY_URL` points at a static file tree (`file://` or dumb HTTP) — real and load-bearing, the by-version fetch source.

There is NO central/hosted registry to "pull from" and NO republish flow; apps carry no dependency manifest. Reworded messages now describe this model and name the real remedy instead of dead-ending at `STREAMLIB_REGISTRY_URL`.

## Changes

- `runtime/streamlib-engine`: snapshot resolve log, `AddModuleError::RegistryNotConfigured` Display + doc, acquire-on-reference warn, source-fetch debug log, and mangled duplicated-token doc/comment fixes in `source.rs` / `recursive_walker.rs`.
- `sdk/streamlib-idents`: `ResolverError::RegistryNotConfigured` Display (keeps the `no registry is configured` substring), and a `ResolverOptions::from_env` doc fix — it does NOT default to a first-party URL (`from_env` returns `None` when unset; the old doc was factually wrong).
- `tools/streamlib-cli` + `tools/streamlib-build-orchestrator`: vocabulary tidy (`static generic store` → `static registry tree`), the mangled Deno-codegen error + module doc, and the native-host build log.

## Intentionally kept (load-bearing)

- The `Strategy::Registry` enum variant name and the `RegistryNotConfigured` variant names (both `ResolverError` and `AddModuleError`) are unchanged — internal, referenced across ~19 sites incl. pattern-matching tests. Only MESSAGES/doc-comments changed.
- The word "registry" is correct for the static tree; only central/hosted implications were removed.

## Test coupling

`runtime/streamlib-engine/src/core/config/project_config.rs` asserts on the literal substring `no registry is configured`. The reworded `ResolverError` message preserves that substring, so the assertion stays green (verified — 13/13 project_config tests pass).

## Gates

- `cargo build -p streamlib-idents` / `-p streamlib` / `-p streamlib-cli` / `-p streamlib-build-orchestrator` — pass. (Pre-existing `streamlib-engine` vulkan/rhi dead-code warnings are unrelated to this string-only change.)
- `cargo test -p streamlib-idents --lib` — 237 passed.
- `cargo test -p streamlib-engine --lib project_config` — 13 passed.

Closes #1570
Partial #1569

🤖 Generated with [Claude Code](https://claude.com/claude-code)
