### PR TITLE
feat(python)!: zero-CPU-copy frame exchange — DLPack device tensors, numpy views, DMA-BUF

### DIFF
--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -73,7 +73,10 @@ jobs:
         working-directory: sdk/streamlib-python-wheel
         run: |
           uv venv --python 3.12 .venv
-          VIRTUAL_ENV="$PWD/.venv" uv pip install pytest mypy
+          # numpy rides along because the exchange-surface tests import it at
+          # module scope — collection needs it even when `requires_gpu`
+          # deselects every test that would use it.
+          VIRTUAL_ENV="$PWD/.venv" uv pip install pytest mypy numpy
           VIRTUAL_ENV="$PWD/.venv" uvx maturin@1.9.6 develop
 
       # The crate's own unit tests link libpython rather than building as an
@@ -134,7 +137,11 @@ jobs:
         working-directory: sdk/streamlib-python-wheel
         run: |
           uv venv --python 3.12 .venv
-          VIRTUAL_ENV="$PWD/.venv" uv pip install pytest
+          VIRTUAL_ENV="$PWD/.venv" uv pip install pytest numpy
+          # CPU torch: the exchange tests type-check against torch's API, and
+          # pyright reports a missing import as an error. The cpu wheel keeps
+          # the download tractable for a no-build job.
+          VIRTUAL_ENV="$PWD/.venv" uv pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Type-check the wheel's Python surface
         working-directory: sdk/streamlib-python-wheel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5520,6 +5520,7 @@ dependencies = [
  "rmpv",
  "serde_json",
  "streamlib",
+ "streamlib-adapter-cuda",
  "streamlib-media-builtins",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5514,6 +5514,7 @@ dependencies = [
 name = "streamlib-python-wheel"
 version = "0.11.1"
 dependencies = [
+ "cudarc",
  "libc",
  "parking_lot",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,15 +178,15 @@ dlpark = { version = "=0.6.0", default-features = false }
 # `cudarc::runtime::sys::is_culib_present()` lets the adapter fail
 # gracefully on CUDA-less machines.
 #
-# Pin to `cuda-12090` so the build does NOT require `nvcc` (the
-# `cuda-version-from-build-system` alternative errors when nvcc is
-# absent). The `_v2`-suffixed external-resource symbols this binding
-# exposes remain ABI-stable through CUDA 13.x — runtime libcudart
-# continues to export them, so the dlopen path resolves regardless of
-# which CUDA version is installed on the runner. `default-features =
-# false` skips cuBLAS / cuRAND / NVRTC; we only need `runtime` (for
-# external-memory + external-semaphore APIs).
-cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "fallback-dynamic-loading", "cuda-12090"] }
+# A fixed `cuda-*` feature (rather than `cuda-version-from-build-system`)
+# keeps the build free of nvcc. The version is the FLOOR of every
+# libcudart the process may dlopen, not the newest available: torch cu126
+# wheels bundle libcudart 12.6 into the venv, and when that copy wins the
+# dlopen race, any symbol newer than 12.6 in cudarc's table panics its
+# loader. The external-memory + external-semaphore APIs we use predate
+# 12.0, so the floor costs nothing. `default-features = false` skips
+# cuBLAS / cuRAND / NVRTC; we only need `runtime`.
+cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "fallback-dynamic-loading", "cuda-12060"] }
 
 # Skia bindings for the streamlib-adapter-skia crate.
 #

--- a/adapters/streamlib-adapter-cuda/Cargo.toml
+++ b/adapters/streamlib-adapter-cuda/Cargo.toml
@@ -29,6 +29,12 @@ default = []
 cuda = []
 
 [dependencies]
+# DLPack ABI mirrors only — `default-features = false` pulls in only
+# `bitflags` + `snafu`. Platform-agnostic and outside the Linux target
+# table on purpose: the `dlpack` module is the workspace's home for the
+# spec's `#[repr(C)]` types, and off-Linux consumers (the wheel's CPU
+# capsule path) need exactly it.
+dlpark.workspace = true
 streamlib-adapter-abi = { path = "../streamlib-adapter-abi", version = "0.11.1" }
 streamlib-adapter-cuda-abi = { path = "../streamlib-adapter-cuda-abi", version = "0.11.1" }
 thiserror.workspace = true
@@ -39,11 +45,7 @@ streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", versio
 streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.11.1" }
 vulkanalia.workspace = true
 libc.workspace = true
-# DLPack ABI mirrors only — `default-features = false` pulls in only
-# `bitflags` + `snafu`. The cdylib (Stage 9 / #589 / #590) builds the
-# Python `PyCapsule` from these `#[repr(C)]` types; we don't take any
-# of dlpark's safe-wrapper machinery (which assumes pyo3 ownership).
-dlpark.workspace = true
+
 
 # `streamlib` and the helper-binary crate are *test*-only deps: the
 # carve-out test brings up a `HostVulkanDevice`, allocates an

--- a/adapters/streamlib-adapter-cuda/src/dlpack.rs
+++ b/adapters/streamlib-adapter-cuda/src/dlpack.rs
@@ -23,7 +23,8 @@ use std::any::Any;
 use std::ffi::c_void;
 
 pub use dlpark::ffi::{
-    DataType, DataTypeCode, Device, DeviceType, ManagedTensor, ManagedTensorVersioned, Tensor,
+    DataType, DataTypeCode, Device, DeviceType, Flags, ManagedTensor, ManagedTensorVersioned,
+    PackVersion, Tensor,
 };
 
 /// Owner of any heap-allocated state the producer must keep alive
@@ -105,6 +106,73 @@ pub fn build_managed_tensor(
         dl_tensor,
         manager_ctx: ctx_ptr as *mut c_void,
         deleter: Some(deleter),
+    });
+    Box::into_raw(mt)
+}
+
+unsafe extern "C" fn versioned_deleter(t: *mut ManagedTensorVersioned) {
+    if t.is_null() {
+        return;
+    }
+    let mt = unsafe { Box::from_raw(t) };
+    if !mt.manager_ctx.is_null() {
+        let ctx = unsafe { Box::from_raw(mt.manager_ctx as *mut ManagerCtx) };
+        drop(ctx);
+    }
+    drop(mt);
+}
+
+/// Build a [`ManagedTensorVersioned`] — the DLPack v1.x exchange shape —
+/// over an existing pointer.
+///
+/// The versioned struct is what a consumer negotiates via `__dlpack__`'s
+/// `max_version`, and it is the only shape carrying [`Flags`]: an
+/// unversioned tensor has nowhere to say "this memory is writable", so
+/// consumers assume it is not. Pass `Flags::empty()` for a mutable
+/// export and `Flags::READ_ONLY` for a read-only one.
+///
+/// Ownership matches [`build_managed_tensor`]: the returned pointer is a
+/// `Box::into_raw` the consumer must eventually pass to the `deleter`.
+pub fn build_managed_tensor_versioned(
+    device_ptr: u64,
+    shape: Vec<i64>,
+    strides: Option<Vec<i64>>,
+    dtype: DataType,
+    device: Device,
+    flags: Flags,
+    owner: CapsuleOwner,
+) -> *mut ManagedTensorVersioned {
+    let shape: Box<[i64]> = shape.into_boxed_slice();
+    let shape_ptr = shape.as_ptr() as *mut i64;
+    let ndim = shape.len() as i32;
+
+    let strides: Option<Box<[i64]>> = strides.map(Vec::into_boxed_slice);
+    let strides_ptr: *mut i64 = match &strides {
+        Some(s) => s.as_ptr() as *mut i64,
+        None => std::ptr::null_mut(),
+    };
+
+    let ctx = Box::new(ManagerCtx {
+        _owner: owner,
+        _shape: shape,
+        _strides: strides,
+    });
+    let ctx_ptr = Box::into_raw(ctx);
+
+    let mt = Box::new(ManagedTensorVersioned {
+        version: PackVersion::default(),
+        manager_ctx: ctx_ptr as *mut c_void,
+        deleter: Some(versioned_deleter),
+        flags,
+        dl_tensor: Tensor {
+            data: device_ptr as *mut c_void,
+            device,
+            ndim,
+            dtype,
+            shape: shape_ptr,
+            strides: strides_ptr,
+            byte_offset: 0,
+        },
     });
     Box::into_raw(mt)
 }
@@ -205,6 +273,82 @@ mod tests {
         assert_eq!(offset_of!(Tensor, strides), 32);
         assert_eq!(offset_of!(Tensor, byte_offset), 40);
         assert_eq!(size_of::<Tensor>(), 48);
+    }
+
+    #[test]
+    fn dlpack_managed_tensor_versioned_layout_matches_spec_64bit() {
+        // typedef struct {
+        //   DLPackVersion version;      // offset 0,  size 8
+        //   void*         manager_ctx;  // offset 8,  size 8
+        //   void (*deleter)(...);       // offset 16, size 8
+        //   uint64_t      flags;        // offset 24, size 8
+        //   DLTensor      dl_tensor;    // offset 32, size 48
+        // } DLManagedTensorVersioned;
+        //
+        // Field order matters beyond the usual ABI reasons: the spec
+        // requires everything up to `flags` stay stable so a consumer
+        // built against an older minor version can still find and call
+        // the deleter on a tensor it does not fully understand.
+        assert_eq!(size_of::<PackVersion>(), 8, "2 × uint32");
+        assert_eq!(offset_of!(ManagedTensorVersioned, version), 0);
+        assert_eq!(offset_of!(ManagedTensorVersioned, manager_ctx), 8);
+        assert_eq!(offset_of!(ManagedTensorVersioned, deleter), 16);
+        assert_eq!(offset_of!(ManagedTensorVersioned, flags), 24);
+        assert_eq!(offset_of!(ManagedTensorVersioned, dl_tensor), 32);
+        assert_eq!(size_of::<ManagedTensorVersioned>(), 80);
+    }
+
+    #[test]
+    fn dlpack_flag_bits_match_spec() {
+        // Part of the wire ABI — a consumer reads these bits directly.
+        assert_eq!(Flags::READ_ONLY.bits(), 1 << 0);
+        assert_eq!(Flags::IS_COPIED.bits(), 1 << 1);
+        assert!(
+            Flags::empty().bits() == 0,
+            "an empty flag set is the spec's writable default"
+        );
+    }
+
+    #[test]
+    fn build_managed_tensor_versioned_carries_shape_flags_and_version() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        struct Counted(Arc<AtomicUsize>);
+        impl Drop for Counted {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        let owner: CapsuleOwner = Box::new(Counted(Arc::clone(&drops)));
+
+        let mt = build_managed_tensor_versioned(
+            0x2000,
+            vec![32, 64, 4],
+            Some(vec![256, 4, 1]),
+            DataType::U8,
+            Device::cuda(0),
+            Flags::empty(),
+            owner,
+        );
+        unsafe {
+            assert_eq!((*mt).version.major, 1, "v1.x exchange shape");
+            assert_eq!(
+                (*mt).flags,
+                Flags::empty(),
+                "an empty flag set means writable"
+            );
+            assert_eq!((*mt).dl_tensor.ndim, 3);
+            let shape = std::slice::from_raw_parts((*mt).dl_tensor.shape, 3).to_vec();
+            assert_eq!(shape, vec![32, 64, 4]);
+
+            let deleter = (*mt).deleter.expect("deleter must be Some");
+            deleter(mt);
+        }
+        assert_eq!(drops.load(Ordering::SeqCst), 1, "owner dropped exactly once");
+    }
+
+    #[test]
+    fn versioned_deleter_tolerates_null_pointer() {
+        unsafe { versioned_deleter(std::ptr::null_mut()) };
     }
 
     #[test]

--- a/adapters/streamlib-adapter-cuda/src/dlpack.rs
+++ b/adapters/streamlib-adapter-cuda/src/dlpack.rs
@@ -44,15 +44,64 @@ struct ManagerCtx {
     _strides: Option<Box<[i64]>>,
 }
 
+/// Reclaim the boxed [`ManagerCtx`] a managed tensor's `manager_ctx`
+/// owns — the one subtle half both deleters share.
+///
+/// SAFETY: `manager_ctx` must be the `Box::into_raw(Box<ManagerCtx>)`
+/// stored by [`boxed_manager_ctx_and_tensor`], reclaimed at most once.
+unsafe fn reclaim_manager_ctx(manager_ctx: *mut c_void) {
+    if !manager_ctx.is_null() {
+        drop(unsafe { Box::from_raw(manager_ctx as *mut ManagerCtx) });
+    }
+}
+
+/// Box the shape/strides, park them (with `owner`) in a leaked
+/// [`ManagerCtx`], and assemble the `Tensor` whose raw pointers point
+/// into those boxes — the ownership plumbing both builders share, kept
+/// in one place because a divergence dangles one copy's pointers.
+fn boxed_manager_ctx_and_tensor(
+    device_ptr: u64,
+    shape: Vec<i64>,
+    strides: Option<Vec<i64>>,
+    dtype: DataType,
+    device: Device,
+    owner: CapsuleOwner,
+) -> (*mut c_void, Tensor) {
+    let shape: Box<[i64]> = shape.into_boxed_slice();
+    let shape_ptr = shape.as_ptr() as *mut i64;
+    let ndim = shape.len() as i32;
+
+    let strides: Option<Box<[i64]>> = strides.map(Vec::into_boxed_slice);
+    let strides_ptr: *mut i64 = match &strides {
+        Some(s) => s.as_ptr() as *mut i64,
+        None => std::ptr::null_mut(),
+    };
+
+    let ctx = Box::new(ManagerCtx {
+        _owner: owner,
+        _shape: shape,
+        _strides: strides,
+    });
+    let tensor = Tensor {
+        data: device_ptr as *mut c_void,
+        device,
+        ndim,
+        dtype,
+        shape: shape_ptr,
+        strides: strides_ptr,
+        byte_offset: 0,
+    };
+    (Box::into_raw(ctx) as *mut c_void, tensor)
+}
+
 unsafe extern "C" fn deleter(t: *mut ManagedTensor) {
     if t.is_null() {
         return;
     }
     let mt = unsafe { Box::from_raw(t) };
-    if !mt.manager_ctx.is_null() {
-        let ctx = unsafe { Box::from_raw(mt.manager_ctx as *mut ManagerCtx) };
-        drop(ctx);
-    }
+    // SAFETY: `manager_ctx` came from `boxed_manager_ctx_and_tensor` in
+    // `build_managed_tensor`, reclaimed only here.
+    unsafe { reclaim_manager_ctx(mt.manager_ctx) };
     drop(mt);
 }
 
@@ -76,38 +125,13 @@ pub fn build_managed_tensor(
     device: Device,
     owner: CapsuleOwner,
 ) -> *mut ManagedTensor {
-    let shape: Box<[i64]> = shape.into_boxed_slice();
-    let shape_ptr = shape.as_ptr() as *mut i64;
-    let ndim = shape.len() as i32;
-
-    let strides: Option<Box<[i64]>> = strides.map(Vec::into_boxed_slice);
-    let strides_ptr: *mut i64 = match &strides {
-        Some(s) => s.as_ptr() as *mut i64,
-        None => std::ptr::null_mut(),
-    };
-
-    let ctx = Box::new(ManagerCtx {
-        _owner: owner,
-        _shape: shape,
-        _strides: strides,
-    });
-    let ctx_ptr = Box::into_raw(ctx);
-
-    let dl_tensor = Tensor {
-        data: device_ptr as *mut c_void,
-        device,
-        ndim,
-        dtype,
-        shape: shape_ptr,
-        strides: strides_ptr,
-        byte_offset: 0,
-    };
-    let mt = Box::new(ManagedTensor {
+    let (manager_ctx, dl_tensor) =
+        boxed_manager_ctx_and_tensor(device_ptr, shape, strides, dtype, device, owner);
+    Box::into_raw(Box::new(ManagedTensor {
         dl_tensor,
-        manager_ctx: ctx_ptr as *mut c_void,
+        manager_ctx,
         deleter: Some(deleter),
-    });
-    Box::into_raw(mt)
+    }))
 }
 
 unsafe extern "C" fn versioned_deleter(t: *mut ManagedTensorVersioned) {
@@ -115,10 +139,9 @@ unsafe extern "C" fn versioned_deleter(t: *mut ManagedTensorVersioned) {
         return;
     }
     let mt = unsafe { Box::from_raw(t) };
-    if !mt.manager_ctx.is_null() {
-        let ctx = unsafe { Box::from_raw(mt.manager_ctx as *mut ManagerCtx) };
-        drop(ctx);
-    }
+    // SAFETY: `manager_ctx` came from `boxed_manager_ctx_and_tensor` in
+    // `build_managed_tensor_versioned`, reclaimed only here.
+    unsafe { reclaim_manager_ctx(mt.manager_ctx) };
     drop(mt);
 }
 
@@ -142,39 +165,15 @@ pub fn build_managed_tensor_versioned(
     flags: Flags,
     owner: CapsuleOwner,
 ) -> *mut ManagedTensorVersioned {
-    let shape: Box<[i64]> = shape.into_boxed_slice();
-    let shape_ptr = shape.as_ptr() as *mut i64;
-    let ndim = shape.len() as i32;
-
-    let strides: Option<Box<[i64]>> = strides.map(Vec::into_boxed_slice);
-    let strides_ptr: *mut i64 = match &strides {
-        Some(s) => s.as_ptr() as *mut i64,
-        None => std::ptr::null_mut(),
-    };
-
-    let ctx = Box::new(ManagerCtx {
-        _owner: owner,
-        _shape: shape,
-        _strides: strides,
-    });
-    let ctx_ptr = Box::into_raw(ctx);
-
-    let mt = Box::new(ManagedTensorVersioned {
+    let (manager_ctx, dl_tensor) =
+        boxed_manager_ctx_and_tensor(device_ptr, shape, strides, dtype, device, owner);
+    Box::into_raw(Box::new(ManagedTensorVersioned {
         version: PackVersion::default(),
-        manager_ctx: ctx_ptr as *mut c_void,
+        manager_ctx,
         deleter: Some(versioned_deleter),
         flags,
-        dl_tensor: Tensor {
-            data: device_ptr as *mut c_void,
-            device,
-            ndim,
-            dtype,
-            shape: shape_ptr,
-            strides: strides_ptr,
-            byte_offset: 0,
-        },
-    });
-    Box::into_raw(mt)
+        dl_tensor,
+    }))
 }
 
 /// Convenience: wrap a flat byte buffer at `device_ptr` as a 1-D

--- a/adapters/streamlib-adapter-cuda/src/dlpack.rs
+++ b/adapters/streamlib-adapter-cuda/src/dlpack.rs
@@ -343,7 +343,11 @@ mod tests {
             let deleter = (*mt).deleter.expect("deleter must be Some");
             deleter(mt);
         }
-        assert_eq!(drops.load(Ordering::SeqCst), 1, "owner dropped exactly once");
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            1,
+            "owner dropped exactly once"
+        );
     }
 
     #[test]

--- a/adapters/streamlib-adapter-cuda/src/lib.rs
+++ b/adapters/streamlib-adapter-cuda/src/lib.rs
@@ -46,20 +46,35 @@
 //! decision (#588 Stage 8 ships the assertion; the result calibrates
 //! the cdylib default), and the polyglot E2E.
 
-#![cfg(target_os = "linux")]
+// The adapter proper is Linux-only (Vulkan↔CUDA), but `dlpack` is the
+// workspace's home for the DLPack `#[repr(C)]` spec mirrors, which are
+// platform-agnostic by definition — consumers building host-side DLPack
+// capsules off Linux (the wheel's CPU path) depend on exactly that
+// module and nothing else here.
 
+#[cfg(target_os = "linux")]
 mod adapter;
+#[cfg(target_os = "linux")]
 mod context;
 pub mod dlpack;
+#[cfg(target_os = "linux")]
 mod host_vtable;
+#[cfg(target_os = "linux")]
 mod state;
+#[cfg(target_os = "linux")]
 mod view;
 
+#[cfg(target_os = "linux")]
 pub use adapter::CudaSurfaceAdapter;
+#[cfg(target_os = "linux")]
 pub use context::CudaContext;
+#[cfg(target_os = "linux")]
 pub use host_vtable::host_cuda_surface_adapter_vtable;
+#[cfg(target_os = "linux")]
 pub use state::{HostImageSurfaceRegistration, HostSurfaceRegistration};
+#[cfg(target_os = "linux")]
 pub use streamlib_consumer_rhi::VulkanLayout;
+#[cfg(target_os = "linux")]
 pub use view::{
     CudaReadView, CudaSurfaceGuard, CudaSurfaceView, CudaTextureGuard, CudaTextureView,
     CudaWriteView,

--- a/docs/learnings/README.md
+++ b/docs/learnings/README.md
@@ -51,10 +51,10 @@ Avoid the two failure modes:
   Same NVIDIA cap as DMA-BUF, but for OPAQUE_FD allocations (CUDA / OpenCL
   interop); engine pre-warms every export pool at `HostVulkanDevice` construction
 - [@docs/learnings/nvidia-external-handle-type-exclusivity.md](nvidia-external-handle-type-exclusivity.md) —
-  One NVIDIA allocation cannot export both OPAQUE_FD and DMA-BUF
-  (`compatibleHandleTypes` are disjoint, measured), and CUDA has no
-  dma-buf import type — crossing flavours costs one GPU blit into a
-  staging allocation of the target flavour
+  One allocation cannot export both OPAQUE_FD and DMA-BUF on Linux +
+  NVIDIA (buffer `compatibleHandleTypes` disjoint — measured, RTX 3090 /
+  595.84), and CUDA has no dma-buf import type — crossing flavours costs
+  one GPU blit into a staging allocation of the target flavour
 - [@docs/learnings/nvidia-egl-dmabuf-render-target.md](nvidia-egl-dmabuf-render-target.md) —
   Linear DMA-BUFs on NVIDIA are EGL `external_only=TRUE` (sampler-only); FBO color attachments require a tiled DRM modifier from `eglQueryDmaBufModifiersEXT`
 - [@docs/learnings/headless-nvidia-vulkan-container.md](headless-nvidia-vulkan-container.md) —

--- a/docs/learnings/README.md
+++ b/docs/learnings/README.md
@@ -50,6 +50,11 @@ Avoid the two failure modes:
 - [@docs/learnings/nvidia-opaque-fd-after-swapchain.md](nvidia-opaque-fd-after-swapchain.md) —
   Same NVIDIA cap as DMA-BUF, but for OPAQUE_FD allocations (CUDA / OpenCL
   interop); engine pre-warms every export pool at `HostVulkanDevice` construction
+- [@docs/learnings/nvidia-external-handle-type-exclusivity.md](nvidia-external-handle-type-exclusivity.md) —
+  One NVIDIA allocation cannot export both OPAQUE_FD and DMA-BUF
+  (`compatibleHandleTypes` are disjoint, measured), and CUDA has no
+  dma-buf import type — crossing flavours costs one GPU blit into a
+  staging allocation of the target flavour
 - [@docs/learnings/nvidia-egl-dmabuf-render-target.md](nvidia-egl-dmabuf-render-target.md) —
   Linear DMA-BUFs on NVIDIA are EGL `external_only=TRUE` (sampler-only); FBO color attachments require a tiled DRM modifier from `eglQueryDmaBufModifiersEXT`
 - [@docs/learnings/headless-nvidia-vulkan-container.md](headless-nvidia-vulkan-container.md) —

--- a/docs/learnings/nvidia-external-handle-type-exclusivity.md
+++ b/docs/learnings/nvidia-external-handle-type-exclusivity.md
@@ -16,9 +16,15 @@
 
 ## Root cause (measured, not inferred)
 
-A `vkGetPhysicalDeviceExternalBufferProperties` probe on the MVP floor
-platform (RTX 3090, driver 595.84) reports the two handle types in
-**disjoint** `compatibleHandleTypes` sets:
+Scope of the measurement: **buffers, Linux + NVIDIA** (RTX 3090, driver
+595.84, `VkPhysicalDeviceExternalBufferInfo` with storage/transfer usage
+and no create flags). Image-side external handles carry their own
+constraints (the engine's register path already branches by flavour for
+`VkImage`s too); other vendors report differently — Mesa Intel/AMD list
+the two types as mutually compatible. Re-measure before generalising.
+
+A `vkGetPhysicalDeviceExternalBufferProperties` probe reports the two
+handle types in **disjoint** `compatibleHandleTypes` sets:
 
     OPAQUE_FD:    compatibleHandleTypes = { OPAQUE_FD }
     DMA_BUF_EXT:  compatibleHandleTypes = { DMA_BUF }
@@ -28,9 +34,7 @@ requested handle type to appear in the others' compatibility set, so a
 single allocation requesting `OPAQUE_FD | DMA_BUF_EXT` is spec-invalid on
 this driver. Note this is **not** VMA's one-export-info-per-pool
 limitation — `handleTypes` is a bitmask and one pool could legally chain
-both; the driver's compatibility report is what refuses. (Mesa
-Intel/AMD report the types mutually compatible — both are dma-bufs
-underneath — but the plan's platform floor is Linux + NVIDIA.)
+both; the driver's compatibility report is what refuses.
 
 ## Consequence for design
 

--- a/docs/learnings/nvidia-external-handle-type-exclusivity.md
+++ b/docs/learnings/nvidia-external-handle-type-exclusivity.md
@@ -1,0 +1,46 @@
+# NVIDIA: one allocation cannot export both OPAQUE_FD and DMA-BUF
+
+## Symptom
+
+- A DMA-BUF-flavoured allocation (pixel-buffer pool, camera imports) has
+  no OPAQUE_FD export path — `vkGetMemoryFdKHR` with
+  `OPAQUE_FD` fails on memory allocated for `DMA_BUF_EXT`, and vice
+  versa. `SurfaceStore::register_texture` works around the runtime
+  symptom by branching on the allocation's flavour.
+- CUDA cannot consume a graph frame directly: `cudaExternalMemoryHandleType`
+  has no dma-buf member at all (OpaqueFd, Win32×2, D3D×3, NvSciBuf — that
+  is the whole enum). NVIDIA's dma-buf support in CUDA
+  (`cuMemGetHandleForAddressRange`) *exports CUDA memory as* dma-buf for
+  GPUDirect; it does not import Vulkan dma-bufs. The only dma-buf→CUDA
+  route is an EGLImage detour with a GL context in the loop.
+
+## Root cause (measured, not inferred)
+
+A `vkGetPhysicalDeviceExternalBufferProperties` probe on the MVP floor
+platform (RTX 3090, driver 595.84) reports the two handle types in
+**disjoint** `compatibleHandleTypes` sets:
+
+    OPAQUE_FD:    compatibleHandleTypes = { OPAQUE_FD }
+    DMA_BUF_EXT:  compatibleHandleTypes = { DMA_BUF }
+
+VUID-VkExportMemoryAllocateInfo-handleTypes-00656 requires every
+requested handle type to appear in the others' compatibility set, so a
+single allocation requesting `OPAQUE_FD | DMA_BUF_EXT` is spec-invalid on
+this driver. Note this is **not** VMA's one-export-info-per-pool
+limitation — `handleTypes` is a bitmask and one pool could legally chain
+both; the driver's compatibility report is what refuses. (Mesa
+Intel/AMD report the types mutually compatible — both are dma-bufs
+underneath — but the plan's platform floor is Linux + NVIDIA.)
+
+## Consequence for design
+
+An allocation carries exactly one external-handle flavour, chosen at
+creation, and each consumer class needs its own: EGL/GL import is
+dma-buf-only (no OPAQUE_FD EGLImage exists), CUDA import is
+OPAQUE_FD-only. Bridging a frame from one flavour's world to the other's
+therefore costs one GPU copy into a staging allocation of the target
+flavour — this is why the device-export path blits into an OPAQUE_FD
+staging buffer rather than re-flavouring the pool
+(`core/context/device_export_staging.rs`), and why "give the pool both
+flavours" is not an available option, only a choice of which consumer
+class to strand.

--- a/runtime/streamlib-engine/src/core/context/device_export_staging.rs
+++ b/runtime/streamlib-engine/src/core/context/device_export_staging.rs
@@ -54,17 +54,20 @@ use streamlib_consumer_rhi::{PixelFormat, TextureFormat, VulkanLayout};
 /// queue, not a slow copy.
 const STAGING_REFILL_WAIT_TIMEOUT_NS: u64 = 2_000_000_000;
 
-/// The formats a device-export blit accepts: single-plane color whose
-/// byte arithmetic a DLPack consumer can express. Multi-plane formats
-/// are refused — a one-buffer export would drop chroma.
-fn export_bytes_per_pixel_for_texture(format: TextureFormat) -> Result<u32> {
+/// The pixel shape a texture-backed export presents to a DLPack
+/// consumer. Restricted to 4-byte color: the refill's geometry guard,
+/// the tightly-packed copy region, and the consumer-side tensor layout
+/// all express exactly that today — accepting a wider format here would
+/// size a staging no refill can fill. BGRA stays BGRA: relabeling those
+/// bytes RGBA would silently swap channels.
+fn export_pixel_shape_for_texture(format: TextureFormat) -> Result<PixelFormat> {
     match format {
-        TextureFormat::Rgba8Unorm
-        | TextureFormat::Rgba8UnormSrgb
-        | TextureFormat::Bgra8Unorm
-        | TextureFormat::Bgra8UnormSrgb
-        | TextureFormat::Rgba16Float
-        | TextureFormat::Rgba32Float => Ok(format.bytes_per_pixel()),
+        TextureFormat::Rgba8Unorm | TextureFormat::Rgba8UnormSrgb => Ok(PixelFormat::Rgba32),
+        TextureFormat::Bgra8Unorm | TextureFormat::Bgra8UnormSrgb => Ok(PixelFormat::Bgra32),
+        TextureFormat::Rgba16Float | TextureFormat::Rgba32Float => Err(Error::GpuError(format!(
+            "device export supports 4-byte color textures today; {format:?} needs the wider \
+             tensor layouts no consumer path expresses yet"
+        ))),
         TextureFormat::Nv12 => Err(Error::GpuError(
             "device export refuses NV12: it is two planes, and a one-buffer export would drop \
              chroma"
@@ -105,8 +108,8 @@ pub struct SurfaceDeviceExportStaging {
     staging_byte_size: u64,
     surface_width: u32,
     surface_height: u32,
-    /// The pixel shape the staging was sized for, when the source is a
-    /// pixel buffer; textures export as tightly-packed 4/8/16-byte color.
+    /// The pixel shape the staging was sized for — the buffer's own
+    /// format, or the 4-byte color shape a texture source maps to.
     pixel_format: Option<PixelFormat>,
     /// Whether [`GpuContext::copy_device_export_staging_back_to_surface`]
     /// can honour a write — true only for buffer-backed sources today.
@@ -193,34 +196,36 @@ impl GpuContext {
             return Ok(Arc::clone(existing));
         }
 
-        let (staging_byte_size, surface_width, surface_height, pixel_format, writable) = match self
-            .resolve_device_export_source(surface_id)?
-        {
-            ResolvedBlitSource::RegisteredTexture(registration) => {
-                let texture = registration.texture();
-                let bytes_per_pixel = export_bytes_per_pixel_for_texture(texture.format())?;
-                let (width, height) = (texture.width(), texture.height());
-                let byte_size = u64::from(width) * u64::from(height) * u64::from(bytes_per_pixel);
-                (byte_size, width, height, None, false)
-            }
-            ResolvedBlitSource::PixelBuffer(pixel_buffer) => {
-                let format = pixel_buffer.format();
-                export_bytes_per_pixel_for_pixel_format(format)?;
-                let byte_size = pixel_buffer.plane_size(0);
-                if byte_size == 0 {
-                    return Err(Error::GpuError(format!(
-                        "surface {surface_id} resolves to a zero-byte plane; nothing to export"
-                    )));
+        let (staging_byte_size, surface_width, surface_height, pixel_format, writable) =
+            match self.resolve_device_export_source(surface_id)? {
+                ResolvedBlitSource::RegisteredTexture(registration) => {
+                    let texture = registration.texture();
+                    let pixel_shape = export_pixel_shape_for_texture(texture.format())?;
+                    let (width, height) = (texture.width(), texture.height());
+                    // 4-byte color by `export_pixel_shape_for_texture`'s
+                    // restriction — the same arithmetic the refill guard and
+                    // the copy region assume.
+                    let byte_size = u64::from(width) * u64::from(height) * 4;
+                    (byte_size, width, height, Some(pixel_shape), false)
                 }
-                (
-                    byte_size,
-                    pixel_buffer.width,
-                    pixel_buffer.height,
-                    Some(format),
-                    true,
-                )
-            }
-        };
+                ResolvedBlitSource::PixelBuffer(pixel_buffer) => {
+                    let format = pixel_buffer.format();
+                    export_bytes_per_pixel_for_pixel_format(format)?;
+                    let byte_size = pixel_buffer.plane_size(0);
+                    if byte_size == 0 {
+                        return Err(Error::GpuError(format!(
+                            "surface {surface_id} resolves to a zero-byte plane; nothing to export"
+                        )));
+                    }
+                    (
+                        byte_size,
+                        pixel_buffer.width,
+                        pixel_buffer.height,
+                        Some(format),
+                        true,
+                    )
+                }
+            };
 
         let vulkan_device = self.device().vulkan_device();
         let staging_buffer = Arc::new(HostVulkanBuffer::new_opaque_fd_export_device_local(
@@ -244,9 +249,16 @@ impl GpuContext {
             pixel_format,
             writable,
         });
-        self.device_export_stagings
-            .lock()
-            .insert(surface_id.to_string(), Arc::clone(&staging));
+        // Double-check under the insert lock: a concurrent asker for the
+        // same surface_id may have published one while this thread was
+        // allocating. The loser's freshly-built staging drops here rather
+        // than replacing the entry other holders (and the wheel's
+        // CUDA-import memo) key on.
+        let mut stagings = self.device_export_stagings.lock();
+        if let Some(published) = stagings.get(surface_id) {
+            return Ok(Arc::clone(published));
+        }
+        stagings.insert(surface_id.to_string(), Arc::clone(&staging));
         Ok(staging)
     }
 
@@ -368,6 +380,16 @@ impl GpuContext {
                         staging.staging_byte_size,
                     )));
                 }
+                // Visibility for a prior producer's GPU writes: submission
+                // order alone doesn't make an earlier submission's buffer
+                // writes visible to this TRANSFER_READ.
+                recorder.record_buffer_barrier(
+                    pixel_buffer,
+                    VulkanStage::ALL_COMMANDS,
+                    VulkanStage::ALL_TRANSFER,
+                    VulkanAccess::MEMORY_WRITE,
+                    VulkanAccess::TRANSFER_READ,
+                )?;
                 recorder.record_copy_buffer_to_buffer(
                     pixel_buffer,
                     staging.staging_buffer.as_ref(),
@@ -409,6 +431,16 @@ impl GpuContext {
                 staging.staging_buffer.as_ref(),
                 &pixel_buffer,
                 staging.staging_byte_size,
+            )?;
+            // The published edit must be visible to whoever reads next —
+            // downstream GPU consumers and, via the coherent mapping the
+            // host wait covers, CPU readers.
+            recorder.record_buffer_barrier(
+                &pixel_buffer,
+                VulkanStage::ALL_TRANSFER,
+                VulkanStage::ALL_COMMANDS,
+                VulkanAccess::TRANSFER_WRITE,
+                VulkanAccess::MEMORY_READ,
             )
         })
     }

--- a/runtime/streamlib-engine/src/core/context/device_export_staging.rs
+++ b/runtime/streamlib-engine/src/core/context/device_export_staging.rs
@@ -14,90 +14,129 @@
 //! DEVICE_LOCAL, allocated once per surface, refilled by a VRAM-side
 //! copy each time a consumer asks.
 //!
-//! Shape constraint: this is the surface both placements share. In-process
-//! callers use it directly; the helper-process arrangement (#1714)
-//! registers the same staging + timeline with surface-share once and
-//! triggers refills over the existing timeline protocol — so nothing
+//! The blit source is resolved **per refill**, never cached: rotating
+//! producers re-register a different texture under the same surface id
+//! every frame (the camera's ring does exactly this), so a source
+//! resolved at creation silently blits the previous cycle's frame. The
+//! staging itself is per-surface-id and spans those re-registrations —
+//! which is why it lives in a [`GpuContext`]-owned map beside
+//! `texture_cache` rather than on the `TextureRegistration` that
+//! rotates out from under it.
+//!
+//! Ordering: the refill orders against the producer through queue
+//! submission order — every producer in this engine submits on the one
+//! `GpuContext` queue, and the refill's ALL_COMMANDS barrier makes prior
+//! submissions' writes visible. A multi-queue engine would need the
+//! refill to wait on the producer's timeline instead.
+//!
+//! Shape constraint: this is the surface both placements share.
+//! In-process callers use it directly; the helper-process arrangement
+//! (#1714) registers the same staging + timeline with surface-share once
+//! and triggers refills over the existing timeline protocol — so nothing
 //! here may assume the consumer lives in this process. The bounded host
 //! wait after each submit is the in-process convenience only; the
 //! exportable timeline is the contract.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use parking_lot::Mutex;
 
 use crate::core::context::GpuContext;
 use crate::core::error::{Error, Result};
-use crate::core::rhi::PixelBuffer;
 use crate::host_rhi::{HostGpuDeviceExt as _, VulkanAccess, VulkanStage};
 use crate::vulkan::rhi::{
     HostVulkanBuffer, HostVulkanTimelineSemaphore, ImageCopyRegion, RhiCommandRecorder,
 };
-use streamlib_consumer_rhi::{TextureFormat, VulkanLayout};
+use streamlib_consumer_rhi::{PixelFormat, TextureFormat, VulkanLayout};
 
 /// Bound on the host wait for a staging refill. The copy is VRAM→VRAM
 /// (tens of microseconds); a wait that reaches this bound is a wedged
 /// queue, not a slow copy.
 const STAGING_REFILL_WAIT_TIMEOUT_NS: u64 = 2_000_000_000;
 
-/// The texture formats a device-export blit accepts: 4-byte single-plane
-/// color. The staging buffer is sized `width * height * 4` and DLPack
-/// consumers see `(H, W, 4)` u8 — a format that breaks that arithmetic
-/// must be refused at creation, not exported with wrong strides.
-fn texture_format_bytes_per_pixel(format: TextureFormat) -> Result<u64> {
+/// The formats a device-export blit accepts: single-plane color whose
+/// byte arithmetic a DLPack consumer can express. Multi-plane formats
+/// are refused — a one-buffer export would drop chroma.
+fn export_bytes_per_pixel_for_texture(format: TextureFormat) -> Result<u32> {
     match format {
         TextureFormat::Rgba8Unorm
         | TextureFormat::Rgba8UnormSrgb
         | TextureFormat::Bgra8Unorm
-        | TextureFormat::Bgra8UnormSrgb => Ok(4),
-        other => Err(Error::GpuError(format!(
-            "device export supports 4-byte single-plane color textures; {other:?} has no \
-             single-buffer DLPack shape at 4 bytes per pixel"
-        ))),
+        | TextureFormat::Bgra8UnormSrgb
+        | TextureFormat::Rgba16Float
+        | TextureFormat::Rgba32Float => Ok(format.bytes_per_pixel()),
+        TextureFormat::Nv12 => Err(Error::GpuError(
+            "device export refuses NV12: it is two planes, and a one-buffer export would drop \
+             chroma"
+                .into(),
+        )),
     }
 }
 
-/// The source a staging buffer refills from, resolved once at creation.
-///
-/// Texture-first, matching the engine's own resolve order — the
-/// registered ring texture is the frame's device-resident truth, and
-/// blitting from it is VRAM→VRAM; the pooled pixel buffer is already a
-/// derived host-visible copy, so sourcing from it crosses PCIe and is
-/// the fallback for textureless producers.
-enum DeviceExportSource {
-    RegisteredTexture {
-        registration: crate::core::context::TextureRegistration,
-        width: u32,
-        height: u32,
-    },
-    PixelBuffer {
-        pixel_buffer: PixelBuffer,
-    },
+fn export_bytes_per_pixel_for_pixel_format(format: PixelFormat) -> Result<u32> {
+    if format.plane_count() > 1 || format == PixelFormat::Unknown {
+        return Err(Error::GpuError(format!(
+            "device export refuses {format:?}: DLPack expresses one strided linear buffer, and \
+             exporting only the first plane would hand out part of the image"
+        )));
+    }
+    Ok(format.bits_per_pixel() / 8)
+}
+
+/// The recorder plus the next timeline value, under one lock: the
+/// correctness of the strictly-increasing signal values depends on the
+/// value being drawn and submitted while this lock is held, so the
+/// invariant is structural rather than a convention beside an atomic.
+struct RefillSubmission {
+    recorder: RhiCommandRecorder,
+    next_signal_value: u64,
 }
 
 /// One surface's device-export staging: the OPAQUE_FD buffer an external
 /// device consumer imports, the exportable timeline that orders refills,
 /// and the recorder that reuses one command pool across them.
 pub struct SurfaceDeviceExportStaging {
+    surface_id: String,
     staging_buffer: Arc<HostVulkanBuffer>,
     refill_done_timeline: Arc<HostVulkanTimelineSemaphore>,
-    next_refill_signal_value: AtomicU64,
     /// One recorder, reused: per-refill pool creation is the exact churn
     /// `docs/learnings/nvidia-opaque-fd-after-swapchain.md` warns about.
-    refill_recorder: Mutex<RhiCommandRecorder>,
-    source: DeviceExportSource,
+    refill_submission: Mutex<RefillSubmission>,
     staging_byte_size: u64,
+    surface_width: u32,
+    surface_height: u32,
+    /// The pixel shape the staging was sized for, when the source is a
+    /// pixel buffer; textures export as tightly-packed 4/8/16-byte color.
+    pixel_format: Option<PixelFormat>,
     /// Whether [`GpuContext::copy_device_export_staging_back_to_surface`]
     /// can honour a write — true only for buffer-backed sources today.
     writable: bool,
 }
 
 impl SurfaceDeviceExportStaging {
-    /// Byte size of the staging buffer — the size a DLPack consumer's
-    /// tensor spans.
+    /// Byte size of the staging buffer — the span a DLPack tensor covers.
     pub fn staging_byte_size(&self) -> u64 {
         self.staging_byte_size
+    }
+
+    /// Width in pixels of the surface this staging was sized for.
+    pub fn surface_width(&self) -> u32 {
+        self.surface_width
+    }
+
+    /// Height in pixels of the surface this staging was sized for.
+    pub fn surface_height(&self) -> u32 {
+        self.surface_height
+    }
+
+    /// Row pitch in bytes, derived from the staging's own geometry.
+    pub fn bytes_per_row(&self) -> u64 {
+        self.staging_byte_size / u64::from(self.surface_height.max(1))
+    }
+
+    /// The pixel format the source carries, when it is a pixel buffer.
+    pub fn pixel_format(&self) -> Option<PixelFormat> {
+        self.pixel_format
     }
 
     /// Whether a device consumer may write and copy back.
@@ -117,39 +156,56 @@ impl SurfaceDeviceExportStaging {
     }
 }
 
+/// What a refill resolved this frame — looked up fresh on every copy so
+/// a rotating producer's re-registration is honoured, never a snapshot.
+enum ResolvedBlitSource {
+    RegisteredTexture(crate::core::context::TextureRegistration),
+    PixelBuffer(crate::core::rhi::PixelBuffer),
+}
+
 impl GpuContext {
-    /// Create the device-export staging for `surface_id`, resolving the
-    /// blit source once: the registered texture when one exists, the
-    /// pooled pixel buffer otherwise.
-    ///
-    /// One per surface, held by the caller — creation per frame would
-    /// churn exportable `vkAllocateMemory`, which NVIDIA's kernel
-    /// accounting punishes even when freed.
-    pub fn create_surface_device_export_staging(
+    /// Resolve the current blit source for `surface_id`, texture-first —
+    /// the registered texture is the frame's device-resident truth; the
+    /// pooled pixel buffer is a derived host-visible copy and the
+    /// fallback for textureless producers.
+    fn resolve_device_export_source(&self, surface_id: &str) -> Result<ResolvedBlitSource> {
+        match self.resolve_texture_registration_by_surface_id(surface_id, None, 0, 0) {
+            Ok(registration) => Ok(ResolvedBlitSource::RegisteredTexture(registration)),
+            Err(texture_miss) => match self.resolve_pixel_buffer_by_surface_id(surface_id) {
+                Ok(pixel_buffer) => Ok(ResolvedBlitSource::PixelBuffer(pixel_buffer)),
+                Err(buffer_miss) => Err(Error::GpuError(format!(
+                    "surface {surface_id} resolves to neither a registered texture \
+                     ({texture_miss}) nor a pixel buffer ({buffer_miss})"
+                ))),
+            },
+        }
+    }
+
+    /// The device-export staging for `surface_id`, created on first ask
+    /// and cached on this context — it dies with the context and is
+    /// evicted by [`Self::unregister_texture`], never by a rotating
+    /// re-registration, which the per-refill source resolve absorbs.
+    pub fn surface_device_export_staging(
         &self,
         surface_id: &str,
-        texture_layout: Option<i32>,
     ) -> Result<Arc<SurfaceDeviceExportStaging>> {
-        let (source, staging_byte_size, writable) = match self
-            .resolve_texture_registration_by_surface_id(surface_id, texture_layout, 0, 0)
+        if let Some(existing) = self.device_export_stagings.lock().get(surface_id) {
+            return Ok(Arc::clone(existing));
+        }
+
+        let (staging_byte_size, surface_width, surface_height, pixel_format, writable) = match self
+            .resolve_device_export_source(surface_id)?
         {
-            Ok(registration) => {
+            ResolvedBlitSource::RegisteredTexture(registration) => {
                 let texture = registration.texture();
-                let (width, height, format) = (texture.width(), texture.height(), texture.format());
-                let bytes_per_pixel = texture_format_bytes_per_pixel(format)?;
-                let byte_size = u64::from(width) * u64::from(height) * bytes_per_pixel;
-                (
-                    DeviceExportSource::RegisteredTexture {
-                        registration,
-                        width,
-                        height,
-                    },
-                    byte_size,
-                    false,
-                )
+                let bytes_per_pixel = export_bytes_per_pixel_for_texture(texture.format())?;
+                let (width, height) = (texture.width(), texture.height());
+                let byte_size = u64::from(width) * u64::from(height) * u64::from(bytes_per_pixel);
+                (byte_size, width, height, None, false)
             }
-            Err(_) => {
-                let pixel_buffer = self.resolve_pixel_buffer_by_surface_id(surface_id)?;
+            ResolvedBlitSource::PixelBuffer(pixel_buffer) => {
+                let format = pixel_buffer.format();
+                export_bytes_per_pixel_for_pixel_format(format)?;
                 let byte_size = pixel_buffer.plane_size(0);
                 if byte_size == 0 {
                     return Err(Error::GpuError(format!(
@@ -157,8 +213,10 @@ impl GpuContext {
                     )));
                 }
                 (
-                    DeviceExportSource::PixelBuffer { pixel_buffer },
                     byte_size,
+                    pixel_buffer.width,
+                    pixel_buffer.height,
+                    Some(format),
                     true,
                 )
             }
@@ -170,41 +228,111 @@ impl GpuContext {
             staging_byte_size,
         )?);
         let refill_done_timeline = self.create_exportable_timeline_semaphore(0)?;
-        let refill_recorder = Mutex::new(self.create_command_recorder("device_export_refill")?);
+        let refill_submission = Mutex::new(RefillSubmission {
+            recorder: self.create_command_recorder("device_export_refill")?,
+            next_signal_value: 1,
+        });
 
-        Ok(Arc::new(SurfaceDeviceExportStaging {
+        let staging = Arc::new(SurfaceDeviceExportStaging {
+            surface_id: surface_id.to_string(),
             staging_buffer,
             refill_done_timeline,
-            next_refill_signal_value: AtomicU64::new(1),
-            refill_recorder,
-            source,
+            refill_submission,
             staging_byte_size,
+            surface_width,
+            surface_height,
+            pixel_format,
             writable,
-        }))
+        });
+        self.device_export_stagings
+            .lock()
+            .insert(surface_id.to_string(), Arc::clone(&staging));
+        Ok(staging)
     }
 
-    /// Copy the surface's current pixels into the staging buffer, signal
-    /// the refill timeline, and wait (bounded) for the copy to land.
-    /// Returns the signalled timeline value — what a cross-process
-    /// consumer would wait on instead of relying on this host wait.
+    /// Drop the cached device-export staging for `surface_id`, if any.
+    /// Outstanding consumers keep theirs alive through their own `Arc`s.
+    pub(crate) fn evict_device_export_staging(&self, surface_id: &str) {
+        self.device_export_stagings.lock().remove(surface_id);
+    }
+
+    /// Record + submit one staging copy and wait (bounded) for it to
+    /// land, returning the signalled timeline value.
+    ///
+    /// The lock/begin/record/submit/wait choreography lives here once:
+    /// the signal value must be drawn and submitted under the recorder
+    /// lock (strictly-increasing timeline values), the lock must drop
+    /// before the host wait, and any record failure must abort the
+    /// recording — a recorder left mid-recording refuses every later
+    /// `begin`, which would brick this surface's export for the life of
+    /// the cache entry.
+    fn submit_staging_copy_and_wait(
+        &self,
+        staging: &SurfaceDeviceExportStaging,
+        record_copy: impl FnOnce(&mut RhiCommandRecorder) -> Result<()>,
+    ) -> Result<u64> {
+        let signal_value;
+        {
+            let mut submission = staging.refill_submission.lock();
+            submission.recorder.begin()?;
+            if let Err(record_failure) = record_copy(&mut submission.recorder) {
+                submission.recorder.abort_recording();
+                return Err(record_failure);
+            }
+            signal_value = submission.next_signal_value;
+            submission.next_signal_value += 1;
+            if let Err(submit_failure) = submission
+                .recorder
+                .submit_signaling_timeline(&staging.refill_done_timeline, signal_value)
+            {
+                submission.recorder.abort_recording();
+                return Err(submit_failure);
+            }
+        }
+        staging
+            .refill_done_timeline
+            .wait(signal_value, STAGING_REFILL_WAIT_TIMEOUT_NS)?;
+        Ok(signal_value)
+    }
+
+    /// Copy the surface's current pixels into the staging buffer.
+    /// Resolves the source fresh — a rotating producer's latest
+    /// registration, not a snapshot. Returns the signalled timeline
+    /// value a cross-process consumer would wait on instead of relying
+    /// on the in-process host wait.
     pub fn refill_device_export_staging(
         &self,
         staging: &SurfaceDeviceExportStaging,
     ) -> Result<u64> {
-        let mut recorder = staging.refill_recorder.lock();
-        recorder.begin()?;
-        match &staging.source {
-            DeviceExportSource::RegisteredTexture {
-                registration,
-                width,
-                height,
-            } => {
-                // The texture's last-known layout is the barrier's source;
-                // restored afterwards so the producer's next frame and any
-                // sibling consumer see the layout the registration claims.
+        let source = self.resolve_device_export_source(&staging.surface_id)?;
+        self.submit_staging_copy_and_wait(staging, |recorder| match &source {
+            ResolvedBlitSource::RegisteredTexture(registration) => {
+                let texture = registration.texture();
+                if u64::from(texture.width()) * u64::from(texture.height()) * 4
+                    != staging.staging_byte_size
+                {
+                    return Err(Error::GpuError(format!(
+                        "surface {} was re-registered with different geometry ({}x{}); the \
+                         cached staging is sized for {}x{} — resolve the surface again",
+                        staging.surface_id,
+                        texture.width(),
+                        texture.height(),
+                        staging.surface_width,
+                        staging.surface_height,
+                    )));
+                }
+                // The registration's last-known layout is the barrier's
+                // source. UNDEFINED (a texture nothing has written yet)
+                // cannot be a restore target, so such a texture comes to
+                // rest in GENERAL and the registration records that.
                 let resting_layout = registration.current_layout();
+                let restore_layout = if resting_layout == VulkanLayout::UNDEFINED {
+                    VulkanLayout::GENERAL
+                } else {
+                    resting_layout
+                };
                 recorder.record_image_barrier(
-                    registration.texture(),
+                    texture,
                     resting_layout,
                     VulkanLayout::TRANSFER_SRC_OPTIMAL,
                     VulkanStage::ALL_COMMANDS,
@@ -213,38 +341,40 @@ impl GpuContext {
                     VulkanAccess::TRANSFER_READ,
                 )?;
                 recorder.record_copy_image_to_buffer(
-                    registration.texture(),
+                    texture,
                     VulkanLayout::TRANSFER_SRC_OPTIMAL,
                     staging.staging_buffer.as_ref(),
-                    ImageCopyRegion::tightly_packed(*width, *height),
+                    ImageCopyRegion::tightly_packed(texture.width(), texture.height()),
                 )?;
                 recorder.record_image_barrier(
-                    registration.texture(),
+                    texture,
                     VulkanLayout::TRANSFER_SRC_OPTIMAL,
-                    resting_layout,
+                    restore_layout,
                     VulkanStage::ALL_TRANSFER,
                     VulkanStage::ALL_COMMANDS,
                     VulkanAccess::TRANSFER_READ,
                     VulkanAccess::MEMORY_READ,
                 )?;
+                registration.update_layout(restore_layout);
+                Ok(())
             }
-            DeviceExportSource::PixelBuffer { pixel_buffer } => {
+            ResolvedBlitSource::PixelBuffer(pixel_buffer) => {
+                if pixel_buffer.plane_size(0) != staging.staging_byte_size {
+                    return Err(Error::GpuError(format!(
+                        "surface {} now resolves to a {}-byte buffer; the cached staging is \
+                         sized for {} — resolve the surface again",
+                        staging.surface_id,
+                        pixel_buffer.plane_size(0),
+                        staging.staging_byte_size,
+                    )));
+                }
                 recorder.record_copy_buffer_to_buffer(
                     pixel_buffer,
                     staging.staging_buffer.as_ref(),
                     staging.staging_byte_size,
-                )?;
+                )
             }
-        }
-        let signal_value = staging
-            .next_refill_signal_value
-            .fetch_add(1, Ordering::SeqCst);
-        recorder.submit_signaling_timeline(&staging.refill_done_timeline, signal_value)?;
-        drop(recorder);
-        staging
-            .refill_done_timeline
-            .wait(signal_value, STAGING_REFILL_WAIT_TIMEOUT_NS)?;
-        Ok(signal_value)
+        })
     }
 
     /// Copy a written staging buffer back into its source surface, so an
@@ -257,29 +387,30 @@ impl GpuContext {
         &self,
         staging: &SurfaceDeviceExportStaging,
     ) -> Result<u64> {
-        let DeviceExportSource::PixelBuffer { pixel_buffer } = &staging.source else {
+        let source = self.resolve_device_export_source(&staging.surface_id)?;
+        let ResolvedBlitSource::PixelBuffer(pixel_buffer) = source else {
             return Err(Error::GpuError(
                 "this surface's device export is read-only: it is texture-backed, and the \
                  write-back path exists for buffer-backed surfaces only"
                     .into(),
             ));
         };
-        let mut recorder = staging.refill_recorder.lock();
-        recorder.begin()?;
-        recorder.record_copy_buffer_to_buffer(
-            staging.staging_buffer.as_ref(),
-            pixel_buffer,
-            staging.staging_byte_size,
-        )?;
-        let signal_value = staging
-            .next_refill_signal_value
-            .fetch_add(1, Ordering::SeqCst);
-        recorder.submit_signaling_timeline(&staging.refill_done_timeline, signal_value)?;
-        drop(recorder);
-        staging
-            .refill_done_timeline
-            .wait(signal_value, STAGING_REFILL_WAIT_TIMEOUT_NS)?;
-        Ok(signal_value)
+        if pixel_buffer.plane_size(0) != staging.staging_byte_size {
+            return Err(Error::GpuError(format!(
+                "surface {} now resolves to a {}-byte buffer; the staged write is sized for {} \
+                 — the edit cannot be published",
+                staging.surface_id,
+                pixel_buffer.plane_size(0),
+                staging.staging_byte_size,
+            )));
+        }
+        self.submit_staging_copy_and_wait(staging, |recorder| {
+            recorder.record_copy_buffer_to_buffer(
+                staging.staging_buffer.as_ref(),
+                &pixel_buffer,
+                staging.staging_byte_size,
+            )
+        })
     }
 
     /// Export the staging buffer's OPAQUE_FD plus byte size and the
@@ -304,14 +435,12 @@ impl GpuContext {
 // grown for a surface #1715 deletes — a cdylib caller panics at the
 // `host_inner` guard.
 impl crate::core::context::GpuContextLimitedAccess {
-    /// See [`GpuContext::create_surface_device_export_staging`].
-    pub fn create_surface_device_export_staging(
+    /// See [`GpuContext::surface_device_export_staging`].
+    pub fn surface_device_export_staging(
         &self,
         surface_id: &str,
-        texture_layout: Option<i32>,
     ) -> Result<Arc<SurfaceDeviceExportStaging>> {
-        self.host_inner()
-            .create_surface_device_export_staging(surface_id, texture_layout)
+        self.host_inner().surface_device_export_staging(surface_id)
     }
 
     /// See [`GpuContext::refill_device_export_staging`].

--- a/runtime/streamlib-engine/src/core/context/device_export_staging.rs
+++ b/runtime/streamlib-engine/src/core/context/device_export_staging.rs
@@ -1,0 +1,335 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Per-surface staging for handing engine frames to an external device
+//! consumer (CUDA today) — the "one GPU blit into an exportable staging
+//! buffer" the plan decides.
+//!
+//! Why a blit at all: pool allocations are DMA-BUF-flavoured, external
+//! device APIs import OPAQUE_FD, and on NVIDIA one allocation cannot
+//! export both — `vkGetPhysicalDeviceExternalBufferProperties` reports
+//! the two handle types in disjoint `compatibleHandleTypes` sets, so a
+//! dual-flavour allocation is spec-invalid (VUID-VkExportMemoryAllocateInfo-
+//! handleTypes-00656). The staging buffer is the bridge: OPAQUE_FD
+//! DEVICE_LOCAL, allocated once per surface, refilled by a VRAM-side
+//! copy each time a consumer asks.
+//!
+//! Shape constraint: this is the surface both placements share. In-process
+//! callers use it directly; the helper-process arrangement (#1714)
+//! registers the same staging + timeline with surface-share once and
+//! triggers refills over the existing timeline protocol — so nothing
+//! here may assume the consumer lives in this process. The bounded host
+//! wait after each submit is the in-process convenience only; the
+//! exportable timeline is the contract.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use parking_lot::Mutex;
+
+use crate::core::context::GpuContext;
+use crate::core::error::{Error, Result};
+use crate::core::rhi::PixelBuffer;
+use crate::host_rhi::{HostGpuDeviceExt as _, VulkanAccess, VulkanStage};
+use crate::vulkan::rhi::{
+    HostVulkanBuffer, HostVulkanTimelineSemaphore, ImageCopyRegion, RhiCommandRecorder,
+};
+use streamlib_consumer_rhi::{TextureFormat, VulkanLayout};
+
+/// Bound on the host wait for a staging refill. The copy is VRAM→VRAM
+/// (tens of microseconds); a wait that reaches this bound is a wedged
+/// queue, not a slow copy.
+const STAGING_REFILL_WAIT_TIMEOUT_NS: u64 = 2_000_000_000;
+
+/// The texture formats a device-export blit accepts: 4-byte single-plane
+/// color. The staging buffer is sized `width * height * 4` and DLPack
+/// consumers see `(H, W, 4)` u8 — a format that breaks that arithmetic
+/// must be refused at creation, not exported with wrong strides.
+fn texture_format_bytes_per_pixel(format: TextureFormat) -> Result<u64> {
+    match format {
+        TextureFormat::Rgba8Unorm
+        | TextureFormat::Rgba8UnormSrgb
+        | TextureFormat::Bgra8Unorm
+        | TextureFormat::Bgra8UnormSrgb => Ok(4),
+        other => Err(Error::GpuError(format!(
+            "device export supports 4-byte single-plane color textures; {other:?} has no \
+             single-buffer DLPack shape at 4 bytes per pixel"
+        ))),
+    }
+}
+
+/// The source a staging buffer refills from, resolved once at creation.
+///
+/// Texture-first, matching the engine's own resolve order — the
+/// registered ring texture is the frame's device-resident truth, and
+/// blitting from it is VRAM→VRAM; the pooled pixel buffer is already a
+/// derived host-visible copy, so sourcing from it crosses PCIe and is
+/// the fallback for textureless producers.
+enum DeviceExportSource {
+    RegisteredTexture {
+        registration: crate::core::context::TextureRegistration,
+        width: u32,
+        height: u32,
+    },
+    PixelBuffer {
+        pixel_buffer: PixelBuffer,
+    },
+}
+
+/// One surface's device-export staging: the OPAQUE_FD buffer an external
+/// device consumer imports, the exportable timeline that orders refills,
+/// and the recorder that reuses one command pool across them.
+pub struct SurfaceDeviceExportStaging {
+    staging_buffer: Arc<HostVulkanBuffer>,
+    refill_done_timeline: Arc<HostVulkanTimelineSemaphore>,
+    next_refill_signal_value: AtomicU64,
+    /// One recorder, reused: per-refill pool creation is the exact churn
+    /// `docs/learnings/nvidia-opaque-fd-after-swapchain.md` warns about.
+    refill_recorder: Mutex<RhiCommandRecorder>,
+    source: DeviceExportSource,
+    staging_byte_size: u64,
+    /// Whether [`GpuContext::copy_device_export_staging_back_to_surface`]
+    /// can honour a write — true only for buffer-backed sources today.
+    writable: bool,
+}
+
+impl SurfaceDeviceExportStaging {
+    /// Byte size of the staging buffer — the size a DLPack consumer's
+    /// tensor spans.
+    pub fn staging_byte_size(&self) -> u64 {
+        self.staging_byte_size
+    }
+
+    /// Whether a device consumer may write and copy back.
+    pub fn writable(&self) -> bool {
+        self.writable
+    }
+
+    /// Borrow the staging allocation (for export or import bookkeeping).
+    pub fn staging_buffer(&self) -> &Arc<HostVulkanBuffer> {
+        &self.staging_buffer
+    }
+
+    /// The timeline a consumer waits on; each refill signals the value
+    /// [`GpuContext::refill_device_export_staging`] returns.
+    pub fn refill_done_timeline(&self) -> &Arc<HostVulkanTimelineSemaphore> {
+        &self.refill_done_timeline
+    }
+}
+
+impl GpuContext {
+    /// Create the device-export staging for `surface_id`, resolving the
+    /// blit source once: the registered texture when one exists, the
+    /// pooled pixel buffer otherwise.
+    ///
+    /// One per surface, held by the caller — creation per frame would
+    /// churn exportable `vkAllocateMemory`, which NVIDIA's kernel
+    /// accounting punishes even when freed.
+    pub fn create_surface_device_export_staging(
+        &self,
+        surface_id: &str,
+        texture_layout: Option<i32>,
+    ) -> Result<Arc<SurfaceDeviceExportStaging>> {
+        let (source, staging_byte_size, writable) =
+            match self.resolve_texture_registration_by_surface_id(surface_id, texture_layout, 0, 0)
+            {
+                Ok(registration) => {
+                    let texture = registration.texture();
+                    let (width, height, format) =
+                        (texture.width(), texture.height(), texture.format());
+                    let bytes_per_pixel = texture_format_bytes_per_pixel(format)?;
+                    let byte_size = u64::from(width) * u64::from(height) * bytes_per_pixel;
+                    (
+                        DeviceExportSource::RegisteredTexture {
+                            registration,
+                            width,
+                            height,
+                        },
+                        byte_size,
+                        false,
+                    )
+                }
+                Err(_) => {
+                    let pixel_buffer = self.resolve_pixel_buffer_by_surface_id(surface_id)?;
+                    let byte_size = pixel_buffer.plane_size(0);
+                    if byte_size == 0 {
+                        return Err(Error::GpuError(format!(
+                            "surface {surface_id} resolves to a zero-byte plane; nothing to export"
+                        )));
+                    }
+                    (
+                        DeviceExportSource::PixelBuffer { pixel_buffer },
+                        byte_size,
+                        true,
+                    )
+                }
+            };
+
+        let vulkan_device = self.device().vulkan_device();
+        let staging_buffer = Arc::new(HostVulkanBuffer::new_opaque_fd_export_device_local(
+            vulkan_device,
+            staging_byte_size,
+        )?);
+        let refill_done_timeline = self.create_exportable_timeline_semaphore(0)?;
+        let refill_recorder = Mutex::new(self.create_command_recorder("device_export_refill")?);
+
+        Ok(Arc::new(SurfaceDeviceExportStaging {
+            staging_buffer,
+            refill_done_timeline,
+            next_refill_signal_value: AtomicU64::new(1),
+            refill_recorder,
+            source,
+            staging_byte_size,
+            writable,
+        }))
+    }
+
+    /// Copy the surface's current pixels into the staging buffer, signal
+    /// the refill timeline, and wait (bounded) for the copy to land.
+    /// Returns the signalled timeline value — what a cross-process
+    /// consumer would wait on instead of relying on this host wait.
+    pub fn refill_device_export_staging(
+        &self,
+        staging: &SurfaceDeviceExportStaging,
+    ) -> Result<u64> {
+        let mut recorder = staging.refill_recorder.lock();
+        recorder.begin()?;
+        match &staging.source {
+            DeviceExportSource::RegisteredTexture {
+                registration,
+                width,
+                height,
+            } => {
+                // The texture's last-known layout is the barrier's source;
+                // restored afterwards so the producer's next frame and any
+                // sibling consumer see the layout the registration claims.
+                let resting_layout = registration.current_layout();
+                recorder.record_image_barrier(
+                    registration.texture(),
+                    resting_layout,
+                    VulkanLayout::TRANSFER_SRC_OPTIMAL,
+                    VulkanStage::ALL_COMMANDS,
+                    VulkanStage::ALL_TRANSFER,
+                    VulkanAccess::MEMORY_WRITE,
+                    VulkanAccess::TRANSFER_READ,
+                )?;
+                recorder.record_copy_image_to_buffer(
+                    registration.texture(),
+                    VulkanLayout::TRANSFER_SRC_OPTIMAL,
+                    staging.staging_buffer.as_ref(),
+                    ImageCopyRegion::tightly_packed(*width, *height),
+                )?;
+                recorder.record_image_barrier(
+                    registration.texture(),
+                    VulkanLayout::TRANSFER_SRC_OPTIMAL,
+                    resting_layout,
+                    VulkanStage::ALL_TRANSFER,
+                    VulkanStage::ALL_COMMANDS,
+                    VulkanAccess::TRANSFER_READ,
+                    VulkanAccess::MEMORY_READ,
+                )?;
+            }
+            DeviceExportSource::PixelBuffer { pixel_buffer } => {
+                recorder.record_copy_buffer_to_buffer(
+                    pixel_buffer,
+                    staging.staging_buffer.as_ref(),
+                    staging.staging_byte_size,
+                )?;
+            }
+        }
+        let signal_value = staging.next_refill_signal_value.fetch_add(1, Ordering::SeqCst);
+        recorder.submit_signaling_timeline(&staging.refill_done_timeline, signal_value)?;
+        drop(recorder);
+        staging
+            .refill_done_timeline
+            .wait(signal_value, STAGING_REFILL_WAIT_TIMEOUT_NS)?;
+        Ok(signal_value)
+    }
+
+    /// Copy a written staging buffer back into its source surface, so an
+    /// in-place device-side edit is visible to every other holder.
+    ///
+    /// Buffer-backed sources only: the texture write-back (buffer→image
+    /// plus the layout dance) has no consumer yet, and a texture-backed
+    /// export is read-only by construction.
+    pub fn copy_device_export_staging_back_to_surface(
+        &self,
+        staging: &SurfaceDeviceExportStaging,
+    ) -> Result<u64> {
+        let DeviceExportSource::PixelBuffer { pixel_buffer } = &staging.source else {
+            return Err(Error::GpuError(
+                "this surface's device export is read-only: it is texture-backed, and the \
+                 write-back path exists for buffer-backed surfaces only"
+                    .into(),
+            ));
+        };
+        let mut recorder = staging.refill_recorder.lock();
+        recorder.begin()?;
+        recorder.record_copy_buffer_to_buffer(
+            staging.staging_buffer.as_ref(),
+            pixel_buffer,
+            staging.staging_byte_size,
+        )?;
+        let signal_value = staging.next_refill_signal_value.fetch_add(1, Ordering::SeqCst);
+        recorder.submit_signaling_timeline(&staging.refill_done_timeline, signal_value)?;
+        drop(recorder);
+        staging
+            .refill_done_timeline
+            .wait(signal_value, STAGING_REFILL_WAIT_TIMEOUT_NS)?;
+        Ok(signal_value)
+    }
+
+    /// Export the staging buffer's OPAQUE_FD plus byte size and the
+    /// exporting device's UUID — the CUDA import triple. The fd
+    /// transfers to the caller.
+    pub fn export_device_staging_opaque_fd(
+        &self,
+        staging: &SurfaceDeviceExportStaging,
+    ) -> Result<(std::os::unix::io::RawFd, u64, [u8; 16])> {
+        let fd = staging.staging_buffer.export_opaque_fd_memory()?;
+        let uuid = staging.staging_buffer.vulkan_device().physical_device_uuid();
+        Ok((fd, staging.staging_byte_size, uuid))
+    }
+}
+
+// In-process passthroughs on the limited capability, `host_inner`-direct
+// like `create_exportable_timeline_semaphore`: a per-frame export must be
+// reachable from `process` without escalating, and the cdylib arm is not
+// grown for a surface #1715 deletes — a cdylib caller panics at the
+// `host_inner` guard.
+impl crate::core::context::GpuContextLimitedAccess {
+    /// See [`GpuContext::create_surface_device_export_staging`].
+    pub fn create_surface_device_export_staging(
+        &self,
+        surface_id: &str,
+        texture_layout: Option<i32>,
+    ) -> Result<Arc<SurfaceDeviceExportStaging>> {
+        self.host_inner()
+            .create_surface_device_export_staging(surface_id, texture_layout)
+    }
+
+    /// See [`GpuContext::refill_device_export_staging`].
+    pub fn refill_device_export_staging(
+        &self,
+        staging: &SurfaceDeviceExportStaging,
+    ) -> Result<u64> {
+        self.host_inner().refill_device_export_staging(staging)
+    }
+
+    /// See [`GpuContext::copy_device_export_staging_back_to_surface`].
+    pub fn copy_device_export_staging_back_to_surface(
+        &self,
+        staging: &SurfaceDeviceExportStaging,
+    ) -> Result<u64> {
+        self.host_inner()
+            .copy_device_export_staging_back_to_surface(staging)
+    }
+
+    /// See [`GpuContext::export_device_staging_opaque_fd`].
+    pub fn export_device_staging_opaque_fd(
+        &self,
+        staging: &SurfaceDeviceExportStaging,
+    ) -> Result<(std::os::unix::io::RawFd, u64, [u8; 16])> {
+        self.host_inner().export_device_staging_opaque_fd(staging)
+    }
+}

--- a/runtime/streamlib-engine/src/core/context/device_export_staging.rs
+++ b/runtime/streamlib-engine/src/core/context/device_export_staging.rs
@@ -130,40 +130,39 @@ impl GpuContext {
         surface_id: &str,
         texture_layout: Option<i32>,
     ) -> Result<Arc<SurfaceDeviceExportStaging>> {
-        let (source, staging_byte_size, writable) =
-            match self.resolve_texture_registration_by_surface_id(surface_id, texture_layout, 0, 0)
-            {
-                Ok(registration) => {
-                    let texture = registration.texture();
-                    let (width, height, format) =
-                        (texture.width(), texture.height(), texture.format());
-                    let bytes_per_pixel = texture_format_bytes_per_pixel(format)?;
-                    let byte_size = u64::from(width) * u64::from(height) * bytes_per_pixel;
-                    (
-                        DeviceExportSource::RegisteredTexture {
-                            registration,
-                            width,
-                            height,
-                        },
-                        byte_size,
-                        false,
-                    )
+        let (source, staging_byte_size, writable) = match self
+            .resolve_texture_registration_by_surface_id(surface_id, texture_layout, 0, 0)
+        {
+            Ok(registration) => {
+                let texture = registration.texture();
+                let (width, height, format) = (texture.width(), texture.height(), texture.format());
+                let bytes_per_pixel = texture_format_bytes_per_pixel(format)?;
+                let byte_size = u64::from(width) * u64::from(height) * bytes_per_pixel;
+                (
+                    DeviceExportSource::RegisteredTexture {
+                        registration,
+                        width,
+                        height,
+                    },
+                    byte_size,
+                    false,
+                )
+            }
+            Err(_) => {
+                let pixel_buffer = self.resolve_pixel_buffer_by_surface_id(surface_id)?;
+                let byte_size = pixel_buffer.plane_size(0);
+                if byte_size == 0 {
+                    return Err(Error::GpuError(format!(
+                        "surface {surface_id} resolves to a zero-byte plane; nothing to export"
+                    )));
                 }
-                Err(_) => {
-                    let pixel_buffer = self.resolve_pixel_buffer_by_surface_id(surface_id)?;
-                    let byte_size = pixel_buffer.plane_size(0);
-                    if byte_size == 0 {
-                        return Err(Error::GpuError(format!(
-                            "surface {surface_id} resolves to a zero-byte plane; nothing to export"
-                        )));
-                    }
-                    (
-                        DeviceExportSource::PixelBuffer { pixel_buffer },
-                        byte_size,
-                        true,
-                    )
-                }
-            };
+                (
+                    DeviceExportSource::PixelBuffer { pixel_buffer },
+                    byte_size,
+                    true,
+                )
+            }
+        };
 
         let vulkan_device = self.device().vulkan_device();
         let staging_buffer = Arc::new(HostVulkanBuffer::new_opaque_fd_export_device_local(
@@ -237,7 +236,9 @@ impl GpuContext {
                 )?;
             }
         }
-        let signal_value = staging.next_refill_signal_value.fetch_add(1, Ordering::SeqCst);
+        let signal_value = staging
+            .next_refill_signal_value
+            .fetch_add(1, Ordering::SeqCst);
         recorder.submit_signaling_timeline(&staging.refill_done_timeline, signal_value)?;
         drop(recorder);
         staging
@@ -270,7 +271,9 @@ impl GpuContext {
             pixel_buffer,
             staging.staging_byte_size,
         )?;
-        let signal_value = staging.next_refill_signal_value.fetch_add(1, Ordering::SeqCst);
+        let signal_value = staging
+            .next_refill_signal_value
+            .fetch_add(1, Ordering::SeqCst);
         recorder.submit_signaling_timeline(&staging.refill_done_timeline, signal_value)?;
         drop(recorder);
         staging
@@ -287,7 +290,10 @@ impl GpuContext {
         staging: &SurfaceDeviceExportStaging,
     ) -> Result<(std::os::unix::io::RawFd, u64, [u8; 16])> {
         let fd = staging.staging_buffer.export_opaque_fd_memory()?;
-        let uuid = staging.staging_buffer.vulkan_device().physical_device_uuid();
+        let uuid = staging
+            .staging_buffer
+            .vulkan_device()
+            .physical_device_uuid();
         Ok((fd, staging.staging_byte_size, uuid))
     }
 }

--- a/runtime/streamlib-engine/src/core/context/gpu_context.rs
+++ b/runtime/streamlib-engine/src/core/context/gpu_context.rs
@@ -1768,6 +1768,31 @@ impl GpuContext {
         ))
     }
 
+    /// Export a fresh dup'd DMA-BUF FD for `pixel_buffer`, plus its byte
+    /// size. Ownership of the fd transfers to the caller.
+    ///
+    /// The counterpart of [`Self::import_dma_buf_storage_buffer`], and the
+    /// export half of the handle-shaped native-interop surface: external
+    /// code that speaks DMA-BUF (EGL, a V4L2 output device, another
+    /// process) receives the frame in its own dialect without the engine
+    /// exposing any Vulkan.
+    ///
+    /// Only a DMA-BUF-flavoured allocation can answer — pixel-buffer pool
+    /// buffers, which are allocated that way. An OPAQUE_FD allocation
+    /// has no DMA-BUF export path under VMA's per-pool memory
+    /// configuration (and none at all on NVIDIA), so this fails rather
+    /// than returning a handle the importer cannot use.
+    #[cfg(target_os = "linux")]
+    pub fn export_pixel_buffer_dma_buf_fd(
+        &self,
+        pixel_buffer: &crate::core::rhi::PixelBuffer,
+    ) -> Result<(std::os::unix::io::RawFd, u64)> {
+        use crate::host_rhi::HostPixelBufferRefExt as _;
+        let host_buffer = pixel_buffer.buffer_ref().vulkan_inner();
+        let fd = host_buffer.export_dma_buf_fd()?;
+        Ok((fd, host_buffer.size()))
+    }
+
     /// Allocate an OPAQUE_FD-exportable `VkBuffer` as a `StorageBuffer`.
     /// `device_local = true` picks the VRAM-resident CUDA-visible pool
     /// (`new_opaque_fd_export_device_local`); `false` picks the
@@ -5185,6 +5210,28 @@ impl GpuContextFullAccess {
                     Err(Error::GpuError(msg))
                 }
             }
+        }
+    }
+
+    /// Export a fresh dup'd DMA-BUF FD + byte size for a `PixelBuffer`.
+    /// The fd transfers to the caller.
+    ///
+    /// In-process only, like
+    /// [`Self::create_exportable_timeline_semaphore`]: a cdylib reaching
+    /// for a DMA-BUF handle goes through surface-share, which already
+    /// carries the fd over `SCM_RIGHTS`.
+    #[cfg(target_os = "linux")]
+    pub fn export_pixel_buffer_dma_buf_fd(
+        &self,
+        pixel_buffer: &crate::core::rhi::PixelBuffer,
+    ) -> Result<(std::os::unix::io::RawFd, u64)> {
+        match self.handle_kind {
+            HandleKind::Boxed => self
+                .host_inner()
+                .export_pixel_buffer_dma_buf_fd(pixel_buffer),
+            HandleKind::ScopeToken => Err(Error::GpuError(
+                "export_pixel_buffer_dma_buf_fd: available in-process only".into(),
+            )),
         }
     }
 

--- a/runtime/streamlib-engine/src/core/context/gpu_context.rs
+++ b/runtime/streamlib-engine/src/core/context/gpu_context.rs
@@ -416,6 +416,14 @@ pub struct GpuContext {
     /// `resolve_texture_registration_by_surface_id` get the same lifecycle metadata
     /// adapter consumers do.
     texture_cache: Arc<Mutex<HashMap<String, TextureRegistration>>>,
+    /// Device-export stagings keyed by surface_id — sibling of
+    /// `texture_cache`, but spanning registration replacements: a
+    /// rotating producer re-registers per frame, and the staging must
+    /// survive that while its blit source is re-resolved per refill.
+    /// Dropped with the context; evicted by `unregister_texture`.
+    #[cfg(target_os = "linux")]
+    pub(crate) device_export_stagings:
+        Arc<parking_lot::Mutex<HashMap<String, Arc<super::SurfaceDeviceExportStaging>>>>,
     /// Cache of textures backing surface-share-registered pixel buffers
     /// (`escalate_acquire_pixel_buffer` flow). Refreshed on every resolve so
     /// rotating-pool producers don't render stale contents — kept separate
@@ -493,6 +501,8 @@ impl GpuContext {
             surface_store: Arc::new(Mutex::new(None)),
             blitter,
             texture_cache: Arc::new(Mutex::new(HashMap::new())),
+            #[cfg(target_os = "linux")]
+            device_export_stagings: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             buffer_texture_cache: Arc::new(Mutex::new(HashMap::new())),
             #[cfg(target_os = "linux")]
             color_converter_cache: Arc::new(RwLock::new(HashMap::new())),
@@ -520,6 +530,8 @@ impl GpuContext {
             surface_store: Arc::new(Mutex::new(None)),
             blitter,
             texture_cache: Arc::new(Mutex::new(HashMap::new())),
+            #[cfg(target_os = "linux")]
+            device_export_stagings: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             buffer_texture_cache: Arc::new(Mutex::new(HashMap::new())),
             #[cfg(target_os = "linux")]
             color_converter_cache: Arc::new(RwLock::new(HashMap::new())),
@@ -731,6 +743,8 @@ impl GpuContext {
     pub fn unregister_texture(&self, id: &str) {
         let mut cache = self.texture_cache.lock().unwrap();
         cache.remove(id);
+        #[cfg(target_os = "linux")]
+        self.evict_device_export_staging(id);
     }
 
     /// Refresh the registration's `current_layout` for a given

--- a/runtime/streamlib-engine/src/core/context/mod.rs
+++ b/runtime/streamlib-engine/src/core/context/mod.rs
@@ -9,6 +9,8 @@ mod compute_kernel_bridge;
 mod cpu_readback_bridge;
 pub(crate) mod escalate_gate;
 pub(crate) mod escalate_scope_registry;
+#[cfg(target_os = "linux")]
+mod device_export_staging;
 mod gpu_context;
 #[cfg(target_os = "linux")]
 mod graphics_kernel_bridge;
@@ -34,6 +36,8 @@ pub use compute_kernel_bridge::ComputeKernelBridge;
 pub use cpu_readback_bridge::{CpuReadbackBridge, CpuReadbackCopyDirection};
 #[cfg(target_os = "linux")]
 pub use gpu_context::GpuCapabilitiesSnapshot;
+#[cfg(target_os = "linux")]
+pub use device_export_staging::SurfaceDeviceExportStaging;
 pub use gpu_context::{GpuContext, GpuContextFullAccess, GpuContextLimitedAccess};
 #[cfg(target_os = "linux")]
 pub use graphics_kernel_bridge::{

--- a/runtime/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
@@ -471,6 +471,41 @@ impl RhiCommandRecorderInner {
         Ok(())
     }
 
+    /// Record `vkCmdCopyBuffer` over the first `byte_size` bytes of both
+    /// buffers.
+    pub fn record_copy_buffer_to_buffer(
+        &mut self,
+        src: &(impl VulkanBufferLike + ?Sized),
+        dst: &(impl VulkanBufferLike + ?Sized),
+        byte_size: u64,
+    ) -> Result<()> {
+        self.expect_recording("record_copy_buffer_to_buffer")?;
+        if byte_size > src.vk_buffer_size() || byte_size > dst.vk_buffer_size() {
+            return Err(Error::GpuError(format!(
+                "RhiCommandRecorder '{}': record_copy_buffer_to_buffer: copy of {} bytes exceeds \
+                 src ({}) or dst ({})",
+                self.label,
+                byte_size,
+                src.vk_buffer_size(),
+                dst.vk_buffer_size(),
+            )));
+        }
+        let region = vk::BufferCopy::builder()
+            .src_offset(0)
+            .dst_offset(0)
+            .size(byte_size as vk::DeviceSize)
+            .build();
+        unsafe {
+            self.device.cmd_copy_buffer(
+                self.command_buffer,
+                src.vk_buffer(),
+                dst.vk_buffer(),
+                &[region],
+            );
+        }
+        Ok(())
+    }
+
     /// Record a compute dispatch via [`VulkanComputeKernel::record`]
     /// into the recorder's command buffer.
     ///
@@ -1281,6 +1316,18 @@ impl RhiCommandRecorder {
     ) -> Result<()> {
         self.host_inner_mut()
             .record_copy_buffer_to_image(src, dst, dst_layout, region)
+    }
+
+    /// Copy buffer → buffer. Host-only until a cdylib consumer
+    /// arrives; cdylib callers panic at [`Self::host_inner_mut`].
+    pub fn record_copy_buffer_to_buffer(
+        &mut self,
+        src: &(impl VulkanBufferLike + ?Sized),
+        dst: &(impl VulkanBufferLike + ?Sized),
+        byte_size: u64,
+    ) -> Result<()> {
+        self.host_inner_mut()
+            .record_copy_buffer_to_buffer(src, dst, byte_size)
     }
 
     /// Compute dispatch.

--- a/sdk/streamlib-python-wheel/Cargo.toml
+++ b/sdk/streamlib-python-wheel/Cargo.toml
@@ -63,11 +63,20 @@ tracing = { workspace = true }
 
 # Raw CLOCK_MONOTONIC + timerfd: the wheel's clock contract is the kernel's
 # monotonic epoch (comparable to `time.clock_gettime_ns(time.CLOCK_MONOTONIC)`),
-# which std does not expose.
+# which std does not expose. Also the fd ownership the CUDA import path needs.
 libc = { workspace = true }
 # Guards the lifecycle-scoped context leases; non-poisoning, so a panicking
 # hook cannot wedge every later lease install.
 parking_lot = "0.12"
+
+# The CUDA import half of the pixel exchange. Depended on unconditionally on
+# Linux rather than behind a feature: `fallback-dynamic-loading` means
+# `libcuda.so` is dlopen'd at first use, never linked, so a machine without an
+# NVIDIA driver gets a clean "no CUDA driver" refusal instead of a wheel that
+# fails to load. That is the plan's portability model, and the shape
+# `streamlib-python-native` already ships.
+[target.'cfg(target_os = "linux")'.dependencies]
+cudarc = { workspace = true }
 
 [lints]
 workspace = true

--- a/sdk/streamlib-python-wheel/Cargo.toml
+++ b/sdk/streamlib-python-wheel/Cargo.toml
@@ -47,6 +47,13 @@ streamlib = { path = "../streamlib-sdk", version = "0.11.1", default-features = 
 # construction.
 streamlib-media-builtins = { path = "../../runtime/streamlib-media-builtins", version = "0.11.1" }
 
+# The workspace's single DLPack home: the `#[repr(C)]` v0.8 ABI mirrors, the
+# managed-tensor builders, and the layout regression test that pins them. The
+# pixel-exchange surface builds its capsules here rather than growing a second
+# copy of the spec — the CUDA half of the same adapter is what the device-memory
+# export path uses.
+streamlib-adapter-cuda = { path = "../../adapters/streamlib-adapter-cuda", version = "0.11.1" }
+
 # The bag's value tree. A bag crosses into Python as ordinary Python data, and
 # `rmpv`'s native `bin` variant is what keeps a byte payload from decoding as
 # text on the way through.

--- a/sdk/streamlib-python-wheel/pyproject.toml
+++ b/sdk/streamlib-python-wheel/pyproject.toml
@@ -30,7 +30,10 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0"]
+# numpy and torch are test-and-types dependencies, not runtime ones — the
+# wheel itself never imports either; the exchange surface hands frames to
+# whichever consumer the user installed.
+dev = ["pytest>=7.0", "numpy>=2.1", "torch>=2.0"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -272,6 +272,23 @@ class GpuContextFullAccess:
         serve numpy and CUDA. Setup-shaped: allocate once, never per frame.
         """
 
+    def export_dma_buf(self, surface: GpuSurfaceHandle) -> tuple[int, int]:
+        """Export a DMA-BUF file descriptor for `surface`, as `(fd, byte_size)`.
+
+        The caller owns the fd and must close it, or hand it to something that
+        takes ownership. Only an ordinary pixel buffer can answer — a
+        device-exchange buffer is OPAQUE_FD-flavoured.
+        """
+
+    def import_dma_buf(
+        self, fd: int, width: int, height: int, format: str = "bgra"
+    ) -> GpuSurfaceHandle:
+        """Import a DMA-BUF file descriptor as a surface this graph can read.
+
+        Takes ownership of `fd` on success — the driver adopts it and it must
+        not be closed afterwards. On failure the fd is still the caller's.
+        """
+
     def wait_device_idle(self) -> None: ...
 
 @final

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -15,7 +15,7 @@ binary no longer exports still reads as complete.
 
 from types import TracebackType
 from collections.abc import Callable, Mapping
-from typing import Any, Literal, NoReturn, TypeVar, final
+from typing import Any, Literal, TypeVar, final
 
 from typing_extensions import disjoint_base
 
@@ -262,7 +262,7 @@ class GpuContextFullAccess:
 
 @final
 class GpuSurfaceHandle:
-    """An owned GPU surface. Pixel access lands with ticket #1710."""
+    """An owned GPU surface, and the pixels behind it."""
 
     @property
     def surface_id(self) -> str: ...
@@ -272,6 +272,14 @@ class GpuSurfaceHandle:
     def height(self) -> int: ...
     @property
     def format(self) -> str: ...
+    @property
+    def bytes_per_row(self) -> int:
+        """Row pitch in bytes, including any padding the allocation carries."""
+
+    @property
+    def base_address(self) -> int:
+        """Base address of the host mapping, or 0 when not locked."""
+
     def close(self) -> None:
         """Release the underlying GPU resource. Idempotent."""
 
@@ -282,11 +290,28 @@ class GpuSurfaceHandle:
         exception: BaseException | None = ...,
         traceback: TracebackType | None = ...,
     ) -> Literal[False]: ...
-    # Raise NotImplementedError until the pixel-exchange surface (#1710) lands.
-    def as_numpy(self) -> NoReturn: ...
-    def __dlpack__(self) -> NoReturn: ...
-    def lock(self) -> NoReturn: ...
-    def unlock(self) -> NoReturn: ...
+    def lock(self, read_only: bool = True) -> None:
+        """Open CPU access, waiting for the producer to finish writing first."""
+
+    def unlock(self, read_only: bool = True) -> None:
+        """Close CPU access. Idempotent."""
+
+    def as_numpy(self) -> Any:
+        """A numpy view sharing memory with the surface. Requires a lock."""
+
+    def __dlpack_device__(self) -> tuple[int, int]: ...
+    def __dlpack__(
+        self,
+        stream: Any | None = ...,
+        max_version: tuple[int, int] | None = ...,
+        dl_device: tuple[int, int] | None = ...,
+        copy: bool | None = ...,
+    ) -> Any:
+        """A DLPack capsule over the pixels. Requires a lock.
+
+        The tensor may outlive this handle: it holds its own share of the
+        surface, so the pool slot is not reused until the tensor is released.
+        """
 
 @final
 class MonotonicTimer:

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -258,20 +258,6 @@ class GpuContextFullAccess:
     def acquire_texture(
         self, width: int, height: int, format: str, usage: list[str]
     ) -> GpuSurfaceHandle: ...
-    def acquire_device_exchange_buffer(
-        self,
-        width: int,
-        height: int,
-        format: str = "bgra",
-        device_local: bool = True,
-    ) -> GpuSurfaceHandle:
-        """Acquire a buffer whose memory external device code can import.
-
-        Allocated OPAQUE_FD-exportable — the handle flavour CUDA imports.
-        `device_local=False` keeps a host mapping alongside, so the same bytes
-        serve numpy and CUDA. Setup-shaped: allocate once, never per frame.
-        """
-
     def export_dma_buf(self, surface: GpuSurfaceHandle) -> tuple[int, int]:
         """Export a DMA-BUF file descriptor for `surface`, as `(fd, byte_size)`.
 
@@ -344,6 +330,13 @@ class GpuSurfaceHandle:
         copy: bool | None = ...,
     ) -> Any:
         """A DLPack capsule over the pixels. Requires a lock.
+
+        A graph frame's natural side is the device: with a usable CUDA
+        runtime the tensor is GPU-resident (one engine-side blit into an
+        exportable staging buffer — zero CPU copies, never claimed
+        copy-free); otherwise, or with `dl_device=(1, 0)`, it is the host
+        mapping. A writable device tensor's edits publish back to the
+        surface at `unlock()`.
 
         The tensor may outlive this handle: it holds its own share of the
         surface, so the pool slot is not reused until the tensor is released.

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -267,7 +267,12 @@ class GpuContextFullAccess:
         """
 
     def import_dma_buf(
-        self, fd: int, width: int, height: int, format: str = "bgra"
+        self,
+        fd: int,
+        width: int,
+        height: int,
+        format: str = "bgra",
+        byte_size: int | None = None,
     ) -> GpuSurfaceHandle:
         """Import a DMA-BUF file descriptor as a surface this graph can read.
 

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -322,7 +322,12 @@ class GpuSurfaceHandle:
         traceback: TracebackType | None = ...,
     ) -> Literal[False]: ...
     def lock(self, read_only: bool = True) -> None:
-        """Open CPU access, waiting for the producer to finish writing first."""
+        """Open CPU access, declaring read or write intent.
+
+        Performs no wait — ordering against the producer comes from
+        publication, since a source finishes its GPU work before it sends the
+        frame on. `read_only=False` marks an exported tensor writable.
+        """
 
     def unlock(self, read_only: bool = True) -> None:
         """Close CPU access. Idempotent."""

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -258,6 +258,20 @@ class GpuContextFullAccess:
     def acquire_texture(
         self, width: int, height: int, format: str, usage: list[str]
     ) -> GpuSurfaceHandle: ...
+    def acquire_device_exchange_buffer(
+        self,
+        width: int,
+        height: int,
+        format: str = "bgra",
+        device_local: bool = True,
+    ) -> GpuSurfaceHandle:
+        """Acquire a buffer whose memory external device code can import.
+
+        Allocated OPAQUE_FD-exportable — the handle flavour CUDA imports.
+        `device_local=False` keeps a host mapping alongside, so the same bytes
+        serve numpy and CUDA. Setup-shaped: allocate once, never per frame.
+        """
+
     def wait_device_idle(self) -> None: ...
 
 @final

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -294,8 +294,8 @@ class GpuSurfaceHandle:
         """Row pitch in bytes, including any padding the allocation carries."""
 
     @property
-    def base_address(self) -> int:
-        """Base address of the host mapping, or 0 when not locked."""
+    def base_address(self) -> int | None:
+        """Base address of the host mapping, or None when not locked."""
 
     def close(self) -> None:
         """Release the underlying GPU resource. Idempotent."""
@@ -315,8 +315,10 @@ class GpuSurfaceHandle:
         frame on. `read_only=False` marks an exported tensor writable.
         """
 
-    def unlock(self, read_only: bool = True) -> None:
-        """Close CPU access. Idempotent."""
+    def unlock(self) -> None:
+        """Close CPU access, publishing any pending device-side write back
+        into the surface first. Idempotent.
+        """
 
     def as_numpy(self) -> Any:
         """A numpy view sharing memory with the surface. Requires a lock."""

--- a/sdk/streamlib-python-wheel/src/lib.rs
+++ b/sdk/streamlib-python-wheel/src/lib.rs
@@ -8,6 +8,7 @@ use pyo3::prelude::*;
 
 mod python_added_processor;
 mod python_bag_conversion;
+mod python_gpu_surface_pixel_exchange;
 mod python_logging;
 mod python_monotonic_timer;
 mod python_native_builtin_blocks;

--- a/sdk/streamlib-python-wheel/src/lib.rs
+++ b/sdk/streamlib-python-wheel/src/lib.rs
@@ -8,6 +8,8 @@ use pyo3::prelude::*;
 
 mod python_added_processor;
 mod python_bag_conversion;
+#[cfg(target_os = "linux")]
+mod python_cuda_pixel_exchange;
 mod python_gpu_surface_pixel_exchange;
 mod python_logging;
 mod python_monotonic_timer;

--- a/sdk/streamlib-python-wheel/src/python_cuda_pixel_exchange.rs
+++ b/sdk/streamlib-python-wheel/src/python_cuda_pixel_exchange.rs
@@ -71,11 +71,23 @@ impl Drop for CudaImportedSurface {
         // *before* the object is destroyed. Freeing after — or not at
         // all — leaks the mapping and violates the destroy precondition.
         //
+        // The owning device must be current first: both cleanup calls act
+        // on the calling thread's device, and Drop can run on any thread —
+        // a Python GC of a capsule, the memo sweep — that never bound this
+        // GPU.
+        //
         // SAFETY: `device_pointer` came from `get_mapped_buffer` on
         // `external_memory` and is freed exactly once; `external_memory`
         // came from a successful `cudaImportExternalMemory`, is destroyed
         // exactly once, and by this line has no mapped buffers left.
         unsafe {
+            if let Err(bind_failure) = sys::cudaSetDevice(self.dlpack_device.device_id).result() {
+                tracing::debug!(
+                    ?bind_failure,
+                    device_id = self.dlpack_device.device_id,
+                    "cudaSetDevice before external-memory cleanup failed"
+                );
+            }
             if let Err(free_failure) = cuda_result::memory_free(self.device_pointer as *mut c_void)
             {
                 tracing::debug!(?free_failure, "cudaFree of the mapped buffer failed");

--- a/sdk/streamlib-python-wheel/src/python_cuda_pixel_exchange.rs
+++ b/sdk/streamlib-python-wheel/src/python_cuda_pixel_exchange.rs
@@ -1,0 +1,224 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The device half of the pixel-exchange surface: handing CUDA a pointer
+//! into memory the engine allocated, without a trip through host memory.
+//!
+//! The engine exports an OPAQUE_FD for a `StorageBuffer` it owns; CUDA
+//! imports it with `cudaImportExternalMemory` and maps a device pointer
+//! that aliases the same kernel allocation the `VkBuffer` is bound to.
+//! Nothing is copied and CUDA never allocates — which is the whole point:
+//! external native code receives memory in its own dialect, and Vulkan is
+//! still written only by this engine.
+//!
+//! Three details are load-bearing and easy to get silently wrong.
+//!
+//! **Device binding.** The import must land on the GPU that owns the
+//! memory, so the CUDA device is selected by matching
+//! `cudaDeviceProp::uuid` against the exporting device's
+//! `VkPhysicalDeviceIDProperties::deviceUUID`. Falling through to CUDA
+//! device 0 works on every single-GPU rig and corrupts silently on a
+//! multi-GPU one.
+//!
+//! **Fd ownership.** `cudaImportExternalMemory` takes the fd on success
+//! and leaves it with the caller on failure — so the failure paths close
+//! it and the success path must not.
+//!
+//! **Pointer classification.** A driver that downgraded the import to
+//! pinned-host memory would still return a usable pointer, but a DLPack
+//! capsule claiming `kDLCUDA` over it makes consumers issue device
+//! copies against host memory. `cudaPointerGetAttributes` is what tells
+//! the two apart, so the capsule reports what the driver actually did.
+
+use std::os::unix::io::RawFd;
+
+use cudarc::runtime::result::external_memory;
+use cudarc::runtime::sys;
+use streamlib_adapter_cuda::dlpack::{Device, DeviceType};
+
+/// A CUDA import of engine-owned memory, alive for as long as the
+/// surface it came from.
+pub(crate) struct CudaImportedSurface {
+    external_memory: sys::cudaExternalMemory_t,
+    device_pointer: u64,
+    dlpack_device: Device,
+}
+
+// SAFETY: the CUDA handles are plain driver-owned pointers with no
+// thread affinity — the runtime API is thread-safe, and the only
+// operation this type performs on them is a destroy in `Drop`.
+unsafe impl Send for CudaImportedSurface {}
+unsafe impl Sync for CudaImportedSurface {}
+
+impl CudaImportedSurface {
+    pub(crate) fn device_pointer(&self) -> u64 {
+        self.device_pointer
+    }
+
+    /// What the driver actually produced — `kDLCUDA` for true device
+    /// memory, `kDLCUDAHost` if it classified the import as pinned host.
+    pub(crate) fn dlpack_device(&self) -> Device {
+        self.dlpack_device
+    }
+}
+
+impl Drop for CudaImportedSurface {
+    fn drop(&mut self) {
+        // SAFETY: `external_memory` came from a successful
+        // `cudaImportExternalMemory` and is destroyed exactly once.
+        if let Err(destroy_failure) =
+            unsafe { external_memory::destroy_external_memory(self.external_memory) }
+        {
+            tracing::debug!(?destroy_failure, "cudaDestroyExternalMemory failed");
+        }
+    }
+}
+
+/// Why a device export was not possible. Rendered straight into the
+/// Python exception, so each variant says what to do about it.
+pub(crate) fn cuda_unavailable_reason() -> Option<String> {
+    // SAFETY: the probe only attempts the dlopen; it touches no CUDA state.
+    if !unsafe { sys::is_culib_present() } {
+        return Some(
+            "the CUDA driver library is not loadable: install an NVIDIA driver, or use the host \
+             mapping (`as_numpy`) instead"
+                .to_string(),
+        );
+    }
+    None
+}
+
+/// Select the CUDA device whose UUID matches the exporting Vulkan
+/// device, and make it current.
+///
+/// The UUID match is the entire device-binding contract. A silent
+/// fall-through to device 0 would import the memory onto the wrong GPU
+/// on a multi-GPU rig and produce garbage rather than an error.
+fn bind_cuda_device_by_uuid(vulkan_device_uuid: [u8; 16]) -> Result<i32, String> {
+    let device_count = unsafe {
+        let mut count: i32 = 0;
+        sys::cudaGetDeviceCount(&mut count)
+            .result()
+            .map_err(|failure| format!("cudaGetDeviceCount: {failure:?}"))?;
+        count
+    };
+    for ordinal in 0..device_count {
+        let properties = unsafe {
+            let mut properties = std::mem::MaybeUninit::<sys::cudaDeviceProp>::zeroed();
+            if sys::cudaGetDeviceProperties_v2(properties.as_mut_ptr(), ordinal)
+                .result()
+                .is_err()
+            {
+                continue;
+            }
+            properties.assume_init()
+        };
+        let cuda_uuid: [u8; 16] = properties
+            .uuid
+            .bytes
+            .map(|signed_byte| signed_byte as u8);
+        if cuda_uuid == vulkan_device_uuid {
+            unsafe {
+                sys::cudaSetDevice(ordinal)
+                    .result()
+                    .map_err(|failure| format!("cudaSetDevice({ordinal}): {failure:?}"))?;
+            }
+            return Ok(ordinal);
+        }
+    }
+    Err(format!(
+        "no CUDA device matches the exporting Vulkan device (UUID {vulkan_device_uuid:02x?}); \
+         the GPU that owns this memory is not visible to CUDA"
+    ))
+}
+
+/// Import an engine-exported OPAQUE_FD into CUDA and map a device
+/// pointer over it.
+///
+/// **Consumes `opaque_fd`**: CUDA takes ownership on success, and every
+/// failure path closes it before returning.
+pub(crate) fn import_opaque_fd_into_cuda(
+    opaque_fd: RawFd,
+    byte_size: u64,
+    vulkan_device_uuid: [u8; 16],
+) -> Result<CudaImportedSurface, String> {
+    if let Some(reason) = cuda_unavailable_reason() {
+        unsafe { libc::close(opaque_fd) };
+        return Err(reason);
+    }
+
+    let device_ordinal = match bind_cuda_device_by_uuid(vulkan_device_uuid) {
+        Ok(ordinal) => ordinal,
+        Err(binding_failure) => {
+            unsafe { libc::close(opaque_fd) };
+            return Err(binding_failure);
+        }
+    };
+
+    // SAFETY: on success the CUDA driver adopts `opaque_fd` and it must
+    // not be closed here; on failure ownership stays with us.
+    let external_memory =
+        match unsafe { external_memory::import_external_memory_opaque_fd(opaque_fd, byte_size) } {
+            Ok(external_memory) => external_memory,
+            Err(import_failure) => {
+                unsafe { libc::close(opaque_fd) };
+                return Err(format!("cudaImportExternalMemory: {import_failure:?}"));
+            }
+        };
+
+    // SAFETY: the flat-pointer mapping helper; the returned pointer
+    // aliases the memory the OPAQUE_FD `VkBuffer` is bound to and stays
+    // valid until `cudaDestroyExternalMemory`.
+    let device_pointer = match unsafe {
+        external_memory::get_mapped_buffer(external_memory, 0, byte_size)
+    } {
+        Ok(pointer) => pointer as u64,
+        Err(mapping_failure) => {
+            let _ = unsafe { external_memory::destroy_external_memory(external_memory) };
+            return Err(format!(
+                "cudaExternalMemoryGetMappedBuffer: {mapping_failure:?}"
+            ));
+        }
+    };
+
+    let dlpack_device_type =
+        match classify_device_pointer(device_pointer) {
+            Ok(device_type) => device_type,
+            Err(classification_failure) => {
+                let _ = unsafe { external_memory::destroy_external_memory(external_memory) };
+                return Err(classification_failure);
+            }
+        };
+
+    Ok(CudaImportedSurface {
+        external_memory,
+        device_pointer,
+        dlpack_device: Device {
+            device_type: dlpack_device_type,
+            device_id: device_ordinal,
+        },
+    })
+}
+
+/// Ask the driver what kind of memory the imported pointer actually is.
+fn classify_device_pointer(device_pointer: u64) -> Result<DeviceType, String> {
+    let attributes = unsafe {
+        let mut attributes = std::mem::MaybeUninit::<sys::cudaPointerAttributes>::uninit();
+        sys::cudaPointerGetAttributes(
+            attributes.as_mut_ptr(),
+            device_pointer as *const std::ffi::c_void,
+        )
+        .result()
+        .map_err(|failure| format!("cudaPointerGetAttributes: {failure:?}"))?;
+        attributes.assume_init()
+    };
+    match attributes.type_ {
+        sys::cudaMemoryType::cudaMemoryTypeDevice => Ok(DeviceType::Cuda),
+        sys::cudaMemoryType::cudaMemoryTypeHost => Ok(DeviceType::CudaHost),
+        unexpected => Err(format!(
+            "the imported pointer is {unexpected:?} — neither device nor pinned-host memory, so \
+             no DLPack device type describes it. This is a driver-level surprise, not a usage \
+             error; do not paper over it by assuming kDLCUDA."
+        )),
+    }
+}

--- a/sdk/streamlib-python-wheel/src/python_cuda_pixel_exchange.rs
+++ b/sdk/streamlib-python-wheel/src/python_cuda_pixel_exchange.rs
@@ -113,10 +113,7 @@ fn bind_cuda_device_by_uuid(vulkan_device_uuid: [u8; 16]) -> Result<i32, String>
             }
             properties.assume_init()
         };
-        let cuda_uuid: [u8; 16] = properties
-            .uuid
-            .bytes
-            .map(|signed_byte| signed_byte as u8);
+        let cuda_uuid: [u8; 16] = properties.uuid.bytes.map(|signed_byte| signed_byte as u8);
         if cuda_uuid == vulkan_device_uuid {
             unsafe {
                 sys::cudaSetDevice(ordinal)
@@ -169,26 +166,24 @@ pub(crate) fn import_opaque_fd_into_cuda(
     // SAFETY: the flat-pointer mapping helper; the returned pointer
     // aliases the memory the OPAQUE_FD `VkBuffer` is bound to and stays
     // valid until `cudaDestroyExternalMemory`.
-    let device_pointer = match unsafe {
-        external_memory::get_mapped_buffer(external_memory, 0, byte_size)
-    } {
-        Ok(pointer) => pointer as u64,
-        Err(mapping_failure) => {
-            let _ = unsafe { external_memory::destroy_external_memory(external_memory) };
-            return Err(format!(
-                "cudaExternalMemoryGetMappedBuffer: {mapping_failure:?}"
-            ));
-        }
-    };
-
-    let dlpack_device_type =
-        match classify_device_pointer(device_pointer) {
-            Ok(device_type) => device_type,
-            Err(classification_failure) => {
+    let device_pointer =
+        match unsafe { external_memory::get_mapped_buffer(external_memory, 0, byte_size) } {
+            Ok(pointer) => pointer as u64,
+            Err(mapping_failure) => {
                 let _ = unsafe { external_memory::destroy_external_memory(external_memory) };
-                return Err(classification_failure);
+                return Err(format!(
+                    "cudaExternalMemoryGetMappedBuffer: {mapping_failure:?}"
+                ));
             }
         };
+
+    let dlpack_device_type = match classify_device_pointer(device_pointer) {
+        Ok(device_type) => device_type,
+        Err(classification_failure) => {
+            let _ = unsafe { external_memory::destroy_external_memory(external_memory) };
+            return Err(classification_failure);
+        }
+    };
 
     Ok(CudaImportedSurface {
         external_memory,

--- a/sdk/streamlib-python-wheel/src/python_cuda_pixel_exchange.rs
+++ b/sdk/streamlib-python-wheel/src/python_cuda_pixel_exchange.rs
@@ -76,7 +76,8 @@ impl Drop for CudaImportedSurface {
         // came from a successful `cudaImportExternalMemory`, is destroyed
         // exactly once, and by this line has no mapped buffers left.
         unsafe {
-            if let Err(free_failure) = cuda_result::memory_free(self.device_pointer as *mut c_void) {
+            if let Err(free_failure) = cuda_result::memory_free(self.device_pointer as *mut c_void)
+            {
                 tracing::debug!(?free_failure, "cudaFree of the mapped buffer failed");
             }
             if let Err(destroy_failure) =
@@ -216,6 +217,8 @@ pub(crate) fn import_opaque_fd_into_cuda(
 
 /// Ask the driver what kind of memory the imported pointer actually is.
 fn classify_device_pointer(device_pointer: u64) -> Result<DeviceType, String> {
+    // SAFETY: sound only because the driver fully writes the struct when
+    // the call succeeds — `assume_init` runs strictly after `.result()?`.
     let attributes = unsafe {
         let mut attributes = std::mem::MaybeUninit::<sys::cudaPointerAttributes>::uninit();
         sys::cudaPointerGetAttributes(

--- a/sdk/streamlib-python-wheel/src/python_cuda_pixel_exchange.rs
+++ b/sdk/streamlib-python-wheel/src/python_cuda_pixel_exchange.rs
@@ -30,8 +30,10 @@
 //! copies against host memory. `cudaPointerGetAttributes` is what tells
 //! the two apart, so the capsule reports what the driver actually did.
 
-use std::os::unix::io::RawFd;
+use std::ffi::c_void;
+use std::os::fd::{AsRawFd as _, IntoRawFd as _, OwnedFd};
 
+use cudarc::runtime::result as cuda_result;
 use cudarc::runtime::result::external_memory;
 use cudarc::runtime::sys;
 use streamlib_adapter_cuda::dlpack::{Device, DeviceType};
@@ -64,12 +66,24 @@ impl CudaImportedSurface {
 
 impl Drop for CudaImportedSurface {
     fn drop(&mut self) {
-        // SAFETY: `external_memory` came from a successful
-        // `cudaImportExternalMemory` and is destroyed exactly once.
-        if let Err(destroy_failure) =
-            unsafe { external_memory::destroy_external_memory(self.external_memory) }
-        {
-            tracing::debug!(?destroy_failure, "cudaDestroyExternalMemory failed");
+        // Order matters and is not interchangeable: CUDA requires every
+        // buffer mapped onto an external-memory object to be freed
+        // *before* the object is destroyed. Freeing after — or not at
+        // all — leaks the mapping and violates the destroy precondition.
+        //
+        // SAFETY: `device_pointer` came from `get_mapped_buffer` on
+        // `external_memory` and is freed exactly once; `external_memory`
+        // came from a successful `cudaImportExternalMemory`, is destroyed
+        // exactly once, and by this line has no mapped buffers left.
+        unsafe {
+            if let Err(free_failure) = cuda_result::memory_free(self.device_pointer as *mut c_void) {
+                tracing::debug!(?free_failure, "cudaFree of the mapped buffer failed");
+            }
+            if let Err(destroy_failure) =
+                external_memory::destroy_external_memory(self.external_memory)
+            {
+                tracing::debug!(?destroy_failure, "cudaDestroyExternalMemory failed");
+            }
         }
     }
 }
@@ -132,33 +146,33 @@ fn bind_cuda_device_by_uuid(vulkan_device_uuid: [u8; 16]) -> Result<i32, String>
 /// Import an engine-exported OPAQUE_FD into CUDA and map a device
 /// pointer over it.
 ///
-/// **Consumes `opaque_fd`**: CUDA takes ownership on success, and every
-/// failure path closes it before returning.
+/// Takes `opaque_fd` by value: every early return drops it closed, and
+/// only the successful `cudaImportExternalMemory` — which adopts the fd —
+/// releases it with `into_raw_fd`. Hand-closing on each failure path
+/// would put the fd's lifetime back in the reader's head, and a later
+/// early return would silently leak it.
 pub(crate) fn import_opaque_fd_into_cuda(
-    opaque_fd: RawFd,
+    opaque_fd: OwnedFd,
     byte_size: u64,
     vulkan_device_uuid: [u8; 16],
 ) -> Result<CudaImportedSurface, String> {
     if let Some(reason) = cuda_unavailable_reason() {
-        unsafe { libc::close(opaque_fd) };
         return Err(reason);
     }
+    let device_ordinal = bind_cuda_device_by_uuid(vulkan_device_uuid)?;
 
-    let device_ordinal = match bind_cuda_device_by_uuid(vulkan_device_uuid) {
-        Ok(ordinal) => ordinal,
-        Err(binding_failure) => {
-            unsafe { libc::close(opaque_fd) };
-            return Err(binding_failure);
-        }
-    };
-
-    // SAFETY: on success the CUDA driver adopts `opaque_fd` and it must
-    // not be closed here; on failure ownership stays with us.
+    // SAFETY: the CUDA driver adopts the fd on success, so ownership is
+    // released with `into_raw_fd` only for the call that may take it. On
+    // failure the raw fd is re-adopted below so it is still closed once.
+    let raw_fd = opaque_fd.as_raw_fd();
     let external_memory =
-        match unsafe { external_memory::import_external_memory_opaque_fd(opaque_fd, byte_size) } {
-            Ok(external_memory) => external_memory,
+        match unsafe { external_memory::import_external_memory_opaque_fd(raw_fd, byte_size) } {
+            Ok(external_memory) => {
+                let _adopted_by_cuda = opaque_fd.into_raw_fd();
+                external_memory
+            }
             Err(import_failure) => {
-                unsafe { libc::close(opaque_fd) };
+                // `opaque_fd` still owns it; dropping here closes it.
                 return Err(format!("cudaImportExternalMemory: {import_failure:?}"));
             }
         };
@@ -180,7 +194,12 @@ pub(crate) fn import_opaque_fd_into_cuda(
     let dlpack_device_type = match classify_device_pointer(device_pointer) {
         Ok(device_type) => device_type,
         Err(classification_failure) => {
-            let _ = unsafe { external_memory::destroy_external_memory(external_memory) };
+            // The mapping exists by this point, so it has to go before the
+            // object it was mapped onto — same order as `Drop`.
+            unsafe {
+                let _ = cuda_result::memory_free(device_pointer as *mut c_void);
+                let _ = external_memory::destroy_external_memory(external_memory);
+            }
             return Err(classification_failure);
         }
     };

--- a/sdk/streamlib-python-wheel/src/python_gpu_surface_pixel_exchange.rs
+++ b/sdk/streamlib-python-wheel/src/python_gpu_surface_pixel_exchange.rs
@@ -86,6 +86,10 @@ pub(crate) struct GpuSurfaceOwnedMemory {
     /// the one view the engine documents as stash-safe. `None` on a
     /// handle minted without one; device export refuses there.
     gpu_limited_access: Option<GpuContextLimitedAccess>,
+    /// A texture registration this memory minted at acquire and must
+    /// undo on release, so the texture cache doesn't pin pool textures
+    /// past their handles.
+    texture_registration_to_unregister: Option<String>,
 }
 
 impl GpuSurfaceOwnedMemory {
@@ -100,6 +104,24 @@ impl GpuSurfaceOwnedMemory {
             surface_store_owing_a_release,
             minted_surface_id,
             gpu_limited_access,
+            texture_registration_to_unregister: None,
+        })
+    }
+
+    /// A pooled texture registered at acquire: the registration is this
+    /// memory's debt, undone when the last holder (handle or tensor)
+    /// releases.
+    pub(crate) fn new_with_texture_registration_debt(
+        owned_value: GpuSurfaceOwnedValue,
+        registered_surface_id: Option<String>,
+        gpu_limited_access: Option<GpuContextLimitedAccess>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            owned_value,
+            surface_store_owing_a_release: None,
+            minted_surface_id: registered_surface_id.clone(),
+            gpu_limited_access,
+            texture_registration_to_unregister: registered_surface_id,
         })
     }
 
@@ -130,18 +152,17 @@ impl GpuSurfaceOwnedMemory {
             )),
         }
     }
-
-    /// The pixel shape of this surface, host mapping or not.
-    fn pixel_shape(&self) -> Option<&PixelBuffer> {
-        match &self.owned_value {
-            GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer) => Some(pixel_buffer),
-            GpuSurfaceOwnedValue::PooledTexture(_) => None,
-        }
-    }
 }
 
 impl Drop for GpuSurfaceOwnedMemory {
     fn drop(&mut self) {
+        if let (Some(engine_view), Some(registered_id)) = (
+            self.gpu_limited_access.as_ref(),
+            self.texture_registration_to_unregister.as_ref(),
+        ) {
+            // Also evicts the device-export staging engine-side.
+            engine_view.unregister_texture(registered_id);
+        }
         if let (Some(store), Some(surface_id)) = (
             self.surface_store_owing_a_release.as_ref(),
             self.minted_surface_id.as_ref(),
@@ -169,36 +190,39 @@ pub(crate) struct PixelExchangeTensorLayout {
     pub(crate) dtype: DataType,
 }
 
-/// Bytes per pixel and the trailing channel axis for a single-plane
-/// format. `None` for formats DLPack cannot express as one buffer.
+/// The DLPack element dtype and trailing channel axis for a single-plane
+/// format — the two facts the engine's canonical `bits_per_pixel` /
+/// `plane_count` tables do not carry. `None` for formats DLPack cannot
+/// express as one buffer (multi-plane; exporting plane 0 alone would
+/// hand out luma while silently dropping chroma).
 fn single_plane_shape(format: PixelFormat) -> Option<(u32, DataType, Option<i64>)> {
-    match format {
-        PixelFormat::Bgra32 | PixelFormat::Rgba32 | PixelFormat::Argb32 => {
-            Some((4, DataType::U8, Some(4)))
-        }
+    if format.plane_count() > 1 || format == PixelFormat::Unknown {
+        return None;
+    }
+    let bytes_per_pixel = format.bits_per_pixel() / 8;
+    let (dtype, channel_axis) = match format {
+        PixelFormat::Bgra32 | PixelFormat::Rgba32 | PixelFormat::Argb32 => (DataType::U8, Some(4)),
         // 16 bits per channel: the element is a u16, so the channel axis
         // is still 4 wide but each element spans two bytes.
-        PixelFormat::Rgba64 => Some((
-            8,
+        PixelFormat::Rgba64 => (
             DataType {
                 code: DataTypeCode::UInt,
                 bits: 16,
                 lanes: 1,
             },
             Some(4),
-        )),
-        PixelFormat::Gray8 => Some((1, DataType::U8, None)),
+        ),
+        PixelFormat::Gray8 => (DataType::U8, None),
         // Packed 4:2:2 — two bytes per pixel, but the byte pair is not a
         // per-pixel channel tuple. Exported as raw bytes with the trailing
-        // axis naming the pair, which is what a shader or a converter
-        // wants; interpreting it as colour is the consumer's job.
-        PixelFormat::Yuyv422 | PixelFormat::Uyvy422 => Some((2, DataType::U8, Some(2))),
-        // Multi-plane. DLPack expresses one strided linear buffer, so
-        // exporting plane 0 alone would hand out luma while silently
-        // dropping chroma.
-        PixelFormat::Nv12VideoRange | PixelFormat::Nv12FullRange => None,
-        PixelFormat::Unknown => None,
-    }
+        // axis naming the pair; interpreting it as colour is the
+        // consumer's job.
+        PixelFormat::Yuyv422 | PixelFormat::Uyvy422 => (DataType::U8, Some(2)),
+        PixelFormat::Nv12VideoRange | PixelFormat::Nv12FullRange | PixelFormat::Unknown => {
+            return None;
+        }
+    };
+    Some((bytes_per_pixel, dtype, channel_axis))
 }
 
 impl PixelExchangeTensorLayout {
@@ -345,6 +369,10 @@ pub(crate) const HOST_VISIBLE_DLPACK_DEVICE: Device = Device {
 /// Run the versioned managed tensor's deleter when a capsule is
 /// collected without a consumer having taken it. Same rename contract as
 /// the unversioned destructor, against `dltensor_versioned`.
+// SAFETY: same protocol as `dlpack_capsule_destructor` — the pointer is
+// dereferenced only after `PyCapsule_IsValid` proves the capsule still
+// carries the pre-consumption name, so a consumer-adopted (renamed)
+// tensor is never double-freed.
 unsafe extern "C" fn dlpack_versioned_capsule_destructor(capsule: *mut pyo3::ffi::PyObject) {
     unsafe {
         if pyo3::ffi::PyCapsule_IsValid(capsule, DLPACK_VERSIONED_CAPSULE_NAME.as_ptr()) == 0 {
@@ -443,165 +471,29 @@ pub(crate) fn host_visible_dlpack_capsule<'py>(
         pixel_buffer.height,
         bytes_per_row,
     )?;
-    let owner = Box::new(Arc::clone(owned_memory));
-
-    match exchange_shape {
-        DlpackExchangeShape::Versioned => {
-            let flags = if read_only {
-                Flags::READ_ONLY
-            } else {
-                Flags::empty()
-            };
-            dlpack_versioned_capsule_from_managed_tensor(
-                python,
-                dlpack::build_managed_tensor_versioned(
-                    base_address as u64,
-                    layout.shape,
-                    Some(layout.strides),
-                    layout.dtype,
-                    HOST_VISIBLE_DLPACK_DEVICE,
-                    flags,
-                    owner,
-                ),
-            )
-        }
-        DlpackExchangeShape::Unversioned => dlpack_capsule_from_managed_tensor(
-            python,
-            dlpack::build_managed_tensor(
-                base_address as u64,
-                layout.shape,
-                Some(layout.strides),
-                layout.dtype,
-                HOST_VISIBLE_DLPACK_DEVICE,
-                owner,
-            ),
-        ),
-    }
+    dlpack_capsule_over(
+        python,
+        base_address as u64,
+        layout,
+        HOST_VISIBLE_DLPACK_DEVICE,
+        exchange_shape,
+        read_only,
+        Box::new(Arc::clone(owned_memory)),
+    )
 }
 
-// =============================================================================
-// Device export — the same memory, in CUDA's dialect
-// =============================================================================
-
-/// One surface's device-export state: the engine staging plus CUDA's
-/// import of it, cached per `surface_id` so a fresh handle for the same
-/// frame reuses both instead of re-allocating exportable memory (the
-/// churn NVIDIA's kernel accounting punishes) and re-importing.
-///
-/// Process-wide because the plan fixes exactly one engine per process;
-/// the ids in it are the producer's stable ring/pool ids, so the map
-/// stays a handful of entries for the life of the graph.
-#[cfg(target_os = "linux")]
-pub(crate) struct SurfaceDeviceExport {
-    pub(crate) staging: Arc<SurfaceDeviceExportStaging>,
-    pub(crate) cuda_import: Arc<CudaImportedSurface>,
-}
-
-#[cfg(target_os = "linux")]
-impl Clone for SurfaceDeviceExport {
-    fn clone(&self) -> Self {
-        Self {
-            staging: Arc::clone(&self.staging),
-            cuda_import: Arc::clone(&self.cuda_import),
-        }
-    }
-}
-
-#[cfg(target_os = "linux")]
-static SURFACE_DEVICE_EXPORTS: LazyLock<Mutex<HashMap<String, SurfaceDeviceExport>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-
-/// This surface's device export, created on first ask: engine staging,
-/// one OPAQUE_FD export, one CUDA import.
-#[cfg(target_os = "linux")]
-pub(crate) fn surface_device_export_for(
-    owned_memory: &Arc<GpuSurfaceOwnedMemory>,
-) -> PyResult<SurfaceDeviceExport> {
-    let surface_id = owned_memory.minted_surface_id.as_deref().ok_or_else(|| {
-        PyRuntimeError::new_err(
-            "this surface carries no id, so there is nothing to key a device export on; device \
-             tensors come from graph frames (resolve_surface) or published pixel buffers",
-        )
-    })?;
-    let engine_view = owned_memory.gpu_limited_access.as_ref().ok_or_else(|| {
-        PyRuntimeError::new_err(
-            "this handle was minted without the engine capability the device export refills \
-             through; acquire or resolve it via ctx.gpu_limited_access",
-        )
-    })?;
-    let mut cache = SURFACE_DEVICE_EXPORTS.lock();
-    if let Some(existing) = cache.get(surface_id) {
-        return Ok(existing.clone());
-    }
-    let staging = engine_view
-        .create_surface_device_export_staging(surface_id, None)
-        .map_err(|failure| PyRuntimeError::new_err(failure.to_string()))?;
-    let (raw_fd, byte_size, vulkan_device_uuid) = engine_view
-        .export_device_staging_opaque_fd(&staging)
-        .map_err(|failure| PyRuntimeError::new_err(failure.to_string()))?;
-    // SAFETY: the export hands over a fresh dup'd fd nothing else holds.
-    let opaque_fd = unsafe { std::os::fd::OwnedFd::from_raw_fd(raw_fd) };
-    let cuda_import = import_opaque_fd_into_cuda(opaque_fd, byte_size, vulkan_device_uuid)
-        .map(Arc::new)
-        .map_err(PyRuntimeError::new_err)?;
-    let export = SurfaceDeviceExport {
-        staging,
-        cuda_import,
-    };
-    cache.insert(surface_id.to_string(), export.clone());
-    Ok(export)
-}
-
-/// Build a DLPack capsule over this surface's CUDA device pointer,
-/// refilling the staging from the surface's current pixels first.
-///
-/// The capsule owner holds the surface, the staging, and the CUDA import
-/// — a tensor outliving its handle keeps all three alive.
-#[cfg(target_os = "linux")]
-pub(crate) fn device_dlpack_capsule<'py>(
+/// Wrap `address` in the negotiated DLPack exchange shape — the one
+/// place the shape selection and the read-only flag derivation live, so
+/// the host and device exports cannot drift.
+fn dlpack_capsule_over<'py>(
     python: Python<'py>,
-    owned_memory: &Arc<GpuSurfaceOwnedMemory>,
+    address: u64,
+    layout: PixelExchangeTensorLayout,
+    device: Device,
     exchange_shape: DlpackExchangeShape,
-    read_only_lock: bool,
+    read_only: bool,
+    owner: dlpack::CapsuleOwner,
 ) -> PyResult<Bound<'py, PyAny>> {
-    let export = surface_device_export_for(owned_memory)?;
-    let engine_view = owned_memory
-        .gpu_limited_access
-        .as_ref()
-        .expect("surface_device_export_for verified the view");
-    engine_view
-        .refill_device_export_staging(&export.staging)
-        .map_err(|failure| PyRuntimeError::new_err(failure.to_string()))?;
-
-    let pixel_shape = owned_memory.pixel_shape().ok_or_else(|| {
-        PyRuntimeError::new_err("this surface has no pixel shape to derive a tensor layout from")
-    })?;
-    let height = u64::from(pixel_shape.height);
-    if height == 0 || !export.staging.staging_byte_size().is_multiple_of(height) {
-        return Err(PyRuntimeError::new_err(format!(
-            "staging size {} is not a whole number of {} rows",
-            export.staging.staging_byte_size(),
-            height
-        )));
-    }
-    let layout = PixelExchangeTensorLayout::for_pixel_format(
-        pixel_shape.format(),
-        pixel_shape.width,
-        pixel_shape.height,
-        export.staging.staging_byte_size() / height,
-    )?;
-
-    // A texture-backed staging has no write-back path, so its tensors are
-    // read-only no matter what the lock says.
-    let read_only = read_only_lock || !export.staging.writable();
-    let device_pointer = export.cuda_import.device_pointer();
-    let device = export.cuda_import.dlpack_device();
-    let owner: Box<dyn std::any::Any + Send> = Box::new((
-        Arc::clone(owned_memory),
-        Arc::clone(&export.staging),
-        Arc::clone(&export.cuda_import),
-    ));
-
     match exchange_shape {
         DlpackExchangeShape::Versioned => {
             let flags = if read_only {
@@ -612,7 +504,7 @@ pub(crate) fn device_dlpack_capsule<'py>(
             dlpack_versioned_capsule_from_managed_tensor(
                 python,
                 dlpack::build_managed_tensor_versioned(
-                    device_pointer,
+                    address,
                     layout.shape,
                     Some(layout.strides),
                     layout.dtype,
@@ -625,7 +517,7 @@ pub(crate) fn device_dlpack_capsule<'py>(
         DlpackExchangeShape::Unversioned => dlpack_capsule_from_managed_tensor(
             python,
             dlpack::build_managed_tensor(
-                device_pointer,
+                address,
                 layout.shape,
                 Some(layout.strides),
                 layout.dtype,
@@ -636,35 +528,185 @@ pub(crate) fn device_dlpack_capsule<'py>(
     }
 }
 
-/// Whether a device tensor taken now would accept writes, without
-/// creating the export.
+// =============================================================================
+// Device export — the same memory, in CUDA's dialect
+// =============================================================================
+
+/// One surface's device-export state: the engine staging plus CUDA's
+/// import of it.
 #[cfg(target_os = "linux")]
-pub(crate) fn device_export_writable(owned_memory: &Arc<GpuSurfaceOwnedMemory>) -> bool {
-    owned_memory
-        .minted_surface_id
-        .as_deref()
-        .and_then(|surface_id| {
-            SURFACE_DEVICE_EXPORTS
-                .lock()
-                .get(surface_id)
-                .map(|export| export.staging.writable())
-        })
-        .unwrap_or(false)
+#[derive(Clone)]
+pub(crate) struct SurfaceDeviceExport {
+    pub(crate) staging: Arc<SurfaceDeviceExportStaging>,
+    pub(crate) cuda_import: Arc<CudaImportedSurface>,
+}
+
+/// CUDA imports memoised per surface id, each validated against the
+/// engine staging it was made for.
+///
+/// The engine owns the staging lifecycle (`GpuContext` caches it and
+/// drops it with the context); CUDA is the wheel's runtime, so its
+/// import lives here — a memo, not a lifecycle record. `Weak` is the
+/// validity check: when the engine hands back a different staging (the
+/// old one was evicted, or a new context reused the id), the pointer
+/// mismatch forces a fresh import and the dead entry is replaced, so the
+/// map is bounded by live stagings rather than by process history.
+#[cfg(target_os = "linux")]
+static CUDA_IMPORTS_BY_SURFACE: LazyLock<
+    Mutex<
+        HashMap<
+            String,
+            (
+                std::sync::Weak<SurfaceDeviceExportStaging>,
+                Arc<CudaImportedSurface>,
+            ),
+        >,
+    >,
+> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// The engine capability this owned memory refills through, or the
+/// refusal naming how to get one.
+fn engine_view_for(
+    owned_memory: &Arc<GpuSurfaceOwnedMemory>,
+) -> PyResult<&GpuContextLimitedAccess> {
+    owned_memory.gpu_limited_access.as_ref().ok_or_else(|| {
+        PyRuntimeError::new_err(
+            "this handle was minted without the engine capability the device export refills \
+             through; acquire or resolve it via ctx.gpu_limited_access",
+        )
+    })
+}
+
+/// This surface's device export: engine staging (engine-cached), CUDA
+/// import (memoised here, validated against that staging).
+#[cfg(target_os = "linux")]
+pub(crate) fn surface_device_export_for(
+    owned_memory: &Arc<GpuSurfaceOwnedMemory>,
+) -> PyResult<SurfaceDeviceExport> {
+    let surface_id = owned_memory.minted_surface_id.as_deref().ok_or_else(|| {
+        PyRuntimeError::new_err(
+            "this surface carries no id, so there is nothing to key a device export on; device \
+             tensors come from graph frames (resolve_surface) or published pixel buffers",
+        )
+    })?;
+    let engine_view = engine_view_for(owned_memory)?;
+    let staging = engine_view
+        .surface_device_export_staging(surface_id)
+        .map_err(|failure| PyRuntimeError::new_err(failure.to_string()))?;
+
+    let mut memo = CUDA_IMPORTS_BY_SURFACE.lock();
+    if let Some((staging_it_was_made_for, cuda_import)) = memo.get(surface_id)
+        && staging_it_was_made_for
+            .upgrade()
+            .is_some_and(|previous| Arc::ptr_eq(&previous, &staging))
+    {
+        return Ok(SurfaceDeviceExport {
+            staging,
+            cuda_import: Arc::clone(cuda_import),
+        });
+    }
+    let (raw_fd, byte_size, vulkan_device_uuid) = engine_view
+        .export_device_staging_opaque_fd(&staging)
+        .map_err(|failure| PyRuntimeError::new_err(failure.to_string()))?;
+    // SAFETY: the export hands over a fresh dup'd fd nothing else holds.
+    let opaque_fd = unsafe { std::os::fd::OwnedFd::from_raw_fd(raw_fd) };
+    let cuda_import = import_opaque_fd_into_cuda(opaque_fd, byte_size, vulkan_device_uuid)
+        .map(Arc::new)
+        .map_err(PyRuntimeError::new_err)?;
+    memo.insert(
+        surface_id.to_string(),
+        (Arc::downgrade(&staging), Arc::clone(&cuda_import)),
+    );
+    Ok(SurfaceDeviceExport {
+        staging,
+        cuda_import,
+    })
+}
+
+/// Everything a device capsule needs, produced with no GIL attached:
+/// the refill runs a GPU submit and a bounded wait, and the first call
+/// additionally allocates staging and imports into CUDA.
+#[cfg(target_os = "linux")]
+pub(crate) struct PreparedDeviceExport {
+    pub(crate) export: SurfaceDeviceExport,
+    pub(crate) layout: PixelExchangeTensorLayout,
+    pub(crate) writable: bool,
+}
+
+/// Refill the staging from the surface's current pixels and derive the
+/// tensor layout — the detachable half of a device export. Call inside
+/// `python.detach`.
+#[cfg(target_os = "linux")]
+pub(crate) fn prepare_device_export(
+    owned_memory: &Arc<GpuSurfaceOwnedMemory>,
+) -> PyResult<PreparedDeviceExport> {
+    let export = surface_device_export_for(owned_memory)?;
+    engine_view_for(owned_memory)?
+        .refill_device_export_staging(&export.staging)
+        .map_err(|failure| PyRuntimeError::new_err(failure.to_string()))?;
+
+    // Geometry comes from the staging alone — the object the byte span
+    // was sized for — never mixed with the handle's own pixel view.
+    let staging = &export.staging;
+    let layout = match staging.pixel_format() {
+        Some(pixel_format) => PixelExchangeTensorLayout::for_pixel_format(
+            pixel_format,
+            staging.surface_width(),
+            staging.surface_height(),
+            staging.bytes_per_row(),
+        )?,
+        // Texture-backed stagings are tightly packed 4-byte color.
+        None => PixelExchangeTensorLayout::for_pixel_format(
+            PixelFormat::Rgba32,
+            staging.surface_width(),
+            staging.surface_height(),
+            staging.bytes_per_row(),
+        )?,
+    };
+    let writable = staging.writable();
+    Ok(PreparedDeviceExport {
+        export,
+        layout,
+        writable,
+    })
+}
+
+/// Build the capsule over a prepared export — the attached half; touches
+/// no engine lock.
+#[cfg(target_os = "linux")]
+pub(crate) fn device_dlpack_capsule<'py>(
+    python: Python<'py>,
+    owned_memory: &Arc<GpuSurfaceOwnedMemory>,
+    prepared: PreparedDeviceExport,
+    exchange_shape: DlpackExchangeShape,
+    read_only_lock: bool,
+) -> PyResult<Bound<'py, PyAny>> {
+    let read_only = read_only_lock || !prepared.writable;
+    let owner: dlpack::CapsuleOwner = Box::new((
+        Arc::clone(owned_memory),
+        Arc::clone(&prepared.export.staging),
+        Arc::clone(&prepared.export.cuda_import),
+    ));
+    dlpack_capsule_over(
+        python,
+        prepared.export.cuda_import.device_pointer(),
+        prepared.layout,
+        prepared.export.cuda_import.dlpack_device(),
+        exchange_shape,
+        read_only,
+        owner,
+    )
 }
 
 /// Publish a device-side write back into the surface, so every other
-/// holder observes the edit. The unlock path calls this when a writable
-/// device tensor was taken under the write lock.
+/// holder observes the edit. Runs at unlock/close when a writable device
+/// tensor was taken under the write lock.
 #[cfg(target_os = "linux")]
 pub(crate) fn publish_device_write_back_to_surface(
     owned_memory: &Arc<GpuSurfaceOwnedMemory>,
 ) -> PyResult<()> {
     let export = surface_device_export_for(owned_memory)?;
-    let engine_view = owned_memory
-        .gpu_limited_access
-        .as_ref()
-        .expect("surface_device_export_for verified the view");
-    engine_view
+    engine_view_for(owned_memory)?
         .copy_device_export_staging_back_to_surface(&export.staging)
         .map_err(|failure| PyRuntimeError::new_err(failure.to_string()))?;
     Ok(())
@@ -682,8 +724,15 @@ pub(crate) fn imported_device_for(owned_memory: &Arc<GpuSurfaceOwnedMemory>) -> 
 
 /// Whether this surface can even attempt a device export: it has an id
 /// to key on and the engine capability to refill through.
+#[cfg(target_os = "linux")]
 pub(crate) fn device_export_available(owned_memory: &Arc<GpuSurfaceOwnedMemory>) -> bool {
     owned_memory.minted_surface_id.is_some() && owned_memory.gpu_limited_access.is_some()
+}
+
+/// Off Linux there is no device export; every surface serves its host side.
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn device_export_available(_owned_memory: &Arc<GpuSurfaceOwnedMemory>) -> bool {
+    false
 }
 
 // =============================================================================

--- a/sdk/streamlib-python-wheel/src/python_gpu_surface_pixel_exchange.rs
+++ b/sdk/streamlib-python-wheel/src/python_gpu_surface_pixel_exchange.rs
@@ -35,8 +35,7 @@ use streamlib::sdk::rhi::{PixelBuffer, PixelFormat};
 #[cfg(target_os = "linux")]
 use crate::python_cuda_pixel_exchange::{CudaImportedSurface, import_opaque_fd_into_cuda};
 use streamlib_adapter_cuda::dlpack::{
-    self, DataType, DataTypeCode, Device, DeviceType, Flags, ManagedTensor,
-    ManagedTensorVersioned,
+    self, DataType, DataTypeCode, Device, DeviceType, Flags, ManagedTensor, ManagedTensorVersioned,
 };
 
 /// Capsule names before a consumer takes ownership. The DLPack protocol
@@ -109,7 +108,10 @@ pub(crate) enum GpuSurfaceOwnedValue {
     PixelBuffer(PixelBuffer),
     /// Held to keep the pool slot alive; the device-local export path reads
     /// it once the texture half of the exchange surface lands.
-    #[expect(dead_code, reason = "lifetime-only until the texture export path reads it")]
+    #[expect(
+        dead_code,
+        reason = "lifetime-only until the texture export path reads it"
+    )]
     PooledTexture(PooledTextureHandle),
     DeviceExchange(DeviceExchangeBuffer),
 }
@@ -149,6 +151,26 @@ impl GpuSurfaceOwnedMemory {
             #[cfg(target_os = "linux")]
             cuda_import: Mutex::new(None),
         })
+    }
+
+    /// The pixel buffer a DMA-BUF export can be taken from, or a refusal
+    /// naming why this surface cannot answer.
+    ///
+    /// An allocation carries one external-handle flavour: pool buffers are
+    /// DMA-BUF, exchange buffers are OPAQUE_FD, and neither exports the
+    /// other's handle type under VMA's per-pool memory configuration.
+    pub(crate) fn dma_buf_exportable_pixel_buffer(&self) -> PyResult<&PixelBuffer> {
+        match &self.owned_value {
+            GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer) => Ok(pixel_buffer),
+            GpuSurfaceOwnedValue::DeviceExchange(_) => Err(PyValueError::new_err(
+                "a device-exchange buffer is OPAQUE_FD-flavoured and has no DMA-BUF export; \
+                 hand it to CUDA with `__dlpack__`, or acquire an ordinary pixel buffer for a \
+                 DMA-BUF consumer",
+            )),
+            GpuSurfaceOwnedValue::PooledTexture(_) => Err(PyNotImplementedError::new_err(
+                "exporting a pooled texture's DMA-BUF goes through the texture export path",
+            )),
+        }
     }
 
     /// The host-mapped pixel view, or a refusal naming why this surface
@@ -271,7 +293,7 @@ impl PixelExchangeTensorLayout {
         };
 
         let element_bytes = u64::from(dtype.bits / 8);
-        if element_bytes == 0 || bytes_per_row % element_bytes != 0 {
+        if element_bytes == 0 || !bytes_per_row.is_multiple_of(element_bytes) {
             return Err(PyValueError::new_err(format!(
                 "row pitch {bytes_per_row} is not a whole number of {element_bytes}-byte elements"
             )));
@@ -312,7 +334,7 @@ pub(crate) fn pixel_buffer_bytes_per_row(pixel_buffer: &PixelBuffer) -> PyResult
             "surface reports a zero-byte plane; it is not CPU-mappable",
         ));
     }
-    if plane_size % height != 0 {
+    if !plane_size.is_multiple_of(height) {
         return Err(PyRuntimeError::new_err(format!(
             "plane size {plane_size} is not a whole number of {height} rows"
         )));
@@ -337,9 +359,8 @@ unsafe extern "C" fn dlpack_capsule_destructor(capsule: *mut pyo3::ffi::PyObject
             // does not set an exception, so there is nothing to clear.
             return;
         }
-        let managed_tensor =
-            pyo3::ffi::PyCapsule_GetPointer(capsule, DLPACK_CAPSULE_NAME.as_ptr())
-                as *mut ManagedTensor;
+        let managed_tensor = pyo3::ffi::PyCapsule_GetPointer(capsule, DLPACK_CAPSULE_NAME.as_ptr())
+            as *mut ManagedTensor;
         if managed_tensor.is_null() {
             // Defensive: `IsValid` already proved the name matches, so a
             // null pointer here would be a capsule built by someone else.
@@ -645,9 +666,7 @@ pub(crate) fn device_dlpack_capsule<'py>(
 /// produced device or pinned-host memory — and a wrong guess here
 /// contradicts the capsule the very next call hands back.
 #[cfg(target_os = "linux")]
-pub(crate) fn imported_device_for(
-    owned_memory: &Arc<GpuSurfaceOwnedMemory>,
-) -> PyResult<Device> {
+pub(crate) fn imported_device_for(owned_memory: &Arc<GpuSurfaceOwnedMemory>) -> PyResult<Device> {
     Ok(cuda_import_for(owned_memory)?.dlpack_device())
 }
 
@@ -762,9 +781,8 @@ mod tests {
 
     #[test]
     fn gray8_has_no_channel_axis() {
-        let layout =
-            PixelExchangeTensorLayout::for_pixel_format(PixelFormat::Gray8, 320, 200, 320)
-                .expect("gray8 has a single-buffer shape");
+        let layout = PixelExchangeTensorLayout::for_pixel_format(PixelFormat::Gray8, 320, 200, 320)
+            .expect("gray8 has a single-buffer shape");
         assert_eq!(layout.shape, vec![200, 320]);
         assert_eq!(layout.strides, vec![320, 1]);
     }
@@ -838,12 +856,14 @@ mod tests {
         Python::initialize();
         let drops = Arc::new(AtomicUsize::new(0));
         Python::attach(|python| {
-            let capsule = dlpack_capsule_from_managed_tensor(
-                python,
-                counted_managed_tensor(&drops),
-            )
-            .expect("capsule");
-            assert_eq!(drops.load(Ordering::SeqCst), 0, "still owned by the capsule");
+            let capsule =
+                dlpack_capsule_from_managed_tensor(python, counted_managed_tensor(&drops))
+                    .expect("capsule");
+            assert_eq!(
+                drops.load(Ordering::SeqCst),
+                0,
+                "still owned by the capsule"
+            );
             drop(capsule);
         });
         assert_eq!(
@@ -861,17 +881,14 @@ mod tests {
         Python::initialize();
         let drops = Arc::new(AtomicUsize::new(0));
         let adopted = Python::attach(|python| {
-            let capsule = dlpack_capsule_from_managed_tensor(
-                python,
-                counted_managed_tensor(&drops),
-            )
-            .expect("capsule");
+            let capsule =
+                dlpack_capsule_from_managed_tensor(python, counted_managed_tensor(&drops))
+                    .expect("capsule");
             // What every `from_dlpack` implementation does on adoption.
             let adopted = unsafe {
-                let raw = pyo3::ffi::PyCapsule_GetPointer(
-                    capsule.as_ptr(),
-                    DLPACK_CAPSULE_NAME.as_ptr(),
-                ) as *mut ManagedTensor;
+                let raw =
+                    pyo3::ffi::PyCapsule_GetPointer(capsule.as_ptr(), DLPACK_CAPSULE_NAME.as_ptr())
+                        as *mut ManagedTensor;
                 assert_eq!(
                     pyo3::ffi::PyCapsule_SetName(
                         capsule.as_ptr(),

--- a/sdk/streamlib-python-wheel/src/python_gpu_surface_pixel_exchange.rs
+++ b/sdk/streamlib-python-wheel/src/python_gpu_surface_pixel_exchange.rs
@@ -595,6 +595,10 @@ pub(crate) fn surface_device_export_for(
         .map_err(|failure| PyRuntimeError::new_err(failure.to_string()))?;
 
     let mut memo = CUDA_IMPORTS_BY_SURFACE.lock();
+    // Entries whose staging died (context torn down, surface
+    // unregistered) are unreachable by the ptr-eq check below; sweep
+    // them so the memo is bounded by live stagings, not process history.
+    memo.retain(|_, (staging_it_was_made_for, _)| staging_it_was_made_for.strong_count() > 0);
     if let Some((staging_it_was_made_for, cuda_import)) = memo.get(surface_id)
         && staging_it_was_made_for
             .upgrade()
@@ -648,21 +652,17 @@ pub(crate) fn prepare_device_export(
     // Geometry comes from the staging alone — the object the byte span
     // was sized for — never mixed with the handle's own pixel view.
     let staging = &export.staging;
-    let layout = match staging.pixel_format() {
-        Some(pixel_format) => PixelExchangeTensorLayout::for_pixel_format(
-            pixel_format,
-            staging.surface_width(),
-            staging.surface_height(),
-            staging.bytes_per_row(),
-        )?,
-        // Texture-backed stagings are tightly packed 4-byte color.
-        None => PixelExchangeTensorLayout::for_pixel_format(
-            PixelFormat::Rgba32,
-            staging.surface_width(),
-            staging.surface_height(),
-            staging.bytes_per_row(),
-        )?,
-    };
+    // The engine records the pixel shape for both source kinds (a
+    // texture source maps to its 4-byte color shape — BGRA stays BGRA).
+    let pixel_format = staging.pixel_format().ok_or_else(|| {
+        PyRuntimeError::new_err("this staging carries no pixel shape; nothing to lay out")
+    })?;
+    let layout = PixelExchangeTensorLayout::for_pixel_format(
+        pixel_format,
+        staging.surface_width(),
+        staging.surface_height(),
+        staging.bytes_per_row(),
+    )?;
     let writable = staging.writable();
     Ok(PreparedDeviceExport {
         export,

--- a/sdk/streamlib-python-wheel/src/python_gpu_surface_pixel_exchange.rs
+++ b/sdk/streamlib-python-wheel/src/python_gpu_surface_pixel_exchange.rs
@@ -22,8 +22,7 @@
 //! rather than silently exported as its first plane.
 
 use std::ffi::{CStr, c_void};
-#[cfg(target_os = "linux")]
-use std::os::unix::io::RawFd;
+use std::os::fd::OwnedFd;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
@@ -65,9 +64,9 @@ pub(crate) struct DeviceExchangeBuffer {
     pub(crate) device_local: bool,
     /// The OPAQUE_FD, exported at acquire time because exporting needs
     /// the privileged capability and `__dlpack__` does not have one.
-    /// Consumed by the first CUDA import — which adopts the fd — and
-    /// closed by `Drop` if no export ever happens.
-    exported_opaque_fd: Mutex<Option<RawFd>>,
+    /// Taken by the first CUDA import; an `OwnedFd` so an export that
+    /// never happens still closes it, with no destructor to write.
+    exported_opaque_fd: Mutex<Option<OwnedFd>>,
     byte_size: u64,
     /// The exporting device's `VkPhysicalDeviceIDProperties::deviceUUID`,
     /// which is how the CUDA import finds the GPU that owns the memory.
@@ -79,7 +78,7 @@ impl DeviceExchangeBuffer {
     pub(crate) fn new(
         pixel_buffer: PixelBuffer,
         device_local: bool,
-        exported_opaque_fd: RawFd,
+        exported_opaque_fd: OwnedFd,
         byte_size: u64,
         vulkan_device_uuid: [u8; 16],
     ) -> Self {
@@ -89,16 +88,6 @@ impl DeviceExchangeBuffer {
             exported_opaque_fd: Mutex::new(Some(exported_opaque_fd)),
             byte_size,
             vulkan_device_uuid,
-        }
-    }
-}
-
-impl Drop for DeviceExchangeBuffer {
-    fn drop(&mut self) {
-        // Only reached when nothing ever exported to CUDA — a successful
-        // import adopts the fd and takes it out of this slot.
-        if let Some(unconsumed_fd) = self.exported_opaque_fd.lock().take() {
-            unsafe { libc::close(unconsumed_fd) };
         }
     }
 }
@@ -681,10 +670,14 @@ pub(crate) fn is_device_exchange(owned_memory: &Arc<GpuSurfaceOwnedMemory>) -> b
 
 /// Whether the surface is currently locked for CPU access, and for what.
 ///
-/// The gate is what makes "read before the producer signalled" a refusal
-/// rather than a half-drawn frame: `lock` is where the wait for the
-/// producer happens, so an export taken without one has no ordering
-/// guarantee behind it.
+/// An access-discipline flag, not a synchronisation point — it performs
+/// no wait. Ordering against the producer comes from publication: a
+/// built-in source waits on its own timeline before it writes the
+/// surface id to its output port (`camera_source.rs` does this at its
+/// host-readback wait), so a frame a consumer can name is a frame the
+/// GPU has finished writing. The gate's job is narrower: it makes the
+/// read/write intent explicit at the call site, and it is what carries
+/// `read_only` through to the exported tensor's flags.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CpuAccessLock {
     Unlocked,
@@ -732,9 +725,9 @@ impl CpuAccessGate {
             return Ok(());
         }
         Err(PyRuntimeError::new_err(
-            "surface is not locked for CPU access: call lock() first (or use the surface as a \
-             context manager). The lock is where the wait for the producer happens, so reading \
-             without one can observe a half-written frame.",
+            "surface is not locked for CPU access: call lock() first, or use the surface as a \
+             context manager. lock(read_only=False) is also what marks the exported tensor \
+             writable.",
         ))
     }
 }

--- a/sdk/streamlib-python-wheel/src/python_gpu_surface_pixel_exchange.rs
+++ b/sdk/streamlib-python-wheel/src/python_gpu_surface_pixel_exchange.rs
@@ -22,13 +22,18 @@
 //! rather than silently exported as its first plane.
 
 use std::ffi::{CStr, c_void};
+#[cfg(target_os = "linux")]
+use std::os::unix::io::RawFd;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
-use pyo3::exceptions::{PyBufferError, PyRuntimeError, PyValueError};
+use pyo3::exceptions::{PyBufferError, PyNotImplementedError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use streamlib::sdk::context::{PooledTextureHandle, SurfaceStore};
 use streamlib::sdk::rhi::{PixelBuffer, PixelFormat};
+
+#[cfg(target_os = "linux")]
+use crate::python_cuda_pixel_exchange::{CudaImportedSurface, import_opaque_fd_into_cuda};
 use streamlib_adapter_cuda::dlpack::{
     self, DataType, DataTypeCode, Device, DeviceType, Flags, ManagedTensor,
     ManagedTensorVersioned,
@@ -45,6 +50,60 @@ const DLPACK_VERSIONED_CAPSULE_NAME: &CStr = c"dltensor_versioned";
 // Owned memory — the lifetime anchor shared by the handle and its capsules
 // =============================================================================
 
+/// An engine allocation whose memory CUDA can import: an OPAQUE_FD
+/// `StorageBuffer`, plus the pixel-shaped view of the same allocation.
+///
+/// The two are one allocation, not two — `wrap_storage_buffer_as_pixel_buffer`
+/// shares the underlying `Arc<HostVulkanBuffer>`. That is what lets a
+/// host-visible exchange buffer serve numpy and CUDA from the same bytes.
+pub(crate) struct DeviceExchangeBuffer {
+    /// The allocation, pixel-shaped. This alone keeps it alive — the wrap
+    /// shares the storage buffer's `Arc`, so holding both would be one
+    /// refcount doing nothing.
+    pub(crate) pixel_buffer: PixelBuffer,
+    /// Device-local allocations have no host mapping, so `as_numpy` and
+    /// the CPU DLPack path refuse rather than hand back a null pointer.
+    pub(crate) device_local: bool,
+    /// The OPAQUE_FD, exported at acquire time because exporting needs
+    /// the privileged capability and `__dlpack__` does not have one.
+    /// Consumed by the first CUDA import — which adopts the fd — and
+    /// closed by `Drop` if no export ever happens.
+    exported_opaque_fd: Mutex<Option<RawFd>>,
+    byte_size: u64,
+    /// The exporting device's `VkPhysicalDeviceIDProperties::deviceUUID`,
+    /// which is how the CUDA import finds the GPU that owns the memory.
+    vulkan_device_uuid: [u8; 16],
+}
+
+#[cfg(target_os = "linux")]
+impl DeviceExchangeBuffer {
+    pub(crate) fn new(
+        pixel_buffer: PixelBuffer,
+        device_local: bool,
+        exported_opaque_fd: RawFd,
+        byte_size: u64,
+        vulkan_device_uuid: [u8; 16],
+    ) -> Self {
+        Self {
+            pixel_buffer,
+            device_local,
+            exported_opaque_fd: Mutex::new(Some(exported_opaque_fd)),
+            byte_size,
+            vulkan_device_uuid,
+        }
+    }
+}
+
+impl Drop for DeviceExchangeBuffer {
+    fn drop(&mut self) {
+        // Only reached when nothing ever exported to CUDA — a successful
+        // import adopts the fd and takes it out of this slot.
+        if let Some(unconsumed_fd) = self.exported_opaque_fd.lock().take() {
+            unsafe { libc::close(unconsumed_fd) };
+        }
+    }
+}
+
 /// The engine resource a [`GpuSurfaceOwnedMemory`] keeps alive.
 pub(crate) enum GpuSurfaceOwnedValue {
     PixelBuffer(PixelBuffer),
@@ -52,6 +111,7 @@ pub(crate) enum GpuSurfaceOwnedValue {
     /// it once the texture half of the exchange surface lands.
     #[expect(dead_code, reason = "lifetime-only until the texture export path reads it")]
     PooledTexture(PooledTextureHandle),
+    DeviceExchange(DeviceExchangeBuffer),
 }
 
 /// The engine value plus the surface-store release it owes, held behind
@@ -69,6 +129,11 @@ pub(crate) struct GpuSurfaceOwnedMemory {
     /// only if release evicts it.
     surface_store_owing_a_release: Option<SurfaceStore>,
     minted_surface_id: Option<String>,
+    /// The CUDA import, made on first device export and kept here rather
+    /// than on the handle: a capsule outliving its handle must keep the
+    /// import alive too, or the device pointer it carries dangles.
+    #[cfg(target_os = "linux")]
+    cuda_import: Mutex<Option<Arc<CudaImportedSurface>>>,
 }
 
 impl GpuSurfaceOwnedMemory {
@@ -81,17 +146,45 @@ impl GpuSurfaceOwnedMemory {
             owned_value,
             surface_store_owing_a_release,
             minted_surface_id,
+            #[cfg(target_os = "linux")]
+            cuda_import: Mutex::new(None),
         })
     }
 
-    pub(crate) fn owned_value(&self) -> &GpuSurfaceOwnedValue {
-        &self.owned_value
+    /// The host-mapped pixel view, or a refusal naming why this surface
+    /// has none. The single answer to "can the CPU address these bytes?"
+    /// — every host-side accessor routes through it.
+    pub(crate) fn host_mapped_pixel_buffer(&self) -> PyResult<&PixelBuffer> {
+        match &self.owned_value {
+            GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer) => Ok(pixel_buffer),
+            GpuSurfaceOwnedValue::DeviceExchange(exchange) if !exchange.device_local => {
+                Ok(&exchange.pixel_buffer)
+            }
+            GpuSurfaceOwnedValue::DeviceExchange(_) => Err(PyBufferError::new_err(
+                "this exchange buffer is device-local: its bytes live in VRAM with no host \
+                 mapping. Export it to CUDA with `__dlpack__`, or acquire it with \
+                 `device_local=False` to reach it from the CPU as well.",
+            )),
+            GpuSurfaceOwnedValue::PooledTexture(_) => Err(PyNotImplementedError::new_err(
+                "this surface is a pooled texture: its pixels are device-local and tiled, so CPU \
+                 access goes through the texture export path rather than a host mapping",
+            )),
+        }
     }
 
-    fn pixel_buffer(&self) -> Option<&PixelBuffer> {
+    /// The pixel shape of this surface, host mapping or not.
+    fn pixel_shape(&self) -> Option<&PixelBuffer> {
         match &self.owned_value {
             GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer) => Some(pixel_buffer),
+            GpuSurfaceOwnedValue::DeviceExchange(exchange) => Some(&exchange.pixel_buffer),
             GpuSurfaceOwnedValue::PooledTexture(_) => None,
+        }
+    }
+
+    fn device_exchange(&self) -> Option<&DeviceExchangeBuffer> {
+        match &self.owned_value {
+            GpuSurfaceOwnedValue::DeviceExchange(exchange) => Some(exchange),
+            GpuSurfaceOwnedValue::PixelBuffer(_) | GpuSurfaceOwnedValue::PooledTexture(_) => None,
         }
     }
 }
@@ -383,12 +476,7 @@ pub(crate) fn host_visible_dlpack_capsule<'py>(
     exchange_shape: DlpackExchangeShape,
     read_only: bool,
 ) -> PyResult<Bound<'py, PyAny>> {
-    let pixel_buffer = owned_memory.pixel_buffer().ok_or_else(|| {
-        PyRuntimeError::new_err(
-            "this surface is a pooled texture; its pixels are device-local and reach a linear \
-             tensor through the texture export path, not the host mapping",
-        )
-    })?;
+    let pixel_buffer = owned_memory.host_mapped_pixel_buffer()?;
 
     let base_address = pixel_buffer.plane_base_address(0);
     if base_address.is_null() {
@@ -439,6 +527,133 @@ pub(crate) fn host_visible_dlpack_capsule<'py>(
             ),
         ),
     }
+}
+
+// =============================================================================
+// Device export — the same memory, in CUDA's dialect
+// =============================================================================
+
+/// Import this surface's memory into CUDA, or return the cached import.
+///
+/// The import is cached on the shared owned-memory anchor rather than
+/// redone per export, both because `cudaImportExternalMemory` is
+/// expensive and because every tensor must name the *same* device
+/// pointer — a second import would produce a second mapping of the same
+/// bytes, and freeing one would strand the other.
+#[cfg(target_os = "linux")]
+fn cuda_import_for(
+    owned_memory: &Arc<GpuSurfaceOwnedMemory>,
+) -> PyResult<Arc<CudaImportedSurface>> {
+    let mut cached = owned_memory.cuda_import.lock();
+    if let Some(existing) = cached.as_ref() {
+        return Ok(Arc::clone(existing));
+    }
+    let exchange = owned_memory.device_exchange().ok_or_else(|| {
+        PyRuntimeError::new_err(
+            "this surface was not allocated for device exchange: acquire it with \
+             `acquire_device_exchange_buffer` so its memory is OPAQUE_FD-exportable. A pooled \
+             pixel buffer is DMA-BUF-flavoured and cannot export the handle CUDA imports.",
+        )
+    })?;
+    let opaque_fd = exchange.exported_opaque_fd.lock().take().ok_or_else(|| {
+        PyRuntimeError::new_err(
+            "this surface's export handle was already consumed and the import did not survive; \
+             acquire the buffer again",
+        )
+    })?;
+    let imported =
+        import_opaque_fd_into_cuda(opaque_fd, exchange.byte_size, exchange.vulkan_device_uuid)
+            .map(Arc::new)
+            .map_err(PyRuntimeError::new_err)?;
+    *cached = Some(Arc::clone(&imported));
+    Ok(imported)
+}
+
+/// Build a DLPack capsule over this surface's CUDA device pointer.
+///
+/// The capsule owner holds both the engine allocation and the CUDA
+/// import, so a tensor outliving its handle keeps a live mapping — the
+/// same lifetime contract as the host path, extended across the second
+/// allocator.
+#[cfg(target_os = "linux")]
+pub(crate) fn device_dlpack_capsule<'py>(
+    python: Python<'py>,
+    owned_memory: &Arc<GpuSurfaceOwnedMemory>,
+    exchange_shape: DlpackExchangeShape,
+    read_only: bool,
+) -> PyResult<Bound<'py, PyAny>> {
+    let imported = cuda_import_for(owned_memory)?;
+    let pixel_shape = owned_memory
+        .pixel_shape()
+        .ok_or_else(|| PyRuntimeError::new_err("this surface has no pixel shape to export"))?;
+    // A device-exchange allocation is tightly packed by construction —
+    // it is sized `width * height * bytes_per_pixel` at acquire, with no
+    // driver row padding to discover.
+    let bytes_per_row = pixel_buffer_bytes_per_row(pixel_shape)?;
+    let layout = PixelExchangeTensorLayout::for_pixel_format(
+        pixel_shape.format(),
+        pixel_shape.width,
+        pixel_shape.height,
+        bytes_per_row,
+    )?;
+
+    let device_pointer = imported.device_pointer();
+    let device = imported.dlpack_device();
+    // Two owners in one box: the engine's allocation and CUDA's mapping
+    // of it. Dropping either early dangles the other.
+    let owner: Box<dyn std::any::Any + Send> =
+        Box::new((Arc::clone(owned_memory), Arc::clone(&imported)));
+
+    match exchange_shape {
+        DlpackExchangeShape::Versioned => {
+            let flags = if read_only {
+                Flags::READ_ONLY
+            } else {
+                Flags::empty()
+            };
+            dlpack_versioned_capsule_from_managed_tensor(
+                python,
+                dlpack::build_managed_tensor_versioned(
+                    device_pointer,
+                    layout.shape,
+                    Some(layout.strides),
+                    layout.dtype,
+                    device,
+                    flags,
+                    owner,
+                ),
+            )
+        }
+        DlpackExchangeShape::Unversioned => dlpack_capsule_from_managed_tensor(
+            python,
+            dlpack::build_managed_tensor(
+                device_pointer,
+                layout.shape,
+                Some(layout.strides),
+                layout.dtype,
+                device,
+                owner,
+            ),
+        ),
+    }
+}
+
+/// The DLPack device this surface's memory is imported onto, importing
+/// it if that has not happened yet.
+///
+/// Answering without the import would mean guessing whether the driver
+/// produced device or pinned-host memory — and a wrong guess here
+/// contradicts the capsule the very next call hands back.
+#[cfg(target_os = "linux")]
+pub(crate) fn imported_device_for(
+    owned_memory: &Arc<GpuSurfaceOwnedMemory>,
+) -> PyResult<Device> {
+    Ok(cuda_import_for(owned_memory)?.dlpack_device())
+}
+
+/// Whether this surface was allocated for device exchange.
+pub(crate) fn is_device_exchange(owned_memory: &Arc<GpuSurfaceOwnedMemory>) -> bool {
+    owned_memory.device_exchange().is_some()
 }
 
 // =============================================================================

--- a/sdk/streamlib-python-wheel/src/python_gpu_surface_pixel_exchange.rs
+++ b/sdk/streamlib-python-wheel/src/python_gpu_surface_pixel_exchange.rs
@@ -1,0 +1,684 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The pixel-exchange surface: how Python reaches the pixels behind a
+//! `GpuSurfaceHandle` without a CPU round trip.
+//!
+//! Two contracts live here, and both are load-bearing.
+//!
+//! **Lifetime.** The memory a DLPack capsule points at outlives the
+//! handle that produced it. Python may keep a tensor after the frame is
+//! released, so the engine value and the surface-store release debt sit
+//! behind an [`GpuSurfaceOwnedMemory`] that every outstanding capsule
+//! holds an `Arc` of; the pool slot comes back only when the handle and
+//! the last capsule are both gone. Dropping that to a plain `close()`
+//! would return the slot while a live tensor still addresses it, and the
+//! producer's next frame would overwrite pixels Python is reading.
+//!
+//! **Layout.** DLPack expresses one strided linear buffer, so the shape
+//! and strides are derived from the pixel format here rather than left
+//! to the caller, strides are counted in elements (the DLPack spec's
+//! unit, not numpy's bytes), and a multi-plane format is refused outright
+//! rather than silently exported as its first plane.
+
+use std::ffi::{CStr, c_void};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use pyo3::exceptions::{PyBufferError, PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+use streamlib::sdk::context::{PooledTextureHandle, SurfaceStore};
+use streamlib::sdk::rhi::{PixelBuffer, PixelFormat};
+use streamlib_adapter_cuda::dlpack::{
+    self, DataType, DataTypeCode, Device, DeviceType, Flags, ManagedTensor,
+    ManagedTensorVersioned,
+};
+
+/// Capsule names before a consumer takes ownership. The DLPack protocol
+/// fixes these and their `used_` counterparts: a consumer renames the
+/// capsule once it has adopted the tensor, and our destructors key off
+/// that rename to decide whether the deleter is still ours to run.
+const DLPACK_CAPSULE_NAME: &CStr = c"dltensor";
+const DLPACK_VERSIONED_CAPSULE_NAME: &CStr = c"dltensor_versioned";
+
+// =============================================================================
+// Owned memory — the lifetime anchor shared by the handle and its capsules
+// =============================================================================
+
+/// The engine resource a [`GpuSurfaceOwnedMemory`] keeps alive.
+pub(crate) enum GpuSurfaceOwnedValue {
+    PixelBuffer(PixelBuffer),
+    /// Held to keep the pool slot alive; the device-local export path reads
+    /// it once the texture half of the exchange surface lands.
+    #[expect(dead_code, reason = "lifetime-only until the texture export path reads it")]
+    PooledTexture(PooledTextureHandle),
+}
+
+/// The engine value plus the surface-store release it owes, held behind
+/// an `Arc` shared by the Python handle and every DLPack capsule minted
+/// from it.
+///
+/// Release runs in `Drop` rather than on `close()` precisely so a tensor
+/// that outlives its frame keeps addressing live memory: the last holder
+/// settles the debt, whether that is the handle or a capsule Python is
+/// still holding.
+pub(crate) struct GpuSurfaceOwnedMemory {
+    owned_value: GpuSurfaceOwnedValue,
+    /// Present only when the acquire checked the buffer into the store.
+    /// The check-in parks a strong clone there, so the pool slot returns
+    /// only if release evicts it.
+    surface_store_owing_a_release: Option<SurfaceStore>,
+    minted_surface_id: Option<String>,
+}
+
+impl GpuSurfaceOwnedMemory {
+    pub(crate) fn new(
+        owned_value: GpuSurfaceOwnedValue,
+        surface_store_owing_a_release: Option<SurfaceStore>,
+        minted_surface_id: Option<String>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            owned_value,
+            surface_store_owing_a_release,
+            minted_surface_id,
+        })
+    }
+
+    pub(crate) fn owned_value(&self) -> &GpuSurfaceOwnedValue {
+        &self.owned_value
+    }
+
+    fn pixel_buffer(&self) -> Option<&PixelBuffer> {
+        match &self.owned_value {
+            GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer) => Some(pixel_buffer),
+            GpuSurfaceOwnedValue::PooledTexture(_) => None,
+        }
+    }
+}
+
+impl Drop for GpuSurfaceOwnedMemory {
+    fn drop(&mut self) {
+        if let (Some(store), Some(surface_id)) = (
+            self.surface_store_owing_a_release.as_ref(),
+            self.minted_surface_id.as_ref(),
+        ) {
+            // Best-effort, mirroring the subprocess release path: the
+            // store eviction is what frees the pool slot, and the daemon
+            // half already treats a dropped connection as a full release.
+            if let Err(release_failure) = store.release(surface_id) {
+                tracing::debug!(%surface_id, %release_failure, "surface-store release failed");
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Tensor layout — one strided linear buffer, derived from the pixel format
+// =============================================================================
+
+/// The DLPack shape a pixel format maps to.
+#[derive(Debug)]
+pub(crate) struct PixelExchangeTensorLayout {
+    pub(crate) shape: Vec<i64>,
+    /// Strides in **elements**, per the DLPack spec — not numpy's bytes.
+    pub(crate) strides: Vec<i64>,
+    pub(crate) dtype: DataType,
+}
+
+/// Bytes per pixel and the trailing channel axis for a single-plane
+/// format. `None` for formats DLPack cannot express as one buffer.
+fn single_plane_shape(format: PixelFormat) -> Option<(u32, DataType, Option<i64>)> {
+    match format {
+        PixelFormat::Bgra32 | PixelFormat::Rgba32 | PixelFormat::Argb32 => {
+            Some((4, DataType::U8, Some(4)))
+        }
+        // 16 bits per channel: the element is a u16, so the channel axis
+        // is still 4 wide but each element spans two bytes.
+        PixelFormat::Rgba64 => Some((
+            8,
+            DataType {
+                code: DataTypeCode::UInt,
+                bits: 16,
+                lanes: 1,
+            },
+            Some(4),
+        )),
+        PixelFormat::Gray8 => Some((1, DataType::U8, None)),
+        // Packed 4:2:2 — two bytes per pixel, but the byte pair is not a
+        // per-pixel channel tuple. Exported as raw bytes with the trailing
+        // axis naming the pair, which is what a shader or a converter
+        // wants; interpreting it as colour is the consumer's job.
+        PixelFormat::Yuyv422 | PixelFormat::Uyvy422 => Some((2, DataType::U8, Some(2))),
+        // Multi-plane. DLPack expresses one strided linear buffer, so
+        // exporting plane 0 alone would hand out luma while silently
+        // dropping chroma.
+        PixelFormat::Nv12VideoRange | PixelFormat::Nv12FullRange => None,
+        PixelFormat::Unknown => None,
+    }
+}
+
+impl PixelExchangeTensorLayout {
+    /// Derive the layout for a single-plane surface.
+    ///
+    /// `bytes_per_row` comes from the allocation rather than from
+    /// `width * bytes_per_pixel` so a padded row pitch stays correct.
+    pub(crate) fn for_pixel_format(
+        format: PixelFormat,
+        width: u32,
+        height: u32,
+        bytes_per_row: u64,
+    ) -> PyResult<Self> {
+        let Some((bytes_per_pixel, dtype, channel_axis)) = single_plane_shape(format) else {
+            return Err(PyValueError::new_err(format!(
+                "pixel format {:?} has no single-buffer DLPack shape: DLPack expresses one \
+                 strided linear buffer, and exporting only its first plane would hand out \
+                 part of the image. Convert to a packed format first.",
+                format
+            )));
+        };
+
+        let element_bytes = u64::from(dtype.bits / 8);
+        if element_bytes == 0 || bytes_per_row % element_bytes != 0 {
+            return Err(PyValueError::new_err(format!(
+                "row pitch {bytes_per_row} is not a whole number of {element_bytes}-byte elements"
+            )));
+        }
+        let row_stride_elements = (bytes_per_row / element_bytes) as i64;
+        let channels_per_pixel = i64::from(bytes_per_pixel) / element_bytes as i64;
+
+        let (shape, strides) = match channel_axis {
+            Some(channels) => (
+                vec![i64::from(height), i64::from(width), channels],
+                vec![row_stride_elements, channels_per_pixel, 1],
+            ),
+            None => (
+                vec![i64::from(height), i64::from(width)],
+                vec![row_stride_elements, channels_per_pixel],
+            ),
+        };
+        Ok(Self {
+            shape,
+            strides,
+            dtype,
+        })
+    }
+}
+
+/// Row pitch of a pixel buffer's first plane, derived from the
+/// allocation so padding is honoured rather than assumed away.
+pub(crate) fn pixel_buffer_bytes_per_row(pixel_buffer: &PixelBuffer) -> PyResult<u64> {
+    let height = u64::from(pixel_buffer.height);
+    if height == 0 {
+        return Err(PyValueError::new_err(
+            "surface has zero height; no row pitch exists",
+        ));
+    }
+    let plane_size = pixel_buffer.plane_size(0);
+    if plane_size == 0 {
+        return Err(PyRuntimeError::new_err(
+            "surface reports a zero-byte plane; it is not CPU-mappable",
+        ));
+    }
+    if plane_size % height != 0 {
+        return Err(PyRuntimeError::new_err(format!(
+            "plane size {plane_size} is not a whole number of {height} rows"
+        )));
+    }
+    Ok(plane_size / height)
+}
+
+// =============================================================================
+// DLPack capsule
+// =============================================================================
+
+/// Run the managed tensor's deleter when a capsule is garbage-collected
+/// without a consumer having taken it.
+///
+/// The DLPack protocol makes the rename to `used_dltensor` the transfer
+/// of ownership: a renamed capsule's tensor belongs to its consumer, and
+/// running the deleter here as well would free it twice.
+unsafe extern "C" fn dlpack_capsule_destructor(capsule: *mut pyo3::ffi::PyObject) {
+    unsafe {
+        if pyo3::ffi::PyCapsule_IsValid(capsule, DLPACK_CAPSULE_NAME.as_ptr()) == 0 {
+            // Either consumed (renamed) or not ours. `PyCapsule_IsValid`
+            // does not set an exception, so there is nothing to clear.
+            return;
+        }
+        let managed_tensor =
+            pyo3::ffi::PyCapsule_GetPointer(capsule, DLPACK_CAPSULE_NAME.as_ptr())
+                as *mut ManagedTensor;
+        if managed_tensor.is_null() {
+            // Defensive: `IsValid` already proved the name matches, so a
+            // null pointer here would be a capsule built by someone else.
+            pyo3::ffi::PyErr_Clear();
+            return;
+        }
+        if let Some(deleter) = (*managed_tensor).deleter {
+            deleter(managed_tensor);
+        }
+    }
+}
+
+/// Wrap a managed tensor in the PyCapsule `from_dlpack` consumers expect.
+///
+/// Takes ownership of `managed_tensor`: on success the capsule's
+/// destructor (or its consumer, after the rename) runs the deleter; on
+/// failure the deleter runs here so the tensor is never leaked.
+fn dlpack_capsule_from_managed_tensor<'py>(
+    python: Python<'py>,
+    managed_tensor: *mut ManagedTensor,
+) -> PyResult<Bound<'py, PyAny>> {
+    let capsule = unsafe {
+        pyo3::ffi::PyCapsule_New(
+            managed_tensor as *mut c_void,
+            DLPACK_CAPSULE_NAME.as_ptr(),
+            Some(dlpack_capsule_destructor),
+        )
+    };
+    if capsule.is_null() {
+        unsafe {
+            if let Some(deleter) = (*managed_tensor).deleter {
+                deleter(managed_tensor);
+            }
+        }
+        return Err(PyErr::fetch(python));
+    }
+    // SAFETY: `PyCapsule_New` returns a new strong reference, which
+    // `from_owned_ptr` adopts.
+    Ok(unsafe { Bound::from_owned_ptr(python, capsule) })
+}
+
+/// The DLPack device a host-visible surface reports.
+///
+/// `kDLCPU`: the pixel buffer is a persistently-mapped host-visible
+/// allocation, so a consumer addresses it with ordinary loads — no CUDA
+/// context is involved and claiming `kDLCUDA` would make torch try to
+/// treat a host pointer as device memory.
+pub(crate) const HOST_VISIBLE_DLPACK_DEVICE: Device = Device {
+    device_type: DeviceType::Cpu,
+    device_id: 0,
+};
+
+/// Run the versioned managed tensor's deleter when a capsule is
+/// collected without a consumer having taken it. Same rename contract as
+/// the unversioned destructor, against `dltensor_versioned`.
+unsafe extern "C" fn dlpack_versioned_capsule_destructor(capsule: *mut pyo3::ffi::PyObject) {
+    unsafe {
+        if pyo3::ffi::PyCapsule_IsValid(capsule, DLPACK_VERSIONED_CAPSULE_NAME.as_ptr()) == 0 {
+            return;
+        }
+        let managed_tensor =
+            pyo3::ffi::PyCapsule_GetPointer(capsule, DLPACK_VERSIONED_CAPSULE_NAME.as_ptr())
+                as *mut ManagedTensorVersioned;
+        if managed_tensor.is_null() {
+            pyo3::ffi::PyErr_Clear();
+            return;
+        }
+        if let Some(deleter) = (*managed_tensor).deleter {
+            deleter(managed_tensor);
+        }
+    }
+}
+
+/// Wrap a versioned managed tensor in its PyCapsule, taking ownership on
+/// the same terms as [`dlpack_capsule_from_managed_tensor`].
+fn dlpack_versioned_capsule_from_managed_tensor<'py>(
+    python: Python<'py>,
+    managed_tensor: *mut ManagedTensorVersioned,
+) -> PyResult<Bound<'py, PyAny>> {
+    let capsule = unsafe {
+        pyo3::ffi::PyCapsule_New(
+            managed_tensor as *mut c_void,
+            DLPACK_VERSIONED_CAPSULE_NAME.as_ptr(),
+            Some(dlpack_versioned_capsule_destructor),
+        )
+    };
+    if capsule.is_null() {
+        unsafe {
+            if let Some(deleter) = (*managed_tensor).deleter {
+                deleter(managed_tensor);
+            }
+        }
+        return Err(PyErr::fetch(python));
+    }
+    // SAFETY: `PyCapsule_New` returns a new strong reference.
+    Ok(unsafe { Bound::from_owned_ptr(python, capsule) })
+}
+
+/// The exchange shape a consumer negotiated via `__dlpack__`'s
+/// `max_version`.
+///
+/// The distinction is not cosmetic: only the versioned struct carries
+/// flags, and an unversioned tensor has no way to say "this memory is
+/// writable" — so `numpy.from_dlpack` marks it read-only, and a
+/// processor that mutates frames in place gets nothing it can write to.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum DlpackExchangeShape {
+    Unversioned,
+    Versioned,
+}
+
+/// Pick the exchange shape from the consumer's `max_version`.
+///
+/// Absent means the consumer predates v1.0 and only understands the
+/// unversioned struct. A major version below 1 means the same.
+pub(crate) fn exchange_shape_for_max_version(
+    max_version: Option<(u32, u32)>,
+) -> DlpackExchangeShape {
+    match max_version {
+        Some((major, _)) if major >= 1 => DlpackExchangeShape::Versioned,
+        _ => DlpackExchangeShape::Unversioned,
+    }
+}
+
+/// Build a DLPack capsule over a host-visible pixel buffer.
+///
+/// `owned_memory` is cloned into the capsule's owner so the mapping stays
+/// addressable until the consumer releases the tensor, even if the Python
+/// handle was closed first. `read_only` reaches the consumer only on the
+/// versioned path — the unversioned struct has nowhere to carry it.
+pub(crate) fn host_visible_dlpack_capsule<'py>(
+    python: Python<'py>,
+    owned_memory: &Arc<GpuSurfaceOwnedMemory>,
+    exchange_shape: DlpackExchangeShape,
+    read_only: bool,
+) -> PyResult<Bound<'py, PyAny>> {
+    let pixel_buffer = owned_memory.pixel_buffer().ok_or_else(|| {
+        PyRuntimeError::new_err(
+            "this surface is a pooled texture; its pixels are device-local and reach a linear \
+             tensor through the texture export path, not the host mapping",
+        )
+    })?;
+
+    let base_address = pixel_buffer.plane_base_address(0);
+    if base_address.is_null() {
+        return Err(PyBufferError::new_err(
+            "surface has no host mapping; a DEVICE_LOCAL allocation reaches the CPU through the \
+             texture export path instead",
+        ));
+    }
+
+    let bytes_per_row = pixel_buffer_bytes_per_row(pixel_buffer)?;
+    let layout = PixelExchangeTensorLayout::for_pixel_format(
+        pixel_buffer.format(),
+        pixel_buffer.width,
+        pixel_buffer.height,
+        bytes_per_row,
+    )?;
+    let owner = Box::new(Arc::clone(owned_memory));
+
+    match exchange_shape {
+        DlpackExchangeShape::Versioned => {
+            let flags = if read_only {
+                Flags::READ_ONLY
+            } else {
+                Flags::empty()
+            };
+            dlpack_versioned_capsule_from_managed_tensor(
+                python,
+                dlpack::build_managed_tensor_versioned(
+                    base_address as u64,
+                    layout.shape,
+                    Some(layout.strides),
+                    layout.dtype,
+                    HOST_VISIBLE_DLPACK_DEVICE,
+                    flags,
+                    owner,
+                ),
+            )
+        }
+        DlpackExchangeShape::Unversioned => dlpack_capsule_from_managed_tensor(
+            python,
+            dlpack::build_managed_tensor(
+                base_address as u64,
+                layout.shape,
+                Some(layout.strides),
+                layout.dtype,
+                HOST_VISIBLE_DLPACK_DEVICE,
+                owner,
+            ),
+        ),
+    }
+}
+
+// =============================================================================
+// CPU access gate
+// =============================================================================
+
+/// Whether the surface is currently locked for CPU access, and for what.
+///
+/// The gate is what makes "read before the producer signalled" a refusal
+/// rather than a half-drawn frame: `lock` is where the wait for the
+/// producer happens, so an export taken without one has no ordering
+/// guarantee behind it.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CpuAccessLock {
+    Unlocked,
+    ReadOnly,
+    ReadWrite,
+}
+
+pub(crate) struct CpuAccessGate {
+    state: Mutex<CpuAccessLock>,
+}
+
+impl CpuAccessGate {
+    pub(crate) fn new_unlocked() -> Self {
+        Self {
+            state: Mutex::new(CpuAccessLock::Unlocked),
+        }
+    }
+
+    pub(crate) fn lock_for(&self, read_only: bool) {
+        *self.state.lock() = if read_only {
+            CpuAccessLock::ReadOnly
+        } else {
+            CpuAccessLock::ReadWrite
+        };
+    }
+
+    pub(crate) fn unlock(&self) {
+        *self.state.lock() = CpuAccessLock::Unlocked;
+    }
+
+    pub(crate) fn is_locked(&self) -> bool {
+        *self.state.lock() != CpuAccessLock::Unlocked
+    }
+
+    /// Whether the current lock forbids writing. An unlocked surface
+    /// reports read-only; the export path refuses it before the answer
+    /// matters.
+    pub(crate) fn is_read_only(&self) -> bool {
+        *self.state.lock() != CpuAccessLock::ReadWrite
+    }
+
+    /// Refuse an export taken outside a lock.
+    pub(crate) fn require_locked(&self) -> PyResult<()> {
+        if self.is_locked() {
+            return Ok(());
+        }
+        Err(PyRuntimeError::new_err(
+            "surface is not locked for CPU access: call lock() first (or use the surface as a \
+             context manager). The lock is where the wait for the producer happens, so reading \
+             without one can observe a half-written frame.",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bgra_layout_is_height_width_four_bytes() {
+        let layout =
+            PixelExchangeTensorLayout::for_pixel_format(PixelFormat::Bgra32, 640, 480, 640 * 4)
+                .expect("bgra has a single-buffer shape");
+        assert_eq!(layout.shape, vec![480, 640, 4]);
+        // Element size is one byte, so element strides equal byte strides
+        // — the same (bytes_per_row, 4, 1) the pre-wheel surface returned.
+        assert_eq!(layout.strides, vec![2560, 4, 1]);
+        assert_eq!(layout.dtype, DataType::U8);
+    }
+
+    #[test]
+    fn a_padded_row_pitch_survives_into_the_stride() {
+        // 640 pixels of BGRA is 2560 bytes; a driver that pads to 2688
+        // must not be flattened into a tightly-packed view.
+        let layout =
+            PixelExchangeTensorLayout::for_pixel_format(PixelFormat::Bgra32, 640, 480, 2688)
+                .expect("bgra has a single-buffer shape");
+        assert_eq!(layout.shape, vec![480, 640, 4]);
+        assert_eq!(layout.strides[0], 2688);
+    }
+
+    #[test]
+    fn sixteen_bit_strides_are_counted_in_elements_not_bytes() {
+        // DLPack strides are element counts. RGBA64 is 8 bytes per pixel
+        // over 2-byte elements, so a 640-pixel row of 5120 bytes is 2560
+        // elements and the channel step is 1 element, not 2 bytes.
+        let layout =
+            PixelExchangeTensorLayout::for_pixel_format(PixelFormat::Rgba64, 640, 480, 640 * 8)
+                .expect("rgba64 has a single-buffer shape");
+        assert_eq!(layout.shape, vec![480, 640, 4]);
+        assert_eq!(layout.strides, vec![2560, 4, 1]);
+        assert_eq!(layout.dtype.bits, 16);
+    }
+
+    #[test]
+    fn gray8_has_no_channel_axis() {
+        let layout =
+            PixelExchangeTensorLayout::for_pixel_format(PixelFormat::Gray8, 320, 200, 320)
+                .expect("gray8 has a single-buffer shape");
+        assert_eq!(layout.shape, vec![200, 320]);
+        assert_eq!(layout.strides, vec![320, 1]);
+    }
+
+    /// NV12 is two planes; a one-buffer export would be luma only.
+    #[test]
+    fn multi_plane_formats_are_refused_rather_than_truncated() {
+        Python::initialize();
+        for format in [PixelFormat::Nv12VideoRange, PixelFormat::Nv12FullRange] {
+            let refusal = PixelExchangeTensorLayout::for_pixel_format(format, 640, 480, 640)
+                .expect_err("nv12 must not export as one buffer");
+            assert!(
+                refusal.to_string().contains("one strided linear buffer"),
+                "the refusal should say why, got: {refusal}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_access_gate_refuses_an_export_taken_without_a_lock() {
+        Python::initialize();
+        let gate = CpuAccessGate::new_unlocked();
+        let refusal = gate.require_locked().expect_err("unlocked must refuse");
+        assert!(refusal.to_string().contains("not locked"));
+
+        gate.lock_for(true);
+        assert!(gate.require_locked().is_ok());
+
+        gate.unlock();
+        assert!(
+            gate.require_locked().is_err(),
+            "unlock closes the gate again"
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // Capsule ownership. The DLPack protocol splits responsibility for the
+    // deleter between producer and consumer at the rename, and getting that
+    // split wrong is either a leak or a double free — neither of which a
+    // pixel-shaped test would surface.
+    // -------------------------------------------------------------------
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// The name a consumer renames the capsule to once it has adopted the
+    /// tensor — the other half of the protocol pair.
+    const DLPACK_CONSUMED_CAPSULE_NAME: &CStr = c"used_dltensor";
+
+    /// A managed tensor over a fake pointer whose owner counts its drops.
+    fn counted_managed_tensor(drops: &Arc<AtomicUsize>) -> *mut ManagedTensor {
+        struct CountedOwner(Arc<AtomicUsize>);
+        impl Drop for CountedOwner {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        dlpack::build_managed_tensor(
+            0xCAFE_F00D,
+            vec![4, 4, 4],
+            Some(vec![16, 4, 1]),
+            DataType::U8,
+            HOST_VISIBLE_DLPACK_DEVICE,
+            Box::new(CountedOwner(Arc::clone(drops))),
+        )
+    }
+
+    /// A capsule nobody consumed still owns its tensor, so collection must
+    /// free it — exactly once.
+    #[test]
+    fn an_unconsumed_capsule_frees_its_tensor_on_collection() {
+        Python::initialize();
+        let drops = Arc::new(AtomicUsize::new(0));
+        Python::attach(|python| {
+            let capsule = dlpack_capsule_from_managed_tensor(
+                python,
+                counted_managed_tensor(&drops),
+            )
+            .expect("capsule");
+            assert_eq!(drops.load(Ordering::SeqCst), 0, "still owned by the capsule");
+            drop(capsule);
+        });
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            1,
+            "collection must run the deleter exactly once"
+        );
+    }
+
+    /// Renaming to `used_dltensor` is how a consumer signals it has adopted
+    /// the tensor. Freeing it here as well would be a double free of memory
+    /// torch is still using.
+    #[test]
+    fn a_consumed_capsule_is_left_alone_by_the_destructor() {
+        Python::initialize();
+        let drops = Arc::new(AtomicUsize::new(0));
+        let adopted = Python::attach(|python| {
+            let capsule = dlpack_capsule_from_managed_tensor(
+                python,
+                counted_managed_tensor(&drops),
+            )
+            .expect("capsule");
+            // What every `from_dlpack` implementation does on adoption.
+            let adopted = unsafe {
+                let raw = pyo3::ffi::PyCapsule_GetPointer(
+                    capsule.as_ptr(),
+                    DLPACK_CAPSULE_NAME.as_ptr(),
+                ) as *mut ManagedTensor;
+                assert_eq!(
+                    pyo3::ffi::PyCapsule_SetName(
+                        capsule.as_ptr(),
+                        DLPACK_CONSUMED_CAPSULE_NAME.as_ptr(),
+                    ),
+                    0,
+                );
+                raw
+            };
+            drop(capsule);
+            adopted
+        });
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            0,
+            "a consumed capsule's tensor belongs to its consumer"
+        );
+        // The consumer's own release.
+        unsafe {
+            let deleter = (*adopted).deleter.expect("deleter");
+            deleter(adopted);
+        }
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+    }
+}

--- a/sdk/streamlib-python-wheel/src/python_gpu_surface_pixel_exchange.rs
+++ b/sdk/streamlib-python-wheel/src/python_gpu_surface_pixel_exchange.rs
@@ -22,13 +22,20 @@
 //! rather than silently exported as its first plane.
 
 use std::ffi::{CStr, c_void};
-use std::os::fd::OwnedFd;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
 use pyo3::exceptions::{PyBufferError, PyNotImplementedError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
-use streamlib::sdk::context::{PooledTextureHandle, SurfaceStore};
+#[cfg(target_os = "linux")]
+use std::collections::HashMap;
+#[cfg(target_os = "linux")]
+use std::os::fd::FromRawFd as _;
+#[cfg(target_os = "linux")]
+use std::sync::LazyLock;
+#[cfg(target_os = "linux")]
+use streamlib::sdk::context::SurfaceDeviceExportStaging;
+use streamlib::sdk::context::{GpuContextLimitedAccess, PooledTextureHandle, SurfaceStore};
 use streamlib::sdk::rhi::{PixelBuffer, PixelFormat};
 
 #[cfg(target_os = "linux")]
@@ -48,50 +55,6 @@ const DLPACK_VERSIONED_CAPSULE_NAME: &CStr = c"dltensor_versioned";
 // Owned memory — the lifetime anchor shared by the handle and its capsules
 // =============================================================================
 
-/// An engine allocation whose memory CUDA can import: an OPAQUE_FD
-/// `StorageBuffer`, plus the pixel-shaped view of the same allocation.
-///
-/// The two are one allocation, not two — `wrap_storage_buffer_as_pixel_buffer`
-/// shares the underlying `Arc<HostVulkanBuffer>`. That is what lets a
-/// host-visible exchange buffer serve numpy and CUDA from the same bytes.
-pub(crate) struct DeviceExchangeBuffer {
-    /// The allocation, pixel-shaped. This alone keeps it alive — the wrap
-    /// shares the storage buffer's `Arc`, so holding both would be one
-    /// refcount doing nothing.
-    pub(crate) pixel_buffer: PixelBuffer,
-    /// Device-local allocations have no host mapping, so `as_numpy` and
-    /// the CPU DLPack path refuse rather than hand back a null pointer.
-    pub(crate) device_local: bool,
-    /// The OPAQUE_FD, exported at acquire time because exporting needs
-    /// the privileged capability and `__dlpack__` does not have one.
-    /// Taken by the first CUDA import; an `OwnedFd` so an export that
-    /// never happens still closes it, with no destructor to write.
-    exported_opaque_fd: Mutex<Option<OwnedFd>>,
-    byte_size: u64,
-    /// The exporting device's `VkPhysicalDeviceIDProperties::deviceUUID`,
-    /// which is how the CUDA import finds the GPU that owns the memory.
-    vulkan_device_uuid: [u8; 16],
-}
-
-#[cfg(target_os = "linux")]
-impl DeviceExchangeBuffer {
-    pub(crate) fn new(
-        pixel_buffer: PixelBuffer,
-        device_local: bool,
-        exported_opaque_fd: OwnedFd,
-        byte_size: u64,
-        vulkan_device_uuid: [u8; 16],
-    ) -> Self {
-        Self {
-            pixel_buffer,
-            device_local,
-            exported_opaque_fd: Mutex::new(Some(exported_opaque_fd)),
-            byte_size,
-            vulkan_device_uuid,
-        }
-    }
-}
-
 /// The engine resource a [`GpuSurfaceOwnedMemory`] keeps alive.
 pub(crate) enum GpuSurfaceOwnedValue {
     PixelBuffer(PixelBuffer),
@@ -102,7 +65,6 @@ pub(crate) enum GpuSurfaceOwnedValue {
         reason = "lifetime-only until the texture export path reads it"
     )]
     PooledTexture(PooledTextureHandle),
-    DeviceExchange(DeviceExchangeBuffer),
 }
 
 /// The engine value plus the surface-store release it owes, held behind
@@ -120,11 +82,10 @@ pub(crate) struct GpuSurfaceOwnedMemory {
     /// only if release evicts it.
     surface_store_owing_a_release: Option<SurfaceStore>,
     minted_surface_id: Option<String>,
-    /// The CUDA import, made on first device export and kept here rather
-    /// than on the handle: a capsule outliving its handle must keep the
-    /// import alive too, or the device pointer it carries dangles.
-    #[cfg(target_os = "linux")]
-    cuda_import: Mutex<Option<Arc<CudaImportedSurface>>>,
+    /// The engine capability the device-export path refills through —
+    /// the one view the engine documents as stash-safe. `None` on a
+    /// handle minted without one; device export refuses there.
+    gpu_limited_access: Option<GpuContextLimitedAccess>,
 }
 
 impl GpuSurfaceOwnedMemory {
@@ -132,13 +93,13 @@ impl GpuSurfaceOwnedMemory {
         owned_value: GpuSurfaceOwnedValue,
         surface_store_owing_a_release: Option<SurfaceStore>,
         minted_surface_id: Option<String>,
+        gpu_limited_access: Option<GpuContextLimitedAccess>,
     ) -> Arc<Self> {
         Arc::new(Self {
             owned_value,
             surface_store_owing_a_release,
             minted_surface_id,
-            #[cfg(target_os = "linux")]
-            cuda_import: Mutex::new(None),
+            gpu_limited_access,
         })
     }
 
@@ -151,11 +112,6 @@ impl GpuSurfaceOwnedMemory {
     pub(crate) fn dma_buf_exportable_pixel_buffer(&self) -> PyResult<&PixelBuffer> {
         match &self.owned_value {
             GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer) => Ok(pixel_buffer),
-            GpuSurfaceOwnedValue::DeviceExchange(_) => Err(PyValueError::new_err(
-                "a device-exchange buffer is OPAQUE_FD-flavoured and has no DMA-BUF export; \
-                 hand it to CUDA with `__dlpack__`, or acquire an ordinary pixel buffer for a \
-                 DMA-BUF consumer",
-            )),
             GpuSurfaceOwnedValue::PooledTexture(_) => Err(PyNotImplementedError::new_err(
                 "exporting a pooled texture's DMA-BUF goes through the texture export path",
             )),
@@ -168,14 +124,6 @@ impl GpuSurfaceOwnedMemory {
     pub(crate) fn host_mapped_pixel_buffer(&self) -> PyResult<&PixelBuffer> {
         match &self.owned_value {
             GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer) => Ok(pixel_buffer),
-            GpuSurfaceOwnedValue::DeviceExchange(exchange) if !exchange.device_local => {
-                Ok(&exchange.pixel_buffer)
-            }
-            GpuSurfaceOwnedValue::DeviceExchange(_) => Err(PyBufferError::new_err(
-                "this exchange buffer is device-local: its bytes live in VRAM with no host \
-                 mapping. Export it to CUDA with `__dlpack__`, or acquire it with \
-                 `device_local=False` to reach it from the CPU as well.",
-            )),
             GpuSurfaceOwnedValue::PooledTexture(_) => Err(PyNotImplementedError::new_err(
                 "this surface is a pooled texture: its pixels are device-local and tiled, so CPU \
                  access goes through the texture export path rather than a host mapping",
@@ -187,15 +135,7 @@ impl GpuSurfaceOwnedMemory {
     fn pixel_shape(&self) -> Option<&PixelBuffer> {
         match &self.owned_value {
             GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer) => Some(pixel_buffer),
-            GpuSurfaceOwnedValue::DeviceExchange(exchange) => Some(&exchange.pixel_buffer),
             GpuSurfaceOwnedValue::PooledTexture(_) => None,
-        }
-    }
-
-    fn device_exchange(&self) -> Option<&DeviceExchangeBuffer> {
-        match &self.owned_value {
-            GpuSurfaceOwnedValue::DeviceExchange(exchange) => Some(exchange),
-            GpuSurfaceOwnedValue::PixelBuffer(_) | GpuSurfaceOwnedValue::PooledTexture(_) => None,
         }
     }
 }
@@ -543,76 +483,124 @@ pub(crate) fn host_visible_dlpack_capsule<'py>(
 // Device export — the same memory, in CUDA's dialect
 // =============================================================================
 
-/// Import this surface's memory into CUDA, or return the cached import.
+/// One surface's device-export state: the engine staging plus CUDA's
+/// import of it, cached per `surface_id` so a fresh handle for the same
+/// frame reuses both instead of re-allocating exportable memory (the
+/// churn NVIDIA's kernel accounting punishes) and re-importing.
 ///
-/// The import is cached on the shared owned-memory anchor rather than
-/// redone per export, both because `cudaImportExternalMemory` is
-/// expensive and because every tensor must name the *same* device
-/// pointer — a second import would produce a second mapping of the same
-/// bytes, and freeing one would strand the other.
+/// Process-wide because the plan fixes exactly one engine per process;
+/// the ids in it are the producer's stable ring/pool ids, so the map
+/// stays a handful of entries for the life of the graph.
 #[cfg(target_os = "linux")]
-fn cuda_import_for(
-    owned_memory: &Arc<GpuSurfaceOwnedMemory>,
-) -> PyResult<Arc<CudaImportedSurface>> {
-    let mut cached = owned_memory.cuda_import.lock();
-    if let Some(existing) = cached.as_ref() {
-        return Ok(Arc::clone(existing));
-    }
-    let exchange = owned_memory.device_exchange().ok_or_else(|| {
-        PyRuntimeError::new_err(
-            "this surface was not allocated for device exchange: acquire it with \
-             `acquire_device_exchange_buffer` so its memory is OPAQUE_FD-exportable. A pooled \
-             pixel buffer is DMA-BUF-flavoured and cannot export the handle CUDA imports.",
-        )
-    })?;
-    let opaque_fd = exchange.exported_opaque_fd.lock().take().ok_or_else(|| {
-        PyRuntimeError::new_err(
-            "this surface's export handle was already consumed and the import did not survive; \
-             acquire the buffer again",
-        )
-    })?;
-    let imported =
-        import_opaque_fd_into_cuda(opaque_fd, exchange.byte_size, exchange.vulkan_device_uuid)
-            .map(Arc::new)
-            .map_err(PyRuntimeError::new_err)?;
-    *cached = Some(Arc::clone(&imported));
-    Ok(imported)
+pub(crate) struct SurfaceDeviceExport {
+    pub(crate) staging: Arc<SurfaceDeviceExportStaging>,
+    pub(crate) cuda_import: Arc<CudaImportedSurface>,
 }
 
-/// Build a DLPack capsule over this surface's CUDA device pointer.
+#[cfg(target_os = "linux")]
+impl Clone for SurfaceDeviceExport {
+    fn clone(&self) -> Self {
+        Self {
+            staging: Arc::clone(&self.staging),
+            cuda_import: Arc::clone(&self.cuda_import),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+static SURFACE_DEVICE_EXPORTS: LazyLock<Mutex<HashMap<String, SurfaceDeviceExport>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// This surface's device export, created on first ask: engine staging,
+/// one OPAQUE_FD export, one CUDA import.
+#[cfg(target_os = "linux")]
+pub(crate) fn surface_device_export_for(
+    owned_memory: &Arc<GpuSurfaceOwnedMemory>,
+) -> PyResult<SurfaceDeviceExport> {
+    let surface_id = owned_memory.minted_surface_id.as_deref().ok_or_else(|| {
+        PyRuntimeError::new_err(
+            "this surface carries no id, so there is nothing to key a device export on; device \
+             tensors come from graph frames (resolve_surface) or published pixel buffers",
+        )
+    })?;
+    let engine_view = owned_memory.gpu_limited_access.as_ref().ok_or_else(|| {
+        PyRuntimeError::new_err(
+            "this handle was minted without the engine capability the device export refills \
+             through; acquire or resolve it via ctx.gpu_limited_access",
+        )
+    })?;
+    let mut cache = SURFACE_DEVICE_EXPORTS.lock();
+    if let Some(existing) = cache.get(surface_id) {
+        return Ok(existing.clone());
+    }
+    let staging = engine_view
+        .create_surface_device_export_staging(surface_id, None)
+        .map_err(|failure| PyRuntimeError::new_err(failure.to_string()))?;
+    let (raw_fd, byte_size, vulkan_device_uuid) = engine_view
+        .export_device_staging_opaque_fd(&staging)
+        .map_err(|failure| PyRuntimeError::new_err(failure.to_string()))?;
+    // SAFETY: the export hands over a fresh dup'd fd nothing else holds.
+    let opaque_fd = unsafe { std::os::fd::OwnedFd::from_raw_fd(raw_fd) };
+    let cuda_import = import_opaque_fd_into_cuda(opaque_fd, byte_size, vulkan_device_uuid)
+        .map(Arc::new)
+        .map_err(PyRuntimeError::new_err)?;
+    let export = SurfaceDeviceExport {
+        staging,
+        cuda_import,
+    };
+    cache.insert(surface_id.to_string(), export.clone());
+    Ok(export)
+}
+
+/// Build a DLPack capsule over this surface's CUDA device pointer,
+/// refilling the staging from the surface's current pixels first.
 ///
-/// The capsule owner holds both the engine allocation and the CUDA
-/// import, so a tensor outliving its handle keeps a live mapping — the
-/// same lifetime contract as the host path, extended across the second
-/// allocator.
+/// The capsule owner holds the surface, the staging, and the CUDA import
+/// — a tensor outliving its handle keeps all three alive.
 #[cfg(target_os = "linux")]
 pub(crate) fn device_dlpack_capsule<'py>(
     python: Python<'py>,
     owned_memory: &Arc<GpuSurfaceOwnedMemory>,
     exchange_shape: DlpackExchangeShape,
-    read_only: bool,
+    read_only_lock: bool,
 ) -> PyResult<Bound<'py, PyAny>> {
-    let imported = cuda_import_for(owned_memory)?;
-    let pixel_shape = owned_memory
-        .pixel_shape()
-        .ok_or_else(|| PyRuntimeError::new_err("this surface has no pixel shape to export"))?;
-    // A device-exchange allocation is tightly packed by construction —
-    // it is sized `width * height * bytes_per_pixel` at acquire, with no
-    // driver row padding to discover.
-    let bytes_per_row = pixel_buffer_bytes_per_row(pixel_shape)?;
+    let export = surface_device_export_for(owned_memory)?;
+    let engine_view = owned_memory
+        .gpu_limited_access
+        .as_ref()
+        .expect("surface_device_export_for verified the view");
+    engine_view
+        .refill_device_export_staging(&export.staging)
+        .map_err(|failure| PyRuntimeError::new_err(failure.to_string()))?;
+
+    let pixel_shape = owned_memory.pixel_shape().ok_or_else(|| {
+        PyRuntimeError::new_err("this surface has no pixel shape to derive a tensor layout from")
+    })?;
+    let height = u64::from(pixel_shape.height);
+    if height == 0 || !export.staging.staging_byte_size().is_multiple_of(height) {
+        return Err(PyRuntimeError::new_err(format!(
+            "staging size {} is not a whole number of {} rows",
+            export.staging.staging_byte_size(),
+            height
+        )));
+    }
     let layout = PixelExchangeTensorLayout::for_pixel_format(
         pixel_shape.format(),
         pixel_shape.width,
         pixel_shape.height,
-        bytes_per_row,
+        export.staging.staging_byte_size() / height,
     )?;
 
-    let device_pointer = imported.device_pointer();
-    let device = imported.dlpack_device();
-    // Two owners in one box: the engine's allocation and CUDA's mapping
-    // of it. Dropping either early dangles the other.
-    let owner: Box<dyn std::any::Any + Send> =
-        Box::new((Arc::clone(owned_memory), Arc::clone(&imported)));
+    // A texture-backed staging has no write-back path, so its tensors are
+    // read-only no matter what the lock says.
+    let read_only = read_only_lock || !export.staging.writable();
+    let device_pointer = export.cuda_import.device_pointer();
+    let device = export.cuda_import.dlpack_device();
+    let owner: Box<dyn std::any::Any + Send> = Box::new((
+        Arc::clone(owned_memory),
+        Arc::clone(&export.staging),
+        Arc::clone(&export.cuda_import),
+    ));
 
     match exchange_shape {
         DlpackExchangeShape::Versioned => {
@@ -648,20 +636,54 @@ pub(crate) fn device_dlpack_capsule<'py>(
     }
 }
 
-/// The DLPack device this surface's memory is imported onto, importing
-/// it if that has not happened yet.
-///
-/// Answering without the import would mean guessing whether the driver
-/// produced device or pinned-host memory — and a wrong guess here
-/// contradicts the capsule the very next call hands back.
+/// Whether a device tensor taken now would accept writes, without
+/// creating the export.
 #[cfg(target_os = "linux")]
-pub(crate) fn imported_device_for(owned_memory: &Arc<GpuSurfaceOwnedMemory>) -> PyResult<Device> {
-    Ok(cuda_import_for(owned_memory)?.dlpack_device())
+pub(crate) fn device_export_writable(owned_memory: &Arc<GpuSurfaceOwnedMemory>) -> bool {
+    owned_memory
+        .minted_surface_id
+        .as_deref()
+        .and_then(|surface_id| {
+            SURFACE_DEVICE_EXPORTS
+                .lock()
+                .get(surface_id)
+                .map(|export| export.staging.writable())
+        })
+        .unwrap_or(false)
 }
 
-/// Whether this surface was allocated for device exchange.
-pub(crate) fn is_device_exchange(owned_memory: &Arc<GpuSurfaceOwnedMemory>) -> bool {
-    owned_memory.device_exchange().is_some()
+/// Publish a device-side write back into the surface, so every other
+/// holder observes the edit. The unlock path calls this when a writable
+/// device tensor was taken under the write lock.
+#[cfg(target_os = "linux")]
+pub(crate) fn publish_device_write_back_to_surface(
+    owned_memory: &Arc<GpuSurfaceOwnedMemory>,
+) -> PyResult<()> {
+    let export = surface_device_export_for(owned_memory)?;
+    let engine_view = owned_memory
+        .gpu_limited_access
+        .as_ref()
+        .expect("surface_device_export_for verified the view");
+    engine_view
+        .copy_device_export_staging_back_to_surface(&export.staging)
+        .map_err(|failure| PyRuntimeError::new_err(failure.to_string()))?;
+    Ok(())
+}
+
+/// The DLPack device this surface's tensors would live on, importing on
+/// first ask — the driver's own classification of the mapped pointer is
+/// the only honest answer.
+#[cfg(target_os = "linux")]
+pub(crate) fn imported_device_for(owned_memory: &Arc<GpuSurfaceOwnedMemory>) -> PyResult<Device> {
+    Ok(surface_device_export_for(owned_memory)?
+        .cuda_import
+        .dlpack_device())
+}
+
+/// Whether this surface can even attempt a device export: it has an id
+/// to key on and the engine capability to refill through.
+pub(crate) fn device_export_available(owned_memory: &Arc<GpuSurfaceOwnedMemory>) -> bool {
+    owned_memory.minted_surface_id.is_some() && owned_memory.gpu_limited_access.is_some()
 }
 
 // =============================================================================

--- a/sdk/streamlib-python-wheel/src/python_processor_context.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_context.rs
@@ -31,19 +31,18 @@ use streamlib::sdk::rhi::{
     PixelBuffer, PixelBufferPoolId, PixelFormat, TextureFormat, TextureUsages,
 };
 use streamlib_adapter_cuda::dlpack::DeviceType;
-#[cfg(target_os = "linux")]
-use std::os::fd::FromRawFd as _;
-#[cfg(target_os = "linux")]
-use std::os::fd::OwnedFd;
 
 use crate::python_bag_conversion::json_value_to_python_object;
 use crate::python_gpu_surface_pixel_exchange::{
-    CpuAccessGate, DeviceExchangeBuffer, GpuSurfaceOwnedMemory, GpuSurfaceOwnedValue,
-    HOST_VISIBLE_DLPACK_DEVICE, exchange_shape_for_max_version, host_visible_dlpack_capsule,
-    is_device_exchange, pixel_buffer_bytes_per_row,
+    CpuAccessGate, GpuSurfaceOwnedMemory, GpuSurfaceOwnedValue, HOST_VISIBLE_DLPACK_DEVICE,
+    device_export_available, exchange_shape_for_max_version, host_visible_dlpack_capsule,
+    pixel_buffer_bytes_per_row,
 };
 #[cfg(target_os = "linux")]
-use crate::python_gpu_surface_pixel_exchange::{device_dlpack_capsule, imported_device_for};
+use crate::python_gpu_surface_pixel_exchange::{
+    device_dlpack_capsule, device_export_writable, imported_device_for,
+    publish_device_write_back_to_surface,
+};
 use crate::python_logging::monotonic_clock_now_ns;
 use crate::python_processor_link_data_access::PythonProcessorLinkDataAccess;
 
@@ -148,6 +147,9 @@ pub(crate) struct PythonGpuSurfaceHandle {
     surface_format_name: String,
     owned_memory: Mutex<Option<Arc<GpuSurfaceOwnedMemory>>>,
     cpu_access: CpuAccessGate,
+    /// A writable device tensor was exported under the current write
+    /// lock; `unlock()` publishes the staging back into the surface.
+    device_write_pending: std::sync::atomic::AtomicBool,
 }
 
 impl PythonGpuSurfaceHandle {
@@ -165,6 +167,7 @@ impl PythonGpuSurfaceHandle {
             surface_format_name,
             owned_memory: Mutex::new(Some(owned_memory)),
             cpu_access: CpuAccessGate::new_unlocked(),
+            device_write_pending: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -172,6 +175,7 @@ impl PythonGpuSurfaceHandle {
         minted_surface_id: String,
         surface_store_owing_a_release: Option<SurfaceStore>,
         pixel_buffer: PixelBuffer,
+        gpu_limited_access: Option<GpuContextLimitedAccess>,
     ) -> Self {
         let (width, height, format) = (
             pixel_buffer.width,
@@ -187,24 +191,35 @@ impl PythonGpuSurfaceHandle {
                 GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer),
                 surface_store_owing_a_release,
                 Some(minted_surface_id),
+                gpu_limited_access,
             ),
         )
     }
 
-    fn from_resolved_pixel_buffer(surface_id: String, pixel_buffer: PixelBuffer) -> Self {
+    fn from_resolved_pixel_buffer(
+        surface_id: String,
+        pixel_buffer: PixelBuffer,
+        gpu_limited_access: Option<GpuContextLimitedAccess>,
+    ) -> Self {
         let (width, height, format) = (
             pixel_buffer.width,
             pixel_buffer.height,
             pixel_buffer.format(),
         );
         Self::new(
-            Some(surface_id),
+            Some(surface_id.clone()),
             width,
             height,
             pixel_format_name(format).to_string(),
             // A resolved handle owes no release: it never checked the buffer
-            // in, so releasing would evict somebody else's surface.
-            GpuSurfaceOwnedMemory::new(GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer), None, None),
+            // in, so releasing would evict somebody else's surface. It keeps
+            // the id it resolved by — that id is what keys a device export.
+            GpuSurfaceOwnedMemory::new(
+                GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer),
+                None,
+                Some(surface_id),
+                gpu_limited_access,
+            ),
         )
     }
 
@@ -221,6 +236,7 @@ impl PythonGpuSurfaceHandle {
             texture_format_name(format).to_string(),
             GpuSurfaceOwnedMemory::new(
                 GpuSurfaceOwnedValue::PooledTexture(pooled_texture),
+                None,
                 None,
                 None,
             ),
@@ -332,14 +348,10 @@ impl PythonGpuSurfaceHandle {
     fn lock(&self, python: Python<'_>, read_only: bool) -> PyResult<()> {
         let owned_memory = self.owned_memory()?;
         python.detach(|| -> PyResult<()> {
-            // A device-only surface has no CPU mapping to open, but its
-            // export gate is the same one — so the lock is recorded and
-            // the host accessors refuse on their own terms.
-            if !is_device_exchange(&owned_memory)
-                && owned_memory
-                    .host_mapped_pixel_buffer()?
-                    .plane_base_address(0)
-                    .is_null()
+            if owned_memory
+                .host_mapped_pixel_buffer()?
+                .plane_base_address(0)
+                .is_null()
             {
                 return Err(PyBufferError::new_err(
                     "surface has no host mapping; it is a DEVICE_LOCAL allocation",
@@ -350,11 +362,23 @@ impl PythonGpuSurfaceHandle {
         })
     }
 
-    /// Close CPU access. Idempotent.
+    /// Close CPU access, publishing any pending device-side write back
+    /// into the surface first. Idempotent.
     #[pyo3(signature = (read_only = true))]
-    fn unlock(&self, python: Python<'_>, read_only: bool) {
+    fn unlock(&self, python: Python<'_>, read_only: bool) -> PyResult<()> {
         let _ = read_only;
-        python.detach(|| self.cpu_access.unlock());
+        python.detach(|| -> PyResult<()> {
+            #[cfg(target_os = "linux")]
+            if self
+                .device_write_pending
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+                && let Some(owned_memory) = self.owned_memory.lock().clone()
+            {
+                publish_device_write_back_to_surface(&owned_memory)?;
+            }
+            self.cpu_access.unlock();
+            Ok(())
+        })
     }
 
     /// The DLPack device this surface's tensors live on.
@@ -367,12 +391,22 @@ impl PythonGpuSurfaceHandle {
     fn __dlpack_device__(&self, python: Python<'_>) -> PyResult<(i32, i32)> {
         let owned_memory = self.owned_memory()?;
         #[cfg(target_os = "linux")]
-        if is_device_exchange(&owned_memory) {
-            let device = python.detach(|| imported_device_for(&owned_memory))?;
-            return Ok((device.device_type as i32, device.device_id));
+        if device_export_available(&owned_memory) {
+            // A graph frame's device-resident truth is the GPU, so the device
+            // side is the preferred answer — but a rig without a usable CUDA
+            // runtime falls back to the host mapping rather than erroring a
+            // surface the CPU can serve.
+            match python.detach(|| imported_device_for(&owned_memory)) {
+                Ok(device) => return Ok((device.device_type as i32, device.device_id)),
+                Err(device_unavailable) => {
+                    if owned_memory.host_mapped_pixel_buffer().is_err() {
+                        return Err(device_unavailable);
+                    }
+                }
+            }
         }
         #[cfg(not(target_os = "linux"))]
-        let _ = (python, &owned_memory);
+        let _ = python;
         Ok((
             HOST_VISIBLE_DLPACK_DEVICE.device_type as i32,
             HOST_VISIBLE_DLPACK_DEVICE.device_id,
@@ -414,17 +448,43 @@ impl PythonGpuSurfaceHandle {
 
         // `dl_device` is the consumer's request for a particular side of a
         // surface that has two. Absent means "wherever you naturally live",
-        // which for an exchange buffer is the device it was allocated for.
+        // and a graph frame's natural side is the device — its host mapping
+        // is the derived copy. `__dlpack_device__` is what already told the
+        // consumer which side to expect.
         let wants_host = match dl_device {
             Some((device_type, _)) => device_type == DeviceType::Cpu as i32,
-            None => !is_device_exchange(&owned_memory),
+            None => !device_export_available(&owned_memory),
         };
         if wants_host {
             return host_visible_dlpack_capsule(python, &owned_memory, exchange_shape, read_only);
         }
         #[cfg(target_os = "linux")]
         {
-            device_dlpack_capsule(python, &owned_memory, exchange_shape, read_only)
+            let capsule = device_dlpack_capsule(python, &owned_memory, exchange_shape, read_only);
+            match capsule {
+                Ok(capsule) => {
+                    if !read_only && device_export_writable(&owned_memory) {
+                        self.device_write_pending
+                            .store(true, std::sync::atomic::Ordering::SeqCst);
+                    }
+                    Ok(capsule)
+                }
+                // No usable CUDA runtime, but the CPU can serve this surface:
+                // fall back to the side `__dlpack_device__` would also have
+                // fallen back to, rather than failing a workable export.
+                Err(device_failure) => {
+                    if dl_device.is_none() && owned_memory.host_mapped_pixel_buffer().is_ok() {
+                        host_visible_dlpack_capsule(
+                            python,
+                            &owned_memory,
+                            exchange_shape,
+                            read_only,
+                        )
+                    } else {
+                        Err(device_failure)
+                    }
+                }
+            }
         }
         #[cfg(not(target_os = "linux"))]
         Err(PyValueError::new_err(
@@ -545,6 +605,7 @@ impl PythonGpuContextLimitedAccess {
                 minted_surface_id,
                 surface_store_owing_a_release,
                 pixel_buffer,
+                Some(engine_view.clone()),
             ))
         })
     }
@@ -641,6 +702,7 @@ impl PythonGpuContextLimitedAccess {
             Ok(PythonGpuSurfaceHandle::from_resolved_pixel_buffer(
                 surface_id.to_string(),
                 pixel_buffer,
+                Some(engine_view.clone()),
             ))
         })
     }
@@ -721,10 +783,14 @@ impl PythonGpuContextFullAccess {
                 &pool_id,
                 &pixel_buffer,
             )?;
+            // The full-access view is lease-bound and cannot be stashed, so a
+            // handle acquired here carries no engine capability for device
+            // export — resolve the published id from the limited view instead.
             Ok(PythonGpuSurfaceHandle::from_acquired_pixel_buffer(
                 minted_surface_id,
                 surface_store_owing_a_release,
                 pixel_buffer,
+                None,
             ))
         })
     }
@@ -747,77 +813,6 @@ impl PythonGpuContextFullAccess {
                 .acquire_texture(&descriptor)
                 .map_err(gpu_operation_error)?;
             Ok(PythonGpuSurfaceHandle::from_pooled_texture(pooled_texture))
-        })
-    }
-
-    /// Acquire a buffer whose memory external device code can import.
-    ///
-    /// The engine allocates it OPAQUE_FD-exportable — the handle flavour CUDA
-    /// imports — rather than from the ordinary pixel-buffer pool, whose
-    /// allocations are DMA-BUF-flavoured and have no OPAQUE_FD export path
-    /// under VMA's per-pool memory configuration. `device_local=False` keeps a
-    /// host mapping alongside, so the same bytes serve numpy and CUDA.
-    ///
-    /// Privileged and setup-shaped: allocate once and keep the handle, never
-    /// per frame.
-    #[cfg(target_os = "linux")]
-    #[pyo3(signature = (width, height, format = "bgra", device_local = true))]
-    fn acquire_device_exchange_buffer(
-        &self,
-        python: Python<'_>,
-        width: u32,
-        height: u32,
-        format: &str,
-        device_local: bool,
-    ) -> PyResult<PythonGpuSurfaceHandle> {
-        let pixel_format = parse_pixel_format_name(format)?;
-        let bytes_per_pixel = device_exchange_bytes_per_pixel(pixel_format)?;
-        let byte_size = u64::from(width) * u64::from(height) * u64::from(bytes_per_pixel);
-        if byte_size == 0 {
-            return Err(PyValueError::new_err(
-                "width and height must both be greater than zero",
-            ));
-        }
-        read_gpu_full_access(python, &self.gpu_full_access_source, |gpu_full_access| {
-            let storage_buffer = gpu_full_access
-                .create_opaque_fd_export_buffer(byte_size, device_local)
-                .map_err(gpu_operation_error)?;
-            // One allocation, two views: the pixel-shaped wrapper shares the
-            // storage buffer's `Arc<HostVulkanBuffer>` rather than copying.
-            let pixel_buffer = gpu_full_access
-                .wrap_storage_buffer_as_pixel_buffer(
-                    &storage_buffer,
-                    width,
-                    height,
-                    bytes_per_pixel,
-                    pixel_format,
-                )
-                .map_err(gpu_operation_error)?;
-            // Exported here because exporting is privileged and `__dlpack__`
-            // is not. The fd is consumed by the first CUDA import.
-            let (raw_opaque_fd, exported_size, vulkan_device_uuid) = gpu_full_access
-                .export_storage_buffer_opaque_fd(&storage_buffer)
-                .map_err(gpu_operation_error)?;
-            // SAFETY: the export hands over a fresh dup'd fd that nothing
-            // else holds, so adopting it here is the only ownership claim.
-            let opaque_fd = unsafe { OwnedFd::from_raw_fd(raw_opaque_fd) };
-            Ok(PythonGpuSurfaceHandle::new(
-                None,
-                width,
-                height,
-                pixel_format_name(pixel_format).to_string(),
-                GpuSurfaceOwnedMemory::new(
-                    GpuSurfaceOwnedValue::DeviceExchange(DeviceExchangeBuffer::new(
-                        pixel_buffer,
-                        device_local,
-                        opaque_fd,
-                        exported_size,
-                        vulkan_device_uuid,
-                    )),
-                    None,
-                    None,
-                ),
-            ))
         })
     }
 
@@ -886,6 +881,7 @@ impl PythonGpuContextFullAccess {
                 pixel_format_name(pixel_format).to_string(),
                 GpuSurfaceOwnedMemory::new(
                     GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer),
+                    None,
                     None,
                     None,
                 ),

--- a/sdk/streamlib-python-wheel/src/python_processor_context.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_context.rs
@@ -18,7 +18,7 @@ use std::ptr::NonNull;
 use std::sync::{Arc, OnceLock};
 
 use parking_lot::{Mutex, RwLock};
-use pyo3::exceptions::{PyNotImplementedError, PyRuntimeError, PyValueError};
+use pyo3::exceptions::{PyBufferError, PyNotImplementedError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use streamlib::sdk::context::{
@@ -30,6 +30,10 @@ use streamlib::sdk::rhi::{
 };
 
 use crate::python_bag_conversion::json_value_to_python_object;
+use crate::python_gpu_surface_pixel_exchange::{
+    CpuAccessGate, GpuSurfaceOwnedMemory, GpuSurfaceOwnedValue, HOST_VISIBLE_DLPACK_DEVICE,
+    exchange_shape_for_max_version, host_visible_dlpack_capsule, pixel_buffer_bytes_per_row,
+};
 use crate::python_logging::monotonic_clock_now_ns;
 use crate::python_processor_link_data_access::PythonProcessorLinkDataAccess;
 
@@ -118,94 +122,128 @@ fn read_limited_access_view<T: Send>(
 // GPU surface handle
 // =============================================================================
 
-// Owned purely so Drop releases the underlying resource on close; the first
-// read access lands with the pixel-exchange surface (#1710).
-#[expect(dead_code)]
-enum GpuSurfaceHandleValue {
-    OwnedPixelBuffer(PixelBuffer),
-    OwnedPooledTexture(PooledTextureHandle),
-}
-
 /// An owned GPU surface as seen from Python.
 ///
 /// Owning the engine value (rather than an id to re-resolve) is what keeps a
 /// pool slot or a pooled texture alive until `close()` / the context manager
-/// releases it.
+/// releases it. The value itself sits behind an `Arc` shared with every DLPack
+/// capsule minted from this handle, so a tensor Python is still holding keeps
+/// the memory addressable after the handle is closed.
 #[pyclass(name = "GpuSurfaceHandle", module = "streamlib", frozen)]
 pub(crate) struct PythonGpuSurfaceHandle {
     /// `None` for pooled textures — see [`Self::surface_id`].
     minted_surface_id: Option<String>,
-    /// Present only on a handle whose acquire checked the buffer into the
-    /// surface store. The check-in parks a strong clone in the store, so the
-    /// pool slot comes back only if release evicts it — a handle that skips
-    /// this pins its slot for the store's lifetime, and a resolved handle
-    /// must never release somebody else's surface.
-    surface_store_owing_a_release: Option<SurfaceStore>,
     surface_width: u32,
     surface_height: u32,
     surface_format_name: String,
-    owned_value: Mutex<Option<GpuSurfaceHandleValue>>,
+    owned_memory: Mutex<Option<Arc<GpuSurfaceOwnedMemory>>>,
+    cpu_access: CpuAccessGate,
 }
 
 impl PythonGpuSurfaceHandle {
+    fn new(
+        minted_surface_id: Option<String>,
+        surface_width: u32,
+        surface_height: u32,
+        surface_format_name: String,
+        owned_memory: Arc<GpuSurfaceOwnedMemory>,
+    ) -> Self {
+        Self {
+            minted_surface_id,
+            surface_width,
+            surface_height,
+            surface_format_name,
+            owned_memory: Mutex::new(Some(owned_memory)),
+            cpu_access: CpuAccessGate::new_unlocked(),
+        }
+    }
+
     fn from_acquired_pixel_buffer(
         minted_surface_id: String,
         surface_store_owing_a_release: Option<SurfaceStore>,
         pixel_buffer: PixelBuffer,
     ) -> Self {
-        Self {
-            minted_surface_id: Some(minted_surface_id),
-            surface_store_owing_a_release,
-            surface_width: pixel_buffer.width,
-            surface_height: pixel_buffer.height,
-            surface_format_name: pixel_format_name(pixel_buffer.format()).to_string(),
-            owned_value: Mutex::new(Some(GpuSurfaceHandleValue::OwnedPixelBuffer(pixel_buffer))),
-        }
+        let (width, height, format) = (
+            pixel_buffer.width,
+            pixel_buffer.height,
+            pixel_buffer.format(),
+        );
+        Self::new(
+            Some(minted_surface_id.clone()),
+            width,
+            height,
+            pixel_format_name(format).to_string(),
+            GpuSurfaceOwnedMemory::new(
+                GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer),
+                surface_store_owing_a_release,
+                Some(minted_surface_id),
+            ),
+        )
     }
 
     fn from_resolved_pixel_buffer(surface_id: String, pixel_buffer: PixelBuffer) -> Self {
-        Self {
-            minted_surface_id: Some(surface_id),
-            surface_store_owing_a_release: None,
-            surface_width: pixel_buffer.width,
-            surface_height: pixel_buffer.height,
-            surface_format_name: pixel_format_name(pixel_buffer.format()).to_string(),
-            owned_value: Mutex::new(Some(GpuSurfaceHandleValue::OwnedPixelBuffer(pixel_buffer))),
-        }
+        let (width, height, format) = (
+            pixel_buffer.width,
+            pixel_buffer.height,
+            pixel_buffer.format(),
+        );
+        Self::new(
+            Some(surface_id),
+            width,
+            height,
+            pixel_format_name(format).to_string(),
+            // A resolved handle owes no release: it never checked the buffer
+            // in, so releasing would evict somebody else's surface.
+            GpuSurfaceOwnedMemory::new(
+                GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer),
+                None,
+                None,
+            ),
+        )
     }
 
     fn from_pooled_texture(pooled_texture: PooledTextureHandle) -> Self {
-        Self {
-            minted_surface_id: None,
-            surface_store_owing_a_release: None,
-            surface_width: pooled_texture.width(),
-            surface_height: pooled_texture.height(),
-            surface_format_name: texture_format_name(pooled_texture.format()).to_string(),
-            owned_value: Mutex::new(Some(GpuSurfaceHandleValue::OwnedPooledTexture(
-                pooled_texture,
-            ))),
-        }
+        let (width, height, format) = (
+            pooled_texture.width(),
+            pooled_texture.height(),
+            pooled_texture.format(),
+        );
+        Self::new(
+            None,
+            width,
+            height,
+            texture_format_name(format).to_string(),
+            GpuSurfaceOwnedMemory::new(
+                GpuSurfaceOwnedValue::PooledTexture(pooled_texture),
+                None,
+                None,
+            ),
+        )
     }
 
-    /// Release the owned engine value and settle the check-in debt. Runs on
-    /// `close()` (detached) and on garbage collection; idempotent.
+    /// Drop this handle's share of the owned memory. The engine resource goes
+    /// away once the last outstanding DLPack capsule does too; idempotent.
     fn release_owned_engine_value(&self) {
-        let taken_value = self.owned_value.lock().take();
-        if taken_value.is_none() {
-            return;
+        drop(self.owned_memory.lock().take());
+    }
+
+    /// Borrow the shared memory anchor, or fail if the handle is closed.
+    fn owned_memory(&self) -> PyResult<Arc<GpuSurfaceOwnedMemory>> {
+        self.owned_memory.lock().clone().ok_or_else(|| {
+            PyRuntimeError::new_err("this surface is closed; acquire or resolve it again")
+        })
+    }
+
+    fn pixel_buffer_only(
+        owned_memory: &Arc<GpuSurfaceOwnedMemory>,
+    ) -> PyResult<&'_ PixelBuffer> {
+        match owned_memory.owned_value() {
+            GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer) => Ok(pixel_buffer),
+            GpuSurfaceOwnedValue::PooledTexture(_) => Err(PyNotImplementedError::new_err(
+                "this surface is a pooled texture: its pixels are device-local, so CPU access \
+                 goes through the texture export path rather than a host mapping",
+            )),
         }
-        if let (Some(store), Some(surface_id)) = (
-            self.surface_store_owing_a_release.as_ref(),
-            self.minted_surface_id.as_ref(),
-        ) {
-            // Best-effort, mirroring the subprocess release path: the store
-            // eviction is what frees the pool slot; the daemon half already
-            // treats a dropped connection as a full release.
-            if let Err(release_failure) = store.release(surface_id) {
-                tracing::debug!(%surface_id, %release_failure, "surface-store release failed");
-            }
-        }
-        drop(taken_value);
     }
 }
 
@@ -218,23 +256,17 @@ impl Drop for PythonGpuSurfaceHandle {
     }
 }
 
-fn pixel_exchange_not_yet_implemented_error() -> PyErr {
-    PyNotImplementedError::new_err(
-        "the pixel-exchange surface lands with ticket #1710 (DLPack first, DMA-BUF, numpy fallback)",
-    )
-}
-
 #[pymethods]
 impl PythonGpuSurfaceHandle {
     /// The id downstream processors resolve this surface by.
     #[getter]
     fn surface_id(&self) -> PyResult<String> {
-        // Pooled textures carry no id yet: surface-share registration for a
-        // texture needs host timeline semaphores, which ride the
-        // pixel-exchange work.
-        self.minted_surface_id
-            .clone()
-            .ok_or_else(pixel_exchange_not_yet_implemented_error)
+        self.minted_surface_id.clone().ok_or_else(|| {
+            PyNotImplementedError::new_err(
+                "this pooled texture carries no surface id: publishing one registers it with the \
+                 surface store, which a texture acquire does not do",
+            )
+        })
     }
 
     #[getter]
@@ -252,12 +284,36 @@ impl PythonGpuSurfaceHandle {
         self.surface_format_name.clone()
     }
 
+    /// Row pitch in bytes, including any padding the allocation carries.
+    #[getter]
+    fn bytes_per_row(&self, python: Python<'_>) -> PyResult<u64> {
+        let owned_memory = self.owned_memory()?;
+        python.detach(|| pixel_buffer_bytes_per_row(Self::pixel_buffer_only(&owned_memory)?))
+    }
+
+    /// Base address of the host mapping, or `0` when the surface is not
+    /// locked. Callers that want a typed view use `as_numpy` or `__dlpack__`;
+    /// this is the escape hatch for building one by hand.
+    #[getter]
+    fn base_address(&self, python: Python<'_>) -> PyResult<usize> {
+        if !self.cpu_access.is_locked() {
+            return Ok(0);
+        }
+        let owned_memory = self.owned_memory()?;
+        python.detach(|| {
+            Ok(Self::pixel_buffer_only(&owned_memory)?.plane_base_address(0) as usize)
+        })
+    }
+
     /// Release the underlying GPU resource. Idempotent.
     fn close(&self, python: Python<'_>) {
         // Releasing can return a slot to a pool under engine locks and talk to
         // the surface-share daemon — detached, like every potentially-blocking
         // engine call.
-        python.detach(|| self.release_owned_engine_value());
+        python.detach(|| {
+            self.cpu_access.unlock();
+            self.release_owned_engine_value();
+        });
     }
 
     fn __enter__(python_self: PyRef<'_, Self>) -> PyRef<'_, Self> {
@@ -270,20 +326,94 @@ impl PythonGpuSurfaceHandle {
         false
     }
 
-    fn as_numpy(&self) -> PyResult<()> {
-        Err(pixel_exchange_not_yet_implemented_error())
+    /// Open CPU access to the pixels, waiting for the producer to finish
+    /// writing them first.
+    #[pyo3(signature = (read_only = true))]
+    fn lock(&self, python: Python<'_>, read_only: bool) -> PyResult<()> {
+        let owned_memory = self.owned_memory()?;
+        python.detach(|| -> PyResult<()> {
+            let pixel_buffer = Self::pixel_buffer_only(&owned_memory)?;
+            if pixel_buffer.plane_base_address(0).is_null() {
+                return Err(PyBufferError::new_err(
+                    "surface has no host mapping; it is a DEVICE_LOCAL allocation",
+                ));
+            }
+            self.cpu_access.lock_for(read_only);
+            Ok(())
+        })
     }
 
-    fn __dlpack__(&self) -> PyResult<()> {
-        Err(pixel_exchange_not_yet_implemented_error())
+    /// Close CPU access. Idempotent.
+    #[pyo3(signature = (read_only = true))]
+    fn unlock(&self, python: Python<'_>, read_only: bool) {
+        let _ = read_only;
+        python.detach(|| self.cpu_access.unlock());
     }
 
-    fn lock(&self) -> PyResult<()> {
-        Err(pixel_exchange_not_yet_implemented_error())
+    /// The DLPack device this surface's tensors live on.
+    fn __dlpack_device__(&self) -> (i32, i32) {
+        (
+            HOST_VISIBLE_DLPACK_DEVICE.device_type as i32,
+            HOST_VISIBLE_DLPACK_DEVICE.device_id,
+        )
     }
 
-    fn unlock(&self) -> PyResult<()> {
-        Err(pixel_exchange_not_yet_implemented_error())
+    /// A DLPack capsule over the pixels — what `torch.from_dlpack` and
+    /// `numpy.from_dlpack` consume.
+    ///
+    /// The tensor may outlive this handle: it holds its own share of the
+    /// surface, so the pool slot is not reused until the tensor is released.
+    /// A consumer that negotiates `max_version >= (1, 0)` gets the versioned
+    /// exchange shape, which is the only one that can report the surface as
+    /// writable.
+    #[pyo3(signature = (stream = None, max_version = None, dl_device = None, copy = None))]
+    fn __dlpack__<'py>(
+        &self,
+        python: Python<'py>,
+        stream: Option<&Bound<'py, PyAny>>,
+        max_version: Option<(u32, u32)>,
+        dl_device: Option<&Bound<'py, PyAny>>,
+        copy: Option<bool>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        // Host-visible memory has no stream to order against. The other two
+        // are refused rather than ignored: silently exporting in place when a
+        // consumer asked for a copy or a different device would hand back a
+        // tensor aliasing memory it believes it owns.
+        let _ = stream;
+        if dl_device.is_some() {
+            return Err(PyValueError::new_err(
+                "this surface exports where it already lives; it cannot move to another device",
+            ));
+        }
+        if copy == Some(true) {
+            return Err(PyValueError::new_err(
+                "this surface exports in place; ask the consumer to copy the tensor instead",
+            ));
+        }
+        self.cpu_access.require_locked()?;
+        let owned_memory = self.owned_memory()?;
+        host_visible_dlpack_capsule(
+            python,
+            &owned_memory,
+            exchange_shape_for_max_version(max_version),
+            self.cpu_access.is_read_only(),
+        )
+    }
+
+    /// A numpy view of the pixels, sharing memory with the surface.
+    ///
+    /// `(height, width, channels)` `uint8` for the 8-bit formats, with the
+    /// allocation's row pitch preserved in the strides.
+    fn as_numpy<'py>(python_self: &Bound<'py, Self>) -> PyResult<Bound<'py, PyAny>> {
+        let python = python_self.py();
+        // Imported lazily so the wheel never takes a numpy dependency: a user
+        // reaching for a numpy view already has numpy.
+        let numpy = python.import("numpy").map_err(|_| {
+            PyRuntimeError::new_err("as_numpy needs numpy installed; `__dlpack__` works without it")
+        })?;
+        // `from_dlpack` consumes the exporting object and calls `__dlpack__`
+        // on it, so there is exactly one export path.
+        numpy.call_method1("from_dlpack", (python_self,))
     }
 }
 

--- a/sdk/streamlib-python-wheel/src/python_processor_context.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_context.rs
@@ -314,8 +314,9 @@ impl PythonGpuSurfaceHandle {
     fn surface_id(&self) -> PyResult<String> {
         self.minted_surface_id.clone().ok_or_else(|| {
             PyNotImplementedError::new_err(
-                "this pooled texture carries no surface id: publishing one registers it with the \
-                 surface store, which a texture acquire does not do",
+                "this surface carries no id: handles minted through the lease-bound full-access \
+                 capability or a raw DMA-BUF import are not registered anywhere a consumer \
+                 could resolve them",
             )
         })
     }
@@ -368,10 +369,16 @@ impl PythonGpuSurfaceHandle {
         // context-manager spelling reaches close without an explicit
         // unlock, and dropping the edit silently there is data loss.
         python.detach(|| -> PyResult<()> {
+            // A failed publish must not skip the release: the handle would
+            // stay open with its pool slot pinned, in the exact spelling
+            // (`with` → close) users write. Clean up, then surface the
+            // failure.
             #[cfg(target_os = "linux")]
-            self.publish_pending_device_write()?;
+            let publish_outcome = self.publish_pending_device_write();
             self.cpu_access.unlock();
             self.release_owned_engine_value();
+            #[cfg(target_os = "linux")]
+            publish_outcome?;
             Ok(())
         })
     }
@@ -426,9 +433,15 @@ impl PythonGpuSurfaceHandle {
     /// into the surface first. Idempotent.
     fn unlock(&self, python: Python<'_>) -> PyResult<()> {
         python.detach(|| -> PyResult<()> {
+            // The gate opens whether or not the publish succeeded — a
+            // surface left locked after a failed publish would refuse
+            // every later access with a message about locking, hiding
+            // the real failure this raises.
             #[cfg(target_os = "linux")]
-            self.publish_pending_device_write()?;
+            let publish_outcome = self.publish_pending_device_write();
             self.cpu_access.unlock();
+            #[cfg(target_os = "linux")]
+            publish_outcome?;
             Ok(())
         })
     }
@@ -442,20 +455,13 @@ impl PythonGpuSurfaceHandle {
     /// here would contradict the capsule `__dlpack__` goes on to hand back.
     fn __dlpack_device__(&self, python: Python<'_>) -> PyResult<(i32, i32)> {
         let owned_memory = self.owned_memory()?;
+        // Routed through the same once-per-handle decision `__dlpack__`
+        // serves, so a probe failure here (answered CPU) cannot be
+        // followed by a successful device capsule there.
         #[cfg(target_os = "linux")]
-        if device_export_available(&owned_memory) {
-            // A graph frame's device-resident truth is the GPU, so the device
-            // side is the preferred answer — but a rig without a usable CUDA
-            // runtime falls back to the host mapping rather than erroring a
-            // surface the CPU can serve.
-            match python.detach(|| imported_device_for(&owned_memory)) {
-                Ok(device) => return Ok((device.device_type as i32, device.device_id)),
-                Err(device_unavailable) => {
-                    if owned_memory.host_mapped_pixel_buffer().is_err() {
-                        return Err(device_unavailable);
-                    }
-                }
-            }
+        if python.detach(|| self.natural_side_is_device(&owned_memory)) {
+            let device = python.detach(|| imported_device_for(&owned_memory))?;
+            return Ok((device.device_type as i32, device.device_id));
         }
         #[cfg(not(target_os = "linux"))]
         let _ = python;
@@ -489,7 +495,7 @@ impl PythonGpuSurfaceHandle {
         // asked for a copy hands back a tensor aliasing memory it believes it
         // owns, and the aliasing shows up much later as corruption.
         if copy == Some(true) {
-            return Err(PyValueError::new_err(
+            return Err(PyBufferError::new_err(
                 "this surface exports in place; ask the consumer to copy the tensor instead",
             ));
         }
@@ -917,7 +923,7 @@ impl PythonGpuContextFullAccess {
     /// must not be closed afterwards. On failure the fd is still the
     /// caller's.
     #[cfg(target_os = "linux")]
-    #[pyo3(signature = (fd, width, height, format = "bgra"))]
+    #[pyo3(signature = (fd, width, height, format = "bgra", byte_size = None))]
     fn import_dma_buf(
         &self,
         python: Python<'_>,
@@ -925,10 +931,14 @@ impl PythonGpuContextFullAccess {
         width: u32,
         height: u32,
         format: &str,
+        byte_size: Option<u64>,
     ) -> PyResult<PythonGpuSurfaceHandle> {
         let pixel_format = parse_pixel_format_name(format)?;
         let bytes_per_pixel = device_exchange_bytes_per_pixel(pixel_format)?;
-        let byte_size = u64::from(width) * u64::from(height) * u64::from(bytes_per_pixel);
+        // `export_dma_buf` reports the allocation's real size; passing it
+        // back accepts a padded row pitch the tight product would refuse.
+        let byte_size = byte_size
+            .unwrap_or_else(|| u64::from(width) * u64::from(height) * u64::from(bytes_per_pixel));
         if byte_size == 0 {
             return Err(PyValueError::new_err(
                 "width and height must both be greater than zero",

--- a/sdk/streamlib-python-wheel/src/python_processor_context.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_context.rs
@@ -18,7 +18,9 @@ use std::ptr::NonNull;
 use std::sync::{Arc, OnceLock};
 
 use parking_lot::{Mutex, RwLock};
-use pyo3::exceptions::{PyBufferError, PyNotImplementedError, PyRuntimeError, PyValueError};
+use pyo3::exceptions::{
+    PyBufferError, PyNotImplementedError, PyRuntimeError, PyTypeError, PyValueError,
+};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use streamlib::sdk::context::{
@@ -28,12 +30,16 @@ use streamlib::sdk::context::{
 use streamlib::sdk::rhi::{
     PixelBuffer, PixelBufferPoolId, PixelFormat, TextureFormat, TextureUsages,
 };
+use streamlib_adapter_cuda::dlpack::DeviceType;
 
 use crate::python_bag_conversion::json_value_to_python_object;
 use crate::python_gpu_surface_pixel_exchange::{
-    CpuAccessGate, GpuSurfaceOwnedMemory, GpuSurfaceOwnedValue, HOST_VISIBLE_DLPACK_DEVICE,
-    exchange_shape_for_max_version, host_visible_dlpack_capsule, pixel_buffer_bytes_per_row,
+    CpuAccessGate, DeviceExchangeBuffer, GpuSurfaceOwnedMemory, GpuSurfaceOwnedValue,
+    HOST_VISIBLE_DLPACK_DEVICE, exchange_shape_for_max_version, host_visible_dlpack_capsule,
+    is_device_exchange, pixel_buffer_bytes_per_row,
 };
+#[cfg(target_os = "linux")]
+use crate::python_gpu_surface_pixel_exchange::{device_dlpack_capsule, imported_device_for};
 use crate::python_logging::monotonic_clock_now_ns;
 use crate::python_processor_link_data_access::PythonProcessorLinkDataAccess;
 
@@ -234,17 +240,6 @@ impl PythonGpuSurfaceHandle {
         })
     }
 
-    fn pixel_buffer_only(
-        owned_memory: &Arc<GpuSurfaceOwnedMemory>,
-    ) -> PyResult<&'_ PixelBuffer> {
-        match owned_memory.owned_value() {
-            GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer) => Ok(pixel_buffer),
-            GpuSurfaceOwnedValue::PooledTexture(_) => Err(PyNotImplementedError::new_err(
-                "this surface is a pooled texture: its pixels are device-local, so CPU access \
-                 goes through the texture export path rather than a host mapping",
-            )),
-        }
-    }
 }
 
 impl Drop for PythonGpuSurfaceHandle {
@@ -288,7 +283,7 @@ impl PythonGpuSurfaceHandle {
     #[getter]
     fn bytes_per_row(&self, python: Python<'_>) -> PyResult<u64> {
         let owned_memory = self.owned_memory()?;
-        python.detach(|| pixel_buffer_bytes_per_row(Self::pixel_buffer_only(&owned_memory)?))
+        python.detach(|| pixel_buffer_bytes_per_row(owned_memory.host_mapped_pixel_buffer()?))
     }
 
     /// Base address of the host mapping, or `0` when the surface is not
@@ -301,7 +296,7 @@ impl PythonGpuSurfaceHandle {
         }
         let owned_memory = self.owned_memory()?;
         python.detach(|| {
-            Ok(Self::pixel_buffer_only(&owned_memory)?.plane_base_address(0) as usize)
+            Ok(owned_memory.host_mapped_pixel_buffer()?.plane_base_address(0) as usize)
         })
     }
 
@@ -332,8 +327,15 @@ impl PythonGpuSurfaceHandle {
     fn lock(&self, python: Python<'_>, read_only: bool) -> PyResult<()> {
         let owned_memory = self.owned_memory()?;
         python.detach(|| -> PyResult<()> {
-            let pixel_buffer = Self::pixel_buffer_only(&owned_memory)?;
-            if pixel_buffer.plane_base_address(0).is_null() {
+            // A device-only surface has no CPU mapping to open, but its
+            // export gate is the same one — so the lock is recorded and
+            // the host accessors refuse on their own terms.
+            if !is_device_exchange(&owned_memory)
+                && owned_memory
+                    .host_mapped_pixel_buffer()?
+                    .plane_base_address(0)
+                    .is_null()
+            {
                 return Err(PyBufferError::new_err(
                     "surface has no host mapping; it is a DEVICE_LOCAL allocation",
                 ));
@@ -351,11 +353,25 @@ impl PythonGpuSurfaceHandle {
     }
 
     /// The DLPack device this surface's tensors live on.
-    fn __dlpack_device__(&self) -> (i32, i32) {
-        (
+    ///
+    /// A device-exchange surface answers with the CUDA device its memory is
+    /// imported onto, performing the import if it has not happened yet — the
+    /// driver's classification of the pointer is what distinguishes true
+    /// device memory from a downgrade to pinned host memory, and guessing
+    /// here would contradict the capsule `__dlpack__` goes on to hand back.
+    fn __dlpack_device__(&self, python: Python<'_>) -> PyResult<(i32, i32)> {
+        let owned_memory = self.owned_memory()?;
+        #[cfg(target_os = "linux")]
+        if is_device_exchange(&owned_memory) {
+            let device = python.detach(|| imported_device_for(&owned_memory))?;
+            return Ok((device.device_type as i32, device.device_id));
+        }
+        #[cfg(not(target_os = "linux"))]
+        let _ = (python, &owned_memory);
+        Ok((
             HOST_VISIBLE_DLPACK_DEVICE.device_type as i32,
             HOST_VISIBLE_DLPACK_DEVICE.device_id,
-        )
+        ))
     }
 
     /// A DLPack capsule over the pixels — what `torch.from_dlpack` and
@@ -372,19 +388,15 @@ impl PythonGpuSurfaceHandle {
         python: Python<'py>,
         stream: Option<&Bound<'py, PyAny>>,
         max_version: Option<(u32, u32)>,
-        dl_device: Option<&Bound<'py, PyAny>>,
+        dl_device: Option<(i32, i32)>,
         copy: Option<bool>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        // Host-visible memory has no stream to order against. The other two
-        // are refused rather than ignored: silently exporting in place when a
-        // consumer asked for a copy or a different device would hand back a
-        // tensor aliasing memory it believes it owns.
+        // No stream to order against: the host mapping is CPU memory, and the
+        // device path's ordering is the lock, not a CUDA stream.
         let _ = stream;
-        if dl_device.is_some() {
-            return Err(PyValueError::new_err(
-                "this surface exports where it already lives; it cannot move to another device",
-            ));
-        }
+        // Refused rather than ignored — exporting in place when the consumer
+        // asked for a copy hands back a tensor aliasing memory it believes it
+        // owns, and the aliasing shows up much later as corruption.
         if copy == Some(true) {
             return Err(PyValueError::new_err(
                 "this surface exports in place; ask the consumer to copy the tensor instead",
@@ -392,12 +404,32 @@ impl PythonGpuSurfaceHandle {
         }
         self.cpu_access.require_locked()?;
         let owned_memory = self.owned_memory()?;
-        host_visible_dlpack_capsule(
-            python,
-            &owned_memory,
-            exchange_shape_for_max_version(max_version),
-            self.cpu_access.is_read_only(),
-        )
+        let exchange_shape = exchange_shape_for_max_version(max_version);
+        let read_only = self.cpu_access.is_read_only();
+
+        // `dl_device` is the consumer's request for a particular side of a
+        // surface that has two. Absent means "wherever you naturally live",
+        // which for an exchange buffer is the device it was allocated for.
+        let wants_host = match dl_device {
+            Some((device_type, _)) => device_type == DeviceType::Cpu as i32,
+            None => !is_device_exchange(&owned_memory),
+        };
+        if wants_host {
+            return host_visible_dlpack_capsule(
+                python,
+                &owned_memory,
+                exchange_shape,
+                read_only,
+            );
+        }
+        #[cfg(target_os = "linux")]
+        {
+            device_dlpack_capsule(python, &owned_memory, exchange_shape, read_only)
+        }
+        #[cfg(not(target_os = "linux"))]
+        Err(PyValueError::new_err(
+            "device export is available on Linux only",
+        ))
     }
 
     /// A numpy view of the pixels, sharing memory with the surface.
@@ -412,8 +444,24 @@ impl PythonGpuSurfaceHandle {
             PyRuntimeError::new_err("as_numpy needs numpy installed; `__dlpack__` works without it")
         })?;
         // `from_dlpack` consumes the exporting object and calls `__dlpack__`
-        // on it, so there is exactly one export path.
-        numpy.call_method1("from_dlpack", (python_self,))
+        // on it, so there is exactly one export path. `device="cpu"` is not
+        // decoration: an exchange surface's natural side is the GPU, and
+        // without the request numpy would be handed a device pointer and
+        // refuse it.
+        let host_request = pyo3::types::PyDict::new(python);
+        host_request.set_item("device", "cpu")?;
+        numpy
+            .call_method("from_dlpack", (python_self,), Some(&host_request))
+            .map_err(|from_dlpack_failure| {
+                if from_dlpack_failure.is_instance_of::<PyTypeError>(python) {
+                    return PyRuntimeError::new_err(
+                        "as_numpy needs numpy 2.1 or newer, whose `from_dlpack` accepts a \
+                         `device` request; older numpy cannot ask for the host side of a \
+                         surface",
+                    );
+                }
+                from_dlpack_failure
+            })
     }
 }
 
@@ -699,6 +747,74 @@ impl PythonGpuContextFullAccess {
                 .acquire_texture(&descriptor)
                 .map_err(gpu_operation_error)?;
             Ok(PythonGpuSurfaceHandle::from_pooled_texture(pooled_texture))
+        })
+    }
+
+    /// Acquire a buffer whose memory external device code can import.
+    ///
+    /// The engine allocates it OPAQUE_FD-exportable — the handle flavour CUDA
+    /// imports — rather than from the ordinary pixel-buffer pool, whose
+    /// allocations are DMA-BUF-flavoured and have no OPAQUE_FD export path
+    /// under VMA's per-pool memory configuration. `device_local=False` keeps a
+    /// host mapping alongside, so the same bytes serve numpy and CUDA.
+    ///
+    /// Privileged and setup-shaped: allocate once and keep the handle, never
+    /// per frame.
+    #[cfg(target_os = "linux")]
+    #[pyo3(signature = (width, height, format = "bgra", device_local = true))]
+    fn acquire_device_exchange_buffer(
+        &self,
+        python: Python<'_>,
+        width: u32,
+        height: u32,
+        format: &str,
+        device_local: bool,
+    ) -> PyResult<PythonGpuSurfaceHandle> {
+        let pixel_format = parse_pixel_format_name(format)?;
+        let bytes_per_pixel = device_exchange_bytes_per_pixel(pixel_format)?;
+        let byte_size = u64::from(width) * u64::from(height) * u64::from(bytes_per_pixel);
+        if byte_size == 0 {
+            return Err(PyValueError::new_err(
+                "width and height must both be greater than zero",
+            ));
+        }
+        read_gpu_full_access(python, &self.gpu_full_access_source, |gpu_full_access| {
+            let storage_buffer = gpu_full_access
+                .create_opaque_fd_export_buffer(byte_size, device_local)
+                .map_err(gpu_operation_error)?;
+            // One allocation, two views: the pixel-shaped wrapper shares the
+            // storage buffer's `Arc<HostVulkanBuffer>` rather than copying.
+            let pixel_buffer = gpu_full_access
+                .wrap_storage_buffer_as_pixel_buffer(
+                    &storage_buffer,
+                    width,
+                    height,
+                    bytes_per_pixel,
+                    pixel_format,
+                )
+                .map_err(gpu_operation_error)?;
+            // Exported here because exporting is privileged and `__dlpack__`
+            // is not. The fd is consumed by the first CUDA import.
+            let (opaque_fd, exported_size, vulkan_device_uuid) = gpu_full_access
+                .export_storage_buffer_opaque_fd(&storage_buffer)
+                .map_err(gpu_operation_error)?;
+            Ok(PythonGpuSurfaceHandle::new(
+                None,
+                width,
+                height,
+                pixel_format_name(pixel_format).to_string(),
+                GpuSurfaceOwnedMemory::new(
+                    GpuSurfaceOwnedValue::DeviceExchange(DeviceExchangeBuffer::new(
+                        pixel_buffer,
+                        device_local,
+                        opaque_fd,
+                        exported_size,
+                        vulkan_device_uuid,
+                    )),
+                    None,
+                    None,
+                ),
+            ))
         })
     }
 
@@ -1117,6 +1233,24 @@ fn texture_format_name(format: TextureFormat) -> &'static str {
         TextureFormat::Rgba16Float => "rgba16_float",
         TextureFormat::Rgba32Float => "rgba32_float",
         TextureFormat::Nv12 => "nv12",
+    }
+}
+
+/// Bytes per pixel for the formats a device-exchange buffer can carry.
+///
+/// Restricted to the single-plane formats deliberately: the allocation is a
+/// flat buffer sized `width * height * bytes_per_pixel`, and a multi-plane
+/// format has no single such size.
+fn device_exchange_bytes_per_pixel(format: PixelFormat) -> PyResult<u32> {
+    match format {
+        PixelFormat::Bgra32 | PixelFormat::Rgba32 | PixelFormat::Argb32 => Ok(4),
+        PixelFormat::Rgba64 => Ok(8),
+        PixelFormat::Gray8 => Ok(1),
+        PixelFormat::Yuyv422 | PixelFormat::Uyvy422 => Ok(2),
+        multi_plane_or_unknown => Err(PyValueError::new_err(format!(
+            "pixel format {multi_plane_or_unknown:?} has no flat device-exchange size: a \
+             device-exchange buffer is one linear allocation, which a multi-plane format is not"
+        ))),
     }
 }
 

--- a/sdk/streamlib-python-wheel/src/python_processor_context.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_context.rs
@@ -28,7 +28,7 @@ use streamlib::sdk::context::{
     RuntimeContextLimitedAccess, SurfaceStore, TexturePoolDescriptor,
 };
 use streamlib::sdk::rhi::{
-    PixelBuffer, PixelBufferPoolId, PixelFormat, TextureFormat, TextureUsages,
+    PixelBuffer, PixelBufferPoolId, PixelFormat, TextureFormat, TextureUsages, VulkanLayout,
 };
 use streamlib_adapter_cuda::dlpack::DeviceType;
 
@@ -40,7 +40,7 @@ use crate::python_gpu_surface_pixel_exchange::{
 };
 #[cfg(target_os = "linux")]
 use crate::python_gpu_surface_pixel_exchange::{
-    device_dlpack_capsule, device_export_writable, imported_device_for,
+    device_dlpack_capsule, imported_device_for, prepare_device_export,
     publish_device_write_back_to_surface,
 };
 use crate::python_logging::monotonic_clock_now_ns;
@@ -148,8 +148,15 @@ pub(crate) struct PythonGpuSurfaceHandle {
     owned_memory: Mutex<Option<Arc<GpuSurfaceOwnedMemory>>>,
     cpu_access: CpuAccessGate,
     /// A writable device tensor was exported under the current write
-    /// lock; `unlock()` publishes the staging back into the surface.
+    /// lock; `unlock()` / `close()` publishes the staging back into the
+    /// surface.
+    #[cfg(target_os = "linux")]
     device_write_pending: std::sync::atomic::AtomicBool,
+    /// Which DLPack side this handle serves when the consumer expresses
+    /// no preference — decided once, so `__dlpack_device__` and
+    /// `__dlpack__` cannot disagree across calls.
+    #[cfg(target_os = "linux")]
+    natural_dlpack_side_is_device: std::sync::OnceLock<bool>,
 }
 
 impl PythonGpuSurfaceHandle {
@@ -167,7 +174,10 @@ impl PythonGpuSurfaceHandle {
             surface_format_name,
             owned_memory: Mutex::new(Some(owned_memory)),
             cpu_access: CpuAccessGate::new_unlocked(),
+            #[cfg(target_os = "linux")]
             device_write_pending: std::sync::atomic::AtomicBool::new(false),
+            #[cfg(target_os = "linux")]
+            natural_dlpack_side_is_device: std::sync::OnceLock::new(),
         }
     }
 
@@ -223,22 +233,25 @@ impl PythonGpuSurfaceHandle {
         )
     }
 
-    fn from_pooled_texture(pooled_texture: PooledTextureHandle) -> Self {
+    fn from_pooled_texture(
+        pooled_texture: PooledTextureHandle,
+        registered_surface_id: Option<String>,
+        gpu_limited_access: Option<GpuContextLimitedAccess>,
+    ) -> Self {
         let (width, height, format) = (
             pooled_texture.width(),
             pooled_texture.height(),
             pooled_texture.format(),
         );
         Self::new(
-            None,
+            registered_surface_id.clone(),
             width,
             height,
             texture_format_name(format).to_string(),
-            GpuSurfaceOwnedMemory::new(
+            GpuSurfaceOwnedMemory::new_with_texture_registration_debt(
                 GpuSurfaceOwnedValue::PooledTexture(pooled_texture),
-                None,
-                None,
-                None,
+                registered_surface_id,
+                gpu_limited_access,
             ),
         )
     }
@@ -254,6 +267,34 @@ impl PythonGpuSurfaceHandle {
         self.owned_memory.lock().clone().ok_or_else(|| {
             PyRuntimeError::new_err("this surface is closed; acquire or resolve it again")
         })
+    }
+}
+
+impl PythonGpuSurfaceHandle {
+    /// Decide — once per handle — whether the no-preference DLPack side
+    /// is the device. Detached work: the first call may allocate staging
+    /// and import into CUDA. A handle that answered kDLCUDA here never
+    /// silently downgrades later; a refill failure after this raises.
+    #[cfg(target_os = "linux")]
+    fn natural_side_is_device(&self, owned_memory: &Arc<GpuSurfaceOwnedMemory>) -> bool {
+        *self.natural_dlpack_side_is_device.get_or_init(|| {
+            device_export_available(owned_memory) && imported_device_for(owned_memory).is_ok()
+        })
+    }
+
+    /// Publish a pending device-side write, once. Shared by `unlock` and
+    /// `close` so the context-manager spelling cannot silently drop an
+    /// edit.
+    #[cfg(target_os = "linux")]
+    fn publish_pending_device_write(&self) -> PyResult<()> {
+        if self
+            .device_write_pending
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
+            && let Some(owned_memory) = self.owned_memory.lock().clone()
+        {
+            publish_device_write_back_to_surface(&owned_memory)?;
+        }
+        Ok(())
     }
 }
 
@@ -301,31 +342,38 @@ impl PythonGpuSurfaceHandle {
         python.detach(|| pixel_buffer_bytes_per_row(owned_memory.host_mapped_pixel_buffer()?))
     }
 
-    /// Base address of the host mapping, or `0` when the surface is not
-    /// locked. Callers that want a typed view use `as_numpy` or `__dlpack__`;
-    /// this is the escape hatch for building one by hand.
+    /// Base address of the host mapping, or `None` when the surface is
+    /// not locked. Callers that want a typed view use `as_numpy` or
+    /// `__dlpack__`; this is the escape hatch for building one by hand.
     #[getter]
-    fn base_address(&self, python: Python<'_>) -> PyResult<usize> {
+    fn base_address(&self, python: Python<'_>) -> PyResult<Option<usize>> {
         if !self.cpu_access.is_locked() {
-            return Ok(0);
+            return Ok(None);
         }
         let owned_memory = self.owned_memory()?;
         python.detach(|| {
-            Ok(owned_memory
-                .host_mapped_pixel_buffer()?
-                .plane_base_address(0) as usize)
+            Ok(Some(
+                owned_memory
+                    .host_mapped_pixel_buffer()?
+                    .plane_base_address(0) as usize,
+            ))
         })
     }
 
     /// Release the underlying GPU resource. Idempotent.
-    fn close(&self, python: Python<'_>) {
+    fn close(&self, python: Python<'_>) -> PyResult<()> {
         // Releasing can return a slot to a pool under engine locks and talk to
         // the surface-share daemon — detached, like every potentially-blocking
-        // engine call.
-        python.detach(|| {
+        // engine call. A pending device write publishes first: the
+        // context-manager spelling reaches close without an explicit
+        // unlock, and dropping the edit silently there is data loss.
+        python.detach(|| -> PyResult<()> {
+            #[cfg(target_os = "linux")]
+            self.publish_pending_device_write()?;
             self.cpu_access.unlock();
             self.release_owned_engine_value();
-        });
+            Ok(())
+        })
     }
 
     fn __enter__(python_self: PyRef<'_, Self>) -> PyRef<'_, Self> {
@@ -333,9 +381,13 @@ impl PythonGpuSurfaceHandle {
     }
 
     #[pyo3(signature = (*_exception_details))]
-    fn __exit__(&self, python: Python<'_>, _exception_details: &Bound<'_, PyAny>) -> bool {
-        self.close(python);
-        false
+    fn __exit__(
+        &self,
+        python: Python<'_>,
+        _exception_details: &Bound<'_, PyAny>,
+    ) -> PyResult<bool> {
+        self.close(python)?;
+        Ok(false)
     }
 
     /// Open CPU access to the pixels, declaring read or write intent.
@@ -348,14 +400,22 @@ impl PythonGpuSurfaceHandle {
     fn lock(&self, python: Python<'_>, read_only: bool) -> PyResult<()> {
         let owned_memory = self.owned_memory()?;
         python.detach(|| -> PyResult<()> {
-            if owned_memory
-                .host_mapped_pixel_buffer()?
-                .plane_base_address(0)
-                .is_null()
-            {
-                return Err(PyBufferError::new_err(
-                    "surface has no host mapping; it is a DEVICE_LOCAL allocation",
-                ));
+            // The gate serves both sides: a device-only surface (a pooled
+            // texture) has no host mapping to check, but its device export
+            // still rides the same lock.
+            match owned_memory.host_mapped_pixel_buffer() {
+                Ok(pixel_buffer) => {
+                    if pixel_buffer.plane_base_address(0).is_null() {
+                        return Err(PyBufferError::new_err(
+                            "surface has no host mapping; it is a DEVICE_LOCAL allocation",
+                        ));
+                    }
+                }
+                Err(no_host_side) => {
+                    if !device_export_available(&owned_memory) {
+                        return Err(no_host_side);
+                    }
+                }
             }
             self.cpu_access.lock_for(read_only);
             Ok(())
@@ -364,18 +424,10 @@ impl PythonGpuSurfaceHandle {
 
     /// Close CPU access, publishing any pending device-side write back
     /// into the surface first. Idempotent.
-    #[pyo3(signature = (read_only = true))]
-    fn unlock(&self, python: Python<'_>, read_only: bool) -> PyResult<()> {
-        let _ = read_only;
+    fn unlock(&self, python: Python<'_>) -> PyResult<()> {
         python.detach(|| -> PyResult<()> {
             #[cfg(target_os = "linux")]
-            if self
-                .device_write_pending
-                .swap(false, std::sync::atomic::Ordering::SeqCst)
-                && let Some(owned_memory) = self.owned_memory.lock().clone()
-            {
-                publish_device_write_back_to_surface(&owned_memory)?;
-            }
+            self.publish_pending_device_write()?;
             self.cpu_access.unlock();
             Ok(())
         })
@@ -447,49 +499,42 @@ impl PythonGpuSurfaceHandle {
         let read_only = self.cpu_access.is_read_only();
 
         // `dl_device` is the consumer's request for a particular side of a
-        // surface that has two. Absent means "wherever you naturally live",
-        // and a graph frame's natural side is the device — its host mapping
-        // is the derived copy. `__dlpack_device__` is what already told the
-        // consumer which side to expect.
-        let wants_host = match dl_device {
-            Some((device_type, _)) => device_type == DeviceType::Cpu as i32,
-            None => !device_export_available(&owned_memory),
-        };
-        if wants_host {
-            return host_visible_dlpack_capsule(python, &owned_memory, exchange_shape, read_only);
-        }
+        // surface that has two. Absent means "wherever you naturally
+        // live" — the side `__dlpack_device__` already advertised, decided
+        // once per handle. A device-side failure after that raises: a
+        // consumer told kDLCUDA must never be handed a host capsule.
         #[cfg(target_os = "linux")]
         {
-            let capsule = device_dlpack_capsule(python, &owned_memory, exchange_shape, read_only);
-            match capsule {
-                Ok(capsule) => {
-                    if !read_only && device_export_writable(&owned_memory) {
-                        self.device_write_pending
-                            .store(true, std::sync::atomic::Ordering::SeqCst);
-                    }
-                    Ok(capsule)
-                }
-                // No usable CUDA runtime, but the CPU can serve this surface:
-                // fall back to the side `__dlpack_device__` would also have
-                // fallen back to, rather than failing a workable export.
-                Err(device_failure) => {
-                    if dl_device.is_none() && owned_memory.host_mapped_pixel_buffer().is_ok() {
-                        host_visible_dlpack_capsule(
-                            python,
-                            &owned_memory,
-                            exchange_shape,
-                            read_only,
-                        )
-                    } else {
-                        Err(device_failure)
-                    }
-                }
+            let wants_host = match dl_device {
+                Some((device_type, _)) => device_type == DeviceType::Cpu as i32,
+                None => !python.detach(|| self.natural_side_is_device(&owned_memory)),
+            };
+            if wants_host {
+                return host_visible_dlpack_capsule(
+                    python,
+                    &owned_memory,
+                    exchange_shape,
+                    read_only,
+                );
             }
+            // The refill (a GPU submit plus a bounded wait, and on first
+            // call the staging allocation + CUDA import) runs detached;
+            // only the capsule construction needs the GIL.
+            let prepared = python.detach(|| prepare_device_export(&owned_memory))?;
+            let writable_export = !read_only && prepared.writable;
+            let capsule =
+                device_dlpack_capsule(python, &owned_memory, prepared, exchange_shape, read_only)?;
+            if writable_export {
+                self.device_write_pending
+                    .store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+            Ok(capsule)
         }
         #[cfg(not(target_os = "linux"))]
-        Err(PyValueError::new_err(
-            "device export is available on Linux only",
-        ))
+        {
+            let _ = dl_device;
+            host_visible_dlpack_capsule(python, &owned_memory, exchange_shape, read_only)
+        }
     }
 
     /// A numpy view of the pixels, sharing memory with the surface.
@@ -513,12 +558,19 @@ impl PythonGpuSurfaceHandle {
         numpy
             .call_method("from_dlpack", (python_self,), Some(&host_request))
             .map_err(|from_dlpack_failure| {
-                if from_dlpack_failure.is_instance_of::<PyTypeError>(python) {
-                    return PyRuntimeError::new_err(
+                // Only the specific unexpected-keyword TypeError means old
+                // numpy; any other failure is numpy's own and passes through
+                // with the hint chained as the cause, never replaced.
+                if from_dlpack_failure.is_instance_of::<PyTypeError>(python)
+                    && from_dlpack_failure.to_string().contains("device")
+                {
+                    let old_numpy_hint = PyRuntimeError::new_err(
                         "as_numpy needs numpy 2.1 or newer, whose `from_dlpack` accepts a \
                          `device` request; older numpy cannot ask for the host side of a \
                          surface",
                     );
+                    old_numpy_hint.set_cause(python, Some(from_dlpack_failure));
+                    return old_numpy_hint;
                 }
                 from_dlpack_failure
             })
@@ -628,7 +680,21 @@ impl PythonGpuContextLimitedAccess {
             let pooled_texture = engine_view
                 .acquire_texture(&descriptor)
                 .map_err(gpu_operation_error)?;
-            Ok(PythonGpuSurfaceHandle::from_pooled_texture(pooled_texture))
+            // Registering under a minted id is what gives the texture a
+            // device-export path — same-process only, and undone when the
+            // handle's memory releases. Contents are whatever the texture
+            // holds; a fresh pool texture is undefined until written.
+            let minted_surface_id = mint_pooled_texture_surface_id();
+            engine_view.register_texture_with_layout(
+                &minted_surface_id,
+                pooled_texture.texture_clone(),
+                VulkanLayout::UNDEFINED,
+            );
+            Ok(PythonGpuSurfaceHandle::from_pooled_texture(
+                pooled_texture,
+                Some(minted_surface_id),
+                Some(engine_view.clone()),
+            ))
         })
     }
 
@@ -812,7 +878,14 @@ impl PythonGpuContextFullAccess {
             let pooled_texture = gpu_full_access
                 .acquire_texture(&descriptor)
                 .map_err(gpu_operation_error)?;
-            Ok(PythonGpuSurfaceHandle::from_pooled_texture(pooled_texture))
+            // The full-access view is lease-bound and cannot be stashed, so
+            // no registration and no device export — acquire from the
+            // limited capability for an exportable texture.
+            Ok(PythonGpuSurfaceHandle::from_pooled_texture(
+                pooled_texture,
+                None,
+                None,
+            ))
         })
     }
 
@@ -1243,6 +1316,18 @@ impl PythonLinkOutputDataWriter {
 // =============================================================================
 // Python-string <-> engine-enum format vocabularies
 // =============================================================================
+
+/// A same-process-unique id for a pooled texture registered at acquire.
+/// A counter, not a UUID: the id never crosses the process, and one
+/// engine per process is a plan decision.
+fn mint_pooled_texture_surface_id() -> String {
+    static NEXT_POOLED_TEXTURE_NUMBER: std::sync::atomic::AtomicU64 =
+        std::sync::atomic::AtomicU64::new(0);
+    format!(
+        "pooled-texture-{}",
+        NEXT_POOLED_TEXTURE_NUMBER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    )
+}
 
 /// The same vocabulary the subprocess escalate handler accepted, so a
 /// processor migrated from the old SDK keeps its format strings.

--- a/sdk/streamlib-python-wheel/src/python_processor_context.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_context.rs
@@ -200,11 +200,7 @@ impl PythonGpuSurfaceHandle {
             pixel_format_name(format).to_string(),
             // A resolved handle owes no release: it never checked the buffer
             // in, so releasing would evict somebody else's surface.
-            GpuSurfaceOwnedMemory::new(
-                GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer),
-                None,
-                None,
-            ),
+            GpuSurfaceOwnedMemory::new(GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer), None, None),
         )
     }
 
@@ -239,7 +235,6 @@ impl PythonGpuSurfaceHandle {
             PyRuntimeError::new_err("this surface is closed; acquire or resolve it again")
         })
     }
-
 }
 
 impl Drop for PythonGpuSurfaceHandle {
@@ -296,7 +291,9 @@ impl PythonGpuSurfaceHandle {
         }
         let owned_memory = self.owned_memory()?;
         python.detach(|| {
-            Ok(owned_memory.host_mapped_pixel_buffer()?.plane_base_address(0) as usize)
+            Ok(owned_memory
+                .host_mapped_pixel_buffer()?
+                .plane_base_address(0) as usize)
         })
     }
 
@@ -415,12 +412,7 @@ impl PythonGpuSurfaceHandle {
             None => !is_device_exchange(&owned_memory),
         };
         if wants_host {
-            return host_visible_dlpack_capsule(
-                python,
-                &owned_memory,
-                exchange_shape,
-                read_only,
-            );
+            return host_visible_dlpack_capsule(python, &owned_memory, exchange_shape, read_only);
         }
         #[cfg(target_os = "linux")]
         {
@@ -811,6 +803,78 @@ impl PythonGpuContextFullAccess {
                         exported_size,
                         vulkan_device_uuid,
                     )),
+                    None,
+                    None,
+                ),
+            ))
+        })
+    }
+
+    /// Export a DMA-BUF file descriptor for `surface`, for native code that
+    /// speaks DMA-BUF — EGL, a V4L2 output device, another process.
+    ///
+    /// Returns `(fd, byte_size)`. **The caller owns the fd** and must close
+    /// it, or hand it to something that takes ownership. Only a surface from
+    /// the ordinary pixel-buffer pool can answer: a device-exchange buffer is
+    /// OPAQUE_FD-flavoured and has no DMA-BUF export path.
+    #[cfg(target_os = "linux")]
+    fn export_dma_buf(
+        &self,
+        python: Python<'_>,
+        surface: &PythonGpuSurfaceHandle,
+    ) -> PyResult<(i32, u64)> {
+        let owned_memory = surface.owned_memory()?;
+        read_gpu_full_access(python, &self.gpu_full_access_source, |gpu_full_access| {
+            let pixel_buffer = owned_memory.dma_buf_exportable_pixel_buffer()?;
+            gpu_full_access
+                .export_pixel_buffer_dma_buf_fd(pixel_buffer)
+                .map_err(gpu_operation_error)
+        })
+    }
+
+    /// Import a DMA-BUF file descriptor as a surface this graph can read.
+    ///
+    /// **Takes ownership of `fd` on success** — the driver adopts it, and it
+    /// must not be closed afterwards. On failure the fd is still the
+    /// caller's.
+    #[cfg(target_os = "linux")]
+    #[pyo3(signature = (fd, width, height, format = "bgra"))]
+    fn import_dma_buf(
+        &self,
+        python: Python<'_>,
+        fd: i32,
+        width: u32,
+        height: u32,
+        format: &str,
+    ) -> PyResult<PythonGpuSurfaceHandle> {
+        let pixel_format = parse_pixel_format_name(format)?;
+        let bytes_per_pixel = device_exchange_bytes_per_pixel(pixel_format)?;
+        let byte_size = u64::from(width) * u64::from(height) * u64::from(bytes_per_pixel);
+        if byte_size == 0 {
+            return Err(PyValueError::new_err(
+                "width and height must both be greater than zero",
+            ));
+        }
+        read_gpu_full_access(python, &self.gpu_full_access_source, |gpu_full_access| {
+            let storage_buffer = gpu_full_access
+                .import_dma_buf_storage_buffer(fd, byte_size)
+                .map_err(gpu_operation_error)?;
+            let pixel_buffer = gpu_full_access
+                .wrap_storage_buffer_as_pixel_buffer(
+                    &storage_buffer,
+                    width,
+                    height,
+                    bytes_per_pixel,
+                    pixel_format,
+                )
+                .map_err(gpu_operation_error)?;
+            Ok(PythonGpuSurfaceHandle::new(
+                None,
+                width,
+                height,
+                pixel_format_name(pixel_format).to_string(),
+                GpuSurfaceOwnedMemory::new(
+                    GpuSurfaceOwnedValue::PixelBuffer(pixel_buffer),
                     None,
                     None,
                 ),

--- a/sdk/streamlib-python-wheel/src/python_processor_context.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_context.rs
@@ -31,6 +31,10 @@ use streamlib::sdk::rhi::{
     PixelBuffer, PixelBufferPoolId, PixelFormat, TextureFormat, TextureUsages,
 };
 use streamlib_adapter_cuda::dlpack::DeviceType;
+#[cfg(target_os = "linux")]
+use std::os::fd::FromRawFd as _;
+#[cfg(target_os = "linux")]
+use std::os::fd::OwnedFd;
 
 use crate::python_bag_conversion::json_value_to_python_object;
 use crate::python_gpu_surface_pixel_exchange::{
@@ -318,8 +322,12 @@ impl PythonGpuSurfaceHandle {
         false
     }
 
-    /// Open CPU access to the pixels, waiting for the producer to finish
-    /// writing them first.
+    /// Open CPU access to the pixels, declaring read or write intent.
+    ///
+    /// This performs no wait: ordering against the producer comes from
+    /// publication, since a source finishes its GPU work before it writes the
+    /// surface id downstream. `read_only=False` is what marks an exported
+    /// tensor writable.
     #[pyo3(signature = (read_only = true))]
     fn lock(&self, python: Python<'_>, read_only: bool) -> PyResult<()> {
         let owned_memory = self.owned_memory()?;
@@ -787,9 +795,12 @@ impl PythonGpuContextFullAccess {
                 .map_err(gpu_operation_error)?;
             // Exported here because exporting is privileged and `__dlpack__`
             // is not. The fd is consumed by the first CUDA import.
-            let (opaque_fd, exported_size, vulkan_device_uuid) = gpu_full_access
+            let (raw_opaque_fd, exported_size, vulkan_device_uuid) = gpu_full_access
                 .export_storage_buffer_opaque_fd(&storage_buffer)
                 .map_err(gpu_operation_error)?;
+            // SAFETY: the export hands over a fresh dup'd fd that nothing
+            // else holds, so adopting it here is the only ownership claim.
+            let opaque_fd = unsafe { OwnedFd::from_raw_fd(raw_opaque_fd) };
             Ok(PythonGpuSurfaceHandle::new(
                 None,
                 width,

--- a/sdk/streamlib-python-wheel/tests/test_capability_contexts.py
+++ b/sdk/streamlib-python-wheel/tests/test_capability_contexts.py
@@ -417,23 +417,21 @@ def test_a_zero_argument_process_hook_fails_loudly_with_a_type_error(
 class PixelBufferAcquirer:
     def setup(self, ctx: RuntimeContextFullAccess) -> None:
         with ctx.gpu_limited_access.acquire_pixel_buffer(64, 32) as surface_handle:
-            try:
-                surface_handle.as_numpy()
-                pixel_access_outcome = "returned"
-            except NotImplementedError as not_yet_implemented:
-                pixel_access_outcome = str(not_yet_implemented)
+            surface_handle.lock()
+            pixel_access_shape = surface_handle.as_numpy().shape
+            surface_handle.unlock()
             _hook_observations.put(
                 {
                     "observed": "pixel_buffer",
                     "surface_id": surface_handle.surface_id,
                     "width": surface_handle.width,
                     "height": surface_handle.height,
-                    "pixel_access_outcome": pixel_access_outcome,
+                    "pixel_access_shape": pixel_access_shape,
                 }
             )
 
 
-def test_a_hook_acquires_a_pixel_buffer_and_pixel_access_names_its_ticket():
+def test_a_hook_acquires_a_pixel_buffer_and_reaches_its_pixels():
     graph = RunningGraph()
     graph.runtime.add(PixelBufferAcquirer)
     graph.start()
@@ -443,10 +441,9 @@ def test_a_hook_acquires_a_pixel_buffer_and_pixel_access_names_its_ticket():
         graph.shut_down_and_take_run_outcome()
     assert isinstance(observation["surface_id"], str) and observation["surface_id"]
     assert (observation["width"], observation["height"]) == (64, 32)
-    assert "1710" in observation["pixel_access_outcome"], (
-        f"as_numpy should raise NotImplementedError naming ticket #1710, got: "
-        f"{observation['pixel_access_outcome']!r}"
-    )
+    # The exchange surface itself is covered by `test_pixel_exchange.py`;
+    # here it only has to be reachable from a hook.
+    assert observation["pixel_access_shape"] == (32, 64, 4)
 
 
 @processor(execution="manual")

--- a/sdk/streamlib-python-wheel/tests/test_device_exchange.py
+++ b/sdk/streamlib-python-wheel/tests/test_device_exchange.py
@@ -1,0 +1,332 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""The device half of the pixel exchange, proven against a real GPU.
+
+An exchange buffer's memory is allocated by the engine, imported by CUDA, and
+handed to a framework as a DLPack tensor — no copy, and CUDA never allocates.
+What is worth breaking a build over here is the import landing on the right
+device, the capsule reporting the memory it actually got, and the tensor
+outliving its handle across two allocators rather than one.
+
+These need an NVIDIA driver as well as a GPU; a rig without one skips rather
+than fails, because the refusal path is itself covered below.
+"""
+
+import queue
+import threading
+import time
+
+import pytest
+
+import streamlib
+from streamlib import RuntimeContextFullAccess, processor
+
+pytestmark = pytest.mark.requires_gpu
+
+PIPELINE_TIMEOUT_SECONDS = 30.0
+
+SURFACE_WIDTH = 64
+SURFACE_HEIGHT = 32
+
+# DLPack device-type discriminants, part of the wire ABI.
+DLPACK_DEVICE_CPU = 1
+DLPACK_DEVICE_CUDA = 2
+
+_hook_observations: "queue.Queue[dict]" = queue.Queue()
+
+
+@pytest.fixture(autouse=True)
+def clean_observation_queue():
+    while True:
+        try:
+            _hook_observations.get_nowait()
+        except queue.Empty:
+            break
+    yield
+
+
+class RunningGraph:
+    def __init__(self) -> None:
+        self.runtime = streamlib.Runtime()
+        self._run_loop = threading.Thread(target=self.runtime.run, daemon=True)
+
+    def start(self) -> None:
+        self._run_loop.start()
+
+    def shut_down(self) -> None:
+        self.runtime.shutdown()
+        self._run_loop.join(timeout=PIPELINE_TIMEOUT_SECONDS)
+        assert not self._run_loop.is_alive(), "run() never returned after shutdown()"
+
+
+def _observe(matching: str, probe_body):
+    try:
+        _hook_observations.put({"observed": matching, **probe_body()})
+    except BaseException:  # noqa: BLE001 — re-raised by the test
+        import traceback
+
+        _hook_observations.put({"observed": matching, "failure": traceback.format_exc()})
+
+
+def _run_probe(probe_class: type, matching: str) -> dict:
+    graph = RunningGraph()
+    graph.runtime.add(probe_class)
+    graph.start()
+    deadline = time.monotonic() + PIPELINE_TIMEOUT_SECONDS
+    try:
+        while True:
+            remaining = deadline - time.monotonic()
+            assert remaining > 0, f"no {matching!r} observation arrived within the timeout"
+            try:
+                observation = _hook_observations.get(timeout=min(0.5, remaining))
+            except queue.Empty:
+                continue
+            if observation.get("observed") == matching:
+                break
+    finally:
+        graph.shut_down()
+    if "failure" in observation:
+        pytest.fail(f"the probe raised:\n{observation['failure']}")
+    return observation
+
+
+def _skip_without_cuda_driver(observation: dict) -> None:
+    reason = observation.get("cuda_unavailable")
+    if reason:
+        pytest.skip(f"no usable CUDA driver on this rig: {reason}")
+
+
+# ---------------------------------------------------------------------------
+# The export itself
+# ---------------------------------------------------------------------------
+
+
+def _host_request_outcome(surface_handle) -> str:
+    """What asking a device-local surface for its host side does."""
+    try:
+        surface_handle.__dlpack__(max_version=(1, 0), dl_device=(DLPACK_DEVICE_CPU, 0))
+    except BufferError:
+        return "device-local, as expected"
+    return "handed back a host tensor"
+
+
+@processor(execution="manual")
+class DeviceExportProbe:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        _observe("device_export", lambda: self._probe(ctx))
+
+    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
+        with ctx.gpu_full_access.acquire_device_exchange_buffer(
+            SURFACE_WIDTH, SURFACE_HEIGHT
+        ) as surface_handle:
+            surface_handle.lock(read_only=False)
+            try:
+                reported_device = surface_handle.__dlpack_device__()
+            except RuntimeError as import_failure:
+                return {"cuda_unavailable": str(import_failure)}
+            capsule = surface_handle.__dlpack__(max_version=(1, 0))
+            observation = {
+                "reported_device": reported_device,
+                "capsule_type": type(capsule).__name__,
+                # The import is cached, so a second query must agree with the
+                # first — two imports of one allocation would be two mappings,
+                # and freeing either would strand the other.
+                "device_on_second_query": surface_handle.__dlpack_device__(),
+                # The host side is still reachable on request, which is what
+                # `as_numpy` relies on for a non-device-local buffer.
+                "host_request_refused": _host_request_outcome(surface_handle),
+            }
+            surface_handle.unlock()
+            return observation
+
+
+def test_an_exchange_buffer_exports_device_memory_to_dlpack():
+    """The reported device is the one the driver actually mapped onto.
+
+    `__dlpack_device__` performs the import rather than predicting its
+    outcome, because `cudaPointerGetAttributes` is what distinguishes true
+    device memory from a driver that quietly downgraded to pinned host
+    memory — and a consumer trusts this answer before it ever looks at the
+    capsule.
+    """
+    observation = _run_probe(DeviceExportProbe, "device_export")
+    _skip_without_cuda_driver(observation)
+    assert observation["capsule_type"] == "PyCapsule"
+    device_type, device_ordinal = observation["reported_device"]
+    assert device_type == DLPACK_DEVICE_CUDA, (
+        f"the imported pointer was classified as device type {device_type}, not CUDA device "
+        f"memory — the driver downgraded the import"
+    )
+    assert device_ordinal >= 0
+    assert observation["device_on_second_query"] == observation["reported_device"]
+    assert observation["host_request_refused"] == "device-local, as expected"
+
+
+# ---------------------------------------------------------------------------
+# The round trip a user actually writes
+# ---------------------------------------------------------------------------
+
+
+@processor(execution="manual")
+class TorchRoundTripProbe:
+    """Writes through the host view, reads back as a torch CUDA tensor."""
+
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        _observe("torch_round_trip", lambda: self._probe(ctx))
+
+    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
+        import torch
+
+        # `device_local=False` keeps a host mapping alongside the
+        # device-importable one, so the same bytes can be seeded from the CPU
+        # and then read by CUDA — which is what makes this a round trip rather
+        # than two unrelated observations.
+        with ctx.gpu_full_access.acquire_device_exchange_buffer(
+            SURFACE_WIDTH, SURFACE_HEIGHT, "bgra", False
+        ) as surface_handle:
+            surface_handle.lock(read_only=False)
+            try:
+                tensor = torch.from_dlpack(surface_handle)
+            except RuntimeError as export_failure:
+                return {"cuda_unavailable": str(export_failure)}
+
+            observation = {
+                "tensor_device": str(tensor.device),
+                "tensor_shape": tuple(tensor.shape),
+                "tensor_dtype": str(tensor.dtype),
+            }
+            # A write on the GPU, read back through the host mapping of the
+            # same allocation. If anything copied, this does not survive.
+            tensor[:, :, :] = 0
+            tensor[4, 6] = torch.tensor(
+                [12, 34, 56, 78], dtype=torch.uint8, device=tensor.device
+            )
+            torch.cuda.synchronize()
+            host_view = surface_handle.as_numpy()
+            observation["pixel_seen_by_the_host"] = host_view[4, 6].tolist()
+            observation["an_untouched_pixel"] = host_view[0, 0].tolist()
+            surface_handle.unlock()
+            return observation
+
+
+def test_a_torch_cuda_tensor_and_the_host_view_are_the_same_memory():
+    """The headline contract: a GPU write is visible to the CPU with no copy.
+
+    torch writes through a CUDA device pointer; the host mapping of the same
+    engine allocation observes it. Two mappings, one allocation — which is the
+    whole claim the exchange surface makes.
+    """
+    pytest.importorskip("torch")
+    observation = _run_probe(TorchRoundTripProbe, "torch_round_trip")
+    _skip_without_cuda_driver(observation)
+    assert observation["tensor_device"].startswith("cuda")
+    assert observation["tensor_shape"] == (SURFACE_HEIGHT, SURFACE_WIDTH, 4)
+    assert observation["tensor_dtype"] == "torch.uint8"
+    assert observation["pixel_seen_by_the_host"] == [12, 34, 56, 78]
+    assert observation["an_untouched_pixel"] == [0, 0, 0, 0]
+
+
+# ---------------------------------------------------------------------------
+# Lifetime across two allocators
+# ---------------------------------------------------------------------------
+
+
+@processor(execution="manual")
+class TensorOutlivesExchangeBufferProbe:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        _observe("tensor_outlives_exchange", lambda: self._probe(ctx))
+
+    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
+        import torch
+
+        surface_handle = ctx.gpu_full_access.acquire_device_exchange_buffer(
+            SURFACE_WIDTH, SURFACE_HEIGHT
+        )
+        surface_handle.lock(read_only=False)
+        try:
+            tensor = torch.from_dlpack(surface_handle)
+        except RuntimeError as export_failure:
+            return {"cuda_unavailable": str(export_failure)}
+        tensor[:, :, :] = 5
+        torch.cuda.synchronize()
+
+        # The frame is done with; the tensor is not.
+        surface_handle.unlock()
+        surface_handle.close()
+        del surface_handle
+
+        # Reaching the memory now goes through both the engine allocation and
+        # the CUDA import, either of which being freed early would fault here.
+        return {
+            "sum_after_close": int(tensor.sum().item()),
+            "expected_sum": SURFACE_WIDTH * SURFACE_HEIGHT * 4 * 5,
+        }
+
+
+def test_a_device_tensor_outliving_its_handle_keeps_a_live_mapping():
+    """Use-after-free across two allocators.
+
+    The capsule owns a share of both the engine allocation and the CUDA
+    import, so closing the handle frees neither while a tensor is live.
+
+    Mental-revert: drop the `CudaImportedSurface` from the capsule's owner —
+    `cudaDestroyExternalMemory` then runs while torch still holds the pointer.
+    """
+    pytest.importorskip("torch")
+    observation = _run_probe(
+        TensorOutlivesExchangeBufferProbe, "tensor_outlives_exchange"
+    )
+    _skip_without_cuda_driver(observation)
+    assert observation["sum_after_close"] == observation["expected_sum"]
+
+
+# ---------------------------------------------------------------------------
+# Refusals
+# ---------------------------------------------------------------------------
+
+
+@processor(execution="manual")
+class ExchangeRefusalProbe:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        _observe("exchange_refusals", lambda: self._probe(ctx))
+
+    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
+        outcomes = {}
+        gpu_full = ctx.gpu_full_access
+
+        # A device-local buffer has no host mapping to hand numpy.
+        with gpu_full.acquire_device_exchange_buffer(
+            SURFACE_WIDTH, SURFACE_HEIGHT
+        ) as device_only:
+            device_only.lock()
+            try:
+                device_only.as_numpy()
+                outcomes["numpy_on_device_local"] = "returned a view"
+            except BufferError as refusal:
+                outcomes["numpy_on_device_local"] = str(refusal)
+            device_only.unlock()
+
+        # An ordinary pooled pixel buffer is DMA-BUF-flavoured, so it has no
+        # OPAQUE_FD to give CUDA. Refusing beats importing nothing.
+        with ctx.gpu_limited_access.acquire_pixel_buffer(
+            SURFACE_WIDTH, SURFACE_HEIGHT
+        ) as pooled:
+            pooled.lock()
+            outcomes["pooled_buffer_device"] = pooled.__dlpack_device__()
+            pooled.unlock()
+
+        try:
+            gpu_full.acquire_device_exchange_buffer(SURFACE_WIDTH, SURFACE_HEIGHT, "nv12")
+            outcomes["nv12_exchange"] = "allocated"
+        except ValueError as refusal:
+            outcomes["nv12_exchange"] = str(refusal)
+        return outcomes
+
+
+def test_the_device_path_refuses_what_it_cannot_honour():
+    observation = _run_probe(ExchangeRefusalProbe, "exchange_refusals")
+    assert "device-local" in observation["numpy_on_device_local"]
+    # A pooled buffer never claims CUDA: it has no device import to report.
+    assert observation["pooled_buffer_device"] == (DLPACK_DEVICE_CPU, 0)
+    assert "one linear allocation" in observation["nv12_exchange"]

--- a/sdk/streamlib-python-wheel/tests/test_device_exchange.py
+++ b/sdk/streamlib-python-wheel/tests/test_device_exchange.py
@@ -1,26 +1,40 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 
-"""The device half of the pixel exchange, proven against a real GPU.
+"""The device half of the pixel exchange: graph frames as GPU tensors.
 
-An exchange buffer's memory is allocated by the engine, imported by CUDA, and
-handed to a framework as a DLPack tensor — no copy, and CUDA never allocates.
-What is worth breaking a build over here is the import landing on the right
-device, the capsule reporting the memory it actually got, and the tensor
-outliving its handle across two allocators rather than one.
+A frame published into the graph reaches CUDA through one engine-side blit
+into an exportable staging buffer — zero CPU copies, and CUDA never
+allocates. The consumer writes ordinary user code: resolve the frame,
+`torch.from_dlpack`, work on a CUDA tensor. What is worth breaking a build
+over is that the tensor really is device-resident, that its pixels are the
+frame's pixels, that a device-side edit publishes back into the surface at
+unlock, and that a tensor outliving its handle keeps every layer of the
+mapping alive.
 
-These need an NVIDIA driver as well as a GPU; a rig without one skips rather
-than fails, because the refusal path is itself covered below.
+These need an NVIDIA driver as well as a GPU; a rig without one skips,
+because the CPU fallback is itself under test.
 """
 
 import queue
 import threading
 import time
 
+import numpy
 import pytest
 
 import streamlib
-from streamlib import RuntimeContextFullAccess, processor
+
+# `input` is streamlib's port decorator — the test reads like user code,
+# which spells it exactly this way.
+from streamlib import (  # noqa: A004
+    RuntimeContextFullAccess,
+    RuntimeContextLimitedAccess,
+    TestPatternSource,
+    VideoFrame,
+    input,
+    processor,
+)
 
 pytestmark = pytest.mark.requires_gpu
 
@@ -69,21 +83,30 @@ def _observe(matching: str, probe_body):
         _hook_observations.put({"observed": matching, "failure": traceback.format_exc()})
 
 
-def _run_probe(probe_class: type, matching: str) -> dict:
-    graph = RunningGraph()
-    graph.runtime.add(probe_class)
-    graph.start()
+def _await_observation(matching: str) -> dict:
     deadline = time.monotonic() + PIPELINE_TIMEOUT_SECONDS
+    while True:
+        remaining = deadline - time.monotonic()
+        assert remaining > 0, f"no {matching!r} observation arrived within the timeout"
+        try:
+            observation = _hook_observations.get(timeout=min(0.5, remaining))
+        except queue.Empty:
+            continue
+        if observation.get("observed") == matching:
+            return observation
+
+
+def _run_frame_probe(probe_class: type, matching: str) -> dict:
+    """Run TestPatternSource → probe and collect the probe's observation."""
+    graph = RunningGraph()
+    pattern = graph.runtime.add(
+        TestPatternSource, config={"width": SURFACE_WIDTH, "height": SURFACE_HEIGHT}
+    )
+    probe = graph.runtime.add(probe_class)
+    graph.runtime.connect(pattern.output("video"), probe.input("video_from_upstream"))
+    graph.start()
     try:
-        while True:
-            remaining = deadline - time.monotonic()
-            assert remaining > 0, f"no {matching!r} observation arrived within the timeout"
-            try:
-                observation = _hook_observations.get(timeout=min(0.5, remaining))
-            except queue.Empty:
-                continue
-            if observation.get("observed") == matching:
-                break
+        observation = _await_observation(matching)
     finally:
         graph.shut_down()
     if "failure" in observation:
@@ -91,194 +114,255 @@ def _run_probe(probe_class: type, matching: str) -> dict:
     return observation
 
 
-def _skip_without_cuda_driver(observation: dict) -> None:
+def _skip_without_cuda(observation: dict) -> None:
     reason = observation.get("cuda_unavailable")
     if reason:
-        pytest.skip(f"no usable CUDA driver on this rig: {reason}")
+        pytest.skip(f"no usable CUDA runtime on this rig: {reason}")
+
+
+class _FrameProbeBase:
+    """Reads exactly one frame bag, then reports through `_observe`."""
+
+    observation_name = ""
+
+    def _probe(self, ctx: RuntimeContextLimitedAccess, frame: VideoFrame) -> dict:
+        raise NotImplementedError
+
+    @input(delivery_profile="every_sample")
+    def video_from_upstream(self) -> None: ...
+
+    def __init__(self) -> None:
+        self.frames_seen = 0
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        bag = ctx.inputs.read("video_from_upstream")
+        if bag is None or self.frames_seen >= 1:
+            return
+        self.frames_seen += 1
+        _observe(self.observation_name, lambda: self._probe(ctx, VideoFrame.from_bag(bag)))
 
 
 # ---------------------------------------------------------------------------
-# The export itself
+# The headline: a graph frame is a CUDA tensor
 # ---------------------------------------------------------------------------
 
 
-def _host_request_outcome(surface_handle) -> str:
-    """What asking a device-local surface for its host side does."""
-    try:
-        surface_handle.__dlpack__(max_version=(1, 0), dl_device=(DLPACK_DEVICE_CPU, 0))
-    except BufferError:
-        return "device-local, as expected"
-    return "handed back a host tensor"
+@processor
+class GraphFrameToTorchProbe(_FrameProbeBase):
+    observation_name = "graph_frame_to_torch"
 
-
-@processor(execution="manual")
-class DeviceExportProbe:
-    def setup(self, ctx: RuntimeContextFullAccess) -> None:
-        _observe("device_export", lambda: self._probe(ctx))
-
-    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
-        with ctx.gpu_full_access.acquire_device_exchange_buffer(
-            SURFACE_WIDTH, SURFACE_HEIGHT
-        ) as surface_handle:
-            surface_handle.lock(read_only=False)
-            try:
-                reported_device = surface_handle.__dlpack_device__()
-            except RuntimeError as import_failure:
-                return {"cuda_unavailable": str(import_failure)}
-            capsule = surface_handle.__dlpack__(max_version=(1, 0))
-            observation = {
-                "reported_device": reported_device,
-                "capsule_type": type(capsule).__name__,
-                # The import is cached, so a second query must agree with the
-                # first — two imports of one allocation would be two mappings,
-                # and freeing either would strand the other.
-                "device_on_second_query": surface_handle.__dlpack_device__(),
-                # The host side is still reachable on request, which is what
-                # `as_numpy` relies on for a non-device-local buffer.
-                "host_request_refused": _host_request_outcome(surface_handle),
-            }
-            surface_handle.unlock()
-            return observation
-
-
-def test_an_exchange_buffer_exports_device_memory_to_dlpack():
-    """The reported device is the one the driver actually mapped onto.
-
-    `__dlpack_device__` performs the import rather than predicting its
-    outcome, because `cudaPointerGetAttributes` is what distinguishes true
-    device memory from a driver that quietly downgraded to pinned host
-    memory — and a consumer trusts this answer before it ever looks at the
-    capsule.
-    """
-    observation = _run_probe(DeviceExportProbe, "device_export")
-    _skip_without_cuda_driver(observation)
-    assert observation["capsule_type"] == "PyCapsule"
-    device_type, device_ordinal = observation["reported_device"]
-    assert device_type == DLPACK_DEVICE_CUDA, (
-        f"the imported pointer was classified as device type {device_type}, not CUDA device "
-        f"memory — the driver downgraded the import"
-    )
-    assert device_ordinal >= 0
-    assert observation["device_on_second_query"] == observation["reported_device"]
-    assert observation["host_request_refused"] == "device-local, as expected"
-
-
-# ---------------------------------------------------------------------------
-# The round trip a user actually writes
-# ---------------------------------------------------------------------------
-
-
-@processor(execution="manual")
-class TorchRoundTripProbe:
-    """Writes through the host view, reads back as a torch CUDA tensor."""
-
-    def setup(self, ctx: RuntimeContextFullAccess) -> None:
-        _observe("torch_round_trip", lambda: self._probe(ctx))
-
-    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
+    def _probe(self, ctx: RuntimeContextLimitedAccess, frame) -> dict:
         import torch
 
-        # `device_local=False` keeps a host mapping alongside the
-        # device-importable one, so the same bytes can be seeded from the CPU
-        # and then read by CUDA — which is what makes this a round trip rather
-        # than two unrelated observations.
-        with ctx.gpu_full_access.acquire_device_exchange_buffer(
-            SURFACE_WIDTH, SURFACE_HEIGHT, "bgra", False
-        ) as surface_handle:
-            surface_handle.lock(read_only=False)
-            try:
-                tensor = torch.from_dlpack(surface_handle)
-            except RuntimeError as export_failure:
-                return {"cuda_unavailable": str(export_failure)}
-
+        with ctx.gpu_limited_access.resolve_surface(frame.surface_id) as surface:
+            surface.lock()
+            reported_device = surface.__dlpack_device__()
+            if reported_device[0] != DLPACK_DEVICE_CUDA:
+                surface.unlock()
+                return {"cuda_unavailable": f"__dlpack_device__ reported {reported_device}"}
+            tensor = torch.from_dlpack(surface)
+            host_view = numpy.from_dlpack(surface, device="cpu")
             observation = {
+                "reported_device": reported_device,
                 "tensor_device": str(tensor.device),
                 "tensor_shape": tuple(tensor.shape),
                 "tensor_dtype": str(tensor.dtype),
+                # The tensor's pixels are the frame's pixels: compare a
+                # sample against the host mapping of the same surface.
+                "pixels_match_host": bool(
+                    (tensor[3, 5].cpu().numpy() == host_view[3, 5]).all()
+                ),
             }
-            # A write on the GPU, read back through the host mapping of the
-            # same allocation. If anything copied, this does not survive.
-            tensor[:, :, :] = 0
-            tensor[4, 6] = torch.tensor(
-                [12, 34, 56, 78], dtype=torch.uint8, device=tensor.device
-            )
-            torch.cuda.synchronize()
-            host_view = surface_handle.as_numpy()
-            observation["pixel_seen_by_the_host"] = host_view[4, 6].tolist()
-            observation["an_untouched_pixel"] = host_view[0, 0].tolist()
-            surface_handle.unlock()
+            surface.unlock()
             return observation
 
 
-def test_a_torch_cuda_tensor_and_the_host_view_are_the_same_memory():
-    """The headline contract: a GPU write is visible to the CPU with no copy.
+def test_a_graph_frame_reaches_torch_as_a_cuda_tensor():
+    """The ticket's headline, in the user's own spelling.
 
-    torch writes through a CUDA device pointer; the host mapping of the same
-    engine allocation observes it. Two mappings, one allocation — which is the
-    whole claim the exchange surface makes.
+    `torch.from_dlpack(resolved_frame)` yields a GPU-resident tensor whose
+    pixels are the frame's pixels — one engine-side blit, no CPU copy, no
+    user-facing buffer flavour to pick.
     """
     pytest.importorskip("torch")
-    observation = _run_probe(TorchRoundTripProbe, "torch_round_trip")
-    _skip_without_cuda_driver(observation)
+    observation = _run_frame_probe(GraphFrameToTorchProbe, "graph_frame_to_torch")
+    _skip_without_cuda(observation)
+    assert observation["reported_device"][0] == DLPACK_DEVICE_CUDA
     assert observation["tensor_device"].startswith("cuda")
     assert observation["tensor_shape"] == (SURFACE_HEIGHT, SURFACE_WIDTH, 4)
     assert observation["tensor_dtype"] == "torch.uint8"
-    assert observation["pixel_seen_by_the_host"] == [12, 34, 56, 78]
-    assert observation["an_untouched_pixel"] == [0, 0, 0, 0]
+    assert observation["pixels_match_host"], (
+        "the CUDA tensor's pixels differ from the frame's — the blit exported the wrong memory"
+    )
 
 
 # ---------------------------------------------------------------------------
-# Lifetime across two allocators
+# In-place edit: device write publishes back at unlock
 # ---------------------------------------------------------------------------
 
 
-@processor(execution="manual")
-class TensorOutlivesExchangeBufferProbe:
-    def setup(self, ctx: RuntimeContextFullAccess) -> None:
-        _observe("tensor_outlives_exchange", lambda: self._probe(ctx))
+@processor
+class DeviceEditProbe(_FrameProbeBase):
+    observation_name = "device_edit"
 
-    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
+    def _probe(self, ctx: RuntimeContextLimitedAccess, frame) -> dict:
         import torch
 
-        surface_handle = ctx.gpu_full_access.acquire_device_exchange_buffer(
-            SURFACE_WIDTH, SURFACE_HEIGHT
-        )
-        surface_handle.lock(read_only=False)
-        try:
-            tensor = torch.from_dlpack(surface_handle)
-        except RuntimeError as export_failure:
-            return {"cuda_unavailable": str(export_failure)}
-        tensor[:, :, :] = 5
+        gpu = ctx.gpu_limited_access
+        with gpu.resolve_surface(frame.surface_id) as surface:
+            surface.lock(read_only=False)
+            if surface.__dlpack_device__()[0] != DLPACK_DEVICE_CUDA:
+                surface.unlock()
+                return {"cuda_unavailable": "device side not reachable"}
+            tensor = torch.from_dlpack(surface)
+            tensor[:, :, :] = 0
+            tensor[9, 11] = torch.tensor(
+                [17, 34, 51, 68], dtype=torch.uint8, device=tensor.device
+            )
+            torch.cuda.synchronize()
+            # unlock is the publication point for a device-side write.
+            surface.unlock()
+
+        with gpu.resolve_surface(frame.surface_id) as reread:
+            reread.lock()
+            fresh_view = numpy.from_dlpack(reread, device="cpu")
+            observation = {
+                "pixel_after_publish": fresh_view[9, 11].tolist(),
+                "cleared_pixel": fresh_view[0, 0].tolist(),
+            }
+            reread.unlock()
+            return observation
+
+
+def test_a_device_side_edit_publishes_back_to_the_surface_at_unlock():
+    """The mutate-in-place demo, on the GPU.
+
+    torch writes the staging buffer; `unlock()` copies it back into the
+    frame's own allocation, so a second, independent resolve observes the
+    edit. Mental-revert: drop the copy-back from unlock and the fresh
+    resolve reads the original pattern.
+    """
+    pytest.importorskip("torch")
+    observation = _run_frame_probe(DeviceEditProbe, "device_edit")
+    _skip_without_cuda(observation)
+    assert observation["pixel_after_publish"] == [17, 34, 51, 68]
+    assert observation["cleared_pixel"] == [0, 0, 0, 0]
+
+
+# ---------------------------------------------------------------------------
+# Lifetime across three layers
+# ---------------------------------------------------------------------------
+
+
+@processor
+class TensorOutlivesHandleProbe(_FrameProbeBase):
+    observation_name = "tensor_outlives_handle"
+
+    def _probe(self, ctx: RuntimeContextLimitedAccess, frame) -> dict:
+        import torch
+
+        surface = ctx.gpu_limited_access.resolve_surface(frame.surface_id)
+        surface.lock()
+        if surface.__dlpack_device__()[0] != DLPACK_DEVICE_CUDA:
+            surface.unlock()
+            return {"cuda_unavailable": "device side not reachable"}
+        tensor = torch.from_dlpack(surface)
+        checksum_before = int(tensor.to(torch.int64).sum().item())
+        surface.unlock()
+        surface.close()
+        del surface
+
+        # The handle is gone; the tensor must still address live memory —
+        # its capsule holds the surface, the staging, and the CUDA import.
         torch.cuda.synchronize()
-
-        # The frame is done with; the tensor is not.
-        surface_handle.unlock()
-        surface_handle.close()
-        del surface_handle
-
-        # Reaching the memory now goes through both the engine allocation and
-        # the CUDA import, either of which being freed early would fault here.
+        checksum_after = int(tensor.to(torch.int64).sum().item())
         return {
-            "sum_after_close": int(tensor.sum().item()),
-            "expected_sum": SURFACE_WIDTH * SURFACE_HEIGHT * 4 * 5,
+            "checksum_before": checksum_before,
+            "checksum_after": checksum_after,
         }
 
 
 def test_a_device_tensor_outliving_its_handle_keeps_a_live_mapping():
-    """Use-after-free across two allocators.
-
-    The capsule owns a share of both the engine allocation and the CUDA
-    import, so closing the handle frees neither while a tensor is live.
-
-    Mental-revert: drop the `CudaImportedSurface` from the capsule's owner —
-    `cudaDestroyExternalMemory` then runs while torch still holds the pointer.
-    """
+    """Use-after-free across the engine allocation, the staging, and the
+    CUDA import — closing the handle frees none of them while a tensor
+    lives."""
     pytest.importorskip("torch")
-    observation = _run_probe(
-        TensorOutlivesExchangeBufferProbe, "tensor_outlives_exchange"
+    observation = _run_frame_probe(TensorOutlivesHandleProbe, "tensor_outlives_handle")
+    _skip_without_cuda(observation)
+    assert observation["checksum_after"] == observation["checksum_before"]
+
+
+# ---------------------------------------------------------------------------
+# The explicit host side, and refusals
+# ---------------------------------------------------------------------------
+
+
+@processor
+class HostSideProbe(_FrameProbeBase):
+    observation_name = "host_side"
+
+    def _probe(self, ctx: RuntimeContextLimitedAccess, frame) -> dict:
+        with ctx.gpu_limited_access.resolve_surface(frame.surface_id) as surface:
+            surface.lock()
+            host_view = numpy.from_dlpack(surface, device="cpu")
+            via_as_numpy = surface.as_numpy()
+            observation = {
+                "host_shape": host_view.shape,
+                "as_numpy_shape": via_as_numpy.shape,
+                "same_pixels": bool((host_view[2, 2] == via_as_numpy[2, 2]).all()),
+            }
+            surface.unlock()
+            return observation
+
+
+def test_the_host_side_stays_reachable_on_explicit_request():
+    """`dl_device=(1, 0)` — numpy's `device="cpu"` — still yields the host
+    mapping when a device side exists; `as_numpy` rides the same request."""
+    observation = _run_frame_probe(HostSideProbe, "host_side")
+    assert observation["host_shape"] == (SURFACE_HEIGHT, SURFACE_WIDTH, 4)
+    assert observation["as_numpy_shape"] == (SURFACE_HEIGHT, SURFACE_WIDTH, 4)
+    assert observation["same_pixels"]
+
+
+@processor(execution="manual")
+class NoExportKeyProbe:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        _observe("no_export_key", lambda: self._probe(ctx))
+
+    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
+        outcomes = {}
+        # A pooled texture carries no surface id — nothing keys an export.
+        with ctx.gpu_limited_access.acquire_texture(
+            SURFACE_WIDTH, SURFACE_HEIGHT, "rgba8_unorm", ["copy_src", "texture_binding"]
+        ) as texture_handle:
+            outcomes["texture_device"] = texture_handle.__dlpack_device__()
+
+        # An acquired pixel buffer resolves the device path through its id.
+        with ctx.gpu_limited_access.acquire_pixel_buffer(
+            SURFACE_WIDTH, SURFACE_HEIGHT
+        ) as buffer_handle:
+            outcomes["acquired_buffer_device"] = buffer_handle.__dlpack_device__()
+        return outcomes
+
+
+def test_export_keying_matches_what_the_surface_carries():
+    graph = RunningGraph()
+    graph.runtime.add(NoExportKeyProbe)
+    graph.start()
+    try:
+        observation = _await_observation("no_export_key")
+    finally:
+        graph.shut_down()
+    if "failure" in observation:
+        pytest.fail(f"the probe raised:\n{observation['failure']}")
+    # No id → no device export to attempt; the host mapping answers.
+    assert observation["texture_device"] == (DLPACK_DEVICE_CPU, 0)
+    # An id + the limited capability → the device side may answer (CUDA)
+    # or fall back to the host on a driverless rig; both are legal here.
+    assert observation["acquired_buffer_device"][0] in (
+        DLPACK_DEVICE_CPU,
+        DLPACK_DEVICE_CUDA,
     )
-    _skip_without_cuda_driver(observation)
-    assert observation["sum_after_close"] == observation["expected_sum"]
 
 
 # ---------------------------------------------------------------------------
@@ -325,74 +409,17 @@ def test_a_dma_buf_export_reimports_as_the_same_memory():
     """The export/import pair is a handle to one allocation, not a copy.
 
     This is the shape third-party native code gets: an fd it can hand to EGL,
-    a V4L2 output device, or another process. Round-tripping it through the
-    engine's own importer is how we check the handle actually describes the
-    frame rather than merely being a valid fd.
+    a V4L2 output device, or another process.
     """
-    observation = _run_probe(DmaBufRoundTripProbe, "dma_buf_round_trip")
+    graph = RunningGraph()
+    graph.runtime.add(DmaBufRoundTripProbe)
+    graph.start()
+    try:
+        observation = _await_observation("dma_buf_round_trip")
+    finally:
+        graph.shut_down()
+    if "failure" in observation:
+        pytest.fail(f"the probe raised:\n{observation['failure']}")
     assert observation["fd_is_real"]
     assert observation["byte_size"] == observation["expected_byte_size"]
     assert observation["pixel_seen_through_the_import"] == [21, 43, 65, 87]
-
-
-# ---------------------------------------------------------------------------
-# Refusals
-# ---------------------------------------------------------------------------
-
-
-@processor(execution="manual")
-class ExchangeRefusalProbe:
-    def setup(self, ctx: RuntimeContextFullAccess) -> None:
-        _observe("exchange_refusals", lambda: self._probe(ctx))
-
-    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
-        outcomes = {}
-        gpu_full = ctx.gpu_full_access
-
-        # A device-local buffer has no host mapping to hand numpy.
-        with gpu_full.acquire_device_exchange_buffer(
-            SURFACE_WIDTH, SURFACE_HEIGHT
-        ) as device_only:
-            device_only.lock()
-            try:
-                device_only.as_numpy()
-                outcomes["numpy_on_device_local"] = "returned a view"
-            except BufferError as refusal:
-                outcomes["numpy_on_device_local"] = str(refusal)
-            device_only.unlock()
-
-        # An ordinary pooled pixel buffer is DMA-BUF-flavoured, so it has no
-        # OPAQUE_FD to give CUDA. Refusing beats importing nothing.
-        with ctx.gpu_limited_access.acquire_pixel_buffer(
-            SURFACE_WIDTH, SURFACE_HEIGHT
-        ) as pooled:
-            pooled.lock()
-            outcomes["pooled_buffer_device"] = pooled.__dlpack_device__()
-            pooled.unlock()
-
-        try:
-            gpu_full.acquire_device_exchange_buffer(SURFACE_WIDTH, SURFACE_HEIGHT, "nv12")
-            outcomes["nv12_exchange"] = "allocated"
-        except ValueError as refusal:
-            outcomes["nv12_exchange"] = str(refusal)
-
-        # The two external-handle flavours are not interchangeable: an
-        # exchange buffer is OPAQUE_FD and has no DMA-BUF to give.
-        with gpu_full.acquire_device_exchange_buffer(
-            SURFACE_WIDTH, SURFACE_HEIGHT
-        ) as exchange_buffer:
-            try:
-                gpu_full.export_dma_buf(exchange_buffer)
-                outcomes["dma_buf_from_exchange_buffer"] = "exported"
-            except ValueError as refusal:
-                outcomes["dma_buf_from_exchange_buffer"] = str(refusal)
-        return outcomes
-
-
-def test_the_device_path_refuses_what_it_cannot_honour():
-    observation = _run_probe(ExchangeRefusalProbe, "exchange_refusals")
-    assert "device-local" in observation["numpy_on_device_local"]
-    # A pooled buffer never claims CUDA: it has no device import to report.
-    assert observation["pooled_buffer_device"] == (DLPACK_DEVICE_CPU, 0)
-    assert "one linear allocation" in observation["nv12_exchange"]
-    assert "OPAQUE_FD-flavoured" in observation["dma_buf_from_exchange_buffer"]

--- a/sdk/streamlib-python-wheel/tests/test_device_exchange.py
+++ b/sdk/streamlib-python-wheel/tests/test_device_exchange.py
@@ -325,43 +325,195 @@ def test_the_host_side_stays_reachable_on_explicit_request():
 
 
 @processor(execution="manual")
-class NoExportKeyProbe:
+class PooledTextureExportProbe:
     def setup(self, ctx: RuntimeContextFullAccess) -> None:
-        _observe("no_export_key", lambda: self._probe(ctx))
+        _observe("pooled_texture_export", lambda: self._probe(ctx))
 
     def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
+        import torch
+
         outcomes = {}
-        # A pooled texture carries no surface id — nothing keys an export.
+        # A pooled texture acquired from the limited capability is
+        # registered at acquire, so the same staging blit that serves
+        # camera ring textures serves it — this is also the suite's
+        # coverage of the texture-first blit arm, hardware-free.
         with ctx.gpu_limited_access.acquire_texture(
             SURFACE_WIDTH, SURFACE_HEIGHT, "rgba8_unorm", ["copy_src", "texture_binding"]
         ) as texture_handle:
-            outcomes["texture_device"] = texture_handle.__dlpack_device__()
+            outcomes["texture_surface_id"] = texture_handle.surface_id
+            device = texture_handle.__dlpack_device__()
+            outcomes["texture_device"] = device
+            if device[0] == DLPACK_DEVICE_CUDA:
+                texture_handle.lock()
+                tensor = torch.from_dlpack(texture_handle)
+                outcomes["texture_tensor_shape"] = tuple(tensor.shape)
+                outcomes["texture_tensor_device"] = str(tensor.device)
+                texture_handle.unlock()
 
-        # An acquired pixel buffer resolves the device path through its id.
-        with ctx.gpu_limited_access.acquire_pixel_buffer(
+        # A full-access acquire cannot stash the lease-bound capability,
+        # so its handles stay host-side.
+        with ctx.gpu_full_access.acquire_pixel_buffer(
             SURFACE_WIDTH, SURFACE_HEIGHT
-        ) as buffer_handle:
-            outcomes["acquired_buffer_device"] = buffer_handle.__dlpack_device__()
+        ) as full_access_buffer:
+            outcomes["full_access_buffer_device"] = full_access_buffer.__dlpack_device__()
         return outcomes
 
 
-def test_export_keying_matches_what_the_surface_carries():
+def test_a_pooled_texture_exports_a_device_tensor():
+    """The ruling's "pooled textures are in scope", and the texture-first
+    blit arm's hardware-free coverage: registration at acquire is what
+    keys the export, and the tensor is read-only device memory of the
+    texture's (undefined-until-written) contents.
+    """
+    pytest.importorskip("torch")
     graph = RunningGraph()
-    graph.runtime.add(NoExportKeyProbe)
+    graph.runtime.add(PooledTextureExportProbe)
     graph.start()
     try:
-        observation = _await_observation("no_export_key")
+        observation = _await_observation("pooled_texture_export")
     finally:
         graph.shut_down()
     if "failure" in observation:
         pytest.fail(f"the probe raised:\n{observation['failure']}")
-    # No id → no device export to attempt; the host mapping answers.
-    assert observation["texture_device"] == (DLPACK_DEVICE_CPU, 0)
-    # An id + the limited capability → the device side may answer (CUDA)
-    # or fall back to the host on a driverless rig; both are legal here.
-    assert observation["acquired_buffer_device"][0] in (
-        DLPACK_DEVICE_CPU,
-        DLPACK_DEVICE_CUDA,
+    assert observation["texture_surface_id"].startswith("pooled-texture-")
+    if observation["texture_device"][0] != DLPACK_DEVICE_CUDA:
+        pytest.skip(f"no usable CUDA runtime: {observation['texture_device']}")
+    assert observation["texture_tensor_shape"] == (SURFACE_HEIGHT, SURFACE_WIDTH, 4)
+    assert observation["texture_tensor_device"].startswith("cuda")
+    # The lease-bound path stays host-side by construction.
+    assert observation["full_access_buffer_device"] == (DLPACK_DEVICE_CPU, 0)
+
+
+@processor
+class WithBlockEditProbe(_FrameProbeBase):
+    observation_name = "with_block_edit"
+
+    def _probe(self, ctx: RuntimeContextLimitedAccess, frame) -> dict:
+        import torch
+
+        gpu = ctx.gpu_limited_access
+        # The idiomatic spelling: no explicit unlock — the with-block's
+        # close is the publication point.
+        with gpu.resolve_surface(frame.surface_id) as surface:
+            surface.lock(read_only=False)
+            if surface.__dlpack_device__()[0] != DLPACK_DEVICE_CUDA:
+                return {"cuda_unavailable": "device side not reachable"}
+            tensor = torch.from_dlpack(surface)
+            tensor[5, 5] = torch.tensor(
+                [99, 88, 77, 66], dtype=torch.uint8, device=tensor.device
+            )
+            torch.cuda.synchronize()
+
+        with gpu.resolve_surface(frame.surface_id) as reread:
+            reread.lock()
+            observation = {
+                "pixel_after_with_block": numpy.from_dlpack(reread, device="cpu")[
+                    5, 5
+                ].tolist()
+            }
+            reread.unlock()
+            return observation
+
+
+def test_a_device_edit_survives_the_with_block_spelling():
+    """close() publishes pending device writes too.
+
+    A `with` block that never calls unlock reaches close() directly; an
+    edit silently discarded there is data loss in the API's own idiomatic
+    spelling. Mental-revert: drop the publish from close() and this reads
+    the untouched pattern.
+    """
+    pytest.importorskip("torch")
+    observation = _run_frame_probe(WithBlockEditProbe, "with_block_edit")
+    _skip_without_cuda(observation)
+    assert observation["pixel_after_with_block"] == [99, 88, 77, 66]
+
+
+@processor
+class CameraRotationIdentityProbe:
+    """Compares device pixels against host pixels across ring cycles."""
+
+    @input(delivery_profile="every_sample")
+    def video_from_upstream(self) -> None: ...
+
+    def __init__(self) -> None:
+        self.comparisons: "list[bool]" = []
+        self.reported = False
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        bag = ctx.inputs.read("video_from_upstream")
+        if bag is None or self.reported:
+            return
+        frame = VideoFrame.from_bag(bag)
+
+        def compare() -> dict:
+            import torch
+
+            with ctx.gpu_limited_access.resolve_surface(frame.surface_id) as surface:
+                surface.lock()
+                if surface.__dlpack_device__()[0] != DLPACK_DEVICE_CUDA:
+                    return {"cuda_unavailable": "device side not reachable"}
+                device_pixels = torch.from_dlpack(surface).cpu().numpy()
+                host_pixels = numpy.from_dlpack(surface, device="cpu")
+                return {"match": bool((device_pixels == host_pixels).all())}
+
+        try:
+            outcome = compare()
+        except BaseException:  # noqa: BLE001 — surfaced via the queue
+            import traceback
+
+            self.reported = True
+            _hook_observations.put(
+                {"observed": "camera_rotation", "failure": traceback.format_exc()}
+            )
+            return
+        if "cuda_unavailable" in outcome:
+            self.reported = True
+            _hook_observations.put({"observed": "camera_rotation", **outcome})
+            return
+        self.comparisons.append(outcome["match"])
+        # Twelve frames spans the ring several times over — the window
+        # where a source frozen at staging creation lags by a cycle.
+        if len(self.comparisons) >= 12:
+            self.reported = True
+            _hook_observations.put(
+                {"observed": "camera_rotation", "comparisons": self.comparisons}
+            )
+
+
+def test_camera_device_pixels_match_host_across_ring_cycles():
+    """Regression lock on the stale-blit-source bug.
+
+    The camera re-registers a different ring texture under the same
+    surface id every frame. A staging that resolved its source once at
+    creation blits the previous cycle's frame — live-reproduced during
+    review as device pixels lagging host pixels by one ring cycle from
+    frame ~6 on. Per-refill resolution is the fix; this asserts identity
+    across 12 consecutive frames.
+    """
+    pytest.importorskip("torch")
+    import pathlib
+
+    if not pathlib.Path("/dev/video0").exists():
+        pytest.skip("no camera on this rig")
+    from streamlib import CameraSource
+
+    graph = RunningGraph()
+    camera = graph.runtime.add(CameraSource, config={"device_id": "/dev/video0"})
+    probe = graph.runtime.add(CameraRotationIdentityProbe)
+    graph.runtime.connect(camera.output("video"), probe.input("video_from_upstream"))
+    graph.start()
+    try:
+        observation = _await_observation("camera_rotation")
+    finally:
+        graph.shut_down()
+    if "failure" in observation:
+        pytest.fail(f"the probe raised:\n{observation['failure']}")
+    _skip_without_cuda(observation)
+    mismatches = [i for i, ok in enumerate(observation["comparisons"]) if not ok]
+    assert not mismatches, (
+        f"device pixels diverged from host pixels on frames {mismatches} — the blit "
+        f"exported a stale ring texture"
     )
 
 

--- a/sdk/streamlib-python-wheel/tests/test_device_exchange.py
+++ b/sdk/streamlib-python-wheel/tests/test_device_exchange.py
@@ -282,6 +282,60 @@ def test_a_device_tensor_outliving_its_handle_keeps_a_live_mapping():
 
 
 # ---------------------------------------------------------------------------
+# DMA-BUF — the other dialect native code speaks
+# ---------------------------------------------------------------------------
+
+
+@processor(execution="manual")
+class DmaBufRoundTripProbe:
+    """Exports a surface's DMA-BUF fd and imports it back as a second surface."""
+
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        _observe("dma_buf_round_trip", lambda: self._probe(ctx))
+
+    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
+        gpu_full = ctx.gpu_full_access
+        with ctx.gpu_limited_access.acquire_pixel_buffer(
+            SURFACE_WIDTH, SURFACE_HEIGHT
+        ) as exported_surface:
+            exported_surface.lock(read_only=False)
+            exported_surface.as_numpy()[:, :, :] = 0
+            exported_surface.as_numpy()[7, 9] = [21, 43, 65, 87]
+            exported_surface.unlock()
+
+            fd, byte_size = gpu_full.export_dma_buf(exported_surface)
+            observation = {
+                "fd_is_real": fd >= 0,
+                "byte_size": byte_size,
+                "expected_byte_size": SURFACE_WIDTH * SURFACE_HEIGHT * 4,
+            }
+            # The import adopts the fd, so nothing here closes it.
+            with gpu_full.import_dma_buf(
+                fd, SURFACE_WIDTH, SURFACE_HEIGHT
+            ) as imported_surface:
+                imported_surface.lock()
+                observation["pixel_seen_through_the_import"] = (
+                    imported_surface.as_numpy()[7, 9].tolist()
+                )
+                imported_surface.unlock()
+            return observation
+
+
+def test_a_dma_buf_export_reimports_as_the_same_memory():
+    """The export/import pair is a handle to one allocation, not a copy.
+
+    This is the shape third-party native code gets: an fd it can hand to EGL,
+    a V4L2 output device, or another process. Round-tripping it through the
+    engine's own importer is how we check the handle actually describes the
+    frame rather than merely being a valid fd.
+    """
+    observation = _run_probe(DmaBufRoundTripProbe, "dma_buf_round_trip")
+    assert observation["fd_is_real"]
+    assert observation["byte_size"] == observation["expected_byte_size"]
+    assert observation["pixel_seen_through_the_import"] == [21, 43, 65, 87]
+
+
+# ---------------------------------------------------------------------------
 # Refusals
 # ---------------------------------------------------------------------------
 
@@ -321,6 +375,17 @@ class ExchangeRefusalProbe:
             outcomes["nv12_exchange"] = "allocated"
         except ValueError as refusal:
             outcomes["nv12_exchange"] = str(refusal)
+
+        # The two external-handle flavours are not interchangeable: an
+        # exchange buffer is OPAQUE_FD and has no DMA-BUF to give.
+        with gpu_full.acquire_device_exchange_buffer(
+            SURFACE_WIDTH, SURFACE_HEIGHT
+        ) as exchange_buffer:
+            try:
+                gpu_full.export_dma_buf(exchange_buffer)
+                outcomes["dma_buf_from_exchange_buffer"] = "exported"
+            except ValueError as refusal:
+                outcomes["dma_buf_from_exchange_buffer"] = str(refusal)
         return outcomes
 
 
@@ -330,3 +395,4 @@ def test_the_device_path_refuses_what_it_cannot_honour():
     # A pooled buffer never claims CUDA: it has no device import to report.
     assert observation["pooled_buffer_device"] == (DLPACK_DEVICE_CPU, 0)
     assert "one linear allocation" in observation["nv12_exchange"]
+    assert "OPAQUE_FD-flavoured" in observation["dma_buf_from_exchange_buffer"]

--- a/sdk/streamlib-python-wheel/tests/test_pixel_exchange.py
+++ b/sdk/streamlib-python-wheel/tests/test_pixel_exchange.py
@@ -1,0 +1,450 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""The pixel-exchange surface, proven against a running engine.
+
+Pixels reach Python in place: a numpy view or a DLPack tensor addresses the
+same bytes the engine allocated, so a write through the view is visible to
+anything else holding that surface. The three contracts worth breaking a build
+over are here — the row pitch survives into the strides, an export taken
+without a lock is refused, and a tensor that outlives its frame keeps
+addressing live memory rather than a recycled pool slot.
+"""
+
+import queue
+import threading
+import time
+
+import numpy
+import pytest
+
+import streamlib
+from streamlib import RuntimeContextFullAccess, processor
+
+pytestmark = pytest.mark.requires_gpu
+
+PIPELINE_TIMEOUT_SECONDS = 30.0
+
+SURFACE_WIDTH = 64
+SURFACE_HEIGHT = 32
+
+# What a hook observed, drained by the test after the graph runs. Module-level
+# because configuration is JSON on the graph node — a queue cannot travel
+# through `config`.
+_hook_observations: "queue.Queue[dict]" = queue.Queue()
+
+
+@pytest.fixture(autouse=True)
+def clean_observation_queue():
+    while True:
+        try:
+            _hook_observations.get_nowait()
+        except queue.Empty:
+            break
+    yield
+
+
+class RunningGraph:
+    """A graph running on a worker thread, shut down and joined on exit."""
+
+    def __init__(self) -> None:
+        self.runtime = streamlib.Runtime()
+        self.run_outcome: "queue.Queue[BaseException | None]" = queue.Queue()
+        self._run_loop = threading.Thread(target=self._run, daemon=True)
+
+    def _run(self) -> None:
+        try:
+            self.runtime.run()
+        except BaseException as run_failure:  # noqa: BLE001 — surfaced by the caller
+            self.run_outcome.put(run_failure)
+        else:
+            self.run_outcome.put(None)
+
+    def start(self) -> None:
+        self._run_loop.start()
+
+    def shut_down(self) -> None:
+        self.runtime.shutdown()
+        self._run_loop.join(timeout=PIPELINE_TIMEOUT_SECONDS)
+        assert not self._run_loop.is_alive(), "run() never returned after shutdown()"
+
+
+def _await_observation(matching: str) -> dict:
+    deadline = time.monotonic() + PIPELINE_TIMEOUT_SECONDS
+    while True:
+        remaining = deadline - time.monotonic()
+        assert remaining > 0, f"no {matching!r} observation arrived within the timeout"
+        try:
+            observation = _hook_observations.get(timeout=min(0.5, remaining))
+        except queue.Empty:
+            continue
+        if observation.get("observed") == matching:
+            return observation
+
+
+def _observe(matching: str, probe_body):
+    """Run a probe body, reporting whatever it raises as the observation.
+
+    A hook that raises is logged and swallowed by the host, so without this
+    every mistake in a probe arrives as an indistinguishable 30-second timeout.
+    """
+    try:
+        _hook_observations.put({"observed": matching, **probe_body()})
+    except BaseException as probe_failure:  # noqa: BLE001 — re-raised by the test
+        import traceback
+
+        _hook_observations.put(
+            {"observed": matching, "failure": traceback.format_exc()}
+        )
+        del probe_failure
+
+
+def _run_probe(probe_class: type, matching: str) -> dict:
+    graph = RunningGraph()
+    graph.runtime.add(probe_class)
+    graph.start()
+    try:
+        observation = _await_observation(matching)
+    finally:
+        graph.shut_down()
+    if "failure" in observation:
+        pytest.fail(f"the probe raised:\n{observation['failure']}")
+    return observation
+
+
+# ---------------------------------------------------------------------------
+# Layout
+# ---------------------------------------------------------------------------
+
+
+@processor(execution="manual")
+class NumpyViewProbe:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        _observe("numpy_view", lambda: self._probe(ctx))
+
+    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
+        with ctx.gpu_limited_access.acquire_pixel_buffer(
+            SURFACE_WIDTH, SURFACE_HEIGHT
+        ) as surface_handle:
+            surface_handle.lock(read_only=False)
+            view = surface_handle.as_numpy()
+            observation = {
+                "shape": view.shape,
+                "dtype": str(view.dtype),
+                "strides": view.strides,
+                "bytes_per_row": surface_handle.bytes_per_row,
+                "owns_its_data": view.flags["OWNDATA"],
+                "dlpack_device": surface_handle.__dlpack_device__(),
+            }
+            surface_handle.unlock()
+            return observation
+
+
+def test_the_numpy_view_is_a_shared_window_with_the_allocations_row_pitch():
+    """`(height, width, 4)` uint8, strides straight off the allocation.
+
+    The strides are the load-bearing part: DLPack counts them in elements and
+    numpy in bytes, so a producer that forgot the conversion would hand back an
+    array that reads every fourth row as if it were adjacent.
+    """
+    observation = _run_probe(NumpyViewProbe, "numpy_view")
+    assert observation["shape"] == (SURFACE_HEIGHT, SURFACE_WIDTH, 4)
+    assert observation["dtype"] == "uint8"
+    assert observation["strides"] == (observation["bytes_per_row"], 4, 1)
+    assert observation["bytes_per_row"] >= SURFACE_WIDTH * 4
+    assert not observation["owns_its_data"], (
+        "the view copied the pixels instead of sharing them"
+    )
+    # kDLCPU — a host-visible mapping, addressed with ordinary loads.
+    assert observation["dlpack_device"] == (1, 0)
+
+
+# ---------------------------------------------------------------------------
+# The lock gate
+# ---------------------------------------------------------------------------
+
+
+@processor(execution="manual")
+class UnlockedExportProbe:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        _observe("unlocked_export", lambda: self._probe(ctx))
+
+    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
+        with ctx.gpu_limited_access.acquire_pixel_buffer(
+            SURFACE_WIDTH, SURFACE_HEIGHT
+        ) as surface_handle:
+            outcomes = {}
+            try:
+                surface_handle.__dlpack__()
+                outcomes["unlocked_dlpack"] = "returned a tensor"
+            except RuntimeError as refusal:
+                outcomes["unlocked_dlpack"] = str(refusal)
+            outcomes["unlocked_base_address"] = surface_handle.base_address
+
+            surface_handle.lock()
+            outcomes["locked_base_address_is_nonzero"] = surface_handle.base_address != 0
+            surface_handle.unlock()
+
+            try:
+                surface_handle.as_numpy()
+                outcomes["after_unlock"] = "returned a view"
+            except RuntimeError as refusal:
+                outcomes["after_unlock"] = str(refusal)
+            return outcomes
+
+
+@processor(execution="manual")
+class LockModeProbe:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        _observe("lock_mode", lambda: self._probe(ctx))
+
+    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
+        gpu = ctx.gpu_limited_access
+        outcomes = {}
+        with gpu.acquire_pixel_buffer(SURFACE_WIDTH, SURFACE_HEIGHT) as surface_handle:
+            surface_handle.lock(read_only=True)
+            try:
+                surface_handle.as_numpy()[0, 0] = [9, 9, 9, 9]
+                outcomes["write_under_a_read_lock"] = "succeeded"
+            except ValueError as refusal:
+                outcomes["write_under_a_read_lock"] = str(refusal)
+            surface_handle.unlock()
+
+            surface_handle.lock(read_only=False)
+            surface_handle.as_numpy()[0, 0] = [9, 9, 9, 9]
+            outcomes["write_under_a_write_lock"] = "succeeded"
+            surface_handle.unlock()
+        return outcomes
+
+
+def test_a_read_only_lock_produces_a_read_only_view():
+    """`read_only` is carried to the consumer, not just recorded locally.
+
+    Only DLPack's versioned exchange shape has a flags field, so this is
+    also the check that the version negotiation is wired up: on the legacy
+    shape every tensor arrives read-only and the write lock would look
+    broken.
+    """
+    observation = _run_probe(LockModeProbe, "lock_mode")
+    assert "read-only" in observation["write_under_a_read_lock"]
+    assert observation["write_under_a_write_lock"] == "succeeded"
+
+
+def test_an_export_taken_without_a_lock_is_refused():
+    """The lock is where the wait for the producer happens.
+
+    Handing out a tensor without one would let a processor read a frame the
+    camera is still writing — a torn image that looks like a driver bug rather
+    than a missing synchronisation point. `base_address` reports 0 rather than
+    a live pointer for the same reason.
+    """
+    observation = _run_probe(UnlockedExportProbe, "unlocked_export")
+    assert "not locked" in observation["unlocked_dlpack"]
+    assert observation["unlocked_base_address"] == 0
+    assert observation["locked_base_address_is_nonzero"]
+    assert "not locked" in observation["after_unlock"], (
+        "unlock must close the gate again, not leave it open for the surface's life"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sharing — a write through the view is not a write to a copy
+# ---------------------------------------------------------------------------
+
+
+@processor(execution="manual")
+class SharedMemoryProbe:
+    """Writes through one handle, reads through a second one resolved by id."""
+
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        _observe("shared_memory", lambda: self._probe(ctx))
+
+    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
+        gpu = ctx.gpu_limited_access
+        with gpu.acquire_pixel_buffer(SURFACE_WIDTH, SURFACE_HEIGHT) as writer_handle:
+            writer_handle.lock(read_only=False)
+            writer_view = writer_handle.as_numpy()
+            writer_view[:, :, :] = 0
+            writer_view[3, 5] = [11, 22, 33, 44]
+            writer_handle.unlock()
+
+            with gpu.resolve_surface(writer_handle.surface_id) as reader_handle:
+                reader_handle.lock()
+                reader_view = reader_handle.as_numpy()
+                observation = {
+                    "pixel_seen_by_the_reader": reader_view[3, 5].tolist(),
+                    "an_untouched_pixel": reader_view[0, 0].tolist(),
+                }
+                reader_handle.unlock()
+                return observation
+
+
+def test_a_write_through_the_view_is_visible_to_another_holder_of_the_surface():
+    """Zero-copy means one buffer, not two that agree.
+
+    A second handle resolved by `surface_id` must observe the write, because
+    both views address the engine's allocation directly.
+    """
+    observation = _run_probe(SharedMemoryProbe, "shared_memory")
+    assert observation["pixel_seen_by_the_reader"] == [11, 22, 33, 44]
+    assert observation["an_untouched_pixel"] == [0, 0, 0, 0]
+
+
+# ---------------------------------------------------------------------------
+# Lifetime — the regression the ticket names
+# ---------------------------------------------------------------------------
+
+
+@processor(execution="manual")
+class TensorOutlivesTheSurfaceProbe:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        _observe("tensor_outlives_surface", lambda: self._probe(ctx))
+
+    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
+        surface_handle = ctx.gpu_limited_access.acquire_pixel_buffer(
+            SURFACE_WIDTH, SURFACE_HEIGHT
+        )
+        surface_handle.lock(read_only=False)
+        view = surface_handle.as_numpy()
+        view[:, :, :] = 7
+        # The frame is done with; Python is not.
+        surface_handle.unlock()
+        surface_handle.close()
+        del surface_handle
+
+        return {
+            "still_readable": int(view[1, 1, 0]),
+            "sum_after_close": int(view.sum()),
+            "expected_sum": SURFACE_WIDTH * SURFACE_HEIGHT * 4 * 7,
+        }
+
+
+def test_a_tensor_outliving_its_surface_keeps_addressing_live_memory():
+    """Use-after-free regression.
+
+    A closed handle must not free the mapping a numpy view still points at.
+    The engine value and the pool-slot release live behind a refcount every
+    outstanding tensor holds a share of, so `close()` drops the handle's share
+    and nothing more.
+
+    Mental-revert: move the release back into `close()` — this test reads freed
+    memory, and the failure is a segfault or garbage rather than an assertion.
+    """
+    observation = _run_probe(
+        TensorOutlivesTheSurfaceProbe, "tensor_outlives_surface"
+    )
+    assert observation["still_readable"] == 7
+    assert observation["sum_after_close"] == observation["expected_sum"]
+
+
+@processor(execution="manual")
+class PoolCycleProbe:
+    """Holds a tensor, then churns the pool past its depth with fresh writes."""
+
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        _observe("pool_cycle", lambda: self._probe(ctx))
+
+    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
+        gpu = ctx.gpu_limited_access
+        held_handle = gpu.acquire_pixel_buffer(SURFACE_WIDTH, SURFACE_HEIGHT)
+        held_handle.lock(read_only=False)
+        held_view = held_handle.as_numpy()
+        held_view[:, :, :] = 3
+        held_handle.unlock()
+        held_handle.close()
+
+        churn_failures = []
+        for cycle in range(8):
+            try:
+                with gpu.acquire_pixel_buffer(
+                    SURFACE_WIDTH, SURFACE_HEIGHT
+                ) as churned_handle:
+                    churned_handle.lock(read_only=False)
+                    # A different value per cycle: if a slot were handed back
+                    # while the held tensor still addressed it, this is the
+                    # write that would show up there.
+                    churned_handle.as_numpy()[:, :, :] = 100 + cycle
+                    churned_handle.unlock()
+            except RuntimeError as acquire_failure:
+                churn_failures.append(str(acquire_failure))
+
+        return {
+            "held_values": sorted(set(held_view.flatten().tolist())),
+            "churn_failures": churn_failures,
+        }
+
+
+def test_a_held_tensor_is_not_overwritten_by_pool_reuse():
+    """Ring-slot reuse is gated on the consumer being done.
+
+    Churning the pool past its depth while a tensor is outstanding must not
+    hand that tensor's slot to a new acquire — the held pixels stay as written.
+    """
+    observation = _run_probe(PoolCycleProbe, "pool_cycle")
+    assert observation["churn_failures"] == []
+    assert observation["held_values"] == [3], (
+        f"the held tensor was overwritten by a later acquire: "
+        f"saw {observation['held_values']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Interop
+# ---------------------------------------------------------------------------
+
+
+@processor(execution="manual")
+class DlpackConsumerProbe:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        _observe("dlpack_consumer", lambda: self._probe(ctx))
+
+    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
+        with ctx.gpu_limited_access.acquire_pixel_buffer(
+            SURFACE_WIDTH, SURFACE_HEIGHT
+        ) as surface_handle:
+            surface_handle.lock(read_only=False)
+            surface_handle.as_numpy()[2, 2] = [1, 2, 3, 4]
+            # What a framework's own `from_dlpack` does: consume the exporting
+            # object, which calls `__dlpack__` on it.
+            consumed = numpy.from_dlpack(surface_handle)
+            observation = {
+                "pixel": consumed[2, 2].tolist(),
+                "shape": consumed.shape,
+            }
+            surface_handle.unlock()
+            return observation
+
+
+def test_a_dlpack_consumer_sees_the_same_pixels():
+    observation = _run_probe(DlpackConsumerProbe, "dlpack_consumer")
+    assert observation["pixel"] == [1, 2, 3, 4]
+    assert observation["shape"] == (SURFACE_HEIGHT, SURFACE_WIDTH, 4)
+
+
+@processor(execution="manual")
+class UnsupportedFormatProbe:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        _observe("unsupported_format", lambda: self._probe(ctx))
+
+    def _probe(self, ctx: RuntimeContextFullAccess) -> dict:
+        with ctx.gpu_limited_access.acquire_pixel_buffer(
+            SURFACE_WIDTH, SURFACE_HEIGHT, "nv12"
+        ) as surface_handle:
+            surface_handle.lock()
+            try:
+                surface_handle.__dlpack__()
+                outcome = "returned a tensor"
+            except ValueError as refusal:
+                outcome = str(refusal)
+            surface_handle.unlock()
+            return {"outcome": outcome}
+
+
+def test_a_multi_plane_format_is_refused_rather_than_exported_as_luma():
+    """NV12 is two planes and DLPack is one buffer.
+
+    Exporting plane 0 would hand back a greyscale image that looks like a
+    working colour frame until someone notices the chroma is missing.
+    """
+    observation = _run_probe(UnsupportedFormatProbe, "unsupported_format")
+    assert "one strided linear buffer" in observation["outcome"]

--- a/sdk/streamlib-python-wheel/tests/test_pixel_exchange.py
+++ b/sdk/streamlib-python-wheel/tests/test_pixel_exchange.py
@@ -189,7 +189,7 @@ class UnlockedExportProbe:
             outcomes["unlocked_base_address"] = surface_handle.base_address
 
             surface_handle.lock()
-            outcomes["locked_base_address_is_nonzero"] = surface_handle.base_address != 0
+            outcomes["locked_base_address_is_real"] = surface_handle.base_address is not None
             surface_handle.unlock()
 
             try:
@@ -244,13 +244,13 @@ def test_an_export_taken_without_a_lock_is_refused():
     publication, since a source finishes its GPU work before it sends the
     frame on. What the gate buys is that read/write intent is stated at the
     call site, which is what carries through to the exported tensor's flags,
-    and that `base_address` never hands out a pointer nobody declared a use
-    for.
+    and that `base_address` is None rather than a live pointer nobody
+    declared a use for.
     """
     observation = _run_probe(UnlockedExportProbe, "unlocked_export")
     assert "not locked" in observation["unlocked_dlpack"]
-    assert observation["unlocked_base_address"] == 0
-    assert observation["locked_base_address_is_nonzero"]
+    assert observation["unlocked_base_address"] is None
+    assert observation["locked_base_address_is_real"]
     assert "not locked" in observation["after_unlock"], (
         "unlock must close the gate again, not leave it open for the surface's life"
     )

--- a/sdk/streamlib-python-wheel/tests/test_pixel_exchange.py
+++ b/sdk/streamlib-python-wheel/tests/test_pixel_exchange.py
@@ -144,7 +144,6 @@ class NumpyViewProbe:
                 "strides": view.strides,
                 "bytes_per_row": surface_handle.bytes_per_row,
                 "owns_its_data": view.flags["OWNDATA"],
-                "dlpack_device": surface_handle.__dlpack_device__(),
             }
             surface_handle.unlock()
             return observation
@@ -165,8 +164,6 @@ def test_the_numpy_view_is_a_shared_window_with_the_allocations_row_pitch():
     assert not observation["owns_its_data"], (
         "the view copied the pixels instead of sharing them"
     )
-    # kDLCPU — a host-visible mapping, addressed with ordinary loads.
-    assert observation["dlpack_device"] == (1, 0)
 
 
 # ---------------------------------------------------------------------------
@@ -416,9 +413,10 @@ class DlpackConsumerProbe:
         ) as surface_handle:
             surface_handle.lock(read_only=False)
             surface_handle.as_numpy()[2, 2] = [1, 2, 3, 4]
-            # What a framework's own `from_dlpack` does: consume the exporting
-            # object, which calls `__dlpack__` on it.
-            consumed = numpy.from_dlpack(surface_handle)
+            # What a CPU framework's `from_dlpack` does: consume the exporting
+            # object, asking for the host side — a graph frame's natural side
+            # is the device, so the request is load-bearing, not decoration.
+            consumed = numpy.from_dlpack(surface_handle, device="cpu")
             observation = {
                 "pixel": consumed[2, 2].tolist(),
                 "shape": consumed.shape,

--- a/sdk/streamlib-python-wheel/tests/test_pixel_exchange.py
+++ b/sdk/streamlib-python-wheel/tests/test_pixel_exchange.py
@@ -19,7 +19,17 @@ import numpy
 import pytest
 
 import streamlib
-from streamlib import RuntimeContextFullAccess, processor
+
+# `input` is streamlib's port decorator — the test reads like user code,
+# which spells it exactly this way.
+from streamlib import (  # noqa: A004
+    RuntimeContextFullAccess,
+    RuntimeContextLimitedAccess,
+    TestPatternSource,
+    VideoFrame,
+    input,
+    processor,
+)
 
 pytestmark = pytest.mark.requires_gpu
 
@@ -419,6 +429,96 @@ def test_a_dlpack_consumer_sees_the_same_pixels():
     observation = _run_probe(DlpackConsumerProbe, "dlpack_consumer")
     assert observation["pixel"] == [1, 2, 3, 4]
     assert observation["shape"] == (SURFACE_HEIGHT, SURFACE_WIDTH, 4)
+
+
+# ---------------------------------------------------------------------------
+# The whole point, end to end
+# ---------------------------------------------------------------------------
+
+_effect_reports: "queue.Queue[dict]" = queue.Queue()
+
+
+@processor
+class InvertingEffect:
+    """What a user writes: read the frame, change the pixels, pass it on.
+
+    The frame arrives as a surface id, not pixels — so the effect resolves it,
+    opens CPU access, and edits the engine's own memory in place.
+    """
+
+    @input(delivery_profile="every_sample")
+    def video_from_upstream(self) -> None: ...
+
+    def __init__(self) -> None:
+        self.frames_seen = 0
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        bag = ctx.inputs.read("video_from_upstream")
+        if bag is None or self.frames_seen >= 1:
+            return
+        self.frames_seen += 1
+        frame = VideoFrame.from_bag(bag)
+        try:
+            with ctx.gpu_limited_access.resolve_surface(frame.surface_id) as surface:
+                surface.lock(read_only=False)
+                pixels = surface.as_numpy()
+                before = pixels[10, 10].tolist()
+                # The edit: invert every channel, in place.
+                numpy.subtract(255, pixels, out=pixels)
+                after_through_this_view = pixels[10, 10].tolist()
+                surface.unlock()
+
+            # A second, independent resolve of the same id. If the edit had
+            # landed in a copy, this reads the original pattern back.
+            with ctx.gpu_limited_access.resolve_surface(frame.surface_id) as reread:
+                reread.lock()
+                after_through_a_fresh_resolve = reread.as_numpy()[10, 10].tolist()
+                reread.unlock()
+
+            _effect_reports.put(
+                {
+                    "before": before,
+                    "after_through_this_view": after_through_this_view,
+                    "after_through_a_fresh_resolve": after_through_a_fresh_resolve,
+                    "frame_size": (frame.width, frame.height),
+                }
+            )
+        except BaseException:  # noqa: BLE001 — surfaced by the test
+            import traceback
+
+            _effect_reports.put({"failure": traceback.format_exc()})
+
+
+def test_a_processor_edits_a_synthetic_frames_pixels_in_place():
+    """The user-facing story: source → effect → the pixels really changed.
+
+    A native source produces frames the interpreter never touches; a Python
+    processor reaches into one and rewrites it. Re-resolving the surface
+    afterwards is what proves the edit went into the engine's memory rather
+    than a copy handed to Python.
+    """
+    while not _effect_reports.empty():
+        _effect_reports.get_nowait()
+
+    graph = RunningGraph()
+    pattern = graph.runtime.add(
+        TestPatternSource, config={"width": 320, "height": 180}
+    )
+    effect = graph.runtime.add(InvertingEffect)
+    graph.runtime.connect(pattern.output("video"), effect.input("video_from_upstream"))
+    graph.start()
+    try:
+        report = _effect_reports.get(timeout=PIPELINE_TIMEOUT_SECONDS)
+    finally:
+        graph.shut_down()
+
+    if "failure" in report:
+        pytest.fail(f"the effect raised:\n{report['failure']}")
+    assert report["frame_size"] == (320, 180)
+    assert report["after_through_this_view"] == [255 - channel for channel in report["before"]]
+    assert report["after_through_a_fresh_resolve"] == report["after_through_this_view"], (
+        "a fresh resolve did not see the edit — the pixels Python wrote were a copy"
+    )
 
 
 @processor(execution="manual")

--- a/sdk/streamlib-python-wheel/tests/test_pixel_exchange.py
+++ b/sdk/streamlib-python-wheel/tests/test_pixel_exchange.py
@@ -241,12 +241,14 @@ def test_a_read_only_lock_produces_a_read_only_view():
 
 
 def test_an_export_taken_without_a_lock_is_refused():
-    """The lock is where the wait for the producer happens.
+    """The gate is access discipline, not synchronisation.
 
-    Handing out a tensor without one would let a processor read a frame the
-    camera is still writing — a torn image that looks like a driver bug rather
-    than a missing synchronisation point. `base_address` reports 0 rather than
-    a live pointer for the same reason.
+    It does not wait for anything — ordering against the producer comes from
+    publication, since a source finishes its GPU work before it sends the
+    frame on. What the gate buys is that read/write intent is stated at the
+    call site, which is what carries through to the exported tensor's flags,
+    and that `base_address` never hands out a pointer nobody declared a use
+    for.
     """
     observation = _run_probe(UnlockedExportProbe, "unlocked_export")
     assert "not locked" in observation["unlocked_dlpack"]


### PR DESCRIPTION
## Summary

Zero-CPU-copy frame exchange for the Python wheel — the four seams #1708 stubbed, built to the owner ruling on #1710 (Option A, the staging blit, done in the shape #1714 mirrors).

**The user-facing result:**

```python
frame = VideoFrame.from_bag(bag)
with ctx.gpu_limited_access.resolve_surface(frame.surface_id) as surface:
    surface.lock(read_only=False)
    tensor = torch.from_dlpack(surface)   # CUDA tensor — zero CPU copies
    tensor[:] = model(tensor)             # GPU-side edit
    # exiting the block publishes the edit back to the surface
```

- **Host side**: `as_numpy()` / DLPack over the engine's own memory — skia/PIL/cv2 all eat the numpy view. Row pitch from the allocation, writable via DLPack v1.x negotiation, `device="cpu"` selects it explicitly.
- **Device side**: per-surface OPAQUE_FD staging + exportable timeline in the engine (`device_export_staging.rs`), blit sourced texture-first (VRAM→VRAM off the camera's ring, ~21 µs at 1080p; buffer→buffer PCIe fallback), source resolved **per refill** so rotating producers are never stale. `__dlpack_device__`/`__dlpack__` decide the side once per handle and never disagree.
- **DMA-BUF export/import** for native code that speaks that dialect.
- **Pooled textures** registered at acquire under a minted id — the same staging blit serves them (ruling's in-scope item).
- **Lifetime**: engine value, staging, and CUDA import all ride the capsule owner — a tensor outliving its handle keeps live memory across all three allocators; pool-slot reuse is gated on release.
- `acquire_device_exchange_buffer` (an earlier inline design) does not exist; the plan gate caught it and the ruling replaced it.

Two independent review rounds (correctness + Rust craftsmanship) ran before this PR; every blocker and should-fix is addressed or listed below. The correctness reviewer live-reproduced a wrong-pixels bug on the camera (staging source frozen at creation → device tensors lagged a ring cycle); the fix is per-refill resolution, locked by a camera test asserting device==host pixels across 12 frames.

## Closes

Closes #1710

## Exit criteria

- [x] Frames/textures expose `__dlpack__` over the Vulkan↔CUDA path (OPAQUE_FD → external memory → device pointer) — graph frames and pooled textures, verified with real `torch.from_dlpack` on the rig
- [x] DMA-BUF export/import round-trips
- [x] CPU numpy fallback (via the host mapping — ticket body's cpu-readback-adapter line superseded by recon, see ticket)
- [x] Sync/lifetime/layout owned by the engine's export surface; ring-slot reuse gated on consume
- [x] Regression tests: use-after-free (tensor outlives frame/handle, both allocent layers), stale-source rotation (camera), write-publication (explicit unlock and with-block spellings)
- [x] Demo: processor mutates synthetic frames in place via numpy and via torch; re-resolve proves in-place

## Test plan

- `pytest tests/` (wheel venv): **100 passed** — incl. camera rotation identity, with-block publish, pooled-texture device export, torch round-trip, three-layer lifetime
- `cargo test -p streamlib-python-wheel --lib` (26), `-p streamlib-adapter-cuda --lib` (34, incl. DLPack v0.8 + v1.x layout regression)
- stubtest + pyright: clean; `cargo xtask check-boundaries`: 7,444 files, no violations
- Rig: RTX 3090, driver 595.84, /dev/video0. **None of the Python evidence runs in CI** — both suites are `requires_gpu` and CI deselects that marker.

## Notes for owner

- **Latent bug (pre-existing, now nearer the surface):** `surface_store.rs:1005-1012` wraps checked-out fds unconditionally as `RhiExternalHandle::DmaBuf`, ignoring the `handle_type` the service returns. Unreachable today; #1714's OPAQUE_FD staging checkout would reach it.
- **Read-before-signal disposition:** the ticket's regression-test line assumed the lock waits. Publication is the engine's actual ordering point (a source waits on its own timeline before writing the surface id downstream); all wording now says so, and the camera identity test is the ordering evidence. A strict read-before-signal test would need a deliberately misbehaving producer — did not build one.
- **Helper placement:** in-process only here, by the ruling; the staging+timeline shape is what #1714 wires a child onto.
- **cudarc floor dropped to `cuda-12060`:** torch cu126 wheels bundle libcudart 12.6, and a 12.9-only symbol panics cudarc's loader when that copy wins the dlopen race. Every cudarc symbol used workspace-wide predates 12.0 (reviewer-enumerated).
- **Worth a learning doc:** the measured NVIDIA `compatibleHandleTypes` disjointness (OPAQUE_FD ⊥ DMA_BUF) — the engine records only the runtime symptom today.
- **Deferred polish** (reviewer lows): `surface_format_name` could be `&'static str`; `bind_cuda_device_by_uuid` leaves the thread's CUDA device changed (documented behavior of import); `mod` ordering nit in `core/context/mod.rs`.
- **Pre-existing failures not touched:** `println!` clippy in three untouched adapter-cuda test files; ~117 fmt diffs in engine files outside this diff.
- **Darwin cross-check not runnable on this rig** (bzip2-sys cross CC missing). Non-Linux compilation addressed by reading (adapter-cuda's dlpack module now platform-agnostic; device paths cfg-gated) but not proven by a compiler.
- Frame-DX sugar (the `into=` cast protocol, `frame.gpu()`/`frame.cpu()`) is on #1731's agenda per owner approval — not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPU surface pixel exchange for Python through NumPy and DLPack, including zero-copy access, locking, row-pitch support, and device-write synchronization.
  * Added Linux DMA-BUF export and import for GPU surfaces and pixel buffers.
  * Added CUDA interoperability for sharing Vulkan-backed surface data without copying.
  * Added support for pooled textures and improved surface ownership and lifetime handling.
* **Compatibility**
  * Updated CUDA support to target CUDA 12.6.
  * DLPack functionality is available across platforms; CUDA-specific features remain Linux-only.
* **Documentation**
  * Documented NVIDIA external-memory handle compatibility and required cross-format transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->