### PR TITLE
fix(pack): refuse a `#[processor]` attribute that names a foreign package

### DIFF
--- a/sdk/streamlib-processor-extract/src/lib.rs
+++ b/sdk/streamlib-processor-extract/src/lib.rs
@@ -58,6 +58,7 @@ pub use reachable::{
     enumerate_processor_source_module_arms,
     enumerate_processor_source_module_files_the_crate_names,
     extract_processors_across_every_build_target, extract_reachable_rust_processors,
+    refuse_rust_processor_attributes_naming_a_foreign_package,
 };
 
 /// One processor derived from a `#[processor(...)]` attribute in source.
@@ -234,7 +235,66 @@ pub enum ExtractError {
         /// The named disagreement, labelled with each arm's source file.
         difference: String,
     },
+
+    /// A `#[processor("@org/package/Type")]` attribute names an `@org/package`
+    /// that is not the declaring package's own.
+    ///
+    /// The derived `processors:` entry keeps only the `Type` segment, and at
+    /// load the runtime recomposes each ident from the package's own org and
+    /// name. The attribute's `@org/package` is therefore dropped on the derive
+    /// side and kept on the register side, so the artifact packs cleanly and
+    /// fails only at `add_module` — "declared in the manifest but not
+    /// registered by the dylib" — naming an ident that appears nowhere in the
+    /// source. A typo'd org is the common case.
+    #[error(
+        "processor `{processor_type_name}` in {declared_in} declares \
+         `@{declared_org}/{declared_package}`, but this package is \
+         `@{package_own_org}/{package_own_name}`. A `#[processor(...)]` attribute can \
+         only name its own package: the derived `processors:` entry keeps just the \
+         `Type`, and the runtime recomposes the ident from this package's org and name \
+         at load — so a foreign `@org/package` packs cleanly and fails at `add_module` \
+         with an ident that is in no source file. Write \
+         `@{package_own_org}/{package_own_name}/{processor_type_name}`, or move the \
+         processor into the package it names"
+    )]
+    ProcessorAttributeNamesAForeignPackage {
+        processor_type_name: String,
+        declared_in: PathBuf,
+        declared_org: String,
+        declared_package: String,
+        package_own_org: String,
+        package_own_name: String,
+    },
+
+    /// A `#[processor(...)]` attribute in a distributable package declared no
+    /// identity string, so the macro synthesized the in-app `@app/local`
+    /// sentinel. Same load-time failure as a foreign `@org/package`, but the
+    /// author wrote no `@org/package` at all — telling them to "move the
+    /// processor into the package it names" would name a package that does not
+    /// exist.
+    #[error(
+        "processor `{processor_type_name}` in {declared_in} declares no identity string, so \
+         the attribute synthesized the in-app `@{APP_LOCAL_ORG}/{APP_LOCAL_PACKAGE}` sentinel \
+         — which is for processors defined inside an application, not for a distributable \
+         package. This package is `@{package_own_org}/{package_own_name}`, and at load the \
+         runtime looks the processor up under that name, so the sentinel registration is \
+         never found. Give the attribute its identity: \
+         `@{package_own_org}/{package_own_name}/{processor_type_name}`"
+    )]
+    ProcessorAttributeDeclaresNoPackageIdentity {
+        processor_type_name: String,
+        declared_in: PathBuf,
+        package_own_org: String,
+        package_own_name: String,
+    },
 }
+
+/// The org half of the identity a `#[processor(...)]` attribute synthesizes
+/// when it declares none — the in-app sentinel, never a distributable package.
+pub const APP_LOCAL_ORG: &str = "app";
+
+/// The package half of the synthesized in-app identity. See [`APP_LOCAL_ORG`].
+pub const APP_LOCAL_PACKAGE: &str = "local";
 
 /// Derive the `processors:` manifest section from a Rust package's source.
 ///

