### PR TITLE
fix(engine): compare port schema idents version-blind

### DIFF
--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -667,6 +667,8 @@ mod connect_schema_agreement_tests {
 
     const PRODUCER_TYPE: &str = "SchemaMismatchProducer";
     const CONSUMER_TYPE: &str = "SchemaMismatchConsumer";
+    const SENTINEL_PRODUCER_TYPE: &str = "VersionSentinelProducer";
+    const VERSIONED_CONSUMER_TYPE: &str = "VersionedSchemaConsumer";
 
     fn ident(package: &str, ty: &str) -> SchemaIdent {
         SchemaIdent::new(
@@ -679,6 +681,15 @@ mod connect_schema_agreement_tests {
 
     fn schema(ty: &str) -> PortSchemaSpec {
         PortSchemaSpec::Specific(ident("core", ty))
+    }
+
+    fn schema_at(ty: &str, major: u32, minor: u32, patch: u32) -> PortSchemaSpec {
+        PortSchemaSpec::Specific(SchemaIdent::new(
+            Org::new("test").unwrap(),
+            Package::new("core").unwrap(),
+            TypeName::new(ty).unwrap(),
+            SemVer::new(major, minor, patch),
+        ))
     }
 
     /// Register a producer type (`out` → VideoFrame) and a consumer type
@@ -707,17 +718,56 @@ mod connect_schema_agreement_tests {
         });
     }
 
-    /// Fresh compiler holding one producer node and one consumer node, plus the
-    /// wiring refs for their mismatched ports.
-    fn compiler_with_mismatched_pair() -> (Arc<Compiler>, OutputLinkPortRef, InputLinkPortRef) {
-        ensure_mismatch_types_registered();
+    /// Register the cross-language-shaped pair: a producer whose `out` port
+    /// carries the `0.0.0` version-free sentinel a Rust cdylib synthesizes, and
+    /// a consumer whose `in` port carries the `1.0.0` a manifest-resolved
+    /// Python/Deno port inherits from its schema owner's package. Same schema
+    /// identity, different version — the asymmetry every wireable Rust→Python
+    /// link in the tree hits. Idempotent across tests in the process.
+    fn ensure_cross_language_types_registered() {
+        static REGISTER: Once = Once::new();
+        REGISTER.call_once(|| {
+            let mut producer = ProcessorDescriptor::new(
+                ident("connectcheck", SENTINEL_PRODUCER_TYPE),
+                "version-free sentinel producer",
+            );
+            producer.outputs.push(PortDescriptor::iceoryx2(
+                "out",
+                "output",
+                schema_at("VideoFrame", 0, 0, 0),
+            ));
+            PROCESSOR_REGISTRY
+                .register_descriptor_only(producer)
+                .expect("register sentinel producer descriptor");
+
+            let mut consumer = ProcessorDescriptor::new(
+                ident("connectcheck", VERSIONED_CONSUMER_TYPE),
+                "manifest-versioned consumer",
+            );
+            consumer.inputs.push(PortDescriptor::iceoryx2(
+                "in",
+                "input",
+                schema_at("VideoFrame", 1, 0, 0),
+            ));
+            PROCESSOR_REGISTRY
+                .register_descriptor_only(consumer)
+                .expect("register versioned consumer descriptor");
+        });
+    }
+
+    /// Fresh compiler holding one node of each named registered type, plus the
+    /// wiring refs for the producer's `out` and the consumer's `in`.
+    fn compiler_with_pair(
+        producer_type: &str,
+        consumer_type: &str,
+    ) -> (Arc<Compiler>, OutputLinkPortRef, InputLinkPortRef) {
         let compiler = Arc::new(Compiler::new());
         let (from_id, to_id): (ProcessorUniqueId, ProcessorUniqueId) =
             compiler.scope(|graph, _tx| {
                 let from = graph
                     .traversal_mut()
                     .add_v(ProcessorSpec::new(
-                        ident("connectcheck", PRODUCER_TYPE),
+                        ident("connectcheck", producer_type),
                         Value::Null,
                     ))
                     .first()
@@ -727,7 +777,7 @@ mod connect_schema_agreement_tests {
                 let to = graph
                     .traversal_mut()
                     .add_v(ProcessorSpec::new(
-                        ident("connectcheck", CONSUMER_TYPE),
+                        ident("connectcheck", consumer_type),
                         Value::Null,
                     ))
                     .first()
@@ -741,6 +791,21 @@ mod connect_schema_agreement_tests {
             OutputLinkPortRef::new(from_id, "out"),
             InputLinkPortRef::new(to_id, "in"),
         )
+    }
+
+    /// Fresh compiler holding one producer node and one consumer node, plus the
+    /// wiring refs for their mismatched ports.
+    fn compiler_with_mismatched_pair() -> (Arc<Compiler>, OutputLinkPortRef, InputLinkPortRef) {
+        ensure_mismatch_types_registered();
+        compiler_with_pair(PRODUCER_TYPE, CONSUMER_TYPE)
+    }
+
+    /// Fresh compiler holding the cross-language-shaped pair, plus its wiring
+    /// refs.
+    fn compiler_with_cross_language_pair()
+    -> (Arc<Compiler>, OutputLinkPortRef, InputLinkPortRef) {
+        ensure_cross_language_types_registered();
+        compiler_with_pair(SENTINEL_PRODUCER_TYPE, VERSIONED_CONSUMER_TYPE)
     }
 
     fn block_on<F: std::future::Future>(fut: F) -> F::Output {
@@ -800,6 +865,61 @@ mod connect_schema_agreement_tests {
             "loose connect over a concrete producer/consumer schema mismatch must \
              emit the connect-time warn; captured WARN messages: {captured:?}"
         );
+    }
+
+    /// Exit-criterion lock for #1654: the cross-language link shape wires
+    /// SILENTLY. A Rust cdylib port stamps the `0.0.0` version-free sentinel
+    /// while its Python/Deno peer carries the schema owner's package version,
+    /// so before the version-blind comparator every wireable Rust→Python link
+    /// in the tree emitted this warn. CI never caught it because it runs
+    /// lib-tests only and never wires a live cross-language pipeline — this
+    /// test is that missing coverage, at the wiring site rather than in a unit
+    /// test of the classifier alone.
+    ///
+    /// Restore the version-sensitive comparison and the warn fires again,
+    /// failing here.
+    #[test]
+    fn loose_connect_is_silent_across_the_version_free_sentinel_asymmetry() {
+        let (compiler, from, to) = compiler_with_cross_language_pair();
+        let warnings = CapturedWarnings::default();
+        let subscriber = tracing_subscriber::registry().with(warnings.clone());
+
+        let result = tracing::subscriber::with_default(subscriber, || {
+            block_on(connect_impl(
+                compiler,
+                from,
+                to,
+                SchemaValidationPosture::Loose,
+            ))
+        });
+
+        result.expect("the cross-language pair must wire");
+
+        let captured = warnings.0.lock().unwrap();
+        assert!(
+            !captured
+                .iter()
+                .any(|m| m.contains("does not match consumer input")),
+            "a `0.0.0` sentinel producer and a `1.0.0` consumer share a schema \
+             identity and must wire without a schema warn; captured WARN \
+             messages: {captured:?}"
+        );
+    }
+
+    /// The same cross-language pair must also survive the STRICT posture — the
+    /// version axis is not a mismatch at any posture, so a safety-critical
+    /// channel does not have to choose between strict validation and wiring a
+    /// Python processor.
+    #[test]
+    fn strict_connect_accepts_the_version_free_sentinel_asymmetry() {
+        let (compiler, from, to) = compiler_with_cross_language_pair();
+        block_on(connect_impl(
+            compiler,
+            from,
+            to,
+            SchemaValidationPosture::Strict,
+        ))
+        .expect("strict posture must accept a version-only difference");
     }
 
     #[test]

--- a/runtime/streamlib-engine/src/core/schema_agreement.rs
+++ b/runtime/streamlib-engine/src/core/schema_agreement.rs
@@ -14,8 +14,14 @@
 //!   the consumer port's expected tag), compared per read.
 //!
 //! Agreement is intentionally permissive: an `Any` / unset tag on *either* side
-//! is the tolerant wildcard and never mismatches. Only two concrete-but-unequal
-//! schemas are a mismatch. The default posture is [loose-but-observed][Loose] —
+//! is the tolerant wildcard and never mismatches. Only two concrete schemas
+//! with different `(org, package, type)` identity tuples are a mismatch.
+//! Comparison is version-blind, matching every other resolution surface in the
+//! runtime (registry lookup, loader cross-check, processor resolution): a Rust
+//! cdylib port carries the `0.0.0` version-free sentinel while a
+//! manifest-resolved Python/Deno port carries its schema owner's package
+//! version, and those two ends describe the same schema. The default posture is
+//! [loose-but-observed][Loose] —
 //! a mismatch is a `tracing::warn`, not a hard error — matching the #1345 design
 //! (a graph that ran yesterday must not stop running because a port was
 //! re-typed). A safety-critical wiring site opts into [`Strict`][Strict] to turn
@@ -53,10 +59,10 @@ pub enum SchemaValidationPosture {
 /// Whether a producer schema and a consumer schema agree.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SchemaAgreement {
-    /// The two ends agree — identical concrete schemas, or a wildcard
-    /// (`Any` / unset) on at least one side.
+    /// The two ends agree — concrete schemas sharing an identity tuple, or a
+    /// wildcard (`Any` / unset) on at least one side.
     Compatible,
-    /// Both ends declare a concrete schema and the two differ.
+    /// Both ends declare a concrete schema and their identity tuples differ.
     Mismatch,
 }
 
@@ -66,14 +72,15 @@ pub enum SchemaAgreement {
 /// [`PortSchemaSpec::Named`], which the registry never yields for a wired link
 /// but is handled here defensively — on either side is
 /// [`Compatible`](SchemaAgreement::Compatible): the check can only assert a
-/// mismatch when *both* ends are concrete [`PortSchemaSpec::Specific`].
+/// mismatch when *both* ends are concrete [`PortSchemaSpec::Specific`], and
+/// then only on the version-blind identity tuple.
 pub fn classify_port_schema_agreement(
     producer: &PortSchemaSpec,
     consumer: &PortSchemaSpec,
 ) -> SchemaAgreement {
     match (producer.specific(), consumer.specific()) {
         (Some(producer_ident), Some(consumer_ident)) => {
-            if producer_ident == consumer_ident {
+            if producer_ident.matches_schema_tuple(consumer_ident) {
                 SchemaAgreement::Compatible
             } else {
                 SchemaAgreement::Mismatch
@@ -87,14 +94,15 @@ pub fn classify_port_schema_agreement(
 /// Classify a stamped inbound-frame tag against a consumer port's expected tag.
 ///
 /// An [unset][SchemaIdentWire::is_unset] tag on either side is the wildcard and
-/// never mismatches; two set-but-unequal tags are a mismatch.
+/// never mismatches; two set tags with different identity tuples are a
+/// mismatch. Version-blind, like the connect-time classifier.
 pub fn classify_wire_schema_agreement(
     stamped: &SchemaIdentWire,
     expected: &SchemaIdentWire,
 ) -> SchemaAgreement {
     if stamped.is_unset() || expected.is_unset() {
         SchemaAgreement::Compatible
-    } else if stamped == expected {
+    } else if stamped.matches_schema_tuple(expected) {
         SchemaAgreement::Compatible
     } else {
         SchemaAgreement::Mismatch
@@ -159,13 +167,24 @@ mod tests {
     use super::*;
     use streamlib_idents::{Org, Package, SchemaIdent, SemVer, TypeName};
 
-    fn spec(org: &str, package: &str, ty: &str, major: u32) -> PortSchemaSpec {
+    fn spec_at(
+        org: &str,
+        package: &str,
+        ty: &str,
+        major: u32,
+        minor: u32,
+        patch: u32,
+    ) -> PortSchemaSpec {
         PortSchemaSpec::Specific(SchemaIdent::new(
             Org::new(org).unwrap(),
             Package::new(package).unwrap(),
             TypeName::new(ty).unwrap(),
-            SemVer::new(major, 0, 0),
+            SemVer::new(major, minor, patch),
         ))
+    }
+
+    fn spec(org: &str, package: &str, ty: &str, major: u32) -> PortSchemaSpec {
+        spec_at(org, package, ty, major, 0, 0)
     }
 
     fn ctx() -> ConnectSchemaContext<'static> {
@@ -205,23 +224,53 @@ mod tests {
         );
     }
 
-    /// Revert lock: two distinct concrete specs MUST classify as a mismatch.
-    /// Mentally revert the comparison to always-`Compatible` and this fails —
-    /// which is exactly the "no consumer reads the tag" gap #1430 closes.
+    /// Revert lock: two concrete specs with different identity tuples MUST
+    /// classify as a mismatch. Mentally revert the comparison to
+    /// always-`Compatible` and this fails — which is exactly the "no consumer
+    /// reads the tag" gap #1430 closes. Every segment of the tuple is
+    /// load-bearing, not just the type.
     #[test]
     fn distinct_concrete_specs_mismatch() {
         let producer = spec("tatolab", "core", "VideoFrame", 1);
-        let consumer = spec("tatolab", "core", "AudioFrame", 1);
-        assert_eq!(
-            classify_port_schema_agreement(&producer, &consumer),
-            SchemaAgreement::Mismatch,
-        );
-        // Same type, different major version is still a concrete mismatch.
-        let consumer_v2 = spec("tatolab", "core", "VideoFrame", 2);
-        assert_eq!(
-            classify_port_schema_agreement(&producer, &consumer_v2),
-            SchemaAgreement::Mismatch,
-        );
+        for consumer in [
+            spec("tatolab", "core", "AudioFrame", 1),
+            spec("tatolab", "vision", "VideoFrame", 1),
+            spec("acme", "core", "VideoFrame", 1),
+        ] {
+            assert_eq!(
+                classify_port_schema_agreement(&producer, &consumer),
+                SchemaAgreement::Mismatch,
+                "{producer} vs {consumer} differ in the identity tuple",
+            );
+        }
+    }
+
+    /// Revert lock (#1654): agreement is version-blind. A Rust cdylib port
+    /// carries the `0.0.0` version-free sentinel while a manifest-resolved
+    /// Python/Deno port carries its schema owner's package version — the same
+    /// schema, so the link must wire silently. Restore `==` over the derived
+    /// `PartialEq` (all four fields) and every cross-language link classifies
+    /// as `Mismatch` again, failing here.
+    #[test]
+    fn same_tuple_different_version_is_compatible() {
+        let sentinel = spec_at("tatolab", "core", "VideoFrame", 0, 0, 0);
+        for other in [
+            spec_at("tatolab", "core", "VideoFrame", 1, 0, 0),
+            spec_at("tatolab", "core", "VideoFrame", 2, 7, 3),
+            spec_at("tatolab", "core", "VideoFrame", 0, 1, 0),
+            spec_at("tatolab", "core", "VideoFrame", 0, 0, 5),
+        ] {
+            assert_eq!(
+                classify_port_schema_agreement(&sentinel, &other),
+                SchemaAgreement::Compatible,
+                "{sentinel} vs {other} share an identity tuple",
+            );
+            assert_eq!(
+                classify_port_schema_agreement(&other, &sentinel),
+                SchemaAgreement::Compatible,
+                "agreement is symmetric",
+            );
+        }
     }
 
     #[test]
@@ -305,6 +354,34 @@ mod tests {
             SchemaIdentWire::from_segments("tatolab", "core", "AudioFrame", 1, 0, 0).unwrap();
         assert_eq!(
             classify_wire_schema_agreement(&stamped, &expected),
+            SchemaAgreement::Mismatch,
+        );
+    }
+
+    /// Revert lock (#1654): the per-frame read path is version-blind too. The
+    /// stamped tag and the port's expected tag are resolved from the same two
+    /// asymmetric sources as the connect-time specs, so a version-sensitive
+    /// comparison here warns once per port on every cross-language link.
+    #[test]
+    fn wire_agreement_ignores_the_version_axis() {
+        let sentinel =
+            SchemaIdentWire::from_segments("tatolab", "core", "VideoFrame", 0, 0, 0).unwrap();
+        let versioned =
+            SchemaIdentWire::from_segments("tatolab", "core", "VideoFrame", 1, 2, 3).unwrap();
+        assert_eq!(
+            classify_wire_schema_agreement(&sentinel, &versioned),
+            SchemaAgreement::Compatible,
+        );
+        assert_eq!(
+            classify_wire_schema_agreement(&versioned, &sentinel),
+            SchemaAgreement::Compatible,
+        );
+
+        // The version axis is ignored; the identity tuple is not.
+        let other_package =
+            SchemaIdentWire::from_segments("tatolab", "vision", "VideoFrame", 1, 2, 3).unwrap();
+        assert_eq!(
+            classify_wire_schema_agreement(&versioned, &other_package),
             SchemaAgreement::Mismatch,
         );
     }

--- a/runtime/streamlib-engine/src/core/schema_agreement.rs
+++ b/runtime/streamlib-engine/src/core/schema_agreement.rs
@@ -100,9 +100,7 @@ pub fn classify_wire_schema_agreement(
     stamped: &SchemaIdentWire,
     expected: &SchemaIdentWire,
 ) -> SchemaAgreement {
-    if stamped.is_unset() || expected.is_unset() {
-        SchemaAgreement::Compatible
-    } else if stamped.matches_schema_tuple(expected) {
+    if stamped.is_unset() || expected.is_unset() || stamped.matches_schema_tuple(expected) {
         SchemaAgreement::Compatible
     } else {
         SchemaAgreement::Mismatch

--- a/runtime/streamlib-engine/src/iceoryx2/input.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/input.rs
@@ -994,6 +994,38 @@ mod tests {
         assert!(!mb_any.schema_mismatch_observed("in"));
     }
 
+    /// Exit-criterion lock for #1654 on the READ path — the other half of the
+    /// spurious cross-language warn. A frame stamped with the `0.0.0`
+    /// version-free sentinel a Rust cdylib synthesizes, arriving at a port
+    /// whose expected tag carries its schema owner's package version, is the
+    /// same schema: no mismatch, no once-per-port warn. Restore the
+    /// version-sensitive tag comparison and `schema_mismatch_observed` flips
+    /// to `true`, failing here.
+    #[test]
+    fn read_raw_is_silent_across_the_version_free_sentinel_asymmetry() {
+        let mailboxes = InputMailboxesInner::new();
+        mailboxes.add_port("in", 64, ReadMode::ReadNextInOrder);
+
+        let expected =
+            SchemaIdentWire::from_segments("tatolab", "core", "VideoFrame", 1, 0, 0).unwrap();
+        mailboxes.set_port_expected_schema_ident("in", expected);
+
+        let stamped_sentinel =
+            SchemaIdentWire::from_segments("tatolab", "core", "VideoFrame", 0, 0, 0).unwrap();
+        assert!(mailboxes.route(frame_with_schema("in", stamped_sentinel)));
+
+        let read = mailboxes
+            .read_raw("in")
+            .expect("read_raw must succeed")
+            .expect("a frame is queued");
+        assert_eq!(read.0, vec![9, 8, 7, 6], "payload delivered");
+        assert!(
+            !mailboxes.schema_mismatch_observed("in"),
+            "a version-only difference is the same schema identity and must not \
+             be observed as a mismatch",
+        );
+    }
+
     /// N→1 fan-in DELIVERY lock (#1419): a destination consuming TWO inbound
     /// channels binds two subscribers to ONE local input port; `receive_pending`
     /// routes every frame from both channels into that shared mailbox.

--- a/runtime/streamlib-ipc-types/src/lib.rs
+++ b/runtime/streamlib-ipc-types/src/lib.rs
@@ -441,6 +441,16 @@ impl SchemaIdentWire {
         std::str::from_utf8(&self.type_name[..self.type_len as usize]).unwrap_or("")
     }
 
+    /// Whether two tags share the same `(org, package, type)` identity tuple,
+    /// version-blind — the wire-side mirror of
+    /// `streamlib_idents::SchemaIdent::matches_schema_tuple`, and the
+    /// projection every schema-agreement check compares on.
+    pub fn matches_schema_tuple(&self, other: &SchemaIdentWire) -> bool {
+        self.org_str() == other.org_str()
+            && self.package_str() == other.package_str()
+            && self.type_str() == other.type_str()
+    }
+
     /// Render the joined `@org/package/Type@major.minor.patch` form for
     /// human-facing surfaces (logs, error messages). One-way: the joined
     /// form never round-trips back through any parser at the structured
@@ -742,6 +752,27 @@ mod tests {
         assert_eq!(ident.version_minor, 0);
         assert_eq!(ident.version_patch, 0);
         assert_eq!(ident.render_joined(), "@tatolab/core/VideoFrame@1.0.0");
+    }
+
+    #[test]
+    fn schema_ident_wire_matches_schema_tuple_ignores_version() {
+        let ident = sample_ident();
+        let other_version =
+            SchemaIdentWire::from_segments("tatolab", "core", "VideoFrame", 9, 4, 2).unwrap();
+        assert!(ident.matches_schema_tuple(&other_version));
+        assert!(other_version.matches_schema_tuple(&ident));
+
+        for differing in [
+            SchemaIdentWire::from_segments("acme", "core", "VideoFrame", 1, 0, 0).unwrap(),
+            SchemaIdentWire::from_segments("tatolab", "vision", "VideoFrame", 1, 0, 0).unwrap(),
+            SchemaIdentWire::from_segments("tatolab", "core", "AudioFrame", 1, 0, 0).unwrap(),
+        ] {
+            assert!(
+                !ident.matches_schema_tuple(&differing),
+                "every segment of the identity tuple is load-bearing: {}",
+                differing.render_joined(),
+            );
+        }
     }
 
     #[test]

--- a/runtime/streamlib-ipc-types/src/lib.rs
+++ b/runtime/streamlib-ipc-types/src/lib.rs
@@ -340,6 +340,13 @@ impl std::error::Error for SchemaIdentWireError {}
 ///
 /// Length-prefix semantics: `*_len = 0` means "empty segment" (zero
 /// readable bytes); the trailing buffer bytes are zeroed at construction.
+///
+/// The derived `PartialEq` / `Hash` below are version-INCLUSIVE, which is
+/// correct for byte-identity but wrong for deciding whether two ports carry
+/// the same schema: a Rust cdylib stamps the `0.0.0` version-free sentinel
+/// while its Python/Deno peer carries the schema owner's package version.
+/// Schema agreement compares [`Self::matches_schema_tuple`] instead. Reaching
+/// for `==` there is what reintroduced #1460 as #1477.
 #[derive(Clone, Copy, Eq, PartialEq, Hash, ZeroCopySend)]
 #[repr(C)]
 pub struct SchemaIdentWire {

--- a/sdk/streamlib-idents/src/ident.rs
+++ b/sdk/streamlib-idents/src/ident.rs
@@ -322,6 +322,11 @@ impl JsonSchema for TypeName {
 /// use streamlib_idents::SchemaIdent;
 /// let _: SchemaIdent = "@tatolab/core/VideoFrame@1.0.0".parse().unwrap();
 /// ```
+///
+/// The derived `PartialEq` below is version-inclusive. Every resolution
+/// surface in the runtime binds version-blind, so anything deciding whether
+/// two idents name the same schema compares [`Self::matches_schema_tuple`],
+/// not `==` — reaching for `==` there is what reintroduced #1460 as #1477.
 #[derive(
     Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
 )]


### PR DESCRIPTION
## Summary

- `classify_port_schema_agreement` and `classify_wire_schema_agreement` were the last two resolution surfaces still comparing a `SchemaIdent` version-inclusively, through its derived `PartialEq` over all four fields. Every other surface — registry lookup, loader cross-check, processor resolution, `ProcessorTypeReference` after #1648 — binds version-blind. Both now compare on the `(org, package, type)` identity tuple.
- Adds `SchemaIdentWire::matches_schema_tuple`, the wire-side mirror of the existing `SchemaIdent::matches_schema_tuple`, so the version-blind projection is named once rather than inlined into the classifier.
- The type-level check is untouched: a miswired `VideoFrame`→`AudioFrame` link still classifies as `Mismatch`, and #1430's revert locks stay green. Only the version axis is removed.

## Closes

Closes #1654

## Exit criteria

- [x] `@x/y/T@0.0.0` vs `@x/y/T@1.0.0` classifies `Compatible`, with a revert-lock test asserting it — `same_tuple_different_version_is_compatible`, plus the wire-side `wire_agreement_ignores_the_version_axis`.
- [x] `@x/y/VideoFrame` vs `@x/y/AudioFrame` still classifies `Mismatch`, existing revert locks green — `distinct_concrete_specs_mismatch` (widened to cover all three tuple segments, not just the type).
- [x] No spurious warn on a Rust→Python link — locked at both wiring sites, connect and read (see Test plan).

## What changed vs. the issue body

No divergence — every citation in the body verified accurate against current code. One imprecision worth noting for future readers: the table locates `classify_wire_schema_agreement` at `iceoryx2/input.rs:467-484`, which is its *caller*; the function itself is at `schema_agreement.rs:91-102`. The Design section cites correctly.

Per the body, the `Strict` posture is left in place — this is a comparator fix, not a policy change.

## Test plan

The issue notes this regression shipped twice because CI runs lib-tests only and never wires a live cross-language pipeline. Coverage was therefore added at the **wiring sites**, not just on the classifiers — this module's own doctrine (`operations_runtime.rs:641-645`) says classifier-only tests don't catch wiring-site regressions.

| gate | result |
|---|---|
| `cargo check` (both edited crates) | pass |
| `cargo test -p streamlib-ipc-types` | pass — 17 |
| `cargo test -p streamlib-idents` | pass — 256 |
| `cargo test -p streamlib-engine --lib` | 1742 pass, 2 pre-existing failures (below) |
| `cargo test -p streamlib --test app_sugar_test` | pass — 7 |
| `cargo doc` intra-doc links | clean |
| clippy on edited files | no new warnings; one pre-existing `if_same_then_else` removed |

**Revert-lock proof.** Rather than assert the locks bite, I reverted both comparators to `==` and re-ran: all five new tests fail, and every pre-existing mismatch test stays green — confirming the tests exercise the bug and that the type-level check was not weakened.

New tests:
- `same_tuple_different_version_is_compatible` / `wire_agreement_ignores_the_version_axis` — the classifiers.
- `loose_connect_is_silent_across_the_version_free_sentinel_asymmetry` / `strict_connect_accepts_the_version_free_sentinel_asymmetry` — through `connect_impl`, with a producer carrying the `0.0.0` sentinel and a consumer carrying `1.0.0`.
- `read_raw_is_silent_across_the_version_free_sentinel_asymmetry` — the read path, the other half of the spurious warn.
- `schema_ident_wire_matches_schema_tuple_ignores_version` — the new projection directly.

Both sources of the real asymmetry are already independently locked in CI, so the hardcoded pair in the connect test is provably representative: `grammar.rs:552,672` lock the `0.0.0` sentinel, and `project_config.rs:433` locks the manifest-inherited version.

### Live cross-language run — attempted, blocked

The Validation shape asks for a live cross-language link emitting no schema warning. I attempted it on `examples/polyglot-manual-source` (Python/Deno source → Rust sink, no camera or display). It confirmed the asymmetry on real in-tree code — `streamlib link ./python` and `./deno` both report `frame_out (@tatolab/core/VideoFrame@1.0.0)`, while the Rust sink declares the version-free `input("video_in", "@tatolab/core/VideoFrame")` → `@0.0.0`.

The runtime connect was not reached: the counting-sink plugin needs `_generated_rust_crate_root_/lib.rs`, which `cargo xtask generate-crate-roots` only produces for in-tree packages and the build orchestrator only produces during a real package install, not a `link`. `setup.sh` + `streamlib install` therefore do not leave that example runnable on unmodified `main`. Pre-existing gap, unrelated to this change; not patched here. The environment was fully restored afterward (`streamlib unlink --engine`, generated artifacts removed).

## Pre-existing failures (not introduced here, not fixed here)

Both fail identically on clean `main` at `731585ad`:

- `processor_spec::tests::serde_emits_structured_name_object_not_joined_string` — expects `"1.0.0"`, gets `Null`.
- `module_loader::lazy_load_error_tests::lazy_module_load_failed_names_type_package_and_detail` — expects `SemVer 1.0.0`, gets `0.0.0`.

Both are #1648 fallout: tests still asserting a version on a now-version-free *processor* reference. Same regression class as this ticket, on the processor axis rather than the schema axis.

Also observed: `module_loader::from_source::tests::stages_python_source_into_a_loadable_session_package` is flaky — failed once under the parallel suite, passes in isolation and on re-run.

## Notes

- **Derived-`PartialEq` trap.** The issue records that #1460 fixed this class and #1477 reintroduced it three weeks later *through derived `PartialEq`*. `SchemaIdent` and `SchemaIdentWire` both still derive version-inclusive equality (correct for byte-identity, wrong for agreement), so each now carries a note pointing agreement comparisons at `matches_schema_tuple`. Cheapest available guard against a third recurrence.
- **Extraction, called out per CLAUDE.md.** `compiler_with_pair` is extracted from `compiler_with_mismatched_pair` so the mismatched and cross-language shapes share one node-construction body — real duplication, not a speculative refactor.
- **Polyglot sweep: no migration needed.** No Python/Deno schema-agreement classifier exists; the SDKs only construct and encode `SchemaIdentWire`. Deno's `SchemaIdent.equals()` and Python's frozen-dataclass `__eq__` are version-inclusive but have no agreement callers, so there is no old pattern to migrate. Adding version-blind helpers with zero callers would be speculative API.
- This removes the constraint #1651 currently has to legislate by review convention — the `0.0.0` sentinel no longer has to be mandated on every polyglot port `SchemaIdent`.

## Follow-ups

None filed. Two candidates for the owner's call: the two #1648-fallout test failures above, and the `polyglot-manual-source` linked-package provisioning gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)