### PR TITLE
fix(screen-capture): drop stale processors: from streamlib.yaml (unblocks docker emit)

### DIFF
--- a/packages/screen-capture/streamlib.yaml
+++ b/packages/screen-capture/streamlib.yaml
@@ -18,25 +18,3 @@ schemas:
     file: schemas/screen_capture_config.yaml
   VideoFrame:
     package: '@tatolab/core'
-processors:
-- name: ScreenCapture
-  description: Captures display, window, or application content using ScreenCaptureKit (macOS 12.3+)
-  runtime:
-    language: rust
-    options:
-      unsafe_send: true
-      python_version: null
-    env: {}
-  entrypoint: null
-  execution: manual
-  scheduling: null
-  config:
-    name: config
-    schema: ScreenCaptureConfig
-  state: []
-  inputs: []
-  outputs:
-  - name: video
-    schema: VideoFrame
-    description: Captured video frames from screen content
-    delivery_profile: null


### PR DESCRIPTION
Removes the stale `processors: ScreenCapture` from `packages/screen-capture/streamlib.yaml`. That processor is parked under `#[cfg(any())]` (compiles on no target), so it drifted from code and broke the static package-source emit — revealed once #1583 repaired the registry-caused `--cargo-closure` failure that was masking it.

Verified: local `xtask static-package-source emit` completes (15 emitted, non-distributable test-fixtures skipped). Stacked on #1583 so the full Docker build can be verified green.

Refs #1411

🤖 Generated with [Claude Code](https://claude.com/claude-code)