### PR TITLE
docs(plan): re-sequence the host-services strip into the contract deletion

### DIFF
--- a/docs/plan/changes/importable-python-library-ripout.md
+++ b/docs/plan/changes/importable-python-library-ripout.md
@@ -89,8 +89,10 @@ where a bullet says otherwise)
   and the `auto-build` feature. The strip has no earlier home because **the cdylib
   test corpus asserts exactly the behaviour it removes**: the 22 `load_project_dylib_*`
   / `pack_then_load_smoke` / `cdylib_owns_tokio_runtime` engine tests, the 4
-  `export_plugin_*` plugin-abi tests, `twin_drift_guard` and `check-cdylib-reach`.
-  Those die on this ticket and nowhere earlier, so no earlier stopping point is green.
+  `export_plugin_*` plugin-abi tests, and `twin_drift_guard`. Those die on this ticket
+  and nowhere earlier, so no earlier stopping point is green. (`check-cdylib-reach`
+  asserts the same invariant and retires with the CI/xtask bullet above; its timing is
+  that bullet's to state, not this one's.)
   Stripping dispatch ahead of them is not unsafe — it is untestable, and pointless
   while the code it serves still ships.
   - **One part of the surface must outlive the ABI, not merely follow it**: the
@@ -104,23 +106,23 @@ where a bullet says otherwise)
   - **Owed to `/reconcile-tracker`**: #1715's body, its stack breakdown, and its file
     count all predate this move and name neither the strip nor the `streamlib-sdk`
     clause.
-- **What must survive the strip**: the helper children's privileged-access route —
-  the escalate GPU ops carried over the subprocess IPC path, which is independent of
-  `host_services` and always was. This is distinct from the cdylib's escalate route
-  (`host_services/gpu_context/limited/escalate.rs`), which dies with the ABI; the two
-  share a name and nothing else. #1743 unblocked #1714 without the strip on exactly
-  this basis.
+- **What must survive the strip**: the helper children's privileged-access route — the
+  escalate GPU ops over the subprocess IPC path. Its own machinery names `host_services`
+  nowhere, but it reaches the GPU through the mode-routed
+  `GpuContextLimitedAccess::escalate`; a helper request is serviced in the app process,
+  so it always takes the host arm. The strip removes the other arm — this route is not
+  merely spared, the branch collapses onto the path it already used. Distinct from the
+  cdylib escalate route (`host_services/gpu_context/limited/escalate.rs`), which dies
+  with the ABI. #1743 unblocked #1714 on this basis.
 
 ## REMOVED
 
 Each bullet is a pattern the ship gate verifies is gone from the tree.
 
-Known gate defect, recorded here because it changes what these bullets are worth: the
-gate takes everything after `- REMOVED: ` on one line and greps it as a fixed string,
-so any bullet carrying two `/`-joined items or a parenthetical can never match and
-passes vacuously. Several below are in that state. Splitting them is the fix; it is
-not this change's scope, and until then a passing gate is weaker evidence than it
-looks.
+Known gate defect: it greps everything after the `- REMOVED:` prefix on one line
+verbatim, so any bullet joining two items with `/` or carrying a parenthetical can
+never match and passes vacuously. Several below are in that state. Splitting them is
+the fix, out of scope here; until then a green gate is weak evidence.
 
 `streamlib-adapter-cuda-helpers` is already gone, deleted early by #1743 / PR #1751
 with its three tests re-homed into `streamlib-adapter-cuda`; its bullet's `-cuda-abi`

--- a/docs/plan/changes/importable-python-library-ripout.md
+++ b/docs/plan/changes/importable-python-library-ripout.md
@@ -6,7 +6,8 @@ surface, and dev experience must exist before their predecessors are deleted. Sa
 The REMOVED inventory below was verified by a dedicated audit agent against the tree
 (reverse-dependency sweep, CI/xtask enumeration) on 2026-08-02.
 
-## MODIFIED — survivor rewires (sequenced before the deletions they unblock)
+## MODIFIED — survivor rewires (sequenced before the deletions they unblock, except
+where a bullet says otherwise)
 
 - **api-server relocation first** (already DECIDED, `[control-plane-one-surface]`):
   moves from `packages/api-server` into `runtime/`; its live-mutation verbs
