### PR TITLE
plan: decide §Control plane & observability — one surface, one binary

### DIFF
--- a/docs/decisions/control-plane-one-surface.md
+++ b/docs/decisions/control-plane-one-surface.md
@@ -1,0 +1,50 @@
+# One control-plane surface
+
+Rationale for the `[control-plane-one-surface]` entries in `docs/plan/ARCHITECTURE.md`
+§Control plane & observability, decided 2026-07-29.
+
+## Trigger
+
+Read this before adding any second way to inspect or mutate a running node (a new
+socket, a bespoke CLI channel, a side API), before moving or duplicating the api-server,
+or before changing node discovery or the tap's delivery guarantees.
+
+## Decision
+
+There is exactly one control plane: the api-server's HTTP + WebSocket + MCP surface,
+hosted in-process by any runtime that enables it. The MCP tool set is the canonical
+control vocabulary — the CLI is a pure JSON-RPC client of the same tools agents call, so
+humans, scripts, and agents drive identical verbs; REST/WS routes expose the same
+operations for programmatic clients. The api-server is engine-side infrastructure and
+relocates into the `runtime/` tree: it is a host (statically linked, never dlopen'd) and
+cannot follow the packages tree out of the repo.
+
+Node discovery is a per-user on-disk registry — one JSON file per live node in the OS's
+standard per-user runtime directory — written only by control-plane-hosting runtimes and
+pruned only when both liveness signals (a control round-trip and a process check) fail.
+
+Observability: the JSONL log schema is a durable contract; tap forwards bags verbatim
+(no transcode) and trades completeness for guaranteed non-interference with the
+pipeline; graph and health inspection ride the same control plane.
+
+Auth and remote-access posture remain OPEN — nothing here decides a security model.
+
+## Rejected alternatives
+
+- **A second control path** (bespoke CLI socket, side-channel debug API) — two
+  vocabularies drift; agents and humans stop seeing the same system.
+- **api-server as a distributable package** — it drives the registry, pubsub, and the
+  graph API; a host cannot cross the plugin ABI, and its current home made it a standing
+  exception to "packages are downstream consumers."
+- **A discovery daemon or well-known port** — files in the per-user runtime directory
+  need no daemon, survive nothing they shouldn't, and prune safely on double-dead
+  evidence.
+- **A lossless tap** — a parked tap consumer on a lossless channel back-pressures the
+  source processor; verbatim-but-droppable is the deliberate trade.
+
+## Consequences
+
+- New control verbs are added once, as MCP tools, and every client gets them.
+- Relocating the api-server is engine-tree work to schedule; until it lands the plan
+  supersedes the old "exception" framing.
+- Remote access and auth need their own decision before any networked-control work.

--- a/docs/decisions/single-binary-launch.md
+++ b/docs/decisions/single-binary-launch.md
@@ -1,0 +1,40 @@
+# One shipped binary, embeddable library
+
+Rationale for the `[single-binary-launch]` entry in `docs/plan/ARCHITECTURE.md`
+§Control plane & observability, decided 2026-07-29.
+
+## Trigger
+
+Read this before adding a second executable, before wiring `run`/`dev` to spawn a
+separate runtime process, or when someone asks whether streamlib can be embedded in
+another application.
+
+## Decision
+
+One shipped binary — `streamlib` — bundles the CLI, the runtime host, and build
+orchestration. `streamlib run` and `streamlib dev` host the runtime in-process (the
+Rust path compiles a generated-main harness around the user's entry; Python/TS entries
+run through the subprocess SDK bound to the control plane). The standalone
+streamlib-runtime binary retires.
+
+Embeddability is unaffected, because the binary is packaging, not architecture: the
+engine remains an ordinary embeddable Rust library that a host application (an
+Isaac-Sim-style app, a custom tool) links and drives in-process, and non-Rust hosts
+embed by driving a runtime through the client-SDK / control-plane path.
+
+## Rejected alternatives
+
+- **Two binaries (CLI spawns a runtime executable)** — two hosts drift, two artifacts
+  ship, and the subprocess indirection buys nothing the in-process host doesn't already
+  provide.
+- **Binary-only runtime (no library path)** — kills legitimate Rust embedding; the
+  library is the substrate, the binary is one consumer of it.
+
+## Consequences
+
+- PyPI ships exactly one artifact; there is no version skew between "the CLI" and "the
+  runtime."
+- Retiring the standalone runtime binary is engine-tree work to schedule; its
+  boot/registry behaviors move into the CLI-hosted path.
+- The client SDK (launch + control from Python/TS) is a real surface the plan now
+  depends on for the embedding story.

--- a/docs/plan/ARCHITECTURE.md
+++ b/docs/plan/ARCHITECTURE.md
@@ -84,4 +84,23 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
 
 ## Control plane & observability
 
-- **OPEN**
+- **DECIDED** — One control plane: the api-server's HTTP + WebSocket + MCP surface,
+  hosted in-process by any runtime that enables it. The MCP tool set is the canonical
+  control vocabulary; the CLI is a pure JSON-RPC client of it — agents and humans drive
+  the same verbs; REST/WS routes serve the same operations for programmatic clients.
+  [control-plane-one-surface]
+- **DECIDED** — The api-server is engine-side infrastructure and relocates into the
+  `runtime/` tree: it is a host — statically linked, never dlopen'd — and cannot follow
+  the packages tree out of the repo. [control-plane-one-surface]
+- **DECIDED** — One shipped binary (CLI + runtime + build orchestration): `run`/`dev`
+  host the runtime in-process; the standalone streamlib-runtime binary retires. The
+  engine remains an embeddable Rust library for host apps; non-Rust embedding drives a
+  runtime through the client-SDK / control-plane path. [single-binary-launch]
+- **DECIDED** — Node discovery is a per-user on-disk registry — one JSON file per live
+  node in the OS's standard per-user runtime directory — written only by
+  control-plane-hosting runtimes, pruned only when both liveness signals (control
+  round-trip, process check) fail. [control-plane-one-surface]
+- **DECIDED** — Observability: the JSONL log schema is a durable contract; tap forwards
+  bags verbatim, trading completeness for guaranteed non-interference; graph and health
+  inspection ride the same control plane. [control-plane-one-surface]
+- **OPEN** — Auth and remote-access posture.

--- a/docs/plan/GLOSSARY.md
+++ b/docs/plan/GLOSSARY.md
@@ -26,6 +26,13 @@ adding the identity label. _Avoid_: "project", "consumer app" (redundant).
 **Bag**: the self-describing msgpack named map a link carries — the schema-free view of
 a payload; consumers cast it to a type at read time. _Avoid_: "message", "envelope".
 
+**Control plane**: the HTTP/WebSocket/MCP surface a runtime hosts for inspection and
+mutation; the CLI and client SDKs are its clients. _Avoid_: "API server" as the concept
+(that is the component hosting it).
+
+**Node**: a live runtime reachable over its control plane; discovered via the per-user
+on-disk registry. _Avoid_: "instance", "server".
+
 **Processor**: the unit of pipeline computation, declared with `#[processor]` and wired
 by ports.
 

--- a/docs/plan/diagrams/system.mmd
+++ b/docs/plan/diagrams/system.mmd
@@ -4,11 +4,12 @@ flowchart LR
     apps["Example apps"]
   end
 
-  cli["streamlib CLI\n(tools/streamlib-cli)"]
-  engine["Engine runtime\n(runtime/streamlib-engine)"]
+  cli["streamlib — one shipped binary\n(CLI + runtime host + build orchestration)"]
+  ctl["Control plane\n(api-server: HTTP / WS / MCP — engine-side, runtime/)"]
+  engine["Engine runtime\n(runtime/streamlib-engine — embeddable library)"]
   rhi["RHI\n(vulkan/rhi + streamlib-consumer-rhi)"]
   abi["Plugin ABI\n(repr(C), runtime/streamlib-plugin-abi)"]
-  sdk["SDKs\n(Rust / Python / Deno)"]
+  sdk["SDKs\n(Rust / Python / Deno + control-plane client)"]
   pkgsrc["Package source\n(versioned artifacts, never sibling dirs)"]
 
   apps --> sdk
@@ -16,6 +17,7 @@ flowchart LR
   sdk --> abi
   abi --> engine
   engine --> rhi
-  cli --> engine
+  cli --> ctl
+  ctl --> engine
   cli --> pkgsrc
   pkgsrc --> engine


### PR DESCRIPTION
## What

/align session (2026-07-29), follows #1675/#1676. Flips §Control plane & observability:

- **DECIDED** — one control plane: api-server's HTTP + WS + MCP surface, hosted in-process; MCP is the canonical control vocabulary; the CLI is a pure JSON-RPC client. `[control-plane-one-surface]`
- **DECIDED** — api-server is engine-side infrastructure and relocates into `runtime/` (it is a host and cannot follow the packages tree out of the repo). `[control-plane-one-surface]`
- **DECIDED** — one shipped binary (CLI + runtime + build orchestration); `run`/`dev` host the runtime in-process; the standalone streamlib-runtime binary retires; the engine remains an embeddable Rust library, non-Rust embedding via the client-SDK/control-plane path. `[single-binary-launch]`
- **DECIDED** — file-based per-user node registry, double-dead pruning. `[control-plane-one-surface]`
- **DECIDED** — JSONL log schema as durable contract; verbatim non-interfering tap; graph/health over the same plane. `[control-plane-one-surface]`
- **OPEN** — auth and remote-access posture.

Also: `system.mmd` now routes cli → control plane → engine and labels the one-binary/embeddable-library split; glossary gains **Control plane** and **Node**; ADRs `control-plane-one-surface.md` and `single-binary-launch.md`.

## Notes

- Owner-approved in-session per align step 5 (restate confirmed).
- Consequences for later sessions (tickets via /propose-change, not here): api-server relocation, streamlib-runtime retirement, client-SDK launch surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxEKuEbR3vqZCSFdZaYete