### PR TITLE
fix(plugin-abi): one definition of the reserved `control:` topic prefix

### DIFF
--- a/docs/architecture/plugin-abi.md
+++ b/docs/architecture/plugin-abi.md
@@ -438,18 +438,22 @@ asserts the borrow's POD getters return the real values.
   layout-changing edit that forgot to bump the matching version
   constant still changes it — catching a same-constant /
   different-layout republish that a version-only check would miss.
-- `PUBSUB_CONTROL_TOPIC_*` — the reserved `control:` topic strings (see
-  below). Their *values* are wire contract, not their layout, so they
-  are locked by constant-value tests rather than folded into the
+- `PUBSUB_RESERVED_CONTROL_TOPIC_PREFIX` and `PUBSUB_CONTROL_TOPIC_*` —
+  the reserved `control:` namespace prefix and the topic strings under
+  it (see below). Their *values* are wire contract, not their layout, so
+  they are locked by constant-value tests rather than folded into the
   fingerprint: a rename is a break both sides must agree on, and
   folding it would gratuitously invalidate every already-built plugin
   whose layout is fine.
 
 ### Reserved `control:` PUBSUB topics
 
-The `control:` topic prefix is reserved for host-interpreted control
-requests, and is the wire form for plugin→host asks that need no
-return value. A plugin publishes through `HostServices::pubsub_publish`
+The `control:` topic prefix — `PUBSUB_RESERVED_CONTROL_TOPIC_PREFIX`,
+the single definition both the host's reservation check and every
+reserved topic constant are derived from — is reserved for
+host-interpreted control requests, and is the wire form for plugin→host
+asks that need no return value. A plugin publishes through
+`HostServices::pubsub_publish`
 like any other topic; the host matches the reserved topics **before**
 its general `Event` decode, maps each onto an internal action, and
 never re-publishes the bytes to subscribers. Three consequences the

--- a/runtime/streamlib-engine/src/core/plugin/host_services/mod.rs
+++ b/runtime/streamlib-engine/src/core/plugin/host_services/mod.rs
@@ -843,14 +843,6 @@ unsafe extern "C" fn host_tracing_emit(
     )
 }
 
