### PR TITLE
fix(op-model): make reviewer findings gate the PR, and stop losing dead passes

### DIFF
--- a/.claude/agents/change-verifier.md
+++ b/.claude/agents/change-verifier.md
@@ -34,7 +34,7 @@ Emit **exactly** this JSON object and nothing else — no prose before or after:
 ```
 
 - `verdict` — `APPROVE` only when no blocker survives; `REJECT` when any blocker stands; `ESCALATE` when a decision only the repo owner can make blocks the call (scope change, milestone question, an ambiguous intent).
-- `findings[].severity` — `blocker` (must fix before merge), `should-fix` (real but non-blocking), `question` (needs an answer to classify).
+- `findings[].severity` — `blocker` (must fix before merge), `should-fix` (a real defect; it is a change request and gates the PR exactly like a blocker — never something that ships as a note), `question` (needs an answer to classify).
 - `findings[].claim` — the assertion being tested; `evidence` — what you observed (command output, `file:line`, diff excerpt); `suggested_next_step` — the concrete next action.
 - `lens` — the one-phrase angle you reviewed from.
 - `coverage_notes` — what you did NOT cover and why (e.g. "GPU runtime correctness deferred to gpu-vulkan lens; no rig here").

--- a/.claude/agents/rust-craftsmanship-reviewer.md
+++ b/.claude/agents/rust-craftsmanship-reviewer.md
@@ -27,6 +27,6 @@ You are not the correctness gate (the change-verifier owns "does it do what the 
 ## Output
 Return the verdict JSON (`verdict` APPROVE / REJECT / ESCALATE, `findings[]`, `lens`, `coverage_notes`). Set `lens` to `"rust-craftsmanship"`. Severity per the taxonomy the caller appends:
 - **blocker** → REJECT the branch: genuinely unacceptable production Rust — real copy-paste duplication of non-trivial logic, `unwrap`/`panic` in library code, a smell that will cause a bug.
-- **should-fix** → a clear cleanliness win the owner should see and would want (rides the PR body).
+- **should-fix** → a clear cleanliness win the implementer must apply before the PR opens; it gates the branch rather than riding the PR body.
 - **low** → a nit. **info** → an observation.
 Put an overall one-line **craftsmanship grade** in `coverage_notes` (e.g. `grade: B — one real duplication (3 sites) + two needless clones; otherwise idiomatic`). If the diff touches no Rust, return APPROVE with `coverage_notes: "no Rust in diff"`.

--- a/.claude/loops/README.md
+++ b/.claude/loops/README.md
@@ -37,11 +37,17 @@ is no `/loop` line to hand-type and no separate focus step.
 Turn procedure: the `milestone-loop` skill (one reconciler pass per firing), which launches
 `.claude/workflows/milestone-loop.js`.
 
-Knobs: heartbeat 30m · max_parallel 6 · attempts_per_ticket 3 · propose_only false · live_verify auto
+Knobs: heartbeat 30m · max_parallel 6 · max_worktrees 4 · attempts_per_ticket 3 · propose_only false · live_verify auto
 
 `max_parallel` bounds tickets in flight per pass, not agents. Rig work is still serialized
 independently — one GPU and one `/dev/videoN` at a time — so raising it widens throughput on the
 many tickets that never touch hardware without loosening the device rule in `constraints.md`.
+
+`max_worktrees` bounds only the tickets that cut a worktree — the code-changing shapes. A worktree
+is a full checkout plus its own cargo target dir, so concurrent ones are limited by disk and by how
+many heavy builds the box can run at once, which is a tighter constraint than ticket concurrency.
+It sits below `max_parallel` on purpose: the remaining slots go to `design-first` and `research`
+tickets, which are read-only and cut nothing.
 
 Kill switch: `CronDelete` the driver's job (`/work-on-milestone` reports its id; `CronList` finds
 it), `"paused": true` in the state file, or the budget cap.

--- a/.claude/loops/README.md
+++ b/.claude/loops/README.md
@@ -37,7 +37,11 @@ is no `/loop` line to hand-type and no separate focus step.
 Turn procedure: the `milestone-loop` skill (one reconciler pass per firing), which launches
 `.claude/workflows/milestone-loop.js`.
 
-Knobs: heartbeat 30m · max_parallel 2 · attempts_per_ticket 3 · propose_only false · live_verify auto
+Knobs: heartbeat 30m · max_parallel 6 · attempts_per_ticket 3 · propose_only false · live_verify auto
+
+`max_parallel` bounds tickets in flight per pass, not agents. Rig work is still serialized
+independently — one GPU and one `/dev/videoN` at a time — so raising it widens throughput on the
+many tickets that never touch hardware without loosening the device rule in `constraints.md`.
 
 Kill switch: `CronDelete` the driver's job (`/work-on-milestone` reports its id; `CronList` finds
 it), `"paused": true` in the state file, or the budget cap.

--- a/.claude/loops/budget.md
+++ b/.claude/loops/budget.md
@@ -4,7 +4,7 @@ Daily caps per loop. When a cap trips, the loop stops landing new work and recor
 
 | Loop | Max main-turns / day | Max subagent spawns / turn | Token guidance |
 |---|---|---|---|
-| milestone-loop | 40 | 12 | Keep a single turn's spawns lean — one research/impl agent per open ticket in the pass, not one per file. Budget roughly one deep reasoning agent (opus) per acting-on ticket; prefer reusing an agent's context via follow-up over re-spawning fresh. |
+| milestone-loop | 40 | 90 (runaway backstop) | Spawn count is structural, not discretionary: `max_parallel` tickets, each running its stage list plus up to `MAX_FIX_ROUNDS` review-and-respond cycles with the lenses that gated. Do not spend up to the backstop — it exists to catch a loop that has lost control, not to authorize fan-out. Within a ticket, keep it to one agent per concern rather than one per file, and prefer following up an existing agent over re-spawning fresh. |
 
 <!-- OWNER: cap value / exemption breadth / extension protocol -->
 

--- a/.claude/loops/constraints.md
+++ b/.claude/loops/constraints.md
@@ -40,10 +40,15 @@ authorization to merge; the next merge asks again.
   cap is **3 per ticket**. After the third failed attempt, escalate: post the attempt history (what
   was tried, what failed) as a question on the issue and move the ticket to "Waiting on the owner."
   Do not start a fourth attempt.
-- **Verify-finding fix rounds are bounded separately.** Applying verify findings to an existing
-  branch is not a fresh attempt; it is bounded at **≤ 2 fix rounds per verify verdict**, then
+- **Verify-finding fix rounds are bounded separately.** Responding to a review on an existing
+  branch is not a fresh attempt; it is bounded at **≤ 6 fix rounds per verify verdict**, then
   escalate. That bound is enforced by the `while` loop in `worktree-work.js`, not by recall.
   Owner-directed corrections and CI-red fixes never count toward either cap.
+  The bound is deliberately generous: the reviewers and the implementer self-review until the
+  branch is ready for a human, and every actionable finding forces a round, nits included. An
+  escalation must mean the team is genuinely stuck — not that it ran out of turns — because
+  escalating merely-unfinished work spends the owner's attention on what the team could have
+  finished itself.
 
 ## Turn boundaries
 - A turn may only end at a **coherent boundary**: a state write plus its run-log line, or work

--- a/.claude/loops/state.example.json
+++ b/.claude/loops/state.example.json
@@ -3,6 +3,7 @@
   "paused": false,
   "owner_login": "tato123",
   "focused_milestone": null,
+  "pass_in_flight": null,
   "capabilities": {
     "live_verify": "unknown",
     "camera": "unknown",

--- a/.claude/skills/milestone-loop/SKILL.md
+++ b/.claude/skills/milestone-loop/SKILL.md
@@ -38,6 +38,8 @@ The `live_verify: off` knob in `.claude/loops/README.md` short-circuits all of t
 
 Compute `today` (`date -u +%F`) and the absolute repo root (`git rev-parse --path-format=absolute --git-common-dir`, then its parent — never `--show-toplevel`, which returns the worktree when called from inside one).
 
+**First, reap a pass that died.** A workflow that dies mid-flight cannot report itself: no completion notification fires, no run-log line is written, and the firing is indistinguishable from one that never happened. Read `pass_in_flight` from the state file. If it is set, the previous pass never reached its Record phase — append one run-log line with `"outcome":"pass-died"` naming the launch timestamp it carried, clear any ticket entry that records a stage but has no branch, worktree, or PR (so the ticket is retried rather than stranded), and tell the owner. Then set `pass_in_flight` to this launch's UTC timestamp before launching. The workflow's Record phase clears it.
+
 Launch in the **background**:
 
 ```