--- a/sdk/streamlib-processor-extract/src/reachable.rs
+++ b/sdk/streamlib-processor-extract/src/reachable.rs
@@ -53,6 +53,7 @@ use syn::punctuated::Punctuated;
 use syn::{Meta, Token};
 
 use streamlib_idents::PACKAGE_PROCESSOR_SOURCE_DIR_NAME as PROCESSOR_SOURCE_DIR_NAME;
+use streamlib_idents::{Org, Package};
 
 use crate::derive::describe_divergent_processor_declarations;
 use crate::{
@@ -526,6 +527,50 @@ pub fn extract_processors_across_every_build_target(
         processor_declarations,
         processor_availability,
     })
+}
+
+/// Refuse a Rust `#[processor("@org/package/Type")]` attribute that names a
+/// package other than the one declaring it.
+///
+/// Checked across every build target rather than the host's: a foreign
+/// `@org/package` on an Apple-only arm is the same broken artifact, and
+/// publishing from Linux would ship it unremarked.
+///
+/// Rust only — the Python and Deno decorators carry the same
+/// `@org/package/Type` ident with the same asymmetry, and are not covered.
+#[tracing::instrument(skip_all, fields(package_dir = %package_dir.display()))]
+pub fn refuse_rust_processor_attributes_naming_a_foreign_package(
+    package_dir: &Path,
+    package_own_org: &Org,
+    package_own_name: &Package,
+) -> Result<(), ExtractError> {
+    let declared = extract_processors_across_every_build_target(package_dir)?;
+
+    for processor in &declared.processor_declarations {
+        let declared_ident = &processor.schema_ident;
+        if &declared_ident.org == package_own_org && &declared_ident.package == package_own_name {
+            continue;
+        }
+        if declared_ident.org.as_str() == crate::APP_LOCAL_ORG
+            && declared_ident.package.as_str() == crate::APP_LOCAL_PACKAGE
+        {
+            return Err(ExtractError::ProcessorAttributeDeclaresNoPackageIdentity {
+                processor_type_name: processor.schema.name.clone(),
+                declared_in: processor.source_file.clone(),
+                package_own_org: package_own_org.to_string(),
+                package_own_name: package_own_name.to_string(),
+            });
+        }
+        return Err(ExtractError::ProcessorAttributeNamesAForeignPackage {
+            processor_type_name: processor.schema.name.clone(),
+            declared_in: processor.source_file.clone(),
+            declared_org: declared_ident.org.to_string(),
+            declared_package: declared_ident.package.to_string(),
+            package_own_org: package_own_org.to_string(),
+            package_own_name: package_own_name.to_string(),
+        });
+    }
+    Ok(())
 }
 
 /// Refuse a processor `Type` that one build target collected twice.
