### PR TITLE
refactor(infra)!: rename static-registry xtask command + docker/CI vars to package-source

### DIFF
--- a/.github/workflows/check-pack-load.yml
+++ b/.github/workflows/check-pack-load.yml
@@ -89,7 +89,7 @@ jobs:
 
       # `.slpkg` store + catalog renderers, atomic staged-swap, and the
       # completeness negative gate (folded in from the retired
-      # static-registry workflow).
+      # static package-source workflow).
       - name: cargo test -p streamlib-pack
         run: cargo test --locked -p streamlib-pack
 

--- a/.github/workflows/check-package-version-drift.yml
+++ b/.github/workflows/check-package-version-drift.yml
@@ -7,10 +7,10 @@ name: Check Package Version Drift
 # `packages/*/Cargo.toml` `[package].version` equals its `streamlib.yaml`
 # `package.version` (the single source of truth). Schema-only packages (no
 # `Cargo.toml`) and workspace-inherited versions are skipped. A drift means
-# a stale crate version could reach the registry; the remedy is
+# a stale crate version could reach the package source; the remedy is
 # `cargo xtask check-package-version-drift --fix`.
 #
-# See also `docs/architecture/static-registry.md`.
+# See also `docs/architecture/package-source.md`.
 
 on:
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,21 @@
 # StreamLib — self-contained, headless, GPU-capable runtime image.
 #
 # Multi-stage:
-#   * builder : full toolchain (GPU-free). Emits an image-local STATIC registry
-#               tree (cargo sparse closure + vulkanalia fork + pypi + npm +
-#               `.slpkg` generic store + catalog + release manifest) from THIS
-#               checkout, and builds the runtime binaries.
+#   * builder : full toolchain (GPU-free). Emits an image-local STATIC
+#               package-source tree (cargo sparse closure + vulkanalia fork +
+#               pypi + npm + `.slpkg` generic store + catalog + release manifest)
+#               from THIS checkout, and builds the runtime binaries.
 #               (docker/build-stage1.sh does all of it.)
 #   * final   : nvidia/cuda runtime base + GPU/Vulkan/GLVND + V4L2 + userspace
 #               audio + the build toolchain (build-capable). Carries the static
-#               registry tree, the app dir, and the cargo caches. Runs the
+#               package-source tree, the app dir, and the cargo caches. Runs the
 #               service via docker/entrypoint.sh — no .deb, no systemd.
 #
-# The image is build-capable on purpose: the image-local static registry tree +
-# toolchain let `runtime.add_module` resolve and build packages against the same
-# registry-by-version model used locally (docs/architecture/static-registry.md).
-# There is no registry daemon: cargo + npm resolve over a dumb `python3 -m
+# The image is build-capable on purpose: the image-local static package-source
+# tree + toolchain let `runtime.add_module` resolve and build packages against
+# the same package-source-by-version model used locally
+# (docs/architecture/package-source.md). There is no daemon: cargo + npm resolve
+# over a dumb `python3 -m
 # http.server` mount the entrypoint serves (sparse + npm are HTTP-only by spec),
 # and pypi + `.slpkg` read the same tree straight off `file://`. The api-server
 # core module builds from source on first boot (warm cargo cache -> tens of
@@ -67,14 +68,14 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
 WORKDIR /src
 COPY . /src
 
-# Emit the image-local static registry tree (all internal libs + SDKs +
+# Emit the image-local static package-source tree (all internal libs + SDKs +
 # packages) and build the binaries. SKIP_* map to the emit's per-ecosystem
 # skip flags for faster iteration.
 ARG SKIP_PYTHON_SDK=0
 ARG SKIP_DENO_SDK=0
 ARG SKIP_PACKAGES=0
 ENV SRC=/src APP_DIR=/opt/streamlib \
-    REGISTRY_DIR=/opt/streamlib/registry REGISTRY_PORT=8799
+    PACKAGE_SOURCE_DIR=/opt/streamlib/package-source PACKAGE_SOURCE_PORT=8799
 RUN chmod +x docker/build-stage1.sh \
  && SKIP_PYTHON_SDK=${SKIP_PYTHON_SDK} SKIP_DENO_SDK=${SKIP_DENO_SDK} \
     SKIP_PACKAGES=${SKIP_PACKAGES} \
@@ -105,7 +106,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Language toolchains (Rust + cargo caches, uv, deno, jtd-codegen) and the
-# runtime cargo/npm registry config, lifted from the builder.
+# runtime cargo/npm package-source config, lifted from the builder.
 COPY --from=builder /usr/local/rustup /usr/local/rustup
 COPY --from=builder /usr/local/cargo  /usr/local/cargo
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
@@ -113,17 +114,17 @@ COPY --from=builder /usr/local/bin/deno /usr/local/bin/deno
 COPY --from=builder /usr/local/bin/jtd-codegen /usr/local/bin/jtd-codegen
 COPY --from=builder /root/.npmrc /root/.npmrc
 
-# The app dir: binaries + package source + the image-local static registry tree
-# (under /opt/streamlib/registry) the entrypoint serves / reads for add_module.
+# The app dir: binaries + package source + the image-local static package-source
+# tree (under /opt/streamlib/package-source) the entrypoint serves / reads for add_module.
 COPY --from=builder /opt/streamlib /opt/streamlib
 
 COPY docker/entrypoint.sh /usr/local/bin/streamlib-entrypoint
 COPY docker/pipewire/10-virtual.conf /etc/pipewire/pipewire.conf.d/10-virtual.conf
 RUN chmod +x /usr/local/bin/streamlib-entrypoint
 
-# Registry resolution against the image-local static tree: pypi + `.slpkg` read
+# Package-source resolution against the image-local static tree: pypi + `.slpkg` read
 # `file://` with no server; cargo + npm resolve over the localhost static mount
