### PR TITLE
chore(op-model): reduce the milestone-loop skill to the workflow launcher

### DIFF
--- a/.claude/skills/milestone-loop/SKILL.md
+++ b/.claude/skills/milestone-loop/SKILL.md
@@ -1,104 +1,75 @@
 ---
 name: milestone-loop
-description: Run one reconciler pass of the standing milestone-loop — the turn procedure the `/loop 30m /goal …` firing invokes. Use when a loop firing (or a sprint-mode `/goal` with the owner present) needs to move the focused milestone one bounded step toward "merged, or waiting on the owner or on blockers." Reconciles loop state against GitHub, routes and classifies ready issues, launches the matching workflow, parks anything needing the owner, records state, and yields at a coherent boundary.
+description: Run one reconciler pass of the standing milestone-loop — the turn procedure the `/loop 30m /goal …` firing invokes. Use when a loop firing (or a sprint-mode `/goal` with the owner present) needs to move the focused milestone one bounded step toward "merged, or waiting on the owner or on blockers." Checks the kill switch, probes rig capability, launches the milestone-loop workflow, and surfaces anything needing the owner.
 ---
 
 # milestone-loop — the reconciler pass
 
-One firing of the standing loop is one turn of this procedure. A turn moves the focused milestone forward and yields; the `/goal` evaluator decides whether to fire again. Do the eight steps in order. Never end mid-edit — a turn ends only at a coherent boundary (a checkpoint commit + a state note, or work cleanly handed off).
+One firing of the standing loop is one run of `.claude/workflows/milestone-loop.js`. That workflow does the reconciling, classifying, planning, dispatching, and recording. This skill exists only for the four things a workflow script structurally cannot do:
+
+- **Filesystem access** — workflow scripts have none, so the kill-switch check happens here and paths arrive as arguments.
+- **The date** — `Date.now()` and argless `new Date()` throw inside a workflow (they would break resume), so `today` is computed here.
+- **The sandbox bypass** — the rig capability probe decides whether live verification may run at all.
+- **Reaching the owner** — `PushNotification` and `AskUserQuestion` are main-context only. A workflow returns owner-facing items; it never posts them.
+
+Everything with branching logic in it — routing, conflict analysis, stage selection, fix-round bounding — lives in the workflow as real control flow. Do not re-implement any of it here.
 
 This skill operates the loop; it never edits the loop's own definition, rules, agents, or constraints (that is a separate operating-model PR — see `.claude/rules/flow.md`).
 
-## 1. Load state and check the stops
-**FIRST, before any other read, `gh` call, or run-log line:** read ONLY the `paused` field of `.claude/loops/state/milestone-loop.json`. If it is `true`, **stop** — no other reads, no `gh` calls, no run-log line. That is a kill switch, and a paused firing must be a near-free no-op. If the file does not exist, create it from `.claude/loops/state.example.json` and treat `focused_milestone: null` as "ask the owner which milestone, then stop."
+## 1. Check the kill switch
 
-If not paused, read (in order):
-- `.claude/loops/constraints.md` — **binding**. These are hard rules for this turn, not guidance.
-- `.claude/loops/budget.md`. Measure **today's spend** with the mechanical meter — one Bash call, never a full read of the run-log:
+**FIRST, before any other read, `gh` call, or run-log line:** read ONLY the `paused` field of `.claude/loops/state/milestone-loop.json`. If it is `true`, **stop** — no other reads, no `gh` calls, no run-log line. A paused firing must be a near-free no-op, which is why this check stays here rather than costing a workflow launch to discover.
 
-  ```
-  grep -c "^{\"ts\":\"$(date -u +%F)" .claude/loops/state/milestone-loop.run-log.jsonl
-  ```
+If the file does not exist, create it from `.claude/loops/state.example.json`.
 
-  This counts the run-log lines whose `ts` is **today's UTC date** (`date -u +%F`); the day is the UTC date of `ts`, so the count can never be conflated with the cumulative turn number, and it survives the day rollover. Read at most the last few events with `tail -n` for context — never the whole file. If the count is **≥80% of the daily cap**, run this turn in **propose_only** mode (plan, draft, post questions — land no new code). If the daily cap is already hit, append a `"outcome":"budget-cap"` run-log line and stop. Owner-directed corrections and red-CI fixes are **exempt** from propose-only/cap (see `.claude/loops/budget.md`).
+Read `.claude/loops/constraints.md` — **binding**, hard rules for this turn.
 
