### PR TITLE
fix(cli): quiet the happy-path 'no registry configured' WARN during streamlib link/add

### DIFF
--- a/tools/streamlib-cli/Cargo.toml
+++ b/tools/streamlib-cli/Cargo.toml
@@ -93,6 +93,7 @@ libc.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-# Serialize tests that swap the process-global `XDG_RUNTIME_DIR` for a tempdir
-# node registry (resolver branch coverage), matching the engine's env-swap tests.
+# Serialize tests that mutate process-global env — the node-registry resolver
+# branch (`XDG_RUNTIME_DIR`) and the #1343 summary-read link tests
+# (`STREAMLIB_PACKAGE_SOURCE` / `STREAMLIB_LINK_CHECKOUT`).
 serial_test = "3.2"

--- a/tools/streamlib-cli/src/commands/add.rs
+++ b/tools/streamlib-cli/src/commands/add.rs
@@ -369,8 +369,7 @@ fn print_link_report(report: &LinkPackageReport) {
 /// Print the processors the added package contributes, read from its own
 /// materialized `streamlib.yaml` (no network, no catalog).
 fn print_processor_summary(package_dir: &Path) {
-    use streamlib::engine_internal::core::ProjectConfig;
-    let config = match ProjectConfig::load(package_dir) {
+    let config = match load_summary_config(package_dir) {
         Ok(config) => config,
         Err(e) => {
             // The manifest already validated during the add; a read failure
@@ -414,6 +413,32 @@ fn print_processor_summary(package_dir: &Path) {
             println!("    Config: {} ({})", config_ref.name, config_ref.schema);
         }
     }
+}
+
+/// Load the just-placed package's config for the summary, resolving its
+/// bare-name schema deps through the active `streamlib link` checkout the
+/// build/run path resolves through — so a linked, zero-package-source dev loop
+/// prints a full summary instead of warning that no package source is
+/// configured. A corrupt marker degrades to a no-link resolve (the summary is
+/// cosmetic and runs only after the add/link already succeeded).
+fn load_summary_config(
+    package_dir: &Path,
+) -> streamlib::engine_internal::core::Result<streamlib::engine_internal::core::ProjectConfig> {
+    use streamlib::engine_internal::core::ProjectConfig;
+
+    let link_checkout = match streamlib_idents::link_marker::find_and_load_active_link(package_dir) {
+        Ok(active) => active.map(|(_marker, manifest)| manifest.checkout),
+        Err(e) => {
+            tracing::debug!(
+                dir = %package_dir.display(),
+                error = %e,
+                "add: link marker unreadable while preparing the processor summary; \
+                 resolving without a link"
+            );
+            None
+        }
+    };
+    ProjectConfig::load_with_link(package_dir, link_checkout.as_deref())
 }
 
 /// Convert a canonical-form string (`@org/name`) into a typed [`PackageRef`]
@@ -654,6 +679,158 @@ processors:
             kept.join("\n"),
             original.trim_end_matches('\n'),
             "content outside the dependencies block changed:\n{written}"
+        );
+    }
+
+    /// Removes the resolution-driving env for a test's duration and restores it
+    /// after, so a stray `STREAMLIB_PACKAGE_SOURCE` / `STREAMLIB_LINK_CHECKOUT`
+    /// in the shell can't make the summary-read link test non-deterministic.
+    struct CleanResolutionEnv {
+        prev_package_source: Option<std::ffi::OsString>,
+        prev_link: Option<std::ffi::OsString>,
+    }
+    impl CleanResolutionEnv {
+        fn new() -> Self {
+            let prev_package_source = std::env::var_os("STREAMLIB_PACKAGE_SOURCE");
+            let prev_link = std::env::var_os("STREAMLIB_LINK_CHECKOUT");
+            // SAFETY: the test using this guard is `#[serial]`, so no other
+            // thread races the process-global environment for its lifetime.
+            unsafe {
+                std::env::remove_var("STREAMLIB_PACKAGE_SOURCE");
+                std::env::remove_var("STREAMLIB_LINK_CHECKOUT");
+            }
+            Self {
+                prev_package_source,
+                prev_link,
+            }
+        }
+    }
+    impl Drop for CleanResolutionEnv {
+        fn drop(&mut self) {
+            unsafe {
+                match self.prev_package_source.take() {
+                    Some(v) => std::env::set_var("STREAMLIB_PACKAGE_SOURCE", v),
+                    None => std::env::remove_var("STREAMLIB_PACKAGE_SOURCE"),
+                }
+                match self.prev_link.take() {
+                    Some(v) => std::env::set_var("STREAMLIB_LINK_CHECKOUT", v),
+                    None => std::env::remove_var("STREAMLIB_LINK_CHECKOUT"),
+                }
+            }
+        }
+    }
+
+    /// A materialized package whose port imports a bare `VideoFrame` from
+    /// `@tatolab/core` (a bare version dep, no package source, NO patch) — the
+    /// shape that forces the summary read to walk the dep graph to resolve the
+    /// schema.
+    fn write_named_port_consumer(package_dir: &Path) {
+        std::fs::write(
+            package_dir.join("streamlib.yaml"),
+            r#"
+package:
+  org: tatolab
+  name: consumer
+  version: 1.0.0
+dependencies:
+  "@tatolab/core":
+    version: ^1.0.0
+schemas:
+  VideoFrame:
+    package: "@tatolab/core"
+processors:
+  - name: Consumer
+    description: d
+    runtime: rust
+    execution: manual
+    inputs:
+      - name: in0
+        schema: VideoFrame
+    outputs: []
+"#,
+        )
+        .unwrap();
+    }
+
+    /// A linked checkout carrying `packages/core` with the `VideoFrame` schema —
+    /// the tree the active link redirects schema resolution at.
+    fn write_checkout_core(checkout: &Path) {
+        let core = checkout.join("packages").join("core");
+        std::fs::create_dir_all(core.join("schemas")).unwrap();
+        std::fs::write(
+            core.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: core\n  version: 1.0.0\nschemas:\n  VideoFrame:\n    file: schemas/video_frame.yaml\n",
+        )
+        .unwrap();
+        std::fs::write(
+            core.join("schemas/video_frame.yaml"),
+            "metadata:\n  type: VideoFrame\nproperties: {}\n",
+        )
+        .unwrap();
+    }
+
+    /// Write an active `streamlib link` marker at `app_root` pointing at
+    /// `checkout` — the same `.streamlib/link.json` the build/run path discovers.
+    fn write_active_link_marker(app_root: &Path, checkout: &Path) {
+        use streamlib_idents::link_marker::{
+            LINK_MANIFEST_FILE, LINK_STATE_DIR, LinkManifest, LinkTransactionState,
+        };
+        let state_dir = app_root.join(LINK_STATE_DIR);
+        std::fs::create_dir_all(&state_dir).unwrap();
+        let manifest = LinkManifest {
+            checkout: checkout.to_path_buf(),
+            python_sdk_path: checkout.join("sdk/streamlib-python"),
+            deno_sdk_entrypoint_path: checkout.join("sdk/streamlib-deno/mod.ts"),
+            linked_at: "2026-01-01T00:00:00Z".to_string(),
+            linked_crate_count: 0,
+            state: LinkTransactionState::Active,
+            files: Vec::new(),
+        };
+        std::fs::write(
+            state_dir.join(LINK_MANIFEST_FILE),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+    }
+
+    /// Regression for #1343: a `streamlib add`/`link` summary read against a
+    /// package with an external schema dep, under an active link and ZERO
+    /// package source, must resolve through the link's checkout and succeed — no
+    /// `no package source is configured` WARN (the warn in
+    /// `print_processor_summary` fires iff `load_summary_config` returns `Err`).
+    #[test]
+    #[serial_test::serial]
+    fn summary_read_resolves_schema_dep_through_active_link_no_package_source() {
+        let _env = CleanResolutionEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let app = tmp.path().join("app");
+        let package_dir = app
+            .join("streamlib_modules")
+            .join("@tatolab")
+            .join("consumer");
+        std::fs::create_dir_all(&package_dir).unwrap();
+        write_named_port_consumer(&package_dir);
+        let checkout = tmp.path().join("checkout");
+        write_checkout_core(&checkout);
+        write_active_link_marker(&app, &checkout);
+
+        // Happy path: the marker is discoverable above the materialized package
+        // dir, so the summary read resolves the bare-name schema dep from the
+        // linked checkout — success, no spurious WARN.
+        load_summary_config(&package_dir).expect(
+            "summary read must resolve the schema dep through the active link, zero package source",
+        );
+
+        // Mental revert: the un-link-aware load the summary used before the fix
+        // (`ProjectConfig::load` == `load_with_link(_, None)`) can't see the
+        // checkout and fails `PackageSourceNotConfigured` — the exact WARN the
+        // fix removes. This is what proves the marker is what resolved it.
+        let err = streamlib::engine_internal::core::ProjectConfig::load(&package_dir)
+            .expect_err("without link-awareness the summary read must fail with no package source");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no package source is configured") || msg.contains("cannot be resolved"),
+            "expected a package-source-not-configured failure, got: {msg}"
         );
     }
 }


