### PR TITLE
feat(python): the importable wheel + interpreter-lifecycle contract

### DIFF
--- a/.github/workflows/lint-logging.yml
+++ b/.github/workflows/lint-logging.yml
@@ -8,7 +8,7 @@ name: Lint Logging
 #   `#[allow(clippy::disallowed_macros)]`, `#[cfg(test)]`, and platform cfg
 #   gates exactly as clippy would on `ubuntu-latest`.
 # - Python: banned `print()`/`sys.stdout`/`logging.basicConfig` in
-#   sdk/streamlib-python.
+#   sdk/streamlib-python and sdk/streamlib-python-wheel/python.
 # - TypeScript: banned `console.*`/`Deno.stdout.write` in sdk/streamlib-deno.
 #
 # Rationale for not using `cargo clippy --workspace`: it transitively compiles

--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -47,6 +47,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-wheel-
 
+      # Scoped to the signals module rather than the whole engine lib suite,
+      # which is a tracked follow-up (see test.yml) pending a parallel-run
+      # flake. These need no GPU, and without them the ownership, restoration,
+      # retake and stale-signal locks run nowhere in CI.
+      - name: Shutdown-signal ownership tests
+        run: cargo test --locked -p streamlib-engine --lib -- core::signals
+
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
@@ -65,10 +72,11 @@ jobs:
       # memory, and a software rasterizer (lavapipe) cannot — verified in a
       # GPU-less container. So this job proves the half of the contract that
       # does not need a device: the wheel imports, the engine boots and tears
-      # down, and neither the exception path nor a never-run Runtime hangs at
-      # interpreter finalization. The `requires_gpu` half — Ctrl-C during and
-      # after startup, GIL release while blocking, SIGINT handback, no zombie —
-      # runs on the rig.
+      # down, and neither the exception path nor a Runtime still referenced at
+      # interpreter exit hangs finalization. The `requires_gpu` half — Ctrl-C
+      # during and after startup, GIL release while blocking, SIGINT handback,
+      # cross-thread shutdown, no surviving process group — is rig-only by
+      # owner decision (2026-08-03) rather than a self-hosted GPU runner.
       - name: Interpreter-lifecycle contract (GPU-free half)
         working-directory: sdk/streamlib-python-wheel
         env:

--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -1,0 +1,78 @@
+name: Python Wheel
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  wheel-interpreter-lifecycle:
+    name: Wheel build + interpreter lifecycle (no GPU)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        # Same minimal engine build set as test.yml: the engine's build.rs
+        # compiles GLSL with glslc and generates JTD bindings, and the Linux
+        # dep set links Vulkan.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config \
+            protobuf-compiler \
+            libvulkan-dev \
+            glslc
+
+      - name: Install jtd-codegen
+        run: |
+          curl -sSL https://github.com/jsontypedef/json-typedef-codegen/releases/download/v0.4.1/x86_64-unknown-linux-gnu.zip -o /tmp/jtd-codegen.zip
+          unzip -q /tmp/jtd-codegen.zip -d /tmp/jtd-codegen
+          sudo install -m 0755 /tmp/jtd-codegen/jtd-codegen /usr/local/bin/jtd-codegen
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        continue-on-error: true
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-wheel-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-wheel-
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build and install the wheel
+        # `maturin develop` is the local build the ticket scopes; release
+        # packaging (repo release artifacts + the PEP 503 simple index) is a
+        # later ticket.
+        working-directory: sdk/streamlib-python-wheel
+        run: |
+          uv venv --python 3.12 .venv
+          VIRTUAL_ENV="$PWD/.venv" uv pip install pytest
+          VIRTUAL_ENV="$PWD/.venv" uvx maturin@1.9.6 develop
+
+      # The runner has no GPU. `Runner::start()` initializes a GPU context whose
+      # DMA-BUF pool pre-warm needs a driver that can allocate exportable device
+      # memory, and a software rasterizer (lavapipe) cannot — verified in a
+      # GPU-less container. So this job proves the half of the contract that
+      # does not need a device: the wheel imports, the engine boots and tears
+      # down, and neither the exception path nor a never-run Runtime hangs at
+      # interpreter finalization. The `requires_gpu` half — Ctrl-C during and
+      # after startup, GIL release while blocking, SIGINT handback, no zombie —
+      # runs on the rig.
+      - name: Interpreter-lifecycle contract (GPU-free half)
+        working-directory: sdk/streamlib-python-wheel
+        env:
+          XDG_RUNTIME_DIR: /tmp/streamlib-runtime-dir
+        run: |
+          mkdir -p "$XDG_RUNTIME_DIR"
+          .venv/bin/python -m pytest tests/ -v -m "not requires_gpu"

--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -51,8 +51,10 @@ jobs:
       # which is a tracked follow-up (see test.yml) pending a parallel-run
       # flake. These need no GPU, and without them the ownership, restoration,
       # retake and stale-signal locks run nowhere in CI.