@@ -3367,5 +3412,146 @@ mod tests {
         // `not(feature = "x")` is satisfied BY absence, so a scope it prunes
         // was pruned by the feature being PRESENT — not the confusing case.
         assert!(collect(r#"not(feature = "cuda")"#, &linux()).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod foreign_package_attribute_tests {
+    use super::*;
+    use crate::scan_fixture_tempdir::{
+        ScanFixtureTempDir, scan_fixture_tempdir_named, write_scan_fixture_file as write,
+    };
+
+    fn tempdir() -> ScanFixtureTempDir {
+        scan_fixture_tempdir_named("slforeign")
+    }
+
+    fn demo_package() -> (Org, Package) {
+        (Org::new("tatolab").unwrap(), Package::new("demo").unwrap())
+    }
+
+    /// The bug: a foreign `@org/package` derives a clean entry, passes the
+    /// drift gate, packs, and fails only at `add_module`. Mental-revert —
+    /// delete the refusal and this returns `Ok`, which is exactly the artifact
+    /// that cannot load.
+    #[test]
+    fn a_processor_attribute_naming_another_package_is_refused() {
+        let tmp = tempdir();
+        write(
+            tmp.path(),
+            "processors/capture.rs",
+            r#"#[processor("@other/pkg/Capture", execution = manual)]
+            pub struct CaptureProcessor;"#,
+        );
+
+        let (org, package) = demo_package();
+        let error =
+            refuse_rust_processor_attributes_naming_a_foreign_package(tmp.path(), &org, &package)
+                .expect_err("a foreign @org/package must be refused");
+
+        let rendered = error.to_string();
+        assert!(rendered.contains("@other/pkg"), "{rendered}");
+        assert!(rendered.contains("@tatolab/demo"), "{rendered}");
+        assert!(rendered.contains("capture.rs"), "{rendered}");
+        assert!(rendered.contains("Capture"), "{rendered}");
+    }
+
+    /// Only the `@org/package` half is the package's business — the `Type`
+    /// segment is free, and every in-tree processor names its own package.
+    #[test]
+    fn a_processor_attribute_naming_its_own_package_is_accepted() {
+        let tmp = tempdir();
+        write(
+            tmp.path(),
+            "processors/capture.rs",
+            r#"#[processor("@tatolab/demo/Capture", execution = manual)]
+            pub struct CaptureProcessor;"#,
+        );
+
+        let (org, package) = demo_package();
+        refuse_rust_processor_attributes_naming_a_foreign_package(tmp.path(), &org, &package)
+            .expect("a processor naming its own package is fine");
+    }
+
+    /// A same-org, different-package attribute is the near-miss the `org`-only
+    /// comparison would wave through, and it fails at load identically.
+    #[test]
+    fn a_processor_attribute_naming_a_sibling_package_in_the_same_org_is_refused() {
+        let tmp = tempdir();
+        write(
+            tmp.path(),
+            "processors/capture.rs",
+            r#"#[processor("@tatolab/camera/Capture", execution = manual)]
+            pub struct CaptureProcessor;"#,
+        );
+
+        let (org, package) = demo_package();
+        let error =
+            refuse_rust_processor_attributes_naming_a_foreign_package(tmp.path(), &org, &package)
+                .expect_err("a sibling package in the same org must still be refused");
+        assert!(error.to_string().contains("@tatolab/camera"), "{error}");
+    }
+
+    /// Publishing happens from one host, so a foreign `@org/package` on an
+    /// arm that host does not compile would ship unremarked if the check
+    /// resolved against the host target instead of every build target.
+    #[test]
+    fn a_foreign_package_on_a_non_host_arm_is_still_refused() {
+        let tmp = tempdir();
+        write(
+            tmp.path(),
+            "processors/apple_capture.rs",
+            r#"#![cfg(target_os = "macos")]
+            #[processor("@other/pkg/AppleCapture", execution = manual)]
+            pub struct AppleCaptureProcessor;"#,
+        );
+
+        let (org, package) = demo_package();
+        let error =
+            refuse_rust_processor_attributes_naming_a_foreign_package(tmp.path(), &org, &package)
+                .expect_err("a non-host arm must be checked too");
+        assert!(error.to_string().contains("@other/pkg"), "{error}");
+    }
+
+    /// A bare `#[processor(execution = manual)]` synthesizes the in-app
+    /// `@app/local` sentinel. It fails at load exactly like a foreign
+    /// `@org/package`, but the author wrote no `@org/package` at all — so it
+    /// gets its own diagnostic rather than being told to move the processor
+    /// into a package that does not exist.
+    #[test]
+    fn a_processor_attribute_declaring_no_identity_is_refused_by_its_own_name() {
+        let tmp = tempdir();
+        write(
+            tmp.path(),
+            "processors/capture.rs",
+            r#"#[processor(execution = manual)]
+            pub struct CaptureProcessor;"#,
+        );
+
+        let (org, package) = demo_package();
+        let error =
+            refuse_rust_processor_attributes_naming_a_foreign_package(tmp.path(), &org, &package)
+                .expect_err("a synthesized @app/local identity must be refused");
+
+        assert!(
+            matches!(
+                error,
+                ExtractError::ProcessorAttributeDeclaresNoPackageIdentity { .. }
+            ),
+            "the sentinel gets its own variant, not the foreign-package one: {error}"
+        );
+        let rendered = error.to_string();
+        assert!(rendered.contains("@app/local"), "{rendered}");
+        assert!(rendered.contains("@tatolab/demo/Capture"), "{rendered}");
+    }
+
+    /// A package with no `processors/` at all is first-class and must not be
+    /// refused for having nothing to check.
+    #[test]
+    fn a_package_with_no_processor_source_dir_is_accepted() {
+        let tmp = tempdir();
+        let (org, package) = demo_package();
+        refuse_rust_processor_attributes_naming_a_foreign_package(tmp.path(), &org, &package)
+            .expect("a schema-only package declares no attribute to check");
     }
 }

--- a/tools/streamlib-pack/src/lib.rs
+++ b/tools/streamlib-pack/src/lib.rs
@@ -559,6 +559,15 @@ pub fn assemble_artifact_with_cargo_config(
         // whose committed `processors:` disagrees. `StagedDir` (runtime
         // orchestrator load-time build) is exempt — it assembles an already-
         // published, drift-validated artifact.
+        //
+        // Ordered before the drift gate deliberately: a foreign `@org/package`
+        // derives an entry that AGREES with the manifest, so the drift gate
+        // reports nothing and the more specific diagnostic would never fire.
+        streamlib_processor_extract::refuse_rust_processor_attributes_naming_a_foreign_package(
+            pkg_dir,
+            &package.org,
+            &package.name,
+        )?;
         enforce_processor_manifest_matches_code(pkg_dir, &config.processors)?;
         // Reconcile the hand-declared `dependencies:` against the dependency
         // set derived from the package's schema/port references. An undeclared
@@ -1885,7 +1894,7 @@ mod tests {
         .unwrap();
         std::fs::write(
             dir.join("processors/camera.rs"),
-            r#"#[processor("@tatolab/camera/Camera", execution = manual, output("video", "@tatolab/core/VideoFrame"))]
+            r#"#[processor("@tatolab/cam/Camera", execution = manual, output("video", "@tatolab/core/VideoFrame"))]
             pub struct Camera;
             "#,
         )
@@ -1915,7 +1924,7 @@ mod tests {
         .unwrap();
         std::fs::write(
             dir.join("processors/camera.rs"),
-            r#"#[processor("@tatolab/camera/Camera", execution = manual, output("video", "@tatolab/core/VideoFrame"))]
+            r#"#[processor("@tatolab/cam/Camera", execution = manual, output("video", "@tatolab/core/VideoFrame"))]
             pub struct Camera;
             "#,
         )
@@ -2022,6 +2031,50 @@ mod tests {
         )
         .expect("in-sync manifest must build");
         assert_eq!(outcome.processors, 1);
+    }
+
+    /// A `#[processor("@other/pkg/Type")]` derives a `processors:` entry that
+    /// agrees with the manifest — only the `Type` survives the derive — so the
+    /// drift gate below waves it through and the `.slpkg` packs clean, failing
+    /// only at `add_module` on an ident found in no source file (#1644).
+    /// Mentally revert the `refuse_rust_processor_attributes_naming_a_foreign_package`
+    /// call and this build succeeds, shipping exactly that artifact.
+    #[test]
+    fn slpkg_build_fails_on_a_processor_attribute_naming_a_foreign_package() {
+        let dir = tempdir().unwrap();
+        write_rust_processor_pkg(
+            dir.path(),
+            "processors:\n- name: Camera\n  runtime: rust\n  execution: manual\n  \
+             outputs:\n  - name: video\n    schema: VideoFrame\n",
+        );
+        // Same `Camera` type the manifest declares — only the `@org/package`
+        // is foreign, which is precisely what the drift gate cannot see.
+        std::fs::write(
+            dir.path().join("processors/camera.rs"),
+            r#"#[processor("@other/pkg/Camera", execution = manual, output("video", "@tatolab/core/VideoFrame"))]
+            pub struct Camera;
+            "#,
+        )
+        .unwrap();
+
+        let out = dir.path().join("o.slpkg");
+        let err = assemble_artifact(
+            dir.path(),
+            &AssembleTarget::Slpkg(out),
+            &slpkg_opts(false),
+            &(),
+        )
+        .unwrap_err();
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("@other/pkg"),
+            "must name the foreign id: {msg}"
+        );
+        assert!(
+            msg.contains("@tatolab/cam"),
+            "must name the package's own id: {msg}"
+        );
     }
 
     /// The truth-flip gate (#1411): a `.slpkg` build is a hard error when the


### PR DESCRIPTION
Closes #1644. Stacked on #1669.

## What

A Rust processor whose `#[processor(...)]` attribute named a **foreign** `@org/package` — `#[processor("@other/pkg/Capture")]` inside `@tatolab/camera` — derived a clean `processors:` entry, passed the publish-time drift gate, and packed into a valid `.slpkg`. It failed only at `add_module`:

```
Processor '<ident>' declared in streamlib.yaml but not registered by the dylib.
Ensure export_plugin!() includes this processor.
```

…naming an ident that appears in **no source file**. The derived entry keeps only the `Type` segment; at load the runtime recomposes each ident from the package's own org and name. So the attribute's `@org/package` is dropped on the derive side, kept on the register side, and nothing reconciled the two. A typo'd org is the common case.

## Where the check lives, and why

`refuse_rust_processor_attributes_naming_a_foreign_package` is in `streamlib-processor-extract`, beside the two existing id-grouping refusals and on the datum that already existed for exactly this (`ExtractedProcessor::schema_ident` — until now only ever compared between two arms of the *same* package). The publish path calls it, where the package's own identity is already in hand.

Splitting it that way is deliberate: **#1624 is reshaping the publish path.** When it lands it moves the *call site*, not the check.

Two ordering/scope decisions:

- **Before the drift gate.** A foreign `@org/package` derives an entry that *agrees* with the manifest, so drift reports nothing and the specific diagnostic would never fire if it ran second.
- **Across every build target, not the host's.** A foreign `@org/package` on an Apple-only arm is the same broken artifact, and publishing from Linux would ship it unremarked. Locked by a test that a host-resolved check would pass on Linux.

## The `@app/local` case

A bare `#[processor(execution = manual)]` synthesizes the in-app `@app/local` sentinel. In a distributable package that fails at load identically — but the author wrote no `@org/package` at all, so telling them to "move the processor into the package it names" would name a package that doesn't exist. It gets its own error variant and its own message. No in-tree instances.

## The gate found three real defects on its first run

Three `streamlib-pack` fixtures carried this exact bug: a `@tatolab/camera/Camera` attribute in a package whose manifest and `Cargo.toml` both say `cam`. Corrected here. `slpkg_build_fails_on_processor_manifest_drift` still fails for the drift reason it names.

I also checked every real package: **all 53 `#[processor(...)]` attributes across in-tree `packages/` and `examples/` name their own package.** Nothing in the tree breaks.

## Tests

Six in `streamlib-processor-extract` (foreign package, own package accepted, same-org sibling still refused, non-host arm still refused, `@app/local` gets its own variant, schema-only package accepted) plus **one in `streamlib-pack` pinning the wiring** — `slpkg_build_fails_on_a_processor_attribute_naming_a_foreign_package`. Mental-revert verified empirically: deleting the call from `assemble_artifact_with_cargo_config` makes that test fail, so it pins the seam the issue is actually about.

## Notes for the reviewer

- **Unremarked widening worth knowing:** the new check calls `extract_processors_across_every_build_target`, which also raises `OverlappingProcessorDeclarations` / `DivergentProcessorDeclarations`. Those cross-target refusals previously never ran on the `Slpkg` path (only the host-resolved drift walk did). I think that's a good widening, but `pkg publish` can now reject a package it accepted yesterday for a second reason. No in-tree package is affected.
- **Rust only.** The name says so. The Python and Deno decorators carry the same `@org/package/Type` ident with the same derive-drops / register-keeps asymmetry and stay unguarded. Not filed — flagging it for your call.
- `StagedDir` stays exempt, matching the three refusals already on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
