### PR TITLE
plan: decide §Processor model & scheduling — cast-not-contract data plane

### DIFF
--- a/docs/decisions/data-plane-cast-not-contract.md
+++ b/docs/decisions/data-plane-cast-not-contract.md
@@ -1,0 +1,53 @@
+# Data plane: cast, not contract
+
+Rationale for the `[data-plane-cast-not-contract]` entries in
+`docs/plan/ARCHITECTURE.md` §Processor model & scheduling, decided 2026-07-29.
+
+## Trigger
+
+Read this before designing anything that compares a producer's and a consumer's schema
+declarations, adds a version check to the data path, refuses or warns a `connect` based
+on types, or attaches channel policy to a schema definition.
+
+## Decision
+
+A link is pure plumbing — output port → input port, carrying a bag. Typing is
+unilateral: the producer declares what it writes, the consumer declares what it reads,
+and the two declarations are hints that are never compared. Consuming is a cast at read
+time (in the spirit of TypeScript `as` or parsing an arbitrary object with zod): success
+is decided by the bag's actual shape, not by matching declared identities. The engine
+mediates no schema agreement — connect always wires (an advisory log line when two
+declared hints differ is acceptable; refusal is not), nothing matches tags per read, the
+wire tag survives only as inert observability metadata, and versions never appear at the
+code layer: version is a resolution-time concern (install/link + lockfile, the
+node_modules model).
+
+Channel policy (delivery profile, ring depth, overflow) is declared port-locally at the
+consuming input port — policy is not type information and never rides a schema. A
+concretely-typed input port with no declared delivery profile is a wiring error, not a
+silent default.
+
+## Rejected alternatives
+
+- **Engine-mediated schema agreement (strict/loose connect, per-read tag matching)** —
+  re-couples the two ends the design keeps independent, and breaks down across languages
+  and across nodes, where the other end's declarations aren't reachable.
+- **Version matching on the data path** — created a bug class of its own (version-blind
+  sentinel vs version-carrying peers compared with `==`), and contradicts the
+  node_modules model where using code never sees versions.
+- **Schema-carried channel policy** — policy piggybacking on type identity; has no
+  cross-host carrier under mesh transports, so each endpoint must be able to derive its
+  policy locally from its own port declaration.
+- **Silent delivery-profile default** — sample-stream payloads (audio, encoded video)
+  silently degraded to latest-wins would drop data without any visible error.
+
+## Consequences
+
+- The trade is explicit: less static strictness for better developer experience and
+  simpler language-to-language and node-to-node interop — a cast either works or it
+  doesn't, regardless of who produced the bag.
+- Type mismatches surface as runtime read failures at the consumer, not wiring errors.
+- The existing agreement machinery, strict-connect posture, per-read expected-schema
+  plumbing, and load-bearing wire-tag version fields are unintended shape to be removed;
+  per §Product's zero-ceremony bar this removal is MVP-blocking work.
+- The wire tag stays for tap, debugging, and catalog display only.

--- a/docs/decisions/execution-model.md
+++ b/docs/decisions/execution-model.md
@@ -1,0 +1,43 @@
+# Execution model: blessed as built, flavors intended but undesigned
+
+Rationale for the `[execution-model]` entries in `docs/plan/ARCHITECTURE.md`
+§Processor model & scheduling, decided 2026-07-29.
+
+## Trigger
+
+Read this before adding execution or scheduling options, proposing a thread pool or
+async runtime for processors, or treating the unreferenced execution-flavor components
+as dead code to delete.
+
+## Decision
+
+The implemented model is the decided model: three execution modes (reactive / manual /
+continuous); one dedicated OS thread per processor; thread priority driven by the
+processor's registered descriptor (realtime / high / normal), never by name heuristics;
+synchronous lifecycle traits (no host async runtime — a processor needing async builds
+its own in setup); and the Full/Limited capability typestate on the phase axis
+(setup/teardown privileged, process limited).
+
+Additional execution flavors — green-thread-style lightweight scheduling and similar —
+are intended so one node can scale to many more processors than one OS thread each
+allows, trading some realtime guarantees; dedicated threads remain the path for
+realtime processors. The design is unstarted, so the plan records this OPEN with
+direction: do not build until designed, and the design must not add configuration
+dials — flavor selection arrives via defaults and derivation, not new knobs in
+processor declarations.
+
+## Rejected alternatives
+
+- **Blessing flavors as DECIDED now** — commits to a design that doesn't exist.
+- **Dropping the flavor intent from the plan** — loses a settled owner intent and
+  invites deleting the component-layer groundwork as cleanup.
+- **Name-heuristic thread priority** — already replaced by descriptor-driven priority;
+  recorded here so it doesn't return.
+- **A host-provided async runtime for processors** — the synchronous trait surface is
+  the contract; embedding an async runtime in the host couples every plugin to it.
+
+## Consequences
+
+- The execution-flavor components stay in the tree as groundwork, not residue.
+- Any future flavor design is DevEx-gated: the configuration surface must not grow.
+- Realtime processors keep dedicated threads regardless of what flavors are added.

