### PR TITLE
fix(macros): preserve #[cfg] on processor struct fields

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,12 @@ jobs:
       # twin-drift and tier-1 wire-format locks — the guards against silent ABI
       # layout drift (which corrupts the driver only in a separately-built .slpkg).
       # These crates are pure-repr / engine-free, so they add no flaky or GPU tests.
+      # streamlib-macros carries the `#[processor]` field-attribute emission locks.
       # streamlib-engine's lib tests (host-body tier-1 + engine twin) are a tracked
-      # follow-up, pending a fix to a parallel-run test flake.
+      # follow-up, pending a fix to a parallel-run test flake — attribute_macro_test
+      # is named explicitly because it is the compile-level half of those emission
+      # locks and cannot live in the proc-macro crate's own lib tests.
       - name: Run unit tests
-        run: cargo test --locked -p streamlib -p streamlib-plugin-abi -p streamlib-plugin-sdk -p streamlib-processor-extract --lib
+        run: |
+          cargo test --locked -p streamlib -p streamlib-macros -p streamlib-plugin-abi -p streamlib-plugin-sdk -p streamlib-processor-extract --lib
+          cargo test --locked -p streamlib-engine --test attribute_macro_test

--- a/packages/camera/src/camera_to_cuda_copy.rs
+++ b/packages/camera/src/camera_to_cuda_copy.rs
@@ -56,17 +56,8 @@ const DEFAULT_SURFACE_WIDTH: u32 = 1920;
 #[cfg(target_os = "linux")]
 const DEFAULT_SURFACE_HEIGHT: u32 = 1080;
 
-// Per-platform backend stash. The proc-macro strips `#[cfg]` from
-// individual struct fields, so we collapse the platform-conditional
-// type into a single alias and instantiate against the right impl
-// at setup time.
 #[cfg(target_os = "linux")]
