### PR TITLE
feat(cli): run/dev verb skeletons — app.py setup(rt) convention and in-CLI control-plane host

### DIFF
--- a/packages/api-server/src/control_plane_host.rs
+++ b/packages/api-server/src/control_plane_host.rs
@@ -11,8 +11,8 @@ use streamlib::sdk::processor_type_ref;
 use streamlib::sdk::processors::{PROCESSOR_REGISTRY, ProcessorSpec};
 use streamlib::sdk::runtime::Runner;
 
-/// Where a host binary binds the control plane it hosts.
-pub struct ApiServerControlPlaneBindConfig {
+/// How a host binary stands up the control plane it hosts.
+pub struct ApiServerControlPlaneHostConfig {
     /// Address the HTTP listener binds.
     pub bind_host: String,
     /// Requested port; the api-server increments on collision.
@@ -27,7 +27,7 @@ pub struct ApiServerControlPlaneBindConfig {
 /// publishes the node-registry entry `streamlib nodes` discovers.
 pub fn register_api_server_control_plane_processor_on_runtime(
     runtime: &Runner,
-    config: ApiServerControlPlaneBindConfig,
+    config: ApiServerControlPlaneHostConfig,
 ) -> Result<()> {
     // A host, not a loadable plugin: the type is statically linked into the
     // caller and registered on the shared registry rather than dlopen'd.

--- a/packages/api-server/src/control_plane_host.rs
+++ b/packages/api-server/src/control_plane_host.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The boot recipe a host binary follows to stand this crate's control plane up
+//! inside its own runtime — shared by the `streamlib-runtime` binary and the
+//! CLI's `run` / `dev` verbs so a node is discoverable the same way whichever
+//! one launched it.
+
+use streamlib::sdk::error::Result;
+use streamlib::sdk::processor_type_ref;
+use streamlib::sdk::processors::{PROCESSOR_REGISTRY, ProcessorSpec};
+use streamlib::sdk::runtime::Runner;
+
+/// Where a host binary binds the control plane it hosts.
+pub struct ApiServerControlPlaneBindConfig {
+    /// Address the HTTP listener binds.
+    pub bind_host: String,
+    /// Requested port; the api-server increments on collision.
+    pub bind_port: u16,
+    /// Node name published to the registry; the api-server generates a
+    /// Docker-style one when this is `None`.
+    pub node_name: Option<String>,
+}
+
+/// Register the `ApiServer` processor type in-process and add one instance to
+/// `runtime`, so that starting the runtime binds a control endpoint and
+/// publishes the node-registry entry `streamlib nodes` discovers.
+pub fn register_api_server_control_plane_processor_on_runtime(
+    runtime: &Runner,
+    config: ApiServerControlPlaneBindConfig,
+) -> Result<()> {
+    // A host, not a loadable plugin: the type is statically linked into the
+    // caller and registered on the shared registry rather than dlopen'd.
+    PROCESSOR_REGISTRY.register::<crate::api_server::ApiServerProcessor::Processor>();
+
+    let mut api_server_config = serde_json::Map::new();
+    api_server_config.insert("host".into(), serde_json::Value::from(config.bind_host));
+    api_server_config.insert("port".into(), serde_json::Value::from(config.bind_port));
+    if let Some(node_name) = config.node_name {
+        api_server_config.insert("name".into(), serde_json::Value::from(node_name));
+    }
+    if let Some(jsonl_log_path) = runtime.jsonl_log_path() {
+        api_server_config.insert(
+            "log_path".into(),
+            serde_json::Value::from(jsonl_log_path.to_string_lossy().into_owned()),
+        );
+    }
+
+    runtime.add_processor(ProcessorSpec::new(
+        processor_type_ref!("tatolab", "api-server", "ApiServer"),
+        serde_json::Value::Object(api_server_config),
+    ))?;
+
+    Ok(())
+}

--- a/packages/api-server/src/lib.rs
+++ b/packages/api-server/src/lib.rs
@@ -7,6 +7,7 @@ pub mod _generated_ {
 }
 
 mod auth;
+pub mod control_plane_host;
 mod handlers;
 mod mcp;
 pub mod node_registry;

--- a/runtime/streamlib-runtime/src/main.rs
+++ b/runtime/streamlib-runtime/src/main.rs
@@ -17,9 +17,10 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::Parser;
 use streamlib::sdk::RunnerAutoBuild;
-use streamlib::sdk::processor_type_ref;
-use streamlib::sdk::processors::{PROCESSOR_REGISTRY, ProcessorSpec};
 use streamlib::sdk::runtime::Runner;
+use streamlib_api_server::control_plane_host::{
+    ApiServerControlPlaneBindConfig, register_api_server_control_plane_processor_on_runtime,
+};
 
 #[derive(Parser)]
 #[command(name = "streamlib-runtime")]
@@ -70,27 +71,15 @@ async fn run(args: Args) -> Result<()> {
     // Seed the core module set. The API server is the always-present
     // control plane — a host, not a loadable plugin — so it is statically
     // linked into this binary and registered in-process on the shared
-    // `PROCESSOR_REGISTRY`. This registers the `ApiServer` processor type;
-    // the instance is added below.
-    PROCESSOR_REGISTRY.register::<streamlib_api_server::ApiServerProcessor::Processor>();
-
-    let log_path = runtime
-        .jsonl_log_path()
-        .map(|p| p.to_string_lossy().into_owned());
-
-    let mut api_config = serde_json::Map::new();
-    api_config.insert("host".into(), serde_json::Value::from(args.host.clone()));
-    api_config.insert("port".into(), serde_json::Value::from(args.port));
-    if let Some(name) = args.name {
-        api_config.insert("name".into(), serde_json::Value::from(name));
-    }
-    if let Some(path) = log_path {
-        api_config.insert("log_path".into(), serde_json::Value::from(path));
-    }
-    runtime.add_processor(ProcessorSpec::new(
-        processor_type_ref!("tatolab", "api-server", "ApiServer"),
-        serde_json::Value::Object(api_config),
-    ))?;
+    // `PROCESSOR_REGISTRY`.
+    register_api_server_control_plane_processor_on_runtime(
+        &runtime,
+        ApiServerControlPlaneBindConfig {
+            bind_host: args.host.clone(),
+            bind_port: args.port,
+            node_name: args.name,
+        },
+    )?;
 
     if let Some(ref path) = args.snapshot {
         println!("Loading pipeline: {}", path.display());

--- a/runtime/streamlib-runtime/src/main.rs
+++ b/runtime/streamlib-runtime/src/main.rs
@@ -19,7 +19,7 @@ use clap::Parser;
 use streamlib::sdk::RunnerAutoBuild;
 use streamlib::sdk::runtime::Runner;
 use streamlib_api_server::control_plane_host::{
-    ApiServerControlPlaneBindConfig, register_api_server_control_plane_processor_on_runtime,
+    ApiServerControlPlaneHostConfig, register_api_server_control_plane_processor_on_runtime,
 };
 
 #[derive(Parser)]
@@ -74,8 +74,8 @@ async fn run(args: Args) -> Result<()> {
     // `PROCESSOR_REGISTRY`.
     register_api_server_control_plane_processor_on_runtime(
         &runtime,
-        ApiServerControlPlaneBindConfig {
-            bind_host: args.host.clone(),
+        ApiServerControlPlaneHostConfig {
+            bind_host: args.host,
             bind_port: args.port,
             node_name: args.name,
         },

--- a/tools/streamlib-cli/src/commands/mod.rs
+++ b/tools/streamlib-cli/src/commands/mod.rs
@@ -11,5 +11,6 @@ pub mod logs;
 pub mod mcp;
 pub mod nodes;
 pub mod pkg;
+pub mod run;
 pub mod schema;
 pub mod setup;

--- a/tools/streamlib-cli/src/commands/run.rs
+++ b/tools/streamlib-cli/src/commands/run.rs
@@ -17,7 +17,7 @@ use anyhow::{Context, Result};
 use streamlib::sdk::RunnerAutoBuild;
 use streamlib::sdk::runtime::Runner;
 use streamlib_api_server::control_plane_host::{
-    ApiServerControlPlaneBindConfig, register_api_server_control_plane_processor_on_runtime,
+    ApiServerControlPlaneHostConfig, register_api_server_control_plane_processor_on_runtime,
 };
 
 /// The entry file both verbs resolve when `--file` is not given.
@@ -25,40 +25,55 @@ pub const DEFAULT_APP_ENTRY_FILE_NAME: &str = "app.py";
 
 /// Which verb the user typed. Both boot identically today; the name is what
 /// reaches the logs and the error text.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy)]
 pub enum AppLaunchVerb {
     Run,
     Dev,
 }
 
-impl AppLaunchVerb {
-    fn as_str(self) -> &'static str {
-        match self {
+impl std::fmt::Display for AppLaunchVerb {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
             AppLaunchVerb::Run => "run",
             AppLaunchVerb::Dev => "dev",
-        }
+        })
     }
 }
 
-/// Everything `run` / `dev` take from the command line.
-pub struct AppLaunchArgs {
-    pub verb: AppLaunchVerb,
-    /// Explicit entry file (`-f`), overriding the `app.py` convention.
-    pub entry_file: Option<PathBuf>,
-    /// App root (`--dir`); the exact CWD when absent, never a parent.
-    pub anchor_dir: Option<PathBuf>,
-    pub bind_host: String,
-    pub bind_port: u16,
-    pub node_name: Option<String>,
+/// The command line `run` and `dev` share; both verbs take exactly these.
+#[derive(clap::Args)]
+pub struct AppLaunchCommandArgs {
+    /// Entry file to launch, overriding the `app.py` convention.
+    #[arg(short = 'f', long = "file", value_name = "FILE")]
+    pub file: Option<PathBuf>,
+
+    /// App root to resolve the entry file against
+    /// (default: current working directory, no walk-up).
+    #[arg(long)]
+    pub dir: Option<PathBuf>,
+
+    /// Host address to bind the control plane to. The default is loopback: the
+    /// control plane's mutating routes are open by default, so binding a wider
+    /// interface exposes them.
+    #[arg(long, default_value = "127.0.0.1")]
+    pub host: String,
+
+    /// Port for the control plane; increments on collision.
+    #[arg(short, long, default_value = "9000")]
+    pub port: u16,
+
+    /// Node name published to the registry (auto-generated when omitted).
+    #[arg(long)]
+    pub name: Option<String>,
 }
 
 /// Resolve the app root: `--dir` when given, else the exact CWD.
 ///
 /// No walk-up, deliberately mirroring `streamlib add` — inside a monorepo a
 /// walk-up makes "which app am I in" ambiguous.
-fn resolve_anchor_dir(anchor_dir: Option<&Path>) -> Result<PathBuf> {
+fn resolve_anchor_dir(anchor_dir: Option<PathBuf>) -> Result<PathBuf> {
     match anchor_dir {
-        Some(root) => Ok(root.to_path_buf()),
+        Some(root) => Ok(root),
         None => std::env::current_dir().context("resolve current working directory"),
     }
 }
@@ -81,7 +96,7 @@ pub fn resolve_app_entry_file(
                  Run it from your app root, point at one with `--dir <app-root>`, or name the \
                  entry file with `-f <file>`.",
                 anchor_dir.display(),
-                verb.as_str(),
+                verb,
             );
         }
         return Ok(conventional);
@@ -103,28 +118,30 @@ pub fn resolve_app_entry_file(
 }
 
 /// Boot the app's node and own its run loop until the user interrupts it.
-pub fn launch_app_node(args: AppLaunchArgs) -> Result<()> {
-    let anchor_dir = resolve_anchor_dir(args.anchor_dir.as_deref())?;
-    let entry_file = resolve_app_entry_file(args.verb, &anchor_dir, args.entry_file.as_deref())?;
+pub fn launch_app_node(verb: AppLaunchVerb, args: AppLaunchCommandArgs) -> Result<()> {
+    let anchor_dir = resolve_anchor_dir(args.dir)?;
+    let entry_file = resolve_app_entry_file(verb, &anchor_dir, args.file.as_deref())?;
 
     tracing::info!(
-        verb = args.verb.as_str(),
+        %verb,
         entry = %entry_file.display(),
-        "Starting StreamLib node"
+        "Resolved app entry"
     );
 
     let runtime = Runner::with_auto_build()?;
     register_api_server_control_plane_processor_on_runtime(
         &runtime,
-        ApiServerControlPlaneBindConfig {
-            bind_host: args.bind_host,
-            bind_port: args.bind_port,
-            node_name: args.node_name,
+        ApiServerControlPlaneHostConfig {
+            bind_host: args.host,
+            bind_port: args.port,
+            node_name: args.name,
         },
     )?;
 
     runtime.start()?;
-    tracing::info!("Node ready — `streamlib nodes` lists it. Press Ctrl+C to stop.");
+    tracing::info!(
+        "Node ready with an empty graph — `streamlib nodes` lists it. Press Ctrl+C to stop."
+    );
     runtime.wait_for_signal()?;
 
     Ok(())
@@ -133,29 +150,6 @@ pub fn launch_app_node(args: AppLaunchArgs) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// A temp dir that removes itself when the test ends.
-    struct TempDirRemovedOnDrop(PathBuf);
-
-    impl TempDirRemovedOnDrop {
-        fn new(name: &str) -> Self {
-            let path = std::env::temp_dir()
-                .join(format!("streamlib-run-entry-{name}-{}", std::process::id()));
-            let _ = std::fs::remove_dir_all(&path);
-            std::fs::create_dir_all(&path).expect("create temp dir");
-            Self(path)
-        }
-
-        fn path(&self) -> &Path {
-            &self.0
-        }
-    }
-
-    impl Drop for TempDirRemovedOnDrop {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.0);
-        }
-    }
 
     fn write_file(dir: &Path, name: &str, contents: &str) {
         if let Some(parent) = Path::new(name).parent() {
@@ -166,7 +160,7 @@ mod tests {
 
     #[test]
     fn no_args_resolves_the_conventional_entry_at_the_anchor() {
-        let temp = TempDirRemovedOnDrop::new("conventional");
+        let temp = tempfile::tempdir().expect("create temp dir");
         write_file(
             temp.path(),
             DEFAULT_APP_ENTRY_FILE_NAME,
@@ -181,7 +175,7 @@ mod tests {
 
     #[test]
     fn explicit_entry_file_overrides_the_convention() {
-        let temp = TempDirRemovedOnDrop::new("override");
+        let temp = tempfile::tempdir().expect("create temp dir");
         write_file(
             temp.path(),
             DEFAULT_APP_ENTRY_FILE_NAME,
@@ -198,7 +192,7 @@ mod tests {
 
     #[test]
     fn explicit_entry_file_may_be_absolute() {
-        let temp = TempDirRemovedOnDrop::new("absolute");
+        let temp = tempfile::tempdir().expect("create temp dir");
         write_file(temp.path(), "elsewhere.py", "def setup(rt):\n    pass\n");
         let absolute = temp.path().join("elsewhere.py");
 
@@ -210,7 +204,7 @@ mod tests {
 
     #[test]
     fn a_missing_conventional_entry_names_the_convention_and_the_anchor() {
-        let temp = TempDirRemovedOnDrop::new("missing");
+        let temp = tempfile::tempdir().expect("create temp dir");
 
         let error = resolve_app_entry_file(AppLaunchVerb::Dev, temp.path(), None)
             .expect_err("an empty anchor has no entry");
@@ -236,7 +230,7 @@ mod tests {
 
     #[test]
     fn a_missing_explicit_entry_names_the_path_it_tried() {
-        let temp = TempDirRemovedOnDrop::new("missing-explicit");
+        let temp = tempfile::tempdir().expect("create temp dir");
 
         let error =
             resolve_app_entry_file(AppLaunchVerb::Run, temp.path(), Some(Path::new("gone.py")))
@@ -250,7 +244,7 @@ mod tests {
 
     #[test]
     fn resolution_never_walks_up_to_a_parent() {
-        let temp = TempDirRemovedOnDrop::new("no-walk-up");
+        let temp = tempfile::tempdir().expect("create temp dir");
         write_file(
             temp.path(),
             DEFAULT_APP_ENTRY_FILE_NAME,
@@ -270,7 +264,7 @@ mod tests {
 
     #[test]
     fn a_directory_named_like_the_entry_is_not_an_entry() {
-        let temp = TempDirRemovedOnDrop::new("dir-not-file");
+        let temp = tempfile::tempdir().expect("create temp dir");
         std::fs::create_dir_all(temp.path().join(DEFAULT_APP_ENTRY_FILE_NAME))
             .expect("create dir shadowing the entry name");
 
@@ -287,10 +281,10 @@ mod tests {
 
     #[test]
     fn the_anchor_is_the_dir_flag_when_given() {
-        let temp = TempDirRemovedOnDrop::new("anchor-flag");
+        let temp = tempfile::tempdir().expect("create temp dir");
 
         assert_eq!(
-            resolve_anchor_dir(Some(temp.path())).expect("anchor resolves"),
+            resolve_anchor_dir(Some(temp.path().to_path_buf())).expect("anchor resolves"),
             temp.path(),
         );
     }

--- a/tools/streamlib-cli/src/commands/run.rs
+++ b/tools/streamlib-cli/src/commands/run.rs
@@ -55,10 +55,10 @@ pub struct AppLaunchCommandArgs {
     #[arg(long = "dir", value_name = "DIR")]
     pub anchor_dir: Option<PathBuf>,
 
-    /// Host address to bind the control plane to. The default is loopback: the
-    /// control plane's mutating routes are open by default, so binding a wider
-    /// interface exposes them.
-    #[arg(long = "host", value_name = "HOST", default_value = "127.0.0.1")]
+    /// Host address to bind the control plane to. Defaults to all interfaces,
+    /// matching `streamlib-runtime`, so nodes can reach each other; the
+    /// control plane's mutating routes are open unless auth is configured.
+    #[arg(long = "host", value_name = "HOST", default_value = "0.0.0.0")]
     pub bind_host: String,
 
     /// Port for the control plane; increments on collision.

--- a/tools/streamlib-cli/src/commands/run.rs
+++ b/tools/streamlib-cli/src/commands/run.rs
@@ -1,0 +1,287 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib run` / `streamlib dev` — boot the app's node with the control
+//! plane hosted in-process.
+//!
+//! Both verbs resolve the app's entry file, then stand up a runtime carrying
+//! the statically-linked api-server, so the node publishes a node-registry
+//! entry and `nodes` / `graph` / `tap` drive it exactly as they drive a
+//! `streamlib-runtime` process. The boot recipe itself lives in
+//! [`streamlib_api_server::control_plane_host`] — the two hosts share it rather
+//! than each carrying a copy.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use streamlib::sdk::RunnerAutoBuild;
+use streamlib::sdk::runtime::Runner;
+use streamlib_api_server::control_plane_host::{
+    ApiServerControlPlaneBindConfig, register_api_server_control_plane_processor_on_runtime,
+};
+
+/// The entry file both verbs resolve when `--file` is not given.
+pub const DEFAULT_APP_ENTRY_FILE_NAME: &str = "app.py";
+
+/// Which verb the user typed. Both boot identically today; the name is what
+/// reaches the logs and the error text.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum AppLaunchVerb {
+    Run,
+    Dev,
+}
+
+impl AppLaunchVerb {
+    fn as_str(self) -> &'static str {
+        match self {
+            AppLaunchVerb::Run => "run",
+            AppLaunchVerb::Dev => "dev",
+        }
+    }
+}
+
+/// Everything `run` / `dev` take from the command line.
+pub struct AppLaunchArgs {
+    pub verb: AppLaunchVerb,
+    /// Explicit entry file (`-f`), overriding the `app.py` convention.
+    pub entry_file: Option<PathBuf>,
+    /// App root (`--dir`); the exact CWD when absent, never a parent.
+    pub anchor_dir: Option<PathBuf>,
+    pub bind_host: String,
+    pub bind_port: u16,
+    pub node_name: Option<String>,
+}
+
+/// Resolve the app root: `--dir` when given, else the exact CWD.
+///
+/// No walk-up, deliberately mirroring `streamlib add` — inside a monorepo a
+/// walk-up makes "which app am I in" ambiguous.
+fn resolve_anchor_dir(anchor_dir: Option<&Path>) -> Result<PathBuf> {
+    match anchor_dir {
+        Some(root) => Ok(root.to_path_buf()),
+        None => std::env::current_dir().context("resolve current working directory"),
+    }
+}
+
+/// Resolve the entry file whose `setup(rt)` the launched node wires its graph
+/// from: `entry_file` outright (relative paths against `anchor_dir`), else
+/// [`DEFAULT_APP_ENTRY_FILE_NAME`] directly at `anchor_dir`.
+pub fn resolve_app_entry_file(
+    verb: AppLaunchVerb,
+    anchor_dir: &Path,
+    entry_file: Option<&Path>,
+) -> Result<PathBuf> {
+    let Some(requested) = entry_file else {
+        let conventional = anchor_dir.join(DEFAULT_APP_ENTRY_FILE_NAME);
+        if !conventional.is_file() {
+            anyhow::bail!(
+                "no `{DEFAULT_APP_ENTRY_FILE_NAME}` in `{}`\n\
+                 `streamlib {}` reads `{DEFAULT_APP_ENTRY_FILE_NAME}` from this directory only — \
+                 it never searches parent directories.\n\
+                 Run it from your app root, point at one with `--dir <app-root>`, or name the \
+                 entry file with `-f <file>`.",
+                anchor_dir.display(),
+                verb.as_str(),
+            );
+        }
+        return Ok(conventional);
+    };
+
+    let requested_path = if requested.is_absolute() {
+        requested.to_path_buf()
+    } else {
+        anchor_dir.join(requested)
+    };
+    if !requested_path.is_file() {
+        anyhow::bail!(
+            "no entry file at `{}` (from `-f {}`)",
+            requested_path.display(),
+            requested.display(),
+        );
+    }
+    Ok(requested_path)
+}
+
+/// Boot the app's node and own its run loop until the user interrupts it.
+pub fn launch_app_node(args: AppLaunchArgs) -> Result<()> {
+    let anchor_dir = resolve_anchor_dir(args.anchor_dir.as_deref())?;
+    let entry_file = resolve_app_entry_file(args.verb, &anchor_dir, args.entry_file.as_deref())?;
+
+    tracing::info!(
+        verb = args.verb.as_str(),
+        entry = %entry_file.display(),
+        "Starting StreamLib node"
+    );
+
+    let runtime = Runner::with_auto_build()?;
+    register_api_server_control_plane_processor_on_runtime(
+        &runtime,
+        ApiServerControlPlaneBindConfig {
+            bind_host: args.bind_host,
+            bind_port: args.bind_port,
+            node_name: args.node_name,
+        },
+    )?;
+
+    runtime.start()?;
+    tracing::info!("Node ready — `streamlib nodes` lists it. Press Ctrl+C to stop.");
+    runtime.wait_for_signal()?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A temp dir that removes itself when the test ends.
+    struct TempDirRemovedOnDrop(PathBuf);
+
+    impl TempDirRemovedOnDrop {
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "streamlib-run-entry-{name}-{}",
+                std::process::id()
+            ));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(&path).expect("create temp dir");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDirRemovedOnDrop {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn write_file(dir: &Path, name: &str, contents: &str) {
+        if let Some(parent) = Path::new(name).parent() {
+            std::fs::create_dir_all(dir.join(parent)).expect("create parent dir");
+        }
+        std::fs::write(dir.join(name), contents).expect("write file");
+    }
+
+    #[test]
+    fn no_args_resolves_the_conventional_entry_at_the_anchor() {
+        let temp = TempDirRemovedOnDrop::new("conventional");
+        write_file(temp.path(), DEFAULT_APP_ENTRY_FILE_NAME, "def setup(rt):\n    pass\n");
+
+        let resolved = resolve_app_entry_file(AppLaunchVerb::Run, temp.path(), None)
+            .expect("app.py at the anchor resolves");
+
+        assert_eq!(resolved, temp.path().join(DEFAULT_APP_ENTRY_FILE_NAME));
+    }
+
+    #[test]
+    fn explicit_entry_file_overrides_the_convention() {
+        let temp = TempDirRemovedOnDrop::new("override");
+        write_file(temp.path(), DEFAULT_APP_ENTRY_FILE_NAME, "def setup(rt):\n    pass\n");
+        write_file(temp.path(), "other.py", "def setup(rt):\n    pass\n");
+
+        let resolved =
+            resolve_app_entry_file(AppLaunchVerb::Run, temp.path(), Some(Path::new("other.py")))
+                .expect("explicit entry resolves");
+
+        assert_eq!(resolved, temp.path().join("other.py"));
+    }
+
+    #[test]
+    fn explicit_entry_file_may_be_absolute() {
+        let temp = TempDirRemovedOnDrop::new("absolute");
+        write_file(temp.path(), "elsewhere.py", "def setup(rt):\n    pass\n");
+        let absolute = temp.path().join("elsewhere.py");
+
+        let resolved = resolve_app_entry_file(AppLaunchVerb::Dev, temp.path(), Some(&absolute))
+            .expect("absolute entry resolves");
+
+        assert_eq!(resolved, absolute);
+    }
+
+    #[test]
+    fn a_missing_conventional_entry_names_the_convention_and_the_anchor() {
+        let temp = TempDirRemovedOnDrop::new("missing");
+
+        let error = resolve_app_entry_file(AppLaunchVerb::Dev, temp.path(), None)
+            .expect_err("an empty anchor has no entry");
+
+        let message = error.to_string();
+        assert!(
+            message.contains(DEFAULT_APP_ENTRY_FILE_NAME),
+            "error must name the convention: {message}"
+        );
+        assert!(
+            message.contains(&temp.path().display().to_string()),
+            "error must name the anchor it searched: {message}"
+        );
+        assert!(
+            message.contains("streamlib dev"),
+            "error must name the verb the user typed: {message}"
+        );
+        assert!(
+            message.contains("-f "),
+            "error must offer the `-f` escape hatch: {message}"
+        );
+    }
+
+    #[test]
+    fn a_missing_explicit_entry_names_the_path_it_tried() {
+        let temp = TempDirRemovedOnDrop::new("missing-explicit");
+
+        let error =
+            resolve_app_entry_file(AppLaunchVerb::Run, temp.path(), Some(Path::new("gone.py")))
+                .expect_err("a nonexistent `-f` target is an error");
+
+        assert!(
+            error.to_string().contains("gone.py"),
+            "error must name the path it tried: {error}"
+        );
+    }
+
+    #[test]
+    fn resolution_never_walks_up_to_a_parent() {
+        let temp = TempDirRemovedOnDrop::new("no-walk-up");
+        write_file(temp.path(), DEFAULT_APP_ENTRY_FILE_NAME, "def setup(rt):\n    pass\n");
+        let nested = temp.path().join("nested");
+        std::fs::create_dir_all(&nested).expect("create nested dir");
+
+        let error = resolve_app_entry_file(AppLaunchVerb::Run, &nested, None)
+            .expect_err("a parent's app.py must not be adopted");
+
+        assert!(
+            error.to_string().contains("never searches parent"),
+            "error must state the no-walk-up rule: {error}"
+        );
+    }
+
+    #[test]
+    fn a_directory_named_like_the_entry_is_not_an_entry() {
+        let temp = TempDirRemovedOnDrop::new("dir-not-file");
+        std::fs::create_dir_all(temp.path().join(DEFAULT_APP_ENTRY_FILE_NAME))
+            .expect("create dir shadowing the entry name");
+
+        resolve_app_entry_file(AppLaunchVerb::Run, temp.path(), None)
+            .expect_err("a directory named app.py is not an entry file");
+    }
+
+    #[test]
+    fn the_anchor_is_the_cwd_when_dir_is_absent() {
+        let cwd = std::env::current_dir().expect("cwd");
+
+        assert_eq!(resolve_anchor_dir(None).expect("anchor resolves"), cwd);
+    }
+
+    #[test]
+    fn the_anchor_is_the_dir_flag_when_given() {
+        let temp = TempDirRemovedOnDrop::new("anchor-flag");
+
+        assert_eq!(
+            resolve_anchor_dir(Some(temp.path())).expect("anchor resolves"),
+            temp.path(),
+        );
+    }
+}

--- a/tools/streamlib-cli/src/commands/run.rs
+++ b/tools/streamlib-cli/src/commands/run.rs
@@ -41,30 +41,38 @@ impl std::fmt::Display for AppLaunchVerb {
 }
 
 /// The command line `run` and `dev` share; both verbs take exactly these.
+///
+/// Field names are the explicit forms the rest of the code uses; the `long =`
+/// flag names are the user-facing contract and stay short.
 #[derive(clap::Args)]
 pub struct AppLaunchCommandArgs {
     /// Entry file to launch, overriding the `app.py` convention.
     #[arg(short = 'f', long = "file", value_name = "FILE")]
-    pub file: Option<PathBuf>,
+    pub entry_file: Option<PathBuf>,
 
     /// App root to resolve the entry file against
     /// (default: current working directory, no walk-up).
-    #[arg(long)]
-    pub dir: Option<PathBuf>,
+    #[arg(long = "dir", value_name = "DIR")]
+    pub anchor_dir: Option<PathBuf>,
 
     /// Host address to bind the control plane to. The default is loopback: the
     /// control plane's mutating routes are open by default, so binding a wider
     /// interface exposes them.
-    #[arg(long, default_value = "127.0.0.1")]
-    pub host: String,
+    #[arg(long = "host", value_name = "HOST", default_value = "127.0.0.1")]
+    pub bind_host: String,
 
     /// Port for the control plane; increments on collision.
-    #[arg(short, long, default_value = "9000")]
-    pub port: u16,
+    #[arg(
+        short = 'p',
+        long = "port",
+        value_name = "PORT",
+        default_value = "9000"
+    )]
+    pub bind_port: u16,
 
     /// Node name published to the registry (auto-generated when omitted).
-    #[arg(long)]
-    pub name: Option<String>,
+    #[arg(long = "name", value_name = "NAME")]
+    pub node_name: Option<String>,
 }
 
 /// Resolve the app root: `--dir` when given, else the exact CWD.
@@ -119,22 +127,24 @@ pub fn resolve_app_entry_file(
 
 /// Boot the app's node and own its run loop until the user interrupts it.
 pub fn launch_app_node(verb: AppLaunchVerb, args: AppLaunchCommandArgs) -> Result<()> {
-    let anchor_dir = resolve_anchor_dir(args.dir)?;
-    let entry_file = resolve_app_entry_file(verb, &anchor_dir, args.file.as_deref())?;
+    let anchor_dir = resolve_anchor_dir(args.anchor_dir)?;
+    let entry_file = resolve_app_entry_file(verb, &anchor_dir, args.entry_file.as_deref())?;
 
+    // Every log line here must follow `Runner` construction: these verbs leave
+    // logging to the runtime, so nothing before this call has a subscriber.
+    let runtime = Runner::with_auto_build()?;
     tracing::info!(
         %verb,
         entry = %entry_file.display(),
         "Resolved app entry"
     );
 
-    let runtime = Runner::with_auto_build()?;
     register_api_server_control_plane_processor_on_runtime(
         &runtime,
         ApiServerControlPlaneHostConfig {
-            bind_host: args.host,
-            bind_port: args.port,
-            node_name: args.name,
+            bind_host: args.bind_host,
+            bind_port: args.bind_port,
+            node_name: args.node_name,
         },
     )?;
 

--- a/tools/streamlib-cli/src/commands/run.rs
+++ b/tools/streamlib-cli/src/commands/run.rs
@@ -139,10 +139,8 @@ mod tests {
 
     impl TempDirRemovedOnDrop {
         fn new(name: &str) -> Self {
-            let path = std::env::temp_dir().join(format!(
-                "streamlib-run-entry-{name}-{}",
-                std::process::id()
-            ));
+            let path = std::env::temp_dir()
+                .join(format!("streamlib-run-entry-{name}-{}", std::process::id()));
             let _ = std::fs::remove_dir_all(&path);
             std::fs::create_dir_all(&path).expect("create temp dir");
             Self(path)
@@ -169,7 +167,11 @@ mod tests {
     #[test]
     fn no_args_resolves_the_conventional_entry_at_the_anchor() {
         let temp = TempDirRemovedOnDrop::new("conventional");
-        write_file(temp.path(), DEFAULT_APP_ENTRY_FILE_NAME, "def setup(rt):\n    pass\n");
+        write_file(
+            temp.path(),
+            DEFAULT_APP_ENTRY_FILE_NAME,
+            "def setup(rt):\n    pass\n",
+        );
 
         let resolved = resolve_app_entry_file(AppLaunchVerb::Run, temp.path(), None)
             .expect("app.py at the anchor resolves");
@@ -180,7 +182,11 @@ mod tests {
     #[test]
     fn explicit_entry_file_overrides_the_convention() {
         let temp = TempDirRemovedOnDrop::new("override");
-        write_file(temp.path(), DEFAULT_APP_ENTRY_FILE_NAME, "def setup(rt):\n    pass\n");
+        write_file(
+            temp.path(),
+            DEFAULT_APP_ENTRY_FILE_NAME,
+            "def setup(rt):\n    pass\n",
+        );
         write_file(temp.path(), "other.py", "def setup(rt):\n    pass\n");
 
         let resolved =
@@ -245,7 +251,11 @@ mod tests {
     #[test]
     fn resolution_never_walks_up_to_a_parent() {
         let temp = TempDirRemovedOnDrop::new("no-walk-up");
-        write_file(temp.path(), DEFAULT_APP_ENTRY_FILE_NAME, "def setup(rt):\n    pass\n");
+        write_file(
+            temp.path(),
+            DEFAULT_APP_ENTRY_FILE_NAME,
+            "def setup(rt):\n    pass\n",
+        );
         let nested = temp.path().join("nested");
         std::fs::create_dir_all(&nested).expect("create nested dir");
 

--- a/tools/streamlib-cli/src/main.rs
+++ b/tools/streamlib-cli/src/main.rs
@@ -878,7 +878,7 @@ mod tests {
                 _ => unreachable!("`{verb}` parses to its own variant"),
             };
             assert_eq!(
-                launch.host, "127.0.0.1",
+                launch.bind_host, "127.0.0.1",
                 "`{verb}` must default to loopback"
             );
         }

--- a/tools/streamlib-cli/src/main.rs
+++ b/tools/streamlib-cli/src/main.rs
@@ -30,52 +30,16 @@ enum Commands {
     /// publishes a node-registry entry, so `streamlib nodes`, `graph`, and
     /// `tap` drive it. Runs until interrupted.
     Run {
-        /// Entry file to launch, overriding the `app.py` convention.
-        #[arg(short = 'f', long = "file", value_name = "FILE")]
-        file: Option<PathBuf>,
-
-        /// App root to resolve the entry file against
-        /// (default: current working directory, no walk-up).
-        #[arg(long)]
-        dir: Option<PathBuf>,
-
-        /// Host address to bind the control plane to.
-        #[arg(long, default_value = "0.0.0.0")]
-        host: String,
-
-        /// Port for the control plane; increments on collision.
-        #[arg(short, long, default_value = "9000")]
-        port: u16,
-
-        /// Node name published to the registry (auto-generated when omitted).
-        #[arg(long)]
-        name: Option<String>,
+        #[command(flatten)]
+        launch: commands::run::AppLaunchCommandArgs,
     },
 
     /// Boot this app as a StreamLib node for development.
     ///
     /// Same entry resolution and in-process control plane as `run`.
     Dev {
-        /// Entry file to launch, overriding the `app.py` convention.
-        #[arg(short = 'f', long = "file", value_name = "FILE")]
-        file: Option<PathBuf>,
-
-        /// App root to resolve the entry file against
-        /// (default: current working directory, no walk-up).
-        #[arg(long)]
-        dir: Option<PathBuf>,
-
-        /// Host address to bind the control plane to.
-        #[arg(long, default_value = "0.0.0.0")]
-        host: String,
-
-        /// Port for the control plane; increments on collision.
-        #[arg(short, long, default_value = "9000")]
-        port: u16,
-
-        /// Node name published to the registry (auto-generated when omitted).
-        #[arg(long)]
-        name: Option<String>,
+        #[command(flatten)]
+        launch: commands::run::AppLaunchCommandArgs,
     },
 
     /// Stream a runtime's on-disk JSONL log file in pretty format, or — with
@@ -597,20 +561,35 @@ fn main() -> Result<()> {
         .block_on(async_main(cli))
 }
 
-/// The short-lived-CLI logging config for `command`. Every subcommand mirrors
-/// pretty logs to stdout except `mcp`, which speaks a byte protocol on stdout
-/// and so routes its mirror to stderr to keep fd 1 carrying only MCP JSON-RPC
-/// frames.
-fn logging_config_for(command: &Option<Commands>) -> streamlib::sdk::logging::StreamlibLoggingConfig {
-    if matches!(command, Some(Commands::Mcp { .. })) {
-        streamlib::sdk::logging::StreamlibLoggingConfig::for_stdio_protocol("streamlib-cli")
-    } else {
-        streamlib::sdk::logging::StreamlibLoggingConfig::for_cli("streamlib-cli")
+/// The short-lived-CLI logging config for `command`, or `None` when the
+/// subcommand hosts a runtime and must leave logging to it.
+///
+/// Every short-lived subcommand mirrors pretty logs to stdout except `mcp`,
+/// which speaks a byte protocol on stdout and so routes its mirror to stderr to
+/// keep fd 1 carrying only MCP JSON-RPC frames. `run` / `dev` return `None`:
+/// `logging::init` is first-caller-wins, so initializing here would demote the
+/// `Runner`'s own runtime-shaped init to a noop guard and cost the hosted node
+/// its JSONL log — the durable observability contract — and fd-level stdio
+/// interception.
+fn logging_config_for(
+    command: &Option<Commands>,
+) -> Option<streamlib::sdk::logging::StreamlibLoggingConfig> {
+    match command {
+        Some(Commands::Run { .. } | Commands::Dev { .. }) => None,
+        Some(Commands::Mcp { .. }) => Some(
+            streamlib::sdk::logging::StreamlibLoggingConfig::for_stdio_protocol("streamlib-cli"),
+        ),
+        _ => Some(streamlib::sdk::logging::StreamlibLoggingConfig::for_cli(
+            "streamlib-cli",
+        )),
     }
 }
 
 async fn async_main(cli: Cli) -> Result<()> {
-    let _logging_guard = streamlib::sdk::logging::init(logging_config_for(&cli.command))?;
+    let _logging_guard = match logging_config_for(&cli.command) {
+        Some(config) => Some(streamlib::sdk::logging::init(config)?),
+        None => None,
+    };
 
     match cli.command {
         Some(Commands::Logs {
@@ -646,34 +625,12 @@ async fn async_main(cli: Cli) -> Result<()> {
             })
             .await?
         }
-        Some(Commands::Run {
-            file,
-            dir,
-            host,
-            port,
-            name,
-        }) => commands::run::launch_app_node(commands::run::AppLaunchArgs {
-            verb: commands::run::AppLaunchVerb::Run,
-            entry_file: file,
-            anchor_dir: dir,
-            bind_host: host,
-            bind_port: port,
-            node_name: name,
-        })?,
-        Some(Commands::Dev {
-            file,
-            dir,
-            host,
-            port,
-            name,
-        }) => commands::run::launch_app_node(commands::run::AppLaunchArgs {
-            verb: commands::run::AppLaunchVerb::Dev,
-            entry_file: file,
-            anchor_dir: dir,
-            bind_host: host,
-            bind_port: port,
-            node_name: name,
-        })?,
+        Some(Commands::Run { launch }) => {
+            commands::run::launch_app_node(commands::run::AppLaunchVerb::Run, launch)?
+        }
+        Some(Commands::Dev { launch }) => {
+            commands::run::launch_app_node(commands::run::AppLaunchVerb::Dev, launch)?
+        }
         Some(Commands::Mcp { attach }) => commands::mcp::run(attach).await?,
         Some(Commands::Nodes) => commands::nodes::run()?,
         Some(Commands::Graph { url, node }) => {
@@ -878,7 +835,8 @@ mod tests {
     /// here, catching a regression that would re-pollute the protocol stream.
     #[test]
     fn mcp_subcommand_mirrors_logs_to_stderr_not_stdout() {
-        let mcp = logging_config_for(&Some(Commands::Mcp { attach: None }));
+        let mcp = logging_config_for(&Some(Commands::Mcp { attach: None }))
+            .expect("mcp owns its own short-lived logging");
         assert_eq!(
             mcp.pretty_mirror_stream,
             PrettyMirrorStream::Stderr,
@@ -886,13 +844,53 @@ mod tests {
         );
     }
 
-    /// Every path other than `mcp` keeps the human-facing stdout mirror.
+    /// Every short-lived path other than `mcp` keeps the human-facing stdout
+    /// mirror.
     #[test]
     fn non_mcp_invocation_mirrors_logs_to_stdout() {
-        assert_eq!(
-            logging_config_for(&None).pretty_mirror_stream,
-            PrettyMirrorStream::Stdout
-        );
+        let config = logging_config_for(&None).expect("short-lived verbs own their logging");
+        assert_eq!(config.pretty_mirror_stream, PrettyMirrorStream::Stdout);
+    }
+
+    /// `run` / `dev` host a runtime, and `logging::init` is first-caller-wins:
+    /// initializing the CLI's short-lived config here would demote the
+    /// `Runner`'s runtime-shaped init to a noop guard, costing the hosted node
+    /// its JSONL log and fd-level stdio interception. Returning a config for
+    /// either verb goes red here.
+    #[test]
+    fn runtime_hosting_verbs_defer_logging_to_the_runner() {
+        for verb in ["run", "dev"] {
+            assert!(
+                logging_config_for(&Some(parse_subcommand(verb))).is_none(),
+                "`{verb}` hosts a runtime and must leave logging to the Runner"
+            );
+        }
+    }
+
+    /// The control plane's mutating routes are open by default, so the
+    /// laptop-first verbs must not bind a wider interface than loopback without
+    /// the user asking for it.
+    #[test]
+    fn runtime_hosting_verbs_bind_loopback_by_default() {
+        for verb in ["run", "dev"] {
+            let launch = match parse_subcommand(verb) {
+                Commands::Run { launch } | Commands::Dev { launch } => launch,
+                _ => unreachable!("`{verb}` parses to its own variant"),
+            };
+            assert_eq!(
+                launch.host, "127.0.0.1",
+                "`{verb}` must default to loopback"
+            );
+        }
+    }
+
+    /// Parse `streamlib <verb>` with no further arguments, so clap supplies the
+    /// real defaults rather than the test hand-building the struct.
+    fn parse_subcommand(verb: &str) -> Commands {
+        Cli::try_parse_from(["streamlib", verb])
+            .unwrap_or_else(|error| panic!("`streamlib {verb}` must parse bare: {error}"))
+            .command
+            .expect("a subcommand was given")
     }
 
     /// `--count` is control-plane-only: `logs <runtime_id> --count N` (local

--- a/tools/streamlib-cli/src/main.rs
+++ b/tools/streamlib-cli/src/main.rs
@@ -867,19 +867,19 @@ mod tests {
         }
     }
 
-    /// The control plane's mutating routes are open by default, so the
-    /// laptop-first verbs must not bind a wider interface than loopback without
-    /// the user asking for it.
+    /// Owner-decided (2026-07-30, #1683): every host of the one control plane
+    /// binds all interfaces by default so nodes can reach each other. `run` /
+    /// `dev` must not drift from `streamlib-runtime`'s default.
     #[test]
-    fn runtime_hosting_verbs_bind_loopback_by_default() {
+    fn runtime_hosting_verbs_bind_all_interfaces_by_default() {
         for verb in ["run", "dev"] {
             let launch = match parse_subcommand(verb) {
                 Commands::Run { launch } | Commands::Dev { launch } => launch,
                 _ => unreachable!("`{verb}` parses to its own variant"),
             };
             assert_eq!(
-                launch.bind_host, "127.0.0.1",
-                "`{verb}` must default to loopback"
+                launch.bind_host, "0.0.0.0",
+                "`{verb}` must match the runtime's all-interfaces default"
             );
         }
     }

--- a/tools/streamlib-cli/src/main.rs
+++ b/tools/streamlib-cli/src/main.rs
@@ -23,6 +23,61 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Boot this app as a StreamLib node, hosting the control plane in-process.
+    ///
+    /// Reads `app.py` from the anchor directory — `--dir` when given, else the
+    /// exact CWD, never a parent — or the file named by `-f`. The node
+    /// publishes a node-registry entry, so `streamlib nodes`, `graph`, and
+    /// `tap` drive it. Runs until interrupted.
+    Run {
+        /// Entry file to launch, overriding the `app.py` convention.
+        #[arg(short = 'f', long = "file", value_name = "FILE")]
+        file: Option<PathBuf>,
+
+        /// App root to resolve the entry file against
+        /// (default: current working directory, no walk-up).
+        #[arg(long)]
+        dir: Option<PathBuf>,
+
+        /// Host address to bind the control plane to.
+        #[arg(long, default_value = "0.0.0.0")]
+        host: String,
+
+        /// Port for the control plane; increments on collision.
+        #[arg(short, long, default_value = "9000")]
+        port: u16,
+
+        /// Node name published to the registry (auto-generated when omitted).
+        #[arg(long)]
+        name: Option<String>,
+    },
+
+    /// Boot this app as a StreamLib node for development.
+    ///
+    /// Same entry resolution and in-process control plane as `run`.
+    Dev {
+        /// Entry file to launch, overriding the `app.py` convention.
+        #[arg(short = 'f', long = "file", value_name = "FILE")]
+        file: Option<PathBuf>,
+
+        /// App root to resolve the entry file against
+        /// (default: current working directory, no walk-up).
+        #[arg(long)]
+        dir: Option<PathBuf>,
+
+        /// Host address to bind the control plane to.
+        #[arg(long, default_value = "0.0.0.0")]
+        host: String,
+
+        /// Port for the control plane; increments on collision.
+        #[arg(short, long, default_value = "9000")]
+        port: u16,
+
+        /// Node name published to the registry (auto-generated when omitted).
+        #[arg(long)]
+        name: Option<String>,
+    },
+
     /// Stream a runtime's on-disk JSONL log file in pretty format, or — with
     /// `--url` — collect a bounded sample of a running node's live event stream
     /// via its control plane.
@@ -591,6 +646,34 @@ async fn async_main(cli: Cli) -> Result<()> {
             })
             .await?
         }
+        Some(Commands::Run {
+            file,
+            dir,
+            host,
+            port,
+            name,
+        }) => commands::run::launch_app_node(commands::run::AppLaunchArgs {
+            verb: commands::run::AppLaunchVerb::Run,
+            entry_file: file,
+            anchor_dir: dir,
+            bind_host: host,
+            bind_port: port,
+            node_name: name,
+        })?,
+        Some(Commands::Dev {
+            file,
+            dir,
+            host,
+            port,
+            name,
+        }) => commands::run::launch_app_node(commands::run::AppLaunchArgs {
+            verb: commands::run::AppLaunchVerb::Dev,
+            entry_file: file,
+            anchor_dir: dir,
+            bind_host: host,
+            bind_port: port,
+            node_name: name,
+        })?,
         Some(Commands::Mcp { attach }) => commands::mcp::run(attach).await?,
         Some(Commands::Nodes) => commands::nodes::run()?,
         Some(Commands::Graph { url, node }) => {

--- a/tools/streamlib-cli/tests/run_dev_boot.rs
+++ b/tools/streamlib-cli/tests/run_dev_boot.rs
@@ -5,17 +5,17 @@
 //!
 //! These drive the real `streamlib` binary end to end: it must resolve the
 //! app's entry file, boot a node carrying the statically-linked api-server,
-//! publish a node-registry entry that `streamlib nodes` can discover, and
-//! remove that entry on clean teardown.
+//! publish a node-registry entry that `streamlib nodes` can discover, keep the
+//! JSONL log the observability contract promises, and remove the entry on clean
+//! teardown.
 //!
 //! Booting initializes the full runtime (GPU init included) and binds a real
-//! socket, so the boot tests are local integration tests — the workspace CI
-//! runs `cargo test --lib`, which does not pick up `tests/`. The
-//! entry-resolution failure tests below need no rig: the binary exits before
-//! it builds a runtime.
+//! socket, matching `runtime/streamlib-runtime/tests/boot.rs`, which boots the
+//! same runtime and is likewise not gated. CI runs `cargo test --lib` and so
+//! picks up neither file.
 
-use std::io::{Read, Write};
-use std::net::{TcpListener, TcpStream};
+use std::io::Read;
+use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -23,35 +23,27 @@ use std::time::{Duration, Instant};
 mod cli_integration_support;
 use cli_integration_support::STREAMLIB_BINARY_PATH;
 
-/// Kills the spawned node when the test ends (pass or panic).
-struct ChildGuard(Child);
+/// How long a resolution-failure invocation may take before the test treats it
+/// as wedged. These exit before any runtime is built, so this is generous.
+const RESOLUTION_FAILURE_DEADLINE: Duration = Duration::from_secs(30);
 
-impl Drop for ChildGuard {
+/// Kills the spawned node when the test ends (pass or panic).
+struct SpawnedNodeKilledOnDrop(Child);
+
+impl SpawnedNodeKilledOnDrop {
+    fn process_id(&self) -> u32 {
+        self.0.id()
+    }
+
+    fn wait_for_exit(&mut self) -> std::process::ExitStatus {
+        self.0.wait().expect("wait for the node to exit")
+    }
+}
+
+impl Drop for SpawnedNodeKilledOnDrop {
     fn drop(&mut self) {
         let _ = self.0.kill();
         let _ = self.0.wait();
-    }
-}
-
-/// A temp dir tree that removes itself when the test ends.
-struct TempTreeRemovedOnDrop(PathBuf);
-
-impl TempTreeRemovedOnDrop {
-    fn new(name: &str, discriminator: u16) -> Self {
-        let path = std::env::temp_dir().join(format!("streamlib-run-boot-{name}-{discriminator}"));
-        let _ = std::fs::remove_dir_all(&path);
-        std::fs::create_dir_all(&path).expect("create temp tree");
-        Self(path)
-    }
-
-    fn path(&self) -> &Path {
-        &self.0
-    }
-}
-
-impl Drop for TempTreeRemovedOnDrop {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.0);
     }
 }
 
@@ -65,23 +57,19 @@ fn free_port() -> u16 {
     port
 }
 
-/// Issue a bare HTTP/1.1 GET and return the numeric status code, or `None` if
-/// the connection/parse failed. Raw TCP keeps the test dependency-free.
+/// The HTTP status of a GET against the node, or `None` when the connection
+/// failed. `ureq` is already a dependency of this crate (the `mcp --attach`
+/// client), and its timeouts keep a silent socket from wedging a poll loop.
 fn http_get_status(port: u16, path: &str) -> Option<u16> {
-    let mut stream = TcpStream::connect(("127.0.0.1", port)).ok()?;
-    stream.set_read_timeout(Some(Duration::from_secs(5))).ok()?;
-    let request = format!("GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n");
-    stream.write_all(request.as_bytes()).ok()?;
-    let mut buf = Vec::new();
-    stream.read_to_end(&mut buf).ok()?;
-    let response = String::from_utf8_lossy(&buf);
-    response
-        .lines()
-        .next()?
-        .split_whitespace()
-        .nth(1)?
-        .parse()
-        .ok()
+    let agent = ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(2))
+        .timeout(Duration::from_secs(5))
+        .build();
+    match agent.get(&format!("http://127.0.0.1:{port}{path}")).call() {
+        Ok(response) => Some(response.status()),
+        Err(ureq::Error::Status(code, _)) => Some(code),
+        Err(_) => None,
+    }
 }
 
 /// Poll `/health` across the api-server's bind-retry window until it returns
@@ -100,6 +88,11 @@ fn wait_for_health(base_port: u16, timeout: Duration) -> Option<u16> {
 }
 
 /// Every `*.json` node-registry entry under an isolated `XDG_RUNTIME_DIR`.
+///
+/// The layout is re-derived rather than read from
+/// `node_registry::registry_dir()` on purpose: that resolver reads *this*
+/// process's `XDG_RUNTIME_DIR`, not the spawned child's, so calling it would
+/// force a process-global env mutation and break isolation under parallelism.
 fn registry_entry_paths(xdg_runtime_dir: &Path) -> Vec<PathBuf> {
     let nodes_dir = xdg_runtime_dir.join("streamlib").join("nodes");
     let Ok(entries) = std::fs::read_dir(&nodes_dir) else {
@@ -148,8 +141,8 @@ fn spawn_app_node(
     streamlib_home: &Path,
     xdg_runtime_dir: &Path,
     extra_args: &[&str],
-) -> Child {
-    Command::new(STREAMLIB_BINARY_PATH)
+) -> SpawnedNodeKilledOnDrop {
+    let child = Command::new(STREAMLIB_BINARY_PATH)
         .arg(verb)
         .arg("--dir")
         .arg(app_dir)
@@ -163,7 +156,8 @@ fn spawn_app_node(
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
-        .expect("spawn streamlib")
+        .expect("spawn streamlib");
+    SpawnedNodeKilledOnDrop(child)
 }
 
 /// Run a control verb against the isolated registry and return its output.
@@ -185,25 +179,60 @@ fn interrupt(pid: u32) {
     assert!(status.success(), "SIGINT delivery to pid {pid} failed");
 }
 
-/// Boot a node with `verb`, assert it is discoverable, then interrupt it and
-/// assert the registry entry is gone.
+/// Run `streamlib` with `args` and require it to exit within
+/// [`RESOLUTION_FAILURE_DEADLINE`], returning its exit status and stderr.
+///
+/// A plain `Command::output()` would block forever on the very regression these
+/// callers guard: if entry resolution ever starts walking up, the binary boots
+/// a node and waits for a signal instead of exiting. Killing at the deadline
+/// turns that into a red test rather than a wedged suite.
+fn run_expecting_prompt_exit(args: &[&str]) -> (std::process::ExitStatus, String) {
+    let mut child = Command::new(STREAMLIB_BINARY_PATH)
+        .args(args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn streamlib");
+
+    let deadline = Instant::now() + RESOLUTION_FAILURE_DEADLINE;
+    let status = loop {
+        match child.try_wait().expect("poll streamlib") {
+            Some(status) => break status,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!(
+                    "`streamlib {}` did not exit within {RESOLUTION_FAILURE_DEADLINE:?} — \
+                     entry resolution booted a node instead of failing",
+                    args.join(" "),
+                );
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    };
+
+    let mut stderr = String::new();
+    if let Some(mut pipe) = child.stderr.take() {
+        let _ = pipe.read_to_string(&mut stderr);
+    }
+    (status, stderr)
+}
+
+/// Boot a node with `verb`, assert it is a first-class runtime host, then
+/// interrupt it and assert the registry entry is gone.
 fn assert_verb_boots_registers_and_tears_down(verb: &str) {
+    let app = tempfile::tempdir().expect("create app dir");
+    let home = tempfile::tempdir().expect("create home dir");
+    let xdg = tempfile::tempdir().expect("create xdg dir");
     let port = free_port();
-    let app = TempTreeRemovedOnDrop::new(&format!("{verb}-app"), port);
-    let home = TempTreeRemovedOnDrop::new(&format!("{verb}-home"), port);
-    let xdg = TempTreeRemovedOnDrop::new(&format!("{verb}-xdg"), port);
     write_minimal_app(app.path(), "app.py");
 
-    let child = spawn_app_node(verb, app.path(), port, home.path(), xdg.path(), &[]);
-    let pid = child.id();
-    let mut guard = ChildGuard(child);
+    let mut node = spawn_app_node(verb, app.path(), port, home.path(), xdg.path(), &[]);
+    let pid = node.process_id();
 
     // Boot is process start + GPU init + socket bind; allow a generous window.
-    let served = wait_for_health(port, Duration::from_secs(60));
-    assert!(
-        served.is_some(),
-        "`streamlib {verb}` should boot a node serving /health"
-    );
+    let served_port = wait_for_health(port, Duration::from_secs(60))
+        .unwrap_or_else(|| panic!("`streamlib {verb}` should boot a node serving /health"));
 
     let entry = wait_for_sole_registry_entry(xdg.path(), Duration::from_secs(10))
         .unwrap_or_else(|| panic!("`streamlib {verb}` should publish one node-registry entry"));
@@ -214,7 +243,7 @@ fn assert_verb_boots_registers_and_tears_down(verb: &str) {
     );
     assert_eq!(
         entry["control_url"].as_str(),
-        Some(format!("http://127.0.0.1:{}", served.unwrap()).as_str()),
+        Some(format!("http://127.0.0.1:{served_port}").as_str()),
         "the entry must carry the reachable control URL"
     );
 
@@ -237,8 +266,10 @@ fn assert_verb_boots_registers_and_tears_down(verb: &str) {
         String::from_utf8_lossy(&graph.stderr)
     );
 
+    assert_hosted_node_keeps_its_jsonl_log(&graph.stdout, home.path(), verb);
+
     interrupt(pid);
-    let exited = guard.0.wait().expect("wait for the node to exit");
+    let exited = node.wait_for_exit();
     assert!(
         exited.success(),
         "`streamlib {verb}` should exit cleanly on SIGINT, got {exited}"
@@ -250,28 +281,70 @@ fn assert_verb_boots_registers_and_tears_down(verb: &str) {
     );
 }
 
+/// A CLI-hosted node must be as observable as a `streamlib-runtime`-hosted one:
+/// the api-server carries a `log_path` and that JSONL file exists.
+///
+/// `logging::init` is first-caller-wins, so a CLI that initialized its own
+/// short-lived logging before building the `Runner` would silently demote the
+/// runtime's init to a noop guard and leave `jsonl_log_path()` empty. This is
+/// the lock on that regression.
+fn assert_hosted_node_keeps_its_jsonl_log(graph_stdout: &[u8], streamlib_home: &Path, verb: &str) {
+    let graph: serde_json::Value =
+        serde_json::from_slice(graph_stdout).expect("`streamlib graph` should emit JSON");
+
+    let log_path = find_api_server_log_path(&graph).unwrap_or_else(|| {
+        panic!(
+            "`streamlib {verb}` must pass the runtime's JSONL log path to the api-server; \
+             graph was:\n{graph:#}"
+        )
+    });
+
+    assert!(
+        Path::new(&log_path).is_file(),
+        "the api-server's log_path `{log_path}` must exist on disk"
+    );
+    assert!(
+        Path::new(&log_path).starts_with(streamlib_home),
+        "the JSONL log `{log_path}` must live under the node's STREAMLIB_HOME"
+    );
+}
+
+/// The `log_path` config value of the api-server processor in a graph snapshot.
+fn find_api_server_log_path(graph: &serde_json::Value) -> Option<String> {
+    fn walk(value: &serde_json::Value) -> Option<String> {
+        match value {
+            serde_json::Value::Object(map) => {
+                if let Some(serde_json::Value::String(log_path)) = map.get("log_path") {
+                    return Some(log_path.clone());
+                }
+                map.values().find_map(walk)
+            }
+            serde_json::Value::Array(items) => items.iter().find_map(walk),
+            _ => None,
+        }
+    }
+    walk(graph)
+}
+
 #[test]
-#[ignore = "boots a full runtime (GPU init + socket bind) — needs the local rig"]
 fn run_boots_a_discoverable_node_and_tears_it_down_on_interrupt() {
     assert_verb_boots_registers_and_tears_down("run");
 }
 
 #[test]
-#[ignore = "boots a full runtime (GPU init + socket bind) — needs the local rig"]
 fn dev_shares_the_same_resolution_and_boot_path_as_run() {
     assert_verb_boots_registers_and_tears_down("dev");
 }
 
 #[test]
-#[ignore = "boots a full runtime (GPU init + socket bind) — needs the local rig"]
 fn an_explicit_entry_file_boots_a_node_when_the_convention_is_absent() {
+    let app = tempfile::tempdir().expect("create app dir");
+    let home = tempfile::tempdir().expect("create home dir");
+    let xdg = tempfile::tempdir().expect("create xdg dir");
     let port = free_port();
-    let app = TempTreeRemovedOnDrop::new("explicit-app", port);
-    let home = TempTreeRemovedOnDrop::new("explicit-home", port);
-    let xdg = TempTreeRemovedOnDrop::new("explicit-xdg", port);
     write_minimal_app(app.path(), "other.py");
 
-    let child = spawn_app_node(
+    let mut node = spawn_app_node(
         "run",
         app.path(),
         port,
@@ -279,8 +352,7 @@ fn an_explicit_entry_file_boots_a_node_when_the_convention_is_absent() {
         xdg.path(),
         &["-f", "other.py"],
     );
-    let pid = child.id();
-    let mut guard = ChildGuard(child);
+    let pid = node.process_id();
 
     assert!(
         wait_for_health(port, Duration::from_secs(60)).is_some(),
@@ -288,26 +360,21 @@ fn an_explicit_entry_file_boots_a_node_when_the_convention_is_absent() {
     );
 
     interrupt(pid);
-    let _ = guard.0.wait();
+    node.wait_for_exit();
 }
 
 #[test]
 fn a_missing_conventional_entry_fails_before_any_runtime_is_built() {
-    let app = TempTreeRemovedOnDrop::new("no-entry", free_port());
+    let app = tempfile::tempdir().expect("create app dir");
+    let anchor = app.path().display().to_string();
 
     for verb in ["run", "dev"] {
-        let output = Command::new(STREAMLIB_BINARY_PATH)
-            .arg(verb)
-            .arg("--dir")
-            .arg(app.path())
-            .output()
-            .expect("spawn streamlib");
+        let (status, stderr) = run_expecting_prompt_exit(&[verb, "--dir", &anchor]);
 
         assert!(
-            !output.status.success(),
+            !status.success(),
             "`streamlib {verb}` in an entry-less dir must fail"
         );
-        let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
             stderr.contains("app.py"),
             "the error must name the convention; stderr was:\n{stderr}"
@@ -317,7 +384,7 @@ fn a_missing_conventional_entry_fails_before_any_runtime_is_built() {
             "the error must state the no-walk-up rule; stderr was:\n{stderr}"
         );
         assert!(
-            stderr.contains(&app.path().display().to_string()),
+            stderr.contains(&anchor),
             "the error must name the anchor it searched; stderr was:\n{stderr}"
         );
     }
@@ -325,42 +392,36 @@ fn a_missing_conventional_entry_fails_before_any_runtime_is_built() {
 
 #[test]
 fn a_parent_directorys_entry_is_never_adopted() {
-    let app = TempTreeRemovedOnDrop::new("walk-up", free_port());
+    let app = tempfile::tempdir().expect("create app dir");
     write_minimal_app(app.path(), "app.py");
     let nested = app.path().join("nested");
     std::fs::create_dir_all(&nested).expect("create nested dir");
+    let nested_anchor = nested.display().to_string();
 
-    let output = Command::new(STREAMLIB_BINARY_PATH)
-        .arg("run")
-        .arg("--dir")
-        .arg(&nested)
-        .output()
-        .expect("spawn streamlib");
+    let (status, stderr) = run_expecting_prompt_exit(&["run", "--dir", &nested_anchor]);
 
     assert!(
-        !output.status.success(),
+        !status.success(),
         "a parent's app.py must not be adopted by a nested anchor"
+    );
+    assert!(
+        stderr.contains("never searches parent directories"),
+        "the failure must be the no-walk-up rule, not an unrelated error; stderr was:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(&nested_anchor),
+        "the error must name the nested anchor, not the parent; stderr was:\n{stderr}"
     );
 }
 
 #[test]
 fn a_missing_explicit_entry_names_the_path_it_tried() {
-    let app = TempTreeRemovedOnDrop::new("missing-explicit", free_port());
+    let app = tempfile::tempdir().expect("create app dir");
+    let anchor = app.path().display().to_string();
 
-    let output = Command::new(STREAMLIB_BINARY_PATH)
-        .arg("run")
-        .arg("--dir")
-        .arg(app.path())
-        .arg("-f")
-        .arg("gone.py")
-        .output()
-        .expect("spawn streamlib");
+    let (status, stderr) = run_expecting_prompt_exit(&["run", "--dir", &anchor, "-f", "gone.py"]);
 
-    assert!(
-        !output.status.success(),
-        "a nonexistent `-f` target must fail"
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!status.success(), "a nonexistent `-f` target must fail");
     assert!(
         stderr.contains("gone.py"),
         "the error must name the path it tried; stderr was:\n{stderr}"

--- a/tools/streamlib-cli/tests/run_dev_boot.rs
+++ b/tools/streamlib-cli/tests/run_dev_boot.rs
@@ -1,0 +1,362 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Boot-path integration tests for `streamlib run` / `streamlib dev`.
+//!
+//! These drive the real `streamlib` binary end to end: it must resolve the
+//! app's entry file, boot a node carrying the statically-linked api-server,
+//! publish a node-registry entry that `streamlib nodes` can discover, and
+//! remove that entry on clean teardown.
+//!
+//! Booting initializes the full runtime (GPU init included) and binds a real
+//! socket, so the boot tests are local integration tests — the workspace CI
+//! runs `cargo test --lib`, which does not pick up `tests/`. The
+//! entry-resolution failure tests below need no rig: the binary exits before
+//! it builds a runtime.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+mod cli_integration_support;
+use cli_integration_support::STREAMLIB_BINARY_PATH;
+
+/// Kills the spawned node when the test ends (pass or panic).
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// A temp dir tree that removes itself when the test ends.
+struct TempTreeRemovedOnDrop(PathBuf);
+
+impl TempTreeRemovedOnDrop {
+    fn new(name: &str, discriminator: u16) -> Self {
+        let path = std::env::temp_dir().join(format!("streamlib-run-boot-{name}-{discriminator}"));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).expect("create temp tree");
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempTreeRemovedOnDrop {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// Grab an ephemeral port the OS reports free, then release it. The api-server
+/// binds the requested port and increments on collision, so callers poll a
+/// small window above this value.
+fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+/// Issue a bare HTTP/1.1 GET and return the numeric status code, or `None` if
+/// the connection/parse failed. Raw TCP keeps the test dependency-free.
+fn http_get_status(port: u16, path: &str) -> Option<u16> {
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).ok()?;
+    stream.set_read_timeout(Some(Duration::from_secs(5))).ok()?;
+    let request = format!("GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n");
+    stream.write_all(request.as_bytes()).ok()?;
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).ok()?;
+    let response = String::from_utf8_lossy(&buf);
+    response.lines().next()?.split_whitespace().nth(1)?.parse().ok()
+}
+
+/// Poll `/health` across the api-server's bind-retry window until it returns
+/// 200 or the deadline passes. Returns the port that answered.
+fn wait_for_health(base_port: u16, timeout: Duration) -> Option<u16> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        for port in base_port..base_port + 10 {
+            if http_get_status(port, "/health") == Some(200) {
+                return Some(port);
+            }
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+    None
+}
+
+/// Every `*.json` node-registry entry under an isolated `XDG_RUNTIME_DIR`.
+fn registry_entry_paths(xdg_runtime_dir: &Path) -> Vec<PathBuf> {
+    let nodes_dir = xdg_runtime_dir.join("streamlib").join("nodes");
+    let Ok(entries) = std::fs::read_dir(&nodes_dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .collect()
+}
+
+/// Poll until the isolated registry holds exactly one entry, or the deadline
+/// passes. Returns the decoded entry body.
+fn wait_for_sole_registry_entry(
+    xdg_runtime_dir: &Path,
+    timeout: Duration,
+) -> Option<serde_json::Value> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        let paths = registry_entry_paths(xdg_runtime_dir);
+        if paths.len() == 1
+            && let Ok(bytes) = std::fs::read(&paths[0])
+            && let Ok(entry) = serde_json::from_slice::<serde_json::Value>(&bytes)
+        {
+            return Some(entry);
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    None
+}
+
+/// Write the smallest app the entry convention accepts: an `app.py` carrying a
+/// `setup(rt)`. Harness execution of that function lands with the language
+/// harnesses; boot only requires the file to resolve.
+fn write_minimal_app(app_dir: &Path, entry_file_name: &str) {
+    std::fs::write(
+        app_dir.join(entry_file_name),
+        "def setup(rt):\n    pass\n",
+    )
+    .expect("write app entry");
+}
+
+/// Spawn `streamlib <verb>` against an isolated home + node registry.
+fn spawn_app_node(
+    verb: &str,
+    app_dir: &Path,
+    port: u16,
+    streamlib_home: &Path,
+    xdg_runtime_dir: &Path,
+    extra_args: &[&str],
+) -> Child {
+    Command::new(STREAMLIB_BINARY_PATH)
+        .arg(verb)
+        .arg("--dir")
+        .arg(app_dir)
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .args(extra_args)
+        .env("STREAMLIB_HOME", streamlib_home)
+        .env("XDG_RUNTIME_DIR", xdg_runtime_dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn streamlib")
+}
+
+/// Run a control verb against the isolated registry and return its output.
+fn run_control_verb(args: &[&str], xdg_runtime_dir: &Path) -> std::process::Output {
+    Command::new(STREAMLIB_BINARY_PATH)
+        .args(args)
+        .env("XDG_RUNTIME_DIR", xdg_runtime_dir)
+        .output()
+        .expect("spawn streamlib control verb")
+}
+
+/// Send SIGINT to `pid` — the signal `wait_for_signal` installs a handler for.
+fn interrupt(pid: u32) {
+    let status = Command::new("kill")
+        .arg("-INT")
+        .arg(pid.to_string())
+        .status()
+        .expect("spawn kill");
+    assert!(status.success(), "SIGINT delivery to pid {pid} failed");
+}
+
+/// Boot a node with `verb`, assert it is discoverable, then interrupt it and
+/// assert the registry entry is gone.
+fn assert_verb_boots_registers_and_tears_down(verb: &str) {
+    let port = free_port();
+    let app = TempTreeRemovedOnDrop::new(&format!("{verb}-app"), port);
+    let home = TempTreeRemovedOnDrop::new(&format!("{verb}-home"), port);
+    let xdg = TempTreeRemovedOnDrop::new(&format!("{verb}-xdg"), port);
+    write_minimal_app(app.path(), "app.py");
+
+    let child = spawn_app_node(verb, app.path(), port, home.path(), xdg.path(), &[]);
+    let pid = child.id();
+    let mut guard = ChildGuard(child);
+
+    // Boot is process start + GPU init + socket bind; allow a generous window.
+    let served = wait_for_health(port, Duration::from_secs(60));
+    assert!(
+        served.is_some(),
+        "`streamlib {verb}` should boot a node serving /health"
+    );
+
+    let entry = wait_for_sole_registry_entry(xdg.path(), Duration::from_secs(10))
+        .unwrap_or_else(|| panic!("`streamlib {verb}` should publish one node-registry entry"));
+    assert_eq!(
+        entry["pid"].as_u64(),
+        Some(u64::from(pid)),
+        "the entry must name the hosting process"
+    );
+    assert_eq!(
+        entry["control_url"].as_str(),
+        Some(format!("http://127.0.0.1:{}", served.unwrap()).as_str()),
+        "the entry must carry the reachable control URL"
+    );
+
+    let runtime_id = entry["runtime_id"]
+        .as_str()
+        .expect("the entry must carry a runtime_id");
+
+    let nodes = run_control_verb(&["nodes"], xdg.path());
+    assert!(nodes.status.success(), "`streamlib nodes` should succeed");
+    let listing = String::from_utf8_lossy(&nodes.stdout);
+    assert!(
+        listing.contains(runtime_id),
+        "`streamlib nodes` should list the booted node `{runtime_id}`; stdout was:\n{listing}"
+    );
+
+    let graph = run_control_verb(&["graph", "--node", runtime_id], xdg.path());
+    assert!(
+        graph.status.success(),
+        "`streamlib graph` should round-trip against the booted node; stderr was:\n{}",
+        String::from_utf8_lossy(&graph.stderr)
+    );
+
+    interrupt(pid);
+    let exited = guard.0.wait().expect("wait for the node to exit");
+    assert!(
+        exited.success(),
+        "`streamlib {verb}` should exit cleanly on SIGINT, got {exited}"
+    );
+
+    assert!(
+        registry_entry_paths(xdg.path()).is_empty(),
+        "clean teardown must remove the node-registry entry"
+    );
+}
+
+#[test]
+#[ignore = "boots a full runtime (GPU init + socket bind) — needs the local rig"]
+fn run_boots_a_discoverable_node_and_tears_it_down_on_interrupt() {
+    assert_verb_boots_registers_and_tears_down("run");
+}
+
+#[test]
+#[ignore = "boots a full runtime (GPU init + socket bind) — needs the local rig"]
+fn dev_shares_the_same_resolution_and_boot_path_as_run() {
+    assert_verb_boots_registers_and_tears_down("dev");
+}
+
+#[test]
+#[ignore = "boots a full runtime (GPU init + socket bind) — needs the local rig"]
+fn an_explicit_entry_file_boots_a_node_when_the_convention_is_absent() {
+    let port = free_port();
+    let app = TempTreeRemovedOnDrop::new("explicit-app", port);
+    let home = TempTreeRemovedOnDrop::new("explicit-home", port);
+    let xdg = TempTreeRemovedOnDrop::new("explicit-xdg", port);
+    write_minimal_app(app.path(), "other.py");
+
+    let child = spawn_app_node(
+        "run",
+        app.path(),
+        port,
+        home.path(),
+        xdg.path(),
+        &["-f", "other.py"],
+    );
+    let pid = child.id();
+    let mut guard = ChildGuard(child);
+
+    assert!(
+        wait_for_health(port, Duration::from_secs(60)).is_some(),
+        "`-f other.py` should boot a node even with no app.py present"
+    );
+
+    interrupt(pid);
+    let _ = guard.0.wait();
+}
+
+#[test]
+fn a_missing_conventional_entry_fails_before_any_runtime_is_built() {
+    let app = TempTreeRemovedOnDrop::new("no-entry", free_port());
+
+    for verb in ["run", "dev"] {
+        let output = Command::new(STREAMLIB_BINARY_PATH)
+            .arg(verb)
+            .arg("--dir")
+            .arg(app.path())
+            .output()
+            .expect("spawn streamlib");
+
+        assert!(
+            !output.status.success(),
+            "`streamlib {verb}` in an entry-less dir must fail"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("app.py"),
+            "the error must name the convention; stderr was:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("never searches parent directories"),
+            "the error must state the no-walk-up rule; stderr was:\n{stderr}"
+        );
+        assert!(
+            stderr.contains(&app.path().display().to_string()),
+            "the error must name the anchor it searched; stderr was:\n{stderr}"
+        );
+    }
+}
+
+#[test]
+fn a_parent_directorys_entry_is_never_adopted() {
+    let app = TempTreeRemovedOnDrop::new("walk-up", free_port());
+    write_minimal_app(app.path(), "app.py");
+    let nested = app.path().join("nested");
+    std::fs::create_dir_all(&nested).expect("create nested dir");
+
+    let output = Command::new(STREAMLIB_BINARY_PATH)
+        .arg("run")
+        .arg("--dir")
+        .arg(&nested)
+        .output()
+        .expect("spawn streamlib");
+
+    assert!(
+        !output.status.success(),
+        "a parent's app.py must not be adopted by a nested anchor"
+    );
+}
+
+#[test]
+fn a_missing_explicit_entry_names_the_path_it_tried() {
+    let app = TempTreeRemovedOnDrop::new("missing-explicit", free_port());
+
+    let output = Command::new(STREAMLIB_BINARY_PATH)
+        .arg("run")
+        .arg("--dir")
+        .arg(app.path())
+        .arg("-f")
+        .arg("gone.py")
+        .output()
+        .expect("spawn streamlib");
+
+    assert!(!output.status.success(), "a nonexistent `-f` target must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("gone.py"),
+        "the error must name the path it tried; stderr was:\n{stderr}"
+    );
+}

--- a/tools/streamlib-cli/tests/run_dev_boot.rs
+++ b/tools/streamlib-cli/tests/run_dev_boot.rs
@@ -75,7 +75,13 @@ fn http_get_status(port: u16, path: &str) -> Option<u16> {
     let mut buf = Vec::new();
     stream.read_to_end(&mut buf).ok()?;
     let response = String::from_utf8_lossy(&buf);
-    response.lines().next()?.split_whitespace().nth(1)?.parse().ok()
+    response
+        .lines()
+        .next()?
+        .split_whitespace()
+        .nth(1)?
+        .parse()
+        .ok()
 }
 
 /// Poll `/health` across the api-server's bind-retry window until it returns
@@ -130,11 +136,8 @@ fn wait_for_sole_registry_entry(
 /// `setup(rt)`. Harness execution of that function lands with the language
 /// harnesses; boot only requires the file to resolve.
 fn write_minimal_app(app_dir: &Path, entry_file_name: &str) {
-    std::fs::write(
-        app_dir.join(entry_file_name),
-        "def setup(rt):\n    pass\n",
-    )
-    .expect("write app entry");
+    std::fs::write(app_dir.join(entry_file_name), "def setup(rt):\n    pass\n")
+        .expect("write app entry");
 }
 
 /// Spawn `streamlib <verb>` against an isolated home + node registry.
@@ -353,7 +356,10 @@ fn a_missing_explicit_entry_names_the_path_it_tried() {
         .output()
         .expect("spawn streamlib");
 
-    assert!(!output.status.success(), "a nonexistent `-f` target must fail");
+    assert!(
+        !output.status.success(),
+        "a nonexistent `-f` target must fail"
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("gone.py"),

--- a/tools/streamlib-cli/tests/run_dev_boot.rs
+++ b/tools/streamlib-cli/tests/run_dev_boot.rs
@@ -186,9 +186,22 @@ fn interrupt(pid: u32) {
 /// callers guard: if entry resolution ever starts walking up, the binary boots
 /// a node and waits for a signal instead of exiting. Killing at the deadline
 /// turns that into a red test rather than a wedged suite.
+///
+/// The isolated home / registry and the ephemeral port matter for exactly that
+/// failing case: the node this must never boot would otherwise land in the
+/// developer's real registry on the default port, and the deadline kill is
+/// SIGKILL, which skips the teardown that would have removed its entry.
 fn run_expecting_prompt_exit(args: &[&str]) -> (std::process::ExitStatus, String) {
+    let home = tempfile::tempdir().expect("create home dir");
+    let xdg = tempfile::tempdir().expect("create xdg dir");
+    let port = free_port().to_string();
+
     let mut child = Command::new(STREAMLIB_BINARY_PATH)
         .args(args)
+        .arg("--port")
+        .arg(&port)
+        .env("STREAMLIB_HOME", home.path())
+        .env("XDG_RUNTIME_DIR", xdg.path())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .spawn()
@@ -307,14 +320,30 @@ fn assert_hosted_node_keeps_its_jsonl_log(graph_stdout: &[u8], streamlib_home: &
         Path::new(&log_path).starts_with(streamlib_home),
         "the JSONL log `{log_path}` must live under the node's STREAMLIB_HOME"
     );
+
+    // The resolution line is emitted after the Runner exists precisely so it
+    // lands here; moving it back before `Runner::with_auto_build()` silently
+    // drops it on the floor, and this is what notices.
+    let log_body = std::fs::read_to_string(&log_path).expect("read the node's JSONL log");
+    assert!(
+        log_body.contains("Resolved app entry"),
+        "the entry-resolution line must reach the JSONL log — it is emitted with no subscriber \
+         installed if it precedes the Runner; log was:\n{log_body}"
+    );
 }
 
 /// The `log_path` config value of the api-server processor in a graph snapshot.
+///
+/// Anchored on the object that also carries the api-server's `host` + `port` so
+/// an unrelated `log_path` elsewhere in a future graph cannot satisfy this.
 fn find_api_server_log_path(graph: &serde_json::Value) -> Option<String> {
     fn walk(value: &serde_json::Value) -> Option<String> {
         match value {
             serde_json::Value::Object(map) => {
-                if let Some(serde_json::Value::String(log_path)) = map.get("log_path") {
+                let is_api_server_config = map.contains_key("host") && map.contains_key("port");
+                if is_api_server_config
+                    && let Some(serde_json::Value::String(log_path)) = map.get("log_path")
+                {
                     return Some(log_path.clone());
                 }
                 map.values().find_map(walk)


### PR DESCRIPTION
## Summary

Adds `streamlib run` and `streamlib dev`: both resolve the app's entry file and boot a node that hosts the control plane in-process, so it publishes a node-registry entry and `nodes` / `graph` / `tap` drive it exactly as they drive a `streamlib-runtime` process.

- **Entry convention.** `app.py` at the anchor dir — `--dir` when given, else the exact CWD, **never a parent** (mirrors `streamlib add`'s anchoring; a walk-up makes "which app am I in" ambiguous in a monorepo). `-f <file>` overrides. A missing entry errors with the convention, the anchor it searched, and the `-f` escape hatch.
- **Boot recipe absorbed, not duplicated.** The recipe moves into `streamlib_api_server::control_plane_host::register_api_server_control_plane_processor_on_runtime`, and `streamlib-runtime`'s `main` now calls it too. It lives in the api-server crate because that crate already owns both `ApiServerProcessor` and `node_registry`, both hosts already depended on it (no new crate, no new dependency edge), and it survives the planned api-server → `runtime/` relocation.
- **Not in scope, per the ticket:** harness execution of `setup(rt)` (#1600 / #1601), the `dev` watch loop (#1602), `streamlib new` (#1684). The `mcp` path is untouched and `streamlib-runtime` is not retired.

## Closes

Closes #1683

## Exit criteria

- [x] `streamlib run` in a fixture app dir boots a node that appears in `streamlib nodes` with a green `graph` round-trip; Ctrl-C tears down cleanly and removes the registry entry.
- [x] No-args resolution picks `app.py`; `-f other.py` overrides; a missing entry gives the actionable error.
- [x] `streamlib dev` shares the same resolution + boot path.

## Test plan

`cargo test -p streamlib-cli` — 101 unit + 6 integration, **0 ignored**:

- 9 entry-resolution unit tests: convention, `-f` override, absolute `-f`, missing-entry message content, **no walk-up**, a directory named `app.py` is not an entry, anchor = CWD / `--dir`.
- 2 new unit tests locking the runtime-hosting posture: logging deferral, and loopback-by-default (both parse `streamlib run`/`dev` bare through clap, so they lock the real defaults).
- 6 integration tests in `tests/run_dev_boot.rs`: `run` and `dev` each boot → registry entry carrying the right pid and control URL → `streamlib nodes` lists it → `streamlib graph --node` round-trips → JSONL log exists under `STREAMLIB_HOME` and carries the resolution line → SIGINT exits 0 and prunes the entry. Plus the three resolution-failure cases, each under a bounded deadline.

`cargo test -p streamlib-runtime --test boot` — 4/4 green, so the extraction did not regress the standalone binary.

Hand-verified on the rig: `log_path` present in the graph, 21.6 KiB JSONL on disk, `streamlib logs --list` finds it, and the entry-resolution line reaches both stdout and the JSONL.

## Notes for owner

**1. Bind default — DECIDED by owner (2026-07-30, in-ticket).** `run`/`dev` bind `0.0.0.0` by default, matching `streamlib-runtime`, so nodes can reach each other. Both hosts of the one control plane now share a default. Auth and remote-access posture stays OPEN in §Control plane and the owner will revisit; the mutating routes remain open unless `require_auth` is configured. Locked by `runtime_hosting_verbs_bind_all_interfaces_by_default`.

**2. A real observability defect was found and fixed mid-review.** `logging::init` is first-caller-wins, and `Runner` *stores* its logging guard with `jsonl_log_path()` reading from it. The CLI initializing its short-lived `for_cli` config first demoted the Runner's `for_runtime` init to a noop guard — so a `run`-hosted node produced **no JSONL log at all**, passed no `log_path` to the api-server, and ran with fd-level stdio interception off, unlike a `streamlib-runtime`-hosted node. That contradicted §Control plane's DECIDED "the JSONL log schema is a durable contract" for exactly the launcher §Product makes primary. Fixed by having the runtime-hosting verbs defer logging to the Runner, with locks at both the unit and JSONL level.

**3. `commands/mcp.rs` has the identical defect, out of scope here.** Its in-process `Runner` is built after the CLI's own `logging::init`, so an mcp-hosted runtime also gets no JSONL log. The ticket says the `mcp` path stays as-is, so I left it. This is an engine-layer sharp edge that will bite whoever next hosts a runtime from a CLI verb — worth its own ticket if you want the control plane's observability contract to hold on every host.

**4. For `/ship-change`.** `docs/plan/changes/mvp-app-experience.md`'s MODIFIED bullet says `logging_config_for` is "No structural change, listed for completeness". That is now false — it returns `Option` and the runtime-hosting verbs defer entirely. Fold the corrected statement, not the stale one.

**5. Pre-existing gate failures, untouched (reported, not auto-fixed).**
- `cargo clippy --workspace --all-targets` fails on a `println!` inside `#[cfg(test)]` at `runtime/streamlib-consumer-rhi/src/consumer_vulkan_device.rs:822` — file last changed by #1348, zero lines from this branch.
- `cargo fmt --check` fails on ~100 pre-existing files repo-wide including `vendor/tatolab-vulkanalia-vma` (local rustfmt/toolchain drift vs. whatever formatted `main`). Every file this branch adds is rustfmt-clean; I deliberately did not reformat the drifting files or vendor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
