### PR TITLE
plan: schema-free-ports change set — three sequenced deltas

### DIFF
--- a/docs/decisions/one-monotonic-clock.md
+++ b/docs/decisions/one-monotonic-clock.md
@@ -10,7 +10,15 @@ language, and before writing code that assumes a timestamp starts near zero.
 
 ## Decision
 
-One concept — the machine's monotonic clock — in every language the project speaks.
+One concept — the machine's monotonic clock — in every language the project speaks, on
+the data plane. Scoped by the owner (2026-08-03) to what a processor stamps, reads, or
+compares: frames, bags, audio ticks, `ctx.time`. Wall clock survives on exactly four
+observability surfaces — log record `host_ts` and `source_ts`, log file naming, and the
+control-plane pubsub event timestamp — because correlating with the outside world and
+with other hosts' logs is a job monotonic time cannot do. Everything else is monotonic;
+a wall-clock value never enters the data plane and is never compared against a media
+timestamp. Adding a fifth wall-clock surface is a plan change, not a judgement call, and
+`cargo xtask check-clock-usage` enforces the list mechanically.
 Timestamps are raw `clock_gettime(CLOCK_MONOTONIC)` on Linux and `mach_absolute_time`
 on Apple: the same epoch V4L2 and ALSA stamp their buffers with, and the same value any
 other process on the host would read. No process-relative epoch, and exactly one

--- a/docs/decisions/schema-free-ports.md
+++ b/docs/decisions/schema-free-ports.md
@@ -54,7 +54,12 @@ grammar is deleted from every authoring surface.
 - Identity and label separate cleanly: the import path is exact and machine-facing, the
   instance's display name is human-facing and may repeat. Engine-appended counters on
   duplicate labels are a convenience the owner accepted as revisitable (2026-08-03).
-- The entry file must be imported, not executed as a script — otherwise a class defined
-  in it identifies as `__main__:…`, which no helper process can import and which varies
-  with the launch path.
+- A class defined in the entry file run as `python app.py` identifies as `__main__:…`.
+  That is legal and runs in-process (owner, 2026-08-03) — forbidding it would contradict
+  "an importable Python library" and retire the `python app.py` harness the
+  interpreter-lifecycle contract was proven against. The consequence lands where it
+  actually bites: no helper process can import `__main__`, so the engine refuses to
+  helper-place such a class, with an error naming the fix. Identity is therefore
+  per-launch-arrangement, and the only cross-process reader of it is the placement path
+  that already refuses these classes.
 - Cross-language and cross-node interop rest entirely on the bag being self-describing.

--- a/docs/plan/ARCHITECTURE.md
+++ b/docs/plan/ARCHITECTURE.md
@@ -62,7 +62,7 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   as in-process capabilities (torch/cupy and GL consumers); only their cross-DSO
   `-abi` halves die with the plugin ABI. [importable-python-library]
 
-## Processor model & scheduling — IN-FLIGHT (→ schema-agreement-ripout, importable-python-library)
+## Processor model & scheduling — IN-FLIGHT (→ schema-free-ports, processor-class-identity, importable-python-library)
 
 - **DECIDED** — A link is pure plumbing: output port → input port, carrying a bag
   (self-describing msgpack named map). The engine has no type layer: ports carry no
@@ -111,9 +111,10 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
 - **DECIDED** — A processor's identity is its class, named by its fully-qualified
   import path (`my_app.filters:BlurProcessor` in Python, the type path in Rust) —
   derived mechanically, never authored, and the same string in the registry, in the
-  control plane's type field, and for helper-process placement. The entry file is
-  imported as a module, never executed as `__main__`, so identity never depends on how
-  the app was launched. The `@org/package/Type` identity grammar is deleted along with
+  control plane's type field, and for helper-process placement. A processor defined in
+  the entry file run as `python app.py` identifies as `__main__:<Type>` and is legal
+  in-process; the engine refuses to helper-place it, with an error naming the fix (move
+  the class to an importable module). The `@org/package/Type` identity grammar is deleted along with
   the `@app/local` synthesis; `@processor` declares execution, interval, scheduling
   priority, and description only. [schema-free-ports]
 - **DECIDED** — An instance's display name is the human-facing label — passed at `add`,
@@ -134,7 +135,7 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   Python-facing API design is its own session. [importable-python-library]
 - **OPEN** — Everything else.
 
-## Media I/O — camera, display, audio — IN-FLIGHT (→ importable-python-library)
+## Media I/O — camera, display, audio — IN-FLIGHT (→ importable-python-library, one-monotonic-clock)
 
 - **DECIDED** — First-party camera, display, and audio are native built-in processors
   in the engine tree, statically linked into the wheel — pre-built named blocks
@@ -162,10 +163,16 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   deadlines allow: camera-class sources and block-level audio are viable behind the
   SDK's GIL-release contract; vsync-paced present loops and device audio callbacks
   stay native, always. [importable-python-library]
-- **DECIDED** — One clock: every engine timestamp is the machine's monotonic clock
-  (`CLOCK_MONOTONIC` on Linux, `mach_absolute_time` on Apple) — the same epoch the
-  V4L2 and ALSA driver stamps carry, comparable across every node on a host. No
+- **DECIDED** — One clock on the data plane: every timestamp a processor stamps, reads,
+  or compares — frames, bags, audio ticks, `ctx.time` — is the machine's monotonic clock
+  (`CLOCK_MONOTONIC` on Linux, `mach_absolute_time` on Apple), the same epoch the V4L2
+  and ALSA driver stamps carry, comparable across every node on a host. No
   process-relative epoch anywhere, and each language exports exactly one name for it.