### PR DESCRIPTION
## The bug (#1343)

`streamlib link` / `streamlib add` print a scary

```
WARN … @tatolab/core cannot be resolved: no registry is configured
```

while reading a package's processor-summary — even though the link/add itself succeeds (exit 0) and the external schema dep resolves fine at build/run time through the active link's checkout / `STREAMLIB_LINK_CHECKOUT`. In the no-registry, link-based dev model this is the **normal** state, so the warning fires on the happy path and misleads first-run developers/agents running `./setup.sh`.

**Where it came from:** the summary read (`add.rs` → `print_processor_summary` → `ProjectConfig::load`) resolves the package's external schema deps to render the port idents, but `ProjectConfig::load` is link-unaware — unlike the build/run path, which resolves through the active link marker (`find_and_load_active_link` / `link_checkout_from_marker`). With no registry and no threaded checkout, the resolve fails `RegistryNotConfigured` and the summary degrades with a WARN.

## The fix (preferred approach: make the summary read link-aware)

Added `load_summary_config(package_dir)`, which discovers the active `.streamlib/link.json` marker above the just-placed package dir (the same marker the build/run path uses) and threads its checkout into `ProjectConfig::load_with_link`. On the happy path the schema dep now resolves from the linked checkout and the summary prints clean — no WARN. A corrupt marker degrades to a no-link resolve at `debug` level (the summary is cosmetic and runs only after the operation already succeeded).

