### PR TITLE
plan: schema-free ports, class identity, one monotonic clock

### DIFF
--- a/docs/decisions/data-plane-cast-not-contract.md
+++ b/docs/decisions/data-plane-cast-not-contract.md
@@ -1,5 +1,11 @@
 # Data plane: cast, not contract
 
+> Partially superseded 2026-08-03 by `schema-free-ports.md`. The cast-at-read core and
+> the port-local channel policy stand. What no longer holds: unilateral type hints on a
+> port (there are no port type declarations at all), the advisory connect warning
+> (nothing to compare), the surviving inert wire tag (removed), and "concretely-typed"
+> as a qualifier on the delivery-profile rule (every input port must declare one).
+
 Rationale for the `[data-plane-cast-not-contract]` entries in
 `docs/plan/ARCHITECTURE.md` §Processor model & scheduling, decided 2026-07-29.
 

--- a/docs/decisions/one-monotonic-clock.md
+++ b/docs/decisions/one-monotonic-clock.md
@@ -1,0 +1,36 @@
+# One monotonic clock
+
+Rationale for the `[one-monotonic-clock]` entry in `docs/plan/ARCHITECTURE.md`
+§Media I/O, decided 2026-08-03.
+
+## Trigger
+
+Read this before adding any timestamp source, epoch offset, or clock export in any
+language, and before writing code that assumes a timestamp starts near zero.
+
+## Decision
+
+One concept — the machine's monotonic clock — in every language the project speaks.
+Timestamps are raw `clock_gettime(CLOCK_MONOTONIC)` on Linux and `mach_absolute_time`
+on Apple: the same epoch V4L2 and ALSA stamp their buffers with, and the same value any
+other process on the host would read. No process-relative epoch, and exactly one
+exported name per language.
+
+`MediaClock` remains the cross-platform seam — Rust's std exposes no raw monotonic
+clock, so something has to name it — but it is a naming boundary, not a second epoch.
+
+## Rejected alternatives
+
+- **Process-start-relative epoch** (the Linux `MediaClock` behavior) — destroys
+  comparability between a frame's driver stamp and the engine's own, between processes
+  on one host (helper placement makes this routine), and between nodes. It also diverged
+  from its own macOS twin, which was already machine-wide.
+- **Two exported clock names** (`media_clock_now_ns` alongside `monotonic_now_ns`) — two
+  names for one number invite the reader to assume they differ.
+
+## Consequences
+
+- Call sites that read a timestamp as "seconds since start" are wrong and must subtract
+  their own baseline explicitly.
+- The wheel's duplicate export is deleted once the epochs match.
+- A/V sync, when designed, starts from a single comparable timebase shared with drivers.