+  Wall clock is permitted on exactly four observability surfaces and nowhere else: log
+  record `host_ts` and `source_ts`, log file naming, and the control-plane pubsub event
+  timestamp — their job is correlating with the outside world, which monotonic time
+  cannot do. A wall-clock value never enters the data plane and is never compared against
+  a media timestamp; a fifth surface is a plan change, not a judgement call.
   [one-monotonic-clock]
 - **OPEN** — Audio backend: PipeWire-native on Linux is the intent (the current
   CPAL → ALSA path is interim); do not build until a research memo settles it. A/V

--- a/docs/plan/GLOSSARY.md
+++ b/docs/plan/GLOSSARY.md
@@ -53,6 +53,17 @@ itself.
 `latest`, `every_sample`, or `lossless`. Declared explicitly on every input port; there
 is no default. _Avoid_: "QoS", "channel mode".
 
+**Monotonic clock**: the machine's boot-relative clock (`CLOCK_MONOTONIC` /
+`mach_absolute_time`) — the epoch of every data-plane timestamp and of the V4L2 and ALSA
+driver stamps. The default; anything a processor stamps or compares uses it. _Avoid_:
+"media clock" for the epoch (`MediaClock` is the Rust naming seam, not a second clock),
+"timestamp" unqualified where the epoch matters.
+
+**Wall clock**: UNIX time — permitted only on the four observability surfaces (log
+`host_ts`, log `source_ts`, log file naming, control-plane event timestamp), because they
+correlate with the outside world. Never on the data plane, never compared against a
+monotonic timestamp. _Avoid_: "system time", "real time".
+
 **Engine primitive**: a hardware capability the engine owns and exposes through its
 handle-shaped surface — GPU memory import/export (DMA-BUF / OPAQUE_FD), the present
 target, texture rings, codec sessions, the audio clock, color resolution. Built-ins and

