### PR TITLE
plan: importable Python library — the SDK-shape pivot

### DIFF
--- a/docs/decisions/control-plane-one-surface.md
+++ b/docs/decisions/control-plane-one-surface.md
@@ -34,8 +34,14 @@ Auth and remote-access posture remain OPEN — nothing here decides a security m
 - **A second control path** (bespoke CLI socket, side-channel debug API) — two
   vocabularies drift; agents and humans stop seeing the same system.
 - **api-server as a distributable package** — it drives the registry, pubsub, and the
-  graph API; a host cannot cross the plugin ABI, and its current home made it a standing
-  exception to "packages are downstream consumers."
+  graph API; ~~a host cannot cross the plugin ABI, and its current home made it a
+  standing exception to "packages are downstream consumers."~~ — Rationale updated
+  2026-08-02 by `importable-python-library.md` (the plugin ABI and packages doctrine
+  are deleted): the api-server is statically-linked engine infrastructure hosted by
+  the wheel and the `streamlib` crate; the relocation into `runtime/` stands and is a
+  sequencing prerequisite of the rip-out. Its mutation verbs (submit / replace /
+  connect / remove) and their MCP tools are removed — the vocabulary is
+  observation-shaped.
 - **A discovery daemon or well-known port** — files in the per-user runtime directory
   need no daemon, survive nothing they shouldn't, and prune safely on double-dead
   evidence.

--- a/docs/decisions/dependency-reconciliation.md
+++ b/docs/decisions/dependency-reconciliation.md
@@ -1,5 +1,10 @@
 # Dependency reconciliation at package publish
 
+> **Superseded 2026-08-02 by `importable-python-library.md`.** The pivot deletes `pkg
+> publish`, `streamlib-pack`, the `dependencies:`/`schemas:` manifest maps, `.slpkg`,
+> and the orchestrator staging this ADR reconciles — PyPI and cargo own dependency
+> resolution now. Kept for the historical record only.
+
 ## Trigger
 
 Reach for this when touching how a package's declared `dependencies:` relates to

--- a/docs/decisions/importable-python-library.md
+++ b/docs/decisions/importable-python-library.md
@@ -1,0 +1,121 @@
+# Importable Python library — the SDK-shape pivot
+
+Rationale for the `[importable-python-library]` entries across `docs/plan/ARCHITECTURE.md`,
+decided by the owner 2026-08-01, direction confirmed verbatim 2026-08-02. Supersedes parts of
+`single-binary-launch.md`, `media-io-layering.md`, and `product-mvp-sentence.md` (annotated
+in place).
+
+## Trigger
+
+Read this before reintroducing any custom distribution mechanism (module folders, install
+verbs, runtime downloading), before proposing a new dlopen/ABI extension path, before putting
+Python in a per-frame media path, or when someone asks why streamlib is a wheel and not a
+framework.
+
+## The direction, verbatim (owner-confirmed)
+
+1. StreamLib becomes an importable Python library: `pip install streamlib` delivers one PyO3
+   wheel containing the Python API and the Rust engine, and a StreamLib app is a normal Python
+   codebase — one uv-managed venv, one Python version, ordinary PyPI dependencies, no manifest,
+   no custom module system (`streamlib_modules/`, add/install/link/pkg, and runtime downloading
+   are deleted).
+2. Processors are Python classes — written in the app or imported from pip-installed packages —
+   and `rt.add` takes the class; whether the engine runs a processor in-process or in a helper
+   process spawned from that same interpreter and venv is an under-the-hood engine placement
+   decision, never a user-facing runtime definition.
+3. The plugin ABI is deleted entirely: third-party native code ships as ordinary Python packages
+   that expose handles (frames, FDs, device pointers) to a Python processor and never speak
+   streamlib internals, while first-party camera, display, and audio ship inside the wheel as
+   native pre-built blocks driven from Python by configuration.
+4. Python is the sole focus runtime: cross-language interop happens on the wire between mesh
+   nodes as self-describing bags — never in-graph — so the current Deno SDK is deleted with the
+   subprocess machinery it's built on, while TypeScript authoring is paused-not-rejected (a
+   future importable TypeScript SDK on this same model), and a Rust app remains a plain cargo
+   project on the `streamlib` crate.
+5. The CLI slims to `new` / `dev` / `run` as a thin runner plus the observation verbs
+   (`nodes` / `graph` / `tap` / `logs` / `mcp`); build orchestration, packaging, provisioning,
+   and codegen verbs are deleted — compilation happens at publish time with standard tools, and
+   JTD schemas are demoted to advisory, experimental type info behind a rip-out-cheap seam,
+   never a requirement for accessing data.
+
+## Why
+
+**The pain was never processes — it was environments.** What the framework shape forced was an
+interpreter zoo: per-processor venv provisioning, a custom module system (`streamlib_modules/`,
+`.slpkg`, install/link), runtime downloading, and compile-at-the-destination machinery
+(`BuildOrchestrator`). That was the community-hostile, bespoke layer. The ideal is one venv,
+uv, PyPI, one Python version, a codebase that feels like any normal Python app. Whether the
+engine places a processor in-process or in a helper process spawned from the same interpreter
+is an implementation detail — the measured gap (subprocess p50 0.161ms vs in-process 0.085ms at
+720p60) makes both placements viable, so placement is demoted from architecture to engine
+policy. Distribution, execution, and polyglot reach are three separable axes; the decision is
+about the first.
+
+**The plugin ABI's tenants all left.** First-party media bakes into the wheel; Python packages
+extend via CPython's own stable ABI (the numpy/pydantic-core model — compiled internals, no
+streamlib linkage); Rust apps compile processors from source. Of the ABI's 22 vtables, ~20
+existed only to let a dlopen'd plugin reach engine GPU primitives without sharing a Rust type —
+in one process those calls are ordinary Rust. The closed-source-vendor case is served by the
+Python-package path: native internals expose transferable handles (DMA-BUF FD, CUDA device
+pointer, buffers) and a Python processor wraps them. There is exactly one authoring surface,
+and one engine per process.
+
+**Native built-ins, Python everywhere else — the evidence.** Three independent analyses
+converged: (a) the engine's primitive surface is already handle-shaped — the old media packages
+crossed the ABI with fds, u64 handles, byte buffers, and POD, so the public interop contract
+costs nothing new; (b) with one shared interpreter, a vsync-paced present (`begin_frame` blocks
+up to a full refresh by design) or a device audio callback under the GIL stalls the entire
+Python plane — display and audio device loops must be native; camera is Python-viable only
+under a strict GIL-release discipline that does not yet exist in the SDK; (c) no surveyed
+in-process realtime system (Holoscan, GStreamer) runs Python per frame in first-party
+capture/present/audio — Python composes, native code moves frames; the one Python-media system
+(dora-rs) buys it with process-per-node isolation and still went native for codecs. Dogfooding
+favors shipping built-ins in the shape vendors are told to use — which the handle-shaped
+contract satisfies without putting Python in deadline paths.
+
+## Rejected alternatives
+
+- **Keep the framework + custom module system** — the bespoke distribution layer was the
+  fragility; every cited Python dev-tool win is an importable library, not an IoC runtime.
+- **In-process as dogma (kill subprocess machinery outright)** — conflates the execution axis
+  with the distribution axis; same-interpreter helper processes preserve isolation for
+  blocking-heavy processors at no DX cost. What dies is per-processor *environments*, not
+  processes.
+- **First-party media as Python processors ("eat our own cooking")** — disqualified for
+  display (vsync block under the GIL freezes every Python processor, every frame) and audio
+  (never-block-never-malloc vs GC and unbounded GIL waits); the dogfooding value is captured
+  instead by first-party Python transforms/effects and by the handle contract being the same
+  one built-ins use.
+- **Keep a narrow ABI for closed-source vendors** — resurrects the 22-vtable maintenance
+  surface for a user that does not exist; two engines in one process (a vendor wheel linking
+  its own streamlib) is silent breakage; the answer to engine-internal GPU access is a
+  conversation, not an ABI.
+- **Retire TypeScript permanently** — the hobbyist / video-creator audience keeps it alive as
+  a future target; what dies is the subprocess-polyglot substrate, and a future TS SDK is
+  importable-library-shaped. Paused, not rejected.
+- **JTD as the mesh contract** — codegen'd exact types were strong when we controlled
+  compilation; on a wire between nodes we don't compile, the self-describing bag is the
+  contract and cast-at-read already governs in-graph. JTD stays advisory and cheap to rip out
+  (possibly replaced by Arrow later).
+
+## Consequences
+
+- The largest deletion in the project's history: plugin ABI (all vtables, handshake,
+  fingerprints, layout tests), plugin-sdk cdylib arm, five `-abi` adapter crates, cdylib
+  flavors, `BuildOrchestrator` + build-on-place + cargo-build + pack + `.slpkg`, the
+  add/install/link/pkg/generate/schema/setup verbs, the Deno SDK and native cdylib, the
+  standalone runtime binary, `streamlib_modules/` and the package source. Rip-out is
+  inventoried by the pivot's change file, never kept running in parallel.
+- The wheel becomes the build product: maturin/CI, abi3 across a small Python version range,
+  camera/display statically linked. Our CI builds our wheel; nothing else is ever compiled by
+  streamlib.
+- First-party media moves *into* the engine tree; lag-by-design ends for built-ins.
+- The Python SDK grows a load-bearing GIL-release contract (zero `allow_threads` exists today);
+  the spike's latency numbers were measured with no blocking I/O in any callback and must not
+  be cited for Python-hosted display/audio.
+- One engine addition closes the display loop: a "present this surface (fit/fill,
+  color-managed)" composition call, so the display block is config + one call.
+- The interop adapters (Vulkan↔CUDA, Vulkan↔GL) survive minus their `-abi` halves; the
+  torch/cupy zero-copy story is the largest remaining technical risk, now explicit.
+- M39 is re-derived against this direction; the client-SDK/control-plane embedding story for
+  Python is superseded by in-process embedding via the wheel.

--- a/docs/decisions/importable-python-library.md
+++ b/docs/decisions/importable-python-library.md
@@ -108,7 +108,11 @@ contract satisfies without putting Python in deadline paths.
   inventoried by the pivot's change file, never kept running in parallel.
 - The wheel becomes the build product: maturin/CI, abi3 across a small Python version range,
   camera/display statically linked. Our CI builds our wheel; nothing else is ever compiled by
-  streamlib.
+  streamlib. Initial releases are repo-hosted wheel artifacts; PyPI publication is deferred
+  until the project rename (name reservation before then would burn the throwaway name).
+- Re-authoring the old packages and examples into the new shapes (built-ins absorption aside,
+  which is rip-out work) is deferred to its own planning sessions and milestones after the
+  wheel exists — dispositions are recorded in the pivot's change file, not ticketed now.
 - First-party media moves *into* the engine tree; lag-by-design ends for built-ins.
 - The Python SDK grows a load-bearing GIL-release contract (zero `allow_threads` exists today);
   the spike's latency numbers were measured with no blocking I/O in any callback and must not

--- a/docs/decisions/manifest-extraction-capability.md
+++ b/docs/decisions/manifest-extraction-capability.md
@@ -1,5 +1,13 @@
 # Manifest extraction as a shared source-scan capability
 
+> **Superseded 2026-08-02 by `importable-python-library.md`.** The pivot deletes the
+> `processors:` manifest, `streamlib-processor-extract`, `streamlib-pack`, `pkg
+> publish`, `.slpkg`, the Deno extractor, and `export_plugin!` — this ADR describes the
+> deleted world. Two things survive it: the `#[processor(...)]` attribute as the single
+> source of truth for a Rust processor's identity/mode/ports, and the requirement that
+> its grammar has exactly one parser — which must relocate out of the deleted
+> `streamlib_processor_extract` crate into a surviving home for `streamlib-macros`.
+
 ## Trigger
 
 Reach for this when touching how a package's `processors:` manifest section

--- a/docs/decisions/media-io-layering.md
+++ b/docs/decisions/media-io-layering.md
@@ -12,23 +12,29 @@ work.
 
 ## Decision
 
-The engine owns hardware primitives; media processors are packages. The primitives —
-DMA-BUF / OPAQUE_FD import and export, the present target, the audio clock, color
-resolution, codec sessions — live behind `GpuContext`, the RHI, and the ABI vtables,
-and packages reach them only across the plugin ABI. No media processor is
-engine-internal.
+> ~~The engine owns hardware primitives; media processors are packages. The primitives
+> live behind `GpuContext`, the RHI, and the ABI vtables, and packages reach them only
+> across the plugin ABI. No media processor is engine-internal.~~ — Superseded
+> 2026-08-02 by `importable-python-library.md`. The plugin ABI is deleted; first-party
+> camera, display, and audio are native built-in processors in the engine tree,
+> statically linked into the wheel. The *layering half* survives as internal
+> discipline: built-ins are written against the same handle-shaped primitives
+> (DMA-BUF / OPAQUE_FD, present target, audio clock, color resolution, codec sessions)
+> third parties get — never against private engine guts.
 
-First-party media packages lag by design while the engine moves, then upgrade to the
-current engine exactly once, as the final MVP step — the Next.js model: prove the
-runtime solid first, then bring consumers forward before release.
+> ~~First-party media packages lag by design while the engine moves, then upgrade to
+> the current engine exactly once, as the final MVP step.~~ — Superseded 2026-08-02 by
+> `importable-python-library.md`. Built-ins ship inside the wheel, current by
+> construction; lag-by-design ends for media.
 
 Capture is V4L2-only. Apple capture (AVFoundation) stays undesigned until a milestone
 traces to it; only the TCC permission shims exist.
 