-The knobs (`heartbeat`, `max_parallel`, `attempts_per_ticket`, `propose_only`, `live_verify`) come from `.claude/loops/README.md`. Honor `max_parallel` and `attempts_per_ticket` (cap 3) as hard limits this turn.
+## 2. Preflight capability probe
 
-**Preflight capability probe.** Read the `capabilities` object in the state file. If `probed_utcdate` equals today's UTC date (`date -u +%F`) and the block is present, trust the cache — skip the probe. Otherwise (block absent, or `probed_utcdate` stale, or any value is `unknown`) re-probe once for this loop-arm with READ-ONLY, sandbox-safe device probes: `ls /dev/video*`, `v4l2-ctl --device <n> --info` (query verbs only), `$DISPLAY` + `xdpyinfo`, and `/dev/dri/*` for a GPU — plus a ONE-TIME cheap bypass smoke (e.g. capture a single vivid frame via the `dangerouslyDisableSandbox` bypass) to confirm the bypass is actually permitted. Write the result back into `capabilities` (step 7): `camera`/`gpu`/`display` from the device probes, and `live_verify: "available"` only when the rig is present AND the bypass smoke succeeded (`"unavailable"` otherwise); stamp `probed_utcdate`. A **hand-set owner override wins** — refresh every key EXCEPT those listed in `capabilities.owner_overrides`, which is how a hand-set value is distinguished from a probed one. `live_verify: off` in the `.claude/loops/README.md` knob short-circuits the whole thing — treat live_verify as unavailable and park every live check.
+Read `capabilities` from the state file. If `probed_utcdate` equals today's UTC date (`date -u +%F`), trust the cache and skip the probe.
 
-## 2. Sync against GitHub
-GitHub is the source of truth; the state file only caches the loop's picture.
+Otherwise re-probe with READ-ONLY, sandbox-safe device probes: `ls /dev/video*`, `v4l2-ctl --device <n> --info` (query verbs only), `$DISPLAY` + `xdpyinfo`, and `/dev/dri/*` for a GPU — plus a ONE-TIME cheap bypass smoke (capture a single vivid frame via the Bash `dangerouslyDisableSandbox` bypass) to confirm the bypass is actually permitted.
 
-**Idle delta-probe first (cheap short-circuit).** Before the full sync, check whether anything actually changed since last turn. The state file caches, from the previous pass: the focused milestone's newest issue/comment `updatedAt`, each loop-owned open PR's head SHA + mergeable state, and the ids of in-flight background tasks. Re-read those with 1–2 `gh` calls plus a task-status check. If there is **no delta** AND (all code slots are full OR the loop is fully owner-gated), append the idle run-log line (`"outcome":"idle"`) and yield immediately — skip the rest of step 2 through step 6. Otherwise continue.
+Set `live_verify` to `available` only when the rig is present AND the bypass smoke succeeded; `unavailable` otherwise. Refresh every capability key **except** those named in `capabilities.owner_overrides` — that list is how a hand-set value is distinguished from a probed one. Stamp `probed_utcdate`.
 
-**Freshness.** `git fetch origin` and fast-forward the primary checkout's `main` as part of reconciliation — the local tree is part of the picture GitHub is the source of truth for, and a stale local `main` gives every new worktree a stale base (which is what lets an implement agent fabricate a no-diff "success").
+The `live_verify: off` knob in `.claude/loops/README.md` short-circuits all of this: treat live verification as unavailable and let every rig-touching ticket park.
 
