### PR TITLE
feat(extract): group processors by id, expose per-target availability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5345,6 +5345,7 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 0.8.23",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/docs/decisions/manifest-extraction-capability.md
+++ b/docs/decisions/manifest-extraction-capability.md
@@ -187,22 +187,30 @@ split with a non-unix fallback arm fails the same way.
 
 **The model relates one cluster of target atoms, and prunes rather than
 guesses outside it.** The cluster is `target_os`, `target_family` and the bare
-`unix` / `windows` flags. `rustc` fixes every other target key against those
+`unix` / `windows` flags. `rustc` fixes every other target atom against those
 and against one another too — no target is both `target_env = "msvc"` and
 `target_os = "linux"`, none is both `target_arch = "wasm32"` and `target_env =
 "msvc"`, no `target_vendor = "apple"` target is `not(unix)` — and the model
-holds none of those facts, so an assignment that pins a key from outside the
-cluster while a second target atom is decided is dropped instead of printed as
-a proof. Inside the cluster the same discipline applies to what the rules
-cannot decide: a `target_os` outside the OS → family table decides nothing
-about families, and a `target_family` outside `unix` / `windows` defines
-neither flag, which deliberately drops `wasi` (genuinely both `wasm` and
-`unix`, the multi-valued case single-valued modelling gives up). Every rule
-and every gap therefore prunes, so the error direction is toward missing an
-overlap rather than inventing one — on the single assumption the model cannot
-check, that a value a predicate names is a value some target defines. The cost
-of a missed detection is bounded by the concrete-target net: the host that
-actually compiles both arms still fails.
+holds none of those facts, so an assignment that DEFINES an atom from outside
+the cluster (a key it pins a value for, or a bare `target_*` flag it sets)
+while a second target atom is decided is dropped instead of printed as a
+proof. A cluster atom counts as decided wherever the predicates mention it,
+whether the assignment names a value for it or leaves it at "some value the
+predicates never name": that unnamed slot is exactly what makes a NEGATED
+`target_os` / `target_family` value true, so `target_env = "msvc"` against
+`not(target_os = "windows")` is dropped for the same reason as `target_env =
+"msvc"` against `target_os = "linux"`. Inside the cluster the same discipline
+applies to what the rules cannot decide: a `target_os` outside the OS → family
+table decides nothing about families, and a `target_family` outside `unix` /
+`windows` defines neither flag, which deliberately drops `wasi` (genuinely
+both `wasm` and `unix`, the multi-valued case single-valued modelling gives
+up). Every rule and every gap therefore prunes, so the error direction is
+toward missing an overlap rather than inventing one. Two assumptions stay
+unchecked, and both are about one atom rather than about how two atoms relate:
+that a value a predicate names is a value some target defines, and that an
+atom a predicate names is one some target leaves undefined. The cost of a
+missed detection is bounded by the concrete-target net: the host that actually
+compiles both arms still fails.
 
 **Divergence is refused over the whole derived projection, not just ports.** The
 `processors:` section is derived from whichever arm the publishing host

--- a/docs/decisions/manifest-extraction-capability.md
+++ b/docs/decisions/manifest-extraction-capability.md
@@ -150,3 +150,69 @@ artifact and does not re-run it.
   replace the hand-authored `processors:` as the authoritative truth-source, and
   a drift check between the two a hard `pkg publish` error without false positives
   on cfg-gated packages.
