### PR TITLE
fix(ci): build glslc from source for the manylinux wheel

### DIFF
--- a/.github/workflows/release-wheel.yml
+++ b/.github/workflows/release-wheel.yml
@@ -55,11 +55,28 @@ jobs:
           # The engine's build.rs compiles GLSL and generates JTD bindings, so
           # the container needs the same toolchain the test workflows install.
           before-script-linux: |
+            set -euo pipefail
             dnf install -y pkgconfig protobuf-compiler clang-devel \
-              vulkan-headers vulkan-loader-devel glslang python3-devel unzip
+              vulkan-headers vulkan-loader-devel python3-devel unzip \
+              cmake ninja-build git
             curl -sSL https://github.com/jsontypedef/json-typedef-codegen/releases/download/v0.4.1/x86_64-unknown-linux-gnu.zip -o /tmp/jtd-codegen.zip
             unzip -q /tmp/jtd-codegen.zip -d /tmp/jtd-codegen
             install -m 0755 /tmp/jtd-codegen/jtd-codegen /usr/local/bin/jtd-codegen
+            # `glslc`, which the engine's build.rs invokes to compile GLSL.
+            # Built from source rather than installed: AlmaLinux 8 — the
+            # manylinux_2_28 base — packages no glslc in base or EPEL (it lives
+            # in shaderc, not glslang, and neither is there), and Google's own
+            # prebuilt link currently 404s. Pinned so a release build is
+            # reproducible; ~4 minutes with ninja.
+            git clone --depth 1 --branch v2026.3 https://github.com/google/shaderc /tmp/shaderc
+            cd /tmp/shaderc
+            ./utils/git-sync-deps
+            cmake -GNinja -B build -DCMAKE_BUILD_TYPE=Release \
+              -DSHADERC_SKIP_TESTS=ON -DSHADERC_SKIP_EXAMPLES=ON \
+              -DSHADERC_SKIP_COPYRIGHT_CHECK=ON
+            ninja -C build glslc_exe
+            install -m 0755 build/glslc/glslc /usr/local/bin/glslc
+            glslc --version
 
       # A wheel that cannot be installed and cannot answer `--help` is not a
       # release artifact. This is the first moment the console script exists as


### PR DESCRIPTION
## Summary

The wheel-release job introduced in #1739 failed on its first real run — `Error: Unable to find a match: glslang`. It never reached the build.

Two things were wrong with one line. `glslang` is not packaged on AlmaLinux 8 (the manylinux_2_28 base), and it would have been the wrong package anyway: the engine's `build.rs` invokes **`glslc`**, which ships in shaderc, not glslang.

Verified in the container rather than guessed at a third time:

```
$ docker run --rm quay.io/pypa/manylinux_2_28_x86_64 \
    bash -c 'dnf -q provides "*/bin/glslc"; dnf install -y epel-release; dnf -q provides "*/bin/glslc"'
Error: No Matches found          # base
Error: No Matches found          # with EPEL
```

Google's own prebuilt shaderc link is also dead right now — the documented badge URL redirects to an `install.tgz` that returns 404 — so there is no prebuilt to fetch. `glslc` is therefore built from a pinned shaderc tag: reproducible, no fragile external artifact, ~4 minutes under ninja against a 90-minute job budget.

`glslc --version` runs at the end of `before-script-linux`, so a future break in that build fails the step responsible instead of surfacing as a confusing compile error later.

## Closes

Part of #1711 — this repairs the release channel that ticket shipped. #1711's remainder stays blocked on #1714.

## Test plan

Ran the complete `before-script-linux` inside `quay.io/pypa/manylinux_2_28_x86_64`:

```
[281/281] Linking CXX executable glslc/glslc
+ install -m 0755 build/glslc/glslc /usr/local/bin/glslc
+ glslc --version
shaderc v2026.3 v2026.3
spirv-tools v2026.3 v2022.4-1283-gb707790a
glslang 11.1.0-1493-g168d452a
```

`vulkan-headers` and `vulkan-loader-devel` resolve on AlmaLinux 8 and are unchanged — `glslang` was the only bad name.

The end-to-end proof is the workflow itself, which cannot run until this is on `main`. Once merged, dispatching **Release Wheel** with `tag_name: v0.13.0` attaches a wheel to the release that was already cut and publishes the index.

## Notes for owner

- **v0.13.0 released with no wheel attached.** The tag and GitHub Release exist; the wheel and index do not. After merge, a manual `workflow_dispatch` with `tag_name: v0.13.0` backfills both — that path exists precisely for this.
- **`trigger-schemas` failed in the same run**, and it is not mine: it also failed on the run at `2026-08-05T00:27:45Z`, before #1739 existed. Reported, not touched.
- GitHub Pages is now enabled with source `GitHub Actions`; `build_type: workflow`, site `https://tatolab.github.io/streamlib/`, nothing deployed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved release package builds by using a consistent, validated shader compilation toolchain.
  - Updated the build environment to improve reliability and reproducibility across supported platforms.
  - Added compiler version verification before release artifacts are packaged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->