-Reconcile via `gh`:
-- **Prune ghosts** — drop state entries for PRs that merged or issues that closed since last turn.
-- **GC merged worktrees** — run `.claude/scripts/gc-merged-worktrees.sh`. It removes any worktree
-  under `.claude/worktrees/` whose branch has a merged PR (whoever merged it — a mobile merge leaves
-  no local event), reclaiming its multi-GB build target. Safe/idempotent: only touches merged-PR
-  worktrees, never an in-flight or unpushed one. (Also fires immediately after the loop's own
-  `gh pr merge` via the `worktree-gc` PostToolUse hook.)
-- **Validate IDs** — every ticket ref in the state file still resolves to an open issue in the focused milestone.
-- **Consume owner answers.** The owner login is `owner_login` in the state file (operator-set — never derived from `gh repo view`, which returns the org). The loop's own `gh` identity shares that login, so `author.login` equality **cannot** distinguish an owner answer from the loop's own comment. Detection runs off a **comment-id ledger** instead: every time the loop posts a comment on a ticket (a claim, a parked question, any update — step 6), it records that comment's id (returned by `gh api`) in the ticket's state entry. A parked question is cleared by any comment on that ticket that postdates the question **and whose id the loop did NOT record as its own** — never by a comment the loop posted itself.
-- **Conflicting PRs.** A loop-owned open PR that is CONFLICTING vs `main` → launch `.claude/workflows/worktree-work.js` with `mode: 'rebase'` (a zone-matched lead rebases in-worktree, re-runs the gates, force-pushes). Rebases do **not** occupy `max_parallel` code slots — they add no new surface — so a mergeable PR never queues behind busy code slots, and the main context never hand-rebases. (N4, decided: auto-rebase on conflict, since `max_parallel 2` keeps force-push noise low.)
+## 3. Launch the workflow
 
-Cache the delta-probe fields and the comment-id ledger back into the state file in step 7.
+Compute `today` (`date -u +%F`) and the absolute repo root (`git rev-parse --path-format=absolute --git-common-dir`, then its parent — never `--show-toplevel`, which returns the worktree when called from inside one).
 
-## 3. Route and classify every candidate
-A **candidate** is an issue in the focused milestone with: no open `blocked-by` edge, unclaimed, ungated (no open owner question), and not on `hold`. For each candidate, read the issue **fresh from GitHub** (labels are display output — never read a label as input) and classify:
-- **Work shape** — one of: `design-first` (architecture brief before any build; **required** for engine-zone features per `.claude/rules/engine-doctrine.md`), `implement`, `bug-reproduce-first` (a failing test lands before the fix), or `research`.
-- **Zones touched** — which code areas (RHI/vulkan, plugin-abi, python/deno, packages/registry, camera/v4l2, docs, …) — drives which domain expert the workflow spawns and the parallel-conflict analysis.
-- **Rig needs** — GPU / camera / audio / none.
-- **Risk** — how far the change reaches (engine-core vs leaf).
+Launch in the **background**:
 