+
+## Grouping by processor id: what is refused, what is data
+
+Once two files under one `processors/` tree can declare the same processor id
+under different `#[cfg]`, three things become possible. Two are refused at the
+scan; the third is the datum the scan now produces.
+
+**Overlap is refused, with a witness.** Two arms some build target compiles
+both of would register the same `Type` twice. The plugin registry's duplicate
+branch keeps whichever it saw first and logs at `debug`, and the drift check —
+keyed by the same `Type` name — collapses the pair before it compares, so the
+failure is silent at both seams. It is refused at the scan instead, proven two
+independent ways. The target-resolved walk needs no reasoning: it resolved one
+concrete target and collected the name twice. The across-every-target walk
+brute-forces satisfiability of the two arms' conjoined predicates over only the
+atoms those predicates themselves mention, and refuses **only on a satisfying
+assignment it can print**. That search carries a deliberate domain model — every
+`target_*` key is single-valued except the genuinely set-valued `feature` /
+`target_feature` / `target_has_atomic`, and the `unix` / `windows` families are
+mutually exclusive with `windows` holding exactly one `target_os`. Without it,
+`target_os = "linux"` against `any(target_os = "macos", target_os = "ios")`
+reads satisfiable and every platform-split package fails its own build. The
+model's rules are facts about how `rustc` sets these atoms, so each one can only
+ever remove a FALSE overlap; the cost of being wrong in the other direction — a
+missed detection — is bounded by the concrete-target net.
+
+**Divergence is refused over the whole derived projection, not just ports.** The
+`processors:` section is derived from whichever arm the publishing host
+compiles, so a difference in ANY field the manifest entry carries — the full
+`@org/package/Type` identity, execution, ports, scheduling, description, the
+config binding — makes the shipped manifest host-dependent. That is a wider
+surface than the language-uniform drift surface above, deliberately: drift
+compares a *hand-authored* manifest against *code*, where the excluded fields
+are authored rather than derived, while divergence compares two pieces of code
+that must derive the same entry. Port and execution differences are named by the
+same comparator the drift report uses, generalized from "manifest vs code" to a
+labelled two-sided comparison — one diagnostic with two callers, not two copies.
+Grouping is by `Type` name rather than the full identity because that is the key
+the registry keys registration on, so two arms sharing a `Type` under different
+`@org/package` collide there and surface here as a divergence rather than
+passing as two unrelated processors.
+
+**A gap is not an error — it is availability.** A package that declares a
+processor on some targets and on none of the others is ordinary. Which targets
+those are is carried as a per-processor `#[cfg(...)]` **predicate** — the
+disjunction over each declaring arm's conjoined predicates, `None` meaning
+unconditional — never as an enumerated target set. There is no closed target
+universe (an arm may gate on `redox`, `android`, a cargo feature, a custom cfg),
+so a fixed list would go stale and misreport; the enumerated answer is derived
+on demand for whatever targets a caller cares about, through the one cfg
+evaluator rather than a second implementation of cfg semantics. The crate-root
+generator's `export_plugin!` outer gate is that same disjunction: "the target
+compiles at least one of this package's processors".
+
+Availability is scan output, consumed in-process. It is deliberately NOT added
+to `streamlib.yaml`'s `processors:` section: that section's comparison surface
+is language-uniform by design, and Python and Deno have no cfg to project.
+
+A `#[cfg(feature = "…")]`-gated processor is the one case the target-resolved
+walk cannot decide correctly on its own — the scan target derives os / arch /
+family from the running host and cannot know which features a downstream build
+enables, so the processor evaluates false and leaves the derived set. It bites
+one seam later as a confusing drift error ("listed in `processors:` but no
+longer declared in code"), so the walk warns at the prune site with the file,
+the predicate and the undefined feature rather than leaving the absence
+unexplained.

--- a/docs/decisions/manifest-extraction-capability.md
+++ b/docs/decisions/manifest-extraction-capability.md
@@ -125,8 +125,8 @@ artifact and does not re-run it.
 - **`cfg-expr` / `target-lexicon` for the overlap search.** They ship the target
   coherence rules as data rather than the hand-written model below. Neither is
   in the tree today, so adopting one is a new-dependency decision for a
-  build-seam crate that currently pulls only `syn` / `quote` / `toml` — and the
-  model needs one more thing than either provides: an explicit "this fact is
+  build-seam crate that currently pulls only `syn` / `quote` / `toml` — and
+  the model needs one more thing than either provides: an explicit "this fact is
   unknown, leave the pair unproven" answer, which is what keeps the refusal
   sound. Worth revisiting if the coherence rules grow past the target-atom
   cluster the model relates today.
@@ -141,12 +141,11 @@ artifact and does not re-run it.
   `processors/`, including platform arms a given host does not compile
   (`camera_linux.rs` vs `camera_apple.rs`) and parked directories
   (`_apple_impl_pending_/`), so two platform arms that both declare the same
-  processor both surface.
-  `extract_reachable_rust_processors`
-  resolves that raw scan to the set the build **target** actually compiles: it
-  enumerates the top-level arms under `processors/` the way the generated crate
-  root declares them (a directory backed by `mod.rs` keeps directory ownership,
-  a flat `.rs` is a flat arm), follows each
+  processor both surface. `extract_reachable_rust_processors` resolves that raw
+  scan to the set the build **target** actually compiles: it enumerates the
+  top-level arms under `processors/` the way the generated crate root declares
+  them (a directory backed by `mod.rs` keeps directory ownership, a flat `.rs`
+  is a flat arm), follows each
   `mod` the way `rustc` resolves module files (honoring `#[path]`), and evaluates
   the `#[cfg(...)]` predicate on every `mod` and every `#[processor(...)]`-bearing
   struct against a `ModuleReachabilityTarget` (the target's cfg atoms:
@@ -187,23 +186,23 @@ last, `target_os = "ios"` against `not(unix)` reads satisfiable and a platform
 split with a non-unix fallback arm fails the same way.
 
 **The model relates one cluster of target atoms, and prunes rather than
-guesses outside it.** The cluster is `target_os`, `target_family` and the bare `unix` /
-`windows` flags. `rustc` fixes every other target key against those and against
-one another too — no target is both `target_env = "msvc"` and `target_os =
-"linux"`, none is both `target_arch = "wasm32"` and `target_env = "msvc"`, no
-`target_vendor = "apple"` target is `not(unix)` — and the model holds none of
-those facts, so an assignment that pins a key from outside the cluster while a
-second target atom is decided is dropped instead of printed as a proof. Inside
-the cluster the same discipline applies to what the rules cannot decide: a
-`target_os` outside the OS → family table decides nothing about families, and
-a `target_family` outside `unix` / `windows` defines neither flag, which
-deliberately drops `wasi` (genuinely both `wasm` and `unix`, the multi-valued
-case single-valued modelling gives up). Every rule and every gap therefore
-prunes, so the error direction is toward missing an overlap rather than
-inventing one — on the single assumption the model cannot check, that a value
-a predicate names is a value some target defines. The cost of a missed
-detection is bounded by the concrete-target net: the host that actually
-compiles both arms still fails.
+guesses outside it.** The cluster is `target_os`, `target_family` and the bare
+`unix` / `windows` flags. `rustc` fixes every other target key against those
+and against one another too — no target is both `target_env = "msvc"` and
+`target_os = "linux"`, none is both `target_arch = "wasm32"` and `target_env =
+"msvc"`, no `target_vendor = "apple"` target is `not(unix)` — and the model
+holds none of those facts, so an assignment that pins a key from outside the
+cluster while a second target atom is decided is dropped instead of printed as
+a proof. Inside the cluster the same discipline applies to what the rules
+cannot decide: a `target_os` outside the OS → family table decides nothing
+about families, and a `target_family` outside `unix` / `windows` defines
+neither flag, which deliberately drops `wasi` (genuinely both `wasm` and
+`unix`, the multi-valued case single-valued modelling gives up). Every rule
+and every gap therefore prunes, so the error direction is toward missing an
+overlap rather than inventing one — on the single assumption the model cannot
+check, that a value a predicate names is a value some target defines. The cost
+of a missed detection is bounded by the concrete-target net: the host that
+actually compiles both arms still fails.
 
 **Divergence is refused over the whole derived projection, not just ports.** The
 `processors:` section is derived from whichever arm the publishing host

--- a/docs/decisions/manifest-extraction-capability.md
+++ b/docs/decisions/manifest-extraction-capability.md
@@ -158,10 +158,10 @@ under different `#[cfg]`, three things become possible. Two are refused at the
 scan; the third is the datum the scan now produces.
 
 **Overlap is refused, with a witness.** Two arms some build target compiles
-both of would register the same `Type` twice. The plugin registry's duplicate
-branch keeps whichever it saw first and logs at `debug`, and the drift check —
-keyed by the same `Type` name — collapses the pair before it compares, so the
-failure is silent at both seams. It is refused at the scan instead, proven two
+both of derive one `processors:` entry between them: the section keeps only the
+`Type` segment, so the entry that ships is whichever arm the walk reached first,
+and the drift check — keyed by that same name — collapses the pair before it
+compares. The failure is silent at both seams. It is refused at the scan instead, proven two
 independent ways. The target-resolved walk needs no reasoning: it resolved one
 concrete target and collected the name twice. The across-every-target walk
 brute-forces satisfiability of the two arms' conjoined predicates over only the
@@ -199,10 +199,13 @@ are authored rather than derived, while divergence compares two pieces of code
 that must derive the same entry. Port and execution differences are named by the
 same comparator the drift report uses, generalized from "manifest vs code" to a
 labelled two-sided comparison — one diagnostic with two callers, not two copies.
-Grouping is by `Type` name rather than the full identity because that is the key
-the registry keys registration on, so two arms sharing a `Type` under different
-`@org/package` collide there and surface here as a divergence rather than
-passing as two unrelated processors.
+Grouping is by `Type` name rather than the full identity because that is the
+only segment the derived entry keeps: the attribute's `@org/package` is dropped,
+and at load the runtime composes each processor's structured ident from the
+package's own org / name plus the short name. Two arms sharing a `Type` fold
+into one manifest entry and one composed ident whatever `@org/package` their
+attributes named, so they surface here as a divergence rather than passing as
+two unrelated processors.
 
 **A gap is not an error — it is availability.** A package that declares a
 processor on some targets and on none of the others is ordinary. Which targets

--- a/docs/decisions/manifest-extraction-capability.md
+++ b/docs/decisions/manifest-extraction-capability.md
@@ -166,15 +166,27 @@ independent ways. The target-resolved walk needs no reasoning: it resolved one
 concrete target and collected the name twice. The across-every-target walk
 brute-forces satisfiability of the two arms' conjoined predicates over only the
 atoms those predicates themselves mention, and refuses **only on a satisfying
-assignment it can print**. That search carries a deliberate domain model — every
-`target_*` key is single-valued except the genuinely set-valued `feature` /
-`target_feature` / `target_has_atomic`, and the `unix` / `windows` families are
-mutually exclusive with `windows` holding exactly one `target_os`. Without it,
-`target_os = "linux"` against `any(target_os = "macos", target_os = "ios")`
-reads satisfiable and every platform-split package fails its own build. The
-model's rules are facts about how `rustc` sets these atoms, so each one can only
-ever remove a FALSE overlap; the cost of being wrong in the other direction — a
-missed detection — is bounded by the concrete-target net.
+assignment it can print**. That search carries a deliberate domain model of how
+`rustc` sets these atoms: `target_*` keys are modelled single-valued except
+`feature` / `target_feature` / `target_has_atomic`; the `unix` / `windows`
+families are mutually exclusive, spelled interchangeably as a bare flag or a
+`target_family` value, with `windows` holding exactly one `target_os`; and a
+known `target_os` fixes the families its target defines, both ways. Without the
+first rule, `target_os = "linux"` against `any(target_os = "macos", target_os =
+"ios")` reads satisfiable and every platform-split package fails its own build.
+Without the last, `target_os = "ios"` against `not(unix)` reads satisfiable and
+a platform split with a non-unix fallback arm fails the same way.
+
+**The model's error direction is toward missing an overlap, never inventing
+one.** Every rule and every fact the model lacks PRUNES candidate assignments,
+so a witness is only ever offered when the model can say the assignment is one a
+real target could have. Two facts it deliberately lacks: `target_family` is
+genuinely multi-valued on the wasm-with-libc targets (`wasi` and `emscripten`
+are both `wasm` and `unix`) yet is modelled single-valued, and the `target_os` →
+family table names only single-family OSes. A `target_os` outside that table
+therefore cannot witness anything weighed against a family atom — it is left
+unproven rather than guessed. The cost of a missed detection is bounded by the
+concrete-target net: the host that actually compiles both arms still fails.
 
 **Divergence is refused over the whole derived projection, not just ports.** The
 `processors:` section is derived from whichever arm the publishing host

--- a/docs/decisions/manifest-extraction-capability.md
+++ b/docs/decisions/manifest-extraction-capability.md
@@ -122,6 +122,13 @@ artifact and does not re-run it.
 - **Extraction only inside `streamlib-pack`.** Pack is the natural consumer,
   but the grammar must also be shared with the proc-macro, and a future
   live-submit path needs the extractor without the whole pack crate.
+- **`cfg-expr` / `target-lexicon` for the overlap search.** They ship the target
+  coherence rules as data rather than the hand-written model below. Neither is
+  in the tree today, so adopting one is a new-dependency decision for a build-
+  seam crate that currently pulls only `syn` / `quote` / `toml` — and the model
+  needs one more thing than either provides: an explicit "this fact is unknown,
+  leave the pair unproven" answer, which is what keeps the refusal sound. Worth
+  revisiting if the coherence rules grow past target families.
 
 ## Consequences
 
@@ -230,4 +237,14 @@ enables, so the processor evaluates false and leaves the derived set. It bites
 one seam later as a confusing drift error ("listed in `processors:` but no
 longer declared in code"), so the walk warns at the prune site with the file,
 the predicate and the undefined feature rather than leaving the absence
-unexplained.
+unexplained. The warning is raised only where a `#[processor(...)]` really left
+the set — the prune site re-walks what it pruned with cfg resolution off and
+stays silent for a feature-gated helper module, whose absence explains nothing.
+
+Both refusals reach a package through crate-root generation, so they gate every
+build and every `pkg publish` of a package that DECLARES a generated crate root.
+A package that commits its own crate root (the one in-tree host rlib) is scanned
+across targets only by the extractor's own tests: cross-target divergence there
+would surface on a host that compiles both arms rather than at generation. That
+exposure follows from generation being opt-in, and is accepted rather than
+worked around with a second discovery path.

--- a/docs/decisions/manifest-extraction-capability.md
+++ b/docs/decisions/manifest-extraction-capability.md
@@ -124,11 +124,12 @@ artifact and does not re-run it.
   live-submit path needs the extractor without the whole pack crate.
 - **`cfg-expr` / `target-lexicon` for the overlap search.** They ship the target
   coherence rules as data rather than the hand-written model below. Neither is
-  in the tree today, so adopting one is a new-dependency decision for a build-
-  seam crate that currently pulls only `syn` / `quote` / `toml` — and the model
-  needs one more thing than either provides: an explicit "this fact is unknown,
-  leave the pair unproven" answer, which is what keeps the refusal sound. Worth
-  revisiting if the coherence rules grow past target families.
+  in the tree today, so adopting one is a new-dependency decision for a
+  build-seam crate that currently pulls only `syn` / `quote` / `toml` — and the
+  model needs one more thing than either provides: an explicit "this fact is
+  unknown, leave the pair unproven" answer, which is what keeps the refusal
+  sound. Worth revisiting if the coherence rules grow past the target-atom
+  cluster the model relates today.
 
 ## Consequences
 
@@ -166,34 +167,43 @@ scan; the third is the datum the scan now produces.
 
 **Overlap is refused, with a witness.** Two arms some build target compiles
 both of derive one `processors:` entry between them: the section keeps only the
-`Type` segment, so the entry that ships is whichever arm the walk reached first,
-and the drift check — keyed by that same name — collapses the pair before it
-compares. The failure is silent at both seams. It is refused at the scan instead, proven two
-independent ways. The target-resolved walk needs no reasoning: it resolved one
-concrete target and collected the name twice. The across-every-target walk
-brute-forces satisfiability of the two arms' conjoined predicates over only the
-atoms those predicates themselves mention, and refuses **only on a satisfying
-assignment it can print**. That search carries a deliberate domain model of how
-`rustc` sets these atoms: `target_*` keys are modelled single-valued except
-`feature` / `target_feature` / `target_has_atomic`; the `unix` / `windows`
-families are mutually exclusive, spelled interchangeably as a bare flag or a
-`target_family` value, with `windows` holding exactly one `target_os`; and a
-known `target_os` fixes the families its target defines, both ways. Without the
-first rule, `target_os = "linux"` against `any(target_os = "macos", target_os =
-"ios")` reads satisfiable and every platform-split package fails its own build.
-Without the last, `target_os = "ios"` against `not(unix)` reads satisfiable and
-a platform split with a non-unix fallback arm fails the same way.
+`Type` segment, so the entry that ships is whichever arm the walk reached
+first, and the drift check — keyed by that same name — collapses the pair
+before it compares. The failure is silent at both seams. It is refused at the
+scan instead, proven two independent ways. The target-resolved walk needs no
+reasoning: it resolved one concrete target and collected the name twice. The
+across-every-target walk brute-forces satisfiability of the two arms' conjoined
+predicates over only the atoms those predicates themselves mention, and refuses
+**only on a satisfying assignment it can print**. That search carries a
+deliberate domain model of how `rustc` sets these atoms: `target_*` keys are
+modelled single-valued except `feature` / `target_feature` /
+`target_has_atomic`; the `unix` / `windows` families are mutually exclusive,
+spelled interchangeably as a bare flag or a `target_family` value, with
+`windows` holding exactly one `target_os`; and a known `target_os` fixes the
+families its target defines, both ways. Without the first rule, `target_os =
+"linux"` against `any(target_os = "macos", target_os = "ios")` reads
+satisfiable and every platform-split package fails its own build. Without the
+last, `target_os = "ios"` against `not(unix)` reads satisfiable and a platform
+split with a non-unix fallback arm fails the same way.
 
-**The model's error direction is toward missing an overlap, never inventing
-one.** Every rule and every fact the model lacks PRUNES candidate assignments,
-so a witness is only ever offered when the model can say the assignment is one a
-real target could have. Two facts it deliberately lacks: `target_family` is
-genuinely multi-valued on the wasm-with-libc targets (`wasi` and `emscripten`
-are both `wasm` and `unix`) yet is modelled single-valued, and the `target_os` →
-family table names only single-family OSes. A `target_os` outside that table
-therefore cannot witness anything weighed against a family atom — it is left
-unproven rather than guessed. The cost of a missed detection is bounded by the
-concrete-target net: the host that actually compiles both arms still fails.
+**The model relates one cluster of target atoms, and prunes rather than
+guesses outside it.** The cluster is `target_os`, `target_family` and the bare `unix` /
+`windows` flags. `rustc` fixes every other target key against those and against
+one another too — no target is both `target_env = "msvc"` and `target_os =
+"linux"`, none is both `target_arch = "wasm32"` and `target_env = "msvc"`, no
+`target_vendor = "apple"` target is `not(unix)` — and the model holds none of
+those facts, so an assignment that pins a key from outside the cluster while a
+second target atom is decided is dropped instead of printed as a proof. Inside
+the cluster the same discipline applies to what the rules cannot decide: a
+`target_os` outside the OS → family table decides nothing about families, and
+a `target_family` outside `unix` / `windows` defines neither flag, which
+deliberately drops `wasi` (genuinely both `wasm` and `unix`, the multi-valued
+case single-valued modelling gives up). Every rule and every gap therefore
+prunes, so the error direction is toward missing an overlap rather than
+inventing one — on the single assumption the model cannot check, that a value
+a predicate names is a value some target defines. The cost of a missed
+detection is bounded by the concrete-target net: the host that actually
+compiles both arms still fails.
 
 **Divergence is refused over the whole derived projection, not just ports.** The
 `processors:` section is derived from whichever arm the publishing host
@@ -203,16 +213,16 @@ config binding — makes the shipped manifest host-dependent. That is a wider
 surface than the language-uniform drift surface above, deliberately: drift
 compares a *hand-authored* manifest against *code*, where the excluded fields
 are authored rather than derived, while divergence compares two pieces of code
-that must derive the same entry. Port and execution differences are named by the
-same comparator the drift report uses, generalized from "manifest vs code" to a
-labelled two-sided comparison — one diagnostic with two callers, not two copies.
-Grouping is by `Type` name rather than the full identity because that is the
-only segment the derived entry keeps: the attribute's `@org/package` is dropped,
-and at load the runtime composes each processor's structured ident from the
-package's own org / name plus the short name. Two arms sharing a `Type` fold
-into one manifest entry and one composed ident whatever `@org/package` their
-attributes named, so they surface here as a divergence rather than passing as
-two unrelated processors.
+that must derive the same entry. Port and execution differences are named by
+the same comparator the drift report uses, generalized from "manifest vs code"
+to a labelled two-sided comparison — one diagnostic with two callers, not two
+copies. Grouping is by `Type` name rather than the full identity because that
+is the only segment the derived entry keeps: the attribute's `@org/package` is
+dropped, and at load the runtime composes each processor's structured ident
+from the package's own org / name plus the short name. Two arms sharing a
+`Type` fold into one manifest entry and one composed ident whatever
+`@org/package` their attributes named, so they surface here as a divergence
+rather than passing as two unrelated processors.
 
 **A gap is not an error — it is availability.** A package that declares a
 processor on some targets and on none of the others is ordinary. Which targets

--- a/packages/camera/processors/camera_to_cuda_copy.rs
+++ b/packages/camera/processors/camera_to_cuda_copy.rs
@@ -102,7 +102,7 @@ struct LinuxCudaCopyGpuResources {
 // only path that flows external config through to the processor.)
 #[streamlib_plugin_sdk::sdk::processor(
     "@tatolab/camera/CameraToCudaCopy",
-    description = "Host-pipeline producer: camera VkImage -> cuda OPAQUE_FD VkBuffer with timeline signal for cross-API CUDA interop. Linux-only (CUDA is Linux-only on the in-tree adapter set).",
+    description = "Host-pipeline producer: camera VkImage -> cuda OPAQUE_FD VkBuffer with timeline signal for cross-API CUDA interop. Declared on every target; the CUDA interop path is Linux-only on the in-tree adapter set, so setup() fails elsewhere.",
     execution = reactive,
     scheduling = high,
     config = crate::_generated_::CameraToCudaCopyConfig,

--- a/packages/camera/processors/camera_to_cuda_copy.rs
+++ b/packages/camera/processors/camera_to_cuda_copy.rs
@@ -103,7 +103,7 @@ struct LinuxCudaCopyGpuResources {
 // only path that flows external config through to the processor.)
 #[streamlib_plugin_sdk::sdk::processor(
     "@tatolab/camera/CameraToCudaCopy",
-    description = "Host-pipeline producer: camera VkImage -> cuda OPAQUE_FD VkBuffer with timeline signal for cross-API CUDA interop. Declared on every target; the CUDA interop path is Linux-only on the in-tree adapter set, so setup() fails elsewhere.",
+    description = "Host-pipeline producer: camera VkImage -> cuda OPAQUE_FD VkBuffer with timeline signal for cross-API CUDA interop. The CUDA interop path is Linux-only on the in-tree adapter set, so setup() returns a configuration error elsewhere.",
     execution = reactive,
     scheduling = high,
     config = crate::_generated_::CameraToCudaCopyConfig,

--- a/packages/camera/processors/camera_to_cuda_copy.rs
+++ b/packages/camera/processors/camera_to_cuda_copy.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Camera → CUDA host-pipeline copy processor (Linux only).
+//! Camera → CUDA host-pipeline copy processor.
 //!
 //! Drops the CPU staging hop for any consumer that wants the camera
 //! frame as a GPU-resident CUDA tensor (e.g. PyTorch / JAX inference,
@@ -22,9 +22,10 @@
 //! the lifecycle binding to a single processor instance is what
 //! guarantees the cuda surface never outlives its producer.
 //!
-//! Linux-only. CUDA is Linux-only on the in-tree adapter set;
-//! macOS / iOS builds compile a no-op stub that returns a
-//! configuration error from `setup()`.
+//! Declared on every build target — the struct carries no `#[cfg]`,
+//! only its fields and internals do. CUDA is Linux-only on the
+//! in-tree adapter set, so macOS / iOS builds compile a no-op stub
+//! that returns a configuration error from `setup()`.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use streamlib_plugin_sdk::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};

--- a/packages/camera/streamlib.yaml
+++ b/packages/camera/streamlib.yaml
@@ -39,7 +39,7 @@ processors:
     description: Live video frames from the camera
     delivery_profile: null
 - name: CameraToCudaCopy
-  description: 'Host-pipeline producer: camera VkImage -> cuda OPAQUE_FD VkBuffer with timeline signal for cross-API CUDA interop. Linux-only (CUDA is Linux-only on the in-tree adapter set).'
+  description: 'Host-pipeline producer: camera VkImage -> cuda OPAQUE_FD VkBuffer with timeline signal for cross-API CUDA interop. Declared on every target; the CUDA interop path is Linux-only on the in-tree adapter set, so setup() fails elsewhere.'
   runtime: rust
   entrypoint: null
   execution: reactive

--- a/packages/camera/streamlib.yaml
+++ b/packages/camera/streamlib.yaml
@@ -39,7 +39,7 @@ processors:
     description: Live video frames from the camera
     delivery_profile: null
 - name: CameraToCudaCopy
-  description: 'Host-pipeline producer: camera VkImage -> cuda OPAQUE_FD VkBuffer with timeline signal for cross-API CUDA interop. Declared on every target; the CUDA interop path is Linux-only on the in-tree adapter set, so setup() fails elsewhere.'
+  description: 'Host-pipeline producer: camera VkImage -> cuda OPAQUE_FD VkBuffer with timeline signal for cross-API CUDA interop. The CUDA interop path is Linux-only on the in-tree adapter set, so setup() returns a configuration error elsewhere.'
   runtime: rust
   entrypoint: null
   execution: reactive

--- a/sdk/streamlib-processor-extract/Cargo.toml
+++ b/sdk/streamlib-processor-extract/Cargo.toml
@@ -28,6 +28,9 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 serde_yaml = { workspace = true }
+# The scan's prune diagnostics are asserted on, not just logged — a captured
+# subscriber is what makes a `tracing::warn!` a testable contract.
+tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true

--- a/sdk/streamlib-processor-extract/src/crate_root.rs
+++ b/sdk/streamlib-processor-extract/src/crate_root.rs
@@ -33,8 +33,8 @@ use streamlib_idents::PACKAGE_PROCESSOR_SOURCE_DIR_NAME as PROCESSOR_SOURCE_DIR_
 
 use crate::reachable::{
     ProcessorSetAcrossEveryBuildTarget, ProcessorSourceModuleArm, conjoin_cfg_predicates,
-    disjoin_distinct_cfg_predicates, enumerate_processor_source_module_arms,
-    extract_processors_across_every_build_target,
+    disjoin_cfg_predicates_when_every_alternative_is_conditional,
+    enumerate_processor_source_module_arms, extract_processors_across_every_build_target,
 };
 use crate::{ExtractError, ExtractedProcessor};
 
@@ -477,12 +477,12 @@ fn render_plugin_export_envelope(
 /// The `#[cfg(...)]` the whole `export_plugin!` invocation carries, or `None`
 /// when at least one processor is available unconditionally.
 fn plugin_export_envelope_gate(processors: &ProcessorSetAcrossEveryBuildTarget) -> Option<String> {
-    let availability_predicates: Option<Vec<&str>> = processors
-        .processor_availability
-        .iter()
-        .map(|entry| entry.availability_cfg_predicate.as_deref())
-        .collect();
-    Some(disjoin_distinct_cfg_predicates(availability_predicates?))
+    disjoin_cfg_predicates_when_every_alternative_is_conditional(
+        processors
+            .processor_availability
+            .iter()
+            .map(|entry| entry.availability_cfg_predicate.as_deref()),
+    )
 }
 
 /// The path an `export_plugin!` entry names: the module path from the crate

--- a/sdk/streamlib-processor-extract/src/crate_root.rs
+++ b/sdk/streamlib-processor-extract/src/crate_root.rs
@@ -32,7 +32,8 @@ use std::path::{Path, PathBuf};
 use streamlib_idents::PACKAGE_PROCESSOR_SOURCE_DIR_NAME as PROCESSOR_SOURCE_DIR_NAME;
 
 use crate::reachable::{
-    ProcessorSourceModuleArm, enumerate_processor_source_module_arms,
+    ProcessorSetAcrossEveryBuildTarget, ProcessorSourceModuleArm, conjoin_cfg_predicates,
+    disjoin_distinct_cfg_predicates, enumerate_processor_source_module_arms,
     extract_processors_across_every_build_target,
 };
 use crate::{ExtractError, ExtractedProcessor};
@@ -302,7 +303,7 @@ pub fn generate_rust_crate_root_source(
     let processors = if request.emits_plugin_export_envelope {
         extract_processors_across_every_build_target(request.package_dir)?
     } else {
-        Vec::new()
+        ProcessorSetAcrossEveryBuildTarget::default()
     };
 
     let mut source = String::new();
@@ -331,7 +332,7 @@ pub fn generate_rust_crate_root_source(
     if request.emits_plugin_export_envelope
         && let Some(envelope) = render_plugin_export_envelope(&processors)
     {
-        exported_processor_entry_count = processors.len();
+        exported_processor_entry_count = processors.processor_declarations.len();
         source.push('\n');
         source.push_str(&envelope);
     }
@@ -445,61 +446,43 @@ fn render_module_arm_declaration(arm: &ProcessorSourceModuleArm) -> String {
 /// processor on any target (a cdylib whose only arm is parked ships no
 /// `STREAMLIB_PLUGIN` symbol, which is what it did before folder-backed
 /// discovery too).
-fn render_plugin_export_envelope(processors: &[ExtractedProcessor]) -> Option<String> {
-    if processors.is_empty() {
+fn render_plugin_export_envelope(
+    processors: &ProcessorSetAcrossEveryBuildTarget,
+) -> Option<String> {
+    if processors.processor_declarations.is_empty() {
         return None;
     }
-
-    let entries: Vec<(Option<String>, String)> = processors
-        .iter()
-        .map(|processor| {
-            (
-                conjoin_cfg_predicates(&processor.cfg_predicates),
-                processor_export_type_path(processor),
-            )
-        })
-        .collect();
 
     let mut out = String::new();
     // The declaration must not be emitted on a target that compiles none of
     // these entries: `export_plugin!` anchors its fingerprint on the first
-    // surviving entry, and an all-stripped invocation is a compile error. An
-    // unconditional entry makes the gate unnecessary.
-    if entries.iter().all(|(predicate, _)| predicate.is_some()) {
-        let mut distinct: Vec<&str> = Vec::new();
-        for predicate in entries
-            .iter()
-            .filter_map(|(predicate, _)| predicate.as_deref())
-        {
-            if !distinct.contains(&predicate) {
-                distinct.push(predicate);
-            }
-        }
-        let gate = match distinct.as_slice() {
-            [single] => (*single).to_string(),
-            many => format!("any({})", many.join(", ")),
-        };
+    // surviving entry, and an all-stripped invocation is a compile error. The
+    // gate is therefore "some processor is available here", which is exactly the
+    // disjunction of the per-processor availability predicates — an
+    // unconditionally-available processor makes it unnecessary.
+    if let Some(gate) = plugin_export_envelope_gate(processors) {
         let _ = writeln!(out, "#[cfg({gate})]");
     }
     out.push_str("streamlib_plugin_abi::export_plugin!(\n");
-    for (predicate, type_path) in &entries {
-        if let Some(predicate) = predicate {
+    for processor in &processors.processor_declarations {
+        if let Some(predicate) = conjoin_cfg_predicates(&processor.cfg_predicates) {
             let _ = writeln!(out, "    #[cfg({predicate})]");
         }
-        let _ = writeln!(out, "    {type_path},");
+        let _ = writeln!(out, "    {},", processor_export_type_path(processor));
     }
     out.push_str(");\n");
     Some(out)
 }
 
-/// Fold the `#[cfg]` predicates in force at a processor into one predicate.
-/// Several nested predicates are ANDed the way `rustc` applies them.
-fn conjoin_cfg_predicates(predicates: &[String]) -> Option<String> {
-    match predicates {
-        [] => None,
-        [single] => Some(single.clone()),
-        many => Some(format!("all({})", many.join(", "))),
-    }
+/// The `#[cfg(...)]` the whole `export_plugin!` invocation carries, or `None`
+/// when at least one processor is available unconditionally.
+fn plugin_export_envelope_gate(processors: &ProcessorSetAcrossEveryBuildTarget) -> Option<String> {
+    let availability_predicates: Option<Vec<&str>> = processors
+        .processor_availability
+        .iter()
+        .map(|entry| entry.availability_cfg_predicate.as_deref())
+        .collect();
+    Some(disjoin_distinct_cfg_predicates(availability_predicates?))
 }
 
 /// The path an `export_plugin!` entry names: the module path from the crate

--- a/sdk/streamlib-processor-extract/src/derive.rs
+++ b/sdk/streamlib-processor-extract/src/derive.rs
@@ -724,7 +724,7 @@ const DERIVED_FROM_CODE_SURFACE_LABEL: &str = "code";
 /// meaningful between two `processors/` arms declaring one processor id, where
 /// neither side is "the manifest" — see
 /// [`describe_divergent_processor_declarations`].
-pub fn describe_processor_surface_difference(
+pub(crate) fn describe_processor_surface_difference(
     processor_type_name: &str,
     left_label: &str,
     left: &ProcessorSurface,

--- a/sdk/streamlib-processor-extract/src/derive.rs
+++ b/sdk/streamlib-processor-extract/src/derive.rs
@@ -680,7 +680,13 @@ pub fn check_processor_manifest_drift(
             None => only_in_code.push((*name).to_string()),
             Some(committed_surface) => {
                 if code_surface != committed_surface {
-                    differing.push(describe_difference(name, committed_surface, code_surface));
+                    differing.push(describe_processor_surface_difference(
+                        name,
+                        COMMITTED_MANIFEST_SURFACE_LABEL,
+                        committed_surface,
+                        DERIVED_FROM_CODE_SURFACE_LABEL,
+                        code_surface,
+                    ));
                 }
             }
         }
@@ -705,57 +711,169 @@ pub fn check_processor_manifest_drift(
     })
 }
 
-/// One-line description of how two surfaces of the same-named processor differ.
-fn describe_difference(name: &str, manifest: &ProcessorSurface, code: &ProcessorSurface) -> String {
-    if manifest.execution != code.execution {
+/// How the committed `processors:` side of a comparison is named in a
+/// difference line.
+const COMMITTED_MANIFEST_SURFACE_LABEL: &str = "`processors:`";
+/// How the code-derived side of a comparison is named in a difference line.
+const DERIVED_FROM_CODE_SURFACE_LABEL: &str = "code";
+
+/// One-line description of how two identity surfaces of the same-named
+/// processor differ, each side named by `left_label` / `right_label`.
+///
+/// Two-sided rather than manifest-vs-code because the same disagreement is
+/// meaningful between two `processors/` arms declaring one processor id, where
+/// neither side is "the manifest" — see
+/// [`describe_divergent_processor_declarations`].
+pub fn describe_processor_surface_difference(
+    processor_type_name: &str,
+    left_label: &str,
+    left: &ProcessorSurface,
+    right_label: &str,
+    right: &ProcessorSurface,
+) -> String {
+    let name = processor_type_name;
+    if left.execution != right.execution {
         return format!(
-            "`{name}` execution differs: `processors:` says {:?}, code declares {:?}",
-            manifest.execution, code.execution
+            "`{name}` execution differs: {left_label} declares {:?}, {right_label} declares {:?}",
+            left.execution, right.execution
         );
     }
-    let manifest_inputs = port_names(&manifest.inputs);
-    let code_inputs = port_names(&code.inputs);
-    if manifest_inputs != code_inputs {
+    let left_inputs = port_names(&left.inputs);
+    let right_inputs = port_names(&right.inputs);
+    if left_inputs != right_inputs {
         return format!(
-            "`{name}` input ports differ: `processors:` has [{}], code declares [{}]",
-            manifest_inputs.join(", "),
-            code_inputs.join(", ")
+            "`{name}` input ports differ: {left_label} declares [{}], {right_label} declares [{}]",
+            left_inputs.join(", "),
+            right_inputs.join(", ")
         );
     }
-    let manifest_outputs = port_names(&manifest.outputs);
-    let code_outputs = port_names(&code.outputs);
-    if manifest_outputs != code_outputs {
+    let left_outputs = port_names(&left.outputs);
+    let right_outputs = port_names(&right.outputs);
+    if left_outputs != right_outputs {
         return format!(
-            "`{name}` output ports differ: `processors:` has [{}], code declares [{}]",
-            manifest_outputs.join(", "),
-            code_outputs.join(", ")
+            "`{name}` output ports differ: {left_label} declares [{}], {right_label} declares [{}]",
+            left_outputs.join(", "),
+            right_outputs.join(", ")
         );
     }
     // Port names match on both sides, so the surfaces zip by position; the only
     // remaining difference is a port that kept its name but changed schema type.
     // Name the port and both types so the author knows exactly what moved.
-    let differing_port = manifest
+    let differing_port = left
         .inputs
         .iter()
-        .zip(&code.inputs)
-        .map(|(manifest_port, code_port)| ("input", manifest_port, code_port))
+        .zip(&right.inputs)
+        .map(|(left_port, right_port)| ("input", left_port, right_port))
         .chain(
-            manifest
-                .outputs
+            left.outputs
                 .iter()
-                .zip(&code.outputs)
-                .map(|(manifest_port, code_port)| ("output", manifest_port, code_port)),
+                .zip(&right.outputs)
+                .map(|(left_port, right_port)| ("output", left_port, right_port)),
         )
-        .find(|(_, manifest_port, code_port)| manifest_port.schema != code_port.schema);
-    if let Some((direction, manifest_port, code_port)) = differing_port {
+        .find(|(_, left_port, right_port)| left_port.schema != right_port.schema);
+    if let Some((direction, left_port, right_port)) = differing_port {
         return format!(
-            "`{name}` {direction} port `{}` schema type differs: `processors:` says {}, code declares {}",
-            manifest_port.name,
-            describe_port_schema(&manifest_port.schema),
-            describe_port_schema(&code_port.schema),
+            "`{name}` {direction} port `{}` schema type differs: {left_label} declares {}, \
+             {right_label} declares {}",
+            left_port.name,
+            describe_port_schema(&left_port.schema),
+            describe_port_schema(&right_port.schema),
         );
     }
-    format!("`{name}` port schema types differ between `processors:` and code")
+    format!("`{name}` port schema types differ between {left_label} and {right_label}")
+}
+
+/// How two `#[processor(...)]` declarations sharing one `Type` name disagree,
+/// or `None` when they derive byte-identical manifest entries.
+///
+/// The comparison surface is the WHOLE derived projection — the full
+/// `@org/package/Type` identity, the [`ProcessorSchema`] the manifest entry is
+/// built from, and the config binding — not the lossy drift surface. A
+/// `processors:` section is derived from whichever arm the publishing host
+/// compiles, so a difference in any of those fields (not just ports) makes the
+/// shipped manifest host-dependent.
+pub(crate) fn describe_divergent_processor_declarations(
+    first: &ExtractedProcessor,
+    second: &ExtractedProcessor,
+) -> Option<String> {
+    let name = first.schema.name.as_str();
+    let first_label = first.source_file.display().to_string();
+    let second_label = second.source_file.display().to_string();
+
+    if first.schema_ident != second.schema_ident {
+        return Some(format!(
+            "`{name}` identity differs: {first_label} declares `{}`, {second_label} declares `{}`",
+            first.schema_ident, second.schema_ident
+        ));
+    }
+
+    let first_surface = ProcessorSurface::from_extracted(first);
+    let second_surface = ProcessorSurface::from_extracted(second);
+    if first_surface != second_surface {
+        return Some(describe_processor_surface_difference(
+            name,
+            &first_label,
+            &first_surface,
+            &second_label,
+            &second_surface,
+        ));
+    }
+
+    if first.config_schema_id != second.config_schema_id {
+        return Some(format!(
+            "`{name}` config binding differs: {first_label} declares {}, {second_label} declares {}",
+            describe_optional_config_schema_id(first.config_schema_id.as_deref()),
+            describe_optional_config_schema_id(second.config_schema_id.as_deref()),
+        ));
+    }
+
+    // Everything the identity surface deliberately drops — description,
+    // scheduling, `unsafe_send`, state — still lands in the derived manifest
+    // entry verbatim, so the two projections are compared whole. Serialized
+    // rather than field-by-field so a field added to `ProcessorSchema` is
+    // covered without an edit here.
+    let first_projection = serde_json::to_value(&first.schema).ok()?;
+    let second_projection = serde_json::to_value(&second.schema).ok()?;
+    if first_projection == second_projection {
+        return None;
+    }
+    let differing_fields = differing_manifest_projection_field_names(
+        first_projection.as_object()?,
+        second_projection.as_object()?,
+    );
+    Some(format!(
+        "`{name}` manifest entries differ in {}: {first_label} and {second_label} derive \
+         different `processors:` entries",
+        differing_fields.join(", ")
+    ))
+}
+
+/// The `processors:` entry fields two whole-projection JSON objects disagree
+/// on, backtick-quoted and sorted.
+fn differing_manifest_projection_field_names(
+    first: &serde_json::Map<String, serde_json::Value>,
+    second: &serde_json::Map<String, serde_json::Value>,
+) -> Vec<String> {
+    let mut names: BTreeSet<String> = BTreeSet::new();
+    for (field, value) in first {
+        if second.get(field) != Some(value) {
+            names.insert(format!("`{field}`"));
+        }
+    }
+    for field in second.keys() {
+        if !first.contains_key(field) {
+            names.insert(format!("`{field}`"));
+        }
+    }
+    names.into_iter().collect()
+}
+
+/// Render a processor's optional config-schema binding for a difference line.
+fn describe_optional_config_schema_id(config_schema_id: Option<&str>) -> String {
+    match config_schema_id {
+        None => "no config".to_string(),
+        Some(id) => format!("`{id}`"),
+    }
 }
 
 fn port_names(ports: &[PortSurface]) -> Vec<String> {
@@ -1279,9 +1397,46 @@ processors:
             outputs: vec![],
         };
 
-        let message = describe_difference("Mixer", &manifest, &code);
+        let message = describe_processor_surface_difference(
+            "Mixer",
+            COMMITTED_MANIFEST_SURFACE_LABEL,
+            &manifest,
+            DERIVED_FROM_CODE_SURFACE_LABEL,
+            &code,
+        );
         assert!(message.contains("input port `frame`"), "{message}");
-        assert!(message.contains("VideoFrame"), "{message}");
-        assert!(message.contains("AudioFrame"), "{message}");
+        assert!(
+            message.contains("`processors:` declares `VideoFrame`"),
+            "{message}"
+        );
+        assert!(message.contains("code declares `AudioFrame`"), "{message}");
+    }
+
+    /// The same comparator, given two `processors/` arm labels instead of
+    /// manifest-vs-code, names the arms rather than "`processors:`" / "code".
+    /// One diagnostic serves both callers; a second copy would drift.
+    #[test]
+    fn the_surface_comparator_names_whichever_two_sides_it_is_given() {
+        let surface = |execution| ProcessorSurface {
+            name: "AudioCapture".to_string(),
+            execution,
+            inputs: vec![],
+            outputs: vec![],
+        };
+        let message = describe_processor_surface_difference(
+            "AudioCapture",
+            "processors/linux/audio_capture.rs",
+            &surface(ProcessorSchemaExecution::Manual),
+            "processors/apple/audio_capture.rs",
+            &surface(ProcessorSchemaExecution::Reactive),
+        );
+        assert!(
+            message.contains("processors/linux/audio_capture.rs declares Manual"),
+            "{message}"
+        );
+        assert!(
+            message.contains("processors/apple/audio_capture.rs declares Reactive"),
+            "{message}"
+        );
     }
 }

--- a/sdk/streamlib-processor-extract/src/derive.rs
+++ b/sdk/streamlib-processor-extract/src/derive.rs
@@ -682,10 +682,14 @@ pub fn check_processor_manifest_drift(
                 if code_surface != committed_surface {
                     differing.push(describe_processor_surface_difference(
                         name,
-                        COMMITTED_MANIFEST_SURFACE_LABEL,
-                        committed_surface,
-                        DERIVED_FROM_CODE_SURFACE_LABEL,
-                        code_surface,
+                        ProcessorSurfaceWithDiagnosticLabel {
+                            diagnostic_label: COMMITTED_MANIFEST_SURFACE_LABEL,
+                            processor_surface: committed_surface,
+                        },
+                        ProcessorSurfaceWithDiagnosticLabel {
+                            diagnostic_label: DERIVED_FROM_CODE_SURFACE_LABEL,
+                            processor_surface: code_surface,
+                        },
                     ));
                 }
             }
@@ -717,8 +721,18 @@ const COMMITTED_MANIFEST_SURFACE_LABEL: &str = "`processors:`";
 /// How the code-derived side of a comparison is named in a difference line.
 const DERIVED_FROM_CODE_SURFACE_LABEL: &str = "code";
 
+/// One side of a two-sided surface comparison, bound to the label the
+/// diagnostic names it by — a label cannot travel with the other side's
+/// surface.
+pub(crate) struct ProcessorSurfaceWithDiagnosticLabel<'comparison> {
+    /// How this side is named in a difference line.
+    pub diagnostic_label: &'comparison str,
+    /// The surface this side declares.
+    pub processor_surface: &'comparison ProcessorSurface,
+}
+
 /// One-line description of how two identity surfaces of the same-named
-/// processor differ, each side named by `left_label` / `right_label`.
+/// processor differ, each side named by its own label.
 ///
 /// Two-sided rather than manifest-vs-code because the same disagreement is
 /// meaningful between two `processors/` arms declaring one processor id, where
@@ -726,12 +740,12 @@ const DERIVED_FROM_CODE_SURFACE_LABEL: &str = "code";
 /// [`describe_divergent_processor_declarations`].
 pub(crate) fn describe_processor_surface_difference(
     processor_type_name: &str,
-    left_label: &str,
-    left: &ProcessorSurface,
-    right_label: &str,
-    right: &ProcessorSurface,
+    left: ProcessorSurfaceWithDiagnosticLabel<'_>,
+    right: ProcessorSurfaceWithDiagnosticLabel<'_>,
 ) -> String {
     let name = processor_type_name;
+    let (left_label, left) = (left.diagnostic_label, left.processor_surface);
+    let (right_label, right) = (right.diagnostic_label, right.processor_surface);
     if left.execution != right.execution {
         return format!(
             "`{name}` execution differs: {left_label} declares {:?}, {right_label} declares {:?}",
@@ -812,10 +826,14 @@ pub(crate) fn describe_divergent_processor_declarations(
     if first_surface != second_surface {
         return Some(describe_processor_surface_difference(
             name,
-            &first_label,
-            &first_surface,
-            &second_label,
-            &second_surface,
+            ProcessorSurfaceWithDiagnosticLabel {
+                diagnostic_label: &first_label,
+                processor_surface: &first_surface,
+            },
+            ProcessorSurfaceWithDiagnosticLabel {
+                diagnostic_label: &second_label,
+                processor_surface: &second_surface,
+            },
         ));
     }
 
@@ -832,19 +850,37 @@ pub(crate) fn describe_divergent_processor_declarations(
     // entry verbatim, so the two projections are compared whole. Serialized
     // rather than field-by-field so a field added to `ProcessorSchema` is
     // covered without an edit here.
-    let first_projection = serde_json::to_value(&first.schema).ok()?;
-    let second_projection = serde_json::to_value(&second.schema).ok()?;
+    //
+    // `None` is read by the caller as "these two arms agree" and passes a build
+    // gate, so no branch below may return it without having compared: a
+    // projection that will not serialize is reported as a difference, not as
+    // agreement.
+    let (Ok(first_projection), Ok(second_projection)) = (
+        serde_json::to_value(&first.schema),
+        serde_json::to_value(&second.schema),
+    ) else {
+        return Some(format!(
+            "`{name}` manifest entries could not be compared: {first_label} and {second_label} \
+             derive `processors:` entries that do not serialize"
+        ));
+    };
     if first_projection == second_projection {
         return None;
     }
-    let differing_fields = differing_manifest_projection_field_names(
-        first_projection.as_object()?,
-        second_projection.as_object()?,
-    );
-    Some(format!(
-        "`{name}` manifest entries differ in {}: {first_label} and {second_label} derive \
-         different `processors:` entries",
+    let differing_fields = match (first_projection.as_object(), second_projection.as_object()) {
+        (Some(first_fields), Some(second_fields)) => {
+            differing_manifest_projection_field_names(first_fields, second_fields)
+        }
+        _ => Vec::new(),
+    };
+    let differing_fields = if differing_fields.is_empty() {
+        "an unnamed field".to_string()
+    } else {
         differing_fields.join(", ")
+    };
+    Some(format!(
+        "`{name}` manifest entries differ in {differing_fields}: {first_label} and \
+         {second_label} derive different `processors:` entries"
     ))
 }
 
@@ -1399,10 +1435,14 @@ processors:
 
         let message = describe_processor_surface_difference(
             "Mixer",
-            COMMITTED_MANIFEST_SURFACE_LABEL,
-            &manifest,
-            DERIVED_FROM_CODE_SURFACE_LABEL,
-            &code,
+            ProcessorSurfaceWithDiagnosticLabel {
+                diagnostic_label: COMMITTED_MANIFEST_SURFACE_LABEL,
+                processor_surface: &manifest,
+            },
+            ProcessorSurfaceWithDiagnosticLabel {
+                diagnostic_label: DERIVED_FROM_CODE_SURFACE_LABEL,
+                processor_surface: &code,
+            },
         );
         assert!(message.contains("input port `frame`"), "{message}");
         assert!(
@@ -1425,10 +1465,14 @@ processors:
         };
         let message = describe_processor_surface_difference(
             "AudioCapture",
-            "processors/linux/audio_capture.rs",
-            &surface(ProcessorSchemaExecution::Manual),
-            "processors/apple/audio_capture.rs",
-            &surface(ProcessorSchemaExecution::Reactive),
+            ProcessorSurfaceWithDiagnosticLabel {
+                diagnostic_label: "processors/linux/audio_capture.rs",
+                processor_surface: &surface(ProcessorSchemaExecution::Manual),
+            },
+            ProcessorSurfaceWithDiagnosticLabel {
+                diagnostic_label: "processors/apple/audio_capture.rs",
+                processor_surface: &surface(ProcessorSchemaExecution::Reactive),
+            },
         );
         assert!(
             message.contains("processors/linux/audio_capture.rs declares Manual"),

--- a/sdk/streamlib-processor-extract/src/derive.rs
+++ b/sdk/streamlib-processor-extract/src/derive.rs
@@ -1466,20 +1466,20 @@ processors:
         let message = describe_processor_surface_difference(
             "AudioCapture",
             ProcessorSurfaceWithDiagnosticLabel {
-                diagnostic_label: "processors/linux/audio_capture.rs",
+                diagnostic_label: "processors/audio_capture_linux.rs",
                 processor_surface: &surface(ProcessorSchemaExecution::Manual),
             },
             ProcessorSurfaceWithDiagnosticLabel {
-                diagnostic_label: "processors/apple/audio_capture.rs",
+                diagnostic_label: "processors/audio_capture_apple.rs",
                 processor_surface: &surface(ProcessorSchemaExecution::Reactive),
             },
         );
         assert!(
-            message.contains("processors/linux/audio_capture.rs declares Manual"),
+            message.contains("processors/audio_capture_linux.rs declares Manual"),
             "{message}"
         );
         assert!(
-            message.contains("processors/apple/audio_capture.rs declares Reactive"),
+            message.contains("processors/audio_capture_apple.rs declares Reactive"),
             "{message}"
         );
     }

--- a/sdk/streamlib-processor-extract/src/lib.rs
+++ b/sdk/streamlib-processor-extract/src/lib.rs
@@ -203,8 +203,9 @@ pub enum ExtractError {
     #[error(
         "processor `{processor_type_name}` is declared twice for one build target \
          ({witness_build_target_atoms}): {first_declared_in} and {second_declared_in} — \
-         that target compiles both arms and registers only the first; narrow one arm's \
-         `#[cfg(...)]` so the two are disjoint"
+         that target compiles both arms and derives one `processors:` entry from \
+         whichever the walk reached first; narrow one arm's `#[cfg(...)]` so the two \
+         are disjoint"
     )]
     OverlappingProcessorDeclarations {
         processor_type_name: String,

--- a/sdk/streamlib-processor-extract/src/lib.rs
+++ b/sdk/streamlib-processor-extract/src/lib.rs
@@ -37,7 +37,7 @@ pub(crate) mod scan_fixture_tempdir;
 use std::path::{Path, PathBuf};
 
 use streamlib_idents::PACKAGE_PROCESSOR_SOURCE_DIR_NAME as PROCESSOR_SOURCE_DIR_NAME;
-use streamlib_processor_schema::ProcessorSchema;
+use streamlib_processor_schema::{ProcessorSchema, SchemaIdent};
 
 pub use crate_root::{
     GeneratedCrateRootSource, RustCrateRootGenerationRequest, generate_rust_crate_root_source,
@@ -47,13 +47,16 @@ pub use derive::{
     DeriveError, DerivedProcessorSet, ExtractedManifestPort, ExtractedManifestProcessor,
     ManifestDriftReport, PackageLanguage, PortSchemaSurface, PortSurface, ProcessorSurface,
     SkippedLanguage, SubprocessProcessorExtractor, SystemSubprocessProcessorExtractor,
-    check_processor_manifest_drift, derive_package_processor_surfaces, detect_package_languages,
-    filter_committed_to_languages, parse_subprocess_manifest_json_full,
+    check_processor_manifest_drift, derive_package_processor_surfaces,
+    describe_processor_surface_difference, detect_package_languages, filter_committed_to_languages,
+    parse_subprocess_manifest_json_full,
 };
 pub use grammar::{ParsedPort, ParsedProcessorAttr};
 pub use reachable::{
-    ModuleReachabilityTarget, ProcessorSourceModuleArm, enumerate_processor_source_module_arms,
-    extract_processors_across_every_build_target, extract_reachable_rust_processors,
+    ModuleReachabilityTarget, ProcessorAvailabilityAcrossBuildTargets,
+    ProcessorSetAcrossEveryBuildTarget, ProcessorSourceModuleArm,
+    enumerate_processor_source_module_arms, extract_processors_across_every_build_target,
+    extract_reachable_rust_processors,
 };
 
 /// One processor derived from a `#[processor(...)]` attribute in source.
@@ -68,6 +71,11 @@ pub use reachable::{
 pub struct ExtractedProcessor {
     /// The manifest-shaped processor schema derived from the attribute.
     pub schema: ProcessorSchema,
+    /// The full `@org/package/Type@version` identity the attribute declared.
+    /// [`ProcessorSchema`] keeps only the `Type` segment, so this is the only
+    /// place a scan consumer can tell two same-`Type` processors declared under
+    /// different `@org/package` apart.
+    pub schema_ident: SchemaIdent,
     /// The version-free config-schema identity the attribute declared (or
     /// synthesized from the config type), if the processor binds a config.
     pub config_schema_id: Option<String>,
@@ -178,6 +186,50 @@ pub enum ExtractError {
         module: String,
         declared_in: PathBuf,
         resolved: PathBuf,
+    },
+
+    /// Two `#[processor(...)]` declarations share one `Type` name and a single
+    /// build target compiles both. The plugin registry keys registration on that
+    /// name and skips the second registration at `debug`, so the surviving
+    /// processor is decided by arm order rather than by the author — and the
+    /// publish-time drift check, keyed by the same name, collapses the pair
+    /// before it ever compares. Refused at the scan, with a build target that
+    /// exhibits the overlap.
+    ///
+    /// Proven two ways, never guessed: a target-resolved scan that collects the
+    /// name twice reports the target it resolved against, and the
+    /// across-every-target scan reports a satisfying assignment it searched out
+    /// of the atoms the two arms' own predicates mention.
+    #[error(
+        "processor `{processor_type_name}` is declared twice for one build target \
+         ({witness_build_target_atoms}): {first_declared_in} and {second_declared_in} — \
+         that target compiles both arms and registers only the first; narrow one arm's \
+         `#[cfg(...)]` so the two are disjoint"
+    )]
+    OverlappingProcessorDeclarations {
+        processor_type_name: String,
+        first_declared_in: PathBuf,
+        second_declared_in: PathBuf,
+        /// The cfg atoms of a build target that compiles both declarations.
+        witness_build_target_atoms: String,
+    },
+
+    /// Two `#[processor(...)]` declarations share one `Type` name but derive
+    /// different manifest entries. The `processors:` section is derived from
+    /// whichever arm the publishing host compiles, so any difference at all —
+    /// identity, execution, ports, scheduling, description, config binding —
+    /// makes the shipped manifest depend on the publishing host.
+    #[error(
+        "processor `{processor_type_name}` is declared by two `processors/` arms that \
+         disagree, so the derived `processors:` section would depend on which arm the \
+         publishing host compiles: {difference}"
+    )]
+    DivergentProcessorDeclarations {
+        processor_type_name: String,
+        first_declared_in: PathBuf,
+        second_declared_in: PathBuf,
+        /// The named disagreement, labelled with each arm's source file.
+        difference: String,
     },
 }
 
@@ -351,6 +403,7 @@ pub(crate) fn parse_processor_attr(
 
     Ok(ExtractedProcessor {
         schema: parsed.to_processor_schema(),
+        schema_ident: parsed.ident.clone(),
         config_schema_id: parsed.config_schema_id.clone(),
         config_field_name: parsed.config_field_name.clone(),
         struct_name: struct_ident.to_string(),

--- a/sdk/streamlib-processor-extract/src/lib.rs
+++ b/sdk/streamlib-processor-extract/src/lib.rs
@@ -189,12 +189,12 @@ pub enum ExtractError {
     },
 
     /// Two `#[processor(...)]` declarations share one `Type` name and a single
-    /// build target compiles both. The plugin registry keys registration on that
-    /// name and skips the second registration at `debug`, so the surviving
-    /// processor is decided by arm order rather than by the author — and the
-    /// publish-time drift check, keyed by the same name, collapses the pair
-    /// before it ever compares. Refused at the scan, with a build target that
-    /// exhibits the overlap.
+    /// build target compiles both. The derived `processors:` section keeps only
+    /// the `Type` segment, so the two collapse into ONE entry whose content is
+    /// decided by walk order rather than by the author — and the publish-time
+    /// drift check, keyed by the same name, collapses the pair before it ever
+    /// compares. Refused at the scan, with a build target that exhibits the
+    /// overlap.
     ///
     /// Proven two ways, never guessed: a target-resolved scan that collects the
     /// name twice reports the target it resolved against, and the

--- a/sdk/streamlib-processor-extract/src/lib.rs
+++ b/sdk/streamlib-processor-extract/src/lib.rs
@@ -47,9 +47,8 @@ pub use derive::{
     DeriveError, DerivedProcessorSet, ExtractedManifestPort, ExtractedManifestProcessor,
     ManifestDriftReport, PackageLanguage, PortSchemaSurface, PortSurface, ProcessorSurface,
     SkippedLanguage, SubprocessProcessorExtractor, SystemSubprocessProcessorExtractor,
-    check_processor_manifest_drift, derive_package_processor_surfaces,
-    describe_processor_surface_difference, detect_package_languages, filter_committed_to_languages,
-    parse_subprocess_manifest_json_full,
+    check_processor_manifest_drift, derive_package_processor_surfaces, detect_package_languages,
+    filter_committed_to_languages, parse_subprocess_manifest_json_full,
 };
 pub use grammar::{ParsedPort, ParsedProcessorAttr};
 pub use reachable::{
@@ -71,10 +70,11 @@ pub use reachable::{
 pub struct ExtractedProcessor {
     /// The manifest-shaped processor schema derived from the attribute.
     pub schema: ProcessorSchema,
-    /// The full `@org/package/Type@version` identity the attribute declared.
-    /// [`ProcessorSchema`] keeps only the `Type` segment, so this is the only
-    /// place a scan consumer can tell two same-`Type` processors declared under
-    /// different `@org/package` apart.
+    /// The version-free `@org/package/Type` identity the attribute declared,
+    /// carrying the `0.0.0` sentinel the grammar synthesizes rather than a real
+    /// version. [`ProcessorSchema`] keeps only the `Type` segment, so this is
+    /// the only place a scan consumer can tell two same-`Type` processors
+    /// declared under different `@org/package` apart.
     pub schema_ident: SchemaIdent,
     /// The version-free config-schema identity the attribute declared (or
     /// synthesized from the config type), if the processor binds a config.

--- a/sdk/streamlib-processor-extract/src/reachable.rs
+++ b/sdk/streamlib-processor-extract/src/reachable.rs
@@ -32,16 +32,29 @@
 //! pruning turned off, recording each predicate it passed through instead. That
 //! is what lets the crate-root generator mirror the author's `#[cfg]` onto the
 //! `export_plugin!` entry verbatim rather than re-deriving a platform rule.
+//!
+//! Both walks then group what they collected by processor `Type` name — the key
+//! the plugin registry actually keys registration on — and refuse the two ways
+//! two arms declaring one processor can be wrong: they OVERLAP (some build
+//! target compiles both, so registration order decides which one ships) or they
+//! DIVERGE (they derive different manifest entries, so the shipped
+//! `processors:` section depends on which arm the publishing host compiled). A
+//! GAP is not refused: a package legitimately declares a processor on some
+//! targets and not others, which is exactly what
+//! [`ProcessorAvailabilityAcrossBuildTargets`] makes readable data instead of
+//! prose in a description string.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use quote::ToTokens;
+use streamlib_processor_schema::SchemaIdent;
 use syn::punctuated::Punctuated;
 use syn::{Meta, Token};
 
 use streamlib_idents::PACKAGE_PROCESSOR_SOURCE_DIR_NAME as PROCESSOR_SOURCE_DIR_NAME;
 
+use crate::derive::describe_divergent_processor_declarations;
 use crate::{
     ExtractError, ExtractedProcessor, ProcessorDeclarationSite, parse_processor_attr,
     processor_attr,
@@ -118,6 +131,34 @@ impl ModuleReachabilityTarget {
     /// Whether the bare flag `name` is defined by this target.
     fn has_flag(&self, name: &str) -> bool {
         self.flags.contains(name)
+    }
+
+    /// The single value this target defines for a cfg key, if it defines
+    /// exactly one. `None` for a key the target leaves unset.
+    fn single_defined_value_of_cfg_key(&self, key: &str) -> Option<&str> {
+        let mut values = self
+            .key_values
+            .iter()
+            .filter(|(defined_key, _)| defined_key == key)
+            .map(|(_, value)| value.as_str());
+        let first = values.next()?;
+        values.next().is_none().then_some(first)
+    }
+
+    /// The cfg atoms this target defines, rendered the way a `#[cfg(...)]`
+    /// predicate spells them (`target_os = "linux", unix`) — how a diagnostic
+    /// names the build target it is talking about.
+    pub fn describe_defined_cfg_atoms(&self) -> String {
+        let mut atoms: Vec<String> = self
+            .key_values
+            .iter()
+            .map(|(key, value)| format!("{key} = \"{value}\""))
+            .collect();
+        atoms.extend(self.flags.iter().cloned());
+        if atoms.is_empty() {
+            return "a build target defining no cfg atoms".to_string();
+        }
+        atoms.join(", ")
     }
 
     /// Whether a `#[cfg(...)]` predicate, given as the source text the generated
@@ -344,6 +385,73 @@ fn parse_cfg_combinator(list: &syn::MetaList) -> Option<(String, Punctuated<Meta
     Some((combinator, operands))
 }
 
+/// Every `#[processor(...)]` a package declares on ANY build target, plus the
+/// per-processor availability those declarations resolve to.
+///
+/// The two halves answer two different questions off one walk: the declaration
+/// list is per-ARM (two platform arms declaring one processor contribute two
+/// entries, each with its own predicates) and is what the crate-root generator
+/// turns into `export_plugin!` entries; the availability list is per-PROCESSOR
+/// and is what answers "does this processor exist on target X".
+#[derive(Debug, Clone, Default)]
+pub struct ProcessorSetAcrossEveryBuildTarget {
+    /// One entry per `#[processor(...)]` declaration, in walk order, each
+    /// carrying the `#[cfg(...)]` predicates that gate its own arm.
+    pub processor_declarations: Vec<ExtractedProcessor>,
+    /// One entry per distinct processor `Type` name, in first-declaration
+    /// order.
+    pub processor_availability: Vec<ProcessorAvailabilityAcrossBuildTargets>,
+}
+
+impl ProcessorSetAcrossEveryBuildTarget {
+    /// The availability of the processor a `Type` name identifies.
+    pub fn availability_of_processor_type_name(
+        &self,
+        processor_type_name: &str,
+    ) -> Option<&ProcessorAvailabilityAcrossBuildTargets> {
+        self.processor_availability
+            .iter()
+            .find(|entry| entry.processor_type_name == processor_type_name)
+    }
+}
+
+/// Which build targets one processor exists on, as the `#[cfg(...)]` predicate
+/// its declaring arms resolve to.
+///
+/// A predicate rather than an enumerated target set: there is no closed target
+/// universe — an arm may gate on `redox`, `android`, a cargo feature, a custom
+/// cfg — so a fixed list of targets would go stale and misreport. A caller
+/// answers "is it available on target X?" with
+/// [`Self::is_available_on_build_target`], which routes through the one cfg
+/// evaluator ([`ModuleReachabilityTarget::cfg_predicate_source_holds`]) rather
+/// than reimplementing cfg semantics beside it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessorAvailabilityAcrossBuildTargets {
+    /// The `Type` segment — the name the plugin registry keys registration on,
+    /// and therefore the name two arms collide under.
+    pub processor_type_name: String,
+    /// The full `@org/package/Type@version` identity every declaring arm agrees
+    /// on (a disagreement here is refused as divergence, never merged).
+    pub processor_schema_ident: SchemaIdent,
+    /// The disjunction over each declaring arm's conjoined `#[cfg(...)]`
+    /// predicates, as source text. `None` is unconditional: some arm is gated
+    /// by nothing, so the processor exists on every build target.
+    pub availability_cfg_predicate: Option<String>,
+    /// Each declaring arm's source file, relative to the scanned package
+    /// directory, in walk order.
+    pub declaring_arm_source_files: Vec<PathBuf>,
+}
+
+impl ProcessorAvailabilityAcrossBuildTargets {
+    /// Whether a build target compiles this processor.
+    pub fn is_available_on_build_target(&self, target: &ModuleReachabilityTarget) -> bool {
+        match &self.availability_cfg_predicate {
+            None => true,
+            Some(predicate) => target.cfg_predicate_source_holds(predicate),
+        }
+    }
+}
+
 /// How a module walk treats the `#[cfg(...)]` predicates it meets.
 enum ModuleWalkCfgResolution<'walk> {
     /// Prune every module / struct the build target does not compile. The
@@ -370,19 +478,26 @@ enum ModuleWalkCfgResolution<'walk> {
 /// `#[cfg(any())]` parked directory — is never collected. The result is
 /// deterministic (source order within a file, arm order across files) and
 /// de-duplicated by resolved source file.
+///
+/// Two surviving declarations of one processor `Type` are refused as
+/// [`ExtractError::OverlappingProcessorDeclarations`]: this target compiles
+/// both, which is a proof of overlap needing no reasoning about predicates.
 #[tracing::instrument(skip_all, fields(package_dir = %package_dir.display()))]
 pub fn extract_reachable_rust_processors(
     package_dir: &Path,
     target: &ModuleReachabilityTarget,
 ) -> Result<Vec<ExtractedProcessor>, ExtractError> {
-    walk_processor_source_arms(
+    let processors = walk_processor_source_arms(
         package_dir,
         ModuleWalkCfgResolution::AgainstBuildTarget(target),
-    )
+    )?;
+    refuse_processors_declared_twice_for_one_build_target(&processors, target)?;
+    Ok(processors)
 }
 
 /// Every `#[processor(...)]` a Rust package declares on ANY target, each
-/// carrying the `#[cfg(...)]` predicates that gate it.
+/// carrying the `#[cfg(...)]` predicates that gate it, plus the per-processor
+/// availability they resolve to.
 ///
 /// This is the crate-root generator's input: it needs the union across targets
 /// (a Linux host still generates the macOS arm's `export_plugin!` entry, gated)
@@ -391,11 +506,164 @@ pub fn extract_reachable_rust_processors(
 /// statically-unsatisfiable predicate such as `#[cfg(any())]` — are excluded:
 /// they compile on no target, so naming them in a generated arm would only
 /// produce a declaration entry that is always stripped.
+///
+/// Two arms declaring one processor `Type` are refused when some build target
+/// compiles both ([`ExtractError::OverlappingProcessorDeclarations`]) or when
+/// they derive different manifest entries
+/// ([`ExtractError::DivergentProcessorDeclarations`]).
 #[tracing::instrument(skip_all, fields(package_dir = %package_dir.display()))]
 pub fn extract_processors_across_every_build_target(
     package_dir: &Path,
-) -> Result<Vec<ExtractedProcessor>, ExtractError> {
-    walk_processor_source_arms(package_dir, ModuleWalkCfgResolution::AcrossEveryBuildTarget)
+) -> Result<ProcessorSetAcrossEveryBuildTarget, ExtractError> {
+    let processor_declarations =
+        walk_processor_source_arms(package_dir, ModuleWalkCfgResolution::AcrossEveryBuildTarget)?;
+    let processor_availability =
+        resolve_processor_availability_across_build_targets(&processor_declarations)?;
+    tracing::debug!(
+        declarations = processor_declarations.len(),
+        processors = processor_availability.len(),
+        "resolved per-processor availability"
+    );
+    Ok(ProcessorSetAcrossEveryBuildTarget {
+        processor_declarations,
+        processor_availability,
+    })
+}
+
+/// Refuse a processor `Type` that one build target collected twice.
+///
+/// No satisfiability argument is needed here: the walk already resolved a
+/// concrete target and it compiled both arms. This is the reasoning-free net
+/// behind [`find_build_target_compiling_both_declarations`] — an exotic
+/// predicate pair the atom model calls disjoint still fails loudly on the host
+/// that actually compiles both.
+fn refuse_processors_declared_twice_for_one_build_target(
+    processors: &[ExtractedProcessor],
+    target: &ModuleReachabilityTarget,
+) -> Result<(), ExtractError> {
+    for (index, first) in processors.iter().enumerate() {
+        let Some(second) = processors[index + 1..]
+            .iter()
+            .find(|second| second.schema.name == first.schema.name)
+        else {
+            continue;
+        };
+        return Err(ExtractError::OverlappingProcessorDeclarations {
+            processor_type_name: first.schema.name.clone(),
+            first_declared_in: first.source_file.clone(),
+            second_declared_in: second.source_file.clone(),
+            witness_build_target_atoms: target.describe_defined_cfg_atoms(),
+        });
+    }
+    Ok(())
+}
+
+/// Group the across-every-target declarations by processor `Type` name, refuse
+/// the overlapping and divergent groups, and fold each surviving group into its
+/// availability predicate.
+fn resolve_processor_availability_across_build_targets(
+    declarations: &[ExtractedProcessor],
+) -> Result<Vec<ProcessorAvailabilityAcrossBuildTargets>, ExtractError> {
+    let mut out = Vec::new();
+    for (processor_type_name, declaring_arms) in
+        group_declarations_by_processor_type_name(declarations)
+    {
+        refuse_overlapping_processor_declarations(processor_type_name, &declaring_arms)?;
+        refuse_divergent_processor_declarations(processor_type_name, &declaring_arms)?;
+
+        let arm_predicates: Vec<Option<String>> = declaring_arms
+            .iter()
+            .map(|arm| conjoin_cfg_predicates(&arm.cfg_predicates))
+            .collect();
+        // One unconditional arm makes the processor unconditional: its
+        // disjunction with anything is `true`, and an `any(...)` naming the
+        // other arms would understate where it exists.
+        let availability_cfg_predicate = arm_predicates
+            .iter()
+            .all(|predicate| predicate.is_some())
+            .then(|| {
+                disjoin_distinct_cfg_predicates(arm_predicates.iter().filter_map(|p| p.as_deref()))
+            });
+
+        out.push(ProcessorAvailabilityAcrossBuildTargets {
+            processor_type_name: processor_type_name.to_string(),
+            processor_schema_ident: declaring_arms[0].schema_ident.clone(),
+            availability_cfg_predicate,
+            declaring_arm_source_files: declaring_arms
+                .iter()
+                .map(|arm| arm.source_file.clone())
+                .collect(),
+        });
+    }
+    Ok(out)
+}
+
+/// Declarations grouped by processor `Type` name, groups in first-declaration
+/// order and arms within a group in walk order.
+///
+/// `Type` name rather than the full `@org/package/Type`: that is the key the
+/// plugin registry keys registration on, so two arms sharing a `Type` under
+/// different `@org/package` collide there and must be caught here rather than
+/// pass as two unrelated processors.
+fn group_declarations_by_processor_type_name(
+    declarations: &[ExtractedProcessor],
+) -> Vec<(&str, Vec<&ExtractedProcessor>)> {
+    let mut groups: Vec<(&str, Vec<&ExtractedProcessor>)> = Vec::new();
+    for declaration in declarations {
+        let processor_type_name = declaration.schema.name.as_str();
+        match groups
+            .iter_mut()
+            .find(|(grouped_name, _)| *grouped_name == processor_type_name)
+        {
+            Some((_, declaring_arms)) => declaring_arms.push(declaration),
+            None => groups.push((processor_type_name, vec![declaration])),
+        }
+    }
+    groups
+}
+
+/// Refuse a processor group whose arms are not mutually exclusive, naming a
+/// build target that compiles both.
+fn refuse_overlapping_processor_declarations(
+    processor_type_name: &str,
+    declaring_arms: &[&ExtractedProcessor],
+) -> Result<(), ExtractError> {
+    for (index, first) in declaring_arms.iter().enumerate() {
+        for second in &declaring_arms[index + 1..] {
+            let Some(witness) = find_build_target_compiling_both_declarations(first, second) else {
+                continue;
+            };
+            return Err(ExtractError::OverlappingProcessorDeclarations {
+                processor_type_name: processor_type_name.to_string(),
+                first_declared_in: first.source_file.clone(),
+                second_declared_in: second.source_file.clone(),
+                witness_build_target_atoms: witness.describe_defined_cfg_atoms(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Refuse a processor group whose arms derive different manifest entries.
+fn refuse_divergent_processor_declarations(
+    processor_type_name: &str,
+    declaring_arms: &[&ExtractedProcessor],
+) -> Result<(), ExtractError> {
+    let Some((first, rest)) = declaring_arms.split_first() else {
+        return Ok(());
+    };
+    for second in rest {
+        let Some(difference) = describe_divergent_processor_declarations(first, second) else {
+            continue;
+        };
+        return Err(ExtractError::DivergentProcessorDeclarations {
+            processor_type_name: processor_type_name.to_string(),
+            first_declared_in: first.source_file.clone(),
+            second_declared_in: second.source_file.clone(),
+            difference,
+        });
+    }
+    Ok(())
 }
 
 fn walk_processor_source_arms(
@@ -474,6 +742,7 @@ impl ReachableModuleWalker<'_> {
         // `mod foo { #![cfg] }` instead folds them into `ItemMod::attrs`, which
         // `walk_item` gates.
         let Some(pushed_predicate_count) = self.enter_cfg_scope(&parsed.attrs) else {
+            self.warn_if_an_undefined_feature_pruned_the_scope(&parsed.attrs, file);
             tracing::trace!(file = %file.display(), "module file excluded by file-level cfg");
             return Ok(());
         };
@@ -509,6 +778,12 @@ impl ReachableModuleWalker<'_> {
                 // A struct behind a false `#[cfg(...)]` is not compiled, so its
                 // `#[processor]` (if any) is not a real processor for this target.
                 let Some(pushed_predicate_count) = self.enter_cfg_scope(&item_struct.attrs) else {
+                    if processor_attr(&item_struct.attrs).is_some() {
+                        self.warn_if_an_undefined_feature_pruned_the_scope(
+                            &item_struct.attrs,
+                            declaring_file,
+                        );
+                    }
                     return Ok(());
                 };
                 if let Some(attr) = processor_attr(&item_struct.attrs) {
@@ -533,6 +808,10 @@ impl ReachableModuleWalker<'_> {
             }
             syn::Item::Mod(item_mod) => {
                 let Some(pushed_predicate_count) = self.enter_cfg_scope(&item_mod.attrs) else {
+                    self.warn_if_an_undefined_feature_pruned_the_scope(
+                        &item_mod.attrs,
+                        declaring_file,
+                    );
                     return Ok(());
                 };
                 self.module_path_segments.push(item_mod.ident.to_string());
@@ -679,6 +958,85 @@ impl ReachableModuleWalker<'_> {
         self.active_cfg_predicates
             .truncate(self.active_cfg_predicates.len() - pushed_predicate_count);
     }
+
+    /// Say so when a target-resolved walk pruned a scope for want of a cargo
+    /// feature.
+    ///
+    /// [`ModuleReachabilityTarget::for_host`] derives `target_os` / `target_arch`
+    /// / `target_family` plus the family flag and infers no features — it cannot
+    /// know which features a downstream build enables. A feature-gated
+    /// `#[processor(...)]` therefore evaluates false and leaves the derived set,
+    /// and the publish-time drift gate then reports the committed entry as
+    /// "listed in `processors:` but no longer declared in code" — a confusing
+    /// error rather than a quiet one. Naming the file, the predicate and the
+    /// missing feature turns it into an actionable one.
+    fn warn_if_an_undefined_feature_pruned_the_scope(
+        &self,
+        attrs: &[syn::Attribute],
+        declaring_file: &Path,
+    ) {
+        let ModuleWalkCfgResolution::AgainstBuildTarget(target) = self.cfg_resolution else {
+            return;
+        };
+        for attr in attrs.iter().filter(|attr| attr.path().is_ident("cfg")) {
+            let Ok(meta) = attr.parse_args::<Meta>() else {
+                continue;
+            };
+            if eval_cfg_meta(&meta, target) {
+                continue;
+            }
+            let mut undefined_features = BTreeSet::new();
+            collect_undefined_feature_atoms(&meta, target, &mut undefined_features);
+            if undefined_features.is_empty() {
+                continue;
+            }
+            tracing::warn!(
+                file = %declaring_file.display(),
+                predicate = %render_cfg_predicate(&meta),
+                undefined_features = %undefined_features.into_iter().collect::<Vec<_>>().join(", "),
+                "pruned a cfg scope gated on cargo features the scan target does not define — \
+                 any `#[processor(...)]` under it is absent from the derived `processors:` set \
+                 and will read as removed from code; declare the feature on the target with \
+                 `ModuleReachabilityTarget::with_feature` if the build enables it"
+            );
+        }
+    }
+}
+
+/// Every `feature = "<name>"` atom in a predicate that `target` does not
+/// define.
+fn collect_undefined_feature_atoms(
+    meta: &Meta,
+    target: &ModuleReachabilityTarget,
+    out: &mut BTreeSet<String>,
+) {
+    match meta {
+        Meta::Path(_) => {}
+        Meta::NameValue(name_value) => {
+            if !name_value.path.is_ident("feature") {
+                return;
+            }
+            if let Some(name) = literal_str(&name_value.value)
+                && !target.has_key_value("feature", &name)
+            {
+                out.insert(name);
+            }
+        }
+        Meta::List(list) => {
+            let Some((combinator, inner)) = parse_cfg_combinator(list) else {
+                return;
+            };
+            // `not(feature = "x")` is satisfied BY the feature's absence, so a
+            // scope it prunes was pruned by the feature being present, not
+            // missing — the confusion this warns about cannot arise there.
+            if !matches!(combinator.as_str(), "all" | "any") {
+                return;
+            }
+            for operand in &inner {
+                collect_undefined_feature_atoms(operand, target, out);
+            }
+        }
+    }
 }
 
 /// A child `mod` resolved to its file, plus how it was resolved — `rustc` gives
@@ -746,6 +1104,301 @@ fn cfg_predicate_is_statically_unsatisfiable(meta: &Meta) -> bool {
         "any" => inner.iter().all(cfg_predicate_is_statically_unsatisfiable),
         "all" => inner.iter().any(cfg_predicate_is_statically_unsatisfiable),
         _ => false,
+    }
+}
+
+/// Fold the `#[cfg(...)]` predicates in force at one declaration into a single
+/// predicate. Nested predicates are ANDed the way `rustc` applies them; no
+/// predicate at all is unconditional.
+///
+/// The one owner of the conjunction rule: the crate-root generator renders it
+/// onto an `export_plugin!` entry and the availability resolution folds it into
+/// a processor's availability predicate, off the same function.
+pub(crate) fn conjoin_cfg_predicates(predicates: &[String]) -> Option<String> {
+    match predicates {
+        [] => None,
+        [single] => Some(single.clone()),
+        many => Some(format!("all({})", many.join(", "))),
+    }
+}
+
+/// Fold alternative `#[cfg(...)]` predicates into their disjunction,
+/// de-duplicated and in first-seen order. A single distinct predicate folds to
+/// itself rather than a one-armed `any(...)`.
+pub(crate) fn disjoin_distinct_cfg_predicates<'predicate>(
+    predicates: impl IntoIterator<Item = &'predicate str>,
+) -> String {
+    let mut distinct: Vec<&str> = Vec::new();
+    for predicate in predicates {
+        if !distinct.contains(&predicate) {
+            distinct.push(predicate);
+        }
+    }
+    match distinct.as_slice() {
+        [single] => (*single).to_string(),
+        many => format!("any({})", many.join(", ")),
+    }
+}
+
+/// cfg keys a build target may define more than one value for.
+///
+/// Everything else — `target_os`, `target_arch`, `target_family`, `target_env`,
+/// `target_vendor`, `target_endian`, `target_pointer_width`, `target_abi`,
+/// `panic`, and any custom key — admits at most one value, which is what makes
+/// `target_os = "linux"` and `any(target_os = "macos", target_os = "ios")`
+/// provably disjoint rather than reading as satisfiable. Single-valued is the
+/// deliberate default: modelling a genuinely set-valued key as single-valued
+/// can only ever MISS an overlap (the concrete-target net still catches it),
+/// while the reverse would invent one and refuse a correct package.
+const SET_VALUED_CFG_KEYS: [&str; 3] = ["feature", "target_feature", "target_has_atomic"];
+
+/// Ceiling on the assignment search. A processor group's predicates mention a
+/// handful of atoms in practice; a pathological one is left unproven (no
+/// refusal) rather than searched to a stall.
+const MAX_CANDIDATE_BUILD_TARGET_ASSIGNMENTS: usize = 4096;
+
+/// A build target that compiles BOTH declarations, or `None` when none was
+/// found.
+///
+/// Exhaustive over the atoms the two declarations' own predicates mention, so a
+/// `Some` is a proof carrying its own witness — the polarity that matters,
+/// because the caller refuses the build on it. A `None` is "not proven", not
+/// "proven disjoint": an unparseable predicate, a search past the ceiling, and
+/// a genuinely disjoint pair all land there, and the concrete-target duplicate
+/// check remains the backstop.
+fn find_build_target_compiling_both_declarations(
+    first: &ExtractedProcessor,
+    second: &ExtractedProcessor,
+) -> Option<ModuleReachabilityTarget> {
+    let first_predicates = parse_cfg_predicate_sources(&first.cfg_predicates)?;
+    let second_predicates = parse_cfg_predicate_sources(&second.cfg_predicates)?;
+
+    let mut atoms = CfgPredicateAtomUniverse::default();
+    for predicate in first_predicates.iter().chain(&second_predicates) {
+        atoms.collect_from(predicate);
+    }
+
+    let candidates = atoms.candidate_build_targets()?;
+    candidates.into_iter().find(|candidate| {
+        first_predicates
+            .iter()
+            .chain(&second_predicates)
+            .all(|predicate| eval_cfg_meta(predicate, candidate))
+    })
+}
+
+/// Parse every recorded predicate source back into a `Meta`, or `None` if any
+/// one of them is unreadable — a predicate the evaluator cannot read cannot
+/// take part in a proof.
+fn parse_cfg_predicate_sources(predicate_sources: &[String]) -> Option<Vec<Meta>> {
+    predicate_sources
+        .iter()
+        .map(|source| syn::parse_str::<Meta>(source).ok())
+        .collect()
+}
+
+/// Every cfg atom a set of predicates mentions — the search space an overlap
+/// proof enumerates. Atoms outside it are irrelevant: a predicate's truth
+/// depends only on the atoms it names.
+#[derive(Debug, Default)]
+struct CfgPredicateAtomUniverse {
+    /// Values mentioned per single-valued cfg key (`target_os = "linux"`).
+    single_valued_key_values: BTreeMap<String, BTreeSet<String>>,
+    /// Values mentioned per set-valued cfg key (`feature = "cuda"`).
+    set_valued_key_values: BTreeMap<String, BTreeSet<String>>,
+    /// Bare flag atoms mentioned (`unix`).
+    flags: BTreeSet<String>,
+}
+
+impl CfgPredicateAtomUniverse {
+    fn collect_from(&mut self, meta: &Meta) {
+        match meta {
+            Meta::Path(path) => {
+                if let Some(ident) = path.get_ident() {
+                    self.flags.insert(ident.to_string());
+                }
+            }
+            Meta::NameValue(name_value) => {
+                let (Some(key), Some(value)) = (
+                    name_value.path.get_ident().map(|ident| ident.to_string()),
+                    literal_str(&name_value.value),
+                ) else {
+                    return;
+                };
+                let by_key = if SET_VALUED_CFG_KEYS.contains(&key.as_str()) {
+                    &mut self.set_valued_key_values
+                } else {
+                    &mut self.single_valued_key_values
+                };
+                by_key.entry(key).or_default().insert(value);
+            }
+            Meta::List(list) => {
+                let Some((combinator, inner)) = parse_cfg_combinator(list) else {
+                    return;
+                };
+                if !matches!(combinator.as_str(), "all" | "any" | "not") {
+                    return;
+                }
+                for operand in &inner {
+                    self.collect_from(operand);
+                }
+            }
+        }
+    }
+
+    /// Every coherent build target that assigns these atoms, or `None` when the
+    /// search space exceeds [`MAX_CANDIDATE_BUILD_TARGET_ASSIGNMENTS`].
+    fn candidate_build_targets(&self) -> Option<Vec<ModuleReachabilityTarget>> {
+        let choices = self.candidate_atom_choices();
+        let mut assignment_count: usize = 1;
+        for choice in &choices {
+            assignment_count = assignment_count.checked_mul(choice.arity())?;
+            if assignment_count > MAX_CANDIDATE_BUILD_TARGET_ASSIGNMENTS {
+                tracing::debug!(
+                    atoms = choices.len(),
+                    "cfg overlap search space exceeds the ceiling — leaving the pair unproven"
+                );
+                return None;
+            }
+        }
+
+        let mut candidates = Vec::with_capacity(assignment_count);
+        for encoded in 0..assignment_count {
+            let mut remaining = encoded;
+            let mut target = ModuleReachabilityTarget::new();
+            for choice in &choices {
+                let arity = choice.arity();
+                choice.apply(remaining % arity, &mut target);
+                remaining /= arity;
+            }
+            if self.candidate_build_target_is_coherent(&target) {
+                candidates.push(target);
+            }
+        }
+        Some(candidates)
+    }
+
+    fn candidate_atom_choices(&self) -> Vec<CandidateCfgAtomChoice<'_>> {
+        let mut choices = Vec::new();
+        for (key, values) in &self.single_valued_key_values {
+            choices.push(CandidateCfgAtomChoice::SingleValuedKey {
+                key,
+                values: values.iter().map(String::as_str).collect(),
+            });
+        }
+        for (key, values) in &self.set_valued_key_values {
+            for value in values {
+                choices.push(CandidateCfgAtomChoice::SetValuedKeyValue { key, value });
+            }
+        }
+        for flag in &self.flags {
+            choices.push(CandidateCfgAtomChoice::Flag(flag));
+        }
+        choices
+    }
+
+    /// Whether a candidate assignment describes a build target that could
+    /// actually exist. Every rule is a fact about how `rustc` sets these atoms,
+    /// so filtering by them only ever removes a target that would have proven a
+    /// false overlap — it can never hide a real one:
+    ///
+    /// - `unix` and `windows` are the two target families a `cfg` names, and no
+    ///   target is in both;
+    /// - the windows family holds exactly one `target_os`, `windows`;
+    /// - `target_family = "unix"` / `"windows"` and the bare `unix` / `windows`
+    ///   flag are the same fact spelled two ways.
+    fn candidate_build_target_is_coherent(&self, target: &ModuleReachabilityTarget) -> bool {
+        let defines_unix = target.has_flag("unix");
+        let defines_windows = target.has_flag("windows");
+        if defines_unix && defines_windows {
+            return false;
+        }
+        let target_os = target.single_defined_value_of_cfg_key("target_os");
+        let target_family = target.single_defined_value_of_cfg_key("target_family");
+
+        if defines_windows && target_os.is_some_and(|os| os != "windows") {
+            return false;
+        }
+        if defines_unix && target_os == Some("windows") {
+            return false;
+        }
+        if target_os == Some("windows") {
+            if self.flags.contains("windows") && !defines_windows {
+                return false;
+            }
+            if target_family.is_some_and(|family| family != "windows") {
+                return false;
+            }
+        }
+        if target_family == Some("windows") {
+            if target_os.is_some_and(|os| os != "windows") {
+                return false;
+            }
+            if self.flags.contains("unix") && defines_unix {
+                return false;
+            }
+            if self.flags.contains("windows") && !defines_windows {
+                return false;
+            }
+        }
+        if target_family == Some("unix") {
+            if defines_windows {
+                return false;
+            }
+            if self.flags.contains("unix") && !defines_unix {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// One slot in the assignment search: a cfg atom (or single-valued key) the
+/// candidate build target either defines, or defines a particular value for.
+enum CandidateCfgAtomChoice<'atom> {
+    /// A key admitting at most one value: each mentioned value, plus "some
+    /// other value the predicates never name", which is the arity's `+ 1`.
+    SingleValuedKey {
+        key: &'atom str,
+        values: Vec<&'atom str>,
+    },
+    /// One `key = "value"` a target either defines or does not, independently
+    /// of the key's other values.
+    SetValuedKeyValue { key: &'atom str, value: &'atom str },
+    /// One bare flag a target either defines or does not.
+    Flag(&'atom str),
+}
+
+impl CandidateCfgAtomChoice<'_> {
+    fn arity(&self) -> usize {
+        match self {
+            CandidateCfgAtomChoice::SingleValuedKey { values, .. } => values.len() + 1,
+            CandidateCfgAtomChoice::SetValuedKeyValue { .. } | CandidateCfgAtomChoice::Flag(_) => 2,
+        }
+    }
+
+    fn apply(&self, selection: usize, target: &mut ModuleReachabilityTarget) {
+        match self {
+            CandidateCfgAtomChoice::SingleValuedKey { key, values } => {
+                if let Some(value) = values.get(selection) {
+                    target
+                        .key_values
+                        .insert((key.to_string(), value.to_string()));
+                }
+            }
+            CandidateCfgAtomChoice::SetValuedKeyValue { key, value } => {
+                if selection == 1 {
+                    target
+                        .key_values
+                        .insert((key.to_string(), value.to_string()));
+                }
+            }
+            CandidateCfgAtomChoice::Flag(flag) => {
+                if selection == 1 {
+                    target.flags.insert(flag.to_string());
+                }
+            }
+        }
     }
 }
 
@@ -880,8 +1533,8 @@ mod tests {
             pub struct Live;"#,
         );
 
-        let procs = extract_processors_across_every_build_target(root).unwrap();
-        assert_eq!(names(procs), vec!["Live"]);
+        let set = extract_processors_across_every_build_target(root).unwrap();
+        assert_eq!(names(set.processor_declarations), vec!["Live"]);
     }
 
     /// Two platform arms declaring the same processor: only the arm the target
@@ -936,8 +1589,9 @@ mod tests {
             pub struct AppleCam;"#,
         );
 
-        let procs = extract_processors_across_every_build_target(root).unwrap();
-        let mut by_name: Vec<(String, Vec<String>, Vec<String>)> = procs
+        let set = extract_processors_across_every_build_target(root).unwrap();
+        let mut by_name: Vec<(String, Vec<String>, Vec<String>)> = set
+            .processor_declarations
             .into_iter()
             .map(|p| (p.schema.name, p.cfg_predicates, p.module_path_segments))
             .collect();
@@ -974,11 +1628,19 @@ mod tests {
             #[processor("@tatolab/demo/CudaOnly", execution = reactive)]
             pub struct CudaOnly;"#,
         );
-        let procs = extract_processors_across_every_build_target(root).unwrap();
-        assert_eq!(procs.len(), 1);
+        let set = extract_processors_across_every_build_target(root).unwrap();
+        assert_eq!(set.processor_declarations.len(), 1);
         assert_eq!(
-            procs[0].cfg_predicates,
+            set.processor_declarations[0].cfg_predicates,
             vec!["unix".to_string(), r#"feature = "cuda""#.to_string()]
+        );
+        // The same conjunction is what the availability predicate folds to.
+        assert_eq!(
+            set.availability_of_processor_type_name("CudaOnly")
+                .unwrap()
+                .availability_cfg_predicate
+                .as_deref(),
+            Some(r#"all(unix, feature = "cuda")"#)
         );
     }
 

--- a/sdk/streamlib-processor-extract/src/reachable.rs
+++ b/sdk/streamlib-processor-extract/src/reachable.rs
@@ -2854,14 +2854,14 @@ mod tests {
         let root = tmp.path();
         write(
             root,
-            "processors/linux/mod.rs",
+            "processors/audio_capture_linux.rs",
             r#"#![cfg(target_os = "linux")]
             #[processor("@tatolab/demo/AudioCapture", execution = manual, output("audio", "@tatolab/core/AudioFrame"))]
             pub struct LinuxAudioCapture;"#,
         );
         write(
             root,
-            "processors/apple/mod.rs",
+            "processors/audio_capture_apple.rs",
             r#"#![cfg(any(target_os = "macos", target_os = "ios"))]
             #[processor("@tatolab/demo/AudioCapture", execution = manual, output("audio", "@tatolab/core/AudioFrame"))]
             pub struct AppleAudioCapture;"#,
@@ -2881,14 +2881,14 @@ mod tests {
         let root = tmp.path();
         write(
             root,
-            "processors/linux/mod.rs",
+            "processors/audio_capture_linux.rs",
             r#"#![cfg(target_os = "linux")]
             #[processor("@tatolab/demo/AudioCapture", execution = manual, output("audio", "@tatolab/core/AudioFrame"))]
             pub struct LinuxAudioCapture;"#,
         );
         write(
             root,
-            "processors/apple/mod.rs",
+            "processors/audio_capture_apple.rs",
             r#"#![cfg(any(target_os = "macos", target_os = "ios"))]
             #[processor("@tatolab/demo/AudioCapture", execution = manual, output("audio", "@tatolab/core/AudioFrame"))]
             pub struct AppleAudioCapture;"#,
@@ -2901,8 +2901,8 @@ mod tests {
         assert_eq!(
             availability.declaring_arm_source_files,
             vec![
-                PathBuf::from("processors/apple/mod.rs"),
-                PathBuf::from("processors/linux/mod.rs"),
+                PathBuf::from("processors/audio_capture_apple.rs"),
+                PathBuf::from("processors/audio_capture_linux.rs"),
             ]
         );
         for os in ["linux", "macos", "ios"] {
@@ -2974,14 +2974,14 @@ mod tests {
         let root = tmp.path();
         write(
             root,
-            "processors/linux/mod.rs",
+            "processors/audio_capture_linux.rs",
             r#"#![cfg(target_os = "linux")]
             #[processor("@tatolab/demo/AudioCapture", execution = manual, output("audio", "@tatolab/core/AudioFrame"))]
             pub struct LinuxAudioCapture;"#,
         );
         write(
             root,
-            "processors/apple/mod.rs",
+            "processors/audio_capture_apple.rs",
             r#"#![cfg(any(target_os = "macos", target_os = "ios"))]
             #[processor("@tatolab/demo/AudioCapture", execution = manual, output("audio", "@tatolab/core/VideoFrame"))]
             pub struct AppleAudioCapture;"#,
@@ -3001,8 +3001,8 @@ mod tests {
         assert!(difference.contains("AudioFrame"), "{difference}");
         assert!(difference.contains("VideoFrame"), "{difference}");
         assert!(
-            difference.contains("processors/apple/mod.rs")
-                && difference.contains("processors/linux/mod.rs"),
+            difference.contains("processors/audio_capture_apple.rs")
+                && difference.contains("processors/audio_capture_linux.rs"),
             "{difference}"
         );
     }
@@ -3014,14 +3014,14 @@ mod tests {
         let root = tmp.path();
         write(
             root,
-            "processors/linux/mod.rs",
+            "processors/audio_capture_linux.rs",
             r#"#![cfg(target_os = "linux")]
             #[processor("@tatolab/demo/AudioCapture", execution = manual)]
             pub struct LinuxAudioCapture;"#,
         );
         write(
             root,
-            "processors/apple/mod.rs",
+            "processors/audio_capture_apple.rs",
             r#"#![cfg(any(target_os = "macos", target_os = "ios"))]
             #[processor("@tatolab/demo/AudioCapture", execution = reactive)]
             pub struct AppleAudioCapture;"#,
@@ -3046,14 +3046,14 @@ mod tests {
         let root = tmp.path();
         write(
             root,
-            "processors/linux/mod.rs",
+            "processors/audio_capture_linux.rs",
             r#"#![cfg(target_os = "linux")]
             #[processor("@tatolab/demo/AudioCapture", execution = manual)]
             pub struct LinuxAudioCapture;"#,
         );
         write(
             root,
-            "processors/apple/mod.rs",
+            "processors/audio_capture_apple.rs",
             r#"#![cfg(any(target_os = "macos", target_os = "ios"))]
             #[processor("@tatolab/other/AudioCapture", execution = manual)]
             pub struct AppleAudioCapture;"#,
@@ -3081,14 +3081,14 @@ mod tests {
         let root = tmp.path();
         write(
             root,
-            "processors/linux/mod.rs",
+            "processors/audio_capture_linux.rs",
             r#"#![cfg(target_os = "linux")]
             #[processor("@tatolab/demo/AudioCapture", description = "ALSA capture", execution = manual)]
             pub struct LinuxAudioCapture;"#,
         );
         write(
             root,
-            "processors/apple/mod.rs",
+            "processors/audio_capture_apple.rs",
             r#"#![cfg(any(target_os = "macos", target_os = "ios"))]
             #[processor("@tatolab/demo/AudioCapture", description = "CoreAudio capture", execution = manual)]
             pub struct AppleAudioCapture;"#,

--- a/sdk/streamlib-processor-extract/src/reachable.rs
+++ b/sdk/streamlib-processor-extract/src/reachable.rs
@@ -747,7 +747,9 @@ impl ReachableModuleWalker<'_> {
         // `mod foo { #![cfg] }` instead folds them into `ItemMod::attrs`, which
         // `walk_item` gates.
         let Some(pushed_predicate_count) = self.enter_cfg_scope(&parsed.attrs) else {
-            self.warn_if_an_undefined_feature_pruned_the_scope(&parsed.attrs, file);
+            self.warn_if_an_undefined_cargo_feature_pruned_a_processor(&parsed.attrs, file, || {
+                self.pruned_module_file_declares_a_processor(file, mod_dir)
+            });
             tracing::trace!(file = %file.display(), "module file excluded by file-level cfg");
             return Ok(());
         };
@@ -783,12 +785,11 @@ impl ReachableModuleWalker<'_> {
                 // A struct behind a false `#[cfg(...)]` is not compiled, so its
                 // `#[processor]` (if any) is not a real processor for this target.
                 let Some(pushed_predicate_count) = self.enter_cfg_scope(&item_struct.attrs) else {
-                    if processor_attr(&item_struct.attrs).is_some() {
-                        self.warn_if_an_undefined_feature_pruned_the_scope(
-                            &item_struct.attrs,
-                            declaring_file,
-                        );
-                    }
+                    self.warn_if_an_undefined_cargo_feature_pruned_a_processor(
+                        &item_struct.attrs,
+                        declaring_file,
+                        || processor_attr(&item_struct.attrs).is_some(),
+                    );
                     return Ok(());
                 };
                 if let Some(attr) = processor_attr(&item_struct.attrs) {
@@ -813,9 +814,18 @@ impl ReachableModuleWalker<'_> {
             }
             syn::Item::Mod(item_mod) => {
                 let Some(pushed_predicate_count) = self.enter_cfg_scope(&item_mod.attrs) else {
-                    self.warn_if_an_undefined_feature_pruned_the_scope(
+                    self.warn_if_an_undefined_cargo_feature_pruned_a_processor(
                         &item_mod.attrs,
                         declaring_file,
+                        || {
+                            self.pruned_module_item_declares_a_processor(
+                                item,
+                                declaring_file,
+                                mod_dir,
+                                path_attribute_base_dir,
+                                rel_path,
+                            )
+                        },
                     );
                     return Ok(());
                 };
@@ -964,8 +974,8 @@ impl ReachableModuleWalker<'_> {
             .truncate(self.active_cfg_predicates.len() - pushed_predicate_count);
     }
 
-    /// Say so when a target-resolved walk pruned a scope for want of a cargo
-    /// feature.
+    /// Say so when a target-resolved walk pruned a `#[processor(...)]` for want
+    /// of a cargo feature.
     ///
     /// [`ModuleReachabilityTarget::for_host`] derives `target_os` / `target_arch`
     /// / `target_family` plus the family flag and infers no features — it cannot
@@ -975,14 +985,21 @@ impl ReachableModuleWalker<'_> {
     /// "listed in `processors:` but no longer declared in code" — a confusing
     /// error rather than a quiet one. Naming the file, the predicate and the
     /// missing feature turns it into an actionable one.
-    fn warn_if_an_undefined_feature_pruned_the_scope(
+    ///
+    /// `pruned_scope_declares_a_processor` is what keeps the message true: a
+    /// feature-gated helper module under `processors/` declares no processor,
+    /// so nothing left the derived set and there is nothing to explain.
+    fn warn_if_an_undefined_cargo_feature_pruned_a_processor(
         &self,
         attrs: &[syn::Attribute],
         declaring_file: &Path,
+        pruned_scope_declares_a_processor: impl FnOnce() -> bool,
     ) {
         let ModuleWalkCfgResolution::AgainstBuildTarget(target) = self.cfg_resolution else {
             return;
         };
+        let mut pruning_predicates: Vec<String> = Vec::new();
+        let mut undefined_features: BTreeSet<String> = BTreeSet::new();
         for attr in attrs.iter().filter(|attr| attr.path().is_ident("cfg")) {
             let Ok(meta) = attr.parse_args::<Meta>() else {
                 continue;
@@ -990,20 +1007,73 @@ impl ReachableModuleWalker<'_> {
             if eval_cfg_meta(&meta, target) {
                 continue;
             }
-            let mut undefined_features = BTreeSet::new();
-            collect_undefined_feature_atoms(&meta, target, &mut undefined_features);
-            if undefined_features.is_empty() {
+            let mut features_this_predicate_names = BTreeSet::new();
+            collect_undefined_feature_atoms(&meta, target, &mut features_this_predicate_names);
+            if features_this_predicate_names.is_empty() {
                 continue;
             }
-            tracing::warn!(
-                file = %declaring_file.display(),
-                predicate = %render_cfg_predicate(&meta),
-                undefined_features = %undefined_features.into_iter().collect::<Vec<_>>().join(", "),
-                "pruned a cfg scope gated on cargo features the scan target does not define — \
-                 any `#[processor(...)]` under it is absent from the derived `processors:` set \
-                 and will read as removed from code; declare the feature on the target with \
-                 `ModuleReachabilityTarget::with_feature` if the build enables it"
-            );
+            pruning_predicates.push(render_cfg_predicate(&meta));
+            undefined_features.extend(features_this_predicate_names);
+        }
+        if undefined_features.is_empty() || !pruned_scope_declares_a_processor() {
+            return;
+        }
+        tracing::warn!(
+            file = %declaring_file.display(),
+            predicate = %pruning_predicates.join(", "),
+            undefined_features = %undefined_features.into_iter().collect::<Vec<_>>().join(", "),
+            "pruned a `#[processor(...)]` behind a cfg gated on cargo features the scan target \
+             does not define — it is absent from the derived `processors:` set and will read as \
+             removed from code; declare the feature on the target with \
+             `ModuleReachabilityTarget::with_feature` if the build enables it"
+        );
+    }
+
+    /// Whether the module file a cfg predicate pruned would have declared a
+    /// `#[processor(...)]`.
+    fn pruned_module_file_declares_a_processor(&self, file: &Path, mod_dir: &Path) -> bool {
+        let mut across_every_build_target = self.walker_across_every_build_target();
+        across_every_build_target.walk_file(file, mod_dir).is_ok()
+            && !across_every_build_target.out.is_empty()
+    }
+
+    /// Whether the `mod` a cfg predicate pruned would have declared a
+    /// `#[processor(...)]`, in its own body or in any file below it.
+    fn pruned_module_item_declares_a_processor(
+        &self,
+        item: &syn::Item,
+        declaring_file: &Path,
+        mod_dir: &Path,
+        path_attribute_base_dir: &Path,
+        rel_path: &Path,
+    ) -> bool {
+        let mut across_every_build_target = self.walker_across_every_build_target();
+        across_every_build_target
+            .walk_item(
+                item,
+                declaring_file,
+                mod_dir,
+                path_attribute_base_dir,
+                rel_path,
+            )
+            .is_ok()
+            && !across_every_build_target.out.is_empty()
+    }
+
+    /// A second walker over the same package with cfg pruning off — how a
+    /// pruned scope is asked what it would have contributed. Its own walk
+    /// raises no diagnostics (the warning is target-resolved only), so this
+    /// cannot recurse.
+    fn walker_across_every_build_target(&self) -> ReachableModuleWalker<'_> {
+        ReachableModuleWalker {
+            package_dir: self.package_dir,
+            cfg_resolution: ModuleWalkCfgResolution::AcrossEveryBuildTarget,
+            top_level_arm_module_files: self.top_level_arm_module_files.clone(),
+            visited: BTreeSet::new(),
+            active_cfg_predicates: Vec::new(),
+            module_path_segments: Vec::new(),
+            enclosing_private_module_name: None,
+            out: Vec::new(),
         }
     }
 }
@@ -1590,6 +1660,41 @@ mod tests {
     fn names(mut procs: Vec<ExtractedProcessor>) -> Vec<String> {
         procs.sort_by(|a, b| a.schema.name.cmp(&b.schema.name));
         procs.into_iter().map(|p| p.schema.name).collect()
+    }
+
+    /// A `tracing` writer that keeps what a scan emitted, so a diagnostic can be
+    /// asserted on rather than only read in a log.
+    #[derive(Clone, Default)]
+    struct CapturedScanDiagnosticBuffer(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CapturedScanDiagnosticBuffer {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'writer> tracing_subscriber::fmt::MakeWriter<'writer> for CapturedScanDiagnosticBuffer {
+        type Writer = Self;
+        fn make_writer(&'writer self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// The `WARN`-level diagnostics a scan emitted, rendered.
+    fn warnings_emitted_by(scan: impl FnOnce()) -> String {
+        let captured = CapturedScanDiagnosticBuffer::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(captured.clone())
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .finish();
+        tracing::subscriber::with_default(subscriber, scan);
+        let rendered = captured.0.lock().unwrap().clone();
+        String::from_utf8(rendered).unwrap()
     }
 
     /// The parked-directory convention (`#![cfg(any())]` in
@@ -2865,6 +2970,91 @@ mod tests {
             names(extract_reachable_rust_processors(root, &macos()).unwrap()),
             vec!["Capture"]
         );
+    }
+
+    /// The diagnostic itself, observed: a feature-gated processor the scan
+    /// target cannot satisfy is named at the prune site, both when a file-level
+    /// `#![cfg]` prunes it and when the `mod` that would have reached it is
+    /// pruned a file above. Delete either call site and this fails.
+    #[test]
+    fn a_processor_pruned_by_an_undefined_feature_is_warned_about() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "processors/cuda_arm.rs",
+            r#"#![cfg(feature = "cuda")]
+            #[processor("@tatolab/demo/CudaCopy", execution = manual)]
+            pub struct CudaCopy;"#,
+        );
+        write(
+            root,
+            "processors/vulkan_arm/mod.rs",
+            r#"#[cfg(feature = "vulkan")]
+            pub mod blit;"#,
+        );
+        write(
+            root,
+            "processors/vulkan_arm/blit.rs",
+            r#"#[processor("@tatolab/demo/VulkanBlit", execution = manual)]
+            pub struct VulkanBlit;"#,
+        );
+
+        let warnings = warnings_emitted_by(|| {
+            let procs = extract_reachable_rust_processors(root, &linux()).unwrap();
+            assert!(names(procs).is_empty(), "neither feature is defined");
+        });
+        assert!(warnings.contains("processors/cuda_arm.rs"), "{warnings}");
+        assert!(warnings.contains("undefined_features=cuda"), "{warnings}");
+        assert!(
+            warnings.contains("processors/vulkan_arm/mod.rs"),
+            "{warnings}"
+        );
+        assert!(warnings.contains("undefined_features=vulkan"), "{warnings}");
+
+        // With the feature declared on the scan target nothing is pruned, so
+        // there is nothing to explain.
+        let quiet = warnings_emitted_by(|| {
+            let target = linux().with_feature("cuda").with_feature("vulkan");
+            let procs = extract_reachable_rust_processors(root, &target).unwrap();
+            assert_eq!(names(procs), vec!["CudaCopy", "VulkanBlit"]);
+        });
+        assert!(quiet.is_empty(), "{quiet}");
+    }
+
+    /// A feature-gated scope under `processors/` that declares NO processor is
+    /// pruned silently: nothing left the derived set, so the warning's whole
+    /// subject is absent and emitting it would be noise on every scan.
+    #[test]
+    fn a_feature_gated_scope_declaring_no_processor_is_pruned_silently() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "processors/arm/mod.rs",
+            r#"#[cfg(feature = "cuda")]
+            pub mod cuda_helpers;
+
+            #[processor("@tatolab/demo/Copy", execution = manual)]
+            pub struct Copy;"#,
+        );
+        write(
+            root,
+            "processors/arm/cuda_helpers.rs",
+            "pub fn align_pitch(width: usize) -> usize { width }",
+        );
+        write(
+            root,
+            "processors/cuda_only_helpers.rs",
+            r#"#![cfg(feature = "cuda")]
+            pub fn device_count() -> usize { 0 }"#,
+        );
+
+        let warnings = warnings_emitted_by(|| {
+            let procs = extract_reachable_rust_processors(root, &linux()).unwrap();
+            assert_eq!(names(procs), vec!["Copy"]);
+        });
+        assert!(warnings.is_empty(), "{warnings}");
     }
 
     /// A feature-gated scope the scan target cannot satisfy is named rather

--- a/sdk/streamlib-processor-extract/src/reachable.rs
+++ b/sdk/streamlib-processor-extract/src/reachable.rs
@@ -1278,6 +1278,11 @@ fn target_families_of_known_target_os(target_os: &str) -> Option<&'static [&'sta
         .map(|(_, families)| *families)
 }
 
+/// The `target_*` cfg keys the coherence rules can weigh against each other:
+/// `target_os` fixes a target's families, and `target_family` — spelled as a
+/// value or as the bare `unix` / `windows` flag — is that same fact.
+const TARGET_CFG_KEYS_THE_COHERENCE_RULES_RELATE: [&str; 2] = ["target_os", "target_family"];
+
 /// Ceiling on the assignment search. A processor group's predicates mention a
 /// handful of atoms in practice; a pathological one is left unproven (no
 /// refusal) rather than searched to a stall.
@@ -1291,14 +1296,19 @@ const MAX_CANDIDATE_BUILD_TARGET_ASSIGNMENTS: usize = 4096;
 /// witness. That polarity is the whole point: the caller refuses a build on it,
 /// so the witness must be an assignment some real target could have, which is
 /// what [`CfgPredicateAtomUniverse::candidate_build_target_is_coherent`] is
-/// for. Every rule there, and every fact the model does not know, PRUNES
-/// candidates — so the model's error direction is toward `None`.
+/// for. Every rule there PRUNES candidates, and an assignment pinning target
+/// atoms the rules relate to nothing is pruned rather than guessed at — so the
+/// model's error direction is toward `None`, on the one assumption it cannot
+/// check: that a value a predicate names is a value some target defines — two
+/// arms both gated on a misspelled `target_os = "linxu"` still witness each
+/// other, which is the answer an author wants anyway.
 ///
 /// A `None` is therefore "not proven", NOT "proven disjoint": an unparseable
 /// predicate, a search past the ceiling, a `target_os` outside
-/// [`TARGET_FAMILIES_BY_KNOWN_TARGET_OS`] weighed against a family atom, and a
-/// genuinely disjoint pair all land there. The concrete-target duplicate check
-/// stays the backstop for every one of them.
+/// [`TARGET_FAMILIES_BY_KNOWN_TARGET_OS`] weighed against a family atom, a pair
+/// resting on two target keys the rules cannot relate (`target_env` against
+/// `target_os`), and a genuinely disjoint pair all land there. The
+/// concrete-target duplicate check stays the backstop for every one of them.
 fn find_build_target_satisfying_both_cfg_predicate_sets(
     first_predicate_sources: &[String],
     second_predicate_sources: &[String],
@@ -1453,6 +1463,44 @@ impl CfgPredicateAtomUniverse {
             || self.single_valued_key_values.contains_key("target_family")
     }
 
+    /// Whether a candidate pins a `target_*` key from outside the cluster
+    /// [`TARGET_CFG_KEYS_THE_COHERENCE_RULES_RELATE`] names, while a second
+    /// target atom is decided.
+    ///
+    /// `rustc` fixes the target keys against one another — no target is both
+    /// `target_env = "msvc"` and `target_os = "linux"`, none is both
+    /// `target_arch = "wasm32"` and `target_env = "msvc"`, no `target_vendor =
+    /// "apple"` target is `not(unix)` — and the model holds none of those
+    /// facts. Weighing two of them is therefore a guess, and this search's
+    /// answers are read as proofs, so the candidate is dropped. A mentioned
+    /// bare family flag counts as that second atom whether the candidate
+    /// defines it or not — an assignment decides a flag both ways, unlike a
+    /// single-valued key it can leave at "some value the predicates never
+    /// name".
+    fn candidate_pins_target_cfg_keys_the_rules_cannot_relate(
+        &self,
+        candidate: &ModuleReachabilityTarget,
+    ) -> bool {
+        let mut pinned_relatable_keys: BTreeSet<&str> = BTreeSet::new();
+        let mut pinned_unrelatable_keys: BTreeSet<&str> = BTreeSet::new();
+        for (key, _) in &candidate.key_values {
+            if !key.starts_with("target_") {
+                continue;
+            }
+            if TARGET_CFG_KEYS_THE_COHERENCE_RULES_RELATE.contains(&key.as_str()) {
+                pinned_relatable_keys.insert(key.as_str());
+            } else {
+                pinned_unrelatable_keys.insert(key.as_str());
+            }
+        }
+        if pinned_unrelatable_keys.is_empty() {
+            return false;
+        }
+        pinned_relatable_keys.len() + pinned_unrelatable_keys.len() > 1
+            || self.mentions_flag("unix")
+            || self.mentions_flag("windows")
+    }
+
     /// Whether a candidate assignment describes a build target that could
     /// actually exist. Every rule is a fact about how `rustc` sets these atoms,
     /// so filtering by them only ever removes a target that would have proven a
@@ -1460,8 +1508,11 @@ impl CfgPredicateAtomUniverse {
     ///
     /// - `unix` and `windows` are the two target families a `cfg` names, and no
     ///   target is in both;
-    /// - `target_family = "unix"` / `"windows"` and the bare `unix` / `windows`
-    ///   flag are the same fact spelled two ways;
+    /// - the family flags a target defines are exactly the one its
+    ///   `target_family` names — the same fact spelled two ways, so a
+    ///   `target_family` outside the pair (`wasm`) defines neither flag. That
+    ///   is where modelling `target_family` single-valued costs a witness:
+    ///   `wasi` really is `wasm` AND `unix`, and this drops it;
     /// - the windows family holds exactly one `target_os`, `windows`;
     /// - a `target_os` [`TARGET_FAMILIES_BY_KNOWN_TARGET_OS`] names fixes the
     ///   families the target defines, both ways — `target_os = "ios"` forces
@@ -1470,22 +1521,25 @@ impl CfgPredicateAtomUniverse {
     /// A `target_os` that table does NOT name fixes nothing, so such a
     /// candidate is rejected outright once a family atom is in play: assigning
     /// it either way would be a guess, and this function's answers are read as
-    /// proofs.
+    /// proofs. A candidate pinning target keys the rules relate to nothing is
+    /// dropped for the same reason (see
+    /// [`CfgPredicateAtomUniverse::candidate_pins_target_cfg_keys_the_rules_cannot_relate`]).
     fn candidate_build_target_is_coherent(&self, candidate: &ModuleReachabilityTarget) -> bool {
         if candidate.has_flag("unix") && candidate.has_flag("windows") {
+            return false;
+        }
+        if self.candidate_pins_target_cfg_keys_the_rules_cannot_relate(candidate) {
             return false;
         }
         let candidate_target_os = candidate.single_defined_value_of_cfg_key("target_os");
         let candidate_target_family = candidate.single_defined_value_of_cfg_key("target_family");
 
-        for (family, opposite_family) in [("unix", "windows"), ("windows", "unix")] {
-            if candidate_target_family == Some(family) {
-                if candidate.has_flag(opposite_family) {
-                    return false;
-                }
-                if self.mentions_flag(family) && !candidate.has_flag(family) {
-                    return false;
-                }
+        for family in ["unix", "windows"] {
+            if let Some(candidate_target_family) = candidate_target_family
+                && self.mentions_flag(family)
+                && candidate.has_flag(family) != (candidate_target_family == family)
+            {
+                return false;
             }
             if candidate.has_flag(family)
                 && self.mentions_single_valued_key_value("target_family", family)
@@ -2538,20 +2592,107 @@ mod tests {
             )
             .is_none()
         );
-        // With no family atom in play the same OS proves normally.
+        // With no family atom in play the same OS proves normally: a cargo
+        // feature is free of the target, so the pair really can both compile.
         assert!(
             find_build_target_satisfying_both_cfg_predicate_sets(
                 &predicates(&[r#"target_os = "wasi""#]),
-                &predicates(&[r#"target_pointer_width = "32""#]),
+                &predicates(&[r#"feature = "cuda""#]),
             )
             .is_some()
         );
     }
 
-    /// The shape milestone 39 endorses at its widest: a platform split whose
-    /// third arm is the `not(unix)` fallback. All three are pairwise disjoint on
-    /// every real target, so the scan must ACCEPT them and fold them into one
-    /// availability entry.
+    /// The model reads a single-valued `target_family` as THE family, so a
+    /// value outside `unix` / `windows` defines neither flag. Without that,
+    /// `#![cfg(target_family = "wasm")]` and `#![cfg(windows)]` read satisfiable
+    /// — no rustc target is in both families — and a correct package is refused
+    /// on every build.
+    #[test]
+    fn a_target_family_outside_the_family_flags_defines_neither_flag() {
+        for family_atom in ["windows", "unix"] {
+            assert!(
+                find_build_target_satisfying_both_cfg_predicate_sets(
+                    &predicates(&[r#"target_family = "wasm""#]),
+                    &predicates(&[family_atom]),
+                )
+                .is_none(),
+                "a `wasm` target_family cannot also define `{family_atom}` in this model"
+            );
+        }
+        // The flag a `target_family` DOES name still proves.
+        assert!(
+            find_build_target_satisfying_both_cfg_predicate_sets(
+                &predicates(&[r#"target_family = "unix""#]),
+                &predicates(&["unix"]),
+            )
+            .is_some()
+        );
+    }
+
+    /// `rustc` fixes the target keys against one another and the model holds
+    /// none of those facts, so a pair resting on two of them is left UNPROVEN.
+    /// Without that, `#![cfg(target_env = "msvc")]` and `#![cfg(target_os =
+    /// "linux")]` read satisfiable on a build target no rustc triple has.
+    #[test]
+    fn a_pair_resting_on_unrelatable_target_keys_is_left_unproven() {
+        for (first, second) in [
+            (r#"target_env = "msvc""#, r#"target_os = "linux""#),
+            (r#"target_arch = "wasm32""#, r#"target_os = "linux""#),
+            (r#"target_vendor = "apple""#, "not(unix)"),
+            (r#"target_arch = "wasm32""#, r#"target_env = "msvc""#),
+        ] {
+            assert!(
+                find_build_target_satisfying_both_cfg_predicate_sets(
+                    &predicates(&[first]),
+                    &predicates(&[second]),
+                )
+                .is_none(),
+                "`{first}` and `{second}` name target keys the model cannot relate"
+            );
+        }
+        // One such key on its own pins nothing against anything.
+        assert!(
+            find_build_target_satisfying_both_cfg_predicate_sets(
+                &predicates(&[r#"target_env = "msvc""#]),
+                &predicates(&[r#"not(target_env = "gnu")"#]),
+            )
+            .is_some()
+        );
+    }
+
+    /// The end-to-end shape the two coherence gaps refused: arms gated on
+    /// families no target holds at once are disjoint, so the scan ACCEPTS them.
+    #[test]
+    fn arms_split_across_unrelated_target_keys_are_accepted() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "processors/wasm_arm.rs",
+            r#"#![cfg(target_family = "wasm")]
+            #[processor("@tatolab/demo/Capture", execution = manual)]
+            pub struct WasmCapture;"#,
+        );
+        write(
+            root,
+            "processors/windows_arm.rs",
+            r#"#![cfg(windows)]
+            #[processor("@tatolab/demo/Capture", execution = manual)]
+            pub struct WindowsCapture;"#,
+        );
+
+        let set = extract_processors_across_every_build_target(root)
+            .expect("no target is in both the wasm and windows families");
+        let availability = set
+            .availability_of_processor_type_name("Capture")
+            .expect("the two arms fold to one availability entry");
+        assert!(availability.is_available_on_build_target(&build_target_for_os("windows")));
+    }
+
+    /// A three-arm platform split whose third arm is the `not(unix)` fallback.
+    /// All three are pairwise disjoint on every real target, so the scan must
+    /// ACCEPT them and fold them into one availability entry.
     #[test]
     fn a_platform_split_with_a_non_unix_fallback_arm_is_accepted() {
         let tmp = tempdir();

--- a/sdk/streamlib-processor-extract/src/reachable.rs
+++ b/sdk/streamlib-processor-extract/src/reachable.rs
@@ -33,10 +33,11 @@
 //! is what lets the crate-root generator mirror the author's `#[cfg]` onto the
 //! `export_plugin!` entry verbatim rather than re-deriving a platform rule.
 //!
-//! Both walks then group what they collected by processor `Type` name — the key
-//! the plugin registry actually keys registration on — and refuse the two ways
-//! two arms declaring one processor can be wrong: they OVERLAP (some build
-//! target compiles both, so registration order decides which one ships) or they
+//! Both walks then group what they collected by processor `Type` name — the one
+//! segment the derived `processors:` entry keeps, and the segment the runtime
+//! re-composes each processor's ident from — and refuse the two ways two arms
+//! declaring one processor can be wrong: they OVERLAP (some build target
+//! compiles both, so walk order decides whose entry ships) or they
 //! DIVERGE (they derive different manifest entries, so the shipped
 //! `processors:` section depends on which arm the publishing host compiled). A
 //! GAP is not refused: a package legitimately declares a processor on some
@@ -590,10 +591,12 @@ fn resolve_processor_availability_across_build_targets(
 /// Declarations grouped by processor `Type` name, groups in first-declaration
 /// order and arms within a group in walk order.
 ///
-/// `Type` name rather than the full `@org/package/Type`: that is the key the
-/// plugin registry keys registration on, so two arms sharing a `Type` under
-/// different `@org/package` collide there and must be caught here rather than
-/// pass as two unrelated processors.
+/// `Type` name rather than the full `@org/package/Type`: the derived
+/// `processors:` entry keeps only that segment, and at load the runtime
+/// composes each processor's structured ident from the PACKAGE's own org / name
+/// plus it. Two arms sharing a `Type` therefore fold into one manifest entry
+/// and one composed ident whatever `@org/package` their attributes named, so
+/// they must be caught here rather than pass as two unrelated processors.
 fn group_declarations_by_processor_type_name(
     declarations: &[ExtractedProcessor],
 ) -> Vec<(&str, Vec<&ExtractedProcessor>)> {
@@ -2853,9 +2856,11 @@ mod tests {
     }
 
     /// Two arms sharing a `Type` under DIFFERENT `@org/package` are a
-    /// divergence, not two unrelated processors: the plugin registry keys
-    /// registration on the `Type` name alone, so they collide there. Mentally
-    /// drop the `SchemaIdent` off `ExtractedProcessor` and this passes silently.
+    /// divergence, not two unrelated processors: the derived `processors:`
+    /// entry drops the `@org/package` the attribute named, and the runtime
+    /// composes the ident from the package's own — so the two fold into one
+    /// entry either way. Mentally drop the `SchemaIdent` off
+    /// `ExtractedProcessor` and this passes silently.
     #[test]
     fn arms_sharing_a_type_under_different_packages_are_refused() {
         let tmp = tempdir();

--- a/sdk/streamlib-processor-extract/src/reachable.rs
+++ b/sdk/streamlib-processor-extract/src/reachable.rs
@@ -630,7 +630,10 @@ fn refuse_overlapping_processor_declarations(
 ) -> Result<(), ExtractError> {
     for (index, first) in declaring_arms.iter().enumerate() {
         for second in &declaring_arms[index + 1..] {
-            let Some(witness) = find_build_target_compiling_both_declarations(first, second) else {
+            let Some(witness) = find_build_target_satisfying_both_cfg_predicate_sets(
+                &first.cfg_predicates,
+                &second.cfg_predicates,
+            ) else {
                 continue;
             };
             return Err(ExtractError::OverlappingProcessorDeclarations {
@@ -1157,21 +1160,22 @@ const SET_VALUED_CFG_KEYS: [&str; 3] = ["feature", "target_feature", "target_has
 /// refusal) rather than searched to a stall.
 const MAX_CANDIDATE_BUILD_TARGET_ASSIGNMENTS: usize = 4096;
 
-/// A build target that compiles BOTH declarations, or `None` when none was
-/// found.
+/// A build target on which every predicate in BOTH sets holds, or `None` when
+/// none was found.
 ///
-/// Exhaustive over the atoms the two declarations' own predicates mention, so a
-/// `Some` is a proof carrying its own witness — the polarity that matters,
-/// because the caller refuses the build on it. A `None` is "not proven", not
+/// Exhaustive over the atoms the two sets themselves mention — a predicate's
+/// truth depends only on the atoms it names — so a `Some` is a proof carrying
+/// its own witness. That polarity is the whole point: the caller refuses a
+/// build on it, so it must never be a hunch. A `None` is "not proven", NOT
 /// "proven disjoint": an unparseable predicate, a search past the ceiling, and
 /// a genuinely disjoint pair all land there, and the concrete-target duplicate
-/// check remains the backstop.
-fn find_build_target_compiling_both_declarations(
-    first: &ExtractedProcessor,
-    second: &ExtractedProcessor,
+/// check stays the backstop for the first two.
+fn find_build_target_satisfying_both_cfg_predicate_sets(
+    first_predicate_sources: &[String],
+    second_predicate_sources: &[String],
 ) -> Option<ModuleReachabilityTarget> {
-    let first_predicates = parse_cfg_predicate_sources(&first.cfg_predicates)?;
-    let second_predicates = parse_cfg_predicate_sources(&second.cfg_predicates)?;
+    let first_predicates = parse_cfg_predicate_sources(first_predicate_sources)?;
+    let second_predicates = parse_cfg_predicate_sources(second_predicate_sources)?;
 
     let mut atoms = CfgPredicateAtomUniverse::default();
     for predicate in first_predicates.iter().chain(&second_predicates) {
@@ -1471,6 +1475,18 @@ mod tests {
             .with_key_value("target_os", "macos")
             .with_key_value("target_family", "unix")
             .with_flag("unix")
+    }
+
+    fn build_target_for_os(os: &str) -> ModuleReachabilityTarget {
+        let family = if os == "windows" { "windows" } else { "unix" };
+        ModuleReachabilityTarget::new()
+            .with_key_value("target_os", os)
+            .with_key_value("target_family", family)
+            .with_flag(family)
+    }
+
+    fn predicates(sources: &[&str]) -> Vec<String> {
+        sources.iter().map(|s| (*s).to_string()).collect()
     }
 
     fn names(mut procs: Vec<ExtractedProcessor>) -> Vec<String> {
@@ -2196,5 +2212,477 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    /// The two arms of a real platform-split package (`@tatolab/audio`) —
+    /// `target_os = "linux"` against `any(target_os = "macos", target_os =
+    /// "ios")`. Modelling `target_os` as SINGLE-VALUED is what makes them
+    /// provably disjoint; with the atoms independent this reads satisfiable and
+    /// the overlap check would refuse a correct package on every build.
+    #[test]
+    fn platform_split_arms_have_no_satisfying_build_target() {
+        assert!(
+            find_build_target_satisfying_both_cfg_predicate_sets(
+                &predicates(&[r#"target_os = "linux""#]),
+                &predicates(&[r#"any(target_os = "macos", target_os = "ios")"#]),
+            )
+            .is_none()
+        );
+    }
+
+    /// A family flag against a `target_os` value inside that family is
+    /// satisfiable, and the witness names the assignment that proves it.
+    #[test]
+    fn a_family_flag_and_an_os_inside_it_have_a_satisfying_build_target() {
+        let witness = find_build_target_satisfying_both_cfg_predicate_sets(
+            &predicates(&["unix"]),
+            &predicates(&[r#"target_os = "linux""#]),
+        )
+        .expect("unix and target_os = \"linux\" are satisfied together");
+        let atoms = witness.describe_defined_cfg_atoms();
+        assert!(atoms.contains(r#"target_os = "linux""#), "{atoms}");
+        assert!(atoms.contains("unix"), "{atoms}");
+    }
+
+    /// The coherence rules are facts about how `rustc` sets these atoms, so
+    /// they only ever remove a candidate that would have proven a FALSE overlap:
+    /// `unix` and `windows` are never both set, and the windows family holds
+    /// exactly one `target_os`. Mentally drop
+    /// `candidate_build_target_is_coherent` and each of these reads satisfiable.
+    #[test]
+    fn incoherent_build_targets_are_not_offered_as_witnesses() {
+        assert!(
+            find_build_target_satisfying_both_cfg_predicate_sets(
+                &predicates(&["unix"]),
+                &predicates(&["windows"]),
+            )
+            .is_none(),
+            "no target is in both families"
+        );
+        assert!(
+            find_build_target_satisfying_both_cfg_predicate_sets(
+                &predicates(&["windows"]),
+                &predicates(&[r#"target_os = "linux""#]),
+            )
+            .is_none(),
+            "the windows family holds only `target_os = \"windows\"`"
+        );
+        assert!(
+            find_build_target_satisfying_both_cfg_predicate_sets(
+                &predicates(&["unix"]),
+                &predicates(&[r#"target_family = "windows""#]),
+            )
+            .is_none(),
+            "`target_family` and the family flag are the same fact"
+        );
+    }
+
+    /// Cargo features are a SET, not a single value: a target enables many at
+    /// once, so two feature-gated arms really can both compile.
+    #[test]
+    fn two_feature_gated_arms_are_satisfiable_together() {
+        assert!(
+            find_build_target_satisfying_both_cfg_predicate_sets(
+                &predicates(&[r#"feature = "cuda""#]),
+                &predicates(&[r#"feature = "vulkan""#]),
+            )
+            .is_some()
+        );
+    }
+
+    /// Two arms with no `#[cfg]` at all are satisfied by every target, which is
+    /// the degenerate overlap: the empty predicate set holds vacuously.
+    #[test]
+    fn two_unconditional_arms_are_satisfiable_together() {
+        assert!(
+            find_build_target_satisfying_both_cfg_predicate_sets(&[], &[]).is_some(),
+            "an unconditional arm compiles everywhere, so two of them always collide"
+        );
+    }
+
+    /// Two arms one build target compiles both of are refused, naming both
+    /// source files and a target that exhibits the overlap. Mentally revert the
+    /// refusal and the package builds with two `export_plugin!` entries under
+    /// one name, of which the registry keeps whichever it sees first.
+    #[test]
+    fn overlapping_arms_are_refused_with_a_witness_build_target() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "processors/unix_arm.rs",
+            r#"#![cfg(unix)]
+            #[processor("@tatolab/demo/Capture", execution = manual, output("v", "@tatolab/core/VideoFrame"))]
+            pub struct UnixCapture;"#,
+        );
+        write(
+            root,
+            "processors/linux_arm.rs",
+            r#"#![cfg(target_os = "linux")]
+            #[processor("@tatolab/demo/Capture", execution = manual, output("v", "@tatolab/core/VideoFrame"))]
+            pub struct LinuxCapture;"#,
+        );
+
+        let error = extract_processors_across_every_build_target(root).unwrap_err();
+        let ExtractError::OverlappingProcessorDeclarations {
+            processor_type_name,
+            first_declared_in,
+            second_declared_in,
+            witness_build_target_atoms,
+        } = &error
+        else {
+            panic!("expected OverlappingProcessorDeclarations, got {error:?}");
+        };
+        assert_eq!(processor_type_name, "Capture");
+        let declared_in = [
+            first_declared_in.to_string_lossy().to_string(),
+            second_declared_in.to_string_lossy().to_string(),
+        ];
+        assert!(
+            declared_in.contains(&"processors/unix_arm.rs".to_string())
+                && declared_in.contains(&"processors/linux_arm.rs".to_string()),
+            "{declared_in:?}"
+        );
+        assert!(
+            witness_build_target_atoms.contains(r#"target_os = "linux""#),
+            "{witness_build_target_atoms}"
+        );
+        assert!(error.to_string().contains("declared twice"), "{error}");
+    }
+
+    /// The assertion that protects `@tatolab/audio`: two arms gated on disjoint
+    /// platform predicates are NOT an overlap, so the check refuses only on a
+    /// proven collision rather than on any two arms sharing a name.
+    #[test]
+    fn disjoint_platform_arms_declaring_one_processor_are_accepted() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "processors/linux/mod.rs",
+            r#"#![cfg(target_os = "linux")]
+            #[processor("@tatolab/demo/AudioCapture", execution = manual, output("audio", "@tatolab/core/AudioFrame"))]
+            pub struct LinuxAudioCapture;"#,
+        );
+        write(
+            root,
+            "processors/apple/mod.rs",
+            r#"#![cfg(any(target_os = "macos", target_os = "ios"))]
+            #[processor("@tatolab/demo/AudioCapture", execution = manual, output("audio", "@tatolab/core/AudioFrame"))]
+            pub struct AppleAudioCapture;"#,
+        );
+
+        let set = extract_processors_across_every_build_target(root).unwrap();
+        assert_eq!(set.processor_declarations.len(), 2);
+        assert_eq!(set.processor_availability.len(), 1);
+    }
+
+    /// Availability is the disjunction over the declaring arms, answered
+    /// through the one cfg evaluator — the datum that replaces "which targets
+    /// is this on?" being prose in a description string.
+    #[test]
+    fn a_two_arm_processors_availability_covers_both_arms_targets() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "processors/linux/mod.rs",
+            r#"#![cfg(target_os = "linux")]
+            #[processor("@tatolab/demo/AudioCapture", execution = manual, output("audio", "@tatolab/core/AudioFrame"))]
+            pub struct LinuxAudioCapture;"#,
+        );
+        write(
+            root,
+            "processors/apple/mod.rs",
+            r#"#![cfg(any(target_os = "macos", target_os = "ios"))]
+            #[processor("@tatolab/demo/AudioCapture", execution = manual, output("audio", "@tatolab/core/AudioFrame"))]
+            pub struct AppleAudioCapture;"#,
+        );
+
+        let set = extract_processors_across_every_build_target(root).unwrap();
+        let availability = set
+            .availability_of_processor_type_name("AudioCapture")
+            .expect("the two arms fold to one availability entry");
+        assert_eq!(
+            availability.processor_schema_ident.to_string(),
+            "@tatolab/demo/AudioCapture@0.0.0"
+        );
+        assert_eq!(
+            availability.declaring_arm_source_files,
+            vec![
+                PathBuf::from("processors/apple/mod.rs"),
+                PathBuf::from("processors/linux/mod.rs"),
+            ]
+        );
+        for os in ["linux", "macos", "ios"] {
+            assert!(
+                availability.is_available_on_build_target(&build_target_for_os(os)),
+                "AudioCapture must be available on {os}: {:?}",
+                availability.availability_cfg_predicate
+            );
+        }
+        assert!(
+            !availability.is_available_on_build_target(&build_target_for_os("windows")),
+            "neither arm compiles on windows"
+        );
+    }
+
+    /// An unconditional arm makes the processor unconditional: no predicate at
+    /// all, available everywhere. An `any(...)` naming the other arms would
+    /// understate where it exists.
+    #[test]
+    fn an_unconditional_arm_yields_unconditional_availability() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "processors/always.rs",
+            r#"#[processor("@tatolab/demo/Always", execution = reactive)]
+            pub struct Always;"#,
+        );
+        let set = extract_processors_across_every_build_target(root).unwrap();
+        let availability = set
+            .availability_of_processor_type_name("Always")
+            .expect("the unconditional arm has an availability entry");
+        assert!(availability.availability_cfg_predicate.is_none());
+        for os in ["linux", "macos", "ios", "windows"] {
+            assert!(availability.is_available_on_build_target(&build_target_for_os(os)));
+        }
+    }
+
+    /// A GAP is not an error: a package that declares a processor on some
+    /// targets and none on others is legitimate (`@tatolab/clap` is Apple-only,
+    /// `@tatolab/frame-tap` Linux-only). Availability reports the gap; nothing
+    /// refuses it.
+    #[test]
+    fn a_processor_available_on_no_common_target_is_not_an_error() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "processors/apple_only.rs",
+            r#"#![cfg(any(target_os = "macos", target_os = "ios"))]
+            #[processor("@tatolab/demo/AppleOnly", execution = reactive)]
+            pub struct AppleOnly;"#,
+        );
+        let set = extract_processors_across_every_build_target(root).unwrap();
+        let availability = set
+            .availability_of_processor_type_name("AppleOnly")
+            .unwrap();
+        assert!(!availability.is_available_on_build_target(&build_target_for_os("linux")));
+        assert!(availability.is_available_on_build_target(&build_target_for_os("macos")));
+    }
+
+    /// Two disjoint arms declaring one processor with different PORTS are
+    /// refused: the derived `processors:` section would carry whichever port
+    /// set the publishing host happened to compile. The diagnostic names the
+    /// port and both schema types, not just "they differ".
+    #[test]
+    fn arms_declaring_one_processor_with_different_ports_are_refused() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "processors/linux/mod.rs",
+            r#"#![cfg(target_os = "linux")]
+            #[processor("@tatolab/demo/AudioCapture", execution = manual, output("audio", "@tatolab/core/AudioFrame"))]
+            pub struct LinuxAudioCapture;"#,
+        );
+        write(
+            root,
+            "processors/apple/mod.rs",
+            r#"#![cfg(any(target_os = "macos", target_os = "ios"))]
+            #[processor("@tatolab/demo/AudioCapture", execution = manual, output("audio", "@tatolab/core/VideoFrame"))]
+            pub struct AppleAudioCapture;"#,
+        );
+
+        let error = extract_processors_across_every_build_target(root).unwrap_err();
+        let ExtractError::DivergentProcessorDeclarations {
+            processor_type_name,
+            difference,
+            ..
+        } = &error
+        else {
+            panic!("expected DivergentProcessorDeclarations, got {error:?}");
+        };
+        assert_eq!(processor_type_name, "AudioCapture");
+        assert!(difference.contains("output port `audio`"), "{difference}");
+        assert!(difference.contains("AudioFrame"), "{difference}");
+        assert!(difference.contains("VideoFrame"), "{difference}");
+        assert!(
+            difference.contains("processors/apple/mod.rs")
+                && difference.contains("processors/linux/mod.rs"),
+            "{difference}"
+        );
+    }
+
+    /// The same refusal for a differing execution mode.
+    #[test]
+    fn arms_declaring_one_processor_with_different_execution_are_refused() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "processors/linux/mod.rs",
+            r#"#![cfg(target_os = "linux")]
+            #[processor("@tatolab/demo/AudioCapture", execution = manual)]
+            pub struct LinuxAudioCapture;"#,
+        );
+        write(
+            root,
+            "processors/apple/mod.rs",
+            r#"#![cfg(any(target_os = "macos", target_os = "ios"))]
+            #[processor("@tatolab/demo/AudioCapture", execution = reactive)]
+            pub struct AppleAudioCapture;"#,
+        );
+
+        let error = extract_processors_across_every_build_target(root).unwrap_err();
+        let ExtractError::DivergentProcessorDeclarations { difference, .. } = &error else {
+            panic!("expected DivergentProcessorDeclarations, got {error:?}");
+        };
+        assert!(difference.contains("execution differs"), "{difference}");
+    }
+
+    /// Two arms sharing a `Type` under DIFFERENT `@org/package` are a
+    /// divergence, not two unrelated processors: the plugin registry keys
+    /// registration on the `Type` name alone, so they collide there. Mentally
+    /// drop the `SchemaIdent` off `ExtractedProcessor` and this passes silently.
+    #[test]
+    fn arms_sharing_a_type_under_different_packages_are_refused() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "processors/linux/mod.rs",
+            r#"#![cfg(target_os = "linux")]
+            #[processor("@tatolab/demo/AudioCapture", execution = manual)]
+            pub struct LinuxAudioCapture;"#,
+        );
+        write(
+            root,
+            "processors/apple/mod.rs",
+            r#"#![cfg(any(target_os = "macos", target_os = "ios"))]
+            #[processor("@tatolab/other/AudioCapture", execution = manual)]
+            pub struct AppleAudioCapture;"#,
+        );
+
+        let error = extract_processors_across_every_build_target(root).unwrap_err();
+        let ExtractError::DivergentProcessorDeclarations { difference, .. } = &error else {
+            panic!("expected DivergentProcessorDeclarations, got {error:?}");
+        };
+        assert!(difference.contains("identity differs"), "{difference}");
+        assert!(
+            difference.contains("@tatolab/demo/AudioCapture")
+                && difference.contains("@tatolab/other/AudioCapture"),
+            "{difference}"
+        );
+    }
+
+    /// The drift surface excludes `description`, but the derived manifest entry
+    /// carries it — so two arms whose descriptions disagree still ship a
+    /// host-dependent `processors:`. The whole-projection comparison is what
+    /// catches it; the lossy identity surface alone would not.
+    #[test]
+    fn arms_declaring_one_processor_with_different_descriptions_are_refused() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "processors/linux/mod.rs",
+            r#"#![cfg(target_os = "linux")]
+            #[processor("@tatolab/demo/AudioCapture", description = "ALSA capture", execution = manual)]
+            pub struct LinuxAudioCapture;"#,
+        );
+        write(
+            root,
+            "processors/apple/mod.rs",
+            r#"#![cfg(any(target_os = "macos", target_os = "ios"))]
+            #[processor("@tatolab/demo/AudioCapture", description = "CoreAudio capture", execution = manual)]
+            pub struct AppleAudioCapture;"#,
+        );
+
+        let error = extract_processors_across_every_build_target(root).unwrap_err();
+        let ExtractError::DivergentProcessorDeclarations { difference, .. } = &error else {
+            panic!("expected DivergentProcessorDeclarations, got {error:?}");
+        };
+        assert!(difference.contains("`description`"), "{difference}");
+    }
+
+    /// The reasoning-free net: a target-resolved scan that collects one `Type`
+    /// twice has PROVEN the overlap by compiling both, with no satisfiability
+    /// argument at all. This is what still fires when a predicate pair the atom
+    /// model cannot decide is compiled by a real host.
+    #[test]
+    fn one_build_target_collecting_a_processor_twice_is_refused() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "processors/unix_arm.rs",
+            r#"#![cfg(unix)]
+            #[processor("@tatolab/demo/Capture", execution = manual)]
+            pub struct UnixCapture;"#,
+        );
+        write(
+            root,
+            "processors/linux_arm.rs",
+            r#"#![cfg(target_os = "linux")]
+            #[processor("@tatolab/demo/Capture", execution = manual)]
+            pub struct LinuxCapture;"#,
+        );
+
+        let error = extract_reachable_rust_processors(root, &linux()).unwrap_err();
+        let ExtractError::OverlappingProcessorDeclarations {
+            processor_type_name,
+            witness_build_target_atoms,
+            ..
+        } = &error
+        else {
+            panic!("expected OverlappingProcessorDeclarations, got {error:?}");
+        };
+        assert_eq!(processor_type_name, "Capture");
+        assert!(
+            witness_build_target_atoms.contains(r#"target_os = "linux""#),
+            "{witness_build_target_atoms}"
+        );
+
+        // The same package on macOS compiles only the `unix` arm — one
+        // declaration, no refusal. The overlap is a property of the target, and
+        // the message names the target it was proven on.
+        assert_eq!(
+            names(extract_reachable_rust_processors(root, &macos()).unwrap()),
+            vec!["Capture"]
+        );
+    }
+
+    /// A feature-gated scope the scan target cannot satisfy is named rather
+    /// than silently dropped: `for_host()` infers no cargo features, so the
+    /// processor leaves the derived set and the publish-time drift gate reports
+    /// the committed entry as "no longer declared in code". The atoms the
+    /// warning names come from here.
+    #[test]
+    fn undefined_feature_atoms_in_a_pruning_predicate_are_named() {
+        let collect = |source: &str, target: &ModuleReachabilityTarget| {
+            let meta = syn::parse_str::<Meta>(source).unwrap();
+            let mut out = BTreeSet::new();
+            collect_undefined_feature_atoms(&meta, target, &mut out);
+            out.into_iter().collect::<Vec<_>>()
+        };
+
+        assert_eq!(
+            collect(r#"all(unix, feature = "cuda")"#, &linux()),
+            vec!["cuda".to_string()]
+        );
+        assert_eq!(
+            collect(r#"any(feature = "cuda", feature = "vulkan")"#, &linux()),
+            vec!["cuda".to_string(), "vulkan".to_string()]
+        );
+        // A feature the target DOES define is not the reason the scope pruned.
+        assert!(collect(r#"feature = "cuda""#, &linux().with_feature("cuda")).is_empty());
+        // Nothing feature-shaped pruned a platform-only predicate.
+        assert!(collect(r#"target_os = "windows""#, &linux()).is_empty());
+        // `not(feature = "x")` is satisfied BY absence, so a scope it prunes
+        // was pruned by the feature being PRESENT — not the confusing case.
+        assert!(collect(r#"not(feature = "cuda")"#, &linux()).is_empty());
     }
 }

--- a/sdk/streamlib-processor-extract/src/reachable.rs
+++ b/sdk/streamlib-processor-extract/src/reachable.rs
@@ -125,7 +125,8 @@ impl ModuleReachabilityTarget {
     /// Whether `("key", "value")` is defined by this target.
     fn has_key_value(&self, key: &str, value: &str) -> bool {
         self.key_values
-            .contains(&(key.to_string(), value.to_string()))
+            .iter()
+            .any(|(defined_key, defined_value)| defined_key == key && defined_value == value)
     }
 
     /// Whether the bare flag `name` is defined by this target.
@@ -148,7 +149,7 @@ impl ModuleReachabilityTarget {
     /// The cfg atoms this target defines, rendered the way a `#[cfg(...)]`
     /// predicate spells them (`target_os = "linux", unix`) — how a diagnostic
     /// names the build target it is talking about.
-    pub fn describe_defined_cfg_atoms(&self) -> String {
+    pub(crate) fn describe_defined_cfg_atoms(&self) -> String {
         let mut atoms: Vec<String> = self
             .key_values
             .iter()
@@ -156,7 +157,7 @@ impl ModuleReachabilityTarget {
             .collect();
         atoms.extend(self.flags.iter().cloned());
         if atoms.is_empty() {
-            return "a build target defining no cfg atoms".to_string();
+            return "no cfg atoms".to_string();
         }
         atoms.join(", ")
     }
@@ -1144,17 +1145,70 @@ pub(crate) fn disjoin_distinct_cfg_predicates<'predicate>(
     }
 }
 
-/// cfg keys a build target may define more than one value for.
+/// cfg keys the model lets a build target define more than one value for.
 ///
-/// Everything else — `target_os`, `target_arch`, `target_family`, `target_env`,
+/// Every other key — `target_os`, `target_arch`, `target_family`, `target_env`,
 /// `target_vendor`, `target_endian`, `target_pointer_width`, `target_abi`,
-/// `panic`, and any custom key — admits at most one value, which is what makes
-/// `target_os = "linux"` and `any(target_os = "macos", target_os = "ios")`
-/// provably disjoint rather than reading as satisfiable. Single-valued is the
-/// deliberate default: modelling a genuinely set-valued key as single-valued
-/// can only ever MISS an overlap (the concrete-target net still catches it),
-/// while the reverse would invent one and refuse a correct package.
+/// `panic`, and any custom key — is modelled as admitting at most one value,
+/// which is what makes `target_os = "linux"` and `any(target_os = "macos",
+/// target_os = "ios")` provably disjoint rather than reading as satisfiable.
+/// Single-valued is the deliberate default: modelling a genuinely set-valued
+/// key as single-valued can only ever MISS an overlap (the concrete-target net
+/// still catches it), while the reverse would invent one and refuse a correct
+/// package.
+///
+/// `target_family` is the known exception the model deliberately keeps
+/// single-valued: `rustc` sets it twice for the wasm-with-libc targets (`wasi`
+/// and `emscripten` are both `wasm` AND `unix`). Those OSes are therefore
+/// absent from [`TARGET_FAMILIES_BY_KNOWN_TARGET_OS`], which makes a candidate
+/// assigning one unusable as a witness rather than a wrong one.
 const SET_VALUED_CFG_KEYS: [&str; 3] = ["feature", "target_feature", "target_has_atomic"];
+
+/// The `target_family` values `rustc` defines for a `target_os`, for the single-
+/// family OSes the model knows.
+///
+/// The implication the atom search cannot derive on its own: nothing in a
+/// predicate's own atoms says that `target_os = "ios"` forces `unix`, so
+/// without this table a candidate is free to assign the pair `target_os =
+/// "ios"` + no `unix` — a target that does not exist — and offer it as a proof
+/// that a `#[cfg(target_os = "ios")]` arm and a `#[cfg(not(unix))]` arm
+/// overlap.
+///
+/// Deliberately partial. A `target_os` this table does not name determines
+/// nothing about the target's families, so a candidate assigning one cannot
+/// witness a predicate pair that mentions a family atom at all (see
+/// [`CfgPredicateAtomUniverse::candidate_build_target_is_coherent`]) — an
+/// unknown OS costs a missed overlap, never a false one, which is why the
+/// multi-family wasm targets are left out rather than approximated.
+const TARGET_FAMILIES_BY_KNOWN_TARGET_OS: &[(&str, &[&str])] = &[
+    ("android", &["unix"]),
+    ("dragonfly", &["unix"]),
+    ("freebsd", &["unix"]),
+    ("fuchsia", &["unix"]),
+    ("haiku", &["unix"]),
+    ("illumos", &["unix"]),
+    ("ios", &["unix"]),
+    ("linux", &["unix"]),
+    ("macos", &["unix"]),
+    ("netbsd", &["unix"]),
+    ("none", &[]),
+    ("openbsd", &["unix"]),
+    ("redox", &["unix"]),
+    ("solaris", &["unix"]),
+    ("tvos", &["unix"]),
+    ("visionos", &["unix"]),
+    ("watchos", &["unix"]),
+    ("windows", &["windows"]),
+];
+
+/// The families [`TARGET_FAMILIES_BY_KNOWN_TARGET_OS`] pins for a `target_os`,
+/// or `None` for one it does not name.
+fn target_families_of_known_target_os(target_os: &str) -> Option<&'static [&'static str]> {
+    TARGET_FAMILIES_BY_KNOWN_TARGET_OS
+        .iter()
+        .find(|(known_target_os, _)| *known_target_os == target_os)
+        .map(|(_, families)| *families)
+}
 
 /// Ceiling on the assignment search. A processor group's predicates mention a
 /// handful of atoms in practice; a pathological one is left unproven (no
@@ -1165,12 +1219,18 @@ const MAX_CANDIDATE_BUILD_TARGET_ASSIGNMENTS: usize = 4096;
 /// none was found.
 ///
 /// Exhaustive over the atoms the two sets themselves mention — a predicate's
-/// truth depends only on the atoms it names — so a `Some` is a proof carrying
-/// its own witness. That polarity is the whole point: the caller refuses a
-/// build on it, so it must never be a hunch. A `None` is "not proven", NOT
-/// "proven disjoint": an unparseable predicate, a search past the ceiling, and
-/// a genuinely disjoint pair all land there, and the concrete-target duplicate
-/// check stays the backstop for the first two.
+/// truth depends only on the atoms it names — so a `Some` carries its own
+/// witness. That polarity is the whole point: the caller refuses a build on it,
+/// so the witness must be an assignment some real target could have, which is
+/// what [`CfgPredicateAtomUniverse::candidate_build_target_is_coherent`] is
+/// for. Every rule there, and every fact the model does not know, PRUNES
+/// candidates — so the model's error direction is toward `None`.
+///
+/// A `None` is therefore "not proven", NOT "proven disjoint": an unparseable
+/// predicate, a search past the ceiling, a `target_os` outside
+/// [`TARGET_FAMILIES_BY_KNOWN_TARGET_OS`] weighed against a family atom, and a
+/// genuinely disjoint pair all land there. The concrete-target duplicate check
+/// stays the backstop for every one of them.
 fn find_build_target_satisfying_both_cfg_predicate_sets(
     first_predicate_sources: &[String],
     second_predicate_sources: &[String],
@@ -1183,8 +1243,7 @@ fn find_build_target_satisfying_both_cfg_predicate_sets(
         atoms.collect_from(predicate);
     }
 
-    let candidates = atoms.candidate_build_targets()?;
-    candidates.into_iter().find(|candidate| {
+    atoms.candidate_build_targets()?.find(|candidate| {
         first_predicates
             .iter()
             .chain(&second_predicates)
@@ -1253,7 +1312,13 @@ impl CfgPredicateAtomUniverse {
 
     /// Every coherent build target that assigns these atoms, or `None` when the
     /// search space exceeds [`MAX_CANDIDATE_BUILD_TARGET_ASSIGNMENTS`].
-    fn candidate_build_targets(&self) -> Option<Vec<ModuleReachabilityTarget>> {
+    ///
+    /// Lazy: the caller stops at the first assignment that satisfies both
+    /// predicate sets, and the ceiling is what bounds the walk, so materializing
+    /// the space would only build targets nobody looks at.
+    fn candidate_build_targets(
+        &self,
+    ) -> Option<impl Iterator<Item = ModuleReachabilityTarget> + '_> {
         let choices = self.candidate_atom_choices();
         let mut assignment_count: usize = 1;
         for choice in &choices {
@@ -1267,20 +1332,17 @@ impl CfgPredicateAtomUniverse {
             }
         }
 
-        let mut candidates = Vec::with_capacity(assignment_count);
-        for encoded in 0..assignment_count {
+        Some((0..assignment_count).filter_map(move |encoded| {
             let mut remaining = encoded;
-            let mut target = ModuleReachabilityTarget::new();
+            let mut candidate = ModuleReachabilityTarget::new();
             for choice in &choices {
                 let arity = choice.arity();
-                choice.apply(remaining % arity, &mut target);
+                choice.apply(remaining % arity, &mut candidate);
                 remaining /= arity;
             }
-            if self.candidate_build_target_is_coherent(&target) {
-                candidates.push(target);
-            }
-        }
-        Some(candidates)
+            self.candidate_build_target_is_coherent(&candidate)
+                .then_some(candidate)
+        }))
     }
 
     fn candidate_atom_choices(&self) -> Vec<CandidateCfgAtomChoice<'_>> {
@@ -1302,6 +1364,27 @@ impl CfgPredicateAtomUniverse {
         choices
     }
 
+    /// Whether the predicates mention a bare flag atom.
+    fn mentions_flag(&self, flag: &str) -> bool {
+        self.flags.contains(flag)
+    }
+
+    /// Whether the predicates mention `key = "value"` for a single-valued key.
+    fn mentions_single_valued_key_value(&self, key: &str, value: &str) -> bool {
+        self.single_valued_key_values
+            .get(key)
+            .is_some_and(|mentioned| mentioned.contains(value))
+    }
+
+    /// Whether the predicates mention any atom whose truth is decided by the
+    /// target's families — the atoms a `target_os` outside
+    /// [`TARGET_FAMILIES_BY_KNOWN_TARGET_OS`] cannot decide.
+    fn mentions_a_target_family_atom(&self) -> bool {
+        self.mentions_flag("unix")
+            || self.mentions_flag("windows")
+            || self.single_valued_key_values.contains_key("target_family")
+    }
+
     /// Whether a candidate assignment describes a build target that could
     /// actually exist. Every rule is a fact about how `rustc` sets these atoms,
     /// so filtering by them only ever removes a target that would have proven a
@@ -1309,52 +1392,66 @@ impl CfgPredicateAtomUniverse {
     ///
     /// - `unix` and `windows` are the two target families a `cfg` names, and no
     ///   target is in both;
-    /// - the windows family holds exactly one `target_os`, `windows`;
     /// - `target_family = "unix"` / `"windows"` and the bare `unix` / `windows`
-    ///   flag are the same fact spelled two ways.
-    fn candidate_build_target_is_coherent(&self, target: &ModuleReachabilityTarget) -> bool {
-        let defines_unix = target.has_flag("unix");
-        let defines_windows = target.has_flag("windows");
-        if defines_unix && defines_windows {
+    ///   flag are the same fact spelled two ways;
+    /// - the windows family holds exactly one `target_os`, `windows`;
+    /// - a `target_os` [`TARGET_FAMILIES_BY_KNOWN_TARGET_OS`] names fixes the
+    ///   families the target defines, both ways — `target_os = "ios"` forces
+    ///   `unix`, and forbids `windows`.
+    ///
+    /// A `target_os` that table does NOT name fixes nothing, so such a
+    /// candidate is rejected outright once a family atom is in play: assigning
+    /// it either way would be a guess, and this function's answers are read as
+    /// proofs.
+    fn candidate_build_target_is_coherent(&self, candidate: &ModuleReachabilityTarget) -> bool {
+        if candidate.has_flag("unix") && candidate.has_flag("windows") {
             return false;
         }
-        let target_os = target.single_defined_value_of_cfg_key("target_os");
-        let target_family = target.single_defined_value_of_cfg_key("target_family");
+        let candidate_target_os = candidate.single_defined_value_of_cfg_key("target_os");
+        let candidate_target_family = candidate.single_defined_value_of_cfg_key("target_family");
 
-        if defines_windows && target_os.is_some_and(|os| os != "windows") {
+        for (family, opposite_family) in [("unix", "windows"), ("windows", "unix")] {
+            if candidate_target_family == Some(family) {
+                if candidate.has_flag(opposite_family) {
+                    return false;
+                }
+                if self.mentions_flag(family) && !candidate.has_flag(family) {
+                    return false;
+                }
+            }
+            if candidate.has_flag(family)
+                && self.mentions_single_valued_key_value("target_family", family)
+                && candidate_target_family != Some(family)
+            {
+                return false;
+            }
+        }
+
+        if (candidate.has_flag("windows") || candidate_target_family == Some("windows"))
+            && self.mentions_single_valued_key_value("target_os", "windows")
+            && candidate_target_os != Some("windows")
+        {
             return false;
         }
-        if defines_unix && target_os == Some("windows") {
-            return false;
-        }
-        if target_os == Some("windows") {
-            if self.flags.contains("windows") && !defines_windows {
-                return false;
-            }
-            if target_family.is_some_and(|family| family != "windows") {
-                return false;
-            }
-        }
-        if target_family == Some("windows") {
-            if target_os.is_some_and(|os| os != "windows") {
-                return false;
-            }
-            if self.flags.contains("unix") && defines_unix {
-                return false;
-            }
-            if self.flags.contains("windows") && !defines_windows {
+
+        let Some(candidate_target_os) = candidate_target_os else {
+            return true;
+        };
+        let Some(families) = target_families_of_known_target_os(candidate_target_os) else {
+            return !self.mentions_a_target_family_atom();
+        };
+        for family in ["unix", "windows"] {
+            if self.mentions_flag(family) && candidate.has_flag(family) != families.contains(&family)
+            {
                 return false;
             }
         }
-        if target_family == Some("unix") {
-            if defines_windows {
-                return false;
-            }
-            if self.flags.contains("unix") && !defines_unix {
-                return false;
-            }
+        match candidate_target_family {
+            Some(family) => families.contains(&family),
+            None => !families
+                .iter()
+                .any(|family| self.mentions_single_valued_key_value("target_family", family)),
         }
-        true
     }
 }
 
@@ -2276,6 +2373,120 @@ mod tests {
             .is_none(),
             "`target_family` and the family flag are the same fact"
         );
+    }
+
+    /// A `target_os` the model knows carries its family with it: no target is
+    /// both `target_os = "ios"` and `not(unix)`. Without
+    /// [`TARGET_FAMILIES_BY_KNOWN_TARGET_OS`] the search assigns that pair
+    /// freely, calls it a proof, and refuses the three-arm platform split
+    /// below on every build.
+    #[test]
+    fn a_known_os_and_a_negated_family_flag_have_no_satisfying_build_target() {
+        for os_predicate in [
+            r#"target_os = "linux""#,
+            r#"any(target_os = "macos", target_os = "ios")"#,
+            r#"target_os = "android""#,
+        ] {
+            assert!(
+                find_build_target_satisfying_both_cfg_predicate_sets(
+                    &predicates(&[os_predicate]),
+                    &predicates(&["not(unix)"]),
+                )
+                .is_none(),
+                "`{os_predicate}` names a unix-family OS, so no target satisfies it and `not(unix)`"
+            );
+        }
+        assert!(
+            find_build_target_satisfying_both_cfg_predicate_sets(
+                &predicates(&[r#"target_os = "windows""#]),
+                &predicates(&["not(windows)"]),
+            )
+            .is_none()
+        );
+        // The other direction still proves: a unix OS and the family flag it
+        // implies really do overlap.
+        assert!(
+            find_build_target_satisfying_both_cfg_predicate_sets(
+                &predicates(&[r#"target_os = "macos""#]),
+                &predicates(&["unix"]),
+            )
+            .is_some()
+        );
+    }
+
+    /// A `target_os` outside the family table decides nothing, so a pair that
+    /// weighs one against a family atom is left UNPROVEN rather than guessed in
+    /// either direction — `wasi` is both `wasm` and `unix`, which is exactly the
+    /// guess a partial table must not make.
+    #[test]
+    fn an_unmodelled_os_weighed_against_a_family_atom_is_left_unproven() {
+        assert!(
+            find_build_target_satisfying_both_cfg_predicate_sets(
+                &predicates(&[r#"target_os = "wasi""#]),
+                &predicates(&["not(unix)"]),
+            )
+            .is_none()
+        );
+        assert!(
+            find_build_target_satisfying_both_cfg_predicate_sets(
+                &predicates(&[r#"target_os = "wasi""#]),
+                &predicates(&["unix"]),
+            )
+            .is_none()
+        );
+        // With no family atom in play the same OS proves normally.
+        assert!(
+            find_build_target_satisfying_both_cfg_predicate_sets(
+                &predicates(&[r#"target_os = "wasi""#]),
+                &predicates(&[r#"target_pointer_width = "32""#]),
+            )
+            .is_some()
+        );
+    }
+
+    /// The shape milestone 39 endorses at its widest: a platform split whose
+    /// third arm is the `not(unix)` fallback. All three are pairwise disjoint on
+    /// every real target, so the scan must ACCEPT them and fold them into one
+    /// availability entry.
+    #[test]
+    fn a_platform_split_with_a_non_unix_fallback_arm_is_accepted() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write(
+            root,
+            "processors/linux_arm.rs",
+            r#"#![cfg(target_os = "linux")]
+            #[processor("@tatolab/demo/Capture", execution = manual)]
+            pub struct LinuxCapture;"#,
+        );
+        write(
+            root,
+            "processors/apple_arm.rs",
+            r#"#![cfg(any(target_os = "macos", target_os = "ios"))]
+            #[processor("@tatolab/demo/Capture", execution = manual)]
+            pub struct AppleCapture;"#,
+        );
+        write(
+            root,
+            "processors/other_arm.rs",
+            r#"#![cfg(not(unix))]
+            #[processor("@tatolab/demo/Capture", execution = manual)]
+            pub struct OtherCapture;"#,
+        );
+
+        let set = extract_processors_across_every_build_target(root)
+            .expect("three pairwise-disjoint arms are not an overlap");
+        assert_eq!(set.processor_declarations.len(), 3);
+        let availability = set
+            .availability_of_processor_type_name("Capture")
+            .expect("the three arms fold to one availability entry");
+        for os in ["linux", "macos", "ios", "windows"] {
+            assert!(
+                availability.is_available_on_build_target(&build_target_for_os(os)),
+                "some arm covers {os}: {:?}",
+                availability.availability_cfg_predicate
+            );
+        }
     }
 
     /// Cargo features are a SET, not a single value: a target enables many at

--- a/sdk/streamlib-processor-extract/src/reachable.rs
+++ b/sdk/streamlib-processor-extract/src/reachable.rs
@@ -48,7 +48,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use quote::ToTokens;
-use streamlib_processor_schema::SchemaIdent;
 use syn::punctuated::Punctuated;
 use syn::{Meta, Token};
 
@@ -428,13 +427,9 @@ impl ProcessorSetAcrossEveryBuildTarget {
 /// than reimplementing cfg semantics beside it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcessorAvailabilityAcrossBuildTargets {
-    /// The `Type` segment — the name the plugin registry keys registration on,
-    /// and therefore the name two arms collide under.
+    /// The `Type` segment — the only segment the derived `processors:` entry
+    /// keeps, and therefore the name two arms collide under.
     pub processor_type_name: String,
-    /// The version-free `@org/package/Type` identity every declaring arm agrees
-    /// on, carrying the grammar's `0.0.0` sentinel rather than a real version
-    /// (a disagreement here is refused as divergence, never merged).
-    pub processor_schema_ident: SchemaIdent,
     /// The disjunction over each declaring arm's conjoined `#[cfg(...)]`
     /// predicates, as source text. `None` is unconditional: some arm is gated
     /// by nothing, so the processor exists on every build target.
@@ -543,15 +538,14 @@ fn refuse_processors_declared_twice_for_one_build_target(
     processors: &[ExtractedProcessor],
     target: &ModuleReachabilityTarget,
 ) -> Result<(), ExtractError> {
-    for (index, first) in processors.iter().enumerate() {
-        let Some(second) = processors[index + 1..]
-            .iter()
-            .find(|second| second.schema.name == first.schema.name)
-        else {
+    for (processor_type_name, declaring_arms) in
+        group_declarations_by_processor_type_name(processors)
+    {
+        let [first, second, ..] = declaring_arms.as_slice() else {
             continue;
         };
         return Err(ExtractError::OverlappingProcessorDeclarations {
-            processor_type_name: first.schema.name.clone(),
+            processor_type_name: processor_type_name.to_string(),
             first_declared_in: first.source_file.clone(),
             second_declared_in: second.source_file.clone(),
             witness_build_target_atoms: target.describe_defined_cfg_atoms(),
@@ -577,20 +571,13 @@ fn resolve_processor_availability_across_build_targets(
             .iter()
             .map(|arm| conjoin_cfg_predicates(&arm.cfg_predicates))
             .collect();
-        // One unconditional arm makes the processor unconditional: its
-        // disjunction with anything is `true`, and an `any(...)` naming the
-        // other arms would understate where it exists.
-        let availability_cfg_predicate = arm_predicates
-            .iter()
-            .all(|predicate| predicate.is_some())
-            .then(|| {
-                disjoin_distinct_cfg_predicates(arm_predicates.iter().filter_map(|p| p.as_deref()))
-            });
 
         out.push(ProcessorAvailabilityAcrossBuildTargets {
             processor_type_name: processor_type_name.to_string(),
-            processor_schema_ident: declaring_arms[0].schema_ident.clone(),
-            availability_cfg_predicate,
+            availability_cfg_predicate:
+                disjoin_cfg_predicates_when_every_alternative_is_conditional(
+                    arm_predicates.iter().map(Option::as_deref),
+                ),
             declaring_arm_source_files: declaring_arms
                 .iter()
                 .map(|arm| arm.source_file.clone())
@@ -1197,21 +1184,29 @@ pub(crate) fn conjoin_cfg_predicates(predicates: &[String]) -> Option<String> {
     }
 }
 
-/// Fold alternative `#[cfg(...)]` predicates into their disjunction,
-/// de-duplicated and in first-seen order. A single distinct predicate folds to
-/// itself rather than a one-armed `any(...)`.
-pub(crate) fn disjoin_distinct_cfg_predicates<'predicate>(
-    predicates: impl IntoIterator<Item = &'predicate str>,
-) -> String {
+/// Fold alternative `#[cfg(...)]` predicates into their disjunction, `None`
+/// when the alternatives are unconditional — either because one of them is
+/// (its disjunction with anything holds everywhere, and an `any(...)` naming
+/// the others would understate where it holds) or because there are none to
+/// gate on.
+///
+/// The one owner of the disjunction rule: a processor's availability across its
+/// declaring arms and the crate root's `export_plugin!` gate across the
+/// package's processors are the same fold.
+pub(crate) fn disjoin_cfg_predicates_when_every_alternative_is_conditional<'predicate>(
+    alternatives: impl IntoIterator<Item = Option<&'predicate str>>,
+) -> Option<String> {
+    let conditional_alternatives: Option<Vec<&str>> = alternatives.into_iter().collect();
     let mut distinct: Vec<&str> = Vec::new();
-    for predicate in predicates {
+    for predicate in conditional_alternatives? {
         if !distinct.contains(&predicate) {
             distinct.push(predicate);
         }
     }
     match distinct.as_slice() {
-        [single] => (*single).to_string(),
-        many => format!("any({})", many.join(", ")),
+        [] => None,
+        [single] => Some((*single).to_string()),
+        many => Some(format!("any({})", many.join(", "))),
     }
 }
 
@@ -1511,7 +1506,8 @@ impl CfgPredicateAtomUniverse {
             return !self.mentions_a_target_family_atom();
         };
         for family in ["unix", "windows"] {
-            if self.mentions_flag(family) && candidate.has_flag(family) != families.contains(&family)
+            if self.mentions_flag(family)
+                && candidate.has_flag(family) != families.contains(&family)
             {
                 return false;
             }
@@ -2720,10 +2716,6 @@ mod tests {
         let availability = set
             .availability_of_processor_type_name("AudioCapture")
             .expect("the two arms fold to one availability entry");
-        assert_eq!(
-            availability.processor_schema_ident.to_string(),
-            "@tatolab/demo/AudioCapture@0.0.0"
-        );
         assert_eq!(
             availability.declaring_arm_source_files,
             vec![

--- a/sdk/streamlib-processor-extract/src/reachable.rs
+++ b/sdk/streamlib-processor-extract/src/reachable.rs
@@ -1296,17 +1296,22 @@ const MAX_CANDIDATE_BUILD_TARGET_ASSIGNMENTS: usize = 4096;
 /// witness. That polarity is the whole point: the caller refuses a build on it,
 /// so the witness must be an assignment some real target could have, which is
 /// what [`CfgPredicateAtomUniverse::candidate_build_target_is_coherent`] is
-/// for. Every rule there PRUNES candidates, and an assignment pinning target
-/// atoms the rules relate to nothing is pruned rather than guessed at — so the
-/// model's error direction is toward `None`, on the one assumption it cannot
-/// check: that a value a predicate names is a value some target defines — two
-/// arms both gated on a misspelled `target_os = "linxu"` still witness each
-/// other, which is the answer an author wants anyway.
+/// for. Every rule there PRUNES candidates, and an assignment resting on target
+/// atoms the rules relate to nothing is pruned rather than guessed at, so the
+/// model's error direction is toward `None`.
+///
+/// Two assumptions stay unchecked, and both are about a single atom rather than
+/// about how two atoms relate: that a value a predicate names is a value some
+/// target defines, and that an atom a predicate names is one some target leaves
+/// undefined. So two arms both gated on a misspelled `target_os = "linxu"` still
+/// witness each other — which is the answer an author wants anyway — and a
+/// candidate turning an unstable bare flag like `target_thread_local` off is
+/// taken at its word.
 ///
 /// A `None` is therefore "not proven", NOT "proven disjoint": an unparseable
 /// predicate, a search past the ceiling, a `target_os` outside
 /// [`TARGET_FAMILIES_BY_KNOWN_TARGET_OS`] weighed against a family atom, a pair
-/// resting on two target keys the rules cannot relate (`target_env` against
+/// resting on two target atoms the rules cannot relate (`target_env` against
 /// `target_os`), and a genuinely disjoint pair all land there. The
 /// concrete-target duplicate check stays the backstop for every one of them.
 fn find_build_target_satisfying_both_cfg_predicate_sets(
@@ -1454,51 +1459,60 @@ impl CfgPredicateAtomUniverse {
             .is_some_and(|mentioned| mentioned.contains(value))
     }
 
+    /// Whether the predicates mention `unix` or `windows` — the `target_family`
+    /// fact spelled as a bare flag.
+    fn mentions_a_bare_family_flag(&self) -> bool {
+        self.mentions_flag("unix") || self.mentions_flag("windows")
+    }
+
     /// Whether the predicates mention any atom whose truth is decided by the
     /// target's families — the atoms a `target_os` outside
     /// [`TARGET_FAMILIES_BY_KNOWN_TARGET_OS`] cannot decide.
     fn mentions_a_target_family_atom(&self) -> bool {
-        self.mentions_flag("unix")
-            || self.mentions_flag("windows")
+        self.mentions_a_bare_family_flag()
             || self.single_valued_key_values.contains_key("target_family")
     }
 
-    /// Whether a candidate pins a `target_*` key from outside the cluster
+    /// Whether a candidate defines a `target_*` atom from outside the cluster
     /// [`TARGET_CFG_KEYS_THE_COHERENCE_RULES_RELATE`] names, while a second
     /// target atom is decided.
     ///
-    /// `rustc` fixes the target keys against one another — no target is both
+    /// `rustc` fixes the target atoms against one another — no target is both
     /// `target_env = "msvc"` and `target_os = "linux"`, none is both
     /// `target_arch = "wasm32"` and `target_env = "msvc"`, no `target_vendor =
     /// "apple"` target is `not(unix)` — and the model holds none of those
     /// facts. Weighing two of them is therefore a guess, and this search's
-    /// answers are read as proofs, so the candidate is dropped. A mentioned
-    /// bare family flag counts as that second atom whether the candidate
-    /// defines it or not — an assignment decides a flag both ways, unlike a
-    /// single-valued key it can leave at "some value the predicates never
-    /// name".
-    fn candidate_pins_target_cfg_keys_the_rules_cannot_relate(
+    /// answers are read as proofs, so the candidate is dropped.
+    ///
+    /// Only an atom the candidate DEFINES counts on the unrelatable side: a
+    /// candidate that leaves a key at "some value the predicates never name",
+    /// or a flag unset, claims no more than that the atom is absent somewhere,
+    /// which is what every single-valued key in this model already rests on.
+    /// The relatable side is the mirror: `target_os`, `target_family` and the
+    /// family flags count as decided wherever the PREDICATES mention them,
+    /// defined or not, because it is exactly that unnamed-value slot that makes
+    /// a negated `target_os` / `target_family` value true.
+    fn candidate_rests_on_target_cfg_atoms_the_rules_cannot_relate(
         &self,
         candidate: &ModuleReachabilityTarget,
     ) -> bool {
-        let mut pinned_relatable_keys: BTreeSet<&str> = BTreeSet::new();
-        let mut pinned_unrelatable_keys: BTreeSet<&str> = BTreeSet::new();
-        for (key, _) in &candidate.key_values {
-            if !key.starts_with("target_") {
-                continue;
-            }
-            if TARGET_CFG_KEYS_THE_COHERENCE_RULES_RELATE.contains(&key.as_str()) {
-                pinned_relatable_keys.insert(key.as_str());
-            } else {
-                pinned_unrelatable_keys.insert(key.as_str());
-            }
+        let mut decided_target_cfg_atom_names: BTreeSet<&str> = candidate
+            .key_values
+            .iter()
+            .map(|(key, _)| key.as_str())
+            .chain(candidate.flags.iter().map(String::as_str))
+            .filter(|atom| atom.starts_with("target_"))
+            .collect();
+        let defines_an_unrelatable_target_atom = decided_target_cfg_atom_names
+            .iter()
+            .any(|atom| !TARGET_CFG_KEYS_THE_COHERENCE_RULES_RELATE.contains(atom));
+        if self.single_valued_key_values.contains_key("target_os") {
+            decided_target_cfg_atom_names.insert("target_os");
         }
-        if pinned_unrelatable_keys.is_empty() {
-            return false;
+        if self.mentions_a_target_family_atom() {
+            decided_target_cfg_atom_names.insert("target_family");
         }
-        pinned_relatable_keys.len() + pinned_unrelatable_keys.len() > 1
-            || self.mentions_flag("unix")
-            || self.mentions_flag("windows")
+        defines_an_unrelatable_target_atom && decided_target_cfg_atom_names.len() > 1
     }
 
     /// Whether a candidate assignment describes a build target that could
@@ -1521,14 +1535,14 @@ impl CfgPredicateAtomUniverse {
     /// A `target_os` that table does NOT name fixes nothing, so such a
     /// candidate is rejected outright once a family atom is in play: assigning
     /// it either way would be a guess, and this function's answers are read as
-    /// proofs. A candidate pinning target keys the rules relate to nothing is
-    /// dropped for the same reason (see
-    /// [`CfgPredicateAtomUniverse::candidate_pins_target_cfg_keys_the_rules_cannot_relate`]).
+    /// proofs. A candidate resting on target atoms the rules relate to nothing
+    /// is dropped for the same reason (see
+    /// [`CfgPredicateAtomUniverse::candidate_rests_on_target_cfg_atoms_the_rules_cannot_relate`]).
     fn candidate_build_target_is_coherent(&self, candidate: &ModuleReachabilityTarget) -> bool {
         if candidate.has_flag("unix") && candidate.has_flag("windows") {
             return false;
         }
-        if self.candidate_pins_target_cfg_keys_the_rules_cannot_relate(candidate) {
+        if self.candidate_rests_on_target_cfg_atoms_the_rules_cannot_relate(candidate) {
             return false;
         }
         let candidate_target_os = candidate.single_defined_value_of_cfg_key("target_os");
@@ -2630,10 +2644,16 @@ mod tests {
         );
     }
 
-    /// `rustc` fixes the target keys against one another and the model holds
+    /// `rustc` fixes the target atoms against one another and the model holds
     /// none of those facts, so a pair resting on two of them is left UNPROVEN.
     /// Without that, `#![cfg(target_env = "msvc")]` and `#![cfg(target_os =
     /// "linux")]` read satisfiable on a build target no rustc triple has.
+    ///
+    /// A NEGATED `target_os` / `target_family` value is the same fact spelled
+    /// the other way: the candidate satisfies it by leaving the key at "some
+    /// value the predicates never name", so the key decides the pair without
+    /// ever appearing in the witness. A bare `target_*` flag the candidate
+    /// defines counts on the unrelatable side too.
     #[test]
     fn a_pair_resting_on_unrelatable_target_keys_is_left_unproven() {
         for (first, second) in [
@@ -2641,6 +2661,16 @@ mod tests {
             (r#"target_arch = "wasm32""#, r#"target_os = "linux""#),
             (r#"target_vendor = "apple""#, "not(unix)"),
             (r#"target_arch = "wasm32""#, r#"target_env = "msvc""#),
+            (r#"target_env = "msvc""#, r#"not(target_os = "windows")"#),
+            (
+                r#"target_env = "msvc""#,
+                r#"not(target_family = "windows")"#,
+            ),
+            (
+                r#"target_vendor = "apple""#,
+                r#"not(target_family = "unix")"#,
+            ),
+            ("target_thread_local", r#"target_os = "linux""#),
         ] {
             assert!(
                 find_build_target_satisfying_both_cfg_predicate_sets(
@@ -2648,7 +2678,7 @@ mod tests {
                     &predicates(&[second]),
                 )
                 .is_none(),
-                "`{first}` and `{second}` name target keys the model cannot relate"
+                "`{first}` and `{second}` name target atoms the model cannot relate"
             );
         }
         // One such key on its own pins nothing against anything.
@@ -2656,6 +2686,14 @@ mod tests {
             find_build_target_satisfying_both_cfg_predicate_sets(
                 &predicates(&[r#"target_env = "msvc""#]),
                 &predicates(&[r#"not(target_env = "gnu")"#]),
+            )
+            .is_some()
+        );
+        // Nor does one weighed against an atom that is free of the target.
+        assert!(
+            find_build_target_satisfying_both_cfg_predicate_sets(
+                &predicates(&[r#"target_env = "msvc""#]),
+                &predicates(&[r#"feature = "cuda""#]),
             )
             .is_some()
         );

--- a/sdk/streamlib-processor-extract/src/reachable.rs
+++ b/sdk/streamlib-processor-extract/src/reachable.rs
@@ -430,8 +430,9 @@ pub struct ProcessorAvailabilityAcrossBuildTargets {
     /// The `Type` segment — the name the plugin registry keys registration on,
     /// and therefore the name two arms collide under.
     pub processor_type_name: String,
-    /// The full `@org/package/Type@version` identity every declaring arm agrees
-    /// on (a disagreement here is refused as divergence, never merged).
+    /// The version-free `@org/package/Type` identity every declaring arm agrees
+    /// on, carrying the grammar's `0.0.0` sentinel rather than a real version
+    /// (a disagreement here is refused as divergence, never merged).
     pub processor_schema_ident: SchemaIdent,
     /// The disjunction over each declaring arm's conjoined `#[cfg(...)]`
     /// predicates, as source text. `None` is unconditional: some arm is gated
@@ -534,7 +535,7 @@ pub fn extract_processors_across_every_build_target(
 ///
 /// No satisfiability argument is needed here: the walk already resolved a
 /// concrete target and it compiled both arms. This is the reasoning-free net
-/// behind [`find_build_target_compiling_both_declarations`] — an exotic
+/// behind [`find_build_target_satisfying_both_cfg_predicate_sets`] — an exotic
 /// predicate pair the atom model calls disjoint still fails loudly on the host
 /// that actually compiles both.
 fn refuse_processors_declared_twice_for_one_build_target(

--- a/sdk/streamlib-processor-extract/tests/real_package_reachability.rs
+++ b/sdk/streamlib-processor-extract/tests/real_package_reachability.rs
@@ -25,7 +25,9 @@ use streamlib_processor_extract::crate_root::{
     generate_rust_crate_root_source,
 };
 use streamlib_processor_extract::{
-    ModuleReachabilityTarget, extract_reachable_rust_processors, extract_rust_processors,
+    ModuleReachabilityTarget, ProcessorAvailabilityAcrossBuildTargets,
+    extract_processors_across_every_build_target, extract_reachable_rust_processors,
+    extract_rust_processors,
 };
 
 fn workspace_root() -> PathBuf {
@@ -67,6 +69,36 @@ fn sorted_names(procs: Vec<streamlib_processor_extract::ExtractedProcessor>) -> 
 
 fn reachable_names(dir: &Path, os: &str) -> Vec<String> {
     sorted_names(extract_reachable_rust_processors(dir, &target_for(os)).unwrap())
+}
+
+/// The availability entry a package's across-every-target scan resolves for one
+/// processor `Type`.
+fn availability_of(
+    dir: &Path,
+    processor_type_name: &str,
+) -> ProcessorAvailabilityAcrossBuildTargets {
+    extract_processors_across_every_build_target(dir)
+        .unwrap_or_else(|e| panic!("scanning {}: {e}", dir.display()))
+        .availability_of_processor_type_name(processor_type_name)
+        .unwrap_or_else(|| {
+            panic!(
+                "{} must declare `{processor_type_name}` on some target",
+                dir.display()
+            )
+        })
+        .clone()
+}
+
+/// The build targets, out of the ones the in-tree packages actually split on,
+/// a processor is available for.
+fn available_build_target_operating_systems(
+    availability: &ProcessorAvailabilityAcrossBuildTargets,
+) -> Vec<String> {
+    ["linux", "macos", "ios", "windows"]
+        .into_iter()
+        .filter(|os| availability.is_available_on_build_target(&target_for(os)))
+        .map(str::to_string)
+        .collect()
 }
 
 #[test]
@@ -128,19 +160,71 @@ fn audio_declares_its_platform_free_arms_on_windows() {
     );
 }
 
-/// The Linux and Apple audio arms both declare `AudioCapture` / `AudioOutput`;
-/// only the target's arm may surface.
+/// `@tatolab/audio` is the live two-arm case: `processors/linux/` and
+/// `processors/apple/` each declare `AudioCapture` and `AudioOutput`, kept
+/// identical today by copy-paste discipline alone. The scan's divergence check
+/// is what turns that discipline into a build gate — the two arms derive one
+/// availability entry per processor, which they can only do by agreeing on the
+/// whole manifest projection. Mentally change one arm's port name and this
+/// scan fails instead of silently shipping a host-dependent `processors:`.
 #[test]
-fn audio_platform_arms_resolve_to_one_arm_per_target() {
+fn the_audio_platform_arms_agree_well_enough_to_fold_into_one_processor() {
+    let dir = package_dir("audio");
+    let capture = availability_of(&dir, "AudioCapture");
     assert_eq!(
-        reachable_names(&package_dir("audio"), "linux"),
-        reachable_names(&package_dir("audio"), "macos"),
-        "both platform arms must declare the same processor identities — a \
-         divergence here means one arm silently ships a different set"
+        capture.declaring_arm_source_files,
+        vec![
+            PathBuf::from("processors/apple/audio_capture.rs"),
+            PathBuf::from("processors/linux/audio_capture.rs"),
+        ],
+        "both platform arms must declare `AudioCapture`"
     );
-    let linux = reachable_names(&package_dir("audio"), "linux");
-    assert_eq!(linux.iter().filter(|n| *n == "AudioCapture").count(), 1);
-    assert_eq!(linux.iter().filter(|n| *n == "AudioOutput").count(), 1);
+    assert_eq!(
+        available_build_target_operating_systems(&capture),
+        vec!["linux", "macos", "ios"],
+        "availability is the disjunction of the two arms' gates: {:?}",
+        capture.availability_cfg_predicate
+    );
+    assert_eq!(
+        capture.processor_schema_ident.to_string(),
+        "@tatolab/audio/AudioCapture@0.0.0"
+    );
+
+    // Only the target's own arm resolves, so no target registers it twice.
+    for os in ["linux", "macos"] {
+        let names = reachable_names(&dir, os);
+        assert_eq!(names.iter().filter(|n| *n == "AudioCapture").count(), 1);
+        assert_eq!(names.iter().filter(|n| *n == "AudioOutput").count(), 1);
+    }
+}
+
+/// `@tatolab/camera`'s `CameraToCudaCopy` carries no `#[cfg]` at all — only its
+/// fields and internals are gated — so it is available on every target and
+/// fails in `setup()` off Linux. That is the datum that supersedes the
+/// "Linux-only" prose the description string used to carry, and it is what
+/// `camera_keeps_its_unconditional_arm_on_apple_targets` observes from the
+/// other side.
+#[test]
+fn the_unconditional_camera_arm_is_available_on_every_build_target() {
+    let availability = availability_of(&package_dir("camera"), "CameraToCudaCopy");
+    assert!(
+        availability.availability_cfg_predicate.is_none(),
+        "an unconditional processor carries no availability predicate, got {:?}",
+        availability.availability_cfg_predicate
+    );
+    assert_eq!(
+        available_build_target_operating_systems(&availability),
+        vec!["linux", "macos", "ios", "windows"]
+    );
+
+    // Its Linux-gated sibling is the contrast: a real per-target availability.
+    let camera = availability_of(&package_dir("camera"), "Camera");
+    assert_eq!(
+        available_build_target_operating_systems(&camera),
+        vec!["linux"],
+        "`Camera`'s only live arm is `processors/linux/`: {:?}",
+        camera.availability_cfg_predicate
+    );
 }
 
 /// `@tatolab/clap` is Apple-only: every arm carries the same
@@ -276,6 +360,68 @@ fn the_generated_register_list_equals_the_reachable_set_on_every_target() {
                 reachable,
                 "{} on {os}: the generated `export_plugin!` register list and the \
                  reachability-resolved manifest set must be the same set",
+                package.display()
+            );
+        }
+    }
+}
+
+/// Every in-tree folder-backed package must pass the id-grouping checks — the
+/// regression net that says the overlap and divergence rules do not
+/// false-positive on real source.
+///
+/// The two checks fire from different seams and neither subsumes the other:
+/// `extract_processors_across_every_build_target` proves overlap out of the
+/// arms' own predicates and compares their whole manifest projections, while
+/// `extract_reachable_rust_processors` resolves one concrete target and refuses
+/// a `Type` it collected twice there. A package is only clean when both agree,
+/// on every target it might be built for.
+#[test]
+fn every_in_tree_package_passes_the_processor_id_grouping_checks() {
+    let packages = discover_package_dirs_declaring_a_generated_crate_root(&workspace_root())
+        .expect("discovering folder-backed packages");
+    assert!(
+        packages.len() >= 15,
+        "expected the in-tree folder-backed packages; found {packages:?}"
+    );
+
+    for package in &packages {
+        let set = extract_processors_across_every_build_target(package)
+            .unwrap_or_else(|e| panic!("{}: {e}", package.display()));
+
+        // Every declaration folds into exactly one availability entry, and no
+        // two entries share a `Type` — the registry's collision key.
+        let distinct_type_names: BTreeSet<&str> = set
+            .processor_declarations
+            .iter()
+            .map(|declaration| declaration.schema.name.as_str())
+            .collect();
+        assert_eq!(
+            set.processor_availability.len(),
+            distinct_type_names.len(),
+            "{}: one availability entry per distinct processor `Type`",
+            package.display()
+        );
+
+        for os in ["linux", "macos", "ios", "windows"] {
+            let target = target_for(os);
+            let reachable: Vec<String> =
+                sorted_names(extract_reachable_rust_processors(package, &target).unwrap());
+            let available: Vec<String> = {
+                let mut names: Vec<String> = set
+                    .processor_availability
+                    .iter()
+                    .filter(|entry| entry.is_available_on_build_target(&target))
+                    .map(|entry| entry.processor_type_name.clone())
+                    .collect();
+                names.sort();
+                names
+            };
+            assert_eq!(
+                reachable,
+                available,
+                "{} on {os}: the availability predicates and the target-resolved \
+                 scan must name the same processors",
                 package.display()
             );
         }

--- a/sdk/streamlib-processor-extract/tests/real_package_reachability.rs
+++ b/sdk/streamlib-processor-extract/tests/real_package_reachability.rs
@@ -160,8 +160,9 @@ fn audio_declares_its_platform_free_arms_on_windows() {
     );
 }
 
-/// `@tatolab/audio` is the live two-arm case: `processors/linux/` and
-/// `processors/apple/` each declare `AudioCapture` and `AudioOutput`, kept
+/// `@tatolab/audio` is the live two-arm case: `audio_capture_linux.rs` and
+/// `audio_capture_apple.rs` each declare `AudioCapture` (and the two
+/// `audio_output_*` siblings `AudioOutput`) under mutually-exclusive gates, kept
 /// identical today by copy-paste discipline alone. The scan's divergence check
 /// is what turns that discipline into a build gate — the two arms derive one
 /// availability entry per processor, which they can only do by agreeing on the
@@ -174,8 +175,8 @@ fn the_audio_platform_arms_agree_well_enough_to_fold_into_one_processor() {
     assert_eq!(
         capture.declaring_arm_source_files,
         vec![
-            PathBuf::from("processors/apple/audio_capture.rs"),
-            PathBuf::from("processors/linux/audio_capture.rs"),
+            PathBuf::from("processors/audio_capture_apple.rs"),
+            PathBuf::from("processors/audio_capture_linux.rs"),
         ],
         "both platform arms must declare `AudioCapture`"
     );
@@ -231,7 +232,7 @@ fn the_unconditional_camera_arm_is_available_on_every_build_target() {
     assert_eq!(
         available_build_target_operating_systems(&camera),
         vec!["linux"],
-        "`Camera`'s only live arm is `processors/linux/`: {:?}",
+        "`Camera`'s only live arm is `processors/camera_linux.rs`: {:?}",
         camera.availability_cfg_predicate
     );
 }

--- a/sdk/streamlib-processor-extract/tests/real_package_reachability.rs
+++ b/sdk/streamlib-processor-extract/tests/real_package_reachability.rs
@@ -399,7 +399,7 @@ fn every_in_tree_package_passes_the_processor_id_grouping_checks() {
             .unwrap_or_else(|e| panic!("{}: {e}", package.display()));
 
         // Every declaration folds into exactly one availability entry, and no
-        // two entries share a `Type` — the registry's collision key.
+        // two entries share a `Type` — the `processors:` collision key.
         let distinct_type_names: BTreeSet<&str> = set
             .processor_declarations
             .iter()

--- a/sdk/streamlib-processor-extract/tests/real_package_reachability.rs
+++ b/sdk/streamlib-processor-extract/tests/real_package_reachability.rs
@@ -185,9 +185,18 @@ fn the_audio_platform_arms_agree_well_enough_to_fold_into_one_processor() {
         "availability is the disjunction of the two arms' gates: {:?}",
         capture.availability_cfg_predicate
     );
+    // Both arms declare the same `@org/package/Type`, which is what the
+    // divergence check enforces before they are allowed to fold into one entry.
+    let declared_idents: BTreeSet<String> = extract_processors_across_every_build_target(&dir)
+        .expect("scanning @tatolab/audio")
+        .processor_declarations
+        .iter()
+        .filter(|declaration| declaration.schema.name == "AudioCapture")
+        .map(|declaration| declaration.schema_ident.to_string())
+        .collect();
     assert_eq!(
-        capture.processor_schema_ident.to_string(),
-        "@tatolab/audio/AudioCapture@0.0.0"
+        declared_idents,
+        BTreeSet::from(["@tatolab/audio/AudioCapture@0.0.0".to_string()])
     );
 
     // Only the target's own arm resolves, so no target registers it twice.


### PR DESCRIPTION
Stacked PR — base branch is `feat/1589-folder-backed-processor-discovery` (not `main`); that branch must merge first. Part of #1591.

## Summary

Once two files can declare the same processor id under different `cfg`, three failures become
possible that nothing caught before: overlapping cfg (duplicate registration on one target),
divergent ports (same id, different signature, held together only by copy-paste discipline), and
a silent gap (no arm matches a target). This PR groups processor declarations by id during the
scan, rejects the build on overlap and on signature divergence (both file paths / differing ports
named in the error), and threads the per-target availability set through as scan output instead of
leaving it as prose in `packages/camera/streamlib.yaml`.

Key pieces:
- `sdk/streamlib-processor-extract/src/reachable.rs`: the cfg-overlap / reachability prover —
  decides whether two predicates can be simultaneously satisfiable, with an explicit,
  documented-in-`docs/decisions/manifest-extraction-capability.md` boundary on which `target_*`
  keys the coherence rules relate (`target_os`, `target_arch`, `target_family` + the family flag).
  The error direction is deliberately toward missing an overlap rather than inventing one.
- `sdk/streamlib-processor-extract/src/derive.rs` / `crate_root.rs`: group declarations by
  processor id, run the overlap/divergence gates, and surface per-target availability.
- `packages/camera/processors/camera_to_cuda_copy.rs` / `packages/camera/streamlib.yaml`: camera's
  two-arm processor now carries its real availability as data, and the description prose is
  corrected to match.
- `sdk/streamlib-processor-extract/tests/real_package_reachability.rs`: fixtures for each failure
  mode (overlap, divergence) plus a positive fixture asserting the availability set for a two-arm
  processor, run against every in-tree package.

## Test evidence

Full gate battery, re-run in the worktree:
- `cargo run -p xtask -- generate-crate-roots` → 19 roots, `git status` clean (zero drift).
- All 14 xtask CI gates exit 0: lint-logging, check-boundaries, check-schema-versions,
  check-no-streamlib-metadata, check-no-reverse-dns, check-no-inventory-submit,
  check-processor-spec-new, check-cdylib-reach, check-no-escalate-in-lifecycle,
  check-consumer-rhi-repr, check-device-wait-idle, check-manifest-schema,
  check-package-version-drift, check-vendored-vulkanalia.
- All four `test.yml` commands green: 2+16+77+105(1 ignored)+119 lib;
  `attribute_macro_test` 11; `--tests` 1+2+3+119+12; `--doc` 3 (+1 ignored).
- Consumers: xtask 224, streamlib-pack 66+3+3+1+3, build-orchestrator, streamlib-macros 46/16 —
  all green.
- `cargo check --workspace --all-targets --locked` exit 0.
- `cargo clippy -p streamlib-processor-extract --all-targets` — zero diagnostics in this crate
  (the 3 pre-existing warnings are in `streamlib-idents`, untouched by this branch).
- `cargo doc -p streamlib-processor-extract --no-deps` warning-free.
- `streamlib-engine --test pack_then_load_smoke` — 3 passed.
- No new `.rs` files (no BUSL-header exposure); no Apple path touched (no cross-compile stage owed).

No E2E / rig report — this ticket is marked "Needs the physical rig? No", and nothing here touches
GPU/camera/display/codec at runtime; it's a build-time extraction/validation change.

## Review notes

Self-review ran to completion; every actionable finding below was either fixed already or declined
with a reason the reviewer accepted. Listed for visibility only — no unresolved defects remain.

- **R3-1 is genuinely closed**: the invented-witness class from a negated relatable value no longer
  produces a witness, and the new rule never invents a witness the old one did not. Verified in a
  `/tmp` scratch export of HEAD (repo never mutated): reverting only the prune body to the pre-fix
  form while keeping the new tests reddens `a_pair_resting_on_unrelatable_target_keys_is_left_unproven`
  (`reachable.rs:2676`) under `target_env = "msvc"` / `not(target_os = "windows")`. A 25x25
  differential probe (625 predicate pairs, old rule vs new) shows 78 rows changed, all SOME→NONE,
  zero NONE→SOME — the fix strictly widens pruning and adds no new proof.
- **Each of the three rule legs the fix added is independently non-vacuous** — re-derived, not
  trusted. Dropping the `mentions_a_target_family_atom()` insertion reddens `target_vendor = "apple"`
  vs `not(unix)`; narrowing that leg to `mentions_a_bare_family_flag()` reddens
  `target_env = "msvc"` vs `not(target_family = "windows")`; dropping `.chain(candidate.flags…)`
  reddens `target_thread_local` vs `target_os = "linux"`. The opposite direction is also defended:
  an unconditional-`true` mutant reddens 8 tests, including
  `overlapping_arms_are_refused_with_a_witness_build_target` and
  `two_unconditional_arms_are_satisfiable_together`, so the gate can't be silently over-pruned into
  vacuity.
- **DECLINE ACCEPTED** — "call `mentions_a_bare_family_flag` from the prune site too" (R2 low #2,
  second half). Substituting it in for `mentions_a_target_family_atom()` at the prune site reddens
  `a_pair_resting_on_unrelatable_target_keys_is_left_unproven` on `target_env = "msvc"` /
  `not(target_family = "windows")` — the narrower helper reintroduces the bug.
  `mentions_a_bare_family_flag` (`reachable.rs:1464`) still names the concept and
  `mentions_a_target_family_atom` (`reachable.rs:1471`) reads off it.
- **DECLINE ACCEPTED, with a correction to the stated reason** — the absence side of an unrelatable
  target atom stays unmodelled. `not(target_thread_local)` vs `target_os = "linux"` still returns a
  witness, so a bare `target_*` flag negated by one arm can still produce a spurious refusal. The
  cited headline justification for declining wasn't on point (`target_os` is inside
  `TARGET_CFG_KEYS_THE_COHERENCE_RULES_RELATE`, `reachable.rs:1284`, so it was never in scope); the
  second example is correct — `not(target_env = "gnu")` vs `target_os = "linux"` is a genuine witness
  (linux-musl), so pruning key-absence would cost a real proof. Exposure is nil on stable rustc
  (`target_thread_local` is unstable, no in-tree predicate names a bare `target_*` flag); the
  assumption is named in both the rustdoc (`reachable.rs:1298-1310`) and
  `docs/decisions/manifest-extraction-capability.md:199-212`. Follow-up if a bare `target_*` flag
  ever appears in a real predicate: mirror the flag side of the rule.
- **DECLINE ACCEPTED** — the five 81-82 column lines in the decision doc are not branch-added.
  `awk length>80` finds lines 46, 93, 149, 150, 158; `git blame` attributes them to 10e3ad6c,
  476e9a69, 05c3e999, 8a48c9ed, all confirmed ancestors of `origin/main`. Re-wrapping them would be
  the unrelated auto-fix engine doctrine forbids.
- **DECLINE ACCEPTED** — workspace-wide `cargo fmt --all -- --check` red is pre-existing, outside
  this branch. `rustfmt --edition 2024 --check` on `origin/main` copies of `grammar.rs` and
  `camera_to_cuda_copy.rs` both fail there already; `grammar.rs` is untouched by this branch, and
  the camera fmt diff sits in the `impl … ReactiveProcessor` block while the branch only edits that
  file's module docs and the `description =` string. Every branch-touched file's own hunks pass
  `rustfmt --check` clean (`reachable.rs`, `derive.rs`, `crate_root.rs`,
  `real_package_reachability.rs` fully clean).
- **The fix trades gate completeness for witness soundness** — the prove-side of the overlap gate
  got measurably weaker, intentionally and documented. Of the 78 differential rows that changed,
  several were real overlaps now left unproven, e.g. `not(target_os = "linux")` vs
  `target_arch = "x86_64"` (macos-x86_64 satisfies both), and `not(target_os = "windows")` vs
  `target_arch = "x86_64"`. Those pairs fall through to the concrete-target duplicate net
  (`refuse_processors_declared_twice_for_one_build_target`, `reachable.rs:538`), which only fires on
  a host that compiles both arms. The decision doc states this polarity explicitly.
- **Pre-existing, not a delta regression**: an exact duplicate declaration is not proven when its
  cfg mentions an unrelatable key. `all(target_os = "linux", target_arch = "x86_64")` weighed
  against itself returns `NONE` under both the old and new rule (identical row 599 in the old/new
  probe dumps). Unchanged by this fix; a candidate follow-up only if the model is ever extended.
- **Full gate battery re-run independently** — see Test evidence above; every gate the implementer
  claimed is green, and nothing untouched broke.
