### PR TITLE
fix(extract): evaluate file-level #![cfg] in reachable.rs walk_file

### DIFF
--- a/sdk/streamlib-processor-extract/src/reachable.rs
+++ b/sdk/streamlib-processor-extract/src/reachable.rs
@@ -558,8 +558,44 @@ mod tests {
         );
     }
 
+    /// A file-level gate prunes the whole subtree, not just the gated file's own
+    /// items: an excluded file's `mod child;` is never followed, so a processor
+    /// living one level down is not collected either. An implementation that
+    /// filtered items instead of returning early would still descend and collect
+    /// `DeepChild`.
+    #[test]
+    fn file_level_inner_cfg_prunes_the_child_module_subtree() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "src/lib.rs", "pub mod gated;\n");
+        write(
+            root,
+            "src/gated.rs",
+            r#"#![cfg(target_os = "linux")]
+
+            pub mod child;"#,
+        );
+        write(
+            root,
+            "src/gated/child.rs",
+            r#"#[processor("@tatolab/demo/DeepChild", execution = reactive)]
+            pub struct DeepChild;"#,
+        );
+
+        assert!(
+            extract_reachable_rust_processors(root, &macos())
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            names(extract_reachable_rust_processors(root, &linux()).unwrap()),
+            vec!["DeepChild"]
+        );
+    }
+
     /// File-level gates run through the same combinator evaluator as item-level
-    /// ones: `all(...)` and `not(...)` resolve against the target.
+    /// ones: `all(...)`, `not(...)`, and `any(...)` resolve against the target,
+    /// mirroring [`cfg_combinators_evaluate`].
     #[test]
     fn file_level_inner_cfg_evaluates_combinators() {
         let tmp = tempdir();
@@ -567,7 +603,7 @@ mod tests {
         write(
             root,
             "src/lib.rs",
-            "pub mod unix_not_linux;\npub mod unix_and_linux;\n",
+            "pub mod unix_not_linux;\npub mod unix_and_linux;\npub mod any_exotic;\n",
         );
         write(
             root,
@@ -585,10 +621,73 @@ mod tests {
             #[processor("@tatolab/demo/UnixAndLinux", execution = reactive)]
             pub struct UnixAndLinux;"#,
         );
+        write(
+            root,
+            "src/any_exotic.rs",
+            r#"#![cfg(any(target_os = "windows", target_os = "redox"))]
+
+            #[processor("@tatolab/demo/AnyExotic", execution = reactive)]
+            pub struct AnyExotic;"#,
+        );
 
         assert_eq!(
             names(extract_reachable_rust_processors(root, &linux()).unwrap()),
             vec!["UnixAndLinux"]
+        );
+    }
+
+    /// The crate root is a module file like any other: a false `#![cfg]` on
+    /// `lib.rs` strips the whole crate, which is what `rustc` does (the
+    /// `#![cfg(any())]` parse-only idiom).
+    #[test]
+    fn file_level_inner_cfg_on_the_crate_root_strips_the_crate() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "src/lib.rs",
+            r#"#![cfg(target_os = "windows")]
+
+            #[processor("@tatolab/demo/NeverBuilt", execution = reactive)]
+            pub struct NeverBuilt;"#,
+        );
+
+        assert!(
+            extract_reachable_rust_processors(root, &linux())
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    /// An inner `#![cfg]` inside an *inline* `mod foo { ... }` is folded into
+    /// `ItemMod::attrs` by `syn`, so the `mod` arm of the walk already gates it.
+    /// This pins that half against a regression while the file-level half is
+    /// fixed.
+    #[test]
+    fn inline_mod_inner_cfg_is_honored() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "src/lib.rs",
+            r#"
+            pub mod inline_linux {
+                #![cfg(target_os = "linux")]
+
+                #[processor("@tatolab/demo/InlineLinux", execution = reactive)]
+                pub struct InlineLinux;
+            }
+            "#,
+        );
+
+        assert!(
+            extract_reachable_rust_processors(root, &macos())
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            names(extract_reachable_rust_processors(root, &linux()).unwrap()),
+            vec!["InlineLinux"]
         );
     }
 

--- a/sdk/streamlib-processor-extract/src/reachable.rs
+++ b/sdk/streamlib-processor-extract/src/reachable.rs
@@ -704,20 +704,46 @@ mod tests {
         );
     }
 
-    /// The evaluator fails closed at file level too: a predicate it cannot prove
-    /// means "not reachable", never "reachable".
+    /// The evaluator fails closed at file level too: a predicate whose tokens
+    /// are not a `Meta` at all means "not reachable", never "reachable". `syn`
+    /// parses an attribute body as an unvalidated token stream, so this file
+    /// reaches `eval_cfg_attr` and only fails at `parse_args`.
     #[test]