-Stamp the classification back as **display labels** (`gh label create` any that don't exist yet). The labels are output for humans and for `loop-status`; nothing in this loop reads them back as control.
+```
+Workflow({ scriptPath: ".claude/workflows/milestone-loop.js",
+           args: { today, repo_root, max_parallel, attempts_per_ticket, live_verify, attended } })
+```
 
-## 4. Parallel-conflict analysis
-Before launching a batch, refuse any pair that would collide:
-- **Same physical rig** — one in-flight ticket per GPU and per `/dev/videoN`. Serialize rig work; never launch two rig attempts at once.
-- **Predicted same hot-file surface** — especially ABI vtable / layout files, shared schema files, or a single core module two tickets both rewrite. Serialize these; a merge race there is expensive.
-- **Dependency edges** — never launch a ticket whose `blocked-by` is still open.
+Knobs (`heartbeat`, `max_parallel`, `attempts_per_ticket`, `propose_only`, `live_verify`) come from `.claude/loops/README.md`.
 
-Reduce the candidate set to a launchable batch that fits `max_parallel` and violates no conflict.
+Run this in the **primary checkout, never a worktree**. A session started in a worktree has no `.claude/loops/state/`, no `settings.local.json`, and no `merge-authorization.local` — `git worktree add` checks out tracked files only. The loop would start with no state, write a fresh one, and split-brain against the primary. Git permits a worktree inside a worktree, so this fails silently rather than erroring.
 
-## 5. ACT (skip in propose_only)
-For each ticket in the launchable batch:
-1. **Claim it** — post an owner-visible comment `▶ claimed — <one-sentence what & why>` (record its comment id in the ledger, step 2) and create the canonical branch `feat/<n>-<slug>`.
-2. **Launch the matching workflow** via the Workflow tool, in the **background**, one fresh worktree per attempt (`isolation: 'worktree'` on the build agents inside the script):
-   - `design-first` → `.claude/workflows/draft-design.js`
-   - `implement` / `bug-reproduce-first` → `.claude/workflows/worktree-work.js`, which owns the worktree's whole lifecycle: it creates the worktree and canonical branch from a fresh `origin/main`, composes its stage list from the ticket's shape and zones, walks it, verifies, applies bounded fix rounds, and opens the PR. It returns the branch, worktree path, the stages it planned and ran, the verdict, and any owner-facing items.
-   - `research` → `.claude/workflows/run-research.js`
-   - Verification is a stage **inside** that workflow, not a separate launch. A `PASS` opens a PR **ready for review** (a PASS means the branch is verified and ready to merge, so it is NEVER a draft — but never a merge either; merging is the owner's); a `FIX` runs a bounded fix round in the same worktree; a `DISCUSS` returns an owner item for the main context to park.
-   - **Live verification is loop-run, not parked, when the rig is present.** When `capabilities.live_verify == available` (step 1 preflight) AND the ticket's classified rig-needs (GPU / camera / display / codec — step 3) are non-empty, the loop RUNS `/verify-live` ITSELF as verify-change's evidence stage: build in the sandbox, run the built binary with the Bash `dangerouslyDisableSandbox` bypass + `DISPLAY=:1`, capture the window, Read the image / compute PSNR, and attach the evidence to R2 + the PR (see `.claude/skills/verify-live/SKILL.md` LOOP-RUN mode). It **parks** the live check for the human (step 6) ONLY when `live_verify != available` (rig unavailable, bypass denied, or `live_verify: off`). **Safety gate stays ASK, never hard-block:** read-only observation evals (camera→display, PSNR, decode roundtrip) auto-run; anything with a real-world SAFETY gate (actuators, motors, drone control) still ASKS the owner for approval first (step 6) before running.
-   - **Fixing an existing branch never gets hand-rolled.** A verify `FIX` is applied by the fix round inside `worktree-work.js`, in the same worktree, bounded at 2 rounds by the script's `while` loop rather than by recall. A conflicting-PR rebase runs the same workflow with `mode: 'rebase'`. **Never a hand-rolled `fix-<issue>.js` script, never a main-context edit.** The re-verify after a fix round is a delta re-verify: it keeps the change-verifier (still running the full gate battery) and the evidence audit but skips the domain-lens + craftsmanship fan-out, which already cleared the branch on the first full verify.
+## 4. Surface what needs the owner
 
-   Invoke as `{ scriptPath: ".claude/workflows/<script>.js", args: { issue: N, branch, … } }`.
+The workflow returns `owner_items` — parked questions, `DISCUSS` verdicts, escalations, and cap notices. It cannot reach the owner itself. For each item:
 
-   **Attempt accounting.** An *attempt* is a fresh workflow launch — a new worktree, from Claim. The attempt cap is **3** per ticket; at the third failed attempt, **escalate** (step 6) rather than starting a fourth. Attempts are counted here because they span workflow runs; fix rounds live inside a single run and are bounded by that script. Owner-directed corrections and CI-red fixes never count toward the attempt cap.
+**If the owner is interactively reachable** (running attended, not a headless firing), use **`AskUserQuestion`** — structured and one-click. Frame 2–4 tight options, and **ALWAYS include an option that lets the owner launch research subagents to help decide** (e.g. "Research it first" → spawn Opus research agents on the decision, then re-present). Mirror the decision as a GitHub comment so there is a durable record.
 
-In **propose_only** mode, do not launch — instead post the plan-of-record for each candidate as an issue comment and move on.
+**When the owner is NOT reachable** (autonomous firing), park it as a GitHub comment — `AskUserQuestion` needs a live user:
 
-## 6. PARK anything needing the owner
-When a ticket needs a decision only the repo owner can make (an answered question, a merge, a milestone-scope call, or the attempt cap tripped):
-
-**If the owner is interactively reachable this turn** (the loop is running attended, not a headless cron firing), surface the decision with the **`AskUserQuestion` tool** — it's cleaner than a comment (structured, one-click). Frame 2–4 tight options, and **ALWAYS include an option that lets the owner launch research subagents to help decide** (e.g. "Research it first" → the loop spawns Opus research agents on the decision — approaches, trade-offs, a grounded recommendation — then re-presents). Still mirror the decision as a GitHub comment (below) so there's a durable record, and still record the ticket in "Waiting on the owner".
-
-**When the owner is NOT reachable this turn** (autonomous firing), park it as a GitHub comment instead — `AskUserQuestion` needs a live user:
 - Add the `gate` display label.
-- Post **one** decision comment in this **strict shape**, so the owner sees a pending decision at a glance and can answer in one token without reading prose (the owner has reported not even realizing a decision was pending, buried under paragraphs):
-  - **First line is a marked header** — `## ⛔ DECISION NEEDED — <the decision in one line>` (or `## ❓ OWNER QUESTION — <…>`). The marker + the one-line ask must be the very first thing in the comment.
-  - **Immediately below, the isolated replyable ask** — the choice as tight options the owner answers in one token: `**(a)** … · **(b)** … — reply **(a)** or **(b)**.` Put nothing between the header and the options.
-  - **Grounding / context goes BELOW a `---` divider** (keep it short) — never before the ask.
-- **Ping the owner via the `PushNotification` tool** — one line: what's pending + the ticket #. It reaches the owner's phone through their linked channel (e.g. Telegram). Only for a *new* question this turn; never re-ping a still-open one. **Only the loop's main context can reach the owner** — workflow subagents have no notification tool, so a workflow that surfaces an owner-facing need RETURNS it to the main loop (a `DISCUSS` / `owner-question` verdict) and the main loop posts the comment + sends the ping. A subagent never tries to reach the owner directly.
+- Post **one** decision comment in this **strict shape**, so a pending decision is visible at a glance without reading prose (the owner has reported not realizing a decision was pending, buried under paragraphs):
+  - **First line is a marked header** — `## ⛔ DECISION NEEDED — <the decision in one line>` (or `## ❓ OWNER QUESTION — <…>`).
+  - **Immediately below, the isolated replyable ask** — `**(a)** … · **(b)** … — reply **(a)** or **(b)**.` Nothing between the header and the options.
+  - **Grounding goes BELOW a `---` divider**, kept short — never before the ask.
+- **Ping via `PushNotification`** — one line: what's pending plus the ticket #. Only for a *new* question this turn; never re-ping a still-open one.
 
-Move the ticket to the state file's "Waiting on the owner" section with the question's age, and record the decision comment's id in the ledger (step 7).
+Record every comment id the loop posts into that ticket's `comment_ids` ledger in the state file. Parked-question detection keys off that ledger, never `author.login` — the loop's `gh` identity shares the owner's login, so a question is cleared only by a comment whose id the loop did not record.
 
-## 7. Write state and append the run-log
-Rewrite `.claude/loops/state/milestone-loop.json` to the loop's current picture. Every ticket the pass touched gets an entry under `tickets` carrying its `stage`, `attempt`, `fix_rounds`, `branch`, `worktree_path`, `workflow_run_id`, classification (`zones` / `shape` / `rig_needs` / `lead`), and `comment_ids` — the ledger of the loop's own comments, so the next pass can detect an owner answer per step 2. The Acting on / Waiting / Watch / Ignored sections are **derived** from `stage` by `loop-status`; do not store them. Also persist the `delta_probe` cache so the next pass can run cheaply (the milestone's newest issue/comment `updatedAt`, each loop-owned open PR's head SHA + mergeable state, and in-flight background-task ids). When the step-1 preflight re-probed this pass, write the fresh `capabilities` values with today's `probed_utcdate` — never touching a key listed in `owner_overrides`. Append **exactly one** JSON-lines event to `.claude/loops/state/milestone-loop.run-log.jsonl` with the turn's `items`, `actions`, `attempts`, `verdicts`, `escalations`, `est_tokens`, and `outcome` (`progressed` / `blocked` / `budget-cap` / `idle`).
+Labels are display output. Nothing reads a label as control.
 
-The state directory is gitignored — write it in place and never commit it. `branch-shield.sh` refuses commits on `main`, which is exactly why this state cannot be tracked.
+## 5. Yield
 
-## 8. Yield at a coherent boundary
-End the turn only when work is checkpointed or cleanly handed off — a background workflow launched, a draft PR opened, a question posted, plus the state write and run-log line from step 7. A headless final turn never ends with un-checkpointed background work. Do not decide whether to continue — the `/goal` evaluator fires the next turn.
+The workflow writes the state file and appends exactly one run-log event before it returns; a turn is checkpointed by that write, not by a commit (the state directory is gitignored — `branch-shield.sh` refuses commits on `main`, which is why it must be).
+
+End the turn once the workflow is launched or its owner-items are posted. Do not decide whether to continue — the `/goal` evaluator fires the next turn.

--- a/.claude/skills/work-on-ticket/SKILL.md
+++ b/.claude/skills/work-on-ticket/SKILL.md
@@ -1,43 +1,58 @@
 ---
 name: work-on-ticket
-description: Take one ticket end-to-end in the current session with the owner present — the interactive counterpart to the standing loop. Use when they say "work on issue N", "let's do this ticket", "pick up X and I'll answer questions as you go", or want to drive a single issue to a draft PR now. Same router, same workflow scripts, same verifier as the loop — but questions come inline instead of parking.
+description: Take one ticket end-to-end in the current session with the owner present — the interactive counterpart to the standing loop. Use when they say "work on issue N", "let's do this ticket", "pick up X and I'll answer questions as you go", or want to drive a single issue to a PR now. Same workflow, same composed stages, same verifier as the loop — but questions come inline instead of parking.
 ---
 
 # work-on-ticket — the interactive one
 
-This is the debug interface for the loop: the same machinery a `milestone-loop` turn runs, driven on a single ticket with the owner in the room. The one difference is where questions go — **inline, not parked**.
+The debug interface for the loop: the same machinery a `milestone-loop` turn runs, driven on a single ticket with the owner in the room. The one difference is where questions go — **inline, not parked**.
 
 ## When to use vs the loop
-Use `work-on-ticket` when the owner is present and wants to drive a specific issue now and answer questions in real time. Use `milestone-loop` for the standing autonomous pass. The routing, the workflow scripts, and the verifier are identical — so a ticket taken here lands the same shape of work (branch, worktree-per-attempt, draft PR, verifier gate) that the loop would have produced.
+
+Use `work-on-ticket` when the owner is present and wants to drive a specific issue now and answer questions in real time. Use `milestone-loop` for the standing pass. The workflow, the stage composition, and the verifier are identical — so a ticket taken here lands the same shape of work the loop would have produced.
 
 ## Procedure
 
-### 1. Read the ticket fresh
-Pull the issue body from GitHub and read it against current code — the body is the goal, not a spec, and its file paths / claims may have gone stale. Confirm what's still true before locking a plan.
+### 1. Classify the ticket
 
-### 2. Classify (same router as the loop)
-Classify the work exactly as `milestone-loop` step 3 does: **work shape** (`design-first` — required for engine-zone features / `implement` / `bug-reproduce-first` / `research`), **zones touched**, **rig needs**, **risk**. Pick the build lead by zone (abi → plugin-abi-expert, python/deno → polyglot-ipc-expert, packages/package-source → package-source-expert, vulkan/rhi/video → gpu-vulkan-expert, camera/v4l2 → linux-media-expert, else generic).
+Read the issue fresh from GitHub against current code — the body is the goal, not a spec, and its file paths and claims may have gone stale. Determine the same four things the loop's classifier does:
 
-### 3. Announce the plan-of-record
+- **shape** — `design-first` (required for engine-zone features per `.claude/rules/engine-doctrine.md`) / `implement` / `bug-reproduce-first` / `research`
+- **zones** — the code areas touched
+- **rig_needs** — gpu / camera / display / audio, or none
+- **lead** — the domain expert for those zones, or null for generic
+
+Labels are display output; never read one as control input.
+
+### 2. Announce the plan-of-record
+
 State the fresh plan — what you'll change, the test shape, the scenario for live verification if any — and where it supersedes the issue body. This is the moment to catch a wrong assumption before work starts.
 
-### 4. Run the matching workflow
-Launch the same script the loop would:
-- `design-first` → `.claude/workflows/draft-design.js`
-- `implement` / `bug-reproduce-first` → `.claude/workflows/worktree-work.js`
-- `research` → `.claude/workflows/run-research.js`
+### 3. Launch the workflow
 
-Work in a fresh worktree per attempt; checkpoint at logical boundaries (commits are contractual, not optional). Honor the attempt cap of 3.
+Compute `today` (`date -u +%F`) and the absolute repo root, then launch the same script the loop dispatches to:
 
-### 5. Questions go inline — this is the whole difference
-Whenever the work hits a decision only the owner can make — an ambiguous requirement, a scope call, a design fork, a milestone question — **ask them directly with `AskUserQuestion`**, right then. Do NOT park a `gate` label and a question comment the way the loop does; they're here, so get the answer and keep going. Reserve GitHub-comment parking for the autonomous loop.
+```
+Workflow({ scriptPath: ".claude/workflows/worktree-work.js",
+           args: { issue, slug, zones, shape, lead, rig_needs, live_verify, repo_root, today } })
+```
 
-Everything else that isn't owner-only — a fact you can derive, a check you can run — you resolve yourself; don't turn a derivable question into an interruption.
+`design-first` routes to `draft-design.js` and `research` to `run-research.js` instead.
 
-### 6. Verify and open a draft PR
-Verification is a stage inside `worktree-work.js`, not a separate launch. A `PASS` opens a PR ready for review (never a merge — merging stays the owner's call). A `FIX` runs a bounded fix round in the same worktree. A `DISCUSS` comes back as an owner item, which you surface inline here rather than parking.
+The workflow composes its own stage list from `shape` and `zones`, creates the worktree and branch, gates, verifies, applies bounded fix rounds, and opens the PR ready for review on a `PASS`. Do not hand-roll any of those steps here, and never edit the branch from this context — the constraint against main-context edits is not relaxed just because the owner is watching.
 
-If the change needs live rig verification (GPU / camera / display), you cannot run it from a sandboxed session — hand off via `/verify-live`: emit the exact command block for the owner's terminal, and audit the output they report back.
+Honor the attempt cap of 3.
 
-### 7. Report
-Close with what landed: the branch, the draft PR, the verifier verdict, any follow-ups surfaced (don't auto-file them — surface and let the owner decide), and whatever still needs a live run.
+### 4. Questions go inline — this is the whole difference
+
+The workflow returns `owner_items` for anything only the owner can decide. Surface each one with **`AskUserQuestion`**, right then. Do NOT park a `gate` label and a question comment the way the loop does — they're here, so get the answer and keep going.
+
+Everything that isn't owner-only — a fact you can derive, a check you can run — you resolve yourself; don't turn a derivable question into an interruption.
+
+### 5. Live verification
+
+If the ticket's `rig_needs` are non-empty, the workflow runs the Evidence stage itself when `live_verify` is `available`. When it isn't, hand off via `/verify-live`: emit the exact command block for the owner's terminal and audit the output they report back.
+
+### 6. Report
+
+Close with what landed: the branch, the PR, the verifier verdict, the stages the workflow actually composed and ran, any follow-ups surfaced (don't auto-file them — surface and let the owner decide), and whatever still needs a live run.


### PR DESCRIPTION
With the reconciler now living in .claude/workflows/milestone-loop.js, the
skill's eight prose steps described logic that runs as code. Two descriptions of
the same state machine is how they drift apart.

The skill keeps only what the workflow runtime structurally forbids:

  - filesystem access (workflow scripts have none), so the paused kill-switch
    check stays here and paths arrive as arguments;
  - the date — Date.now() and argless new Date() throw inside a workflow because
    they would break resume, so `today` is computed here and passed in;
  - the sandbox bypass, since the rig capability probe decides whether live
    verification may run at all;
  - reaching the owner — PushNotification and AskUserQuestion are main-context
    only, so the workflow returns owner_items and never posts them.

The paused check in particular stays in the main context deliberately: a paused
firing must be a near-free no-op, and launching a workflow to discover you are
paused is not.

Everything with branching in it — routing, conflict analysis, stage selection,
fix-round bounding — now lives in the workflow, and the skill says so rather
than restating it.

work-on-ticket gets the same treatment: it is the attended launcher for the same
worktree-work.js, differing only in that owner items are answered inline via
AskUserQuestion instead of parked as a gate comment. It no longer promises a
draft PR (a verified branch opens ready for review), and it no longer implies
the main-context edit ban relaxes because the owner is watching.

Also records the runtime posture: run the loop in the primary checkout, never a
worktree. A worktree session has no state, no settings.local.json, and no
merge-authorization.local, so it would start blank and split-brain against the
primary — and git permits a worktree inside a worktree, so it fails silently
rather than erroring.

Stack layer 3 of 3.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ykuJjE7uJK87KHCoaE3c5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>