--- a/docs/plan/ARCHITECTURE.md
+++ b/docs/plan/ARCHITECTURE.md
@@ -42,7 +42,23 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
 
 ## Processor model & scheduling
 
-- **OPEN**
+- **DECIDED** — A link is pure plumbing: output port → input port, carrying a bag
+  (self-describing msgpack named map). Producer and consumer type declarations are
+  unilateral hints, never compared; consuming is a cast at read time. The engine
+  mediates no schema agreement: connect never refuses a link (advisory log at most),
+  no per-read tag matching, the wire tag is inert observability metadata, and versions
+  never appear at the code layer — resolution-time only. [data-plane-cast-not-contract]
+- **DECIDED** — Channel policy (delivery profile, ring depth, overflow) is declared
+  port-locally at the consuming input port, never carried by schemas; a concretely-typed
+  input port with no declared delivery profile is a wiring error, not a silent default.
+  [data-plane-cast-not-contract]
+- **DECIDED** — Three execution modes (reactive / manual / continuous); one dedicated
+  OS thread per processor with descriptor-driven priority (realtime / high / normal);
+  synchronous lifecycle traits; Full/Limited capability typestate on the phase axis
+  (setup/teardown vs process). [execution-model]
+- **OPEN** — Additional execution flavors to scale processor count (lightweight /
+  green-thread style): intended, do not build until designed; hard constraint — no new
+  configuration dials. [execution-model]
 
 ## Graphics (RHI / GPU)
 

--- a/docs/plan/GLOSSARY.md
+++ b/docs/plan/GLOSSARY.md
@@ -23,6 +23,9 @@ directory.
 `streamlib.lock` and `streamlib_modules/`; carries no manifest. Promotes to a package by
 adding the identity label. _Avoid_: "project", "consumer app" (redundant).
 
+**Bag**: the self-describing msgpack named map a link carries — the schema-free view of
+a payload; consumers cast it to a type at read time. _Avoid_: "message", "envelope".
+
 **Processor**: the unit of pipeline computation, declared with `#[processor]` and wired
 by ports.
 


### PR DESCRIPTION
## What

/align session (2026-07-29), follows #1675 (merged). Flips §Processor model & scheduling:

- **DECIDED** — links are pure plumbing carrying bags; producer/consumer declarations are unilateral hints; consuming is a cast at read time; the engine mediates no schema agreement (connect never refuses, no per-read tag matching, wire tag inert, versions resolution-time only). `[data-plane-cast-not-contract]`
- **DECIDED** — channel policy is port-local at the consuming input port; missing delivery profile on a concretely-typed input is a wiring error, not a silent default. `[data-plane-cast-not-contract]`
- **DECIDED** — the implemented execution model is blessed: three modes, dedicated thread per processor with descriptor-driven priority, synchronous lifecycle, Full/Limited phase typestate. `[execution-model]`
- **OPEN with direction** — lightweight/green-thread execution flavors: intended, do not build until designed, no new configuration dials. `[execution-model]`

Also: **Bag** glossary term; ADRs `docs/decisions/data-plane-cast-not-contract.md` and `docs/decisions/execution-model.md`.

## Notes

- Transcribes the owner's 2026-07-29 /reconcile-understanding corrections into the plan; per §Product's zero-ceremony bar, the schema-agreement rip-out is now plan-anchored MVP-blocking work (tickets via /propose-change → /derive-tickets, not this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxEKuEbR3vqZCSFdZaYete