### PR TITLE
feat!: name a processor by name alone — delete the version-pinned reference

### DIFF
--- a/runtime/streamlib-engine/src/core/graph/traversal/mutation_ops/add_v_op.rs
+++ b/runtime/streamlib-engine/src/core/graph/traversal/mutation_ops/add_v_op.rs
@@ -24,29 +24,22 @@ impl<'a> TraversalSourceMut<'a> {
     /// why — runtime-dynamic systems prefer "load-and-mark-failed" over
     /// "silently-skip" so observability survives the misconfiguration.
     pub fn add_v(self, spec: ProcessorSpec) -> ProcessorTraversalMut<'a> {
-        // Resolve the reference to the concrete registered ident + its ports.
-        // `VersionPinned` matches version-exact (the #1325 path); a version-free
-        // `ResolveToInstalled` resolves `(org, package, type)` to the single
-        // installed provider. Both gate on `port_info` presence — every
-        // registered processor has a `port_info` entry (subprocess-only
-        // descriptors register empty port lists), so both variants resolve any
-        // registered type and miss only a genuinely-unregistered one.
-        let resolved = match &spec.name {
-            ProcessorTypeReference::VersionPinned(ident) => PROCESSOR_REGISTRY
-                .port_info(ident)
-                .map(|ports| (ident.clone(), ports)),
-            ProcessorTypeReference::ResolveToInstalled {
-                org,
-                package,
-                r#type,
-            } => PROCESSOR_REGISTRY
-                .resolve_installed_processor_type(org, package, r#type)
-                .and_then(|ident| {
-                    PROCESSOR_REGISTRY
-                        .port_info(&ident)
-                        .map(|ports| (ident, ports))
-                }),
-        };
+        // Resolve `(org, package, type)` to the installed provider's registered
+        // ident + its ports. Gated on `port_info` presence — every registered
+        // processor has an entry (subprocess-only descriptors register empty
+        // port lists), so this resolves any registered type and misses only a
+        // genuinely-unregistered one.
+        let resolved = PROCESSOR_REGISTRY
+            .resolve_installed_processor_type(
+                spec.name.org(),
+                spec.name.package(),
+                spec.name.r#type(),
+            )
+            .and_then(|ident| {
+                PROCESSOR_REGISTRY
+                    .port_info(&ident)
+                    .map(|ports| (ident, ports))
+            });
 
         let registry_miss = resolved.is_none();
 
@@ -58,8 +51,8 @@ impl<'a> TraversalSourceMut<'a> {
         }
 
         // On a miss, build the failed node with the reference's diagnostic
-        // ident (concrete for `VersionPinned`; `(org, package, type)@0.0.0` for
-        // a version-free reference) so it stays visible via `GET /api/graph`.
+        // ident (`(org, package, type)@0.0.0`) so it stays visible via
+        // `GET /api/graph`.
         let (node_ident, (inputs, outputs)) =
             resolved.unwrap_or_else(|| (spec.name.to_diagnostic_ident(), (vec![], vec![])));
 

--- a/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
+++ b/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
@@ -1386,8 +1386,8 @@ impl ProcessorInstanceFactory {
     /// The one-installed-version-per-package invariant means at most one
     /// version is registered for a tuple in a process; if more than one
     /// somehow is, the highest `SemVer` wins deterministically. This is the
-    /// terminal resolution for a version-free
-    /// [`ProcessorTypeReference::ResolveToInstalled`](crate::core::processors::ProcessorTypeReference),
+    /// terminal resolution for a
+    /// [`ProcessorTypeReference`](crate::core::processors::ProcessorTypeReference),
     /// distinct from [`Self::resolve_any_version`] (which the version-omitting
     /// call-site macro uses against already-registered types).
     pub fn resolve_installed_processor_type(
@@ -1626,14 +1626,14 @@ mod tests {
             .register_descriptor_only(unit_descriptor(registered.clone()))
             .expect("register the api-server descriptor at the 0.0.0 sentinel");
 
-        // The fix's arm: a version-free `ResolveToInstalled` reference resolves
-        // `(org, package, type)` to the concrete 0.0.0 registration, and that
-        // ident carries a `port_info` entry — so `add_v` resolves the node.
-        let version_free = ProcessorTypeReference::ResolveToInstalled {
-            org: Org::new("tatolab").unwrap(),
-            package: Package::new("api-server").unwrap(),
-            r#type: TypeName::new("ApiServer").unwrap(),
-        };
+        // A reference resolves `(org, package, type)` to the concrete 0.0.0
+        // registration, and that ident carries a `port_info` entry — so `add_v`
+        // resolves the node.
+        let version_free = ProcessorTypeReference::new(
+            Org::new("tatolab").unwrap(),
+            Package::new("api-server").unwrap(),
+            TypeName::new("ApiServer").unwrap(),
+        );
         let resolved = factory.resolve_installed_processor_type(
             version_free.org(),
             version_free.package(),
@@ -1649,12 +1649,13 @@ mod tests {
             "the resolved ident must carry a port_info entry so add_v resolves the node"
         );
 
-        // The reverted-bug arm: the old `schema_ident!(…, \"1.0.0\")` produced a
-        // `VersionPinned(@1.0.0)` reference, which `add_v` resolves version-EXACT
-        // via `port_info`. Against a 0.0.0-only registration that lookup misses —
-        // the node would be added in Error state and the api-server would never
-        // compile (→ /health never served). Mentally reverting main.rs to the
-        // pinned form reproduces exactly this miss.
+        // Why a reference may not carry a version: the registry is version-EXACT,
+        // and a code-declared processor registers under the 0.0.0 version-free
+        // sentinel. A reference pinned at 1.0.0 therefore missed a processor that
+        // was loaded and registered — the api-server booted with its node in
+        // Error state and never served /health. `ProcessorTypeReference` has no
+        // version field now, so that reference cannot be written; this locks the
+        // exactness that made it fatal.
         let one_zero_zero = ident("tatolab", "api-server", "ApiServer", SemVer::new(1, 0, 0));
         assert!(
             factory.port_info(&one_zero_zero).is_none(),

--- a/runtime/streamlib-engine/src/core/processors/processor_spec.rs
+++ b/runtime/streamlib-engine/src/core/processors/processor_spec.rs
@@ -118,37 +118,38 @@ mod tests {
         assert_eq!(spec.display_name.as_deref(), Some("Camera A"));
     }
 
-    /// A `SchemaIdent` still constructs a spec (via `From<SchemaIdent>`),
-    /// landing as a version-pinned reference — the #1325 call-site shape is
-    /// unchanged.
+    /// A `SchemaIdent` still constructs a spec (via `From<SchemaIdent>`), and
+    /// its version is dropped on the way in: a resolved identity narrows to a
+    /// reference, and a reference names no version.
     #[test]
-    fn schema_ident_builds_version_pinned_spec() {
+    fn schema_ident_narrows_to_a_version_free_reference() {
         let spec = ProcessorSpec::new(
             ident("tatolab", "core", "VideoFrame", SemVer::new(1, 0, 0)),
             serde_json::Value::Null,
         );
-        assert!(matches!(
-            spec.name,
-            ProcessorTypeReference::VersionPinned(_)
-        ));
+        assert_eq!(spec.name.org().as_str(), "tatolab");
+        assert_eq!(spec.name.package().as_str(), "core");
+        assert_eq!(spec.name.r#type().as_str(), "VideoFrame");
+        let value = serde_json::to_value(&spec).unwrap();
+        assert!(
+            value["name"].get("version").is_none(),
+            "a spec built from a pinned ident must still put no version on the wire"
+        );
     }
 
-    /// A version-free reference builds a spec that carries no version at the
-    /// reference site — the shape that reaches the lazy hook.
+    /// A reference builds a spec that carries no version at the reference site
+    /// — the shape that reaches the lazy hook.
     #[test]
-    fn version_free_reference_builds_resolve_to_installed_spec() {
+    fn a_reference_builds_a_spec_with_no_version_at_the_reference_site() {
         let spec = ProcessorSpec::new(
-            ProcessorTypeReference::ResolveToInstalled {
-                org: Org::new("tatolab").unwrap(),
-                package: Package::new("camera").unwrap(),
-                r#type: TypeName::new("Camera").unwrap(),
-            },
+            ProcessorTypeReference::new(
+                Org::new("tatolab").unwrap(),
+                Package::new("camera").unwrap(),
+                TypeName::new("Camera").unwrap(),
+            ),
             serde_json::json!({"fps": 30}),
         );
-        assert!(matches!(
-            spec.name,
-            ProcessorTypeReference::ResolveToInstalled { .. }
-        ));
+        assert_eq!(spec.name.r#type().as_str(), "Camera");
         // The wire carries the three-key form, no version key.
         let value = serde_json::to_value(&spec).unwrap();
         assert!(value["name"].get("version").is_none());
@@ -160,11 +161,11 @@ mod tests {
     #[test]
     fn version_free_spec_msgpack_round_trip() {
         let spec = ProcessorSpec::new(
-            ProcessorTypeReference::ResolveToInstalled {
-                org: Org::new("tatolab").unwrap(),
-                package: Package::new("camera").unwrap(),
-                r#type: TypeName::new("Camera").unwrap(),
-            },
+            ProcessorTypeReference::new(
+                Org::new("tatolab").unwrap(),
+                Package::new("camera").unwrap(),
+                TypeName::new("Camera").unwrap(),
+            ),
             serde_json::json!({"width": 1920}),
         );
         let bytes = rmp_serde::to_vec_named(&spec).expect("encode");

--- a/runtime/streamlib-engine/src/core/processors/processor_type_reference.rs
+++ b/runtime/streamlib-engine/src/core/processors/processor_type_reference.rs
@@ -8,112 +8,90 @@ use serde::{Deserialize, Serialize};
 use crate::core::descriptors::{Org, Package, SchemaIdent, SemVer, TypeName};
 
 /// How a [`ProcessorSpec`](crate::core::processors::ProcessorSpec) names its
-/// processor type: either a fully version-pinned identity, or a version-free
-/// reference resolved to the single installed provider at add time.
+/// processor type: `(org, package, type)`, resolved against whatever the
+/// installed set provides.
 ///
-/// The version-free [`Self::ResolveToInstalled`] form is what makes lazy
-/// plugin discovery reach the runtime hook: it carries only `(org, package,
-/// type)` and defers version resolution to `add_processor` time, so a
-/// reference to a not-yet-loaded package triggers the lazy load instead of
-/// failing at the call site. The version-pinned [`Self::VersionPinned`] form
-/// is the exact-`SchemaIdent` path.
+/// Carries no version, and has no field one could be written into. A version
+/// belongs to package *resolution* — the lockfile records what `add` / `link` /
+/// `install` selected, and the module walker checks the installed slot against
+/// it. By the time code names a processor the question is already settled, so a
+/// reference is an import: ask by name, get whatever is installed.
 ///
-/// Wire compatibility: `#[serde(untagged)]` with [`Self::VersionPinned`]
-/// first means a version-pinned reference serializes byte-identically to a
-/// bare [`SchemaIdent`] (a four-key `{org, package, type, version}` map), and
-/// a version-free reference serializes as the three-key `{org, package,
-/// type}` map. Deserialization tries [`Self::VersionPinned`] first (it
-/// requires `version`) and falls to [`Self::ResolveToInstalled`] when
-/// `version` is absent — order alone disambiguates.
+/// A version at the reference site could only disagree with that resolution.
+/// It used to be expressible, and the disagreement resolved version-exact
+/// against a registry whose entries are version-free — so a pinned reference
+/// missed a processor that was loaded and registered, and the caller saw
+/// "unknown processor type".
+///
+/// Wire form: the three-key `{org, package, type}` map. A `version` key from an
+/// older payload deserializes and is dropped, which is the same answer
+/// resolution would have given.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum ProcessorTypeReference {
-    /// Version-pinned — the exact [`SchemaIdent`] (including its version) must
-    /// be registered for the reference to resolve.
-    VersionPinned(SchemaIdent),
-    /// Version-free — resolve `(org, package, type)` to the single installed
-    /// provider's registered descriptor at add time.
-    ResolveToInstalled {
-        org: Org,
-        package: Package,
-        #[serde(rename = "type")]
-        r#type: TypeName,
-    },
+pub struct ProcessorTypeReference {
+    pub org: Org,
+    pub package: Package,
+    #[serde(rename = "type")]
+    pub r#type: TypeName,
 }
 
 impl ProcessorTypeReference {
-    /// The referenced org, common to both forms.
+    /// Build a reference from its three parts.
+    pub fn new(org: Org, package: Package, r#type: TypeName) -> Self {
+        Self {
+            org,
+            package,
+            r#type,
+        }
+    }
+
+    /// The referenced org.
     pub fn org(&self) -> &Org {
-        match self {
-            Self::VersionPinned(ident) => &ident.org,
-            Self::ResolveToInstalled { org, .. } => org,
-        }
+        &self.org
     }
 
-    /// The referenced package, common to both forms.
+    /// The referenced package.
     pub fn package(&self) -> &Package {
-        match self {
-            Self::VersionPinned(ident) => &ident.package,
-            Self::ResolveToInstalled { package, .. } => package,
-        }
+        &self.package
     }
 
-    /// The referenced processor type short name, common to both forms.
+    /// The referenced processor type short name.
     pub fn r#type(&self) -> &TypeName {
-        match self {
-            Self::VersionPinned(ident) => &ident.r#type,
-            Self::ResolveToInstalled { r#type, .. } => r#type,
-        }
-    }
-
-    /// The pinned [`SchemaIdent`] when this is a [`Self::VersionPinned`]
-    /// reference; `None` for the version-free form.
-    pub fn as_version_pinned(&self) -> Option<&SchemaIdent> {
-        match self {
-            Self::VersionPinned(ident) => Some(ident),
-            Self::ResolveToInstalled { .. } => None,
-        }
+        &self.r#type
     }
 
     /// A concrete [`SchemaIdent`] for diagnostics (error messages, the failed
-    /// node's identity in the graph). The pinned form yields its real ident;
-    /// the version-free form renders `(org, package, type)@0.0.0` — the same
-    /// version-free placeholder convention
+    /// node's identity in the graph), rendering `(org, package, type)@0.0.0` —
+    /// the same version-free placeholder convention
     /// [`ProcessorInstanceFactory::resolve_any_version`](crate::core::processors::ProcessorInstanceFactory::resolve_any_version)
-    /// already uses. Never stored as a real registration key.
+    /// uses. Never stored as a real registration key.
     pub fn to_diagnostic_ident(&self) -> SchemaIdent {
-        match self {
-            Self::VersionPinned(ident) => ident.clone(),
-            Self::ResolveToInstalled {
-                org,
-                package,
-                r#type,
-            } => SchemaIdent::new(
-                org.clone(),
-                package.clone(),
-                r#type.clone(),
-                SemVer::new(0, 0, 0),
-            ),
-        }
+        SchemaIdent::new(
+            self.org.clone(),
+            self.package.clone(),
+            self.r#type.clone(),
+            SemVer::new(0, 0, 0),
+        )
     }
 }
 
+/// Narrow a resolved identity to a reference. The version is dropped: it
+/// described which package was selected at resolution time, which is not a
+/// question the reference site gets to reopen.
 impl From<SchemaIdent> for ProcessorTypeReference {
     fn from(ident: SchemaIdent) -> Self {
-        Self::VersionPinned(ident)
+        Self::new(ident.org, ident.package, ident.r#type)
     }
 }
 
 impl fmt::Display for ProcessorTypeReference {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::VersionPinned(ident) => write!(f, "{ident}"),
-            Self::ResolveToInstalled {
-                org,
-                package,
-                r#type,
-            } => write!(f, "@{org}/{package}/{type} (version-free)", type = r#type),
-        }
+        write!(
+            f,
+            "@{org}/{package}/{type}",
+            org = self.org,
+            package = self.package,
+            type = self.r#type
+        )
     }
 }
 
@@ -121,124 +99,87 @@ impl fmt::Display for ProcessorTypeReference {
 mod tests {
     use super::*;
 
-    fn pinned(org: &str, pkg: &str, ty: &str, v: SemVer) -> ProcessorTypeReference {
-        ProcessorTypeReference::VersionPinned(SchemaIdent::new(
+    fn reference(org: &str, pkg: &str, ty: &str) -> ProcessorTypeReference {
+        ProcessorTypeReference::new(
             Org::new(org).unwrap(),
             Package::new(pkg).unwrap(),
             TypeName::new(ty).unwrap(),
-            v,
-        ))
-    }
-
-    fn free(org: &str, pkg: &str, ty: &str) -> ProcessorTypeReference {
-        ProcessorTypeReference::ResolveToInstalled {
-            org: Org::new(org).unwrap(),
-            package: Package::new(pkg).unwrap(),
-            r#type: TypeName::new(ty).unwrap(),
-        }
+        )
     }
 
     #[test]
-    fn accessors_project_both_variants_to_the_same_triple() {
-        let p = pinned("tatolab", "camera", "Camera", SemVer::new(1, 2, 3));
-        let f = free("tatolab", "camera", "Camera");
-        for r in [&p, &f] {
-            assert_eq!(r.org().as_str(), "tatolab");
-            assert_eq!(r.package().as_str(), "camera");
-            assert_eq!(r.r#type().as_str(), "Camera");
-        }
+    fn accessors_project_the_triple() {
+        let r = reference("tatolab", "camera", "Camera");
+        assert_eq!(r.org().as_str(), "tatolab");
+        assert_eq!(r.package().as_str(), "camera");
+        assert_eq!(r.r#type().as_str(), "Camera");
     }
 
+    /// Narrowing keeps the triple and drops the version — the reference site
+    /// does not get to reopen what resolution already decided.
     #[test]
-    fn from_schema_ident_is_version_pinned() {
+    fn from_schema_ident_drops_the_resolved_version() {
         let ident = SchemaIdent::new(
             Org::new("tatolab").unwrap(),
             Package::new("camera").unwrap(),
             TypeName::new("Camera").unwrap(),
             SemVer::new(4, 5, 6),
         );
-        let r: ProcessorTypeReference = ident.clone().into();
-        assert_eq!(r.as_version_pinned(), Some(&ident));
+        assert_eq!(
+            ProcessorTypeReference::from(ident),
+            reference("tatolab", "camera", "Camera")
+        );
     }
 
     #[test]
-    fn diagnostic_ident_uses_zero_version_for_version_free() {
+    fn diagnostic_ident_uses_the_zero_version_placeholder() {
         assert_eq!(
-            free("tatolab", "camera", "Camera")
+            reference("tatolab", "camera", "Camera")
                 .to_diagnostic_ident()
                 .version,
             SemVer::new(0, 0, 0)
         );
-        // The pinned form keeps its real version in diagnostics.
-        assert_eq!(
-            pinned("tatolab", "camera", "Camera", SemVer::new(7, 0, 0))
-                .to_diagnostic_ident()
-                .version,
-            SemVer::new(7, 0, 0)
-        );
     }
 
     #[test]
-    fn version_pinned_serializes_byte_identically_to_bare_schema_ident() {
-        // Wire-compat lock: the untagged newtype variant must serialize
-        // exactly as the inner SchemaIdent — a four-key object — so existing
-        // engine-free plugins that send version-pinned specs are unaffected.
-        let ident = SchemaIdent::new(
-            Org::new("tatolab").unwrap(),
-            Package::new("core").unwrap(),
-            TypeName::new("VideoFrame").unwrap(),
-            SemVer::new(1, 0, 0),
-        );
-        let via_ref = serde_json::to_value(ProcessorTypeReference::from(ident.clone())).unwrap();
-        let via_ident = serde_json::to_value(&ident).unwrap();
-        assert_eq!(via_ref, via_ident);
-        assert!(via_ref.is_object());
-        assert_eq!(via_ref["version"], "1.0.0");
-    }
-
-    #[test]
-    fn version_free_serializes_as_three_key_object_without_version() {
-        let value = serde_json::to_value(free("tatolab", "camera", "Camera")).unwrap();
+    fn serializes_as_a_three_key_object_without_version() {
+        let value = serde_json::to_value(reference("tatolab", "camera", "Camera")).unwrap();
         assert!(value.is_object());
         assert_eq!(value["org"], "tatolab");
         assert_eq!(value["package"], "camera");
         assert_eq!(value["type"], "Camera");
         assert!(
             value.get("version").is_none(),
-            "the version-free form must not carry a version key"
+            "a reference must not carry a version key"
         );
     }
 
+    /// A payload from before references dropped their version still parses —
+    /// the key is ignored, which is the answer resolution would have given.
     #[test]
-    fn untagged_round_trip_preserves_each_variant() {
-        for (label, r) in [
-            (
-                "pinned",
-                pinned("tatolab", "camera", "Camera", SemVer::new(2, 1, 0)),
-            ),
-            ("free", free("tatolab", "camera", "Camera")),
-        ] {
-            // JSON
-            let json = serde_json::to_string(&r).unwrap();
-            let back: ProcessorTypeReference = serde_json::from_str(&json).unwrap();
-            assert_eq!(r, back, "{label} lost equality over JSON");
-            // msgpack (the plugin-ABI wire) — untagged relies on the
-            // self-describing map, which msgpack is.
-            let bytes = rmp_serde::to_vec_named(&r).unwrap();
-            let back: ProcessorTypeReference = rmp_serde::from_slice(&bytes).unwrap();
-            assert_eq!(r, back, "{label} lost equality over msgpack");
-        }
+    fn a_versioned_payload_parses_and_drops_the_version() {
+        let json = r#"{"org":"tatolab","package":"camera","type":"Camera","version":"1.2.3"}"#;
+        let parsed: ProcessorTypeReference = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed, reference("tatolab", "camera", "Camera"));
     }
 
     #[test]
-    fn four_key_input_deserializes_as_version_pinned_not_version_free() {
-        // A wire object carrying `version` must resolve to VersionPinned —
-        // the ordering guarantee that keeps the version-pinned wire stable.
-        let json = r#"{"org":"tatolab","package":"camera","type":"Camera","version":"3.0.0"}"#;
-        let r: ProcessorTypeReference = serde_json::from_str(json).unwrap();
-        assert!(
-            matches!(r, ProcessorTypeReference::VersionPinned(_)),
-            "a four-key object must deserialize as VersionPinned, got {r:?}"
+    fn round_trips_over_json_and_msgpack() {
+        let r = reference("tatolab", "camera", "Camera");
+        let back: ProcessorTypeReference =
+            serde_json::from_str(&serde_json::to_string(&r).unwrap()).unwrap();
+        assert_eq!(r, back, "lost equality over JSON");
+        // msgpack is the plugin-ABI wire.
+        let back: ProcessorTypeReference =
+            rmp_serde::from_slice(&rmp_serde::to_vec_named(&r).unwrap()).unwrap();
+        assert_eq!(r, back, "lost equality over msgpack");
+    }
+
+    #[test]
+    fn display_renders_the_version_free_identity() {
+        assert_eq!(
+            reference("tatolab", "camera", "Camera").to_string(),
+            "@tatolab/camera/Camera"
         );
     }
 }

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/lazy_discovery.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/lazy_discovery.rs
@@ -86,8 +86,7 @@ pub(super) fn resolve_providing_module(
             // well-formed install (a fully-qualified type embeds its package,
             // and `streamlib add` writes one slot per @org/name), so this is a
             // duplicate/malformed folder the caller must resolve by hand.
-            let mut packages: Vec<PackageRef> =
-                matches.iter().map(|m| m.package.clone()).collect();
+            let mut packages: Vec<PackageRef> = matches.iter().map(|m| m.package.clone()).collect();
             packages.sort_by_key(|p| p.to_string());
             tracing::warn!(
                 processor_type = %processor_type,
@@ -145,7 +144,7 @@ fn scan_for_providers(
             if !seen_dirs.insert(package_dir.clone()) {
                 continue;
             }
-            if let Some(package) = package_declares_processor(&package_dir, processor_type) {
+            if let Some(package) = package_declares_processor(&package_dir, processor_type)? {
                 matches.push(ProviderMatch {
                     package,
                     package_dir,
@@ -162,38 +161,42 @@ fn scan_for_providers(
 /// name equals the referenced type name. Returns the owning [`PackageRef`] on
 /// a match; a missing / unreadable / malformed manifest is treated as "no
 /// match" (this folder just isn't the provider).
+/// Whether the package installed at `package_dir` declares `processor_type`.
+///
+/// An unparseable manifest is an error, not a skip: an installed package whose
+/// manifest cannot be read is indistinguishable from an absent one to every
+/// caller downstream, so the reference surfaces as "unknown processor type" and
+/// the actual cause — a malformed install — never reaches the operator.
 fn package_declares_processor(
     package_dir: &Path,
     processor_type: &SchemaIdent,
-) -> Option<PackageRef> {
+) -> Result<Option<PackageRef>> {
     let manifest_path = package_dir.join(streamlib_idents::Manifest::FILE_NAME);
-    let content = std::fs::read_to_string(&manifest_path).ok()?;
-    let config: ProjectConfigMinimal = match serde_yaml::from_str(&content) {
-        Ok(config) => config,
-        Err(e) => {
-            tracing::warn!(
-                manifest = %manifest_path.display(),
-                error = %e,
-                "skipping unparseable streamlib.yaml during lazy discovery"
-            );
-            return None;
-        }
+    let Ok(content) = std::fs::read_to_string(&manifest_path) else {
+        return Ok(None);
     };
-    let package = config.package.as_ref()?;
+    let config: ProjectConfigMinimal = serde_yaml::from_str(&content).map_err(|e| {
+        Error::Configuration(format!(
+            "the package installed at {} has an unreadable {}: {e}. Lazy discovery cannot tell \
+             which processors it provides, so a reference to one would surface as an unknown \
+             processor type.",
+            package_dir.display(),
+            streamlib_idents::Manifest::FILE_NAME,
+        ))
+    })?;
+    let Some(package) = config.package.as_ref() else {
+        return Ok(None);
+    };
     if package.org.as_str() != processor_type.org.as_str()
         || package.name.as_str() != processor_type.package.as_str()
     {
-        return None;
+        return Ok(None);
     }
     let declares_type = config
         .processors
         .iter()
         .any(|processor| processor.name == processor_type.r#type.as_str());
-    if declares_type {
-        Some(PackageRef::new(package.org.clone(), package.name.clone()))
-    } else {
-        None
-    }
+    Ok(declares_type.then(|| PackageRef::new(package.org.clone(), package.name.clone())))
 }
 
 /// Directory entries readers of `streamlib_modules/` must skip: dot-prefixed
@@ -270,7 +273,10 @@ mod tests {
         // Package present, but no folder declares `Ghost`.
         let resolved =
             resolve_providing_module(root.path(), &ident("tatolab", "camera", "Ghost")).unwrap();
-        assert!(resolved.is_none(), "an undeclared type must resolve to None");
+        assert!(
+            resolved.is_none(),
+            "an undeclared type must resolve to None"
+        );
 
         // Package absent entirely.
         let resolved =
@@ -294,7 +300,14 @@ mod tests {
         // declared identity). Discovery must refuse rather than pick one.
         let root = tempfile::tempdir().unwrap();
         write_package(root.path(), "tatolab", "dup", &["Thing"]);
-        write_package_at(root.path(), "@tatolab", "dup-alias", "tatolab", "dup", &["Thing"]);
+        write_package_at(
+            root.path(),
+            "@tatolab",
+            "dup-alias",
+            "tatolab",
+            "dup",
+            &["Thing"],
+        );
 
         let err = resolve_providing_module(root.path(), &ident("tatolab", "dup", "Thing"))
             .expect_err("two folders declaring the same type must be ambiguous");
@@ -346,6 +359,9 @@ mod tests {
             streamlib_idents::SemVer::new(9, 9, 9),
         );
         let resolved = resolve_providing_module(root.path(), &referenced).unwrap();
-        assert!(resolved.is_some(), "version at reference site must not gate discovery");
+        assert!(
+            resolved.is_some(),
+            "version at reference site must not gate discovery"
+        );
     }
 }

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -829,22 +829,16 @@ impl Runner {
         &self,
         processor_type: &crate::core::processors::ProcessorTypeReference,
     ) -> std::result::Result<Option<AddedModule>, crate::core::error::Error> {
-        use crate::core::processors::{PROCESSOR_REGISTRY, ProcessorTypeReference};
-        // Fast path: already registered? A version-pinned reference checks the
-        // exact ident (unchanged #1325 behavior); a version-free reference
-        // checks the installed `(org, package, type)` tuple.
-        let already_registered = match processor_type {
-            ProcessorTypeReference::VersionPinned(ident) => {
-                PROCESSOR_REGISTRY.port_info(ident).is_some()
-            }
-            ProcessorTypeReference::ResolveToInstalled {
-                org,
-                package,
-                r#type,
-            } => PROCESSOR_REGISTRY
-                .resolve_installed_processor_type(org, package, r#type)
-                .is_some(),
-        };
+        use crate::core::processors::PROCESSOR_REGISTRY;
+        // Fast path: already registered? Checked against the installed
+        // `(org, package, type)` tuple.
+        let already_registered = PROCESSOR_REGISTRY
+            .resolve_installed_processor_type(
+                processor_type.org(),
+                processor_type.package(),
+                processor_type.r#type(),
+            )
+            .is_some();
         if already_registered {
             return Ok(None);
         }
@@ -891,13 +885,11 @@ impl Runner {
             processor_type.org().clone(),
             processor_type.package().clone(),
         );
-        // The range comes from the reference itself, not any app manifest: a
-        // version-pinned ref acquires that exact version; a version-free ref
-        // takes the highest release the package source holds.
-        let range = match processor_type.as_version_pinned() {
-            Some(ident) => streamlib_idents::SemVerRange::Exact(ident.version),
-            None => streamlib_idents::SemVerRange::Any,
-        };
+        // A reference names no version, so acquisition takes the highest
+        // release the package source holds; the lockfile records what was
+        // selected. A constraint belongs to resolution, never to the site that
+        // names the processor.
+        let range = streamlib_idents::SemVerRange::Any;
         if !acquire::acquisition_permitted(&pkg_ref, &range) {
             return Ok(None);
         }
@@ -1101,11 +1093,11 @@ mod lazy_load_error_tests {
     /// the `0.0.0` version-free placeholder.
     #[test]
     fn lazy_module_load_failed_projects_version_free_reference() {
-        let type_ref = crate::core::processors::ProcessorTypeReference::ResolveToInstalled {
-            org: streamlib_idents::Org::new("tatolab").unwrap(),
-            package: streamlib_idents::Package::new("camera").unwrap(),
-            r#type: streamlib_idents::TypeName::new("Camera").unwrap(),
-        };
+        let type_ref = crate::core::processors::ProcessorTypeReference::new(
+            streamlib_idents::Org::new("tatolab").unwrap(),
+            streamlib_idents::Package::new("camera").unwrap(),
+            streamlib_idents::TypeName::new("Camera").unwrap(),
+        );
         let underlying = AddModuleError::ModuleNotFound {
             package: streamlib_idents::PackageRef::new(
                 streamlib_idents::Org::new("tatolab").unwrap(),

--- a/runtime/streamlib-engine/tests/cdylib_owns_tokio_runtime.rs
+++ b/runtime/streamlib-engine/tests/cdylib_owns_tokio_runtime.rs
@@ -26,9 +26,9 @@ use serde_json::json;
 use serial_test::serial;
 use streamlib::sdk::RunnerAutoBuild;
 use streamlib::sdk::module_ident_any_version;
+use streamlib::sdk::processor_type_ref;
 use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::runtime::{BuildPolicy, Runner, Strategy};
-use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
 fn copy_dir_contents(src: &Path, dst: &Path) {
@@ -117,7 +117,7 @@ fn dlopen_processor_owns_tokio_runtime_and_binds_tcp_listener() {
             "add_module_with ManifestDirectory must succeed against a real test-fixtures cdylib",
         );
 
-    let ident = schema_ident!("tatolab", "test-fixtures", "TcpBindTestProcessor", "1.0.0");
+    let ident = processor_type_ref!("tatolab", "test-fixtures", "TcpBindTestProcessor");
 
     runtime
         .add_processor(ProcessorSpec::new(

--- a/runtime/streamlib-engine/tests/load_project_dylib_camera_smoke.rs
+++ b/runtime/streamlib-engine/tests/load_project_dylib_camera_smoke.rs
@@ -92,9 +92,9 @@ use std::time::Duration;
 use serde_json::json;
 use serial_test::serial;
 use streamlib::sdk::module_ident_any_version;
+use streamlib::sdk::processor_type_ref;
 use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::runtime::{BuildPolicy, Runner, Strategy};
-use streamlib::sdk::schema_ident;
 use streamlib_engine::core::runtime::host_target_triple;
 
 fn copy_dir_contents(src: &Path, dst: &Path) {
@@ -189,7 +189,7 @@ fn dlopen_camera_processor_completes_lifecycle_against_vivid() {
         )
         .expect("add_module_with must succeed against the camera cdylib");
 
-    let ident = schema_ident!("tatolab", "camera", "Camera", "1.0.0");
+    let ident = processor_type_ref!("tatolab", "camera", "Camera");
 
     // vivid is at `/dev/video0` on this host. The streamlib testing
     // doc names `/dev/video2`, but that's a different vivid class

--- a/runtime/streamlib-engine/tests/load_project_dylib_lazy_discovery.rs
+++ b/runtime/streamlib-engine/tests/load_project_dylib_lazy_discovery.rs
@@ -23,7 +23,7 @@ use serial_test::serial;
 use streamlib::sdk::error::Error;
 use streamlib::sdk::processors::{PROCESSOR_REGISTRY, ProcessorInstance, ProcessorSpec};
 use streamlib::sdk::runtime::Runner;
-use streamlib::sdk::{RunnerAutoBuild, schema_ident};
+use streamlib::sdk::{RunnerAutoBuild, processor_type_ref};
 use streamlib_engine::core::graph::ProcessorNode;
 use streamlib_engine::core::runtime::{host_target_triple, loaded_plugin_library_count};
 
@@ -73,13 +73,17 @@ fn write_manifest_package(
         dir.join("streamlib.yaml"),
         format!(
             "package:\n  org: {pkg_org}\n  name: {pkg_name}\n  version: 1.0.0\nprocessors:\n  \
-             - name: {proc}\n    version: 1.0.0\n    description: d\n    runtime: rust\n    \
+             - name: {proc}\n    description: d\n    runtime: rust\n    \
              execution: manual\n    inputs: []\n    outputs: []\n"
         ),
     )
     .unwrap();
     if with_cargo {
-        std::fs::write(dir.join("Cargo.toml"), b"[package]\nname='x'\nversion='0.0.0'\n").unwrap();
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            b"[package]\nname='x'\nversion='0.0.0'\n",
+        )
+        .unwrap();
     }
 }
 
@@ -166,7 +170,8 @@ fn add_processor_lazily_loads_plugin_from_streamlib_modules_with_no_load_call() 
     Runner::set_app_modules_dir(app.path());
     let runtime = Runner::with_auto_build().unwrap();
 
-    let fixtures_ident = || schema_ident!("tatolab", "test-fixtures", "TestConfiguredProcessor", "1.0.0");
+    let fixtures_ident =
+        || processor_type_ref!("tatolab", "test-fixtures", "TestConfiguredProcessor");
 
     // (1) First reference lazily discovers + loads the providing package.
     let libraries_before = loaded_plugin_library_count();
@@ -204,7 +209,7 @@ fn add_processor_lazily_loads_plugin_from_streamlib_modules_with_no_load_call() 
     // (3) Referencing an ABSENT package returns a typed error, and the runtime
     // keeps operating.
     let absent = runtime.add_processor(ProcessorSpec::new(
-        schema_ident!("tatolab", "definitely-not-installed", "Ghost", "1.0.0"),
+        processor_type_ref!("tatolab", "definitely-not-installed", "Ghost"),
         serde_json::json!({}),
     ));
     assert!(
@@ -246,7 +251,15 @@ fn add_processor_returns_ambiguous_error_for_duplicate_providers() {
     // end-to-end (through the lazy hook into add_processor_impl), and the
     // runtime must keep operating afterward.
     let app = tempfile::tempdir().unwrap();
-    write_manifest_package(app.path(), "@tatolab", "dup", "tatolab", "dup", "Thing", false);
+    write_manifest_package(
+        app.path(),
+        "@tatolab",
+        "dup",
+        "tatolab",
+        "dup",
+        "Thing",
+        false,
+    );
     write_manifest_package(
         app.path(),
         "@tatolab",
@@ -262,7 +275,7 @@ fn add_processor_returns_ambiguous_error_for_duplicate_providers() {
     let runtime = Runner::new().unwrap();
 
     let result = runtime.add_processor(ProcessorSpec::new(
-        schema_ident!("tatolab", "dup", "Thing", "1.0.0"),
+        processor_type_ref!("tatolab", "dup", "Thing"),
         serde_json::json!({}),
     ));
     assert!(
@@ -273,7 +286,7 @@ fn add_processor_returns_ambiguous_error_for_duplicate_providers() {
     // Runtime keeps operating: a subsequent reference to an absent package
     // returns a typed error rather than wedging.
     let after = runtime.add_processor(ProcessorSpec::new(
-        schema_ident!("tatolab", "not-there", "Nope", "1.0.0"),
+        processor_type_ref!("tatolab", "not-there", "Nope"),
         serde_json::json!({}),
     ));
     assert!(matches!(after, Err(Error::UnknownProcessorType { .. })));
@@ -302,7 +315,7 @@ fn add_processor_returns_lazy_load_failed_for_unbuildable_package() {
     let runtime = Runner::new().unwrap(); // no orchestrator wired
 
     let result = runtime.add_processor(ProcessorSpec::new(
-        schema_ident!("tatolab", "broken", "BrokenProcessor", "1.0.0"),
+        processor_type_ref!("tatolab", "broken", "BrokenProcessor"),
         serde_json::json!({}),
     ));
     assert!(
@@ -313,7 +326,7 @@ fn add_processor_returns_lazy_load_failed_for_unbuildable_package() {
     // The failed lazy load left zero partial state and the runtime keeps
     // operating.
     let after = runtime.add_processor(ProcessorSpec::new(
-        schema_ident!("tatolab", "still-absent", "Nope", "1.0.0"),
+        processor_type_ref!("tatolab", "still-absent", "Nope"),
         serde_json::json!({}),
     ));
     assert!(matches!(after, Err(Error::UnknownProcessorType { .. })));

--- a/sdk/streamlib-macros/src/lib.rs
+++ b/sdk/streamlib-macros/src/lib.rs
@@ -17,11 +17,11 @@
 //!   convention). Returns `Result<SchemaIdent, Error>` —
 //!   `Error::UnknownProcessorType` when nothing matches.
 //! - `streamlib::sdk::schema_ident!("org", "package", "Type", "1.0.0")` —
-//!   strict version-pinning form. Same four fields as the long
-//!   [`SchemaIdent::new`] constructor, validated at compile time,
-//!   expands to the long form verbatim. Reach for this when you have a
-//!   reason to refuse newer-but-compatible registered versions; the
-//!   `_any_version` form is the right default for everything else.
+//!   the same four fields as the long [`SchemaIdent::new`] constructor,
+//!   validated at compile time and expanding to it verbatim. For the
+//!   *resolved* identities that carry a version (lockfile entries, registry
+//!   keys); naming a processor from code goes through `processor_type_ref!`,
+//!   which carries no version at all.
 
 mod codegen;
 mod config_descriptor;
@@ -261,8 +261,8 @@ fn expand_schema_ident_any_version(
 /// processor-type reference for the lazy-discovery world (app code that never
 /// calls `add_module`).
 ///
-/// Expands to a `ProcessorTypeReference::ResolveToInstalled` value with no
-/// version and **no registry lookup at the call site**, so the reference
+/// Expands to a `ProcessorTypeReference` value, which carries no version and
+/// does **no registry lookup at the call site**, so the reference
 /// reaches `add_processor`'s lazy hook and resolves to the single installed
 /// provider — loading its package from `streamlib_modules/` on first
 /// reference. This is the canonical form for referencing a processor by
@@ -314,11 +314,11 @@ fn expand_processor_type_ref(
     })?;
 
     Ok(quote! {
-        ::streamlib::sdk::processors::ProcessorTypeReference::ResolveToInstalled {
-            org: ::streamlib::sdk::descriptors::Org::new(#org_str).expect("validated by macro"),
-            package: ::streamlib::sdk::descriptors::Package::new(#package_str).expect("validated by macro"),
-            r#type: ::streamlib::sdk::descriptors::TypeName::new(#type_str).expect("validated by macro"),
-        }
+        ::streamlib::sdk::processors::ProcessorTypeReference::new(
+            ::streamlib::sdk::descriptors::Org::new(#org_str).expect("validated by macro"),
+            ::streamlib::sdk::descriptors::Package::new(#package_str).expect("validated by macro"),
+            ::streamlib::sdk::descriptors::TypeName::new(#type_str).expect("validated by macro"),
+        )
     })
 }
 

--- a/sdk/streamlib-processor-extract/src/grammar.rs
+++ b/sdk/streamlib-processor-extract/src/grammar.rs
@@ -481,8 +481,8 @@ fn parse_port_schema(content: ParseStream<'_>) -> syn::Result<PortSchemaSpec> {
 /// the runtime binds version-blind, and versions are derived at package-build
 /// time — never hand-authored. A trailing `@<version>` is rejected. The
 /// synthesized `SchemaIdent` carries the `0.0.0` version-free sentinel — the
-/// same placeholder `ProcessorTypeReference::ResolveToInstalled` renders and
-/// the runtime schema registry (which stores/looks up unversioned) ignores.
+/// same placeholder `ProcessorTypeReference` renders for diagnostics and the
+/// runtime schema registry (which stores/looks up unversioned) ignores.
 pub fn parse_schema_ident_str(raw: &str, span: proc_macro2::Span) -> syn::Result<SchemaIdent> {
     let err = |msg: String| syn::Error::new(span, msg);
 

--- a/sdk/streamlib-sdk/src/lib.rs
+++ b/sdk/streamlib-sdk/src/lib.rs
@@ -216,24 +216,22 @@ pub mod sdk {
     pub use streamlib_engine::schema_ident_any_version;
 
     /// `streamlib::sdk::schema_ident!("org", "package", "Type", "1.0.0")` —
-    /// strict version-pinning form. Short form of
-    /// [`SchemaIdent::new`](descriptors::SchemaIdent::new). Reach for
-    /// this only when you have a deliberate reason to refuse
-    /// newer-but-compatible registered versions; otherwise prefer
-    /// [`schema_ident_any_version!`].
+    /// compile-time-validated short form of
+    /// [`SchemaIdent::new`](descriptors::SchemaIdent::new), for the *resolved*
+    /// identities that carry a version: lockfile entries, registry keys,
+    /// package resolution. It is not how code references a processor — pass one
+    /// to `ProcessorSpec::new` and the version is dropped. Use
+    /// [`processor_type_ref!`] to name a processor.
     pub use streamlib_engine::schema_ident;
 
-    /// `streamlib::sdk::processor_type_ref!("org", "package", "Type")` — a
-    /// **version-free** processor-type reference for the lazy-discovery world
-    /// (app code that never calls `add_module`). Validates `(org, package,
-    /// type)` at compile time and expands to a
-    /// [`ProcessorTypeReference::ResolveToInstalled`](processors::ProcessorTypeReference)
-    /// with no version and **no registry lookup at the call site**, so the
-    /// reference reaches `add_processor`'s lazy hook and resolves to the
-    /// single installed provider — loading its package from
-    /// `streamlib_modules/` on first reference. This is the canonical form for
-    /// referencing a processor by `@org/package/Type` with no version; prefer
-    /// it over [`schema_ident_any_version!`] when you want lazy loading.
+    /// `streamlib::sdk::processor_type_ref!("org", "package", "Type")` — the
+    /// canonical way to name a processor. Validates `(org, package, type)` at
+    /// compile time and expands to a
+    /// [`ProcessorTypeReference`](processors::ProcessorTypeReference), which
+    /// carries no version and does **no registry lookup at the call site**, so
+    /// the reference reaches `add_processor`'s lazy hook and resolves to the
+    /// installed provider — loading its package from `streamlib_modules/` on
+    /// first reference.
     pub use streamlib_engine::processor_type_ref;
 
     /// `streamlib::sdk::module_ident!("org", "name", "^1.0.0")` —

--- a/sdk/streamlib-sdk/src/sdk/app.rs
+++ b/sdk/streamlib-sdk/src/sdk/app.rs
@@ -80,11 +80,11 @@ impl App {
                 std::any::type_name::<P>()
             ))
         })?;
-        let reference = ProcessorTypeReference::ResolveToInstalled {
-            org: loaded.ident.org,
-            package: loaded.ident.name,
-            r#type: descriptor.name.r#type,
-        };
+        let reference = ProcessorTypeReference::new(
+            loaded.ident.org,
+            loaded.ident.name,
+            descriptor.name.r#type,
+        );
         self.runner
             .add_processor(ProcessorSpec::new(reference, config))
     }

--- a/sdk/streamlib-sdk/tests/app_sugar_test.rs
+++ b/sdk/streamlib-sdk/tests/app_sugar_test.rs
@@ -19,7 +19,9 @@ use std::collections::HashMap;
 use streamlib::sdk::App;
 use streamlib::sdk::context::RuntimeContextFullAccess;
 use streamlib::sdk::error::{Error, Result};
-use streamlib::sdk::processors::{Config, GeneratedProcessor, ManualProcessor, ProcessorSpec, ProcessorTypeReference};
+use streamlib::sdk::processors::{
+    Config, GeneratedProcessor, ManualProcessor, ProcessorSpec, ProcessorTypeReference,
+};
 use streamlib::sdk::runtime::Runner;
 
 // =============================================================================
@@ -51,7 +53,10 @@ manual_fixture!(EquivAlpha, "@tatolab/app-sugar-test/EquivAlpha");
 manual_fixture!(EquivBeta, "@tatolab/app-sugar-test/EquivBeta");
 manual_fixture!(PassthroughNode, "@tatolab/app-sugar-test/PassthroughNode");
 manual_fixture!(MaterializeNode, "@tatolab/app-sugar-test/MaterializeNode");
-manual_fixture!(IgnoredConnectNode, "@tatolab/app-sugar-test/IgnoredConnectNode");
+manual_fixture!(
+    IgnoredConnectNode,
+    "@tatolab/app-sugar-test/IgnoredConnectNode"
+);
 
 /// Register a `#[processor]` host type live under `@session/<name>` and derive
 /// the version-free reference that resolves it — the same reference shape
@@ -66,11 +71,7 @@ where
         .add_local_blocking::<P>(serde_json::Value::Null)
         .expect("session registration must succeed");
     let descriptor = P::descriptor().expect("fixture exposes a descriptor");
-    ProcessorTypeReference::ResolveToInstalled {
-        org: loaded.ident.org,
-        package: loaded.ident.name,
-        r#type: descriptor.name.r#type,
-    }
+    ProcessorTypeReference::new(loaded.ident.org, loaded.ident.name, descriptor.name.r#type)
 }
 
 /// Replace each captured concrete id with its positional token so two graphs
@@ -97,8 +98,12 @@ fn app_add_matches_runner_add_processor_snapshot() {
 
     // App-built graph.
     let app = App::new().expect("App::new");
-    let app_alpha = app.add(alpha_ref.clone(), config.clone()).expect("app add alpha");
-    let app_beta = app.add(beta_ref.clone(), config.clone()).expect("app add beta");
+    let app_alpha = app
+        .add(alpha_ref.clone(), config.clone())
+        .expect("app add alpha");
+    let app_beta = app
+        .add(beta_ref.clone(), config.clone())
+        .expect("app add beta");
     let app_snapshot = normalize_ids(
         &app.runner().to_json().expect("app graph json"),
         &[app_alpha.to_string(), app_beta.to_string()],
@@ -273,8 +278,12 @@ fn app_connect_between_real_processors_on_valid_ports_returns_ok() {
     let sink_ref = register_ported_type("AppConnectOkSink", "video_in", "_unused_out");
 
     let app = App::new().expect("App::new");
-    let source = app.add(source_ref, serde_json::json!({})).expect("app add source");
-    let sink = app.add(sink_ref, serde_json::json!({})).expect("app add sink");
+    let source = app
+        .add(source_ref, serde_json::json!({}))
+        .expect("app add source");
+    let sink = app
+        .add(sink_ref, serde_json::json!({}))
+        .expect("app add sink");
 
     // The ids `App` handed back are the default uppercase-leading form — the
     // shape that pre-fix produced `InvalidLink` for every real connect.
@@ -324,11 +333,11 @@ fn add_rejects_a_non_serializable_config() {
 
     // The config is encoded before the reference is ever resolved, so any
     // reference works — the serialization error must fire first.
-    let reference = ProcessorTypeReference::ResolveToInstalled {
-        org: Org::new("tatolab").unwrap(),
-        package: Package::new("app-sugar-test").unwrap(),
-        r#type: TypeName::new("Whatever").unwrap(),
-    };
+    let reference = ProcessorTypeReference::new(
+        Org::new("tatolab").unwrap(),
+        Package::new("app-sugar-test").unwrap(),
+        TypeName::new("Whatever").unwrap(),
+    );
 
     let app = App::new().expect("App::new");
     // A compound (tuple) map key cannot become a JSON object key — `to_value`
@@ -360,7 +369,11 @@ fn connect_to_nonexistent_port_surfaces_processor_port_not_found() {
         .expect_err("connecting a nonexistent port must fail");
 
     match error {
-        Error::ProcessorPortNotFound { port_name, direction, .. } => {
+        Error::ProcessorPortNotFound {
+            port_name,
+            direction,
+            ..
+        } => {
             assert_eq!(port_name, "no_such_out");
             assert_eq!(direction, PortDirection::Output);
         }


### PR DESCRIPTION
A processor reference is an import: ask for `@org/package/Type`, get whatever is
installed. `add` / `link` / `install` decide the version and record it in
`streamlib.lock`; the module walker checks the installed slot against that. By
the time code names a processor the question is settled, so the reference site
has nothing to add.

Every layer already worked that way except one.

| Layer | Version? | State |
|---|---|---|
| Resolve / install → `streamlib.lock` | yes — resolved version + content hash | already correct |
| Installed tree `streamlib_modules/@org/name/` | version-free slot, checked against the lock at the walker | already correct |
| Discovery (`resolve_providing_module`) | none — its own comment says it "ignores the reference-site version", returns `SemVerRange::Any` | already correct |
| **Usage (`ProcessorTypeReference`)** | **re-imposed a version, matched version-EXACT** | **fixed here** |

Processors register under the `0.0.0` version-free sentinel the `#[processor]`
grammar synthesizes, because a code-declared identity has no version. A
`VersionPinned` reference matched exact, so it missed a processor that had just
been discovered, loaded and registered — and the caller got
`UnknownProcessorType`.

## This already cost us once

`processor_instance_factory.rs` carries a regression test for it. The api-server
booted with its node in Error state and never served `/health`; the diagnosis at
the time was *"the old `schema_ident!(…, "1.0.0")` produced a
`VersionPinned(@1.0.0)` reference, which `add_v` resolves version-EXACT"*. The
call site was migrated and the test written — but the pinned path was left in
place, so the landmine stayed armed. `load_project_dylib_lazy_discovery` was
standing on it.

## What changed

`ProcessorTypeReference` is a struct of `(org, package, type)` with no version
field, so a pinned reference **cannot be written** rather than merely being
discouraged. `From<SchemaIdent>` narrows and drops the version. `add_v` and the
lazy-load fast path lose their two-armed match. Acquire-on-reference takes the
highest release the package source holds, because a constraint belongs to
resolution. A `version` key on an older wire payload parses and is ignored —
the same answer resolution would have given.

`schema_ident!` stays. A *resolved* identity legitimately carries a version
(lockfile entries, registry keys); its docs just no longer present it as a way
to reference a processor.

## Two further fixes, same silent-failure shape

- The lazy-discovery fixture wrote `version: 1.0.0` on a `processors:` entry.
  `ProcessorSchema` is `deny_unknown_fields` and real manifests carry no such
  key, so every fixture package silently failed to parse — another version
  remnant.
- An unparseable manifest under `streamlib_modules/` was logged at `warn` and
  skipped, making a malformed install indistinguishable from an absent one. Now
  a typed `Configuration` error naming the package directory and the parse
  failure.

## Pre-existing, and a coverage gap worth its own change

`load_project_dylib_lazy_discovery`'s three tests fail identically on `main`
before this change — this is not a regression from the folder-backed-discovery
stack.

They went unnoticed because **no CI job runs any of the 20
`load_project_dylib_*` binaries.** `check-pack-load.yml` states that
"Rust-cdylib load coverage meanwhile lives in the `load_project_dylib_*` dlopen
integration tests", but no workflow invokes them. Untouched here; it wants its
own change, and sizing it means splitting the headless-safe set from the
rig-only set.

## Verified

Three previously-red tests pass; `version_free_ref` and `abi_mismatch` still
pass; `test.yml` legs and `app_sugar_test` green; all 14 xtask gates pass;
`cargo doc -p streamlib --no-deps` reports no unresolved links.

Branched off `main`, independent of #1640 / #1646 — it will want a rebase
after those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