-# docker/entrypoint.sh serves on ${STREAMLIB_REGISTRY_HTTP_PORT} (sparse + npm
+# docker/entrypoint.sh serves on ${STREAMLIB_PACKAGE_SOURCE_HTTP_PORT} (sparse + npm
 # are HTTP-only by spec). The cargo `[source]`-replacement that redirects the
 # canonical `tatolab` index to that mount lives in $CARGO_HOME/config.toml
 # (written at build time, carried in via the /usr/local/cargo COPY).
@@ -131,10 +132,10 @@ ENV PATH=/opt/streamlib/bin:/usr/local/cargo/bin:/usr/local/bin:/usr/local/sbin:
     RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     STREAMLIB_HOME=/opt/streamlib \
-    STREAMLIB_REGISTRY_DIR=/opt/streamlib/registry \
-    STREAMLIB_REGISTRY_HTTP_PORT=8799 \
-    STREAMLIB_PACKAGE_SOURCE=file:///opt/streamlib/registry \
-    UV_INDEX=file:///opt/streamlib/registry/pypi/simple \
+    STREAMLIB_PACKAGE_SOURCE_DIR=/opt/streamlib/package-source \
+    STREAMLIB_PACKAGE_SOURCE_HTTP_PORT=8799 \
+    STREAMLIB_PACKAGE_SOURCE=file:///opt/streamlib/package-source \
+    UV_INDEX=file:///opt/streamlib/package-source/pypi/simple \
     XDG_RUNTIME_DIR=/run/user/0 \
     NVIDIA_DRIVER_CAPABILITIES=all \
     NVIDIA_VISIBLE_DEVICES=all

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,15 +3,15 @@
 A multi-stage, GPU-capable Docker image that ships StreamLib as a
 **self-contained, headless** runtime service: real NVIDIA Vulkan with no
 display server, userspace audio with no hardware, and an **image-local static
-registry tree pre-filled to match the source checkout** so the runtime can
-resolve and build new packages against the registry-by-version model entirely
-offline. There is no registry daemon — the tree is plain files, served for
+package-source tree pre-filled to match the source checkout** so the runtime can
+resolve and build new packages against the package-source-by-version model entirely
+offline. There is no daemon — the tree is plain files, served for
 cargo/npm by a dumb `python3 -m http.server` mount and read for pypi/`.slpkg`
 straight off `file://`.
 
 This replaces the earlier `.deb` plan — the image *is* the distribution unit,
-and the same registry-only resolution model that runs locally
-([`docs/architecture/static-registry.md`](../docs/architecture/static-registry.md))
+and the same package-source resolution model that runs locally
+([`docs/architecture/package-source.md`](../docs/architecture/package-source.md))
 runs inside the container.
 
 ## The setup splits across three layers — only one is the Dockerfile
@@ -22,7 +22,7 @@ access live on the host and in the run config.
 | Layer | What | Where |
 |---|---|---|
 | **1. Host** | NVIDIA driver, `nvidia-container-toolkit` wired into Docker, optional `v4l2loopback` virtual camera nodes | [`scripts/docker/host-prereqs.sh`](../scripts/docker/host-prereqs.sh) |
-| **2. Image** | Vulkan/GLVND + V4L2 + userspace audio + build toolchain + the static registry tree + the runtime | [`Dockerfile`](../Dockerfile) |
+| **2. Image** | Vulkan/GLVND + V4L2 + userspace audio + build toolchain + the static package-source tree + the runtime | [`Dockerfile`](../Dockerfile) |
 | **3. Run** | `--gpus all`, camera `--device`, RT opt-in | [`docker-compose.yml`](../docker-compose.yml) / `docker run` |
 
 ## Quick start
@@ -39,7 +39,7 @@ docker run --rm --gpus all -e NVIDIA_DRIVER_CAPABILITIES=all -p 9000:9000 stream
 ```
 
 The runtime's HTTP/WebSocket control plane is then on `localhost:9000`. The
-static registry mount the entrypoint serves for cargo/npm is localhost-internal
+static package-source mount the entrypoint serves for cargo/npm is localhost-internal
 (`127.0.0.1:8799` inside the container) and not exposed.
 
 ## What's inside
@@ -52,9 +52,9 @@ static registry mount the entrypoint serves for cargo/npm is localhost-internal
 - **Audio — userspace, no hardware.** cpal → ALSA → PipeWire via `pipewire-alsa`;
   a declarative virtual null sink ([`docker/pipewire/10-virtual.conf`](pipewire/10-virtual.conf))
   comes up in the entrypoint. No `/dev/snd`.
-- **Registry — image-local static tree, no daemon.** Stage 1 runs
-  `cargo xtask static-registry emit --cargo-closure` to write a plain on-disk
-  tree at `/opt/streamlib/registry`: a cargo sparse closure (the vendored
+- **Package source — image-local static tree, no daemon.** Stage 1 runs
+  `cargo xtask static-package-source emit --cargo-closure` to write a plain on-disk
+  tree at `/opt/streamlib/package-source`: a cargo sparse closure (the vendored
   `tatolab-vulkanalia*` crates included), a pypi-simple tree, an npm packument
   set, the `.slpkg` generic store,
   the catalog, and the release manifest (written last, the atomicity flip). The
@@ -95,5 +95,5 @@ static registry mount the entrypoint serves for cargo/npm is localhost-internal
   595.71.05, NVIDIA Container Toolkit 1.19.x. `nvidia/vulkan` is abandoned — do
   not use it; the CUDA runtime base + GLVND libs is the headless-Vulkan recipe.
 - systemd-in-Docker is avoided; [`docker/entrypoint.sh`](entrypoint.sh) is the
-  supervisor (registry mount + audio backgrounded with readiness polling,
+  supervisor (package-source mount + audio backgrounded with readiness polling,
   runtime exec'd as PID 1).

--- a/docker/build-stage1.sh
+++ b/docker/build-stage1.sh
@@ -4,32 +4,32 @@
 # Runs inside the `builder` image (full toolchain, GPU-free). It:
 #   1. builds the streamlib CLI + streamlib-runtime binaries in-place (the
 #      vulkanalia fork is vendored at vendor/tatolab-vulkanalia* and resolves by
-#      path — no registry bootstrap of any kind),
-#   2. emits the full image-local static registry tree (cargo closure — which
-#      includes the vendored tatolab-vulkanalia* crates — + pypi + npm +
+#      path — no package-source bootstrap of any kind),
+#   2. emits the full image-local static package-source tree (cargo closure —
+#      which includes the vendored tatolab-vulkanalia* crates — + pypi + npm +
 #      `.slpkg` generic store + catalog + release manifest) via
-#      `cargo xtask static-registry emit --cargo-closure`,
+#      `cargo xtask static-package-source emit --cargo-closure`,
 #   3. assembles the /opt/streamlib app dir (binaries + package source),
 #   4. writes the runtime cargo `[source]`-replacement + npm config pointing at
 #      the image-local tree, and runs an api-server resolution preflight.
 #
-# There is NO registry daemon. The RUNTIME tree is plain files the entrypoint
+# There is NO daemon. The RUNTIME tree is plain files the entrypoint
 # re-serves for cargo + npm over a dumb `python3 -m http.server` mount (sparse
 # + npm are HTTP-only by spec), while pypi + `.slpkg` read it straight off
 # `file://`. The final stage COPYs /opt/streamlib (carrying the tree) +
 # /usr/local/cargo (carrying the runtime `[source]` config) and
 # docker/entrypoint.sh re-serves the mount at runtime.