@@ -22,7 +23,11 @@ The REMOVED inventory below was verified by a dedicated audit agent against the 
 - **Adapter capability traits** (`VulkanWritable`, `GlWritable`, `CpuReadable`, …)
   relocate out of doomed `adapters/streamlib-adapter-abi` into the surviving adapter
   cores' shared home; the cores' dev-deps on doomed `-helpers` crates drop with their
-  subprocess-parity tests.
+  subprocess-parity tests. **Shipped in #1743 / PR #1751**: the home is
+  `adapters/streamlib-surface-adapter`. The split is drawn at the cross-DSO boundary,
+  not around the named traits — they are defined in terms of the guards and the
+  surface descriptor, so the whole non-cross-DSO half travels with them, leaving
+  `streamlib-adapter-abi` as exactly the cross-DSO half this change deletes.
 - **`sdk/streamlib-python-native` retires into the wheel**: helper processes import
   the wheel itself (one native artifact, per §Distribution); the iceoryx2 transport
   and `escalate`/`subprocess_bridge` re-scope to same-interpreter spawns
@@ -30,11 +35,31 @@ The REMOVED inventory below was verified by a dedicated audit agent against the 
   `native_lib_resolver.rs`'s cdylib resolution die. Verify-before-delete: the
   iceoryx2 log-forwarding pair in `core/plugin/` — keep a successor if helper-process
   logging rides it.
-- **Engine host-services strip**: the dual-mode cdylib branch comes out of the ~10
-  retained files that dispatch through `core/plugin/host_services` (`gpu_context`,
-  `texture`, `bus`, `iceoryx2/input`, `vulkan_present_target`, `host_rhi`,
-  `processor_instance_factory`, `runtime_shutdown_request`); `streamlib-sdk` drops its
-  `core::plugin` re-exports and the `auto-build` feature.
+- **Engine host-services strip** — **no longer a survivor rewire; moved to the
+  contract-deletion ticket below.**
+
+  > ~~the dual-mode cdylib branch comes out of the ~10 retained files that dispatch
+  > through `core/plugin/host_services` (`gpu_context`, `texture`, `bus`,
+  > `iceoryx2/input`, `vulkan_present_target`, `host_rhi`,
+  > `processor_instance_factory`, `runtime_shutdown_request`)~~ — the eight named are
+  > a subset, not the surface; and the strip is re-sequenced. Amended 2026-08-05 from
+  > the #1743 implementation audit (PR #1751, `153f84e4`); the re-sequencing is an
+  > owner ruling of the same day.
+  >
+  > **Scale.** The retained surface is materially larger than eight files and spans
+  > the whole RHI — the Vulkan kernel and command-recorder files alone are denser than
+  > anything on the list. It resists enumeration because the coupling has two distinct
+  > shapes that no single pattern catches: a runtime branch on `host_callbacks()`, and
+  > a direct `host_services::host_*_vtable()` call with no `host_callbacks()` mention
+  > at all. Three of the eight named — `iceoryx2/input`, `vulkan_present_target`,
+  > `processor_instance_factory` — are the second shape only. This change states no
+  > file count deliberately: two successive audits produced numbers that measured
+  > different predicates. **The inventory belongs to #1715, derived by reading the RHI
+  > at implementation time.**
+  >
+  > **Sequencing.** The strip does not precede the deletions; see the stacked-PR
+  > bullet. The clause moving `streamlib-sdk` off its `core::plugin` re-exports and
+  > the `auto-build` feature moves there with it, unchanged.
 - **`core/streamlib_home.rs`** re-scopes: the `streamlib_modules`/`packages/` walk
   dies; logging paths and the node registry keep a home-dir resolver.
 - **`sdk/streamlib-idents` / `sdk/streamlib-processor-schema`**: manifest/lockfile
@@ -57,12 +82,49 @@ The REMOVED inventory below was verified by a dedicated audit agent against the 
   `check-no-inventory-submit`, `check-no-reverse-dns` (doc pointer), `test.yml`,
   `schemas.yml`. Keep — device-wait-idle, no-escalate-in-lifecycle,
   vendored-vulkanalia, license-check, pr-title, release-please.
