### PR TITLE
fix(ci): keep the wheel build's working directory out of the shaderc checkout

### DIFF
--- a/.github/workflows/release-wheel.yml
+++ b/.github/workflows/release-wheel.yml
@@ -96,6 +96,11 @@ jobs:
         run: |
           python3 -m venv /tmp/wheel-check
           /tmp/wheel-check/bin/pip install --no-index sdk/streamlib-python-wheel/dist/*.whl
+          # The scaffolded effect imports numpy, which the scaffold declares as
+          # its own dependency — installing it here is what `uv sync` does for a
+          # real user, and it makes the import below prove the declared set is
+          # actually sufficient.
+          /tmp/wheel-check/bin/pip install 'numpy>=2.1'
           /tmp/wheel-check/bin/streamlib --help
           /tmp/wheel-check/bin/streamlib new /tmp/scaffold-check --test-pattern
           test -f /tmp/scaffold-check/app.py

--- a/.github/workflows/release-wheel.yml
+++ b/.github/workflows/release-wheel.yml
@@ -56,9 +56,15 @@ jobs:
           # the container needs the same toolchain the test workflows install.
           before-script-linux: |
             set -euo pipefail
+            # No python3-devel: it replaces the image's /usr/bin/python3
+            # (3.12) with AlmaLinux's 3.6, which maturin refuses — and an
+            # extension-module wheel links no libpython, so the headers it
+            # brings are not needed here. The Ubuntu test workflow does need
+            # them; that job builds the crate's unit tests, which link it.
             dnf install -y pkgconfig protobuf-compiler clang-devel \
-              vulkan-headers vulkan-loader-devel python3-devel unzip \
+              vulkan-headers vulkan-loader-devel unzip \
               cmake ninja-build git
+            python3 --version
             curl -sSL https://github.com/jsontypedef/json-typedef-codegen/releases/download/v0.4.1/x86_64-unknown-linux-gnu.zip -o /tmp/jtd-codegen.zip
             unzip -q /tmp/jtd-codegen.zip -d /tmp/jtd-codegen
             install -m 0755 /tmp/jtd-codegen/jtd-codegen /usr/local/bin/jtd-codegen

--- a/.github/workflows/release-wheel.yml
+++ b/.github/workflows/release-wheel.yml
@@ -69,13 +69,18 @@ jobs:
             # prebuilt link currently 404s. Pinned so a release build is
             # reproducible; ~4 minutes with ninja.
             git clone --depth 1 --branch v2026.3 https://github.com/google/shaderc /tmp/shaderc
-            cd /tmp/shaderc
-            ./utils/git-sync-deps
-            cmake -GNinja -B build -DCMAKE_BUILD_TYPE=Release \
-              -DSHADERC_SKIP_TESTS=ON -DSHADERC_SKIP_EXAMPLES=ON \
-              -DSHADERC_SKIP_COPYRIGHT_CHECK=ON
-            ninja -C build glslc_exe
-            install -m 0755 build/glslc/glslc /usr/local/bin/glslc
+            # In a subshell: maturin runs in the shell this script leaves
+            # behind, so a bare `cd` here builds the wheel from the shaderc
+            # checkout and fails with "Can't find /tmp/shaderc/Cargo.toml".
+            (
+              cd /tmp/shaderc
+              ./utils/git-sync-deps
+              cmake -GNinja -B build -DCMAKE_BUILD_TYPE=Release \
+                -DSHADERC_SKIP_TESTS=ON -DSHADERC_SKIP_EXAMPLES=ON \
+                -DSHADERC_SKIP_COPYRIGHT_CHECK=ON
+              ninja -C build glslc_exe
+              install -m 0755 build/glslc/glslc /usr/local/bin/glslc
+            )
             glslc --version
 
       # A wheel that cannot be installed and cannot answer `--help` is not a


### PR DESCRIPTION
## Summary

#1746 got the wheel build past dependency install — `glslc` now builds — and it then failed on the next thing:

```
💥 maturin failed
  Caused by: Can't find /tmp/shaderc/Cargo.toml (in /tmp/shaderc)
```

`before-script-linux` did `cd /tmp/shaderc` and never returned. maturin runs in the shell that script leaves behind, so it looked for the project inside the shaderc checkout. The shaderc build now happens in a subshell.

## Why #1746 didn't catch it

I verified that script by running it **alone** in the container. It passes alone — it always would have. What breaks is *the script followed by a directory-sensitive command*, which is precisely what `maturin-action` does and precisely what my check omitted.

So the test here is the sequence, not the script:

```
=== fixed workflow (subshell) ===
PASS: CWD preserved
=== as it is on main right now (bare cd) ===
FAIL: CWD leaked to /tmp/shaderc
```

That probe parses `before-script-linux` **verbatim out of the workflow file**, stubs only the network/compile commands, and asserts the working directory is unchanged at the end. It fails against `main` and passes against this branch, so it is a real reproduction rather than a restatement of the fix.

## Closes

Part of #1711 — repairs the release channel. #1711's remainder stays blocked on #1714.

## Test plan

- Probe above: red on `main`, green here.
- `release-wheel.yml` parses.
- The end-to-end proof is still the workflow itself. After merge, dispatch **Release Wheel** with `tag_name: v0.13.1` to attach the wheel to the release already cut and publish the index.

## Notes for owner

- **v0.13.0 and v0.13.1 are both released with no wheel.** One dispatch after this merges backfills whichever tag you point it at; the index is rebuilt from the full release history either way, so it self-heals.
- **`trigger-schemas` is still failing and is not mine** — it also failed on the `2026-08-05T00:27:45Z` run, before any of this. Worth its own look.
- Two CI-only failures in a row on a path whose only real exercise is a release. If this one is also wrong, the next thing I'd do is stop patching forward and run the whole job locally with `act`, or add a `pull_request`-triggered dry-run of the wheel build so it is exercised before a release depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release wheel builds so shader compilation no longer changes the working directory unexpectedly.
  * Improved reliability of packaging and installation during release builds.
  * Updated the build environment to support verification with newer NumPy versions and ensure required native tooling is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->