### PR TITLE
plan: align §Media I/O — packages over engine primitives (5 DECIDED, audio OPEN)

### DIFF
--- a/docs/decisions/media-io-layering.md
+++ b/docs/decisions/media-io-layering.md
@@ -1,0 +1,71 @@
+# Media I/O: packages over engine primitives
+
+Rationale for the `[media-io-layering]` entries in `docs/plan/ARCHITECTURE.md`
+§Media I/O, decided 2026-07-30.
+
+## Trigger
+
+Read this before adding a media processor (camera, display, audio) to the engine tree,
+before duplicating a hardware primitive inside a package, before scheduling media
+package upgrades against engine milestones, or before starting any non-V4L2 capture
+work.
+
+## Decision
+
+The engine owns hardware primitives; media processors are packages. The primitives —
+DMA-BUF / OPAQUE_FD import and export, the present target, the audio clock, color
+resolution, codec sessions — live behind `GpuContext`, the RHI, and the ABI vtables,
+and packages reach them only across the plugin ABI. No media processor is
+engine-internal.
+
+First-party media packages lag by design while the engine moves, then upgrade to the
+current engine exactly once, as the final MVP step — the Next.js model: prove the
+runtime solid first, then bring consumers forward before release.
+
+Capture is V4L2-only. Apple capture (AVFoundation) stays undesigned until a milestone
+traces to it; only the TCC permission shims exist.
+
+Windowing splits at the raw window handle: the package creates and owns the window;
+the engine mints the present target from the raw handle and keeps every swapchain and
+acquire detail host-side, plus the platform main-thread event loop where the OS
+demands it. Camera-to-GPU transport is zero-copy DMA-BUF import when the device
+exports it, with a transparent CPU-upload fallback chosen automatically — no
+configuration dial.
+
+Audio backend stays open with a stated intent: PipeWire-native on Linux, the current
+CPAL-over-ALSA path interim, pending a research memo. The engine's decided audio
+surface is the clock primitive.
+
+## Rejected alternatives
+
+- **Engine-internal media processors** — breaks engine purity (the engine's own
+  manifest declares no domain packages), couples driver churn to engine releases, and
+  demotes the plugin ABI to a second-class path the moment first-party code bypasses
+  it.
+- **Continuous lockstep upgrades of media packages** — churns consumers on every
+  engine change before the design has settled; a single end-of-milestone upgrade
+  proves the design once, against a stable runtime.
+- **Scaffold-generated media processors (no first-party packages)** — turns every
+  scaffolded app into a fork of driver code nobody upgrades; capture/display fixes
+  would never reach existing apps.
+- **Deciding AVFoundation capture now** — no MVP trace (the floor is Linux + NVIDIA);
+  designing it without a driving consumer violates plan-first.
+- **Engine-owned windows** — drags winit event handling, input, and window policy into
+  the engine for one consumer's convenience; the raw-window-handle seam already gives
+  the engine everything the swapchain needs.
+- **Zero-copy required (no CPU fallback)** — kills virtual and test devices (vivid,
+  v4l2loopback) and any driver without DMA-BUF export; a user-visible transport dial
+  would break the zero-ceremony bar.
+- **Committing to PipeWire (or CPAL) today** — audio has no MVP trace and the
+  realtime claims are unmeasured; committing without a research memo is the kind of
+  inference-from-vibes the plan exists to prevent.
+
+## Consequences
+
+- MVP completion includes a final consumer-upgrade pass over the media packages and
+  the scaffold's effect chain — that pass is MVP work, not optional backlog.
+- Engine changes may break media packages mid-development; that is expected, not a
+  defect, and files no tickets.
+- The plugin ABI must carry every capability media processors need — there is no
+  side door, so a missing primitive is engine work, never an ABI bypass.
+- Non-Linux capture waits, including for contributors on Apple hardware.

--- a/docs/plan/ARCHITECTURE.md
+++ b/docs/plan/ARCHITECTURE.md
@@ -68,7 +68,28 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
 
 ## Media I/O — camera, display, audio
 