-- The contract-deletion ticket lands as a **pre-approved stacked-PR structure** (the
-  86-file blast radius is unreviewable as one diff).
+- The contract-deletion ticket lands as a **pre-approved stacked-PR structure** — its
+  blast radius is unreviewable as one diff. **The engine host-services strip is one of
+  its stack levels** (moved here 2026-08-05, owner-ruled), alongside the
+  `core/plugin/` deletion, carrying `streamlib-sdk` off its `core::plugin` re-exports
+  and the `auto-build` feature. The strip has no earlier home because **the cdylib
+  test corpus asserts exactly the behaviour it removes**: the 22 `load_project_dylib_*`
+  / `pack_then_load_smoke` / `cdylib_owns_tokio_runtime` engine tests, the 4
+  `export_plugin_*` plugin-abi tests, `twin_drift_guard` and `check-cdylib-reach`.
+  Those die on this ticket and nowhere earlier, so no earlier stopping point is green.
+  Stripping dispatch ahead of them is not unsafe — it is untestable, and pointless
+  while the code it serves still ships.
+  - **One part of the surface must outlive the ABI, not merely follow it**: the
+    `host_inner()` capability guards. Each panics when reached from cdylib code
+    precisely because the alternative is dereferencing host-private layout under the
+    cdylib's view of it — UB, by the guards' own stated rationale. They are the last
+    thing to go, after the last cdylib.
+  - The earlier claim that removing the dead vtable fields would cascade into this
+    ticket is **withdrawn** — the fields are inert once unread, and nothing forces
+    them out ahead of `core/plugin/`.
+  - **Owed to `/reconcile-tracker`**: #1715's body, its stack breakdown, and its file
+    count all predate this move and name neither the strip nor the `streamlib-sdk`
+    clause.
+- **What must survive the strip**: the helper children's privileged-access route —
+  the escalate GPU ops carried over the subprocess IPC path, which is independent of
+  `host_services` and always was. This is distinct from the cdylib's escalate route
+  (`host_services/gpu_context/limited/escalate.rs`), which dies with the ABI; the two
+  share a name and nothing else. #1743 unblocked #1714 without the strip on exactly
+  this basis.
 
 ## REMOVED
 
 Each bullet is a pattern the ship gate verifies is gone from the tree.
+
+Known gate defect, recorded here because it changes what these bullets are worth: the
+gate takes everything after `- REMOVED: ` on one line and greps it as a fixed string,
+so any bullet carrying two `/`-joined items or a parenthetical can never match and
+passes vacuously. Several below are in that state. Splitting them is the fix; it is
+not this change's scope, and until then a passing gate is weaker evidence than it
+looks.
+
+`streamlib-adapter-cuda-helpers` is already gone, deleted early by #1743 / PR #1751
+with its three tests re-homed into `streamlib-adapter-cuda`; its bullet's `-cuda-abi`
+half still belongs to this ticket.
 
 - REMOVED: `runtime/streamlib-plugin-abi`
 - REMOVED: `sdk/streamlib-plugin-sdk`


### PR DESCRIPTION
## Summary

`importable-python-library-ripout.md` (Change B) listed the **engine host-services strip** as a survivor rewire, sequenced ahead of the plugin-ABI deletions and sized at "~10 retained files" naming eight. Implementing #1743 (PR #1751, merged `153f84e4`) established that both halves need correcting. This amends the change file in place — no new artifact, no ADR: nothing here changes `ARCHITECTURE.md`, the plugin ABI's deletion is already DECIDED in §Packages, and the placement pivot already has its ADR.

**Scale.** The eight named files are a subset, not the surface. The coupling has two distinct shapes that no single pattern catches — a runtime branch on `host_callbacks()`, and a bare `host_services::host_*_vtable()` call with no `host_callbacks()` mention at all. Three of the eight (`iceoryx2/input`, `vulkan_present_target`, `processor_instance_factory`) are the second shape only. **This change deliberately states no file count**: two successive audits produced numbers that measured different predicates. The inventory belongs to #1715, derived by reading the RHI at implementation time.