-# See docs/architecture/static-registry.md.
+# See docs/architecture/package-source.md.
 #
-# Configure-by-env (Dockerfile ARGs -> ENV): SRC, APP_DIR, REGISTRY_DIR,
-# REGISTRY_PORT, CARGO_HOME, and the SKIP_* toggles.
+# Configure-by-env (Dockerfile ARGs -> ENV): SRC, APP_DIR, PACKAGE_SOURCE_DIR,
+# PACKAGE_SOURCE_PORT, CARGO_HOME, and the SKIP_* toggles.
 set -euo pipefail
 
 SRC="${SRC:-/src}"
 APP_DIR="${APP_DIR:-/opt/streamlib}"
-REGISTRY_DIR="${REGISTRY_DIR:-${APP_DIR}/registry}"
-REGISTRY_PORT="${REGISTRY_PORT:-8799}"
-REGISTRY_BASE_URL="http://127.0.0.1:${REGISTRY_PORT}"
+PACKAGE_SOURCE_DIR="${PACKAGE_SOURCE_DIR:-${APP_DIR}/package-source}"
+PACKAGE_SOURCE_PORT="${PACKAGE_SOURCE_PORT:-8799}"
+PACKAGE_SOURCE_BASE_URL="http://127.0.0.1:${PACKAGE_SOURCE_PORT}"
 CARGO_HOME="${CARGO_HOME:?CARGO_HOME must be set}"
 
 # Map the fast-iteration skip toggles to the emit's per-ecosystem skip flags.
@@ -49,7 +49,7 @@ trap cleanup EXIT
 # ---------------------------------------------------------------------------
 # 1. Build the streamlib CLI + runtime binaries in-place. The vulkanalia fork
 #    is vendored at vendor/tatolab-vulkanalia* and resolves by path — no
-#    registry bootstrap or [source] replacement is needed for this build.
+#    package-source bootstrap or [source] replacement is needed for this build.
 # ---------------------------------------------------------------------------
 log "building streamlib CLI + runtime (release)"
 ( cd "$SRC" && cargo build --release -p streamlib-cli -p streamlib-runtime )
@@ -57,8 +57,8 @@ log "building streamlib CLI + runtime (release)"
 [ -x "$SRC/target/release/streamlib-runtime" ] || fail "streamlib-runtime not built"
 
 # ---------------------------------------------------------------------------
-# 2. Emit the full image-local static registry tree. --cargo-closure packages
-#    every workspace release-closure crate (including the vendored
+# 2. Emit the full image-local static package-source tree. --cargo-closure
+#    packages every workspace release-closure crate (including the vendored
 #    tatolab-vulkanalia* crates); pypi + npm + `.slpkg` store + catalog +
 #    release manifest (the atomicity flip) ride the same emit. The emit
 #    manages its OWN transient sub-servers internally (its inner
@@ -69,7 +69,7 @@ log "building streamlib CLI + runtime (release)"
 #    here, unlike the CI reference which runs a post-emit `cargo test
 #    --locked` in the same workspace.
 # ---------------------------------------------------------------------------
-EMIT_ARGS=(--out "$REGISTRY_DIR" --cargo-closure --base-url "$REGISTRY_BASE_URL")
+EMIT_ARGS=(--out "$PACKAGE_SOURCE_DIR" --cargo-closure --base-url "$PACKAGE_SOURCE_BASE_URL")
 [ "$SKIP_PYTHON_SDK" = 1 ] && EMIT_ARGS+=(--no-pypi)
 [ "$SKIP_DENO_SDK" = 1 ]   && EMIT_ARGS+=(--no-npm)
 [ "$SKIP_PACKAGES" = 1 ]   && EMIT_ARGS+=(--no-slpkg)
