### PR TITLE
chore(xtask): lint orphan .rs files under processors/

### DIFF
--- a/.github/workflows/check-processor-source-reachability.yml
+++ b/.github/workflows/check-processor-source-reachability.yml
@@ -1,0 +1,50 @@
+name: Check Processor Source Reachability
+
+# Orphan-file gate for the folder-backed package layout. Cargo and clippy
+# both ignore a `.rs` under `processors/` that no `mod` chain names, or that
+# only a predicate holding on zero build targets names — the author gets a
+# file that silently compiles nowhere, with no diagnostic.
+#
+# Choosing compiler-interpreted `cfg` over a scanner gave up the one thing a
+# scanner does well: telling you a file exists. `cargo xtask
+# check-processor-source-reachability` puts it back, walking every
+# folder-backed package's generated module tree with `syn` and reporting any
+# `.rs` under `processors/` it never reaches. Sub-second, no workspace build.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  xtask-check-processor-source-reachability:
+    name: xtask check-processor-source-reachability
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-xtask-${{ hashFiles('xtask/Cargo.toml', 'xtask/Cargo.lock', 'Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-xtask-
+
+      - name: cargo xtask check-processor-source-reachability
+        run: cargo run --locked -q -p xtask -- check-processor-source-reachability
+
+      - name: cargo test -p xtask check_processor_source_reachability (unit tests)
+        run: cargo test --locked -p xtask check_processor_source_reachability

--- a/sdk/streamlib-processor-extract/src/lib.rs
+++ b/sdk/streamlib-processor-extract/src/lib.rs
@@ -40,8 +40,9 @@ use streamlib_idents::PACKAGE_PROCESSOR_SOURCE_DIR_NAME as PROCESSOR_SOURCE_DIR_
 use streamlib_processor_schema::{ProcessorSchema, SchemaIdent};
 
 pub use crate_root::{
-    GeneratedCrateRootSource, RustCrateRootGenerationRequest, generate_rust_crate_root_source,
-    write_generated_rust_crate_root,
+    GeneratedCrateRootSource, RustCrateRootGenerationRequest,
+    discover_package_dirs_declaring_a_generated_crate_root, generate_rust_crate_root_source,
+    generated_crate_root_lib_path_value, write_generated_rust_crate_root,
 };
 pub use derive::{
     DeriveError, DerivedProcessorSet, ExtractedManifestPort, ExtractedManifestProcessor,
@@ -54,8 +55,9 @@ pub use grammar::{ParsedPort, ParsedProcessorAttr};
 pub use reachable::{
     ModuleReachabilityTarget, ProcessorAvailabilityAcrossBuildTargets,
     ProcessorSetAcrossEveryBuildTarget, ProcessorSourceModuleArm,
-    enumerate_processor_source_module_arms, extract_processors_across_every_build_target,
-    extract_reachable_rust_processors,
+    enumerate_processor_source_module_arms,
+    enumerate_processor_source_module_files_the_crate_names,
+    extract_processors_across_every_build_target, extract_reachable_rust_processors,
 };
 
 /// One processor derived from a `#[processor(...)]` attribute in source.

--- a/sdk/streamlib-processor-extract/src/reachable.rs
+++ b/sdk/streamlib-processor-extract/src/reachable.rs
@@ -661,6 +661,108 @@ fn refuse_divergent_processor_declarations(
     Ok(())
 }
 
+/// Every module file under `<package_dir>/processors` that the generated crate
+/// root's module tree names, whether or not any build target compiles it.
+///
+/// **Declaration** reachability, deliberately not compile reachability. The
+/// parked-module convention (`#![cfg(any())]` on an `_apple_impl_pending_/`
+/// arm) is a subtree the crate names and no target compiles, and unparking it
+/// must stay a cfg edit and nothing else — so a walk that pruned it would call
+/// every file under it an orphan. Cfg is therefore ignored outright rather
+/// than evaluated: the question this answers is "does anything name this
+/// file", which is the one question `cargo` and `clippy` cannot, because a
+/// file nothing names is simply absent from the build.
+///
+/// A `mod` that resolves to no file is skipped rather than refused: `rustc`
+/// does not require a module file for a `mod` the build prunes, so an
+/// unresolvable one is not evidence of an orphan.
+#[tracing::instrument(skip_all, fields(package_dir = %package_dir.display()))]
+pub fn enumerate_processor_source_module_files_the_crate_names(
+    package_dir: &Path,
+) -> Result<BTreeSet<PathBuf>, ExtractError> {
+    let arms = enumerate_processor_source_module_arms(package_dir)?;
+    let mut named = BTreeSet::new();
+
+    for arm in &arms {
+        collect_module_files_named_from(
+            &arm.module_file,
+            &arm.top_level_arm_child_module_search_dir(),
+            &mut named,
+        )?;
+    }
+
+    tracing::debug!(module_files = named.len(), "enumerated named module files");
+    Ok(named)
+}
+
+/// Parse `file`, record it, and descend into every `mod` it declares — inline
+/// or external, gated or not.
+fn collect_module_files_named_from(
+    file: &Path,
+    mod_dir: &Path,
+    named: &mut BTreeSet<PathBuf>,
+) -> Result<(), ExtractError> {
+    if !named.insert(file.to_path_buf()) {
+        return Ok(());
+    }
+
+    let body = std::fs::read_to_string(file).map_err(|e| ExtractError::Io {
+        path: file.to_path_buf(),
+        source: e,
+    })?;
+    let parsed = syn::parse_file(&body).map_err(|e| ExtractError::Syntax {
+        path: file.to_path_buf(),
+        source: e,
+    })?;
+
+    let path_attribute_base_dir = file.parent().unwrap_or_else(|| Path::new("")).to_path_buf();
+    for item in &parsed.items {
+        collect_module_files_named_by_item(item, file, mod_dir, &path_attribute_base_dir, named)?;
+    }
+    Ok(())
+}
+
+fn collect_module_files_named_by_item(
+    item: &syn::Item,
+    declaring_file: &Path,
+    mod_dir: &Path,
+    path_attribute_base_dir: &Path,
+    named: &mut BTreeSet<PathBuf>,
+) -> Result<(), ExtractError> {
+    let syn::Item::Mod(item_mod) = item else {
+        return Ok(());
+    };
+
+    match &item_mod.content {
+        Some((_, items)) => {
+            let inner_dir = mod_dir.join(item_mod.ident.to_string());
+            for inner in items {
+                collect_module_files_named_by_item(
+                    inner,
+                    declaring_file,
+                    &inner_dir,
+                    &inner_dir,
+                    named,
+                )?;
+            }
+        }
+        None => {
+            let Ok(resolved) = resolve_external_module_file(
+                item_mod,
+                declaring_file,
+                mod_dir,
+                path_attribute_base_dir,
+            ) else {
+                return Ok(());
+            };
+            let child_mod_dir =
+                resolved_child_module_search_dir(&resolved, &item_mod.ident.to_string());
+            collect_module_files_named_from(&resolved.module_file, &child_mod_dir, named)?;
+        }
+    }
+    Ok(())
+}
+
 fn walk_processor_source_arms(
     package_dir: &Path,
     cfg_resolution: ModuleWalkCfgResolution<'_>,
@@ -844,7 +946,7 @@ impl ReachableModuleWalker<'_> {
                     }
                     // External `mod foo;` resolves to a sibling file.
                     None => {
-                        let resolved = self.resolve_module_file(
+                        let resolved = resolve_external_module_file(
                             item_mod,
                             declaring_file,
                             mod_dir,
@@ -876,58 +978,6 @@ impl ReachableModuleWalker<'_> {
             _ => {}
         }
         Ok(())
-    }
-
-    /// Resolve an external `mod <name>;` to its source file, honoring a
-    /// `#[path = "..."]` override and otherwise the standard
-    /// `<mod_dir>/<name>.rs` then `<mod_dir>/<name>/mod.rs` search.
-    ///
-    /// `rustc` resolves a `#[path]` on a non-inline module against the directory
-    /// holding the declaring file (`path_attribute_base_dir`), which is NOT the
-    /// directory that module's plain `mod` children resolve against.
-    fn resolve_module_file(
-        &self,
-        item_mod: &syn::ItemMod,
-        declaring_file: &Path,
-        mod_dir: &Path,
-        path_attribute_base_dir: &Path,
-    ) -> Result<ResolvedChildModule, ExtractError> {
-        let name = item_mod.ident.to_string();
-
-        if let Some(path_attr) = path_override(&item_mod.attrs) {
-            let candidate = path_attribute_base_dir.join(&path_attr);
-            if candidate.is_file() {
-                return Ok(ResolvedChildModule {
-                    module_file: candidate,
-                    resolved_via_path_attribute: true,
-                });
-            }
-            return Err(ExtractError::UnresolvedModule {
-                module: name,
-                declared_in: declaring_file.to_path_buf(),
-                candidates: candidate.display().to_string(),
-            });
-        }
-
-        let flat = mod_dir.join(format!("{name}.rs"));
-        if flat.is_file() {
-            return Ok(ResolvedChildModule {
-                module_file: flat,
-                resolved_via_path_attribute: false,
-            });
-        }
-        let nested = mod_dir.join(&name).join("mod.rs");
-        if nested.is_file() {
-            return Ok(ResolvedChildModule {
-                module_file: nested,
-                resolved_via_path_attribute: false,
-            });
-        }
-        Err(ExtractError::UnresolvedModule {
-            module: name,
-            declared_in: declaring_file.to_path_buf(),
-            candidates: format!("{} or {}", flat.display(), nested.display()),
-        })
     }
 
     /// Enter the cfg scope an item's attributes open. Returns `None` when the
@@ -1110,6 +1160,61 @@ fn collect_undefined_feature_atoms(
 struct ResolvedChildModule {
     module_file: PathBuf,
     resolved_via_path_attribute: bool,
+}
+
+/// Resolve an external `mod <name>;` to its source file, honoring a
+/// `#[path = "..."]` override and otherwise the standard `<mod_dir>/<name>.rs`
+/// then `<mod_dir>/<name>/mod.rs` search.
+///
+/// `rustc` resolves a `#[path]` on a non-inline module against the directory
+/// holding the declaring file (`path_attribute_base_dir`), which is NOT the
+/// directory that module's plain `mod` children resolve against.
+///
+/// Shared by the cfg-resolved processor walk and the cfg-blind declaration
+/// walk: both must agree on which file a `mod` names, or the orphan gate would
+/// report a file the extractor reads (or miss one it doesn't).
+fn resolve_external_module_file(
+    item_mod: &syn::ItemMod,
+    declaring_file: &Path,
+    mod_dir: &Path,
+    path_attribute_base_dir: &Path,
+) -> Result<ResolvedChildModule, ExtractError> {
+    let name = item_mod.ident.to_string();
+
+    if let Some(path_attr) = path_override(&item_mod.attrs) {
+        let candidate = path_attribute_base_dir.join(&path_attr);
+        if candidate.is_file() {
+            return Ok(ResolvedChildModule {
+                module_file: candidate,
+                resolved_via_path_attribute: true,
+            });
+        }
+        return Err(ExtractError::UnresolvedModule {
+            module: name,
+            declared_in: declaring_file.to_path_buf(),
+            candidates: candidate.display().to_string(),
+        });
+    }
+
+    let flat = mod_dir.join(format!("{name}.rs"));
+    if flat.is_file() {
+        return Ok(ResolvedChildModule {
+            module_file: flat,
+            resolved_via_path_attribute: false,
+        });
+    }
+    let nested = mod_dir.join(&name).join("mod.rs");
+    if nested.is_file() {
+        return Ok(ResolvedChildModule {
+            module_file: nested,
+            resolved_via_path_attribute: false,
+        });
+    }
+    Err(ExtractError::UnresolvedModule {
+        module: name,
+        declared_in: declaring_file.to_path_buf(),
+        candidates: format!("{} or {}", flat.display(), nested.display()),
+    })
 }
 
 /// Evaluate a single `#[cfg(<predicate>)]`. A malformed predicate the parser

--- a/xtask/src/check_processor_source_reachability.rs
+++ b/xtask/src/check_processor_source_reachability.rs
@@ -1,0 +1,528 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! CI gate reporting `.rs` files under a folder-backed package's `processors/`
+//! directory that nothing in the generated module tree names.
+//!
+//! Compiler-interpreted `cfg` beats a scanner everywhere except one place: a
+//! file no `mod` chain names is not "excluded on this target", it is absent
+//! from the build entirely. `cargo` and `clippy` both say nothing — verified.
+//! An author lands `processors/camera/windows.rs`, forgets the `mod windows;`,
+//! and the file sits in the tree compiling nowhere and reviewed by no one.
+//!
+//! The bar is **declaration** reachability, not compile reachability: a file
+//! passes if any `mod` chain rooted at a generated crate-root arm names it,
+//! whether or not a build target compiles it. That is forced by the
+//! parked-module convention — `packages/*/processors/_apple_impl_pending_/`
+//! opens with `#![cfg(any())]` and compiles on no target by design, yet the
+//! generated crate root still declares the arm so that unparking is a cfg edit
+//! and nothing else. A compile-reachability bar would call all ~15 files under
+//! those parked directories orphans.
+//!
+//! Consequence worth naming: a `mod` behind a predicate no real target
+//! satisfies (a typo'd `target_os`) still counts as naming its file. Proving
+//! that class needs a real rustc target registry, which the cfg evaluator in
+//! `streamlib-processor-extract` does not have — it proves satisfiability over
+//! the atoms a predicate mentions, under which a typo'd `target_os` is
+//! satisfiable. This gate closes the "nothing names it" hole; the typo hole
+//! stays open.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use streamlib_idents::PACKAGE_PROCESSOR_SOURCE_DIR_NAME;
+use streamlib_processor_extract::{
+    discover_package_dirs_declaring_a_generated_crate_root,
+    enumerate_processor_source_module_files_the_crate_names,
+};
+use walkdir::WalkDir;
+
+/// One `.rs` under a package's `processors/` directory that no `mod` chain in
+/// the package's generated module tree names.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct OrphanProcessorSourceFile {
+    /// The package whose `processors/` directory holds the file.
+    pub package_dir: PathBuf,
+    /// The unnamed file.
+    pub orphan_file: PathBuf,
+}
+
+/// What one sweep of the workspace found, plus how much source it read — a
+/// gate that scanned nothing must fail loudly rather than report a clean tree.
+#[derive(Debug, Default)]
+pub struct ProcessorSourceReachabilityReport {
+    pub orphans: Vec<OrphanProcessorSourceFile>,
+    pub scanned_processor_source_file_count: usize,
+    pub scanned_package_count: usize,
+    /// Directories holding `processors/` that this sweep did not cover,
+    /// because the package commits its own crate root instead of declaring
+    /// the generated one. Reported rather than dropped: a gate that quietly
+    /// skips part of its stated scope reads as "covered everything".
+    pub processor_source_dirs_outside_the_sweep: Vec<PathBuf>,
+}
+
+pub fn run(workspace_root: &Path) -> Result<()> {
+    let report = scan_workspace(workspace_root)?;
+
+    crate::ensure_source_walking_gate_read_source(
+        "check-processor-source-reachability",
+        &format!("every folder-backed package's {PACKAGE_PROCESSOR_SOURCE_DIR_NAME}/"),
+        report.scanned_processor_source_file_count,
+        "an orphan processor source file sit in the tree",
+    )?;
+
+    for skipped in &report.processor_source_dirs_outside_the_sweep {
+        println!(
+            "  note: {} is not swept — its package commits its own crate root, so its \
+             processor source is named by `#[path]` from `src/` rather than by a \
+             generated arm.",
+            skipped
+                .strip_prefix(workspace_root)
+                .unwrap_or(skipped)
+                .display(),
+        );
+    }
+
+    if report.orphans.is_empty() {
+        println!(
+            "✓ check-processor-source-reachability: every one of {} .rs file(s) under \
+             {}/ across {} folder-backed package(s) is named by the generated module tree.",
+            report.scanned_processor_source_file_count,
+            PACKAGE_PROCESSOR_SOURCE_DIR_NAME,
+            report.scanned_package_count,
+        );
+        return Ok(());
+    }
+
+    eprintln!(
+        "✗ check-processor-source-reachability: {} orphan file(s) — nothing in the \
+         generated module tree names them, so cargo and clippy never read them:",
+        report.orphans.len()
+    );
+    for orphan in &report.orphans {
+        eprintln!(
+            "  {}  (package {})",
+            orphan
+                .orphan_file
+                .strip_prefix(workspace_root)
+                .unwrap_or(&orphan.orphan_file)
+                .display(),
+            orphan
+                .package_dir
+                .strip_prefix(workspace_root)
+                .unwrap_or(&orphan.package_dir)
+                .display(),
+        );
+    }
+    eprintln!(
+        "\nFix:\n  \
+         A top-level `{dir}/<name>.rs` or `{dir}/<name>/mod.rs` becomes an arm \
+         automatically, so an orphan is always a nested file no `mod` names.\n  \
+         Options:\n    \
+           1. Add the missing `mod <name>;` to the `mod.rs` of the directory \
+              holding it (the usual cause — a file landed without its \
+              declaration).\n    \
+           2. If it belongs to a parked platform arm, move it under that arm's \
+              directory and declare it from the parked `mod.rs`. Parked source \
+              is still named by the crate; `#![cfg(any())]` gates it, it does \
+              not hide it.\n    \
+           3. If it is genuinely dead, delete it.",
+        dir = PACKAGE_PROCESSOR_SOURCE_DIR_NAME,
+    );
+
+    anyhow::bail!("check-processor-source-reachability failed");
+}
+
+/// Sweep every folder-backed package under `workspace_root`.
+pub fn scan_workspace(workspace_root: &Path) -> Result<ProcessorSourceReachabilityReport> {
+    let package_dirs = discover_package_dirs_declaring_a_generated_crate_root(workspace_root)
+        .with_context(|| {
+            format!(
+                "discovering folder-backed packages under {}",
+                workspace_root.display()
+            )
+        })?;
+
+    let mut report = ProcessorSourceReachabilityReport {
+        scanned_package_count: package_dirs.len(),
+        processor_source_dirs_outside_the_sweep: processor_source_dirs_outside(
+            workspace_root,
+            &package_dirs,
+        ),
+        ..Default::default()
+    };
+    for package_dir in &package_dirs {
+        scan_package(package_dir, &mut report)?;
+    }
+    report.orphans.sort();
+    Ok(report)
+}
+
+fn scan_package(package_dir: &Path, report: &mut ProcessorSourceReachabilityReport) -> Result<()> {
+    let processor_source_dir = package_dir.join(PACKAGE_PROCESSOR_SOURCE_DIR_NAME);
+    if !processor_source_dir.is_dir() {
+        return Ok(());
+    }
+
+    let named: BTreeSet<PathBuf> =
+        enumerate_processor_source_module_files_the_crate_names(package_dir)
+            .with_context(|| {
+                format!(
+                    "enumerating named module files in {}",
+                    package_dir.display()
+                )
+            })?
+            .iter()
+            .map(|module_file| comparable_form(module_file))
+            .collect();
+
+    for rust_file in rust_files_under(&processor_source_dir) {
+        report.scanned_processor_source_file_count += 1;
+        if !named.contains(&comparable_form(&rust_file)) {
+            report.orphans.push(OrphanProcessorSourceFile {
+                package_dir: package_dir.to_path_buf(),
+                orphan_file: rust_file,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// The form two paths to the same file must be reduced to before they can be
+/// compared.
+///
+/// `#[path = "../shared/helper.rs"]` resolves to a path carrying a literal
+/// `..` component, while the directory walk yields the already-descended form.
+/// `PathBuf` equality is lexical and does not reduce `..`, so without this a
+/// correctly declared file reads as an orphan — and the gate would tell the
+/// author to move or delete it. Canonicalizing also makes both sides agree
+/// through a symlinked directory, which lexical reduction gets wrong.
+///
+/// Both sides name a file that exists, so the fallback is unreachable in
+/// practice; it keeps a racing deletion from turning into a panic.
+fn comparable_form(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Every `<dir>/processors` under `workspace_root` belonging to a Cargo
+/// package that is not in `swept_package_dirs` — a package that commits its
+/// own crate root pulls its processor source in by `#[path]` from `src/`, and
+/// this sweep starts from generated arms, so it never sees those files.
+fn processor_source_dirs_outside(
+    workspace_root: &Path,
+    swept_package_dirs: &[PathBuf],
+) -> Vec<PathBuf> {
+    let swept: BTreeSet<&Path> = swept_package_dirs.iter().map(PathBuf::as_path).collect();
+    let mut outside: Vec<PathBuf> = WalkDir::new(workspace_root)
+        .into_iter()
+        // Depth 0 is the workspace root itself, whose own name is not the
+        // sweep's business — a root under a dot-directory (or a `/tmp/.tmpXXX`
+        // fixture) would otherwise prune the entire walk to nothing.
+        .filter_entry(|entry| {
+            let name = entry.file_name().to_string_lossy();
+            entry.depth() == 0
+                || (name != "target" && name != "node_modules" && !name.starts_with('.'))
+        })
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| {
+            entry.file_type().is_dir() && entry.file_name() == PACKAGE_PROCESSOR_SOURCE_DIR_NAME
+        })
+        .map(|entry| entry.into_path())
+        .filter(|processor_source_dir| {
+            let Some(package_dir) = processor_source_dir.parent() else {
+                return false;
+            };
+            package_dir.join("Cargo.toml").is_file() && !swept.contains(package_dir)
+        })
+        .collect();
+    outside.sort();
+    outside
+}
+
+/// Every `.rs` under `dir`, recursively. `processors/` is the shared discovery
+/// root for every language, so `.py` / `.ts` siblings are simply not this
+/// gate's business.
+fn rust_files_under(dir: &Path) -> BTreeSet<PathBuf> {
+    WalkDir::new(dir)
+        .into_iter()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().is_file())
+        .map(|entry| entry.into_path())
+        .filter(|path| path.extension().and_then(|e| e.to_str()) == Some("rs"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use streamlib_processor_extract::generated_crate_root_lib_path_value;
+
+    /// A workspace holding exactly one folder-backed package, so a scan's
+    /// findings are attributable to the files the test wrote and nothing else.
+    fn workspace_with_one_folder_backed_package(files: &[(&str, &str)]) -> tempfile::TempDir {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let package_dir = workspace.path().join("packages/fixture");
+        std::fs::create_dir_all(&package_dir).expect("create package dir");
+        std::fs::write(
+            package_dir.join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"fixture\"\nversion = \"0.1.0\"\n\n\
+                 [lib]\npath = \"{}\"\n",
+                generated_crate_root_lib_path_value()
+            ),
+        )
+        .expect("write Cargo.toml");
+
+        for (relative_path, body) in files {
+            let path = package_dir.join(relative_path);
+            std::fs::create_dir_all(path.parent().expect("parent")).expect("create dirs");
+            std::fs::write(path, body).expect("write fixture file");
+        }
+        workspace
+    }
+
+    fn orphan_file_names(report: &ProcessorSourceReachabilityReport) -> Vec<String> {
+        report
+            .orphans
+            .iter()
+            .map(|orphan| {
+                orphan
+                    .orphan_file
+                    .file_name()
+                    .expect("file name")
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect()
+    }
+
+    /// The gate's whole reason to exist, and the issue's stated validation
+    /// shape: one file nothing declares, one declared only behind a
+    /// non-host target. Exactly one failure, and it names the orphan.
+    #[test]
+    fn an_undeclared_file_is_an_orphan_and_a_non_host_only_file_is_not() {
+        let workspace = workspace_with_one_folder_backed_package(&[
+            (
+                "processors/camera/mod.rs",
+                "#[cfg(target_os = \"macos\")]\nmod apple_capture;\n",
+            ),
+            ("processors/camera/apple_capture.rs", "pub struct Apple;\n"),
+            ("processors/camera/forgotten.rs", "pub struct Forgotten;\n"),
+        ]);
+
+        let report = scan_workspace(workspace.path()).expect("scan");
+
+        assert_eq!(
+            orphan_file_names(&report),
+            vec!["forgotten.rs"],
+            "the Apple-only file is declared and must pass when linted on \
+             any host; only the undeclared file is an orphan"
+        );
+    }
+
+    /// The parked-module convention: `#![cfg(any())]` compiles on no target by
+    /// design, and the generated crate root still declares the arm so that
+    /// unparking is a cfg edit and nothing else. A compile-reachability bar
+    /// would call every file under a parked directory an orphan — this locks
+    /// that it does not.
+    #[test]
+    fn a_file_declared_inside_a_parked_subtree_is_not_an_orphan() {
+        let workspace = workspace_with_one_folder_backed_package(&[
+            (
+                "processors/_apple_impl_pending_/mod.rs",
+                "#![cfg(any())]\nmod parked_camera;\n",
+            ),
+            (
+                "processors/_apple_impl_pending_/parked_camera.rs",
+                "pub struct ParkedCamera;\n",
+            ),
+        ]);
+
+        let report = scan_workspace(workspace.path()).expect("scan");
+
+        assert!(
+            report.orphans.is_empty(),
+            "parked source is named by the crate, not hidden from it: {:?}",
+            orphan_file_names(&report)
+        );
+        assert_eq!(report.scanned_processor_source_file_count, 2);
+    }
+
+    /// A nested file reached through two `mod` hops, one of them a `mod.rs`
+    /// directory arm. Without this the gate could pass by only ever resolving
+    /// one level and calling everything deeper unreachable — which the
+    /// single-hop cases above would not distinguish.
+    #[test]
+    fn a_file_reached_through_a_multi_hop_mod_chain_is_not_an_orphan() {
+        let workspace = workspace_with_one_folder_backed_package(&[
+            ("processors/codec/mod.rs", "mod inner;\n"),
+            ("processors/codec/inner/mod.rs", "mod leaf;\n"),
+            ("processors/codec/inner/leaf.rs", "pub struct Leaf;\n"),
+        ]);
+
+        let report = scan_workspace(workspace.path()).expect("scan");
+
+        assert!(
+            report.orphans.is_empty(),
+            "{:?}",
+            orphan_file_names(&report)
+        );
+        assert_eq!(report.scanned_processor_source_file_count, 3);
+    }
+
+    /// A `#[path]`-attributed `mod` names a file the standard search would
+    /// never find. Resolving it is why this walk shares the extractor's
+    /// resolution primitive instead of re-deriving one.
+    #[test]
+    fn a_file_named_only_by_a_path_attributed_mod_is_not_an_orphan() {
+        let workspace = workspace_with_one_folder_backed_package(&[
+            (
+                "processors/codec/mod.rs",
+                "#[path = \"vendored/impl.rs\"]\nmod vendored_impl;\n",
+            ),
+            (
+                "processors/codec/vendored/impl.rs",
+                "pub struct Vendored;\n",
+            ),
+        ]);
+
+        let report = scan_workspace(workspace.path()).expect("scan");
+
+        assert!(
+            report.orphans.is_empty(),
+            "{:?}",
+            orphan_file_names(&report)
+        );
+    }
+
+    /// A `#[path]` that climbs out of its own directory resolves to a path
+    /// carrying a literal `..`, while the directory walk yields the descended
+    /// form. Comparing those lexically calls a correctly declared file an
+    /// orphan and tells the author to delete it — the one failure a gate
+    /// cannot have.
+    #[test]
+    fn a_file_named_by_a_parent_relative_path_attribute_is_not_an_orphan() {
+        let workspace = workspace_with_one_folder_backed_package(&[
+            (
+                "processors/codec/mod.rs",
+                "#[path = \"../shared/helper.rs\"]\nmod helper;\n",
+            ),
+            ("processors/shared/mod.rs", "pub struct Shared;\n"),
+            ("processors/shared/helper.rs", "pub struct Helper;\n"),
+        ]);
+
+        let report = scan_workspace(workspace.path()).expect("scan");
+
+        assert!(
+            report.orphans.is_empty(),
+            "a `..`-relative #[path] names its file just as much as a plain \
+             `mod` does: {:?}",
+            orphan_file_names(&report)
+        );
+    }
+
+    /// An inline `mod foo { ... }` introduces a `foo` directory component for
+    /// its children's file resolution. Getting that wrong makes every file
+    /// under an inline module an orphan, and no other test would notice.
+    #[test]
+    fn a_file_declared_from_inside_an_inline_mod_is_not_an_orphan() {
+        let workspace = workspace_with_one_folder_backed_package(&[
+            ("processors/codec/mod.rs", "mod inner {\n    mod leaf;\n}\n"),
+            ("processors/codec/inner/leaf.rs", "pub struct Leaf;\n"),
+        ]);
+
+        let report = scan_workspace(workspace.path()).expect("scan");
+
+        assert!(
+            report.orphans.is_empty(),
+            "{:?}",
+            orphan_file_names(&report)
+        );
+        assert_eq!(report.scanned_processor_source_file_count, 2);
+    }
+
+    /// A package that commits its own crate root pulls its processor source in
+    /// by `#[path]` from `src/`, which this sweep never starts from. The
+    /// directory is reported rather than dropped — a gate that quietly skips
+    /// part of its stated scope reads as "covered everything".
+    #[test]
+    fn a_processors_dir_on_a_package_that_commits_its_own_crate_root_is_reported_as_unswept() {
+        let workspace = workspace_with_one_folder_backed_package(&[(
+            "processors/blur.rs",
+            "pub struct Blur;\n",
+        )]);
+        let committed = workspace.path().join("packages/committed");
+        std::fs::create_dir_all(committed.join("processors")).expect("create dirs");
+        std::fs::write(
+            committed.join("Cargo.toml"),
+            "[package]\nname = \"committed\"\nversion = \"0.1.0\"\n",
+        )
+        .expect("write Cargo.toml");
+        std::fs::write(
+            committed.join("processors/api_server.rs"),
+            "pub struct ApiServer;\n",
+        )
+        .expect("write processor");
+
+        let report = scan_workspace(workspace.path()).expect("scan");
+
+        assert!(
+            report.orphans.is_empty(),
+            "an unswept directory must not be reported as orphans: {:?}",
+            orphan_file_names(&report)
+        );
+        assert_eq!(
+            report.processor_source_dirs_outside_the_sweep,
+            vec![committed.join("processors")]
+        );
+    }
+
+    /// A top-level `processors/<name>.rs` becomes an arm with no `mod`
+    /// anywhere, so the gate must not demand a declaration for it.
+    #[test]
+    fn a_top_level_arm_needs_no_mod_declaration() {
+        let workspace = workspace_with_one_folder_backed_package(&[(
+            "processors/blur.rs",
+            "pub struct Blur;\n",
+        )]);
+
+        let report = scan_workspace(workspace.path()).expect("scan");
+
+        assert!(
+            report.orphans.is_empty(),
+            "{:?}",
+            orphan_file_names(&report)
+        );
+        assert_eq!(report.scanned_processor_source_file_count, 1);
+    }
+
+    /// A `processors/` subdirectory with no `mod.rs` is not an arm, so nothing
+    /// names the Rust source inside it. The extractor only `warn`s about this
+    /// today; the set diff makes it a failure.
+    #[test]
+    fn rust_source_in_a_subdirectory_with_no_mod_rs_is_an_orphan() {
+        let workspace = workspace_with_one_folder_backed_package(&[(
+            "processors/stray/helper.rs",
+            "pub struct Helper;\n",
+        )]);
+
+        let report = scan_workspace(workspace.path()).expect("scan");
+
+        assert_eq!(orphan_file_names(&report), vec!["helper.rs"]);
+    }
+
+    /// A package with no `processors/` at all is first-class (schema-only), so
+    /// it contributes no findings — and, importantly, no files, which is what
+    /// `ensure_source_walking_gate_read_source` exists to notice.
+    #[test]
+    fn a_package_with_no_processor_source_dir_contributes_nothing() {
+        let workspace = workspace_with_one_folder_backed_package(&[]);
+
+        let report = scan_workspace(workspace.path()).expect("scan");
+
+        assert!(report.orphans.is_empty());
+        assert_eq!(report.scanned_processor_source_file_count, 0);
+        assert_eq!(report.scanned_package_count, 1);
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -22,6 +22,7 @@ pub mod check_no_inventory_submit;
 pub mod check_no_reverse_dns;
 pub mod check_no_streamlib_metadata;
 pub mod check_package_version_drift;
+pub mod check_processor_source_reachability;
 pub mod check_processor_spec_new;
 pub mod check_schema_versions;
 pub mod check_vendored_vulkanalia;
@@ -153,6 +154,12 @@ enum Commands {
     /// `SchemaIdent::new(...)` or via the macro-emitted
     /// `<Module>::schema_ident()`).
     CheckProcessorSpecNew,
+
+    /// CI gate reporting `.rs` files under a folder-backed package's
+    /// `processors/` directory that no `mod` chain in the generated module
+    /// tree names. Cargo and clippy both ignore such a file — it is absent
+    /// from the build, not excluded from it — so nothing else says a word.
+    CheckProcessorSourceReachability,
 
     /// CI gate for the cdylib-reachability invariant on engine `Host*`
     /// constructors. Fails when any constructor-class method
@@ -324,6 +331,9 @@ fn main() -> Result<()> {
         Commands::CheckNoReverseDns => check_no_reverse_dns::run(&workspace_root()?)?,
         Commands::CheckNoInventorySubmit => check_no_inventory_submit::run(&workspace_root()?)?,
         Commands::CheckProcessorSpecNew => check_processor_spec_new::run(&workspace_root()?)?,
+        Commands::CheckProcessorSourceReachability => {
+            check_processor_source_reachability::run(&workspace_root()?)?
+        }
         Commands::CheckCdylibReach => check_cdylib_reach::run(&workspace_root()?)?,
         Commands::CheckNoEscalateInLifecycle => {
             check_no_escalate_in_lifecycle::run(&workspace_root()?)?


### PR DESCRIPTION
Closes #1597. Stacked on #1666.

## What

Compiler-interpreted `cfg` beats a scanner everywhere except one place: a `.rs` under `processors/` that no `mod` chain names is not "excluded on this target", it is **absent from the build entirely**. Cargo and clippy both say nothing. An author lands `processors/camera/windows.rs`, forgets the `mod windows;`, and the file sits in the tree compiling nowhere and reviewed by no one.

`cargo xtask check-processor-source-reachability` walks every folder-backed package's generated module tree and reports any `.rs` under `processors/` it never reaches. On the current tree: **97 files across 19 packages, no orphans.**

## The bar: declaration reachability, not compile reachability

A file passes if any `mod` chain rooted at a generated crate-root arm names it, **whether or not a build target compiles it**.

The parked-module convention forces this. `packages/*/processors/_apple_impl_pending_/mod.rs` opens with `#![cfg(any())]` — compiles on no target, by design — and those seven directories hold ~15 further `.rs` files declared by `mod` statements inside the parked `mod.rs`. `crate_root.rs`'s `a_fully_parked_cdylib_emits_no_plugin_envelope` asserts the generated root still declares parked arms, so that *"unparking is a cfg edit and nothing else"*. A compile-reachability bar would flag every one of those files.

## Where it lives

The walk is in `streamlib-processor-extract`, which already owns module resolution (`#[path]` overrides, flat-vs-`mod.rs` search, inline mods, arm enumeration). Re-deriving that in xtask would be a parallel system, and the two walks would drift on which file a `mod` names.

`ReachableModuleWalker::resolve_module_file` is now the free `resolve_external_module_file`, shared by the cfg-resolved processor walk and the new cfg-blind declaration walk. Body is unchanged; only `&self` (unused) was dropped.

## Tests — 10 fixture tests

Undeclared file is an orphan while a `#[cfg(target_os = "macos")]` sibling is not · parked subtree passes · multi-hop `mod` chain · `#[path]`-attributed mod · **`..`-relative `#[path]`** · **inline `mod foo { mod leaf; }` directory nesting** · top-level arm needs no `mod` · subdirectory with no `mod.rs` is an orphan · schema-only package contributes nothing · unswept `processors/` is reported.

Also verified empirically: dropping a real orphan into `packages/camera/processors/` makes the gate fail and name the exact path; removing it makes it pass again.

## Fixed during pre-PR review

The first pass compared `#[path = "../shared/helper.rs"]` (which resolves to a path carrying a literal `..`) against the directory walk's descended form. `PathBuf` equality is lexical and does not reduce `..`, so a **correctly declared file would have been reported as an orphan and the gate would have told the author to delete it.** Both sides are now reduced through `comparable_form` (canonicalize), which also makes them agree through a symlinked directory. Locked by `a_file_named_by_a_parent_relative_path_attribute_is_not_an_orphan`.

## Known gaps — disclosed, not silently narrowed

Two things this gate does **not** catch. Both are stated in the module docs and, for the second, printed on every run.

1. **A typo'd cfg predicate.** A `mod` behind a predicate no real target satisfies (`#[cfg(target_os = "windwos")]`) still counts as naming its file. Proving that class needs a rustc target-value registry; the cfg evaluator in `streamlib-processor-extract` proves satisfiability over the atoms a predicate *mentions*, under which a typo'd `target_os` is satisfiable (see `reachable.rs`'s "two arms both gated on a misspelled `target_os` still witness each other"). Note this also means the issue's own narrative example — a top-level `processors/camera_windows.rs` with a wrong predicate — is not caught, since a top-level file is auto-arm'd and needs no `mod` at all. What ships catches *nested* files nothing names. **Filed as a follow-up.**

2. **`packages/api-server/processors/`.** That package commits its own `src/lib.rs` and pulls `processors/api_server.rs` in by `#[path]`, so it has no generated arms to start from. Rather than drop it silently, the gate **prints the directory it skipped on every run** and the report carries `processor_source_dirs_outside_the_sweep`. Locked by a test.

## Notes for the reviewer

- Behavior change worth knowing: this gate is the first thing in the repo that parses parked `mod.rs` *children*. Rustc strips a cfg-pruned `mod` before loading its file, so those leaves were previously never parsed by anything. All of them parse today (the gate is green); a future half-written parked file would fail the gate with a syntax error rather than being ignored.
- The `let Ok(resolved) = ... else { return Ok(()) }` in the declaration walk biases toward over-reporting, never under-reporting: rustc does not require a module file for a `mod` the build prunes, so an unresolvable one is not evidence of an orphan.
- `cargo fmt` on this box (rustfmt 1.8.0-stable) wants to reformat 139 unrelated workspace files. None of that is in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