-Windowing splits at the raw window handle: the package creates and owns the window;
-the engine mints the present target from the raw handle and keeps every swapchain and
-acquire detail host-side, plus the platform main-thread event loop where the OS
-demands it. Camera-to-GPU transport is zero-copy DMA-BUF import when the device
+Windowing splits at the raw window handle: ~~the package~~ the built-in display
+processor (since 2026-08-02, per `importable-python-library.md`) creates and owns the
+window; the engine mints the present target from the raw handle and keeps every
+swapchain and acquire detail host-side, plus the platform main-thread event loop where
+the OS demands it. Camera-to-GPU transport is zero-copy DMA-BUF import when the device
 exports it, with a transparent CPU-upload fallback chosen automatically — no
 configuration dial.
 
@@ -38,10 +44,12 @@ surface is the clock primitive.
 
 ## Rejected alternatives
 
-- **Engine-internal media processors** — breaks engine purity (the engine's own
-  manifest declares no domain packages), couples driver churn to engine releases, and
-  demotes the plugin ABI to a second-class path the moment first-party code bypasses
-  it.
+- ~~**Engine-internal media processors** — breaks engine purity, couples driver churn
+  to engine releases, and demotes the plugin ABI to a second-class path the moment
+  first-party code bypasses it.~~ — Superseded 2026-08-02 by
+  `importable-python-library.md`: this is now the chosen shape. The rejection rested
+  on the plugin ABI existing to be demoted; with the ABI deleted and media shipping
+  inside the wheel, the purity concern is met by the internal layering wall instead.
 - **Continuous lockstep upgrades of media packages** — churns consumers on every
   engine change before the design has settled; a single end-of-milestone upgrade
   proves the design once, against a stable runtime.
@@ -62,10 +70,13 @@ surface is the clock primitive.
 
 ## Consequences
 
-- MVP completion includes a final consumer-upgrade pass over the media packages and
-  the scaffold's effect chain — that pass is MVP work, not optional backlog.
-- Engine changes may break media packages mid-development; that is expected, not a
-  defect, and files no tickets.
-- The plugin ABI must carry every capability media processors need — there is no
-  side door, so a missing primitive is engine work, never an ABI bypass.
+- ~~MVP completion includes a final consumer-upgrade pass over the media packages and
+  the scaffold's effect chain.~~ — Superseded 2026-08-02: built-ins live in the engine
+  tree; there is no upgrade pass because there is no lag.
+- ~~Engine changes may break media packages mid-development; that is expected, not a
+  defect, and files no tickets.~~ — Superseded 2026-08-02: media built-ins move with
+  the engine in the same tree and the same PRs.
+- ~~The plugin ABI must carry every capability media processors need.~~ — Superseded
+  2026-08-02: the ABI is deleted; the equivalent discipline is that the handle-shaped
+  primitive surface must carry every capability *third-party* media bindings need.
 - Non-Linux capture waits, including for contributors on Apple hardware.

--- a/docs/decisions/media-io-layering.md
+++ b/docs/decisions/media-io-layering.md
@@ -59,8 +59,12 @@ surface is the clock primitive.
 - **Deciding AVFoundation capture now** — no MVP trace (the floor is Linux + NVIDIA);
   designing it without a driving consumer violates plan-first.
 - **Engine-owned windows** — drags winit event handling, input, and window policy into
-  the engine for one consumer's convenience; the raw-window-handle seam already gives
-  the engine everything the swapchain needs.
+  the engine *core* for one consumer's convenience; the raw-window-handle seam already
+  gives the engine everything the swapchain needs. — Scope narrowed 2026-08-02 by
+  `importable-python-library.md`: the built-in display block (engine tree, wheel) now
+  owns window creation and the event pump, but the raw-window-handle seam between
+  windowing code and the present target stands; the engine *core* still never owns
+  window policy.
 - **Zero-copy required (no CPU fallback)** — kills virtual and test devices (vivid,
   v4l2loopback) and any driver without DMA-BUF export; a user-visible transport dial
   would break the zero-ceremony bar.

--- a/docs/decisions/product-mvp-sentence.md
+++ b/docs/decisions/product-mvp-sentence.md
@@ -24,8 +24,10 @@ Its load-bearing terms:
 
 - **Python consumer.** Python vision/ML developers are the audience for realtime GPU
   pipelines without writing Vulkan.
-- **PyPI ships the single binary** (CLI + runtime + build orchestration) — the ruff/uv
-  pattern: one install, no toolchain, native motion for the persona.
+- ~~**PyPI ships the single binary** (CLI + runtime + build orchestration) — the
+  ruff/uv pattern.~~ — Superseded 2026-08-02 by `importable-python-library.md`. PyPI
+  ships one *wheel* — Python API + CLI + engine via PyO3, the pydantic-core pattern;
+  build orchestration is deleted. Still one install, no toolchain.
 - **Batteries-included scaffold.** `streamlib new` generates a *working* camera →
   effect → display app with dependencies already installed; first `streamlib dev` shows
   live video before any code is written; the user's first act is editing the scaffolded
@@ -35,16 +37,21 @@ Its load-bearing terms:
 - **`app.py` + `setup(rt)` by convention, `-f` override.** Matches what Python
   developers rely on (Flask defaults to `app.py`; FastAPI's `uvicorn main:app` is the
   explicit variant); the override keeps the point-at-a-script launch.
-- **Apps carry no manifest.** The npm model: `add`/`link` write `streamlib.lock`,
+- **Apps carry no manifest.** ~~The npm model: `add`/`link` write `streamlib.lock`,
   `streamlib_modules/` holds the installed set, and the identity label exists only
-  because a package is shared. An app promotes to a package by adding the label.
-- **App-local processors use the plugin discovery scan** on the app's `processors/`
-  folder, minted `@app/local/<Name>`. Two reference spellings resolve to one
-  registration: the string id, or the imported class — the decorated class carries its
-  identity; importing it in `app.py` attaches metadata only, execution stays in the
-  engine-spawned subprocess. The class form keeps go-to-definition and type checking
-  working, which is also what makes the loop agent-friendly (small `app.py`, one obvious
-  processor file, `graph`/`tap` to verify an edit landed).
+  because a package is shared. An app promotes to a package by adding the label.~~ —
+  Superseded 2026-08-02 by `importable-python-library.md`. Stronger now: the pip/uv
+  model, no streamlib-specific files at all — `pyproject.toml` and the venv are the
+  whole dependency story; a processor package is an ordinary PyPI package.
+- ~~**App-local processors use the plugin discovery scan** on the app's `processors/`
+  folder, minted `@app/local/<Name>`; execution stays in the engine-spawned
+  subprocess.~~ — Superseded 2026-08-02 by `importable-python-library.md`. App-local
+  processors are ordinary Python classes imported into `app.py`; `rt.add` takes the
+  class; no discovery scan, no minted ids, and execution placement (in-process or a
+  same-interpreter helper process) is the engine's decision. The surviving point: the
+  class form keeps go-to-definition and type checking working, which is what makes the
+  loop agent-friendly (small `app.py`, one obvious processor file, `graph`/`tap` to
+  verify an edit landed).
 - **`add`/`connect` is the pipeline API** — the existing primitive, explicit about
   ports.
 
@@ -76,7 +83,10 @@ Its load-bearing terms:
 - The zero-ceremony bar makes the schema-agreement rip-out (no engine schema matching,
   cast-at-read, no versions at the code layer) MVP-blocking work, not cleanup.
 - `streamlib new` (app scaffold) is a new command to design and build.
-- Existing Rust plugins port to the new format as the final step, so they install as
-  modules; consumer examples continue to lag by design until then.
+- ~~Existing Rust plugins port to the new format as the final step, so they install as
+  modules; consumer examples continue to lag by design until then.~~ — Superseded
+  2026-08-02 by `importable-python-library.md`: there is no plugin format to port to;
+  first-party media becomes engine-tree built-ins, and other plugin functionality is
+  re-authored as Python packages or cargo crates per the pivot's change file.
 - The MVP claim is narrow (one persona, one platform, one GPU vendor) and must be kept
   honest: widening any axis is a plan change, not a ticket.

--- a/docs/decisions/product-mvp-sentence.md
+++ b/docs/decisions/product-mvp-sentence.md
@@ -15,10 +15,15 @@ The MVP promises the **developer experience**, not the capability. Camera → pr
 display pipelines, shader/compute processors, and packages already exist and work; what
 does not exist is the simplified experience around them. The sentence:
 
-> A Python developer on Linux with an NVIDIA GPU installs streamlib from PyPI, runs
+> A Python developer on Linux with an NVIDIA GPU pip-installs streamlib, runs
 > `streamlib new` then `streamlib dev`, sees their camera live in a window within a
 > minute, and makes the pipeline theirs by editing the scaffolded processor — zero
-> ceremony: no manifest, no `main()`, no schema wrangling, hot-reload on save.
+> ceremony: no manifest, no `main()`, no schema wrangling, a fast edit loop.
+
+(Sentence updated 2026-08-02 by `importable-python-library`: "from PyPI" → pip-install
+from repo releases until the rename; "hot-reload on save" → "a fast edit loop" —
+re-running `dev` is the MVP loop; processor-granular reload-on-save is a nicety,
+never module machinery.)
 
 Its load-bearing terms:
 
@@ -71,9 +76,11 @@ Its load-bearing terms:
 - **Entry point named in a config file** — ceremony returning through the side door.
 - **Every app is also a package** — a consumer needs no publishable identity; forcing
   one re-creates the manifest ceremony being removed.
-- **Import-only or strings-only local processors** — import-only forks the discovery
-  model from plugins; strings-only loses IDE/agent ergonomics. One mechanism, two
-  spellings, costs neither.
+- ~~**Import-only or strings-only local processors** — import-only forks the discovery
+  model from plugins; strings-only loses IDE/agent ergonomics.~~ — Superseded
+  2026-08-02 by `importable-python-library.md`: import-only (class-form `rt.add`) IS
+  the decided shape; the discovery-scan model it would have "forked from" is deleted,
+  and IDE/agent ergonomics are what the class form provides.
 - **Higher-level pipeline API now** (chaining sugar, declarative graphs, or a
   Holoscan-style `compose()` subclass) — the subclass shape is *more* ceremony than
   `setup(rt)`; sugar remains compatible later where port inference is unambiguous.

--- a/docs/decisions/single-binary-launch.md
+++ b/docs/decisions/single-binary-launch.md
@@ -11,16 +11,25 @@ another application.
 
 ## Decision
 
-One shipped binary — `streamlib` — bundles the CLI, the runtime host, and build
-orchestration. `streamlib run` and `streamlib dev` host the runtime in-process (the
-Rust path compiles a generated-main harness around the user's entry; Python/TS entries
-run through the subprocess SDK bound to the control plane). The standalone
-streamlib-runtime binary retires.
+> ~~One shipped binary — `streamlib` — bundles the CLI, the runtime host, and build
+> orchestration. `streamlib run` and `streamlib dev` host the runtime in-process (the
+> Rust path compiles a generated-main harness around the user's entry; Python/TS entries
+> run through the subprocess SDK bound to the control plane).~~ — Superseded 2026-08-02
+> by `importable-python-library.md`. The shipped artifact is the PyPI wheel (Python API +
+> CLI + engine via PyO3); build orchestration is deleted entirely; Python entries run
+> in-process via the wheel, not through a subprocess SDK. The generated-main Rust harness
+> is dead — a Rust app is a plain cargo project.
 
-Embeddability is unaffected, because the binary is packaging, not architecture: the
-engine remains an ordinary embeddable Rust library that a host application (an
-Isaac-Sim-style app, a custom tool) links and drives in-process, and non-Rust hosts
-embed by driving a runtime through the client-SDK / control-plane path.
+The standalone streamlib-runtime binary retires. What survives of this decision: there
+is still exactly one CLI, `run`/`dev` still host the runtime in-process as a thin
+runner, and there is no version skew between "the CLI" and "the runtime" — both ship in
+the one wheel.
+
+> ~~Non-Rust hosts embed by driving a runtime through the client-SDK / control-plane
+> path.~~ — Superseded 2026-08-02 by `importable-python-library.md`. Exactly backwards
+> now: Python is the primary host and embeds the engine in-process by importing the
+> wheel. The control plane exists to observe and drive running nodes, not to embed.
+> Rust embedding is unchanged: the engine remains an ordinary embeddable library.
 
 ## Rejected alternatives
 

--- a/docs/decisions/single-binary-launch.md
+++ b/docs/decisions/single-binary-launch.md
@@ -41,9 +41,13 @@ the one wheel.
 
 ## Consequences
 
-- PyPI ships exactly one artifact; there is no version skew between "the CLI" and "the
-  runtime."
+- ~~PyPI ships exactly one artifact.~~ — Superseded 2026-08-02 by
+  `importable-python-library.md`: two artifacts, one version (wheel + `streamlib`
+  crate), repo-hosted until the rename. Still no version skew between "the CLI" and
+  "the runtime" — both live in the wheel.
 - Retiring the standalone runtime binary is engine-tree work to schedule; its
   boot/registry behaviors move into the CLI-hosted path.
-- The client SDK (launch + control from Python/TS) is a real surface the plan now
-  depends on for the embedding story.
+- ~~The client SDK (launch + control from Python/TS) is a real surface the plan now
+  depends on for the embedding story.~~ — Superseded 2026-08-02 by
+  `importable-python-library.md`: Python embeds by importing the wheel; the control
+  plane observes running nodes, it does not embed.

