### PR TITLE
fix(cli): un-rot the package fixtures, collapsing four copies into one

### DIFF
--- a/tools/streamlib-cli/tests/add_remove.rs
+++ b/tools/streamlib-cli/tests/add_remove.rs
@@ -10,49 +10,23 @@
 //! (arg parsing, `--dir` anchoring, report printing) end-to-end over a real
 //! `.slpkg` assembled by `streamlib-pack`.
 
-use std::path::Path;
-use std::process::Command;
+mod cli_integration_support;
+
+use cli_integration_support::{run_streamlib_binary, write_single_processor_foo_package_source};
 
 use streamlib_pack::{
     AssembleOptions, AssembleTarget, CargoProfile, PathDepPolicy, assemble_artifact,
 };
 
-const BIN: &str = env!("CARGO_BIN_EXE_streamlib");
-
-/// Create a package at `dir`: a manifest declaring one processor + one owned
-/// schema (no Rust/Python sources — add never builds, so none are needed).
-fn write_foo_package(dir: &Path) {
-    std::fs::create_dir_all(dir.join("schemas")).unwrap();
-    std::fs::write(
-        dir.join("streamlib.yaml"),
-        "package:\n  org: tatolab\n  name: foo\n  version: 1.1.0\n  \
-         description: a demo add package\nschemas:\n  FooFrame:\n    file: schemas/foo_frame.yaml\n\
-         processors:\n  - name: Foo\n    version: 1.0.0\n    description: does foo\n    \
-         runtime: python\n    execution: manual\n    entrypoint: \"foo:Foo\"\n    \
-         inputs: []\n    outputs: []\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("schemas/foo_frame.yaml"),
-        "metadata:\n  type: FooFrame\n  description: \"A demo frame\"\nproperties:\n  \
-         width:\n    type: uint32\n  height:\n    type: uint32\n",
-    )
-    .unwrap();
-}
-
-fn run(args: &[&str]) -> std::process::Output {
-    Command::new(BIN).args(args).output().expect("spawn streamlib binary")
-}
-
 #[test]
 fn add_folder_and_slpkg_then_remove_via_app_modules() {
     let pkg = tempfile::tempdir().unwrap();
-    write_foo_package(pkg.path());
+    write_single_processor_foo_package_source(pkg.path(), "a demo add package");
     let app_root = tempfile::tempdir().unwrap();
     let app_dir = app_root.path().to_str().unwrap();
 
     // --- add (folder source) -------------------------------------------
-    let out = run(&["add", pkg.path().to_str().unwrap(), "--dir", app_dir]);
+    let out = run_streamlib_binary(&["add", pkg.path().to_str().unwrap(), "--dir", app_dir]);
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
         out.status.success(),
@@ -60,14 +34,18 @@ fn add_folder_and_slpkg_then_remove_via_app_modules() {
         out.status,
         String::from_utf8_lossy(&out.stderr)
     );
-    assert!(stdout.contains("Added @tatolab/foo v1.1.0"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("Added @tatolab/foo v1.1.0"),
+        "stdout: {stdout}"
+    );
     assert!(stdout.contains("Processors (1):"), "stdout: {stdout}");
     assert!(stdout.contains("Foo — does foo"), "stdout: {stdout}");
 
-    let slot = app_root
-        .path()
-        .join("streamlib_modules/@tatolab/foo");
-    assert!(slot.join("streamlib.yaml").is_file(), "modules slot missing");
+    let slot = app_root.path().join("streamlib_modules/@tatolab/foo");
+    assert!(
+        slot.join("streamlib.yaml").is_file(),
+        "modules slot missing"
+    );
     let lock = std::fs::read_to_string(app_root.path().join("streamlib.lock")).unwrap();
     assert!(lock.contains("@tatolab/foo"), "lock: {lock}");
     assert!(lock.contains("kind: path"), "lock: {lock}");
@@ -88,7 +66,7 @@ fn add_folder_and_slpkg_then_remove_via_app_modules() {
     )
     .expect("assemble source .slpkg");
 
-    let out = run(&["add", slpkg.to_str().unwrap(), "--dir", app_dir]);
+    let out = run_streamlib_binary(&["add", slpkg.to_str().unwrap(), "--dir", app_dir]);
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
         out.status.success(),
@@ -109,20 +87,23 @@ fn add_folder_and_slpkg_then_remove_via_app_modules() {
     );
 
     // --- remove ---------------------------------------------------------
-    let out = run(&["remove", "@tatolab/foo", "--dir", app_dir]);
+    let out = run_streamlib_binary(&["remove", "@tatolab/foo", "--dir", app_dir]);
     let rstdout = String::from_utf8_lossy(&out.stdout);
     assert!(
         out.status.success(),
         "remove failed: {rstdout}\n{}",
         String::from_utf8_lossy(&out.stderr)
     );
-    assert!(rstdout.contains("Removed @tatolab/foo v1.1.0"), "stdout: {rstdout}");
+    assert!(
+        rstdout.contains("Removed @tatolab/foo v1.1.0"),
+        "stdout: {rstdout}"
+    );
     assert!(!slot.exists(), "modules slot must be gone");
     let lock = std::fs::read_to_string(app_root.path().join("streamlib.lock")).unwrap();
     assert!(!lock.contains("@tatolab/foo"), "still locked: {lock}");
 
     // Removing an absent package fails loud.
-    let out = run(&["remove", "@tatolab/foo", "--dir", app_dir]);
+    let out = run_streamlib_binary(&["remove", "@tatolab/foo", "--dir", app_dir]);
     assert!(!out.status.success(), "remove of absent package must fail");
     assert!(
         String::from_utf8_lossy(&out.stderr).contains("not installed"),
@@ -134,10 +115,10 @@ fn add_folder_and_slpkg_then_remove_via_app_modules() {
 #[test]
 fn add_folder_with_expect_sha256_warns_on_stderr_but_succeeds() {
     let pkg = tempfile::tempdir().unwrap();
-    write_foo_package(pkg.path());
+    write_single_processor_foo_package_source(pkg.path(), "a demo add package");
     let app_root = tempfile::tempdir().unwrap();
 
-    let out = run(&[
+    let out = run_streamlib_binary(&[
         "add",
         pkg.path().to_str().unwrap(),
         "--dir",
@@ -149,24 +130,33 @@ fn add_folder_with_expect_sha256_warns_on_stderr_but_succeeds() {
     let stderr = String::from_utf8_lossy(&out.stderr);
     // A folder source has no archive bytes; the sha pin is a no-op and must be
     // called out on stderr rather than silently ignored, but the add succeeds.
-    assert!(out.status.success(), "folder add must still succeed: {stderr}");
+    assert!(
+        out.status.success(),
+        "folder add must still succeed: {stderr}"
+    );
     assert!(
         stderr.contains("--expect-sha256 is ignored for a folder source"),
         "expected a stderr warning, got: {stderr}"
     );
-    assert!(stdout.contains("Added @tatolab/foo v1.1.0"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("Added @tatolab/foo v1.1.0"),
+        "stdout: {stdout}"
+    );
 }
 
 #[test]
 fn add_version_coordinate_gets_guidance_error() {
     let app_root = tempfile::tempdir().unwrap();
-    let out = run(&[
+    let out = run_streamlib_binary(&[
         "add",
         "@tatolab/foo",
         "--dir",
         app_root.path().to_str().unwrap(),
     ]);
-    assert!(!out.status.success(), "a version coordinate must be rejected");
+    assert!(
+        !out.status.success(),
+        "a version coordinate must be rejected"
+    );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         stderr.contains("version coordinate"),
@@ -180,7 +170,7 @@ fn add_version_coordinate_gets_guidance_error() {
 #[test]
 fn add_with_expect_sha256_mismatch_fails_with_no_partial_state() {
     let pkg = tempfile::tempdir().unwrap();
-    write_foo_package(pkg.path());
+    write_single_processor_foo_package_source(pkg.path(), "a demo add package");
     let artifacts = tempfile::tempdir().unwrap();
     let slpkg = artifacts.path().join("foo.slpkg");
     assemble_artifact(
@@ -197,7 +187,7 @@ fn add_with_expect_sha256_mismatch_fails_with_no_partial_state() {
     .expect("assemble source .slpkg");
 
     let app_root = tempfile::tempdir().unwrap();
-    let out = run(&[
+    let out = run_streamlib_binary(&[
         "add",
         slpkg.to_str().unwrap(),
         "--dir",

--- a/tools/streamlib-cli/tests/cli_integration_support/mod.rs
+++ b/tools/streamlib-cli/tests/cli_integration_support/mod.rs
@@ -1,0 +1,72 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Shared fixtures for the `streamlib` CLI integration binaries.
+//!
+//! Each file under `tests/` is its own crate, so without a shared module every
+//! one re-declares the binary path, the spawn helper, and a `foo` package
+//! fixture — and a manifest-schema change has to be chased through each copy
+//! independently.
+
+#![allow(dead_code)]
+
+use std::path::Path;
+use std::process::Command;
+
+/// The `streamlib` binary the integration tests drive.
+pub const STREAMLIB_BINARY_PATH: &str = env!("CARGO_BIN_EXE_streamlib");
+
+/// Run the `streamlib` binary with `args` and capture its output.
+pub fn run_streamlib_binary(args: &[&str]) -> std::process::Output {
+    Command::new(STREAMLIB_BINARY_PATH)
+        .args(args)
+        .output()
+        .expect("spawn streamlib binary")
+}
+
+/// Write a `@tatolab/foo` package source tree at `dir` declaring one owned
+/// schema and no processors — the smallest publishable package, and the one
+/// that assembles without a toolchain build.
+pub fn write_schema_only_foo_package_source(dir: &Path, description: &str) {
+    write_foo_package_source(dir, description, None);
+}
+
+/// Write a `@tatolab/foo` package source tree at `dir` declaring one owned
+/// schema and one manual Python processor.
+///
+/// The processor entry carries no `version:` key: versioning is a
+/// package-level property, and the manifest schema rejects a per-processor one.
+pub fn write_single_processor_foo_package_source(dir: &Path, description: &str) {
+    write_foo_package_source(
+        dir,
+        description,
+        Some(
+            "processors:\n  - name: Foo\n    description: does foo\n    \
+             runtime: python\n    execution: manual\n    entrypoint: \"foo:Foo\"\n    \
+             inputs: []\n    outputs: []\n",
+        ),
+    );
+}
+
+fn write_foo_package_source(dir: &Path, description: &str, processors_block: Option<&str>) {
+    std::fs::create_dir_all(dir.join("schemas")).unwrap();
+    std::fs::write(
+        dir.join("streamlib.yaml"),
+        format!(
+            // Quoted: this is the one fixture entry point for four binaries,
+            // and an unquoted description carrying `:` or `#` would parse as
+            // something other than what the caller passed.
+            "package:\n  org: tatolab\n  name: foo\n  version: 1.1.0\n  \
+             description: \"{description}\"\nschemas:\n  FooFrame:\n    \
+             file: schemas/foo_frame.yaml\n{}",
+            processors_block.unwrap_or_default()
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("schemas/foo_frame.yaml"),
+        "metadata:\n  type: FooFrame\n  description: \"A demo frame\"\nproperties:\n  \
+         width:\n    type: uint32\n  height:\n    type: uint32\n",
+    )
+    .unwrap();
+}

--- a/tools/streamlib-cli/tests/install_from_lock.rs
+++ b/tools/streamlib-cli/tests/install_from_lock.rs
@@ -12,35 +12,13 @@
 //! real `.slpkg` assembled by `streamlib-pack` — the container/CI preinstall
 //! story (commit the lock, run `install` at image build).
 
-use std::path::Path;
-use std::process::Command;
+mod cli_integration_support;
+
+use cli_integration_support::{run_streamlib_binary, write_schema_only_foo_package_source};
 
 use streamlib_pack::{
     AssembleOptions, AssembleTarget, CargoProfile, PathDepPolicy, assemble_artifact,
 };
-
-const BIN: &str = env!("CARGO_BIN_EXE_streamlib");
-
-/// A schema-only package (no Rust/Python sources — install never builds).
-fn write_foo_package(dir: &Path) {
-    std::fs::create_dir_all(dir.join("schemas")).unwrap();
-    std::fs::write(
-        dir.join("streamlib.yaml"),
-        "package:\n  org: tatolab\n  name: foo\n  version: 1.1.0\n  \
-         description: a demo install package\nschemas:\n  FooFrame:\n    file: schemas/foo_frame.yaml\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("schemas/foo_frame.yaml"),
-        "metadata:\n  type: FooFrame\n  description: \"A demo frame\"\nproperties:\n  \
-         width:\n    type: uint32\n  height:\n    type: uint32\n",
-    )
-    .unwrap();
-}
-
-fn run(args: &[&str]) -> std::process::Output {
-    Command::new(BIN).args(args).output().expect("spawn streamlib binary")
-}
 
 /// The docker/CI story: `add` a portable archive source into a source app,
 /// commit its `streamlib.lock`, then reproduce a byte-equivalent
@@ -48,7 +26,7 @@ fn run(args: &[&str]) -> std::process::Output {
 #[test]
 fn install_reproduces_modules_in_a_clean_checkout_from_the_lock() {
     let pkg = tempfile::tempdir().unwrap();
-    write_foo_package(pkg.path());
+    write_schema_only_foo_package_source(pkg.path(), "a demo install package");
 
     // A real source-only `.slpkg` (a portable, machine-independent source).
     let artifacts = tempfile::tempdir().unwrap();
@@ -69,7 +47,7 @@ fn install_reproduces_modules_in_a_clean_checkout_from_the_lock() {
     // Source app: `add` records the archive source in streamlib.lock.
     let source_app = tempfile::tempdir().unwrap();
     let src_dir = source_app.path().to_str().unwrap();
-    let out = run(&["add", slpkg.to_str().unwrap(), "--dir", src_dir]);
+    let out = run_streamlib_binary(&["add", slpkg.to_str().unwrap(), "--dir", src_dir]);
     assert!(
         out.status.success(),
         "add failed: {}\n{}",
@@ -97,14 +75,17 @@ fn install_reproduces_modules_in_a_clean_checkout_from_the_lock() {
     );
 
     // Reproduce.
-    let out = run(&["install", "--dir", dest_dir]);
+    let out = run_streamlib_binary(&["install", "--dir", dest_dir]);
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
         out.status.success(),
         "install failed: {stdout}\n{}",
         String::from_utf8_lossy(&out.stderr)
     );
-    assert!(stdout.contains("Reproduced 1 package(s)"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("Reproduced 1 package(s)"),
+        "stdout: {stdout}"
+    );
     assert!(stdout.contains("@tatolab/foo"), "stdout: {stdout}");
     assert!(stdout.contains("materialized"), "stdout: {stdout}");
 
@@ -120,7 +101,7 @@ fn install_reproduces_modules_in_a_clean_checkout_from_the_lock() {
     );
 
     // Install is idempotent (second run reproduces the same folder).
-    let out = run(&["install", "--dir", dest_dir]);
+    let out = run_streamlib_binary(&["install", "--dir", dest_dir]);
     assert!(out.status.success(), "second install must succeed");
     assert_eq!(
         std::fs::read(&dest_slot).unwrap(),
@@ -133,14 +114,16 @@ fn install_reproduces_modules_in_a_clean_checkout_from_the_lock() {
 #[test]
 fn install_recovers_deleted_modules_dir_from_the_lock() {
     let pkg = tempfile::tempdir().unwrap();
-    write_foo_package(pkg.path());
+    write_schema_only_foo_package_source(pkg.path(), "a demo install package");
     let app = tempfile::tempdir().unwrap();
     let dir = app.path().to_str().unwrap();
 
     // A folder `add` (Path source) into the app.
-    let out = run(&["add", pkg.path().to_str().unwrap(), "--dir", dir]);
+    let out = run_streamlib_binary(&["add", pkg.path().to_str().unwrap(), "--dir", dir]);
     assert!(out.status.success(), "add failed");
-    let slot = app.path().join("streamlib_modules/@tatolab/foo/streamlib.yaml");
+    let slot = app
+        .path()
+        .join("streamlib_modules/@tatolab/foo/streamlib.yaml");
     let before = std::fs::read(&slot).unwrap();
 
     // Nuke the modules folder, keep the lock.
@@ -148,7 +131,7 @@ fn install_recovers_deleted_modules_dir_from_the_lock() {
     assert!(app.path().join("streamlib.lock").exists());
 
     // Install reproduces it.
-    let out = run(&["install", "--dir", dir]);
+    let out = run_streamlib_binary(&["install", "--dir", dir]);
     assert!(
         out.status.success(),
         "install failed: {}",
@@ -161,7 +144,7 @@ fn install_recovers_deleted_modules_dir_from_the_lock() {
 #[test]
 fn install_without_a_lockfile_fails_loud() {
     let app = tempfile::tempdir().unwrap();
-    let out = run(&["install", "--dir", app.path().to_str().unwrap()]);
+    let out = run_streamlib_binary(&["install", "--dir", app.path().to_str().unwrap()]);
     assert!(!out.status.success(), "install with no lock must fail");
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(

--- a/tools/streamlib-cli/tests/link_unlink.rs
+++ b/tools/streamlib-cli/tests/link_unlink.rs
@@ -10,47 +10,19 @@
 //! printing) and the npm-link dev loop: symlink a checkout, edit it, observe
 //! the edit live through the slot, then unlink.
 
-use std::path::Path;
-use std::process::Command;
+mod cli_integration_support;
 
-const BIN: &str = env!("CARGO_BIN_EXE_streamlib");
-
-/// Create a package at `dir`: a manifest declaring one processor + one owned
-/// schema (link never builds, so no sources are needed).
-fn write_foo_package(dir: &Path, description: &str) {
-    std::fs::create_dir_all(dir.join("schemas")).unwrap();
-    std::fs::write(
-        dir.join("streamlib.yaml"),
-        format!(
-            "package:\n  org: tatolab\n  name: foo\n  version: 1.1.0\n  \
-             description: {description}\nschemas:\n  FooFrame:\n    file: schemas/foo_frame.yaml\n\
-             processors:\n  - name: Foo\n    version: 1.0.0\n    description: does foo\n    \
-             runtime: python\n    execution: manual\n    entrypoint: \"foo:Foo\"\n    \
-             inputs: []\n    outputs: []\n"
-        ),
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("schemas/foo_frame.yaml"),
-        "metadata:\n  type: FooFrame\n  description: \"A demo frame\"\nproperties:\n  \
-         width:\n    type: uint32\n  height:\n    type: uint32\n",
-    )
-    .unwrap();
-}
-
-fn run(args: &[&str]) -> std::process::Output {
-    Command::new(BIN).args(args).output().expect("spawn streamlib binary")
-}
+use cli_integration_support::{run_streamlib_binary, write_single_processor_foo_package_source};
 
 #[test]
 fn link_then_edit_reflected_live_then_unlink() {
     let checkout = tempfile::tempdir().unwrap();
-    write_foo_package(checkout.path(), "a demo link package");
+    write_single_processor_foo_package_source(checkout.path(), "a demo link package");
     let app_root = tempfile::tempdir().unwrap();
     let app_dir = app_root.path().to_str().unwrap();
 
     // --- link -----------------------------------------------------------
-    let out = run(&["link", checkout.path().to_str().unwrap(), "--dir", app_dir]);
+    let out = run_streamlib_binary(&["link", checkout.path().to_str().unwrap(), "--dir", app_dir]);
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
         out.status.success(),
@@ -58,12 +30,18 @@ fn link_then_edit_reflected_live_then_unlink() {
         out.status,
         String::from_utf8_lossy(&out.stderr)
     );
-    assert!(stdout.contains("Linked @tatolab/foo v1.1.0"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("Linked @tatolab/foo v1.1.0"),
+        "stdout: {stdout}"
+    );
     assert!(stdout.contains("Processors (1):"), "stdout: {stdout}");
 
     let slot = app_root.path().join("streamlib_modules/@tatolab/foo");
     assert!(
-        std::fs::symlink_metadata(&slot).unwrap().file_type().is_symlink(),
+        std::fs::symlink_metadata(&slot)
+            .unwrap()
+            .file_type()
+            .is_symlink(),
         "slot must be a symlink, not a copy"
     );
     let lock = std::fs::read_to_string(app_root.path().join("streamlib.lock")).unwrap();
@@ -71,7 +49,7 @@ fn link_then_edit_reflected_live_then_unlink() {
     assert!(lock.contains("kind: link"), "lock: {lock}");
 
     // --- edit the checkout: the slot reflects it live, no re-link -------
-    write_foo_package(checkout.path(), "EDITED AFTER LINK");
+    write_single_processor_foo_package_source(checkout.path(), "EDITED AFTER LINK");
     let slot_manifest = std::fs::read_to_string(slot.join("streamlib.yaml")).unwrap();
     assert!(
         slot_manifest.contains("EDITED AFTER LINK"),
@@ -79,22 +57,28 @@ fn link_then_edit_reflected_live_then_unlink() {
     );
 
     // --- unlink ---------------------------------------------------------
-    let out = run(&["unlink", "@tatolab/foo", "--dir", app_dir]);
+    let out = run_streamlib_binary(&["unlink", "@tatolab/foo", "--dir", app_dir]);
     let ustdout = String::from_utf8_lossy(&out.stdout);
     assert!(
         out.status.success(),
         "unlink failed: {ustdout}\n{}",
         String::from_utf8_lossy(&out.stderr)
     );
-    assert!(ustdout.contains("Unlinked @tatolab/foo"), "stdout: {ustdout}");
-    assert!(std::fs::symlink_metadata(&slot).is_err(), "slot must be gone");
+    assert!(
+        ustdout.contains("Unlinked @tatolab/foo"),
+        "stdout: {ustdout}"
+    );
+    assert!(
+        std::fs::symlink_metadata(&slot).is_err(),
+        "slot must be gone"
+    );
     let lock = std::fs::read_to_string(app_root.path().join("streamlib.lock")).unwrap();
     assert!(!lock.contains("@tatolab/foo"), "still locked: {lock}");
     // The linked checkout on disk is untouched.
     assert!(checkout.path().join("streamlib.yaml").is_file());
 
     // Unlinking an absent package fails loud.
-    let out = run(&["unlink", "@tatolab/foo", "--dir", app_dir]);
+    let out = run_streamlib_binary(&["unlink", "@tatolab/foo", "--dir", app_dir]);
     assert!(!out.status.success(), "unlink of absent package must fail");
     assert!(
         String::from_utf8_lossy(&out.stderr).contains("not linked"),
@@ -106,18 +90,21 @@ fn link_then_edit_reflected_live_then_unlink() {
 #[test]
 fn link_over_added_copy_flips_to_symlink_and_unlink_of_copy_is_refused() {
     let checkout = tempfile::tempdir().unwrap();
-    write_foo_package(checkout.path(), "a demo package");
+    write_single_processor_foo_package_source(checkout.path(), "a demo package");
     let app_root = tempfile::tempdir().unwrap();
     let app_dir = app_root.path().to_str().unwrap();
 
     // Add (a real copy), then unlink must refuse it (it's not a link).
     assert!(
-        run(&["add", checkout.path().to_str().unwrap(), "--dir", app_dir])
+        run_streamlib_binary(&["add", checkout.path().to_str().unwrap(), "--dir", app_dir])
             .status
             .success()
     );
-    let out = run(&["unlink", "@tatolab/foo", "--dir", app_dir]);
-    assert!(!out.status.success(), "unlink of an added copy must be refused");
+    let out = run_streamlib_binary(&["unlink", "@tatolab/foo", "--dir", app_dir]);
+    assert!(
+        !out.status.success(),
+        "unlink of an added copy must be refused"
+    );
     assert!(
         String::from_utf8_lossy(&out.stderr).contains("use `streamlib remove`"),
         "stderr should redirect to remove: {}",
@@ -125,18 +112,25 @@ fn link_over_added_copy_flips_to_symlink_and_unlink_of_copy_is_refused() {
     );
 
     // Link over the added copy: the slot flips to a symlink, lock flips to link.
-    let out = run(&["link", checkout.path().to_str().unwrap(), "--dir", app_dir]);
+    let out = run_streamlib_binary(&["link", checkout.path().to_str().unwrap(), "--dir", app_dir]);
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(out.status.success(), "link over add failed: {stdout}");
     assert!(stdout.contains("Relinked @tatolab/foo"), "stdout: {stdout}");
     let slot = app_root.path().join("streamlib_modules/@tatolab/foo");
     assert!(
-        std::fs::symlink_metadata(&slot).unwrap().file_type().is_symlink(),
+        std::fs::symlink_metadata(&slot)
+            .unwrap()
+            .file_type()
+            .is_symlink(),
         "slot must become a symlink"
     );
     let lock = std::fs::read_to_string(app_root.path().join("streamlib.lock")).unwrap();
     assert!(lock.contains("kind: link"), "lock: {lock}");
-    assert_eq!(lock.matches("@tatolab/foo").count(), 1, "one lock entry: {lock}");
+    assert_eq!(
+        lock.matches("@tatolab/foo").count(),
+        1,
+        "one lock entry: {lock}"
+    );
 }
 
 #[test]
@@ -146,7 +140,7 @@ fn link_a_non_directory_is_rejected() {
     std::fs::write(&file, b"archive-not-a-folder").unwrap();
     let app_root = tempfile::tempdir().unwrap();
 
-    let out = run(&[
+    let out = run_streamlib_binary(&[
         "link",
         file.to_str().unwrap(),
         "--dir",
@@ -158,7 +152,13 @@ fn link_a_non_directory_is_rejected() {
         "stderr: {}",
         String::from_utf8_lossy(&out.stderr)
     );
-    assert!(!app_root.path().join("streamlib_modules").join("@tatolab").exists());
+    assert!(
+        !app_root
+            .path()
+            .join("streamlib_modules")
+            .join("@tatolab")
+            .exists()
+    );
 }
 
 #[test]
@@ -166,7 +166,7 @@ fn unlink_name_with_engine_is_a_usage_error() {
     // `unlink --engine` removes the whole-tree engine link and takes no
     // package name; a stray positional must bail rather than be silently
     // ignored (symmetric with the --dir / --force / --skip-verify guards).
-    let out = run(&["unlink", "@tatolab/foo", "--engine"]);
+    let out = run_streamlib_binary(&["unlink", "@tatolab/foo", "--engine"]);
     assert!(!out.status.success(), "unlink <name> --engine must fail");
     assert!(
         String::from_utf8_lossy(&out.stderr).contains("takes no package name"),
@@ -179,7 +179,7 @@ fn unlink_name_with_engine_is_a_usage_error() {
 fn bare_link_without_path_or_engine_is_a_usage_error() {
     // Pre-1.0: the old `link` (bare = engine link) shape is gone. A bare
     // `link` with no path and no `--engine` is a loud error.
-    let out = run(&["link"]);
+    let out = run_streamlib_binary(&["link"]);
     assert!(!out.status.success(), "bare link must fail");
     assert!(
         String::from_utf8_lossy(&out.stderr).contains("needs a package checkout path"),

--- a/tools/streamlib-cli/tests/pkg_publish_catalog.rs
+++ b/tools/streamlib-cli/tests/pkg_publish_catalog.rs
@@ -14,30 +14,14 @@
 //! `publish()` does. It uses a schema-only package (no processors) so the
 //! source-only assemble needs no Rust/Python toolchain.
 
-use std::path::Path;
+mod cli_integration_support;
+
 use std::process::Command;
 
+use cli_integration_support::{
+    STREAMLIB_BINARY_PATH, run_streamlib_binary, write_schema_only_foo_package_source,
+};
 use streamlib_idents::{CatalogClient, Org, Package, SchemaIdent, SemVer, TypeName};
-
-const BIN: &str = env!("CARGO_BIN_EXE_streamlib");
-
-/// A schema-only `foo` package (one owned schema, no processors) — the smallest
-/// publishable package that assembles without a toolchain build.
-fn write_foo_package(dir: &Path) {
-    std::fs::create_dir_all(dir.join("schemas")).unwrap();
-    std::fs::write(
-        dir.join("streamlib.yaml"),
-        "package:\n  org: tatolab\n  name: foo\n  version: 1.1.0\n  \
-         description: a demo publish package\nschemas:\n  FooFrame:\n    file: schemas/foo_frame.yaml\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("schemas/foo_frame.yaml"),
-        "metadata:\n  type: FooFrame\n  description: \"A demo frame\"\nproperties:\n  \
-         width:\n    type: uint32\n  height:\n    type: uint32\n",
-    )
-    .unwrap();
-}
 
 #[test]
 fn pkg_publish_writes_fetchable_catalog_and_owned_jtd() {
@@ -46,10 +30,10 @@ fn pkg_publish_writes_fetchable_catalog_and_owned_jtd() {
     // has a realistic layout to enumerate.
     let workspace = tempfile::tempdir().unwrap();
     let pkg_dir = workspace.path().join("packages").join("foo");
-    write_foo_package(&pkg_dir);
+    write_schema_only_foo_package_source(&pkg_dir, "a demo publish package");
 
     let package_source = format!("file://{}", tree.path().display());
-    let out = Command::new(BIN)
+    let out = Command::new(STREAMLIB_BINARY_PATH)
         .args(["pkg", "publish"])
         .current_dir(&pkg_dir)
         .env("STREAMLIB_PACKAGE_SOURCE", &package_source)
@@ -147,7 +131,7 @@ processors:
     .unwrap();
 
     let package_source = format!("file://{}", tree.path().display());
-    let out = Command::new(BIN)
+    let out = Command::new(STREAMLIB_BINARY_PATH)
         .args(["pkg", "publish"])
         .current_dir(&pkg_dir)
         .env("STREAMLIB_PACKAGE_SOURCE", &package_source)
@@ -171,10 +155,7 @@ processors:
 #[test]
 fn pkg_build_and_inspect_verbs_are_gone() {
     for removed_verb in ["build", "inspect"] {
-        let out = Command::new(BIN)
-            .args(["pkg", removed_verb])
-            .output()
-            .expect("spawn streamlib binary");
+        let out = run_streamlib_binary(&["pkg", removed_verb]);
         assert!(
             !out.status.success(),
             "`streamlib pkg {removed_verb}` must not be a recognized verb"


### PR DESCRIPTION
Closes #1625. Stacked on #1667.

## What

`cargo test -p streamlib-cli` could not be reported green. Five tests failed, all bottoming out in the same parse:

```
processors[0]: unknown field `version`, expected one of `name`, `description`,
`runtime`, `entrypoint`, `execution`, `scheduling`, `config`, `state`,
`inputs`, `outputs`
```

The shared package fixture wrote a `streamlib.yaml` whose processor entry still carried a `version:` key the manifest schema dropped — versioning is a package-level property. Fixture rot, not a product defect, but it made the crate's suite unusable as a gate: every PR touching the CLI had to hand-wave "known red at base", and a real regression in those five tests was invisible.

**After: `cargo test -p streamlib-cli` → 105 passed, 0 failed, no warnings.**

## Why four, not two

The issue named two rotted fixtures. There were **four** copies — each file under `tests/` is its own crate, so `add_remove.rs`, `link_unlink.rs`, `install_from_lock.rs`, and `pkg_publish_catalog.rs` each re-declared the binary path, the spawn helper, and a `write_foo_package`.

That's also *why* this went unnoticed: the two carrying a `processors:` block went red, the two schema-only ones stayed green, so the crate looked partly healthy. Fixing two and leaving two would have left the same trap. They now share `tests/cli_integration_support/mod.rs`, exposing the two package shapes over one manifest builder:

- `write_schema_only_foo_package_source(dir, description)` — used by `install_from_lock`, `pkg_publish_catalog`
- `write_single_processor_foo_package_source(dir, description)` — used by `add_remove`, `link_unlink`

Per-call-site descriptions are preserved exactly, so `link_unlink`'s live-edit assertion still greps the string it wrote.

## Why not `streamlib_idents::archive::package_archive_fixtures`

The issue suggested that module as "the existing home for shared package fixtures". I looked and declined: it builds **in-memory archive bytes** from arbitrary entries — it authors no manifest and writes no source tree, and `streamlib-cli` doesn't enable its `archive-test-fixtures` feature. Putting a manifest-authoring fixture there would mean cross-crate feature plumbing to serve consumers that all live in one crate. A `tests/`-local module keeps the fixture next to its only four callers. Happy to move it if you'd rather have one cross-crate home.

## Fixed during pre-PR review

The four call-site rewrites were done mechanically, so the review pass reverse-substituted the renames and diffed the entire post-`#[test]` region of all four files against the parent commit. Every surviving difference is rustfmt reflow plus the new description argument — no assertion text, message, or count changed, and no test was dropped. Also folded in from that pass:

- One missed collapse: `pkg_build_and_inspect_verbs_are_gone` still hand-rolled the `Command::new(...)` that `run_streamlib_binary` is.
- The interpolated `description` is now quoted in the emitted YAML — it's the single fixture entry point for four binaries, and an unquoted value carrying `:` or `#` would parse as something other than what the caller passed.

## Notes for the reviewer

- `#![allow(dead_code)]` on the shared module is load-bearing: each of its five public items is unused by at least one of the four binaries.
- Scope is exactly the four test files plus the new module. `cargo fmt` on this box wants to reformat six files under `tools/streamlib-cli/src/` — pre-existing on the parent branch, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
