### PR TITLE
fix(engine): compare processor idents version-blind in remove_module's in-use guard

### DIFF
--- a/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
+++ b/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
@@ -1349,7 +1349,7 @@ impl ProcessorInstanceFactory {
         self.descriptors
             .read()
             .keys()
-            .filter(|id| &id.org == org && &id.package == package && &id.r#type == type_name)
+            .filter(|id| id.schema_identity_tuple() == (org, package, type_name))
             .max_by_key(|id| id.version)
             .cloned()
     }

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -627,7 +627,7 @@ impl Runner {
         // holds the registered version.
         let unregistered = crate::core::processors::PROCESSOR_REGISTRY
             .unregister_processor_types(&processor_idents);
-        let removed_type_set: std::collections::HashSet<(
+        let removed_type_set: HashSet<(
             &crate::core::descriptors::Org,
             &crate::core::descriptors::Package,
             &crate::core::descriptors::TypeName,

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/mod.rs
@@ -620,10 +620,21 @@ impl Runner {
         // the removed types, RESTORE the registrations and refuse. Nodes
         // marked pending-deletion are excluded — the graph has committed
         // to removing them and the compiler never spawns one.
+        //
+        // The set keys on the version-blind identity tuple, not the whole
+        // ident: a node added while its type was unregistered carries the
+        // `(org, package, type)@0.0.0` diagnostic ident, while the ledger
+        // holds the registered version.
         let unregistered = crate::core::processors::PROCESSOR_REGISTRY
             .unregister_processor_types(&processor_idents);
-        let removed_type_set: std::collections::HashSet<&crate::core::descriptors::SchemaIdent> =
-            processor_idents.iter().collect();
+        let removed_type_set: std::collections::HashSet<(
+            &crate::core::descriptors::Org,
+            &crate::core::descriptors::Package,
+            &crate::core::descriptors::TypeName,
+        )> = processor_idents
+            .iter()
+            .map(|ident| ident.schema_identity_tuple())
+            .collect();
         let processors_in_use: Vec<(
             crate::core::graph::ProcessorUniqueId,
             crate::core::descriptors::SchemaIdent,
@@ -634,7 +645,7 @@ impl Runner {
                 .v(())
                 .iter()
                 .filter(|node| {
-                    removed_type_set.contains(&node.processor_type)
+                    removed_type_set.contains(&node.processor_type.schema_identity_tuple())
                         && !node.has::<crate::core::graph::PendingDeletionComponent>()
                 })
                 .map(|node| (node.id.clone(), node.processor_type.clone()))

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/tests.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/tests.rs
@@ -3793,6 +3793,110 @@ processors:
         );
     }
 
+    /// A node added *before* its module loaded carries the
+    /// `(org, package, type)@0.0.0` diagnostic ident, while the ledger holds
+    /// the registered version. The in-use guard must still see it — matching
+    /// version-inclusively let `remove_module` unload the module and strand
+    /// the node (#1660, the processor-ident arm of #1654's defect class).
+    #[test]
+    #[serial]
+    fn remove_module_in_use_guard_sees_a_node_stamped_with_the_diagnostic_version() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = HomeGuard::install(home.path());
+        let runtime = Runner::new().expect("Runner::new");
+        let tmp = tempfile::tempdir().unwrap();
+        let pkg = tmp.path().join("rm-stale-ident");
+        std::fs::create_dir_all(pkg.join("schemas")).unwrap();
+        std::fs::write(
+            pkg.join("schemas/rm_stale_ident_config.yaml"),
+            "metadata:\n  type: RmStaleIdentConfigSchema\n",
+        )
+        .unwrap();
+        std::fs::write(
+            pkg.join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: rm-stale-ident\n  version: \"1.2.0\"\n\
+             schemas:\n  RmStaleIdentConfigSchema:\n    file: schemas/rm_stale_ident_config.yaml\n\
+             processors:\n\
+             \x20 - name: RmStaleIdentProcessor\n\
+             \x20   runtime: typescript\n\
+             \x20   entrypoint: main.ts\n\
+             \x20   execution: manual\n\
+             \x20   config:\n\
+             \x20     name: config\n\
+             \x20     schema: RmStaleIdentConfigSchema\n",
+        )
+        .unwrap();
+
+        // (1) Reference the type before its module loads. The package lives
+        // outside this Runner's home, so lazy discovery finds no provider and
+        // the node lands in Error state carrying the `@0.0.0` ident.
+        let type_reference = crate::core::processors::ProcessorTypeReference::new(
+            streamlib_idents::Org::new("tatolab").unwrap(),
+            streamlib_idents::Package::new("rm-stale-ident").unwrap(),
+            streamlib_idents::TypeName::new("RmStaleIdentProcessor").unwrap(),
+        );
+        let err = runtime
+            .add_processor(crate::core::processors::ProcessorSpec::new(
+                type_reference,
+                serde_json::json!({}),
+            ))
+            .expect_err("add_processor before the module loads must miss the registry");
+        assert!(
+            matches!(err, crate::core::Error::UnknownProcessorType { .. }),
+            "expected UnknownProcessorType, got: {err:?}",
+        );
+
+        // (2) Load the module, registering the type at its real version.
+        runtime
+            .add_module_with_blocking(
+                tatolab_ident("rm-stale-ident"),
+                path_strategy_never_build(&pkg),
+            )
+            .expect("processor package load must succeed");
+        let descriptor = crate::core::processors::PROCESSOR_REGISTRY
+            .list_registered()
+            .into_iter()
+            .find(|d| d.name.r#type.as_str() == "RmStaleIdentProcessor")
+            .expect("RmStaleIdentProcessor must be registered");
+        assert_eq!(
+            descriptor.name.version,
+            crate::core::descriptors::SemVer::new(1, 2, 0),
+            "the fixture must register a version the stranded node cannot be carrying"
+        );
+
+        // (3) The guard must refuse: the graph node names the same type, one
+        // version stamp apart.
+        let err = runtime
+            .remove_module(tatolab_ident("rm-stale-ident"))
+            .expect_err("removal must refuse while a stranded node still names the type");
+        match &err {
+            RemoveModuleError::ProcessorsInUse {
+                processor_ids,
+                processor_types,
+                ..
+            } => {
+                assert!(
+                    !processor_ids.is_empty(),
+                    "the refusal must name the node holding the type"
+                );
+                assert!(
+                    processor_types.iter().any(|t| {
+                        t.r#type.as_str() == "RmStaleIdentProcessor"
+                            && t.version == crate::core::descriptors::SemVer::new(0, 0, 0)
+                    }),
+                    "the reported node must be the one stamped with the diagnostic \
+                     version — a version-inclusive guard would have missed it: \
+                     {processor_types:?}"
+                );
+            }
+            other => panic!("expected ProcessorsInUse, got {other:?}"),
+        }
+        assert!(
+            crate::core::processors::PROCESSOR_REGISTRY.is_registered(&descriptor.name),
+            "a refused removal must restore the processor registration"
+        );
+    }
+
     /// Load/unload/reload ×2 of the same package on one Runner: the
     /// registry snapshot after every reload equals the snapshot after the
     /// first load.

--- a/sdk/streamlib-idents/src/ident.rs
+++ b/sdk/streamlib-idents/src/ident.rs
@@ -745,10 +745,9 @@ version: 0.4.33-dev.2
 
         let diagnostic = ident("tatolab", "camera", "Camera", SemVer::new(0, 0, 0));
         assert!(set.contains(&diagnostic.schema_identity_tuple()));
-        assert!(
-            !set.contains(&ident("tatolab", "camera", "Microphone", SemVer::new(1, 2, 0))
-                .schema_identity_tuple())
-        );
+        assert!(!set.contains(
+            &ident("tatolab", "camera", "Microphone", SemVer::new(1, 2, 0)).schema_identity_tuple()
+        ));
     }
 
     #[test]

--- a/sdk/streamlib-idents/src/ident.rs
+++ b/sdk/streamlib-idents/src/ident.rs
@@ -361,9 +361,18 @@ impl SchemaIdent {
         }
     }
 
+    /// The `(org, package, type)` identity tuple with the version projected
+    /// away — the borrowed form usable as a hash/order key, which
+    /// [`Self::matches_schema_tuple`] alone cannot express. Set membership
+    /// keyed on a whole `SchemaIdent` binds version-inclusively through the
+    /// derived `Hash` + `Eq`; key on this instead.
+    pub fn schema_identity_tuple(&self) -> (&Org, &Package, &TypeName) {
+        (&self.org, &self.package, &self.r#type)
+    }
+
     /// Whether two idents share the same `(org, package, type)` identity tuple, version-blind (the registry is version-lookup-blind).
     pub fn matches_schema_tuple(&self, other: &SchemaIdent) -> bool {
-        self.org == other.org && self.package == other.package && self.r#type == other.r#type
+        self.schema_identity_tuple() == other.schema_identity_tuple()
     }
 }
 
@@ -687,6 +696,58 @@ version: 0.4.33-dev.2
         assert!(
             msg.contains("release") && msg.contains("dev"),
             "error must name the release-only rule: {msg}"
+        );
+    }
+
+    /// The `@0.0.0` diagnostic placeholder and a real registered version name
+    /// the same type. Derived `PartialEq` says otherwise — every resolution
+    /// surface must go through the tuple.
+    #[test]
+    fn identity_tuple_ignores_the_version() {
+        let diagnostic = ident("tatolab", "camera", "Camera", SemVer::new(0, 0, 0));
+        let registered = ident("tatolab", "camera", "Camera", SemVer::new(1, 2, 0));
+        assert_eq!(
+            diagnostic.schema_identity_tuple(),
+            registered.schema_identity_tuple()
+        );
+        assert!(diagnostic.matches_schema_tuple(&registered));
+        assert_ne!(
+            diagnostic, registered,
+            "derived PartialEq stays version-inclusive — the tuple is the version-blind projection"
+        );
+    }
+
+    #[test]
+    fn identity_tuple_separates_idents_differing_before_the_version() {
+        let camera = ident("tatolab", "camera", "Camera", SemVer::new(1, 0, 0));
+        for other in [
+            ident("acme", "camera", "Camera", SemVer::new(1, 0, 0)),
+            ident("tatolab", "display", "Camera", SemVer::new(1, 0, 0)),
+            ident("tatolab", "camera", "CameraFrame", SemVer::new(1, 0, 0)),
+        ] {
+            assert_ne!(
+                camera.schema_identity_tuple(),
+                other.schema_identity_tuple(),
+                "{camera} and {other} must not share an identity tuple"
+            );
+            assert!(!camera.matches_schema_tuple(&other));
+        }
+    }
+
+    /// The projection is a usable hash key — this is what `matches_schema_tuple`
+    /// alone could not express, and what left `remove_module`'s in-use guard
+    /// version-inclusive (#1660).
+    #[test]
+    fn identity_tuple_is_a_version_blind_hash_key() {
+        let registered = ident("tatolab", "camera", "Camera", SemVer::new(1, 2, 0));
+        let set: std::collections::HashSet<_> =
+            std::iter::once(registered.schema_identity_tuple()).collect();
+
+        let diagnostic = ident("tatolab", "camera", "Camera", SemVer::new(0, 0, 0));
+        assert!(set.contains(&diagnostic.schema_identity_tuple()));
+        assert!(
+            !set.contains(&ident("tatolab", "camera", "Microphone", SemVer::new(1, 2, 0))
+                .schema_identity_tuple())
         );
     }
 


### PR DESCRIPTION
## Summary

- `remove_module`'s in-use guard built a `HashSet<&SchemaIdent>` from the ledger's `processor_idents` and tested `contains(&node.processor_type)`. `SchemaIdent`'s derived `Hash` + `Eq` are version-inclusive, so a graph node added while its type was unregistered — which carries the `(org, package, type)@0.0.0` diagnostic ident from `add_v_op.rs:57` — never matched the ledger's real-version idents. The guard passed and the module unloaded, stranding the node.
- `matches_schema_tuple` (added by #1654) covers pairwise comparison but cannot express **set membership**, which is the gap that let this survive that sweep. Adds `SchemaIdent::schema_identity_tuple() -> (&Org, &Package, &TypeName)` as the borrowed version-blind hash/order key, and routes the guard through it.
- Same-PR DRY sweep, called out per the no-silent-refactors rule: `matches_schema_tuple` and `ProcessorInstanceFactory::highest_registered_for_tuple` were each projecting the same tuple by hand. Both now go through the one accessor — three hand-rolled projections is what keeps regenerating this bug class.

## Closes

Closes #1660

## Exit criteria

- [x] The in-use guard detects a node referencing a removed type regardless of the version stamped on its ident, and `remove_module` refuses with `RemoveModuleError::ProcessorsInUse`.
- [x] Keyed on the `(org, package, type)` tuple — the issue noted a `HashSet` on the full ident cannot express a version-blind lookup.
- [x] Regression test covering the issue's repro steps 1–3.

## Test plan

- `cargo test -p streamlib-engine --lib` — 1745 passed, 128 ignored
- `cargo test -p streamlib-idents` — 245 lib + 12 doctests + 2 `no_parse_api` passed
- `cargo clippy -p streamlib-idents -p streamlib-engine --all-targets` — no new warnings on touched files
- `cargo xtask` lint suite, all 13 checks CI runs — pass
- `cargo doc -p streamlib --no-deps` — no rustdoc warnings on the new item

**Regression test verified against a reverted guard.** With `contains(&node.processor_type)` restored, `remove_module_in_use_guard_sees_a_node_stamped_with_the_diagnostic_version` fails at `removal must refuse while a stranded node still names the type`. It locks the fix, not the implementation. The assertion pins the `0.0.0` stamp specifically, so it cannot pass by accidentally matching the registered ident.

## Behavior change worth knowing

`replace_processor_from_source` routes through `remove_module` (`from_source.rs:203`). A stranded `@session/<name>/<Type>@0.0.0` Error node now blocks `replace` for that session type, where the version mismatch previously let it through silently. That is the invariant the guard documents — and the issue's "Expected" section asks for exactly this — but it means an operator with a stranded node must `remove_processor` it first. The `ProcessorsInUse` error names the offending `processor_ids`, so the remedy is actionable. The normal replace loop is unaffected: a successfully-spawned session node and the ledger both carry the same `0.0.N`.

## Follow-ups

Both surfaced by the pre-PR review, both deliberately not swept in:

- #1662 — `GraphSnapshot::validate()` (`graph_snapshot.rs:239`) does an exact-key `port_info()` lookup on a *persisted* versioned ident, so a snapshot saved at pkg@1.2.0 is rejected after the package moves to 1.3.0 — even though `to_processor_spec()` → `add_processor` resolves version-blind. Same defect class, but the right fix is a wire-format decision (should `ProcessorDefinition::processor_type` be a `ProcessorTypeReference`?), not a comparator swap.
- #1663 — `stages_typescript_source_with_a_deno_json_import_map` flakes ~1-in-3 on the shared `STREAMLIB_HOME` global. Bisected against `main` @ `02ef854d` (ok/ok/FAILED/FAILED/ok/ok over six runs) to confirm pre-existing, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)