-      - name: Shutdown-signal ownership tests
-        run: cargo test --locked -p streamlib-engine --lib -- core::signals
+      - name: Shutdown-signal ownership and stop-idempotency tests
+        run: |
+          cargo test --locked -p streamlib-engine --lib -- \
+            core::signals core::runtime::runtime::tests::stopping
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3650,6 +3650,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
 
 [[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3763,6 +3769,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc153f5fd745cc038b5eed86622125969f8a39834a57bc96beaaf2512b1da729"
+dependencies = [
+ "libc",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb77d9aa6d647507b55c69ee714d266d84c526c78ff0bc6dd8757f58591e64d1"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3160087aa5733bce7d9a729f8c55f85a2a53b74742a09613178eeebff0722253"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f9d455db760a9a0b0ddeaac25f1390b8a36ba73dfbda9f127cac6fc340d4d5"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e343bcec300ff262f5806a33a4e51b6d097a8a46435f512fcb83e95592581625"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5387,6 +5450,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "streamlib-python-wheel"
+version = "0.10.2"
+dependencies = [
+ "pyo3",
+ "streamlib",
+ "tracing",
+]
+
+[[package]]
 name = "streamlib-runtime"
 version = "0.10.2"
 dependencies = [
@@ -5483,6 +5555,12 @@ dependencies = [
  "libc",
  "xattr",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tatolab-vulkanalia"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "adapters/streamlib-adapter-skia-abi", # Cross-DSO callback table for streamlib-adapter-skia — extern "C" vtable consumed by host wiring + cdylib shim (#889)
     "sdk/streamlib-deno-native", # FFI cdylib for Deno subprocess iceoryx2 access
     "sdk/streamlib-python-native", # FFI cdylib for Python subprocess iceoryx2 access
+    "sdk/streamlib-python-wheel", # The importable Python wheel — CPython imports the engine and authors pipelines in-process
     "runtime/streamlib-ipc-types",  # Shared iceoryx2 payload types for cross-process IPC
     "runtime/streamlib-moq",        # MoQ-over-QUIC transport library (sessions + catalog); the @tatolab/moq package's processors + the api-server build on it
     "vendor/tatolab-vulkanalia",     # Vendored vulkanalia fork (Apache-2.0) — see docs/architecture/vendored-vulkanalia.md

--- a/runtime/streamlib-engine/src/core/runtime/runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/runtime.rs
@@ -908,10 +908,17 @@ impl Runner {
     where
         F: FnMut(&Self) -> ControlFlow<()>,
     {
-        // Install signal handlers
-        crate::core::signals::install_signal_handlers().map_err(|e| {
-            crate::core::Error::Configuration(format!("Failed to install signal handlers: {}", e))
-        })?;
+        // Held to the end of this function, so the dispositions are handed back
+        // only after the teardown below has run.
+        let _shutdown_signals =
+            crate::core::signals::ScopedShutdownSignalOwnership::take_until_dropped().map_err(
+                |e| {
+                    crate::core::Error::Configuration(format!(
+                        "Failed to own shutdown signals: {}",
+                        e
+                    ))
+                },
+            )?;
 
         let shutdown_flag = Arc::new(AtomicBool::new(false));
         let shutdown_flag_clone = Arc::clone(&shutdown_flag);

--- a/runtime/streamlib-engine/src/core/runtime/runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/runtime.rs
@@ -626,6 +626,14 @@ impl Runner {
     /// Stop the runtime.
     #[tracing::instrument(name = "runtime.stop", skip_all)]
     pub fn stop(&self) -> Result<()> {
+        // Idempotent: the run loop stops the runtime itself, and an embedding
+        // host tears down afterwards. Without this both publish the
+        // Stopping/Stopped pair and every subscriber sees the transition twice.
+        if *self.status.lock() == RuntimeStatus::Stopped {
+            tracing::debug!("[stop] Already stopped");
+            return Ok(());
+        }
+
         tracing::info!("[stop] Beginning graceful shutdown");
         *self.status.lock() = RuntimeStatus::Stopping;
         PUBSUB.publish(
@@ -910,9 +918,25 @@ impl Runner {
     /// that lands on CPython's handler there can never be turned into a
     /// `KeyboardInterrupt` and the process hangs.
     pub fn start_and_wait_for_shutdown(self: &Arc<Self>) -> Result<()> {
-        let _shutdown_signals = Self::take_shutdown_signal_ownership()?;
-        self.start()?;
-        self.wait_for_shutdown_observation_with(|_| ControlFlow::Continue(()))
+        let run_outcome = {
+            let _shutdown_signals = Self::take_shutdown_signal_ownership()?;
+            self.start().and_then(|()| {
+                self.wait_for_shutdown_observation_with(|_| ControlFlow::Continue(()))
+            })
+        };
+        Self::clear_shutdown_requests_latched_during_teardown();
+        run_outcome
+    }
+
+    /// Take any request that landed after the run loop stopped observing.
+    ///
+    /// Called once shutdown-signal ownership has dropped, so no further signal
+    /// can reach the funnel. Without it a Ctrl-C during teardown stays latched
+    /// and the next run loop in this process returns immediately having run
+    /// nothing — the embedded case, where one interpreter hosts several run
+    /// loops in turn.
+    fn clear_shutdown_requests_latched_during_teardown() {
+        crate::core::runtime::take_runtime_shutdown_request_latch();
     }
 
     fn take_shutdown_signal_ownership()
@@ -937,10 +961,14 @@ impl Runner {
     where
         F: FnMut(&Self) -> ControlFlow<()>,
     {
-        // Held to the end of this function, so the dispositions are handed back
-        // only after the teardown below has run.
-        let _shutdown_signals = Self::take_shutdown_signal_ownership()?;
-        self.wait_for_shutdown_observation_with(callback)
+        let wait_outcome = {
+            // Held only for the wait, so the dispositions are handed back once
+            // the teardown inside has run.
+            let _shutdown_signals = Self::take_shutdown_signal_ownership()?;
+            self.wait_for_shutdown_observation_with(callback)
+        };
+        Self::clear_shutdown_requests_latched_during_teardown();
+        wait_outcome
     }
 
     /// The wait loop itself, for callers that already own the shutdown signals.

--- a/runtime/streamlib-engine/src/core/runtime/runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/runtime.rs
@@ -898,28 +898,56 @@ impl Runner {
         self.wait_for_signal_with(|_| ControlFlow::Continue(()))
     }
 
+    /// Own the shutdown signals, [`start`](Self::start), block until shutdown,
+    /// and tear down — the whole run in one call.
+    ///
+    /// Preferred over `start()` followed by
+    /// [`wait_for_signal`](Self::wait_for_signal), because signal ownership
+    /// spans startup here: a Ctrl-C arriving while the graph is still coming up
+    /// reaches the request funnel rather than whatever disposition was
+    /// installed before. In an embedded host that gap is not merely a lost
+    /// signal — the wheel's `rt.run()` blocks with the GIL released, so a SIGINT
+    /// that lands on CPython's handler there can never be turned into a
+    /// `KeyboardInterrupt` and the process hangs.
+    pub fn start_and_wait_for_shutdown(self: &Arc<Self>) -> Result<()> {
+        let _shutdown_signals = Self::take_shutdown_signal_ownership()?;
+        self.start()?;
+        self.wait_for_shutdown_observation_with(|_| ControlFlow::Continue(()))
+    }
+
+    fn take_shutdown_signal_ownership()
+    -> Result<crate::core::signals::ScopedShutdownSignalOwnership> {
+        crate::core::signals::ScopedShutdownSignalOwnership::take_until_dropped().map_err(
+            |ownership_failure| {
+                crate::core::Error::Configuration(format!(
+                    "Failed to own shutdown signals: {}",
+                    ownership_failure
+                ))
+            },
+        )
+    }
+
     /// Block until shutdown signal, with periodic callback for dynamic control.
     ///
     /// This is the run-loop owner: it observes both the `RuntimeShutdown`
     /// event and the shutdown-request latch, then runs the normal teardown.
     /// The latch is polled as well as the event because a request published
     /// before this subscriber was wired up leaves no event to receive.
-    pub fn wait_for_signal_with<F>(self: &Arc<Self>, mut callback: F) -> Result<()>
+    pub fn wait_for_signal_with<F>(self: &Arc<Self>, callback: F) -> Result<()>
     where
         F: FnMut(&Self) -> ControlFlow<()>,
     {
         // Held to the end of this function, so the dispositions are handed back
         // only after the teardown below has run.
-        let _shutdown_signals =
-            crate::core::signals::ScopedShutdownSignalOwnership::take_until_dropped().map_err(
-                |e| {
-                    crate::core::Error::Configuration(format!(
-                        "Failed to own shutdown signals: {}",
-                        e
-                    ))
-                },
-            )?;
+        let _shutdown_signals = Self::take_shutdown_signal_ownership()?;
+        self.wait_for_shutdown_observation_with(callback)
+    }
 
+    /// The wait loop itself, for callers that already own the shutdown signals.
+    fn wait_for_shutdown_observation_with<F>(self: &Arc<Self>, mut callback: F) -> Result<()>
+    where
+        F: FnMut(&Self) -> ControlFlow<()>,
+    {
         let shutdown_flag = Arc::new(AtomicBool::new(false));
         let shutdown_flag_clone = Arc::clone(&shutdown_flag);
 

--- a/runtime/streamlib-engine/src/core/runtime/runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/runtime.rs
@@ -626,16 +626,20 @@ impl Runner {
     /// Stop the runtime.
     #[tracing::instrument(name = "runtime.stop", skip_all)]
     pub fn stop(&self) -> Result<()> {
-        // Idempotent: the run loop stops the runtime itself, and an embedding
-        // host tears down afterwards. Without this both publish the
-        // Stopping/Stopped pair and every subscriber sees the transition twice.
-        if *self.status.lock() == RuntimeStatus::Stopped {
-            tracing::debug!("[stop] Already stopped");
-            return Ok(());
+        // Idempotent, and claimed under one lock acquisition so two concurrent
+        // callers cannot both pass the check: the run loop stops the runtime
+        // itself and an embedding host tears down afterwards, and without this
+        // every subscriber sees the Stopping/Stopped pair twice.
+        {
+            let mut runtime_status = self.status.lock();
+            if *runtime_status == RuntimeStatus::Stopped {
+                tracing::debug!("[stop] Already stopped");
+                return Ok(());
+            }
+            *runtime_status = RuntimeStatus::Stopping;
         }
 
         tracing::info!("[stop] Beginning graceful shutdown");
-        *self.status.lock() = RuntimeStatus::Stopping;
         PUBSUB.publish(
             topics::RUNTIME_GLOBAL,
             &Event::RuntimeGlobal(RuntimeEvent::RuntimeStopping),
@@ -913,10 +917,7 @@ impl Runner {
     /// [`wait_for_signal`](Self::wait_for_signal), because signal ownership
     /// spans startup here: a Ctrl-C arriving while the graph is still coming up
     /// reaches the request funnel rather than whatever disposition was
-    /// installed before. In an embedded host that gap is not merely a lost
-    /// signal — the wheel's `rt.run()` blocks with the GIL released, so a SIGINT
-    /// that lands on CPython's handler there can never be turned into a
-    /// `KeyboardInterrupt` and the process hangs.
+    /// installed before.
     pub fn start_and_wait_for_shutdown(self: &Arc<Self>) -> Result<()> {
         let run_outcome = {
             let _shutdown_signals = Self::take_shutdown_signal_ownership()?;
@@ -931,10 +932,7 @@ impl Runner {
     /// Take any request that landed after the run loop stopped observing.
     ///
     /// Called once shutdown-signal ownership has dropped, so no further signal
-    /// can reach the funnel. Without it a Ctrl-C during teardown stays latched
-    /// and the next run loop in this process returns immediately having run
-    /// nothing — the embedded case, where one interpreter hosts several run
-    /// loops in turn.
+    /// can reach the funnel.
     fn clear_shutdown_requests_latched_during_teardown() {
         crate::core::runtime::take_runtime_shutdown_request_latch();
     }
@@ -1048,11 +1046,9 @@ impl Runner {
                 );
             }
 
-            // The request has been observed; leaving it latched would make the
-            // next `wait_for_signal_with` in this process return instantly.
-            crate::core::runtime::take_runtime_shutdown_request_latch();
-
-            // Auto-stop on exit
+            // Auto-stop on exit. The observed request is taken by the caller
+            // once shutdown-signal ownership has dropped, which also catches
+            // anything latched during this teardown.
             self.stop()?;
 
             Ok(())
@@ -1811,5 +1807,69 @@ mod tests {
                 assert!(resp.get("error").is_some());
             });
         }
+    }
+
+    /// An embedding host tears the engine down after the run loop already
+    /// stopped it, so the second `stop()` must be a no-op rather than a second
+    /// full teardown that republishes the transition to every subscriber.
+    ///
+    /// Mental-revert: removing the already-stopped early return in `stop()`
+    /// makes the second call publish `RuntimeStopping`/`RuntimeStopped` again
+    /// and fails the counts below.
+    #[test]
+    #[serial_test::serial]
+    fn stopping_an_already_stopped_runtime_is_a_no_op() {
+        use crate::core::pubsub::{Event, EventListener, PUBSUB, RuntimeEvent, topics};
+
+        #[derive(Default)]
+        struct StopTransitionCounter {
+            stopping: usize,
+            stopped: usize,
+        }
+
+        struct CountingListener(Arc<Mutex<StopTransitionCounter>>);
+
+        impl EventListener for CountingListener {
+            fn on_event(&mut self, event: &Event) -> Result<()> {
+                let mut counts = self.0.lock();
+                match event {
+                    Event::RuntimeGlobal(RuntimeEvent::RuntimeStopping) => counts.stopping += 1,
+                    Event::RuntimeGlobal(RuntimeEvent::RuntimeStopped) => counts.stopped += 1,
+                    _ => {}
+                }
+                Ok(())
+            }
+        }
+
+        let runner = Runner::new().expect("a runner boots without a graph");
+        let counts = Arc::new(Mutex::new(StopTransitionCounter::default()));
+        let listener: Arc<Mutex<dyn EventListener>> =
+            Arc::new(Mutex::new(CountingListener(Arc::clone(&counts))));
+        PUBSUB.subscribe(topics::RUNTIME_GLOBAL, Arc::clone(&listener));
+
+        runner.stop().expect("the first stop succeeds");
+        runner.stop().expect("the second stop succeeds");
+
+        // Delivery is not synchronous with the publish, so wait for the first
+        // teardown's pair to land before counting — otherwise a duplicate that
+        // simply arrived late would read as "published once".
+        let delivery_deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < delivery_deadline {
+            if counts.lock().stopped >= 1 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(250));
+
+        let observed = counts.lock();
+        assert_eq!(
+            observed.stopping, 1,
+            "RuntimeStopping must be published exactly once across two stops",
+        );
+        assert_eq!(
+            observed.stopped, 1,
+            "RuntimeStopped must be published exactly once across two stops",
+        );
     }
 }

--- a/runtime/streamlib-engine/src/core/signals.rs
+++ b/runtime/streamlib-engine/src/core/signals.rs
@@ -43,12 +43,6 @@ struct UnixSignalForwarding {
 
 /// One signal's pre-existing disposition, restored on drop unless already
 /// restored explicitly.
-///
-/// The restore is RAII because it must survive every failure path in
-/// `install()` — a handler left pointing at the self-pipe with no forwarding
-/// thread behind it swallows Ctrl-C and SIGTERM for the rest of the process.
-/// Carrying the signal number alongside its action also makes restoring one
-/// signal's disposition onto another unrepresentable.
 #[cfg(all(unix, not(target_os = "macos")))]
 struct DisplacedSignalDisposition {
     signal: libc::c_int,
@@ -158,11 +152,11 @@ extern "C" fn write_delivered_signal_to_self_pipe(delivered_signal: libc::c_int)
     };
     let delivered_signal_byte = delivered_signal as u8;
     // SAFETY: `write_end` stays open for the process lifetime, and the source
-    // is one byte of stack this frame owns. The write is non-blocking, so a
-    // failure here means the pipe is backed up and a shutdown request is
-    // already queued — dropping this one changes nothing. `errno` is saved and
-    // restored around it because the handler preempted a syscall that may be
-    // about to read its own errno.
+    // is one byte of stack this frame owns. A failure is either a full pipe (a
+    // request is already queued) or a descriptor the process has lost; neither
+    // is actionable from signal context. `errno` is saved and restored around
+    // it because the handler preempted a syscall that may be about to read its
+    // own errno.
     unsafe {
         let errno_slot = libc::__errno_location();
         let interrupted_errno = *errno_slot;
@@ -205,9 +199,6 @@ impl ScopedShutdownSignalOwnership {
         // otherwise be read by this owner and shut it down on the spot.
         drain_pending_bytes(self_pipe.read_end)?;
 
-        // Both displacements restore themselves if anything below fails —
-        // including the thread spawn, which would otherwise leave the handlers
-        // installed with nothing reading the pipe.
         let displaced_sigint = DisplacedSignalDisposition::displace_with_self_pipe_handler(SIGINT)?;
         let displaced_sigterm =
             DisplacedSignalDisposition::displace_with_self_pipe_handler(SIGTERM)?;
@@ -244,10 +235,13 @@ impl ScopedShutdownSignalOwnership {
                 trigger_macos_termination();
             })
             .map_err(std::io::Error::other)?;
+            // Claimed here rather than after the SIGTERM install below: the
+            // ctrlc handler is already irreversible, so a later failure that
+            // left this unset would re-enter this branch forever and every
+            // subsequent take would fail on `MultipleHandlers`.
+            let _ = MACOS_TERMINATION_HANDLERS_INSTALLED.set(());
 
             install_sigterm_handler_macos()?;
-
-            let _ = MACOS_TERMINATION_HANDLERS_INSTALLED.set(());
             tracing::info!(
                 "macOS shutdown signals owned (Ctrl+C via ctrlc, SIGTERM via signal-hook)"
             );
@@ -270,9 +264,7 @@ impl Drop for ScopedShutdownSignalOwnership {
         if let Some(mut forwarding) = self.signal_forwarding.take() {
             // Restore before winding the thread down, so a signal arriving
             // during teardown reaches whoever held the disposition rather than
-            // a handler whose reader is going away. This is the call that hands
-            // SIGINT back to CPython in the wheel. Both are already-restored
-            // after this, so their `Drop` is a no-op.
+            // a handler whose reader is going away.
             forwarding.displaced_sigint.restore_now();
             forwarding.displaced_sigterm.restore_now();
 
@@ -305,9 +297,6 @@ fn shutdown_signal_self_pipe() -> std::io::Result<&'static ShutdownSignalSelfPip
 
     // A full pipe must never block the handler, so the write end is
     // non-blocking; a dropped byte only ever means a request is already queued.
-    // Checked rather than assumed: leaving the write end blocking would let the
-    // handler stall inside signal context, the one thing this design must not
-    // do.
     // SAFETY: `pipe_ends[1]` was just returned by `pipe2`.
     if unsafe { libc::fcntl(pipe_ends[1], libc::F_SETFL, libc::O_NONBLOCK) } < 0 {
         let flag_failure = std::io::Error::last_os_error();
@@ -329,10 +318,6 @@ fn shutdown_signal_self_pipe() -> std::io::Result<&'static ShutdownSignalSelfPip
 
 /// Read the self-pipe until stopped, funnelling each delivered signal into
 /// [`request_runtime_shutdown`].
-///
-/// The wait is a bounded `poll` rather than a blocking `read` so the stop flag
-/// is observed even if the stop byte never lands — a lost wakeup here would
-/// hang `join()` inside a `Drop`.
 #[cfg(all(unix, not(target_os = "macos")))]
 fn forward_signals_until_stopped(read_end: std::os::fd::RawFd) {
     tracing::debug!("Shutdown-signal forwarding thread started");
@@ -395,9 +380,6 @@ fn forward_signals_until_stopped(read_end: std::os::fd::RawFd) {
 /// Ask the forwarding thread to stop, and nudge it out of its poll.
 #[cfg(all(unix, not(target_os = "macos")))]
 fn stop_forwarding_thread() {
-    // The flag is what actually bounds the join; the byte only shortens the
-    // wait from the poll interval to immediately, so a failed write is
-    // recoverable and not worth failing teardown over.
     FORWARDING_THREAD_SHOULD_STOP.store(true, Ordering::SeqCst);
 
     let Some(self_pipe) = SHUTDOWN_SIGNAL_SELF_PIPE.get() else {
@@ -420,11 +402,8 @@ fn stop_forwarding_thread() {
     }
 }
 
-/// Discard bytes left in the pipe by a previous owner.
-///
-/// Both `fcntl`s are checked because the drain below only terminates while the
-/// read end is non-blocking — on an unchecked failure it would block forever
-/// inside `install()`, which is inside `rt.run()`.
+/// Discard bytes left in the pipe by a previous owner. Terminates only while
+/// the read end is non-blocking, so both `fcntl`s are checked.
 #[cfg(all(unix, not(target_os = "macos")))]
 fn drain_pending_bytes(read_end: std::os::fd::RawFd) -> std::io::Result<()> {
     // SAFETY: `read_end` stays open for the process lifetime; the destination

--- a/runtime/streamlib-engine/src/core/signals.rs
+++ b/runtime/streamlib-engine/src/core/signals.rs
@@ -37,8 +37,80 @@ pub struct ScopedShutdownSignalOwnership {
 #[cfg(all(unix, not(target_os = "macos")))]
 struct UnixSignalForwarding {
     forwarding_thread: std::thread::JoinHandle<()>,
-    previous_sigint_disposition: libc::sigaction,
-    previous_sigterm_disposition: libc::sigaction,
+    displaced_sigint: DisplacedSignalDisposition,
+    displaced_sigterm: DisplacedSignalDisposition,
+}
+
+/// One signal's pre-existing disposition, restored on drop unless already
+/// restored explicitly.
+///
+/// The restore is RAII because it must survive every failure path in
+/// `install()` — a handler left pointing at the self-pipe with no forwarding
+/// thread behind it swallows Ctrl-C and SIGTERM for the rest of the process.
+/// Carrying the signal number alongside its action also makes restoring one
+/// signal's disposition onto another unrepresentable.
+#[cfg(all(unix, not(target_os = "macos")))]
+struct DisplacedSignalDisposition {
+    signal: libc::c_int,
+    previous_action: libc::sigaction,
+    already_restored: bool,
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+impl DisplacedSignalDisposition {
+    /// Point `signal` at the self-pipe handler, capturing what it displaced.
+    fn displace_with_self_pipe_handler(signal: libc::c_int) -> std::io::Result<Self> {
+        // SAFETY: `requested` is fully initialized before use, `displaced` is
+        // owned here and written by the kernel, and the handler installed is a
+        // plain `extern "C"` function with no Rust-level invariants to uphold.
+        unsafe {
+            let mut requested: libc::sigaction = std::mem::zeroed();
+            let handler: extern "C" fn(libc::c_int) = write_delivered_signal_to_self_pipe;
+            requested.sa_sigaction = handler as usize;
+            // SA_RESTART so a shutdown signal does not surface as EINTR in
+            // engine threads blocked on a syscall — the request funnel is the
+            // only path that reacts to it.
+            requested.sa_flags = libc::SA_RESTART;
+            libc::sigemptyset(&mut requested.sa_mask);
+
+            let mut previous_action: libc::sigaction = std::mem::zeroed();
+            if libc::sigaction(signal, &requested, &mut previous_action) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(Self {
+                signal,
+                previous_action,
+                already_restored: false,
+            })
+        }
+    }
+
+    /// Hand the signal back to whoever held it. Idempotent.
+    fn restore_now(&mut self) {
+        if self.already_restored {
+            return;
+        }
+        self.already_restored = true;
+        // SAFETY: `previous_action` was captured by this same value's
+        // constructor for this same signal, and a NULL `oldact` discards the
+        // displaced action.
+        let restored =
+            unsafe { libc::sigaction(self.signal, &self.previous_action, std::ptr::null_mut()) };
+        if restored != 0 {
+            tracing::error!(
+                signal = self.signal,
+                error = %std::io::Error::last_os_error(),
+                "failed to restore the previous signal disposition"
+            );
+        }
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+impl Drop for DisplacedSignalDisposition {
+    fn drop(&mut self) {
+        self.restore_now();
+    }
 }
 
 /// The process-lifetime self-pipe the signal handler writes to.
@@ -62,11 +134,23 @@ static SHUTDOWN_SIGNAL_SELF_PIPE: std::sync::OnceLock<ShutdownSignalSelfPipe> =
 #[cfg(all(unix, not(target_os = "macos")))]
 const FORWARDING_THREAD_STOP_BYTE: u8 = 0;
 
+/// What actually bounds the join in `Drop` — the stop byte only shortens the
+/// wait, so losing it must not be able to hang teardown.
+#[cfg(all(unix, not(target_os = "macos")))]
+static FORWARDING_THREAD_SHOULD_STOP: AtomicBool = AtomicBool::new(false);
+
+#[cfg(all(unix, not(target_os = "macos")))]
+const FORWARDING_THREAD_STOP_POLL_INTERVAL_MILLISECONDS: libc::c_int = 250;
+
 /// Writes the delivered signal number to the self-pipe.
 ///
-/// Async-signal-safe by construction: one `write(2)` to a descriptor that lives
-/// for the process lifetime, and nothing else. All interpretation — logging,
+/// Three calls, each async-signal-safe: the `OnceLock` read is a plain atomic
+/// load with no locking, `__errno_location` is a pure TLS address computation,
+/// and `write(2)` is on the POSIX AS-safe list. All interpretation — logging,
 /// attribution, the shutdown request itself — happens on the forwarding thread.
+/// Re-entry is safe too: `sa_mask` is empty, so a SIGTERM may preempt this
+/// mid-SIGINT, and the nested errno save/restore still leaves the outer value
+/// intact.
 #[cfg(all(unix, not(target_os = "macos")))]
 extern "C" fn write_delivered_signal_to_self_pipe(delivered_signal: libc::c_int) {
     let Some(self_pipe) = SHUTDOWN_SIGNAL_SELF_PIPE.get() else {
@@ -74,10 +158,11 @@ extern "C" fn write_delivered_signal_to_self_pipe(delivered_signal: libc::c_int)
     };
     let delivered_signal_byte = delivered_signal as u8;
     // SAFETY: `write_end` stays open for the process lifetime, and the source
-    // is one byte of stack this frame owns. A failed or short write means the
-    // pipe is full — a shutdown request is already queued, so dropping this one
-    // changes nothing. `errno` is saved and restored around the write because
-    // the handler preempted a syscall that may be about to read its own errno.
+    // is one byte of stack this frame owns. The write is non-blocking, so a
+    // failure here means the pipe is backed up and a shutdown request is
+    // already queued — dropping this one changes nothing. `errno` is saved and
+    // restored around it because the handler preempted a syscall that may be
+    // about to read its own errno.
     unsafe {
         let errno_slot = libc::__errno_location();
         let interrupted_errno = *errno_slot;
@@ -120,15 +205,14 @@ impl ScopedShutdownSignalOwnership {
         // otherwise be read by this owner and shut it down on the spot.
         drain_pending_bytes(self_pipe.read_end);
 
-        let previous_sigint_disposition = install_self_pipe_handler(SIGINT)?;
-        let previous_sigterm_disposition = match install_self_pipe_handler(SIGTERM) {
-            Ok(previous) => previous,
-            Err(sigterm_failure) => {
-                restore_disposition(SIGINT, &previous_sigint_disposition);
-                return Err(sigterm_failure);
-            }
-        };
+        // Both displacements restore themselves if anything below fails —
+        // including the thread spawn, which would otherwise leave the handlers
+        // installed with nothing reading the pipe.
+        let displaced_sigint = DisplacedSignalDisposition::displace_with_self_pipe_handler(SIGINT)?;
+        let displaced_sigterm =
+            DisplacedSignalDisposition::displace_with_self_pipe_handler(SIGTERM)?;
 
+        FORWARDING_THREAD_SHOULD_STOP.store(false, Ordering::SeqCst);
         let read_end = self_pipe.read_end;
         let forwarding_thread = std::thread::Builder::new()
             .name("shutdown-signal-forwarding".to_string())
@@ -138,26 +222,37 @@ impl ScopedShutdownSignalOwnership {
         Ok(Self {
             signal_forwarding: Some(UnixSignalForwarding {
                 forwarding_thread,
-                previous_sigint_disposition,
-                previous_sigterm_disposition,
+                displaced_sigint,
+                displaced_sigterm,
             }),
         })
     }
 
     #[cfg(target_os = "macos")]
     fn install() -> std::io::Result<Self> {
-        // Ctrl+C reaches teardown through `NSApplication.terminate` rather than
-        // the request funnel, because an AppKit app's shutdown must run
-        // `applicationWillTerminate` on the main thread.
-        ctrlc::set_handler(move || {
-            tracing::info!("Ctrl+C received, triggering graceful shutdown");
-            trigger_macos_termination();
-        })
-        .map_err(std::io::Error::other)?;
+        // Installed once per process, not once per owner: `ctrlc::set_handler`
+        // refuses a second call outright, and each SIGTERM registration would
+        // leak another polling thread. Ownership after the first take is
+        // therefore the claim alone — which is also why `Drop` restores nothing
+        // here.
+        if MACOS_TERMINATION_HANDLERS_INSTALLED.get().is_none() {
+            // Ctrl+C reaches teardown through `NSApplication.terminate` rather
+            // than the request funnel, because an AppKit app's shutdown must
+            // run `applicationWillTerminate` on the main thread.
+            ctrlc::set_handler(move || {
+                tracing::info!("Ctrl+C received, triggering graceful shutdown");
+                trigger_macos_termination();
+            })
+            .map_err(std::io::Error::other)?;
 
-        install_sigterm_handler_macos()?;
+            install_sigterm_handler_macos()?;
 
-        tracing::info!("macOS shutdown signals owned (Ctrl+C via ctrlc, SIGTERM via signal-hook)");
+            let _ = MACOS_TERMINATION_HANDLERS_INSTALLED.set(());
+            tracing::info!(
+                "macOS shutdown signals owned (Ctrl+C via ctrlc, SIGTERM via signal-hook)"
+            );
+        }
+
         Ok(Self {})
     }
 
@@ -172,18 +267,14 @@ impl ScopedShutdownSignalOwnership {
 impl Drop for ScopedShutdownSignalOwnership {
     fn drop(&mut self) {
         #[cfg(all(unix, not(target_os = "macos")))]
-        if let Some(forwarding) = self.signal_forwarding.take() {
-            // Restore first, so no further delivery reaches our handler while
-            // the forwarding thread is being wound down. This is the call that
-            // hands SIGINT back to CPython in the wheel.
-            restore_disposition(
-                signal_hook::consts::signal::SIGINT,
-                &forwarding.previous_sigint_disposition,
-            );
-            restore_disposition(
-                signal_hook::consts::signal::SIGTERM,
-                &forwarding.previous_sigterm_disposition,
-            );
+        if let Some(mut forwarding) = self.signal_forwarding.take() {
+            // Restore before winding the thread down, so a signal arriving
+            // during teardown reaches whoever held the disposition rather than
+            // a handler whose reader is going away. This is the call that hands
+            // SIGINT back to CPython in the wheel. Both are already-restored
+            // after this, so their `Drop` is a no-op.
+            forwarding.displaced_sigint.restore_now();
+            forwarding.displaced_sigterm.restore_now();
 
             stop_forwarding_thread();
             if forwarding.forwarding_thread.join().is_err() {
@@ -214,9 +305,18 @@ fn shutdown_signal_self_pipe() -> std::io::Result<&'static ShutdownSignalSelfPip
 
     // A full pipe must never block the handler, so the write end is
     // non-blocking; a dropped byte only ever means a request is already queued.
+    // Checked rather than assumed: leaving the write end blocking would let the
+    // handler stall inside signal context, the one thing this design must not
+    // do.
     // SAFETY: `pipe_ends[1]` was just returned by `pipe2`.
-    unsafe {
-        libc::fcntl(pipe_ends[1], libc::F_SETFL, libc::O_NONBLOCK);
+    if unsafe { libc::fcntl(pipe_ends[1], libc::F_SETFL, libc::O_NONBLOCK) } < 0 {
+        let flag_failure = std::io::Error::last_os_error();
+        // SAFETY: both ends were just created here and are not published yet.
+        unsafe {
+            libc::close(pipe_ends[0]);
+            libc::close(pipe_ends[1]);
+        }
+        return Err(flag_failure);
     }
 
     Ok(
@@ -227,36 +327,42 @@ fn shutdown_signal_self_pipe() -> std::io::Result<&'static ShutdownSignalSelfPip
     )
 }
 
-/// Point `signal` at the self-pipe handler, returning the displaced disposition.
-#[cfg(all(unix, not(target_os = "macos")))]
-fn install_self_pipe_handler(signal: libc::c_int) -> std::io::Result<libc::sigaction> {
-    // SAFETY: `requested` is fully initialized below before use, `displaced` is
-    // owned here and written by the kernel, and the handler installed is a
-    // plain `extern "C"` function with no Rust-level invariants to uphold.
-    unsafe {
-        let mut requested: libc::sigaction = std::mem::zeroed();
-        let handler: extern "C" fn(libc::c_int) = write_delivered_signal_to_self_pipe;
-        requested.sa_sigaction = handler as usize;
-        // SA_RESTART so a shutdown signal does not surface as EINTR in engine
-        // threads blocked on a syscall — the request funnel is the only path
-        // that reacts to it.
-        requested.sa_flags = libc::SA_RESTART;
-        libc::sigemptyset(&mut requested.sa_mask);
-
-        let mut displaced: libc::sigaction = std::mem::zeroed();
-        if libc::sigaction(signal, &requested, &mut displaced) != 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        Ok(displaced)
-    }
-}
-
-/// Read the self-pipe until the stop byte arrives, funnelling each delivered
-/// signal into [`request_runtime_shutdown`].
+/// Read the self-pipe until stopped, funnelling each delivered signal into
+/// [`request_runtime_shutdown`].
+///
+/// The wait is a bounded `poll` rather than a blocking `read` so the stop flag
+/// is observed even if the stop byte never lands — a lost wakeup here would
+/// hang `join()` inside a `Drop`.
 #[cfg(all(unix, not(target_os = "macos")))]
 fn forward_signals_until_stopped(read_end: std::os::fd::RawFd) {
     tracing::debug!("Shutdown-signal forwarding thread started");
-    loop {
+    while !FORWARDING_THREAD_SHOULD_STOP.load(Ordering::SeqCst) {
+        let mut awaited = libc::pollfd {
+            fd: read_end,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: one owned `pollfd` describing a descriptor that stays open
+        // for the process lifetime.
+        let ready = unsafe {
+            libc::poll(
+                std::ptr::from_mut(&mut awaited),
+                1,
+                FORWARDING_THREAD_STOP_POLL_INTERVAL_MILLISECONDS,
+            )
+        };
+        if ready < 0 {
+            let poll_failure = std::io::Error::last_os_error();
+            if poll_failure.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            tracing::error!(error = %poll_failure, "Shutdown-signal forwarding: poll failed");
+            break;
+        }
+        if ready == 0 {
+            continue;
+        }
+
         let mut delivered = 0u8;
         // SAFETY: `read_end` stays open for the process lifetime and the
         // destination is one byte of stack this frame owns.
@@ -286,20 +392,30 @@ fn forward_signals_until_stopped(read_end: std::os::fd::RawFd) {
     tracing::debug!("Shutdown-signal forwarding thread exiting");
 }
 
-/// Wake the forwarding thread with the stop byte so it can leave its blocking
-/// read.
+/// Ask the forwarding thread to stop, and nudge it out of its poll.
 #[cfg(all(unix, not(target_os = "macos")))]
 fn stop_forwarding_thread() {
+    // The flag is what actually bounds the join; the byte only shortens the
+    // wait from the poll interval to immediately, so a failed write is
+    // recoverable and not worth failing teardown over.
+    FORWARDING_THREAD_SHOULD_STOP.store(true, Ordering::SeqCst);
+
     let Some(self_pipe) = SHUTDOWN_SIGNAL_SELF_PIPE.get() else {
         return;
     };
     // SAFETY: `write_end` stays open for the process lifetime; the source is
     // one byte of stack this frame owns.
-    unsafe {
+    let written = unsafe {
         libc::write(
             self_pipe.write_end,
             std::ptr::from_ref(&FORWARDING_THREAD_STOP_BYTE).cast(),
             1,
+        )
+    };
+    if written != 1 {
+        tracing::debug!(
+            error = %std::io::Error::last_os_error(),
+            "Shutdown-signal forwarding: stop byte not delivered; the thread will stop on its next poll"
         );
     }
 }
@@ -332,19 +448,9 @@ fn read_current_disposition(signal: libc::c_int) -> libc::sigaction {
     }
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
-fn restore_disposition(signal: libc::c_int, disposition: &libc::sigaction) {
-    // SAFETY: `disposition` was produced by the query above for this same
-    // signal, and a NULL `oldact` discards the displaced action.
-    let restored = unsafe { libc::sigaction(signal, disposition, std::ptr::null_mut()) };
-    if restored != 0 {
-        tracing::error!(
-            signal,
-            error = %std::io::Error::last_os_error(),
-            "failed to restore the previous signal disposition"
-        );
-    }
-}
+/// Set once the process-lifetime macOS handlers are in place.
+#[cfg(target_os = "macos")]
+static MACOS_TERMINATION_HANDLERS_INSTALLED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
 
 #[cfg(target_os = "macos")]
 fn install_sigterm_handler_macos() -> std::io::Result<()> {

--- a/runtime/streamlib-engine/src/core/signals.rs
+++ b/runtime/streamlib-engine/src/core/signals.rs
@@ -203,7 +203,7 @@ impl ScopedShutdownSignalOwnership {
         let self_pipe = shutdown_signal_self_pipe()?;
         // A signal delivered during the previous owner's teardown would
         // otherwise be read by this owner and shut it down on the spot.
-        drain_pending_bytes(self_pipe.read_end);
+        drain_pending_bytes(self_pipe.read_end)?;
 
         // Both displacements restore themselves if anything below fails —
         // including the thread spawn, which would otherwise leave the handlers
@@ -421,17 +421,29 @@ fn stop_forwarding_thread() {
 }
 
 /// Discard bytes left in the pipe by a previous owner.
+///
+/// Both `fcntl`s are checked because the drain below only terminates while the
+/// read end is non-blocking — on an unchecked failure it would block forever
+/// inside `install()`, which is inside `rt.run()`.
 #[cfg(all(unix, not(target_os = "macos")))]
-fn drain_pending_bytes(read_end: std::os::fd::RawFd) {
+fn drain_pending_bytes(read_end: std::os::fd::RawFd) -> std::io::Result<()> {
     // SAFETY: `read_end` stays open for the process lifetime; the destination
     // buffer is owned by this frame.
     unsafe {
         let original_flags = libc::fcntl(read_end, libc::F_GETFL);
-        libc::fcntl(read_end, libc::F_SETFL, original_flags | libc::O_NONBLOCK);
+        if original_flags < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        if libc::fcntl(read_end, libc::F_SETFL, original_flags | libc::O_NONBLOCK) < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
         let mut discarded = [0u8; 32];
         while libc::read(read_end, discarded.as_mut_ptr().cast(), discarded.len()) > 0 {}
-        libc::fcntl(read_end, libc::F_SETFL, original_flags);
+        if libc::fcntl(read_end, libc::F_SETFL, original_flags) < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
     }
+    Ok(())
 }
 
 /// Read a signal's current disposition without changing it. The restoration

--- a/runtime/streamlib-engine/src/core/signals.rs
+++ b/runtime/streamlib-engine/src/core/signals.rs
@@ -1,94 +1,349 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+//! Shutdown-signal ownership, scoped to the lifetime of a run loop.
+//!
+//! Ownership is a value, not a process-wide side effect: whoever owns the run
+//! loop takes [`ScopedShutdownSignalOwnership`] for as long as it blocks and
+//! drops it afterwards, which restores the signal dispositions that were
+//! installed before. The wheel's `rt.run()` depends on that restoration — it
+//! hands SIGINT back to CPython, so a Ctrl-C after `run()` returns raises
+//! `KeyboardInterrupt` instead of being swallowed by a handler whose run loop
+//! is gone.
+
 #[cfg(all(unix, not(target_os = "macos")))]
 use crate::core::runtime::request_runtime_shutdown;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-static SIGNAL_HANDLER_INSTALLED: AtomicBool = AtomicBool::new(false);
+/// Only one run loop may own the shutdown signals at a time — two owners would
+/// race to restore dispositions and the loser would restore a disposition the
+/// winner had already replaced.
+static SHUTDOWN_SIGNALS_OWNED: AtomicBool = AtomicBool::new(false);
 
-/// Install native signal handlers for shutdown signals
+/// Owns SIGTERM + SIGINT for as long as it is alive, funnelling both into
+/// [`request_runtime_shutdown`](crate::core::runtime::request_runtime_shutdown).
 ///
-/// Captures SIGTERM and SIGINT (Ctrl+C). Unix/Linux funnels them into
-/// [`request_runtime_shutdown`](crate::core::runtime::request_runtime_shutdown)
-/// like every other shutdown boundary; macOS instead routes through
-/// `NSApplication.terminate`, which reaches the same teardown via
-/// `applicationWillTerminate` and never touches the funnel. This function
-/// spawns a background thread to handle signals without blocking the signal
-/// handler.
+/// Dropping it stops the forwarding thread, joins it, and restores the signal
+/// dispositions captured at construction. macOS instead routes termination
+/// through `NSApplication.terminate` (reaching the same teardown via
+/// `applicationWillTerminate`), which cannot be uninstalled — there, drop
+/// releases the ownership claim only.
+pub struct ScopedShutdownSignalOwnership {
+    #[cfg(all(unix, not(target_os = "macos")))]
+    signal_forwarding: Option<UnixSignalForwarding>,
+}
+
+/// The Linux forwarding thread plus the dispositions it displaced.
+#[cfg(all(unix, not(target_os = "macos")))]
+struct UnixSignalForwarding {
+    forwarding_thread: std::thread::JoinHandle<()>,
+    previous_sigint_disposition: libc::sigaction,
+    previous_sigterm_disposition: libc::sigaction,
+}
+
+/// The process-lifetime self-pipe the signal handler writes to.
 ///
-/// # Platform Support
-/// - Unix/Linux: Uses libc signal handling via signal-hook
-/// - macOS: Uses ctrlc crate (works with NSApplication GUI apps) + signal-hook for SIGTERM
-/// - Windows: Not yet implemented (would use SetConsoleCtrlHandler)
+/// Created once and never torn down, because a handler that is already
+/// executing when ownership drops must still write somewhere valid — closing
+/// these would leave a window where an in-flight handler writes to a reused
+/// descriptor. The reader end is drained and re-read by each new owner instead.
+#[cfg(all(unix, not(target_os = "macos")))]
+struct ShutdownSignalSelfPipe {
+    read_end: std::os::fd::RawFd,
+    write_end: std::os::fd::RawFd,
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+static SHUTDOWN_SIGNAL_SELF_PIPE: std::sync::OnceLock<ShutdownSignalSelfPipe> =
+    std::sync::OnceLock::new();
+
+/// Wakes the forwarding thread for shutdown rather than for a signal. Real
+/// signal numbers start at 1, so zero can never collide with one.
+#[cfg(all(unix, not(target_os = "macos")))]
+const FORWARDING_THREAD_STOP_BYTE: u8 = 0;
+
+/// Writes the delivered signal number to the self-pipe.
 ///
-/// # Safety
-/// Signal handlers must be async-signal-safe. We immediately write to a pipe
-/// and handle the event in a separate thread to avoid restrictions.
-pub fn install_signal_handlers() -> std::io::Result<()> {
-    // Only install once
-    if SIGNAL_HANDLER_INSTALLED.swap(true, Ordering::SeqCst) {
-        tracing::warn!("Signal handlers already installed, skipping");
-        return Ok(());
+/// Async-signal-safe by construction: one `write(2)` to a descriptor that lives
+/// for the process lifetime, and nothing else. All interpretation — logging,
+/// attribution, the shutdown request itself — happens on the forwarding thread.
+#[cfg(all(unix, not(target_os = "macos")))]
+extern "C" fn write_delivered_signal_to_self_pipe(delivered_signal: libc::c_int) {
+    let Some(self_pipe) = SHUTDOWN_SIGNAL_SELF_PIPE.get() else {
+        return;
+    };
+    let delivered_signal_byte = delivered_signal as u8;
+    // SAFETY: `write_end` stays open for the process lifetime, and the source
+    // is one byte of stack this frame owns. A failed or short write means the
+    // pipe is full — a shutdown request is already queued, so dropping this one
+    // changes nothing. `errno` is saved and restored around the write because
+    // the handler preempted a syscall that may be about to read its own errno.
+    unsafe {
+        let errno_slot = libc::__errno_location();
+        let interrupted_errno = *errno_slot;
+        libc::write(
+            self_pipe.write_end,
+            std::ptr::from_ref(&delivered_signal_byte).cast(),
+            1,
+        );
+        *errno_slot = interrupted_errno;
     }
+}
 
-    #[cfg(target_os = "macos")]
-    {
-        install_macos_signal_handlers()?;
+impl ScopedShutdownSignalOwnership {
+    /// Take ownership of the shutdown signals until the returned value drops.
+    ///
+    /// Fails if another run loop already owns them.
+    pub fn take_until_dropped() -> std::io::Result<Self> {
+        if SHUTDOWN_SIGNALS_OWNED.swap(true, Ordering::SeqCst) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "shutdown signals are already owned by a running run loop",
+            ));
+        }
+
+        match Self::install() {
+            Ok(owned) => Ok(owned),
+            Err(installation_failure) => {
+                SHUTDOWN_SIGNALS_OWNED.store(false, Ordering::SeqCst);
+                Err(installation_failure)
+            }
+        }
     }
 
     #[cfg(all(unix, not(target_os = "macos")))]
-    {
-        install_unix_signal_handlers()?;
+    fn install() -> std::io::Result<Self> {
+        use signal_hook::consts::signal::{SIGINT, SIGTERM};
+
+        let self_pipe = shutdown_signal_self_pipe()?;
+        // A signal delivered during the previous owner's teardown would
+        // otherwise be read by this owner and shut it down on the spot.
+        drain_pending_bytes(self_pipe.read_end);
+
+        let previous_sigint_disposition = install_self_pipe_handler(SIGINT)?;
+        let previous_sigterm_disposition = match install_self_pipe_handler(SIGTERM) {
+            Ok(previous) => previous,
+            Err(sigterm_failure) => {
+                restore_disposition(SIGINT, &previous_sigint_disposition);
+                return Err(sigterm_failure);
+            }
+        };
+
+        let read_end = self_pipe.read_end;
+        let forwarding_thread = std::thread::Builder::new()
+            .name("shutdown-signal-forwarding".to_string())
+            .spawn(move || forward_signals_until_stopped(read_end))?;
+
+        tracing::info!("Shutdown signals owned by this run loop (SIGTERM, SIGINT)");
+        Ok(Self {
+            signal_forwarding: Some(UnixSignalForwarding {
+                forwarding_thread,
+                previous_sigint_disposition,
+                previous_sigterm_disposition,
+            }),
+        })
     }
-
-    #[cfg(windows)]
-    {
-        install_windows_signal_handlers()?;
-    }
-
-    Ok(())
-}
-
-/// Force reinstall signal handlers (useful if external libraries override them)
-///
-/// Some libraries (like CoreAudio) may install their own signal handlers that override ours.
-/// Call this AFTER initializing processors to re-claim signal handling.
-pub fn reinstall_signal_handlers() -> std::io::Result<()> {
-    tracing::info!("Force reinstalling signal handlers...");
 
     #[cfg(target_os = "macos")]
-    {
-        install_macos_signal_handlers()?;
-    }
+    fn install() -> std::io::Result<Self> {
+        // Ctrl+C reaches teardown through `NSApplication.terminate` rather than
+        // the request funnel, because an AppKit app's shutdown must run
+        // `applicationWillTerminate` on the main thread.
+        ctrlc::set_handler(move || {
+            tracing::info!("Ctrl+C received, triggering graceful shutdown");
+            trigger_macos_termination();
+        })
+        .map_err(std::io::Error::other)?;
 
-    #[cfg(all(unix, not(target_os = "macos")))]
-    {
-        install_unix_signal_handlers()?;
+        install_sigterm_handler_macos()?;
+
+        tracing::info!("macOS shutdown signals owned (Ctrl+C via ctrlc, SIGTERM via signal-hook)");
+        Ok(Self {})
     }
 
     #[cfg(windows)]
-    {
-        install_windows_signal_handlers()?;
+    fn install() -> std::io::Result<Self> {
+        // Would use SetConsoleCtrlHandler; the platform floor is Linux.
+        tracing::warn!("Windows signal handling not yet implemented");
+        Ok(Self {})
     }
-
-    Ok(())
 }
 
-#[cfg(target_os = "macos")]
-fn install_macos_signal_handlers() -> std::io::Result<()> {
-    // Use ctrlc crate for Ctrl+C - it works reliably with NSApplication
-    ctrlc::set_handler(move || {
-        tracing::info!("Ctrl+C received, triggering graceful shutdown");
-        trigger_macos_termination();
-    })
-    .map_err(std::io::Error::other)?;
+impl Drop for ScopedShutdownSignalOwnership {
+    fn drop(&mut self) {
+        #[cfg(all(unix, not(target_os = "macos")))]
+        if let Some(forwarding) = self.signal_forwarding.take() {
+            // Restore first, so no further delivery reaches our handler while
+            // the forwarding thread is being wound down. This is the call that
+            // hands SIGINT back to CPython in the wheel.
+            restore_disposition(
+                signal_hook::consts::signal::SIGINT,
+                &forwarding.previous_sigint_disposition,
+            );
+            restore_disposition(
+                signal_hook::consts::signal::SIGTERM,
+                &forwarding.previous_sigterm_disposition,
+            );
 
-    // Still use signal-hook for SIGTERM (system shutdown, kill command)
-    install_sigterm_handler_macos()?;
+            stop_forwarding_thread();
+            if forwarding.forwarding_thread.join().is_err() {
+                tracing::error!("Shutdown-signal forwarding thread panicked");
+            }
+            tracing::debug!("Shutdown-signal dispositions restored");
+        }
 
-    tracing::info!("macOS signal handlers installed (Ctrl+C via ctrlc, SIGTERM via signal-hook)");
-    Ok(())
+        SHUTDOWN_SIGNALS_OWNED.store(false, Ordering::SeqCst);
+    }
+}
+
+/// The process-lifetime self-pipe, created on first use.
+#[cfg(all(unix, not(target_os = "macos")))]
+fn shutdown_signal_self_pipe() -> std::io::Result<&'static ShutdownSignalSelfPipe> {
+    if let Some(existing) = SHUTDOWN_SIGNAL_SELF_PIPE.get() {
+        return Ok(existing);
+    }
+
+    let mut pipe_ends: [libc::c_int; 2] = [-1, -1];
+    // SAFETY: `pipe2` writes exactly two descriptors into the array we own.
+    // `O_CLOEXEC` keeps the descriptors out of helper processes the runtime
+    // spawns, which must not be able to request our shutdown by accident.
+    let created = unsafe { libc::pipe2(pipe_ends.as_mut_ptr(), libc::O_CLOEXEC) };
+    if created != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    // A full pipe must never block the handler, so the write end is
+    // non-blocking; a dropped byte only ever means a request is already queued.
+    // SAFETY: `pipe_ends[1]` was just returned by `pipe2`.
+    unsafe {
+        libc::fcntl(pipe_ends[1], libc::F_SETFL, libc::O_NONBLOCK);
+    }
+
+    Ok(
+        SHUTDOWN_SIGNAL_SELF_PIPE.get_or_init(|| ShutdownSignalSelfPipe {
+            read_end: pipe_ends[0],
+            write_end: pipe_ends[1],
+        }),
+    )
+}
+
+/// Point `signal` at the self-pipe handler, returning the displaced disposition.
+#[cfg(all(unix, not(target_os = "macos")))]
+fn install_self_pipe_handler(signal: libc::c_int) -> std::io::Result<libc::sigaction> {
+    // SAFETY: `requested` is fully initialized below before use, `displaced` is
+    // owned here and written by the kernel, and the handler installed is a
+    // plain `extern "C"` function with no Rust-level invariants to uphold.
+    unsafe {
+        let mut requested: libc::sigaction = std::mem::zeroed();
+        let handler: extern "C" fn(libc::c_int) = write_delivered_signal_to_self_pipe;
+        requested.sa_sigaction = handler as usize;
+        // SA_RESTART so a shutdown signal does not surface as EINTR in engine
+        // threads blocked on a syscall — the request funnel is the only path
+        // that reacts to it.
+        requested.sa_flags = libc::SA_RESTART;
+        libc::sigemptyset(&mut requested.sa_mask);
+
+        let mut displaced: libc::sigaction = std::mem::zeroed();
+        if libc::sigaction(signal, &requested, &mut displaced) != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(displaced)
+    }
+}
+
+/// Read the self-pipe until the stop byte arrives, funnelling each delivered
+/// signal into [`request_runtime_shutdown`].
+#[cfg(all(unix, not(target_os = "macos")))]
+fn forward_signals_until_stopped(read_end: std::os::fd::RawFd) {
+    tracing::debug!("Shutdown-signal forwarding thread started");
+    loop {
+        let mut delivered = 0u8;
+        // SAFETY: `read_end` stays open for the process lifetime and the
+        // destination is one byte of stack this frame owns.
+        let bytes_read =
+            unsafe { libc::read(read_end, std::ptr::from_mut(&mut delivered).cast(), 1) };
+
+        if bytes_read < 0 {
+            let read_failure = std::io::Error::last_os_error();
+            if read_failure.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            tracing::error!(error = %read_failure, "Shutdown-signal forwarding: read failed");
+            break;
+        }
+        // EOF is unreachable while the write end is held for the process
+        // lifetime, but treating it as a stop keeps the loop bounded.
+        if bytes_read == 0 || delivered == FORWARDING_THREAD_STOP_BYTE {
+            break;
+        }
+
+        let signal_name = signal_hook::low_level::signal_name(libc::c_int::from(delivered))
+            .unwrap_or("unrecognized signal");
+        if let Err(error) = request_runtime_shutdown(&format!("posix signal {signal_name}")) {
+            tracing::error!(%error, "Shutdown-signal forwarding: request failed");
+        }
+    }
+    tracing::debug!("Shutdown-signal forwarding thread exiting");
+}
+
+/// Wake the forwarding thread with the stop byte so it can leave its blocking
+/// read.
+#[cfg(all(unix, not(target_os = "macos")))]
+fn stop_forwarding_thread() {
+    let Some(self_pipe) = SHUTDOWN_SIGNAL_SELF_PIPE.get() else {
+        return;
+    };
+    // SAFETY: `write_end` stays open for the process lifetime; the source is
+    // one byte of stack this frame owns.
+    unsafe {
+        libc::write(
+            self_pipe.write_end,
+            std::ptr::from_ref(&FORWARDING_THREAD_STOP_BYTE).cast(),
+            1,
+        );
+    }
+}
+
+/// Discard bytes left in the pipe by a previous owner.
+#[cfg(all(unix, not(target_os = "macos")))]
+fn drain_pending_bytes(read_end: std::os::fd::RawFd) {
+    // SAFETY: `read_end` stays open for the process lifetime; the destination
+    // buffer is owned by this frame.
+    unsafe {
+        let original_flags = libc::fcntl(read_end, libc::F_GETFL);
+        libc::fcntl(read_end, libc::F_SETFL, original_flags | libc::O_NONBLOCK);
+        let mut discarded = [0u8; 32];
+        while libc::read(read_end, discarded.as_mut_ptr().cast(), discarded.len()) > 0 {}
+        libc::fcntl(read_end, libc::F_SETFL, original_flags);
+    }
+}
+
+/// Read a signal's current disposition without changing it. The restoration
+/// contract is only witnessable against the kernel's own record, so this exists
+/// for the tests that assert it.
+#[cfg(all(test, unix, not(target_os = "macos")))]
+fn read_current_disposition(signal: libc::c_int) -> libc::sigaction {
+    // SAFETY: a NULL `act` is POSIX's read-only query. `previous` is a fully
+    // owned, zeroed `sigaction` the kernel writes into.
+    unsafe {
+        let mut previous: libc::sigaction = std::mem::zeroed();
+        libc::sigaction(signal, std::ptr::null(), &mut previous);
+        previous
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn restore_disposition(signal: libc::c_int, disposition: &libc::sigaction) {
+    // SAFETY: `disposition` was produced by the query above for this same
+    // signal, and a NULL `oldact` discards the displaced action.
+    let restored = unsafe { libc::sigaction(signal, disposition, std::ptr::null_mut()) };
+    if restored != 0 {
+        tracing::error!(
+            signal,
+            error = %std::io::Error::last_os_error(),
+            "failed to restore the previous signal disposition"
+        );
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -96,13 +351,10 @@ fn install_sigterm_handler_macos() -> std::io::Result<()> {
     use signal_hook::consts::signal::SIGTERM;
     use signal_hook::flag;
     use std::sync::Arc;
-    use std::sync::atomic::AtomicBool;
 
-    // Use flag approach for SIGTERM - simpler than pipe
     let term_flag = Arc::new(AtomicBool::new(false));
     flag::register(SIGTERM, Arc::clone(&term_flag))?;
 
-    // Monitor the flag in a background thread
     std::thread::spawn(move || {
         loop {
             if term_flag.load(Ordering::Relaxed) {
@@ -117,52 +369,10 @@ fn install_sigterm_handler_macos() -> std::io::Result<()> {
     Ok(())
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
-fn install_unix_signal_handlers() -> std::io::Result<()> {
-    use signal_hook::consts::signal::{SIGINT, SIGTERM};
-    use signal_hook::iterator::Signals;
-
-    // `Signals` owns the async-signal-safe self-pipe and yields the delivered
-    // signal NUMBER. `low_level::pipe::register` cannot: its handler writes a
-    // fixed `b"X"` wakeup byte, so a reader can never tell SIGINT from SIGTERM
-    // — and the shutdown `reason` this funnels into is operator-facing
-    // attribution.
-    let mut signals = Signals::new([SIGTERM, SIGINT])?;
-
-    // Detached: it runs for the process lifetime, and there is no shutdown
-    // path that joins it.
-    std::thread::Builder::new()
-        .name("signal-handler".to_string())
-        .spawn(move || {
-            tracing::debug!("Signal handler thread started, waiting for signals");
-            for signal in signals.forever() {
-                let signal_name =
-                    signal_hook::low_level::signal_name(signal).unwrap_or("unrecognized signal");
-                if let Err(error) = request_runtime_shutdown(&format!("posix signal {signal_name}"))
-                {
-                    tracing::error!(%error, "Signal handler: runtime-shutdown request failed");
-                }
-            }
-            tracing::debug!("Signal handler thread exiting");
-        })?;
-
-    tracing::info!("Native signal handlers installed (SIGTERM, SIGINT)");
-    Ok(())
-}
-
-#[cfg(windows)]
-fn install_windows_signal_handlers() -> std::io::Result<()> {
-    // TODO: Implement Windows signal handling using SetConsoleCtrlHandler
-    tracing::warn!("Windows signal handling not yet implemented");
-    Ok(())
-}
-
 #[cfg(target_os = "macos")]
 fn trigger_macos_termination() {
     use dispatch2::DispatchQueue;
 
-    // Call NSApplication.terminate() on the main thread
-    // This will trigger applicationWillTerminate: for graceful shutdown
     DispatchQueue::main().exec_async(move || {
         use objc2::MainThreadMarker;
         use objc2_app_kit::NSApplication;
@@ -182,16 +392,164 @@ fn trigger_macos_termination() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
+    /// The restoration contract, asserted at the only layer that can witness it:
+    /// the kernel's own record of the handler. `rt.run()` returning with SIGINT
+    /// still pointed at a dead run loop's forwarding thread is exactly the
+    /// "Ctrl-C stops working after run()" failure the wheel must not ship.
+    ///
+    /// Mental-revert: dropping the `restore_disposition` calls from `Drop`
+    /// leaves `sa_sigaction` pointing at the self-pipe handler and fails.
     #[test]
-    fn test_signal_handler_install_once() {
-        // Reset flag for test
-        SIGNAL_HANDLER_INSTALLED.store(false, Ordering::SeqCst);
+    #[serial]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn dropping_ownership_restores_the_previous_dispositions() {
+        use signal_hook::consts::signal::{SIGINT, SIGTERM};
 
-        let result1 = install_signal_handlers();
-        let result2 = install_signal_handlers();
+        let sigint_before = read_current_disposition(SIGINT);
+        let sigterm_before = read_current_disposition(SIGTERM);
 
-        assert!(result1.is_ok());
-        assert!(result2.is_ok()); // Should succeed but not install twice
+        {
+            let _owned = ScopedShutdownSignalOwnership::take_until_dropped()
+                .expect("no other run loop owns the shutdown signals");
+            assert_ne!(
+                read_current_disposition(SIGINT).sa_sigaction,
+                sigint_before.sa_sigaction,
+                "taking ownership must actually displace the SIGINT handler",
+            );
+        }
+
+        assert_eq!(
+            read_current_disposition(SIGINT).sa_sigaction,
+            sigint_before.sa_sigaction,
+            "SIGINT must be handed back to whoever held it",
+        );
+        assert_eq!(
+            read_current_disposition(SIGTERM).sa_sigaction,
+            sigterm_before.sa_sigaction,
+            "SIGTERM must be handed back to whoever held it",
+        );
+    }
+
+    /// Ownership is exclusive, and a refused take must not disturb the owner's
+    /// handlers — nor leak the claim, or every later run loop in the process
+    /// would be refused.
+    #[test]
+    #[serial]
+    fn a_second_owner_is_refused_while_the_first_is_alive() {
+        let first = ScopedShutdownSignalOwnership::take_until_dropped()
+            .expect("no other run loop owns the shutdown signals");
+        assert!(
+            ScopedShutdownSignalOwnership::take_until_dropped().is_err(),
+            "a second run loop must not be able to take the shutdown signals",
+        );
+        drop(first);
+
+        drop(
+            ScopedShutdownSignalOwnership::take_until_dropped()
+                .expect("ownership must be retakeable once the first owner drops"),
+        );
+    }
+
+    /// Raise SIGINT and wait for the forwarding thread to latch a request.
+    /// Panics rather than hanging if the signal never arrives.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn raise_sigint_and_await_latched_request(context: &str) {
+        use crate::core::runtime::is_runtime_shutdown_requested;
+
+        // SAFETY: SIGINT is owned by the caller's live
+        // `ScopedShutdownSignalOwnership`, so this reaches the self-pipe
+        // handler rather than the default terminate action.
+        assert_eq!(
+            unsafe { libc::raise(signal_hook::consts::signal::SIGINT) },
+            0,
+            "raising SIGINT must succeed ({context})",
+        );
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            if is_runtime_shutdown_requested() {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        panic!("SIGINT was never funnelled into a runtime-shutdown request ({context})");
+    }
+
+    /// The whole point of owning the signals: a delivered SIGINT must reach the
+    /// request funnel the run loop polls.
+    #[test]
+    #[serial]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn a_delivered_sigint_becomes_a_runtime_shutdown_request() {
+        let _latch_cleared_even_on_unwind =
+            crate::core::RuntimeShutdownRequestLatchClearedOnDrop::clear_now_and_on_drop();
+
+        let _owned = ScopedShutdownSignalOwnership::take_until_dropped()
+            .expect("no other run loop owns the shutdown signals");
+        raise_sigint_and_await_latched_request("first owner");
+    }
+
+    /// Re-taking after a drop is the wheel's second-`Runtime()`-in-one-process
+    /// case, and it must still *work* — asserting the handler pointer alone
+    /// would not catch it.
+    ///
+    /// This is a regression lock on a real defect: a registry-based
+    /// implementation (signal-hook's `Signals`) installs its dispatcher once
+    /// per signal and skips reinstallation on later registrations, so restoring
+    /// the previous disposition on drop desynchronizes the registry from the
+    /// kernel and leaves the SECOND run loop silently unable to catch Ctrl-C.
+    /// Mental-revert: reverting to `Signals::new` + `handle().close()` passes
+    /// the disposition asserts above and fails here on the second iteration.
+    #[test]
+    #[serial]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn every_retaken_ownership_still_catches_sigint() {
+        for ownership_generation in 1..=3 {
+            let _latch_cleared_even_on_unwind =
+                crate::core::RuntimeShutdownRequestLatchClearedOnDrop::clear_now_and_on_drop();
+
+            let owned = ScopedShutdownSignalOwnership::take_until_dropped()
+                .expect("each run loop in turn may own the shutdown signals");
+            raise_sigint_and_await_latched_request(&format!(
+                "ownership generation {ownership_generation}"
+            ));
+            drop(owned);
+        }
+    }
+
+    /// A signal delivered while the previous owner was tearing down must not
+    /// shut the next run loop down the instant it starts.
+    #[test]
+    #[serial]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn a_stale_signal_does_not_shut_down_the_next_run_loop() {
+        let _latch_cleared_even_on_unwind =
+            crate::core::RuntimeShutdownRequestLatchClearedOnDrop::clear_now_and_on_drop();
+
+        {
+            let _owned = ScopedShutdownSignalOwnership::take_until_dropped()
+                .expect("no other run loop owns the shutdown signals");
+            // Written straight into the pipe so it is still unread when the
+            // owner below starts — racing a real signal against teardown would
+            // make this test flaky rather than deterministic.
+            let self_pipe = shutdown_signal_self_pipe().expect("the self-pipe exists");
+            let stale = signal_hook::consts::signal::SIGINT as u8;
+            // SAFETY: the write end stays open for the process lifetime; the
+            // source is one byte of stack this frame owns.
+            unsafe {
+                libc::write(self_pipe.write_end, std::ptr::from_ref(&stale).cast(), 1);
+            }
+        }
+
+        crate::core::runtime::take_runtime_shutdown_request_latch();
+        let _owned = ScopedShutdownSignalOwnership::take_until_dropped()
+            .expect("ownership must be retakeable once the first owner drops");
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        assert!(
+            !crate::core::runtime::is_runtime_shutdown_requested(),
+            "a byte left over from the previous owner must not shut this run loop down",
+        );
     }
 }

--- a/runtime/streamlib-runtime/src/main.rs
+++ b/runtime/streamlib-runtime/src/main.rs
@@ -91,14 +91,12 @@ async fn run(args: Args) -> Result<()> {
             .await?;
     }
 
-    runtime.start()?;
-
     if args.snapshot.is_none() {
-        println!("Empty graph ready — use the API to add processors");
+        println!("Starting with an empty graph — use the API to add processors");
     }
     println!("Press Ctrl+C to stop");
 
-    runtime.wait_for_signal()?;
+    runtime.start_and_wait_for_shutdown()?;
 
     Ok(())
 }

--- a/sdk/streamlib-python-wheel/Cargo.toml
+++ b/sdk/streamlib-python-wheel/Cargo.toml
@@ -1,0 +1,48 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+# The importable wheel: CPython imports this cdylib and drives the engine
+# in-process. The inverted arrangement (a Rust binary embedding CPython) was the
+# #1702 spike's shape and is not what ships.
+
+[package]
+name = "streamlib-python-wheel"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+# The SPDX identifier rather than the workspace's `license-file`: maturin
+# refuses a license file outside the project root, and the repo LICENSE sits
+# four levels up. Same license, declared inline.
+license = "BUSL-1.1"
+repository.workspace = true
+description = "streamlib — the importable Python wheel: CPython imports the engine and authors pipelines in-process"
+publish = false
+
+[lib]
+# The extension module lands at `streamlib._engine`, so the cdylib maturin picks
+# up must be named `_engine`. `rlib` rides alongside so the crate's own Rust
+# tests build against a normal interpreter link.
+name = "_engine"
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# Off by default so `cargo test` links libpython; maturin turns it on for the
+# wheel build, where the symbols resolve against the host interpreter instead.
+extension-module = ["pyo3/extension-module"]
+
+[dependencies]
+# 0.29 is the first release with the `attach`/`detach` naming; 0.28 and earlier
+# spell these `Python::with_gil` / `py.allow_threads`, which were REMOVED rather
+# than deprecated. `abi3-py310` builds one wheel for CPython 3.10 and every
+# later GIL-enabled release — free-threaded builds wait for a stable ABI to
+# exist for them.
+pyo3 = { version = "0.29.0", features = ["abi3-py310"] }
+
+# `default-features = false` drops the SDK's `auto-build` feature: the wheel
+# resolves nothing from source and links no build tooling.
+streamlib = { path = "../streamlib-sdk", version = "0.10.2", default-features = false }
+
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/sdk/streamlib-python-wheel/pyproject.toml
+++ b/sdk/streamlib-python-wheel/pyproject.toml
@@ -7,6 +7,11 @@ build-backend = "maturin"
 
 [project]
 name = "streamlib"
+# Tracks [workspace.package].version in the root Cargo.toml — the plan's "two
+# artifacts, one version, released together". Nothing bumps this yet:
+# release-please's extra-files list covers only the workspace Cargo.toml, and
+# check-package-version-drift scans `packages/*`. Wiring the bump belongs with
+# release packaging (#1711); until then keep it in sync by hand on release.
 version = "0.10.2"
 description = "StreamLib — a realtime streaming engine with Python authoring"
 # abi3-py310 in Cargo.toml is the binding half of this floor; the two move

--- a/sdk/streamlib-python-wheel/pyproject.toml
+++ b/sdk/streamlib-python-wheel/pyproject.toml
@@ -1,0 +1,42 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[build-system]
+requires = ["maturin>=1.7,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "streamlib"
+version = "0.10.2"
+description = "StreamLib — a realtime streaming engine with Python authoring"
+# abi3-py310 in Cargo.toml is the binding half of this floor; the two move
+# together or the wheel claims interpreters its ABI tag does not cover.
+requires-python = ">=3.10"
+license = { text = "BUSL-1.1" }
+authors = [{ name = "Jonathan Fontanez", email = "fontanezj1@gmail.com" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[tool.pytest.ini_options]
+markers = [
+    # `Runner::start()` initializes a GPU context, and the engine's DMA-BUF
+    # pool pre-warm needs a driver that can actually allocate exportable
+    # device memory. A software rasterizer (lavapipe) cannot, so a GPU-less
+    # runner deselects these with `-m "not requires_gpu"`.
+    "requires_gpu: needs a Vulkan device that can allocate exportable DMA-BUF memory",
+]
+
+[tool.maturin]
+python-source = "python"
+module-name = "streamlib._engine"
+features = ["extension-module"]

--- a/sdk/streamlib-python-wheel/python/streamlib/__init__.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/__init__.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""StreamLib — a realtime streaming engine with Python authoring.
+
+The engine runs in this interpreter's process: `Runtime()` boots it and
+`rt.run()` blocks until Ctrl-C with the GIL released.
+"""
+
+import atexit
+import weakref
+
+from ._engine import Runtime as _NativeRuntime
+
+__all__ = ["Runtime"]
+
+
+# Engine threads must be joined before CPython finalizes. `Runtime.run()` does
+# that on its own; this covers the paths where `run()` never returns normally —
+# an exception between construction and `run()`, or an interpreter exiting while
+# a Runtime is still referenced, where `__del__` ordering is not guaranteed.
+_live_runtimes: "weakref.WeakSet[Runtime]" = weakref.WeakSet()
+
+
+class Runtime(_NativeRuntime):
+    """The engine, running in this process."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        _live_runtimes.add(self)
+
+
+@atexit.register
+def _shut_down_live_runtimes() -> None:
+    # Copied first: `shutdown()` can drop the last reference to a Runtime, and
+    # mutating the WeakSet while iterating it would raise.
+    for runtime in list(_live_runtimes):
+        runtime.shutdown()

--- a/sdk/streamlib-python-wheel/src/lib.rs
+++ b/sdk/streamlib-python-wheel/src/lib.rs
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The native half of the streamlib wheel — the extension module CPython
+//! imports as `streamlib._engine`.
+
+use pyo3::prelude::*;
+
+mod python_runtime_lifecycle;
+
+pub use python_runtime_lifecycle::PythonRuntimeHandle;
+
+#[pymodule]
+fn _engine(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<PythonRuntimeHandle>()?;
+    Ok(())
+}

--- a/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
+++ b/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
@@ -1,0 +1,125 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The interpreter-lifecycle contract: engine teardown strictly precedes
+//! interpreter finalization.
+//!
+//! Every blocking step runs with the GIL released, and the engine is dropped —
+//! not merely stopped — before [`PythonRuntimeHandle::run`] returns, so no
+//! engine thread can still be alive when CPython finalizes.
+
+use std::sync::Arc;
+
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use streamlib::sdk::runtime::Runner;
+
+/// The engine, held by a Python object.
+///
+/// Single-use by construction: [`run`](PythonRuntimeHandle::run) takes the
+/// engine out and drops it before returning, because "all engine threads
+/// joined before `run()` returns" is not something a still-shared handle can
+/// promise.
+// `subclass` so the Python-side `streamlib.Runtime` can extend this to register
+// itself with the `atexit` teardown hook.
+#[pyclass(name = "Runtime", module = "streamlib", unsendable, subclass)]
+pub struct PythonRuntimeHandle {
+    /// `None` once the engine has been run or torn down.
+    engine: Option<Arc<Runner>>,
+}
+
+impl PythonRuntimeHandle {
+    /// Drop the engine with the GIL released, joining its threads.
+    ///
+    /// Releasing the GIL is not an optimization: an engine thread that needs
+    /// the GIL to finish (a Python processor, once those exist) would deadlock
+    /// against a teardown that held it.
+    fn drop_engine_without_holding_the_gil(python: Python<'_>, engine: Arc<Runner>) {
+        python.detach(move || {
+            let Some(owned_engine) = Arc::into_inner(engine) else {
+                // Something outlived the handle's reference, so dropping here
+                // joins nothing. Fail loud rather than let `run()` return on a
+                // contract it did not keep.
+                tracing::error!(
+                    "engine teardown left a live reference behind — engine threads may outlive \
+                     interpreter finalization"
+                );
+                return;
+            };
+            drop(owned_engine);
+        });
+    }
+}
+
+#[pymethods]
+impl PythonRuntimeHandle {
+    /// Boot the engine.
+    #[new]
+    fn new(python: Python<'_>) -> PyResult<Self> {
+        let engine = python
+            .detach(Runner::new)
+            .map_err(|engine_failure| PyRuntimeError::new_err(engine_failure.to_string()))?;
+        Ok(Self {
+            engine: Some(engine),
+        })
+    }
+
+    /// Run the pipeline until Ctrl-C or SIGTERM, then tear the engine down.
+    ///
+    /// Owns SIGINT while it blocks and hands it back to CPython before
+    /// returning, so a later Ctrl-C raises `KeyboardInterrupt` as usual.
+    fn run(&mut self, python: Python<'_>) -> PyResult<()> {
+        let engine = self.engine.take().ok_or_else(|| {
+            PyRuntimeError::new_err(
+                "this Runtime has already been run; construct a new one to run again",
+            )
+        })?;
+
+        // Owns the shutdown signals across startup as well as the wait: with the
+        // GIL released here, a SIGINT that reached CPython's handler instead
+        // could never become a `KeyboardInterrupt`, and this call would block
+        // forever.
+        let run_outcome = python.detach(|| engine.start_and_wait_for_shutdown());
+
+        // Unconditional: a failed start must still not leave engine threads
+        // alive to race interpreter finalization.
+        Self::drop_engine_without_holding_the_gil(python, engine);
+
+        run_outcome.map_err(|engine_failure| PyRuntimeError::new_err(engine_failure.to_string()))
+    }
+
+    /// Tear the engine down if it has not been run. Idempotent.
+    ///
+    /// The escape hatch for the exception path — `streamlib`'s `atexit` hook
+    /// and `__exit__` both land here.
+    fn shutdown(&mut self, python: Python<'_>) {
+        if let Some(engine) = self.engine.take() {
+            Self::drop_engine_without_holding_the_gil(python, engine);
+        }
+    }
+
+    fn __enter__(python_self: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        python_self
+    }
+
+    /// Never suppresses the exception — returning false lets it propagate once
+    /// the engine is down.
+    #[pyo3(signature = (*_exception_details))]
+    fn __exit__(&mut self, python: Python<'_>, _exception_details: &Bound<'_, PyAny>) -> bool {
+        self.shutdown(python);
+        false
+    }
+}
+
+impl Drop for PythonRuntimeHandle {
+    /// Covers the garbage-collected path, where neither `__exit__` nor the
+    /// `atexit` hook ran.
+    fn drop(&mut self) {
+        let Some(engine) = self.engine.take() else {
+            return;
+        };
+        Python::attach(|python| {
+            Self::drop_engine_without_holding_the_gil(python, engine);
+        });
+    }
+}

--- a/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
+++ b/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
@@ -8,11 +8,24 @@
 //! not merely stopped — before [`PythonRuntimeHandle::run`] returns, so no
 //! engine thread can still be alive when CPython finalizes.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::runtime::{Runner, request_runtime_shutdown};
+
+/// A reference to the engine outlived the handle, so its threads were not
+/// joined and the teardown contract was not kept.
+struct EngineTeardownIncomplete;
+
+impl From<EngineTeardownIncomplete> for PyErr {
+    fn from(_: EngineTeardownIncomplete) -> Self {
+        PyRuntimeError::new_err(
+            "engine teardown left a live reference behind — engine threads may outlive \
+             interpreter finalization",
+        )
+    }
+}
 
 /// The engine, held by a Python object.
 ///
@@ -22,32 +35,57 @@ use streamlib::sdk::runtime::Runner;
 /// promise.
 // `subclass` so the Python-side `streamlib.Runtime` can extend this to register
 // itself with the `atexit` teardown hook.
-#[pyclass(name = "Runtime", module = "streamlib", unsendable, subclass)]
+#[pyclass(name = "Runtime", module = "streamlib", subclass)]
 pub struct PythonRuntimeHandle {
     /// `None` once the engine has been run or torn down.
-    engine: Option<Arc<Runner>>,
+    ///
+    /// Behind a lock rather than `&mut self` so every method takes `&self`: a
+    /// `&mut self` `run()` keeps the pyclass mutably borrowed for the whole
+    /// blocking call, and `shutdown()` from a worker thread then fails on the
+    /// borrow instead of stopping the pipeline.
+    engine: Mutex<Option<Arc<Runner>>>,
 }
 
 impl PythonRuntimeHandle {
+    /// Take the engine out, leaving the handle empty. Whoever gets `Some` owns
+    /// the teardown.
+    fn take_engine(&self) -> Option<Arc<Runner>> {
+        self.engine
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+    }
+
     /// Drop the engine with the GIL released, joining its threads.
     ///
     /// Releasing the GIL is not an optimization: an engine thread that needs
     /// the GIL to finish (a Python processor, once those exist) would deadlock
     /// against a teardown that held it.
-    fn drop_engine_without_holding_the_gil(python: Python<'_>, engine: Arc<Runner>) {
+    fn drop_engine_without_holding_the_gil(
+        python: Python<'_>,
+        engine: Arc<Runner>,
+    ) -> Result<(), EngineTeardownIncomplete> {
         python.detach(move || {
-            let Some(owned_engine) = Arc::into_inner(engine) else {
-                // Something outlived the handle's reference, so dropping here
-                // joins nothing. Fail loud rather than let `run()` return on a
-                // contract it did not keep.
-                tracing::error!(
-                    "engine teardown left a live reference behind — engine threads may outlive \
-                     interpreter finalization"
-                );
-                return;
-            };
-            drop(owned_engine);
-        });
+            // `start()` parks an `Arc<Runner>` inside the `RuntimeContext` it
+            // stores on the runner, and only `stop()` clears it. Without this
+            // the cycle survives every path where the run loop did not stop the
+            // engine itself — a failed `start()`, or a handle torn down before
+            // it ever ran — and `into_inner` below would join nothing.
+            if let Err(stop_failure) = engine.stop() {
+                tracing::warn!(%stop_failure, "engine stop reported a failure during teardown");
+            }
+
+            match Arc::into_inner(engine) {
+                Some(owned_engine) => {
+                    drop(owned_engine);
+                    Ok(())
+                }
+                // Reached only if something still holds a reference, which means
+                // the threads are not joined. The caller raises rather than
+                // returning on a contract it did not keep.
+                None => Err(EngineTeardownIncomplete),
+            }
+        })
     }
 }
 
@@ -60,7 +98,7 @@ impl PythonRuntimeHandle {
             .detach(Runner::new)
             .map_err(|engine_failure| PyRuntimeError::new_err(engine_failure.to_string()))?;
         Ok(Self {
-            engine: Some(engine),
+            engine: Mutex::new(Some(engine)),
         })
     }
 
@@ -68,8 +106,8 @@ impl PythonRuntimeHandle {
     ///
     /// Owns SIGINT while it blocks and hands it back to CPython before
     /// returning, so a later Ctrl-C raises `KeyboardInterrupt` as usual.
-    fn run(&mut self, python: Python<'_>) -> PyResult<()> {
-        let engine = self.engine.take().ok_or_else(|| {
+    fn run(&self, python: Python<'_>) -> PyResult<()> {
+        let engine = self.take_engine().ok_or_else(|| {
             PyRuntimeError::new_err(
                 "this Runtime has already been run; construct a new one to run again",
             )
@@ -83,18 +121,29 @@ impl PythonRuntimeHandle {
 
         // Unconditional: a failed start must still not leave engine threads
         // alive to race interpreter finalization.
-        Self::drop_engine_without_holding_the_gil(python, engine);
+        let teardown_outcome = Self::drop_engine_without_holding_the_gil(python, engine);
 
-        run_outcome.map_err(|engine_failure| PyRuntimeError::new_err(engine_failure.to_string()))
+        // The run failure is the more informative one, so it wins if both fired.
+        run_outcome
+            .map_err(|engine_failure| PyRuntimeError::new_err(engine_failure.to_string()))?;
+        Ok(teardown_outcome?)
     }
 
-    /// Tear the engine down if it has not been run. Idempotent.
+    /// Ask the pipeline to stop, and tear the engine down if it never ran.
     ///
-    /// The escape hatch for the exception path — `streamlib`'s `atexit` hook
-    /// and `__exit__` both land here.
-    fn shutdown(&mut self, python: Python<'_>) {
-        if let Some(engine) = self.engine.take() {
-            Self::drop_engine_without_holding_the_gil(python, engine);
+    /// Safe to call from any thread and at any point: while `run()` is
+    /// blocking, this is what ends it — the request goes through the same
+    /// funnel Ctrl-C does, and `run()` performs the teardown. Before `run()`,
+    /// it tears the engine down here. Idempotent either way.
+    fn shutdown(&self, python: Python<'_>) -> PyResult<()> {
+        match self.take_engine() {
+            Some(engine) => Ok(Self::drop_engine_without_holding_the_gil(python, engine)?),
+            // Either `run()` owns the engine and is blocking on it, or teardown
+            // already happened — the request funnel is idempotent, so asking
+            // again costs nothing and the second case is a no-op.
+            None => python
+                .detach(|| request_runtime_shutdown("streamlib.Runtime.shutdown()"))
+                .map_err(|request_failure| PyRuntimeError::new_err(request_failure.to_string())),
         }
     }
 
@@ -105,21 +154,33 @@ impl PythonRuntimeHandle {
     /// Never suppresses the exception — returning false lets it propagate once
     /// the engine is down.
     #[pyo3(signature = (*_exception_details))]
-    fn __exit__(&mut self, python: Python<'_>, _exception_details: &Bound<'_, PyAny>) -> bool {
-        self.shutdown(python);
-        false
+    fn __exit__(
+        &self,
+        python: Python<'_>,
+        _exception_details: &Bound<'_, PyAny>,
+    ) -> PyResult<bool> {
+        self.shutdown(python)?;
+        Ok(false)
     }
 }
 
 impl Drop for PythonRuntimeHandle {
     /// Covers the garbage-collected path, where neither `__exit__` nor the
     /// `atexit` hook ran.
+    ///
+    /// Only reachable while the handle still owns the engine; a `Drop` cannot
+    /// report failure, so this is the one caller that may only log.
     fn drop(&mut self) {
-        let Some(engine) = self.engine.take() else {
+        let Some(engine) = self.take_engine() else {
             return;
         };
         Python::attach(|python| {
-            Self::drop_engine_without_holding_the_gil(python, engine);
+            if Self::drop_engine_without_holding_the_gil(python, engine).is_err() {
+                tracing::error!(
+                    "engine teardown left a live reference behind — engine threads may outlive \
+                     interpreter finalization"
+                );
+            }
         });
     }
 }

--- a/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
+++ b/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
@@ -8,6 +8,7 @@
 //! not merely stopped — before [`PythonRuntimeHandle::run`] returns, so no
 //! engine thread can still be alive when CPython finalizes.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use pyo3::exceptions::PyRuntimeError;
@@ -44,6 +45,14 @@ pub struct PythonRuntimeHandle {
     /// blocking call, and `shutdown()` from a worker thread then fails on the
     /// borrow instead of stopping the pipeline.
     engine: Mutex<Option<Arc<Runner>>>,
+    /// True only while `run()` is blocked on the engine.
+    ///
+    /// `shutdown()` needs it to tell "a run loop is waiting for a request" from
+    /// "teardown already happened". The shutdown-request latch is
+    /// process-global and first-observer-wins, so requesting one with no run
+    /// loop waiting leaves it set for the *next* run loop in this interpreter,
+    /// which then returns immediately having run nothing.
+    run_loop_is_blocking: AtomicBool,
 }
 
 impl PythonRuntimeHandle {
@@ -99,6 +108,7 @@ impl PythonRuntimeHandle {
             .map_err(|engine_failure| PyRuntimeError::new_err(engine_failure.to_string()))?;
         Ok(Self {
             engine: Mutex::new(Some(engine)),
+            run_loop_is_blocking: AtomicBool::new(false),
         })
     }
 
@@ -106,6 +116,11 @@ impl PythonRuntimeHandle {
     ///
     /// Owns SIGINT while it blocks and hands it back to CPython before
     /// returning, so a later Ctrl-C raises `KeyboardInterrupt` as usual.
+    ///
+    /// Linux only, matching the platform floor. On macOS the engine's run loop
+    /// is an `NSApplication` loop that terminates the process instead of
+    /// returning, so none of the above holds there — not the return, not the
+    /// teardown, not the handback.
     fn run(&self, python: Python<'_>) -> PyResult<()> {
         let engine = self.take_engine().ok_or_else(|| {
             PyRuntimeError::new_err(
@@ -117,7 +132,9 @@ impl PythonRuntimeHandle {
         // GIL released here, a SIGINT that reached CPython's handler instead
         // could never become a `KeyboardInterrupt`, and this call would block
         // forever.
+        self.run_loop_is_blocking.store(true, Ordering::SeqCst);
         let run_outcome = python.detach(|| engine.start_and_wait_for_shutdown());
+        self.run_loop_is_blocking.store(false, Ordering::SeqCst);
 
         // Unconditional: a failed start must still not leave engine threads
         // alive to race interpreter finalization.
@@ -136,15 +153,18 @@ impl PythonRuntimeHandle {
     /// funnel Ctrl-C does, and `run()` performs the teardown. Before `run()`,
     /// it tears the engine down here. Idempotent either way.
     fn shutdown(&self, python: Python<'_>) -> PyResult<()> {
-        match self.take_engine() {
-            Some(engine) => Ok(Self::drop_engine_without_holding_the_gil(python, engine)?),
-            // Either `run()` owns the engine and is blocking on it, or teardown
-            // already happened — the request funnel is idempotent, so asking
-            // again costs nothing and the second case is a no-op.
-            None => python
-                .detach(|| request_runtime_shutdown("streamlib.Runtime.shutdown()"))
-                .map_err(|request_failure| PyRuntimeError::new_err(request_failure.to_string())),
+        if let Some(engine) = self.take_engine() {
+            return Ok(Self::drop_engine_without_holding_the_gil(python, engine)?);
         }
+        if !self.run_loop_is_blocking.load(Ordering::SeqCst) {
+            // Teardown already happened. Requesting here would latch a shutdown
+            // nobody is waiting for, and the next run loop in this interpreter
+            // would observe it and exit immediately.
+            return Ok(());
+        }
+        python
+            .detach(|| request_runtime_shutdown("streamlib.Runtime.shutdown()"))
+            .map_err(|request_failure| PyRuntimeError::new_err(request_failure.to_string()))
     }
 
     fn __enter__(python_self: PyRef<'_, Self>) -> PyRef<'_, Self> {

--- a/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
+++ b/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
@@ -8,61 +8,62 @@
 //! not merely stopped — before [`PythonRuntimeHandle::run`] returns, so no
 //! engine thread can still be alive when CPython finalizes.
 
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use streamlib::sdk::runtime::{Runner, request_runtime_shutdown};
+use streamlib::sdk::runtime::{
+    Runner, request_runtime_shutdown, take_runtime_shutdown_request_latch,
+};
 
 /// A reference to the engine outlived the handle, so its threads were not
 /// joined and the teardown contract was not kept.
 struct EngineTeardownIncomplete;
 
-impl From<EngineTeardownIncomplete> for PyErr {
-    fn from(_: EngineTeardownIncomplete) -> Self {
-        PyRuntimeError::new_err(
+impl std::fmt::Display for EngineTeardownIncomplete {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(
             "engine teardown left a live reference behind — engine threads may outlive \
              interpreter finalization",
         )
     }
 }
 
+impl From<EngineTeardownIncomplete> for PyErr {
+    fn from(teardown_failure: EngineTeardownIncomplete) -> Self {
+        PyRuntimeError::new_err(teardown_failure.to_string())
+    }
+}
+
+/// Where the handle is in its one-way lifecycle.
+///
+/// One locked value rather than an engine slot plus a "running" flag, because
+/// `shutdown()` must decide *and act* without the run loop's exit racing it: the
+/// shutdown-request latch is process-global and first-observer-wins, so a
+/// request issued after the run loop stopped observing is inherited by the next
+/// run loop in the interpreter, which then returns having run nothing.
+enum PythonRuntimeLifecycleState {
+    EngineConstructedNotYetRun(Arc<Runner>),
+    RunLoopBlockedUntilShutdownRequested,
+    EngineTornDownAndThreadsJoined,
+}
+
 /// The engine, held by a Python object.
 ///
 /// Single-use by construction: [`run`](PythonRuntimeHandle::run) takes the
-/// engine out and drops it before returning, because "all engine threads
-/// joined before `run()` returns" is not something a still-shared handle can
-/// promise.
+/// engine out and drops it before returning.
 // `subclass` so the Python-side `streamlib.Runtime` can extend this to register
 // itself with the `atexit` teardown hook.
 #[pyclass(name = "Runtime", module = "streamlib", subclass)]
 pub struct PythonRuntimeHandle {
-    /// `None` once the engine has been run or torn down.
-    ///
-    /// Behind a lock rather than `&mut self` so every method takes `&self`: a
-    /// `&mut self` `run()` keeps the pyclass mutably borrowed for the whole
-    /// blocking call, and `shutdown()` from a worker thread then fails on the
-    /// borrow instead of stopping the pipeline.
-    engine: Mutex<Option<Arc<Runner>>>,
-    /// True only while `run()` is blocked on the engine.
-    ///
-    /// `shutdown()` needs it to tell "a run loop is waiting for a request" from
-    /// "teardown already happened". The shutdown-request latch is
-    /// process-global and first-observer-wins, so requesting one with no run
-    /// loop waiting leaves it set for the *next* run loop in this interpreter,
-    /// which then returns immediately having run nothing.
-    run_loop_is_blocking: AtomicBool,
+    lifecycle: Mutex<PythonRuntimeLifecycleState>,
 }
 
 impl PythonRuntimeHandle {
-    /// Take the engine out, leaving the handle empty. Whoever gets `Some` owns
-    /// the teardown.
-    fn take_engine(&self) -> Option<Arc<Runner>> {
-        self.engine
+    fn lifecycle(&self) -> MutexGuard<'_, PythonRuntimeLifecycleState> {
+        self.lifecycle
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .take()
     }
 
     /// Drop the engine with the GIL released, joining its threads.
@@ -89,9 +90,8 @@ impl PythonRuntimeHandle {
                     drop(owned_engine);
                     Ok(())
                 }
-                // Reached only if something still holds a reference, which means
-                // the threads are not joined. The caller raises rather than
-                // returning on a contract it did not keep.
+                // Something still holds a reference, so the threads are not
+                // joined.
                 None => Err(EngineTeardownIncomplete),
             }
         })
@@ -107,40 +107,65 @@ impl PythonRuntimeHandle {
             .detach(Runner::new)
             .map_err(|engine_failure| PyRuntimeError::new_err(engine_failure.to_string()))?;
         Ok(Self {
-            engine: Mutex::new(Some(engine)),
-            run_loop_is_blocking: AtomicBool::new(false),
+            lifecycle: Mutex::new(PythonRuntimeLifecycleState::EngineConstructedNotYetRun(
+                engine,
+            )),
         })
     }
 
-    /// Run the pipeline until Ctrl-C or SIGTERM, then tear the engine down.
+    /// Run the pipeline until Ctrl-C, SIGTERM, or [`shutdown`], then tear the
+    /// engine down.
     ///
     /// Owns SIGINT while it blocks and hands it back to CPython before
     /// returning, so a later Ctrl-C raises `KeyboardInterrupt` as usual.
+    ///
+    /// Call it from the main thread. On a worker thread the interpreter can
+    /// begin finalizing while this is still inside teardown, and the thread is
+    /// killed the moment it reattaches.
     ///
     /// Linux only, matching the platform floor. On macOS the engine's run loop
     /// is an `NSApplication` loop that terminates the process instead of
     /// returning, so none of the above holds there — not the return, not the
     /// teardown, not the handback.
+    ///
+    /// [`shutdown`]: PythonRuntimeHandle::shutdown
     fn run(&self, python: Python<'_>) -> PyResult<()> {
-        let engine = self.take_engine().ok_or_else(|| {
-            PyRuntimeError::new_err(
-                "this Runtime has already been run; construct a new one to run again",
-            )
-        })?;
+        let engine = {
+            let mut lifecycle = self.lifecycle();
+            match std::mem::replace(
+                &mut *lifecycle,
+                PythonRuntimeLifecycleState::RunLoopBlockedUntilShutdownRequested,
+            ) {
+                PythonRuntimeLifecycleState::EngineConstructedNotYetRun(engine) => engine,
+                already_run => {
+                    *lifecycle = already_run;
+                    return Err(PyRuntimeError::new_err(
+                        "this Runtime has already been run; construct a new one to run again",
+                    ));
+                }
+            }
+        };
 
         // Owns the shutdown signals across startup as well as the wait: with the
         // GIL released here, a SIGINT that reached CPython's handler instead
         // could never become a `KeyboardInterrupt`, and this call would block
         // forever.
-        self.run_loop_is_blocking.store(true, Ordering::SeqCst);
         let run_outcome = python.detach(|| engine.start_and_wait_for_shutdown());
-        self.run_loop_is_blocking.store(false, Ordering::SeqCst);
+
+        {
+            let mut lifecycle = self.lifecycle();
+            // Taken under the same lock `shutdown()` holds while it requests, so
+            // a request issued in the window between the run loop's last
+            // observation and this transition is consumed here rather than left
+            // for the next run loop in this interpreter.
+            take_runtime_shutdown_request_latch();
+            *lifecycle = PythonRuntimeLifecycleState::EngineTornDownAndThreadsJoined;
+        }
 
         // Unconditional: a failed start must still not leave engine threads
         // alive to race interpreter finalization.
         let teardown_outcome = Self::drop_engine_without_holding_the_gil(python, engine);
 
-        // The run failure is the more informative one, so it wins if both fired.
         run_outcome
             .map_err(|engine_failure| PyRuntimeError::new_err(engine_failure.to_string()))?;
         Ok(teardown_outcome?)
@@ -148,23 +173,37 @@ impl PythonRuntimeHandle {
 
     /// Ask the pipeline to stop, and tear the engine down if it never ran.
     ///
-    /// Safe to call from any thread and at any point: while `run()` is
-    /// blocking, this is what ends it — the request goes through the same
-    /// funnel Ctrl-C does, and `run()` performs the teardown. Before `run()`,
-    /// it tears the engine down here. Idempotent either way.
+    /// Safe to call from any thread. While `run()` is blocking this is what
+    /// ends it — the request goes through the same funnel Ctrl-C does, and
+    /// `run()` performs the teardown. Before `run()`, it tears the engine down
+    /// here. After teardown it does nothing. Idempotent in every case.
+    ///
+    /// It returns as soon as the request is issued; when `run()` is blocking on
+    /// another thread, teardown completes on that thread rather than this one.
     fn shutdown(&self, python: Python<'_>) -> PyResult<()> {
-        if let Some(engine) = self.take_engine() {
-            return Ok(Self::drop_engine_without_holding_the_gil(python, engine)?);
+        let mut lifecycle = self.lifecycle();
+        match &*lifecycle {
+            PythonRuntimeLifecycleState::EngineConstructedNotYetRun(_) => {
+                let PythonRuntimeLifecycleState::EngineConstructedNotYetRun(engine) =
+                    std::mem::replace(
+                        &mut *lifecycle,
+                        PythonRuntimeLifecycleState::EngineTornDownAndThreadsJoined,
+                    )
+                else {
+                    unreachable!("matched EngineConstructedNotYetRun under the same lock")
+                };
+                drop(lifecycle);
+                Ok(Self::drop_engine_without_holding_the_gil(python, engine)?)
+            }
+            PythonRuntimeLifecycleState::RunLoopBlockedUntilShutdownRequested => {
+                // Issued while still holding the lock: `run()` takes it to move
+                // to the torn-down state and clears the latch there, so this
+                // request cannot outlive the run loop it is meant for.
+                request_runtime_shutdown("streamlib.Runtime.shutdown()")
+                    .map_err(|request_failure| PyRuntimeError::new_err(request_failure.to_string()))
+            }
+            PythonRuntimeLifecycleState::EngineTornDownAndThreadsJoined => Ok(()),
         }
-        if !self.run_loop_is_blocking.load(Ordering::SeqCst) {
-            // Teardown already happened. Requesting here would latch a shutdown
-            // nobody is waiting for, and the next run loop in this interpreter
-            // would observe it and exit immediately.
-            return Ok(());
-        }
-        python
-            .detach(|| request_runtime_shutdown("streamlib.Runtime.shutdown()"))
-            .map_err(|request_failure| PyRuntimeError::new_err(request_failure.to_string()))
     }
 
     fn __enter__(python_self: PyRef<'_, Self>) -> PyRef<'_, Self> {
@@ -188,18 +227,20 @@ impl Drop for PythonRuntimeHandle {
     /// Covers the garbage-collected path, where neither `__exit__` nor the
     /// `atexit` hook ran.
     ///
-    /// Only reachable while the handle still owns the engine; a `Drop` cannot
-    /// report failure, so this is the one caller that may only log.
+    /// A `Drop` cannot report failure, so this is the one caller that may only
+    /// log.
     fn drop(&mut self) {
-        let Some(engine) = self.take_engine() else {
-            return;
+        let engine = match std::mem::replace(
+            &mut *self.lifecycle(),
+            PythonRuntimeLifecycleState::EngineTornDownAndThreadsJoined,
+        ) {
+            PythonRuntimeLifecycleState::EngineConstructedNotYetRun(engine) => engine,
+            _ => return,
         };
         Python::attach(|python| {
-            if Self::drop_engine_without_holding_the_gil(python, engine).is_err() {
-                tracing::error!(
-                    "engine teardown left a live reference behind — engine threads may outlive \
-                     interpreter finalization"
-                );
+            if let Err(teardown_failure) = Self::drop_engine_without_holding_the_gil(python, engine)
+            {
+                tracing::error!(%teardown_failure);
             }
         });
     }

--- a/sdk/streamlib-python-wheel/tests/interpreter_lifecycle_app.py
+++ b/sdk/streamlib-python-wheel/tests/interpreter_lifecycle_app.py
@@ -18,18 +18,16 @@ import time
 import streamlib
 
 
+KEYBOARD_INTERRUPT_UPPER_BOUND_SECONDS = 5.0
+
+# Held at module scope on purpose: a Runtime still reachable from a module
+# global when the interpreter starts finalizing is the case `Drop` alone does
+# not obviously cover, and the one the `atexit` hook exists for.
+RUNTIME_HELD_AT_MODULE_SCOPE: "streamlib.Runtime | None" = None
+
+
 def marker(text: str) -> None:
     print(f"MARKER:{text}", flush=True)
-
-
-def raise_sigint_after(delay_seconds: float) -> None:
-    """Deliver a real SIGINT to this process from a background thread."""
-
-    def deliver() -> None:
-        time.sleep(delay_seconds)
-        os.kill(os.getpid(), signal.SIGINT)
-
-    threading.Thread(target=deliver, daemon=True).start()
 
 
 def scenario_ctrl_c() -> None:
@@ -42,7 +40,9 @@ def scenario_ctrl_c() -> None:
 def scenario_gil_released_while_running() -> None:
     """A Python thread must keep making progress while `run()` blocks.
 
-    If `run()` held the GIL, this counter would be stuck at zero.
+    The counter is sampled either side of `run()` rather than over the whole
+    scenario, so the reported delta is progress made *during* the blocking call
+    and nowhere else. The driver sends the SIGINT that ends it.
     """
     progress = {"ticks": 0}
     keep_counting = threading.Event()
@@ -57,26 +57,33 @@ def scenario_gil_released_while_running() -> None:
     counting_thread.start()
 
     runtime = streamlib.Runtime()
-    raise_sigint_after(2.0)
+    ticks_before_run = progress["ticks"]
     runtime.run()
+    ticks_during_run = progress["ticks"] - ticks_before_run
 
     keep_counting.clear()
     counting_thread.join(timeout=5.0)
-    marker(f"PYTHON_THREAD_TICKS={progress['ticks']}")
+    marker(f"PYTHON_THREAD_TICKS={ticks_during_run}")
 
 
 def scenario_sigint_handed_back_to_cpython() -> None:
-    """After `run()` returns, SIGINT must reach CPython again."""
+    """After `run()` returns, SIGINT must reach CPython again.
+
+    The driver sends the first SIGINT; this sends the second one itself,
+    because the point is what happens to a signal raised *after* `run()` has
+    handed the disposition back.
+    """
     runtime = streamlib.Runtime()
-    raise_sigint_after(2.0)
     runtime.run()
     marker("RUN_RETURNED")
 
     try:
         os.kill(os.getpid(), signal.SIGINT)
         # CPython's handler sets a flag that the next bytecode check turns into
-        # KeyboardInterrupt; sleeping gives it that check.
-        time.sleep(2.0)
+        # KeyboardInterrupt, which interrupts this sleep immediately. The
+        # duration is an upper bound on that check, not a sequencing delay — a
+        # swallowed signal is what makes it elapse in full.
+        time.sleep(KEYBOARD_INTERRUPT_UPPER_BOUND_SECONDS)
     except KeyboardInterrupt:
         marker("KEYBOARD_INTERRUPT_RAISED")
     else:
@@ -93,15 +100,29 @@ def scenario_exception_inside_context_manager() -> None:
 
 
 def scenario_never_run() -> None:
-    """A Runtime that is constructed and never run must not hang at exit."""
+    """A Runtime dropped without running must not hang at exit.
+
+    The result is unbound, so CPython refcounts it to zero immediately and this
+    exercises the pyclass `Drop` — not the `atexit` hook.
+    """
     streamlib.Runtime()
     marker("CONSTRUCTED_WITHOUT_RUNNING")
+
+
+def scenario_still_referenced_at_exit() -> None:
+    """A Runtime alive at interpreter exit must still tear the engine down.
+
+    Nothing here drops the reference, so teardown has to come from interpreter
+    shutdown — the `atexit` hook, or module-global clearing reaching `Drop`.
+    """
+    global RUNTIME_HELD_AT_MODULE_SCOPE
+    RUNTIME_HELD_AT_MODULE_SCOPE = streamlib.Runtime()
+    marker("STILL_REFERENCED_AT_EXIT")
 
 
 def scenario_second_run_is_refused() -> None:
     """`run()` consumes the engine, so a second call must fail loudly."""
     runtime = streamlib.Runtime()
-    raise_sigint_after(2.0)
     runtime.run()
     marker("RUN_RETURNED")
     try:
@@ -112,13 +133,42 @@ def scenario_second_run_is_refused() -> None:
         marker("SECOND_RUN_WAS_ALLOWED")
 
 
+def scenario_shutdown_from_another_thread() -> None:
+    """`shutdown()` from a worker thread must end a blocking `run()`.
+
+    This is the programmatic stop — no signal involved. The worker waits for the
+    engine's own ready line on the main thread's behalf via a barrier the
+    driver cannot see, so it uses the same readiness the driver does: it is
+    started only once `run()` is about to be entered.
+    """
+    runtime = streamlib.Runtime()
+
+    stop_requested = threading.Event()
+
+    def request_stop() -> None:
+        # The driver signals readiness by closing stdin; until then the engine
+        # may still be coming up.
+        sys.stdin.read()
+        stop_requested.set()
+        runtime.shutdown()
+
+    threading.Thread(target=request_stop, daemon=True).start()
+    runtime.run()
+
+    marker("RUN_RETURNED")
+    if stop_requested.is_set():
+        marker("STOPPED_FROM_ANOTHER_THREAD")
+
+
 SCENARIOS = {
     "ctrl_c": scenario_ctrl_c,
     "gil_released": scenario_gil_released_while_running,
     "sigint_handed_back": scenario_sigint_handed_back_to_cpython,
     "exception_in_context_manager": scenario_exception_inside_context_manager,
     "never_run": scenario_never_run,
+    "still_referenced_at_exit": scenario_still_referenced_at_exit,
     "second_run_refused": scenario_second_run_is_refused,
+    "shutdown_from_another_thread": scenario_shutdown_from_another_thread,
 }
 
 

--- a/sdk/streamlib-python-wheel/tests/interpreter_lifecycle_app.py
+++ b/sdk/streamlib-python-wheel/tests/interpreter_lifecycle_app.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""The app under test — a real `python app.py`, driven by
+`test_interpreter_lifecycle.py`.
+
+Each scenario prints markers the driver asserts on. Markers are flushed as they
+are printed because the engine writes its own logs to this same stdout from
+Rust, and an unflushed Python buffer would reorder them.
+"""
+
+import os
+import signal
+import sys
+import threading
+import time
+
+import streamlib
+
+
+def marker(text: str) -> None:
+    print(f"MARKER:{text}", flush=True)
+
+
+def raise_sigint_after(delay_seconds: float) -> None:
+    """Deliver a real SIGINT to this process from a background thread."""
+
+    def deliver() -> None:
+        time.sleep(delay_seconds)
+        os.kill(os.getpid(), signal.SIGINT)
+
+    threading.Thread(target=deliver, daemon=True).start()
+
+
+def scenario_ctrl_c() -> None:
+    """The demo: boot, block, and exit cleanly when the driver sends Ctrl-C."""
+    runtime = streamlib.Runtime()
+    runtime.run()
+    marker("RUN_RETURNED")
+
+
+def scenario_gil_released_while_running() -> None:
+    """A Python thread must keep making progress while `run()` blocks.
+
+    If `run()` held the GIL, this counter would be stuck at zero.
+    """
+    progress = {"ticks": 0}
+    keep_counting = threading.Event()
+    keep_counting.set()
+
+    def count() -> None:
+        while keep_counting.is_set():
+            progress["ticks"] += 1
+            time.sleep(0.001)
+
+    counting_thread = threading.Thread(target=count, daemon=True)
+    counting_thread.start()
+
+    runtime = streamlib.Runtime()
+    raise_sigint_after(2.0)
+    runtime.run()
+
+    keep_counting.clear()
+    counting_thread.join(timeout=5.0)
+    marker(f"PYTHON_THREAD_TICKS={progress['ticks']}")
+
+
+def scenario_sigint_handed_back_to_cpython() -> None:
+    """After `run()` returns, SIGINT must reach CPython again."""
+    runtime = streamlib.Runtime()
+    raise_sigint_after(2.0)
+    runtime.run()
+    marker("RUN_RETURNED")
+
+    try:
+        os.kill(os.getpid(), signal.SIGINT)
+        # CPython's handler sets a flag that the next bytecode check turns into
+        # KeyboardInterrupt; sleeping gives it that check.
+        time.sleep(2.0)
+    except KeyboardInterrupt:
+        marker("KEYBOARD_INTERRUPT_RAISED")
+    else:
+        marker("SIGINT_WAS_SWALLOWED")
+
+
+def scenario_exception_inside_context_manager() -> None:
+    """An exception must not strand the engine, and must still propagate."""
+    try:
+        with streamlib.Runtime():
+            raise ValueError("failure inside the with-block")
+    except ValueError:
+        marker("EXCEPTION_PROPAGATED")
+
+
+def scenario_never_run() -> None:
+    """A Runtime that is constructed and never run must not hang at exit."""
+    streamlib.Runtime()
+    marker("CONSTRUCTED_WITHOUT_RUNNING")
+
+
+def scenario_second_run_is_refused() -> None:
+    """`run()` consumes the engine, so a second call must fail loudly."""
+    runtime = streamlib.Runtime()
+    raise_sigint_after(2.0)
+    runtime.run()
+    marker("RUN_RETURNED")
+    try:
+        runtime.run()
+    except RuntimeError:
+        marker("SECOND_RUN_REFUSED")
+    else:
+        marker("SECOND_RUN_WAS_ALLOWED")
+
+
+SCENARIOS = {
+    "ctrl_c": scenario_ctrl_c,
+    "gil_released": scenario_gil_released_while_running,
+    "sigint_handed_back": scenario_sigint_handed_back_to_cpython,
+    "exception_in_context_manager": scenario_exception_inside_context_manager,
+    "never_run": scenario_never_run,
+    "second_run_refused": scenario_second_run_is_refused,
+}
+
+
+if __name__ == "__main__":
+    SCENARIOS[sys.argv[1]]()
+    marker("CLEAN_EXIT")

--- a/sdk/streamlib-python-wheel/tests/interpreter_lifecycle_app.py
+++ b/sdk/streamlib-python-wheel/tests/interpreter_lifecycle_app.py
@@ -167,6 +167,45 @@ def scenario_shutdown_from_another_thread() -> None:
         marker("STOPPED_FROM_ANOTHER_THREAD")
 
 
+def scenario_shutdown_spun_across_the_run_loop_exit() -> None:
+    """Hammer `shutdown()` from a worker across the first run loop's exit.
+
+    The sequential `with`-block case only ever calls `shutdown()` once `run()`
+    has fully returned. This one deliberately lands calls *during* the exit —
+    the window where a request can be issued after the run loop stopped
+    observing but before the handle is marked torn down. Any request that
+    escapes is inherited by the second pipeline, which then returns instantly.
+    """
+    first_runtime = streamlib.Runtime()
+    keep_requesting = threading.Event()
+    keep_requesting.set()
+
+    def spin_shutdown() -> None:
+        while keep_requesting.is_set():
+            first_runtime.shutdown()
+
+    spinner = threading.Thread(target=spin_shutdown, daemon=True)
+
+    def start_spinning_once_running() -> None:
+        sys.stdin.read()
+        spinner.start()
+
+    threading.Thread(target=start_spinning_once_running, daemon=True).start()
+    first_runtime.run()
+    # Keeps spinning across the exit on purpose — stopped only once the second
+    # pipeline is about to start.
+    keep_requesting.clear()
+    spinner.join(timeout=10.0)
+    marker("PIPELINE_1_RETURNED")
+
+    with streamlib.Runtime() as second_runtime:
+        marker("PIPELINE_2_RUNNING")
+        started = time.monotonic()
+        second_runtime.run()
+        blocked_milliseconds = round((time.monotonic() - started) * 1000)
+    marker(f"PIPELINE_2_BLOCKED_MS={blocked_milliseconds}")
+
+
 def scenario_two_pipelines_in_one_process() -> None:
     """Two run loops in turn, each through the context manager.
 
@@ -198,6 +237,7 @@ SCENARIOS = {
     "second_run_refused": scenario_second_run_is_refused,
     "shutdown_from_another_thread": scenario_shutdown_from_another_thread,
     "two_pipelines_in_one_process": scenario_two_pipelines_in_one_process,
+    "shutdown_spun_across_the_run_loop_exit": scenario_shutdown_spun_across_the_run_loop_exit,
 }
 
 

--- a/sdk/streamlib-python-wheel/tests/interpreter_lifecycle_app.py
+++ b/sdk/streamlib-python-wheel/tests/interpreter_lifecycle_app.py
@@ -20,11 +20,6 @@ import streamlib
 
 KEYBOARD_INTERRUPT_UPPER_BOUND_SECONDS = 5.0
 
-# Held at module scope on purpose: a Runtime still reachable from a module
-# global when the interpreter starts finalizing is the case `Drop` alone does
-# not obviously cover, and the one the `atexit` hook exists for.
-RUNTIME_HELD_AT_MODULE_SCOPE: "streamlib.Runtime | None" = None
-
 
 def marker(text: str) -> None:
     print(f"MARKER:{text}", flush=True)
@@ -109,15 +104,27 @@ def scenario_never_run() -> None:
     marker("CONSTRUCTED_WITHOUT_RUNNING")
 
 
-def scenario_still_referenced_at_exit() -> None:
-    """A Runtime alive at interpreter exit must still tear the engine down.
+def scenario_held_by_a_live_thread_at_exit() -> None:
+    """A Runtime reachable only from a live daemon thread's frame at exit.
 
-    Nothing here drops the reference, so teardown has to come from interpreter
-    shutdown — the `atexit` hook, or module-global clearing reaching `Drop`.
+    This is the case the `atexit` hook is actually load-bearing for. A
+    module-global reference is not: interpreter shutdown clears module globals
+    and that reaches `Drop` on its own. Here the only reference lives in a
+    parked daemon thread's frame, which CPython never unwinds — without the
+    hook the engine's threads are simply alive when the interpreter finalizes,
+    and no teardown runs at all.
     """
-    global RUNTIME_HELD_AT_MODULE_SCOPE
-    RUNTIME_HELD_AT_MODULE_SCOPE = streamlib.Runtime()
-    marker("STILL_REFERENCED_AT_EXIT")
+    holding_thread_is_parked = threading.Event()
+
+    def hold_runtime_forever() -> None:
+        _runtime_held_in_this_frame = streamlib.Runtime()  # noqa: F841
+        holding_thread_is_parked.set()
+        # Never returns, so the frame — and the only reference — stays alive.
+        threading.Event().wait()
+
+    threading.Thread(target=hold_runtime_forever, daemon=True).start()
+    holding_thread_is_parked.wait(timeout=60.0)
+    marker("HELD_BY_LIVE_THREAD_AT_EXIT")
 
 
 def scenario_second_run_is_refused() -> None:
@@ -160,15 +167,37 @@ def scenario_shutdown_from_another_thread() -> None:
         marker("STOPPED_FROM_ANOTHER_THREAD")
 
 
+def scenario_two_pipelines_in_one_process() -> None:
+    """Two run loops in turn, each through the context manager.
+
+    The driver Ctrl-Cs each one. The second must block on its own account — if
+    it inherits the first pipeline's shutdown request it returns immediately,
+    which the reported monotonic span makes visible. The engine initializes its
+    logging pathway once per process, so the second runtime emits no log lines
+    of its own and this scenario announces its own readiness instead.
+    """
+    with streamlib.Runtime() as first_runtime:
+        first_runtime.run()
+    marker("PIPELINE_1_RETURNED")
+
+    with streamlib.Runtime() as second_runtime:
+        marker("PIPELINE_2_RUNNING")
+        started = time.monotonic()
+        second_runtime.run()
+        blocked_milliseconds = round((time.monotonic() - started) * 1000)
+    marker(f"PIPELINE_2_BLOCKED_MS={blocked_milliseconds}")
+
+
 SCENARIOS = {
     "ctrl_c": scenario_ctrl_c,
     "gil_released": scenario_gil_released_while_running,
     "sigint_handed_back": scenario_sigint_handed_back_to_cpython,
     "exception_in_context_manager": scenario_exception_inside_context_manager,
     "never_run": scenario_never_run,
-    "still_referenced_at_exit": scenario_still_referenced_at_exit,
+    "held_by_a_live_thread_at_exit": scenario_held_by_a_live_thread_at_exit,
     "second_run_refused": scenario_second_run_is_refused,
     "shutdown_from_another_thread": scenario_shutdown_from_another_thread,
+    "two_pipelines_in_one_process": scenario_two_pipelines_in_one_process,
 }
 
 

--- a/sdk/streamlib-python-wheel/tests/test_interpreter_lifecycle.py
+++ b/sdk/streamlib-python-wheel/tests/test_interpreter_lifecycle.py
@@ -142,6 +142,40 @@ class AppUnderTest:
         return self
 
 
+    def kill_process_group(self) -> None:
+        """Leave nothing behind, however this app's test ended.
+
+        A failed wait raises without touching the process, and the app runs in
+        its own session — so without this an assertion failure strands a live
+        engine holding a GPU context, an iceoryx2 node and a socket, silently
+        contaminating every later run on the same rig.
+        """
+        try:
+            os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+        for pipe in (self.process.stdout, self.process.stdin):
+            if pipe is not None and not pipe.closed:
+                pipe.close()
+
+
+@pytest.fixture
+def app_under_test():
+    """Hands out apps and kills their process groups no matter how a test ends."""
+    started: list[AppUnderTest] = []
+
+    def start(scenario: str) -> AppUnderTest:
+        app = start_app(scenario)
+        started.append(app)
+        return app
+
+    try:
+        yield start
+    finally:
+        for app in started:
+            app.kill_process_group()
+
+
 def start_app(scenario: str) -> AppUnderTest:
     process = subprocess.Popen(
         [sys.executable, str(APP_UNDER_TEST), scenario],
@@ -158,34 +192,34 @@ def start_app(scenario: str) -> AppUnderTest:
     return AppUnderTest(process)
 
 
-def run_scenario_to_completion(scenario: str) -> AppUnderTest:
+def run_scenario_to_completion(start, scenario: str) -> AppUnderTest:
     """Run a scenario that ends on its own."""
-    return start_app(scenario).await_clean_exit()
+    return start(scenario).await_clean_exit()
 
 
-def run_scenario_interrupted_once_running(scenario: str) -> AppUnderTest:
+def run_scenario_interrupted_once_running(start, scenario: str) -> AppUnderTest:
     """Boot the scenario, wait for the engine's ready line, then Ctrl-C it."""
-    app = start_app(scenario)
+    app = start(scenario)
     app.await_engine_ready()
     app.interrupt()
     return app.await_clean_exit()
 
 
 @pytest.mark.requires_gpu
-def test_ctrl_c_exits_cleanly():
+def test_ctrl_c_exits_cleanly(app_under_test):
     """The demo: Ctrl-C on a running pipeline returns from `run()` and exits 0.
 
     This is the arrangement the #1702 spike never ran — there, Rust embedded
     CPython; here CPython imports the engine.
     """
-    app = run_scenario_interrupted_once_running("ctrl_c")
+    app = run_scenario_interrupted_once_running(app_under_test, "ctrl_c")
     assert "RUN_RETURNED" in app.markers(), (
         f"run() must return on Ctrl-C rather than raising; output:\n{app.output}"
     )
 
 
 @pytest.mark.requires_gpu
-def test_ctrl_c_during_startup_still_exits_cleanly():
+def test_ctrl_c_during_startup_still_exits_cleanly(app_under_test):
     """Ctrl-C while the graph is still coming up must still exit cleanly.
 
     Regression lock on a real hang: signal ownership used to begin inside the
@@ -195,7 +229,7 @@ def test_ctrl_c_during_startup_still_exits_cleanly():
     shutting down. Mental-revert: moving ownership back inside the wait loop
     (`start()` then `wait_for_signal()`) hangs here until the timeout.
     """
-    app = start_app("ctrl_c")
+    app = app_under_test("ctrl_c")
     app.await_output_containing(ENGINE_STARTING_LOG_LINE, "the engine to begin starting")
     app.interrupt()
 
@@ -206,7 +240,7 @@ def test_ctrl_c_during_startup_still_exits_cleanly():
 
 
 @pytest.mark.requires_gpu
-def test_no_survivors_are_left_in_the_process_group():
+def test_no_survivors_are_left_in_the_process_group(app_under_test):
     """The app's whole process group must be gone, not just its leader.
 
     A `waitpid` check cannot show this — the parent has already reaped the
@@ -214,7 +248,7 @@ def test_no_survivors_are_left_in_the_process_group():
     The engine spawns threads rather than children today, so this is a forward
     lock for #1714, which places processors in child interpreters.
     """
-    app = start_app("ctrl_c")
+    app = app_under_test("ctrl_c")
     process_group = os.getpgid(app.process.pid)
     app.await_engine_ready()
     app.interrupt()
@@ -226,13 +260,13 @@ def test_no_survivors_are_left_in_the_process_group():
 
 
 @pytest.mark.requires_gpu
-def test_the_gil_is_released_while_run_blocks():
+def test_the_gil_is_released_while_run_blocks(app_under_test):
     """A Python thread must keep running while `run()` blocks.
 
     Mental-revert: dropping the `python.detach` around the run loop pins the
     GIL for the whole run and leaves the counter at zero.
     """
-    app = run_scenario_interrupted_once_running("gil_released")
+    app = run_scenario_interrupted_once_running(app_under_test, "gil_released")
 
     ticks = next(
         int(marker.removeprefix("PYTHON_THREAD_TICKS="))
@@ -246,39 +280,39 @@ def test_the_gil_is_released_while_run_blocks():
 
 
 @pytest.mark.requires_gpu
-def test_sigint_is_handed_back_to_cpython():
+def test_sigint_is_handed_back_to_cpython(app_under_test):
     """After `run()` returns, Ctrl-C must raise KeyboardInterrupt again.
 
     Mental-revert: leaving the engine's handler installed swallows the second
     SIGINT and the app reports SIGINT_WAS_SWALLOWED instead.
     """
-    app = run_scenario_interrupted_once_running("sigint_handed_back")
+    app = run_scenario_interrupted_once_running(app_under_test, "sigint_handed_back")
     assert "KEYBOARD_INTERRUPT_RAISED" in app.markers(), (
         f"SIGINT after run() must reach CPython's handler; output:\n{app.output}"
     )
 
 
-def test_an_exception_still_tears_the_engine_down():
+def test_an_exception_still_tears_the_engine_down(app_under_test):
     """The exception path keeps the teardown guarantee and re-raises."""
-    app = run_scenario_to_completion("exception_in_context_manager")
+    app = run_scenario_to_completion(app_under_test, "exception_in_context_manager")
     assert "EXCEPTION_PROPAGATED" in app.markers(), (
         f"__exit__ must not suppress the exception; output:\n{app.output}"
     )
 
 
-def test_a_runtime_that_never_runs_does_not_hang_at_exit():
+def test_a_runtime_that_never_runs_does_not_hang_at_exit(app_under_test):
     """A booted-but-unrun engine shuts down without hanging the interpreter.
 
     This is the `Drop` path: the scenario leaves the Runtime unbound, so it is
     refcounted to zero on the spot. The at-exit case is the test below.
     """
-    app = run_scenario_to_completion("never_run")
+    app = run_scenario_to_completion(app_under_test, "never_run")
     assert "CONSTRUCTED_WITHOUT_RUNNING" in app.markers(), (
         f"the scenario did not run; output:\n{app.output}"
     )
 
 
-def test_a_runtime_held_by_a_live_thread_is_torn_down_at_exit():
+def test_a_runtime_held_by_a_live_thread_is_torn_down_at_exit(app_under_test):
     """The `atexit` hook's lock: a Runtime CPython will never collect.
 
     The reference lives in a parked daemon thread's frame, which interpreter
@@ -290,7 +324,7 @@ def test_a_runtime_held_by_a_live_thread_is_torn_down_at_exit():
     Mental-revert: removing `@atexit.register` from `streamlib/__init__.py`
     leaves the shutdown line absent entirely.
     """
-    app = run_scenario_to_completion("held_by_a_live_thread_at_exit")
+    app = run_scenario_to_completion(app_under_test, "held_by_a_live_thread_at_exit")
     assert "HELD_BY_LIVE_THREAD_AT_EXIT" in app.markers(), (
         f"the scenario did not run; output:\n{app.output}"
     )
@@ -301,7 +335,7 @@ def test_a_runtime_held_by_a_live_thread_is_torn_down_at_exit():
 
 
 @pytest.mark.requires_gpu
-def test_a_second_pipeline_in_one_process_still_blocks():
+def test_a_second_pipeline_in_one_process_still_blocks(app_under_test):
     """Two run loops in one interpreter: the second must not inherit the first's
     shutdown request.
 
@@ -319,7 +353,7 @@ def test_a_second_pipeline_in_one_process_still_blocks():
     Mental-revert: dropping the `run_loop_is_blocking` guard in `shutdown()`
     makes the second run return in milliseconds and fails the threshold below.
     """
-    app = start_app("two_pipelines_in_one_process")
+    app = app_under_test("two_pipelines_in_one_process")
 
     app.await_engine_ready()
     app.interrupt()
@@ -355,17 +389,57 @@ SECOND_PIPELINE_MINIMUM_BLOCKED_MILLISECONDS = 2000
 
 
 @pytest.mark.requires_gpu
-def test_a_second_run_is_refused():
+def test_shutdown_spun_across_the_run_loop_exit_does_not_poison_the_next(app_under_test):
+    """A `shutdown()` racing the run loop's exit must not reach the next loop.
+
+    The defect this covers is real and was reproduced independently at ~350ms in
+    2 of 3 trials: a check-then-act guard lets a worker read "still running",
+    release the GIL, and issue its request after the run loop stopped observing,
+    so the next pipeline inherits it.
+
+    Honest scope: this is a concurrent smoke test, NOT a regression lock. The
+    fix is structural — the request is issued under the same lock `run()` takes
+    to transition and clear the latch, so the interleaving cannot occur — and
+    reintroducing the racy shape does not make this test red on this rig (3 of 3
+    green). Treat a failure here as real; do not read a pass as proof.
+    """
+    app = app_under_test("shutdown_spun_across_the_run_loop_exit")
+    app.await_engine_ready()
+
+    # Starts the spinner; it keeps calling shutdown() straight through the exit.
+    app.process.stdin.close()
+    app.process.stdin = None
+
+    app.await_marker("PIPELINE_1_RETURNED")
+    app.await_marker("PIPELINE_2_RUNNING")
+    time.sleep(SECOND_PIPELINE_OBSERVATION_WINDOW_SECONDS)
+    app.interrupt()
+
+    app.await_clean_exit()
+
+    blocked_milliseconds = next(
+        int(marker.removeprefix("PIPELINE_2_BLOCKED_MS="))
+        for marker in app.markers()
+        if marker.startswith("PIPELINE_2_BLOCKED_MS=")
+    )
+    assert blocked_milliseconds >= SECOND_PIPELINE_MINIMUM_BLOCKED_MILLISECONDS, (
+        f"the second run loop returned after only {blocked_milliseconds}ms — a shutdown() "
+        f"racing the first loop's exit escaped into it; output:\n{app.output}"
+    )
+
+
+@pytest.mark.requires_gpu
+def test_a_second_run_is_refused(app_under_test):
     """`run()` drops the engine to keep its teardown promise, so the handle is
     single-use and says so."""
-    app = run_scenario_interrupted_once_running("second_run_refused")
+    app = run_scenario_interrupted_once_running(app_under_test, "second_run_refused")
     assert "SECOND_RUN_REFUSED" in app.markers(), (
         f"a second run() must raise rather than silently do nothing; output:\n{app.output}"
     )
 
 
 @pytest.mark.requires_gpu
-def test_shutdown_from_another_thread_ends_a_blocking_run():
+def test_shutdown_from_another_thread_ends_a_blocking_run(app_under_test):
     """`shutdown()` must end a running pipeline, from any thread.
 
     The programmatic stop, with no signal involved. Two ways this regresses:
@@ -373,7 +447,7 @@ def test_shutdown_from_another_thread_ends_a_blocking_run():
     `PanicException`, and letting `shutdown()` return early when `run()` owns
     the engine makes it a silent no-op that never ends the run.
     """
-    app = start_app("shutdown_from_another_thread")
+    app = app_under_test("shutdown_from_another_thread")
     app.await_engine_ready()
 
     # Closing stdin is the readiness handshake the app waits on, so the

--- a/sdk/streamlib-python-wheel/tests/test_interpreter_lifecycle.py
+++ b/sdk/streamlib-python-wheel/tests/test_interpreter_lifecycle.py
@@ -25,6 +25,8 @@ APP_UNDER_TEST = Path(__file__).parent / "interpreter_lifecycle_app.py"
 ENGINE_READY_TIMEOUT_SECONDS = 60.0
 CLEAN_EXIT_TIMEOUT_SECONDS = 60.0
 
+MARKER_PREFIX = "MARKER:"
+
 ENGINE_READY_LOG_LINE = "[start] Runtime started"
 # Emitted early inside `start()` — after the run loop has taken shutdown-signal
 # ownership, but well before the graph is up.
@@ -43,22 +45,29 @@ class AppUnderTest:
         return "".join(self.output_lines)
 
     def markers(self) -> set[str]:
-        return {
-            line.strip().removeprefix("MARKER:")
-            for line in self.output_lines
-            if line.startswith("MARKER:")
-        }
+        # Matched anywhere in the line, not just at its start: while the engine
+        # is alive its stdio interceptor captures the app's `print()` and
+        # re-emits it inside a tracing record, so a marker emitted before
+        # teardown arrives as `… stdio_interceptor — MARKER:X`.
+        found: set[str] = set()
+        for line in self.output_lines:
+            marker_start = line.find(MARKER_PREFIX)
+            if marker_start != -1:
+                found.add(line[marker_start + len(MARKER_PREFIX) :].strip())
+        return found
 
 
 def start_app(scenario: str) -> subprocess.Popen:
     return subprocess.Popen(
         [sys.executable, str(APP_UNDER_TEST), scenario],
+        stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
         bufsize=1,
         # Its own process group, so a SIGINT aimed at the app cannot reach the
-        # test runner that spawned it.
+        # test runner that spawned it — and so the group can be checked for
+        # survivors after it exits.
         start_new_session=True,
     )
 
@@ -126,6 +135,19 @@ def run_scenario_to_completion(scenario: str, *, starts_engine: bool = True) -> 
     return await_clean_exit(process, already_read)
 
 
+def run_scenario_interrupted_once_running(scenario: str) -> AppUnderTest:
+    """Boot the scenario, wait for the engine's ready line, then Ctrl-C it.
+
+    Sequencing on the engine's own log rather than a sleep is what makes the
+    delivery point deterministic — a fixed delay races a cold boot, which the
+    60s ready budget exists precisely because it can take.
+    """
+    process = start_app(scenario)
+    already_read = read_until_engine_ready(process)
+    process.send_signal(signal.SIGINT)
+    return await_clean_exit(process, already_read)
+
+
 @pytest.mark.requires_gpu
 def test_ctrl_c_exits_cleanly():
     """The demo: Ctrl-C on a running pipeline returns from `run()` and exits 0.
@@ -167,15 +189,24 @@ def test_ctrl_c_during_startup_still_exits_cleanly():
 
 
 @pytest.mark.requires_gpu
-def test_no_zombie_is_left_behind():
-    """A clean exit must also mean a reaped process, not a zombie."""
+def test_no_survivors_are_left_in_the_process_group():
+    """The app's whole process group must be gone, not just its leader.
+
+    `waitpid` cannot show this — `communicate()` has already reaped the child,
+    so it would raise `ChildProcessError` for any exited process whatsoever and
+    assert nothing. The engine spawns threads rather than children today, so
+    what this actually locks is that no *future* helper process (#1714 places
+    processors in children of this same interpreter) outlives the run.
+    """
     process = start_app("ctrl_c")
+    process_group = os.getpgid(process.pid)
     already_read = read_until_engine_ready(process)
     process.send_signal(signal.SIGINT)
     await_clean_exit(process, already_read)
 
-    with pytest.raises(ChildProcessError):
-        os.waitpid(process.pid, 0)
+    # Signal 0 delivers nothing; it only asks whether the group still exists.
+    with pytest.raises(ProcessLookupError):
+        os.killpg(process_group, 0)
 
 
 @pytest.mark.requires_gpu
@@ -185,7 +216,7 @@ def test_the_gil_is_released_while_run_blocks():
     Mental-revert: dropping the `python.detach` around the run loop pins the
     GIL for the whole run and leaves the counter at zero.
     """
-    app = run_scenario_to_completion("gil_released")
+    app = run_scenario_interrupted_once_running("gil_released")
 
     ticks = next(
         int(marker.removeprefix("PYTHON_THREAD_TICKS="))
@@ -205,7 +236,7 @@ def test_sigint_is_handed_back_to_cpython():
     Mental-revert: leaving the engine's handler installed swallows the second
     SIGINT and the app reports SIGINT_WAS_SWALLOWED instead.
     """
-    app = run_scenario_to_completion("sigint_handed_back")
+    app = run_scenario_interrupted_once_running("sigint_handed_back")
     assert "KEYBOARD_INTERRUPT_RAISED" in app.markers(), (
         f"SIGINT after run() must reach CPython's handler; output:\n{app.output}"
     )
@@ -220,11 +251,52 @@ def test_an_exception_still_tears_the_engine_down():
 
 
 def test_a_runtime_that_never_runs_does_not_hang_at_exit():
-    """The `atexit` half of the guarantee: a booted-but-unrun engine still
-    shuts down before the interpreter finalizes."""
+    """A booted-but-unrun engine shuts down without hanging the interpreter.
+
+    This is the `Drop` path: the scenario leaves the Runtime unbound, so it is
+    refcounted to zero on the spot. The at-exit case is the test below.
+    """
     app = run_scenario_to_completion("never_run", starts_engine=False)
     assert "CONSTRUCTED_WITHOUT_RUNNING" in app.markers(), (
         f"the scenario did not run; output:\n{app.output}"
+    )
+
+
+def test_a_runtime_still_referenced_at_exit_is_torn_down():
+    """A Runtime alive at interpreter exit must not hang finalization.
+
+    Distinct from the never-run case: there the result is unbound and `Drop`
+    fires immediately, so the reference is already gone by the time the
+    interpreter shuts down. Here a module global holds it, which is the case the
+    `atexit` hook in `streamlib/__init__.py` exists for.
+    """
+    app = run_scenario_to_completion("still_referenced_at_exit", starts_engine=False)
+    assert "STILL_REFERENCED_AT_EXIT" in app.markers(), (
+        f"the scenario did not run; output:\n{app.output}"
+    )
+
+
+@pytest.mark.requires_gpu
+def test_shutdown_from_another_thread_ends_a_blocking_run():
+    """`shutdown()` must end a running pipeline, from any thread.
+
+    The programmatic stop, with no signal involved. Two ways this regresses:
+    marking the pyclass `unsendable` makes the cross-thread call raise
+    `PanicException`, and letting `shutdown()` return early when `run()` owns
+    the engine makes it a silent no-op that never ends the run.
+    """
+    process = start_app("shutdown_from_another_thread")
+    already_read = read_until_engine_ready(process)
+
+    # Closing stdin is the readiness handshake the app waits on, so the
+    # shutdown request cannot land before the engine is up. Cleared afterwards
+    # because `communicate()` flushes `stdin` and would raise on a closed one.
+    process.stdin.close()
+    process.stdin = None
+
+    app = await_clean_exit(process, already_read)
+    assert "STOPPED_FROM_ANOTHER_THREAD" in app.markers(), (
+        f"shutdown() from a worker thread must end run(); output:\n{app.output}"
     )
 
 
@@ -232,7 +304,7 @@ def test_a_runtime_that_never_runs_does_not_hang_at_exit():
 def test_a_second_run_is_refused():
     """`run()` drops the engine to keep its teardown promise, so the handle is
     single-use and says so."""
-    app = run_scenario_to_completion("second_run_refused")
+    app = run_scenario_interrupted_once_running("second_run_refused")
     assert "SECOND_RUN_REFUSED" in app.markers(), (
         f"a second run() must raise rather than silently do nothing; output:\n{app.output}"
     )

--- a/sdk/streamlib-python-wheel/tests/test_interpreter_lifecycle.py
+++ b/sdk/streamlib-python-wheel/tests/test_interpreter_lifecycle.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""The interpreter-lifecycle contract, proven against a real `python app.py`.
+
+The arrangement under test is the wheel's: CPython starts, imports the engine,
+and drives it in-process. Every assertion here is made from outside that
+process, because the failures being ruled out — a zombie, a hang at
+interpreter finalization, a non-zero exit — are only visible to a parent.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+APP_UNDER_TEST = Path(__file__).parent / "interpreter_lifecycle_app.py"
+
+# Generous: a cold engine boot stands up an iceoryx2 node, a surface-sharing
+# socket, and a GPU context. A real hang blows through it anyway.
+ENGINE_READY_TIMEOUT_SECONDS = 60.0
+CLEAN_EXIT_TIMEOUT_SECONDS = 60.0
+
+ENGINE_READY_LOG_LINE = "[start] Runtime started"
+# Emitted early inside `start()` — after the run loop has taken shutdown-signal
+# ownership, but well before the graph is up.
+ENGINE_STARTING_LOG_LINE = "[start] Initializing GPU context"
+
+
+class AppUnderTest:
+    """A running `python app.py`, with its stdout captured line by line."""
+
+    def __init__(self, process: subprocess.Popen, output_lines: list[str]):
+        self.process = process
+        self.output_lines = output_lines
+
+    @property
+    def output(self) -> str:
+        return "".join(self.output_lines)
+
+    def markers(self) -> set[str]:
+        return {
+            line.strip().removeprefix("MARKER:")
+            for line in self.output_lines
+            if line.startswith("MARKER:")
+        }
+
+
+def start_app(scenario: str) -> subprocess.Popen:
+    return subprocess.Popen(
+        [sys.executable, str(APP_UNDER_TEST), scenario],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        # Its own process group, so a SIGINT aimed at the app cannot reach the
+        # test runner that spawned it.
+        start_new_session=True,
+    )
+
+
+def read_until_log_line(process: subprocess.Popen, awaited_line: str) -> list[str]:
+    """Collect output until the engine logs `awaited_line`.
+
+    Waiting for the engine's own log line rather than sleeping pins exactly
+    which point of the lifecycle a signal is delivered at.
+    """
+    collected: list[str] = []
+    deadline = time.monotonic() + ENGINE_READY_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        line = process.stdout.readline()
+        if not line:
+            raise AssertionError(
+                f"the app exited before logging {awaited_line!r}; "
+                f"output:\n{''.join(collected)}"
+            )
+        collected.append(line)
+        if awaited_line in line:
+            return collected
+    raise AssertionError(
+        f"the engine never logged {awaited_line!r} within {ENGINE_READY_TIMEOUT_SECONDS}s; "
+        f"output:\n{''.join(collected)}"
+    )
+
+
+def read_until_engine_ready(process: subprocess.Popen) -> list[str]:
+    return read_until_log_line(process, ENGINE_READY_LOG_LINE)
+
+
+def await_clean_exit(process: subprocess.Popen, already_read: list[str]) -> AppUnderTest:
+    """Drain the app's remaining output and require a clean, timely exit."""
+    try:
+        remaining_output, _ = process.communicate(timeout=CLEAN_EXIT_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        remaining_output, _ = process.communicate()
+        raise AssertionError(
+            f"the app did not exit within {CLEAN_EXIT_TIMEOUT_SECONDS}s — engine teardown "
+            f"hung, or the interpreter hung at finalization; output:\n"
+            f"{''.join(already_read)}{remaining_output}"
+        )
+
+    app = AppUnderTest(process, already_read + remaining_output.splitlines(keepends=True))
+    assert process.returncode == 0, (
+        f"expected a clean exit, got returncode {process.returncode}; output:\n{app.output}"
+    )
+    assert "CLEAN_EXIT" in app.markers(), (
+        f"the app did not reach the end of its scenario; output:\n{app.output}"
+    )
+    return app
+
+
+def run_scenario_to_completion(scenario: str, *, starts_engine: bool = True) -> AppUnderTest:
+    """Run a scenario that ends on its own.
+
+    `starts_engine=False` for scenarios that construct a Runtime but never call
+    `run()` — there is no ready line to wait for, and waiting would just read to
+    EOF.
+    """
+    process = start_app(scenario)
+    already_read = read_until_engine_ready(process) if starts_engine else []
+    return await_clean_exit(process, already_read)
+
+
+@pytest.mark.requires_gpu
+def test_ctrl_c_exits_cleanly():
+    """The demo: Ctrl-C on a running pipeline returns from `run()` and exits 0.
+
+    This is the arrangement the #1702 spike never ran — there, Rust embedded
+    CPython; here CPython imports the engine.
+    """
+    process = start_app("ctrl_c")
+    already_read = read_until_engine_ready(process)
+
+    process.send_signal(signal.SIGINT)
+
+    app = await_clean_exit(process, already_read)
+    assert "RUN_RETURNED" in app.markers(), (
+        f"run() must return on Ctrl-C rather than raising; output:\n{app.output}"
+    )
+
+
+@pytest.mark.requires_gpu
+def test_ctrl_c_during_startup_still_exits_cleanly():
+    """Ctrl-C while the graph is still coming up must still exit cleanly.
+
+    Regression lock on a real hang: signal ownership used to begin inside the
+    wait loop, so a SIGINT during `start()` landed on CPython's handler. With
+    the GIL released for the whole of `run()`, the flag CPython sets can never
+    be turned into a `KeyboardInterrupt` — the app blocked forever rather than
+    shutting down. Mental-revert: moving ownership back inside the wait loop
+    (`start()` then `wait_for_signal()`) hangs here until the timeout.
+    """
+    process = start_app("ctrl_c")
+    already_read = read_until_log_line(process, ENGINE_STARTING_LOG_LINE)
+
+    process.send_signal(signal.SIGINT)
+
+    app = await_clean_exit(process, already_read)
+    assert "RUN_RETURNED" in app.markers(), (
+        f"run() must return on a Ctrl-C taken during startup; output:\n{app.output}"
+    )
+
+
+@pytest.mark.requires_gpu
+def test_no_zombie_is_left_behind():
+    """A clean exit must also mean a reaped process, not a zombie."""
+    process = start_app("ctrl_c")
+    already_read = read_until_engine_ready(process)
+    process.send_signal(signal.SIGINT)
+    await_clean_exit(process, already_read)
+
+    with pytest.raises(ChildProcessError):
+        os.waitpid(process.pid, 0)
+
+
+@pytest.mark.requires_gpu
+def test_the_gil_is_released_while_run_blocks():
+    """A Python thread must keep running while `run()` blocks.
+
+    Mental-revert: dropping the `python.detach` around the run loop pins the
+    GIL for the whole run and leaves the counter at zero.
+    """
+    app = run_scenario_to_completion("gil_released")
+
+    ticks = next(
+        int(marker.removeprefix("PYTHON_THREAD_TICKS="))
+        for marker in app.markers()
+        if marker.startswith("PYTHON_THREAD_TICKS=")
+    )
+    assert ticks > 0, (
+        f"a Python thread made no progress while run() blocked — the GIL was held; "
+        f"output:\n{app.output}"
+    )
+
+
+@pytest.mark.requires_gpu
+def test_sigint_is_handed_back_to_cpython():
+    """After `run()` returns, Ctrl-C must raise KeyboardInterrupt again.
+
+    Mental-revert: leaving the engine's handler installed swallows the second
+    SIGINT and the app reports SIGINT_WAS_SWALLOWED instead.
+    """
+    app = run_scenario_to_completion("sigint_handed_back")
+    assert "KEYBOARD_INTERRUPT_RAISED" in app.markers(), (
+        f"SIGINT after run() must reach CPython's handler; output:\n{app.output}"
+    )
+
+
+def test_an_exception_still_tears_the_engine_down():
+    """The exception path keeps the teardown guarantee and re-raises."""
+    app = run_scenario_to_completion("exception_in_context_manager", starts_engine=False)
+    assert "EXCEPTION_PROPAGATED" in app.markers(), (
+        f"__exit__ must not suppress the exception; output:\n{app.output}"
+    )
+
+
+def test_a_runtime_that_never_runs_does_not_hang_at_exit():
+    """The `atexit` half of the guarantee: a booted-but-unrun engine still
+    shuts down before the interpreter finalizes."""
+    app = run_scenario_to_completion("never_run", starts_engine=False)
+    assert "CONSTRUCTED_WITHOUT_RUNNING" in app.markers(), (
+        f"the scenario did not run; output:\n{app.output}"
+    )
+
+
+@pytest.mark.requires_gpu
+def test_a_second_run_is_refused():
+    """`run()` drops the engine to keep its teardown promise, so the handle is
+    single-use and says so."""
+    app = run_scenario_to_completion("second_run_refused")
+    assert "SECOND_RUN_REFUSED" in app.markers(), (
+        f"a second run() must raise rather than silently do nothing; output:\n{app.output}"
+    )

--- a/sdk/streamlib-python-wheel/tests/test_interpreter_lifecycle.py
+++ b/sdk/streamlib-python-wheel/tests/test_interpreter_lifecycle.py
@@ -5,14 +5,16 @@
 
 The arrangement under test is the wheel's: CPython starts, imports the engine,
 and drives it in-process. Every assertion here is made from outside that
-process, because the failures being ruled out — a zombie, a hang at
+process, because the failures being ruled out — a surviving process, a hang at
 interpreter finalization, a non-zero exit — are only visible to a parent.
 """
 
 import os
+import queue
 import signal
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -31,18 +33,76 @@ ENGINE_READY_LOG_LINE = "[start] Runtime started"
 # Emitted early inside `start()` — after the run loop has taken shutdown-signal
 # ownership, but well before the graph is up.
 ENGINE_STARTING_LOG_LINE = "[start] Initializing GPU context"
+ENGINE_STOPPED_LOG_LINE = "[stop] Graceful shutdown complete"
 
 
 class AppUnderTest:
-    """A running `python app.py`, with its stdout captured line by line."""
+    """A running `python app.py`, with its output pumped off the pipe.
 
-    def __init__(self, process: subprocess.Popen, output_lines: list[str]):
+    Every wait here is bounded. A plain `readline()` blocks indefinitely when
+    the app goes quiet, which makes a deadline checked between lines useless —
+    that is how a hung app turns into a hung test run rather than a failure with
+    a diagnostic.
+    """
+
+    def __init__(self, process: subprocess.Popen):
         self.process = process
-        self.output_lines = output_lines
+        self.output_lines: list[str] = []
+        self._incoming: queue.Queue[str | None] = queue.Queue()
+        self._reached_end_of_output = False
+        threading.Thread(target=self._pump_output, daemon=True).start()
+
+    def _pump_output(self) -> None:
+        for line in self.process.stdout:
+            self._incoming.put(line)
+        self._incoming.put(None)
 
     @property
     def output(self) -> str:
         return "".join(self.output_lines)
+
+    def _next_line(self, deadline: float) -> str | None:
+        """The next line, or None at end of output. Raises past the deadline."""
+        while True:
+            if self._reached_end_of_output:
+                return None
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError
+            try:
+                line = self._incoming.get(timeout=min(0.5, remaining))
+            except queue.Empty:
+                continue
+            if line is None:
+                self._reached_end_of_output = True
+                return None
+            self.output_lines.append(line)
+            return line
+
+    def await_output_containing(self, awaited: str, what: str) -> None:
+        """Wait for a line containing `awaited`.
+
+        Sequencing on the app's or engine's own output rather than a sleep is
+        what pins the point of the lifecycle a signal is delivered at.
+        """
+        deadline = time.monotonic() + ENGINE_READY_TIMEOUT_SECONDS
+        while True:
+            try:
+                line = self._next_line(deadline)
+            except TimeoutError:
+                raise AssertionError(
+                    f"timed out waiting for {what}; output:\n{self.output}"
+                ) from None
+            if line is None:
+                raise AssertionError(f"the app exited before {what}; output:\n{self.output}")
+            if awaited in line:
+                return
+
+    def await_engine_ready(self) -> None:
+        self.await_output_containing(ENGINE_READY_LOG_LINE, "the engine to start")
+
+    def await_marker(self, marker: str) -> None:
+        self.await_output_containing(f"{MARKER_PREFIX}{marker}", f"marker {marker}")
 
     def markers(self) -> set[str]:
         # Matched anywhere in the line, not just at its start: while the engine
@@ -56,9 +116,34 @@ class AppUnderTest:
                 found.add(line[marker_start + len(MARKER_PREFIX) :].strip())
         return found
 
+    def interrupt(self) -> None:
+        self.process.send_signal(signal.SIGINT)
 
-def start_app(scenario: str) -> subprocess.Popen:
-    return subprocess.Popen(
+    def await_clean_exit(self) -> "AppUnderTest":
+        """Drain the remaining output and require a clean, timely exit."""
+        deadline = time.monotonic() + CLEAN_EXIT_TIMEOUT_SECONDS
+        try:
+            while self._next_line(deadline) is not None:
+                pass
+        except TimeoutError:
+            self.process.kill()
+            raise AssertionError(
+                f"the app did not exit within {CLEAN_EXIT_TIMEOUT_SECONDS}s — engine teardown "
+                f"hung, or the interpreter hung at finalization; output:\n{self.output}"
+            ) from None
+
+        returncode = self.process.wait(timeout=max(0.0, deadline - time.monotonic()))
+        assert returncode == 0, (
+            f"expected a clean exit, got returncode {returncode}; output:\n{self.output}"
+        )
+        assert "CLEAN_EXIT" in self.markers(), (
+            f"the app did not reach the end of its scenario; output:\n{self.output}"
+        )
+        return self
+
+
+def start_app(scenario: str) -> AppUnderTest:
+    process = subprocess.Popen(
         [sys.executable, str(APP_UNDER_TEST), scenario],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
@@ -70,82 +155,20 @@ def start_app(scenario: str) -> subprocess.Popen:
         # survivors after it exits.
         start_new_session=True,
     )
+    return AppUnderTest(process)
 
 
-def read_until_log_line(process: subprocess.Popen, awaited_line: str) -> list[str]:
-    """Collect output until the engine logs `awaited_line`.
-
-    Waiting for the engine's own log line rather than sleeping pins exactly
-    which point of the lifecycle a signal is delivered at.
-    """
-    collected: list[str] = []
-    deadline = time.monotonic() + ENGINE_READY_TIMEOUT_SECONDS
-    while time.monotonic() < deadline:
-        line = process.stdout.readline()
-        if not line:
-            raise AssertionError(
-                f"the app exited before logging {awaited_line!r}; "
-                f"output:\n{''.join(collected)}"
-            )
-        collected.append(line)
-        if awaited_line in line:
-            return collected
-    raise AssertionError(
-        f"the engine never logged {awaited_line!r} within {ENGINE_READY_TIMEOUT_SECONDS}s; "
-        f"output:\n{''.join(collected)}"
-    )
-
-
-def read_until_engine_ready(process: subprocess.Popen) -> list[str]:
-    return read_until_log_line(process, ENGINE_READY_LOG_LINE)
-
-
-def await_clean_exit(process: subprocess.Popen, already_read: list[str]) -> AppUnderTest:
-    """Drain the app's remaining output and require a clean, timely exit."""
-    try:
-        remaining_output, _ = process.communicate(timeout=CLEAN_EXIT_TIMEOUT_SECONDS)
-    except subprocess.TimeoutExpired:
-        process.kill()
-        remaining_output, _ = process.communicate()
-        raise AssertionError(
-            f"the app did not exit within {CLEAN_EXIT_TIMEOUT_SECONDS}s — engine teardown "
-            f"hung, or the interpreter hung at finalization; output:\n"
-            f"{''.join(already_read)}{remaining_output}"
-        )
-
-    app = AppUnderTest(process, already_read + remaining_output.splitlines(keepends=True))
-    assert process.returncode == 0, (
-        f"expected a clean exit, got returncode {process.returncode}; output:\n{app.output}"
-    )
-    assert "CLEAN_EXIT" in app.markers(), (
-        f"the app did not reach the end of its scenario; output:\n{app.output}"
-    )
-    return app
-
-
-def run_scenario_to_completion(scenario: str, *, starts_engine: bool = True) -> AppUnderTest:
-    """Run a scenario that ends on its own.
-
-    `starts_engine=False` for scenarios that construct a Runtime but never call
-    `run()` — there is no ready line to wait for, and waiting would just read to
-    EOF.
-    """
-    process = start_app(scenario)
-    already_read = read_until_engine_ready(process) if starts_engine else []
-    return await_clean_exit(process, already_read)
+def run_scenario_to_completion(scenario: str) -> AppUnderTest:
+    """Run a scenario that ends on its own."""
+    return start_app(scenario).await_clean_exit()
 
 
 def run_scenario_interrupted_once_running(scenario: str) -> AppUnderTest:
-    """Boot the scenario, wait for the engine's ready line, then Ctrl-C it.
-
-    Sequencing on the engine's own log rather than a sleep is what makes the
-    delivery point deterministic — a fixed delay races a cold boot, which the
-    60s ready budget exists precisely because it can take.
-    """
-    process = start_app(scenario)
-    already_read = read_until_engine_ready(process)
-    process.send_signal(signal.SIGINT)
-    return await_clean_exit(process, already_read)
+    """Boot the scenario, wait for the engine's ready line, then Ctrl-C it."""
+    app = start_app(scenario)
+    app.await_engine_ready()
+    app.interrupt()
+    return app.await_clean_exit()
 
 
 @pytest.mark.requires_gpu
@@ -155,12 +178,7 @@ def test_ctrl_c_exits_cleanly():
     This is the arrangement the #1702 spike never ran — there, Rust embedded
     CPython; here CPython imports the engine.
     """
-    process = start_app("ctrl_c")
-    already_read = read_until_engine_ready(process)
-
-    process.send_signal(signal.SIGINT)
-
-    app = await_clean_exit(process, already_read)
+    app = run_scenario_interrupted_once_running("ctrl_c")
     assert "RUN_RETURNED" in app.markers(), (
         f"run() must return on Ctrl-C rather than raising; output:\n{app.output}"
     )
@@ -177,12 +195,11 @@ def test_ctrl_c_during_startup_still_exits_cleanly():
     shutting down. Mental-revert: moving ownership back inside the wait loop
     (`start()` then `wait_for_signal()`) hangs here until the timeout.
     """
-    process = start_app("ctrl_c")
-    already_read = read_until_log_line(process, ENGINE_STARTING_LOG_LINE)
+    app = start_app("ctrl_c")
+    app.await_output_containing(ENGINE_STARTING_LOG_LINE, "the engine to begin starting")
+    app.interrupt()
 
-    process.send_signal(signal.SIGINT)
-
-    app = await_clean_exit(process, already_read)
+    app.await_clean_exit()
     assert "RUN_RETURNED" in app.markers(), (
         f"run() must return on a Ctrl-C taken during startup; output:\n{app.output}"
     )
@@ -192,17 +209,16 @@ def test_ctrl_c_during_startup_still_exits_cleanly():
 def test_no_survivors_are_left_in_the_process_group():
     """The app's whole process group must be gone, not just its leader.
 
-    `waitpid` cannot show this — `communicate()` has already reaped the child,
-    so it would raise `ChildProcessError` for any exited process whatsoever and
-    assert nothing. The engine spawns threads rather than children today, so
-    what this actually locks is that no *future* helper process (#1714 places
-    processors in children of this same interpreter) outlives the run.
+    A `waitpid` check cannot show this — the parent has already reaped the
+    child, so it raises `ChildProcessError` for any exited process whatsoever.
+    The engine spawns threads rather than children today, so this is a forward
+    lock for #1714, which places processors in child interpreters.
     """
-    process = start_app("ctrl_c")
-    process_group = os.getpgid(process.pid)
-    already_read = read_until_engine_ready(process)
-    process.send_signal(signal.SIGINT)
-    await_clean_exit(process, already_read)
+    app = start_app("ctrl_c")
+    process_group = os.getpgid(app.process.pid)
+    app.await_engine_ready()
+    app.interrupt()
+    app.await_clean_exit()
 
     # Signal 0 delivers nothing; it only asks whether the group still exists.
     with pytest.raises(ProcessLookupError):
@@ -244,7 +260,7 @@ def test_sigint_is_handed_back_to_cpython():
 
 def test_an_exception_still_tears_the_engine_down():
     """The exception path keeps the teardown guarantee and re-raises."""
-    app = run_scenario_to_completion("exception_in_context_manager", starts_engine=False)
+    app = run_scenario_to_completion("exception_in_context_manager")
     assert "EXCEPTION_PROPAGATED" in app.markers(), (
         f"__exit__ must not suppress the exception; output:\n{app.output}"
     )
@@ -256,23 +272,95 @@ def test_a_runtime_that_never_runs_does_not_hang_at_exit():
     This is the `Drop` path: the scenario leaves the Runtime unbound, so it is
     refcounted to zero on the spot. The at-exit case is the test below.
     """
-    app = run_scenario_to_completion("never_run", starts_engine=False)
+    app = run_scenario_to_completion("never_run")
     assert "CONSTRUCTED_WITHOUT_RUNNING" in app.markers(), (
         f"the scenario did not run; output:\n{app.output}"
     )
 
 
-def test_a_runtime_still_referenced_at_exit_is_torn_down():
-    """A Runtime alive at interpreter exit must not hang finalization.
+def test_a_runtime_held_by_a_live_thread_is_torn_down_at_exit():
+    """The `atexit` hook's lock: a Runtime CPython will never collect.
 
-    Distinct from the never-run case: there the result is unbound and `Drop`
-    fires immediately, so the reference is already gone by the time the
-    interpreter shuts down. Here a module global holds it, which is the case the
-    `atexit` hook in `streamlib/__init__.py` exists for.
+    The reference lives in a parked daemon thread's frame, which interpreter
+    shutdown does not unwind — so unlike the never-run case, `Drop` never fires
+    on its own. Asserting the engine's own teardown line rather than a scenario
+    marker is what makes this a lock: a clean exit code alone is also what you
+    get when no teardown runs at all.
+
+    Mental-revert: removing `@atexit.register` from `streamlib/__init__.py`
+    leaves the shutdown line absent entirely.
     """
-    app = run_scenario_to_completion("still_referenced_at_exit", starts_engine=False)
-    assert "STILL_REFERENCED_AT_EXIT" in app.markers(), (
+    app = run_scenario_to_completion("held_by_a_live_thread_at_exit")
+    assert "HELD_BY_LIVE_THREAD_AT_EXIT" in app.markers(), (
         f"the scenario did not run; output:\n{app.output}"
+    )
+    assert ENGINE_STOPPED_LOG_LINE in app.output, (
+        f"the engine was never torn down — its threads outlived interpreter "
+        f"finalization; output:\n{app.output}"
+    )
+
+
+@pytest.mark.requires_gpu
+def test_a_second_pipeline_in_one_process_still_blocks():
+    """Two run loops in one interpreter: the second must not inherit the first's
+    shutdown request.
+
+    Regression lock on a real defect. The shutdown-request latch is
+    process-global and first-observer-wins, so a `shutdown()` issued once the
+    engine was already torn down — which `__exit__` does on every
+    `with streamlib.Runtime()` block — left it set, and the next `run()`
+    returned immediately having run nothing.
+
+    The second run is timed by the app against a monotonic clock rather than
+    waited on via the engine's log, because the engine only initializes its
+    logging pathway once per process: a second `Runner` in the same process
+    emits nothing at all.
+
+    Mental-revert: dropping the `run_loop_is_blocking` guard in `shutdown()`
+    makes the second run return in milliseconds and fails the threshold below.
+    """
+    app = start_app("two_pipelines_in_one_process")
+
+    app.await_engine_ready()
+    app.interrupt()
+    app.await_marker("PIPELINE_1_RETURNED")
+
+    # The second engine is silent, so the app announces its own readiness.
+    app.await_marker("PIPELINE_2_RUNNING")
+    # Held open deliberately: `run()` also spends time in `start()`, so only a
+    # span longer than a boot distinguishes "blocked until interrupted" from
+    # "returned on a stale request as soon as the graph was up".
+    time.sleep(SECOND_PIPELINE_OBSERVATION_WINDOW_SECONDS)
+    app.interrupt()
+
+    app.await_clean_exit()
+
+    blocked_milliseconds = next(
+        int(marker.removeprefix("PIPELINE_2_BLOCKED_MS="))
+        for marker in app.markers()
+        if marker.startswith("PIPELINE_2_BLOCKED_MS=")
+    )
+    assert blocked_milliseconds >= SECOND_PIPELINE_MINIMUM_BLOCKED_MILLISECONDS, (
+        f"the second run loop returned after only {blocked_milliseconds}ms — it inherited "
+        f"the first pipeline's shutdown request instead of blocking; output:\n{app.output}"
+    )
+
+
+# How long the second pipeline is left running before it is interrupted, and
+# the floor its measured span must clear. The floor sits well above a cold
+# engine boot so a run that returned on a stale shutdown request cannot reach
+# it, and well below the window so ordinary scheduling jitter cannot fail it.
+SECOND_PIPELINE_OBSERVATION_WINDOW_SECONDS = 3.0
+SECOND_PIPELINE_MINIMUM_BLOCKED_MILLISECONDS = 2000
+
+
+@pytest.mark.requires_gpu
+def test_a_second_run_is_refused():
+    """`run()` drops the engine to keep its teardown promise, so the handle is
+    single-use and says so."""
+    app = run_scenario_interrupted_once_running("second_run_refused")
+    assert "SECOND_RUN_REFUSED" in app.markers(), (
+        f"a second run() must raise rather than silently do nothing; output:\n{app.output}"
     )
 
 
@@ -285,26 +373,14 @@ def test_shutdown_from_another_thread_ends_a_blocking_run():
     `PanicException`, and letting `shutdown()` return early when `run()` owns
     the engine makes it a silent no-op that never ends the run.
     """
-    process = start_app("shutdown_from_another_thread")
-    already_read = read_until_engine_ready(process)
+    app = start_app("shutdown_from_another_thread")
+    app.await_engine_ready()
 
     # Closing stdin is the readiness handshake the app waits on, so the
-    # shutdown request cannot land before the engine is up. Cleared afterwards
-    # because `communicate()` flushes `stdin` and would raise on a closed one.
-    process.stdin.close()
-    process.stdin = None
+    # shutdown request cannot land before the engine is up.
+    app.process.stdin.close()
 
-    app = await_clean_exit(process, already_read)
+    app.await_clean_exit()
     assert "STOPPED_FROM_ANOTHER_THREAD" in app.markers(), (
         f"shutdown() from a worker thread must end run(); output:\n{app.output}"
-    )
-
-
-@pytest.mark.requires_gpu
-def test_a_second_run_is_refused():
-    """`run()` drops the engine to keep its teardown promise, so the handle is
-    single-use and says so."""
-    app = run_scenario_interrupted_once_running("second_run_refused")
-    assert "SECOND_RUN_REFUSED" in app.markers(), (
-        f"a second run() must raise rather than silently do nothing; output:\n{app.output}"
     )

--- a/sdk/streamlib-sdk/src/sdk/app.rs
+++ b/sdk/streamlib-sdk/src/sdk/app.rs
@@ -104,11 +104,9 @@ impl App {
     }
 
     /// Start the graph, then block until a shutdown signal
-    /// ([`Runner::start`](crate::sdk::runtime::Runner) +
-    /// [`wait_for_signal`](crate::sdk::runtime::Runner)).
+    /// ([`Runner::start_and_wait_for_shutdown`](crate::sdk::runtime::Runner)).
     pub fn run(&self) -> Result<()> {
-        self.runner.start()?;
-        self.runner.wait_for_signal()
+        self.runner.start_and_wait_for_shutdown()
     }
 
     /// The underlying [`Runner`] — the escape

--- a/tools/streamlib-cli/src/commands/run.rs
+++ b/tools/streamlib-cli/src/commands/run.rs
@@ -148,11 +148,10 @@ pub fn launch_app_node(verb: AppLaunchVerb, args: AppLaunchCommandArgs) -> Resul
         },
     )?;
 
-    runtime.start()?;
     tracing::info!(
-        "Node ready with an empty graph — `streamlib nodes` lists it. Press Ctrl+C to stop."
+        "Starting node with an empty graph — `streamlib nodes` lists it. Press Ctrl+C to stop."
     );
-    runtime.wait_for_signal()?;
+    runtime.start_and_wait_for_shutdown()?;
 
     Ok(())
 }

--- a/xtask/src/lint_logging.rs
+++ b/xtask/src/lint_logging.rs
@@ -28,41 +28,32 @@ pub struct LintTarget {
     pub allow_substring: &'static str,
 }
 
+/// One policy, applied to every Python root the engine tree owns. A second
+/// literal would let the wheel's package silently lint less than the SDK's the
+/// first time the ban list or the exclusions change.
+const fn python_logging_lint_target(name: &'static str, root_relative: &'static str) -> LintTarget {
+    LintTarget {
+        name,
+        root_relative,
+        extension: "py",
+        exclude_path_segments: &[
+            "tests",
+            "_generated_",
+            "__pycache__",
+            ".venv",
+            "build",
+            "dist",
+        ],
+        exclude_file_suffixes: &["_test.py"],
+        comment_prefix: "#",
+        banned_substrings: &["print(", "sys.stdout", "sys.stderr", "logging.basicConfig"],
+        allow_substring: "streamlib.log.",
+    }
+}
+
 pub const TARGETS: &[LintTarget] = &[
-    LintTarget {
-        name: "python",
-        root_relative: "sdk/streamlib-python",
-        extension: "py",
-        exclude_path_segments: &[
-            "tests",
-            "_generated_",
-            "__pycache__",
-            ".venv",
-            "build",
-            "dist",
-        ],
-        exclude_file_suffixes: &["_test.py"],
-        comment_prefix: "#",
-        banned_substrings: &["print(", "sys.stdout", "sys.stderr", "logging.basicConfig"],
-        allow_substring: "streamlib.log.",
-    },
-    LintTarget {
-        name: "python-wheel",
-        root_relative: "sdk/streamlib-python-wheel/python",
-        extension: "py",
-        exclude_path_segments: &[
-            "tests",
-            "_generated_",
-            "__pycache__",
-            ".venv",
-            "build",
-            "dist",
-        ],
-        exclude_file_suffixes: &["_test.py"],
-        comment_prefix: "#",
-        banned_substrings: &["print(", "sys.stdout", "sys.stderr", "logging.basicConfig"],
-        allow_substring: "streamlib.log.",
-    },
+    python_logging_lint_target("python", "sdk/streamlib-python"),
+    python_logging_lint_target("python-wheel", "sdk/streamlib-python-wheel/python"),
     LintTarget {
         name: "typescript",
         root_relative: "sdk/streamlib-deno",
@@ -984,12 +975,22 @@ mod tests {
         violations
     }
 
-    const PYTHON_TARGET: &LintTarget = &TARGETS[0];
-    const TYPESCRIPT_TARGET: &LintTarget = &TARGETS[1];
+    /// Resolved by name, not position: `TARGETS` gains entries over time, and
+    /// an index would silently retarget every assertion below when it does.
+    fn lint_target_named(name: &str) -> &'static LintTarget {
+        TARGETS
+            .iter()
+            .find(|target| target.name == name)
+            .unwrap_or_else(|| panic!("no lint target named {name}"))
+    }
 
     #[test]
     fn rejects_print_in_python_library() {
-        let v = scan_fixture_tree(PYTHON_TARGET, "print(\"hello\")\n", "src/app.py");
+        let v = scan_fixture_tree(
+            lint_target_named("python"),
+            "print(\"hello\")\n",
+            "src/app.py",
+        );
         assert_eq!(v.len(), 1);
         assert_eq!(v[0].matched_pattern, "print(");
     }
@@ -997,7 +998,7 @@ mod tests {
     #[test]
     fn rejects_sys_stdout_in_python() {
         let v = scan_fixture_tree(
-            PYTHON_TARGET,
+            lint_target_named("python"),
             "import sys\nsys.stdout.write(\"hi\")\n",
             "src/app.py",
         );
@@ -1008,7 +1009,7 @@ mod tests {
     #[test]
     fn rejects_logging_basicconfig_in_python() {
         let v = scan_fixture_tree(
-            PYTHON_TARGET,
+            lint_target_named("python"),
             "import logging\nlogging.basicConfig(level=logging.INFO)\n",
             "src/app.py",
         );
@@ -1018,7 +1019,11 @@ mod tests {
 
     #[test]
     fn rejects_console_log_in_ts_library() {
-        let v = scan_fixture_tree(TYPESCRIPT_TARGET, "console.log(\"hello\");\n", "src/app.ts");
+        let v = scan_fixture_tree(
+            lint_target_named("typescript"),
+            "console.log(\"hello\");\n",
+            "src/app.ts",
+        );
         assert_eq!(v.len(), 1);
         assert_eq!(v[0].matched_pattern, "console.log");
     }
@@ -1026,7 +1031,7 @@ mod tests {
     #[test]
     fn rejects_deno_stdout_write_in_ts() {
         let v = scan_fixture_tree(
-            TYPESCRIPT_TARGET,
+            lint_target_named("typescript"),
             "await Deno.stdout.write(new TextEncoder().encode(\"x\"));\n",
             "src/app.ts",
         );
@@ -1038,7 +1043,7 @@ mod tests {
     fn rejects_every_console_method_variant() {
         for method in ["log", "warn", "error", "info", "debug"] {
             let src = format!("console.{}(\"x\");\n", method);
-            let v = scan_fixture_tree(TYPESCRIPT_TARGET, &src, "src/app.ts");
+            let v = scan_fixture_tree(lint_target_named("typescript"), &src, "src/app.ts");
             assert_eq!(v.len(), 1, "console.{} should be rejected", method);
         }
     }
@@ -1046,7 +1051,7 @@ mod tests {
     #[test]
     fn accepts_streamlib_log_python() {
         let v = scan_fixture_tree(
-            PYTHON_TARGET,
+            lint_target_named("python"),
             "import streamlib\nstreamlib.log.info(\"hi\")\n",
             "src/app.py",
         );
@@ -1056,7 +1061,7 @@ mod tests {
     #[test]
     fn accepts_streamlib_log_ts() {
         let v = scan_fixture_tree(
-            TYPESCRIPT_TARGET,
+            lint_target_named("typescript"),
             "import * as streamlib from \"./mod.ts\";\nstreamlib.log.info(\"hi\");\n",
             "src/app.ts",
         );
@@ -1066,7 +1071,7 @@ mod tests {
     #[test]
     fn skips_comment_lines_python() {
         let v = scan_fixture_tree(
-            PYTHON_TARGET,
+            lint_target_named("python"),
             "# don't use print(\"x\") here\nstreamlib.log.info(\"ok\")\n",
             "src/app.py",
         );
@@ -1076,7 +1081,7 @@ mod tests {
     #[test]
     fn skips_comment_lines_ts() {
         let v = scan_fixture_tree(
-            TYPESCRIPT_TARGET,
+            lint_target_named("typescript"),
             "// don't use console.log here\nstreamlib.log.info(\"ok\");\n",
             "src/app.ts",
         );
@@ -1095,7 +1100,13 @@ mod tests {
         write_fixture(&root, "src/app.py", "streamlib.log.info(\"ok\")\n");
         let mut violations = Vec::new();
         let mut files_scanned = 0usize;
-        scan_target(&root, PYTHON_TARGET, &mut violations, &mut files_scanned).unwrap();
+        scan_target(
+            &root,
+            lint_target_named("python"),
+            &mut violations,
+            &mut files_scanned,
+        )
+        .unwrap();
         assert!(
             violations.is_empty(),
             "tests/ should be excluded: {:?}",
@@ -1106,7 +1117,7 @@ mod tests {
     #[test]
     fn allow_file_pragma_skips_entire_file_python() {
         let v = scan_fixture_tree(
-            PYTHON_TARGET,
+            lint_target_named("python"),
             "# streamlib:lint-logging:allow-file — this is the interceptor installer itself\nimport sys\nsys.stdout = MyInterceptor()\n",
             "src/_log_interceptors.py",
         );
@@ -1120,7 +1131,7 @@ mod tests {
     #[test]
     fn allow_file_pragma_skips_entire_file_ts() {
         let v = scan_fixture_tree(
-            TYPESCRIPT_TARGET,
+            lint_target_named("typescript"),
             "// streamlib:lint-logging:allow-file — interceptor installer\nDeno.stdout.write(new Uint8Array());\n",
             "src/_log_interceptors.ts",
         );
@@ -1134,7 +1145,7 @@ mod tests {
     #[test]
     fn allow_line_pragma_skips_single_line_python() {
         let v = scan_fixture_tree(
-            PYTHON_TARGET,
+            lint_target_named("python"),
             "sys.stderr.write(\"fallback\")  # streamlib:lint-logging:allow-line\nprint(\"bad\")\n",
             "src/app.py",
         );
@@ -1152,7 +1163,7 @@ mod tests {
         let mut files_scanned = 0usize;
         scan_target(
             &root,
-            TYPESCRIPT_TARGET,
+            lint_target_named("typescript"),
             &mut violations,
             &mut files_scanned,
         )
@@ -1436,12 +1447,12 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
         write_fixture(
-            &root.join(TARGETS[0].root_relative),
+            &root.join(lint_target_named("python").root_relative),
             "streamlib/app.py",
             "streamlib.log.info(\"ok\")\n",
         );
         write_fixture(
-            &root.join(TARGETS[1].root_relative),
+            &root.join(lint_target_named("typescript").root_relative),
             "mod.ts",
             "streamlib.log.info(\"ok\");\n",
         );

--- a/xtask/src/lint_logging.rs
+++ b/xtask/src/lint_logging.rs
@@ -47,6 +47,23 @@ pub const TARGETS: &[LintTarget] = &[
         allow_substring: "streamlib.log.",
     },
     LintTarget {
+        name: "python-wheel",
+        root_relative: "sdk/streamlib-python-wheel/python",
+        extension: "py",
+        exclude_path_segments: &[
+            "tests",
+            "_generated_",
+            "__pycache__",
+            ".venv",
+            "build",
+            "dist",
+        ],
+        exclude_file_suffixes: &["_test.py"],
+        comment_prefix: "#",
+        banned_substrings: &["print(", "sys.stdout", "sys.stderr", "logging.basicConfig"],
+        allow_substring: "streamlib.log.",
+    },
+    LintTarget {
         name: "typescript",
         root_relative: "sdk/streamlib-deno",
         extension: "ts",


### PR DESCRIPTION
## Summary

The riskiest pivot assumption, retired: `python app.py` imports the engine, runs a pipeline in-process, and exits cleanly on Ctrl-C. The #1702 spike measured the *inverted* arrangement (a Rust binary embedding CPython); this is the wheel arrangement it never ran.

`sdk/streamlib-python-wheel` is a maturin abi3 project (`abi3-py310` — one wheel for CPython 3.10+) that CPython imports as `streamlib`. `Runtime()` boots the engine; `rt.run()` blocks with the GIL released, owns SIGINT while it does, and hands the disposition back before returning.

**Interpreter-lifecycle contract.** `run()` *drops* the engine rather than merely stopping it, so its threads are joined before the call returns — the handle is single-use because a still-shared one cannot promise that. `__exit__`, an `atexit` hook, and the pyclass `Drop` cover the paths where `run()` never returns normally.

**Two real bugs found and fixed, each with a regression lock that is red without the fix:**

- **Ctrl-C during startup hung the app forever.** Signal ownership began *inside* the wait loop, so a SIGINT during `start()` landed on CPython's handler — and with the GIL released for the whole of `run()`, the flag CPython sets can never become a `KeyboardInterrupt`. Reverting the fix hangs `test_ctrl_c_during_startup_still_exits_cleanly` to its 60s timeout.
- **`shutdown()` poisoned the next run loop.** The shutdown-request latch is process-global and first-observer-wins, so a request issued after teardown — which `__exit__` does on every `with streamlib.Runtime()` block — left it set for the next `run()`, which returned having run nothing. Reverting the guard makes the second pipeline return in ~350ms instead of blocking ≥2000ms.

**Engine changes** (one system extended, no parallel one): `install_signal_handlers` installed SIGINT/SIGTERM process-globally behind a one-shot latch and never restored them — so the wheel could not hand SIGINT back, and a *second* run loop in one process got no handlers at all. It is replaced by `ScopedShutdownSignalOwnership`, an RAII value held for the duration of a run loop. The mechanism is a self-pipe this module owns rather than signal-hook's `Signals`: `signal_hook_registry` installs its dispatcher once per signal and skips reinstallation, so restoring the previous disposition on drop desynchronizes the registry from the kernel and silently breaks Ctrl-C for the second run loop. `Runner::stop()` is now idempotent, and `Runner::start_and_wait_for_shutdown()` spans ownership across startup.

## Closes

Closes #1707

## Exit criteria

- [x] Maturin-built abi3 wheel, locally via `maturin develop` (release packaging is #1711)
- [x] `rt.run()` blocks with the GIL released; owns SIGINT; restores CPython's handler
- [x] Engine teardown strictly precedes interpreter finalization; threads joined; `atexit`/context-manager guarantee on the exception path
- [x] Headless CI harness running a real `python app.py` — **partially: see "CI coverage" below**
- [x] Demo: fresh uv venv → locally built wheel → `python app.py` → Ctrl-C exits clean

## Test plan

11 Python tests driving a real `python app.py` subprocess, plus 5 engine unit tests. All green on the rig (RTX 3090):

- Ctrl-C while running, and during startup (regression lock)
- GIL released while `run()` blocks — a Python thread's tick count across the call
- SIGINT handed back: a second Ctrl-C after `run()` raises `KeyboardInterrupt`
- Two pipelines in one process — the second must block on its own account (regression lock)
- `shutdown()` from a worker thread ends a blocking `run()`
- Exception inside the context manager still tears down and re-raises
- A Runtime held by a parked daemon thread's frame at exit is still torn down (the `atexit` hook's lock — asserts the engine's own teardown line, since "no teardown at all" also exits 0)
- No survivors left in the process group
- Second `run()` refused
- Engine: ownership restore, exclusivity, retake-still-catches-SIGINT, delivered-SIGINT-latches, stale-signal isolation

Gates: 27/27 via `local-ci-runner` (xtask check suite, clippy on changed crates, test.yml's unit gates), plus `check-boundaries`, `lint-logging`, and the CI unit gate re-run after the final round.

## CI coverage — needs your eye

The ticket asks for a headless CI harness doing `start, run, Ctrl-C, clean exit`. **A GPU-less runner cannot do the `start` leg.** Verified in a container with no `/dev/dri`: `Runner::start()` fails its DMA-BUF buffer-pool pre-warm (`vmaCreateBuffer failed: A device memory allocation has failed`) because a software rasterizer cannot allocate exportable DMA-BUF memory. (An earlier local failure showing a tiled-modifier VUID violation was an artifact of this box having real DRM *and* forced-software Vulkan — not representative of a runner.)

Per your call, the GPU half stays **rig-only** rather than adding a self-hosted GPU runner. CI (`.github/workflows/python-wheel.yml`) therefore proves: the wheel builds via maturin, the engine boots and tears down, the exception path and the at-exit path do not hang finalization, and the 5 shutdown-signal unit tests — which previously ran in **no** workflow at all. The six `requires_gpu` tests are deselected with the reason stated in the workflow.

## Notes for owner

1. **macOS is unverified and structurally unfinished.** `cargo check --target aarch64-apple-darwin` cannot run on this host — it dies compiling `lzma-sys` (`cc: unrecognized command-line option '-arch'`), a missing Apple cross-toolchain, not this code. Worse, the macOS run loop is an `NSApplication` loop that *terminates the process instead of returning*, so `rt.run()` there would never return, never tear down, never hand SIGINT back. `run()`'s rustdoc now scopes its promises to Linux (the plan's platform floor). A macOS wheel needs a design answer first.
2. **The engine initializes logging once per process.** A second `Runner` in the same interpreter emits no log lines at all — its guard drops with the first. Harmless for `dev` (a new process each time), but the importable arrangement makes several sequential run loops in one interpreter normal. Surfaced while writing the two-pipeline test, which now times itself monotonically instead of waiting on engine logs.
3. **The stdio interceptor swallows `print()`** into `tracing` at WARN while the engine is alive, so a user's `print()` mid-run comes back as `… stdio_interceptor — <text>`. Pre-existing, but it now sits directly under the primary authoring surface and will confuse Python authors in #1708.
4. **The teardown lock is empty-graph-only.** No Python API adds a processor until #1708, so "all engine threads joined" and "every anchored thread state released" are proven against a graph with zero processors. Worth carrying forward as an explicit acceptance criterion on #1708.
5. **`tools/streamlib-cli/src/commands/run.rs` still does `start()` then `wait_for_signal()`**, so the startup-window gap `start_and_wait_for_shutdown()` exists to close remains open on the CLI path. Out of scope — Change B rewrites that path.
6. **Two in-tree distributions now both claim the name `streamlib`.** Do not install both in one venv; the setuptools SDK at `sdk/streamlib-python` is frozen until #1715.
7. **End-state / no-cruft check** (your condition on the crate location): nothing surviving in the engine tree imports `sdk/streamlib-python` — every reference is in `link`/`add` provisioning, subprocess polyglot tests, or doc comments in crates Change B deletes. The one survivor was `xtask`'s `lint-logging` zone list, which this PR repoints (the wheel's Python package was linted by *nothing* before). Note the plan's "the authoring surface carries over into the wheel's API" is optimistic: `processor_context.py`, `log.py`, and `clock.py` are subprocess-shaped and get **re-authored** in #1708/#1710, not moved. Either way the end state is one directory. Worth correcting the Change A wording in an `/align` pass so #1708 is not estimated as a file move.
8. **Wheel version is hand-synced.** `release-please` bumps only the workspace `Cargo.toml`, and `check-package-version-drift` scans `packages/*`, so nothing enforces the plan's "two artifacts, one version". Wiring it belongs with #1711; a comment records that in the meantime.

## Post-review round 3 (added after the PR opened)

A final adjudication pass found one blocker and several cleanliness items. All fixed:

- **`shutdown()`'s guard was a check-then-act race.** The `AtomicBool` let a worker read "still running", release the GIL inside the request, and land it *after* the run loop stopped observing — poisoning the next run loop. Reproduced independently at ~350ms in 2 of 3 trials. The engine slot and the flag are now one locked `PythonRuntimeLifecycleState`, with the request issued under the same lock `run()` takes to transition and clear the latch. **The fix is structural, not test-proven** — a concurrent smoke test ships with it, but reintroducing the racy shape does not make it red on this rig (3/3 green), and its docstring says so rather than claiming a lock it does not earn.
- **`start_and_wait_for_shutdown` shipped beside its verbatim duplicate** — the sequence its own rustdoc calls defective. `App::run()`, `streamlib run`, and the standalone runtime binary now use it, so signal ownership spans startup on those paths too. That was a "search first, extend never parallel" violation.
- **`Runner::stop()`'s idempotence is now locked by a test** that counts published transitions (2 instead of 1 without the guard), and claims one lock instead of two.
- **`lint_logging`'s Python policy is one `const fn`** applied to both roots instead of a copied 17-line record; its tests resolve targets by name, so adding a target no longer silently retargets unrelated assertions.
- **The test driver now kills each app's process group in fixture teardown.** Without it a failed assertion stranded a live engine holding a GPU context and an iceoryx2 node — two such orphans were found on the rig, and earlier suite runs had been sharing it with them. Re-verified clean: 12/12 with zero survivors.
- Comment layer trimmed per `.claude/rules/comments.md` (decision-justification moved here; SAFETY blocks, the async-signal-safety proof, and the `Mental-revert:` notes kept).

**Additional note for the owner:** `rt.run()` on a non-main thread is outside what this proves. The `atexit` hook is fire-and-forget, so if `run()` is blocking on a worker when the main thread finishes, CPython can finalize mid-teardown. `run()`'s rustdoc now says to call it from the main thread; whether worker-thread `run()` should be supported is a design question, not a defect here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

