### PR TITLE
fix(pkg): refuse a path-carrying package where it is materialized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5217,6 +5217,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
+ "toml 0.8.23",
  "tracing",
  "ureq",
  "zip",

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/errors.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/errors.rs
@@ -326,6 +326,21 @@ pub enum AddModuleError {
         detail: String,
     },
 
+    /// The archive carries a dev-time path artifact — a path `patch:` override
+    /// or a Cargo path dependency — so it resolves only on the machine that
+    /// authored it and can never build here.
+    #[error(
+        "Package archive at {} carries path artifact(s) [{offenders}] — a path resolves \
+         only on the machine that wrote it, so the package cannot be materialized. \
+         Publish a standalone artifact, or use `streamlib link` for a local checkout \
+         you are still editing",
+        archive.display()
+    )]
+    PackageArchiveIsNotStandalone {
+        archive: std::path::PathBuf,
+        offenders: String,
+    },
+
     /// The archive carries a `streamlib.yaml` with no `package:` identity
     /// block, so the loader cannot derive the `@org/name` slot to materialize
     /// into.

--- a/runtime/streamlib-engine/src/core/runtime/module_loader/package_archive.rs
+++ b/runtime/streamlib-engine/src/core/runtime/module_loader/package_archive.rs
@@ -92,6 +92,10 @@ fn add_package_failure_to_add_module_error(
         AppModulesError::MissingPackageIdentity { .. } => {
             AddModuleError::PackageArchiveMissingPackageIdentity { archive }
         }
+        AppModulesError::PackageIsNotStandalone { offenders, .. }
+        | AppModulesError::InstallPackageIsNotStandalone { offenders, .. } => {
+            AddModuleError::PackageArchiveIsNotStandalone { archive, offenders }
+        }
         AppModulesError::StagePromoteFailed {
             package_dir,
             detail,
@@ -279,6 +283,38 @@ mod tests {
                 archive.display()
             ),
             "the extraction succeeded — the message must name the contents, not extraction"
+        );
+    }
+
+    /// A path artifact is a validation refusal, not a materialization failure.
+    /// Without its own arm it falls through to the stage-neutral catch-all,
+    /// which restates the archive path a second time — exactly what the arms
+    /// above exist to prevent.
+    #[test]
+    fn an_archive_carrying_a_path_artifact_names_the_offender_once() {
+        let app_root = tempfile::tempdir().unwrap();
+        let src = tempfile::tempdir().unwrap();
+        let archive = write_archive(
+            src.path(),
+            "path-artifact.slpkg",
+            &[entry(
+                "streamlib.yaml",
+                "package:\n  org: tatolab\n  name: camera\n  version: 1.0.0\n\
+                 patch:\n  '@tatolab/core':\n    path: ../core\n",
+            )],
+        );
+
+        let err = extract_failure(&archive, app_root.path());
+        assert!(
+            matches!(err, AddModuleError::PackageArchiveIsNotStandalone { .. }),
+            "{err:?}"
+        );
+        let rendered = err.to_string();
+        assert!(rendered.contains("../core"), "{rendered}");
+        assert_eq!(
+            rendered.matches(&archive.display().to_string()).count(),
+            1,
+            "the archive path must appear once, not restated by a nested Display: {rendered}"
         );
     }
 

--- a/sdk/streamlib-idents/Cargo.toml
+++ b/sdk/streamlib-idents/Cargo.toml
@@ -20,6 +20,9 @@ archive-test-fixtures = []
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 serde_json = { workspace = true }
+# Cargo-manifest parsing for the path-artifact guard — a materialized Rust
+# package's `Cargo.toml` is part of what `app_modules` installs.
+toml = { workspace = true }
 thiserror = { workspace = true }
 sha2 = { workspace = true }
 zip = "2.2"

