### PR TITLE
chore(ci): stop calling the schema/client job on every release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -134,12 +134,17 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  # Trigger schema/client generation on new releases
-  trigger-schemas:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
-    uses: ./.github/workflows/schemas.yml
-    secrets: inherit
+  # `trigger-schemas` is deliberately not called. The job builds the whole
+  # engine and then fails generating TypeScript from the JTD schema layer —
+  # `TS2374: Duplicate index signature` in `schema-types.ts` — and it has failed
+  # on every release since its last successful publish on 2026-01-08. Nothing in
+  # the tree consumes the `@tatolab/streamlib-client` package it would publish.
+  #
+  # Not repaired, because the half that fails is being deleted: §Processor model
+  # decides "no JTD, no schema registry, no embedded schemas, no codegen and no
+  # generated type classes". `schemas.yml` is kept, with its `workflow_dispatch`,
+  # so the surviving OpenAPI/client question can be settled where the ripout
+  # re-scopes it (#1715 / #1712) rather than by deleting it here.
 
   # Build the wheel onto the release just cut and republish the simple index.
   # Called in-run for the same reason trigger-schemas is: the release was


### PR DESCRIPTION
## Summary

`trigger-schemas` builds the entire engine and then fails, on every release. Removing the call from the release chain reclaims that time; the workflow file stays put.

## Why not just fix it

The failure is in the half that is being deleted:

```
##[error]src/schema-types.ts(173,3): error TS2374: Duplicate index signature for type 'string'.  (×4)
Error: error occurred in dts build
```

`schema-types.ts` is generated from the JTD schema layer, and §Processor model & scheduling decides there isn't one:

> There is no schema layer: no JTD, no schema registry, no embedded schemas, no codegen and no generated type classes, and no schema identity grammar anywhere in the engine or the authoring surfaces.

Repairing that TypeScript is work thrown away at #1715.

## Evidence

| check | result |
|---|---|
| `trigger-schemas` on the last 5 release runs | `failure` × 5 |
| last successful publish | **2026-01-08**, seven months ago |
| in-tree consumers of `@tatolab/streamlib-client` | none — the only two references are the workflow that generates it |
| steps before the failure | all succeed, including the full engine build |

So nothing that currently works is lost, and each release stops paying for an engine build that ends in red.

## What is deliberately *not* decided here

`schemas.yml` is kept, `workflow_dispatch` and all. Its two halves have different fates: the JTD/Zod half dies with the schema layer, but the **OpenAPI spec and a control-plane TypeScript client are not obviously dead** — the api-server survives and relocates (#1712), and a client for the control plane is a different thing from the TypeScript *authoring* SDK, which is paused-not-rejected.

Change B already lists `schemas.yml` under CI **re-scope** rather than removal, so that is the right place to settle it. This PR only stops paying for it in the meantime.

## Closes

Part of #1711 — reclaims CI time on the release path that ticket added to. Not a fix for #1715's re-scope.

## Test plan

- `release-please.yml` parses; jobs are now `release-please`, `trigger-wheel-release`.
- No behaviour change to the wheel path — `trigger-wheel-release` is untouched and independent.
- `schemas.yml` remains dispatchable for anyone who wants to run it by hand.

## Notes for owner

The one question for whoever does the re-scope: does the OpenAPI/client half survive, or go with the schema layer? Nothing consumes the published package today, so "delete it entirely" is a live option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the release process by removing an automated schema and client generation step.
  * Releases now proceed directly to package publishing after tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->