--- a/docs/decisions/schema-free-ports.md
+++ b/docs/decisions/schema-free-ports.md
@@ -1,0 +1,60 @@
+# Schema-free ports
+
+Rationale for the `[schema-free-ports]` entries in `docs/plan/ARCHITECTURE.md`
+§Processor model & scheduling, decided 2026-08-03. Supersedes
+`data-plane-cast-not-contract.md`, which kept unilateral hints, an advisory connect
+warning, and an inert wire tag — this decision removes all three.
+
+## Trigger
+
+Read this before adding any type, schema, or identity field to a port declaration;
+before making `connect` inspect what either end carries; before reintroducing codegen,
+a schema registry, or a `@org/package/Type` string anywhere in an authoring surface.
+
+## Decision
+
+A port declares name, description, and — on an input — delivery profile. Nothing else.
+Type information belongs to the authoring language and never reaches the engine: a
+Python port method's return annotation is documentation and type-checker input, and
+`ctx.inputs.read(port, into=T)` is the reader's own strictness dial; a Rust read is
+typed by the struct it deserializes into, with serde as the always-on validation. The
+engine has no type layer at all — no declarations to compare, so no comparison, no
+advisory warning, no wire tag, no schema registry, no codegen, no JTD.
+
+A processor's identity is its class, named by its fully-qualified import path — one
+string everywhere, including what the control plane prints. The `@org/package/Type@version`
+grammar is deleted from every authoring surface.
+
+## Rejected alternatives
+
+- **Unilateral hints kept as advisory metadata** (the previous decision) — a declaration
+  no code may act on is a field that reliably drifts from reality and misleads whoever
+  reads it. Removing the comparison but keeping the hint bought nothing and cost a wire
+  field, a stamping path, and a warn site.
+- **`@org/package/Type@version` as port or processor identity** — module addressing that
+  outlived its address space. With PyPI and cargo as the package systems and `rt.add`
+  taking the class, the identity grammar names nothing the import system does not
+  already name, and forces two representations of one processor. Empirically it is
+  already broken: `schema=` on a port fails reads against the half-deleted registry.
+- **Engine-side validation of the language's type declaration** — would require the
+  engine to model Python's and Rust's type systems, and would recreate schema agreement
+  under a new name.
+
+## Consequences
+
+- Nothing in the control plane can say what a port carries; `graph` and `tap` show
+  name, description, delivery profile, direction. This is accepted cost, not oversight.
+- The delivery-profile default is gone with the schema that carried `metadata.flow_class`,
+  so every input port must declare one. The owner accepted this with reservation
+  (2026-08-03: "we can do the recommended and change later, not crazy about this") —
+  the alternatives were a flat default that silently drops audio samples, or inference
+  from a type layer that no longer exists. Revisit if the explicit declaration proves
+  noisy in real apps.
+- `SchemaIdentWire` leaves the frame header; layout locks move with it.
+- Identity and label separate cleanly: the import path is exact and machine-facing, the
+  instance's display name is human-facing and may repeat. Engine-appended counters on
+  duplicate labels are a convenience the owner accepted as revisitable (2026-08-03).
+- The entry file must be imported, not executed as a script — otherwise a class defined
+  in it identifies as `__main__:…`, which no helper process can import and which varies
+  with the launch path.
+- Cross-language and cross-node interop rest entirely on the bag being self-describing.

--- a/docs/plan/ARCHITECTURE.md
+++ b/docs/plan/ARCHITECTURE.md
@@ -65,15 +65,29 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
 ## Processor model & scheduling — IN-FLIGHT (→ schema-agreement-ripout, importable-python-library)
 
 - **DECIDED** — A link is pure plumbing: output port → input port, carrying a bag
-  (self-describing msgpack named map). Producer and consumer type declarations are
-  unilateral hints, never compared; consuming is a cast at read time. The engine
-  mediates no schema agreement: connect never refuses a link (advisory log at most),
-  no per-read tag matching, the wire tag is inert observability metadata, and versions
-  never appear at the code layer — resolution-time only. [data-plane-cast-not-contract]
+  (self-describing msgpack named map). The engine has no type layer: ports carry no
+  type declaration, connect never inspects or compares types and never warns, no read
+  path examines a tag, and the frame header carries no schema ident. Consuming is a
+  cast at read time; a mismatch surfaces as a decode failure at the consuming
+  processor. [schema-free-ports]
+- **DECIDED** — A port declares three things and nothing else: name, description, and
+  — on an input — delivery profile. Type information belongs to the authoring language
+  and never reaches the engine: in Python the port method's return annotation is the
+  declaration, read by humans and type checkers only, with `ctx.inputs.read(port)`
+  yielding the bag as a mapping and `read(port, into=T)` the opt-in strictness dial
+  (a TypedDict casts for free, a dataclass or pydantic model constructs and validates,
+  raising at read); in Rust the read target's `Deserialize` impl is the validation,
+  always on, with no free-cast mode. [schema-free-ports]
 - **DECIDED** — Channel policy (delivery profile, ring depth, overflow) is declared
-  port-locally at the consuming input port, never carried by schemas; a concretely-typed
-  input port with no declared delivery profile is a wiring error, not a silent default.
-  [data-plane-cast-not-contract]
+  port-locally at the consuming input port. Every input port declares its delivery
+  profile explicitly — there is no default and nothing left to infer one from, so an
+  input port without one is a wiring error. [schema-free-ports]
+- **DECIDED** — There is no schema layer: no JTD, no schema registry, no embedded
+  schemas, no codegen and no generated type classes, and no schema identity grammar
+  anywhere in the engine or the authoring surfaces. [schema-free-ports]
+- **DECIDED** — Port rendering in the control plane is name, description, delivery
+  profile, and direction; no port carries a type in `graph`, `tap`, or any snapshot.
+  [schema-free-ports]
 - **DECIDED** — Three execution modes (reactive / manual / continuous); one dedicated
   OS thread per processor with descriptor-driven priority (realtime / high / normal);
   synchronous lifecycle traits; Full/Limited capability typestate on the phase axis