-/// Reserved topic-namespace prefix for host-interpreted `control:` topics
-/// (e.g. [`streamlib_plugin_abi::PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST`]).
-/// A topic under this prefix is mapped to a host action in
-/// [`host_pubsub_publish`] and is never decoded as an `Event` or delivered
-/// to subscribers; a prefixed topic that matches no handler is warn-dropped,
-/// never re-published.
-const RESERVED_CONTROL_TOPIC_PREFIX: &str = "control:";
-
 unsafe extern "C" fn host_pubsub_publish(
     _host: HostHandle,
     topic_ptr: *const u8,
@@ -891,7 +883,7 @@ unsafe extern "C" fn host_pubsub_publish(
             // into the general `Event` decode / re-publish path below, which
             // would silently hijack or swallow the reserved topic. Enforcing
             // the reservation here makes it host-defended, not prose.
-            if topic.starts_with(RESERVED_CONTROL_TOPIC_PREFIX) {
+            if topic.starts_with(streamlib_plugin_abi::PUBSUB_RESERVED_CONTROL_TOPIC_PREFIX) {
                 tracing::warn!(
                     target: "streamlib::plugin",
                     topic,
@@ -1535,7 +1527,11 @@ mod runtime_shutdown_control_topic_tests {
         PUBSUB.init(&runtime_id, node);
 
         // A reserved `control:`-prefixed topic that maps to NO host handler.
-        let unhandled_control_topic = format!("control:unhandled-{}", uuid::Uuid::new_v4());
+        let unhandled_control_topic = format!(
+            "{}unhandled-{}",
+            streamlib_plugin_abi::PUBSUB_RESERVED_CONTROL_TOPIC_PREFIX,
+            uuid::Uuid::new_v4()
+        );
 
         let (tx, rx) = mpsc::channel();
         let listener: Arc<Mutex<dyn EventListener>> =

--- a/runtime/streamlib-plugin-abi/src/lib.rs
+++ b/runtime/streamlib-plugin-abi/src/lib.rs
@@ -408,6 +408,15 @@ pub const PLUGIN_ABI_LAYOUT_FINGERPRINT: u64 = {
 // Reserved PUBSUB control topics
 // =============================================================================
 
+/// Reserved topic-namespace prefix for [`HostServices::pubsub_publish`]. A
+/// topic under this prefix is host-interpreted: the host maps it onto an
+/// internal action and never decodes it as an `Event` or delivers it to
+/// subscribers, and a prefixed topic matching no handler is warn-dropped.
+///
+/// The prefix is wire contract shared by every host and every plugin, and
+/// every `PUBSUB_CONTROL_TOPIC_*` constant lives under it.
+pub const PUBSUB_RESERVED_CONTROL_TOPIC_PREFIX: &str = "control:";
+
 /// Reserved control topic for [`HostServices::pubsub_publish`]: an
 /// engine-free plugin asks the host runtime to shut down (equivalent
 /// to SIGINT/SIGTERM). The payload is a msgpack-encoded UTF-8 string —
@@ -1336,6 +1345,67 @@ mod control_topic_tests {
         assert_eq!(
             PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST,
             "control:runtime-shutdown-request"
+        );
+    }
+
+    /// The prefix is what the host's reservation check matches on, so its
+    /// value is wire contract in its own right: renaming it would make the
+    /// host deliver reserved topics to `Custom` subscribers.
+    #[test]
+    fn reserved_control_topic_prefix_value_is_locked() {
+        assert_eq!(PUBSUB_RESERVED_CONTROL_TOPIC_PREFIX, "control:");
+    }
+
+    /// A reserved topic declared outside the prefix skips the host's
+    /// reserved-namespace defense in `host_pubsub_publish` and falls
+    /// through to the general `Event` decode, so renaming either constant
+    /// alone is a break. The topics come from a scan of this crate's own
+    /// source rather than a hand-kept list, so a topic added later is
+    /// covered without anyone remembering to extend this test.
+    #[test]
+    fn every_reserved_control_topic_starts_with_the_reserved_prefix() {
+        // Top-level declarations only — the same text indented is this
+        // test talking about the pattern, not declaring a topic.
+        const TOPIC_DECLARATION_LINE_PREFIX: &str = "pub const PUBSUB_CONTROL_TOPIC_";
+
+        let source_lines: Vec<&str> = include_str!("lib.rs").lines().collect();
+        let mut scanned_topic_count = 0usize;
+
+        for (line_index, line) in source_lines.iter().enumerate() {
+            if !line.starts_with(TOPIC_DECLARATION_LINE_PREFIX) {
+                continue;
+            }
+
+            let mut declaration = String::new();
+            for continuation in &source_lines[line_index..] {
+                declaration.push_str(continuation);
+                if continuation.contains(';') {
+                    break;
+                }
+            }
+
+            let value_open = declaration
+                .find('"')
+                .unwrap_or_else(|| panic!("no string literal in declaration: {declaration}"));
+            let value_close = declaration[value_open + 1..]
+                .find('"')
+                .unwrap_or_else(|| panic!("unterminated string literal in: {declaration}"))
+                + value_open
+                + 1;
+            let topic = &declaration[value_open + 1..value_close];
+
+            assert!(
+                topic.starts_with(PUBSUB_RESERVED_CONTROL_TOPIC_PREFIX),
+                "reserved control topic {topic:?} does not start with \
+                 {PUBSUB_RESERVED_CONTROL_TOPIC_PREFIX:?}"
+            );
+            scanned_topic_count += 1;
+        }
+
+        assert!(
+            scanned_topic_count > 0,
+            "the scan matched no {TOPIC_DECLARATION_LINE_PREFIX:?} declaration — \
+             the declarations moved or changed shape, leaving this guard vacuous"
         );
     }
 }


### PR DESCRIPTION
Closes #1639.

## What

The reserved `control:` topic namespace is a host↔plugin wire contract, but its prefix was spelled twice with nothing tying the two together:

- `PUBSUB_CONTROL_TOPIC_RUNTIME_SHUTDOWN_REQUEST` in `streamlib-plugin-abi` — public, locked by a constant-value test.
- `const RESERVED_CONTROL_TOPIC_PREFIX: &str = "control:"` — **private to the engine's host services**, and the thing that actually decides at runtime whether a published topic is host-interpreted or delivered to subscribers.

Change `"control:"` on either side and the two disagree: the host either delivers a reserved topic to `Custom` subscribers, or warn-drops a legitimate one. Nothing fails to compile, and the ABI crate's constant-value test only pinned its own literal.

## How

- `PUBSUB_RESERVED_CONTROL_TOPIC_PREFIX` is now public in `streamlib-plugin-abi` — the single definition.
- The host's reservation check in `host_pubsub_publish` reads it instead of restating it. The private const is gone.
- The engine test that builds an unhandled reserved topic derives it from the constant too, so the test can't drift from the thing it exercises.
- `docs/architecture/plugin-abi.md` described the reservation in prose without naming a constant; it now points at the one that owns it.

## Tests

Three tests in `streamlib-plugin-abi`:

1. `reserved_control_topic_prefix_value_is_locked` — constant-value lock on the prefix.
2. `runtime_shutdown_request_control_topic_value_is_locked` — the pre-existing lock, unchanged.
3. `every_reserved_control_topic_starts_with_the_reserved_prefix` — **scans this crate's own source** (`include_str!("lib.rs")`) for every top-level `PUBSUB_CONTROL_TOPIC_*` declaration and asserts each value starts with the prefix.

(3) is a scan rather than a hand-kept array so a reserved topic added later is covered without anyone remembering to extend the test, and it asserts it matched at least one declaration — a scan that finds nothing fails loudly rather than passing vacuously (the #1630 class).

Mental-revert verified: renaming the topic value to `"ctl:runtime-shutdown-request"` fails (3) with `reserved control topic "ctl:runtime-shutdown-request" does not start with "control:"`. Renaming the prefix alone fails (2) and (3).

`cargo test -p streamlib-plugin-abi --lib` — 79 passed. `cargo test -p streamlib-engine --lib host_pubsub_publish` — 4 passed.

## Notes for the reviewer

- **No polyglot work needed.** A repo-wide grep confirms `"control:"` appears as a literal only at the constant's definition and inside the two locking assertions — no Python, Deno, or C-header mirror spells it independently.
- **Pre-existing, unrelated, not touched here:** `core::plugin::host_services::audio_clock::…::on_tick_drops_user_data_exactly_once_on_success_path` fails on `origin/main` when run as part of the `host_services::` filter (passes in isolation — order-dependent shared counter). Confirmed pre-existing by stashing this change and re-running. Reported, not fixed, per the no-auto-fixing-unrelated-issues rule.
- **Pre-existing:** 139 files in the workspace are `cargo fmt --check`-dirty on rustfmt 1.8.0-stable, including the hunk immediately adjacent to the new constant. Untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