--- a/sdk/streamlib-idents/src/app_modules.rs
+++ b/sdk/streamlib-idents/src/app_modules.rs
@@ -329,6 +329,34 @@ pub enum AppModulesError {
     #[error("'{source_label}' is not a valid streamlib package: {detail}")]
     InvalidPackage { source_label: String, detail: String },
 
+    /// The package carries a dev-time path artifact, so it resolves only on the
+    /// machine that authored it.
+    #[error(
+        "'{source_label}' carries path artifact(s) [{offenders}] — a path resolves only \
+         on the machine that wrote it, so the package is not installable. `add` and \
+         `install` take finalized artifacts; use `streamlib link` for a local checkout \
+         you are still editing"
+    )]
+    PackageIsNotStandalone {
+        source_label: String,
+        offenders: String,
+    },
+
+    /// A lockfile entry reproduces a package that carries a path artifact. Same
+    /// defect as [`AppModulesError::PackageIsNotStandalone`], reached through
+    /// `install` rather than `add`, and named by package because the user did
+    /// not type a source.
+    #[error(
+        "{package} carries path artifact(s) [{offenders}] — the lockfile pins a package \
+         that resolves only on the machine that wrote it, so it cannot be reproduced. \
+         Re-add it from a finalized artifact, or use `streamlib link` for a local \
+         checkout you are still editing"
+    )]
+    InstallPackageIsNotStandalone {
+        package: PackageRef,
+        offenders: String,
+    },
+
     /// The staged package's manifest has no `package:` identity block.
     #[error(
         "'{source_label}' has no `package:` block in its streamlib.yaml — a package \
@@ -598,6 +626,18 @@ impl AppModulesDir {
                 source_label: source_label.clone(),
                 detail: e.to_string(),
             })?;
+
+        // Refused here, before promote, so no slot and no lock entry ever
+        // records a package that resolves only on the machine that wrote it.
+        // Every container — folder, zip, tar.gz, module loader — reaches this
+        // one point, which is why the check cannot live producer-side.
+        refuse_path_artifacts(&staged_package_root, |offenders| {
+            AppModulesError::PackageIsNotStandalone {
+                source_label: source_label.clone(),
+                offenders,
+            }
+        })?;
+
         let package_meta =
             manifest
                 .package
