### PR TITLE
pivot(plan): control-plane exposure is an auth question, not a bind question

### DIFF
--- a/docs/decisions/control-plane-bind-posture.md
+++ b/docs/decisions/control-plane-bind-posture.md
@@ -1,0 +1,48 @@
+# Control-plane exposure is an auth question, not a bind question
+
+Rationale for the `[control-plane-bind-posture]` entries in `docs/plan/ARCHITECTURE.md`
+§Control plane & observability, decided 2026-08-04.
+
+## Trigger
+
+Read this before changing what address a node listens on by default, before giving `dev`
+a different network posture from `run`, and before treating a narrow bind as the thing
+that protects a node.
+
+## Decision
+
+`dev` and `run` bind the control plane identically — all interfaces (`0.0.0.0`) by
+default, narrowed per invocation by `--host`. There is no dev-only exposure posture.
+
+Scoping exposure down belongs entirely to the OPEN auth and remote-access posture. A
+node another host can reach is bound wide by definition, so the bind address cannot be
+the lever that scopes exposure: it is a reachability control, and the system's target
+shape — nodes discovering and driving each other across a mesh — requires reachability.
+What remains is *who may call*, which is authentication and authorization. Until that is
+decided, nothing narrows the default.
+
+> ~~`dev` binds loopback by default.~~ — Superseded 2026-08-04 by this record. The
+> behaviour never existed: the retired Rust `run`/`dev` bound all interfaces, and the
+> wheel's launcher preserves that. The plan text was the thing out of step, and deciding
+> a bind default ahead of the auth posture was premature.
+
+## Rejected alternatives
+
+- **`dev` loopback, `run` wide** — makes the dev loop unable to reach a mesh, the one
+  thing a second host needs to see; a developer's first cross-machine test then fails
+  for a reason the plan invented.
+- **Bind default and auth posture decided separately** — two dials for one concern, and
+  the bind dial would be settled first while providing none of the protection, inviting
+  a narrow default to stand in for the missing auth story.
+- **Narrow default with a mesh opt-in flag** — a new configuration dial, which the
+  zero-ceremony bar forbids, and it still answers reachability rather than authority.
+
+## Consequences
+
+- A node on a shared network is reachable by anything that can route to it until the
+  auth posture lands. Accepted knowingly: the alternative is a dev loop that cannot do
+  what the product is for.
+- The auth posture now carries the whole exposure question, including the mesh-facing
+  half — it cannot be settled as authentication mechanics alone.
+- `--host` stays the per-invocation narrowing lever for anyone who wants it today; it is
+  an override, never a default.

--- a/docs/plan/ARCHITECTURE.md
+++ b/docs/plan/ARCHITECTURE.md
@@ -224,7 +224,7 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   adapter closure excludes skia. Helper processes import the wheel itself — one
   native artifact, no separate helper cdylib. [importable-python-library]
 
-## Control plane & observability — IN-FLIGHT (→ importable-python-library)
+## Control plane & observability — IN-FLIGHT (→ importable-python-library, control-plane-bind-posture)
 
 - **DECIDED** — One control plane: the api-server's HTTP + WebSocket + MCP surface,
   hosted in-process by any runtime that enables it. The MCP tool set is the canonical
@@ -233,7 +233,11 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   Post-pivot the vocabulary is observation-shaped: graph, tap, logs, health, nodes.
   The live-mutation verbs (submit / replace / connect / remove) and their MCP tools
   are removed — code is the source of truth; the edit loop is `dev`, not live
-  mutation. `dev` binds loopback by default. [importable-python-library]
+  mutation. [importable-python-library]
+- **DECIDED** — `dev` and `run` bind the control plane identically: all interfaces
+  (`0.0.0.0`) by default, narrowed per invocation by `--host`. There is no dev-only
+  exposure posture — a node another host can reach is bound wide by definition, so
+  reachability is not the lever that scopes exposure. [control-plane-bind-posture]
 - **DECIDED** — The api-server is engine-side infrastructure and relocates into the
   `runtime/` tree: it is a host — statically linked, never dlopen'd. Its new host is
   the wheel (and the `streamlib` crate for Rust apps); the relocation is a sequencing
@@ -252,4 +256,7 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
 - **DECIDED** — Observability: the JSONL log schema is a durable contract; tap forwards
   bags verbatim, trading completeness for guaranteed non-interference; graph and health
   inspection ride the same control plane. [control-plane-one-surface]
-- **OPEN** — Auth and remote-access posture.
+- **OPEN** — Auth and remote-access posture: how a node authenticates and authorizes
+  control-plane callers, and what it exposes to a mesh. Scoping exposure down is decided
+  here and only here — it is a question of who may call, never of what the node listens
+  on, so no narrower bind default is set ahead of it. [control-plane-bind-posture]

