### PR TITLE
docs(loop): add a hello-world smoke marker to verify the loop end-to-end

### DIFF
--- a/docs/loop-smoke-test.md
+++ b/docs/loop-smoke-test.md
@@ -1,0 +1,6 @@
+# Loop smoke test
+
+This file exists only as a smoke marker for the milestone-loop's worktree workflow — it proves the
+loop can take an issue (#1611) from a fresh worktree through a commit, a pull request, and a merge
+end to end. It documents nothing about streamlib itself and is safe to delete once the loop rework
+has landed.


### PR DESCRIPTION
Closes #1611

## Summary

Adds `docs/loop-smoke-test.md`, a deliberately trivial one-file marker whose sole
purpose is to exercise the milestone-loop's full path end to end: claim -> worktree
-> rederive -> implement -> gates -> self-review -> verify -> PR. The file documents
nothing about streamlib itself and is safe to delete once the loop rework has landed.

## Change

- New file only: `docs/loop-smoke-test.md` (6 lines added, 0 files modified).
- No code, no tests, no index/nav changes — none are needed (no `mkdocs.yml`,
  `docs/README.md`, or `docs/index.md` exist; `git grep loop-smoke-test` finds no
  other reference).

## Test evidence

- `git diff origin/main...HEAD --stat` -> `docs/loop-smoke-test.md | 6 ++++++, 1 file changed, 6 insertions(+)`.
- 14 xtask gates and 2 cargo test gates ran green; all are diff-independent for this
  change (see review items below — this is expected for a docs-only marker, not a
  gap being papered over).
- `git check-ignore` exits 1 for the new file, confirming it is tracked, not ignored.

## E2E report

Not applicable — this ticket is documentation-only and touches no runtime,
GPU/camera, IPC, or codec path. No `/verify-live` run was needed or performed.

## Review items (non-blocking)

- **[low]** `docs/loop-smoke-test.md:4` — The shipped file carries a tracker
  reference that the branch's own plan of record explicitly committed to omitting.
  Line 4 reads "...it proves the loop can take an issue (#1611) from a fresh
  worktree...". The plan-of-record comment on issue #1611 states under "No tracker
  references in the file body": "the marker gains nothing from an issue number, so
  it will carry none. The tracker linkage lives in the PR/commit, per policy." The
  diff contradicts that. Not a hard-gate violation: `.claude/rules/docs-policy.md`
  scopes the tracker-ref ban textually to `docs/architecture/`, and this file is
  top-level `docs/`, so no CI or rule check fires. Confirmed by re-reading the rule
  rather than taking the plan's reading on faith. Suggested next step: either drop
  the `(#1611)` from line 4 so the file matches its stated plan and the spirit of
  docs-policy, or leave it and note here that the tracker ref was deliberately kept
  for provenance on a throwaway marker — do not silently ship the divergence
  unexplained.

- **[info]** `docs/loop-smoke-test.md:1` — Every gate that runs on this PR is
  vacuous with respect to this diff; the thing actually under test is the loop
  process, which the diff supplies no evidence about. The diff adds zero lines of
  code and zero tests, so the 14 xtask gates and the two cargo test gates are all
  diff-independent — they would pass identically against `origin/main`. Mentally
  reverting the change removes only a markdown file; nothing in the repo would
  fail. This is by design (issue body: "Deliberately trivial: the point is to
  exercise claim -> worktree -> rederive -> implement -> gates -> self-review ->
  verify -> PR, not to produce useful output"), so the usual "the negative test
  must actually fail" bar does not apply — the change adds no gate and protects no
  invariant. Recording it so no reader mistakes the green battery for evidence that
  the loop machinery works. No action needed on this branch — the real acceptance
  signal for milestone 40 is whether the claim -> worktree -> PR -> merge sequence
  completed without a human in the path, which is observed on GitHub, not in this
  diff.

- **[info]** `docs/loop-smoke-test.md:6` — Scope is clean and the ticket's "done
  means" is met literally. `git diff origin/main...HEAD --stat` ->
  `docs/loop-smoke-test.md | 6 ++++++, 1 file changed, 6 insertions(+)`. Zero
  existing files modified, satisfying "Do not modify any existing file". The file
  is an H1 plus one paragraph stating it exists only as a smoke marker for the
  milestone-loop's worktree workflow and is safe to delete — matching the requested
  content. Verified independently that no index update is needed: no `mkdocs.yml`,
  `docs/README.md`, or `docs/index.md` exist, `git grep loop-smoke-test` finds no
  other reference, and `git check-ignore` exits 1 so the file is tracked. Top-level
  `docs/*.md` is precedented (`logging.md`, `logging-schema.md`,
  `testing-hardware.md`, `rig-profile.example.md`). The docs-policy learnings-index
  requirement applies only to `docs/learnings/`, so it does not bind here. No
  opportunistic refactor, no unrelated fix, no new trait/struct/module, no
  engine-model surface touched. No action needed.

- **[info]** `docs/loop-smoke-test.md:6` — The file's own deletion trigger
  references state that is not on main, but the wording stays generic enough to be
  correct on arrival. Line 6 says "safe to delete once the loop rework has landed".
  The reworked op-model (`.claude/loops/`, `/work-on-milestone`) is unmerged on
  `chore/op-model-milestone-driver` — origin/main's `CLAUDE.md` still describes the
  older shape. The file cites no paths, so it does not assert unshipped structure
  as fact; the only forward-looking clause is the deletion trigger, which the issue
  body itself requested. Deletion is correctly left as the owner's call and out of
  scope here. No action needed — track the marker's removal alongside the
  loop-rework merge rather than in this PR.
