### PR TITLE
docs(architecture): correct schema-identity registry-source wording to the static file tree

### DIFF
--- a/docs/architecture/schema-identity-and-packaging.md
+++ b/docs/architecture/schema-identity-and-packaging.md
@@ -239,9 +239,9 @@ dependencies:
 Three dependency source flavors are supported:
 
 - **Registry** (string form `"^1.0.0"` or `{ version: "^1.0.0" }`).
-  Resolved against a registry; the v1 design assumes a Cloudflare R2
-  / GitHub Releases-backed registry, but the resolver is source-
-  agnostic.
+  Resolved by `@org/name` + version range against the static `.slpkg`
+  file tree — the only registry — served tokenless over `file://` or
+  any dumb HTTP directory mount (see `static-registry.md`).
 - **Path** (`{ path: ../foo }`). Local-filesystem dependency, used
   inside the streamlib monorepo for pre-publish work.
 - **Git** (`{ git: <url>, rev: <commit-sha> }`). Pinned-commit-only;
@@ -280,7 +280,7 @@ packages:
     version: 1.0.0
     source:
       kind: registry
-      url: https://packages.streamlib.dev
+      url: file:///path/to/registry-tree
     content_hash: "sha256:0123456789abcdef…"
   "@tatolab/h264":
     version: 0.4.2


### PR DESCRIPTION
## What

Correct the one committed architecture doc that implied a hosted/central package registry.

`docs/architecture/schema-identity-and-packaging.md` described the **Registry** dependency-source flavor as "the v1 design assumes a Cloudflare R2 / GitHub Releases-backed registry" and showed a fabricated `url: https://packages.streamlib.dev` in the lockfile worked example. Under the model of record there is no hosted/central registry: the only registry is the static `.slpkg` file tree, served tokenless over `file://` or a dumb HTTP directory mount. A fresh agent reading this doc concluded there was a central registry to pull packages from.

- Reword the Registry source flavor to: resolved by `@org/name` + version range against the static `.slpkg` file tree — the only registry — over `file://` or any dumb HTTP mount (points at `static-registry.md`).
- Change the lockfile example `url:` from `https://packages.streamlib.dev` to `file:///path/to/registry-tree` (keeping the real `kind: registry` discriminant).

## Scope note (audit correction)

A full read-only audit found this is the **only** committed doc with genuinely misleading hosted-registry wording. In particular:
- `docs/architecture/static-registry.md` is intentionally **kept** — it accurately documents the real static file tree. (Issue #1570 §2 suggested deleting it; that suggestion is superseded by the audit — deleting it would drop the canonical real-model doc.)
- `gitea-registry-ops.local.md` is a gitignored `.local` per-machine file, not part of the committed doc set.

This doc is on the committed edit-deny list (`.claude/settings.json`); the owner authorized this specific correction.

Refs #1570 #1569

🤖 Generated with [Claude Code](https://claude.com/claude-code)