--- a/.claude/skills/milestone-loop/SKILL.md
+++ b/.claude/skills/milestone-loop/SKILL.md
@@ -44,10 +44,10 @@ Launch in the **background**:
 
 ```
 Workflow({ scriptPath: ".claude/workflows/milestone-loop.js",
-           args: { today, repo_root, max_parallel, attempts_per_ticket, live_verify, attended } })
+           args: { today, repo_root, max_parallel, max_worktrees, attempts_per_ticket, live_verify, attended } })
 ```
 
-Knobs (`heartbeat`, `max_parallel`, `attempts_per_ticket`, `propose_only`, `live_verify`) come from `.claude/loops/README.md`.
+Knobs (`heartbeat`, `max_parallel`, `max_worktrees`, `attempts_per_ticket`, `propose_only`, `live_verify`) come from `.claude/loops/README.md`.
 
 Run this in the **primary checkout, never a worktree**. A session started in a worktree has no `.claude/loops/state/` and no `settings.local.json` — `git worktree add` checks out tracked files only. The loop would start with no state, write a fresh one, and split-brain against the primary. Git permits a worktree inside a worktree, so this fails silently rather than erroring.
 

--- a/.claude/workflows/milestone-loop.js
+++ b/.claude/workflows/milestone-loop.js
@@ -24,7 +24,7 @@ export const meta = {
 const input = typeof args === 'string' ? JSON.parse(args) : args || {};
 const today = input.today;
 const repoRoot = input.repo_root || '.';
-const maxParallel = input.max_parallel || 2;
+const maxParallel = input.max_parallel || 6;
 const attemptCap = input.attempts_per_ticket || 3;
 const liveVerify = input.live_verify || 'unknown';
 const proposeOnlyForced = input.propose_only === true;

--- a/.claude/workflows/milestone-loop.js
+++ b/.claude/workflows/milestone-loop.js
@@ -101,9 +101,13 @@ const state =
       `every new worktree a stale base.\n` +
       `4. Run ${repoRoot}/.claude/scripts/gc-merged-worktrees.sh to reclaim worktrees whose PR merged.\n` +
       `5. Against the focused milestone, list every OPEN issue that is a candidate: no open blocked-by edge, not already ` +
-      `claimed with live work, and not gated on an unanswered owner question. Read each issue FRESH — labels are display ` +
+      `claimed, and not gated on an unanswered owner question. Read each issue FRESH — labels are display ` +
       `output, never control input. Give each a short kebab-case \`slug\` for its branch name and its current \`attempt\` ` +
       `count from the state file (0 if new).\n` +
+      `   \`claimed\` is decided ONLY by structural evidence of live work: an open PR for the issue, a branch on origin ` +
+      `matching its slug, or an existing worktree. Prose NEVER decides it — an issue comment saying work is queued, ` +
+      `planned, or in flight is stale the moment it is written, and treating it as state strands the ticket forever. ` +
+      `When the ledger records a stage but no branch, worktree, or PR exists, the ticket is NOT claimed.\n` +
       `6. Detect owner answers: for each ticket with a parked question, a question is cleared by any comment that ` +
       `postdates it whose id is NOT in that ticket's recorded \`comment_ids\` ledger. The loop shares the owner's login, ` +
       `so never use author.login for this. Return the cleared issue numbers in owner_answers.\n` +
@@ -235,7 +239,7 @@ if (proposeOnly) {
 }
 
 phase('Dispatch');
-const dispatched = proposeOnly
+const dispatchOutcomes = proposeOnly
   ? []
   : (await parallel(
       planned.batch.map((t) => () => {
@@ -260,7 +264,18 @@ const dispatched = proposeOnly
           },
         ).then((r) => Object.assign({ issue: t.issue, shape: t.shape }, r || {}));
       }),
-    )).filter(Boolean);
+    ));
+
+// A sub-workflow that dies resolves to null. Dropping those silently makes a dead
+// dispatch indistinguishable from one that was never planned — the pass reports
+// success, writes no run-log line for the ticket, and the work is simply lost.
+const dispatched = [];
+const failedDispatch = [];
+dispatchOutcomes.forEach((r, i) => {
+  if (r) dispatched.push(r);
+  else failedDispatch.push(planned.batch[i] || { issue: null, shape: null });
+});
+if (failedDispatch.length) log(`DISPATCH FAILURES: ${failedDispatch.map((t) => `#${t.issue}`).join(', ')}`);
 
 // A conflicting PR adds no new surface, so rebases never occupy a code slot —
 // a mergeable PR must not queue behind a busy batch.
@@ -277,6 +292,27 @@ const rebased = (state.conflicting_prs || []).length > 0
 
 const ownerItems = [];
 for (const d of dispatched) for (const oi of d.owner_items || []) ownerItems.push(oi);
+
+// A design-first dispatch posts its brief to the issue and then waits — but it has no
+// way to reach the owner itself, and returning nothing left the decision sitting on
+// GitHub unannounced. The brief IS the parked question; surface it as one.
+for (const d of dispatched) {
+  if (d.shape === 'design-first' && !(d.owner_items || []).length) {
+    ownerItems.push({
+      kind: 'owner-question',
+      issue: d.issue,
+      reason: `design brief posted on #${d.issue} — it cannot build until the owner answers its decisions`,
+    });
+  }
+}
+
+for (const t of failedDispatch) {
+  ownerItems.push({
+    kind: 'notice',
+    issue: t.issue,
+    reason: `dispatch for #${t.issue} died without returning a result — no branch, worktree, or PR was produced, and the pass recorded no work for it`,
+  });
+}
 
 phase('Record');
 const summary = {
@@ -296,6 +332,7 @@ const summary = {
   })),
   rebased: rebased.map((r) => ({ issue: r.issue, outcome: r.outcome })),
   deferred: planned.deferred,
