### PR TITLE
chore(spike): all three arms, the warm-restart battery, and the gate evaluator (#1702)

### DIFF
--- a/spikes/streamlib-pyembed-spike/.gitignore
+++ b/spikes/streamlib-pyembed-spike/.gitignore
@@ -1,5 +1,4 @@
 /target
 /artifacts
-/.provisioned
 /streamlib_modules
 /streamlib.lock

--- a/spikes/streamlib-pyembed-spike/.gitignore
+++ b/spikes/streamlib-pyembed-spike/.gitignore
@@ -1,2 +1,5 @@
 /target
 /artifacts
+/.provisioned
+/streamlib_modules
+/streamlib.lock

--- a/spikes/streamlib-pyembed-spike/README.md
+++ b/spikes/streamlib-pyembed-spike/README.md
@@ -44,7 +44,7 @@ its own name rather than an unmeasured one under the frozen name.
 |---|---|
 | `rust-passthrough-floor` | The engine's own wire-hop cost, no interpreter. Run this first at every cell. |
 | `in-process-python` | The same graph with a Python callable on the processor thread. |
-| subprocess baseline | Today's model. **Not in this PR** — Tier B, see #1702. |
+| `subprocess-python-baseline` | Today's model: same callback, own process, own venv, through the python-native cdylib. The arm the pivot is measured against. |
 
 The floor arm exists because gate 5 does not discriminate: PyO3 callback overhead passes its
 0.5ms budget by ~39x naive and ~3300x anchored, while the engine's `read_raw` allocates a fresh
@@ -52,44 +52,48 @@ The floor arm exists because gate 5 does not discriminate: PyO3 callback overhea
 (`plugin-abi/src/vtables/input_mailboxes.rs:156-157`, allocation inside the retry loop). Without a
 floor arm a large absolute latency is unattributable.
 
-Smoke numbers from this branch (10s cells, not protocol runs — see "Status" below):
+Numbers from this branch (720p60, passthrough, 30s cells, surface references — not protocol runs;
+see "Status"):
 
 ```
-720p30  floor  emit->sink p50 9.63ms   p99 11.09ms
-720p30  python emit->sink p50 9.61ms   p99 11.08ms   stage callback p50 13.8µs
-1080p30 python emit->sink p50 27.16ms  p99 29.38ms   stage callback p50 4.18ms (realistic)
+arm                          p50       p99     p99.9       max
+rust-passthrough-floor   0.071ms   0.107ms   0.120ms   0.124ms
+in-process-python        0.089ms   0.120ms   0.133ms   0.144ms
+subprocess-python-baseline 0.180ms 0.238ms   0.265ms   1.141ms
 ```
 
-The Python arm is indistinguishable from the pure-Rust floor at the same geometry. The wire hop
-dominates by three orders of magnitude over the PyO3 callback.
+In-process beats the baseline 2.0x at p50 and 2.0x at p99. PyO3 costs ~18µs at p50 over the
+pure-Rust floor.
 
-**The floor scales with payload, and that bounds the protocol.** Floor-arm p50 is 1.44ms at
-640x480, 9.63ms at 720p, ~27ms at 1080p — the engine's `read_raw` allocates a fresh 64 KiB `Vec`,
-then a fresh full-size `Vec`, then memcpys, per read per hop. At 1080p the two-hop service time
-exceeds the 60fps frame period (16.6ms), so a 1080p60 cell runs saturated and its percentiles would
-describe queue occupancy rather than latency. Posted to #1702; 1080p is a 30fps-only geometry until
-the owner rules.
+## What crosses the wire
 
-## The GIL attachment anchor
+`--wire-payload-mode surface-reference` (the default) puts a fixed-width surface reference on the
+link, matching what a real `@tatolab/core/VideoFrame` weighs — it references its GPU surface by id
+(`packages/core/schemas/video_frame.yaml`). The pixels the callback views are resolved
+process-locally, standing in for `GpuContext::resolve_pixel_buffer_by_surface_id`
+(`gpu_context.rs:681`), which an in-process processor can already reach with no engine change.
 
-`Python::attach` on a foreign thread maps to `PyGILState_Ensure()`, which builds a thread state on
-entry and destroys it on exit. CPython 3.12 virtual-allocates the frame datastack chunk on first
-Python frame push and frees it on thread-state delete — one `mmap` + one `munmap` per frame
-(measured: 1041 mmap / 1005 munmap per 1000 calls). The anchor holds one unreleased
-`PyGILState_Ensure` parked with `PyEval_SaveThread`, dropping per-call cost from p50 6.3µs to
-p50 110ns. Public `pyo3::ffi` only.
+`--wire-payload-mode full-pixel-payload` pushes whole uncompressed pictures instead. It exists only
+to reproduce the payload sweep that retracted an earlier ~27ms 1080p "floor", and the summarizer
+refuses to let such a cell back any gate. At 1080p60 the two modes differ by 175x (0.091ms vs
+15.917ms) — the earlier figure was the harness's transport choice, not an engine property.
 
-Whether the real SDK should anchor processor threads is a pivot design question these numbers do
-not settle: anchoring trades a resident thread state per processor thread for the syscall pair.
-`--disable-gil-anchor` is the control condition.
+The reference body is padded to a fixed 192 bytes on purpose: a bare encoding varies with the
+decimal digit count of the geometry it describes, which would make the resolution leg of the matrix
+vary transport width as well as pixel work.
 
-## Delivery profile
+## Startup settle
 
-Every input port declares `delivery_profile = "every_sample"`. Owner decision on #1702: latency
-percentiles are the primary signal; drop counts are reported, not gated. Under `latest`
-(SkipToLatest) the sink drains to the newest sample, pinning latency near one frame period and
-making the percentile gates near-vacuous. `delivery_profile` is a compile error on an `output(...)`
-(`grammar.rs:432-448`) — it is consumer-side only.
+`--startup-settle-seconds` (default 2.0) is a quiet period before the source's first frame, held
+identical across arms. `Runner::start()` returns once the graph compiles, but a Python subprocess
+needs ~0.66s more to spawn, import, and reach its poll loop; frames emitted into that window queue
+up, and under `every_sample` the backlog is never dropped. It drains only as fast as the consumer
+runs ahead of the source, so it outlives the warmup exclusion, which excludes by *time*.
+
+Before the settle existed, the baseline arm reported p50 183ms over a 20s cell and 84ms over a 40s
+cell against 0.089ms in-process. All of it was startup transient. The recorder now also compares its
+first measured decile against its last and reports `backlog_drain_fraction`; a cell that shed a
+fifth of its latency across its own life is refused rather than reported.
 
 ## Running a cell
 
@@ -103,8 +107,63 @@ PYTHONPATH=python ./target/release/tier_a_harness \
   --output-directory ./artifacts
 ```
 
-`python/runner.py` invokes the harness once per cell; one cell per process keeps interpreter, GC,
-and allocator state from leaking between cells.
+`python/runner.py` invokes the harness once per cell over an A/B/A schedule; one cell per process
+keeps interpreter, GC, and allocator state from leaking between cells.
+
+### The subprocess baseline arm needs provisioning first
+
+```
+python3 python/provision_subprocess_baseline_package.py
+```
+
+Idempotent, and required before any `--mode subprocess` cell. Three prerequisites the harness
+cannot satisfy from inside a measurement run, each of which fails in a way that reads as a slow or
+absent baseline rather than a broken one:
+
+- `libstreamlib_python_native.so` is absent from `target/`. It is built and pinned by absolute path
+  via `STREAMLIB_PYTHON_NATIVE_LIB` so a stale or foreign artifact cannot win — an unpinned
+  subprocess resolves a different cdylib whose iceoryx2 service constants disagree with the host's,
+  fails to open its own input channel with `DoesNotSupportRequestedAmountOfPublishers`, and the cell
+  reports an arm that produced no frames.
+- The package's `streamlib` dependency resolves from no index. A `[tool.uv.sources]` path override
+  at this checkout's Python SDK is injected into a staged copy — the same rewrite
+  `streamlib link --engine` performs (`python_venv.rs:360-393`), scoped to the package so a
+  measurement run neither depends on nor disturbs global link state.
+- `streamlib install` skips linked entries by design and the module loader refuses to cold-build an
+  installed slot, so nothing in between provisions a linked Python package's venv.
+
+`STREAMLIB_MODULES_DIR` points the module slot, the link, and the lock file at the spike crate, so
+provisioning writes nothing outside `spikes/`.
+
+### Warm-restart battery (gate 6)
+
+```
+PYTHONPATH=python python3 python/warm_restart_battery.py \
+  --harness-binary ./target/release/tier_a_harness \
+  --warm-run-count 10 --extra-import torch --output-dir ./artifacts/restart
+```
+
+1 cold + N warm restarts, each a fresh process, measuring exec-to-first-frame from a pre-spawn
+`CLOCK_MONOTONIC` stamp to the sink's first-frame stamp. On this branch: warm median **0.869s**
+against a 1.5s threshold, cold 0.919s.
+
+### Evaluating the gates
+
+```
+python3 python/summarize_measurement_matrix.py ./artifacts
+```
+
+Built around one rule: never report a verdict a cell cannot support, because a silently skipped gate
+reads as a passed one. Cells are refused — loudly, with the reason — when they were built with
+stamping compiled out, carry the full-pixel payload, resolved a delivery profile other than
+`every_sample`, received no frames, disagreed on clocks, saturated the histogram, or drained a
+startup backlog.
+
+Two gates stay NOT EVALUATED until the owner states a number. Owner decision 3 made the
+floor-vs-PyO3 delta the gate and decision 4 added an absolute p99.9 ceiling; neither names a
+threshold, and #1702 states thresholds are evaluated verbatim and never decided inline. Both
+quantities are computed and printed; `--floor-delta-gate-ms` and `--absolute-p99-9-ceiling-ms` turn
+them into verdicts.
 
 Add `--require-locked-measurement-state` for gated cells. The harness **verifies** the machine is
 locked and fails fast; it never invokes `sudo` (`sudo -n` fails on the reference box and a password
@@ -119,7 +178,7 @@ owner checklist of privileged commands as data.
 | `machine-spec.json` | CPU/governor/boost, kernel + preemption, glibc, GPU + driver, Python/numpy, scheduling class, loadavg. Unknown knobs carry an explicit reason, never a silent default. |
 | `per-frame-measurements.jsonl` | One object per frame, warmup-excluded frames included (raw data is raw). |
 | `source-emit-to-sink-receive.histogram` | Mergeable HDR histogram export. |
-| `summary.json` | p50/p99/p99.9/max, drop count, and the anomaly counters. Never a headline mean — the distribution is heavily tailed. |
+| `summary.json` | p50/p99/p99.9/max, drop count, the anomaly counters, `backlog_drain_fraction`, and the sink's first-frame stamp (gate 6's endpoint). Never a headline mean — the distribution is heavily tailed. |
 | `gc-collections-embedded-interpreter.jsonl` | Every CPython collection in the interpreter that ran the callback, monotonic-stamped so a latency tail spike can be attributed to a GC. In-process arm only. |
 
 An empty GC record file is a real result, not a broken recorder: the per-frame numpy view is
@@ -128,9 +187,11 @@ generational pass is triggered during a short cell. The recorder is asserted fun
 independently (`python/test_spike_harness_contract.py` forces collections and asserts a nonzero
 count).
 
-Two counters invalidate a cell rather than degrading it, and the harness logs both at `error`:
-`negative_latency_anomaly_count` (sink stamp before emit stamp ⇒ the arms' clocks disagree) and
-`histogram_range_saturation_count` (percentiles are clipped).
+Three signals invalidate a cell rather than degrading it, and the harness logs each at `error`:
+`negative_latency_anomaly_count` (sink stamp before emit stamp ⇒ the arms' clocks disagree),
+`histogram_range_saturation_count` (percentiles are clipped), and `backlog_drain_fraction` past
+0.20 (the cell was draining a startup queue, so its percentiles describe occupancy and vary with
+how long it ran).
 
 ## Which arrangement Tier A measures
 
@@ -145,13 +206,16 @@ what the warm-restart battery measures. Posted to #1702 as an owner decision.
 
 ## Status
 
-**This PR delivers the Tier A harness and proves it runs end-to-end. It does not deliver the
-protocol numbers.** No 10-minute cell, no A/B/A matrix, no soak, no GC-tuned cells. Those and the
-subprocess baseline are Tier B (PR 2), and two protocol questions remain open with the owner:
-SCHED_OTHER vs SCHED_FIFO for the primary numbers, and whether to add an absolute p99.9 ceiling
-(tail risk sits beyond p99 — measured 611µs p99.9 and 12.8ms max under GIL contention, where only
-a relative-to-baseline delta is gated today).
+**Delivered here: all three arms, the warm-restart battery, and the gate evaluator. Not delivered:
+the protocol matrix or the verdict.** No 10-minute cells, no soak, no GC-tuned cells, no Tier B —
+those are the next PR in the stack.
+
+Gate 6 is measured and passes (0.869s warm median against 1.5s). Gates 1, 2, 4 and 5 pass on
+exploratory 720p60 cells. Gates 3 and the floor-delta gate cannot be evaluated at all until the
+owner states their thresholds.
 
 Payload is capped at 1080p: subprocess links are `UntrustedSession` (16 MiB ceiling), in-process
 host-to-host links are `Trusted` (64 MiB). 4K BGRA fits the in-process arm and is refused on the
-subprocess arm, so the two are structurally incomparable above 16 MiB.
+subprocess arm, so the two are structurally incomparable above 16 MiB — though under
+`surface-reference` the wire body no longer tracks geometry, so the cap binds only the full-pixel
+sweep.

--- a/spikes/streamlib-pyembed-spike/README.md
+++ b/spikes/streamlib-pyembed-spike/README.md
@@ -95,6 +95,27 @@ cell against 0.089ms in-process. All of it was startup transient. The recorder n
 first measured decile against its last and reports `backlog_drain_fraction`; a cell that shed a
 fifth of its latency across its own life is refused rather than reported.
 
+## The GIL attachment anchor
+
+`Python::attach` on a foreign thread maps to `PyGILState_Ensure()`, which builds a thread state on
+entry and destroys it on exit. CPython 3.12 virtual-allocates the frame datastack chunk on first
+Python frame push and frees it on thread-state delete — one `mmap` + one `munmap` per frame
+(measured: 1041 mmap / 1005 munmap per 1000 calls). The anchor holds one unreleased
+`PyGILState_Ensure` parked with `PyEval_SaveThread`, dropping per-call cost from p50 6.3µs to
+p50 110ns. Public `pyo3::ffi` only.
+
+Whether the real SDK should anchor processor threads is a pivot design question these numbers do
+not settle: anchoring trades a resident thread state per processor thread for the syscall pair.
+`--disable-gil-anchor` is the control condition.
+
+## Delivery profile
+
+Every input port declares `delivery_profile = "every_sample"`. Owner decision on #1702: latency
+percentiles are the primary signal; drop counts are reported, not gated. Under `latest`
+(SkipToLatest) the sink drains to the newest sample, pinning latency near one frame period and
+making the percentile gates near-vacuous. `delivery_profile` is a compile error on an `output(...)`
+(`grammar.rs:432-448`) — it is consumer-side only.
+
 ## Running a cell
 
 ```

--- a/spikes/streamlib-pyembed-spike/python/provision_subprocess_baseline_package.py
+++ b/spikes/streamlib-pyembed-spike/python/provision_subprocess_baseline_package.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys

--- a/spikes/streamlib-pyembed-spike/python/provision_subprocess_baseline_package.py
+++ b/spikes/streamlib-pyembed-spike/python/provision_subprocess_baseline_package.py
@@ -270,6 +270,16 @@ def provision(release: bool) -> dict:
     }
 
 
