### PR TITLE
feat(media): media built-ins foundation — present compositor, TestPatternSource, rt.add native blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5469,6 +5469,7 @@ dependencies = [
  "rmpv",
  "serde_json",
  "streamlib",
+ "streamlib-media-builtins",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5326,6 +5326,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "streamlib-media-builtins"
+version = "0.11.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "streamlib",
+ "tracing",
+]
+
+[[package]]
 name = "streamlib-moq"
 version = "0.11.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5329,6 +5329,8 @@ dependencies = [
 name = "streamlib-media-builtins"
 version = "0.11.0"
 dependencies = [
+ "rmp-serde",
+ "rmpv",
  "serde",
  "serde_json",
  "streamlib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "tools/streamlib-pack",      # Package-artifact assembly shared between `streamlib pkg publish` (CLI) and `streamlib-build-orchestrator` (runtime) — emits a .slpkg or an extracted staged dir
     "tools/streamlib-build-orchestrator", # Default polyglot BuildOrchestrator impl — runtime materialization of source packages (depends on engine for the trait + cargo-build for the helpers)
     "runtime/streamlib-runtime",   # Standalone runtime binary (spawned by CLI)
+    "runtime/streamlib-media-builtins", # First-party media built-ins (test pattern, camera, display) — native blocks statically linked into the wheel
     "sdk/streamlib-processor-schema", # Processor schema types + YAML parser shared between streamlib runtime and streamlib-macros
     "sdk/streamlib-jtd-codegen", # JTD-codegen pipeline: schema YAML → typed Rust/Python/TypeScript bindings
     "sdk/streamlib-idents",    # Structured schema identifiers, semver, manifest/lockfile types (#399)

--- a/runtime/streamlib-engine/src/host_rhi.rs
+++ b/runtime/streamlib-engine/src/host_rhi.rs
@@ -62,7 +62,10 @@ pub use crate::vulkan::rhi::{
 };
 
 #[cfg(target_os = "linux")]
-pub use crate::vulkan::rhi::{MAX_FRAMES_IN_FLIGHT, PresentFrame, VulkanPresentTarget};
+pub use crate::vulkan::rhi::{
+    MAX_FRAMES_IN_FLIGHT, PresentFrame, PresentScalingMode, VulkanPresentCompositor,
+    VulkanPresentTarget, composition_scale,
+};
 
 pub use vulkanalia::vk::GeometryInstanceFlagsKHR;
 

--- a/runtime/streamlib-engine/src/host_rhi.rs
+++ b/runtime/streamlib-engine/src/host_rhi.rs
@@ -64,7 +64,7 @@ pub use crate::vulkan::rhi::{
 #[cfg(target_os = "linux")]
 pub use crate::vulkan::rhi::{
     MAX_FRAMES_IN_FLIGHT, PresentFrame, PresentScalingMode, VulkanPresentCompositor,
-    VulkanPresentTarget, composition_scale,
+    VulkanPresentTarget,
 };
 
 pub use vulkanalia::vk::GeometryInstanceFlagsKHR;

--- a/runtime/streamlib-engine/src/vulkan/rhi/mod.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/mod.rs
@@ -101,6 +101,13 @@ pub use vulkan_present_target::{
 pub(crate) use vulkan_present_target::PresentTargetInner;
 
 #[cfg(target_os = "linux")]
+mod vulkan_present_compositor;
+#[cfg(target_os = "linux")]
+pub use vulkan_present_compositor::{
+    PresentScalingMode, VulkanPresentCompositor, composition_scale,
+};
+
+#[cfg(target_os = "linux")]
 mod vulkan_swapchain_colorspace;
 #[cfg(target_os = "linux")]
 pub use vulkan_swapchain_colorspace::{

--- a/runtime/streamlib-engine/src/vulkan/rhi/mod.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/mod.rs
@@ -103,9 +103,7 @@ pub(crate) use vulkan_present_target::PresentTargetInner;
 #[cfg(target_os = "linux")]
 mod vulkan_present_compositor;
 #[cfg(target_os = "linux")]
-pub use vulkan_present_compositor::{
-    PresentScalingMode, VulkanPresentCompositor, composition_scale,
-};
+pub use vulkan_present_compositor::{PresentScalingMode, VulkanPresentCompositor};
 
 #[cfg(target_os = "linux")]
 mod vulkan_swapchain_colorspace;

--- a/runtime/streamlib-engine/src/vulkan/rhi/vulkan_present_compositor.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/vulkan_present_compositor.rs
@@ -1,0 +1,675 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Present-composition primitive: draws a source texture onto a presentation
+//! attachment with aspect-managed scaling and black bars.
+//!
+//! Absorbs the draw step display consumers previously assembled by hand
+//! (blit kernel + descriptor staging + barrier + fullscreen-triangle draw)
+//! into one call per frame. Colorspace selection and HDR metadata stay with
+//! [`VulkanPresentTarget`](super::VulkanPresentTarget) — the compositor's
+//! kernel is (re)built against whatever attachment format that pick yields.
+
+use std::sync::Arc;
+
+use crate::core::rhi::{
+    AttachmentFormats, ColorBlendState, ColorWriteMask, DepthStencilState, DrawCall,
+    GraphicsBindingSpec, GraphicsDynamicState, GraphicsKernelDescriptor, GraphicsPipelineState,
+    GraphicsPushConstants, GraphicsShaderStageFlags, GraphicsStage, MultisampleState,
+    PrimitiveTopology, RasterizationState, ScissorRect, Texture, TextureFormat, VertexInputState,
+    Viewport, VulkanLayout,
+};
+use crate::core::{Error, Result};
+
+use super::vulkan_command_recorder::RhiCommandRecorder;
+use super::vulkan_device::HostVulkanDevice;
+use super::vulkan_graphics_kernel::{OffscreenColorTarget, OffscreenDraw, VulkanGraphicsKernel};
+use super::vulkan_pipeline_flags::{VulkanAccess, VulkanStage};
+use super::vulkan_present_target::{MAX_FRAMES_IN_FLIGHT, PresentFrame};
+
+/// How a source rectangle maps onto a destination of a different aspect ratio.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PresentScalingMode {
+    /// Preserve aspect; the whole source is visible, black bars fill the rest.
+    Fit,
+    /// Preserve aspect; the destination is covered, source overflow is cropped.
+    Fill,
+    /// Ignore aspect; the source is stretched to the destination exactly.
+    Stretch,
+}
+
+/// Per-axis UV scale for the display-blit fragment shader's
+/// `(uv - 0.5) / scale + 0.5` sampling (out-of-range samples render black).
+pub fn composition_scale(
+    mode: PresentScalingMode,
+    source_extent: (u32, u32),
+    destination_extent: (u32, u32),
+) -> (f32, f32) {
+    let source_aspect = source_extent.0 as f32 / source_extent.1 as f32;
+    let destination_aspect = destination_extent.0 as f32 / destination_extent.1 as f32;
+    match mode {
+        PresentScalingMode::Stretch => (1.0, 1.0),
+        PresentScalingMode::Fit => {
+            if source_aspect > destination_aspect {
+                (1.0, destination_aspect / source_aspect)
+            } else {
+                (source_aspect / destination_aspect, 1.0)
+            }
+        }
+        PresentScalingMode::Fill => {
+            if source_aspect > destination_aspect {
+                (source_aspect / destination_aspect, 1.0)
+            } else {
+                (1.0, destination_aspect / source_aspect)
+            }
+        }
+    }
+}
+
+/// Owns the display-blit graphics kernel for one attachment format and
+/// records "draw this texture onto that attachment" as a single call.
+pub struct VulkanPresentCompositor {
+    kernel: VulkanGraphicsKernel,
+    attachment_format: TextureFormat,
+}
+
+const DISPLAY_BLIT_VERT_SPV: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/display_blit.vert.spv"));
+const DISPLAY_BLIT_FRAG_SPV: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/display_blit.frag.spv"));
+
+/// Push-constant block of `display_blit.frag`: `vec2 scale` + `vec2 offset`.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct DisplayBlitPushConstants {
+    scale: [f32; 2],
+    offset: [f32; 2],
+}
+
+fn build_display_blit_kernel(
+    vulkan_device: &Arc<HostVulkanDevice>,
+    attachment_format: TextureFormat,
+) -> Result<VulkanGraphicsKernel> {
+    let stages = [
+        GraphicsStage::vertex(DISPLAY_BLIT_VERT_SPV),
+        GraphicsStage::fragment(DISPLAY_BLIT_FRAG_SPV),
+    ];
+    let bindings = [GraphicsBindingSpec::sampled_texture(
+        0,
+        GraphicsShaderStageFlags::FRAGMENT,
+    )];
+    let descriptor = GraphicsKernelDescriptor {
+        label: "present-compositor-display-blit",
+        stages: &stages,
+        bindings: &bindings,
+        push_constants: GraphicsPushConstants {
+            size: std::mem::size_of::<DisplayBlitPushConstants>() as u32,
+            stages: GraphicsShaderStageFlags::FRAGMENT,
+        },
+        pipeline_state: GraphicsPipelineState {
+            topology: PrimitiveTopology::TriangleList,
+            vertex_input: VertexInputState::None,
+            rasterization: RasterizationState::default(),
+            multisample: MultisampleState::default(),
+            depth_stencil: DepthStencilState::Disabled,
+            color_blend: ColorBlendState::Disabled {
+                color_write_mask: ColorWriteMask::RGBA,
+            },
+            attachment_formats: AttachmentFormats::color_only(attachment_format),
+            dynamic_state: GraphicsDynamicState::ViewportScissor,
+        },
+        descriptor_sets_in_flight: MAX_FRAMES_IN_FLIGHT as u32,
+    };
+    VulkanGraphicsKernel::new(vulkan_device, &descriptor)
+}
+
+impl VulkanPresentCompositor {
+    /// Build the compositor's kernel against `attachment_format` (the
+    /// present target's [`color_format`](super::VulkanPresentTarget::color_format),
+    /// or an offscreen target's format).
+    pub fn new(
+        vulkan_device: &Arc<HostVulkanDevice>,
+        attachment_format: TextureFormat,
+    ) -> Result<Self> {
+        Ok(Self {
+            kernel: build_display_blit_kernel(vulkan_device, attachment_format)?,
+            attachment_format,
+        })
+    }
+
+    /// The attachment format the current kernel was built against.
+    pub fn attachment_format(&self) -> TextureFormat {
+        self.attachment_format
+    }
+
+    /// Rebuild the kernel if `attachment_format` differs from the current one
+    /// (a swapchain recreate can flip SDR BGRA8 → HDR10 A2B10G10R10). Returns
+    /// whether a rebuild happened.
+    pub fn ensure_attachment_format(
+        &mut self,
+        vulkan_device: &Arc<HostVulkanDevice>,
+        attachment_format: TextureFormat,
+    ) -> Result<bool> {
+        if attachment_format == self.attachment_format {
+            return Ok(false);
+        }
+        self.kernel = build_display_blit_kernel(vulkan_device, attachment_format)?;
+        self.attachment_format = attachment_format;
+        Ok(true)
+    }
+
+    /// Record the composition of `source` onto an acquired swapchain frame.
+    ///
+    /// Transitions `source` to `SHADER_READ_ONLY_OPTIMAL` when
+    /// `source_current_layout` says it is not there already — the caller's
+    /// layout bookkeeping must record that transition. Opens and closes its
+    /// own dynamic-rendering pass (clearing to black), so call it once per
+    /// frame with no pass active.
+    pub fn compose_to_present_frame(
+        &self,
+        frame: &mut PresentFrame<'_>,
+        source: &Texture,
+        source_current_layout: VulkanLayout,
+        scaling: PresentScalingMode,
+    ) -> Result<()> {
+        if frame.color_format != self.attachment_format {
+            return Err(Error::GpuError(format!(
+                "VulkanPresentCompositor: kernel was built for {:?} but the acquired \
+                 frame's attachment is {:?} — call ensure_attachment_format after a \
+                 swapchain recreate",
+                self.attachment_format, frame.color_format
+            )));
+        }
+        let frame_index = frame.frame_index;
+        let destination_extent = frame.extent;
+
+        self.kernel.set_sampled_texture(frame_index, 0, source)?;
+        if source_current_layout != VulkanLayout::SHADER_READ_ONLY_OPTIMAL {
+            frame.recorder.record_image_barrier(
+                source,
+                source_current_layout,
+                VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+                VulkanStage::ALL_COMMANDS,
+                VulkanStage::FRAGMENT_SHADER,
+                VulkanAccess::MEMORY_WRITE,
+                VulkanAccess::SHADER_SAMPLED_READ,
+            )?;
+        }
+
+        let (scale_x, scale_y) = composition_scale(
+            scaling,
+            (source.width(), source.height()),
+            destination_extent,
+        );
+        self.kernel.set_push_constants_value(
+            frame_index,
+            &DisplayBlitPushConstants {
+                scale: [scale_x, scale_y],
+                offset: [0.0, 0.0],
+            },
+        )?;
+
+        frame.begin_rendering(Some([0.0, 0.0, 0.0, 1.0]))?;
+        let draw = DrawCall {
+            vertex_count: 3,
+            instance_count: 1,
+            first_vertex: 0,
+            first_instance: 0,
+            viewport: Some(Viewport::full(destination_extent.0, destination_extent.1)),
+            scissor: Some(ScissorRect::full(destination_extent.0, destination_extent.1)),
+        };
+        frame.recorder.record_draw(&self.kernel, frame_index, &draw)?;
+        frame.end_rendering()
+    }
+
+    /// Compose `source` into `destination` without a window: the offscreen
+    /// arm of the same draw, used by headless callers and the composition
+    /// correctness tests. Submits and waits; `destination` is left in
+    /// `COLOR_ATTACHMENT_OPTIMAL`, `source` in `SHADER_READ_ONLY_OPTIMAL`.
+    pub fn compose_to_offscreen_texture(
+        &self,
+        vulkan_device: &Arc<HostVulkanDevice>,
+        frame_index: u32,
+        destination: &Texture,
+        source: &Texture,
+        source_current_layout: VulkanLayout,
+        scaling: PresentScalingMode,
+    ) -> Result<()> {
+        if destination.format() != self.attachment_format {
+            return Err(Error::GpuError(format!(
+                "VulkanPresentCompositor: kernel was built for {:?} but the offscreen \
+                 destination is {:?} — call ensure_attachment_format first",
+                self.attachment_format,
+                destination.format()
+            )));
+        }
+        if source_current_layout != VulkanLayout::SHADER_READ_ONLY_OPTIMAL {
+            let mut recorder = RhiCommandRecorder::new(
+                vulkan_device,
+                "present-compositor-offscreen-source-barrier",
+            )?;
+            recorder.begin()?;
+            recorder.record_image_barrier(
+                source,
+                source_current_layout,
+                VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+                VulkanStage::ALL_COMMANDS,
+                VulkanStage::FRAGMENT_SHADER,
+                VulkanAccess::MEMORY_WRITE,
+                VulkanAccess::SHADER_SAMPLED_READ,
+            )?;
+            recorder.submit_and_wait()?;
+        }
+
+        self.kernel.set_sampled_texture(frame_index, 0, source)?;
+        let (scale_x, scale_y) = composition_scale(
+            scaling,
+            (source.width(), source.height()),
+            (destination.width(), destination.height()),
+        );
+        self.kernel.set_push_constants_value(
+            frame_index,
+            &DisplayBlitPushConstants {
+                scale: [scale_x, scale_y],
+                offset: [0.0, 0.0],
+            },
+        )?;
+
+        self.kernel.offscreen_render(
+            frame_index,
+            &[OffscreenColorTarget {
+                texture: destination,
+                clear_color: Some([0.0, 0.0, 0.0, 1.0]),
+            }],
+            (destination.width(), destination.height()),
+            OffscreenDraw::Draw(DrawCall {
+                vertex_count: 3,
+                instance_count: 1,
+                first_vertex: 0,
+                first_instance: 0,
+                viewport: None,
+                scissor: None,
+            }),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- composition_scale: pure math, no GPU --------------------------------
+
+    /// Wide 16:9 source into a narrower 4:3 destination.
+    const SRC_16_9: (u32, u32) = (1920, 1080);
+    const DST_4_3: (u32, u32) = (1024, 768);
+
+    #[test]
+    fn stretch_ignores_aspect() {
+        assert_eq!(
+            composition_scale(PresentScalingMode::Stretch, SRC_16_9, DST_4_3),
+            (1.0, 1.0)
+        );
+    }
+
+    #[test]
+    fn fit_letterboxes_wide_source_in_narrow_destination() {
+        let (sx, sy) = composition_scale(PresentScalingMode::Fit, SRC_16_9, DST_4_3);
+        assert_eq!(sx, 1.0, "full width is used");
+        let expected = (4.0 / 3.0) / (16.0 / 9.0);
+        assert!((sy - expected).abs() < 1e-6, "got {sy}, want {expected}");
+        assert!(sy < 1.0, "vertical shrink → black bars top and bottom");
+    }
+
+    #[test]
+    fn fit_pillarboxes_narrow_source_in_wide_destination() {
+        let (sx, sy) = composition_scale(PresentScalingMode::Fit, DST_4_3, SRC_16_9);
+        assert_eq!(sy, 1.0, "full height is used");
+        assert!(sx < 1.0, "horizontal shrink → black bars left and right");
+    }
+
+    #[test]
+    fn fill_crops_wide_source_in_narrow_destination() {
+        let (sx, sy) = composition_scale(PresentScalingMode::Fill, SRC_16_9, DST_4_3);
+        assert_eq!(sy, 1.0);
+        assert!(sx > 1.0, "horizontal magnify → left/right edges cropped");
+    }
+
+    #[test]
+    fn fill_crops_narrow_source_in_wide_destination() {
+        let (sx, sy) = composition_scale(PresentScalingMode::Fill, DST_4_3, SRC_16_9);
+        assert_eq!(sx, 1.0);
+        assert!(sy > 1.0, "vertical magnify → top/bottom edges cropped");
+    }
+
+    #[test]
+    fn matched_aspect_is_identity_in_every_mode() {
+        for mode in [
+            PresentScalingMode::Fit,
+            PresentScalingMode::Fill,
+            PresentScalingMode::Stretch,
+        ] {
+            assert_eq!(
+                composition_scale(mode, (1920, 1080), (1280, 720)),
+                (1.0, 1.0),
+                "{mode:?}"
+            );
+        }
+    }
+
+    // ---- GPU tests -----------------------------------------------------------
+
+    use crate::core::rhi::{TextureDescriptor, TextureSourceLayout, TextureUsages};
+    use crate::host_rhi::HostTextureExt;
+    use crate::vulkan::rhi::{HostVulkanBuffer, HostVulkanTexture, VulkanTextureReadback};
+
+    fn try_vulkan_device() -> Option<Arc<HostVulkanDevice>> {
+        match HostVulkanDevice::new() {
+            Ok(d) => Some(d),
+            Err(_) => {
+                println!("Skipping - no Vulkan device available");
+                None
+            }
+        }
+    }
+
+    #[test]
+    fn constructs_for_bgra8_attachment() {
+        let device = match try_vulkan_device() {
+            Some(d) => d,
+            None => return,
+        };
+        let compositor = VulkanPresentCompositor::new(&device, TextureFormat::Bgra8Unorm)
+            .expect("compositor must construct");
+        assert_eq!(compositor.attachment_format(), TextureFormat::Bgra8Unorm);
+    }
+
+    #[test]
+    fn ensure_attachment_format_rebuilds_only_on_change() {
+        let device = match try_vulkan_device() {
+            Some(d) => d,
+            None => return,
+        };
+        let mut compositor =
+            VulkanPresentCompositor::new(&device, TextureFormat::Bgra8Unorm).expect("compositor");
+        assert!(
+            !compositor
+                .ensure_attachment_format(&device, TextureFormat::Bgra8Unorm)
+                .expect("same format"),
+            "same format must not rebuild"
+        );
+        assert!(
+            compositor
+                .ensure_attachment_format(&device, TextureFormat::Rgba8Unorm)
+                .expect("new format"),
+            "format flip must rebuild"
+        );
+        assert_eq!(compositor.attachment_format(), TextureFormat::Rgba8Unorm);
+    }
+
+    #[test]
+    fn offscreen_destination_format_mismatch_is_rejected() {
+        let device = match try_vulkan_device() {
+            Some(d) => d,
+            None => return,
+        };
+        let compositor =
+            VulkanPresentCompositor::new(&device, TextureFormat::Bgra8Unorm).expect("compositor");
+        let destination = make_solid_texture(&device, 64, 64, TextureFormat::Rgba8Unorm, [0; 4]);
+        let source = make_solid_texture(&device, 64, 64, TextureFormat::Bgra8Unorm, [255; 4]);
+        let err = compositor
+            .compose_to_offscreen_texture(
+                &device,
+                0,
+                &destination,
+                &source,
+                VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+                PresentScalingMode::Stretch,
+            )
+            .expect_err("format mismatch must be rejected");
+        assert!(
+            format!("{err}").contains("ensure_attachment_format"),
+            "error names the fix: {err}"
+        );
+    }
+
+    /// Allocate a sampled+attachment-capable texture and fill it with one
+    /// solid color via a staged copy, leaving it in
+    /// `SHADER_READ_ONLY_OPTIMAL`.
+    fn make_solid_texture(
+        device: &Arc<HostVulkanDevice>,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+        color: [u8; 4],
+    ) -> Texture {
+        let descriptor = TextureDescriptor {
+            width,
+            height,
+            format,
+            usage: TextureUsages::COPY_SRC
+                | TextureUsages::COPY_DST
+                | TextureUsages::TEXTURE_BINDING
+                | TextureUsages::RENDER_ATTACHMENT,
+            label: Some("present-compositor-test-texture"),
+        };
+        let host_texture = HostVulkanTexture::new(device, &descriptor).expect("texture");
+        let texture = <Texture as HostTextureExt>::from_vulkan(host_texture);
+
+        let byte_count = (width as u64) * (height as u64) * 4;
+        let staging = HostVulkanBuffer::new(device, byte_count).expect("staging");
+        unsafe {
+            let mut mapped = staging.mapped_ptr();
+            for _ in 0..(width * height) {
+                std::ptr::copy_nonoverlapping(color.as_ptr(), mapped, 4);
+                mapped = mapped.add(4);
+            }
+        }
+
+        let mut recorder =
+            RhiCommandRecorder::new(device, "present-compositor-test-upload").expect("recorder");
+        recorder.begin().expect("begin");
+        recorder
+            .record_image_barrier(
+                &texture,
+                VulkanLayout::UNDEFINED,
+                VulkanLayout::TRANSFER_DST_OPTIMAL,
+                VulkanStage::ALL_COMMANDS,
+                VulkanStage::COPY,
+                VulkanAccess::NONE,
+                VulkanAccess::TRANSFER_WRITE,
+            )
+            .expect("to transfer-dst");
+        recorder
+            .record_copy_buffer_to_image(
+                &staging,
+                &texture,
+                VulkanLayout::TRANSFER_DST_OPTIMAL,
+                super::super::vulkan_command_recorder::ImageCopyRegion::tightly_packed(
+                    width, height,
+                ),
+            )
+            .expect("copy");
+        recorder
+            .record_image_barrier(
+                &texture,
+                VulkanLayout::TRANSFER_DST_OPTIMAL,
+                VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+                VulkanStage::COPY,
+                VulkanStage::FRAGMENT_SHADER,
+                VulkanAccess::TRANSFER_WRITE,
+                VulkanAccess::SHADER_SAMPLED_READ,
+            )
+            .expect("to shader-read");
+        recorder.submit_and_wait().expect("upload submit");
+        texture
+    }
+
+    /// Read `destination` back and return its BGRA bytes.
+    fn read_back(device: &Arc<HostVulkanDevice>, destination: &Texture) -> Vec<u8> {
+        let readback = VulkanTextureReadback::new(
+            device,
+            &crate::core::rhi::TextureReadbackDescriptor {
+                label: "present-compositor-test-readback",
+                format: destination.format(),
+                width: destination.width(),
+                height: destination.height(),
+            },
+        )
+        .expect("readback");
+        let ticket = readback
+            .submit(destination, TextureSourceLayout::ColorAttachment)
+            .expect("readback submit");
+        readback
+            .wait_and_read(ticket, u64::MAX)
+            .expect("readback wait")
+            .to_vec()
+    }
+
+    fn pixel_at(bytes: &[u8], width: u32, x: u32, y: u32) -> [u8; 4] {
+        let offset = ((y * width + x) * 4) as usize;
+        [
+            bytes[offset],
+            bytes[offset + 1],
+            bytes[offset + 2],
+            bytes[offset + 3],
+        ]
+    }
+
+    #[cfg_attr(
+        not(feature = "hardware-tests"),
+        ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md"
+    )]
+    #[test]
+    fn fit_composition_letterboxes_with_black_bars() {
+        let device = match try_vulkan_device() {
+            Some(d) => d,
+            None => return,
+        };
+        // White 2:1 source into a square destination: Fit shrinks vertically —
+        // white band across the middle, black bars top and bottom.
+        let source = make_solid_texture(
+            &device,
+            128,
+            64,
+            TextureFormat::Bgra8Unorm,
+            [255, 255, 255, 255],
+        );
+        let destination =
+            make_solid_texture(&device, 64, 64, TextureFormat::Bgra8Unorm, [0, 0, 0, 255]);
+        let compositor =
+            VulkanPresentCompositor::new(&device, TextureFormat::Bgra8Unorm).expect("compositor");
+        compositor
+            .compose_to_offscreen_texture(
+                &device,
+                0,
+                &destination,
+                &source,
+                VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+                PresentScalingMode::Fit,
+            )
+            .expect("compose");
+
+        let bytes = read_back(&device, &destination);
+        // Bars: y ∈ [0, 16) and [48, 64). Content: y ∈ (16, 48).
+        assert_eq!(
+            pixel_at(&bytes, 64, 32, 4),
+            [0, 0, 0, 255],
+            "top bar is black"
+        );
+        assert_eq!(
+            pixel_at(&bytes, 64, 32, 60),
+            [0, 0, 0, 255],
+            "bottom bar is black"
+        );
+        assert_eq!(
+            pixel_at(&bytes, 64, 32, 32),
+            [255, 255, 255, 255],
+            "center is source content"
+        );
+    }
+
+    #[cfg_attr(
+        not(feature = "hardware-tests"),
+        ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md"
+    )]
+    #[test]
+    fn fill_composition_covers_the_destination() {
+        let device = match try_vulkan_device() {
+            Some(d) => d,
+            None => return,
+        };
+        let source = make_solid_texture(
+            &device,
+            128,
+            64,
+            TextureFormat::Bgra8Unorm,
+            [0, 0, 255, 255],
+        );
+        let destination =
+            make_solid_texture(&device, 64, 64, TextureFormat::Bgra8Unorm, [0, 0, 0, 255]);
+        let compositor =
+            VulkanPresentCompositor::new(&device, TextureFormat::Bgra8Unorm).expect("compositor");
+        compositor
+            .compose_to_offscreen_texture(
+                &device,
+                0,
+                &destination,
+                &source,
+                VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+                PresentScalingMode::Fill,
+            )
+            .expect("compose");
+
+        let bytes = read_back(&device, &destination);
+        for (x, y) in [(0, 0), (63, 0), (0, 63), (63, 63), (32, 32)] {
+            assert_eq!(
+                pixel_at(&bytes, 64, x, y),
+                [0, 0, 255, 255],
+                "({x},{y}) is covered by source content — no bars in Fill"
+            );
+        }
+    }
+
+    #[cfg_attr(
+        not(feature = "hardware-tests"),
+        ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md"
+    )]
+    #[test]
+    fn stretch_composition_fills_regardless_of_aspect() {
+        let device = match try_vulkan_device() {
+            Some(d) => d,
+            None => return,
+        };
+        let source = make_solid_texture(
+            &device,
+            128,
+            32,
+            TextureFormat::Bgra8Unorm,
+            [0, 255, 0, 255],
+        );
+        let destination =
+            make_solid_texture(&device, 64, 64, TextureFormat::Bgra8Unorm, [0, 0, 0, 255]);
+        let compositor =
+            VulkanPresentCompositor::new(&device, TextureFormat::Bgra8Unorm).expect("compositor");
+        compositor
+            .compose_to_offscreen_texture(
+                &device,
+                0,
+                &destination,
+                &source,
+                VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+                PresentScalingMode::Stretch,
+            )
+            .expect("compose");
+
+        let bytes = read_back(&device, &destination);
+        for (x, y) in [(0, 0), (63, 63), (32, 32)] {
+            assert_eq!(
+                pixel_at(&bytes, 64, x, y),
+                [0, 255, 0, 255],
+                "({x},{y}) is stretched source content"
+            );
+        }
+    }
+}