--- a/docs/plan/ARCHITECTURE.md
+++ b/docs/plan/ARCHITECTURE.md
@@ -15,7 +15,7 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   ordinary uv-managed venv, runs `streamlib new` then `streamlib dev`,
   sees their camera live in a window within a minute, and makes the pipeline theirs by
   editing the scaffolded processor — zero ceremony: no manifest, no `main()`, no schema
-  wrangling, hot-reload on save. Every ticket traces to this sentence or does not
+  wrangling, a fast edit loop. Every ticket traces to this sentence or does not
   exist. [importable-python-library]
 - **DECIDED** — Terms of the sentence: StreamLib is an importable Python library — one
   PyPI wheel carrying the Python API, the CLI, and the Rust engine (PyO3, the
@@ -54,10 +54,13 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   [importable-python-library]
 - **DECIDED** — The engine's handle-shaped primitive surface is the public contract
   for native interop: DMA-BUF / OPAQUE_FD import and export, the present target,
-  texture rings, codec byte pumps, the audio clock, color resolution. The
-  Vulkan↔CUDA and Vulkan↔GL interop adapters survive as in-process capabilities
-  (torch/cupy and GL consumers); only their cross-DSO `-abi` halves die with the
-  plugin ABI. [importable-python-library]
+  texture rings, codec byte pumps, the audio clock, color resolution — surfaced to
+  the Python ecosystem as DLPack and the CUDA Array Interface (DLPack first). The
+  contract is zero-CPU-copy, stated honestly: tiled engine textures reach a linear
+  tensor via one GPU blit into an exportable staging buffer, because DLPack expresses
+  strided linear memory only. The Vulkan↔CUDA and Vulkan↔GL interop adapters survive
+  as in-process capabilities (torch/cupy and GL consumers); only their cross-DSO
+  `-abi` halves die with the plugin ABI. [importable-python-library]
 
 ## Processor model & scheduling — IN-FLIGHT (→ schema-agreement-ripout, importable-python-library)
 
@@ -82,7 +85,15 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   run on). The engine chooses per processor; placement heuristics are engine
   implementation, not plan-level commitments. Same user code either way — no
   interpreter zoo, no per-processor environments, no placement configuration surface
-  beyond a single opt-in. [importable-python-library]
+  beyond a single opt-in. Constraints that make transparency true: helper spawn is
+  exec-of-`sys.executable`, never fork (GPU contexts are fork-unsafe); a
+  helper-placeable processor class must be import-addressable from a module whose
+  import is side-effect-safe; the engine equalizes link limits across placements or
+  refuses a transparent move it cannot honor. [importable-python-library]
+- **DECIDED** — The MVP edit loop is re-running `dev` (warm restart is sub-second by
+  construction). Reload-on-save is a nicety, not MVP-gating, and when built it is
+  processor-granular — stop the processor, re-import its class, re-instantiate,
+  rewire its ports — never module-loading machinery. [importable-python-library]
 - **DECIDED** — JTD schemas are advisory, experimental type information behind a
   rip-out-cheap seam — never a requirement for accessing data, in-graph or on the
   wire, and never baked in as fundamental (replaceable wholesale, e.g. by Arrow,
@@ -96,6 +107,10 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
 
 - **DECIDED** — All Vulkan lives in the RHI (`vulkan/rhi/` + `streamlib-consumer-rhi`); one
   kernel abstraction per pipeline kind; consumers go through `GpuContext` only.
+- **DECIDED** — The engine's kernel primitives are exposable to Python as configured
+  blocks: shader/compute source and binding config passed from Python, compiled and
+  executed by the engine on its device — no user-side Vulkan, ever. Shape only; the
+  Python-facing API design is its own session. [importable-python-library]
 - **OPEN** — Everything else.
 
 ## Media I/O — camera, display, audio — IN-FLIGHT (→ importable-python-library)
@@ -129,7 +144,9 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
 - **OPEN** — Audio backend: PipeWire-native on Linux is the intent (the current
   CPAL → ALSA path is interim); do not build until a research memo settles it. A/V
   sync model likewise OPEN. The engine's decided audio surface is the clock
-  primitive. [media-io-layering]
+  primitive. Hard constraint for the memo: the backend must be dlopen-at-runtime or
+  live outside the wheel — a linked libasound/libpipewire is not
+  manylinux-portable. [media-io-layering]
 
 ## Networking — transport, moq, webrtc
 
@@ -148,27 +165,46 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
 - **DECIDED** — The Python SDK carries a GIL-release contract: every native binding
   that can block releases the GIL around the blocking call, and pixels never cross
   into Python — frames travel as handles / surface ids. [importable-python-library]
+- **DECIDED** — The wheel carries an interpreter-lifecycle contract: `rt.run()` owns
+  SIGINT while it blocks (Ctrl-C returns cleanly and restores CPython's handler), and
+  engine teardown strictly precedes interpreter finalization — all engine threads
+  joined and every anchored thread state released before `rt.run()` returns, with an
+  `atexit`/context-manager guarantee on the exception path. Proven against a real
+  `python app.py` harness, the arrangement the spike never ran.
+  [importable-python-library]
 
 ## Distribution & versioning — IN-FLIGHT (→ importable-python-library)
 
 - **DECIDED** — Two artifacts, one version, released together: the streamlib wheel
   (Python API + CLI + engine) and the `streamlib` crate for Rust apps. Initial
-  release channel is this repo's releases (pip/uv-installable wheel artifacts) —
-  PyPI publication waits for the project rename; the artifact is identical either
-  way. Positioning is "realtime engine, Python authoring" — the Rust engine is named
-  as material; never marketed as "a Python library" even though the shape is one.
+  release channel is this repo's releases served through a static PEP 503 simple
+  index (`pip install streamlib --index-url …` — one stable incantation) — PyPI
+  publication waits for the project rename; the artifact is identical either way.
+  Positioning is "realtime engine, Python authoring" — the Rust engine is named as
+  material; never marketed as "a Python library" even though the shape is one.
   [importable-python-library]
+- **DECIDED** — Wheel portability model: system libraries (Vulkan loader, window
+  system, libcuda) are dlopen'd at runtime, never linked — the wgpu/opencv-python
+  manylinux shape; "baked in" means our Rust is compiled in, not that system deps
+  are static. abi3 across a small range of GIL-enabled CPython builds only
+  (free-threaded builds wait for the stable ABI to exist for them). The wheel's
+  adapter closure excludes skia. Helper processes import the wheel itself — one
+  native artifact, no separate helper cdylib. [importable-python-library]
 
 ## Control plane & observability — IN-FLIGHT (→ importable-python-library)
 
 - **DECIDED** — One control plane: the api-server's HTTP + WebSocket + MCP surface,
   hosted in-process by any runtime that enables it. The MCP tool set is the canonical
-  control vocabulary; the CLI is a pure JSON-RPC client of it — agents and humans drive
+  control vocabulary; the CLI is a pure JSON-RPC client of it — agents and humans use
   the same verbs; REST/WS routes serve the same operations for programmatic clients.
-  [control-plane-one-surface]
+  Post-pivot the vocabulary is observation-shaped: graph, tap, logs, health, nodes.
+  The live-mutation verbs (submit / replace / connect / remove) and their MCP tools
+  are removed — code is the source of truth; the edit loop is `dev`, not live
+  mutation. `dev` binds loopback by default. [importable-python-library]
 - **DECIDED** — The api-server is engine-side infrastructure and relocates into the
-  `runtime/` tree: it is a host — statically linked, never dlopen'd — and cannot follow
-  the packages tree out of the repo. [control-plane-one-surface]
+  `runtime/` tree: it is a host — statically linked, never dlopen'd. Its new host is
+  the wheel (and the `streamlib` crate for Rust apps); the relocation is a sequencing
+  prerequisite of the rip-out. [control-plane-one-surface]
 - **DECIDED** — The CLI ships inside the wheel and slims to `new` / `dev` / `run` (a
   thin runner over the same engine the wheel exposes) plus the observation verbs
   (`nodes` / `graph` / `tap` / `logs` / `mcp`); build-orchestration, packaging,

--- a/docs/plan/ARCHITECTURE.md
+++ b/docs/plan/ARCHITECTURE.md
@@ -8,39 +8,57 @@ never round-tripped back) move together: every DECIDED entry is represented in t
 
 Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an owner decision.
 
-## Product (the MVP sentence) — IN-FLIGHT (→ mvp-app-experience, pypi-packaging)
+## Product (the MVP sentence) — IN-FLIGHT (→ importable-python-library)
 
 - **DECIDED** — A Python developer on Linux with an NVIDIA GPU installs streamlib from
-  PyPI, runs `streamlib new` then `streamlib dev`, sees their camera live in a window
-  within a minute, and makes the pipeline theirs by editing the scaffolded processor —
-  zero ceremony: no manifest, no `main()`, no schema wrangling, hot-reload on save.
-  Every ticket traces to this sentence or does not exist. [product-mvp-sentence]
-- **DECIDED** — Terms of the sentence: PyPI ships the single binary (CLI + runtime +
-  orchestrator); platform floor is Linux + NVIDIA; `streamlib new` scaffolds a working
-  camera → effect → display app with dependencies already installed — first `streamlib
-  dev` shows live video before any editing; `dev`/`run` find `app.py`'s `setup(rt)` by
-  convention, `-f <file>` overrides; an app carries no manifest (entry file +
-  `streamlib.lock` + `streamlib_modules/`) and promotes to a package by adding the
-  identity label; app-local processors live in `processors/`, discovered by the same
-  scan as plugins, minted `@app/local/<Name>`, and `rt.add` accepts the string id or
-  the imported class; the pipeline API is `add`/`connect`. [product-mvp-sentence]
+  PyPI into an ordinary uv-managed venv, runs `streamlib new` then `streamlib dev`,
+  sees their camera live in a window within a minute, and makes the pipeline theirs by
+  editing the scaffolded processor — zero ceremony: no manifest, no `main()`, no schema
+  wrangling, hot-reload on save. Every ticket traces to this sentence or does not
+  exist. [importable-python-library]
+- **DECIDED** — Terms of the sentence: StreamLib is an importable Python library — one
+  PyPI wheel carrying the Python API, the CLI, and the Rust engine (PyO3, the
+  pydantic-core model); a StreamLib app is a normal Python codebase — one venv, one
+  Python version, ordinary PyPI dependencies, nothing dynamically downloaded;
+  `dev`/`run` find `app.py`'s `setup(rt)` by convention, `-f <file>` overrides;
+  processors are Python classes written in the app or imported from pip-installed
+  packages, and `rt.add` takes the class; the pipeline API is `add`/`connect`.
+  [importable-python-library]
 - **DECIDED** — The zero-ceremony bar (the sentence is untrue until all hold): no
   manifest authoring; no boilerplate entry; bags/schemas fixed (no engine schema
-  matching, cast-at-read, no versions at the code layer); scaffolding commands for
-  app, plugin, processor, and schema. [product-mvp-sentence]
-- **DECIDED** — Rust processor authoring (C++ later) stays a supported capability for
-  hardware-facing packages, outside the MVP sentence; existing Rust plugins port to
-  the new format as the final step, so they install as modules. [product-mvp-sentence]
+  matching, cast-at-read, no versions at the code layer); scaffolding for app and
+  processor; the scaffold pins `.python-version` (3.12) and the wheel supports a small
+  Python version range. [importable-python-library]
+- **DECIDED** — Rust authoring stays a supported capability: a Rust app is a plain
+  cargo project depending on the `streamlib` crate — no wrapper generation, no special
+  format; third-party Rust processors for Rust apps are ordinary cargo dependencies,
+  source-compiled. [importable-python-library]
 
-## Module system — packages, versions, imports
+## Packages & extension model — IN-FLIGHT (→ importable-python-library)
 
-- **DECIDED** — Packages resolve like node modules: version ranges resolved from a package
-  source at build time, never from sibling directories. `add`/`install` take finalized
-  artifacts only; `link` is the sole local-dev path.
-- **OPEN** — Remaining resolution semantics (lockfile story, upgrade flow, engine-version
-  compatibility signaling).
+- **DECIDED** — PyPI and cargo are the package systems. The custom module system is
+  deleted in full: `streamlib_modules/`, the `.slpkg` format, `streamlib.lock`, the
+  package source, the `add`/`install`/`link`/`pkg` verbs, `BuildOrchestrator` and all
+  runtime downloading or compiling. Compilation happens at publish time, by the
+  author, with standard tools (maturin/CI for wheels, cargo for crates) — StreamLib
+  never compiles user code. [importable-python-library]
+- **DECIDED** — The plugin ABI is deleted: no dlopen'd processor cdylibs, no `repr(C)`
+  vtable surface, no load handshake, no build fingerprints. The extension paths are
+  Python packages and Rust source crates only. [importable-python-library]
+- **DECIDED** — Third-party native code (closed-source included) ships as an ordinary
+  Python package whose native internals expose capabilities to Python as handles —
+  frames, FDs, device pointers, buffers — wrapped by a Python processor. It never
+  links the engine and never speaks streamlib internals; the CPython ABI is the only
+  binary boundary, and exactly one streamlib engine lives in a process.
+  [importable-python-library]
+- **DECIDED** — The engine's handle-shaped primitive surface is the public contract
+  for native interop: DMA-BUF / OPAQUE_FD import and export, the present target,
+  texture rings, codec byte pumps, the audio clock, color resolution. The
+  Vulkan↔CUDA and Vulkan↔GL interop adapters survive as in-process capabilities
+  (torch/cupy and GL consumers); only their cross-DSO `-abi` halves die with the
+  plugin ABI. [importable-python-library]
 
