### PR TITLE
chore(macros): derive the initializer attribute set instead of storing it alongside the definition set

### DIFF
--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -939,8 +939,9 @@ mod processor_struct_emit_tests {
         attributes.iter().map(attribute_path_ident).collect()
     }
 
-    /// Every attribute authored across the probe's fields, in authored order.
-    fn authored_attributes(custom_fields: &[CustomField]) -> Vec<&syn::Attribute> {
+    fn attributes_authored_across_probe_custom_fields(
+        custom_fields: &[CustomField],
+    ) -> Vec<&syn::Attribute> {
         custom_fields
             .iter()
             .flat_map(|custom_field| {
@@ -956,11 +957,11 @@ mod processor_struct_emit_tests {
     /// rendering.
     fn forwarded_attribute_path_idents(
         custom_fields: &[CustomField],
-        is_forwarded_onto_site: impl Fn(&syn::Attribute) -> bool,
+        is_forwarded_onto_emission_site: impl Fn(&syn::Attribute) -> bool,
     ) -> Vec<String> {
-        authored_attributes(custom_fields)
+        attributes_authored_across_probe_custom_fields(custom_fields)
             .into_iter()
-            .filter(|attribute| is_forwarded_onto_site(attribute))
+            .filter(|attribute| is_forwarded_onto_emission_site(attribute))
             .map(attribute_path_ident)
             .collect()
     }
@@ -1408,6 +1409,7 @@ mod processor_struct_emit_tests {
                 #[allow(dead_code)]
                 #[expect(unused_parens)]
                 #[cfg(target_os = "linux")]
+                #[cfg_attr(target_os = "linux", allow(unused))]
                 #[serde(skip)]
                 cfg_and_lint_annotated_backend_state: Option<u32>,
             }
@@ -1439,21 +1441,21 @@ mod processor_struct_emit_tests {
             attribute_path_idents(&initializer.attrs),
             vec!["cfg".to_string()],
             "the `from_config` initializer must carry the authored `#[cfg]` and nothing else — \
-             the probe also authors `doc`, `allow`, `expect`, and a derive helper"
+             the probe also authors `doc`, `allow`, `expect`, `cfg_attr`, and a derive helper"
         );
     }
 
-    /// The two emission sites filter the authored list independently, so
-    /// nothing structural stops the initializer from taking an attribute the
-    /// field definition drops. That combination is uncompilable output: a
-    /// presence-changing attribute on the initializer for a field the
-    /// definition did not gate the same way initializes a field that isn't
-    /// there. The initializer's accepted set must stay a subset.
+    /// The initializer's accepted set must stay a subset of the field
+    /// definition's: a presence-changing attribute on the initializer for a
+    /// field the definition did not gate the same way initializes a field that
+    /// isn't there. [`is_forwarded_onto_generated_field_definition`] holds the
+    /// nesting by construction, so this is the regression pin that catches an
+    /// edit splitting the two sites back into independent lists.
     #[test]
     fn every_attribute_the_from_config_initializer_takes_also_reaches_the_field_definition() {
         let custom_fields =
             extract_custom_fields(&struct_with_a_cfg_alongside_every_other_forwardable_attribute());
-        let authored = authored_attributes(&custom_fields);
+        let authored = attributes_authored_across_probe_custom_fields(&custom_fields);
         assert!(
             authored
                 .iter()

--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -201,10 +201,11 @@ fn is_forwarded_onto_from_config_initializer(attribute: &syn::Attribute) -> bool
 }
 
 /// `cfg_attr` on a processor struct field is refused rather than dropped: it can
-/// expand to a presence-changing `cfg`, and the two emission sites are filtered
-/// independently, so an expansion that gates the field definition without gating
-/// the `from_config` initializer desyncs them into an error far from its cause.
-/// Silently discarding it is the same failure class as #1588.
+/// expand to a presence-changing `cfg`, and the field definition accepts a strict
+/// superset of what the `from_config` initializer accepts, so an expansion
+/// admitted at the definition site alone gates the field without gating its
+/// initializer — an error far from its cause. Silently discarding it is the same
+/// failure class as #1588.
 fn refused_field_attribute_diagnostics(item: &ItemStruct) -> TokenStream {
     let syn::Fields::Named(fields) = &item.fields else {
         return quote! {};

--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -165,14 +165,8 @@ pub fn generate_from_processor_schema(
 struct CustomField {
     name: Ident,
     ty: syn::Type,
-    /// Authored attributes re-emitted onto the generated `Processor` struct
-    /// field, filtered by [`is_forwarded_onto_generated_field_definition`].
-    attributes_for_generated_field_definition: Vec<syn::Attribute>,
-    /// Authored attributes re-emitted onto the `from_config` struct-literal
-    /// initializer, filtered by
-    /// [`is_forwarded_onto_from_config_initializer`]. Narrower than the field
-    /// definition's set — the two must stay in lockstep on presence.
-    attributes_for_from_config_initializer: Vec<syn::Attribute>,
+    /// The field's authored attributes verbatim; each emission site filters.
+    attributes_authored_on_processor_struct_field: Vec<syn::Attribute>,
 }
 
 /// Authoring contract for `#[processor]` struct fields: `cfg` is the
@@ -244,18 +238,7 @@ fn extract_custom_fields(item: &ItemStruct) -> Vec<CustomField> {
                     .clone()
                     .expect("Named field must have ident"),
                 ty: authored_field.ty.clone(),
-                attributes_for_generated_field_definition: authored_field
-                    .attrs
-                    .iter()
-                    .filter(|attribute| is_forwarded_onto_generated_field_definition(attribute))
-                    .cloned()
-                    .collect(),
-                attributes_for_from_config_initializer: authored_field
-                    .attrs
-                    .iter()
-                    .filter(|attribute| is_forwarded_onto_from_config_initializer(attribute))
-                    .cloned()
-                    .collect(),
+                attributes_authored_on_processor_struct_field: authored_field.attrs.clone(),
             })
             .collect(),
         syn::Fields::Unit => Vec::new(),
@@ -295,7 +278,10 @@ fn generate_processor_struct_from_schema(
     let custom_field_defs: Vec<TokenStream> = custom_fields
         .iter()
         .map(|custom_field| {
-            let attributes = &custom_field.attributes_for_generated_field_definition;
+            let attributes = custom_field
+                .attributes_authored_on_processor_struct_field
+                .iter()
+                .filter(|attribute| is_forwarded_onto_generated_field_definition(attribute));
             let name = &custom_field.name;
             let ty = &custom_field.ty;
             quote! { #(#attributes)* pub #name: #ty, }
@@ -637,7 +623,10 @@ fn generate_from_config_from_schema(
     let custom_field_inits: Vec<TokenStream> = custom_fields
         .iter()
         .map(|custom_field| {
-            let attributes = &custom_field.attributes_for_from_config_initializer;
+            let attributes = custom_field
+                .attributes_authored_on_processor_struct_field
+                .iter()
+                .filter(|attribute| is_forwarded_onto_from_config_initializer(attribute));
             let name = &custom_field.name;
             quote! { #(#attributes)* #name: ::std::default::Default::default(), }
         })
@@ -931,29 +920,41 @@ mod processor_struct_emit_tests {
             .collect()
     }
 
+    fn attribute_path_ident(attribute: &syn::Attribute) -> String {
+        let path = attribute.path();
+        path.get_ident()
+            .map(Ident::to_string)
+            .unwrap_or_else(|| render_token_stream_without_whitespace(quote! { #path }))
+    }
+
     /// The path ident of each attribute, in authored order.
     fn attribute_path_idents(attributes: &[syn::Attribute]) -> Vec<String> {
-        attributes
+        attributes.iter().map(attribute_path_ident).collect()
+    }
+
+    /// Every attribute authored across the probe's fields, in authored order.
+    fn authored_attributes(custom_fields: &[CustomField]) -> Vec<&syn::Attribute> {
+        custom_fields
             .iter()
-            .map(|attribute| {
-                let path = attribute.path();
-                path.get_ident()
-                    .map(Ident::to_string)
-                    .unwrap_or_else(|| render_token_stream_without_whitespace(quote! { #path }))
+            .flat_map(|custom_field| {
+                custom_field
+                    .attributes_authored_on_processor_struct_field
+                    .iter()
             })
             .collect()
     }
 
-    /// The attribute path idents the filter kept for one emission site — the
+    /// The attribute path idents one emission site's filter keeps — the
     /// decision the filter actually makes, read without going through a
     /// rendering.
     fn forwarded_attribute_path_idents(
         custom_fields: &[CustomField],
-        attributes_for_site: impl Fn(&CustomField) -> &Vec<syn::Attribute>,
+        is_forwarded_onto_site: impl Fn(&syn::Attribute) -> bool,
     ) -> Vec<String> {
-        custom_fields
-            .iter()
-            .flat_map(|custom_field| attribute_path_idents(attributes_for_site(custom_field)))
+        authored_attributes(custom_fields)
+            .into_iter()
+            .filter(|attribute| is_forwarded_onto_site(attribute))
+            .map(attribute_path_ident)
             .collect()
     }
 
@@ -1261,9 +1262,10 @@ mod processor_struct_emit_tests {
     #[test]
     fn processor_struct_does_not_forward_expect_onto_the_generated_pub_field() {
         let custom_fields = extract_custom_fields(&annotated_field_struct());
-        let forwarded_attribute_paths = forwarded_attribute_path_idents(&custom_fields, |field| {
-            &field.attributes_for_generated_field_definition
-        });
+        let forwarded_attribute_paths = forwarded_attribute_path_idents(
+            &custom_fields,
+            is_forwarded_onto_generated_field_definition,
+        );
         assert!(
             !forwarded_attribute_paths.contains(&"expect".to_string()),
             "`expect` must not reach the generated `pub` field — it would land \

--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -169,26 +169,33 @@ struct CustomField {
     attributes_authored_on_processor_struct_field: Vec<syn::Attribute>,
 }
 
-/// Authoring contract for `#[processor]` struct fields: `cfg` is the
-/// load-bearing forward — dropping it makes a platform-conditional field
-/// unconditional and its platform-specific type fails to resolve off that
-/// platform. `doc` and the `allow` / `warn` / `deny` / `forbid` controls ride
-/// along so an author's `///` and `#[allow(dead_code)]` survive expansion.
-/// `expect` is excluded: the generated field is `pub` where the authored one
-/// was private, so a `dead_code` expectation the author wrote to silence a
-/// warning becomes an `unfulfilled_lint_expectation` warning instead.
+/// Authoring contract for `#[processor]` struct fields. Everything
+/// [`is_forwarded_onto_from_config_initializer`] takes is admitted here first,
+/// because an initializer gating a field the definition did not gate the same
+/// way initializes a field that isn't there. `doc` and the `allow` / `warn` /
+/// `deny` / `forbid` controls are the extras layered on top of that set, so an
+/// author's `///` and `#[allow(dead_code)]` survive expansion. `expect` is
+/// excluded from both: the generated field is `pub` where the authored one was
+/// private, so a `dead_code` expectation the author wrote to silence a warning
+/// becomes an `unfulfilled_lint_expectation` warning instead.
 fn is_forwarded_onto_generated_field_definition(attribute: &syn::Attribute) -> bool {
+    if is_forwarded_onto_from_config_initializer(attribute) {
+        return true;
+    }
+
     let path = attribute.path();
-    path.is_ident("cfg")
-        || path.is_ident("doc")
+    path.is_ident("doc")
         || path.is_ident("allow")
         || path.is_ident("warn")
         || path.is_ident("deny")
         || path.is_ident("forbid")
 }
 
-/// `cfg` is the only attribute a struct-expression field takes cleanly — a
-/// `doc` there is an `unused_doc_comments` warning and the gates deny warnings.
+/// `cfg` is the load-bearing forward — dropping it makes a platform-conditional
+/// field unconditional and its platform-specific type fails to resolve off that
+/// platform — and it is the only attribute a struct-expression field takes
+/// cleanly: a `doc` there is an `unused_doc_comments` warning and the gates deny
+/// warnings.
 fn is_forwarded_onto_from_config_initializer(attribute: &syn::Attribute) -> bool {
     attribute.path().is_ident("cfg")
 }

--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -1435,4 +1435,40 @@ mod processor_struct_emit_tests {
              the probe also authors `doc`, `allow`, `expect`, and a derive helper"
         );
     }
+
+    /// The two emission sites filter the authored list independently, so
+    /// nothing structural stops the initializer from taking an attribute the
+    /// field definition drops. That combination is uncompilable output: a
+    /// presence-changing attribute on the initializer for a field the
+    /// definition did not gate the same way initializes a field that isn't
+    /// there. The initializer's accepted set must stay a subset.
+    #[test]
+    fn every_attribute_the_from_config_initializer_takes_also_reaches_the_field_definition() {
+        let custom_fields =
+            extract_custom_fields(&struct_with_a_cfg_alongside_every_other_forwardable_attribute());
+        let authored = authored_attributes(&custom_fields);
+        assert!(
+            authored
+                .iter()
+                .any(|attribute| is_forwarded_onto_from_config_initializer(attribute)),
+            "the probe must author at least one initializer-forwarded attribute, or this \
+             test passes vacuously — it authors: {:?}",
+            authored
+                .iter()
+                .copied()
+                .map(attribute_path_ident)
+                .collect::<Vec<String>>()
+        );
+        for attribute in authored {
+            if is_forwarded_onto_from_config_initializer(attribute) {
+                assert!(
+                    is_forwarded_onto_generated_field_definition(attribute),
+                    "`{}` reaches the `from_config` initializer but not the generated \
+                     field definition — the initializer would gate a field the definition \
+                     does not declare the same way",
+                    attribute_path_ident(attribute)
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Ticket
Closes #1617

## Summary
`CustomField` in `sdk/streamlib-macros/src/codegen.rs` used to store two pre-filtered
attribute vectors per authored processor struct field — one for the generated field
definition, one for the `from_config` initializer — kept in sync by a hand-written doc
comment ("the two must stay in lockstep on presence"). This PR stores the field's
authored attributes once, verbatim, and filters at each emission site with the
predicate that already owns that site's rule.

**The mechanism is structural nesting.** `is_forwarded_onto_generated_field_definition`
opens by delegating:

```rust
fn is_forwarded_onto_generated_field_definition(attribute: &syn::Attribute) -> bool {
    if is_forwarded_onto_from_config_initializer(attribute) {
        return true;
    }

    let path = attribute.path();
    path.is_ident("doc")
        || path.is_ident("allow")
        || path.is_ident("warn")
        || path.is_ident("deny")
        || path.is_ident("forbid")
}
```

The definition site's accept-set is therefore *the initializer's set plus the extras*,
not a second independent literal ident list that happens to contain the first. The
invariant the generated code depends on — an attribute reaching the `from_config`
initializer must also reach the field definition, or the initializer gates a field the
definition did not declare the same way — now holds by construction for every attribute
in the language, rather than for the handful a probe struct samples.

**Behavior-preserving.** The two accept-sets are the same set before and after:

| Site | Before | After |
| --- | --- | --- |
| field definition | `cfg, doc, allow, warn, deny, forbid` (one literal list) | `{cfg}` (delegated) ∪ `{doc, allow, warn, deny, forbid}` (extras) |
| `from_config` initializer | `cfg` | `cfg` (unchanged) |

`{cfg} ∪ {doc, allow, warn, deny, forbid}` is exactly the old definition list, so every
emitted token stream is identical. `expect` stays excluded from both sites — the
generated field is `pub` where the authored one was private, so a forwarded
`#[expect(dead_code)]` lands unfulfilled and warns `unfulfilled_lint_expectations`.

**The two predicates stay separate functions.** The craftsmanship review on #1615
concluded that parameterizing them into one helper with a site-selector argument would
be a regression — the rules are genuinely different for the two syntactic positions (a
`doc` on a struct-expression field is an `unused_doc_comments` warning and the gates
deny warnings), and #1617 restates that constraint. Only the *storage* merged, and now
the *nesting* is expressed in code; the *rules* remain two named functions with their
own docs and their own site rationale.

### Honest scope of the safety win
The marginal safety this buys **today** is small. `refused_field_attribute_diagnostics`
(added in #1615) already emits a `compile_error!` for `cfg_attr` on an authored
processor field, and `cfg_attr` is the only presence-changing attribute an author can
reach for besides `cfg` itself. So there is no reachable desync on `main` right now, and
this PR fixes no live defect.

Its value is that it closes the **future-edit drift class** permanently, at zero
behavioral cost. The concrete instance: `cfg_attr` support was deferred on #1615 as a
should-fix follow-up (the refusal diagnostic was taken as the minimum instead). Whoever
picks that up removes the refusal — and at that moment the only thing standing between
the two emission sites is whether they remember to widen both predicates. With the
delegation in place, widening `is_forwarded_onto_from_config_initializer` widens the
field definition automatically; the two cannot be widened apart. Note there is no
tracking issue filed for that `cfg_attr` work yet — the deferral currently lives only in
#1615's body.

### Called-out extraction
Per engine doctrine ("extraction is fine if it replaces real duplication AND is called
out in the PR"): `attribute_path_ident` (`codegen.rs:931`) is a **new test-only helper**
lifted out of `attribute_path_idents`. It renders one attribute's path ident, and now has
**four call sites across three functions** — `attribute_path_idents` (`:940`),
`forwarded_attribute_path_idents` (`:966`), and the subset test, which uses it twice
(`:1469` in the vacuity-guard message, `:1479` in the failure message). No production
callers.

### Test-side changes
- The subset probe `struct_with_a_cfg_alongside_every_other_forwardable_attribute` now
  authors `#[cfg_attr(target_os = "linux", allow(unused))]` alongside its `#[cfg]`.
  `cfg_attr` is the attribute this file's own comments name as the desync vector, and
  without it in the probe the subset test cannot observe the exact drift it exists to
  catch (proof in Mutation D below). `refused_field_attribute_diagnostics` still refuses
  `cfg_attr` on authored fields via `compile_error!` — untouched; these unit tests call
  the predicates and emitters directly, so the guard does not interfere with them.
- Two naming-rule fixes: the `forwarded_attribute_path_idents` predicate parameter
  `is_forwarded_onto_site` → `is_forwarded_onto_emission_site`, and the helper
  `authored_attributes` → `attributes_authored_across_probe_custom_fields` (which lets
  its doc comment go away — the name now carries it).
- The subset test's doc was rewritten: it previously stated "nothing structural stops
  the initializer from taking an attribute the field definition drops," which the
  delegation makes false. It is now described as the regression pin that catches an edit
  splitting the two sites back into independent lists.

No pre-existing assertion was edited to make anything pass. The only test-side edits are
the two renames, the probe addition, the two doc rewrites, and the one assertion-message
enumeration that had to name the new probe attribute.

### Storage / allocation note
`CustomField` now stores **one unfiltered clone of every authored attribute**, replacing
two narrow filtered clones. This is not a removal of per-field clones — it is two narrow
clones becoming one wide one. Proc-macro expansion is compile-time and per-field
attribute counts are single-digit, so it is not measurable; at both emission sites the
filtered result is a lazy `std::iter::Filter` that `quote!` repetition consumes directly,
so no intermediate `Vec<syn::Attribute>` is materialized.

Consequently `CustomField` **intentionally retains attributes neither emission site
emits** — `serde`, `cfg_attr`, and any derive helper. A retained `cfg_attr` on
`CustomField` is not a forwarding bug: neither predicate accepts it, and it never reaches
generated output.

## Test evidence
Run from the worktree at `52d763d8`.

```
$ cargo test --locked -p streamlib-macros
running 16 tests
test codegen::processor_struct_emit_tests::from_config_initializer_does_not_construct_audio_converter ... ok
test codegen::processor_struct_emit_tests::every_attribute_the_from_config_initializer_takes_also_reaches_the_field_definition ... ok
test codegen::processor_struct_emit_tests::processor_struct_does_not_carry_audio_field ... ok
test codegen::processor_struct_emit_tests::from_config_initializer_preserves_cfg_attribute_on_custom_field ... ok
test codegen::processor_struct_emit_tests::from_config_initializer_forwards_cfg_only ... ok
test codegen::processor_struct_emit_tests::processor_struct_does_not_forward_expect_onto_the_generated_pub_field ... ok
test codegen::processor_struct_emit_tests::processor_struct_preserves_cfg_attribute_on_custom_field ... ok
test codegen::processor_struct_emit_tests::processor_struct_forwards_doc_and_lint_attributes_but_not_cfg_attr ... ok
test codegen::processor_struct_emit_tests::plugin_abi_object_port_fields_stay_unconditional_when_every_custom_field_is_compiled_out ... ok
test codegen::processor_struct_emit_tests::a_dropped_derive_helper_attribute_on_a_processor_field_stays_silent ... ok
test codegen::processor_struct_emit_tests::cfg_attr_on_a_processor_field_emits_a_compile_error_naming_the_field ... ok
(+ 5 config_descriptor tests)

test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 1 passed; 0 failed  (complete_impl_test)
test result: ok. 1 passed; 0 failed  (macro_tests)
```

```
$ cargo test --locked -p streamlib-engine --test attribute_macro_test
running 11 tests
test cfg_gated_processor_field_survives_onto_both_generated_sites ... ok
test cfg_gated_processor_still_declares_its_port_fields_unconditionally ... ok
test empty_config_is_a_tolerant_bag ... ok
test test_bare_processor_synthesizes_app_local_identity ... ok
test test_input_link_module_exists ... ok
test test_module_structure_generated ... ok
test test_output_link_module_exists ... ok
test test_port_marker_names ... ok
test test_processor_instantiation ... ok
test test_processor_schema_ident_declared_in_attribute ... ok
test test_processor_schema_ident_renders_canonical_joined_form ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`cargo fmt -p streamlib-macros -- --check` clean. `cargo clippy -p streamlib-macros
--all-targets` surfaces 7 pre-existing `collapsible_if` warnings, all in
`config_descriptor.rs` and none in `codegen.rs` — reported, not auto-fixed, per the
no-unrelated-fixes rule.

## Mutation evidence
This change's whole product is a guard, so here is the guard biting. Every run below was
done in a scratch export of the branch under `/tmp` (never in the worktree, never on the
branch), reverted to green afterwards. Captured at `c5fb1aa5`; the only later commit
(`52d763d8`) rewords one doc comment and touches no predicate, so the results stand.

**Mutation A — drop `cfg` from the field definition's accept-set** (remove the delegation
`if` block, leaving only the `doc`/`allow`/`warn`/`deny`/`forbid` extras):

```
`cfg` reaches the `from_config` initializer but not the generated field definition —
the initializer would gate a field the definition does not declare the same way

failures:
    every_attribute_the_from_config_initializer_takes_also_reaches_the_field_definition
    plugin_abi_object_port_fields_stay_unconditional_when_every_custom_field_is_compiled_out
    processor_struct_preserves_cfg_attribute_on_custom_field
test result: FAILED. 13 passed; 3 failed
```

**Mutation B — add `expect` to the initializer's accept-set**
(`is_ident("cfg") || is_ident("expect")`):

```
failures:
    from_config_initializer_forwards_cfg_only
    processor_struct_does_not_forward_expect_onto_the_generated_pub_field
test result: FAILED. 14 passed; 2 failed
```

Worth stating precisely: under the new shape, mutation B is *not* caught by the subset
test — delegation means widening the initializer widens the definition too, so the
subset relation still holds. It is caught by the `expect`-exclusion test instead. That is
the guard working as designed: the nesting makes subset violations unrepresentable, and
the site-specific tests keep owning the site-specific rules.

**Mutation C — the combination that breaks the nesting**: remove the delegation *and*
widen `is_forwarded_onto_from_config_initializer` to accept `cfg_attr`:

```
`cfg` reaches the `from_config` initializer but not the generated field definition —
the initializer would gate a field the definition does not declare the same way

failures:
    every_attribute_the_from_config_initializer_takes_also_reaches_the_field_definition
    from_config_initializer_forwards_cfg_only
    plugin_abi_object_port_fields_stay_unconditional_when_every_custom_field_is_compiled_out
    processor_struct_preserves_cfg_attribute_on_custom_field
test result: FAILED. 12 passed; 4 failed
```

**Mutation C′ — the isolating drift edit**, which simulates exactly the future `cfg_attr`
PR going wrong: restore the pre-branch two-independent-lists shape (definition lists
`cfg|doc|allow|warn|deny|forbid` literally, no delegation) and widen only the initializer
to accept `cfg_attr`:

```
`cfg_attr` reaches the `from_config` initializer but not the generated field definition —
the initializer would gate a field the definition does not declare the same way

failures:
    every_attribute_the_from_config_initializer_takes_also_reaches_the_field_definition
    from_config_initializer_forwards_cfg_only
test result: FAILED. 14 passed; 2 failed
```

**Mutation D — proof the probe addition is load-bearing.** Mutation C′ again, but with
`#[cfg_attr(...)]` removed from the subset probe (i.e. the probe as this branch had it
before this fix round):

```
test result: ok. 16 passed; 0 failed
```

The drift passes the entire suite undetected. That is the concrete reason
`#[cfg_attr(target_os = "linux", allow(unused))]` was added to the probe: without it the
subset test cannot see the one attribute the desync would actually ride in on.

Scratch reverted after every run; `test result: ok. 16 passed; 0 failed` confirmed on the
reverted copy, byte-identical to the worktree.

## E2E / live rig
Not applicable — proc-macro-only, and #1617 is marked "Needs the physical rig? No."

