### PR TITLE
plan: decide §Product — the MVP sentence

### DIFF
--- a/docs/decisions/product-mvp-sentence.md
+++ b/docs/decisions/product-mvp-sentence.md
@@ -1,0 +1,82 @@
+# The MVP sentence — why this shape
+
+Rationale for the `[product-mvp-sentence]` entries in `docs/plan/ARCHITECTURE.md`
+§Product, decided in an /align session on 2026-07-29.
+
+## Trigger
+
+Read this when scoping work against the MVP sentence, when tempted to widen the MVP's
+audience/platform/language, or when a "simpler" proposal reintroduces a manifest, an
+entry-point config, or an engine-side schema check.
+
+## Decision
+
+The MVP promises the **developer experience**, not the capability. Camera → processor →
+display pipelines, shader/compute processors, and packages already exist and work; what
+does not exist is the simplified experience around them. The sentence:
+
+> A Python developer on Linux with an NVIDIA GPU installs streamlib from PyPI, runs
+> `streamlib new` then `streamlib dev`, sees their camera live in a window within a
+> minute, and makes the pipeline theirs by editing the scaffolded processor — zero
+> ceremony: no manifest, no `main()`, no schema wrangling, hot-reload on save.
+
+Its load-bearing terms:
+
+- **Python consumer.** Python vision/ML developers are the audience for realtime GPU
+  pipelines without writing Vulkan.
+- **PyPI ships the single binary** (CLI + runtime + build orchestration) — the ruff/uv
+  pattern: one install, no toolchain, native motion for the persona.
+- **Batteries-included scaffold.** `streamlib new` generates a *working* camera →
+  effect → display app with dependencies already installed; first `streamlib dev` shows
+  live video before any code is written; the user's first act is editing the scaffolded
+  effect processor already wired into the pipeline. This create-next-app moment is most
+  of what "amazing DevEx" means, and it is the integration piece that was missing from
+  the CLI-forward design (which scaffolds plugins only).
+- **`app.py` + `setup(rt)` by convention, `-f` override.** Matches what Python
+  developers rely on (Flask defaults to `app.py`; FastAPI's `uvicorn main:app` is the
+  explicit variant); the override keeps the point-at-a-script launch.
+- **Apps carry no manifest.** The npm model: `add`/`link` write `streamlib.lock`,
+  `streamlib_modules/` holds the installed set, and the identity label exists only
+  because a package is shared. An app promotes to a package by adding the label.
+- **App-local processors use the plugin discovery scan** on the app's `processors/`
+  folder, minted `@app/local/<Name>`. Two reference spellings resolve to one
+  registration: the string id, or the imported class — the decorated class carries its
+  identity; importing it in `app.py` attaches metadata only, execution stays in the
+  engine-spawned subprocess. The class form keeps go-to-definition and type checking
+  working, which is also what makes the loop agent-friendly (small `app.py`, one obvious
+  processor file, `graph`/`tap` to verify an edit landed).
+- **`add`/`connect` is the pipeline API** — the existing primitive, explicit about
+  ports.
+
+## Rejected alternatives
+
+- **Polyglot MVP** — an MVP addressed to everyone ships for no one. Rust authoring stays
+  a supported capability for hardware-facing packages (C++ later), outside the sentence.
+  TypeScript is deliberately de-prioritized: live-visual-effects users are better served
+  eventually by processors exposing web-based authoring than by a first-class TS
+  consumer story.
+- **Broader platform floor (any Vulkan GPU, macOS)** — promises verification work that
+  does not exist; Linux + NVIDIA is where the code is.
+- **curl-installer as primary channel** — worse first touch for a pip-native audience;
+  can be added later.
+- **Minimal (empty) scaffold** — kills the first-run payoff; the zero-to-video minute is
+  the pitch.
+- **Entry point named in a config file** — ceremony returning through the side door.
+- **Every app is also a package** — a consumer needs no publishable identity; forcing
+  one re-creates the manifest ceremony being removed.
+- **Import-only or strings-only local processors** — import-only forks the discovery
+  model from plugins; strings-only loses IDE/agent ergonomics. One mechanism, two
+  spellings, costs neither.
+- **Higher-level pipeline API now** (chaining sugar, declarative graphs, or a
+  Holoscan-style `compose()` subclass) — the subclass shape is *more* ceremony than
+  `setup(rt)`; sugar remains compatible later where port inference is unambiguous.
+
+## Consequences
+
+- The zero-ceremony bar makes the schema-agreement rip-out (no engine schema matching,
+  cast-at-read, no versions at the code layer) MVP-blocking work, not cleanup.
+- `streamlib new` (app scaffold) is a new command to design and build.
+- Existing Rust plugins port to the new format as the final step, so they install as
+  modules; consumer examples continue to lag by design until then.
+- The MVP claim is narrow (one persona, one platform, one GPU vendor) and must be kept
+  honest: widening any axis is a plan change, not a ticket.