-## Processor model & scheduling — IN-FLIGHT (→ schema-agreement-ripout)
+## Processor model & scheduling — IN-FLIGHT (→ schema-agreement-ripout, importable-python-library)
 
 - **DECIDED** — A link is pure plumbing: output port → input port, carrying a bag
   (self-describing msgpack named map). Producer and consumer type declarations are
@@ -56,6 +74,17 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   OS thread per processor with descriptor-driven priority (realtime / high / normal);
   synchronous lifecycle traits; Full/Limited capability typestate on the phase axis
   (setup/teardown vs process). [execution-model]
+- **DECIDED** — Execution placement is an engine concern, never a user-facing runtime
+  definition: Python processors run in-process by default, and the engine may place a
+  processor in a helper process spawned from the same interpreter and venv
+  (`sys.executable`) — same code either way, no interpreter zoo, no per-processor
+  environments, no placement configuration surface beyond a single opt-in.
+  [importable-python-library]
+- **DECIDED** — JTD schemas are advisory, experimental type information behind a
+  rip-out-cheap seam — never a requirement for accessing data, in-graph or on the
+  wire, and never baked in as fundamental (replaceable wholesale, e.g. by Arrow,
+  without touching the data plane). No user-facing codegen verb.
+  [importable-python-library]
 - **OPEN** — Additional execution flavors to scale processor count (lightweight /
   green-thread style): intended, do not build until designed; hard constraint — no new
   configuration dials. [execution-model]
@@ -66,26 +95,34 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   kernel abstraction per pipeline kind; consumers go through `GpuContext` only.
 - **OPEN** — Everything else.
 
-## Media I/O — camera, display, audio
+## Media I/O — camera, display, audio — IN-FLIGHT (→ importable-python-library)
 
-- **DECIDED** — The engine ships no media processors: camera, display, and audio are
-  packages loaded over the plugin ABI. The engine owns the hardware primitives they
-  build on — DMA-BUF / OPAQUE_FD import and export, the present target, the audio
-  clock, color resolution, codec sessions — exposed only through `GpuContext`, the
-  RHI, and the ABI vtables. [media-io-layering]
-- **DECIDED** — First-party media packages lag by design during engine development and
-  are upgraded to the current engine as the final MVP step, once the runtime is proven
-  solid — before the MVP ships, never continuously. [media-io-layering]
+- **DECIDED** — First-party camera, display, and audio are native built-in processors
+  in the engine tree, statically linked into the wheel — pre-built named blocks
+  instantiated and configured from Python (`rt.add(CameraSource)`), whose per-frame
+  paths never enter the interpreter. Lag-by-design ends: built-ins ship inside the
+  wheel, current by construction. [importable-python-library]
+- **DECIDED** — Built-ins are written against the same handle-shaped hardware
+  primitives third parties get — DMA-BUF / OPAQUE_FD import-export, present target,
+  audio clock, color resolution, codec sessions — never against private engine guts;
+  the layering wall survives the ABI's deletion as internal discipline.
+  [importable-python-library]
 - **DECIDED** — V4L2 is the only capture backend (platform floor: Linux + NVIDIA).
   Apple capture (AVFoundation) is post-MVP and undesigned; only the TCC permission
   shims exist. [media-io-layering]
-- **DECIDED** — Windowing splits at the raw window handle: window creation and its
-  lifetime are package-side; the engine mints the present target from the raw handle
-  and owns every swapchain and acquire detail, plus the platform main-thread event
-  loop where the OS demands it. [media-io-layering]
+- **DECIDED** — Windowing: the built-in display owns window creation and the event
+  pump; the raw-window-handle seam remains the internal boundary — the engine mints
+  the present target from the raw handle and owns every swapchain and acquire detail,
+  plus the platform main-thread event loop where the OS demands it (in the importable
+  arrangement the process main thread belongs to the user's script; `rt.run()` blocks
+  with the GIL released while the engine pumps). [importable-python-library]
 - **DECIDED** — Camera → GPU transport: zero-copy DMA-BUF import when the device
   exports it, transparent CPU-upload fallback otherwise, selected automatically —
   no configuration dial. [media-io-layering]
+- **DECIDED** — Python-authored media processors (vendor or user) are supported where
+  deadlines allow: camera-class sources and block-level audio are viable behind the
+  SDK's GIL-release contract; vsync-paced present loops and device audio callbacks
+  stay native, always. [importable-python-library]
 - **OPEN** — Audio backend: PipeWire-native on Linux is the intent (the current
   CPAL → ALSA path is interim); do not build until a research memo settles it. A/V
   sync model likewise OPEN. The engine's decided audio surface is the clock
@@ -93,17 +130,31 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
 
 ## Networking — transport, moq, webrtc
 
-- **OPEN**
+- **DECIDED** — Cross-language interop happens on the wire between nodes, as
+  self-describing bags — never in-graph. [importable-python-library]
+- **OPEN** — Everything else (transport choice, moq, webrtc, mesh discovery).
 
-## Language SDKs & parity
+## Language SDKs & parity — IN-FLIGHT (→ importable-python-library)
 
-- **OPEN** — Which runtime leads during MVP; which surfaces are parity-required.
+- **DECIDED** — Python is the sole focus runtime: the importable PyO3 wheel is the
+  primary authoring surface. The Deno SDK and the subprocess-polyglot machinery are
+  deleted with the module system they are built on. TypeScript authoring is paused,
+  not rejected — a future TypeScript SDK follows this same importable-library model
+  (a native module a TypeScript app imports; Deno itself optional), aimed at the
+  hobbyist / video-creator audience when it is scheduled. [importable-python-library]
+- **DECIDED** — The Python SDK carries a GIL-release contract: every native binding
+  that can block releases the GIL around the blocking call, and pixels never cross
+  into Python — frames travel as handles / surface ids. [importable-python-library]
 
-## Distribution & versioning
+## Distribution & versioning — IN-FLIGHT (→ importable-python-library)
 
-- **OPEN**
+- **DECIDED** — Two artifacts, one version, released together: the streamlib wheel on
+  PyPI (Python API + CLI + engine) and the `streamlib` crate for Rust apps.
+  Positioning is "realtime engine, Python authoring" — the Rust engine is named as
+  material; never marketed as "a Python library" even though the shape is one.
+  [importable-python-library]
 
-## Control plane & observability — IN-FLIGHT (→ mvp-app-experience)
+## Control plane & observability — IN-FLIGHT (→ importable-python-library)
 
 - **DECIDED** — One control plane: the api-server's HTTP + WebSocket + MCP surface,
   hosted in-process by any runtime that enables it. The MCP tool set is the canonical
@@ -113,10 +164,13 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
 - **DECIDED** — The api-server is engine-side infrastructure and relocates into the
   `runtime/` tree: it is a host — statically linked, never dlopen'd — and cannot follow
   the packages tree out of the repo. [control-plane-one-surface]
