### PR TITLE
chore(spike): Tier A harness for the in-process Python go/no-go (#1702)

### DIFF
--- a/spikes/streamlib-pyembed-spike/.gitignore
+++ b/spikes/streamlib-pyembed-spike/.gitignore
@@ -1,0 +1,2 @@
+/target
+/artifacts

--- a/spikes/streamlib-pyembed-spike/Cargo.toml
+++ b/spikes/streamlib-pyembed-spike/Cargo.toml
@@ -19,19 +19,16 @@ publish = false
 
 [lib]
 name = "streamlib_pyembed_spike"
-# `rlib` feeds the Rust-launched Tier A harness binary; `cdylib` is what CPython
-# dlopens when the spike is driven from `python3 python/runner.py`. The two are
-# built in separate invocations because they need opposite `extension-module`
-# settings — see the feature comment below.
-crate-type = ["rlib", "cdylib"]
+# `rlib` only. A `cdylib` + `extension-module` pair would claim CPython can
+# import this crate, but there is no `#[pymodule]` here: Tier A embeds CPython in
+# a Rust binary instead. #1702's design sketches the opposite arrangement
+# (a `PyApp` `#[pyclass]` CPython imports), and which one the pivot ships is an
+# owner decision — see the embed-vs-import note posted to the issue. Declaring an
+# unusable build target would only make that open question look settled.
+crate-type = ["rlib"]
 
 [features]
 default = []
-# PyO3's `extension-module` omits the libpython link. It MUST be on when CPython
-# dlopens our cdylib (the interpreter already provides the symbols) and MUST be
-# off when a Rust binary embeds the interpreter (nothing else supplies them).
-# The Tier A harness binary is the embedding case, so this stays off by default.
-extension-module = ["pyo3/extension-module"]
 # Compiles every measurement stamp out. The control cell for "does the
 # instrument move the measurement" builds with this on; a throughput delta
 # between it and a default build is instrument overhead, not signal.
@@ -55,6 +52,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1.41"
+# Used only for the post-stop scoped subscriber in the harness binary: the
+# engine owns the global dispatcher and drops it at `Runner::stop()`, so a cell's
+# completion and invalidation records need a subscriber of our own to reach a log.
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [lints]

--- a/spikes/streamlib-pyembed-spike/Cargo.toml
+++ b/spikes/streamlib-pyembed-spike/Cargo.toml
@@ -1,0 +1,72 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+# Throwaway spike for #1702 — measures in-process Python (CPython embedded via
+# PyO3) against today's subprocess-per-Python-processor model. Not a workspace
+# member and not a distributable: it self-roots via the `[workspace]` table
+# below, the same convention `examples/*` and most `packages/*` follow (see the
+# root Cargo.toml comment at :44-56). Nothing in the engine depends on it.
+
+[package]
+name = "streamlib-pyembed-spike"
+version = "0.0.0"
+edition = "2024"
+rust-version = "1.85"
+authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
+license-file = "../../LICENSE"
+repository = "https://github.com/tatolab/streamlib"
+publish = false
+
+[lib]
+name = "streamlib_pyembed_spike"
+# `rlib` feeds the Rust-launched Tier A harness binary; `cdylib` is what CPython
+# dlopens when the spike is driven from `python3 python/runner.py`. The two are
+# built in separate invocations because they need opposite `extension-module`
+# settings — see the feature comment below.
+crate-type = ["rlib", "cdylib"]
+
+[features]
+default = []
+# PyO3's `extension-module` omits the libpython link. It MUST be on when CPython
+# dlopens our cdylib (the interpreter already provides the symbols) and MUST be
+# off when a Rust binary embeds the interpreter (nothing else supplies them).
+# The Tier A harness binary is the embedding case, so this stays off by default.
+extension-module = ["pyo3/extension-module"]
+# Compiles every measurement stamp out. The control cell for "does the
+# instrument move the measurement" builds with this on; a throughput delta
+# between it and a default build is instrument overhead, not signal.
+stamping-compiled-out = []
+
+[dependencies]
+streamlib = { path = "../../sdk/streamlib-sdk" }
+
+# pyo3 0.29 is the first release with the `attach`/`detach` naming; 0.28 and
+# earlier spell these `Python::with_gil` / `py.allow_threads`, which were
+# REMOVED rather than deprecated. rust-numpy 0.29 is the matching release.
+# `auto-initialize` is deliberately absent: the harness calls
+# `Python::initialize()` itself so interpreter startup is ordered explicitly
+# against `GpuContext` init and iceoryx2 node creation.
+pyo3 = "0.29.0"
+numpy = "0.29.0"
+
+hdrhistogram = "7.5"
+libc = "0.2.177"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+clap = { version = "4", features = ["derive"] }
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[lints]
+workspace = true
+
+# Self-root. The spike is its own workspace, so it inherits nothing from the
+# engine tree — including the clippy lint table. The `disallowed_macros` deny
+# below plus the sibling clippy.toml reproduce the engine's println/eprintln ban
+# here; without them the doctrine would be unenforced in exactly the crate
+# nobody reviews closely (xtask lint-logging's ZONE_PARENTS does not cover
+# `spikes/`).
+[workspace]
+
+[workspace.lints.clippy]
+disallowed_macros = "deny"

--- a/spikes/streamlib-pyembed-spike/README.md
+++ b/spikes/streamlib-pyembed-spike/README.md
@@ -16,8 +16,15 @@ The engine is untouched. Every processor enters through the existing `App::add_l
 
 This crate self-roots its own `[workspace]` table, the same convention `examples/*` and most
 `packages/*` follow (root `Cargo.toml:44-56`). It builds with `cd spikes/streamlib-pyembed-spike
-&& cargo build`, keeps its own `Cargo.lock`, and never enters the engine's release closure or CI
-gate surface. Cold dependency build measured at **63s** on the reference machine.
+&& cargo build` and never enters the engine's release closure or CI gate surface. Cold dependency
+build measured at **63s** on the reference machine.
+
+Its `Cargo.lock` is **not committed** — the repo ignores every non-root lockfile
+(`.gitignore:51-52`) and this crate follows that convention rather than overriding it. The cost is
+real for a benchmark: `pyo3`/`numpy`/`hdrhistogram` are caret ranges, so a rerun can resolve
+different patch versions than the run that produced a given number. Until that is addressed, the
+resolved versions of a run are recoverable only from the machine that produced it. Raised as a note
+for the owner rather than decided here.
 
 ## What is measured, and what is not
 
@@ -56,6 +63,13 @@ Smoke numbers from this branch (10s cells, not protocol runs — see "Status" be
 The Python arm is indistinguishable from the pure-Rust floor at the same geometry. The wire hop
 dominates by three orders of magnitude over the PyO3 callback.
 
+**The floor scales with payload, and that bounds the protocol.** Floor-arm p50 is 1.44ms at
+640x480, 9.63ms at 720p, ~27ms at 1080p — the engine's `read_raw` allocates a fresh 64 KiB `Vec`,
+then a fresh full-size `Vec`, then memcpys, per read per hop. At 1080p the two-hop service time
+exceeds the 60fps frame period (16.6ms), so a 1080p60 cell runs saturated and its percentiles would
+describe queue occupancy rather than latency. Posted to #1702; 1080p is a 30fps-only geometry until
+the owner rules.
+
 ## The GIL attachment anchor
 
 `Python::attach` on a foreign thread maps to `PyGILState_Ensure()`, which builds a thread state on
@@ -89,8 +103,8 @@ PYTHONPATH=python ./target/release/tier_a_harness \
   --output-directory ./artifacts
 ```
 
-`python/runner.py` drives A/B/A interleaving across cells; one cell per process keeps interpreter,
-GC, and allocator state from leaking between cells.
+`python/runner.py` invokes the harness once per cell; one cell per process keeps interpreter, GC,
+and allocator state from leaking between cells.
 
 Add `--require-locked-measurement-state` for gated cells. The harness **verifies** the machine is
 locked and fails fast; it never invokes `sudo` (`sudo -n` fails on the reference box and a password
@@ -106,10 +120,28 @@ owner checklist of privileged commands as data.
 | `per-frame-measurements.jsonl` | One object per frame, warmup-excluded frames included (raw data is raw). |
 | `source-emit-to-sink-receive.histogram` | Mergeable HDR histogram export. |
 | `summary.json` | p50/p99/p99.9/max, drop count, and the anomaly counters. Never a headline mean — the distribution is heavily tailed. |
+| `gc-collections-embedded-interpreter.jsonl` | Every CPython collection in the interpreter that ran the callback, monotonic-stamped so a latency tail spike can be attributed to a GC. In-process arm only. |
+
+An empty GC record file is a real result, not a broken recorder: the per-frame numpy view is
+released as soon as the callback returns, so gen0's tracked-container count does not climb and no
+generational pass is triggered during a short cell. The recorder is asserted functional
+independently (`python/test_spike_harness_contract.py` forces collections and asserts a nonzero
+count).
 
 Two counters invalidate a cell rather than degrading it, and the harness logs both at `error`:
 `negative_latency_anomaly_count` (sink stamp before emit stamp ⇒ the arms' clocks disagree) and
 `histogram_range_saturation_count` (percentiles are clipped).
+
+## Which arrangement Tier A measures
+
+A Rust `main` that calls `Python::initialize()` and embeds CPython — **not** the `PyApp`
+`#[pyclass]` that CPython imports, which is what #1702's design sketches. The crate is
+`crate-type = ["rlib"]` only; there is no `#[pymodule]`.
+
+The per-frame path is identical either way (the processor thread is a foreign thread to CPython in
+both arrangements), so `source_emit_to_sink_receive` transfers. What does NOT transfer is main-thread
+ownership, SIGINT ownership, and interpreter-init ordering against `GpuContext` — which is exactly
+what the warm-restart battery measures. Posted to #1702 as an owner decision.
 
 ## Status
 

--- a/spikes/streamlib-pyembed-spike/README.md
+++ b/spikes/streamlib-pyembed-spike/README.md
@@ -1,0 +1,125 @@
+<!--
+Copyright (c) 2025 Jonathan Fontanez
+SPDX-License-Identifier: BUSL-1.1
+-->
+
+# streamlib-pyembed-spike — #1702
+
+Throwaway spike measuring in-process Python (CPython embedded via PyO3) against today's
+subprocess-per-Python-processor model. **Nothing here is an API proposal.** The callback token
+registry, the process-global measurement collection point, and the Python-facing shapes are
+deliberate spike artifacts; #1702 defers API design until after the numbers exist.
+
+The engine is untouched. Every processor enters through the existing `App::add_local` path.
+
+## Not a workspace member
+
+This crate self-roots its own `[workspace]` table, the same convention `examples/*` and most
+`packages/*` follow (root `Cargo.toml:44-56`). It builds with `cd spikes/streamlib-pyembed-spike
+&& cargo build`, keeps its own `Cargo.lock`, and never enters the engine's release closure or CI
+gate surface. Cold dependency build measured at **63s** on the reference machine.
+
+## What is measured, and what is not
+
+The metric is **`source_emit_to_sink_receive`**, stamped raw `CLOCK_MONOTONIC` on both sides.
+
+It is **not** capture-to-present. Tier A has no camera and no display, and present time is not
+observable in *either* tier without an engine change this spike forbids: the only present-path
+instrumentation is `#[tracing::instrument(level = "trace")]` on `VulkanPresentTarget::end_frame`
+(`vulkan_present_target.rs:630`), and `Cargo.toml:93` pins tracing with `release_max_level_debug`,
+compiling trace out of every release build. `ProcessorMetrics` is declared and read but written by
+nothing in `runtime/ sdk/ tools/`. Owner decision on #1702: report the observable quantity under
+its own name rather than an unmeasured one under the frozen name.
+
+## The three arms
+
+| `--arm` | What it isolates |
+|---|---|
+| `rust-passthrough-floor` | The engine's own wire-hop cost, no interpreter. Run this first at every cell. |
+| `in-process-python` | The same graph with a Python callable on the processor thread. |
+| subprocess baseline | Today's model. **Not in this PR** — Tier B, see #1702. |
+
+The floor arm exists because gate 5 does not discriminate: PyO3 callback overhead passes its
+0.5ms budget by ~39x naive and ~3300x anchored, while the engine's `read_raw` allocates a fresh
+64 KiB `Vec`, then a fresh full-size `Vec`, then memcpys, **per read**
+(`plugin-abi/src/vtables/input_mailboxes.rs:156-157`, allocation inside the retry loop). Without a
+floor arm a large absolute latency is unattributable.
+
+Smoke numbers from this branch (10s cells, not protocol runs — see "Status" below):
+
+```
+720p30  floor  emit->sink p50 9.63ms   p99 11.09ms
+720p30  python emit->sink p50 9.61ms   p99 11.08ms   stage callback p50 13.8µs
+1080p30 python emit->sink p50 27.16ms  p99 29.38ms   stage callback p50 4.18ms (realistic)
+```
+
+The Python arm is indistinguishable from the pure-Rust floor at the same geometry. The wire hop
+dominates by three orders of magnitude over the PyO3 callback.
+
+## The GIL attachment anchor
+
+`Python::attach` on a foreign thread maps to `PyGILState_Ensure()`, which builds a thread state on
+entry and destroys it on exit. CPython 3.12 virtual-allocates the frame datastack chunk on first
+Python frame push and frees it on thread-state delete — one `mmap` + one `munmap` per frame
+(measured: 1041 mmap / 1005 munmap per 1000 calls). The anchor holds one unreleased
+`PyGILState_Ensure` parked with `PyEval_SaveThread`, dropping per-call cost from p50 6.3µs to
+p50 110ns. Public `pyo3::ffi` only.
+
+Whether the real SDK should anchor processor threads is a pivot design question these numbers do
+not settle: anchoring trades a resident thread state per processor thread for the syscall pair.
+`--disable-gil-anchor` is the control condition.
+
+## Delivery profile
+
+Every input port declares `delivery_profile = "every_sample"`. Owner decision on #1702: latency
+percentiles are the primary signal; drop counts are reported, not gated. Under `latest`
+(SkipToLatest) the sink drains to the newest sample, pinning latency near one frame period and
+making the percentile gates near-vacuous. `delivery_profile` is a compile error on an `output(...)`
+(`grammar.rs:432-448`) — it is consumer-side only.
+
+## Running a cell
+
+```
+cargo build --release
+PYTHONPATH=python ./target/release/tier_a_harness \
+  --arm in-process-python --fps 30 --frame-width 1920 --frame-height 1080 \
+  --duration-seconds 600 --warmup-exclusion-seconds 60 \
+  --stage-callback-module spike_stage_callbacks \
+  --stage-callback-attribute realistic_stage \
+  --output-directory ./artifacts
+```
+
+`python/runner.py` drives A/B/A interleaving across cells; one cell per process keeps interpreter,
+GC, and allocator state from leaking between cells.
+
+Add `--require-locked-measurement-state` for gated cells. The harness **verifies** the machine is
+locked and fails fast; it never invokes `sudo` (`sudo -n` fails on the reference box and a password
+prompt would wedge an unattended multi-hour run). `machine_specification_probe` emits the exact
+owner checklist of privileged commands as data.
+
+## Artifact directory, per cell
+
+| File | Contents |
+|---|---|
+| `cell-spec.json` | Every resolved parameter, including the delivery profile and metric name. The summarizer refuses to evaluate a gate the recorded configuration cannot support. |
+| `machine-spec.json` | CPU/governor/boost, kernel + preemption, glibc, GPU + driver, Python/numpy, scheduling class, loadavg. Unknown knobs carry an explicit reason, never a silent default. |
+| `per-frame-measurements.jsonl` | One object per frame, warmup-excluded frames included (raw data is raw). |
+| `source-emit-to-sink-receive.histogram` | Mergeable HDR histogram export. |
+| `summary.json` | p50/p99/p99.9/max, drop count, and the anomaly counters. Never a headline mean — the distribution is heavily tailed. |
+
+Two counters invalidate a cell rather than degrading it, and the harness logs both at `error`:
+`negative_latency_anomaly_count` (sink stamp before emit stamp ⇒ the arms' clocks disagree) and
+`histogram_range_saturation_count` (percentiles are clipped).
+
+## Status
+
+**This PR delivers the Tier A harness and proves it runs end-to-end. It does not deliver the
+protocol numbers.** No 10-minute cell, no A/B/A matrix, no soak, no GC-tuned cells. Those and the
+subprocess baseline are Tier B (PR 2), and two protocol questions remain open with the owner:
+SCHED_OTHER vs SCHED_FIFO for the primary numbers, and whether to add an absolute p99.9 ceiling
+(tail risk sits beyond p99 — measured 611µs p99.9 and 12.8ms max under GIL contention, where only
+a relative-to-baseline delta is gated today).
+
+Payload is capped at 1080p: subprocess links are `UntrustedSession` (16 MiB ceiling), in-process
+host-to-host links are `Trusted` (64 MiB). 4K BGRA fits the in-process arm and is refused on the
+subprocess arm, so the two are structurally incomparable above 16 MiB.

--- a/spikes/streamlib-pyembed-spike/clippy.toml
+++ b/spikes/streamlib-pyembed-spike/clippy.toml
@@ -1,0 +1,7 @@
+disallowed-macros = [
+    { path = "std::println", reason = "Use tracing::info! / streamlib.log.info() instead. See docs/logging.md." },
+    { path = "std::eprintln", reason = "Use tracing::warn! / tracing::error! / streamlib.log.warn() instead. See docs/logging.md." },
+    { path = "std::print", reason = "Use tracing::info! / streamlib.log.info() instead. See docs/logging.md." },
+    { path = "std::eprint", reason = "Use tracing::warn! / tracing::error! / streamlib.log.warn() instead. See docs/logging.md." },
+    { path = "std::dbg", reason = "Use tracing::debug! instead. See docs/logging.md." },
+]

--- a/spikes/streamlib-pyembed-spike/python/gc_collection_attribution.py
+++ b/spikes/streamlib-pyembed-spike/python/gc_collection_attribution.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Timestamps every CPython garbage collection so a latency tail spike in the
+Rust-side per-frame JSONL can be attributed to a GC pause rather than to PyO3."""
+
+import gc
+import json
+import os
+import time
+
+# The Rust side stamps raw CLOCK_MONOTONIC via libc::clock_gettime
+# (src/monotonic_clock.rs). `time.monotonic_ns()` reports
+# implementation='clock_gettime(CLOCK_MONOTONIC)' on Linux and would agree here,
+# but it is mach_absolute_time on macOS and QueryPerformanceCounter on Windows --
+# a different epoch, silently. Naming the clock explicitly is what makes GC
+# stamps and frame stamps joinable by construction rather than by platform luck.
+MONOTONIC_CLOCK_IDENTIFIER = time.CLOCK_MONOTONIC
+
+GARBAGE_COLLECTION_MODE_DEFAULT = "default"
+GARBAGE_COLLECTION_MODE_TUNED = "tuned"
+SUPPORTED_GARBAGE_COLLECTION_MODES = (
+    GARBAGE_COLLECTION_MODE_DEFAULT,
+    GARBAGE_COLLECTION_MODE_TUNED,
+)
+
+COLLECTION_PHASE_START = "start"
+COLLECTION_PHASE_STOP = "stop"
+
+# Generation-0 fires once per (allocations - deallocations) exceeding its
+# threshold; CPython's stock 700 means a numpy stage allocating a handful of
+# temporaries per frame triggers a sweep every few frames. 50_000 pushes it well
+# past a whole measurement cell's churn. Generations 1 and 2 count collections of
+# the generation below, so 100/100 turns a stock gen-2 sweep every ~70_000
+# allocations into one every ~350_000_000.
+TUNED_GENERATION_ZERO_ALLOCATION_SURPLUS_THRESHOLD = 50_000
+TUNED_GENERATION_ONE_COLLECTION_COUNT_THRESHOLD = 100
+TUNED_GENERATION_TWO_COLLECTION_COUNT_THRESHOLD = 100
+
+
+def read_raw_monotonic_clock_nanoseconds():
+    """Read CLOCK_MONOTONIC in nanoseconds, the one clock every spike arm shares."""
+    return time.clock_gettime_ns(MONOTONIC_CLOCK_IDENTIFIER)
+
+
+class GarbageCollectionPauseAttributionRecorder:
+    """Records phase-stamped CPython collection events and the GC configuration
+    they ran under, for joining against the Rust-side per-frame latency JSONL."""
+
+    def __init__(self):
+        self._collection_phase_events = []
+        self._pending_collection_start_stamp_by_generation = {}
+        self._collection_phase_callback = None
+        self._applied_garbage_collection_mode = GARBAGE_COLLECTION_MODE_DEFAULT
+        self._garbage_collection_thresholds_at_install = gc.get_threshold()
+        self._frozen_object_count_after_tuning = None
+
+    def install_collection_phase_callback(self):
+        """Start recording collection events. Idempotent."""
+        if self._collection_phase_callback is not None:
+            return
+
+        collection_phase_events = self._collection_phase_events
+
+        def record_collection_phase_event(collection_phase, collection_info):
+            # Stamp first: everything below is recorded latency that did not
+            # happen inside the collector.
+            collection_phase_stamp_nanoseconds = time.clock_gettime_ns(
+                MONOTONIC_CLOCK_IDENTIFIER
+            )
+            # Appending a flat tuple rather than building a dict keeps this
+            # callback from allocating the very containers it is measuring the
+            # sweep of. Records are expanded to dicts at export time.
+            collection_phase_events.append(
+                (
+                    collection_phase,
+                    collection_info.get("generation"),
+                    collection_info.get("collected"),
+                    collection_info.get("uncollectable"),
+                    collection_phase_stamp_nanoseconds,
+                )
+            )
+
+        self._collection_phase_callback = record_collection_phase_event
+        gc.callbacks.append(record_collection_phase_event)
+
+    def uninstall_collection_phase_callback(self):
+        """Stop recording collection events. Idempotent."""
+        if self._collection_phase_callback is None:
+            return
+        if self._collection_phase_callback in gc.callbacks:
+            gc.callbacks.remove(self._collection_phase_callback)
+        self._collection_phase_callback = None
+
+    def apply_garbage_collection_mode(self, garbage_collection_mode):
+        """Apply `default` or `tuned` GC settings, returning the resolved
+        configuration for the cell spec."""
+        if garbage_collection_mode not in SUPPORTED_GARBAGE_COLLECTION_MODES:
+            raise ValueError(
+                "unsupported garbage collection mode "
+                f"{garbage_collection_mode!r}; expected one of "
+                f"{SUPPORTED_GARBAGE_COLLECTION_MODES}"
+            )
+
+        self._applied_garbage_collection_mode = garbage_collection_mode
+        if garbage_collection_mode == GARBAGE_COLLECTION_MODE_TUNED:
+            # A full sweep first so everything reachable at this point is
+            # settled, then gc.freeze() moves every currently-tracked object into
+            # the permanent generation, which no collection ever traverses again.
+            # Interpreter startup, module import and numpy's own type objects
+            # account for thousands of long-lived containers that a stock gen-2
+            # sweep re-walks every time -- the exact work that shows up as a
+            # multi-millisecond tail spike in a 16.6ms frame budget.
+            gc.collect()
+            gc.freeze()
+            self._frozen_object_count_after_tuning = gc.get_freeze_count()
+            gc.set_threshold(
+                TUNED_GENERATION_ZERO_ALLOCATION_SURPLUS_THRESHOLD,
+                TUNED_GENERATION_ONE_COLLECTION_COUNT_THRESHOLD,
+                TUNED_GENERATION_TWO_COLLECTION_COUNT_THRESHOLD,
+            )
+        self._garbage_collection_thresholds_at_install = gc.get_threshold()
+        return self.report_garbage_collection_configuration()
+
+    def report_garbage_collection_configuration(self):
+        """The GC configuration actually in force, for recording into the cell spec."""
+        return {
+            "applied_garbage_collection_mode": self._applied_garbage_collection_mode,
+            "garbage_collector_enabled": gc.isenabled(),
+            "generation_thresholds": list(gc.get_threshold()),
+            "frozen_permanent_generation_object_count": gc.get_freeze_count(),
+            "frozen_permanent_generation_object_count_immediately_after_tuning": (
+                self._frozen_object_count_after_tuning
+            ),
+            "collection_phase_callback_installed": (
+                self._collection_phase_callback is not None
+            ),
+            "monotonic_clock_identifier": "CLOCK_MONOTONIC",
+            "monotonic_clock_implementation": (
+                time.get_clock_info("monotonic").implementation
+            ),
+        }
+
+    def recorded_collection_phase_event_count(self):
+        """Number of phase events recorded so far (two per completed collection)."""
+        return len(self._collection_phase_events)
+
+    def export_collection_records_as_jsonl(self, output_path):
+        """Write one JSON object per recorded phase event to `output_path`,
+        returning the number of lines written."""
+        self._pending_collection_start_stamp_by_generation = {}
+        output_directory = os.path.dirname(os.path.abspath(output_path))
+        if output_directory:
+            os.makedirs(output_directory, exist_ok=True)
+
+        written_line_count = 0
+        with open(output_path, "w", encoding="utf-8") as jsonl_output_file:
+            for collection_phase_event in self._collection_phase_events:
+                jsonl_output_file.write(
+                    json.dumps(self._expand_collection_phase_event(collection_phase_event))
+                )
+                jsonl_output_file.write("\n")
+                written_line_count += 1
+        return written_line_count
+
+    def _expand_collection_phase_event(self, collection_phase_event):
+        (
+            collection_phase,
+            generation,
+            collected_object_count,
+            uncollectable_object_count,
+            collection_phase_stamp_nanoseconds,
+        ) = collection_phase_event
+
+        collection_record = {
+            "collection_phase": collection_phase,
+            "generation": generation,
+            # CPython zero-fills both counters on the `start` phase and only
+            # populates them on `stop` (verified on CPython 3.12.3); the start
+            # values are recorded as-reported and must not be read as results.
+            "collected_object_count": collected_object_count,
+            "uncollectable_object_count": uncollectable_object_count,
+            "collection_phase_monotonic_nanoseconds": collection_phase_stamp_nanoseconds,
+            "collection_start_monotonic_nanoseconds": None,
+            "collection_stop_monotonic_nanoseconds": None,
+            "collection_duration_nanoseconds": None,
+        }
+
+        if collection_phase == COLLECTION_PHASE_START:
+            self._pending_collection_start_stamp_by_generation[generation] = (
+                collection_phase_stamp_nanoseconds
+            )
+            collection_record["collection_start_monotonic_nanoseconds"] = (
+                collection_phase_stamp_nanoseconds
+            )
+            return collection_record
+
+        collection_record["collection_stop_monotonic_nanoseconds"] = (
+            collection_phase_stamp_nanoseconds
+        )
+        collection_start_stamp_nanoseconds = (
+            self._pending_collection_start_stamp_by_generation.pop(generation, None)
+        )
+        if collection_start_stamp_nanoseconds is not None:
+            collection_record["collection_start_monotonic_nanoseconds"] = (
+                collection_start_stamp_nanoseconds
+            )
+            collection_record["collection_duration_nanoseconds"] = (
+                collection_phase_stamp_nanoseconds - collection_start_stamp_nanoseconds
+            )
+        return collection_record
+
+    def __enter__(self):
+        self.install_collection_phase_callback()
+        return self
+
+    def __exit__(self, exception_type, exception_value, exception_traceback):
+        self.uninstall_collection_phase_callback()
+        return False

--- a/spikes/streamlib-pyembed-spike/python/runner.py
+++ b/spikes/streamlib-pyembed-spike/python/runner.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Measurement-cell driver for the #1702 in-process-Python spike: resolves one
+cell of the (arm x fps x stage x gc) matrix, records its spec, and runs it.
+
+Throwaway spike code. Its API shape is explicitly not a proposal for the SDK."""
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+
+import numpy
+
+from gc_collection_attribution import (
+    GARBAGE_COLLECTION_MODE_DEFAULT,
+    GARBAGE_COLLECTION_MODE_TUNED,
+    GarbageCollectionPauseAttributionRecorder,
+    read_raw_monotonic_clock_nanoseconds,
+)
+
+MEASUREMENT_CELL_LOGGER = logging.getLogger("streamlib_pyembed_spike.runner")
+
+MEASUREMENT_ARM_IN_PROCESS_PYTHON = "in-process"
+MEASUREMENT_ARM_SUBPROCESS_PYTHON = "subprocess"
+MEASUREMENT_ARM_RUST_PASSTHROUGH_FLOOR = "rust-floor"
+SUPPORTED_MEASUREMENT_ARMS = (
+    MEASUREMENT_ARM_IN_PROCESS_PYTHON,
+    MEASUREMENT_ARM_SUBPROCESS_PYTHON,
+    MEASUREMENT_ARM_RUST_PASSTHROUGH_FLOOR,
+)
+
+STAGE_NAME_PASSTHROUGH = "passthrough"
+STAGE_NAME_REALISTIC = "realistic"
+SUPPORTED_STAGE_NAMES = (STAGE_NAME_PASSTHROUGH, STAGE_NAME_REALISTIC)
+
+# Owner decision for #1702: latency percentiles are the primary signal and every
+# emitted sample must reach the sink, so no lossy delivery profile is offered.
+# Drops are counted and reported but do not gate.
+RESOLVED_DELIVERY_PROFILE = "every_sample"
+
+# The metric the Rust sink computes from the in-band preamble. "capture to
+# present" is NOT observable in this rig and must never be used as a metric name.
+PRIMARY_LATENCY_METRIC_NAME = "source_emit_to_sink_receive"
+
+FRAME_CHANNEL_COUNT = 4
+REALISTIC_STAGE_CALIBRATION_ITERATION_COUNT = 200
+REALISTIC_STAGE_CALIBRATION_WARMUP_ITERATION_COUNT = 10
+
+# Tuned on this rig (Ryzen-class x86_64, CPython 3.12.3, numpy 2.4.4) so the
+# realistic stage lands inside the ticket's 2-5ms budget for 1920x1080x4 uint8:
+# measured p50 ~2.5ms, p99 ~4.5ms. Changing any of these three constants
+# re-tunes the cost and invalidates cross-cell comparison.
+REALISTIC_STAGE_GAIN_NUMERATOR = 5
+REALISTIC_STAGE_GAIN_DENOMINATOR = 4
+REALISTIC_STAGE_BRIGHTNESS_BIAS = 8
+
+# PROVISIONAL, see the contract note on
+# `invoke_rust_measurement_harness_for_measurement_cell`: the handover mechanism
+# for the in-process arm's stage callable is not finalized.
+STAGE_CALLBACK_MODULE_ENVIRONMENT_VARIABLE = (
+    "STREAMLIB_PYEMBED_SPIKE_STAGE_CALLBACK_MODULE_PATH"
+)
+STAGE_CALLBACK_FACTORY_ENVIRONMENT_VARIABLE = (
+    "STREAMLIB_PYEMBED_SPIKE_STAGE_CALLBACK_FACTORY_NAME"
+)
+HARNESS_BINARY_ENVIRONMENT_VARIABLE = "STREAMLIB_PYEMBED_SPIKE_HARNESS_BINARY"
+
+MEASUREMENT_CELL_SPECIFICATION_FILE_NAME = "cell-spec.json"
+# Two files, because under the exec arrangement two interpreters exist and only
+# the one running the stage callback can explain a frame-latency tail spike.
+RUNNER_INTERPRETER_GARBAGE_COLLECTION_RECORD_FILE_NAME = (
+    "gc-collections-runner-interpreter.jsonl"
+)
+EMBEDDED_INTERPRETER_GARBAGE_COLLECTION_RECORD_FILE_NAME = (
+    "gc-collections-embedded-interpreter.jsonl"
+)
+
+
+def passthrough_measurement_stage_callback(frame_pixel_array):
+    """The zero-work stage: everything it costs is GIL acquisition plus building
+    the numpy view over the Rust buffer."""
+    return None
+
+
+def build_realistic_measurement_stage_callback(frame_width, frame_height):
+    """Build the ~2-5ms numpy stage callback for a frame geometry.
+
+    The returned callable mutates the caller's array in place. It never rebinds
+    the name: the array aliases a Rust-owned buffer, so a rebind would discard
+    the work silently."""
+    expected_element_count = frame_width * frame_height * FRAME_CHANNEL_COUNT
+    expected_frame_shape = (frame_height, frame_width, FRAME_CHANNEL_COUNT)
+    # Sized once and reused. A per-frame 16 MB int16 temporary would make this
+    # cell an allocator benchmark: the in-process arm shares the engine's
+    # allocator and the subprocess arm does not, so that churn would land
+    # unevenly on the two arms' tails and confound the comparison being made.
+    intermediate_pixel_scratch = numpy.empty(expected_frame_shape, dtype=numpy.int16)
+
+    def realistic_measurement_stage_callback(frame_pixel_array):
+        frame_pixel_view = _reshape_frame_pixel_array_without_copying(
+            frame_pixel_array, expected_element_count, expected_frame_shape
+        )
+        numpy.copyto(intermediate_pixel_scratch, frame_pixel_view, casting="unsafe")
+        numpy.multiply(
+            intermediate_pixel_scratch,
+            REALISTIC_STAGE_GAIN_NUMERATOR,
+            out=intermediate_pixel_scratch,
+        )
+        numpy.floor_divide(
+            intermediate_pixel_scratch,
+            REALISTIC_STAGE_GAIN_DENOMINATOR,
+            out=intermediate_pixel_scratch,
+        )
+        numpy.add(
+            intermediate_pixel_scratch,
+            REALISTIC_STAGE_BRIGHTNESS_BIAS,
+            out=intermediate_pixel_scratch,
+        )
+        numpy.clip(intermediate_pixel_scratch, 0, 255, out=intermediate_pixel_scratch)
+        numpy.copyto(frame_pixel_view, intermediate_pixel_scratch, casting="unsafe")
+        return None
+
+    return realistic_measurement_stage_callback
+
+
+def _reshape_frame_pixel_array_without_copying(
+    frame_pixel_array, expected_element_count, expected_frame_shape
+):
+    if frame_pixel_array.size != expected_element_count:
+        raise ValueError(
+            f"frame carries {frame_pixel_array.size} elements, "
+            f"cell geometry expects {expected_element_count}"
+        )
+    if frame_pixel_array.shape == expected_frame_shape:
+        return frame_pixel_array
+    # numpy.reshape falls back to a copy when the source is not C-contiguous,
+    # and a copy would send every pixel write to a temporary the Rust side never
+    # reads. Refuse rather than silently produce a no-op stage.
+    if not frame_pixel_array.flags.c_contiguous:
+        raise ValueError(
+            "frame buffer is not C-contiguous; reshaping it would copy and the "
+            "stage would no longer write through to the Rust buffer"
+        )
+    return frame_pixel_array.reshape(expected_frame_shape)
+
+
+def build_measurement_stage_callback_for_stage_name(
+    stage_name, frame_width, frame_height
+):
+    """Resolve a `--stage` value to the callable the harness invokes per frame."""
+    if stage_name == STAGE_NAME_PASSTHROUGH:
+        return passthrough_measurement_stage_callback
+    if stage_name == STAGE_NAME_REALISTIC:
+        return build_realistic_measurement_stage_callback(frame_width, frame_height)
+    raise ValueError(
+        f"unsupported stage name {stage_name!r}; expected one of {SUPPORTED_STAGE_NAMES}"
+    )
+
+
+def summarize_sorted_nanosecond_samples(sorted_nanosecond_samples):
+    """Percentile summary of already-sorted samples.
+
+    No mean: the distribution is heavily tailed and a mean headline would hide
+    exactly the GC and scheduler spikes this spike exists to find."""
+    last_sample_index = len(sorted_nanosecond_samples) - 1
+
+    def sample_at_percentile(percentile_fraction):
+        sample_index = int(percentile_fraction * last_sample_index)
+        return sorted_nanosecond_samples[sample_index]
+
+    return {
+        "sample_count": len(sorted_nanosecond_samples),
+        "p50_nanoseconds": sample_at_percentile(0.50),
+        "p99_nanoseconds": sample_at_percentile(0.99),
+        "p99_9_nanoseconds": sample_at_percentile(0.999),
+        "max_nanoseconds": sorted_nanosecond_samples[last_sample_index],
+    }
+
+
+def measure_stage_callback_cost_on_this_machine(
+    measurement_stage_callback, frame_width, frame_height
+):
+    """Time the stage callback against a synthetic frame so the cell spec records
+    what the stage actually costs on the machine the cell ran on."""
+    synthetic_frame_pixel_array = numpy.random.default_rng(seed=1702).integers(
+        0,
+        256,
+        size=(frame_height, frame_width, FRAME_CHANNEL_COUNT),
+        dtype=numpy.uint8,
+    )
+    for _ in range(REALISTIC_STAGE_CALIBRATION_WARMUP_ITERATION_COUNT):
+        measurement_stage_callback(synthetic_frame_pixel_array)
+
+    observed_nanosecond_samples = []
+    for _ in range(REALISTIC_STAGE_CALIBRATION_ITERATION_COUNT):
+        started_at_nanoseconds = read_raw_monotonic_clock_nanoseconds()
+        measurement_stage_callback(synthetic_frame_pixel_array)
+        observed_nanosecond_samples.append(
+            read_raw_monotonic_clock_nanoseconds() - started_at_nanoseconds
+        )
+    observed_nanosecond_samples.sort()
+    return summarize_sorted_nanosecond_samples(observed_nanosecond_samples)
+
+
+def build_measurement_cell_directory_name(
+    measurement_arm, frames_per_second, stage_name, garbage_collection_mode,
+    repetition_index,
+):
+    """Unambiguous, lexically sortable directory name for one cell.
+
+    Zero-padded so a plain `sort` orders 8fps before 60fps, and arm-first so an
+    A/B/A schedule's cells still group by arm on disk."""
+    return (
+        f"arm-{measurement_arm}"
+        f"__fps-{frames_per_second:03d}"
+        f"__stage-{stage_name}"
+        f"__gc-{garbage_collection_mode}"
+        f"__rep-{repetition_index:03d}"
+    )
+
+
+def build_measurement_cell_specification(
+    command_line_arguments,
+    garbage_collection_configuration,
+    stage_callback_cost_summary,
+    measurement_cell_directory,
+):
+    """Every resolved parameter of the cell.
+
+    The summarizer refuses to evaluate a gate the recorded configuration cannot
+    support, so a missing field here silently drops a gate from the artifact."""
+    return {
+        "measurement_arm": command_line_arguments.mode,
+        "frames_per_second": command_line_arguments.fps,
+        "stage_name": command_line_arguments.stage,
+        "garbage_collection_mode": command_line_arguments.gc,
+        "duration_seconds": command_line_arguments.duration,
+        "frame_width": command_line_arguments.frame_width,
+        "frame_height": command_line_arguments.frame_height,
+        "frame_channel_count": FRAME_CHANNEL_COUNT,
+        "repetition_index": command_line_arguments.repetition_index,
+        "output_directory": os.path.abspath(command_line_arguments.output_dir),
+        "measurement_cell_directory": os.path.abspath(measurement_cell_directory),
+        "delivery_profile": RESOLVED_DELIVERY_PROFILE,
+        "primary_latency_metric_name": PRIMARY_LATENCY_METRIC_NAME,
+        "expected_frame_count": int(
+            command_line_arguments.fps * command_line_arguments.duration
+        ),
+        "applied_garbage_collection_configuration": garbage_collection_configuration,
+        "measured_stage_callback_cost": stage_callback_cost_summary,
+        "realistic_stage_operation": (
+            "int16 scratch: gain "
+            f"{REALISTIC_STAGE_GAIN_NUMERATOR}/{REALISTIC_STAGE_GAIN_DENOMINATOR}, "
+            f"bias +{REALISTIC_STAGE_BRIGHTNESS_BIAS}, clip 0..255, "
+            "written back in place"
+        ),
+        "python_version": sys.version,
+        "numpy_version": numpy.__version__,
+        "runner_module_path": os.path.abspath(__file__),
+    }
+
+
+def invoke_rust_measurement_harness_for_measurement_cell(
+    harness_binary_path, measurement_cell_directory, measurement_cell_specification_path
+):
+    """Run the Rust side of the cell. This is the only place the two languages meet.
+
+    Contract as implemented (subprocess exec):
+      argv: <harness_binary_path>
+            --cell-directory <measurement_cell_directory>
+            --cell-specification <measurement_cell_specification_path>
+      The harness reads every resolved parameter from the cell spec, writes its
+      per-frame JSONL into the cell directory, and exits 0 only on a clean run.
+      For the `in-process` arm it loads this module and calls
+      `build_measurement_stage_callback_for_stage_name`, located via the two
+      STAGE_CALLBACK_* environment variables set below.
+
+    OPEN: the orchestrator has not settled whether the harness is a binary that
+    embeds CPython (this path) or a cdylib that CPython imports (in which case
+    this function becomes an import plus a call, and the environment variables
+    below are unnecessary). Both arrangements keep the boundary in this one
+    function."""
+    harness_environment = dict(os.environ)
+    harness_environment[STAGE_CALLBACK_MODULE_ENVIRONMENT_VARIABLE] = os.path.abspath(
+        __file__
+    )
+    harness_environment[STAGE_CALLBACK_FACTORY_ENVIRONMENT_VARIABLE] = (
+        "build_measurement_stage_callback_for_stage_name"
+    )
+    harness_command_line = [
+        harness_binary_path,
+        "--cell-directory",
+        measurement_cell_directory,
+        "--cell-specification",
+        measurement_cell_specification_path,
+    ]
+    MEASUREMENT_CELL_LOGGER.info(
+        "invoking rust measurement harness: %s", " ".join(harness_command_line)
+    )
+    completed_harness_process = subprocess.run(
+        harness_command_line, env=harness_environment, check=False
+    )
+    return completed_harness_process.returncode
+
+
+def set_up_embedded_interpreter_for_measurement_cell(measurement_cell_specification):
+    """Call this from inside the interpreter that will actually run the stage
+    callback, before the first frame.
+
+    Under the exec arrangement that interpreter is the one the harness binary
+    embeds, not the one running this module's `__main__` — a GC recorder
+    installed in the wrong interpreter records collections that cannot have
+    caused any frame's latency. Returns the stage callback paired with the
+    recorder to hand back to `tear_down_embedded_interpreter_for_measurement_cell`."""
+    garbage_collection_recorder = GarbageCollectionPauseAttributionRecorder()
+    garbage_collection_recorder.apply_garbage_collection_mode(
+        measurement_cell_specification["garbage_collection_mode"]
+    )
+    garbage_collection_recorder.install_collection_phase_callback()
+    measurement_stage_callback = build_measurement_stage_callback_for_stage_name(
+        measurement_cell_specification["stage_name"],
+        measurement_cell_specification["frame_width"],
+        measurement_cell_specification["frame_height"],
+    )
+    return measurement_stage_callback, garbage_collection_recorder
+
+
+def tear_down_embedded_interpreter_for_measurement_cell(
+    garbage_collection_recorder, measurement_cell_specification
+):
+    """Stop recording and flush the embedded interpreter's GC records into the
+    cell directory. Returns the number of phase events written."""
+    garbage_collection_recorder.uninstall_collection_phase_callback()
+    return garbage_collection_recorder.export_collection_records_as_jsonl(
+        os.path.join(
+            measurement_cell_specification["measurement_cell_directory"],
+            EMBEDDED_INTERPRETER_GARBAGE_COLLECTION_RECORD_FILE_NAME,
+        )
+    )
+
+
+def parse_measurement_cell_command_line_arguments(command_line_argument_values=None):
+    """Parse one cell's parameters."""
+    argument_parser = argparse.ArgumentParser(
+        prog="runner.py", description="Run one #1702 measurement cell."
+    )
+    argument_parser.add_argument("--fps", type=int, required=True)
+    argument_parser.add_argument(
+        "--stage", choices=SUPPORTED_STAGE_NAMES, required=True
+    )
+    argument_parser.add_argument(
+        "--mode",
+        choices=SUPPORTED_MEASUREMENT_ARMS,
+        required=True,
+        help="the comparison arm; rust-floor is a pure-Rust passthrough that "
+        "isolates engine wire-hop cost from PyO3 cost",
+    )
+    argument_parser.add_argument(
+        "--gc",
+        choices=(GARBAGE_COLLECTION_MODE_DEFAULT, GARBAGE_COLLECTION_MODE_TUNED),
+        default=GARBAGE_COLLECTION_MODE_DEFAULT,
+    )
+    argument_parser.add_argument("--duration", type=float, required=True)
+    argument_parser.add_argument("--output-dir", required=True)
+    argument_parser.add_argument("--frame-width", type=int, default=1920)
+    argument_parser.add_argument("--frame-height", type=int, default=1080)
+    argument_parser.add_argument("--repetition-index", type=int, default=0)
+    argument_parser.add_argument(
+        "--harness-binary",
+        default=os.environ.get(HARNESS_BINARY_ENVIRONMENT_VARIABLE),
+        help="path to the built Rust harness binary; defaults to "
+        f"${HARNESS_BINARY_ENVIRONMENT_VARIABLE}",
+    )
+    argument_parser.add_argument(
+        "--skip-harness-invocation",
+        action="store_true",
+        help="resolve the cell and write cell-spec.json without running it",
+    )
+    return argument_parser.parse_args(command_line_argument_values)
+
+
+def configure_measurement_cell_logging():
+    """Route runner output through `logging`; bare print would interleave badly
+    with the harness's own stdout in an A/B/A schedule."""
+    logging.basicConfig(
+        level=logging.INFO,
+        stream=sys.stderr,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+
+def run_measurement_cell(command_line_arguments):
+    """Resolve, record and run one cell. Returns the process exit status."""
+    measurement_cell_directory = os.path.join(
+        os.path.abspath(command_line_arguments.output_dir),
+        build_measurement_cell_directory_name(
+            command_line_arguments.mode,
+            command_line_arguments.fps,
+            command_line_arguments.stage,
+            command_line_arguments.gc,
+            command_line_arguments.repetition_index,
+        ),
+    )
+    os.makedirs(measurement_cell_directory, exist_ok=True)
+
+    garbage_collection_recorder = GarbageCollectionPauseAttributionRecorder()
+    garbage_collection_configuration = (
+        garbage_collection_recorder.apply_garbage_collection_mode(
+            command_line_arguments.gc
+        )
+    )
+
+    measurement_stage_callback = build_measurement_stage_callback_for_stage_name(
+        command_line_arguments.stage,
+        command_line_arguments.frame_width,
+        command_line_arguments.frame_height,
+    )
+    stage_callback_cost_summary = measure_stage_callback_cost_on_this_machine(
+        measurement_stage_callback,
+        command_line_arguments.frame_width,
+        command_line_arguments.frame_height,
+    )
+    MEASUREMENT_CELL_LOGGER.info(
+        "stage %s measured cost p50=%.3fms p99=%.3fms max=%.3fms",
+        command_line_arguments.stage,
+        stage_callback_cost_summary["p50_nanoseconds"] / 1e6,
+        stage_callback_cost_summary["p99_nanoseconds"] / 1e6,
+        stage_callback_cost_summary["max_nanoseconds"] / 1e6,
+    )
+
+    measurement_cell_specification = build_measurement_cell_specification(
+        command_line_arguments,
+        garbage_collection_configuration,
+        stage_callback_cost_summary,
+        measurement_cell_directory,
+    )
+    measurement_cell_specification_path = os.path.join(
+        measurement_cell_directory, MEASUREMENT_CELL_SPECIFICATION_FILE_NAME
+    )
+    with open(
+        measurement_cell_specification_path, "w", encoding="utf-8"
+    ) as specification_file:
+        json.dump(measurement_cell_specification, specification_file, indent=2)
+        specification_file.write("\n")
+    MEASUREMENT_CELL_LOGGER.info(
+        "wrote cell spec %s", measurement_cell_specification_path
+    )
+
+    if command_line_arguments.skip_harness_invocation:
+        return 0
+    if not command_line_arguments.harness_binary:
+        MEASUREMENT_CELL_LOGGER.error(
+            "no harness binary; pass --harness-binary or set $%s",
+            HARNESS_BINARY_ENVIRONMENT_VARIABLE,
+        )
+        return 2
+
+    garbage_collection_recorder.install_collection_phase_callback()
+    try:
+        harness_exit_status = invoke_rust_measurement_harness_for_measurement_cell(
+            command_line_arguments.harness_binary,
+            measurement_cell_directory,
+            measurement_cell_specification_path,
+        )
+    finally:
+        garbage_collection_recorder.uninstall_collection_phase_callback()
+        written_record_count = (
+            garbage_collection_recorder.export_collection_records_as_jsonl(
+                os.path.join(
+                    measurement_cell_directory,
+                    RUNNER_INTERPRETER_GARBAGE_COLLECTION_RECORD_FILE_NAME,
+                )
+            )
+        )
+        MEASUREMENT_CELL_LOGGER.info(
+            "recorded %d gc phase events in the runner interpreter", written_record_count
+        )
+
+    if harness_exit_status != 0:
+        MEASUREMENT_CELL_LOGGER.error(
+            "harness exited %d for cell %s",
+            harness_exit_status,
+            measurement_cell_directory,
+        )
+    return harness_exit_status
+
+
+if __name__ == "__main__":
+    configure_measurement_cell_logging()
+    sys.exit(run_measurement_cell(parse_measurement_cell_command_line_arguments()))

--- a/spikes/streamlib-pyembed-spike/python/runner.py
+++ b/spikes/streamlib-pyembed-spike/python/runner.py
@@ -2,8 +2,14 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 
-"""Measurement-cell driver for the #1702 in-process-Python spike: resolves one
-cell of the (arm x fps x stage x gc) matrix, records its spec, and runs it.
+"""Drives the Rust Tier A harness over an A/B/A interleaved schedule: one
+harness process per cell, a pure-Rust floor cell on either side of the arm under
+test, so a drift in the machine between cells shows up as a floor-to-floor
+difference instead of being charged to the arm under test.
+
+The harness owns every measurement artifact of a cell, `cell-spec.json`
+included. This runner records only what it resolved itself, into
+`runner-invocation.json`, which points at the harness's cell directory.
 
 Throwaway spike code. Its API shape is explicitly not a proposal for the SDK."""
 
@@ -13,6 +19,7 @@ import logging
 import os
 import subprocess
 import sys
+import time
 
 import numpy
 
@@ -22,144 +29,261 @@ from gc_collection_attribution import (
     GarbageCollectionPauseAttributionRecorder,
     read_raw_monotonic_clock_nanoseconds,
 )
+from spike_stage_callbacks import build_measurement_stage_callback_for_stage_name
 
 MEASUREMENT_CELL_LOGGER = logging.getLogger("streamlib_pyembed_spike.runner")
 
-MEASUREMENT_ARM_IN_PROCESS_PYTHON = "in-process"
-MEASUREMENT_ARM_SUBPROCESS_PYTHON = "subprocess"
-MEASUREMENT_ARM_RUST_PASSTHROUGH_FLOOR = "rust-floor"
-SUPPORTED_MEASUREMENT_ARMS = (
-    MEASUREMENT_ARM_IN_PROCESS_PYTHON,
-    MEASUREMENT_ARM_SUBPROCESS_PYTHON,
-    MEASUREMENT_ARM_RUST_PASSTHROUGH_FLOOR,
+RUNNER_MODE_IN_PROCESS_PYTHON = "in-process"
+RUNNER_MODE_SUBPROCESS_PYTHON = "subprocess"
+RUNNER_MODE_RUST_PASSTHROUGH_FLOOR = "rust-floor"
+SUPPORTED_RUNNER_MODES = (
+    RUNNER_MODE_IN_PROCESS_PYTHON,
+    RUNNER_MODE_SUBPROCESS_PYTHON,
+    RUNNER_MODE_RUST_PASSTHROUGH_FLOOR,
 )
+
+# The runner's `--mode` spelling is the ticket's documented CLI; the harness's
+# `--arm` spelling is what lands in the artifacts. They are deliberately
+# separate vocabularies and this table is the only place they meet.
+HARNESS_ARM_BY_RUNNER_MODE = {
+    RUNNER_MODE_IN_PROCESS_PYTHON: "in-process-python",
+    RUNNER_MODE_RUST_PASSTHROUGH_FLOOR: "rust-passthrough-floor",
+}
 
 STAGE_NAME_PASSTHROUGH = "passthrough"
 STAGE_NAME_REALISTIC = "realistic"
 SUPPORTED_STAGE_NAMES = (STAGE_NAME_PASSTHROUGH, STAGE_NAME_REALISTIC)
 
-# Owner decision for #1702: latency percentiles are the primary signal and every
-# emitted sample must reach the sink, so no lossy delivery profile is offered.
-# Drops are counted and reported but do not gate.
-RESOLVED_DELIVERY_PROFILE = "every_sample"
+# The harness imports this module from PYTHONPATH inside its embedded
+# interpreter and calls the resolved attribute once per frame.
+HARNESS_STAGE_CALLBACK_MODULE_NAME = "spike_stage_callbacks"
+HARNESS_STAGE_CALLBACK_ATTRIBUTE_BY_STAGE_NAME = {
+    STAGE_NAME_PASSTHROUGH: "passthrough_stage",
+    STAGE_NAME_REALISTIC: "realistic_stage",
+}
 
-# The metric the Rust sink computes from the in-band preamble. "capture to
-# present" is NOT observable in this rig and must never be used as a metric name.
-PRIMARY_LATENCY_METRIC_NAME = "source_emit_to_sink_receive"
-
-FRAME_CHANNEL_COUNT = 4
-REALISTIC_STAGE_CALIBRATION_ITERATION_COUNT = 200
-REALISTIC_STAGE_CALIBRATION_WARMUP_ITERATION_COUNT = 10
-
-# Tuned on this rig (Ryzen-class x86_64, CPython 3.12.3, numpy 2.4.4) so the
-# realistic stage lands inside the ticket's 2-5ms budget for 1920x1080x4 uint8:
-# measured p50 ~2.5ms, p99 ~4.5ms. Changing any of these three constants
-# re-tunes the cost and invalidates cross-cell comparison.
-REALISTIC_STAGE_GAIN_NUMERATOR = 5
-REALISTIC_STAGE_GAIN_DENOMINATOR = 4
-REALISTIC_STAGE_BRIGHTNESS_BIAS = 8
-
-# PROVISIONAL, see the contract note on
-# `invoke_rust_measurement_harness_for_measurement_cell`: the handover mechanism
-# for the in-process arm's stage callable is not finalized.
-STAGE_CALLBACK_MODULE_ENVIRONMENT_VARIABLE = (
-    "STREAMLIB_PYEMBED_SPIKE_STAGE_CALLBACK_MODULE_PATH"
-)
-STAGE_CALLBACK_FACTORY_ENVIRONMENT_VARIABLE = (
-    "STREAMLIB_PYEMBED_SPIKE_STAGE_CALLBACK_FACTORY_NAME"
-)
 HARNESS_BINARY_ENVIRONMENT_VARIABLE = "STREAMLIB_PYEMBED_SPIKE_HARNESS_BINARY"
 
-MEASUREMENT_CELL_SPECIFICATION_FILE_NAME = "cell-spec.json"
-# Two files, because under the exec arrangement two interpreters exist and only
-# the one running the stage callback can explain a frame-latency tail spike.
+RUNNER_INVOCATION_RECORD_FILE_NAME = "runner-invocation.json"
+HARNESS_CELL_SPECIFICATION_FILE_NAME = "cell-spec.json"
+HARNESS_CELL_SUMMARY_FILE_NAME = "summary.json"
 RUNNER_INTERPRETER_GARBAGE_COLLECTION_RECORD_FILE_NAME = (
     "gc-collections-runner-interpreter.jsonl"
 )
-EMBEDDED_INTERPRETER_GARBAGE_COLLECTION_RECORD_FILE_NAME = (
-    "gc-collections-embedded-interpreter.jsonl"
-)
+
+FRAME_CHANNEL_COUNT = 4
+STAGE_CALLBACK_CALIBRATION_ITERATION_COUNT = 200
+STAGE_CALLBACK_CALIBRATION_WARMUP_ITERATION_COUNT = 10
+
+# The protocol excludes the first 60s of every cell. A cell shorter than that
+# cannot honour it, so short exploratory cells fall back to the value below and
+# are logged as non-protocol rather than silently measuring nothing.
+PROTOCOL_WARMUP_EXCLUSION_SECONDS = 60
+EXPLORATORY_CELL_WARMUP_EXCLUSION_SECONDS = 1
+
+# Some filesystems round modification times to whole seconds, so a cell
+# directory written milliseconds after the harness started can carry a stamp
+# fractionally before it. The newest match wins, so the slack only widens the
+# candidate set.
+CELL_DIRECTORY_MODIFICATION_TIME_SLACK_SECONDS = 2.0
 
 
-def passthrough_measurement_stage_callback(frame_pixel_array):
-    """The zero-work stage: everything it costs is GIL acquisition plus building
-    the numpy view over the Rust buffer."""
-    return None
+class SubprocessArmIsTierBAndNotImplementedError(NotImplementedError):
+    """Raised for `--mode subprocess`, which no code path in this PR implements."""
 
 
-def build_realistic_measurement_stage_callback(frame_width, frame_height):
-    """Build the ~2-5ms numpy stage callback for a frame geometry.
-
-    The returned callable mutates the caller's array in place. It never rebinds
-    the name: the array aliases a Rust-owned buffer, so a rebind would discard
-    the work silently."""
-    expected_element_count = frame_width * frame_height * FRAME_CHANNEL_COUNT
-    expected_frame_shape = (frame_height, frame_width, FRAME_CHANNEL_COUNT)
-    # Sized once and reused. A per-frame 16 MB int16 temporary would make this
-    # cell an allocator benchmark: the in-process arm shares the engine's
-    # allocator and the subprocess arm does not, so that churn would land
-    # unevenly on the two arms' tails and confound the comparison being made.
-    intermediate_pixel_scratch = numpy.empty(expected_frame_shape, dtype=numpy.int16)
-
-    def realistic_measurement_stage_callback(frame_pixel_array):
-        frame_pixel_view = _reshape_frame_pixel_array_without_copying(
-            frame_pixel_array, expected_element_count, expected_frame_shape
+def resolve_harness_arm_for_runner_mode(runner_mode):
+    """Map a runner `--mode` to the harness `--arm` token it drives."""
+    if runner_mode == RUNNER_MODE_SUBPROCESS_PYTHON:
+        raise SubprocessArmIsTierBAndNotImplementedError(
+            "--mode subprocess is the Tier B baseline and is not in this PR: no "
+            "subprocess arm exists in the harness, which accepts only "
+            "in-process-python and rust-passthrough-floor. Run it from the Tier B "
+            "work on #1702."
         )
-        numpy.copyto(intermediate_pixel_scratch, frame_pixel_view, casting="unsafe")
-        numpy.multiply(
-            intermediate_pixel_scratch,
-            REALISTIC_STAGE_GAIN_NUMERATOR,
-            out=intermediate_pixel_scratch,
-        )
-        numpy.floor_divide(
-            intermediate_pixel_scratch,
-            REALISTIC_STAGE_GAIN_DENOMINATOR,
-            out=intermediate_pixel_scratch,
-        )
-        numpy.add(
-            intermediate_pixel_scratch,
-            REALISTIC_STAGE_BRIGHTNESS_BIAS,
-            out=intermediate_pixel_scratch,
-        )
-        numpy.clip(intermediate_pixel_scratch, 0, 255, out=intermediate_pixel_scratch)
-        numpy.copyto(frame_pixel_view, intermediate_pixel_scratch, casting="unsafe")
-        return None
-
-    return realistic_measurement_stage_callback
-
-
-def _reshape_frame_pixel_array_without_copying(
-    frame_pixel_array, expected_element_count, expected_frame_shape
-):
-    if frame_pixel_array.size != expected_element_count:
+    if runner_mode not in HARNESS_ARM_BY_RUNNER_MODE:
         raise ValueError(
-            f"frame carries {frame_pixel_array.size} elements, "
-            f"cell geometry expects {expected_element_count}"
+            f"unsupported runner mode {runner_mode!r}; expected one of "
+            f"{SUPPORTED_RUNNER_MODES}"
         )
-    if frame_pixel_array.shape == expected_frame_shape:
-        return frame_pixel_array
-    # numpy.reshape falls back to a copy when the source is not C-contiguous,
-    # and a copy would send every pixel write to a temporary the Rust side never
-    # reads. Refuse rather than silently produce a no-op stage.
-    if not frame_pixel_array.flags.c_contiguous:
+    return HARNESS_ARM_BY_RUNNER_MODE[runner_mode]
+
+
+def resolve_harness_stage_callback_attribute_for_stage_name(stage_name):
+    """Map a runner `--stage` to the callable the harness imports per frame."""
+    if stage_name not in HARNESS_STAGE_CALLBACK_ATTRIBUTE_BY_STAGE_NAME:
         raise ValueError(
-            "frame buffer is not C-contiguous; reshaping it would copy and the "
-            "stage would no longer write through to the Rust buffer"
+            f"unsupported stage name {stage_name!r}; expected one of "
+            f"{SUPPORTED_STAGE_NAMES}"
         )
-    return frame_pixel_array.reshape(expected_frame_shape)
+    return HARNESS_STAGE_CALLBACK_ATTRIBUTE_BY_STAGE_NAME[stage_name]
 
 
-def build_measurement_stage_callback_for_stage_name(
-    stage_name, frame_width, frame_height
+def resolve_cell_duration_seconds(requested_duration_seconds):
+    """The harness measures in whole seconds, so a fractional duration is a
+    request the rig cannot honour and must not be rounded away silently."""
+    whole_duration_seconds = int(requested_duration_seconds)
+    if whole_duration_seconds != requested_duration_seconds:
+        raise ValueError(
+            f"--duration {requested_duration_seconds} is not a whole number of "
+            "seconds; the harness's --duration-seconds is integral"
+        )
+    if whole_duration_seconds < 1:
+        raise ValueError("--duration must be at least one second")
+    return whole_duration_seconds
+
+
+def resolve_warmup_exclusion_seconds(
+    requested_warmup_exclusion_seconds, cell_duration_seconds
 ):
-    """Resolve a `--stage` value to the callable the harness invokes per frame."""
-    if stage_name == STAGE_NAME_PASSTHROUGH:
-        return passthrough_measurement_stage_callback
-    if stage_name == STAGE_NAME_REALISTIC:
-        return build_realistic_measurement_stage_callback(frame_width, frame_height)
-    raise ValueError(
-        f"unsupported stage name {stage_name!r}; expected one of {SUPPORTED_STAGE_NAMES}"
+    """Resolve the warmup exclusion the harness is told to apply."""
+    if requested_warmup_exclusion_seconds is not None:
+        resolved_warmup_exclusion_seconds = requested_warmup_exclusion_seconds
+    elif cell_duration_seconds > PROTOCOL_WARMUP_EXCLUSION_SECONDS:
+        resolved_warmup_exclusion_seconds = PROTOCOL_WARMUP_EXCLUSION_SECONDS
+    else:
+        resolved_warmup_exclusion_seconds = EXPLORATORY_CELL_WARMUP_EXCLUSION_SECONDS
+        MEASUREMENT_CELL_LOGGER.warning(
+            "cell duration %ds cannot carry the protocol's %ds warmup exclusion; "
+            "excluding %ds instead — these cells are exploratory and their "
+            "percentiles are not protocol numbers",
+            cell_duration_seconds,
+            PROTOCOL_WARMUP_EXCLUSION_SECONDS,
+            EXPLORATORY_CELL_WARMUP_EXCLUSION_SECONDS,
+        )
+
+    if resolved_warmup_exclusion_seconds < 0:
+        raise ValueError("--warmup-exclusion-seconds cannot be negative")
+    # A cell whose warmup covers its whole duration still exits 0 and still
+    # writes a summary — one whose percentiles are all zero, which reads like a
+    # very fast cell rather than an empty one.
+    if resolved_warmup_exclusion_seconds >= cell_duration_seconds:
+        raise ValueError(
+            f"a {resolved_warmup_exclusion_seconds}s warmup exclusion covers the "
+            f"whole {cell_duration_seconds}s cell and no frame would be measured; "
+            "lengthen --duration or pass a smaller --warmup-exclusion-seconds"
+        )
+    return resolved_warmup_exclusion_seconds
+
+
+def build_interleaved_measurement_schedule_for_runner_mode(runner_mode):
+    """The cell order inside one repetition: floor, arm under test, floor.
+
+    A schedule of only floor cells would compare the floor against itself, so
+    the floor mode collapses to a single cell per repetition."""
+    if runner_mode == RUNNER_MODE_RUST_PASSTHROUGH_FLOOR:
+        return (RUNNER_MODE_RUST_PASSTHROUGH_FLOOR,)
+    return (
+        RUNNER_MODE_RUST_PASSTHROUGH_FLOOR,
+        runner_mode,
+        RUNNER_MODE_RUST_PASSTHROUGH_FLOOR,
     )
+
+
+def build_harness_repetition_index(
+    runner_repetition_index, schedule_position_index, schedule_length
+):
+    """Give every cell of every repetition its own harness repetition index.
+
+    The harness derives its cell directory name from arm, rate, GIL anchor and
+    repetition index — the two floor cells of one A/B/A repetition agree on all
+    but the last, so sharing an index would make the second silently overwrite
+    the first."""
+    return runner_repetition_index * schedule_length + schedule_position_index
+
+
+def build_tier_a_harness_command_line(
+    command_line_arguments,
+    harness_arm,
+    harness_repetition_index,
+    cell_duration_seconds,
+    warmup_exclusion_seconds,
+    garbage_collection_mode,
+):
+    """The exact argv for one cell. Every flag here is declared by
+    `src/bin/tier_a_harness.rs`; the harness rejects anything else."""
+    harness_command_line = [
+        command_line_arguments.harness_binary,
+        "--arm",
+        harness_arm,
+        "--fps",
+        str(command_line_arguments.fps),
+        "--frame-width",
+        str(command_line_arguments.frame_width),
+        "--frame-height",
+        str(command_line_arguments.frame_height),
+        "--channels",
+        str(FRAME_CHANNEL_COUNT),
+        "--duration-seconds",
+        str(cell_duration_seconds),
+        "--warmup-exclusion-seconds",
+        str(warmup_exclusion_seconds),
+        "--repetition-index",
+        str(harness_repetition_index),
+        "--stage-callback-module",
+        HARNESS_STAGE_CALLBACK_MODULE_NAME,
+        "--garbage-collection-mode",
+        garbage_collection_mode,
+        "--stage-callback-attribute",
+        resolve_harness_stage_callback_attribute_for_stage_name(
+            command_line_arguments.stage
+        ),
+        "--output-directory",
+        os.path.abspath(command_line_arguments.output_dir),
+    ]
+    if command_line_arguments.disable_gil_anchor:
+        harness_command_line.append("--disable-gil-anchor")
+    if command_line_arguments.require_locked_measurement_state:
+        harness_command_line.append("--require-locked-measurement-state")
+    return harness_command_line
+
+
+def build_tier_a_harness_process_environment():
+    """The harness imports the stage callback module by name from PYTHONPATH, so
+    this module's own directory has to be on it whatever the caller's cwd is."""
+    harness_process_environment = dict(os.environ)
+    spike_python_directory = os.path.dirname(os.path.abspath(__file__))
+    existing_python_path = harness_process_environment.get("PYTHONPATH", "")
+    harness_process_environment["PYTHONPATH"] = os.pathsep.join(
+        [spike_python_directory, existing_python_path]
+        if existing_python_path
+        else [spike_python_directory]
+    )
+    return harness_process_environment
+
+
+def locate_measurement_cell_directory_created_by_harness(
+    harness_output_directory, harness_started_at_epoch_seconds
+):
+    """Find the cell directory the harness just created, by looking rather than
+    predicting: the harness derives the name from its own specification and this
+    runner must not carry a second copy of that rule."""
+    if not os.path.isdir(harness_output_directory):
+        return None
+    earliest_acceptable_modification_time = (
+        harness_started_at_epoch_seconds - CELL_DIRECTORY_MODIFICATION_TIME_SLACK_SECONDS
+    )
+    newest_cell_directory_path = None
+    newest_summary_modification_time = None
+    with os.scandir(harness_output_directory) as output_directory_entries:
+        for output_directory_entry in output_directory_entries:
+            if not output_directory_entry.is_dir():
+                continue
+            candidate_summary_path = os.path.join(
+                output_directory_entry.path, HARNESS_CELL_SUMMARY_FILE_NAME
+            )
+            if not os.path.isfile(candidate_summary_path):
+                continue
+            summary_modification_time = os.stat(candidate_summary_path).st_mtime
+            if summary_modification_time < earliest_acceptable_modification_time:
+                continue
+            if (
+                newest_summary_modification_time is None
+                or summary_modification_time > newest_summary_modification_time
+            ):
+                newest_summary_modification_time = summary_modification_time
+                newest_cell_directory_path = output_directory_entry.path
+    return newest_cell_directory_path
 
 
 def summarize_sorted_nanosecond_samples(sorted_nanosecond_samples):
@@ -182,22 +306,24 @@ def summarize_sorted_nanosecond_samples(sorted_nanosecond_samples):
     }
 
 
-def measure_stage_callback_cost_on_this_machine(
-    measurement_stage_callback, frame_width, frame_height
-):
-    """Time the stage callback against a synthetic frame so the cell spec records
-    what the stage actually costs on the machine the cell ran on."""
+def measure_stage_callback_cost_in_runner_interpreter(stage_name, frame_width, frame_height):
+    """Time the harness's own stage callable against a synthetic frame, so the
+    invocation record says what that stage costs on this machine.
+
+    This runs in the runner's interpreter, not the harness's embedded one: it
+    sizes the stage, it does not measure the cell."""
+    measurement_stage_callback = build_measurement_stage_callback_for_stage_name(stage_name)
     synthetic_frame_pixel_array = numpy.random.default_rng(seed=1702).integers(
         0,
         256,
         size=(frame_height, frame_width, FRAME_CHANNEL_COUNT),
         dtype=numpy.uint8,
     )
-    for _ in range(REALISTIC_STAGE_CALIBRATION_WARMUP_ITERATION_COUNT):
+    for _ in range(STAGE_CALLBACK_CALIBRATION_WARMUP_ITERATION_COUNT):
         measurement_stage_callback(synthetic_frame_pixel_array)
 
     observed_nanosecond_samples = []
-    for _ in range(REALISTIC_STAGE_CALIBRATION_ITERATION_COUNT):
+    for _ in range(STAGE_CALLBACK_CALIBRATION_ITERATION_COUNT):
         started_at_nanoseconds = read_raw_monotonic_clock_nanoseconds()
         measurement_stage_callback(synthetic_frame_pixel_array)
         observed_nanosecond_samples.append(
@@ -207,169 +333,304 @@ def measure_stage_callback_cost_on_this_machine(
     return summarize_sorted_nanosecond_samples(observed_nanosecond_samples)
 
 
-def build_measurement_cell_directory_name(
-    measurement_arm, frames_per_second, stage_name, garbage_collection_mode,
-    repetition_index,
-):
-    """Unambiguous, lexically sortable directory name for one cell.
-
-    Zero-padded so a plain `sort` orders 8fps before 60fps, and arm-first so an
-    A/B/A schedule's cells still group by arm on disk."""
-    return (
-        f"arm-{measurement_arm}"
-        f"__fps-{frames_per_second:03d}"
-        f"__stage-{stage_name}"
-        f"__gc-{garbage_collection_mode}"
-        f"__rep-{repetition_index:03d}"
-    )
-
-
-def build_measurement_cell_specification(
+def build_runner_invocation_record(
     command_line_arguments,
-    garbage_collection_configuration,
+    harness_arm,
+    harness_command_line,
+    runner_repetition_index,
+    schedule_position_index,
+    harness_repetition_index,
+    cell_duration_seconds,
+    warmup_exclusion_seconds,
+    runner_interpreter_garbage_collection_configuration,
     stage_callback_cost_summary,
     measurement_cell_directory,
 ):
-    """Every resolved parameter of the cell.
+    """What this runner resolved for one cell, and where the harness's own
+    authoritative specification for that cell lives.
 
-    The summarizer refuses to evaluate a gate the recorded configuration cannot
-    support, so a missing field here silently drops a gate from the artifact."""
+    Deliberately carries no measurement parameter the harness records itself:
+    two files claiming to be the cell's specification is how the artifact
+    directory acquires two disagreeing answers."""
     return {
-        "measurement_arm": command_line_arguments.mode,
-        "frames_per_second": command_line_arguments.fps,
+        "runner_mode": command_line_arguments.mode,
+        "harness_arm": harness_arm,
         "stage_name": command_line_arguments.stage,
-        "garbage_collection_mode": command_line_arguments.gc,
-        "duration_seconds": command_line_arguments.duration,
-        "frame_width": command_line_arguments.frame_width,
-        "frame_height": command_line_arguments.frame_height,
-        "frame_channel_count": FRAME_CHANNEL_COUNT,
-        "repetition_index": command_line_arguments.repetition_index,
-        "output_directory": os.path.abspath(command_line_arguments.output_dir),
-        "measurement_cell_directory": os.path.abspath(measurement_cell_directory),
-        "delivery_profile": RESOLVED_DELIVERY_PROFILE,
-        "primary_latency_metric_name": PRIMARY_LATENCY_METRIC_NAME,
-        "expected_frame_count": int(
-            command_line_arguments.fps * command_line_arguments.duration
+        "harness_stage_callback_module": HARNESS_STAGE_CALLBACK_MODULE_NAME,
+        "harness_stage_callback_attribute": (
+            resolve_harness_stage_callback_attribute_for_stage_name(
+                command_line_arguments.stage
+            )
         ),
-        "applied_garbage_collection_configuration": garbage_collection_configuration,
-        "measured_stage_callback_cost": stage_callback_cost_summary,
-        "realistic_stage_operation": (
-            "int16 scratch: gain "
-            f"{REALISTIC_STAGE_GAIN_NUMERATOR}/{REALISTIC_STAGE_GAIN_DENOMINATOR}, "
-            f"bias +{REALISTIC_STAGE_BRIGHTNESS_BIAS}, clip 0..255, "
-            "written back in place"
+        "harness_binary_path": os.path.abspath(command_line_arguments.harness_binary),
+        "harness_command_line": harness_command_line,
+        "harness_output_directory": os.path.abspath(command_line_arguments.output_dir),
+        "measurement_cell_directory": measurement_cell_directory,
+        "authoritative_cell_specification_path": os.path.join(
+            measurement_cell_directory, HARNESS_CELL_SPECIFICATION_FILE_NAME
         ),
+        "interleaved_schedule": list(
+            build_interleaved_measurement_schedule_for_runner_mode(
+                command_line_arguments.mode
+            )
+        ),
+        "runner_repetition_index": runner_repetition_index,
+        "schedule_position_index": schedule_position_index,
+        "harness_repetition_index": harness_repetition_index,
+        "cell_duration_seconds": cell_duration_seconds,
+        "warmup_exclusion_seconds": warmup_exclusion_seconds,
+        "expected_frame_count": command_line_arguments.fps * cell_duration_seconds,
+        # Applied to the interpreter this runner runs in. Nothing configures the
+        # harness's embedded interpreter, so this must never be read as the
+        # cell's GC configuration.
+        "runner_interpreter_garbage_collection_configuration": (
+            runner_interpreter_garbage_collection_configuration
+        ),
+        "measured_stage_callback_cost_in_runner_interpreter": stage_callback_cost_summary,
         "python_version": sys.version,
         "numpy_version": numpy.__version__,
         "runner_module_path": os.path.abspath(__file__),
     }
 
 
-def invoke_rust_measurement_harness_for_measurement_cell(
-    harness_binary_path, measurement_cell_directory, measurement_cell_specification_path
+def write_json_document(output_path, document):
+    """Write one pretty-printed JSON document, newline-terminated."""
+    with open(output_path, "w", encoding="utf-8") as json_output_file:
+        json.dump(document, json_output_file, indent=2)
+        json_output_file.write("\n")
+
+
+def run_one_measurement_cell(
+    command_line_arguments,
+    cell_runner_mode,
+    runner_repetition_index,
+    schedule_position_index,
+    schedule_length,
+    cell_duration_seconds,
+    warmup_exclusion_seconds,
+    runner_interpreter_garbage_collection_configuration,
+    stage_callback_cost_summary,
 ):
-    """Run the Rust side of the cell. This is the only place the two languages meet.
-
-    Contract as implemented (subprocess exec):
-      argv: <harness_binary_path>
-            --cell-directory <measurement_cell_directory>
-            --cell-specification <measurement_cell_specification_path>
-      The harness reads every resolved parameter from the cell spec, writes its
-      per-frame JSONL into the cell directory, and exits 0 only on a clean run.
-      For the `in-process` arm it loads this module and calls
-      `build_measurement_stage_callback_for_stage_name`, located via the two
-      STAGE_CALLBACK_* environment variables set below.
-
-    OPEN: the orchestrator has not settled whether the harness is a binary that
-    embeds CPython (this path) or a cdylib that CPython imports (in which case
-    this function becomes an import plus a call, and the environment variables
-    below are unnecessary). Both arrangements keep the boundary in this one
-    function."""
-    harness_environment = dict(os.environ)
-    harness_environment[STAGE_CALLBACK_MODULE_ENVIRONMENT_VARIABLE] = os.path.abspath(
-        __file__
+    """Run one cell to completion. Returns the harness's exit status."""
+    harness_arm = resolve_harness_arm_for_runner_mode(cell_runner_mode)
+    harness_repetition_index = build_harness_repetition_index(
+        runner_repetition_index, schedule_position_index, schedule_length
     )
-    harness_environment[STAGE_CALLBACK_FACTORY_ENVIRONMENT_VARIABLE] = (
-        "build_measurement_stage_callback_for_stage_name"
+    harness_command_line = build_tier_a_harness_command_line(
+        command_line_arguments,
+        harness_arm,
+        harness_repetition_index,
+        cell_duration_seconds,
+        warmup_exclusion_seconds,
+        command_line_arguments.gc,
     )
-    harness_command_line = [
-        harness_binary_path,
-        "--cell-directory",
-        measurement_cell_directory,
-        "--cell-specification",
-        measurement_cell_specification_path,
-    ]
     MEASUREMENT_CELL_LOGGER.info(
-        "invoking rust measurement harness: %s", " ".join(harness_command_line)
+        "repetition %d position %d of %d: invoking harness: %s",
+        runner_repetition_index,
+        schedule_position_index,
+        schedule_length,
+        " ".join(harness_command_line),
     )
-    completed_harness_process = subprocess.run(
-        harness_command_line, env=harness_environment, check=False
-    )
-    return completed_harness_process.returncode
 
-
-def set_up_embedded_interpreter_for_measurement_cell(measurement_cell_specification):
-    """Call this from inside the interpreter that will actually run the stage
-    callback, before the first frame.
-
-    Under the exec arrangement that interpreter is the one the harness binary
-    embeds, not the one running this module's `__main__` — a GC recorder
-    installed in the wrong interpreter records collections that cannot have
-    caused any frame's latency. Returns the stage callback paired with the
-    recorder to hand back to `tear_down_embedded_interpreter_for_measurement_cell`."""
     garbage_collection_recorder = GarbageCollectionPauseAttributionRecorder()
-    garbage_collection_recorder.apply_garbage_collection_mode(
-        measurement_cell_specification["garbage_collection_mode"]
-    )
     garbage_collection_recorder.install_collection_phase_callback()
-    measurement_stage_callback = build_measurement_stage_callback_for_stage_name(
-        measurement_cell_specification["stage_name"],
-        measurement_cell_specification["frame_width"],
-        measurement_cell_specification["frame_height"],
+    harness_started_at_epoch_seconds = time.time()
+    try:
+        completed_harness_process = subprocess.run(
+            harness_command_line,
+            env=build_tier_a_harness_process_environment(),
+            check=False,
+        )
+    finally:
+        garbage_collection_recorder.uninstall_collection_phase_callback()
+    harness_exit_status = completed_harness_process.returncode
+
+    measurement_cell_directory = locate_measurement_cell_directory_created_by_harness(
+        os.path.abspath(command_line_arguments.output_dir),
+        harness_started_at_epoch_seconds,
     )
-    return measurement_stage_callback, garbage_collection_recorder
+    if measurement_cell_directory is None:
+        MEASUREMENT_CELL_LOGGER.error(
+            "harness exited %d and left no cell directory under %s",
+            harness_exit_status,
+            os.path.abspath(command_line_arguments.output_dir),
+        )
+        return harness_exit_status if harness_exit_status != 0 else 2
+    MEASUREMENT_CELL_LOGGER.info(
+        "harness exited %d for cell %s", harness_exit_status, measurement_cell_directory
+    )
 
-
-def tear_down_embedded_interpreter_for_measurement_cell(
-    garbage_collection_recorder, measurement_cell_specification
-):
-    """Stop recording and flush the embedded interpreter's GC records into the
-    cell directory. Returns the number of phase events written."""
-    garbage_collection_recorder.uninstall_collection_phase_callback()
-    return garbage_collection_recorder.export_collection_records_as_jsonl(
+    written_record_count = garbage_collection_recorder.export_collection_records_as_jsonl(
         os.path.join(
-            measurement_cell_specification["measurement_cell_directory"],
-            EMBEDDED_INTERPRETER_GARBAGE_COLLECTION_RECORD_FILE_NAME,
+            measurement_cell_directory,
+            RUNNER_INTERPRETER_GARBAGE_COLLECTION_RECORD_FILE_NAME,
         )
     )
+    MEASUREMENT_CELL_LOGGER.info(
+        "recorded %d gc phase events in the runner interpreter while the cell ran",
+        written_record_count,
+    )
+
+    write_json_document(
+        os.path.join(measurement_cell_directory, RUNNER_INVOCATION_RECORD_FILE_NAME),
+        build_runner_invocation_record(
+            command_line_arguments,
+            harness_arm,
+            harness_command_line,
+            runner_repetition_index,
+            schedule_position_index,
+            harness_repetition_index,
+            cell_duration_seconds,
+            warmup_exclusion_seconds,
+            runner_interpreter_garbage_collection_configuration,
+            stage_callback_cost_summary
+            if cell_runner_mode == RUNNER_MODE_IN_PROCESS_PYTHON
+            else None,
+            measurement_cell_directory,
+        ),
+    )
+    return harness_exit_status
+
+
+def run_interleaved_measurement_schedule(command_line_arguments):
+    """Run every cell of every repetition in A/B/A order, stopping at the first
+    cell the harness refuses. Returns the process exit status."""
+    resolve_harness_arm_for_runner_mode(command_line_arguments.mode)
+    cell_duration_seconds = resolve_cell_duration_seconds(command_line_arguments.duration)
+    warmup_exclusion_seconds = resolve_warmup_exclusion_seconds(
+        command_line_arguments.warmup_exclusion_seconds, cell_duration_seconds
+    )
+    interleaved_schedule = build_interleaved_measurement_schedule_for_runner_mode(
+        command_line_arguments.mode
+    )
+
+    if not command_line_arguments.harness_binary:
+        MEASUREMENT_CELL_LOGGER.error(
+            "no harness binary; pass --harness-binary or set $%s",
+            HARNESS_BINARY_ENVIRONMENT_VARIABLE,
+        )
+        return 2
+    if not os.path.isfile(command_line_arguments.harness_binary):
+        MEASUREMENT_CELL_LOGGER.error(
+            "harness binary %s does not exist; run `cargo build --release`",
+            command_line_arguments.harness_binary,
+        )
+        return 2
+
+    garbage_collection_recorder = GarbageCollectionPauseAttributionRecorder()
+    runner_interpreter_garbage_collection_configuration = (
+        garbage_collection_recorder.apply_garbage_collection_mode(
+            command_line_arguments.gc
+        )
+    )
+    MEASUREMENT_CELL_LOGGER.info(
+        "gc mode %s applied to the runner interpreter only; the harness's embedded "
+        "interpreter runs its own default configuration",
+        command_line_arguments.gc,
+    )
+
+    stage_callback_cost_summary = measure_stage_callback_cost_in_runner_interpreter(
+        command_line_arguments.stage,
+        command_line_arguments.frame_width,
+        command_line_arguments.frame_height,
+    )
+    MEASUREMENT_CELL_LOGGER.info(
+        "stage %s measured cost p50=%.3fms p99=%.3fms max=%.3fms",
+        command_line_arguments.stage,
+        stage_callback_cost_summary["p50_nanoseconds"] / 1e6,
+        stage_callback_cost_summary["p99_nanoseconds"] / 1e6,
+        stage_callback_cost_summary["max_nanoseconds"] / 1e6,
+    )
+
+    os.makedirs(os.path.abspath(command_line_arguments.output_dir), exist_ok=True)
+
+    if command_line_arguments.skip_harness_invocation:
+        MEASUREMENT_CELL_LOGGER.info(
+            "skipping harness invocation; schedule for %d repetition(s): %s",
+            command_line_arguments.repetitions,
+            " -> ".join(interleaved_schedule),
+        )
+        return 0
+
+    for repetition_offset in range(command_line_arguments.repetitions):
+        runner_repetition_index = (
+            command_line_arguments.repetition_index + repetition_offset
+        )
+        for schedule_position_index, cell_runner_mode in enumerate(interleaved_schedule):
+            harness_exit_status = run_one_measurement_cell(
+                command_line_arguments,
+                cell_runner_mode,
+                runner_repetition_index,
+                schedule_position_index,
+                len(interleaved_schedule),
+                cell_duration_seconds,
+                warmup_exclusion_seconds,
+                runner_interpreter_garbage_collection_configuration,
+                stage_callback_cost_summary,
+            )
+            if harness_exit_status != 0:
+                MEASUREMENT_CELL_LOGGER.error(
+                    "stopping the schedule: repetition %d position %d exited %d",
+                    runner_repetition_index,
+                    schedule_position_index,
+                    harness_exit_status,
+                )
+                return harness_exit_status
+    return 0
 
 
 def parse_measurement_cell_command_line_arguments(command_line_argument_values=None):
-    """Parse one cell's parameters."""
+    """Parse the schedule's parameters."""
     argument_parser = argparse.ArgumentParser(
-        prog="runner.py", description="Run one #1702 measurement cell."
+        prog="runner.py",
+        description="Run an A/B/A interleaved schedule of #1702 measurement cells.",
     )
     argument_parser.add_argument("--fps", type=int, required=True)
-    argument_parser.add_argument(
-        "--stage", choices=SUPPORTED_STAGE_NAMES, required=True
-    )
+    argument_parser.add_argument("--stage", choices=SUPPORTED_STAGE_NAMES, required=True)
     argument_parser.add_argument(
         "--mode",
-        choices=SUPPORTED_MEASUREMENT_ARMS,
+        choices=SUPPORTED_RUNNER_MODES,
         required=True,
-        help="the comparison arm; rust-floor is a pure-Rust passthrough that "
-        "isolates engine wire-hop cost from PyO3 cost",
+        help="the arm under test; rust-floor is a pure-Rust passthrough that "
+        "isolates engine wire-hop cost from PyO3 cost, and is also the A of the "
+        "A/B/A schedule. subprocess is Tier B and not implemented in this PR",
     )
     argument_parser.add_argument(
         "--gc",
         choices=(GARBAGE_COLLECTION_MODE_DEFAULT, GARBAGE_COLLECTION_MODE_TUNED),
         default=GARBAGE_COLLECTION_MODE_DEFAULT,
+        help="GC configuration for the runner's own interpreter; it does not "
+        "reach the harness's embedded interpreter",
     )
-    argument_parser.add_argument("--duration", type=float, required=True)
+    argument_parser.add_argument(
+        "--duration", type=float, required=True, help="per-cell duration in whole seconds"
+    )
     argument_parser.add_argument("--output-dir", required=True)
     argument_parser.add_argument("--frame-width", type=int, default=1920)
     argument_parser.add_argument("--frame-height", type=int, default=1080)
-    argument_parser.add_argument("--repetition-index", type=int, default=0)
+    argument_parser.add_argument(
+        "--warmup-exclusion-seconds",
+        type=int,
+        default=None,
+        help=f"defaults to {PROTOCOL_WARMUP_EXCLUSION_SECONDS}s for cells long "
+        f"enough to carry it, {EXPLORATORY_CELL_WARMUP_EXCLUSION_SECONDS}s otherwise",
+    )
+    argument_parser.add_argument(
+        "--repetition-index",
+        type=int,
+        default=0,
+        help="index of the first repetition, so a second schedule can extend an "
+        "existing output directory without overwriting its cells",
+    )
+    argument_parser.add_argument(
+        "--repetitions",
+        type=int,
+        default=1,
+        help="how many A/B/A repetitions to run; each contributes one harness "
+        "process per cell",
+    )
+    argument_parser.add_argument("--disable-gil-anchor", action="store_true")
+    argument_parser.add_argument("--require-locked-measurement-state", action="store_true")
     argument_parser.add_argument(
         "--harness-binary",
         default=os.environ.get(HARNESS_BINARY_ENVIRONMENT_VARIABLE),
@@ -379,7 +640,7 @@ def parse_measurement_cell_command_line_arguments(command_line_argument_values=N
     argument_parser.add_argument(
         "--skip-harness-invocation",
         action="store_true",
-        help="resolve the cell and write cell-spec.json without running it",
+        help="resolve and log the schedule without running any cell",
     )
     return argument_parser.parse_args(command_line_argument_values)
 
@@ -394,102 +655,16 @@ def configure_measurement_cell_logging():
     )
 
 
-def run_measurement_cell(command_line_arguments):
-    """Resolve, record and run one cell. Returns the process exit status."""
-    measurement_cell_directory = os.path.join(
-        os.path.abspath(command_line_arguments.output_dir),
-        build_measurement_cell_directory_name(
-            command_line_arguments.mode,
-            command_line_arguments.fps,
-            command_line_arguments.stage,
-            command_line_arguments.gc,
-            command_line_arguments.repetition_index,
-        ),
-    )
-    os.makedirs(measurement_cell_directory, exist_ok=True)
-
-    garbage_collection_recorder = GarbageCollectionPauseAttributionRecorder()
-    garbage_collection_configuration = (
-        garbage_collection_recorder.apply_garbage_collection_mode(
-            command_line_arguments.gc
-        )
-    )
-
-    measurement_stage_callback = build_measurement_stage_callback_for_stage_name(
-        command_line_arguments.stage,
-        command_line_arguments.frame_width,
-        command_line_arguments.frame_height,
-    )
-    stage_callback_cost_summary = measure_stage_callback_cost_on_this_machine(
-        measurement_stage_callback,
-        command_line_arguments.frame_width,
-        command_line_arguments.frame_height,
-    )
-    MEASUREMENT_CELL_LOGGER.info(
-        "stage %s measured cost p50=%.3fms p99=%.3fms max=%.3fms",
-        command_line_arguments.stage,
-        stage_callback_cost_summary["p50_nanoseconds"] / 1e6,
-        stage_callback_cost_summary["p99_nanoseconds"] / 1e6,
-        stage_callback_cost_summary["max_nanoseconds"] / 1e6,
-    )
-
-    measurement_cell_specification = build_measurement_cell_specification(
-        command_line_arguments,
-        garbage_collection_configuration,
-        stage_callback_cost_summary,
-        measurement_cell_directory,
-    )
-    measurement_cell_specification_path = os.path.join(
-        measurement_cell_directory, MEASUREMENT_CELL_SPECIFICATION_FILE_NAME
-    )
-    with open(
-        measurement_cell_specification_path, "w", encoding="utf-8"
-    ) as specification_file:
-        json.dump(measurement_cell_specification, specification_file, indent=2)
-        specification_file.write("\n")
-    MEASUREMENT_CELL_LOGGER.info(
-        "wrote cell spec %s", measurement_cell_specification_path
-    )
-
-    if command_line_arguments.skip_harness_invocation:
-        return 0
-    if not command_line_arguments.harness_binary:
-        MEASUREMENT_CELL_LOGGER.error(
-            "no harness binary; pass --harness-binary or set $%s",
-            HARNESS_BINARY_ENVIRONMENT_VARIABLE,
-        )
-        return 2
-
-    garbage_collection_recorder.install_collection_phase_callback()
+def main():
+    """Entry point: exit status is the first failing cell's, or 0."""
+    configure_measurement_cell_logging()
+    command_line_arguments = parse_measurement_cell_command_line_arguments()
     try:
-        harness_exit_status = invoke_rust_measurement_harness_for_measurement_cell(
-            command_line_arguments.harness_binary,
-            measurement_cell_directory,
-            measurement_cell_specification_path,
-        )
-    finally:
-        garbage_collection_recorder.uninstall_collection_phase_callback()
-        written_record_count = (
-            garbage_collection_recorder.export_collection_records_as_jsonl(
-                os.path.join(
-                    measurement_cell_directory,
-                    RUNNER_INTERPRETER_GARBAGE_COLLECTION_RECORD_FILE_NAME,
-                )
-            )
-        )
-        MEASUREMENT_CELL_LOGGER.info(
-            "recorded %d gc phase events in the runner interpreter", written_record_count
-        )
-
-    if harness_exit_status != 0:
-        MEASUREMENT_CELL_LOGGER.error(
-            "harness exited %d for cell %s",
-            harness_exit_status,
-            measurement_cell_directory,
-        )
-    return harness_exit_status
+        return run_interleaved_measurement_schedule(command_line_arguments)
+    except (SubprocessArmIsTierBAndNotImplementedError, ValueError) as refusal:
+        MEASUREMENT_CELL_LOGGER.error("%s", refusal)
+        return 2
 
 
 if __name__ == "__main__":
-    configure_measurement_cell_logging()
-    sys.exit(run_measurement_cell(parse_measurement_cell_command_line_arguments()))
+    sys.exit(main())

--- a/spikes/streamlib-pyembed-spike/python/spike_stage_callbacks.py
+++ b/spikes/streamlib-pyembed-spike/python/spike_stage_callbacks.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""The per-frame stage callbacks the embedded interpreter invokes.
+
+Kept out of runner.py deliberately: the Rust harness imports this module from
+inside the embedded interpreter, and runner.py owns an argparse CLI and a
+__main__ block that must not execute on import.
+
+Every callback mutates its argument in place. The array aliases a Rust-owned
+buffer for the duration of the call only, so rebinding the name discards the
+work silently and retaining the array past the call is a use-after-free the Rust
+side detects and reports but cannot prevent.
+"""
+
+import numpy
+
+FRAME_CHANNEL_COUNT = 4
+
+# A gain-and-bias pass, chosen to land in the protocol's 2-5ms band for
+# 1920x1080x4 uint8 while staying a plausible real effect rather than a
+# synthetic spin. Integer ops on an int16 intermediate avoid float conversion
+# cost dominating the measurement.
+REALISTIC_STAGE_GAIN_NUMERATOR = 5
+REALISTIC_STAGE_GAIN_DENOMINATOR = 4
+REALISTIC_STAGE_BRIGHTNESS_BIAS = 8
+
+# Scratch buffers are allocated once per frame shape and reused. A per-frame
+# 16 MB int16 temporary would turn this cell into an allocator benchmark: the
+# in-process arm shares the engine's allocator and the subprocess arm does not,
+# so the churn would land unevenly on the two arms' tails and confound exactly
+# the comparison being made.
+_intermediate_pixel_scratch_by_frame_shape = {}
+
+
+def passthrough_stage(frame_pixel_array):
+    """The zero-work stage: its whole cost is GIL acquisition plus building the
+    numpy view over the Rust buffer."""
+    return None
+
+
+def realistic_stage(frame_pixel_array):
+    """The ~2-5ms numpy stage, operating in place on the aliased Rust buffer."""
+    frame_pixel_view = _reshape_frame_pixel_array_without_copying(frame_pixel_array)
+    intermediate_pixel_scratch = _intermediate_pixel_scratch_for_shape(
+        frame_pixel_view.shape
+    )
+    numpy.copyto(intermediate_pixel_scratch, frame_pixel_view, casting="unsafe")
+    numpy.multiply(
+        intermediate_pixel_scratch,
+        REALISTIC_STAGE_GAIN_NUMERATOR,
+        out=intermediate_pixel_scratch,
+    )
+    numpy.floor_divide(
+        intermediate_pixel_scratch,
+        REALISTIC_STAGE_GAIN_DENOMINATOR,
+        out=intermediate_pixel_scratch,
+    )
+    numpy.add(
+        intermediate_pixel_scratch,
+        REALISTIC_STAGE_BRIGHTNESS_BIAS,
+        out=intermediate_pixel_scratch,
+    )
+    numpy.clip(intermediate_pixel_scratch, 0, 255, out=intermediate_pixel_scratch)
+    numpy.copyto(frame_pixel_view, intermediate_pixel_scratch, casting="unsafe")
+    return None
+
+
+def build_measurement_stage_callback_for_stage_name(stage_name):
+    """Resolve a `--stage` value to the callable the harness invokes per frame."""
+    if stage_name == "passthrough":
+        return passthrough_stage
+    if stage_name == "realistic":
+        return realistic_stage
+    raise ValueError(
+        f"unsupported stage name {stage_name!r}; expected 'passthrough' or 'realistic'"
+    )
+
+
+def _intermediate_pixel_scratch_for_shape(frame_shape):
+    scratch = _intermediate_pixel_scratch_by_frame_shape.get(frame_shape)
+    if scratch is None:
+        scratch = numpy.empty(frame_shape, dtype=numpy.int16)
+        _intermediate_pixel_scratch_by_frame_shape[frame_shape] = scratch
+    return scratch
+
+
+def _reshape_frame_pixel_array_without_copying(frame_pixel_array):
+    if frame_pixel_array.ndim == 3:
+        return frame_pixel_array
+    if frame_pixel_array.size % FRAME_CHANNEL_COUNT != 0:
+        raise ValueError(
+            f"frame carries {frame_pixel_array.size} elements, "
+            f"not a multiple of {FRAME_CHANNEL_COUNT} channels"
+        )
+    # numpy.reshape falls back to a copy when the source is not C-contiguous,
+    # and a copy would send every pixel write to a temporary the Rust side never
+    # reads. Refuse rather than silently produce a no-op stage.
+    if not frame_pixel_array.flags.c_contiguous:
+        raise ValueError(
+            "frame buffer is not C-contiguous; reshaping it would copy and the "
+            "stage would no longer write through to the Rust buffer"
+        )
+    return frame_pixel_array.reshape(
+        (1, frame_pixel_array.size // FRAME_CHANNEL_COUNT, FRAME_CHANNEL_COUNT)
+    )

--- a/spikes/streamlib-pyembed-spike/python/test_spike_harness_contract.py
+++ b/spikes/streamlib-pyembed-spike/python/test_spike_harness_contract.py
@@ -1,0 +1,331 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Contract tests for the Python side of the spike.
+
+The load-bearing one is `the_command_line_runner_py_builds_is_accepted_by_the_harness`:
+runner.py and `src/bin/tier_a_harness.rs` are written independently and nothing
+else proves their argv agree. Runnable with
+`python3 -m unittest discover -s python`; no pytest dependency."""
+
+import gc
+import os
+import subprocess
+import tempfile
+import time
+import unittest
+
+import numpy
+
+import runner
+import spike_stage_callbacks
+from gc_collection_attribution import GarbageCollectionPauseAttributionRecorder
+
+SPIKE_CRATE_DIRECTORY = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_HARNESS_BINARY_PATH = os.path.join(
+    SPIKE_CRATE_DIRECTORY, "target", "release", "tier_a_harness"
+)
+
+# Long enough for the source to emit past the exploratory warmup exclusion, short
+# enough that the suite stays a smoke test.
+CONTRACT_CELL_DURATION_SECONDS = "3"
+# The contract under test is argv acceptance, not throughput, so the smallest
+# geometry that still exercises the whole graph is the right one.
+CONTRACT_FRAME_WIDTH_PIXELS = "320"
+CONTRACT_FRAME_HEIGHT_PIXELS = "240"
+
+HARNESS_PROCESS_TIMEOUT_SECONDS = 180
+
+
+def locate_built_harness_binary_path():
+    """The release binary, or None when the checkout has not been built."""
+    harness_binary_path = os.environ.get(
+        runner.HARNESS_BINARY_ENVIRONMENT_VARIABLE, DEFAULT_HARNESS_BINARY_PATH
+    )
+    return harness_binary_path if os.path.isfile(harness_binary_path) else None
+
+
+def require_built_harness_binary_path():
+    """Skip rather than fail on a clean checkout: an unbuilt binary is a missing
+    prerequisite, not a broken contract."""
+    harness_binary_path = locate_built_harness_binary_path()
+    if harness_binary_path is None:
+        raise unittest.SkipTest(
+            f"no harness binary at {DEFAULT_HARNESS_BINARY_PATH}; run "
+            "`cargo build --release` in spikes/streamlib-pyembed-spike"
+        )
+    return harness_binary_path
+
+
+class TierAHarnessCommandLineContractTest(unittest.TestCase):
+    """runner.py's argv against the harness that has to accept it."""
+
+    def build_contract_command_line_arguments(self, harness_binary_path, output_directory):
+        return runner.parse_measurement_cell_command_line_arguments(
+            [
+                "--fps",
+                "30",
+                "--stage",
+                "passthrough",
+                "--mode",
+                runner.RUNNER_MODE_IN_PROCESS_PYTHON,
+                "--duration",
+                CONTRACT_CELL_DURATION_SECONDS,
+                "--frame-width",
+                CONTRACT_FRAME_WIDTH_PIXELS,
+                "--frame-height",
+                CONTRACT_FRAME_HEIGHT_PIXELS,
+                "--output-dir",
+                output_directory,
+                "--harness-binary",
+                harness_binary_path,
+            ]
+        )
+
+    def test_every_flag_runner_py_emits_is_declared_by_the_harness(self):
+        """Fails fast and names the offending flag; the full run below is the
+        stronger but slower form of the same assertion."""
+        harness_binary_path = require_built_harness_binary_path()
+        harness_help_text = subprocess.run(
+            [harness_binary_path, "--help"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=HARNESS_PROCESS_TIMEOUT_SECONDS,
+        ).stdout
+
+        with tempfile.TemporaryDirectory() as output_directory:
+            harness_command_line = runner.build_tier_a_harness_command_line(
+                self.build_contract_command_line_arguments(
+                    harness_binary_path, output_directory
+                ),
+                runner.HARNESS_ARM_BY_RUNNER_MODE[runner.RUNNER_MODE_IN_PROCESS_PYTHON],
+                0,
+                3,
+                1,
+                runner.GARBAGE_COLLECTION_MODE_DEFAULT,
+            )
+        emitted_flags = [
+            argument for argument in harness_command_line if argument.startswith("--")
+        ]
+        self.assertTrue(emitted_flags)
+        for emitted_flag in emitted_flags:
+            self.assertIn(
+                emitted_flag,
+                harness_help_text,
+                f"runner.py emits {emitted_flag}, which the harness does not declare",
+            )
+
+    def test_the_command_line_runner_py_builds_is_accepted_by_the_harness(self):
+        harness_binary_path = require_built_harness_binary_path()
+        with tempfile.TemporaryDirectory() as output_directory:
+            command_line_arguments = self.build_contract_command_line_arguments(
+                harness_binary_path, output_directory
+            )
+            harness_command_line = runner.build_tier_a_harness_command_line(
+                command_line_arguments,
+                runner.HARNESS_ARM_BY_RUNNER_MODE[runner.RUNNER_MODE_IN_PROCESS_PYTHON],
+                0,
+                int(CONTRACT_CELL_DURATION_SECONDS),
+                1,
+                runner.GARBAGE_COLLECTION_MODE_DEFAULT,
+            )
+
+            harness_started_at_epoch_seconds = time.time()
+            completed_harness_process = subprocess.run(
+                harness_command_line,
+                env=runner.build_tier_a_harness_process_environment(),
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=HARNESS_PROCESS_TIMEOUT_SECONDS,
+            )
+            self.assertEqual(
+                completed_harness_process.returncode,
+                0,
+                "the harness rejected runner.py's command line:\n"
+                f"{' '.join(harness_command_line)}\n"
+                f"{completed_harness_process.stderr}",
+            )
+
+            measurement_cell_directory = (
+                runner.locate_measurement_cell_directory_created_by_harness(
+                    output_directory, harness_started_at_epoch_seconds
+                )
+            )
+            self.assertIsNotNone(
+                measurement_cell_directory,
+                f"the harness left no cell directory under {output_directory}: "
+                f"{os.listdir(output_directory)}",
+            )
+            self.assertTrue(
+                os.path.isfile(
+                    os.path.join(
+                        measurement_cell_directory, runner.HARNESS_CELL_SUMMARY_FILE_NAME
+                    )
+                )
+            )
+
+    def test_subprocess_mode_is_refused_as_tier_b(self):
+        with self.assertRaises(runner.SubprocessArmIsTierBAndNotImplementedError) as refusal:
+            runner.resolve_harness_arm_for_runner_mode(
+                runner.RUNNER_MODE_SUBPROCESS_PYTHON
+            )
+        self.assertIn("not in this PR", str(refusal.exception))
+
+    def test_a_fractional_duration_is_refused_rather_than_rounded(self):
+        with self.assertRaises(ValueError):
+            runner.resolve_cell_duration_seconds(2.5)
+
+    def test_a_warmup_exclusion_covering_the_whole_cell_is_refused(self):
+        """Such a cell exits 0 with all-zero percentiles, which reads like a very
+        fast cell rather than an empty one."""
+        with self.assertRaises(ValueError):
+            runner.resolve_warmup_exclusion_seconds(5, 5)
+
+    def test_a_short_cell_falls_back_to_the_exploratory_warmup_exclusion(self):
+        self.assertEqual(
+            runner.resolve_warmup_exclusion_seconds(None, 10),
+            runner.EXPLORATORY_CELL_WARMUP_EXCLUSION_SECONDS,
+        )
+        self.assertEqual(
+            runner.resolve_warmup_exclusion_seconds(
+                None, runner.PROTOCOL_WARMUP_EXCLUSION_SECONDS * 10
+            ),
+            runner.PROTOCOL_WARMUP_EXCLUSION_SECONDS,
+        )
+
+
+class InterleavedMeasurementScheduleTest(unittest.TestCase):
+    """The A/B/A ordering and the per-cell repetition indices it depends on."""
+
+    def test_the_schedule_places_a_floor_cell_on_either_side_of_the_arm_under_test(self):
+        self.assertEqual(
+            runner.build_interleaved_measurement_schedule_for_runner_mode(
+                runner.RUNNER_MODE_IN_PROCESS_PYTHON
+            ),
+            (
+                runner.RUNNER_MODE_RUST_PASSTHROUGH_FLOOR,
+                runner.RUNNER_MODE_IN_PROCESS_PYTHON,
+                runner.RUNNER_MODE_RUST_PASSTHROUGH_FLOOR,
+            ),
+        )
+
+    def test_the_floor_mode_runs_a_single_cell_per_repetition(self):
+        self.assertEqual(
+            runner.build_interleaved_measurement_schedule_for_runner_mode(
+                runner.RUNNER_MODE_RUST_PASSTHROUGH_FLOOR
+            ),
+            (runner.RUNNER_MODE_RUST_PASSTHROUGH_FLOOR,),
+        )
+
+    def test_every_cell_of_every_repetition_gets_its_own_harness_repetition_index(self):
+        """The harness names its cell directory from arm, rate, GIL anchor and
+        repetition index — the two floor cells of one repetition agree on all but
+        the last, so a shared index would overwrite a cell's raw data."""
+        schedule = runner.build_interleaved_measurement_schedule_for_runner_mode(
+            runner.RUNNER_MODE_IN_PROCESS_PYTHON
+        )
+        assigned_indices_by_arm = {}
+        for runner_repetition_index in range(3):
+            for schedule_position_index, cell_runner_mode in enumerate(schedule):
+                harness_repetition_index = runner.build_harness_repetition_index(
+                    runner_repetition_index, schedule_position_index, len(schedule)
+                )
+                assigned_indices_by_arm.setdefault(cell_runner_mode, []).append(
+                    harness_repetition_index
+                )
+        for cell_runner_mode, assigned_indices in assigned_indices_by_arm.items():
+            self.assertEqual(
+                len(assigned_indices),
+                len(set(assigned_indices)),
+                f"{cell_runner_mode} cells collide on harness repetition indices "
+                f"{assigned_indices}",
+            )
+
+
+class RealisticStageCallbackTest(unittest.TestCase):
+    """The stage callback the harness calls per frame, against the aliasing rules
+    the Rust side cannot enforce."""
+
+    def test_realistic_stage_writes_through_a_view_into_the_original_buffer(self):
+        """A rebind instead of an in-place write would leave the Rust-owned
+        buffer untouched and turn the stage into a silent no-op."""
+        original_frame_pixel_buffer = numpy.full((2, 3, 4), 100, dtype=numpy.uint8)
+        frame_pixel_view = original_frame_pixel_buffer.view()
+        self.assertTrue(frame_pixel_view.base is original_frame_pixel_buffer)
+
+        spike_stage_callbacks.realistic_stage(frame_pixel_view)
+
+        expected_pixel_value = (
+            100
+            * spike_stage_callbacks.REALISTIC_STAGE_GAIN_NUMERATOR
+            // spike_stage_callbacks.REALISTIC_STAGE_GAIN_DENOMINATOR
+            + spike_stage_callbacks.REALISTIC_STAGE_BRIGHTNESS_BIAS
+        )
+        self.assertTrue(
+            numpy.array_equal(
+                original_frame_pixel_buffer,
+                numpy.full((2, 3, 4), expected_pixel_value, dtype=numpy.uint8),
+            ),
+            f"the original buffer still reads {original_frame_pixel_buffer.ravel()[:8]}",
+        )
+
+    def test_realistic_stage_refuses_a_non_c_contiguous_frame(self):
+        """Reshaping a strided array copies, and every pixel write would land in
+        the copy the Rust side never reads."""
+        contiguous_pixel_buffer = numpy.zeros(64, dtype=numpy.uint8)
+        strided_frame_pixel_view = contiguous_pixel_buffer[::2]
+        self.assertFalse(strided_frame_pixel_view.flags.c_contiguous)
+
+        with self.assertRaises(ValueError) as refusal:
+            spike_stage_callbacks.realistic_stage(strided_frame_pixel_view)
+        self.assertIn("C-contiguous", str(refusal.exception))
+
+    def test_the_stage_name_the_runner_emits_resolves_to_a_real_callable(self):
+        for stage_name in runner.SUPPORTED_STAGE_NAMES:
+            callback_attribute_name = (
+                runner.resolve_harness_stage_callback_attribute_for_stage_name(stage_name)
+            )
+            self.assertTrue(
+                callable(getattr(spike_stage_callbacks, callback_attribute_name)),
+                f"{runner.HARNESS_STAGE_CALLBACK_MODULE_NAME} exposes no callable "
+                f"{callback_attribute_name}",
+            )
+
+
+class GarbageCollectionPauseAttributionRecorderTest(unittest.TestCase):
+    """The recorder that makes a latency tail spike attributable to a GC pause."""
+
+    def test_a_forced_collection_is_recorded_and_exported(self):
+        recorder = GarbageCollectionPauseAttributionRecorder()
+        with recorder:
+            gc.collect()
+        recorded_event_count = recorder.recorded_collection_phase_event_count()
+        self.assertGreater(recorded_event_count, 0)
+
+        with tempfile.TemporaryDirectory() as export_directory:
+            export_path = os.path.join(export_directory, "gc-collections.jsonl")
+            written_line_count = recorder.export_collection_records_as_jsonl(export_path)
+            self.assertEqual(written_line_count, recorded_event_count)
+            with open(export_path, encoding="utf-8") as exported_records_file:
+                self.assertEqual(
+                    len(exported_records_file.read().splitlines()), written_line_count
+                )
+
+    def test_no_events_are_recorded_after_the_callback_is_uninstalled(self):
+        recorder = GarbageCollectionPauseAttributionRecorder()
+        with recorder:
+            gc.collect()
+        recorded_event_count_at_uninstall = (
+            recorder.recorded_collection_phase_event_count()
+        )
+        gc.collect()
+        self.assertEqual(
+            recorder.recorded_collection_phase_event_count(),
+            recorded_event_count_at_uninstall,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spikes/streamlib-pyembed-spike/src/bin/tier_a_harness.rs
+++ b/spikes/streamlib-pyembed-spike/src/bin/tier_a_harness.rs
@@ -1,0 +1,189 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Runs one Tier A measurement cell and writes its artifact directory.
+//!
+//! Invoked per cell by `python/runner.py`, which owns A/B/A interleaving across
+//! cells. One cell per process is deliberate: it keeps interpreter state, GC
+//! history, and allocator state from leaking between cells, and it makes the
+//! warm-restart battery measure the same startup path a user would hit.
+
+// Same rationale as the library root: the engine's `Error` is 168 bytes, and
+// boxing it would diverge these signatures from the API being measured.
+#![allow(clippy::result_large_err)]
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use pyo3::prelude::*;
+use streamlib::sdk::error::{Error, Result};
+use streamlib_pyembed_spike::machine_specification_probe::{
+    machine_is_in_locked_measurement_state, probe_machine_specification,
+};
+use streamlib_pyembed_spike::python_processor_callback_registry::register_python_callback_under_token;
+use streamlib_pyembed_spike::tier_a_measurement_cell::{
+    MeasurementArm, TierAMeasurementCellSpecification, run_tier_a_measurement_cell,
+};
+
+#[derive(Parser, Debug)]
+#[command(about = "Run one Tier A measurement cell for the #1702 PyO3 spike")]
+struct TierAHarnessArguments {
+    /// Which comparison arm to run.
+    #[arg(long, value_parser = parse_measurement_arm)]
+    arm: MeasurementArm,
+
+    #[arg(long, default_value_t = 30)]
+    fps: u32,
+
+    #[arg(long, default_value_t = 1920)]
+    frame_width: u32,
+
+    #[arg(long, default_value_t = 1080)]
+    frame_height: u32,
+
+    #[arg(long, default_value_t = 4)]
+    channels: u32,
+
+    #[arg(long, default_value_t = 600)]
+    duration_seconds: u64,
+
+    #[arg(long, default_value_t = 60)]
+    warmup_exclusion_seconds: u64,
+
+    #[arg(long, default_value_t = 0)]
+    repetition_index: u32,
+
+    /// Python module exposing the stage callback, importable from PYTHONPATH.
+    #[arg(long, default_value = "spike_stage_callbacks")]
+    stage_callback_module: String,
+
+    /// Callable within `--stage-callback-module` to invoke per frame.
+    #[arg(long, default_value = "passthrough_stage")]
+    stage_callback_attribute: String,
+
+    /// Control condition for what the GIL attachment anchor is worth.
+    #[arg(long)]
+    disable_gil_anchor: bool,
+
+    /// Refuse to run unless every latency-relevant knob is locked. Off by
+    /// default so exploratory runs work; the protocol's gated cells set it.
+    #[arg(long)]
+    require_locked_measurement_state: bool,
+
+    #[arg(long)]
+    output_directory: PathBuf,
+}
+
+fn parse_measurement_arm(value: &str) -> std::result::Result<MeasurementArm, String> {
+    match value {
+        "in-process-python" => Ok(MeasurementArm::InProcessPython),
+        "rust-passthrough-floor" => Ok(MeasurementArm::RustPassthroughFloor),
+        other => Err(format!(
+            "unknown arm `{other}` — expected `in-process-python` or `rust-passthrough-floor`"
+        )),
+    }
+}
+
+fn main() -> Result<()> {
+    // No subscriber is installed here on purpose: `Runner::new()` installs the
+    // engine's global tracing dispatcher, and a second `set_global_default`
+    // aborts the run before a single frame is measured.
+    let arguments = TierAHarnessArguments::parse();
+
+    let machine_specification = probe_machine_specification();
+    if arguments.require_locked_measurement_state
+        && !machine_is_in_locked_measurement_state(&machine_specification)
+    {
+        return Err(Error::Configuration(
+            "machine is not in a locked measurement state and \
+             --require-locked-measurement-state was set; see machine-spec.json for which knob \
+             is unlocked and the owner checklist for the commands that lock it"
+                .to_string(),
+        ));
+    }
+
+    // CPython comes up before `App::new` so interpreter initialization is
+    // ordered ahead of GpuContext init and iceoryx2 node creation rather than
+    // racing them from a processor thread.
+    Python::initialize();
+
+    let python_callback_registration_token = format!(
+        "{}::{}::rep-{}",
+        arguments.stage_callback_module, arguments.stage_callback_attribute, arguments.repetition_index
+    );
+
+    if arguments.arm == MeasurementArm::InProcessPython {
+        Python::attach(|python| -> Result<()> {
+            let module = python
+                .import(arguments.stage_callback_module.as_str())
+                .map_err(|error| {
+                    Error::Configuration(format!(
+                        "cannot import stage callback module `{}` — is PYTHONPATH set to the \
+                         spike's python/ directory? {error}",
+                        arguments.stage_callback_module
+                    ))
+                })?;
+            let callable = module
+                .getattr(arguments.stage_callback_attribute.as_str())
+                .map_err(|error| {
+                    Error::Configuration(format!(
+                        "module `{}` exposes no `{}`: {error}",
+                        arguments.stage_callback_module, arguments.stage_callback_attribute
+                    ))
+                })?;
+            register_python_callback_under_token(
+                python_callback_registration_token.clone(),
+                callable.unbind(),
+            );
+            Ok(())
+        })?;
+    }
+
+    let specification = TierAMeasurementCellSpecification {
+        arm: arguments.arm,
+        frame_width_pixels: arguments.frame_width,
+        frame_height_pixels: arguments.frame_height,
+        channel_count: arguments.channels,
+        target_frames_per_second: arguments.fps,
+        cell_duration_seconds: arguments.duration_seconds,
+        warmup_exclusion_seconds: arguments.warmup_exclusion_seconds,
+        python_callback_registration_token,
+        anchor_processor_thread_gil: !arguments.disable_gil_anchor,
+        resolved_delivery_profile: "every_sample".to_string(),
+        measured_metric_name: "source_emit_to_sink_receive".to_string(),
+        repetition_index: arguments.repetition_index,
+    };
+
+    let cell_directory = arguments
+        .output_directory
+        .join(specification.artifact_directory_name());
+    let outcome = run_tier_a_measurement_cell(&specification, &cell_directory)?;
+
+    tracing::info!(
+        cell = %specification.artifact_directory_name(),
+        received_frames = outcome.received_frame_count,
+        measured_frames = outcome.measured_frame_count,
+        dropped_frames = outcome.dropped_frame_count,
+        p50_ns = outcome.source_emit_to_sink_receive.p50_nanoseconds,
+        p99_ns = outcome.source_emit_to_sink_receive.p99_nanoseconds,
+        p99_9_ns = outcome.source_emit_to_sink_receive.p99_9_nanoseconds,
+        max_ns = outcome.source_emit_to_sink_receive.max_nanoseconds,
+        "cell complete"
+    );
+
+    if outcome.negative_latency_anomaly_count > 0 {
+        tracing::error!(
+            count = outcome.negative_latency_anomaly_count,
+            "cell recorded sink stamps earlier than their emit stamps — the clocks disagree \
+             and this cell's percentiles must not be used"
+        );
+    }
+    if outcome.histogram_range_saturation_count > 0 {
+        tracing::error!(
+            count = outcome.histogram_range_saturation_count,
+            "samples exceeded the histogram range — reported percentiles are clipped"
+        );
+    }
+
+    Ok(())
+}

--- a/spikes/streamlib-pyembed-spike/src/bin/tier_a_harness.rs
+++ b/spikes/streamlib-pyembed-spike/src/bin/tier_a_harness.rs
@@ -17,6 +17,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use pyo3::prelude::*;
 use streamlib::sdk::error::{Error, Result};
+use streamlib_pyembed_spike::monotonic_clock::MEASUREMENT_STAMPING_IS_COMPILED_IN;
 use streamlib_pyembed_spike::machine_specification_probe::{
     machine_is_in_locked_measurement_state, probe_machine_specification,
 };
@@ -64,6 +65,11 @@ struct TierAHarnessArguments {
     /// Control condition for what the GIL attachment anchor is worth.
     #[arg(long)]
     disable_gil_anchor: bool,
+
+    /// `default` leaves CPython's collector alone; `tuned` applies
+    /// `gc.freeze()` plus raised thresholds inside the embedded interpreter.
+    #[arg(long, default_value = "default")]
+    garbage_collection_mode: String,
 
     /// Refuse to run unless every latency-relevant knob is locked. Off by
     /// default so exploratory runs work; the protocol's gated cells set it.
@@ -149,16 +155,45 @@ fn main() -> Result<()> {
         warmup_exclusion_seconds: arguments.warmup_exclusion_seconds,
         python_callback_registration_token,
         anchor_processor_thread_gil: !arguments.disable_gil_anchor,
+        stage_callback_attribute: arguments.stage_callback_attribute.clone(),
         resolved_delivery_profile: "every_sample".to_string(),
         measured_metric_name: "source_emit_to_sink_receive".to_string(),
         repetition_index: arguments.repetition_index,
+        measurement_stamping_is_compiled_in: MEASUREMENT_STAMPING_IS_COMPILED_IN,
     };
 
     let cell_directory = arguments
         .output_directory
         .join(specification.artifact_directory_name());
+
+    // The recorder has to live in the interpreter that runs the callback. In the
+    // runner's interpreter it would time collections that cannot have caused any
+    // frame's latency — which is what it did before, reporting 0 events.
+    let garbage_collection_recorder = if arguments.arm == MeasurementArm::InProcessPython {
+        Some(install_embedded_interpreter_garbage_collection_recorder(
+            &arguments.garbage_collection_mode,
+        )?)
+    } else {
+        None
+    };
+
     let outcome = run_tier_a_measurement_cell(&specification, &cell_directory)?;
 
+    if let Some(recorder) = garbage_collection_recorder {
+        export_embedded_interpreter_garbage_collection_records(&recorder, &cell_directory)?;
+    }
+
+    // `Runner::stop()` has torn the engine's global dispatcher down by now, so
+    // every record below would be dropped on the floor without a subscriber of
+    // our own. An unattended matrix run would then show no sign that a cell was
+    // invalid — the counters would reach summary.json and nothing else.
+    let post_stop_subscriber = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .finish();
+    tracing::subscriber::with_default(post_stop_subscriber, || {
     tracing::info!(
         cell = %specification.artifact_directory_name(),
         received_frames = outcome.received_frame_count,
@@ -184,6 +219,79 @@ fn main() -> Result<()> {
             "samples exceeded the histogram range — reported percentiles are clipped"
         );
     }
+    });
 
     Ok(())
+}
+
+/// Install the GC phase recorder inside the embedded interpreter and apply the
+/// requested collector mode, returning the recorder object.
+fn install_embedded_interpreter_garbage_collection_recorder(
+    garbage_collection_mode: &str,
+) -> Result<Py<PyAny>> {
+    Python::attach(|python| {
+        let module = python
+            .import("gc_collection_attribution")
+            .map_err(|error| {
+                Error::Configuration(format!(
+                    "cannot import gc_collection_attribution — is PYTHONPATH set to the spike's \
+                     python/ directory? {error}"
+                ))
+            })?;
+        let recorder = module
+            .getattr("GarbageCollectionPauseAttributionRecorder")
+            .and_then(|class| class.call0())
+            .map_err(|error| {
+                Error::Runtime(format!("constructing the GC recorder failed: {error}"))
+            })?;
+        recorder
+            .call_method1("apply_garbage_collection_mode", (garbage_collection_mode,))
+            .map_err(|error| {
+                Error::Configuration(format!(
+                    "unsupported --garbage-collection-mode `{garbage_collection_mode}`: {error}"
+                ))
+            })?;
+        recorder
+            .call_method0("install_collection_phase_callback")
+            .map_err(|error| {
+                Error::Runtime(format!("installing the GC callback failed: {error}"))
+            })?;
+        Ok(recorder.unbind())
+    })
+}
+
+/// Uninstall the recorder and write its records beside the cell's other artifacts.
+fn export_embedded_interpreter_garbage_collection_records(
+    recorder: &Py<PyAny>,
+    cell_directory: &std::path::Path,
+) -> Result<()> {
+    let record_path = cell_directory.join("gc-collections-embedded-interpreter.jsonl");
+    Python::attach(|python| {
+        let recorder = recorder.bind(python);
+        recorder
+            .call_method0("uninstall_collection_phase_callback")
+            .map_err(|error| {
+                Error::Runtime(format!("uninstalling the GC callback failed: {error}"))
+            })?;
+        let recorded_event_count = recorder
+            .call_method0("recorded_collection_phase_event_count")
+            .and_then(|count| count.extract::<u64>())
+            .map_err(|error| {
+                Error::Runtime(format!("reading the GC event count failed: {error}"))
+            })?;
+        recorder
+            .call_method1(
+                "export_collection_records_as_jsonl",
+                (record_path.to_string_lossy().as_ref(),),
+            )
+            .map_err(|error| {
+                Error::Runtime(format!("exporting the GC records failed: {error}"))
+            })?;
+        tracing::info!(
+            recorded_event_count,
+            path = %record_path.display(),
+            "exported embedded-interpreter GC records"
+        );
+        Ok(())
+    })
 }

--- a/spikes/streamlib-pyembed-spike/src/latency_measurement_recorder.rs
+++ b/spikes/streamlib-pyembed-spike/src/latency_measurement_recorder.rs
@@ -24,10 +24,14 @@ use hdrhistogram::Histogram;
 use hdrhistogram::serialization::V2DeflateSerializer;
 use hdrhistogram::serialization::interval_log::{IntervalLogWriterBuilder, Tag};
 
-/// 100ns is one order below `CLOCK_MONOTONIC`'s reported 1ns resolution and 60s
-/// is two orders above the worst plausible stall, so no real sample lands
+/// 1ns matches `CLOCK_MONOTONIC`'s reported resolution, so nothing the clock can
+/// distinguish is quantized away. A coarser floor silently rounds sub-floor
+/// samples into the first bucket while `max()` still reports the true value,
+/// which publishes a summary where p50 exceeds max — observed with a 100ns floor
+/// against the floor arm's all-zero stage durations (p50 63ns, max 0ns).
+/// 60s is two orders above the worst plausible stall, so no real sample lands
 /// outside the range and every cell can share one bucket layout.
-const HISTOGRAM_LOWEST_DISCERNIBLE_NANOSECONDS: u64 = 100;
+const HISTOGRAM_LOWEST_DISCERNIBLE_NANOSECONDS: u64 = 1;
 const HISTOGRAM_HIGHEST_TRACKABLE_NANOSECONDS: u64 = 60_000_000_000;
 const HISTOGRAM_SIGNIFICANT_FIGURES: u8 = 3;
 
@@ -89,14 +93,21 @@ pub struct LatencyMeasurementRecorder {
 impl LatencyMeasurementRecorder {
     /// `warmup_exclusion_nanoseconds` drops early frames from the percentiles
     /// (the protocol excludes the first 60s of every cell).
-    pub fn new(warmup_exclusion_nanoseconds: i64) -> Self {
+    ///
+    /// `expected_frame_count` preallocates both per-frame vectors. It is a
+    /// measurement requirement, not a micro-optimization: `record_frame_measurement`
+    /// runs on the sink's per-frame path, and a `Vec` doubling there stalls that
+    /// frame's successor by the memcpy, landing self-inflicted spikes in exactly
+    /// the p99.9 tail this artifact publishes. An undersized hint degrades to the
+    /// old behavior rather than failing, so callers should pass slack.
+    pub fn new(warmup_exclusion_nanoseconds: i64, expected_frame_count: usize) -> Self {
         Self {
             warmup_exclusion_nanoseconds,
             first_source_emit_monotonic_nanoseconds: None,
-            every_received_frame_measurement: Vec::new(),
+            every_received_frame_measurement: Vec::with_capacity(expected_frame_count),
             source_emit_to_sink_receive_histogram: new_nanosecond_histogram(),
             stage_callback_histogram: new_nanosecond_histogram(),
-            measured_sink_receive_monotonic_nanoseconds: Vec::new(),
+            measured_sink_receive_monotonic_nanoseconds: Vec::with_capacity(expected_frame_count),
             lowest_measured_frame_sequence_number: None,
             highest_measured_frame_sequence_number: None,
             measured_frame_count: 0,
@@ -106,8 +117,16 @@ impl LatencyMeasurementRecorder {
     }
 
     /// Take one frame's stamps, called once per frame the sink observes.
+    ///
+    /// With `stamping-compiled-out` the stamps are all zero, so only the frame
+    /// count is kept: throughput stays observable, and no histogram or
+    /// percentile work runs. That is the whole point of the control build — any
+    /// throughput delta against a default build is instrument overhead.
     pub fn record_frame_measurement(&mut self, measurement: PerFrameLatencyMeasurement) {
         self.every_received_frame_measurement.push(measurement);
+        if !crate::monotonic_clock::MEASUREMENT_STAMPING_IS_COMPILED_IN {
+            return;
+        }
         let first_source_emit_monotonic_nanoseconds = *self
             .first_source_emit_monotonic_nanoseconds
             .get_or_insert(measurement.source_emit_monotonic_nanoseconds);
@@ -342,7 +361,11 @@ fn summarize_nanosecond_histogram(histogram: &Histogram<u64>) -> LatencyPercenti
     }
 }
 
-#[cfg(test)]
+// These exercise the recording logic that `stamping-compiled-out` removes. In a
+// control build there is nothing left to assert: `record_frame_measurement`
+// keeps only the frame count, which is what makes that build a throughput
+// control rather than a measurement.
+#[cfg(all(test, not(feature = "stamping-compiled-out")))]
 mod tests {
     use super::*;
     use hdrhistogram::serialization::interval_log::LogEntry;
@@ -377,7 +400,7 @@ mod tests {
     /// non-comparable.
     #[test]
     fn frame_exactly_on_the_warmup_deadline_is_measured() {
-        let mut recorder = LatencyMeasurementRecorder::new(WARMUP_EXCLUSION_NANOSECONDS);
+        let mut recorder = LatencyMeasurementRecorder::new(WARMUP_EXCLUSION_NANOSECONDS, 0);
         recorder.record_frame_measurement(build_per_frame_latency_measurement(0, 1_000, 5_000, 0));
         recorder.record_frame_measurement(build_per_frame_latency_measurement(
             1,
@@ -404,7 +427,7 @@ mod tests {
     /// disagree about which frames the cell measured.
     #[test]
     fn warmup_excluded_frames_reach_the_jsonl_but_not_the_histograms() {
-        let mut recorder = LatencyMeasurementRecorder::new(WARMUP_EXCLUSION_NANOSECONDS);
+        let mut recorder = LatencyMeasurementRecorder::new(WARMUP_EXCLUSION_NANOSECONDS, 0);
         for frame_sequence_number in 0..10u64 {
             recorder.record_frame_measurement(build_per_frame_latency_measurement(
                 frame_sequence_number,
@@ -434,7 +457,7 @@ mod tests {
     /// must be counted exactly once.
     #[test]
     fn dropped_frame_count_counts_a_synthetic_sequence_gap() {
-        let mut recorder = LatencyMeasurementRecorder::new(0);
+        let mut recorder = LatencyMeasurementRecorder::new(0, 0);
         for frame_sequence_number in [0u64, 1, 2, 5, 6] {
             recorder.record_frame_measurement(build_per_frame_latency_measurement(
                 frame_sequence_number,
@@ -451,7 +474,7 @@ mod tests {
     /// charged a gap against sequence number 0 or against nothing at all.
     #[test]
     fn first_observed_frame_reports_no_drop() {
-        let mut recorder = LatencyMeasurementRecorder::new(0);
+        let mut recorder = LatencyMeasurementRecorder::new(0, 0);
         recorder.record_frame_measurement(build_per_frame_latency_measurement(7, 1_000, 5_000, 0));
         assert_eq!(recorder.dropped_frame_count(), 0);
         assert_eq!(recorder.received_frame_count(), 1);
@@ -461,7 +484,7 @@ mod tests {
     /// leave a permanent phantom drop in the report.
     #[test]
     fn out_of_order_arrival_reports_no_phantom_drop() {
-        let mut recorder = LatencyMeasurementRecorder::new(0);
+        let mut recorder = LatencyMeasurementRecorder::new(0, 0);
         for frame_sequence_number in [0u64, 2, 1, 3] {
             recorder.record_frame_measurement(build_per_frame_latency_measurement(
                 frame_sequence_number,
@@ -478,7 +501,7 @@ mod tests {
     /// mode of the embedded arm and must be legible as such.
     #[test]
     fn no_frames_received_reports_a_zero_count_summary() {
-        let recorder = LatencyMeasurementRecorder::new(WARMUP_EXCLUSION_NANOSECONDS);
+        let recorder = LatencyMeasurementRecorder::new(WARMUP_EXCLUSION_NANOSECONDS, 0);
         assert_eq!(recorder.received_frame_count(), 0);
         assert_eq!(recorder.dropped_frame_count(), 0);
         assert!(recorder.rolling_one_second_frame_rate_windows().is_empty());
@@ -497,7 +520,7 @@ mod tests {
     /// it must be counted and kept out of the histogram.
     #[test]
     fn negative_latency_increments_the_anomaly_counter_and_skips_the_histogram() {
-        let mut recorder = LatencyMeasurementRecorder::new(0);
+        let mut recorder = LatencyMeasurementRecorder::new(0, 0);
         recorder.record_frame_measurement(build_per_frame_latency_measurement(
             0, 1_000_000, 2_000_000, 0,
         ));
@@ -517,7 +540,7 @@ mod tests {
     /// it means instrumentation is broken; it must surface, not be absorbed.
     #[test]
     fn negative_stage_callback_duration_increments_the_anomaly_counter() {
-        let mut recorder = LatencyMeasurementRecorder::new(0);
+        let mut recorder = LatencyMeasurementRecorder::new(0, 0);
         recorder.record_frame_measurement(build_per_frame_latency_measurement(
             0, 1_000_000, 500_000, -1,
         ));
@@ -537,7 +560,7 @@ mod tests {
     fn percentiles_match_a_hand_computed_distribution() {
         const ONE_MILLISECOND_NANOSECONDS: i64 = 1_000_000;
         const ONE_HUNDRED_MILLISECONDS_NANOSECONDS: i64 = 100_000_000;
-        let mut recorder = LatencyMeasurementRecorder::new(0);
+        let mut recorder = LatencyMeasurementRecorder::new(0, 0);
         for frame_sequence_number in 0..1_000u64 {
             let latency_nanoseconds = if frame_sequence_number < 990 {
                 ONE_MILLISECOND_NANOSECONDS
@@ -589,7 +612,7 @@ mod tests {
     #[test]
     fn rolling_windows_report_the_nominal_rate_of_a_perfectly_paced_stream() {
         const FIFTY_FPS_PERIOD_NANOSECONDS: i64 = ONE_SECOND_NANOSECONDS / 50;
-        let mut recorder = LatencyMeasurementRecorder::new(0);
+        let mut recorder = LatencyMeasurementRecorder::new(0, 0);
         for frame_sequence_number in 0..300u64 {
             recorder.record_frame_measurement(build_per_frame_latency_measurement(
                 frame_sequence_number,
@@ -610,7 +633,7 @@ mod tests {
     /// compact object per line, no wrapping array, every field intact.
     #[test]
     fn jsonl_round_trips_line_by_line_through_serde_json() {
-        let mut recorder = LatencyMeasurementRecorder::new(0);
+        let mut recorder = LatencyMeasurementRecorder::new(0, 0);
         let written_measurements: Vec<PerFrameLatencyMeasurement> = (0..5u64)
             .map(|frame_sequence_number| {
                 build_per_frame_latency_measurement(
@@ -663,8 +686,8 @@ mod tests {
     /// cross-cell percentiles would be uncomputable.
     #[test]
     fn histogram_export_decodes_and_merges_across_cells() {
-        let mut first_cell_recorder = LatencyMeasurementRecorder::new(0);
-        let mut second_cell_recorder = LatencyMeasurementRecorder::new(0);
+        let mut first_cell_recorder = LatencyMeasurementRecorder::new(0, 0);
+        let mut second_cell_recorder = LatencyMeasurementRecorder::new(0, 0);
         for frame_sequence_number in 0..100u64 {
             first_cell_recorder.record_frame_measurement(build_per_frame_latency_measurement(
                 frame_sequence_number,
@@ -752,5 +775,59 @@ mod tests {
             }
         }
         decoded_bytes
+    }
+}
+
+#[cfg(all(test, not(feature = "stamping-compiled-out")))]
+mod histogram_range_tests {
+    use super::*;
+
+    /// A summary must never report p50 above max. With a histogram floor above
+    /// the clock's resolution, sub-floor samples round up into the first bucket
+    /// while `max()` keeps the true value — the floor arm's all-zero stage
+    /// durations produced p50 63ns against max 0ns before the floor was
+    /// lowered to 1ns.
+    #[test]
+    fn an_all_zero_quantity_never_reports_a_percentile_above_its_maximum() {
+        let mut recorder = LatencyMeasurementRecorder::new(0, 8);
+        for frame_sequence_number in 0..300 {
+            recorder.record_frame_measurement(PerFrameLatencyMeasurement {
+                frame_sequence_number,
+                source_emit_monotonic_nanoseconds: 1_000 * frame_sequence_number as i64,
+                sink_receive_monotonic_nanoseconds: 1_000 * frame_sequence_number as i64 + 500,
+                stage_callback_nanoseconds: 0,
+            });
+        }
+        let summary = recorder.stage_callback_summary();
+        assert!(
+            summary.p50_nanoseconds <= summary.max_nanoseconds,
+            "p50 {} exceeds max {}",
+            summary.p50_nanoseconds,
+            summary.max_nanoseconds
+        );
+        assert!(summary.p99_9_nanoseconds <= summary.max_nanoseconds);
+    }
+
+    /// Sub-microsecond stage durations are the anchored PyO3 path's whole
+    /// signal (p50 ~110ns measured); a floor that quantized them would erase
+    /// the difference the spike exists to size.
+    #[test]
+    fn sub_microsecond_durations_are_not_quantized_into_one_bucket() {
+        let mut recorder = LatencyMeasurementRecorder::new(0, 8);
+        for (index, stage_callback_nanoseconds) in [100_i64, 200, 400, 800].into_iter().enumerate() {
+            recorder.record_frame_measurement(PerFrameLatencyMeasurement {
+                frame_sequence_number: index as u64,
+                source_emit_monotonic_nanoseconds: 1_000 * index as i64,
+                sink_receive_monotonic_nanoseconds: 1_000 * index as i64 + 500,
+                stage_callback_nanoseconds,
+            });
+        }
+        let summary = recorder.stage_callback_summary();
+        assert_eq!(summary.max_nanoseconds, 800);
+        assert!(
+            summary.p50_nanoseconds >= 200 && summary.p50_nanoseconds <= 400,
+            "p50 {} collapsed the 100..800ns spread",
+            summary.p50_nanoseconds
+        );
     }
 }

--- a/spikes/streamlib-pyembed-spike/src/latency_measurement_recorder.rs
+++ b/spikes/streamlib-pyembed-spike/src/latency_measurement_recorder.rs
@@ -1,0 +1,756 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Per-frame accumulation and artifact emission for one measurement cell.
+//!
+//! Two accounting rules are easy to get wrong and are load-bearing for the
+//! comparison:
+//!
+//! - The JSONL is raw. Every frame handed to the recorder appears in it,
+//!   including the warmup-excluded ones and the clock-anomaly ones. The
+//!   histograms, the drop count and the frame-rate windows see only the
+//!   post-warmup frames. Re-deriving percentiles from the JSONL therefore
+//!   requires re-applying the warmup filter — the two artifacts are not
+//!   expected to agree by row count.
+//! - Drops come from gaps in [`PerFrameLatencyMeasurement::frame_sequence_number`],
+//!   never from timing. A slow frame is a latency outlier, not a drop.
+
+use std::fs::File;
+use std::io::{self, BufWriter, Write};
+use std::path::Path;
+use std::time::Duration;
+
+use hdrhistogram::Histogram;
+use hdrhistogram::serialization::V2DeflateSerializer;
+use hdrhistogram::serialization::interval_log::{IntervalLogWriterBuilder, Tag};
+
+/// 100ns is one order below `CLOCK_MONOTONIC`'s reported 1ns resolution and 60s
+/// is two orders above the worst plausible stall, so no real sample lands
+/// outside the range and every cell can share one bucket layout.
+const HISTOGRAM_LOWEST_DISCERNIBLE_NANOSECONDS: u64 = 100;
+const HISTOGRAM_HIGHEST_TRACKABLE_NANOSECONDS: u64 = 60_000_000_000;
+const HISTOGRAM_SIGNIFICANT_FIGURES: u8 = 3;
+
+const ONE_SECOND_NANOSECONDS: i64 = 1_000_000_000;
+
+/// Interval-log tag for the Tier A headline quantity.
+const SOURCE_EMIT_TO_SINK_RECEIVE_HISTOGRAM_TAG: &str = "source_emit_to_sink_receive";
+/// Interval-log tag for time spent inside the stage callback.
+const STAGE_CALLBACK_HISTOGRAM_TAG: &str = "stage_callback";
+
+/// One frame's journey through the graph. All stamps are raw CLOCK_MONOTONIC nanoseconds.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct PerFrameLatencyMeasurement {
+    pub frame_sequence_number: u64,
+    pub source_emit_monotonic_nanoseconds: i64,
+    pub sink_receive_monotonic_nanoseconds: i64,
+    /// Time inside the stage callback itself (0 for the floor arm's no-op).
+    pub stage_callback_nanoseconds: i64,
+}
+
+/// Percentiles for one measured quantity. Never carries a headline mean.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct LatencyPercentileSummary {
+    pub sample_count: u64,
+    pub p50_nanoseconds: u64,
+    pub p99_nanoseconds: u64,
+    pub p99_9_nanoseconds: u64,
+    pub max_nanoseconds: u64,
+}
+
+impl LatencyPercentileSummary {
+    /// The summary reported when a quantity has no post-warmup samples at all.
+    fn empty() -> Self {
+        Self {
+            sample_count: 0,
+            p50_nanoseconds: 0,
+            p99_nanoseconds: 0,
+            p99_9_nanoseconds: 0,
+            max_nanoseconds: 0,
+        }
+    }
+}
+
+/// Accumulates one measurement cell's frames and writes its artifacts.
+pub struct LatencyMeasurementRecorder {
+    warmup_exclusion_nanoseconds: i64,
+    first_source_emit_monotonic_nanoseconds: Option<i64>,
+    every_received_frame_measurement: Vec<PerFrameLatencyMeasurement>,
+    source_emit_to_sink_receive_histogram: Histogram<u64>,
+    stage_callback_histogram: Histogram<u64>,
+    measured_sink_receive_monotonic_nanoseconds: Vec<i64>,
+    lowest_measured_frame_sequence_number: Option<u64>,
+    highest_measured_frame_sequence_number: Option<u64>,
+    measured_frame_count: u64,
+    negative_latency_anomaly_count: u64,
+    histogram_range_saturation_count: u64,
+}
+
+impl LatencyMeasurementRecorder {
+    /// `warmup_exclusion_nanoseconds` drops early frames from the percentiles
+    /// (the protocol excludes the first 60s of every cell).
+    pub fn new(warmup_exclusion_nanoseconds: i64) -> Self {
+        Self {
+            warmup_exclusion_nanoseconds,
+            first_source_emit_monotonic_nanoseconds: None,
+            every_received_frame_measurement: Vec::new(),
+            source_emit_to_sink_receive_histogram: new_nanosecond_histogram(),
+            stage_callback_histogram: new_nanosecond_histogram(),
+            measured_sink_receive_monotonic_nanoseconds: Vec::new(),
+            lowest_measured_frame_sequence_number: None,
+            highest_measured_frame_sequence_number: None,
+            measured_frame_count: 0,
+            negative_latency_anomaly_count: 0,
+            histogram_range_saturation_count: 0,
+        }
+    }
+
+    /// Take one frame's stamps, called once per frame the sink observes.
+    pub fn record_frame_measurement(&mut self, measurement: PerFrameLatencyMeasurement) {
+        self.every_received_frame_measurement.push(measurement);
+        let first_source_emit_monotonic_nanoseconds = *self
+            .first_source_emit_monotonic_nanoseconds
+            .get_or_insert(measurement.source_emit_monotonic_nanoseconds);
+
+        // Boundary rule: a frame whose emit stamp sits exactly on the warmup
+        // deadline is MEASURED. The exclusion is "the first N nanoseconds", a
+        // half-open interval, so the deadline itself is the first measured instant.
+        let elapsed_since_first_emit_nanoseconds =
+            measurement.source_emit_monotonic_nanoseconds - first_source_emit_monotonic_nanoseconds;
+        if elapsed_since_first_emit_nanoseconds < self.warmup_exclusion_nanoseconds {
+            return;
+        }
+
+        self.measured_frame_count += 1;
+        self.measured_sink_receive_monotonic_nanoseconds
+            .push(measurement.sink_receive_monotonic_nanoseconds);
+        self.lowest_measured_frame_sequence_number = Some(
+            self.lowest_measured_frame_sequence_number
+                .map_or(measurement.frame_sequence_number, |lowest| {
+                    lowest.min(measurement.frame_sequence_number)
+                }),
+        );
+        self.highest_measured_frame_sequence_number = Some(
+            self.highest_measured_frame_sequence_number
+                .map_or(measurement.frame_sequence_number, |highest| {
+                    highest.max(measurement.frame_sequence_number)
+                }),
+        );
+
+        let source_emit_to_sink_receive_nanoseconds = measurement
+            .sink_receive_monotonic_nanoseconds
+            - measurement.source_emit_monotonic_nanoseconds;
+        if source_emit_to_sink_receive_nanoseconds < 0 {
+            // Never clamp to 0: a sink stamp preceding its own emit stamp means
+            // the two arms are not on the same clock, which is the exact failure
+            // the protocol's clock handshake exists to catch. Clamping would
+            // publish it as a suspiciously fast p50.
+            self.negative_latency_anomaly_count += 1;
+        } else {
+            record_nanoseconds_into_histogram(
+                &mut self.source_emit_to_sink_receive_histogram,
+                &mut self.histogram_range_saturation_count,
+                source_emit_to_sink_receive_nanoseconds as u64,
+            );
+        }
+
+        if measurement.stage_callback_nanoseconds < 0 {
+            self.negative_latency_anomaly_count += 1;
+        } else {
+            record_nanoseconds_into_histogram(
+                &mut self.stage_callback_histogram,
+                &mut self.histogram_range_saturation_count,
+                measurement.stage_callback_nanoseconds as u64,
+            );
+        }
+    }
+
+    /// Percentiles of the Tier A headline quantity over the measured frames.
+    pub fn source_emit_to_sink_receive_summary(&self) -> LatencyPercentileSummary {
+        summarize_nanosecond_histogram(&self.source_emit_to_sink_receive_histogram)
+    }
+
+    /// Percentiles of time spent inside the stage callback over the measured frames.
+    pub fn stage_callback_summary(&self) -> LatencyPercentileSummary {
+        summarize_nanosecond_histogram(&self.stage_callback_histogram)
+    }
+
+    /// Frames missing from the sequence — reported, not gated (owner decision).
+    ///
+    /// Computed as the measured sequence span minus the measured arrivals, so a
+    /// frame that arrives out of order closes its own gap when it lands instead
+    /// of being counted as a drop and then double-counted on arrival. Duplicate
+    /// sequence numbers would under-count; an `every_sample` link does not
+    /// produce them.
+    pub fn dropped_frame_count(&self) -> u64 {
+        match (
+            self.lowest_measured_frame_sequence_number,
+            self.highest_measured_frame_sequence_number,
+        ) {
+            (Some(lowest), Some(highest)) => {
+                (highest - lowest + 1).saturating_sub(self.measured_frame_count)
+            }
+            _ => 0,
+        }
+    }
+
+    /// Every frame handed to the recorder, warmup-excluded ones included. Read
+    /// this before any percentile: a summary from an empty histogram is all
+    /// zeroes, which reads like a very fast run rather than a refused one.
+    pub fn received_frame_count(&self) -> u64 {
+        self.every_received_frame_measurement.len() as u64
+    }
+
+    /// Post-warmup frames that entered the histograms and the drop accounting.
+    pub fn measured_frame_count(&self) -> u64 {
+        self.measured_frame_count
+    }
+
+    /// Samples whose computed duration was negative — a nonzero value here
+    /// invalidates the cell's latency numbers rather than degrading them.
+    pub fn negative_latency_anomaly_count(&self) -> u64 {
+        self.negative_latency_anomaly_count
+    }
+
+    /// Samples above the histogram's 60s ceiling, recorded at the ceiling. A
+    /// nonzero value means `max` and the top percentiles are floors, not values.
+    pub fn histogram_range_saturation_count(&self) -> u64 {
+        self.histogram_range_saturation_count
+    }
+
+    /// Rolling 1-second achieved-frame-rate windows, for the fps-stability check.
+    ///
+    /// One entry per measured frame whose full 1-second lookback fits inside the
+    /// cell: the count of measured frames received in `(t - 1s, t]`, which at a
+    /// steady 60fps is exactly 60.0. Sink-receive stamps are used because
+    /// achieved frame rate is a property of the consumer, and they are
+    /// non-decreasing because one single-threaded sink stamps them all.
+    pub fn rolling_one_second_frame_rate_windows(&self) -> Vec<f64> {
+        let sink_receive_stamps = &self.measured_sink_receive_monotonic_nanoseconds;
+        let mut frame_rate_windows = Vec::new();
+        let Some(&first_sink_receive_stamp) = sink_receive_stamps.first() else {
+            return frame_rate_windows;
+        };
+        let mut window_start_index = 0usize;
+        for (index, &sink_receive_stamp) in sink_receive_stamps.iter().enumerate() {
+            let window_lower_bound_nanoseconds = sink_receive_stamp - ONE_SECOND_NANOSECONDS;
+            while sink_receive_stamps[window_start_index] <= window_lower_bound_nanoseconds {
+                window_start_index += 1;
+            }
+            if sink_receive_stamp - first_sink_receive_stamp < ONE_SECOND_NANOSECONDS {
+                continue;
+            }
+            frame_rate_windows.push((index + 1 - window_start_index) as f64);
+        }
+        frame_rate_windows
+    }
+
+    pub fn write_per_frame_measurement_jsonl(&self, path: &Path) -> io::Result<()> {
+        let mut buffered_jsonl_writer = BufWriter::new(File::create(path)?);
+        for measurement in &self.every_received_frame_measurement {
+            serde_json::to_writer(&mut buffered_jsonl_writer, measurement)?;
+            buffered_jsonl_writer.write_all(b"\n")?;
+        }
+        buffered_jsonl_writer.flush()
+    }
+
+    /// Write both histograms as an HdrHistogram interval log (`.hlog`).
+    ///
+    /// Chosen for mergeability: it is the only HdrHistogram interchange format
+    /// that carries several tagged histograms in one file, its V2+DEFLATE
+    /// payloads decode back to full `Histogram` values, and because every cell
+    /// shares the bucket layout fixed above, `Histogram::add` merges cells
+    /// losslessly. Percentiles stored per cell could not be merged at all.
+    pub fn write_mergeable_histogram_export(&self, path: &Path) -> io::Result<()> {
+        let mut buffered_interval_log_writer = BufWriter::new(File::create(path)?);
+        let mut histogram_serializer = V2DeflateSerializer::new();
+        {
+            // No `StartTime` header: it is wall-clock seconds-since-epoch, and
+            // this spike stamps nothing but CLOCK_MONOTONIC. Intervals are
+            // expressed as an offset from the cell's own start instead.
+            let mut interval_log_writer = IntervalLogWriterBuilder::new()
+                .add_comment("streamlib-pyembed-spike measurement cell; values are nanoseconds")
+                .begin_log_with(&mut buffered_interval_log_writer, &mut histogram_serializer)?;
+            let measured_interval_duration = self.measured_interval_duration();
+            for (histogram_tag, histogram) in [
+                (
+                    SOURCE_EMIT_TO_SINK_RECEIVE_HISTOGRAM_TAG,
+                    &self.source_emit_to_sink_receive_histogram,
+                ),
+                (STAGE_CALLBACK_HISTOGRAM_TAG, &self.stage_callback_histogram),
+            ] {
+                interval_log_writer
+                    .write_histogram(
+                        histogram,
+                        Duration::ZERO,
+                        measured_interval_duration,
+                        Tag::new(histogram_tag),
+                    )
+                    .map_err(|error| {
+                        io::Error::other(format!(
+                            "interval log write failed for {histogram_tag}: {error:?}"
+                        ))
+                    })?;
+            }
+        }
+        buffered_interval_log_writer.flush()
+    }
+
+    /// Span from the first to the last measured sink-receive stamp.
+    fn measured_interval_duration(&self) -> Duration {
+        let stamps = &self.measured_sink_receive_monotonic_nanoseconds;
+        match (stamps.first(), stamps.last()) {
+            (Some(&first), Some(&last)) if last > first => {
+                Duration::from_nanos((last - first) as u64)
+            }
+            _ => Duration::ZERO,
+        }
+    }
+}
+
+fn new_nanosecond_histogram() -> Histogram<u64> {
+    Histogram::<u64>::new_with_bounds(
+        HISTOGRAM_LOWEST_DISCERNIBLE_NANOSECONDS,
+        HISTOGRAM_HIGHEST_TRACKABLE_NANOSECONDS,
+        HISTOGRAM_SIGNIFICANT_FIGURES,
+    )
+    .expect("the histogram bounds are compile-time constants and satisfy hdrhistogram's rules")
+}
+
+fn record_nanoseconds_into_histogram(
+    histogram: &mut Histogram<u64>,
+    histogram_range_saturation_count: &mut u64,
+    value_nanoseconds: u64,
+) {
+    let recordable_nanoseconds = value_nanoseconds.min(HISTOGRAM_HIGHEST_TRACKABLE_NANOSECONDS);
+    let record_failed = histogram.record(recordable_nanoseconds).is_err();
+    if record_failed || recordable_nanoseconds != value_nanoseconds {
+        *histogram_range_saturation_count += 1;
+    }
+}
+
+fn summarize_nanosecond_histogram(histogram: &Histogram<u64>) -> LatencyPercentileSummary {
+    if histogram.is_empty() {
+        return LatencyPercentileSummary::empty();
+    }
+    LatencyPercentileSummary {
+        sample_count: histogram.len(),
+        p50_nanoseconds: histogram.value_at_quantile(0.5),
+        p99_nanoseconds: histogram.value_at_quantile(0.99),
+        p99_9_nanoseconds: histogram.value_at_quantile(0.999),
+        max_nanoseconds: histogram.max(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hdrhistogram::serialization::interval_log::LogEntry;
+
+    const WARMUP_EXCLUSION_NANOSECONDS: i64 = 60 * ONE_SECOND_NANOSECONDS;
+
+    fn build_per_frame_latency_measurement(
+        frame_sequence_number: u64,
+        source_emit_monotonic_nanoseconds: i64,
+        source_emit_to_sink_receive_nanoseconds: i64,
+        stage_callback_nanoseconds: i64,
+    ) -> PerFrameLatencyMeasurement {
+        PerFrameLatencyMeasurement {
+            frame_sequence_number,
+            source_emit_monotonic_nanoseconds,
+            sink_receive_monotonic_nanoseconds: source_emit_monotonic_nanoseconds
+                + source_emit_to_sink_receive_nanoseconds,
+            stage_callback_nanoseconds,
+        }
+    }
+
+    fn temporary_artifact_path(file_name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "streamlib-pyembed-spike-{}-{file_name}",
+            std::process::id()
+        ))
+    }
+
+    /// The warmup boundary is half-open: a frame landing exactly on the deadline
+    /// is measured. Flipping this to exclusive would silently shift every cell's
+    /// sample set by one frame and make cells built by different code paths
+    /// non-comparable.
+    #[test]
+    fn frame_exactly_on_the_warmup_deadline_is_measured() {
+        let mut recorder = LatencyMeasurementRecorder::new(WARMUP_EXCLUSION_NANOSECONDS);
+        recorder.record_frame_measurement(build_per_frame_latency_measurement(0, 1_000, 5_000, 0));
+        recorder.record_frame_measurement(build_per_frame_latency_measurement(
+            1,
+            1_000 + WARMUP_EXCLUSION_NANOSECONDS - 1,
+            5_000,
+            0,
+        ));
+        recorder.record_frame_measurement(build_per_frame_latency_measurement(
+            2,
+            1_000 + WARMUP_EXCLUSION_NANOSECONDS,
+            5_000,
+            0,
+        ));
+        assert_eq!(recorder.received_frame_count(), 3);
+        assert_eq!(recorder.measured_frame_count(), 1);
+        assert_eq!(
+            recorder.source_emit_to_sink_receive_summary().sample_count,
+            1
+        );
+    }
+
+    /// Warmup-excluded frames stay in the raw JSONL but must not reach the
+    /// histograms or the drop count — otherwise the artifact and the summary
+    /// disagree about which frames the cell measured.
+    #[test]
+    fn warmup_excluded_frames_reach_the_jsonl_but_not_the_histograms() {
+        let mut recorder = LatencyMeasurementRecorder::new(WARMUP_EXCLUSION_NANOSECONDS);
+        for frame_sequence_number in 0..10u64 {
+            recorder.record_frame_measurement(build_per_frame_latency_measurement(
+                frame_sequence_number,
+                frame_sequence_number as i64 * 1_000_000,
+                5_000,
+                0,
+            ));
+        }
+        assert_eq!(recorder.received_frame_count(), 10);
+        assert_eq!(recorder.measured_frame_count(), 0);
+        assert_eq!(recorder.dropped_frame_count(), 0);
+        assert_eq!(
+            recorder.source_emit_to_sink_receive_summary().sample_count,
+            0
+        );
+
+        let jsonl_path = temporary_artifact_path("warmup-excluded.jsonl");
+        recorder
+            .write_per_frame_measurement_jsonl(&jsonl_path)
+            .expect("jsonl write");
+        let jsonl_contents = std::fs::read_to_string(&jsonl_path).expect("jsonl read");
+        assert_eq!(jsonl_contents.lines().count(), 10);
+        std::fs::remove_file(&jsonl_path).ok();
+    }
+
+    /// Drops are gaps in the sequence, never timing. A missing sequence number
+    /// must be counted exactly once.
+    #[test]
+    fn dropped_frame_count_counts_a_synthetic_sequence_gap() {
+        let mut recorder = LatencyMeasurementRecorder::new(0);
+        for frame_sequence_number in [0u64, 1, 2, 5, 6] {
+            recorder.record_frame_measurement(build_per_frame_latency_measurement(
+                frame_sequence_number,
+                frame_sequence_number as i64 * 16_666_667,
+                5_000,
+                0,
+            ));
+        }
+        assert_eq!(recorder.received_frame_count(), 5);
+        assert_eq!(recorder.dropped_frame_count(), 2);
+    }
+
+    /// The very first observed frame has no predecessor, so it must not be
+    /// charged a gap against sequence number 0 or against nothing at all.
+    #[test]
+    fn first_observed_frame_reports_no_drop() {
+        let mut recorder = LatencyMeasurementRecorder::new(0);
+        recorder.record_frame_measurement(build_per_frame_latency_measurement(7, 1_000, 5_000, 0));
+        assert_eq!(recorder.dropped_frame_count(), 0);
+        assert_eq!(recorder.received_frame_count(), 1);
+    }
+
+    /// A frame arriving after its successor must close its own gap rather than
+    /// leave a permanent phantom drop in the report.
+    #[test]
+    fn out_of_order_arrival_reports_no_phantom_drop() {
+        let mut recorder = LatencyMeasurementRecorder::new(0);
+        for frame_sequence_number in [0u64, 2, 1, 3] {
+            recorder.record_frame_measurement(build_per_frame_latency_measurement(
+                frame_sequence_number,
+                frame_sequence_number as i64 * 16_666_667,
+                5_000,
+                0,
+            ));
+        }
+        assert_eq!(recorder.dropped_frame_count(), 0);
+    }
+
+    /// A run where the sink received nothing must report zero samples, not
+    /// panic and not divide by zero — a refused run is the most likely failure
+    /// mode of the embedded arm and must be legible as such.
+    #[test]
+    fn no_frames_received_reports_a_zero_count_summary() {
+        let recorder = LatencyMeasurementRecorder::new(WARMUP_EXCLUSION_NANOSECONDS);
+        assert_eq!(recorder.received_frame_count(), 0);
+        assert_eq!(recorder.dropped_frame_count(), 0);
+        assert!(recorder.rolling_one_second_frame_rate_windows().is_empty());
+
+        let summary = recorder.source_emit_to_sink_receive_summary();
+        assert_eq!(summary.sample_count, 0);
+        assert_eq!(summary.p50_nanoseconds, 0);
+        assert_eq!(summary.p99_nanoseconds, 0);
+        assert_eq!(summary.p99_9_nanoseconds, 0);
+        assert_eq!(summary.max_nanoseconds, 0);
+        assert_eq!(recorder.stage_callback_summary().sample_count, 0);
+    }
+
+    /// A sink stamp preceding its emit stamp means the arms disagree on the
+    /// clock. Clamping it to 0 would publish the disagreement as a fast p50, so
+    /// it must be counted and kept out of the histogram.
+    #[test]
+    fn negative_latency_increments_the_anomaly_counter_and_skips_the_histogram() {
+        let mut recorder = LatencyMeasurementRecorder::new(0);
+        recorder.record_frame_measurement(build_per_frame_latency_measurement(
+            0, 1_000_000, 2_000_000, 0,
+        ));
+        recorder.record_frame_measurement(build_per_frame_latency_measurement(
+            1, 2_000_000, -500_000, 0,
+        ));
+        assert_eq!(recorder.negative_latency_anomaly_count(), 1);
+        assert_eq!(recorder.received_frame_count(), 2);
+        assert_eq!(recorder.measured_frame_count(), 2);
+        assert_eq!(
+            recorder.source_emit_to_sink_receive_summary().sample_count,
+            1
+        );
+    }
+
+    /// A negative stage-callback duration is single-clock and single-process, so
+    /// it means instrumentation is broken; it must surface, not be absorbed.
+    #[test]
+    fn negative_stage_callback_duration_increments_the_anomaly_counter() {
+        let mut recorder = LatencyMeasurementRecorder::new(0);
+        recorder.record_frame_measurement(build_per_frame_latency_measurement(
+            0, 1_000_000, 500_000, -1,
+        ));
+        assert_eq!(recorder.negative_latency_anomaly_count(), 1);
+        assert_eq!(recorder.stage_callback_summary().sample_count, 0);
+        assert_eq!(
+            recorder.source_emit_to_sink_receive_summary().sample_count,
+            1
+        );
+    }
+
+    /// Hand-computed distribution: 990 samples at 1ms and 10 at 100ms. p50 and
+    /// p99 must both land on 1ms (the p99 cut falls exactly on the 990th
+    /// sample), p99.9 and max on 100ms. Guards an off-by-one in the quantile
+    /// wiring, which would move the headline number by two orders of magnitude.
+    #[test]
+    fn percentiles_match_a_hand_computed_distribution() {
+        const ONE_MILLISECOND_NANOSECONDS: i64 = 1_000_000;
+        const ONE_HUNDRED_MILLISECONDS_NANOSECONDS: i64 = 100_000_000;
+        let mut recorder = LatencyMeasurementRecorder::new(0);
+        for frame_sequence_number in 0..1_000u64 {
+            let latency_nanoseconds = if frame_sequence_number < 990 {
+                ONE_MILLISECOND_NANOSECONDS
+            } else {
+                ONE_HUNDRED_MILLISECONDS_NANOSECONDS
+            };
+            recorder.record_frame_measurement(build_per_frame_latency_measurement(
+                frame_sequence_number,
+                frame_sequence_number as i64 * 16_666_667,
+                latency_nanoseconds,
+                0,
+            ));
+        }
+
+        let summary = recorder.source_emit_to_sink_receive_summary();
+        assert_eq!(summary.sample_count, 1_000);
+        assert_within_three_significant_figures(
+            summary.p50_nanoseconds,
+            ONE_MILLISECOND_NANOSECONDS,
+        );
+        assert_within_three_significant_figures(
+            summary.p99_nanoseconds,
+            ONE_MILLISECOND_NANOSECONDS,
+        );
+        assert_within_three_significant_figures(
+            summary.p99_9_nanoseconds,
+            ONE_HUNDRED_MILLISECONDS_NANOSECONDS,
+        );
+        assert_within_three_significant_figures(
+            summary.max_nanoseconds,
+            ONE_HUNDRED_MILLISECONDS_NANOSECONDS,
+        );
+    }
+
+    fn assert_within_three_significant_figures(actual_nanoseconds: u64, expected_nanoseconds: i64) {
+        let expected = expected_nanoseconds as f64;
+        let relative_error = (actual_nanoseconds as f64 - expected).abs() / expected;
+        assert!(
+            relative_error < 0.002,
+            "{actual_nanoseconds}ns is not within 3 significant figures of {expected_nanoseconds}ns"
+        );
+    }
+
+    /// A perfectly paced stream must report exactly its nominal rate in every
+    /// rolling window; an off-by-one in the half-open window bounds would show
+    /// as a permanent 49 or 51 and be misread as pacing jitter. 50fps is used
+    /// rather than 60 because its period divides one second exactly, so the
+    /// expected count is arithmetic rather than a rounding artifact.
+    #[test]
+    fn rolling_windows_report_the_nominal_rate_of_a_perfectly_paced_stream() {
+        const FIFTY_FPS_PERIOD_NANOSECONDS: i64 = ONE_SECOND_NANOSECONDS / 50;
+        let mut recorder = LatencyMeasurementRecorder::new(0);
+        for frame_sequence_number in 0..300u64 {
+            recorder.record_frame_measurement(build_per_frame_latency_measurement(
+                frame_sequence_number,
+                frame_sequence_number as i64 * FIFTY_FPS_PERIOD_NANOSECONDS,
+                500_000,
+                0,
+            ));
+        }
+        let frame_rate_windows = recorder.rolling_one_second_frame_rate_windows();
+        assert_eq!(frame_rate_windows.len(), 300 - 50);
+        assert!(
+            frame_rate_windows.iter().all(|&rate| rate == 50.0),
+            "expected every rolling window to report 50fps, got {frame_rate_windows:?}"
+        );
+    }
+
+    /// The JSONL is the raw record every later analysis re-derives from: one
+    /// compact object per line, no wrapping array, every field intact.
+    #[test]
+    fn jsonl_round_trips_line_by_line_through_serde_json() {
+        let mut recorder = LatencyMeasurementRecorder::new(0);
+        let written_measurements: Vec<PerFrameLatencyMeasurement> = (0..5u64)
+            .map(|frame_sequence_number| {
+                build_per_frame_latency_measurement(
+                    frame_sequence_number,
+                    frame_sequence_number as i64 * 16_666_667,
+                    1_234_567,
+                    89_012,
+                )
+            })
+            .collect();
+        for measurement in &written_measurements {
+            recorder.record_frame_measurement(*measurement);
+        }
+
+        let jsonl_path = temporary_artifact_path("round-trip.jsonl");
+        recorder
+            .write_per_frame_measurement_jsonl(&jsonl_path)
+            .expect("jsonl write");
+        let jsonl_contents = std::fs::read_to_string(&jsonl_path).expect("jsonl read");
+        std::fs::remove_file(&jsonl_path).ok();
+
+        assert!(!jsonl_contents.starts_with('['));
+        let parsed_lines: Vec<serde_json::Value> = jsonl_contents
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("each line is a standalone JSON object"))
+            .collect();
+        assert_eq!(parsed_lines.len(), written_measurements.len());
+        for (parsed, written) in parsed_lines.iter().zip(&written_measurements) {
+            assert_eq!(
+                parsed["frame_sequence_number"],
+                written.frame_sequence_number
+            );
+            assert_eq!(
+                parsed["source_emit_monotonic_nanoseconds"],
+                written.source_emit_monotonic_nanoseconds
+            );
+            assert_eq!(
+                parsed["sink_receive_monotonic_nanoseconds"],
+                written.sink_receive_monotonic_nanoseconds
+            );
+            assert_eq!(
+                parsed["stage_callback_nanoseconds"],
+                written.stage_callback_nanoseconds
+            );
+        }
+    }
+
+    /// The histogram export has to decode back into mergeable histograms — if it
+    /// did not, per-cell files could not be combined and the protocol's
+    /// cross-cell percentiles would be uncomputable.
+    #[test]
+    fn histogram_export_decodes_and_merges_across_cells() {
+        let mut first_cell_recorder = LatencyMeasurementRecorder::new(0);
+        let mut second_cell_recorder = LatencyMeasurementRecorder::new(0);
+        for frame_sequence_number in 0..100u64 {
+            first_cell_recorder.record_frame_measurement(build_per_frame_latency_measurement(
+                frame_sequence_number,
+                frame_sequence_number as i64 * 16_666_667,
+                2_000_000,
+                0,
+            ));
+            second_cell_recorder.record_frame_measurement(build_per_frame_latency_measurement(
+                frame_sequence_number,
+                frame_sequence_number as i64 * 16_666_667,
+                4_000_000,
+                0,
+            ));
+        }
+
+        let first_cell_path = temporary_artifact_path("first-cell.hlog");
+        let second_cell_path = temporary_artifact_path("second-cell.hlog");
+        first_cell_recorder
+            .write_mergeable_histogram_export(&first_cell_path)
+            .expect("first cell export");
+        second_cell_recorder
+            .write_mergeable_histogram_export(&second_cell_path)
+            .expect("second cell export");
+
+        let mut merged_histogram = new_nanosecond_histogram();
+        let mut merged_sample_count = 0u64;
+        for path in [&first_cell_path, &second_cell_path] {
+            let log_bytes = std::fs::read(path).expect("hlog read");
+            let mut histogram_deserializer = hdrhistogram::serialization::Deserializer::new();
+            for log_entry in
+                hdrhistogram::serialization::interval_log::IntervalLogIterator::new(&log_bytes)
+            {
+                let LogEntry::Interval(interval_log_histogram) =
+                    log_entry.expect("hlog entry parses")
+                else {
+                    continue;
+                };
+                if interval_log_histogram.tag().map(|tag| tag.as_str())
+                    != Some(SOURCE_EMIT_TO_SINK_RECEIVE_HISTOGRAM_TAG)
+                {
+                    continue;
+                }
+                let encoded_histogram_bytes =
+                    base64_decode_histogram(interval_log_histogram.encoded_histogram());
+                let decoded_histogram: Histogram<u64> = histogram_deserializer
+                    .deserialize(&mut encoded_histogram_bytes.as_slice())
+                    .expect("histogram deserializes");
+                merged_sample_count += decoded_histogram.len();
+                merged_histogram
+                    .add(&decoded_histogram)
+                    .expect("cells share bounds");
+            }
+        }
+        std::fs::remove_file(&first_cell_path).ok();
+        std::fs::remove_file(&second_cell_path).ok();
+
+        assert_eq!(merged_sample_count, 200);
+        assert_eq!(merged_histogram.len(), 200);
+        assert_within_three_significant_figures(merged_histogram.value_at_quantile(0.5), 2_000_000);
+        assert_within_three_significant_figures(merged_histogram.max(), 4_000_000);
+    }
+
+    /// The interval log stores histograms base64'd; decoding here rather than
+    /// depending on a base64 crate keeps the spike's dependency set as declared.
+    fn base64_decode_histogram(encoded: &str) -> Vec<u8> {
+        const BASE64_ALPHABET: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let mut accumulator: u32 = 0;
+        let mut accumulated_bits: u32 = 0;
+        let mut decoded_bytes = Vec::new();
+        for encoded_byte in encoded.bytes() {
+            if encoded_byte == b'=' {
+                break;
+            }
+            let sextet = BASE64_ALPHABET
+                .iter()
+                .position(|&alphabet_byte| alphabet_byte == encoded_byte)
+                .expect("interval log payloads are standard base64")
+                as u32;
+            accumulator = (accumulator << 6) | sextet;
+            accumulated_bits += 6;
+            if accumulated_bits >= 8 {
+                accumulated_bits -= 8;
+                decoded_bytes.push((accumulator >> accumulated_bits) as u8);
+            }
+        }
+        decoded_bytes
+    }
+}

--- a/spikes/streamlib-pyembed-spike/src/lib.rs
+++ b/spikes/streamlib-pyembed-spike/src/lib.rs
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Throwaway spike for #1702: does an in-process Python processor (CPython
+//! embedded via PyO3) beat today's subprocess-per-Python-processor model?
+//!
+//! Nothing here is an API proposal. The callback-injection token registry, the
+//! process-global measurement collection point, and the Python-facing shapes are
+//! all deliberate spike artifacts — #1702 defers API design until after the
+//! numbers exist. The engine is untouched; every processor enters through the
+//! existing `App::add_local` path.
+//!
+//! Tier A measures `source_emit_to_sink_receive`, NOT capture-to-present: there
+//! is no camera and no display on this arm, and present time is not observable
+//! in either arm without an engine change the spike forbids.
+
+// Every fallible path returns the engine's own `streamlib::sdk::error::Error`,
+// which is 168 bytes. Boxing it here would diverge the spike's signatures from
+// the engine API it exists to measure.
+#![allow(clippy::result_large_err)]
+
+pub mod latency_measurement_recorder;
+pub mod machine_specification_probe;
+pub mod measuring_sink_processor;
+pub mod monotonic_clock;
+pub mod python_callback_stage_processor;
+pub mod python_gil_attachment_anchor;
+pub mod python_processor_callback_registry;
+pub mod rust_passthrough_floor_stage_processor;
+pub mod synthetic_frame_measurement_preamble;
+pub mod synthetic_frame_source_processor;
+pub mod tier_a_measurement_cell;
+pub mod zero_copy_numpy_frame_view;

--- a/spikes/streamlib-pyembed-spike/src/machine_specification_probe.rs
+++ b/spikes/streamlib-pyembed-spike/src/machine_specification_probe.rs
@@ -1,0 +1,1757 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Everything about this machine that moves a latency number, captured into
+//! `machine-spec.json` beside every measurement artifact.
+//!
+//! A `source_emit_to_sink_receive` percentile is only defensible if a reader can
+//! tell whether the box was locked down or noisy while it was collected. This
+//! module records the knobs, records *why* a knob could not be read when it
+//! could not, and refuses to call the machine locked on anything it does not
+//! know for certain.
+//!
+//! Nothing here ever invokes `sudo`. `sudo -n` fails on the reference box, so a
+//! privileged probe would sit on a password prompt and wedge an unattended
+//! multi-hour run. Where locking needs root, the current state is recorded and
+//! the exact command an owner would run is emitted as data — never executed.
+
+use std::collections::BTreeSet;
+use std::ffi::CStr;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// File name the measurement harness writes this artifact under.
+pub const MACHINE_SPECIFICATION_JSON_FILE_NAME: &str = "machine-spec.json";
+
+/// Bumped whenever a field is added, removed, or given a different meaning, so
+/// an artifact from an older run is never silently compared against a newer one.
+pub const MACHINE_SPECIFICATION_SCHEMA_VERSION: u32 = 1;
+
+/// A one-minute load average at or above this means other work was resident on
+/// the box, and a gated measurement cell is refused.
+pub const MAXIMUM_ONE_MINUTE_LOAD_AVERAGE_FOR_LOCKED_MEASUREMENT_STATE: f64 = 1.0;
+
+/// A probed field: either an observation, or an explicit reason it is unknown.
+/// There is no third state — a missing sysfs file becomes an `Unavailable`
+/// carrying the OS error, never an empty string or a zero.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "probe_outcome", rename_all = "snake_case")]
+pub enum ProbedValueOrUnavailableReason<ObservedValue> {
+    /// The probe ran and produced this value.
+    Observed {
+        /// The observation.
+        value: ObservedValue,
+    },
+    /// The probe could not run, or ran and produced nothing usable.
+    Unavailable {
+        /// Why, in enough detail to reproduce the failure on another box.
+        reason: String,
+    },
+}
+
+impl<ObservedValue> ProbedValueOrUnavailableReason<ObservedValue> {
+    /// The observation, or `None` when the probe could not determine it.
+    pub fn observed_value(&self) -> Option<&ObservedValue> {
+        match self {
+            Self::Observed { value } => Some(value),
+            Self::Unavailable { .. } => None,
+        }
+    }
+
+    /// Why the field is unknown, or `None` when it was observed.
+    pub fn unavailable_reason(&self) -> Option<&str> {
+        match self {
+            Self::Observed { .. } => None,
+            Self::Unavailable { reason } => Some(reason),
+        }
+    }
+
+    fn unavailable(reason: impl Into<String>) -> Self {
+        Self::Unavailable {
+            reason: reason.into(),
+        }
+    }
+
+    fn observed(value: ObservedValue) -> Self {
+        Self::Observed { value }
+    }
+}
+
+/// Everything about this machine that moves a latency number.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MachineSpecification {
+    /// Schema of this artifact; see [`MACHINE_SPECIFICATION_SCHEMA_VERSION`].
+    pub machine_specification_schema_version: u32,
+    /// Wall-clock stamp for provenance only. Never feeds a latency computation —
+    /// every measured interval in this spike comes from `CLOCK_MONOTONIC`.
+    pub probed_at_unix_epoch_seconds: ProbedValueOrUnavailableReason<u64>,
+    /// `PRETTY_NAME` from `/etc/os-release`.
+    pub operating_system_pretty_name: ProbedValueOrUnavailableReason<String>,
+    /// Hostname, so two artifacts from different boxes cannot be confused.
+    pub host_name: ProbedValueOrUnavailableReason<String>,
+
+    /// CPU model, topology, and every frequency knob.
+    pub central_processing_unit: CentralProcessingUnitSpecification,
+    /// Kernel identity, preemption model, and the sysctls that move tails.
+    pub kernel: KernelSpecification,
+    /// glibc version — it decides which futex and `clock_gettime` paths run.
+    pub c_library_version: ProbedValueOrUnavailableReason<String>,
+    /// GPU identity, driver, and clock state.
+    pub graphics_processing_unit: GraphicsProcessingUnitSpecification,
+    /// RAM and swap.
+    pub memory: MemorySpecification,
+    /// The interpreter and numpy the Python arms run against.
+    pub python_runtime: PythonRuntimeSpecification,
+    /// Scheduling class and niceness of the process that ran this probe.
+    pub probing_process_scheduling: ProbingProcessSchedulingSpecification,
+    /// What else was resident on the box when the probe ran.
+    pub machine_load_at_probe_time: MachineLoadSpecification,
+
+    /// Every reason this machine was not in a locked measurement state at probe
+    /// time. Computed once by [`probe_machine_specification`]; recomputable from
+    /// the observation fields with [`locked_measurement_state_violations`].
+    pub locked_measurement_state_violations: Vec<String>,
+    /// The privileged commands that would clear the violations above.
+    /// Recorded as data. Never executed.
+    pub owner_commands_to_reach_locked_measurement_state:
+        Vec<OwnerPrivilegedCommandToReachLockedMeasurementState>,
+}
+
+/// CPU model, topology, and every frequency knob that moves a latency tail.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CentralProcessingUnitSpecification {
+    /// `model name` from `/proc/cpuinfo`.
+    pub model_name: ProbedValueOrUnavailableReason<String>,
+    /// Distinct `(package, core)` pairs in sysfs topology.
+    pub physical_core_count: ProbedValueOrUnavailableReason<usize>,
+    /// Online logical processors machine-wide.
+    pub logical_processor_count: ProbedValueOrUnavailableReason<usize>,
+    /// Logical processors this process may actually run on — affinity and cgroup
+    /// aware, so it can be lower than `logical_processor_count`.
+    pub logical_processor_count_available_to_this_process: ProbedValueOrUnavailableReason<usize>,
+    /// `/sys/devices/system/cpu/smt/control`: `on`, `off`, `forceoff`,
+    /// `notsupported`, or `notimplemented`.
+    pub simultaneous_multithreading_control: ProbedValueOrUnavailableReason<String>,
+    /// cpufreq driver in charge, e.g. `amd-pstate-epp`, `intel_pstate`.
+    pub frequency_scaling_driver: ProbedValueOrUnavailableReason<String>,
+    // The three per-policy fields below are sequences rather than maps.
+    // `ProbedValueOrUnavailableReason` is internally tagged, and serde's
+    // internally-tagged path buffers through `Content`, which drops serde_json's
+    // integer-map-key coercion: a `BTreeMap<u32, _>` here serializes fine and
+    // then fails to deserialize with `invalid type: string "0", expected u32`.
+    // A sequence also keeps policies in numeric order, where a string-keyed map
+    // would sort `policy10` ahead of `policy2`.
+    /// Governor of each cpufreq policy, ascending by policy number.
+    pub frequency_scaling_governor_per_policy:
+        ProbedValueOrUnavailableReason<Vec<CpuFrequencyPolicyObservation<String>>>,
+    /// Energy/performance preference of each cpufreq policy.
+    pub energy_performance_preference_per_policy:
+        ProbedValueOrUnavailableReason<Vec<CpuFrequencyPolicyObservation<String>>>,
+    /// `scaling_cur_freq` of each policy at probe time, converted from kHz to MHz.
+    pub current_frequency_megahertz_per_policy:
+        ProbedValueOrUnavailableReason<Vec<CpuFrequencyPolicyObservation<f64>>>,
+    /// Whether opportunistic boost / turbo is enabled.
+    pub boost_is_enabled: ProbedValueOrUnavailableReason<bool>,
+    /// Which sysfs file the boost state was read from — the AMD and Intel
+    /// drivers expose it under different paths with inverted polarity.
+    pub boost_control_sysfs_path: ProbedValueOrUnavailableReason<String>,
+    /// `/sys/devices/system/cpu/isolated`. An observed empty string means no
+    /// processor is isolated, which is a real observation, not an unknown.
+    pub isolated_processor_cpu_list: ProbedValueOrUnavailableReason<String>,
+    /// `/sys/devices/system/cpu/nohz_full`. Empty means no tickless processor.
+    pub tickless_processor_cpu_list: ProbedValueOrUnavailableReason<String>,
+}
+
+/// One cpufreq policy's reading of a single sysfs attribute.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CpuFrequencyPolicyObservation<ObservedAttribute> {
+    /// The `N` in `/sys/devices/system/cpu/cpufreq/policyN`.
+    pub policy_number: u32,
+    /// What that policy reported.
+    pub observed_attribute: ObservedAttribute,
+}
+
+/// Kernel identity, preemption model, and the sysctls that move latency tails.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KernelSpecification {
+    /// `/proc/sys/kernel/osrelease`.
+    pub release: ProbedValueOrUnavailableReason<String>,
+    /// `/proc/sys/kernel/version` — the build banner carrying the preempt token.
+    pub version_banner: ProbedValueOrUnavailableReason<String>,
+    /// The `PREEMPT*` token from the build banner, e.g. `PREEMPT_DYNAMIC`.
+    pub build_preemption_model: ProbedValueOrUnavailableReason<String>,
+    /// Whether this is a `PREEMPT_RT` kernel.
+    pub is_preempt_realtime: ProbedValueOrUnavailableReason<bool>,
+    /// The live preemption mode of a `PREEMPT_DYNAMIC` kernel. Lives in debugfs,
+    /// which is root-only on a stock Ubuntu install, so this is normally an
+    /// `Unavailable` carrying the permission error.
+    pub runtime_preemption_mode: ProbedValueOrUnavailableReason<String>,
+    /// `/proc/cmdline`, which carries `isolcpus`, `nohz_full`, `mitigations`.
+    pub boot_command_line: ProbedValueOrUnavailableReason<String>,
+    /// The selected transparent-hugepage policy: `always`, `madvise`, or `never`.
+    pub transparent_hugepage_policy: ProbedValueOrUnavailableReason<String>,
+    /// `kernel.randomize_va_space`: 0 off, 1 conservative, 2 full.
+    pub address_space_layout_randomization_level: ProbedValueOrUnavailableReason<i64>,
+    /// `kernel.sched_rt_runtime_us`. A positive value throttles SCHED_FIFO work
+    /// to that slice of every period, which shows up as periodic latency spikes.
+    pub realtime_scheduler_runtime_microseconds: ProbedValueOrUnavailableReason<i64>,
+    /// `kernel.timer_migration`.
+    pub timer_migration_is_enabled: ProbedValueOrUnavailableReason<bool>,
+    /// `kernel.perf_event_paranoid`. Recorded because it decides what profiling
+    /// evidence an unprivileged run can attach to the artifact; it does not
+    /// itself move a latency number and so does not gate a cell.
+    pub performance_event_paranoid_level: ProbedValueOrUnavailableReason<i64>,
+}
+
+/// GPU identity, driver, and clock state as `nvidia-smi` reports them.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphicsProcessingUnitSpecification {
+    /// Marketing name of GPU 0.
+    pub model_name: ProbedValueOrUnavailableReason<String>,
+    /// NVIDIA kernel driver version.
+    pub driver_version: ProbedValueOrUnavailableReason<String>,
+    /// Persistence mode. Off means the driver unloads between clients and the
+    /// first submission of a cell pays initialization cost the rest do not.
+    pub persistence_mode: ProbedValueOrUnavailableReason<String>,
+    /// Current performance state, `P0` (max) through `P8` (idle).
+    pub performance_state: ProbedValueOrUnavailableReason<String>,
+    /// Compute mode, e.g. `Default`, `Exclusive_Process`.
+    pub compute_mode: ProbedValueOrUnavailableReason<String>,
+    /// Total device memory in mebibytes.
+    pub total_memory_mebibytes: ProbedValueOrUnavailableReason<f64>,
+    /// Enforced power limit in watts.
+    pub power_limit_watts: ProbedValueOrUnavailableReason<f64>,
+    /// Graphics clock at probe time, in megahertz.
+    pub current_graphics_clock_megahertz: ProbedValueOrUnavailableReason<f64>,
+    /// Highest graphics clock the device will report, in megahertz.
+    pub maximum_graphics_clock_megahertz: ProbedValueOrUnavailableReason<f64>,
+    /// Memory clock at probe time, in megahertz.
+    pub current_memory_clock_megahertz: ProbedValueOrUnavailableReason<f64>,
+    /// NVML `clocks_event_reasons.active` bitmask as reported, hex.
+    pub active_clock_event_reasons_bitmask: ProbedValueOrUnavailableReason<String>,
+    /// Whether `--lock-gpu-clocks` is in force. NVML exposes no read-back for
+    /// the locked range, so on an unprivileged probe this is always an
+    /// `Unavailable` and the lock is a stated protocol variable rather than a
+    /// gate condition.
+    pub graphics_clock_lock_state: ProbedValueOrUnavailableReason<String>,
+}
+
+/// RAM and swap.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemorySpecification {
+    /// `MemTotal` in kibibytes.
+    pub total_kibibytes: ProbedValueOrUnavailableReason<u64>,
+    /// `MemAvailable` in kibibytes at probe time.
+    pub available_kibibytes: ProbedValueOrUnavailableReason<u64>,
+    /// `SwapTotal` in kibibytes.
+    pub swap_total_kibibytes: ProbedValueOrUnavailableReason<u64>,
+    /// `SwapTotal - SwapFree` in kibibytes: pages already out at probe time,
+    /// each of which is a multi-millisecond fault waiting to land in a tail.
+    pub swap_used_kibibytes: ProbedValueOrUnavailableReason<u64>,
+    /// Whether any swap device is configured.
+    pub swap_is_enabled: ProbedValueOrUnavailableReason<bool>,
+}
+
+/// The interpreter and numpy the Python arms of the spike run against.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PythonRuntimeSpecification {
+    /// Absolute path of the interpreter that answered the probe.
+    pub interpreter_executable_path: ProbedValueOrUnavailableReason<String>,
+    /// Dotted version, e.g. `3.12.3`.
+    pub interpreter_version: ProbedValueOrUnavailableReason<String>,
+    /// Full `sys.version` banner, which carries the compiler and build date.
+    pub interpreter_version_banner: ProbedValueOrUnavailableReason<String>,
+    /// numpy version, which decides the zero-copy buffer path the PyO3 arm hits.
+    pub numpy_version: ProbedValueOrUnavailableReason<String>,
+    /// Whether this is a free-threaded build with the GIL disabled — the single
+    /// fact that most changes what an in-process Python result means.
+    pub global_interpreter_lock_is_disabled: ProbedValueOrUnavailableReason<bool>,
+}
+
+/// Scheduling class and niceness of the process that ran this probe.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProbingProcessSchedulingSpecification {
+    /// `SCHED_OTHER`, `SCHED_FIFO`, `SCHED_RR`, `SCHED_BATCH`, `SCHED_IDLE`,
+    /// or `SCHED_DEADLINE`. A stated protocol variable: both spike arms must
+    /// run under the same one for their percentiles to be comparable.
+    pub scheduling_policy_name: ProbedValueOrUnavailableReason<String>,
+    /// Raw `sched_getscheduler` result with `SCHED_RESET_ON_FORK` masked off.
+    pub scheduling_policy_number: ProbedValueOrUnavailableReason<i32>,
+    /// Whether `SCHED_RESET_ON_FORK` was set — children would drop back to
+    /// `SCHED_OTHER`, which silently un-does a `chrt` on a spawned arm.
+    pub scheduling_policy_resets_on_fork: ProbedValueOrUnavailableReason<bool>,
+    /// Realtime priority, 0 under the fair-share classes.
+    pub realtime_priority: ProbedValueOrUnavailableReason<i32>,
+    /// Niceness, -20 through 19.
+    pub niceness: ProbedValueOrUnavailableReason<i32>,
+}
+
+/// What else was resident on the box when the probe ran.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MachineLoadSpecification {
+    /// One-minute load average.
+    pub load_average_one_minute: ProbedValueOrUnavailableReason<f64>,
+    /// Five-minute load average.
+    pub load_average_five_minutes: ProbedValueOrUnavailableReason<f64>,
+    /// Fifteen-minute load average.
+    pub load_average_fifteen_minutes: ProbedValueOrUnavailableReason<f64>,
+    /// Currently runnable kernel scheduling entities.
+    pub runnable_scheduling_entity_count: ProbedValueOrUnavailableReason<u64>,
+    /// Total kernel scheduling entities on the box.
+    pub total_scheduling_entity_count: ProbedValueOrUnavailableReason<u64>,
+}
+
+/// A root-only command that would clear one locked-state violation. Emitted as
+/// data for an owner to run by hand — this module never executes it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OwnerPrivilegedCommandToReachLockedMeasurementState {
+    /// The knob the command locks.
+    pub knob_description: String,
+    /// What the probe saw, so the owner can tell whether it is still needed.
+    pub current_observed_state: String,
+    /// The exact shell command, verbatim.
+    pub shell_command: String,
+    /// The command that puts the knob back afterwards.
+    pub reverting_shell_command: String,
+}
+
+/// One knob's lock command paired with the command that puts it back. Pairing
+/// them in one value is what keeps a lock step from outliving its restore step.
+#[derive(Debug, Clone, Copy)]
+pub struct ReferenceMachineLockAndRestoreCommandPair {
+    /// The knob both commands target.
+    pub knob_description: &'static str,
+    /// Run before the measurement run.
+    pub locking_shell_command: &'static str,
+    /// Run after it — leaving SMT off and swap disabled is a change to the
+    /// owner's daily machine, not a measurement artifact.
+    pub restoring_shell_command: &'static str,
+}
+
+/// What [`owner_checklist_to_reach_locked_measurement_state`] actually emitted
+/// on the reference box on 2026-08-01: AMD Ryzen 9 5900X (12 physical / 24
+/// logical) on `amd-pstate-epp`, Ubuntu 24.04.4, kernel 7.0.0-28-generic
+/// `PREEMPT_DYNAMIC`, RTX 3090 on driver 595.84.
+///
+/// The `performance` governor and `madvise` hugepage policy were already in
+/// their locked state, so no command for them appears. The one remaining
+/// violation on that box — a 3.45 one-minute load average — has no command:
+/// it clears by quiescing the machine before the run.
+pub const OWNER_CHECKLIST_OBSERVED_ON_REFERENCE_MACHINE:
+    &[ReferenceMachineLockAndRestoreCommandPair] = &[
+    ReferenceMachineLockAndRestoreCommandPair {
+        knob_description: "opportunistic CPU boost/turbo",
+        locking_shell_command: "echo 0 | sudo tee /sys/devices/system/cpu/cpufreq/boost",
+        restoring_shell_command: "echo 1 | sudo tee /sys/devices/system/cpu/cpufreq/boost",
+    },
+    ReferenceMachineLockAndRestoreCommandPair {
+        knob_description: "simultaneous multithreading",
+        locking_shell_command: "echo off | sudo tee /sys/devices/system/cpu/smt/control",
+        restoring_shell_command: "echo on | sudo tee /sys/devices/system/cpu/smt/control",
+    },
+    ReferenceMachineLockAndRestoreCommandPair {
+        knob_description: "swap",
+        locking_shell_command: "sudo swapoff -a",
+        restoring_shell_command: "sudo swapon -a",
+    },
+    ReferenceMachineLockAndRestoreCommandPair {
+        knob_description: "GPU persistence mode",
+        locking_shell_command: "sudo nvidia-smi -pm 1",
+        restoring_shell_command: "sudo nvidia-smi -pm 0",
+    },
+    ReferenceMachineLockAndRestoreCommandPair {
+        knob_description: "GPU graphics clock lock",
+        locking_shell_command: "sudo nvidia-smi -i 0 --lock-gpu-clocks=1680,1680",
+        restoring_shell_command: "sudo nvidia-smi -i 0 --reset-gpu-clocks",
+    },
+];
+
+const CPU_FREQUENCY_SCALING_SYSFS_DIRECTORY: &str = "/sys/devices/system/cpu/cpufreq";
+const CPU_TOPOLOGY_SYSFS_DIRECTORY: &str = "/sys/devices/system/cpu";
+const AMD_AND_ACPI_BOOST_SYSFS_PATH: &str = "/sys/devices/system/cpu/cpufreq/boost";
+const INTEL_PSTATE_NO_TURBO_SYSFS_PATH: &str = "/sys/devices/system/cpu/intel_pstate/no_turbo";
+const TRANSPARENT_HUGEPAGE_SYSFS_PATH: &str = "/sys/kernel/mm/transparent_hugepage/enabled";
+const RUNTIME_PREEMPTION_MODE_DEBUGFS_PATH: &str = "/sys/kernel/debug/sched/preempt";
+
+/// Probe the machine. Never fails: a probe that cannot run records why.
+pub fn probe_machine_specification() -> MachineSpecification {
+    let mut specification = MachineSpecification {
+        machine_specification_schema_version: MACHINE_SPECIFICATION_SCHEMA_VERSION,
+        probed_at_unix_epoch_seconds: probe_unix_epoch_seconds(),
+        operating_system_pretty_name: probe_operating_system_pretty_name(),
+        host_name: read_trimmed_file_contents("/proc/sys/kernel/hostname"),
+        central_processing_unit: probe_central_processing_unit(),
+        kernel: probe_kernel(),
+        c_library_version: probe_c_library_version(),
+        graphics_processing_unit: probe_graphics_processing_unit(),
+        memory: probe_memory(),
+        python_runtime: probe_python_runtime(),
+        probing_process_scheduling: probe_process_scheduling(),
+        machine_load_at_probe_time: probe_machine_load(),
+        locked_measurement_state_violations: Vec::new(),
+        owner_commands_to_reach_locked_measurement_state: Vec::new(),
+    };
+
+    specification.locked_measurement_state_violations =
+        locked_measurement_state_violations(&specification);
+    specification.owner_commands_to_reach_locked_measurement_state =
+        owner_checklist_to_reach_locked_measurement_state(&specification);
+
+    tracing::info!(
+        violation_count = specification.locked_measurement_state_violations.len(),
+        "probed machine specification"
+    );
+    specification
+}
+
+/// True when every latency-relevant knob is in its locked/deterministic state.
+/// The harness refuses to run a gated cell when this is false.
+pub fn machine_is_in_locked_measurement_state(specification: &MachineSpecification) -> bool {
+    locked_measurement_state_violations(specification).is_empty()
+}
+
+/// Every reason this machine is not in a locked measurement state, recomputed
+/// from the observation fields. An unknown field is always a violation.
+///
+/// The gate covers knobs that are readable without root, demonstrably move the
+/// latency tail, and are machine-global rather than per-run. Scheduling policy,
+/// `perf_event_paranoid`, and the GPU clock lock are stated protocol variables
+/// recorded in the artifact instead: the first two are properties of how the
+/// harness was launched, and NVML exposes no read-back for the third.
+pub fn locked_measurement_state_violations(specification: &MachineSpecification) -> Vec<String> {
+    let mut violations = Vec::new();
+    let central_processing_unit = &specification.central_processing_unit;
+
+    match &central_processing_unit.frequency_scaling_governor_per_policy {
+        ProbedValueOrUnavailableReason::Unavailable { reason } => violations.push(format!(
+            "cpufreq governor is unknown, which counts as unlocked: {reason}"
+        )),
+        ProbedValueOrUnavailableReason::Observed { value } => {
+            if value.is_empty() {
+                violations.push(
+                    "cpufreq exposed no policies, so the governor could not be confirmed"
+                        .to_string(),
+                );
+            }
+            let policies_not_on_performance: Vec<String> = value
+                .iter()
+                .filter(|observation| observation.observed_attribute != "performance")
+                .map(|observation| {
+                    format!(
+                        "policy{}={}",
+                        observation.policy_number, observation.observed_attribute
+                    )
+                })
+                .collect();
+            if !policies_not_on_performance.is_empty() {
+                violations.push(format!(
+                    "cpufreq governor is not `performance` on {}",
+                    policies_not_on_performance.join(", ")
+                ));
+            }
+        }
+    }
+
+    record_violation_unless_boolean_knob_matches(
+        &central_processing_unit.boost_is_enabled,
+        false,
+        "CPU boost/turbo",
+        &mut violations,
+    );
+
+    match &central_processing_unit.simultaneous_multithreading_control {
+        ProbedValueOrUnavailableReason::Unavailable { reason } => violations.push(format!(
+            "simultaneous multithreading state is unknown, which counts as unlocked: {reason}"
+        )),
+        ProbedValueOrUnavailableReason::Observed { value } => {
+            if !matches!(value.as_str(), "off" | "forceoff" | "notsupported") {
+                violations.push(format!(
+                    "simultaneous multithreading is `{value}`; a sibling thread sharing the core \
+                     is a tail-latency source"
+                ));
+            }
+        }
+    }
+
+    record_violation_unless_boolean_knob_matches(
+        &specification.memory.swap_is_enabled,
+        false,
+        "swap",
+        &mut violations,
+    );
+
+    match &specification.kernel.transparent_hugepage_policy {
+        ProbedValueOrUnavailableReason::Unavailable { reason } => violations.push(format!(
+            "transparent hugepage policy is unknown, which counts as unlocked: {reason}"
+        )),
+        ProbedValueOrUnavailableReason::Observed { value } => {
+            if value.as_str() == "always" {
+                violations.push(
+                    "transparent hugepages are set to `always`; khugepaged compaction stalls land \
+                     directly in the p99.9"
+                        .to_string(),
+                );
+            }
+        }
+    }
+
+    match &specification.graphics_processing_unit.persistence_mode {
+        ProbedValueOrUnavailableReason::Unavailable { reason } => violations.push(format!(
+            "GPU persistence mode is unknown, which counts as unlocked: {reason}"
+        )),
+        ProbedValueOrUnavailableReason::Observed { value } => {
+            if !value.eq_ignore_ascii_case("enabled") {
+                violations.push(format!(
+                    "GPU persistence mode is `{value}`; the driver unloads between clients and the \
+                     first submissions of a cell pay initialization the rest do not"
+                ));
+            }
+        }
+    }
+
+    match &specification
+        .machine_load_at_probe_time
+        .load_average_one_minute
+    {
+        ProbedValueOrUnavailableReason::Unavailable { reason } => violations.push(format!(
+            "one-minute load average is unknown, which counts as unlocked: {reason}"
+        )),
+        ProbedValueOrUnavailableReason::Observed { value } => {
+            if *value >= MAXIMUM_ONE_MINUTE_LOAD_AVERAGE_FOR_LOCKED_MEASUREMENT_STATE {
+                violations.push(format!(
+                    "one-minute load average is {value:.2}, at or above the \
+                     {MAXIMUM_ONE_MINUTE_LOAD_AVERAGE_FOR_LOCKED_MEASUREMENT_STATE:.2} ceiling; \
+                     other work was resident on the box"
+                ));
+            }
+        }
+    }
+
+    violations
+}
+
+/// The privileged commands that would clear this machine's violations, derived
+/// from what was actually observed. Data only — nothing here is ever executed,
+/// and `sudo` is never invoked by this crate.
+pub fn owner_checklist_to_reach_locked_measurement_state(
+    specification: &MachineSpecification,
+) -> Vec<OwnerPrivilegedCommandToReachLockedMeasurementState> {
+    let mut checklist = Vec::new();
+    let central_processing_unit = &specification.central_processing_unit;
+
+    let governors_already_locked = matches!(
+        &central_processing_unit.frequency_scaling_governor_per_policy,
+        ProbedValueOrUnavailableReason::Observed { value }
+            if !value.is_empty()
+                && value
+                    .iter()
+                    .all(|observation| observation.observed_attribute == "performance")
+    );
+    if !governors_already_locked {
+        checklist.push(OwnerPrivilegedCommandToReachLockedMeasurementState {
+            knob_description: "cpufreq governor on every policy".to_string(),
+            current_observed_state: describe_probed_value(
+                &central_processing_unit.frequency_scaling_governor_per_policy,
+                |governor_per_policy| {
+                    summarize_distinct_values(
+                        governor_per_policy
+                            .iter()
+                            .map(|observation| &observation.observed_attribute),
+                    )
+                },
+            ),
+            shell_command: "sudo cpupower frequency-set -g performance".to_string(),
+            reverting_shell_command: "sudo cpupower frequency-set -g schedutil".to_string(),
+        });
+    }
+
+    if !boolean_knob_is_observed_as(&central_processing_unit.boost_is_enabled, false) {
+        let boost_control_path = central_processing_unit
+            .boost_control_sysfs_path
+            .observed_value()
+            .cloned()
+            .unwrap_or_else(|| AMD_AND_ACPI_BOOST_SYSFS_PATH.to_string());
+        let boost_is_inverted_polarity = boost_control_path == INTEL_PSTATE_NO_TURBO_SYSFS_PATH;
+        let (disabling_value, enabling_value) = if boost_is_inverted_polarity {
+            ("1", "0")
+        } else {
+            ("0", "1")
+        };
+        checklist.push(OwnerPrivilegedCommandToReachLockedMeasurementState {
+            knob_description: "opportunistic CPU boost/turbo".to_string(),
+            current_observed_state: describe_probed_value(
+                &central_processing_unit.boost_is_enabled,
+                |is_enabled| if *is_enabled { "enabled" } else { "disabled" }.to_string(),
+            ),
+            shell_command: format!("echo {disabling_value} | sudo tee {boost_control_path}"),
+            reverting_shell_command: format!(
+                "echo {enabling_value} | sudo tee {boost_control_path}"
+            ),
+        });
+    }
+
+    let multithreading_already_off = matches!(
+        &central_processing_unit.simultaneous_multithreading_control,
+        ProbedValueOrUnavailableReason::Observed { value }
+            if matches!(value.as_str(), "off" | "forceoff" | "notsupported")
+    );
+    if !multithreading_already_off {
+        checklist.push(OwnerPrivilegedCommandToReachLockedMeasurementState {
+            knob_description: "simultaneous multithreading".to_string(),
+            current_observed_state: describe_probed_value(
+                &central_processing_unit.simultaneous_multithreading_control,
+                Clone::clone,
+            ),
+            shell_command: "echo off | sudo tee /sys/devices/system/cpu/smt/control".to_string(),
+            reverting_shell_command: "echo on | sudo tee /sys/devices/system/cpu/smt/control"
+                .to_string(),
+        });
+    }
+
+    let hugepage_policy_already_acceptable = matches!(
+        &specification.kernel.transparent_hugepage_policy,
+        ProbedValueOrUnavailableReason::Observed { value } if value.as_str() != "always"
+    );
+    if !hugepage_policy_already_acceptable {
+        checklist.push(OwnerPrivilegedCommandToReachLockedMeasurementState {
+            knob_description: "transparent hugepage policy".to_string(),
+            current_observed_state: describe_probed_value(
+                &specification.kernel.transparent_hugepage_policy,
+                Clone::clone,
+            ),
+            shell_command: format!("echo never | sudo tee {TRANSPARENT_HUGEPAGE_SYSFS_PATH}"),
+            reverting_shell_command: format!(
+                "echo madvise | sudo tee {TRANSPARENT_HUGEPAGE_SYSFS_PATH}"
+            ),
+        });
+    }
+
+    if !boolean_knob_is_observed_as(&specification.memory.swap_is_enabled, false) {
+        checklist.push(OwnerPrivilegedCommandToReachLockedMeasurementState {
+            knob_description: "swap".to_string(),
+            current_observed_state: describe_probed_value(
+                &specification.memory.swap_is_enabled,
+                |is_enabled| if *is_enabled { "enabled" } else { "disabled" }.to_string(),
+            ),
+            shell_command: "sudo swapoff -a".to_string(),
+            reverting_shell_command: "sudo swapon -a".to_string(),
+        });
+    }
+
+    let graphics_processing_unit = &specification.graphics_processing_unit;
+    let persistence_already_enabled = matches!(
+        &graphics_processing_unit.persistence_mode,
+        ProbedValueOrUnavailableReason::Observed { value } if value.eq_ignore_ascii_case("enabled")
+    );
+    if !persistence_already_enabled {
+        checklist.push(OwnerPrivilegedCommandToReachLockedMeasurementState {
+            knob_description: "GPU persistence mode".to_string(),
+            current_observed_state: describe_probed_value(
+                &graphics_processing_unit.persistence_mode,
+                Clone::clone,
+            ),
+            shell_command: "sudo nvidia-smi -pm 1".to_string(),
+            reverting_shell_command: "sudo nvidia-smi -pm 0".to_string(),
+        });
+    }
+
+    // NVML reports no locked-clock range back, so this entry is emitted on every
+    // run rather than gated on an observation, and it is deliberately not one of
+    // the violations `machine_is_in_locked_measurement_state` counts.
+    let graphics_clock_lock_megahertz = graphics_processing_unit
+        .maximum_graphics_clock_megahertz
+        .observed_value()
+        .map_or(1695, |maximum_megahertz| {
+            // Locking at the reported maximum invites thermal slowdown mid-cell;
+            // NVIDIA's rated boost clock sits near 80% of it.
+            (maximum_megahertz * 0.8).round() as i64
+        });
+    checklist.push(OwnerPrivilegedCommandToReachLockedMeasurementState {
+        knob_description: "GPU graphics clock lock (not readable back from NVML)".to_string(),
+        current_observed_state: describe_probed_value(
+            &graphics_processing_unit.current_graphics_clock_megahertz,
+            |megahertz| format!("{megahertz} MHz at probe time"),
+        ),
+        shell_command: format!(
+            "sudo nvidia-smi -i 0 --lock-gpu-clocks={graphics_clock_lock_megahertz},\
+             {graphics_clock_lock_megahertz}"
+        ),
+        reverting_shell_command: "sudo nvidia-smi -i 0 --reset-gpu-clocks".to_string(),
+    });
+
+    checklist
+}
+
+/// Serialize the specification to `machine-spec.json` under `directory_path`.
+pub fn write_machine_specification_json_file(
+    specification: &MachineSpecification,
+    directory_path: &Path,
+) -> std::io::Result<std::path::PathBuf> {
+    std::fs::create_dir_all(directory_path)?;
+    let file_path = directory_path.join(MACHINE_SPECIFICATION_JSON_FILE_NAME);
+    let serialized = serde_json::to_string_pretty(specification)
+        .map_err(|error| std::io::Error::other(error.to_string()))?;
+    std::fs::write(&file_path, serialized)?;
+    Ok(file_path)
+}
+
+fn record_violation_unless_boolean_knob_matches(
+    probed_knob: &ProbedValueOrUnavailableReason<bool>,
+    required_value: bool,
+    knob_description: &str,
+    violations: &mut Vec<String>,
+) {
+    match probed_knob {
+        ProbedValueOrUnavailableReason::Unavailable { reason } => violations.push(format!(
+            "{knob_description} state is unknown, which counts as unlocked: {reason}"
+        )),
+        ProbedValueOrUnavailableReason::Observed { value } => {
+            if *value != required_value {
+                violations.push(format!(
+                    "{knob_description} is {}, and a locked measurement state requires it {}",
+                    if *value { "enabled" } else { "disabled" },
+                    if required_value {
+                        "enabled"
+                    } else {
+                        "disabled"
+                    }
+                ));
+            }
+        }
+    }
+}
+
+fn boolean_knob_is_observed_as(
+    probed_knob: &ProbedValueOrUnavailableReason<bool>,
+    expected_value: bool,
+) -> bool {
+    probed_knob.observed_value() == Some(&expected_value)
+}
+
+fn describe_probed_value<ObservedValue>(
+    probed_value: &ProbedValueOrUnavailableReason<ObservedValue>,
+    describe_observation: impl Fn(&ObservedValue) -> String,
+) -> String {
+    match probed_value {
+        ProbedValueOrUnavailableReason::Observed { value } => describe_observation(value),
+        ProbedValueOrUnavailableReason::Unavailable { reason } => format!("unknown: {reason}"),
+    }
+}
+
+fn summarize_distinct_values<'a>(values: impl Iterator<Item = &'a String>) -> String {
+    let distinct: BTreeSet<&str> = values.map(String::as_str).collect();
+    if distinct.is_empty() {
+        "no values reported".to_string()
+    } else {
+        distinct.into_iter().collect::<Vec<_>>().join(", ")
+    }
+}
+
+fn read_trimmed_file_contents(path: impl AsRef<Path>) -> ProbedValueOrUnavailableReason<String> {
+    let path = path.as_ref();
+    match std::fs::read_to_string(path) {
+        Ok(contents) => ProbedValueOrUnavailableReason::observed(contents.trim().to_string()),
+        Err(error) => ProbedValueOrUnavailableReason::unavailable(format!(
+            "`{}` could not be read: {error}",
+            path.display()
+        )),
+    }
+}
+
+fn read_file_contents_parsed<ParsedValue>(
+    path: impl AsRef<Path>,
+) -> ProbedValueOrUnavailableReason<ParsedValue>
+where
+    ParsedValue: std::str::FromStr,
+    ParsedValue::Err: std::fmt::Display,
+{
+    let path = path.as_ref();
+    match read_trimmed_file_contents(path) {
+        ProbedValueOrUnavailableReason::Unavailable { reason } => {
+            ProbedValueOrUnavailableReason::unavailable(reason)
+        }
+        ProbedValueOrUnavailableReason::Observed { value } => match value.parse::<ParsedValue>() {
+            Ok(parsed) => ProbedValueOrUnavailableReason::observed(parsed),
+            Err(error) => ProbedValueOrUnavailableReason::unavailable(format!(
+                "`{}` held `{value}`, which did not parse: {error}",
+                path.display()
+            )),
+        },
+    }
+}
+
+fn read_sysfs_boolean_flag(path: &str) -> ProbedValueOrUnavailableReason<bool> {
+    match read_file_contents_parsed::<i64>(path) {
+        ProbedValueOrUnavailableReason::Observed { value } => {
+            ProbedValueOrUnavailableReason::observed(value != 0)
+        }
+        ProbedValueOrUnavailableReason::Unavailable { reason } => {
+            ProbedValueOrUnavailableReason::unavailable(reason)
+        }
+    }
+}
+
+fn run_command_capturing_trimmed_standard_output(
+    program: &str,
+    arguments: &[&str],
+) -> Result<String, String> {
+    let output = std::process::Command::new(program)
+        .args(arguments)
+        .output()
+        .map_err(|error| format!("`{program}` could not be executed: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "`{program}` exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn probe_unix_epoch_seconds() -> ProbedValueOrUnavailableReason<u64> {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(elapsed) => ProbedValueOrUnavailableReason::observed(elapsed.as_secs()),
+        Err(error) => ProbedValueOrUnavailableReason::unavailable(format!(
+            "the system clock is before the Unix epoch: {error}"
+        )),
+    }
+}
+
+fn probe_operating_system_pretty_name() -> ProbedValueOrUnavailableReason<String> {
+    match std::fs::read_to_string("/etc/os-release") {
+        Err(error) => ProbedValueOrUnavailableReason::unavailable(format!(
+            "`/etc/os-release` could not be read: {error}"
+        )),
+        Ok(contents) => contents
+            .lines()
+            .find_map(|line| line.strip_prefix("PRETTY_NAME="))
+            .map(|value| {
+                ProbedValueOrUnavailableReason::observed(value.trim().trim_matches('"').to_string())
+            })
+            .unwrap_or_else(|| {
+                ProbedValueOrUnavailableReason::unavailable(
+                    "`/etc/os-release` carried no PRETTY_NAME line".to_string(),
+                )
+            }),
+    }
+}
+
+fn probe_c_library_version() -> ProbedValueOrUnavailableReason<String> {
+    // SAFETY: `gnu_get_libc_version` returns a pointer to a static NUL-terminated
+    // string owned by glibc; it is never null and never freed.
+    let version = unsafe { CStr::from_ptr(libc::gnu_get_libc_version()) };
+    match version.to_str() {
+        Ok(version) => ProbedValueOrUnavailableReason::observed(version.to_string()),
+        Err(error) => ProbedValueOrUnavailableReason::unavailable(format!(
+            "`gnu_get_libc_version` returned non-UTF-8 bytes: {error}"
+        )),
+    }
+}
+
+fn probe_central_processing_unit() -> CentralProcessingUnitSpecification {
+    let (physical_core_count, logical_processor_count) = probe_processor_topology_counts();
+    let (boost_is_enabled, boost_control_sysfs_path) = probe_boost_state();
+
+    CentralProcessingUnitSpecification {
+        model_name: probe_processor_model_name(),
+        physical_core_count,
+        logical_processor_count,
+        logical_processor_count_available_to_this_process: match std::thread::available_parallelism(
+        ) {
+            Ok(count) => ProbedValueOrUnavailableReason::observed(count.get()),
+            Err(error) => ProbedValueOrUnavailableReason::unavailable(format!(
+                "`available_parallelism` failed: {error}"
+            )),
+        },
+        simultaneous_multithreading_control: read_trimmed_file_contents(
+            "/sys/devices/system/cpu/smt/control",
+        ),
+        frequency_scaling_driver: read_trimmed_file_contents(format!(
+            "{CPU_FREQUENCY_SCALING_SYSFS_DIRECTORY}/policy0/scaling_driver"
+        )),
+        frequency_scaling_governor_per_policy: probe_text_attribute_per_cpu_frequency_policy(
+            "scaling_governor",
+        ),
+        energy_performance_preference_per_policy: probe_text_attribute_per_cpu_frequency_policy(
+            "energy_performance_preference",
+        ),
+        current_frequency_megahertz_per_policy: probe_current_frequency_megahertz_per_policy(),
+        boost_is_enabled,
+        boost_control_sysfs_path,
+        isolated_processor_cpu_list: read_trimmed_file_contents("/sys/devices/system/cpu/isolated"),
+        tickless_processor_cpu_list: read_trimmed_file_contents(
+            "/sys/devices/system/cpu/nohz_full",
+        ),
+    }
+}
+
+fn probe_processor_model_name() -> ProbedValueOrUnavailableReason<String> {
+    match std::fs::read_to_string("/proc/cpuinfo") {
+        Err(error) => ProbedValueOrUnavailableReason::unavailable(format!(
+            "`/proc/cpuinfo` could not be read: {error}"
+        )),
+        Ok(contents) => contents
+            .lines()
+            .find(|line| line.starts_with("model name"))
+            .and_then(|line| line.split_once(':'))
+            .map(|(_, model_name)| {
+                ProbedValueOrUnavailableReason::observed(model_name.trim().to_string())
+            })
+            .unwrap_or_else(|| {
+                ProbedValueOrUnavailableReason::unavailable(
+                    "`/proc/cpuinfo` carried no `model name` line".to_string(),
+                )
+            }),
+    }
+}
+
+fn probe_processor_topology_counts() -> (
+    ProbedValueOrUnavailableReason<usize>,
+    ProbedValueOrUnavailableReason<usize>,
+) {
+    let entries = match std::fs::read_dir(CPU_TOPOLOGY_SYSFS_DIRECTORY) {
+        Ok(entries) => entries,
+        Err(error) => {
+            let reason = format!("`{CPU_TOPOLOGY_SYSFS_DIRECTORY}` could not be listed: {error}");
+            return (
+                ProbedValueOrUnavailableReason::unavailable(reason.clone()),
+                ProbedValueOrUnavailableReason::unavailable(reason),
+            );
+        }
+    };
+
+    let mut distinct_physical_cores: BTreeSet<(String, String)> = BTreeSet::new();
+    let mut logical_processor_count = 0usize;
+    for entry in entries.flatten() {
+        let entry_name = entry.file_name().to_string_lossy().into_owned();
+        let Some(processor_number) = entry_name.strip_prefix("cpu") else {
+            continue;
+        };
+        if !processor_number
+            .chars()
+            .all(|character| character.is_ascii_digit())
+            || processor_number.is_empty()
+        {
+            continue;
+        }
+        logical_processor_count += 1;
+        let topology_directory = entry.path().join("topology");
+        let package_identifier =
+            read_trimmed_file_contents(topology_directory.join("physical_package_id"));
+        let core_identifier = read_trimmed_file_contents(topology_directory.join("core_id"));
+        if let (Some(package_identifier), Some(core_identifier)) = (
+            package_identifier.observed_value(),
+            core_identifier.observed_value(),
+        ) {
+            distinct_physical_cores.insert((package_identifier.clone(), core_identifier.clone()));
+        }
+    }
+
+    let physical_core_count = if distinct_physical_cores.is_empty() {
+        ProbedValueOrUnavailableReason::unavailable(format!(
+            "no `{CPU_TOPOLOGY_SYSFS_DIRECTORY}/cpu*/topology` entry exposed both \
+             physical_package_id and core_id"
+        ))
+    } else {
+        ProbedValueOrUnavailableReason::observed(distinct_physical_cores.len())
+    };
+    let logical_processor_count = if logical_processor_count == 0 {
+        ProbedValueOrUnavailableReason::unavailable(format!(
+            "`{CPU_TOPOLOGY_SYSFS_DIRECTORY}` listed no `cpuN` entries"
+        ))
+    } else {
+        ProbedValueOrUnavailableReason::observed(logical_processor_count)
+    };
+    (physical_core_count, logical_processor_count)
+}
+
+fn read_cpu_frequency_policy_numbers() -> Result<Vec<u32>, String> {
+    let entries = std::fs::read_dir(CPU_FREQUENCY_SCALING_SYSFS_DIRECTORY).map_err(|error| {
+        format!("`{CPU_FREQUENCY_SCALING_SYSFS_DIRECTORY}` could not be listed: {error}")
+    })?;
+    let mut policy_numbers: Vec<u32> = entries
+        .flatten()
+        .filter_map(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .strip_prefix("policy")
+                .and_then(|policy_number| policy_number.parse::<u32>().ok())
+        })
+        .collect();
+    policy_numbers.sort_unstable();
+    Ok(policy_numbers)
+}
+
+fn probe_text_attribute_per_cpu_frequency_policy(
+    attribute_file_name: &str,
+) -> ProbedValueOrUnavailableReason<Vec<CpuFrequencyPolicyObservation<String>>> {
+    let policy_numbers = match read_cpu_frequency_policy_numbers() {
+        Ok(policy_numbers) => policy_numbers,
+        Err(reason) => return ProbedValueOrUnavailableReason::unavailable(reason),
+    };
+    let mut observations = Vec::new();
+    for policy_number in &policy_numbers {
+        let path = format!(
+            "{CPU_FREQUENCY_SCALING_SYSFS_DIRECTORY}/policy{policy_number}/{attribute_file_name}"
+        );
+        if let Some(value) = read_trimmed_file_contents(&path).observed_value() {
+            observations.push(CpuFrequencyPolicyObservation {
+                policy_number: *policy_number,
+                observed_attribute: value.clone(),
+            });
+        }
+    }
+    if observations.is_empty() && !policy_numbers.is_empty() {
+        return ProbedValueOrUnavailableReason::unavailable(format!(
+            "none of the {} cpufreq policies exposed `{attribute_file_name}`",
+            policy_numbers.len()
+        ));
+    }
+    ProbedValueOrUnavailableReason::observed(observations)
+}
+
+fn probe_current_frequency_megahertz_per_policy()
+-> ProbedValueOrUnavailableReason<Vec<CpuFrequencyPolicyObservation<f64>>> {
+    let policy_numbers = match read_cpu_frequency_policy_numbers() {
+        Ok(policy_numbers) => policy_numbers,
+        Err(reason) => return ProbedValueOrUnavailableReason::unavailable(reason),
+    };
+    let mut observations = Vec::new();
+    for policy_number in &policy_numbers {
+        let path = format!(
+            "{CPU_FREQUENCY_SCALING_SYSFS_DIRECTORY}/policy{policy_number}/scaling_cur_freq"
+        );
+        // sysfs reports cpufreq frequencies in kHz.
+        if let Some(kilohertz) = read_file_contents_parsed::<f64>(&path).observed_value() {
+            observations.push(CpuFrequencyPolicyObservation {
+                policy_number: *policy_number,
+                observed_attribute: kilohertz / 1000.0,
+            });
+        }
+    }
+    if observations.is_empty() && !policy_numbers.is_empty() {
+        return ProbedValueOrUnavailableReason::unavailable(format!(
+            "none of the {} cpufreq policies exposed `scaling_cur_freq`",
+            policy_numbers.len()
+        ));
+    }
+    ProbedValueOrUnavailableReason::observed(observations)
+}
+
+fn probe_boost_state() -> (
+    ProbedValueOrUnavailableReason<bool>,
+    ProbedValueOrUnavailableReason<String>,
+) {
+    // The two cpufreq driver families spell boost differently and with opposite
+    // polarity: `cpufreq/boost` is 1 when boost is ON, `intel_pstate/no_turbo`
+    // is 1 when boost is OFF.
+    if let Some(boost_is_enabled) =
+        read_sysfs_boolean_flag(AMD_AND_ACPI_BOOST_SYSFS_PATH).observed_value()
+    {
+        return (
+            ProbedValueOrUnavailableReason::observed(*boost_is_enabled),
+            ProbedValueOrUnavailableReason::observed(AMD_AND_ACPI_BOOST_SYSFS_PATH.to_string()),
+        );
+    }
+    if let Some(turbo_is_disabled) =
+        read_sysfs_boolean_flag(INTEL_PSTATE_NO_TURBO_SYSFS_PATH).observed_value()
+    {
+        return (
+            ProbedValueOrUnavailableReason::observed(!*turbo_is_disabled),
+            ProbedValueOrUnavailableReason::observed(INTEL_PSTATE_NO_TURBO_SYSFS_PATH.to_string()),
+        );
+    }
+    let reason = format!(
+        "neither `{AMD_AND_ACPI_BOOST_SYSFS_PATH}` nor `{INTEL_PSTATE_NO_TURBO_SYSFS_PATH}` \
+         was readable"
+    );
+    (
+        ProbedValueOrUnavailableReason::unavailable(reason.clone()),
+        ProbedValueOrUnavailableReason::unavailable(reason),
+    )
+}
+
+fn probe_kernel() -> KernelSpecification {
+    let release = read_trimmed_file_contents("/proc/sys/kernel/osrelease");
+    let version_banner = read_trimmed_file_contents("/proc/sys/kernel/version");
+    let build_configuration = release
+        .observed_value()
+        .map(|release| read_trimmed_file_contents(format!("/boot/config-{release}")));
+
+    KernelSpecification {
+        build_preemption_model: probe_build_preemption_model(&version_banner),
+        is_preempt_realtime: probe_is_preempt_realtime(
+            &version_banner,
+            build_configuration.as_ref(),
+        ),
+        runtime_preemption_mode: read_trimmed_file_contents(RUNTIME_PREEMPTION_MODE_DEBUGFS_PATH),
+        boot_command_line: read_trimmed_file_contents("/proc/cmdline"),
+        transparent_hugepage_policy: probe_transparent_hugepage_policy(),
+        address_space_layout_randomization_level: read_file_contents_parsed(
+            "/proc/sys/kernel/randomize_va_space",
+        ),
+        realtime_scheduler_runtime_microseconds: read_file_contents_parsed(
+            "/proc/sys/kernel/sched_rt_runtime_us",
+        ),
+        timer_migration_is_enabled: read_sysfs_boolean_flag("/proc/sys/kernel/timer_migration"),
+        performance_event_paranoid_level: read_file_contents_parsed(
+            "/proc/sys/kernel/perf_event_paranoid",
+        ),
+        release,
+        version_banner,
+    }
+}
+
+fn probe_build_preemption_model(
+    version_banner: &ProbedValueOrUnavailableReason<String>,
+) -> ProbedValueOrUnavailableReason<String> {
+    match version_banner {
+        ProbedValueOrUnavailableReason::Unavailable { reason } => {
+            ProbedValueOrUnavailableReason::unavailable(format!(
+                "the kernel build banner was unreadable: {reason}"
+            ))
+        }
+        ProbedValueOrUnavailableReason::Observed { value } => value
+            .split_whitespace()
+            .find(|token| token.starts_with("PREEMPT"))
+            .map(|token| ProbedValueOrUnavailableReason::observed(token.to_string()))
+            .unwrap_or_else(|| {
+                ProbedValueOrUnavailableReason::unavailable(format!(
+                    "the kernel build banner `{value}` carried no PREEMPT token"
+                ))
+            }),
+    }
+}
+
+fn probe_is_preempt_realtime(
+    version_banner: &ProbedValueOrUnavailableReason<String>,
+    build_configuration: Option<&ProbedValueOrUnavailableReason<String>>,
+) -> ProbedValueOrUnavailableReason<bool> {
+    if let Some(ProbedValueOrUnavailableReason::Observed { value }) = build_configuration {
+        return ProbedValueOrUnavailableReason::observed(
+            value
+                .lines()
+                .any(|line| line.trim() == "CONFIG_PREEMPT_RT=y"),
+        );
+    }
+    match version_banner {
+        ProbedValueOrUnavailableReason::Observed { value } => {
+            ProbedValueOrUnavailableReason::observed(
+                value.split_whitespace().any(|token| token == "PREEMPT_RT"),
+            )
+        }
+        ProbedValueOrUnavailableReason::Unavailable { reason } => {
+            ProbedValueOrUnavailableReason::unavailable(format!(
+                "neither `/boot/config-<release>` nor the kernel build banner was readable: \
+                 {reason}"
+            ))
+        }
+    }
+}
+
+fn probe_transparent_hugepage_policy() -> ProbedValueOrUnavailableReason<String> {
+    // The file lists every policy and brackets the active one:
+    // `always [madvise] never`.
+    match read_trimmed_file_contents(TRANSPARENT_HUGEPAGE_SYSFS_PATH) {
+        ProbedValueOrUnavailableReason::Unavailable { reason } => {
+            ProbedValueOrUnavailableReason::unavailable(reason)
+        }
+        ProbedValueOrUnavailableReason::Observed { value } => value
+            .split_whitespace()
+            .find_map(|token| {
+                token
+                    .strip_prefix('[')
+                    .and_then(|token| token.strip_suffix(']'))
+            })
+            .map(|selected| ProbedValueOrUnavailableReason::observed(selected.to_string()))
+            .unwrap_or_else(|| {
+                ProbedValueOrUnavailableReason::unavailable(format!(
+                    "`{TRANSPARENT_HUGEPAGE_SYSFS_PATH}` held `{value}`, which bracketed no \
+                     selected policy"
+                ))
+            }),
+    }
+}
+
+/// Field order of the single `nvidia-smi` query this module issues. Verified
+/// against driver 595.84 — `clocks.applications.graphics` is deliberately
+/// absent because that driver answers it with "Requested functionality has
+/// been deprecated" rather than a value.
+const NVIDIA_SMI_QUERY_FIELDS: &str = "name,driver_version,persistence_mode,pstate,memory.total,\
+     power.limit,clocks.current.graphics,clocks.max.graphics,clocks.current.memory,\
+     clocks_event_reasons.active,compute_mode";
+
+fn probe_graphics_processing_unit() -> GraphicsProcessingUnitSpecification {
+    let graphics_clock_lock_state = ProbedValueOrUnavailableReason::unavailable(
+        "NVML exposes no read-back for the `--lock-gpu-clocks` range, and this probe never \
+         escalates to root; the lock is a stated protocol variable, not a probed one"
+            .to_string(),
+    );
+
+    let query_output = run_command_capturing_trimmed_standard_output(
+        "nvidia-smi",
+        &[
+            &format!("--query-gpu={NVIDIA_SMI_QUERY_FIELDS}"),
+            "--format=csv,noheader,nounits",
+            "-i",
+            "0",
+        ],
+    );
+    let first_device_line = match query_output {
+        Err(reason) => {
+            return unavailable_graphics_processing_unit(&reason, graphics_clock_lock_state);
+        }
+        Ok(output) => match output.lines().next().map(str::to_string) {
+            Some(line) => line,
+            None => {
+                return unavailable_graphics_processing_unit(
+                    "`nvidia-smi` printed no device rows",
+                    graphics_clock_lock_state,
+                );
+            }
+        },
+    };
+
+    let fields: Vec<String> = first_device_line
+        .split(',')
+        .map(|field| field.trim().to_string())
+        .collect();
+    let expected_field_count = NVIDIA_SMI_QUERY_FIELDS.split(',').count();
+    if fields.len() != expected_field_count {
+        return unavailable_graphics_processing_unit(
+            &format!(
+                "`nvidia-smi` returned {} comma-separated fields, expected {expected_field_count}: \
+                 `{first_device_line}`",
+                fields.len()
+            ),
+            graphics_clock_lock_state,
+        );
+    }
+
+    let text_field = |index: usize| -> ProbedValueOrUnavailableReason<String> {
+        let field = &fields[index];
+        if field.is_empty() || field.starts_with("[N/A") || field.starts_with("[Not") {
+            ProbedValueOrUnavailableReason::unavailable(format!(
+                "`nvidia-smi` reported `{field}` for query field {index}"
+            ))
+        } else {
+            ProbedValueOrUnavailableReason::observed(field.clone())
+        }
+    };
+    let numeric_field = |index: usize| -> ProbedValueOrUnavailableReason<f64> {
+        match text_field(index) {
+            ProbedValueOrUnavailableReason::Unavailable { reason } => {
+                ProbedValueOrUnavailableReason::unavailable(reason)
+            }
+            ProbedValueOrUnavailableReason::Observed { value } => match value.parse::<f64>() {
+                Ok(parsed) => ProbedValueOrUnavailableReason::observed(parsed),
+                Err(error) => ProbedValueOrUnavailableReason::unavailable(format!(
+                    "`nvidia-smi` query field {index} held `{value}`, which did not parse: {error}"
+                )),
+            },
+        }
+    };
+
+    GraphicsProcessingUnitSpecification {
+        model_name: text_field(0),
+        driver_version: text_field(1),
+        persistence_mode: text_field(2),
+        performance_state: text_field(3),
+        total_memory_mebibytes: numeric_field(4),
+        power_limit_watts: numeric_field(5),
+        current_graphics_clock_megahertz: numeric_field(6),
+        maximum_graphics_clock_megahertz: numeric_field(7),
+        current_memory_clock_megahertz: numeric_field(8),
+        active_clock_event_reasons_bitmask: text_field(9),
+        compute_mode: text_field(10),
+        graphics_clock_lock_state,
+    }
+}
+
+fn unavailable_graphics_processing_unit(
+    reason: &str,
+    graphics_clock_lock_state: ProbedValueOrUnavailableReason<String>,
+) -> GraphicsProcessingUnitSpecification {
+    let unavailable_text =
+        || ProbedValueOrUnavailableReason::<String>::unavailable(reason.to_string());
+    let unavailable_number =
+        || ProbedValueOrUnavailableReason::<f64>::unavailable(reason.to_string());
+    GraphicsProcessingUnitSpecification {
+        model_name: unavailable_text(),
+        driver_version: unavailable_text(),
+        persistence_mode: unavailable_text(),
+        performance_state: unavailable_text(),
+        compute_mode: unavailable_text(),
+        total_memory_mebibytes: unavailable_number(),
+        power_limit_watts: unavailable_number(),
+        current_graphics_clock_megahertz: unavailable_number(),
+        maximum_graphics_clock_megahertz: unavailable_number(),
+        current_memory_clock_megahertz: unavailable_number(),
+        active_clock_event_reasons_bitmask: unavailable_text(),
+        graphics_clock_lock_state,
+    }
+}
+
+fn probe_memory() -> MemorySpecification {
+    let meminfo_contents = match std::fs::read_to_string("/proc/meminfo") {
+        Ok(contents) => contents,
+        Err(error) => {
+            let reason = format!("`/proc/meminfo` could not be read: {error}");
+            return MemorySpecification {
+                total_kibibytes: ProbedValueOrUnavailableReason::unavailable(reason.clone()),
+                available_kibibytes: ProbedValueOrUnavailableReason::unavailable(reason.clone()),
+                swap_total_kibibytes: ProbedValueOrUnavailableReason::unavailable(reason.clone()),
+                swap_used_kibibytes: ProbedValueOrUnavailableReason::unavailable(reason.clone()),
+                swap_is_enabled: ProbedValueOrUnavailableReason::unavailable(reason),
+            };
+        }
+    };
+
+    let read_kibibytes = |key: &str| -> ProbedValueOrUnavailableReason<u64> {
+        // Every size line is `Key:<whitespace><number> kB`.
+        meminfo_contents
+            .lines()
+            .find_map(|line| line.strip_prefix(&format!("{key}:")))
+            .and_then(|remainder| remainder.split_whitespace().next())
+            .map(|number| match number.parse::<u64>() {
+                Ok(parsed) => ProbedValueOrUnavailableReason::observed(parsed),
+                Err(error) => ProbedValueOrUnavailableReason::unavailable(format!(
+                    "`/proc/meminfo` line `{key}` held `{number}`, which did not parse: {error}"
+                )),
+            })
+            .unwrap_or_else(|| {
+                ProbedValueOrUnavailableReason::unavailable(format!(
+                    "`/proc/meminfo` carried no `{key}` line"
+                ))
+            })
+    };
+
+    let swap_total_kibibytes = read_kibibytes("SwapTotal");
+    let swap_free_kibibytes = read_kibibytes("SwapFree");
+    let swap_used_kibibytes = match (
+        swap_total_kibibytes.observed_value(),
+        swap_free_kibibytes.observed_value(),
+    ) {
+        (Some(total), Some(free)) => {
+            ProbedValueOrUnavailableReason::observed(total.saturating_sub(*free))
+        }
+        _ => ProbedValueOrUnavailableReason::unavailable(
+            "`/proc/meminfo` did not carry both SwapTotal and SwapFree".to_string(),
+        ),
+    };
+    let swap_is_enabled = match swap_total_kibibytes.observed_value() {
+        Some(total) => ProbedValueOrUnavailableReason::observed(*total > 0),
+        None => ProbedValueOrUnavailableReason::unavailable(
+            "`/proc/meminfo` carried no `SwapTotal` line".to_string(),
+        ),
+    };
+
+    MemorySpecification {
+        total_kibibytes: read_kibibytes("MemTotal"),
+        available_kibibytes: read_kibibytes("MemAvailable"),
+        swap_total_kibibytes,
+        swap_used_kibibytes,
+        swap_is_enabled,
+    }
+}
+
+/// Emitted by the interpreter the subprocess arm actually launches, so the
+/// recorded numpy is the one that arm imports rather than one linked at build
+/// time.
+const PYTHON_RUNTIME_PROBE_SOURCE: &str = "import json, sys\n\
+     report = {'executable': sys.executable, 'version': sys.version.split()[0],\n\
+     'version_banner': sys.version, 'gil_disabled': not getattr(sys, '_is_gil_enabled', \
+     lambda: True)()}\n\
+     try:\n\
+     \x20   import numpy\n\
+     \x20   report['numpy_version'] = numpy.__version__\n\
+     except Exception as import_failure:\n\
+     \x20   report['numpy_import_failure'] = repr(import_failure)\n\
+     print(json.dumps(report))\n";
+
+fn probe_python_runtime() -> PythonRuntimeSpecification {
+    let unavailable_python = |reason: String| PythonRuntimeSpecification {
+        interpreter_executable_path: ProbedValueOrUnavailableReason::unavailable(reason.clone()),
+        interpreter_version: ProbedValueOrUnavailableReason::unavailable(reason.clone()),
+        interpreter_version_banner: ProbedValueOrUnavailableReason::unavailable(reason.clone()),
+        numpy_version: ProbedValueOrUnavailableReason::unavailable(reason.clone()),
+        global_interpreter_lock_is_disabled: ProbedValueOrUnavailableReason::unavailable(reason),
+    };
+
+    let report_json = match run_command_capturing_trimmed_standard_output(
+        "python3",
+        &["-c", PYTHON_RUNTIME_PROBE_SOURCE],
+    ) {
+        Ok(report_json) => report_json,
+        Err(reason) => return unavailable_python(reason),
+    };
+    let report: serde_json::Value = match serde_json::from_str(&report_json) {
+        Ok(report) => report,
+        Err(error) => {
+            return unavailable_python(format!(
+                "the python3 probe printed `{report_json}`, which is not JSON: {error}"
+            ));
+        }
+    };
+
+    let text_member = |key: &str| match report.get(key).and_then(serde_json::Value::as_str) {
+        Some(value) => ProbedValueOrUnavailableReason::observed(value.to_string()),
+        None => ProbedValueOrUnavailableReason::unavailable(format!(
+            "the python3 probe report carried no `{key}`"
+        )),
+    };
+
+    let numpy_version = match report
+        .get("numpy_version")
+        .and_then(serde_json::Value::as_str)
+    {
+        Some(version) => ProbedValueOrUnavailableReason::observed(version.to_string()),
+        None => ProbedValueOrUnavailableReason::unavailable(
+            report
+                .get("numpy_import_failure")
+                .and_then(serde_json::Value::as_str)
+                .map(|failure| {
+                    format!("`import numpy` failed in the probed interpreter: {failure}")
+                })
+                .unwrap_or_else(|| {
+                    "the python3 probe report carried neither `numpy_version` nor \
+                     `numpy_import_failure`"
+                        .to_string()
+                }),
+        ),
+    };
+
+    PythonRuntimeSpecification {
+        interpreter_executable_path: text_member("executable"),
+        interpreter_version: text_member("version"),
+        interpreter_version_banner: text_member("version_banner"),
+        numpy_version,
+        global_interpreter_lock_is_disabled: match report
+            .get("gil_disabled")
+            .and_then(serde_json::Value::as_bool)
+        {
+            Some(is_disabled) => ProbedValueOrUnavailableReason::observed(is_disabled),
+            None => ProbedValueOrUnavailableReason::unavailable(
+                "the python3 probe report carried no `gil_disabled`".to_string(),
+            ),
+        },
+    }
+}
+
+fn probe_process_scheduling() -> ProbingProcessSchedulingSpecification {
+    // SAFETY: pid 0 means "the calling process"; the call reads no memory.
+    let raw_policy = unsafe { libc::sched_getscheduler(0) };
+    let (scheduling_policy_number, scheduling_policy_name, scheduling_policy_resets_on_fork) =
+        if raw_policy < 0 {
+            let error = std::io::Error::last_os_error();
+            let reason = format!("`sched_getscheduler(0)` failed: {error}");
+            (
+                ProbedValueOrUnavailableReason::unavailable(reason.clone()),
+                ProbedValueOrUnavailableReason::unavailable(reason.clone()),
+                ProbedValueOrUnavailableReason::unavailable(reason),
+            )
+        } else {
+            let resets_on_fork = raw_policy & libc::SCHED_RESET_ON_FORK != 0;
+            let policy = raw_policy & !libc::SCHED_RESET_ON_FORK;
+            (
+                ProbedValueOrUnavailableReason::observed(policy),
+                ProbedValueOrUnavailableReason::observed(scheduling_policy_name_for_number(policy)),
+                ProbedValueOrUnavailableReason::observed(resets_on_fork),
+            )
+        };
+
+    let mut scheduling_parameters = libc::sched_param { sched_priority: 0 };
+    // SAFETY: `scheduling_parameters` is a valid, initialized out-parameter.
+    let parameter_return_code = unsafe { libc::sched_getparam(0, &mut scheduling_parameters) };
+    let realtime_priority = if parameter_return_code < 0 {
+        ProbedValueOrUnavailableReason::unavailable(format!(
+            "`sched_getparam(0)` failed: {}",
+            std::io::Error::last_os_error()
+        ))
+    } else {
+        ProbedValueOrUnavailableReason::observed(scheduling_parameters.sched_priority)
+    };
+
+    ProbingProcessSchedulingSpecification {
+        scheduling_policy_name,
+        scheduling_policy_number,
+        scheduling_policy_resets_on_fork,
+        realtime_priority,
+        niceness: probe_niceness(),
+    }
+}
+
+fn scheduling_policy_name_for_number(policy: libc::c_int) -> String {
+    match policy {
+        libc::SCHED_OTHER => "SCHED_OTHER".to_string(),
+        libc::SCHED_FIFO => "SCHED_FIFO".to_string(),
+        libc::SCHED_RR => "SCHED_RR".to_string(),
+        libc::SCHED_BATCH => "SCHED_BATCH".to_string(),
+        libc::SCHED_IDLE => "SCHED_IDLE".to_string(),
+        6 => "SCHED_DEADLINE".to_string(),
+        other => format!("unrecognized scheduling policy {other}"),
+    }
+}
+
+fn probe_niceness() -> ProbedValueOrUnavailableReason<i32> {
+    // `getpriority` returns -1 both for the legitimate niceness -1 and for
+    // failure, so errno must be cleared first and re-read to tell them apart.
+    // SAFETY: `__errno_location` returns this thread's errno slot, which is
+    // valid for the life of the thread.
+    unsafe { *libc::__errno_location() = 0 };
+    // SAFETY: `getpriority` reads no caller memory; who=0 means this process.
+    let niceness = unsafe { libc::getpriority(libc::PRIO_PROCESS, 0) };
+    // SAFETY: same slot as above.
+    let errno_after_call = unsafe { *libc::__errno_location() };
+    if niceness == -1 && errno_after_call != 0 {
+        return ProbedValueOrUnavailableReason::unavailable(format!(
+            "`getpriority(PRIO_PROCESS, 0)` failed: {}",
+            std::io::Error::from_raw_os_error(errno_after_call)
+        ));
+    }
+    ProbedValueOrUnavailableReason::observed(niceness)
+}
+
+fn probe_machine_load() -> MachineLoadSpecification {
+    // `/proc/loadavg` is `<1m> <5m> <15m> <runnable>/<total> <last pid>`.
+    let loadavg_contents = match read_trimmed_file_contents("/proc/loadavg") {
+        ProbedValueOrUnavailableReason::Observed { value } => value,
+        ProbedValueOrUnavailableReason::Unavailable { reason } => {
+            return MachineLoadSpecification {
+                load_average_one_minute: ProbedValueOrUnavailableReason::unavailable(
+                    reason.clone(),
+                ),
+                load_average_five_minutes: ProbedValueOrUnavailableReason::unavailable(
+                    reason.clone(),
+                ),
+                load_average_fifteen_minutes: ProbedValueOrUnavailableReason::unavailable(
+                    reason.clone(),
+                ),
+                runnable_scheduling_entity_count: ProbedValueOrUnavailableReason::unavailable(
+                    reason.clone(),
+                ),
+                total_scheduling_entity_count: ProbedValueOrUnavailableReason::unavailable(reason),
+            };
+        }
+    };
+
+    let fields: Vec<&str> = loadavg_contents.split_whitespace().collect();
+    let load_average = |index: usize| -> ProbedValueOrUnavailableReason<f64> {
+        match fields.get(index) {
+            None => ProbedValueOrUnavailableReason::unavailable(format!(
+                "`/proc/loadavg` held `{loadavg_contents}`, which has no field {index}"
+            )),
+            Some(field) => match field.parse::<f64>() {
+                Ok(parsed) => ProbedValueOrUnavailableReason::observed(parsed),
+                Err(error) => ProbedValueOrUnavailableReason::unavailable(format!(
+                    "`/proc/loadavg` field {index} held `{field}`, which did not parse: {error}"
+                )),
+            },
+        }
+    };
+
+    let entity_counts = fields.get(3).and_then(|field| field.split_once('/'));
+    let entity_count = |selected: Option<&str>| -> ProbedValueOrUnavailableReason<u64> {
+        match selected {
+            None => ProbedValueOrUnavailableReason::unavailable(format!(
+                "`/proc/loadavg` held `{loadavg_contents}`, whose fourth field is not \
+                 `<runnable>/<total>`"
+            )),
+            Some(count) => match count.parse::<u64>() {
+                Ok(parsed) => ProbedValueOrUnavailableReason::observed(parsed),
+                Err(error) => ProbedValueOrUnavailableReason::unavailable(format!(
+                    "`/proc/loadavg` entity count `{count}` did not parse: {error}"
+                )),
+            },
+        }
+    };
+
+    MachineLoadSpecification {
+        load_average_one_minute: load_average(0),
+        load_average_five_minutes: load_average(1),
+        load_average_fifteen_minutes: load_average(2),
+        runnable_scheduling_entity_count: entity_count(entity_counts.map(|(runnable, _)| runnable)),
+        total_scheduling_entity_count: entity_count(entity_counts.map(|(_, total)| total)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Guards against a probe path that panics or aborts the harness before a
+    /// single measurement is taken, on any field.
+    #[test]
+    fn probing_the_machine_produces_a_serializable_specification() {
+        let specification = probe_machine_specification();
+        assert_eq!(
+            specification.machine_specification_schema_version,
+            MACHINE_SPECIFICATION_SCHEMA_VERSION
+        );
+        let serialized = serde_json::to_string_pretty(&specification)
+            .expect("a machine specification must always serialize");
+        assert!(serialized.contains("central_processing_unit"));
+        assert!(serialized.contains("probe_outcome"));
+    }
+
+    /// Guards against a serde attribute change that makes `machine-spec.json`
+    /// unreadable by the report tool that has to consume it later.
+    #[test]
+    fn the_machine_specification_json_round_trips_byte_for_byte() {
+        let specification = probe_machine_specification();
+        let first_serialization = serde_json::to_string_pretty(&specification)
+            .expect("a machine specification must always serialize");
+        let deserialized: MachineSpecification = serde_json::from_str(&first_serialization)
+            .expect("a machine specification must deserialize from its own output");
+        let second_serialization = serde_json::to_string_pretty(&deserialized)
+            .expect("a round-tripped machine specification must serialize");
+        assert_eq!(first_serialization, second_serialization);
+    }
+
+    /// Guards against the gate silently treating an unreadable knob as locked,
+    /// which would let a gated cell run on an unknown machine state.
+    #[test]
+    fn an_unknown_knob_is_never_counted_as_a_locked_measurement_state() {
+        let mut specification = probe_machine_specification();
+        specification.central_processing_unit.boost_is_enabled =
+            ProbedValueOrUnavailableReason::unavailable(
+                "synthetic: the boost sysfs file was removed".to_string(),
+            );
+
+        assert!(!machine_is_in_locked_measurement_state(&specification));
+        let violations = locked_measurement_state_violations(&specification);
+        assert!(
+            violations
+                .iter()
+                .any(|violation| violation.contains("boost") && violation.contains("unknown")),
+            "the boost violation must name the knob and say it is unknown: {violations:?}"
+        );
+    }
+
+    /// Guards against an unknown knob being papered over by an owner checklist
+    /// that omits the command needed to resolve it.
+    #[test]
+    fn an_unknown_knob_still_yields_an_owner_command_to_lock_it() {
+        let mut specification = probe_machine_specification();
+        specification.memory.swap_is_enabled = ProbedValueOrUnavailableReason::unavailable(
+            "synthetic: /proc/meminfo was unreadable".to_string(),
+        );
+
+        let checklist = owner_checklist_to_reach_locked_measurement_state(&specification);
+        let swap_command = checklist
+            .iter()
+            .find(|command| command.knob_description == "swap")
+            .expect("an unknown swap state must still produce a swapoff command");
+        assert_eq!(swap_command.shell_command, "sudo swapoff -a");
+        assert!(swap_command.current_observed_state.starts_with("unknown:"));
+    }
+
+    /// Guards against a missing sysfs file on a different machine turning into a
+    /// panic or an empty-string default instead of a recorded reason.
+    #[test]
+    fn a_probe_pointed_at_a_nonexistent_sysfs_path_records_a_reason() {
+        let missing_path = "/sys/devices/system/cpu/cpufreq/policy_that_does_not_exist/governor";
+
+        let text_probe = read_trimmed_file_contents(missing_path);
+        let text_reason = text_probe
+            .unavailable_reason()
+            .expect("a missing sysfs file must record a reason, not an empty string");
+        assert!(text_reason.contains(missing_path));
+        assert!(text_probe.observed_value().is_none());
+
+        let numeric_probe = read_file_contents_parsed::<i64>(missing_path);
+        assert!(numeric_probe.unavailable_reason().is_some());
+
+        let flag_probe = read_sysfs_boolean_flag(missing_path);
+        assert!(flag_probe.unavailable_reason().is_some());
+    }
+
+    /// Guards against a sysfs file that exists but holds an unparseable value
+    /// being reported as a plausible-looking zero.
+    #[test]
+    fn an_unparseable_sysfs_value_records_a_reason_rather_than_a_default() {
+        let probe = read_file_contents_parsed::<i64>("/proc/sys/kernel/osrelease");
+        let reason = probe
+            .unavailable_reason()
+            .expect("a kernel release string must not parse as an integer");
+        assert!(reason.contains("did not parse"));
+    }
+
+    /// Guards against a reference lock step that cannot be undone, which would
+    /// leave the owner's daily machine silently in measurement configuration.
+    #[test]
+    fn every_reference_lock_command_has_a_distinct_restore_command() {
+        for command_pair in OWNER_CHECKLIST_OBSERVED_ON_REFERENCE_MACHINE {
+            assert!(
+                !command_pair.locking_shell_command.is_empty()
+                    && !command_pair.restoring_shell_command.is_empty(),
+                "`{}` is missing a command",
+                command_pair.knob_description
+            );
+            assert_ne!(
+                command_pair.locking_shell_command, command_pair.restoring_shell_command,
+                "`{}` locks and restores with the same command",
+                command_pair.knob_description
+            );
+        }
+    }
+
+    /// Guards against the reference checklist listing a command for a knob the
+    /// gate does not actually require, which would send an owner to `sudo` for
+    /// nothing.
+    #[test]
+    fn every_reference_lock_command_is_reachable_from_the_derived_checklist() {
+        let mut fully_unlocked_specification = probe_machine_specification();
+        let central_processing_unit = &mut fully_unlocked_specification.central_processing_unit;
+        central_processing_unit.boost_is_enabled = ProbedValueOrUnavailableReason::observed(true);
+        central_processing_unit.boost_control_sysfs_path =
+            ProbedValueOrUnavailableReason::observed(AMD_AND_ACPI_BOOST_SYSFS_PATH.to_string());
+        central_processing_unit.simultaneous_multithreading_control =
+            ProbedValueOrUnavailableReason::observed("on".to_string());
+        fully_unlocked_specification.memory.swap_is_enabled =
+            ProbedValueOrUnavailableReason::observed(true);
+        fully_unlocked_specification
+            .graphics_processing_unit
+            .persistence_mode = ProbedValueOrUnavailableReason::observed("Disabled".to_string());
+
+        let derived_commands: Vec<String> =
+            owner_checklist_to_reach_locked_measurement_state(&fully_unlocked_specification)
+                .into_iter()
+                .map(|command| command.shell_command)
+                .collect();
+
+        for command_pair in OWNER_CHECKLIST_OBSERVED_ON_REFERENCE_MACHINE {
+            let lock_command = command_pair.locking_shell_command;
+            // The GPU clock lock megahertz is derived from the observed maximum
+            // clock, so that one entry is matched by knob rather than by value.
+            let knob_prefix = lock_command
+                .split_once('=')
+                .map(|(knob, _)| format!("{knob}="))
+                .unwrap_or_else(|| lock_command.to_string());
+            assert!(
+                derived_commands
+                    .iter()
+                    .any(|derived| derived.starts_with(&knob_prefix)),
+                "`{lock_command}` is in the reference checklist but the derived checklist \
+                 never emits it: {derived_commands:?}"
+            );
+        }
+    }
+
+    /// Guards against this crate ever acquiring a privileged probe: a password
+    /// prompt in an unattended multi-hour run wedges the whole measurement.
+    #[test]
+    fn no_probe_path_invokes_a_privileged_command() {
+        let module_source = include_str!("machine_specification_probe.rs");
+        for line in module_source.lines() {
+            let is_command_invocation = line.contains("Command::new");
+            assert!(
+                !(is_command_invocation && line.contains("sudo")),
+                "a probe must never spawn sudo: {line}"
+            );
+        }
+    }
+}

--- a/spikes/streamlib-pyembed-spike/src/machine_specification_probe.rs
+++ b/spikes/streamlib-pyembed-spike/src/machine_specification_probe.rs
@@ -102,7 +102,16 @@ pub struct MachineSpecification {
     /// RAM and swap.
     pub memory: MemorySpecification,
     /// The interpreter and numpy the Python arms run against.
-    pub python_runtime: PythonRuntimeSpecification,
+    /// The `python3` on PATH — the interpreter the SUBPROCESS baseline arm
+    /// launches. Not necessarily the one the in-process arm runs.
+    pub subprocess_python_runtime: PythonRuntimeSpecification,
+    /// The interpreter CPython is embedded from in THIS process, which is what
+    /// produced the in-process arm's numbers. PyO3 links it at build time, so it
+    /// need not be the `python3` on PATH, and it resolves numpy against a
+    /// different `sys.path`. `None` until
+    /// [`record_embedded_python_runtime`] is called from inside a
+    /// `Python::attach` — the probe itself cannot take the GIL.
+    pub embedded_python_runtime: Option<PythonRuntimeSpecification>,
     /// Scheduling class and niceness of the process that ran this probe.
     pub probing_process_scheduling: ProbingProcessSchedulingSpecification,
     /// What else was resident on the box when the probe ran.
@@ -386,7 +395,8 @@ pub fn probe_machine_specification() -> MachineSpecification {
         c_library_version: probe_c_library_version(),
         graphics_processing_unit: probe_graphics_processing_unit(),
         memory: probe_memory(),
-        python_runtime: probe_python_runtime(),
+        subprocess_python_runtime: probe_python_runtime(),
+        embedded_python_runtime: None,
         probing_process_scheduling: probe_process_scheduling(),
         machine_load_at_probe_time: probe_machine_load(),
         locked_measurement_state_violations: Vec::new(),
@@ -683,19 +693,6 @@ pub fn owner_checklist_to_reach_locked_measurement_state(
     checklist
 }
 
-/// Serialize the specification to `machine-spec.json` under `directory_path`.
-pub fn write_machine_specification_json_file(
-    specification: &MachineSpecification,
-    directory_path: &Path,
-) -> std::io::Result<std::path::PathBuf> {
-    std::fs::create_dir_all(directory_path)?;
-    let file_path = directory_path.join(MACHINE_SPECIFICATION_JSON_FILE_NAME);
-    let serialized = serde_json::to_string_pretty(specification)
-        .map_err(|error| std::io::Error::other(error.to_string()))?;
-    std::fs::write(&file_path, serialized)?;
-    Ok(file_path)
-}
-
 fn record_violation_unless_boolean_knob_matches(
     probed_knob: &ProbedValueOrUnavailableReason<bool>,
     required_value: bool,
@@ -792,10 +789,21 @@ fn read_sysfs_boolean_flag(path: &str) -> ProbedValueOrUnavailableReason<bool> {
     }
 }
 
+/// Programs this module refuses to spawn. Enforced at the single call site every
+/// probe funnels through, rather than by scanning source text for `sudo` — a
+/// program name reaching `Command::new` through a variable would defeat that.
+const PRIVILEGE_ESCALATION_PROGRAMS_THIS_MODULE_REFUSES_TO_SPAWN: &[&str] =
+    &["sudo", "doas", "pkexec", "su", "run0"];
+
 fn run_command_capturing_trimmed_standard_output(
     program: &str,
     arguments: &[&str],
 ) -> Result<String, String> {
+    if PRIVILEGE_ESCALATION_PROGRAMS_THIS_MODULE_REFUSES_TO_SPAWN.contains(&program) {
+        return Err(format!(
+            "refusing to spawn `{program}`: a privileged probe would sit on a password prompt              and wedge an unattended measurement run. The locking commands are emitted as data              for the owner to run, never executed here."
+        ));
+    }
     let output = std::process::Command::new(program)
         .args(arguments)
         .output()
@@ -1578,6 +1586,73 @@ fn probe_machine_load() -> MachineLoadSpecification {
     }
 }
 
+/// Fill in [`MachineSpecification::embedded_python_runtime`] by asking the
+/// interpreter embedded in this process about itself.
+///
+/// Separate from [`probe_machine_specification`] because it needs the GIL, and
+/// the probe runs before `Python::initialize()` on the arms that never embed an
+/// interpreter at all.
+pub fn record_embedded_python_runtime(
+    specification: &mut MachineSpecification,
+    python: pyo3::Python<'_>,
+) {
+    use pyo3::types::PyAnyMethods as _;
+
+    fn probe_embedded_attribute(
+        python: pyo3::Python<'_>,
+        module_name: &str,
+        attribute_expression: &str,
+    ) -> ProbedValueOrUnavailableReason<String> {
+        use pyo3::types::PyAnyMethods as _;
+
+        match python
+            .import(module_name)
+            .and_then(|module| module.getattr(attribute_expression))
+            .and_then(|attribute| attribute.str())
+        {
+            Ok(text) => match text.extract::<String>() {
+                Ok(value) => ProbedValueOrUnavailableReason::observed(value),
+                Err(error) => ProbedValueOrUnavailableReason::unavailable(format!(
+                    "{module_name}.{attribute_expression} did not extract as str: {error}"
+                )),
+            },
+            Err(error) => ProbedValueOrUnavailableReason::unavailable(format!(
+                "reading {module_name}.{attribute_expression} from the embedded interpreter \
+                 failed: {error}"
+            )),
+        }
+    }
+
+    let version = python.version_info();
+    let interpreter_version = ProbedValueOrUnavailableReason::observed(format!(
+        "{}.{}.{}",
+        version.major, version.minor, version.patch
+    ));
+
+    // `sys._is_gil_enabled` exists only on free-threaded-capable builds; its
+    // absence means a conventional GIL build, which is the answer we want.
+    let global_interpreter_lock_is_disabled = match python
+        .import("sys")
+        .and_then(|sys| sys.getattr("_is_gil_enabled"))
+    {
+        Ok(callable) => match callable.call0().and_then(|result| result.extract::<bool>()) {
+            Ok(gil_is_enabled) => ProbedValueOrUnavailableReason::observed(!gil_is_enabled),
+            Err(error) => ProbedValueOrUnavailableReason::unavailable(format!(
+                "sys._is_gil_enabled() failed: {error}"
+            )),
+        },
+        Err(_) => ProbedValueOrUnavailableReason::observed(false),
+    };
+
+    specification.embedded_python_runtime = Some(PythonRuntimeSpecification {
+        interpreter_executable_path: probe_embedded_attribute(python, "sys", "executable"),
+        interpreter_version,
+        interpreter_version_banner: probe_embedded_attribute(python, "sys", "version"),
+        numpy_version: probe_embedded_attribute(python, "numpy", "__version__"),
+        global_interpreter_lock_is_disabled,
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1745,13 +1820,28 @@ mod tests {
     /// prompt in an unattended multi-hour run wedges the whole measurement.
     #[test]
     fn no_probe_path_invokes_a_privileged_command() {
-        let module_source = include_str!("machine_specification_probe.rs");
-        for line in module_source.lines() {
-            let is_command_invocation = line.contains("Command::new");
+        // Asserted at the chokepoint every probe funnels through, not by
+        // scanning source text: `Command::new(program)` takes a variable, so a
+        // grep for a literal `sudo` beside `Command::new` would pass a caller
+        // that reached it through one.
+        for privileged_program in PRIVILEGE_ESCALATION_PROGRAMS_THIS_MODULE_REFUSES_TO_SPAWN {
+            let outcome =
+                run_command_capturing_trimmed_standard_output(privileged_program, &["--version"]);
+            let refusal = outcome.expect_err("a privileged program must be refused, not spawned");
             assert!(
-                !(is_command_invocation && line.contains("sudo")),
-                "a probe must never spawn sudo: {line}"
+                refusal.contains("refusing to spawn"),
+                "expected an explicit refusal for `{privileged_program}`, got: {refusal}"
             );
         }
+    }
+
+    /// The deny list must not block ordinary probes — an over-broad refusal
+    /// would turn every observation into an `Unavailable` and silently make the
+    /// machine look unlocked.
+    #[test]
+    fn an_ordinary_probe_program_is_still_spawnable() {
+        let observed =
+            run_command_capturing_trimmed_standard_output("uname", &["-r"]).expect("uname runs");
+        assert!(!observed.is_empty());
     }
 }

--- a/spikes/streamlib-pyembed-spike/src/measuring_sink_processor.rs
+++ b/spikes/streamlib-pyembed-spike/src/measuring_sink_processor.rs
@@ -15,7 +15,7 @@ use streamlib::sdk::processors::ReactiveProcessor;
 use crate::latency_measurement_recorder::{
     LatencyMeasurementRecorder, PerFrameLatencyMeasurement,
 };
-use crate::monotonic_clock::read_monotonic_clock_nanoseconds;
+use crate::monotonic_clock::read_measurement_stamp_nanoseconds;
 use crate::synthetic_frame_measurement_preamble::{
     SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES, SyntheticFrameMeasurementPreamble,
 };
@@ -86,7 +86,7 @@ impl ReactiveProcessor for MeasuringSinkProcessor::Processor {
         // Stamped immediately after the read returns, so the engine's own
         // read-side allocation and memcpy land inside the measured interval —
         // they are part of the latency a user would experience.
-        let sink_receive_monotonic_nanoseconds = read_monotonic_clock_nanoseconds();
+        let sink_receive_monotonic_nanoseconds = read_measurement_stamp_nanoseconds();
 
         let preamble = SyntheticFrameMeasurementPreamble::read_from_payload_prefix(&frame_payload)
             .ok_or_else(|| {
@@ -116,7 +116,9 @@ impl ReactiveProcessor for MeasuringSinkProcessor::Processor {
     }
 }
 
-#[cfg(test)]
+// The second test asserts recorder contents, which a control build does not
+// populate — see the note on the recorder's own test module.
+#[cfg(all(test, not(feature = "stamping-compiled-out")))]
 mod tests {
     use super::*;
 
@@ -125,7 +127,7 @@ mod tests {
     /// means a cell that ran for ten minutes and reported nothing.
     #[test]
     fn the_collection_point_round_trips_a_recorder() {
-        install_measurement_collection_point(LatencyMeasurementRecorder::new(0));
+        install_measurement_collection_point(LatencyMeasurementRecorder::new(0, 0));
         let recovered = take_measurement_collection_point();
         assert!(recovered.is_some());
         assert!(
@@ -138,7 +140,7 @@ mod tests {
     /// first — two cells in one process have to stay separate.
     #[test]
     fn installing_replaces_rather_than_merges() {
-        let mut first = LatencyMeasurementRecorder::new(0);
+        let mut first = LatencyMeasurementRecorder::new(0, 0);
         first.record_frame_measurement(PerFrameLatencyMeasurement {
             frame_sequence_number: 0,
             source_emit_monotonic_nanoseconds: 0,
@@ -146,7 +148,7 @@ mod tests {
             stage_callback_nanoseconds: 0,
         });
         install_measurement_collection_point(first);
-        install_measurement_collection_point(LatencyMeasurementRecorder::new(0));
+        install_measurement_collection_point(LatencyMeasurementRecorder::new(0, 0));
         let recovered = take_measurement_collection_point().expect("second recorder is installed");
         assert_eq!(
             recovered.received_frame_count(),

--- a/spikes/streamlib-pyembed-spike/src/measuring_sink_processor.rs
+++ b/spikes/streamlib-pyembed-spike/src/measuring_sink_processor.rs
@@ -1,0 +1,157 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Terminal processor of every spike graph: stamps arrival, reconstructs the
+//! per-frame measurement, and parks it where the harness can collect it after
+//! the run.
+
+use std::sync::{Mutex, OnceLock};
+
+use serde::{Deserialize, Serialize};
+use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::processors::ReactiveProcessor;
+
+use crate::latency_measurement_recorder::{
+    LatencyMeasurementRecorder, PerFrameLatencyMeasurement,
+};
+use crate::monotonic_clock::read_monotonic_clock_nanoseconds;
+use crate::synthetic_frame_measurement_preamble::{
+    SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES, SyntheticFrameMeasurementPreamble,
+};
+
+/// The recorder the sink feeds. Process-global because the sink is instantiated
+/// by the engine, which offers no channel for handing an owned collaborator to a
+/// processor instance — a spike artifact, not a proposed pattern.
+fn measurement_collection_point() -> &'static Mutex<Option<LatencyMeasurementRecorder>> {
+    static MEASUREMENT_COLLECTION_POINT: OnceLock<Mutex<Option<LatencyMeasurementRecorder>>> =
+        OnceLock::new();
+    MEASUREMENT_COLLECTION_POINT.get_or_init(|| Mutex::new(None))
+}
+
+/// Install the recorder for the cell about to run, discarding any recorder left
+/// by a previous cell in the same process.
+pub fn install_measurement_collection_point(recorder: LatencyMeasurementRecorder) {
+    *measurement_collection_point()
+        .lock()
+        .expect("measurement collection point mutex is never held across a panic") =
+        Some(recorder);
+}
+
+/// Take the recorder back once the graph has stopped.
+pub fn take_measurement_collection_point() -> Option<LatencyMeasurementRecorder> {
+    measurement_collection_point()
+        .lock()
+        .expect("measurement collection point mutex is never held across a panic")
+        .take()
+}
+
+/// Configuration for [`MeasuringSinkProcessor`]. Empty by design — the sink
+/// derives everything it reports from the preamble, so it cannot be
+/// misconfigured into disagreeing with the source.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct MeasuringSinkConfiguration {}
+
+#[streamlib::sdk::processor(
+    "@spike/pyembed/MeasuringSink",
+    execution = reactive,
+    config = crate::measuring_sink_processor::MeasuringSinkConfiguration,
+    config_field = "configuration",
+    input("frame_in", any, delivery_profile = "every_sample"),
+)]
+pub struct MeasuringSinkProcessor;
+
+impl ReactiveProcessor for MeasuringSinkProcessor::Processor {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        if measurement_collection_point()
+            .lock()
+            .expect("measurement collection point mutex is never held across a panic")
+            .is_none()
+        {
+            return Err(Error::Configuration(
+                "no measurement collection point installed — the harness must install one \
+                 before starting the graph, or the cell would run and record nothing"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        let Some((frame_payload, _frame_timestamp_nanoseconds)) =
+            self.inputs.read_raw("frame_in")?
+        else {
+            return Ok(());
+        };
+        // Stamped immediately after the read returns, so the engine's own
+        // read-side allocation and memcpy land inside the measured interval —
+        // they are part of the latency a user would experience.
+        let sink_receive_monotonic_nanoseconds = read_monotonic_clock_nanoseconds();
+
+        let preamble = SyntheticFrameMeasurementPreamble::read_from_payload_prefix(&frame_payload)
+            .ok_or_else(|| {
+                Error::Link(format!(
+                    "frame payload of {} bytes is shorter than the {SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES}-byte measurement preamble",
+                    frame_payload.len()
+                ))
+            })?;
+
+        measurement_collection_point()
+            .lock()
+            .expect("measurement collection point mutex is never held across a panic")
+            .as_mut()
+            .ok_or_else(|| {
+                Error::Configuration(
+                    "measurement collection point was taken while the graph was still running"
+                        .to_string(),
+                )
+            })?
+            .record_frame_measurement(PerFrameLatencyMeasurement {
+                frame_sequence_number: preamble.frame_sequence_number,
+                source_emit_monotonic_nanoseconds: preamble.source_emit_monotonic_nanoseconds,
+                sink_receive_monotonic_nanoseconds,
+                stage_callback_nanoseconds: preamble.stage_callback_nanoseconds,
+            });
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Installing then taking must hand back the same recorder — the harness
+    /// reads its numbers exclusively through this handoff, so a lost recorder
+    /// means a cell that ran for ten minutes and reported nothing.
+    #[test]
+    fn the_collection_point_round_trips_a_recorder() {
+        install_measurement_collection_point(LatencyMeasurementRecorder::new(0));
+        let recovered = take_measurement_collection_point();
+        assert!(recovered.is_some());
+        assert!(
+            take_measurement_collection_point().is_none(),
+            "taking twice must not resurrect a recorder"
+        );
+    }
+
+    /// Installing a second recorder must not silently accumulate into the
+    /// first — two cells in one process have to stay separate.
+    #[test]
+    fn installing_replaces_rather_than_merges() {
+        let mut first = LatencyMeasurementRecorder::new(0);
+        first.record_frame_measurement(PerFrameLatencyMeasurement {
+            frame_sequence_number: 0,
+            source_emit_monotonic_nanoseconds: 0,
+            sink_receive_monotonic_nanoseconds: 1_000,
+            stage_callback_nanoseconds: 0,
+        });
+        install_measurement_collection_point(first);
+        install_measurement_collection_point(LatencyMeasurementRecorder::new(0));
+        let recovered = take_measurement_collection_point().expect("second recorder is installed");
+        assert_eq!(
+            recovered.received_frame_count(),
+            0,
+            "the replacement recorder must not inherit the first cell's frames"
+        );
+    }
+}

--- a/spikes/streamlib-pyembed-spike/src/monotonic_clock.rs
+++ b/spikes/streamlib-pyembed-spike/src/monotonic_clock.rs
@@ -1,0 +1,118 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Raw `CLOCK_MONOTONIC` stamps, the one clock both spike arms share.
+//!
+//! The engine's `MediaClock` is `Instant::elapsed()` from a process-local
+//! `OnceLock` (`runtime/streamlib-engine/src/core/media_clock.rs:12-17`), so two
+//! processes report unrelated epochs. The subprocess baseline arm stamps in
+//! Python with `time.clock_gettime_ns(time.CLOCK_MONOTONIC)`
+//! (`sdk/streamlib-python/python/streamlib/clock.py:29-34`); stamping raw
+//! `CLOCK_MONOTONIC` on the Rust side too is what makes the two arms comparable
+//! by construction rather than by luck.
+//!
+//! `CLOCK_MONOTONIC` (not `_RAW`) is deliberate: it is NTP-slewed but never
+//! stepped, it is what Python exposes, and slew over a 10-minute cell is far
+//! below the microsecond resolution these measurements care about.
+
+/// A `CLOCK_MONOTONIC` reading in nanoseconds since an unspecified epoch that is
+/// fixed for the lifetime of the machine's boot.
+pub type MonotonicNanoseconds = i64;
+
+/// Read `CLOCK_MONOTONIC` as nanoseconds.
+pub fn read_monotonic_clock_nanoseconds() -> MonotonicNanoseconds {
+    let mut timespec = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: `timespec` is a valid, fully-initialized out-parameter and
+    // CLOCK_MONOTONIC is always available on Linux.
+    let return_code = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut timespec) };
+    debug_assert_eq!(return_code, 0, "clock_gettime(CLOCK_MONOTONIC) cannot fail");
+    timespec.tv_sec * 1_000_000_000 + timespec.tv_nsec
+}
+
+/// Read the resolution `CLOCK_MONOTONIC` reports for itself, in nanoseconds.
+/// A measurement whose spread approaches this number is reporting clock
+/// granularity rather than the thing being measured.
+pub fn read_monotonic_clock_resolution_nanoseconds() -> i64 {
+    let mut timespec = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: same contract as `clock_gettime` above.
+    let return_code = unsafe { libc::clock_getres(libc::CLOCK_MONOTONIC, &mut timespec) };
+    debug_assert_eq!(return_code, 0, "clock_getres(CLOCK_MONOTONIC) cannot fail");
+    timespec.tv_sec * 1_000_000_000 + timespec.tv_nsec
+}
+
+/// Busy-wait until `deadline_nanoseconds`, yielding the CPU between polls.
+///
+/// The synthetic source paces itself with this rather than `thread::sleep`
+/// because sleep overshoot at 60fps (16.6ms period) is the same order as the
+/// latency being measured — an imprecise pacer would show up as source jitter
+/// and be misread as pipeline latency.
+pub fn spin_until_monotonic_deadline(deadline_nanoseconds: MonotonicNanoseconds) {
+    // Sleep away the bulk, spin the last slice. 1ms is comfortably above the
+    // worst observed `nanosleep` overshoot under SCHED_OTHER on this platform.
+    const SPIN_THRESHOLD_NANOSECONDS: i64 = 1_000_000;
+    loop {
+        let remaining_nanoseconds = deadline_nanoseconds - read_monotonic_clock_nanoseconds();
+        if remaining_nanoseconds <= 0 {
+            return;
+        }
+        if remaining_nanoseconds > SPIN_THRESHOLD_NANOSECONDS {
+            std::thread::sleep(std::time::Duration::from_nanos(
+                (remaining_nanoseconds - SPIN_THRESHOLD_NANOSECONDS) as u64,
+            ));
+        } else {
+            std::hint::spin_loop();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The clock must be strictly non-decreasing across back-to-back reads —
+    /// the property every latency number in the artifact depends on.
+    #[test]
+    fn monotonic_clock_never_goes_backwards() {
+        let mut previous_reading = read_monotonic_clock_nanoseconds();
+        for _ in 0..100_000 {
+            let current_reading = read_monotonic_clock_nanoseconds();
+            assert!(
+                current_reading >= previous_reading,
+                "CLOCK_MONOTONIC went backwards: {previous_reading} then {current_reading}"
+            );
+            previous_reading = current_reading;
+        }
+    }
+
+    /// The pacer must not return early — a source that fires ahead of its
+    /// deadline would inflate the measured inter-frame rate.
+    #[test]
+    fn spin_until_deadline_never_returns_early() {
+        for _ in 0..200 {
+            let deadline = read_monotonic_clock_nanoseconds() + 200_000;
+            spin_until_monotonic_deadline(deadline);
+            assert!(
+                read_monotonic_clock_nanoseconds() >= deadline,
+                "pacer returned before its deadline"
+            );
+        }
+    }
+
+    /// Resolution must be fine enough that microsecond-scale stage overhead is
+    /// not quantization noise. Linux reports 1ns here; a platform reporting
+    /// coarser than 1µs would invalidate the gate-5 sanity check.
+    #[test]
+    fn monotonic_clock_resolution_is_finer_than_one_microsecond() {
+        let resolution_nanoseconds = read_monotonic_clock_resolution_nanoseconds();
+        assert!(
+            resolution_nanoseconds < 1_000,
+            "CLOCK_MONOTONIC resolution {resolution_nanoseconds}ns is too coarse for this spike"
+        );
+    }
+}

--- a/spikes/streamlib-pyembed-spike/src/monotonic_clock.rs
+++ b/spikes/streamlib-pyembed-spike/src/monotonic_clock.rs
@@ -32,6 +32,32 @@ pub fn read_monotonic_clock_nanoseconds() -> MonotonicNanoseconds {
     timespec.tv_sec * 1_000_000_000 + timespec.tv_nsec
 }
 
+/// Read a measurement stamp, or return 0 when stamping is compiled out.
+///
+/// Every instrumentation stamp goes through this, and nothing else does — the
+/// source's frame pacing calls [`read_monotonic_clock_nanoseconds`] directly
+/// because pacing is the cell's behavior, not its instrument. Building with
+/// `--features stamping-compiled-out` therefore removes exactly the
+/// instrumentation and leaves the graph running identically, which is what makes
+/// a throughput delta between the two builds attributable to the instrument.
+#[cfg(not(feature = "stamping-compiled-out"))]
+#[inline(always)]
+pub fn read_measurement_stamp_nanoseconds() -> MonotonicNanoseconds {
+    read_monotonic_clock_nanoseconds()
+}
+
+/// Stamping compiled out — see the enabled variant for the contract.
+#[cfg(feature = "stamping-compiled-out")]
+#[inline(always)]
+pub fn read_measurement_stamp_nanoseconds() -> MonotonicNanoseconds {
+    0
+}
+
+/// Whether this build records measurements. Written into `cell-spec.json` so a
+/// control-cell artifact can never be mistaken for a measurement cell.
+pub const MEASUREMENT_STAMPING_IS_COMPILED_IN: bool =
+    cfg!(not(feature = "stamping-compiled-out"));
+
 /// Read the resolution `CLOCK_MONOTONIC` reports for itself, in nanoseconds.
 /// A measurement whose spread approaches this number is reporting clock
 /// granularity rather than the thing being measured.
@@ -102,6 +128,36 @@ mod tests {
                 "pacer returned before its deadline"
             );
         }
+    }
+
+    /// The control build must actually compile stamping out. A declared feature
+    /// with no `cfg` site would make the "does the instrument move the
+    /// measurement" control cell report zero overhead by construction — a
+    /// fabricated number in the one crate whose whole output is numbers.
+    #[test]
+    fn the_stamping_feature_actually_changes_what_is_compiled() {
+        if MEASUREMENT_STAMPING_IS_COMPILED_IN {
+            assert_ne!(
+                read_measurement_stamp_nanoseconds(),
+                0,
+                "a measurement build must return real stamps"
+            );
+        } else {
+            assert_eq!(
+                read_measurement_stamp_nanoseconds(),
+                0,
+                "a stamping-compiled-out build must not read the clock"
+            );
+        }
+    }
+
+    /// Pacing must survive the control build: the source paces off
+    /// [`read_monotonic_clock_nanoseconds`], not the gated stamp, so a control
+    /// cell still emits frames at the target rate and its throughput stays
+    /// comparable to a measurement cell's.
+    #[test]
+    fn pacing_reads_the_clock_regardless_of_the_stamping_feature() {
+        assert_ne!(read_monotonic_clock_nanoseconds(), 0);
     }
 
     /// Resolution must be fine enough that microsecond-scale stage overhead is

--- a/spikes/streamlib-pyembed-spike/src/python_callback_stage_processor.rs
+++ b/spikes/streamlib-pyembed-spike/src/python_callback_stage_processor.rs
@@ -1,0 +1,203 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The measured arm: a processor that runs a Python callable in-process, on the
+//! engine's own dedicated processor thread, once per frame.
+
+use std::cell::RefCell;
+
+use pyo3::prelude::*;
+use serde::{Deserialize, Serialize};
+use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::processors::ReactiveProcessor;
+
+use crate::monotonic_clock::read_monotonic_clock_nanoseconds;
+use crate::python_gil_attachment_anchor::PythonGilAttachmentAnchorForProcessorThread;
+use crate::python_processor_callback_registry::resolve_python_callback_for_token;
+use crate::synthetic_frame_measurement_preamble::{
+    SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES, SyntheticFrameMeasurementPreamble,
+};
+use crate::zero_copy_numpy_frame_view::{
+    NumpyFrameViewEscapeOutcome, invoke_python_callback_over_zero_copy_frame_view,
+    preload_numpy_c_array_api_before_first_frame_view,
+};
+
+thread_local! {
+    /// Holds this processor thread's CPython thread state open for the thread's
+    /// lifetime. Thread-local rather than a struct field because the anchor is
+    /// `!Send` by construction and the engine instantiates a processor on a
+    /// different thread than the one that runs it.
+    static PROCESSOR_THREAD_GIL_ANCHOR:
+        RefCell<Option<PythonGilAttachmentAnchorForProcessorThread>> =
+        const { RefCell::new(None) };
+}
+
+/// Frame geometry plus the registry token naming the callable to invoke.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PythonCallbackStageConfiguration {
+    pub frame_width_pixels: u32,
+    pub frame_height_pixels: u32,
+    pub channel_count: u32,
+    /// Key into the process-global callback registry. A `Py<PyAny>` cannot ride
+    /// the config because `Config` requires `Serialize + DeserializeOwned`
+    /// (`core/processors/traits/config.rs:47-51`).
+    pub python_callback_registration_token: String,
+    /// Anchoring the thread state removes a per-frame mmap/munmap pair. Off is
+    /// the control condition that measures what anchoring is worth.
+    pub anchor_processor_thread_gil: bool,
+}
+
+impl Default for PythonCallbackStageConfiguration {
+    fn default() -> Self {
+        Self {
+            frame_width_pixels: 1920,
+            frame_height_pixels: 1080,
+            channel_count: 4,
+            python_callback_registration_token: String::new(),
+            anchor_processor_thread_gil: true,
+        }
+    }
+}
+
+#[streamlib::sdk::processor(
+    "@spike/pyembed/PythonCallbackStage",
+    execution = reactive,
+    config = crate::python_callback_stage_processor::PythonCallbackStageConfiguration,
+    config_field = "configuration",
+    input("frame_in", any, delivery_profile = "every_sample"),
+    output("frame_out", any),
+)]
+pub struct PythonCallbackStageProcessor {
+    resolved_python_callback: Option<Py<PyAny>>,
+    observed_frame_view_escape_count: u64,
+}
+
+impl PythonCallbackStageProcessor::Processor {
+    fn ensure_processor_thread_gil_anchor_installed(&self) {
+        if !self.configuration.anchor_processor_thread_gil {
+            return;
+        }
+        PROCESSOR_THREAD_GIL_ANCHOR.with(|anchor_slot| {
+            let mut anchor_slot = anchor_slot.borrow_mut();
+            if anchor_slot.is_none() {
+                *anchor_slot = Some(
+                    PythonGilAttachmentAnchorForProcessorThread::attach_current_thread_and_park_gil(
+                    ),
+                );
+            }
+        });
+    }
+}
+
+impl ReactiveProcessor for PythonCallbackStageProcessor::Processor {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let token = self.configuration.python_callback_registration_token.clone();
+        let callable = Python::attach(|python| -> Result<Option<Py<PyAny>>> {
+            // numpy's C API table is imported lazily on first use. Forcing it
+            // here keeps that one-time cost out of the first measured frame,
+            // where it would land in the p99.9 tail and be misread as a stall.
+            preload_numpy_c_array_api_before_first_frame_view(python).map_err(|error| {
+                Error::Runtime(format!("failed to import the numpy C array API: {error}"))
+            })?;
+            Ok(resolve_python_callback_for_token(python, &token))
+        })?;
+        self.resolved_python_callback = Some(callable.ok_or_else(|| {
+            Error::Configuration(format!(
+                "no Python callable registered under token `{token}` — register it before \
+                 starting the graph"
+            ))
+        })?);
+        Ok(())
+    }
+
+    fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        let Some((mut frame_payload, frame_timestamp_nanoseconds)) =
+            self.inputs.read_raw("frame_in")?
+        else {
+            return Ok(());
+        };
+        if frame_payload.len() <= SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES {
+            return Err(Error::Link(format!(
+                "frame payload of {} bytes carries no pixels after the measurement preamble",
+                frame_payload.len()
+            )));
+        }
+
+        self.ensure_processor_thread_gil_anchor_installed();
+        let callable = self
+            .resolved_python_callback
+            .as_ref()
+            .ok_or_else(|| Error::Configuration("setup did not resolve a callable".to_string()))?;
+
+        let callback_started_nanoseconds = read_monotonic_clock_nanoseconds();
+        let escape_outcome = Python::attach(|python| {
+            invoke_python_callback_over_zero_copy_frame_view(
+                python,
+                callable,
+                &mut frame_payload[SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES..],
+                self.configuration.frame_height_pixels as usize,
+                self.configuration.frame_width_pixels as usize,
+                self.configuration.channel_count as usize,
+            )
+        })
+        .map_err(|python_error| {
+            Error::Runtime(format!("python stage callback raised: {python_error}"))
+        })?;
+        let callback_finished_nanoseconds = read_monotonic_clock_nanoseconds();
+
+        if let NumpyFrameViewEscapeOutcome::RetainedByPythonWithRefcount(refcount) = escape_outcome {
+            self.observed_frame_view_escape_count += 1;
+            // Not fatal to the run, but it invalidates the zero-copy premise for
+            // this frame and the retained view now aliases a buffer about to be
+            // dropped — the number must reach the artifact, not just a log.
+            tracing::warn!(
+                refcount,
+                total_escapes = self.observed_frame_view_escape_count,
+                "python callback retained the frame view past its call"
+            );
+        }
+
+        // Only the stage-duration field is patched. The sink derives
+        // source_emit_to_sink_receive from the source's original stamp, so this
+        // stage must never restamp the sequence number or the emit time.
+        SyntheticFrameMeasurementPreamble::patch_stage_callback_nanoseconds_in_payload_prefix(
+            &mut frame_payload,
+            callback_finished_nanoseconds - callback_started_nanoseconds,
+        );
+        self.outputs
+            .write_raw("frame_out", &frame_payload, frame_timestamp_nanoseconds)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The token is the whole callback-injection mechanism; a config that
+    /// silently lost it would fail at setup with a confusing error instead of
+    /// at validation.
+    #[test]
+    fn configuration_round_trips_the_callback_token_through_serde() {
+        let configuration = PythonCallbackStageConfiguration {
+            python_callback_registration_token: "cell-42-passthrough".to_string(),
+            anchor_processor_thread_gil: false,
+            ..PythonCallbackStageConfiguration::default()
+        };
+        let encoded = serde_json::to_value(&configuration).expect("serializes");
+        let decoded: PythonCallbackStageConfiguration =
+            serde_json::from_value(encoded).expect("deserializes");
+        assert_eq!(decoded, configuration);
+        assert_eq!(decoded.python_callback_registration_token, "cell-42-passthrough");
+        assert!(!decoded.anchor_processor_thread_gil);
+    }
+
+    /// Anchoring defaults on: the unanchored path costs a per-frame mmap/munmap
+    /// pair, and a silent flip of this default would change every number the
+    /// spike produces without changing any measurement code.
+    #[test]
+    fn gil_anchoring_is_on_by_default() {
+        assert!(PythonCallbackStageConfiguration::default().anchor_processor_thread_gil);
+    }
+}

--- a/spikes/streamlib-pyembed-spike/src/python_callback_stage_processor.rs
+++ b/spikes/streamlib-pyembed-spike/src/python_callback_stage_processor.rs
@@ -12,7 +12,7 @@ use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAcc
 use streamlib::sdk::error::{Error, Result};
 use streamlib::sdk::processors::ReactiveProcessor;
 
-use crate::monotonic_clock::read_monotonic_clock_nanoseconds;
+use crate::monotonic_clock::read_measurement_stamp_nanoseconds;
 use crate::python_gil_attachment_anchor::PythonGilAttachmentAnchorForProcessorThread;
 use crate::python_processor_callback_registry::resolve_python_callback_for_token;
 use crate::synthetic_frame_measurement_preamble::{
@@ -130,7 +130,7 @@ impl ReactiveProcessor for PythonCallbackStageProcessor::Processor {
             .as_ref()
             .ok_or_else(|| Error::Configuration("setup did not resolve a callable".to_string()))?;
 
-        let callback_started_nanoseconds = read_monotonic_clock_nanoseconds();
+        let callback_started_nanoseconds = read_measurement_stamp_nanoseconds();
         let escape_outcome = Python::attach(|python| {
             invoke_python_callback_over_zero_copy_frame_view(
                 python,
@@ -144,7 +144,7 @@ impl ReactiveProcessor for PythonCallbackStageProcessor::Processor {
         .map_err(|python_error| {
             Error::Runtime(format!("python stage callback raised: {python_error}"))
         })?;
-        let callback_finished_nanoseconds = read_monotonic_clock_nanoseconds();
+        let callback_finished_nanoseconds = read_measurement_stamp_nanoseconds();
 
         if let NumpyFrameViewEscapeOutcome::RetainedByPythonWithRefcount(refcount) = escape_outcome {
             self.observed_frame_view_escape_count += 1;

--- a/spikes/streamlib-pyembed-spike/src/python_gil_attachment_anchor.rs
+++ b/spikes/streamlib-pyembed-spike/src/python_gil_attachment_anchor.rs
@@ -44,6 +44,20 @@ impl PythonGilAttachmentAnchorForProcessorThread {
     /// The caller must not hold the GIL when calling this, and
     /// `Python::initialize()` must already have run.
     pub fn attach_current_thread_and_park_gil() -> Self {
+        // Both preconditions are fatal-or-UB if violated: `PyGILState_Ensure` on
+        // an uninitialized interpreter is a `Py_FatalError`, and a recursive
+        // ensure followed by the unconditional `PyEval_SaveThread` below would
+        // drop the GIL out from under an outer holder.
+        debug_assert_ne!(
+            unsafe { pyo3::ffi::Py_IsInitialized() },
+            0,
+            "Python::initialize() must run before a processor thread anchors"
+        );
+        debug_assert_eq!(
+            unsafe { pyo3::ffi::PyGILState_Check() },
+            0,
+            "the anchoring thread must not already hold the GIL"
+        );
         // SAFETY: the interpreter is initialized before any processor thread
         // starts (the harness calls `Python::initialize()` before `App::new`),
         // and this thread holds no thread state yet — `PyGILState_Ensure`

--- a/spikes/streamlib-pyembed-spike/src/python_gil_attachment_anchor.rs
+++ b/spikes/streamlib-pyembed-spike/src/python_gil_attachment_anchor.rs
@@ -1,0 +1,182 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Keeps a processor thread's CPython thread state alive for the thread's whole
+//! lifetime, so per-frame `Python::attach` re-acquires the GIL instead of
+//! rebuilding a thread state.
+//!
+//! Without an anchor, `Python::attach` maps to `PyGILState_Ensure()` on a
+//! foreign thread, which creates a thread state on entry and destroys it on
+//! exit. CPython 3.12 virtual-allocates the per-thread-state frame datastack
+//! chunk on the first Python frame push and frees it on thread-state delete, so
+//! every frame costs one `mmap` + one `munmap`. Measured on this rig: 1041 mmap
+//! and 1005 munmap syscalls per 1000 callback invocations, p50 6.3µs per call.
+//! Anchoring drops that to p50 110ns / p99 151ns — the syscall pair disappears.
+//!
+//! The mechanism is one `PyGILState_Ensure()` that is never released, parked
+//! immediately with `PyEval_SaveThread()` so the thread does not hold the GIL
+//! between frames. Public `pyo3::ffi` only; no engine change.
+//!
+//! This is a spike measurement device. Whether the real SDK should anchor
+//! processor threads is a design question for the pivot, not something these
+//! numbers settle — anchoring trades a resident thread state per processor
+//! thread (a few KiB of datastack) for the per-frame syscall pair.
+
+use std::marker::PhantomData;
+
+/// Holds one processor thread's CPython thread state open.
+///
+/// Create it on the processor thread, drop it on that same thread. It is
+/// deliberately neither `Send` nor `Sync`: CPython thread states are strictly
+/// thread-confined, and releasing one from a different thread than the one that
+/// created it corrupts the interpreter.
+pub struct PythonGilAttachmentAnchorForProcessorThread {
+    gil_state: pyo3::ffi::PyGILState_STATE,
+    parked_thread_state: *mut pyo3::ffi::PyThreadState,
+    // Anchors the !Send + !Sync obligation in the type system rather than in a
+    // comment nobody reads at the call site.
+    _thread_confined: PhantomData<*const ()>,
+}
+
+impl PythonGilAttachmentAnchorForProcessorThread {
+    /// Attach this thread to the interpreter and park the GIL.
+    ///
+    /// The caller must not hold the GIL when calling this, and
+    /// `Python::initialize()` must already have run.
+    pub fn attach_current_thread_and_park_gil() -> Self {
+        // SAFETY: the interpreter is initialized before any processor thread
+        // starts (the harness calls `Python::initialize()` before `App::new`),
+        // and this thread holds no thread state yet — `PyGILState_Ensure`
+        // creates one and takes the GIL.
+        let gil_state = unsafe { pyo3::ffi::PyGILState_Ensure() };
+        // SAFETY: we hold the GIL from the `PyGILState_Ensure` above.
+        // `PyEval_SaveThread` releases the GIL and returns the still-live
+        // thread state, which we keep so `PyGILState_Release` can be paired
+        // correctly in `Drop`.
+        let parked_thread_state = unsafe { pyo3::ffi::PyEval_SaveThread() };
+        Self {
+            gil_state,
+            parked_thread_state,
+            _thread_confined: PhantomData,
+        }
+    }
+}
+
+impl Drop for PythonGilAttachmentAnchorForProcessorThread {
+    fn drop(&mut self) {
+        // SAFETY: restores the exact thread state parked in the constructor on
+        // the same thread (enforced by !Send), reclaiming the GIL, then
+        // releases the matching `PyGILState_Ensure`. Pairing is one-to-one.
+        unsafe {
+            pyo3::ffi::PyEval_RestoreThread(self.parked_thread_state);
+            pyo3::ffi::PyGILState_Release(self.gil_state);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::monotonic_clock::read_monotonic_clock_nanoseconds;
+    use pyo3::prelude::*;
+    use std::sync::OnceLock;
+
+    fn initialize_interpreter_once() {
+        static INTERPRETER_INITIALIZED: OnceLock<()> = OnceLock::new();
+        INTERPRETER_INITIALIZED.get_or_init(Python::initialize);
+    }
+
+    /// The anchor must not leave the GIL held — an anchored processor thread
+    /// that kept the GIL between frames would serialize every other processor
+    /// in the graph and invalidate every number the spike produces.
+    #[test]
+    fn anchor_does_not_hold_the_gil_between_frames() {
+        initialize_interpreter_once();
+        std::thread::spawn(|| {
+            let _anchor = PythonGilAttachmentAnchorForProcessorThread::attach_current_thread_and_park_gil();
+            // SAFETY: read-only query of the current thread's GIL ownership.
+            let holds_gil_while_parked = unsafe { pyo3::ffi::PyGILState_Check() };
+            assert_eq!(
+                holds_gil_while_parked, 0,
+                "the anchor must park the GIL, not hold it"
+            );
+            Python::attach(|_python| {
+                // SAFETY: same read-only query, inside an attach scope.
+                let holds_gil_inside_attach = unsafe { pyo3::ffi::PyGILState_Check() };
+                assert_eq!(
+                    holds_gil_inside_attach, 1,
+                    "attach must reclaim the GIL for the callback body"
+                );
+            });
+        })
+        .join()
+        .expect("anchored thread does not panic");
+    }
+
+    /// An anchored thread must still be able to call Python correctly — the
+    /// anchor is a performance device and must not change semantics.
+    #[test]
+    fn anchored_thread_calls_python_correctly() {
+        initialize_interpreter_once();
+        let observed_result = std::thread::spawn(|| {
+            let _anchor = PythonGilAttachmentAnchorForProcessorThread::attach_current_thread_and_park_gil();
+            Python::attach(|python| {
+                python
+                    .eval(pyo3::ffi::c_str!("6 * 7"), None, None)
+                    .expect("expression evaluates")
+                    .extract::<i64>()
+                    .expect("returns an int")
+            })
+        })
+        .join()
+        .expect("anchored thread does not panic");
+        assert_eq!(observed_result, 42);
+    }
+
+    /// The anchor's reason for existing, asserted rather than assumed: it must
+    /// make repeated attach+call materially cheaper than the unanchored path.
+    ///
+    /// The threshold is deliberately loose (2x) so the test asserts the
+    /// mechanism works rather than pinning a machine-specific ratio — the
+    /// measured ratio on the development rig was ~53x at p50. If this fails,
+    /// the anchor is not doing what the whole design assumes.
+    #[test]
+    fn anchoring_is_materially_cheaper_than_rebuilding_the_thread_state() {
+        initialize_interpreter_once();
+        const CALIBRATION_ITERATIONS: usize = 20_000;
+
+        fn median_attach_and_call_nanoseconds(anchored: bool) -> i64 {
+            std::thread::spawn(move || {
+                let _anchor = anchored.then(
+                    PythonGilAttachmentAnchorForProcessorThread::attach_current_thread_and_park_gil,
+                );
+                let callable = Python::attach(|python| {
+                    python
+                        .eval(pyo3::ffi::c_str!("lambda value: value"), None, None)
+                        .expect("lambda compiles")
+                        .unbind()
+                });
+                let mut samples = Vec::with_capacity(CALIBRATION_ITERATIONS);
+                for _ in 0..CALIBRATION_ITERATIONS {
+                    let started = read_monotonic_clock_nanoseconds();
+                    Python::attach(|python| {
+                        let _ = callable.call1(python, (1i64,)).expect("call succeeds");
+                    });
+                    samples.push(read_monotonic_clock_nanoseconds() - started);
+                }
+                samples.sort_unstable();
+                samples[samples.len() / 2]
+            })
+            .join()
+            .expect("calibration thread does not panic")
+        }
+
+        let unanchored_median = median_attach_and_call_nanoseconds(false);
+        let anchored_median = median_attach_and_call_nanoseconds(true);
+        assert!(
+            anchored_median * 2 < unanchored_median,
+            "anchoring must materially beat thread-state rebuild, \
+             got anchored p50 {anchored_median}ns vs unanchored p50 {unanchored_median}ns"
+        );
+    }
+}

--- a/spikes/streamlib-pyembed-spike/src/python_processor_callback_registry.rs
+++ b/spikes/streamlib-pyembed-spike/src/python_processor_callback_registry.rs
@@ -1,0 +1,141 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Process-global slot mapping a config token to the Python callable a
+//! [`PythonCallbackStageProcessor`] invokes per frame.
+//!
+//! [`PythonCallbackStageProcessor`]: crate::python_callback_stage_processor::PythonCallbackStageProcessor
+//!
+//! A callable cannot ride the processor config: `Config` is a blanket impl over
+//! `Serialize + DeserializeOwned`
+//! (`runtime/streamlib-engine/src/core/processors/traits/config.rs:47-51`), and a
+//! `Py<PyAny>` is neither. So the config carries a string token and the callable
+//! is parked here under that token before the graph starts.
+//!
+//! This indirection is a spike artifact, not a proposal. The real design would
+//! hand the callable to the processor directly; #1702 explicitly defers that
+//! ("real callback-injection design" is listed as a product-design item for the
+//! pivot doc). Nothing here should be read as an API recommendation.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use pyo3::prelude::*;
+
+/// Opaque key carried in the processor config, resolved to a callable at setup.
+pub type PythonCallbackRegistrationToken = String;
+
+fn python_callback_slots()
+-> &'static Mutex<HashMap<PythonCallbackRegistrationToken, Py<PyAny>>> {
+    static PYTHON_CALLBACK_SLOTS: OnceLock<
+        Mutex<HashMap<PythonCallbackRegistrationToken, Py<PyAny>>>,
+    > = OnceLock::new();
+    PYTHON_CALLBACK_SLOTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Park `callable` under `token`, replacing any callable already registered
+/// there and returning it.
+pub fn register_python_callback_under_token(
+    token: PythonCallbackRegistrationToken,
+    callable: Py<PyAny>,
+) -> Option<Py<PyAny>> {
+    python_callback_slots()
+        .lock()
+        .expect("python callback registry mutex is never held across a panic")
+        .insert(token, callable)
+}
+
+/// Resolve `token` to a new reference to its callable, or `None` if nothing was
+/// registered under it.
+pub fn resolve_python_callback_for_token(
+    python: Python<'_>,
+    token: &str,
+) -> Option<Py<PyAny>> {
+    python_callback_slots()
+        .lock()
+        .expect("python callback registry mutex is never held across a panic")
+        .get(token)
+        .map(|callable| callable.clone_ref(python))
+}
+
+/// Drop the callable registered under `token`, returning it if there was one.
+pub fn unregister_python_callback_for_token(token: &str) -> Option<Py<PyAny>> {
+    python_callback_slots()
+        .lock()
+        .expect("python callback registry mutex is never held across a panic")
+        .remove(token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn initialize_interpreter_once() {
+        static INTERPRETER_INITIALIZED: OnceLock<()> = OnceLock::new();
+        INTERPRETER_INITIALIZED.get_or_init(Python::initialize);
+    }
+
+    /// The registry's whole purpose: a callable parked before start is
+    /// retrievable from a different thread once the graph is running.
+    #[test]
+    fn a_registered_callable_resolves_from_a_foreign_thread() {
+        initialize_interpreter_once();
+        let token = "resolves-from-foreign-thread".to_string();
+        Python::attach(|python| {
+            let callable = python
+                .eval(pyo3::ffi::c_str!("lambda value: value + 1"), None, None)
+                .expect("lambda compiles")
+                .unbind();
+            register_python_callback_under_token(token.clone(), callable);
+        });
+
+        let token_for_thread = token.clone();
+        let observed_result = std::thread::spawn(move || {
+            Python::attach(|python| {
+                let callable = resolve_python_callback_for_token(python, &token_for_thread)
+                    .expect("the callable parked on the main thread resolves here");
+                callable
+                    .call1(python, (41i64,))
+                    .expect("call succeeds")
+                    .extract::<i64>(python)
+                    .expect("returns an int")
+            })
+        })
+        .join()
+        .expect("callback thread does not panic");
+
+        assert_eq!(observed_result, 42);
+        unregister_python_callback_for_token(&token);
+    }
+
+    /// An unregistered token must resolve to `None` rather than panicking, so
+    /// the stage can surface a typed configuration error instead of aborting a
+    /// measurement run mid-cell.
+    #[test]
+    fn an_unknown_token_resolves_to_none() {
+        initialize_interpreter_once();
+        Python::attach(|python| {
+            assert!(resolve_python_callback_for_token(python, "never-registered").is_none());
+        });
+    }
+
+    /// Unregistering must actually release the slot — a leaked callable would
+    /// keep an interpreter reference alive past teardown and confound the
+    /// warm-restart battery's RSS readings.
+    #[test]
+    fn unregistering_releases_the_slot() {
+        initialize_interpreter_once();
+        let token = "released-on-unregister".to_string();
+        Python::attach(|python| {
+            let callable = python
+                .eval(pyo3::ffi::c_str!("lambda value: value"), None, None)
+                .expect("lambda compiles")
+                .unbind();
+            register_python_callback_under_token(token.clone(), callable);
+        });
+        assert!(unregister_python_callback_for_token(&token).is_some());
+        Python::attach(|python| {
+            assert!(resolve_python_callback_for_token(python, &token).is_none());
+        });
+    }
+}

--- a/spikes/streamlib-pyembed-spike/src/rust_passthrough_floor_stage_processor.rs
+++ b/spikes/streamlib-pyembed-spike/src/rust_passthrough_floor_stage_processor.rs
@@ -1,0 +1,112 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The floor arm: structurally identical to the Python stage but with no
+//! interpreter, isolating the engine's own wire-hop cost from PyO3's.
+//!
+//! Without this arm a large absolute latency is unattributable. The engine's
+//! public `read_raw` allocates a fresh 64 KiB `Vec`, then a fresh full-size
+//! `Vec`, then memcpys, on every read
+//! (`runtime/streamlib-plugin-abi/src/vtables/input_mailboxes.rs:156-157`, the
+//! allocation sitting inside the retry loop) — at 1080p BGRA that is an 8.3 MB
+//! allocation per hop. Measured against this floor, the PyO3 delta is what the
+//! pivot actually turns on; measured against nothing, it is confounded with the
+//! wire hop.
+
+use serde::{Deserialize, Serialize};
+use streamlib::sdk::context::RuntimeContextLimitedAccess;
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::processors::ReactiveProcessor;
+
+use crate::synthetic_frame_measurement_preamble::{
+    SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES, SyntheticFrameMeasurementPreamble,
+};
+
+/// Frame geometry for [`RustPassthroughFloorStageProcessor`]. Deliberately
+/// mirrors the Python stage's geometry fields so the two arms are configured
+/// identically.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RustPassthroughFloorStageConfiguration {
+    pub frame_width_pixels: u32,
+    pub frame_height_pixels: u32,
+    pub channel_count: u32,
+}
+
+impl Default for RustPassthroughFloorStageConfiguration {
+    fn default() -> Self {
+        Self {
+            frame_width_pixels: 1920,
+            frame_height_pixels: 1080,
+            channel_count: 4,
+        }
+    }
+}
+
+#[streamlib::sdk::processor(
+    "@spike/pyembed/RustPassthroughFloorStage",
+    execution = reactive,
+    config = crate::rust_passthrough_floor_stage_processor::RustPassthroughFloorStageConfiguration,
+    config_field = "configuration",
+    input("frame_in", any, delivery_profile = "every_sample"),
+    output("frame_out", any),
+)]
+pub struct RustPassthroughFloorStageProcessor;
+
+impl ReactiveProcessor for RustPassthroughFloorStageProcessor::Processor {
+    fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        let Some((mut frame_payload, frame_timestamp_nanoseconds)) =
+            self.inputs.read_raw("frame_in")?
+        else {
+            return Ok(());
+        };
+        if frame_payload.len() <= SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES {
+            return Err(Error::Link(format!(
+                "frame payload of {} bytes carries no pixels after the measurement preamble",
+                frame_payload.len()
+            )));
+        }
+
+        // Zero, not a measured span: this arm's whole purpose is that nothing
+        // happens between read and write, so the sink's stage-duration column
+        // is meaningfully empty rather than noise.
+        SyntheticFrameMeasurementPreamble::patch_stage_callback_nanoseconds_in_payload_prefix(
+            &mut frame_payload,
+            0,
+        );
+        self.outputs
+            .write_raw("frame_out", &frame_payload, frame_timestamp_nanoseconds)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The floor arm is only a valid control if it is configured with the same
+    /// geometry as the Python arm — a mismatch would compare different payload
+    /// sizes and therefore different allocation costs.
+    #[test]
+    fn floor_geometry_defaults_match_the_python_stage_geometry() {
+        let floor = RustPassthroughFloorStageConfiguration::default();
+        let python = crate::python_callback_stage_processor::PythonCallbackStageConfiguration::default();
+        assert_eq!(floor.frame_width_pixels, python.frame_width_pixels);
+        assert_eq!(floor.frame_height_pixels, python.frame_height_pixels);
+        assert_eq!(floor.channel_count, python.channel_count);
+    }
+
+    /// The config must survive the serde round-trip the engine performs when it
+    /// validates and stores an instance config.
+    #[test]
+    fn configuration_round_trips_through_serde_json() {
+        let configuration = RustPassthroughFloorStageConfiguration {
+            frame_width_pixels: 1280,
+            frame_height_pixels: 720,
+            channel_count: 4,
+        };
+        let encoded = serde_json::to_value(&configuration).expect("serializes");
+        let decoded: RustPassthroughFloorStageConfiguration =
+            serde_json::from_value(encoded).expect("deserializes");
+        assert_eq!(decoded, configuration);
+    }
+}

--- a/spikes/streamlib-pyembed-spike/src/synthetic_frame_measurement_preamble.rs
+++ b/spikes/streamlib-pyembed-spike/src/synthetic_frame_measurement_preamble.rs
@@ -1,0 +1,221 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The 24-byte measurement preamble the spike prepends to every frame payload.
+//!
+//! Wire contract (little-endian, packed, no padding). The source writes the
+//! first two fields, the stage fills in the third, the sink reads all three:
+//!
+//! ```text
+//! offset 0..8   u64  frame sequence number, starting at 0, +1 per emitted frame
+//! offset 8..16  i64  source emit stamp, raw CLOCK_MONOTONIC nanoseconds
+//! offset 16..24 i64  stage callback duration in nanoseconds, 0 until the stage fills it
+//! offset 24..   [u8] the frame pixel payload
+//! ```
+//!
+//! The stage duration rides the frame rather than a side channel so it is
+//! correlated to its own frame by construction — a cross-thread channel would
+//! need the sequence number to re-associate them and could interleave under
+//! load, silently attributing one frame's stall to another.
+//!
+//! Both fields have to ride the payload rather than the engine's own metadata:
+//! `FrameHeader` carries no sequence field
+//! (`runtime/streamlib-ipc-types/src/lib.rs:210` — the 204-byte header is port
+//! key + schema ident + timestamp + length), and `@tatolab/core/VideoFrame`
+//! deliberately removed its `frame_index` field, with the schema stating
+//! `timestamp_ns` is the sole ordering primitive
+//! (`packages/core/schemas/video_frame.yaml:43`). Re-adding either would be an
+//! engine change the spike forbids.
+//!
+//! A raw preamble rather than a msgpack named map: the ports are declared `any`,
+//! so no schema is ever consulted, and msgpack would cost a full encode+decode
+//! of an 8.3 MB body on every hop — contaminating the exact number being
+//! measured.
+
+use crate::monotonic_clock::MonotonicNanoseconds;
+
+/// Byte length of the preamble prefixed to every spike frame payload.
+pub const SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES: usize = 24;
+
+/// Byte offset of the stage-duration field, which the stage patches in place
+/// without rewriting the fields the source owns.
+const STAGE_CALLBACK_NANOSECONDS_OFFSET: usize = 16;
+
+/// The per-frame measurement fields carried in-band ahead of the pixel payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SyntheticFrameMeasurementPreamble {
+    /// Emission ordinal, starting at 0. Gaps observed at the sink are dropped
+    /// frames; the sink counts them rather than inferring drops from timing.
+    pub frame_sequence_number: u64,
+    /// Raw `CLOCK_MONOTONIC` nanoseconds captured immediately before the source
+    /// handed the frame to its output port.
+    pub source_emit_monotonic_nanoseconds: MonotonicNanoseconds,
+    /// Wall time spent inside the stage's callback. Zero on a frame that has not
+    /// yet passed a stage, and zero for the floor arm's no-op stage.
+    pub stage_callback_nanoseconds: i64,
+}
+
+impl SyntheticFrameMeasurementPreamble {
+    /// Serialize into the first [`SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES`]
+    /// of `payload_buffer`.
+    ///
+    /// Returns `false` if the buffer is too short to hold the preamble.
+    pub fn write_into_payload_prefix(&self, payload_buffer: &mut [u8]) -> bool {
+        if payload_buffer.len() < SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES {
+            return false;
+        }
+        payload_buffer[0..8].copy_from_slice(&self.frame_sequence_number.to_le_bytes());
+        payload_buffer[8..16]
+            .copy_from_slice(&self.source_emit_monotonic_nanoseconds.to_le_bytes());
+        payload_buffer[16..24].copy_from_slice(&self.stage_callback_nanoseconds.to_le_bytes());
+        true
+    }
+
+    /// Patch only the stage-duration field, leaving the source-owned fields
+    /// byte-identical.
+    ///
+    /// Returns `false` if the buffer is too short to hold the preamble.
+    pub fn patch_stage_callback_nanoseconds_in_payload_prefix(
+        payload_buffer: &mut [u8],
+        stage_callback_nanoseconds: i64,
+    ) -> bool {
+        if payload_buffer.len() < SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES {
+            return false;
+        }
+        payload_buffer
+            [STAGE_CALLBACK_NANOSECONDS_OFFSET..STAGE_CALLBACK_NANOSECONDS_OFFSET + 8]
+            .copy_from_slice(&stage_callback_nanoseconds.to_le_bytes());
+        true
+    }
+
+    /// Parse from the first [`SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES`] of
+    /// `payload_buffer`, returning `None` if the buffer is too short.
+    pub fn read_from_payload_prefix(payload_buffer: &[u8]) -> Option<Self> {
+        if payload_buffer.len() < SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES {
+            return None;
+        }
+        let mut sequence_bytes = [0u8; 8];
+        sequence_bytes.copy_from_slice(&payload_buffer[0..8]);
+        let mut emit_stamp_bytes = [0u8; 8];
+        emit_stamp_bytes.copy_from_slice(&payload_buffer[8..16]);
+        let mut stage_duration_bytes = [0u8; 8];
+        stage_duration_bytes.copy_from_slice(&payload_buffer[16..24]);
+        Some(Self {
+            frame_sequence_number: u64::from_le_bytes(sequence_bytes),
+            source_emit_monotonic_nanoseconds: i64::from_le_bytes(emit_stamp_bytes),
+            stage_callback_nanoseconds: i64::from_le_bytes(stage_duration_bytes),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The wire contract must survive a write/read cycle exactly — every
+    /// latency number and every drop count is derived from these three fields.
+    #[test]
+    fn preamble_round_trips_through_the_payload_prefix() {
+        let original = SyntheticFrameMeasurementPreamble {
+            frame_sequence_number: 0x0123_4567_89ab_cdef,
+            source_emit_monotonic_nanoseconds: 1_234_567_890_123_456,
+            stage_callback_nanoseconds: 4_200_000,
+        };
+        let mut payload_buffer = vec![0u8; 64];
+        assert!(original.write_into_payload_prefix(&mut payload_buffer));
+        let parsed = SyntheticFrameMeasurementPreamble::read_from_payload_prefix(&payload_buffer)
+            .expect("a 64-byte buffer holds the preamble");
+        assert_eq!(parsed, original);
+    }
+
+    /// Writing must not disturb the pixel payload that follows it — the Python
+    /// stage receives a view starting at the preamble's end and must see the
+    /// bytes the source wrote.
+    #[test]
+    fn preamble_write_leaves_the_pixel_payload_untouched() {
+        let mut payload_buffer = vec![0xAAu8; 128];
+        let preamble = SyntheticFrameMeasurementPreamble {
+            frame_sequence_number: 7,
+            source_emit_monotonic_nanoseconds: 99,
+            stage_callback_nanoseconds: 0,
+        };
+        assert!(preamble.write_into_payload_prefix(&mut payload_buffer));
+        assert!(
+            payload_buffer[SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES..]
+                .iter()
+                .all(|&byte| byte == 0xAA),
+            "the preamble write overran into the pixel payload"
+        );
+    }
+
+    /// The stage patches its duration in place; if that patch disturbed the
+    /// source's sequence number or emit stamp, every latency number downstream
+    /// would be silently wrong rather than obviously broken.
+    #[test]
+    fn patching_the_stage_duration_leaves_the_source_fields_intact() {
+        let source_written = SyntheticFrameMeasurementPreamble {
+            frame_sequence_number: 4242,
+            source_emit_monotonic_nanoseconds: 987_654_321,
+            stage_callback_nanoseconds: 0,
+        };
+        let mut payload_buffer = vec![0xCDu8; 96];
+        assert!(source_written.write_into_payload_prefix(&mut payload_buffer));
+        assert!(
+            SyntheticFrameMeasurementPreamble::patch_stage_callback_nanoseconds_in_payload_prefix(
+                &mut payload_buffer,
+                3_500_000,
+            )
+        );
+
+        let parsed = SyntheticFrameMeasurementPreamble::read_from_payload_prefix(&payload_buffer)
+            .expect("preamble parses");
+        assert_eq!(parsed.frame_sequence_number, 4242);
+        assert_eq!(parsed.source_emit_monotonic_nanoseconds, 987_654_321);
+        assert_eq!(parsed.stage_callback_nanoseconds, 3_500_000);
+        assert!(
+            payload_buffer[SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES..]
+                .iter()
+                .all(|&byte| byte == 0xCD),
+            "the stage patch overran into the pixel payload"
+        );
+    }
+
+    /// A short buffer must be refused rather than silently truncated — a
+    /// truncated preamble would deserialize into a plausible-looking but wrong
+    /// sequence number and corrupt the drop accounting.
+    #[test]
+    fn preamble_refuses_a_buffer_shorter_than_the_contract() {
+        let mut too_short = vec![0u8; SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES - 1];
+        let preamble = SyntheticFrameMeasurementPreamble {
+            frame_sequence_number: 1,
+            source_emit_monotonic_nanoseconds: 2,
+            stage_callback_nanoseconds: 3,
+        };
+        assert!(!preamble.write_into_payload_prefix(&mut too_short));
+        assert!(
+            !SyntheticFrameMeasurementPreamble::patch_stage_callback_nanoseconds_in_payload_prefix(
+                &mut too_short,
+                1,
+            )
+        );
+        assert!(SyntheticFrameMeasurementPreamble::read_from_payload_prefix(&too_short).is_none());
+    }
+
+    /// Little-endian is the stated contract; pin the exact byte order so a
+    /// future edit that swaps endianness fails here rather than silently
+    /// producing nonsense stamps.
+    #[test]
+    fn preamble_byte_order_is_little_endian() {
+        let preamble = SyntheticFrameMeasurementPreamble {
+            frame_sequence_number: 1,
+            source_emit_monotonic_nanoseconds: 1,
+            stage_callback_nanoseconds: 1,
+        };
+        let mut payload_buffer = vec![0u8; SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES];
+        assert!(preamble.write_into_payload_prefix(&mut payload_buffer));
+        assert_eq!(
+            payload_buffer,
+            vec![1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]
+        );
+    }
+}

--- a/spikes/streamlib-pyembed-spike/src/synthetic_frame_source_processor.rs
+++ b/spikes/streamlib-pyembed-spike/src/synthetic_frame_source_processor.rs
@@ -1,0 +1,208 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Tier A's frame generator: emits fixed-size frames at a target rate with a
+//! measurement preamble, standing in for a camera on the headless arm.
+
+use serde::{Deserialize, Serialize};
+use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::processors::ContinuousProcessor;
+
+use crate::monotonic_clock::{
+    MonotonicNanoseconds, read_monotonic_clock_nanoseconds, spin_until_monotonic_deadline,
+};
+use crate::synthetic_frame_measurement_preamble::{
+    SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES, SyntheticFrameMeasurementPreamble,
+};
+
+/// Frame geometry and pacing for [`SyntheticFrameSourceProcessor`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SyntheticFrameSourceConfiguration {
+    pub frame_width_pixels: u32,
+    pub frame_height_pixels: u32,
+    pub channel_count: u32,
+    pub target_frames_per_second: u32,
+}
+
+impl Default for SyntheticFrameSourceConfiguration {
+    fn default() -> Self {
+        Self {
+            frame_width_pixels: 1920,
+            frame_height_pixels: 1080,
+            channel_count: 4,
+            target_frames_per_second: 30,
+        }
+    }
+}
+
+impl SyntheticFrameSourceConfiguration {
+    /// Pixel bytes per frame, excluding the measurement preamble.
+    pub fn frame_pixel_byte_count(&self) -> usize {
+        self.frame_width_pixels as usize
+            * self.frame_height_pixels as usize
+            * self.channel_count as usize
+    }
+
+    /// Nanoseconds between consecutive frame emissions at the target rate.
+    pub fn frame_period_nanoseconds(&self) -> Result<i64> {
+        if self.target_frames_per_second == 0 {
+            return Err(Error::Configuration(
+                "target_frames_per_second must be greater than zero".to_string(),
+            ));
+        }
+        Ok(1_000_000_000 / self.target_frames_per_second as i64)
+    }
+}
+
+#[streamlib::sdk::processor(
+    "@spike/pyembed/SyntheticFrameSource",
+    execution = continuous,
+    config = crate::synthetic_frame_source_processor::SyntheticFrameSourceConfiguration,
+    config_field = "configuration",
+    output("frame_out", any),
+)]
+pub struct SyntheticFrameSourceProcessor {
+    next_frame_sequence_number: u64,
+    frame_payload_buffer: Vec<u8>,
+    /// Absolute deadlines derived from a fixed origin rather than accumulated
+    /// per-frame sleeps. The engine's continuous loop runs `process()` then
+    /// sleeps its own interval (`execution/thread_runner.rs:150-158`), so a
+    /// relative pacer would drift by that interval every frame.
+    emission_origin_monotonic_nanoseconds: MonotonicNanoseconds,
+}
+
+impl ContinuousProcessor for SyntheticFrameSourceProcessor::Processor {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let total_payload_bytes = SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES
+            + self.configuration.frame_pixel_byte_count();
+        self.frame_payload_buffer = vec![0u8; total_payload_bytes];
+        // A non-uniform pattern so a stage that silently drops or zeroes the
+        // payload is distinguishable from one that passes it through.
+        for (index, byte) in self.frame_payload_buffer
+            [SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES..]
+            .iter_mut()
+            .enumerate()
+        {
+            *byte = (index % 251) as u8;
+        }
+        self.next_frame_sequence_number = 0;
+        self.emission_origin_monotonic_nanoseconds = read_monotonic_clock_nanoseconds();
+        tracing::info!(
+            frame_bytes = total_payload_bytes,
+            target_fps = self.configuration.target_frames_per_second,
+            "synthetic frame source ready"
+        );
+        Ok(())
+    }
+
+    fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        let frame_period_nanoseconds = self.configuration.frame_period_nanoseconds()?;
+        let emission_deadline = self.emission_origin_monotonic_nanoseconds
+            + (self.next_frame_sequence_number as i64) * frame_period_nanoseconds;
+        spin_until_monotonic_deadline(emission_deadline);
+
+        // The emit stamp is taken after pacing and immediately before the
+        // write, so pacing wait never lands inside the measured latency.
+        let preamble = SyntheticFrameMeasurementPreamble {
+            frame_sequence_number: self.next_frame_sequence_number,
+            source_emit_monotonic_nanoseconds: read_monotonic_clock_nanoseconds(),
+            // The stage patches this in place; the source leaves it zero so a
+            // frame that never reached a stage is distinguishable.
+            stage_callback_nanoseconds: 0,
+        };
+        if !preamble.write_into_payload_prefix(&mut self.frame_payload_buffer) {
+            return Err(Error::Configuration(
+                "frame payload buffer is smaller than the measurement preamble".to_string(),
+            ));
+        }
+
+        self.outputs.write_raw(
+            "frame_out",
+            &self.frame_payload_buffer,
+            preamble.source_emit_monotonic_nanoseconds,
+        )?;
+        self.next_frame_sequence_number += 1;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 1080p BGRA plus the preamble must stay inside the 16 MiB untrusted-session
+    /// payload ceiling, because the subprocess baseline arm's links are
+    /// classified UntrustedSession (`open_iceoryx2_service_op.rs:149-153`,
+    /// `streamlib-ipc-types/src/lib.rs:43`). Exceeding it would make the two
+    /// arms structurally incomparable rather than merely slower.
+    #[test]
+    fn default_frame_fits_the_untrusted_session_payload_ceiling() {
+        const UNTRUSTED_SESSION_PAYLOAD_CEILING_BYTES: usize = 16 * 1024 * 1024;
+        let configuration = SyntheticFrameSourceConfiguration::default();
+        let total_bytes = SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES
+            + configuration.frame_pixel_byte_count();
+        assert_eq!(configuration.frame_pixel_byte_count(), 8_294_400);
+        assert!(
+            total_bytes < UNTRUSTED_SESSION_PAYLOAD_CEILING_BYTES,
+            "{total_bytes} bytes exceeds the subprocess arm's ceiling"
+        );
+    }
+
+    /// 4K would fit the in-process arm's 64 MiB Trusted ceiling but is refused
+    /// on the subprocess arm — the boundary that caps this benchmark at 1080p.
+    #[test]
+    fn four_k_frame_exceeds_the_untrusted_session_ceiling() {
+        const UNTRUSTED_SESSION_PAYLOAD_CEILING_BYTES: usize = 16 * 1024 * 1024;
+        let configuration = SyntheticFrameSourceConfiguration {
+            frame_width_pixels: 3840,
+            frame_height_pixels: 2160,
+            ..SyntheticFrameSourceConfiguration::default()
+        };
+        assert!(configuration.frame_pixel_byte_count() > UNTRUSTED_SESSION_PAYLOAD_CEILING_BYTES);
+    }
+
+    /// Both protocol rates must produce exact periods; a rate that divided
+    /// unevenly would accumulate pacing error across a 10-minute cell.
+    #[test]
+    fn protocol_frame_rates_yield_expected_periods() {
+        for (frames_per_second, expected_period_nanoseconds) in [(30, 33_333_333), (60, 16_666_666)]
+        {
+            let configuration = SyntheticFrameSourceConfiguration {
+                target_frames_per_second: frames_per_second,
+                ..SyntheticFrameSourceConfiguration::default()
+            };
+            assert_eq!(
+                configuration.frame_period_nanoseconds().expect("valid rate"),
+                expected_period_nanoseconds
+            );
+        }
+    }
+
+    /// A zero rate must surface a configuration error rather than dividing by
+    /// zero inside the processor loop.
+    #[test]
+    fn zero_frame_rate_is_a_configuration_error() {
+        let configuration = SyntheticFrameSourceConfiguration {
+            target_frames_per_second: 0,
+            ..SyntheticFrameSourceConfiguration::default()
+        };
+        assert!(configuration.frame_period_nanoseconds().is_err());
+    }
+
+    /// The config must survive the serde round-trip the engine performs when it
+    /// validates and stores an instance config.
+    #[test]
+    fn configuration_round_trips_through_serde_json() {
+        let configuration = SyntheticFrameSourceConfiguration {
+            frame_width_pixels: 1280,
+            frame_height_pixels: 720,
+            channel_count: 4,
+            target_frames_per_second: 60,
+        };
+        let encoded = serde_json::to_value(&configuration).expect("serializes");
+        let decoded: SyntheticFrameSourceConfiguration =
+            serde_json::from_value(encoded).expect("deserializes");
+        assert_eq!(decoded, configuration);
+    }
+}

--- a/spikes/streamlib-pyembed-spike/src/synthetic_frame_source_processor.rs
+++ b/spikes/streamlib-pyembed-spike/src/synthetic_frame_source_processor.rs
@@ -10,7 +10,8 @@ use streamlib::sdk::error::{Error, Result};
 use streamlib::sdk::processors::ContinuousProcessor;
 
 use crate::monotonic_clock::{
-    MonotonicNanoseconds, read_monotonic_clock_nanoseconds, spin_until_monotonic_deadline,
+    MonotonicNanoseconds, read_measurement_stamp_nanoseconds, read_monotonic_clock_nanoseconds,
+    spin_until_monotonic_deadline,
 };
 use crate::synthetic_frame_measurement_preamble::{
     SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES, SyntheticFrameMeasurementPreamble,
@@ -106,7 +107,7 @@ impl ContinuousProcessor for SyntheticFrameSourceProcessor::Processor {
         // write, so pacing wait never lands inside the measured latency.
         let preamble = SyntheticFrameMeasurementPreamble {
             frame_sequence_number: self.next_frame_sequence_number,
-            source_emit_monotonic_nanoseconds: read_monotonic_clock_nanoseconds(),
+            source_emit_monotonic_nanoseconds: read_measurement_stamp_nanoseconds(),
             // The stage patches this in place; the source leaves it zero so a
             // frame that never reached a stage is distinguishable.
             stage_callback_nanoseconds: 0,

--- a/spikes/streamlib-pyembed-spike/src/tier_a_measurement_cell.rs
+++ b/spikes/streamlib-pyembed-spike/src/tier_a_measurement_cell.rs
@@ -1,0 +1,324 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Builds and runs one Tier A measurement cell: synthetic source → stage → sink,
+//! headless, in a single process.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use streamlib::sdk::App;
+use streamlib::sdk::error::{Error, Result};
+
+use crate::latency_measurement_recorder::{
+    LatencyMeasurementRecorder, LatencyPercentileSummary,
+};
+use crate::machine_specification_probe::{MachineSpecification, probe_machine_specification};
+use crate::measuring_sink_processor::{
+    MeasuringSinkConfiguration, MeasuringSinkProcessor, install_measurement_collection_point,
+    take_measurement_collection_point,
+};
+use crate::monotonic_clock::{
+    read_monotonic_clock_nanoseconds, spin_until_monotonic_deadline,
+};
+use crate::python_callback_stage_processor::{
+    PythonCallbackStageConfiguration, PythonCallbackStageProcessor,
+};
+use crate::rust_passthrough_floor_stage_processor::{
+    RustPassthroughFloorStageConfiguration, RustPassthroughFloorStageProcessor,
+};
+use crate::synthetic_frame_source_processor::{
+    SyntheticFrameSourceConfiguration, SyntheticFrameSourceProcessor,
+};
+
+/// Which of the three comparison arms a cell runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MeasurementArm {
+    /// CPython embedded in this process, callback on the processor thread.
+    InProcessPython,
+    /// Pure-Rust passthrough — the engine wire-hop floor, no interpreter.
+    RustPassthroughFloor,
+}
+
+impl MeasurementArm {
+    /// Stable token used in cell directory names and in `cell-spec.json`.
+    pub fn as_artifact_token(self) -> &'static str {
+        match self {
+            MeasurementArm::InProcessPython => "in-process-python",
+            MeasurementArm::RustPassthroughFloor => "rust-passthrough-floor",
+        }
+    }
+}
+
+/// Everything that defines one cell. Recorded verbatim into `cell-spec.json` so
+/// the summarizer can refuse to evaluate a gate the cell cannot support.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TierAMeasurementCellSpecification {
+    pub arm: MeasurementArm,
+    pub frame_width_pixels: u32,
+    pub frame_height_pixels: u32,
+    pub channel_count: u32,
+    pub target_frames_per_second: u32,
+    pub cell_duration_seconds: u64,
+    pub warmup_exclusion_seconds: u64,
+    pub python_callback_registration_token: String,
+    pub anchor_processor_thread_gil: bool,
+    /// Declared on every input port. Owner decision for #1702: latency
+    /// percentiles are the primary signal, so drops are reported not gated.
+    pub resolved_delivery_profile: String,
+    /// The quantity the percentiles describe. Deliberately not
+    /// "capture-to-present" — Tier A has no capture and no present.
+    pub measured_metric_name: String,
+    pub repetition_index: u32,
+}
+
+impl TierAMeasurementCellSpecification {
+    /// Directory name for this cell: sortable, and unambiguous across arms,
+    /// rates, and repetitions.
+    pub fn artifact_directory_name(&self) -> String {
+        format!(
+            "arm-{}__fps-{:03}__gil-anchor-{}__rep-{:02}",
+            self.arm.as_artifact_token(),
+            self.target_frames_per_second,
+            if self.anchor_processor_thread_gil {
+                "on"
+            } else {
+                "off"
+            },
+            self.repetition_index,
+        )
+    }
+}
+
+/// What one cell produced, alongside the spec that produced it.
+#[derive(Debug, Clone, Serialize)]
+pub struct TierAMeasurementCellOutcome {
+    pub specification: TierAMeasurementCellSpecification,
+    pub machine_specification: MachineSpecification,
+    pub source_emit_to_sink_receive: LatencyPercentileSummary,
+    pub stage_callback: LatencyPercentileSummary,
+    pub received_frame_count: u64,
+    /// Frames that survived the warmup exclusion and therefore back the
+    /// percentiles above.
+    pub measured_frame_count: u64,
+    pub dropped_frame_count: u64,
+    /// A sink stamp earlier than its emit stamp. Nonzero means the two arms'
+    /// clocks disagree, which invalidates the cell rather than degrading it.
+    pub negative_latency_anomaly_count: u64,
+    /// Samples that exceeded the histogram's configured range. Nonzero means the
+    /// reported percentiles are clipped and the cell must be rerun with a wider
+    /// range, not interpreted.
+    pub histogram_range_saturation_count: u64,
+    pub rolling_one_second_frame_rate_windows: Vec<f64>,
+}
+
+/// Build the graph, run it for the cell's duration, and return its outcome.
+///
+/// The caller must have registered the Python callable under
+/// `python_callback_registration_token` before calling this when the arm is
+/// [`MeasurementArm::InProcessPython`], and must have called
+/// `Python::initialize()` before any engine thread starts.
+pub fn run_tier_a_measurement_cell(
+    specification: &TierAMeasurementCellSpecification,
+    artifact_directory: &Path,
+) -> Result<TierAMeasurementCellOutcome> {
+    std::fs::create_dir_all(artifact_directory)?;
+
+    let warmup_exclusion_nanoseconds = (specification.warmup_exclusion_seconds as i64)
+        .checked_mul(1_000_000_000)
+        .ok_or_else(|| {
+            Error::Configuration("warmup exclusion overflows a nanosecond count".to_string())
+        })?;
+    install_measurement_collection_point(LatencyMeasurementRecorder::new(
+        warmup_exclusion_nanoseconds,
+    ));
+
+    let app = App::new()?;
+    let source = app.add_local::<SyntheticFrameSourceProcessor::Processor>(
+        SyntheticFrameSourceConfiguration {
+            frame_width_pixels: specification.frame_width_pixels,
+            frame_height_pixels: specification.frame_height_pixels,
+            channel_count: specification.channel_count,
+            target_frames_per_second: specification.target_frames_per_second,
+        },
+    )?;
+
+    let stage = match specification.arm {
+        MeasurementArm::InProcessPython => app
+            .add_local::<PythonCallbackStageProcessor::Processor>(
+                PythonCallbackStageConfiguration {
+                    frame_width_pixels: specification.frame_width_pixels,
+                    frame_height_pixels: specification.frame_height_pixels,
+                    channel_count: specification.channel_count,
+                    python_callback_registration_token: specification
+                        .python_callback_registration_token
+                        .clone(),
+                    anchor_processor_thread_gil: specification.anchor_processor_thread_gil,
+                },
+            )?,
+        MeasurementArm::RustPassthroughFloor => app
+            .add_local::<RustPassthroughFloorStageProcessor::Processor>(
+                RustPassthroughFloorStageConfiguration {
+                    frame_width_pixels: specification.frame_width_pixels,
+                    frame_height_pixels: specification.frame_height_pixels,
+                    channel_count: specification.channel_count,
+                },
+            )?,
+    };
+
+    let sink = app.add_local::<MeasuringSinkProcessor::Processor>(MeasuringSinkConfiguration {})?;
+
+    app.connect((&source, "frame_out"), (&stage, "frame_in"))?;
+    app.connect((&stage, "frame_out"), (&sink, "frame_in"))?;
+
+    let machine_specification = probe_machine_specification();
+
+    app.runner().start()?;
+    let cell_deadline = read_monotonic_clock_nanoseconds()
+        + (specification.cell_duration_seconds as i64) * 1_000_000_000;
+    spin_until_monotonic_deadline(cell_deadline);
+    app.runner().stop()?;
+
+    let recorder = take_measurement_collection_point().ok_or_else(|| {
+        Error::Runtime(
+            "the measurement collection point vanished during the cell — no numbers to report"
+                .to_string(),
+        )
+    })?;
+
+    // Read the frame count before any percentile: a fully-refused run must be
+    // reported as zero frames, never as a fast one.
+    let received_frame_count = recorder.received_frame_count();
+    if received_frame_count == 0 {
+        return Err(Error::Runtime(format!(
+            "cell `{}` received zero frames — the graph ran but nothing arrived at the sink",
+            specification.artifact_directory_name()
+        )));
+    }
+
+    recorder
+        .write_per_frame_measurement_jsonl(&artifact_directory.join("per-frame-measurements.jsonl"))?;
+    recorder.write_mergeable_histogram_export(
+        &artifact_directory.join("source-emit-to-sink-receive.histogram"),
+    )?;
+
+    let outcome = TierAMeasurementCellOutcome {
+        specification: specification.clone(),
+        machine_specification,
+        source_emit_to_sink_receive: recorder.source_emit_to_sink_receive_summary(),
+        stage_callback: recorder.stage_callback_summary(),
+        received_frame_count,
+        measured_frame_count: recorder.measured_frame_count(),
+        dropped_frame_count: recorder.dropped_frame_count(),
+        negative_latency_anomaly_count: recorder.negative_latency_anomaly_count(),
+        histogram_range_saturation_count: recorder.histogram_range_saturation_count(),
+        rolling_one_second_frame_rate_windows: recorder.rolling_one_second_frame_rate_windows(),
+    };
+
+    write_json_artifact(
+        &artifact_directory.join("cell-spec.json"),
+        &outcome.specification,
+    )?;
+    write_json_artifact(&artifact_directory.join("machine-spec.json"), &outcome.machine_specification)?;
+    write_json_artifact(&artifact_directory.join("summary.json"), &outcome)?;
+
+    Ok(outcome)
+}
+
+fn write_json_artifact<T: Serialize>(path: &PathBuf, value: &T) -> Result<()> {
+    let encoded = serde_json::to_vec_pretty(value)
+        .map_err(|error| Error::Runtime(format!("failed to encode {}: {error}", path.display())))?;
+    std::fs::write(path, encoded)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn example_specification() -> TierAMeasurementCellSpecification {
+        TierAMeasurementCellSpecification {
+            arm: MeasurementArm::InProcessPython,
+            frame_width_pixels: 1920,
+            frame_height_pixels: 1080,
+            channel_count: 4,
+            target_frames_per_second: 60,
+            cell_duration_seconds: 600,
+            warmup_exclusion_seconds: 60,
+            python_callback_registration_token: "cell-token".to_string(),
+            anchor_processor_thread_gil: true,
+            resolved_delivery_profile: "every_sample".to_string(),
+            measured_metric_name: "source_emit_to_sink_receive".to_string(),
+            repetition_index: 3,
+        }
+    }
+
+    /// Cell directories must be unambiguous and sort sensibly, because A/B/A
+    /// interleaving writes many sibling cells that differ only in arm and
+    /// repetition — a collision would silently overwrite a cell's raw data.
+    #[test]
+    fn cell_directory_names_encode_every_distinguishing_dimension() {
+        let name = example_specification().artifact_directory_name();
+        assert_eq!(name, "arm-in-process-python__fps-060__gil-anchor-on__rep-03");
+
+        let floor_arm = TierAMeasurementCellSpecification {
+            arm: MeasurementArm::RustPassthroughFloor,
+            ..example_specification()
+        };
+        assert_ne!(floor_arm.artifact_directory_name(), name);
+    }
+
+    /// Zero-padding keeps 30fps sorting before 60fps and rep-02 before rep-10 in
+    /// a plain lexicographic directory listing.
+    #[test]
+    fn cell_directory_names_sort_lexicographically_by_rate_and_repetition() {
+        let thirty = TierAMeasurementCellSpecification {
+            target_frames_per_second: 30,
+            ..example_specification()
+        };
+        let sixty = example_specification();
+        assert!(thirty.artifact_directory_name() < sixty.artifact_directory_name());
+
+        let second = TierAMeasurementCellSpecification {
+            repetition_index: 2,
+            ..example_specification()
+        };
+        let tenth = TierAMeasurementCellSpecification {
+            repetition_index: 10,
+            ..example_specification()
+        };
+        assert!(second.artifact_directory_name() < tenth.artifact_directory_name());
+    }
+
+    /// The metric name is load-bearing: "capture-to-present" is not observable
+    /// in Tier A, and a spec that claimed it would mislabel the public
+    /// benchmark artifact.
+    #[test]
+    fn the_recorded_metric_name_is_not_capture_to_present() {
+        let specification = example_specification();
+        assert_eq!(
+            specification.measured_metric_name,
+            "source_emit_to_sink_receive"
+        );
+        assert!(!specification.measured_metric_name.contains("present"));
+    }
+
+    /// The owner's delivery-profile decision must survive into the artifact —
+    /// the summarizer keys gate eligibility off this field.
+    #[test]
+    fn the_recorded_delivery_profile_is_every_sample() {
+        assert_eq!(example_specification().resolved_delivery_profile, "every_sample");
+    }
+
+    /// The spec round-trips so a cell can be replayed exactly from its own
+    /// artifact directory.
+    #[test]
+    fn cell_specification_round_trips_through_serde_json() {
+        let specification = example_specification();
+        let encoded = serde_json::to_value(&specification).expect("serializes");
+        let decoded: TierAMeasurementCellSpecification =
+            serde_json::from_value(encoded).expect("deserializes");
+        assert_eq!(decoded, specification);
+    }
+}

--- a/spikes/streamlib-pyembed-spike/src/tier_a_measurement_cell.rs
+++ b/spikes/streamlib-pyembed-spike/src/tier_a_measurement_cell.rs
@@ -13,14 +13,14 @@ use streamlib::sdk::error::{Error, Result};
 use crate::latency_measurement_recorder::{
     LatencyMeasurementRecorder, LatencyPercentileSummary,
 };
-use crate::machine_specification_probe::{MachineSpecification, probe_machine_specification};
+use crate::machine_specification_probe::{
+    MACHINE_SPECIFICATION_JSON_FILE_NAME, MachineSpecification, probe_machine_specification,
+};
 use crate::measuring_sink_processor::{
     MeasuringSinkConfiguration, MeasuringSinkProcessor, install_measurement_collection_point,
     take_measurement_collection_point,
 };
-use crate::monotonic_clock::{
-    read_monotonic_clock_nanoseconds, spin_until_monotonic_deadline,
-};
+use crate::monotonic_clock::{read_monotonic_clock_nanoseconds, spin_until_monotonic_deadline};
 use crate::python_callback_stage_processor::{
     PythonCallbackStageConfiguration, PythonCallbackStageProcessor,
 };
@@ -31,7 +31,8 @@ use crate::synthetic_frame_source_processor::{
     SyntheticFrameSourceConfiguration, SyntheticFrameSourceProcessor,
 };
 
-/// Which of the three comparison arms a cell runs.
+/// Which of the two Rust-side comparison arms a cell runs. The third arm, the
+/// subprocess baseline, is driven from `python/runner.py`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum MeasurementArm {
@@ -64,6 +65,10 @@ pub struct TierAMeasurementCellSpecification {
     pub warmup_exclusion_seconds: u64,
     pub python_callback_registration_token: String,
     pub anchor_processor_thread_gil: bool,
+    /// The callable the stage invoked, e.g. `passthrough_stage`. Part of the
+    /// cell directory name: two cells differing only by stage would otherwise
+    /// collide and the second would overwrite the first.
+    pub stage_callback_attribute: String,
     /// Declared on every input port. Owner decision for #1702: latency
     /// percentiles are the primary signal, so drops are reported not gated.
     pub resolved_delivery_profile: String,
@@ -71,6 +76,10 @@ pub struct TierAMeasurementCellSpecification {
     /// "capture-to-present" — Tier A has no capture and no present.
     pub measured_metric_name: String,
     pub repetition_index: u32,
+    /// False in a `stamping-compiled-out` control build, whose only valid output
+    /// is a throughput comparison. Recorded so a control cell's artifact can
+    /// never be read as a measurement cell's.
+    pub measurement_stamping_is_compiled_in: bool,
 }
 
 impl TierAMeasurementCellSpecification {
@@ -78,9 +87,10 @@ impl TierAMeasurementCellSpecification {
     /// rates, and repetitions.
     pub fn artifact_directory_name(&self) -> String {
         format!(
-            "arm-{}__fps-{:03}__gil-anchor-{}__rep-{:02}",
+            "arm-{}__fps-{:03}__stage-{}__gil-anchor-{}__rep-{:02}",
             self.arm.as_artifact_token(),
             self.target_frames_per_second,
+            self.stage_callback_attribute,
             if self.anchor_processor_thread_gil {
                 "on"
             } else {
@@ -130,8 +140,13 @@ pub fn run_tier_a_measurement_cell(
         .ok_or_else(|| {
             Error::Configuration("warmup exclusion overflows a nanosecond count".to_string())
         })?;
+    let expected_frame_count = (specification.cell_duration_seconds as usize)
+        .saturating_mul(specification.target_frames_per_second as usize)
+        .saturating_mul(12)
+        / 10;
     install_measurement_collection_point(LatencyMeasurementRecorder::new(
         warmup_exclusion_nanoseconds,
+        expected_frame_count,
     ));
 
     let app = App::new()?;
@@ -220,7 +235,10 @@ pub fn run_tier_a_measurement_cell(
         &artifact_directory.join("cell-spec.json"),
         &outcome.specification,
     )?;
-    write_json_artifact(&artifact_directory.join("machine-spec.json"), &outcome.machine_specification)?;
+    write_json_artifact(
+        &artifact_directory.join(MACHINE_SPECIFICATION_JSON_FILE_NAME),
+        &outcome.machine_specification,
+    )?;
     write_json_artifact(&artifact_directory.join("summary.json"), &outcome)?;
 
     Ok(outcome)
@@ -248,9 +266,11 @@ mod tests {
             warmup_exclusion_seconds: 60,
             python_callback_registration_token: "cell-token".to_string(),
             anchor_processor_thread_gil: true,
+            stage_callback_attribute: "passthrough_stage".to_string(),
             resolved_delivery_profile: "every_sample".to_string(),
             measured_metric_name: "source_emit_to_sink_receive".to_string(),
             repetition_index: 3,
+            measurement_stamping_is_compiled_in: true,
         }
     }
 
@@ -260,7 +280,10 @@ mod tests {
     #[test]
     fn cell_directory_names_encode_every_distinguishing_dimension() {
         let name = example_specification().artifact_directory_name();
-        assert_eq!(name, "arm-in-process-python__fps-060__gil-anchor-on__rep-03");
+        assert_eq!(
+            name,
+            "arm-in-process-python__fps-060__stage-passthrough_stage__gil-anchor-on__rep-03"
+        );
 
         let floor_arm = TierAMeasurementCellSpecification {
             arm: MeasurementArm::RustPassthroughFloor,
@@ -320,5 +343,41 @@ mod tests {
         let decoded: TierAMeasurementCellSpecification =
             serde_json::from_value(encoded).expect("deserializes");
         assert_eq!(decoded, specification);
+    }
+}
+
+#[cfg(test)]
+mod cell_directory_collision_tests {
+    use super::*;
+
+    /// Two cells differing only by stage must not share a directory. They did
+    /// before the stage token was added, and the second silently overwrote the
+    /// first — losing half a matrix with no error.
+    #[test]
+    fn cells_differing_only_by_stage_get_distinct_directories() {
+        let passthrough = TierAMeasurementCellSpecification {
+            arm: MeasurementArm::InProcessPython,
+            frame_width_pixels: 1280,
+            frame_height_pixels: 720,
+            channel_count: 4,
+            target_frames_per_second: 30,
+            cell_duration_seconds: 600,
+            warmup_exclusion_seconds: 60,
+            python_callback_registration_token: "token".to_string(),
+            anchor_processor_thread_gil: true,
+            stage_callback_attribute: "passthrough_stage".to_string(),
+            resolved_delivery_profile: "every_sample".to_string(),
+            measured_metric_name: "source_emit_to_sink_receive".to_string(),
+            repetition_index: 0,
+            measurement_stamping_is_compiled_in: true,
+        };
+        let realistic = TierAMeasurementCellSpecification {
+            stage_callback_attribute: "realistic_stage".to_string(),
+            ..passthrough.clone()
+        };
+        assert_ne!(
+            passthrough.artifact_directory_name(),
+            realistic.artifact_directory_name()
+        );
     }
 }

--- a/spikes/streamlib-pyembed-spike/src/zero_copy_numpy_frame_view.rs
+++ b/spikes/streamlib-pyembed-spike/src/zero_copy_numpy_frame_view.rs
@@ -1,0 +1,455 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Hands a Rust-owned pixel buffer to a Python callable as a numpy `uint8`
+//! array that aliases the buffer, with no copy and no ownership transfer.
+//!
+//! rust-numpy has no safe public way to do this: `PyArray::from_slice` copies
+//! element by element, `from_vec` / `into_pyarray` move the allocation into a
+//! `PySliceContainer` base object, and `new_with_data` / `from_raw_parts` are
+//! private. The only reachable route is the C API re-export — `PY_ARRAY_API`
+//! plus `npyffi` — calling `PyArray_New` with a caller-supplied `data` pointer
+//! and no `NPY_ARRAY_OWNDATA` flag.
+//!
+//! The view is valid only for the duration of the call. Nothing in numpy or
+//! CPython enforces that. This module *detects* a violation after the fact by
+//! reading the array's reference count; it cannot *prevent* one.
+
+use std::ffi::{c_int, c_void};
+use std::ptr;
+
+use numpy::PY_ARRAY_API;
+use numpy::npyffi::{self, NPY_ARRAY_C_CONTIGUOUS, NPY_ARRAY_WRITEABLE, NPY_TYPES, npy_intp};
+use pyo3::exceptions::PyValueError;
+use pyo3::types::PyAnyMethods;
+use pyo3::{Bound, Py, PyAny, PyResult, Python};
+
+/// Reference count the frame view is expected to carry once the callback has
+/// returned and its return value has been released.
+///
+/// Exactly one strong reference exists at that point: the `Bound` this module
+/// holds, created from the new reference `PyArray_New` returned. `call1` may
+/// pass the argument through CPython's vectorcall protocol (borrowed, no
+/// container) or through a temporary argument tuple depending on the build, but
+/// either way that temporary is released before `call1` returns, and a Python
+/// callee's frame drops its argument references when the frame exits. So a
+/// well-behaved callback leaves the count at 1, and anything above 1 is a
+/// reference the callback parked somewhere that outlives the call.
+const FRAME_VIEW_REFCOUNT_WITH_NO_PYTHON_REFERENCE_HELD: isize = 1;
+
+/// Whether the Python callback retained a reference to the frame view past its call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NumpyFrameViewEscapeOutcome {
+    NoEscape,
+    RetainedByPythonWithRefcount(isize),
+}
+
+/// Invoke `callable` with a zero-copy numpy uint8 view of shape
+/// (height, width, channel_count) aliasing `frame_pixel_bytes`.
+///
+/// The view aliases the caller's buffer for the duration of the call only. If
+/// the callback keeps it, the returned outcome says so — dereferencing that
+/// retained array after `frame_pixel_bytes` goes away is a use-after-free that
+/// this function reports but does not prevent.
+pub fn invoke_python_callback_over_zero_copy_frame_view(
+    python: Python<'_>,
+    callable: &Py<PyAny>,
+    frame_pixel_bytes: &mut [u8],
+    frame_height_pixels: usize,
+    frame_width_pixels: usize,
+    channel_count: usize,
+) -> PyResult<NumpyFrameViewEscapeOutcome> {
+    let required_byte_count = frame_height_pixels
+        .checked_mul(frame_width_pixels)
+        .and_then(|pixel_count| pixel_count.checked_mul(channel_count))
+        .ok_or_else(|| {
+            PyValueError::new_err(format!(
+                "frame shape ({frame_height_pixels}, {frame_width_pixels}, {channel_count}) \
+                 overflows a byte count"
+            ))
+        })?;
+    if frame_pixel_bytes.len() != required_byte_count {
+        return Err(PyValueError::new_err(format!(
+            "frame buffer holds {} bytes but shape \
+             ({frame_height_pixels}, {frame_width_pixels}, {channel_count}) needs \
+             {required_byte_count}",
+            frame_pixel_bytes.len()
+        )));
+    }
+
+    let mut frame_view_dimensions: [npy_intp; 3] = [
+        frame_height_pixels as npy_intp,
+        frame_width_pixels as npy_intp,
+        channel_count as npy_intp,
+    ];
+    let frame_pixel_bytes_pointer = frame_pixel_bytes.as_mut_ptr();
+
+    // SAFETY: `PyArray_New` builds an array header around `data` without
+    // reading or copying it. Soundness rests on four things:
+    //   - The interpreter is attached (`python` proves it) and numpy's C API
+    //     capsule is loaded, so the API slot and `PyArray_Type` are valid.
+    //   - `frame_view_dimensions` lives until `PyArray_New` returns; numpy
+    //     copies the dims into the array header, it does not alias them. Null
+    //     `strides` asks numpy to compute C-contiguous strides; itemsize 0 is
+    //     ignored for a fixed-width type like `NPY_UBYTE`.
+    //   - The flags deliberately omit `NPY_ARRAY_OWNDATA`, and numpy clears it
+    //     itself on the caller-supplied-data path, so numpy will never free the
+    //     Rust allocation. Null `obj` means no subclass `__array_finalize__`.
+    //   - `frame_pixel_bytes_pointer` is valid for `required_byte_count` bytes
+    //     and, because `frame_pixel_bytes` is a `&mut` borrow held across this
+    //     whole function, nothing else in Rust reads or writes it while Python
+    //     can. That borrow is what makes the alias sound, and it is upheld by
+    //     the caller through the borrow checker.
+    // The obligation the borrow checker CANNOT uphold: the array must not
+    // outlive this call. Python is free to stash it; if it does and later
+    // touches it, that is a read or write of freed (or reused) Rust memory.
+    // `read_numpy_frame_view_escape_outcome` below reports that it happened —
+    // it does not stop it.
+    let frame_view_array = unsafe {
+        let raw_frame_view_array_pointer = PY_ARRAY_API.PyArray_New(
+            python,
+            npyffi::get_type_object(python, npyffi::NpyTypes::PyArray_Type),
+            frame_view_dimensions.len() as c_int,
+            frame_view_dimensions.as_mut_ptr(),
+            NPY_TYPES::NPY_UBYTE as c_int,
+            ptr::null_mut(),
+            frame_pixel_bytes_pointer.cast::<c_void>(),
+            0,
+            NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_WRITEABLE,
+            ptr::null_mut(),
+        );
+        Bound::from_owned_ptr_or_err(python, raw_frame_view_array_pointer)?
+    };
+
+    let callback_call_result = callable.bind(python).call1((&frame_view_array,));
+
+    // A callback that returns the view unchanged is well-behaved, but the
+    // returned handle is a strong reference and would read as a retention.
+    // Release it before counting.
+    let callback_raised_error = match callback_call_result {
+        Ok(callback_return_value) => {
+            drop(callback_return_value);
+            None
+        }
+        Err(callback_error) => Some(callback_error),
+    };
+
+    let escape_outcome = read_numpy_frame_view_escape_outcome(&frame_view_array);
+
+    if let Some(callback_error) = callback_raised_error {
+        // A raising callback is itself an escape route: the exception carries a
+        // traceback holding the callback's frame, and that frame holds the view
+        // in its locals. The error is what the caller asked about, so the
+        // retention goes to the log rather than the return value.
+        if let NumpyFrameViewEscapeOutcome::RetainedByPythonWithRefcount(observed_refcount) =
+            escape_outcome
+        {
+            tracing::warn!(
+                observed_refcount,
+                "python callback raised; its traceback still references the frame view"
+            );
+        }
+        return Err(callback_error);
+    }
+
+    Ok(escape_outcome)
+}
+
+/// Import numpy and load its C array API so the first frame does not pay for it.
+///
+/// Without this, the first `invoke_python_callback_over_zero_copy_frame_view`
+/// on a process pays a module import inside the measured region and lands in
+/// the p99.9 bucket.
+pub fn preload_numpy_c_array_api_before_first_frame_view(python: Python<'_>) -> PyResult<()> {
+    pyo3::types::PyModule::import(python, "numpy")?;
+    // SAFETY: numpy imported cleanly above, so the capsule lookup this forces
+    // has a module to read from. The returned type-object pointer is borrowed
+    // from numpy's static API table and is only discarded here.
+    let _ = unsafe { npyffi::get_type_object(python, npyffi::NpyTypes::PyArray_Type) };
+    Ok(())
+}
+
+fn read_numpy_frame_view_escape_outcome(
+    frame_view_array: &Bound<'_, PyAny>,
+) -> NumpyFrameViewEscapeOutcome {
+    // SAFETY: `frame_view_array` is a live strong reference held by this stack
+    // frame, so the object header is allocated while `Py_REFCNT` reads it, and
+    // the interpreter is attached for as long as the `Bound` exists. The read
+    // takes no reference of its own, so it cannot leak.
+    let observed_refcount = unsafe { pyo3::ffi::Py_REFCNT(frame_view_array.as_ptr()) };
+    if observed_refcount > FRAME_VIEW_REFCOUNT_WITH_NO_PYTHON_REFERENCE_HELD {
+        NumpyFrameViewEscapeOutcome::RetainedByPythonWithRefcount(observed_refcount)
+    } else {
+        NumpyFrameViewEscapeOutcome::NoEscape
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::OnceLock;
+
+    use pyo3::types::{PyDict, PyDictMethods, PyList, PyListMethods};
+
+    use super::*;
+    use crate::monotonic_clock::read_monotonic_clock_nanoseconds;
+
+    fn initialize_interpreter_once() {
+        static INTERPRETER_INITIALIZED: OnceLock<()> = OnceLock::new();
+        INTERPRETER_INITIALIZED.get_or_init(Python::initialize);
+    }
+
+    /// Compiles `lambda_source` with `observation_sink` bound in its globals as
+    /// a list, so a callback can report what it saw without retaining the view.
+    fn compile_callback_with_observation_sink<'py>(
+        python: Python<'py>,
+        lambda_source: &std::ffi::CStr,
+    ) -> (Py<PyAny>, Bound<'py, PyList>) {
+        let callback_globals = PyDict::new(python);
+        let observation_sink = PyList::empty(python);
+        callback_globals
+            .set_item("observation_sink", &observation_sink)
+            .expect("globals accept the sink");
+        let callable = python
+            .eval(lambda_source, Some(&callback_globals), None)
+            .expect("lambda compiles")
+            .unbind();
+        (callable, observation_sink)
+    }
+
+    /// Guards against a silent regression to a copying constructor: if the
+    /// array ever stops aliasing the Rust allocation, every latency number this
+    /// spike produces is measuring a memcpy that the real design would not pay.
+    #[test]
+    fn python_writes_through_the_view_into_the_rust_buffer() {
+        initialize_interpreter_once();
+        let mut frame_pixel_bytes = vec![0u8; 2 * 3 * 4];
+        Python::attach(|python| {
+            let callable = python
+                .eval(
+                    pyo3::ffi::c_str!("lambda frame_view: frame_view.__setitem__((0, 0, 0), 200)"),
+                    None,
+                    None,
+                )
+                .expect("lambda compiles")
+                .unbind();
+            let escape_outcome = invoke_python_callback_over_zero_copy_frame_view(
+                python,
+                &callable,
+                &mut frame_pixel_bytes,
+                2,
+                3,
+                4,
+            )
+            .expect("callback runs");
+            assert_eq!(escape_outcome, NumpyFrameViewEscapeOutcome::NoEscape);
+        });
+        assert_eq!(frame_pixel_bytes[0], 200);
+    }
+
+    /// Guards the array header contract. `OWNDATA` true would mean numpy
+    /// believes it may free the Rust allocation; a wrong dtype or a
+    /// non-C-contiguous layout would make downstream Python silently reinterpret
+    /// the pixels.
+    #[test]
+    fn the_view_is_a_c_contiguous_non_owning_uint8_array_of_the_requested_shape() {
+        initialize_interpreter_once();
+        let mut frame_pixel_bytes = vec![0u8; 5 * 7 * 3];
+        Python::attach(|python| {
+            let (callable, observation_sink) = compile_callback_with_observation_sink(
+                python,
+                pyo3::ffi::c_str!(
+                    "lambda frame_view: observation_sink.append((\
+                     bool(frame_view.flags.owndata), \
+                     bool(frame_view.flags.c_contiguous), \
+                     bool(frame_view.flags.writeable), \
+                     str(frame_view.dtype), \
+                     frame_view.shape))"
+                ),
+            );
+            let escape_outcome = invoke_python_callback_over_zero_copy_frame_view(
+                python,
+                &callable,
+                &mut frame_pixel_bytes,
+                5,
+                7,
+                3,
+            )
+            .expect("callback runs");
+            assert_eq!(escape_outcome, NumpyFrameViewEscapeOutcome::NoEscape);
+
+            let (owns_data, is_c_contiguous, is_writeable, dtype_name, observed_shape): (
+                bool,
+                bool,
+                bool,
+                String,
+                (usize, usize, usize),
+            ) = observation_sink
+                .get_item(0)
+                .expect("the callback recorded one observation")
+                .extract()
+                .expect("observation has the recorded shape");
+
+            assert!(!owns_data, "numpy must not believe it owns the Rust buffer");
+            assert!(is_c_contiguous);
+            assert!(is_writeable);
+            assert_eq!(dtype_name, "uint8");
+            assert_eq!(observed_shape, (5, 7, 3));
+        });
+    }
+
+    /// Guards the escape check's sensitivity. A baseline off by one makes this
+    /// check fire on every frame or on none, and either way it stops being
+    /// evidence about whether in-process Python is safe to ship.
+    #[test]
+    fn a_callback_that_stashes_the_view_is_reported_as_retained() {
+        initialize_interpreter_once();
+        let mut frame_pixel_bytes = vec![0u8; 4 * 4 * 4];
+        Python::attach(|python| {
+            let (callable, retained_reference_sink) = compile_callback_with_observation_sink(
+                python,
+                pyo3::ffi::c_str!("lambda frame_view: observation_sink.append(frame_view)"),
+            );
+            let escape_outcome = invoke_python_callback_over_zero_copy_frame_view(
+                python,
+                &callable,
+                &mut frame_pixel_bytes,
+                4,
+                4,
+                4,
+            )
+            .expect("callback runs");
+
+            match escape_outcome {
+                NumpyFrameViewEscapeOutcome::RetainedByPythonWithRefcount(observed_refcount) => {
+                    assert!(observed_refcount >= 2, "got {observed_refcount}");
+                }
+                NumpyFrameViewEscapeOutcome::NoEscape => {
+                    panic!("a stashed view must be reported as retained")
+                }
+            }
+
+            // Release the dangling view while the Rust buffer is still alive.
+            // Letting it outlive `frame_pixel_bytes` is exactly the
+            // use-after-free this module can report but not prevent.
+            retained_reference_sink
+                .call_method0("clear")
+                .expect("the sink clears");
+        });
+    }
+
+    /// Guards against a check that always fires: an ordinary callback must come
+    /// back clean, otherwise the harness would flag every measured frame.
+    #[test]
+    fn a_well_behaved_callback_is_reported_as_no_escape() {
+        initialize_interpreter_once();
+        let mut frame_pixel_bytes = vec![0u8; 4 * 4 * 4];
+        Python::attach(|python| {
+            let callable = python
+                .eval(pyo3::ffi::c_str!("lambda frame_view: int(frame_view[0, 0, 0])"), None, None)
+                .expect("lambda compiles")
+                .unbind();
+            let escape_outcome = invoke_python_callback_over_zero_copy_frame_view(
+                python,
+                &callable,
+                &mut frame_pixel_bytes,
+                4,
+                4,
+                4,
+            )
+            .expect("callback runs");
+            assert_eq!(escape_outcome, NumpyFrameViewEscapeOutcome::NoEscape);
+        });
+    }
+
+    /// Guards against a shape that disagrees with the buffer reaching
+    /// `PyArray_New`, which would hand Python an array reading past the
+    /// allocation. It must surface as a Python exception, not a panic unwinding
+    /// through the interpreter.
+    #[test]
+    fn a_shape_that_does_not_match_the_buffer_returns_a_value_error() {
+        initialize_interpreter_once();
+        let mut frame_pixel_bytes = vec![0u8; 10];
+        Python::attach(|python| {
+            let callable = python
+                .eval(pyo3::ffi::c_str!("lambda frame_view: None"), None, None)
+                .expect("lambda compiles")
+                .unbind();
+            let invocation_error = invoke_python_callback_over_zero_copy_frame_view(
+                python,
+                &callable,
+                &mut frame_pixel_bytes,
+                4,
+                4,
+                4,
+            )
+            .expect_err("a mismatched shape is rejected");
+            assert!(invocation_error.is_instance_of::<PyValueError>(python));
+        });
+    }
+
+    /// The load-bearing proof that the view is zero-copy rather than merely
+    /// documented as such: a copying constructor costs one memcpy per frame, so
+    /// a 6.75x larger frame would cost ~6.75x more. Aliasing costs the same for
+    /// both. The threshold is deliberately loose so this asserts the mechanism,
+    /// not a machine-specific ratio.
+    #[test]
+    fn invocation_cost_does_not_scale_with_frame_size() {
+        initialize_interpreter_once();
+
+        fn minimum_invocation_nanoseconds(
+            python: Python<'_>,
+            callable: &Py<PyAny>,
+            frame_height_pixels: usize,
+            frame_width_pixels: usize,
+        ) -> i64 {
+            const CHANNEL_COUNT: usize = 4;
+            const WARMUP_ITERATIONS: usize = 200;
+            const MEASURED_ITERATIONS: usize = 2_000;
+
+            let mut frame_pixel_bytes =
+                vec![0u8; frame_height_pixels * frame_width_pixels * CHANNEL_COUNT];
+            let mut minimum_nanoseconds = i64::MAX;
+            for iteration in 0..(WARMUP_ITERATIONS + MEASURED_ITERATIONS) {
+                let started_at_nanoseconds = read_monotonic_clock_nanoseconds();
+                invoke_python_callback_over_zero_copy_frame_view(
+                    python,
+                    callable,
+                    &mut frame_pixel_bytes,
+                    frame_height_pixels,
+                    frame_width_pixels,
+                    CHANNEL_COUNT,
+                )
+                .expect("callback runs");
+                let elapsed_nanoseconds =
+                    read_monotonic_clock_nanoseconds() - started_at_nanoseconds;
+                if iteration >= WARMUP_ITERATIONS {
+                    minimum_nanoseconds = minimum_nanoseconds.min(elapsed_nanoseconds);
+                }
+            }
+            minimum_nanoseconds
+        }
+
+        Python::attach(|python| {
+            preload_numpy_c_array_api_before_first_frame_view(python)
+                .expect("numpy is importable");
+            let callable = python
+                .eval(pyo3::ffi::c_str!("lambda frame_view: None"), None, None)
+                .expect("lambda compiles")
+                .unbind();
+
+            let small_frame_nanoseconds =
+                minimum_invocation_nanoseconds(python, &callable, 480, 640);
+            let large_frame_nanoseconds =
+                minimum_invocation_nanoseconds(python, &callable, 1080, 1920);
+
+            // 6.75x the bytes; allow 3x the time plus a fixed 2µs of scheduler
+            // slack before calling it size-dependent.
+            assert!(
+                large_frame_nanoseconds <= small_frame_nanoseconds * 3 + 2_000,
+                "cost scales with frame size, so the view is not zero-copy: \
+                 640x480x4 min {small_frame_nanoseconds}ns vs \
+                 1920x1080x4 min {large_frame_nanoseconds}ns"
+            );
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Tier A of the #1702 go/no-go spike: a throwaway crate that measures in-process Python (CPython
embedded via PyO3) against today's subprocess-per-Python-processor model, plus proof it runs end
to end. **Zero engine changes** — every processor enters through the existing `App::add_local`
path, and nothing outside `spikes/` is touched.

**This PR delivers the harness, not the protocol numbers.** No 10-minute cells, no full A/B/A
matrix, no soak, no subprocess baseline. Those are PR 2 (stacked: `spike/1702-pyembed-tier-b`).

### The interesting early result

| cell (10s smoke, not a protocol run) | emit→sink p50 | stage callback p50 |
|---|---|---|
| 720p30 Rust floor (no interpreter) | 9.63 ms | — |
| 720p30 Python passthrough | 9.61 ms | 13.8 µs |
| 1080p30 Python realistic | 27.16 ms | 4.18 ms |

The Python arm is **indistinguishable from the pure-Rust floor**. The engine wire hop outweighs the
PyO3 callback by roughly three orders of magnitude. That attribution is only possible because of
the floor arm, which was added after recon showed gate 5 passes by ~39x naive / ~3300x anchored and
therefore does not discriminate.

### Owner decisions that shaped this, recorded on the issue

Two `[NEEDS DECISION]` comments were posted before and during implementation
([first](https://github.com/tatolab/streamlib/issues/1702#issuecomment-5153081295),
[second](https://github.com/tatolab/streamlib/issues/1702#issuecomment-5153235020)). Answered:
`every_sample` delivery profile with latency percentiles primary; metric renamed to
`source_emit_to_sink_receive` because capture-to-present is not observable in either tier; floor
arm added and gate 5 demoted; Tier B goes 720p30 + 720p60.

**Still open and blocking the protocol runs, not this PR:** SCHED_OTHER vs SCHED_FIFO for the
primary numbers; whether to add an absolute p99.9 ceiling; whether 1080p60 is dropped (see below);
and whether the embed-vs-import arrangement needs measuring both ways.

## Closes

Closes nothing — #1702 stays open until the verdict is posted after Tier B.

## Exit criteria

Against #1702's "Done means", this PR covers item 2 (the artifact machinery) and none of item 1 or 3:

- [x] Artifact dir emitted per cell: runner script with `--fps --stage --mode --gc --duration`,
      `machine-spec.json`, per-frame JSONL, mergeable HDR histogram export, `summary.json`,
      GC telemetry sidecar, repro README.
- [x] Timer overhead microbenched and the stamping-compiled-out control implemented and proven.
- [ ] Tier A and Tier B numbers under the frozen protocol — PR 2.
- [ ] A verdict posted — PR 2.

## Test plan

- `cargo test --release` → **63 pass**, and `--features stamping-compiled-out` → **47 pass**
  (the recorder's tests are correctly absent from a control build).
- `cargo clippy --all-targets` → **clean** for this crate.
- `python3 -m unittest discover -s python` → **14 pass**, including one that invokes the harness
  with the exact argv `runner.py` builds and asserts a `summary.json` appears.
- End-to-end verified on the rig for both arms at 640x480 / 720p / 1080p, 30 and 60fps, GIL anchor
  on and off, and through `runner.py` with A/B/A interleaving. Zero drops, zero negative-latency
  anomalies, zero histogram saturation across every run.
- Load-bearing claims are asserted, not commented: zero-copy is proven by Python writing through
  into the Rust buffer and by invocation cost being flat across a 6.75x frame-size change; the GIL
  anchor is proven by a measured 4.1x end-to-end difference against its own control condition.

## Notes for owner

**1. The engine wire hop is the dominant cost, and it bounds the protocol.** Floor-arm p50 is
1.44ms at 640x480, 9.63ms at 720p, ~27ms at 1080p — pure Rust, no Python. `read_raw` allocates a
fresh 64 KiB `Vec`, then a fresh full-size `Vec`, then memcpys, **per read per hop**
(`plugin-abi/src/vtables/input_mailboxes.rs:156-157`, allocation inside the retry loop). At 1080p
the two-hop service time exceeds the 60fps frame period, so a 1080p60 cell runs saturated and its
percentiles would describe queue occupancy rather than latency. `read_raw_bounded` exists on the
engine's `InputMailboxesInner` (`iceoryx2/input.rs:448`) and would allow a reused buffer, but is
not exposed on the SDK's input reader. **This is a finding about the engine that is independent of
the pivot** — worth your call whether it becomes real work.

**2. The spike's `Cargo.lock` is not committed**, following `.gitignore:51-52` rather than
overriding it. For a crate whose output is gating numbers, caret-ranged deps mean a rerun can
resolve different versions. Flagged rather than decided.

**3. Nothing here is an API proposal.** The callback token registry, the process-global measurement
collection point, and the Python shapes are deliberate spike artifacts. #1702 defers API design
until after the numbers.

**4. Two reviewers ran against this branch and both initially returned REJECT.** Every blocker and
should-fix is addressed in the second commit; the most serious were that `runner.py` could not
invoke the harness at all, and that the `stamping-compiled-out` control feature had no `cfg` sites
and would have reported zero instrument overhead by construction.

**5. Known gap carried to PR 2:** escape detection via `Py_REFCNT` is exact only on a GIL-based
CPython; on a free-threaded build (3.13t+) biased reference counting makes it advisory. Also, a
callback that stashes `frame_view.ctypes.data` as a raw integer escapes the address without holding
a reference and reads as `NoEscape`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