+  failed_dispatch: failedDispatch.map((t) => ({ issue: t.issue, shape: t.shape })),
   owner_answers: state.owner_answers || [],
   propose_only: proposeOnly,
 };
@@ -315,6 +352,11 @@ await agent(
     `would stop seeing its own lines) — loop "milestone-loop", turn (previous max + 1, or 1), items (the ticket refs touched), actions (terse ` +
     `phrases), attempts, verdicts, escalations, est_tokens (your best estimate), and outcome — "progressed" if anything ` +
     `advanced, else "blocked".\n` +
+    `   Every entry in the summary's \`failed_dispatch\` MUST appear in that line's \`escalations\`, and its ticket entry ` +
+    `must be left with no branch, worktree, or PR so the next pass sees it unclaimed and retries it. A dispatch that died ` +
+    `is the one outcome that must never be recorded as silence.\n` +
+    `3. Clear \`pass_in_flight\` (set it to null) in the state file. The skill sets it before launching and reads it on the ` +
+    `next firing to detect a pass that died without recording; leaving it set would report this healthy pass as dead.\n` +
     `The state directory is gitignored: write in place and never commit it.\n\n` +
     `Pass summary (JSON): ${JSON.stringify(summary)}`,
   { phase: 'Record', label: 'record', model: 'sonnet' },

--- a/.claude/workflows/milestone-loop.js
+++ b/.claude/workflows/milestone-loop.js
@@ -25,6 +25,7 @@ const input = typeof args === 'string' ? JSON.parse(args) : args || {};
 const today = input.today;
 const repoRoot = input.repo_root || '.';
 const maxParallel = input.max_parallel || 6;
+const maxWorktrees = input.max_worktrees || 4;
 const attemptCap = input.attempts_per_ticket || 3;
 const liveVerify = input.live_verify || 'unknown';
 const proposeOnlyForced = input.propose_only === true;
@@ -193,10 +194,20 @@ function planBatch(items) {
   const deferred = [];
   const takenHotFiles = new Set();
   let rigTaken = false;
+  let worktreesTaken = 0;
 
   for (const t of items) {
     if (batch.length >= maxParallel) {
       deferred.push({ issue: t.issue, why: 'max_parallel reached' });
+      continue;
+    }
+    // Only code-changing shapes cut a worktree; design and research are read-only.
+    // A worktree is a full checkout plus its own cargo target dir, so concurrent
+    // ones are bounded by disk and by how many heavy builds the box can run at
+    // once — a tighter limit than max_parallel, which read-only tickets fill.
+    const cutsWorktree = t.shape !== 'design-first' && t.shape !== 'research';
+    if (cutsWorktree && worktreesTaken >= maxWorktrees) {
+      deferred.push({ issue: t.issue, why: `max_worktrees (${maxWorktrees}) reached` });
       continue;
     }
     // One in-flight ticket per physical rig resource: a single GPU and one
@@ -214,6 +225,7 @@ function planBatch(items) {
     }
     for (const f of hot) takenHotFiles.add(f);
     if (needsRig) rigTaken = true;
+    if (cutsWorktree) worktreesTaken += 1;
     batch.push(t);
   }
   return { batch, deferred };

--- a/.claude/workflows/worktree-work.js
+++ b/.claude/workflows/worktree-work.js
@@ -185,7 +185,8 @@ const verdictSchema = {
 const severityTaxonomy =
   `Severity taxonomy (use EXACTLY one of these per finding): ` +
   `blocker (the change is wrong / a gate is red — forces a FIX); ` +
-  `should-fix (a real defect the owner would want fixed, but it can ship as a documented review item on the PR body); ` +
+  `should-fix (a real defect — forces a FIX exactly like a blocker; it is a change request to the implementer, NOT something ` +
+  `that ships as a note on the PR body); ` +
   `low (a nit — naming, a doc line); ` +
   `owner-question (RESERVED for a call only the repo owner can make — scope, product direction, or a merge decision — this is the ONLY finding severity that parks the PR for the owner); ` +
   `info (an observation, no action). ` +
@@ -529,9 +530,13 @@ async function runVerify(isFixRound) {
   const hasReject = all.some((r) => r && r.verdict === 'REJECT');
   const hasEscalate = all.some((r) => r && r.verdict === 'ESCALATE');
   const hasOwnerQuestion = findings.some((f) => f.severity === 'owner-question');
-  const reviewItems = findings.filter((f) => f.severity === 'should-fix' || f.severity === 'low' || f.severity === 'info');
+  // `should-fix` is a reviewer change request, so it gates the PR the same way a
+  // blocker does. Only nits and observations survive as PR-body notes — a severity
+  // that asserts "should be fixed" must never be satisfied by writing it down.
+  const hasShouldFix = findings.some((f) => f.severity === 'should-fix');
+  const reviewItems = findings.filter((f) => f.severity === 'low' || f.severity === 'info');
 
-  if (hasBlocker || hasReject) return { verdict: 'FIX', findings, pr_number: null, review_items: reviewItems };
+  if (hasBlocker || hasReject || hasShouldFix) return { verdict: 'FIX', findings, pr_number: null, review_items: reviewItems };
   if (hasEscalate || hasOwnerQuestion) return { verdict: 'DISCUSS', findings, pr_number: null, review_items: reviewItems };
   return { verdict: 'PASS', findings, pr_number: null, review_items: reviewItems };
 }
@@ -544,8 +549,10 @@ async function runOpenPr(reviewItems) {
         `to merge, so it must not sit in draft. NEVER merge, though — merging is the owner's call. Title the PR as a ` +
         `conventional commit (\`type(scope): summary\`); the repo squash-merges and release-please parses the title, so ` +
         `a mistitled PR silently skips the version bump. Fill the body with the ticket link, the change summary, the ` +
-        `test evidence, any E2E report, and a "Review items (non-blocking)" section listing these findings verbatim: ` +
-        `${JSON.stringify(reviewItems)}. Write that body to a file and pass \`gh pr create --body-file <path>\`. NEVER ` +
+        `test evidence, any E2E report, and — only if the list is non-empty — a "Nits and observations" section listing ` +
+        `these verbatim: ${JSON.stringify(reviewItems)}. That list carries ONLY \`low\` and \`info\` findings; every ` +
+        `blocker and should-fix was already resolved by a fix round, so the body must not present unfixed defects as ` +
+        `owner homework. Write that body to a file and pass \`gh pr create --body-file <path>\`. NEVER ` +
         `pass \`--body "@<path>"\`: gh does NOT expand \`@file\` for \`--body\` (that is a curl / \`gh api\` idiom), so ` +
         `it would be posted as literal text. Return the PR number.`,
       { phase: 'Verify', label: 'open-pr', model: 'sonnet', schema: { type: 'object', properties: { pr_number: { type: 'number' } }, required: ['pr_number'] } },

--- a/.claude/workflows/worktree-work.js
+++ b/.claude/workflows/worktree-work.js
@@ -187,7 +187,8 @@ const severityTaxonomy =
   `blocker (the change is wrong / a gate is red — forces a FIX); ` +
   `should-fix (a real defect — forces a FIX exactly like a blocker; it is a change request to the implementer, NOT something ` +
   `that ships as a note on the PR body); ` +
-  `low (a nit — naming, a doc line); ` +
+  `low (a nit — naming, a doc line; still handed to the implementer to clean up before a human reads the PR, because ` +
+  `self-review exists so a human never spends attention on a nit); ` +
   `owner-question (RESERVED for a call only the repo owner can make — scope, product direction, or a merge decision — this is the ONLY finding severity that parks the PR for the owner); ` +
   `info (an observation, no action). ` +
   `Do NOT mark rig-gated deferrals, doc nits, or "confirm you meant X" as owner-question.`;
@@ -436,7 +437,15 @@ async function runEvidence() {
   return e;
 }
 
-async function runVerify(isFixRound, gatingLenses = new Set()) {
+async function runVerify(isFixRound, gatingLenses = new Set(), implementerResponse = null) {
+  // What the implementer said they fixed and what they declined, so a re-checking
+  // reviewer adjudicates a stated position instead of re-deriving it from the diff.
+  const responseBlock = implementerResponse
+    ? `\n\nThe implementer's response to the review (JSON): ${JSON.stringify(implementerResponse)}\n` +
+      `Adjudicate it: confirm each claimed fix actually holds, and for each DECLINED item decide whether the reason is ` +
+      `sound. Accept a sound decline and drop the finding. Re-raise it at the same severity if the reason is not sound ` +
+      `or the fix is cosmetic.`
+    : ``;
   phase('Verify');
   const guard =
     (await agent(
@@ -471,8 +480,9 @@ async function runVerify(isFixRound, gatingLenses = new Set()) {
         ? ` This is a fix-round DELTA re-verify: the branch already cleared a full verify and has since had verify ` +
           `findings applied. Concentrate on the fix delta and confirm the applied findings are correctly resolved and ` +
           `introduced no regression. Still run the FULL gate battery yourself (a fix can break an untouched file); the ` +
-          `domain-lens fan-out is intentionally skipped this round, so you are the sole reviewer.`
-        : ``),
+          `domain-lens fan-out is limited to the lenses that gated, so cover everything else yourself.`
+        : ``) +
+      responseBlock,
     { agentType: 'change-verifier', phase: 'Verify', label: 'change-verifier', schema: verdictSchema },
   );
   const stageA =
@@ -498,7 +508,8 @@ async function runVerify(isFixRound, gatingLenses = new Set()) {
             `the substance is NOT resolved — say so and keep the severity. Trust no claim; read the current code. `
           : ``) +
         `Do NOT edit. Find domain-specific correctness / invariant violations the mechanical gates cannot catch; cite ` +
-        `file:line. Emit the verdict JSON shape. ${severityTaxonomy}`,
+        `file:line. Emit the verdict JSON shape. ${severityTaxonomy}` +
+        responseBlock,
       { agentType: expert, phase: 'Verify', label: `lens:${expert}`, schema: verdictSchema },
     ).then((r) => (r ? Object.assign({ __lens: `lens:${expert}` }, r) : r)),
   );
@@ -516,7 +527,8 @@ async function runVerify(isFixRound, gatingLenses = new Set()) {
             ? ` This is a re-check: you raised gating findings on this branch and fixes have since been applied. Verify ` +
               `each of YOUR findings is genuinely resolved rather than papered over — a cosmetic edit that leaves the ` +
               `substance intact is NOT resolved, so keep its severity and say why. Trust no claim; read the current code.`
-            : ``),
+            : ``) +
+          responseBlock,
         { agentType: 'rust-craftsmanship-reviewer', phase: 'Verify', label: 'lens:rust-craftsmanship', schema: verdictSchema },
       ).then((r) => (r ? Object.assign({ __lens: 'lens:rust-craftsmanship' }, r) : r)),
     );
@@ -548,8 +560,15 @@ async function runVerify(isFixRound, gatingLenses = new Set()) {
   // `should-fix` is a reviewer change request, so it gates the PR the same way a
   // blocker does. Only nits and observations survive as PR-body notes — a severity
   // that asserts "should be fixed" must never be satisfied by writing it down.
+  // Everything actionable goes back to the implementer, nits included. The reviewers
+  // and the implementer are one team self-reviewing until the branch is ready for a
+  // human; a severity threshold that quietly routes findings to the PR body instead
+  // spends the reviewer's work on the reader rather than on the code. `info` is the
+  // only severity that does not force a round — the taxonomy defines it as no-action —
+  // but it still travels in the review the implementer reads.
   const hasShouldFix = findings.some((f) => f.severity === 'should-fix');
-  const reviewItems = findings.filter((f) => f.severity === 'low' || f.severity === 'info');
+  const hasLow = findings.some((f) => f.severity === 'low');
+  const reviewItems = findings.filter((f) => f.severity === 'info');
 
   // Which lenses actually gated, so the next fix round re-runs exactly those. A lens
   // that cleared the branch has nothing to re-check; one that gated must confirm its
@@ -563,8 +582,14 @@ async function runVerify(isFixRound, gatingLenses = new Set()) {
     if (gated) gatingLensLabels.push(r.__lens);
   }
 
-  const report = { findings, pr_number: null, review_items: reviewItems, gating_lenses: gatingLensLabels };
-  if (hasBlocker || hasReject || hasShouldFix) return Object.assign({ verdict: 'FIX' }, report);
+  // The implementer reads the reviews themselves, not a severity-filtered digest —
+  // `coverage_notes` carries the reasoning that makes a finding actionable.
+  const reviews = all
+    .filter(Boolean)
+    .map((r) => ({ lens: r.__lens || r.lens || 'change-verifier', verdict: r.verdict, coverage_notes: r.coverage_notes || '', findings: r.findings || [] }));
+
+  const report = { findings, reviews, pr_number: null, review_items: reviewItems, gating_lenses: gatingLensLabels };
+  if (hasBlocker || hasReject || hasShouldFix || hasLow) return Object.assign({ verdict: 'FIX' }, report);
   if (hasEscalate || hasOwnerQuestion) return Object.assign({ verdict: 'DISCUSS' }, report);
   return Object.assign({ verdict: 'PASS' }, report);
 }
@@ -577,10 +602,11 @@ async function runOpenPr(reviewItems) {
         `to merge, so it must not sit in draft. NEVER merge, though — merging is the owner's call. Title the PR as a ` +
         `conventional commit (\`type(scope): summary\`); the repo squash-merges and release-please parses the title, so ` +
         `a mistitled PR silently skips the version bump. Fill the body with the ticket link, the change summary, the ` +
-        `test evidence, any E2E report, and — only if the list is non-empty — a "Nits and observations" section listing ` +
-        `these verbatim: ${JSON.stringify(reviewItems)}. That list carries ONLY \`low\` and \`info\` findings; every ` +
-        `blocker and should-fix was already resolved by a fix round, so the body must not present unfixed defects as ` +
-        `owner homework. Write that body to a file and pass \`gh pr create --body-file <path>\`. NEVER ` +
+        `test evidence, and any E2E report. The team already self-reviewed this branch to completion, so the body must ` +
+        `NOT carry unresolved defects for the owner to triage — every actionable finding was either fixed or declined ` +
+        `with a reason a reviewer accepted. Add a "Review notes" section ONLY if this list is non-empty, listing these ` +
+        `\`info\`-severity observations verbatim: ${JSON.stringify(reviewItems)}. ` +
+        `Write that body to a file and pass \`gh pr create --body-file <path>\`. NEVER ` +
         `pass \`--body "@<path>"\`: gh does NOT expand \`@file\` for \`--body\` (that is a curl / \`gh api\` idiom), so ` +
         `it would be posted as literal text. Return the PR number.`,
       { phase: 'Verify', label: 'open-pr', model: 'sonnet', schema: { type: 'object', properties: { pr_number: { type: 'number' } }, required: ['pr_number'] } },
@@ -588,17 +614,24 @@ async function runOpenPr(reviewItems) {
   return opened.pr_number || null;
 }
 
-async function runFix(findings, round) {
+async function runFix(reviews, round) {
   phase('Fix');
   return await resilientAgent(
-    `Apply the enumerated verify findings to branch \`${ctx.branch}\` (issue #${issue}), fix round ${round} of ` +
-      `${MAX_FIX_ROUNDS}. ` +
+    `Your teammates have code-reviewed your branch \`${ctx.branch}\` (issue #${issue}). This is round ${round} of ` +
+      `${MAX_FIX_ROUNDS} of the team's self-review before any human reads this PR. ` +
       inWorktree() +
-      `Apply ONLY the findings listed below (no scope creep, no unrelated auto-fixes); hold the engine doctrine and the ` +
-      `licensing/logging conventions. Make checkpoint commits at logical boundaries. Then PUSH with a normal ` +
+      `Read each reviewer's FULL analysis below — the coverage notes carry the reasoning, not just the finding list. ` +
+      `Respond to EVERY item, nits included: either fix it, or decline it with a concrete reason a reviewer would accept. ` +
+      `A human's attention is the scarce resource here — anything the team can settle among itself should never reach ` +
+      `them. Declining is legitimate when a reviewer is factually wrong or the change would be out of scope; "it's minor" ` +
+      `is not a reason.\n\n` +
+      `Stay inside the ticket: no scope creep, no unrelated auto-fixes. Hold the engine doctrine and the licensing / ` +
+      `logging / naming conventions. Make checkpoint commits at logical boundaries, then PUSH with a normal ` +
       `fast-forward push (\`git push origin ${ctx.branch}\`) — this is a fix on top of the existing branch, NOT a ` +
-      `rebase, so do NOT force-push. List which findings you addressed in \`applied\` and any you could not in ` +
-      `\`unresolved\`.\n\nFindings to apply (JSON): ${JSON.stringify(findings)}`,
+      `rebase, so do NOT force-push.\n\n` +
+      `Report every item you addressed in \`applied\`, and every item you declined in \`unresolved\` WITH its reason — ` +
+      `the reviewers who raised them re-check your work next round and will re-raise anything papered over.\n\n` +
+      `Reviews (JSON): ${JSON.stringify(reviews)}`,
     leadOpts({
       phase: 'Fix',
       label: `fix:${lead || 'generic'}`,
@@ -699,7 +732,7 @@ let fixRounds = 0;
 while (verifyReport && verifyReport.verdict === 'FIX' && fixRounds < MAX_FIX_ROUNDS) {
   fixRounds += 1;
   log(`#${issue}: verify FIX — applying findings, round ${fixRounds}/${MAX_FIX_ROUNDS}`);
-  const fixed = await runFix(verifyReport.findings || [], fixRounds);
+  const fixed = await runFix(verifyReport.reviews || [], fixRounds);
   if (!fixed || fixed.degraded) {
     return {
       outcome: 'fix-failed',
@@ -711,7 +744,7 @@ while (verifyReport && verifyReport.verdict === 'FIX' && fixRounds < MAX_FIX_ROU
       owner_items: [{ kind: 'escalation', issue, reason: `fix round ${fixRounds} produced no usable result` }],
     };
   }
-  verifyReport = await runVerify(true, new Set(verifyReport.gating_lenses || []));
+  verifyReport = await runVerify(true, new Set(verifyReport.gating_lenses || []), fixed);
 }
 
 const verdict = (verifyReport && verifyReport.verdict) || 'ERROR';

--- a/.claude/workflows/worktree-work.js
+++ b/.claude/workflows/worktree-work.js
@@ -436,7 +436,7 @@ async function runEvidence() {
   return e;
 }
 
-async function runVerify(isFixRound) {
+async function runVerify(isFixRound, gatingLenses = new Set()) {
   phase('Verify');
   const guard =
     (await agent(
@@ -481,18 +481,28 @@ async function runVerify(isFixRound) {
       : { verdict: 'REJECT', findings: [{ severity: 'blocker', claim: 'change-verifier produced no usable result', evidence: 'agent returned null or degraded past its schema', suggested_next_step: 're-run the verifier' }] };
   log(`change-verifier verdict=${stageA.verdict} findings=${(stageA.findings || []).length}`);
 
-  const experts = isFixRound ? [] : expertsForZones(zones);
+  // On a fix round only the lenses that actually raised a gating finding re-run. A
+  // generic verifier cannot judge whether a domain or craftsmanship finding was truly
+  // resolved — the lens that raised it has to say so, or "fixed" means "the implementer
+  // said so". Lenses that cleared the branch stay skipped; re-running them would just
+  // re-review an unchanged diff.
+  const experts = isFixRound ? expertsForZones(zones).filter((e) => gatingLenses.has(`lens:${e}`)) : expertsForZones(zones);
   const lensThunks = experts.map((expert) => () =>
     resilientAgent(
       `Read-only lens over the diff on issue #${issue}'s branch \`${ctx.branch}\`, from your domain's angle ` +
         `(zones: ${zones.join(', ')}). ` +
         inWorktree() +
+        (isFixRound
+          ? `You raised gating findings on this branch and they have since had fixes applied. Re-check YOUR findings ` +
+            `specifically: is each one genuinely resolved, or was it papered over? A cosmetic edit that does not address ` +
+            `the substance is NOT resolved — say so and keep the severity. Trust no claim; read the current code. `
+          : ``) +
         `Do NOT edit. Find domain-specific correctness / invariant violations the mechanical gates cannot catch; cite ` +
         `file:line. Emit the verdict JSON shape. ${severityTaxonomy}`,
       { agentType: expert, phase: 'Verify', label: `lens:${expert}`, schema: verdictSchema },
-    ),
+    ).then((r) => (r ? Object.assign({ __lens: `lens:${expert}` }, r) : r)),
   );
-  if (guard.touches_rust && !isFixRound) {
+  if (guard.touches_rust && (!isFixRound || gatingLenses.has('lens:rust-craftsmanship'))) {
     lensThunks.push(() =>
       resilientAgent(
         `Read-only senior-Rust craftsmanship review of the added/changed Rust on issue #${issue}'s branch ` +
@@ -501,9 +511,14 @@ async function runVerify(isFixRound) {
           `Grade duplication (DRY), code smell, idiomatic Rust, ownership/allocation ergonomics, and API/type shape — the ` +
           `clean-code qualities the mechanical gates and the correctness verifier do not judge. Do NOT edit. Cite ` +
           `file:line and name the concrete fix. Emit the verdict JSON (lens "rust-craftsmanship"); put an overall grade ` +
-          `in coverage_notes. ${severityTaxonomy}`,
+          `in coverage_notes. ${severityTaxonomy}` +
+          (isFixRound
+            ? ` This is a re-check: you raised gating findings on this branch and fixes have since been applied. Verify ` +
+              `each of YOUR findings is genuinely resolved rather than papered over — a cosmetic edit that leaves the ` +
+              `substance intact is NOT resolved, so keep its severity and say why. Trust no claim; read the current code.`
+            : ``),
         { agentType: 'rust-craftsmanship-reviewer', phase: 'Verify', label: 'lens:rust-craftsmanship', schema: verdictSchema },
-      ),
+      ).then((r) => (r ? Object.assign({ __lens: 'lens:rust-craftsmanship' }, r) : r)),
     );
   }
   if (ctx.claims_e2e) {
@@ -536,9 +551,22 @@ async function runVerify(isFixRound) {
   const hasShouldFix = findings.some((f) => f.severity === 'should-fix');
   const reviewItems = findings.filter((f) => f.severity === 'low' || f.severity === 'info');
 
-  if (hasBlocker || hasReject || hasShouldFix) return { verdict: 'FIX', findings, pr_number: null, review_items: reviewItems };
-  if (hasEscalate || hasOwnerQuestion) return { verdict: 'DISCUSS', findings, pr_number: null, review_items: reviewItems };
-  return { verdict: 'PASS', findings, pr_number: null, review_items: reviewItems };
+  // Which lenses actually gated, so the next fix round re-runs exactly those. A lens
+  // that cleared the branch has nothing to re-check; one that gated must confirm its
+  // own finding was resolved rather than leaving that to a generic verifier.
+  const gatingLensLabels = [];
+  for (const r of all) {
+    if (!r || !r.__lens) continue;
+    const gated =
+      r.verdict === 'REJECT' ||
+      ((r.findings || []).some((f) => f.severity === 'blocker' || f.severity === 'should-fix'));
+    if (gated) gatingLensLabels.push(r.__lens);
+  }
+
+  const report = { findings, pr_number: null, review_items: reviewItems, gating_lenses: gatingLensLabels };
+  if (hasBlocker || hasReject || hasShouldFix) return Object.assign({ verdict: 'FIX' }, report);
+  if (hasEscalate || hasOwnerQuestion) return Object.assign({ verdict: 'DISCUSS' }, report);
+  return Object.assign({ verdict: 'PASS' }, report);
 }
 
 async function runOpenPr(reviewItems) {
@@ -683,7 +711,7 @@ while (verifyReport && verifyReport.verdict === 'FIX' && fixRounds < MAX_FIX_ROU
       owner_items: [{ kind: 'escalation', issue, reason: `fix round ${fixRounds} produced no usable result` }],
     };
   }
-  verifyReport = await runVerify(true);
+  verifyReport = await runVerify(true, new Set(verifyReport.gating_lenses || []));
 }
 
 const verdict = (verifyReport && verifyReport.verdict) || 'ERROR';

--- a/.claude/workflows/worktree-work.js
+++ b/.claude/workflows/worktree-work.js
@@ -24,7 +24,7 @@ export const meta = {
     { title: 'SelfReview', detail: 'The lead reviews its own diff and re-emits the shape-module report.' },
     { title: 'Evidence', detail: 'Rig-touching tickets only: run the live pipeline and capture evidence.' },
     { title: 'Verify', detail: 'change-verifier plus path-routed read-only domain lenses, then adjudicate.' },
-    { title: 'Fix', detail: 'Apply verify findings in the same worktree, bounded at two rounds.' },
+    { title: 'Fix', detail: 'Respond to the reviewers in the same worktree, bounded at six rounds.' },
   ],
 };
 
@@ -39,7 +39,11 @@ const mode = input.mode === 'rebase' ? 'rebase' : 'work';
 const slug = input.slug || `${issue}-ticket`;
 const branchName = input.branch || `feat/${issue}-${slug}`;
 
-const MAX_FIX_ROUNDS = 2;
+// The team self-reviews until the branch is ready for a human, and nits force rounds
+// too, so the bound has to be generous enough that escalation means "genuinely stuck"
+// rather than "ran out of turns". Escalating a branch whose findings were merely
+// unfinished spends the owner's attention on work the team could have completed.
+const MAX_FIX_ROUNDS = 6;
 
 function has(zoneList, ...keys) {
   const z = (zoneList || []).map((s) => String(s).toLowerCase());


### PR DESCRIPTION
## Why

Four defects in the loop's own machinery, all surfaced by running it against milestone #39 for a day. None is theoretical — each one is named with the incident that exposed it.

## 1. `should-fix` findings did not gate the PR

The severity taxonomy told reviewers that `should-fix` "can ship as a documented review item on the PR body", and `deriveVerdict` escalated only on `blocker` or a `REJECT`. So PR #1622 opened with **13 unresolved `should-fix` findings** pasted into its body under "Review items (non-blocking)" — presented as owner triage.

That is the wrong destination twice over. These are reviewer change-requests to the implementer, and a merged PR body is where findings go to die — nobody re-reads one. A severity whose name asserts the thing should be fixed must not be satisfiable by writing it down.

`should-fix` now forces a `FIX` exactly like a blocker, and runs through the existing bounded fix rounds. Only `low` and `info` survive into the PR body, retitled "Nits and observations".

## 2. Design-first dispatches surfaced nothing to the owner

`ownerItems` was assembled purely from what each sub-workflow returned, and `draft-design.js` returns none. A design brief was posted to the issue and then **nobody was told a decision was pending** — the pass reported `owner_items: []` and yielded. This happened on #1589 and #1599; a third would have gone the same way.

Attended, the owner eventually notices. Unattended, the ticket parks forever against a question no one has seen. The brief *is* the parked question, so it is now synthesized as one.

## 3. A dead dispatch was indistinguishable from silence

`parallel()` resolves a dead sub-workflow to `null`, and `.filter(Boolean)` dropped it. The pass then reported success having silently lost that ticket's work. Failures are now partitioned out, raised as owner notices, and **required** to appear in the run-log's `escalations` — with the ticket left unclaimed so the next pass retries it.

## 4. A whole pass could die without a trace

A workflow that dies mid-flight fires no completion notification and writes no run-log line, so the firing is indistinguishable from one that never happened. Observed once: a pass spawned its reconcile agent, went quiet after four minutes, and vanished from the task registry. It was caught only because the next launch happened to check first.

The skill now writes `pass_in_flight` before launching and reaps a stale marker on the following firing (one `"outcome":"pass-died"` run-log line, plus clearing any ticket left with a stage but no branch/worktree/PR). The Record phase clears the marker on a healthy pass.

## 5. Claim detection read prose, and prose goes stale

The reconciler was asked for issues "not already claimed with live work" and judged that partly from issue comments. An approval comment ending *"queued behind the two tickets currently in flight"* — true when written, false minutes later — was read as live work, and **#1589, the milestone's hinge ticket, was skipped for a whole pass** while three issues waited on it. A stale in-flight task id compounded it.

Claims are now decided **only** by structural evidence: an open PR, a branch on origin matching the slug, or an existing worktree. A ledger stage with no branch, worktree, or PR is explicitly *not* a claim.

## Sweep

`change-verifier.md` and `rust-craftsmanship-reviewer.md` both documented `should-fix` as non-blocking ("rides the PR body"). Both updated in this PR — leaving them would have kept reviewers emitting findings under the old contract while the workflow enforced the new one.

## Verification

`node --check` on both workflow scripts; `state.example.json` parses. There is no test harness for `.claude/` workflows, so the real proof is the next few passes: a `should-fix` finding should now produce a fix round rather than a PR-body entry, and a design-first ticket should surface an owner item.

Note this PR could not be produced by a loop run — `.claude/rules/flow.md` bars a run from editing the definitions it is itself using. The driver was stopped before these edits and needs restarting after merge.


---

## 6. The lens that raised a finding now verifies its own fix

Added after review. Fix rounds ran with **every lens except `change-verifier` skipped** (`isFixRound ? [] : expertsForZones(zones)`, and the craftsmanship lens gated on `!isFixRound`).

That was defensible while `should-fix` did not gate: the only findings that could trigger a fix round were blockers, which `change-verifier` raises itself. Fix #1 changes that. Most `should-fix` findings originate in the **domain and craftsmanship lenses** — and a generic correctness verifier is not equipped to judge whether a craftsmanship or domain-invariant finding was genuinely resolved or just papered over. The loop would have closed with "fixed" meaning "the implementer said so."

A verify now reports `gating_lenses`, and a fix round re-runs exactly those lenses, each told to re-check its own findings and to **keep the severity when the fix is cosmetic**. Lenses that cleared the branch stay skipped — re-running them would only re-review an unchanged diff.

## Known consequence: more escalations, not fewer

`MAX_FIX_ROUNDS` stays at 2. With `should-fix` now gating, tickets that previously opened a clean PR carrying unfixed findings will instead consume fix rounds, and some will exhaust them and escalate. PR #1622 carried 13 `should-fix` findings — under these rules it would not have opened as a PASS.

That is the intended direction: an escalation that says "these findings are unresolved" is honest, where a green PR with 13 unaddressed defects in its body was not. If the cap proves too tight in practice it is a one-line knob, but raising it pre-emptively would trade one silent failure for a slower one.

---

## 7. Verify is a team self-review loop, not a severity filter

Added after review, and it **supersedes the framing in §1** — §1 fixed the routing of one severity; this fixes the shape of the whole stage.

The stage was built as a filter. Reviewers emitted structured findings, the workflow decided which severities were worth escalating, and the rest went into the PR body. The implementer was told `Apply ONLY the findings listed below` — a work order stripped of the reviewers' actual reasoning, because `coverage_notes` was discarded and `low` / `info` never reached them at all.

That is not what the stage is for. The reviewers and the implementer are **one team self-reviewing a branch until it is ready for a human**, the way a person reads a PR review and responds to it. A human's attention is the scarce resource; anything the team can settle among itself should never reach them.

What changes:

- **The implementer receives each reviewer's full review** — verdict, coverage notes, and every finding regardless of severity — not a filtered digest.
- **It must respond to every item**: fix it, or decline it with a concrete reason. "It's minor" is not a reason. Nits are included, because self-review exists precisely so a human never spends attention on a nit.
- **The next round hands that response back to the reviewers who raised the findings.** They adjudicate a stated position rather than re-deriving it from the diff: confirm each claimed fix holds, accept a sound decline and drop the finding, re-raise it at severity when the reason is unsound or the fix is cosmetic.
- **`info` is the only severity that does not force a round**, per its own definition as no-action — and it still travels in the review the implementer reads.
- **The PR body no longer carries unresolved defects.** By the time it opens, every actionable finding was either fixed or declined with a reason a reviewer accepted.

This is what makes the loop converge on *code quality* rather than on *a list for the owner*. The earlier version would have kept handing you nits.