+def provisioning_record_path() -> Path:
+    """Where `provision()`'s record is left for `runner.py` to read.
+
+    The record is the single source of the environment a subprocess cell needs.
+    Recomputing it in the runner would be a second copy of the same derivation,
+    and the two drifting is exactly how the cdylib pin gets lost.
+    """
+    return resolve_spike_crate_root() / ".provisioned" / "provisioning-record.json"
+
+
 def main() -> int:
     argument_parser = argparse.ArgumentParser(description=__doc__)
     argument_parser.add_argument(
@@ -286,6 +296,7 @@ def main() -> int:
     os.environ[APP_MODULES_DIRECTORY_ENVIRONMENT_VARIABLE] = record[
         "application_modules_root"
     ]
+    provisioning_record_path().write_text(json.dumps(record, indent=2) + "\n")
     sys.stdout.write(json.dumps(record, indent=2) + "\n")
     return 0
 

--- a/spikes/streamlib-pyembed-spike/python/provision_subprocess_baseline_package.py
+++ b/spikes/streamlib-pyembed-spike/python/provision_subprocess_baseline_package.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -94,7 +95,7 @@ def build_python_native_cdylib(engine_checkout_root: Path, release: bool) -> Pat
 def stage_baseline_package_with_sdk_path_override(
     engine_checkout_root: Path,
 ) -> Path:
-    """Copy the package source to a gitignored slot, injecting the SDK path.
+    """Copy the package source to a slot under target/, injecting the SDK path.
 
     The override carries an absolute path, so the staged copy stays valid
     wherever the build orchestrator relocates it.
@@ -103,9 +104,7 @@ def stage_baseline_package_with_sdk_path_override(
     if not (source_directory / "streamlib.yaml").is_file():
         raise RuntimeError(f"no package source at {source_directory}")
 
-    staged_directory = (
-        resolve_spike_crate_root() / ".provisioned" / PACKAGE_NAME
-    )
+    staged_directory = provisioned_package_root() / PACKAGE_NAME
     if staged_directory.exists():
         shutil.rmtree(staged_directory)
     staged_directory.parent.mkdir(parents=True, exist_ok=True)
@@ -172,7 +171,87 @@ def link_staged_package_into_app_modules(
     return slot
 
 
-def provision_package_venv(staged_directory: Path) -> Path:
+def resolve_interpreter_embedded_by_harness(spike_crate_root: Path) -> str:
+    """The CPython `major.minor` the harness binary links, e.g. `3.12`.
+
+    Read from the binary rather than assumed, because it is the interpreter the
+    in-process arm actually runs and the baseline's venv has to match it. Left
+    unpinned, `uv venv` picks the newest interpreter on the box: this rig
+    produced CPython 3.14.4 for the subprocess arm against 3.12.3 embedded in
+    the harness, which makes the two arms' numbers a comparison of interpreter
+    versions as much as of hosting.
+    """
+    harness_binary = spike_crate_root / "target" / "release" / "tier_a_harness"
+    if not harness_binary.is_file():
+        raise RuntimeError(
+            f"{harness_binary} is absent; build it before provisioning so the "
+            "baseline venv can be pinned to the interpreter it embeds"
+        )
+    linked_libraries = subprocess.run(
+        ["ldd", str(harness_binary)], check=True, capture_output=True, text=True
+    ).stdout
+    match = re.search(r"libpython(\d+\.\d+)\.so", linked_libraries)
+    if match is None:
+        raise RuntimeError(
+            f"{harness_binary} links no libpython — cannot determine which "
+            "interpreter the in-process arm runs, so the arms cannot be matched"
+        )
+    return match.group(1)
+
+
+def resolve_numpy_version_for_interpreter(interpreter: str) -> str | None:
+    """numpy's version under `interpreter`, or None when it is not installed."""
+    probe = subprocess.run(
+        [interpreter, "-c", "import numpy; print(numpy.__version__)"],
+        capture_output=True,
+        text=True,
+    )
+    return probe.stdout.strip() if probe.returncode == 0 else None
+
+
+def assert_arms_share_a_runtime(
+    venv_python: Path,
+    embedded_interpreter: str,
+    in_process_numpy_version: str | None,
+) -> None:
+    """Refuse a provisioning whose two arms would run different Pythons.
+
+    Checked here rather than trusted, because the failure is invisible in every
+    artifact the run produces: both arms report plausible latencies and the
+    difference between them silently includes an interpreter-version delta.
+    """
+    reported = subprocess.run(
+        [
+            str(venv_python),
+            "-c",
+            "import sys, numpy; "
+            "print(f'{sys.version_info.major}.{sys.version_info.minor}'); "
+            "print(numpy.__version__)",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.split()
+    venv_interpreter, venv_numpy_version = reported[0], reported[1]
+
+    if venv_interpreter != embedded_interpreter:
+        raise RuntimeError(
+            f"the baseline venv runs CPython {venv_interpreter} but the harness "
+            f"embeds {embedded_interpreter}; the two arms would differ by "
+            "interpreter version as well as by hosting"
+        )
+    if (
+        in_process_numpy_version is not None
+        and venv_numpy_version != in_process_numpy_version
+    ):
+        raise RuntimeError(
+            f"the baseline venv has numpy {venv_numpy_version} but the in-process "
+            f"arm runs {in_process_numpy_version}; the realistic stage's cost is "
+            "numpy's, so the arms would not be comparable"
+        )
+
+
+def provision_package_venv(staged_directory: Path, spike_crate_root: Path) -> Path:
     """Create the package's `.venv`, which is what makes the slot loadable.
 
     `streamlib install` skips linked entries ("linked entries stay
@@ -188,22 +267,29 @@ def provision_package_venv(staged_directory: Path) -> Path:
     (`ensure_streamlib_generated_in_venv`) has nothing left to do; it is
     verified rather than repeated.
     """
+    embedded_interpreter = resolve_interpreter_embedded_by_harness(spike_crate_root)
     venv_directory = staged_directory / ".venv"
-    subprocess.run(["uv", "venv", str(venv_directory)], check=True)
-    venv_python = venv_directory / "bin" / "python"
     subprocess.run(
-        [
-            "uv",
-            "pip",
-            "install",
-            "--python",
-            str(venv_python),
-            str(staged_directory),
-        ],
+        ["uv", "venv", "--python", embedded_interpreter, str(venv_directory)],
         check=True,
     )
+    venv_python = venv_directory / "bin" / "python"
+
+    # numpy pinned to the in-process arm's version for the same reason as the
+    # interpreter: the realistic stage's cost is numpy's, so two versions make
+    # the stage-callback column a comparison of numpy releases.
+    in_process_numpy_version = resolve_numpy_version_for_interpreter(
+        f"python{embedded_interpreter}"
+    )
+    install_arguments = ["uv", "pip", "install", "--python", str(venv_python)]
+    if in_process_numpy_version is not None:
+        install_arguments.append(f"numpy=={in_process_numpy_version}")
+    install_arguments.append(str(staged_directory))
+    subprocess.run(install_arguments, check=True)
     if not venv_python.is_file():
         raise RuntimeError(f"uv reported success but {venv_python} is absent")
+
+    assert_arms_share_a_runtime(venv_python, embedded_interpreter, in_process_numpy_version)
 
     generated_probe = subprocess.run(
         [
@@ -245,7 +331,7 @@ def provision(release: bool) -> dict:
     staged_directory = stage_baseline_package_with_sdk_path_override(
         engine_checkout_root
     )
-    venv_python = provision_package_venv(staged_directory)
+    venv_python = provision_package_venv(staged_directory, application_modules_root)
     slot = link_staged_package_into_app_modules(
         application_modules_root,
         staged_directory,
@@ -263,11 +349,27 @@ def provision(release: bool) -> dict:
         ),
         "staged_package_directory": str(staged_directory),
         "package_venv_python": str(venv_python),
+        "embedded_interpreter": resolve_interpreter_embedded_by_harness(
+            application_modules_root
+        ),
         "linked_module_slot": str(slot),
         "processor_type_reference": (
             f"@{PACKAGE_ORG}/{PACKAGE_NAME}/PyembedSubprocessBaselineStage"
         ),
     }
+
+
+def provisioned_package_root() -> Path:
+    """Where the staged package and its venv live.
+
+    Under `target/` rather than a dot-directory at the crate root because the
+    repo's `check-manifest-schema` walk skips `target/`, `node_modules/`,
+    `.git/` and `.streamlib/` and nothing else (`xtask/src/manifest_schema.rs:66`).
+    A staged copy anywhere else puts both its own manifest and the `streamlib.yaml`
+    vendored inside its venv in front of that gate, failing it locally on any
+    machine that has provisioned — a false failure on a file no one committed.
+    """
+    return resolve_spike_crate_root() / "target" / "provisioned"
 
 
 def provisioning_record_path() -> Path:
@@ -277,7 +379,7 @@ def provisioning_record_path() -> Path:
     Recomputing it in the runner would be a second copy of the same derivation,
     and the two drifting is exactly how the cdylib pin gets lost.
     """
-    return resolve_spike_crate_root() / ".provisioned" / "provisioning-record.json"
+    return provisioned_package_root() / "provisioning-record.json"
 
 
 def main() -> int:

--- a/spikes/streamlib-pyembed-spike/python/provision_subprocess_baseline_package.py
+++ b/spikes/streamlib-pyembed-spike/python/provision_subprocess_baseline_package.py
@@ -1,0 +1,294 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Make the #1702 subprocess baseline arm runnable, deterministically.
+
+Three prerequisites the harness cannot satisfy from inside a measurement run,
+each of which fails in a way that is easy to misread as a slow baseline rather
+than a broken one:
+
+1. ``libstreamlib_python_native.so`` must exist. Without it every subprocess
+   dies at load and the arm reports zero frames.
+2. The baseline package's ``streamlib`` dependency resolves from no index —
+   ``uv`` reports "not found in the package registry". A path override at this
+   checkout's Python SDK is injected into a staged copy of the package, which
+   is the same rewrite ``streamlib link --engine`` performs
+   (``python_venv.rs:360-393``), scoped here so a measurement run neither
+   depends on nor disturbs global link state.
+3. The staged copy has to sit in a ``streamlib_modules/@spike/...`` slot for
+   the module loader to resolve it.
+
+Run this before any ``--mode subprocess`` cell. It is idempotent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+PACKAGE_ORG = "spike"
+PACKAGE_NAME = "pyembed-subprocess-baseline"
+PACKAGE_SOURCE_DIRECTORY_NAME = "subprocess_baseline_package"
+
+PYTHON_NATIVE_LIBRARY_FILE_NAME = "libstreamlib_python_native.so"
+PYTHON_NATIVE_LIBRARY_ENVIRONMENT_VARIABLE = "STREAMLIB_PYTHON_NATIVE_LIB"
+
+# Points the module loader's `streamlib_modules/` lookup at the spike crate
+# instead of the checkout root (`streamlib_home.rs:116,148`). Without it the
+# link, the lock file, and the module slot all land at the repo root, which the
+# spike has no business writing to.
+APP_MODULES_DIRECTORY_ENVIRONMENT_VARIABLE = "STREAMLIB_MODULES_DIR"
+
+
+def resolve_spike_crate_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def resolve_engine_checkout_root() -> Path:
+    """The repo root — the first ancestor carrying both `packages/` and `sdk/`.
+
+    Derived rather than configured so a worktree copy of the spike provisions
+    against its own checkout instead of whichever one happens to be linked.
+    """
+    for candidate in resolve_spike_crate_root().parents:
+        if (candidate / "packages").is_dir() and (candidate / "sdk").is_dir():
+            return candidate
+    raise RuntimeError(
+        "cannot locate the engine checkout root above "
+        f"{resolve_spike_crate_root()} — expected an ancestor with packages/ and sdk/"
+    )
+
+
+def build_python_native_cdylib(engine_checkout_root: Path, release: bool) -> Path:
+    """Build the python-native cdylib and return the artifact path.
+
+    Pinned by absolute path rather than left to a search: a stale artifact from
+    an earlier build would otherwise win silently and the baseline arm would
+    measure a cdylib that is not the one under test.
+    """
+    profile_arguments = ["--release"] if release else []
+    subprocess.run(
+        ["cargo", "build", *profile_arguments, "-p", "streamlib-python-native"],
+        cwd=engine_checkout_root,
+        check=True,
+    )
+    artifact = (
+        engine_checkout_root
+        / "target"
+        / ("release" if release else "debug")
+        / PYTHON_NATIVE_LIBRARY_FILE_NAME
+    )
+    if not artifact.is_file():
+        raise RuntimeError(
+            f"cargo reported success but {artifact} is absent — the baseline arm "
+            "cannot run without the python-native cdylib"
+        )
+    return artifact
+
+
+def stage_baseline_package_with_sdk_path_override(
+    engine_checkout_root: Path,
+) -> Path:
+    """Copy the package source to a gitignored slot, injecting the SDK path.
+
+    The override carries an absolute path, so the staged copy stays valid
+    wherever the build orchestrator relocates it.
+    """
+    source_directory = resolve_spike_crate_root() / PACKAGE_SOURCE_DIRECTORY_NAME
+    if not (source_directory / "streamlib.yaml").is_file():
+        raise RuntimeError(f"no package source at {source_directory}")
+
+    staged_directory = (
+        resolve_spike_crate_root() / ".provisioned" / PACKAGE_NAME
+    )
+    if staged_directory.exists():
+        shutil.rmtree(staged_directory)
+    staged_directory.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(
+        source_directory,
+        staged_directory,
+        ignore=shutil.ignore_patterns("__pycache__", ".venv", "*.pyc"),
+    )
+
+    python_sdk_path = engine_checkout_root / "sdk" / "streamlib-python"
+    if not (python_sdk_path / "setup.py").is_file():
+        raise RuntimeError(f"no Python SDK at {python_sdk_path}")
+
+    pyproject_path = staged_directory / "pyproject.toml"
+    pyproject_body = pyproject_path.read_text()
+    declares_a_uv_sources_table = any(
+        line.strip() == "[tool.uv.sources]"
+        for line in pyproject_body.splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    if declares_a_uv_sources_table:
+        raise RuntimeError(
+            "the committed pyproject already carries a [tool.uv.sources] table; "
+            "the override would be ambiguous"
+        )
+    pyproject_path.write_text(
+        pyproject_body
+        + "\n[tool.uv.sources]\n"
+        + f'streamlib = {{ path = "{python_sdk_path}", editable = true }}\n'
+    )
+    return staged_directory
+
+
+def link_staged_package_into_app_modules(
+    application_modules_root: Path,
+    staged_directory: Path,
+    streamlib_executable: Path,
+) -> Path:
+    """Symlink the staged package into `streamlib_modules/@spike/<name>`.
+
+    `link` rather than `add`/`install`: those two take finalized artifacts, and
+    this is a local checkout that changes between runs.
+    """
+    application_modules_root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            str(streamlib_executable),
+            "link",
+            str(staged_directory),
+            "--dir",
+            str(application_modules_root),
+        ],
+        cwd=application_modules_root,
+        check=True,
+    )
+    slot = (
+        application_modules_root
+        / "streamlib_modules"
+        / f"@{PACKAGE_ORG}"
+        / PACKAGE_NAME
+    )
+    if not slot.exists():
+        raise RuntimeError(f"streamlib link reported success but {slot} is absent")
+    return slot
+
+
+def provision_package_venv(staged_directory: Path) -> Path:
+    """Create the package's `.venv`, which is what makes the slot loadable.
+
+    `streamlib install` skips linked entries ("linked entries stay
+    lazy/edit-rebuild", `install.rs:21-22`), and the module loader refuses to
+    cold-build an installed slot — it demands `.venv/bin/python` and returns
+    `InstalledPackageNotBuilt` otherwise (`source.rs:677-701`). Nothing in
+    between provisions a linked Python package, so this mirrors the two steps
+    the build orchestrator would have run (`python_venv.rs:93-147`): `uv venv`,
+    then a source install of the package itself.
+
+    The SDK arrives editable from this checkout, whose `streamlib/_generated_`
+    tree is already populated, so the orchestrator's codegen step
+    (`ensure_streamlib_generated_in_venv`) has nothing left to do; it is
+    verified rather than repeated.
+    """
+    venv_directory = staged_directory / ".venv"
+    subprocess.run(["uv", "venv", str(venv_directory)], check=True)
+    venv_python = venv_directory / "bin" / "python"
+    subprocess.run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(venv_python),
+            str(staged_directory),
+        ],
+        check=True,
+    )
+    if not venv_python.is_file():
+        raise RuntimeError(f"uv reported success but {venv_python} is absent")
+
+    generated_probe = subprocess.run(
+        [
+            str(venv_python),
+            "-c",
+            "import streamlib._generated_ as g; print(g.__file__)",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if generated_probe.returncode != 0:
+        raise RuntimeError(
+            "the provisioned venv has no populated streamlib._generated_ tree, so "
+            "the subprocess would fail at import rather than run slowly: "
+            f"{generated_probe.stderr.strip()}"
+        )
+    return venv_python
+
+
+def resolve_streamlib_executable(engine_checkout_root: Path, release: bool) -> Path:
+    executable = (
+        engine_checkout_root
+        / "target"
+        / ("release" if release else "debug")
+        / "streamlib"
+    )
+    if not executable.is_file():
+        raise RuntimeError(
+            f"{executable} is absent — build it with "
+            f"`cargo build {'--release ' if release else ''}-p streamlib-cli`"
+        )
+    return executable
+
+
+def provision(release: bool) -> dict:
+    engine_checkout_root = resolve_engine_checkout_root()
+    application_modules_root = resolve_spike_crate_root()
+    native_library = build_python_native_cdylib(engine_checkout_root, release)
+    staged_directory = stage_baseline_package_with_sdk_path_override(
+        engine_checkout_root
+    )
+    venv_python = provision_package_venv(staged_directory)
+    slot = link_staged_package_into_app_modules(
+        application_modules_root,
+        staged_directory,
+        resolve_streamlib_executable(engine_checkout_root, release),
+    )
+    return {
+        "engine_checkout_root": str(engine_checkout_root),
+        "python_native_library_path": str(native_library),
+        "python_native_library_environment_variable": (
+            PYTHON_NATIVE_LIBRARY_ENVIRONMENT_VARIABLE
+        ),
+        "application_modules_root": str(application_modules_root),
+        "application_modules_root_environment_variable": (
+            APP_MODULES_DIRECTORY_ENVIRONMENT_VARIABLE
+        ),
+        "staged_package_directory": str(staged_directory),
+        "package_venv_python": str(venv_python),
+        "linked_module_slot": str(slot),
+        "processor_type_reference": (
+            f"@{PACKAGE_ORG}/{PACKAGE_NAME}/PyembedSubprocessBaselineStage"
+        ),
+    }
+
+
+def main() -> int:
+    argument_parser = argparse.ArgumentParser(description=__doc__)
+    argument_parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="provision against the debug profile instead of release",
+    )
+    arguments = argument_parser.parse_args()
+
+    record = provision(release=not arguments.debug)
+    os.environ[PYTHON_NATIVE_LIBRARY_ENVIRONMENT_VARIABLE] = record[
+        "python_native_library_path"
+    ]
+    os.environ[APP_MODULES_DIRECTORY_ENVIRONMENT_VARIABLE] = record[
+        "application_modules_root"
+    ]
+    sys.stdout.write(json.dumps(record, indent=2) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spikes/streamlib-pyembed-spike/python/provision_subprocess_baseline_package.py
+++ b/spikes/streamlib-pyembed-spike/python/provision_subprocess_baseline_package.py
@@ -171,15 +171,14 @@ def link_staged_package_into_app_modules(
     return slot
 
 
-def resolve_interpreter_embedded_by_harness(spike_crate_root: Path) -> str:
-    """The CPython `major.minor` the harness binary links, e.g. `3.12`.
+def probe_embedded_python_runtime(spike_crate_root: Path) -> dict:
+    """Ask the harness which interpreter it actually embeds.
 
-    Read from the binary rather than assumed, because it is the interpreter the
-    in-process arm actually runs and the baseline's venv has to match it. Left
-    unpinned, `uv venv` picks the newest interpreter on the box: this rig
-    produced CPython 3.14.4 for the subprocess arm against 3.12.3 embedded in
-    the harness, which makes the two arms' numbers a comparison of interpreter
-    versions as much as of hosting.
+    Asked rather than inferred. `ldd` yields only `3.12`, and `uv venv --python
+    3.12` is then free to resolve its own managed build: this rig paired an
+    embedded CPython 3.12.3 (Ubuntu/GCC) with a baseline venv on 3.12.13
+    (python-build-standalone/Clang) — a different compiler, ten patch releases
+    apart — while a major.minor comparison called them the same runtime.
     """
     harness_binary = spike_crate_root / "target" / "release" / "tier_a_harness"
     if not harness_binary.is_file():
@@ -187,68 +186,84 @@ def resolve_interpreter_embedded_by_harness(spike_crate_root: Path) -> str:
             f"{harness_binary} is absent; build it before provisioning so the "
             "baseline venv can be pinned to the interpreter it embeds"
         )
-    linked_libraries = subprocess.run(
-        ["ldd", str(harness_binary)], check=True, capture_output=True, text=True
-    ).stdout
-    match = re.search(r"libpython(\d+\.\d+)\.so", linked_libraries)
-    if match is None:
-        raise RuntimeError(
-            f"{harness_binary} links no libpython — cannot determine which "
-            "interpreter the in-process arm runs, so the arms cannot be matched"
-        )
-    return match.group(1)
-
-
-def resolve_numpy_version_for_interpreter(interpreter: str) -> str | None:
-    """numpy's version under `interpreter`, or None when it is not installed."""
-    probe = subprocess.run(
-        [interpreter, "-c", "import numpy; print(numpy.__version__)"],
+    report_path = provisioned_package_root() / "embedded-python-runtime.json"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            str(harness_binary),
+            "--report-embedded-python-runtime-to",
+            str(report_path),
+        ],
+        check=True,
         capture_output=True,
-        text=True,
     )
-    return probe.stdout.strip() if probe.returncode == 0 else None
+    return json.loads(report_path.read_text())
 
 
-def assert_arms_share_a_runtime(
-    venv_python: Path,
-    embedded_interpreter: str,
-    in_process_numpy_version: str | None,
-) -> None:
+def resolve_interpreter_executable_for_runtime(embedded_runtime: dict) -> str:
+    """The executable for the embedded interpreter, from its own `base_prefix`."""
+    candidate = (
+        Path(embedded_runtime["base_prefix"])
+        / "bin"
+        / f"python{embedded_runtime['major_minor']}"
+    )
+    if not candidate.is_file():
+        raise RuntimeError(
+            f"the harness embeds CPython {embedded_runtime['version']} with base_prefix "
+            f"{embedded_runtime['base_prefix']}, but {candidate} does not exist, so the "
+            "baseline venv cannot be pinned to the same interpreter"
+        )
+    return str(candidate)
+
+
+def assert_arms_share_a_runtime(venv_python: Path, embedded_runtime: dict) -> None:
     """Refuse a provisioning whose two arms would run different Pythons.
 
-    Checked here rather than trusted, because the failure is invisible in every
-    artifact the run produces: both arms report plausible latencies and the
-    difference between them silently includes an interpreter-version delta.
+    Compares the full `major.minor.micro` and the build banner, not just the
+    minor version: two CPython 3.12 builds from different compilers ten patch
+    releases apart are not the same runtime, and a guard that says they are
+    reproduces the confound it was written to prevent. numpy is compared
+    exactly, and an absent version on either side is a refusal rather than a
+    skipped check.
     """
     reported = subprocess.run(
         [
             str(venv_python),
             "-c",
-            "import sys, numpy; "
-            "print(f'{sys.version_info.major}.{sys.version_info.minor}'); "
-            "print(numpy.__version__)",
+            "import sys, json;\n"
+            "v = sys.version_info;\n"
+            "try:\n"
+            "    import numpy; n = numpy.__version__\n"
+            "except ImportError:\n"
+            "    n = None\n"
+            "print(json.dumps({'version': f'{v.major}.{v.minor}.{v.micro}', "
+            "'version_banner': sys.version, 'numpy_version': n}))",
         ],
         check=True,
         capture_output=True,
         text=True,
-    ).stdout.split()
-    venv_interpreter, venv_numpy_version = reported[0], reported[1]
+    ).stdout.strip()
+    venv_runtime = json.loads(reported)
 
-    if venv_interpreter != embedded_interpreter:
-        raise RuntimeError(
-            f"the baseline venv runs CPython {venv_interpreter} but the harness "
-            f"embeds {embedded_interpreter}; the two arms would differ by "
-            "interpreter version as well as by hosting"
-        )
-    if (
-        in_process_numpy_version is not None
-        and venv_numpy_version != in_process_numpy_version
+    for field, description in (
+        ("version", "CPython version"),
+        ("version_banner", "CPython build"),
+        ("numpy_version", "numpy version"),
     ):
-        raise RuntimeError(
-            f"the baseline venv has numpy {venv_numpy_version} but the in-process "
-            f"arm runs {in_process_numpy_version}; the realistic stage's cost is "
-            "numpy's, so the arms would not be comparable"
-        )
+        embedded_value = embedded_runtime.get(field)
+        venv_value = venv_runtime.get(field)
+        if embedded_value is None or venv_value is None:
+            raise RuntimeError(
+                f"the {description} is unknown on one of the arms "
+                f"(in-process {embedded_value!r}, baseline {venv_value!r}); the arms "
+                "cannot be shown to share a runtime, so they are not comparable"
+            )
+        if embedded_value != venv_value:
+            raise RuntimeError(
+                f"the arms disagree on {description}: the in-process arm runs "
+                f"{embedded_value!r} and the baseline venv runs {venv_value!r}; every "
+                "reported difference between them would include that delta"
+            )
 
 
 def provision_package_venv(staged_directory: Path, spike_crate_root: Path) -> Path:
@@ -267,29 +282,49 @@ def provision_package_venv(staged_directory: Path, spike_crate_root: Path) -> Pa
     (`ensure_streamlib_generated_in_venv`) has nothing left to do; it is
     verified rather than repeated.
     """
-    embedded_interpreter = resolve_interpreter_embedded_by_harness(spike_crate_root)
+    embedded_runtime = probe_embedded_python_runtime(spike_crate_root)
+    embedded_interpreter_executable = resolve_interpreter_executable_for_runtime(
+        embedded_runtime
+    )
     venv_directory = staged_directory / ".venv"
     subprocess.run(
-        ["uv", "venv", "--python", embedded_interpreter, str(venv_directory)],
+        [
+            "uv",
+            "venv",
+            "--python",
+            embedded_interpreter_executable,
+            str(venv_directory),
+        ],
         check=True,
     )
     venv_python = venv_directory / "bin" / "python"
 
-    # numpy pinned to the in-process arm's version for the same reason as the
-    # interpreter: the realistic stage's cost is numpy's, so two versions make
-    # the stage-callback column a comparison of numpy releases.
-    in_process_numpy_version = resolve_numpy_version_for_interpreter(
-        f"python{embedded_interpreter}"
+    # numpy pinned to the in-process arm's own version, taken from the embedded
+    # interpreter rather than from a `python3.X` on PATH: the realistic stage's
+    # cost is numpy's, so two versions make the stage-callback column a
+    # comparison of numpy releases.
+    in_process_numpy_version = embedded_runtime.get("numpy_version")
+    if in_process_numpy_version is None:
+        raise RuntimeError(
+            "the embedded interpreter has no numpy, so the baseline cannot be pinned "
+            "to the in-process arm's version and the arms would not be comparable"
+        )
+    subprocess.run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(venv_python),
+            f"numpy=={in_process_numpy_version}",
+            str(staged_directory),
+        ],
+        check=True,
     )
-    install_arguments = ["uv", "pip", "install", "--python", str(venv_python)]
-    if in_process_numpy_version is not None:
-        install_arguments.append(f"numpy=={in_process_numpy_version}")
-    install_arguments.append(str(staged_directory))
-    subprocess.run(install_arguments, check=True)
     if not venv_python.is_file():
         raise RuntimeError(f"uv reported success but {venv_python} is absent")
 
-    assert_arms_share_a_runtime(venv_python, embedded_interpreter, in_process_numpy_version)
+    assert_arms_share_a_runtime(venv_python, embedded_runtime)
 
     generated_probe = subprocess.run(
         [
@@ -349,7 +384,7 @@ def provision(release: bool) -> dict:
         ),
         "staged_package_directory": str(staged_directory),
         "package_venv_python": str(venv_python),
-        "embedded_interpreter": resolve_interpreter_embedded_by_harness(
+        "embedded_python_runtime": probe_embedded_python_runtime(
             application_modules_root
         ),
         "linked_module_slot": str(slot),

--- a/spikes/streamlib-pyembed-spike/python/runner.py
+++ b/spikes/streamlib-pyembed-spike/python/runner.py
@@ -33,6 +33,13 @@ from spike_stage_callbacks import build_measurement_stage_callback_for_stage_nam
 
 MEASUREMENT_CELL_LOGGER = logging.getLogger("streamlib_pyembed_spike.runner")
 
+SPIKE_CRATE_ROOT_DIRECTORY = os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__))
+)
+SUBPROCESS_BASELINE_PACKAGE_NAME = "pyembed-subprocess-baseline"
+APP_MODULES_DIRECTORY_ENVIRONMENT_VARIABLE = "STREAMLIB_MODULES_DIR"
+PYTHON_NATIVE_LIBRARY_ENVIRONMENT_VARIABLE = "STREAMLIB_PYTHON_NATIVE_LIB"
+
 RUNNER_MODE_IN_PROCESS_PYTHON = "in-process"
 RUNNER_MODE_SUBPROCESS_PYTHON = "subprocess"
 RUNNER_MODE_RUST_PASSTHROUGH_FLOOR = "rust-floor"
@@ -48,6 +55,7 @@ SUPPORTED_RUNNER_MODES = (
 HARNESS_ARM_BY_RUNNER_MODE = {
     RUNNER_MODE_IN_PROCESS_PYTHON: "in-process-python",
     RUNNER_MODE_RUST_PASSTHROUGH_FLOOR: "rust-passthrough-floor",
+    RUNNER_MODE_SUBPROCESS_PYTHON: "subprocess-python-baseline",
 }
 
 STAGE_NAME_PASSTHROUGH = "passthrough"
@@ -88,19 +96,17 @@ EXPLORATORY_CELL_WARMUP_EXCLUSION_SECONDS = 1
 CELL_DIRECTORY_MODIFICATION_TIME_SLACK_SECONDS = 2.0
 
 
-class SubprocessArmIsTierBAndNotImplementedError(NotImplementedError):
-    """Raised for `--mode subprocess`, which no code path in this PR implements."""
+class SubprocessBaselineArmIsNotProvisionedError(RuntimeError):
+    """Raised when `--mode subprocess` runs before its provisioning step.
+
+    The failure it replaces is silent and expensive: an unprovisioned slot
+    fails at graph build, and a matrix run would record the baseline arm as
+    absent rather than as unrunnable.
+    """
 
 
 def resolve_harness_arm_for_runner_mode(runner_mode):
     """Map a runner `--mode` to the harness `--arm` token it drives."""
-    if runner_mode == RUNNER_MODE_SUBPROCESS_PYTHON:
-        raise SubprocessArmIsTierBAndNotImplementedError(
-            "--mode subprocess is the Tier B baseline and is not in this PR: no "
-            "subprocess arm exists in the harness, which accepts only "
-            "in-process-python and rust-passthrough-floor. Run it from the Tier B "
-            "work on #1702."
-        )
     if runner_mode not in HARNESS_ARM_BY_RUNNER_MODE:
         raise ValueError(
             f"unsupported runner mode {runner_mode!r}; expected one of "
@@ -249,7 +255,67 @@ def build_tier_a_harness_process_environment():
         if existing_python_path
         else [spike_python_directory]
     )
+    harness_process_environment.update(read_subprocess_baseline_arm_environment())
     return harness_process_environment
+
+
+def read_subprocess_baseline_arm_environment():
+    """The two variables a subprocess cell needs, taken from the provisioning
+    record rather than re-derived.
+
+    Both are load-bearing and both fail silently. Without
+    `STREAMLIB_MODULES_DIR` the loader looks for the package beside whatever
+    the caller's cwd happens to be. Without `STREAMLIB_PYTHON_NATIVE_LIB` the
+    spawned subprocess resolves *some other* `libstreamlib_python_native.so`,
+    whose iceoryx2 service constants do not match the host's — the subprocess
+    then fails to open its own input channel with
+    `DoesNotSupportRequestedAmountOfPublishers`, the sink receives nothing, and
+    the cell reads as an arm that produced no frames rather than one that was
+    misconfigured. That is the failure #1702's finding 6 asked to be pinned
+    against, and it only appears when the runner drives the cell, because a
+    hand-run cell inherits the variable from the operator's shell.
+
+    Returns an empty mapping when nothing has been provisioned; the guard in
+    `require_subprocess_baseline_arm_is_provisioned` is what refuses the run.
+    """
+    provisioning_record_path = os.path.join(
+        SPIKE_CRATE_ROOT_DIRECTORY, ".provisioned", "provisioning-record.json"
+    )
+    if not os.path.isfile(provisioning_record_path):
+        return {}
+    with open(provisioning_record_path) as provisioning_record_file:
+        provisioning_record = json.load(provisioning_record_file)
+    return {
+        APP_MODULES_DIRECTORY_ENVIRONMENT_VARIABLE: provisioning_record[
+            "application_modules_root"
+        ],
+        PYTHON_NATIVE_LIBRARY_ENVIRONMENT_VARIABLE: provisioning_record[
+            "python_native_library_path"
+        ],
+    }
+
+
+def require_subprocess_baseline_arm_is_provisioned():
+    """Refuse a subprocess cell whose package slot was never provisioned.
+
+    Checked here rather than left to the graph build so an unattended matrix
+    run stops with the fix-it instead of recording the arm as absent.
+    """
+    venv_python = os.path.join(
+        SPIKE_CRATE_ROOT_DIRECTORY,
+        ".provisioned",
+        SUBPROCESS_BASELINE_PACKAGE_NAME,
+        ".venv",
+        "bin",
+        "python",
+    )
+    if not os.path.isfile(venv_python):
+        raise SubprocessBaselineArmIsNotProvisionedError(
+            "--mode subprocess needs its package provisioned first: no venv at "
+            f"{venv_python}. Run "
+            "`python3 python/provision_subprocess_baseline_package.py` from the "
+            "spike crate root, then rerun."
+        )
 
 
 def locate_measurement_cell_directory_created_by_harness(
@@ -496,6 +562,8 @@ def run_interleaved_measurement_schedule(command_line_arguments):
     """Run every cell of every repetition in A/B/A order, stopping at the first
     cell the harness refuses. Returns the process exit status."""
     resolve_harness_arm_for_runner_mode(command_line_arguments.mode)
+    if command_line_arguments.mode == RUNNER_MODE_SUBPROCESS_PYTHON:
+        require_subprocess_baseline_arm_is_provisioned()
     cell_duration_seconds = resolve_cell_duration_seconds(command_line_arguments.duration)
     warmup_exclusion_seconds = resolve_warmup_exclusion_seconds(
         command_line_arguments.warmup_exclusion_seconds, cell_duration_seconds
@@ -593,7 +661,8 @@ def parse_measurement_cell_command_line_arguments(command_line_argument_values=N
         required=True,
         help="the arm under test; rust-floor is a pure-Rust passthrough that "
         "isolates engine wire-hop cost from PyO3 cost, and is also the A of the "
-        "A/B/A schedule. subprocess is Tier B and not implemented in this PR",
+        "A/B/A schedule. subprocess is today's model and requires "
+        "provision_subprocess_baseline_package.py to have run",
     )
     argument_parser.add_argument(
         "--gc",
@@ -661,7 +730,7 @@ def main():
     command_line_arguments = parse_measurement_cell_command_line_arguments()
     try:
         return run_interleaved_measurement_schedule(command_line_arguments)
-    except (SubprocessArmIsTierBAndNotImplementedError, ValueError) as refusal:
+    except (SubprocessBaselineArmIsNotProvisionedError, ValueError) as refusal:
         MEASUREMENT_CELL_LOGGER.error("%s", refusal)
         return 2
 

--- a/spikes/streamlib-pyembed-spike/python/runner.py
+++ b/spikes/streamlib-pyembed-spike/python/runner.py
@@ -39,6 +39,7 @@ SPIKE_CRATE_ROOT_DIRECTORY = os.path.dirname(
 SUBPROCESS_BASELINE_PACKAGE_NAME = "pyembed-subprocess-baseline"
 APP_MODULES_DIRECTORY_ENVIRONMENT_VARIABLE = "STREAMLIB_MODULES_DIR"
 PYTHON_NATIVE_LIBRARY_ENVIRONMENT_VARIABLE = "STREAMLIB_PYTHON_NATIVE_LIB"
+BASELINE_VENV_PYTHON_ENVIRONMENT_VARIABLE = "STREAMLIB_BASELINE_VENV_PYTHON"
 
 RUNNER_MODE_IN_PROCESS_PYTHON = "in-process"
 RUNNER_MODE_SUBPROCESS_PYTHON = "subprocess"
@@ -279,7 +280,7 @@ def read_subprocess_baseline_arm_environment():
     `require_subprocess_baseline_arm_is_provisioned` is what refuses the run.
     """
     provisioning_record_path = os.path.join(
-        SPIKE_CRATE_ROOT_DIRECTORY, ".provisioned", "provisioning-record.json"
+        SPIKE_CRATE_ROOT_DIRECTORY, "target", "provisioned", "provisioning-record.json"
     )
     if not os.path.isfile(provisioning_record_path):
         return {}
@@ -292,6 +293,12 @@ def read_subprocess_baseline_arm_environment():
         PYTHON_NATIVE_LIBRARY_ENVIRONMENT_VARIABLE: provisioning_record[
             "python_native_library_path"
         ],
+        # Without this the machine-spec probe falls back to reporting the
+        # interpreter as unknown rather than reporting `python3` on PATH as if
+        # it were the one the subprocess arm launches.
+        BASELINE_VENV_PYTHON_ENVIRONMENT_VARIABLE: provisioning_record[
+            "package_venv_python"
+        ],
     }
 
 
@@ -303,7 +310,8 @@ def require_subprocess_baseline_arm_is_provisioned():
     """
     venv_python = os.path.join(
         SPIKE_CRATE_ROOT_DIRECTORY,
-        ".provisioned",
+        "target",
+        "provisioned",
         SUBPROCESS_BASELINE_PACKAGE_NAME,
         ".venv",
         "bin",

--- a/spikes/streamlib-pyembed-spike/python/summarize_measurement_matrix.py
+++ b/spikes/streamlib-pyembed-spike/python/summarize_measurement_matrix.py
@@ -154,6 +154,11 @@ def build_cell_condition_key(cell: dict) -> tuple:
         specification["frame_height_pixels"],
         specification["target_frames_per_second"],
         specification["stage_callback_attribute"],
+        # The module too, not just the attribute: it became a per-cell knob in
+        # the same change that added the settle, so two cells running
+        # same-named callables from different modules would otherwise be
+        # compared head-to-head.
+        specification.get("stage_callback_module"),
         specification["anchor_processor_thread_gil"],
         # Part of the key, not just the admissibility check: arms measured under
         # different settles are not comparable, and omitting it let a settle-0
@@ -219,7 +224,15 @@ def evaluate_condition(
     absolute_p99_9_ceiling_milliseconds: float | None,
 ) -> dict:
     """Evaluate every gate this condition's admissible cells can support."""
-    width, height, frames_per_second, stage, gil_anchor, startup_settle = condition_key
+    (
+        width,
+        height,
+        frames_per_second,
+        stage,
+        stage_module,
+        gil_anchor,
+        startup_settle,
+    ) = condition_key
     verdicts: dict[str, dict] = {}
 
     def record(gate: str, passed: bool | None, detail: str) -> None:
@@ -370,6 +383,7 @@ def evaluate_condition(
             "frame_height_pixels": height,
             "target_frames_per_second": frames_per_second,
             "stage_callback_attribute": stage,
+            "stage_callback_module": stage_module,
             "anchor_processor_thread_gil": gil_anchor,
             "startup_settle_seconds": startup_settle,
         },

--- a/spikes/streamlib-pyembed-spike/python/summarize_measurement_matrix.py
+++ b/spikes/streamlib-pyembed-spike/python/summarize_measurement_matrix.py
@@ -45,8 +45,22 @@ ARM_SUBPROCESS_PYTHON_BASELINE = "subprocess-python-baseline"
 # frame and the percentiles are pinned near one frame period whatever happens.
 REQUIRED_DELIVERY_PROFILE = "every_sample"
 
-# Matches the Rust harness's own invalidation bound.
-BACKLOG_DRAIN_FRACTION_INVALIDATING_A_CELL = 0.20
+# Matches the Rust harness's own invalidation bound. Applied to the absolute
+# value: a cell whose latency *grew* across its life is saturating, which is as
+# disqualifying as one that was draining.
+BACKLOG_TREND_FRACTION_INVALIDATING_A_CELL = 0.20
+
+# A pipeline whose per-frame service time reaches its frame period cannot keep
+# up, so its percentiles describe queue occupancy rather than latency. This is
+# the check that catches a *steady* backlog, which no trend detector can see:
+# with the settle removed, a subprocess cell sat at p50 66.9ms with a trend of
+# -0.002 — a stable queue, invisible to the decile comparison, and the
+# summarizer passed gate 1 against it at 0.127ms vs 66.9ms.
+SATURATION_FRAME_PERIOD_MULTIPLE_INVALIDATING_A_CELL = 1.0
+
+# Owner decision: cells must be measured from a quiescent graph. A cell run with
+# a shorter settle than its peers is not comparable to them.
+PROTOCOL_STARTUP_SETTLE_SECONDS = 2.0
 
 # Gate 2's stated absolute ceilings, by target rate.
 GATE_2_ABSOLUTE_CEILING_MILLISECONDS_BY_RATE = {60: 50.0, 30: 100.0}
@@ -98,15 +112,36 @@ def describe_cell_inadmissibility(cell: dict) -> str | None:
         return "recorded sink stamps earlier than their emit stamps; the clocks disagree"
     if summary.get("histogram_range_saturation_count", 0):
         return "saturated the histogram range; its top percentiles are floors, not values"
-    if (
-        summary.get("backlog_drain_fraction", 0.0)
-        > BACKLOG_DRAIN_FRACTION_INVALIDATING_A_CELL
-    ):
+    backlog_trend = summary.get("backlog_drain_fraction", 0.0)
+    if abs(backlog_trend) > BACKLOG_TREND_FRACTION_INVALIDATING_A_CELL:
+        direction = "shed" if backlog_trend > 0 else "gained"
         return (
-            "shed "
-            f"{summary['backlog_drain_fraction']:.0%} of its latency across its own "
-            "life; it was draining a startup backlog, so its percentiles describe "
-            "queue occupancy and depend on how long it ran"
+            f"{direction} {abs(backlog_trend):.0%} of its latency across its own life; "
+            "it was draining or building a queue, so its percentiles describe queue "
+            "occupancy and depend on how long it ran"
+        )
+
+    frame_period_milliseconds = 1000.0 / specification["target_frames_per_second"]
+    p50_milliseconds = (
+        summary["source_emit_to_sink_receive"]["p50_nanoseconds"]
+        / NANOSECONDS_PER_MILLISECOND
+    )
+    saturation_ceiling = (
+        frame_period_milliseconds * SATURATION_FRAME_PERIOD_MULTIPLE_INVALIDATING_A_CELL
+    )
+    if p50_milliseconds >= saturation_ceiling:
+        return (
+            f"ran at p50 {p50_milliseconds:.3f}ms against a {frame_period_milliseconds:.3f}ms "
+            "frame period; per-frame service time reached the frame period, so the "
+            "pipeline was saturated and these percentiles describe queue occupancy"
+        )
+
+    settle = specification.get("startup_settle_seconds")
+    if settle is None or settle < PROTOCOL_STARTUP_SETTLE_SECONDS:
+        return (
+            f"ran with a {settle}s startup settle, below the protocol's "
+            f"{PROTOCOL_STARTUP_SETTLE_SECONDS}s; frames emitted before the graph was "
+            "quiescent queue up and the backlog outlives the warmup exclusion"
         )
     return None
 
@@ -120,6 +155,10 @@ def build_cell_condition_key(cell: dict) -> tuple:
         specification["target_frames_per_second"],
         specification["stage_callback_attribute"],
         specification["anchor_processor_thread_gil"],
+        # Part of the key, not just the admissibility check: arms measured under
+        # different settles are not comparable, and omitting it let a settle-0
+        # baseline be compared head-to-head with settle-2 in-process cells.
+        specification.get("startup_settle_seconds"),
     )
 
 
@@ -180,7 +219,7 @@ def evaluate_condition(
     absolute_p99_9_ceiling_milliseconds: float | None,
 ) -> dict:
     """Evaluate every gate this condition's admissible cells can support."""
-    width, height, frames_per_second, stage, gil_anchor = condition_key
+    width, height, frames_per_second, stage, gil_anchor, startup_settle = condition_key
     verdicts: dict[str, dict] = {}
 
     def record(gate: str, passed: bool | None, detail: str) -> None:
@@ -271,14 +310,30 @@ def evaluate_condition(
                 "no cell was long enough to produce a full rolling 1s window",
             )
         else:
+            # Only the first of gate 4's four clauses. Reported under its own
+            # name so the other three are visibly absent rather than folded
+            # into a bare PASS for the whole gate.
             record(
-                "gate_4_frame_rate_stability",
+                "gate_4a_rolling_frame_rate_floor",
                 worst_window >= frames_per_second - 1,
                 f"worst rolling 1s window {worst_window:.2f}fps against a "
                 f"{frames_per_second - 1}fps floor; "
                 f"{in_process['dropped_frame_count']} drops (reported, not gated — "
                 "owner decision 1)",
             )
+        record(
+            "gate_4b_sub_target_windows_are_gc_attributable",
+            None,
+            "not implemented: needs the sub-target windows joined against "
+            "gc-collections-embedded-interpreter.jsonl, which this evaluator does "
+            "not read",
+        )
+        record(
+            "gate_4c_soak_shows_no_monotonic_growth",
+            None,
+            "not implemented: needs a soak cell and an RSS series, neither of which "
+            "this PR produces",
+        )
         record(
             "gate_5_callback_sanity",
             in_process["stage_callback_p99_ms"] <= GATE_5_CALLBACK_SANITY_MILLISECONDS,
@@ -316,9 +371,35 @@ def evaluate_condition(
             "target_frames_per_second": frames_per_second,
             "stage_callback_attribute": stage,
             "anchor_processor_thread_gil": gil_anchor,
+            "startup_settle_seconds": startup_settle,
         },
         "arms": arms,
         "gates": verdicts,
+    }
+
+
+def evaluate_warm_restart_battery(matrix_directory: str) -> dict:
+    """Gate 6, read from the battery's own record when one is present.
+
+    Folded into this report rather than left in a separate file: the GO decision
+    is read from one place, and a gate that lives somewhere else reads as a gate
+    nobody measured.
+    """
+    battery_path = os.path.join(matrix_directory, "warm-restart-battery.json")
+    if not os.path.isfile(battery_path):
+        return {
+            "verdict": "NOT EVALUATED",
+            "detail": f"no warm-restart-battery.json under {matrix_directory}; run "
+            "python/warm_restart_battery.py",
+        }
+    with open(battery_path) as battery_file:
+        battery = json.load(battery_file)
+    return {
+        "verdict": "PASS" if battery["gate_6_passes"] else "FAIL",
+        "detail": f"warm restart median {battery['warm_restart_median_seconds']:.3f}s "
+        f"against {battery['gate_6_median_threshold_seconds']}s "
+        f"(first run {battery['first_restart_seconds']:.3f}s, "
+        f"arm {battery['harness_arm']})",
     }
 
 
@@ -359,17 +440,19 @@ def summarize_measurement_matrix(
         for condition_key, arms in sorted(cells_by_condition_and_arm.items())
     ]
 
+    warm_restart_gate = evaluate_warm_restart_battery(matrix_directory)
     every_verdict = [
         verdict["verdict"]
         for condition in conditions
         for verdict in condition["gates"].values()
-    ]
+    ] + [warm_restart_gate["verdict"]]
     return {
         "matrix_directory": matrix_directory,
         "cell_count": len(cells),
         "admissible_cell_count": len(admissible),
         "excluded_cells": excluded,
         "conditions": conditions,
+        "gate_6_warm_restart": warm_restart_gate,
         "gate_tally": {
             "pass": every_verdict.count("PASS"),
             "fail": every_verdict.count("FAIL"),
@@ -407,6 +490,11 @@ def render_report(matrix_summary: dict) -> str:
             lines.append(f"  [{gate['verdict']:>13}] {gate_name}")
             lines.append(f"                  {gate['detail']}")
         lines.append("")
+
+    warm_restart_gate = matrix_summary["gate_6_warm_restart"]
+    lines.append(f"  [{warm_restart_gate['verdict']:>13}] gate_6_warm_restart")
+    lines.append(f"                  {warm_restart_gate['detail']}")
+    lines.append("")
 
     tally = matrix_summary["gate_tally"]
     lines.append(

--- a/spikes/streamlib-pyembed-spike/python/summarize_measurement_matrix.py
+++ b/spikes/streamlib-pyembed-spike/python/summarize_measurement_matrix.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Evaluate #1702's gates over a directory of measurement cells.
+
+The rule this is built around: **never report a verdict a cell cannot support.**
+A gate is evaluated only when every cell backing it is admissible and its
+threshold is actually stated. Anything else is reported as NOT EVALUATED with
+the reason, because a silently-skipped gate reads as a passed one.
+
+Four ways a cell is inadmissible, all recorded in its own artifacts:
+
+* `measurement_stamping_is_compiled_in: false` — a control build whose only
+  valid output is throughput.
+* `wire_payload_mode: full-pixel-payload` — the retracted payload sweep, which
+  measures transport size rather than the hosting question.
+* `negative_latency_anomaly_count` or `histogram_range_saturation_count`
+  nonzero — clocks disagreed, or percentiles are clipped floors.
+* `backlog_drain_fraction` past its bound — the cell was draining a startup
+  queue, so its percentiles describe occupancy and vary with cell duration.
+
+Two of the amended gates carry no stated threshold. Owner decision 3 added a
+floor-vs-PyO3 delta gate and decision 4 added an absolute p99.9 ceiling, but
+neither names a number, and #1702 is explicit that thresholds are evaluated
+verbatim and never decided inline. Both are computed and reported; both stay
+NOT EVALUATED until `--floor-delta-gate-ms` / `--absolute-p99-9-ceiling-ms` are
+passed. That is a deliberate refusal, not an omission.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+
+ARM_IN_PROCESS_PYTHON = "in-process-python"
+ARM_RUST_PASSTHROUGH_FLOOR = "rust-passthrough-floor"
+ARM_SUBPROCESS_PYTHON_BASELINE = "subprocess-python-baseline"
+
+# Owner decision 1: latency percentiles are primary, so a cell must have been
+# wired for every-sample delivery. Under `latest` the sink drains to the newest
+# frame and the percentiles are pinned near one frame period whatever happens.
+REQUIRED_DELIVERY_PROFILE = "every_sample"
+
+# Matches the Rust harness's own invalidation bound.
+BACKLOG_DRAIN_FRACTION_INVALIDATING_A_CELL = 0.20
+
+# Gate 2's stated absolute ceilings, by target rate.
+GATE_2_ABSOLUTE_CEILING_MILLISECONDS_BY_RATE = {60: 50.0, 30: 100.0}
+GATE_2_BASELINE_HEADROOM_MILLISECONDS = 2.0
+# Gate 5, demoted to a sanity check by owner decision 3.
+GATE_5_CALLBACK_SANITY_MILLISECONDS = 0.5
+
+NANOSECONDS_PER_MILLISECOND = 1e6
+
+
+def load_measurement_cells(matrix_directory: str) -> list[dict]:
+    """Every cell under `matrix_directory`, as its summary plus its path."""
+    cells = []
+    for summary_path in sorted(
+        glob.glob(os.path.join(matrix_directory, "*", "summary.json"))
+    ):
+        with open(summary_path) as summary_file:
+            cells.append(
+                {
+                    "directory": os.path.dirname(summary_path),
+                    "summary": json.load(summary_file),
+                }
+            )
+    return cells
+
+
+def describe_cell_inadmissibility(cell: dict) -> str | None:
+    """Why this cell cannot back a gated number, or None when it can."""
+    summary = cell["summary"]
+    specification = summary["specification"]
+
+    if not specification.get("measurement_stamping_is_compiled_in", True):
+        return "built with stamping compiled out; only its throughput is meaningful"
+    if specification.get("wire_payload_mode") != "surface-reference":
+        return (
+            "carries "
+            f"{specification.get('wire_payload_mode')!r} on the wire; the retracted "
+            "payload sweep measures transport size, not the hosting question"
+        )
+    if specification.get("resolved_delivery_profile") != REQUIRED_DELIVERY_PROFILE:
+        return (
+            "resolved delivery profile "
+            f"{specification.get('resolved_delivery_profile')!r}; latency percentiles "
+            f"require {REQUIRED_DELIVERY_PROFILE!r} (owner decision 1)"
+        )
+    if summary.get("received_frame_count", 0) == 0:
+        return "received no frames"
+    if summary.get("negative_latency_anomaly_count", 0):
+        return "recorded sink stamps earlier than their emit stamps; the clocks disagree"
+    if summary.get("histogram_range_saturation_count", 0):
+        return "saturated the histogram range; its top percentiles are floors, not values"
+    if (
+        summary.get("backlog_drain_fraction", 0.0)
+        > BACKLOG_DRAIN_FRACTION_INVALIDATING_A_CELL
+    ):
+        return (
+            "shed "
+            f"{summary['backlog_drain_fraction']:.0%} of its latency across its own "
+            "life; it was draining a startup backlog, so its percentiles describe "
+            "queue occupancy and depend on how long it ran"
+        )
+    return None
+
+
+def build_cell_condition_key(cell: dict) -> tuple:
+    """Everything but the arm — the cells that must be compared against each other."""
+    specification = cell["summary"]["specification"]
+    return (
+        specification["frame_width_pixels"],
+        specification["frame_height_pixels"],
+        specification["target_frames_per_second"],
+        specification["stage_callback_attribute"],
+        specification["anchor_processor_thread_gil"],
+    )
+
+
+def median_of(values: list[float]) -> float:
+    ordered = sorted(values)
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[middle]
+    return (ordered[middle - 1] + ordered[middle]) / 2
+
+
+def summarize_arm_across_repetitions(cells: list[dict]) -> dict:
+    """Median of each percentile across an arm's repetitions at one condition.
+
+    Median rather than mean: the distribution is heavily tailed, and one bad
+    repetition should not move the arm's reported figure.
+    """
+    def median_percentile(percentile_key: str) -> float:
+        return median_of(
+            [
+                cell["summary"]["source_emit_to_sink_receive"][percentile_key]
+                / NANOSECONDS_PER_MILLISECOND
+                for cell in cells
+            ]
+        )
+
+    return {
+        "repetition_count": len(cells),
+        "p50_ms": median_percentile("p50_nanoseconds"),
+        "p99_ms": median_percentile("p99_nanoseconds"),
+        "p99_9_ms": median_percentile("p99_9_nanoseconds"),
+        "max_ms": median_percentile("max_nanoseconds"),
+        "stage_callback_p99_ms": median_of(
+            [
+                cell["summary"]["stage_callback"]["p99_nanoseconds"]
+                / NANOSECONDS_PER_MILLISECOND
+                for cell in cells
+            ]
+        ),
+        "dropped_frame_count": sum(
+            cell["summary"]["dropped_frame_count"] for cell in cells
+        ),
+        "worst_rolling_frame_rate": min(
+            (
+                min(cell["summary"]["rolling_one_second_frame_rate_windows"])
+                for cell in cells
+                if cell["summary"]["rolling_one_second_frame_rate_windows"]
+            ),
+            default=None,
+        ),
+    }
+
+
+def evaluate_condition(
+    condition_key: tuple,
+    arms: dict,
+    floor_delta_gate_milliseconds: float | None,
+    absolute_p99_9_ceiling_milliseconds: float | None,
+) -> dict:
+    """Evaluate every gate this condition's admissible cells can support."""
+    width, height, frames_per_second, stage, gil_anchor = condition_key
+    verdicts: dict[str, dict] = {}
+
+    def record(gate: str, passed: bool | None, detail: str) -> None:
+        verdicts[gate] = {
+            "verdict": "NOT EVALUATED" if passed is None else ("PASS" if passed else "FAIL"),
+            "detail": detail,
+        }
+
+    in_process = arms.get(ARM_IN_PROCESS_PYTHON)
+    baseline = arms.get(ARM_SUBPROCESS_PYTHON_BASELINE)
+    floor = arms.get(ARM_RUST_PASSTHROUGH_FLOOR)
+
+    if in_process is None or baseline is None:
+        missing = [
+            name
+            for name, arm in (
+                (ARM_IN_PROCESS_PYTHON, in_process),
+                (ARM_SUBPROCESS_PYTHON_BASELINE, baseline),
+            )
+            if arm is None
+        ]
+        for gate in ("gate_1_p50", "gate_2_p99", "gate_3_p99_9"):
+            record(gate, None, f"no admissible cells for {', '.join(missing)}")
+    else:
+        record(
+            "gate_1_p50",
+            in_process["p50_ms"] < baseline["p50_ms"],
+            f"in-process p50 {in_process['p50_ms']:.3f}ms vs baseline "
+            f"{baseline['p50_ms']:.3f}ms",
+        )
+
+        absolute_ceiling = GATE_2_ABSOLUTE_CEILING_MILLISECONDS_BY_RATE.get(
+            frames_per_second
+        )
+        if absolute_ceiling is None:
+            record(
+                "gate_2_p99",
+                None,
+                f"#1702 states an absolute p99 ceiling for 30 and 60fps only, not "
+                f"{frames_per_second}fps",
+            )
+        else:
+            record(
+                "gate_2_p99",
+                in_process["p99_ms"]
+                <= baseline["p99_ms"] + GATE_2_BASELINE_HEADROOM_MILLISECONDS
+                and in_process["p99_ms"] <= absolute_ceiling,
+                f"in-process p99 {in_process['p99_ms']:.3f}ms vs baseline+2ms "
+                f"{baseline['p99_ms'] + GATE_2_BASELINE_HEADROOM_MILLISECONDS:.3f}ms "
+                f"and absolute {absolute_ceiling:.1f}ms",
+            )
+
+        one_frame_period_milliseconds = 1000.0 / frames_per_second
+        relative_p99_9_passes = (
+            in_process["p99_9_ms"] <= baseline["p99_9_ms"] + one_frame_period_milliseconds
+        )
+        if absolute_p99_9_ceiling_milliseconds is None:
+            record(
+                "gate_3_p99_9",
+                None,
+                "owner decision 4 added an absolute p99.9 ceiling but states no "
+                "number; pass --absolute-p99-9-ceiling-ms to evaluate. Relative "
+                f"half would {'pass' if relative_p99_9_passes else 'fail'}: "
+                f"in-process p99.9 {in_process['p99_9_ms']:.3f}ms vs baseline+one "
+                f"frame period "
+                f"{baseline['p99_9_ms'] + one_frame_period_milliseconds:.3f}ms",
+            )
+        else:
+            record(
+                "gate_3_p99_9",
+                relative_p99_9_passes
+                and in_process["p99_9_ms"] <= absolute_p99_9_ceiling_milliseconds,
+                f"in-process p99.9 {in_process['p99_9_ms']:.3f}ms vs baseline+one "
+                f"frame period "
+                f"{baseline['p99_9_ms'] + one_frame_period_milliseconds:.3f}ms and "
+                f"absolute {absolute_p99_9_ceiling_milliseconds:.3f}ms",
+            )
+
+    if in_process is None:
+        record("gate_4_frame_rate_stability", None, "no admissible in-process cells")
+        record("gate_5_callback_sanity", None, "no admissible in-process cells")
+    else:
+        worst_window = in_process["worst_rolling_frame_rate"]
+        if worst_window is None:
+            record(
+                "gate_4_frame_rate_stability",
+                None,
+                "no cell was long enough to produce a full rolling 1s window",
+            )
+        else:
+            record(
+                "gate_4_frame_rate_stability",
+                worst_window >= frames_per_second - 1,
+                f"worst rolling 1s window {worst_window:.2f}fps against a "
+                f"{frames_per_second - 1}fps floor; "
+                f"{in_process['dropped_frame_count']} drops (reported, not gated — "
+                "owner decision 1)",
+            )
+        record(
+            "gate_5_callback_sanity",
+            in_process["stage_callback_p99_ms"] <= GATE_5_CALLBACK_SANITY_MILLISECONDS,
+            f"callback p99 {in_process['stage_callback_p99_ms']:.4f}ms against "
+            f"{GATE_5_CALLBACK_SANITY_MILLISECONDS}ms — demoted to a sanity check by "
+            "owner decision 3, never a NO-GO on its own",
+        )
+
+    if in_process is None or floor is None:
+        record("floor_delta", None, "needs both an in-process and a floor arm")
+    else:
+        floor_delta_milliseconds = in_process["p50_ms"] - floor["p50_ms"]
+        detail = (
+            f"PyO3 costs {floor_delta_milliseconds:.4f}ms at p50 over the pure-Rust "
+            f"floor ({in_process['p50_ms']:.3f}ms vs {floor['p50_ms']:.3f}ms)"
+        )
+        if floor_delta_gate_milliseconds is None:
+            record(
+                "floor_delta",
+                None,
+                f"{detail}. Owner decision 3 made this the gate but states no "
+                "threshold; pass --floor-delta-gate-ms to evaluate",
+            )
+        else:
+            record(
+                "floor_delta",
+                floor_delta_milliseconds <= floor_delta_gate_milliseconds,
+                f"{detail}, against {floor_delta_gate_milliseconds:.4f}ms",
+            )
+
+    return {
+        "condition": {
+            "frame_width_pixels": width,
+            "frame_height_pixels": height,
+            "target_frames_per_second": frames_per_second,
+            "stage_callback_attribute": stage,
+            "anchor_processor_thread_gil": gil_anchor,
+        },
+        "arms": arms,
+        "gates": verdicts,
+    }
+
+
+def summarize_measurement_matrix(
+    matrix_directory: str,
+    floor_delta_gate_milliseconds: float | None,
+    absolute_p99_9_ceiling_milliseconds: float | None,
+) -> dict:
+    cells = load_measurement_cells(matrix_directory)
+    admissible: list[dict] = []
+    excluded: list[dict] = []
+    for cell in cells:
+        reason = describe_cell_inadmissibility(cell)
+        if reason is None:
+            admissible.append(cell)
+        else:
+            excluded.append(
+                {"directory": os.path.basename(cell["directory"]), "reason": reason}
+            )
+
+    cells_by_condition_and_arm: dict[tuple, dict[str, list]] = {}
+    for cell in admissible:
+        condition = cells_by_condition_and_arm.setdefault(
+            build_cell_condition_key(cell), {}
+        )
+        condition.setdefault(cell["summary"]["specification"]["arm"], []).append(cell)
+
+    conditions = [
+        evaluate_condition(
+            condition_key,
+            {
+                arm: summarize_arm_across_repetitions(arm_cells)
+                for arm, arm_cells in arms.items()
+            },
+            floor_delta_gate_milliseconds,
+            absolute_p99_9_ceiling_milliseconds,
+        )
+        for condition_key, arms in sorted(cells_by_condition_and_arm.items())
+    ]
+
+    every_verdict = [
+        verdict["verdict"]
+        for condition in conditions
+        for verdict in condition["gates"].values()
+    ]
+    return {
+        "matrix_directory": matrix_directory,
+        "cell_count": len(cells),
+        "admissible_cell_count": len(admissible),
+        "excluded_cells": excluded,
+        "conditions": conditions,
+        "gate_tally": {
+            "pass": every_verdict.count("PASS"),
+            "fail": every_verdict.count("FAIL"),
+            "not_evaluated": every_verdict.count("NOT EVALUATED"),
+        },
+    }
+
+
+def render_report(matrix_summary: dict) -> str:
+    lines = [
+        f"#1702 gate evaluation over {matrix_summary['matrix_directory']}",
+        f"  {matrix_summary['admissible_cell_count']} of "
+        f"{matrix_summary['cell_count']} cells admissible",
+        "",
+    ]
+    for excluded in matrix_summary["excluded_cells"]:
+        lines.append(f"  EXCLUDED {excluded['directory']}")
+        lines.append(f"           {excluded['reason']}")
+    if matrix_summary["excluded_cells"]:
+        lines.append("")
+
+    for condition in matrix_summary["conditions"]:
+        c = condition["condition"]
+        lines.append(
+            f"{c['frame_width_pixels']}x{c['frame_height_pixels']} @ "
+            f"{c['target_frames_per_second']}fps  stage={c['stage_callback_attribute']}  "
+            f"gil-anchor={'on' if c['anchor_processor_thread_gil'] else 'off'}"
+        )
+        for arm_name, arm in sorted(condition["arms"].items()):
+            lines.append(
+                f"  {arm_name:28} p50 {arm['p50_ms']:8.3f}ms  p99 {arm['p99_ms']:8.3f}ms  "
+                f"p99.9 {arm['p99_9_ms']:8.3f}ms  (n={arm['repetition_count']})"
+            )
+        for gate_name, gate in condition["gates"].items():
+            lines.append(f"  [{gate['verdict']:>13}] {gate_name}")
+            lines.append(f"                  {gate['detail']}")
+        lines.append("")
+
+    tally = matrix_summary["gate_tally"]
+    lines.append(
+        f"{tally['pass']} pass, {tally['fail']} fail, "
+        f"{tally['not_evaluated']} not evaluated"
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    argument_parser = argparse.ArgumentParser(description=__doc__)
+    argument_parser.add_argument("matrix_directory")
+    argument_parser.add_argument(
+        "--floor-delta-gate-ms",
+        type=float,
+        default=None,
+        help="threshold for the floor-vs-PyO3 p50 delta gate (owner decision 3 "
+        "added the gate but stated no number)",
+    )
+    argument_parser.add_argument(
+        "--absolute-p99-9-ceiling-ms",
+        type=float,
+        default=None,
+        help="absolute p99.9 ceiling (owner decision 4 added it but stated no number)",
+    )
+    argument_parser.add_argument("--json-out", default=None)
+    arguments = argument_parser.parse_args()
+
+    matrix_summary = summarize_measurement_matrix(
+        arguments.matrix_directory,
+        arguments.floor_delta_gate_ms,
+        arguments.absolute_p99_9_ceiling_ms,
+    )
+    if arguments.json_out:
+        with open(arguments.json_out, "w") as json_file:
+            json.dump(matrix_summary, json_file, indent=2)
+    sys.stdout.write(render_report(matrix_summary) + "\n")
+    # A failing gate is a result, not a harness error, so the exit status
+    # distinguishes them: 0 for "evaluated", 1 for "a gate failed".
+    return 1 if matrix_summary["gate_tally"]["fail"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/spikes/streamlib-pyembed-spike/python/test_measurement_matrix_summary.py
+++ b/spikes/streamlib-pyembed-spike/python/test_measurement_matrix_summary.py
@@ -43,6 +43,7 @@ def build_cell_summary(
             "wire_payload_mode": wire_payload_mode,
             "startup_settle_seconds": startup_settle_seconds,
             "stage_callback_attribute": "passthrough_stage",
+            "stage_callback_module": "spike_stage_callbacks",
             "anchor_processor_thread_gil": True,
             "resolved_delivery_profile": delivery_profile,
             "measured_metric_name": "source_emit_to_sink_receive",

--- a/spikes/streamlib-pyembed-spike/python/test_measurement_matrix_summary.py
+++ b/spikes/streamlib-pyembed-spike/python/test_measurement_matrix_summary.py
@@ -1,0 +1,323 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Tests for the gate evaluator.
+
+The property under test throughout is the one the evaluator exists for: a gate
+it cannot honestly evaluate must come out NOT EVALUATED, never PASS. A silently
+skipped gate reads as a passed one, and this artifact is what a GO decision
+rests on."""
+
+import json
+import os
+import tempfile
+import unittest
+
+import summarize_measurement_matrix as summarizer
+
+
+def build_cell_summary(
+    arm,
+    p50_nanoseconds=100_000,
+    p99_nanoseconds=140_000,
+    p99_9_nanoseconds=180_000,
+    stage_callback_p99_nanoseconds=20_000,
+    frames_per_second=60,
+    wire_payload_mode="surface-reference",
+    delivery_profile="every_sample",
+    stamping_compiled_in=True,
+    received_frame_count=900,
+    negative_latency_anomaly_count=0,
+    histogram_range_saturation_count=0,
+    backlog_drain_fraction=0.0,
+    rolling_windows=None,
+):
+    return {
+        "specification": {
+            "arm": arm,
+            "frame_width_pixels": 1280,
+            "frame_height_pixels": 720,
+            "channel_count": 4,
+            "target_frames_per_second": frames_per_second,
+            "wire_payload_mode": wire_payload_mode,
+            "stage_callback_attribute": "passthrough_stage",
+            "anchor_processor_thread_gil": True,
+            "resolved_delivery_profile": delivery_profile,
+            "measured_metric_name": "source_emit_to_sink_receive",
+            "measurement_stamping_is_compiled_in": stamping_compiled_in,
+        },
+        "source_emit_to_sink_receive": {
+            "p50_nanoseconds": p50_nanoseconds,
+            "p99_nanoseconds": p99_nanoseconds,
+            "p99_9_nanoseconds": p99_9_nanoseconds,
+            "max_nanoseconds": p99_9_nanoseconds,
+        },
+        "stage_callback": {
+            "p50_nanoseconds": stage_callback_p99_nanoseconds // 2,
+            "p99_nanoseconds": stage_callback_p99_nanoseconds,
+            "p99_9_nanoseconds": stage_callback_p99_nanoseconds,
+            "max_nanoseconds": stage_callback_p99_nanoseconds,
+        },
+        "received_frame_count": received_frame_count,
+        "measured_frame_count": received_frame_count,
+        "dropped_frame_count": 0,
+        "negative_latency_anomaly_count": negative_latency_anomaly_count,
+        "histogram_range_saturation_count": histogram_range_saturation_count,
+        "backlog_drain_fraction": backlog_drain_fraction,
+        "first_frame_sink_receive_monotonic_nanoseconds": 1_000,
+        "rolling_one_second_frame_rate_windows": (
+            [60.0] * 10 if rolling_windows is None else rolling_windows
+        ),
+    }
+
+
+def write_matrix(matrix_directory, named_summaries):
+    for cell_name, summary in named_summaries.items():
+        cell_directory = os.path.join(matrix_directory, cell_name)
+        os.makedirs(cell_directory)
+        with open(os.path.join(cell_directory, "summary.json"), "w") as summary_file:
+            json.dump(summary, summary_file)
+
+
+class CellAdmissibilityTest(unittest.TestCase):
+    def test_a_well_formed_cell_is_admissible(self):
+        self.assertIsNone(
+            summarizer.describe_cell_inadmissibility(
+                {"directory": "d", "summary": build_cell_summary("in-process-python")}
+            )
+        )
+
+    def test_a_control_build_cell_cannot_back_a_gate(self):
+        reason = summarizer.describe_cell_inadmissibility(
+            {
+                "directory": "d",
+                "summary": build_cell_summary(
+                    "in-process-python", stamping_compiled_in=False
+                ),
+            }
+        )
+        self.assertIn("stamping compiled out", reason)
+
+    def test_a_full_pixel_payload_cell_cannot_back_a_gate(self):
+        """It measures transport size, which is the retracted sweep, not the
+        hosting question the pivot turns on."""
+        reason = summarizer.describe_cell_inadmissibility(
+            {
+                "directory": "d",
+                "summary": build_cell_summary(
+                    "in-process-python", wire_payload_mode="full-pixel-payload"
+                ),
+            }
+        )
+        self.assertIn("payload sweep", reason)
+
+    def test_a_latest_profile_cell_cannot_back_a_latency_gate(self):
+        """Owner decision 1: under `latest` the sink drains to the newest frame
+        and the percentiles are pinned near one frame period regardless."""
+        reason = summarizer.describe_cell_inadmissibility(
+            {
+                "directory": "d",
+                "summary": build_cell_summary(
+                    "in-process-python", delivery_profile="latest"
+                ),
+            }
+        )
+        self.assertIn("every_sample", reason)
+
+    def test_a_cell_that_drained_a_backlog_cannot_back_a_gate(self):
+        reason = summarizer.describe_cell_inadmissibility(
+            {
+                "directory": "d",
+                "summary": build_cell_summary(
+                    "in-process-python", backlog_drain_fraction=0.4
+                ),
+            }
+        )
+        self.assertIn("startup backlog", reason)
+
+    def test_a_clock_disagreement_cannot_back_a_gate(self):
+        reason = summarizer.describe_cell_inadmissibility(
+            {
+                "directory": "d",
+                "summary": build_cell_summary(
+                    "in-process-python", negative_latency_anomaly_count=3
+                ),
+            }
+        )
+        self.assertIn("clocks disagree", reason)
+
+    def test_a_saturated_histogram_cannot_back_a_gate(self):
+        reason = summarizer.describe_cell_inadmissibility(
+            {
+                "directory": "d",
+                "summary": build_cell_summary(
+                    "in-process-python", histogram_range_saturation_count=1
+                ),
+            }
+        )
+        self.assertIn("floors, not values", reason)
+
+    def test_an_empty_cell_cannot_back_a_gate(self):
+        """Its percentiles are all zero, which reads as very fast rather than
+        as nothing having arrived."""
+        reason = summarizer.describe_cell_inadmissibility(
+            {
+                "directory": "d",
+                "summary": build_cell_summary(
+                    "in-process-python", received_frame_count=0
+                ),
+            }
+        )
+        self.assertIn("no frames", reason)
+
+
+class GateEvaluationTest(unittest.TestCase):
+    def summarize(self, named_summaries, **kwargs):
+        with tempfile.TemporaryDirectory() as matrix_directory:
+            write_matrix(matrix_directory, named_summaries)
+            return summarizer.summarize_measurement_matrix(
+                matrix_directory,
+                kwargs.get("floor_delta_gate_milliseconds"),
+                kwargs.get("absolute_p99_9_ceiling_milliseconds"),
+            )
+
+    def build_three_arm_matrix(self, **in_process_overrides):
+        return {
+            "floor": build_cell_summary(
+                "rust-passthrough-floor",
+                p50_nanoseconds=74_000,
+                p99_nanoseconds=107_000,
+                p99_9_nanoseconds=134_000,
+                stage_callback_p99_nanoseconds=0,
+            ),
+            "in-process": build_cell_summary(
+                "in-process-python", **in_process_overrides
+            ),
+            "baseline": build_cell_summary(
+                "subprocess-python-baseline",
+                p50_nanoseconds=167_000,
+                p99_nanoseconds=236_000,
+                p99_9_nanoseconds=296_000,
+            ),
+        }
+
+    def gate(self, matrix_summary, gate_name):
+        return matrix_summary["conditions"][0]["gates"][gate_name]
+
+    def test_a_healthy_matrix_passes_every_stated_gate(self):
+        matrix_summary = self.summarize(self.build_three_arm_matrix())
+        for gate_name in (
+            "gate_1_p50",
+            "gate_2_p99",
+            "gate_4_frame_rate_stability",
+            "gate_5_callback_sanity",
+        ):
+            self.assertEqual(
+                self.gate(matrix_summary, gate_name)["verdict"],
+                "PASS",
+                f"{gate_name}: {self.gate(matrix_summary, gate_name)['detail']}",
+            )
+
+    def test_an_unstated_absolute_p99_9_ceiling_leaves_gate_3_unevaluated(self):
+        """Owner decision 4 added the ceiling but named no number, and #1702 is
+        explicit that thresholds are never decided inline. Reporting PASS on the
+        relative half alone would silently narrow the gate."""
+        gate = self.gate(self.summarize(self.build_three_arm_matrix()), "gate_3_p99_9")
+        self.assertEqual(gate["verdict"], "NOT EVALUATED")
+        self.assertIn("states no number", gate["detail"])
+
+    def test_supplying_the_ceiling_evaluates_gate_3(self):
+        gate = self.gate(
+            self.summarize(
+                self.build_three_arm_matrix(), absolute_p99_9_ceiling_milliseconds=1.0
+            ),
+            "gate_3_p99_9",
+        )
+        self.assertEqual(gate["verdict"], "PASS")
+
+    def test_a_supplied_ceiling_can_fail_gate_3(self):
+        gate = self.gate(
+            self.summarize(
+                self.build_three_arm_matrix(), absolute_p99_9_ceiling_milliseconds=0.01
+            ),
+            "gate_3_p99_9",
+        )
+        self.assertEqual(gate["verdict"], "FAIL")
+
+    def test_an_unstated_floor_delta_threshold_leaves_that_gate_unevaluated(self):
+        gate = self.gate(self.summarize(self.build_three_arm_matrix()), "floor_delta")
+        self.assertEqual(gate["verdict"], "NOT EVALUATED")
+        self.assertIn("0.0", gate["detail"])
+        self.assertIn("states no threshold", gate["detail"])
+
+    def test_a_slower_in_process_arm_fails_gate_1(self):
+        matrix_summary = self.summarize(
+            self.build_three_arm_matrix(p50_nanoseconds=900_000)
+        )
+        self.assertEqual(self.gate(matrix_summary, "gate_1_p50")["verdict"], "FAIL")
+
+    def test_a_missing_baseline_arm_leaves_the_comparison_gates_unevaluated(self):
+        """The baseline arm failing to run must never read as the in-process arm
+        winning."""
+        matrix = self.build_three_arm_matrix()
+        del matrix["baseline"]
+        matrix_summary = self.summarize(matrix)
+        for gate_name in ("gate_1_p50", "gate_2_p99", "gate_3_p99_9"):
+            self.assertEqual(
+                self.gate(matrix_summary, gate_name)["verdict"], "NOT EVALUATED"
+            )
+
+    def test_an_unstated_rate_leaves_the_absolute_p99_ceiling_unevaluated(self):
+        """#1702 states absolute p99 ceilings for 30 and 60fps only."""
+        matrix = {
+            "floor": build_cell_summary(
+                "rust-passthrough-floor", frames_per_second=24
+            ),
+            "in-process": build_cell_summary(
+                "in-process-python", frames_per_second=24
+            ),
+            "baseline": build_cell_summary(
+                "subprocess-python-baseline",
+                frames_per_second=24,
+                p50_nanoseconds=167_000,
+            ),
+        }
+        gate = self.gate(self.summarize(matrix), "gate_2_p99")
+        self.assertEqual(gate["verdict"], "NOT EVALUATED")
+
+    def test_a_dropped_frame_rate_window_fails_gate_4(self):
+        matrix_summary = self.summarize(
+            self.build_three_arm_matrix(rolling_windows=[60.0, 60.0, 51.0])
+        )
+        self.assertEqual(
+            self.gate(matrix_summary, "gate_4_frame_rate_stability")["verdict"], "FAIL"
+        )
+
+    def test_inadmissible_cells_are_reported_rather_than_dropped_silently(self):
+        matrix = self.build_three_arm_matrix()
+        matrix["sweep"] = build_cell_summary(
+            "in-process-python", wire_payload_mode="full-pixel-payload"
+        )
+        matrix_summary = self.summarize(matrix)
+        self.assertEqual(len(matrix_summary["excluded_cells"]), 1)
+        self.assertEqual(matrix_summary["cell_count"], 4)
+        self.assertEqual(matrix_summary["admissible_cell_count"], 3)
+
+    def test_arms_are_summarized_by_median_across_repetitions(self):
+        """A heavily-tailed distribution means one bad repetition must not move
+        the arm's reported figure."""
+        matrix = self.build_three_arm_matrix()
+        matrix["in-process-rep-1"] = build_cell_summary(
+            "in-process-python", p50_nanoseconds=100_000
+        )
+        matrix["in-process-rep-2"] = build_cell_summary(
+            "in-process-python", p50_nanoseconds=9_000_000
+        )
+        matrix_summary = self.summarize(matrix)
+        arm = matrix_summary["conditions"][0]["arms"]["in-process-python"]
+        self.assertEqual(arm["repetition_count"], 3)
+        self.assertAlmostEqual(arm["p50_ms"], 0.1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spikes/streamlib-pyembed-spike/python/test_measurement_matrix_summary.py
+++ b/spikes/streamlib-pyembed-spike/python/test_measurement_matrix_summary.py
@@ -30,6 +30,7 @@ def build_cell_summary(
     negative_latency_anomaly_count=0,
     histogram_range_saturation_count=0,
     backlog_drain_fraction=0.0,
+    startup_settle_seconds=2.0,
     rolling_windows=None,
 ):
     return {
@@ -40,6 +41,7 @@ def build_cell_summary(
             "channel_count": 4,
             "target_frames_per_second": frames_per_second,
             "wire_payload_mode": wire_payload_mode,
+            "startup_settle_seconds": startup_settle_seconds,
             "stage_callback_attribute": "passthrough_stage",
             "anchor_processor_thread_gil": True,
             "resolved_delivery_profile": delivery_profile,
@@ -133,7 +135,49 @@ class CellAdmissibilityTest(unittest.TestCase):
                 ),
             }
         )
-        self.assertIn("startup backlog", reason)
+        self.assertIn("queue", reason)
+
+    def test_a_cell_whose_latency_grew_cannot_back_a_gate(self):
+        """Saturation is as disqualifying as draining, and the harness's check
+        was one-sided: a cell that gained 35% across its life was admitted."""
+        reason = summarizer.describe_cell_inadmissibility(
+            {
+                "directory": "d",
+                "summary": build_cell_summary(
+                    "in-process-python", backlog_drain_fraction=-0.35
+                ),
+            }
+        )
+        self.assertIn("gained", reason)
+
+    def test_a_saturated_cell_cannot_back_a_gate_even_with_a_flat_trend(self):
+        """The case no trend detector can see. With the settle removed, a
+        subprocess cell sat at p50 66.9ms with a trend of -0.002 — a stable
+        queue — and gate 1 passed against it at 0.127ms vs 66.9ms."""
+        reason = summarizer.describe_cell_inadmissibility(
+            {
+                "directory": "d",
+                "summary": build_cell_summary(
+                    "subprocess-python-baseline",
+                    p50_nanoseconds=66_900_000,
+                    p99_nanoseconds=71_600_000,
+                    p99_9_nanoseconds=72_000_000,
+                    backlog_drain_fraction=-0.002,
+                ),
+            }
+        )
+        self.assertIn("saturated", reason)
+
+    def test_a_cell_run_below_the_protocol_settle_cannot_back_a_gate(self):
+        reason = summarizer.describe_cell_inadmissibility(
+            {
+                "directory": "d",
+                "summary": build_cell_summary(
+                    "in-process-python", startup_settle_seconds=0.0
+                ),
+            }
+        )
+        self.assertIn("startup settle", reason)
 
     def test_a_clock_disagreement_cannot_back_a_gate(self):
         reason = summarizer.describe_cell_inadmissibility(
@@ -209,7 +253,7 @@ class GateEvaluationTest(unittest.TestCase):
         for gate_name in (
             "gate_1_p50",
             "gate_2_p99",
-            "gate_4_frame_rate_stability",
+            "gate_4a_rolling_frame_rate_floor",
             "gate_5_callback_sanity",
         ):
             self.assertEqual(
@@ -290,7 +334,7 @@ class GateEvaluationTest(unittest.TestCase):
             self.build_three_arm_matrix(rolling_windows=[60.0, 60.0, 51.0])
         )
         self.assertEqual(
-            self.gate(matrix_summary, "gate_4_frame_rate_stability")["verdict"], "FAIL"
+            self.gate(matrix_summary, "gate_4a_rolling_frame_rate_floor")["verdict"], "FAIL"
         )
 
     def test_inadmissible_cells_are_reported_rather_than_dropped_silently(self):

--- a/spikes/streamlib-pyembed-spike/python/test_spike_harness_contract.py
+++ b/spikes/streamlib-pyembed-spike/python/test_spike_harness_contract.py
@@ -14,6 +14,7 @@ import subprocess
 import tempfile
 import time
 import unittest
+import unittest.mock
 
 import numpy
 
@@ -166,12 +167,69 @@ class TierAHarnessCommandLineContractTest(unittest.TestCase):
                 )
             )
 
-    def test_subprocess_mode_is_refused_as_tier_b(self):
-        with self.assertRaises(runner.SubprocessArmIsTierBAndNotImplementedError) as refusal:
+    def test_subprocess_mode_resolves_to_the_baseline_arm(self):
+        self.assertEqual(
             runner.resolve_harness_arm_for_runner_mode(
                 runner.RUNNER_MODE_SUBPROCESS_PYTHON
+            ),
+            "subprocess-python-baseline",
+        )
+
+    def test_every_runner_mode_maps_to_a_harness_arm(self):
+        """A mode accepted by argparse but absent from the table would fail
+        mid-schedule, after earlier cells had already burned their minutes."""
+        for runner_mode in runner.SUPPORTED_RUNNER_MODES:
+            self.assertIn(runner_mode, runner.HARNESS_ARM_BY_RUNNER_MODE)
+
+    def test_an_unprovisioned_subprocess_arm_is_refused_before_any_cell_runs(self):
+        """The failure this replaces is silent: an unprovisioned slot fails at
+        graph build, and an unattended matrix would record the baseline arm as
+        absent rather than as unrunnable."""
+        with unittest.mock.patch("os.path.isfile", return_value=False):
+            with self.assertRaises(
+                runner.SubprocessBaselineArmIsNotProvisionedError
+            ) as refusal:
+                runner.require_subprocess_baseline_arm_is_provisioned()
+        self.assertIn("provision_subprocess_baseline_package.py", str(refusal.exception))
+
+    def test_the_harness_environment_carries_both_subprocess_arm_pins(self):
+        """Both are load-bearing and both fail silently when absent.
+
+        Losing the cdylib pin is the one that actually happened: the spawned
+        subprocess resolved a different `libstreamlib_python_native.so`, failed
+        to open its own input channel with
+        `DoesNotSupportRequestedAmountOfPublishers`, and the cell reported an
+        arm that produced no frames rather than one that was misconfigured. It
+        only reproduced under the runner, because a hand-run cell inherits the
+        variable from the operator's shell."""
+        if not os.path.isfile(
+            os.path.join(
+                runner.SPIKE_CRATE_ROOT_DIRECTORY,
+                ".provisioned",
+                "provisioning-record.json",
             )
-        self.assertIn("not in this PR", str(refusal.exception))
+        ):
+            raise unittest.SkipTest(
+                "no provisioning record; run "
+                "python/provision_subprocess_baseline_package.py"
+            )
+        environment = runner.build_tier_a_harness_process_environment()
+        self.assertTrue(
+            os.path.isdir(
+                environment[runner.APP_MODULES_DIRECTORY_ENVIRONMENT_VARIABLE]
+            )
+        )
+        self.assertTrue(
+            os.path.isfile(
+                environment[runner.PYTHON_NATIVE_LIBRARY_ENVIRONMENT_VARIABLE]
+            )
+        )
+
+    def test_an_unprovisioned_checkout_yields_no_subprocess_arm_environment(self):
+        """The refusal belongs to the provisioning guard, which names the fix.
+        Silently exporting a guessed path here would restore the failure above."""
+        with unittest.mock.patch("os.path.isfile", return_value=False):
+            self.assertEqual(runner.read_subprocess_baseline_arm_environment(), {})
 
     def test_a_fractional_duration_is_refused_rather_than_rounded(self):
         with self.assertRaises(ValueError):

--- a/spikes/streamlib-pyembed-spike/python/test_spike_harness_contract.py
+++ b/spikes/streamlib-pyembed-spike/python/test_spike_harness_contract.py
@@ -205,7 +205,8 @@ class TierAHarnessCommandLineContractTest(unittest.TestCase):
         if not os.path.isfile(
             os.path.join(
                 runner.SPIKE_CRATE_ROOT_DIRECTORY,
-                ".provisioned",
+                "target",
+                "provisioned",
                 "provisioning-record.json",
             )
         ):

--- a/spikes/streamlib-pyembed-spike/python/warm_restart_battery.py
+++ b/spikes/streamlib-pyembed-spike/python/warm_restart_battery.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Gate 6 of #1702: how long a restart takes to put a frame on the wire.
+
+One cold run followed by N warm ones, each a fresh process, measuring
+exec-to-first-frame: a `CLOCK_MONOTONIC` stamp taken immediately before spawn
+against the stamp the harness's sink records when it sees its first frame. Both
+sides read the same clock on the same machine, so no offset estimation is
+involved and nothing depends on the harness reporting its own start time
+honestly.
+
+Why the cold run is separate rather than dropped: it is the only one that pays
+the page cache, and reporting it inside the median would understate the warm
+figure the dev loop actually feels while overstating the first-run figure a user
+hits. Both are reported; only the warm ones back the gate.
+
+The battery forces `--startup-settle-seconds 0`. The settle exists so latency
+cells measure a quiescent graph; here it would simply be added to every number.
+
+Gate 6 as amended asks for `import torch` reported separately. `--extra-import`
+takes any module and reports its import cost in this interpreter, so the number
+is attributable rather than folded into the harness's own startup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+
+import runner
+
+# Gate 6's threshold: warm restart at or under this median backs a GO.
+WARM_RESTART_MEDIAN_GATE_SECONDS = 1.5
+# Above this, #1702 calls the execution pivot dead outright.
+WARM_RESTART_NO_GO_SECONDS = 5.0
+
+# Long enough to be certain a frame lands and the cell writes its summary,
+# short enough that eleven runs stay quick. The battery measures startup, so
+# nothing past the first frame matters.
+BATTERY_CELL_DURATION_SECONDS = 3
+BATTERY_FRAME_WIDTH_PIXELS = 1280
+BATTERY_FRAME_HEIGHT_PIXELS = 720
+
+
+class RestartRunProducedNoFrameError(RuntimeError):
+    """Raised when a run finished without the sink ever seeing a frame.
+
+    Reported rather than skipped: a battery that quietly dropped such runs
+    would report the median of whichever runs happened to work.
+    """
+
+
+def run_one_restart_and_measure_seconds(
+    harness_binary_path: str,
+    harness_arm: str,
+    output_directory: str,
+    repetition_index: int,
+) -> float:
+    """Spawn one harness process and return its exec-to-first-frame seconds."""
+    harness_command_line = [
+        harness_binary_path,
+        "--arm",
+        harness_arm,
+        "--fps",
+        "60",
+        "--frame-width",
+        str(BATTERY_FRAME_WIDTH_PIXELS),
+        "--frame-height",
+        str(BATTERY_FRAME_HEIGHT_PIXELS),
+        "--duration-seconds",
+        str(BATTERY_CELL_DURATION_SECONDS),
+        "--warmup-exclusion-seconds",
+        "0",
+        "--startup-settle-seconds",
+        "0",
+        "--repetition-index",
+        str(repetition_index),
+        "--output-directory",
+        output_directory,
+    ]
+
+    spawned_at_epoch_seconds = time.time()
+    # Taken as late as possible: everything between this stamp and `exec` is
+    # charged to the restart, which is the honest direction for a startup gate.
+    spawned_at_monotonic_nanoseconds = time.monotonic_ns()
+    completed_process = subprocess.run(
+        harness_command_line,
+        env=runner.build_tier_a_harness_process_environment(),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed_process.returncode != 0:
+        raise RestartRunProducedNoFrameError(
+            f"restart run {repetition_index} exited {completed_process.returncode}:\n"
+            f"{completed_process.stderr[-2000:]}"
+        )
+
+    cell_directory = runner.locate_measurement_cell_directory_created_by_harness(
+        output_directory, spawned_at_epoch_seconds
+    )
+    if cell_directory is None:
+        raise RestartRunProducedNoFrameError(
+            f"restart run {repetition_index} left no cell directory under "
+            f"{output_directory}"
+        )
+    with open(
+        os.path.join(cell_directory, runner.HARNESS_CELL_SUMMARY_FILE_NAME)
+    ) as summary_file:
+        summary = json.load(summary_file)
+
+    first_frame_monotonic_nanoseconds = summary[
+        "first_frame_sink_receive_monotonic_nanoseconds"
+    ]
+    if first_frame_monotonic_nanoseconds is None:
+        raise RestartRunProducedNoFrameError(
+            f"restart run {repetition_index} completed but its sink never saw a frame"
+        )
+    return (
+        first_frame_monotonic_nanoseconds - spawned_at_monotonic_nanoseconds
+    ) / 1e9
+
+
+def measure_extra_import_seconds(module_name: str) -> float:
+    """Import cost of `module_name` in a fresh interpreter, reported separately."""
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import time;"
+            "start=time.monotonic_ns();"
+            f"__import__({module_name!r});"
+            "print((time.monotonic_ns()-start)/1e9)",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return float(probe.stdout.strip())
+
+
+def run_warm_restart_battery(
+    harness_binary_path: str,
+    harness_arm: str,
+    output_directory: str,
+    warm_run_count: int,
+    extra_import_module_names: list[str],
+) -> dict:
+    os.makedirs(output_directory, exist_ok=True)
+    cold_restart_seconds = run_one_restart_and_measure_seconds(
+        harness_binary_path, harness_arm, output_directory, 0
+    )
+    warm_restart_seconds = [
+        run_one_restart_and_measure_seconds(
+            harness_binary_path, harness_arm, output_directory, index + 1
+        )
+        for index in range(warm_run_count)
+    ]
+
+    warm_restart_median_seconds = statistics.median(warm_restart_seconds)
+    return {
+        "harness_arm": harness_arm,
+        "cold_restart_seconds": cold_restart_seconds,
+        "warm_restart_seconds": warm_restart_seconds,
+        "warm_restart_median_seconds": warm_restart_median_seconds,
+        "warm_restart_maximum_seconds": max(warm_restart_seconds),
+        "gate_6_median_threshold_seconds": WARM_RESTART_MEDIAN_GATE_SECONDS,
+        "gate_6_passes": warm_restart_median_seconds
+        <= WARM_RESTART_MEDIAN_GATE_SECONDS,
+        "no_go_threshold_seconds": WARM_RESTART_NO_GO_SECONDS,
+        "exceeds_no_go_threshold": warm_restart_median_seconds
+        > WARM_RESTART_NO_GO_SECONDS,
+        "extra_import_seconds": {
+            module_name: measure_extra_import_seconds(module_name)
+            for module_name in extra_import_module_names
+        },
+    }
+
+
+def main() -> int:
+    argument_parser = argparse.ArgumentParser(description=__doc__)
+    argument_parser.add_argument(
+        "--harness-binary",
+        default=os.environ.get(runner.HARNESS_BINARY_ENVIRONMENT_VARIABLE),
+        required=False,
+    )
+    argument_parser.add_argument(
+        "--arm",
+        default="in-process-python",
+        help="which arm restarts; the gate is about the in-process one, and the "
+        "subprocess arm is available for comparison",
+    )
+    argument_parser.add_argument("--warm-run-count", type=int, default=10)
+    argument_parser.add_argument(
+        "--extra-import",
+        action="append",
+        default=[],
+        metavar="MODULE",
+        help="report this module's import cost separately (gate 6 names torch)",
+    )
+    argument_parser.add_argument("--output-dir", required=True)
+    arguments = argument_parser.parse_args()
+
+    if not arguments.harness_binary or not os.path.isfile(arguments.harness_binary):
+        sys.stderr.write(
+            "no harness binary; pass --harness-binary or set "
+            f"${runner.HARNESS_BINARY_ENVIRONMENT_VARIABLE}\n"
+        )
+        return 2
+
+    battery_record = run_warm_restart_battery(
+        arguments.harness_binary,
+        arguments.arm,
+        arguments.output_dir,
+        arguments.warm_run_count,
+        arguments.extra_import,
+    )
+    with open(
+        os.path.join(arguments.output_dir, "warm-restart-battery.json"), "w"
+    ) as record_file:
+        json.dump(battery_record, record_file, indent=2)
+    sys.stdout.write(json.dumps(battery_record, indent=2) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/spikes/streamlib-pyembed-spike/python/warm_restart_battery.py
+++ b/spikes/streamlib-pyembed-spike/python/warm_restart_battery.py
@@ -11,10 +11,11 @@ sides read the same clock on the same machine, so no offset estimation is
 involved and nothing depends on the harness reporting its own start time
 honestly.
 
-Why the cold run is separate rather than dropped: it is the only one that pays
-the page cache, and reporting it inside the median would understate the warm
-figure the dev loop actually feels while overstating the first-run figure a user
-hits. Both are reported; only the warm ones back the gate.
+The first run is reported separately rather than dropped, because it carries
+whatever one-time cost the box has not yet paid. It is deliberately NOT called a
+cold restart: nothing here evicts the page cache, so it is "the first run of
+this battery", not a measurement of a cold start. Only the warm runs back the
+gate.
 
 The battery forces `--startup-settle-seconds 0`. The settle exists so latency
 cells measure a quiescent graph; here it would simply be added to every number.
@@ -27,7 +28,6 @@ is attributable rather than folded into the harness's own startup.
 from __future__ import annotations
 
 import argparse
-import importlib
 import json
 import os
 import statistics
@@ -147,6 +147,13 @@ def measure_extra_import_seconds(module_name: str) -> float:
     return float(probe.stdout.strip())
 
 
+# The battery's own cells live here rather than beside the matrix's. They share
+# arm, geometry and rate with protocol cells, so the harness derives the same
+# directory name and a battery run pointed at a matrix directory silently
+# overwrites the cells it collides with.
+BATTERY_CELL_SUBDIRECTORY_NAME = "warm-restart-cells"
+
+
 def run_warm_restart_battery(
     harness_binary_path: str,
     harness_arm: str,
@@ -155,12 +162,14 @@ def run_warm_restart_battery(
     extra_import_module_names: list[str],
 ) -> dict:
     os.makedirs(output_directory, exist_ok=True)
-    cold_restart_seconds = run_one_restart_and_measure_seconds(
-        harness_binary_path, harness_arm, output_directory, 0
+    cell_directory = os.path.join(output_directory, BATTERY_CELL_SUBDIRECTORY_NAME)
+    os.makedirs(cell_directory, exist_ok=True)
+    first_restart_seconds = run_one_restart_and_measure_seconds(
+        harness_binary_path, harness_arm, cell_directory, 0
     )
     warm_restart_seconds = [
         run_one_restart_and_measure_seconds(
-            harness_binary_path, harness_arm, output_directory, index + 1
+            harness_binary_path, harness_arm, cell_directory, index + 1
         )
         for index in range(warm_run_count)
     ]
@@ -168,7 +177,7 @@ def run_warm_restart_battery(
     warm_restart_median_seconds = statistics.median(warm_restart_seconds)
     return {
         "harness_arm": harness_arm,
-        "cold_restart_seconds": cold_restart_seconds,
+        "first_restart_seconds": first_restart_seconds,
         "warm_restart_seconds": warm_restart_seconds,
         "warm_restart_median_seconds": warm_restart_median_seconds,
         "warm_restart_maximum_seconds": max(warm_restart_seconds),

--- a/spikes/streamlib-pyembed-spike/src/bin/tier_a_harness.rs
+++ b/spikes/streamlib-pyembed-spike/src/bin/tier_a_harness.rs
@@ -37,8 +37,12 @@ const BACKLOG_TREND_FRACTION_INVALIDATING_A_CELL: f64 = 0.20;
 #[command(about = "Run one Tier A measurement cell for the #1702 PyO3 spike")]
 struct TierAHarnessArguments {
     /// Which comparison arm to run.
-    #[arg(long, value_parser = MeasurementArm::parse_from_flag_value)]
-    arm: MeasurementArm,
+    #[arg(
+        long,
+        value_parser = MeasurementArm::parse_from_flag_value,
+        required_unless_present = "report_embedded_python_runtime_to"
+    )]
+    arm: Option<MeasurementArm>,
 
     #[arg(long, default_value_t = 30)]
     fps: u32,
@@ -100,8 +104,53 @@ struct TierAHarnessArguments {
     #[arg(long)]
     require_locked_measurement_state: bool,
 
+    /// Write the embedded interpreter's identity as JSON to this path and exit,
+    /// without running a cell. Provisioning uses it to pin the baseline venv to
+    /// the exact interpreter the in-process arm runs, rather than to a
+    /// `python3.X` on PATH that merely shares a minor version. A file rather
+    /// than stdout: the engine's tracing output shares stdout, and a parser
+    /// would have to pick the JSON back out of it.
     #[arg(long)]
-    output_directory: PathBuf,
+    report_embedded_python_runtime_to: Option<PathBuf>,
+
+    #[arg(long, required_unless_present = "report_embedded_python_runtime_to")]
+    output_directory: Option<PathBuf>,
+}
+
+/// Report the embedded interpreter's full version, install prefix and numpy.
+fn report_embedded_python_runtime(report_path: &std::path::Path) -> Result<()> {
+    Python::initialize();
+    let report = Python::attach(|python| -> Result<String> {
+        let probe = python
+            .import("sys")
+            .and_then(|sys| {
+                let version: String = sys.getattr("version")?.extract()?;
+                let base_prefix: String = sys.getattr("base_prefix")?.extract()?;
+                let version_info = sys.getattr("version_info")?;
+                let major: u32 = version_info.getattr("major")?.extract()?;
+                let minor: u32 = version_info.getattr("minor")?.extract()?;
+                let micro: u32 = version_info.getattr("micro")?.extract()?;
+                let numpy_version: Option<String> = python
+                    .import("numpy")
+                    .ok()
+                    .and_then(|numpy| numpy.getattr("__version__").ok())
+                    .and_then(|value| value.extract().ok());
+                Ok(serde_json::json!({
+                    "version_banner": version,
+                    "version": format!("{major}.{minor}.{micro}"),
+                    "major_minor": format!("{major}.{minor}"),
+                    "base_prefix": base_prefix,
+                    "numpy_version": numpy_version,
+                })
+                .to_string())
+            })
+            .map_err(|error| {
+                Error::Runtime(format!("probing the embedded interpreter failed: {error}"))
+            })?;
+        Ok(probe)
+    })?;
+    std::fs::write(report_path, report)?;
+    Ok(())
 }
 
 fn main() -> Result<()> {
@@ -109,6 +158,18 @@ fn main() -> Result<()> {
     // engine's global tracing dispatcher, and a second `set_global_default`
     // aborts the run before a single frame is measured.
     let arguments = TierAHarnessArguments::parse();
+
+    if let Some(report_path) = arguments.report_embedded_python_runtime_to.as_deref() {
+        return report_embedded_python_runtime(report_path);
+    }
+
+    let arm = arguments
+        .arm
+        .ok_or_else(|| Error::Configuration("--arm is required".to_string()))?;
+    let output_directory = arguments
+        .output_directory
+        .clone()
+        .ok_or_else(|| Error::Configuration("--output-directory is required".to_string()))?;
 
     let machine_specification = probe_machine_specification();
     if arguments.require_locked_measurement_state
@@ -125,7 +186,7 @@ fn main() -> Result<()> {
     // The subprocess baseline arm runs its callback in a spawned interpreter,
     // so bringing one up here would add a cost that arm does not have and
     // would misattribute this process's GC pauses to it.
-    if arguments.arm.runs_the_callback_in_the_harness_interpreter() {
+    if arm.runs_the_callback_in_the_harness_interpreter() {
         // CPython comes up before `App::new` so interpreter initialization is
         // ordered ahead of GpuContext init and iceoryx2 node creation rather
         // than racing them from a processor thread.
@@ -139,7 +200,7 @@ fn main() -> Result<()> {
         arguments.repetition_index
     );
 
-    if arguments.arm.runs_the_callback_in_the_harness_interpreter() {
+    if arm.runs_the_callback_in_the_harness_interpreter() {
         Python::attach(|python| -> Result<()> {
             let module = python
                 .import(arguments.stage_callback_module.as_str())
@@ -167,7 +228,7 @@ fn main() -> Result<()> {
     }
 
     let specification = TierAMeasurementCellSpecification {
-        arm: arguments.arm,
+        arm,
         frame_width_pixels: arguments.frame_width,
         frame_height_pixels: arguments.frame_height,
         channel_count: arguments.channels,
@@ -186,15 +247,13 @@ fn main() -> Result<()> {
         measurement_stamping_is_compiled_in: MEASUREMENT_STAMPING_IS_COMPILED_IN,
     };
 
-    let cell_directory = arguments
-        .output_directory
-        .join(specification.artifact_directory_name());
+    let cell_directory = output_directory.join(specification.artifact_directory_name());
 
     // The recorder has to live in the interpreter that runs the callback. In the
     // runner's interpreter it would time collections that cannot have caused any
     // frame's latency — which is what it did before, reporting 0 events.
     let garbage_collection_recorder =
-        if arguments.arm.runs_the_callback_in_the_harness_interpreter() {
+        if arm.runs_the_callback_in_the_harness_interpreter() {
             Some(install_embedded_interpreter_garbage_collection_recorder(
                 &arguments.garbage_collection_mode,
             )?)

--- a/spikes/streamlib-pyembed-spike/src/bin/tier_a_harness.rs
+++ b/spikes/streamlib-pyembed-spike/src/bin/tier_a_harness.rs
@@ -22,6 +22,7 @@ use streamlib_pyembed_spike::machine_specification_probe::{
     machine_is_in_locked_measurement_state, probe_machine_specification,
 };
 use streamlib_pyembed_spike::python_processor_callback_registry::register_python_callback_under_token;
+use streamlib_pyembed_spike::synthetic_frame_wire_payload_mode::SyntheticFrameWirePayloadMode;
 use streamlib_pyembed_spike::tier_a_measurement_cell::{
     MeasurementArm, TierAMeasurementCellSpecification, run_tier_a_measurement_cell,
 };
@@ -44,6 +45,16 @@ struct TierAHarnessArguments {
 
     #[arg(long, default_value_t = 4)]
     channels: u32,
+
+    /// `surface-reference` matches what a real `VideoFrame` weighs on the wire
+    /// and is what the protocol cells measure; `full-pixel-payload` reproduces
+    /// the payload sweep that retracted the 27ms floor.
+    #[arg(
+        long,
+        default_value = "surface-reference",
+        value_parser = SyntheticFrameWirePayloadMode::parse_from_flag_value
+    )]
+    wire_payload_mode: SyntheticFrameWirePayloadMode,
 
     #[arg(long, default_value_t = 600)]
     duration_seconds: u64,
@@ -151,6 +162,7 @@ fn main() -> Result<()> {
         frame_height_pixels: arguments.frame_height,
         channel_count: arguments.channels,
         target_frames_per_second: arguments.fps,
+        wire_payload_mode: arguments.wire_payload_mode,
         cell_duration_seconds: arguments.duration_seconds,
         warmup_exclusion_seconds: arguments.warmup_exclusion_seconds,
         python_callback_registration_token,

--- a/spikes/streamlib-pyembed-spike/src/bin/tier_a_harness.rs
+++ b/spikes/streamlib-pyembed-spike/src/bin/tier_a_harness.rs
@@ -17,28 +17,27 @@ use std::path::PathBuf;
 use clap::Parser;
 use pyo3::prelude::*;
 use streamlib::sdk::error::{Error, Result};
-use streamlib_pyembed_spike::monotonic_clock::MEASUREMENT_STAMPING_IS_COMPILED_IN;
 use streamlib_pyembed_spike::machine_specification_probe::{
     machine_is_in_locked_measurement_state, probe_machine_specification,
 };
+use streamlib_pyembed_spike::monotonic_clock::MEASUREMENT_STAMPING_IS_COMPILED_IN;
 use streamlib_pyembed_spike::python_processor_callback_registry::register_python_callback_under_token;
+use streamlib_pyembed_spike::synthetic_frame_source_processor::default_startup_settle_seconds;
 use streamlib_pyembed_spike::synthetic_frame_wire_payload_mode::SyntheticFrameWirePayloadMode;
 use streamlib_pyembed_spike::tier_a_measurement_cell::{
     MeasurementArm, TierAMeasurementCellSpecification, run_tier_a_measurement_cell,
 };
 
 /// A steady-state cell's first and last measured deciles agree to within noise.
-/// A fifth of the latency disappearing across the cell is a draining queue, not
-/// jitter — see [`LatencyMeasurementRecorder::backlog_drain_fraction`].
-///
-/// [`LatencyMeasurementRecorder::backlog_drain_fraction`]: streamlib_pyembed_spike::latency_measurement_recorder::LatencyMeasurementRecorder::backlog_drain_fraction
-const BACKLOG_DRAIN_FRACTION_INVALIDATING_A_CELL: f64 = 0.20;
+/// Compared as a magnitude: a cell whose latency grew is saturating, which is
+/// as disqualifying as one that was draining.
+const BACKLOG_TREND_FRACTION_INVALIDATING_A_CELL: f64 = 0.20;
 
 #[derive(Parser, Debug)]
 #[command(about = "Run one Tier A measurement cell for the #1702 PyO3 spike")]
 struct TierAHarnessArguments {
     /// Which comparison arm to run.
-    #[arg(long, value_parser = parse_measurement_arm)]
+    #[arg(long, value_parser = MeasurementArm::parse_from_flag_value)]
     arm: MeasurementArm,
 
     #[arg(long, default_value_t = 30)]
@@ -67,7 +66,7 @@ struct TierAHarnessArguments {
     /// and held identical across arms: the subprocess arm needs ~0.66s to reach
     /// its poll loop, and frames emitted into that window become a backlog that
     /// outlives the warmup exclusion.
-    #[arg(long, default_value_t = 2.0)]
+    #[arg(long, default_value_t = default_startup_settle_seconds())]
     startup_settle_seconds: f64,
 
     #[arg(long, default_value_t = 600)]
@@ -105,18 +104,6 @@ struct TierAHarnessArguments {
     output_directory: PathBuf,
 }
 
-fn parse_measurement_arm(value: &str) -> std::result::Result<MeasurementArm, String> {
-    match value {
-        "in-process-python" => Ok(MeasurementArm::InProcessPython),
-        "rust-passthrough-floor" => Ok(MeasurementArm::RustPassthroughFloor),
-        "subprocess-python-baseline" => Ok(MeasurementArm::SubprocessPythonBaseline),
-        other => Err(format!(
-            "unknown arm `{other}` — expected `in-process-python`, `rust-passthrough-floor`, \
-             or `subprocess-python-baseline`"
-        )),
-    }
-}
-
 fn main() -> Result<()> {
     // No subscriber is installed here on purpose: `Runner::new()` installs the
     // engine's global tracing dispatcher, and a second `set_global_default`
@@ -147,7 +134,9 @@ fn main() -> Result<()> {
 
     let python_callback_registration_token = format!(
         "{}::{}::rep-{}",
-        arguments.stage_callback_module, arguments.stage_callback_attribute, arguments.repetition_index
+        arguments.stage_callback_module,
+        arguments.stage_callback_attribute,
+        arguments.repetition_index
     );
 
     if arguments.arm.runs_the_callback_in_the_harness_interpreter() {
@@ -189,6 +178,7 @@ fn main() -> Result<()> {
         warmup_exclusion_seconds: arguments.warmup_exclusion_seconds,
         python_callback_registration_token,
         anchor_processor_thread_gil: !arguments.disable_gil_anchor,
+        stage_callback_module: arguments.stage_callback_module.clone(),
         stage_callback_attribute: arguments.stage_callback_attribute.clone(),
         resolved_delivery_profile: "every_sample".to_string(),
         measured_metric_name: "source_emit_to_sink_receive".to_string(),
@@ -203,16 +193,14 @@ fn main() -> Result<()> {
     // The recorder has to live in the interpreter that runs the callback. In the
     // runner's interpreter it would time collections that cannot have caused any
     // frame's latency — which is what it did before, reporting 0 events.
-    let garbage_collection_recorder = if arguments
-        .arm
-        .runs_the_callback_in_the_harness_interpreter()
-    {
-        Some(install_embedded_interpreter_garbage_collection_recorder(
-            &arguments.garbage_collection_mode,
-        )?)
-    } else {
-        None
-    };
+    let garbage_collection_recorder =
+        if arguments.arm.runs_the_callback_in_the_harness_interpreter() {
+            Some(install_embedded_interpreter_garbage_collection_recorder(
+                &arguments.garbage_collection_mode,
+            )?)
+        } else {
+            None
+        };
 
     let outcome = run_tier_a_measurement_cell(&specification, &cell_directory)?;
 
@@ -231,40 +219,47 @@ fn main() -> Result<()> {
         )
         .finish();
     tracing::subscriber::with_default(post_stop_subscriber, || {
-    tracing::info!(
-        cell = %specification.artifact_directory_name(),
-        received_frames = outcome.received_frame_count,
-        measured_frames = outcome.measured_frame_count,
-        dropped_frames = outcome.dropped_frame_count,
-        p50_ns = outcome.source_emit_to_sink_receive.p50_nanoseconds,
-        p99_ns = outcome.source_emit_to_sink_receive.p99_nanoseconds,
-        p99_9_ns = outcome.source_emit_to_sink_receive.p99_9_nanoseconds,
-        max_ns = outcome.source_emit_to_sink_receive.max_nanoseconds,
-        "cell complete"
-    );
+        tracing::info!(
+            cell = %specification.artifact_directory_name(),
+            received_frames = outcome.received_frame_count,
+            measured_frames = outcome.measured_frame_count,
+            dropped_frames = outcome.dropped_frame_count,
+            p50_ns = outcome.source_emit_to_sink_receive.p50_nanoseconds,
+            p99_ns = outcome.source_emit_to_sink_receive.p99_nanoseconds,
+            p99_9_ns = outcome.source_emit_to_sink_receive.p99_9_nanoseconds,
+            max_ns = outcome.source_emit_to_sink_receive.max_nanoseconds,
+            "cell complete"
+        );
 
-    if outcome.negative_latency_anomaly_count > 0 {
-        tracing::error!(
-            count = outcome.negative_latency_anomaly_count,
-            "cell recorded sink stamps earlier than their emit stamps — the clocks disagree \
+        if outcome.negative_latency_anomaly_count > 0 {
+            tracing::error!(
+                count = outcome.negative_latency_anomaly_count,
+                "cell recorded sink stamps earlier than their emit stamps — the clocks disagree \
              and this cell's percentiles must not be used"
-        );
-    }
-    if outcome.histogram_range_saturation_count > 0 {
-        tracing::error!(
-            count = outcome.histogram_range_saturation_count,
-            "samples exceeded the histogram range — reported percentiles are clipped"
-        );
-    }
-    if outcome.backlog_drain_fraction > BACKLOG_DRAIN_FRACTION_INVALIDATING_A_CELL {
-        tracing::error!(
-            backlog_drain_fraction = outcome.backlog_drain_fraction,
-            startup_settle_seconds = specification.startup_settle_seconds,
-            "cell latency fell steadily from its first measured decile to its last — it was \
-             draining a startup backlog, so these percentiles describe queue occupancy and \
-             depend on how long the cell ran; raise --startup-settle-seconds and rerun"
-        );
-    }
+            );
+        }
+        if outcome.histogram_range_saturation_count > 0 {
+            tracing::error!(
+                count = outcome.histogram_range_saturation_count,
+                "samples exceeded the histogram range — reported percentiles are clipped"
+            );
+        }
+        if outcome.backlog_drain_fraction.abs() > BACKLOG_TREND_FRACTION_INVALIDATING_A_CELL {
+            tracing::error!(
+                backlog_trend_fraction = outcome.backlog_drain_fraction,
+                direction = if outcome.backlog_drain_fraction > 0.0 {
+                    "draining"
+                } else {
+                    "building"
+                },
+                startup_settle_seconds = specification.startup_settle_seconds,
+                "cell latency moved steadily between its first and last measured decile, so \
+                 these percentiles describe queue occupancy and depend on how long the cell \
+                 ran. Two causes: a startup backlog, which --startup-settle-seconds fixes, or \
+                 per-frame service time at or above the frame period, which it cannot — \
+                 compare the achieved rate against the target to tell them apart"
+            );
+        }
     });
 
     Ok(())
@@ -330,9 +325,7 @@ fn export_embedded_interpreter_garbage_collection_records(
                 "export_collection_records_as_jsonl",
                 (record_path.to_string_lossy().as_ref(),),
             )
-            .map_err(|error| {
-                Error::Runtime(format!("exporting the GC records failed: {error}"))
-            })?;
+            .map_err(|error| Error::Runtime(format!("exporting the GC records failed: {error}")))?;
         tracing::info!(
             recorded_event_count,
             path = %record_path.display(),

--- a/spikes/streamlib-pyembed-spike/src/bin/tier_a_harness.rs
+++ b/spikes/streamlib-pyembed-spike/src/bin/tier_a_harness.rs
@@ -27,6 +27,13 @@ use streamlib_pyembed_spike::tier_a_measurement_cell::{
     MeasurementArm, TierAMeasurementCellSpecification, run_tier_a_measurement_cell,
 };
 
+/// A steady-state cell's first and last measured deciles agree to within noise.
+/// A fifth of the latency disappearing across the cell is a draining queue, not
+/// jitter — see [`LatencyMeasurementRecorder::backlog_drain_fraction`].
+///
+/// [`LatencyMeasurementRecorder::backlog_drain_fraction`]: streamlib_pyembed_spike::latency_measurement_recorder::LatencyMeasurementRecorder::backlog_drain_fraction
+const BACKLOG_DRAIN_FRACTION_INVALIDATING_A_CELL: f64 = 0.20;
+
 #[derive(Parser, Debug)]
 #[command(about = "Run one Tier A measurement cell for the #1702 PyO3 spike")]
 struct TierAHarnessArguments {
@@ -55,6 +62,13 @@ struct TierAHarnessArguments {
         value_parser = SyntheticFrameWirePayloadMode::parse_from_flag_value
     )]
     wire_payload_mode: SyntheticFrameWirePayloadMode,
+
+    /// Quiet period before the source's first frame. Sized for the slowest arm
+    /// and held identical across arms: the subprocess arm needs ~0.66s to reach
+    /// its poll loop, and frames emitted into that window become a backlog that
+    /// outlives the warmup exclusion.
+    #[arg(long, default_value_t = 2.0)]
+    startup_settle_seconds: f64,
 
     #[arg(long, default_value_t = 600)]
     duration_seconds: u64,
@@ -95,8 +109,10 @@ fn parse_measurement_arm(value: &str) -> std::result::Result<MeasurementArm, Str
     match value {
         "in-process-python" => Ok(MeasurementArm::InProcessPython),
         "rust-passthrough-floor" => Ok(MeasurementArm::RustPassthroughFloor),
+        "subprocess-python-baseline" => Ok(MeasurementArm::SubprocessPythonBaseline),
         other => Err(format!(
-            "unknown arm `{other}` — expected `in-process-python` or `rust-passthrough-floor`"
+            "unknown arm `{other}` — expected `in-process-python`, `rust-passthrough-floor`, \
+             or `subprocess-python-baseline`"
         )),
     }
 }
@@ -119,17 +135,22 @@ fn main() -> Result<()> {
         ));
     }
 
-    // CPython comes up before `App::new` so interpreter initialization is
-    // ordered ahead of GpuContext init and iceoryx2 node creation rather than
-    // racing them from a processor thread.
-    Python::initialize();
+    // The subprocess baseline arm runs its callback in a spawned interpreter,
+    // so bringing one up here would add a cost that arm does not have and
+    // would misattribute this process's GC pauses to it.
+    if arguments.arm.runs_the_callback_in_the_harness_interpreter() {
+        // CPython comes up before `App::new` so interpreter initialization is
+        // ordered ahead of GpuContext init and iceoryx2 node creation rather
+        // than racing them from a processor thread.
+        Python::initialize();
+    }
 
     let python_callback_registration_token = format!(
         "{}::{}::rep-{}",
         arguments.stage_callback_module, arguments.stage_callback_attribute, arguments.repetition_index
     );
 
-    if arguments.arm == MeasurementArm::InProcessPython {
+    if arguments.arm.runs_the_callback_in_the_harness_interpreter() {
         Python::attach(|python| -> Result<()> {
             let module = python
                 .import(arguments.stage_callback_module.as_str())
@@ -163,6 +184,7 @@ fn main() -> Result<()> {
         channel_count: arguments.channels,
         target_frames_per_second: arguments.fps,
         wire_payload_mode: arguments.wire_payload_mode,
+        startup_settle_seconds: arguments.startup_settle_seconds,
         cell_duration_seconds: arguments.duration_seconds,
         warmup_exclusion_seconds: arguments.warmup_exclusion_seconds,
         python_callback_registration_token,
@@ -181,7 +203,10 @@ fn main() -> Result<()> {
     // The recorder has to live in the interpreter that runs the callback. In the
     // runner's interpreter it would time collections that cannot have caused any
     // frame's latency — which is what it did before, reporting 0 events.
-    let garbage_collection_recorder = if arguments.arm == MeasurementArm::InProcessPython {
+    let garbage_collection_recorder = if arguments
+        .arm
+        .runs_the_callback_in_the_harness_interpreter()
+    {
         Some(install_embedded_interpreter_garbage_collection_recorder(
             &arguments.garbage_collection_mode,
         )?)
@@ -229,6 +254,15 @@ fn main() -> Result<()> {
         tracing::error!(
             count = outcome.histogram_range_saturation_count,
             "samples exceeded the histogram range — reported percentiles are clipped"
+        );
+    }
+    if outcome.backlog_drain_fraction > BACKLOG_DRAIN_FRACTION_INVALIDATING_A_CELL {
+        tracing::error!(
+            backlog_drain_fraction = outcome.backlog_drain_fraction,
+            startup_settle_seconds = specification.startup_settle_seconds,
+            "cell latency fell steadily from its first measured decile to its last — it was \
+             draining a startup backlog, so these percentiles describe queue occupancy and \
+             depend on how long the cell ran; raise --startup-settle-seconds and rerun"
         );
     }
     });

--- a/spikes/streamlib-pyembed-spike/src/latency_measurement_recorder.rs
+++ b/spikes/streamlib-pyembed-spike/src/latency_measurement_recorder.rs
@@ -318,11 +318,15 @@ impl LatencyMeasurementRecorder {
         if first_decile_median <= 0 {
             return 0.0;
         }
-        let absolute_drop_nanoseconds = first_decile_median - last_decile_median;
-        if absolute_drop_nanoseconds < self.frame_period_nanoseconds / 2 {
+        // The floor applies to the magnitude, and the returned fraction keeps
+        // its sign. Testing the signed drop against a positive floor made every
+        // growing cell return exactly 0.0, so the saturation direction was
+        // unreachable and both callers' `abs()` was dead.
+        let signed_drop_nanoseconds = first_decile_median - last_decile_median;
+        if signed_drop_nanoseconds.abs() < self.frame_period_nanoseconds / 2 {
             return 0.0;
         }
-        absolute_drop_nanoseconds as f64 / first_decile_median as f64
+        signed_drop_nanoseconds as f64 / first_decile_median as f64
     }
 
     /// Rolling 1-second achieved-frame-rate windows, for the fps-stability check.
@@ -570,6 +574,21 @@ mod tests {
     fn a_proportionally_identical_drop_of_whole_frame_periods_is_flagged() {
         let recorder = record_cell_with_latency_trend(110_000_000, 76_000_000, 1_000);
         assert!(recorder.backlog_drain_fraction() > 0.20);
+    }
+
+    /// A cell whose latency GREW is saturating, which invalidates it just as a
+    /// draining one does. Reported as a negative fraction so the direction
+    /// survives to the caller; testing the signed drop against a positive floor
+    /// previously collapsed every growing cell to exactly 0.0, leaving the
+    /// saturation direction unreachable and both callers' `abs()` dead.
+    #[test]
+    fn a_cell_whose_latency_grew_reports_a_negative_fraction() {
+        let recorder = record_cell_with_latency_trend(76_000_000, 110_000_000, 1_000);
+        assert!(
+            recorder.backlog_drain_fraction() <= -0.20,
+            "a saturating cell reported {}",
+            recorder.backlog_drain_fraction()
+        );
     }
 
     /// Too few frames for two disjoint deciles must yield no verdict rather

--- a/spikes/streamlib-pyembed-spike/src/latency_measurement_recorder.rs
+++ b/spikes/streamlib-pyembed-spike/src/latency_measurement_recorder.rs
@@ -37,6 +37,12 @@ const HISTOGRAM_SIGNIFICANT_FIGURES: u8 = 3;
 
 const ONE_SECOND_NANOSECONDS: i64 = 1_000_000_000;
 
+/// 60fps, the protocol's faster rate. File-scoped so every test module shares
+/// one period — the backlog check's absolute floor is derived from it, so two
+/// modules disagreeing would test two different thresholds.
+#[cfg(test)]
+const FRAME_PERIOD_NANOSECONDS: i64 = 16_666_666;
+
 /// Interval-log tag for the Tier A headline quantity.
 const SOURCE_EMIT_TO_SINK_RECEIVE_HISTOGRAM_TAG: &str = "source_emit_to_sink_receive";
 /// Interval-log tag for time spent inside the stage callback.
@@ -78,6 +84,7 @@ impl LatencyPercentileSummary {
 /// Accumulates one measurement cell's frames and writes its artifacts.
 pub struct LatencyMeasurementRecorder {
     warmup_exclusion_nanoseconds: i64,
+    frame_period_nanoseconds: i64,
     first_source_emit_monotonic_nanoseconds: Option<i64>,
     every_received_frame_measurement: Vec<PerFrameLatencyMeasurement>,
     source_emit_to_sink_receive_histogram: Histogram<u64>,
@@ -100,9 +107,19 @@ impl LatencyMeasurementRecorder {
     /// frame's successor by the memcpy, landing self-inflicted spikes in exactly
     /// the p99.9 tail this artifact publishes. An undersized hint degrades to the
     /// old behavior rather than failing, so callers should pass slack.
-    pub fn new(warmup_exclusion_nanoseconds: i64, expected_frame_count: usize) -> Self {
+    ///
+    /// `frame_period_nanoseconds` is what makes the backlog verdict meaningful:
+    /// a queue is measured in whole frames, so the drain check requires an
+    /// absolute drop of at least half a frame period as well as a proportional
+    /// one.
+    pub fn new(
+        warmup_exclusion_nanoseconds: i64,
+        frame_period_nanoseconds: i64,
+        expected_frame_count: usize,
+    ) -> Self {
         Self {
             warmup_exclusion_nanoseconds,
+            frame_period_nanoseconds,
             first_source_emit_monotonic_nanoseconds: None,
             every_received_frame_measurement: Vec::with_capacity(expected_frame_count),
             source_emit_to_sink_receive_histogram: new_nanosecond_histogram(),
@@ -131,12 +148,11 @@ impl LatencyMeasurementRecorder {
             .first_source_emit_monotonic_nanoseconds
             .get_or_insert(measurement.source_emit_monotonic_nanoseconds);
 
-        // Boundary rule: a frame whose emit stamp sits exactly on the warmup
-        // deadline is MEASURED. The exclusion is "the first N nanoseconds", a
-        // half-open interval, so the deadline itself is the first measured instant.
-        let elapsed_since_first_emit_nanoseconds =
-            measurement.source_emit_monotonic_nanoseconds - first_source_emit_monotonic_nanoseconds;
-        if elapsed_since_first_emit_nanoseconds < self.warmup_exclusion_nanoseconds {
+        if !measurement_is_post_warmup(
+            &measurement,
+            first_source_emit_monotonic_nanoseconds,
+            self.warmup_exclusion_nanoseconds,
+        ) {
             return;
         }
 
@@ -262,17 +278,30 @@ impl LatencyMeasurementRecorder {
     /// subprocess was still spawning. Excluding warmup by time does not remove
     /// it, because the backlog outlives the exclusion window.
     ///
-    /// Zero when there are too few measured frames for two disjoint deciles.
+    /// Zero when there are too few measured frames for two disjoint deciles, or
+    /// when the absolute drop is smaller than half a frame period.
+    ///
+    /// The absolute floor is load-bearing, not belt-and-braces. A backlog is
+    /// queued frames, so a real one sheds whole frame periods — the case this
+    /// exists for shed 100ms+ at a 16.7ms period. Without the floor, a healthy
+    /// in-process cell running at ~90µs total was reported as 27-31% "draining"
+    /// off a ~30µs difference between its first and last decile, which is cache
+    /// warming. A ratio alone rejects precisely the fastest, healthiest cells.
     pub fn backlog_drain_fraction(&self) -> f64 {
+        let Some(first_source_emit_monotonic_nanoseconds) =
+            self.first_source_emit_monotonic_nanoseconds
+        else {
+            return 0.0;
+        };
         let latencies: Vec<i64> = self
             .every_received_frame_measurement
             .iter()
             .filter(|measurement| {
-                let Some(first) = self.first_source_emit_monotonic_nanoseconds else {
-                    return false;
-                };
-                measurement.source_emit_monotonic_nanoseconds - first
-                    >= self.warmup_exclusion_nanoseconds
+                measurement_is_post_warmup(
+                    measurement,
+                    first_source_emit_monotonic_nanoseconds,
+                    self.warmup_exclusion_nanoseconds,
+                )
             })
             .map(|measurement| {
                 measurement.sink_receive_monotonic_nanoseconds
@@ -289,7 +318,11 @@ impl LatencyMeasurementRecorder {
         if first_decile_median <= 0 {
             return 0.0;
         }
-        (first_decile_median - last_decile_median) as f64 / first_decile_median as f64
+        let absolute_drop_nanoseconds = first_decile_median - last_decile_median;
+        if absolute_drop_nanoseconds < self.frame_period_nanoseconds / 2 {
+            return 0.0;
+        }
+        absolute_drop_nanoseconds as f64 / first_decile_median as f64
     }
 
     /// Rolling 1-second achieved-frame-rate windows, for the fps-stability check.
@@ -382,6 +415,22 @@ impl LatencyMeasurementRecorder {
     }
 }
 
+/// Whether a frame survives the warmup exclusion.
+///
+/// One definition, two callers. Boundary rule: a frame whose emit stamp sits
+/// exactly on the warmup deadline is MEASURED — the exclusion is "the first N
+/// nanoseconds", a half-open interval, so the deadline itself is the first
+/// measured instant. Two copies of that rule drifting would make the
+/// percentiles and the backlog verdict describe different sample sets.
+fn measurement_is_post_warmup(
+    measurement: &PerFrameLatencyMeasurement,
+    first_source_emit_monotonic_nanoseconds: i64,
+    warmup_exclusion_nanoseconds: i64,
+) -> bool {
+    measurement.source_emit_monotonic_nanoseconds - first_source_emit_monotonic_nanoseconds
+        >= warmup_exclusion_nanoseconds
+}
+
 /// Median of an already-chronological slice, taken by sorting a copy so the
 /// caller's ordering (which carries the time axis) survives.
 fn median_of(samples: &[i64]) -> i64 {
@@ -460,7 +509,8 @@ mod tests {
         last_latency_nanoseconds: i64,
         frame_count: u64,
     ) -> LatencyMeasurementRecorder {
-        let mut recorder = LatencyMeasurementRecorder::new(0, frame_count as usize);
+        let mut recorder =
+            LatencyMeasurementRecorder::new(0, FRAME_PERIOD_NANOSECONDS, frame_count as usize);
         for index in 0..frame_count {
             let progress = index as f64 / (frame_count - 1) as f64;
             let latency = first_latency_nanoseconds
@@ -500,6 +550,28 @@ mod tests {
         );
     }
 
+    /// The absolute floor is the difference between a working detector and one
+    /// that rejects the fastest cells in the matrix.
+    ///
+    /// A healthy in-process cell runs around 90µs end to end, so tens of µs of
+    /// cache warming between its first and last decile is a *large fraction* of
+    /// a very small number. Two real 720p60 cells were refused at 27% and 31%
+    /// off ~30µs of drift before this floor existed. A backlog is queued frames
+    /// and sheds whole frame periods; 30µs at a 16.7ms period is not one.
+    #[test]
+    fn a_fast_cell_drifting_by_microseconds_is_not_flagged_as_draining() {
+        let recorder = record_cell_with_latency_trend(110_000, 76_000, 1_000);
+        assert_eq!(recorder.backlog_drain_fraction(), 0.0);
+    }
+
+    /// ...while a drop of whole frame periods at the same proportion still
+    /// trips, so the floor narrows the detector rather than disabling it.
+    #[test]
+    fn a_proportionally_identical_drop_of_whole_frame_periods_is_flagged() {
+        let recorder = record_cell_with_latency_trend(110_000_000, 76_000_000, 1_000);
+        assert!(recorder.backlog_drain_fraction() > 0.20);
+    }
+
     /// Too few frames for two disjoint deciles must yield no verdict rather
     /// than a verdict computed from overlapping samples.
     #[test]
@@ -521,7 +593,7 @@ mod tests {
     /// non-comparable.
     #[test]
     fn frame_exactly_on_the_warmup_deadline_is_measured() {
-        let mut recorder = LatencyMeasurementRecorder::new(WARMUP_EXCLUSION_NANOSECONDS, 0);
+        let mut recorder = LatencyMeasurementRecorder::new(WARMUP_EXCLUSION_NANOSECONDS, FRAME_PERIOD_NANOSECONDS, 0);
         recorder.record_frame_measurement(build_per_frame_latency_measurement(0, 1_000, 5_000, 0));
         recorder.record_frame_measurement(build_per_frame_latency_measurement(
             1,
@@ -548,7 +620,7 @@ mod tests {
     /// disagree about which frames the cell measured.
     #[test]
     fn warmup_excluded_frames_reach_the_jsonl_but_not_the_histograms() {
-        let mut recorder = LatencyMeasurementRecorder::new(WARMUP_EXCLUSION_NANOSECONDS, 0);
+        let mut recorder = LatencyMeasurementRecorder::new(WARMUP_EXCLUSION_NANOSECONDS, FRAME_PERIOD_NANOSECONDS, 0);
         for frame_sequence_number in 0..10u64 {
             recorder.record_frame_measurement(build_per_frame_latency_measurement(
                 frame_sequence_number,
@@ -578,7 +650,7 @@ mod tests {
     /// must be counted exactly once.
     #[test]
     fn dropped_frame_count_counts_a_synthetic_sequence_gap() {
-        let mut recorder = LatencyMeasurementRecorder::new(0, 0);
+        let mut recorder = LatencyMeasurementRecorder::new(0, FRAME_PERIOD_NANOSECONDS, 0);
         for frame_sequence_number in [0u64, 1, 2, 5, 6] {
             recorder.record_frame_measurement(build_per_frame_latency_measurement(
                 frame_sequence_number,
@@ -595,7 +667,7 @@ mod tests {
     /// charged a gap against sequence number 0 or against nothing at all.
     #[test]
     fn first_observed_frame_reports_no_drop() {
-        let mut recorder = LatencyMeasurementRecorder::new(0, 0);
+        let mut recorder = LatencyMeasurementRecorder::new(0, FRAME_PERIOD_NANOSECONDS, 0);
         recorder.record_frame_measurement(build_per_frame_latency_measurement(7, 1_000, 5_000, 0));
         assert_eq!(recorder.dropped_frame_count(), 0);
         assert_eq!(recorder.received_frame_count(), 1);
@@ -605,7 +677,7 @@ mod tests {
     /// leave a permanent phantom drop in the report.
     #[test]
     fn out_of_order_arrival_reports_no_phantom_drop() {
-        let mut recorder = LatencyMeasurementRecorder::new(0, 0);
+        let mut recorder = LatencyMeasurementRecorder::new(0, FRAME_PERIOD_NANOSECONDS, 0);
         for frame_sequence_number in [0u64, 2, 1, 3] {
             recorder.record_frame_measurement(build_per_frame_latency_measurement(
                 frame_sequence_number,
@@ -622,7 +694,7 @@ mod tests {
     /// mode of the embedded arm and must be legible as such.
     #[test]
     fn no_frames_received_reports_a_zero_count_summary() {
-        let recorder = LatencyMeasurementRecorder::new(WARMUP_EXCLUSION_NANOSECONDS, 0);
+        let recorder = LatencyMeasurementRecorder::new(WARMUP_EXCLUSION_NANOSECONDS, FRAME_PERIOD_NANOSECONDS, 0);
         assert_eq!(recorder.received_frame_count(), 0);
         assert_eq!(recorder.dropped_frame_count(), 0);
         assert!(recorder.rolling_one_second_frame_rate_windows().is_empty());
@@ -641,7 +713,7 @@ mod tests {
     /// it must be counted and kept out of the histogram.
     #[test]
     fn negative_latency_increments_the_anomaly_counter_and_skips_the_histogram() {
-        let mut recorder = LatencyMeasurementRecorder::new(0, 0);
+        let mut recorder = LatencyMeasurementRecorder::new(0, FRAME_PERIOD_NANOSECONDS, 0);
         recorder.record_frame_measurement(build_per_frame_latency_measurement(
             0, 1_000_000, 2_000_000, 0,
         ));
@@ -661,7 +733,7 @@ mod tests {
     /// it means instrumentation is broken; it must surface, not be absorbed.
     #[test]
     fn negative_stage_callback_duration_increments_the_anomaly_counter() {
-        let mut recorder = LatencyMeasurementRecorder::new(0, 0);
+        let mut recorder = LatencyMeasurementRecorder::new(0, FRAME_PERIOD_NANOSECONDS, 0);
         recorder.record_frame_measurement(build_per_frame_latency_measurement(
             0, 1_000_000, 500_000, -1,
         ));
@@ -681,7 +753,7 @@ mod tests {
     fn percentiles_match_a_hand_computed_distribution() {
         const ONE_MILLISECOND_NANOSECONDS: i64 = 1_000_000;
         const ONE_HUNDRED_MILLISECONDS_NANOSECONDS: i64 = 100_000_000;
-        let mut recorder = LatencyMeasurementRecorder::new(0, 0);
+        let mut recorder = LatencyMeasurementRecorder::new(0, FRAME_PERIOD_NANOSECONDS, 0);
         for frame_sequence_number in 0..1_000u64 {
             let latency_nanoseconds = if frame_sequence_number < 990 {
                 ONE_MILLISECOND_NANOSECONDS
@@ -733,7 +805,7 @@ mod tests {
     #[test]
     fn rolling_windows_report_the_nominal_rate_of_a_perfectly_paced_stream() {
         const FIFTY_FPS_PERIOD_NANOSECONDS: i64 = ONE_SECOND_NANOSECONDS / 50;
-        let mut recorder = LatencyMeasurementRecorder::new(0, 0);
+        let mut recorder = LatencyMeasurementRecorder::new(0, FRAME_PERIOD_NANOSECONDS, 0);
         for frame_sequence_number in 0..300u64 {
             recorder.record_frame_measurement(build_per_frame_latency_measurement(
                 frame_sequence_number,
@@ -754,7 +826,7 @@ mod tests {
     /// compact object per line, no wrapping array, every field intact.
     #[test]
     fn jsonl_round_trips_line_by_line_through_serde_json() {
-        let mut recorder = LatencyMeasurementRecorder::new(0, 0);
+        let mut recorder = LatencyMeasurementRecorder::new(0, FRAME_PERIOD_NANOSECONDS, 0);
         let written_measurements: Vec<PerFrameLatencyMeasurement> = (0..5u64)
             .map(|frame_sequence_number| {
                 build_per_frame_latency_measurement(
@@ -807,8 +879,8 @@ mod tests {
     /// cross-cell percentiles would be uncomputable.
     #[test]
     fn histogram_export_decodes_and_merges_across_cells() {
-        let mut first_cell_recorder = LatencyMeasurementRecorder::new(0, 0);
-        let mut second_cell_recorder = LatencyMeasurementRecorder::new(0, 0);
+        let mut first_cell_recorder = LatencyMeasurementRecorder::new(0, FRAME_PERIOD_NANOSECONDS, 0);
+        let mut second_cell_recorder = LatencyMeasurementRecorder::new(0, FRAME_PERIOD_NANOSECONDS, 0);
         for frame_sequence_number in 0..100u64 {
             first_cell_recorder.record_frame_measurement(build_per_frame_latency_measurement(
                 frame_sequence_number,
@@ -910,7 +982,7 @@ mod histogram_range_tests {
     /// lowered to 1ns.
     #[test]
     fn an_all_zero_quantity_never_reports_a_percentile_above_its_maximum() {
-        let mut recorder = LatencyMeasurementRecorder::new(0, 8);
+        let mut recorder = LatencyMeasurementRecorder::new(0, crate::latency_measurement_recorder::FRAME_PERIOD_NANOSECONDS, 8);
         for frame_sequence_number in 0..300 {
             recorder.record_frame_measurement(PerFrameLatencyMeasurement {
                 frame_sequence_number,
@@ -934,8 +1006,9 @@ mod histogram_range_tests {
     /// the difference the spike exists to size.
     #[test]
     fn sub_microsecond_durations_are_not_quantized_into_one_bucket() {
-        let mut recorder = LatencyMeasurementRecorder::new(0, 8);
-        for (index, stage_callback_nanoseconds) in [100_i64, 200, 400, 800].into_iter().enumerate() {
+        let mut recorder = LatencyMeasurementRecorder::new(0, crate::latency_measurement_recorder::FRAME_PERIOD_NANOSECONDS, 8);
+        for (index, stage_callback_nanoseconds) in [100_i64, 200, 400, 800].into_iter().enumerate()
+        {
             recorder.record_frame_measurement(PerFrameLatencyMeasurement {
                 frame_sequence_number: index as u64,
                 source_emit_monotonic_nanoseconds: 1_000 * index as i64,

--- a/spikes/streamlib-pyembed-spike/src/latency_measurement_recorder.rs
+++ b/spikes/streamlib-pyembed-spike/src/latency_measurement_recorder.rs
@@ -40,7 +40,7 @@ const ONE_SECOND_NANOSECONDS: i64 = 1_000_000_000;
 /// 60fps, the protocol's faster rate. File-scoped so every test module shares
 /// one period — the backlog check's absolute floor is derived from it, so two
 /// modules disagreeing would test two different thresholds.
-#[cfg(test)]
+#[cfg(all(test, not(feature = "stamping-compiled-out")))]
 const FRAME_PERIOD_NANOSECONDS: i64 = 16_666_666;
 
 /// Interval-log tag for the Tier A headline quantity.

--- a/spikes/streamlib-pyembed-spike/src/latency_measurement_recorder.rs
+++ b/spikes/streamlib-pyembed-spike/src/latency_measurement_recorder.rs
@@ -237,6 +237,49 @@ impl LatencyMeasurementRecorder {
         self.histogram_range_saturation_count
     }
 
+    /// How much lower the last tenth of the cell's latencies run than the first
+    /// tenth, as a ratio of the first tenth's median.
+    ///
+    /// A cell in steady state hovers near zero. A materially positive value
+    /// means the graph entered the measured window with a queue and spent the
+    /// cell draining it, so the percentiles describe queue occupancy decaying
+    /// over time rather than per-frame latency — and, critically, they depend
+    /// on how long the cell ran. Measured on this branch before the source
+    /// gained its startup settle: the subprocess arm at 720p60 reported p50
+    /// 183ms over 20s and 84ms over 40s, purely from frames emitted while the
+    /// subprocess was still spawning. Excluding warmup by time does not remove
+    /// it, because the backlog outlives the exclusion window.
+    ///
+    /// Zero when there are too few measured frames for two disjoint deciles.
+    pub fn backlog_drain_fraction(&self) -> f64 {
+        let latencies: Vec<i64> = self
+            .every_received_frame_measurement
+            .iter()
+            .filter(|measurement| {
+                let Some(first) = self.first_source_emit_monotonic_nanoseconds else {
+                    return false;
+                };
+                measurement.source_emit_monotonic_nanoseconds - first
+                    >= self.warmup_exclusion_nanoseconds
+            })
+            .map(|measurement| {
+                measurement.sink_receive_monotonic_nanoseconds
+                    - measurement.source_emit_monotonic_nanoseconds
+            })
+            .collect();
+
+        let decile_length = latencies.len() / 10;
+        if decile_length == 0 {
+            return 0.0;
+        }
+        let first_decile_median = median_of(&latencies[..decile_length]);
+        let last_decile_median = median_of(&latencies[latencies.len() - decile_length..]);
+        if first_decile_median <= 0 {
+            return 0.0;
+        }
+        (first_decile_median - last_decile_median) as f64 / first_decile_median as f64
+    }
+
     /// Rolling 1-second achieved-frame-rate windows, for the fps-stability check.
     ///
     /// One entry per measured frame whose full 1-second lookback fits inside the
@@ -327,6 +370,17 @@ impl LatencyMeasurementRecorder {
     }
 }
 
+/// Median of an already-chronological slice, taken by sorting a copy so the
+/// caller's ordering (which carries the time axis) survives.
+fn median_of(samples: &[i64]) -> i64 {
+    if samples.is_empty() {
+        return 0;
+    }
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+    sorted[sorted.len() / 2]
+}
+
 fn new_nanosecond_histogram() -> Histogram<u64> {
     Histogram::<u64>::new_with_bounds(
         HISTOGRAM_LOWEST_DISCERNIBLE_NANOSECONDS,
@@ -385,6 +439,61 @@ mod tests {
                 + source_emit_to_sink_receive_nanoseconds,
             stage_callback_nanoseconds,
         }
+    }
+
+    /// Record `frame_count` post-warmup frames whose latency runs linearly from
+    /// `first_latency_nanoseconds` to `last_latency_nanoseconds`.
+    fn record_cell_with_latency_trend(
+        first_latency_nanoseconds: i64,
+        last_latency_nanoseconds: i64,
+        frame_count: u64,
+    ) -> LatencyMeasurementRecorder {
+        let mut recorder = LatencyMeasurementRecorder::new(0, frame_count as usize);
+        for index in 0..frame_count {
+            let progress = index as f64 / (frame_count - 1) as f64;
+            let latency = first_latency_nanoseconds
+                + ((last_latency_nanoseconds - first_latency_nanoseconds) as f64 * progress) as i64;
+            recorder.record_frame_measurement(build_per_frame_latency_measurement(
+                index,
+                index as i64 * 16_666_666,
+                latency,
+                1_000,
+            ));
+        }
+        recorder
+    }
+
+    /// The detector's whole job: a cell that entered the measured window with a
+    /// queue reports percentiles that describe the queue draining, and they
+    /// change with cell duration. This is what made a 720p60 subprocess cell
+    /// report p50 183ms over 20s and 84ms over 40s.
+    #[test]
+    fn a_cell_draining_a_startup_backlog_is_detected() {
+        let recorder = record_cell_with_latency_trend(180_000_000, 20_000_000, 1_000);
+        assert!(
+            recorder.backlog_drain_fraction() > 0.20,
+            "a cell whose latency fell 9x across its life was not flagged: {}",
+            recorder.backlog_drain_fraction()
+        );
+    }
+
+    /// A steady cell must not be flagged, or every valid cell would be refused.
+    #[test]
+    fn a_steady_state_cell_is_not_flagged_as_draining() {
+        let recorder = record_cell_with_latency_trend(90_000, 91_000, 1_000);
+        assert!(
+            recorder.backlog_drain_fraction().abs() < 0.20,
+            "a steady cell was flagged as draining: {}",
+            recorder.backlog_drain_fraction()
+        );
+    }
+
+    /// Too few frames for two disjoint deciles must yield no verdict rather
+    /// than a verdict computed from overlapping samples.
+    #[test]
+    fn a_cell_too_short_to_form_two_deciles_yields_no_drain_verdict() {
+        let recorder = record_cell_with_latency_trend(180_000_000, 20_000_000, 9);
+        assert_eq!(recorder.backlog_drain_fraction(), 0.0);
     }
 
     fn temporary_artifact_path(file_name: &str) -> std::path::PathBuf {

--- a/spikes/streamlib-pyembed-spike/src/latency_measurement_recorder.rs
+++ b/spikes/streamlib-pyembed-spike/src/latency_measurement_recorder.rs
@@ -225,6 +225,18 @@ impl LatencyMeasurementRecorder {
         self.measured_frame_count
     }
 
+    /// When the sink saw its very first frame, warmup exclusion ignored.
+    ///
+    /// The endpoint of gate 6's restart measurement: paired with a stamp the
+    /// battery takes before spawning the process, it is exec-to-first-frame on
+    /// one monotonic clock. Warmup exclusion is deliberately not applied — the
+    /// question is when output first appeared, not when measurement began.
+    pub fn first_frame_sink_receive_monotonic_nanoseconds(&self) -> Option<i64> {
+        self.every_received_frame_measurement
+            .first()
+            .map(|measurement| measurement.sink_receive_monotonic_nanoseconds)
+    }
+
     /// Samples whose computed duration was negative — a nonzero value here
     /// invalidates the cell's latency numbers rather than degrading them.
     pub fn negative_latency_anomaly_count(&self) -> u64 {

--- a/spikes/streamlib-pyembed-spike/src/lib.rs
+++ b/spikes/streamlib-pyembed-spike/src/lib.rs
@@ -29,5 +29,6 @@ pub mod python_processor_callback_registry;
 pub mod rust_passthrough_floor_stage_processor;
 pub mod synthetic_frame_measurement_preamble;
 pub mod synthetic_frame_source_processor;
+pub mod synthetic_frame_wire_payload_mode;
 pub mod tier_a_measurement_cell;
 pub mod zero_copy_numpy_frame_view;

--- a/spikes/streamlib-pyembed-spike/src/machine_specification_probe.rs
+++ b/spikes/streamlib-pyembed-spike/src/machine_specification_probe.rs
@@ -102,8 +102,11 @@ pub struct MachineSpecification {
     /// RAM and swap.
     pub memory: MemorySpecification,
     /// The interpreter and numpy the Python arms run against.
-    /// The `python3` on PATH — the interpreter the SUBPROCESS baseline arm
-    /// launches. Not necessarily the one the in-process arm runs.
+    /// The interpreter the SUBPROCESS baseline arm actually launches: the
+    /// provisioned package venv named by `STREAMLIB_BASELINE_VENV_PYTHON`.
+    /// Unavailable, never guessed, when that is unset — probing `python3` on
+    /// PATH instead reported this rig's 3.12.3 while the arm was really running
+    /// the venv's 3.14.4, which is a confound the artifact then denied.
     pub subprocess_python_runtime: PythonRuntimeSpecification,
     /// The interpreter CPython is embedded from in THIS process, which is what
     /// produced the in-process arm's numbers. PyO3 links it at build time, so it
@@ -1380,6 +1383,10 @@ const PYTHON_RUNTIME_PROBE_SOURCE: &str = "import json, sys\n\
      \x20   report['numpy_import_failure'] = repr(import_failure)\n\
      print(json.dumps(report))\n";
 
+/// Names the provisioned baseline venv's interpreter. Set by
+/// `python/runner.py` from the provisioning record.
+pub const BASELINE_VENV_PYTHON_ENVIRONMENT_VARIABLE: &str = "STREAMLIB_BASELINE_VENV_PYTHON";
+
 fn probe_python_runtime() -> PythonRuntimeSpecification {
     let unavailable_python = |reason: String| PythonRuntimeSpecification {
         interpreter_executable_path: ProbedValueOrUnavailableReason::unavailable(reason.clone()),
@@ -1389,8 +1396,16 @@ fn probe_python_runtime() -> PythonRuntimeSpecification {
         global_interpreter_lock_is_disabled: ProbedValueOrUnavailableReason::unavailable(reason),
     };
 
+    let Ok(baseline_venv_python) = std::env::var(BASELINE_VENV_PYTHON_ENVIRONMENT_VARIABLE)
+    else {
+        return unavailable_python(format!(
+            "${BASELINE_VENV_PYTHON_ENVIRONMENT_VARIABLE} is unset, so the interpreter \
+             the subprocess arm launches is unknown; run \
+             python/provision_subprocess_baseline_package.py"
+        ));
+    };
     let report_json = match run_command_capturing_trimmed_standard_output(
-        "python3",
+        &baseline_venv_python,
         &["-c", PYTHON_RUNTIME_PROBE_SOURCE],
     ) {
         Ok(report_json) => report_json,
@@ -1400,7 +1415,7 @@ fn probe_python_runtime() -> PythonRuntimeSpecification {
         Ok(report) => report,
         Err(error) => {
             return unavailable_python(format!(
-                "the python3 probe printed `{report_json}`, which is not JSON: {error}"
+                "the baseline venv probe printed `{report_json}`, which is not JSON: {error}"
             ));
         }
     };
@@ -1408,7 +1423,7 @@ fn probe_python_runtime() -> PythonRuntimeSpecification {
     let text_member = |key: &str| match report.get(key).and_then(serde_json::Value::as_str) {
         Some(value) => ProbedValueOrUnavailableReason::observed(value.to_string()),
         None => ProbedValueOrUnavailableReason::unavailable(format!(
-            "the python3 probe report carried no `{key}`"
+            "the baseline venv probe report carried no `{key}`"
         )),
     };
 

--- a/spikes/streamlib-pyembed-spike/src/measuring_sink_processor.rs
+++ b/spikes/streamlib-pyembed-spike/src/measuring_sink_processor.rs
@@ -127,7 +127,7 @@ mod tests {
     /// means a cell that ran for ten minutes and reported nothing.
     #[test]
     fn the_collection_point_round_trips_a_recorder() {
-        install_measurement_collection_point(LatencyMeasurementRecorder::new(0, 0));
+        install_measurement_collection_point(LatencyMeasurementRecorder::new(0, 0, 0));
         let recovered = take_measurement_collection_point();
         assert!(recovered.is_some());
         assert!(
@@ -140,7 +140,7 @@ mod tests {
     /// first — two cells in one process have to stay separate.
     #[test]
     fn installing_replaces_rather_than_merges() {
-        let mut first = LatencyMeasurementRecorder::new(0, 0);
+        let mut first = LatencyMeasurementRecorder::new(0, 0, 0);
         first.record_frame_measurement(PerFrameLatencyMeasurement {
             frame_sequence_number: 0,
             source_emit_monotonic_nanoseconds: 0,
@@ -148,7 +148,7 @@ mod tests {
             stage_callback_nanoseconds: 0,
         });
         install_measurement_collection_point(first);
-        install_measurement_collection_point(LatencyMeasurementRecorder::new(0, 0));
+        install_measurement_collection_point(LatencyMeasurementRecorder::new(0, 0, 0));
         let recovered = take_measurement_collection_point().expect("second recorder is installed");
         assert_eq!(
             recovered.received_frame_count(),

--- a/spikes/streamlib-pyembed-spike/src/python_callback_stage_processor.rs
+++ b/spikes/streamlib-pyembed-spike/src/python_callback_stage_processor.rs
@@ -18,7 +18,10 @@ use crate::python_processor_callback_registry::resolve_python_callback_for_token
 use crate::synthetic_frame_measurement_preamble::{
     SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES, SyntheticFrameMeasurementPreamble,
 };
-use crate::synthetic_frame_wire_payload_mode::SyntheticFrameWirePayloadMode;
+use crate::synthetic_frame_wire_payload_mode::{
+    SURFACE_REFERENCE_BODY_BYTES, SyntheticFrameWirePayloadMode, encode_synthetic_pixel_bytes,
+    frame_pixel_byte_count,
+};
 use crate::zero_copy_numpy_frame_view::{
     NumpyFrameViewEscapeOutcome, invoke_python_callback_over_zero_copy_frame_view,
     preload_numpy_c_array_api_before_first_frame_view,
@@ -71,9 +74,11 @@ impl PythonCallbackStageConfiguration {
     /// Pixel bytes for one frame of this geometry — the extent the callback's
     /// numpy view spans, wherever those pixels live.
     pub fn frame_pixel_byte_count(&self) -> usize {
-        self.frame_width_pixels as usize
-            * self.frame_height_pixels as usize
-            * self.channel_count as usize
+        frame_pixel_byte_count(
+            self.frame_width_pixels,
+            self.frame_height_pixels,
+            self.channel_count,
+        )
     }
 }
 
@@ -117,7 +122,10 @@ impl PythonCallbackStageProcessor::Processor {
 
 impl ReactiveProcessor for PythonCallbackStageProcessor::Processor {
     fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        let token = self.configuration.python_callback_registration_token.clone();
+        let token = self
+            .configuration
+            .python_callback_registration_token
+            .clone();
         let callable = Python::attach(|python| -> Result<Option<Py<PyAny>>> {
             // numpy's C API table is imported lazily on first use. Forcing it
             // here keeps that one-time cost out of the first measured frame,
@@ -134,13 +142,9 @@ impl ReactiveProcessor for PythonCallbackStageProcessor::Processor {
             ))
         })?);
 
-        if self.configuration.wire_payload_mode
-            == SyntheticFrameWirePayloadMode::SurfaceReference
-        {
-            let pixel_byte_count = self.configuration.frame_pixel_byte_count();
-            self.locally_resolved_surface_pixel_buffer = (0..pixel_byte_count)
-                .map(|index| (index % 251) as u8)
-                .collect();
+        if self.configuration.wire_payload_mode == SyntheticFrameWirePayloadMode::SurfaceReference {
+            self.locally_resolved_surface_pixel_buffer =
+                encode_synthetic_pixel_bytes(self.configuration.frame_pixel_byte_count());
         }
         Ok(())
     }
@@ -167,6 +171,27 @@ impl ReactiveProcessor for PythonCallbackStageProcessor::Processor {
         // Under SurfaceReference the wire carried a reference, so the callback's
         // view spans this stage's locally resolved surface; under
         // FullPixelPayload the pixels arrived in-band and the view spans them.
+        // Checked against the *wire body's* width, not the local buffer's: under
+        // SurfaceReference the local buffer is geometry-sized by construction, so
+        // comparing it to the geometry would pass a full-pixel source paired with
+        // a surface-reference stage without a word.
+        let wire_body_byte_count = frame_payload.len() - SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES;
+        let expected_wire_body_byte_count = match self.configuration.wire_payload_mode {
+            SyntheticFrameWirePayloadMode::SurfaceReference => SURFACE_REFERENCE_BODY_BYTES,
+            SyntheticFrameWirePayloadMode::FullPixelPayload => {
+                self.configuration.frame_pixel_byte_count()
+            }
+        };
+        if wire_body_byte_count != expected_wire_body_byte_count {
+            return Err(Error::Link(format!(
+                "stage is configured for {} and expects a {}-byte wire body, but {} bytes \
+                 arrived — the source and stage disagree about the wire payload mode",
+                self.configuration.wire_payload_mode.as_artifact_token(),
+                expected_wire_body_byte_count,
+                wire_body_byte_count
+            )));
+        }
+
         let callback_pixel_bytes: &mut [u8] = match self.configuration.wire_payload_mode {
             SyntheticFrameWirePayloadMode::SurfaceReference => {
                 &mut self.locally_resolved_surface_pixel_buffer
@@ -175,14 +200,6 @@ impl ReactiveProcessor for PythonCallbackStageProcessor::Processor {
                 &mut frame_payload[SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES..]
             }
         };
-        if callback_pixel_bytes.len() != self.configuration.frame_pixel_byte_count() {
-            return Err(Error::Link(format!(
-                "stage has {} pixel bytes to view but its geometry declares {} — the source and \
-                 stage disagree about the wire payload mode",
-                callback_pixel_bytes.len(),
-                self.configuration.frame_pixel_byte_count()
-            )));
-        }
 
         let callback_started_nanoseconds = read_measurement_stamp_nanoseconds();
         let escape_outcome = Python::attach(|python| {
@@ -200,7 +217,8 @@ impl ReactiveProcessor for PythonCallbackStageProcessor::Processor {
         })?;
         let callback_finished_nanoseconds = read_measurement_stamp_nanoseconds();
 
-        if let NumpyFrameViewEscapeOutcome::RetainedByPythonWithRefcount(refcount) = escape_outcome {
+        if let NumpyFrameViewEscapeOutcome::RetainedByPythonWithRefcount(refcount) = escape_outcome
+        {
             self.observed_frame_view_escape_count += 1;
             // Not fatal to the run, but it invalidates the zero-copy premise for
             // this frame and the retained view now aliases a buffer about to be
@@ -243,7 +261,10 @@ mod tests {
         let decoded: PythonCallbackStageConfiguration =
             serde_json::from_value(encoded).expect("deserializes");
         assert_eq!(decoded, configuration);
-        assert_eq!(decoded.python_callback_registration_token, "cell-42-passthrough");
+        assert_eq!(
+            decoded.python_callback_registration_token,
+            "cell-42-passthrough"
+        );
         assert!(!decoded.anchor_processor_thread_gil);
     }
 

--- a/spikes/streamlib-pyembed-spike/src/python_callback_stage_processor.rs
+++ b/spikes/streamlib-pyembed-spike/src/python_callback_stage_processor.rs
@@ -18,6 +18,7 @@ use crate::python_processor_callback_registry::resolve_python_callback_for_token
 use crate::synthetic_frame_measurement_preamble::{
     SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES, SyntheticFrameMeasurementPreamble,
 };
+use crate::synthetic_frame_wire_payload_mode::SyntheticFrameWirePayloadMode;
 use crate::zero_copy_numpy_frame_view::{
     NumpyFrameViewEscapeOutcome, invoke_python_callback_over_zero_copy_frame_view,
     preload_numpy_c_array_api_before_first_frame_view,
@@ -46,6 +47,11 @@ pub struct PythonCallbackStageConfiguration {
     /// Anchoring the thread state removes a per-frame mmap/munmap pair. Off is
     /// the control condition that measures what anchoring is worth.
     pub anchor_processor_thread_gil: bool,
+    /// Must match the source's mode: it decides whether the callback's numpy
+    /// view is over the wire payload or over this stage's locally resolved
+    /// surface.
+    #[serde(default)]
+    pub wire_payload_mode: SyntheticFrameWirePayloadMode,
 }
 
 impl Default for PythonCallbackStageConfiguration {
@@ -56,7 +62,18 @@ impl Default for PythonCallbackStageConfiguration {
             channel_count: 4,
             python_callback_registration_token: String::new(),
             anchor_processor_thread_gil: true,
+            wire_payload_mode: SyntheticFrameWirePayloadMode::SurfaceReference,
         }
+    }
+}
+
+impl PythonCallbackStageConfiguration {
+    /// Pixel bytes for one frame of this geometry — the extent the callback's
+    /// numpy view spans, wherever those pixels live.
+    pub fn frame_pixel_byte_count(&self) -> usize {
+        self.frame_width_pixels as usize
+            * self.frame_height_pixels as usize
+            * self.channel_count as usize
     }
 }
 
@@ -71,6 +88,14 @@ impl Default for PythonCallbackStageConfiguration {
 pub struct PythonCallbackStageProcessor {
     resolved_python_callback: Option<Py<PyAny>>,
     observed_frame_view_escape_count: u64,
+    /// The pixels the callback sees under
+    /// [`SyntheticFrameWirePayloadMode::SurfaceReference`], standing in for what
+    /// `GpuContext::resolve_pixel_buffer_by_surface_id`
+    /// (`core/context/gpu_context.rs:681`) hands an in-process processor. It is
+    /// process-local by construction — a surface reference on the wire means
+    /// the pixels never made the hop, which is the whole point of the mode.
+    /// Empty under [`SyntheticFrameWirePayloadMode::FullPixelPayload`].
+    locally_resolved_surface_pixel_buffer: Vec<u8>,
 }
 
 impl PythonCallbackStageProcessor::Processor {
@@ -108,6 +133,15 @@ impl ReactiveProcessor for PythonCallbackStageProcessor::Processor {
                  starting the graph"
             ))
         })?);
+
+        if self.configuration.wire_payload_mode
+            == SyntheticFrameWirePayloadMode::SurfaceReference
+        {
+            let pixel_byte_count = self.configuration.frame_pixel_byte_count();
+            self.locally_resolved_surface_pixel_buffer = (0..pixel_byte_count)
+                .map(|index| (index % 251) as u8)
+                .collect();
+        }
         Ok(())
     }
 
@@ -119,7 +153,7 @@ impl ReactiveProcessor for PythonCallbackStageProcessor::Processor {
         };
         if frame_payload.len() <= SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES {
             return Err(Error::Link(format!(
-                "frame payload of {} bytes carries no pixels after the measurement preamble",
+                "frame payload of {} bytes carries nothing after the measurement preamble",
                 frame_payload.len()
             )));
         }
@@ -130,12 +164,32 @@ impl ReactiveProcessor for PythonCallbackStageProcessor::Processor {
             .as_ref()
             .ok_or_else(|| Error::Configuration("setup did not resolve a callable".to_string()))?;
 
+        // Under SurfaceReference the wire carried a reference, so the callback's
+        // view spans this stage's locally resolved surface; under
+        // FullPixelPayload the pixels arrived in-band and the view spans them.
+        let callback_pixel_bytes: &mut [u8] = match self.configuration.wire_payload_mode {
+            SyntheticFrameWirePayloadMode::SurfaceReference => {
+                &mut self.locally_resolved_surface_pixel_buffer
+            }
+            SyntheticFrameWirePayloadMode::FullPixelPayload => {
+                &mut frame_payload[SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES..]
+            }
+        };
+        if callback_pixel_bytes.len() != self.configuration.frame_pixel_byte_count() {
+            return Err(Error::Link(format!(
+                "stage has {} pixel bytes to view but its geometry declares {} — the source and \
+                 stage disagree about the wire payload mode",
+                callback_pixel_bytes.len(),
+                self.configuration.frame_pixel_byte_count()
+            )));
+        }
+
         let callback_started_nanoseconds = read_measurement_stamp_nanoseconds();
         let escape_outcome = Python::attach(|python| {
             invoke_python_callback_over_zero_copy_frame_view(
                 python,
                 callable,
-                &mut frame_payload[SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES..],
+                callback_pixel_bytes,
                 self.configuration.frame_height_pixels as usize,
                 self.configuration.frame_width_pixels as usize,
                 self.configuration.channel_count as usize,

--- a/spikes/streamlib-pyembed-spike/src/rust_passthrough_floor_stage_processor.rs
+++ b/spikes/streamlib-pyembed-spike/src/rust_passthrough_floor_stage_processor.rs
@@ -21,18 +21,18 @@ use streamlib::sdk::processors::ReactiveProcessor;
 use crate::synthetic_frame_measurement_preamble::{
     SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES, SyntheticFrameMeasurementPreamble,
 };
-use crate::synthetic_frame_wire_payload_mode::SyntheticFrameWirePayloadMode;
-
-/// Frame geometry and wire mode for [`RustPassthroughFloorStageProcessor`].
-/// Deliberately mirrors the Python stage's fields so the two arms are
-/// configured identically.
+/// Frame geometry for [`RustPassthroughFloorStageProcessor`]. Deliberately
+/// mirrors the Python stage's geometry fields so the two arms are configured
+/// identically.
+///
+/// No wire-mode field: this stage copies its payload through without looking at
+/// it, so the wire width it sees is entirely the source's choice and a mode knob
+/// here would be inert.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RustPassthroughFloorStageConfiguration {
     pub frame_width_pixels: u32,
     pub frame_height_pixels: u32,
     pub channel_count: u32,
-    #[serde(default)]
-    pub wire_payload_mode: SyntheticFrameWirePayloadMode,
 }
 
 impl Default for RustPassthroughFloorStageConfiguration {
@@ -41,7 +41,6 @@ impl Default for RustPassthroughFloorStageConfiguration {
             frame_width_pixels: 1920,
             frame_height_pixels: 1080,
             channel_count: 4,
-            wire_payload_mode: SyntheticFrameWirePayloadMode::SurfaceReference,
         }
     }
 }
@@ -93,25 +92,11 @@ mod tests {
     #[test]
     fn floor_geometry_defaults_match_the_python_stage_geometry() {
         let floor = RustPassthroughFloorStageConfiguration::default();
-        let python = crate::python_callback_stage_processor::PythonCallbackStageConfiguration::default();
+        let python =
+            crate::python_callback_stage_processor::PythonCallbackStageConfiguration::default();
         assert_eq!(floor.frame_width_pixels, python.frame_width_pixels);
         assert_eq!(floor.frame_height_pixels, python.frame_height_pixels);
         assert_eq!(floor.channel_count, python.channel_count);
-        assert_eq!(floor.wire_payload_mode, python.wire_payload_mode);
-    }
-
-    /// The floor arm's whole value is attributing latency to the wire hop, so
-    /// it must carry the same wire payload mode the Python arm does. A floor
-    /// measured on surface references against a Python arm measured on whole
-    /// pictures would report the PyO3 delta as the difference between two
-    /// payload sizes.
-    #[test]
-    fn the_floor_arm_defaults_to_the_same_wire_payload_mode_as_the_source() {
-        assert_eq!(
-            RustPassthroughFloorStageConfiguration::default().wire_payload_mode,
-            crate::synthetic_frame_source_processor::SyntheticFrameSourceConfiguration::default()
-                .wire_payload_mode
-        );
     }
 
     /// The config must survive the serde round-trip the engine performs when it
@@ -122,7 +107,6 @@ mod tests {
             frame_width_pixels: 1280,
             frame_height_pixels: 720,
             channel_count: 4,
-            wire_payload_mode: SyntheticFrameWirePayloadMode::FullPixelPayload,
         };
         let encoded = serde_json::to_value(&configuration).expect("serializes");
         let decoded: RustPassthroughFloorStageConfiguration =

--- a/spikes/streamlib-pyembed-spike/src/rust_passthrough_floor_stage_processor.rs
+++ b/spikes/streamlib-pyembed-spike/src/rust_passthrough_floor_stage_processor.rs
@@ -21,15 +21,18 @@ use streamlib::sdk::processors::ReactiveProcessor;
 use crate::synthetic_frame_measurement_preamble::{
     SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES, SyntheticFrameMeasurementPreamble,
 };
+use crate::synthetic_frame_wire_payload_mode::SyntheticFrameWirePayloadMode;
 
-/// Frame geometry for [`RustPassthroughFloorStageProcessor`]. Deliberately
-/// mirrors the Python stage's geometry fields so the two arms are configured
-/// identically.
+/// Frame geometry and wire mode for [`RustPassthroughFloorStageProcessor`].
+/// Deliberately mirrors the Python stage's fields so the two arms are
+/// configured identically.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RustPassthroughFloorStageConfiguration {
     pub frame_width_pixels: u32,
     pub frame_height_pixels: u32,
     pub channel_count: u32,
+    #[serde(default)]
+    pub wire_payload_mode: SyntheticFrameWirePayloadMode,
 }
 
 impl Default for RustPassthroughFloorStageConfiguration {
@@ -38,6 +41,7 @@ impl Default for RustPassthroughFloorStageConfiguration {
             frame_width_pixels: 1920,
             frame_height_pixels: 1080,
             channel_count: 4,
+            wire_payload_mode: SyntheticFrameWirePayloadMode::SurfaceReference,
         }
     }
 }
@@ -61,7 +65,7 @@ impl ReactiveProcessor for RustPassthroughFloorStageProcessor::Processor {
         };
         if frame_payload.len() <= SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES {
             return Err(Error::Link(format!(
-                "frame payload of {} bytes carries no pixels after the measurement preamble",
+                "frame payload of {} bytes carries nothing after the measurement preamble",
                 frame_payload.len()
             )));
         }
@@ -93,6 +97,21 @@ mod tests {
         assert_eq!(floor.frame_width_pixels, python.frame_width_pixels);
         assert_eq!(floor.frame_height_pixels, python.frame_height_pixels);
         assert_eq!(floor.channel_count, python.channel_count);
+        assert_eq!(floor.wire_payload_mode, python.wire_payload_mode);
+    }
+
+    /// The floor arm's whole value is attributing latency to the wire hop, so
+    /// it must carry the same wire payload mode the Python arm does. A floor
+    /// measured on surface references against a Python arm measured on whole
+    /// pictures would report the PyO3 delta as the difference between two
+    /// payload sizes.
+    #[test]
+    fn the_floor_arm_defaults_to_the_same_wire_payload_mode_as_the_source() {
+        assert_eq!(
+            RustPassthroughFloorStageConfiguration::default().wire_payload_mode,
+            crate::synthetic_frame_source_processor::SyntheticFrameSourceConfiguration::default()
+                .wire_payload_mode
+        );
     }
 
     /// The config must survive the serde round-trip the engine performs when it
@@ -103,6 +122,7 @@ mod tests {
             frame_width_pixels: 1280,
             frame_height_pixels: 720,
             channel_count: 4,
+            wire_payload_mode: SyntheticFrameWirePayloadMode::FullPixelPayload,
         };
         let encoded = serde_json::to_value(&configuration).expect("serializes");
         let decoded: RustPassthroughFloorStageConfiguration =

--- a/spikes/streamlib-pyembed-spike/src/synthetic_frame_source_processor.rs
+++ b/spikes/streamlib-pyembed-spike/src/synthetic_frame_source_processor.rs
@@ -32,6 +32,25 @@ pub struct SyntheticFrameSourceConfiguration {
     /// pixels for it actually cross the link (owner decision 7 on #1702).
     #[serde(default)]
     pub wire_payload_mode: SyntheticFrameWirePayloadMode,
+    /// Quiet period between `setup()` and the first emitted frame.
+    ///
+    /// Load-bearing for the subprocess baseline arm and harmless for the other
+    /// two. `Runner::start()` returns once the graph is compiled, but a Python
+    /// subprocess needs a few hundred milliseconds more to spawn, import, and
+    /// reach its poll loop. Frames emitted into that window queue up, and under
+    /// `every_sample` the backlog is never dropped — it drains only as fast as
+    /// the consumer runs ahead of the source. Measured on this branch at
+    /// 720p60: p50 183ms over a 20s cell, 84ms over a 40s cell, against 0.09ms
+    /// for the in-process arm. Those are startup transients, not latencies, and
+    /// excluding warmup *by time* does not remove them because the backlog
+    /// outlives the exclusion window.
+    #[serde(default = "default_startup_settle_seconds")]
+    pub startup_settle_seconds: f64,
+}
+
+/// Comfortably past the ~0.66s the subprocess arm takes to reach its poll loop.
+fn default_startup_settle_seconds() -> f64 {
+    2.0
 }
 
 impl Default for SyntheticFrameSourceConfiguration {
@@ -42,6 +61,7 @@ impl Default for SyntheticFrameSourceConfiguration {
             channel_count: 4,
             target_frames_per_second: 30,
             wire_payload_mode: SyntheticFrameWirePayloadMode::SurfaceReference,
+            startup_settle_seconds: default_startup_settle_seconds(),
         }
     }
 }
@@ -110,9 +130,11 @@ impl ContinuousProcessor for SyntheticFrameSourceProcessor::Processor {
             .resize(SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES, 0u8);
         self.frame_payload_buffer.extend_from_slice(&wire_body);
         self.next_frame_sequence_number = 0;
-        self.emission_origin_monotonic_nanoseconds = read_monotonic_clock_nanoseconds();
+        self.emission_origin_monotonic_nanoseconds = read_monotonic_clock_nanoseconds()
+            + (self.configuration.startup_settle_seconds * 1_000_000_000.0) as i64;
         tracing::info!(
             frame_bytes = self.frame_payload_buffer.len(),
+            startup_settle_seconds = self.configuration.startup_settle_seconds,
             wire_payload_mode = self.configuration.wire_payload_mode.as_artifact_token(),
             target_fps = self.configuration.target_frames_per_second,
             "synthetic frame source ready"
@@ -291,11 +313,40 @@ mod tests {
             channel_count: 4,
             target_frames_per_second: 60,
             wire_payload_mode: SyntheticFrameWirePayloadMode::FullPixelPayload,
+            startup_settle_seconds: 2.5,
         };
         let encoded = serde_json::to_value(&configuration).expect("serializes");
         let decoded: SyntheticFrameSourceConfiguration =
             serde_json::from_value(encoded).expect("deserializes");
         assert_eq!(decoded, configuration);
+    }
+
+    /// The settle exists because the subprocess arm needs ~0.66s to reach its
+    /// poll loop; frames emitted before then become a backlog that the warmup
+    /// exclusion cannot remove. A default of zero would silently restore the
+    /// 183ms-vs-0.09ms comparison that measured startup transients.
+    #[test]
+    fn the_source_settles_before_its_first_frame_by_default() {
+        assert!(SyntheticFrameSourceConfiguration::default().startup_settle_seconds >= 1.0);
+    }
+
+    /// An older `cell-spec.json` predating the settle must not silently replay
+    /// with no settle at all — the field defaults to the protocol value.
+    #[test]
+    fn a_configuration_without_a_startup_settle_decodes_to_the_protocol_default() {
+        let decoded: SyntheticFrameSourceConfiguration = serde_json::from_value(
+            serde_json::json!({
+                "frame_width_pixels": 1280,
+                "frame_height_pixels": 720,
+                "channel_count": 4,
+                "target_frames_per_second": 60,
+            }),
+        )
+        .expect("deserializes without the settle");
+        assert_eq!(
+            decoded.startup_settle_seconds,
+            SyntheticFrameSourceConfiguration::default().startup_settle_seconds
+        );
     }
 
     /// A config written before the mode existed must decode to the protocol

--- a/spikes/streamlib-pyembed-spike/src/synthetic_frame_source_processor.rs
+++ b/spikes/streamlib-pyembed-spike/src/synthetic_frame_source_processor.rs
@@ -17,7 +17,8 @@ use crate::synthetic_frame_measurement_preamble::{
     SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES, SyntheticFrameMeasurementPreamble,
 };
 use crate::synthetic_frame_wire_payload_mode::{
-    SyntheticFrameWirePayloadMode, encode_surface_reference_body,
+    SyntheticFrameWirePayloadMode, encode_surface_reference_body, encode_synthetic_pixel_bytes,
+    frame_pixel_byte_count,
 };
 
 /// Frame geometry, pacing, and what rides the wire for
@@ -49,7 +50,12 @@ pub struct SyntheticFrameSourceConfiguration {
 }
 
 /// Comfortably past the ~0.66s the subprocess arm takes to reach its poll loop.
-fn default_startup_settle_seconds() -> f64 {
+///
+/// The single home for this value: the cell specification, the harness's clap
+/// default, and this config all read it, so a cell replayed from an older
+/// artifact cannot decode to a zero settle and silently reproduce the startup
+/// backlog the settle exists to prevent.
+pub fn default_startup_settle_seconds() -> f64 {
     2.0
 }
 
@@ -70,9 +76,11 @@ impl SyntheticFrameSourceConfiguration {
     /// Pixel bytes for one frame of this geometry, whether or not they cross
     /// the wire.
     pub fn frame_pixel_byte_count(&self) -> usize {
-        self.frame_width_pixels as usize
-            * self.frame_height_pixels as usize
-            * self.channel_count as usize
+        frame_pixel_byte_count(
+            self.frame_width_pixels,
+            self.frame_height_pixels,
+            self.channel_count,
+        )
     }
 
     /// The bytes riding behind the measurement preamble under this mode.
@@ -84,11 +92,7 @@ impl SyntheticFrameSourceConfiguration {
                 self.target_frames_per_second,
             ),
             SyntheticFrameWirePayloadMode::FullPixelPayload => {
-                // A non-uniform pattern so a stage that silently drops or zeroes
-                // the payload is distinguishable from one that passes it through.
-                (0..self.frame_pixel_byte_count())
-                    .map(|index| (index % 251) as u8)
-                    .collect()
+                encode_synthetic_pixel_bytes(self.frame_pixel_byte_count())
             }
         }
     }
@@ -217,8 +221,7 @@ mod tests {
             ..four_k
         };
         assert!(
-            four_k_by_reference.wire_body_bytes().len()
-                < UNTRUSTED_SESSION_PAYLOAD_CEILING_BYTES
+            four_k_by_reference.wire_body_bytes().len() < UNTRUSTED_SESSION_PAYLOAD_CEILING_BYTES
         );
     }
 
@@ -286,7 +289,9 @@ mod tests {
                 ..SyntheticFrameSourceConfiguration::default()
             };
             assert_eq!(
-                configuration.frame_period_nanoseconds().expect("valid rate"),
+                configuration
+                    .frame_period_nanoseconds()
+                    .expect("valid rate"),
                 expected_period_nanoseconds
             );
         }
@@ -334,15 +339,14 @@ mod tests {
     /// with no settle at all — the field defaults to the protocol value.
     #[test]
     fn a_configuration_without_a_startup_settle_decodes_to_the_protocol_default() {
-        let decoded: SyntheticFrameSourceConfiguration = serde_json::from_value(
-            serde_json::json!({
+        let decoded: SyntheticFrameSourceConfiguration =
+            serde_json::from_value(serde_json::json!({
                 "frame_width_pixels": 1280,
                 "frame_height_pixels": 720,
                 "channel_count": 4,
                 "target_frames_per_second": 60,
-            }),
-        )
-        .expect("deserializes without the settle");
+            }))
+            .expect("deserializes without the settle");
         assert_eq!(
             decoded.startup_settle_seconds,
             SyntheticFrameSourceConfiguration::default().startup_settle_seconds
@@ -354,15 +358,14 @@ mod tests {
     /// `cell-spec.json` without hand-editing it.
     #[test]
     fn a_configuration_without_a_wire_payload_mode_decodes_to_surface_reference() {
-        let decoded: SyntheticFrameSourceConfiguration = serde_json::from_value(
-            serde_json::json!({
+        let decoded: SyntheticFrameSourceConfiguration =
+            serde_json::from_value(serde_json::json!({
                 "frame_width_pixels": 1280,
                 "frame_height_pixels": 720,
                 "channel_count": 4,
                 "target_frames_per_second": 60,
-            }),
-        )
-        .expect("deserializes without the mode");
+            }))
+            .expect("deserializes without the mode");
         assert_eq!(
             decoded.wire_payload_mode,
             SyntheticFrameWirePayloadMode::SurfaceReference

--- a/spikes/streamlib-pyembed-spike/src/synthetic_frame_source_processor.rs
+++ b/spikes/streamlib-pyembed-spike/src/synthetic_frame_source_processor.rs
@@ -16,14 +16,22 @@ use crate::monotonic_clock::{
 use crate::synthetic_frame_measurement_preamble::{
     SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES, SyntheticFrameMeasurementPreamble,
 };
+use crate::synthetic_frame_wire_payload_mode::{
+    SyntheticFrameWirePayloadMode, encode_surface_reference_body,
+};
 
-/// Frame geometry and pacing for [`SyntheticFrameSourceProcessor`].
+/// Frame geometry, pacing, and what rides the wire for
+/// [`SyntheticFrameSourceProcessor`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SyntheticFrameSourceConfiguration {
     pub frame_width_pixels: u32,
     pub frame_height_pixels: u32,
     pub channel_count: u32,
     pub target_frames_per_second: u32,
+    /// The geometry above always describes the frame; this decides whether the
+    /// pixels for it actually cross the link (owner decision 7 on #1702).
+    #[serde(default)]
+    pub wire_payload_mode: SyntheticFrameWirePayloadMode,
 }
 
 impl Default for SyntheticFrameSourceConfiguration {
@@ -33,16 +41,36 @@ impl Default for SyntheticFrameSourceConfiguration {
             frame_height_pixels: 1080,
             channel_count: 4,
             target_frames_per_second: 30,
+            wire_payload_mode: SyntheticFrameWirePayloadMode::SurfaceReference,
         }
     }
 }
 
 impl SyntheticFrameSourceConfiguration {
-    /// Pixel bytes per frame, excluding the measurement preamble.
+    /// Pixel bytes for one frame of this geometry, whether or not they cross
+    /// the wire.
     pub fn frame_pixel_byte_count(&self) -> usize {
         self.frame_width_pixels as usize
             * self.frame_height_pixels as usize
             * self.channel_count as usize
+    }
+
+    /// The bytes riding behind the measurement preamble under this mode.
+    pub fn wire_body_bytes(&self) -> Vec<u8> {
+        match self.wire_payload_mode {
+            SyntheticFrameWirePayloadMode::SurfaceReference => encode_surface_reference_body(
+                self.frame_width_pixels,
+                self.frame_height_pixels,
+                self.target_frames_per_second,
+            ),
+            SyntheticFrameWirePayloadMode::FullPixelPayload => {
+                // A non-uniform pattern so a stage that silently drops or zeroes
+                // the payload is distinguishable from one that passes it through.
+                (0..self.frame_pixel_byte_count())
+                    .map(|index| (index % 251) as u8)
+                    .collect()
+            }
+        }
     }
 
     /// Nanoseconds between consecutive frame emissions at the target rate.
@@ -75,22 +103,17 @@ pub struct SyntheticFrameSourceProcessor {
 
 impl ContinuousProcessor for SyntheticFrameSourceProcessor::Processor {
     fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        let total_payload_bytes = SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES
-            + self.configuration.frame_pixel_byte_count();
-        self.frame_payload_buffer = vec![0u8; total_payload_bytes];
-        // A non-uniform pattern so a stage that silently drops or zeroes the
-        // payload is distinguishable from one that passes it through.
-        for (index, byte) in self.frame_payload_buffer
-            [SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES..]
-            .iter_mut()
-            .enumerate()
-        {
-            *byte = (index % 251) as u8;
-        }
+        let wire_body = self.configuration.wire_body_bytes();
+        self.frame_payload_buffer =
+            Vec::with_capacity(SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES + wire_body.len());
+        self.frame_payload_buffer
+            .resize(SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES, 0u8);
+        self.frame_payload_buffer.extend_from_slice(&wire_body);
         self.next_frame_sequence_number = 0;
         self.emission_origin_monotonic_nanoseconds = read_monotonic_clock_nanoseconds();
         tracing::info!(
-            frame_bytes = total_payload_bytes,
+            frame_bytes = self.frame_payload_buffer.len(),
+            wire_payload_mode = self.configuration.wire_payload_mode.as_artifact_token(),
             target_fps = self.configuration.target_frames_per_second,
             "synthetic frame source ready"
         );
@@ -132,17 +155,20 @@ impl ContinuousProcessor for SyntheticFrameSourceProcessor::Processor {
 mod tests {
     use super::*;
 
-    /// 1080p BGRA plus the preamble must stay inside the 16 MiB untrusted-session
-    /// payload ceiling, because the subprocess baseline arm's links are
-    /// classified UntrustedSession (`open_iceoryx2_service_op.rs:149-153`,
+    /// A full-pixel 1080p frame plus the preamble must stay inside the 16 MiB
+    /// untrusted-session payload ceiling, because the subprocess baseline arm's
+    /// links are classified UntrustedSession (`open_iceoryx2_service_op.rs:149-153`,
     /// `streamlib-ipc-types/src/lib.rs:43`). Exceeding it would make the two
     /// arms structurally incomparable rather than merely slower.
     #[test]
-    fn default_frame_fits_the_untrusted_session_payload_ceiling() {
+    fn a_full_pixel_1080p_frame_fits_the_untrusted_session_payload_ceiling() {
         const UNTRUSTED_SESSION_PAYLOAD_CEILING_BYTES: usize = 16 * 1024 * 1024;
-        let configuration = SyntheticFrameSourceConfiguration::default();
-        let total_bytes = SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES
-            + configuration.frame_pixel_byte_count();
+        let configuration = SyntheticFrameSourceConfiguration {
+            wire_payload_mode: SyntheticFrameWirePayloadMode::FullPixelPayload,
+            ..SyntheticFrameSourceConfiguration::default()
+        };
+        let total_bytes =
+            SYNTHETIC_FRAME_MEASUREMENT_PREAMBLE_BYTES + configuration.wire_body_bytes().len();
         assert_eq!(configuration.frame_pixel_byte_count(), 8_294_400);
         assert!(
             total_bytes < UNTRUSTED_SESSION_PAYLOAD_CEILING_BYTES,
@@ -150,17 +176,81 @@ mod tests {
         );
     }
 
-    /// 4K would fit the in-process arm's 64 MiB Trusted ceiling but is refused
-    /// on the subprocess arm — the boundary that caps this benchmark at 1080p.
+    /// 4K pixels would fit the in-process arm's 64 MiB Trusted ceiling but are
+    /// refused on the subprocess arm — the boundary that caps the full-pixel
+    /// sweep at 1080p. The reference mode is not bound by it at any geometry.
     #[test]
-    fn four_k_frame_exceeds_the_untrusted_session_ceiling() {
+    fn four_k_pixels_exceed_the_untrusted_session_ceiling_but_a_reference_does_not() {
         const UNTRUSTED_SESSION_PAYLOAD_CEILING_BYTES: usize = 16 * 1024 * 1024;
-        let configuration = SyntheticFrameSourceConfiguration {
+        let four_k = SyntheticFrameSourceConfiguration {
             frame_width_pixels: 3840,
             frame_height_pixels: 2160,
+            wire_payload_mode: SyntheticFrameWirePayloadMode::FullPixelPayload,
             ..SyntheticFrameSourceConfiguration::default()
         };
-        assert!(configuration.frame_pixel_byte_count() > UNTRUSTED_SESSION_PAYLOAD_CEILING_BYTES);
+        assert!(four_k.wire_body_bytes().len() > UNTRUSTED_SESSION_PAYLOAD_CEILING_BYTES);
+
+        let four_k_by_reference = SyntheticFrameSourceConfiguration {
+            wire_payload_mode: SyntheticFrameWirePayloadMode::SurfaceReference,
+            ..four_k
+        };
+        assert!(
+            four_k_by_reference.wire_body_bytes().len()
+                < UNTRUSTED_SESSION_PAYLOAD_CEILING_BYTES
+        );
+    }
+
+    /// Owner decision 7: the protocol cells carry surface references, not
+    /// pictures. A default that regressed to full pixels would silently
+    /// reproduce the retracted 27ms floor and report it as a gated number.
+    #[test]
+    fn the_source_defaults_to_putting_a_surface_reference_on_the_wire() {
+        let configuration = SyntheticFrameSourceConfiguration::default();
+        assert_eq!(
+            configuration.wire_payload_mode,
+            SyntheticFrameWirePayloadMode::SurfaceReference
+        );
+        assert!(configuration.wire_body_bytes().len() < 1024);
+    }
+
+    /// The 1080p60 cell is only measurable because the wire body no longer
+    /// tracks geometry: a full-pixel two-hop service time exceeds the 16.6ms
+    /// frame period and the cell runs permanently saturated.
+    #[test]
+    fn a_surface_reference_wire_body_does_not_grow_with_frame_geometry() {
+        let seven_twenty = SyntheticFrameSourceConfiguration {
+            frame_width_pixels: 1280,
+            frame_height_pixels: 720,
+            ..SyntheticFrameSourceConfiguration::default()
+        };
+        let ten_eighty = SyntheticFrameSourceConfiguration::default();
+        assert_eq!(
+            seven_twenty.wire_body_bytes().len(),
+            ten_eighty.wire_body_bytes().len(),
+            "the resolution leg must vary pixel work, never transport width"
+        );
+        assert_ne!(
+            seven_twenty.frame_pixel_byte_count(),
+            ten_eighty.frame_pixel_byte_count()
+        );
+    }
+
+    /// The full-pixel body must keep the non-uniform pattern, which is what
+    /// distinguishes a stage that passed the payload through from one that
+    /// zeroed it.
+    #[test]
+    fn the_full_pixel_wire_body_carries_a_non_uniform_pattern() {
+        let configuration = SyntheticFrameSourceConfiguration {
+            frame_width_pixels: 4,
+            frame_height_pixels: 2,
+            channel_count: 4,
+            wire_payload_mode: SyntheticFrameWirePayloadMode::FullPixelPayload,
+            ..SyntheticFrameSourceConfiguration::default()
+        };
+        let body = configuration.wire_body_bytes();
+        assert_eq!(body.len(), 32);
+        assert_eq!(body[0], 0);
+        assert_eq!(body[31], 31);
     }
 
     /// Both protocol rates must produce exact periods; a rate that divided
@@ -200,10 +290,31 @@ mod tests {
             frame_height_pixels: 720,
             channel_count: 4,
             target_frames_per_second: 60,
+            wire_payload_mode: SyntheticFrameWirePayloadMode::FullPixelPayload,
         };
         let encoded = serde_json::to_value(&configuration).expect("serializes");
         let decoded: SyntheticFrameSourceConfiguration =
             serde_json::from_value(encoded).expect("deserializes");
         assert_eq!(decoded, configuration);
+    }
+
+    /// A config written before the mode existed must decode to the protocol
+    /// default rather than failing, so a cell can be replayed from an older
+    /// `cell-spec.json` without hand-editing it.
+    #[test]
+    fn a_configuration_without_a_wire_payload_mode_decodes_to_surface_reference() {
+        let decoded: SyntheticFrameSourceConfiguration = serde_json::from_value(
+            serde_json::json!({
+                "frame_width_pixels": 1280,
+                "frame_height_pixels": 720,
+                "channel_count": 4,
+                "target_frames_per_second": 60,
+            }),
+        )
+        .expect("deserializes without the mode");
+        assert_eq!(
+            decoded.wire_payload_mode,
+            SyntheticFrameWirePayloadMode::SurfaceReference
+        );
     }
 }

--- a/spikes/streamlib-pyembed-spike/src/synthetic_frame_wire_payload_mode.rs
+++ b/spikes/streamlib-pyembed-spike/src/synthetic_frame_wire_payload_mode.rs
@@ -1,0 +1,240 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! What the spike puts on the wire behind the measurement preamble, and how
+//! wide a surface reference is.
+//!
+//! Owner decision 7 on #1702: Tier A carries reference-sized frames matching a
+//! surface-id frame's weight. The early Tier A run that reported a ~27ms floor
+//! at 1080p was pushing whole uncompressed pictures through main memory — a
+//! choice of this harness, not a property of the engine. A real
+//! `@tatolab/core/VideoFrame` references its GPU surface by id and weighs a few
+//! hundred bytes (`packages/core/schemas/video_frame.yaml`), so the reference
+//! mode is what the protocol cells measure and the full-pixel mode survives
+//! only to keep that retracted result reproducible.
+
+use serde::{Deserialize, Serialize};
+
+/// What rides the wire behind the measurement preamble.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum SyntheticFrameWirePayloadMode {
+    /// A surface reference weighing what a real `VideoFrame` weighs. The
+    /// protocol default; pixels never cross the link.
+    #[default]
+    SurfaceReference,
+    /// The whole uncompressed picture. Reproduces the payload-size sweep that
+    /// retracted the 27ms floor; never the basis of a gated number.
+    FullPixelPayload,
+}
+
+impl SyntheticFrameWirePayloadMode {
+    /// Stable token used in cell directory names and in `cell-spec.json`.
+    pub fn as_artifact_token(self) -> &'static str {
+        match self {
+            SyntheticFrameWirePayloadMode::SurfaceReference => "surface-reference",
+            SyntheticFrameWirePayloadMode::FullPixelPayload => "full-pixel-payload",
+        }
+    }
+
+    /// Parse the `--wire-payload-mode` flag value.
+    pub fn parse_from_flag_value(value: &str) -> std::result::Result<Self, String> {
+        match value {
+            "surface-reference" => Ok(SyntheticFrameWirePayloadMode::SurfaceReference),
+            "full-pixel-payload" => Ok(SyntheticFrameWirePayloadMode::FullPixelPayload),
+            other => Err(format!(
+                "unknown wire payload mode `{other}` — expected `surface-reference` or \
+                 `full-pixel-payload`"
+            )),
+        }
+    }
+}
+
+/// The fields a `@tatolab/core/VideoFrame` carries on the wire, populated with
+/// values a Linux camera would actually produce.
+///
+/// This exists so the reference body's width is *derived* from the schema
+/// rather than asserted as a magic constant: change the schema and this struct
+/// diverges visibly, where a hardcoded byte count would silently stay wrong.
+/// The optional HDR members (`color_info`, `mastering_display`, `content_light`)
+/// are absent, matching an SDR camera stream.
+#[derive(Debug, Serialize)]
+struct RepresentativeVideoFrameSurfaceReference {
+    surface_id: String,
+    width: u32,
+    height: u32,
+    timestamp_ns: String,
+    fps: u32,
+    texture_layout: i32,
+}
+
+impl RepresentativeVideoFrameSurfaceReference {
+    fn for_geometry(width_pixels: u32, height_pixels: u32, frames_per_second: u32) -> Self {
+        Self {
+            // Shaped like the ids the surface-share service mints: a device
+            // stem plus a pool slot. Length matters here, content does not.
+            surface_id: "camera-vivid-video0-texture-pool-slot-03".to_string(),
+            width: width_pixels,
+            height: height_pixels,
+            // The schema carries this as a string to survive JSON's 53-bit
+            // integer limit, so the encoded body pays for 19 digits of text.
+            timestamp_ns: "1754081999123456789".to_string(),
+            fps: frames_per_second,
+            // VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL.
+            texture_layout: 5,
+        }
+    }
+}
+
+/// Fixed wire width of a surface reference, in bytes.
+///
+/// Held constant across geometries on purpose. A bare encoding varies by a
+/// byte or two with the decimal digit count of `width`/`height` (640 is three
+/// digits, 1920 is four), which would make the resolution leg of the matrix
+/// vary transport cost as well as pixel work — a confound in exactly the
+/// comparison the leg exists to make. Sized above the widest encoding any
+/// geometry produces, and asserted to be so.
+pub const SURFACE_REFERENCE_BODY_BYTES: usize = 192;
+
+/// Encode a surface reference for `width_pixels`x`height_pixels` at
+/// `frames_per_second`, returning the bytes that ride behind the preamble.
+///
+/// The body is built once at setup and reused unchanged for every frame: the
+/// measured quantity is transport plus callback cost, both of which turn on the
+/// body's *width*, and re-encoding per frame would add a cost the real path —
+/// which encodes its bag once per frame in the producer, off this measurement's
+/// critical path — does not have here.
+///
+/// The result is zero-padded to [`SURFACE_REFERENCE_BODY_BYTES`]. Padding is
+/// invisible to every consumer here because the spike's ports are declared
+/// `any`, so no schema is ever consulted and the body is opaque bytes.
+pub fn encode_surface_reference_body(
+    width_pixels: u32,
+    height_pixels: u32,
+    frames_per_second: u32,
+) -> Vec<u8> {
+    let reference = RepresentativeVideoFrameSurfaceReference::for_geometry(
+        width_pixels,
+        height_pixels,
+        frames_per_second,
+    );
+    // Infallible for this struct — every member is a plain scalar or String.
+    let mut body = serde_json::to_vec(&reference).unwrap_or_default();
+    debug_assert!(
+        body.len() <= SURFACE_REFERENCE_BODY_BYTES,
+        "a {}x{} surface reference encodes to {} bytes, over the fixed wire width of {}",
+        width_pixels,
+        height_pixels,
+        body.len(),
+        SURFACE_REFERENCE_BODY_BYTES
+    );
+    body.resize(SURFACE_REFERENCE_BODY_BYTES, 0u8);
+    body
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The protocol default must be the reference mode. A silent flip back to
+    /// full-pixel would reproduce the retracted 27ms artifact and report it as a
+    /// gated number.
+    #[test]
+    fn the_default_wire_payload_mode_is_surface_reference() {
+        assert_eq!(
+            SyntheticFrameWirePayloadMode::default(),
+            SyntheticFrameWirePayloadMode::SurfaceReference
+        );
+    }
+
+    /// A surface reference has to stay in the hundreds of bytes to be worth the
+    /// name. If the schema grows a large member this fails rather than quietly
+    /// turning the reference cell into a payload cell.
+    #[test]
+    fn the_surface_reference_body_weighs_a_few_hundred_bytes() {
+        let body = encode_surface_reference_body(1920, 1080, 60);
+        assert!(
+            (64..1024).contains(&body.len()),
+            "surface reference body is {} bytes, which is no longer reference-sized",
+            body.len()
+        );
+    }
+
+    /// The reference body's width must not track the geometry it describes —
+    /// that independence is the entire point, and it is what makes a 1080p60
+    /// cell measurable where a full-pixel one saturates. It must hold across
+    /// digit-count boundaries, which is where the unpadded encoding differed.
+    #[test]
+    fn the_surface_reference_body_width_is_independent_of_frame_geometry() {
+        let widths: Vec<usize> = [(640, 480), (1280, 720), (1920, 1080), (3840, 2160)]
+            .into_iter()
+            .map(|(width, height)| encode_surface_reference_body(width, height, 30).len())
+            .collect();
+        assert!(
+            widths.iter().all(|width| *width == SURFACE_REFERENCE_BODY_BYTES),
+            "surface reference widths varied across geometries: {widths:?}"
+        );
+    }
+
+    /// The padding has to leave room for the widest geometry the matrix runs,
+    /// or a 4K reference would be truncated into a shorter body and quietly
+    /// measure a narrower wire than a 1080p one.
+    #[test]
+    fn the_fixed_wire_width_exceeds_the_widest_encoding_any_geometry_produces() {
+        let widest = RepresentativeVideoFrameSurfaceReference::for_geometry(3840, 2160, 240);
+        let encoded = serde_json::to_vec(&widest).expect("serializes");
+        assert!(
+            encoded.len() < SURFACE_REFERENCE_BODY_BYTES,
+            "widest encoding is {} bytes against a fixed width of {}",
+            encoded.len(),
+            SURFACE_REFERENCE_BODY_BYTES
+        );
+    }
+
+    /// 1080p BGRA is 8.29 MB; a surface reference must be smaller by orders of
+    /// magnitude or the mode buys nothing.
+    #[test]
+    fn a_surface_reference_is_orders_of_magnitude_below_a_full_picture() {
+        let body = encode_surface_reference_body(1920, 1080, 60);
+        let full_picture_bytes = 1920usize * 1080 * 4;
+        assert!(full_picture_bytes / body.len() > 10_000);
+    }
+
+    /// The token is part of the cell directory name, so two cells differing only
+    /// by wire mode must not collide.
+    #[test]
+    fn wire_payload_modes_have_distinct_artifact_tokens() {
+        assert_ne!(
+            SyntheticFrameWirePayloadMode::SurfaceReference.as_artifact_token(),
+            SyntheticFrameWirePayloadMode::FullPixelPayload.as_artifact_token()
+        );
+    }
+
+    /// Every token the harness prints must parse back, so a cell can be replayed
+    /// from its own `cell-spec.json`.
+    #[test]
+    fn artifact_tokens_round_trip_through_the_flag_parser() {
+        for mode in [
+            SyntheticFrameWirePayloadMode::SurfaceReference,
+            SyntheticFrameWirePayloadMode::FullPixelPayload,
+        ] {
+            assert_eq!(
+                SyntheticFrameWirePayloadMode::parse_from_flag_value(mode.as_artifact_token()),
+                Ok(mode)
+            );
+        }
+        assert!(SyntheticFrameWirePayloadMode::parse_from_flag_value("latest").is_err());
+    }
+
+    /// The mode rides `cell-spec.json`, so it must survive serde in the same
+    /// kebab-case form the flag uses.
+    #[test]
+    fn wire_payload_mode_round_trips_through_serde_in_flag_form() {
+        let encoded = serde_json::to_value(SyntheticFrameWirePayloadMode::FullPixelPayload)
+            .expect("serializes");
+        assert_eq!(encoded, serde_json::json!("full-pixel-payload"));
+        let decoded: SyntheticFrameWirePayloadMode =
+            serde_json::from_value(encoded).expect("deserializes");
+        assert_eq!(decoded, SyntheticFrameWirePayloadMode::FullPixelPayload);
+    }
+}

--- a/spikes/streamlib-pyembed-spike/src/synthetic_frame_wire_payload_mode.rs
+++ b/spikes/streamlib-pyembed-spike/src/synthetic_frame_wire_payload_mode.rs
@@ -86,6 +86,31 @@ impl RepresentativeVideoFrameSurfaceReference {
     }
 }
 
+/// Modulus of the non-uniform byte pattern every pixel buffer in the spike
+/// carries, wherever those pixels live.
+///
+/// Shared rather than re-typed because the comparison depends on it: the
+/// full-pixel wire body, the in-process stage's locally resolved surface, and
+/// the subprocess baseline's own buffer must feed the callback identical
+/// bytes, or a mode or arm comparison stops comparing like with like. The
+/// Python side reads it from the config this constant fills.
+pub const SYNTHETIC_PIXEL_PATTERN_MODULUS: usize = 251;
+
+/// Pixel bytes for one frame of this geometry.
+pub fn frame_pixel_byte_count(width_pixels: u32, height_pixels: u32, channel_count: u32) -> usize {
+    width_pixels as usize * height_pixels as usize * channel_count as usize
+}
+
+/// `pixel_byte_count` bytes of the shared non-uniform pattern.
+///
+/// Non-uniform so a stage that silently drops or zeroes the payload is
+/// distinguishable from one that passes it through.
+pub fn encode_synthetic_pixel_bytes(pixel_byte_count: usize) -> Vec<u8> {
+    (0..pixel_byte_count)
+        .map(|index| (index % SYNTHETIC_PIXEL_PATTERN_MODULUS) as u8)
+        .collect()
+}
+
 /// Fixed wire width of a surface reference, in bytes.
 ///
 /// Held constant across geometries on purpose. A bare encoding varies by a
@@ -119,8 +144,13 @@ pub fn encode_surface_reference_body(
         frames_per_second,
     );
     // Infallible for this struct — every member is a plain scalar or String.
-    let mut body = serde_json::to_vec(&reference).unwrap_or_default();
-    debug_assert!(
+    let mut body = serde_json::to_vec(&reference)
+        .expect("a struct of plain scalars and Strings always serializes");
+    // `assert!`, not `debug_assert!`: the numbers are taken in release, and the
+    // `resize` below would *truncate* an over-long encoding into a silently
+    // narrower wire — losing the one property the mode rests on, in exactly the
+    // build where it matters. Runs once at setup, off any measured path.
+    assert!(
         body.len() <= SURFACE_REFERENCE_BODY_BYTES,
         "a {}x{} surface reference encodes to {} bytes, over the fixed wire width of {}",
         width_pixels,
@@ -171,7 +201,9 @@ mod tests {
             .map(|(width, height)| encode_surface_reference_body(width, height, 30).len())
             .collect();
         assert!(
-            widths.iter().all(|width| *width == SURFACE_REFERENCE_BODY_BYTES),
+            widths
+                .iter()
+                .all(|width| *width == SURFACE_REFERENCE_BODY_BYTES),
             "surface reference widths varied across geometries: {widths:?}"
         );
     }

--- a/spikes/streamlib-pyembed-spike/src/tier_a_measurement_cell.rs
+++ b/spikes/streamlib-pyembed-spike/src/tier_a_measurement_cell.rs
@@ -306,7 +306,18 @@ pub fn run_tier_a_measurement_cell(
     app.connect((&source, "frame_out"), (&stage, "frame_in"))?;
     app.connect((&stage, "frame_out"), (&sink, "frame_in"))?;
 
-    let machine_specification = probe_machine_specification();
+    let mut machine_specification = probe_machine_specification();
+    // Without this the in-process arm's own artifact names only the *other*
+    // arm's interpreter, so a reader of the headline number cannot see what
+    // produced it.
+    if specification.arm.runs_the_callback_in_the_harness_interpreter() {
+        pyo3::Python::attach(|python| {
+            crate::machine_specification_probe::record_embedded_python_runtime(
+                &mut machine_specification,
+                python,
+            )
+        });
+    }
 
     app.runner().start()?;
     let cell_deadline = read_monotonic_clock_nanoseconds()

--- a/spikes/streamlib-pyembed-spike/src/tier_a_measurement_cell.rs
+++ b/spikes/streamlib-pyembed-spike/src/tier_a_measurement_cell.rs
@@ -181,6 +181,10 @@ pub struct TierAMeasurementCellOutcome {
     /// startup backlog and its percentiles describe queue occupancy, not
     /// latency — see [`LatencyMeasurementRecorder::backlog_drain_fraction`].
     pub backlog_drain_fraction: f64,
+    /// Raw `CLOCK_MONOTONIC` nanoseconds at which the sink saw its first frame.
+    /// Gate 6's restart battery pairs this with its own pre-spawn stamp to get
+    /// exec-to-first-frame without either side estimating the other's clock.
+    pub first_frame_sink_receive_monotonic_nanoseconds: Option<i64>,
     pub rolling_one_second_frame_rate_windows: Vec<f64>,
 }
 
@@ -309,6 +313,8 @@ pub fn run_tier_a_measurement_cell(
         negative_latency_anomaly_count: recorder.negative_latency_anomaly_count(),
         histogram_range_saturation_count: recorder.histogram_range_saturation_count(),
         backlog_drain_fraction: recorder.backlog_drain_fraction(),
+        first_frame_sink_receive_monotonic_nanoseconds: recorder
+            .first_frame_sink_receive_monotonic_nanoseconds(),
         rolling_one_second_frame_rate_windows: recorder.rolling_one_second_frame_rate_windows(),
     };
 

--- a/spikes/streamlib-pyembed-spike/src/tier_a_measurement_cell.rs
+++ b/spikes/streamlib-pyembed-spike/src/tier_a_measurement_cell.rs
@@ -8,13 +8,11 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use streamlib::sdk::App;
-use streamlib::sdk::error::{Error, Result};
 use streamlib::sdk::descriptors::{Org, Package, TypeName};
+use streamlib::sdk::error::{Error, Result};
 use streamlib::sdk::processors::ProcessorTypeReference;
 
-use crate::latency_measurement_recorder::{
-    LatencyMeasurementRecorder, LatencyPercentileSummary,
-};
+use crate::latency_measurement_recorder::{LatencyMeasurementRecorder, LatencyPercentileSummary};
 use crate::machine_specification_probe::{
     MACHINE_SPECIFICATION_JSON_FILE_NAME, MachineSpecification, probe_machine_specification,
 };
@@ -32,7 +30,9 @@ use crate::rust_passthrough_floor_stage_processor::{
 use crate::synthetic_frame_source_processor::{
     SyntheticFrameSourceConfiguration, SyntheticFrameSourceProcessor,
 };
-use crate::synthetic_frame_wire_payload_mode::SyntheticFrameWirePayloadMode;
+use crate::synthetic_frame_wire_payload_mode::{
+    SURFACE_REFERENCE_BODY_BYTES, SYNTHETIC_PIXEL_PATTERN_MODULUS, SyntheticFrameWirePayloadMode,
+};
 
 /// Identity of the processor the subprocess baseline arm instantiates.
 /// Provisioned into a `streamlib_modules/@spike/...` slot by
@@ -43,9 +43,12 @@ pub const SUBPROCESS_BASELINE_STAGE_PACKAGE: &str = "pyembed-subprocess-baseline
 pub const SUBPROCESS_BASELINE_STAGE_TYPE_NAME: &str = "PyembedSubprocessBaselineStage";
 
 /// Module on `PYTHONPATH` exposing the stage callables both Python arms invoke.
-/// Shared on purpose: the arms must run byte-identical callback bodies or the
-/// comparison measures two different workloads.
 pub const SPIKE_STAGE_CALLBACK_MODULE: &str = "spike_stage_callbacks";
+
+/// Default for [`TierAMeasurementCellSpecification::stage_callback_module`].
+pub fn default_stage_callback_module() -> String {
+    SPIKE_STAGE_CALLBACK_MODULE.to_string()
+}
 
 /// Build the baseline stage's type reference from its three identity segments.
 pub fn subprocess_baseline_stage_type_reference() -> Result<ProcessorTypeReference> {
@@ -86,6 +89,22 @@ impl MeasurementArm {
         }
     }
 
+    /// Parse the `--arm` flag value. Colocated with [`Self::as_artifact_token`]
+    /// so the two spellings cannot drift: the token is a cell-directory
+    /// component, and a printed token that no longer parses back makes a cell
+    /// unreplayable from its own artifact.
+    pub fn parse_from_flag_value(value: &str) -> std::result::Result<Self, String> {
+        match value {
+            "in-process-python" => Ok(MeasurementArm::InProcessPython),
+            "rust-passthrough-floor" => Ok(MeasurementArm::RustPassthroughFloor),
+            "subprocess-python-baseline" => Ok(MeasurementArm::SubprocessPythonBaseline),
+            other => Err(format!(
+                "unknown arm `{other}` — expected `in-process-python`, \
+                 `rust-passthrough-floor`, or `subprocess-python-baseline`"
+            )),
+        }
+    }
+
     /// Whether this arm runs its callback inside the harness's own interpreter.
     /// The subprocess arm does not, so registering a callback for it, or
     /// installing a GC recorder in this process, would measure nothing.
@@ -112,12 +131,23 @@ pub struct TierAMeasurementCellSpecification {
     /// measured from a quiescent graph rather than through its own startup
     /// backlog. Identical across arms — it is a property of the cell, not of
     /// the arm, or the arms would not be comparable.
-    #[serde(default)]
+    ///
+    /// A bare `#[serde(default)]` would be 0.0 here, and this value is copied
+    /// into the source's config unconditionally — so replaying a `cell-spec.json`
+    /// written before this field existed would silently reinstate the startup
+    /// backlog rather than the protocol settle.
+    #[serde(default = "crate::synthetic_frame_source_processor::default_startup_settle_seconds")]
     pub startup_settle_seconds: f64,
     pub cell_duration_seconds: u64,
     pub warmup_exclusion_seconds: u64,
     pub python_callback_registration_token: String,
     pub anchor_processor_thread_gil: bool,
+    /// The module both Python arms import the callable from. Recorded and
+    /// threaded to the subprocess arm rather than hardcoded there: the two arms
+    /// must run byte-identical callback bodies, and a non-default module on the
+    /// in-process side used to leave the subprocess side on the default.
+    #[serde(default = "default_stage_callback_module")]
+    pub stage_callback_module: String,
     /// The callable the stage invoked, e.g. `passthrough_stage`. Part of the
     /// cell directory name: two cells differing only by stage would otherwise
     /// collide and the second would overwrite the first.
@@ -211,6 +241,7 @@ pub fn run_tier_a_measurement_cell(
         / 10;
     install_measurement_collection_point(LatencyMeasurementRecorder::new(
         warmup_exclusion_nanoseconds,
+        1_000_000_000 / specification.target_frames_per_second.max(1) as i64,
         expected_frame_count,
     ));
 
@@ -246,7 +277,6 @@ pub fn run_tier_a_measurement_cell(
                     frame_width_pixels: specification.frame_width_pixels,
                     frame_height_pixels: specification.frame_height_pixels,
                     channel_count: specification.channel_count,
-                    wire_payload_mode: specification.wire_payload_mode,
                 },
             )?,
         // `add`, not `add_local`: this arm exists to exercise the package +
@@ -260,8 +290,13 @@ pub fn run_tier_a_measurement_cell(
                 "frame_height_pixels": specification.frame_height_pixels,
                 "channel_count": specification.channel_count,
                 "wire_payload_mode": specification.wire_payload_mode,
-                "stage_callback_module": SPIKE_STAGE_CALLBACK_MODULE,
+                "stage_callback_module": specification.stage_callback_module,
                 "stage_callback_attribute": specification.stage_callback_attribute,
+                // Sent rather than re-typed in Python: both Python arms must
+                // hand the callback identical bytes or the comparison stops
+                // comparing like with like.
+                "synthetic_pixel_pattern_modulus": SYNTHETIC_PIXEL_PATTERN_MODULUS,
+                "surface_reference_body_bytes": SURFACE_REFERENCE_BODY_BYTES,
             }),
         )?,
     };
@@ -296,8 +331,9 @@ pub fn run_tier_a_measurement_cell(
         )));
     }
 
-    recorder
-        .write_per_frame_measurement_jsonl(&artifact_directory.join("per-frame-measurements.jsonl"))?;
+    recorder.write_per_frame_measurement_jsonl(
+        &artifact_directory.join("per-frame-measurements.jsonl"),
+    )?;
     recorder.write_mergeable_histogram_export(
         &artifact_directory.join("source-emit-to-sink-receive.histogram"),
     )?;
@@ -353,6 +389,7 @@ mod tests {
             startup_settle_seconds: 2.0,
             cell_duration_seconds: 600,
             warmup_exclusion_seconds: 60,
+            stage_callback_module: SPIKE_STAGE_CALLBACK_MODULE.to_string(),
             python_callback_registration_token: "cell-token".to_string(),
             anchor_processor_thread_gil: true,
             stage_callback_attribute: "passthrough_stage".to_string(),
@@ -416,6 +453,43 @@ mod tests {
         );
     }
 
+    /// Every arm token the harness prints must parse back, or a cell cannot be
+    /// replayed from its own `cell-spec.json` and its directory name stops
+    /// naming anything the harness accepts.
+    #[test]
+    fn arm_tokens_round_trip_through_the_flag_parser() {
+        for arm in [
+            MeasurementArm::InProcessPython,
+            MeasurementArm::RustPassthroughFloor,
+            MeasurementArm::SubprocessPythonBaseline,
+        ] {
+            assert_eq!(
+                MeasurementArm::parse_from_flag_value(arm.as_artifact_token()),
+                Ok(arm)
+            );
+        }
+        assert!(MeasurementArm::parse_from_flag_value("in-process").is_err());
+    }
+
+    /// The settle is copied into the source's config unconditionally, so a spec
+    /// decoding to 0.0 would reinstate the startup backlog the settle exists to
+    /// prevent — silently, on an artifact written before the field existed.
+    #[test]
+    fn a_specification_without_a_startup_settle_decodes_to_the_protocol_default() {
+        let mut encoded = serde_json::to_value(example_specification()).expect("serializes");
+        encoded
+            .as_object_mut()
+            .expect("a spec encodes to an object")
+            .remove("startup_settle_seconds");
+        let decoded: TierAMeasurementCellSpecification =
+            serde_json::from_value(encoded).expect("deserializes without the settle");
+        assert_eq!(
+            decoded.startup_settle_seconds,
+            crate::synthetic_frame_source_processor::default_startup_settle_seconds()
+        );
+        assert!(decoded.startup_settle_seconds > 0.0);
+    }
+
     /// Owner decision 7 rides the artifact: a summarizer reading a cell must be
     /// able to tell a protocol cell from a payload-sweep cell without guessing.
     #[test]
@@ -465,7 +539,10 @@ mod tests {
     /// the summarizer keys gate eligibility off this field.
     #[test]
     fn the_recorded_delivery_profile_is_every_sample() {
-        assert_eq!(example_specification().resolved_delivery_profile, "every_sample");
+        assert_eq!(
+            example_specification().resolved_delivery_profile,
+            "every_sample"
+        );
     }
 
     /// The spec round-trips so a cell can be replayed exactly from its own
@@ -499,6 +576,7 @@ mod cell_directory_collision_tests {
             startup_settle_seconds: 2.0,
             cell_duration_seconds: 600,
             warmup_exclusion_seconds: 60,
+            stage_callback_module: SPIKE_STAGE_CALLBACK_MODULE.to_string(),
             python_callback_registration_token: "token".to_string(),
             anchor_processor_thread_gil: true,
             stage_callback_attribute: "passthrough_stage".to_string(),

--- a/spikes/streamlib-pyembed-spike/src/tier_a_measurement_cell.rs
+++ b/spikes/streamlib-pyembed-spike/src/tier_a_measurement_cell.rs
@@ -9,6 +9,8 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use streamlib::sdk::App;
 use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::descriptors::{Org, Package, TypeName};
+use streamlib::sdk::processors::ProcessorTypeReference;
 
 use crate::latency_measurement_recorder::{
     LatencyMeasurementRecorder, LatencyPercentileSummary,
@@ -32,8 +34,35 @@ use crate::synthetic_frame_source_processor::{
 };
 use crate::synthetic_frame_wire_payload_mode::SyntheticFrameWirePayloadMode;
 
-/// Which of the two Rust-side comparison arms a cell runs. The third arm, the
-/// subprocess baseline, is driven from `python/runner.py`.
+/// Identity of the processor the subprocess baseline arm instantiates.
+/// Provisioned into a `streamlib_modules/@spike/...` slot by
+/// `python/provision_subprocess_baseline_package.py`, which must have run
+/// before a cell on this arm starts.
+pub const SUBPROCESS_BASELINE_STAGE_ORG: &str = "spike";
+pub const SUBPROCESS_BASELINE_STAGE_PACKAGE: &str = "pyembed-subprocess-baseline";
+pub const SUBPROCESS_BASELINE_STAGE_TYPE_NAME: &str = "PyembedSubprocessBaselineStage";
+
+/// Module on `PYTHONPATH` exposing the stage callables both Python arms invoke.
+/// Shared on purpose: the arms must run byte-identical callback bodies or the
+/// comparison measures two different workloads.
+pub const SPIKE_STAGE_CALLBACK_MODULE: &str = "spike_stage_callbacks";
+
+/// Build the baseline stage's type reference from its three identity segments.
+pub fn subprocess_baseline_stage_type_reference() -> Result<ProcessorTypeReference> {
+    fn malformed(segment: &str, error: impl std::fmt::Display) -> Error {
+        Error::Configuration(format!(
+            "the subprocess baseline stage's {segment} segment is malformed: {error}"
+        ))
+    }
+    Ok(ProcessorTypeReference::new(
+        Org::new(SUBPROCESS_BASELINE_STAGE_ORG).map_err(|e| malformed("org", e))?,
+        Package::new(SUBPROCESS_BASELINE_STAGE_PACKAGE).map_err(|e| malformed("package", e))?,
+        TypeName::new(SUBPROCESS_BASELINE_STAGE_TYPE_NAME).map_err(|e| malformed("type", e))?,
+    ))
+}
+
+/// Which comparison arm a cell runs. All three build the same three-processor
+/// graph and differ only in what hosts the stage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum MeasurementArm {
@@ -41,6 +70,10 @@ pub enum MeasurementArm {
     InProcessPython,
     /// Pure-Rust passthrough — the engine wire-hop floor, no interpreter.
     RustPassthroughFloor,
+    /// Today's model: the same callback in its own process, its own venv,
+    /// reached through the python-native cdylib. The arm the pivot is measured
+    /// against.
+    SubprocessPythonBaseline,
 }
 
 impl MeasurementArm {
@@ -49,7 +82,15 @@ impl MeasurementArm {
         match self {
             MeasurementArm::InProcessPython => "in-process-python",
             MeasurementArm::RustPassthroughFloor => "rust-passthrough-floor",
+            MeasurementArm::SubprocessPythonBaseline => "subprocess-python-baseline",
         }
+    }
+
+    /// Whether this arm runs its callback inside the harness's own interpreter.
+    /// The subprocess arm does not, so registering a callback for it, or
+    /// installing a GC recorder in this process, would measure nothing.
+    pub fn runs_the_callback_in_the_harness_interpreter(self) -> bool {
+        matches!(self, MeasurementArm::InProcessPython)
     }
 }
 
@@ -67,6 +108,12 @@ pub struct TierAMeasurementCellSpecification {
     /// payload sweep and must never back a gated number.
     #[serde(default)]
     pub wire_payload_mode: SyntheticFrameWirePayloadMode,
+    /// Quiet period before the source's first frame, so a slow-starting arm is
+    /// measured from a quiescent graph rather than through its own startup
+    /// backlog. Identical across arms — it is a property of the cell, not of
+    /// the arm, or the arms would not be comparable.
+    #[serde(default)]
+    pub startup_settle_seconds: f64,
     pub cell_duration_seconds: u64,
     pub warmup_exclusion_seconds: u64,
     pub python_callback_registration_token: String,
@@ -129,6 +176,11 @@ pub struct TierAMeasurementCellOutcome {
     /// reported percentiles are clipped and the cell must be rerun with a wider
     /// range, not interpreted.
     pub histogram_range_saturation_count: u64,
+    /// How far the cell's latency fell from its first measured decile to its
+    /// last. Materially positive means the cell spent its life draining a
+    /// startup backlog and its percentiles describe queue occupancy, not
+    /// latency — see [`LatencyMeasurementRecorder::backlog_drain_fraction`].
+    pub backlog_drain_fraction: f64,
     pub rolling_one_second_frame_rate_windows: Vec<f64>,
 }
 
@@ -166,6 +218,7 @@ pub fn run_tier_a_measurement_cell(
             channel_count: specification.channel_count,
             target_frames_per_second: specification.target_frames_per_second,
             wire_payload_mode: specification.wire_payload_mode,
+            startup_settle_seconds: specification.startup_settle_seconds,
         },
     )?;
 
@@ -192,6 +245,21 @@ pub fn run_tier_a_measurement_cell(
                     wire_payload_mode: specification.wire_payload_mode,
                 },
             )?,
+        // `add`, not `add_local`: this arm exists to exercise the package +
+        // compiler language-dispatch path that spawns a Python subprocess
+        // (`spawn_python_native_subprocess_op.rs`), which is exactly what the
+        // in-process arm proposes to replace.
+        MeasurementArm::SubprocessPythonBaseline => app.add(
+            subprocess_baseline_stage_type_reference()?,
+            serde_json::json!({
+                "frame_width_pixels": specification.frame_width_pixels,
+                "frame_height_pixels": specification.frame_height_pixels,
+                "channel_count": specification.channel_count,
+                "wire_payload_mode": specification.wire_payload_mode,
+                "stage_callback_module": SPIKE_STAGE_CALLBACK_MODULE,
+                "stage_callback_attribute": specification.stage_callback_attribute,
+            }),
+        )?,
     };
 
     let sink = app.add_local::<MeasuringSinkProcessor::Processor>(MeasuringSinkConfiguration {})?;
@@ -240,6 +308,7 @@ pub fn run_tier_a_measurement_cell(
         dropped_frame_count: recorder.dropped_frame_count(),
         negative_latency_anomaly_count: recorder.negative_latency_anomaly_count(),
         histogram_range_saturation_count: recorder.histogram_range_saturation_count(),
+        backlog_drain_fraction: recorder.backlog_drain_fraction(),
         rolling_one_second_frame_rate_windows: recorder.rolling_one_second_frame_rate_windows(),
     };
 
@@ -275,6 +344,7 @@ mod tests {
             channel_count: 4,
             target_frames_per_second: 60,
             wire_payload_mode: SyntheticFrameWirePayloadMode::SurfaceReference,
+            startup_settle_seconds: 2.0,
             cell_duration_seconds: 600,
             warmup_exclusion_seconds: 60,
             python_callback_registration_token: "cell-token".to_string(),
@@ -420,6 +490,7 @@ mod cell_directory_collision_tests {
             channel_count: 4,
             target_frames_per_second: 30,
             wire_payload_mode: SyntheticFrameWirePayloadMode::SurfaceReference,
+            startup_settle_seconds: 2.0,
             cell_duration_seconds: 600,
             warmup_exclusion_seconds: 60,
             python_callback_registration_token: "token".to_string(),

--- a/spikes/streamlib-pyembed-spike/src/tier_a_measurement_cell.rs
+++ b/spikes/streamlib-pyembed-spike/src/tier_a_measurement_cell.rs
@@ -30,6 +30,7 @@ use crate::rust_passthrough_floor_stage_processor::{
 use crate::synthetic_frame_source_processor::{
     SyntheticFrameSourceConfiguration, SyntheticFrameSourceProcessor,
 };
+use crate::synthetic_frame_wire_payload_mode::SyntheticFrameWirePayloadMode;
 
 /// Which of the two Rust-side comparison arms a cell runs. The third arm, the
 /// subprocess baseline, is driven from `python/runner.py`.
@@ -61,6 +62,11 @@ pub struct TierAMeasurementCellSpecification {
     pub frame_height_pixels: u32,
     pub channel_count: u32,
     pub target_frames_per_second: u32,
+    /// What crossed the link. Owner decision 7 makes `surface-reference` the
+    /// protocol mode; a `full-pixel-payload` cell measures the retracted
+    /// payload sweep and must never back a gated number.
+    #[serde(default)]
+    pub wire_payload_mode: SyntheticFrameWirePayloadMode,
     pub cell_duration_seconds: u64,
     pub warmup_exclusion_seconds: u64,
     pub python_callback_registration_token: String,
@@ -87,9 +93,12 @@ impl TierAMeasurementCellSpecification {
     /// rates, and repetitions.
     pub fn artifact_directory_name(&self) -> String {
         format!(
-            "arm-{}__fps-{:03}__stage-{}__gil-anchor-{}__rep-{:02}",
+            "arm-{}__{:04}x{:04}__fps-{:03}__wire-{}__stage-{}__gil-anchor-{}__rep-{:02}",
             self.arm.as_artifact_token(),
+            self.frame_width_pixels,
+            self.frame_height_pixels,
             self.target_frames_per_second,
+            self.wire_payload_mode.as_artifact_token(),
             self.stage_callback_attribute,
             if self.anchor_processor_thread_gil {
                 "on"
@@ -156,6 +165,7 @@ pub fn run_tier_a_measurement_cell(
             frame_height_pixels: specification.frame_height_pixels,
             channel_count: specification.channel_count,
             target_frames_per_second: specification.target_frames_per_second,
+            wire_payload_mode: specification.wire_payload_mode,
         },
     )?;
 
@@ -170,6 +180,7 @@ pub fn run_tier_a_measurement_cell(
                         .python_callback_registration_token
                         .clone(),
                     anchor_processor_thread_gil: specification.anchor_processor_thread_gil,
+                    wire_payload_mode: specification.wire_payload_mode,
                 },
             )?,
         MeasurementArm::RustPassthroughFloor => app
@@ -178,6 +189,7 @@ pub fn run_tier_a_measurement_cell(
                     frame_width_pixels: specification.frame_width_pixels,
                     frame_height_pixels: specification.frame_height_pixels,
                     channel_count: specification.channel_count,
+                    wire_payload_mode: specification.wire_payload_mode,
                 },
             )?,
     };
@@ -262,6 +274,7 @@ mod tests {
             frame_height_pixels: 1080,
             channel_count: 4,
             target_frames_per_second: 60,
+            wire_payload_mode: SyntheticFrameWirePayloadMode::SurfaceReference,
             cell_duration_seconds: 600,
             warmup_exclusion_seconds: 60,
             python_callback_registration_token: "cell-token".to_string(),
@@ -282,7 +295,8 @@ mod tests {
         let name = example_specification().artifact_directory_name();
         assert_eq!(
             name,
-            "arm-in-process-python__fps-060__stage-passthrough_stage__gil-anchor-on__rep-03"
+            "arm-in-process-python__1920x1080__fps-060__wire-surface-reference__\
+             stage-passthrough_stage__gil-anchor-on__rep-03"
         );
 
         let floor_arm = TierAMeasurementCellSpecification {
@@ -290,6 +304,50 @@ mod tests {
             ..example_specification()
         };
         assert_ne!(floor_arm.artifact_directory_name(), name);
+    }
+
+    /// The amended matrix runs 720p and 1080p at both rates. Before geometry
+    /// entered the directory name, a 720p60 cell and a 1080p60 cell that agreed
+    /// on every other dimension shared a directory and the second silently
+    /// overwrote the first — losing half the resolution leg with no error.
+    #[test]
+    fn cells_differing_only_by_frame_geometry_get_distinct_directories() {
+        let ten_eighty = example_specification();
+        let seven_twenty = TierAMeasurementCellSpecification {
+            frame_width_pixels: 1280,
+            frame_height_pixels: 720,
+            ..example_specification()
+        };
+        assert_ne!(
+            seven_twenty.artifact_directory_name(),
+            ten_eighty.artifact_directory_name()
+        );
+    }
+
+    /// A surface-reference cell and a full-pixel cell measure different
+    /// phenomena at the same geometry; sharing a directory would let the
+    /// retracted payload sweep overwrite a gated cell.
+    #[test]
+    fn cells_differing_only_by_wire_payload_mode_get_distinct_directories() {
+        let reference = example_specification();
+        let full_pixels = TierAMeasurementCellSpecification {
+            wire_payload_mode: SyntheticFrameWirePayloadMode::FullPixelPayload,
+            ..example_specification()
+        };
+        assert_ne!(
+            reference.artifact_directory_name(),
+            full_pixels.artifact_directory_name()
+        );
+    }
+
+    /// Owner decision 7 rides the artifact: a summarizer reading a cell must be
+    /// able to tell a protocol cell from a payload-sweep cell without guessing.
+    #[test]
+    fn the_recorded_wire_payload_mode_defaults_to_surface_reference() {
+        assert_eq!(
+            example_specification().wire_payload_mode,
+            SyntheticFrameWirePayloadMode::SurfaceReference
+        );
     }
 
     /// Zero-padding keeps 30fps sorting before 60fps and rep-02 before rep-10 in
@@ -361,6 +419,7 @@ mod cell_directory_collision_tests {
             frame_height_pixels: 720,
             channel_count: 4,
             target_frames_per_second: 30,
+            wire_payload_mode: SyntheticFrameWirePayloadMode::SurfaceReference,
             cell_duration_seconds: 600,
             warmup_exclusion_seconds: 60,
             python_callback_registration_token: "token".to_string(),

--- a/spikes/streamlib-pyembed-spike/subprocess_baseline_package/pyembed_subprocess_baseline_stage.py
+++ b/spikes/streamlib-pyembed-spike/subprocess_baseline_package/pyembed_subprocess_baseline_stage.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""The #1702 baseline arm: the spike's stage callback, hosted in a subprocess.
+
+Byte-for-byte the same work the in-process arm does per frame — read the
+payload, hand a numpy view of the frame's pixels to the same callable from
+``spike_stage_callbacks``, patch the stage duration into the measurement
+preamble, write the payload on. Everything that differs is the hosting: a
+separate process, a per-package venv, and the payload crossing iceoryx2 through
+the python-native cdylib rather than staying in one address space.
+
+Two deliberate departures from the SDK's public surface, both in service of
+measuring the same quantity as the in-process arm:
+
+* ``inputs._read_raw`` / ``slpn_output_write`` are used directly instead of
+  ``inputs.read`` / ``outputs.write``. The public pair msgpack-encodes and
+  decodes, which the in-process arm's ``read_raw``/``write_raw`` do not — the
+  encode would land inside the measured span and show up as PyO3 winning.
+* The pixels the callback views come from a process-local buffer allocated at
+  setup, exactly as on the in-process arm. A real subprocess would pay a
+  cpu-readback escalate round trip to reach a GPU surface's pixels, so this
+  biases the comparison *toward* the baseline. That direction is the safe one:
+  a GO decided against a conservatively-fast baseline is still a GO.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import importlib
+import struct
+import time
+
+# Mirrors `synthetic_frame_measurement_preamble.rs`: little-endian, packed,
+# u64 sequence number, i64 source emit stamp, i64 stage callback duration.
+MEASUREMENT_PREAMBLE_BYTES = 24
+STAGE_CALLBACK_NANOSECONDS_OFFSET = 16
+
+DEFAULT_STAGE_CALLBACK_MODULE = "spike_stage_callbacks"
+DEFAULT_STAGE_CALLBACK_ATTRIBUTE = "passthrough_stage"
+
+
+class PyembedSubprocessBaselineStage:
+    """Reactive stage that runs the spike callback once per frame."""
+
+    def setup(self, ctx) -> None:
+        import numpy
+
+        config = ctx.config
+        self._frame_width_pixels = int(config.get("frame_width_pixels", 1920))
+        self._frame_height_pixels = int(config.get("frame_height_pixels", 1080))
+        self._channel_count = int(config.get("channel_count", 4))
+        self._wire_payload_mode = str(
+            config.get("wire_payload_mode", "surface-reference")
+        )
+
+        module_name = str(
+            config.get("stage_callback_module", DEFAULT_STAGE_CALLBACK_MODULE)
+        )
+        attribute_name = str(
+            config.get("stage_callback_attribute", DEFAULT_STAGE_CALLBACK_ATTRIBUTE)
+        )
+        self._stage_callback = getattr(
+            importlib.import_module(module_name), attribute_name
+        )
+
+        pixel_byte_count = (
+            self._frame_width_pixels * self._frame_height_pixels * self._channel_count
+        )
+        # Same non-uniform fill the in-process arm's locally resolved surface
+        # carries, so a callback that inspects content sees identical input.
+        pattern = bytes((index % 251) for index in range(251))
+        repeats = pixel_byte_count // len(pattern) + 1
+        self._locally_resolved_surface_pixels = numpy.frombuffer(
+            (pattern * repeats)[:pixel_byte_count], dtype=numpy.uint8
+        ).reshape(
+            self._frame_height_pixels, self._frame_width_pixels, self._channel_count
+        ).copy()
+
+        self._observed_frame_count = 0
+
+    def process(self, ctx) -> None:
+        import numpy
+
+        frame_payload, frame_timestamp_ns = ctx.inputs._read_raw("frame_in")
+        if frame_payload is None:
+            return
+        if len(frame_payload) <= MEASUREMENT_PREAMBLE_BYTES:
+            raise ValueError(
+                f"frame payload of {len(frame_payload)} bytes carries nothing after "
+                "the measurement preamble"
+            )
+
+        if self._wire_payload_mode == "full-pixel-payload":
+            frame_view = numpy.frombuffer(
+                frame_payload, dtype=numpy.uint8, offset=MEASUREMENT_PREAMBLE_BYTES
+            ).reshape(
+                self._frame_height_pixels,
+                self._frame_width_pixels,
+                self._channel_count,
+            )
+        else:
+            frame_view = self._locally_resolved_surface_pixels
+
+        callback_started_ns = time.monotonic_ns()
+        self._stage_callback(frame_view)
+        callback_finished_ns = time.monotonic_ns()
+
+        outgoing = bytearray(frame_payload)
+        struct.pack_into(
+            "<q",
+            outgoing,
+            STAGE_CALLBACK_NANOSECONDS_OFFSET,
+            callback_finished_ns - callback_started_ns,
+        )
+        _write_raw_payload(ctx, "frame_out", bytes(outgoing), frame_timestamp_ns)
+        self._observed_frame_count += 1
+
+    def teardown(self, ctx) -> None:
+        from streamlib import log
+
+        log.info(
+            "subprocess baseline stage complete",
+            observed_frame_count=self._observed_frame_count,
+        )
+
+
+def _write_raw_payload(ctx, port_name: str, payload: bytes, timestamp_ns: int) -> None:
+    """Publish `payload` verbatim, bypassing the SDK's msgpack encode.
+
+    ``NativeOutputs.write`` packs its argument; the in-process arm's
+    ``write_raw`` does not. Going straight to the same FFI entry point the SDK
+    itself calls is what keeps the two arms symmetric.
+    """
+    outputs = ctx.outputs
+    buffer = (ctypes.c_uint8 * len(payload)).from_buffer_copy(payload)
+    result = outputs._lib.slpn_output_write(
+        outputs._ctx_ptr,
+        port_name.encode("utf-8"),
+        ctypes.cast(buffer, ctypes.c_void_p),
+        len(payload),
+        timestamp_ns,
+    )
+    if result != 0:
+        raise RuntimeError(
+            f"slpn_output_write refused a {len(payload)}-byte payload on "
+            f"'{port_name}' with code {result}"
+        )

--- a/spikes/streamlib-pyembed-spike/subprocess_baseline_package/pyembed_subprocess_baseline_stage.py
+++ b/spikes/streamlib-pyembed-spike/subprocess_baseline_package/pyembed_subprocess_baseline_stage.py
@@ -3,25 +3,33 @@
 
 """The #1702 baseline arm: the spike's stage callback, hosted in a subprocess.
 
-Byte-for-byte the same work the in-process arm does per frame — read the
-payload, hand a numpy view of the frame's pixels to the same callable from
+The same shape of work the in-process arm does per frame — read the payload,
+hand a numpy view of the frame's pixels to the same callable from
 ``spike_stage_callbacks``, patch the stage duration into the measurement
-preamble, write the payload on. Everything that differs is the hosting: a
+preamble, write the payload on — hosted the way today's model hosts it: a
 separate process, a per-package venv, and the payload crossing iceoryx2 through
 the python-native cdylib rather than staying in one address space.
 
-Two deliberate departures from the SDK's public surface, both in service of
-measuring the same quantity as the in-process arm:
+Two departures from the SDK's public surface, both taken so the two arms measure
+the same quantity:
 
 * ``inputs._read_raw`` / ``slpn_output_write`` are used directly instead of
   ``inputs.read`` / ``outputs.write``. The public pair msgpack-encodes and
   decodes, which the in-process arm's ``read_raw``/``write_raw`` do not — the
   encode would land inside the measured span and show up as PyO3 winning.
 * The pixels the callback views come from a process-local buffer allocated at
-  setup, exactly as on the in-process arm. A real subprocess would pay a
-  cpu-readback escalate round trip to reach a GPU surface's pixels, so this
-  biases the comparison *toward* the baseline. That direction is the safe one:
-  a GO decided against a conservatively-fast baseline is still a GO.
+  setup, exactly as on the in-process arm.
+
+The per-frame work is NOT byte-for-byte identical across the arms, and the
+residual asymmetries pull in both directions. Against the in-process arm: it
+builds a fresh numpy array per frame and runs a refcount escape check, neither
+of which this stage does (it reuses one array from setup). Against this arm: it
+makes three payload copies per frame (``bytearray``, ``bytes``, and
+``from_buffer_copy``) and drains a lifecycle queue, none of which the in-process
+arm has. Separately, a real subprocess would pay a cpu-readback escalate round
+trip to reach a GPU surface's pixels, which this stage does not — that one
+biases *toward* the baseline, which is the safe direction: a GO decided against
+a conservatively-fast baseline is still a GO.
 """
 
 from __future__ import annotations
@@ -38,6 +46,13 @@ STAGE_CALLBACK_NANOSECONDS_OFFSET = 16
 
 DEFAULT_STAGE_CALLBACK_MODULE = "spike_stage_callbacks"
 DEFAULT_STAGE_CALLBACK_ATTRIBUTE = "passthrough_stage"
+
+# Both arrive in the config from the Rust side rather than being re-typed here.
+# The pattern modulus is load-bearing: both Python arms must hand the callback
+# identical bytes, or the arm comparison stops comparing like with like. The
+# fallbacks exist only so a hand-written config still runs.
+DEFAULT_SYNTHETIC_PIXEL_PATTERN_MODULUS = 251
+DEFAULT_SURFACE_REFERENCE_BODY_BYTES = 192
 
 
 class PyembedSubprocessBaselineStage:
@@ -64,12 +79,24 @@ class PyembedSubprocessBaselineStage:
             importlib.import_module(module_name), attribute_name
         )
 
+        self._surface_reference_body_bytes = int(
+            config.get(
+                "surface_reference_body_bytes", DEFAULT_SURFACE_REFERENCE_BODY_BYTES
+            )
+        )
+        pattern_modulus = int(
+            config.get(
+                "synthetic_pixel_pattern_modulus",
+                DEFAULT_SYNTHETIC_PIXEL_PATTERN_MODULUS,
+            )
+        )
+
         pixel_byte_count = (
             self._frame_width_pixels * self._frame_height_pixels * self._channel_count
         )
         # Same non-uniform fill the in-process arm's locally resolved surface
         # carries, so a callback that inspects content sees identical input.
-        pattern = bytes((index % 251) for index in range(251))
+        pattern = bytes((index % pattern_modulus) for index in range(pattern_modulus))
         repeats = pixel_byte_count // len(pattern) + 1
         self._locally_resolved_surface_pixels = numpy.frombuffer(
             (pattern * repeats)[:pixel_byte_count], dtype=numpy.uint8
@@ -77,6 +104,13 @@ class PyembedSubprocessBaselineStage:
             self._frame_height_pixels, self._frame_width_pixels, self._channel_count
         ).copy()
 
+        # Resolved at setup, never per frame: the guard below runs on the hot
+        # path and `.tobytes()` there would allocate a full picture every frame.
+        self._expected_wire_body_byte_count = (
+            pixel_byte_count
+            if self._wire_payload_mode == "full-pixel-payload"
+            else self._surface_reference_body_bytes
+        )
         self._observed_frame_count = 0
 
     def process(self, ctx) -> None:
@@ -85,10 +119,13 @@ class PyembedSubprocessBaselineStage:
         frame_payload, frame_timestamp_ns = ctx.inputs._read_raw("frame_in")
         if frame_payload is None:
             return
-        if len(frame_payload) <= MEASUREMENT_PREAMBLE_BYTES:
+        wire_body_byte_count = len(frame_payload) - MEASUREMENT_PREAMBLE_BYTES
+        if wire_body_byte_count != self._expected_wire_body_byte_count:
             raise ValueError(
-                f"frame payload of {len(frame_payload)} bytes carries nothing after "
-                "the measurement preamble"
+                f"stage is configured for {self._wire_payload_mode!r} and expects a "
+                f"{self._expected_wire_body_byte_count}-byte wire body, but "
+                f"{wire_body_byte_count} bytes arrived — the source and stage "
+                "disagree about the wire payload mode"
             )
 
         if self._wire_payload_mode == "full-pixel-payload":

--- a/spikes/streamlib-pyembed-spike/subprocess_baseline_package/pyproject.toml
+++ b/spikes/streamlib-pyembed-spike/subprocess_baseline_package/pyproject.toml
@@ -1,0 +1,29 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# `streamlib` carries no version bound and resolves from no index. The
+# provisioning step (`python/provision_subprocess_baseline_package.py`) injects
+# a `[tool.uv.sources]` path override at this checkout's Python SDK before the
+# build orchestrator provisions the venv — the same rewrite
+# `streamlib link --engine` performs (`python_venv.rs:360-393`), scoped to this
+# package instead of the whole tree so a measurement run never depends on, or
+# disturbs, global link state.
+
+[project]
+name = "pyembed-subprocess-baseline"
+version = "0.1.0"
+description = "Subprocess baseline arm for the #1702 in-process Python go/no-go spike"
+requires-python = ">=3.10"
+dependencies = [
+    "streamlib",
+    "iceoryx2>=0.8.1",
+    "msgpack>=1.0",
+    "numpy>=1.24.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/spikes/streamlib-pyembed-spike/subprocess_baseline_package/streamlib.yaml
+++ b/spikes/streamlib-pyembed-spike/subprocess_baseline_package/streamlib.yaml
@@ -1,0 +1,33 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# The #1702 subprocess baseline arm: the same stage the in-process arm runs,
+# hosted the way today's model hosts a Python processor — its own process, its
+# own venv, frames crossing iceoryx2 through the python-native cdylib.
+#
+# Ports are `any` so the payload stays the spike's opaque preamble + body and no
+# msgpack encode/decode enters the measured path. That matches the in-process
+# arm's `write_raw`/`read_raw`, which is the only way the two arms measure the
+# same quantity.
+
+package:
+  org: spike
+  name: pyembed-subprocess-baseline
+  version: 0.1.0
+  description: 'Subprocess baseline arm for the #1702 in-process Python go/no-go spike'
+
+processors:
+- name: PyembedSubprocessBaselineStage
+  description: 'Runs the spike stage callback in a subprocess-hosted Python processor — the arm the in-process arm is measured against'
+  runtime: python
+  entrypoint: pyembed_subprocess_baseline_stage:PyembedSubprocessBaselineStage
+  execution: reactive
+  config: null
+  state: []
+  inputs:
+  - name: frame_in
+    schema: any
+    delivery_profile: every_sample
+  outputs:
+  - name: frame_out
+    schema: any

--- a/spikes/streamlib-pyembed-spike/subprocess_baseline_package/streamlib.yaml
+++ b/spikes/streamlib-pyembed-spike/subprocess_baseline_package/streamlib.yaml
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
+# yaml-language-server: $schema=../../../schemas/streamlib.schema.json
 #
 # The #1702 subprocess baseline arm: the same stage the in-process arm runs,
 # hosted the way today's model hosts a Python processor — its own process, its


### PR DESCRIPTION
> [!CAUTION]
> **RETRACTED (2026-08-06, `in-process-hosting-ripout`).** The in-process latency measurements below — the `0.085ms` / `0.161ms` p50 pair, every ratio derived from them, any "fraction of a frame budget" phrasing (including "0.6% of a frame budget"), and the directional claim that in-process was never worse than subprocess — are **retracted as placement evidence and must not be cited**. The two Python arms were later found to have been built against different CPython builds (`32ef370b`) and were never re-measured on equal builds, and the `/artifacts` directory behind every published table was gitignored, so none of it is auditable. The placement decision is helper-process-only (ADR `docs/decisions/helper-process-placement-only.md`, owner 2026-08-04), made on isolation grounds that never rested on these numbers. The spike tree is deleted; the deletion commit carries this retraction, and the warm-restart exec-to-first-frame metric definition (the one unretracted measurement) is lifted into #1714. The original text is preserved below, unedited, for the record.

## Summary

Stacked on #1703 (`spike/1702-pyembed-tier-a`) — review this against that branch, not `main`.

Completes the measurement apparatus for #1702: **all three arms**, the warm-restart battery, and
the gate evaluator. **Zero files outside `spikes/streamlib-pyembed-spike/`.**

This PR does **not** deliver the protocol numbers or the verdict. No 10-minute cells, no soak, no
GC-tuned cells, no Tier B rig work — those are the next PR in the stack.

### The three-arm comparison

720p60, passthrough, 15s cells, surface references, both Python arms on CPython 3.12.3 / numpy 2.4.4:

| arm | p50 | p99 | p99.9 |
|---|---|---|---|
| rust-passthrough-floor | 0.079ms | 0.108ms | 0.116ms |
| in-process-python | 0.085ms | 0.127ms | 0.155ms |
| subprocess-python-baseline | 0.161ms | 0.234ms | 0.302ms |

In-process beats today's model ~2x at p50 and p99; PyO3 costs single-digit microseconds over the
pure-Rust floor. **These are exploratory cells on a shared box, not protocol runs** — a reviewer's
independent runs reproduced the p50 ordering and ratios but measured tails 25-35x higher under
load. Treat every tail figure here as indicative only.

### Owner decision 7, and the retraction it settles

The synthetic source now puts a fixed-width surface reference on the wire; the pixels the callback
views are resolved process-locally, standing in for `GpuContext::resolve_pixel_buffer_by_surface_id`
(`gpu_context.rs:681`), which an in-process processor already reaches with no engine change. At
1080p60 the two modes differ **175x** (0.091ms vs 15.917ms), which closes out finding 8 with
evidence on the branch rather than by assertion. `--wire-payload-mode full-pixel-payload` keeps the
retracted sweep reproducible and the summarizer refuses to let such a cell back any gate.

### Gate status

Gates 1, 2, 4a and 5 pass. Gate 6 passes (warm restart median **0.863s** against 1.5s).
**Gates 3 and floor-delta cannot be evaluated at all** — see Notes.

## Closes

Closes nothing — #1702 stays open until the verdict is posted after the rig matrix.

## Exit criteria

- [x] Subprocess baseline arm, entering through `App::add` so it exercises the real
      language-dispatch/spawn path.
- [x] Warm-restart battery (gate 6), measured and passing.
- [x] Gate evaluator that refuses what it cannot honestly judge.
- [x] Reference-sized frames (owner decision 7).
- [ ] Tier B rig cells, protocol matrix, verdict — next PR.

## Test plan

- `cargo test --release` → **88 pass**; `--features stamping-compiled-out` → **66 pass**.
- `cargo clippy --all-targets --release` → clean under **both** feature configurations.
- `python3 -m unittest discover -s python` → **40 pass**.
- `cargo xtask check-manifest-schema` → green (115 manifests).
- Three review rounds (`review-pr` ×3, `rust-craftsmanship-reviewer`, `local-ci-runner`). Final
  verdict APPROVE, with every fix re-derived from a from-scratch re-provision and live cell runs
  rather than from commit messages.
- End-to-end on the rig: full A/B/A schedule in subprocess mode from an environment with
  `PYTHONPATH`, `STREAMLIB_MODULES_DIR` and `STREAMLIB_PYTHON_NATIVE_LIB` all unset.

## Notes for owner

**1. Two gates cannot be evaluated until you state a number.** Decision 3 made the floor-vs-PyO3
delta the gate; decision 4 added an absolute p99.9 ceiling. Neither names a threshold, and #1702
says thresholds are evaluated verbatim and never decided inline. Both quantities are computed and
printed; both stay `NOT EVALUATED` until `--floor-delta-gate-ms` / `--absolute-p99-9-ceiling-ms` are
passed. **These block the verdict, not this PR** — but they need answering before the rig matrix
burns hours producing numbers no gate can consume.

**2. Gate 6 measures the embed arrangement, not the one that would ship.** The battery restarts
`tier_a_harness`, a Rust binary embedding CPython — neither `streamlib dev` nor `python app.py`
importing a wheel. Ticket comment 9 raised this and no decision resolved it; a reviewer flagged it
independently. 0.863s is a **lower bound**.

**3. Three measurement defects were found by running the thing, not by reading it.** Each would have
produced a plausible number meaning something else. (a) A startup backlog made the baseline read
p50 183ms vs 0.089ms in-process — pure artifact, since `Runner::start()` returns before a Python
subprocess reaches its poll loop. (b) Without `STREAMLIB_PYTHON_NATIVE_LIB` the subprocess resolves
a *different* cdylib whose iceoryx2 constants disagree with the host's, and the cell reports an arm
that produced no frames — it only reproduces under the runner, because a hand-run cell inherits the
variable from the shell. (c) The two arms ran different CPython builds (3.12.3 Ubuntu/GCC vs 3.12.13
python-build-standalone/Clang) while a guard named `assert_arms_share_a_runtime` called them the
same. All three are fixed and guarded.

**4. The engine sheds frames rather than growing an unbounded queue.** A reviewer could not drive a
cell into the "latency grows" direction end-to-end: an overloaded 1080p cell at 600fps dropped 2631
frames with a plateaued p50 instead. So the saturation direction is a transient-queue case in
practice, and the p50-vs-frame-period ceiling is what actually catches overload. Worth knowing when
reading the gate.

**5. Cross-arm runtime parity is proven at provisioning time, not per cell.** Each arm records its
own runtime into `machine-spec.json`, and they agree byte-for-byte on this rig, but the summarizer
does not cross-check them across a matrix. Your call whether that becomes an admissibility check.

**6. The residual per-frame asymmetries between the Python arms pull both ways** and are enumerated
in the baseline stage's docstring: in-process builds a fresh numpy array and runs a refcount escape
check per frame; the subprocess arm makes three payload copies and drains a lifecycle queue. The
process-local pixel source also makes the baseline faster than any real subprocess, which would pay
a cpu-readback round trip — that bias is conservative, and a GO against a conservatively-fast
baseline is still a GO.

**7. Engine finding, unchanged and unfixed here** (owner decision 6): `read_raw` allocates a 64 KiB
buffer, finds the frame does not fit, discards it and reallocates, every frame per hop
(`plugin-abi/src/vtables/input_mailboxes.rs:156-157`). Recorded as worth its own ticket.

**8. `polyglot-manual-source` could not be reused as the baseline fixture**, contrary to the earlier
handoff: it is a *source* with no input port, and no cached package is a raw passthrough with `any`
ports. The spike authors its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