-- **DECIDED** — One shipped binary (CLI + runtime + build orchestration): `run`/`dev`
-  host the runtime in-process; the standalone streamlib-runtime binary retires. The
-  engine remains an embeddable Rust library for host apps; non-Rust embedding drives a
-  runtime through the client-SDK / control-plane path. [single-binary-launch]
+- **DECIDED** — The CLI ships inside the wheel and slims to `new` / `dev` / `run` (a
+  thin runner over the same engine the wheel exposes) plus the observation verbs
+  (`nodes` / `graph` / `tap` / `logs` / `mcp`); build-orchestration, packaging,
+  provisioning, and codegen verbs are deleted. The standalone streamlib-runtime
+  binary retires. Python embeds the engine in-process via the wheel; the control
+  plane exists to observe and drive *running* nodes, not to embed.
+  [importable-python-library]
 - **DECIDED** — Node discovery is a per-user on-disk registry — one JSON file per live
   node in the OS's standard per-user runtime directory — written only by
   control-plane-hosting runtimes, pruned only when both liveness signals (control

--- a/docs/plan/ARCHITECTURE.md
+++ b/docs/plan/ARCHITECTURE.md
@@ -10,8 +10,9 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
 
 ## Product (the MVP sentence) — IN-FLIGHT (→ importable-python-library)
 
-- **DECIDED** — A Python developer on Linux with an NVIDIA GPU installs streamlib from
-  PyPI into an ordinary uv-managed venv, runs `streamlib new` then `streamlib dev`,
+- **DECIDED** — A Python developer on Linux with an NVIDIA GPU pip-installs streamlib
+  (initially from this repo's releases; PyPI after the project rename) into an
+  ordinary uv-managed venv, runs `streamlib new` then `streamlib dev`,
   sees their camera live in a window within a minute, and makes the pipeline theirs by
   editing the scaffolded processor — zero ceremony: no manifest, no `main()`, no schema
   wrangling, hot-reload on save. Every ticket traces to this sentence or does not
@@ -150,10 +151,12 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
 
 ## Distribution & versioning — IN-FLIGHT (→ importable-python-library)
 
-- **DECIDED** — Two artifacts, one version, released together: the streamlib wheel on
-  PyPI (Python API + CLI + engine) and the `streamlib` crate for Rust apps.
-  Positioning is "realtime engine, Python authoring" — the Rust engine is named as
-  material; never marketed as "a Python library" even though the shape is one.
+- **DECIDED** — Two artifacts, one version, released together: the streamlib wheel
+  (Python API + CLI + engine) and the `streamlib` crate for Rust apps. Initial
+  release channel is this repo's releases (pip/uv-installable wheel artifacts) —
+  PyPI publication waits for the project rename; the artifact is identical either
+  way. Positioning is "realtime engine, Python authoring" — the Rust engine is named
+  as material; never marketed as "a Python library" even though the shape is one.
   [importable-python-library]
 
 ## Control plane & observability — IN-FLIGHT (→ importable-python-library)

--- a/docs/plan/ARCHITECTURE.md
+++ b/docs/plan/ARCHITECTURE.md
@@ -75,11 +75,13 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   synchronous lifecycle traits; Full/Limited capability typestate on the phase axis
   (setup/teardown vs process). [execution-model]
 - **DECIDED** — Execution placement is an engine concern, never a user-facing runtime
-  definition: Python processors run in-process by default, and the engine may place a
-  processor in a helper process spawned from the same interpreter and venv
-  (`sys.executable`) — same code either way, no interpreter zoo, no per-processor
-  environments, no placement configuration surface beyond a single opt-in.
-  [importable-python-library]
+  definition. Both placements are first-class: in-process (lowest latency, shares the
+  app's interpreter) and helper processes spawned from that same interpreter and venv
+  (`sys.executable` — each with its own GIL, the isolation model dora-style systems
+  run on). The engine chooses per processor; placement heuristics are engine
+  implementation, not plan-level commitments. Same user code either way — no
+  interpreter zoo, no per-processor environments, no placement configuration surface
+  beyond a single opt-in. [importable-python-library]
 - **DECIDED** — JTD schemas are advisory, experimental type information behind a
   rip-out-cheap seam — never a requirement for accessing data, in-graph or on the
   wire, and never baked in as fundamental (replaceable wholesale, e.g. by Arrow,

--- a/docs/plan/GLOSSARY.md
+++ b/docs/plan/GLOSSARY.md
@@ -3,53 +3,58 @@
 The shared language. Terms only — zero implementation detail. Maintained by the
 `glossary` skill inside plan-editing sessions; project-specific terms only.
 
-**Host**: the engine process that loads plugins. _Avoid_: "runtime process", "main app".
+**The wheel**: the single distributed artifact for Python — Python API + CLI + engine
+in one PyO3 package. _Avoid_: "the binary" (pre-pivot), "the SDK" (that is its API
+surface).
 
-**Plugin**: a package's compiled cdylib loaded by the host across the plugin ABI.
-_Avoid_: DSO, shared object, FFI module.
+**App**: a normal Python codebase — an entry file (`app.py` defining `setup(rt)`) plus
+`pyproject.toml` and one venv; no manifest, no streamlib-specific files. _Avoid_:
+"project", "consumer app" (redundant).
 
-**Plugin ABI**: the `#[repr(C)]` boundary between host and plugin. _Avoid_: FFI, COM.
+**Package**: an ordinary PyPI or cargo package. A processor package's native internals
+expose handles to Python and never speak streamlib internals. _Avoid_: "plugin",
+"module" (pre-pivot module-system terms).
 
-**Package**: the distributable unit (source tree + `streamlib.yaml`) resolved by version
-from a package source. _Avoid_: "plugin" (that is the compiled artifact).
+**Built-in**: a first-party native processor shipped inside the wheel (camera, display,
+audio) — instantiated and configured from Python; its per-frame path never enters the
+interpreter.
 
-**Package source**: the store packages resolve from at build time — never a sibling
-directory.
-
-**Link**: the sole local-development path for consuming a package from a folder.
-`add`/`install` take finalized artifacts only.
-
-**App**: a consumer of packages — an entry file (`app.py` defining `setup(rt)`) plus
-`streamlib.lock` and `streamlib_modules/`; carries no manifest. Promotes to a package by
-adding the identity label. _Avoid_: "project", "consumer app" (redundant).
+**Placement**: where the engine runs a processor — in-process, or in a helper process
+spawned from the same interpreter and venv. An engine decision behind a single opt-in,
+never a user-facing runtime definition.
 
 **Bag**: the self-describing msgpack named map a link carries — the schema-free view of
 a payload; consumers cast it to a type at read time. _Avoid_: "message", "envelope".
 
-**Control plane**: the HTTP/WebSocket/MCP surface a runtime hosts for inspection and
-mutation; the CLI and client SDKs are its clients. _Avoid_: "API server" as the concept
-(that is the component hosting it).
+**Control plane**: the HTTP/WebSocket/MCP surface a runtime hosts for observing and
+inspecting running nodes; the CLI is its client. Embedding happens by importing the
+wheel, never through the control plane. _Avoid_: "API server" as the concept (that is
+the component hosting it).
 
 **Node**: a live runtime reachable over its control plane; discovered via the per-user
 on-disk registry. _Avoid_: "instance", "server".
 
-**Processor**: the unit of pipeline computation, declared with `#[processor]` and wired
-by ports.
+**Processor**: the unit of pipeline computation — a Python class (`@processor`) or a
+Rust type (`#[processor]`) — wired by ports.
 
-**Engine primitive**: a hardware capability the engine owns and exposes to packages
-across the plugin ABI — GPU memory import/export, the present target, the audio clock,
-codec sessions. Packages compose primitives; they never reimplement them.
+**Engine primitive**: a hardware capability the engine owns and exposes through its
+handle-shaped surface — GPU memory import/export (DMA-BUF / OPAQUE_FD), the present
+target, texture rings, codec sessions, the audio clock, color resolution. Built-ins and
+external code compose primitives; they never reimplement them.
 
-**Present target**: the engine-owned presentation surface minted from a
-package-supplied window handle; the only way frames reach a window.
+**Handle**: a transferable value crossing the native↔Python boundary — a DMA-BUF fd, a
+CUDA device pointer, a surface id, a byte buffer. Pixels never cross as Python objects.
 
-**Lag by design**: consumers (distributable packages, examples) track the engine only at
-planned upgrade points — upgraded as the final step of a milestone once the runtime is
-proven solid, never continuously mid-development. _Avoid_: reading "lag" as "never
-upgraded", "abandoned".
+**Present target**: the engine-owned presentation surface minted from a raw window
+handle; the only way frames reach a window.
 
 **The plan**: `docs/plan/ARCHITECTURE.md` plus `docs/plan/diagrams/` — the single source
 of architectural decisions.
 
 **Change**: a typed delta proposal against the plan (`docs/plan/changes/`), marked
 ADDED / MODIFIED / REMOVED.
+
+Retired by the 2026-08-02 pivot (see `docs/decisions/importable-python-library.md`):
+**Host** (loads-plugins sense), **Plugin**, **Plugin ABI**, **Package source**,
+**Link**, **Lag by design** — these named the deleted plugin-ABI / module-system world;
+do not reuse them.

--- a/docs/plan/OPERATING-MODEL.md
+++ b/docs/plan/OPERATING-MODEL.md
@@ -90,7 +90,8 @@ dangle silently, unreviewable PR diffs). The pipeline instead:
 
 A change proposal (`changes/<name>.md`) is written as a **delta against the plan**, never
 a restatement: sections marked `ADDED` / `MODIFIED` / `REMOVED`, ≤200 lines, deriving
-≤5 tickets. Two markers with different powers:
+as few tracer-bullet tickets as it honestly needs (count is guidance, not a cap —
+owner decision 2026-08-02). Two markers with different powers:
 
 - `[NEEDS CLARIFICATION]` — a factual gap; the agent resolves it by reading the repo.
 - `[NEEDS DECISION]` — an architectural choice; the agent may NOT resolve it. It stops,
@@ -158,7 +159,7 @@ wrangle determinism out of a stochastic system — predictability of process, no
 | `/plan` | Router. Reads ARCHITECTURE.md statuses + open changes + ticket frontier, says where you are and which skill is next. (reference, no procedure) | remembering the catalog |
 | `/align` | `batch-grilling` + `glossary` over one plan section → OPEN→DECIDED edits + diagram update. Nothing else moves. (high freedom) | the debate you want to have once |
 | `/propose-change` | Read-only recon by domain experts first (the measured fix for context-blind specs) → delta proposal with `[NEEDS DECISION]` blocks → **stop for owner approval**. (medium) | `draft-design` |
-| `/derive-tickets` | Approved change → ≤5 tracer-bullet tickets: vertical slices, each demoable, each sized to one context window, blocking edges declared; wide refactors sequenced expand→migrate-in-batches→contract. Quiz the owner on the list until approved, then publish. (medium) | `file-issue` for planned work (kept for bugs) |
+| `/derive-tickets` | Approved change → tracer-bullet tickets (as few as honestly needed; count is guidance, not a cap): vertical slices, each demoable, each sized to one context window, blocking edges declared; wide refactors sequenced expand→migrate-in-batches→contract. Quiz the owner on the list until approved, then publish. (medium) | `file-issue` for planned work (kept for bugs) |
 | `/implement` | Load ticket + its change + plan section → **plan gate**: any needed decision not DECIDED ⇒ stop with `[NEEDS DECISION]` → announce plan, owner confirms → build test-first at pre-agreed seams → gate battery via `local-ci-runner` → one review pass → PR (`Closes #N` per line). (low freedom at the gates, normal freedom in the code) | the external `amos-next` protocol, brought in-tree |
 | `/ship-change` | Fold delta into plan, flip statuses, REMOVED-grep gate, regenerate diagrams + Excalidraw export, archive. Exact scripts, no prose latitude. (lowest freedom) | nothing — the missing piece |
 | `/pivot` | Owner declares a direction change → plan edited FIRST → inventory of now-legacy code/docs/rules → a rip-out change with REMOVED sections → deletion tickets. (medium) | nothing — legitimizes the deletion agents currently resist |
@@ -267,7 +268,8 @@ PR — never accreted mid-session because something annoyed an agent once.
 
 ## Numeric caps (hard numbers survive agent interpretation; prose doesn't)
 
-- Change proposal ≤ 200 lines. Tickets per change ≤ 5 — exceeding means split the change.
+- Change proposal ≤ 200 lines. Ticket count per change is guidance, not a cap (owner
+  decision 2026-08-02): as few tracer bullets as the change honestly needs.
 - Scale gate, decided at entry: bug fix / refactor / test work → **no change artifact at
   all** (the default path); new behavior or changed contract → delta change; anything
   touching the RHI, the IPC wire format, the processor model, or the Python API's

--- a/docs/plan/OPERATING-MODEL.md
+++ b/docs/plan/OPERATING-MODEL.md
@@ -122,10 +122,10 @@ Retired by consolidation change (its own tracked change with tickets, not a side
 
 | Cluster | Today | Becomes |
 |---|---|---|
-| Package/module system (6 docs, 2,367 L, densest supersession zone) | competing, unowned | ARCHITECTURE.md §Module system + at most one reference doc |
-| Surface adapters (4 docs, 1,931 L) | overlapping | §Adapters + one authoring reference |
+| Package/module system (6 docs, 2,367 L, densest supersession zone) | competing, unowned | ~~ARCHITECTURE.md §Module system + at most one reference doc~~ — Superseded 2026-08-02 by `importable-python-library`: the module system is deleted; these docs are removed outright by the rip-out change |
+| Surface adapters (4 docs, 1,931 L) | overlapping | §Adapters + one authoring reference (ABI halves deleted by the pivot; consolidate what survives) |
 | RHI kernels (5 docs, one identical skeleton) | five copies of one template | one reference doc, five sections |
-| Plugin ABI / cdylib (3 docs, 1,425 L) | mixed state+rationale | §Plugin ABI; `cdylib-reachability.md`'s decision-tree content moves to an ADR |
+| Plugin ABI / cdylib (3 docs, 1,425 L) | mixed state+rationale | ~~§Plugin ABI; `cdylib-reachability.md`'s decision-tree content moves to an ADR~~ — Superseded 2026-08-02: the plugin ABI is deleted; these docs are removed outright by the rip-out change |
 | `vendored-vulkanalia.md`, logging pair | fine | kept |
 | Root `README.md` | worst-rotted doc in the tree | rewritten against the plan |
 
@@ -187,7 +187,9 @@ ends with a say-back loop, and none of them commits work:
   `gh-stack`; `local-ci-runner`; `rust-craftsmanship-reviewer`; the five domain experts
   (with two charter fixes: `polyglot-ipc-expert` still mandates the repealed
   Python+Deno-together rule; `package-source-expert` aligns to the plan's module-system
-  entry).
+  entry). — Charter-fix note superseded 2026-08-02 by `importable-python-library`:
+  `plugin-abi-expert` and `package-source-expert` retire with their subjects;
+  `polyglot-ipc-expert` re-scopes to helper-process IPC.
 - **Consolidated:** `pr-review-gate` + `change-verifier` overlap heavily (both check test
   lock-in, scope, boundaries, naming) and each PR currently runs up to four review
   lenses. Owner review is the bottleneck — one merged `review-pr` lens (plus
@@ -245,7 +247,7 @@ Agents cannot quietly rewrite the decision source:
 ### Rules have a lifecycle
 
 Rules under `.claude/rules/` shrink to **invariants only** (licensing, naming, RHI
-boundary, plugin ABI, comments). Process prose migrates into skill gates, which are
+boundary, comments — the plugin-ABI rule retires with the ABI, 2026-08-02). Process prose migrates into skill gates, which are
 testable; a rule that a skill gate now enforces gets deleted via `/propose-rule`. New
 rules enter only through `/propose-rule` — evidence, draft, owner approval, dedicated
 PR — never accreted mid-session because something annoyed an agent once.
@@ -268,7 +270,9 @@ PR — never accreted mid-session because something annoyed an agent once.
 - Change proposal ≤ 200 lines. Tickets per change ≤ 5 — exceeding means split the change.
 - Scale gate, decided at entry: bug fix / refactor / test work → **no change artifact at
   all** (the default path); new behavior or changed contract → delta change; anything
-  touching plugin ABI, RHI, IPC wire format, or the processor model → delta + ADR.
+  touching the RHI, the IPC wire format, the processor model, or the Python API's
+  public contract → delta + ADR (the plugin-ABI trigger retired 2026-08-02 with the
+  ABI).
 
 ## Rollout (MVP-first; each wave usable before the next starts)
 
@@ -296,10 +300,13 @@ PR — never accreted mid-session because something annoyed an agent once.
    primary (today's "LOOP-RUN" vocabulary gets renamed `self-run`; no relation to the
    retired loop), owner-terminal handshake as fallback.
 4. The three edit-denied docs (`logging-schema.md`, `testing-hardware.md`,
-   `schema-identity-and-packaging.md`) — the last has four supersession blocks and can
-   only rot while frozen. Unfreeze into the consolidation, or keep frozen?
-5. Parked ticket #1624 (retire `.slpkg` for plain `.zip`) — becomes a plan decision in
-   §Distribution; ~650 occurrences hang on it.
+   `schema-identity-and-packaging.md`) — ~~the last has four supersession blocks and
+   can only rot while frozen. Unfreeze into the consolidation, or keep frozen?~~ —
+   Resolved 2026-08-02 by `importable-python-library`: `schema-identity-and-packaging`
+   is deleted by the rip-out; the question remains only for the first two.
+5. ~~Parked ticket #1624 (retire `.slpkg` for plain `.zip`) — becomes a plan decision
+   in §Distribution; ~650 occurrences hang on it.~~ — Resolved 2026-08-02: `.slpkg` is
+   deleted entirely by `importable-python-library`; #1624 is moot.
 6. Bring the ticket lifecycle in-tree (replace external amos-next protocol with
    `/implement`) — recommend yes; it is the single highest-leverage move the inventory
    found.

--- a/docs/plan/changes/README.md
+++ b/docs/plan/changes/README.md
@@ -5,8 +5,10 @@ ticketed by `/derive-tickets`, folded in and archived by `/ship-change`.
 
 Format: sections typed `ADDED:` / `MODIFIED:` / `REMOVED:`. Every `- REMOVED: <pattern>`
 bullet is a grep pattern `.claude/scripts/ship-change-removed-gate.sh` verifies is gone
-from the tree before the change may archive. Limits: ≤200 lines per change, ≤5 derived
-tickets — exceeding either means the change splits.
+from the tree before the change may archive. Limits: ≤200 lines per change. Ticket count
+is guidance, not a cap (owner decision 2026-08-02): derive as few tracer-bullet tickets
+as the change honestly needs — the cap existed to stop ticket-spam, and a change that
+needs more vertical slices splits only when it is genuinely two changes.
 
 Unresolvable choices are written as `[NEEDS DECISION]` blocks (options + recommendation)
 and only the owner resolves them. Archived changes live in `archive/` as

--- a/docs/plan/changes/importable-python-library-ripout.md
+++ b/docs/plan/changes/importable-python-library-ripout.md
@@ -1,0 +1,119 @@
+# Change: importable-python-library-ripout
+
+**Change B of the pivot pair — rip out the old world.** Blocked on
+`importable-python-library.md` (Change A) shipping: the wheel, built-ins, exchange
+surface, and dev experience must exist before their predecessors are deleted. Same ADR.
+The REMOVED inventory below was verified by a dedicated audit agent against the tree
+(reverse-dependency sweep, CI/xtask enumeration) on 2026-08-02.
+
+## MODIFIED — survivor rewires (sequenced before the deletions they unblock)
+
+- **api-server relocation first** (already DECIDED, `[control-plane-one-surface]`):
+  moves from `packages/api-server` into `runtime/`; its live-mutation verbs
+  (`submit`/`replace`/`connect`/`remove`) and their MCP tools are removed — the
+  vocabulary is observation-shaped (graph, tap, logs, health, nodes). The CLI `mcp`
+  verb and `Dockerfile`/`docker/` re-point at the wheel-hosted runtime (or the Docker
+  packaging story is deleted with a note — decide in-ticket from what CI uses).
+- **`sdk/vulkan-jpeg`** rewires its pervasive `streamlib_plugin_sdk::sdk::*` imports
+  to `streamlib-sdk`; the cdylib-safety constraint drops.
+- **`sdk/streamlib-macros`**: the `#[processor]` attribute grammar relocates out of
+  doomed `streamlib-processor-extract` into a surviving home (per the superseded
+  manifest-extraction ADR: exactly one parser, still true).
+- **Adapter capability traits** (`VulkanWritable`, `GlWritable`, `CpuReadable`, …)
+  relocate out of doomed `adapters/streamlib-adapter-abi` into the surviving adapter
+  cores' shared home; the cores' dev-deps on doomed `-helpers` crates drop with their
+  subprocess-parity tests.
+- **`sdk/streamlib-python-native` retires into the wheel**: helper processes import
+  the wheel itself (one native artifact, per §Distribution); the iceoryx2 transport
+  and `escalate`/`subprocess_bridge` re-scope to same-interpreter spawns
+  (exec-of-`sys.executable`, never fork); venv-provisioning and
+  `native_lib_resolver.rs`'s cdylib resolution die. Verify-before-delete: the
+  iceoryx2 log-forwarding pair in `core/plugin/` — keep a successor if helper-process
+  logging rides it.
+- **Engine host-services strip**: the dual-mode cdylib branch comes out of the ~10
+  retained files that dispatch through `core/plugin/host_services` (`gpu_context`,
+  `texture`, `bus`, `iceoryx2/input`, `vulkan_present_target`, `host_rhi`,
+  `processor_instance_factory`, `runtime_shutdown_request`); `streamlib-sdk` drops its
+  `core::plugin` re-exports and the `auto-build` feature.
+- **`core/streamlib_home.rs`** re-scopes: the `streamlib_modules`/`packages/` walk
+  dies; logging paths and the node registry keep a home-dir resolver.
+- **`sdk/streamlib-idents` / `sdk/streamlib-processor-schema`**: manifest/lockfile
+  modules die (`app_modules`, `archive`, `catalog`, `lockfile`, `manifest`,
+  `package_source`, `path_artifact_guard`, `release`, `resolver`); the schema-ident
+  core behind the JTD seam survives; `streamlib-jtd-codegen` goes internal-only.
+- **`packages/test-fixtures`** loses its plugin/cdylib arm (the in-process
+  attribute-macro tests keep it alive); `test-fixtures-abi-mismatch` dies whole.
+- **CI/xtask**: die — `check-cdylib-reach`, `check-pack-load`,
+  `check-package-version-drift`, `check-manifest-schema`,
+  `check-no-streamlib-metadata`, `check-schema-versions`,
+  `check-processor-source-reachability` (+ `generate_crate_roots`),
+  `install-packages`, xtask `StripPublishManifest`/`StaticPackageSource`. Re-scope —
+  `check-consumer-rhi-repr` (owner call: rationale was plugin FFI), `check-boundaries`
+  (keep RHI wall; drop slpkg/cdylib allowlists), `lint-logging` (drop Deno arm),
+  `check-no-inventory-submit`, `check-no-reverse-dns` (doc pointer), `test.yml`,
+  `schemas.yml`. Keep — device-wait-idle, no-escalate-in-lifecycle,
+  vendored-vulkanalia, license-check, pr-title, release-please.
+- The contract-deletion ticket lands as a **pre-approved stacked-PR structure** (the
+  86-file blast radius is unreviewable as one diff).
+
+## REMOVED
+
+Each bullet is a pattern the ship gate verifies is gone from the tree.
+
+- REMOVED: `runtime/streamlib-plugin-abi`
+- REMOVED: `sdk/streamlib-plugin-sdk`
+- REMOVED: `export_plugin!` / `install_host_services` / `HostServices` / `ProcessorVTable` / `PluginAbiObject`
+- REMOVED: `adapters/streamlib-adapter-abi`
+- REMOVED: `streamlib-adapter-vulkan-abi` / `streamlib-adapter-vulkan-helpers`
+- REMOVED: `streamlib-adapter-opengl-abi`
+- REMOVED: `streamlib-adapter-cpu-readback-abi` / `streamlib-adapter-cpu-readback-helpers`
+- REMOVED: `streamlib-adapter-cuda-abi` / `streamlib-adapter-cuda-helpers`
+- REMOVED: `streamlib-adapter-skia-abi`
+- REMOVED: `runtime/streamlib-engine/src/core/plugin/` (vtable backings,
+  `build_fingerprint`, `twin_drift_guard`, load handshake)
+- REMOVED: `runtime/streamlib-engine/src/core/runtime/module_loader/`
+- REMOVED: `runtime/streamlib-engine/src/core/runtime/install.rs` / `add_modules_from_lockfile`
+- REMOVED: `native_lib_resolver`
+- REMOVED: `load_project_dylib` (engine dylib-load test corpus) / `pack_then_load_smoke` /
+  `cdylib_owns_tokio_runtime` / `polyglot_linux_check_out_deno` / `folder_backed_package_build`
+- REMOVED: `tools/streamlib-build-orchestrator` / `BuildOrchestrator`
+- REMOVED: `tools/streamlib-cargo-build`
+- REMOVED: `tools/streamlib-pack`
+- REMOVED: `tools/streamlib-cross-rustc-fixture`
+- REMOVED: `.slpkg`
+- REMOVED: `streamlib_modules`
+- REMOVED: `tools/streamlib-cli/src/commands/{add,install,link,pkg,build_on_place,generate,schema,setup}.rs`
+  (+ `commands/link/`; mutation verbs trimmed from `control.rs` and `mcp.rs`; doomed
+  CLI tests `add_remove`/`install_from_lock`/`link_unlink`/`pkg_publish_catalog`)
+- REMOVED: `RunnerAutoBuild` and the sdk `auto-build` feature
+- REMOVED: `runtime/streamlib-runtime`
+- REMOVED: `sdk/streamlib-deno` / `sdk/streamlib-deno-native`
+- REMOVED: `spawn_deno_subprocess_op`
+- REMOVED: `sdk/streamlib-processor-extract`
+- REMOVED: `sdk/streamlib-python/python/streamlib/_processor_registry.py` /
+  `extract_processors.py` / `setup.py` / `cgl_context.py`
+- REMOVED: `schemas/streamlib.schema.json`
+- REMOVED: `scripts/sync-inter-crate-versions.py`
+- REMOVED: `packages/test-fixtures-abi-mismatch`
+- REMOVED: `docs/architecture/{plugin-abi,package-development-model,package-source,package-staging-layout,runtime-module-materialization,schema-identity-and-packaging,subprocess-rhi-parity,cdylib-reachability,zero-ceremony-authoring}.md`
+  (plus ABI-half edits in `adapter-authoring`, `adapter-runtime-integration`,
+  `surface-adapter`, `texture-registration`, `compute-kernel`, `ray-tracing-kernel`,
+  `third-party-gpu-backends`; historical notes on the two cdylib/slpkg learnings)
+
+## Companion operating-model PR (dedicated, per the flow rule)
+
+Retires `.claude/rules/plugin-boundary.md`, agents `plugin-abi-expert` +
+`package-source-expert` (re-scopes `polyglot-ipc-expert`), skills
+`author-and-submit-processor` + `hot-swap-live-processor`; updates CLAUDE.md +
+`engine-doctrine.md` (ABI layout-test non-negotiable, packages-lag doctrine,
+`streamlib.yaml` purity line); lifts `.claude/settings.json` deny rules for
+`packages/**`/`examples/**` as those trees are deleted; prunes issue-template
+package/plugin fields; rewrites the workspace-comment block in `Cargo.toml`.
+
+## Dispositions — deferred re-authoring (recorded, not ticketed)
+
+Old consumers are re-authored in their own planning sessions after the wheel exists:
+mavlink-class → plain-Python packages; GPU-heavy → Python packages with native wheels
+exposing handles; `polyglot-*` + `camera-deno-subprocess` examples → deleted, replaced
+by normal Python app examples; MoQ package → rides surviving `runtime/streamlib-moq`,
+disposition when §Networking is scheduled.

--- a/docs/plan/changes/importable-python-library.md
+++ b/docs/plan/changes/importable-python-library.md
@@ -33,6 +33,15 @@ Scale tier: touches the plugin ABI and the processor model → change artifact +
   handles — the display block becomes window lifecycle + one call per frame.
 - `streamlib new` app scaffold: `app.py` with `setup(rt)`, `pyproject.toml`,
   `.python-version` pinned (3.12), working camera → effect → display wiring.
+- Engine kernel primitives exposed to Python as configured blocks: shader/compute
+  source and binding config passed from Python; the engine compiles and runs it on its
+  device (the custom-GPU-effect story — no Rust, no user-side Vulkan). API design gets
+  its own session; the change commits only to the shape.
+- Standard zero-copy exchange surface: streamlib frames/textures expose DLPack and the
+  CUDA Array Interface, plus DMA-BUF export/import, with sync, lifetime (pinned to the
+  Python object), and layout owned by the engine's export surface — external native
+  code receives memory in its own dialect (torch/cupy/CUDA/fd) and never creates a
+  GPU context; Vulkan is written by this engine alone.
 
 ## MODIFIED
 

--- a/docs/plan/changes/importable-python-library.md
+++ b/docs/plan/changes/importable-python-library.md
@@ -1,132 +1,79 @@
 # Change: importable-python-library
 
-The rip-out and reshape for the SDK-shape pivot. Implements every
-`[importable-python-library]` DECIDED entry (§Product, §Packages & extension model,
-§Processor model, §Media I/O, §Networking, §Language SDKs, §Distribution, §Control
-plane). ADR: `docs/decisions/importable-python-library.md` (carries the owner-confirmed
-five-sentence direction). Recon verified 2026-08-02: three read-only agent sweeps
-(engine media primitives, GIL/data-plane cost, ecosystem precedent) plus direct
-enumeration of the module loader, plugin host, CLI verbs, and workspace members.
+**Change A of the pivot pair — build the new world beside the old.** The rip-out is
+`importable-python-library-ripout.md` (Change B), blocked on this change shipping.
+Implements the `[importable-python-library]` DECIDED entries (§Product, §Packages &
+extension model, §Processor model, §Graphics, §Media I/O, §Language SDKs,
+§Distribution, §Control plane). ADR: `docs/decisions/importable-python-library.md`.
+Recon verified 2026-08-02: three read-only agent sweeps (engine media primitives,
+GIL/data-plane cost, ecosystem precedent) plus a four-agent audit pass (plan coherence,
+rip-out completeness, DX red-team, technical risk) — findings folded in below.
 
-Scale tier: touches the plugin ABI and the processor model → change artifact + ADR.
+Scale tier: touches the processor model and the Python API's public contract → change
+artifact + ADR.
 
 ## ADDED
 
-- The streamlib wheel: maturin-built PyO3 package = Python API + CLI + engine,
-  statically linked camera/display; abi3 across a small Python version range; released
-  as repo-hosted wheel artifacts (PyPI deferred until the project rename).
-- In-process Python authoring: `Runtime` exposed to Python via PyO3; `@processor`
-  classes execute in-process; `rt.add` accepts the imported class; `rt.run()` blocks
-  with the GIL released while the engine (and any OS-mandated main-thread pump) runs.
-- Helper-process placement: the engine may place a Python processor in a process
-  spawned from `sys.executable` (same interpreter, same venv) over the existing
-  iceoryx2 transport; placement is engine policy with a single opt-in, no other
-  user-facing surface.
-- GIL-release contract in the Python SDK: every native binding that can block releases
-  the GIL around the blocking call; frames travel as handles / surface ids, never as
-  pixels in Python.
-- Built-in media blocks in the engine tree: camera (V4L2), display, audio as native
-  processors written against the handle-shaped primitives (DMA-BUF/OPAQUE_FD import,
-  present target, texture ring, color resolution, audio clock).
-- Engine present-composition call ("present this surface, fit/fill, color-managed")
-  absorbing the draw step the old display package drove through recorder/kernel
-  handles — the display block becomes window lifecycle + one call per frame.
-- `streamlib new` app scaffold: `app.py` with `setup(rt)`, `pyproject.toml`,
-  `.python-version` pinned (3.12), working camera → effect → display wiring.
-- Engine kernel primitives exposed to Python as configured blocks: shader/compute
-  source and binding config passed from Python; the engine compiles and runs it on its
-  device (the custom-GPU-effect story — no Rust, no user-side Vulkan). API design gets
-  its own session; the change commits only to the shape.
-- Standard zero-copy exchange surface: streamlib frames/textures expose DLPack and the
-  CUDA Array Interface, plus DMA-BUF export/import, with sync, lifetime (pinned to the
-  Python object), and layout owned by the engine's export surface — external native
-  code receives memory in its own dialect (torch/cupy/CUDA/fd) and never creates a
-  GPU context; Vulkan is written by this engine alone.
+- **The wheel proof + interpreter-lifecycle contract** (the riskiest assumption,
+  retired first): a maturin-built abi3 PyO3 wheel; `rt.run()` owns SIGINT while it
+  blocks (Ctrl-C returns cleanly, CPython's handler restored) and engine teardown
+  strictly precedes interpreter finalization — threads joined, anchored thread states
+  released, `atexit`/context-manager guarantee on the exception path. Proven against a
+  real `python app.py` harness in headless CI — the arrangement the spike never ran.
+- **In-process Python authoring**: `Runtime` via PyO3; `@processor` classes execute
+  in-process on the dedicated-thread model; `rt.add(ImportedClass)`; the GIL-release
+  contract (every blocking native binding releases the GIL; pixels never cross —
+  handles/surface ids only) with a test proving a blocked native call stalls no other
+  Python processor. Generated `.pyi` stubs ship in the wheel (IDE autocomplete). A
+  single-processor test harness (feed a synthetic frame, assert output — no hardware)
+  ships with it; it is also how built-ins are tested.
+- **Built-in media blocks**: native V4L2 camera and display processors in the engine
+  tree, written against the handle-shaped primitives; the engine absorbs the draw step
+  via a "present this surface (fit/fill, color-managed)" composition call. Display is
+  greenfield against `vulkan_present_target` (window/event-pump code never lived in the
+  engine) — budgeted as a rewrite, not a move. Human-shaped failure messages (no
+  camera, no `video` group, no Vulkan ICD, wrong Python) plus a test-pattern fallback
+  source so the scaffold demos hardware-free.
+- **Zero-CPU-copy exchange surface, DLPack first**: frames/textures expose
+  `__dlpack__` (CUDA Array Interface may follow; its default-stream semantics are
+  weaker), DMA-BUF export/import, and a CPU numpy view fallback via the cpu-readback
+  adapter. Tiled textures reach a linear tensor via one GPU blit into an exportable
+  staging buffer — stated honestly, never marketed as copy-free. Sync, lifetime
+  (pinned to the Python object; ring-slot reuse gated on consume), and layout owned by
+  the engine's export surface. Regression tests: use-after-free, read-before-signal.
+- **The dev experience**: `dev`/`run` import `app.py` and execute `setup(rt)` (today's
+  run boots an empty graph — this is the missing glue); a bad save prints the
+  traceback and keeps the last good pipeline running; the MVP edit loop is re-running
+  `dev` (reload-on-save is a later nicety, processor-granular per the plan, never
+  module machinery); a dev-mode GIL-hold watchdog warns when a callback holds the GIL
+  beyond threshold; `dev` binds loopback. `streamlib new` scaffolds `app.py` +
+  `pyproject.toml` + `.python-version` (3.12) with working camera → effect → display
+  wiring where the effect touches pixels via the exchange surface.
+- **Packaging + release channel**: the CLI ships as the wheel's console script; wheels
+  publish as repo release artifacts served through a static PEP 503 simple index
+  (`pip install streamlib --index-url …` — one stable incantation; identical artifact
+  when PyPI arrives after the rename). System libs (Vulkan loader, window system,
+  libcuda) are dlopen'd at runtime, never linked; adapter closure excludes skia;
+  GIL-enabled CPython builds only.
 
 ## MODIFIED
 
-- `sdk/streamlib-python`: subprocess SDK → the wheel's Python API surface (authoring
-  decorators kept; hosting/provisioning code dropped).
-- Subprocess machinery (`spawn_python_native_subprocess_op`, `subprocess_bridge`,
-  `subprocess_escalate`, `streamlib-python-native`, `surface_share`,
-  `streamlib-surface-client`): retained and re-scoped as the helper-process placement
-  path — same-interpreter spawns only; all venv-provisioning and module-resolution
-  tendrils removed.
-- Adapters: `streamlib-adapter-vulkan` / `-opengl` / `-cuda` / `-skia` /
-  `-cpu-readback` cores retained as in-process interop capabilities; their cross-DSO
-  `-abi` and `-helpers` crates removed (see REMOVED).
-- CLI: `run` / `dev` stay (thin runner, #1699 shape) plus `nodes` / `graph` / `tap` /
-  `logs` / `mcp`; ships inside the wheel as a console script. Live-mutation control
-  verbs (`submit` / `replace` / `connect` / `remove`) and their MCP tools are removed;
-  `dev`'s hot-reload is the edit loop.
-- `sdk/streamlib-jtd-codegen`: internal-only (first-party Rust↔Python type parity
-  behind the rip-out-cheap seam); no user-facing codegen verb.
-- `sdk/vulkan-jpeg`: retained; cdylib-safety constraint dropped.
-- `xtask` / CI: lints and gates referencing the ABI, cdylib flavors, or `.slpkg`
-  cross-build soundness removed with their subjects.
-- `.claude/` rules, agents, and skills tied to dead systems (rule `plugin-boundary`,
-  agents `plugin-abi-expert` / `package-source-expert`, skills
-  `author-and-submit-processor` / `hot-swap-live-processor`, CLAUDE.md +
-  `engine-doctrine` ABI/packages-lag/`streamlib.yaml`-purity lines): updated in a
-  dedicated operating-model PR per the flow rule, sequenced with the rip-out.
+- `sdk/streamlib-python`: authoring surface (`decorators.py`, `processor_context.py`,
+  `frame_payload.py`, `gpu_surface.py`, `clock.py`, `log.py`, `schema_ident.py`,
+  `_generated_/`) carries over into the wheel's API; the hosting/provisioning half
+  (`_processor_registry.py`, `extract_processors.py`, setuptools packaging,
+  `streamlib.yaml`, `cgl_context.py`) is Change-B deletion scope.
+- `tools/streamlib-cli` `run`/`dev`: gain the `setup(rt)` import-and-execute path and
+  drop `RunnerAutoBuild` from the run path (auto-build dies with Change B).
+- Kernel primitives exposed to Python as configured blocks (§Graphics DECIDED): shape
+  committed here; API design is its own session before any ticket exists.
 
-## REMOVED
+## Out of scope (this change)
 
-Each bullet is a pattern the ship gate verifies is gone from the tree.
-
-- REMOVED: `runtime/streamlib-plugin-abi` (all 22 vtables, PluginAbiObject, layout tests)
-- REMOVED: `sdk/streamlib-plugin-sdk`
-- REMOVED: `export_plugin!` / `install_host_services` / `HostServices` / `ProcessorVTable`
-- REMOVED: `adapters/streamlib-adapter-abi`
-- REMOVED: `streamlib-adapter-vulkan-abi` / `streamlib-adapter-vulkan-helpers`
-- REMOVED: `streamlib-adapter-opengl-abi`
-- REMOVED: `streamlib-adapter-cpu-readback-abi` / `streamlib-adapter-cpu-readback-helpers`
-- REMOVED: `streamlib-adapter-cuda-abi` / `streamlib-adapter-cuda-helpers`
-- REMOVED: `streamlib-adapter-skia-abi`
-- REMOVED: `runtime/streamlib-engine/src/core/plugin/` (host vtable backings,
-  `build_fingerprint`, `twin_drift_guard`, load handshake)
-- REMOVED: `runtime/streamlib-engine/src/core/runtime/module_loader/` (incl.
-  `BuildOrchestrator`, package archive/staging/ledger/acquire)
-- REMOVED: `tools/streamlib-build-orchestrator`
-- REMOVED: `tools/streamlib-cargo-build`
-- REMOVED: `tools/streamlib-pack`
-- REMOVED: `tools/streamlib-cross-rustc-fixture`
-- REMOVED: `.slpkg`
-- REMOVED: `streamlib_modules`
-- REMOVED: `tools/streamlib-cli/src/commands/{add,install,link,pkg,build_on_place,generate,schema,setup}.rs`
-  (+ `commands/link/`; `setup` is PATH plumbing for the retired standalone binary —
-  pip console scripts own PATH)
-- REMOVED: `runtime/streamlib-runtime` (standalone binary)
-- REMOVED: `sdk/streamlib-deno` / `sdk/streamlib-deno-native`
-- REMOVED: `spawn_deno_subprocess_op`
-- REMOVED: `sdk/streamlib-processor-extract` (manifest derivation from source)
-- REMOVED: manifest/lockfile types in `sdk/streamlib-idents` /
-  `sdk/streamlib-processor-schema` (schema-ident types behind the JTD seam survive)
-- REMOVED: `packages/test-fixtures-abi-mismatch`
-- REMOVED: `docs/architecture/{plugin-abi,package-development-model,package-source,package-staging-layout,runtime-module-materialization,schema-identity-and-packaging,subprocess-rhi-parity,cdylib-reachability,zero-ceremony-authoring}.md`
-  (shipped-state docs follow their code out; adapter docs lose their ABI halves)
-
-## Dispositions — deferred re-authoring (recorded, not ticketed)
-
-Old consumers are re-authored, never mechanically ported, in their own planning
-sessions and milestones after the wheel exists:
-
-- Camera / display packages → absorbed into the wheel as built-ins (the one
-  disposition that IS this change's work).
-- mavlink-class packages → plain-Python processor packages (e.g. over pymavlink).
-- Hardware/GPU-heavy packages → Python packages with a native wheel inside exposing
-  handles only; the Python processor class is the sole exposed surface.
-- `escalate` host-side ops → reshaped with the helper-process machinery (engine tree).
-- `polyglot-*` and `camera-deno-subprocess` examples → deleted; replaced by normal
-  Python app examples.
-- MoQ package → rides `runtime/streamlib-moq` (survives); disposition when
-  §Networking is scheduled.
-
-## Out of scope
-
-- PyPI publication and the project rename (repo-hosted wheels until then).
-- Consumer re-authoring beyond built-ins absorption (own sessions, own milestones).
-- Audio backend selection (§Media I/O OPEN — research memo), A/V sync, additional
-  execution flavors, networking transport.
-- Folding `streamlib-consumer-rhi` back into the RHI (a later simplification; the
-  crate split is harmless meanwhile).
+- Everything REMOVED — that is Change B (`importable-python-library-ripout.md`),
+  blocked on this change: the plugin ABI, module system, build tools, Deno SDK, CLI
+  verb deletion, survivor rewires, api-server relocation, helper-process re-scope,
+  companion operating-model PR.
+- PyPI publication and the rename; consumer re-authoring (dispositions recorded in
+  Change B); audio built-in (backend OPEN); kernel-blocks API design session; TS SDK;
+  networking transport.

--- a/docs/plan/changes/importable-python-library.md
+++ b/docs/plan/changes/importable-python-library.md
@@ -1,0 +1,123 @@
+# Change: importable-python-library
+
+The rip-out and reshape for the SDK-shape pivot. Implements every
+`[importable-python-library]` DECIDED entry (§Product, §Packages & extension model,
+§Processor model, §Media I/O, §Networking, §Language SDKs, §Distribution, §Control
+plane). ADR: `docs/decisions/importable-python-library.md` (carries the owner-confirmed
+five-sentence direction). Recon verified 2026-08-02: three read-only agent sweeps
+(engine media primitives, GIL/data-plane cost, ecosystem precedent) plus direct
+enumeration of the module loader, plugin host, CLI verbs, and workspace members.
+
+Scale tier: touches the plugin ABI and the processor model → change artifact + ADR.
+
+## ADDED
+
+- The streamlib wheel: maturin-built PyO3 package = Python API + CLI + engine,
+  statically linked camera/display; abi3 across a small Python version range; released
+  as repo-hosted wheel artifacts (PyPI deferred until the project rename).
+- In-process Python authoring: `Runtime` exposed to Python via PyO3; `@processor`
+  classes execute in-process; `rt.add` accepts the imported class; `rt.run()` blocks
+  with the GIL released while the engine (and any OS-mandated main-thread pump) runs.
+- Helper-process placement: the engine may place a Python processor in a process
+  spawned from `sys.executable` (same interpreter, same venv) over the existing
+  iceoryx2 transport; placement is engine policy with a single opt-in, no other
+  user-facing surface.
+- GIL-release contract in the Python SDK: every native binding that can block releases
+  the GIL around the blocking call; frames travel as handles / surface ids, never as
+  pixels in Python.
+- Built-in media blocks in the engine tree: camera (V4L2), display, audio as native
+  processors written against the handle-shaped primitives (DMA-BUF/OPAQUE_FD import,
+  present target, texture ring, color resolution, audio clock).
+- Engine present-composition call ("present this surface, fit/fill, color-managed")
+  absorbing the draw step the old display package drove through recorder/kernel
+  handles — the display block becomes window lifecycle + one call per frame.
+- `streamlib new` app scaffold: `app.py` with `setup(rt)`, `pyproject.toml`,
+  `.python-version` pinned (3.12), working camera → effect → display wiring.
+
+## MODIFIED
+
+- `sdk/streamlib-python`: subprocess SDK → the wheel's Python API surface (authoring
+  decorators kept; hosting/provisioning code dropped).
+- Subprocess machinery (`spawn_python_native_subprocess_op`, `subprocess_bridge`,
+  `subprocess_escalate`, `streamlib-python-native`, `surface_share`,
+  `streamlib-surface-client`): retained and re-scoped as the helper-process placement
+  path — same-interpreter spawns only; all venv-provisioning and module-resolution
+  tendrils removed.
+- Adapters: `streamlib-adapter-vulkan` / `-opengl` / `-cuda` / `-skia` /
+  `-cpu-readback` cores retained as in-process interop capabilities; their cross-DSO
+  `-abi` and `-helpers` crates removed (see REMOVED).
+- CLI: `run` / `dev` stay (thin runner, #1699 shape) plus `nodes` / `graph` / `tap` /
+  `logs` / `mcp`; ships inside the wheel as a console script. Live-mutation control
+  verbs (`submit` / `replace` / `connect` / `remove`) and their MCP tools are removed;
+  `dev`'s hot-reload is the edit loop.
+- `sdk/streamlib-jtd-codegen`: internal-only (first-party Rust↔Python type parity
+  behind the rip-out-cheap seam); no user-facing codegen verb.
+- `sdk/vulkan-jpeg`: retained; cdylib-safety constraint dropped.
+- `xtask` / CI: lints and gates referencing the ABI, cdylib flavors, or `.slpkg`
+  cross-build soundness removed with their subjects.
+- `.claude/` rules, agents, and skills tied to dead systems (rule `plugin-boundary`,
+  agents `plugin-abi-expert` / `package-source-expert`, skills
+  `author-and-submit-processor` / `hot-swap-live-processor`, CLAUDE.md +
+  `engine-doctrine` ABI/packages-lag/`streamlib.yaml`-purity lines): updated in a
+  dedicated operating-model PR per the flow rule, sequenced with the rip-out.
+
+## REMOVED
+
+Each bullet is a pattern the ship gate verifies is gone from the tree.
+
+- REMOVED: `runtime/streamlib-plugin-abi` (all 22 vtables, PluginAbiObject, layout tests)
+- REMOVED: `sdk/streamlib-plugin-sdk`
+- REMOVED: `export_plugin!` / `install_host_services` / `HostServices` / `ProcessorVTable`
+- REMOVED: `adapters/streamlib-adapter-abi`
+- REMOVED: `streamlib-adapter-vulkan-abi` / `streamlib-adapter-vulkan-helpers`
+- REMOVED: `streamlib-adapter-opengl-abi`
+- REMOVED: `streamlib-adapter-cpu-readback-abi` / `streamlib-adapter-cpu-readback-helpers`
+- REMOVED: `streamlib-adapter-cuda-abi` / `streamlib-adapter-cuda-helpers`
+- REMOVED: `streamlib-adapter-skia-abi`
+- REMOVED: `runtime/streamlib-engine/src/core/plugin/` (host vtable backings,
+  `build_fingerprint`, `twin_drift_guard`, load handshake)
+- REMOVED: `runtime/streamlib-engine/src/core/runtime/module_loader/` (incl.
+  `BuildOrchestrator`, package archive/staging/ledger/acquire)
+- REMOVED: `tools/streamlib-build-orchestrator`
+- REMOVED: `tools/streamlib-cargo-build`
+- REMOVED: `tools/streamlib-pack`
+- REMOVED: `tools/streamlib-cross-rustc-fixture`
+- REMOVED: `.slpkg`
+- REMOVED: `streamlib_modules`
+- REMOVED: `tools/streamlib-cli/src/commands/{add,install,link,pkg,build_on_place,generate,schema,setup}.rs`
+  (+ `commands/link/`; `setup` is PATH plumbing for the retired standalone binary —
+  pip console scripts own PATH)
+- REMOVED: `runtime/streamlib-runtime` (standalone binary)
+- REMOVED: `sdk/streamlib-deno` / `sdk/streamlib-deno-native`
+- REMOVED: `spawn_deno_subprocess_op`
+- REMOVED: `sdk/streamlib-processor-extract` (manifest derivation from source)
+- REMOVED: manifest/lockfile types in `sdk/streamlib-idents` /
+  `sdk/streamlib-processor-schema` (schema-ident types behind the JTD seam survive)
+- REMOVED: `packages/test-fixtures-abi-mismatch`
+- REMOVED: `docs/architecture/{plugin-abi,package-development-model,package-source,package-staging-layout,runtime-module-materialization,schema-identity-and-packaging,subprocess-rhi-parity,cdylib-reachability,zero-ceremony-authoring}.md`
+  (shipped-state docs follow their code out; adapter docs lose their ABI halves)
+
+## Dispositions — deferred re-authoring (recorded, not ticketed)
+
+Old consumers are re-authored, never mechanically ported, in their own planning
+sessions and milestones after the wheel exists:
+
+- Camera / display packages → absorbed into the wheel as built-ins (the one
+  disposition that IS this change's work).
+- mavlink-class packages → plain-Python processor packages (e.g. over pymavlink).
+- Hardware/GPU-heavy packages → Python packages with a native wheel inside exposing
+  handles only; the Python processor class is the sole exposed surface.
+- `escalate` host-side ops → reshaped with the helper-process machinery (engine tree).
+- `polyglot-*` and `camera-deno-subprocess` examples → deleted; replaced by normal
+  Python app examples.
+- MoQ package → rides `runtime/streamlib-moq` (survives); disposition when
+  §Networking is scheduled.
+
+## Out of scope
+
+- PyPI publication and the project rename (repo-hosted wheels until then).
+- Consumer re-authoring beyond built-ins absorption (own sessions, own milestones).
+- Audio backend selection (§Media I/O OPEN — research memo), A/V sync, additional
+  execution flavors, networking transport.
+- Folding `streamlib-consumer-rhi` back into the RHI (a later simplification; the
+  crate split is harmless meanwhile).

--- a/docs/plan/changes/mvp-app-experience.md
+++ b/docs/plan/changes/mvp-app-experience.md
@@ -1,5 +1,11 @@
 # Change: mvp-app-experience
 
+> **Partially superseded 2026-08-02 by `importable-python-library.md`.** Its
+> package-source, discovery-scan, string-id, and subprocess-execution sections are dead;
+> the `app.py`/`setup(rt)` convention, `streamlib new`, and class-form `rt.add` survive
+> and are restated by the pivot change. `/reconcile-tracker` sorts its tickets
+> accordingly; derive nothing new from this file.
+
 Implements §Product's sentence terms — `streamlib new`, the `app.py`/`setup(rt)` entry
 convention, app-local processors, string-or-class `rt.add` — and §Control plane's
 "`run`/`dev` host the runtime in-process" entry. ADRs: `product-mvp-sentence.md`,

--- a/docs/plan/changes/pypi-packaging.md
+++ b/docs/plan/changes/pypi-packaging.md
@@ -1,5 +1,10 @@
 # Change: pypi-packaging
 
+> **Superseded 2026-08-02 by `importable-python-library.md`.** The shipped artifact is
+> now a PyO3 wheel (Python API + CLI + engine), not packaging around a standalone
+> binary, and initial releases are repo-hosted (PyPI deferred until the rename). Do not
+> derive tickets from this file; `/reconcile-tracker` retires its open tickets.
+
 Implements the "installs streamlib from PyPI" clause of `[product-mvp-sentence]`
 (§Product) and the "PyPI ships exactly one artifact" consequence of
 `[single-binary-launch]` (§Control plane). No ADR: nothing here touches the plugin ABI,

--- a/docs/plan/changes/schema-agreement-ripout.md
+++ b/docs/plan/changes/schema-agreement-ripout.md
@@ -1,5 +1,12 @@
 # Change: schema-agreement-ripout
 
+> **Reconciliation note 2026-08-02** (`importable-python-library` pivot): the core
+> decision here — advisory connect, cast-at-read, inert wire tag — stands unchanged.
+> But this file's STAY rationale cites `module_loader/` paths, `sdk/streamlib-deno`,
+> the consumer-upgrade-backlog doctrine, and plugin-ABI version bumps — all deleted by
+> the pivot. Where a cited path is gone, the pivot's change files govern; the
+> `SchemaIdent` survival case is registry/factory only.
+
 Implements `[data-plane-cast-not-contract]` (§Processor model & scheduling) and the
 "bags/schemas fixed" clause of the zero-ceremony bar (§Product). ADR:
 `docs/decisions/data-plane-cast-not-contract.md`. Recon verified every claim below at

--- a/docs/plan/diagrams/system.mmd
+++ b/docs/plan/diagrams/system.mmd
@@ -1,23 +1,28 @@
 flowchart LR
-  subgraph consumers["Consumers — tatolab/streamlib-packages (lag by design)"]
-    pkgs["Distributable packages"]
-    apps["Example apps"]
+  subgraph env["One uv-managed venv — one Python, PyPI deps only"]
+    app["User Python app\n(app.py setup(rt) — normal codebase)"]
+    pkgs["Processor packages\n(ordinary PyPI packages; native internals\nexpose handles, never streamlib internals)"]
+    wheel["streamlib wheel — PyPI\n(Python API + CLI + engine, PyO3)"]
   end
 
-  cli["streamlib — one shipped binary\n(CLI + runtime host + build orchestration)"]
-  ctl["Control plane\n(api-server: HTTP / WS / MCP — engine-side, runtime/)"]
-  engine["Engine runtime\n(runtime/streamlib-engine — embeddable library)"]
+  rustapp["Rust app\n(plain cargo project)"]
+  crate["streamlib crate\n(embeddable Rust library)"]
+  engine["Engine runtime\n(runtime/streamlib-engine)"]
+  media["Built-in media blocks\n(camera / display / audio — native,\nin the wheel, handle-shaped primitives)"]
   rhi["RHI\n(vulkan/rhi + streamlib-consumer-rhi)"]
-  abi["Plugin ABI\n(repr(C), runtime/streamlib-plugin-abi)"]
-  sdk["SDKs\n(Rust / Python / Deno + control-plane client)"]
-  pkgsrc["Package source\n(versioned artifacts, never sibling dirs)"]
+  interop["Interop adapters\n(Vulkan↔CUDA, Vulkan↔GL — in-process)"]
+  ctl["Control plane\n(api-server: HTTP / WS / MCP — engine-side)"]
+  cli["CLI (in the wheel)\nnew / dev / run · nodes / graph / tap / logs / mcp"]
+  wire["Wire\n(self-describing bags between nodes —\nthe only cross-language boundary)"]
 
-  apps --> sdk
-  pkgs --> abi
-  sdk --> abi
-  abi --> engine
+  pkgs --> app
+  app --> wheel
+  wheel --> engine
+  rustapp --> crate
+  crate --> engine
+  media --> engine
   engine --> rhi
-  cli --> ctl
+  engine --> interop
   ctl --> engine
-  cli --> pkgsrc
-  pkgsrc --> engine
+  cli --> ctl
+  engine --> wire

--- a/docs/plan/diagrams/system.mmd
+++ b/docs/plan/diagrams/system.mmd
@@ -2,7 +2,8 @@ flowchart LR
   subgraph env["One uv-managed venv — one Python, PyPI deps only"]
     app["User Python app\n(app.py setup(rt) — normal codebase)"]
     pkgs["Processor packages\n(ordinary PyPI packages; native internals\nexpose handles, never streamlib internals)"]
-    wheel["streamlib wheel — PyPI\n(Python API + CLI + engine, PyO3)"]
+    wheel["streamlib wheel\n(Python API + CLI + engine, PyO3 —\nrepo releases now, PyPI after rename)"]
+    helper["Helper processes\n(spawned from sys.executable — engine\nplacement decision, same code either way)"]
   end
 
   rustapp["Rust app\n(plain cargo project)"]
@@ -15,9 +16,13 @@ flowchart LR
   cli["CLI (in the wheel)\nnew / dev / run · nodes / graph / tap / logs / mcp"]
   wire["Wire\n(self-describing bags between nodes —\nthe only cross-language boundary)"]
 
+  registry["Node registry\n(per-user on-disk, one JSON per live node)"]
+
   pkgs --> app
   app --> wheel
   wheel --> engine
+  engine --> helper
+  ctl --> registry
   rustapp --> crate
   crate --> engine
   media --> engine


### PR DESCRIPTION
## The pivot, in five sentences (owner-confirmed verbatim, 2026-08-02)

1. StreamLib becomes an importable Python library: `pip install streamlib` delivers one PyO3 wheel containing the Python API and the Rust engine, and a StreamLib app is a normal Python codebase — one uv-managed venv, one Python version, ordinary PyPI dependencies, no manifest, no custom module system (`streamlib_modules/`, add/install/link/pkg, and runtime downloading are deleted).
2. Processors are Python classes — written in the app or imported from pip-installed packages — and `rt.add` takes the class; whether the engine runs a processor in-process or in a helper process spawned from that same interpreter and venv is an under-the-hood engine placement decision, never a user-facing runtime definition.
3. The plugin ABI is deleted entirely: third-party native code ships as ordinary Python packages that expose handles (frames, FDs, device pointers) to a Python processor and never speak streamlib internals, while first-party camera, display, and audio ship inside the wheel as native pre-built blocks driven from Python by configuration.
4. Python is the sole focus runtime: cross-language interop happens on the wire between mesh nodes as self-describing bags — never in-graph — so the current Deno SDK is deleted with the subprocess machinery it's built on, while TypeScript authoring is paused-not-rejected (a future importable TypeScript SDK on this same model), and a Rust app remains a plain cargo project on the `streamlib` crate.
5. The CLI slims to `new` / `dev` / `run` as a thin runner plus the observation verbs (`nodes` / `graph` / `tap` / `logs` / `mcp`); build orchestration, packaging, provisioning, and codegen verbs are deleted — compilation happens at publish time with standard tools, and JTD schemas are demoted to advisory, experimental type info behind a rip-out-cheap seam, never a requirement for accessing data.

## What this PR changes

- **ARCHITECTURE.md** — §Product, §Module system (now §Packages & extension model), §Processor model, §Media I/O, §Networking, §Language SDKs, §Distribution, §Control plane rewritten with `[importable-python-library]` DECIDED entries; contradicted entries replaced.
- **New ADR** `docs/decisions/importable-python-library.md` — carries the direction verbatim, the why (the pain was environments, never processes; the ABI's tenants all left; native built-ins per the GIL/precedent evidence), rejected alternatives, and consequences.
- **Supersession annotations** (dated strikethrough per docs policy) in `single-binary-launch.md`, `media-io-layering.md`, `product-mvp-sentence.md`.
- **`diagrams/system.mmd`** — redrawn around the wheel-in-one-venv shape.

## Evidence behind the media built-ins split

Three independent analyses (engine-primitive inventory, GIL/data-plane cost, ecosystem survey): the engine's primitive surface is already handle-shaped (fds/u64/POD — the old ABI proved it); a vsync-blocked present or device audio callback under a shared GIL stalls the entire Python plane every frame; no surveyed in-process realtime system (Holoscan, GStreamer) runs Python per-frame in first-party capture/present/audio — dora-rs does only via process-per-node isolation, and went native for codecs.

## Next (per /pivot)

Step 3 legacy inventory → step 4 rip-out `/propose-change` + `/derive-tickets` → step 5 `/reconcile-tracker` (unfreezes M39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)