-type GpuBackendStash = Option<LinuxState>;
-#[cfg(not(target_os = "linux"))]
-type GpuBackendStash = ();
-
-#[cfg(target_os = "linux")]
-struct LinuxState {
+struct LinuxCudaCopyGpuResources {
     /// Cuda OPAQUE_FD DEVICE_LOCAL `VkBuffer` the per-frame copy fills.
     storage_buffer: StorageBuffer,
     /// The same allocation viewed as a `PixelBuffer` for the surface-store
@@ -119,7 +110,8 @@ struct LinuxState {
     output("video_out", "@tatolab/core/VideoFrame", description = "Camera frame forwarded verbatim; cuda surface side-effect happens during process()"),
 )]
 pub struct CameraToCudaCopyProcessor {
-    backend: GpuBackendStash,
+    #[cfg(target_os = "linux")]
+    linux_cuda_copy_gpu_resources: Option<LinuxCudaCopyGpuResources>,
     frame_count: AtomicU64,
 }
 
@@ -214,7 +206,7 @@ impl CameraToCudaCopyProcessor::Processor {
 
         let copy_recorder = full.create_command_recorder("camera_to_cuda_copy")?;
 
-        self.backend = Some(LinuxState {
+        self.linux_cuda_copy_gpu_resources = Some(LinuxCudaCopyGpuResources {
             storage_buffer,
             pixel_buffer,
             produce_done,
@@ -245,36 +237,46 @@ impl CameraToCudaCopyProcessor::Processor {
 
     #[cfg(target_os = "linux")]
     fn process_frame_inner(&mut self, frame: &VideoFrame) -> Result<()> {
-        let backend = self.backend.as_mut().ok_or_else(|| {
-            Error::Configuration("CameraToCudaCopy: backend not initialized".into())
-        })?;
+        let linux_cuda_copy_gpu_resources =
+            self.linux_cuda_copy_gpu_resources.as_mut().ok_or_else(|| {
+                Error::Configuration(
+                    "CameraToCudaCopy: GPU resources not initialized (setup() did not run)".into(),
+                )
+            })?;
 
         // Resolve the camera ring texture. The camera processor produces
         // RGBA8 ring textures registered under fresh UUIDs and rotates through
         // them; `frame.surface_id` carries the current ring slot's UUID.
-        let texture = backend.gpu_ctx.resolve_texture_by_surface_id(
-            &frame.surface_id,
-            frame.texture_layout,
-            frame.width,
-            frame.height,
-        )?;
+        let texture = linux_cuda_copy_gpu_resources
+            .gpu_ctx
+            .resolve_texture_by_surface_id(
+                &frame.surface_id,
+                frame.texture_layout,
+                frame.width,
+                frame.height,
+            )?;
 
         let cam_w = texture.width();
         let cam_h = texture.height();
-        if cam_w != backend.width || cam_h != backend.height {
+        if cam_w != linux_cuda_copy_gpu_resources.width
+            || cam_h != linux_cuda_copy_gpu_resources.height
+        {
             return Err(Error::Configuration(format!(
                 "CameraToCudaCopy: camera resolution {cam_w}x{cam_h} differs from \
                  cuda surface {}x{}; GPU-side resize is not implemented in this processor \
                  (the cuda buffer is a flat VkBuffer, not a VkImage, so vkCmdBlitImage \
                  cannot target it). Configure the camera at the same resolution.",
-                backend.width, backend.height
+                linux_cuda_copy_gpu_resources.width, linux_cuda_copy_gpu_resources.height
             )));
         }
 
-        backend.produce_signal_value += 1;
-        let signal_value = backend.produce_signal_value;
-        let region = ImageCopyRegion::tightly_packed(backend.width, backend.height);
-        let recorder = &mut backend.copy_recorder;
+        linux_cuda_copy_gpu_resources.produce_signal_value += 1;
+        let signal_value = linux_cuda_copy_gpu_resources.produce_signal_value;
+        let region = ImageCopyRegion::tightly_packed(
+            linux_cuda_copy_gpu_resources.width,
+            linux_cuda_copy_gpu_resources.height,
+        );
+        let recorder = &mut linux_cuda_copy_gpu_resources.copy_recorder;
 
         // The camera leaves ring textures in SHADER_READ_ONLY_OPTIMAL — its
         // registered per-surface invariant (the camera's own post-copy barrier
@@ -297,7 +299,7 @@ impl CameraToCudaCopyProcessor::Processor {
         recorder.record_copy_image_to_buffer(
             &texture,
             VulkanLayout::TRANSFER_SRC_OPTIMAL,
-            &backend.storage_buffer,
+            &linux_cuda_copy_gpu_resources.storage_buffer,
             region,
         )?;
         recorder.record_image_barrier(
@@ -314,7 +316,8 @@ impl CameraToCudaCopyProcessor::Processor {
         // No `consume_done` wait on the write path: the camera drops ticks when
         // the consumer skips a frame, and a GPU-wait on a stale consume edge
         // would deadlock the producer against a consumer that never read.
-        recorder.submit_signaling_timeline(&backend.produce_done, signal_value)?;
+        recorder
+            .submit_signaling_timeline(&linux_cuda_copy_gpu_resources.produce_done, signal_value)?;
         Ok(())
     }
 

--- a/runtime/streamlib-engine/tests/attribute_macro_test.rs
+++ b/runtime/streamlib-engine/tests/attribute_macro_test.rs
@@ -167,6 +167,94 @@ fn test_bare_processor_synthesizes_app_local_identity() {
     );
 }
 
+/// A field type that only exists on Linux, so the processor below can gate a
+/// field on the real `target_os` rather than only on always-true / always-false
+/// predicates.
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+pub struct CfgGatedFieldLinuxOnlyState {
+    pub linux_only_marker: u32,
+}
+
+/// The non-Linux half of the same pair.
+#[cfg(not(target_os = "linux"))]
+#[derive(Default)]
+pub struct CfgGatedFieldNonLinuxOnlyState {
+    pub non_linux_only_marker: u32,
+}
+
+/// A field type compiled on every target, gated by an always-true `cfg`.
+#[derive(Default)]
+pub struct CfgGatedFieldAlwaysCompiledState {
+    pub always_compiled_marker: u32,
+}
+
+// #1588: a `#[cfg]` authored on a processor struct field must be re-emitted at
+// BOTH generated sites — the `Processor` field definition and its `from_config`
+// struct-literal initializer. This is a compile-level proof: `any()` is false on
+// every target, so `never_compiled_state`'s deliberately-undeclared type only
+// resolves if the macro stripped that field from both sites; `all()` is true on
+// every target, so `always_compiled_state` only compiles if the surviving arm
+// still gets its initializer. The `target_os` pair exercises the real-world
+// shape on top of the target-independent halves.
+#[streamlib::sdk::processor(
+    "@tatolab/streamlib-engine/CfgGatedFieldProcessor",
+    execution = manual,
+    input("video_in", any),
+    output("video_out", any),
+)]
+pub struct CfgGatedFieldProcessor {
+    #[cfg(any())]
+    never_compiled_state: ThisTypeIsDeliberatelyUndeclared,
+    // The forwarded `allow` is load-bearing twice over: it silences
+    // `non_minimal_cfg` on the deliberately-degenerate always-true predicate,
+    // and it only reaches the generated field at all if the macro forwards lint
+    // controls — so this line also exercises that half of the filter in-tree.
+    #[allow(clippy::non_minimal_cfg)]
+    #[cfg(all())]
+    always_compiled_state: CfgGatedFieldAlwaysCompiledState,
+    #[cfg(target_os = "linux")]
+    linux_only_state: CfgGatedFieldLinuxOnlyState,
+    #[cfg(not(target_os = "linux"))]
+    non_linux_only_state: CfgGatedFieldNonLinuxOnlyState,
+}
+
+impl streamlib_engine::ManualProcessor for CfgGatedFieldProcessor::Processor {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn cfg_gated_processor_field_survives_onto_both_generated_sites() {
+    let processor = CfgGatedFieldProcessor::Processor::from_config(EmptyConfig).unwrap();
+    assert_eq!(processor.always_compiled_state.always_compiled_marker, 0);
+    #[cfg(target_os = "linux")]
+    assert_eq!(processor.linux_only_state.linux_only_marker, 0);
+    #[cfg(not(target_os = "linux"))]
+    assert_eq!(processor.non_linux_only_state.non_linux_only_marker, 0);
+}
+
+#[test]
+fn cfg_gated_processor_still_declares_its_port_fields_unconditionally() {
+    // The `inputs` / `outputs` PluginAbiObject fields are emitted ahead of the
+    // custom fields and are patched by name in `set_iceoryx2_resources` — the
+    // field-attribute filter must never reach them. Naming both fields here is
+    // the compile-level half; `is_configured()` is false until the host wires
+    // them after `from_config` returns.
+    let processor = CfgGatedFieldProcessor::Processor::from_config(EmptyConfig).unwrap();
+    assert!(!processor.inputs.is_configured());
+    assert!(!processor.outputs.is_configured());
+}
+
 #[test]
 fn test_processor_schema_ident_renders_canonical_joined_form() {
     // The structured SchemaIdent's Display impl produces the canonical

--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -174,8 +174,11 @@ struct CustomField {
 /// Authoring contract for `#[processor]` struct fields: `cfg` is the
 /// load-bearing forward — dropping it makes a platform-conditional field
 /// unconditional and its platform-specific type fails to resolve off that
-/// platform. `doc` and the lint controls ride along so an author's `///` and
-/// `#[allow(dead_code)]` survive expansion.
+/// platform. `doc` and the `allow` / `warn` / `deny` / `forbid` controls ride
+/// along so an author's `///` and `#[allow(dead_code)]` survive expansion.
+/// `expect` is excluded: the generated field is `pub` where the authored one
+/// was private, so a `dead_code` expectation the author wrote to silence a
+/// warning becomes an `unfulfilled_lint_expectation` warning instead.
 fn is_forwarded_onto_generated_field_definition(attribute: &syn::Attribute) -> bool {
     let path = attribute.path();
     path.is_ident("cfg")
@@ -184,7 +187,6 @@ fn is_forwarded_onto_generated_field_definition(attribute: &syn::Attribute) -> b
         || path.is_ident("warn")
         || path.is_ident("deny")
         || path.is_ident("forbid")
-        || path.is_ident("expect")
 }
 
 /// `cfg` is the only attribute a struct-expression field takes cleanly — a
@@ -894,6 +896,25 @@ mod processor_struct_emit_tests {
             .collect()
     }
 
+    /// The attribute path idents the filter kept for one emission site, in
+    /// authored order — the decision the filter actually makes, read without
+    /// going through a rendering.
+    fn forwarded_attribute_path_idents(
+        custom_fields: &[CustomField],
+        attributes_for_site: impl Fn(&CustomField) -> &Vec<syn::Attribute>,
+    ) -> Vec<String> {
+        custom_fields
+            .iter()
+            .flat_map(|custom_field| attributes_for_site(custom_field).iter())
+            .map(|attribute| {
+                let path = attribute.path();
+                path.get_ident()
+                    .map(Ident::to_string)
+                    .unwrap_or_else(|| render_without_whitespace(quote! { #path }))
+            })
+            .collect()
+    }
+
     fn platform_conditional_field_struct() -> ItemStruct {
         syn::parse_quote! {
             struct PlatformConditionalFieldProbe {
@@ -1026,6 +1047,7 @@ mod processor_struct_emit_tests {
             struct AnnotatedFieldProbe {
                 /// Authored doc on a processor field.
                 #[allow(dead_code)]
+                #[expect(unused_parens)]
                 #[cfg_attr(target_os = "linux", allow(unused))]
                 #[serde(skip)]
                 annotated_backend_state: Option<u32>,
@@ -1067,6 +1089,31 @@ mod processor_struct_emit_tests {
         );
     }
 
+    /// `expect` is the one lint control that must NOT ride along. The macro
+    /// re-emits the authored field as `pub`, which changes which lints can fire
+    /// on it at all, so a forwarded `#[expect(...)]` the author wrote to silence
+    /// a warning lands unfulfilled and warns `unfulfilled_lint_expectation`
+    /// instead — the inverse of the silencing they asked for.
+    #[test]
+    fn processor_struct_does_not_forward_expect_onto_the_generated_pub_field() {
+        let custom_fields = extract_custom_fields(&annotated_field_struct());
+        let forwarded_attribute_paths = forwarded_attribute_path_idents(&custom_fields, |field| {
+            &field.attributes_for_generated_field_definition
+        });
+        assert!(
+            !forwarded_attribute_paths.contains(&"expect".to_string()),
+            "`expect` must not reach the generated `pub` field — it would land \
+             unfulfilled and warn; forwarded attributes were: {:?}",
+            forwarded_attribute_paths
+        );
+        assert!(
+            forwarded_attribute_paths.contains(&"allow".to_string()),
+            "the probe must still exercise a forwarded lint control, or this \
+             test passes vacuously; forwarded attributes were: {:?}",
+            forwarded_attribute_paths
+        );
+    }
+
     /// The `from_config` struct-literal site takes `cfg` only — a `doc` on a
     /// struct-expression field is an `unused_doc_comments` warning and the
     /// gates deny warnings.
@@ -1083,7 +1130,7 @@ mod processor_struct_emit_tests {
             "from_config must still initialize the field — got: {}",
             rendered
         );
-        for dropped in ["doc", "allow", "cfg_attr", "serde"] {
+        for dropped in ["doc", "allow", "expect", "cfg_attr", "serde"] {
             assert!(
                 !rendered.contains(dropped),
                 "from_config initializer must forward `cfg` only, found `{}` — got: {}",

--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -923,7 +923,7 @@ mod processor_struct_emit_tests {
 
     /// `TokenStream::to_string` spacing is not part of any contract, so
     /// assertions compare against a whitespace-free rendering.
-    fn render_without_whitespace(tokens: TokenStream) -> String {
+    fn render_token_stream_without_whitespace(tokens: TokenStream) -> String {
         tokens
             .to_string()
             .chars()
@@ -931,23 +931,114 @@ mod processor_struct_emit_tests {
             .collect()
     }
 
-    /// The attribute path idents the filter kept for one emission site, in
-    /// authored order — the decision the filter actually makes, read without
-    /// going through a rendering.
+    /// The path ident of each attribute, in authored order.
+    fn attribute_path_idents(attributes: &[syn::Attribute]) -> Vec<String> {
+        attributes
+            .iter()
+            .map(|attribute| {
+                let path = attribute.path();
+                path.get_ident()
+                    .map(Ident::to_string)
+                    .unwrap_or_else(|| render_token_stream_without_whitespace(quote! { #path }))
+            })
+            .collect()
+    }
+
+    /// The attribute path idents the filter kept for one emission site — the
+    /// decision the filter actually makes, read without going through a
+    /// rendering.
     fn forwarded_attribute_path_idents(
         custom_fields: &[CustomField],
         attributes_for_site: impl Fn(&CustomField) -> &Vec<syn::Attribute>,
     ) -> Vec<String> {
         custom_fields
             .iter()
-            .flat_map(|custom_field| attributes_for_site(custom_field).iter())
-            .map(|attribute| {
-                let path = attribute.path();
-                path.get_ident()
-                    .map(Ident::to_string)
-                    .unwrap_or_else(|| render_without_whitespace(quote! { #path }))
+            .flat_map(|custom_field| attribute_path_idents(attributes_for_site(custom_field)))
+            .collect()
+    }
+
+    fn parse_generated_processor_struct(tokens: TokenStream) -> ItemStruct {
+        syn::parse2(tokens).expect("the struct emitter must emit a parseable `struct Processor`")
+    }
+
+    fn declared_field_names(generated_struct: &ItemStruct) -> Vec<String> {
+        match &generated_struct.fields {
+            syn::Fields::Named(fields) => fields
+                .named
+                .iter()
+                .filter_map(|field| field.ident.as_ref().map(Ident::to_string))
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    fn declared_field<'a>(
+        generated_struct: &'a ItemStruct,
+        field_name: &str,
+    ) -> Option<&'a syn::Field> {
+        match &generated_struct.fields {
+            syn::Fields::Named(fields) => fields.named.iter().find(|field| {
+                field
+                    .ident
+                    .as_ref()
+                    .is_some_and(|ident| ident == field_name)
+            }),
+            _ => None,
+        }
+    }
+
+    fn type_path_last_segment(ty: &syn::Type) -> Option<String> {
+        match ty {
+            syn::Type::Path(type_path) => type_path
+                .path
+                .segments
+                .last()
+                .map(|segment| segment.ident.to_string()),
+            _ => None,
+        }
+    }
+
+    /// The `Self { .. }` literal the emitted `from_config` returns, so field
+    /// assertions read the struct expression rather than its rendering.
+    fn parse_generated_from_config_struct_expression(tokens: TokenStream) -> syn::ExprStruct {
+        let from_config: syn::ImplItemFn =
+            syn::parse2(tokens).expect("the from_config emitter must emit a parseable method");
+        let tail = from_config
+            .block
+            .stmts
+            .last()
+            .expect("from_config must have a body");
+        let syn::Stmt::Expr(syn::Expr::Call(ok_call), _) = tail else {
+            panic!("from_config must end in an `Ok(..)` tail expression — got: {tail:?}");
+        };
+        match ok_call.args.first() {
+            Some(syn::Expr::Struct(struct_expression)) => struct_expression.clone(),
+            other => panic!("from_config must wrap a `Self {{ .. }}` literal — got: {other:?}"),
+        }
+    }
+
+    fn initialized_field_names(struct_expression: &syn::ExprStruct) -> Vec<String> {
+        struct_expression
+            .fields
+            .iter()
+            .filter_map(|field_value| match &field_value.member {
+                syn::Member::Named(ident) => Some(ident.to_string()),
+                syn::Member::Unnamed(_) => None,
             })
             .collect()
+    }
+
+    fn initialized_field<'a>(
+        struct_expression: &'a syn::ExprStruct,
+        field_name: &str,
+    ) -> Option<&'a syn::FieldValue> {
+        struct_expression
+            .fields
+            .iter()
+            .find(|field_value| match &field_value.member {
+                syn::Member::Named(ident) => ident == field_name,
+                syn::Member::Unnamed(_) => false,
+            })
     }
 
     fn platform_conditional_field_struct() -> ItemStruct {
@@ -988,49 +1079,91 @@ mod processor_struct_emit_tests {
     /// The `inputs` / `outputs` fields are the `#[repr(C)]` `(handle, vtable)`
     /// PluginAbiObjects the host patches through
     /// `ProcessorVTable::set_iceoryx2_resources`, so their presence is a plugin
-    /// ABI contract, not an authoring convenience: they are emitted from the
-    /// port schema ahead of the custom fields and no authored field attribute
-    /// may ever reach them. Compiling out every authored field is the
-    /// adversarial case — if the #1588 attribute filter ever widened to the
-    /// whole field list, these assertions are what catches it.
+    /// ABI contract, not an authoring convenience: no authored field attribute
+    /// may ever reach them, at either emission site. Compiling out every
+    /// authored field is the adversarial case — if the #1588 attribute filter
+    /// ever widened to the whole field list, these assertions are what catches
+    /// it. Declaration order is deliberately not asserted: `Processor` is not
+    /// `#[repr(C)]`, so its field order is not a contract.
     #[test]
     fn plugin_abi_object_port_fields_stay_unconditional_when_every_custom_field_is_compiled_out() {
         let schema = schema_declaring_iceoryx2_input_and_output_ports();
         let custom_fields = extract_custom_fields(&struct_with_every_custom_field_compiled_out());
 
-        let struct_rendered = render_without_whitespace(generate_processor_struct_from_schema(
-            &schema,
-            &None,
-            &custom_fields,
-        ));
-        assert!(
-            struct_rendered.contains(
-                "pubstructProcessor{pubinputs:__streamlib_sdk::iceoryx2::InputMailboxes,\
-                 puboutputs:__streamlib_sdk::iceoryx2::OutputWriter,"
-            ),
-            "the PluginAbiObject port fields must open the generated struct with \
-             nothing interposed — got: {}",
-            struct_rendered
+        let generated_struct = parse_generated_processor_struct(
+            generate_processor_struct_from_schema(&schema, &None, &custom_fields),
         );
-        assert!(
-            struct_rendered.contains("#[cfg(any())]pubnever_compiled_backend_state"),
-            "the probe must actually exercise the attribute filter — got: {}",
-            struct_rendered
+        for (port_field_name, port_field_type) in
+            [("inputs", "InputMailboxes"), ("outputs", "OutputWriter")]
+        {
+            let port_field =
+                declared_field(&generated_struct, port_field_name).unwrap_or_else(|| {
+                    panic!(
+                        "the generated Processor struct must declare the `{}` PluginAbiObject port \
+                     field — it declares {:?}",
+                        port_field_name,
+                        declared_field_names(&generated_struct)
+                    )
+                });
+            assert!(
+                port_field.attrs.is_empty(),
+                "the `{}` port field must be unconditional — no authored field attribute may \
+                 reach it, but it carries {:?}",
+                port_field_name,
+                attribute_path_idents(&port_field.attrs)
+            );
+            assert!(
+                matches!(port_field.vis, syn::Visibility::Public(_)),
+                "the `{}` port field must stay `pub` — the host patches it after `from_config` \
+                 returns",
+                port_field_name
+            );
+            assert_eq!(
+                type_path_last_segment(&port_field.ty).as_deref(),
+                Some(port_field_type),
+                "the `{}` port field must keep its PluginAbiObject type",
+                port_field_name
+            );
+        }
+
+        let compiled_out_field = declared_field(&generated_struct, "never_compiled_backend_state")
+            .unwrap_or_else(|| {
+                panic!(
+                    "the probe's compiled-out field must still be emitted so this test exercises \
+                     the attribute filter — the struct declares {:?}",
+                    declared_field_names(&generated_struct)
+                )
+            });
+        assert_eq!(
+            attribute_path_idents(&compiled_out_field.attrs),
+            vec!["cfg".to_string()],
+            "the probe must actually exercise the attribute filter — its compiled-out field has \
+             to carry the authored `#[cfg]`"
         );
 
-        let from_config_rendered = render_without_whitespace(generate_from_config_from_schema(
-            &schema,
-            &None,
-            &custom_fields,
-        ));
-        assert!(
-            from_config_rendered.contains(
-                "Ok(Self{inputs:__streamlib_sdk::iceoryx2::InputMailboxes::empty(),\
-                 outputs:__streamlib_sdk::iceoryx2::OutputWriter::empty(),"
-            ),
-            "the PluginAbiObject port initializers must stay unconditional — got: {}",
-            from_config_rendered
+        let from_config_struct_expression = parse_generated_from_config_struct_expression(
+            generate_from_config_from_schema(&schema, &None, &custom_fields),
         );
+        for port_field_name in ["inputs", "outputs"] {
+            let port_initializer =
+                initialized_field(&from_config_struct_expression, port_field_name).unwrap_or_else(
+                    || {
+                        panic!(
+                            "`from_config` must initialize the `{}` PluginAbiObject port field — \
+                             it initializes {:?}",
+                            port_field_name,
+                            initialized_field_names(&from_config_struct_expression)
+                        )
+                    },
+                );
+            assert!(
+                port_initializer.attrs.is_empty(),
+                "the `{}` port initializer must stay unconditional — no authored field attribute \
+                 may reach it, but it carries {:?}",
+                port_field_name,
+                attribute_path_idents(&port_initializer.attrs)
+            );
+        }
     }
 
     /// Locks #1588: a `#[cfg]` authored on a processor struct field must be
@@ -1040,11 +1173,9 @@ mod processor_struct_emit_tests {
     #[test]
     fn processor_struct_preserves_cfg_attribute_on_custom_field() {
         let custom_fields = extract_custom_fields(&platform_conditional_field_struct());
-        let rendered = render_without_whitespace(generate_processor_struct_from_schema(
-            &minimal_schema(),
-            &None,
-            &custom_fields,
-        ));
+        let rendered = render_token_stream_without_whitespace(
+            generate_processor_struct_from_schema(&minimal_schema(), &None, &custom_fields),
+        );
         assert!(
             rendered.contains(r#"#[cfg(target_os="linux")]publinux_only_backend_state"#),
             "generated Processor struct must carry the authored `#[cfg]` on \
@@ -1064,7 +1195,7 @@ mod processor_struct_emit_tests {
     #[test]
     fn from_config_initializer_preserves_cfg_attribute_on_custom_field() {
         let custom_fields = extract_custom_fields(&platform_conditional_field_struct());
-        let rendered = render_without_whitespace(generate_from_config_from_schema(
+        let rendered = render_token_stream_without_whitespace(generate_from_config_from_schema(
             &minimal_schema(),
             &None,
             &custom_fields,
@@ -1096,11 +1227,9 @@ mod processor_struct_emit_tests {
     #[test]
     fn processor_struct_forwards_doc_and_lint_attributes_but_not_cfg_attr() {
         let custom_fields = extract_custom_fields(&annotated_field_struct());
-        let rendered = render_without_whitespace(generate_processor_struct_from_schema(
-            &minimal_schema(),
-            &None,
-            &custom_fields,
-        ));
+        let rendered = render_token_stream_without_whitespace(
+            generate_processor_struct_from_schema(&minimal_schema(), &None, &custom_fields),
+        );
         assert!(
             rendered.contains("Authoreddoconaprocessorfield."),
             "generated Processor struct must carry the authored doc — got: {}",
@@ -1162,10 +1291,10 @@ mod processor_struct_emit_tests {
                     previous_ident_was_compile_error = ident == "compile_error";
                 }
                 TokenTree::Group(group) => {
-                    if previous_ident_was_compile_error {
-                        if let Ok(message) = syn::parse2::<syn::LitStr>(group.stream()) {
-                            messages.push(message.value());
-                        }
+                    if previous_ident_was_compile_error
+                        && let Ok(message) = syn::parse2::<syn::LitStr>(group.stream())
+                    {
+                        messages.push(message.value());
                     }
                     previous_ident_was_compile_error = false;
                     messages.extend(compile_error_messages(group.stream()));
@@ -1226,9 +1355,8 @@ mod processor_struct_emit_tests {
     /// failure class as #1588 itself.
     #[test]
     fn cfg_attr_on_a_processor_field_emits_a_compile_error_naming_the_field() {
-        let messages = compile_error_messages(expand_probe_processor(
-            &struct_with_cfg_attr_on_a_field(),
-        ));
+        let messages =
+            compile_error_messages(expand_probe_processor(&struct_with_cfg_attr_on_a_field()));
         assert_eq!(
             messages.len(),
             1,
@@ -1264,29 +1392,45 @@ mod processor_struct_emit_tests {
         );
     }
 
-    /// The `from_config` struct-literal site takes `cfg` only — a `doc` on a
-    /// struct-expression field is an `unused_doc_comments` warning and the
-    /// gates deny warnings.
+    fn struct_with_a_cfg_alongside_every_other_forwardable_attribute() -> ItemStruct {
+        syn::parse_quote! {
+            struct CfgAlongsideEveryOtherAttributeProbe {
+                /// Authored doc on a processor field.
+                #[allow(dead_code)]
+                #[expect(unused_parens)]
+                #[cfg(target_os = "linux")]
+                #[serde(skip)]
+                cfg_and_lint_annotated_backend_state: Option<u32>,
+            }
+        }
+    }
+
+    /// The `from_config` struct-literal site takes `cfg` and nothing else — a
+    /// `doc` on a struct-expression field is an `unused_doc_comments` warning
+    /// and the gates deny warnings.
     #[test]
     fn from_config_initializer_forwards_cfg_only() {
-        let custom_fields = extract_custom_fields(&annotated_field_struct());
-        let rendered = render_without_whitespace(generate_from_config_from_schema(
-            &minimal_schema(),
-            &None,
-            &custom_fields,
-        ));
-        assert!(
-            rendered.contains("annotated_backend_state:"),
-            "from_config must still initialize the field — got: {}",
-            rendered
+        let custom_fields =
+            extract_custom_fields(&struct_with_a_cfg_alongside_every_other_forwardable_attribute());
+        let from_config_struct_expression = parse_generated_from_config_struct_expression(
+            generate_from_config_from_schema(&minimal_schema(), &None, &custom_fields),
         );
-        for dropped in ["doc", "allow", "expect", "cfg_attr", "serde"] {
-            assert!(
-                !rendered.contains(dropped),
-                "from_config initializer must forward `cfg` only, found `{}` — got: {}",
-                dropped,
-                rendered
-            );
-        }
+
+        let initializer = initialized_field(
+            &from_config_struct_expression,
+            "cfg_and_lint_annotated_backend_state",
+        )
+        .unwrap_or_else(|| {
+            panic!(
+                "`from_config` must still initialize the authored field — it initializes {:?}",
+                initialized_field_names(&from_config_struct_expression)
+            )
+        });
+        assert_eq!(
+            attribute_path_idents(&initializer.attrs),
+            vec!["cfg".to_string()],
+            "the `from_config` initializer must carry the authored `#[cfg]` and nothing else — \
+             the probe also authors `doc`, `allow`, `expect`, and a derive helper"
+        );
     }
 }

--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -10,8 +10,9 @@
 //! - Processor trait implementation
 
 use proc_macro2::{Ident, Span, TokenStream};
-use quote::quote;
+use quote::{quote, quote_spanned};
 use streamlib_processor_schema::{PortSchemaSpec, ProcessorSchema, SchemaIdent};
+use syn::spanned::Spanned;
 use syn::{ItemStruct, Path};
 
 /// Emit a `SchemaIdent` literal expression. Inputs are pre-validated by the
@@ -85,6 +86,7 @@ pub fn generate_from_processor_schema(
 
     // Extract custom fields from the user's struct
     let custom_fields = extract_custom_fields(item);
+    let refused_field_attribute_diagnostics = refused_field_attribute_diagnostics(item);
 
     let processor_struct =
         generate_processor_struct_from_schema(schema, &config_field_name, &custom_fields);
@@ -131,6 +133,8 @@ pub fn generate_from_processor_schema(
             // below resolve without any `streamlib` aliasing in the consumer.
             #[allow(unused_imports)]
             use #sdk_root as __streamlib_sdk;
+
+            #refused_field_attribute_diagnostics
 
             /// Configuration type for this processor.
             pub type Config = #config_type;
@@ -191,10 +195,41 @@ fn is_forwarded_onto_generated_field_definition(attribute: &syn::Attribute) -> b
 
 /// `cfg` is the only attribute a struct-expression field takes cleanly — a
 /// `doc` there is an `unused_doc_comments` warning and the gates deny warnings.
-/// `cfg_attr` is forwarded to neither site: an expansion that changes presence
-/// would desync the field definition from this initializer.
 fn is_forwarded_onto_from_config_initializer(attribute: &syn::Attribute) -> bool {
     attribute.path().is_ident("cfg")
+}
+
+/// `cfg_attr` on a processor struct field is refused rather than dropped: it can
+/// expand to a presence-changing `cfg`, and the two emission sites are filtered
+/// independently, so an expansion that gates the field definition without gating
+/// the `from_config` initializer desyncs them into an error far from its cause.
+/// Silently discarding it is the same failure class as #1588.
+fn refused_field_attribute_diagnostics(item: &ItemStruct) -> TokenStream {
+    let syn::Fields::Named(fields) = &item.fields else {
+        return quote! {};
+    };
+
+    let diagnostics: Vec<TokenStream> = fields
+        .named
+        .iter()
+        .filter_map(|authored_field| {
+            let field_name = authored_field.ident.as_ref()?;
+            let refused = authored_field
+                .attrs
+                .iter()
+                .find(|attribute| attribute.path().is_ident("cfg_attr"))?;
+            let message = format!(
+                "`#[cfg_attr(...)]` is not supported on `#[processor]` struct fields (field \
+                 `{field_name}`): a `cfg_attr` that expands to a `cfg` would change the field's \
+                 presence on the generated `Processor` struct without changing it on the \
+                 `from_config` initializer, and the two would no longer agree. Author the \
+                 `#[cfg(...)]` directly on the field instead."
+            );
+            Some(quote_spanned! { refused.span() => compile_error!(#message); })
+        })
+        .collect();
+
+    quote! { #(#diagnostics)* }
 }
 
 /// Extract custom fields from the user's struct definition.
@@ -1111,6 +1146,121 @@ mod processor_struct_emit_tests {
             "the probe must still exercise a forwarded lint control, or this \
              test passes vacuously; forwarded attributes were: {:?}",
             forwarded_attribute_paths
+        );
+    }
+
+    /// Every `compile_error!` message in a generated token stream, so a
+    /// diagnostic test asserts on the text the author will actually read.
+    fn compile_error_messages(tokens: TokenStream) -> Vec<String> {
+        use proc_macro2::TokenTree;
+
+        let mut messages = Vec::new();
+        let mut previous_ident_was_compile_error = false;
+        for tree in tokens {
+            match tree {
+                TokenTree::Ident(ident) => {
+                    previous_ident_was_compile_error = ident == "compile_error";
+                }
+                TokenTree::Group(group) => {
+                    if previous_ident_was_compile_error {
+                        if let Ok(message) = syn::parse2::<syn::LitStr>(group.stream()) {
+                            messages.push(message.value());
+                        }
+                    }
+                    previous_ident_was_compile_error = false;
+                    messages.extend(compile_error_messages(group.stream()));
+                }
+                TokenTree::Punct(_) => {}
+                TokenTree::Literal(_) => previous_ident_was_compile_error = false,
+            }
+        }
+        messages
+    }
+
+    fn probe_schema_ident() -> SchemaIdent {
+        use streamlib_processor_schema::{Org, Package, SemVer, TypeName};
+        SchemaIdent::new(
+            Org::new("tatolab").expect("valid org"),
+            Package::new("streamlib-macros").expect("valid package"),
+            TypeName::new("FieldAttributeProbe").expect("valid type name"),
+            SemVer::new(0, 0, 0),
+        )
+    }
+
+    fn expand_probe_processor(item: &ItemStruct) -> TokenStream {
+        generate_from_processor_schema(
+            item,
+            &minimal_schema(),
+            &probe_schema_ident(),
+            None,
+            None,
+            None,
+            quote! { streamlib },
+        )
+    }
+
+    fn struct_with_cfg_attr_on_a_field() -> ItemStruct {
+        syn::parse_quote! {
+            struct CfgAttrFieldProbe {
+                #[cfg_attr(target_os = "linux", allow(unused))]
+                cfg_attr_annotated_backend_state: Option<u32>,
+                unannotated_frame_counter: u64,
+            }
+        }
+    }
+
+    fn struct_with_dropped_derive_helper_attributes_on_a_field() -> ItemStruct {
+        syn::parse_quote! {
+            struct DeriveHelperAnnotatedFieldProbe {
+                /// Authored doc on a processor field.
+                #[allow(dead_code)]
+                #[serde(skip)]
+                #[schemars(skip)]
+                derive_helper_annotated_backend_state: Option<u32>,
+            }
+        }
+    }
+
+    /// A `cfg_attr` on a processor field is refused loudly instead of dropped
+    /// silently — silently dropping a presence-changing attribute is the same
+    /// failure class as #1588 itself.
+    #[test]
+    fn cfg_attr_on_a_processor_field_emits_a_compile_error_naming_the_field() {
+        let messages = compile_error_messages(expand_probe_processor(
+            &struct_with_cfg_attr_on_a_field(),
+        ));
+        assert_eq!(
+            messages.len(),
+            1,
+            "exactly one field carries `cfg_attr`, so exactly one diagnostic is \
+             expected — got: {:?}",
+            messages
+        );
+        assert!(
+            messages[0].contains("cfg_attr_annotated_backend_state"),
+            "the diagnostic must name the offending field so the author can find \
+             it — got: {}",
+            messages[0]
+        );
+        assert!(
+            messages[0].contains("cfg_attr"),
+            "the diagnostic must name the unsupported attribute — got: {}",
+            messages[0]
+        );
+    }
+
+    /// The refusal is scoped to `cfg_attr`. Derive-helper attributes are dropped
+    /// by design — erroring on those would break every processor carrying one.
+    #[test]
+    fn a_dropped_derive_helper_attribute_on_a_processor_field_stays_silent() {
+        let messages = compile_error_messages(expand_probe_processor(
+            &struct_with_dropped_derive_helper_attributes_on_a_field(),
+        ));
+        assert!(
+            messages.is_empty(),
+            "only `cfg_attr` is refused; a dropped derive-helper attribute must \
+             not raise a diagnostic — got: {:?}",
+            messages
         );
     }
 

--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -161,6 +161,38 @@ pub fn generate_from_processor_schema(
 struct CustomField {
     name: Ident,
     ty: syn::Type,
+    /// Authored attributes re-emitted onto the generated `Processor` struct
+    /// field, filtered by [`is_forwarded_onto_generated_field_definition`].
+    attributes_for_generated_field_definition: Vec<syn::Attribute>,
+    /// Authored attributes re-emitted onto the `from_config` struct-literal
+    /// initializer, filtered by
+    /// [`is_forwarded_onto_from_config_initializer`]. Narrower than the field
+    /// definition's set — the two must stay in lockstep on presence.
+    attributes_for_from_config_initializer: Vec<syn::Attribute>,
+}
+
+/// Authoring contract for `#[processor]` struct fields: `cfg` is the
+/// load-bearing forward — dropping it makes a platform-conditional field
+/// unconditional and its platform-specific type fails to resolve off that
+/// platform. `doc` and the lint controls ride along so an author's `///` and
+/// `#[allow(dead_code)]` survive expansion.
+fn is_forwarded_onto_generated_field_definition(attribute: &syn::Attribute) -> bool {
+    let path = attribute.path();
+    path.is_ident("cfg")
+        || path.is_ident("doc")
+        || path.is_ident("allow")
+        || path.is_ident("warn")
+        || path.is_ident("deny")
+        || path.is_ident("forbid")
+        || path.is_ident("expect")
+}
+
+/// `cfg` is the only attribute a struct-expression field takes cleanly — a
+/// `doc` there is an `unused_doc_comments` warning and the gates deny warnings.
+/// `cfg_attr` is forwarded to neither site: an expansion that changes presence
+/// would desync the field definition from this initializer.
+fn is_forwarded_onto_from_config_initializer(attribute: &syn::Attribute) -> bool {
+    attribute.path().is_ident("cfg")
 }
 
 /// Extract custom fields from the user's struct definition.
@@ -169,9 +201,24 @@ fn extract_custom_fields(item: &ItemStruct) -> Vec<CustomField> {
         syn::Fields::Named(fields) => fields
             .named
             .iter()
-            .map(|f| CustomField {
-                name: f.ident.clone().expect("Named field must have ident"),
-                ty: f.ty.clone(),
+            .map(|authored_field| CustomField {
+                name: authored_field
+                    .ident
+                    .clone()
+                    .expect("Named field must have ident"),
+                ty: authored_field.ty.clone(),
+                attributes_for_generated_field_definition: authored_field
+                    .attrs
+                    .iter()
+                    .filter(|attribute| is_forwarded_onto_generated_field_definition(attribute))
+                    .cloned()
+                    .collect(),
+                attributes_for_from_config_initializer: authored_field
+                    .attrs
+                    .iter()
+                    .filter(|attribute| is_forwarded_onto_from_config_initializer(attribute))
+                    .cloned()
+                    .collect(),
             })
             .collect(),
         syn::Fields::Unit => Vec::new(),
@@ -210,10 +257,11 @@ fn generate_processor_struct_from_schema(
     // Generate custom fields from the user's struct definition
     let custom_field_defs: Vec<TokenStream> = custom_fields
         .iter()
-        .map(|f| {
-            let name = &f.name;
-            let ty = &f.ty;
-            quote! { pub #name: #ty, }
+        .map(|custom_field| {
+            let attributes = &custom_field.attributes_for_generated_field_definition;
+            let name = &custom_field.name;
+            let ty = &custom_field.ty;
+            quote! { #(#attributes)* pub #name: #ty, }
         })
         .collect();
 
@@ -551,9 +599,10 @@ fn generate_from_config_from_schema(
     // Initialize custom fields with Default::default()
     let custom_field_inits: Vec<TokenStream> = custom_fields
         .iter()
-        .map(|f| {
-            let name = &f.name;
-            quote! { #name: ::std::default::Default::default(), }
+        .map(|custom_field| {
+            let attributes = &custom_field.attributes_for_from_config_initializer;
+            let name = &custom_field.name;
+            quote! { #(#attributes)* #name: ::std::default::Default::default(), }
         })
         .collect();
 
@@ -897,5 +946,77 @@ mod processor_struct_emit_tests {
              `linux_only_backend_state` initializer — got: {}",
             rendered
         );
+    }
+
+    fn annotated_field_struct() -> ItemStruct {
+        syn::parse_quote! {
+            struct AnnotatedFieldProbe {
+                /// Authored doc on a processor field.
+                #[allow(dead_code)]
+                #[cfg_attr(target_os = "linux", allow(unused))]
+                #[serde(skip)]
+                annotated_backend_state: Option<u32>,
+            }
+        }
+    }
+
+    /// The field-definition site forwards `doc` and the lint controls so an
+    /// author's `///` and `#[allow(dead_code)]` survive expansion; `cfg_attr`
+    /// and unknown attributes stay dropped.
+    #[test]
+    fn processor_struct_forwards_doc_and_lint_attributes_but_not_cfg_attr() {
+        let custom_fields = extract_custom_fields(&annotated_field_struct());
+        let rendered = render_without_whitespace(generate_processor_struct_from_schema(
+            &minimal_schema(),
+            &None,
+            &custom_fields,
+        ));
+        assert!(
+            rendered.contains("Authoreddoconaprocessorfield."),
+            "generated Processor struct must carry the authored doc — got: {}",
+            rendered
+        );
+        assert!(
+            rendered.contains("#[allow(dead_code)]"),
+            "generated Processor struct must carry the authored lint control — got: {}",
+            rendered
+        );
+        assert!(
+            !rendered.contains("cfg_attr"),
+            "`cfg_attr` must not be forwarded — its expansion could change \
+             field presence and desync the two emission sites — got: {}",
+            rendered
+        );
+        assert!(
+            !rendered.contains("serde"),
+            "unknown attributes stay dropped — got: {}",
+            rendered
+        );
+    }
+
+    /// The `from_config` struct-literal site takes `cfg` only — a `doc` on a
+    /// struct-expression field is an `unused_doc_comments` warning and the
+    /// gates deny warnings.
+    #[test]
+    fn from_config_initializer_forwards_cfg_only() {
+        let custom_fields = extract_custom_fields(&annotated_field_struct());
+        let rendered = render_without_whitespace(generate_from_config_from_schema(
+            &minimal_schema(),
+            &None,
+            &custom_fields,
+        ));
+        assert!(
+            rendered.contains("annotated_backend_state:"),
+            "from_config must still initialize the field — got: {}",
+            rendered
+        );
+        for dropped in ["doc", "allow", "cfg_attr", "serde"] {
+            assert!(
+                !rendered.contains(dropped),
+                "from_config initializer must forward `cfg` only, found `{}` — got: {}",
+                dropped,
+                rendered
+            );
+        }
     }
 }

--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -834,4 +834,68 @@ mod processor_struct_emit_tests {
             rendered
         );
     }
+
+    /// `TokenStream::to_string` spacing is not part of any contract, so
+    /// assertions compare against a whitespace-free rendering.
+    fn render_without_whitespace(tokens: TokenStream) -> String {
+        tokens
+            .to_string()
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect()
+    }
+
+    fn platform_conditional_field_struct() -> ItemStruct {
+        syn::parse_quote! {
+            struct PlatformConditionalFieldProbe {
+                #[cfg(target_os = "linux")]
+                linux_only_backend_state: Option<u32>,
+                platform_agnostic_state: u64,
+            }
+        }
+    }
+
+    /// Locks #1588: a `#[cfg]` authored on a processor struct field must be
+    /// re-emitted on the generated `Processor` field, or the field becomes
+    /// unconditional and its platform-specific type fails to resolve off that
+    /// platform.
+    #[test]
+    fn processor_struct_preserves_cfg_attribute_on_custom_field() {
+        let custom_fields = extract_custom_fields(&platform_conditional_field_struct());
+        let rendered = render_without_whitespace(generate_processor_struct_from_schema(
+            &minimal_schema(),
+            &None,
+            &custom_fields,
+        ));
+        assert!(
+            rendered.contains(r#"#[cfg(target_os="linux")]publinux_only_backend_state"#),
+            "generated Processor struct must carry the authored `#[cfg]` on \
+             `linux_only_backend_state` — got: {}",
+            rendered
+        );
+        assert!(
+            !rendered.contains(r#"#[cfg(target_os="linux")]pubplatform_agnostic_state"#),
+            "the `#[cfg]` must not leak onto the unconditional field — got: {}",
+            rendered
+        );
+    }
+
+    /// Locks #1588: the `from_config` struct-literal initializer must carry the
+    /// same `#[cfg]` as the field it initializes — an unconditional initializer
+    /// for a conditional field does not compile.
+    #[test]
+    fn from_config_initializer_preserves_cfg_attribute_on_custom_field() {
+        let custom_fields = extract_custom_fields(&platform_conditional_field_struct());
+        let rendered = render_without_whitespace(generate_from_config_from_schema(
+            &minimal_schema(),
+            &None,
+            &custom_fields,
+        ));
+        assert!(
+            rendered.contains(r#"#[cfg(target_os="linux")]linux_only_backend_state:"#),
+            "from_config must carry the authored `#[cfg]` on the \
+             `linux_only_backend_state` initializer — got: {}",
+            rendered
+        );
+    }
 }

--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -829,7 +829,7 @@ fn generate_iceoryx2_accessors_from_schema(schema: &ProcessorSchema) -> TokenStr
 #[cfg(test)]
 mod processor_struct_emit_tests {
     use super::*;
-    use streamlib_processor_schema::ProcessorSchema;
+    use streamlib_processor_schema::{PortSchemaSpec, ProcessorPortSchema, ProcessorSchema};
 
     fn minimal_schema() -> ProcessorSchema {
         ProcessorSchema {
@@ -902,6 +902,79 @@ mod processor_struct_emit_tests {
                 platform_agnostic_state: u64,
             }
         }
+    }
+
+    fn schema_declaring_iceoryx2_input_and_output_ports() -> ProcessorSchema {
+        let port = |name: &str| ProcessorPortSchema {
+            name: name.to_string(),
+            schema: PortSchemaSpec::Any,
+            description: None,
+            delivery_profile: None,
+        };
+        ProcessorSchema {
+            inputs: vec![port("video_in")],
+            outputs: vec![port("video_out")],
+            ..minimal_schema()
+        }
+    }
+
+    fn struct_with_every_custom_field_compiled_out() -> ItemStruct {
+        syn::parse_quote! {
+            struct EveryCustomFieldCompiledOutProbe {
+                #[cfg(any())]
+                never_compiled_backend_state: Option<u32>,
+                #[cfg(any())]
+                never_compiled_frame_counter: u64,
+            }
+        }
+    }
+
+    /// The `inputs` / `outputs` fields are the `#[repr(C)]` `(handle, vtable)`
+    /// PluginAbiObjects the host patches through
+    /// `ProcessorVTable::set_iceoryx2_resources`, so their presence is a plugin
+    /// ABI contract, not an authoring convenience: they are emitted from the
+    /// port schema ahead of the custom fields and no authored field attribute
+    /// may ever reach them. Compiling out every authored field is the
+    /// adversarial case — if the #1588 attribute filter ever widened to the
+    /// whole field list, these assertions are what catches it.
+    #[test]
+    fn plugin_abi_object_port_fields_stay_unconditional_when_every_custom_field_is_compiled_out() {
+        let schema = schema_declaring_iceoryx2_input_and_output_ports();
+        let custom_fields = extract_custom_fields(&struct_with_every_custom_field_compiled_out());
+
+        let struct_rendered = render_without_whitespace(generate_processor_struct_from_schema(
+            &schema,
+            &None,
+            &custom_fields,
+        ));
+        assert!(
+            struct_rendered.contains(
+                "pubstructProcessor{pubinputs:__streamlib_sdk::iceoryx2::InputMailboxes,\
+                 puboutputs:__streamlib_sdk::iceoryx2::OutputWriter,"
+            ),
+            "the PluginAbiObject port fields must open the generated struct with \
+             nothing interposed — got: {}",
+            struct_rendered
+        );
+        assert!(
+            struct_rendered.contains("#[cfg(any())]pubnever_compiled_backend_state"),
+            "the probe must actually exercise the attribute filter — got: {}",
+            struct_rendered
+        );
+
+        let from_config_rendered = render_without_whitespace(generate_from_config_from_schema(
+            &schema,
+            &None,
+            &custom_fields,
+        ));
+        assert!(
+            from_config_rendered.contains(
+                "Ok(Self{inputs:__streamlib_sdk::iceoryx2::InputMailboxes::empty(),\
+                 outputs:__streamlib_sdk::iceoryx2::OutputWriter::empty(),"
+            ),
+            "the PluginAbiObject port initializers must stay unconditional — got: {}",
+            from_config_rendered
+        );
     }
 
     /// Locks #1588: a `#[cfg]` authored on a processor struct field must be

--- a/sdk/streamlib-macros/src/lib.rs
+++ b/sdk/streamlib-macros/src/lib.rs
@@ -54,9 +54,12 @@ use syn::{
 /// `streamlib.yaml`.
 ///
 /// Authoring contract for struct fields: `#[cfg]`, `///` docs, and the lint
-/// controls (`allow` / `warn` / `deny` / `forbid` / `expect`) are forwarded onto
-/// the generated field; `#[cfg]` alone is also forwarded onto its `from_config`
-/// initializer. Every other field attribute — including `cfg_attr` — is dropped.
+/// controls (`allow` / `warn` / `deny` / `forbid`) are forwarded onto the
+/// generated field; `#[cfg]` alone is also forwarded onto its `from_config`
+/// initializer. `#[expect]` is not forwarded — the generated field is `pub`
+/// where the authored one was private, so a `dead_code` expectation would land
+/// unfulfilled and warn. Every other field attribute — including `cfg_attr` —
+/// is dropped.
 ///
 /// The macro emits the processor's type, port markers, descriptor, and
 /// `schema_ident()` accessor — but does NOT register the processor in

--- a/sdk/streamlib-macros/src/lib.rs
+++ b/sdk/streamlib-macros/src/lib.rs
@@ -53,6 +53,11 @@ use syn::{
 /// `@app/local/<StructName>` identity so a bare crate compiles with no
 /// `streamlib.yaml`.
 ///
+/// Authoring contract for struct fields: `#[cfg]`, `///` docs, and the lint
+/// controls (`allow` / `warn` / `deny` / `forbid` / `expect`) are forwarded onto
+/// the generated field; `#[cfg]` alone is also forwarded onto its `from_config`
+/// initializer. Every other field attribute — including `cfg_attr` — is dropped.
+///
 /// The macro emits the processor's type, port markers, descriptor, and
 /// `schema_ident()` accessor — but does NOT register the processor in
 /// the global `PROCESSOR_REGISTRY`. Callers register processors through

--- a/sdk/streamlib-macros/src/lib.rs
+++ b/sdk/streamlib-macros/src/lib.rs
@@ -58,8 +58,9 @@ use syn::{
 /// generated field; `#[cfg]` alone is also forwarded onto its `from_config`
 /// initializer. `#[expect]` is not forwarded — the generated field is `pub`
 /// where the authored one was private, so a `dead_code` expectation would land
-/// unfulfilled and warn. Every other field attribute — including `cfg_attr` —
-/// is dropped.
+/// unfulfilled and warn. `#[cfg_attr]` on a field is a compile error, because a
+/// `cfg_attr` expanding to a `cfg` would gate one of the two emission sites and
+/// not the other. Every other field attribute is dropped.
 ///
 /// The macro emits the processor's type, port markers, descriptor, and
 /// `schema_ident()` accessor — but does NOT register the processor in


### PR DESCRIPTION
Closes #1588

## Summary

`#[processor]`-generated struct fields dropped every field-level attribute the author wrote,
including `#[cfg(...)]`. That silently produced the wrong compiled shape on cfg-gated fields (a
field could be declared conditionally by the author but always emitted — or vice versa — by the
generated `Processor` struct and its `from_config` initializer), with no diagnostic.

This PR:
- Adds `is_forwarded_onto_generated_field_definition` / `is_forwarded_onto_from_config_initializer`
  in `sdk/streamlib-macros/src/codegen.rs` so authored field attributes are forwarded onto both
  generated sites instead of being dropped. The field definition site forwards
  `cfg`/`doc`/`allow`/`warn`/`deny`/`forbid`; the `from_config` initializer forwards `cfg`
  only (an attribute-position vs. expression-position asymmetry — `doc`/`allow`/etc. are invalid on
  a struct-literal field value). `expect` is deliberately NOT forwarded, and a `#[cfg_attr(...)]`
  on a processor struct field is now a `compile_error!` rather than a silent drop — see the
  resolved review items below.
- Removes the `GpuBackendStash` type-alias workaround in
  `packages/camera/src/camera_to_cuda_copy.rs` that existed only to route around the dropped-`cfg`
  bug, putting `#[cfg(target_os = "linux")]` directly on the field. In the same edit, renames
  `backend` -> `linux_cuda_copy_gpu_resources` and `LinuxState` -> `LinuxCudaCopyGpuResources`
  (bare `State`/`backend` violate `.claude/rules/naming.md` and sit on the declarations this fix
  has to touch anyway) and rewrites the runtime error string from `"CameraToCudaCopy: backend not
  initialized"` to `"CameraToCudaCopy: GPU resources not initialized (setup() did not run)"`.
  Calling this out explicitly as a scope extension beyond the ticket's stated done-means, per the
  naming-rule justification above — see the non-blocking review item on this below.
- Adds regression coverage in `runtime/streamlib-engine/tests/attribute_macro_test.rs`
  (`CfgGatedFieldProcessor`) and unit tests in `sdk/streamlib-macros/src/codegen.rs` pinning that a
  `#[cfg(any())]` field is dropped from both generated sites, a `#[cfg(all())]` field survives on
  both, and the `PluginAbiObject` `inputs`/`outputs` port fields can never be reached by the
  field-attribute filter.
- The `#[processor]` authoring contract at `sdk/streamlib-macros/src/lib.rs` documents which field
  attributes are forwarded and to which generated site.

`cfg_attr` on a processor field is deliberately out of scope for this PR (the ticket's open design
question named it as a candidate but did not require it) — flagged below as a should-fix follow-up
since it re-opens a narrower version of the same bug class with no diagnostic.

## Test evidence

Re-verified from scratch in this session — **a prior session working this branch was interrupted
by a power loss, so nothing from that session was trusted; every check below was re-run against
the current worktree rather than inherited.**

- `git status --porcelain -uall` empty; `HEAD` (`b7c2ca1b`) matches
  `origin/fix/1588-preserve-cfg-on-processor-fields`; `git merge-base origin/main HEAD` equals
  `origin/main`'s tip (`c3a0ffdb`), so a rebase onto `main` is a no-op. No `streamlib link` residue
  in the worktree (`.cargo/config.toml` is the tracked xtask alias only; no `[patch.crates-io]`
  anywhere; no `.streamlib/link.json`; the gitignored `.streamlib/` holds only `logs/`).
- `cargo test -p streamlib-macros` — 12 lib tests + 2 integration tests + doctests, all green.
- `cargo test -p streamlib-engine --test attribute_macro_test` — 11/11 green.
- `cargo check --workspace --all-targets` — 0 errors.
- `cargo doc -p streamlib --no-deps` — warning-free.
- All 14 xtask gates green: `lint-logging`, `check-boundaries`, `check-cdylib-reach`,
  `check-no-reverse-dns`, `check-processor-spec-new`, `check-no-escalate-in-lifecycle`,
  `check-schema-versions`, `check-package-version-drift`, `check-manifest-schema`,
  `check-no-streamlib-metadata`, `check-vendored-vulkanalia`, `check-consumer-rhi-repr`,
  `check-device-wait-idle`, `check-no-inventory-submit`.

**Tests are non-vacuous (re-derived, not inherited from ordering):** copied `HEAD`'s tree to
`/tmp/verify1588` via `git archive` and neutralized only the two filter predicates
(`is_forwarded_onto_generated_field_definition` / `is_forwarded_onto_from_config_initializer`
early-return `false`, i.e. exactly pre-fix behavior; tests untouched). Result:
`cargo test -p streamlib-macros --lib` -> `test result: FAILED. 8 passed; 4 failed`, with the four
#1588 tests failing on real rendered output (e.g.
`got: pubstructProcessor{publinux_only_backend_state:Option<u32>,...}` — no `cfg`).
`cargo check -p streamlib-engine --tests` -> exit 101 with `error[E0425]: cannot find type
ThisTypeIsDeliberatelyUndeclared ... attribute_macro_test.rs:208` and `cannot find type
CfgGatedFieldNonLinuxOnlyState ... :219`. The fifth test
(`from_config_initializer_forwards_cfg_only`) is vacuous in the revert direction but non-vacuous in
the widening direction: widening the initializer filter to match the definition filter fails with
`must forward cfg only, found doc`. Scratch `codegen.rs` was then restored byte-identical to `HEAD`
(verified by diff).

**Package compile proof (`@tatolab/camera`, the ticket's second done-means, and the only file not
compiled by any workspace target):** in `/tmp/verify1588` (HEAD tree, `codegen.rs` byte-identical
to `HEAD`), appended a `[patch.crates-io]` block derived from `cargo metadata` (the same override
shape `streamlib link --engine` writes, per
`tools/streamlib-cli/src/commands/link.rs`) and ran
`STREAMLIB_LINK_CHECKOUT=/tmp/verify1588 cargo check --lib` in `packages/camera` -> `Finished dev
profile`. `cargo clippy --lib --all-targets` surfaces only pre-existing warnings (the large-`Err`-
variant lint on the two `_inner` fns at `camera_to_cuda_copy.rs:149,239`). `git grep` for
`GpuBackendStash` / `LinuxState` across `packages/`, `sdk/`, `runtime/`, `tools/`, `adapters/`,
`examples/`, `docs/` returns nothing. CI's install-packages gate (triggers on `packages/**` +
`sdk/**`) will re-run this on the PR.

### Cross-compile check (`aarch64-apple-darwin`): not applicable, and not runnable on this host — ENVIRONMENTAL BLOCKER

This change touches no Apple path — the diff is `sdk/streamlib-macros/src/{codegen.rs,lib.rs}`,
`runtime/streamlib-engine/tests/attribute_macro_test.rs`, and
`packages/camera/src/camera_to_cuda_copy.rs`; nothing under an `apple/` directory, no
`target_os = "macos"`/`"ios"` or `target_vendor = "apple"` code. CLAUDE.md scopes the darwin
cross-check to Apple-file edits, so the rule does not apply here.

Independently: `cargo check --target aarch64-apple-darwin` cannot pass on this Linux host for
**any** crate in this tree, regardless of this change. The host `cc` is not an Apple cross
toolchain, and the failing dependency chain (`streamlib-idents` -> `zip` -> `xz2` -> `lzma-sys`,
plus `ring` / `zstd-sys` / `bzip2-sys`) sits under essentially every SDK crate. Probed twice against
unrelated crates (`-p streamlib-error`, `-p streamlib-plugin-sdk`); both fail in native C build
scripts with `cc: error: unrecognized command-line option '-arch'`. This is a pre-existing
host-toolchain gap, not a regression from this PR.

Target-independent evidence is in-tree instead:
`runtime/streamlib-engine/tests/attribute_macro_test.rs` declares a `#[cfg(any())]` field typed by
`ThisTypeIsDeliberatelyUndeclared` (a name that exists nowhere in the tree) alongside a
`#[cfg(all())]` field. `any()` is false and `all()` is true on **every** target, so the test crate
compiles only if the macro re-emits the `#[cfg]` at both generated sites — the field definition and
the `from_config` initializer — and drops the false arm from both. That is the merge-blocking
property, and it holds on any host: the macro never interprets the predicate, rustc does. A
darwin-only cfg would exercise no macro behavior the `any()`/`all()` pair doesn't already pin.

**Follow-up needed:** a real darwin build of `@tatolab/camera` (and the SDK crates it depends on)
requires a machine with an actual Apple SDK / cross toolchain — not reproducible on this Linux box.
Filing that as a follow-up rather than blocking this PR on it, consistent with the low-severity
review item below on the non-Linux compiled shape being unverified by any gate.

## Review items (non-blocking)

**[info] `sdk/streamlib-macros/src/codegen.rs:179`** — The branch's tests are non-vacuous: reverting
the production change turns them red. I re-derived this myself rather than trusting the red-commit
ordering.
Evidence: I copied HEAD's tree to `/tmp/verify1588` via `git archive` and neutralized ONLY the two
filter predicates (`is_forwarded_onto_generated_field_definition` /
`is_forwarded_onto_from_config_initializer` early-return false — exactly the pre-fix behavior,
tests untouched). Result: `cargo test -p streamlib-macros --lib` -> `test result: FAILED. 8 passed;
4 failed` with the four #1588 tests failing on real rendered output (e.g. `got:
pubstructProcessor{publinux_only_backend_state:Option<u32>,...}` — no cfg). `cargo check -p
streamlib-engine --tests` -> EXIT=101 with `error[E0425]: cannot find type
ThisTypeIsDeliberatelyUndeclared ... attribute_macro_test.rs:208` and `cannot find type
CfgGatedFieldNonLinuxOnlyState ... :219`. The fifth test (`from_config_initializer_forwards_cfg_only`)
is vacuous in the revert direction but non-vacuous in the widening direction: when I widened the
initializer filter to match the definition filter it failed with `must forward cfg only, found
doc`. Then restored the scratch codegen.rs byte-identical to HEAD (verified by diff).
Suggested next step: None — this is the evidence backing the APPROVE.

**[RESOLVED — e0fd3763] [should-fix] `sdk/streamlib-macros/src/codegen.rs:187`** — `expect` in the field-definition
allowlist inverts its own semantics: forwarding `#[expect(lint)]` from a private authored field
onto the generated `pub` field turns silence into a new warning, which is the opposite of the
stated rationale ("lint controls ride along so an author's ... survive expansion").
Evidence: rustc 1.94.0 probes I ran: `struct S { #[expect(dead_code)] f: u32 }` (private) compiles
clean — expectation fulfilled. `pub struct S { #[expect(dead_code)] pub f: u32 }` emits `warning:
this lint expectation is unfulfilled ... #[warn(unfulfilled_lint_expectations)]`, in both a lib
crate and a bin crate. The macro always emits `pub #name` (codegen.rs:264), so an authored
`#[expect(dead_code)]` — the exact companion of the `#[allow(dead_code)]` the rustdoc contract
cites — is always unfulfilled after expansion. Before this change the attribute was dropped and
produced nothing. No in-tree processor uses `expect` on a field today, so nothing is red.
Suggested next step: Drop `expect` from `is_forwarded_onto_generated_field_definition` (keep
allow/warn/deny/forbid), or keep it and note the caveat in the `#[processor]` authoring contract at
sdk/streamlib-macros/src/lib.rs:56.
Resolution (e0fd3763): `expect` dropped from the allowlist; rationale recorded on the predicate
doc (codegen.rs:178-185) and on the `#[processor]` authoring contract
(sdk/streamlib-macros/src/lib.rs:56-62). Reproduced independently before and after against the
`streamlib` rlib — where a `pub` field in a `pub mod` really is externally reachable, so
`dead_code` cannot fire: a private `#[expect(dead_code)]` processor field emitted `warning: this
lint expectation is unfulfilled ... note: #[warn(unfulfilled_lint_expectations)] on by default`
before, and the crate checked warning-free after. Locked by
`processor_struct_does_not_forward_expect_onto_the_generated_pub_field`, which reads the filter's
kept-attribute set rather than a rendering; re-adding `expect` to the allowlist reds it with
`forwarded attributes were: ["doc", "allow", "expect"]`. No in-tree processor field uses
`#[expect]`.

**[low] `packages/camera/src/camera_to_cuda_copy.rs:114`** — The camera commit carries a rename and
an error-message rewrite that go beyond the ticket's done-means ("drops the GpuBackendStash
type-alias workaround and its explanatory comment"). Engine doctrine treats opportunistic fixes as
report-not-fix.
Evidence: dc5f65c3 renames `backend` -> `linux_cuda_copy_gpu_resources` and `LinuxState` ->
`LinuxCudaCopyGpuResources` across 16 sites (camera_to_cuda_copy.rs:60,114,209,240-320) and
rewrites the runtime error string from `"CameraToCudaCopy: backend not initialized"` to
`"CameraToCudaCopy: GPU resources not initialized (setup() did not run)"` (:243). The rename is
defensible — `LinuxState`/`backend` violate .claude/rules/naming.md and sit on the declarations the
fix has to edit anyway — and the issue's plan-of-record comment pre-announced it, but no PR body
existed yet to carry the callout.
Suggested next step: State the rename + error-string change explicitly in the PR body as a
called-out (not silent) scope extension, with the naming-rule justification. (Done above, in the
Summary section of this PR body.)

**[low] `runtime/streamlib-engine/tests/attribute_macro_test.rs:175`** — The new test fixtures
reintroduce the bare-`State` suffix that this same PR removes from production code.
Evidence: `CfgGatedFieldLinuxOnlyState` (:175), `CfgGatedFieldNonLinuxOnlyState` (:182),
`CfgGatedFieldAlwaysCompiledState` (:188), and the fields `never_compiled_state` /
`always_compiled_state` / `linux_only_state` / `non_linux_only_state` (:208-220) — while dc5f65c3
renames `LinuxState` -> `LinuxCudaCopyGpuResources` in packages/camera for exactly that reason.
.claude/rules/naming.md lists `State` among the banned bare generic words.
Suggested next step: Optional: rename the fixtures to name what they hold (e.g.
`CfgGatedFieldLinuxOnlyMarker`), or leave as-is on the grounds that they are throwaway
macro-expansion probes with no data source/direction to encode.

**[low] `sdk/streamlib-macros/src/codegen.rs:1086`** — Two of the new tests assert on raw
substrings of the whole rendered token stream, so unrelated codegen growth can red them
spuriously.
Evidence: `for dropped in ["doc", "allow", "cfg_attr", "serde"] { assert!(!rendered.contains(dropped),
...) }` (:1086) scans the entire `from_config` rendering, not just the custom-field initializer;
likewise `!rendered.contains("serde")` at :1064. Any future generated token containing
`doc`/`allow` anywhere in `from_config` fails the test with a misleading message. It fails loudly
rather than silently, so the risk is a false alarm, not a missed regression.
Suggested next step: Optional: narrow the negative assertions to the substring window around
`annotated_backend_state:` instead of the whole rendering.

**[info] `sdk/streamlib-macros/src/codegen.rs:190`** — The asymmetric filter's stated justification
checks out; the ticket's open design question ("forward all attributes or filter to
cfg/cfg_attr/doc") is answered with a documented allowlist, deliberately excluding `cfg_attr`.
Evidence: rustc probe: `let s = S { #[doc = "x"] f: 0 };` -> `warning: unused doc comment ...
rustdoc does not generate documentation for expression fields`, confirming the comment at
codegen.rs:190-193 and the definition/initializer asymmetry. `cfg_attr` is excluded at both sites
with the desync rationale stated in code and negatively asserted at both sites (:1058, :1086). The
authoring contract is documented on the `#[processor]` rustdoc (sdk/streamlib-macros/src/lib.rs:56-59).
Suggested next step: None; note the `cfg_attr` deferral in the PR body since the ticket's Design
section named it as a candidate. (Done above, in the Summary section.)

**[low] `packages/camera/src/camera_to_cuda_copy.rs:114`** — There is exactly one path by which an
authored field attribute can affect a PluginAbiObject port field, and this change makes it
target-scoped: an authored field named `inputs` / `outputs` / the declared config field name
collides with the generated field, and a forwarded `#[cfg]` now decides per-target whether the
collision happens. The macro has no reserved-field-name guard.
Evidence: `extract_custom_fields` (sdk/streamlib-macros/src/codegen.rs:199-227) accepts any
authored name; the port fields are emitted unconditionally ahead of the custom fields (:268-275)
and the config field at :235-237. A grep of sdk/streamlib-macros/src for a reserved-name
`compile_error!` finds none. Before this change a colliding field was a duplicate-field error on
every target (caught immediately); with `#[cfg(target_os = "macos")] inputs: T` the E0124/E0560 now
only fires on macOS and escapes a Linux-only CI (no workflow in .github/workflows references
`aarch64-apple-darwin`). The failure remains a hard compile error, never silent ABI corruption.
Suggested next step: Optional follow-up: emit a `compile_error!` from `extract_custom_fields` when
an authored field name is `inputs`, `outputs`, or the declared config field name. Worth a line on
the PR body either way, since the new lock test's doc comment claims "no authored field attribute
may ever reach them" and this is the one exception. (Note added — see Summary.)

**[info] `runtime/streamlib-engine/tests/attribute_macro_test.rs:204`** — No half-applied edit from
the power loss; branch state is coherent and every mechanical gate is green. Re-derived
independently.
Evidence: `git status --porcelain -uall` empty; HEAD b7c2ca1b == origin/fix/1588-preserve-cfg-on-processor-fields;
`git merge-base origin/main HEAD` == origin/main tip c3a0ffdb (rebase is a no-op); no `streamlib
link` residue (`.cargo/config.toml` is the tracked xtask alias, no `[patch.crates-io]` anywhere, no
`.streamlib/link.json`; the gitignored `.streamlib/` holds only `logs/`). Only two call sites
consume `custom_fields` (codegen.rs:258, :600) and both re-emit. Green in the worktree: `cargo test
-p streamlib-macros` (12 lib + 2 integration + doctests), `cargo test -p streamlib-engine --test
attribute_macro_test` (11/11), `cargo check --workspace --all-targets` (0 errors), `cargo doc -p
streamlib --no-deps` (warning-free), and all 14 xtask gates (lint-logging, check-boundaries,
check-cdylib-reach, check-no-reverse-dns, check-processor-spec-new,
check-no-escalate-in-lifecycle, check-schema-versions, check-package-version-drift,
check-manifest-schema, check-no-streamlib-metadata, check-vendored-vulkanalia,
check-consumer-rhi-repr, check-device-wait-idle, check-no-inventory-submit).
Suggested next step: None.

**[info] `packages/camera/src/camera_to_cuda_copy.rs:60`** — No other in-tree processor is affected
by the newly-forwarded attributes, so there is no unmigrated consumer of the old pattern.
Evidence: I scanned every `#[processor(...)]`-annotated struct body in the tree for field
attributes: only packages/camera/src/camera_to_cuda_copy.rs and the new engine test carry `#[cfg]`
on a field. Every other hit is a `///` doc (frame-tap, h264/h265, mp4, opus, moq, api-server, jpeg,
audio, display, screen-capture, blending-compositor example) — those docs now survive expansion,
which is additive, and `cargo doc -p streamlib --no-deps` is warning-free. packages/camera/streamlib.yaml
records `state: []` for CameraToCudaCopy, so the rename leaves no stale manifest reference.
Suggested next step: None.

**[info] `runtime/streamlib-plugin-abi/src/vtables/processor.rs:86`** — Confirmed (refuting
nothing): the generated `Processor` struct never crosses the plugin ABI. The instance transits as
an opaque `*mut c_void`, and every cast back to the concrete type is same-side, so the field list,
field order, and layout of the generated struct are not ABI shape. No layout-version bump or
fingerprint change is owed by this diff.
Evidence: `ProcessorVTable::construct` returns `*mut c_void` and every other slot takes `instance:
*mut c_void` (runtime/streamlib-plugin-abi/src/vtables/processor.rs:86-97, 223-232). Both arms box
and cast inside the crate that monomorphizes `P`: cdylib arm `Box::into_raw(Box::new(processor)) as
*mut c_void` / `Box::from_raw(instance as *mut P)`
(sdk/streamlib-plugin-sdk/src/plugin/processor_vtable.rs:116,135); engine arm the same
(runtime/streamlib-engine/src/core/plugin/processor_vtable.rs:128,147). The host never names
`P::Processor`. No field-derived wire payload exists either: `to_runtime_json` defaults to
`JsonValue::Null` and never enumerates fields (sdk/streamlib-plugin-sdk/src/processors.rs:284-286),
and the descriptor is generated from the attribute schema, not from the struct fields
(sdk/streamlib-macros/src/codegen.rs:414-415).
Suggested next step: Nothing to do. If the PR body claims ABI-neutrality, this is the citation set
to back it.

**[info] `sdk/streamlib-macros/src/codegen.rs:245`** — The `inputs` / `outputs` PluginAbiObject
port fields can never be reached by the field-attribute filter, and a definition/initializer
presence desync is impossible by construction — not merely untested.
Evidence: The port fields are synthesized from `schema.inputs` / `schema.outputs`
(sdk/streamlib-macros/src/codegen.rs:245-255 for the struct, :582-592 for the initializer), while
the filter only ever walks `item.fields.named` (:199-227) — disjoint sources. Presence is governed
solely by `cfg`, which both filters forward (:181, :195); the only other presence-bearing
attribute, `cfg_attr`, is excluded from both (:59 of sdk/streamlib-macros/src/lib.rs documents
this). So the initializer's set is exactly the presence-bearing subset of the definition's set.
`has_iceoryx2_outputs` / `has_iceoryx2_inputs` and the `set_iceoryx2_resources` body are likewise
schema-driven consts (:727-782), so no authored attribute can make the host and the cdylib
disagree about port presence. A future desync (someone adding `cfg_attr` to one filter only) would
surface as E0063 "missing field" or E0560 "no field named" — loud, never silent.
Suggested next step: None. The new lock test at codegen.rs:941 is a reasonable behavioral pin on
top of the structural argument.

**[info] `sdk/streamlib-macros/src/codegen.rs:194`** — The lint-control asymmetry (definition gets
`allow`/`warn`/`deny`/`forbid`/`expect`, initializer gets `cfg` only) is benign for
attribute-position lints — I probed it rather than reasoning about it.
Evidence: Built a two-crate proc-macro probe reproducing the exact filter split (rustc 1.94.0).
With `#[allow(clippy::non_minimal_cfg)] #[cfg(all())]` on a field, the diagnostic is silenced
whether the `allow` is forwarded to the definition site only, or to the initializer site only — a
single `allow` on the authored field reaches the (span-deduped) diagnostic either way. Plain-code
baseline confirms `non_minimal_cfg` does fire on a struct-expression field's `#[cfg(all())]`, so
the probe was live. `unexpected_cfgs` is not silenceable by a field-level `allow` even in ordinary
non-macro code (fires during cfg-stripping), so that is pre-existing rustc behavior, not an
asymmetry introduced here. Concretely: the new engine test's `#[allow(clippy::non_minimal_cfg)]
#[cfg(all())]` at runtime/streamlib-engine/tests/attribute_macro_test.rs:213-214 is safe as
written.
Suggested next step: None.

**[RESOLVED — 29964f2c] [should-fix] `.github/workflows/test.yml:67`** — None of the five regression tests this PR adds
are run by any CI workflow — the #1588 lock is not actually locked.
Evidence: test.yml:67 runs `cargo test --locked -p streamlib -p streamlib-plugin-abi -p
streamlib-plugin-sdk -p streamlib-processor-extract --lib`. `streamlib-macros` is not in the `-p`
list, so the four new `processor_struct_emit_tests` cases in sdk/streamlib-macros/src/codegen.rs
never run; `--lib` excludes integration tests, and `runtime/streamlib-engine` is not in the list at
all, so runtime/streamlib-engine/tests/attribute_macro_test.rs never runs either. Grepping every
workflow for non-xtask `cargo test` yields only test.yml:67 and check-pack-load.yml:94/:100 (`-p
streamlib-pack`, and `--test pack_then_load_smoke -p streamlib-engine`) — neither reaches these
tests. I ran both suites locally in the worktree and all pass (12/12 macros unit, 11/11
attribute_macro_test), so this is a gate-selection gap, not a red test.
Suggested next step: Add `-p streamlib-macros` to the test.yml `-p` list and add a `cargo test
--locked --test attribute_macro_test -p streamlib-engine` step, mirroring the
`pack_then_load_smoke` pattern already used in check-pack-load.yml:100. If a CI edit is out of
scope for this PR, note the gap on the PR body and file the follow-up. (Noting here; treating the
CI edit as a follow-up rather than expanding this PR's scope.)
Resolution (29964f2c): both are now under the existing unit gate rather than a new job —
`.github/workflows/test.yml:69-72` adds `-p streamlib-macros` to the `--lib` invocation and a
second `cargo test --locked -p streamlib-engine --test attribute_macro_test` line in the same
step, mirroring check-pack-load.yml:100. Verified by running both commands verbatim in the
worktree: the first reports `streamlib_macros` 15/15 alongside streamlib 2, plugin-abi 77,
plugin-sdk 105, processor-extract 62; the second reports attribute_macro_test 11/11. The engine's
lib tests stay excluded — that flake is still a tracked follow-up.

**[low] `packages/camera/src/lib.rs:22`** — No CI gate compiles the non-Linux arm of
`camera_to_cuda_copy.rs`, and this diff changed that arm's shape (the field vanishes entirely
instead of being `backend: ()`).
Evidence: lib.rs:22 `pub mod camera_to_cuda_copy;` is NOT cfg-gated (unlike `pub mod camera;` at
:13), so Apple targets do compile this file's `#[cfg(not(target_os = "linux"))]` stubs.
install-packages.yml:42-44 runs `runs-on: ubuntu-latest` only, test.yml:15 likewise, and no
workflow runs `cargo check --target aarch64-apple-darwin` — which engine-doctrine requires for
Apple-path edits made on Linux. I verified the arm out-of-band by rewriting the file's `target_os =
"linux"` predicates to `any()` in a scratch copy and compiling natively: clean. A true `--target
aarch64-apple-darwin` build of the package is not reproducible on this box (a transitive
`lzma-sys` build dep needs an Apple C toolchain: `cc: error: unrecognized command-line option
'-mmacosx-version-min=11.0'`). The macro's own `#[cfg(any())]` / `#[cfg(all())]` probes in
attribute_macro_test.rs prove presence/absence forwarding target-independently, which is what
limits this to low.
Suggested next step: Record the cfg-flip cross-arm compile in the PR body as the Apple-path
verification, per the engine-doctrine convention that a real-device/target check that can't run
locally is filed as a follow-up and noted in the PR. (Done — see the Cross-compile section above.)

**[low] `sdk/streamlib-macros/src/codegen.rs:264`** — The macro promotes author-private processor
fields to `pub`, publishing the camera's OPAQUE_FD buffer + exportable timeline handles to any
external crate. Pre-existing, but this PR is the natural place to note it because it is now the
only thing standing between an external caller and the hazard the file documents.
Evidence: codegen.rs:264 emits `quote! { #(#attributes)* pub #name: #ty, }` — visibility is
hard-coded `pub`, and the field attributes are now forwarded while the authored visibility (none,
i.e. private) is not. `packages/camera/src/camera_to_cuda_copy.rs:114` declares
`linux_cuda_copy_gpu_resources` with no `pub`, yet the generated field is public and `Processor` is
externally reachable via `pub mod camera_to_cuda_copy` + `pub use` in lib.rs:22/:40. An external
crate can therefore assign `processor.linux_cuda_copy_gpu_resources = None`, dropping the
`StorageBuffer` and both `HostTimelineSemaphore`s — exactly the failure the struct's own doc at
camera_to_cuda_copy.rs:69-73 warns about ("dropping either drops the host `VkSemaphore` refcount to
zero and a subprocess consumer blocks forever on it"). `pub` is required for the authoring pattern
(the author's `impl` lives in the parent module), but `pub(super)` satisfies that and closes the
external hole.
Suggested next step: File a follow-up to emit `pub(super)` instead of `pub` for custom fields
(port/config fields keep `pub` — the host patches `inputs`/`outputs` by name), and check the
in-tree processors that read a sibling module's processor field before flipping it.

**[low] `sdk/streamlib-macros/src/codegen.rs:179`** — The two forward sets are asymmetric in a way
the doc contract does not flag, and forwarding `expect` can itself turn a green build red.
Evidence: codegen.rs:179 forwards `allow`/`warn`/`deny`/`forbid`/`expect` onto the field
definition, while codegen.rs:194 forwards only `cfg` onto the `from_config` initializer. An author
who writes `#[allow(deprecated)]` on a field to silence a lint fired by that field's
`Default::default()` site gets it dropped. Separately, a forwarded `#[expect(some_lint)]` lands on
the generated field where the lint may not fire, producing `unfulfilled_lint_expectation` — a
warning the author cannot see from their source. I confirmed the `allow` forward is genuinely
load-bearing for the in-tree case: `clippy::non_minimal_cfg` does fire on `#[cfg(all())]` (probed
on a scratch crate), so the `#[allow(clippy::non_minimal_cfg)]` at attribute_macro_test.rs is not
decorative.
Suggested next step: Either drop `expect` from the field-definition forward set (keep
`allow`/`warn`/`deny`/`forbid`), or extend the lib.rs:56-59 authoring contract to state that lint
controls reach the field definition only, not the initializer.

**[info] `packages/camera/src/camera_to_cuda_copy.rs:273`** — `produce_signal_value` advances
before the recorder work is submitted, so a mid-record failure leaves the host counter ahead of the
semaphore. Pre-existing, unchanged by this diff — noted only because the rename touched these
lines.
Evidence: camera_to_cuda_copy.rs:273 increments `produce_signal_value`, then :289-:313 record
`begin`/barrier/copy/barrier and :319-:320 submit. Any `?` between :273 and :320 returns with the
counter advanced and nothing signalled; the next successful frame signals N+2 against a semaphore
still at N. Timeline monotonicity is not violated, and a consumer that waits on "greater than last
observed" still unblocks — a consumer that waits on a precomputed N+1 would not. In practice the
error propagates out of `process()` and faults the processor, so the desync is not observable
today.
Suggested next step: No action for this PR. If the resilience model ever changes so `process()`
errors are non-fatal, move the increment to just before `submit_signaling_timeline`.

**[info] `packages/camera/src/camera_to_cuda_copy.rs:113`** — The Linux camera arm is genuinely
gated in CI, so the rename is covered where it matters most.
Evidence: install-packages.yml:20-26 triggers on `packages/**` and `sdk/**` (both touched by this
PR) and compiles every distributable package via the on-box `streamlib add` path.
`packages/camera/streamlib.yaml` declares no `patch:` entries and `packages/camera/Cargo.toml`
declares no path deps, so `non_distributable_path_offenders`
(tools/streamlib-pack/src/lib.rs:1295) returns empty and `@tatolab/camera` is in the enumerated set
rather than the skip set. I reproduced that compile locally with the SDK crates path-patched:
clean.
Suggested next step: None.

**[should-fix] `sdk/streamlib-macros/src/codegen.rs:164`** — `CustomField` stores two attribute
vectors where the second is fully derivable from the first, and the lockstep invariant between them
is maintained by hand (the doc comment says so out loud).
Evidence: L164-171 declares `attributes_for_generated_field_definition` and
`attributes_for_from_config_initializer` with the note "the two must stay in lockstep on
presence". Since `is_forwarded_onto_from_config_initializer` (L194) accepts exactly `cfg`, and
`is_forwarded_onto_generated_field_definition` (L179) also accepts `cfg`, the second Vec is by
construction `first.iter().filter(|a| a.path().is_ident("cfg"))`. `extract_custom_fields`
(L210-221) therefore walks `authored_field.attrs` twice and clones the `cfg` attribute twice per
field to materialize a subset it already has.
Suggested next step: Drop `attributes_for_from_config_initializer` from `CustomField`; at the
initializer emit site (L603) derive it: `let attributes =
custom_field.attributes_for_generated_field_definition.iter().filter(|attribute|
attribute.path().is_ident("cfg"));` — quote's `#(#attributes)*` repetition accepts any
`IntoIterator`. This deletes one struct field, one filter/clone pass, and makes the presence-desync
the comment warns about structurally unrepresentable (the initializer set can no longer contain
anything the definition set lacks).

**[RESOLVED — 4c65f7b9] [should-fix] `sdk/streamlib-macros/src/codegen.rs:210`** — Non-forwarded field attributes are
dropped silently with no diagnostic — the exact failure class #1588 was, left open for `cfg_attr`
and every unknown attribute.
Evidence: `extract_custom_fields` (L210-221) keeps the whitelist and discards the rest without a
word. An author writing `#[serde(skip)]` or `#[cfg_attr(feature = "x", cfg(target_os = "linux"))]`
on a processor field gets silently-wrong generated code — and `cfg_attr` is precisely the one
dropped attribute that can still change field presence. The rustdoc at
sdk/streamlib-macros/src/lib.rs:56-59 documents the drop, but documentation does not reach the
author who wrote the attribute. The crate already has a `compile_error!` emission path for
author-facing macro diagnostics (codegen.rs:48-55).
Suggested next step: In `extract_custom_fields`, collect the non-forwarded attributes per field and
emit a `compile_error!` naming the field and the attribute path (at minimum for `cfg_attr`, which
is presence-affecting): "#[processor] field `x`: attribute `cfg_attr` is not forwarded onto the
generated field". A hard error is cheap here — the in-tree sweep shows only `cfg` and `allow` in
use on processor fields today, so the blast radius is zero.
Resolution (4c65f7b9): taken at the `cfg_attr` scope the item calls the minimum, and deliberately
no wider. `refused_field_attribute_diagnostics` (codegen.rs:198-232) emits a `compile_error!`
spanned at the offending attribute, spliced into the generated module at codegen.rs:137.
Confirmed end-to-end against a real processor: `error: #[cfg_attr(...)] is not supported on
#[processor] struct fields (field `cfg_attr_annotated_backend_state`): a cfg_attr that expands to
a cfg would change the field's presence on the generated Processor struct without changing it on
the from_config initializer, and the two would no longer agree. Author the #[cfg(...)] directly
on the field instead.` — with the caret on the attribute itself, not on the macro invocation. NOT
widened to unknown attributes: the macro drops derive-helper attributes such as `#[serde(...)]` by
design and the existing suite probes exactly that, so a blanket error would break in-tree
authors. Both halves locked (`cfg_attr_on_a_processor_field_emits_a_compile_error_naming_the_field`,
`a_dropped_derive_helper_attribute_on_a_processor_field_stays_silent`). Re-verified before
committing that no `#[processor]` struct field in the tree carries a `cfg_attr` — every
`#[processor]` struct body across packages/, runtime/, examples/ and sdk/ scanned, zero hits — and
all 15 distributable packages still compile through `xtask install-packages`.

**[RESOLVED — b3e7144f] [should-fix] `sdk/streamlib-macros/src/codegen.rs:952`** — The PluginAbiObject port-field
assertions are brittle by construction: they hard-code the rendered token text, so unrelated
codegen churn breaks them with a message that misdescribes the failure.
Evidence: L951-954 asserts `struct_rendered.contains("pubstructProcessor{pubinputs:__streamlib_sdk::iceoryx2::InputMailboxes,puboutputs:__streamlib_sdk::iceoryx2::OutputWriter,")`
and L971-974 the analogous `Ok(Self{inputs:...::empty(),outputs:...::empty(),`. That couples the
test to (a) the `__streamlib_sdk` alias name, (b) the full `iceoryx2::InputMailboxes` path, (c)
inputs-before-outputs ordering, (d) the fields sitting literally at the head of the struct. None of
those are the property under test — the property is "no authored field attribute reaches
`inputs`/`outputs`" — and a rename of the alias or an `#[allow(...)]` emitted above the port fields
would fail this test claiming the attribute filter regressed.
Suggested next step: Assert structurally instead of on text: `syn` is already a dependency with
`full` + `extra-traits` (sdk/streamlib-macros/Cargo.toml:13), so `let generated: ItemStruct =
syn::parse2(tokens).expect(...)` then find the fields named `inputs`/`outputs` and assert
`field.attrs.is_empty()`. That is strictly stronger (catches an attribute inserted anywhere, not
only a prefix at the head) and immune to path/order churn. Same treatment for the `from_config`
half via `syn::parse2::<syn::ImplItemFn>` and the struct-literal's `FieldValue.attrs`.
Resolution (b3e7144f): taken as suggested, at both sites. The test now parses the emitted tokens
(`syn::parse2::<ItemStruct>`, and `syn::parse2::<syn::ImplItemFn>` down to the `Self { .. }`
literal) and asserts the property per port field: declared, `pub`, `attrs.is_empty()`, and the
type path's last segment still `InputMailboxes` / `OutputWriter`. Declaration order is no longer
asserted at all — `Processor` is not `#[repr(C)]`, so its field order is not a contract — and the
non-vacuity guard is now an exact `["cfg"]` attribute-set check on the compiled-out probe field.
Failure messages name the real property and print the actual field / attribute lists.
Mutation-checked both directions: moving the port fields to the tail of the struct and the
initializer (a benign reorder) reds the OLD assertion — `the PluginAbiObject port fields must open
the generated struct with nothing interposed` — and passes the new one; leaking a `#[doc]` onto
the `inputs` field reds the new one with `the inputs port field must be unconditional — no
authored field attribute may reach it, but it carries ["doc"]`. The test helper
`render_without_whitespace` is renamed `render_token_stream_without_whitespace` per
.claude/rules/naming.md.

**[RESOLVED — b3e7144f] [low] `sdk/streamlib-macros/src/codegen.rs:1086`** — `from_config_initializer_forwards_cfg_only`
scans the whole rendered function for bare substrings, which is a future false-positive trap with a
misleading failure message.
Evidence: L1086-1093 loops `for dropped in ["doc", "allow", "cfg_attr", "serde"]` asserting
`!rendered.contains(dropped)` over the entire `fn from_config` rendering, not just the field
initializer. Codegen already emits `#[allow(dead_code)]` / `#[allow(non_snake_case)]` /
`#[allow(unused_imports)]` elsewhere in this file (L106, L125, L132); the day `from_config` grows
any `#[allow(...)]` for an unrelated reason, this test fails with "from_config initializer must
forward `cfg` only, found `allow`" while the attribute filter is perfectly healthy. It is also
name-sensitive: a probe field named `documentation_state` would trip the `doc` check.
Suggested next step: Scope the assertion to the field initializer — parse with
`syn::parse2::<syn::ImplItemFn>` and check the `FieldValue`'s `attrs` for
`annotated_backend_state`, or at minimum slice `rendered` to the initializer span before the
substring scan.
Resolution (b3e7144f): rewritten by the same change as the port-field item above — recorded here
too because it is the same test. It parses the emitted `from_config` down to the `Self { .. }`
literal and asserts the initializer's attribute set is exactly `["cfg"]`, against a probe field
that also authors `doc`, `allow`, `expect` and a derive helper. That is strictly stronger than the
old absence-of-five-known-names scan and no longer sensitive to unrelated tokens elsewhere in the
function. Widening the initializer filter to accept `allow` reds it with `left: ["allow", "cfg"]
right: ["cfg"]`.

**[low] `packages/camera/src/camera_to_cuda_copy.rs:240`** — The rename leaves a 30-character local
binding repeated 11 times inside one function, forcing rustfmt into awkward splits that read worse
than the code it replaced.
Evidence: `linux_cuda_copy_gpu_resources` is bound at L240 and then repeated at L250, L261, L262,
L269 (twice), L273, L274, L276, L277, L279, L302, L320 — producing the three-line `gpu_ctx` call
chain at L250-257, the split condition at L261-263, and the wrapped
`recorder.submit_signaling_timeline(...)` at L319-320. The struct field name is right; the local
binding is what hurts.
Suggested next step: Destructure once instead of rebinding the whole struct: `let
LinuxCudaCopyGpuResources { gpu_ctx, storage_buffer, produce_done, copy_recorder, width, height,
produce_signal_value, .. } = self.linux_cuda_copy_gpu_resources.as_mut().ok_or_else(...)?;` — every
binding is zero-context-explicit on its own, the field-level borrow split is the same one the code
already relies on at L279/L302, and the body reads as it did before the rename. Alternatively hoist
the record-and-submit sequence onto `impl LinuxCudaCopyGpuResources` as a `&mut self` method, which
also reifies the concept.

**[low] `sdk/streamlib-macros/src/codegen.rs:205`** — `.expect("Named field must have ident")` is a
panic path in library code, re-touched by this diff.
Evidence: L205-208 inside the `syn::Fields::Named` arm. It is provably unreachable (a named field
always has an ident), but the repo convention is `?` over `.unwrap()`/`expect` in library code, and
a proc-macro panic surfaces to the author as an opaque "proc macro panicked" rather than a spanned
diagnostic. The diff reflowed these exact lines for the `f` -> `authored_field` rename, so it is in
scope for a cheap cleanup.
Suggested next step: Either `filter_map` the ident away (`let name = authored_field.ident.clone()?;`
inside a `filter_map`) or route it through the existing `compile_error!` emission path so an
impossible-input regression reports as a spanned macro error instead of a panic.

**[low] `sdk/streamlib-macros/src/codegen.rs:986`** — The five new unit tests repeat the same
two-line arrange step verbatim.
Evidence: `let custom_fields = extract_custom_fields(&<probe>()); let rendered =
render_without_whitespace(generate_processor_struct_from_schema(&minimal_schema(), &None,
&custom_fields));` appears at L986-991, L1042-1046 and (with `generate_from_config_from_schema`) at
L1010-1014, L1076-1080, plus both variants at L945-949/L965-969. Six copies of the same call shape.
Suggested next step: Two helpers next to `render_without_whitespace` — `fn
render_generated_processor_struct(authored: &ItemStruct, schema: &ProcessorSchema) -> String` and
`fn render_generated_from_config(authored: &ItemStruct, schema: &ProcessorSchema) -> String` —
collapse each test to one arrange line and put the assertions in the foreground.

**[info] `sdk/streamlib-macros/src/codegen.rs:179`** — Direct answer to the question posed: the two
attribute-filter predicates are NOT duplication, and parameterizing them into one helper would be a
regression.
Evidence: `is_forwarded_onto_generated_field_definition` (L179-188) and
`is_forwarded_onto_from_config_initializer` (L194-196) encode two different policies with different
rationales (documented at L174-178 and L190-193), not the same logic written twice. Collapsing them
into `is_forwarded_onto(site, attribute)` would introduce a site-selector parameter — the
boolean/enum-parameter trap — for two one-line policies that currently read as their own names at
the call sites. The real DRY item in this neighbourhood is the derived-state duplication in
`CustomField`, filed separately above.
Suggested next step: Keep both predicates as named functions. The only optional tidy is the
seven-arm `is_ident` chain at L181-187, which could read `["cfg", "doc", "allow", "warn", "deny",
"forbid", "expect"].iter().any(|name| path.is_ident(name))` — a wash today, worth doing only if the
set grows.

**[info] `packages/camera/src/camera_to_cuda_copy.rs:112`** — The consumer sweep checks out: the
fix is at the engine (macro) layer and the one in-tree workaround for the old bug is removed in the
same PR.
Evidence: I scanned every `#[processor(...)]` struct body in packages/, runtime/, examples/ and
sdk/ for field-level attributes. The only real pre-fix workaround was this file's `GpuBackendStash`
type alias (deleted) plus the `LinuxState` -> `LinuxCudaCopyGpuResources` rename, which also retires
a naming-rule violation. The only other field attributes in-tree are `#[allow(dead_code)]` in
packages/mp4/src/_apple_impl_pending_/mp4_writer.rs:47-52 (previously dropped, now forwarded —
harmless, and that directory is not compiled).
Suggested next step: Nothing to do; noted so the PR body can state the sweep was verified rather
than assumed. (Done — see the Summary's canonical-pattern-sweep framing above.)