-    fn file_level_inner_cfg_fails_closed_on_unparseable_predicate() {
+    fn file_level_inner_cfg_fails_closed_on_an_unparseable_predicate() {
         let tmp = tempdir();
         let root = tmp.path();
-        write(root, "src/lib.rs", "pub mod bogus;\n");
+        write(root, "src/lib.rs", "pub mod unparseable;\n");
         write(
             root,
-            "src/bogus.rs",
+            "src/unparseable.rs",
+            r#"#![cfg(target_os =)]
+
+            #[processor("@tatolab/demo/Unparseable", execution = reactive)]
+            pub struct Unparseable;"#,
+        );
+
+        assert!(
+            extract_reachable_rust_processors(root, &linux())
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    /// The other fail-closed path: `target_os = 42` *is* a well-formed `Meta`,
+    /// so `parse_args` succeeds and the atom lookup — not the parser — is what
+    /// must refuse it, because a cfg value is always a string literal.
+    #[test]
+    fn file_level_inner_cfg_fails_closed_on_a_non_string_predicate_value() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "src/lib.rs", "pub mod non_string_value;\n");
+        write(
+            root,
+            "src/non_string_value.rs",
             r#"#![cfg(target_os = 42)]
 
-            #[processor("@tatolab/demo/Bogus", execution = reactive)]
-            pub struct Bogus;"#,
+            #[processor("@tatolab/demo/NonStringValue", execution = reactive)]
+            pub struct NonStringValue;"#,
         );
 
         assert!(

--- a/sdk/streamlib-processor-extract/src/reachable.rs
+++ b/sdk/streamlib-processor-extract/src/reachable.rs
@@ -18,6 +18,8 @@
 //! way `rustc` does (honoring `#[path = "..."]`), evaluates the `#[cfg(...)]`
 //! predicate on every `mod` and every `#[processor(...)]`-bearing struct against
 //! a [`ModuleReachabilityTarget`], and collects only the processors that survive.
+//! A module file's own inner `#![cfg(...)]` gates it the same way, pruning the
+//! whole subtree it declares.
 //!
 //! The parked-directory convention needs no special case: a parked module is
 //! declared `#[cfg(any())]` (an always-false predicate), so cfg evaluation skips
@@ -112,7 +114,8 @@ impl ModuleReachabilityTarget {
 /// Starts at the crate root (`src/lib.rs`, else `src/main.rs`, else both when a
 /// crate carries a lib and a bin), follows every reachable `mod` the way
 /// `rustc` resolves module files, and evaluates `#[cfg(...)]` on each `mod` and
-/// each `#[processor(...)]`-bearing struct against `target`. A `#[processor]`
+/// each `#[processor(...)]`-bearing struct against `target`, plus the inner
+/// `#![cfg(...)]` a module file declares on itself. A `#[processor]`
 /// under a cfg-excluded module — a cross-platform arm, a disabled feature, or a
 /// `#[cfg(any())]` parked directory — is never collected. The result is
 /// deterministic (source order within a file, module-declaration order across
@@ -187,6 +190,16 @@ impl ReachableModuleWalker<'_> {
             path: file.to_path_buf(),
             source: e,
         })?;
+
+        // A file-level inner `#![cfg(...)]` gates the module the file *is*, so a
+        // false predicate strips the file and everything it declares — including
+        // its `mod` children. `syn` keeps these on `File::attrs`; an inline
+        // `mod foo { #![cfg] }` instead folds them into `ItemMod::attrs`, which
+        // `walk_item` gates.
+        if !self.cfg_reachable(&parsed.attrs) {
+            tracing::trace!(file = %file.display(), "module file excluded by file-level cfg");
+            return Ok(());
+        }
 
         let rel = file
             .strip_prefix(self.crate_root)

--- a/sdk/streamlib-processor-extract/src/reachable.rs
+++ b/sdk/streamlib-processor-extract/src/reachable.rs
@@ -512,6 +512,109 @@ mod tests {
         );
     }
 
+    /// A file-level inner `#![cfg(...)]` gates the whole file the same way an
+    /// outer `#[cfg]` on the `mod` declaration does. The declaring `mod` is
+    /// unconditional, so only `syn::File::attrs` carries the gate.
+    #[test]
+    fn file_level_inner_cfg_excludes_the_whole_file() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "src/lib.rs", "pub mod linux_only;\n");
+        write(
+            root,
+            "src/linux_only.rs",
+            r#"#![cfg(target_os = "linux")]
+
+            #[processor("@tatolab/demo/LinuxOnly", execution = reactive)]
+            pub struct LinuxOnly;"#,
+        );
+
+        assert!(
+            extract_reachable_rust_processors(root, &macos())
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    /// The including half of the file-level gate: the same file under a target
+    /// that satisfies its `#![cfg]` still contributes its processor.
+    #[test]
+    fn file_level_inner_cfg_includes_when_target_matches() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "src/lib.rs", "pub mod linux_only;\n");
+        write(
+            root,
+            "src/linux_only.rs",
+            r#"#![cfg(target_os = "linux")]
+
+            #[processor("@tatolab/demo/LinuxOnly", execution = reactive)]
+            pub struct LinuxOnly;"#,
+        );
+
+        assert_eq!(
+            names(extract_reachable_rust_processors(root, &linux()).unwrap()),
+            vec!["LinuxOnly"]
+        );
+    }
+
+    /// File-level gates run through the same combinator evaluator as item-level
+    /// ones: `all(...)` and `not(...)` resolve against the target.
+    #[test]
+    fn file_level_inner_cfg_evaluates_combinators() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "src/lib.rs",
+            "pub mod unix_not_linux;\npub mod unix_and_linux;\n",
+        );
+        write(
+            root,
+            "src/unix_not_linux.rs",
+            r#"#![cfg(all(unix, not(target_os = "linux")))]
+
+            #[processor("@tatolab/demo/UnixNotLinux", execution = reactive)]
+            pub struct UnixNotLinux;"#,
+        );
+        write(
+            root,
+            "src/unix_and_linux.rs",
+            r#"#![cfg(all(unix, target_os = "linux"))]
+
+            #[processor("@tatolab/demo/UnixAndLinux", execution = reactive)]
+            pub struct UnixAndLinux;"#,
+        );
+
+        assert_eq!(
+            names(extract_reachable_rust_processors(root, &linux()).unwrap()),
+            vec!["UnixAndLinux"]
+        );
+    }
+
+    /// The evaluator fails closed at file level too: a predicate it cannot prove
+    /// means "not reachable", never "reachable".
+    #[test]
+    fn file_level_inner_cfg_fails_closed_on_unparseable_predicate() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(root, "src/lib.rs", "pub mod bogus;\n");
+        write(
+            root,
+            "src/bogus.rs",
+            r#"#![cfg(target_os = 42)]
+
+            #[processor("@tatolab/demo/Bogus", execution = reactive)]
+            pub struct Bogus;"#,
+        );
+
+        assert!(
+            extract_reachable_rust_processors(root, &linux())
+                .unwrap()
+                .is_empty()
+        );
+    }
+
     /// A module never `mod`-declared from the crate root is unreachable — a
     /// stray `.rs` under `src/` (scratch file, unwired arm) is not compiled and
     /// must not contribute a processor. The raw whole-tree scan would collect it.