@@ -94,11 +108,18 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   construction). Reload-on-save is a nicety, not MVP-gating, and when built it is
   processor-granular — stop the processor, re-import its class, re-instantiate,
   rewire its ports — never module-loading machinery. [importable-python-library]
-- **DECIDED** — JTD schemas are advisory, experimental type information behind a
-  rip-out-cheap seam — never a requirement for accessing data, in-graph or on the
-  wire, and never baked in as fundamental (replaceable wholesale, e.g. by Arrow,
-  without touching the data plane). No user-facing codegen verb.
-  [importable-python-library]
+- **DECIDED** — A processor's identity is its class, named by its fully-qualified
+  import path (`my_app.filters:BlurProcessor` in Python, the type path in Rust) —
+  derived mechanically, never authored, and the same string in the registry, in the
+  control plane's type field, and for helper-process placement. The entry file is
+  imported as a module, never executed as `__main__`, so identity never depends on how
+  the app was launched. The `@org/package/Type` identity grammar is deleted along with
+  the `@app/local` synthesis; `@processor` declares execution, interval, scheduling
+  priority, and description only. [schema-free-ports]
+- **DECIDED** — An instance's display name is the human-facing label — passed at `add`,
+  readable off the returned handle, and the prefix on its log records; it defaults to
+  the class's short name and the engine disambiguates duplicates within one graph.
+  Identity is never derived from it. [schema-free-ports]
 - **OPEN** — Additional execution flavors to scale processor count (lightweight /
   green-thread style): intended, do not build until designed; hard constraint — no new
   configuration dials. [execution-model]
@@ -141,6 +162,11 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   deadlines allow: camera-class sources and block-level audio are viable behind the
   SDK's GIL-release contract; vsync-paced present loops and device audio callbacks
   stay native, always. [importable-python-library]
+- **DECIDED** — One clock: every engine timestamp is the machine's monotonic clock
+  (`CLOCK_MONOTONIC` on Linux, `mach_absolute_time` on Apple) — the same epoch the
+  V4L2 and ALSA driver stamps carry, comparable across every node on a host. No
+  process-relative epoch anywhere, and each language exports exactly one name for it.
+  [one-monotonic-clock]
 - **OPEN** — Audio backend: PipeWire-native on Linux is the intent (the current
   CPAL → ALSA path is interim); do not build until a research memo settles it. A/V
   sync model likewise OPEN. The engine's decided audio surface is the clock

--- a/docs/plan/GLOSSARY.md
+++ b/docs/plan/GLOSSARY.md
@@ -35,7 +35,23 @@ the component hosting it).
 on-disk registry. _Avoid_: "instance", "server".
 
 **Processor**: the unit of pipeline computation — a Python class (`@processor`) or a
-Rust type (`#[processor]`) — wired by ports.
+Rust type (`#[processor]`) — wired by ports. Its identity is the class itself, named by
+its fully-qualified import path. _Avoid_: an authored `@org/package/Type` name.
+
+**Display name**: an instance's human-facing label — passed at `add`, prefixing its log
+records, defaulting to the class's short name. Never an identity. _Avoid_: "processor
+name", "id".
+
+**Port**: a processor's named attachment point for a link. Declares name, description,
+and — on an input — delivery profile; never a type. _Avoid_: "channel" for the port
+itself.
+
+**Link**: one wired connection, output port → input port, carrying bags. _Avoid_:
+"edge", "connection", "pipe".
+
+**Delivery profile**: the consuming input port's policy for which bags it receives —
+`latest`, `every_sample`, or `lossless`. Declared explicitly on every input port; there
+is no default. _Avoid_: "QoS", "channel mode".
 
 **Engine primitive**: a hardware capability the engine owns and exposes through its
 handle-shaped surface — GPU memory import/export (DMA-BUF / OPAQUE_FD), the present
@@ -56,5 +72,11 @@ ADDED / MODIFIED / REMOVED.
 
 Retired by the 2026-08-02 pivot (see `docs/decisions/importable-python-library.md`):
 **Host** (loads-plugins sense), **Plugin**, **Plugin ABI**, **Package source**,
