### PR TITLE
feat(media): CameraSource + DisplayWindow built-ins — live camera to window, verified on the rig

### DIFF
--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -28,6 +28,7 @@ jobs:
           sudo apt-get install -y \
             pkg-config \
             protobuf-compiler \
+            libclang-dev \
             libvulkan-dev \
             glslc \
             python3-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
           sudo apt-get install -y \
             pkg-config \
             protobuf-compiler \
+            libclang-dev \
             libvulkan-dev \
             glslc
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,6 +417,29 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
+version = "0.65.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
@@ -1789,6 +1812,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2453,6 +2485,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128fmt"
@@ -3468,6 +3506,12 @@ dependencies = [
  "digest",
  "hmac",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -5329,12 +5373,15 @@ dependencies = [
 name = "streamlib-media-builtins"
 version = "0.11.0"
 dependencies = [
+ "libc",
  "rmp-serde",
  "rmpv",
  "serde",
  "serde_json",
  "streamlib",
  "tracing",
+ "uuid",
+ "v4l",
 ]
 
 [[package]]
@@ -6198,6 +6245,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "v4l"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8fbfea44a46799d62c55323f3c55d06df722fbe577851d848d328a1041c3403"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "v4l2-sys-mit",
+]
+
+[[package]]
+name = "v4l2-sys-mit"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6779878362b9bacadc7893eac76abe69612e8837ef746573c4a5239daf11990b"
+dependencies = [
+ "bindgen 0.65.1",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6592,6 +6659,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5374,6 +5374,7 @@ name = "streamlib-media-builtins"
 version = "0.11.0"
 dependencies = [
  "libc",
+ "raw-window-handle",
  "rmp-serde",
  "rmpv",
  "serde",
@@ -5382,6 +5383,7 @@ dependencies = [
  "tracing",
  "uuid",
  "v4l",
+ "winit",
 ]
 
 [[package]]

--- a/runtime/streamlib-engine/src/core/context/gpu_context.rs
+++ b/runtime/streamlib-engine/src/core/context/gpu_context.rs
@@ -1418,6 +1418,24 @@ impl GpuContext {
         vsync: bool,
         color_traits: Option<&crate::core::color::ColorTraits>,
     ) -> Result<crate::vulkan::rhi::PresentTarget> {
+        let target =
+            self.create_vulkan_present_target(window, width, height, vsync, color_traits)?;
+        Ok(crate::vulkan::rhi::PresentTarget::from_target(target))
+    }
+
+    /// The host-side flavor of [`Self::create_present_target`]: mints the
+    /// raw [`crate::vulkan::rhi::VulkanPresentTarget`] without the ABI-safe
+    /// wrapper. In-process consumers (via
+    /// [`GpuContextFullAccess::create_present_target`]) drive it directly.
+    #[cfg(target_os = "linux")]
+    pub fn create_vulkan_present_target(
+        &self,
+        window: &(impl raw_window_handle::HasWindowHandle + raw_window_handle::HasDisplayHandle),
+        width: u32,
+        height: u32,
+        vsync: bool,
+        color_traits: Option<&crate::core::color::ColorTraits>,
+    ) -> Result<crate::vulkan::rhi::VulkanPresentTarget> {
         tracing::debug!(
             rhi_op = "create_present_target",
             width,
@@ -1425,16 +1443,29 @@ impl GpuContext {
             vsync,
             "GpuContext::create_present_target"
         );
-        let vulkan_device = &self.device.inner;
-        let target = crate::vulkan::rhi::VulkanPresentTarget::new(
-            vulkan_device,
+        crate::vulkan::rhi::VulkanPresentTarget::new(
+            &self.device.inner,
             window,
             width,
             height,
             vsync,
             color_traits,
-        )?;
-        Ok(crate::vulkan::rhi::PresentTarget::from_target(target))
+        )
+    }
+
+    /// Build a [`crate::vulkan::rhi::VulkanPresentCompositor`] for
+    /// `attachment_format`.
+    #[cfg(target_os = "linux")]
+    pub fn create_present_compositor(
+        &self,
+        attachment_format: crate::core::rhi::TextureFormat,
+    ) -> Result<crate::vulkan::rhi::VulkanPresentCompositor> {
+        tracing::debug!(
+            rhi_op = "create_present_compositor",
+            ?attachment_format,
+            "GpuContext::create_present_compositor"
+        );
+        crate::vulkan::rhi::VulkanPresentCompositor::new(&self.device.inner, attachment_format)
     }
 
     /// Create a Vulkan video session — the privileged
@@ -3705,10 +3736,10 @@ impl GpuContextLimitedAccess {
 }
 
 impl GpuContextFullAccess {
-    /// Construct an OPAQUE_FD-exportable timeline semaphore (the FullAccess
-    /// entry point [`GpuContext::create_exportable_timeline_semaphore`]
-    /// documents). In-process (Boxed) only — the cdylib scope-token path has
-    /// no vtable slot for it.
+    /// Construct an OPAQUE_FD-exportable timeline semaphore — the
+    /// FullAccess-callable entry point over
+    /// [`GpuContext::create_exportable_timeline_semaphore`]. In-process
+    /// (Boxed) only — the cdylib scope-token path has no vtable slot for it.
     #[cfg(target_os = "linux")]
     pub fn create_exportable_timeline_semaphore(
         &self,
@@ -3738,8 +3769,7 @@ impl GpuContextFullAccess {
         color_traits: Option<&crate::core::color::ColorTraits>,
     ) -> Result<crate::vulkan::rhi::VulkanPresentTarget> {
         match self.handle_kind {
-            HandleKind::Boxed => crate::vulkan::rhi::VulkanPresentTarget::new(
-                &self.host_inner().device.inner,
+            HandleKind::Boxed => self.host_inner().create_vulkan_present_target(
                 window,
                 width,
                 height,
@@ -3764,10 +3794,9 @@ impl GpuContextFullAccess {
         attachment_format: crate::core::rhi::TextureFormat,
     ) -> Result<crate::vulkan::rhi::VulkanPresentCompositor> {
         match self.handle_kind {
-            HandleKind::Boxed => crate::vulkan::rhi::VulkanPresentCompositor::new(
-                &self.host_inner().device.inner,
-                attachment_format,
-            ),
+            HandleKind::Boxed => self
+                .host_inner()
+                .create_present_compositor(attachment_format),
             HandleKind::ScopeToken => Err(Error::GpuError(
                 "create_present_compositor: available in-process only".into(),
             )),
@@ -5680,6 +5709,41 @@ mod tests {
         assert_eq!(resolved.height(), 480);
 
         println!("Texture cache: register + resolve OK");
+    }
+
+    /// A same-process producer that publishes only a pixel buffer (no
+    /// texture registration) must resolve through the pool's local cache —
+    /// the cross-process surface store cannot serve OPAQUE_FD-backed buffers
+    /// to a host-side consumer at all. Mental-revert: removing the
+    /// pool-cache arm in `resolve_texture_registration_by_surface_id`'s
+    /// Path 3 makes this test fail with "No texture or pixel buffer found".
+    /// GPU-gated: skips when no device is present.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn same_process_pixel_buffer_resolves_without_the_surface_store() {
+        let gpu = match GpuContext::init_for_platform() {
+            Ok(g) => g,
+            Err(_) => {
+                println!("Skipping - no GPU device available");
+                return;
+            }
+        };
+
+        let (pool_id, pixel_buffer) = gpu
+            .acquire_pixel_buffer(16, 16, PixelFormat::Rgba32)
+            .expect("acquire pixel buffer");
+
+        let registration = gpu
+            .resolve_texture_registration_by_surface_id(&pool_id.to_string(), None, 16, 16)
+            .expect("pixel-buffer-only surface must resolve same-process");
+        assert_eq!(registration.texture().width(), 16);
+        assert_eq!(registration.texture().height(), 16);
+        assert_eq!(
+            registration.current_layout(),
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+            "the refresh upload leaves the texture shader-readable"
+        );
+        drop(pixel_buffer);
     }
 
     /// #1262 OPAQUE_FD/CUDA producer surface — positive mint/export/wrap

--- a/runtime/streamlib-engine/src/core/context/gpu_context.rs
+++ b/runtime/streamlib-engine/src/core/context/gpu_context.rs
@@ -3716,6 +3716,56 @@ impl GpuContextFullAccess {
         }
     }
 
+    /// Build a swapchain-backed [`crate::vulkan::rhi::VulkanPresentTarget`]
+    /// from a native window handle. In-process (Boxed) only — cdylib
+    /// consumers use the plugin-ABI `create_present_target` slot, which
+    /// hands out the ABI-safe handle flavor instead.
+    #[cfg(target_os = "linux")]
+    pub fn create_present_target(
+        &self,
+        window: &(impl raw_window_handle::HasWindowHandle + raw_window_handle::HasDisplayHandle),
+        width: u32,
+        height: u32,
+        vsync: bool,
+        color_traits: Option<&crate::core::color::ColorTraits>,
+    ) -> Result<crate::vulkan::rhi::VulkanPresentTarget> {
+        match self.handle_kind {
+            HandleKind::Boxed => crate::vulkan::rhi::VulkanPresentTarget::new(
+                &self.host_inner().device.inner,
+                window,
+                width,
+                height,
+                vsync,
+                color_traits,
+            ),
+            HandleKind::ScopeToken => Err(Error::GpuError(
+                "create_present_target: available in-process only — cdylib consumers use \
+                 the plugin-ABI present-target slot"
+                    .into(),
+            )),
+        }
+    }
+
+    /// Build a [`crate::vulkan::rhi::VulkanPresentCompositor`] for
+    /// `attachment_format` (typically the present target's
+    /// [`color_format`](crate::vulkan::rhi::VulkanPresentTarget::color_format)).
+    /// In-process (Boxed) only.
+    #[cfg(target_os = "linux")]
+    pub fn create_present_compositor(
+        &self,
+        attachment_format: crate::core::rhi::TextureFormat,
+    ) -> Result<crate::vulkan::rhi::VulkanPresentCompositor> {
+        match self.handle_kind {
+            HandleKind::Boxed => crate::vulkan::rhi::VulkanPresentCompositor::new(
+                &self.host_inner().device.inner,
+                attachment_format,
+            ),
+            HandleKind::ScopeToken => Err(Error::GpuError(
+                "create_present_compositor: available in-process only".into(),
+            )),
+        }
+    }
+
     /// Wait for the GPU device to become idle.
     ///
     /// Mode-routed; see [`Self::create_compute_kernel`] for the

--- a/runtime/streamlib-engine/src/core/context/gpu_context.rs
+++ b/runtime/streamlib-engine/src/core/context/gpu_context.rs
@@ -831,12 +831,20 @@ impl GpuContext {
         // silently render the previous frame.
         #[cfg(target_os = "linux")]
         {
-            let buffer = {
-                let surface_store = self.surface_store.lock().unwrap();
-                surface_store
-                    .as_ref()
-                    .and_then(|store| store.lookup_buffer(surface_id).ok())
-            };
+            // Same-process pool first: a producer that published only a
+            // pixel buffer (no texture registration) resolves through the
+            // pool's local cache without any socket round-trip — the
+            // cross-process store can't serve OPAQUE_FD-backed buffers to a
+            // host-side consumer at all.
+            let buffer = self
+                .pixel_buffer_pool_manager
+                .get_from_cache(surface_id)
+                .or_else(|| {
+                    let surface_store = self.surface_store.lock().unwrap();
+                    surface_store
+                        .as_ref()
+                        .and_then(|store| store.lookup_buffer(surface_id).ok())
+                });
             if let Some(buffer) = buffer {
                 let texture =
                     self.refresh_pixel_buffer_texture(surface_id, &buffer, width, height)?;

--- a/runtime/streamlib-engine/src/core/context/gpu_context.rs
+++ b/runtime/streamlib-engine/src/core/context/gpu_context.rs
@@ -3697,6 +3697,25 @@ impl GpuContextLimitedAccess {
 }
 
 impl GpuContextFullAccess {
+    /// Construct an OPAQUE_FD-exportable timeline semaphore (the FullAccess
+    /// entry point [`GpuContext::create_exportable_timeline_semaphore`]
+    /// documents). In-process (Boxed) only — the cdylib scope-token path has
+    /// no vtable slot for it.
+    #[cfg(target_os = "linux")]
+    pub fn create_exportable_timeline_semaphore(
+        &self,
+        initial_value: u64,
+    ) -> Result<std::sync::Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>> {
+        match self.handle_kind {
+            HandleKind::Boxed => self
+                .host_inner()
+                .create_exportable_timeline_semaphore(initial_value),
+            HandleKind::ScopeToken => Err(Error::GpuError(
+                "create_exportable_timeline_semaphore: available in-process only".into(),
+            )),
+        }
+    }
+
     /// Wait for the GPU device to become idle.
     ///
     /// Mode-routed; see [`Self::create_compute_kernel`] for the
@@ -5100,7 +5119,8 @@ impl GpuContextFullAccess {
             HandleKind::ScopeToken => {
                 if self.vtable.is_null() {
                     return Err(Error::GpuError(
-                        "create_opaque_fd_export_buffer: GpuContextFullAccess has null vtable".into(),
+                        "create_opaque_fd_export_buffer: GpuContextFullAccess has null vtable"
+                            .into(),
                     ));
                 }
                 let mut out_buffer: std::mem::MaybeUninit<crate::core::rhi::StorageBuffer> =
@@ -5265,15 +5285,11 @@ impl GpuContextFullAccess {
                     ));
                 }
                 let (consume_handle, consume_value) = match consume_done {
-                    Some((sem, value)) => {
-                        (sem as *const _ as *const std::ffi::c_void, value)
-                    }
+                    Some((sem, value)) => (sem as *const _ as *const std::ffi::c_void, value),
                     None => (std::ptr::null(), 0),
                 };
                 let (produce_handle, produce_value) = match produce_done {
-                    Some((sem, value)) => {
-                        (sem as *const _ as *const std::ffi::c_void, value)
-                    }
+                    Some((sem, value)) => (sem as *const _ as *const std::ffi::c_void, value),
                     None => (std::ptr::null(), 0),
                 };
                 let mut err_buf = [0u8; 512];
@@ -5303,7 +5319,6 @@ impl GpuContextFullAccess {
             }
         }
     }
-
 
     /// Read-once GPU capability snapshot. Backs the camera processor's
     /// vendor-name / external-memory / cross-device-DMA-BUF-probe
@@ -5674,7 +5689,13 @@ mod tests {
         // Wrap → PixelBuffer sharing the same allocation, with the
         // caller's pixel-shape metadata cached.
         let pixel_buffer = gpu
-            .wrap_storage_buffer_as_pixel_buffer(&storage, W, H, BPP, crate::core::rhi::PixelFormat::Bgra32)
+            .wrap_storage_buffer_as_pixel_buffer(
+                &storage,
+                W,
+                H,
+                BPP,
+                crate::core::rhi::PixelFormat::Bgra32,
+            )
             .expect("wrap_storage_buffer_as_pixel_buffer failed");
         assert_eq!(pixel_buffer.width, W);
         assert_eq!(pixel_buffer.height, H);
@@ -5875,7 +5896,10 @@ mod tests {
         for i in 0..BYTES as usize {
             let got = unsafe { *dst_ptr.add(i) };
             let want = (i % 251) as u8;
-            assert_eq!(got, want, "destination byte {i} mismatch: got {got}, want {want}");
+            assert_eq!(
+                got, want,
+                "destination byte {i} mismatch: got {got}, want {want}"
+            );
         }
 
         println!(

--- a/runtime/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
@@ -886,8 +886,9 @@ impl RhiCommandRecorderInner {
     /// The begun-but-unsubmitted command buffer is discarded at that
     /// `begin()`'s `reset_command_buffer`. Used when a frame is abandoned
     /// after `begin()` but before submit (e.g. swapchain `OUT_OF_DATE_KHR`
-    /// on acquire), so the recorder slot is reusable next attempt.
-    pub(crate) fn abort_recording(&mut self) {
+    /// on acquire, or a failed per-frame record), so the recorder slot is
+    /// reusable next attempt. Harmless when nothing is recording.
+    pub fn abort_recording(&mut self) {
         self.render_pass_balance.mark_closed();
         *self.state.lock() = RecorderState::Idle;
     }
@@ -1140,14 +1141,13 @@ impl RhiCommandRecorder {
         unsafe { (*(self.handle as *const RhiCommandRecorderInner)).in_render_pass() }
     }
 
-    /// Host-side abandon-recording used by
-    /// [`VulkanPresentTarget::begin_frame`](super::vulkan_present_target::VulkanPresentTarget::begin_frame)
-    /// when a frame is dropped after `begin()` but before submit (swapchain
-    /// `OUT_OF_DATE_KHR` on acquire). Resets the recorder to `Idle` so the
-    /// reused slot begins clean next attempt. See
-    /// [`RhiCommandRecorderInner::abort_recording`]. **Panics if called
-    /// from cdylib code** (present targets are host-only).
-    pub(crate) fn abort_recording(&mut self) {
+    /// Abandon an in-progress recording used when a frame is dropped after
+    /// `begin()` but before submit (swapchain `OUT_OF_DATE_KHR` on acquire,
+    /// or a failed per-frame record). Resets the recorder to `Idle` so the
+    /// reused slot begins clean next attempt; harmless when nothing is
+    /// recording. See [`RhiCommandRecorderInner::abort_recording`].
+    /// **Panics if called from cdylib code** (host-only recorders).
+    pub fn abort_recording(&mut self) {
         self.host_inner_mut().abort_recording();
     }
 

--- a/runtime/streamlib-engine/src/vulkan/rhi/vulkan_device.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/vulkan_device.rs
@@ -542,15 +542,27 @@ impl HostVulkanDevice {
             .flags(instance_create_flags)
             .build();
 
-        let instance = unsafe { entry.create_instance(&instance_info, None) }
-            .map_err(|e| Error::GpuError(format!("Failed to create Vulkan instance: {e}")))?;
+        let instance = unsafe { entry.create_instance(&instance_info, None) }.map_err(|e| {
+            Error::GpuError(if e == vk::ErrorCode::INCOMPATIBLE_DRIVER {
+                "No usable Vulkan driver (ICD) was found. Install your GPU vendor's Vulkan \
+                 driver — the proprietary NVIDIA driver, or `mesa-vulkan-drivers` for \
+                 AMD/Intel — then check `vulkaninfo` runs."
+                    .to_string()
+            } else {
+                format!("Failed to create Vulkan instance: {e}")
+            })
+        })?;
 
         // 5. Select physical device
         let physical_devices = unsafe { instance.enumerate_physical_devices() }
             .map_err(|e| Error::GpuError(format!("Failed to enumerate devices: {e}")))?;
 
         if physical_devices.is_empty() {
-            return Err(Error::GpuError("No Vulkan devices found".into()));
+            return Err(Error::GpuError(
+                "A Vulkan loader is present but reports no GPU. Check that your GPU vendor's \
+                 Vulkan driver is installed and `vulkaninfo` lists a device."
+                    .into(),
+            ));
         }
 
         // Prefer discrete GPU, fall back to first available

--- a/runtime/streamlib-engine/src/vulkan/rhi/vulkan_present_compositor.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/vulkan_present_compositor.rs
@@ -211,18 +211,21 @@ impl VulkanPresentCompositor {
         )
     }
 
-    /// Record the composition of `source` onto an acquired swapchain frame.
+    /// Record the composition of a registered source texture onto an
+    /// acquired swapchain frame.
     ///
-    /// Transitions `source` to `SHADER_READ_ONLY_OPTIMAL` when
-    /// `source_current_layout` says it is not there already — the caller's
-    /// layout bookkeeping must record that transition. Opens and closes its
-    /// own dynamic-rendering pass (clearing to black) on both the success and
-    /// the error path, so call it once per frame with no pass active.
+    /// Owns the source's layout bookkeeping: when the registration says the
+    /// texture is not in `SHADER_READ_ONLY_OPTIMAL`, the transition is
+    /// recorded and the registration updated at record time — the present
+    /// target submits everything recorded even when a later step fails (its
+    /// forward-progress contract), so recorded means executed. Opens and
+    /// closes its own dynamic-rendering pass (clearing to black) on both the
+    /// success and the error path; call it once per frame with no pass
+    /// active.
     pub fn compose_to_present_frame(
         &self,
         frame: &mut PresentFrame<'_>,
-        source: &Texture,
-        source_current_layout: VulkanLayout,
+        source_registration: &crate::core::context::TextureRegistration,
         scaling: PresentScalingMode,
     ) -> Result<()> {
         self.reject_attachment_format_mismatch(
@@ -231,6 +234,8 @@ impl VulkanPresentCompositor {
         )?;
         let frame_index = frame.frame_index;
         let destination_extent = frame.extent;
+        let source = source_registration.texture();
+        let source_current_layout = source_registration.current_layout();
 
         self.stage_source_and_scaling(frame_index, source, destination_extent, scaling)?;
         if source_current_layout != VulkanLayout::SHADER_READ_ONLY_OPTIMAL {
@@ -243,6 +248,7 @@ impl VulkanPresentCompositor {
                 VulkanAccess::MEMORY_WRITE,
                 VulkanAccess::SHADER_SAMPLED_READ,
             )?;
+            source_registration.update_layout(VulkanLayout::SHADER_READ_ONLY_OPTIMAL);
         }
 
         frame.begin_rendering(Some([0.0, 0.0, 0.0, 1.0]))?;

--- a/runtime/streamlib-engine/src/vulkan/rhi/vulkan_sync.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/vulkan_sync.rs
@@ -337,9 +337,10 @@ impl HostVulkanTimelineSemaphore {
     /// Block until the timeline counter has reached or surpassed `value`.
     ///
     /// `timeout_ns` is the per-call timeout; pass `u64::MAX` for "no
-    /// timeout". Returns `Ok(())` on success and
-    /// [`Error::GpuError`] (containing the underlying VkResult) on
-    /// timeout or driver failure.
+    /// timeout". Returns `Ok(())` only when the value was reached:
+    /// `vkWaitSemaphores` reports a timeout as `VK_TIMEOUT` — a *positive*
+    /// success code — which maps to [`Error::GpuError`] here, alongside
+    /// genuine driver failures.
     pub fn wait(&self, value: u64, timeout_ns: u64) -> Result<()> {
         let semaphores = [self.semaphore];
         let values = [value];
@@ -348,13 +349,17 @@ impl HostVulkanTimelineSemaphore {
             .semaphores(&semaphores)
             .values(&values)
             .build();
-        unsafe { self.device.wait_semaphores(&info, timeout_ns) }
-            .map(|_| ())
-            .map_err(|e| {
-                Error::GpuError(format!(
-                    "vkWaitSemaphores(value={value}, timeout_ns={timeout_ns}): {e}"
-                ))
-            })
+        let outcome = unsafe { self.device.wait_semaphores(&info, timeout_ns) }.map_err(|e| {
+            Error::GpuError(format!(
+                "vkWaitSemaphores(value={value}, timeout_ns={timeout_ns}): {e}"
+            ))
+        })?;
+        if outcome == vk::SuccessCode::TIMEOUT {
+            return Err(Error::GpuError(format!(
+                "vkWaitSemaphores(value={value}) timed out after {timeout_ns} ns"
+            )));
+        }
+        Ok(())
     }
 
     /// Host-side signal: advance the counter to `value` from the CPU.
@@ -447,6 +452,36 @@ mod tests {
         let semaphore = VulkanSemaphore::new(device.device());
         assert!(semaphore.is_ok(), "Semaphore creation should succeed");
         println!("Vulkan semaphore created successfully");
+    }
+
+    /// `vkWaitSemaphores` reports timeout as `VK_TIMEOUT` — a *positive*
+    /// success code — so a wrapper that only checks `Err` silently converts
+    /// a timed-out wait into `Ok`. Mental-revert: with the `SuccessCode::
+    /// TIMEOUT` mapping removed from [`HostVulkanTimelineSemaphore::wait`],
+    /// this test fails at the `expect_err`.
+    #[cfg(target_os = "linux")]
+    #[cfg_attr(
+        not(feature = "hardware-tests"),
+        ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md"
+    )]
+    #[test]
+    fn timeline_semaphore_bounded_wait_reports_timeout_as_error() {
+        let device = match HostVulkanDevice::new() {
+            Ok(d) => d,
+            Err(_) => {
+                println!("Skipping test - Vulkan not available");
+                return;
+            }
+        };
+        let sem = HostVulkanTimelineSemaphore::new(device.device(), 0)
+            .expect("create timeline semaphore");
+        let timeout_error = sem
+            .wait(1, 1_000_000)
+            .expect_err("a 1 ms wait on a never-signaled value must be an error, not Ok");
+        assert!(
+            format!("{timeout_error}").contains("timed out"),
+            "error names the timeout: {timeout_error}"
+        );
     }
 
     #[cfg(target_os = "linux")]

--- a/runtime/streamlib-media-builtins/Cargo.toml
+++ b/runtime/streamlib-media-builtins/Cargo.toml
@@ -23,6 +23,8 @@ tracing = { workspace = true }
 v4l = "0.14"
 uuid = { version = "1.11", features = ["v4"] }
 libc = { workspace = true }
+winit = "0.30"
+raw-window-handle = "0.6"
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/runtime/streamlib-media-builtins/Cargo.toml
+++ b/runtime/streamlib-media-builtins/Cargo.toml
@@ -19,6 +19,11 @@ streamlib = { path = "../../sdk/streamlib-sdk", version = "0.11.0", default-feat
 serde = { workspace = true }
 tracing = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+v4l = "0.14"
+uuid = { version = "1.11", features = ["v4"] }
+libc = { workspace = true }
+
 [dev-dependencies]
 serde_json = { workspace = true }
 rmp-serde = { workspace = true }

--- a/runtime/streamlib-media-builtins/src/camera_source.rs
+++ b/runtime/streamlib-media-builtins/src/camera_source.rs
@@ -104,6 +104,15 @@ pub fn list_camera_capture_devices() -> Result<Vec<CameraCaptureDevice>> {
             name: caps.card,
         });
     }
+    // `read_dir` order is unspecified; sort by the numeric node index so the
+    // "first camera found" default is stable across runs.
+    devices.sort_by_key(|device| {
+        device
+            .id
+            .trim_start_matches("/dev/video")
+            .parse::<u32>()
+            .unwrap_or(u32::MAX)
+    });
     Ok(devices)
 }
 
@@ -215,46 +224,31 @@ impl ManualProcessor for CameraSource::Processor {
             .map_err(|e| Error::Configuration(format!("Failed to read current format: {}", e)))?;
 
         // Negotiate format + resolution: enumerate frame sizes for NV12
-        // (preferred) or YUYV, pick the highest resolution, then set_format.
-        let fmt = negotiate_capture_format(&mut dev, current_fmt, &self.camera_name)?;
-
-        // Cap capture resolution at config.max_width / max_height (defaults
-        // 1920x1080 preserve the real-time-encoding guardrail; high-resolution
-        // use cases opt in by raising the cap).
+        // (preferred) or YUYV and pick the highest resolution that fits the
+        // configured cap (defaults 1920x1080 preserve the real-time-encoding
+        // guardrail; high-resolution use cases opt in by raising it).
+        // VIDIOC_S_FMT snaps to the nearest supported size — which can be
+        // LARGER than a naive capped request — so the cap constrains the
+        // enumeration, and a driver that still snaps above it gets a warning.
         let max_width = self.config.max_width.unwrap_or(1920);
         let max_height = self.config.max_height.unwrap_or(1080);
-        let fmt = if fmt.width > max_width || fmt.height > max_height {
-            let mut capped = fmt;
-            capped.width = max_width;
-            capped.height = max_height;
-            match dev.set_format(&capped) {
-                Ok(f) => {
-                    tracing::info!(
-                        "CameraSource {}: capped resolution from {}x{} to {}x{}",
-                        self.camera_name,
-                        fmt.width,
-                        fmt.height,
-                        f.width,
-                        f.height
-                    );
-                    f
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "CameraSource {}: failed to cap resolution to {}x{} ({}), using {}x{}",
-                        self.camera_name,
-                        max_width,
-                        max_height,
-                        e,
-                        fmt.width,
-                        fmt.height
-                    );
-                    fmt
-                }
-            }
-        } else {
-            fmt
-        };
+        let fmt = negotiate_capture_format(
+            &mut dev,
+            current_fmt,
+            &self.camera_name,
+            max_width,
+            max_height,
+        )?;
+        if fmt.width > max_width || fmt.height > max_height {
+            tracing::warn!(
+                "CameraSource {}: driver snapped to {}x{}, above the configured cap {}x{}",
+                self.camera_name,
+                fmt.width,
+                fmt.height,
+                max_width,
+                max_height
+            );
+        }
 
         let capture_width = fmt.width;
         let capture_height = fmt.height;
@@ -359,11 +353,14 @@ impl CameraSource::Processor {
     }
 }
 
-/// Pick NV12 (preferred) or YUYV at the highest resolution the device offers.
+/// Pick NV12 (preferred) or YUYV at the highest enumerated resolution that
+/// fits within `max_width` x `max_height`.
 fn negotiate_capture_format(
     dev: &mut v4l::Device,
     current_fmt: v4l::format::Format,
     camera_name: &str,
+    max_width: u32,
+    max_height: u32,
 ) -> Result<v4l::format::Format> {
     let nv12_fourcc = FourCC::new(b"NV12");
     let yuyv_fourcc = FourCC::new(b"YUYV");
@@ -374,8 +371,15 @@ fn negotiate_capture_format(
         for fs in framesizes {
             let (w, h) = match &fs.size {
                 v4l::framesize::FrameSizeEnum::Discrete(d) => (d.width, d.height),
-                v4l::framesize::FrameSizeEnum::Stepwise(s) => (s.max_width, s.max_height),
+                // Stepwise ranges include every size up to the max; clamp the
+                // candidate into the cap instead of discarding the range.
+                v4l::framesize::FrameSizeEnum::Stepwise(s) => {
+                    (s.max_width.min(max_width), s.max_height.min(max_height))
+                }
             };
+            if w > max_width || h > max_height {
+                continue;
+            }
             let pixels = w as u64 * h as u64;
             if pixels > best_pixels {
                 best_pixels = pixels;
@@ -816,28 +820,54 @@ fn capture_thread_loop(
                 v4l2_buf.type_ = v4l::buffer::Type::VideoCapture as u32;
                 v4l2_buf.memory = v4l::memory::Memory::Mmap as u32;
                 v4l2_buf.index = i;
-                libc::ioctl(
+                if libc::ioctl(
                     device_fd,
                     v4l::v4l2::vidioc::VIDIOC_QBUF as libc::c_ulong,
                     &mut v4l2_buf,
-                );
+                ) != 0
+                {
+                    tracing::error!(
+                        camera = camera_name,
+                        buffer_index = i,
+                        errno = std::io::Error::last_os_error().raw_os_error(),
+                        "initial VIDIOC_QBUF failed"
+                    );
+                }
             }
             let mut buf_type: u32 = v4l::buffer::Type::VideoCapture as u32;
-            libc::ioctl(
+            if libc::ioctl(
                 device_fd,
                 v4l::v4l2::vidioc::VIDIOC_STREAMON as libc::c_ulong,
                 &mut buf_type,
-            );
+            ) != 0
+            {
+                tracing::error!(
+                    camera = camera_name,
+                    errno = std::io::Error::last_os_error().raw_os_error(),
+                    "VIDIOC_STREAMON failed — camera produces no frames; stopping capture thread"
+                );
+                return;
+            }
         }
     }
 
     let requeue = |buf: Option<v4l::v4l_sys::v4l2_buffer>| {
         if let Some(mut v4l2_buf) = buf {
-            unsafe {
+            let result = unsafe {
                 libc::ioctl(
                     device_fd,
                     v4l::v4l2::vidioc::VIDIOC_QBUF as libc::c_ulong,
                     &mut v4l2_buf,
+                )
+            };
+            if result != 0 {
+                // Each failed requeue permanently removes one buffer from the
+                // driver queue; after V4L2_BUFFER_COUNT of them the DMA-BUF
+                // path starves silently.
+                tracing::error!(
+                    buffer_index = v4l2_buf.index,
+                    errno = std::io::Error::last_os_error().raw_os_error(),
+                    "VIDIOC_QBUF requeue failed — one capture buffer lost"
                 );
             }
         }

--- a/runtime/streamlib-media-builtins/src/camera_source.rs
+++ b/runtime/streamlib-media-builtins/src/camera_source.rs
@@ -845,6 +845,12 @@ fn capture_thread_loop(
 
     let mut ping_pong_index: usize = 0;
     let mut consecutive_dropped_frames: u64 = 0;
+    // The next timeline value to signal. Advances the moment a submit
+    // succeeds — even when the frame is later dropped on a readback timeout —
+    // because timeline signals must be strictly increasing and that submit's
+    // signal is already in flight. Distinct from `frame_counter`, which
+    // counts *published* frames only.
+    let mut next_timeline_signal_value: u64 = 1;
 
     while is_capturing.load(Ordering::Acquire) {
         // ---- Step 1: Acquire frame and select input SSBO ----
@@ -923,16 +929,16 @@ fn capture_thread_loop(
         }
 
         // Wait for the previous use of this ring texture slot to complete.
-        // Frame N uses slot N % RING_TEXTURE_COUNT; the previous use was
-        // frame N - RING_TEXTURE_COUNT which signaled timeline value
-        // (N - RING_TEXTURE_COUNT + 1). The first RING_TEXTURE_COUNT frames
-        // skip (initial timeline value 0). The counter advances only after a
-        // fully-submitted frame, so this wait always names a signal that is
-        // genuinely in flight; the bound turns a stalled GPU into dropped
-        // frames instead of a hung capture thread.
-        let frame_num = frame_counter.load(Ordering::Relaxed);
-        if frame_num >= RING_TEXTURE_COUNT as u64 {
-            let wait_value = frame_num - (RING_TEXTURE_COUNT as u64 - 1);
+        // Submission N (zero-based) uses slot N % RING_TEXTURE_COUNT; the
+        // previous use was submission N - RING_TEXTURE_COUNT, which signaled
+        // timeline value (N - RING_TEXTURE_COUNT + 1). The first
+        // RING_TEXTURE_COUNT submissions skip (initial timeline value 0).
+        // The signal counter advances only on a successful submit, so this
+        // wait always names a signal that is genuinely in flight; the bound
+        // turns a stalled GPU into dropped frames instead of a hung thread.
+        let submitted_frames = next_timeline_signal_value - 1;
+        if submitted_frames >= RING_TEXTURE_COUNT as u64 {
+            let wait_value = submitted_frames - (RING_TEXTURE_COUNT as u64 - 1);
             if let Err(e) = camera_timeline.wait(wait_value, RING_SLOT_WAIT_TIMEOUT_NS) {
                 tracing::warn!(
                     camera = camera_name,
@@ -944,7 +950,7 @@ fn capture_thread_loop(
             }
         }
 
-        let ring_index = (frame_num as usize) % RING_TEXTURE_COUNT;
+        let ring_index = (submitted_frames as usize) % RING_TEXTURE_COUNT;
 
         // The per-frame GPU unit is one fallible block so there is exactly
         // one failure exit: the V4L2 buffer is requeued and the recorder
@@ -1072,14 +1078,18 @@ fn capture_thread_loop(
                 )
                 .map_err(|e| Error::GpuError(format!("pixel-buffer host-read barrier: {e}")))?;
 
-            // Submit + signal timeline value (= frame_num + 1 so consumers
-            // can wait on a monotonically advancing counter), then wait so
-            // the pixel buffer is host-readable before the IPC write below.
+            // Submit + signal the next timeline value, then wait so the
+            // pixel buffer is host-readable before the IPC write below. The
+            // signal counter advances as soon as the submit lands — the
+            // signal is in flight even if the wait below times out, and a
+            // timeline value must never be signaled twice.
+            let signaled_value = next_timeline_signal_value;
             recorder
-                .submit_signaling_timeline(&camera_timeline, frame_num + 1)
+                .submit_signaling_timeline(&camera_timeline, signaled_value)
                 .map_err(|e| Error::GpuError(format!("submit compute dispatch: {e}")))?;
+            next_timeline_signal_value += 1;
             camera_timeline
-                .wait(frame_num + 1, HOST_READBACK_WAIT_TIMEOUT_NS)
+                .wait(signaled_value, HOST_READBACK_WAIT_TIMEOUT_NS)
                 .map_err(|e| Error::GpuError(format!("host-readback timeline wait: {e}")))?;
 
             Ok((surface_id, pooled_buffer))
@@ -1111,9 +1121,8 @@ fn capture_thread_loop(
         };
         consecutive_dropped_frames = 0;
 
-        // Commit the frame: its signal (frame_num + 1) is on the timeline,
-        // so the next ring-slot wait can never outrun it.
-        frame_counter.fetch_add(1, Ordering::Relaxed);
+        // Commit the published frame count.
+        let published_frames = frame_counter.fetch_add(1, Ordering::Relaxed);
 
         let frame = VideoFrame {
             surface_id,
@@ -1137,7 +1146,7 @@ fn capture_thread_loop(
         // write has been delivered into the link's ring.
         drop(pooled_buffer);
 
-        if frame_num == 0 {
+        if published_frames == 0 {
             let mode = if use_dmabuf {
                 "DMA-BUF zero-copy"
             } else {
@@ -1152,8 +1161,12 @@ fn capture_thread_loop(
                 ?fourcc,
                 "first frame captured via GPU compute",
             );
-        } else if frame_num.is_multiple_of(300) {
-            tracing::debug!(camera = camera_name, frame = frame_num, "frame milestone");
+        } else if published_frames.is_multiple_of(300) {
+            tracing::debug!(
+                camera = camera_name,
+                frame = published_frames,
+                "frame milestone"
+            );
         }
 
         if !use_dmabuf {

--- a/runtime/streamlib-media-builtins/src/camera_source.rs
+++ b/runtime/streamlib-media-builtins/src/camera_source.rs
@@ -148,17 +148,26 @@ impl ManualProcessor for CameraSource::Processor {
                 let devices = list_camera_capture_devices()?;
                 devices.first().map(|d| d.id.clone()).ok_or_else(|| {
                     Error::Configuration(
-                        "No V4L2 capture devices found. Check that a camera is connected.".into(),
+                        "No camera found: nothing under /dev/video* reports video capture. \
+                         Check the camera is plugged in (`ls /dev/video*`), or use \
+                         TestPatternSource to run without one."
+                            .into(),
                     )
                 })?
             }
         };
 
         let mut dev = v4l::Device::with_path(&device_path).map_err(|e| {
-            Error::Configuration(format!(
-                "Failed to open V4L2 device '{}': {}",
-                device_path, e
-            ))
+            Error::Configuration(if e.kind() == std::io::ErrorKind::PermissionDenied {
+                format!(
+                    "Camera '{}' exists but you don't have permission to open it. Add \
+                         yourself to the `video` group — `sudo usermod -aG video $USER` — \
+                         then log out and back in.",
+                    device_path
+                )
+            } else {
+                format!("Failed to open V4L2 device '{}': {}", device_path, e)
+            })
         })?;
 
         let caps = dev.query_caps().map_err(|e| {

--- a/runtime/streamlib-media-builtins/src/camera_source.rs
+++ b/runtime/streamlib-media-builtins/src/camera_source.rs
@@ -14,9 +14,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
-use streamlib::sdk::color::{
-    ColorSpaceKind, MatrixId, PrimariesId, RangeId, TransferId, resolve_color_defaults,
-};
+use streamlib::sdk::color::{ColorSpaceKind, RangeId, TransferId, resolve_color_defaults};
 use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess};
 use streamlib::sdk::engine::host_rhi::{
     HostSurfaceStoreExt, HostVulkanTimelineSemaphore, ImageCopyRegion, RhiCommandRecorder,
@@ -546,10 +544,13 @@ fn capture_thread_loop(
     // converter's push constants use. Held for the life of the capture
     // thread — V4L2 colorspace doesn't change mid-stream.
     let resolved_color = resolve_color_defaults(
-        cached_color_info.primaries.as_ref().map(primaries_id),
-        cached_color_info.transfer.as_ref().map(transfer_id),
-        cached_color_info.matrix.as_ref().map(matrix_id),
-        cached_color_info.range.as_ref().map(range_id),
+        cached_color_info
+            .primaries
+            .as_ref()
+            .map(Primaries::engine_id),
+        cached_color_info.transfer.as_ref().map(Transfer::engine_id),
+        cached_color_info.matrix.as_ref().map(Matrix::engine_id),
+        cached_color_info.range.as_ref().map(Range::engine_id),
         ColorSpaceKind::Yuv,
     );
 
@@ -1145,67 +1146,6 @@ fn capture_thread_loop(
     drop(camera_timeline);
 }
 
-// Per-axis maps from the bag's H.273 vocabulary to the engine's color IDs.
-// The engine accepts only its own primitive types in public signatures, so
-// each consumer translates at the boundary.
-
-fn primaries_id(p: &Primaries) -> PrimariesId {
-    match p {
-        Primaries::Bt709 => PrimariesId::Bt709,
-        Primaries::Bt470M => PrimariesId::Bt470M,
-        Primaries::Bt470Bg => PrimariesId::Bt470Bg,
-        Primaries::Smpte170m => PrimariesId::Smpte170m,
-        Primaries::Smpte240m => PrimariesId::Smpte240m,
-        Primaries::Film => PrimariesId::Film,
-        Primaries::Bt2020 => PrimariesId::Bt2020,
-        Primaries::Smpte428 => PrimariesId::Smpte428,
-        Primaries::Smpte431 => PrimariesId::Smpte431,
-        Primaries::Smpte432 => PrimariesId::Smpte432,
-        Primaries::Ebu3213 => PrimariesId::Ebu3213,
-    }
-}
-
-fn transfer_id(t: &Transfer) -> TransferId {
-    match t {
-        Transfer::Srgb => TransferId::Srgb,
-        Transfer::Bt709
-        | Transfer::Smpte170m
-        | Transfer::Bt2020TenBit
-        | Transfer::Bt2020TwelveBit => TransferId::Bt709,
-        Transfer::Smpte2084 => TransferId::Pq,
-        Transfer::AribStdB67 => TransferId::Hlg,
-        Transfer::Linear => TransferId::Linear,
-        // Gamma22 / Gamma28 / Smpte240m / Log* / Xvycc / Bt1361 / Smpte428
-        // are uncommon end-to-end; map to Linear (no transform).
-        _ => TransferId::Linear,
-    }
-}
-
-fn matrix_id(m: &Matrix) -> MatrixId {
-    match m {
-        Matrix::Identity => MatrixId::Identity,
-        Matrix::Bt709 => MatrixId::Bt709,
-        Matrix::Fcc => MatrixId::Fcc,
-        Matrix::Bt470Bg => MatrixId::Bt470Bg,
-        Matrix::Smpte170m => MatrixId::Smpte170m,
-        Matrix::Smpte240m => MatrixId::Smpte240m,
-        Matrix::Ycgco => MatrixId::Ycgco,
-        Matrix::Bt2020Ncl => MatrixId::Bt2020Ncl,
-        Matrix::Bt2020Cl => MatrixId::Bt2020Cl,
-        Matrix::Smpte2085 => MatrixId::Smpte2085,
-        Matrix::ChromaNcl => MatrixId::ChromaNcl,
-        Matrix::ChromaCl => MatrixId::ChromaCl,
-        Matrix::Ictcp => MatrixId::Ictcp,
-    }
-}
-
-fn range_id(r: &Range) -> RangeId {
-    match r {
-        Range::Limited => RangeId::Limited,
-        Range::Full => RangeId::Full,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1223,15 +1163,5 @@ mod tests {
         let config: CameraSourceConfig = serde_json::from_str("{}").expect("empty config");
         assert_eq!(config.device_id, None);
         assert_eq!((config.max_width, config.max_height), (None, None));
-    }
-
-    /// Every bag-vocabulary color axis maps to an engine ID without panicking.
-    #[test]
-    fn color_axis_maps_are_total() {
-        use crate::video_frame::{Matrix, Primaries, Range, Transfer};
-        let _ = primaries_id(&Primaries::Bt709);
-        let _ = transfer_id(&Transfer::Xvycc);
-        let _ = matrix_id(&Matrix::Ictcp);
-        let _ = range_id(&Range::Full);
     }
 }

--- a/runtime/streamlib-media-builtins/src/camera_source.rs
+++ b/runtime/streamlib-media-builtins/src/camera_source.rs
@@ -195,7 +195,7 @@ impl ManualProcessor for CameraSource::Processor {
         let max_width = self.config.max_width.unwrap_or(1920);
         let max_height = self.config.max_height.unwrap_or(1080);
         let fmt = if fmt.width > max_width || fmt.height > max_height {
-            let mut capped = fmt.clone();
+            let mut capped = fmt;
             capped.width = max_width;
             capped.height = max_height;
             match dev.set_format(&capped) {
@@ -240,7 +240,7 @@ impl ManualProcessor for CameraSource::Processor {
         );
 
         let mut stream =
-            v4l::io::mmap::Stream::with_buffers(&mut dev, Type::VideoCapture, V4L2_BUFFER_COUNT)
+            v4l::io::mmap::Stream::with_buffers(&dev, Type::VideoCapture, V4L2_BUFFER_COUNT)
                 .map_err(|e| {
                     Error::Configuration(format!("Failed to create V4L2 mmap stream: {}", e))
                 })?;
@@ -355,7 +355,7 @@ fn negotiate_capture_format(
     if let Ok(framesizes) = dev.enum_framesizes(nv12_fourcc)
         && let Some((best_w, best_h)) = highest_resolution(&framesizes)
     {
-        let mut try_fmt = current_fmt.clone();
+        let mut try_fmt = current_fmt;
         try_fmt.fourcc = nv12_fourcc;
         try_fmt.width = best_w;
         try_fmt.height = best_h;
@@ -1115,7 +1115,7 @@ fn capture_thread_loop(
                 ?fourcc,
                 "first frame captured via GPU compute",
             );
-        } else if frame_num % 300 == 0 {
+        } else if frame_num.is_multiple_of(300) {
             tracing::debug!(camera = camera_name, frame = frame_num, "frame milestone");
         }
 

--- a/runtime/streamlib-media-builtins/src/camera_source.rs
+++ b/runtime/streamlib-media-builtins/src/camera_source.rs
@@ -25,8 +25,8 @@ use streamlib::sdk::iceoryx2::OutputWriter;
 use streamlib::sdk::media_clock::MediaClock;
 use streamlib::sdk::processors::ManualProcessor;
 use streamlib::sdk::rhi::{
-    PixelFormat, RhiColorConverter, SourceLayoutInfo, StorageBuffer, Texture, TextureFormat,
-    VulkanLayout,
+    PixelBuffer, PixelFormat, RhiColorConverter, SourceLayoutInfo, StorageBuffer, Texture,
+    TextureFormat, VulkanLayout,
 };
 
 use v4l::FourCC;
@@ -42,6 +42,14 @@ const RING_TEXTURE_COUNT: usize = 2;
 
 /// Number of V4L2 mmap buffers to request.
 const V4L2_BUFFER_COUNT: u32 = 4;
+
+/// Bound on the wait for a ring slot's previous frame. Normally sub-frame;
+/// a stalled GPU degrades to dropped frames, never a hung capture thread.
+const RING_SLOT_WAIT_TIMEOUT_NS: u64 = 2_000_000_000;
+
+/// Bound on the host wait for this frame's own submit. The signal is certain
+/// after a successful submit unless the device is lost.
+const HOST_READBACK_WAIT_TIMEOUT_NS: u64 = 5_000_000_000;
 
 /// Configuration for [`CameraSource`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -130,10 +138,7 @@ impl ManualProcessor for CameraSource::Processor {
             self.camera_name,
             frame_count
         );
-        self.is_capturing.store(false, Ordering::Release);
-        if let Some(handle) = self.capture_thread_handle.take() {
-            let _ = handle.join();
-        }
+        self.stop_capture_thread();
         Ok(())
     }
 
@@ -158,15 +163,39 @@ impl ManualProcessor for CameraSource::Processor {
         };
 
         let mut dev = v4l::Device::with_path(&device_path).map_err(|e| {
-            Error::Configuration(if e.kind() == std::io::ErrorKind::PermissionDenied {
-                format!(
+            Error::Configuration(match e.kind() {
+                std::io::ErrorKind::PermissionDenied => format!(
                     "Camera '{}' exists but you don't have permission to open it. Add \
-                         yourself to the `video` group — `sudo usermod -aG video $USER` — \
-                         then log out and back in.",
+                     yourself to the `video` group — `sudo usermod -aG video $USER` — \
+                     then log out and back in.",
                     device_path
-                )
-            } else {
-                format!("Failed to open V4L2 device '{}': {}", device_path, e)
+                ),
+                std::io::ErrorKind::NotFound => {
+                    let attached = list_camera_capture_devices()
+                        .map(|devices| {
+                            devices
+                                .iter()
+                                .map(|device| format!("{} ({})", device.id, device.name))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        })
+                        .unwrap_or_default();
+                    if attached.is_empty() {
+                        format!(
+                            "Camera '{}' does not exist and no other camera is attached. \
+                             Check the camera is plugged in (`ls /dev/video*`), or use \
+                             TestPatternSource to run without one.",
+                            device_path
+                        )
+                    } else {
+                        format!(
+                            "Camera '{}' does not exist. Attached cameras: {}. Fix \
+                             device_id, or omit it to use the first camera found.",
+                            device_path, attached
+                        )
+                    }
+                }
+                _ => format!("Failed to open V4L2 device '{}': {}", device_path, e),
             })
         })?;
 
@@ -294,6 +323,18 @@ impl ManualProcessor for CameraSource::Processor {
     }
 
     fn stop(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.stop_capture_thread();
+        tracing::info!(
+            "CameraSource {}: stopped ({} frames)",
+            self.camera_name,
+            self.frame_counter.load(Ordering::Relaxed)
+        );
+        Ok(())
+    }
+}
+
+impl CameraSource::Processor {
+    fn stop_capture_thread(&mut self) {
         self.is_capturing.store(false, Ordering::Release);
 
         // Bounded wait: the capture thread can be inside a long timeline wait
@@ -315,13 +356,6 @@ impl ManualProcessor for CameraSource::Processor {
                 );
             }
         }
-
-        tracing::info!(
-            "CameraSource {}: stopped ({} frames)",
-            self.camera_name,
-            self.frame_counter.load(Ordering::Relaxed)
-        );
-        Ok(())
     }
 }
 
@@ -418,9 +452,25 @@ struct CameraGpuResources {
     ring_texture_ids: Vec<String>,
     use_dmabuf: bool,
     dmabuf_imported_buffers: Vec<StorageBuffer>,
-    dmabuf_fds: [i32; V4L2_BUFFER_COUNT as usize],
     vulkan_device_name: String,
     probe_skipped: bool,
+}
+
+/// The two V4L2 capture formats the GPU converter has shaders for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CaptureFormat {
+    Nv12,
+    Yuyv,
+}
+
+impl CaptureFormat {
+    fn from_fourcc(fourcc: FourCC) -> Option<Self> {
+        match &fourcc.repr {
+            b"NV12" => Some(Self::Nv12),
+            b"YUYV" => Some(Self::Yuyv),
+            _ => None,
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -436,19 +486,14 @@ fn capture_thread_loop(
     fourcc: FourCC,
     capture_fps: Option<u32>,
 ) {
-    let fourcc_bytes = fourcc.repr;
-
-    match &fourcc_bytes {
-        b"NV12" | b"YUYV" => {}
-        _ => {
-            tracing::error!(
-                camera = camera_name,
-                ?fourcc,
-                "unsupported format — no GPU compute shader available",
-            );
-            return;
-        }
-    }
+    let Some(capture_format) = CaptureFormat::from_fourcc(fourcc) else {
+        tracing::error!(
+            camera = camera_name,
+            ?fourcc,
+            "unsupported format — no GPU compute shader available",
+        );
+        return;
+    };
 
     let device_fd = stream.handle().fd();
 
@@ -508,15 +553,9 @@ fn capture_thread_loop(
         } else {
             // ioctl failed — emit "all unknown" colors and fall back to
             // tight-packed buffer sizing.
-            let tight_bytes_per_line = match &fourcc_bytes {
-                b"NV12" => width,
-                b"YUYV" => width * 2,
-                _ => unreachable!("guarded by FourCC match above"),
-            };
-            let tight_size_image = match &fourcc_bytes {
-                b"NV12" => width * height * 3 / 2,
-                b"YUYV" => width * height * 2,
-                _ => unreachable!(),
+            let (tight_bytes_per_line, tight_size_image) = match capture_format {
+                CaptureFormat::Nv12 => (width, width * height * 3 / 2),
+                CaptureFormat::Yuyv => (width * 2, width * height * 2),
             };
             (ColorInfo::default(), tight_bytes_per_line, tight_size_image)
         }
@@ -526,19 +565,18 @@ fn capture_thread_loop(
     // (vivid reports 3840-byte stride for 1920-wide NV12). Truncating to
     // tight-pack size memcpys only half the Y plane and reads garbage UV.
     let input_byte_size = v4l2_size_image as usize;
-    let input_alloc_size = input_byte_size.div_ceil(4).wrapping_mul(4) as u64;
+    let input_alloc_size = input_byte_size.next_multiple_of(4) as u64;
 
     // Source-buffer layout for the converter's push constants. NV12 uses
     // `bytesperline` for both planes (V4L2 bi-planar convention); YUYV is a
     // single packed plane.
-    let src_layout = match &fourcc_bytes {
-        b"NV12" => SourceLayoutInfo::nv12(
+    let src_layout = match capture_format {
+        CaptureFormat::Nv12 => SourceLayoutInfo::nv12(
             v4l2_bytes_per_line,
             v4l2_bytes_per_line,
             v4l2_bytes_per_line * height,
         ),
-        b"YUYV" => SourceLayoutInfo::yuyv(v4l2_bytes_per_line),
-        _ => unreachable!("guarded by FourCC match above"),
+        CaptureFormat::Yuyv => SourceLayoutInfo::yuyv(v4l2_bytes_per_line),
     };
     tracing::info!(
         camera = camera_name,
@@ -566,11 +604,10 @@ fn capture_thread_loop(
     // Map (fourcc, resolved range) to the canonical PixelFormat used as the
     // converter cache key. The push-constant matrix bakes the range
     // expansion in.
-    let src_pixel_format = match (&fourcc_bytes, &resolved_color.range) {
-        (b"NV12", RangeId::Full) => PixelFormat::Nv12FullRange,
-        (b"NV12", _) => PixelFormat::Nv12VideoRange,
-        (b"YUYV", _) => PixelFormat::Yuyv422,
-        _ => unreachable!("guarded by FourCC match above"),
+    let src_pixel_format = match (capture_format, &resolved_color.range) {
+        (CaptureFormat::Nv12, RangeId::Full) => PixelFormat::Nv12FullRange,
+        (CaptureFormat::Nv12, _) => PixelFormat::Nv12VideoRange,
+        (CaptureFormat::Yuyv, _) => PixelFormat::Yuyv422,
     };
 
     let setup_result = gpu_context.escalate(|full| {
@@ -613,12 +650,16 @@ fn capture_thread_loop(
         // it stays inside the escalation; failure falls through to MMAP.
         let probe_skipped = !caps.supports_cross_device_dma_buf_probe;
         let mut use_dmabuf = false;
-        let mut dmabuf_fds: [i32; V4L2_BUFFER_COUNT as usize] = [-1; V4L2_BUFFER_COUNT as usize];
         let mut dmabuf_imported_buffers: Vec<StorageBuffer> = Vec::new();
         if caps.supports_external_memory && !is_virtual_device && !probe_skipped {
-            let mut imported: Vec<Option<StorageBuffer>> =
-                (0..V4L2_BUFFER_COUNT as usize).map(|_| None).collect();
-            let mut all_imported = true;
+            // Fd ownership: `import_dma_buf_storage_buffer` consumes the fd
+            // on success (`vkImportMemoryFdInfoKHR` transfers it to the
+            // driver, which closes it at free); on failure the fd stays ours
+            // and is closed here. Successfully imported fds are never closed
+            // by this code. Buffers already imported when a later index
+            // fails are dropped with the Vec, freeing their memory (and fd)
+            // through Vulkan.
+            let mut imported: Vec<StorageBuffer> = Vec::with_capacity(V4L2_BUFFER_COUNT as usize);
             for i in 0..V4L2_BUFFER_COUNT as usize {
                 let fd: i32 = unsafe {
                     let mut expbuf: v4l::v4l_sys::v4l2_exportbuffer = std::mem::zeroed();
@@ -639,14 +680,10 @@ fn capture_thread_loop(
                             "VIDIOC_EXPBUF not supported — using MMAP path"
                         );
                     }
-                    all_imported = false;
                     break;
                 }
                 match full.import_dma_buf_storage_buffer(fd, input_alloc_size) {
-                    Ok(buf) => {
-                        dmabuf_fds[i] = fd;
-                        imported[i] = Some(buf);
-                    }
+                    Ok(imported_buffer) => imported.push(imported_buffer),
                     Err(e) => {
                         if i == 0 {
                             if vulkan_device_name.to_lowercase().contains("nvidia") {
@@ -668,21 +705,13 @@ fn capture_thread_loop(
                             }
                         }
                         unsafe { libc::close(fd) };
-                        all_imported = false;
                         break;
                     }
                 }
             }
-            if all_imported {
-                dmabuf_imported_buffers = imported.into_iter().map(|o| o.unwrap()).collect();
+            if imported.len() == V4L2_BUFFER_COUNT as usize {
+                dmabuf_imported_buffers = imported;
                 use_dmabuf = true;
-            } else {
-                for fd in &mut dmabuf_fds {
-                    if *fd >= 0 {
-                        unsafe { libc::close(*fd) };
-                        *fd = -1;
-                    }
-                }
             }
         }
 
@@ -698,7 +727,6 @@ fn capture_thread_loop(
             ring_texture_ids,
             use_dmabuf,
             dmabuf_imported_buffers,
-            dmabuf_fds,
             vulkan_device_name,
             probe_skipped,
         })
@@ -716,7 +744,6 @@ fn capture_thread_loop(
         ring_texture_ids,
         use_dmabuf,
         dmabuf_imported_buffers,
-        mut dmabuf_fds,
         vulkan_device_name,
         probe_skipped,
     } = match setup_result {
@@ -817,6 +844,7 @@ fn capture_thread_loop(
     };
 
     let mut ping_pong_index: usize = 0;
+    let mut consecutive_dropped_frames: u64 = 0;
 
     while is_capturing.load(Ordering::Acquire) {
         // ---- Step 1: Acquire frame and select input SSBO ----
@@ -898,188 +926,197 @@ fn capture_thread_loop(
         // Frame N uses slot N % RING_TEXTURE_COUNT; the previous use was
         // frame N - RING_TEXTURE_COUNT which signaled timeline value
         // (N - RING_TEXTURE_COUNT + 1). The first RING_TEXTURE_COUNT frames
-        // skip (initial timeline value 0).
-        let frame_num_peek = frame_counter.load(Ordering::Relaxed);
-        if frame_num_peek >= RING_TEXTURE_COUNT as u64 {
-            let wait_value = frame_num_peek - (RING_TEXTURE_COUNT as u64 - 1);
-            if let Err(e) = camera_timeline.wait(wait_value, u64::MAX) {
-                tracing::warn!(camera = camera_name, error = %e, "timeline wait failed");
+        // skip (initial timeline value 0). The counter advances only after a
+        // fully-submitted frame, so this wait always names a signal that is
+        // genuinely in flight; the bound turns a stalled GPU into dropped
+        // frames instead of a hung capture thread.
+        let frame_num = frame_counter.load(Ordering::Relaxed);
+        if frame_num >= RING_TEXTURE_COUNT as u64 {
+            let wait_value = frame_num - (RING_TEXTURE_COUNT as u64 - 1);
+            if let Err(e) = camera_timeline.wait(wait_value, RING_SLOT_WAIT_TIMEOUT_NS) {
+                tracing::warn!(
+                    camera = camera_name,
+                    error = %e,
+                    "ring-slot timeline wait failed — dropping frame"
+                );
+                requeue(v4l2_requeue_buf);
+                continue;
             }
         }
 
-        let frame_num = frame_counter.fetch_add(1, Ordering::Relaxed);
-
-        // ---- Step 2: Select ring texture + acquire pixel buffer for IPC ----
         let ring_index = (frame_num as usize) % RING_TEXTURE_COUNT;
 
-        let (pool_id, pooled_buffer) = match gpu_context.acquire_pixel_buffer(
-            width,
-            height,
-            PixelFormat::Rgba32,
-        ) {
-            Ok(result) => result,
-            Err(e) => {
-                if frame_num == 0 {
-                    tracing::error!(camera = camera_name, error = %e, "failed to acquire pixel buffer");
-                }
-                requeue(v4l2_requeue_buf);
-                continue;
+        // The per-frame GPU unit is one fallible block so there is exactly
+        // one failure exit: the V4L2 buffer is requeued and the recorder
+        // reset on every path, and the frame counter advances only after the
+        // submit that signals its timeline value.
+        let frame_result: Result<(String, PixelBuffer)> = (|| {
+            // Acquire the pooled pixel buffer for IPC + CPU readback. Its
+            // pool_id is the surface_id — the universal key: same-process
+            // texture cache, cross-process surface-share, and CPU readback
+            // all resolve through it.
+            let (pool_id, pooled_buffer) = gpu_context
+                .acquire_pixel_buffer(width, height, PixelFormat::Rgba32)
+                .map_err(|e| Error::GpuError(format!("acquire pixel buffer: {e}")))?;
+            let surface_id = pool_id.to_string();
+
+            // Register the ring texture under the pixel buffer's pool_id so
+            // a same-process display resolves the texture via the same
+            // surface_id used for pixel-buffer IPC.
+            gpu_context.register_texture_with_layout(
+                &surface_id,
+                ring_textures[ring_index].clone(),
+                VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+            );
+
+            let input_buffer = if use_dmabuf {
+                &dmabuf_imported_buffers[input_ssbo_index]
+            } else {
+                &input_storage_buffers[input_ssbo_index]
+            };
+            let kernel = color_converter
+                .prepare_buffer_to_image_storage(
+                    input_buffer,
+                    src_layout,
+                    &ring_textures[ring_index],
+                    &resolved_color,
+                    // Display path consumes RGBA8_UNORM treated as
+                    // sRGB-encoded by the swapchain; #817 will replace this
+                    // hardcode with the negotiated VkColorSpaceKHR.
+                    TransferId::Srgb,
+                )
+                .map_err(|e| Error::GpuError(format!("color-converter prepare: {e}")))?;
+
+            recorder
+                .begin()
+                .map_err(|e| Error::GpuError(format!("recorder begin: {e}")))?;
+
+            // pre-compute: ring texture UNDEFINED → GENERAL.
+            recorder
+                .record_image_barrier(
+                    &ring_textures[ring_index],
+                    VulkanLayout::UNDEFINED,
+                    VulkanLayout::GENERAL,
+                    VulkanStage::NONE,
+                    VulkanStage::COMPUTE_SHADER,
+                    VulkanAccess::NONE,
+                    VulkanAccess::SHADER_WRITE,
+                )
+                .map_err(|e| Error::GpuError(format!("pre-compute image barrier: {e}")))?;
+
+            // pre-compute: imported DMA-BUF SSBO needs an explicit
+            // read-availability barrier (the V4L2 driver wrote it before we
+            // got the fd). HOST_VISIBLE SSBOs don't — coherent host writes
+            // need no GPU-side sync beyond the implicit submit-time barrier.
+            if use_dmabuf {
+                recorder
+                    .record_buffer_barrier(
+                        &dmabuf_imported_buffers[input_ssbo_index],
+                        VulkanStage::NONE,
+                        VulkanStage::COMPUTE_SHADER,
+                        VulkanAccess::NONE,
+                        VulkanAccess::SHADER_READ,
+                    )
+                    .map_err(|e| Error::GpuError(format!("pre-compute buffer barrier: {e}")))?;
             }
-        };
 
-        // Register the ring texture under the pixel buffer's pool_id so a
-        // same-process display resolves the texture via the same surface_id
-        // used for pixel-buffer IPC.
-        gpu_context.register_texture_with_layout(
-            &pool_id.to_string(),
-            ring_textures[ring_index].clone(),
-            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
-        );
+            recorder
+                .record_dispatch(&kernel, dispatch_x, dispatch_y, 1)
+                .map_err(|e| Error::GpuError(format!("record dispatch: {e}")))?;
 
-        // ---- Step 3: Bind kernel via the color converter ----
-        let input_buffer = if use_dmabuf {
-            &dmabuf_imported_buffers[input_ssbo_index]
-        } else {
-            &input_storage_buffers[input_ssbo_index]
-        };
-        let kernel = match color_converter.prepare_buffer_to_image_storage(
-            input_buffer,
-            src_layout,
-            &ring_textures[ring_index],
-            &resolved_color,
-            // Display path consumes RGBA8_UNORM treated as sRGB-encoded by
-            // the swapchain; #817 will replace this hardcode with the
-            // negotiated VkColorSpaceKHR.
-            TransferId::Srgb,
-        ) {
-            Ok(k) => k,
-            Err(e) => {
-                tracing::error!(camera = camera_name, error = %e, "color_converter prepare failed");
-                requeue(v4l2_requeue_buf);
-                continue;
-            }
-        };
+            // post-compute: ring texture GENERAL → TRANSFER_SRC for the host
+            // pixel-buffer copy.
+            recorder
+                .record_image_barrier(
+                    &ring_textures[ring_index],
+                    VulkanLayout::GENERAL,
+                    VulkanLayout::TRANSFER_SRC_OPTIMAL,
+                    VulkanStage::COMPUTE_SHADER,
+                    VulkanStage::ALL_TRANSFER,
+                    VulkanAccess::SHADER_WRITE,
+                    VulkanAccess::TRANSFER_READ,
+                )
+                .map_err(|e| Error::GpuError(format!("post-compute image barrier: {e}")))?;
 
-        // ---- Step 4: Record + submit ----
-        if let Err(e) = recorder.begin() {
-            tracing::error!(camera = camera_name, error = %e, "recorder.begin failed");
-            requeue(v4l2_requeue_buf);
-            continue;
-        }
+            // Copy ring → pooled pixel buffer (cross-process IPC + CPU
+            // readback).
+            recorder
+                .record_copy_image_to_buffer(
+                    &ring_textures[ring_index],
+                    VulkanLayout::TRANSFER_SRC_OPTIMAL,
+                    &pooled_buffer,
+                    ImageCopyRegion::tightly_packed(width, height),
+                )
+                .map_err(|e| Error::GpuError(format!("copy image to pixel buffer: {e}")))?;
 
-        // pre-compute: ring texture UNDEFINED → GENERAL.
-        if let Err(e) = recorder.record_image_barrier(
-            &ring_textures[ring_index],
-            VulkanLayout::UNDEFINED,
-            VulkanLayout::GENERAL,
-            VulkanStage::NONE,
-            VulkanStage::COMPUTE_SHADER,
-            VulkanAccess::NONE,
-            VulkanAccess::SHADER_WRITE,
-        ) {
-            tracing::error!(camera = camera_name, error = %e, "pre-compute image barrier failed");
-            continue;
-        }
+            // post-copy: ring texture TRANSFER_SRC → SHADER_READ_ONLY
+            // (consumed by display); pixel buffer TRANSFER_WRITE → HOST_READ.
+            recorder
+                .record_image_barrier(
+                    &ring_textures[ring_index],
+                    VulkanLayout::TRANSFER_SRC_OPTIMAL,
+                    VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+                    VulkanStage::ALL_TRANSFER,
+                    VulkanStage::FRAGMENT_SHADER,
+                    VulkanAccess::TRANSFER_READ,
+                    VulkanAccess::SHADER_READ,
+                )
+                .map_err(|e| Error::GpuError(format!("post-copy image barrier: {e}")))?;
+            recorder
+                .record_buffer_barrier(
+                    &pooled_buffer,
+                    VulkanStage::ALL_TRANSFER,
+                    VulkanStage::HOST,
+                    VulkanAccess::TRANSFER_WRITE,
+                    VulkanAccess::HOST_READ,
+                )
+                .map_err(|e| Error::GpuError(format!("pixel-buffer host-read barrier: {e}")))?;
 
-        // pre-compute: imported DMA-BUF SSBO needs an explicit
-        // read-availability barrier (the V4L2 driver wrote it before we got
-        // the fd). HOST_VISIBLE SSBOs don't — coherent host writes need no
-        // GPU-side sync beyond the implicit submit-time barrier.
-        if use_dmabuf
-            && let Err(e) = recorder.record_buffer_barrier(
-                &dmabuf_imported_buffers[input_ssbo_index],
-                VulkanStage::NONE,
-                VulkanStage::COMPUTE_SHADER,
-                VulkanAccess::NONE,
-                VulkanAccess::SHADER_READ,
-            )
-        {
-            tracing::error!(camera = camera_name, error = %e, "pre-compute buffer barrier failed");
-            continue;
-        }
+            // Submit + signal timeline value (= frame_num + 1 so consumers
+            // can wait on a monotonically advancing counter), then wait so
+            // the pixel buffer is host-readable before the IPC write below.
+            recorder
+                .submit_signaling_timeline(&camera_timeline, frame_num + 1)
+                .map_err(|e| Error::GpuError(format!("submit compute dispatch: {e}")))?;
+            camera_timeline
+                .wait(frame_num + 1, HOST_READBACK_WAIT_TIMEOUT_NS)
+                .map_err(|e| Error::GpuError(format!("host-readback timeline wait: {e}")))?;
 
-        if let Err(e) = recorder.record_dispatch(&kernel, dispatch_x, dispatch_y, 1) {
-            tracing::error!(camera = camera_name, error = %e, "record_dispatch failed");
-            continue;
-        }
+            Ok((surface_id, pooled_buffer))
+        })();
 
-        // post-compute: ring texture GENERAL → TRANSFER_SRC for the host
-        // pixel-buffer copy.
-        if let Err(e) = recorder.record_image_barrier(
-            &ring_textures[ring_index],
-            VulkanLayout::GENERAL,
-            VulkanLayout::TRANSFER_SRC_OPTIMAL,
-            VulkanStage::COMPUTE_SHADER,
-            VulkanStage::ALL_TRANSFER,
-            VulkanAccess::SHADER_WRITE,
-            VulkanAccess::TRANSFER_READ,
-        ) {
-            tracing::error!(camera = camera_name, error = %e, "post-compute image barrier failed");
-            continue;
-        }
-
-        // Copy ring → pooled pixel buffer (cross-process IPC + CPU readback).
-        let copy_region = ImageCopyRegion::tightly_packed(width, height);
-        if let Err(e) = recorder.record_copy_image_to_buffer(
-            &ring_textures[ring_index],
-            VulkanLayout::TRANSFER_SRC_OPTIMAL,
-            &pooled_buffer,
-            copy_region,
-        ) {
-            tracing::error!(camera = camera_name, error = %e, "record_copy_image_to_buffer failed");
-            continue;
-        }
-
-        // post-copy: ring texture TRANSFER_SRC → SHADER_READ_ONLY (consumed
-        // by display); pixel buffer TRANSFER_WRITE → HOST_READ.
-        if let Err(e) = recorder.record_image_barrier(
-            &ring_textures[ring_index],
-            VulkanLayout::TRANSFER_SRC_OPTIMAL,
-            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
-            VulkanStage::ALL_TRANSFER,
-            VulkanStage::FRAGMENT_SHADER,
-            VulkanAccess::TRANSFER_READ,
-            VulkanAccess::SHADER_READ,
-        ) {
-            tracing::error!(camera = camera_name, error = %e, "post-copy image barrier failed");
-            continue;
-        }
-        if let Err(e) = recorder.record_buffer_barrier(
-            &pooled_buffer,
-            VulkanStage::ALL_TRANSFER,
-            VulkanStage::HOST,
-            VulkanAccess::TRANSFER_WRITE,
-            VulkanAccess::HOST_READ,
-        ) {
-            tracing::error!(camera = camera_name, error = %e, "pixel-buffer host-read barrier failed");
-            continue;
-        }
-
-        // Submit + signal timeline value (= frame_num + 1 so consumers can
-        // wait on a monotonically advancing counter), then wait so the pixel
-        // buffer is host-readable before the IPC write below.
-        let timeline_signal_value = frame_num + 1;
-        if let Err(e) = recorder.submit_signaling_timeline(&camera_timeline, timeline_signal_value)
-        {
-            if frame_num == 0 {
-                tracing::error!(camera = camera_name, error = %e, "failed to submit compute dispatch");
-            }
-            requeue(v4l2_requeue_buf);
-            continue;
-        }
-        if let Err(e) = camera_timeline.wait(timeline_signal_value, u64::MAX) {
-            tracing::warn!(camera = camera_name, error = %e, "host-readback timeline wait failed");
-        }
-
-        // ---- Step 5: Re-queue V4L2 buffer in DMA-BUF mode ----
+        // The V4L2 buffer goes back to the driver on success and failure
+        // alike — a skipped requeue starves the DMA-BUF queue after
+        // V4L2_BUFFER_COUNT drops.
         requeue(v4l2_requeue_buf);
 
-        // ---- Step 6: Publish frame ----
-        // The pixel-buffer pool_id is the surface_id — the universal key:
-        // same-process texture cache, cross-process surface-share, and CPU
-        // readback all resolve through it.
+        let (surface_id, pooled_buffer) = match frame_result {
+            Ok(frame_surfaces) => frame_surfaces,
+            Err(frame_error) => {
+                // A begun-but-unsubmitted recording would fail the next
+                // begin(); reset it. Harmless when nothing is recording.
+                recorder.abort_recording();
+                consecutive_dropped_frames += 1;
+                if consecutive_dropped_frames == 1 || consecutive_dropped_frames.is_multiple_of(300)
+                {
+                    tracing::warn!(
+                        camera = camera_name,
+                        consecutive_dropped = consecutive_dropped_frames,
+                        error = %frame_error,
+                        "frame dropped"
+                    );
+                }
+                continue;
+            }
+        };
+        consecutive_dropped_frames = 0;
+
+        // Commit the frame: its signal (frame_num + 1) is on the timeline,
+        // so the next ring-slot wait can never outrun it.
+        frame_counter.fetch_add(1, Ordering::Relaxed);
+
         let frame = VideoFrame {
-            surface_id: pool_id.to_string(),
+            surface_id,
             width,
             height,
             timestamp_ns: MediaClock::now().as_nanos() as i64,
@@ -1136,15 +1173,8 @@ fn capture_thread_loop(
         }
     }
 
-    // The VIDIOC_EXPBUF fds were dup'd into Vulkan imports; the V4L2-side
-    // fds are ours to close.
-    for fd in &mut dmabuf_fds {
-        if *fd >= 0 {
-            unsafe { libc::close(*fd) };
-            *fd = -1;
-        }
-    }
-
+    // The imported fds are driver-owned (`vkImportMemoryFdInfoKHR` took
+    // ownership); dropping the buffers frees them through Vulkan.
     drop(dmabuf_imported_buffers);
     drop(ring_textures);
     drop(ring_produce_done);

--- a/runtime/streamlib-media-builtins/src/camera_source.rs
+++ b/runtime/streamlib-media-builtins/src/camera_source.rs
@@ -1,0 +1,1237 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+#![cfg(target_os = "linux")]
+
+//! Built-in V4L2 camera source: capture → GPU color-convert → publish.
+//!
+//! Camera→GPU transport is zero-copy DMA-BUF import when the device exports
+//! it, transparent CPU-upload (MMAP + memcpy) fallback otherwise, selected
+//! automatically — no configuration dial.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use streamlib::sdk::color::{
+    ColorSpaceKind, MatrixId, PrimariesId, RangeId, TransferId, resolve_color_defaults,
+};
+use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess};
+use streamlib::sdk::engine::host_rhi::{
+    HostSurfaceStoreExt, HostVulkanTimelineSemaphore, ImageCopyRegion, RhiCommandRecorder,
+    VulkanAccess, VulkanStage,
+};
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::iceoryx2::OutputWriter;
+use streamlib::sdk::media_clock::MediaClock;
+use streamlib::sdk::processors::ManualProcessor;
+use streamlib::sdk::rhi::{
+    PixelFormat, RhiColorConverter, SourceLayoutInfo, StorageBuffer, Texture, TextureFormat,
+    VulkanLayout,
+};
+
+use v4l::FourCC;
+use v4l::buffer::Type;
+use v4l::io::traits::CaptureStream;
+use v4l::video::Capture;
+
+use crate::video_frame::{ColorInfo, Matrix, Primaries, Range, Transfer, VideoFrame};
+
+/// Number of ring textures for the GPU-resident pipeline (matches
+/// MAX_FRAMES_IN_FLIGHT).
+const RING_TEXTURE_COUNT: usize = 2;
+
+/// Number of V4L2 mmap buffers to request.
+const V4L2_BUFFER_COUNT: u32 = 4;
+
+/// Configuration for [`CameraSource`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct CameraSourceConfig {
+    /// V4L2 device path (`/dev/video0`). Absent: the first capture-capable
+    /// device found.
+    #[serde(default)]
+    pub device_id: Option<String>,
+    /// Resolution cap; the negotiated format is clamped to fit. Default 1920.
+    #[serde(default)]
+    pub max_width: Option<u32>,
+    /// Resolution cap; the negotiated format is clamped to fit. Default 1080.
+    #[serde(default)]
+    pub max_height: Option<u32>,
+}
+
+/// A V4L2 capture device, as enumerated from `/dev/video*`.
+#[derive(Debug, Clone)]
+pub struct CameraCaptureDevice {
+    /// Device path (`/dev/video0`).
+    pub id: String,
+    /// Driver-reported card name.
+    pub name: String,
+}
+
+/// Enumerate available V4L2 capture devices.
+pub fn list_camera_capture_devices() -> Result<Vec<CameraCaptureDevice>> {
+    let mut devices = Vec::new();
+    for entry in std::fs::read_dir("/dev")
+        .map_err(|e| Error::Configuration(format!("Failed to read /dev: {}", e)))?
+    {
+        let Ok(entry) = entry else { continue };
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !name.starts_with("video") {
+            continue;
+        }
+        let Ok(dev) = v4l::Device::with_path(&path) else {
+            continue;
+        };
+        let Ok(caps) = dev.query_caps() else { continue };
+        if !caps
+            .capabilities
+            .contains(v4l::capability::Flags::VIDEO_CAPTURE)
+        {
+            continue;
+        }
+        devices.push(CameraCaptureDevice {
+            id: path.to_string_lossy().to_string(),
+            name: caps.card,
+        });
+    }
+    Ok(devices)
+}
+
+#[streamlib::sdk::processor(
+    "@tatolab/media-builtins/CameraSource",
+    description = "Captures live video from a V4L2 camera (zero-copy DMA-BUF when the device exports it, CPU upload otherwise)",
+    execution = manual,
+    scheduling = high,
+    config = crate::camera_source::CameraSourceConfig,
+    output("video", any, description = "Live camera video frames"),
+)]
+pub struct CameraSource {
+    camera_name: String,
+    gpu_context: Option<GpuContextLimitedAccess>,
+    is_capturing: Arc<AtomicBool>,
+    frame_counter: Arc<AtomicU64>,
+    capture_thread_handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl ManualProcessor for CameraSource::Processor {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        // The capture thread needs an owned handle that escapes into the
+        // thread closure, so the clone at setup is load-bearing here.
+        self.gpu_context = Some(ctx.gpu_limited_access().clone());
+        Ok(())
+    }
+
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let frame_count = self.frame_counter.load(Ordering::Relaxed);
+        tracing::info!(
+            "CameraSource {}: teardown ({} frames)",
+            self.camera_name,
+            frame_count
+        );
+        self.is_capturing.store(false, Ordering::Release);
+        if let Some(handle) = self.capture_thread_handle.take() {
+            let _ = handle.join();
+        }
+        Ok(())
+    }
+
+    fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let gpu_context = self.gpu_context.clone().ok_or_else(|| {
+            Error::Configuration("GPU context not initialized. Call setup() first.".into())
+        })?;
+
+        let device_path = match &self.config.device_id {
+            Some(id) => id.clone(),
+            None => {
+                let devices = list_camera_capture_devices()?;
+                devices.first().map(|d| d.id.clone()).ok_or_else(|| {
+                    Error::Configuration(
+                        "No V4L2 capture devices found. Check that a camera is connected.".into(),
+                    )
+                })?
+            }
+        };
+
+        let mut dev = v4l::Device::with_path(&device_path).map_err(|e| {
+            Error::Configuration(format!(
+                "Failed to open V4L2 device '{}': {}",
+                device_path, e
+            ))
+        })?;
+
+        let caps = dev.query_caps().map_err(|e| {
+            Error::Configuration(format!("Failed to query device capabilities: {}", e))
+        })?;
+        self.camera_name = caps.card.clone();
+        tracing::info!(
+            "CameraSource: opened '{}' (driver: {}, bus: {})",
+            caps.card,
+            caps.driver,
+            caps.bus
+        );
+
+        let current_fmt = dev
+            .format()
+            .map_err(|e| Error::Configuration(format!("Failed to read current format: {}", e)))?;
+
+        // Negotiate format + resolution: enumerate frame sizes for NV12
+        // (preferred) or YUYV, pick the highest resolution, then set_format.
+        let fmt = negotiate_capture_format(&mut dev, current_fmt, &self.camera_name)?;
+
+        // Cap capture resolution at config.max_width / max_height (defaults
+        // 1920x1080 preserve the real-time-encoding guardrail; high-resolution
+        // use cases opt in by raising the cap).
+        let max_width = self.config.max_width.unwrap_or(1920);
+        let max_height = self.config.max_height.unwrap_or(1080);
+        let fmt = if fmt.width > max_width || fmt.height > max_height {
+            let mut capped = fmt.clone();
+            capped.width = max_width;
+            capped.height = max_height;
+            match dev.set_format(&capped) {
+                Ok(f) => {
+                    tracing::info!(
+                        "CameraSource {}: capped resolution from {}x{} to {}x{}",
+                        self.camera_name,
+                        fmt.width,
+                        fmt.height,
+                        f.width,
+                        f.height
+                    );
+                    f
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "CameraSource {}: failed to cap resolution to {}x{} ({}), using {}x{}",
+                        self.camera_name,
+                        max_width,
+                        max_height,
+                        e,
+                        fmt.width,
+                        fmt.height
+                    );
+                    fmt
+                }
+            }
+        } else {
+            fmt
+        };
+
+        let capture_width = fmt.width;
+        let capture_height = fmt.height;
+        let capture_fourcc = fmt.fourcc;
+
+        tracing::info!(
+            "CameraSource {}: capturing {}x{} {:?}",
+            self.camera_name,
+            capture_width,
+            capture_height,
+            capture_fourcc
+        );
+
+        let mut stream =
+            v4l::io::mmap::Stream::with_buffers(&mut dev, Type::VideoCapture, V4L2_BUFFER_COUNT)
+                .map_err(|e| {
+                    Error::Configuration(format!("Failed to create V4L2 mmap stream: {}", e))
+                })?;
+
+        // Poll timeout so the capture thread can check is_capturing.
+        stream.set_timeout(std::time::Duration::from_secs(1));
+
+        let capture_fps: Option<u32> = match dev.params() {
+            Ok(params) if params.interval.numerator > 0 => {
+                Some(params.interval.denominator / params.interval.numerator)
+            }
+            _ => None,
+        };
+
+        self.is_capturing.store(true, Ordering::Release);
+
+        let is_capturing = Arc::clone(&self.is_capturing);
+        let frame_counter = Arc::clone(&self.frame_counter);
+        let outputs: OutputWriter = self.outputs.clone();
+        let camera_name = self.camera_name.clone();
+
+        let handle = std::thread::Builder::new()
+            .name(format!("v4l2-capture-{}", device_path))
+            .spawn(move || {
+                capture_thread_loop(
+                    stream,
+                    is_capturing,
+                    frame_counter,
+                    outputs,
+                    gpu_context,
+                    camera_name,
+                    capture_width,
+                    capture_height,
+                    capture_fourcc,
+                    capture_fps,
+                );
+            })
+            .map_err(|e| Error::Configuration(format!("Failed to spawn capture thread: {}", e)))?;
+
+        self.capture_thread_handle = Some(handle);
+
+        tracing::info!(
+            "CameraSource {}: V4L2 capture started ({}x{} {:?}, {} mmap buffers)",
+            self.camera_name,
+            capture_width,
+            capture_height,
+            capture_fourcc,
+            V4L2_BUFFER_COUNT
+        );
+        Ok(())
+    }
+
+    fn stop(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.is_capturing.store(false, Ordering::Release);
+
+        // Bounded wait: the capture thread can be inside a long timeline wait
+        // or a V4L2 dequeue when stop arrives; both exit promptly under normal
+        // conditions but a stalled GPU / driver state can stretch them out.
+        // Detaching after a 2 s grace window keeps the runtime's shutdown
+        // chain moving; the detached thread is reaped at process exit.
+        if let Some(handle) = self.capture_thread_handle.take() {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while !handle.is_finished() && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            if handle.is_finished() {
+                let _ = handle.join();
+            } else {
+                tracing::warn!(
+                    "CameraSource {}: capture thread did not exit within 2s, detaching",
+                    self.camera_name
+                );
+            }
+        }
+
+        tracing::info!(
+            "CameraSource {}: stopped ({} frames)",
+            self.camera_name,
+            self.frame_counter.load(Ordering::Relaxed)
+        );
+        Ok(())
+    }
+}
+
+/// Pick NV12 (preferred) or YUYV at the highest resolution the device offers.
+fn negotiate_capture_format(
+    dev: &mut v4l::Device,
+    current_fmt: v4l::format::Format,
+    camera_name: &str,
+) -> Result<v4l::format::Format> {
+    let nv12_fourcc = FourCC::new(b"NV12");
+    let yuyv_fourcc = FourCC::new(b"YUYV");
+
+    let highest_resolution = |framesizes: &[v4l::framesize::FrameSize]| -> Option<(u32, u32)> {
+        let mut best_pixels = 0u64;
+        let mut best = None;
+        for fs in framesizes {
+            let (w, h) = match &fs.size {
+                v4l::framesize::FrameSizeEnum::Discrete(d) => (d.width, d.height),
+                v4l::framesize::FrameSizeEnum::Stepwise(s) => (s.max_width, s.max_height),
+            };
+            let pixels = w as u64 * h as u64;
+            if pixels > best_pixels {
+                best_pixels = pixels;
+                best = Some((w, h));
+            }
+        }
+        best
+    };
+
+    // Try NV12 first.
+    if let Ok(framesizes) = dev.enum_framesizes(nv12_fourcc)
+        && let Some((best_w, best_h)) = highest_resolution(&framesizes)
+    {
+        let mut try_fmt = current_fmt.clone();
+        try_fmt.fourcc = nv12_fourcc;
+        try_fmt.width = best_w;
+        try_fmt.height = best_h;
+        if let Ok(f) = dev.set_format(&try_fmt)
+            && f.fourcc == nv12_fourcc
+        {
+            tracing::info!(
+                "CameraSource {}: NV12 available, highest resolution {}x{}",
+                camera_name,
+                f.width,
+                f.height
+            );
+            return Ok(f);
+        }
+    }
+
+    // Fall back to YUYV.
+    tracing::info!(
+        "CameraSource {}: NV12 not available, trying YUYV",
+        camera_name
+    );
+    let (best_w, best_h) = dev
+        .enum_framesizes(yuyv_fourcc)
+        .ok()
+        .and_then(|fs| highest_resolution(&fs))
+        .unwrap_or((current_fmt.width, current_fmt.height));
+
+    let mut try_fmt = current_fmt;
+    try_fmt.fourcc = yuyv_fourcc;
+    try_fmt.width = best_w;
+    try_fmt.height = best_h;
+    let f = dev.set_format(&try_fmt).map_err(|e| {
+        Error::Configuration(format!(
+            "Failed to set camera format (tried NV12, YUYV): {}",
+            e
+        ))
+    })?;
+    if f.fourcc != yuyv_fourcc {
+        return Err(Error::Configuration(format!(
+            "Camera does not support NV12 or YUYV (driver negotiated {:?})",
+            f.fourcc
+        )));
+    }
+    Ok(f)
+}
+
+struct CameraGpuResources {
+    color_converter: RhiColorConverter,
+    recorder: RhiCommandRecorder,
+    timeline: Arc<HostVulkanTimelineSemaphore>,
+    // Per-ring-slot single-writer-per-edge exportable timeline pairs —
+    // `produce_done` signaled by the camera capture path, `consume_done` by
+    // cross-process consumers. See
+    // `docs/architecture/adapter-timeline-single-writer.md`.
+    ring_produce_done: Vec<Arc<HostVulkanTimelineSemaphore>>,
+    ring_consume_done: Vec<Arc<HostVulkanTimelineSemaphore>>,
+    input_storage_buffers: Vec<StorageBuffer>,
+    input_mapped_ptrs: [*mut u8; 2],
+    ring_textures: Vec<Texture>,
+    ring_texture_ids: Vec<String>,
+    use_dmabuf: bool,
+    dmabuf_imported_buffers: Vec<StorageBuffer>,
+    dmabuf_fds: [i32; V4L2_BUFFER_COUNT as usize],
+    vulkan_device_name: String,
+    probe_skipped: bool,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn capture_thread_loop(
+    mut stream: v4l::io::mmap::Stream,
+    is_capturing: Arc<AtomicBool>,
+    frame_counter: Arc<AtomicU64>,
+    outputs: OutputWriter,
+    gpu_context: GpuContextLimitedAccess,
+    camera_name: String,
+    width: u32,
+    height: u32,
+    fourcc: FourCC,
+    capture_fps: Option<u32>,
+) {
+    let fourcc_bytes = fourcc.repr;
+
+    match &fourcc_bytes {
+        b"NV12" | b"YUYV" => {}
+        _ => {
+            tracing::error!(
+                camera = camera_name,
+                ?fourcc,
+                "unsupported format — no GPU compute shader available",
+            );
+            return;
+        }
+    }
+
+    let device_fd = stream.handle().fd();
+
+    // V4L2 driver classification — virtual devices (vivid, v4l2loopback)
+    // allocate buffers in CPU system memory, so DMA-BUF import into the GPU
+    // may succeed at the API level but produce garbage data (cross-device
+    // coherency). Skip the DMA-BUF probe for those — MMAP + memcpy is correct.
+    let is_virtual_device = unsafe {
+        let mut cap: v4l::v4l_sys::v4l2_capability = std::mem::zeroed();
+        let result = libc::ioctl(
+            device_fd,
+            v4l::v4l2::vidioc::VIDIOC_QUERYCAP as libc::c_ulong,
+            &mut cap,
+        );
+        if result == 0 {
+            let driver = std::ffi::CStr::from_ptr(cap.driver.as_ptr().cast())
+                .to_str()
+                .unwrap_or("");
+            let bus = std::ffi::CStr::from_ptr(cap.bus_info.as_ptr().cast())
+                .to_str()
+                .unwrap_or("");
+            driver == "vivid" || driver == "v4l2 loopback" || bus.starts_with("platform:")
+        } else {
+            false
+        }
+    };
+
+    // Query V4L2 format once at start: (1) the colorspace 4-tuple for
+    // `ColorInfo`, (2) `bytesperline` for the source SSBO stride (vivid +
+    // some UVC drivers report stride > width even for NV12), (3) `sizeimage`
+    // for the SSBO allocation (must hold the full V4L2 frame including
+    // padding). V4L2 contract: all three stay constant during streaming.
+    let (cached_color_info, v4l2_bytes_per_line, v4l2_size_image): (ColorInfo, u32, u32) = unsafe {
+        let mut v4l2_fmt: v4l::v4l_sys::v4l2_format = std::mem::zeroed();
+        v4l2_fmt.type_ = v4l::buffer::Type::VideoCapture as u32;
+        if libc::ioctl(
+            device_fd,
+            v4l::v4l2::vidioc::VIDIOC_G_FMT as libc::c_ulong,
+            &mut v4l2_fmt,
+        ) == 0
+        {
+            let pix = v4l2_fmt.fmt.pix;
+            let color = crate::v4l2_color::v4l2_color_to_color_info(
+                pix.colorspace,
+                pix.xfer_func,
+                // ycbcr_enc shares an anonymous union with hsv_enc; use the
+                // YCbCr field since this path is YUV-only (NV12 / YUYV —
+                // guarded by the FourCC match above). `__bindgen_anon_1` is
+                // bindgen's name for the inner `union { ycbcr_enc; hsv_enc }`
+                // — stable on v4l2-sys-mit 0.3.x; an upstream bump that adds
+                // a second anonymous union would shift the suffix and stop
+                // compiling, caught at build time.
+                pix.__bindgen_anon_1.ycbcr_enc,
+                pix.quantization,
+            );
+            (color, pix.bytesperline, pix.sizeimage)
+        } else {
+            // ioctl failed — emit "all unknown" colors and fall back to
+            // tight-packed buffer sizing.
+            let tight_bytes_per_line = match &fourcc_bytes {
+                b"NV12" => width,
+                b"YUYV" => width * 2,
+                _ => unreachable!("guarded by FourCC match above"),
+            };
+            let tight_size_image = match &fourcc_bytes {
+                b"NV12" => width * height * 3 / 2,
+                b"YUYV" => width * height * 2,
+                _ => unreachable!(),
+            };
+            (ColorInfo::default(), tight_bytes_per_line, tight_size_image)
+        }
+    };
+
+    // SSBO must hold the full V4L2 frame including driver-side row padding
+    // (vivid reports 3840-byte stride for 1920-wide NV12). Truncating to
+    // tight-pack size memcpys only half the Y plane and reads garbage UV.
+    let input_byte_size = v4l2_size_image as usize;
+    let input_alloc_size = input_byte_size.div_ceil(4).wrapping_mul(4) as u64;
+
+    // Source-buffer layout for the converter's push constants. NV12 uses
+    // `bytesperline` for both planes (V4L2 bi-planar convention); YUYV is a
+    // single packed plane.
+    let src_layout = match &fourcc_bytes {
+        b"NV12" => SourceLayoutInfo::nv12(
+            v4l2_bytes_per_line,
+            v4l2_bytes_per_line,
+            v4l2_bytes_per_line * height,
+        ),
+        b"YUYV" => SourceLayoutInfo::yuyv(v4l2_bytes_per_line),
+        _ => unreachable!("guarded by FourCC match above"),
+    };
+    tracing::info!(
+        camera = camera_name,
+        bytes_per_line = v4l2_bytes_per_line,
+        size_image = v4l2_size_image,
+        width,
+        height,
+        "V4L2 buffer layout"
+    );
+
+    // Resolve V4L2 ColorInfo to the fully-resolved description the color
+    // converter's push constants use. Held for the life of the capture
+    // thread — V4L2 colorspace doesn't change mid-stream.
+    let resolved_color = resolve_color_defaults(
+        cached_color_info.primaries.as_ref().map(primaries_id),
+        cached_color_info.transfer.as_ref().map(transfer_id),
+        cached_color_info.matrix.as_ref().map(matrix_id),
+        cached_color_info.range.as_ref().map(range_id),
+        ColorSpaceKind::Yuv,
+    );
+
+    // Map (fourcc, resolved range) to the canonical PixelFormat used as the
+    // converter cache key. The push-constant matrix bakes the range
+    // expansion in.
+    let src_pixel_format = match (&fourcc_bytes, &resolved_color.range) {
+        (b"NV12", RangeId::Full) => PixelFormat::Nv12FullRange,
+        (b"NV12", _) => PixelFormat::Nv12VideoRange,
+        (b"YUYV", _) => PixelFormat::Yuyv422,
+        _ => unreachable!("guarded by FourCC match above"),
+    };
+
+    let setup_result = gpu_context.escalate(|full| {
+        let caps = full.gpu_capabilities()?;
+        let vulkan_device_name = caps.device_name.clone();
+
+        let color_converter = full.color_converter(src_pixel_format, PixelFormat::Rgba32)?;
+        let recorder = full.create_command_recorder("camera_capture")?;
+
+        // Host-readback / display-wait timeline. Exportable so cross-process
+        // consumers can wait on it; the camera only waits host-side.
+        let timeline = full.create_exportable_timeline_semaphore(0)?;
+
+        // Double-buffered HOST_VISIBLE input SSBOs (MMAP+memcpy fallback path).
+        let mut input_storage_buffers: Vec<StorageBuffer> = Vec::with_capacity(2);
+        let mut input_mapped_ptrs: [*mut u8; 2] = [std::ptr::null_mut(); 2];
+        for slot in &mut input_mapped_ptrs {
+            let buf = full.acquire_storage_buffer(input_alloc_size)?;
+            *slot = buf.mapped_ptr();
+            input_storage_buffers.push(buf);
+        }
+
+        // 2-texture DEVICE_LOCAL ring via the render-target DMA-BUF
+        // allocation slot (tiled DRM modifier; usage superset is harmless).
+        let mut ring_textures: Vec<Texture> = Vec::with_capacity(RING_TEXTURE_COUNT);
+        let mut ring_texture_ids: Vec<String> = Vec::with_capacity(RING_TEXTURE_COUNT);
+        let mut ring_produce_done = Vec::with_capacity(RING_TEXTURE_COUNT);
+        let mut ring_consume_done = Vec::with_capacity(RING_TEXTURE_COUNT);
+        for _ in 0..RING_TEXTURE_COUNT {
+            let stream_texture =
+                full.acquire_render_target_dma_buf_image(width, height, TextureFormat::Rgba8Unorm)?;
+            ring_texture_ids.push(uuid::Uuid::new_v4().to_string());
+            ring_textures.push(stream_texture);
+            ring_produce_done.push(full.create_exportable_timeline_semaphore(0)?);
+            ring_consume_done.push(full.create_exportable_timeline_semaphore(0)?);
+        }
+
+        // DMA-BUF probe — VIDIOC_EXPBUF on each V4L2 buffer + Vulkan import.
+        // The import side is privileged (allocates VkDeviceMemory + binds) so
+        // it stays inside the escalation; failure falls through to MMAP.
+        let probe_skipped = !caps.supports_cross_device_dma_buf_probe;
+        let mut use_dmabuf = false;
+        let mut dmabuf_fds: [i32; V4L2_BUFFER_COUNT as usize] = [-1; V4L2_BUFFER_COUNT as usize];
+        let mut dmabuf_imported_buffers: Vec<StorageBuffer> = Vec::new();
+        if caps.supports_external_memory && !is_virtual_device && !probe_skipped {
+            let mut imported: Vec<Option<StorageBuffer>> =
+                (0..V4L2_BUFFER_COUNT as usize).map(|_| None).collect();
+            let mut all_imported = true;
+            for i in 0..V4L2_BUFFER_COUNT as usize {
+                let fd: i32 = unsafe {
+                    let mut expbuf: v4l::v4l_sys::v4l2_exportbuffer = std::mem::zeroed();
+                    expbuf.type_ = v4l::buffer::Type::VideoCapture as u32;
+                    expbuf.index = i as u32;
+                    expbuf.flags = libc::O_CLOEXEC as u32;
+                    let r = libc::ioctl(
+                        device_fd,
+                        v4l::v4l2::vidioc::VIDIOC_EXPBUF as libc::c_ulong,
+                        &mut expbuf,
+                    );
+                    if r != 0 { -1 } else { expbuf.fd }
+                };
+                if fd < 0 {
+                    if i == 0 {
+                        tracing::info!(
+                            camera = camera_name,
+                            "VIDIOC_EXPBUF not supported — using MMAP path"
+                        );
+                    }
+                    all_imported = false;
+                    break;
+                }
+                match full.import_dma_buf_storage_buffer(fd, input_alloc_size) {
+                    Ok(buf) => {
+                        dmabuf_fds[i] = fd;
+                        imported[i] = Some(buf);
+                    }
+                    Err(e) => {
+                        if i == 0 {
+                            if vulkan_device_name.to_lowercase().contains("nvidia") {
+                                tracing::info!(
+                                    "CameraSource {}: DMA-BUF import failed on NVIDIA GPU \
+                                     (cross-device DMA-BUF limitation). Falling back to \
+                                     MMAP + memcpy. This is expected and performant with \
+                                     GPU compute.",
+                                    camera_name
+                                );
+                            } else {
+                                tracing::warn!(
+                                    "CameraSource {}: DMA-BUF import failed (unexpected on {}): \
+                                     {}. Falling back to MMAP + memcpy.",
+                                    camera_name,
+                                    vulkan_device_name,
+                                    e
+                                );
+                            }
+                        }
+                        unsafe { libc::close(fd) };
+                        all_imported = false;
+                        break;
+                    }
+                }
+            }
+            if all_imported {
+                dmabuf_imported_buffers = imported.into_iter().map(|o| o.unwrap()).collect();
+                use_dmabuf = true;
+            } else {
+                for fd in &mut dmabuf_fds {
+                    if *fd >= 0 {
+                        unsafe { libc::close(*fd) };
+                        *fd = -1;
+                    }
+                }
+            }
+        }
+
+        Ok(CameraGpuResources {
+            color_converter,
+            recorder,
+            timeline,
+            ring_produce_done,
+            ring_consume_done,
+            input_storage_buffers,
+            input_mapped_ptrs,
+            ring_textures,
+            ring_texture_ids,
+            use_dmabuf,
+            dmabuf_imported_buffers,
+            dmabuf_fds,
+            vulkan_device_name,
+            probe_skipped,
+        })
+    });
+
+    let CameraGpuResources {
+        color_converter,
+        mut recorder,
+        timeline: camera_timeline,
+        ring_produce_done,
+        ring_consume_done,
+        input_storage_buffers,
+        input_mapped_ptrs,
+        ring_textures,
+        ring_texture_ids,
+        use_dmabuf,
+        dmabuf_imported_buffers,
+        mut dmabuf_fds,
+        vulkan_device_name,
+        probe_skipped,
+    } = match setup_result {
+        Ok(resources) => resources,
+        Err(e) => {
+            tracing::error!(camera = camera_name, error = %e, "failed to set up GPU resources");
+            return;
+        }
+    };
+
+    if probe_skipped {
+        tracing::info!(
+            camera = camera_name,
+            device = %vulkan_device_name,
+            "DMA-BUF probe skipped — driver blocklisted for cross-device imports (#638). \
+             Using MMAP + memcpy."
+        );
+    }
+    if use_dmabuf {
+        tracing::info!(
+            camera = camera_name,
+            buffers_imported = V4L2_BUFFER_COUNT,
+            "DMA-BUF zero-copy enabled",
+        );
+    }
+
+    // Each ring slot carries a per-slot single-writer-per-edge exportable
+    // timeline pair; the post-compute barrier transitions the ring to
+    // `SHADER_READ_ONLY_OPTIMAL` before publish, so the registered layout
+    // matches contents by the time any consumer dereferences `surface_id`.
+    for (i, (texture_id, stream_texture)) in ring_texture_ids
+        .iter()
+        .zip(ring_textures.iter())
+        .enumerate()
+    {
+        if let Some(store) = gpu_context.surface_store()
+            && let Err(e) = store.register_texture(
+                texture_id,
+                stream_texture,
+                Some(&ring_produce_done[i]),
+                Some(&ring_consume_done[i]),
+                VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+            )
+        {
+            tracing::warn!(
+                camera = camera_name,
+                ring_index = i,
+                error = %e,
+                "failed to register ring texture with the surface-share service — \
+                 cross-process GPU sharing unavailable, same-process still works",
+            );
+        }
+        gpu_context.register_texture_with_layout(
+            texture_id,
+            stream_texture.clone(),
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+        );
+    }
+
+    let dispatch_x = width.div_ceil(16);
+    let dispatch_y = height.div_ceil(16);
+
+    // DMA-BUF path drives DQBUF/QBUF per frame directly, so it QBUFs the
+    // initial set + STREAMONs manually (the mmap stream does this internally
+    // on first `next()`, which the MMAP path relies on).
+    if use_dmabuf {
+        unsafe {
+            for i in 0..V4L2_BUFFER_COUNT {
+                let mut v4l2_buf: v4l::v4l_sys::v4l2_buffer = std::mem::zeroed();
+                v4l2_buf.type_ = v4l::buffer::Type::VideoCapture as u32;
+                v4l2_buf.memory = v4l::memory::Memory::Mmap as u32;
+                v4l2_buf.index = i;
+                libc::ioctl(
+                    device_fd,
+                    v4l::v4l2::vidioc::VIDIOC_QBUF as libc::c_ulong,
+                    &mut v4l2_buf,
+                );
+            }
+            let mut buf_type: u32 = v4l::buffer::Type::VideoCapture as u32;
+            libc::ioctl(
+                device_fd,
+                v4l::v4l2::vidioc::VIDIOC_STREAMON as libc::c_ulong,
+                &mut buf_type,
+            );
+        }
+    }
+
+    let requeue = |buf: Option<v4l::v4l_sys::v4l2_buffer>| {
+        if let Some(mut v4l2_buf) = buf {
+            unsafe {
+                libc::ioctl(
+                    device_fd,
+                    v4l::v4l2::vidioc::VIDIOC_QBUF as libc::c_ulong,
+                    &mut v4l2_buf,
+                );
+            }
+        }
+    };
+
+    let mut ping_pong_index: usize = 0;
+
+    while is_capturing.load(Ordering::Acquire) {
+        // ---- Step 1: Acquire frame and select input SSBO ----
+        let mut v4l2_requeue_buf: Option<v4l::v4l_sys::v4l2_buffer> = None;
+        let frame_sequence: u32;
+        let input_ssbo_index: usize;
+
+        if use_dmabuf {
+            unsafe {
+                let mut pollfd = libc::pollfd {
+                    fd: device_fd,
+                    events: libc::POLLIN,
+                    revents: 0,
+                };
+                let poll_result = libc::poll(&mut pollfd, 1, 1000);
+                if poll_result == 0 {
+                    continue;
+                }
+                if poll_result < 0 {
+                    if is_capturing.load(Ordering::Acquire) {
+                        tracing::error!(camera = camera_name, "V4L2 poll error");
+                    }
+                    break;
+                }
+
+                let mut v4l2_buf: v4l::v4l_sys::v4l2_buffer = std::mem::zeroed();
+                v4l2_buf.type_ = v4l::buffer::Type::VideoCapture as u32;
+                v4l2_buf.memory = v4l::memory::Memory::Mmap as u32;
+
+                if libc::ioctl(
+                    device_fd,
+                    v4l::v4l2::vidioc::VIDIOC_DQBUF as libc::c_ulong,
+                    &mut v4l2_buf,
+                ) != 0
+                {
+                    if is_capturing.load(Ordering::Acquire) {
+                        tracing::error!(camera = camera_name, "DQBUF failed");
+                    }
+                    continue;
+                }
+
+                input_ssbo_index = v4l2_buf.index as usize;
+                frame_sequence = v4l2_buf.sequence;
+                v4l2_requeue_buf = Some(v4l2_buf);
+            }
+        } else {
+            // MMAP path: stream.next() issues VIDIOC_QBUF + VIDIOC_STREAMON
+            // on its first call, then blocks on VIDIOC_DQBUF with the poll
+            // timeout applied in start(). Do NOT poll the fd before
+            // stream.next() — strict-conformance drivers (v4l2loopback) only
+            // signal POLLIN after STREAMON, so an earlier poll hangs.
+            let (buf, meta) = match stream.next() {
+                Ok(frame) => frame,
+                Err(e) if e.kind() == std::io::ErrorKind::TimedOut => continue,
+                Err(e) => {
+                    if is_capturing.load(Ordering::Acquire) {
+                        tracing::error!(camera = camera_name, error = %e, "V4L2 stream error");
+                    }
+                    break;
+                }
+            };
+            if !is_capturing.load(Ordering::Acquire) {
+                break;
+            }
+            frame_sequence = meta.sequence;
+            input_ssbo_index = ping_pong_index;
+
+            let copy_len = buf.len().min(input_byte_size);
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    buf.as_ptr(),
+                    input_mapped_ptrs[input_ssbo_index],
+                    copy_len,
+                );
+            }
+        }
+
+        // Wait for the previous use of this ring texture slot to complete.
+        // Frame N uses slot N % RING_TEXTURE_COUNT; the previous use was
+        // frame N - RING_TEXTURE_COUNT which signaled timeline value
+        // (N - RING_TEXTURE_COUNT + 1). The first RING_TEXTURE_COUNT frames
+        // skip (initial timeline value 0).
+        let frame_num_peek = frame_counter.load(Ordering::Relaxed);
+        if frame_num_peek >= RING_TEXTURE_COUNT as u64 {
+            let wait_value = frame_num_peek - (RING_TEXTURE_COUNT as u64 - 1);
+            if let Err(e) = camera_timeline.wait(wait_value, u64::MAX) {
+                tracing::warn!(camera = camera_name, error = %e, "timeline wait failed");
+            }
+        }
+
+        let frame_num = frame_counter.fetch_add(1, Ordering::Relaxed);
+
+        // ---- Step 2: Select ring texture + acquire pixel buffer for IPC ----
+        let ring_index = (frame_num as usize) % RING_TEXTURE_COUNT;
+
+        let (pool_id, pooled_buffer) = match gpu_context.acquire_pixel_buffer(
+            width,
+            height,
+            PixelFormat::Rgba32,
+        ) {
+            Ok(result) => result,
+            Err(e) => {
+                if frame_num == 0 {
+                    tracing::error!(camera = camera_name, error = %e, "failed to acquire pixel buffer");
+                }
+                requeue(v4l2_requeue_buf);
+                continue;
+            }
+        };
+
+        // Register the ring texture under the pixel buffer's pool_id so a
+        // same-process display resolves the texture via the same surface_id
+        // used for pixel-buffer IPC.
+        gpu_context.register_texture_with_layout(
+            &pool_id.to_string(),
+            ring_textures[ring_index].clone(),
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+        );
+
+        // ---- Step 3: Bind kernel via the color converter ----
+        let input_buffer = if use_dmabuf {
+            &dmabuf_imported_buffers[input_ssbo_index]
+        } else {
+            &input_storage_buffers[input_ssbo_index]
+        };
+        let kernel = match color_converter.prepare_buffer_to_image_storage(
+            input_buffer,
+            src_layout,
+            &ring_textures[ring_index],
+            &resolved_color,
+            // Display path consumes RGBA8_UNORM treated as sRGB-encoded by
+            // the swapchain; #817 will replace this hardcode with the
+            // negotiated VkColorSpaceKHR.
+            TransferId::Srgb,
+        ) {
+            Ok(k) => k,
+            Err(e) => {
+                tracing::error!(camera = camera_name, error = %e, "color_converter prepare failed");
+                requeue(v4l2_requeue_buf);
+                continue;
+            }
+        };
+
+        // ---- Step 4: Record + submit ----
+        if let Err(e) = recorder.begin() {
+            tracing::error!(camera = camera_name, error = %e, "recorder.begin failed");
+            requeue(v4l2_requeue_buf);
+            continue;
+        }
+
+        // pre-compute: ring texture UNDEFINED → GENERAL.
+        if let Err(e) = recorder.record_image_barrier(
+            &ring_textures[ring_index],
+            VulkanLayout::UNDEFINED,
+            VulkanLayout::GENERAL,
+            VulkanStage::NONE,
+            VulkanStage::COMPUTE_SHADER,
+            VulkanAccess::NONE,
+            VulkanAccess::SHADER_WRITE,
+        ) {
+            tracing::error!(camera = camera_name, error = %e, "pre-compute image barrier failed");
+            continue;
+        }
+
+        // pre-compute: imported DMA-BUF SSBO needs an explicit
+        // read-availability barrier (the V4L2 driver wrote it before we got
+        // the fd). HOST_VISIBLE SSBOs don't — coherent host writes need no
+        // GPU-side sync beyond the implicit submit-time barrier.
+        if use_dmabuf
+            && let Err(e) = recorder.record_buffer_barrier(
+                &dmabuf_imported_buffers[input_ssbo_index],
+                VulkanStage::NONE,
+                VulkanStage::COMPUTE_SHADER,
+                VulkanAccess::NONE,
+                VulkanAccess::SHADER_READ,
+            )
+        {
+            tracing::error!(camera = camera_name, error = %e, "pre-compute buffer barrier failed");
+            continue;
+        }
+
+        if let Err(e) = recorder.record_dispatch(&kernel, dispatch_x, dispatch_y, 1) {
+            tracing::error!(camera = camera_name, error = %e, "record_dispatch failed");
+            continue;
+        }
+
+        // post-compute: ring texture GENERAL → TRANSFER_SRC for the host
+        // pixel-buffer copy.
+        if let Err(e) = recorder.record_image_barrier(
+            &ring_textures[ring_index],
+            VulkanLayout::GENERAL,
+            VulkanLayout::TRANSFER_SRC_OPTIMAL,
+            VulkanStage::COMPUTE_SHADER,
+            VulkanStage::ALL_TRANSFER,
+            VulkanAccess::SHADER_WRITE,
+            VulkanAccess::TRANSFER_READ,
+        ) {
+            tracing::error!(camera = camera_name, error = %e, "post-compute image barrier failed");
+            continue;
+        }
+
+        // Copy ring → pooled pixel buffer (cross-process IPC + CPU readback).
+        let copy_region = ImageCopyRegion::tightly_packed(width, height);
+        if let Err(e) = recorder.record_copy_image_to_buffer(
+            &ring_textures[ring_index],
+            VulkanLayout::TRANSFER_SRC_OPTIMAL,
+            &pooled_buffer,
+            copy_region,
+        ) {
+            tracing::error!(camera = camera_name, error = %e, "record_copy_image_to_buffer failed");
+            continue;
+        }
+
+        // post-copy: ring texture TRANSFER_SRC → SHADER_READ_ONLY (consumed
+        // by display); pixel buffer TRANSFER_WRITE → HOST_READ.
+        if let Err(e) = recorder.record_image_barrier(
+            &ring_textures[ring_index],
+            VulkanLayout::TRANSFER_SRC_OPTIMAL,
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+            VulkanStage::ALL_TRANSFER,
+            VulkanStage::FRAGMENT_SHADER,
+            VulkanAccess::TRANSFER_READ,
+            VulkanAccess::SHADER_READ,
+        ) {
+            tracing::error!(camera = camera_name, error = %e, "post-copy image barrier failed");
+            continue;
+        }
+        if let Err(e) = recorder.record_buffer_barrier(
+            &pooled_buffer,
+            VulkanStage::ALL_TRANSFER,
+            VulkanStage::HOST,
+            VulkanAccess::TRANSFER_WRITE,
+            VulkanAccess::HOST_READ,
+        ) {
+            tracing::error!(camera = camera_name, error = %e, "pixel-buffer host-read barrier failed");
+            continue;
+        }
+
+        // Submit + signal timeline value (= frame_num + 1 so consumers can
+        // wait on a monotonically advancing counter), then wait so the pixel
+        // buffer is host-readable before the IPC write below.
+        let timeline_signal_value = frame_num + 1;
+        if let Err(e) = recorder.submit_signaling_timeline(&camera_timeline, timeline_signal_value)
+        {
+            if frame_num == 0 {
+                tracing::error!(camera = camera_name, error = %e, "failed to submit compute dispatch");
+            }
+            requeue(v4l2_requeue_buf);
+            continue;
+        }
+        if let Err(e) = camera_timeline.wait(timeline_signal_value, u64::MAX) {
+            tracing::warn!(camera = camera_name, error = %e, "host-readback timeline wait failed");
+        }
+
+        // ---- Step 5: Re-queue V4L2 buffer in DMA-BUF mode ----
+        requeue(v4l2_requeue_buf);
+
+        // ---- Step 6: Publish frame ----
+        // The pixel-buffer pool_id is the surface_id — the universal key:
+        // same-process texture cache, cross-process surface-share, and CPU
+        // readback all resolve through it.
+        let frame = VideoFrame {
+            surface_id: pool_id.to_string(),
+            width,
+            height,
+            timestamp_ns: MediaClock::now().as_nanos() as i64,
+            fps: capture_fps,
+            color_info: Some(cached_color_info.clone()),
+            // V4L2 doesn't surface ST.2086 / CLLI; HDR-aware sources only.
+            mastering_display: None,
+            content_light: None,
+            texture_layout: None,
+        };
+        if let Err(e) = outputs.write("video", &frame) {
+            tracing::error!(camera = camera_name, error = %e, "failed to write frame");
+            continue;
+        }
+
+        // The pooled pixel buffer must stay alive until the consumer reads
+        // it; the pool reclaims the slot when this handle drops after the
+        // write has been delivered into the link's ring.
+        drop(pooled_buffer);
+
+        if frame_num == 0 {
+            let mode = if use_dmabuf {
+                "DMA-BUF zero-copy"
+            } else {
+                "MMAP + memcpy"
+            };
+            tracing::info!(
+                camera = camera_name,
+                mode,
+                seq = frame_sequence,
+                width,
+                height,
+                ?fourcc,
+                "first frame captured via GPU compute",
+            );
+        } else if frame_num % 300 == 0 {
+            tracing::debug!(camera = camera_name, frame = frame_num, "frame milestone");
+        }
+
+        if !use_dmabuf {
+            ping_pong_index = 1 - ping_pong_index;
+        }
+    }
+
+    // STREAMOFF in DMA-BUF mode (the mmap stream's Drop handles MMAP mode).
+    if use_dmabuf {
+        unsafe {
+            let mut buf_type: u32 = v4l::buffer::Type::VideoCapture as u32;
+            libc::ioctl(
+                device_fd,
+                v4l::v4l2::vidioc::VIDIOC_STREAMOFF as libc::c_ulong,
+                &mut buf_type,
+            );
+        }
+    }
+
+    // The VIDIOC_EXPBUF fds were dup'd into Vulkan imports; the V4L2-side
+    // fds are ours to close.
+    for fd in &mut dmabuf_fds {
+        if *fd >= 0 {
+            unsafe { libc::close(*fd) };
+            *fd = -1;
+        }
+    }
+
+    drop(dmabuf_imported_buffers);
+    drop(ring_textures);
+    drop(ring_produce_done);
+    drop(ring_consume_done);
+    drop(input_storage_buffers);
+    drop(recorder);
+    drop(color_converter);
+    drop(camera_timeline);
+}
+
+// Per-axis maps from the bag's H.273 vocabulary to the engine's color IDs.
+// The engine accepts only its own primitive types in public signatures, so
+// each consumer translates at the boundary.
+
+fn primaries_id(p: &Primaries) -> PrimariesId {
+    match p {
+        Primaries::Bt709 => PrimariesId::Bt709,
+        Primaries::Bt470M => PrimariesId::Bt470M,
+        Primaries::Bt470Bg => PrimariesId::Bt470Bg,
+        Primaries::Smpte170m => PrimariesId::Smpte170m,
+        Primaries::Smpte240m => PrimariesId::Smpte240m,
+        Primaries::Film => PrimariesId::Film,
+        Primaries::Bt2020 => PrimariesId::Bt2020,
+        Primaries::Smpte428 => PrimariesId::Smpte428,
+        Primaries::Smpte431 => PrimariesId::Smpte431,
+        Primaries::Smpte432 => PrimariesId::Smpte432,
+        Primaries::Ebu3213 => PrimariesId::Ebu3213,
+    }
+}
+
+fn transfer_id(t: &Transfer) -> TransferId {
+    match t {
+        Transfer::Srgb => TransferId::Srgb,
+        Transfer::Bt709
+        | Transfer::Smpte170m
+        | Transfer::Bt2020TenBit
+        | Transfer::Bt2020TwelveBit => TransferId::Bt709,
+        Transfer::Smpte2084 => TransferId::Pq,
+        Transfer::AribStdB67 => TransferId::Hlg,
+        Transfer::Linear => TransferId::Linear,
+        // Gamma22 / Gamma28 / Smpte240m / Log* / Xvycc / Bt1361 / Smpte428
+        // are uncommon end-to-end; map to Linear (no transform).
+        _ => TransferId::Linear,
+    }
+}
+
+fn matrix_id(m: &Matrix) -> MatrixId {
+    match m {
+        Matrix::Identity => MatrixId::Identity,
+        Matrix::Bt709 => MatrixId::Bt709,
+        Matrix::Fcc => MatrixId::Fcc,
+        Matrix::Bt470Bg => MatrixId::Bt470Bg,
+        Matrix::Smpte170m => MatrixId::Smpte170m,
+        Matrix::Smpte240m => MatrixId::Smpte240m,
+        Matrix::Ycgco => MatrixId::Ycgco,
+        Matrix::Bt2020Ncl => MatrixId::Bt2020Ncl,
+        Matrix::Bt2020Cl => MatrixId::Bt2020Cl,
+        Matrix::Smpte2085 => MatrixId::Smpte2085,
+        Matrix::ChromaNcl => MatrixId::ChromaNcl,
+        Matrix::ChromaCl => MatrixId::ChromaCl,
+        Matrix::Ictcp => MatrixId::Ictcp,
+    }
+}
+
+fn range_id(r: &Range) -> RangeId {
+    match r {
+        Range::Limited => RangeId::Limited,
+        Range::Full => RangeId::Full,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_devices_succeeds_with_or_without_cameras() {
+        let devices = list_camera_capture_devices().expect("enumeration must not error");
+        for device in &devices {
+            assert!(device.id.starts_with("/dev/video"), "{}", device.id);
+        }
+    }
+
+    #[test]
+    fn config_defaults_to_no_device_and_uncapped() {
+        let config: CameraSourceConfig = serde_json::from_str("{}").expect("empty config");
+        assert_eq!(config.device_id, None);
+        assert_eq!((config.max_width, config.max_height), (None, None));
+    }
+
+    /// Every bag-vocabulary color axis maps to an engine ID without panicking.
+    #[test]
+    fn color_axis_maps_are_total() {
+        use crate::video_frame::{Matrix, Primaries, Range, Transfer};
+        let _ = primaries_id(&Primaries::Bt709);
+        let _ = transfer_id(&Transfer::Xvycc);
+        let _ = matrix_id(&Matrix::Ictcp);
+        let _ = range_id(&Range::Full);
+    }
+}

--- a/runtime/streamlib-media-builtins/src/display_window.rs
+++ b/runtime/streamlib-media-builtins/src/display_window.rs
@@ -179,6 +179,7 @@ impl ManualProcessor for DisplayWindow::Processor {
                     scaling: scaling.present_scaling_mode(),
                     current_frame_color_info: None,
                     inactive: false,
+                    last_unresolved_surface_id: None,
                 };
                 if let Err(e) = event_loop.run_app(&mut handler) {
                     tracing::error!(error = %e, "DisplayWindow: event loop exited with error");
@@ -246,6 +247,9 @@ struct DisplayWindowEventLoopHandler {
     /// Degraded mode: no surface could be created. The display then behaves
     /// as a sink — drains and discards — so upstream sees a live consumer.
     inactive: bool,
+    /// The last surface id that failed to resolve, so the failure warns once
+    /// per surface instead of once per redraw.
+    last_unresolved_surface_id: Option<String>,
 }
 
 impl ApplicationHandler for DisplayWindowEventLoopHandler {
@@ -460,13 +464,22 @@ impl DisplayWindowEventLoopHandler {
             frame_bag.width,
             frame_bag.height,
         ) {
-            Ok(registration) => registration,
+            Ok(registration) => {
+                self.last_unresolved_surface_id = None;
+                registration
+            }
             Err(e) => {
-                tracing::warn!(
-                    surface_id = %frame_bag.surface_id,
-                    error = %e,
-                    "DisplayWindow: failed to resolve frame texture"
-                );
+                // Redraws retry at frame rate; warn once per surface, not
+                // once per attempt.
+                if self.last_unresolved_surface_id.as_deref() != Some(frame_bag.surface_id.as_str())
+                {
+                    tracing::warn!(
+                        surface_id = %frame_bag.surface_id,
+                        error = %e,
+                        "DisplayWindow: failed to resolve frame texture (warning once per surface)"
+                    );
+                    self.last_unresolved_surface_id = Some(frame_bag.surface_id.clone());
+                }
                 return;
             }
         };

--- a/runtime/streamlib-media-builtins/src/display_window.rs
+++ b/runtime/streamlib-media-builtins/src/display_window.rs
@@ -1,0 +1,575 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+#![cfg(target_os = "linux")]
+
+//! Built-in display: window lifecycle + event pump, one present-composition
+//! call per frame.
+//!
+//! The window and event pump belong to this processor; the engine mints the
+//! present target from the raw window handle and owns every swapchain and
+//! acquire detail. The draw step is
+//! [`VulkanPresentCompositor::compose_to_present_frame`] — the display never
+//! records Vulkan work of its own.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use streamlib::sdk::color::ColorTraits;
+use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess};
+use streamlib::sdk::engine::host_rhi::{
+    PresentScalingMode, VulkanPresentCompositor, VulkanPresentTarget,
+};
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::iceoryx2::InputMailboxes;
+use streamlib::sdk::processors::ManualProcessor;
+use streamlib::sdk::rhi::VulkanLayout;
+
+use winit::application::ApplicationHandler;
+use winit::dpi::PhysicalSize;
+use winit::event::WindowEvent;
+use winit::event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy};
+use winit::window::{Window, WindowAttributes};
+
+use crate::video_frame::{ColorInfo, VideoFrame};
+
+/// How the frame maps onto the window, as configuration vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum DisplayScaling {
+    /// Whole frame visible, black bars fill the rest.
+    #[default]
+    Fit,
+    /// Window covered, frame overflow cropped.
+    Fill,
+    /// Frame stretched to the window exactly.
+    Stretch,
+}
+
+impl DisplayScaling {
+    fn present_scaling_mode(self) -> PresentScalingMode {
+        match self {
+            DisplayScaling::Fit => PresentScalingMode::Fit,
+            DisplayScaling::Fill => PresentScalingMode::Fill,
+            DisplayScaling::Stretch => PresentScalingMode::Stretch,
+        }
+    }
+}
+
+/// Configuration for [`DisplayWindow`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DisplayWindowConfig {
+    /// Window title.
+    #[serde(default = "default_title")]
+    pub title: String,
+    /// Initial window width in pixels.
+    #[serde(default = "default_window_width")]
+    pub width: u32,
+    /// Initial window height in pixels.
+    #[serde(default = "default_window_height")]
+    pub height: u32,
+    /// How the frame maps onto the window.
+    #[serde(default)]
+    pub scaling: DisplayScaling,
+}
+
+fn default_title() -> String {
+    "StreamLib".to_string()
+}
+
+fn default_window_width() -> u32 {
+    1280
+}
+
+fn default_window_height() -> u32 {
+    720
+}
+
+impl Default for DisplayWindowConfig {
+    fn default() -> Self {
+        Self {
+            title: default_title(),
+            width: default_window_width(),
+            height: default_window_height(),
+            scaling: DisplayScaling::default(),
+        }
+    }
+}
+
+#[streamlib::sdk::processor(
+    "@tatolab/media-builtins/DisplayWindow",
+    description = "Shows video frames in a window with vsync",
+    execution = manual,
+    scheduling = high,
+    config = crate::display_window::DisplayWindowConfig,
+    input("video", any, delivery_profile = "latest", description = "Video frames to show in the window"),
+)]
+pub struct DisplayWindow {
+    gpu_context: Option<GpuContextLimitedAccess>,
+    running: Arc<AtomicBool>,
+    frame_counter: Arc<AtomicU64>,
+    render_thread: Option<JoinHandle<()>>,
+    event_loop_proxy: Arc<OnceLock<EventLoopProxy<()>>>,
+}
+
+impl ManualProcessor for DisplayWindow::Processor {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        // The render thread needs an owned handle that escapes into the
+        // thread closure, so the clone at setup is load-bearing.
+        self.gpu_context = Some(ctx.gpu_limited_access().clone());
+        Ok(())
+    }
+
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.stop_render_thread();
+        Ok(())
+    }
+
+    fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let gpu_context = self.gpu_context.clone().ok_or_else(|| {
+            Error::Configuration("GPU context not initialized. Call setup() first.".into())
+        })?;
+
+        self.running.store(true, Ordering::Release);
+        let running = Arc::clone(&self.running);
+        let frame_counter = Arc::clone(&self.frame_counter);
+        let event_loop_proxy = Arc::clone(&self.event_loop_proxy);
+        let inputs: InputMailboxes = self.inputs.clone();
+        let window_title = self.config.title.clone();
+        let window_width = self.config.width;
+        let window_height = self.config.height;
+        let scaling = self.config.scaling;
+
+        let handle = std::thread::Builder::new()
+            .name("display-window".to_string())
+            .spawn(move || {
+                let event_loop = {
+                    // The event loop runs on this render thread, not the
+                    // process main thread; X11 permits that with the
+                    // any-thread opt-in. (Wayland winit permits it too via
+                    // its own extension; the X11 builder path covers today's
+                    // rig.)
+                    use winit::platform::x11::EventLoopBuilderExtX11;
+                    EventLoop::builder().with_any_thread(true).build()
+                };
+                let event_loop = match event_loop {
+                    Ok(el) => el,
+                    Err(e) => {
+                        tracing::error!(error = %e, "DisplayWindow: failed to build event loop");
+                        running.store(false, Ordering::Release);
+                        return;
+                    }
+                };
+                let _ = event_loop_proxy.set(event_loop.create_proxy());
+
+                let mut handler = DisplayWindowEventLoopHandler {
+                    gpu_context,
+                    inputs,
+                    running: Arc::clone(&running),
+                    frame_counter,
+                    window: None,
+                    present_target: None,
+                    compositor: None,
+                    window_title,
+                    width: window_width,
+                    height: window_height,
+                    scaling: scaling.present_scaling_mode(),
+                    current_frame_color_info: None,
+                    inactive: false,
+                };
+                if let Err(e) = event_loop.run_app(&mut handler) {
+                    tracing::error!(error = %e, "DisplayWindow: event loop exited with error");
+                }
+                running.store(false, Ordering::Release);
+            })
+            .map_err(|e| Error::Configuration(format!("Failed to spawn render thread: {}", e)))?;
+
+        self.render_thread = Some(handle);
+        tracing::info!("DisplayWindow: render thread started");
+        Ok(())
+    }
+
+    fn stop(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.stop_render_thread();
+        tracing::info!(
+            "DisplayWindow: stopped ({} frames)",
+            self.frame_counter.load(Ordering::Relaxed)
+        );
+        Ok(())
+    }
+}
+
+impl DisplayWindow::Processor {
+    fn stop_render_thread(&mut self) {
+        self.running.store(false, Ordering::Release);
+        // Wake the event pump so `about_to_wait` observes `running == false`
+        // without waiting for its next timeout tick.
+        if let Some(proxy) = self.event_loop_proxy.get() {
+            let _ = proxy.send_event(());
+        }
+        // Bounded wait: a stalled GPU / driver state can wedge the render
+        // thread; detaching after the grace window keeps the runtime's
+        // shutdown chain moving. The detached thread is reaped at process
+        // exit.
+        if let Some(handle) = self.render_thread.take() {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while !handle.is_finished() && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            if handle.is_finished() {
+                let _ = handle.join();
+            } else {
+                tracing::warn!("DisplayWindow: render thread did not exit within 2s, detaching");
+            }
+        }
+    }
+}
+
+struct DisplayWindowEventLoopHandler {
+    gpu_context: GpuContextLimitedAccess,
+    inputs: InputMailboxes,
+    running: Arc<AtomicBool>,
+    frame_counter: Arc<AtomicU64>,
+    window: Option<Window>,
+    present_target: Option<VulkanPresentTarget>,
+    compositor: Option<VulkanPresentCompositor>,
+    window_title: String,
+    width: u32,
+    height: u32,
+    scaling: PresentScalingMode,
+    /// Last-applied per-frame color description; a change triggers a
+    /// swapchain recreate with the new colorspace pick.
+    current_frame_color_info: Option<ColorInfo>,
+    /// Degraded mode: no surface could be created. The display then behaves
+    /// as a sink — drains and discards — so upstream sees a live consumer.
+    inactive: bool,
+}
+
+impl ApplicationHandler for DisplayWindowEventLoopHandler {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.window.is_some() {
+            return;
+        }
+        let attributes = WindowAttributes::default()
+            .with_title(&self.window_title)
+            .with_inner_size(PhysicalSize::new(self.width, self.height));
+        let window = match event_loop.create_window(attributes) {
+            Ok(w) => w,
+            Err(e) => {
+                tracing::error!(error = %e, "DisplayWindow: window creation failed — running degraded (frames drained, nothing shown)");
+                self.inactive = true;
+                return;
+            }
+        };
+
+        let inner_size = window.inner_size();
+        self.width = inner_size.width.max(1);
+        self.height = inner_size.height.max(1);
+
+        let created = self.gpu_context.escalate(|full| {
+            let present_target =
+                full.create_present_target(&window, self.width, self.height, true, None)?;
+            let compositor = full.create_present_compositor(present_target.color_format())?;
+            Ok((present_target, compositor))
+        });
+        match created {
+            Ok((present_target, compositor)) => {
+                self.present_target = Some(present_target);
+                self.compositor = Some(compositor);
+                self.window = Some(window);
+                tracing::info!(
+                    width = self.width,
+                    height = self.height,
+                    "DisplayWindow: window + present target ready"
+                );
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "DisplayWindow: present-target creation failed — running degraded (frames drained, nothing shown)");
+                self.inactive = true;
+            }
+        }
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        _id: winit::window::WindowId,
+        event: WindowEvent,
+    ) {
+        match event {
+            WindowEvent::CloseRequested => {
+                tracing::info!("DisplayWindow: window close requested");
+                self.running.store(false, Ordering::Release);
+                event_loop.exit();
+            }
+            WindowEvent::Resized(new_size) => {
+                if new_size.width == 0 || new_size.height == 0 {
+                    return;
+                }
+                self.width = new_size.width;
+                self.height = new_size.height;
+                let color_traits = self
+                    .current_frame_color_info
+                    .as_ref()
+                    .map(ColorInfo::engine_color_traits);
+                if let Some(present_target) = self.present_target.as_mut()
+                    && let Err(e) = present_target.recreate(
+                        new_size.width,
+                        new_size.height,
+                        color_traits.as_ref(),
+                    )
+                {
+                    tracing::error!(error = %e, "DisplayWindow: swapchain recreate on resize failed");
+                    event_loop.exit();
+                }
+            }
+            WindowEvent::RedrawRequested => {
+                self.render_frame();
+            }
+            _ => {}
+        }
+    }
+
+    fn user_event(&mut self, event_loop: &ActiveEventLoop, _event: ()) {
+        if !self.running.load(Ordering::Acquire) {
+            event_loop.exit();
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        if !self.running.load(Ordering::Acquire) {
+            event_loop.exit();
+            return;
+        }
+
+        if self.inactive {
+            // Drain and discard so upstream sees a live consumer; the frame
+            // counter still advances per drained frame.
+            let mut drained = 0u64;
+            while let Ok(Some(_)) = self.inputs.read_raw("video") {
+                drained += 1;
+            }
+            if drained > 0 {
+                self.frame_counter.fetch_add(drained, Ordering::Relaxed);
+            }
+            event_loop.set_control_flow(winit::event_loop::ControlFlow::WaitUntil(
+                Instant::now() + Duration::from_millis(2),
+            ));
+            return;
+        }
+
+        if let Some(ref window) = self.window {
+            if self.inputs.has_data("video") {
+                window.request_redraw();
+            } else {
+                event_loop.set_control_flow(winit::event_loop::ControlFlow::WaitUntil(
+                    Instant::now() + Duration::from_millis(1),
+                ));
+            }
+        }
+    }
+}
+
+impl DisplayWindowEventLoopHandler {
+    fn render_frame(&mut self) {
+        if !self.inputs.has_data("video") {
+            return;
+        }
+        if self.present_target.is_none() || self.compositor.is_none() {
+            return;
+        }
+
+        let frame_bag: VideoFrame = match self.inputs.read("video") {
+            Ok(frame) => frame,
+            Err(e) => {
+                tracing::warn!(error = %e, "DisplayWindow: failed to read frame");
+                return;
+            }
+        };
+
+        // Colorspace negotiation — recreate the swapchain when this frame's
+        // `color_info` differs from the last-applied value. First-frame
+        // inspection: the present target was constructed with `None` (legacy
+        // SDR pick) and upgrades to whatever the priority walk picks. A
+        // recreate can flip the attachment format (SDR BGRA8 → HDR10
+        // A2B10G10R10); `ensure_attachment_format` rebuilds the compositor's
+        // kernel when it does.
+        if frame_bag.color_info != self.current_frame_color_info {
+            let color_traits: Option<ColorTraits> = frame_bag
+                .color_info
+                .as_ref()
+                .map(ColorInfo::engine_color_traits);
+            let present_target = self.present_target.as_mut().expect("checked above");
+            match present_target.recreate(self.width, self.height, color_traits.as_ref()) {
+                Ok(()) => {
+                    self.current_frame_color_info = frame_bag.color_info.clone();
+                    let new_format = present_target.color_format();
+                    if let Some(compositor) = self.compositor.as_mut() {
+                        match compositor.ensure_attachment_format(new_format) {
+                            Ok(true) => {
+                                tracing::info!(
+                                    ?new_format,
+                                    "DisplayWindow: rebuilt compositor for new attachment format"
+                                );
+                                // Skip this frame's draw; the next frame uses
+                                // the rebuilt kernel against the new swapchain.
+                                self.frame_counter.fetch_add(1, Ordering::Relaxed);
+                                return;
+                            }
+                            Ok(false) => {}
+                            Err(e) => {
+                                tracing::error!(error = %e, "DisplayWindow: compositor rebuild failed");
+                                self.frame_counter.fetch_add(1, Ordering::Relaxed);
+                                return;
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "DisplayWindow: colorspace recreate failed (keeping previous swapchain)"
+                    );
+                }
+            }
+        }
+
+        // HDR static metadata — only meaningful when the picked colorspace
+        // is PQ/HLG (gated inside `set_hdr_metadata`) and the frame carries
+        // the sidecar.
+        if let (Some(mastering), Some(present_target)) = (
+            frame_bag.mastering_display.as_ref(),
+            self.present_target.as_mut(),
+        ) {
+            let metadata =
+                hdr_static_metadata_from_bag(mastering, frame_bag.content_light.as_ref());
+            if let Err(e) = present_target.set_hdr_metadata(&metadata) {
+                tracing::warn!(error = %e, "DisplayWindow: set_hdr_metadata failed");
+            }
+        }
+
+        // Resolve the frame's texture: same-process texture cache, then
+        // cross-process DMA-BUF import, then pixel-buffer upload — the
+        // engine's blessed resolution order.
+        let registration = match self.gpu_context.resolve_texture_registration_by_surface_id(
+            &frame_bag.surface_id,
+            frame_bag.texture_layout,
+            frame_bag.width,
+            frame_bag.height,
+        ) {
+            Ok(registration) => registration,
+            Err(e) => {
+                tracing::warn!(
+                    surface_id = %frame_bag.surface_id,
+                    error = %e,
+                    "DisplayWindow: failed to resolve frame texture"
+                );
+                return;
+            }
+        };
+        let frame_texture = registration.texture().clone();
+        let source_layout = registration.current_layout();
+
+        let compositor = self.compositor.as_ref().expect("checked above");
+        let scaling = self.scaling;
+        let present_target = self.present_target.as_mut().expect("checked above");
+        let present_result = present_target.render_frame(|frame| {
+            compositor.compose_to_present_frame(frame, &frame_texture, source_layout, scaling)
+        });
+        match present_result {
+            Ok(_presented) => {
+                // The compositor left the source in SHADER_READ_ONLY_OPTIMAL.
+                registration.update_layout(VulkanLayout::SHADER_READ_ONLY_OPTIMAL);
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "DisplayWindow: present failed");
+            }
+        }
+        self.frame_counter.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Translate the bag's HDR sidecar integers to the engine's f32 metadata:
+/// chromaticities are 1/50000 increments → CIE xy, luminances 0.0001 cd/m²
+/// increments → cd/m².
+fn hdr_static_metadata_from_bag(
+    mastering: &crate::video_frame::MasteringDisplay,
+    content_light: Option<&crate::video_frame::ContentLight>,
+) -> streamlib::sdk::color::HdrStaticMetadata {
+    let chromaticity = |v: u32| v as f32 / 50_000.0;
+    streamlib::sdk::color::HdrStaticMetadata {
+        display_primary_red: [
+            chromaticity(mastering.display_primaries_r_x),
+            chromaticity(mastering.display_primaries_r_y),
+        ],
+        display_primary_green: [
+            chromaticity(mastering.display_primaries_g_x),
+            chromaticity(mastering.display_primaries_g_y),
+        ],
+        display_primary_blue: [
+            chromaticity(mastering.display_primaries_b_x),
+            chromaticity(mastering.display_primaries_b_y),
+        ],
+        white_point: [
+            chromaticity(mastering.white_point_x),
+            chromaticity(mastering.white_point_y),
+        ],
+        min_luminance_cd_m2: mastering.min_luminance as f32 * 0.0001,
+        max_luminance_cd_m2: mastering.max_luminance as f32 * 0.0001,
+        max_content_light_level: content_light.map(|cl| cl.max_cll as f32).unwrap_or(0.0),
+        max_frame_average_light_level: content_light.map(|cl| cl.max_fall as f32).unwrap_or(0.0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_defaults_are_720p_fit() {
+        let config: DisplayWindowConfig = serde_json::from_str("{}").expect("empty config");
+        assert_eq!(config.title, "StreamLib");
+        assert_eq!((config.width, config.height), (1280, 720));
+        assert_eq!(config.scaling, DisplayScaling::Fit);
+    }
+
+    #[test]
+    fn scaling_vocabulary_is_snake_case() {
+        let config: DisplayWindowConfig =
+            serde_json::from_str(r#"{"scaling": "fill"}"#).expect("fill");
+        assert_eq!(config.scaling, DisplayScaling::Fill);
+        assert!(
+            serde_json::from_str::<DisplayWindowConfig>(r#"{"scaling": "Letterbox"}"#).is_err(),
+            "old vocabulary is not silently accepted"
+        );
+    }
+
+    #[test]
+    fn hdr_metadata_translation_scales_the_wire_integers() {
+        let mastering = crate::video_frame::MasteringDisplay {
+            display_primaries_r_x: 35_400, // 0.708 in 1/50000
+            display_primaries_r_y: 14_600,
+            display_primaries_g_x: 8_500,
+            display_primaries_g_y: 39_850,
+            display_primaries_b_x: 6_550,
+            display_primaries_b_y: 2_300,
+            white_point_x: 15_635,
+            white_point_y: 16_450,
+            max_luminance: 10_000_000, // 1000 cd/m² in 0.0001 increments
+            min_luminance: 50,         // 0.005 cd/m²
+        };
+        let content_light = crate::video_frame::ContentLight {
+            max_cll: 1_000,
+            max_fall: 400,
+        };
+        let metadata = hdr_static_metadata_from_bag(&mastering, Some(&content_light));
+        assert!((metadata.display_primary_red[0] - 0.708).abs() < 1e-6);
+        assert!((metadata.max_luminance_cd_m2 - 1_000.0).abs() < 1e-3);
+        assert!((metadata.min_luminance_cd_m2 - 0.005).abs() < 1e-6);
+        assert_eq!(metadata.max_content_light_level, 1_000.0);
+        assert_eq!(metadata.max_frame_average_light_level, 400.0);
+    }
+}

--- a/runtime/streamlib-media-builtins/src/display_window.rs
+++ b/runtime/streamlib-media-builtins/src/display_window.rs
@@ -382,6 +382,9 @@ impl DisplayWindowEventLoopHandler {
         if !self.inputs.has_data("video") {
             return;
         }
+        // Not a redundant twin of the let-else below: this early-out runs
+        // before the destructive `latest` read, so a frame is not consumed
+        // when there is nothing to render it into.
         if self.present_target.is_none() || self.compositor.is_none() {
             return;
         }

--- a/runtime/streamlib-media-builtins/src/display_window.rs
+++ b/runtime/streamlib-media-builtins/src/display_window.rs
@@ -148,12 +148,15 @@ impl ManualProcessor for DisplayWindow::Processor {
             .spawn(move || {
                 let event_loop = {
                     // The event loop runs on this render thread, not the
-                    // process main thread; X11 permits that with the
-                    // any-thread opt-in. (Wayland winit permits it too via
-                    // its own extension; the X11 builder path covers today's
-                    // rig.)
+                    // process main thread; both Linux backends need their
+                    // own any-thread opt-in (each trait method flags only
+                    // its backend).
+                    use winit::platform::wayland::EventLoopBuilderExtWayland;
                     use winit::platform::x11::EventLoopBuilderExtX11;
-                    EventLoop::builder().with_any_thread(true).build()
+                    let mut builder = EventLoop::builder();
+                    EventLoopBuilderExtX11::with_any_thread(&mut builder, true);
+                    EventLoopBuilderExtWayland::with_any_thread(&mut builder, true);
+                    builder.build()
                 };
                 let event_loop = match event_loop {
                     Ok(el) => el,
@@ -180,6 +183,7 @@ impl ManualProcessor for DisplayWindow::Processor {
                     current_frame_color_info: None,
                     inactive: false,
                     last_unresolved_surface_id: None,
+                    last_failed_recreate_color_info: None,
                 };
                 if let Err(e) = event_loop.run_app(&mut handler) {
                     tracing::error!(error = %e, "DisplayWindow: event loop exited with error");
@@ -250,6 +254,10 @@ struct DisplayWindowEventLoopHandler {
     /// The last surface id that failed to resolve, so the failure warns once
     /// per surface instead of once per redraw.
     last_unresolved_surface_id: Option<String>,
+    /// The last `color_info` whose swapchain recreate failed, so the failure
+    /// warns once per description instead of once per frame (each frame
+    /// retries the recreate).
+    last_failed_recreate_color_info: Option<Option<ColorInfo>>,
 }
 
 impl ApplicationHandler for DisplayWindowEventLoopHandler {
@@ -284,6 +292,7 @@ impl ApplicationHandler for DisplayWindowEventLoopHandler {
                 self.present_target = Some(present_target);
                 self.compositor = Some(compositor);
                 self.window = Some(window);
+                self.inactive = false;
                 tracing::info!(
                     width = self.width,
                     height = self.height,
@@ -415,6 +424,7 @@ impl DisplayWindowEventLoopHandler {
             match present_target.recreate(self.width, self.height, color_traits.as_ref()) {
                 Ok(()) => {
                     self.current_frame_color_info = frame_bag.color_info.clone();
+                    self.last_failed_recreate_color_info = None;
                     let new_format = present_target.color_format();
                     if let Some(compositor) = self.compositor.as_mut() {
                         match compositor.ensure_attachment_format(new_format) {
@@ -438,10 +448,15 @@ impl DisplayWindowEventLoopHandler {
                     }
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        "DisplayWindow: colorspace recreate failed (keeping previous swapchain)"
-                    );
+                    if self.last_failed_recreate_color_info.as_ref() != Some(&frame_bag.color_info)
+                    {
+                        tracing::warn!(
+                            error = %e,
+                            "DisplayWindow: colorspace recreate failed (keeping previous \
+                             swapchain; warning once per color description)"
+                        );
+                        self.last_failed_recreate_color_info = Some(frame_bag.color_info.clone());
+                    }
                 }
             }
         }
@@ -488,26 +503,20 @@ impl DisplayWindowEventLoopHandler {
                 return;
             }
         };
-        let frame_texture = registration.texture();
-        let source_layout = registration.current_layout();
-
         let scaling = self.scaling;
         let (Some(present_target), Some(compositor)) =
             (self.present_target.as_mut(), self.compositor.as_ref())
         else {
             return;
         };
+        // The compositor owns the source's layout bookkeeping via the
+        // registration, so a draw error after the barrier cannot leave the
+        // registration stale.
         let present_result = present_target.render_frame(|frame| {
-            compositor.compose_to_present_frame(frame, frame_texture, source_layout, scaling)
+            compositor.compose_to_present_frame(frame, &registration, scaling)
         });
-        match present_result {
-            Ok(_presented) => {
-                // The compositor left the source in SHADER_READ_ONLY_OPTIMAL.
-                registration.update_layout(VulkanLayout::SHADER_READ_ONLY_OPTIMAL);
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "DisplayWindow: present failed");
-            }
+        if let Err(e) = present_result {
+            tracing::warn!(error = %e, "DisplayWindow: present failed");
         }
         self.frame_counter.fetch_add(1, Ordering::Relaxed);
     }

--- a/runtime/streamlib-media-builtins/src/display_window.rs
+++ b/runtime/streamlib-media-builtins/src/display_window.rs
@@ -406,7 +406,9 @@ impl DisplayWindowEventLoopHandler {
                 .color_info
                 .as_ref()
                 .map(ColorInfo::engine_color_traits);
-            let present_target = self.present_target.as_mut().expect("checked above");
+            let Some(present_target) = self.present_target.as_mut() else {
+                return;
+            };
             match present_target.recreate(self.width, self.height, color_traits.as_ref()) {
                 Ok(()) => {
                     self.current_frame_color_info = frame_bag.color_info.clone();
@@ -483,14 +485,17 @@ impl DisplayWindowEventLoopHandler {
                 return;
             }
         };
-        let frame_texture = registration.texture().clone();
+        let frame_texture = registration.texture();
         let source_layout = registration.current_layout();
 
-        let compositor = self.compositor.as_ref().expect("checked above");
         let scaling = self.scaling;
-        let present_target = self.present_target.as_mut().expect("checked above");
+        let (Some(present_target), Some(compositor)) =
+            (self.present_target.as_mut(), self.compositor.as_ref())
+        else {
+            return;
+        };
         let present_result = present_target.render_frame(|frame| {
-            compositor.compose_to_present_frame(frame, &frame_texture, source_layout, scaling)
+            compositor.compose_to_present_frame(frame, frame_texture, source_layout, scaling)
         });
         match present_result {
             Ok(_presented) => {

--- a/runtime/streamlib-media-builtins/src/lib.rs
+++ b/runtime/streamlib-media-builtins/src/lib.rs
@@ -9,9 +9,15 @@
 //! Written against the SDK's handle-shaped primitives only — pixel-buffer
 //! pool, texture cache, present target — never private engine guts.
 
+#[cfg(target_os = "linux")]
+pub mod camera_source;
 pub mod test_pattern_source;
+#[cfg(target_os = "linux")]
+pub mod v4l2_color;
 pub mod video_frame;
 
+#[cfg(target_os = "linux")]
+pub use camera_source::{CameraSource, CameraSourceConfig};
 pub use test_pattern_source::{TestPatternSource, TestPatternSourceConfig};
 pub use video_frame::VideoFrame;
 
@@ -22,4 +28,6 @@ use streamlib::sdk::processors::PROCESSOR_REGISTRY;
 /// so hosts may call it more than once.
 pub fn register_media_builtin_processor_types() {
     PROCESSOR_REGISTRY.register::<test_pattern_source::TestPatternSource::Processor>();
+    #[cfg(target_os = "linux")]
+    PROCESSOR_REGISTRY.register::<camera_source::CameraSource::Processor>();
 }

--- a/runtime/streamlib-media-builtins/src/lib.rs
+++ b/runtime/streamlib-media-builtins/src/lib.rs
@@ -11,6 +11,8 @@
 
 #[cfg(target_os = "linux")]
 pub mod camera_source;
+#[cfg(target_os = "linux")]
+pub mod display_window;
 pub mod test_pattern_source;
 #[cfg(target_os = "linux")]
 pub mod v4l2_color;
@@ -18,6 +20,8 @@ pub mod video_frame;
 
 #[cfg(target_os = "linux")]
 pub use camera_source::{CameraSource, CameraSourceConfig};
+#[cfg(target_os = "linux")]
+pub use display_window::{DisplayWindow, DisplayWindowConfig};
 pub use test_pattern_source::{TestPatternSource, TestPatternSourceConfig};
 pub use video_frame::VideoFrame;
 
@@ -30,4 +34,6 @@ pub fn register_media_builtin_processor_types() {
     PROCESSOR_REGISTRY.register::<test_pattern_source::TestPatternSource::Processor>();
     #[cfg(target_os = "linux")]
     PROCESSOR_REGISTRY.register::<camera_source::CameraSource::Processor>();
+    #[cfg(target_os = "linux")]
+    PROCESSOR_REGISTRY.register::<display_window::DisplayWindow::Processor>();
 }

--- a/runtime/streamlib-media-builtins/src/v4l2_color.rs
+++ b/runtime/streamlib-media-builtins/src/v4l2_color.rs
@@ -84,9 +84,9 @@ fn primaries_from_v4l2(colorspace: u32) -> Option<Primaries> {
         V4L2_COLORSPACE_470_SYSTEM_BG => Some(Primaries::Bt470Bg),
         // V4L2_COLORSPACE_JPEG is "shorthand for SRGB primaries + BT.601
         // matrix + full range" per kernel comment.
-        V4L2_COLORSPACE_JPEG | V4L2_COLORSPACE_SRGB | V4L2_COLORSPACE_OPRGB => {
-            Some(Primaries::Bt709)
-        }
+        V4L2_COLORSPACE_JPEG | V4L2_COLORSPACE_SRGB => Some(Primaries::Bt709),
+        // OPRGB (Adobe RGB) primaries have no H.273 code point; don't guess.
+        V4L2_COLORSPACE_OPRGB => None,
         V4L2_COLORSPACE_BT2020 => Some(Primaries::Bt2020),
         V4L2_COLORSPACE_DCI_P3 => Some(Primaries::Smpte431),
         // RAW, anything unrecognized: don't guess.
@@ -147,12 +147,14 @@ fn matrix_from_v4l2(ycbcr_enc: u32, colorspace: u32) -> Option<Matrix> {
 
 fn range_from_v4l2(quantization: u32, colorspace: u32) -> Option<Range> {
     let resolved = if quantization == V4L2_QUANTIZATION_DEFAULT {
-        // V4L2_MAP_QUANTIZATION_DEFAULT: full for JPEG / SRGB / OPRGB,
-        // limited for everything else.
+        // V4L2_MAP_QUANTIZATION_DEFAULT with is_rgb_or_hsv = false (this
+        // path is YUV-only): full range for JPEG only; SRGB and OPRGB YUV
+        // data defaults to limited like everything else. Mapping SRGB to
+        // full (a former bug carried from the incumbent) skipped the range
+        // expansion and rendered limited-range webcam data with crushed
+        // contrast.
         match colorspace {
-            V4L2_COLORSPACE_JPEG | V4L2_COLORSPACE_SRGB | V4L2_COLORSPACE_OPRGB => {
-                V4L2_QUANTIZATION_FULL_RANGE
-            }
+            V4L2_COLORSPACE_JPEG => V4L2_QUANTIZATION_FULL_RANGE,
             V4L2_COLORSPACE_DEFAULT => return None,
             _ => V4L2_QUANTIZATION_LIM_RANGE,
         }
@@ -201,10 +203,11 @@ mod tests {
     }
 
     #[test]
-    fn webcam_srgb_with_defaults_resolves_to_bt601_matrix_full_range() {
-        // The standard UVC webcam combo per V4L2 convention: SRGB
-        // colorspace means SRGB primaries + sRGB transfer + BT.601 matrix +
-        // FULL range. Surprising but documented.
+    fn webcam_srgb_with_defaults_resolves_to_bt601_matrix_limited_range() {
+        // The standard UVC webcam combo: SRGB colorspace means sRGB
+        // primaries/transfer + BT.601 matrix, and the YUV quantization
+        // default is LIMITED — V4L2_MAP_QUANTIZATION_DEFAULT returns full
+        // only for JPEG when the data is YCbCr.
         let info = v4l2_color_to_color_info(
             V4L2_COLORSPACE_SRGB,
             V4L2_XFER_FUNC_DEFAULT,
@@ -214,7 +217,33 @@ mod tests {
         assert_eq!(info.primaries, Some(Primaries::Bt709));
         assert_eq!(info.transfer, Some(Transfer::Srgb));
         assert_eq!(info.matrix, Some(Matrix::Smpte170m));
+        assert_eq!(info.range, Some(Range::Limited));
+    }
+
+    #[test]
+    fn jpeg_with_defaults_is_the_only_full_range_yuv_default() {
+        let info = v4l2_color_to_color_info(
+            V4L2_COLORSPACE_JPEG,
+            V4L2_XFER_FUNC_DEFAULT,
+            V4L2_YCBCR_ENC_DEFAULT,
+            V4L2_QUANTIZATION_DEFAULT,
+        );
         assert_eq!(info.range, Some(Range::Full));
+    }
+
+    #[test]
+    fn oprgb_primaries_are_not_misrepresented() {
+        // OPRGB has no H.273 primaries code point; both axes stay unknown
+        // rather than guessing BT.709.
+        let info = v4l2_color_to_color_info(
+            V4L2_COLORSPACE_OPRGB,
+            V4L2_XFER_FUNC_DEFAULT,
+            V4L2_YCBCR_ENC_DEFAULT,
+            V4L2_QUANTIZATION_DEFAULT,
+        );
+        assert_eq!(info.primaries, None);
+        assert_eq!(info.transfer, None);
+        assert_eq!(info.range, Some(Range::Limited));
     }
 
     #[test]

--- a/runtime/streamlib-media-builtins/src/v4l2_color.rs
+++ b/runtime/streamlib-media-builtins/src/v4l2_color.rs
@@ -1,0 +1,273 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+#![cfg(target_os = "linux")]
+
+//! V4L2 colorspace → [`ColorInfo`] translation.
+//!
+//! Mirrors FFmpeg's `libavcodec/v4l2_buffers.c` mapping plus the
+//! V4L2 `*_DEFAULT` resolution rules from `<linux/videodev2.h>`. V4L2
+//! reports four orthogonal fields on `v4l2_pix_format`: `colorspace`,
+//! `xfer_func`, `ycbcr_enc`, `quantization`. When any sub-field is
+//! `*_DEFAULT` (= 0), V4L2's `V4L2_MAP_*_DEFAULT` macros derive the value
+//! from `colorspace`. We do the same here.
+//!
+//! Each axis returns `Option<T>` — `None` is the canonical "unknown"
+//! representation. `V4L2_COLORSPACE_DEFAULT` and any unrecognized
+//! enumerant propagate as `None`.
+
+use crate::video_frame::{ColorInfo, Matrix, Primaries, Range, Transfer};
+
+// V4L2 `colorspace` enumerants (from `<linux/videodev2.h>`).
+const V4L2_COLORSPACE_DEFAULT: u32 = 0;
+const V4L2_COLORSPACE_SMPTE170M: u32 = 1;
+const V4L2_COLORSPACE_SMPTE240M: u32 = 2;
+const V4L2_COLORSPACE_REC709: u32 = 3;
+const V4L2_COLORSPACE_BT878: u32 = 4;
+const V4L2_COLORSPACE_470_SYSTEM_M: u32 = 5;
+const V4L2_COLORSPACE_470_SYSTEM_BG: u32 = 6;
+const V4L2_COLORSPACE_JPEG: u32 = 7;
+const V4L2_COLORSPACE_SRGB: u32 = 8;
+const V4L2_COLORSPACE_OPRGB: u32 = 9;
+const V4L2_COLORSPACE_BT2020: u32 = 10;
+const V4L2_COLORSPACE_RAW: u32 = 11;
+const V4L2_COLORSPACE_DCI_P3: u32 = 12;
+
+const V4L2_XFER_FUNC_DEFAULT: u32 = 0;
+const V4L2_XFER_FUNC_709: u32 = 1;
+const V4L2_XFER_FUNC_SRGB: u32 = 2;
+const V4L2_XFER_FUNC_OPRGB: u32 = 3;
+const V4L2_XFER_FUNC_SMPTE240M: u32 = 4;
+const V4L2_XFER_FUNC_NONE: u32 = 5;
+const V4L2_XFER_FUNC_DCI_P3: u32 = 6;
+const V4L2_XFER_FUNC_SMPTE2084: u32 = 7;
+
+const V4L2_YCBCR_ENC_DEFAULT: u32 = 0;
+const V4L2_YCBCR_ENC_601: u32 = 1;
+const V4L2_YCBCR_ENC_709: u32 = 2;
+const V4L2_YCBCR_ENC_XV601: u32 = 3;
+const V4L2_YCBCR_ENC_XV709: u32 = 4;
+const V4L2_YCBCR_ENC_SYCC: u32 = 5;
+const V4L2_YCBCR_ENC_BT2020: u32 = 6;
+const V4L2_YCBCR_ENC_BT2020_CONST_LUM: u32 = 7;
+const V4L2_YCBCR_ENC_SMPTE240M: u32 = 8;
+
+const V4L2_QUANTIZATION_DEFAULT: u32 = 0;
+const V4L2_QUANTIZATION_FULL_RANGE: u32 = 1;
+const V4L2_QUANTIZATION_LIM_RANGE: u32 = 2;
+
+/// Translate a V4L2 colorspace report to a [`ColorInfo`]. Sub-fields
+/// reported as `*_DEFAULT` are resolved from the `colorspace` field per the
+/// V4L2 mapping macros; `V4L2_COLORSPACE_DEFAULT` propagates as `None`
+/// across the board.
+pub fn v4l2_color_to_color_info(
+    colorspace: u32,
+    xfer_func: u32,
+    ycbcr_enc: u32,
+    quantization: u32,
+) -> ColorInfo {
+    ColorInfo {
+        primaries: primaries_from_v4l2(colorspace),
+        transfer: transfer_from_v4l2(xfer_func, colorspace),
+        matrix: matrix_from_v4l2(ycbcr_enc, colorspace),
+        range: range_from_v4l2(quantization, colorspace),
+    }
+}
+
+fn primaries_from_v4l2(colorspace: u32) -> Option<Primaries> {
+    match colorspace {
+        V4L2_COLORSPACE_DEFAULT => None,
+        V4L2_COLORSPACE_SMPTE170M | V4L2_COLORSPACE_BT878 => Some(Primaries::Smpte170m),
+        V4L2_COLORSPACE_SMPTE240M => Some(Primaries::Smpte240m),
+        V4L2_COLORSPACE_REC709 => Some(Primaries::Bt709),
+        V4L2_COLORSPACE_470_SYSTEM_M => Some(Primaries::Bt470M),
+        V4L2_COLORSPACE_470_SYSTEM_BG => Some(Primaries::Bt470Bg),
+        // V4L2_COLORSPACE_JPEG is "shorthand for SRGB primaries + BT.601
+        // matrix + full range" per kernel comment.
+        V4L2_COLORSPACE_JPEG | V4L2_COLORSPACE_SRGB | V4L2_COLORSPACE_OPRGB => {
+            Some(Primaries::Bt709)
+        }
+        V4L2_COLORSPACE_BT2020 => Some(Primaries::Bt2020),
+        V4L2_COLORSPACE_DCI_P3 => Some(Primaries::Smpte431),
+        // RAW, anything unrecognized: don't guess.
+        _ => None,
+    }
+}
+
+fn transfer_from_v4l2(xfer_func: u32, colorspace: u32) -> Option<Transfer> {
+    let resolved = if xfer_func == V4L2_XFER_FUNC_DEFAULT {
+        // V4L2_MAP_XFER_FUNC_DEFAULT: derive from colorspace.
+        match colorspace {
+            V4L2_COLORSPACE_OPRGB => V4L2_XFER_FUNC_OPRGB,
+            V4L2_COLORSPACE_SMPTE240M => V4L2_XFER_FUNC_SMPTE240M,
+            V4L2_COLORSPACE_DCI_P3 => V4L2_XFER_FUNC_DCI_P3,
+            V4L2_COLORSPACE_RAW => V4L2_XFER_FUNC_NONE,
+            V4L2_COLORSPACE_SRGB | V4L2_COLORSPACE_JPEG => V4L2_XFER_FUNC_SRGB,
+            V4L2_COLORSPACE_DEFAULT => return None,
+            _ => V4L2_XFER_FUNC_709,
+        }
+    } else {
+        xfer_func
+    };
+    match resolved {
+        V4L2_XFER_FUNC_709 => Some(Transfer::Bt709),
+        V4L2_XFER_FUNC_SRGB => Some(Transfer::Srgb),
+        // OPRGB / DCI_P3 have no direct H.273 mapping; report None rather
+        // than misrepresent.
+        V4L2_XFER_FUNC_OPRGB | V4L2_XFER_FUNC_DCI_P3 => None,
+        V4L2_XFER_FUNC_SMPTE240M => Some(Transfer::Smpte240m),
+        V4L2_XFER_FUNC_NONE => Some(Transfer::Linear),
+        V4L2_XFER_FUNC_SMPTE2084 => Some(Transfer::Smpte2084),
+        _ => None,
+    }
+}
+
+fn matrix_from_v4l2(ycbcr_enc: u32, colorspace: u32) -> Option<Matrix> {
+    let resolved = if ycbcr_enc == V4L2_YCBCR_ENC_DEFAULT {
+        // V4L2_MAP_YCBCR_ENC_DEFAULT: derive from colorspace.
+        match colorspace {
+            V4L2_COLORSPACE_REC709 | V4L2_COLORSPACE_DCI_P3 => V4L2_YCBCR_ENC_709,
+            V4L2_COLORSPACE_BT2020 => V4L2_YCBCR_ENC_BT2020,
+            V4L2_COLORSPACE_SMPTE240M => V4L2_YCBCR_ENC_SMPTE240M,
+            V4L2_COLORSPACE_DEFAULT => return None,
+            _ => V4L2_YCBCR_ENC_601,
+        }
+    } else {
+        ycbcr_enc
+    };
+    match resolved {
+        V4L2_YCBCR_ENC_601 | V4L2_YCBCR_ENC_XV601 | V4L2_YCBCR_ENC_SYCC => Some(Matrix::Smpte170m),
+        V4L2_YCBCR_ENC_709 | V4L2_YCBCR_ENC_XV709 => Some(Matrix::Bt709),
+        V4L2_YCBCR_ENC_BT2020 => Some(Matrix::Bt2020Ncl),
+        V4L2_YCBCR_ENC_BT2020_CONST_LUM => Some(Matrix::Bt2020Cl),
+        V4L2_YCBCR_ENC_SMPTE240M => Some(Matrix::Smpte240m),
+        _ => None,
+    }
+}
+
+fn range_from_v4l2(quantization: u32, colorspace: u32) -> Option<Range> {
+    let resolved = if quantization == V4L2_QUANTIZATION_DEFAULT {
+        // V4L2_MAP_QUANTIZATION_DEFAULT: full for JPEG / SRGB / OPRGB,
+        // limited for everything else.
+        match colorspace {
+            V4L2_COLORSPACE_JPEG | V4L2_COLORSPACE_SRGB | V4L2_COLORSPACE_OPRGB => {
+                V4L2_QUANTIZATION_FULL_RANGE
+            }
+            V4L2_COLORSPACE_DEFAULT => return None,
+            _ => V4L2_QUANTIZATION_LIM_RANGE,
+        }
+    } else {
+        quantization
+    };
+    match resolved {
+        V4L2_QUANTIZATION_FULL_RANGE => Some(Range::Full),
+        V4L2_QUANTIZATION_LIM_RANGE => Some(Range::Limited),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rec709_explicit_maps_to_bt709() {
+        let info = v4l2_color_to_color_info(
+            V4L2_COLORSPACE_REC709,
+            V4L2_XFER_FUNC_709,
+            V4L2_YCBCR_ENC_709,
+            V4L2_QUANTIZATION_LIM_RANGE,
+        );
+        assert_eq!(info.primaries, Some(Primaries::Bt709));
+        assert_eq!(info.transfer, Some(Transfer::Bt709));
+        assert_eq!(info.matrix, Some(Matrix::Bt709));
+        assert_eq!(info.range, Some(Range::Limited));
+    }
+
+    #[test]
+    fn vivid_smpte170m_with_defaults_resolves_to_bt601_525() {
+        // Vivid reports V4L2_COLORSPACE_SMPTE170M with everything else
+        // default. SMPTE 170M is BT.601 525-line.
+        let info = v4l2_color_to_color_info(
+            V4L2_COLORSPACE_SMPTE170M,
+            V4L2_XFER_FUNC_DEFAULT,
+            V4L2_YCBCR_ENC_DEFAULT,
+            V4L2_QUANTIZATION_DEFAULT,
+        );
+        assert_eq!(info.primaries, Some(Primaries::Smpte170m));
+        assert_eq!(info.transfer, Some(Transfer::Bt709));
+        assert_eq!(info.matrix, Some(Matrix::Smpte170m));
+        assert_eq!(info.range, Some(Range::Limited));
+    }
+
+    #[test]
+    fn webcam_srgb_with_defaults_resolves_to_bt601_matrix_full_range() {
+        // The standard UVC webcam combo per V4L2 convention: SRGB
+        // colorspace means SRGB primaries + sRGB transfer + BT.601 matrix +
+        // FULL range. Surprising but documented.
+        let info = v4l2_color_to_color_info(
+            V4L2_COLORSPACE_SRGB,
+            V4L2_XFER_FUNC_DEFAULT,
+            V4L2_YCBCR_ENC_DEFAULT,
+            V4L2_QUANTIZATION_DEFAULT,
+        );
+        assert_eq!(info.primaries, Some(Primaries::Bt709));
+        assert_eq!(info.transfer, Some(Transfer::Srgb));
+        assert_eq!(info.matrix, Some(Matrix::Smpte170m));
+        assert_eq!(info.range, Some(Range::Full));
+    }
+
+    #[test]
+    fn bt2020_with_defaults_resolves_to_bt2020_ncl() {
+        let info = v4l2_color_to_color_info(
+            V4L2_COLORSPACE_BT2020,
+            V4L2_XFER_FUNC_DEFAULT,
+            V4L2_YCBCR_ENC_DEFAULT,
+            V4L2_QUANTIZATION_DEFAULT,
+        );
+        assert_eq!(info.primaries, Some(Primaries::Bt2020));
+        assert_eq!(info.transfer, Some(Transfer::Bt709));
+        assert_eq!(info.matrix, Some(Matrix::Bt2020Ncl));
+        assert_eq!(info.range, Some(Range::Limited));
+    }
+
+    #[test]
+    fn colorspace_default_propagates_none_on_every_axis() {
+        let info = v4l2_color_to_color_info(
+            V4L2_COLORSPACE_DEFAULT,
+            V4L2_XFER_FUNC_DEFAULT,
+            V4L2_YCBCR_ENC_DEFAULT,
+            V4L2_QUANTIZATION_DEFAULT,
+        );
+        assert_eq!(info.primaries, None);
+        assert_eq!(info.transfer, None);
+        assert_eq!(info.matrix, None);
+        assert_eq!(info.range, None);
+    }
+
+    #[test]
+    fn bt2020_with_pq_transfer_resolves_to_smpte2084() {
+        // HDR10 source: BT.2020 primaries + PQ transfer + BT.2020 NCL
+        // matrix + limited range.
+        let info = v4l2_color_to_color_info(
+            V4L2_COLORSPACE_BT2020,
+            V4L2_XFER_FUNC_SMPTE2084,
+            V4L2_YCBCR_ENC_BT2020,
+            V4L2_QUANTIZATION_LIM_RANGE,
+        );
+        assert_eq!(info.primaries, Some(Primaries::Bt2020));
+        assert_eq!(info.transfer, Some(Transfer::Smpte2084));
+        assert_eq!(info.matrix, Some(Matrix::Bt2020Ncl));
+        assert_eq!(info.range, Some(Range::Limited));
+    }
+
+    #[test]
+    fn default_color_info_is_all_none() {
+        // ColorInfo::default() must be the semantic "unknown" state.
+        let info = ColorInfo::default();
+        assert_eq!(info.primaries, None);
+        assert_eq!(info.transfer, None);
+        assert_eq!(info.matrix, None);
+        assert_eq!(info.range, None);
+    }
+}

--- a/runtime/streamlib-media-builtins/src/video_frame.rs
+++ b/runtime/streamlib-media-builtins/src/video_frame.rs
@@ -211,6 +211,89 @@ pub struct MasteringDisplay {
     pub white_point_y: u32,
 }
 
+// Per-axis maps from the bag's H.273 vocabulary to the engine's color IDs.
+// The engine accepts only its own primitive types in public signatures, so
+// this crate translates at the boundary.
+
+impl Primaries {
+    pub(crate) fn engine_id(&self) -> streamlib::sdk::color::PrimariesId {
+        use streamlib::sdk::color::PrimariesId;
+        match self {
+            Primaries::Bt709 => PrimariesId::Bt709,
+            Primaries::Bt470M => PrimariesId::Bt470M,
+            Primaries::Bt470Bg => PrimariesId::Bt470Bg,
+            Primaries::Smpte170m => PrimariesId::Smpte170m,
+            Primaries::Smpte240m => PrimariesId::Smpte240m,
+            Primaries::Film => PrimariesId::Film,
+            Primaries::Bt2020 => PrimariesId::Bt2020,
+            Primaries::Smpte428 => PrimariesId::Smpte428,
+            Primaries::Smpte431 => PrimariesId::Smpte431,
+            Primaries::Smpte432 => PrimariesId::Smpte432,
+            Primaries::Ebu3213 => PrimariesId::Ebu3213,
+        }
+    }
+}
+
+impl Transfer {
+    pub(crate) fn engine_id(&self) -> streamlib::sdk::color::TransferId {
+        use streamlib::sdk::color::TransferId;
+        match self {
+            Transfer::Srgb => TransferId::Srgb,
+            Transfer::Bt709
+            | Transfer::Smpte170m
+            | Transfer::Bt2020TenBit
+            | Transfer::Bt2020TwelveBit => TransferId::Bt709,
+            Transfer::Smpte2084 => TransferId::Pq,
+            Transfer::AribStdB67 => TransferId::Hlg,
+            Transfer::Linear => TransferId::Linear,
+            // Gamma22 / Gamma28 / Smpte240m / Log* / Xvycc / Bt1361 /
+            // Smpte428 are uncommon end-to-end; map to Linear (no transform).
+            _ => TransferId::Linear,
+        }
+    }
+}
+
+impl Matrix {
+    pub(crate) fn engine_id(&self) -> streamlib::sdk::color::MatrixId {
+        use streamlib::sdk::color::MatrixId;
+        match self {
+            Matrix::Identity => MatrixId::Identity,
+            Matrix::Bt709 => MatrixId::Bt709,
+            Matrix::Fcc => MatrixId::Fcc,
+            Matrix::Bt470Bg => MatrixId::Bt470Bg,
+            Matrix::Smpte170m => MatrixId::Smpte170m,
+            Matrix::Smpte240m => MatrixId::Smpte240m,
+            Matrix::Ycgco => MatrixId::Ycgco,
+            Matrix::Bt2020Ncl => MatrixId::Bt2020Ncl,
+            Matrix::Bt2020Cl => MatrixId::Bt2020Cl,
+            Matrix::Smpte2085 => MatrixId::Smpte2085,
+            Matrix::ChromaNcl => MatrixId::ChromaNcl,
+            Matrix::ChromaCl => MatrixId::ChromaCl,
+            Matrix::Ictcp => MatrixId::Ictcp,
+        }
+    }
+}
+
+impl Range {
+    pub(crate) fn engine_id(&self) -> streamlib::sdk::color::RangeId {
+        use streamlib::sdk::color::RangeId;
+        match self {
+            Range::Limited => RangeId::Limited,
+            Range::Full => RangeId::Full,
+        }
+    }
+}
+
+impl ColorInfo {
+    /// The engine's colorspace-pick input: primaries + transfer only.
+    pub(crate) fn engine_color_traits(&self) -> streamlib::sdk::color::ColorTraits {
+        streamlib::sdk::color::ColorTraits {
+            primaries: self.primaries.as_ref().map(Primaries::engine_id),
+            transfer: self.transfer.as_ref().map(Transfer::engine_id),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/runtime/streamlib-media-builtins/src/video_frame.rs
+++ b/runtime/streamlib-media-builtins/src/video_frame.rs
@@ -241,14 +241,21 @@ impl Transfer {
             Transfer::Srgb => TransferId::Srgb,
             Transfer::Bt709
             | Transfer::Smpte170m
+            | Transfer::Smpte240m
             | Transfer::Bt2020TenBit
             | Transfer::Bt2020TwelveBit => TransferId::Bt709,
             Transfer::Smpte2084 => TransferId::Pq,
             Transfer::AribStdB67 => TransferId::Hlg,
             Transfer::Linear => TransferId::Linear,
-            // Gamma22 / Gamma28 / Smpte240m / Log* / Xvycc / Bt1361 /
-            // Smpte428 are uncommon end-to-end; map to Linear (no transform).
-            _ => TransferId::Linear,
+            // No exact engine id for these encoded transfers; a BT.709-shaped
+            // approximation beats Linear, which would skip decoding entirely.
+            Transfer::Gamma22
+            | Transfer::Gamma28
+            | Transfer::Bt1361
+            | Transfer::Log100
+            | Transfer::Log100Sqrt10
+            | Transfer::Smpte428
+            | Transfer::Xvycc => TransferId::Bt709,
         }
     }
 }

--- a/sdk/streamlib-python-wheel/python/streamlib/__init__.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/__init__.py
@@ -25,6 +25,7 @@ from ._engine import MonotonicTimer as MonotonicTimer
 from ._engine import ProcessorInputPortReference as ProcessorInputPortReference
 from ._engine import ProcessorLinkDataAccess as ProcessorLinkDataAccess
 from ._engine import ProcessorOutputPortReference as ProcessorOutputPortReference
+from ._engine import CameraSource as CameraSource
 from ._engine import Runtime as _NativeRuntime
 from ._engine import RuntimeContextFullAccess as RuntimeContextFullAccess
 from ._engine import RuntimeContextLimitedAccess as RuntimeContextLimitedAccess
@@ -44,6 +45,7 @@ from .video_frame import VideoFrame as VideoFrame
 # authoring grammar reads `@input(...)` / `@output(...)`, matching the old SDK.
 __all__ = [
     "AddedProcessor",
+    "CameraSource",
     "ColorInfo",
     "ContentLight",
     "GpuContextFullAccess",

--- a/sdk/streamlib-python-wheel/python/streamlib/__init__.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/__init__.py
@@ -26,6 +26,7 @@ from ._engine import ProcessorInputPortReference as ProcessorInputPortReference
 from ._engine import ProcessorLinkDataAccess as ProcessorLinkDataAccess
 from ._engine import ProcessorOutputPortReference as ProcessorOutputPortReference
 from ._engine import CameraSource as CameraSource
+from ._engine import DisplayWindow as DisplayWindow
 from ._engine import Runtime as _NativeRuntime
 from ._engine import RuntimeContextFullAccess as RuntimeContextFullAccess
 from ._engine import RuntimeContextLimitedAccess as RuntimeContextLimitedAccess
@@ -48,6 +49,7 @@ __all__ = [
     "CameraSource",
     "ColorInfo",
     "ContentLight",
+    "DisplayWindow",
     "GpuContextFullAccess",
     "GpuContextLimitedAccess",
     "GpuSurfaceHandle",

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -32,6 +32,7 @@ __all__ = [
     "ProcessorInputPortReference",
     "ProcessorLinkDataAccess",
     "ProcessorOutputPortReference",
+    "CameraSource",
     "Runtime",
     "RuntimeContextFullAccess",
     "RuntimeContextLimitedAccess",
@@ -40,6 +41,16 @@ __all__ = [
     "media_clock_now_ns",
     "monotonic_now_ns",
 ]
+
+@final
+class CameraSource:
+    """Native built-in block: live V4L2 camera capture (Linux).
+
+    A marker type — pass the class itself to `Runtime.add`
+    (`rt.add(CameraSource, config={"device_id": "/dev/video0"})`); it is
+    never instantiated and its per-frame path never enters the interpreter.
+    Camera→GPU transport auto-selects zero-copy DMA-BUF or CPU upload.
+    """
 
 @final
 class TestPatternSource:

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -61,6 +61,10 @@ class DisplayWindow:
     (`rt.add(DisplayWindow, config={"title": "My app", "scaling": "fit"})`);
     it is never instantiated and its per-frame path never enters the
     interpreter. `scaling` is `"fit"`, `"fill"`, or `"stretch"`.
+
+    One window per process today: the display owns the process-wide event
+    loop, so a second DisplayWindow logs an error and drains its input
+    without showing anything.
     """
 
 @final

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -33,6 +33,7 @@ __all__ = [
     "ProcessorLinkDataAccess",
     "ProcessorOutputPortReference",
     "CameraSource",
+    "DisplayWindow",
     "Runtime",
     "RuntimeContextFullAccess",
     "RuntimeContextLimitedAccess",
@@ -50,6 +51,16 @@ class CameraSource:
     (`rt.add(CameraSource, config={"device_id": "/dev/video0"})`); it is
     never instantiated and its per-frame path never enters the interpreter.
     Camera→GPU transport auto-selects zero-copy DMA-BUF or CPU upload.
+    """
+
+@final
+class DisplayWindow:
+    """Native built-in block: video frames in a vsync'd window (Linux).
+
+    A marker type — pass the class itself to `Runtime.add`
+    (`rt.add(DisplayWindow, config={"title": "My app", "scaling": "fit"})`);
+    it is never instantiated and its per-frame path never enters the
+    interpreter. `scaling` is `"fit"`, `"fill"`, or `"stretch"`.
     """
 
 @final

--- a/sdk/streamlib-python-wheel/src/lib.rs
+++ b/sdk/streamlib-python-wheel/src/lib.rs
@@ -25,6 +25,7 @@ fn _engine(module: &Bound<'_, PyModule>) -> PyResult<()> {
     python_native_builtin_blocks::register_native_builtin_processor_types();
     module.add_class::<PythonRuntimeHandle>()?;
     module.add_class::<python_native_builtin_blocks::PythonTestPatternSourceBlock>()?;
+    module.add_class::<python_native_builtin_blocks::PythonCameraSourceBlock>()?;
     module.add_class::<python_added_processor::PythonAddedProcessor>()?;
     module.add_class::<python_added_processor::PythonProcessorOutputPortReference>()?;
     module.add_class::<python_added_processor::PythonProcessorInputPortReference>()?;

--- a/sdk/streamlib-python-wheel/src/lib.rs
+++ b/sdk/streamlib-python-wheel/src/lib.rs
@@ -26,6 +26,7 @@ fn _engine(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PythonRuntimeHandle>()?;
     module.add_class::<python_native_builtin_blocks::PythonTestPatternSourceBlock>()?;
     module.add_class::<python_native_builtin_blocks::PythonCameraSourceBlock>()?;
+    module.add_class::<python_native_builtin_blocks::PythonDisplayWindowBlock>()?;
     module.add_class::<python_added_processor::PythonAddedProcessor>()?;
     module.add_class::<python_added_processor::PythonProcessorOutputPortReference>()?;
     module.add_class::<python_added_processor::PythonProcessorInputPortReference>()?;

--- a/sdk/streamlib-python-wheel/src/python_native_builtin_blocks.rs
+++ b/sdk/streamlib-python-wheel/src/python_native_builtin_blocks.rs
@@ -29,6 +29,10 @@ impl PythonTestPatternSourceBlock {
     }
 }
 
+/// `streamlib.CameraSource` — live V4L2 camera capture (Linux).
+#[pyclass(name = "CameraSource", module = "streamlib", frozen)]
+pub(crate) struct PythonCameraSourceBlock;
+
 /// Resolve a Python object to a native built-in's type reference, if it is
 /// one of the wheel-exported marker type objects. The identity comes from the
 /// native processor's own declaration — authored once, in the built-ins crate.
@@ -38,6 +42,10 @@ pub(crate) fn native_builtin_type_reference(
 ) -> Option<ProcessorTypeReference> {
     if processor_class.is(python.get_type::<PythonTestPatternSourceBlock>()) {
         return Some(streamlib_media_builtins::TestPatternSource::Processor::schema_ident().into());
+    }
+    #[cfg(target_os = "linux")]
+    if processor_class.is(python.get_type::<PythonCameraSourceBlock>()) {
+        return Some(streamlib_media_builtins::CameraSource::Processor::schema_ident().into());
     }
     None
 }

--- a/sdk/streamlib-python-wheel/src/python_native_builtin_blocks.rs
+++ b/sdk/streamlib-python-wheel/src/python_native_builtin_blocks.rs
@@ -8,6 +8,7 @@
 //! object itself and resolves it to the statically-linked native processor —
 //! per-frame paths never enter the interpreter.
 
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use streamlib::sdk::processors::ProcessorTypeReference;
 
@@ -39,23 +40,42 @@ pub(crate) struct PythonDisplayWindowBlock;
 
 /// Resolve a Python object to a native built-in's type reference, if it is
 /// one of the wheel-exported marker type objects. The identity comes from the
-/// native processor's own declaration — authored once, in the built-ins crate.
+/// native processor's own declaration — authored once, in the built-ins
+/// crate. On a platform where a marker's native processor is not compiled
+/// in, the answer is an explicit unsupported-platform error rather than the
+/// generic "not a processor" rejection.
 pub(crate) fn native_builtin_type_reference(
     python: Python<'_>,
     processor_class: &Bound<'_, PyAny>,
-) -> Option<ProcessorTypeReference> {
+) -> PyResult<Option<ProcessorTypeReference>> {
     if processor_class.is(python.get_type::<PythonTestPatternSourceBlock>()) {
-        return Some(streamlib_media_builtins::TestPatternSource::Processor::schema_ident().into());
+        return Ok(Some(
+            streamlib_media_builtins::TestPatternSource::Processor::schema_ident().into(),
+        ));
     }
-    #[cfg(target_os = "linux")]
     if processor_class.is(python.get_type::<PythonCameraSourceBlock>()) {
-        return Some(streamlib_media_builtins::CameraSource::Processor::schema_ident().into());
+        #[cfg(target_os = "linux")]
+        return Ok(Some(
+            streamlib_media_builtins::CameraSource::Processor::schema_ident().into(),
+        ));
+        #[cfg(not(target_os = "linux"))]
+        return Err(PyRuntimeError::new_err(
+            "CameraSource is Linux-only (V4L2 capture); this platform is not supported \
+             by the streamlib wheel yet",
+        ));
     }
-    #[cfg(target_os = "linux")]
     if processor_class.is(python.get_type::<PythonDisplayWindowBlock>()) {
-        return Some(streamlib_media_builtins::DisplayWindow::Processor::schema_ident().into());
+        #[cfg(target_os = "linux")]
+        return Ok(Some(
+            streamlib_media_builtins::DisplayWindow::Processor::schema_ident().into(),
+        ));
+        #[cfg(not(target_os = "linux"))]
+        return Err(PyRuntimeError::new_err(
+            "DisplayWindow is Linux-only today; this platform is not supported by the \
+             streamlib wheel yet",
+        ));
     }
-    None
+    Ok(None)
 }
 
 /// Register the native built-in processor types on the process-wide registry.

--- a/sdk/streamlib-python-wheel/src/python_native_builtin_blocks.rs
+++ b/sdk/streamlib-python-wheel/src/python_native_builtin_blocks.rs
@@ -33,6 +33,10 @@ impl PythonTestPatternSourceBlock {
 #[pyclass(name = "CameraSource", module = "streamlib", frozen)]
 pub(crate) struct PythonCameraSourceBlock;
 
+/// `streamlib.DisplayWindow` — video frames in a vsync'd window (Linux).
+#[pyclass(name = "DisplayWindow", module = "streamlib", frozen)]
+pub(crate) struct PythonDisplayWindowBlock;
+
 /// Resolve a Python object to a native built-in's type reference, if it is
 /// one of the wheel-exported marker type objects. The identity comes from the
 /// native processor's own declaration — authored once, in the built-ins crate.
@@ -46,6 +50,10 @@ pub(crate) fn native_builtin_type_reference(
     #[cfg(target_os = "linux")]
     if processor_class.is(python.get_type::<PythonCameraSourceBlock>()) {
         return Some(streamlib_media_builtins::CameraSource::Processor::schema_ident().into());
+    }
+    #[cfg(target_os = "linux")]
+    if processor_class.is(python.get_type::<PythonDisplayWindowBlock>()) {
+        return Some(streamlib_media_builtins::DisplayWindow::Processor::schema_ident().into());
     }
     None
 }

--- a/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
+++ b/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
@@ -39,7 +39,7 @@ fn classify_processor_class(
     processor_class: &Bound<'_, PyAny>,
 ) -> PyResult<AddedProcessorClassKind> {
     if let Some(native_reference) =
-        crate::python_native_builtin_blocks::native_builtin_type_reference(python, processor_class)
+        crate::python_native_builtin_blocks::native_builtin_type_reference(python, processor_class)?
     {
         return Ok(AddedProcessorClassKind::NativeBuiltin(native_reference));
     }


### PR DESCRIPTION
## Summary

PR 2 of 2 for #1709, stacked on #1732. The hardware half: the V4L2 **CameraSource** ported into `streamlib-media-builtins` against the in-process SDK surface (NV12/YUYV negotiation at the highest resolution, auto DMA-BUF/CPU-upload transport, ring textures + timeline sequencing, V4L2 colorspace→ColorInfo translation), the greenfield **DisplayWindow** (winit window + event pump owned by the processor; per frame is one `compose_to_present_frame` call through the new `GpuContextFullAccess::create_present_target` / `create_present_compositor` seams PR 1 committed to), **human-shaped errors** for the four named cases, and the **live demo** — `rt.add(CameraSource) → rt.add(DisplayWindow)` showing video in a window on the rig.

The port did not carry its inheritance forward blind. Three defects inherited from the incumbent (plus one pre-existing engine bug the new code exposed) are fixed at the engine layer per doctrine:

- **Capture-loop hang** (incumbent): the frame counter advanced before the submit that signals it, and 7 of 10 failure paths skipped the V4L2 requeue — two transient failures wedged the thread forever, four starved the DMA-BUF queue. Now: one fallible per-frame unit with a single exit, unconditional requeue, `abort_recording` on failure, counter advancing only on success, and a separate strictly-increasing timeline-signal counter so a dropped-after-submit frame can never re-signal a reached value.
- **fd double-close** (incumbent): `vkImportMemoryFdInfoKHR` consumes the fd on success; the teardown loop closed them again. Gone.
- **`VK_TIMEOUT` swallowed** (pre-existing engine): `HostVulkanTimelineSemaphore::wait` returned `Ok` on timeout (a *positive* success code), so every finite-timeout caller — including the vulkan/cuda/cpu-readback adapters' acquire waits — silently succeeded on a stall. Fixed in `vulkan_sync.rs`, locked by a GPU-gated test proven red before the fix; all three adapters' suites re-run green.
- **Same-process pixel-buffer resolution** (engine gap, found live): the resolver's pixel-buffer arm only consulted the cross-process socket, which cannot serve OPAQUE_FD buffers host-side — a producer publishing only a pixel buffer (TestPatternSource) never resolved. The pool's local cache is consulted first; locked by a GPU-gated test proven red-with-revert.

## Closes

Closes #1709

## Exit criteria

- Native V4L2 camera + display processors in the engine tree, exposed as `rt.add(CameraSource)` / `rt.add(DisplayWindow)`, per-frame paths never entering the interpreter ✅
- Engine present-composition call absorbing the draw step; display = window lifecycle + one call per frame ✅ (greenfield against the PR 1 compositor, via the promised `create_present_compositor` seam)
- Camera→GPU zero-copy DMA-BUF with transparent CPU-upload fallback, auto-selected, no dial ✅ (NVIDIA blocklist path exercised live)
- Human-shaped failures: no camera / bogus device (names attached cameras, points at TestPatternSource), not in `video` group, no Vulkan ICD, no GPU device ✅; wrong Python is pip's own refusal via `requires-python` ✅
- Demo: `app.py` camera → display live in a window; bogus camera shows the human-shaped error; test-pattern path works camera-free ✅ (evidence below)

## Live evidence (commit a1429dc4)

![TestPatternSource → DisplayWindow — SMPTE bars, no camera](https://gh-artifact.tatolab.com/pr-1709-media-builtins/pattern_frame2.jpg)

![CameraSource (vivid) → DisplayWindow — NV12 1080p GPU-converted](https://gh-artifact.tatolab.com/pr-1709-media-builtins/camera_frame.jpg)

```
Camera '/dev/video99' does not exist. Attached cameras: /dev/video0 (vivid).
Fix device_id, or omit it to use the first camera found.
```

### E2E Test Report

- **Scenario**: camera+display-only
- **Example**: `camera_display_app.py` (`rt.add(CameraSource) → rt.add(DisplayWindow)`)
- **Codec**: n/a
- **Camera device**: `/dev/video0` (vivid)
- **Resolution**: 1920x1080 NV12
- **Duration / frame limit**: 12 s timed shutdown (58 frames)
- **Build profile**: debug
- **Command**:
    ```
    DISPLAY=:1 .venv/bin/python camera_display_app.py   # wheel built from a1429dc4 via maturin develop
    ```

#### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0 (pass)
- `DEVICE_LOST`: 0 (pass)
- `process() failed`: 0 (pass)
- `Validation Error`: not enabled
- `First frame captured`: 18:12:21.948 (~100 ms after capture start)
- Progress high-water mark: 58 frames published, 0 dropped, clean graceful shutdown

#### PNG samples

- Directory: n/a — window captured via `xdotool` + `import` (DisplayWindow has no PNG-sampler env vars yet; see notes)
- Sample count: 1 per scenario
- PNGs read with Read tool: `camera_frame.png`, `pattern_final.png`
- **What was in the image(s)**: camera run — vivid's 1080p test pattern: timecode overlay (`00:00:07:40x`), control-text block (brightness/contrast/saturation/gain), and vivid's muted bar set (grey, olive, teal, green, magenta, dark red, blue, black), GPU NV12→RGBA converted, aspect-correct in the window. Pattern run — the built-in's eight full-saturation SMPTE bars (white, yellow, cyan, green, magenta, red, blue, black) edge to edge.
- Anomalies: none

#### PSNR

- Reference frame: `n/a — vivid live source; visual description is the gate` (the PSNR fixture rigs cover the color path separately)

#### Outcome

- **Pass** (pattern scenario likewise: 342 frames, all gates zero, clean exit)

## Test plan

- `cargo test -p streamlib-media-builtins` — 18
- `cargo test -p streamlib-engine --lib` — 1753 (one first-attempt SIGABRT = the documented pre-existing parallel flake; clean rerun)
- Hardware (rig): compositor 13, vulkan_sync 5 (incl. the new red-before-fix timeout test), resolver test 1 (proven red-with-revert)
- Adapters after the VK_TIMEOUT fix: vulkan / cuda / cpu-readback suites all green
- Wheel: 81 pytest, stubtest, pyright clean
- Reviews: `review-pr` APPROVE and `rust-craftsmanship-reviewer` APPROVE (grade A) after two fix rounds

## Notes for owner

1. **`start()` failure doesn't fail `rt.run()`** — the bogus-camera app logs the human-shaped error and keeps running with a dead source. Engine lifecycle policy, not changed here; decide whether start-failures should surface to the caller.
2. **vivid delivers 5 fps at 1080p** (`v4l2-ctl --get-parm`: 5/1) — the 58-frame demo count is the device's cap, not the loop's; the pattern leg ran ~29 fps in the same session.
3. **Inherited cross-process machinery carried, not redesigned**: ring textures are registered under UUIDs no bag ever names, and the per-slot produce/consume timeline pairs are never signaled — a cross-process GPU consumer can't use them today (pixel-buffer fallback is what works). Worth its own ticket when cross-process GPU sharing matters.
4. **Frame timestamps are `MediaClock::now()` at publish**, not the V4L2 driver stamp — converges with #1725's epoch unification; the seam is already right.
5. The `platform:` bus heuristic (inherited) disables the DMA-BUF probe on embedded CSI devices — revisit if an embedded target arrives.
6. **Display event loop is X11 any-thread**; a Wayland-only session degrades to drain-and-discard. Rig is X11; noted for later.
7. Both built-ins detach a GPU-holding thread after a 2 s stop grace window (wedged-driver tradeoff, inherited shape).
8. `raw-window-handle` isn't re-exported from the SDK, so third-party callers of `create_present_target` need their own version-matched dep — cheap re-export when wanted.
9. The VK_TIMEOUT fix changes adapter acquire-timeout behavior from silent-success to error — all adapter suites green, but flagging the semantic change.
10. DisplayWindow doesn't yet implement the incumbent's PNG-sampler env vars (`STREAMLIB_DISPLAY_PNG_SAMPLE_DIR`/`FRAME_LIMIT`) that verify-live tooling reads — screenshots via xdotool for now; port is a candidate for the #1711 dev-experience ticket.
11. `libclang-dev` added to test.yml/python-wheel.yml apt lists (the v4l crate's bindgen build) — first CI run on this PR proves it.
12. Engine crate is 41 files out of rustfmt on main (pre-existing drift, none in this stack's diff) — #1310 territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Linux camera capture with V4L2 support, configurable resolution, color conversion, and efficient frame transfer.
  - Added a Linux display window with configurable dimensions, scaling modes, resizing, and HDR presentation support.
  - Exposed camera and display components through the Python package.

- **Bug Fixes**
  - Improved Vulkan driver, device, and synchronization timeout error messages.
  - Improved texture resolution for locally available video buffers.
  - Added safer recovery when frame recording or presentation setup fails.

- **Tests**
  - Added coverage for camera configuration, color handling, display settings, GPU synchronization, and buffer processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->