### PR TITLE
feat(op-model): stack a ticket on its blocker's open PR instead of waiting for a merge

### DIFF
--- a/.claude/loops/README.md
+++ b/.claude/loops/README.md
@@ -43,6 +43,27 @@ Knobs: heartbeat 30m · max_parallel 6 · max_worktrees 4 · attempts_per_ticket
 independently — one GPU and one `/dev/videoN` at a time — so raising it widens throughput on the
 many tickets that never touch hardware without loosening the device rule in `constraints.md`.
 
+## Stacked branches
+
+Merging is the owner's call, and this milestone's dependency graph is deep and narrow, so gating a
+ticket on its blocker being **closed** stalls the whole chain until they wake up. Instead, a ticket
+whose open blockers **all** have an open PR starts anyway, rooted on the deepest of those branches
+rather than on `main`. Each PR targets its parent branch, so a reviewer sees one layer's diff.
+
+- The reconciler sets `stack_base` per candidate; a blocker with no open PR leaves it null and that
+  ticket stays genuinely blocked.
+- Every diff in `worktree-work.js` is taken against `baseRef`, never `origin/main` — on a stacked
+  branch the parent's commits are already in the diff versus main, so reviewing against main would
+  re-review the whole stack at every layer and cascade findings.
+- Hot-file collision detection is **per base branch**. Two branches off the same base that rewrite
+  one file conflict; a layer cannot conflict with its own ancestor, whose commits it already
+  contains.
+- The batch is ordered shallowest-first, so a layer exists before anything stacks on it and the
+  bottom PR reaches the owner soonest — a stack collapses from the bottom.
+- **The repo squash-merges.** When a base PR lands, its branch disappears and the child still
+  carries the parent's pre-squash commits, so the child goes conflicting. The rebase path detects a
+  vanished base, rebases onto `origin/main`, and retargets the PR base to main.
+
 `max_worktrees` bounds only the tickets that cut a worktree — the code-changing shapes. A worktree
 is a full checkout plus its own cargo target dir, so concurrent ones are limited by disk and by how
 many heavy builds the box can run at once, which is a tighter constraint than ticket concurrency.

--- a/.claude/workflows/milestone-loop.js
+++ b/.claude/workflows/milestone-loop.js
@@ -59,6 +59,8 @@ const reconcileSchema = {
           blocked_by_open: { type: 'boolean' },
           claimed: { type: 'boolean' },
           owner_gated: { type: 'boolean' },
+          stack_base: { type: ['string', 'null'] },
+          stack_depth: { type: 'number' },
         },
         required: ['issue'],
       },
@@ -105,10 +107,19 @@ const state =
       `claimed, and not gated on an unanswered owner question. Read each issue FRESH — labels are display ` +
       `output, never control input. Give each a short kebab-case \`slug\` for its branch name and its current \`attempt\` ` +
       `count from the state file (0 if new).\n` +
+      `   A blocked issue is NOT necessarily unstartable. Merging is the owner's call, so waiting for a blocker to close ` +
+      `stalls the whole chain overnight. For each issue whose only open blockers ALL have an open PR, set ` +
+      `\`stack_base\` to the head branch of the blocker whose own stack is deepest (its PR base chain is longest), and ` +
+      `\`stack_depth\` to that chain's length counting from main. The ticket then builds on that branch instead of main. ` +
+      `Set \`stack_base\` to null when any open blocker has NO open PR — there is nothing to build on, and that issue ` +
+      `stays blocked. \`blocked_by_open\` still reports the raw graph; it is stack_base that decides startability.\n` +
       `   \`claimed\` is decided ONLY by structural evidence of live work: an open PR for the issue, a branch on origin ` +
       `matching its slug, or an existing worktree. Prose NEVER decides it — an issue comment saying work is queued, ` +
       `planned, or in flight is stale the moment it is written, and treating it as state strands the ticket forever. ` +
       `When the ledger records a stage but no branch, worktree, or PR exists, the ticket is NOT claimed.\n` +