@@ -79,15 +79,15 @@ EMIT_ARGS=(--out "$REGISTRY_DIR" --cargo-closure --base-url "$REGISTRY_BASE_URL"
 # layer — kept for parity with the CI emit and to stay correct if a build cache
 # mount is ever added.
 rm -rf "$SRC/target/package"
-log "emitting static registry tree at $REGISTRY_DIR (base $REGISTRY_BASE_URL)"
-( cd "$SRC" && cargo run --release -q -p xtask -- static-registry emit "${EMIT_ARGS[@]}" )
-[ -f "$REGISTRY_DIR/cargo/config.json" ] || fail "static registry emit did not produce cargo/config.json"
+log "emitting static package-source tree at $PACKAGE_SOURCE_DIR (base $PACKAGE_SOURCE_BASE_URL)"
+( cd "$SRC" && cargo run --release -q -p xtask -- static-package-source emit "${EMIT_ARGS[@]}" )
+[ -f "$PACKAGE_SOURCE_DIR/cargo/config.json" ] || fail "static package-source emit did not produce cargo/config.json"
 
 # ---------------------------------------------------------------------------
 # 3. Assemble the /opt/streamlib app dir (binaries + package source). packages/
 #    source is required by the runtime's Path{IfStale} boot of api-server (the
 #    staleness check reads the source) and lets in-process add_module resolve
-#    any in-tree package by path. REGISTRY_DIR already lives under $APP_DIR.
+#    any in-tree package by path. PACKAGE_SOURCE_DIR already lives under $APP_DIR.
 # ---------------------------------------------------------------------------
 log "assembling $APP_DIR"
 mkdir -p "$APP_DIR/bin"
@@ -95,13 +95,13 @@ cp "$SRC/target/release/streamlib" "$SRC/target/release/streamlib-runtime" "$APP
 cp -a "$SRC/packages" "$APP_DIR/packages"
 
 # ---------------------------------------------------------------------------
-# 4. Runtime registry config (COPY'd to the final image via /usr/local/cargo +
+# 4. Runtime package-source config (COPY'd to the final image via /usr/local/cargo +
 #    /root). cargo resolves the canonical `tatolab` index through a [source]
 #    replacement pointing at the localhost static mount the entrypoint serves —
 #    source replacement keeps the canonical id in every Cargo.lock. npm reads the
-#    same mount. See docs/architecture/static-registry.md.
+#    same mount. See docs/architecture/package-source.md.
 # ---------------------------------------------------------------------------
-log "writing runtime cargo + npm registry config"
+log "writing runtime cargo + npm package-source config"
 mkdir -p "$CARGO_HOME"
 cat > "$CARGO_HOME/config.toml" <<EOF
 [registries.tatolab]
@@ -112,26 +112,26 @@ registry = "sparse+https://registry.tatolab.com/cargo/"
 replace-with = "tatolab-local"
 
 [source.tatolab-local]
-registry = "sparse+http://127.0.0.1:${REGISTRY_PORT}/cargo/"
+registry = "sparse+http://127.0.0.1:${PACKAGE_SOURCE_PORT}/cargo/"
 EOF
-printf '@tatolab:registry=http://127.0.0.1:%s/npm/\n' "$REGISTRY_PORT" > /root/.npmrc
+printf '@tatolab:registry=http://127.0.0.1:%s/npm/\n' "$PACKAGE_SOURCE_PORT" > /root/.npmrc
 
 # ---------------------------------------------------------------------------
 # 5. Resolution preflight for the api-server core module. The runtime builds
 #    api-server from source on first boot (build-capable image, warm cargo cache
 #    -> tens of seconds); this fetch verifies its dependency graph resolves
 #    against the emitted tree now, so a resolution gap fails the image build
-#    instead of first boot. Serve the tree on $REGISTRY_PORT (the port the
+#    instead of first boot. Serve the tree on $PACKAGE_SOURCE_PORT (the port the
 #    runtime cargo config points at) so `cargo fetch` resolves the closure
 #    (vendored tatolab-vulkanalia* included) exactly as the runtime will. Run in a temp copy so it doesn't pollute
 #    the shipped tree.
 # ---------------------------------------------------------------------------
 log "preflight: api-server dependency resolution against the emitted tree"
-python3 -m http.server "$REGISTRY_PORT" --bind 127.0.0.1 --directory "$REGISTRY_DIR" \
+python3 -m http.server "$PACKAGE_SOURCE_PORT" --bind 127.0.0.1 --directory "$PACKAGE_SOURCE_DIR" \
   >/tmp/preflight-httpd.log 2>&1 &
 PREFLIGHT_PID=$!
 for i in $(seq 1 30); do
-  curl -fsS "$REGISTRY_BASE_URL/cargo/config.json" >/dev/null 2>&1 && break
+  curl -fsS "$PACKAGE_SOURCE_BASE_URL/cargo/config.json" >/dev/null 2>&1 && break
   kill -0 "$PREFLIGHT_PID" 2>/dev/null || { cat /tmp/preflight-httpd.log; fail "preflight static server exited"; }
   [ "$i" = 30 ] && { cat /tmp/preflight-httpd.log; fail "preflight static server did not come up"; }
   sleep 1
@@ -144,4 +144,4 @@ kill "$PREFLIGHT_PID" 2>/dev/null || true
 wait "$PREFLIGHT_PID" 2>/dev/null || true
 PREFLIGHT_PID=""
 
-log "stage 1 complete — static registry tree emitted at $REGISTRY_DIR, binaries + cache assembled at $APP_DIR"
+log "stage 1 complete — static package-source tree emitted at $PACKAGE_SOURCE_DIR, binaries + cache assembled at $APP_DIR"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,21 +4,21 @@
 # Brings up the in-container support processes, then exec's the runtime as PID 1
 # so container-stop signals reach it directly:
 #   1. A dumb static HTTP mount (`python3 -m http.server`) over the image-local
-#      registry tree, so runtime `add_module` module builds resolve cargo
+#      package-source tree, so runtime `add_module` module builds resolve cargo
 #      (sparse is HTTP-only by spec) and deno npm deps offline. pypi + `.slpkg`
-#      read the same tree over `file://` and need no server. No registry daemon.
+#      read the same tree over `file://` and need no server. No daemon.
 #   2. The userspace audio stack (dbus session bus -> PipeWire -> WirePlumber)
 #      with a declarative virtual null sink — no /dev/snd, no display server.
 #   3. `exec streamlib-runtime --host 0.0.0.0` (overridable via the image CMD).
 #
 # Support processes are best-effort: core boot loads the pre-materialized
-# api-server from cache and needs neither the registry mount nor audio, so a
+# api-server from cache and needs neither the package-source mount nor audio, so a
 # support-process hiccup warns but never blocks the runtime. systemd-in-Docker
 # is avoided by design; this entrypoint is the supervisor.
 set -uo pipefail
 
-REGISTRY_DIR="${STREAMLIB_REGISTRY_DIR:-/opt/streamlib/registry}"
-REGISTRY_PORT="${STREAMLIB_REGISTRY_HTTP_PORT:-8799}"
+PACKAGE_SOURCE_DIR="${STREAMLIB_PACKAGE_SOURCE_DIR:-/opt/streamlib/package-source}"
+PACKAGE_SOURCE_PORT="${STREAMLIB_PACKAGE_SOURCE_HTTP_PORT:-8799}"
 XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/0}"
 export XDG_RUNTIME_DIR
 
