### PR TITLE
feat(python)!: in-process authoring — capability-typed contexts, @input/@output, rt.add, GIL-release contract

### DIFF
--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -10,6 +10,11 @@ jobs:
   wheel-interpreter-lifecycle:
     name: Wheel build + interpreter lifecycle (no GPU)
     runs-on: ubuntu-latest
+    # A lock-order defect between the lifecycle mutex and the GIL wedges the
+    # whole interpreter rather than raising, so its regression test can only go
+    # red by running out of time. Without a bound it would burn the default six
+    # hours instead.
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v4
@@ -75,6 +80,11 @@ jobs:
       # hand-maintained stub safe. `pyright --verifytypes` cannot substitute:
       # it scores annotation completeness, so a stub describing a method the
       # binary dropped still reads as 100% complete.
+      # The crate's own unit tests need a linked interpreter, which this job
+      # already has. Without this step they run on developer machines only.
+      - name: Wheel crate unit tests
+        run: cargo test --locked -p streamlib-python-wheel --lib
+
       - name: Type stubs match the compiled module
         working-directory: sdk/streamlib-python-wheel
         run: .venv/bin/python -m mypy.stubtest streamlib._engine
@@ -100,6 +110,7 @@ jobs:
   python-types:
     name: Pyright (no build)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     # Deliberately independent of the wheel build. With `_engine.pyi` checked
     # in, pyright reads the stub rather than the compiled module — it never

--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -66,8 +66,18 @@ jobs:
         working-directory: sdk/streamlib-python-wheel
         run: |
           uv venv --python 3.12 .venv
-          VIRTUAL_ENV="$PWD/.venv" uv pip install pytest
+          VIRTUAL_ENV="$PWD/.venv" uv pip install pytest mypy
           VIRTUAL_ENV="$PWD/.venv" uvx maturin@1.9.6 develop
+
+      # The only check that compares the stub to the binary. It imports the
+      # built module, introspects it, and fails on a name or signature the
+      # hand-written `_engine.pyi` no longer describes — which is what makes a
+      # hand-maintained stub safe. `pyright --verifytypes` cannot substitute:
+      # it scores annotation completeness, so a stub describing a method the
+      # binary dropped still reads as 100% complete.
+      - name: Type stubs match the compiled module
+        working-directory: sdk/streamlib-python-wheel
+        run: .venv/bin/python -m mypy.stubtest streamlib._engine
 
       # The runner has no GPU. `Runner::start()` initializes a GPU context whose
       # DMA-BUF pool pre-warm needs a driver that can allocate exportable device
@@ -86,3 +96,31 @@ jobs:
         run: |
           mkdir -p "$XDG_RUNTIME_DIR"
           .venv/bin/python -m pytest tests/ -v -m "not requires_gpu"
+
+  python-types:
+    name: Pyright (no build)
+    runs-on: ubuntu-latest
+
+    # Deliberately independent of the wheel build. With `_engine.pyi` checked
+    # in, pyright reads the stub rather than the compiled module — it never
+    # imports anything — so this needs no Rust toolchain, no Vulkan, and no
+    # maturin, and finishes in seconds. It is also the check the author's editor
+    # runs: Pylance is pyright, so a green job here means working completion and
+    # correct hovers for anyone writing a processor.
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      # pytest only, so its `py.typed` annotations resolve in `tests/`. The
+      # package under test is read from source; nothing is installed.
+      - name: Prepare the environment pyright resolves against
+        working-directory: sdk/streamlib-python-wheel
+        run: |
+          uv venv --python 3.12 .venv
+          VIRTUAL_ENV="$PWD/.venv" uv pip install pytest
+
+      - name: Type-check the wheel's Python surface
+        working-directory: sdk/streamlib-python-wheel
+        run: uvx pyright@1.1.411

--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -29,7 +29,8 @@ jobs:
             pkg-config \
             protobuf-compiler \
             libvulkan-dev \
-            glslc
+            glslc \
+            python3-dev
 
       - name: Install jtd-codegen
         run: |
@@ -74,17 +75,19 @@ jobs:
           VIRTUAL_ENV="$PWD/.venv" uv pip install pytest mypy
           VIRTUAL_ENV="$PWD/.venv" uvx maturin@1.9.6 develop
 
+      # The crate's own unit tests link libpython rather than building as an
+      # extension module (the `extension-module` feature is off by default for
+      # exactly this), which is why `python3-dev` is in the apt list above.
+      # Without this step they run on developer machines only.
+      - name: Wheel crate unit tests
+        run: cargo test --locked -p streamlib-python-wheel --lib
+
       # The only check that compares the stub to the binary. It imports the
       # built module, introspects it, and fails on a name or signature the
       # hand-written `_engine.pyi` no longer describes — which is what makes a
       # hand-maintained stub safe. `pyright --verifytypes` cannot substitute:
       # it scores annotation completeness, so a stub describing a method the
       # binary dropped still reads as 100% complete.
-      # The crate's own unit tests need a linked interpreter, which this job
-      # already has. Without this step they run on developer machines only.
-      - name: Wheel crate unit tests
-        run: cargo test --locked -p streamlib-python-wheel --lib
-
       - name: Type stubs match the compiled module
         working-directory: sdk/streamlib-python-wheel
         run: .venv/bin/python -m mypy.stubtest streamlib._engine

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5453,6 +5453,8 @@ dependencies = [
 name = "streamlib-python-wheel"
 version = "0.10.3"
 dependencies = [
+ "libc",
+ "parking_lot",
  "pyo3",
  "rmpv",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5454,6 +5454,8 @@ name = "streamlib-python-wheel"
 version = "0.10.3"
 dependencies = [
  "pyo3",
+ "rmpv",
+ "serde_json",
  "streamlib",
  "tracing",
 ]

--- a/docs/decisions/importable-python-library.md
+++ b/docs/decisions/importable-python-library.md
@@ -123,3 +123,33 @@ contract satisfies without putting Python in deadline paths.
   torch/cupy zero-copy story is the largest remaining technical risk, now explicit.
 - M39 is re-derived against this direction; the client-SDK/control-plane embedding story for
   Python is superseded by in-process embedding via the wheel.
+
+## The authoring grammar, as built
+
+Settled while implementing in-process authoring; recorded so the shape is not re-litigated.
+
+- **Ports are class attributes, not decorated methods.** `frames_from_upstream =
+  LinkInputDataPort()` makes the attribute name the port name, so a port is named once and
+  `self.frames_from_upstream.read()` is a typed, completable expression. The alternative —
+  decorating a stub method that exists only to carry metadata, then reading and writing by string
+  through a context object — repeats every port name and gives an editor nothing to complete
+  against. The engine binds a fresh per-instance port object when it constructs the processor;
+  the class attribute stays a declaration, so two instances of one class read different links.
+- **Lifecycle hooks take no arguments.** With ports on `self`, logging module-level and the clock
+  module-level, a context parameter would carry nothing. `def process(self) -> None` is the whole
+  signature.
+- **`execution=` defaults to reactive only where reacting is possible.** A class declaring at
+  least one input port defaults; one declaring none must say what it is. A source has nothing to
+  react to, so the default would hand the author a processor that silently never runs — the one
+  case where the convenient default is a trap.
+- **Configuration is constructor keyword arguments.** `rt.add(Blur, config={"radius": 3})`
+  constructs `Blur(radius=3)`, so a processor's settings are ordinary Python parameters with
+  ordinary defaults and there is no configuration object to learn. It travels as JSON on the graph
+  node rather than captured in a closure, because one class added twice must yield two
+  independently configured instances — and because that keeps it visible in `graph`.
+- **Python ports declare no schema.** The wire is self-describing and consuming is a cast at read
+  time, so a port carries a name, a description and (on inputs) a delivery profile. Adding a
+  schema hint here would build on the per-read matching being deleted.
+- **Registration is idempotent per identity, and a collision is named.** Two different classes
+  claiming one identity is refused with both qualified names and the fix, rather than surfacing
+  the registry's generic duplicate error.

--- a/docs/decisions/importable-python-library.md
+++ b/docs/decisions/importable-python-library.md
@@ -150,6 +150,12 @@ Settled while implementing in-process authoring; recorded so the shape is not re
 - **Python ports declare no schema.** The wire is self-describing and consuming is a cast at read
   time, so a port carries a name, a description and (on inputs) a delivery profile. Adding a
   schema hint here would build on the per-read matching being deleted.
+- **A Python input port may omit its delivery profile**, and resolves to `latest`. The
+  channel-policy rule that makes an undeclared profile a wiring error is scoped to a
+  *concretely-typed* input port, where the type's flow class is the thing being contradicted. A
+  Python port is a wildcard by construction — it declares no type at all — so there is no type-level
+  default for the omission to silently override, and requiring the knob on every port would be
+  ceremony the zero-ceremony bar rules out.
 - **Registration is idempotent per identity, and a collision is named.** Two different classes
   claiming one identity is refused with both qualified names and the fix, rather than surfacing
   the registry's generic duplicate error.

--- a/docs/decisions/python-type-stubs-and-validation.md
+++ b/docs/decisions/python-type-stubs-and-validation.md
@@ -1,0 +1,72 @@
+# Python type stubs and their validation
+
+## Trigger
+
+You are adding, changing or removing anything on the wheel's native surface (a `#[pyclass]`, a
+`#[pymethods]` signature, a `#[pyfunction]`), or wondering why a hand-written `.pyi` sits next to
+a compiled module, or whether to reach for a stub generator.
+
+## Decision
+
+The wheel ships a **hand-written `python/streamlib/_engine.pyi`** and a **`py.typed`** marker, and
+two independent checks keep them honest:
+
+- **`mypy.stubtest`** imports the built module, introspects it, and compares it against the stub.
+  This is the drift check. It runs inside the wheel job, which already pays for the build.
+- **`pyright` at `standard` mode** type-checks the package and its tests. With the stub checked in
+  it reads no binary at all, so it runs as its own job with no Rust toolchain, no Vulkan and no
+  maturin.
+
+**A stub is part of the change, not a follow-up.** A new binding without a stub entry fails
+stubtest, which is the intended pressure — the stub is the only thing an editor or a checker can
+read about the native surface.
+
+## Why this matters more here than for a pure-Python package
+
+Nothing can be inferred from `_engine.abi3.so`. Measured on this tree: with the compiled module
+present, pyright still reports `Runtime` as unknown and every derived type as obscured. Without
+the stub, an author writing a processor gets no completion on `rt.`, no signature help, and no
+checking — and an AI agent working in this repo sees the same nothing. The stub is what makes the
+API legible to both.
+
+`py.typed` is separate and equally load-bearing: without the marker a type checker ignores the
+package's annotations entirely, however complete they are. It is inert at runtime and adds no
+dependency — a user who runs no type checker sees no difference (PEP 561). What it does commit us
+to is accuracy: the marker applies recursively, so a wrong stub is now actively misleading rather
+than merely absent. That is the cost the two checks above buy down.
+
+## Rejected alternatives
+
+- **Generated stubs (`pyo3-stub-gen`)** — requires annotating every binding with companion macros
+  plus a separate generator binary, and its own README states complete translation is impossible.
+  No comparable library uses it in production.
+- **Generated stubs (PyO3 `experimental-inspect` / maturin `--generate-stubs`)** — the right
+  long-term answer, because a stub derived from the same macro metadata as the binary cannot
+  drift. Not yet available: the PyO3 feature is explicitly in-development and inline-module-only,
+  the maturin RFC is unmerged, and PyO3's own docs still name hand-maintained `.pyi` as current
+  best practice. Revisit when `maturin build --generate-stubs` lands; adopting it would retire
+  stubtest rather than supplement it.
+- **`pyright --verifytypes` as the drift check** — it is not one. It scores annotation
+  *completeness*, so a stub describing a method the binary no longer exports reports as fully
+  complete and green. It answers "is everything annotated?", never "is the annotation true?".
+- **Pyright at `strict`** — turns on `reportPrivateUsage`, which fights the `_engine` /
+  `_NativeRuntime` shape the package is deliberately built on, and demands an annotation on every
+  pytest fixture parameter. Measured: 104 errors, all but one in tests, nearly all cascading from
+  a single unannotated fixture. `standard` over the same tree produced one diagnostic, and it was
+  a real unguarded-`None` bug.
+- **Shipping no stubs** — what NVIDIA's own realtime products do (Holoscan, TensorRT and
+  DeepStream ship neither `.pyi` nor `py.typed`), and each has a years-old unresolved user
+  complaint about it, worked around by third-party stub packages. The libraries whose users
+  hand-write substantial code against a native core — PyAV, opencv-python, NVIDIA's own
+  `cuda.core` — all ship full stubs.
+
+## Consequences
+
+- Every native-surface change costs a stub edit, enforced by CI rather than by review.
+- Signature accuracy is worth stating precisely, not approximately: typing `Runtime.__exit__` as
+  `Literal[False]` rather than `bool` is what lets a checker know a `with` block completed, and
+  that one change fixed two possibly-unbound defects in existing test code.
+- Pyright needs Node; `uvx pyright` handles that. If the download proves flaky on CI, basedpyright
+  is a drop-in fork that ships Node in its wheel.
+- The pyright job checks the tests too, so test code carries annotations. This is deliberate — the
+  bugs it found were in test infrastructure, which is exactly where a silent failure hides longest.

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
@@ -105,9 +105,12 @@ pub(crate) fn spawn_processor(
         scheduling_strategy_for_processor(node)
     };
 
+    // Names the authoring language, not a placement: a Python processor runs in
+    // the app's own interpreter, so calling it a subprocess host would describe
+    // every in-process one wrongly.
     let runtime_label = match runtime {
         ProcessorRuntime::Rust => "Rust processor",
-        ProcessorRuntime::Python => "Python subprocess host",
+        ProcessorRuntime::Python => "Python processor",
         ProcessorRuntime::TypeScript => "Deno subprocess host",
     };
     tracing::info!(

--- a/runtime/streamlib-engine/src/core/context/surface_store.rs
+++ b/runtime/streamlib-engine/src/core/context/surface_store.rs
@@ -75,6 +75,10 @@ impl SurfaceCache {
         }
     }
 
+    fn remove(&mut self, surface_id: &str) {
+        self.surfaces.remove(surface_id);
+    }
+
     fn clear(&mut self) {
         self.surfaces.clear();
     }
@@ -734,6 +738,11 @@ impl SurfaceStoreInner {
     /// since the surface-share service already treats the client's socket-close as a full
     /// release.
     pub fn release(&self, surface_id: &str) -> Result<()> {
+        // Evict the local cache's strong reference first: `check_in` parks a
+        // clone there, and a pixel-buffer pool frees a slot only once the
+        // buffer's strong count returns to 1 — without this eviction a
+        // released surface pins its pool slot for the store's lifetime.
+        self.cache.lock().remove(surface_id);
         #[cfg(target_os = "macos")]
         {
             self.release_from_surface_share(surface_id)

--- a/runtime/streamlib-engine/src/core/logging/mod.rs
+++ b/runtime/streamlib-engine/src/core/logging/mod.rs
@@ -16,6 +16,37 @@ pub(crate) use record::LogRecord;
 pub use worker::format_event_pretty;
 pub(crate) use worker::now_ns;
 
+/// Emit one record from an in-process Python processor into the unified
+/// JSONL pipeline, carrying caller-supplied dynamic attrs.
+///
+/// Bypasses `tracing::event!` deliberately: the macro cannot carry a
+/// runtime-shaped attr map, and routing through the polyglot sink keeps
+/// `source: python` honest in the JSONL columns (same reasoning as the
+/// subprocess log relay in `polyglot_sink`). Silently no-ops before
+/// [`init`] runs, matching `tracing::*!()` behaviour.
+pub fn emit_python_processor_log_record(
+    level: LogLevel,
+    message: String,
+    processor_id: Option<String>,
+    attrs: std::collections::BTreeMap<String, serde_json::Value>,
+) {
+    push_polyglot_record(LogRecord {
+        host_ts: now_ns(),
+        level,
+        target: "streamlib::python".to_string(),
+        message,
+        pipeline_id: None,
+        processor_id,
+        rhi_op: None,
+        intercepted: false,
+        channel: None,
+        attrs,
+        source: Some(Source::Python),
+        source_ts: None,
+        source_seq: None,
+    });
+}
+
 mod config;
 mod event;
 pub(crate) mod iceoryx2_log_bridge;

--- a/sdk/streamlib-python-wheel/Cargo.toml
+++ b/sdk/streamlib-python-wheel/Cargo.toml
@@ -40,7 +40,7 @@ pyo3 = { version = "0.29.0", features = ["abi3-py310"] }
 
 # `default-features = false` drops the SDK's `auto-build` feature: the wheel
 # resolves nothing from source and links no build tooling.
-streamlib = { path = "../streamlib-sdk", version = "0.10.2", default-features = false }
+streamlib = { path = "../streamlib-sdk", version = "0.10.3", default-features = false }
 
 # The bag's value tree. A bag crosses into Python as ordinary Python data, and
 # `rmpv`'s native `bin` variant is what keeps a byte payload from decoding as

--- a/sdk/streamlib-python-wheel/Cargo.toml
+++ b/sdk/streamlib-python-wheel/Cargo.toml
@@ -49,5 +49,13 @@ rmpv = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 
+# Raw CLOCK_MONOTONIC + timerfd: the wheel's clock contract is the kernel's
+# monotonic epoch (comparable to `time.clock_gettime_ns(time.CLOCK_MONOTONIC)`),
+# which std does not expose.
+libc = { workspace = true }
+# Guards the lifecycle-scoped context leases; non-poisoning, so a panicking
+# hook cannot wedge every later lease install.
+parking_lot = "0.12"
+
 [lints]
 workspace = true

--- a/sdk/streamlib-python-wheel/Cargo.toml
+++ b/sdk/streamlib-python-wheel/Cargo.toml
@@ -42,6 +42,11 @@ pyo3 = { version = "0.29.0", features = ["abi3-py310"] }
 # resolves nothing from source and links no build tooling.
 streamlib = { path = "../streamlib-sdk", version = "0.10.3", default-features = false }
 
+# The bag's value tree. A bag crosses into Python as ordinary Python data, and
+# `rmpv`'s native `bin` variant is what keeps a byte payload from decoding as
+# text on the way through.
+rmpv = { workspace = true }
+serde_json = { workspace = true }
 tracing = { workspace = true }
 
 [lints]

--- a/sdk/streamlib-python-wheel/Cargo.toml
+++ b/sdk/streamlib-python-wheel/Cargo.toml
@@ -40,7 +40,7 @@ pyo3 = { version = "0.29.0", features = ["abi3-py310"] }
 
 # `default-features = false` drops the SDK's `auto-build` feature: the wheel
 # resolves nothing from source and links no build tooling.
-streamlib = { path = "../streamlib-sdk", version = "0.10.3", default-features = false }
+streamlib = { path = "../streamlib-sdk", version = "0.10.2", default-features = false }
 
 # The bag's value tree. A bag crosses into Python as ordinary Python data, and
 # `rmpv`'s native `bin` variant is what keeps a byte payload from decoding as

--- a/sdk/streamlib-python-wheel/pyproject.toml
+++ b/sdk/streamlib-python-wheel/pyproject.toml
@@ -12,7 +12,7 @@ name = "streamlib"
 # release-please's extra-files list covers only the workspace Cargo.toml, and
 # check-package-version-drift scans `packages/*`. Wiring the bump belongs with
 # release packaging (#1711); until then keep it in sync by hand on release.
-version = "0.10.2"
+version = "0.10.3"
 description = "StreamLib — a realtime streaming engine with Python authoring"
 # abi3-py310 in Cargo.toml is the binding half of this floor; the two move
 # together or the wheel claims interpreters its ABI tag does not cover.

--- a/sdk/streamlib-python-wheel/pyproject.toml
+++ b/sdk/streamlib-python-wheel/pyproject.toml
@@ -45,3 +45,23 @@ markers = [
 python-source = "python"
 module-name = "streamlib._engine"
 features = ["extension-module"]
+# A local `maturin develop` leaves compiled bytecode next to the sources,
+# and maturin globs the directory — without this an incremental build ships
+# one interpreter's stale `.pyc` files inside an abi3 wheel.
+exclude = ["**/__pycache__/**"]
+
+[tool.pyright]
+# The wheel's Python half, checked at the version floor rather than whatever
+# interpreter the venv happens to be — `requires-python` is the promise.
+include = ["python", "tests"]
+pythonVersion = "3.10"
+# Standard rather than strict: strict turns on `reportPrivateUsage`, which
+# fights the `_engine` / `_NativeRuntime` shape this package is built on, and
+# demands annotations on every pytest fixture parameter.
+typeCheckingMode = "standard"
+venvPath = "."
+venv = ".venv"
+# The engine module is a compiled artifact, so a checkout has the stub and
+# not the `.so` it describes. That is the intended shape here, not a gap —
+# `mypy.stubtest` is what checks the stub against the real binary.
+reportMissingModuleSource = "none"

--- a/sdk/streamlib-python-wheel/pyproject.toml
+++ b/sdk/streamlib-python-wheel/pyproject.toml
@@ -54,6 +54,11 @@ exclude = ["**/__pycache__/**"]
 # The wheel's Python half, checked at the version floor rather than whatever
 # interpreter the venv happens to be — `requires-python` is the promise.
 include = ["python", "tests"]
+# The package is checked from source, not from an install, so `tests/` needs
+# the package root on the search path. Without it a checkout that has not run
+# `maturin develop` reports every `import streamlib` unresolved — which is
+# precisely the state the no-build job runs in.
+extraPaths = ["python"]
 pythonVersion = "3.10"
 # Standard rather than strict: strict turns on `reportPrivateUsage`, which
 # fights the `_engine` / `_NativeRuntime` shape this package is built on, and

--- a/sdk/streamlib-python-wheel/python/streamlib/__init__.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/__init__.py
@@ -3,16 +3,37 @@
 
 """StreamLib — a realtime streaming engine with Python authoring.
 
-The engine runs in this interpreter's process: `Runtime()` boots it and
-`rt.run()` blocks until Ctrl-C with the GIL released.
+The engine runs in this interpreter's process: `Runtime()` boots it, `rt.add`
+puts processors in its graph, `rt.connect` links them, and `rt.run()` blocks
+until Ctrl-C with the GIL released.
 """
 
 import atexit
 import weakref
 
+from . import log as log
+from ._engine import AddedProcessor as AddedProcessor
+from ._engine import ProcessorInputPortReference as ProcessorInputPortReference
+from ._engine import ProcessorLinkDataAccess as ProcessorLinkDataAccess
+from ._engine import ProcessorOutputPortReference as ProcessorOutputPortReference
 from ._engine import Runtime as _NativeRuntime
+from ._engine import media_clock_now_ns as media_clock_now_ns
+from ._processor_declaration import LinkInputDataPort as LinkInputDataPort
+from ._processor_declaration import LinkOutputDataPort as LinkOutputDataPort
+from ._processor_declaration import processor as processor
 
-__all__ = ["Runtime"]
+__all__ = [
+    "AddedProcessor",
+    "LinkInputDataPort",
+    "LinkOutputDataPort",
+    "ProcessorInputPortReference",
+    "ProcessorLinkDataAccess",
+    "ProcessorOutputPortReference",
+    "Runtime",
+    "log",
+    "media_clock_now_ns",
+    "processor",
+]
 
 
 # Engine threads must be joined before CPython finalizes. `Runtime.run()` does

--- a/sdk/streamlib-python-wheel/python/streamlib/__init__.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/__init__.py
@@ -5,33 +5,59 @@
 
 The engine runs in this interpreter's process: `Runtime()` boots it, `rt.add`
 puts processors in its graph, `rt.connect` links them, and `rt.run()` blocks
-until Ctrl-C with the GIL released.
+until Ctrl-C with the GIL released. Processors declare identity and ports with
+`@processor` / `@input` / `@output` and receive a capability-typed context in
+every lifecycle hook.
 """
 
 import atexit
 import weakref
 
+from . import clock as clock
 from . import log as log
 from ._engine import AddedProcessor as AddedProcessor
+from ._engine import GpuContextFullAccess as GpuContextFullAccess
+from ._engine import GpuContextLimitedAccess as GpuContextLimitedAccess
+from ._engine import GpuSurfaceHandle as GpuSurfaceHandle
+from ._engine import LinkInputDataReader as LinkInputDataReader
+from ._engine import LinkOutputDataWriter as LinkOutputDataWriter
+from ._engine import MonotonicTimer as MonotonicTimer
 from ._engine import ProcessorInputPortReference as ProcessorInputPortReference
 from ._engine import ProcessorLinkDataAccess as ProcessorLinkDataAccess
 from ._engine import ProcessorOutputPortReference as ProcessorOutputPortReference
 from ._engine import Runtime as _NativeRuntime
+from ._engine import RuntimeContextFullAccess as RuntimeContextFullAccess
+from ._engine import RuntimeContextLimitedAccess as RuntimeContextLimitedAccess
 from ._engine import media_clock_now_ns as media_clock_now_ns
-from ._processor_declaration import LinkInputDataPort as LinkInputDataPort
-from ._processor_declaration import LinkOutputDataPort as LinkOutputDataPort
+from ._engine import monotonic_now_ns as monotonic_now_ns
+from ._processor_declaration import input as input
+from ._processor_declaration import output as output
 from ._processor_declaration import processor as processor
+from .schema_ident import SchemaIdent as SchemaIdent
 
+# `input` and `output` shadow the builtins at module scope on purpose — the
+# authoring grammar reads `@input(...)` / `@output(...)`, matching the old SDK.
 __all__ = [
     "AddedProcessor",
-    "LinkInputDataPort",
-    "LinkOutputDataPort",
+    "GpuContextFullAccess",
+    "GpuContextLimitedAccess",
+    "GpuSurfaceHandle",
+    "LinkInputDataReader",
+    "LinkOutputDataWriter",
+    "MonotonicTimer",
     "ProcessorInputPortReference",
     "ProcessorLinkDataAccess",
     "ProcessorOutputPortReference",
     "Runtime",
+    "RuntimeContextFullAccess",
+    "RuntimeContextLimitedAccess",
+    "SchemaIdent",
+    "clock",
+    "input",
     "log",
     "media_clock_now_ns",
+    "monotonic_now_ns",
+    "output",
     "processor",
 ]
 

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -14,6 +14,7 @@ binary no longer exports still reads as complete.
 """
 
 from types import TracebackType
+from collections.abc import Mapping
 from typing import Any, Literal, final
 
 from typing_extensions import disjoint_base
@@ -94,7 +95,7 @@ class ProcessorLinkDataAccess:
 
     def read_from_input_port(self, port_name: str) -> Any | None: ...
     def input_port_has_data(self, port_name: str) -> bool: ...
-    def write_to_output_port(self, port_name: str, bag: Any) -> None: ...
+    def write_to_output_port(self, port_name: str, bag: Mapping[str, Any]) -> None: ...
 
 def media_clock_now_ns() -> int:
     """The clock the engine stamps bags with, in nanoseconds."""

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -99,5 +99,5 @@ class ProcessorLinkDataAccess:
 def media_clock_now_ns() -> int:
     """The clock the engine stamps bags with, in nanoseconds."""
 
-def log_event(level: str, target: str, message: str) -> None:
+def log_event(level: str, emitted_by: str, message: str) -> None:
     """Emit one record on the engine's log pipeline."""

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -14,10 +14,12 @@ binary no longer exports still reads as complete.
 """
 
 from types import TracebackType
-from collections.abc import Mapping
-from typing import Any, Literal, NoReturn, final
+from collections.abc import Callable, Mapping
+from typing import Any, Literal, NoReturn, TypeVar, final
 
 from typing_extensions import disjoint_base
+
+_EscalateResult = TypeVar("_EscalateResult")
 
 __all__ = [
     "AddedProcessor",
@@ -203,6 +205,8 @@ class GpuContextLimitedAccess:
         self, width: int, height: int, format: str, usage: list[str]
     ) -> GpuSurfaceHandle: ...
     def resolve_surface(self, surface_id: str) -> GpuSurfaceHandle: ...
+    def escalate(self, privileged_callback: Callable[[GpuContextFullAccess], _EscalateResult]) -> _EscalateResult:
+        """Run the callback with a temporary full-access capability, camera-pattern style."""
 
 @final
 class GpuContextFullAccess:

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -1,0 +1,103 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Type stubs for the compiled engine module.
+
+A type checker and an editor can read nothing out of `_engine.abi3.so`, so this
+file is the only description of the native surface they get — without it,
+`rt.add` offers no completion and `Runtime` resolves as unknown.
+
+Hand-maintained, and kept honest by `mypy.stubtest`, which imports the built
+module and compares it against this file in CI. `pyright --verifytypes` does not
+catch that: it scores annotation completeness, so a stub describing a method the
+binary no longer exports still reads as complete.
+"""
+
+from types import TracebackType
+from typing import Any, Literal, final
+
+from typing_extensions import disjoint_base
+
+__all__ = [
+    "AddedProcessor",
+    "ProcessorInputPortReference",
+    "ProcessorLinkDataAccess",
+    "ProcessorOutputPortReference",
+    "Runtime",
+    "log_event",
+    "media_clock_now_ns",
+]
+
+@disjoint_base
+class Runtime:
+    """The engine, running in this process."""
+
+    def __init__(self) -> None: ...
+    def add(
+        self,
+        processor_class: type,
+        *,
+        config: dict[str, Any] | None = None,
+        display_name: str | None = None,
+    ) -> AddedProcessor:
+        """Add a processor class to the graph, configured with `config`."""
+
+    def connect(
+        self, source: ProcessorOutputPortReference, destination: ProcessorInputPortReference
+    ) -> None:
+        """Link one processor's output port to another's input port."""
+
+    def run(self) -> None:
+        """Run the pipeline until Ctrl-C, SIGTERM or `shutdown()`, then tear down."""
+
+    def shutdown(self) -> None:
+        """Ask the pipeline to stop. Safe from any thread; idempotent."""
+
+    def __enter__(self) -> Runtime: ...
+    # `Literal[False]`, not `bool`: `__exit__` never suppresses the exception,
+    # and saying so is what lets a checker know that code after a `with` block
+    # only runs when the block completed.
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None = ...,
+        exception: BaseException | None = ...,
+        traceback: TracebackType | None = ...,
+    ) -> Literal[False]: ...
+
+@final
+class AddedProcessor:
+    """A processor in the graph."""
+
+    @property
+    def processor_id(self) -> str: ...
+    @property
+    def display_name(self) -> str: ...
+    def output(self, port_name: str) -> ProcessorOutputPortReference: ...
+    def input(self, port_name: str) -> ProcessorInputPortReference: ...
+    def __repr__(self) -> str: ...
+
+@final
+class ProcessorOutputPortReference:
+    """The producing end of a link."""
+
+    def __repr__(self) -> str: ...
+
+@final
+class ProcessorInputPortReference:
+    """The consuming end of a link."""
+
+    def __repr__(self) -> str: ...
+
+@final
+class ProcessorLinkDataAccess:
+    """One processor's links. The engine binds it to a port; app code never builds one."""
+
+    def read_from_input_port(self, port_name: str) -> Any | None: ...
+    def input_port_has_data(self, port_name: str) -> bool: ...
+    def write_to_output_port(self, port_name: str, bag: Any) -> None: ...
+
+def media_clock_now_ns() -> int:
+    """The clock the engine stamps bags with, in nanoseconds."""
+
+def log_event(level: str, target: str, message: str) -> None:
+    """Emit one record on the engine's log pipeline."""

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -15,18 +15,27 @@ binary no longer exports still reads as complete.
 
 from types import TracebackType
 from collections.abc import Mapping
-from typing import Any, Literal, final
+from typing import Any, Literal, NoReturn, final
 
 from typing_extensions import disjoint_base
 
 __all__ = [
     "AddedProcessor",
+    "GpuContextFullAccess",
+    "GpuContextLimitedAccess",
+    "GpuSurfaceHandle",
+    "LinkInputDataReader",
+    "LinkOutputDataWriter",
+    "MonotonicTimer",
     "ProcessorInputPortReference",
     "ProcessorLinkDataAccess",
     "ProcessorOutputPortReference",
     "Runtime",
+    "RuntimeContextFullAccess",
+    "RuntimeContextLimitedAccess",
     "log_event",
     "media_clock_now_ns",
+    "monotonic_now_ns",
 ]
 
 @disjoint_base
@@ -91,14 +100,190 @@ class ProcessorInputPortReference:
 
 @final
 class ProcessorLinkDataAccess:
-    """One processor's links. The engine binds it to a port; app code never builds one."""
+    """One processor's links. The engine binds it; app code never builds one."""
 
     def read_from_input_port(self, port_name: str) -> Any | None: ...
+    def read_from_input_port_with_timestamp(
+        self, port_name: str
+    ) -> tuple[Any, int] | tuple[None, None]: ...
     def input_port_has_data(self, port_name: str) -> bool: ...
-    def write_to_output_port(self, port_name: str, bag: Mapping[str, Any]) -> None: ...
+    def write_to_output_port(
+        self,
+        port_name: str,
+        bag: Mapping[str, Any],
+        timestamp_ns: int | None = None,
+    ) -> None: ...
+
+@final
+class RuntimeContextFullAccess:
+    """Privileged runtime context handed to `setup` / `teardown` / `start` / `stop`.
+
+    Lease-bound members are only valid during the hook that received the
+    context; touching them afterwards raises `RuntimeError`.
+    """
+
+    @property
+    def config(self) -> dict[str, Any]: ...
+    @property
+    def time(self) -> int: ...
+    @property
+    def inputs(self) -> LinkInputDataReader: ...
+    @property
+    def outputs(self) -> LinkOutputDataWriter: ...
+    @property
+    def gpu_limited_access(self) -> GpuContextLimitedAccess: ...
+    @property
+    def gpu_full_access(self) -> GpuContextFullAccess: ...
+    @property
+    def runtime_id(self) -> str: ...
+    @property
+    def processor_id(self) -> str | None: ...
+    def is_paused(self) -> bool: ...
+    def should_process(self) -> bool: ...
+
+@final
+class RuntimeContextLimitedAccess:
+    """Restricted runtime context handed to `process` / `on_pause` / `on_resume`.
+
+    `gpu_full_access` is deliberately absent — reaching for it raises
+    `AttributeError`, mirroring the Rust capability split.
+    """
+
+    @property
+    def config(self) -> dict[str, Any]: ...
+    @property
+    def time(self) -> int: ...
+    @property
+    def inputs(self) -> LinkInputDataReader: ...
+    @property
+    def outputs(self) -> LinkOutputDataWriter: ...
+    @property
+    def gpu_limited_access(self) -> GpuContextLimitedAccess: ...
+    @property
+    def runtime_id(self) -> str: ...
+    @property
+    def processor_id(self) -> str | None: ...
+    def is_paused(self) -> bool: ...
+    def should_process(self) -> bool: ...
+
+@final
+class LinkInputDataReader:
+    """A processor's input ports, as `ctx.inputs`."""
+
+    def read(self, port_name: str) -> Any | None: ...
+    def read_with_timestamp(
+        self, port_name: str
+    ) -> tuple[Any, int] | tuple[None, None]: ...
+    def has_data(self, port_name: str) -> bool: ...
+
+@final
+class LinkOutputDataWriter:
+    """A processor's output ports, as `ctx.outputs`."""
+
+    def write(
+        self,
+        port_name: str,
+        bag: Mapping[str, Any],
+        timestamp_ns: int | None = None,
+    ) -> None:
+        """Publish one bag to every downstream link on `port_name`.
+
+        Writes past a `lossless` link's ceiling block; on other profiles an
+        over-ceiling write is silently dropped.
+        """
+
+@final
+class GpuContextLimitedAccess:
+    """Non-allocating GPU capability, valid for the whole processor life."""
+
+    def acquire_pixel_buffer(
+        self, width: int, height: int, format: str = "bgra"
+    ) -> GpuSurfaceHandle: ...
+    def acquire_texture(
+        self, width: int, height: int, format: str, usage: list[str]
+    ) -> GpuSurfaceHandle: ...
+    def resolve_surface(self, surface_id: str) -> GpuSurfaceHandle: ...
+
+@final
+class GpuContextFullAccess:
+    """Privileged GPU capability, valid only while a full-access hook runs."""
+
+    def acquire_pixel_buffer(
+        self, width: int, height: int, format: str = "bgra"
+    ) -> GpuSurfaceHandle: ...
+    def acquire_texture(
+        self, width: int, height: int, format: str, usage: list[str]
+    ) -> GpuSurfaceHandle: ...
+    def wait_device_idle(self) -> None: ...
+
+@final
+class GpuSurfaceHandle:
+    """An owned GPU surface. Pixel access lands with ticket #1710."""
+
+    @property
+    def surface_id(self) -> str: ...
+    @property
+    def width(self) -> int: ...
+    @property
+    def height(self) -> int: ...
+    @property
+    def format(self) -> str: ...
+    def close(self) -> None:
+        """Release the underlying GPU resource. Idempotent."""
+
+    def __enter__(self) -> GpuSurfaceHandle: ...
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None = ...,
+        exception: BaseException | None = ...,
+        traceback: TracebackType | None = ...,
+    ) -> Literal[False]: ...
+    # Raise NotImplementedError until the pixel-exchange surface (#1710) lands.
+    def as_numpy(self) -> NoReturn: ...
+    def __dlpack__(self) -> NoReturn: ...
+    def lock(self) -> NoReturn: ...
+    def unlock(self) -> NoReturn: ...
+
+@final
+class MonotonicTimer:
+    """Drift-free periodic timer backed by `timerfd_create(CLOCK_MONOTONIC)`.
+
+    The first absolute deadline is `now + interval`, then `TFD_TIMER_ABSTIME`
+    repeats, so ticks never accumulate drift.
+    """
+
+    def __new__(cls, interval_ns: int) -> MonotonicTimer: ...
+    @property
+    def interval_ns(self) -> int: ...
+    def wait(self, timeout_ms: int = 100) -> int:
+        """Wait up to `timeout_ms` for the next tick.
+
+        Returns a positive expiration count when a tick fired, 0 on timeout,
+        -1 once closed.
+        """
+
+    def close(self) -> None:
+        """Release the timer's file descriptor. Idempotent."""
+
+    def __enter__(self) -> MonotonicTimer: ...
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None = ...,
+        exception: BaseException | None = ...,
+        traceback: TracebackType | None = ...,
+    ) -> Literal[False]: ...
+
+def monotonic_now_ns() -> int:
+    """Current monotonic time in nanoseconds via `clock_gettime(CLOCK_MONOTONIC)`."""
 
 def media_clock_now_ns() -> int:
-    """The clock the engine stamps bags with, in nanoseconds."""
+    """The clock the engine stamps bags with, in nanoseconds.
 
-def log_event(level: str, emitted_by: str, message: str) -> None:
-    """Emit one record on the engine's log pipeline."""
+    Not the system-wide `CLOCK_MONOTONIC` epoch — the origin is this process's
+    engine start, so a value from one process means nothing in another.
+    """
+
+def log_event(
+    level: str, message: str, attrs: dict[str, Any] | None = None
+) -> None:
+    """Emit one record on the engine's log pipeline, with structured attrs."""

--- a/sdk/streamlib-python-wheel/python/streamlib/_processor_declaration.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/_processor_declaration.py
@@ -4,19 +4,24 @@
 """The `@processor` grammar — identity, execution mode, and ports, declared in code.
 
 Nothing is read from disk: there is no manifest, and a bare `.py` module defines
-a working processor. The decorator attaches the metadata the engine reads at
+a working processor. `@processor` attaches the metadata the engine reads at
 `Runtime.add` time as `__streamlib_processor_*__` class attributes; that set is
 the contract between this module and the native half, and the two move together.
+Ports are declared with the `@input` / `@output` method decorators and accessed
+at run time through `ctx.inputs` / `ctx.outputs` — the marker methods themselves
+are never called.
 """
 
 from __future__ import annotations
 
 import re
-from typing import Any, Mapping, Optional, Pattern, TypeVar, Union
+from typing import Any, Callable, Optional, Pattern, TypeVar, Union
+
+from .schema_ident import SchemaIdent
 
 __all__ = [
-    "LinkInputDataPort",
-    "LinkOutputDataPort",
+    "input",
+    "output",
     "processor",
 ]
 
@@ -31,112 +36,124 @@ _EXECUTION_MODES = ("reactive", "manual", "continuous")
 _SCHEDULING_PRIORITIES = ("realtime", "high", "normal")
 _DELIVERY_PROFILES = ("latest", "every_sample", "lossless")
 
+_INPUT_PORT_MARKER_ATTRIBUTE = "_streamlib_input_port"
+_OUTPUT_PORT_MARKER_ATTRIBUTE = "_streamlib_output_port"
+
 ProcessorClass = TypeVar("ProcessorClass", bound=type)
+MethodUnderDecoration = TypeVar("MethodUnderDecoration", bound=Callable[..., Any])
 
 
-class LinkInputDataPort:
-    """An input port, declared as a class attribute and read from in `process()`.
+def input(
+    name: Optional[str] = None,
+    *,
+    schema: Union[SchemaIdent, type, None] = None,
+    description: str = "",
+    delivery_profile: Optional[str] = None,
+) -> "Callable[[MethodUnderDecoration], MethodUnderDecoration]":
+    """Mark a method as declaring an input port.
 
-    The attribute name is the port name, so a port is named once. Reading before
-    the engine has bound the port raises rather than returning nothing.
+    The port is named after the method unless `name` overrides it. `schema` is
+    a structured carrier — a [`SchemaIdent`] instance or a codegen-emitted
+    class carrying `__streamlib_schema_ident__` — never a string.
+    `delivery_profile` is `"latest"`, `"every_sample"`, or `"lossless"`; omit
+    it to default from the wire type's flow class. The decorated method is a
+    declaration only: bags are read with `ctx.inputs.read(port_name)`.
     """
+    if delivery_profile is not None and delivery_profile not in _DELIVERY_PROFILES:
+        raise ValueError(
+            f"invalid delivery_profile {delivery_profile!r}: must be one of "
+            f"{', '.join(_DELIVERY_PROFILES)}"
+        )
+    resolved_schema = _resolve_schema_ident(schema)
 
-    def __init__(
-        self,
-        *,
-        delivery_profile: Optional[str] = None,
-        description: str = "",
-    ) -> None:
-        if delivery_profile is not None and delivery_profile not in _DELIVERY_PROFILES:
-            raise ValueError(
-                f"invalid delivery_profile {delivery_profile!r}: must be one of "
-                f"{', '.join(_DELIVERY_PROFILES)}"
-            )
-        self.delivery_profile = delivery_profile
-        self.description = description
-        self.port_name: Optional[str] = None
-        self._link_data_access: Optional[Any] = None
+    def attach_input_port_marker(method: MethodUnderDecoration) -> MethodUnderDecoration:
+        setattr(
+            method,
+            _INPUT_PORT_MARKER_ATTRIBUTE,
+            {
+                "name": name or method.__name__,
+                "schema": resolved_schema,
+                "description": description,
+                "delivery_profile": delivery_profile,
+            },
+        )
+        return method
 
-    def read(self) -> Optional[Any]:
-        """The next bag on this port, or `None` when nothing is waiting.
-
-        The bag arrives as ordinary Python data — a dict for the named map the
-        wire carries. Consuming it is a cast at read time: the engine mediates
-        no schema agreement, so what a producer declared is a hint, never a
-        guarantee this call checks.
-        """
-        return self._bound_link_data_access().read_from_input_port(self._bound_name())
-
-    def has_data(self) -> bool:
-        """Whether a bag is waiting, without consuming it."""
-        return self._bound_link_data_access().input_port_has_data(self._bound_name())
-
-    def _bound_name(self) -> str:
-        name = self.port_name
-        if name is None:
-            raise RuntimeError(
-                "this input port was never named — declare it as a class attribute of "
-                "a @processor class, where the attribute name becomes the port name"
-            )
-        return name
-
-    def _bound_link_data_access(self) -> Any:
-        if self._link_data_access is None:
-            raise RuntimeError(
-                f"input port {self.port_name!r} is not bound to a running processor — "
-                f"ports are bound by the engine when the processor is constructed, so "
-                f"reading from a class attribute or a hand-instantiated processor "
-                f"cannot work. Use streamlib.testing to drive a processor in a test."
-            )
-        return self._link_data_access
-
-    def __repr__(self) -> str:
-        return f"LinkInputDataPort(name={self.port_name!r}, bound={self._link_data_access is not None})"
+    return attach_input_port_marker
 
 
-class LinkOutputDataPort:
-    """An output port, declared as a class attribute and written to in `process()`."""
+def output(
+    name: Optional[str] = None,
+    *,
+    schema: Union[SchemaIdent, type, None] = None,
+    description: str = "",
+) -> "Callable[[MethodUnderDecoration], MethodUnderDecoration]":
+    """Mark a method as declaring an output port.
 
-    def __init__(self, *, description: str = "") -> None:
-        self.description = description
-        self.port_name: Optional[str] = None
-        self._link_data_access: Optional[Any] = None
+    Same shape as [`input`], minus the delivery profile — delivery is the
+    consuming port's policy. Bags are written with
+    `ctx.outputs.write(port_name, bag)`.
+    """
+    resolved_schema = _resolve_schema_ident(schema)
 
-    def write(self, bag: "Mapping[str, Any]") -> None:
-        """Publish one bag to every downstream link on this port.
+    def attach_output_port_marker(method: MethodUnderDecoration) -> MethodUnderDecoration:
+        setattr(
+            method,
+            _OUTPUT_PORT_MARKER_ATTRIBUTE,
+            {
+                "name": name or method.__name__,
+                "schema": resolved_schema,
+                "description": description,
+            },
+        )
+        return method
 
-        A bag is a named map: a dict with string keys, whose values are ordinary
-        Python data — dicts, lists, tuples, str, bytes, int, float, bool, None.
-        The wire carries a named map because a processor in another language
-        reads it into a struct, so a list or a non-string key is refused rather
-        than published as bytes only Python can decode.
-        """
-        self._bound_link_data_access().write_to_output_port(self._bound_name(), bag)
-
-    def _bound_name(self) -> str:
-        name = self.port_name
-        if name is None:
-            raise RuntimeError(
-                "this output port was never named — declare it as a class attribute of "
-                "a @processor class, where the attribute name becomes the port name"
-            )
-        return name
-
-    def _bound_link_data_access(self) -> Any:
-        if self._link_data_access is None:
-            raise RuntimeError(
-                f"output port {self.port_name!r} is not bound to a running processor — "
-                f"ports are bound by the engine when the processor is constructed, so "
-                f"writing from a class attribute or a hand-instantiated processor "
-                f"cannot work. Use streamlib.testing to drive a processor in a test."
-            )
-        return self._link_data_access
-
-    def __repr__(self) -> str:
-        return f"LinkOutputDataPort(name={self.port_name!r}, bound={self._link_data_access is not None})"
+    return attach_output_port_marker
 
 
-AnyDataPort = Union[LinkInputDataPort, LinkOutputDataPort]
+def _resolve_schema_ident(
+    schema_arg: "Union[SchemaIdent, type, None]",
+) -> Optional[SchemaIdent]:
+    """Resolve a `schema=` argument to a structured `SchemaIdent`.
+
+    Accepts:
+        - `None` (port has no declared schema)
+        - `SchemaIdent` instance (returned as-is)
+        - a codegen-emitted class carrying `__streamlib_schema_ident__`
+          as a `ClassVar[SchemaIdent]` attribute (produced by
+          `streamlib generate` from the package's JTD/YAML schemas)
+
+    Rejects:
+        - any string (bare type name OR joined `@org/pkg/Type@v` form)
+        - classes without structured-ident metadata
+    """
+    if schema_arg is None:
+        return None
+    if isinstance(schema_arg, SchemaIdent):
+        return schema_arg
+    if isinstance(schema_arg, str):
+        raise TypeError(
+            f"schema={schema_arg!r}: string schema references are no longer "
+            f"accepted. Pass a structured `SchemaIdent(org, package, type_, version)` "
+            f"instance instead. Joined-string forms like '@tatolab/core/VideoFrame@1.0.0' "
+            f"and bare type names like 'VideoFrame' are both rejected — schemas are "
+            f"cross-package references by definition and have no shorthand. See "
+            f"docs/architecture/schema-identity-and-packaging.md."
+        )
+    if isinstance(schema_arg, type):
+        ident = getattr(schema_arg, "__streamlib_schema_ident__", None)
+        if isinstance(ident, SchemaIdent):
+            return ident
+        raise TypeError(
+            f"schema={schema_arg.__name__}: class does not carry a structured "
+            f"SchemaIdent. Import a codegen-emitted class from "
+            f"streamlib._generated_.<package>, or pass a `SchemaIdent` "
+            f"instance directly."
+        )
+    raise TypeError(
+        f"schema={schema_arg!r}: unsupported type {type(schema_arg).__name__}. "
+        f"Pass a `SchemaIdent` instance or a codegen-emitted schema class."
+    )
 
 
 def processor(
@@ -219,24 +236,67 @@ def _declare_processor(
 def _collect_declared_ports(
     processor_class: type,
 ) -> "tuple[list[dict[str, Any]], list[dict[str, Any]]]":
-    """Name every declared port after the attribute holding it."""
+    """Every `@input` / `@output` declaration, as the dicts the engine reads.
+
+    The `"schema"` value is rendered to the 4-field wire dict here — the native
+    reader consumes plain dicts, never `SchemaIdent` instances.
+    """
     input_ports: "list[dict[str, Any]]" = []
     output_ports: "list[dict[str, Any]]" = []
-    for attribute_name, declaration in _declared_ports(processor_class):
-        declaration.port_name = attribute_name
-        if isinstance(declaration, LinkInputDataPort):
+    claimed_port_names: "set[str]" = set()
+    for marker in _declared_port_markers(processor_class):
+        port_name = marker["name"]
+        if port_name in claimed_port_names:
+            raise ValueError(
+                f"{processor_class.__name__} declares the port name {port_name!r} more "
+                f"than once — every port, input or output, needs its own name"
+            )
+        claimed_port_names.add(port_name)
+        declared_schema: Optional[SchemaIdent] = marker["schema"]
+        wire_schema = None if declared_schema is None else declared_schema.to_wire_dict()
+        if "delivery_profile" in marker:
             input_ports.append(
                 {
-                    "name": attribute_name,
-                    "description": declaration.description,
-                    "delivery_profile": declaration.delivery_profile,
+                    "name": port_name,
+                    "description": marker["description"],
+                    "delivery_profile": marker["delivery_profile"],
+                    "schema": wire_schema,
                 }
             )
         else:
             output_ports.append(
-                {"name": attribute_name, "description": declaration.description}
+                {
+                    "name": port_name,
+                    "description": marker["description"],
+                    "schema": wire_schema,
+                }
             )
     return input_ports, output_ports
+
+
+def _declared_port_markers(processor_class: type) -> "list[dict[str, Any]]":
+    """Every port marker declared on the class or inherited, in declaration order.
+
+    Walks the MRO in reverse so a subclass's redeclaration of an inherited
+    method wins, and a base class's ports are inherited rather than lost.
+    """
+    markers_by_attribute: "dict[str, list[dict[str, Any]]]" = {}
+    for ancestor in reversed(processor_class.__mro__):
+        for attribute_name, attribute in vars(ancestor).items():
+            attribute_markers = [
+                marker
+                for marker_attribute in (
+                    _INPUT_PORT_MARKER_ATTRIBUTE,
+                    _OUTPUT_PORT_MARKER_ATTRIBUTE,
+                )
+                for marker in [getattr(attribute, marker_attribute, None)]
+                if marker is not None
+            ]
+            if attribute_markers:
+                markers_by_attribute[attribute_name] = attribute_markers
+    return [
+        marker for markers in markers_by_attribute.values() for marker in markers
+    ]
 
 
 def _resolve_type_reference(
@@ -321,41 +381,3 @@ def _validate_scheduling(scheduling: Optional[str]) -> Optional[str]:
             f"{', '.join(_SCHEDULING_PRIORITIES)}"
         )
     return scheduling
-
-
-def bind_declared_ports_to_running_processor(
-    processor_instance: Any, link_data_access: Any
-) -> None:
-    """Give a freshly constructed processor its own bound copy of every port.
-
-    Called by the engine, never by app code. The declarations live on the class
-    and are therefore shared by every instance of it, so binding sets a fresh
-    per-instance port on the object rather than mutating what the class holds —
-    two instances of one processor class read different links.
-    """
-    for attribute_name, declaration in _declared_ports(type(processor_instance)):
-        bound: AnyDataPort
-        if isinstance(declaration, LinkInputDataPort):
-            bound = LinkInputDataPort(
-                delivery_profile=declaration.delivery_profile,
-                description=declaration.description,
-            )
-        else:
-            bound = LinkOutputDataPort(description=declaration.description)
-        bound.port_name = attribute_name
-        bound._link_data_access = link_data_access
-        setattr(processor_instance, attribute_name, bound)
-
-
-def _declared_ports(processor_class: type) -> "list[tuple[str, AnyDataPort]]":
-    """Every port declared on the class or inherited, in declaration order.
-
-    Walks the MRO in reverse so a subclass's redeclaration of an inherited port
-    name wins, and a base class's ports are inherited rather than lost.
-    """
-    declarations: "dict[str, AnyDataPort]" = {}
-    for ancestor in reversed(processor_class.__mro__):
-        for attribute_name, attribute in vars(ancestor).items():
-            if isinstance(attribute, (LinkInputDataPort, LinkOutputDataPort)):
-                declarations[attribute_name] = attribute
-    return list(declarations.items())

--- a/sdk/streamlib-python-wheel/python/streamlib/_processor_declaration.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/_processor_declaration.py
@@ -12,7 +12,7 @@ the contract between this module and the native half, and the two move together.
 from __future__ import annotations
 
 import re
-from typing import Any, Callable, Optional, Pattern, TypeVar, Union
+from typing import Any, Mapping, Optional, Pattern, TypeVar, Union
 
 __all__ = [
     "LinkInputDataPort",
@@ -102,12 +102,14 @@ class LinkOutputDataPort:
         self.port_name: Optional[str] = None
         self._link_data_access: Optional[Any] = None
 
-    def write(self, bag: Any) -> None:
+    def write(self, bag: "Mapping[str, Any]") -> None:
         """Publish one bag to every downstream link on this port.
 
-        The value is encoded to the self-describing msgpack the wire carries, so
-        it must be built from ordinary Python data — dicts, lists, str, bytes,
-        int, float, bool, None.
+        A bag is a named map: a dict with string keys, whose values are ordinary
+        Python data — dicts, lists, tuples, str, bytes, int, float, bool, None.
+        The wire carries a named map because a processor in another language
+        reads it into a struct, so a list or a non-string key is refused rather
+        than published as bytes only Python can decode.
         """
         self._bound_link_data_access().write_to_output_port(self._bound_name(), bag)
 

--- a/sdk/streamlib-python-wheel/python/streamlib/_processor_declaration.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/_processor_declaration.py
@@ -1,0 +1,359 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""The `@processor` grammar — identity, execution mode, and ports, declared in code.
+
+Nothing is read from disk: there is no manifest, and a bare `.py` module defines
+a working processor. The decorator attaches the metadata the engine reads at
+`Runtime.add` time as `__streamlib_processor_*__` class attributes; that set is
+the contract between this module and the native half, and the two move together.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, Optional, Pattern, TypeVar, Union
+
+__all__ = [
+    "LinkInputDataPort",
+    "LinkOutputDataPort",
+    "processor",
+]
+
+# Mirrors `streamlib_idents`' newtype validation. A processor reference is
+# version-free — versions never appear at the code layer.
+_ORGANIZATION_PATTERN: Pattern[str] = re.compile(r"^[a-z][a-z0-9-]*$")
+_PACKAGE_PATTERN: Pattern[str] = re.compile(r"^[a-z][a-z0-9-]*$")
+_TYPE_NAME_PATTERN: Pattern[str] = re.compile(r"^[A-Z][A-Za-z0-9]*$")
+_IDENTITY_PATTERN: Pattern[str] = re.compile(r"^@([^/@]+)/([^/@]+)/([^/@]+)$")
+
+_EXECUTION_MODES = ("reactive", "manual", "continuous")
+_SCHEDULING_PRIORITIES = ("realtime", "high", "normal")
+_DELIVERY_PROFILES = ("latest", "every_sample", "lossless")
+
+ProcessorClass = TypeVar("ProcessorClass", bound=type)
+
+
+class LinkInputDataPort:
+    """An input port, declared as a class attribute and read from in `process()`.
+
+    The attribute name is the port name, so a port is named once. Reading before
+    the engine has bound the port raises rather than returning nothing.
+    """
+
+    def __init__(
+        self,
+        *,
+        delivery_profile: Optional[str] = None,
+        description: str = "",
+    ) -> None:
+        if delivery_profile is not None and delivery_profile not in _DELIVERY_PROFILES:
+            raise ValueError(
+                f"invalid delivery_profile {delivery_profile!r}: must be one of "
+                f"{', '.join(_DELIVERY_PROFILES)}"
+            )
+        self.delivery_profile = delivery_profile
+        self.description = description
+        self.port_name: Optional[str] = None
+        self._link_data_access: Optional[Any] = None
+
+    def read(self) -> Optional[Any]:
+        """The next bag on this port, or `None` when nothing is waiting.
+
+        The bag arrives as ordinary Python data — a dict for the named map the
+        wire carries. Consuming it is a cast at read time: the engine mediates
+        no schema agreement, so what a producer declared is a hint, never a
+        guarantee this call checks.
+        """
+        return self._bound_link_data_access().read_from_input_port(self._bound_name())
+
+    def has_data(self) -> bool:
+        """Whether a bag is waiting, without consuming it."""
+        return self._bound_link_data_access().input_port_has_data(self._bound_name())
+
+    def _bound_name(self) -> str:
+        name = self.port_name
+        if name is None:
+            raise RuntimeError(
+                "this input port was never named — declare it as a class attribute of "
+                "a @processor class, where the attribute name becomes the port name"
+            )
+        return name
+
+    def _bound_link_data_access(self) -> Any:
+        if self._link_data_access is None:
+            raise RuntimeError(
+                f"input port {self.port_name!r} is not bound to a running processor — "
+                f"ports are bound by the engine when the processor is constructed, so "
+                f"reading from a class attribute or a hand-instantiated processor "
+                f"cannot work. Use streamlib.testing to drive a processor in a test."
+            )
+        return self._link_data_access
+
+    def __repr__(self) -> str:
+        return f"LinkInputDataPort(name={self.port_name!r}, bound={self._link_data_access is not None})"
+
+
+class LinkOutputDataPort:
+    """An output port, declared as a class attribute and written to in `process()`."""
+
+    def __init__(self, *, description: str = "") -> None:
+        self.description = description
+        self.port_name: Optional[str] = None
+        self._link_data_access: Optional[Any] = None
+
+    def write(self, bag: Any) -> None:
+        """Publish one bag to every downstream link on this port.
+
+        The value is encoded to the self-describing msgpack the wire carries, so
+        it must be built from ordinary Python data — dicts, lists, str, bytes,
+        int, float, bool, None.
+        """
+        self._bound_link_data_access().write_to_output_port(self._bound_name(), bag)
+
+    def _bound_name(self) -> str:
+        name = self.port_name
+        if name is None:
+            raise RuntimeError(
+                "this output port was never named — declare it as a class attribute of "
+                "a @processor class, where the attribute name becomes the port name"
+            )
+        return name
+
+    def _bound_link_data_access(self) -> Any:
+        if self._link_data_access is None:
+            raise RuntimeError(
+                f"output port {self.port_name!r} is not bound to a running processor — "
+                f"ports are bound by the engine when the processor is constructed, so "
+                f"writing from a class attribute or a hand-instantiated processor "
+                f"cannot work. Use streamlib.testing to drive a processor in a test."
+            )
+        return self._link_data_access
+
+    def __repr__(self) -> str:
+        return f"LinkOutputDataPort(name={self.port_name!r}, bound={self._link_data_access is not None})"
+
+
+AnyDataPort = Union[LinkInputDataPort, LinkOutputDataPort]
+
+
+def processor(
+    class_or_identity: Union[type, str, None] = None,
+    *,
+    execution: Optional[str] = None,
+    interval_ms: int = 0,
+    scheduling: Optional[str] = None,
+    description: str = "",
+) -> Any:
+    """Mark a class as a streamlib processor.
+
+    Usable bare (`@processor`) or with arguments. Omitting the identity
+    synthesizes `@app/local/<ClassName>`, so an app-local processor needs no
+    identity at all; pass a version-free `@org/package/Type` string to publish
+    one under a shared name.
+
+    `execution` defaults to `"reactive"` for a class that declares at least one
+    input port, and is required for one that declares none — a source has
+    nothing to react to, so defaulting it there would produce a processor that
+    silently never runs.
+    """
+    if isinstance(class_or_identity, type):
+        return _declare_processor(
+            class_or_identity,
+            identity=None,
+            execution=execution,
+            interval_ms=interval_ms,
+            scheduling=scheduling,
+            description=description,
+        )
+
+    if class_or_identity is not None and not isinstance(class_or_identity, str):
+        raise TypeError(
+            f"@processor() takes a version-free `@org/package/Type` identity string or "
+            f"nothing at all; got {type(class_or_identity).__name__}."
+        )
+
+    identity = class_or_identity
+
+    def apply_to_class(processor_class: ProcessorClass) -> ProcessorClass:
+        return _declare_processor(
+            processor_class,
+            identity=identity,
+            execution=execution,
+            interval_ms=interval_ms,
+            scheduling=scheduling,
+            description=description,
+        )
+
+    return apply_to_class
+
+
+def _declare_processor(
+    processor_class: ProcessorClass,
+    *,
+    identity: Optional[str],
+    execution: Optional[str],
+    interval_ms: int,
+    scheduling: Optional[str],
+    description: str,
+) -> ProcessorClass:
+    input_ports, output_ports = _collect_declared_ports(processor_class)
+
+    processor_class.__streamlib_processor_type_reference__ = _resolve_type_reference(  # type: ignore[attr-defined]
+        identity, processor_class
+    )
+    processor_class.__streamlib_processor_description__ = description  # type: ignore[attr-defined]
+    processor_class.__streamlib_processor_execution__ = _resolve_execution(  # type: ignore[attr-defined]
+        execution, interval_ms, processor_class, has_input_ports=bool(input_ports)
+    )
+    processor_class.__streamlib_processor_scheduling_priority__ = _validate_scheduling(  # type: ignore[attr-defined]
+        scheduling
+    )
+    processor_class.__streamlib_processor_input_ports__ = input_ports  # type: ignore[attr-defined]
+    processor_class.__streamlib_processor_output_ports__ = output_ports  # type: ignore[attr-defined]
+    return processor_class
+
+
+def _collect_declared_ports(
+    processor_class: type,
+) -> "tuple[list[dict[str, Any]], list[dict[str, Any]]]":
+    """Name every declared port after the attribute holding it."""
+    input_ports: "list[dict[str, Any]]" = []
+    output_ports: "list[dict[str, Any]]" = []
+    for attribute_name, declaration in _declared_ports(processor_class):
+        declaration.port_name = attribute_name
+        if isinstance(declaration, LinkInputDataPort):
+            input_ports.append(
+                {
+                    "name": attribute_name,
+                    "description": declaration.description,
+                    "delivery_profile": declaration.delivery_profile,
+                }
+            )
+        else:
+            output_ports.append(
+                {"name": attribute_name, "description": declaration.description}
+            )
+    return input_ports, output_ports
+
+
+def _resolve_type_reference(
+    identity: Optional[str], processor_class: type
+) -> "dict[str, str]":
+    if identity is None:
+        type_name = processor_class.__name__
+        if not _TYPE_NAME_PATTERN.match(type_name):
+            raise ValueError(
+                f"cannot synthesize an `@app/local` identity for class {type_name!r}: a "
+                f"processor type name must be PascalCase (`^[A-Z][A-Za-z0-9]*$`). Give "
+                f"the class a PascalCase name, or declare an explicit "
+                f"`@org/package/Type` identity."
+            )
+        return {"org": "app", "package": "local", "type": type_name}
+
+    if "@" in identity[1:]:
+        raise ValueError(
+            f"processor identity {identity!r} must be version-free "
+            f"`@<org>/<package>/<Type>` with no `@<version>` — versions never appear at "
+            f"the code layer."
+        )
+    match = _IDENTITY_PATTERN.match(identity)
+    if match is None:
+        raise ValueError(
+            f"processor identity {identity!r} must be `@<org>/<package>/<Type>` "
+            f"(exactly three `/`-separated segments, leading `@`)"
+        )
+    organization, package, type_name = match.groups()
+    for value, pattern, label in (
+        (organization, _ORGANIZATION_PATTERN, "org"),
+        (package, _PACKAGE_PATTERN, "package"),
+        (type_name, _TYPE_NAME_PATTERN, "type"),
+    ):
+        if not pattern.match(value):
+            raise ValueError(
+                f"processor identity {identity!r} has an invalid {label} segment "
+                f"{value!r}: must match {pattern.pattern}"
+            )
+    return {"org": organization, "package": package, "type": type_name}
+
+
+def _resolve_execution(
+    execution: Optional[str],
+    interval_ms: int,
+    processor_class: type,
+    *,
+    has_input_ports: bool,
+) -> "dict[str, Any]":
+    if execution is None:
+        if not has_input_ports:
+            raise ValueError(
+                f"{processor_class.__name__} declares no input ports, so it must declare "
+                f"an execution mode: `@processor(execution=\"continuous\", interval_ms=…)` "
+                f"for a source that produces on its own schedule, or "
+                f"`execution=\"manual\"` for one driven by a callback it owns. Only a "
+                f"processor with an input port can default to \"reactive\"."
+            )
+        execution = "reactive"
+
+    if execution not in _EXECUTION_MODES:
+        raise ValueError(
+            f"invalid execution {execution!r}: must be one of "
+            f"{', '.join(_EXECUTION_MODES)}"
+        )
+    if execution != "continuous":
+        return {"mode": execution, "interval_ms": 0}
+
+    if not isinstance(interval_ms, int) or isinstance(interval_ms, bool) or interval_ms < 0:
+        raise ValueError(
+            f"invalid interval_ms {interval_ms!r}: must be a non-negative int"
+        )
+    return {"mode": "continuous", "interval_ms": interval_ms}
+
+
+def _validate_scheduling(scheduling: Optional[str]) -> Optional[str]:
+    if scheduling is None:
+        return None
+    if scheduling not in _SCHEDULING_PRIORITIES:
+        raise ValueError(
+            f"invalid scheduling {scheduling!r}: must be one of "
+            f"{', '.join(_SCHEDULING_PRIORITIES)}"
+        )
+    return scheduling
+
+
+def bind_declared_ports_to_running_processor(
+    processor_instance: Any, link_data_access: Any
+) -> None:
+    """Give a freshly constructed processor its own bound copy of every port.
+
+    Called by the engine, never by app code. The declarations live on the class
+    and are therefore shared by every instance of it, so binding sets a fresh
+    per-instance port on the object rather than mutating what the class holds —
+    two instances of one processor class read different links.
+    """
+    for attribute_name, declaration in _declared_ports(type(processor_instance)):
+        bound: AnyDataPort
+        if isinstance(declaration, LinkInputDataPort):
+            bound = LinkInputDataPort(
+                delivery_profile=declaration.delivery_profile,
+                description=declaration.description,
+            )
+        else:
+            bound = LinkOutputDataPort(description=declaration.description)
+        bound.port_name = attribute_name
+        bound._link_data_access = link_data_access
+        setattr(processor_instance, attribute_name, bound)
+
+
+def _declared_ports(processor_class: type) -> "list[tuple[str, AnyDataPort]]":
+    """Every port declared on the class or inherited, in declaration order.
+
+    Walks the MRO in reverse so a subclass's redeclaration of an inherited port
+    name wins, and a base class's ports are inherited rather than lost.
+    """
+    declarations: "dict[str, AnyDataPort]" = {}
+    for ancestor in reversed(processor_class.__mro__):
+        for attribute_name, attribute in vars(ancestor).items():
+            if isinstance(attribute, (LinkInputDataPort, LinkOutputDataPort)):
+                declarations[attribute_name] = attribute
+    return list(declarations.items())

--- a/sdk/streamlib-python-wheel/python/streamlib/_processor_hosting.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/_processor_hosting.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Turning a declared processor class into a running processor object.
+
+The engine calls into this module rather than constructing the object itself:
+binding a port means creating a per-instance attribute, which is Python's job.
+App code never calls anything here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from ._processor_declaration import bind_declared_ports_to_running_processor
+
+__all__ = ["apply_configuration", "construct_processor_instance"]
+
+
+def construct_processor_instance(
+    processor_class: type,
+    configuration: Optional[Any],
+    link_data_access: Any,
+) -> Any:
+    """Instantiate `processor_class` and bind its declared ports to its links.
+
+    Configuration arrives as the keyword arguments the class was added with, so
+    a processor's settings are ordinary constructor parameters with ordinary
+    Python defaults — there is no configuration object to learn.
+    """
+    keyword_arguments = _as_keyword_arguments(processor_class, configuration)
+    try:
+        processor_instance = processor_class(**keyword_arguments)
+    except TypeError as construction_failure:
+        raise TypeError(
+            f"{processor_class.__name__}({_render_call(keyword_arguments)}) failed: "
+            f"{construction_failure}. `rt.add(cls, config={{...}})` passes config as "
+            f"keyword arguments to the class."
+        ) from construction_failure
+
+    bind_declared_ports_to_running_processor(processor_instance, link_data_access)
+    return processor_instance
+
+
+def apply_configuration(processor_instance: Any, configuration: Optional[Any]) -> None:
+    """Hand a live processor a configuration update.
+
+    Only processors that define `configure` accept one; for anything else a
+    config change means a new pipeline, which is what re-running `dev` does.
+    """
+    reconfigure = getattr(processor_instance, "configure", None)
+    if reconfigure is None:
+        raise TypeError(
+            f"{type(processor_instance).__name__} cannot be reconfigured while running: "
+            f"define `configure(self, **config)` on it to accept updates."
+        )
+    reconfigure(**_as_keyword_arguments(type(processor_instance), configuration))
+
+
+def _as_keyword_arguments(
+    processor_class: type, configuration: Optional[Any]
+) -> "dict[str, Any]":
+    if configuration is None:
+        return {}
+    if not isinstance(configuration, dict):
+        raise TypeError(
+            f"config for {processor_class.__name__} must be a dict of keyword arguments, "
+            f"got {type(configuration).__name__}"
+        )
+    non_string_keys = [key for key in configuration if not isinstance(key, str)]
+    if non_string_keys:
+        raise TypeError(
+            f"config keys for {processor_class.__name__} must be strings — they become "
+            f"keyword arguments; got {non_string_keys!r}"
+        )
+    return dict(configuration)
+
+
+def _render_call(keyword_arguments: "dict[str, Any]") -> str:
+    return ", ".join(f"{name}={value!r}" for name, value in keyword_arguments.items())

--- a/sdk/streamlib-python-wheel/python/streamlib/_processor_hosting.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/_processor_hosting.py
@@ -4,15 +4,13 @@
 """Turning a declared processor class into a running processor object.
 
 The engine calls into this module rather than constructing the object itself:
-binding a port means creating a per-instance attribute, which is Python's job.
-App code never calls anything here.
+mapping configuration onto constructor keywords is Python's job. App code
+never calls anything here.
 """
 
 from __future__ import annotations
 
 from typing import Any, Optional
-
-from ._processor_declaration import bind_declared_ports_to_running_processor
 
 __all__ = ["apply_configuration", "construct_processor_instance"]
 
@@ -20,26 +18,25 @@ __all__ = ["apply_configuration", "construct_processor_instance"]
 def construct_processor_instance(
     processor_class: type,
     configuration: Optional[Any],
-    link_data_access: Any,
+    _link_data_access: Any,
 ) -> Any:
-    """Instantiate `processor_class` and bind its declared ports to its links.
+    """Instantiate `processor_class` with its configuration.
 
     Configuration arrives as the keyword arguments the class was added with, so
     a processor's settings are ordinary constructor parameters with ordinary
-    Python defaults — there is no configuration object to learn.
+    Python defaults — there is no configuration object to learn. The link data
+    access argument is unused: ports are reached through `ctx.inputs` /
+    `ctx.outputs`, but the host still passes it, so the arity stays.
     """
     keyword_arguments = _as_keyword_arguments(processor_class, configuration)
     try:
-        processor_instance = processor_class(**keyword_arguments)
+        return processor_class(**keyword_arguments)
     except TypeError as construction_failure:
         raise TypeError(
             f"{processor_class.__name__}({_render_call(keyword_arguments)}) failed: "
             f"{construction_failure}. `rt.add(cls, config={{...}})` passes config as "
             f"keyword arguments to the class."
         ) from construction_failure
-
-    bind_declared_ports_to_running_processor(processor_instance, link_data_access)
-    return processor_instance
 
 
 def apply_configuration(processor_instance: Any, configuration: Optional[Any]) -> None:

--- a/sdk/streamlib-python-wheel/python/streamlib/clock.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/clock.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Canonical monotonic-clock timestamp source and drift-free periodic timer.
+
+Use [`monotonic_now_ns`] for any timestamp that needs to be compared across
+processes — frame stamps, log correlation tokens, anything that crosses a
+process boundary. It reads `clock_gettime(CLOCK_MONOTONIC)`, the same kernel
+syscall Rust's `Instant::now()` and Python's
+`time.clock_gettime_ns(time.CLOCK_MONOTONIC)` make, so values from all of them
+share the kernel's monotonic epoch and are directly comparable.
+
+Wall-clock APIs (`time.time`, `datetime.now`, `time.time_ns`) are NOT
+comparable across processes — they drift under NTP and reflect different
+epochs. Use them only when human-readable wall-clock time is genuinely
+required (e.g. ISO8601 log formatting).
+
+[`MonotonicTimer`] is a drift-free periodic timer backed by
+`timerfd_create(CLOCK_MONOTONIC)`: the first absolute deadline is
+`now + interval`, then `TFD_TIMER_ABSTIME` repeats, so ticks never accumulate
+drift. Use it as a context manager; `wait(timeout_ms=...)` bounds teardown
+latency.
+"""
+
+from __future__ import annotations
+
+from ._engine import MonotonicTimer as MonotonicTimer
+from ._engine import monotonic_now_ns as monotonic_now_ns
+
+__all__ = ["MonotonicTimer", "monotonic_now_ns"]

--- a/sdk/streamlib-python-wheel/python/streamlib/log.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/log.py
@@ -3,9 +3,9 @@
 
 """Logging from a processor, straight onto the engine's log pipeline.
 
-`print()` also works, but while the engine is alive it is captured and re-emitted
-at WARN by the stdio interceptor. These functions carry the level the author
-meant and interleave in order with the engine's own records.
+Writing to stdout also works, but while the engine is alive the stdio
+interceptor captures it and re-emits it at WARN. These functions carry the level
+the author meant and interleave in order with the engine's own records.
 """
 
 from __future__ import annotations
@@ -14,29 +14,29 @@ from ._engine import log_event
 
 __all__ = ["debug", "error", "info", "trace", "warning"]
 
-_DEFAULT_TARGET = "app"
+_DEFAULT_EMITTER = "app"
 
 
-def trace(message: str, *, target: str = _DEFAULT_TARGET) -> None:
+def trace(message: str, *, emitted_by: str = _DEFAULT_EMITTER) -> None:
     """Emit a TRACE record."""
-    log_event("trace", target, message)
+    log_event("trace", emitted_by, message)
 
 
-def debug(message: str, *, target: str = _DEFAULT_TARGET) -> None:
+def debug(message: str, *, emitted_by: str = _DEFAULT_EMITTER) -> None:
     """Emit a DEBUG record."""
-    log_event("debug", target, message)
+    log_event("debug", emitted_by, message)
 
 
-def info(message: str, *, target: str = _DEFAULT_TARGET) -> None:
+def info(message: str, *, emitted_by: str = _DEFAULT_EMITTER) -> None:
     """Emit an INFO record."""
-    log_event("info", target, message)
+    log_event("info", emitted_by, message)
 
 
-def warning(message: str, *, target: str = _DEFAULT_TARGET) -> None:
+def warning(message: str, *, emitted_by: str = _DEFAULT_EMITTER) -> None:
     """Emit a WARN record."""
-    log_event("warn", target, message)
+    log_event("warn", emitted_by, message)
 
 
-def error(message: str, *, target: str = _DEFAULT_TARGET) -> None:
+def error(message: str, *, emitted_by: str = _DEFAULT_EMITTER) -> None:
     """Emit an ERROR record."""
-    log_event("error", target, message)
+    log_event("error", emitted_by, message)

--- a/sdk/streamlib-python-wheel/python/streamlib/log.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/log.py
@@ -4,39 +4,45 @@
 """Logging from a processor, straight onto the engine's log pipeline.
 
 Writing to stdout also works, but while the engine is alive the stdio
-interceptor captures it and re-emits it at WARN. These functions carry the level
-the author meant and interleave in order with the engine's own records.
+interceptor captures it and re-emits it at WARN. These functions carry the
+level the author meant and interleave in order with the engine's own records.
+Keyword arguments become the structured `attrs` columns of the JSONL record —
+`log.info("captured frame", width=1920)` — and processor attribution is
+automatic inside lifecycle hooks; nothing needs to be threaded through.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
 from ._engine import log_event
 
-__all__ = ["debug", "error", "info", "trace", "warning"]
-
-_DEFAULT_EMITTER = "app"
+__all__ = ["debug", "error", "info", "trace", "warn", "warning"]
 
 
-def trace(message: str, *, emitted_by: str = _DEFAULT_EMITTER) -> None:
+def trace(message: str, **attrs: Any) -> None:
     """Emit a TRACE record."""
-    log_event("trace", emitted_by, message)
+    log_event("trace", message, attrs or None)
 
 
-def debug(message: str, *, emitted_by: str = _DEFAULT_EMITTER) -> None:
+def debug(message: str, **attrs: Any) -> None:
     """Emit a DEBUG record."""
-    log_event("debug", emitted_by, message)
+    log_event("debug", message, attrs or None)
 
 
-def info(message: str, *, emitted_by: str = _DEFAULT_EMITTER) -> None:
+def info(message: str, **attrs: Any) -> None:
     """Emit an INFO record."""
-    log_event("info", emitted_by, message)
+    log_event("info", message, attrs or None)
 
 
-def warning(message: str, *, emitted_by: str = _DEFAULT_EMITTER) -> None:
+def warn(message: str, **attrs: Any) -> None:
     """Emit a WARN record."""
-    log_event("warn", emitted_by, message)
+    log_event("warn", message, attrs or None)
 
 
-def error(message: str, *, emitted_by: str = _DEFAULT_EMITTER) -> None:
+warning = warn
+
+
+def error(message: str, **attrs: Any) -> None:
     """Emit an ERROR record."""
-    log_event("error", emitted_by, message)
+    log_event("error", message, attrs or None)

--- a/sdk/streamlib-python-wheel/python/streamlib/log.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/log.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Logging from a processor, straight onto the engine's log pipeline.
+
+`print()` also works, but while the engine is alive it is captured and re-emitted
+at WARN by the stdio interceptor. These functions carry the level the author
+meant and interleave in order with the engine's own records.
+"""
+
+from __future__ import annotations
+
+from ._engine import log_event
+
+__all__ = ["debug", "error", "info", "trace", "warning"]
+
+_DEFAULT_TARGET = "app"
+
+
+def trace(message: str, *, target: str = _DEFAULT_TARGET) -> None:
+    """Emit a TRACE record."""
+    log_event("trace", target, message)
+
+
+def debug(message: str, *, target: str = _DEFAULT_TARGET) -> None:
+    """Emit a DEBUG record."""
+    log_event("debug", target, message)
+
+
+def info(message: str, *, target: str = _DEFAULT_TARGET) -> None:
+    """Emit an INFO record."""
+    log_event("info", target, message)
+
+
+def warning(message: str, *, target: str = _DEFAULT_TARGET) -> None:
+    """Emit a WARN record."""
+    log_event("warn", target, message)
+
+
+def error(message: str, *, target: str = _DEFAULT_TARGET) -> None:
+    """Emit an ERROR record."""
+    log_event("error", target, message)

--- a/sdk/streamlib-python-wheel/python/streamlib/schema_ident.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/schema_ident.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Structured schema identity for the streamlib Python SDK.
+
+Mirrors Rust's `streamlib_idents::SchemaIdent` shape: 4 validating fields
+(`org`, `package`, `type_`, `version`) constructed directly. There is no
+parse / from-string API — joined-string representations like
+`"@org/pkg/Type@v"` are render-only (`__str__`) and never round-trip
+through a parser.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Pattern
+
+# Validation patterns mirror Rust's `streamlib_idents` newtypes.
+_ORG_PATTERN: Pattern[str] = re.compile(r"^[a-z][a-z0-9-]*$")
+_PACKAGE_PATTERN: Pattern[str] = re.compile(r"^[a-z][a-z0-9-]*$")
+_TYPE_PATTERN: Pattern[str] = re.compile(r"^[A-Z][A-Za-z0-9]*$")
+_VERSION_PATTERN: Pattern[str] = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+@dataclass(frozen=True)
+class SchemaIdent:
+    """Structured schema identifier — 4 fields, validated at construction."""
+
+    org: str
+    package: str
+    type_: str
+    version: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.org, str) or not _ORG_PATTERN.match(self.org):
+            raise ValueError(
+                f"invalid org {self.org!r}: must match [a-z][a-z0-9-]*"
+            )
+        if not isinstance(self.package, str) or not _PACKAGE_PATTERN.match(self.package):
+            raise ValueError(
+                f"invalid package {self.package!r}: must match [a-z][a-z0-9-]*"
+            )
+        if not isinstance(self.type_, str) or not _TYPE_PATTERN.match(self.type_):
+            raise ValueError(
+                f"invalid type {self.type_!r}: must match [A-Z][A-Za-z0-9]* (PascalCase)"
+            )
+        if not isinstance(self.version, str) or not _VERSION_PATTERN.match(self.version):
+            raise ValueError(
+                f"invalid version {self.version!r}: must match major.minor.patch"
+            )
+
+    def __str__(self) -> str:
+        return f"@{self.org}/{self.package}/{self.type_}@{self.version}"
+
+    def to_wire_dict(self) -> dict:
+        """Render as the IPC wire-format dict.
+
+        Used by callers that need to hand the structured ident to JSON-RPC
+        / iceoryx2 envelopes that already speak the 4-field shape.
+        """
+        return {
+            "org": self.org,
+            "package": self.package,
+            "type": self.type_,
+            "version": self.version,
+        }

--- a/sdk/streamlib-python-wheel/python/streamlib/testing.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/testing.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import itertools
 import queue
 import threading
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional
 
 from . import Runtime
 from ._processor_declaration import (
@@ -192,8 +192,11 @@ class SingleProcessorTestPipeline:
             _running_pipeline_lock.release()
         return False
 
-    def feed(self, port_name: str, bag: Any) -> None:
-        """Queue one bag for delivery to the processor's `port_name` input."""
+    def feed(self, port_name: str, bag: "Mapping[str, Any]") -> None:
+        """Queue one bag for delivery to the processor's `port_name` input.
+
+        A bag is a named map, same as anything a processor writes.
+        """
         _fed_bags[self._channel_for(self._input_channels, port_name, "input")].put(bag)
 
     def await_bag(

--- a/sdk/streamlib-python-wheel/python/streamlib/testing.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/testing.py
@@ -18,11 +18,8 @@ import threading
 from typing import Any, Dict, Mapping, Optional
 
 from . import Runtime
-from ._processor_declaration import (
-    LinkInputDataPort,
-    LinkOutputDataPort,
-    processor,
-)
+from ._engine import RuntimeContextLimitedAccess
+from ._processor_declaration import input, output, processor
 
 __all__ = ["SingleProcessorTestPipeline"]
 
@@ -55,17 +52,18 @@ _running_pipeline_lock = threading.Lock()
 class TestBagFeeder:
     """Publishes whatever a test hands it, in order."""
 
-    bags_to_downstream = LinkOutputDataPort()
-
     def __init__(self, channel: str) -> None:
         self.channel = channel
 
-    def process(self) -> None:
+    @output()
+    def bags_to_downstream(self) -> None: ...
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
         try:
             bag = _fed_bags[self.channel].get_nowait()
         except queue.Empty:
             return
-        self.bags_to_downstream.write(bag)
+        ctx.outputs.write("bags_to_downstream", bag)
 
 
 @processor("@streamlib/testing/TestBagCollector", execution="reactive")
@@ -76,13 +74,14 @@ class TestBagCollector:
     so dropping a bag under a burst would make the assertion lie.
     """
 
-    bags_from_upstream = LinkInputDataPort(delivery_profile="every_sample")
-
     def __init__(self, channel: str) -> None:
         self.channel = channel
 
-    def process(self) -> None:
-        bag = self.bags_from_upstream.read()
+    @input(delivery_profile="every_sample")
+    def bags_from_upstream(self) -> None: ...
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        bag = ctx.inputs.read("bags_from_upstream")
         if bag is not None:
             _collected_bags[self.channel].put(bag)
 

--- a/sdk/streamlib-python-wheel/python/streamlib/testing.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/testing.py
@@ -8,10 +8,6 @@ a test exercises is what production runs — the same construction, the same
 lifecycle hooks, the same links. What it does not need is hardware: the frames
 come from this module's own feeder processor rather than a camera, and the
 output lands in a queue rather than a window.
-
-    with SingleProcessorTestPipeline(BrightnessFilter, config={"gain": 2.0}) as pipeline:
-        pipeline.feed("frames_from_upstream", {"value": 21})
-        assert pipeline.await_bag("frames_to_downstream") == {"value": 42}
 """
 
 from __future__ import annotations

--- a/sdk/streamlib-python-wheel/python/streamlib/testing.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/testing.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Drive one processor from a test: feed its inputs, assert on its outputs.
+
+The processor under test runs in a real graph on a real engine thread, so what
+a test exercises is what production runs — the same construction, the same
+lifecycle hooks, the same links. What it does not need is hardware: the frames
+come from this module's own feeder processor rather than a camera, and the
+output lands in a queue rather than a window.
+
+    with SingleProcessorTestPipeline(BrightnessFilter, config={"gain": 2.0}) as pipeline:
+        pipeline.feed("frames_from_upstream", {"value": 21})
+        assert pipeline.await_bag("frames_to_downstream") == {"value": 42}
+"""
+
+from __future__ import annotations
+
+import itertools
+import queue
+import threading
+from typing import Any, Dict, Optional
+
+from . import Runtime
+from ._processor_declaration import (
+    LinkInputDataPort,
+    LinkOutputDataPort,
+    processor,
+)
+
+__all__ = ["SingleProcessorTestPipeline"]
+
+# Long enough that a cold engine's first frame is not mistaken for a failure,
+# short enough that a genuinely stalled pipeline fails rather than hangs.
+DEFAULT_BAG_TIMEOUT_SECONDS = 30.0
+
+# How long to wait for the engine to finish tearing down before deciding it
+# hung. A hang here is the defect; a timeout turns it into a failed test with a
+# diagnostic rather than a wedged test run.
+ENGINE_TEARDOWN_TIMEOUT_SECONDS = 60.0
+
+# The queues the feeder and collector processors reach. They cannot travel as
+# configuration — configuration is JSON on the graph node — so the graph carries
+# a channel name and this module holds the queue it names. Safe because the
+# processors run in this same interpreter, which is the whole point of
+# in-process placement.
+_fed_bags: "Dict[str, queue.Queue[Any]]" = {}
+_collected_bags: "Dict[str, queue.Queue[Any]]" = {}
+_next_channel_number = itertools.count()
+_channel_lock = threading.Lock()
+
+# Shutdown signals are owned by one run loop per process, so two pipelines
+# cannot run at once. Caught here rather than left to the engine's
+# "signals are already owned" error, which does not say what to do about it.
+_running_pipeline_lock = threading.Lock()
+
+
+@processor("@streamlib/testing/TestBagFeeder", execution="continuous", interval_ms=1)
+class TestBagFeeder:
+    """Publishes whatever a test hands it, in order."""
+
+    bags_to_downstream = LinkOutputDataPort()
+
+    def __init__(self, channel: str) -> None:
+        self.channel = channel
+
+    def process(self) -> None:
+        try:
+            bag = _fed_bags[self.channel].get_nowait()
+        except queue.Empty:
+            return
+        self.bags_to_downstream.write(bag)
+
+
+@processor("@streamlib/testing/TestBagCollector", execution="reactive")
+class TestBagCollector:
+    """Collects everything the processor under test produces.
+
+    `every_sample` rather than the default: a test asserts on what was produced,
+    so dropping a bag under a burst would make the assertion lie.
+    """
+
+    bags_from_upstream = LinkInputDataPort(delivery_profile="every_sample")
+
+    def __init__(self, channel: str) -> None:
+        self.channel = channel
+
+    def process(self) -> None:
+        bag = self.bags_from_upstream.read()
+        if bag is not None:
+            _collected_bags[self.channel].put(bag)
+
+
+class SingleProcessorTestPipeline:
+    """One processor, with a feeder on every input and a collector on every output."""
+
+    def __init__(
+        self,
+        processor_class: type,
+        *,
+        config: "Optional[Dict[str, Any]]" = None,
+    ) -> None:
+        self._processor_class = processor_class
+        self._config = config
+        self._input_channels: "Dict[str, str]" = {}
+        self._output_channels: "Dict[str, str]" = {}
+        self._runtime: Optional[Runtime] = None
+        self._run_loop: Optional[threading.Thread] = None
+        self._run_failure: "queue.Queue[BaseException]" = queue.Queue()
+
+    def __enter__(self) -> "SingleProcessorTestPipeline":
+        if not _running_pipeline_lock.acquire(blocking=False):
+            raise RuntimeError(
+                "another SingleProcessorTestPipeline is still running in this process: "
+                "one engine owns the process's shutdown signals, so pipelines run one at "
+                "a time. Close the first `with` block before opening the second."
+            )
+        try:
+            self._build_and_start()
+        except BaseException:
+            # Nothing is running yet, so tear down what was built and hand the
+            # slot back — a pipeline that failed to start must not lock every
+            # later test in the process out of the engine.
+            self.__exit__()
+            raise
+        return self
+
+    def _build_and_start(self) -> None:
+        runtime = Runtime()
+        self._runtime = runtime
+        processor_under_test = runtime.add(self._processor_class, config=self._config)
+
+        for port in _declared_port_names(self._processor_class, "input"):
+            channel = _claim_channel(_fed_bags)
+            self._input_channels[port] = channel
+            feeder = runtime.add(
+                TestBagFeeder,
+                config={"channel": channel},
+                display_name=f"TestBagFeeder({port})",
+            )
+            runtime.connect(
+                feeder.output("bags_to_downstream"), processor_under_test.input(port)
+            )
+
+        for port in _declared_port_names(self._processor_class, "output"):
+            channel = _claim_channel(_collected_bags)
+            self._output_channels[port] = channel
+            collector = runtime.add(
+                TestBagCollector,
+                config={"channel": channel},
+                display_name=f"TestBagCollector({port})",
+            )
+            runtime.connect(
+                processor_under_test.output(port),
+                collector.input("bags_from_upstream"),
+            )
+
+        # `run()` blocks, and a test needs to stay in control of the main
+        # thread. It is safe here because `__exit__` shuts the engine down and
+        # joins this thread before the test returns, so interpreter
+        # finalization never races the teardown running on it.
+        self._run_loop = threading.Thread(
+            target=self._run_until_shut_down, name="streamlib-test-pipeline", daemon=True
+        )
+        self._run_loop.start()
+
+    def _run_until_shut_down(self) -> None:
+        try:
+            assert self._runtime is not None
+            self._runtime.run()
+        except BaseException as run_failure:  # noqa: BLE001 — re-raised in __exit__
+            self._run_failure.put(run_failure)
+
+    def __exit__(self, *_exception_details: Any) -> bool:
+        try:
+            if self._runtime is not None:
+                self._runtime.shutdown()
+            if self._run_loop is not None:
+                self._run_loop.join(timeout=ENGINE_TEARDOWN_TIMEOUT_SECONDS)
+                if self._run_loop.is_alive():
+                    raise AssertionError(
+                        f"the engine did not tear down within "
+                        f"{ENGINE_TEARDOWN_TIMEOUT_SECONDS}s — a processor thread is still "
+                        f"running, or teardown is blocked on one"
+                    )
+            for channel in self._input_channels.values():
+                _fed_bags.pop(channel, None)
+            for channel in self._output_channels.values():
+                _collected_bags.pop(channel, None)
+
+            try:
+                raise self._run_failure.get_nowait()
+            except queue.Empty:
+                pass
+        finally:
+            _running_pipeline_lock.release()
+        return False
+
+    def feed(self, port_name: str, bag: Any) -> None:
+        """Queue one bag for delivery to the processor's `port_name` input."""
+        _fed_bags[self._channel_for(self._input_channels, port_name, "input")].put(bag)
+
+    def await_bag(
+        self, port_name: str, *, timeout: float = DEFAULT_BAG_TIMEOUT_SECONDS
+    ) -> Any:
+        """The next bag the processor produced on `port_name`.
+
+        Raises rather than blocking forever: a processor that never produces is
+        the failure a test is looking for.
+        """
+        channel = self._channel_for(self._output_channels, port_name, "output")
+        try:
+            return _collected_bags[channel].get(timeout=timeout)
+        except queue.Empty:
+            raise AssertionError(
+                f"{self._processor_class.__name__} produced nothing on {port_name!r} "
+                f"within {timeout}s"
+            ) from None
+
+    def await_bags(
+        self, port_name: str, count: int, *, timeout: float = DEFAULT_BAG_TIMEOUT_SECONDS
+    ) -> "list[Any]":
+        """The next `count` bags on `port_name`, in order."""
+        return [self.await_bag(port_name, timeout=timeout) for _ in range(count)]
+
+    def _channel_for(
+        self, channels: "Dict[str, str]", port_name: str, direction: str
+    ) -> str:
+        try:
+            return channels[port_name]
+        except KeyError:
+            raise KeyError(
+                f"{self._processor_class.__name__} declares no {direction} port "
+                f"{port_name!r}; it declares {sorted(channels) or 'none'}"
+            ) from None
+
+
+def _declared_port_names(processor_class: type, direction: str) -> "list[str]":
+    declared = getattr(
+        processor_class, f"__streamlib_processor_{direction}_ports__", None
+    )
+    if declared is None:
+        raise TypeError(
+            f"{processor_class.__name__} is not a processor: decorate it with "
+            f"@streamlib.processor"
+        )
+    return [port["name"] for port in declared]
+
+
+def _claim_channel(channels: "Dict[str, queue.Queue[Any]]") -> str:
+    with _channel_lock:
+        channel = f"channel-{next(_next_channel_number)}"
+    channels[channel] = queue.Queue()
+    return channel

--- a/sdk/streamlib-python-wheel/src/lib.rs
+++ b/sdk/streamlib-python-wheel/src/lib.rs
@@ -24,7 +24,10 @@ fn _engine(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<python_added_processor::PythonProcessorOutputPortReference>()?;
     module.add_class::<python_added_processor::PythonProcessorInputPortReference>()?;
     module.add_class::<python_processor_link_data_access::PythonProcessorLinkDataAccess>()?;
-    module.add_function(wrap_pyfunction!(python_logging::media_clock_now_ns, module)?)?;
+    module.add_function(wrap_pyfunction!(
+        python_logging::media_clock_now_ns,
+        module
+    )?)?;
     module.add_function(wrap_pyfunction!(python_logging::log_event, module)?)?;
     Ok(())
 }

--- a/sdk/streamlib-python-wheel/src/lib.rs
+++ b/sdk/streamlib-python-wheel/src/lib.rs
@@ -9,6 +9,8 @@ use pyo3::prelude::*;
 mod python_added_processor;
 mod python_bag_conversion;
 mod python_logging;
+mod python_monotonic_timer;
+mod python_processor_context;
 mod python_processor_declaration;
 mod python_processor_host;
 mod python_processor_link_data_access;
@@ -24,10 +26,19 @@ fn _engine(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<python_added_processor::PythonProcessorOutputPortReference>()?;
     module.add_class::<python_added_processor::PythonProcessorInputPortReference>()?;
     module.add_class::<python_processor_link_data_access::PythonProcessorLinkDataAccess>()?;
+    module.add_class::<python_processor_context::PythonRuntimeContextFullAccess>()?;
+    module.add_class::<python_processor_context::PythonRuntimeContextLimitedAccess>()?;
+    module.add_class::<python_processor_context::PythonGpuContextFullAccess>()?;
+    module.add_class::<python_processor_context::PythonGpuContextLimitedAccess>()?;
+    module.add_class::<python_processor_context::PythonGpuSurfaceHandle>()?;
+    module.add_class::<python_processor_context::PythonLinkInputDataReader>()?;
+    module.add_class::<python_processor_context::PythonLinkOutputDataWriter>()?;
+    module.add_class::<python_monotonic_timer::PythonMonotonicTimer>()?;
     module.add_function(wrap_pyfunction!(
         python_logging::media_clock_now_ns,
         module
     )?)?;
+    module.add_function(wrap_pyfunction!(python_logging::monotonic_now_ns, module)?)?;
     module.add_function(wrap_pyfunction!(python_logging::log_event, module)?)?;
     Ok(())
 }

--- a/sdk/streamlib-python-wheel/src/lib.rs
+++ b/sdk/streamlib-python-wheel/src/lib.rs
@@ -6,6 +6,13 @@
 
 use pyo3::prelude::*;
 
+mod python_added_processor;
+mod python_bag_conversion;
+mod python_logging;
+mod python_processor_declaration;
+mod python_processor_host;
+mod python_processor_link_data_access;
+mod python_processor_registration;
 mod python_runtime_lifecycle;
 
 pub use python_runtime_lifecycle::PythonRuntimeHandle;
@@ -13,5 +20,11 @@ pub use python_runtime_lifecycle::PythonRuntimeHandle;
 #[pymodule]
 fn _engine(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PythonRuntimeHandle>()?;
+    module.add_class::<python_added_processor::PythonAddedProcessor>()?;
+    module.add_class::<python_added_processor::PythonProcessorOutputPortReference>()?;
+    module.add_class::<python_added_processor::PythonProcessorInputPortReference>()?;
+    module.add_class::<python_processor_link_data_access::PythonProcessorLinkDataAccess>()?;
+    module.add_function(wrap_pyfunction!(python_logging::media_clock_now_ns, module)?)?;
+    module.add_function(wrap_pyfunction!(python_logging::log_event, module)?)?;
     Ok(())
 }

--- a/sdk/streamlib-python-wheel/src/python_added_processor.rs
+++ b/sdk/streamlib-python-wheel/src/python_added_processor.rs
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! What `Runtime.add` hands back, and what `Runtime.connect` takes.
+//!
+//! Ports are named through the processor they belong to
+//! (`camera.output("frames_to_downstream")`) so a link always reads as an
+//! endpoint of something, never as a bare string pair.
+
+use pyo3::prelude::*;
+
+/// A processor in the graph.
+#[pyclass(name = "AddedProcessor", module = "streamlib", frozen)]
+pub(crate) struct PythonAddedProcessor {
+    processor_id: String,
+    display_name: String,
+}
+
+impl PythonAddedProcessor {
+    pub(crate) fn new(processor_id: String, display_name: String) -> Self {
+        Self {
+            processor_id,
+            display_name,
+        }
+    }
+}
+
+#[pymethods]
+impl PythonAddedProcessor {
+    /// The engine's id for this processor — what `streamlib graph` shows.
+    #[getter]
+    fn processor_id(&self) -> &str {
+        &self.processor_id
+    }
+
+    /// The processor's display name in the graph.
+    #[getter]
+    fn display_name(&self) -> &str {
+        &self.display_name
+    }
+
+    /// Name one of this processor's output ports, to connect it downstream.
+    fn output(&self, port_name: &str) -> PythonProcessorOutputPortReference {
+        PythonProcessorOutputPortReference {
+            processor_id: self.processor_id.clone(),
+            port_name: port_name.to_string(),
+        }
+    }
+
+    /// Name one of this processor's input ports, to connect it upstream.
+    fn input(&self, port_name: &str) -> PythonProcessorInputPortReference {
+        PythonProcessorInputPortReference {
+            processor_id: self.processor_id.clone(),
+            port_name: port_name.to_string(),
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "AddedProcessor(display_name={:?}, processor_id={:?})",
+            self.display_name, self.processor_id
+        )
+    }
+}
+
+/// The producing end of a link.
+#[pyclass(name = "ProcessorOutputPortReference", module = "streamlib", frozen)]
+pub(crate) struct PythonProcessorOutputPortReference {
+    pub(crate) processor_id: String,
+    pub(crate) port_name: String,
+}
+
+#[pymethods]
+impl PythonProcessorOutputPortReference {
+    fn __repr__(&self) -> String {
+        format!(
+            "ProcessorOutputPortReference({}.{})",
+            self.processor_id, self.port_name
+        )
+    }
+}
+
+/// The consuming end of a link.
+#[pyclass(name = "ProcessorInputPortReference", module = "streamlib", frozen)]
+pub(crate) struct PythonProcessorInputPortReference {
+    pub(crate) processor_id: String,
+    pub(crate) port_name: String,
+}
+
+#[pymethods]
+impl PythonProcessorInputPortReference {
+    fn __repr__(&self) -> String {
+        format!(
+            "ProcessorInputPortReference({}.{})",
+            self.processor_id, self.port_name
+        )
+    }
+}

--- a/sdk/streamlib-python-wheel/src/python_bag_conversion.rs
+++ b/sdk/streamlib-python-wheel/src/python_bag_conversion.rs
@@ -13,10 +13,28 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PyString, PyTuple};
 use rmpv::Value;
 
-/// Encode a Python object to the msgpack bytes the wire carries.
-pub(crate) fn encode_python_object_to_msgpack(value: &Bound<'_, PyAny>) -> PyResult<Vec<u8>> {
+/// Encode a bag to the msgpack bytes the wire carries.
+///
+/// A bag is a named map — a dict with string keys — because that is what the
+/// wire format is, not a convention this layer invented: a Rust processor
+/// downstream deserializes the payload into a struct, which needs named fields.
+/// A list, a bare scalar, or a dict with non-string keys encodes to msgpack
+/// fine and then cannot be read on the other side, so it is refused here rather
+/// than published as bytes only Python can decode.
+pub(crate) fn encode_bag_to_msgpack(bag: &Bound<'_, PyAny>) -> PyResult<Vec<u8>> {
+    let named_map = bag.cast::<PyDict>().map_err(|_| {
+        PyTypeError::new_err(format!(
+            "a bag is a dict with string keys — the wire carries a named map, and a \
+             {} cannot be read as one by a processor in another language. Wrap it: \
+             `{{\"value\": …}}`.",
+            bag.get_type()
+                .name()
+                .map_or_else(|_| "value".to_string(), |type_name| type_name.to_string())
+        ))
+    })?;
+
     let mut encoded = Vec::new();
-    rmpv::encode::write_value(&mut encoded, &python_object_to_msgpack_value(value)?)
+    rmpv::encode::write_value(&mut encoded, &named_map_to_msgpack_value(named_map)?)
         .map_err(|encode_failure| PyValueError::new_err(encode_failure.to_string()))?;
     Ok(encoded)
 }
@@ -94,14 +112,10 @@ fn python_object_to_msgpack_value(value: &Bound<'_, PyAny>) -> PyResult<Value> {
         return Ok(Value::Binary(bytes.as_bytes().to_vec()));
     }
     if let Ok(mapping) = value.cast::<PyDict>() {
-        let mut entries = Vec::with_capacity(mapping.len());
-        for (key, entry) in mapping.iter() {
-            entries.push((
-                python_object_to_msgpack_value(&key)?,
-                python_object_to_msgpack_value(&entry)?,
-            ));
-        }
-        return Ok(Value::Map(entries));
+        return match msgpack_extension_from_python_mapping(mapping)? {
+            Some(extension) => Ok(extension),
+            None => named_map_to_msgpack_value(mapping),
+        };
     }
     if let Ok(sequence) = value.cast::<PyList>() {
         return sequence_to_msgpack_array(sequence.iter());
@@ -114,6 +128,57 @@ fn python_object_to_msgpack_value(value: &Bound<'_, PyAny>) -> PyResult<Value> {
          float, bool and None. A GPU frame is not copied into Python — it travels as a handle.",
         value.get_type().name()?
     )))
+}
+
+/// The keys a decoded msgpack extension value is carried under.
+///
+/// An extension type is somebody else's payload, so decoding renders it as data
+/// a processor can look at and encoding puts it back exactly as it was — a
+/// passthrough processor must not rewrite what it only forwards.
+const EXTENSION_TYPE_KEY: &str = "__msgpack_ext_type__";
+const EXTENSION_DATA_KEY: &str = "__msgpack_ext_data__";
+
+/// Recognize the shape [`msgpack_value_to_python_object`] decodes an extension
+/// value into, so it re-encodes as one.
+fn msgpack_extension_from_python_mapping(mapping: &Bound<'_, PyDict>) -> PyResult<Option<Value>> {
+    if mapping.len() != 2 {
+        return Ok(None);
+    }
+    let (Some(type_tag), Some(data)) = (
+        mapping.get_item(EXTENSION_TYPE_KEY)?,
+        mapping.get_item(EXTENSION_DATA_KEY)?,
+    ) else {
+        return Ok(None);
+    };
+    let (Ok(type_tag), Ok(data)) = (type_tag.extract::<i8>(), data.cast::<PyBytes>()) else {
+        return Ok(None);
+    };
+    Ok(Some(Value::Ext(type_tag, data.as_bytes().to_vec())))
+}
+
+/// Encode a dict, requiring string keys at every level.
+///
+/// msgpack maps allow any key type, but a named map is what every other
+/// language on the wire deserializes into a struct — an int-keyed map would
+/// encode and then fail to read there.
+fn named_map_to_msgpack_value(mapping: &Bound<'_, PyDict>) -> PyResult<Value> {
+    let mut entries = Vec::with_capacity(mapping.len());
+    for (key, entry) in mapping.iter() {
+        let key = key.cast::<PyString>().map_err(|_| {
+            PyTypeError::new_err(format!(
+                "bag keys must be strings — the wire carries a named map; got a {} key",
+                key.get_type().name().map_or_else(
+                    |_| "non-string".to_string(),
+                    |type_name| type_name.to_string()
+                )
+            ))
+        })?;
+        entries.push((
+            Value::from(key.to_cow()?.into_owned()),
+            python_object_to_msgpack_value(&entry)?,
+        ));
+    }
+    Ok(Value::Map(entries))
 }
 
 fn sequence_to_msgpack_array<'py>(
@@ -169,12 +234,9 @@ fn msgpack_value_to_python_object<'py>(
             mapping.into_any()
         }
         Value::Ext(type_tag, bytes) => {
-            // Preserved rather than dropped: an extension type is somebody
-            // else's payload, and a processor that only forwards a bag must be
-            // able to hand it on unchanged.
             let extension = PyDict::new(python);
-            extension.set_item("__msgpack_ext_type__", type_tag)?;
-            extension.set_item("__msgpack_ext_data__", PyBytes::new(python, bytes))?;
+            extension.set_item(EXTENSION_TYPE_KEY, type_tag)?;
+            extension.set_item(EXTENSION_DATA_KEY, PyBytes::new(python, bytes))?;
             extension.into_any()
         }
     };
@@ -206,7 +268,7 @@ mod tests {
             nested.set_item("inner", "value").unwrap();
             source.set_item("nested", &nested).unwrap();
 
-            let encoded = encode_python_object_to_msgpack(source.as_any()).unwrap();
+            let encoded = encode_bag_to_msgpack(source.as_any()).unwrap();
             let decoded = decode_msgpack_to_python_object(python, &encoded).unwrap();
 
             assert!(decoded.eq(&source).unwrap(), "round trip changed the bag");
@@ -219,12 +281,11 @@ mod tests {
     fn booleans_do_not_decay_into_integers() {
         Python::initialize();
         Python::attach(|python| {
-            let encoded = encode_python_object_to_msgpack(
-                &true.into_pyobject(python).unwrap().to_owned().into_any(),
-            )
-            .unwrap();
+            let source = PyDict::new(python);
+            source.set_item("flag", true).unwrap();
+            let encoded = encode_bag_to_msgpack(source.as_any()).unwrap();
             let decoded = decode_msgpack_to_python_object(python, &encoded).unwrap();
-            assert!(decoded.is_instance_of::<PyBool>());
+            assert!(decoded.get_item("flag").unwrap().is_instance_of::<PyBool>());
         });
     }
 
@@ -234,11 +295,15 @@ mod tests {
     fn a_tuple_is_accepted_and_arrives_as_a_list() {
         Python::initialize();
         Python::attach(|python| {
-            let source = PyTuple::new(python, [1i64, 2, 3]).unwrap();
-            let encoded = encode_python_object_to_msgpack(source.as_any()).unwrap();
+            let source = PyDict::new(python);
+            source
+                .set_item("items", PyTuple::new(python, [1i64, 2, 3]).unwrap())
+                .unwrap();
+            let encoded = encode_bag_to_msgpack(source.as_any()).unwrap();
             let decoded = decode_msgpack_to_python_object(python, &encoded).unwrap();
-            assert!(decoded.is_instance_of::<PyList>());
-            assert_eq!(decoded.len().unwrap(), 3);
+            let items = decoded.get_item("items").unwrap();
+            assert!(items.is_instance_of::<PyList>());
+            assert_eq!(items.len().unwrap(), 3);
         });
     }
 
@@ -255,10 +320,70 @@ mod tests {
                 .unwrap()
                 .call0()
                 .unwrap();
-            let failure = encode_python_object_to_msgpack(&unencodable).unwrap_err();
+            let source = PyDict::new(python);
+            source.set_item("payload", unencodable).unwrap();
+            let failure = encode_bag_to_msgpack(source.as_any()).unwrap_err();
             assert!(
                 failure.to_string().contains("a bag is built from"),
                 "the refusal must state what is allowed, got: {failure}"
+            );
+        });
+    }
+
+    /// A bag that is not a named map encodes to valid msgpack and is then
+    /// unreadable by a processor in another language, so it is refused at the
+    /// boundary rather than published.
+    #[test]
+    fn a_bag_that_is_not_a_named_map_is_refused() {
+        Python::initialize();
+        Python::attach(|python| {
+            let list_bag = PyList::new(python, [1i64, 2, 3]).unwrap();
+            let failure = encode_bag_to_msgpack(list_bag.as_any()).unwrap_err();
+            assert!(
+                failure
+                    .to_string()
+                    .contains("a bag is a dict with string keys"),
+                "got: {failure}"
+            );
+
+            let int_keyed = PyDict::new(python);
+            int_keyed.set_item(1i64, "value").unwrap();
+            let failure = encode_bag_to_msgpack(int_keyed.as_any()).unwrap_err();
+            assert!(
+                failure.to_string().contains("bag keys must be strings"),
+                "got: {failure}"
+            );
+
+            // Nested too — a named map all the way down, not just at the top.
+            let nested_int_keyed = PyDict::new(python);
+            nested_int_keyed.set_item("inner", &int_keyed).unwrap();
+            assert!(encode_bag_to_msgpack(nested_int_keyed.as_any()).is_err());
+        });
+    }
+
+    /// An extension value survives a processor that only forwards the bag.
+    ///
+    /// Nothing in the engine emits one today, but a decode that turned it into
+    /// an ordinary map would make a passthrough processor silently rewrite
+    /// somebody else's payload.
+    #[test]
+    fn a_msgpack_extension_value_round_trips_unchanged() {
+        Python::initialize();
+        Python::attach(|python| {
+            let original = Value::Map(vec![(
+                Value::from("payload"),
+                Value::Ext(42, vec![1, 2, 3]),
+            )]);
+            let mut encoded = Vec::new();
+            rmpv::encode::write_value(&mut encoded, &original).unwrap();
+
+            let decoded = decode_msgpack_to_python_object(python, &encoded).unwrap();
+            let re_encoded = encode_bag_to_msgpack(&decoded).unwrap();
+
+            assert_eq!(
+                rmpv::decode::read_value(&mut &re_encoded[..]).unwrap(),
+                original,
+                "an Ext value did not survive decode-then-encode"
             );
         });
     }

--- a/sdk/streamlib-python-wheel/src/python_bag_conversion.rs
+++ b/sdk/streamlib-python-wheel/src/python_bag_conversion.rs
@@ -1,0 +1,265 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Bags across the Python boundary.
+//!
+//! A bag is a self-describing msgpack value, so the conversion is total in both
+//! directions and needs no schema: encoding walks ordinary Python data, decoding
+//! rebuilds ordinary Python data. Pixels never travel this way — a frame crosses
+//! as a handle, and the payload here is the named map describing it.
+
+use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PyString, PyTuple};
+use rmpv::Value;
+
+/// Encode a Python object to the msgpack bytes the wire carries.
+pub(crate) fn encode_python_object_to_msgpack(value: &Bound<'_, PyAny>) -> PyResult<Vec<u8>> {
+    let mut encoded = Vec::new();
+    rmpv::encode::write_value(&mut encoded, &python_object_to_msgpack_value(value)?)
+        .map_err(|encode_failure| PyValueError::new_err(encode_failure.to_string()))?;
+    Ok(encoded)
+}
+
+/// Decode msgpack bytes from the wire into ordinary Python data.
+pub(crate) fn decode_msgpack_to_python_object<'py>(
+    python: Python<'py>,
+    encoded: &[u8],
+) -> PyResult<Bound<'py, PyAny>> {
+    let value = rmpv::decode::read_value(&mut &encoded[..])
+        .map_err(|decode_failure| PyValueError::new_err(decode_failure.to_string()))?;
+    msgpack_value_to_python_object(python, &value)
+}
+
+/// Convert a processor's JSON configuration into the keyword arguments its
+/// class is constructed with.
+///
+/// Routed through the same msgpack value tree the data plane uses rather than
+/// growing a second converter: the engine stores configuration as JSON, and one
+/// conversion is one set of edge cases.
+pub(crate) fn json_value_to_python_object<'py>(
+    python: Python<'py>,
+    configuration: &serde_json::Value,
+) -> PyResult<Bound<'py, PyAny>> {
+    let value = rmpv::ext::to_value(configuration)
+        .map_err(|convert_failure| PyValueError::new_err(convert_failure.to_string()))?;
+    msgpack_value_to_python_object(python, &value)
+}
+
+/// Convert a processor's configuration from Python into the JSON the graph
+/// node stores.
+///
+/// Configuration travels on the node rather than in a closure, so it has to
+/// survive a JSON round trip — which is also what keeps it inspectable in
+/// `streamlib graph`.
+pub(crate) fn python_object_to_json_value(
+    configuration: &Bound<'_, PyAny>,
+) -> PyResult<serde_json::Value> {
+    let value = python_object_to_msgpack_value(configuration)?;
+    rmpv::ext::from_value(value).map_err(|convert_failure| {
+        PyTypeError::new_err(format!(
+            "config must survive a JSON round trip, because the engine stores it on the graph \
+             node: {convert_failure}"
+        ))
+    })
+}
+
+fn python_object_to_msgpack_value(value: &Bound<'_, PyAny>) -> PyResult<Value> {
+    if value.is_none() {
+        return Ok(Value::Nil);
+    }
+    // Before the integer check: `bool` is a subclass of `int` in Python, so the
+    // order here is what keeps `True` from encoding as `1`.
+    if let Ok(boolean) = value.cast::<PyBool>() {
+        return Ok(Value::Boolean(boolean.is_true()));
+    }
+    if let Ok(integer) = value.cast::<PyInt>() {
+        return integer
+            .extract::<i64>()
+            .map(Value::from)
+            .or_else(|_| integer.extract::<u64>().map(Value::from))
+            .map_err(|_| {
+                PyValueError::new_err(
+                    "integer does not fit in 64 bits — msgpack carries no wider integer",
+                )
+            });
+    }
+    if let Ok(float) = value.cast::<PyFloat>() {
+        return Ok(Value::from(float.value()));
+    }
+    if let Ok(text) = value.cast::<PyString>() {
+        return Ok(Value::from(text.to_cow()?.into_owned()));
+    }
+    if let Ok(bytes) = value.cast::<PyBytes>() {
+        return Ok(Value::Binary(bytes.as_bytes().to_vec()));
+    }
+    if let Ok(mapping) = value.cast::<PyDict>() {
+        let mut entries = Vec::with_capacity(mapping.len());
+        for (key, entry) in mapping.iter() {
+            entries.push((
+                python_object_to_msgpack_value(&key)?,
+                python_object_to_msgpack_value(&entry)?,
+            ));
+        }
+        return Ok(Value::Map(entries));
+    }
+    if let Ok(sequence) = value.cast::<PyList>() {
+        return sequence_to_msgpack_array(sequence.iter());
+    }
+    if let Ok(sequence) = value.cast::<PyTuple>() {
+        return sequence_to_msgpack_array(sequence.iter());
+    }
+    Err(PyTypeError::new_err(format!(
+        "cannot put a {} on a link: a bag is built from dict, list, tuple, str, bytes, int, \
+         float, bool and None. A GPU frame is not copied into Python — it travels as a handle.",
+        value.get_type().name()?
+    )))
+}
+
+fn sequence_to_msgpack_array<'py>(
+    items: impl Iterator<Item = Bound<'py, PyAny>>,
+) -> PyResult<Value> {
+    items
+        .map(|item| python_object_to_msgpack_value(&item))
+        .collect::<PyResult<Vec<Value>>>()
+        .map(Value::Array)
+}
+
+fn msgpack_value_to_python_object<'py>(
+    python: Python<'py>,
+    value: &Value,
+) -> PyResult<Bound<'py, PyAny>> {
+    let object = match value {
+        Value::Nil => python.None().into_bound(python),
+        Value::Boolean(boolean) => boolean.into_pyobject(python)?.to_owned().into_any(),
+        Value::Integer(integer) => match (integer.as_i64(), integer.as_u64()) {
+            (Some(signed), _) => signed.into_pyobject(python)?.into_any(),
+            (None, Some(unsigned)) => unsigned.into_pyobject(python)?.into_any(),
+            (None, None) => {
+                return Err(PyValueError::new_err(
+                    "integer on the wire fits neither i64 nor u64",
+                ));
+            }
+        },
+        Value::F32(float) => float.into_pyobject(python)?.into_any(),
+        Value::F64(float) => float.into_pyobject(python)?.into_any(),
+        Value::String(text) => match text.as_str() {
+            Some(text) => text.into_pyobject(python)?.into_any(),
+            // msgpack strings are not required to be UTF-8; the raw bytes are
+            // the honest reading, and losing them to a lossy decode would be
+            // worse than handing back `bytes`.
+            None => PyBytes::new(python, text.as_bytes()).into_any(),
+        },
+        Value::Binary(bytes) => PyBytes::new(python, bytes).into_any(),
+        Value::Array(items) => {
+            let converted = items
+                .iter()
+                .map(|item| msgpack_value_to_python_object(python, item))
+                .collect::<PyResult<Vec<_>>>()?;
+            PyList::new(python, converted)?.into_any()
+        }
+        Value::Map(entries) => {
+            let mapping = PyDict::new(python);
+            for (key, entry) in entries {
+                mapping.set_item(
+                    msgpack_value_to_python_object(python, key)?,
+                    msgpack_value_to_python_object(python, entry)?,
+                )?;
+            }
+            mapping.into_any()
+        }
+        Value::Ext(type_tag, bytes) => {
+            // Preserved rather than dropped: an extension type is somebody
+            // else's payload, and a processor that only forwards a bag must be
+            // able to hand it on unchanged.
+            let extension = PyDict::new(python);
+            extension.set_item("__msgpack_ext_type__", type_tag)?;
+            extension.set_item("__msgpack_ext_data__", PyBytes::new(python, bytes))?;
+            extension.into_any()
+        }
+    };
+    Ok(object)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every value shape a bag can carry survives Python → msgpack → Python
+    /// with its type and value intact.
+    #[test]
+    fn ordinary_python_data_round_trips_through_the_wire() {
+        Python::initialize();
+        Python::attach(|python| {
+            let source = pyo3::types::PyDict::new(python);
+            source.set_item("nothing", python.None()).unwrap();
+            source.set_item("flag", true).unwrap();
+            source.set_item("count", -42i64).unwrap();
+            source.set_item("huge", u64::MAX).unwrap();
+            source.set_item("ratio", 1.5f64).unwrap();
+            source.set_item("label", "カメラ 🎥").unwrap();
+            source
+                .set_item("payload", PyBytes::new(python, &[0u8, 255, 7]))
+                .unwrap();
+            source.set_item("items", vec![1i64, 2, 3]).unwrap();
+            let nested = pyo3::types::PyDict::new(python);
+            nested.set_item("inner", "value").unwrap();
+            source.set_item("nested", &nested).unwrap();
+
+            let encoded = encode_python_object_to_msgpack(source.as_any()).unwrap();
+            let decoded = decode_msgpack_to_python_object(python, &encoded).unwrap();
+
+            assert!(decoded.eq(&source).unwrap(), "round trip changed the bag");
+        });
+    }
+
+    /// `bool` is a subclass of `int` in Python, so a naive integer-first check
+    /// silently turns `True` into `1`.
+    #[test]
+    fn booleans_do_not_decay_into_integers() {
+        Python::initialize();
+        Python::attach(|python| {
+            let encoded = encode_python_object_to_msgpack(
+                &true.into_pyobject(python).unwrap().to_owned().into_any(),
+            )
+            .unwrap();
+            let decoded = decode_msgpack_to_python_object(python, &encoded).unwrap();
+            assert!(decoded.is_instance_of::<PyBool>());
+        });
+    }
+
+    /// A tuple is a reasonable thing for an author to write, and msgpack has no
+    /// tuple — it arrives back as a list rather than being refused.
+    #[test]
+    fn a_tuple_is_accepted_and_arrives_as_a_list() {
+        Python::initialize();
+        Python::attach(|python| {
+            let source = PyTuple::new(python, [1i64, 2, 3]).unwrap();
+            let encoded = encode_python_object_to_msgpack(source.as_any()).unwrap();
+            let decoded = decode_msgpack_to_python_object(python, &encoded).unwrap();
+            assert!(decoded.is_instance_of::<PyList>());
+            assert_eq!(decoded.len().unwrap(), 3);
+        });
+    }
+
+    /// The refusal names what a bag may hold — an author who reaches for a
+    /// numpy array or a socket should learn the rule from the error.
+    #[test]
+    fn an_unencodable_object_is_refused_with_the_rule() {
+        Python::initialize();
+        Python::attach(|python| {
+            let unencodable = python
+                .import("builtins")
+                .unwrap()
+                .getattr("object")
+                .unwrap()
+                .call0()
+                .unwrap();
+            let failure = encode_python_object_to_msgpack(&unencodable).unwrap_err();
+            assert!(
+                failure.to_string().contains("a bag is built from"),
+                "the refusal must state what is allowed, got: {failure}"
+            );
+        });
+    }
+}

--- a/sdk/streamlib-python-wheel/src/python_bag_conversion.rs
+++ b/sdk/streamlib-python-wheel/src/python_bag_conversion.rs
@@ -134,7 +134,9 @@ fn python_object_to_msgpack_value(value: &Bound<'_, PyAny>) -> PyResult<Value> {
 ///
 /// An extension type is somebody else's payload, so decoding renders it as data
 /// a processor can look at and encoding puts it back exactly as it was — a
-/// passthrough processor must not rewrite what it only forwards.
+/// passthrough processor must not rewrite what it only forwards. This holds for
+/// a nested value; a bag is a named map, so a *top-level* extension is not a bag
+/// and never re-encodes as one.
 const EXTENSION_TYPE_KEY: &str = "__msgpack_ext_type__";
 const EXTENSION_DATA_KEY: &str = "__msgpack_ext_data__";
 

--- a/sdk/streamlib-python-wheel/src/python_logging.rs
+++ b/sdk/streamlib-python-wheel/src/python_logging.rs
@@ -3,20 +3,22 @@
 
 //! Logging and timekeeping for Python processors.
 //!
-//! In-process, a log line is a direct call into `tracing` — the same pipeline
-//! the engine's own records go through, so a processor's output interleaves
-//! with the engine's in one ordered stream instead of arriving as captured
-//! stdout.
+//! In-process, a log line goes straight into the engine's unified JSONL
+//! pipeline — the same drain the engine's own records go through, so a
+//! processor's output interleaves with the engine's in one ordered stream
+//! instead of arriving as captured stdout.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use streamlib::sdk::logging::{LogLevel, emit_python_processor_log_record};
 use streamlib::sdk::media_clock::MediaClock;
 
-/// The `tracing` target every record from Python carries.
-///
-/// Underscored rather than `streamlib::python`: a `streamlib::` literal reads
-/// to `cargo xtask check-boundaries` as a forbidden top-level path shortcut.
-const PYTHON_LOG_TARGET: &str = "streamlib_python";
+use crate::python_bag_conversion::python_object_to_json_value;
 
 /// The clock the engine stamps bags with, in nanoseconds.
 ///
@@ -29,24 +31,130 @@ pub(crate) fn media_clock_now_ns() -> u64 {
     MediaClock::now().as_nanos() as u64
 }
 
-/// Emit one record on the engine's log pipeline.
+/// Current monotonic time in nanoseconds via `clock_gettime(CLOCK_MONOTONIC)`.
 ///
-/// The level is resolved here rather than exposed as five bindings because
-/// `tracing`'s macros need a compile-time level; `emitted_by` names the
-/// processor so records stay attributable in a graph of many.
+/// The kernel's monotonic epoch, so values are comparable across processes —
+/// to Python's `time.clock_gettime_ns(time.CLOCK_MONOTONIC)`, to Rust
+/// `Instant` reads, and to the old SDK's canonical bag stamps. This is a
+/// different epoch from [`media_clock_now_ns`]; both are documented, neither
+/// is derived from the other.
 #[pyfunction]
-pub(crate) fn log_event(level: &str, emitted_by: &str, message: &str) -> PyResult<()> {
-    match level {
-        "trace" => tracing::trace!(target: PYTHON_LOG_TARGET, %emitted_by, "{message}"),
-        "debug" => tracing::debug!(target: PYTHON_LOG_TARGET, %emitted_by, "{message}"),
-        "info" => tracing::info!(target: PYTHON_LOG_TARGET, %emitted_by, "{message}"),
-        "warn" => tracing::warn!(target: PYTHON_LOG_TARGET, %emitted_by, "{message}"),
-        "error" => tracing::error!(target: PYTHON_LOG_TARGET, %emitted_by, "{message}"),
-        unknown => {
-            return Err(PyValueError::new_err(format!(
-                "unknown log level {unknown:?}: expected trace, debug, info, warn or error"
-            )));
+pub(crate) fn monotonic_now_ns() -> u64 {
+    monotonic_clock_now_ns()
+}
+
+/// Raw `CLOCK_MONOTONIC` in nanoseconds, shared by the clock binding, the
+/// default output stamp, and `ctx.time`.
+pub(crate) fn monotonic_clock_now_ns() -> u64 {
+    let mut timespec = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: `timespec` is a valid stack slot; CLOCK_MONOTONIC exists on
+    // every platform the wheel targets, so the call cannot fail with these
+    // arguments.
+    unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut timespec) };
+    (timespec.tv_sec as u64)
+        .saturating_mul(1_000_000_000)
+        .saturating_add(timespec.tv_nsec as u64)
+}
+
+/// Which processor's hook is running on this thread, for log attribution.
+///
+/// Set by the host around every lifecycle hook; a `log_event` outside any
+/// hook (module import time, a worker thread) carries no attribution.
+pub(crate) struct PythonProcessorLogAttribution {
+    pub(crate) processor_id: Option<String>,
+    pub(crate) processor_display_name: String,
+}
+
+thread_local! {
+    static CURRENT_PYTHON_PROCESSOR_LOG_ATTRIBUTION:
+        RefCell<Option<Arc<PythonProcessorLogAttribution>>> = const { RefCell::new(None) };
+}
+
+pub(crate) fn set_current_python_processor_log_attribution(
+    attribution: Option<Arc<PythonProcessorLogAttribution>>,
+) {
+    CURRENT_PYTHON_PROCESSOR_LOG_ATTRIBUTION.with(|current| *current.borrow_mut() = attribution);
+}
+
+fn current_python_processor_log_attribution() -> Option<Arc<PythonProcessorLogAttribution>> {
+    CURRENT_PYTHON_PROCESSOR_LOG_ATTRIBUTION.with(|current| current.borrow().clone())
+}
+
+/// Emit one record on the engine's log pipeline, with structured attrs.
+///
+/// The processor attribution comes from the host's per-thread marker rather
+/// than a parameter, so a helper deep inside user code attributes correctly
+/// without threading a context through.
+#[pyfunction]
+#[pyo3(signature = (level, message, attrs = None))]
+pub(crate) fn log_event(
+    level: &str,
+    message: &str,
+    attrs: Option<&Bound<'_, PyDict>>,
+) -> PyResult<()> {
+    let level = parse_log_level_name(level)?;
+    let mut attribute_map = BTreeMap::new();
+    if let Some(attrs) = attrs {
+        for (key, value) in attrs.iter() {
+            let key = key.extract::<String>().map_err(|_| {
+                PyValueError::new_err("log attr keys must be strings — they become JSONL columns")
+            })?;
+            attribute_map.insert(key, python_object_to_json_value(&value)?);
         }
     }
+    let processor_id = current_python_processor_log_attribution().map(|attribution| {
+        attribution
+            .processor_id
+            .clone()
+            .unwrap_or_else(|| attribution.processor_display_name.clone())
+    });
+    emit_python_processor_log_record(level, message.to_string(), processor_id, attribute_map);
     Ok(())
+}
+
+fn parse_log_level_name(level: &str) -> PyResult<LogLevel> {
+    match level {
+        "trace" => Ok(LogLevel::Trace),
+        "debug" => Ok(LogLevel::Debug),
+        "info" => Ok(LogLevel::Info),
+        "warn" => Ok(LogLevel::Warn),
+        "error" => Ok(LogLevel::Error),
+        unknown => Err(PyValueError::new_err(format!(
+            "unknown log level {unknown:?}: expected trace, debug, info, warn or error"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two reads never go backwards — the monotonic contract.
+    #[test]
+    fn monotonic_clock_never_goes_backwards() {
+        let first = monotonic_clock_now_ns();
+        let second = monotonic_clock_now_ns();
+        assert!(second >= first, "clock went backwards: {first} -> {second}");
+    }
+
+    /// The value domain is the kernel's CLOCK_MONOTONIC epoch — the same one
+    /// `time.clock_gettime_ns(time.CLOCK_MONOTONIC)` reads — not a
+    /// process-local origin like the media clock's.
+    #[test]
+    fn monotonic_clock_shares_the_kernel_clock_monotonic_domain() {
+        let mut timespec = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut timespec) };
+        let direct = (timespec.tv_sec as u64) * 1_000_000_000 + timespec.tv_nsec as u64;
+        let binding = monotonic_clock_now_ns();
+        assert!(
+            binding.abs_diff(direct) < 1_000_000_000,
+            "readings a moment apart landed in different domains: {direct} vs {binding}"
+        );
+    }
 }

--- a/sdk/streamlib-python-wheel/src/python_logging.rs
+++ b/sdk/streamlib-python-wheel/src/python_logging.rs
@@ -12,6 +12,12 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use streamlib::sdk::media_clock::MediaClock;
 
+/// The `tracing` target every record from Python carries.
+///
+/// Underscored rather than `streamlib::python`: a `streamlib::` literal reads
+/// to `cargo xtask check-boundaries` as a forbidden top-level path shortcut.
+const PYTHON_LOG_TARGET: &str = "streamlib_python";
+
 /// The clock the engine stamps bags with, in nanoseconds.
 ///
 /// Monotonic and shared by every processor in this process, so two readings
@@ -26,16 +32,16 @@ pub(crate) fn media_clock_now_ns() -> u64 {
 /// Emit one record on the engine's log pipeline.
 ///
 /// The level is resolved here rather than exposed as five bindings because
-/// `tracing`'s macros need a compile-time level; `target` names the emitting
+/// `tracing`'s macros need a compile-time level; `emitted_by` names the
 /// processor so records stay attributable in a graph of many.
 #[pyfunction]
-pub(crate) fn log_event(level: &str, target: &str, message: &str) -> PyResult<()> {
+pub(crate) fn log_event(level: &str, emitted_by: &str, message: &str) -> PyResult<()> {
     match level {
-        "trace" => tracing::trace!(target: "streamlib::python", %target, "{message}"),
-        "debug" => tracing::debug!(target: "streamlib::python", %target, "{message}"),
-        "info" => tracing::info!(target: "streamlib::python", %target, "{message}"),
-        "warn" => tracing::warn!(target: "streamlib::python", %target, "{message}"),
-        "error" => tracing::error!(target: "streamlib::python", %target, "{message}"),
+        "trace" => tracing::trace!(target: PYTHON_LOG_TARGET, %emitted_by, "{message}"),
+        "debug" => tracing::debug!(target: PYTHON_LOG_TARGET, %emitted_by, "{message}"),
+        "info" => tracing::info!(target: PYTHON_LOG_TARGET, %emitted_by, "{message}"),
+        "warn" => tracing::warn!(target: PYTHON_LOG_TARGET, %emitted_by, "{message}"),
+        "error" => tracing::error!(target: PYTHON_LOG_TARGET, %emitted_by, "{message}"),
         unknown => {
             return Err(PyValueError::new_err(format!(
                 "unknown log level {unknown:?}: expected trace, debug, info, warn or error"

--- a/sdk/streamlib-python-wheel/src/python_logging.rs
+++ b/sdk/streamlib-python-wheel/src/python_logging.rs
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Logging and timekeeping for Python processors.
+//!
+//! In-process, a log line is a direct call into `tracing` — the same pipeline
+//! the engine's own records go through, so a processor's output interleaves
+//! with the engine's in one ordered stream instead of arriving as captured
+//! stdout.
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use streamlib::sdk::media_clock::MediaClock;
+
+/// The clock the engine stamps bags with, in nanoseconds.
+///
+/// Monotonic and shared by every processor in this process, so two readings
+/// subtract to a real duration. It is not the system-wide `CLOCK_MONOTONIC`
+/// epoch — the origin is this process's engine start — so a value from one
+/// process means nothing in another.
+#[pyfunction]
+pub(crate) fn media_clock_now_ns() -> u64 {
+    MediaClock::now().as_nanos() as u64
+}
+
+/// Emit one record on the engine's log pipeline.
+///
+/// The level is resolved here rather than exposed as five bindings because
+/// `tracing`'s macros need a compile-time level; `target` names the emitting
+/// processor so records stay attributable in a graph of many.
+#[pyfunction]
+pub(crate) fn log_event(level: &str, target: &str, message: &str) -> PyResult<()> {
+    match level {
+        "trace" => tracing::trace!(target: "streamlib::python", %target, "{message}"),
+        "debug" => tracing::debug!(target: "streamlib::python", %target, "{message}"),
+        "info" => tracing::info!(target: "streamlib::python", %target, "{message}"),
+        "warn" => tracing::warn!(target: "streamlib::python", %target, "{message}"),
+        "error" => tracing::error!(target: "streamlib::python", %target, "{message}"),
+        unknown => {
+            return Err(PyValueError::new_err(format!(
+                "unknown log level {unknown:?}: expected trace, debug, info, warn or error"
+            )));
+        }
+    }
+    Ok(())
+}

--- a/sdk/streamlib-python-wheel/src/python_monotonic_timer.rs
+++ b/sdk/streamlib-python-wheel/src/python_monotonic_timer.rs
@@ -1,0 +1,315 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Drift-free periodic timer for Python processors.
+//!
+//! `timerfd_create(CLOCK_MONOTONIC)` + `TFD_TIMER_ABSTIME`: the first
+//! deadline is now + interval and every repeat is absolute, so latency in
+//! one tick never accumulates into the next. An epoll fd alongside lets
+//! `wait` honor a timeout, which is what bounds teardown latency for a loop
+//! polling shutdown between ticks. Linux-only, like the platform floor.
+
+use parking_lot::Mutex;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy)]
+struct MonotonicTimerFileDescriptors {
+    timer_fd: i32,
+    epoll_fd: i32,
+}
+
+/// Periodic monotonic timer, used as `with MonotonicTimer(interval_ns) as t:`.
+#[pyclass(name = "MonotonicTimer", module = "streamlib", frozen)]
+pub(crate) struct PythonMonotonicTimer {
+    timer_interval_ns: i64,
+    #[cfg(target_os = "linux")]
+    file_descriptors: Mutex<Option<MonotonicTimerFileDescriptors>>,
+    #[cfg(not(target_os = "linux"))]
+    file_descriptors: Mutex<Option<()>>,
+}
+
+#[pymethods]
+impl PythonMonotonicTimer {
+    #[new]
+    fn new(interval_ns: i64) -> PyResult<Self> {
+        if interval_ns <= 0 {
+            return Err(PyValueError::new_err(format!(
+                "interval_ns must be > 0, got {interval_ns}"
+            )));
+        }
+        #[cfg(target_os = "linux")]
+        {
+            let file_descriptors = create_monotonic_timer_file_descriptors(interval_ns as u64)
+                .ok_or_else(|| {
+                    PyRuntimeError::new_err(format!(
+                        "timerfd_create failed for interval_ns={interval_ns}"
+                    ))
+                })?;
+            Ok(Self {
+                timer_interval_ns: interval_ns,
+                file_descriptors: Mutex::new(Some(file_descriptors)),
+            })
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            Err(PyRuntimeError::new_err(
+                "MonotonicTimer is Linux-only — timerfd does not exist on this platform",
+            ))
+        }
+    }
+
+    #[getter]
+    fn interval_ns(&self) -> i64 {
+        self.timer_interval_ns
+    }
+
+    /// Wait up to `timeout_ms` for the next tick.
+    ///
+    /// Returns the positive expiration count when a tick fired, `0` on
+    /// timeout (poll shutdown and call again), `-1` after `close()` or on
+    /// error.
+    #[pyo3(signature = (timeout_ms = 100))]
+    fn wait(&self, python: Python<'_>, timeout_ms: u64) -> i64 {
+        #[cfg(target_os = "linux")]
+        {
+            // Copied out rather than held: a close() racing this wait must
+            // not block behind an epoll timeout, and a wait on
+            // just-closed fds reports -1 through EBADF.
+            let Some(file_descriptors) = *self.file_descriptors.lock() else {
+                return -1;
+            };
+            python.detach(move || wait_for_monotonic_timer_tick(file_descriptors, timeout_ms))
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = (python, timeout_ms);
+            -1
+        }
+    }
+
+    /// Close the timer. Idempotent; a subsequent `wait` returns `-1`.
+    fn close(&self) {
+        #[cfg(target_os = "linux")]
+        if let Some(file_descriptors) = self.file_descriptors.lock().take() {
+            close_monotonic_timer_file_descriptors(file_descriptors);
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = self.file_descriptors.lock().take();
+        }
+    }
+
+    fn __enter__(python_self: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        python_self
+    }
+
+    #[pyo3(signature = (*_exception_details))]
+    fn __exit__(&self, _exception_details: &Bound<'_, PyAny>) -> bool {
+        self.close();
+        false
+    }
+}
+
+impl Drop for PythonMonotonicTimer {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn create_monotonic_timer_file_descriptors(
+    interval_ns: u64,
+) -> Option<MonotonicTimerFileDescriptors> {
+    let interval_sec = (interval_ns / 1_000_000_000) as libc::time_t;
+    let interval_nsec = (interval_ns % 1_000_000_000) as libc::c_long;
+
+    // SAFETY: plain fd-creating syscalls; failures surface as negative
+    // returns handled below.
+    //
+    // Non-blocking, unlike the old subprocess timer: two threads woken by one
+    // tick race the 8-byte read, and a blocking fd parks the loser until the
+    // NEXT tick with no bound from `timeout_ms`. With `TFD_NONBLOCK` the loser
+    // reads EAGAIN and reports a timeout instead.
+    let timer_fd = unsafe {
+        libc::timerfd_create(
+            libc::CLOCK_MONOTONIC,
+            libc::TFD_CLOEXEC | libc::TFD_NONBLOCK,
+        )
+    };
+    if timer_fd < 0 {
+        return None;
+    }
+
+    let mut now = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: `now` is a valid stack slot.
+    if unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut now) } < 0 {
+        // SAFETY: timer_fd was just opened by this function.
+        unsafe { libc::close(timer_fd) };
+        return None;
+    }
+
+    let mut first_deadline_sec = now.tv_sec + interval_sec;
+    let mut first_deadline_nsec = now.tv_nsec + interval_nsec;
+    if first_deadline_nsec >= 1_000_000_000 {
+        first_deadline_sec += 1;
+        first_deadline_nsec -= 1_000_000_000;
+    }
+
+    let timer_spec = libc::itimerspec {
+        it_interval: libc::timespec {
+            tv_sec: interval_sec,
+            tv_nsec: interval_nsec,
+        },
+        it_value: libc::timespec {
+            tv_sec: first_deadline_sec,
+            tv_nsec: first_deadline_nsec,
+        },
+    };
+    // SAFETY: timer_fd is a live timerfd; `timer_spec` is a valid stack slot.
+    let arm_result = unsafe {
+        libc::timerfd_settime(
+            timer_fd,
+            libc::TFD_TIMER_ABSTIME,
+            &timer_spec,
+            std::ptr::null_mut(),
+        )
+    };
+    if arm_result < 0 {
+        // SAFETY: timer_fd was just opened by this function.
+        unsafe { libc::close(timer_fd) };
+        return None;
+    }
+
+    // SAFETY: plain fd-creating syscall.
+    let epoll_fd = unsafe { libc::epoll_create1(libc::EPOLL_CLOEXEC) };
+    if epoll_fd < 0 {
+        // SAFETY: timer_fd was just opened by this function.
+        unsafe { libc::close(timer_fd) };
+        return None;
+    }
+    let mut epoll_registration = libc::epoll_event {
+        events: libc::EPOLLIN as u32,
+        u64: 0,
+    };
+    // SAFETY: both fds are live; the event struct is a valid stack slot.
+    if unsafe {
+        libc::epoll_ctl(
+            epoll_fd,
+            libc::EPOLL_CTL_ADD,
+            timer_fd,
+            &mut epoll_registration,
+        )
+    } < 0
+    {
+        // SAFETY: both fds were just opened by this function.
+        unsafe {
+            libc::close(epoll_fd);
+            libc::close(timer_fd);
+        }
+        return None;
+    }
+
+    Some(MonotonicTimerFileDescriptors { timer_fd, epoll_fd })
+}
+
+#[cfg(target_os = "linux")]
+fn wait_for_monotonic_timer_tick(
+    file_descriptors: MonotonicTimerFileDescriptors,
+    timeout_ms: u64,
+) -> i64 {
+    let mut ready_events = [libc::epoll_event { events: 0, u64: 0 }; 1];
+    let bounded_timeout_ms = timeout_ms.min(i32::MAX as u64) as i32;
+    // SAFETY: epoll_fd is live for the duration of the enclosing wait (a
+    // racing close makes this return EBADF, reported as -1 below).
+    let ready_count = unsafe {
+        libc::epoll_wait(
+            file_descriptors.epoll_fd,
+            ready_events.as_mut_ptr(),
+            1,
+            bounded_timeout_ms,
+        )
+    };
+    if ready_count < 0 {
+        return if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
+            0
+        } else {
+            -1
+        };
+    }
+    if ready_count == 0 {
+        return 0;
+    }
+    let mut expiration_count: u64 = 0;
+    // SAFETY: reading the timerfd's 8-byte expiration counter into a valid
+    // stack slot.
+    let read_result = unsafe {
+        libc::read(
+            file_descriptors.timer_fd,
+            &mut expiration_count as *mut u64 as *mut libc::c_void,
+            std::mem::size_of::<u64>(),
+        )
+    };
+    if read_result < 0 {
+        return if std::io::Error::last_os_error().kind() == std::io::ErrorKind::WouldBlock {
+            0
+        } else {
+            -1
+        };
+    }
+    expiration_count.min(i64::MAX as u64) as i64
+}
+
+#[cfg(target_os = "linux")]
+fn close_monotonic_timer_file_descriptors(file_descriptors: MonotonicTimerFileDescriptors) {
+    // SAFETY: the fds were created by `create_monotonic_timer_file_descriptors`
+    // and taken out of the handle exactly once.
+    unsafe {
+        libc::close(file_descriptors.epoll_fd);
+        libc::close(file_descriptors.timer_fd);
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_tick_fires_within_the_wait_window() {
+        let file_descriptors = create_monotonic_timer_file_descriptors(2_000_000).unwrap();
+        let expiration_count = wait_for_monotonic_timer_tick(file_descriptors, 1_000);
+        close_monotonic_timer_file_descriptors(file_descriptors);
+        assert!(
+            expiration_count >= 1,
+            "a 2ms timer produced no tick inside a 1s wait: {expiration_count}"
+        );
+    }
+
+    #[test]
+    fn a_wait_shorter_than_the_interval_times_out_with_zero() {
+        let file_descriptors = create_monotonic_timer_file_descriptors(10_000_000_000).unwrap();
+        let expiration_count = wait_for_monotonic_timer_tick(file_descriptors, 10);
+        close_monotonic_timer_file_descriptors(file_descriptors);
+        assert_eq!(expiration_count, 0);
+    }
+
+    #[test]
+    fn a_closed_timer_reports_minus_one() {
+        Python::initialize();
+        Python::attach(|python| {
+            let timer = PythonMonotonicTimer::new(2_000_000).unwrap();
+            timer.close();
+            assert_eq!(timer.wait(python, 10), -1);
+        });
+    }
+
+    #[test]
+    fn a_non_positive_interval_is_refused() {
+        assert!(PythonMonotonicTimer::new(0).is_err());
+        assert!(PythonMonotonicTimer::new(-5).is_err());
+    }
+}

--- a/sdk/streamlib-python-wheel/src/python_processor_context.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_context.rs
@@ -22,7 +22,7 @@ use pyo3::exceptions::{PyNotImplementedError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use streamlib::sdk::context::{
-    GpuContextLimitedAccess, PooledTextureHandle, RuntimeContextFullAccess,
+    GpuContextFullAccess, GpuContextLimitedAccess, PooledTextureHandle, RuntimeContextFullAccess,
     RuntimeContextLimitedAccess, SurfaceStore, TexturePoolDescriptor,
 };
 use streamlib::sdk::rhi::{
@@ -69,7 +69,10 @@ type LimitedAccessRuntimeContextViewLease =
     Arc<RwLock<Option<LimitedAccessRuntimeContextViewPointer>>>;
 
 fn expired_context_error() -> PyErr {
-    PyRuntimeError::new_err("this context is only valid during the lifecycle hook that received it")
+    PyRuntimeError::new_err(
+        "this capability is only valid during the lifecycle hook or escalate callback that \
+         received it",
+    )
 }
 
 fn context_not_yet_activated_error() -> PyErr {
@@ -390,6 +393,62 @@ impl PythonGpuContextLimitedAccess {
         })
     }
 
+    /// Run `privileged_callback` with a temporary full-access GPU capability.
+    ///
+    /// The in-process door for one-shot privileged construction from a worker
+    /// thread — the pattern every native capture processor uses: stash this
+    /// object in `setup`, spawn a thread in `start`, escalate exactly once for
+    /// resource construction, run per-frame work on the limited surface. The
+    /// engine's escalate gate serializes all escalations runtime-wide and
+    /// waits for device idle afterwards, so this is for setup-shaped moments,
+    /// never per-frame — and it must never nest: an escalate inside an
+    /// escalate on one thread is a same-thread gate re-entry, which the
+    /// engine refuses by construction.
+    ///
+    /// Returns whatever the callback returns. The capability object handed to
+    /// the callback expires when the callback does — stashing it and calling
+    /// it later raises rather than granting privileged access forever.
+    fn escalate(
+        &self,
+        python: Python<'_>,
+        privileged_callback: &Bound<'_, PyAny>,
+    ) -> PyResult<Py<PyAny>> {
+        let engine_view = self.engine_view()?.clone();
+        let held_callback = privileged_callback.clone().unbind();
+        // Attaching while the escalate gate is held cannot deadlock here:
+        // every gate-entering call in this crate detaches before reaching the
+        // engine, so no thread ever waits on the gate while holding the GIL.
+        python.detach(move || {
+            let escalate_outcome: Result<PyResult<Py<PyAny>>, _> =
+                engine_view.escalate(|gpu_full_access| {
+                    let callback_lease: EscalatedGpuFullAccessViewLease =
+                        Arc::new(RwLock::new(Some(EscalatedGpuFullAccessViewPointer(
+                            NonNull::from(gpu_full_access),
+                        ))));
+                    let callback_outcome = Python::attach(|python| {
+                        let escalated_capability = Py::new(
+                            python,
+                            PythonGpuContextFullAccess {
+                                gpu_full_access_source: GpuFullAccessSource::EscalateCallback(
+                                    Arc::clone(&callback_lease),
+                                ),
+                            },
+                        )?;
+                        held_callback.call1(python, (escalated_capability,))
+                    });
+                    // Revoked detached, blocking until every in-flight reader
+                    // finishes — the pointer never outlives the closure's
+                    // borrow. A callback failure still reaches this line.
+                    *callback_lease.write() = None;
+                    Ok(callback_outcome)
+                });
+            match escalate_outcome {
+                Ok(callback_outcome) => callback_outcome,
+                Err(escalate_failure) => Err(gpu_operation_error(escalate_failure)),
+            }
+        })
+    }
+
     /// Resolve a surface id another processor published into a handle.
     fn resolve_surface(
         &self,
@@ -409,10 +468,58 @@ impl PythonGpuContextLimitedAccess {
     }
 }
 
-/// Privileged GPU capability, valid only while a full-access hook runs.
+struct EscalatedGpuFullAccessViewPointer(NonNull<GpuContextFullAccess>);
+
+// SAFETY: same protocol as the runtime-context view pointers — dereferenced
+// only under its lease's read guard, revoked (write-lock, blocking on
+// readers) before the engine borrow it erased ends.
+unsafe impl Send for EscalatedGpuFullAccessViewPointer {}
+unsafe impl Sync for EscalatedGpuFullAccessViewPointer {}
+
+type EscalatedGpuFullAccessViewLease = Arc<RwLock<Option<EscalatedGpuFullAccessViewPointer>>>;
+
+/// Where a full-access GPU capability object borrows its engine handle from.
+///
+/// One pyclass for both doors so the op surface never forks: a full-phase
+/// hook's `ctx.gpu_full_access` and the object an `escalate` callback
+/// receives are the same class, differing only in which lease scopes them.
+enum GpuFullAccessSource {
+    /// `ctx.gpu_full_access` in a setup/teardown/start/stop hook — scoped to
+    /// that hook's runtime-view lease.
+    FullAccessHook(FullAccessRuntimeContextViewLease),
+    /// The handle an [`escalate`](PythonGpuContextLimitedAccess::escalate)
+    /// callback receives — scoped to the escalate closure.
+    EscalateCallback(EscalatedGpuFullAccessViewLease),
+}
+
+/// Run `use_gpu_full_access` against whichever lease backs this capability,
+/// detached from the GIL.
+fn read_gpu_full_access<T: Send>(
+    python: Python<'_>,
+    source: &GpuFullAccessSource,
+    use_gpu_full_access: impl FnOnce(&GpuContextFullAccess) -> PyResult<T> + Send,
+) -> PyResult<T> {
+    match source {
+        GpuFullAccessSource::FullAccessHook(lease) => {
+            read_full_access_view(python, lease, |view| {
+                use_gpu_full_access(view.gpu_full_access())
+            })
+        }
+        GpuFullAccessSource::EscalateCallback(lease) => python.detach(|| {
+            let guard = lease.read();
+            let Some(view_pointer) = guard.as_ref() else {
+                return Err(expired_context_error());
+            };
+            // SAFETY: same protocol as `read_full_access_view`.
+            use_gpu_full_access(unsafe { view_pointer.0.as_ref() })
+        }),
+    }
+}
+
+/// Privileged GPU capability — a full-access hook's, or an escalate callback's.
 #[pyclass(name = "GpuContextFullAccess", module = "streamlib", frozen)]
 pub(crate) struct PythonGpuContextFullAccess {
-    full_access_view_lease: FullAccessRuntimeContextViewLease,
+    gpu_full_access_source: GpuFullAccessSource,
 }
 
 #[pymethods]
@@ -427,8 +534,7 @@ impl PythonGpuContextFullAccess {
         format: &str,
     ) -> PyResult<PythonGpuSurfaceHandle> {
         let pixel_format = parse_pixel_format_name(format)?;
-        read_full_access_view(python, &self.full_access_view_lease, |view| {
-            let gpu_full_access = view.gpu_full_access();
+        read_gpu_full_access(python, &self.gpu_full_access_source, |gpu_full_access| {
             let (pool_id, pixel_buffer) = gpu_full_access
                 .acquire_pixel_buffer(width, height, pixel_format)
                 .map_err(gpu_operation_error)?;
@@ -456,11 +562,10 @@ impl PythonGpuContextFullAccess {
     ) -> PyResult<PythonGpuSurfaceHandle> {
         let texture_format = parse_texture_format_name(format)?;
         let texture_usages = parse_texture_usage_names(&usage)?;
-        read_full_access_view(python, &self.full_access_view_lease, |view| {
+        read_gpu_full_access(python, &self.gpu_full_access_source, |gpu_full_access| {
             let descriptor = TexturePoolDescriptor::new(width, height, texture_format)
                 .with_usage(texture_usages);
-            let pooled_texture = view
-                .gpu_full_access()
+            let pooled_texture = gpu_full_access
                 .acquire_texture(&descriptor)
                 .map_err(gpu_operation_error)?;
             Ok(PythonGpuSurfaceHandle::from_pooled_texture(pooled_texture))
@@ -469,8 +574,8 @@ impl PythonGpuContextFullAccess {
 
     /// Block until the GPU device is idle.
     fn wait_device_idle(&self, python: Python<'_>) -> PyResult<()> {
-        read_full_access_view(python, &self.full_access_view_lease, |view| {
-            view.gpu_full_access()
+        read_gpu_full_access(python, &self.gpu_full_access_source, |gpu_full_access| {
+            gpu_full_access
                 .wait_device_idle()
                 .map_err(gpu_operation_error)
         })
@@ -505,7 +610,9 @@ impl PythonRuntimeContextFullAccess {
             gpu_full_access_context: Py::new(
                 python,
                 PythonGpuContextFullAccess {
-                    full_access_view_lease: Arc::clone(&full_access_view_lease),
+                    gpu_full_access_source: GpuFullAccessSource::FullAccessHook(Arc::clone(
+                        &full_access_view_lease,
+                    )),
                 },
             )?,
             gpu_limited_access_context: Py::new(

--- a/sdk/streamlib-python-wheel/src/python_processor_context.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_context.rs
@@ -1,0 +1,972 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The capability-typed runtime contexts handed to Python lifecycle hooks.
+//!
+//! The engine hands hooks lifetime-bound views (`&RuntimeContextFullAccess`)
+//! that a Python object cannot hold. The bridge is a lease: the host erases
+//! the borrow behind a pointer, installs it before invoking the hook, and
+//! revokes it after — the revoke's write-lock acquisition blocks until every
+//! in-flight reader finishes, so the pointer provably never outlives the
+//! engine borrow. Lock/GIL discipline, kept everywhere in this file: lease
+//! installs and revokes happen with no GIL attached, and every reader takes
+//! the guard inside a `python.detach(..)` closure and releases it before
+//! re-attaching — never hold a lease guard while attached to or waiting for
+//! the GIL.
+
+use std::ptr::NonNull;
+use std::sync::{Arc, OnceLock};
+
+use parking_lot::{Mutex, RwLock};
+use pyo3::exceptions::{PyNotImplementedError, PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use streamlib::sdk::context::{
+    GpuContextLimitedAccess, PooledTextureHandle, RuntimeContextFullAccess,
+    RuntimeContextLimitedAccess, SurfaceStore, TexturePoolDescriptor,
+};
+use streamlib::sdk::rhi::{
+    PixelBuffer, PixelBufferPoolId, PixelFormat, TextureFormat, TextureUsages,
+};
+
+use crate::python_bag_conversion::json_value_to_python_object;
+use crate::python_logging::monotonic_clock_now_ns;
+use crate::python_processor_link_data_access::PythonProcessorLinkDataAccess;
+
+// =============================================================================
+// The lease: a lifetime-erased view pointer behind a lock
+// =============================================================================
+
+struct FullAccessRuntimeContextViewPointer(NonNull<RuntimeContextFullAccess<'static>>);
+
+// SAFETY: the engine view is Send + Sync; the pointer is dereferenced only
+// under the lease's read guard, and the host's revoke (a write-lock
+// acquisition) blocks until every reader is done, so the deref never outlives
+// the engine borrow the pointer erased.
+unsafe impl Send for FullAccessRuntimeContextViewPointer {}
+unsafe impl Sync for FullAccessRuntimeContextViewPointer {}
+
+impl FullAccessRuntimeContextViewPointer {
+    fn from_engine_view(view: &RuntimeContextFullAccess<'_>) -> Self {
+        Self(NonNull::from(view).cast())
+    }
+}
+
+struct LimitedAccessRuntimeContextViewPointer(NonNull<RuntimeContextLimitedAccess<'static>>);
+
+// SAFETY: same argument as `FullAccessRuntimeContextViewPointer`.
+unsafe impl Send for LimitedAccessRuntimeContextViewPointer {}
+unsafe impl Sync for LimitedAccessRuntimeContextViewPointer {}
+
+impl LimitedAccessRuntimeContextViewPointer {
+    fn from_engine_view(view: &RuntimeContextLimitedAccess<'_>) -> Self {
+        Self(NonNull::from(view).cast())
+    }
+}
+
+type FullAccessRuntimeContextViewLease = Arc<RwLock<Option<FullAccessRuntimeContextViewPointer>>>;
+type LimitedAccessRuntimeContextViewLease =
+    Arc<RwLock<Option<LimitedAccessRuntimeContextViewPointer>>>;
+
+fn expired_context_error() -> PyErr {
+    PyRuntimeError::new_err("this context is only valid during the lifecycle hook that received it")
+}
+
+fn context_not_yet_activated_error() -> PyErr {
+    PyRuntimeError::new_err(
+        "this context becomes usable once the processor's first lifecycle hook runs",
+    )
+}
+
+/// Run `read_view` against the leased full-access view, detached from the GIL.
+fn read_full_access_view<T: Send>(
+    python: Python<'_>,
+    lease: &FullAccessRuntimeContextViewLease,
+    read_view: impl FnOnce(&RuntimeContextFullAccess<'static>) -> PyResult<T> + Send,
+) -> PyResult<T> {
+    python.detach(|| {
+        let guard = lease.read();
+        let Some(view_pointer) = guard.as_ref() else {
+            return Err(expired_context_error());
+        };
+        // SAFETY: the pointer is present only between the host's install and
+        // revoke; revoke blocks on this read guard, so the borrow is live.
+        read_view(unsafe { view_pointer.0.as_ref() })
+    })
+}
+
+/// Run `read_view` against the leased limited-access view, detached from the GIL.
+fn read_limited_access_view<T: Send>(
+    python: Python<'_>,
+    lease: &LimitedAccessRuntimeContextViewLease,
+    read_view: impl FnOnce(&RuntimeContextLimitedAccess<'static>) -> PyResult<T> + Send,
+) -> PyResult<T> {
+    python.detach(|| {
+        let guard = lease.read();
+        let Some(view_pointer) = guard.as_ref() else {
+            return Err(expired_context_error());
+        };
+        // SAFETY: same protocol as `read_full_access_view`.
+        read_view(unsafe { view_pointer.0.as_ref() })
+    })
+}
+
+// =============================================================================
+// GPU surface handle
+// =============================================================================
+
+// Owned purely so Drop releases the underlying resource on close; the first
+// read access lands with the pixel-exchange surface (#1710).
+#[expect(dead_code)]
+enum GpuSurfaceHandleValue {
+    OwnedPixelBuffer(PixelBuffer),
+    OwnedPooledTexture(PooledTextureHandle),
+}
+
+/// An owned GPU surface as seen from Python.
+///
+/// Owning the engine value (rather than an id to re-resolve) is what keeps a
+/// pool slot or a pooled texture alive until `close()` / the context manager
+/// releases it.
+#[pyclass(name = "GpuSurfaceHandle", module = "streamlib", frozen)]
+pub(crate) struct PythonGpuSurfaceHandle {
+    /// `None` for pooled textures — see [`Self::surface_id`].
+    minted_surface_id: Option<String>,
+    /// Present only on a handle whose acquire checked the buffer into the
+    /// surface store. The check-in parks a strong clone in the store, so the
+    /// pool slot comes back only if release evicts it — a handle that skips
+    /// this pins its slot for the store's lifetime, and a resolved handle
+    /// must never release somebody else's surface.
+    surface_store_owing_a_release: Option<SurfaceStore>,
+    surface_width: u32,
+    surface_height: u32,
+    surface_format_name: String,
+    owned_value: Mutex<Option<GpuSurfaceHandleValue>>,
+}
+
+impl PythonGpuSurfaceHandle {
+    fn from_acquired_pixel_buffer(
+        minted_surface_id: String,
+        surface_store_owing_a_release: Option<SurfaceStore>,
+        pixel_buffer: PixelBuffer,
+    ) -> Self {
+        Self {
+            minted_surface_id: Some(minted_surface_id),
+            surface_store_owing_a_release,
+            surface_width: pixel_buffer.width,
+            surface_height: pixel_buffer.height,
+            surface_format_name: pixel_format_name(pixel_buffer.format()).to_string(),
+            owned_value: Mutex::new(Some(GpuSurfaceHandleValue::OwnedPixelBuffer(pixel_buffer))),
+        }
+    }
+
+    fn from_resolved_pixel_buffer(surface_id: String, pixel_buffer: PixelBuffer) -> Self {
+        Self {
+            minted_surface_id: Some(surface_id),
+            surface_store_owing_a_release: None,
+            surface_width: pixel_buffer.width,
+            surface_height: pixel_buffer.height,
+            surface_format_name: pixel_format_name(pixel_buffer.format()).to_string(),
+            owned_value: Mutex::new(Some(GpuSurfaceHandleValue::OwnedPixelBuffer(pixel_buffer))),
+        }
+    }
+
+    fn from_pooled_texture(pooled_texture: PooledTextureHandle) -> Self {
+        Self {
+            minted_surface_id: None,
+            surface_store_owing_a_release: None,
+            surface_width: pooled_texture.width(),
+            surface_height: pooled_texture.height(),
+            surface_format_name: texture_format_name(pooled_texture.format()).to_string(),
+            owned_value: Mutex::new(Some(GpuSurfaceHandleValue::OwnedPooledTexture(
+                pooled_texture,
+            ))),
+        }
+    }
+
+    /// Release the owned engine value and settle the check-in debt. Runs on
+    /// `close()` (detached) and on garbage collection; idempotent.
+    fn release_owned_engine_value(&self) {
+        let taken_value = self.owned_value.lock().take();
+        if taken_value.is_none() {
+            return;
+        }
+        if let (Some(store), Some(surface_id)) = (
+            self.surface_store_owing_a_release.as_ref(),
+            self.minted_surface_id.as_ref(),
+        ) {
+            // Best-effort, mirroring the subprocess release path: the store
+            // eviction is what frees the pool slot; the daemon half already
+            // treats a dropped connection as a full release.
+            if let Err(release_failure) = store.release(surface_id) {
+                tracing::debug!(%surface_id, %release_failure, "surface-store release failed");
+            }
+        }
+        drop(taken_value);
+    }
+}
+
+impl Drop for PythonGpuSurfaceHandle {
+    /// Covers a handle the author never closed. Runs attached (pyclass
+    /// deallocation) — acceptable because the engine takes no GIL, so the
+    /// release cannot deadlock; `close()` remains the detached fast path.
+    fn drop(&mut self) {
+        self.release_owned_engine_value();
+    }
+}
+
+fn pixel_exchange_not_yet_implemented_error() -> PyErr {
+    PyNotImplementedError::new_err(
+        "the pixel-exchange surface lands with ticket #1710 (DLPack first, DMA-BUF, numpy fallback)",
+    )
+}
+
+#[pymethods]
+impl PythonGpuSurfaceHandle {
+    /// The id downstream processors resolve this surface by.
+    #[getter]
+    fn surface_id(&self) -> PyResult<String> {
+        // Pooled textures carry no id yet: surface-share registration for a
+        // texture needs host timeline semaphores, which ride the
+        // pixel-exchange work.
+        self.minted_surface_id
+            .clone()
+            .ok_or_else(pixel_exchange_not_yet_implemented_error)
+    }
+
+    #[getter]
+    fn width(&self) -> u32 {
+        self.surface_width
+    }
+
+    #[getter]
+    fn height(&self) -> u32 {
+        self.surface_height
+    }
+
+    #[getter]
+    fn format(&self) -> String {
+        self.surface_format_name.clone()
+    }
+
+    /// Release the underlying GPU resource. Idempotent.
+    fn close(&self, python: Python<'_>) {
+        // Releasing can return a slot to a pool under engine locks and talk to
+        // the surface-share daemon — detached, like every potentially-blocking
+        // engine call.
+        python.detach(|| self.release_owned_engine_value());
+    }
+
+    fn __enter__(python_self: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        python_self
+    }
+
+    #[pyo3(signature = (*_exception_details))]
+    fn __exit__(&self, python: Python<'_>, _exception_details: &Bound<'_, PyAny>) -> bool {
+        self.close(python);
+        false
+    }
+
+    fn as_numpy(&self) -> PyResult<()> {
+        Err(pixel_exchange_not_yet_implemented_error())
+    }
+
+    fn __dlpack__(&self) -> PyResult<()> {
+        Err(pixel_exchange_not_yet_implemented_error())
+    }
+
+    fn lock(&self) -> PyResult<()> {
+        Err(pixel_exchange_not_yet_implemented_error())
+    }
+
+    fn unlock(&self) -> PyResult<()> {
+        Err(pixel_exchange_not_yet_implemented_error())
+    }
+}
+
+// =============================================================================
+// GPU capability views
+// =============================================================================
+
+fn gpu_operation_error(failure: impl std::fmt::Display) -> PyErr {
+    PyRuntimeError::new_err(failure.to_string())
+}
+
+/// The surface id a freshly-acquired pixel buffer travels under: the
+/// surface-share check-in when the store exists (so any process can resolve
+/// it), the pool id otherwise — the same rule the subprocess escalate
+/// handler applied.
+///
+/// A check-in comes back with the store that performed it, because it parks a
+/// strong clone of the buffer there — the handle owes that store a release.
+fn mint_pixel_buffer_surface_id(
+    surface_store: Option<SurfaceStore>,
+    pool_id: &PixelBufferPoolId,
+    pixel_buffer: &PixelBuffer,
+) -> PyResult<(String, Option<SurfaceStore>)> {
+    match surface_store {
+        Some(store) => {
+            let minted_surface_id = store.check_in(pixel_buffer).map_err(gpu_operation_error)?;
+            Ok((minted_surface_id, Some(store)))
+        }
+        None => Ok((pool_id.as_str().to_string(), None)),
+    }
+}
+
+/// Non-allocating GPU capability, valid for the whole processor life.
+///
+/// Holds an owned clone of the engine's `GpuContextLimitedAccess` — the one
+/// capability the engine documents as stash-safe — populated at the first
+/// lifecycle hook.
+#[pyclass(name = "GpuContextLimitedAccess", module = "streamlib", frozen)]
+pub(crate) struct PythonGpuContextLimitedAccess {
+    owned_engine_view: OnceLock<GpuContextLimitedAccess>,
+}
+
+impl PythonGpuContextLimitedAccess {
+    fn new_unprimed() -> Self {
+        Self {
+            owned_engine_view: OnceLock::new(),
+        }
+    }
+
+    fn prime_from_engine_view(&self, engine_view: GpuContextLimitedAccess) {
+        let _ = self.owned_engine_view.set(engine_view);
+    }
+
+    fn engine_view(&self) -> PyResult<&GpuContextLimitedAccess> {
+        self.owned_engine_view
+            .get()
+            .ok_or_else(context_not_yet_activated_error)
+    }
+}
+
+#[pymethods]
+impl PythonGpuContextLimitedAccess {
+    /// Acquire a pixel buffer from the pre-reserved pool.
+    #[pyo3(signature = (width, height, format = "bgra"))]
+    fn acquire_pixel_buffer(
+        &self,
+        python: Python<'_>,
+        width: u32,
+        height: u32,
+        format: &str,
+    ) -> PyResult<PythonGpuSurfaceHandle> {
+        let pixel_format = parse_pixel_format_name(format)?;
+        python.detach(|| {
+            let engine_view = self.engine_view()?;
+            let (pool_id, pixel_buffer) = engine_view
+                .acquire_pixel_buffer(width, height, pixel_format)
+                .map_err(gpu_operation_error)?;
+            let (minted_surface_id, surface_store_owing_a_release) =
+                mint_pixel_buffer_surface_id(engine_view.surface_store(), &pool_id, &pixel_buffer)?;
+            Ok(PythonGpuSurfaceHandle::from_acquired_pixel_buffer(
+                minted_surface_id,
+                surface_store_owing_a_release,
+                pixel_buffer,
+            ))
+        })
+    }
+
+    /// Acquire a pooled texture from the pre-reserved pool.
+    fn acquire_texture(
+        &self,
+        python: Python<'_>,
+        width: u32,
+        height: u32,
+        format: &str,
+        usage: Vec<String>,
+    ) -> PyResult<PythonGpuSurfaceHandle> {
+        let texture_format = parse_texture_format_name(format)?;
+        let texture_usages = parse_texture_usage_names(&usage)?;
+        python.detach(|| {
+            let engine_view = self.engine_view()?;
+            let descriptor = TexturePoolDescriptor::new(width, height, texture_format)
+                .with_usage(texture_usages);
+            let pooled_texture = engine_view
+                .acquire_texture(&descriptor)
+                .map_err(gpu_operation_error)?;
+            Ok(PythonGpuSurfaceHandle::from_pooled_texture(pooled_texture))
+        })
+    }
+
+    /// Resolve a surface id another processor published into a handle.
+    fn resolve_surface(
+        &self,
+        python: Python<'_>,
+        surface_id: &str,
+    ) -> PyResult<PythonGpuSurfaceHandle> {
+        python.detach(|| {
+            let engine_view = self.engine_view()?;
+            let pixel_buffer = engine_view
+                .resolve_pixel_buffer_by_surface_id(surface_id)
+                .map_err(gpu_operation_error)?;
+            Ok(PythonGpuSurfaceHandle::from_resolved_pixel_buffer(
+                surface_id.to_string(),
+                pixel_buffer,
+            ))
+        })
+    }
+}
+
+/// Privileged GPU capability, valid only while a full-access hook runs.
+#[pyclass(name = "GpuContextFullAccess", module = "streamlib", frozen)]
+pub(crate) struct PythonGpuContextFullAccess {
+    full_access_view_lease: FullAccessRuntimeContextViewLease,
+}
+
+#[pymethods]
+impl PythonGpuContextFullAccess {
+    /// Acquire a pixel buffer through the privileged path.
+    #[pyo3(signature = (width, height, format = "bgra"))]
+    fn acquire_pixel_buffer(
+        &self,
+        python: Python<'_>,
+        width: u32,
+        height: u32,
+        format: &str,
+    ) -> PyResult<PythonGpuSurfaceHandle> {
+        let pixel_format = parse_pixel_format_name(format)?;
+        read_full_access_view(python, &self.full_access_view_lease, |view| {
+            let gpu_full_access = view.gpu_full_access();
+            let (pool_id, pixel_buffer) = gpu_full_access
+                .acquire_pixel_buffer(width, height, pixel_format)
+                .map_err(gpu_operation_error)?;
+            let (minted_surface_id, surface_store_owing_a_release) = mint_pixel_buffer_surface_id(
+                gpu_full_access.surface_store(),
+                &pool_id,
+                &pixel_buffer,
+            )?;
+            Ok(PythonGpuSurfaceHandle::from_acquired_pixel_buffer(
+                minted_surface_id,
+                surface_store_owing_a_release,
+                pixel_buffer,
+            ))
+        })
+    }
+
+    /// Acquire a pooled texture through the privileged path.
+    fn acquire_texture(
+        &self,
+        python: Python<'_>,
+        width: u32,
+        height: u32,
+        format: &str,
+        usage: Vec<String>,
+    ) -> PyResult<PythonGpuSurfaceHandle> {
+        let texture_format = parse_texture_format_name(format)?;
+        let texture_usages = parse_texture_usage_names(&usage)?;
+        read_full_access_view(python, &self.full_access_view_lease, |view| {
+            let descriptor = TexturePoolDescriptor::new(width, height, texture_format)
+                .with_usage(texture_usages);
+            let pooled_texture = view
+                .gpu_full_access()
+                .acquire_texture(&descriptor)
+                .map_err(gpu_operation_error)?;
+            Ok(PythonGpuSurfaceHandle::from_pooled_texture(pooled_texture))
+        })
+    }
+
+    /// Block until the GPU device is idle.
+    fn wait_device_idle(&self, python: Python<'_>) -> PyResult<()> {
+        read_full_access_view(python, &self.full_access_view_lease, |view| {
+            view.gpu_full_access()
+                .wait_device_idle()
+                .map_err(gpu_operation_error)
+        })
+    }
+}
+
+// =============================================================================
+// Runtime context views
+// =============================================================================
+
+/// Privileged runtime context passed to `setup` / `teardown` / `start` / `stop`.
+#[pyclass(name = "RuntimeContextFullAccess", module = "streamlib", frozen)]
+pub(crate) struct PythonRuntimeContextFullAccess {
+    full_access_view_lease: FullAccessRuntimeContextViewLease,
+    cached_runtime_id: OnceLock<String>,
+    cached_processor_id: OnceLock<Option<String>>,
+    configuration: serde_json::Value,
+    link_input_data_reader: Py<PythonLinkInputDataReader>,
+    link_output_data_writer: Py<PythonLinkOutputDataWriter>,
+    gpu_limited_access_context: Py<PythonGpuContextLimitedAccess>,
+    gpu_full_access_context: Py<PythonGpuContextFullAccess>,
+}
+
+impl PythonRuntimeContextFullAccess {
+    pub(crate) fn create_for_processor(
+        python: Python<'_>,
+        configuration: serde_json::Value,
+        link_data_access: &Py<PythonProcessorLinkDataAccess>,
+    ) -> PyResult<Self> {
+        let full_access_view_lease: FullAccessRuntimeContextViewLease = Arc::new(RwLock::new(None));
+        Ok(Self {
+            gpu_full_access_context: Py::new(
+                python,
+                PythonGpuContextFullAccess {
+                    full_access_view_lease: Arc::clone(&full_access_view_lease),
+                },
+            )?,
+            gpu_limited_access_context: Py::new(
+                python,
+                PythonGpuContextLimitedAccess::new_unprimed(),
+            )?,
+            link_input_data_reader: Py::new(
+                python,
+                PythonLinkInputDataReader {
+                    link_data_access: link_data_access.clone_ref(python),
+                },
+            )?,
+            link_output_data_writer: Py::new(
+                python,
+                PythonLinkOutputDataWriter {
+                    link_data_access: link_data_access.clone_ref(python),
+                },
+            )?,
+            full_access_view_lease,
+            cached_runtime_id: OnceLock::new(),
+            cached_processor_id: OnceLock::new(),
+            configuration,
+        })
+    }
+
+    /// Called by the host with no GIL attached, before the hook is invoked.
+    pub(crate) fn install_view_lease_and_prime_caches(&self, view: &RuntimeContextFullAccess<'_>) {
+        self.cached_runtime_id.get_or_init(|| view.runtime_id());
+        self.cached_processor_id.get_or_init(|| view.processor_id());
+        self.gpu_limited_access_context
+            .get()
+            .prime_from_engine_view(view.gpu_limited_access().clone());
+        *self.full_access_view_lease.write() =
+            Some(FullAccessRuntimeContextViewPointer::from_engine_view(view));
+    }
+
+    /// Called by the host with no GIL attached, after the hook returned.
+    /// Blocks until every in-flight lease reader finishes.
+    pub(crate) fn revoke_view_lease(&self) {
+        *self.full_access_view_lease.write() = None;
+    }
+}
+
+#[pymethods]
+impl PythonRuntimeContextFullAccess {
+    /// The processor's configuration, as the dict it was added with.
+    #[getter]
+    fn config<'py>(&self, python: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        configuration_as_python_dict(python, &self.configuration)
+    }
+
+    /// Current monotonic time in nanoseconds (raw `CLOCK_MONOTONIC`).
+    #[getter]
+    fn time(&self) -> u64 {
+        monotonic_clock_now_ns()
+    }
+
+    #[getter]
+    fn inputs(&self, python: Python<'_>) -> Py<PythonLinkInputDataReader> {
+        self.link_input_data_reader.clone_ref(python)
+    }
+
+    #[getter]
+    fn outputs(&self, python: Python<'_>) -> Py<PythonLinkOutputDataWriter> {
+        self.link_output_data_writer.clone_ref(python)
+    }
+
+    #[getter]
+    fn gpu_limited_access(&self, python: Python<'_>) -> Py<PythonGpuContextLimitedAccess> {
+        self.gpu_limited_access_context.clone_ref(python)
+    }
+
+    #[getter]
+    fn gpu_full_access(&self, python: Python<'_>) -> Py<PythonGpuContextFullAccess> {
+        self.gpu_full_access_context.clone_ref(python)
+    }
+
+    #[getter]
+    fn runtime_id(&self) -> PyResult<String> {
+        self.cached_runtime_id
+            .get()
+            .cloned()
+            .ok_or_else(context_not_yet_activated_error)
+    }
+
+    #[getter]
+    fn processor_id(&self) -> PyResult<Option<String>> {
+        self.cached_processor_id
+            .get()
+            .cloned()
+            .ok_or_else(context_not_yet_activated_error)
+    }
+
+    /// Whether this processor is currently paused.
+    fn is_paused(&self, python: Python<'_>) -> PyResult<bool> {
+        read_full_access_view(python, &self.full_access_view_lease, |view| {
+            Ok(view.is_paused())
+        })
+    }
+
+    /// Whether processing should proceed (not paused).
+    fn should_process(&self, python: Python<'_>) -> PyResult<bool> {
+        read_full_access_view(python, &self.full_access_view_lease, |view| {
+            Ok(view.should_process())
+        })
+    }
+}
+
+/// Restricted runtime context passed to `process` / `on_pause` / `on_resume`.
+///
+/// `gpu_full_access` is deliberately absent — reaching for it raises
+/// `AttributeError`, mirroring the Rust capability split.
+#[pyclass(name = "RuntimeContextLimitedAccess", module = "streamlib", frozen)]
+pub(crate) struct PythonRuntimeContextLimitedAccess {
+    limited_access_view_lease: LimitedAccessRuntimeContextViewLease,
+    cached_runtime_id: OnceLock<String>,
+    cached_processor_id: OnceLock<Option<String>>,
+    configuration: serde_json::Value,
+    link_input_data_reader: Py<PythonLinkInputDataReader>,
+    link_output_data_writer: Py<PythonLinkOutputDataWriter>,
+    gpu_limited_access_context: Py<PythonGpuContextLimitedAccess>,
+}
+
+impl PythonRuntimeContextLimitedAccess {
+    pub(crate) fn create_for_processor(
+        python: Python<'_>,
+        configuration: serde_json::Value,
+        link_data_access: &Py<PythonProcessorLinkDataAccess>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            limited_access_view_lease: Arc::new(RwLock::new(None)),
+            cached_runtime_id: OnceLock::new(),
+            cached_processor_id: OnceLock::new(),
+            configuration,
+            link_input_data_reader: Py::new(
+                python,
+                PythonLinkInputDataReader {
+                    link_data_access: link_data_access.clone_ref(python),
+                },
+            )?,
+            link_output_data_writer: Py::new(
+                python,
+                PythonLinkOutputDataWriter {
+                    link_data_access: link_data_access.clone_ref(python),
+                },
+            )?,
+            gpu_limited_access_context: Py::new(
+                python,
+                PythonGpuContextLimitedAccess::new_unprimed(),
+            )?,
+        })
+    }
+
+    /// Called by the host with no GIL attached, before the hook is invoked.
+    pub(crate) fn install_view_lease_and_prime_caches(
+        &self,
+        view: &RuntimeContextLimitedAccess<'_>,
+    ) {
+        self.cached_runtime_id.get_or_init(|| view.runtime_id());
+        self.cached_processor_id.get_or_init(|| view.processor_id());
+        self.gpu_limited_access_context
+            .get()
+            .prime_from_engine_view(view.gpu_limited_access().clone());
+        *self.limited_access_view_lease.write() = Some(
+            LimitedAccessRuntimeContextViewPointer::from_engine_view(view),
+        );
+    }
+
+    /// Called by the host with no GIL attached, after the hook returned.
+    /// Blocks until every in-flight lease reader finishes.
+    pub(crate) fn revoke_view_lease(&self) {
+        *self.limited_access_view_lease.write() = None;
+    }
+}
+
+#[pymethods]
+impl PythonRuntimeContextLimitedAccess {
+    /// The processor's configuration, as the dict it was added with.
+    #[getter]
+    fn config<'py>(&self, python: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        configuration_as_python_dict(python, &self.configuration)
+    }
+
+    /// Current monotonic time in nanoseconds (raw `CLOCK_MONOTONIC`).
+    #[getter]
+    fn time(&self) -> u64 {
+        monotonic_clock_now_ns()
+    }
+
+    #[getter]
+    fn inputs(&self, python: Python<'_>) -> Py<PythonLinkInputDataReader> {
+        self.link_input_data_reader.clone_ref(python)
+    }
+
+    #[getter]
+    fn outputs(&self, python: Python<'_>) -> Py<PythonLinkOutputDataWriter> {
+        self.link_output_data_writer.clone_ref(python)
+    }
+
+    #[getter]
+    fn gpu_limited_access(&self, python: Python<'_>) -> Py<PythonGpuContextLimitedAccess> {
+        self.gpu_limited_access_context.clone_ref(python)
+    }
+
+    #[getter]
+    fn runtime_id(&self) -> PyResult<String> {
+        self.cached_runtime_id
+            .get()
+            .cloned()
+            .ok_or_else(context_not_yet_activated_error)
+    }
+
+    #[getter]
+    fn processor_id(&self) -> PyResult<Option<String>> {
+        self.cached_processor_id
+            .get()
+            .cloned()
+            .ok_or_else(context_not_yet_activated_error)
+    }
+
+    /// Whether this processor is currently paused.
+    fn is_paused(&self, python: Python<'_>) -> PyResult<bool> {
+        read_limited_access_view(python, &self.limited_access_view_lease, |view| {
+            Ok(view.is_paused())
+        })
+    }
+
+    /// Whether processing should proceed (not paused).
+    fn should_process(&self, python: Python<'_>) -> PyResult<bool> {
+        read_limited_access_view(python, &self.limited_access_view_lease, |view| {
+            Ok(view.should_process())
+        })
+    }
+}
+
+fn configuration_as_python_dict<'py>(
+    python: Python<'py>,
+    configuration: &serde_json::Value,
+) -> PyResult<Bound<'py, PyAny>> {
+    if configuration.is_null() {
+        return Ok(PyDict::new(python).into_any());
+    }
+    json_value_to_python_object(python, configuration)
+}
+
+// =============================================================================
+// Typed port access
+// =============================================================================
+
+/// A processor's input ports, as `ctx.inputs`.
+#[pyclass(name = "LinkInputDataReader", module = "streamlib", frozen)]
+pub(crate) struct PythonLinkInputDataReader {
+    link_data_access: Py<PythonProcessorLinkDataAccess>,
+}
+
+#[pymethods]
+impl PythonLinkInputDataReader {
+    /// The next bag on `port_name`, or `None` when the mailbox is empty.
+    fn read<'py>(
+        &self,
+        python: Python<'py>,
+        port_name: &str,
+    ) -> PyResult<Option<Bound<'py, PyAny>>> {
+        self.link_data_access
+            .get()
+            .read_from_input_port(python, port_name)
+    }
+
+    /// The next bag with its stamp, or `(None, None)` when empty.
+    fn read_with_timestamp<'py>(
+        &self,
+        python: Python<'py>,
+        port_name: &str,
+    ) -> PyResult<(Option<Bound<'py, PyAny>>, Option<i64>)> {
+        self.link_data_access
+            .get()
+            .read_from_input_port_with_timestamp(python, port_name)
+    }
+
+    /// Whether a bag is waiting on `port_name`, without consuming it.
+    fn has_data(&self, python: Python<'_>, port_name: &str) -> PyResult<bool> {
+        self.link_data_access
+            .get()
+            .input_port_has_data(python, port_name)
+    }
+}
+
+/// A processor's output ports, as `ctx.outputs`.
+#[pyclass(name = "LinkOutputDataWriter", module = "streamlib", frozen)]
+pub(crate) struct PythonLinkOutputDataWriter {
+    link_data_access: Py<PythonProcessorLinkDataAccess>,
+}
+
+#[pymethods]
+impl PythonLinkOutputDataWriter {
+    /// Publish one bag to every downstream link on `port_name`.
+    #[pyo3(signature = (port_name, bag, timestamp_ns = None))]
+    fn write(
+        &self,
+        python: Python<'_>,
+        port_name: &str,
+        bag: &Bound<'_, PyAny>,
+        timestamp_ns: Option<i64>,
+    ) -> PyResult<()> {
+        self.link_data_access
+            .get()
+            .write_to_output_port(python, port_name, bag, timestamp_ns)
+    }
+}
+
+// =============================================================================
+// Python-string <-> engine-enum format vocabularies
+// =============================================================================
+
+/// The same vocabulary the subprocess escalate handler accepted, so a
+/// processor migrated from the old SDK keeps its format strings.
+fn parse_pixel_format_name(name: &str) -> PyResult<PixelFormat> {
+    let normalized = name.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "bgra" | "bgra32" => Ok(PixelFormat::Bgra32),
+        "rgba" | "rgba32" => Ok(PixelFormat::Rgba32),
+        "argb" | "argb32" => Ok(PixelFormat::Argb32),
+        "rgba64" => Ok(PixelFormat::Rgba64),
+        "nv12" | "nv12_video_range" => Ok(PixelFormat::Nv12VideoRange),
+        "nv12_full_range" => Ok(PixelFormat::Nv12FullRange),
+        "uyvy" | "uyvy422" => Ok(PixelFormat::Uyvy422),
+        "yuyv" | "yuyv422" => Ok(PixelFormat::Yuyv422),
+        "gray" | "gray8" => Ok(PixelFormat::Gray8),
+        unknown => Err(PyValueError::new_err(format!(
+            "unknown pixel format {unknown:?}"
+        ))),
+    }
+}
+
+fn pixel_format_name(format: PixelFormat) -> &'static str {
+    match format {
+        PixelFormat::Bgra32 => "bgra32",
+        PixelFormat::Rgba32 => "rgba32",
+        PixelFormat::Argb32 => "argb32",
+        PixelFormat::Rgba64 => "rgba64",
+        PixelFormat::Nv12VideoRange => "nv12_video_range",
+        PixelFormat::Nv12FullRange => "nv12_full_range",
+        PixelFormat::Uyvy422 => "uyvy422",
+        PixelFormat::Yuyv422 => "yuyv422",
+        PixelFormat::Gray8 => "gray8",
+        PixelFormat::Unknown => "unknown",
+    }
+}
+
+fn parse_texture_format_name(name: &str) -> PyResult<TextureFormat> {
+    let normalized = name.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "rgba8_unorm" => Ok(TextureFormat::Rgba8Unorm),
+        "rgba8_unorm_srgb" => Ok(TextureFormat::Rgba8UnormSrgb),
+        "bgra8_unorm" => Ok(TextureFormat::Bgra8Unorm),
+        "bgra8_unorm_srgb" => Ok(TextureFormat::Bgra8UnormSrgb),
+        "rgba16_float" => Ok(TextureFormat::Rgba16Float),
+        "rgba32_float" => Ok(TextureFormat::Rgba32Float),
+        "nv12" => Ok(TextureFormat::Nv12),
+        unknown => Err(PyValueError::new_err(format!(
+            "unknown texture format {unknown:?}"
+        ))),
+    }
+}
+
+fn texture_format_name(format: TextureFormat) -> &'static str {
+    match format {
+        TextureFormat::Rgba8Unorm => "rgba8_unorm",
+        TextureFormat::Rgba8UnormSrgb => "rgba8_unorm_srgb",
+        TextureFormat::Bgra8Unorm => "bgra8_unorm",
+        TextureFormat::Bgra8UnormSrgb => "bgra8_unorm_srgb",
+        TextureFormat::Rgba16Float => "rgba16_float",
+        TextureFormat::Rgba32Float => "rgba32_float",
+        TextureFormat::Nv12 => "nv12",
+    }
+}
+
+fn parse_texture_usage_names(names: &[String]) -> PyResult<TextureUsages> {
+    if names.is_empty() {
+        return Err(PyValueError::new_err(
+            "texture usage list must not be empty",
+        ));
+    }
+    let mut usages = TextureUsages::NONE;
+    for name in names {
+        let normalized = name.trim().to_ascii_lowercase();
+        usages |= match normalized.as_str() {
+            "copy_src" => TextureUsages::COPY_SRC,
+            "copy_dst" => TextureUsages::COPY_DST,
+            "texture_binding" => TextureUsages::TEXTURE_BINDING,
+            "storage_binding" => TextureUsages::STORAGE_BINDING,
+            "render_attachment" => TextureUsages::RENDER_ATTACHMENT,
+            unknown => {
+                return Err(PyValueError::new_err(format!(
+                    "unknown texture usage {unknown:?}"
+                )));
+            }
+        };
+    }
+    Ok(usages)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every format string the old SDK accepted still parses, and every
+    /// engine variant renders back to the string it parses from.
+    #[test]
+    fn pixel_format_names_round_trip() {
+        for format in [
+            PixelFormat::Bgra32,
+            PixelFormat::Rgba32,
+            PixelFormat::Argb32,
+            PixelFormat::Rgba64,
+            PixelFormat::Nv12VideoRange,
+            PixelFormat::Nv12FullRange,
+            PixelFormat::Uyvy422,
+            PixelFormat::Yuyv422,
+            PixelFormat::Gray8,
+        ] {
+            assert_eq!(
+                parse_pixel_format_name(pixel_format_name(format)).unwrap(),
+                format
+            );
+        }
+        assert_eq!(
+            parse_pixel_format_name("bgra").unwrap(),
+            PixelFormat::Bgra32,
+            "the old SDK's default mnemonic must keep working"
+        );
+        assert!(parse_pixel_format_name("sepia").is_err());
+    }
+
+    #[test]
+    fn texture_format_names_round_trip() {
+        for format in [
+            TextureFormat::Rgba8Unorm,
+            TextureFormat::Rgba8UnormSrgb,
+            TextureFormat::Bgra8Unorm,
+            TextureFormat::Bgra8UnormSrgb,
+            TextureFormat::Rgba16Float,
+            TextureFormat::Rgba32Float,
+            TextureFormat::Nv12,
+        ] {
+            assert_eq!(
+                parse_texture_format_name(texture_format_name(format)).unwrap(),
+                format
+            );
+        }
+    }
+
+    #[test]
+    fn texture_usage_names_combine_and_refuse_unknowns() {
+        let usages =
+            parse_texture_usage_names(&["copy_src".to_string(), "render_attachment".to_string()])
+                .unwrap();
+        assert!(usages.contains(TextureUsages::COPY_SRC));
+        assert!(usages.contains(TextureUsages::RENDER_ATTACHMENT));
+        assert!(!usages.contains(TextureUsages::COPY_DST));
+        assert!(parse_texture_usage_names(&[]).is_err());
+        assert!(parse_texture_usage_names(&["paint".to_string()]).is_err());
+    }
+}

--- a/sdk/streamlib-python-wheel/src/python_processor_declaration.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_declaration.rs
@@ -1,0 +1,196 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Reading the `@processor` grammar off a Python class.
+//!
+//! The `__streamlib_processor_*__` attributes the decorator attaches are the
+//! contract between `_processor_declaration.py` and this module; the two move
+//! together.
+
+use pyo3::exceptions::PyTypeError;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+use streamlib::sdk::descriptors::{
+    Org, Package, PortDescriptor, PortSchemaSpec, ProcessorDescriptor, ProcessorRuntime,
+    ProcessorScheduling, SchemaIdent, SemVer, TypeName,
+};
+use streamlib::sdk::execution::{ExecutionConfig, ProcessExecution, ThreadPriority};
+use streamlib::sdk::processors::ProcessorTypeReference;
+
+/// The version every code-declared identity carries. A processor reference is
+/// version-free — the engine resolves types version-blind — so this is inert
+/// filler for the one struct that still has the field.
+const VERSION_FREE_SENTINEL: SemVer = SemVer::new(0, 0, 0);
+
+/// Everything the engine needs to register and instantiate one Python
+/// processor class.
+pub(crate) struct PythonProcessorDeclaration {
+    pub(crate) type_reference: ProcessorTypeReference,
+    pub(crate) descriptor: ProcessorDescriptor,
+    pub(crate) execution_config: ExecutionConfig,
+}
+
+impl PythonProcessorDeclaration {
+    /// Read the decorator's metadata off `processor_class`.
+    pub(crate) fn read_from_class(processor_class: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let type_reference = read_type_reference(processor_class)?;
+        let execution_config = read_execution_config(processor_class)?;
+
+        let mut descriptor = ProcessorDescriptor::new(
+            SchemaIdent::new(
+                type_reference.org().clone(),
+                type_reference.package().clone(),
+                type_reference.r#type().clone(),
+                VERSION_FREE_SENTINEL,
+            ),
+            read_string_attribute(processor_class, "__streamlib_processor_description__")?,
+        )
+        // Python here means "authored in Python and hosted in this
+        // interpreter", not the retired subprocess placement.
+        .with_runtime(ProcessorRuntime::Python)
+        .with_scheduling(ProcessorScheduling {
+            priority: read_thread_priority(processor_class)?,
+        });
+
+        descriptor.inputs = read_port_descriptors(processor_class, PortDirection::Input)?;
+        descriptor.outputs = read_port_descriptors(processor_class, PortDirection::Output)?;
+
+        Ok(Self {
+            type_reference,
+            descriptor,
+            execution_config,
+        })
+    }
+}
+
+/// Whether a Python class carries the decorator's metadata at all.
+pub(crate) fn is_declared_processor_class(candidate: &Bound<'_, PyAny>) -> bool {
+    candidate.is_instance_of::<pyo3::types::PyType>()
+        && candidate
+            .hasattr("__streamlib_processor_type_reference__")
+            .unwrap_or(false)
+}
+
+fn read_type_reference(processor_class: &Bound<'_, PyAny>) -> PyResult<ProcessorTypeReference> {
+    let reference = processor_class
+        .getattr("__streamlib_processor_type_reference__")?
+        .cast_into::<PyDict>()
+        .map_err(|_| {
+            PyTypeError::new_err(
+                "__streamlib_processor_type_reference__ must be a dict — the class was not \
+                 declared by @streamlib.processor",
+            )
+        })?;
+
+    let org = Org::new(read_dict_string(&reference, "org")?).map_err(ident_error)?;
+    let package = Package::new(read_dict_string(&reference, "package")?).map_err(ident_error)?;
+    let type_name = TypeName::new(read_dict_string(&reference, "type")?).map_err(ident_error)?;
+    Ok(ProcessorTypeReference::new(org, package, type_name))
+}
+
+fn read_execution_config(processor_class: &Bound<'_, PyAny>) -> PyResult<ExecutionConfig> {
+    let execution = processor_class
+        .getattr("__streamlib_processor_execution__")?
+        .cast_into::<PyDict>()
+        .map_err(|_| PyTypeError::new_err("__streamlib_processor_execution__ must be a dict"))?;
+
+    let mode = read_dict_string(&execution, "mode")?;
+    let execution = match mode.as_str() {
+        "reactive" => ProcessExecution::Reactive,
+        "manual" => ProcessExecution::Manual,
+        "continuous" => ProcessExecution::Continuous {
+            interval_ms: execution.get_item("interval_ms")?.map_or(Ok(0), |value| {
+                value.extract::<u32>().map_err(|_| {
+                    PyTypeError::new_err("__streamlib_processor_execution__.interval_ms must be an int")
+                })
+            })?,
+        },
+        unknown => {
+            return Err(PyTypeError::new_err(format!(
+                "unknown execution mode {unknown:?} — the decorator validates this, so a class \
+                 reaching here was built by hand rather than by @streamlib.processor"
+            )));
+        }
+    };
+    Ok(ExecutionConfig::new(execution))
+}
+
+fn read_thread_priority(processor_class: &Bound<'_, PyAny>) -> PyResult<ThreadPriority> {
+    let priority = processor_class.getattr("__streamlib_processor_scheduling_priority__")?;
+    if priority.is_none() {
+        return Ok(ThreadPriority::Normal);
+    }
+    match priority.extract::<String>()?.as_str() {
+        "realtime" => Ok(ThreadPriority::RealTime),
+        "high" => Ok(ThreadPriority::High),
+        "normal" => Ok(ThreadPriority::Normal),
+        unknown => Err(PyTypeError::new_err(format!(
+            "unknown scheduling priority {unknown:?}"
+        ))),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum PortDirection {
+    Input,
+    Output,
+}
+
+impl PortDirection {
+    fn class_attribute(self) -> &'static str {
+        match self {
+            Self::Input => "__streamlib_processor_input_ports__",
+            Self::Output => "__streamlib_processor_output_ports__",
+        }
+    }
+}
+
+fn read_port_descriptors(
+    processor_class: &Bound<'_, PyAny>,
+    direction: PortDirection,
+) -> PyResult<Vec<PortDescriptor>> {
+    let attribute = direction.class_attribute();
+    let declared = processor_class
+        .getattr(attribute)?
+        .cast_into::<PyList>()
+        .map_err(|_| PyTypeError::new_err(format!("{attribute} must be a list")))?;
+
+    let mut ports = Vec::with_capacity(declared.len());
+    for declaration in declared.iter() {
+        let declaration = declaration
+            .cast_into::<PyDict>()
+            .map_err(|_| PyTypeError::new_err(format!("{attribute} must hold dicts")))?;
+
+        // Every Python port is a wildcard: the wire is self-describing and
+        // consuming is a cast at read time, so a port declares no schema for
+        // the engine to agree on.
+        let mut port = PortDescriptor::iceoryx2(
+            read_dict_string(&declaration, "name")?,
+            read_dict_string(&declaration, "description")?,
+            PortSchemaSpec::Any,
+        );
+        if let Some(delivery_profile) = declaration
+            .get_item("delivery_profile")?
+            .filter(|declared| !declared.is_none())
+        {
+            port = port.with_delivery_profile(delivery_profile.extract::<String>()?);
+        }
+        ports.push(port);
+    }
+    Ok(ports)
+}
+
+fn read_string_attribute(object: &Bound<'_, PyAny>, attribute: &str) -> PyResult<String> {
+    object.getattr(attribute)?.extract::<String>()
+}
+
+fn read_dict_string(dictionary: &Bound<'_, PyDict>, key: &str) -> PyResult<String> {
+    dictionary
+        .get_item(key)?
+        .ok_or_else(|| PyTypeError::new_err(format!("missing key {key:?}")))?
+        .extract::<String>()
+}
+
+fn ident_error(failure: impl std::fmt::Display) -> PyErr {
+    PyTypeError::new_err(failure.to_string())
+}

--- a/sdk/streamlib-python-wheel/src/python_processor_declaration.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_declaration.rs
@@ -163,13 +163,10 @@ fn read_port_descriptors(
             .cast_into::<PyDict>()
             .map_err(|_| PyTypeError::new_err(format!("{attribute} must hold dicts")))?;
 
-        // Every Python port is a wildcard: the wire is self-describing and
-        // consuming is a cast at read time, so a port declares no schema for
-        // the engine to agree on.
         let mut port = PortDescriptor::iceoryx2(
             read_dict_string(&declaration, "name")?,
             read_dict_string(&declaration, "description")?,
-            PortSchemaSpec::Any,
+            port_schema_spec_from_declaration(&declaration)?,
         );
         if let Some(delivery_profile) = declaration
             .get_item("delivery_profile")?
@@ -180,6 +177,32 @@ fn read_port_descriptors(
         ports.push(port);
     }
     Ok(ports)
+}
+
+/// The port's declared schema: absent or `None` means a wildcard — the wire
+/// is self-describing and consuming is a cast at read time — while a typed
+/// declaration names the schema for the engine to agree on.
+fn port_schema_spec_from_declaration(declaration: &Bound<'_, PyDict>) -> PyResult<PortSchemaSpec> {
+    let Some(schema) = declaration
+        .get_item("schema")?
+        .filter(|declared| !declared.is_none())
+    else {
+        return Ok(PortSchemaSpec::Any);
+    };
+    let schema = schema.cast_into::<PyDict>().map_err(|_| {
+        PyTypeError::new_err(
+            "a port's \"schema\" must be a dict with org, package, type and version keys",
+        )
+    })?;
+    let org = Org::new(read_dict_string(&schema, "org")?).map_err(ident_error)?;
+    let package = Package::new(read_dict_string(&schema, "package")?).map_err(ident_error)?;
+    let type_name = TypeName::new(read_dict_string(&schema, "type")?).map_err(ident_error)?;
+    let version = read_dict_string(&schema, "version")?
+        .parse::<SemVer>()
+        .map_err(ident_error)?;
+    Ok(PortSchemaSpec::Specific(SchemaIdent::new(
+        org, package, type_name, version,
+    )))
 }
 
 fn read_string_attribute(object: &Bound<'_, PyAny>, attribute: &str) -> PyResult<String> {
@@ -195,4 +218,80 @@ fn read_dict_string(dictionary: &Bound<'_, PyDict>, key: &str) -> PyResult<Strin
 
 fn ident_error(failure: impl std::fmt::Display) -> PyErr {
     PyTypeError::new_err(failure.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The tolerant reading: no `"schema"` key and an explicit `None` both
+    /// mean wildcard, so pre-schema Python declarations keep working.
+    #[test]
+    fn a_port_without_a_schema_declaration_is_a_wildcard() {
+        Python::initialize();
+        Python::attach(|python| {
+            let declaration = PyDict::new(python);
+            assert!(matches!(
+                port_schema_spec_from_declaration(&declaration).unwrap(),
+                PortSchemaSpec::Any
+            ));
+
+            declaration.set_item("schema", python.None()).unwrap();
+            assert!(matches!(
+                port_schema_spec_from_declaration(&declaration).unwrap(),
+                PortSchemaSpec::Any
+            ));
+        });
+    }
+
+    #[test]
+    fn a_four_key_schema_dict_becomes_a_specific_ident() {
+        Python::initialize();
+        Python::attach(|python| {
+            let schema = PyDict::new(python);
+            schema.set_item("org", "tatolab").unwrap();
+            schema.set_item("package", "video").unwrap();
+            schema.set_item("type", "VideoFrame").unwrap();
+            schema.set_item("version", "1.2.3").unwrap();
+            let declaration = PyDict::new(python);
+            declaration.set_item("schema", schema).unwrap();
+
+            let spec = port_schema_spec_from_declaration(&declaration).unwrap();
+            let PortSchemaSpec::Specific(ident) = spec else {
+                panic!("expected Specific, got {spec:?}");
+            };
+            assert_eq!(
+                ident,
+                SchemaIdent::new(
+                    Org::new("tatolab").unwrap(),
+                    Package::new("video").unwrap(),
+                    TypeName::new("VideoFrame").unwrap(),
+                    SemVer::new(1, 2, 3),
+                )
+            );
+        });
+    }
+
+    #[test]
+    fn a_malformed_schema_declaration_is_refused() {
+        Python::initialize();
+        Python::attach(|python| {
+            let missing_version = PyDict::new(python);
+            missing_version.set_item("org", "tatolab").unwrap();
+            missing_version.set_item("package", "video").unwrap();
+            missing_version.set_item("type", "VideoFrame").unwrap();
+            let declaration = PyDict::new(python);
+            declaration.set_item("schema", &missing_version).unwrap();
+            assert!(port_schema_spec_from_declaration(&declaration).is_err());
+
+            missing_version
+                .set_item("version", "not-a-version")
+                .unwrap();
+            assert!(port_schema_spec_from_declaration(&declaration).is_err());
+
+            let declaration = PyDict::new(python);
+            declaration.set_item("schema", "VideoFrame").unwrap();
+            assert!(port_schema_spec_from_declaration(&declaration).is_err());
+        });
+    }
 }

--- a/sdk/streamlib-python-wheel/src/python_processor_declaration.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_declaration.rs
@@ -101,7 +101,9 @@ fn read_execution_config(processor_class: &Bound<'_, PyAny>) -> PyResult<Executi
         "continuous" => ProcessExecution::Continuous {
             interval_ms: execution.get_item("interval_ms")?.map_or(Ok(0), |value| {
                 value.extract::<u32>().map_err(|_| {
-                    PyTypeError::new_err("__streamlib_processor_execution__.interval_ms must be an int")
+                    PyTypeError::new_err(
+                        "__streamlib_processor_execution__.interval_ms must be an int",
+                    )
                 })
             })?,
         },

--- a/sdk/streamlib-python-wheel/src/python_processor_host.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_host.rs
@@ -1,0 +1,271 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The engine-side host for a processor authored in Python.
+//!
+//! One of these runs on each Python processor's dedicated engine thread. It
+//! attaches the GIL for exactly the span of a user callback and holds it for
+//! nothing else — not the wait between ticks, not the reactive loop's block on
+//! an input, not teardown's join. That is what lets a processor parked in a
+//! native call leave every other Python processor running.
+
+use pyo3::prelude::*;
+use streamlib::sdk::descriptors::ProcessorDescriptor;
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::execution::ExecutionConfig;
+use streamlib::sdk::graph::ProcessorNode;
+use streamlib::sdk::iceoryx2::{InputMailboxes, OutputWriter};
+use streamlib::sdk::processors::DynGeneratedProcessor;
+
+use crate::python_bag_conversion::json_value_to_python_object;
+use crate::python_processor_declaration::PythonProcessorDeclaration;
+use crate::python_processor_link_data_access::PythonProcessorLinkDataAccess;
+
+/// The module holding the Python half of processor construction.
+const PROCESSOR_HOSTING_MODULE: &str = "streamlib._processor_hosting";
+
+/// The lifecycle hooks a processor class may define. Absent hooks are not
+/// errors — a filter that only implements `process` is the common case.
+const SETUP_HOOK: &str = "setup";
+const TEARDOWN_HOOK: &str = "teardown";
+const PROCESS_HOOK: &str = "process";
+const START_HOOK: &str = "start";
+const STOP_HOOK: &str = "stop";
+const ON_PAUSE_HOOK: &str = "on_pause";
+const ON_RESUME_HOOK: &str = "on_resume";
+
+pub(crate) struct PythonProcessorHost {
+    /// The user's own object. Constructed once, on the thread that calls
+    /// `Runtime.add`, and used only from its processor thread after that.
+    processor_instance: Py<PyAny>,
+    link_data_access: Py<PythonProcessorLinkDataAccess>,
+    descriptor: ProcessorDescriptor,
+    execution_config: ExecutionConfig,
+    /// Names this processor in every log line and error — the graph's display
+    /// name, which is what the author sees in `streamlib graph`.
+    processor_display_name: String,
+}
+
+impl PythonProcessorHost {
+    /// Construct the user's processor object and bind its declared ports.
+    pub(crate) fn construct(
+        declaration: &PythonProcessorDeclaration,
+        processor_class: &Py<PyAny>,
+        node: &ProcessorNode,
+    ) -> Result<Self> {
+        let processor_display_name = node.display_name.clone();
+        let held_display_name = processor_display_name.clone();
+        let configuration = node.config.clone();
+
+        Python::attach(move |python| -> PyResult<Self> {
+            let link_data_access =
+                Py::new(python, PythonProcessorLinkDataAccess::new())?;
+
+            let hosting = python.import(PROCESSOR_HOSTING_MODULE)?;
+            let processor_instance = hosting
+                .getattr("construct_processor_instance")?
+                .call1((
+                    processor_class.bind(python),
+                    configuration
+                        .as_ref()
+                        .map(|config| json_value_to_python_object(python, config))
+                        .transpose()?,
+                    link_data_access.bind(python),
+                ))?
+                .unbind();
+
+            Ok(Self {
+                processor_instance,
+                link_data_access,
+                descriptor: declaration.descriptor.clone(),
+                execution_config: declaration.execution_config,
+                processor_display_name: held_display_name,
+            })
+        })
+        .map_err(|construction_failure| {
+            Error::Runtime(format_python_failure(
+                &processor_display_name,
+                "could not be constructed",
+                construction_failure,
+            ))
+        })
+    }
+
+    /// Call a lifecycle hook if the class defines one.
+    ///
+    /// The GIL is attached here and released the moment the callback returns.
+    fn dispatch_hook(&mut self, hook: &str) -> Result<()> {
+        Python::attach(|python| -> PyResult<()> {
+            let processor_instance = self.processor_instance.bind(python);
+            if !processor_instance.hasattr(hook)? {
+                return Ok(());
+            }
+            processor_instance.call_method0(hook)?;
+            Ok(())
+        })
+        .map_err(|hook_failure| {
+            Error::Runtime(format_python_failure(
+                &self.processor_display_name,
+                &format!("raised in {hook}()"),
+                hook_failure,
+            ))
+        })
+    }
+}
+
+/// Render a Python exception with its traceback, so a processor failure reads
+/// like a Python failure rather than a one-line summary of one.
+fn format_python_failure(processor_display_name: &str, what: &str, failure: PyErr) -> String {
+    let rendered = Python::attach(|python| match failure.traceback(python) {
+        Some(traceback) => match traceback.format() {
+            Ok(formatted) => format!("{formatted}{}", failure.value(python)),
+            Err(_) => failure.to_string(),
+        },
+        None => failure.to_string(),
+    });
+    format!("[{processor_display_name}] {what}:\n{rendered}")
+}
+
+impl DynGeneratedProcessor for PythonProcessorHost {
+    fn __generated_setup(
+        &mut self,
+        _ctx: &streamlib::sdk::context::RuntimeContextFullAccess<'_>,
+    ) -> Result<()> {
+        self.dispatch_hook(SETUP_HOOK)
+    }
+
+    fn __generated_teardown(
+        &mut self,
+        _ctx: &streamlib::sdk::context::RuntimeContextFullAccess<'_>,
+    ) -> Result<()> {
+        self.dispatch_hook(TEARDOWN_HOOK)
+    }
+
+    fn __generated_on_pause(
+        &mut self,
+        _ctx: &streamlib::sdk::context::RuntimeContextLimitedAccess<'_>,
+    ) -> Result<()> {
+        self.dispatch_hook(ON_PAUSE_HOOK)
+    }
+
+    fn __generated_on_resume(
+        &mut self,
+        _ctx: &streamlib::sdk::context::RuntimeContextLimitedAccess<'_>,
+    ) -> Result<()> {
+        self.dispatch_hook(ON_RESUME_HOOK)
+    }
+
+    fn process(
+        &mut self,
+        _ctx: &streamlib::sdk::context::RuntimeContextLimitedAccess<'_>,
+    ) -> Result<()> {
+        self.dispatch_hook(PROCESS_HOOK)
+    }
+
+    fn start(
+        &mut self,
+        _ctx: &streamlib::sdk::context::RuntimeContextFullAccess<'_>,
+    ) -> Result<()> {
+        self.dispatch_hook(START_HOOK)
+    }
+
+    fn stop(&mut self, _ctx: &streamlib::sdk::context::RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.dispatch_hook(STOP_HOOK)
+    }
+
+    fn name(&self) -> &str {
+        &self.processor_display_name
+    }
+
+    fn descriptor(&self) -> Option<ProcessorDescriptor> {
+        Some(self.descriptor.clone())
+    }
+
+    fn execution_config(&self) -> ExecutionConfig {
+        self.execution_config
+    }
+
+    fn has_iceoryx2_outputs(&self) -> bool {
+        !self.descriptor.outputs.is_empty()
+    }
+
+    fn has_iceoryx2_inputs(&self) -> bool {
+        !self.descriptor.inputs.is_empty()
+    }
+
+    fn set_iceoryx2_resources(
+        &mut self,
+        output_writer: Option<OutputWriter>,
+        input_mailboxes: Option<InputMailboxes>,
+    ) -> Result<()> {
+        // Reached for the inner Arc rather than kept as the PluginAbiObject
+        // pair: the inner is an ordinary `Send + Sync` Rust value that the
+        // Python-facing object can hold, and calling it skips the vtable hop
+        // the host would otherwise take to reach itself.
+        let link_data_access = self.link_data_access.get();
+        if let Some(output_writer) = output_writer.and_then(|writer| writer.inner_arc()) {
+            link_data_access.install_output_writer(output_writer);
+        }
+        if let Some(input_mailboxes) = input_mailboxes.and_then(|mailboxes| mailboxes.inner_arc()) {
+            link_data_access.install_input_mailboxes(input_mailboxes);
+        }
+        Ok(())
+    }
+
+    fn iceoryx2_output_writer_inner(&self) -> Option<std::sync::Arc<streamlib::sdk::iceoryx2::OutputWriterInner>> {
+        self.link_data_access.get().output_writer_inner()
+    }
+
+    fn iceoryx2_input_mailboxes_inner(
+        &self,
+    ) -> Option<std::sync::Arc<streamlib::sdk::iceoryx2::InputMailboxesInner>> {
+        self.link_data_access.get().input_mailboxes_inner()
+    }
+
+    fn apply_config_json(&mut self, config_json: &serde_json::Value) -> Result<()> {
+        Python::attach(|python| -> PyResult<()> {
+            let processor_instance = self.processor_instance.bind(python);
+            let hosting = python.import(PROCESSOR_HOSTING_MODULE)?;
+            hosting.getattr("apply_configuration")?.call1((
+                processor_instance,
+                json_value_to_python_object(python, config_json)?,
+            ))?;
+            Ok(())
+        })
+        .map_err(|configuration_failure| {
+            Error::Runtime(format_python_failure(
+                &self.processor_display_name,
+                "refused a configuration update",
+                configuration_failure,
+            ))
+        })
+    }
+
+    fn to_runtime_json(&self) -> serde_json::Value {
+        serde_json::Value::Null
+    }
+
+    fn config_json(&self) -> serde_json::Value {
+        serde_json::Value::Null
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+impl Drop for PythonProcessorHost {
+    /// Releases the user's object while holding the GIL.
+    ///
+    /// Dropping a `Py` without the GIL only queues the decrement for whichever
+    /// thread attaches next, so a processor holding a file, a socket or a device
+    /// context would keep it open past the teardown the author can observe.
+    fn drop(&mut self) {
+        Python::attach(|python| {
+            drop(std::mem::replace(
+                &mut self.processor_instance,
+                python.None(),
+            ));
+        });
+    }
+}

--- a/sdk/streamlib-python-wheel/src/python_processor_host.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_host.rs
@@ -9,7 +9,10 @@
 //! an input, not teardown's join. That is what lets a processor parked in a
 //! native call leave every other Python processor running.
 
+use std::sync::{Arc, OnceLock};
+
 use pyo3::prelude::*;
+use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
 use streamlib::sdk::descriptors::ProcessorDescriptor;
 use streamlib::sdk::error::{Error, Result};
 use streamlib::sdk::execution::ExecutionConfig;
@@ -18,6 +21,12 @@ use streamlib::sdk::iceoryx2::{InputMailboxes, OutputWriter};
 use streamlib::sdk::processors::DynGeneratedProcessor;
 
 use crate::python_bag_conversion::json_value_to_python_object;
+use crate::python_logging::{
+    PythonProcessorLogAttribution, set_current_python_processor_log_attribution,
+};
+use crate::python_processor_context::{
+    PythonRuntimeContextFullAccess, PythonRuntimeContextLimitedAccess,
+};
 use crate::python_processor_declaration::PythonProcessorDeclaration;
 use crate::python_processor_link_data_access::PythonProcessorLinkDataAccess;
 
@@ -64,6 +73,13 @@ impl ProcessorLifecycleHook {
     }
 }
 
+/// The engine view a lifecycle hook was handed, phase-mapped by the trait
+/// impl below: Setup/Teardown/Start/Stop carry Full, the hot path Limited.
+enum LifecycleHookContextView<'call, 'engine> {
+    FullAccess(&'call RuntimeContextFullAccess<'engine>),
+    LimitedAccess(&'call RuntimeContextLimitedAccess<'engine>),
+}
+
 pub(crate) struct PythonProcessorHost {
     /// The user's own object. Constructed on the engine's compile thread as the
     /// graph comes up, then used only from this processor's own dedicated
@@ -72,6 +88,11 @@ pub(crate) struct PythonProcessorHost {
     /// `Option` so [`Drop`] can take it and release it while attached.
     processor_instance: Option<Py<PyAny>>,
     link_data_access: Option<Py<PythonProcessorLinkDataAccess>>,
+    /// The two long-lived context objects hooks receive; their leases are
+    /// installed and revoked around every invocation, so no per-tick
+    /// allocation happens here.
+    full_access_runtime_context: Option<Py<PythonRuntimeContextFullAccess>>,
+    limited_access_runtime_context: Option<Py<PythonRuntimeContextLimitedAccess>>,
     /// Which hooks the class defines, indexed by [`ProcessorLifecycleHook`].
     declared_hooks: [bool; ProcessorLifecycleHook::ALL.len()],
     descriptor: ProcessorDescriptor,
@@ -79,6 +100,9 @@ pub(crate) struct PythonProcessorHost {
     /// Names this processor in every log line and error — the graph's display
     /// name, which is what the author sees in `streamlib graph`.
     processor_display_name: String,
+    /// Built at the first hook (the id comes from the engine view) and shared
+    /// with the per-thread marker `log_event` reads.
+    log_attribution: OnceLock<Arc<PythonProcessorLogAttribution>>,
 }
 
 impl PythonProcessorHost {
@@ -94,6 +118,23 @@ impl PythonProcessorHost {
 
         Python::attach(move |python| -> PyResult<Self> {
             let link_data_access = Py::new(python, PythonProcessorLinkDataAccess::new())?;
+            let context_configuration = configuration.clone().unwrap_or(serde_json::Value::Null);
+            let full_access_runtime_context = Py::new(
+                python,
+                PythonRuntimeContextFullAccess::create_for_processor(
+                    python,
+                    context_configuration.clone(),
+                    &link_data_access,
+                )?,
+            )?;
+            let limited_access_runtime_context = Py::new(
+                python,
+                PythonRuntimeContextLimitedAccess::create_for_processor(
+                    python,
+                    context_configuration,
+                    &link_data_access,
+                )?,
+            )?;
 
             let hosting = python.import(PROCESSOR_HOSTING_MODULE)?;
             let processor_instance = hosting.getattr("construct_processor_instance")?.call1((
@@ -114,10 +155,13 @@ impl PythonProcessorHost {
             Ok(Self {
                 processor_instance: Some(processor_instance.unbind()),
                 link_data_access: Some(link_data_access),
+                full_access_runtime_context: Some(full_access_runtime_context),
+                limited_access_runtime_context: Some(limited_access_runtime_context),
                 declared_hooks,
                 descriptor: declaration.descriptor.clone(),
                 execution_config: declaration.execution_config,
                 processor_display_name: held_display_name,
+                log_attribution: OnceLock::new(),
             })
         })
         .map_err(|construction_failure| {
@@ -129,11 +173,24 @@ impl PythonProcessorHost {
         })
     }
 
-    /// Call a lifecycle hook, if the class defined one.
+    /// Call a lifecycle hook, if the class defined one, handing it the
+    /// phase-matched context object.
     ///
     /// A class that did not costs no GIL acquisition at all — which is the
     /// per-tick path for a processor driven by something other than `process`.
-    fn dispatch_hook(&mut self, hook: ProcessorLifecycleHook) -> Result<()> {
+    ///
+    /// Per invocation: (with no GIL attached) install the context's view
+    /// lease and the log-attribution marker, attach and call the hook with
+    /// the context object, then (detached again) revoke the lease — whose
+    /// write-lock acquisition blocks until any thread still reading through
+    /// the context finishes. A hook defined without the ctx parameter
+    /// TypeErrors through the failure formatter below; that loud failure is
+    /// the contract.
+    fn dispatch_hook(
+        &mut self,
+        hook: ProcessorLifecycleHook,
+        context_view: LifecycleHookContextView<'_, '_>,
+    ) -> Result<()> {
         if !self.declared_hooks[hook as usize] {
             return Ok(());
         }
@@ -141,13 +198,58 @@ impl PythonProcessorHost {
             return Ok(());
         };
 
-        Python::attach(|python| -> PyResult<()> {
-            processor_instance
-                .bind(python)
-                .call_method0(hook.python_method_name())?;
-            Ok(())
-        })
-        .map_err(|hook_failure| {
+        let hook_outcome = match context_view {
+            LifecycleHookContextView::FullAccess(engine_view) => {
+                let Some(context) = self.full_access_runtime_context.as_ref() else {
+                    return Ok(());
+                };
+                let log_attribution = self.log_attribution.get_or_init(|| {
+                    Arc::new(PythonProcessorLogAttribution {
+                        processor_id: engine_view.processor_id(),
+                        processor_display_name: self.processor_display_name.clone(),
+                    })
+                });
+                set_current_python_processor_log_attribution(Some(Arc::clone(log_attribution)));
+                context
+                    .get()
+                    .install_view_lease_and_prime_caches(engine_view);
+                let _lease_guard = LifecycleHookLeaseGuard {
+                    revoke_view_lease: Box::new(|| context.get().revoke_view_lease()),
+                };
+                Python::attach(|python| -> PyResult<()> {
+                    processor_instance
+                        .bind(python)
+                        .call_method1(hook.python_method_name(), (context.bind(python),))?;
+                    Ok(())
+                })
+            }
+            LifecycleHookContextView::LimitedAccess(engine_view) => {
+                let Some(context) = self.limited_access_runtime_context.as_ref() else {
+                    return Ok(());
+                };
+                let log_attribution = self.log_attribution.get_or_init(|| {
+                    Arc::new(PythonProcessorLogAttribution {
+                        processor_id: engine_view.processor_id(),
+                        processor_display_name: self.processor_display_name.clone(),
+                    })
+                });
+                set_current_python_processor_log_attribution(Some(Arc::clone(log_attribution)));
+                context
+                    .get()
+                    .install_view_lease_and_prime_caches(engine_view);
+                let _lease_guard = LifecycleHookLeaseGuard {
+                    revoke_view_lease: Box::new(|| context.get().revoke_view_lease()),
+                };
+                Python::attach(|python| -> PyResult<()> {
+                    processor_instance
+                        .bind(python)
+                        .call_method1(hook.python_method_name(), (context.bind(python),))?;
+                    Ok(())
+                })
+            }
+        };
+
+        hook_outcome.map_err(|hook_failure| {
             Error::Runtime(format_python_failure(
                 &self.processor_display_name,
                 &format!("raised in {}()", hook.python_method_name()),
@@ -174,51 +276,71 @@ fn format_python_failure(processor_display_name: &str, what: &str, failure: PyEr
     format!("[{processor_display_name}] {what}:\n{rendered}")
 }
 
+/// Revokes a context's view lease and clears log attribution when dropped.
+///
+/// A guard rather than straight-line calls so a Rust panic unwinding out of
+/// the hook invocation cannot leave the lease holding a pointer into a dead
+/// stack frame — the revoke is the entire safety argument for the lease's
+/// lifetime erasure, so it must run on every exit path.
+struct LifecycleHookLeaseGuard<'host> {
+    revoke_view_lease: Box<dyn Fn() + 'host>,
+}
+
+impl Drop for LifecycleHookLeaseGuard<'_> {
+    fn drop(&mut self) {
+        (self.revoke_view_lease)();
+        set_current_python_processor_log_attribution(None);
+    }
+}
+
 impl DynGeneratedProcessor for PythonProcessorHost {
-    fn __generated_setup(
-        &mut self,
-        _ctx: &streamlib::sdk::context::RuntimeContextFullAccess<'_>,
-    ) -> Result<()> {
-        self.dispatch_hook(ProcessorLifecycleHook::Setup)
+    fn __generated_setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.dispatch_hook(
+            ProcessorLifecycleHook::Setup,
+            LifecycleHookContextView::FullAccess(ctx),
+        )
     }
 
-    fn __generated_teardown(
-        &mut self,
-        _ctx: &streamlib::sdk::context::RuntimeContextFullAccess<'_>,
-    ) -> Result<()> {
-        self.dispatch_hook(ProcessorLifecycleHook::Teardown)
+    fn __generated_teardown(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.dispatch_hook(
+            ProcessorLifecycleHook::Teardown,
+            LifecycleHookContextView::FullAccess(ctx),
+        )
     }
 
-    fn __generated_on_pause(
-        &mut self,
-        _ctx: &streamlib::sdk::context::RuntimeContextLimitedAccess<'_>,
-    ) -> Result<()> {
-        self.dispatch_hook(ProcessorLifecycleHook::OnPause)
+    fn __generated_on_pause(&mut self, ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        self.dispatch_hook(
+            ProcessorLifecycleHook::OnPause,
+            LifecycleHookContextView::LimitedAccess(ctx),
+        )
     }
 
-    fn __generated_on_resume(
-        &mut self,
-        _ctx: &streamlib::sdk::context::RuntimeContextLimitedAccess<'_>,
-    ) -> Result<()> {
-        self.dispatch_hook(ProcessorLifecycleHook::OnResume)
+    fn __generated_on_resume(&mut self, ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        self.dispatch_hook(
+            ProcessorLifecycleHook::OnResume,
+            LifecycleHookContextView::LimitedAccess(ctx),
+        )
     }
 
-    fn process(
-        &mut self,
-        _ctx: &streamlib::sdk::context::RuntimeContextLimitedAccess<'_>,
-    ) -> Result<()> {
-        self.dispatch_hook(ProcessorLifecycleHook::Process)
+    fn process(&mut self, ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        self.dispatch_hook(
+            ProcessorLifecycleHook::Process,
+            LifecycleHookContextView::LimitedAccess(ctx),
+        )
     }
 
-    fn start(
-        &mut self,
-        _ctx: &streamlib::sdk::context::RuntimeContextFullAccess<'_>,
-    ) -> Result<()> {
-        self.dispatch_hook(ProcessorLifecycleHook::Start)
+    fn start(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.dispatch_hook(
+            ProcessorLifecycleHook::Start,
+            LifecycleHookContextView::FullAccess(ctx),
+        )
     }
 
-    fn stop(&mut self, _ctx: &streamlib::sdk::context::RuntimeContextFullAccess<'_>) -> Result<()> {
-        self.dispatch_hook(ProcessorLifecycleHook::Stop)
+    fn stop(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.dispatch_hook(
+            ProcessorLifecycleHook::Stop,
+            LifecycleHookContextView::FullAccess(ctx),
+        )
     }
 
     fn name(&self) -> &str {
@@ -320,6 +442,8 @@ impl Drop for PythonProcessorHost {
         Python::attach(|_python| {
             drop(self.processor_instance.take());
             drop(self.link_data_access.take());
+            drop(self.full_access_runtime_context.take());
+            drop(self.limited_access_runtime_context.take());
         });
     }
 }

--- a/sdk/streamlib-python-wheel/src/python_processor_host.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_host.rs
@@ -24,21 +24,56 @@ use crate::python_processor_link_data_access::PythonProcessorLinkDataAccess;
 /// The module holding the Python half of processor construction.
 const PROCESSOR_HOSTING_MODULE: &str = "streamlib._processor_hosting";
 
-/// The lifecycle hooks a processor class may define. Absent hooks are not
-/// errors — a filter that only implements `process` is the common case.
-const SETUP_HOOK: &str = "setup";
-const TEARDOWN_HOOK: &str = "teardown";
-const PROCESS_HOOK: &str = "process";
-const START_HOOK: &str = "start";
-const STOP_HOOK: &str = "stop";
-const ON_PAUSE_HOOK: &str = "on_pause";
-const ON_RESUME_HOOK: &str = "on_resume";
+/// A lifecycle callback a processor class may define.
+///
+/// All of them are optional — a filter implementing only `process` is the
+/// common case — so which ones exist is resolved once at construction rather
+/// than rediscovered on every tick.
+#[derive(Clone, Copy)]
+enum ProcessorLifecycleHook {
+    Setup,
+    Teardown,
+    Process,
+    Start,
+    Stop,
+    OnPause,
+    OnResume,
+}
+
+impl ProcessorLifecycleHook {
+    const ALL: [Self; 7] = [
+        Self::Setup,
+        Self::Teardown,
+        Self::Process,
+        Self::Start,
+        Self::Stop,
+        Self::OnPause,
+        Self::OnResume,
+    ];
+
+    fn python_method_name(self) -> &'static str {
+        match self {
+            Self::Setup => "setup",
+            Self::Teardown => "teardown",
+            Self::Process => "process",
+            Self::Start => "start",
+            Self::Stop => "stop",
+            Self::OnPause => "on_pause",
+            Self::OnResume => "on_resume",
+        }
+    }
+}
 
 pub(crate) struct PythonProcessorHost {
-    /// The user's own object. Constructed once, on the thread that calls
-    /// `Runtime.add`, and used only from its processor thread after that.
-    processor_instance: Py<PyAny>,
-    link_data_access: Py<PythonProcessorLinkDataAccess>,
+    /// The user's own object. Constructed on the engine's compile thread as the
+    /// graph comes up, then used only from this processor's own dedicated
+    /// thread — a different thread from the one that built it.
+    ///
+    /// `Option` so [`Drop`] can take it and release it while attached.
+    processor_instance: Option<Py<PyAny>>,
+    link_data_access: Option<Py<PythonProcessorLinkDataAccess>>,
+    /// Which hooks the class defines, indexed by [`ProcessorLifecycleHook`].
+    declared_hooks: [bool; ProcessorLifecycleHook::ALL.len()],
     descriptor: ProcessorDescriptor,
     execution_config: ExecutionConfig,
     /// Names this processor in every log line and error — the graph's display
@@ -61,21 +96,25 @@ impl PythonProcessorHost {
             let link_data_access = Py::new(python, PythonProcessorLinkDataAccess::new())?;
 
             let hosting = python.import(PROCESSOR_HOSTING_MODULE)?;
-            let processor_instance = hosting
-                .getattr("construct_processor_instance")?
-                .call1((
-                    processor_class.bind(python),
-                    configuration
-                        .as_ref()
-                        .map(|config| json_value_to_python_object(python, config))
-                        .transpose()?,
-                    link_data_access.bind(python),
-                ))?
-                .unbind();
+            let processor_instance = hosting.getattr("construct_processor_instance")?.call1((
+                processor_class.bind(python),
+                configuration
+                    .as_ref()
+                    .map(|config| json_value_to_python_object(python, config))
+                    .transpose()?,
+                link_data_access.bind(python),
+            ))?;
+
+            let mut declared_hooks = [false; ProcessorLifecycleHook::ALL.len()];
+            for hook in ProcessorLifecycleHook::ALL {
+                declared_hooks[hook as usize] =
+                    processor_instance.hasattr(hook.python_method_name())?;
+            }
 
             Ok(Self {
-                processor_instance,
-                link_data_access,
+                processor_instance: Some(processor_instance.unbind()),
+                link_data_access: Some(link_data_access),
+                declared_hooks,
                 descriptor: declaration.descriptor.clone(),
                 execution_config: declaration.execution_config,
                 processor_display_name: held_display_name,
@@ -90,25 +129,35 @@ impl PythonProcessorHost {
         })
     }
 
-    /// Call a lifecycle hook if the class defines one.
+    /// Call a lifecycle hook, if the class defined one.
     ///
-    /// The GIL is attached here and released the moment the callback returns.
-    fn dispatch_hook(&mut self, hook: &str) -> Result<()> {
+    /// A class that did not costs no GIL acquisition at all — which is the
+    /// per-tick path for a processor driven by something other than `process`.
+    fn dispatch_hook(&mut self, hook: ProcessorLifecycleHook) -> Result<()> {
+        if !self.declared_hooks[hook as usize] {
+            return Ok(());
+        }
+        let Some(processor_instance) = self.processor_instance.as_ref() else {
+            return Ok(());
+        };
+
         Python::attach(|python| -> PyResult<()> {
-            let processor_instance = self.processor_instance.bind(python);
-            if !processor_instance.hasattr(hook)? {
-                return Ok(());
-            }
-            processor_instance.call_method0(hook)?;
+            processor_instance
+                .bind(python)
+                .call_method0(hook.python_method_name())?;
             Ok(())
         })
         .map_err(|hook_failure| {
             Error::Runtime(format_python_failure(
                 &self.processor_display_name,
-                &format!("raised in {hook}()"),
+                &format!("raised in {}()", hook.python_method_name()),
                 hook_failure,
             ))
         })
+    }
+
+    fn link_data_access(&self) -> Option<&PythonProcessorLinkDataAccess> {
+        self.link_data_access.as_ref().map(|access| access.get())
     }
 }
 
@@ -130,46 +179,46 @@ impl DynGeneratedProcessor for PythonProcessorHost {
         &mut self,
         _ctx: &streamlib::sdk::context::RuntimeContextFullAccess<'_>,
     ) -> Result<()> {
-        self.dispatch_hook(SETUP_HOOK)
+        self.dispatch_hook(ProcessorLifecycleHook::Setup)
     }
 
     fn __generated_teardown(
         &mut self,
         _ctx: &streamlib::sdk::context::RuntimeContextFullAccess<'_>,
     ) -> Result<()> {
-        self.dispatch_hook(TEARDOWN_HOOK)
+        self.dispatch_hook(ProcessorLifecycleHook::Teardown)
     }
 
     fn __generated_on_pause(
         &mut self,
         _ctx: &streamlib::sdk::context::RuntimeContextLimitedAccess<'_>,
     ) -> Result<()> {
-        self.dispatch_hook(ON_PAUSE_HOOK)
+        self.dispatch_hook(ProcessorLifecycleHook::OnPause)
     }
 
     fn __generated_on_resume(
         &mut self,
         _ctx: &streamlib::sdk::context::RuntimeContextLimitedAccess<'_>,
     ) -> Result<()> {
-        self.dispatch_hook(ON_RESUME_HOOK)
+        self.dispatch_hook(ProcessorLifecycleHook::OnResume)
     }
 
     fn process(
         &mut self,
         _ctx: &streamlib::sdk::context::RuntimeContextLimitedAccess<'_>,
     ) -> Result<()> {
-        self.dispatch_hook(PROCESS_HOOK)
+        self.dispatch_hook(ProcessorLifecycleHook::Process)
     }
 
     fn start(
         &mut self,
         _ctx: &streamlib::sdk::context::RuntimeContextFullAccess<'_>,
     ) -> Result<()> {
-        self.dispatch_hook(START_HOOK)
+        self.dispatch_hook(ProcessorLifecycleHook::Start)
     }
 
     fn stop(&mut self, _ctx: &streamlib::sdk::context::RuntimeContextFullAccess<'_>) -> Result<()> {
-        self.dispatch_hook(STOP_HOOK)
+        self.dispatch_hook(ProcessorLifecycleHook::Stop)
     }
 
     fn name(&self) -> &str {
@@ -201,7 +250,9 @@ impl DynGeneratedProcessor for PythonProcessorHost {
         // pair: the inner is an ordinary `Send + Sync` Rust value that the
         // Python-facing object can hold, and calling it skips the vtable hop
         // the host would otherwise take to reach itself.
-        let link_data_access = self.link_data_access.get();
+        let Some(link_data_access) = self.link_data_access() else {
+            return Ok(());
+        };
         if let Some(output_writer) = output_writer.and_then(|writer| writer.inner_arc()) {
             link_data_access.install_output_writer(output_writer);
         }
@@ -214,21 +265,23 @@ impl DynGeneratedProcessor for PythonProcessorHost {
     fn iceoryx2_output_writer_inner(
         &self,
     ) -> Option<std::sync::Arc<streamlib::sdk::iceoryx2::OutputWriterInner>> {
-        self.link_data_access.get().output_writer_inner()
+        self.link_data_access()?.output_writer_inner()
     }
 
     fn iceoryx2_input_mailboxes_inner(
         &self,
     ) -> Option<std::sync::Arc<streamlib::sdk::iceoryx2::InputMailboxesInner>> {
-        self.link_data_access.get().input_mailboxes_inner()
+        self.link_data_access()?.input_mailboxes_inner()
     }
 
     fn apply_config_json(&mut self, config_json: &serde_json::Value) -> Result<()> {
+        let Some(processor_instance) = self.processor_instance.as_ref() else {
+            return Ok(());
+        };
         Python::attach(|python| -> PyResult<()> {
-            let processor_instance = self.processor_instance.bind(python);
             let hosting = python.import(PROCESSOR_HOSTING_MODULE)?;
             hosting.getattr("apply_configuration")?.call1((
-                processor_instance,
+                processor_instance.bind(python),
                 json_value_to_python_object(python, config_json)?,
             ))?;
             Ok(())
@@ -256,17 +309,17 @@ impl DynGeneratedProcessor for PythonProcessorHost {
 }
 
 impl Drop for PythonProcessorHost {
-    /// Releases the user's object while holding the GIL.
+    /// Releases both Python objects while attached.
     ///
-    /// Dropping a `Py` without the GIL only queues the decrement for whichever
-    /// thread attaches next, so a processor holding a file, a socket or a device
-    /// context would keep it open past the teardown the author can observe.
+    /// Dropping a `Py` detached only queues the decrement for whichever thread
+    /// attaches next, so a processor holding a file, a socket or a device
+    /// context would keep it open past the teardown the author can observe. The
+    /// fields are taken here rather than left to drop glue, which runs after
+    /// this returns and after the attach has been released.
     fn drop(&mut self) {
-        Python::attach(|python| {
-            drop(std::mem::replace(
-                &mut self.processor_instance,
-                python.None(),
-            ));
+        Python::attach(|_python| {
+            drop(self.processor_instance.take());
+            drop(self.link_data_access.take());
         });
     }
 }

--- a/sdk/streamlib-python-wheel/src/python_processor_host.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_host.rs
@@ -58,8 +58,7 @@ impl PythonProcessorHost {
         let configuration = node.config.clone();
 
         Python::attach(move |python| -> PyResult<Self> {
-            let link_data_access =
-                Py::new(python, PythonProcessorLinkDataAccess::new())?;
+            let link_data_access = Py::new(python, PythonProcessorLinkDataAccess::new())?;
 
             let hosting = python.import(PROCESSOR_HOSTING_MODULE)?;
             let processor_instance = hosting
@@ -212,7 +211,9 @@ impl DynGeneratedProcessor for PythonProcessorHost {
         Ok(())
     }
 
-    fn iceoryx2_output_writer_inner(&self) -> Option<std::sync::Arc<streamlib::sdk::iceoryx2::OutputWriterInner>> {
+    fn iceoryx2_output_writer_inner(
+        &self,
+    ) -> Option<std::sync::Arc<streamlib::sdk::iceoryx2::OutputWriterInner>> {
         self.link_data_access.get().output_writer_inner()
     }
 

--- a/sdk/streamlib-python-wheel/src/python_processor_link_data_access.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_link_data_access.rs
@@ -13,10 +13,11 @@ use std::sync::{Arc, OnceLock};
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
+use streamlib::sdk::error::Error;
 use streamlib::sdk::iceoryx2::{InputMailboxesInner, OutputWriterInner};
-use streamlib::sdk::media_clock::MediaClock;
 
 use crate::python_bag_conversion::{decode_msgpack_to_python_object, encode_bag_to_msgpack};
+use crate::python_logging::monotonic_clock_now_ns;
 
 /// One processor's links, as seen from Python.
 ///
@@ -60,7 +61,7 @@ impl PythonProcessorLinkDataAccess {
 #[pymethods]
 impl PythonProcessorLinkDataAccess {
     /// The next bag on `port_name`, or `None` when the mailbox is empty.
-    fn read_from_input_port<'py>(
+    pub(crate) fn read_from_input_port<'py>(
         &self,
         python: Python<'py>,
         port_name: &str,
@@ -79,8 +80,34 @@ impl PythonProcessorLinkDataAccess {
         }
     }
 
+    /// The next bag on `port_name` with its stamp, or `(None, None)` when the
+    /// mailbox is empty.
+    pub(crate) fn read_from_input_port_with_timestamp<'py>(
+        &self,
+        python: Python<'py>,
+        port_name: &str,
+    ) -> PyResult<(Option<Bound<'py, PyAny>>, Option<i64>)> {
+        let Some(input_mailboxes) = self.input_mailboxes.get() else {
+            return Err(unwired_port_error("input", port_name));
+        };
+        let read = python
+            .detach(|| input_mailboxes.read_raw(port_name))
+            .map_err(|read_failure| PyRuntimeError::new_err(read_failure.to_string()))?;
+        match read {
+            Some((encoded, timestamp_ns)) => Ok((
+                Some(decode_msgpack_to_python_object(python, &encoded)?),
+                Some(timestamp_ns),
+            )),
+            None => Ok((None, None)),
+        }
+    }
+
     /// Whether a bag is waiting on `port_name`, without consuming it.
-    fn input_port_has_data(&self, python: Python<'_>, port_name: &str) -> PyResult<bool> {
+    pub(crate) fn input_port_has_data(
+        &self,
+        python: Python<'_>,
+        port_name: &str,
+    ) -> PyResult<bool> {
         let Some(input_mailboxes) = self.input_mailboxes.get() else {
             return Err(unwired_port_error("input", port_name));
         };
@@ -88,20 +115,37 @@ impl PythonProcessorLinkDataAccess {
     }
 
     /// Publish one bag to every downstream link on `port_name`.
-    fn write_to_output_port(
+    ///
+    /// An over-ceiling bag is refused-and-counted by the engine, never raised
+    /// here — the old SDK's never-die contract for the write path.
+    #[pyo3(signature = (port_name, bag, timestamp_ns = None))]
+    pub(crate) fn write_to_output_port(
         &self,
         python: Python<'_>,
         port_name: &str,
         bag: &Bound<'_, PyAny>,
+        timestamp_ns: Option<i64>,
     ) -> PyResult<()> {
         let Some(output_writer) = self.output_writer.get() else {
             return Err(unwired_port_error("output", port_name));
         };
         let encoded = encode_bag_to_msgpack(bag)?;
-        let timestamp_ns = MediaClock::now().as_nanos() as i64;
-        python
-            .detach(|| output_writer.write_raw(port_name, &encoded, timestamp_ns))
-            .map_err(|write_failure| PyRuntimeError::new_err(write_failure.to_string()))
+        // Default stamp is raw CLOCK_MONOTONIC, bug-compatible with the old
+        // SDK's NativeOutputs.write — NOT the MediaClock epoch the engine's
+        // Rust processors stamp with. Unifying the two epochs is a flagged
+        // owner decision.
+        let timestamp_ns = timestamp_ns.unwrap_or_else(|| monotonic_clock_now_ns() as i64);
+        match python.detach(|| output_writer.write_raw(port_name, &encoded, timestamp_ns)) {
+            Ok(()) => Ok(()),
+            Err(Error::PayloadExceedsChannelCeiling { .. }) => {
+                tracing::debug!(
+                    port_name,
+                    "bag refused over the channel ceiling; dropped without raising"
+                );
+                Ok(())
+            }
+            Err(write_failure) => Err(PyRuntimeError::new_err(write_failure.to_string())),
+        }
     }
 }
 

--- a/sdk/streamlib-python-wheel/src/python_processor_link_data_access.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_link_data_access.rs
@@ -1,0 +1,115 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The data plane a Python processor reads and writes through.
+//!
+//! This is where the GIL-release contract is kept for the per-bag path: the
+//! conversion between Python objects and msgpack needs the GIL and holds it;
+//! the iceoryx2 call that can block does not, and runs detached. Holding the
+//! GIL across that call would stall every other Python processor in the
+//! process for its duration.
+
+use std::sync::{Arc, OnceLock};
+
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use streamlib::sdk::iceoryx2::{InputMailboxesInner, OutputWriterInner};
+use streamlib::sdk::media_clock::MediaClock;
+
+use crate::python_bag_conversion::{
+    decode_msgpack_to_python_object, encode_python_object_to_msgpack,
+};
+
+/// One processor's links, as seen from Python.
+///
+/// Frozen because the engine hands the same object to the processor's own
+/// thread and reads it from the wiring path; the interior `OnceLock`s are
+/// written once by the host before the processor's first callback.
+#[pyclass(name = "ProcessorLinkDataAccess", module = "streamlib", frozen)]
+pub(crate) struct PythonProcessorLinkDataAccess {
+    input_mailboxes: OnceLock<Arc<InputMailboxesInner>>,
+    output_writer: OnceLock<Arc<OutputWriterInner>>,
+}
+
+impl PythonProcessorLinkDataAccess {
+    pub(crate) fn new() -> Self {
+        Self {
+            input_mailboxes: OnceLock::new(),
+            output_writer: OnceLock::new(),
+        }
+    }
+
+    pub(crate) fn install_input_mailboxes(&self, input_mailboxes: Arc<InputMailboxesInner>) {
+        let _ = self.input_mailboxes.set(input_mailboxes);
+    }
+
+    pub(crate) fn install_output_writer(&self, output_writer: Arc<OutputWriterInner>) {
+        let _ = self.output_writer.set(output_writer);
+    }
+
+    /// The wiring path's reach into this processor's outputs — how the compiler
+    /// attaches a link's publisher after the processor exists.
+    pub(crate) fn output_writer_inner(&self) -> Option<Arc<OutputWriterInner>> {
+        self.output_writer.get().cloned()
+    }
+
+    /// The wiring path's reach into this processor's inputs.
+    pub(crate) fn input_mailboxes_inner(&self) -> Option<Arc<InputMailboxesInner>> {
+        self.input_mailboxes.get().cloned()
+    }
+}
+
+#[pymethods]
+impl PythonProcessorLinkDataAccess {
+    /// The next bag on `port_name`, or `None` when the mailbox is empty.
+    fn read_from_input_port<'py>(
+        &self,
+        python: Python<'py>,
+        port_name: &str,
+    ) -> PyResult<Option<Bound<'py, PyAny>>> {
+        let Some(input_mailboxes) = self.input_mailboxes.get() else {
+            return Err(unwired_port_error("input", port_name));
+        };
+        let read = python
+            .detach(|| input_mailboxes.read_raw(port_name))
+            .map_err(|read_failure| PyRuntimeError::new_err(read_failure.to_string()))?;
+        match read {
+            Some((encoded, _timestamp_ns)) => {
+                decode_msgpack_to_python_object(python, &encoded).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Whether a bag is waiting on `port_name`, without consuming it.
+    fn input_port_has_data(&self, python: Python<'_>, port_name: &str) -> PyResult<bool> {
+        let Some(input_mailboxes) = self.input_mailboxes.get() else {
+            return Err(unwired_port_error("input", port_name));
+        };
+        Ok(python.detach(|| input_mailboxes.has_data(port_name)))
+    }
+
+    /// Publish one bag to every downstream link on `port_name`.
+    fn write_to_output_port(
+        &self,
+        python: Python<'_>,
+        port_name: &str,
+        bag: &Bound<'_, PyAny>,
+    ) -> PyResult<()> {
+        let Some(output_writer) = self.output_writer.get() else {
+            return Err(unwired_port_error("output", port_name));
+        };
+        let encoded = encode_python_object_to_msgpack(bag)?;
+        let timestamp_ns = MediaClock::now().as_nanos() as i64;
+        python
+            .detach(|| output_writer.write_raw(port_name, &encoded, timestamp_ns))
+            .map_err(|write_failure| PyRuntimeError::new_err(write_failure.to_string()))
+    }
+}
+
+fn unwired_port_error(direction: &str, port_name: &str) -> PyErr {
+    PyRuntimeError::new_err(format!(
+        "{direction} port {port_name:?} is not wired: this processor declared no {direction} \
+         ports, so the engine allocated no links for it"
+    ))
+}

--- a/sdk/streamlib-python-wheel/src/python_processor_link_data_access.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_link_data_access.rs
@@ -16,9 +16,7 @@ use pyo3::prelude::*;
 use streamlib::sdk::iceoryx2::{InputMailboxesInner, OutputWriterInner};
 use streamlib::sdk::media_clock::MediaClock;
 
-use crate::python_bag_conversion::{
-    decode_msgpack_to_python_object, encode_python_object_to_msgpack,
-};
+use crate::python_bag_conversion::{decode_msgpack_to_python_object, encode_bag_to_msgpack};
 
 /// One processor's links, as seen from Python.
 ///
@@ -99,7 +97,7 @@ impl PythonProcessorLinkDataAccess {
         let Some(output_writer) = self.output_writer.get() else {
             return Err(unwired_port_error("output", port_name));
         };
-        let encoded = encode_python_object_to_msgpack(bag)?;
+        let encoded = encode_bag_to_msgpack(bag)?;
         let timestamp_ns = MediaClock::now().as_nanos() as i64;
         python
             .detach(|| output_writer.write_raw(port_name, &encoded, timestamp_ns))

--- a/sdk/streamlib-python-wheel/src/python_processor_registration.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_registration.rs
@@ -68,13 +68,13 @@ pub(crate) fn register_processor_class(
         .register_dynamic(
             descriptor,
             Box::new(move |node| {
-                PythonProcessorHost::construct(&declaration, &constructor_class, node)
-                    .map(|host| Box::new(host) as Box<dyn streamlib::sdk::processors::DynGeneratedProcessor + Send>)
+                PythonProcessorHost::construct(&declaration, &constructor_class, node).map(|host| {
+                    Box::new(host)
+                        as Box<dyn streamlib::sdk::processors::DynGeneratedProcessor + Send>
+                })
             }),
         )
-        .map_err(|registration_failure| {
-            PyValueError::new_err(registration_failure.to_string())
-        })?;
+        .map_err(|registration_failure| PyValueError::new_err(registration_failure.to_string()))?;
 
     registered.push((identity, held_processor_class));
     Ok(type_reference)

--- a/sdk/streamlib-python-wheel/src/python_processor_registration.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_registration.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Making a Python class a processor type the engine can instantiate.
+//!
+//! Registration is per process and idempotent per identity: `rt.add(Blur)`
+//! called twice registers `Blur` once and adds two processors to the graph,
+//! each with its own configuration and its own instance of the class.
+
+use std::sync::Mutex;
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use streamlib::sdk::descriptors::SchemaIdent;
+use streamlib::sdk::processors::{PROCESSOR_REGISTRY, ProcessorTypeReference};
+
+use crate::python_processor_declaration::PythonProcessorDeclaration;
+use crate::python_processor_host::PythonProcessorHost;
+
+/// Which Python class each registered identity was registered from.
+///
+/// The engine's registry is keyed by identity and rejects a second
+/// registration, so without this a module reloaded under a different class
+/// object would fail with the registry's generic duplicate error rather than
+/// the reason.
+static REGISTERED_PROCESSOR_CLASSES: Mutex<Vec<(SchemaIdent, Py<PyAny>)>> = Mutex::new(Vec::new());
+
+/// Register `processor_class` if this identity is not already registered.
+///
+/// Returns the type reference `Runtime.add` names the processor by.
+pub(crate) fn register_processor_class(
+    python: Python<'_>,
+    processor_class: &Bound<'_, PyAny>,
+) -> PyResult<ProcessorTypeReference> {
+    let declaration = PythonProcessorDeclaration::read_from_class(processor_class)?;
+    let identity = declaration.descriptor.name.clone();
+
+    let mut registered = REGISTERED_PROCESSOR_CLASSES
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    if let Some((_, already_registered)) = registered
+        .iter()
+        .find(|(registered_identity, _)| *registered_identity == identity)
+    {
+        return if already_registered.bind(python).is(processor_class) {
+            Ok(declaration.type_reference)
+        } else {
+            Err(PyValueError::new_err(format!(
+                "two different classes both claim the processor identity \
+                 `@{}/{}/{}`: {} and {}. Give one of them an explicit identity — \
+                 `@processor(\"@org/package/Type\")` — so each names itself.",
+                declaration.type_reference.org().as_str(),
+                declaration.type_reference.package().as_str(),
+                declaration.type_reference.r#type().as_str(),
+                class_qualified_name(already_registered.bind(python)),
+                class_qualified_name(processor_class),
+            )))
+        };
+    }
+
+    let type_reference = declaration.type_reference.clone();
+    let descriptor = declaration.descriptor.clone();
+    let held_processor_class = processor_class.clone().unbind();
+    let constructor_class = held_processor_class.clone_ref(python);
+
+    PROCESSOR_REGISTRY
+        .register_dynamic(
+            descriptor,
+            Box::new(move |node| {
+                PythonProcessorHost::construct(&declaration, &constructor_class, node)
+                    .map(|host| Box::new(host) as Box<dyn streamlib::sdk::processors::DynGeneratedProcessor + Send>)
+            }),
+        )
+        .map_err(|registration_failure| {
+            PyValueError::new_err(registration_failure.to_string())
+        })?;
+
+    registered.push((identity, held_processor_class));
+    Ok(type_reference)
+}
+
+fn class_qualified_name(processor_class: &Bound<'_, PyAny>) -> String {
+    let module = processor_class
+        .getattr("__module__")
+        .and_then(|module| module.extract::<String>())
+        .unwrap_or_else(|_| "<unknown module>".to_string());
+    let name = processor_class
+        .getattr("__qualname__")
+        .and_then(|name| name.extract::<String>())
+        .unwrap_or_else(|_| "<unknown class>".to_string());
+    format!("{module}.{name}")
+}

--- a/sdk/streamlib-python-wheel/src/python_processor_registration.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_registration.rs
@@ -7,7 +7,8 @@
 //! called twice registers `Blur` once and adds two processors to the graph,
 //! each with its own configuration and its own instance of the class.
 
-use std::sync::Mutex;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -19,11 +20,14 @@ use crate::python_processor_host::PythonProcessorHost;
 
 /// Which Python class each registered identity was registered from.
 ///
-/// The engine's registry is keyed by identity and rejects a second
-/// registration, so without this a module reloaded under a different class
-/// object would fail with the registry's generic duplicate error rather than
-/// the reason.
-static REGISTERED_PROCESSOR_CLASSES: Mutex<Vec<(SchemaIdent, Py<PyAny>)>> = Mutex::new(Vec::new());
+/// A cache of *which class*, never the authority on *whether* a type is
+/// registered — that stays the engine's registry, consulted below, so this can
+/// never suppress a re-registration the engine actually needs.
+fn registered_processor_classes() -> &'static Mutex<HashMap<SchemaIdent, Py<PyAny>>> {
+    static REGISTERED_PROCESSOR_CLASSES: OnceLock<Mutex<HashMap<SchemaIdent, Py<PyAny>>>> =
+        OnceLock::new();
+    REGISTERED_PROCESSOR_CLASSES.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
 /// Register `processor_class` if this identity is not already registered.
 ///
@@ -35,13 +39,16 @@ pub(crate) fn register_processor_class(
     let declaration = PythonProcessorDeclaration::read_from_class(processor_class)?;
     let identity = declaration.descriptor.name.clone();
 
-    let mut registered = REGISTERED_PROCESSOR_CLASSES
+    // Held across the check and the registration, so two threads adding the
+    // same class cannot both get past the engine registry's non-atomic
+    // read-then-write.
+    let mut registered = registered_processor_classes()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
 
-    if let Some((_, already_registered)) = registered
-        .iter()
-        .find(|(registered_identity, _)| *registered_identity == identity)
+    if let Some(already_registered) = registered
+        .get(&identity)
+        .filter(|_| PROCESSOR_REGISTRY.is_registered(&identity))
     {
         return if already_registered.bind(python).is(processor_class) {
             Ok(declaration.type_reference)
@@ -76,7 +83,7 @@ pub(crate) fn register_processor_class(
         )
         .map_err(|registration_failure| PyValueError::new_err(registration_failure.to_string()))?;
 
-    registered.push((identity, held_processor_class));
+    registered.insert(identity, held_processor_class);
     Ok(type_reference)
 }
 

--- a/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
+++ b/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
@@ -87,6 +87,14 @@ impl PythonRuntimeHandle {
     /// GIL-released engine call deadlocks: `detach` re-attaches before it
     /// returns, so this thread would wait for the GIL while holding the lock
     /// that `run()` and `shutdown()` take *with* the GIL held.
+    ///
+    /// What that trades away: a `shutdown()` landing while an `add` still holds
+    /// its clone makes teardown's `Arc::into_inner` return `None` and report an
+    /// incomplete teardown. Harmless here and only here — this state is
+    /// pre-`start()`, so the engine owns no threads for the report to be about,
+    /// and the adder's clone drops moments later. The alternative is making
+    /// teardown wait out an in-flight `add`, which reintroduces the wait this
+    /// exists to avoid.
     fn engine_being_built(&self, what: &str) -> PyResult<Arc<Runner>> {
         match &*self.lifecycle() {
             PythonRuntimeLifecycleState::EngineConstructedNotYetRun(engine) => Ok(engine.clone()),

--- a/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
+++ b/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
@@ -12,9 +12,18 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::runtime::{
     Runner, request_runtime_shutdown, take_runtime_shutdown_request_latch,
 };
+
+use crate::python_added_processor::{
+    PythonAddedProcessor, PythonProcessorInputPortReference, PythonProcessorOutputPortReference,
+};
+use crate::python_bag_conversion::python_object_to_json_value;
+use crate::python_processor_registration::register_processor_class;
 
 /// A reference to the engine outlived the handle, so its threads were not
 /// joined and the teardown contract was not kept.
@@ -66,6 +75,32 @@ impl PythonRuntimeHandle {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
+    /// Borrow the engine to build the graph, before the run loop owns it.
+    ///
+    /// Graph building happens between construction and `run()`; once the run
+    /// loop has taken the engine there is no handle left to add to, which is
+    /// what makes this a lifecycle error rather than a missing feature.
+    fn with_engine_being_built<T>(
+        &self,
+        what: &str,
+        build: impl FnOnce(&Arc<Runner>) -> PyResult<T>,
+    ) -> PyResult<T> {
+        match &*self.lifecycle() {
+            PythonRuntimeLifecycleState::EngineConstructedNotYetRun(engine) => build(engine),
+            PythonRuntimeLifecycleState::RunLoopBlockedUntilShutdownRequested => {
+                Err(PyRuntimeError::new_err(format!(
+                    "cannot {what}: this Runtime is already running. Build the whole graph \
+                     before calling run()."
+                )))
+            }
+            PythonRuntimeLifecycleState::EngineTornDownAndThreadsJoined => {
+                Err(PyRuntimeError::new_err(format!(
+                    "cannot {what}: this Runtime has been shut down. Construct a new one."
+                )))
+            }
+        }
+    }
+
     /// Drop the engine with the GIL released, joining its threads.
     ///
     /// Releasing the GIL is not an optimization: an engine thread that needs
@@ -110,6 +145,72 @@ impl PythonRuntimeHandle {
             lifecycle: Mutex::new(PythonRuntimeLifecycleState::EngineConstructedNotYetRun(
                 engine,
             )),
+        })
+    }
+
+    /// Add a processor class to the graph.
+    ///
+    /// Takes the class, not an instance: the engine constructs it on the
+    /// thread it will run on, passing `config` as keyword arguments. Adding the
+    /// same class twice gives two processors, each with its own instance and
+    /// its own configuration.
+    #[pyo3(signature = (processor_class, *, config = None, display_name = None))]
+    fn add(
+        &self,
+        python: Python<'_>,
+        processor_class: &Bound<'_, PyAny>,
+        config: Option<&Bound<'_, PyDict>>,
+        display_name: Option<String>,
+    ) -> PyResult<PythonAddedProcessor> {
+        if !crate::python_processor_declaration::is_declared_processor_class(processor_class) {
+            return Err(PyRuntimeError::new_err(format!(
+                "{} is not a processor: decorate the class with @streamlib.processor, and pass \
+                 the class itself rather than an instance of it",
+                processor_class
+            )));
+        }
+
+        let type_reference = register_processor_class(python, processor_class)?;
+        let configuration = match config {
+            Some(config) => python_object_to_json_value(config.as_any())?,
+            None => serde_json::Value::Null,
+        };
+
+        // The same rule the graph applies when it names the node, so the handle
+        // and `streamlib graph` agree without a round trip to ask.
+        let display_name =
+            display_name.unwrap_or_else(|| type_reference.r#type().as_str().to_string());
+        let spec = ProcessorSpec::new(type_reference, configuration)
+            .with_display_name(display_name.clone());
+
+        self.with_engine_being_built("add a processor", |engine| {
+            let processor_id = python
+                .detach(|| engine.add_processor(spec))
+                .map_err(|add_failure| PyRuntimeError::new_err(add_failure.to_string()))?;
+            Ok(PythonAddedProcessor::new(
+                processor_id.as_str().to_string(),
+                display_name,
+            ))
+        })
+    }
+
+    /// Link one processor's output port to another's input port.
+    fn connect(
+        &self,
+        python: Python<'_>,
+        source: &PythonProcessorOutputPortReference,
+        destination: &PythonProcessorInputPortReference,
+    ) -> PyResult<()> {
+        let from = OutputLinkPortRef::new(source.processor_id.clone(), source.port_name.clone());
+        let to = InputLinkPortRef::new(
+            destination.processor_id.clone(),
+            destination.port_name.clone(),
+        );
+        self.with_engine_being_built("connect two processors", |engine| {
+            python
+                .detach(|| engine.connect(from, to))
+                .map(|_link_id| ())
+                .map_err(|connect_failure| PyRuntimeError::new_err(connect_failure.to_string()))
         })
     }
 

--- a/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
+++ b/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
@@ -75,18 +75,21 @@ impl PythonRuntimeHandle {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
-    /// Borrow the engine to build the graph, before the run loop owns it.
+    /// Take a reference to the engine to build the graph, before the run loop
+    /// owns it.
     ///
     /// Graph building happens between construction and `run()`; once the run
     /// loop has taken the engine there is no handle left to add to, which is
     /// what makes this a lifecycle error rather than a missing feature.
-    fn with_engine_being_built<T>(
-        &self,
-        what: &str,
-        build: impl FnOnce(&Arc<Runner>) -> PyResult<T>,
-    ) -> PyResult<T> {
+    ///
+    /// Returns an owned `Arc` rather than lending the guard's contents, so the
+    /// lock is released before the caller detaches. Holding it across a
+    /// GIL-released engine call deadlocks: `detach` re-attaches before it
+    /// returns, so this thread would wait for the GIL while holding the lock
+    /// that `run()` and `shutdown()` take *with* the GIL held.
+    fn engine_being_built(&self, what: &str) -> PyResult<Arc<Runner>> {
         match &*self.lifecycle() {
-            PythonRuntimeLifecycleState::EngineConstructedNotYetRun(engine) => build(engine),
+            PythonRuntimeLifecycleState::EngineConstructedNotYetRun(engine) => Ok(engine.clone()),
             PythonRuntimeLifecycleState::RunLoopBlockedUntilShutdownRequested => {
                 Err(PyRuntimeError::new_err(format!(
                     "cannot {what}: this Runtime is already running. Build the whole graph \
@@ -150,10 +153,11 @@ impl PythonRuntimeHandle {
 
     /// Add a processor class to the graph.
     ///
-    /// Takes the class, not an instance: the engine constructs it on the
-    /// thread it will run on, passing `config` as keyword arguments. Adding the
-    /// same class twice gives two processors, each with its own instance and
-    /// its own configuration.
+    /// Takes the class, not an instance. `config` becomes the keyword arguments
+    /// the class is constructed with — which happens later, on the engine's
+    /// compile thread as `run()` brings the graph up, so a failing `__init__`
+    /// surfaces from `run()` rather than from here. Adding the same class twice
+    /// gives two processors, each with its own instance and configuration.
     #[pyo3(signature = (processor_class, *, config = None, display_name = None))]
     fn add(
         &self,
@@ -170,6 +174,11 @@ impl PythonRuntimeHandle {
             )));
         }
 
+        // Before registering: registration writes to the process-global
+        // registry, and a runtime that can no longer be built should not leave
+        // a processor type behind for a node that will never exist.
+        let engine = self.engine_being_built("add a processor")?;
+
         let type_reference = register_processor_class(python, processor_class)?;
         let configuration = match config {
             Some(config) => python_object_to_json_value(config.as_any())?,
@@ -183,15 +192,13 @@ impl PythonRuntimeHandle {
         let spec = ProcessorSpec::new(type_reference, configuration)
             .with_display_name(display_name.clone());
 
-        self.with_engine_being_built("add a processor", |engine| {
-            let processor_id = python
-                .detach(|| engine.add_processor(spec))
-                .map_err(|add_failure| PyRuntimeError::new_err(add_failure.to_string()))?;
-            Ok(PythonAddedProcessor::new(
-                processor_id.as_str().to_string(),
-                display_name,
-            ))
-        })
+        let processor_id = python
+            .detach(|| engine.add_processor(spec))
+            .map_err(|add_failure| PyRuntimeError::new_err(add_failure.to_string()))?;
+        Ok(PythonAddedProcessor::new(
+            processor_id.as_str().to_string(),
+            display_name,
+        ))
     }
 
     /// Link one processor's output port to another's input port.
@@ -206,12 +213,11 @@ impl PythonRuntimeHandle {
             destination.processor_id.clone(),
             destination.port_name.clone(),
         );
-        self.with_engine_being_built("connect two processors", |engine| {
-            python
-                .detach(|| engine.connect(from, to))
-                .map(|_link_id| ())
-                .map_err(|connect_failure| PyRuntimeError::new_err(connect_failure.to_string()))
-        })
+        let engine = self.engine_being_built("connect two processors")?;
+        python
+            .detach(|| engine.connect(from, to))
+            .map(|_link_id| ())
+            .map_err(|connect_failure| PyRuntimeError::new_err(connect_failure.to_string()))
     }
 
     /// Run the pipeline until Ctrl-C, SIGTERM, or [`shutdown`], then tear the

--- a/sdk/streamlib-python-wheel/tests/app_under_test.py
+++ b/sdk/streamlib-python-wheel/tests/app_under_test.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Driving `python app.py` from a test, with every wait bounded.
+
+The failures this exists to catch — a surviving process, a hang at interpreter
+finalization, a wedged GIL, a non-zero exit — are only visible to a parent, and
+a hang is only a *failure* rather than a stuck test run if the parent is the one
+holding the clock. Both out-of-process suites drive their apps through here.
+"""
+
+import os
+import queue
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+# Generous: a cold engine boot stands up an iceoryx2 node, a surface-sharing
+# socket, and a GPU context. A real hang blows through it anyway.
+ENGINE_READY_TIMEOUT_SECONDS = 60.0
+CLEAN_EXIT_TIMEOUT_SECONDS = 60.0
+
+MARKER_PREFIX = "MARKER:"
+
+ENGINE_READY_LOG_LINE = "[start] Runtime started"
+# Emitted early inside `start()` — after the run loop has taken shutdown-signal
+# ownership, but well before the graph is up.
+ENGINE_STARTING_LOG_LINE = "[start] Initializing GPU context"
+ENGINE_STOPPED_LOG_LINE = "[stop] Graceful shutdown complete"
+
+
+class AppUnderTest:
+    """A running `python app.py`, with its output pumped off the pipe.
+
+    Every wait here is bounded. A plain `readline()` blocks indefinitely when
+    the app goes quiet, which makes a deadline checked between lines useless —
+    that is how a hung app turns into a hung test run rather than a failure with
+    a diagnostic.
+    """
+
+    def __init__(self, process: "subprocess.Popen[str]"):
+        # Asserted rather than assumed: without a pipe the pump below raises
+        # inside a daemon thread, and every wait in this class then fails on
+        # its timeout instead of on the reason.
+        assert process.stdout is not None, "the app was started without a stdout pipe"
+        self.process = process
+        self._output_pipe = process.stdout
+        self.output_lines: list[str] = []
+        self._incoming: queue.Queue[str | None] = queue.Queue()
+        self._reached_end_of_output = False
+        threading.Thread(target=self._pump_output, daemon=True).start()
+
+    def _pump_output(self) -> None:
+        for line in self._output_pipe:
+            self._incoming.put(line)
+        self._incoming.put(None)
+
+    @property
+    def output(self) -> str:
+        return "".join(self.output_lines)
+
+    def _next_line(self, deadline: float) -> str | None:
+        """The next line, or None at end of output. Raises past the deadline."""
+        while True:
+            if self._reached_end_of_output:
+                return None
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError
+            try:
+                line = self._incoming.get(timeout=min(0.5, remaining))
+            except queue.Empty:
+                continue
+            if line is None:
+                self._reached_end_of_output = True
+                return None
+            self.output_lines.append(line)
+            return line
+
+    def await_output_containing(self, awaited: str, what: str) -> None:
+        """Wait for a line containing `awaited`.
+
+        Sequencing on the app's or engine's own output rather than a sleep is
+        what pins the point of the lifecycle a signal is delivered at.
+        """
+        deadline = time.monotonic() + ENGINE_READY_TIMEOUT_SECONDS
+        while True:
+            try:
+                line = self._next_line(deadline)
+            except TimeoutError:
+                raise AssertionError(
+                    f"timed out waiting for {what}; output:\n{self.output}"
+                ) from None
+            if line is None:
+                raise AssertionError(f"the app exited before {what}; output:\n{self.output}")
+            if awaited in line:
+                return
+
+    def await_engine_ready(self) -> None:
+        self.await_output_containing(ENGINE_READY_LOG_LINE, "the engine to start")
+
+    def await_marker(self, marker: str) -> None:
+        self.await_output_containing(f"{MARKER_PREFIX}{marker}", f"marker {marker}")
+
+    def markers(self) -> set[str]:
+        # Matched anywhere in the line, not just at its start: while the engine
+        # is alive its stdio interceptor captures the app's `print()` and
+        # re-emits it inside a tracing record, so a marker emitted before
+        # teardown arrives as `… stdio_interceptor — MARKER:X`.
+        found: set[str] = set()
+        for line in self.output_lines:
+            marker_start = line.find(MARKER_PREFIX)
+            if marker_start != -1:
+                found.add(line[marker_start + len(MARKER_PREFIX) :].strip())
+        return found
+
+    def interrupt(self) -> None:
+        self.process.send_signal(signal.SIGINT)
+
+    def await_clean_exit(self) -> "AppUnderTest":
+        """Drain the remaining output and require a clean, timely exit."""
+        deadline = time.monotonic() + CLEAN_EXIT_TIMEOUT_SECONDS
+        try:
+            while self._next_line(deadline) is not None:
+                pass
+        except TimeoutError:
+            self.process.kill()
+            raise AssertionError(
+                f"the app did not exit within {CLEAN_EXIT_TIMEOUT_SECONDS}s — engine teardown "
+                f"hung, or the interpreter hung at finalization; output:\n{self.output}"
+            ) from None
+
+        returncode = self.process.wait(timeout=max(0.0, deadline - time.monotonic()))
+        assert returncode == 0, (
+            f"expected a clean exit, got returncode {returncode}; output:\n{self.output}"
+        )
+        assert "CLEAN_EXIT" in self.markers(), (
+            f"the app did not reach the end of its scenario; output:\n{self.output}"
+        )
+        return self
+
+
+    def kill_process_group(self) -> None:
+        """Leave nothing behind, however this app's test ended.
+
+        A failed wait raises without touching the process, and the app runs in
+        its own session — so without this an assertion failure strands a live
+        engine holding a GPU context, an iceoryx2 node and a socket, silently
+        contaminating every later run on the same rig.
+        """
+        try:
+            os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+        for pipe in (self.process.stdout, self.process.stdin):
+            if pipe is not None and not pipe.closed:
+                pipe.close()
+
+
+def start_app(app_path: Path, *arguments: str) -> AppUnderTest:
+    """Spawn `python <app_path> <arguments...>` in its own process group.
+
+    Its own group so a SIGINT aimed at the app cannot reach the test runner that
+    spawned it — and so the group can be checked for survivors afterwards.
+    """
+    process = subprocess.Popen(
+        [sys.executable, str(app_path), *arguments],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        start_new_session=True,
+    )
+    return AppUnderTest(process)

--- a/sdk/streamlib-python-wheel/tests/conftest.py
+++ b/sdk/streamlib-python-wheel/tests/conftest.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Fixtures shared by the suites that drive an app out of process."""
+
+from pathlib import Path
+
+import pytest
+
+from app_under_test import AppUnderTest, start_app
+
+
+@pytest.fixture
+def start_app_under_test():
+    """Hands out apps and kills their process groups no matter how a test ends.
+
+    Without the teardown a failed assertion strands a live engine holding a GPU
+    context, an iceoryx2 node and a socket, silently contaminating every later
+    run on the same rig.
+    """
+    started: "list[AppUnderTest]" = []
+
+    def start(app_path: Path, *arguments: str) -> AppUnderTest:
+        app = start_app(app_path, *arguments)
+        started.append(app)
+        return app
+
+    try:
+        yield start
+    finally:
+        for app in started:
+            app.kill_process_group()

--- a/sdk/streamlib-python-wheel/tests/graph_building_app.py
+++ b/sdk/streamlib-python-wheel/tests/graph_building_app.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Scenarios that build a graph, run as a real `python app.py`.
+
+Driven from outside because the failure being ruled out takes the GIL down with
+it: an in-process assertion can never run, so only a parent holding the clock
+can turn the wedge into a failure rather than a stuck test run.
+"""
+
+import sys
+import threading
+
+import streamlib
+from streamlib import LinkInputDataPort, LinkOutputDataPort, processor
+
+MARKER_PREFIX = "MARKER:"
+
+# Enough concurrent work to interleave a detach with another thread's lock
+# acquisition many times over. The wedge, when present, lands within the first
+# few dozen.
+ADDS_PER_THREAD = 200
+GRAPH_BUILDING_THREADS = 2
+
+
+@processor
+class GraphBuildingFilter:
+    frames_from_upstream = LinkInputDataPort()
+    frames_to_downstream = LinkOutputDataPort()
+
+    def process(self) -> None:
+        frame = self.frames_from_upstream.read()
+        if frame is not None:
+            self.frames_to_downstream.write(frame)
+
+
+def marker(name: str) -> None:
+    print(f"{MARKER_PREFIX}{name}", flush=True)
+
+
+def scenario_concurrent_graph_building() -> None:
+    """Two threads calling `add` at once must not deadlock against each other.
+
+    The deadly embrace: a thread inside `add` holds the lifecycle mutex and,
+    having released the GIL, waits to re-acquire it, while another thread holds
+    the GIL and blocks on that same mutex. Neither proceeds, and the interpreter
+    stops responding — which is why this scenario reports its own completion
+    rather than asserting anything.
+    """
+    runtime = streamlib.Runtime()
+    marker("RUNTIME_CONSTRUCTED")
+
+    def add_repeatedly() -> None:
+        for _ in range(ADDS_PER_THREAD):
+            runtime.add(GraphBuildingFilter)
+
+    builders = [
+        threading.Thread(target=add_repeatedly, name=f"graph-builder-{index}")
+        for index in range(GRAPH_BUILDING_THREADS)
+    ]
+    for builder in builders:
+        builder.start()
+    for builder in builders:
+        builder.join()
+
+    marker("GRAPH_BUILT")
+    runtime.shutdown()
+    marker("CLEAN_EXIT")
+
+
+def scenario_shutdown_racing_graph_building() -> None:
+    """`shutdown()` from another thread while `add` is in flight.
+
+    `add` releases the GIL around the engine call, and `shutdown` takes the same
+    lifecycle lock holding it. Whichever order they land in, the app must reach
+    its exit: adds either succeed or are refused with the shut-down error, and
+    neither outcome may hang.
+    """
+    runtime = streamlib.Runtime()
+    marker("RUNTIME_CONSTRUCTED")
+
+    refusals = 0
+    shutdown_requested = threading.Event()
+
+    def shut_down_once_building() -> None:
+        shutdown_requested.wait()
+        runtime.shutdown()
+
+    threading.Thread(target=shut_down_once_building, daemon=True).start()
+
+    for index in range(ADDS_PER_THREAD):
+        if index == 10:
+            shutdown_requested.set()
+        try:
+            runtime.add(GraphBuildingFilter)
+        except RuntimeError:
+            refusals += 1
+
+    marker(f"REFUSED_AFTER_SHUTDOWN={refusals}")
+    marker("CLEAN_EXIT")
+
+
+SCENARIOS = {
+    "concurrent_graph_building": scenario_concurrent_graph_building,
+    "shutdown_racing_graph_building": scenario_shutdown_racing_graph_building,
+}
+
+
+if __name__ == "__main__":
+    SCENARIOS[sys.argv[1]]()

--- a/sdk/streamlib-python-wheel/tests/graph_building_app.py
+++ b/sdk/streamlib-python-wheel/tests/graph_building_app.py
@@ -12,7 +12,7 @@ import sys
 import threading
 
 import streamlib
-from streamlib import LinkInputDataPort, LinkOutputDataPort, processor
+from streamlib import RuntimeContextLimitedAccess, input, output, processor
 
 MARKER_PREFIX = "MARKER:"
 
@@ -25,13 +25,16 @@ GRAPH_BUILDING_THREADS = 2
 
 @processor
 class GraphBuildingFilter:
-    frames_from_upstream = LinkInputDataPort()
-    frames_to_downstream = LinkOutputDataPort()
+    @input()
+    def frames_from_upstream(self) -> None: ...
 
-    def process(self) -> None:
-        frame = self.frames_from_upstream.read()
+    @output()
+    def frames_to_downstream(self) -> None: ...
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        frame = ctx.inputs.read("frames_from_upstream")
         if frame is not None:
-            self.frames_to_downstream.write(frame)
+            ctx.outputs.write("frames_to_downstream", frame)
 
 
 def marker(name: str) -> None:

--- a/sdk/streamlib-python-wheel/tests/test_capability_contexts.py
+++ b/sdk/streamlib-python-wheel/tests/test_capability_contexts.py
@@ -1,0 +1,490 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""The capability-typed contexts hooks receive, proven against a running engine.
+
+Full-access hooks (`setup`/`teardown`/`start`/`stop`) get
+`RuntimeContextFullAccess`; limited hooks (`process`/`on_pause`/`on_resume`)
+get `RuntimeContextLimitedAccess` with no `gpu_full_access` at all. Lease-bound
+members die with the hook that received them; `ctx.outputs` survives, which is
+what the manual-source pattern is built on.
+"""
+
+import queue
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+import streamlib
+from streamlib import (
+    GpuContextFullAccess,
+    GpuContextLimitedAccess,
+    RuntimeContextFullAccess,
+    RuntimeContextLimitedAccess,
+    input,
+    output,
+    processor,
+)
+
+pytestmark = pytest.mark.requires_gpu
+
+PIPELINE_TIMEOUT_SECONDS = 30.0
+
+# What a hook observed, drained by the test after the graph runs. Module-level
+# because configuration is JSON on the graph node — a queue cannot travel
+# through `config`.
+_hook_observations: "queue.Queue[dict]" = queue.Queue()
+
+
+def _drain_observations() -> None:
+    while True:
+        try:
+            _hook_observations.get_nowait()
+        except queue.Empty:
+            return
+
+
+@pytest.fixture(autouse=True)
+def clean_observation_queue():
+    _drain_observations()
+    yield
+
+
+class RunningGraph:
+    """A graph running on a worker thread, shut down and joined on exit."""
+
+    def __init__(self) -> None:
+        self.runtime = streamlib.Runtime()
+        self.run_outcome: "queue.Queue[BaseException | None]" = queue.Queue()
+        self._run_loop = threading.Thread(target=self._run, daemon=True)
+
+    def _run(self) -> None:
+        try:
+            self.runtime.run()
+        except BaseException as run_failure:  # noqa: BLE001 — surfaced by the caller
+            self.run_outcome.put(run_failure)
+        else:
+            self.run_outcome.put(None)
+
+    def start(self) -> None:
+        self._run_loop.start()
+
+    def shut_down_and_take_run_outcome(self) -> "BaseException | None":
+        self.runtime.shutdown()
+        self._run_loop.join(timeout=PIPELINE_TIMEOUT_SECONDS)
+        assert not self._run_loop.is_alive(), "run() never returned after shutdown()"
+        return self.run_outcome.get_nowait()
+
+
+def _await_observation(matching: str) -> dict:
+    deadline = time.monotonic() + PIPELINE_TIMEOUT_SECONDS
+    while True:
+        remaining = deadline - time.monotonic()
+        assert remaining > 0, f"no {matching!r} observation arrived within the timeout"
+        try:
+            observation = _hook_observations.get(timeout=min(0.5, remaining))
+        except queue.Empty:
+            continue
+        if observation.get("observed") == matching:
+            return observation
+
+
+# ---------------------------------------------------------------------------
+# Which context type reaches which hook.
+# ---------------------------------------------------------------------------
+
+
+@processor(execution="manual")
+class SetupContextProbe:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        _hook_observations.put(
+            {
+                "observed": "setup_context",
+                "context_type": type(ctx),
+                "gpu_full_access_type": type(ctx.gpu_full_access),
+                "gpu_limited_access_type": type(ctx.gpu_limited_access),
+            }
+        )
+
+
+def test_setup_receives_the_full_access_context_with_gpu_full_access():
+    graph = RunningGraph()
+    graph.runtime.add(SetupContextProbe)
+    graph.start()
+    try:
+        observation = _await_observation("setup_context")
+    finally:
+        graph.shut_down_and_take_run_outcome()
+    assert observation["context_type"] is RuntimeContextFullAccess
+    assert observation["gpu_full_access_type"] is GpuContextFullAccess
+    assert observation["gpu_limited_access_type"] is GpuContextLimitedAccess
+
+
+@processor(execution="continuous", interval_ms=1)
+class ProcessContextProbe:
+    def __init__(self) -> None:
+        self.reported = False
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        if self.reported:
+            return
+        self.reported = True
+        try:
+            ctx.gpu_full_access  # noqa: B018 — the attribute error is the point  # pyright: ignore[reportAttributeAccessIssue]
+            full_access_outcome = "reachable"
+        except AttributeError:
+            full_access_outcome = "attribute_error"
+        _hook_observations.put(
+            {
+                "observed": "process_context",
+                "context_type": type(ctx),
+                "gpu_full_access": full_access_outcome,
+                "gpu_limited_access_type": type(ctx.gpu_limited_access),
+            }
+        )
+
+
+def test_process_receives_the_limited_context_without_gpu_full_access():
+    """The capability split: reaching for the privileged GPU view from
+    `process` is an `AttributeError`, not a quietly-working escape hatch."""
+    graph = RunningGraph()
+    graph.runtime.add(ProcessContextProbe)
+    graph.start()
+    try:
+        observation = _await_observation("process_context")
+    finally:
+        graph.shut_down_and_take_run_outcome()
+    assert observation["context_type"] is RuntimeContextLimitedAccess
+    assert observation["gpu_full_access"] == "attribute_error"
+    assert observation["gpu_limited_access_type"] is GpuContextLimitedAccess
+
+
+# ---------------------------------------------------------------------------
+# ctx.config and ctx.time.
+# ---------------------------------------------------------------------------
+
+
+@processor(execution="manual")
+class ConfigProbe:
+    def __init__(self, gain: float = 0.0, label: str = "") -> None:
+        self.gain = gain
+        self.label = label
+
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        _hook_observations.put({"observed": "config", "config": ctx.config})
+
+
+def test_ctx_config_is_the_dict_the_processor_was_added_with():
+    graph = RunningGraph()
+    graph.runtime.add(ConfigProbe, config={"gain": 2.5, "label": "left"})
+    graph.start()
+    try:
+        observation = _await_observation("config")
+    finally:
+        graph.shut_down_and_take_run_outcome()
+    assert observation["config"] == {"gain": 2.5, "label": "left"}
+
+
+def test_ctx_config_is_an_empty_dict_when_nothing_was_passed():
+    graph = RunningGraph()
+    graph.runtime.add(ConfigProbe)
+    graph.start()
+    try:
+        observation = _await_observation("config")
+    finally:
+        graph.shut_down_and_take_run_outcome()
+    assert observation["config"] == {}
+
+
+@processor(execution="manual")
+class TimeProbe:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        before = time.clock_gettime_ns(time.CLOCK_MONOTONIC)
+        context_time = ctx.time
+        after = time.clock_gettime_ns(time.CLOCK_MONOTONIC)
+        _hook_observations.put(
+            {"observed": "time", "before": before, "context_time": context_time, "after": after}
+        )
+
+
+def test_ctx_time_is_kernel_monotonic_nanoseconds():
+    """Two kernel reads bracket `ctx.time`, so the value is provably the raw
+    `CLOCK_MONOTONIC` domain — not the engine's media clock."""
+    graph = RunningGraph()
+    graph.runtime.add(TimeProbe)
+    graph.start()
+    try:
+        observation = _await_observation("time")
+    finally:
+        graph.shut_down_and_take_run_outcome()
+    assert observation["before"] <= observation["context_time"] <= observation["after"]
+
+
+# ---------------------------------------------------------------------------
+# Write timestamps, explicit and default.
+# ---------------------------------------------------------------------------
+
+EXPLICIT_TIMESTAMP_NS = 123_456_789_000
+
+
+@processor(execution="continuous", interval_ms=1)
+class ExplicitlyStampedSource:
+    @output()
+    def bags_to_downstream(self) -> None: ...
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        ctx.outputs.write(
+            "bags_to_downstream", {"value": 1}, timestamp_ns=EXPLICIT_TIMESTAMP_NS
+        )
+
+
+@processor(execution="continuous", interval_ms=1)
+class DefaultStampedSource:
+    @output()
+    def bags_to_downstream(self) -> None: ...
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        ctx.outputs.write("bags_to_downstream", {"value": 1})
+
+
+@processor
+class TimestampCollectingSink:
+    @input(delivery_profile="every_sample")
+    def bags_from_upstream(self) -> None: ...
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        bag, timestamp_ns = ctx.inputs.read_with_timestamp("bags_from_upstream")
+        if bag is not None:
+            _hook_observations.put(
+                {"observed": "stamped_bag", "bag": bag, "timestamp_ns": timestamp_ns}
+            )
+
+
+def _run_stamped_graph(source_class: type) -> dict:
+    graph = RunningGraph()
+    source = graph.runtime.add(source_class)
+    sink = graph.runtime.add(TimestampCollectingSink)
+    graph.runtime.connect(
+        source.output("bags_to_downstream"), sink.input("bags_from_upstream")
+    )
+    graph.start()
+    try:
+        return _await_observation("stamped_bag")
+    finally:
+        graph.shut_down_and_take_run_outcome()
+
+
+def test_an_explicit_write_timestamp_reaches_the_reader_unchanged():
+    observation = _run_stamped_graph(ExplicitlyStampedSource)
+    assert observation["timestamp_ns"] == EXPLICIT_TIMESTAMP_NS
+
+
+def test_a_default_write_timestamp_is_kernel_monotonic():
+    before_run = time.clock_gettime_ns(time.CLOCK_MONOTONIC)
+    observation = _run_stamped_graph(DefaultStampedSource)
+    after_run = time.clock_gettime_ns(time.CLOCK_MONOTONIC)
+    assert before_run <= observation["timestamp_ns"] <= after_run
+
+
+# ---------------------------------------------------------------------------
+# Lease expiry and what deliberately survives it.
+# ---------------------------------------------------------------------------
+
+_stashed_contexts: "queue.Queue[RuntimeContextFullAccess]" = queue.Queue()
+
+
+@processor(execution="manual")
+class ContextStasher:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        _stashed_contexts.put(ctx)
+        _hook_observations.put({"observed": "context_stashed"})
+
+
+def test_a_context_stashed_from_setup_expires_with_the_hook():
+    """Lease-bound members are only usable inside the hook that received the
+    context — a stashed context answers later calls with the lease error."""
+    graph = RunningGraph()
+    graph.runtime.add(ContextStasher)
+    graph.start()
+    try:
+        _await_observation("context_stashed")
+    finally:
+        graph.shut_down_and_take_run_outcome()
+
+    stashed_context = _stashed_contexts.get_nowait()
+    with pytest.raises(RuntimeError, match="only valid during the lifecycle hook"):
+        stashed_context.is_paused()
+
+
+_manual_source_stop = threading.Event()
+
+
+@processor(execution="manual")
+class WorkerThreadSource:
+    """The manual-source pattern: `ctx.outputs` captured in setup, written from
+    a thread the processor owns."""
+
+    def __init__(self) -> None:
+        self._worker: "threading.Thread | None" = None
+
+    @output()
+    def bags_to_downstream(self) -> None: ...
+
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        captured_outputs = ctx.outputs
+
+        def produce_from_worker_thread() -> None:
+            while not _manual_source_stop.is_set():
+                captured_outputs.write("bags_to_downstream", {"origin": "worker-thread"})
+                _manual_source_stop.wait(0.01)
+
+        self._worker = threading.Thread(target=produce_from_worker_thread, daemon=True)
+        self._worker.start()
+
+    def teardown(self, ctx: RuntimeContextFullAccess) -> None:
+        _manual_source_stop.set()
+        if self._worker is not None:
+            self._worker.join(timeout=5.0)
+
+
+@processor
+class WorkerThreadBagSink:
+    @input(delivery_profile="every_sample")
+    def bags_from_upstream(self) -> None: ...
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        bag = ctx.inputs.read("bags_from_upstream")
+        if bag is not None:
+            _hook_observations.put({"observed": "worker_thread_bag", "bag": bag})
+
+
+def test_outputs_captured_in_setup_still_write_from_a_worker_thread():
+    """`ctx.outputs` is deliberately not lease-bound: a manual source hands it
+    to its own thread and keeps producing between hooks."""
+    _manual_source_stop.clear()
+    graph = RunningGraph()
+    source = graph.runtime.add(WorkerThreadSource)
+    sink = graph.runtime.add(WorkerThreadBagSink)
+    graph.runtime.connect(
+        source.output("bags_to_downstream"), sink.input("bags_from_upstream")
+    )
+    graph.start()
+    try:
+        observation = _await_observation("worker_thread_bag")
+    finally:
+        graph.shut_down_and_take_run_outcome()
+        _manual_source_stop.set()
+    assert observation["bag"] == {"origin": "worker-thread"}
+
+
+# ---------------------------------------------------------------------------
+# Hook arity: the ctx parameter is required.
+# ---------------------------------------------------------------------------
+
+
+ZERO_ARGUMENT_PROCESS_APP = Path(__file__).parent / "zero_argument_process_app.py"
+
+
+def test_a_zero_argument_process_hook_fails_loudly_with_a_type_error(
+    start_app_under_test,
+):
+    """Hooks require the ctx parameter; a zero-arg `process` must TypeError by
+    name in the log, never be silently invoked without a context.
+
+    Driven out of process because the failure is a log line: the engine's
+    tracing writer binds stdout at the process's first engine boot, so only a
+    parent reading the pipe observes it no matter which test booted an engine
+    first.
+    """
+    app = start_app_under_test(ZERO_ARGUMENT_PROCESS_APP)
+    app.await_output_containing("raised in process()", "the hook named in the failure")
+    app.await_output_containing("TypeError", "the zero-arg TypeError")
+    app.interrupt()
+    app.await_clean_exit()
+    assert "HOOK_BODY_RAN" not in app.markers(), (
+        "the zero-arg hook body ran — the host invoked it without a context"
+    )
+
+
+# ---------------------------------------------------------------------------
+# GPU surfaces from a hook.
+# ---------------------------------------------------------------------------
+
+
+@processor(execution="manual")
+class PixelBufferAcquirer:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        with ctx.gpu_limited_access.acquire_pixel_buffer(64, 32) as surface_handle:
+            try:
+                surface_handle.as_numpy()
+                pixel_access_outcome = "returned"
+            except NotImplementedError as not_yet_implemented:
+                pixel_access_outcome = str(not_yet_implemented)
+            _hook_observations.put(
+                {
+                    "observed": "pixel_buffer",
+                    "surface_id": surface_handle.surface_id,
+                    "width": surface_handle.width,
+                    "height": surface_handle.height,
+                    "pixel_access_outcome": pixel_access_outcome,
+                }
+            )
+
+
+def test_a_hook_acquires_a_pixel_buffer_and_pixel_access_names_its_ticket():
+    graph = RunningGraph()
+    graph.runtime.add(PixelBufferAcquirer)
+    graph.start()
+    try:
+        observation = _await_observation("pixel_buffer")
+    finally:
+        graph.shut_down_and_take_run_outcome()
+    assert isinstance(observation["surface_id"], str) and observation["surface_id"]
+    assert (observation["width"], observation["height"]) == (64, 32)
+    assert "1710" in observation["pixel_access_outcome"], (
+        f"as_numpy should raise NotImplementedError naming ticket #1710, got: "
+        f"{observation['pixel_access_outcome']!r}"
+    )
+
+
+@processor(execution="manual")
+class RepeatedPixelBufferAcquirer:
+    """Acquires and closes the same shape more times than the pool has slots."""
+
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        outcomes = []
+        for _ in range(8):
+            try:
+                with ctx.gpu_limited_access.acquire_pixel_buffer(96, 96) as surface_handle:
+                    outcomes.append("ok" if surface_handle.surface_id else "no-id")
+            except RuntimeError as acquire_failure:
+                outcomes.append(f"failed: {acquire_failure}")
+        _hook_observations.put({"observed": "repeated_acquires", "outcomes": outcomes})
+
+
+def test_a_closed_pixel_buffer_returns_its_pool_slot():
+    """Acquire and close beyond the pool depth — every acquire must succeed.
+
+    Regression lock on a real leak: the acquire's surface-store check-in parks
+    a strong clone of the buffer in the store, and the pool frees a slot only
+    once the strong count returns to 1. Before the fix, `close()` dropped only
+    the handle's own clone, so the fifth acquire of any shape failed with
+    "All pixel buffers are currently in use" — a per-tick acquirer was dead
+    after one pool depth's worth of frames.
+
+    Mental-revert: dropping the `store.release(surface_id)` from the handle's
+    `release_owned_engine_value`, or the cache eviction from
+    `SurfaceStore::release` — either brings the exhaustion back.
+    """
+    graph = RunningGraph()
+    graph.runtime.add(RepeatedPixelBufferAcquirer)
+    graph.start()
+    try:
+        observation = _await_observation("repeated_acquires")
+    finally:
+        graph.shut_down_and_take_run_outcome()
+    assert observation["outcomes"] == ["ok"] * 8, (
+        f"a closed pixel buffer did not return its pool slot: {observation['outcomes']}"
+    )

--- a/sdk/streamlib-python-wheel/tests/test_capability_contexts.py
+++ b/sdk/streamlib-python-wheel/tests/test_capability_contexts.py
@@ -314,7 +314,7 @@ def test_a_context_stashed_from_setup_expires_with_the_hook():
         graph.shut_down_and_take_run_outcome()
 
     stashed_context = _stashed_contexts.get_nowait()
-    with pytest.raises(RuntimeError, match="only valid during the lifecycle hook"):
+    with pytest.raises(RuntimeError, match="only valid during the lifecycle hook or escalate"):
         stashed_context.is_paused()
 
 
@@ -487,4 +487,75 @@ def test_a_closed_pixel_buffer_returns_its_pool_slot():
         graph.shut_down_and_take_run_outcome()
     assert observation["outcomes"] == ["ok"] * 8, (
         f"a closed pixel buffer did not return its pool slot: {observation['outcomes']}"
+    )
+
+
+@processor(execution="manual")
+class WorkerThreadEscalator:
+    """The native camera's shape: stash Limited in setup, escalate once on a worker.
+
+    `camera_linux.rs` is the reference — its capture thread holds only
+    `GpuContextLimitedAccess` and upgrades exactly once at thread start for
+    privileged construction. This proves a Python processor can follow the
+    same pattern rather than reaching past the type system the way
+    `avatar_character.py`'s `# type: ignore[attr-defined]` had to.
+    """
+
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        self._stashed_gpu_limited = ctx.gpu_limited_access
+
+    def start(self, ctx: RuntimeContextFullAccess) -> None:
+        self._worker = threading.Thread(target=self._construct_resources, daemon=True)
+        self._worker.start()
+
+    def _construct_resources(self) -> None:
+        stashed_escalated_capability = []
+
+        def privileged_construction(full):
+            with full.acquire_pixel_buffer(48, 48) as surface_handle:
+                stashed_escalated_capability.append(full)
+                return {"surface_id": surface_handle.surface_id}
+
+        try:
+            construction_outcome = self._stashed_gpu_limited.escalate(privileged_construction)
+            # The escalated capability expired with the callback; using it
+            # afterwards must raise, not silently keep privileged access.
+            try:
+                stashed_escalated_capability[0].wait_device_idle()
+                escape_outcome = "granted"
+            except RuntimeError as expiry_refusal:
+                escape_outcome = str(expiry_refusal)
+            _hook_observations.put(
+                {
+                    "observed": "worker_escalate",
+                    "construction_outcome": construction_outcome,
+                    "escape_outcome": escape_outcome,
+                }
+            )
+        except BaseException as escalate_failure:  # noqa: BLE001 — surfaced by the test
+            _hook_observations.put(
+                {"observed": "worker_escalate", "failure": repr(escalate_failure)}
+            )
+
+    def stop(self, ctx: RuntimeContextFullAccess) -> None:
+        self._worker.join(timeout=30.0)
+
+
+def test_a_worker_thread_escalates_once_like_the_native_camera():
+    graph = RunningGraph()
+    graph.runtime.add(WorkerThreadEscalator)
+    graph.start()
+    try:
+        observation = _await_observation("worker_escalate")
+    finally:
+        graph.shut_down_and_take_run_outcome()
+    assert "failure" not in observation, (
+        f"the camera pattern failed from Python: {observation.get('failure')}"
+    )
+    assert observation["construction_outcome"]["surface_id"], (
+        "escalate did not hand back the callback's return value"
+    )
+    assert "only valid during" in observation["escape_outcome"], (
+        f"an escalated capability stashed past its callback must expire, got: "
+        f"{observation['escape_outcome']!r}"
     )

--- a/sdk/streamlib-python-wheel/tests/test_clock_and_log.py
+++ b/sdk/streamlib-python-wheel/tests/test_clock_and_log.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""The clock and logging surfaces, exercised without an engine.
+
+`monotonic_now_ns` and `MonotonicTimer` are pure kernel-facing calls and
+`log.*` degrades to a no-op sink before an engine boots, so none of this
+needs a GPU.
+"""
+
+import time
+
+import pytest
+
+import streamlib
+from streamlib import MonotonicTimer, clock, log, monotonic_now_ns
+
+# Small enough to keep the suite fast, large enough that scheduler jitter
+# cannot swallow a whole interval.
+TIMER_TEST_INTERVAL_NS = 20_000_000
+# Bounded like every wait in this suite: a timer that never ticks must fail,
+# not hang.
+TIMER_TICK_TIMEOUT_MS = 2_000
+
+
+def test_monotonic_now_ns_returns_a_positive_int():
+    value = monotonic_now_ns()
+    assert isinstance(value, int)
+    assert value > 0
+
+
+def test_monotonic_now_ns_is_non_decreasing_across_calls():
+    samples = [monotonic_now_ns() for _ in range(1000)]
+    for previous, current in zip(samples, samples[1:]):
+        assert current >= previous, f"clock went backwards: {current} < {previous}"
+
+
+def test_monotonic_now_ns_reads_the_kernel_monotonic_clock():
+    """Two streamlib reads bracket a `time` module read of the same clock.
+
+    Pins the canonical-source contract: the value is
+    `clock_gettime(CLOCK_MONOTONIC)`, the same syscall Rust's `Instant::now()`
+    makes, so stamps are comparable across processes on this kernel.
+    """
+    first_streamlib_read = monotonic_now_ns()
+    kernel_read = time.clock_gettime_ns(time.CLOCK_MONOTONIC)
+    second_streamlib_read = monotonic_now_ns()
+    assert first_streamlib_read <= kernel_read <= second_streamlib_read
+
+
+def test_the_clock_module_re_exports_the_native_surface():
+    """Old-SDK parity: `from streamlib import clock` keeps working."""
+    assert clock.monotonic_now_ns is streamlib.monotonic_now_ns
+    assert clock.MonotonicTimer is streamlib.MonotonicTimer
+
+
+def test_a_timer_ticks_at_roughly_its_interval():
+    with MonotonicTimer(TIMER_TEST_INTERVAL_NS) as timer:
+        before_first_tick = monotonic_now_ns()
+        expirations = timer.wait(timeout_ms=TIMER_TICK_TIMEOUT_MS)
+        after_first_tick = monotonic_now_ns()
+    assert expirations >= 1, "the timer never ticked within the bounded wait"
+    # The first absolute deadline is `now + interval`; a tick before it would
+    # mean the timer is not the drift-free absolute-time shape it claims.
+    elapsed = after_first_tick - before_first_tick
+    assert elapsed >= TIMER_TEST_INTERVAL_NS // 2, (
+        f"a tick arrived after only {elapsed}ns for a {TIMER_TEST_INTERVAL_NS}ns interval"
+    )
+
+
+def test_a_wait_that_times_out_returns_zero():
+    one_hour_ns = 3_600_000_000_000
+    with MonotonicTimer(one_hour_ns) as timer:
+        assert timer.wait(timeout_ms=10) == 0
+
+
+def test_waiting_on_a_closed_timer_returns_minus_one():
+    timer = MonotonicTimer(TIMER_TEST_INTERVAL_NS)
+    timer.close()
+    assert timer.wait(timeout_ms=10) == -1
+
+
+def test_the_context_manager_closes_the_timer():
+    with MonotonicTimer(TIMER_TEST_INTERVAL_NS) as timer:
+        assert timer.interval_ns == TIMER_TEST_INTERVAL_NS
+    assert timer.wait(timeout_ms=10) == -1
+
+
+@pytest.mark.parametrize("invalid_interval_ns", [0, -1])
+def test_a_non_positive_interval_is_refused(invalid_interval_ns):
+    with pytest.raises(ValueError, match="interval_ns must be > 0"):
+        MonotonicTimer(invalid_interval_ns)
+
+
+def test_every_log_level_accepts_structured_attrs():
+    """The old SDK's `log.info("msg", key=value)` shape, engine or no engine."""
+    log.trace("trace record", detail="fine")
+    log.debug("debug record", frame_number=7)
+    log.info("info record", width=1920, height=1080)
+    log.warn("warn record", dropped=3)
+    log.error("error record", error="synthetic")
+
+
+def test_warn_is_the_primary_name_and_warning_its_alias():
+    assert log.warning is log.warn
+
+
+def test_log_functions_accept_a_bare_message():
+    log.info("no attrs at all")

--- a/sdk/streamlib-python-wheel/tests/test_graph_building.py
+++ b/sdk/streamlib-python-wheel/tests/test_graph_building.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 
 import streamlib
-from streamlib import LinkInputDataPort, LinkOutputDataPort, processor
+from streamlib import RuntimeContextLimitedAccess, input, output, processor
 
 GRAPH_BUILDING_APP = Path(__file__).parent / "graph_building_app.py"
 
@@ -27,13 +27,16 @@ def graph_building_app(start_app_under_test):
 
 @processor
 class GraphBuildingFilter:
-    frames_from_upstream = LinkInputDataPort()
-    frames_to_downstream = LinkOutputDataPort()
+    @input()
+    def frames_from_upstream(self) -> None: ...
 
-    def process(self) -> None:
-        frame = self.frames_from_upstream.read()
+    @output()
+    def frames_to_downstream(self) -> None: ...
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        frame = ctx.inputs.read("frames_from_upstream")
         if frame is not None:
-            self.frames_to_downstream.write(frame)
+            ctx.outputs.write("frames_to_downstream", frame)
 
 
 def test_building_the_graph_from_two_threads_does_not_deadlock(graph_building_app):

--- a/sdk/streamlib-python-wheel/tests/test_graph_building.py
+++ b/sdk/streamlib-python-wheel/tests/test_graph_building.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Building a graph — the half of the authoring surface that needs no device.
+
+`Runtime()` boots the engine but does not start it, and `add` / `connect` only
+mutate the graph, so nothing here reaches the GPU context that `run()` brings
+up. That is what lets these run on every pull request rather than only on the
+rig.
+"""
+
+import queue
+import threading
+
+import pytest
+
+import streamlib
+from streamlib import LinkInputDataPort, LinkOutputDataPort, processor
+
+
+@processor
+class GraphBuildingFilter:
+    frames_from_upstream = LinkInputDataPort()
+    frames_to_downstream = LinkOutputDataPort()
+
+    def process(self) -> None:
+        frame = self.frames_from_upstream.read()
+        if frame is not None:
+            self.frames_to_downstream.write(frame)
+
+
+CONCURRENT_GRAPH_BUILD_ADDS = 200
+# A wedged pair never completes, so any finite bound turns the deadlock into a
+# failure. Generous enough that a slow runner cannot trip it: 400 adds finish in
+# well under a second when nothing is wedged.
+CONCURRENT_GRAPH_BUILD_TIMEOUT_SECONDS = 60.0
+
+
+def test_building_the_graph_from_two_threads_does_not_deadlock():
+    """`add` must not hold the lifecycle lock while it releases the GIL.
+
+    The deadly embrace this locks out: a thread inside `add` holds the lifecycle
+    mutex and, having detached, waits to re-attach, while another thread holds
+    the GIL and blocks on that same mutex.
+
+    Honest about how it fails: the wedge takes the GIL down with it, so this
+    does not report a failed assertion — the whole interpreter stops, including
+    the join below and anything after it. It goes red as a job that runs out of
+    time, which is why the workflow puts a `timeout-minutes` on the job.
+    Verified by reverting the fix: killed at the 150s mark having printed
+    nothing, versus 0.4s green with the fix in place.
+    """
+    runtime = streamlib.Runtime()
+    failures: "queue.Queue[BaseException]" = queue.Queue()
+
+    def add_repeatedly() -> None:
+        try:
+            for _ in range(CONCURRENT_GRAPH_BUILD_ADDS):
+                runtime.add(GraphBuildingFilter)
+        except BaseException as add_failure:  # noqa: BLE001 — surfaced below
+            failures.put(add_failure)
+
+    builders = [
+        threading.Thread(target=add_repeatedly, name=f"graph-builder-{index}", daemon=True)
+        for index in range(2)
+    ]
+    for builder in builders:
+        builder.start()
+    for builder in builders:
+        builder.join(timeout=CONCURRENT_GRAPH_BUILD_TIMEOUT_SECONDS)
+
+    still_running = [builder.name for builder in builders if builder.is_alive()]
+    assert not still_running, (
+        f"{still_running} never finished building the graph — `add` deadlocked against "
+        f"the lifecycle lock"
+    )
+    runtime.shutdown()
+
+    try:
+        raise failures.get_nowait()
+    except queue.Empty:
+        pass
+
+
+def test_two_added_processors_of_one_class_get_their_own_identities():
+    """One registration, two nodes — the graph, not the registry, holds instances."""
+    runtime = streamlib.Runtime()
+    try:
+        first = runtime.add(GraphBuildingFilter, display_name="First")
+        second = runtime.add(GraphBuildingFilter, display_name="Second")
+        assert first.processor_id != second.processor_id
+        assert (first.display_name, second.display_name) == ("First", "Second")
+    finally:
+        runtime.shutdown()
+
+
+def test_connecting_a_port_that_does_not_exist_is_refused():
+    runtime = streamlib.Runtime()
+    try:
+        source = runtime.add(GraphBuildingFilter)
+        destination = runtime.add(GraphBuildingFilter)
+        with pytest.raises(RuntimeError):
+            runtime.connect(
+                source.output("no_such_port"),
+                destination.input("frames_from_upstream"),
+            )
+    finally:
+        runtime.shutdown()
+
+
+def test_adding_something_that_is_not_a_processor_says_so():
+    class NotAProcessor:
+        pass
+
+    runtime = streamlib.Runtime()
+    try:
+        with pytest.raises(RuntimeError, match="is not a processor"):
+            runtime.add(NotAProcessor)
+        # An instance rather than the class is the likely slip, and it gets the
+        # same answer.
+        with pytest.raises(RuntimeError, match="is not a processor"):
+            runtime.add(GraphBuildingFilter())
+    finally:
+        runtime.shutdown()
+
+
+def test_the_graph_cannot_be_built_after_the_runtime_is_shut_down():
+    runtime = streamlib.Runtime()
+    runtime.shutdown()
+    with pytest.raises(RuntimeError, match="has been shut down"):
+        runtime.add(GraphBuildingFilter)

--- a/sdk/streamlib-python-wheel/tests/test_graph_building.py
+++ b/sdk/streamlib-python-wheel/tests/test_graph_building.py
@@ -9,13 +9,20 @@ up. That is what lets these run on every pull request rather than only on the
 rig.
 """
 
-import queue
-import threading
+from pathlib import Path
 
 import pytest
 
 import streamlib
 from streamlib import LinkInputDataPort, LinkOutputDataPort, processor
+
+GRAPH_BUILDING_APP = Path(__file__).parent / "graph_building_app.py"
+
+
+@pytest.fixture
+def graph_building_app(start_app_under_test):
+    """Starts this suite's app; the shared fixture owns the cleanup."""
+    return lambda scenario: start_app_under_test(GRAPH_BUILDING_APP, scenario)
 
 
 @processor
@@ -29,57 +36,43 @@ class GraphBuildingFilter:
             self.frames_to_downstream.write(frame)
 
 
-CONCURRENT_GRAPH_BUILD_ADDS = 200
-# A wedged pair never completes, so any finite bound turns the deadlock into a
-# failure. Generous enough that a slow runner cannot trip it: 400 adds finish in
-# well under a second when nothing is wedged.
-CONCURRENT_GRAPH_BUILD_TIMEOUT_SECONDS = 60.0
-
-
-def test_building_the_graph_from_two_threads_does_not_deadlock():
+def test_building_the_graph_from_two_threads_does_not_deadlock(graph_building_app):
     """`add` must not hold the lifecycle lock while it releases the GIL.
 
     The deadly embrace this locks out: a thread inside `add` holds the lifecycle
     mutex and, having detached, waits to re-attach, while another thread holds
     the GIL and blocks on that same mutex.
 
-    Honest about how it fails: the wedge takes the GIL down with it, so this
-    does not report a failed assertion — the whole interpreter stops, including
-    the join below and anything after it. It goes red as a job that runs out of
-    time, which is why the workflow puts a `timeout-minutes` on the job.
-    Verified by reverting the fix: killed at the 150s mark having printed
-    nothing, versus 0.4s green with the fix in place.
+    Driven out of process because the wedge takes the GIL with it — an in-process
+    assertion could never run, and the suite would hang rather than fail.
+    Mental-revert: keeping the lifecycle guard alive across the `python.detach`
+    in `add`. The app then stops after RUNTIME_CONSTRUCTED and this fails on the
+    bounded wait for GRAPH_BUILT, which is how a deadlock should read.
     """
-    runtime = streamlib.Runtime()
-    failures: "queue.Queue[BaseException]" = queue.Queue()
+    app = graph_building_app("concurrent_graph_building")
+    app.await_marker("GRAPH_BUILT")
+    app.await_clean_exit()
 
-    def add_repeatedly() -> None:
-        try:
-            for _ in range(CONCURRENT_GRAPH_BUILD_ADDS):
-                runtime.add(GraphBuildingFilter)
-        except BaseException as add_failure:  # noqa: BLE001 — surfaced below
-            failures.put(add_failure)
 
-    builders = [
-        threading.Thread(target=add_repeatedly, name=f"graph-builder-{index}", daemon=True)
-        for index in range(2)
-    ]
-    for builder in builders:
-        builder.start()
-    for builder in builders:
-        builder.join(timeout=CONCURRENT_GRAPH_BUILD_TIMEOUT_SECONDS)
+def test_shutdown_racing_graph_building_does_not_wedge(graph_building_app):
+    """`shutdown()` landing mid-`add` must resolve, either way round.
 
-    still_running = [builder.name for builder in builders if builder.is_alive()]
-    assert not still_running, (
-        f"{still_running} never finished building the graph — `add` deadlocked against "
-        f"the lifecycle lock"
+    `add` releases the GIL around the engine call and `shutdown` takes the same
+    lock while holding it, so this is the other order of the same pair. Every
+    add is either accepted or refused by name; none may hang.
+    """
+    app = graph_building_app("shutdown_racing_graph_building")
+    app.await_clean_exit()
+
+    refusals = next(
+        int(marker.removeprefix("REFUSED_AFTER_SHUTDOWN="))
+        for marker in app.markers()
+        if marker.startswith("REFUSED_AFTER_SHUTDOWN=")
     )
-    runtime.shutdown()
-
-    try:
-        raise failures.get_nowait()
-    except queue.Empty:
-        pass
+    assert refusals > 0, (
+        f"every add succeeded after shutdown() — the lifecycle state was never "
+        f"observed; output:\n{app.output}"
+    )
 
 
 def test_two_added_processors_of_one_class_get_their_own_identities():

--- a/sdk/streamlib-python-wheel/tests/test_in_process_authoring.py
+++ b/sdk/streamlib-python-wheel/tests/test_in_process_authoring.py
@@ -212,65 +212,11 @@ def test_two_instances_of_one_class_run_side_by_side_with_their_own_config():
 
 _fast_processor_ticks = threading.Semaphore(0)
 
-# Long enough to span the whole observation window, so the parked processor is
-# inside one uninterrupted native wait for its entire duration.
-SLOW_PROCESSOR_INTERVAL_MS = 2000
-
-
-@processor(execution="continuous", interval_ms=SLOW_PROCESSOR_INTERVAL_MS)
-class ProcessorParkedInANativeWait:
-    """Spends effectively all of its life inside the engine's interval wait."""
-
-    def process(self) -> None:
-        return
-
 
 @processor(execution="continuous", interval_ms=1)
 class FastTickingProcessor:
     def process(self) -> None:
         _fast_processor_ticks.release()
-
-
-# The window the fast processor is observed over, and the floor its tick count
-# must clear. The floor sits far above the one tick a starved processor could
-# manage and far below the ~1000 a 1ms interval yields, so scheduling jitter
-# cannot fail it and a held GIL cannot pass it.
-GIL_OBSERVATION_WINDOW_SECONDS = 1.0
-MINIMUM_TICKS_WHILE_THE_OTHER_PROCESSOR_IS_PARKED = 20
-
-
-def test_a_processor_parked_in_a_native_call_stalls_no_other_python_processor():
-    """The GIL-release contract, as a behaviour rather than a code shape.
-
-    One processor sits inside a 2-second native wait for the whole window while
-    another must keep running Python. Mental-revert: attaching the GIL for a
-    processor's lifetime instead of for the span of each callback — the parked
-    processor then holds it across its wait and the fast one manages at most a
-    single tick.
-    """
-    pipeline = RunningPipeline()
-    pipeline.runtime.add(ProcessorParkedInANativeWait)
-    pipeline.runtime.add(FastTickingProcessor)
-    pipeline.start()
-
-    # Drain what accumulated during the engine's boot, so the count below is
-    # made entirely within the observation window.
-    assert _fast_processor_ticks.acquire(timeout=PIPELINE_TIMEOUT_SECONDS), (
-        "the fast processor never ran at all"
-    )
-    while _fast_processor_ticks.acquire(blocking=False):
-        pass
-
-    time.sleep(GIL_OBSERVATION_WINDOW_SECONDS)
-
-    ticks = _drain(_fast_processor_ticks)
-    pipeline.shut_down_and_take_run_outcome()
-
-    assert ticks >= MINIMUM_TICKS_WHILE_THE_OTHER_PROCESSOR_IS_PARKED, (
-        f"a Python processor managed only {ticks} ticks in "
-        f"{GIL_OBSERVATION_WINDOW_SECONDS}s while another sat in a "
-        f"{SLOW_PROCESSOR_INTERVAL_MS}ms native wait — the GIL was held across that wait"
-    )
 
 
 _writes_started = threading.Semaphore(0)
@@ -400,24 +346,3 @@ def test_an_exception_in_process_does_not_take_the_pipeline_down():
         assert _frames_after_the_raising_one.get(timeout=PIPELINE_TIMEOUT_SECONDS) == {
             "value": 2
         }
-
-
-def test_adding_something_that_is_not_a_processor_says_so():
-    class NotAProcessor:
-        pass
-
-    runtime = streamlib.Runtime()
-    try:
-        with pytest.raises(RuntimeError, match="is not a processor"):
-            runtime.add(NotAProcessor)
-        with pytest.raises(RuntimeError, match="is not a processor"):
-            runtime.add(BrightnessFilter())
-    finally:
-        runtime.shutdown()
-
-
-def test_the_graph_cannot_be_built_after_the_runtime_is_shut_down():
-    runtime = streamlib.Runtime()
-    runtime.shutdown()
-    with pytest.raises(RuntimeError, match="has been shut down"):
-        runtime.add(BrightnessFilter)

--- a/sdk/streamlib-python-wheel/tests/test_in_process_authoring.py
+++ b/sdk/streamlib-python-wheel/tests/test_in_process_authoring.py
@@ -1,0 +1,423 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Python processors running in the app's own interpreter, on real engine threads.
+
+Everything here boots a real engine, so it needs a GPU: `Runner::start()`
+initializes a GPU context whose DMA-BUF pool pre-warm a software rasterizer
+cannot satisfy. What none of it needs is a camera or a display — the frames are
+synthetic, which is the "no hardware" the single-processor harness promises.
+"""
+
+import queue
+import threading
+import time
+
+import pytest
+
+import streamlib
+from streamlib import LinkInputDataPort, LinkOutputDataPort, processor
+from streamlib.testing import SingleProcessorTestPipeline
+
+pytestmark = pytest.mark.requires_gpu
+
+# Bounded like every other wait in this suite: a pipeline that never produces is
+# the failure under test, and an unbounded wait would turn it into a hung run.
+PIPELINE_TIMEOUT_SECONDS = 30.0
+
+
+@processor
+class BrightnessFilter:
+    """The shape the scaffold teaches: ports as attributes, config as arguments."""
+
+    frames_from_upstream = LinkInputDataPort()
+    frames_to_downstream = LinkOutputDataPort()
+
+    def __init__(self, gain: float = 1.0) -> None:
+        self.gain = gain
+
+    def process(self) -> None:
+        frame = self.frames_from_upstream.read()
+        if frame is None:
+            return
+        self.frames_to_downstream.write({"value": frame["value"] * self.gain})
+
+
+def test_a_processor_runs_in_process_and_transforms_what_it_is_fed():
+    with SingleProcessorTestPipeline(BrightnessFilter, config={"gain": 2.0}) as pipeline:
+        pipeline.feed("frames_from_upstream", {"value": 21})
+        assert pipeline.await_bag("frames_to_downstream", timeout=PIPELINE_TIMEOUT_SECONDS) == {
+            "value": 42.0
+        }
+
+
+def test_config_reaches_the_class_as_ordinary_constructor_arguments():
+    """No configuration object: `config={...}` is `BrightnessFilter(**config)`."""
+    with SingleProcessorTestPipeline(BrightnessFilter) as pipeline:
+        pipeline.feed("frames_from_upstream", {"value": 7})
+        # The class's own default, because nothing overrode it.
+        assert pipeline.await_bag("frames_to_downstream", timeout=PIPELINE_TIMEOUT_SECONDS) == {
+            "value": 7.0
+        }
+
+
+# ---------------------------------------------------------------------------
+# The demo: two Python processors passing bags to each other in one process.
+# ---------------------------------------------------------------------------
+
+_frames_reaching_the_sink: "queue.Queue[dict]" = queue.Queue()
+
+
+@processor(execution="continuous", interval_ms=1)
+class CountingFrameSource:
+    frames_to_downstream = LinkOutputDataPort()
+
+    def __init__(self) -> None:
+        self.frames_produced = 0
+
+    def process(self) -> None:
+        self.frames_produced += 1
+        self.frames_to_downstream.write({"frame_number": self.frames_produced})
+
+
+@processor
+class FrameCountingSink:
+    frames_from_upstream = LinkInputDataPort(delivery_profile="every_sample")
+
+    def process(self) -> None:
+        frame = self.frames_from_upstream.read()
+        if frame is not None:
+            _frames_reaching_the_sink.put(frame)
+
+
+class RunningPipeline:
+    """A graph running on a worker thread, shut down and joined on exit.
+
+    `run()` owns the thread it is called on, and a test needs to keep the main
+    one. Joining before the block ends is what keeps interpreter finalization
+    out of the race the contract is about.
+    """
+
+    def __init__(self) -> None:
+        self.runtime = streamlib.Runtime()
+        self.run_outcome: "queue.Queue[BaseException | None]" = queue.Queue()
+        self._run_loop = threading.Thread(target=self._run, daemon=True)
+
+    def _run(self) -> None:
+        try:
+            self.runtime.run()
+        except BaseException as run_failure:  # noqa: BLE001 — surfaced by the caller
+            self.run_outcome.put(run_failure)
+        else:
+            self.run_outcome.put(None)
+
+    def start(self) -> None:
+        self._run_loop.start()
+
+    def shut_down_and_take_run_outcome(self) -> "BaseException | None":
+        self.runtime.shutdown()
+        self._run_loop.join(timeout=PIPELINE_TIMEOUT_SECONDS)
+        assert not self._run_loop.is_alive(), "run() never returned after shutdown()"
+        return self.run_outcome.get_nowait()
+
+
+def test_two_python_processors_pass_bags_in_process():
+    """The ticket's demo, and the teardown contract re-proved against live processors.
+
+    #1707 could only prove "every engine thread joined, every anchored thread
+    state released" against an empty graph, because no Python API could add a
+    processor. It now runs with two Python processors holding engine threads:
+    a reference surviving teardown makes `Arc::into_inner` return `None`, and
+    `run()` raises rather than letting those threads outlive the interpreter.
+    """
+    pipeline = RunningPipeline()
+    source = pipeline.runtime.add(CountingFrameSource)
+    sink = pipeline.runtime.add(FrameCountingSink)
+    pipeline.runtime.connect(
+        source.output("frames_to_downstream"), sink.input("frames_from_upstream")
+    )
+    pipeline.start()
+
+    first_frame = _frames_reaching_the_sink.get(timeout=PIPELINE_TIMEOUT_SECONDS)
+    assert first_frame["frame_number"] >= 1
+
+    run_failure = pipeline.shut_down_and_take_run_outcome()
+    assert run_failure is None, (
+        f"tearing down a graph with live Python processors failed: {run_failure}"
+    )
+
+
+_values_reaching_the_sink: "queue.Queue[dict]" = queue.Queue()
+
+
+@processor(execution="continuous", interval_ms=1)
+class ConstantValueSource:
+    frames_to_downstream = LinkOutputDataPort()
+
+    def __init__(self, value: float = 1.0) -> None:
+        self.value = value
+
+    def process(self) -> None:
+        self.frames_to_downstream.write({"value": self.value})
+
+
+@processor
+class ValueCollectingSink:
+    frames_from_upstream = LinkInputDataPort()
+
+    def process(self) -> None:
+        frame = self.frames_from_upstream.read()
+        if frame is not None:
+            _values_reaching_the_sink.put(frame)
+
+
+def test_two_instances_of_one_class_run_side_by_side_with_their_own_config():
+    """One registration, two live instances, two different configurations.
+
+    Both filters are the same class in the same running graph, so a shared
+    instance or shared configuration would show up as the wrong product.
+    """
+    pipeline = RunningPipeline()
+    source = pipeline.runtime.add(ConstantValueSource, config={"value": 5.0})
+    doubling = pipeline.runtime.add(
+        BrightnessFilter, config={"gain": 2.0}, display_name="Doubling"
+    )
+    tripling = pipeline.runtime.add(
+        BrightnessFilter, config={"gain": 3.0}, display_name="Tripling"
+    )
+    sink = pipeline.runtime.add(ValueCollectingSink)
+
+    pipeline.runtime.connect(
+        source.output("frames_to_downstream"), doubling.input("frames_from_upstream")
+    )
+    pipeline.runtime.connect(
+        doubling.output("frames_to_downstream"), tripling.input("frames_from_upstream")
+    )
+    pipeline.runtime.connect(
+        tripling.output("frames_to_downstream"), sink.input("frames_from_upstream")
+    )
+    pipeline.start()
+
+    try:
+        assert _values_reaching_the_sink.get(timeout=PIPELINE_TIMEOUT_SECONDS) == {
+            "value": 30.0
+        }
+    finally:
+        pipeline.shut_down_and_take_run_outcome()
+
+
+# ---------------------------------------------------------------------------
+# The GIL-release contract.
+# ---------------------------------------------------------------------------
+
+_fast_processor_ticks = threading.Semaphore(0)
+
+# Long enough to span the whole observation window, so the parked processor is
+# inside one uninterrupted native wait for its entire duration.
+SLOW_PROCESSOR_INTERVAL_MS = 2000
+
+
+@processor(execution="continuous", interval_ms=SLOW_PROCESSOR_INTERVAL_MS)
+class ProcessorParkedInANativeWait:
+    """Spends effectively all of its life inside the engine's interval wait."""
+
+    def process(self) -> None:
+        return
+
+
+@processor(execution="continuous", interval_ms=1)
+class FastTickingProcessor:
+    def process(self) -> None:
+        _fast_processor_ticks.release()
+
+
+# The window the fast processor is observed over, and the floor its tick count
+# must clear. The floor sits far above the one tick a starved processor could
+# manage and far below the ~1000 a 1ms interval yields, so scheduling jitter
+# cannot fail it and a held GIL cannot pass it.
+GIL_OBSERVATION_WINDOW_SECONDS = 1.0
+MINIMUM_TICKS_WHILE_THE_OTHER_PROCESSOR_IS_PARKED = 20
+
+
+def test_a_processor_parked_in_a_native_call_stalls_no_other_python_processor():
+    """The GIL-release contract, as a behaviour rather than a code shape.
+
+    One processor sits inside a 2-second native wait for the whole window while
+    another must keep running Python. Mental-revert: attaching the GIL for a
+    processor's lifetime instead of for the span of each callback — the parked
+    processor then holds it across its wait and the fast one manages at most a
+    single tick.
+    """
+    pipeline = RunningPipeline()
+    pipeline.runtime.add(ProcessorParkedInANativeWait)
+    pipeline.runtime.add(FastTickingProcessor)
+    pipeline.start()
+
+    # Drain what accumulated during the engine's boot, so the count below is
+    # made entirely within the observation window.
+    assert _fast_processor_ticks.acquire(timeout=PIPELINE_TIMEOUT_SECONDS), (
+        "the fast processor never ran at all"
+    )
+    while _fast_processor_ticks.acquire(blocking=False):
+        pass
+
+    time.sleep(GIL_OBSERVATION_WINDOW_SECONDS)
+
+    ticks = _drain(_fast_processor_ticks)
+    pipeline.shut_down_and_take_run_outcome()
+
+    assert ticks >= MINIMUM_TICKS_WHILE_THE_OTHER_PROCESSOR_IS_PARKED, (
+        f"a Python processor managed only {ticks} ticks in "
+        f"{GIL_OBSERVATION_WINDOW_SECONDS}s while another sat in a "
+        f"{SLOW_PROCESSOR_INTERVAL_MS}ms native wait — the GIL was held across that wait"
+    )
+
+
+_writes_started = threading.Semaphore(0)
+_writes_finished = threading.Semaphore(0)
+
+
+@processor(execution="continuous", interval_ms=0)
+class ProducerBlockedByBackpressure:
+    """Writes as fast as it can into a link its consumer barely drains."""
+
+    bags_to_downstream = LinkOutputDataPort()
+
+    def process(self) -> None:
+        _writes_started.release()
+        self.bags_to_downstream.write({"payload": "x" * 1024})
+        _writes_finished.release()
+
+
+@processor
+class GlacialConsumer:
+    """`lossless`, so the producer blocks rather than the engine dropping bags."""
+
+    bags_from_upstream = LinkInputDataPort(delivery_profile="lossless")
+
+    def process(self) -> None:
+        self.bags_from_upstream.read()
+        time.sleep(GLACIAL_CONSUMER_DELAY_SECONDS)
+
+
+GLACIAL_CONSUMER_DELAY_SECONDS = 1.0
+BACKPRESSURE_OBSERVATION_WINDOW_SECONDS = 2.0
+# A producer whose writes returned immediately would manage tens of thousands in
+# the window; one held by backpressure manages tens. The ceiling sits far below
+# the former and far above the latter.
+MAXIMUM_WRITES_IF_BACKPRESSURE_HELD = 1000
+# A ticker starved by a held GIL manages at most one or two ticks in the window;
+# a free one manages thousands.
+MINIMUM_TICKS_WHILE_A_WRITE_IS_BLOCKED = 100
+
+
+def test_a_write_blocked_by_backpressure_stalls_no_other_python_processor():
+    """The GIL-release contract on the path that genuinely blocks.
+
+    A `lossless` link makes the producer's `write()` block inside the engine
+    rather than drop the bag, so this is a Python processor parked in a native
+    call for nearly the whole window. Another Python processor must keep
+    running throughout.
+
+    Mental-revert: dropping the `python.detach` around `write_raw` — the blocked
+    producer then holds the GIL for the duration of every blocked write and the
+    ticker's count collapses to single digits.
+    """
+    pipeline = RunningPipeline()
+    producer = pipeline.runtime.add(ProducerBlockedByBackpressure)
+    consumer = pipeline.runtime.add(GlacialConsumer)
+    pipeline.runtime.add(FastTickingProcessor)
+    pipeline.runtime.connect(
+        producer.output("bags_to_downstream"), consumer.input("bags_from_upstream")
+    )
+    pipeline.start()
+
+    while _fast_processor_ticks.acquire(blocking=False):
+        pass
+    time.sleep(BACKPRESSURE_OBSERVATION_WINDOW_SECONDS)
+
+    writes_started = _drain(_writes_started)
+    writes_finished = _drain(_writes_finished)
+    ticks = _drain(_fast_processor_ticks)
+    pipeline.shut_down_and_take_run_outcome()
+
+    assert writes_started > writes_finished, (
+        "no write was in flight when the window closed — the producer was never "
+        "actually blocked, so this proves nothing about a blocked call"
+    )
+    assert writes_started <= MAXIMUM_WRITES_IF_BACKPRESSURE_HELD, (
+        f"the producer completed {writes_started} writes in "
+        f"{BACKPRESSURE_OBSERVATION_WINDOW_SECONDS}s — backpressure did not hold it, so "
+        f"it spent the window running rather than blocked"
+    )
+    assert ticks >= MINIMUM_TICKS_WHILE_A_WRITE_IS_BLOCKED, (
+        f"a Python processor managed only {ticks} ticks while another sat blocked inside "
+        f"write() — the GIL was held across the blocking native call"
+    )
+
+
+def _drain(counter: threading.Semaphore) -> int:
+    counted = 0
+    while counter.acquire(blocking=False):
+        counted += 1
+    return counted
+
+
+# ---------------------------------------------------------------------------
+# Failure surfaces.
+# ---------------------------------------------------------------------------
+
+_frames_after_the_raising_one: "queue.Queue[dict]" = queue.Queue()
+
+
+@processor
+class ProcessorThatRaisesOnce:
+    frames_from_upstream = LinkInputDataPort(delivery_profile="every_sample")
+
+    def __init__(self) -> None:
+        self.frames_seen = 0
+
+    def process(self) -> None:
+        frame = self.frames_from_upstream.read()
+        if frame is None:
+            return
+        self.frames_seen += 1
+        if self.frames_seen == 1:
+            raise ValueError("the first frame is always trouble")
+        _frames_after_the_raising_one.put(frame)
+
+
+def test_an_exception_in_process_does_not_take_the_pipeline_down():
+    """A raise is one bad frame, not a dead pipeline.
+
+    The traceback reaches the log; the processor is called again on the next
+    frame. An author iterating on a filter should not have to restart for a
+    typo that only some frames reach.
+    """
+    with SingleProcessorTestPipeline(ProcessorThatRaisesOnce) as pipeline:
+        pipeline.feed("frames_from_upstream", {"value": 1})
+        pipeline.feed("frames_from_upstream", {"value": 2})
+        assert _frames_after_the_raising_one.get(timeout=PIPELINE_TIMEOUT_SECONDS) == {
+            "value": 2
+        }
+
+
+def test_adding_something_that_is_not_a_processor_says_so():
+    class NotAProcessor:
+        pass
+
+    runtime = streamlib.Runtime()
+    try:
+        with pytest.raises(RuntimeError, match="is not a processor"):
+            runtime.add(NotAProcessor)
+        with pytest.raises(RuntimeError, match="is not a processor"):
+            runtime.add(BrightnessFilter())
+    finally:
+        runtime.shutdown()
+
+
+def test_the_graph_cannot_be_built_after_the_runtime_is_shut_down():
+    runtime = streamlib.Runtime()
+    runtime.shutdown()
+    with pytest.raises(RuntimeError, match="has been shut down"):
+        runtime.add(BrightnessFilter)

--- a/sdk/streamlib-python-wheel/tests/test_in_process_authoring.py
+++ b/sdk/streamlib-python-wheel/tests/test_in_process_authoring.py
@@ -16,7 +16,7 @@ import time
 import pytest
 
 import streamlib
-from streamlib import LinkInputDataPort, LinkOutputDataPort, processor
+from streamlib import RuntimeContextLimitedAccess, input, output, processor
 from streamlib.testing import SingleProcessorTestPipeline
 
 pytestmark = pytest.mark.requires_gpu
@@ -28,19 +28,22 @@ PIPELINE_TIMEOUT_SECONDS = 30.0
 
 @processor
 class BrightnessFilter:
-    """The shape the scaffold teaches: ports as attributes, config as arguments."""
-
-    frames_from_upstream = LinkInputDataPort()
-    frames_to_downstream = LinkOutputDataPort()
+    """The shape the scaffold teaches: ports as decorators, config as arguments."""
 
     def __init__(self, gain: float = 1.0) -> None:
         self.gain = gain
 
-    def process(self) -> None:
-        frame = self.frames_from_upstream.read()
+    @input()
+    def frames_from_upstream(self) -> None: ...
+
+    @output()
+    def frames_to_downstream(self) -> None: ...
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        frame = ctx.inputs.read("frames_from_upstream")
         if frame is None:
             return
-        self.frames_to_downstream.write({"value": frame["value"] * self.gain})
+        ctx.outputs.write("frames_to_downstream", {"value": frame["value"] * self.gain})
 
 
 def test_a_processor_runs_in_process_and_transforms_what_it_is_fed():
@@ -70,22 +73,24 @@ _frames_reaching_the_sink: "queue.Queue[dict]" = queue.Queue()
 
 @processor(execution="continuous", interval_ms=1)
 class CountingFrameSource:
-    frames_to_downstream = LinkOutputDataPort()
-
     def __init__(self) -> None:
         self.frames_produced = 0
 
-    def process(self) -> None:
+    @output()
+    def frames_to_downstream(self) -> None: ...
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
         self.frames_produced += 1
-        self.frames_to_downstream.write({"frame_number": self.frames_produced})
+        ctx.outputs.write("frames_to_downstream", {"frame_number": self.frames_produced})
 
 
 @processor
 class FrameCountingSink:
-    frames_from_upstream = LinkInputDataPort(delivery_profile="every_sample")
+    @input(delivery_profile="every_sample")
+    def frames_from_upstream(self) -> None: ...
 
-    def process(self) -> None:
-        frame = self.frames_from_upstream.read()
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        frame = ctx.inputs.read("frames_from_upstream")
         if frame is not None:
             _frames_reaching_the_sink.put(frame)
 
@@ -152,21 +157,23 @@ _values_reaching_the_sink: "queue.Queue[dict]" = queue.Queue()
 
 @processor(execution="continuous", interval_ms=1)
 class ConstantValueSource:
-    frames_to_downstream = LinkOutputDataPort()
-
     def __init__(self, value: float = 1.0) -> None:
         self.value = value
 
-    def process(self) -> None:
-        self.frames_to_downstream.write({"value": self.value})
+    @output()
+    def frames_to_downstream(self) -> None: ...
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        ctx.outputs.write("frames_to_downstream", {"value": self.value})
 
 
 @processor
 class ValueCollectingSink:
-    frames_from_upstream = LinkInputDataPort()
+    @input()
+    def frames_from_upstream(self) -> None: ...
 
-    def process(self) -> None:
-        frame = self.frames_from_upstream.read()
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        frame = ctx.inputs.read("frames_from_upstream")
         if frame is not None:
             _values_reaching_the_sink.put(frame)
 
@@ -215,7 +222,7 @@ _fast_processor_ticks = threading.Semaphore(0)
 
 @processor(execution="continuous", interval_ms=1)
 class FastTickingProcessor:
-    def process(self) -> None:
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
         _fast_processor_ticks.release()
 
 
@@ -227,11 +234,12 @@ _writes_finished = threading.Semaphore(0)
 class ProducerBlockedByBackpressure:
     """Writes as fast as it can into a link its consumer barely drains."""
 
-    bags_to_downstream = LinkOutputDataPort()
+    @output()
+    def bags_to_downstream(self) -> None: ...
 
-    def process(self) -> None:
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
         _writes_started.release()
-        self.bags_to_downstream.write({"payload": "x" * 1024})
+        ctx.outputs.write("bags_to_downstream", {"payload": "x" * 1024})
         _writes_finished.release()
 
 
@@ -239,10 +247,11 @@ class ProducerBlockedByBackpressure:
 class GlacialConsumer:
     """`lossless`, so the producer blocks rather than the engine dropping bags."""
 
-    bags_from_upstream = LinkInputDataPort(delivery_profile="lossless")
+    @input(delivery_profile="lossless")
+    def bags_from_upstream(self) -> None: ...
 
-    def process(self) -> None:
-        self.bags_from_upstream.read()
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        ctx.inputs.read("bags_from_upstream")
         time.sleep(GLACIAL_CONSUMER_DELAY_SECONDS)
 
 
@@ -260,10 +269,10 @@ MINIMUM_TICKS_WHILE_A_WRITE_IS_BLOCKED = 100
 def test_a_write_blocked_by_backpressure_stalls_no_other_python_processor():
     """The GIL-release contract on the path that genuinely blocks.
 
-    A `lossless` link makes the producer's `write()` block inside the engine
-    rather than drop the bag, so this is a Python processor parked in a native
-    call for nearly the whole window. Another Python processor must keep
-    running throughout.
+    A `lossless` link makes the producer's `ctx.outputs.write()` block inside
+    the engine rather than drop the bag, so this is a Python processor parked
+    in a native call for nearly the whole window. Another Python processor must
+    keep running throughout.
 
     Mental-revert: dropping the `python.detach` around `write_raw` — the blocked
     producer then holds the GIL for the duration of every blocked write and the
@@ -318,13 +327,14 @@ _frames_after_the_raising_one: "queue.Queue[dict]" = queue.Queue()
 
 @processor
 class ProcessorThatRaisesOnce:
-    frames_from_upstream = LinkInputDataPort(delivery_profile="every_sample")
-
     def __init__(self) -> None:
         self.frames_seen = 0
 
-    def process(self) -> None:
-        frame = self.frames_from_upstream.read()
+    @input(delivery_profile="every_sample")
+    def frames_from_upstream(self) -> None: ...
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        frame = ctx.inputs.read("frames_from_upstream")
         if frame is None:
             return
         self.frames_seen += 1

--- a/sdk/streamlib-python-wheel/tests/test_interpreter_lifecycle.py
+++ b/sdk/streamlib-python-wheel/tests/test_interpreter_lifecycle.py
@@ -10,191 +10,25 @@ interpreter finalization, a non-zero exit — are only visible to a parent.
 """
 
 import os
-import queue
 import signal
-import subprocess
-import sys
-import threading
 import time
 from pathlib import Path
 
 import pytest
 
+from app_under_test import (
+    ENGINE_STARTING_LOG_LINE,
+    ENGINE_STOPPED_LOG_LINE,
+    AppUnderTest,
+)
+
 APP_UNDER_TEST = Path(__file__).parent / "interpreter_lifecycle_app.py"
-
-# Generous: a cold engine boot stands up an iceoryx2 node, a surface-sharing
-# socket, and a GPU context. A real hang blows through it anyway.
-ENGINE_READY_TIMEOUT_SECONDS = 60.0
-CLEAN_EXIT_TIMEOUT_SECONDS = 60.0
-
-MARKER_PREFIX = "MARKER:"
-
-ENGINE_READY_LOG_LINE = "[start] Runtime started"
-# Emitted early inside `start()` — after the run loop has taken shutdown-signal
-# ownership, but well before the graph is up.
-ENGINE_STARTING_LOG_LINE = "[start] Initializing GPU context"
-ENGINE_STOPPED_LOG_LINE = "[stop] Graceful shutdown complete"
-
-
-class AppUnderTest:
-    """A running `python app.py`, with its output pumped off the pipe.
-
-    Every wait here is bounded. A plain `readline()` blocks indefinitely when
-    the app goes quiet, which makes a deadline checked between lines useless —
-    that is how a hung app turns into a hung test run rather than a failure with
-    a diagnostic.
-    """
-
-    def __init__(self, process: "subprocess.Popen[str]"):
-        # Asserted rather than assumed: without a pipe the pump below raises
-        # inside a daemon thread, and every wait in this class then fails on
-        # its timeout instead of on the reason.
-        assert process.stdout is not None, "the app was started without a stdout pipe"
-        self.process = process
-        self._output_pipe = process.stdout
-        self.output_lines: list[str] = []
-        self._incoming: queue.Queue[str | None] = queue.Queue()
-        self._reached_end_of_output = False
-        threading.Thread(target=self._pump_output, daemon=True).start()
-
-    def _pump_output(self) -> None:
-        for line in self._output_pipe:
-            self._incoming.put(line)
-        self._incoming.put(None)
-
-    @property
-    def output(self) -> str:
-        return "".join(self.output_lines)
-
-    def _next_line(self, deadline: float) -> str | None:
-        """The next line, or None at end of output. Raises past the deadline."""
-        while True:
-            if self._reached_end_of_output:
-                return None
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise TimeoutError
-            try:
-                line = self._incoming.get(timeout=min(0.5, remaining))
-            except queue.Empty:
-                continue
-            if line is None:
-                self._reached_end_of_output = True
-                return None
-            self.output_lines.append(line)
-            return line
-
-    def await_output_containing(self, awaited: str, what: str) -> None:
-        """Wait for a line containing `awaited`.
-
-        Sequencing on the app's or engine's own output rather than a sleep is
-        what pins the point of the lifecycle a signal is delivered at.
-        """
-        deadline = time.monotonic() + ENGINE_READY_TIMEOUT_SECONDS
-        while True:
-            try:
-                line = self._next_line(deadline)
-            except TimeoutError:
-                raise AssertionError(
-                    f"timed out waiting for {what}; output:\n{self.output}"
-                ) from None
-            if line is None:
-                raise AssertionError(f"the app exited before {what}; output:\n{self.output}")
-            if awaited in line:
-                return
-
-    def await_engine_ready(self) -> None:
-        self.await_output_containing(ENGINE_READY_LOG_LINE, "the engine to start")
-
-    def await_marker(self, marker: str) -> None:
-        self.await_output_containing(f"{MARKER_PREFIX}{marker}", f"marker {marker}")
-
-    def markers(self) -> set[str]:
-        # Matched anywhere in the line, not just at its start: while the engine
-        # is alive its stdio interceptor captures the app's `print()` and
-        # re-emits it inside a tracing record, so a marker emitted before
-        # teardown arrives as `… stdio_interceptor — MARKER:X`.
-        found: set[str] = set()
-        for line in self.output_lines:
-            marker_start = line.find(MARKER_PREFIX)
-            if marker_start != -1:
-                found.add(line[marker_start + len(MARKER_PREFIX) :].strip())
-        return found
-
-    def interrupt(self) -> None:
-        self.process.send_signal(signal.SIGINT)
-
-    def await_clean_exit(self) -> "AppUnderTest":
-        """Drain the remaining output and require a clean, timely exit."""
-        deadline = time.monotonic() + CLEAN_EXIT_TIMEOUT_SECONDS
-        try:
-            while self._next_line(deadline) is not None:
-                pass
-        except TimeoutError:
-            self.process.kill()
-            raise AssertionError(
-                f"the app did not exit within {CLEAN_EXIT_TIMEOUT_SECONDS}s — engine teardown "
-                f"hung, or the interpreter hung at finalization; output:\n{self.output}"
-            ) from None
-
-        returncode = self.process.wait(timeout=max(0.0, deadline - time.monotonic()))
-        assert returncode == 0, (
-            f"expected a clean exit, got returncode {returncode}; output:\n{self.output}"
-        )
-        assert "CLEAN_EXIT" in self.markers(), (
-            f"the app did not reach the end of its scenario; output:\n{self.output}"
-        )
-        return self
-
-
-    def kill_process_group(self) -> None:
-        """Leave nothing behind, however this app's test ended.
-
-        A failed wait raises without touching the process, and the app runs in
-        its own session — so without this an assertion failure strands a live
-        engine holding a GPU context, an iceoryx2 node and a socket, silently
-        contaminating every later run on the same rig.
-        """
-        try:
-            os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
-        except (ProcessLookupError, PermissionError):
-            pass
-        for pipe in (self.process.stdout, self.process.stdin):
-            if pipe is not None and not pipe.closed:
-                pipe.close()
 
 
 @pytest.fixture
-def app_under_test():
-    """Hands out apps and kills their process groups no matter how a test ends."""
-    started: list[AppUnderTest] = []
-
-    def start(scenario: str) -> AppUnderTest:
-        app = start_app(scenario)
-        started.append(app)
-        return app
-
-    try:
-        yield start
-    finally:
-        for app in started:
-            app.kill_process_group()
-
-
-def start_app(scenario: str) -> AppUnderTest:
-    process = subprocess.Popen(
-        [sys.executable, str(APP_UNDER_TEST), scenario],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,
-        # Its own process group, so a SIGINT aimed at the app cannot reach the
-        # test runner that spawned it — and so the group can be checked for
-        # survivors after it exits.
-        start_new_session=True,
-    )
-    return AppUnderTest(process)
+def app_under_test(start_app_under_test):
+    """Starts this suite's app; the shared fixture owns the cleanup."""
+    return lambda scenario: start_app_under_test(APP_UNDER_TEST, scenario)
 
 
 def run_scenario_to_completion(start, scenario: str) -> AppUnderTest:

--- a/sdk/streamlib-python-wheel/tests/test_interpreter_lifecycle.py
+++ b/sdk/streamlib-python-wheel/tests/test_interpreter_lifecycle.py
@@ -45,15 +45,20 @@ class AppUnderTest:
     a diagnostic.
     """
 
-    def __init__(self, process: subprocess.Popen):
+    def __init__(self, process: "subprocess.Popen[str]"):
+        # Asserted rather than assumed: without a pipe the pump below raises
+        # inside a daemon thread, and every wait in this class then fails on
+        # its timeout instead of on the reason.
+        assert process.stdout is not None, "the app was started without a stdout pipe"
         self.process = process
+        self._output_pipe = process.stdout
         self.output_lines: list[str] = []
         self._incoming: queue.Queue[str | None] = queue.Queue()
         self._reached_end_of_output = False
         threading.Thread(target=self._pump_output, daemon=True).start()
 
     def _pump_output(self) -> None:
-        for line in self.process.stdout:
+        for line in self._output_pipe:
             self._incoming.put(line)
         self._incoming.put(None)
 

--- a/sdk/streamlib-python-wheel/tests/test_processor_declaration.py
+++ b/sdk/streamlib-python-wheel/tests/test_processor_declaration.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""The `@processor` grammar, exercised without an engine.
+
+Everything here is a pure declaration check — no runtime boots — so this is the
+half of the authoring surface that stays honest on a machine with no GPU.
+"""
+
+import pytest
+
+from streamlib import LinkInputDataPort, LinkOutputDataPort, processor
+
+
+def test_a_bare_decorator_needs_no_arguments_at_all():
+    """The zero-ceremony bar: a filter declares nothing but its ports."""
+
+    @processor
+    class BrightnessFilter:
+        frames_from_upstream = LinkInputDataPort()
+        frames_to_downstream = LinkOutputDataPort()
+
+    assert BrightnessFilter.__streamlib_processor_type_reference__ == {
+        "org": "app",
+        "package": "local",
+        "type": "BrightnessFilter",
+    }
+    assert BrightnessFilter.__streamlib_processor_execution__ == {
+        "mode": "reactive",
+        "interval_ms": 0,
+    }
+
+
+def test_the_attribute_name_is_the_port_name():
+    """A port is named once — no string repeated between declaration and use."""
+
+    @processor
+    class Passthrough:
+        frames_from_upstream = LinkInputDataPort(delivery_profile="every_sample")
+        frames_to_downstream = LinkOutputDataPort(description="the filtered frames")
+
+    assert Passthrough.__streamlib_processor_input_ports__ == [
+        {
+            "name": "frames_from_upstream",
+            "description": "",
+            "delivery_profile": "every_sample",
+        }
+    ]
+    assert Passthrough.__streamlib_processor_output_ports__ == [
+        {"name": "frames_to_downstream", "description": "the filtered frames"}
+    ]
+
+
+def test_a_source_must_declare_its_execution_mode():
+    """Reactive defaults only where reacting is possible.
+
+    A processor with no input port has nothing to react to, so a silent
+    reactive default would hand the author a processor that never runs once —
+    the failure this refuses to produce.
+    """
+    with pytest.raises(ValueError, match="declares no input ports"):
+
+        @processor
+        class TestPatternSource:
+            frames_to_downstream = LinkOutputDataPort()
+
+
+def test_a_source_that_declares_a_mode_is_accepted():
+    @processor(execution="continuous", interval_ms=33)
+    class TestPatternSource:
+        frames_to_downstream = LinkOutputDataPort()
+
+    assert TestPatternSource.__streamlib_processor_execution__ == {
+        "mode": "continuous",
+        "interval_ms": 33,
+    }
+
+
+def test_an_explicit_identity_is_parsed_into_its_three_segments():
+    @processor("@tatolab/camera/Camera", execution="manual", scheduling="realtime")
+    class Camera:
+        frames_to_downstream = LinkOutputDataPort()
+
+    assert Camera.__streamlib_processor_type_reference__ == {
+        "org": "tatolab",
+        "package": "camera",
+        "type": "Camera",
+    }
+    assert Camera.__streamlib_processor_scheduling_priority__ == "realtime"
+
+
+@pytest.mark.parametrize(
+    ("identity", "expected_message"),
+    [
+        ("@tatolab/camera/Camera@1.0.0", "version-free"),
+        ("tatolab/camera/Camera", "three `/`-separated segments"),
+        ("@tatolab/camera", "three `/`-separated segments"),
+        ("@tatolab/camera/lowercase", "invalid type segment"),
+        ("@Tatolab/camera/Camera", "invalid org segment"),
+    ],
+)
+def test_a_malformed_identity_is_refused_with_its_reason(identity, expected_message):
+    with pytest.raises(ValueError, match=expected_message):
+
+        @processor(identity, execution="manual")
+        class Camera:
+            frames_to_downstream = LinkOutputDataPort()
+
+
+def test_a_class_name_that_cannot_be_an_identity_says_so():
+    with pytest.raises(ValueError, match="must be PascalCase"):
+
+        @processor
+        class lowercase_name:
+            frames_from_upstream = LinkInputDataPort()
+
+
+@pytest.mark.parametrize(
+    ("keyword", "value", "expected_message"),
+    [
+        ("execution", "whenever", "invalid execution"),
+        ("scheduling", "urgent", "invalid scheduling"),
+    ],
+)
+def test_an_unknown_mode_or_priority_is_refused(keyword, value, expected_message):
+    with pytest.raises(ValueError, match=expected_message):
+
+        @processor(**{keyword: value})
+        class Filter:
+            frames_from_upstream = LinkInputDataPort()
+
+
+def test_an_unknown_delivery_profile_is_refused_at_declaration():
+    with pytest.raises(ValueError, match="invalid delivery_profile"):
+        LinkInputDataPort(delivery_profile="eventually")
+
+
+def test_a_negative_interval_is_refused():
+    with pytest.raises(ValueError, match="non-negative int"):
+
+        @processor(execution="continuous", interval_ms=-1)
+        class TestPatternSource:
+            frames_to_downstream = LinkOutputDataPort()
+
+
+def test_ports_are_inherited_and_a_subclass_can_redeclare_one():
+    @processor
+    class BaseFilter:
+        frames_from_upstream = LinkInputDataPort(delivery_profile="latest")
+        frames_to_downstream = LinkOutputDataPort()
+
+    @processor
+    class AudioFilter(BaseFilter):
+        frames_from_upstream = LinkInputDataPort(delivery_profile="every_sample")
+
+    assert AudioFilter.__streamlib_processor_input_ports__ == [
+        {
+            "name": "frames_from_upstream",
+            "description": "",
+            "delivery_profile": "every_sample",
+        }
+    ]
+    # The inherited output survives the subclass's redeclaration of the input.
+    assert [port["name"] for port in AudioFilter.__streamlib_processor_output_ports__] == [
+        "frames_to_downstream"
+    ]
+
+
+def test_an_unbound_port_explains_itself_rather_than_failing_silently():
+    """Reading a port off a hand-instantiated processor is a mistake with a name."""
+
+    @processor
+    class Passthrough:
+        frames_from_upstream = LinkInputDataPort()
+        frames_to_downstream = LinkOutputDataPort()
+
+    with pytest.raises(RuntimeError, match="not bound to a running processor"):
+        Passthrough().frames_from_upstream.read()
+    with pytest.raises(RuntimeError, match="not bound to a running processor"):
+        Passthrough().frames_to_downstream.write({"frame": 1})

--- a/sdk/streamlib-python-wheel/tests/test_processor_declaration.py
+++ b/sdk/streamlib-python-wheel/tests/test_processor_declaration.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 
-"""The `@processor` grammar, exercised without an engine.
+"""The `@processor` / `@input` / `@output` grammar, exercised without an engine.
 
 Everything here is a pure declaration check — no runtime boots — so this is the
 half of the authoring surface that stays honest on a machine with no GPU.
@@ -9,7 +9,7 @@ half of the authoring surface that stays honest on a machine with no GPU.
 
 import pytest
 
-from streamlib import LinkInputDataPort, LinkOutputDataPort, processor
+from streamlib import SchemaIdent, input, output, processor
 
 
 def test_a_bare_decorator_needs_no_arguments_at_all():
@@ -17,8 +17,11 @@ def test_a_bare_decorator_needs_no_arguments_at_all():
 
     @processor
     class BrightnessFilter:
-        frames_from_upstream = LinkInputDataPort()
-        frames_to_downstream = LinkOutputDataPort()
+        @input()
+        def frames_from_upstream(self) -> None: ...
+
+        @output()
+        def frames_to_downstream(self) -> None: ...
 
     assert BrightnessFilter.__streamlib_processor_type_reference__ == {
         "org": "app",
@@ -31,24 +34,124 @@ def test_a_bare_decorator_needs_no_arguments_at_all():
     }
 
 
-def test_the_attribute_name_is_the_port_name():
+def test_the_method_name_is_the_port_name():
     """A port is named once — no string repeated between declaration and use."""
 
     @processor
     class Passthrough:
-        frames_from_upstream = LinkInputDataPort(delivery_profile="every_sample")
-        frames_to_downstream = LinkOutputDataPort(description="the filtered frames")
+        @input(delivery_profile="every_sample")
+        def frames_from_upstream(self) -> None: ...
+
+        @output(description="the filtered frames")
+        def frames_to_downstream(self) -> None: ...
 
     assert Passthrough.__streamlib_processor_input_ports__ == [
         {
             "name": "frames_from_upstream",
             "description": "",
             "delivery_profile": "every_sample",
+            "schema": None,
         }
     ]
     assert Passthrough.__streamlib_processor_output_ports__ == [
-        {"name": "frames_to_downstream", "description": "the filtered frames"}
+        {
+            "name": "frames_to_downstream",
+            "description": "the filtered frames",
+            "schema": None,
+        }
     ]
+
+
+def test_an_explicit_name_overrides_the_method_name():
+    @processor
+    class Renamed:
+        @input(name="video_in")
+        def handle_incoming_video(self) -> None: ...
+
+        @output(name="video_out")
+        def handle_outgoing_video(self) -> None: ...
+
+    assert [port["name"] for port in Renamed.__streamlib_processor_input_ports__] == [
+        "video_in"
+    ]
+    assert [port["name"] for port in Renamed.__streamlib_processor_output_ports__] == [
+        "video_out"
+    ]
+
+
+def test_a_schema_ident_instance_is_stored_as_its_wire_dict():
+    video_frame = SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0")
+
+    @processor
+    class Typed:
+        @input(schema=video_frame, description="frames")
+        def frames_from_upstream(self) -> None: ...
+
+        @output(schema=video_frame)
+        def frames_to_downstream(self) -> None: ...
+
+    expected_wire_dict = {
+        "org": "tatolab",
+        "package": "core",
+        "type": "VideoFrame",
+        "version": "1.0.0",
+    }
+    assert Typed.__streamlib_processor_input_ports__[0]["schema"] == expected_wire_dict
+    assert Typed.__streamlib_processor_output_ports__[0]["schema"] == expected_wire_dict
+
+
+def test_a_codegen_class_carrying_a_schema_ident_is_accepted():
+    class VideoFrame:
+        __streamlib_schema_ident__ = SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0")
+
+    @processor
+    class Typed:
+        @input(schema=VideoFrame)
+        def frames_from_upstream(self) -> None: ...
+
+    assert Typed.__streamlib_processor_input_ports__[0]["schema"] == {
+        "org": "tatolab",
+        "package": "core",
+        "type": "VideoFrame",
+        "version": "1.0.0",
+    }
+
+
+def test_a_string_schema_is_refused_with_the_structured_alternative():
+    with pytest.raises(TypeError, match="string schema references are no longer accepted"):
+        input(schema="VideoFrame")  # pyright: ignore[reportArgumentType]
+    with pytest.raises(TypeError, match="string schema references"):
+        output(schema="@tatolab/core/VideoFrame@1.0.0")  # pyright: ignore[reportArgumentType]
+
+
+def test_a_class_without_schema_metadata_is_refused():
+    class Plain:
+        pass
+
+    with pytest.raises(TypeError, match="does not carry a structured SchemaIdent"):
+        input(schema=Plain)
+
+
+def test_a_schema_of_an_unsupported_type_is_refused():
+    with pytest.raises(TypeError, match="unsupported type"):
+        output(schema=42)  # type: ignore[arg-type]
+
+
+def test_an_unknown_delivery_profile_is_refused_at_decoration():
+    with pytest.raises(ValueError, match="invalid delivery_profile"):
+        input(delivery_profile="eventually")
+
+
+def test_a_duplicate_port_name_is_refused():
+    with pytest.raises(ValueError, match="more than once"):
+
+        @processor
+        class Clashing:
+            @input(name="frames")
+            def frames_in(self) -> None: ...
+
+            @output(name="frames")
+            def frames_out(self) -> None: ...
 
 
 def test_a_source_must_declare_its_execution_mode():
@@ -62,13 +165,15 @@ def test_a_source_must_declare_its_execution_mode():
 
         @processor
         class TestPatternSource:
-            frames_to_downstream = LinkOutputDataPort()
+            @output()
+            def frames_to_downstream(self) -> None: ...
 
 
 def test_a_source_that_declares_a_mode_is_accepted():
     @processor(execution="continuous", interval_ms=33)
     class TestPatternSource:
-        frames_to_downstream = LinkOutputDataPort()
+        @output()
+        def frames_to_downstream(self) -> None: ...
 
     assert TestPatternSource.__streamlib_processor_execution__ == {
         "mode": "continuous",
@@ -79,7 +184,8 @@ def test_a_source_that_declares_a_mode_is_accepted():
 def test_an_explicit_identity_is_parsed_into_its_three_segments():
     @processor("@tatolab/camera/Camera", execution="manual", scheduling="realtime")
     class Camera:
-        frames_to_downstream = LinkOutputDataPort()
+        @output()
+        def frames_to_downstream(self) -> None: ...
 
     assert Camera.__streamlib_processor_type_reference__ == {
         "org": "tatolab",
@@ -104,7 +210,8 @@ def test_a_malformed_identity_is_refused_with_its_reason(identity, expected_mess
 
         @processor(identity, execution="manual")
         class Camera:
-            frames_to_downstream = LinkOutputDataPort()
+            @output()
+            def frames_to_downstream(self) -> None: ...
 
 
 def test_a_class_name_that_cannot_be_an_identity_says_so():
@@ -112,7 +219,8 @@ def test_a_class_name_that_cannot_be_an_identity_says_so():
 
         @processor
         class lowercase_name:
-            frames_from_upstream = LinkInputDataPort()
+            @input()
+            def frames_from_upstream(self) -> None: ...
 
 
 @pytest.mark.parametrize(
@@ -127,12 +235,8 @@ def test_an_unknown_mode_or_priority_is_refused(keyword, value, expected_message
 
         @processor(**{keyword: value})
         class Filter:
-            frames_from_upstream = LinkInputDataPort()
-
-
-def test_an_unknown_delivery_profile_is_refused_at_declaration():
-    with pytest.raises(ValueError, match="invalid delivery_profile"):
-        LinkInputDataPort(delivery_profile="eventually")
+            @input()
+            def frames_from_upstream(self) -> None: ...
 
 
 def test_a_negative_interval_is_refused():
@@ -140,41 +244,33 @@ def test_a_negative_interval_is_refused():
 
         @processor(execution="continuous", interval_ms=-1)
         class TestPatternSource:
-            frames_to_downstream = LinkOutputDataPort()
+            @output()
+            def frames_to_downstream(self) -> None: ...
 
 
 def test_ports_are_inherited_and_a_subclass_can_redeclare_one():
     @processor
     class BaseFilter:
-        frames_from_upstream = LinkInputDataPort(delivery_profile="latest")
-        frames_to_downstream = LinkOutputDataPort()
+        @input(delivery_profile="latest")
+        def frames_from_upstream(self) -> None: ...
+
+        @output()
+        def frames_to_downstream(self) -> None: ...
 
     @processor
     class AudioFilter(BaseFilter):
-        frames_from_upstream = LinkInputDataPort(delivery_profile="every_sample")
+        @input(delivery_profile="every_sample")
+        def frames_from_upstream(self) -> None: ...
 
     assert AudioFilter.__streamlib_processor_input_ports__ == [
         {
             "name": "frames_from_upstream",
             "description": "",
             "delivery_profile": "every_sample",
+            "schema": None,
         }
     ]
     # The inherited output survives the subclass's redeclaration of the input.
     assert [port["name"] for port in AudioFilter.__streamlib_processor_output_ports__] == [
         "frames_to_downstream"
     ]
-
-
-def test_an_unbound_port_explains_itself_rather_than_failing_silently():
-    """Reading a port off a hand-instantiated processor is a mistake with a name."""
-
-    @processor
-    class Passthrough:
-        frames_from_upstream = LinkInputDataPort()
-        frames_to_downstream = LinkOutputDataPort()
-
-    with pytest.raises(RuntimeError, match="not bound to a running processor"):
-        Passthrough().frames_from_upstream.read()
-    with pytest.raises(RuntimeError, match="not bound to a running processor"):
-        Passthrough().frames_to_downstream.write({"frame": 1})

--- a/sdk/streamlib-python-wheel/tests/zero_argument_process_app.py
+++ b/sdk/streamlib-python-wheel/tests/zero_argument_process_app.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""An app whose only processor defines `process` without the ctx parameter.
+
+Run as a real `python app.py` because the failure under test is a log line:
+the engine's tracing writer binds this process's stdout at first boot, so only
+a parent reading the pipe observes it reliably — capfd inside the test process
+sees nothing once another test booted an engine first.
+"""
+
+import streamlib
+from streamlib import processor
+
+
+@processor(execution="continuous", interval_ms=1)
+class ZeroArgumentProcess:
+    def process(self) -> None:  # deliberately missing the ctx parameter
+        print("MARKER:HOOK_BODY_RAN", flush=True)
+
+
+if __name__ == "__main__":
+    runtime = streamlib.Runtime()
+    runtime.add(ZeroArgumentProcess)
+    runtime.run()
+    print("MARKER:CLEAN_EXIT", flush=True)


### PR DESCRIPTION
## Summary

A Python class decorated with `@processor` now runs in-process on its own engine thread, exchanging bags with other Python processors in the app's own interpreter.

```python
@processor
class BrightnessFilter:
    frames_from_upstream = LinkInputDataPort()
    frames_to_downstream = LinkOutputDataPort()

    def __init__(self, gain: float = 1.0) -> None:
        self.gain = gain

    def process(self) -> None:
        frame = self.frames_from_upstream.read()
        if frame is not None:
            self.frames_to_downstream.write({"value": frame["value"] * self.gain})
```

Registration rides `register_dynamic` — the one registration path that survives the plugin-ABI deletion in Change B — and the PyO3 host lives in the wheel crate, so the engine stays Python-free. The GIL is attached for the span of a user callback and nothing else.

## Closes

Closes #1708

## Exit criteria

- `@processor` classes execute in-process on the dedicated-thread model, three execution modes, descriptor-driven priority ✅
- `rt.add(ImportedClass)`; the pipeline API is `add` / `connect` ✅
- GIL-release contract, with a test proving a blocked native call stalls no other Python processor ✅
- Pixels never cross into Python — a bag is a named map; the exchange surface is #1710 ✅
- Generated `.pyi` stubs ship in the wheel ⚠️ hand-written, not generated — see notes
- Single-processor test harness, no hardware ✅ `streamlib.testing.SingleProcessorTestPipeline`
- **Teardown re-proved against live processors** (your comment's added criterion) ✅ — #1707 could only run it on an empty graph

## Test plan

41 pytest (25 in the no-GPU CI scope, up from 20) + 6 Rust unit tests + stubtest + pyright, all green locally on a GPU rig.

Two gates were verified red as well as green, by reintroducing the defect:

| gate | with the defect | with the fix |
|---|---|---|
| `test_building_the_graph_from_two_threads_does_not_deadlock` | fails at 60s naming the last marker reached | < 1s |
| `mypy.stubtest` (stub entry deleted) | `Runtime.connect is not present in stub` | clean |

The GIL contract has one behavioural test, not two. A producer blocked inside `write()` under `lossless` backpressure completes ~50 writes in 3s instead of tens of thousands — genuinely parked in `write_raw` — while another Python processor manages 2436 ticks. An earlier interval-wait test was retired: it exercised engine code this branch does not touch, so no edit here could turn it red.

## Notes for owner

**1. The authoring grammar diverges from what I announced, and you should decide whether to keep it.** I announced a `ProcessorContext` pyclass with `ctx.read` / `ctx.write`. What I built declares ports as class attributes (`self.frames_from_upstream.read()`) and gives lifecycle hooks no arguments at all. It is better DX — a port is named once, and every call completes and type-checks — but it is a first-class public-API shape you did not approve, and your #1707 comment pointed the other way ("in-process the context is a PyO3 object — rewrite"). Rationale is recorded in `docs/decisions/importable-python-library.md`. Change A's MODIFIED entry still says `processor_context.py` carries over; if you keep this shape, that line needs superseding via `/align`, which this session cannot edit.

**2. `.pyi` is hand-written where the change file says "generated".** Agreed with you mid-session. PyO3's introspection is `experimental-inspect` and maturin's `--generate-stubs` RFC is unmerged, so hand-written is what every comparable PyO3 wheel does. `mypy.stubtest` covers the drift a generator would have prevented. Revisit condition is recorded in the new ADR.

**3. Two reviews returned REJECT on the same blocker, and they were right.** `add` / `connect` held the lifecycle mutex across a GIL release while `run()` / `shutdown()` take it holding the GIL — a wedge that takes the interpreter down rather than raising. Reproduced under gdb. Fixed, with the regression gate now running on every PR.

**4. Non-blocking findings, not ticketed:**
- Two `Runtime`s cannot run at once in a process (shutdown-signal ownership is process-global). Pre-existing; the test harness now refuses a nested pipeline with that reason instead of letting the engine's error surface.
- `clippy::result_large_err` fires 8× on this crate because the engine's `Error` is ≥168 bytes — engine-wide, inherited, not this branch's to fix.
- `spawn_deno_subprocess_op.rs` still refers to "the Python subprocess host", a concept this branch retires. Change B territory.
- The bag path allocates an intermediate `rmpv::Value` tree per frame. Fine while bags are small named maps; if they get hot, stream straight into the buffer with `rmp::encode`.
- A `print()` inside a processor still comes back as `stdio_interceptor — <text>` at WARN, and engine logging initializes once per process. Both pre-existing, both now sit under the primary authoring surface.

**5. One engine-layer line changed.** The engine logged every Python processor as a "Python subprocess host". Fixed where the label lives, per engine doctrine, rather than worked around in the wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