### PR DESCRIPTION
### Ticket
Closes #1587 — https://github.com/tatolab/streamlib/issues/1587

### Summary
`walk_file` parsed each module file and went straight to `parsed.items`; `syn::File::attrs` was never read. `syn` puts a file's inner attributes there, so a `#![cfg(target_os = "linux")]` opening a module file was invisible to the reachability walk and its `#[processor]` was collected for every target — while the same gate written on an inline `mod foo { #![cfg] }` was already honored (`syn` folds those into `ItemMod::attrs`, which `walk_item` already checks). Reachability disagreed with `rustc` depending on where the author happened to write the gate.

The fix is one early return in `walk_file`, right after `syn::parse_file`, routed through the existing `cfg_reachable` evaluator (`sdk/streamlib-processor-extract/src/reachable.rs:199`):

```rust
if !self.cfg_reachable(&parsed.attrs) {
    tracing::trace!(file = %file.display(), "module file excluded by file-level cfg");
    return Ok(());
}
```

No new cfg machinery, no new atoms, no new trait/struct/module — it reuses the same evaluator already used for `mod`- and item-level gates (`cfg_reachable` at `reachable.rs:305`). Because it returns rather than filtering items, an excluded file also prunes the subtree it declares (its `mod` children), matching `rustc`'s own parse-only pruning for a false crate-level `#![cfg]`.

Fail-closed now applies at file granularity: an unmodelled file-level predicate drops the whole file. That's under-collection, which is loud — it surfaces as `only_in_manifest` drift and hard-fails `pkg build`, never a silent ship. Item-level cfg already had that posture; this extends it consistently to file level.

Commits:
- `12ca84e5` test(extract): reproduce file-level `#![cfg]` being ignored by walk_file
- `b75a8908` test(extract): extend the file-level `#![cfg]` reproduction to subtree, root, inline
- `86b22368` fix(extract): honor a file-level `#![cfg]` in the processor reachability walk
- `9f58591d` test(extract): exercise both fail-closed paths of a file-level cfg

Diff: `sdk/streamlib-processor-extract/src/reachable.rs` only — `1 file changed, 242 insertions(+), 1 deletion(-)` (`git diff c3a0ffdb...HEAD --stat`).