**Sequencing.** The strip becomes one of #1715's stack levels (owner ruling, 2026-08-05), alongside the `core/plugin/` deletion, carrying `streamlib-sdk` off its `core::plugin` re-exports and the `auto-build` feature. The reason is the cdylib test corpus — 22 `load_project_dylib_*` / `pack_then_load_smoke` / `cdylib_owns_tokio_runtime` engine tests, 4 `export_plugin_*` plugin-abi tests, `twin_drift_guard`, `check-cdylib-reach` — which asserts exactly the behaviour the strip removes and dies only on that ticket. Stripping dispatch earlier is **not unsafe — it is untestable**, and pointless while the code it serves still ships.

**Shipped-fact records from #1743:** the adapter capability traits' surviving home is `adapters/streamlib-surface-adapter` (split drawn at the cross-DSO boundary), and `streamlib-adapter-cuda-helpers` is already deleted with its three tests re-homed.

## Two claims corrected inside this PR, not quietly dropped

The first draft of this amendment justified the re-sequencing with two arguments that did not survive review, and the file now says so explicitly rather than deleting them:

- **The UB claim is narrowed.** Deleting a dispatch arm does *not* produce UB — the call falls through to `host_inner()`, which carries its own guard and panics (caught at the ABI boundary). UB is real only for the `host_inner()` guards themselves, which is why the file now says they must *outlive* the ABI rather than being stripped with it.
- **The vtable-field cascade claim is withdrawn** in the text. Dead-but-constructed fields are inert; nothing forces them out ahead of `core/plugin/`.

## Also fixed

- The `## MODIFIED — survivor rewires (sequenced before the deletions…)` heading no longer contradicts a bullet living under it.
- The stale `86-file blast radius` figure is dropped — it was a *deletion* count and the strip's files are modified, not deleted.
- The original bullet's `streamlib-sdk` clause is now explicitly stated as moved, not silently relocated.
- A known **ship-gate defect** is recorded in the REMOVED preamble: the gate greps everything after `- REMOVED: ` as one fixed string, so compound bullets (two `/`-joined items, or a parenthetical) can never match and pass vacuously. Several existing bullets are in that state. Splitting them is the fix and is not this change's scope — but a green gate is weaker evidence than it looks until then.

## Review

Three independent verification passes (one Fable, two Opus) were run against this amendment before it was opened. Every round found real errors, all clustered in the same place — attempts to quantify the strip and justify the sequencing by mechanism. The current text removes those claims rather than patching them. What every pass confirmed unchanged: the shipped facts, the escalate decoupling, the `host_inner()` guard line references, the 41 `host_services` files, the test inventory, supersession format, and scope containment.

## Exit criteria

- [x] The strip is no longer sequenced ahead of the deletions it cannot precede
- [x] No file count asserted that a later audit can falsify
- [x] `ARCHITECTURE.md` and `in-process-hosting-ripout.md` untouched
- [x] Every `- REMOVED:` bullet still a bare grep pattern
- [x] 197 lines, under the 200-line cap

## Test plan

Documentation only — no code, no gates. Verified: file length 197; `- REMOVED:` bullets unchanged and bare; working tree contains no other modification; `ARCHITECTURE.md` and `in-process-hosting-ripout.md` byte-identical to `main`.

## Notes for owner

**`/reconcile-tracker` is owed after this merges** — #1715's body predates the move and names neither the strip nor the `streamlib-sdk` clause, and its stack breakdown and file count are stale. The tracker is a projection of the plan, so the plan lands first.

**Not in scope, recorded so they are not lost:**
- `unknown_processor_type_test` should not be deleted in any test-slimming pass — its `ProcessorState::Error` assertion is what the helper crash policy rides on. It is red only on a version field `[schema-free-ports]` removes anyway.
- `stopping_an_already_stopped_runtime_is_a_no_op` fails under parallel run and is excluded from CI as a flake. It looks like a real teardown race, which matters more once #1714 must reap helper children on teardown.
- `docs/testing-hardware.md:104` says not to use `#[serial]`; 53 files do. Doc and practice have drifted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the migration plan to allow explicitly sequenced exceptions during survivor rewiring.
  - Clarified the adapter capability-trait destination and revised stacked-change sequencing.
  - Moved engine host-services work into a dedicated contract-deletion ticket.
  - Documented related test, guard, tracking, and helper-process access requirements.
  - Added a ship-gate matching defect to the removed-items record and noted the prior deletion and test relocation of CUDA helper support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->