+      `   For each conflicting PR also report its \`base_branch\` (the PR's current base). A stack layer whose base ` +
+      `MERGED is conflicting precisely because the repo squash-merges — it still carries the parent's pre-squash ` +
+      `commits — so the rebase needs to know what it was stacked on.\n` +
       `6. Detect owner answers: for each ticket with a parked question, a question is cleared by any comment that ` +
       `postdates it whose id is NOT in that ticket's recorded \`comment_ids\` ledger. The loop shares the owner's login, ` +
       `so never use author.login for this. Return the cleared issue numbers in owner_answers.\n` +
@@ -159,7 +170,17 @@ if (state.no_delta === true) {
 }
 
 const proposeOnly = proposeOnlyForced || state.propose_only === true;
-const candidates = (state.candidates || []).filter((c) => c && c.issue && !c.blocked_by_open && !c.claimed && !c.owner_gated);
+// A blocked ticket is startable when every one of its open blockers already has an
+// open PR: it stacks on the deepest of them instead of waiting. Merging is the owner's
+// call, so gating on a blocker being CLOSED stalls the whole chain until they wake up
+// — which on a deep, narrow graph means one ticket a day.
+const candidates = (state.candidates || []).filter(
+  (c) => c && c.issue && !c.claimed && !c.owner_gated && (!c.blocked_by_open || c.stack_base),
+);
+const stackDepthOf = (c) => (c.stack_base ? c.stack_depth || 1 : 0);
+// Shallowest first: a layer must exist before anything can stack on top of it, and a
+// shallower PR reaches the owner sooner, which collapses the stack from the bottom.
+candidates.sort((a, b) => stackDepthOf(a) - stackDepthOf(b));
 log(`reconciled: milestone=${state.focused_milestone} candidates=${candidates.length} propose_only=${proposeOnly}`);
 
 phase('Classify');
@@ -183,7 +204,10 @@ const classified =
               `- slug: a short kebab-case branch slug.\n` +
               `Do not start any work.`,
             { phase: 'Classify', label: `classify:${c.issue}`, model: 'sonnet', schema: classifySchema },
-          ),
+          // The classifier judges shape and zones; it has no say in where the branch
+          // is rooted, so the reconciler's stack decision is reattached here rather
+          // than round-tripped through an agent that could drop or invent it.
+          ).then((r) => (r ? Object.assign({}, r, { stack_base: c.stack_base || null, stack_depth: c.stack_depth || 0 }) : r)),
         ),
       )).filter(Boolean)
     : [];
@@ -192,7 +216,7 @@ const classified =
 function planBatch(items) {
   const batch = [];
   const deferred = [];
-  const takenHotFiles = new Set();
+  const takenHotFiles = new Map();
   let rigTaken = false;
   let worktreesTaken = 0;
 
@@ -217,13 +241,21 @@ function planBatch(items) {
       deferred.push({ issue: t.issue, why: 'another rig ticket is already in this batch' });
       continue;
     }
+    // Collision detection is per base branch. Two branches off the SAME base that
+    // rewrite one file conflict at merge; a stacked branch cannot conflict with its
+    // own ancestor, because the ancestor's commits are already in its base. Checking
+    // stacked layers against a single global set would defer every one of them —
+    // touching the parent's files is what a stack layer is for.
+    const base = t.stack_base || 'main';
     const hot = t.hot_files || [];
-    const collision = hot.find((f) => takenHotFiles.has(f));
+    const takenForBase = takenHotFiles.get(base) || new Set();
+    const collision = hot.find((f) => takenForBase.has(f));
     if (collision) {
-      deferred.push({ issue: t.issue, why: `predicted hot-file collision on ${collision}` });
+      deferred.push({ issue: t.issue, why: `predicted hot-file collision on ${collision} with another branch off ${base}` });
       continue;
     }
-    for (const f of hot) takenHotFiles.add(f);
+    for (const f of hot) takenForBase.add(f);
+    takenHotFiles.set(base, takenForBase);
     if (needsRig) rigTaken = true;
     if (cutsWorktree) worktreesTaken += 1;
     batch.push(t);
@@ -270,6 +302,7 @@ const dispatchOutcomes = proposeOnly
             shape: t.shape,
             lead: t.lead,
             rig_needs: t.rig_needs,
+            base_branch: t.stack_base || 'main',
             live_verify: liveVerify,
             repo_root: repoRoot,
             today,
@@ -296,7 +329,7 @@ const rebased = (state.conflicting_prs || []).length > 0
       (state.conflicting_prs || []).map((p) => () =>
         workflow(
           { scriptPath: '.claude/workflows/worktree-work.js' },
-          { issue: p.issue, branch: p.branch, mode: 'rebase', zones: p.zones || [], repo_root: repoRoot, today },
+          { issue: p.issue, branch: p.branch, mode: 'rebase', zones: p.zones || [], base_branch: p.base_branch || 'main', repo_root: repoRoot, today },
         ).then((r) => Object.assign({ issue: p.issue }, r || {})),
       ),
     )).filter(Boolean)

