### PR TITLE
fix(engine): back-pressure test releases and joins its blocked publisher instead of wedging the suite

### DIFF
--- a/runtime/streamlib-engine/src/iceoryx2/node.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/node.rs
@@ -477,10 +477,10 @@ mod tests {
     /// (depth+1)th send is observably back-pressured — either it
     /// errors out OR it does not complete promptly relative to the
     /// trivially-completing overflow-on baseline. A send observed as
-    /// blocked is then RELEASED by draining one subscriber slot, and
-    /// the worker is joined on every path — a permanently-parked
-    /// `blocking_send` holds posix-shm connection state that wedges
-    /// the rest of the suite's iceoryx2 tests forever (#1688).
+    /// blocked is then released by draining the subscriber, and the
+    /// worker is joined before the test returns — a publisher left
+    /// parked in a blocked `send()` holds posix-shm connection state
+    /// that wedges the rest of the suite's iceoryx2 tests (#1688).
     ///
     /// Mentally-revert: drop the `.enable_safe_overflow(value)` line
     /// in [`Iceoryx2Node::open_or_create_service`] and this test
@@ -491,7 +491,7 @@ mod tests {
     #[test]
     fn overflow_disabled_publisher_back_pressures_on_full_buffer() {
         use std::sync::mpsc;
-        use std::time::Duration;
+        use std::time::{Duration, Instant};
 
         let depth: usize = 4;
         let node = Iceoryx2Node::new().expect("create iceoryx2 node");
@@ -501,26 +501,24 @@ mod tests {
         let service_for_main = node
             .open_or_create_service(&service_name, 2, depth, /* enable_safe_overflow */ false)
             .expect("open service");
-        // The never-draining subscriber lives on the MAIN thread: it makes
-        // the publisher observe back-pressure at all (without a subscriber,
-        // iceoryx2 drops samples on the floor at send time and the overflow
-        // flag never engages — same gotcha as the overflow-on companion
-        // test), and it is the release valve — draining one slot is what
-        // completes a `Block`-strategy send so the worker can be joined
-        // instead of leaked mid-`blocking_send`.
-        let main_thread_subscriber = service_for_main
+        // A subscriber must exist before any send — without one, iceoryx2
+        // drops samples on the floor at send time and the overflow flag
+        // never engages (same gotcha as the overflow-on companion test).
+        // It stays undrained through the observation window; draining it
+        // afterwards is what completes a `Block`-strategy send.
+        let back_pressure_release_subscriber = service_for_main
             .create_subscriber()
-            .expect("create the never-draining subscriber on the main thread");
+            .expect("create the back-pressure release subscriber");
 
         // iceoryx2 Publishers hold `Rc<>` internally and aren't `Send`,
         // so the publisher must be created on the worker thread via a
         // service reopen. Pre-fill the buffer on the worker, then attempt
         // one more send; the (depth+1)th send is the test signal.
         let (filled_tx, filled_rx) = mpsc::channel::<()>();
-        let (result_tx, result_rx) = mpsc::channel::<std::result::Result<(), String>>();
+        let (result_tx, result_rx) = mpsc::channel::<std::result::Result<Duration, String>>();
         let node_clone = node.clone();
         let service_name_clone = service_name.clone();
-        let worker = std::thread::Builder::new()
+        let overflow_test_publisher_thread = std::thread::Builder::new()
             .name("overflow-test-publisher".into())
             .spawn(move || {
                 let svc = match node_clone.open_or_create_service(
@@ -558,78 +556,149 @@ mod tests {
                         }
                     }
                 }
-                // Buffer is now at `depth`. Signal main and attempt
-                // the (depth+1)th send — this is what the main thread
-                // observes for back-pressure.
+                // Buffer is now at `depth`. Signal main and attempt the
+                // (depth+1)th send — this is what the main thread observes
+                // for back-pressure. Success carries the send's elapsed
+                // time so main can prove the send parked through the
+                // observation window rather than merely starting late.
                 let _ = filled_tx.send(());
-                let res = (|| -> std::result::Result<(), String> {
+                let observed_send_started_at = Instant::now();
+                let res = (|| -> std::result::Result<Duration, String> {
                     let sample = publisher
                         .loan_slice_uninit(8)
                         .map_err(|e| format!("loan failed: {e:?}"))?;
                     let sample = sample.write_from_slice(&[0u8; 8]);
                     sample.send().map_err(|e| format!("send failed: {e:?}"))?;
-                    Ok(())
+                    Ok(observed_send_started_at.elapsed())
                 })();
                 let _ = result_tx.send(res);
             })
             .expect("spawn worker");
 
-        // Wait for the worker to finish pre-filling the buffer.
-        filled_rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("worker should finish pre-filling within 2s");
-
-        // The (depth+1)th send is the test signal. Back-pressure
-        // honors either of:
-        //   - iceoryx2 Block strategy: send blocks, worker doesn't
-        //     send a result → timeout fires, and the blocked send is
-        //     then released below so the worker can be joined.
-        //   - iceoryx2 DiscardSample / explicit PublisherSendError:
-        //     worker delivers Err on result_tx (explicit back-pressure
-        //     signal).
-        // Silent Ok would mean overflow wasn't actually disabled.
-        match result_rx.recv_timeout(Duration::from_millis(400)) {
-            Ok(Ok(())) => {
-                let _ = worker.join();
-                panic!(
-                    "(depth+1)th publisher.send() completed successfully with \
-                     enable_safe_overflow(false) — back-pressure contract \
-                     violated: producer must block or surface an error, not \
-                     silently succeed."
-                );
-            }
-            Ok(Err(_back_pressure_signal)) => {
-                // Explicit error from iceoryx2 — back-pressure observed.
-            }
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                // Worker is parked inside a Block-strategy send() — back-
-                // pressure observed. Release it: drain one slot so the
-                // send completes, then require the worker's Ok within a
-                // bounded window. Never leave the send parked — a leaked
-                // `blocking_send` owns shm connection state and wedges
-                // the suite's other iceoryx2 tests (#1688).
-                main_thread_subscriber
-                    .receive()
-                    .expect("drain one sample to release the blocked send")
-                    .expect("buffer was pre-filled to depth — a sample must be queued");
-                match result_rx.recv_timeout(Duration::from_secs(5)) {
-                    Ok(Ok(())) => {}
-                    Ok(Err(e)) => panic!("released send failed instead of completing: {e}"),
-                    Err(e) => panic!(
-                        "(depth+1)th send did not complete within 5s of draining a \
-                         subscriber slot — the block was not buffer-fullness \
-                         back-pressure: {e:?}"
+        // Every failure defers to the single panic site after the join —
+        // panicking mid-observation would strand the worker parked in a
+        // blocked `send()` owning posix-shm connection state, the exact
+        // suite-wide wedge this test must never cause (#1688).
+        let (back_pressure_contract_failure, worker_reported): (Option<String>, bool) =
+            if filled_rx.recv_timeout(Duration::from_secs(2)).is_err() {
+                (Some("worker did not finish pre-filling within 2s".into()), false)
+            } else {
+                // The (depth+1)th send is the test signal. Back-pressure
+                // honors either of:
+                //   - iceoryx2 Block strategy: send parks, worker delivers
+                //     no result → the 400ms timeout fires, and draining one
+                //     subscriber slot must complete the send.
+                //   - iceoryx2 DiscardSample / explicit PublisherSendError:
+                //     worker delivers Err promptly.
+                // Silent Ok would mean overflow wasn't actually disabled.
+                let observation_window = Duration::from_millis(400);
+                match result_rx.recv_timeout(observation_window) {
+                    Ok(Ok(prompt_send_duration)) => (
+                        Some(format!(
+                            "(depth+1)th publisher.send() completed successfully in \
+                             {prompt_send_duration:?} with enable_safe_overflow(false) — \
+                             back-pressure contract violated: producer must block or \
+                             surface an error, not silently succeed"
+                        )),
+                        true,
+                    ),
+                    Ok(Err(_back_pressure_signal)) => (None, true),
+                    Err(mpsc::RecvTimeoutError::Timeout) => {
+                        match back_pressure_release_subscriber.receive() {
+                            Ok(Some(drained_sample)) => {
+                                // receive() itself frees the queue slot (verified:
+                                // the parked send completes even while the sample
+                                // is held); the early drop returns the payload
+                                // chunk too before the bounded wait.
+                                drop(drained_sample);
+                                match result_rx.recv_timeout(Duration::from_secs(5)) {
+                                    // The worker's timer starts before main's
+                                    // observation window, so a genuinely parked
+                                    // send measures at least the window; a short
+                                    // duration means the send merely started
+                                    // late and never actually back-pressured.
+                                    Ok(Ok(released_send_duration))
+                                        if released_send_duration
+                                            >= observation_window - Duration::from_millis(50) =>
+                                    {
+                                        (None, true)
+                                    }
+                                    Ok(Ok(released_send_duration)) => (
+                                        Some(format!(
+                                            "released send spent only \
+                                             {released_send_duration:?} inside send() — it \
+                                             never parked through the {observation_window:?} \
+                                             observation window, so no back-pressure was \
+                                             demonstrated"
+                                        )),
+                                        true,
+                                    ),
+                                    Ok(Err(e)) => (
+                                        Some(format!(
+                                            "released send failed instead of completing: {e}"
+                                        )),
+                                        true,
+                                    ),
+                                    Err(e) => (
+                                        Some(format!(
+                                            "(depth+1)th send did not complete within 5s of \
+                                             draining a subscriber slot — the block was not \
+                                             buffer-fullness back-pressure: {e:?}"
+                                        )),
+                                        false,
+                                    ),
+                                }
+                            }
+                            Ok(None) => (
+                                Some(
+                                    "buffer was pre-filled to depth yet no sample was \
+                                     queued to drain"
+                                        .into(),
+                                ),
+                                false,
+                            ),
+                            Err(e) => (
+                                Some(format!(
+                                    "draining a sample to release the blocked send \
+                                     failed: {e:?}"
+                                )),
+                                false,
+                            ),
+                        }
+                    }
+                    Err(mpsc::RecvTimeoutError::Disconnected) => (
+                        Some("worker thread exited without reporting a result".into()),
+                        true,
                     ),
                 }
-            }
-            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                let join_result = worker.join();
-                panic!("worker thread panicked unexpectedly: {join_result:?}");
+            };
+
+        // Release pump: on paths where the worker has not provably finished,
+        // keep freeing subscriber slots until it reports or exits, so the
+        // join below is bounded even if a send parked during pre-fill.
+        let mut worker_finished = worker_reported;
+        if !worker_finished {
+            for _ in 0..50 {
+                while let Ok(Some(_drained_sample)) = back_pressure_release_subscriber.receive() {}
+                match result_rx.recv_timeout(Duration::from_millis(100)) {
+                    Ok(_) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                        worker_finished = true;
+                        break;
+                    }
+                    Err(mpsc::RecvTimeoutError::Timeout) => {}
+                }
             }
         }
-        worker
-            .join()
-            .expect("overflow-test-publisher worker must exit cleanly");
+        assert!(
+            worker_finished,
+            "worker never reported despite 5s of subscriber draining — joining would \
+             wedge the suite, failing loudly instead: {back_pressure_contract_failure:?}",
+        );
+        let worker_join_result = overflow_test_publisher_thread.join();
+        if let Some(failure) = back_pressure_contract_failure {
+            panic!("{failure}; worker join result: {worker_join_result:?}");
+        }
+        worker_join_result.expect("overflow-test-publisher worker must exit cleanly");
     }
 
     /// `Iceoryx2Service` stores the configured ring depth and exposes it

--- a/runtime/streamlib-engine/src/iceoryx2/node.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/node.rs
@@ -557,12 +557,12 @@ mod tests {
                     }
                 }
                 // Buffer is now at `depth`. Signal main and attempt the
-                // (depth+1)th send — this is what the main thread observes
-                // for back-pressure. Success carries the send's elapsed
-                // time so main can prove the send parked through the
-                // observation window rather than merely starting late.
-                let _ = filled_tx.send(());
+                // (depth+1)th send — the test signal. Success carries the
+                // send's elapsed time; the timer starts before the signal
+                // so a parked send's measured duration strictly contains
+                // main's observation window.
                 let observed_send_started_at = Instant::now();
+                let _ = filled_tx.send(());
                 let res = (|| -> std::result::Result<Duration, String> {
                     let sample = publisher
                         .loan_slice_uninit(8)
@@ -575,130 +575,127 @@ mod tests {
             })
             .expect("spawn worker");
 
-        // Every failure defers to the single panic site after the join —
-        // panicking mid-observation would strand the worker parked in a
-        // blocked `send()` owning posix-shm connection state, the exact
-        // suite-wide wedge this test must never cause (#1688).
-        let (back_pressure_contract_failure, worker_reported): (Option<String>, bool) =
-            if filled_rx.recv_timeout(Duration::from_secs(2)).is_err() {
-                (Some("worker did not finish pre-filling within 2s".into()), false)
-            } else {
-                // The (depth+1)th send is the test signal. Back-pressure
-                // honors either of:
-                //   - iceoryx2 Block strategy: send parks, worker delivers
-                //     no result → the 400ms timeout fires, and draining one
-                //     subscriber slot must complete the send.
-                //   - iceoryx2 DiscardSample / explicit PublisherSendError:
-                //     worker delivers Err promptly.
-                // Silent Ok would mean overflow wasn't actually disabled.
-                let observation_window = Duration::from_millis(400);
-                match result_rx.recv_timeout(observation_window) {
-                    Ok(Ok(prompt_send_duration)) => (
-                        Some(format!(
-                            "(depth+1)th publisher.send() completed successfully in \
-                             {prompt_send_duration:?} with enable_safe_overflow(false) — \
-                             back-pressure contract violated: producer must block or \
-                             surface an error, not silently succeed"
-                        )),
-                        true,
-                    ),
-                    Ok(Err(_back_pressure_signal)) => (None, true),
-                    Err(mpsc::RecvTimeoutError::Timeout) => {
-                        match back_pressure_release_subscriber.receive() {
-                            Ok(Some(drained_sample)) => {
-                                // receive() itself frees the queue slot (verified:
-                                // the parked send completes even while the sample
-                                // is held); the early drop returns the payload
-                                // chunk too before the bounded wait.
-                                drop(drained_sample);
-                                match result_rx.recv_timeout(Duration::from_secs(5)) {
-                                    // The worker's timer starts before main's
-                                    // observation window, so a genuinely parked
-                                    // send measures at least the window; a short
-                                    // duration means the send merely started
-                                    // late and never actually back-pressured.
-                                    Ok(Ok(released_send_duration))
-                                        if released_send_duration
-                                            >= observation_window - Duration::from_millis(50) =>
-                                    {
-                                        (None, true)
-                                    }
-                                    Ok(Ok(released_send_duration)) => (
-                                        Some(format!(
-                                            "released send spent only \
-                                             {released_send_duration:?} inside send() — it \
-                                             never parked through the {observation_window:?} \
-                                             observation window, so no back-pressure was \
-                                             demonstrated"
-                                        )),
-                                        true,
-                                    ),
-                                    Ok(Err(e)) => (
-                                        Some(format!(
-                                            "released send failed instead of completing: {e}"
-                                        )),
-                                        true,
-                                    ),
-                                    Err(e) => (
-                                        Some(format!(
-                                            "(depth+1)th send did not complete within 5s of \
-                                             draining a subscriber slot — the block was not \
-                                             buffer-fullness back-pressure: {e:?}"
-                                        )),
-                                        false,
-                                    ),
-                                }
-                            }
-                            Ok(None) => (
-                                Some(
-                                    "buffer was pre-filled to depth yet no sample was \
-                                     queued to drain"
-                                        .into(),
-                                ),
-                                false,
-                            ),
-                            Err(e) => (
-                                Some(format!(
-                                    "draining a sample to release the blocked send \
-                                     failed: {e:?}"
-                                )),
-                                false,
-                            ),
-                        }
-                    }
-                    Err(mpsc::RecvTimeoutError::Disconnected) => (
-                        Some("worker thread exited without reporting a result".into()),
-                        true,
-                    ),
-                }
-            };
+        // Every failure defers past the release pump to the single panic
+        // site after the join — panicking while the worker is parked in a
+        // blocked `send()` would strand posix-shm connection state, the
+        // exact suite-wide wedge this test must never cause (#1688). Only
+        // a worker that stays unreleasable after the pump fails earlier,
+        // at the assert.
+        #[derive(Debug)]
+        enum BackPressureObservation {
+            Honored,
+            ContractFailure(String),
+            WorkerStillParked(String),
+        }
+        use BackPressureObservation::{ContractFailure, Honored, WorkerStillParked};
 
-        // Release pump: on paths where the worker has not provably finished,
-        // keep freeing subscriber slots until it reports or exits, so the
-        // join below is bounded even if a send parked during pre-fill.
-        let mut worker_finished = worker_reported;
-        if !worker_finished {
-            for _ in 0..50 {
-                while let Ok(Some(_drained_sample)) = back_pressure_release_subscriber.receive() {}
-                match result_rx.recv_timeout(Duration::from_millis(100)) {
-                    Ok(_) | Err(mpsc::RecvTimeoutError::Disconnected) => {
-                        worker_finished = true;
-                        break;
+        const RELEASE_PUMP_ATTEMPTS: u32 = 50;
+        const RELEASE_PUMP_POLL_INTERVAL: Duration = Duration::from_millis(100);
+        const RELEASED_SEND_COMPLETION_WINDOW: Duration = Duration::from_secs(5);
+
+        let observation = if filled_rx.recv_timeout(Duration::from_secs(2)).is_err() {
+            WorkerStillParked("worker did not finish pre-filling within 2s".into())
+        } else {
+            // The (depth+1)th send is the test signal. Back-pressure
+            // honors either of:
+            //   - iceoryx2 Block strategy: send parks, worker delivers
+            //     no result → the 400ms timeout fires, and draining one
+            //     subscriber slot must complete the send.
+            //   - iceoryx2 DiscardSample / explicit PublisherSendError:
+            //     worker delivers Err promptly.
+            // Silent Ok would mean overflow wasn't actually disabled.
+            let observation_window = Duration::from_millis(400);
+            match result_rx.recv_timeout(observation_window) {
+                Ok(Ok(prompt_send_duration)) => ContractFailure(format!(
+                    "(depth+1)th publisher.send() completed successfully in \
+                     {prompt_send_duration:?} with enable_safe_overflow(false) — \
+                     back-pressure contract violated: producer must block or \
+                     surface an error, not silently succeed"
+                )),
+                Ok(Err(_back_pressure_signal)) => Honored,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    match back_pressure_release_subscriber.receive() {
+                        Ok(Some(drained_sample)) => {
+                            // receive() frees the queue slot (verified); the
+                            // drop returns the payload chunk.
+                            drop(drained_sample);
+                            match result_rx.recv_timeout(RELEASED_SEND_COMPLETION_WINDOW) {
+                                // The worker's timer starts before main's
+                                // observation window opens, so a genuinely
+                                // parked send measures at least the full
+                                // window.
+                                Ok(Ok(released_send_duration))
+                                    if released_send_duration >= observation_window =>
+                                {
+                                    Honored
+                                }
+                                Ok(Ok(released_send_duration)) => ContractFailure(format!(
+                                    "released send spent only {released_send_duration:?} \
+                                     inside send() — it never parked through the \
+                                     {observation_window:?} observation window, so no \
+                                     back-pressure was demonstrated"
+                                )),
+                                Ok(Err(e)) => ContractFailure(format!(
+                                    "released send failed instead of completing: {e}"
+                                )),
+                                Err(mpsc::RecvTimeoutError::Disconnected) => ContractFailure(
+                                    "worker thread exited without reporting a result".into(),
+                                ),
+                                Err(mpsc::RecvTimeoutError::Timeout) => WorkerStillParked(format!(
+                                    "(depth+1)th send did not complete within \
+                                     {RELEASED_SEND_COMPLETION_WINDOW:?} of draining a \
+                                     subscriber slot — the block was not \
+                                     buffer-fullness back-pressure"
+                                )),
+                            }
+                        }
+                        Ok(None) => WorkerStillParked(
+                            "buffer was pre-filled to depth yet no sample was queued \
+                             to drain"
+                                .into(),
+                        ),
+                        Err(e) => WorkerStillParked(format!(
+                            "draining a sample to release the blocked send failed: {e:?}"
+                        )),
                     }
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    ContractFailure("worker thread exited without reporting a result".into())
+                }
+            }
+        };
+
+        // Bounded release pump: keep freeing subscriber slots until the
+        // worker reports or exits, so the join below cannot park forever
+        // on a still-blocked send — even one parked during pre-fill.
+        let release_pump_frees_worker = || {
+            for _ in 0..RELEASE_PUMP_ATTEMPTS {
+                while let Ok(Some(_drained_sample)) = back_pressure_release_subscriber.receive() {}
+                match result_rx.recv_timeout(RELEASE_PUMP_POLL_INTERVAL) {
+                    Ok(_) | Err(mpsc::RecvTimeoutError::Disconnected) => return true,
                     Err(mpsc::RecvTimeoutError::Timeout) => {}
                 }
             }
-        }
+            false
+        };
+        let worker_finished =
+            !matches!(observation, WorkerStillParked(_)) || release_pump_frees_worker();
         assert!(
             worker_finished,
-            "worker never reported despite 5s of subscriber draining — joining would \
-             wedge the suite, failing loudly instead: {back_pressure_contract_failure:?}",
+            "worker never reported despite {:?} of subscriber draining — joining would \
+             hang this test, so failing loudly instead; expect later iceoryx2 tests in \
+             this binary to be perturbed by the still-parked publisher: {observation:?}",
+            RELEASE_PUMP_POLL_INTERVAL * RELEASE_PUMP_ATTEMPTS,
         );
         let worker_join_result = overflow_test_publisher_thread.join();
-        if let Some(failure) = back_pressure_contract_failure {
-            panic!("{failure}; worker join result: {worker_join_result:?}");
+        match observation {
+            Honored => {
+                worker_join_result.expect("overflow-test-publisher worker must exit cleanly")
+            }
+            ContractFailure(failure) | WorkerStillParked(failure) => {
+                panic!("{failure}; worker join result: {worker_join_result:?}")
+            }
         }
-        worker_join_result.expect("overflow-test-publisher worker must exit cleanly");
     }
 
     /// `Iceoryx2Service` stores the configured ring depth and exposes it

--- a/runtime/streamlib-engine/src/iceoryx2/node.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/node.rs
@@ -471,12 +471,16 @@ mod tests {
     /// the back-pressure contract. iceoryx2's per-publisher default
     /// `unable_to_deliver_strategy` may yield either a `Block` (send
     /// blocks until consumer drains) or a non-`Ok` return; both honor
-    /// the "producer is not silently silently dropping under the
-    /// overflow-off contract" invariant we promise muxer / file-writer
-    /// callers. This test fills the buffer past depth and asserts the
+    /// the "producer is not silently dropping under the overflow-off
+    /// contract" invariant we promise muxer / file-writer callers.
+    /// This test fills the buffer past depth and asserts the
     /// (depth+1)th send is observably back-pressured — either it
     /// errors out OR it does not complete promptly relative to the
-    /// trivially-completing overflow-on baseline.
+    /// trivially-completing overflow-on baseline. A send observed as
+    /// blocked is then RELEASED by draining one subscriber slot, and
+    /// the worker is joined on every path — a permanently-parked
+    /// `blocking_send` holds posix-shm connection state that wedges
+    /// the rest of the suite's iceoryx2 tests forever (#1688).
     ///
     /// Mentally-revert: drop the `.enable_safe_overflow(value)` line
     /// in [`Iceoryx2Node::open_or_create_service`] and this test
@@ -497,19 +501,26 @@ mod tests {
         let service_for_main = node
             .open_or_create_service(&service_name, 2, depth, /* enable_safe_overflow */ false)
             .expect("open service");
-        drop(service_for_main); // keep the service alive only via the
-        // worker-side reopen; iceoryx2 services
-        // are reference-counted.
+        // The never-draining subscriber lives on the MAIN thread: it makes
+        // the publisher observe back-pressure at all (without a subscriber,
+        // iceoryx2 drops samples on the floor at send time and the overflow
+        // flag never engages — same gotcha as the overflow-on companion
+        // test), and it is the release valve — draining one slot is what
+        // completes a `Block`-strategy send so the worker can be joined
+        // instead of leaked mid-`blocking_send`.
+        let main_thread_subscriber = service_for_main
+            .create_subscriber()
+            .expect("create the never-draining subscriber on the main thread");
 
         // iceoryx2 Publishers hold `Rc<>` internally and aren't `Send`,
-        // so the publisher must be created on the worker thread. Pre-
-        // fill the buffer on the worker, then attempt one more send;
-        // the (depth+1)th send is the test signal.
+        // so the publisher must be created on the worker thread via a
+        // service reopen. Pre-fill the buffer on the worker, then attempt
+        // one more send; the (depth+1)th send is the test signal.
         let (filled_tx, filled_rx) = mpsc::channel::<()>();
         let (result_tx, result_rx) = mpsc::channel::<std::result::Result<(), String>>();
         let node_clone = node.clone();
         let service_name_clone = service_name.clone();
-        let _worker = std::thread::Builder::new()
+        let worker = std::thread::Builder::new()
             .name("overflow-test-publisher".into())
             .spawn(move || {
                 let svc = match node_clone.open_or_create_service(
@@ -528,18 +539,6 @@ mod tests {
                     Ok(p) => p,
                     Err(e) => {
                         let _ = result_tx.send(Err(format!("publisher failed: {e:?}")));
-                        return;
-                    }
-                };
-                // Attach a never-draining subscriber so the publisher
-                // observes back-pressure on overflow. Without it,
-                // iceoryx2 drops samples on the floor at send time and
-                // the overflow flag never engages — same gotcha as the
-                // overflow-on companion test.
-                let _subscriber = match svc.create_subscriber() {
-                    Ok(s) => s,
-                    Err(e) => {
-                        let _ = result_tx.send(Err(format!("subscriber failed: {e:?}")));
                         return;
                     }
                 };
@@ -583,14 +582,15 @@ mod tests {
         // The (depth+1)th send is the test signal. Back-pressure
         // honors either of:
         //   - iceoryx2 Block strategy: send blocks, worker doesn't
-        //     send a result → timeout fires (test passes; worker is
-        //     leaked, dropped at process exit).
+        //     send a result → timeout fires, and the blocked send is
+        //     then released below so the worker can be joined.
         //   - iceoryx2 DiscardSample / explicit PublisherSendError:
-        //     worker delivers Err on result_tx (test passes — explicit
-        //     back-pressure signal).
+        //     worker delivers Err on result_tx (explicit back-pressure
+        //     signal).
         // Silent Ok would mean overflow wasn't actually disabled.
         match result_rx.recv_timeout(Duration::from_millis(400)) {
             Ok(Ok(())) => {
+                let _ = worker.join();
                 panic!(
                     "(depth+1)th publisher.send() completed successfully with \
                      enable_safe_overflow(false) — back-pressure contract \
@@ -599,15 +599,37 @@ mod tests {
                 );
             }
             Ok(Err(_back_pressure_signal)) => {
-                // Explicit error from iceoryx2 — test passes.
+                // Explicit error from iceoryx2 — back-pressure observed.
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                // Worker is blocking inside send() — test passes.
+                // Worker is parked inside a Block-strategy send() — back-
+                // pressure observed. Release it: drain one slot so the
+                // send completes, then require the worker's Ok within a
+                // bounded window. Never leave the send parked — a leaked
+                // `blocking_send` owns shm connection state and wedges
+                // the suite's other iceoryx2 tests (#1688).
+                main_thread_subscriber
+                    .receive()
+                    .expect("drain one sample to release the blocked send")
+                    .expect("buffer was pre-filled to depth — a sample must be queued");
+                match result_rx.recv_timeout(Duration::from_secs(5)) {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => panic!("released send failed instead of completing: {e}"),
+                    Err(e) => panic!(
+                        "(depth+1)th send did not complete within 5s of draining a \
+                         subscriber slot — the block was not buffer-fullness \
+                         back-pressure: {e:?}"
+                    ),
+                }
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
-                panic!("worker thread panicked unexpectedly");
+                let join_result = worker.join();
+                panic!("worker thread panicked unexpectedly: {join_result:?}");
             }
         }
+        worker
+            .join()
+            .expect("overflow-test-publisher worker must exit cleanly");
     }
 
     /// `Iceoryx2Service` stores the configured ring depth and exposes it


### PR DESCRIPTION
## Summary

The engine's overflow-disabled iceoryx2 back-pressure test observed a `Block`-strategy send via timeout and then leaked its detached `overflow-test-publisher` thread parked inside the blocked `send()`. Under the full parallel lib suite that parked publisher holds posix-shm connection state other iceoryx2 tests need, wedging `cargo test -p streamlib-engine --lib` forever (observed 4 h and 1.5-day hangs, #1688).

The test is restructured so no path can strand a parked publisher:

- The never-draining subscriber moves to the main thread and doubles as the **release valve** — draining one slot is what completes a `Block`-strategy send.
- Every failure defers into a three-variant `BackPressureObservation` (`Honored` / `ContractFailure` / `WorkerStillParked`); a **bounded release pump** (50 × drain-all + 100 ms poll) frees any still-parked send — including one parked during pre-fill — before a **single join site**, and the one panic site is after the join.
- The worker times the observed send (monotonic `Instant`, started before the filled signal): the release arm requires the measured duration to span the 400 ms observation window, upgrading the timeout arm from *inferred* to **proven** back-pressure — an overflow-ON regression can no longer slip through as a scheduling-delay pass.

Test-only change; zero library-code changes.

## Closes

Closes #1688

## Exit criteria

- The suite terminates on every run: 5 clean full parallel `cargo test -p streamlib-engine --lib` runs on this branch (1737 passed / 0 failed, ~39 s each), plus a `--test-threads=1` run and an isolated-worktree run by the CI-gate agent — no hang, no surviving `overflow-test-p…` thread.
- The back-pressure assertion observes the blocked send bounded, releases it, and joins the worker: 40/40 single-test runs at a consistent ~0.41 s (400 ms observation window + ~10 ms release/join — the `Block` arm is the live path).
- Mentally-revert red run (forcing `enable_safe_overflow(true)` in `open_or_create_service`): fails in 0.01 s with the contract-violation panic **and** `worker join result: Ok(())` — the failure path also joins.

## Test plan

- `cargo test -p streamlib-engine --lib iceoryx2::node` — 10/10.
- `cargo test -p streamlib-engine --lib` × 5 — 1737/0 each.
- Local CI gate battery (isolated worktree): 39 passed, 0 failed, 4 skipped (rig/path-filter).
- Reviews: adjudication reviewer APPROVE (round 2), Rust craftsmanship reviewer APPROVE grade A- (round 2); round-2 residuals folded into the final commit (park-timer hoist, observation enum, named pump constants, comment accuracy).
- Empirical probe: holding the drained `Sample` through the entire release wait still releases the parked send — `receive()` alone frees the queue slot in iceoryx2 0.8, so the early drop is belt-and-braces, not load-bearing.

## Notes for owner

- **Unrelated flake 1 — glibc heap-corruption SIGABRT**: one full-suite run aborted with `corrupted size vs. prev_size while consolidating` (seen once by the gate agent in an isolated worktree at the first commit, once by me); retries clean. Not attributable to this diff (test-module-only change), but it is a real intermittent crash in the parallel suite worth its own investigation if it recurs.
- **Unrelated flake 2 — DRM probe hang**: one full-suite run wedged in `vulkan::rhi::drm_modifier_probe::tests::probe_default_display_runs_or_skips_cleanly` (thread alive at 100 % CPU in the Vulkan/CUDA driver stack; verified via `/proc` thread names that no iceoryx2 thread survived — all iceoryx2 tests had passed in that run). Pre-existing GPU-probe behavior under parallel load, out of scope here.
- **Unrelated flake 3 — fd-redirect capture tests**: the adjudication reviewer saw `core::logging::tests::rust_c_printf_via_libc_captured` and `rust_println_captured_via_fd_redirect` fail once in a parallel run; both pass 18/18 in isolation. Parallel-scheduling flake in the fd-capture tests.
- **Residual by design**: if the pump ever fails to free the worker (would imply an iceoryx2 behavior change), the test fails loudly at the assert *without* joining — a hang would be strictly worse — and later iceoryx2 tests in that binary may be perturbed; the assert message says so.
- Repo-wide `cargo fmt --check` is dirty at ~125 pre-existing sites under rustfmt 1.8.0-stable (three of them in this file, untouched); this diff adds none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)