@@ -30,22 +30,22 @@ warn() { printf '[entrypoint] WARN: %s\n' "$*" >&2; }
 mkdir -p "$XDG_RUNTIME_DIR" && chmod 700 "$XDG_RUNTIME_DIR"
 
 # ---------------------------------------------------------------------------
-# 1. Static registry HTTP mount (cargo + npm — sparse + npm are HTTP-only). The
+# 1. Static package-source HTTP mount (cargo + npm — sparse + npm are HTTP-only). The
 #    cargo [source] replacement in $CARGO_HOME/config.toml and /root/.npmrc both
-#    point at http://127.0.0.1:$REGISTRY_PORT; pypi + `.slpkg` resolve the same
+#    point at http://127.0.0.1:$PACKAGE_SOURCE_PORT; pypi + `.slpkg` resolve the same
 #    tree over `file://` with no server. Dumb static file server, no daemon.
 # ---------------------------------------------------------------------------
-if [ -d "$REGISTRY_DIR" ] && command -v python3 >/dev/null 2>&1; then
-  log "serving image-local static registry ($REGISTRY_DIR) on 127.0.0.1:$REGISTRY_PORT"
-  python3 -m http.server "$REGISTRY_PORT" --bind 127.0.0.1 --directory "$REGISTRY_DIR" \
-    >/var/log/streamlib-registry-httpd.log 2>&1 &
+if [ -d "$PACKAGE_SOURCE_DIR" ] && command -v python3 >/dev/null 2>&1; then
+  log "serving image-local static package source ($PACKAGE_SOURCE_DIR) on 127.0.0.1:$PACKAGE_SOURCE_PORT"
+  python3 -m http.server "$PACKAGE_SOURCE_PORT" --bind 127.0.0.1 --directory "$PACKAGE_SOURCE_DIR" \
+    >/var/log/streamlib-package-source-httpd.log 2>&1 &
   for i in $(seq 1 30); do
-    curl -fsS "http://127.0.0.1:${REGISTRY_PORT}/cargo/config.json" >/dev/null 2>&1 && { log "registry mount ready"; break; }
-    [ "$i" = 30 ] && warn "registry mount not ready in 30s (core boot still works; add_module of new packages may not)"
+    curl -fsS "http://127.0.0.1:${PACKAGE_SOURCE_PORT}/cargo/config.json" >/dev/null 2>&1 && { log "package-source mount ready"; break; }
+    [ "$i" = 30 ] && warn "package-source mount not ready in 30s (core boot still works; add_module of new packages may not)"
     sleep 1
   done
 else
-  warn "registry tree/python3 not found — in-container package resolution disabled"
+  warn "package-source tree/python3 not found — in-container package resolution disabled"
 fi
 
 # ---------------------------------------------------------------------------

--- a/sdk/streamlib-python/pyproject.toml
+++ b/sdk/streamlib-python/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "streamlib"
 # Tracks the workspace [workspace.package].version in Cargo.toml. The static
-# registry emit (`cargo xtask static-registry emit`) is authoritative: it builds
+# package-source emit (`cargo xtask static-package-source emit`) is authoritative: it builds
 # the pypi sdist from the workspace version (+ optional -dev.N) at emit time.
 # Keep it in sync with the workspace on release so a bare local `uv build`
 # produces a sane version.

--- a/tools/streamlib-build-orchestrator/src/release_check.rs
+++ b/tools/streamlib-build-orchestrator/src/release_check.rs
@@ -40,10 +40,10 @@ use streamlib_idents::{
     PackageSourceClient, PackageSource, SemVer, SemVerRange, crates_missing_from_release,
 };
 
-/// Registry org the release manifest lives under. Matches the publish
-/// scripts' `STREAMLIB_REGISTRY_ORG` default.
-fn registry_org() -> String {
-    std::env::var("STREAMLIB_REGISTRY_ORG")
+/// Package-source org the release manifest lives under. Matches the publish
+/// scripts' `STREAMLIB_PACKAGE_SOURCE_ORG` default.
+fn package_source_org() -> String {
+    std::env::var("STREAMLIB_PACKAGE_SOURCE_ORG")
         .ok()
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "tatolab".to_string())
@@ -81,7 +81,7 @@ pub(crate) fn assert_release_complete(
         return Ok(());
     };
     let client = PackageSourceClient::new(&config);
-    let org = registry_org();
+    let org = package_source_org();
 
     // Available releases (newest-satisfying selection below). A listing
     // failure degrades to the exact-floor fallback per pin.
@@ -171,7 +171,7 @@ pub(crate) fn assert_release_complete(
         release_version: incomplete_versions.join(", "),
         missing: missing_all.join(", "),
         hint: "the package source has a partial or inconsistent release — re-run the release publish \
-               (cargo xtask static-registry emit) so the full closure lands, or pin a version \
+               (cargo xtask static-package-source emit) so the full closure lands, or pin a version \
                whose release manifest lists every dependency"
             .to_string(),
     })