-**Link**, **Lag by design** — these named the deleted plugin-ABI / module-system world;
-do not reuse them.
+**Link** (the CLI verb — the local-dev install path, not the connection above),
+**Lag by design** — these named the deleted plugin-ABI / module-system world; do not
+reuse them.
+
+Retired by the 2026-08-03 schema-free-ports decision (see
+`docs/decisions/schema-free-ports.md`): **Schema**, **SchemaIdent**, **Schema
+agreement**, **Wire tag**, **Flow class** — the engine has no type layer, so these name
+nothing. Type information is the authoring language's and has no project-specific term.


### PR DESCRIPTION
`/align` over **§Processor model & scheduling**, plus one entry in §Media I/O. Plan text only — no code, no tickets. The deletion inventory comes next via `/propose-change`.

## What was decided

**Ports are schema-free.** A port declares name, description, and — on an input — delivery profile. Nothing else. The engine has no type layer at all: no port type declaration, so connect never inspects or compares and never warns, no read path examines a tag, no schema ident in the frame header, no schema registry, no codegen, no JTD. Type information belongs to the authoring language — Python's return annotation is documentation and type-checker input, `ctx.inputs.read(port, into=T)` is the reader's own strictness dial (TypedDict casts free, dataclass/pydantic validates); Rust is typed by its `Deserialize` target, always on.

**Every input port declares its delivery profile.** The default derived from a schema's `metadata.flow_class` (`delivery_profile.rs:12`), which this decision deletes. There is nothing left to infer from, so an input port without one is a wiring error. The owner accepted this with an explicit reservation, recorded in the ADR as revisit-if-noisy — the alternatives were a flat default that silently drops audio samples, or an inference layer that no longer exists.

**A processor's identity is its class**, named by its fully-qualified import path. `SchemaIdent` was doing double duty as processor identity (`_processor_declaration.py:314`, the wheel's registry key at `python_processor_registration.rs:26`), so the `@org/package/Type` grammar dies there too, along with the `@app/local` synthesis. One string serves the registry, the control plane's type field, and helper-process placement — which already required import-addressability (§Processor model, placement entry). The entry file is imported as a module, never executed as `__main__`, so identity never varies with the launch path. Display naming stays separate and human-facing: passed at `add`, defaulting to the class's short name, disambiguated by the engine within one graph, never an identity.

**One clock.** Every engine timestamp is the machine's monotonic clock (`CLOCK_MONOTONIC` / `mach_absolute_time`) — the epoch V4L2 and ALSA stamp with, comparable across nodes on a host. No process-relative epoch, one exported name per language. Previously ruled, never written into the plan; a prior session was confused by its absence, which is why it is stated explicitly now.

## Supporting changes

- `docs/decisions/schema-free-ports.md` — new ADR. Rejected alternatives include keeping unilateral hints as advisory metadata (a declaration no code may act on drifts and misleads) and keeping the identity grammar (module addressing that outlived its address space).
- `docs/decisions/one-monotonic-clock.md` — new ADR.
- `docs/decisions/data-plane-cast-not-contract.md` — annotated partially superseded. Its cast-at-read core and port-local channel policy stand; unilateral hints, the advisory connect warning, the surviving inert wire tag, and "concretely-typed" as a qualifier do not.
- `docs/plan/GLOSSARY.md` — adds **Port**, **Link**, **Display name**, **Delivery profile**; sharpens **Processor**; retires **Schema / SchemaIdent / Schema agreement / Wire tag / Flow class**. It also scopes the 2026-08-02 "Link" retirement to the **`link` CLI verb** — which is what it always meant (`ARCHITECTURE.md:42` lists it beside `add`/`install`/`pkg`); the output→input sense was collateral damage and is restored.
- `docs/plan/diagrams/system.mmd` — unchanged. It depicts no port, type, or schema node, so nothing structural moved.

## Notes, not action items

- §Processor model's header still reads `(→ schema-agreement-ripout, …)`. That change file is now largely subsumed — its REMOVED inventory grows and its advisory-warn ADDED dies. `/propose-change` retitles it.
- §Product's "bags/schemas fixed (no engine schema matching, cast-at-read…)" is still true, just weaker than what was decided here. Different section, left alone.
- #1709 (camera/display built-ins) stays gated until tickets derive from this — the point of running the align first was so those port declarations get written once against the new grammar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)