### Test evidence
- `cargo test -p streamlib-processor-extract` — green: 70 lib tests + 2 integration tests passing (69+2 before the final fail-closed split commit, 62+2 baseline before this branch).
- Regression check performed by actually reverting the production hunk in a scratch clone (not the repo tree) and re-running: `cargo test -p streamlib-processor-extract --lib` → `64 passed; 6 failed`, failing exactly `file_level_inner_cfg_excludes_the_whole_file`, `_prunes_the_child_module_subtree`, `_evaluates_combinators`, `_on_the_crate_root_strips_the_crate`, `_fails_closed_on_an_unparseable_predicate`, `_fails_closed_on_a_non_string_predicate_value` — confirming the new tests are non-vacuous.
- `cargo test -p streamlib-pack` — green (drift-enforcement consumer of this scan).
- `cargo clippy -p streamlib-processor-extract --all-targets -- -D warnings` — clean on this crate.
- `cargo doc -p streamlib-processor-extract --no-deps` — warning-free.
- Semantics cross-checked directly against `rustc` 1.94 (not just the ticket's prose): a crate with `src/gated.rs` opening `#![cfg(target_os = "windows")]` and declaring `pub mod child;` (child containing `compile_error!`) compiles clean on a non-matching host — confirming the subtree really is pruned, matching this fix's early-return semantics. Same result for a false file-level `#![cfg]` directly on `lib.rs`.
- In-tree blast radius re-derived independently (not just trusted from the commit message): the only `src/` file-level `#![cfg(...)]` outside this branch's own test fixtures is `runtime/streamlib-engine/src/vulkan/rhi/vulkan_swapchain_alloc_repro_test.rs:10`, whose declaring `mod` already carries the identical `#[cfg(all(test, target_os = "linux"))]`, so the walker excluded it before this change too — zero behavior change on this Linux dev host today.

### E2E report
Not applicable. This is a pure Rust logic change in an SDK-side static scanner (`sdk/streamlib-processor-extract`) — no GPU, camera, display, or codec path is touched, so `/verify-live` does not apply. Verification is unit/integration tests plus a direct `rustc` semantics probe (see Test evidence above).

### Review items (non-blocking)
All lenses passed; the following are informational notes and optional follow-ups surfaced during independent verification. None block merge.

### 1. [info] `sdk/streamlib-processor-extract/src/reachable.rs:199`

- **Claim:** The fix is the minimal one the ticket's Design section specified: a single early return after `syn::parse_file` routed through the existing `cfg_reachable` evaluator, with no new cfg machinery, no new atoms, no new trait/struct/module.
- **Evidence:** git diff c3a0ffdb...HEAD --stat = `1 file changed, 242 insertions(+), 1 deletion(-)`, all in reachable.rs. The production hunk is 4 lines of logic (`if !self.cfg_reachable(&parsed.attrs) { trace; return Ok(()); }`) reusing cfg_reachable at :305. No scope creep, no opportunistic refactor, no parallel abstraction.
- **Suggested next step:** None. Engine-doctrine 'extend, never parallel' is satisfied.

### 2. [info] `sdk/streamlib-processor-extract/src/reachable.rs:199`

- **Claim:** The new tests are non-vacuous — mentally reverting is not enough, so I actually reverted the production hunk and re-ran.
- **Evidence:** In /tmp/rev1587 (scratch clone, not the repo tree) `git show 86b22368 -- .../reachable.rs | git apply -R` then `cargo test -p ... --lib` -> `test result: FAILED. 64 passed; 6 failed`, naming file_level_inner_cfg_excludes_the_whole_file, _prunes_the_child_module_subtree, _evaluates_combinators (left ["AnyExotic","UnixAndLinux","UnixNotLinux"] vs right ["UnixAndLinux"]), _on_the_crate_root_strips_the_crate, _fails_closed_on_an_unparseable_predicate, _fails_closed_on_a_non_string_predicate_value. Exactly matches the count the final commit message claims.
- **Suggested next step:** None.

### 3. [info] `sdk/streamlib-processor-extract/src/reachable.rs:585`

- **Claim:** The chosen semantics (early return, i.e. prune the whole subtree; and a false gate on the crate root yields an empty crate) match real rustc, not just the ticket's prose.
- **Evidence:** Probed rustc 1.94 directly. /tmp/cfgprobe: src/gated.rs opens `#![cfg(target_os = "windows")]` and declares `pub mod child;` where src/gated/child.rs contains `compile_error!(...)`; `rustc --crate-type lib src/lib.rs` succeeded — the child was never expanded, so the subtree really is pruned. /tmp/cfgprobe2: a false `#![cfg]` on lib.rs with a `compile_error!` in the body also compiled clean. The tests at :585 and :655 lock exactly this.
- **Suggested next step:** None.

### 4. [info] `sdk/streamlib-processor-extract/src/reachable.rs:199`

- **Claim:** In-tree blast radius on a Linux host is genuinely zero — I re-derived this rather than trusting the commit message's 'byte-identical' claim.
- **Evidence:** `grep -rn '^\s*#!\[cfg(' --include='*.rs' | grep '/src/' | grep -v 'target_os = "linux")]$'` returns exactly one line: runtime/streamlib-engine/src/vulkan/rhi/vulkan_swapchain_alloc_repro_test.rs:10 `#![cfg(all(test, target_os = "linux"))]`. Its declaring `mod` already carries the same `#[cfg(all(test, target_os = "linux"))]` at runtime/streamlib-engine/src/vulkan/rhi/mod.rs:162, so the walker excluded it before the change too; the file also declares no `mod` children and no `#[processor]`. Every other `src/` file-level gate is plain `target_os = "linux"`, which is true for `ModuleReachabilityTarget::for_host()` here, so the guard never fires. runtime/streamlib-consumer-rhi/src/lib.rs:45 is `#![cfg_attr(docsrs, ...)]`, which `cfg_reachable`'s `is_ident("cfg")` filter correctly ignores.
- **Suggested next step:** None.

### 5. [info] `examples/polyglot-manual-source/plugin/src/lib.rs:19`

- **Claim:** The change introduces a new (correct) non-Linux failure mode that is not visible from any gate runnable here and should be stated on the PR body.
- **Evidence:** This package's crate root is entirely `#![cfg(target_os = "linux")]` (line 19) while examples/polyglot-manual-source/plugin/streamlib.yaml:26 commits a `processors:` list containing PolyglotManualSourceCountingSink. After the fix, on a non-Linux host the reachable scan derives an empty Rust set, so tools/streamlib-pack/src/lib.rs:799 `enforce_processor_manifest_matches_code` -> `check_processor_manifest_drift` reports `only_in_manifest` and hard-fails `pkg build`. That is the semantically right answer (the crate compiles to nothing on macOS), and it is loud rather than silent, but it is a behavior change no in-tree gate exercises since this repo builds on Linux.
- **Suggested next step:** State the accepted trade-off (fail-closed now applies at file granularity; a crate-root-gated package derives empty and hard-fails drift on a host whose target the gate excludes) as a documented review item in the PR body, since no PR body exists yet.

### 6. [low] `sdk/streamlib-processor-extract/src/reachable.rs:712`

- **Claim:** Fail-closed on a malformed predicate now silently discards a whole file and its subtree, where rustc would refuse to compile — an honest hard error would be a better long-term shape.
- **Evidence:** `file_level_inner_cfg_fails_closed_on_an_unparseable_predicate` writes `#![cfg(target_os =)]` and asserts the result is empty rather than an `ExtractError`. rustc rejects that source outright. The ticket's Non-derivable notes explicitly directed this ('an unparseable predicate must continue to mean "not reachable", not "reachable"'), and item-level cfg already has this posture via `eval_cfg_attr`'s `Err(_) => false` at :318, so it is per-spec and consistent — but the amplification from one item to one file+subtree is new.
- **Suggested next step:** No change in this PR (it matches the ticket). Consider a follow-up issue to promote an unparseable cfg predicate to a typed `ExtractError` so the author gets the real diagnostic instead of a downstream `only_in_manifest` drift report.

### 7. [low] `sdk/streamlib-processor-extract/tests/real_package_reachability.rs:60`

- **Claim:** No in-tree-package regression test covers a file-level `#![cfg]`; the real-package integration test only exercises packages/camera, which has none.
- **Evidence:** real_package_reachability.rs scans only `packages/camera` (camera_package_dir at :22). `grep -rn '^\s*#!\[cfg(' packages/camera` is empty. The file-level path is covered solely by the tempdir unit tests. Meanwhile examples/camera-python-display/effects and examples/polyglot-manual-source/plugin are real in-tree packages that do carry file-level gates.
- **Suggested next step:** Optional: add a real-package case pinning that examples/polyglot-manual-source/plugin derives its committed processor under a Linux target and an empty set under a macOS target.

### 8. [low] `sdk/streamlib-processor-extract/src/reachable.rs:557`

- **Claim:** The file-level gate is tested on a flat `src/foo.rs` and on the crate root, but not on a directory module `src/foo/mod.rs`.
- **Evidence:** file_level_inner_cfg_excludes_the_whole_file uses src/linux_only.rs; _prunes_the_child_module_subtree uses src/gated.rs; _on_the_crate_root_strips_the_crate uses src/lib.rs. No test writes a gated src/foo/mod.rs. The code path is identical (both flow through walk_file), so the risk is small, but mod.rs is the shape the existing nested_and_path_override_module_resolution test already treats as distinct.
- **Suggested next step:** Optional: add one mod.rs variant, or leave it — the walk_file entry point is shared so the marginal coverage is low.

### 9. [info] `sdk/streamlib-idents/src/semver.rs:269`

- **Claim:** `cargo clippy -D warnings` is red across the workspace, but this is a pre-existing base condition, not introduced by the branch.
- **Evidence:** `cargo clippy -p streamlib-processor-extract --all-targets -- -D warnings` in the worktree fails with 3 errors in streamlib-idents (should_implement_trait at semver.rs:269, plus int_plus_one and map values iteration). Re-ran the same command at base c3a0ffdb in the scratch clone: the identical 3 fire there as warnings ('`streamlib-idents` (lib) generated 3 warnings'). Clippy scoped to this branch's own crate is clean: `cargo clippy -p streamlib-processor-extract --all-targets` produces zero findings in streamlib-processor-extract.
- **Suggested next step:** Do not fix here (doctrine: report unrelated issues surfaced by clippy, never auto-fix). File a separate cleanup issue if the owner wants `-D warnings` to be green workspace-wide.

### 10. [info] `sdk/streamlib-processor-extract/src/reachable.rs:830`

- **Claim:** `cargo fmt --check` is dirty on this branch, but only in untouched code — the repo baseline is not rustfmt-clean under rustc 1.94.
- **Evidence:** `cargo fmt --all -- --check` at base c3a0ffdb reports 367 `Diff in` entries. The one diff inside reachable.rs is at :830, in the pre-existing feature_gated test's single-line `assert!(...)`, not in any line this branch added; every new test in the diff is already in the current rustfmt multi-line form. No `.github/workflows/*` job runs `cargo fmt --check`.
- **Suggested next step:** None for this PR. A workspace-wide rustfmt sweep is its own change.

### 11. [info] `xtask/src/check_cdylib_reach.rs:269`

- **Claim:** Four other in-tree scanners each carry their own `is_ident("cfg")` handling; the plan explicitly deferred them and that deferral is the right call, not a doctrine violation introduced here.
- **Evidence:** check_cdylib_reach.rs:269, lint_logging.rs:586, check_no_inventory_submit.rs:238, check_no_reverse_dns.rs:274 all parse with syn and inspect cfg attributes independently of reachable.rs. These are whole-tree lints with deliberately different semantics (they intentionally inspect all cfg arms), not module-reachability resolvers, and they predate this branch. The change makes no new pattern canonical, so the canonical-pattern-sweep rule does not bite.
- **Suggested next step:** If any of these has an analogous file-level `#![cfg(test)]` blind spot, file it separately — an over-flagging lint is loud, not silent, so it is not urgent.

### 12. [should-fix] `/home/jonathan-fontanez/Repositories/tatolab/streamlib/.claude/worktrees/file-level-cfg-in-walk-file/sdk/streamlib-processor-extract/src/reachable.rs:315`

- **Claim:** The conservative fail-closed cfg evaluator is silent, and this change widens its blast radius from one item to a whole crate/subtree. Because `pkg build` for the `Slpkg` target never compiles the crate, an unevaluable file-level `#![cfg]` surfaces only as a misleading `only_in_manifest` drift error — and source that does not compile still ships to consumers who build it at load time.
- **Evidence:** `walk_file` now returns early on a false file-level predicate with only a `trace!` that does not distinguish "target genuinely does not match" from "we could not evaluate the predicate": reachable.rs:199-202 `if !self.cfg_reachable(&parsed.attrs) { tracing::trace!(file = %file.display(), "module file excluded by file-level cfg"); return Ok(()); }`. The fail-closed arms are silent — reachable.rs:318 `Err(_) => false` and the `return false` arms in `eval_cfg_meta` (reachable.rs:331, 335, 341, 345). The PR pins the silent whole-crate/whole-file drop as tested contract in `file_level_inner_cfg_fails_closed_on_an_unparseable_predicate` (reachable.rs:711) and `file_level_inner_cfg_fails_closed_on_a_non_string_predicate_value` (reachable.rs:736). Meanwhile `tools/streamlib-pack/src/lib.rs:612` gates cdylib compilation to `AssembleTarget::StagedDir` only, so the `Slpkg` publish path never compiles the crate and never independently catches the bad predicate.
- **Suggested next step:** Fix at the evaluator, not at the new call site (engine-layer fix, one system): emit a `tracing::warn!` on `eval_cfg_attr`'s `Err(_)` arm and on `eval_cfg_meta`'s non-ident / non-string-literal arms, carrying the attribute's span/tokens, so a fail-closed exclusion is distinguishable from a legitimate target mismatch in a `pkg build` log. Thread the file path into `cfg_reachable` (or log it at the two `cfg_reachable` call sites on the false branch at warn level) so the message is actionable. The existing item-level behavior gets the same benefit.

### 13. [low] `/home/jonathan-fontanez/Repositories/tatolab/streamlib/docs/decisions/manifest-extraction-capability.md:120`

- **Claim:** The decision doc enumerates the exact set of places cfg is evaluated and is now incomplete — the module rustdoc was updated for the new file-level rule, the decision doc was not.
- **Evidence:** docs/decisions/manifest-extraction-capability.md:120-122 still reads "evaluates the `#[cfg(...)]` predicate on every `mod` and every `#[processor(...)]`-bearing struct against a `ModuleReachabilityTarget`" — an exhaustive-sounding enumeration that omits the file's own inner `#![cfg(...)]`. The corresponding rustdoc in the same PR was amended (reachable.rs:21-22 and reachable.rs:117-118).
- **Suggested next step:** Amend the enumeration in `docs/decisions/manifest-extraction-capability.md` to include the module file's own inner `#![cfg(...)]` (and that a false one prunes the declared subtree). Per `.claude/rules/docs-policy.md` this is an incomplete enumeration, not a supersession, so no strikethrough marker is needed.

### 14. [low] `/home/jonathan-fontanez/Repositories/tatolab/streamlib/.claude/worktrees/file-level-cfg-in-walk-file/sdk/streamlib-processor-extract/src/reachable.rs:677`

- **Claim:** A new test doc comment narrates the change rather than the contract, which `.claude/rules/comments.md` prohibits ("Don't narrate a change").
- **Evidence:** reachable.rs:675-678: "An inner `#![cfg]` inside an *inline* `mod foo { ... }` is folded into `ItemMod::attrs` by `syn`, so the `mod` arm of the walk already gates it. This pins that half against a regression while the file-level half is fixed." The first sentence is a legitimate `syn` behavior contract; the trailing "while the file-level half is fixed" is change narration that will read as stale the moment this merges.
- **Suggested next step:** Drop the trailing clause; keep the `syn` contract sentence, which is the part that carries non-derivable information.

### 15. [info] `/home/jonathan-fontanez/Repositories/tatolab/streamlib/.claude/worktrees/file-level-cfg-in-walk-file/tools/streamlib-pack/src/lib.rs:803`

- **Claim:** The publish-side drift gate builds its reachability target from `for_host()` alone, which by design defines no cargo features. A file-level `#![cfg(feature = "…")]` is now honored too, so the pre-existing feature blind spot extends from `mod`-level gates to whole files. No in-tree package hits it today.
- **Evidence:** `tools/streamlib-pack/src/lib.rs:803` is the only construction site in the tree: `let target = streamlib_processor_extract::ModuleReachabilityTarget::for_host();` — a grep for `with_feature` across `tools/`, `runtime/`, `sdk/` finds no call outside `reachable.rs` itself. `for_host`'s own doc states the constraint (reachable.rs:66-69: "Cargo features are NOT inferred here … add each enabled feature with `ModuleReachabilityTarget::with_feature`"). Because `check_processor_manifest_drift` treats `only_in_manifest` as a hard error, a distributable package that gates a declared processor behind a feature (including a *default* feature) cannot pass `pkg build`.
- **Suggested next step:** Out of scope for this PR. Worth a follow-up issue: have `enforce_processor_manifest_matches_code` read the package's `Cargo.toml` `[features].default` (and any features the pack invocation enables) and seed them via `with_feature`, so the drift target matches the cdylib the consumer will actually build.

### 16. [info] `/home/jonathan-fontanez/Repositories/tatolab/streamlib/.claude/worktrees/file-level-cfg-in-walk-file/sdk/streamlib-processor-extract/src/reachable.rs:199`

- **Claim:** Cross-build divergence note for the source-only `.slpkg` loop: a manifest published from a Linux host that declares a processor now pruned by a file-level `#![cfg(target_os = "linux")]` promises a registration a macOS consumer's load-time build cannot deliver. This is pre-existing for `#[cfg]`-on-`mod` and is not a defect of this diff.
- **Evidence:** A source-only `.slpkg` carries no prebuilt cdylib and is compiled on the consumer's host (`tools/streamlib-pack/src/lib.rs:606-612` and the comment block above it), while the shipped `processors:` section is a single host-independent list validated once, on the publisher's host, against `for_host()`. `packages/camera` already exhibits the `mod`-level shape (its parked Apple arm is `#[cfg(any())]`, per `sdk/streamlib-processor-extract/tests/real_package_reachability.rs:6-14`); this change makes file-level gates behave the same way.
- **Suggested next step:** No action on this PR. Note it on the PR body so the asymmetry is on record; if the owner wants it closed, the shape would be a per-target `processors:` projection or a publish-time multi-target derivation, which is its own issue.

### 17. [should-fix] `/home/jonathan-fontanez/Repositories/tatolab/streamlib/.claude/worktrees/file-level-cfg-in-walk-file/sdk/streamlib-processor-extract/src/reachable.rs:555`

- **Claim:** Real duplication: `file_level_inner_cfg_excludes_the_whole_file` (L532-550) and `file_level_inner_cfg_includes_when_target_matches` (L555-572) build byte-identical fixtures — same `src/lib.rs` body, same `src/linux_only.rs` body, same module name, same processor name — and differ only in the target passed and the assertion. Two copies of one fixture that must change together.
- **Evidence:** L535-543 and L558-566 are character-for-character the same three `write(...)` calls: `write(root, "src/lib.rs", "pub mod linux_only;\n")` then the same `r#"#![cfg(target_os = "linux")] ... pub struct LinuxOnly;"#`. Only L546 (`&macos()` + `is_empty()`) vs L569 (`&linux()` + `vec!["LinuxOnly"]`) differ. This also contradicts the file's own established shape: every other both-arms gate test asserts both directions against a single fixture — `cross_platform_arms_resolve_to_the_target_arm` (L467-501), `file_level_inner_cfg_prunes_the_child_module_subtree` (L580-607, added by this same diff), `inline_mod_inner_cfg_is_honored` (L680-705, same diff), `feature_gated_module_needs_the_feature` (L815-839).
- **Suggested next step:** Collapse the pair into one test (`file_level_inner_cfg_gates_the_whole_file`) that builds the fixture once and asserts both arms back to back, exactly like the sibling `file_level_inner_cfg_prunes_the_child_module_subtree` at L580 already does. Keep the excluding-arm doc sentence and the including-arm doc sentence in the merged doc comment.

### 18. [low] `/home/jonathan-fontanez/Repositories/tatolab/streamlib/.claude/worktrees/file-level-cfg-in-walk-file/sdk/streamlib-processor-extract/src/reachable.rs:714`

- **Claim:** Four of the new tests repeat the same eight-line 'crate root declares one `mod`; that mod file carries a file-level `#![cfg(<predicate>)]` plus one processor' scaffold, varying only the module name and the predicate string.
- **Evidence:** Sites: L535-543, L558-566, L715-723, L739-747. The two fail-closed tests (`..._on_an_unparseable_predicate` L712, `..._on_a_non_string_predicate_value` L736) are structurally identical — same lib.rs shape, same file shape, same `assert!(... .is_empty())` — differing only in `target_os =)` vs `target_os = 42` and the module/struct names.
- **Suggested next step:** Add a helper next to the existing test helpers (`write` L399, `linux` L405, `macos` L412, `names` L419): `fn write_crate_with_one_file_level_cfg_gated_module(root: &Path, module_name: &str, cfg_predicate: &str, processor_name: &str)`. Drive the two fail-closed cases from it so each test body is the predicate plus its assertion; the distinct doc comments (which do carry different information about which code path refuses) stay per-test.

### 19. [low] `/home/jonathan-fontanez/Repositories/tatolab/streamlib/.claude/worktrees/file-level-cfg-in-walk-file/sdk/streamlib-processor-extract/src/reachable.rs:200`

- **Claim:** Asymmetric instrumentation: the new `tracing::trace!` is the only cfg-prune point in the walk that logs. The two pre-existing prune points are silent, so a trace-level run now shows file-level exclusions but not `mod`-level ones — which prune equally large subtrees.
- **Evidence:** New: `tracing::trace!(file = %file.display(), "module file excluded by file-level cfg")` at L200. Silent siblings: the struct exclusion at L227-229 and, more tellingly, the `Item::Mod` exclusion at L236-238 — a `#[cfg(any())] mod parked;` prunes an entire subtree and logs nothing.
- **Suggested next step:** Either add a matching `tracing::trace!(module = %item_mod.ident, "module excluded by cfg")` on the `Item::Mod` early return at L237 (same subtree-pruning coarseness, makes a trace run explain the whole reachable set), or drop the new trace so all three prune points stay uniformly silent. Pick one — don't leave the walk half-instrumented.

### 20. [low] `/home/jonathan-fontanez/Repositories/tatolab/streamlib/.claude/worktrees/file-level-cfg-in-walk-file/sdk/streamlib-processor-extract/src/reachable.rs:302`

- **Claim:** `cfg_reachable`'s doc went stale in this diff: it is now also called with a `syn::File`'s inner attributes, but the doc still describes it as item-only. The repo's comments rule says to fix the docs of a method you touch, in the same edit.
- **Evidence:** L302-304 reads "Whether every `#[cfg(...)]` attribute on an item passes for the target. An item with no `#[cfg]` is always reachable" — but the new call site at L199 passes `&parsed.attrs`, a `syn::File`'s inner attrs, which is not an item.
- **Suggested next step:** Reword to "Whether every `#[cfg(...)]` attribute on an item or a module file passes for the target" (and the second sentence likewise). One-line change at L302.

### 21. [low] `/home/jonathan-fontanez/Repositories/tatolab/streamlib/.claude/worktrees/file-level-cfg-in-walk-file/sdk/streamlib-processor-extract/src/reachable.rs:678`

- **Claim:** Change narration in a doc comment, which `.claude/rules/comments.md` explicitly forbids ("Don't narrate a change"). It describes the state of this PR, so it reads wrong the moment it merges.
- **Evidence:** L677-678: "This pins that half against a regression while the file-level half is fixed." There is no in-flight "file-level half being fixed" once the branch lands — the sentence is PR context that belongs in the commit body.
- **Suggested next step:** Truncate the doc comment after "...so the `mod` arm of the walk already gates it." (L676-677). The remaining two sentences already carry the non-derivable fact (syn folds an inline mod's inner attrs into `ItemMod::attrs`), which is the only part worth a comment.

### 22. [low] `/home/jonathan-fontanez/Repositories/tatolab/streamlib/.claude/worktrees/file-level-cfg-in-walk-file/sdk/streamlib-processor-extract/src/reachable.rs:611`

- **Claim:** Inert intra-doc link: the doc comment links to a private test fn inside `#[cfg(test)]`, which rustdoc never builds — the link resolves to nothing, renders nowhere, and is checked by nothing.
- **Evidence:** L610-611: "mirroring [`cfg_combinators_evaluate`]" — the target is `mod tests`'s private `fn cfg_combinators_evaluate` at L785, inside `#[cfg(test)]`. `cargo doc` does not compile the test cfg, so the intra-doc link is decoration with no link-checking value.
- **Suggested next step:** Use plain backticks: ``mirroring `cfg_combinators_evaluate` ``. Reserve `[`...`]` intra-doc links for items rustdoc actually resolves (the repo's rustdoc convention in engine-doctrine.md is about documented public items).

### 23. [low] `/home/jonathan-fontanez/Repositories/tatolab/streamlib/.claude/worktrees/file-level-cfg-in-walk-file/sdk/streamlib-processor-extract/src/reachable.rs:194`

- **Claim:** The five-line inline comment on the new guard is about twice as long as it needs to be: its first sentence restates what the code plainly does, and only the second sentence carries information you cannot get by reading the code.
- **Evidence:** L194-198. Sentence 1 ("gates the module the file *is*, so a false predicate strips the file and everything it declares — including its `mod` children") is derivable from `if !self.cfg_reachable(&parsed.attrs) { return Ok(()) }` placed before the item loop. Sentence 2 ("`syn` keeps these on `File::attrs`; an inline `mod foo { #![cfg] }` instead folds them into `ItemMod::attrs`") is the load-bearing external-library fact and is exactly what `.claude/rules/comments.md` says to keep.
- **Suggested next step:** Trim to the syn-behavior sentence: `// syn keeps a file's inner attributes on File::attrs; an inline `mod foo { #![cfg] }` instead folds them into ItemMod::attrs, which walk_item gates.` Drop the first sentence.

### 24. [info] `/home/jonathan-fontanez/Repositories/tatolab/streamlib/.claude/worktrees/file-level-cfg-in-walk-file/sdk/streamlib-processor-extract/src/reachable.rs:199`

- **Claim:** Positive note worth keeping in the PR body: the fix is the engine-doctrine-correct shape — it routes the new gate through the existing `cfg_reachable`/`eval_cfg_meta` evaluator rather than adding a parallel file-level cfg path, so combinators, fail-closed behavior and the `#[cfg(any())]` parked-module convention all apply for free.
- **Evidence:** L199 calls the same `cfg_reachable` used at L227 (struct) and L236 (mod); the new `file_level_inner_cfg_evaluates_combinators` (L613) and the two fail-closed tests (L712, L736) confirm the shared evaluator's semantics carry over with zero new logic. Guard placement (after the `visited` insert and parse, before the item loop) is also right — an early `return Ok(())` rather than filtering items, which is what makes subtree pruning fall out.
- **Suggested next step:** No action. Mention the reuse in the PR body as the 'why this shape' note.

### 25. [info] `/home/jonathan-fontanez/Repositories/tatolab/streamlib/.claude/worktrees/file-level-cfg-in-walk-file/sdk/streamlib-processor-extract/src/reachable.rs:830`

- **Claim:** Pre-existing, not caused by this branch: `cargo fmt -p streamlib-processor-extract -- --check` is dirty in this worktree, but every diff site is in code the branch does not touch. Reporting rather than fixing, per the 'no auto-fixing unrelated issues' rule.
- **Evidence:** 18 fmt diff sites across `derive.rs`, `grammar.rs`, `lib.rs`, and `reachable.rs:830`. `reachable.rs:830` is `feature_gated_module_needs_the_feature`, which exists verbatim on `origin/main` (line 592 there) and is untouched by the diff. Local rustfmt is 1.8.0-stable and the repo pins no `rust-toolchain.toml`/`rustfmt.toml`, so this is almost certainly a local-toolchain-vs-CI formatting drift, not a branch regression.
- **Suggested next step:** Nothing on this PR. If CI fmt is green on main, ignore; if it is red on main too, that is a separate housekeeping issue about pinning the toolchain.