@@ -391,7 +391,7 @@ mod tests {
             package: "@tatolab/mavlink".to_string(),
             release_version: "0.5.1".to_string(),
             missing: "streamlib-plugin-sdk@^0.5.0, vulkan-jpeg@^0.5.0".to_string(),
-            hint: "re-run the release publish (cargo xtask static-registry emit)".to_string(),
+            hint: "re-run the release publish (cargo xtask static-package-source emit)".to_string(),
         };
         let rendered = err.to_string();
         assert!(
@@ -405,7 +405,7 @@ mod tests {
         assert!(rendered.contains("vulkan-jpeg@^0.5.0"), "{rendered}");
         assert!(rendered.contains("@tatolab/mavlink"), "{rendered}");
         assert!(
-            rendered.contains("cargo xtask static-registry emit"),
+            rendered.contains("cargo xtask static-package-source emit"),
             "{rendered}"
         );
     }

--- a/tools/streamlib-pack/Cargo.toml
+++ b/tools/streamlib-pack/Cargo.toml
@@ -28,7 +28,7 @@ streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.7.45" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Gapless atomic directory swap (renameat2 RENAME_EXCHANGE) for the static
-# registry staged-tree flip — see static_registry::publish_staged_tree.
+# package-source staged-tree flip — see static_package_source::publish_staged_tree.
 libc = { workspace = true }
 
 [lints]

--- a/tools/streamlib-pack/src/lib.rs
+++ b/tools/streamlib-pack/src/lib.rs
@@ -1254,7 +1254,7 @@ fn manifest_bytes_for(pkg_dir: &Path, policy: PathDepPolicy) -> Result<Vec<u8>> 
 /// non-empty one lists each offender (`` `dep` → `path` ``). A missing
 /// manifest is treated as no offenders.
 ///
-/// The predicate the whole-tree static-registry emit skips on and the CLI
+/// The predicate the whole-tree static package-source emit skips on and the CLI
 /// `.slpkg` gate rejects on share this one definition — the skip is the same
 /// condition, sound by construction rather than a proxy. Filters exactly
 /// [`DependencySpec::Path`], so git/version-range `patch:` overrides never count.
@@ -1282,7 +1282,7 @@ pub(crate) fn path_patch_offenders(pkg_dir: &Path) -> Result<Vec<String>> {
 /// Cargo.toml dependency-table `path` deps ([`cargo_path_dep_offenders`]).
 ///
 /// [`ensure_no_path_artifacts`] rejects on these exact same two helpers for
-/// the [`AssembleTarget::Slpkg`] target, so the whole-tree static-registry
+/// the [`AssembleTarget::Slpkg`] target, so the whole-tree static package-source
 /// emit's skip predicate keys on the same condition it would otherwise
 /// hard-fail on: the skip set equals the rejection set, sound by construction
 /// (one shared definition per half) rather than a proxy. TARGET paths

--- a/tools/streamlib-pack/src/static_package_source.rs
+++ b/tools/streamlib-pack/src/static_package_source.rs
@@ -28,7 +28,7 @@ use streamlib_idents::{
 
 use crate::catalog::{build_package_catalog, build_sibling_versions};
 
-/// Options for [`emit_static_registry`].
+/// Options for [`emit_static_package_source`].
 #[derive(Debug, Clone)]
 pub struct EmitOptions {
     pub workspace_root: PathBuf,
@@ -164,9 +164,9 @@ pub fn sibling_temp(path: &Path, tag: &str) -> PathBuf {
     parent.join(format!(".{name}.{tag}.{nonce}"))
 }
 
-/// The registry org the tree is emitted under (`STREAMLIB_REGISTRY_ORG`, default `tatolab`).
-fn registry_org() -> String {
-    std::env::var("STREAMLIB_REGISTRY_ORG")
+/// The package-source org the tree is emitted under (`STREAMLIB_PACKAGE_SOURCE_ORG`, default `tatolab`).
+fn package_source_org() -> String {
+    std::env::var("STREAMLIB_PACKAGE_SOURCE_ORG")
         .ok()
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "tatolab".to_string())
@@ -198,10 +198,10 @@ fn target_version(base: &str, dev: Option<u32>) -> String {
 /// [`EmitOptions::out`], via a staging dir that is flipped in atomically once
 /// the [`ReleaseManifest`] lands (see [`publish_staged_tree`]). The whole tree
 /// is browsable as a plain HTTP directory index or read over `file://`.
-pub fn emit_static_registry(opts: &EmitOptions) -> Result<()> {
+pub fn emit_static_package_source(opts: &EmitOptions) -> Result<()> {
     let base = workspace_version(&opts.workspace_root)?;
     let target = target_version(&base, opts.dev);
-    let org = registry_org();
+    let org = package_source_org();
 
     build_and_flip(&opts.out, |staging| {
         emit_slpkg_and_manifest(opts, staging, &target, &org)
@@ -311,7 +311,7 @@ fn emit_slpkg_and_manifest(
                     tracing::warn!(
                         package = %pkg_dir.display(),
                         offenders = %offenders.join(", "),
-                        "skipping non-distributable package (path patch or cargo path dep) from static-registry .slpkg emit"
+                        "skipping non-distributable package (path patch or cargo path dep) from static package-source .slpkg emit"
                     );
                     skipped += 1;
                     continue;
@@ -341,7 +341,7 @@ fn emit_slpkg_and_manifest(
             catalog_index.extend(artifacts.index_lines);
             emitted += 1;
         }
-        tracing::info!(emitted, skipped, "static-registry .slpkg emit complete");
+        tracing::info!(emitted, skipped, "static package-source .slpkg emit complete");
     }
 
     // The release manifest lists exactly the `.slpkg` packages this emit
@@ -361,7 +361,7 @@ fn emit_slpkg_and_manifest(
     // the same atomic flip (`build_and_flip`) — a `file://` reader never
     // observes the aggregate without the release it describes. Ordering it
     // last keeps the HTTP-direct-write intuition (index after members)
-    // consistent. The CI static-registry emit smoke asserts the aggregate +
+    // consistent. The CI static package-source emit smoke asserts the aggregate +
     // a per-package catalog exist in the emitted tree, locking this
     // staging-relativity through the real emit path.
     let index_path = staging.join(CATALOG_INDEX_PATH);
@@ -536,7 +536,7 @@ mod tests {
     }
 
     /// The mid-publish window guarantee, exercised through the REAL seam
-    /// (`build_and_flip`, the exact path `emit_static_registry` runs) with a
+    /// (`build_and_flip`, the exact path `emit_static_package_source` runs) with a
     /// CONCURRENT reader: while a new release is built, a reader of the
     /// served tree only ever observes a complete release set — the old
     /// `{0.5.0}` or the new `{0.5.1}` — never a partial or mixed one.

--- a/tools/streamlib-pack/tests/emit_static_package_source_catalog.rs
+++ b/tools/streamlib-pack/tests/emit_static_package_source_catalog.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Integration: the REAL `emit_static_registry` path (→
+//! Integration: the REAL `emit_static_package_source` path (→
 //! `emit_slpkg_and_manifest` → `build_and_flip`) writes the per-package
 //! catalog + owned JTDs + the `catalog/index.ndjson` aggregate INSIDE the
 //! staged tree, so the served tree carries them after the atomic flip.
@@ -13,7 +13,7 @@
 use std::path::Path;
 
 use streamlib_idents::{CatalogClient, Org, Package, PackageRef, SemVer};
-use streamlib_pack::static_package_source::{EmitOptions, emit_static_registry};
+use streamlib_pack::static_package_source::{EmitOptions, emit_static_package_source};
 
 fn write(dir: &Path, rel: &str, body: &str) {
     let path = dir.join(rel);
@@ -102,7 +102,7 @@ fn real_emit_writes_catalog_inside_the_flipped_tree() {
     fixture_workspace(&workspace);
     let out = tmp.path().join("served");
 
-    emit_static_registry(&EmitOptions {
+    emit_static_package_source(&EmitOptions {
         workspace_root: workspace,
         out: out.clone(),
         dev: None,

--- a/tools/streamlib-pack/tests/static_package_source_slpkg.rs
+++ b/tools/streamlib-pack/tests/static_package_source_slpkg.rs
@@ -5,8 +5,8 @@
 //! consumer offline, and a TRUNCATED tree (a member missing from the release
 //! or its `.slpkg` removed) is REJECTED by the consumer-side completeness
 //! check — not silently half-resolved. This is the daemon-free negative gate
-//! from the static-registry issue, exercised against the exact tree layout
-//! `emit_static_registry` produces (`<out>/slpkg/<pkg>/<ver>/<pkg>.slpkg` +
+//! from the static package-source issue, exercised against the exact tree layout
+//! `emit_static_package_source` produces (`<out>/slpkg/<pkg>/<ver>/<pkg>.slpkg` +
 //! `<out>/slpkg/streamlib-release/<V>/manifest.json`).
 
 use streamlib_idents::{
@@ -170,13 +170,13 @@ fn removed_slpkg_from_tree_is_rejected_at_download() {
     );
 }
 
-/// The truncation gate proven against the manifest `emit_static_registry`
+/// The truncation gate proven against the manifest `emit_static_package_source`
 /// ACTUALLY writes (not a hand-built one): emit a minimal fake workspace's
 /// slpkg ecosystem through the real emit path, then truncate the emitted
 /// tree and assert the consumer-side checks reject it.
 #[test]
 fn emitted_tree_truncation_is_rejected_by_consumer_checks() {
-    use streamlib_pack::static_package_source::{EmitOptions, emit_static_registry};
+    use streamlib_pack::static_package_source::{EmitOptions, emit_static_package_source};
 
     // Minimal fake workspace: empty cargo workspace + one schemas-only
     // package (no cargo build at assemble time).
@@ -211,7 +211,7 @@ fn emitted_tree_truncation_is_rejected_by_consumer_checks() {
     .unwrap();
 
     let out = root.path().join("package-source");
-    emit_static_registry(&EmitOptions {
+    emit_static_package_source(&EmitOptions {
         workspace_root: ws.clone(),
         out: out.clone(),
         dev: None,

--- a/xtask/src/install_packages.rs
+++ b/xtask/src/install_packages.rs
@@ -17,7 +17,7 @@
 //!
 //! The distributable set is not a re-derived YAML list: it is driven from the
 //! single [`streamlib_pack::non_distributable_path_offenders`] predicate — the
-//! exact one the whole-tree static-registry emit skips on and the single-package
+//! exact one the whole-tree static package-source emit skips on and the single-package
 //! `streamlib pkg build` hard-fails on — so the CI skip set equals the emit skip
 //! set by construction. A package carrying a `streamlib.yaml` path-`patch:`
 //! block or a `Cargo.toml` dependency-table `path` dep (e.g. `api-server`,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -181,9 +181,9 @@ enum Commands {
     /// `streamlib.yaml` so the published manifest is path-free. Intended to
     /// run against a scratch copy of the crate before `cargo publish` (cargo
     /// bundles `streamlib.yaml` verbatim with no file-rewrite hook). The
-    /// publish-side half of the static registry distribution; the resolver's
-    /// `Registry` arm resolves the now-path-free dep from the registry. See
-    /// `docs/architecture/static-registry.md`.
+    /// publish-side half of the static package-source distribution; the resolver
+    /// resolves the now-path-free dep from the package source. See
+    /// `docs/architecture/package-source.md`.
     StripPublishManifest {
         /// Directory containing the `streamlib.yaml` to strip in place.
         #[arg(long)]
@@ -199,12 +199,12 @@ enum Commands {
     /// `docs/architecture/vendored-vulkanalia.md`.
     CheckVendoredVulkanalia,
 
-    /// Emit a daemon-free STATIC `.slpkg` registry tree (generic store +
+    /// Emit a daemon-free STATIC `.slpkg` package-source tree (generic store +
     /// catalog + release manifest) for the current workspace's `packages/*`
     /// into a directory served over `file://` or a dumb static HTTP mount. No
-    /// registry daemon, no token. See `docs/architecture/static-registry.md`.
+    /// daemon, no token. See `docs/architecture/package-source.md`.
     #[command(subcommand)]
-    StaticRegistry(StaticRegistryAction),
+    StaticPackageSource(StaticPackageSourceAction),
 
     /// Ground-truth enumerator for the `install-packages` CI gate (#1509):
     /// compile every distributable `packages/*` through the SAME on-box user
@@ -225,7 +225,7 @@ enum Commands {
 }
 
 #[derive(Subcommand)]
-enum StaticRegistryAction {
+enum StaticPackageSourceAction {
     /// Emit the `.slpkg` store + catalog + release manifest into `--out`,
     /// flipped in atomically once the release manifest lands.
     Emit {
@@ -301,9 +301,9 @@ fn main() -> Result<()> {
                 .with_context(|| format!("stripping path patches from {}", dir.display()))?;
             tracing::info!(dir = %dir.display(), "stripped path-flavor patch entries from streamlib.yaml");
         }
-        Commands::StaticRegistry(StaticRegistryAction::Emit { out, dev }) => {
-            use streamlib_pack::static_package_source::{EmitOptions, emit_static_registry};
-            emit_static_registry(&EmitOptions {
+        Commands::StaticPackageSource(StaticPackageSourceAction::Emit { out, dev }) => {
+            use streamlib_pack::static_package_source::{EmitOptions, emit_static_package_source};
+            emit_static_package_source(&EmitOptions {
                 workspace_root: workspace_root()?,
                 out,
                 dev,


### PR DESCRIPTION
Atomic infra half of the owner-approved complete purge of "registry" from the package-resolution surface (the term connotes a central hosted service and misleads AI agents). The code + docs rename is in #1578; **this PR stacks on it** and moves the BUILD / CI / CONTAINER layer in lock-step so no reference dangles. Base is `refactor/registry-to-package-source`, so this diff shows only the infra delta.

### What moved (atomically, grouped)
- xtask command: `static-registry emit` → `static-package-source emit` (`StaticPackageSource` clap variant + `StaticPackageSourceAction` enum); `emit_static_registry` → `emit_static_package_source`. Pack test file renamed to `emit_static_package_source_catalog.rs`.
- Docker env vars: `STREAMLIB_REGISTRY_DIR` → `STREAMLIB_PACKAGE_SOURCE_DIR`, `STREAMLIB_REGISTRY_HTTP_PORT` → `STREAMLIB_PACKAGE_SOURCE_HTTP_PORT`; local shell vars `REGISTRY_DIR`/`REGISTRY_PORT`/`REGISTRY_BASE_URL` → `PACKAGE_SOURCE_*`; path `/opt/streamlib/registry` → `/opt/streamlib/package-source`; registry-sense prose reworded. Dockerfile setters and the `build-stage1.sh` / `entrypoint.sh` readers stay in sync.
- `STREAMLIB_REGISTRY_ORG` → `STREAMLIB_PACKAGE_SOURCE_ORG` at both readers (`registry_org()` → `package_source_org()` in `release_check.rs` + `static_package_source.rs`). No in-repo writer sets it; the doc-comments now name the new var.
- CI workflow comments (`check-pack-load.yml`, `check-package-version-drift.yml`), `tools/streamlib-pack/Cargo.toml` comment, and `sdk/streamlib-python/pyproject.toml` comment updated to the new command / module path.

### Preserved (genuinely foreign)
cargo sparse `registry =` keys, `[registries.tatolab]` / `[source.tatolab]`, `registry.tatolab.com`, npmrc `@tatolab:registry=`, and `CARGO_REGISTRIES_TATOLAB_INDEX`.

### Flagged for a separate decision
- `TatolabRegistryPin` / `read_tatolab_registry_pins` (`streamlib-cargo-build`) parse the foreign cargo `registry = "tatolab"` key. Left as-is (renaming ripples across 4 files and the type names the cargo `registry` concept) — reported per instruction.
- Two registry-sense prose comments live in code-vocab, not infra, so they belong to #1578: `Cargo.toml` workspace comment ("from the static registry by version", also references the `Strategy::Registry` enum arm) and `spawn_deno_subprocess_op.rs` ("@tatolab scope at the static registry").

### Gates
- `cargo build -p xtask -p streamlib-pack -p streamlib-build-orchestrator` — clean (only pre-existing `streamlib-engine` dep warnings).
- Renamed pack test + `static_package_source_slpkg` (4) + `release_check` (8) unit tests pass.
- `cargo run -p xtask -- --help` shows `static-package-source`.
- `bash -n` on both docker scripts; Dockerfile setters ↔ script readers verified consistent.
- Repo-wide grep for `static-registry|static_registry|emit_static_registry|STREAMLIB_REGISTRY_DIR|STREAMLIB_REGISTRY_HTTP_PORT|STREAMLIB_REGISTRY_ORG|/opt/streamlib/registry` (minus target/vendor/docs/.claude/loops) returns nothing.

Refs #1570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)