--- a/.claude/workflows/worktree-work.js
+++ b/.claude/workflows/worktree-work.js
@@ -12,7 +12,7 @@ export const meta = {
   description:
     "One ticket from a fresh worktree to an opened PR. Composes its stage list from the ticket's shape and zones, walks it, then verifies with bounded fix rounds.",
   phases: [
-    { title: 'Claim', detail: 'Create the worktree and canonical branch from a fresh origin/main, and post the claim comment.' },
+    { title: 'Claim', detail: 'Create the worktree and canonical branch from a fresh base ref, and post the claim comment.' },
     { title: 'Rederive', detail: 'Verify the issue-body claims against current code and post the plan-of-record.' },
     { title: 'FailingTest', detail: 'bug-reproduce-first only: commit a failing test that reproduces the bug.' },
     { title: 'Implement', detail: 'The zone-matched build lead implements in the worktree with checkpoint commits.' },
@@ -38,6 +38,14 @@ const liveVerify = input.live_verify || 'unavailable';
 const mode = input.mode === 'rebase' ? 'rebase' : 'work';
 const slug = input.slug || `${issue}-ticket`;
 const branchName = input.branch || `feat/${issue}-${slug}`;
+// A ticket whose blockers are merged builds on main; one whose blockers are still
+// open PRs stacks on the topmost of them, so the chain progresses without waiting
+// for the owner to merge. Every diff in this file is taken against baseRef, never
+// origin/main: on a stacked branch the parent's commits are already in the diff vs
+// main, so reviewing against main would re-review the whole stack every layer.
+const baseBranch = input.base_branch || 'main';
+const baseRef = baseBranch === 'main' ? 'origin/main' : `origin/${baseBranch}`;
+const isStacked = baseBranch !== 'main';
 
 // The team self-reviews until the branch is ready for a human, and nits force rounds
 // too, so the bound has to be generous enough that escalation means "genuinely stuck"
@@ -273,8 +281,8 @@ async function runClaim() {
         `1. Post an owner-visible comment on issue #${issue}: "▶ claimed — <one sentence: what and why>". Use ` +
         `\`gh api\` so you get the comment id back, and return it as claim_comment_id.\n` +
         `2. Run: git -C ${repoRoot} fetch origin\n` +
-        `3. Run: git -C ${repoRoot} worktree add ${path} -b ${branchName} origin/main\n` +
-        `   This creates the branch AND the worktree from a fresh origin/main in one step, so the base cannot be stale. ` +
+        `3. Run: git -C ${repoRoot} worktree add ${path} -b ${branchName} ${baseRef}\n` +
+        `   This creates the branch AND the worktree from a fresh ${baseRef} in one step, so the base cannot be stale. ` +
         `If the branch already exists, add the worktree against it instead of creating it.\n` +
         `Return the absolute worktree_path, the branch name, and created: true once the worktree exists.`,
       { phase: 'Claim', label: `claim:${issue}`, model: 'sonnet', schema: claimSchema },
@@ -332,7 +340,7 @@ async function runImplement() {
         `Hold the engine doctrine: extend the existing core system, never spin up a parallel abstraction; production-grade ` +
         `error taxonomy + tracing on engine work; new .rs files carry the BUSL header; tracing not println!/eprintln!. ` +
         `Emit the shape-module report as your structured output — including \`worktree_path\` (${ctx.worktree_path}), the ` +
-        `\`branch\`, your checkpoint commit shas in \`commits\`, and the output of \`git diff origin/main --stat\` in ` +
+        `\`branch\`, your checkpoint commit shas in \`commits\`, and the output of \`git diff ${baseRef} --stat\` in ` +
         `\`diff_stat\`.\n\nPlan-of-record: ${ctx.plan_of_record || '(none posted)'}`,
       leadOpts({ phase: 'Implement', label: `implement:${lead || 'generic'}`, schema: implementSchema }),
     )) || {};
@@ -383,7 +391,7 @@ async function runGates() {
     (await agent(
       `Run the local gate battery for issue #${issue}'s branch (${ctx.branch}) in the change worktree at ` +
         `${ctx.worktree_path || '(MISSING — the claim stage returned no worktree_path)'}. FIRST cd into that worktree. ` +
-        `HARD GUARD: if the worktree path is missing/empty OR \`git -C '${ctx.worktree_path}' diff origin/main --stat\` is ` +
+        `HARD GUARD: if the worktree path is missing/empty OR \`git -C '${ctx.worktree_path}' diff ${baseRef} --stat\` is ` +
         `EMPTY, FAIL immediately and report a no-diff failure — do NOT run the gates against an empty or wrong tree (a ` +
         `fabricated no-diff "success" must not pass to self-review). Otherwise derive the gates from ` +
         `.github/workflows/*.yml and the xtask lint suite at run time and return the pass/fail table. Do not edit anything.`,
@@ -455,7 +463,7 @@ async function runVerify(isFixRound, gatingLenses = new Set(), implementerRespon
     (await agent(
       `Pre-flight ground-truth check for verifying issue #${issue} on branch \`${ctx.branch}\` — read-only, do NOT edit. ` +
         `Confirm all three: (1) issue #${issue} is OPEN; (2) the branch \`${ctx.branch}\` exists on origin; ` +
-        `(3) \`git -C ${ctx.worktree_path} diff origin/main --stat\` is NON-EMPTY. Return { ok: true } only if all three ` +
+        `(3) \`git -C ${ctx.worktree_path} diff ${baseRef} --stat\` is NON-EMPTY. Return { ok: true } only if all three ` +
         `hold; otherwise { ok: false, reason: "<which check failed>" }. Also set touches_rust: true if the diff lists any ` +
         `path ending in \`.rs\`, else false.`,
       {
@@ -602,8 +610,15 @@ async function runOpenPr(reviewItems) {
   const opened =
     (await resilientAgent(
       `All lenses cleared the branch \`${ctx.branch}\` on issue #${issue}. Open a pull request READY FOR REVIEW via gh ` +
-        `(gh pr create --head ${ctx.branch}) — NOT a draft. A PASS means the branch is verified and ready for the owner ` +
-        `to merge, so it must not sit in draft. NEVER merge, though — merging is the owner's call. Title the PR as a ` +
+        `(gh pr create --head ${ctx.branch} --base ${baseBranch}) — NOT a draft. A PASS means the branch is verified ` +
+        `and ready for the owner to merge, so it must not sit in draft. NEVER merge, though — merging is the owner's ` +
+        `call. ` +
+        (isStacked
+          ? `THIS IS A STACKED PR: its base is \`${baseBranch}\`, not main, so GitHub shows only this layer's diff — ` +
+            `do not retarget it at main, which would show the whole stack. Open the body with a one-line stack note ` +
+            `naming the base branch and the issue it belongs to, so a reviewer knows what must merge first. `
+          : ``) +
+        `Title the PR as a ` +
         `conventional commit (\`type(scope): summary\`); the repo squash-merges and release-please parses the title, so ` +
         `a mistitled PR silently skips the version bump. Fill the body with the ticket link, the change summary, the ` +
         `test evidence, and any E2E report. The team already self-reviewed this branch to completion, so the body must ` +
@@ -654,19 +669,26 @@ async function runFix(reviews, round) {
 }
 
 // Rebase mode short-circuits composition entirely: a conflicting PR needs its
-// branch replayed onto origin/main, not a fresh build.
+// branch replayed onto its base, not a fresh build. A stacked branch rebases
+// onto its parent, never onto main, or it would swallow the parent's commits.
 if (mode === 'rebase') {
   phase('Fix');
   const rebased =
     (await resilientAgent(
-      `Rebase branch \`${ctx.branch}\` (issue #${issue}) onto origin/main and resolve. ` +
+      `Rebase branch \`${ctx.branch}\` (issue #${issue}) and resolve.\n` +
+      `FIRST resolve what to rebase ONTO. This branch's recorded base is \`${baseBranch}\`. Check whether that branch ` +
+      `still exists on origin (\`git ls-remote --heads origin ${baseBranch}\`). If it is GONE, its PR merged: the repo ` +
+      `squash-merges, so this branch still carries the parent's now-squashed commits and must be rebased onto ` +
+      `\`origin/main\` — then retarget its PR base to main with \`gh pr edit <n> --base main\`. If the base branch still ` +
+      `exists, rebase onto \`${baseRef}\` and leave the PR base alone. Never rebase a live stack layer onto main; that ` +
+      `would swallow its parent's commits into this PR's diff.\n` +
         (ctx.worktree_path
           ? inWorktree()
           : `Check the branch out in a git worktree under ${repoRoot}/.claude/worktrees/ if one is not already live. `) +
         `Do NOT create a fresh feature branch and do NOT restart from Rederive. Run \`git fetch origin\`; rebase onto ` +
-        `origin/main; resolve every conflict preserving the branch's intent; commit as needed; then force-push with ` +
+        `${baseRef}; resolve every conflict preserving the branch's intent; commit as needed; then force-push with ` +
         `lease (\`git push --force-with-lease\`). Return the absolute worktree_path, branch, resulting commits, and ` +
-        `\`git diff origin/main --stat\` in diff_stat.`,
+        `\`git diff ${baseRef} --stat\` in diff_stat.`,
       leadOpts({ phase: 'Fix', label: `rebase:${lead || 'generic'}`, schema: implementSchema }),
     )) || {};
   return {


### PR DESCRIPTION
## Why

The loop gated startability on a blocker being **closed**, and an issue closes only when its PR merges — which is the owner's call. Milestone #39's graph is six deep and narrow:

```
#1589 → #1592 → #1593 → #1594 → #1596 → #1605
```

So at most one ticket advances per merge. Right now **5 of 19** tickets are unblocked; a run overnight would finish three small ones and then stall until morning with fourteen issues waiting behind two.

A ticket whose open blockers **all** have an open PR now starts anyway, rooted on the deepest of those branches, with its PR targeting that branch so a reviewer sees one layer's diff. A blocker with no open PR still blocks — there is nothing to build on.

## Three things that would have silently defeated it

**Every diff was taken against `origin/main`** — the branch guard, the shape report, and each reviewer prompt. On a stacked branch the parent's commits are already in that diff, so every layer would re-review the entire stack beneath it and cascade the parent's findings into the child's fix rounds. Now each diffs against its own base.

**Hot-file collision detection was global**, so any layer touching a file its parent touched got deferred — which is every layer, since building on a change means editing what it changed. Collisions are now tracked **per base branch**: two branches off one base still conflict, but a layer cannot conflict with an ancestor whose commits it already contains.

**The repo squash-merges.** A landed base leaves its child carrying the parent's pre-squash commits, so the child goes conflicting. The rebase path now detects a base branch that no longer exists on origin, rebases onto main, and retargets the PR base — rather than rebasing a live stack layer onto main, which would swallow its parent's commits into the child's diff.

## Ordering

Batches are ordered shallowest-first: a layer must exist before anything stacks on it, and the bottom PR reaches the owner soonest, so a stack collapses from the bottom.

## Verification

`node --check` on both scripts, plus a planner smoke test over a representative batch:

```
batch:    [ '1589@main', '1592@feat/1589-x', '1597@feat/1589-x', '1624@main' ]
deferred: [ [1591, 'collision extract/lib.rs off feat/1589-x'] ]
```

#1592 and #1597 stack on #1589 without a false collision against it; #1591 correctly defers against #1592, with which it shares both a base and a file.

There is no test harness for `.claude/` workflows, so the real proof is the next few passes — a blocked ticket with an open-PR blocker should start and open a PR based on that branch rather than main.

## What this does not do

`gh stack` (v0.0.8, installed) is not wired in. The stack is expressed through PR base branches, which is what GitHub renders and what `gh stack` itself reads, so the extension remains usable interactively without the loop depending on it.

Note this could not be produced by a loop run — `.claude/rules/flow.md` bars a run from editing the definitions it is using. The driver is stopped and needs restarting after merge.