--- a/docs/plan/changes/importable-python-library.md
+++ b/docs/plan/changes/importable-python-library.md
@@ -46,7 +46,9 @@ artifact + ADR.
   traceback and keeps the last good pipeline running; the MVP edit loop is re-running
   `dev` (reload-on-save is a later nicety, processor-granular per the plan, never
   module machinery); a dev-mode GIL-hold watchdog warns when a callback holds the GIL
-  beyond threshold; `dev` binds loopback. `streamlib new` scaffolds `app.py` +
+  beyond threshold; ~~`dev` binds loopback~~ — superseded 2026-08-04 by
+  `control-plane-bind-posture`: `dev` binds all interfaces, exactly as `run` does.
+  `streamlib new` scaffolds `app.py` +
   `pyproject.toml` + `.python-version` (3.12) with working camera → effect → display
   wiring where the effect touches pixels via the exchange surface.
 - **Packaging + release channel**: the CLI ships as the wheel's console script; wheels


### PR DESCRIPTION
Owner pivot, confirmed in session 2026-08-04. Reverses `ARCHITECTURE.md` §Control plane's "`dev` binds loopback by default."

## The direction

1. `streamlib dev` binds all interfaces (`0.0.0.0`) by default, identically to `run` — there is no dev-only exposure posture.
2. The plan text saying otherwise is reversed in `ARCHITECTURE.md` §Control plane and in `changes/importable-python-library.md`; the behaviour never changed, only the plan was out of step.
3. Scoping the exposure down is not a bind-address decision — a node another host can reach is bound wide by definition, so exposure is scoped by *who may call*, not by *what it listens on*.
4. That scope-down therefore lives entirely inside §Control plane's OPEN "Auth and remote-access posture" entry, widened to say so; no future DECIDED entry sets a narrower bind default.
5. Ticket #1711's "`dev` binds loopback by default" Delivers bullet is superseded, and the `test_cli.py:306` docstring calling the code a plan contradiction stops being true.

## Why this is a correction, not a new direction

Nothing in the tree ever bound loopback. `sdk/streamlib-python-wheel/python/streamlib/cli.py:38` (`DEFAULT_CONTROL_PLANE_BIND_HOST = "0.0.0.0"`), `sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs:270`, and the retiring `runtime/streamlib-runtime/src/main.rs:30` all bind wide, and the deleted Rust `run`/`dev` did too. The plan text was the thing out of step.

The motivation is reachability: the system has to reach mesh networks, and a loopback-bound dev node cannot be seen by another host. Once wide binding is a requirement rather than a choice, the bind address stops being a security control — the only lever that protects a reachable node is authentication and authorization. Settling a bind default first would have been a second dial for one concern, and a narrow default standing in for a missing auth story.

## Changes

- `docs/plan/ARCHITECTURE.md` §Control plane — the loopback sentence leaves the observation-vocabulary DECIDED entry; a new `[control-plane-bind-posture]` DECIDED entry states the identical `dev`/`run` posture and `--host` as the per-invocation override. The OPEN auth entry widens to own the exposure question explicitly.
- `docs/plan/changes/importable-python-library.md` — the dev-experience ADDED bullet's loopback clause struck with a dated supersession annotation.
- `docs/decisions/control-plane-bind-posture.md` — new ADR: trigger, decision, three rejected alternatives (dev-loopback/run-wide, two separate dials, narrow-default-with-mesh-flag), and the accepted cost.
- `docs/plan/diagrams/system.mmd` carries no bind or exposure content — nothing to update.

## Legacy inventory

The old direction was never built, so there is no code to rip out. What it leaves:

| Where | What |
|---|---|
| `sdk/streamlib-python-wheel/tests/test_cli.py:306` | Docstring asserts the code "contradicts `ARCHITECTURE.md`" and that the amendment is "pending" — both false once this merges. Assertion and test name survive; the rationale prose is the edit. |
| Ticket #1711, Delivers | "`dev` binds loopback by default" — superseded, tracker work |

Repo-wide grep for `binds loopback` / `loopback by default` found no other occurrence — no rule, skill, architecture doc, or learning carries it.

## Notes (not in scope, no action)

- #1425 (`api-server bearer-token auth + localhost-default bind`) is CLOSED/COMPLETED in milestone 37's deleted package world. It is where the loopback idea originated.
- `packages/api-server/src/node_registry.rs:318` hardcodes `http://127.0.0.1:<port>` as the advertised `control_url`. Correct as written — §Control plane decided that registry is per-user, on-disk, and same-host; cross-host discovery is §Networking's OPEN mesh-discovery entry.

Follows: rip-out change via `/propose-change`, then `/reconcile-tracker` for #1711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented that development and runtime control planes bind to all network interfaces by default.
  * Added guidance for narrowing the binding per invocation with the `--host` option.
  * Clarified that authentication and authorization determine access, while remote-access settings control exposure scope.
  * Updated architecture and library planning documentation to reflect the revised binding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->