--- a/docs/plan/ARCHITECTURE.md
+++ b/docs/plan/ARCHITECTURE.md
@@ -10,8 +10,27 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
 
 ## Product (the MVP sentence)
 
-- **OPEN** — One sentence a real user acts on: what they install, what they run, what they see.
-  Every ticket traces to this sentence or does not exist.
+- **DECIDED** — A Python developer on Linux with an NVIDIA GPU installs streamlib from
+  PyPI, runs `streamlib new` then `streamlib dev`, sees their camera live in a window
+  within a minute, and makes the pipeline theirs by editing the scaffolded processor —
+  zero ceremony: no manifest, no `main()`, no schema wrangling, hot-reload on save.
+  Every ticket traces to this sentence or does not exist. [product-mvp-sentence]
+- **DECIDED** — Terms of the sentence: PyPI ships the single binary (CLI + runtime +
+  orchestrator); platform floor is Linux + NVIDIA; `streamlib new` scaffolds a working
+  camera → effect → display app with dependencies already installed — first `streamlib
+  dev` shows live video before any editing; `dev`/`run` find `app.py`'s `setup(rt)` by
+  convention, `-f <file>` overrides; an app carries no manifest (entry file +
+  `streamlib.lock` + `streamlib_modules/`) and promotes to a package by adding the
+  identity label; app-local processors live in `processors/`, discovered by the same
+  scan as plugins, minted `@app/local/<Name>`, and `rt.add` accepts the string id or
+  the imported class; the pipeline API is `add`/`connect`. [product-mvp-sentence]
+- **DECIDED** — The zero-ceremony bar (the sentence is untrue until all hold): no
+  manifest authoring; no boilerplate entry; bags/schemas fixed (no engine schema
+  matching, cast-at-read, no versions at the code layer); scaffolding commands for
+  app, plugin, processor, and schema. [product-mvp-sentence]
+- **DECIDED** — Rust processor authoring (C++ later) stays a supported capability for
+  hardware-facing packages, outside the MVP sentence; existing Rust plugins port to
+  the new format as the final step, so they install as modules. [product-mvp-sentence]
 
 ## Module system — packages, versions, imports
 

--- a/docs/plan/GLOSSARY.md
+++ b/docs/plan/GLOSSARY.md
@@ -19,6 +19,10 @@ directory.
 **Link**: the sole local-development path for consuming a package from a folder.
 `add`/`install` take finalized artifacts only.
 
+**App**: a consumer of packages — an entry file (`app.py` defining `setup(rt)`) plus
+`streamlib.lock` and `streamlib_modules/`; carries no manifest. Promotes to a package by
+adding the identity label. _Avoid_: "project", "consumer app" (redundant).
+
 **Processor**: the unit of pipeline computation, declared with `#[processor]` and wired
 by ports.
 


### PR DESCRIPTION
## What

/align session (2026-07-29) flipping §Product OPEN → DECIDED in `docs/plan/ARCHITECTURE.md`:

> A Python developer on Linux with an NVIDIA GPU installs streamlib from PyPI, runs `streamlib new` then `streamlib dev`, sees their camera live in a window within a minute, and makes the pipeline theirs by editing the scaffolded processor — zero ceremony: no manifest, no `main()`, no schema wrangling, hot-reload on save.

Plus three supporting DECIDED entries: the terms of the sentence (PyPI ruff-pattern install, Linux+NVIDIA floor, batteries-included `streamlib new` scaffold, `app.py`+`setup(rt)` convention with `-f` override, manifest-free apps with promotion-by-identity-label, one-discovery-two-spellings local processors, `add`/`connect` API), the zero-ceremony bar, and the Rust-authoring capability line.

Also:
- `docs/plan/GLOSSARY.md`: adds **App**.
- `docs/decisions/product-mvp-sentence.md`: rationale (Trigger / Decision / Rejected alternatives / Consequences).

## Notes

- Owner-approved in-session at every step (batch-grilling rounds; final section restate confirmed).
- Consequence worth flagging for follow-up sessions: the zero-ceremony bar makes the schema-agreement rip-out MVP-blocking; `streamlib new` (app scaffold) is a new command the CLI-forward design didn't include.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxEKuEbR3vqZCSFdZaYete