--- a/docs/plan/changes/one-monotonic-clock.md
+++ b/docs/plan/changes/one-monotonic-clock.md
@@ -1,0 +1,147 @@
+# Change: one-monotonic-clock
+
+**Change 3 of 3 from the 2026-08-03 align.** Independent of the other two — different
+plan section, different ADR, no shared code. Implements the `[one-monotonic-clock]`
+DECIDED entry in §Media I/O. ADR: `docs/decisions/one-monotonic-clock.md`.
+
+Scale tier: change artifact, no new ADR (already written by the align). It changes a
+contract — what epoch a timestamp carries — without touching the plugin ABI, RHI, wire
+format, or processor model.
+
+Recon verified at HEAD `7d334ff7` on 2026-08-03.
+
+## Behavior after this change
+
+Every media timestamp in every language is the machine's monotonic clock — raw
+`clock_gettime(CLOCK_MONOTONIC)` on Linux, `mach_absolute_time` on Apple — the same epoch
+V4L2 and ALSA driver stamps carry, comparable across every process and node on a host.
+`MediaClock` remains the cross-platform naming seam. Each language exports exactly one
+name for it.
+
+## Current state — three process-relative epochs, not one
+
+- **`MediaClock`'s Linux arm is the process-relative epoch** the ADR names:
+  `core/media_clock.rs:12-17` seeds a `OnceLock<Instant>` on first call and returns
+  `start.elapsed()`. The Apple arm (`apple/media_clock.rs:6-31`) is already
+  `mach_absolute_time` and machine-wide, so the twins already disagree.
+- **A second, independent `MediaClock` type exists** at
+  `sdk/streamlib-plugin-sdk/src/media_clock.rs:10-20` — same name, different type, and
+  with **no `cfg` arms at all**, so it is process-relative on macOS too, with its own
+  `START` distinct from the engine's inside the same process. It dies with the ripout
+  (`sdk/streamlib-plugin-sdk`), so this change does not spend budget on it.
+- **`SoftwareAudioClock` is a third epoch** (`core/context/audio_clock.rs:190-199`,
+  `start_time.elapsed()`), and both platform audio clocks read the right clock and then
+  throw the epoch away — `linux/audio_clock.rs:283` (`elapsed_ns = current_ns -
+  start_time_ns`) and `apple/audio_clock.rs:157-161`.
+- **The wheel already has the duplicate export** the ADR kills: `media_clock_now_ns`
+  alongside `monotonic_now_ns` (`python_logging.rs:30` and `:42`), both registered at
+  `src/lib.rs:37-41`. `clock.py` re-exports only `monotonic_now_ns`, so it is already the
+  correct one-name surface.
+- The collision is already flagged in the code:
+  `python_processor_link_data_access.rs:133-136` documents its default stamp as "raw
+  CLOCK_MONOTONIC, bug-compatible with the old SDK … NOT the MediaClock epoch the
+  engine's Rust processors stamp with. Unifying the two epochs is a flagged owner
+  decision." This change is that decision landing.
+- **Driver stamps are discarded, not rebased** — the V4L2 DMA-BUF path reads only
+  `index` and `sequence` and drops `v4l2_buf.timestamp` (`camera_linux.rs:931-949`); the
+  cpal audio callback explicitly discards the `_info` carrying `timestamp().capture`
+  (`audio_capture_linux.rs:277`). Once the epochs match, using them becomes possible —
+  but doing so is A/V-sync work, which is OPEN. Out of scope here.
+
+## Clock scope — RESOLVED by owner, 2026-08-03
+
+**Option (a): the monotonic rule is the data plane's; observability keeps wall clock.**
+The line is drawn by what a timestamp is *for*, and it is drawn exhaustively so no future
+session has to guess.
+
+### Monotonic — the default, and the only legal clock on the data plane
+
+Everything a processor stamps, reads, or compares. Non-exhaustive by design, because this
+is the default: frame and bag timestamps (`iceoryx2/output.rs:449`, the wheel's write path
+at `python_processor_link_data_access.rs:137`), audio tick timestamps, `ctx.time` in every
+language, decoder pass-through stamps, and anything ever compared against a V4L2 or ALSA
+driver stamp. Rust reaches it through `MediaClock`; Python through `monotonic_now_ns`.
+
+### Wall clock — permitted on exactly these four surfaces, and nowhere else
+
+1. Log record `host_ts` (`core/logging/worker.rs:364-369`,
+   `compiler_ops/subprocess_escalate.rs:703`).
+2. Log record `source_ts` as produced by the language SDKs (`streamlib/log.py:142` and its
+   siblings).
+3. Log file naming — `started_at_millis` (`core/logging/init.rs:185`,
+   `core/logging/paths.rs:22`) and the CLI's rendering of both (`commands/logs.rs:222`).
+4. Control-plane pubsub event `timestamp_ns` (`core/pubsub/bus.rs:263-268`).
+
+Their job is correlating StreamLib with the outside world and with other hosts' logs — a
+job monotonic time cannot do. Adding a fifth surface is a plan change, not a judgement
+call.
+
+### The rule that keeps the two from mixing
+
+A wall-clock value never enters the data plane and is never compared against, subtracted
+from, or substituted for a media timestamp. The two are different quantities that happen
+to share a unit; a subtraction across them is always a bug.
+
+Rejected: everything monotonic (`streamlib logs` loses human dates), and carrying both
+numbers per record (reintroduces exactly the "which one do I compare?" question the ADR
+set out to kill).
+
+## REMOVED
+
+Bare patterns — the ship gate greps each line verbatim as a fixed string.
+
+- REMOVED: media_clock_now_ns
+  The wheel's duplicate export: `python_logging.rs:23-32`, registration `src/lib.rs:37-40`,
+  `python/streamlib/__init__.py:31,58`, stub `_engine.pyi:39,283-289`.
+
+## MODIFIED
+
+- MODIFIED: `core/media_clock.rs:12-17` — the Linux arm becomes raw
+  `clock_gettime(CLOCK_MONOTONIC)`, no `OnceLock`, no baseline. This one edit flips the
+  epoch for every `MediaClock::now()` caller, including the engine's default frame stamp
+  at `iceoryx2/output.rs:449`.
+- MODIFIED: `apple/media_clock.rs:24-30` — `host_time_to_nanos` re-queries
+  `mach_timebase_info` on every call; cache it while the file is open.
+- MODIFIED: `core/context/audio_clock.rs:190-199`, `linux/audio_clock.rs:283`,
+  `apple/audio_clock.rs:157-161` — `AudioTickContext.timestamp_ns` stops rebasing to a
+  start and carries the machine epoch, so it is comparable with a frame stamp for the
+  first time.
+- MODIFIED: `core/context/gpu_context.rs:2798-2801` — `escalation_monotonic_ns` is a
+  fourth `OnceLock<Instant>`; it routes through the one clock. Its use is internal
+  rate-limit deltas, so behavior is unchanged.
+- MODIFIED: `core/context/time_context.rs` — `start_ns` and `elapsed_ns()` keep working
+  (they subtract an explicit baseline). `elapsed_secs()` stays the "seconds since start"
+  API; its unit test asserting `0.09..0.2` (`:69-73`) still holds.
+- MODIFIED: `core/logging/event.rs:84` — the `host_ts` doc currently reads "Host monotonic
+  receipt timestamp, nanoseconds since UNIX epoch", which is self-contradictory and is
+  exactly the confusion the allowlist exists to prevent. It says wall clock, and why.
+- MODIFIED: the pin comment at `python_logging.rs:144-145` ("not a process-local origin
+  like the media clock's") and the flag comment at
+  `python_processor_link_data_access.rs:133-136` — both are falsified by this change.
+- MODIFIED: `spikes/streamlib-pyembed-spike/src/monotonic_clock.rs:6-7` carries a stale
+  line-referenced claim about `media_clock.rs:12-17` that this change falsifies.
+
+## ADDED
+
+- ADDED: `cargo xtask check-clock-usage` + its workflow — the mechanical guard that keeps
+  the wall-clock list from growing by accident. It bans wall-clock reads
+  (`SystemTime::now`, `chrono::Utc::now`, `time.time_ns`, `Date.now`) outside an explicit
+  file allowlist holding exactly the four surfaces above, in the shape of the existing
+  `lint-logging` / `check-no-escalate-in-lifecycle` checks. Recon found a set of
+  `SystemTime` uses that mint *unique names*, not timestamps (`vulkan_graphics_kernel.rs:3119`,
+  `surface_share/unix_socket_service.rs:977`, several test helpers); those either move to
+  a counter/uuid or join the allowlist with a stated reason — final at implementation.
+- ADDED: an epoch-parity test asserting `MediaClock::now()` and the wheel's
+  `monotonic_now_ns` land in the same domain as a directly-read
+  `clock_gettime(CLOCK_MONOTONIC)`. The natural home is the existing cross-process gate
+  `tests/polyglot_linux_monotonic_clock_parity.rs:112`, which today does **not** include
+  `MediaClock` — but its Python/Deno subprocess arms are doomed with the ripout, so the
+  surviving shape is host + wheel.
+
+## Notes (not tickets)
+
+- No test anywhere asserts a frame timestamp is small or near zero, so the epoch flip
+  breaks no existing assertion in the engine tree.
+- Consumers that format a raw stamp as seconds will print boot-relative values after the
+  change — `packages/mp4/.../mp4_writer.rs:839-847,895,1164` and the debug-utilities
+  sources that emit near-zero stamps. Deferred re-authoring by doctrine, not this change.

--- a/docs/plan/changes/processor-class-identity.md
+++ b/docs/plan/changes/processor-class-identity.md
@@ -1,0 +1,147 @@
+# Change: processor-class-identity
+
+**Change 2 of 3 from the 2026-08-03 align.** Blocked on `schema-free-ports.md`:
+`SchemaIdent` must lose its port-type role before it can lose its identity role, and
+`sdk/streamlib-idents/src/ident.rs` only becomes deletable once both are gone. Implements
+the two `[schema-free-ports]` DECIDED entries about identity and display name in
+§Processor model & scheduling. ADR: `docs/decisions/schema-free-ports.md`.
+
+Scale tier: change artifact + ADR — it changes the processor model's identity contract
+and the control plane's `type` field. ADR already written by the align.
+
+Recon verified at HEAD `7d334ff7` on 2026-08-03.
+
+## Behavior after this change
+
+A processor is identified by its class's fully-qualified import path —
+`my_app.filters:BlurProcessor` in Python, `my_app::filters::BlurProcessor` in Rust.
+Derived mechanically, never authored. One string in the registry, in the control plane's
+`type` field, and for helper-process placement. `@processor` declares execution,
+interval, scheduling priority, and description only.
+
+An instance's display name is the human-facing label — passed at `add`, readable off the
+returned handle, prefixing its log records, defaulting to the class's short name, with
+the engine disambiguating duplicates within one graph.
+
+## What recon changed about the plan's own claims
+
+- **`display_name` already exists end to end** and needs no new surface: the wheel's
+  `rt.add(cls, *, config, display_name)` (`python_runtime_lifecycle.rs:169-176`), the
+  `AddedProcessor` handle (`python_added_processor.rs:13-63`), `ProcessorNode.display_name`
+  (`processor_node.rs:21`), the log-record prefix (`python_processor_host.rs:268-277`),
+  and the control-plane field (`json_schema.rs:47`). The only missing piece of that plan
+  entry is the **duplicate disambiguation**, which does not exist: `add_v_op.rs:59-61`
+  assigns the type short name verbatim, so `rt.add(Blur)` twice yields two nodes both
+  labeled `Blur`. The only counter in the tree is snapshot-time and applies to the alias,
+  not the display name (`runtime.rs:1313-1328`).
+- **The ADR's "helper-process placement already requires the import path" is half-true.**
+  Helper spawn genuinely consumes a `module:Type` string
+  (`spawn_python_native_subprocess_op.rs:132` → `subprocess_runner.py:95-99`), but nothing
+  derives it *from the class object*: it is authored in `streamlib.yaml`
+  (`processor_registration.rs:447`) or computed from the staged file path
+  (`from_source.rs:335-344`). Both derivation sites die with the module loader. So class-path
+  identity is **new derivation code, not reuse**. `__module__` + `__qualname__` are already
+  read at `python_processor_registration.rs:90-100`, but only to format an error.
+- **Rust identity is captured by the macro, not `std::any::type_name`.** `type_name`'s
+  output format is explicitly unspecified across compiler versions and must not key a
+  registry. The `#[processor]` macro captures
+  `concat!(module_path!(), "::", stringify!(Type))` at the expansion site. Resolved by
+  reading — the plan says "derived mechanically" and this is the only stable mechanism.
+
+## Processors defined in `__main__` — RESOLVED by owner, 2026-08-03
+
+**Option (a): legal, in-process only.** A `@processor` class defined in the entry file the
+user runs with `python app.py` registers as `__main__:BlurProcessor` and runs in-process
+like any other. Identity stays mechanical and honest — it is whatever the import system
+says. The constraint lands at helper placement, where it actually bites: the engine
+refuses to helper-place a `__main__`-defined class with an actionable error ("define it
+in an importable module to run it in a helper process"), because a helper importing
+`__main__` gets its own, not the user's entry file.
+
+This keeps `python app.py` working, keeps the scaffold free to put a processor in the
+entry file, and matches the DECIDED entry that a helper-placeable class "must be
+import-addressable from a module whose import is side-effect-safe"
+(ARCHITECTURE.md:104). The plan's identity entry is corrected accordingly — the
+"never executed as `__main__`" clause is replaced.
+
+Consequence to hold: the same class has a different identity under `python app.py`
+(`__main__:Blur`) than under a loader that imports the entry (`app:Blur`). That is
+accepted — identity is per-launch-arrangement, and the only thing that reads it across
+processes is helper placement, which `__main__` classes are refused from anyway.
+
+Rejected: making `streamlib run`/`dev` the only launcher (contradicts "an importable
+Python library" and retires the harness the lifecycle contract was proven against), and
+rewriting `__main__` to a path-derived module name (path-dependent identity is the exact
+failure the ADR names).
+
+## REMOVED
+
+Bare patterns — the ship gate greps each line verbatim as a fixed string.
+
+- REMOVED: streamlib-idents
+  The crate whole. `ident.rs` (`Org`, `Package`, `TypeName`, `PackageRef`, `SchemaIdent`,
+  `ModuleIdent`, the `validate_*` grammar, the no-parse compile-fail gates), `semver.rs`
+  (`SemVer` loses its last consumer with the package layer), `session.rs`. `channel.rs`
+  (`ChannelName`, `source_channel_name`) is the one non-ident survivor and needs a home —
+  it is live at `operations_runtime.rs:21` and `open_iceoryx2_service_op.rs:353`.
+- REMOVED: SchemaIdent
+- REMOVED: SchemaIdentOutput
+  The control-plane DTO (`schema_ident_output.rs:42`) and the `ProcessorNodeOutput.processor_type`
+  object shape (`json_schema.rs:44-46`) — `type` becomes a plain string.
+- REMOVED: ProcessorTypeReference
+  The version-free narrowing (`processor_type_reference.rs:30`), its three-key JSON
+  wire lock (`processor_spec.rs:76-110`), and `to_diagnostic_ident`.
+- REMOVED: schema_ident_any_version
+- REMOVED: resolve_installed_processor_type
+  With `highest_registered_for_tuple`, `resolve_any_version`, `schema_identity_tuple` and
+  `matches_schema_tuple` — version-blind lookup has nothing left to be blind about.
+- REMOVED: @app/local
+  The synthesis at `_processor_declaration.py:314` and `grammar.rs:255-278`.
+- REMOVED: is_reserved_for_session
+- REMOVED: check-no-reverse-dns
+  The xtask check and its workflow. Its stated rationale is enforcing the
+  `@org/package/Type@version` grammar (`check_no_reverse_dns.rs:5-9`); with that grammar
+  deleted it has no rule left to enforce. This supersedes the ripout's "re-scope" line.
+
+## MODIFIED
+
+- MODIFIED: registry and factory keys move from `SchemaIdent` to the import-path string —
+  the three maps at `processor_instance_factory.rs:807-809`, `ProcessorNode.processor_type`
+  (`processor_node.rs:20`), `GraphSnapshot`'s `ProcessorDefinition.processor_type`
+  (`graph_snapshot.rs:79`), the pubsub events (`events.rs:270-326`), the wheel's class
+  cache (`python_processor_registration.rs:26`) and its duplicate-identity error (`:57-62`,
+  which today tells the author to declare an explicit `@org/package/Type`).
+- MODIFIED: `@processor` loses its identity argument in both languages — the positional
+  identity (`_processor_declaration.py:179-195`, `grammar.rs:161-167`), the
+  `_IDENTITY_PATTERN` regex (`:33`), the `type =` override (`grammar.rs:217`), and the
+  `VERSION_FREE_SENTINEL` (`python_processor_declaration.rs:23`). Execution, interval,
+  scheduling and description stay.
+- MODIFIED: `App::add_local::<P>` (`sdk/streamlib-sdk/src/sdk/app.rs:62-89`) drops its
+  `@session/…` ident minting and registers under the captured type path. Rust `App::add`
+  gains a display-name parameter and returns a handle rather than a bare
+  `ProcessorUniqueId` — today it can reach neither (`ProcessorSpec::with_display_name`
+  exists but `add` never calls it).
+- MODIFIED: `sdk/streamlib-macros` loses the `schema_ident!` / `schema_ident_any_version!`
+  / `module_ident*!` family and gains the type-path capture.
+- MODIFIED: `runtime/streamlib-moq/src/moq_catalog.rs:24-57` keys on the import path.
+
+## ADDED
+
+- ADDED: display-name disambiguation at `add_v_op.rs:59` — the engine appends a counter
+  when a display name already exists in the graph. Mirrored or removed at
+  `python_runtime_lifecycle.rs:198-199`, where the wheel pre-computes the default
+  client-side and never round-trips it.
+- ADDED: import-path derivation for Python (`__module__` + `__qualname__`, colon-joined)
+  and the macro capture for Rust, each with a unit test.
+- ADDED: the helper-placement refusal for `__main__`-defined classes — an actionable
+  error naming the fix (move the class to an importable module), with a test proving an
+  in-process `__main__` processor runs and the same class is refused a helper placement.
+- ADDED: an identity-stability test — a class in an importable module registers under the
+  same string however the app was launched.
+
+## Out of scope
+
+- The `setup(rt)` entry-file loading glue — #1711 / `importable-python-library.md`. This
+  change constrains it (the entry must be imported, not run) but does not build it.
+- Re-authoring `packages/` and `examples/` off the old grammar — deferred re-authoring,
+  recorded in the ripout's dispositions.

--- a/docs/plan/changes/schema-agreement-ripout.md
+++ b/docs/plan/changes/schema-agreement-ripout.md
@@ -1,5 +1,14 @@
 # Change: schema-agreement-ripout
 
+> **Superseded 2026-08-03 by `schema-free-ports.md`** (align #1723, ADR
+> `docs/decisions/schema-free-ports.md`). This change was built around three things the
+> decision deletes: unilateral port hints, an advisory connect warn, and an inert-but-
+> stamped wire tag. Its connect-time half already shipped (commit `0113ea20`); the
+> advisory warn it proposed was never built; its per-read half is absorbed by
+> `schema-free-ports.md`. Its central constraint — "`FrameHeader`/`SchemaIdentWire` byte
+> layout is unchanged" — is now false: the header goes 204 → 76 bytes. Do not derive
+> tickets from this file; `/reconcile-tracker` retires #1679 and #1655.
+
 > **Reconciliation note 2026-08-02** (`importable-python-library` pivot): the core
 > decision here — advisory connect, cast-at-read, inert wire tag — stands unchanged.
 > But this file's STAY rationale cites `module_loader/` paths, `sdk/streamlib-deno`,

--- a/docs/plan/changes/schema-free-ports.md
+++ b/docs/plan/changes/schema-free-ports.md
@@ -1,0 +1,163 @@
+# Change: schema-free-ports
+
+**Change 1 of 3 from the 2026-08-03 align.** Siblings: `processor-class-identity.md`
+(blocked on this one — `SchemaIdent` must lose its port role before it can lose its
+identity role) and `one-monotonic-clock.md` (independent). Implements the four
+`[schema-free-ports]` DECIDED entries in §Processor model & scheduling that concern the
+type layer; the identity entries belong to Change 2. ADR:
+`docs/decisions/schema-free-ports.md`.
+
+Scale tier: change artifact + ADR — this touches the processor model **and** the IPC wire
+format. ADR already written by the align.
+
+Recon verified at HEAD `7d334ff7` on 2026-08-03 by four read-only sweeps (schema/JTD/
+registry, wire/IPC/port surfaces, identity, clock).
+
+## Supersedes `schema-agreement-ripout.md` — archive it, do not ship it
+
+That change kept three things this decision deletes: unilateral port hints, an advisory
+connect warn, and an inert-but-stamped wire tag. Its state at HEAD:
+
+- Its connect-time half **already shipped** (commit `0113ea20`). `ConnectOptions`,
+  `SchemaValidationPosture`, `connect_with{,_async}`, `enforce_connect_schema_agreement`,
+  `classify_port_schema_agreement`, and `Error::SchemaIdentMismatch` are already gone.
+- The advisory warn it proposed as MODIFIED (`port_schema_hints_differ`) was **never
+  built** — there is nothing to remove.
+- Its per-read half is fully live and is absorbed below.
+
+Tickets #1679 and #1655 are superseded — #1679's stated constraint "`FrameHeader` BYTE
+LAYOUT UNTOUCHED" is now false. `/reconcile-tracker` retires both; derive nothing from
+that file.
+
+## Sequencing
+
+Land **after** the ripout's contract deletion (#1715). Two reasons, both from recon:
+the 204→76 header change is a hard cross-runtime break that must move every publisher
+and subscriber in one release, and while `sdk/streamlib-deno-native` and
+`sdk/streamlib-python-native` still exist that means editing two cdylibs the ripout is
+about to delete. Sequencing after it drops the break to two movers: the host and the
+wheel's in-process path.
+
+This change also **reverses two lines of `importable-python-library-ripout.md`**, which
+must be amended in the same PR that lands this file: its `:43` preserves "the schema-ident
+core behind the JTD seam" and demotes `streamlib-jtd-codegen` to internal-only. Both now
+die outright (the ident core in Change 2, the codegen crate here).
+
+## Behavior after this change
+
+A port declares name, description, and — on an input — delivery profile. Nothing carries
+a type. Connect wires without inspecting anything (already true). A frame header is 76
+bytes and carries no schema ident, so no read path can compare one. A consumer discovers
+a mismatch as a decode failure at its own read: in Rust serde is the always-on
+validation, in Python `ctx.inputs.read(port)` yields the bag as a mapping and
+`read(port, into=T)` is the opt-in strictness dial. `graph` and `tap` render a port as
+name, description, delivery profile, direction.
+
+Every input port declares its delivery profile explicitly; there is no default and
+nothing left to infer one from.
+
+## Two factual gaps, resolved by reading (not owner decisions)
+
+- **`expected_payload_bytes` is safe to delete.** It is initial-allocation priming only,
+  not correctness: the read path already grows on demand and stashes the oversized frame
+  across the retry (`iceoryx2/input.rs:705-735` — "nothing is dropped", retiring the
+  pre-#1421 up-front sizing). Only two engine-tree schemas set it. Cost: encoded-video
+  channels start at the 64 KiB default and grow once instead of being primed at 4 MiB.
+- **The `@session` isolation residue dissolves on its own.** `IsolationTier::for_processor`
+  (`core/context/isolation.rs:93`) reaches the untrusted branch only when
+  `cdylib_resident` is true; with the plugin ABI deleted that argument is always false and
+  the tier collapses to a constant. That is the ripout's consequence, not this change's.
+
+## REMOVED
+
+Bare patterns — the ship gate greps each line verbatim as a fixed string.
+
+- REMOVED: SchemaIdentWire
+  The 128-byte wire tag whole: struct (`ipc-types/src/lib.rs:350`), `from_segments`,
+  all five accessors, `render_joined`, `Debug`, `is_unset`, `matches_schema_tuple`, the
+  three size constants, the compile-time ABI lock (`:364-369`), and seven unit tests
+  (`:743-812`, `:861-903`). Includes the hand-written ctypes mirror in
+  `sdk/streamlib-python/python/streamlib/frame_payload.py:53-143`.
+- REMOVED: schema_agreement
+  `runtime/streamlib-engine/src/core/schema_agreement.rs` whole (109 lines incl. its
+  three revert-lock tests) and its declaration at `core/mod.rs:18`.
+- REMOVED: classify_wire_schema_agreement
+- REMOVED: expected_schema_ident
+  `PortConfig.expected_schema_ident` (`iceoryx2/input.rs:221`), its init (`:274`), and
+  `set_port_expected_schema_ident` (`:286`, sole non-test caller
+  `open_iceoryx2_service_op.rs:692`).
+- REMOVED: schema_mismatch_observed
+  The `AtomicBool` (`input.rs:227`), the accessor (`:299`, no production consumer), the
+  `read_raw_bounded` comparison block (`:466-484`), and the three per-read mismatch tests.
+- REMOVED: schema_ident_wire_for_spec
+- REMOVED: PortSchemaSpec
+  The port type declaration itself (`streamlib-processor-schema/src/processor_schema.rs:42`),
+  `PortDescriptor.schema`, the `port_schema_spec_wire` serde mirror, and
+  `port_schema_spec_from_declaration` in the wheel.
+- REMOVED: flow_class
+  `FlowClass` (`iceoryx2/delivery_profile.rs:102-141`), `flow_class_for_port_spec`, and
+  the `metadata.flow_class` declarations in the engine-tree schemas.
+- REMOVED: embedded_schemas
+  `runtime/streamlib-engine/src/core/embedded_schemas/` whole (721 lines + integration
+  tests) — the process-wide schema registry, `delivery_profile_for_input_port`,
+  `expected_payload_bytes_for_port_spec`, `port_schema_spec`, `resolve_node_port_schema`,
+  and the `streamlib::schemas::*` public surface (`engine/src/lib.rs:41-54`).
+- REMOVED: streamlib-jtd-codegen
+  The crate whole, `engine/build.rs`'s `run_for_rust_crate`, the engine's `_generated_`
+  shim module, `cargo xtask generate-schemas`, and the `jtd-codegen v0.4.1` install step
+  in `.github/workflows/schemas.yml`.
+- REMOVED: __streamlib_schema_ident__
+  The generated-class marker and the `_generated_/` trees that carry it.
+- REMOVED: check-processor-spec-new
+  The xtask check and its workflow — it polices `SchemaIdent` literals in port specs.
+
+## MODIFIED
+
+- MODIFIED: `FRAME_HEADER_SIZE` 204 → **76** (`64 + 8 + 4`) and its two asserts
+  (`ipc-types/src/lib.rs:210`, `:832-837`); new offsets `port_key 0..64`,
+  `timestamp_ns 64..72`, `len 72..76`, `data 76..`. `FrameHeader::new` /
+  `write_to_slice` / `read_from_slice` drop the ident; `FrameHeader::schema()` dies.
+  Slot-priming arithmetic shifts by 128 bytes/frame (`iceoryx2/node.rs:168`,
+  `output.rs:183`).
+- MODIFIED: `set_channel_publisher` (`iceoryx2/output.rs:161`), `ChannelEgress`,
+  `wire_rust_source` and `wire_rust_dest` (`open_iceoryx2_service_op.rs:639`, `:674`) —
+  all drop their schema parameters; the per-frame stamp at `output.rs:284` drops the tag.
+- MODIFIED: the host→subprocess wiring envelope JSON loses its `"schema"` key
+  (`open_iceoryx2_service_op.rs:731`, helper `:40-48`) and its parsers stop reading it.
+- MODIFIED: `delivery_profile` becomes **required on every input port** in all authoring
+  surfaces — Rust `#[processor]` `input(...)`, the wheel's `@input`. It is optional today
+  and defaults through the deleted `flow_class` chain. Every engine-tree input port gains
+  an explicit declaration; a missing one is a wiring error.
+- MODIFIED: the `schema=` kwarg is deleted from `@input`/`@output` in the wheel
+  (`_processor_declaration.py:46-156`) and the positional `<schema>` from the Rust port
+  grammar; `streamlib/schema_ident.py` and its `__init__.py` re-export die with it.
+- MODIFIED: `PortInfo.data_type` (`graph/nodes/port_info.rs:13`) is deleted, and with it
+  `PortInfoOutput.data_type` (`json_schema.rs:82`), `PortDescriptorOutput.schema`
+  (`:222`), `RegisteredPortReceipt.schema` (`operations.rs:118`) and their four rendering
+  tests. A port renders as `{name, description, port_kind, delivery_profile}`.
+- MODIFIED: `sdk/streamlib-processor-schema` loses its schema half; `ExecutionConfig`,
+  `ProcessExecution`, `ThreadPriority`, `ProcessorScheduling` and the non-schema half of
+  `PortDescriptor` need a surviving home (crate layout final at implementation).
+
+## ADDED
+
+- ADDED: `read(port, into=T)` on the Python reader — the opt-in strictness dial. A
+  TypedDict casts for free; a dataclass or pydantic model constructs and validates,
+  raising at read. Attaches at `python_processor_context.rs:874` and
+  `python_processor_link_data_access.rs:64`, with the matching `_engine.pyi:175` entry
+  (the stub is part of done — stubtest + pyright gate it).
+- ADDED: cast-not-contract conformance test — a producer publishing type X into a
+  consumer declaring type Y delivers the bag; the consumer's `into=` read raises at read;
+  the plain mapping read of the same frame succeeds; link and both processors stay healthy.
+- ADDED: a missing-delivery-profile wiring-error test on an input port.
+
+## Notes (not tickets)
+
+- **The ship gate is a no-op for most existing REMOVED bullets.** It runs
+  `git grep -InF` on everything after `- REMOVED:`, so any bullet carrying backticks or
+  prose searches for that whole string and matches nothing. Verified: the gate passes
+  `schema-agreement-ripout.md` clean while `schema_agreement` still exists at three
+  sites. Bullets here are bare for that reason; the gate itself is worth a one-line fix.
+- **The gate greps `packages/` and `examples/` too.** Those trees still carry schema
+  idents and lag by design, so these REMOVED patterns cannot go green until the ripout
+  and #1672 have moved them out. That is a sequencing fact, not extra scope.


### PR DESCRIPTION
`/propose-change` over the 2026-08-03 align (#1723), owner-approved. The decision is one align but **three separable deltas** — the combined inventory is ~460 lines, far past the 200-line cap, and each lands independently.

| Change | Scope | Blocked on |
|---|---|---|
| `schema-free-ports` (163 l) | The type layer dies: `SchemaIdentWire` + the 128-byte header slot, the per-read compare, `PortSchemaSpec`, the embedded-schema registry, `streamlib-jtd-codegen`, port-type rendering in `graph`/`tap`. Delivery profile becomes mandatory on every input. | ripout #1715 |
| `processor-class-identity` (147 l) | Identity becomes the class's import path; `@org/package/Type`, `@app/local` and `streamlib-idents` die; display-name duplicates get an engine-appended counter. | `schema-free-ports` |
| `one-monotonic-clock` (147 l) | `MediaClock`'s Linux arm loses its `OnceLock<Instant>` epoch, the audio clocks stop rebasing to a start, the wheel's duplicate `media_clock_now_ns` export dies. | — independent |

## Sequencing

The first two land **after** the ripout's contract deletion (#1715). `FrameHeader` goes **204 → 76 bytes** — a hard cross-runtime break with no version field to negotiate on. Landing after the ripout drops it to two movers (host + wheel) instead of also editing two cdylibs that are about to be deleted.

`one-monotonic-clock` is independent and can ticket immediately.

## Two owner decisions taken during the proposal

**Processors defined in `__main__` are legal, in-process only.** This *reverses* the align's "entry file is imported as a module, never executed as `__main__`" clause. Forbidding it would contradict §Product's "a normal Python codebase" and retire the `python app.py` harness the interpreter-lifecycle contract was proven against. The consequence lands where it actually bites: no helper process can import `__main__`, so the engine refuses to helper-place such a class with an error naming the fix.

**The monotonic rule is the data plane's.** Wall clock is permitted on exactly four observability surfaces — log `host_ts`, log `source_ts`, log file naming, and the control-plane pubsub event timestamp — because correlating with the outside world is a job monotonic time cannot do. Per the owner's ask, this is made drift-proof four ways rather than left as prose: the plan entry names the four inline, the never-compare-across invariant is stated, a new `cargo xtask check-clock-usage` gates it mechanically, and GLOSSARY gains *Monotonic clock* / *Wall clock* entries. Note `core/logging/event.rs:84` currently documents `host_ts` as "monotonic … since UNIX epoch" — the exact confusion the list exists to prevent.

## Supersession

`schema-agreement-ripout.md` is annotated superseded rather than shipped: its connect-time half **already landed** (`0113ea20`), the advisory warn it proposed was **never built**, and its central constraint — "`FrameHeader` byte layout is unchanged" — is now false. #1679 and #1655 retire via `/reconcile-tracker`.

This also **reverses two lines of `importable-python-library-ripout.md`**, which preserved the schema-ident core and demoted `streamlib-jtd-codegen` to internal-only. Both now die outright; that file is amended by whichever change lands first.

## Recon corrections to upstream claims

- The `schema-free-ports` ADR says helper placement "already requires the import path" — **half-true**. Helper spawn consumes a `module:Type` string but derives it from `streamlib.yaml` or a staged file path, never from the class object. This is new derivation code, not reuse.
- **`display_name` already exists end to end** (`rt.add`, `AddedProcessor`, `ProcessorNode`, log attribution). Only duplicate disambiguation is missing — `rt.add(Blur)` twice yields two nodes both labeled `Blur`.

## Notes, not tickets

The ship gate is **a no-op for most existing REMOVED bullets**: it fixed-string-greps everything after `- REMOVED:`, so any bullet carrying backticks or prose matches nothing. Verified — it passes `schema-agreement-ripout.md` clean while `schema_agreement` still exists at three sites. Bullets in these three files are bare for that reason. The gate also greps `packages/`/`examples/`, which lag by design, so these patterns can't go green until #1672 and the ripout move those trees out.

Recon: four read-only sweeps at `7d334ff7`. **No source files touched** — `docs/plan/` and `docs/decisions/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)