### PR TITLE
fix(engine): shutdown-request primitive review fixes (#1599 round 1)

### DIFF
--- a/runtime/streamlib-engine/src/core/context/runtime_ops_shim.rs
+++ b/runtime/streamlib-engine/src/core/context/runtime_ops_shim.rs
@@ -364,9 +364,8 @@ impl RuntimeOperations for RuntimeOpsShim {
     }
 
     fn request_runtime_shutdown(&self, reason: &str) -> Result<()> {
-        // Crosses on the reserved plugin-ABI control topic, not a
-        // `RuntimeOpsVTable` slot: fire-and-forget with no completion payload
-        // (a slot buys a return value or a typed error).
+        // Not a `RuntimeOpsVTable` slot: this one crosses on the reserved
+        // plugin-ABI control topic.
         crate::core::runtime::request_runtime_shutdown(reason)
     }
 }

--- a/runtime/streamlib-engine/src/core/plugin/host_services/mod.rs
+++ b/runtime/streamlib-engine/src/core/plugin/host_services/mod.rs
@@ -327,51 +327,63 @@ pub struct HostCallbacks {
 unsafe impl Send for HostCallbacks {}
 unsafe impl Sync for HostCallbacks {}
 
-impl From<&HostServices> for HostCallbacks {
-    /// Cache the host's table field-by-field. The one place the two structs are
-    /// mapped onto each other — a new [`HostServices`] slot is carried here or
-    /// it never reaches cdylib code.
-    fn from(services: &HostServices) -> Self {
-        Self {
-            host: services.host,
-            tracing_register_callsite: services.tracing_register_callsite,
-            tracing_enabled: services.tracing_enabled,
-            tracing_emit: services.tracing_emit,
-            pubsub_publish: services.pubsub_publish,
-            schema_register: services.schema_register,
-            schema_lookup: services.schema_lookup,
-            iceoryx_log_emit: services.iceoryx_log_emit,
-            processor_register: services.processor_register,
-            runtime_context_vtable: services.runtime_context_vtable,
-            audio_clock_vtable: services.audio_clock_vtable,
-            runtime_ops_vtable: services.runtime_ops_vtable,
-            gpu_context_limited_access_vtable: services.gpu_context_limited_access_vtable,
-            surface_store_vtable: services.surface_store_vtable,
-            gpu_context_full_access_vtable: services.gpu_context_full_access_vtable,
-            texture_ring_methods_vtable: services.texture_ring_methods_vtable,
-            vulkan_compute_kernel_methods_vtable: services.vulkan_compute_kernel_methods_vtable,
-            vulkan_graphics_kernel_methods_vtable: services.vulkan_graphics_kernel_methods_vtable,
-            vulkan_ray_tracing_kernel_methods_vtable: services
-                .vulkan_ray_tracing_kernel_methods_vtable,
-            vulkan_acceleration_structure_methods_vtable: services
-                .vulkan_acceleration_structure_methods_vtable,
-            rhi_color_converter_methods_vtable: services.rhi_color_converter_methods_vtable,
-            rhi_command_recorder_methods_vtable: services.rhi_command_recorder_methods_vtable,
-            output_writer_vtable: services.output_writer_vtable,
-            input_mailboxes_vtable: services.input_mailboxes_vtable,
-            present_target_methods_vtable: services.present_target_methods_vtable,
-            video_encoder_session_methods_vtable: services.video_encoder_session_methods_vtable,
-            video_decoder_session_methods_vtable: services.video_decoder_session_methods_vtable,
-            host_timeline_semaphore_methods_vtable: services.host_timeline_semaphore_methods_vtable,
-            vulkan_texture_readback_methods_vtable: services.vulkan_texture_readback_methods_vtable,
-        }
+/// Cache the host's table field-by-field, after the caller has confirmed
+/// [`HostServices::abi_layout_version`]. Private and named rather than a public
+/// `From` impl so the load handshake's ordering stays structural: reading the
+/// appended tail of a `HostServices` whose version was never checked is not
+/// expressible from outside this module.
+///
+/// One of the two mapping points — the engine-free SDK carries its twin at
+/// `sdk/streamlib-plugin-sdk/src/plugin.rs`, held identical by
+/// `twin_drift_guard`. A new [`HostServices`] slot is carried in BOTH or it
+/// reaches only one of the two cdylib flavors.
+// twin-guard(host-callbacks-field-map): BEGIN
+fn host_callbacks_from_validated_host_services(services: &HostServices) -> HostCallbacks {
+    HostCallbacks {
+        host: services.host,
+        tracing_register_callsite: services.tracing_register_callsite,
+        tracing_enabled: services.tracing_enabled,
+        tracing_emit: services.tracing_emit,
+        pubsub_publish: services.pubsub_publish,
+        schema_register: services.schema_register,
+        schema_lookup: services.schema_lookup,
+        iceoryx_log_emit: services.iceoryx_log_emit,
+        processor_register: services.processor_register,
+        runtime_context_vtable: services.runtime_context_vtable,
+        audio_clock_vtable: services.audio_clock_vtable,
+        runtime_ops_vtable: services.runtime_ops_vtable,
+        gpu_context_limited_access_vtable: services.gpu_context_limited_access_vtable,
+        surface_store_vtable: services.surface_store_vtable,
+        gpu_context_full_access_vtable: services.gpu_context_full_access_vtable,
+        texture_ring_methods_vtable: services.texture_ring_methods_vtable,
+        vulkan_compute_kernel_methods_vtable: services.vulkan_compute_kernel_methods_vtable,
+        vulkan_graphics_kernel_methods_vtable: services.vulkan_graphics_kernel_methods_vtable,
+        vulkan_ray_tracing_kernel_methods_vtable: services.vulkan_ray_tracing_kernel_methods_vtable,
+        vulkan_acceleration_structure_methods_vtable: services
+            .vulkan_acceleration_structure_methods_vtable,
+        rhi_color_converter_methods_vtable: services.rhi_color_converter_methods_vtable,
+        rhi_command_recorder_methods_vtable: services.rhi_command_recorder_methods_vtable,
+        output_writer_vtable: services.output_writer_vtable,
+        input_mailboxes_vtable: services.input_mailboxes_vtable,
+        present_target_methods_vtable: services.present_target_methods_vtable,
+        video_encoder_session_methods_vtable: services.video_encoder_session_methods_vtable,
+        video_decoder_session_methods_vtable: services.video_decoder_session_methods_vtable,
+        host_timeline_semaphore_methods_vtable: services.host_timeline_semaphore_methods_vtable,
+        vulkan_texture_readback_methods_vtable: services.vulkan_texture_readback_methods_vtable,
     }
 }
+// twin-guard(host-callbacks-field-map): END
 
 #[cfg(test)]
 pub(crate) mod host_services_test_support {
-    //! One `HostServices` stand-in for the in-crate tests that need a callback
-    //! table without a live host.
+    //! A `HostServices` stand-in for in-crate tests that need a callback table
+    //! without a live host.
+    //!
+    //! Not the crate's only one: `layout_skew_diagnostic.rs` carries its own
+    //! copy on purpose. That file is a logic-identical twin of the engine-free
+    //! SDK's, and its fixture sits INSIDE the guarded region — calling out to a
+    //! shared builder would leave two unguarded builders free to drift while
+    //! the twin guard still saw identical call text.
 
     use super::*;
     use streamlib_plugin_abi::HOST_SERVICES_LAYOUT_VERSION;
@@ -439,10 +451,27 @@ pub(crate) mod host_services_test_support {
         0
     }
 
+    /// A [`HostCallbacks`] whose `host` + `pubsub_publish` are the caller's,
+    /// every other callback an unused stub, and every inner vtable null.
+    ///
+    /// Built through the same version-matching [`HostServices`] +
+    /// [`host_callbacks_from_validated_host_services`] path `install_host_services`
+    /// takes, so a test's callback table can never be a shape the real install
+    /// would not produce.
+    pub(crate) fn host_callbacks_with_capturing_pubsub_publish(
+        host: HostHandle,
+        pubsub_publish: unsafe extern "C" fn(HostHandle, *const u8, usize, *const u8, usize),
+    ) -> HostCallbacks {
+        host_callbacks_from_validated_host_services(&host_services_with_capturing_pubsub_publish(
+            host,
+            pubsub_publish,
+        ))
+    }
+
     /// A version-matching [`HostServices`] whose `host` + `pubsub_publish` are
     /// the caller's, every other callback an unused stub, and every inner
     /// vtable null.
-    pub(crate) fn host_services_with_capturing_pubsub_publish(
+    fn host_services_with_capturing_pubsub_publish(
         host: HostHandle,
         pubsub_publish: unsafe extern "C" fn(HostHandle, *const u8, usize, *const u8, usize),
     ) -> HostServices {
@@ -555,7 +584,7 @@ pub unsafe fn install_host_services(host_services_ptr: *const c_void) -> Option<
         return None;
     }
 
-    let callbacks = HostCallbacks::from(services);
+    let callbacks = host_callbacks_from_validated_host_services(services);
 
     // Cache the callbacks BEFORE installing tracing — the
     // `ForwardingSubscriber` reads `HOST_CALLBACKS` on every emit.

--- a/runtime/streamlib-engine/src/core/plugin/twin_drift_guard.rs
+++ b/runtime/streamlib-engine/src/core/plugin/twin_drift_guard.rs
@@ -51,6 +51,20 @@ const SDK_RUNTIME_SHUTDOWN_PUBLISH_FILE: &str = concat!(
 const RUNTIME_SHUTDOWN_PUBLISH_TWIN_BEGIN: &str = "twin-guard(runtime-shutdown-publish): BEGIN";
 const RUNTIME_SHUTDOWN_PUBLISH_TWIN_END: &str = "twin-guard(runtime-shutdown-publish): END";
 
+/// Engine-side `HostServices` → `HostCallbacks` field-map twin.
+const ENGINE_HOST_CALLBACKS_FIELD_MAP_FILE: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/src/core/plugin/host_services/mod.rs"
+);
+/// SDK-side `HostServices` → `HostCallbacks` field-map twin.
+const SDK_HOST_CALLBACKS_FIELD_MAP_FILE: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../sdk/streamlib-plugin-sdk/src/plugin.rs"
+);
+/// Line marker bracketing the guarded field map in each twin.
+const HOST_CALLBACKS_FIELD_MAP_TWIN_BEGIN: &str = "twin-guard(host-callbacks-field-map): BEGIN";
+const HOST_CALLBACKS_FIELD_MAP_TWIN_END: &str = "twin-guard(host-callbacks-field-map): END";
+
 /// Strip full-line comments + blank lines, apply the one known import-path shim
 /// (`super::host_services::` → `super::`), then drop all remaining whitespace.
 /// The result preserves the marshalling LOGIC (identifiers, calls, control
@@ -229,6 +243,88 @@ fn logic_identical_runtime_shutdown_publish_twins_stay_in_sync() {
          sdk/streamlib-plugin-sdk/src/runtime_control.rs\n\
          (Both publish the reserved runtime-shutdown control topic; the \
          engine-free SDK can't reuse the engine's copy.)\n"
+    );
+}
+
+/// The `HostServices` → `HostCallbacks` field map is the load handshake's last
+/// step, and it exists twice: the engine's copy runs in a facade cdylib, the
+/// SDK's in an engine-free one. A slot added to only one copy reaches only one
+/// cdylib flavor — a silent, flavor-dependent null callback, never a build
+/// failure. Only the mapping function is twinned in each file, so this is a
+/// marked-region entry. Unbypassable: there is no fixture to update — apply the
+/// same change to BOTH.
+#[test]
+fn logic_identical_host_callbacks_field_map_twins_stay_in_sync() {
+    let eng = normalize(&extract_marked_region(
+        &read_path(ENGINE_HOST_CALLBACKS_FIELD_MAP_FILE),
+        ENGINE_HOST_CALLBACKS_FIELD_MAP_FILE,
+        HOST_CALLBACKS_FIELD_MAP_TWIN_BEGIN,
+        HOST_CALLBACKS_FIELD_MAP_TWIN_END,
+    ));
+    let sdk = normalize(&extract_marked_region(
+        &read_path(SDK_HOST_CALLBACKS_FIELD_MAP_FILE),
+        SDK_HOST_CALLBACKS_FIELD_MAP_FILE,
+        HOST_CALLBACKS_FIELD_MAP_TWIN_BEGIN,
+        HOST_CALLBACKS_FIELD_MAP_TWIN_END,
+    ));
+    assert_eq!(
+        eng, sdk,
+        "\nengine↔SDK HostCallbacks field-map twin has DRIFTED — a slot landed \
+         in one copy but not the other, so it reaches only one cdylib flavor. \
+         Apply the SAME change to BOTH:\n  \
+         runtime/streamlib-engine/src/core/plugin/host_services/mod.rs\n  \
+         sdk/streamlib-plugin-sdk/src/plugin.rs\n"
+    );
+}
+
+/// The marked-region guards above compare NORMALIZED text, so their value rests
+/// on [`normalize`] not erasing the load-bearing tokens. This drives the
+/// comparison against deliberately drifted copies of the runtime-shutdown
+/// publish region: a swapped msgpack encoder or a swapped topic constant must
+/// read as drift, while a comment-only edit must not. Without this, a
+/// `normalize` that over-collapsed would leave every marked-region guard
+/// silently vacuous.
+#[test]
+fn the_marked_region_comparison_detects_a_one_sided_wire_change() {
+    let region = extract_marked_region(
+        &read_path(ENGINE_RUNTIME_SHUTDOWN_PUBLISH_FILE),
+        ENGINE_RUNTIME_SHUTDOWN_PUBLISH_FILE,
+        RUNTIME_SHUTDOWN_PUBLISH_TWIN_BEGIN,
+        RUNTIME_SHUTDOWN_PUBLISH_TWIN_END,
+    );
+    let baseline = normalize(&region);
+
+    for (what_drifted, drifted) in [
+        (
+            "the msgpack encoder",
+            region.replace("rmp_serde::to_vec(", "rmp_serde::to_vec_named("),
+        ),
+        (
+            "the reserved control topic",
+            region.replace(
+                "PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST",
+                "PUBSUB_CONTROL_TOPIC_SOME_OTHER_REQUEST",
+            ),
+        ),
+    ] {
+        assert_ne!(
+            drifted, region,
+            "the {what_drifted} substitution matched nothing — this test no \
+             longer exercises what it claims"
+        );
+        assert_ne!(
+            baseline,
+            normalize(&drifted),
+            "normalize() erased {what_drifted}, so the marked-region twin \
+             guards would not catch a one-sided change to it"
+        );
+    }
+
+    assert_eq!(
+        baseline,
+        normalize(&format!("// a comment-only edit\n{region}")),
+        "normalize() must ignore comment-only edits, or every marked-region \
+         guard fails on prose churn"
     );
 }
 

--- a/runtime/streamlib-engine/src/core/runtime/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/mod.rs
@@ -31,10 +31,12 @@ pub use operations::{
     SchemaValidationPosture, SubmittedProcessorSource,
 };
 pub use runtime::Runner;
-pub use runtime_shutdown_request::{is_runtime_shutdown_requested, request_runtime_shutdown};
-// Clearing the latch cancels a pending shutdown request; only the harness that
-// owns the run loop may do that, so it never reaches the SDK surface.
-pub(crate) use runtime_shutdown_request::take_runtime_shutdown_request_latch;
+#[cfg(test)]
+pub(crate) use runtime_shutdown_request::RuntimeShutdownRequestLatchClearedOnDrop;
+pub use runtime_shutdown_request::{
+    RUNTIME_SHUTDOWN_REQUEST_OBSERVATION_POLL_INTERVAL, is_runtime_shutdown_requested,
+    request_runtime_shutdown, take_runtime_shutdown_request_latch,
+};
 pub use runtime_unique_id::RuntimeUniqueId;
 pub use status::RuntimeStatus;
 pub use streamlib_idents::app_modules::{

--- a/runtime/streamlib-engine/src/core/runtime/operations.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations.rs
@@ -324,11 +324,15 @@ pub trait RuntimeOperations: Send + Sync {
     ///
     /// The effect is process-global (matching the `RuntimeShutdown` event on
     /// `topics::RUNTIME_GLOBAL`): the receiver is not a scoping parameter, and
-    /// with two runtimes alive in one process both loop owners observe it.
+    /// the latch is first-observer-wins — the loop owner that observes the
+    /// request takes it. A request issued while no run loop is running is
+    /// observed by the next one to start, so a start-script that aborts from
+    /// `setup(rt)` still stops the run.
     ///
     /// Fire-and-forget with no completion payload, so unlike every other sync
-    /// method on this trait it never `block_on`s and is safe to call from
-    /// inside a tokio task.
+    /// method on this trait it never `block_on`s and therefore cannot deadlock
+    /// when called from inside a tokio task. It can still block briefly: the
+    /// host arm publishes over iceoryx2.
     fn request_runtime_shutdown(&self, reason: &str) -> Result<()>;
 
     // =========================================================================

--- a/runtime/streamlib-engine/src/core/runtime/runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/runtime.rs
@@ -435,16 +435,6 @@ impl Runner {
     /// Processors can then call runtime operations directly without indirection.
     #[tracing::instrument(name = "runtime.start", skip_all)]
     pub fn start(self: &Arc<Self>) -> Result<()> {
-        // A shutdown request only means anything to a live run loop; taking the
-        // latch at entry keeps a second in-process run from inheriting the
-        // first run's request.
-        if crate::core::runtime::take_runtime_shutdown_request_latch() {
-            tracing::warn!(
-                "discarded a runtime-shutdown request latched before start(): no run loop owned \
-                 it yet, so nothing observed it"
-            );
-        }
-
         // Hard barrier: refuse to run the graph while any module load is
         // still in flight (its processor types may not be registered
         // yet). Await pending loads — e.g. via `await_modules` — first.
@@ -965,11 +955,15 @@ impl Runner {
                     // shutdown observation rides in on the periodic callback,
                     // which routes through `app.terminate` →
                     // `applicationWillTerminate` → the stop callback above.
-                    if runtime_shutdown_observed(&shutdown_flag_for_callback) {
+                    let control_flow = if runtime_shutdown_observed(&shutdown_flag_for_callback) {
+                        ControlFlow::Break(())
+                    } else {
+                        callback(&runtime_for_callback)
+                    };
+                    if control_flow.is_break() {
                         crate::core::runtime::take_runtime_shutdown_request_latch();
-                        return ControlFlow::Break(());
                     }
-                    callback(&runtime_for_callback)
+                    control_flow
                 },
             );
             // Note: run_macos_event_loop never returns - app terminates after stop callback
@@ -986,7 +980,9 @@ impl Runner {
                 }
 
                 // Small sleep to avoid busy-waiting
-                std::thread::sleep(std::time::Duration::from_millis(100));
+                std::thread::sleep(
+                    crate::core::runtime::RUNTIME_SHUTDOWN_REQUEST_OBSERVATION_POLL_INTERVAL,
+                );
             }
 
             // The request has been observed; leaving it latched would make the

--- a/runtime/streamlib-engine/src/core/runtime/runtime_shutdown_request.rs
+++ b/runtime/streamlib-engine/src/core/runtime/runtime_shutdown_request.rs
@@ -8,10 +8,12 @@
 //! publishes `Event::RuntimeGlobal(RuntimeEvent::RuntimeShutdown)`, and the
 //! loop owner ([`crate::core::runtime::Runner::wait_for_signal_with`]) runs the
 //! normal teardown. The latch is process-global (the signal handler and the
-//! plugin ABI hold no `Runner`), so the design assumes one run loop per
-//! process.
+//! plugin ABI hold no `Runner`) and first-observer-wins: whichever loop owner
+//! reads it takes it, so a request issued while no run loop is running is
+//! observed by the next one to start.
 
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use streamlib_plugin_abi::PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST;
 
@@ -26,6 +28,16 @@ use crate::core::pubsub::{Event, PUBSUB, RuntimeEvent};
 /// its own copy of this static, which is precisely why the cdylib arm of the
 /// funnel publishes across the plugin ABI instead of storing here.
 static RUNTIME_SHUTDOWN_REQUEST_LATCH: AtomicBool = AtomicBool::new(false);
+
+/// Fired at most once per image, so the wrong-image diagnostic below stays
+/// fail-loud without becoming a log firehose: the predicate it guards is meant
+/// to be polled, and inside a facade cdylib every emit is a plugin-ABI hop.
+static WRONG_IMAGE_LATCH_READ_WARNING: std::sync::Once = std::sync::Once::new();
+
+/// How often a loop owner re-reads the latch. Shared so the run loop
+/// ([`crate::core::runtime::Runner::wait_for_signal_with`]) and every
+/// out-of-crate loop owner observe a request at the same granularity.
+pub const RUNTIME_SHUTDOWN_REQUEST_OBSERVATION_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Ask whoever owns the run loop to shut the runtime down (equivalent to
 /// Ctrl+C / SIGTERM). Idempotent and fire-and-forget.
@@ -85,19 +97,46 @@ fn is_runtime_shutdown_requested_with_installed_host_callbacks(
     installed_host_callbacks: Option<&HostCallbacks>,
 ) -> bool {
     if installed_host_callbacks.is_some() {
-        tracing::warn!(
-            "is_runtime_shutdown_requested read inside a plugin cdylib: this image's latch is \
-             never set, so the answer is always `false` — the run loop that observes a shutdown \
-             request lives in the host"
-        );
+        WRONG_IMAGE_LATCH_READ_WARNING.call_once(|| {
+            tracing::warn!(
+                "is_runtime_shutdown_requested read inside a plugin cdylib: this image's latch is \
+                 never set, so the answer is always `false` — the run loop that observes a \
+                 shutdown request lives in the host (warned once per image)"
+            );
+        });
     }
     RUNTIME_SHUTDOWN_REQUEST_LATCH.load(Ordering::SeqCst)
 }
 
 /// Clear the latch, returning whether a request was pending. Host-only, for the
 /// same reason as [`is_runtime_shutdown_requested`].
-pub(crate) fn take_runtime_shutdown_request_latch() -> bool {
+///
+/// Taking the latch is what makes it first-observer-wins, so only whoever owns
+/// a run loop may call it — once its loop has ended, so the request it just
+/// observed does not end the next loop in the same process too.
+pub fn take_runtime_shutdown_request_latch() -> bool {
     RUNTIME_SHUTDOWN_REQUEST_LATCH.swap(false, Ordering::SeqCst)
+}
+
+/// Clears the latch on construction and again on drop, so a `#[serial]` test
+/// that touches the process-global latch leaves it clean even when an assertion
+/// unwinds past its own cleanup.
+#[cfg(test)]
+pub(crate) struct RuntimeShutdownRequestLatchClearedOnDrop;
+
+#[cfg(test)]
+impl RuntimeShutdownRequestLatchClearedOnDrop {
+    pub(crate) fn clear_now_and_on_drop() -> Self {
+        take_runtime_shutdown_request_latch();
+        Self
+    }
+}
+
+#[cfg(test)]
+impl Drop for RuntimeShutdownRequestLatchClearedOnDrop {
+    fn drop(&mut self) {
+        take_runtime_shutdown_request_latch();
+    }
 }
 
 /// Publish a shutdown request to the host on the reserved plugin-ABI control
@@ -134,17 +173,18 @@ fn publish_runtime_shutdown_request(callbacks: &HostCallbacks, reason: &str) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::plugin::host_services::host_services_test_support::host_services_with_capturing_pubsub_publish;
+    use crate::core::plugin::host_services::host_services_test_support::host_callbacks_with_capturing_pubsub_publish;
     use core::cell::RefCell;
     use serial_test::serial;
     use streamlib_plugin_abi::HostHandle;
 
     /// The latch is process-global, so every test that touches it runs
-    /// `#[serial]` and leaves it cleared for the next one.
+    /// `#[serial]` and leaves it cleared for the next one — including when an
+    /// assertion inside `body` unwinds.
     fn with_cleared_latch<F: FnOnce()>(body: F) {
-        take_runtime_shutdown_request_latch();
+        let _latch_cleared_even_on_unwind =
+            RuntimeShutdownRequestLatchClearedOnDrop::clear_now_and_on_drop();
         body();
-        take_runtime_shutdown_request_latch();
     }
 
     /// The host binary's `host_callbacks()` is `None`, so this drives the host
@@ -183,9 +223,9 @@ mod tests {
         });
     }
 
-    /// `Runner::start` takes the latch at entry (so a second in-process run is
-    /// not poisoned by the first run's request) and warns on the `true` it gets
-    /// back — a request nobody's run loop ever owned.
+    /// Taking the latch is what makes it first-observer-wins: the loop owner
+    /// that observed the request clears it, so the next loop in the same
+    /// process does not exit on a request that was already served.
     #[test]
     #[serial]
     fn taking_the_latch_reports_the_pending_request_and_unrequests_shutdown() {
@@ -235,10 +275,10 @@ mod tests {
     fn host_callbacks_with_capture(
         sink: &RefCell<Vec<CapturedRuntimeShutdownPublish>>,
     ) -> HostCallbacks {
-        HostCallbacks::from(&host_services_with_capturing_pubsub_publish(
+        host_callbacks_with_capturing_pubsub_publish(
             sink as *const RefCell<Vec<CapturedRuntimeShutdownPublish>> as HostHandle,
             capturing_pubsub_publish,
-        ))
+        )
     }
 
     /// The cdylib arm's wire selection is load-bearing: the host decodes the

--- a/runtime/streamlib-engine/src/core/signals.rs
+++ b/runtime/streamlib-engine/src/core/signals.rs
@@ -9,10 +9,13 @@ static SIGNAL_HANDLER_INSTALLED: AtomicBool = AtomicBool::new(false);
 
 /// Install native signal handlers for shutdown signals
 ///
-/// Captures SIGTERM and SIGINT (Ctrl+C) and funnels them into
+/// Captures SIGTERM and SIGINT (Ctrl+C). Unix/Linux funnels them into
 /// [`request_runtime_shutdown`](crate::core::runtime::request_runtime_shutdown)
-/// like every other shutdown boundary. This function spawns a background thread
-/// to handle signals without blocking the signal handler.
+/// like every other shutdown boundary; macOS instead routes through
+/// `NSApplication.terminate`, which reaches the same teardown via
+/// `applicationWillTerminate` and never touches the funnel. This function
+/// spawns a background thread to handle signals without blocking the signal
+/// handler.
 ///
 /// # Platform Support
 /// - Unix/Linux: Uses libc signal handling via signal-hook
@@ -116,88 +119,34 @@ fn install_sigterm_handler_macos() -> std::io::Result<()> {
 
 #[cfg(all(unix, not(target_os = "macos")))]
 fn install_unix_signal_handlers() -> std::io::Result<()> {
-    use std::os::unix::net::UnixStream;
+    use signal_hook::consts::signal::{SIGINT, SIGTERM};
+    use signal_hook::iterator::Signals;
 
-    // Create a pipe for async-signal-safe communication
-    let (mut reader, writer) = UnixStream::pair()?;
+    // `Signals` owns the async-signal-safe self-pipe and yields the delivered
+    // signal NUMBER. `low_level::pipe::register` cannot: its handler writes a
+    // fixed `b"X"` wakeup byte, so a reader can never tell SIGINT from SIGTERM
+    // — and the shutdown `reason` this funnels into is operator-facing
+    // attribution.
+    let mut signals = Signals::new([SIGTERM, SIGINT])?;
 
-    // Clone writer so each signal registration owns its own fd.
-    // pipe::register() wraps the raw fd in a WakeFd that closes on drop,
-    // so sharing a single fd between two registrations would double-close.
-    let writer_for_sigterm = writer.try_clone()?;
-
-    // Spawn thread to handle signals from pipe
-    let handler_thread = std::thread::Builder::new()
+    // Detached: it runs for the process lifetime, and there is no shutdown
+    // path that joins it.
+    std::thread::Builder::new()
         .name("signal-handler".to_string())
         .spawn(move || {
-            use std::io::Read;
-            let mut buf = [0u8; 1];
-
             tracing::debug!("Signal handler thread started, waiting for signals");
-
-            loop {
-                tracing::trace!("Signal handler: Waiting to read from pipe");
-                match reader.read(&mut buf) {
-                    Ok(0) => {
-                        // Pipe closed, exit thread
-                        tracing::debug!("Signal handler pipe closed, exiting thread");
-                        break;
-                    }
-                    Ok(n) => {
-                        if n > 0 {
-                            let signal = buf[0];
-                            if let Err(error) =
-                                request_runtime_shutdown(&format!("posix signal {signal}"))
-                            {
-                                tracing::error!(
-                                    %error,
-                                    "Signal handler: runtime-shutdown request failed"
-                                );
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        tracing::error!("Signal handler thread error: {}", e);
-                        break;
-                    }
+            for signal in signals.forever() {
+                let signal_name =
+                    signal_hook::low_level::signal_name(signal).unwrap_or("unrecognized signal");
+                if let Err(error) = request_runtime_shutdown(&format!("posix signal {signal_name}"))
+                {
+                    tracing::error!(%error, "Signal handler: runtime-shutdown request failed");
                 }
             }
             tracing::debug!("Signal handler thread exiting");
         })?;
 
-    // Detach the thread so it continues running independently
-    std::mem::forget(handler_thread);
-
-    // Install signal handlers — each takes ownership of its own stream.
-    // into_raw_fd() transfers fd ownership without closing it.
-    install_sigterm_handler(writer_for_sigterm)?;
-    install_sigint_handler(writer)?;
-
     tracing::info!("Native signal handlers installed (SIGTERM, SIGINT)");
-    Ok(())
-}
-
-#[cfg(all(unix, not(target_os = "macos")))]
-fn install_sigterm_handler(pipe: std::os::unix::net::UnixStream) -> std::io::Result<()> {
-    use signal_hook::consts::signal::*;
-    use signal_hook::low_level::pipe;
-    use std::os::unix::io::IntoRawFd;
-
-    // IntoRawFd transfers fd ownership to pipe::register without closing it
-    pipe::register(SIGTERM, pipe.into_raw_fd())?;
-
-    Ok(())
-}
-
-#[cfg(all(unix, not(target_os = "macos")))]
-fn install_sigint_handler(pipe: std::os::unix::net::UnixStream) -> std::io::Result<()> {
-    use signal_hook::consts::signal::*;
-    use signal_hook::low_level::pipe;
-    use std::os::unix::io::IntoRawFd;
-
-    // IntoRawFd transfers fd ownership to pipe::register without closing it
-    pipe::register(SIGINT, pipe.into_raw_fd())?;
-
     Ok(())
 }
 

--- a/runtime/streamlib-engine/src/core/utils/loop_control.rs
+++ b/runtime/streamlib-engine/src/core/utils/loop_control.rs
@@ -31,6 +31,11 @@ impl EventListener for ShutdownListener {
 }
 
 /// Run a loop that automatically exits on shutdown events.
+///
+/// Host-only: both of its shutdown sources are inert inside a plugin cdylib —
+/// the plugin image's `PUBSUB` is never `init()`ed (so the subscription below
+/// never delivers) and the funnel's cdylib arm deliberately latches nothing in
+/// the plugin image's copy of the engine.
 pub fn shutdown_aware_loop<F, E>(mut f: F) -> std::result::Result<(), E>
 where
     F: FnMut() -> std::result::Result<LoopControl, E>,
@@ -85,21 +90,27 @@ mod tests {
     use serial_test::serial;
 
     /// A request latched before the loop subscribes leaves no event to receive,
-    /// so the loop must read the latch too. Mental-revert: dropping the
-    /// `is_runtime_shutdown_requested()` term hangs this test.
+    /// so the loop must read the latch too. The callback breaks itself after a
+    /// bounded number of iterations so a mental-revert (dropping the
+    /// `is_runtime_shutdown_requested()` term) fails the `iterations == 0`
+    /// assertion instead of spinning until a harness timeout.
     #[test]
     #[serial]
     fn latched_shutdown_request_exits_the_loop_without_an_event() {
-        crate::core::runtime::take_runtime_shutdown_request_latch();
+        let _latch_cleared_even_on_unwind =
+            crate::core::runtime::RuntimeShutdownRequestLatchClearedOnDrop::clear_now_and_on_drop();
         crate::core::runtime::request_runtime_shutdown("unit test")
             .expect("the host arm never fails");
 
+        const ITERATIONS_BEFORE_THE_CALLBACK_BREAKS_ITSELF: usize = 4;
         let mut iterations = 0;
         let result = shutdown_aware_loop(|| {
             iterations += 1;
+            if iterations >= ITERATIONS_BEFORE_THE_CALLBACK_BREAKS_ITSELF {
+                return Ok::<LoopControl, ()>(LoopControl::Break);
+            }
             Ok::<LoopControl, ()>(LoopControl::Continue)
         });
-        crate::core::runtime::take_runtime_shutdown_request_latch();
 
         assert!(result.is_ok());
         assert_eq!(

--- a/runtime/streamlib-engine/tests/runtime_shutdown_request_ends_run_loop.rs
+++ b/runtime/streamlib-engine/tests/runtime_shutdown_request_ends_run_loop.rs
@@ -18,6 +18,9 @@
 //!   processor's `start()` runs on its own thread against the harness reaching
 //!   `PUBSUB.subscribe` — so the latch gets its own deterministic test rather
 //!   than riding on that timing.
+//! - A request issued BEFORE `start()` — where the milestone's `setup(rt)`
+//!   inversion puts a start-script that decides to abort — is honored by the
+//!   run loop rather than silently discarded.
 //!
 //! Starts a real `Runner` (GPU + iceoryx2), so this runs outside the `--lib`
 //! gate, which never builds `tests/` integration binaries.
@@ -61,6 +64,39 @@ impl streamlib_engine::ManualProcessor for ShutdownRequestingTestProcessor::Proc
     }
 }
 
+/// Run `runtime`'s loop under a watchdog and assert it ended on the shutdown
+/// request rather than on the watchdog `Break`, with the normal teardown run.
+/// `what_requested_the_shutdown` names the leg under test in the failure
+/// message.
+fn assert_the_run_loop_ends_before_the_watchdog(
+    runtime: &std::sync::Arc<Runner>,
+    what_requested_the_shutdown: &str,
+) {
+    let started = Instant::now();
+    let watchdog_deadline = started + SHUTDOWN_OBSERVED_WATCHDOG;
+    runtime
+        .wait_for_signal_with(|_| {
+            if Instant::now() >= watchdog_deadline {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        })
+        .expect("the harness must exit its run loop cleanly");
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed < SHUTDOWN_OBSERVED_WATCHDOG,
+        "the run loop must end on {what_requested_the_shutdown}, not on the \
+         watchdog break; ran for {elapsed:?}",
+    );
+    assert_eq!(
+        runtime.status(),
+        RuntimeStatus::Stopped,
+        "the harness must run the normal teardown after observing {what_requested_the_shutdown}",
+    );
+}
+
 #[test]
 #[serial]
 fn a_processor_shutdown_request_ends_the_harness_run_loop() {
@@ -75,29 +111,7 @@ fn a_processor_shutdown_request_ends_the_harness_run_loop() {
         .expect("add the shutdown-requesting processor");
     runtime.start().expect("runtime start");
 
-    let started = Instant::now();
-    let watchdog_deadline = started + SHUTDOWN_OBSERVED_WATCHDOG;
-    runtime
-        .wait_for_signal_with(|_| {
-            if Instant::now() >= watchdog_deadline {
-                ControlFlow::Break(())
-            } else {
-                ControlFlow::Continue(())
-            }
-        })
-        .expect("the harness must exit its run loop cleanly");
-    let elapsed = started.elapsed();
-
-    assert!(
-        elapsed < SHUTDOWN_OBSERVED_WATCHDOG,
-        "the run loop must end on the processor's shutdown request, not on the \
-         watchdog break; ran for {elapsed:?}",
-    );
-    assert_eq!(
-        runtime.status(),
-        RuntimeStatus::Stopped,
-        "the harness must run the normal teardown after observing the request",
-    );
+    assert_the_run_loop_ends_before_the_watchdog(&runtime, "the processor's shutdown request");
 }
 
 /// The latch's whole reason to exist: a request published while nothing is
@@ -105,9 +119,8 @@ fn a_processor_shutdown_request_ends_the_harness_run_loop() {
 /// to receive, so only the latch can end the loop.
 ///
 /// Deterministic where the processor-driven test is not — the request is issued
-/// from the harness thread after `start()` (which clears the latch at entry)
-/// and before `wait_for_signal_with` subscribes, so the event is provably
-/// unobserved.
+/// from the harness thread after `start()` and before `wait_for_signal_with`
+/// subscribes, so the event is provably unobserved.
 ///
 /// Mental revert: drop the `is_runtime_shutdown_requested()` term from the poll
 /// loop's condition and the loop runs to the watchdog `Break` — the
@@ -122,27 +135,28 @@ fn a_request_latched_before_the_run_loop_subscribes_still_ends_it() {
         .request_runtime_shutdown("integration test: requested before the loop subscribed")
         .expect("the host arm never fails");
 
-    let started = Instant::now();
-    let watchdog_deadline = started + SHUTDOWN_OBSERVED_WATCHDOG;
-    runtime
-        .wait_for_signal_with(|_| {
-            if Instant::now() >= watchdog_deadline {
-                ControlFlow::Break(())
-            } else {
-                ControlFlow::Continue(())
-            }
-        })
-        .expect("the harness must exit its run loop cleanly");
-    let elapsed = started.elapsed();
+    assert_the_run_loop_ends_before_the_watchdog(&runtime, "the latched request");
+}
 
-    assert!(
-        elapsed < SHUTDOWN_OBSERVED_WATCHDOG,
-        "the run loop must end on the latched request, not on the watchdog \
-         break; ran for {elapsed:?}",
-    );
-    assert_eq!(
-        runtime.status(),
-        RuntimeStatus::Stopped,
-        "the harness must run the normal teardown after observing the latch",
-    );
+/// A start-script that decides to abort calls `request_runtime_shutdown` from
+/// `setup(rt)`, which runs before the harness calls `start()`. The latch is
+/// first-observer-wins, not per-run, so the request survives to the run loop
+/// instead of being discarded — otherwise the caller gets `Ok(())` and a
+/// runtime that never stops.
+///
+/// Mental revert: reinstate a `take_runtime_shutdown_request_latch()` at the top
+/// of `Runner::start` and the loop runs to the watchdog `Break` — the
+/// elapsed-time assertion then fails.
+#[test]
+#[serial]
+fn a_request_issued_before_start_is_observed_by_the_run_loop() {
+    let runtime = Runner::new().expect("Runner::new");
+
+    runtime
+        .request_runtime_shutdown("integration test: the start-script aborted before start()")
+        .expect("the host arm never fails");
+
+    runtime.start().expect("runtime start");
+
+    assert_the_run_loop_ends_before_the_watchdog(&runtime, "the pre-start request");
 }

--- a/sdk/streamlib-plugin-sdk/src/plugin.rs
+++ b/sdk/streamlib-plugin-sdk/src/plugin.rs
@@ -186,6 +186,53 @@ pub fn host_callbacks() -> Option<&'static HostCallbacks> {
     HOST_CALLBACKS.get()
 }
 
+/// Cache the host's table field-by-field, after the caller has confirmed
+/// [`HostServices::abi_layout_version`]. Private and named rather than a public
+/// `From` impl so the load handshake's ordering stays structural: reading the
+/// appended tail of a `HostServices` whose version was never checked is not
+/// expressible from outside this module.
+///
+/// One of the two mapping points — the engine carries its twin at
+/// `runtime/streamlib-engine/src/core/plugin/host_services/mod.rs`, held
+/// identical by `twin_drift_guard`. A new [`HostServices`] slot is carried in
+/// BOTH or it reaches only one of the two cdylib flavors.
+// twin-guard(host-callbacks-field-map): BEGIN
+fn host_callbacks_from_validated_host_services(services: &HostServices) -> HostCallbacks {
+    HostCallbacks {
+        host: services.host,
+        tracing_register_callsite: services.tracing_register_callsite,
+        tracing_enabled: services.tracing_enabled,
+        tracing_emit: services.tracing_emit,
+        pubsub_publish: services.pubsub_publish,
+        schema_register: services.schema_register,
+        schema_lookup: services.schema_lookup,
+        iceoryx_log_emit: services.iceoryx_log_emit,
+        processor_register: services.processor_register,
+        runtime_context_vtable: services.runtime_context_vtable,
+        audio_clock_vtable: services.audio_clock_vtable,
+        runtime_ops_vtable: services.runtime_ops_vtable,
+        gpu_context_limited_access_vtable: services.gpu_context_limited_access_vtable,
+        surface_store_vtable: services.surface_store_vtable,
+        gpu_context_full_access_vtable: services.gpu_context_full_access_vtable,
+        texture_ring_methods_vtable: services.texture_ring_methods_vtable,
+        vulkan_compute_kernel_methods_vtable: services.vulkan_compute_kernel_methods_vtable,
+        vulkan_graphics_kernel_methods_vtable: services.vulkan_graphics_kernel_methods_vtable,
+        vulkan_ray_tracing_kernel_methods_vtable: services.vulkan_ray_tracing_kernel_methods_vtable,
+        vulkan_acceleration_structure_methods_vtable: services
+            .vulkan_acceleration_structure_methods_vtable,
+        rhi_color_converter_methods_vtable: services.rhi_color_converter_methods_vtable,
+        rhi_command_recorder_methods_vtable: services.rhi_command_recorder_methods_vtable,
+        output_writer_vtable: services.output_writer_vtable,
+        input_mailboxes_vtable: services.input_mailboxes_vtable,
+        present_target_methods_vtable: services.present_target_methods_vtable,
+        video_encoder_session_methods_vtable: services.video_encoder_session_methods_vtable,
+        video_decoder_session_methods_vtable: services.video_decoder_session_methods_vtable,
+        host_timeline_semaphore_methods_vtable: services.host_timeline_semaphore_methods_vtable,
+        vulkan_texture_readback_methods_vtable: services.vulkan_texture_readback_methods_vtable,
+    }
+}
+// twin-guard(host-callbacks-field-map): END
+
 // =============================================================================
 // install_host_services — cdylib entry point
 // =============================================================================
@@ -237,38 +284,7 @@ pub unsafe fn install_host_services(host_services_ptr: *const c_void) -> Option<
         return None;
     }
 
-    let callbacks = HostCallbacks {
-        host: services.host,
-        tracing_register_callsite: services.tracing_register_callsite,
-        tracing_enabled: services.tracing_enabled,
-        tracing_emit: services.tracing_emit,
-        pubsub_publish: services.pubsub_publish,
-        schema_register: services.schema_register,
-        schema_lookup: services.schema_lookup,
-        iceoryx_log_emit: services.iceoryx_log_emit,
-        processor_register: services.processor_register,
-        runtime_context_vtable: services.runtime_context_vtable,
-        audio_clock_vtable: services.audio_clock_vtable,
-        runtime_ops_vtable: services.runtime_ops_vtable,
-        gpu_context_limited_access_vtable: services.gpu_context_limited_access_vtable,
-        surface_store_vtable: services.surface_store_vtable,
-        gpu_context_full_access_vtable: services.gpu_context_full_access_vtable,
-        texture_ring_methods_vtable: services.texture_ring_methods_vtable,
-        vulkan_compute_kernel_methods_vtable: services.vulkan_compute_kernel_methods_vtable,
-        vulkan_graphics_kernel_methods_vtable: services.vulkan_graphics_kernel_methods_vtable,
-        vulkan_ray_tracing_kernel_methods_vtable: services.vulkan_ray_tracing_kernel_methods_vtable,
-        vulkan_acceleration_structure_methods_vtable: services
-            .vulkan_acceleration_structure_methods_vtable,
-        rhi_color_converter_methods_vtable: services.rhi_color_converter_methods_vtable,
-        rhi_command_recorder_methods_vtable: services.rhi_command_recorder_methods_vtable,
-        output_writer_vtable: services.output_writer_vtable,
-        input_mailboxes_vtable: services.input_mailboxes_vtable,
-        present_target_methods_vtable: services.present_target_methods_vtable,
-        video_encoder_session_methods_vtable: services.video_encoder_session_methods_vtable,
-        video_decoder_session_methods_vtable: services.video_decoder_session_methods_vtable,
-        host_timeline_semaphore_methods_vtable: services.host_timeline_semaphore_methods_vtable,
-        vulkan_texture_readback_methods_vtable: services.vulkan_texture_readback_methods_vtable,
-    };
+    let callbacks = host_callbacks_from_validated_host_services(services);
 
     // Cache the callbacks BEFORE installing tracing — the
     // `ForwardingSubscriber` reads `HOST_CALLBACKS` on every emit.

--- a/sdk/streamlib-sdk/src/lib.rs
+++ b/sdk/streamlib-sdk/src/lib.rs
@@ -165,9 +165,12 @@ pub mod sdk {
 
     // ---- Runtime-control requests ----
     /// `request_runtime_shutdown` — ask whoever owns the run loop to stop the
-    /// runtime. Path-identical to `streamlib_plugin_sdk::sdk::runtime_control`,
-    /// so a facade-built package and an engine-free package author the same
-    /// call.
+    /// runtime. Call-shape-identical to
+    /// `streamlib_plugin_sdk::sdk::runtime_control`, so a facade-built package
+    /// and an engine-free package author the same call. The failure surface
+    /// differs: this copy has no `PluginHostUnavailable` arm, because a facade
+    /// build cannot distinguish "I am the host" from "I am a cdylib whose
+    /// `install_host_services` never ran" — both read as the host arm.
     pub mod runtime_control {
         pub use streamlib_engine::core::runtime::request_runtime_shutdown;
     }

--- a/tools/streamlib-cli/src/commands/mcp.rs
+++ b/tools/streamlib-cli/src/commands/mcp.rs
@@ -54,6 +54,10 @@ async fn serve_in_process() -> Result<()> {
     )
     .await;
 
+    // This process owned the run loop, so it owns the take: leaving the request
+    // latched would end the next loop in this process before it began.
+    streamlib::sdk::runtime::take_runtime_shutdown_request_latch();
+
     // Tear the runtime down regardless of how the loop ended, then surface any
     // transport error.
     if let Err(stop_error) = runner.stop() {
@@ -63,12 +67,15 @@ async fn serve_in_process() -> Result<()> {
     Ok(())
 }
 
-/// Resolve once a runtime-shutdown request is latched. Polled at the same 100 ms
-/// granularity as `Runner::wait_for_signal_with`, and reads the host binary's
-/// latch — this process is the host that funnelled the request.
+/// Resolve once a runtime-shutdown request is latched, reading the host
+/// binary's latch — this process is the host that funnelled the request. Polled
+/// at the engine's own shutdown-observation granularity.
 async fn wait_until_runtime_shutdown_requested() {
     while !streamlib::sdk::runtime::is_runtime_shutdown_requested() {
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        tokio::time::sleep(
+            streamlib::sdk::runtime::RUNTIME_SHUTDOWN_REQUEST_OBSERVATION_POLL_INTERVAL,
+        )
+        .await;
     }
 }
 
@@ -267,12 +274,21 @@ mod tests {
     /// What makes `serve_in_process` a run-loop owner: the future it hands the
     /// stdio serve loop pends until a request is latched, then resolves — so a
     /// `shutdown` tool call ends the loop and the existing `runner.stop()` tail
-    /// runs. The engine's latch is process-global and taking it is harness-owned
-    /// (`Runner::start`), so this test leaves it set; nothing else in this
-    /// binary observes it.
+    /// runs. The latch is process-global, so this test takes it back on every
+    /// exit path (including an assertion unwind) and leaves the binary clean,
+    /// the same discipline the engine's latch tests follow.
     #[tokio::test]
     #[serial_test::serial]
     async fn the_in_process_loop_owner_waits_for_a_latched_shutdown_request() {
+        struct RuntimeShutdownRequestLatchClearedOnDrop;
+        impl Drop for RuntimeShutdownRequestLatchClearedOnDrop {
+            fn drop(&mut self) {
+                streamlib::sdk::runtime::take_runtime_shutdown_request_latch();
+            }
+        }
+        streamlib::sdk::runtime::take_runtime_shutdown_request_latch();
+        let _latch_cleared_even_on_unwind = RuntimeShutdownRequestLatchClearedOnDrop;
+
         let pending = tokio::time::timeout(
             std::time::Duration::from_millis(250),
             wait_until_runtime_shutdown_requested(),


### PR DESCRIPTION
Round-1 self-review fixes for the shutdown-request primitive (#1599). PR #1629 was squash-merged into `main` (65ebed54) while this review round was in flight, so the fixes land as a follow-up rather than on that branch.

Every reviewer item from round 1 is either fixed here or declined with a reason; the declines are at the bottom.

## Defects

**`posix signal 88` for every signal.** `signal_hook::low_level::pipe::register`'s handler writes a fixed `b"X"` wakeup byte, not the signal number, and SIGINT and SIGTERM shared one pipe — so the operator-facing `reason` the funnel logs was always `posix signal 88`. #1629 promoted that byte from an internal log line into the shutdown `reason`, which is the whole point of the parameter. Now read off `signal_hook::iterator::Signals` and named via `low_level::signal_name`, which also deletes the hand-rolled self-pipe pair and its double-close commentary.

**A pre-start shutdown request was silently discarded.** `Runner::start` took the latch at entry, so a start-script aborting from `setup(rt)` — which runs before the harness calls `start()` under `streamlib run -f entry` — got `Ok(())` and a runtime that never stopped. That is exactly the case #1599's "a start-script can request shutdown" names. The latch is first-observer-wins, not per-run: every loop owner already takes it on exit, so the start-entry take is dropped and the remaining holes are closed — the macOS arm now takes on every `ControlFlow::Break` rather than only the shutdown-observed one, and the CLI's in-process MCP host (a run-loop owner outside the engine crate) takes it in its tail. `take_runtime_shutdown_request_latch` is public for that reason, documented as loop-owner-only.

Locked by `a_request_issued_before_start_is_observed_by_the_run_loop`, verified red on revert (reinstating the `start()` take makes it run to the 5 s watchdog).

**Unbounded warn flood on a polled predicate.** `is_runtime_shutdown_requested` warned on *every* call when host callbacks are installed, and #1629 made `shutdown_aware_loop` call it once per iteration of a loop with no sleep. Inside a facade cdylib each emit is a plugin-ABI hop through the forwarding subscriber. Now `std::sync::Once` — fail-loud, once per image.

## Plugin-ABI seam

**The `HostServices` to `HostCallbacks` field map is now a guarded twin.** It existed twice — the engine's copy runs in a facade cdylib, the SDK's in an engine-free one — with nothing holding the two field lists together. A slot added to one copy only would reach one cdylib flavor and silently not the other: a null callback, never a build failure. Both are now the same private, named `host_callbacks_from_validated_host_services`, bracketed by `twin-guard(host-callbacks-field-map)` and asserted identical.

Private and named rather than the public `From<&HostServices>` impl #1629 introduced also keeps the load handshake's ordering **structural**: reading the appended tail of a `HostServices` whose `abi_layout_version` was never checked is no longer expressible from outside the module. (The `From` impl was public, safe, and read every appended field with no version gate of its own.)

**The marked-region guards are proven non-vacuous.** `the_marked_region_comparison_detects_a_one_sided_wire_change` drives the comparison against deliberately drifted copies of the runtime-shutdown publish region: a swapped msgpack encoder or topic constant must read as drift, a comment-only edit must not. Without it, a `normalize` that over-collapsed would leave every marked-region guard silently passing.

Nothing grows a vtable: no slot added, no `*_VTABLE_LAYOUT_VERSION` moved, `HOST_SERVICES_LAYOUT_VERSION` and `abi_layout_fingerprint` untouched. No already-built plugin is invalidated.

## Tests

- The engine latch tests clear on unwind via a Drop guard, so one assertion failure no longer cascades into every following `#[serial]` test in the binary.
- The CLI test no longer leaves the process-global latch set for the rest of the `streamlib-cli` binary.
- The `loop_control` test's callback breaks itself after a bounded iteration count, so a revert of the latch term fails `iterations == 0` instead of spinning to a harness timeout.
- The two integration tests' duplicated watchdog-and-assert scaffolding is one `assert_the_run_loop_ends_before_the_watchdog` helper; the third case uses it.

## Docs

- `RuntimeOperations::request_runtime_shutdown` no longer promises that two runtimes both observe a request (the latch is first-observer-wins and cannot keep that promise), and no longer implies the call cannot block (the host arm publishes over iceoryx2).
- `install_signal_handlers` no longer claims macOS funnels through the primitive — it routes through `NSApplication.terminate`.
- The facade SDK re-export narrows "path-identical" to the call shape: it has no `PluginHostUnavailable` arm, because a facade build cannot distinguish "I am the host" from "I am a cdylib whose `install_host_services` never ran".
- `shutdown_aware_loop` is documented host-only (both its shutdown sources are inert in a plugin image).
- The `host_services_test_support` module doc no longer claims to be the crate's only `HostServices` stand-in.

## Filed, not fixed here

- #1634 — `request_runtime_shutdown` escalate op so a Python/Deno *subprocess processor* gets an in-graph path. Per the owner's decision on #1599, #1629 is control-plane-only by construction (`POST /api/runtime/shutdown` + the MCP `shutdown` tool already serve a Python or Deno *entry*, language-agnostically).
- #1635 — restore `aarch64-apple-darwin` compilation, make the doctrine cross-compile gate reproducible, then verify the macOS `NSApplication` terminate path on a real device.
- #1636 — emit the OpenAPI spec from the real `ApiDoc` instead of the drifted hand-maintained duplicate in `bin/generate_openapi.rs`.

## Declined

**Migrating `layout_skew_diagnostic.rs`'s `HostServices` fixture onto the shared test-support builder.** That file is a logic-identical engine↔SDK twin under an unbypassable guard, and its 30-field fixture sits *inside* the guarded region. Routing both copies through a shared builder would leave the guard comparing identical *call text* while two builders in unguarded files were free to drift — strictly less coverage than today, on the exact seam the guard exists to protect. The false "one stand-in" doc claim that prompted the finding is corrected instead, with the reason stated in the module doc.

**A `divergent_runtime_shutdown_publish_twin_is_tripwired` companion.** The premise does not hold: `divergent_*_is_tripwired` is the mechanism for twins that *legitimately differ* (hash pin), not a meta-test companion to the identical-twin guards — `logic_identical_twins_stay_in_sync` and `logic_identical_install_skew_diagnostic_twins_stay_in_sync` have no such companion either. The underlying ask (prove the guard is not vacuous) is honored by `the_marked_region_comparison_detects_a_one_sided_wire_change`, named for what it actually does.

## Verification

`cargo test` green on the new base: streamlib-engine `--lib` 1739 passed, plugin-sdk 105, CLI 90, api-server 56, and the `runtime_shutdown_request_ends_run_loop` integration suite 3 passed against a real `Runner` (GPU + iceoryx2). Gates: `lint-logging`, `check-boundaries`, `check-cdylib-reach`, `check-vendored-vulkanalia`, `check-no-escalate-in-lifecycle` all OK. Clippy on the touched files shows no new diagnostic class (only the endemic `result_large_err`).

`cargo check --target aarch64-apple-darwin` still cannot run here — it dies in `lzma-sys`'s C build script before reaching rustc, and there is no zig/cargo-zigbuild on this machine. That is #1635. The macOS arm was read against `apple/runtime_ext.rs:224-249`: `run_macos_event_loop` takes `C: FnMut() -> ControlFlow<()>` and the edited closure returns `ControlFlow<()>`; no type error by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)