This is the issue's **preferred** option — route the summary read's schema-dep resolution through the same checkout the build path resolves through, so it *succeeds* rather than warns — not a blanket suppression.

## Criterion 2 (genuine failures still surface) is preserved

- The add/build **operation** resolves and builds in its own step (`build_added_slot_or_rollback`), which runs **before** the summary and surfaces a genuine resolution failure (rolling the placement back). The summary read is cosmetic and post-success — it can never mask an operation failure.
- The summary's existing degrade-only WARN is untouched: a genuine summary-read failure (e.g. no link *and* no registry, or an unresolvable dep) still logs clearly. Only the happy-path (active link, zero registry) case goes quiet, because it now genuinely resolves.

Scope is confined to the CLI summary path — no edits to the `RegistryNotConfigured` message strings or resolver/error doc comments (owned by the parallel `fix/1570-registry-message-purge`).

## Test

`summary_read_resolves_schema_dep_through_active_link_no_registry` (in `add.rs`) builds a fixture: a materialized consumer package with a bare `VideoFrame` port imported from `@tatolab/core`, an active `.streamlib/link.json` marker above it pointing at a checkout carrying `packages/core`, and **zero** registry env. It asserts:

1. `load_summary_config(package_dir)` returns `Ok` — resolved through the link, so no spurious WARN (the summary's WARN fires iff this returns `Err`).
2. **Mental revert:** the pre-fix `ProjectConfig::load(package_dir)` (== `load_with_link(_, None)`) still fails `RegistryNotConfigured` on the same fixture — proving the link marker is what resolves it and the test genuinely exercises the bug.

## Gates

- `cargo build -p streamlib-cli -p streamlib` — clean (streamlib-cli warning-free; only pre-existing streamlib-engine warnings)
- `cargo test -p streamlib-cli` — all pass, 0 failed (incl. the new regression test)

Closes #1343

🤖 Generated with [Claude Code](https://claude.com/claude-code)