-- **OPEN**
+- **DECIDED** — The engine ships no media processors: camera, display, and audio are
+  packages loaded over the plugin ABI. The engine owns the hardware primitives they
+  build on — DMA-BUF / OPAQUE_FD import and export, the present target, the audio
+  clock, color resolution, codec sessions — exposed only through `GpuContext`, the
+  RHI, and the ABI vtables. [media-io-layering]
+- **DECIDED** — First-party media packages lag by design during engine development and
+  are upgraded to the current engine as the final MVP step, once the runtime is proven
+  solid — before the MVP ships, never continuously. [media-io-layering]
+- **DECIDED** — V4L2 is the only capture backend (platform floor: Linux + NVIDIA).
+  Apple capture (AVFoundation) is post-MVP and undesigned; only the TCC permission
+  shims exist. [media-io-layering]
+- **DECIDED** — Windowing splits at the raw window handle: window creation and its
+  lifetime are package-side; the engine mints the present target from the raw handle
+  and owns every swapchain and acquire detail, plus the platform main-thread event
+  loop where the OS demands it. [media-io-layering]
+- **DECIDED** — Camera → GPU transport: zero-copy DMA-BUF import when the device
+  exports it, transparent CPU-upload fallback otherwise, selected automatically —
+  no configuration dial. [media-io-layering]
+- **OPEN** — Audio backend: PipeWire-native on Linux is the intent (the current
+  CPAL → ALSA path is interim); do not build until a research memo settles it. A/V
+  sync model likewise OPEN. The engine's decided audio surface is the clock
+  primitive. [media-io-layering]
 
 ## Networking — transport, moq, webrtc
 

--- a/docs/plan/GLOSSARY.md
+++ b/docs/plan/GLOSSARY.md
@@ -36,6 +36,18 @@ on-disk registry. _Avoid_: "instance", "server".
 **Processor**: the unit of pipeline computation, declared with `#[processor]` and wired
 by ports.
 
+**Engine primitive**: a hardware capability the engine owns and exposes to packages
+across the plugin ABI — GPU memory import/export, the present target, the audio clock,
+codec sessions. Packages compose primitives; they never reimplement them.
+
+**Present target**: the engine-owned presentation surface minted from a
+package-supplied window handle; the only way frames reach a window.
+
+**Lag by design**: consumers (distributable packages, examples) track the engine only at
+planned upgrade points — upgraded as the final step of a milestone once the runtime is
+proven solid, never continuously mid-development. _Avoid_: reading "lag" as "never
+upgraded", "abandoned".
+
 **The plan**: `docs/plan/ARCHITECTURE.md` plus `docs/plan/diagrams/` — the single source
 of architectural decisions.
 


### PR DESCRIPTION
## What

/align session over `docs/plan/ARCHITECTURE.md` §Media I/O (was fully OPEN). Owner-confirmed section restatement; this PR is the CODEOWNERS review gate.

**DECIDED (all codify the shipped, working shape — no MVP build work created):**
1. **Layering** — engine ships no media processors; camera/display/audio are packages over the plugin ABI; engine owns the hardware primitives (DMA-BUF/OPAQUE_FD import & export, present target, audio clock, color resolution, codec sessions) behind `GpuContext`/RHI/ABI.
2. **Upgrade timing** — first-party media packages lag by design during development and upgrade once, as the final MVP step, after the runtime is proven solid.
3. **Capture floor** — V4L2-only (Linux + NVIDIA); AVFoundation post-MVP, undesigned.
4. **Windowing** — split at the raw window handle: window creation package-side; present target minting, all swapchain/acquire detail, and OS-mandated main-thread event loops engine-side.
5. **Camera → GPU transport** — automatic zero-copy DMA-BUF import with transparent CPU-upload fallback; no configuration dial.

**OPEN (deliberate):** audio backend (PipeWire-native intent recorded; CPAL→ALSA interim; do-not-build pending a research memo) and A/V sync model.

## Files

- `docs/plan/ARCHITECTURE.md` — §Media I/O OPEN → 5 DECIDED + 1 scoped OPEN
- `docs/decisions/media-io-layering.md` — new ADR (trigger / decision / rejected alternatives / consequences)
- `docs/plan/GLOSSARY.md` — adds **Engine primitive**, **Present target**, **Lag by design** (owner clarified "lag" ≠ "never upgraded")

No diagram change: `system.mmd` already shows packages → ABI → engine → RHI; no structural edge changed.

## Notes (non-blocking)

- `core/logging/event.rs:194` fixtures reference a stale legacy target `streamlib::linux::processors::camera` (code long since moved to the camera package) — cosmetic, noting per doctrine rather than filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)