@@ -1743,6 +1783,27 @@ fn sha256_hex(bytes: &[u8]) -> String {
 /// `content_hash` BEFORE promoting (so a mismatch leaves no partial slot),
 /// then atomically promote it into the package's slot. Shares the exact
 /// stage → locate → promote machinery `add_package` uses.
+/// Run the path-artifact predicate over a staged package root and let the
+/// caller name the subject: `add` knows the source the user typed, `install`
+/// knows the package the lockfile pinned, and neither should print the
+/// ephemeral staging directory that was actually scanned.
+fn refuse_path_artifacts(
+    staged_package_root: &Path,
+    to_error: impl FnOnce(String) -> AppModulesError,
+) -> Result<(), AppModulesError> {
+    let offenders = crate::path_artifact_guard::non_distributable_path_offenders(
+        staged_package_root,
+    )
+    .map_err(|e| AppModulesError::InvalidPackage {
+        source_label: staged_package_root.display().to_string(),
+        detail: format!("checking whether the package is standalone: {e}"),
+    })?;
+    if offenders.is_empty() {
+        return Ok(());
+    }
+    Err(to_error(offenders.join(", ")))
+}
+
 fn reproduce_materialized_from_lock(
     package: &PackageRef,
     source: AddPackageSource,
@@ -1760,6 +1821,21 @@ fn reproduce_materialized_from_lock(
         .map_err(|e| map_stage_error_to_install(package, e))?;
     let staged_root = locate_staged_package_root(staging.path(), &source, &source_label)
         .map_err(|e| map_stage_error_to_install(package, e))?;
+
+    // `install` reproduces from a lockfile written before this refusal existed,
+    // or from one a teammate committed, so the same guard `add_package` applies
+    // has to sit on this promote path too — otherwise a path-carrying package
+    // still reaches a slot, just through a different verb.
+    //
+    // Ordered before the content-hash verify below: "this package can never
+    // build anywhere" is the more actionable answer than "its bytes moved
+    // since you locked it" when both are true.
+    refuse_path_artifacts(&staged_root, |offenders| {
+        AppModulesError::InstallPackageIsNotStandalone {
+            package: package.clone(),
+            offenders,
+        }
+    })?;
 
     // Verify the reproduced contents against the pinned content hash BEFORE
     // promoting, so a mismatch leaves no partial slot (the staging dir is swept
@@ -2017,6 +2093,215 @@ mod tests {
             AddPackageSource::detect(at_dir.to_str().unwrap()).unwrap(),
             AddPackageSource::Folder { .. }
         ));
+    }
+
+    // =====================================================================
+    // Path artifacts — a package pinned to the machine that authored it
+    // =====================================================================
+
+    fn manifest_yaml_with_path_patch(org: &str, name: &str, version: &str) -> String {
+        format!(
+            "{}patch:\n  '@tatolab/core':\n    path: ../core\n",
+            manifest_yaml(org, name, version)
+        )
+    }
+
+    fn foo_package_entries_with_path_patch(
+        org: &str,
+        name: &str,
+        version: &str,
+    ) -> [(String, Vec<u8>); 2] {
+        [
+            (
+                Manifest::FILE_NAME.to_string(),
+                manifest_yaml_with_path_patch(org, name, version).into_bytes(),
+            ),
+            (
+                "schemas/foo_frame.yaml".to_string(),
+                SCHEMA_YAML.as_bytes().to_vec(),
+            ),
+        ]
+    }
+
+    fn write_package_folder_with_path_patch(dir: &Path) {
+        write_package_folder(dir, "tatolab", "camera", "2.0.0");
+        std::fs::write(
+            dir.join("streamlib.yaml"),
+            manifest_yaml_with_path_patch("tatolab", "camera", "2.0.0"),
+        )
+        .unwrap();
+    }
+
+    /// The defect (#1626): a dev-time `patch: path:` override installed
+    /// cleanly — slot materialized, lockfile written — and failed much later
+    /// inside the orchestrator's build, naming a missing path rather than the
+    /// unpublishable manifest that caused it.
+    #[test]
+    fn folder_add_refuses_a_manifest_carrying_a_path_patch_override() {
+        let src = tempfile::tempdir().unwrap();
+        write_package_folder_with_path_patch(src.path());
+        let app_root = tempfile::tempdir().unwrap();
+        let app = AppModulesDir::at(app_root.path());
+
+        let error = app
+            .add_package(
+                &AddPackageSource::Folder {
+                    path: src.path().to_path_buf(),
+                },
+                &AddPackageOptions::default(),
+            )
+            .expect_err("a path `patch:` override is not installable");
+
+        assert!(
+            matches!(error, AppModulesError::PackageIsNotStandalone { .. }),
+            "{error}"
+        );
+        let rendered = error.to_string();
+        assert!(rendered.contains("../core"), "{rendered}");
+        assert!(
+            rendered.contains("link"),
+            "the refusal must point at the local-development path: {rendered}"
+        );
+    }
+
+    /// A Cargo path dependency is the other half of the same defect, and the
+    /// half a manifest-only check would miss.
+    #[test]
+    fn folder_add_refuses_a_cargo_manifest_carrying_a_path_dependency() {
+        let src = tempfile::tempdir().unwrap();
+        write_package_folder(src.path(), "tatolab", "camera", "2.0.0");
+        std::fs::write(
+            src.path().join("Cargo.toml"),
+            "[package]\nname = \"camera\"\nversion = \"2.0.0\"\n\n\
+             [dependencies]\nstreamlib-plugin-sdk = { path = \"../../sdk/streamlib-plugin-sdk\" }\n",
+        )
+        .unwrap();
+        let app_root = tempfile::tempdir().unwrap();
+        let app = AppModulesDir::at(app_root.path());
+
+        let error = app
+            .add_package(
+                &AddPackageSource::Folder {
+                    path: src.path().to_path_buf(),
+                },
+                &AddPackageOptions::default(),
+            )
+            .expect_err("a Cargo path dependency is not installable");
+
+        assert!(
+            matches!(error, AppModulesError::PackageIsNotStandalone { .. }),
+            "{error}"
+        );
+        assert!(
+            error.to_string().contains("streamlib-plugin-sdk"),
+            "{error}"
+        );
+    }
+
+    /// The issue's own repro is a zip, and an archive source computes its
+    /// staged root differently from a folder — so the guard has to be proven on
+    /// that path too, not just asserted in prose.
+    #[test]
+    fn zip_add_refuses_a_package_carrying_a_path_patch_override() {
+        let app_root = tempfile::tempdir().unwrap();
+        let app = AppModulesDir::at(app_root.path());
+        let archive = app_root.path().join("camera.slpkg");
+        std::fs::write(
+            &archive,
+            package_archive_bytes(
+                &foo_package_entries_with_path_patch("tatolab", "camera", "2.0.0"),
+                ArchiveKind::Zip,
+                None,
+            ),
+        )
+        .unwrap();
+
+        let error = app
+            .add_package(
+                &AddPackageSource::Archive {
+                    path: archive.clone(),
+                },
+                &AddPackageOptions::default(),
+            )
+            .expect_err("a path `patch:` override is not installable from an archive either");
+
+        assert!(
+            matches!(error, AppModulesError::PackageIsNotStandalone { .. }),
+            "{error}"
+        );
+        assert!(
+            !error.to_string().contains(".staging-"),
+            "the refusal must name the source the user gave, not the ephemeral \
+             staging directory it was scanned in: {error}"
+        );
+    }
+
+    /// The whole point of refusing before promote: the old failure left a
+    /// materialized slot and a lockfile entry behind for a package that could
+    /// never build. Nothing may land — no slot, no lockfile, and no
+    /// `.staging-*` residue from the early return.
+    #[test]
+    fn a_refused_path_artifact_leaves_no_partial_state() {
+        let src = tempfile::tempdir().unwrap();
+        write_package_folder_with_path_patch(src.path());
+        let app_root = tempfile::tempdir().unwrap();
+        let app = AppModulesDir::at(app_root.path());
+
+        app.add_package(
+            &AddPackageSource::Folder {
+                path: src.path().to_path_buf(),
+            },
+            &AddPackageOptions::default(),
+        )
+        .expect_err("must refuse");
+
+        assert_no_partial_state(&app, &[], None);
+    }
+
+    /// `add` refuses a path-carrying package today, but a `streamlib.lock`
+    /// committed before that refusal existed — or written by a teammate —
+    /// still pins one. `install` reproduces through its own stage → promote
+    /// path, so the guard has to sit there too; otherwise the package reaches
+    /// a slot through a different verb and the defect is only half closed.
+    #[test]
+    fn install_from_lockfile_refuses_a_pinned_package_carrying_a_path_artifact() {
+        let src = tempfile::tempdir().unwrap();
+        write_package_folder(src.path(), "tatolab", "camera", "2.0.0");
+        let source_root = tempfile::tempdir().unwrap();
+        let source_app = AppModulesDir::at(source_root.path());
+        source_app
+            .add_package(
+                &AddPackageSource::Folder {
+                    path: src.path().to_path_buf(),
+                },
+                &AddPackageOptions::default(),
+            )
+            .expect("the clean package adds, producing the lock entry");
+
+        // The checkout gains a dev-time path override after it was locked.
+        std::fs::write(
+            src.path().join("streamlib.yaml"),
+            manifest_yaml_with_path_patch("tatolab", "camera", "2.0.0"),
+        )
+        .unwrap();
+
+        let dest_root = tempfile::tempdir().unwrap();
+        let dest = AppModulesDir::at(dest_root.path());
+        std::fs::copy(source_app.lockfile_path(), dest.lockfile_path()).unwrap();
+        let lock_bytes = std::fs::read(dest.lockfile_path()).unwrap();
+
+        let error = dest
+            .install_from_lockfile()
+            .expect_err("a pinned path-carrying package is not reproducible");
+
+        assert!(
+            matches!(error, AppModulesError::InstallPackageIsNotStandalone { .. }),
+            "{error}"
+        );
+        let rendered = error.to_string();
+        assert!(rendered.contains("@tatolab/camera"), "{rendered}");
+        assert!(rendered.contains("../core"), "{rendered}");
+        assert_no_partial_state(&dest, &[], Some(&lock_bytes));
     }
 
     // =====================================================================

--- a/sdk/streamlib-idents/src/lib.rs
+++ b/sdk/streamlib-idents/src/lib.rs
@@ -19,6 +19,7 @@ pub mod link_marker;
 mod lockfile;
 mod manifest;
 mod package_source;
+pub mod path_artifact_guard;
 mod release;
 mod resolver;
 mod semver;

--- a/sdk/streamlib-idents/src/path_artifact_guard.rs
+++ b/sdk/streamlib-idents/src/path_artifact_guard.rs
@@ -1,0 +1,140 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The one definition of "this package is pinned to the machine that wrote it".
+//!
+//! A path-flavored `patch:` override or a Cargo path dependency names a
+//! directory that exists only on the authoring machine. `add` and `install`
+//! take finalized artifacts; `link` is the local-development path. So a package
+//! carrying either is refused wherever it is materialized, whatever the
+//! container it arrived in.
+//!
+//! This lives beside [`crate::app_modules`] rather than in the publish tooling
+//! because the defect belongs to the materialization primitive: folder, zip,
+//! tar.gz, and the runtime module loader all funnel through the same staging
+//! path, and a producer-side-only guard is bypassable by construction once a
+//! plain directory installs without ever going through publish.
+
+use std::path::{Path, PathBuf};
+
+use crate::manifest::{DependencySpec, Manifest};
+
+/// Why a package cannot be materialized into an app's `streamlib_modules/`.
+#[derive(Debug, thiserror::Error)]
+pub enum PathArtifactError {
+    /// A package file could not be read.
+    #[error("read {path}: {detail}")]
+    Unreadable { path: PathBuf, detail: String },
+
+    /// A package file did not parse.
+    #[error("parse {path}: {detail}")]
+    Unparseable { path: PathBuf, detail: String },
+}
+
+/// Every path artifact `package_dir` carries, each rendered for a diagnostic.
+/// Empty means the package is standalone.
+///
+/// The one predicate every consumer is built from — `xtask install-packages`
+/// uses it to decide what it will not compile, the publish path to decide what
+/// it will not ship, and `app_modules` to decide what will not install. Two
+/// spellings would let one of those drift into a gap.
+///
+/// Callers render their own diagnostic: the subject worth naming differs
+/// (the source a user typed, versus the package a lockfile pinned), and the
+/// directory actually scanned is an ephemeral staging path that would mean
+/// nothing to a reader.
+pub fn non_distributable_path_offenders(
+    package_dir: &Path,
+) -> Result<Vec<String>, PathArtifactError> {
+    let mut offenders = path_patch_offenders(package_dir)?;
+    offenders.extend(cargo_path_dependency_offenders(package_dir)?);
+    Ok(offenders)
+}
+
+/// Path-flavored `patch:` overrides the package manifest declares.
+pub fn path_patch_offenders(package_dir: &Path) -> Result<Vec<String>, PathArtifactError> {
+    let manifest_path = package_dir.join(Manifest::FILE_NAME);
+    if !manifest_path.is_file() {
+        return Ok(Vec::new());
+    }
+    let body =
+        std::fs::read_to_string(&manifest_path).map_err(|e| PathArtifactError::Unreadable {
+            path: manifest_path.clone(),
+            detail: e.to_string(),
+        })?;
+    let manifest: Manifest =
+        serde_yaml::from_str(&body).map_err(|e| PathArtifactError::Unparseable {
+            path: manifest_path,
+            detail: e.to_string(),
+        })?;
+
+    Ok(manifest
+        .patch
+        .iter()
+        .filter_map(|(dependency_ref, spec)| match spec {
+            DependencySpec::Path(path_dependency) => Some(format!(
+                "`{dependency_ref}` → `{}`",
+                path_dependency.path.display()
+            )),
+            _ => None,
+        })
+        .collect())
+}
+
+/// Path dependencies the package's `Cargo.toml` declares.
+pub fn cargo_path_dependency_offenders(
+    package_dir: &Path,
+) -> Result<Vec<String>, PathArtifactError> {
+    let cargo_toml_path = package_dir.join("Cargo.toml");
+    if !cargo_toml_path.is_file() {
+        return Ok(Vec::new());
+    }
+    let body =
+        std::fs::read_to_string(&cargo_toml_path).map_err(|e| PathArtifactError::Unreadable {
+            path: cargo_toml_path.clone(),
+            detail: e.to_string(),
+        })?;
+    let document: toml::Value =
+        toml::from_str(&body).map_err(|e| PathArtifactError::Unparseable {
+            path: cargo_toml_path,
+            detail: e.to_string(),
+        })?;
+    Ok(cargo_path_dependency_names(&document))
+}
+
+/// Every dependency in a Cargo manifest declared with a `path` key, across
+/// `[dependencies]`, `[build-dependencies]`, `[dev-dependencies]`, and their
+/// `[target.<cfg>.*]` counterparts.
+fn cargo_path_dependency_names(document: &toml::Value) -> Vec<String> {
+    fn scan_dependency_table(table: &toml::value::Table, out: &mut Vec<String>) {
+        for (name, spec) in table {
+            if let toml::Value::Table(spec_table) = spec
+                && spec_table.contains_key("path")
+            {
+                out.push(name.clone());
+            }
+        }
+    }
+    fn scan_dependency_sections(root: &toml::value::Table, out: &mut Vec<String>) {
+        for key in ["dependencies", "build-dependencies", "dev-dependencies"] {
+            if let Some(toml::Value::Table(table)) = root.get(key) {
+                scan_dependency_table(table, out);
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    if let toml::Value::Table(root) = document {
+        scan_dependency_sections(root, &mut out);
+        if let Some(toml::Value::Table(targets)) = root.get("target") {
+            for target_table in targets.values() {
+                if let toml::Value::Table(table) = target_table {
+                    scan_dependency_sections(table, &mut out);
+                }
+            }
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}

--- a/tools/streamlib-pack/src/lib.rs
+++ b/tools/streamlib-pack/src/lib.rs
@@ -44,6 +44,14 @@ use streamlib_idents::{DependencySpec, Manifest};
 use streamlib_processor_schema::ProcessorLanguage;
 
 pub use streamlib_cargo_build::CargoProfile;
+// The path-artifact predicate now lives beside the materialization primitive
+// that also enforces it (`streamlib_idents::app_modules`). Re-exported so the
+// publish path, the whole-tree emit's skip set, and `xtask install-packages`
+// all keep reading one definition.
+pub use streamlib_idents::path_artifact_guard::non_distributable_path_offenders;
+use streamlib_idents::path_artifact_guard::{
+    cargo_path_dependency_offenders, path_patch_offenders,
+};
 
 pub mod catalog;
 pub mod dependency_reconcile;
@@ -928,7 +936,7 @@ fn ensure_no_path_artifacts(pkg_dir: &Path) -> Result<()> {
         );
     }
 
-    let cargo_offenders = cargo_path_dep_offenders(pkg_dir)?;
+    let cargo_offenders = cargo_path_dependency_offenders(pkg_dir)?;
     if !cargo_offenders.is_empty() {
         anyhow::bail!(
             "{} declares path dependenc(ies) [{}] — a published package must be \
@@ -940,59 +948,6 @@ fn ensure_no_path_artifacts(pkg_dir: &Path) -> Result<()> {
         );
     }
     Ok(())
-}
-
-/// Names of dependency-table `path` deps in `<pkg_dir>/Cargo.toml` — the same
-/// scan [`ensure_no_path_artifacts`] rejects on. Empty when the Cargo.toml is
-/// absent or carries only version-resolved deps. Reads + parses the Cargo.toml
-/// then defers to [`cargo_path_dep_names`], so a `[[bin]].path` / `[lib].path`
-/// TARGET path never counts — only dependency tables are scanned.
-fn cargo_path_dep_offenders(pkg_dir: &Path) -> Result<Vec<String>> {
-    let cargo_path = pkg_dir.join("Cargo.toml");
-    if !cargo_path.exists() {
-        return Ok(Vec::new());
-    }
-    let body = std::fs::read_to_string(&cargo_path)
-        .with_context(|| format!("read {}", cargo_path.display()))?;
-    let doc: toml::Value =
-        toml::from_str(&body).with_context(|| format!("parse {}", cargo_path.display()))?;
-    Ok(cargo_path_dep_names(&doc))
-}
-
-/// Names of dependencies carrying a `path` key across every dependency table
-/// in a parsed `Cargo.toml` — `[dependencies]`, `[build-dependencies]`,
-/// `[dev-dependencies]`, and their `[target.<cfg>.…]` variants.
-fn cargo_path_dep_names(doc: &toml::Value) -> Vec<String> {
-    fn scan_dep_table(table: &toml::value::Table, out: &mut Vec<String>) {
-        for (name, spec) in table {
-            if let toml::Value::Table(t) = spec {
-                if t.contains_key("path") {
-                    out.push(name.clone());
-                }
-            }
-        }
-    }
-    fn scan_section(root: &toml::value::Table, out: &mut Vec<String>) {
-        for key in ["dependencies", "build-dependencies", "dev-dependencies"] {
-            if let Some(toml::Value::Table(t)) = root.get(key) {
-                scan_dep_table(t, out);
-            }
-        }
-    }
-    let mut out = Vec::new();
-    if let toml::Value::Table(root) = doc {
-        scan_section(root, &mut out);
-        if let Some(toml::Value::Table(targets)) = root.get("target") {
-            for (_cfg, tbl) in targets.iter() {
-                if let toml::Value::Table(t) = tbl {
-                    scan_section(t, &mut out);
-                }
-            }
-        }
-    }
-    out.sort();
-    out.dedup();
-    out
 }
 
 /// Whether a directory-entry name is a build artifact / dev-only file
@@ -1301,56 +1256,6 @@ fn manifest_bytes_for(pkg_dir: &Path, policy: PathDepPolicy) -> Result<Vec<u8>> 
         }
         PathDepPolicy::RewriteRelativeToAbsolute => rewrite_manifest_path_deps_absolute(pkg_dir),
     }
-}
-
-/// Names every path-flavor `patch:` entry in `<pkg_dir>/streamlib.yaml` —
-/// dev-time overrides that don't generalize to a distributed artifact. An
-/// empty result means the package is publishable through this gate; a
-/// non-empty one lists each offender (`` `dep` → `path` ``). A missing
-/// manifest is treated as no offenders.
-///
-/// The predicate the whole-tree static package-source emit skips on and the CLI
-/// `.slpkg` gate rejects on share this one definition — the skip is the same
-/// condition, sound by construction rather than a proxy. Filters exactly
-/// [`DependencySpec::Path`], so git/version-range `patch:` overrides never count.
-pub(crate) fn path_patch_offenders(pkg_dir: &Path) -> Result<Vec<String>> {
-    let manifest_path = pkg_dir.join(Manifest::FILE_NAME);
-    if !manifest_path.exists() {
-        return Ok(Vec::new());
-    }
-    let body = std::fs::read_to_string(&manifest_path)
-        .with_context(|| format!("read {}", manifest_path.display()))?;
-    let manifest: Manifest = serde_yaml::from_str(&body)
-        .with_context(|| format!("parse {}", manifest_path.display()))?;
-    Ok(manifest
-        .patch
-        .iter()
-        .filter_map(|(dep_ref, spec)| match spec {
-            DependencySpec::Path(p) => Some(format!("`{}` → `{}`", dep_ref, p.path.display())),
-            _ => None,
-        })
-        .collect())
-}
-
-/// Every non-distributable path artifact in a package dir — the union of
-/// `streamlib.yaml` path-`patch:` overrides ([`path_patch_offenders`]) and
-/// Cargo.toml dependency-table `path` deps ([`cargo_path_dep_offenders`]).
-///
-/// [`ensure_no_path_artifacts`] rejects on these exact same two helpers for
-/// the [`AssembleTarget::Slpkg`] target, so the whole-tree static package-source
-/// emit's skip predicate keys on the same condition it would otherwise
-/// hard-fail on: the skip set equals the rejection set, sound by construction
-/// (one shared definition per half) rather than a proxy. TARGET paths
-/// (`[[bin]].path` / `[lib].path`) are not dependency paths and never count.
-///
-/// `pub` so the `install-packages` CI enumerator (xtask) drives its skip set
-/// from this exact predicate — the same one the whole-tree emit and the
-/// single-package pack hard-fail on — so the CI skip set equals the emit skip
-/// set by construction rather than a re-derived YAML list.
-pub fn non_distributable_path_offenders(pkg_dir: &Path) -> Result<Vec<String>> {
-    let mut offenders = path_patch_offenders(pkg_dir)?;
-    offenders.extend(cargo_path_dep_offenders(pkg_dir)?);
-    Ok(offenders)
 }
 
 /// Reject path-flavor `patch:` entries (dev-time overrides that don't


### PR DESCRIPTION
Closes #1626. Stacked on #1670.

## What

A package folder — or a hand-made zip of one — carrying a dev-time path `patch:` override, or a `Cargo.toml` path dependency, **installed cleanly**. `streamlib add` reported success, the slot was materialized, the lockfile recorded it, and the failure surfaced much later inside the orchestrator's build as a missing path, naming nothing about the unpublishable manifest that caused it.

`add` and `install` take finalized artifacts; `link` is the local-development path. So a package pinned to the machine that authored it is refused **unconditionally**, wherever it is materialized.

## Why the old guard couldn't catch it

The only path-artifact guard was producer-side — `ensure_no_path_artifacts`, reached from `assemble_artifact`'s `Slpkg` branch. Before #1598/#1622 that was mostly sufficient, because the way to get an installable artifact was to run it through pack. Now that a plain directory or any zip/tar.gz installs and loads directly, the producer-side guard is **bypassable by construction**: you simply never call pack.

## Moved down, not duplicated

`non_distributable_path_offenders` and its two halves move **down** into `streamlib-idents::path_artifact_guard`, beside the `app_modules` materialization primitive that now enforces them; `streamlib-pack` re-exports the predicate.

That keeps one definition — `xtask install-packages` uses it to decide what it will not compile, the publish path to decide what it will not ship, and `app_modules` to decide what will not install. Writing a second guard in the consumer layer would have been the parallel-system move the doctrine forbids, and would let the skip set and the reject set drift.

The move is behavior-preserving for existing callers. Only change: `.exists()` → `.is_file()`, so a *directory* named `streamlib.yaml` yields empty rather than a read error.

## Both promote paths, not just the obvious one

`app_modules` has two stage → promote paths. The first review pass only guarded one.

- `add_package`
- `install_from_lockfile` → `reproduce_materialized_from_lock` — a lockfile committed **before this refusal existed**, or written by a teammate, still pins a path-carrying package. Reproducing it would reach a slot through a different verb, leaving the defect half-closed.

On the reproduce path the standalone check is ordered before the content-hash verify: *"this can never build anywhere"* is more actionable than *"its bytes moved since you locked it"* when both are true.

The refusal fires after the staged manifest loads and before promote, so a refused package leaves **no slot, no lockfile entry, and no `.staging-*` residue**.

## Diagnostics name something the reader recognises

Each caller renders its own message rather than sharing one, because the subject worth naming differs — the source a user typed, the package a lockfile pinned, the archive the loader was handed. The directory actually scanned is an ephemeral `.staging-<pid>-<n>` path that would mean nothing to a reader; a test asserts it never appears in the message.

The loader's per-stage taxonomy gets its own arm (`PackageArchiveIsNotStandalone`) so a validation refusal isn't mis-staged as a materialization failure, with a test asserting the archive path appears **once** rather than being restated by a nested `Display`.

Publish-time diagnostics are unchanged: an author publishing is told how to make the package standalone, not to use `link`.

## Tests

Five new, each mental-revert verified:

- folder + path `patch:` override → refused
- folder + Cargo path dependency → refused (the half a manifest-only check misses)
- **zip** + path `patch:` override → refused, and the message names the source rather than the staging dir (an archive computes its staged root differently from a folder — the issue's own repro is a zip)
- refusal leaves no partial state (`assert_no_partial_state`: no slot, no lockfile, no `.staging-*`)
- **`install_from_lockfile`** on a lock pinning a path-carrying package → refused, no partial state
- plus the loader-taxonomy test above

`streamlib-idents` 250 pass · `streamlib-pack` 73 · `streamlib-cli` 105 · engine `module_loader` 167.

## Notes for the reviewer

- **New dependency:** `toml` on `streamlib-idents`, to read a materialized package's `Cargo.toml`. Small next to the crate's existing `zip` / `tar` / `ureq`, and it's part of what `app_modules` installs.
- **`link_package` is deliberately unguarded** — linking a local checkout is exactly what should be allowed.
- **Not fixed, reported:** `Strategy::Git` fetches a checkout and loads it in place without materializing, so a git-sourced package with a path dep still fails deep in the build. Same symptom class, different path, out of this issue's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
