### PR TITLE
test(engine): assert the version-free contract on processor references

### DIFF
--- a/runtime/streamlib-engine/src/core/processors/processor_spec.rs
+++ b/runtime/streamlib-engine/src/core/processors/processor_spec.rs
@@ -91,13 +91,8 @@ mod tests {
         assert_eq!(name["org"], "tatolab");
         assert_eq!(name["package"], "core");
         assert_eq!(name["type"], "VideoFrame");
-        // A processor reference carries no version — the `1.0.0` the spec was
-        // built from is dropped when the ident narrows. Asserted as absence, so
-        // re-pinning a version onto the wire form fails here.
-        assert!(
-            name.get("version").is_none(),
-            "the wire form must carry no `version` key, got {name}"
-        );
+        // Exactly those three keys — a processor reference names no version,
+        // so the `1.0.0` this spec was built from reaches no wire field.
         assert_eq!(
             name.as_object().unwrap().len(),
             3,

--- a/runtime/streamlib-engine/src/core/processors/processor_spec.rs
+++ b/runtime/streamlib-engine/src/core/processors/processor_spec.rs
@@ -74,10 +74,10 @@ mod tests {
 
     #[test]
     fn serde_emits_structured_name_object_not_joined_string() {
-        // Wire-format lock — the name field on the wire is a structured 4-key
-        // object, not the joined `@org/pkg/Type@version` form. The structured
-        // shape is the "structured-everywhere" rule from the architecture
-        // preamble (notes 1, 2 of the issue body).
+        // Wire-format lock — the name field on the wire is a structured 3-key
+        // object, not the joined `@org/pkg/Type` form. The structured shape is
+        // the "structured-everywhere" rule from the architecture preamble
+        // (notes 1, 2 of the issue body).
         let spec = ProcessorSpec::new(
             ident("tatolab", "core", "VideoFrame", SemVer::new(1, 0, 0)),
             serde_json::Value::Null,
@@ -91,12 +91,18 @@ mod tests {
         assert_eq!(name["org"], "tatolab");
         assert_eq!(name["package"], "core");
         assert_eq!(name["type"], "VideoFrame");
-        // `SemVer` serializes as the dotted string form `"1.0.0"`,
-        // not a structured `{major, minor, patch}` object — see
-        // `streamlib-idents::semver`. The four-field rule applies to
-        // `SchemaIdent` segments (org/package/type/version), not to the
-        // version's internal representation.
-        assert_eq!(name["version"], "1.0.0");
+        // A processor reference carries no version — the `1.0.0` the spec was
+        // built from is dropped when the ident narrows. Asserted as absence, so
+        // re-pinning a version onto the wire form fails here.
+        assert!(
+            name.get("version").is_none(),
+            "the wire form must carry no `version` key, got {name}"
+        );
+        assert_eq!(
+            name.as_object().unwrap().len(),
+            3,
+            "the wire form is exactly `org` + `package` + `type`, got {name}"
+        );
     }
 
     #[test]

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -1057,7 +1057,9 @@ mod lazy_load_error_tests {
     /// The recoverable lazy-load error names the referenced type, derives its
     /// providing package `@org/name` from the type's own org + package, and
     /// carries the underlying load-failure detail. Shared by the async and
-    /// blocking lazy paths.
+    /// blocking lazy paths. Narrowing a versioned ident through
+    /// [`ProcessorTypeReference`] drops the version, so the reported type
+    /// renders at the version-free placeholder.
     #[test]
     fn lazy_module_load_failed_names_type_package_and_detail() {
         let processor_type = crate::core::descriptors::SchemaIdent::new(
@@ -1080,7 +1082,19 @@ mod lazy_load_error_tests {
                 package,
                 detail,
             } => {
-                assert_eq!(reported_type, processor_type);
+                // Version-blind on purpose: `SchemaIdent`'s derived `PartialEq`
+                // is version-inclusive, so `reported_type == processor_type`
+                // would assert the version survives the narrowing.
+                assert!(
+                    reported_type.matches_schema_tuple(&processor_type),
+                    "expected the `{processor_type}` identity tuple, got `{reported_type}`"
+                );
+                assert_eq!(
+                    reported_type.version,
+                    streamlib_idents::SemVer::new(0, 0, 0),
+                    "a processor reference carries no version; the reported type \
+                     must render at the version-free placeholder"
+                );
                 assert_eq!(package.to_string(), "@tatolab/camera");
                 assert!(!detail.is_empty(), "the underlying reason must be carried");
             }


### PR DESCRIPTION
## Summary

- Two `streamlib-engine` lib tests failed on `main` because both still asserted a version on a processor reference that #1648 deliberately made version-free. Neither is caught by CI, which does not run this crate's lib tests (#1369).
- Each now locks the version-free contract instead of merely dropping the stale assertion, so re-pinning a version to a processor reference fails them.
- Test-only: no library change, as the issue requires.

## Closes

Closes #1658

## Exit criteria

- [x] Both tests pass on `main` with no library change.
- [x] Each asserts the version-free contract, so re-pinning a version fails them.
  - `processor_spec.rs` — the serialized `name` must be **exactly** `org` + `package` + `type`. Stricter than asserting the `version` key is absent: any fourth key fails, and the sibling `schema_ident_narrows_to_a_version_free_reference` already covers plain absence from the same setup.
  - `module_loader/mod.rs` — identity compared via `SchemaIdent::matches_schema_tuple` (the version-blind comparator #1654 introduced), plus an explicit assert that the reported version is the `0.0.0` placeholder. The old `assert_eq!` went through `SchemaIdent`'s derived, version-inclusive `PartialEq`, which asserted the version *survives* the narrowing.
- [x] No production code changed. The audit the issue asked for did find a real version-inclusive comparison on the processor axis; per "Done means", it is split into its own issue rather than folded in.

## Test plan

`cargo test -p streamlib-engine --lib` — **1744 passed, 0 failed** (the issue body's 1739/2 baseline predates #1656, which added tests). Run four times; clean and exit-0 every time.

Before, on `2a9057c6`, both failures reproduced verbatim as filed:

```
processor_spec.rs:99   left: Null                    right: "1.0.0"
mod.rs:1083            left: ...version: 0.0.0       right: ...version: 1.0.0
```

`cargo clippy -p streamlib-engine --lib --tests` — no new warnings at the touched lines.

Not a CI gate today (#1369); verified locally.

## Follow-ups

- **#1660** — `remove_module`'s in-use guard compares processor idents version-inclusively. `module_loader/mod.rs:637` does `removed_type_set.contains(&node.processor_type)` against a `HashSet<&SchemaIdent>`, so the lookup uses the derived version-inclusive `Hash`/`Eq`. A node added during a registry miss carries the `@org/pkg/Type@0.0.0` diagnostic ident (`add_v_op.rs:57`) while the ledger's idents carry real versions, so the guard can miss it and unload a module a graph node still references. Same defect class as #1654, on the processor axis.
- The other three `to_diagnostic_ident()` consumers were audited and are clean: `mod.rs:753` and `operations_runtime.rs:66` are error-payload-only, `mod.rs:857` feeds a discovery path that matches on the short type name alone. Registry resolution is already tuple-based.
- Observed once and not reproducible: one suite run aborted with SIGABRT during process teardown *after* printing `test result: ok. 1744 passed`. Three subsequent runs exited 0. Not in any path these two test edits touch; noting rather than chasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)