--- a/runtime/streamlib-engine/src/vulkan/rhi/vulkan_present_compositor.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/vulkan_present_compositor.rs
@@ -273,6 +273,23 @@ impl VulkanPresentCompositor {
         scaling: PresentScalingMode,
     ) -> Result<()> {
         self.reject_attachment_format_mismatch(destination.format(), "the offscreen destination")?;
+        // Sampling and rendering the same image is a feedback loop, undefined
+        // without ATTACHMENT_FEEDBACK_LOOP setup this kernel doesn't do.
+        // Compare the underlying VkImages: distinct `Texture` wrappers can
+        // still alias one image.
+        {
+            use crate::host_rhi::HostTextureExt;
+            let source_image = source.vulkan_inner().image();
+            let destination_image = destination.vulkan_inner().image();
+            if source_image.is_some() && source_image == destination_image {
+                return Err(Error::Configuration(
+                    "VulkanPresentCompositor: source and destination are the same VkImage — \
+                     composing a texture onto itself is a feedback loop; render into a \
+                     separate destination"
+                        .into(),
+                ));
+            }
+        }
         if source_current_layout != VulkanLayout::SHADER_READ_ONLY_OPTIMAL {
             let mut recorder = RhiCommandRecorder::new(
                 &self.vulkan_device,
@@ -425,6 +442,29 @@ mod tests {
             "format flip must rebuild"
         );
         assert_eq!(compositor.attachment_format(), TextureFormat::Rgba8Unorm);
+    }
+
+    #[test]
+    fn composing_a_texture_onto_itself_is_rejected() {
+        let Some(device) = try_vulkan_device() else {
+            return;
+        };
+        let compositor =
+            VulkanPresentCompositor::new(&device, TextureFormat::Bgra8Unorm).expect("compositor");
+        let texture = make_solid_texture(&device, 64, 64, TextureFormat::Bgra8Unorm, [0; 4]);
+        let err = compositor
+            .compose_to_offscreen_texture(
+                0,
+                &texture,
+                &texture,
+                VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+                PresentScalingMode::Stretch,
+            )
+            .expect_err("same VkImage as source and destination must be rejected");
+        assert!(
+            format!("{err}").contains("feedback loop"),
+            "error names the hazard: {err}"
+        );
     }
 
     #[test]

--- a/runtime/streamlib-engine/src/vulkan/rhi/vulkan_present_compositor.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/vulkan_present_compositor.rs
@@ -216,9 +216,14 @@ impl VulkanPresentCompositor {
             first_vertex: 0,
             first_instance: 0,
             viewport: Some(Viewport::full(destination_extent.0, destination_extent.1)),
-            scissor: Some(ScissorRect::full(destination_extent.0, destination_extent.1)),
+            scissor: Some(ScissorRect::full(
+                destination_extent.0,
+                destination_extent.1,
+            )),
         };
-        frame.recorder.record_draw(&self.kernel, frame_index, &draw)?;
+        frame
+            .recorder
+            .record_draw(&self.kernel, frame_index, &draw)?;
         frame.end_rendering()
     }
 

--- a/runtime/streamlib-engine/src/vulkan/rhi/vulkan_present_compositor.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/vulkan_present_compositor.rs
@@ -38,29 +38,31 @@ pub enum PresentScalingMode {
     Stretch,
 }
 
-/// Per-axis UV scale for the display-blit fragment shader's
-/// `(uv - 0.5) / scale + 0.5` sampling (out-of-range samples render black).
-pub fn composition_scale(
-    mode: PresentScalingMode,
-    source_extent: (u32, u32),
-    destination_extent: (u32, u32),
-) -> (f32, f32) {
-    let source_aspect = source_extent.0 as f32 / source_extent.1 as f32;
-    let destination_aspect = destination_extent.0 as f32 / destination_extent.1 as f32;
-    match mode {
-        PresentScalingMode::Stretch => (1.0, 1.0),
-        PresentScalingMode::Fit => {
-            if source_aspect > destination_aspect {
-                (1.0, destination_aspect / source_aspect)
-            } else {
-                (source_aspect / destination_aspect, 1.0)
+impl PresentScalingMode {
+    /// Per-axis UV scale for the display-blit fragment shader's
+    /// `(uv - 0.5) / scale + 0.5` sampling (out-of-range samples render black).
+    pub fn uv_scale_for_source_in_destination(
+        self,
+        source_extent: (u32, u32),
+        destination_extent: (u32, u32),
+    ) -> (f32, f32) {
+        let source_aspect = source_extent.0 as f32 / source_extent.1 as f32;
+        let destination_aspect = destination_extent.0 as f32 / destination_extent.1 as f32;
+        match self {
+            PresentScalingMode::Stretch => (1.0, 1.0),
+            PresentScalingMode::Fit => {
+                if source_aspect > destination_aspect {
+                    (1.0, destination_aspect / source_aspect)
+                } else {
+                    (source_aspect / destination_aspect, 1.0)
+                }
             }
-        }
-        PresentScalingMode::Fill => {
-            if source_aspect > destination_aspect {
-                (source_aspect / destination_aspect, 1.0)
-            } else {
-                (1.0, destination_aspect / source_aspect)
+            PresentScalingMode::Fill => {
+                if source_aspect > destination_aspect {
+                    (source_aspect / destination_aspect, 1.0)
+                } else {
+                    (1.0, destination_aspect / source_aspect)
+                }
             }
         }
     }
@@ -69,6 +71,7 @@ pub fn composition_scale(
 /// Owns the display-blit graphics kernel for one attachment format and
 /// records "draw this texture onto that attachment" as a single call.
 pub struct VulkanPresentCompositor {
+    vulkan_device: Arc<HostVulkanDevice>,
     kernel: VulkanGraphicsKernel,
     attachment_format: TextureFormat,
 }
@@ -84,6 +87,21 @@ const DISPLAY_BLIT_FRAG_SPV: &[u8] =
 struct DisplayBlitPushConstants {
     scale: [f32; 2],
     offset: [f32; 2],
+}
+
+/// The vertex-buffer-free fullscreen triangle `display_blit.vert` expects.
+fn fullscreen_triangle_draw_call(
+    viewport: Option<Viewport>,
+    scissor: Option<ScissorRect>,
+) -> DrawCall {
+    DrawCall {
+        vertex_count: 3,
+        instance_count: 1,
+        first_vertex: 0,
+        first_instance: 0,
+        viewport,
+        scissor,
+    }
 }
 
 fn build_display_blit_kernel(
@@ -132,6 +150,7 @@ impl VulkanPresentCompositor {
         attachment_format: TextureFormat,
     ) -> Result<Self> {
         Ok(Self {
+            vulkan_device: Arc::clone(vulkan_device),
             kernel: build_display_blit_kernel(vulkan_device, attachment_format)?,
             attachment_format,
         })
@@ -145,17 +164,51 @@ impl VulkanPresentCompositor {
     /// Rebuild the kernel if `attachment_format` differs from the current one
     /// (a swapchain recreate can flip SDR BGRA8 → HDR10 A2B10G10R10). Returns
     /// whether a rebuild happened.
-    pub fn ensure_attachment_format(
-        &mut self,
-        vulkan_device: &Arc<HostVulkanDevice>,
-        attachment_format: TextureFormat,
-    ) -> Result<bool> {
+    pub fn ensure_attachment_format(&mut self, attachment_format: TextureFormat) -> Result<bool> {
         if attachment_format == self.attachment_format {
             return Ok(false);
         }
-        self.kernel = build_display_blit_kernel(vulkan_device, attachment_format)?;
+        self.kernel = build_display_blit_kernel(&self.vulkan_device, attachment_format)?;
         self.attachment_format = attachment_format;
         Ok(true)
+    }
+
+    fn reject_attachment_format_mismatch(
+        &self,
+        actual: TextureFormat,
+        destination_description: &str,
+    ) -> Result<()> {
+        if actual == self.attachment_format {
+            return Ok(());
+        }
+        Err(Error::GpuError(format!(
+            "VulkanPresentCompositor: kernel was built for {:?} but {destination_description} \
+             is {actual:?} — call ensure_attachment_format first",
+            self.attachment_format
+        )))
+    }
+
+    /// Stage the descriptor-ring slot both arms share: bind `source` at
+    /// binding 0 and stage the scaling push constants.
+    fn stage_source_and_scaling(
+        &self,
+        frame_index: u32,
+        source: &Texture,
+        destination_extent: (u32, u32),
+        scaling: PresentScalingMode,
+    ) -> Result<()> {
+        self.kernel.set_sampled_texture(frame_index, 0, source)?;
+        let (scale_x, scale_y) = scaling.uv_scale_for_source_in_destination(
+            (source.width(), source.height()),
+            destination_extent,
+        );
+        self.kernel.set_push_constants_value(
+            frame_index,
+            &DisplayBlitPushConstants {
+                scale: [scale_x, scale_y],
+                offset: [0.0, 0.0],
+            },
+        )
     }
 
     /// Record the composition of `source` onto an acquired swapchain frame.
@@ -163,8 +216,8 @@ impl VulkanPresentCompositor {
     /// Transitions `source` to `SHADER_READ_ONLY_OPTIMAL` when
     /// `source_current_layout` says it is not there already — the caller's
     /// layout bookkeeping must record that transition. Opens and closes its
-    /// own dynamic-rendering pass (clearing to black), so call it once per
-    /// frame with no pass active.
+    /// own dynamic-rendering pass (clearing to black) on both the success and
+    /// the error path, so call it once per frame with no pass active.
     pub fn compose_to_present_frame(
         &self,
         frame: &mut PresentFrame<'_>,
@@ -172,18 +225,14 @@ impl VulkanPresentCompositor {
         source_current_layout: VulkanLayout,
         scaling: PresentScalingMode,
     ) -> Result<()> {
-        if frame.color_format != self.attachment_format {
-            return Err(Error::GpuError(format!(
-                "VulkanPresentCompositor: kernel was built for {:?} but the acquired \
-                 frame's attachment is {:?} — call ensure_attachment_format after a \
-                 swapchain recreate",
-                self.attachment_format, frame.color_format
-            )));
-        }
+        self.reject_attachment_format_mismatch(
+            frame.color_format,
+            "the acquired frame's attachment",
+        )?;
         let frame_index = frame.frame_index;
         let destination_extent = frame.extent;
 
-        self.kernel.set_sampled_texture(frame_index, 0, source)?;
+        self.stage_source_and_scaling(frame_index, source, destination_extent, scaling)?;
         if source_current_layout != VulkanLayout::SHADER_READ_ONLY_OPTIMAL {
             frame.recorder.record_image_barrier(
                 source,
@@ -196,35 +245,19 @@ impl VulkanPresentCompositor {
             )?;
         }
 
-        let (scale_x, scale_y) = composition_scale(
-            scaling,
-            (source.width(), source.height()),
-            destination_extent,
-        );
-        self.kernel.set_push_constants_value(
-            frame_index,
-            &DisplayBlitPushConstants {
-                scale: [scale_x, scale_y],
-                offset: [0.0, 0.0],
-            },
-        )?;
-
         frame.begin_rendering(Some([0.0, 0.0, 0.0, 1.0]))?;
-        let draw = DrawCall {
-            vertex_count: 3,
-            instance_count: 1,
-            first_vertex: 0,
-            first_instance: 0,
-            viewport: Some(Viewport::full(destination_extent.0, destination_extent.1)),
-            scissor: Some(ScissorRect::full(
+        let draw = fullscreen_triangle_draw_call(
+            Some(Viewport::full(destination_extent.0, destination_extent.1)),
+            Some(ScissorRect::full(
                 destination_extent.0,
                 destination_extent.1,
             )),
-        };
-        frame
-            .recorder
-            .record_draw(&self.kernel, frame_index, &draw)?;
-        frame.end_rendering()
+        );
+        // The pass must close even when the draw fails: an unbalanced
+        // dynamic-rendering pass poisons every later use of this frame.
+        let draw_result = frame.recorder.record_draw(&self.kernel, frame_index, &draw);
+        frame.end_rendering()?;
+        draw_result
     }
 
     /// Compose `source` into `destination` without a window: the offscreen
@@ -233,24 +266,16 @@ impl VulkanPresentCompositor {
     /// `COLOR_ATTACHMENT_OPTIMAL`, `source` in `SHADER_READ_ONLY_OPTIMAL`.
     pub fn compose_to_offscreen_texture(
         &self,
-        vulkan_device: &Arc<HostVulkanDevice>,
         frame_index: u32,
         destination: &Texture,
         source: &Texture,
         source_current_layout: VulkanLayout,
         scaling: PresentScalingMode,
     ) -> Result<()> {
-        if destination.format() != self.attachment_format {
-            return Err(Error::GpuError(format!(
-                "VulkanPresentCompositor: kernel was built for {:?} but the offscreen \
-                 destination is {:?} — call ensure_attachment_format first",
-                self.attachment_format,
-                destination.format()
-            )));
-        }
+        self.reject_attachment_format_mismatch(destination.format(), "the offscreen destination")?;
         if source_current_layout != VulkanLayout::SHADER_READ_ONLY_OPTIMAL {
             let mut recorder = RhiCommandRecorder::new(
-                vulkan_device,
+                &self.vulkan_device,
                 "present-compositor-offscreen-source-barrier",
             )?;
             recorder.begin()?;
@@ -266,35 +291,16 @@ impl VulkanPresentCompositor {
             recorder.submit_and_wait()?;
         }
 
-        self.kernel.set_sampled_texture(frame_index, 0, source)?;
-        let (scale_x, scale_y) = composition_scale(
-            scaling,
-            (source.width(), source.height()),
-            (destination.width(), destination.height()),
-        );
-        self.kernel.set_push_constants_value(
-            frame_index,
-            &DisplayBlitPushConstants {
-                scale: [scale_x, scale_y],
-                offset: [0.0, 0.0],
-            },
-        )?;
-
+        let destination_extent = (destination.width(), destination.height());
+        self.stage_source_and_scaling(frame_index, source, destination_extent, scaling)?;
         self.kernel.offscreen_render(
             frame_index,
             &[OffscreenColorTarget {
                 texture: destination,
                 clear_color: Some([0.0, 0.0, 0.0, 1.0]),
             }],
-            (destination.width(), destination.height()),
-            OffscreenDraw::Draw(DrawCall {
-                vertex_count: 3,
-                instance_count: 1,
-                first_vertex: 0,
-                first_instance: 0,
-                viewport: None,
-                scissor: None,
-            }),
+            destination_extent,
+            OffscreenDraw::Draw(fullscreen_triangle_draw_call(None, None)),
         )
     }
 }
@@ -303,7 +309,7 @@ impl VulkanPresentCompositor {
 mod tests {
     use super::*;
 
-    // ---- composition_scale: pure math, no GPU --------------------------------
+    // ---- scale math: pure, no GPU --------------------------------------------
 
     /// Wide 16:9 source into a narrower 4:3 destination.
     const SRC_16_9: (u32, u32) = (1920, 1080);
@@ -312,14 +318,15 @@ mod tests {
     #[test]
     fn stretch_ignores_aspect() {
         assert_eq!(
-            composition_scale(PresentScalingMode::Stretch, SRC_16_9, DST_4_3),
+            PresentScalingMode::Stretch.uv_scale_for_source_in_destination(SRC_16_9, DST_4_3),
             (1.0, 1.0)
         );
     }
 
     #[test]
     fn fit_letterboxes_wide_source_in_narrow_destination() {
-        let (sx, sy) = composition_scale(PresentScalingMode::Fit, SRC_16_9, DST_4_3);
+        let (sx, sy) =
+            PresentScalingMode::Fit.uv_scale_for_source_in_destination(SRC_16_9, DST_4_3);
         assert_eq!(sx, 1.0, "full width is used");
         let expected = (4.0 / 3.0) / (16.0 / 9.0);
         assert!((sy - expected).abs() < 1e-6, "got {sy}, want {expected}");
@@ -328,21 +335,24 @@ mod tests {
 
     #[test]
     fn fit_pillarboxes_narrow_source_in_wide_destination() {
-        let (sx, sy) = composition_scale(PresentScalingMode::Fit, DST_4_3, SRC_16_9);
+        let (sx, sy) =
+            PresentScalingMode::Fit.uv_scale_for_source_in_destination(DST_4_3, SRC_16_9);
         assert_eq!(sy, 1.0, "full height is used");
         assert!(sx < 1.0, "horizontal shrink → black bars left and right");
     }
 
     #[test]
     fn fill_crops_wide_source_in_narrow_destination() {
-        let (sx, sy) = composition_scale(PresentScalingMode::Fill, SRC_16_9, DST_4_3);
+        let (sx, sy) =
+            PresentScalingMode::Fill.uv_scale_for_source_in_destination(SRC_16_9, DST_4_3);
         assert_eq!(sy, 1.0);
         assert!(sx > 1.0, "horizontal magnify → left/right edges cropped");
     }
 
     #[test]
     fn fill_crops_narrow_source_in_wide_destination() {
-        let (sx, sy) = composition_scale(PresentScalingMode::Fill, DST_4_3, SRC_16_9);
+        let (sx, sy) =
+            PresentScalingMode::Fill.uv_scale_for_source_in_destination(DST_4_3, SRC_16_9);
         assert_eq!(sx, 1.0);
         assert!(sy > 1.0, "vertical magnify → top/bottom edges cropped");
     }
@@ -355,11 +365,18 @@ mod tests {
             PresentScalingMode::Stretch,
         ] {
             assert_eq!(
-                composition_scale(mode, (1920, 1080), (1280, 720)),
+                mode.uv_scale_for_source_in_destination((1920, 1080), (1280, 720)),
                 (1.0, 1.0),
                 "{mode:?}"
             );
         }
+    }
+
+    /// `DisplayBlitPushConstants` is the wire contract with
+    /// `display_blit.frag`'s 16-byte push-constant block.
+    #[test]
+    fn display_blit_push_constants_match_the_shader_block() {
+        assert_eq!(std::mem::size_of::<DisplayBlitPushConstants>(), 16);
     }
 
     // ---- GPU tests -----------------------------------------------------------
@@ -380,9 +397,8 @@ mod tests {
 
     #[test]
     fn constructs_for_bgra8_attachment() {
-        let device = match try_vulkan_device() {
-            Some(d) => d,
-            None => return,
+        let Some(device) = try_vulkan_device() else {
+            return;
         };
         let compositor = VulkanPresentCompositor::new(&device, TextureFormat::Bgra8Unorm)
             .expect("compositor must construct");
@@ -391,21 +407,20 @@ mod tests {
 
     #[test]
     fn ensure_attachment_format_rebuilds_only_on_change() {
-        let device = match try_vulkan_device() {
-            Some(d) => d,
-            None => return,
+        let Some(device) = try_vulkan_device() else {
+            return;
         };
         let mut compositor =
             VulkanPresentCompositor::new(&device, TextureFormat::Bgra8Unorm).expect("compositor");
         assert!(
             !compositor
-                .ensure_attachment_format(&device, TextureFormat::Bgra8Unorm)
+                .ensure_attachment_format(TextureFormat::Bgra8Unorm)
                 .expect("same format"),
             "same format must not rebuild"
         );
         assert!(
             compositor
-                .ensure_attachment_format(&device, TextureFormat::Rgba8Unorm)
+                .ensure_attachment_format(TextureFormat::Rgba8Unorm)
                 .expect("new format"),
             "format flip must rebuild"
         );
@@ -414,9 +429,8 @@ mod tests {
 
     #[test]
     fn offscreen_destination_format_mismatch_is_rejected() {
-        let device = match try_vulkan_device() {
-            Some(d) => d,
-            None => return,
+        let Some(device) = try_vulkan_device() else {
+            return;
         };
         let compositor =
             VulkanPresentCompositor::new(&device, TextureFormat::Bgra8Unorm).expect("compositor");
@@ -424,7 +438,6 @@ mod tests {
         let source = make_solid_texture(&device, 64, 64, TextureFormat::Bgra8Unorm, [255; 4]);
         let err = compositor
             .compose_to_offscreen_texture(
-                &device,
                 0,
                 &destination,
                 &source,
@@ -510,8 +523,41 @@ mod tests {
         texture
     }
 
-    /// Read `destination` back and return its BGRA bytes.
-    fn read_back(device: &Arc<HostVulkanDevice>, destination: &Texture) -> Vec<u8> {
+    /// Compose a solid-colored source into a solid-colored 64×64 destination
+    /// and read the destination back as BGRA bytes.
+    fn compose_solid_source_and_read_back(
+        device: &Arc<HostVulkanDevice>,
+        source_extent: (u32, u32),
+        source_color: [u8; 4],
+        destination_prefill_color: [u8; 4],
+        scaling: PresentScalingMode,
+    ) -> Vec<u8> {
+        let source = make_solid_texture(
+            device,
+            source_extent.0,
+            source_extent.1,
+            TextureFormat::Bgra8Unorm,
+            source_color,
+        );
+        let destination = make_solid_texture(
+            device,
+            64,
+            64,
+            TextureFormat::Bgra8Unorm,
+            destination_prefill_color,
+        );
+        let compositor =
+            VulkanPresentCompositor::new(device, TextureFormat::Bgra8Unorm).expect("compositor");
+        compositor
+            .compose_to_offscreen_texture(
+                0,
+                &destination,
+                &source,
+                VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+                scaling,
+            )
+            .expect("compose");
+
         let readback = VulkanTextureReadback::new(
             device,
             &crate::core::rhi::TextureReadbackDescriptor {
@@ -523,7 +569,7 @@ mod tests {
         )
         .expect("readback");
         let ticket = readback
-            .submit(destination, TextureSourceLayout::ColorAttachment)
+            .submit(&destination, TextureSourceLayout::ColorAttachment)
             .expect("readback submit");
         readback
             .wait_and_read(ticket, u64::MAX)
@@ -541,55 +587,40 @@ mod tests {
         ]
     }
 
+    const BGRA_WHITE: [u8; 4] = [255, 255, 255, 255];
+    const BGRA_BLACK: [u8; 4] = [0, 0, 0, 255];
+    const BGRA_RED: [u8; 4] = [0, 0, 255, 255];
+    const BGRA_GREEN: [u8; 4] = [0, 255, 0, 255];
+
     #[cfg_attr(
         not(feature = "hardware-tests"),
         ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md"
     )]
     #[test]
     fn fit_composition_letterboxes_with_black_bars() {
-        let device = match try_vulkan_device() {
-            Some(d) => d,
-            None => return,
+        let Some(device) = try_vulkan_device() else {
+            return;
         };
-        // White 2:1 source into a square destination: Fit shrinks vertically —
-        // white band across the middle, black bars top and bottom.
-        let source = make_solid_texture(
+        // White 2:1 source into a square destination pre-filled RED: Fit
+        // shrinks vertically — white band across the middle, and the bars
+        // must be the compositor's own black CLEAR, not the pre-fill.
+        let bytes = compose_solid_source_and_read_back(
             &device,
-            128,
-            64,
-            TextureFormat::Bgra8Unorm,
-            [255, 255, 255, 255],
+            (128, 64),
+            BGRA_WHITE,
+            BGRA_RED,
+            PresentScalingMode::Fit,
         );
-        let destination =
-            make_solid_texture(&device, 64, 64, TextureFormat::Bgra8Unorm, [0, 0, 0, 255]);
-        let compositor =
-            VulkanPresentCompositor::new(&device, TextureFormat::Bgra8Unorm).expect("compositor");
-        compositor
-            .compose_to_offscreen_texture(
-                &device,
-                0,
-                &destination,
-                &source,
-                VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
-                PresentScalingMode::Fit,
-            )
-            .expect("compose");
-
-        let bytes = read_back(&device, &destination);
         // Bars: y ∈ [0, 16) and [48, 64). Content: y ∈ (16, 48).
-        assert_eq!(
-            pixel_at(&bytes, 64, 32, 4),
-            [0, 0, 0, 255],
-            "top bar is black"
-        );
+        assert_eq!(pixel_at(&bytes, 64, 32, 4), BGRA_BLACK, "top bar is black");
         assert_eq!(
             pixel_at(&bytes, 64, 32, 60),
-            [0, 0, 0, 255],
+            BGRA_BLACK,
             "bottom bar is black"
         );
         assert_eq!(
             pixel_at(&bytes, 64, 32, 32),
-            [255, 255, 255, 255],
+            BGRA_WHITE,
             "center is source content"
         );
     }
@@ -600,37 +631,20 @@ mod tests {
     )]
     #[test]
     fn fill_composition_covers_the_destination() {
-        let device = match try_vulkan_device() {
-            Some(d) => d,
-            None => return,
+        let Some(device) = try_vulkan_device() else {
+            return;
         };
-        let source = make_solid_texture(
+        let bytes = compose_solid_source_and_read_back(
             &device,
-            128,
-            64,
-            TextureFormat::Bgra8Unorm,
-            [0, 0, 255, 255],
+            (128, 64),
+            BGRA_RED,
+            BGRA_BLACK,
+            PresentScalingMode::Fill,
         );
-        let destination =
-            make_solid_texture(&device, 64, 64, TextureFormat::Bgra8Unorm, [0, 0, 0, 255]);
-        let compositor =
-            VulkanPresentCompositor::new(&device, TextureFormat::Bgra8Unorm).expect("compositor");
-        compositor
-            .compose_to_offscreen_texture(
-                &device,
-                0,
-                &destination,
-                &source,
-                VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
-                PresentScalingMode::Fill,
-            )
-            .expect("compose");
-
-        let bytes = read_back(&device, &destination);
         for (x, y) in [(0, 0), (63, 0), (0, 63), (63, 63), (32, 32)] {
             assert_eq!(
                 pixel_at(&bytes, 64, x, y),
-                [0, 0, 255, 255],
+                BGRA_RED,
                 "({x},{y}) is covered by source content — no bars in Fill"
             );
         }
@@ -642,37 +656,20 @@ mod tests {
     )]
     #[test]
     fn stretch_composition_fills_regardless_of_aspect() {
-        let device = match try_vulkan_device() {
-            Some(d) => d,
-            None => return,
+        let Some(device) = try_vulkan_device() else {
+            return;
         };
-        let source = make_solid_texture(
+        let bytes = compose_solid_source_and_read_back(
             &device,
-            128,
-            32,
-            TextureFormat::Bgra8Unorm,
-            [0, 255, 0, 255],
+            (128, 32),
+            BGRA_GREEN,
+            BGRA_BLACK,
+            PresentScalingMode::Stretch,
         );
-        let destination =
-            make_solid_texture(&device, 64, 64, TextureFormat::Bgra8Unorm, [0, 0, 0, 255]);
-        let compositor =
-            VulkanPresentCompositor::new(&device, TextureFormat::Bgra8Unorm).expect("compositor");
-        compositor
-            .compose_to_offscreen_texture(
-                &device,
-                0,
-                &destination,
-                &source,
-                VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
-                PresentScalingMode::Stretch,
-            )
-            .expect("compose");
-
-        let bytes = read_back(&device, &destination);
         for (x, y) in [(0, 0), (63, 63), (32, 32)] {
             assert_eq!(
                 pixel_at(&bytes, 64, x, y),
-                [0, 255, 0, 255],
+                BGRA_GREEN,
                 "({x},{y}) is stretched source content"
             );
         }

--- a/runtime/streamlib-media-builtins/Cargo.toml
+++ b/runtime/streamlib-media-builtins/Cargo.toml
@@ -1,0 +1,26 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[package]
+name = "streamlib-media-builtins"
+description = "First-party media built-ins: native pre-built blocks (test-pattern source, camera, display) statically linked into the wheel and instantiated from Python by configuration. Written against the SDK's handle-shaped primitives, never engine internals."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license-file.workspace = true
+repository.workspace = true
+
+[lib]
+name = "streamlib_media_builtins"
+path = "src/lib.rs"
+
+[dependencies]
+streamlib = { path = "../../sdk/streamlib-sdk", version = "0.11.0", default-features = false }
+serde = { version = "1.0", features = ["derive"] }
+tracing = { version = "0.1.41", features = ["release_max_level_debug"] }
+
+[dev-dependencies]
+serde_json = { version = "1.0", features = ["preserve_order"] }
+
+[lints]
+workspace = true

--- a/runtime/streamlib-media-builtins/Cargo.toml
+++ b/runtime/streamlib-media-builtins/Cargo.toml
@@ -21,6 +21,8 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+rmp-serde = { workspace = true }
+rmpv = { workspace = true }
 
 [lints]
 workspace = true

--- a/runtime/streamlib-media-builtins/Cargo.toml
+++ b/runtime/streamlib-media-builtins/Cargo.toml
@@ -16,11 +16,11 @@ path = "src/lib.rs"
 
 [dependencies]
 streamlib = { path = "../../sdk/streamlib-sdk", version = "0.11.0", default-features = false }
-serde = { version = "1.0", features = ["derive"] }
-tracing = { version = "0.1.41", features = ["release_max_level_debug"] }
+serde = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-serde_json = { version = "1.0", features = ["preserve_order"] }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/runtime/streamlib-media-builtins/src/lib.rs
+++ b/runtime/streamlib-media-builtins/src/lib.rs
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! First-party media built-ins: native pre-built blocks statically linked
+//! into the wheel and instantiated from Python by configuration
+//! (`rt.add(TestPatternSource)`), whose per-frame paths never enter the
+//! interpreter.
+//!
+//! Written against the SDK's handle-shaped primitives only — pixel-buffer
+//! pool, texture cache, present target — never private engine guts.
+
+pub mod test_pattern_source;
+pub mod video_frame;
+
+pub use test_pattern_source::{TestPatternSource, TestPatternSourceConfig};
+pub use video_frame::VideoFrame;
+
+use streamlib::sdk::processors::PROCESSOR_REGISTRY;
+
+/// Register every media built-in on the process-wide registry. In-process
+/// static registration (the api-server precedent) — no dlopen, and idempotent,
+/// so hosts may call it more than once.
+pub fn register_media_builtin_processor_types() {
+    PROCESSOR_REGISTRY.register::<test_pattern_source::TestPatternSource::Processor>();
+}

--- a/runtime/streamlib-media-builtins/src/test_pattern_source.rs
+++ b/runtime/streamlib-media-builtins/src/test_pattern_source.rs
@@ -113,8 +113,7 @@ impl TestPatternSource::Processor {
             // of a freshly-acquired HOST_VISIBLE pixel buffer, valid for
             // `plane_size` bytes for the buffer's lifetime; the buffer is
             // held on `self` until teardown.
-            let plane =
-                unsafe { std::slice::from_raw_parts_mut(plane_pointer, expected_size) };
+            let plane = unsafe { std::slice::from_raw_parts_mut(plane_pointer, expected_size) };
             fill_smpte_bars_rgba(plane, width, height);
 
             tracing::info!(

--- a/runtime/streamlib-media-builtins/src/test_pattern_source.rs
+++ b/runtime/streamlib-media-builtins/src/test_pattern_source.rs
@@ -1,0 +1,223 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Built-in test-pattern source: SMPTE-style color bars at ~30 fps, no
+//! hardware required — the camera-free way to see a pipeline produce.
+
+use serde::{Deserialize, Serialize};
+use streamlib::sdk::context::{
+    GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
+};
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::media_clock::MediaClock;
+use streamlib::sdk::processors::ContinuousProcessor;
+use streamlib::sdk::rhi::{PixelBuffer, PixelBufferPoolId, PixelFormat};
+
+use crate::video_frame::{ColorInfo, Primaries, Range, Transfer, VideoFrame};
+
+/// Configuration for [`TestPatternSource`]: frame size only — the pattern,
+/// rate, and pixel format are fixed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TestPatternSourceConfig {
+    /// Frame width in pixels.
+    #[serde(default = "default_width")]
+    pub width: u32,
+    /// Frame height in pixels.
+    #[serde(default = "default_height")]
+    pub height: u32,
+}
+
+fn default_width() -> u32 {
+    1280
+}
+
+fn default_height() -> u32 {
+    720
+}
+
+impl Default for TestPatternSourceConfig {
+    fn default() -> Self {
+        Self {
+            width: default_width(),
+            height: default_height(),
+        }
+    }
+}
+
+/// The eight full-saturation SMPTE bars, left to right, as RGBA bytes.
+const SMPTE_BAR_COLORS_RGBA: [[u8; 4]; 8] = [
+    [255, 255, 255, 255], // white
+    [255, 255, 0, 255],   // yellow
+    [0, 255, 255, 255],   // cyan
+    [0, 255, 0, 255],     // green
+    [255, 0, 255, 255],   // magenta
+    [255, 0, 0, 255],     // red
+    [0, 0, 255, 255],     // blue
+    [0, 0, 0, 255],       // black
+];
+
+/// Fill a tightly-packed RGBA plane with vertical SMPTE bars.
+pub(crate) fn fill_smpte_bars_rgba(plane: &mut [u8], width: u32, height: u32) {
+    let bar_count = SMPTE_BAR_COLORS_RGBA.len() as u32;
+    for y in 0..height {
+        for x in 0..width {
+            let bar = ((x * bar_count) / width).min(bar_count - 1) as usize;
+            let offset = ((y * width + x) * 4) as usize;
+            plane[offset..offset + 4].copy_from_slice(&SMPTE_BAR_COLORS_RGBA[bar]);
+        }
+    }
+}
+
+const TEST_PATTERN_FPS: u32 = 30;
+
+#[streamlib::sdk::processor(
+    "@tatolab/media-builtins/TestPatternSource",
+    description = "Synthetic SMPTE-style color-bar source — demos a pipeline with no camera attached",
+    execution = continuous(interval_ms = 33),
+    config = crate::test_pattern_source::TestPatternSourceConfig,
+    output("video", any, description = "Test-pattern video frames"),
+)]
+pub struct TestPatternSource {
+    gpu_context: Option<GpuContextLimitedAccess>,
+    /// The pattern surface, acquired once and republished every tick. The
+    /// held [`PixelBuffer`] keeps the pool slot (and thus the surface id)
+    /// alive for the processor's lifetime.
+    pattern_surface: Option<(PixelBufferPoolId, PixelBuffer)>,
+    pattern_acquire_failed: bool,
+}
+
+impl TestPatternSource::Processor {
+    fn acquire_and_fill_pattern_surface(&mut self) -> Result<PixelBufferPoolId> {
+        if self.pattern_surface.is_none() {
+            let gpu_context = self.gpu_context.as_ref().ok_or_else(|| {
+                Error::Runtime("TestPatternSource: setup() did not stash the GPU context".into())
+            })?;
+            let width = self.config.width;
+            let height = self.config.height;
+            let (pool_id, pixel_buffer) =
+                gpu_context.acquire_pixel_buffer(width, height, PixelFormat::Rgba32)?;
+
+            let plane_pointer = pixel_buffer.plane_base_address(0);
+            let plane_size = pixel_buffer.plane_size(0) as usize;
+            let expected_size = (width as usize) * (height as usize) * 4;
+            if plane_pointer.is_null() || plane_size < expected_size {
+                return Err(Error::Runtime(format!(
+                    "TestPatternSource: pixel-buffer plane unusable (ptr null: {}, size {} < \
+                     expected {})",
+                    plane_pointer.is_null(),
+                    plane_size,
+                    expected_size
+                )));
+            }
+            // SAFETY: `plane_pointer` is the mapped base address of plane 0
+            // of a freshly-acquired HOST_VISIBLE pixel buffer, valid for
+            // `plane_size` bytes for the buffer's lifetime; the buffer is
+            // held on `self` until teardown.
+            let plane =
+                unsafe { std::slice::from_raw_parts_mut(plane_pointer, expected_size) };
+            fill_smpte_bars_rgba(plane, width, height);
+
+            tracing::info!(
+                width,
+                height,
+                surface_id = %pool_id,
+                "TestPatternSource: pattern surface ready"
+            );
+            self.pattern_surface = Some((pool_id, pixel_buffer));
+        }
+        let (pool_id, _pixel_buffer) = self.pattern_surface.as_ref().expect("just filled");
+        Ok(pool_id.clone())
+    }
+}
+
+impl ContinuousProcessor for TestPatternSource::Processor {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.gpu_context = Some(ctx.gpu_limited_access().clone());
+        Ok(())
+    }
+
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.pattern_surface = None;
+        self.gpu_context = None;
+        Ok(())
+    }
+
+    fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        if self.pattern_acquire_failed {
+            return Ok(());
+        }
+        let pool_id = match self.acquire_and_fill_pattern_surface() {
+            Ok(surface_pool_id) => surface_pool_id,
+            Err(acquire_error) => {
+                // Fail once, loudly; stay quiet afterwards instead of
+                // re-erroring every 33 ms tick.
+                self.pattern_acquire_failed = true;
+                return Err(acquire_error);
+            }
+        };
+
+        let frame = VideoFrame {
+            surface_id: pool_id.to_string(),
+            width: self.config.width,
+            height: self.config.height,
+            timestamp_ns: MediaClock::now().as_nanos() as i64,
+            fps: Some(TEST_PATTERN_FPS),
+            color_info: Some(ColorInfo {
+                primaries: Some(Primaries::Bt709),
+                transfer: Some(Transfer::Srgb),
+                matrix: None,
+                range: Some(Range::Full),
+            }),
+            content_light: None,
+            mastering_display: None,
+            texture_layout: None,
+        };
+        self.outputs.write("video", &frame)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bars_cover_the_full_width_in_order() {
+        let (width, height) = (64u32, 4u32);
+        let mut plane = vec![0u8; (width * height * 4) as usize];
+        fill_smpte_bars_rgba(&mut plane, width, height);
+
+        let pixel = |x: u32, y: u32| {
+            let offset = ((y * width + x) * 4) as usize;
+            [
+                plane[offset],
+                plane[offset + 1],
+                plane[offset + 2],
+                plane[offset + 3],
+            ]
+        };
+        // 64px / 8 bars = 8px per bar; sample each bar's center on two rows.
+        for (bar, expected) in SMPTE_BAR_COLORS_RGBA.iter().enumerate() {
+            let x = (bar as u32) * 8 + 4;
+            assert_eq!(pixel(x, 0), *expected, "bar {bar} row 0");
+            assert_eq!(pixel(x, 3), *expected, "bar {bar} row 3");
+        }
+    }
+
+    #[test]
+    fn bars_fill_odd_widths_without_gaps() {
+        let (width, height) = (61u32, 2u32);
+        let mut plane = vec![7u8; (width * height * 4) as usize];
+        fill_smpte_bars_rgba(&mut plane, width, height);
+        // Every alpha byte written → no pixel skipped.
+        for x in 0..width {
+            let offset = ((x * 4) + 3) as usize;
+            assert_eq!(plane[offset], 255, "pixel {x} alpha written");
+        }
+    }
+
+    #[test]
+    fn config_defaults_to_720p() {
+        let config: TestPatternSourceConfig = serde_json::from_str("{}").expect("empty config");
+        assert_eq!((config.width, config.height), (1280, 720));
+    }
+}

--- a/runtime/streamlib-media-builtins/src/test_pattern_source.rs
+++ b/runtime/streamlib-media-builtins/src/test_pattern_source.rs
@@ -5,10 +5,8 @@
 //! hardware required — the camera-free way to see a pipeline produce.
 
 use serde::{Deserialize, Serialize};
-use streamlib::sdk::context::{
-    GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
-};
-use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
+use streamlib::sdk::error::Result;
 use streamlib::sdk::media_clock::MediaClock;
 use streamlib::sdk::processors::ContinuousProcessor;
 use streamlib::sdk::rhi::{PixelBuffer, PixelBufferPoolId, PixelFormat};
@@ -56,19 +54,39 @@ const SMPTE_BAR_COLORS_RGBA: [[u8; 4]; 8] = [
     [0, 0, 0, 255],       // black
 ];
 
-/// Fill a tightly-packed RGBA plane with vertical SMPTE bars.
-pub(crate) fn fill_smpte_bars_rgba(plane: &mut [u8], width: u32, height: u32) {
+/// Fill a tightly-packed RGBA plane with vertical SMPTE bars. Rows are
+/// `width * 4` bytes; a slice shorter than a whole row count fills fewer rows.
+pub(crate) fn fill_smpte_bars_rgba(plane: &mut [u8], width: u32) {
     let bar_count = SMPTE_BAR_COLORS_RGBA.len() as u32;
-    for y in 0..height {
-        for x in 0..width {
-            let bar = ((x * bar_count) / width).min(bar_count - 1) as usize;
-            let offset = ((y * width + x) * 4) as usize;
-            plane[offset..offset + 4].copy_from_slice(&SMPTE_BAR_COLORS_RGBA[bar]);
+    for row in plane.chunks_exact_mut(width as usize * 4) {
+        for (x, pixel) in row.chunks_exact_mut(4).enumerate() {
+            let bar = ((x as u32 * bar_count) / width).min(bar_count - 1) as usize;
+            pixel.copy_from_slice(&SMPTE_BAR_COLORS_RGBA[bar]);
         }
     }
 }
 
 const TEST_PATTERN_FPS: u32 = 30;
+
+/// The one-shot acquisition of the pattern surface, as a single state.
+enum TestPatternSurfaceState {
+    NotYetAcquired,
+    Ready {
+        pool_id: PixelBufferPoolId,
+        /// Held for the processor's lifetime: the [`PixelBuffer`] keeps the
+        /// pool slot (and thus the surface id) alive.
+        _pixel_buffer: PixelBuffer,
+    },
+    /// Acquisition failed once, loudly; every later tick stays quiet instead
+    /// of re-erroring at 30 Hz.
+    AcquireFailedPermanently,
+}
+
+impl Default for TestPatternSurfaceState {
+    fn default() -> Self {
+        Self::NotYetAcquired
+    }
+}
 
 #[streamlib::sdk::processor(
     "@tatolab/media-builtins/TestPatternSource",
@@ -78,81 +96,72 @@ const TEST_PATTERN_FPS: u32 = 30;
     output("video", any, description = "Test-pattern video frames"),
 )]
 pub struct TestPatternSource {
-    gpu_context: Option<GpuContextLimitedAccess>,
-    /// The pattern surface, acquired once and republished every tick. The
-    /// held [`PixelBuffer`] keeps the pool slot (and thus the surface id)
-    /// alive for the processor's lifetime.
-    pattern_surface: Option<(PixelBufferPoolId, PixelBuffer)>,
-    pattern_acquire_failed: bool,
+    surface_state: TestPatternSurfaceState,
 }
 
 impl TestPatternSource::Processor {
-    fn acquire_and_fill_pattern_surface(&mut self) -> Result<PixelBufferPoolId> {
-        if self.pattern_surface.is_none() {
-            let gpu_context = self.gpu_context.as_ref().ok_or_else(|| {
-                Error::Runtime("TestPatternSource: setup() did not stash the GPU context".into())
-            })?;
-            let width = self.config.width;
-            let height = self.config.height;
-            let (pool_id, pixel_buffer) =
-                gpu_context.acquire_pixel_buffer(width, height, PixelFormat::Rgba32)?;
+    fn acquire_and_fill_pattern_surface(
+        &self,
+        ctx: &RuntimeContextLimitedAccess<'_>,
+    ) -> Result<TestPatternSurfaceState> {
+        let width = self.config.width;
+        let height = self.config.height;
+        let (pool_id, pixel_buffer) =
+            ctx.gpu_limited_access()
+                .acquire_pixel_buffer(width, height, PixelFormat::Rgba32)?;
 
-            let plane_pointer = pixel_buffer.plane_base_address(0);
-            let plane_size = pixel_buffer.plane_size(0) as usize;
-            let expected_size = (width as usize) * (height as usize) * 4;
-            if plane_pointer.is_null() || plane_size < expected_size {
-                return Err(Error::Runtime(format!(
-                    "TestPatternSource: pixel-buffer plane unusable (ptr null: {}, size {} < \
-                     expected {})",
-                    plane_pointer.is_null(),
-                    plane_size,
-                    expected_size
-                )));
-            }
-            // SAFETY: `plane_pointer` is the mapped base address of plane 0
-            // of a freshly-acquired HOST_VISIBLE pixel buffer, valid for
-            // `plane_size` bytes for the buffer's lifetime; the buffer is
-            // held on `self` until teardown.
-            let plane = unsafe { std::slice::from_raw_parts_mut(plane_pointer, expected_size) };
-            fill_smpte_bars_rgba(plane, width, height);
-
-            tracing::info!(
-                width,
-                height,
-                surface_id = %pool_id,
-                "TestPatternSource: pattern surface ready"
-            );
-            self.pattern_surface = Some((pool_id, pixel_buffer));
+        let plane_pointer = pixel_buffer.plane_base_address(0);
+        let plane_size = pixel_buffer.plane_size(0) as usize;
+        let expected_size = (width as usize) * (height as usize) * 4;
+        if plane_pointer.is_null() || plane_size < expected_size {
+            return Err(streamlib::sdk::error::Error::Runtime(format!(
+                "TestPatternSource: pixel-buffer plane unusable (ptr null: {}, size {} < \
+                 expected {})",
+                plane_pointer.is_null(),
+                plane_size,
+                expected_size
+            )));
         }
-        let (pool_id, _pixel_buffer) = self.pattern_surface.as_ref().expect("just filled");
-        Ok(pool_id.clone())
+        // SAFETY: `plane_pointer` is the mapped base address of plane 0 of a
+        // freshly-acquired HOST_VISIBLE pixel buffer, valid for `plane_size`
+        // bytes for the buffer's lifetime; the buffer is held in the returned
+        // state until teardown.
+        let plane = unsafe { std::slice::from_raw_parts_mut(plane_pointer, expected_size) };
+        fill_smpte_bars_rgba(plane, width);
+
+        tracing::info!(
+            width,
+            height,
+            surface_id = %pool_id,
+            "TestPatternSource: pattern surface ready"
+        );
+        Ok(TestPatternSurfaceState::Ready {
+            pool_id,
+            _pixel_buffer: pixel_buffer,
+        })
     }
 }
 
 impl ContinuousProcessor for TestPatternSource::Processor {
-    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        self.gpu_context = Some(ctx.gpu_limited_access().clone());
-        Ok(())
-    }
-
     fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        self.pattern_surface = None;
-        self.gpu_context = None;
+        self.surface_state = TestPatternSurfaceState::NotYetAcquired;
         Ok(())
     }
 
-    fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
-        if self.pattern_acquire_failed {
-            return Ok(());
-        }
-        let pool_id = match self.acquire_and_fill_pattern_surface() {
-            Ok(surface_pool_id) => surface_pool_id,
-            Err(acquire_error) => {
-                // Fail once, loudly; stay quiet afterwards instead of
-                // re-erroring every 33 ms tick.
-                self.pattern_acquire_failed = true;
-                return Err(acquire_error);
+    fn process(&mut self, ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        if let TestPatternSurfaceState::NotYetAcquired = self.surface_state {
+            match self.acquire_and_fill_pattern_surface(ctx) {
+                Ok(ready) => self.surface_state = ready,
+                Err(acquire_error) => {
+                    self.surface_state = TestPatternSurfaceState::AcquireFailedPermanently;
+                    return Err(acquire_error);
+                }
             }
+        }
+        let pool_id = match &self.surface_state {
+            TestPatternSurfaceState::Ready { pool_id, .. } => pool_id,
+            TestPatternSurfaceState::AcquireFailedPermanently => return Ok(()),
+            TestPatternSurfaceState::NotYetAcquired => unreachable!("acquired or failed above"),
         };
 
         let frame = VideoFrame {
@@ -183,7 +192,7 @@ mod tests {
     fn bars_cover_the_full_width_in_order() {
         let (width, height) = (64u32, 4u32);
         let mut plane = vec![0u8; (width * height * 4) as usize];
-        fill_smpte_bars_rgba(&mut plane, width, height);
+        fill_smpte_bars_rgba(&mut plane, width);
 
         let pixel = |x: u32, y: u32| {
             let offset = ((y * width + x) * 4) as usize;
@@ -206,7 +215,7 @@ mod tests {
     fn bars_fill_odd_widths_without_gaps() {
         let (width, height) = (61u32, 2u32);
         let mut plane = vec![7u8; (width * height * 4) as usize];
-        fill_smpte_bars_rgba(&mut plane, width, height);
+        fill_smpte_bars_rgba(&mut plane, width);
         // Every alpha byte written → no pixel skipped.
         for x in 0..width {
             let offset = ((x * 4) + 3) as usize;

--- a/runtime/streamlib-media-builtins/src/test_pattern_source.rs
+++ b/runtime/streamlib-media-builtins/src/test_pattern_source.rs
@@ -213,10 +213,9 @@ mod tests {
         let (width, height) = (61u32, 2u32);
         let mut plane = vec![7u8; (width * height * 4) as usize];
         fill_smpte_bars_rgba(&mut plane, width);
-        // Every alpha byte written → no pixel skipped.
-        for x in 0..width {
-            let offset = ((x * 4) + 3) as usize;
-            assert_eq!(plane[offset], 255, "pixel {x} alpha written");
+        // Every alpha byte written, in every row → no pixel skipped.
+        for (pixel_index, pixel) in plane.chunks_exact(4).enumerate() {
+            assert_eq!(pixel[3], 255, "pixel {pixel_index} alpha written");
         }
     }
 

--- a/runtime/streamlib-media-builtins/src/test_pattern_source.rs
+++ b/runtime/streamlib-media-builtins/src/test_pattern_source.rs
@@ -72,7 +72,9 @@ pub(crate) fn fill_smpte_bars_rgba(plane: &mut [u8], width: u32) {
 const TEST_PATTERN_FPS: u32 = 30;
 
 /// The one-shot acquisition of the pattern surface, as a single state.
+#[derive(Default)]
 enum TestPatternSurfaceState {
+    #[default]
     NotYetAcquired,
     Ready {
         pool_id: PixelBufferPoolId,
@@ -83,12 +85,6 @@ enum TestPatternSurfaceState {
     /// Acquisition failed once, loudly; every later tick stays quiet instead
     /// of re-erroring at 30 Hz.
     AcquireFailedPermanently,
-}
-
-impl Default for TestPatternSurfaceState {
-    fn default() -> Self {
-        Self::NotYetAcquired
-    }
 }
 
 #[streamlib::sdk::processor(

--- a/runtime/streamlib-media-builtins/src/test_pattern_source.rs
+++ b/runtime/streamlib-media-builtins/src/test_pattern_source.rs
@@ -57,6 +57,9 @@ const SMPTE_BAR_COLORS_RGBA: [[u8; 4]; 8] = [
 /// Fill a tightly-packed RGBA plane with vertical SMPTE bars. Rows are
 /// `width * 4` bytes; a slice shorter than a whole row count fills fewer rows.
 pub(crate) fn fill_smpte_bars_rgba(plane: &mut [u8], width: u32) {
+    if width == 0 {
+        return;
+    }
     let bar_count = SMPTE_BAR_COLORS_RGBA.len() as u32;
     for row in plane.chunks_exact_mut(width as usize * 4) {
         for (x, pixel) in row.chunks_exact_mut(4).enumerate() {
@@ -158,10 +161,8 @@ impl ContinuousProcessor for TestPatternSource::Processor {
                 }
             }
         }
-        let pool_id = match &self.surface_state {
-            TestPatternSurfaceState::Ready { pool_id, .. } => pool_id,
-            TestPatternSurfaceState::AcquireFailedPermanently => return Ok(()),
-            TestPatternSurfaceState::NotYetAcquired => unreachable!("acquired or failed above"),
+        let TestPatternSurfaceState::Ready { pool_id, .. } = &self.surface_state else {
+            return Ok(());
         };
 
         let frame = VideoFrame {

--- a/runtime/streamlib-media-builtins/src/video_frame.rs
+++ b/runtime/streamlib-media-builtins/src/video_frame.rs
@@ -6,7 +6,9 @@
 //! A link carries a self-describing msgpack named map; these types are the
 //! optional Rust cast for it — never declared on a port, never registered
 //! anywhere. The field names ARE the wire contract: a consumer in any
-//! language reads the same keys from the bag dict.
+//! language reads the same keys from the bag dict. The map is open — a
+//! producer may carry extra keys and this cast ignores them, matching the
+//! Python cast's behavior.
 
 use serde::{Deserialize, Serialize};
 
@@ -17,7 +19,6 @@ use serde::{Deserialize, Serialize};
 /// need "frame N" semantics derive it from timestamps, never from a
 /// cross-processor counter.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct VideoFrame {
     /// GPU surface id, resolved out-of-band via the engine's surface APIs.
     pub surface_id: String,
@@ -25,8 +26,10 @@ pub struct VideoFrame {
     pub width: u32,
     /// Frame height in pixels.
     pub height: u32,
-    /// Machine-monotonic timestamp in nanoseconds — the same epoch V4L2 and
-    /// ALSA driver stamps carry.
+    /// Monotonic timestamp in nanoseconds, stamped via `MediaClock`. Today
+    /// that epoch is process-relative; it becomes the machine's monotonic
+    /// epoch (comparable to V4L2/ALSA driver stamps) when #1725 lands —
+    /// until then, compare stamps only within one process.
     pub timestamp_ns: i64,
     /// H.273 / ITU-T VUI four-tuple describing this frame's color. Absent
     /// means unknown; every consumer treats absent as all-`unspecified`.
@@ -52,7 +55,6 @@ pub struct VideoFrame {
 
 /// Per-frame color description (H.273 / ITU-T VUI 4-tuple).
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct ColorInfo {
     /// YCbCr matrix coefficients (H.273 `MatrixCoefficients`). Absent =
     /// unspecified (H.273 value 2).
@@ -177,7 +179,6 @@ pub enum Transfer {
 
 /// HDR10 content light level (MaxCLL / MaxFALL).
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct ContentLight {
     /// Maximum content light level in cd/m², peak single-pixel.
     pub max_cll: u32,
@@ -187,7 +188,6 @@ pub struct ContentLight {
 
 /// SMPTE ST.2086 mastering display color volume (HDR10 static metadata).
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct MasteringDisplay {
     /// Blue primary x chromaticity in 1/50000 increments.
     pub display_primaries_b_x: u32,
@@ -249,6 +249,21 @@ mod tests {
             !map.contains_key("content_light") && !map.contains_key("mastering_display"),
             "absent optionals stay off the wire"
         );
+    }
+
+    /// The bag map is open: a producer carrying extra keys must not break
+    /// this cast (mirrors the Python cast's behavior).
+    #[test]
+    fn video_frame_cast_ignores_unknown_keys() {
+        let bag = serde_json::json!({
+            "surface_id": "9",
+            "width": 16,
+            "height": 16,
+            "timestamp_ns": 5,
+            "a_future_key": "ignored",
+        });
+        let frame: VideoFrame = serde_json::from_value(bag).expect("open map");
+        assert_eq!(frame.surface_id, "9");
     }
 
     #[test]

--- a/runtime/streamlib-media-builtins/src/video_frame.rs
+++ b/runtime/streamlib-media-builtins/src/video_frame.rs
@@ -1,0 +1,267 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The video-frame bag convention the built-ins produce and consume.
+//!
+//! A link carries a self-describing msgpack named map; these types are the
+//! optional Rust cast for it — never declared on a port, never registered
+//! anywhere. The field names ARE the wire contract: a consumer in any
+//! language reads the same keys from the bag dict.
+
+use serde::{Deserialize, Serialize};
+
+/// Video frame bag: references a GPU surface by id — pixels never ride the
+/// link. `surface_id` is the handoff contract (texture cache in-process,
+/// surface-share DMA-BUF cross-process, pixel buffer for CPU readback);
+/// `timestamp_ns` is the ordering primitive; nothing else. Consumers that
+/// need "frame N" semantics derive it from timestamps, never from a
+/// cross-processor counter.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct VideoFrame {
+    /// GPU surface id, resolved out-of-band via the engine's surface APIs.
+    pub surface_id: String,
+    /// Frame width in pixels.
+    pub width: u32,
+    /// Frame height in pixels.
+    pub height: u32,
+    /// Machine-monotonic timestamp in nanoseconds — the same epoch V4L2 and
+    /// ALSA driver stamps carry.
+    pub timestamp_ns: i64,
+    /// H.273 / ITU-T VUI four-tuple describing this frame's color. Absent
+    /// means unknown; every consumer treats absent as all-`unspecified`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color_info: Option<ColorInfo>,
+    /// HDR10 content light level (MaxCLL / MaxFALL). Absent for SDR streams
+    /// or when not measured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_light: Option<ContentLight>,
+    /// Source frame rate in frames per second, set by the capture device.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fps: Option<u32>,
+    /// SMPTE ST.2086 mastering display color volume (HDR10 static metadata).
+    /// Absent for SDR streams.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mastering_display: Option<MasteringDisplay>,
+    /// Producer's published `VkImageLayout` for this frame's texture, as the
+    /// raw int32 enumerant — a per-frame override of the per-surface layout
+    /// published via surface-share. Absent when the per-surface default holds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub texture_layout: Option<i32>,
+}
+
+/// Per-frame color description (H.273 / ITU-T VUI 4-tuple).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ColorInfo {
+    /// YCbCr matrix coefficients (H.273 `MatrixCoefficients`). Absent =
+    /// unspecified (H.273 value 2).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matrix: Option<Matrix>,
+    /// Color primaries (H.273 `ColourPrimaries`). Absent = unspecified.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primaries: Option<Primaries>,
+    /// Quantization range (VUI `video_full_range_flag`). Absent = unspecified.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub range: Option<Range>,
+    /// Transfer characteristic (H.273 `TransferCharacteristics`). Absent =
+    /// unspecified.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transfer: Option<Transfer>,
+}
+
+/// YCbCr matrix coefficients (H.273 `MatrixCoefficients` enumerant).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Matrix {
+    #[serde(rename = "bt2020_cl")]
+    Bt2020Cl,
+    #[serde(rename = "bt2020_ncl")]
+    Bt2020Ncl,
+    #[serde(rename = "bt470_bg")]
+    Bt470Bg,
+    #[serde(rename = "bt709")]
+    Bt709,
+    #[serde(rename = "chroma_cl")]
+    ChromaCl,
+    #[serde(rename = "chroma_ncl")]
+    ChromaNcl,
+    #[serde(rename = "fcc")]
+    Fcc,
+    #[serde(rename = "ictcp")]
+    Ictcp,
+    #[serde(rename = "identity")]
+    Identity,
+    #[serde(rename = "smpte170m")]
+    Smpte170m,
+    #[serde(rename = "smpte2085")]
+    Smpte2085,
+    #[serde(rename = "smpte240m")]
+    Smpte240m,
+    #[serde(rename = "ycgco")]
+    Ycgco,
+}
+
+/// Color primaries (H.273 `ColourPrimaries` enumerant).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Primaries {
+    #[serde(rename = "bt2020")]
+    Bt2020,
+    #[serde(rename = "bt470_bg")]
+    Bt470Bg,
+    #[serde(rename = "bt470_m")]
+    Bt470M,
+    #[serde(rename = "bt709")]
+    Bt709,
+    #[serde(rename = "ebu3213")]
+    Ebu3213,
+    #[serde(rename = "film")]
+    Film,
+    #[serde(rename = "smpte170m")]
+    Smpte170m,
+    #[serde(rename = "smpte240m")]
+    Smpte240m,
+    #[serde(rename = "smpte428")]
+    Smpte428,
+    #[serde(rename = "smpte431")]
+    Smpte431,
+    #[serde(rename = "smpte432")]
+    Smpte432,
+}
+
+/// Quantization range (H.264/H.265 VUI `video_full_range_flag`:
+/// `limited` = 0, `full` = 1).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Range {
+    #[serde(rename = "full")]
+    Full,
+    #[serde(rename = "limited")]
+    Limited,
+}
+
+/// Transfer characteristic (H.273 `TransferCharacteristics` enumerant).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Transfer {
+    #[serde(rename = "arib_std_b67")]
+    AribStdB67,
+    #[serde(rename = "bt1361")]
+    Bt1361,
+    #[serde(rename = "bt2020_ten_bit")]
+    Bt2020TenBit,
+    #[serde(rename = "bt2020_twelve_bit")]
+    Bt2020TwelveBit,
+    #[serde(rename = "bt709")]
+    Bt709,
+    #[serde(rename = "gamma22")]
+    Gamma22,
+    #[serde(rename = "gamma28")]
+    Gamma28,
+    #[serde(rename = "linear")]
+    Linear,
+    #[serde(rename = "log100")]
+    Log100,
+    #[serde(rename = "log100_sqrt10")]
+    Log100Sqrt10,
+    #[serde(rename = "smpte170m")]
+    Smpte170m,
+    #[serde(rename = "smpte2084")]
+    Smpte2084,
+    #[serde(rename = "smpte240m")]
+    Smpte240m,
+    #[serde(rename = "smpte428")]
+    Smpte428,
+    #[serde(rename = "srgb")]
+    Srgb,
+    #[serde(rename = "xvycc")]
+    Xvycc,
+}
+
+/// HDR10 content light level (MaxCLL / MaxFALL).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContentLight {
+    /// Maximum content light level in cd/m², peak single-pixel.
+    pub max_cll: u32,
+    /// Maximum frame-average light level in cd/m².
+    pub max_fall: u32,
+}
+
+/// SMPTE ST.2086 mastering display color volume (HDR10 static metadata).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MasteringDisplay {
+    /// Blue primary x chromaticity in 1/50000 increments.
+    pub display_primaries_b_x: u32,
+    /// Blue primary y chromaticity in 1/50000 increments.
+    pub display_primaries_b_y: u32,
+    /// Green primary x chromaticity in 1/50000 increments.
+    pub display_primaries_g_x: u32,
+    /// Green primary y chromaticity in 1/50000 increments.
+    pub display_primaries_g_y: u32,
+    /// Red primary x chromaticity in 1/50000 increments.
+    pub display_primaries_r_x: u32,
+    /// Red primary y chromaticity in 1/50000 increments.
+    pub display_primaries_r_y: u32,
+    /// Maximum mastering display luminance in 0.0001 cd/m² increments.
+    pub max_luminance: u32,
+    /// Minimum mastering display luminance in 0.0001 cd/m² increments.
+    pub min_luminance: u32,
+    /// White point x chromaticity in 1/50000 increments.
+    pub white_point_x: u32,
+    /// White point y chromaticity in 1/50000 increments.
+    pub white_point_y: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The bag is a named map: field names are the cross-language contract.
+    /// Locks the wire keys against accidental rename.
+    #[test]
+    fn video_frame_bag_carries_the_documented_keys() {
+        let frame = VideoFrame {
+            surface_id: "42".to_string(),
+            width: 1280,
+            height: 720,
+            timestamp_ns: 123_456_789,
+            fps: Some(30),
+            color_info: Some(ColorInfo {
+                primaries: Some(Primaries::Bt709),
+                transfer: Some(Transfer::Srgb),
+                matrix: None,
+                range: Some(Range::Full),
+            }),
+            content_light: None,
+            mastering_display: None,
+            texture_layout: None,
+        };
+        let value = serde_json::to_value(&frame).expect("serialize");
+        let map = value.as_object().expect("named map");
+        assert_eq!(map["surface_id"], "42");
+        assert_eq!(map["width"], 1280);
+        assert_eq!(map["height"], 720);
+        assert_eq!(map["timestamp_ns"], 123_456_789);
+        assert_eq!(map["fps"], 30);
+        assert_eq!(map["color_info"]["primaries"], "bt709");
+        assert_eq!(map["color_info"]["transfer"], "srgb");
+        assert_eq!(map["color_info"]["range"], "full");
+        assert!(
+            !map.contains_key("content_light") && !map.contains_key("mastering_display"),
+            "absent optionals stay off the wire"
+        );
+    }
+
+    #[test]
+    fn video_frame_round_trips() {
+        let frame = VideoFrame {
+            surface_id: "7".to_string(),
+            width: 640,
+            height: 480,
+            timestamp_ns: 1,
+            ..VideoFrame::default()
+        };
+        let bytes = serde_json::to_vec(&frame).expect("serialize");
+        let back: VideoFrame = serde_json::from_slice(&bytes).expect("deserialize");
+        assert_eq!(back, frame);
+    }
+}

--- a/runtime/streamlib-media-builtins/src/video_frame.rs
+++ b/runtime/streamlib-media-builtins/src/video_frame.rs
@@ -266,6 +266,44 @@ mod tests {
         assert_eq!(frame.surface_id, "9");
     }
 
+    /// The actual wire is msgpack via `rmp_serde::to_vec_named` (what
+    /// `OutputWriter::write` does) — lock the named-map encoding and the
+    /// documented keys at that boundary, not just JSON.
+    #[test]
+    fn video_frame_msgpack_wire_is_a_named_map_with_the_documented_keys() {
+        let frame = VideoFrame {
+            surface_id: "42".to_string(),
+            width: 1280,
+            height: 720,
+            timestamp_ns: 123_456_789,
+            fps: Some(30),
+            ..VideoFrame::default()
+        };
+        let wire_bytes = rmp_serde::to_vec_named(&frame).expect("msgpack serialize");
+        let value: rmpv::Value =
+            rmpv::decode::read_value(&mut wire_bytes.as_slice()).expect("msgpack decode");
+        let rmpv::Value::Map(entries) = value else {
+            panic!("wire value must be a named map, got {value:?}");
+        };
+        let key = |name: &str| {
+            entries
+                .iter()
+                .find(|(k, _)| k.as_str() == Some(name))
+                .unwrap_or_else(|| panic!("wire map missing key {name:?}"))
+                .1
+                .clone()
+        };
+        assert_eq!(key("surface_id").as_str(), Some("42"));
+        assert_eq!(key("width").as_u64(), Some(1280));
+        assert_eq!(key("height").as_u64(), Some(720));
+        assert_eq!(key("timestamp_ns").as_i64(), Some(123_456_789));
+        assert_eq!(key("fps").as_u64(), Some(30));
+
+        let round_tripped: VideoFrame =
+            rmp_serde::from_slice(&wire_bytes).expect("msgpack deserialize");
+        assert_eq!(round_tripped, frame);
+    }
+
     #[test]
     fn video_frame_round_trips() {
         let frame = VideoFrame {

--- a/sdk/streamlib-python-wheel/Cargo.toml
+++ b/sdk/streamlib-python-wheel/Cargo.toml
@@ -42,6 +42,11 @@ pyo3 = { version = "0.29.0", features = ["abi3-py310"] }
 # resolves nothing from source and links no build tooling.
 streamlib = { path = "../streamlib-sdk", version = "0.11.0", default-features = false }
 
+# The native media built-ins the wheel exports as pre-built named blocks
+# (`rt.add(TestPatternSource)`), statically linked so they are current by
+# construction.
+streamlib-media-builtins = { path = "../../runtime/streamlib-media-builtins", version = "0.11.0" }
+
 # The bag's value tree. A bag crosses into Python as ordinary Python data, and
 # `rmpv`'s native `bin` variant is what keeps a byte payload from decoding as
 # text on the way through.

--- a/sdk/streamlib-python-wheel/python/streamlib/__init__.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/__init__.py
@@ -28,22 +28,30 @@ from ._engine import ProcessorOutputPortReference as ProcessorOutputPortReferenc
 from ._engine import Runtime as _NativeRuntime
 from ._engine import RuntimeContextFullAccess as RuntimeContextFullAccess
 from ._engine import RuntimeContextLimitedAccess as RuntimeContextLimitedAccess
+from ._engine import TestPatternSource as TestPatternSource
 from ._engine import media_clock_now_ns as media_clock_now_ns
 from ._engine import monotonic_now_ns as monotonic_now_ns
 from ._processor_declaration import input as input
 from ._processor_declaration import output as output
 from ._processor_declaration import processor as processor
 from .schema_ident import SchemaIdent as SchemaIdent
+from .video_frame import ColorInfo as ColorInfo
+from .video_frame import ContentLight as ContentLight
+from .video_frame import MasteringDisplay as MasteringDisplay
+from .video_frame import VideoFrame as VideoFrame
 
 # `input` and `output` shadow the builtins at module scope on purpose — the
 # authoring grammar reads `@input(...)` / `@output(...)`, matching the old SDK.
 __all__ = [
     "AddedProcessor",
+    "ColorInfo",
+    "ContentLight",
     "GpuContextFullAccess",
     "GpuContextLimitedAccess",
     "GpuSurfaceHandle",
     "LinkInputDataReader",
     "LinkOutputDataWriter",
+    "MasteringDisplay",
     "MonotonicTimer",
     "ProcessorInputPortReference",
     "ProcessorLinkDataAccess",
@@ -52,6 +60,8 @@ __all__ = [
     "RuntimeContextFullAccess",
     "RuntimeContextLimitedAccess",
     "SchemaIdent",
+    "TestPatternSource",
+    "VideoFrame",
     "clock",
     "input",
     "log",

--- a/sdk/streamlib-python-wheel/python/streamlib/__init__.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/__init__.py
@@ -31,7 +31,7 @@ from ._engine import RuntimeContextLimitedAccess as RuntimeContextLimitedAccess
 from ._engine import TestPatternSource as TestPatternSource
 from ._engine import media_clock_now_ns as media_clock_now_ns
 from ._engine import monotonic_now_ns as monotonic_now_ns
-from ._processor_declaration import input as input
+from ._processor_declaration import input as input  # noqa: A004 — deliberate, see below
 from ._processor_declaration import output as output
 from ._processor_declaration import processor as processor
 from .schema_ident import SchemaIdent as SchemaIdent

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -35,10 +35,24 @@ __all__ = [
     "Runtime",
     "RuntimeContextFullAccess",
     "RuntimeContextLimitedAccess",
+    "TestPatternSource",
     "log_event",
     "media_clock_now_ns",
     "monotonic_now_ns",
 ]
+
+@final
+class TestPatternSource:
+    """Native built-in block: SMPTE-style color bars, no hardware.
+
+    A marker type — pass the class itself to `Runtime.add`
+    (`rt.add(TestPatternSource, config={"width": 1280, "height": 720})`);
+    it is never instantiated and its per-frame path never enters the
+    interpreter.
+    """
+
+    # Keeps pytest from collecting the `Test*`-named class in user suites.
+    __test__: Literal[False]
 
 @disjoint_base
 class Runtime:

--- a/sdk/streamlib-python-wheel/python/streamlib/video_frame.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/video_frame.py
@@ -13,8 +13,9 @@ frame references a GPU surface by `surface_id`, resolved out-of-band.
 from __future__ import annotations
 
 import typing
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Literal, Mapping, cast
+from typing import Any, Literal, cast
 
 __all__ = [
     "ColorInfo",
@@ -39,6 +40,23 @@ Matrix = Literal[
 Range = Literal["full", "limited"]
 
 _NestedCast = typing.TypeVar("_NestedCast", "ContentLight", "MasteringDisplay")
+
+
+def _is_plain_int(value: Any) -> bool:
+    """`bool` is an `int` subclass; a frame dimension of `True` is a bug."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _require_int_or_none(key: str, value: Any) -> "int | None":
+    if value is not None and not _is_plain_int(value):
+        raise ValueError(f"bag is not a video frame: {key!r} must be int or absent")
+    return value
+
+
+def _require_mapping_or_none(key: str, value: Any) -> "Mapping[str, Any] | None":
+    if value is not None and not isinstance(value, Mapping):
+        raise ValueError(f"bag is not a video frame: {key!r} must be a mapping or absent")
+    return value
 
 
 def _cast_nested(
@@ -112,7 +130,8 @@ class VideoFrame:
 
     @classmethod
     def from_bag(cls, bag: Mapping[str, Any]) -> "VideoFrame":
-        """Construct from a bag dict, raising on missing or mistyped keys."""
+        """Construct from a bag dict, raising ValueError on missing or
+        mistyped keys — required and optional alike."""
         try:
             surface_id = bag["surface_id"]
             width = bag["width"]
@@ -124,24 +143,26 @@ class VideoFrame:
             ) from None
         if (
             not isinstance(surface_id, str)
-            or not isinstance(width, int)
-            or not isinstance(height, int)
-            or not isinstance(timestamp_ns, int)
+            or not _is_plain_int(width)
+            or not _is_plain_int(height)
+            or not _is_plain_int(timestamp_ns)
         ):
             raise ValueError(
                 "bag is not a video frame: surface_id must be str and "
                 "width/height/timestamp_ns must be int"
             )
 
-        color_info_bag = bag.get("color_info")
-        content_light_bag = bag.get("content_light")
-        mastering_display_bag = bag.get("mastering_display")
+        color_info_bag = _require_mapping_or_none("color_info", bag.get("color_info"))
+        content_light_bag = _require_mapping_or_none("content_light", bag.get("content_light"))
+        mastering_display_bag = _require_mapping_or_none(
+            "mastering_display", bag.get("mastering_display")
+        )
         return cls(
             surface_id=surface_id,
             width=width,
             height=height,
             timestamp_ns=timestamp_ns,
-            fps=bag.get("fps"),
+            fps=_require_int_or_none("fps", bag.get("fps")),
             color_info=(
                 ColorInfo(
                     primaries=cast("Primaries | None", color_info_bag.get("primaries")),
@@ -162,5 +183,5 @@ class VideoFrame:
                 if mastering_display_bag is not None
                 else None
             ),
-            texture_layout=bag.get("texture_layout"),
+            texture_layout=_require_int_or_none("texture_layout", bag.get("texture_layout")),
         )

--- a/sdk/streamlib-python-wheel/python/streamlib/video_frame.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/video_frame.py
@@ -12,6 +12,7 @@ frame references a GPU surface by `surface_id`, resolved out-of-band.
 
 from __future__ import annotations
 
+import typing
 from dataclasses import dataclass
 from typing import Any, Literal, Mapping, cast
 
@@ -36,6 +37,20 @@ Matrix = Literal[
     "fcc", "ictcp", "identity", "smpte170m", "smpte2085", "smpte240m", "ycgco",
 ]
 Range = Literal["full", "limited"]
+
+_NestedCast = typing.TypeVar("_NestedCast", "ContentLight", "MasteringDisplay")
+
+
+def _cast_nested(
+    key: str, nested_type: "type[_NestedCast]", nested_bag: Mapping[str, Any]
+) -> "_NestedCast":
+    """Construct a nested cast, keeping the ValueError contract of `from_bag`."""
+    try:
+        return nested_type(**nested_bag)
+    except TypeError as construction_error:
+        raise ValueError(
+            f"bag is not a video frame: {key!r} is malformed ({construction_error})"
+        ) from None
 
 
 @dataclass(frozen=True)
@@ -80,8 +95,9 @@ class MasteringDisplay:
 class VideoFrame:
     """A video-frame bag, cast: GPU surface reference plus per-frame metadata.
 
-    ``surface_id`` is the handoff contract; ``timestamp_ns`` (machine-monotonic
-    nanoseconds) is the ordering primitive.
+    ``surface_id`` is the handoff contract; ``timestamp_ns`` (monotonic
+    nanoseconds — process-relative until the engine's clock-epoch unification
+    lands) is the ordering primitive.
     """
 
     surface_id: str
@@ -137,12 +153,12 @@ class VideoFrame:
                 else None
             ),
             content_light=(
-                ContentLight(**content_light_bag)
+                _cast_nested("content_light", ContentLight, content_light_bag)
                 if content_light_bag is not None
                 else None
             ),
             mastering_display=(
-                MasteringDisplay(**mastering_display_bag)
+                _cast_nested("mastering_display", MasteringDisplay, mastering_display_bag)
                 if mastering_display_bag is not None
                 else None
             ),

--- a/sdk/streamlib-python-wheel/python/streamlib/video_frame.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/video_frame.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""The optional typed cast for a video-frame bag.
+
+A link carries a self-describing bag (a dict); its keys are the contract and
+reading them directly is always enough. `VideoFrame.from_bag` is the opt-in
+strictness dial for consumers that want construction-time validation and
+attribute access instead of key lookups. Pixels never ride the bag — the
+frame references a GPU surface by `surface_id`, resolved out-of-band.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, cast
+
+__all__ = [
+    "ColorInfo",
+    "ContentLight",
+    "MasteringDisplay",
+    "VideoFrame",
+]
+
+Primaries = Literal[
+    "bt2020", "bt470_bg", "bt470_m", "bt709", "ebu3213", "film",
+    "smpte170m", "smpte240m", "smpte428", "smpte431", "smpte432",
+]
+Transfer = Literal[
+    "arib_std_b67", "bt1361", "bt2020_ten_bit", "bt2020_twelve_bit", "bt709",
+    "gamma22", "gamma28", "linear", "log100", "log100_sqrt10", "smpte170m",
+    "smpte2084", "smpte240m", "smpte428", "srgb", "xvycc",
+]
+Matrix = Literal[
+    "bt2020_cl", "bt2020_ncl", "bt470_bg", "bt709", "chroma_cl", "chroma_ncl",
+    "fcc", "ictcp", "identity", "smpte170m", "smpte2085", "smpte240m", "ycgco",
+]
+Range = Literal["full", "limited"]
+
+
+@dataclass(frozen=True)
+class ColorInfo:
+    """H.273 / ITU-T VUI four-tuple. ``None`` means unspecified."""
+
+    primaries: Primaries | None = None
+    transfer: Transfer | None = None
+    matrix: Matrix | None = None
+    range: Range | None = None
+
+
+@dataclass(frozen=True)
+class ContentLight:
+    """HDR10 content light level (MaxCLL / MaxFALL), in cd/m²."""
+
+    max_cll: int
+    max_fall: int
+
+
+@dataclass(frozen=True)
+class MasteringDisplay:
+    """SMPTE ST.2086 mastering display color volume (HDR10 static metadata).
+
+    Chromaticities are in 1/50000 increments; luminances in 0.0001 cd/m²
+    increments.
+    """
+
+    display_primaries_r_x: int
+    display_primaries_r_y: int
+    display_primaries_g_x: int
+    display_primaries_g_y: int
+    display_primaries_b_x: int
+    display_primaries_b_y: int
+    white_point_x: int
+    white_point_y: int
+    max_luminance: int
+    min_luminance: int
+
+
+@dataclass(frozen=True)
+class VideoFrame:
+    """A video-frame bag, cast: GPU surface reference plus per-frame metadata.
+
+    ``surface_id`` is the handoff contract; ``timestamp_ns`` (machine-monotonic
+    nanoseconds) is the ordering primitive.
+    """
+
+    surface_id: str
+    width: int
+    height: int
+    timestamp_ns: int
+    fps: int | None = None
+    color_info: ColorInfo | None = None
+    content_light: ContentLight | None = None
+    mastering_display: MasteringDisplay | None = None
+    texture_layout: int | None = None
+
+    @classmethod
+    def from_bag(cls, bag: Mapping[str, Any]) -> "VideoFrame":
+        """Construct from a bag dict, raising on missing or mistyped keys."""
+        try:
+            surface_id = bag["surface_id"]
+            width = bag["width"]
+            height = bag["height"]
+            timestamp_ns = bag["timestamp_ns"]
+        except KeyError as missing:
+            raise ValueError(
+                f"bag is not a video frame: missing key {missing.args[0]!r}"
+            ) from None
+        if (
+            not isinstance(surface_id, str)
+            or not isinstance(width, int)
+            or not isinstance(height, int)
+            or not isinstance(timestamp_ns, int)
+        ):
+            raise ValueError(
+                "bag is not a video frame: surface_id must be str and "
+                "width/height/timestamp_ns must be int"
+            )
+
+        color_info_bag = bag.get("color_info")
+        content_light_bag = bag.get("content_light")
+        mastering_display_bag = bag.get("mastering_display")
+        return cls(
+            surface_id=surface_id,
+            width=width,
+            height=height,
+            timestamp_ns=timestamp_ns,
+            fps=bag.get("fps"),
+            color_info=(
+                ColorInfo(
+                    primaries=cast("Primaries | None", color_info_bag.get("primaries")),
+                    transfer=cast("Transfer | None", color_info_bag.get("transfer")),
+                    matrix=cast("Matrix | None", color_info_bag.get("matrix")),
+                    range=cast("Range | None", color_info_bag.get("range")),
+                )
+                if color_info_bag is not None
+                else None
+            ),
+            content_light=(
+                ContentLight(**content_light_bag)
+                if content_light_bag is not None
+                else None
+            ),
+            mastering_display=(
+                MasteringDisplay(**mastering_display_bag)
+                if mastering_display_bag is not None
+                else None
+            ),
+            texture_layout=bag.get("texture_layout"),
+        )

--- a/sdk/streamlib-python-wheel/src/lib.rs
+++ b/sdk/streamlib-python-wheel/src/lib.rs
@@ -10,6 +10,7 @@ mod python_added_processor;
 mod python_bag_conversion;
 mod python_logging;
 mod python_monotonic_timer;
+mod python_native_builtin_blocks;
 mod python_processor_context;
 mod python_processor_declaration;
 mod python_processor_host;
@@ -21,7 +22,9 @@ pub use python_runtime_lifecycle::PythonRuntimeHandle;
 
 #[pymodule]
 fn _engine(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    python_native_builtin_blocks::register_native_builtin_processor_types();
     module.add_class::<PythonRuntimeHandle>()?;
+    module.add_class::<python_native_builtin_blocks::PythonTestPatternSourceBlock>()?;
     module.add_class::<python_added_processor::PythonAddedProcessor>()?;
     module.add_class::<python_added_processor::PythonProcessorOutputPortReference>()?;
     module.add_class::<python_added_processor::PythonProcessorInputPortReference>()?;

--- a/sdk/streamlib-python-wheel/src/python_native_builtin_blocks.rs
+++ b/sdk/streamlib-python-wheel/src/python_native_builtin_blocks.rs
@@ -9,7 +9,6 @@
 //! per-frame paths never enter the interpreter.
 
 use pyo3::prelude::*;
-use streamlib::sdk::descriptors::{Org, Package, TypeName};
 use streamlib::sdk::processors::ProcessorTypeReference;
 
 /// `streamlib.TestPatternSource` — SMPTE-style color bars, no hardware.
@@ -31,17 +30,14 @@ impl PythonTestPatternSourceBlock {
 }
 
 /// Resolve a Python object to a native built-in's type reference, if it is
-/// one of the wheel-exported marker type objects.
+/// one of the wheel-exported marker type objects. The identity comes from the
+/// native processor's own declaration — authored once, in the built-ins crate.
 pub(crate) fn native_builtin_type_reference(
     python: Python<'_>,
     processor_class: &Bound<'_, PyAny>,
 ) -> Option<ProcessorTypeReference> {
     if processor_class.is(python.get_type::<PythonTestPatternSourceBlock>()) {
-        return Some(ProcessorTypeReference::new(
-            Org::new("tatolab").expect("static org ident"),
-            Package::new("media-builtins").expect("static package ident"),
-            TypeName::new("TestPatternSource").expect("static type ident"),
-        ));
+        return Some(streamlib_media_builtins::TestPatternSource::Processor::schema_ident().into());
     }
     None
 }

--- a/sdk/streamlib-python-wheel/src/python_native_builtin_blocks.rs
+++ b/sdk/streamlib-python-wheel/src/python_native_builtin_blocks.rs
@@ -36,7 +36,7 @@ pub(crate) fn native_builtin_type_reference(
     python: Python<'_>,
     processor_class: &Bound<'_, PyAny>,
 ) -> Option<ProcessorTypeReference> {
-    if processor_class.is(&python.get_type::<PythonTestPatternSourceBlock>()) {
+    if processor_class.is(python.get_type::<PythonTestPatternSourceBlock>()) {
         return Some(ProcessorTypeReference::new(
             Org::new("tatolab").expect("static org ident"),
             Package::new("media-builtins").expect("static package ident"),

--- a/sdk/streamlib-python-wheel/src/python_native_builtin_blocks.rs
+++ b/sdk/streamlib-python-wheel/src/python_native_builtin_blocks.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The wheel-exported names for the native media built-ins.
+//!
+//! `streamlib.TestPatternSource` is a marker class: never instantiated, never
+//! subclassed, carrying no Python behavior. `Runtime.add` recognizes the type
+//! object itself and resolves it to the statically-linked native processor —
+//! per-frame paths never enter the interpreter.
+
+use pyo3::prelude::*;
+use streamlib::sdk::descriptors::{Org, Package, TypeName};
+use streamlib::sdk::processors::ProcessorTypeReference;
+
+/// `streamlib.TestPatternSource` — SMPTE-style color bars, no hardware.
+///
+/// No `#[new]`: instantiating a marker is always a mistake, and PyO3's
+/// "no constructor defined" error says so.
+#[pyclass(name = "TestPatternSource", module = "streamlib", frozen)]
+pub(crate) struct PythonTestPatternSourceBlock;
+
+#[pymethods]
+impl PythonTestPatternSourceBlock {
+    /// The class is named `Test*`, which pytest would otherwise collect as a
+    /// test class; this attribute tells it not to.
+    #[classattr]
+    #[pyo3(name = "__test__")]
+    fn dunder_test() -> bool {
+        false
+    }
+}
+
+/// Resolve a Python object to a native built-in's type reference, if it is
+/// one of the wheel-exported marker type objects.
+pub(crate) fn native_builtin_type_reference(
+    python: Python<'_>,
+    processor_class: &Bound<'_, PyAny>,
+) -> Option<ProcessorTypeReference> {
+    if processor_class.is(&python.get_type::<PythonTestPatternSourceBlock>()) {
+        return Some(ProcessorTypeReference::new(
+            Org::new("tatolab").expect("static org ident"),
+            Package::new("media-builtins").expect("static package ident"),
+            TypeName::new("TestPatternSource").expect("static type ident"),
+        ));
+    }
+    None
+}
+
+/// Register the native built-in processor types on the process-wide registry.
+/// Idempotent; called once at module import.
+pub(crate) fn register_native_builtin_processor_types() {
+    streamlib_media_builtins::register_media_builtin_processor_types();
+}

--- a/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
+++ b/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
@@ -25,6 +25,34 @@ use crate::python_added_processor::{
 use crate::python_bag_conversion::python_object_to_json_value;
 use crate::python_processor_registration::register_processor_class;
 
+/// What kind of thing `Runtime.add` was handed, resolved once up front.
+enum AddedProcessorClassKind {
+    /// A wheel-exported marker for a statically-linked native processor.
+    NativeBuiltin(streamlib::sdk::processors::ProcessorTypeReference),
+    /// A class carrying the `@streamlib.processor` declaration.
+    DeclaredPythonClass,
+}
+
+/// Classify `processor_class`, owning the not-a-processor rejection.
+fn classify_processor_class(
+    python: Python<'_>,
+    processor_class: &Bound<'_, PyAny>,
+) -> PyResult<AddedProcessorClassKind> {
+    if let Some(native_reference) =
+        crate::python_native_builtin_blocks::native_builtin_type_reference(python, processor_class)
+    {
+        return Ok(AddedProcessorClassKind::NativeBuiltin(native_reference));
+    }
+    if crate::python_processor_declaration::is_declared_processor_class(processor_class) {
+        return Ok(AddedProcessorClassKind::DeclaredPythonClass);
+    }
+    Err(PyRuntimeError::new_err(format!(
+        "{} is not a processor: decorate the class with @streamlib.processor, and pass \
+         the class itself rather than an instance of it",
+        processor_class
+    )))
+}
+
 /// A reference to the engine outlived the handle, so its threads were not
 /// joined and the teardown contract was not kept.
 struct EngineTeardownIncomplete;
@@ -174,20 +202,7 @@ impl PythonRuntimeHandle {
         config: Option<&Bound<'_, PyDict>>,
         display_name: Option<String>,
     ) -> PyResult<PythonAddedProcessor> {
-        let native_builtin_reference =
-            crate::python_native_builtin_blocks::native_builtin_type_reference(
-                python,
-                processor_class,
-            );
-        if native_builtin_reference.is_none()
-            && !crate::python_processor_declaration::is_declared_processor_class(processor_class)
-        {
-            return Err(PyRuntimeError::new_err(format!(
-                "{} is not a processor: decorate the class with @streamlib.processor, and pass \
-                 the class itself rather than an instance of it",
-                processor_class
-            )));
-        }
+        let class_kind = classify_processor_class(python, processor_class)?;
 
         // Before registering: registration writes to the process-global
         // registry, and a runtime that can no longer be built should not leave
@@ -196,9 +211,11 @@ impl PythonRuntimeHandle {
 
         // Native built-ins were registered at module import; only a Python
         // class needs registering here.
-        let type_reference = match native_builtin_reference {
-            Some(native_reference) => native_reference,
-            None => register_processor_class(python, processor_class)?,
+        let type_reference = match class_kind {
+            AddedProcessorClassKind::NativeBuiltin(native_reference) => native_reference,
+            AddedProcessorClassKind::DeclaredPythonClass => {
+                register_processor_class(python, processor_class)?
+            }
         };
         let configuration = match config {
             Some(config) => python_object_to_json_value(config.as_any())?,

--- a/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
+++ b/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
@@ -174,7 +174,14 @@ impl PythonRuntimeHandle {
         config: Option<&Bound<'_, PyDict>>,
         display_name: Option<String>,
     ) -> PyResult<PythonAddedProcessor> {
-        if !crate::python_processor_declaration::is_declared_processor_class(processor_class) {
+        let native_builtin_reference =
+            crate::python_native_builtin_blocks::native_builtin_type_reference(
+                python,
+                processor_class,
+            );
+        if native_builtin_reference.is_none()
+            && !crate::python_processor_declaration::is_declared_processor_class(processor_class)
+        {
             return Err(PyRuntimeError::new_err(format!(
                 "{} is not a processor: decorate the class with @streamlib.processor, and pass \
                  the class itself rather than an instance of it",
@@ -187,7 +194,12 @@ impl PythonRuntimeHandle {
         // a processor type behind for a node that will never exist.
         let engine = self.engine_being_built("add a processor")?;
 
-        let type_reference = register_processor_class(python, processor_class)?;
+        // Native built-ins were registered at module import; only a Python
+        // class needs registering here.
+        let type_reference = match native_builtin_reference {
+            Some(native_reference) => native_reference,
+            None => register_processor_class(python, processor_class)?,
+        };
         let configuration = match config {
             Some(config) => python_object_to_json_value(config.as_any())?,
             None => serde_json::Value::Null,

--- a/sdk/streamlib-python-wheel/tests/test_native_builtin_blocks.py
+++ b/sdk/streamlib-python-wheel/tests/test_native_builtin_blocks.py
@@ -10,12 +10,19 @@ The graph tests boot a real engine (GPU required); the marker and
 
 import queue
 import threading
-import time
 
 import pytest
 
 import streamlib
-from streamlib import RuntimeContextLimitedAccess, TestPatternSource, VideoFrame, input, processor
+# `input` is streamlib's port decorator — the test reads like user code,
+# which spells it exactly this way.
+from streamlib import (  # noqa: A004
+    RuntimeContextLimitedAccess,
+    TestPatternSource,
+    VideoFrame,
+    input,
+    processor,
+)
 
 PIPELINE_TIMEOUT_SECONDS = 30.0
 ENGINE_TEARDOWN_TIMEOUT_SECONDS = 60.0
@@ -74,6 +81,24 @@ def test_video_frame_rejects_mistyped_fields():
     with pytest.raises(ValueError, match="must be int"):
         VideoFrame.from_bag(
             {"surface_id": "1", "width": 1, "height": 1, "timestamp_ns": "not-an-int"}
+        )
+
+
+def test_video_frame_rejects_mistyped_optional_fields():
+    valid = {"surface_id": "1", "width": 1, "height": 1, "timestamp_ns": 0}
+    with pytest.raises(ValueError, match="fps"):
+        VideoFrame.from_bag({**valid, "fps": "30"})
+    with pytest.raises(ValueError, match="texture_layout"):
+        VideoFrame.from_bag({**valid, "texture_layout": "GENERAL"})
+    with pytest.raises(ValueError, match="color_info"):
+        VideoFrame.from_bag({**valid, "color_info": "srgb"})
+
+
+def test_video_frame_rejects_bool_dimensions():
+    # bool is an int subclass; a width of True is a bug, not a width.
+    with pytest.raises(ValueError, match="must be int"):
+        VideoFrame.from_bag(
+            {"surface_id": "1", "width": True, "height": 1, "timestamp_ns": 0}
         )
 
 

--- a/sdk/streamlib-python-wheel/tests/test_native_builtin_blocks.py
+++ b/sdk/streamlib-python-wheel/tests/test_native_builtin_blocks.py
@@ -77,6 +77,19 @@ def test_video_frame_rejects_mistyped_fields():
         )
 
 
+def test_video_frame_wraps_malformed_nested_metadata_in_the_same_error():
+    with pytest.raises(ValueError, match="content_light"):
+        VideoFrame.from_bag(
+            {
+                "surface_id": "1",
+                "width": 1,
+                "height": 1,
+                "timestamp_ns": 0,
+                "content_light": {"max_cll": 1000, "unexpected_key": 1},
+            }
+        )
+
+
 # ---- the native block in a real graph (GPU) --------------------------------
 
 _received_bags: "queue.Queue[dict]" = queue.Queue()

--- a/sdk/streamlib-python-wheel/tests/test_native_builtin_blocks.py
+++ b/sdk/streamlib-python-wheel/tests/test_native_builtin_blocks.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""The native built-in blocks: marker classes resolved by `rt.add`, frames
+produced by native code the interpreter never enters.
+
+The graph tests boot a real engine (GPU required); the marker and
+`VideoFrame` cast tests are pure Python.
+"""
+
+import queue
+import threading
+import time
+
+import pytest
+
+import streamlib
+from streamlib import RuntimeContextLimitedAccess, TestPatternSource, VideoFrame, input, processor
+
+PIPELINE_TIMEOUT_SECONDS = 30.0
+ENGINE_TEARDOWN_TIMEOUT_SECONDS = 60.0
+
+
+# ---- marker semantics (no GPU) ---------------------------------------------
+
+
+def test_the_marker_class_cannot_be_instantiated():
+    with pytest.raises(TypeError):
+        TestPatternSource()
+
+
+def test_an_undecorated_class_is_still_rejected_by_add():
+    class NotAProcessor:
+        pass
+
+    runtime = streamlib.Runtime()
+    try:
+        with pytest.raises(RuntimeError, match="not a processor"):
+            runtime.add(NotAProcessor)
+    finally:
+        runtime.shutdown()
+
+
+# ---- VideoFrame cast (no GPU) ----------------------------------------------
+
+
+def test_video_frame_casts_a_bag_with_full_metadata():
+    bag = {
+        "surface_id": "42",
+        "width": 1280,
+        "height": 720,
+        "timestamp_ns": 123_456_789,
+        "fps": 30,
+        "color_info": {"primaries": "bt709", "transfer": "srgb", "range": "full"},
+    }
+    frame = VideoFrame.from_bag(bag)
+    assert frame.surface_id == "42"
+    assert (frame.width, frame.height) == (1280, 720)
+    assert frame.timestamp_ns == 123_456_789
+    assert frame.fps == 30
+    assert frame.color_info is not None
+    assert frame.color_info.primaries == "bt709"
+    assert frame.color_info.transfer == "srgb"
+    assert frame.color_info.matrix is None
+    assert frame.content_light is None
+
+
+def test_video_frame_names_the_missing_key():
+    with pytest.raises(ValueError, match="surface_id"):
+        VideoFrame.from_bag({"width": 1, "height": 1, "timestamp_ns": 0})
+
+
+def test_video_frame_rejects_mistyped_fields():
+    with pytest.raises(ValueError, match="must be int"):
+        VideoFrame.from_bag(
+            {"surface_id": "1", "width": 1, "height": 1, "timestamp_ns": "not-an-int"}
+        )
+
+
+# ---- the native block in a real graph (GPU) --------------------------------
+
+_received_bags: "queue.Queue[dict]" = queue.Queue()
+
+
+@processor
+class VideoFrameProbe:
+    """Collects every video-frame bag the native source publishes."""
+
+    @input(delivery_profile="every_sample")
+    def video_from_upstream(self) -> None: ...
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        bag = ctx.inputs.read("video_from_upstream")
+        if bag is not None:
+            _received_bags.put(bag)
+
+
+@pytest.mark.requires_gpu
+def test_the_test_pattern_source_produces_frames_a_python_processor_reads():
+    """The whole built-in mechanism, end to end: marker class → native
+    registration → native production → bag read by an in-process Python
+    processor — no camera, no window."""
+    while not _received_bags.empty():
+        _received_bags.get_nowait()
+
+    runtime = streamlib.Runtime()
+    pattern = runtime.add(TestPatternSource, config={"width": 320, "height": 180})
+    probe = runtime.add(VideoFrameProbe)
+    runtime.connect(pattern.output("video"), probe.input("video_from_upstream"))
+
+    run_thread = threading.Thread(target=runtime.run, name="engine-run")
+    run_thread.start()
+    try:
+        first_bag = _received_bags.get(timeout=PIPELINE_TIMEOUT_SECONDS)
+        second_bag = _received_bags.get(timeout=PIPELINE_TIMEOUT_SECONDS)
+    finally:
+        runtime.shutdown()
+        run_thread.join(timeout=ENGINE_TEARDOWN_TIMEOUT_SECONDS)
+        assert not run_thread.is_alive(), "engine did not tear down in time"
+
+    frame = VideoFrame.from_bag(first_bag)
+    assert (frame.width, frame.height) == (320, 180)
+    assert frame.surface_id, "surface_id names the pattern surface"
+    assert frame.fps == 30
+    assert frame.color_info is not None and frame.color_info.transfer == "srgb"
+
+    later_frame = VideoFrame.from_bag(second_bag)
+    assert later_frame.surface_id == frame.surface_id, (
+        "the pattern surface is acquired once and republished"
+    )
+    assert later_frame.timestamp_ns > frame.timestamp_ns, (
+        "timestamps are the ordering primitive and must advance"
+    )
+
+
+def test_display_name_defaults_to_the_type_name():
+    runtime = streamlib.Runtime()
+    try:
+        pattern = runtime.add(TestPatternSource)
+        assert pattern.display_name == "TestPatternSource"
+    finally:
+        runtime.shutdown()


### PR DESCRIPTION
## Summary

PR 1 of a two-PR stack for #1709. The hardware-free half: the present-composition RHI primitive, the `streamlib-media-builtins` crate with the first native block, and the Python surface that makes `rt.add(TestPatternSource)` work — proving the whole built-in mechanism end to end (marker class → in-process native registration → native frame production → bag read by a Python processor) with no camera and no window. PR 2 (stacked: `feat/1709-camera-display-blocks`) carries the V4L2 camera, the greenfield display, the human-shaped errors, and the live rig demo.

- **`VulkanPresentCompositor`** (`runtime/streamlib-engine/src/vulkan/rhi/`): absorbs the display-blit draw the old display assembled by hand — kernel build against the attachment format, format-flip rebuild, source barrier, fit/fill/stretch scale math, fullscreen-triangle draw. Present-frame arm + offscreen arm; composition correctness locked by offscreen readback tests on real hardware (letterbox bars prove the compositor's own CLEAR, not the pre-fill).
- **`runtime/streamlib-media-builtins`**: new workspace crate on the api-server precedent (depends on `streamlib` SDK, `PROCESSOR_REGISTRY.register::<T>()`, statically linked, never dlopen'd). Hand-written serde `VideoFrame` + H.273 color family — wire-compatible with the incumbent bag convention except `timestamp_ns` becomes **integer** nanoseconds (owner decision). `TestPatternSource`: SMPTE bars into a pooled pixel buffer once, republished at ~30 fps, ports schema-free (`any`).
- **Wheel**: `streamlib.TestPatternSource` marker pyclass (never instantiated, `__test__ = False` so pytest never collects the `Test*` name); `Runtime.add` classifies marker vs `@processor` class and resolves the marker to the native registry entry — identity read from the generated `Processor::schema_ident()`, authored once. `streamlib.VideoFrame` pure-Python dataclass cast (`from_bag`) — the bag dict stays the documented contract; the cast is the opt-in strictness dial.

## Closes

(none — #1709 closes with PR 2)

## Exit criteria (this PR's slice of #1709)

- Engine present-composition call, test-first at the offscreen seam ✅ (fit/fill/stretch verified by pixel readback on hardware)
- Test-pattern fallback source so the pipeline demos hardware-free ✅ (`rt.add(TestPatternSource)` → frames flow, no camera)
- Built-ins written against handle-shaped primitives only ✅ (pixel-buffer pool + registry; no engine guts)
- Per-frame paths never enter the interpreter ✅ (native vtable dispatch; Python is construction-time only)
- Explicit `delivery_profile` on every input port per the ticket comment ✅ (the source has only an output; the test probe declares `every_sample` explicitly)

## Test plan

- `cargo test -p streamlib-engine --lib vulkan_present_compositor --features hardware-tests -- --test-threads=1` — 13 passed on the rig (composition pixel-correctness included)
- `cargo test -p streamlib-media-builtins` — 6 passed
- Wheel: 81 pytest (incl. the GPU end-to-end mechanism test), `mypy.stubtest` clean, pyright clean
- Gates: `check-boundaries`, `lint-logging`, BUSL headers — all green
- Reviews: `review-pr` PASS and `rust-craftsmanship-reviewer` APPROVE (A-) after one fix round (findings: public-surface trim, balanced render pass on the error path, device ownership, single-source identity, open bag map, honest timestamp docs — all applied)

## Notes for owner

1. **PR 2 owes the `GpuContextFullAccess::create_present_compositor` seam.** The compositor's present-frame arm is host-internal in this PR (no reachable consumer yet); the display built-in must reach it through a handle-shaped `create_*` seam mirroring `create_present_target`, or it would violate the §Media I/O layering DECIDED. PR 2 carries that seam next to its consumer.
2. **`timestamp_ns` epoch is process-relative until #1725 lands** — documented as such in both language casts. Consumers comparing stamps against driver stamps depend on #1725; the producer already stamps through the `MediaClock` seam so #1725's fix flows through without touching this code.
3. **`TestPatternSource` goes permanently quiet after one acquire failure** (one loud error, then healthy-but-silent at 30 Hz). Deliberate for now; PR 2's human-shaped-errors slice revisits it.
4. The incumbent `packages/camera`/`packages/display` are untouched reference material (deny-ruled consumers); their hand-assembled blit copy remains until those trees are deleted by Change B.
5. Wheel dev-build version string still reads 0.10.3 locally (release-please owns real versioning; no action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a native SMPTE test-pattern video source producing 30 FPS frames without hardware.
  * Added video-frame metadata support, including color, HDR, timing, and texture details.
  * Exposed test-pattern and video-frame types through the Python SDK.
  * Added Vulkan presentation compositing with Fit, Fill, and Stretch scaling modes.
* **Bug Fixes**
  * Improved validation for malformed video-frame metadata and unsupported rendering feedback loops.
* **Tests**
  * Added coverage for frame generation, metadata serialization, scaling, validation, and Python integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->